### PR TITLE
[nexus] Add `StartSaga::saga_run` to await completion

### DIFF
--- a/nexus/src/app/background/init.rs
+++ b/nexus/src/app/background/init.rs
@@ -912,6 +912,7 @@ fn init_dns(
 #[cfg(test)]
 pub mod test {
     use crate::app::saga::StartSaga;
+    use crate::app::saga::StartSagaCompletionFuture;
     use dropshot::HandlerTaskMode;
     use futures::FutureExt;
     use nexus_db_model::DnsGroup;
@@ -952,6 +953,18 @@ pub mod test {
         > {
             let _ = self.count.fetch_add(1, Ordering::SeqCst);
             async { Ok(()) }.boxed()
+        }
+
+        fn saga_run(
+            &self,
+            dag: steno::SagaDag,
+        ) -> futures::prelude::future::BoxFuture<
+            '_,
+            Result<(), omicron_common::api::external::Error>,
+        > {
+            // Because we don't actually run sagas, this is equivalent to
+            // `saga_start`.
+            self.saga_start(dag)
         }
     }
 

--- a/nexus/src/app/background/tasks/instance_updater.rs
+++ b/nexus/src/app/background/tasks/instance_updater.rs
@@ -184,7 +184,8 @@ impl InstanceUpdater {
                     let start_saga = self.sagas.clone();
                     sagas.spawn(async move {
                         start_saga
-                            .saga_start(saga)
+                            // Start the saga and wait for it to complete
+                            .saga_run(saga)
                             .await
                             .map_err(|e| (instance_id, e))
                     });

--- a/nexus/src/app/background/tasks/instance_updater.rs
+++ b/nexus/src/app/background/tasks/instance_updater.rs
@@ -23,6 +23,7 @@ use omicron_common::api::external::ListResultVec;
 use serde_json::json;
 use std::future::Future;
 use std::sync::Arc;
+use steno::SagaId;
 use tokio::task::JoinSet;
 use uuid::Uuid;
 
@@ -138,17 +139,18 @@ impl InstanceUpdater {
                         .saga_errors
                         .push((None, format!("unexpected JoinError: {err}")));
                 }
-                Ok(Err((instance_id, err))) => {
-                    const MSG: &'static str = "update saga failed";
+                Ok(Err((instance_id, saga_id, err))) => {
                     warn!(
                         opctx.log,
-                        "{MSG}!";
+                        "update saga failed!";
                         "instance_id" => %instance_id,
+                        "saga_id" => %saga_id,
                         "error" => &err,
                     );
-                    status
-                        .saga_errors
-                        .push((Some(instance_id), err.to_string()));
+                    status.saga_errors.push((
+                        Some(instance_id),
+                        format!("update saga {saga_id} failed: {err}"),
+                    ));
                 }
                 Ok(Ok(())) => status.sagas_completed += 1,
             }
@@ -159,7 +161,7 @@ impl InstanceUpdater {
         &self,
         opctx: &OpContext,
         status: &mut InstanceUpdaterStatus,
-        sagas: &mut JoinSet<Result<(), (Uuid, Error)>>,
+        sagas: &mut JoinSet<Result<(), (Uuid, SagaId, Error)>>,
         instances: impl IntoIterator<Item = Instance>,
     ) {
         let serialized_authn = authn::saga::Serialized::for_opctx(opctx);
@@ -171,25 +173,21 @@ impl InstanceUpdater {
                         .instance_id(instance_id)
                         .lookup_for(authz::Action::Modify)
                         .await?;
-                instance_update::SagaInstanceUpdate::prepare(
+                let dag = instance_update::SagaInstanceUpdate::prepare(
                     &instance_update::Params {
                         serialized_authn: serialized_authn.clone(),
                         authz_instance,
                     },
-                )
+                )?;
+                self.sagas.saga_run(dag).await
             }
             .await;
             match saga {
-                Ok(saga) => {
-                    let start_saga = self.sagas.clone();
-                    sagas.spawn(async move {
-                        start_saga
-                            // Start the saga and wait for it to complete
-                            .saga_run(saga)
-                            .await
-                            .map_err(|e| (instance_id, e))
-                    });
+                Ok((saga_id, completed)) => {
                     status.sagas_started += 1;
+                    sagas.spawn(async move {
+                        completed.await.map_err(|e| (instance_id, saga_id, e))
+                    });
                 }
                 Err(err) => {
                     const ERR_MSG: &str = "failed to start update saga";

--- a/nexus/src/app/background/tasks/instance_watcher.rs
+++ b/nexus/src/app/background/tasks/instance_watcher.rs
@@ -251,7 +251,7 @@ impl InstanceWatcher {
                 }
                 Ok(Some((_, saga))) => {
                     check.update_saga_queued = true;
-                    if let Err(e) = sagas.saga_start(saga).await {
+                    if let Err(e) = sagas.saga_run(saga).await {
                         warn!(opctx.log, "update saga failed"; "error" => ?e);
                         check.result = Err(Incomplete::UpdateFailed);
                     }

--- a/nexus/src/app/background/tasks/region_replacement.rs
+++ b/nexus/src/app/background/tasks/region_replacement.rs
@@ -53,7 +53,8 @@ impl RegionReplacementDetector {
         let saga_dag = SagaRegionReplacementStart::prepare(&params)?;
         // We only care that the saga was started, and don't wish to wait for it
         // to complete, so use `StartSaga::saga_start`, rather than `saga_run`.
-        self.sagas.saga_start(saga_dag).await
+        self.sagas.saga_start(saga_dag).await?;
+        Ok(())
     }
 }
 

--- a/nexus/src/app/background/tasks/region_replacement.rs
+++ b/nexus/src/app/background/tasks/region_replacement.rs
@@ -51,6 +51,8 @@ impl RegionReplacementDetector {
         };
 
         let saga_dag = SagaRegionReplacementStart::prepare(&params)?;
+        // We only care that the saga was started, and don't wish to wait for it
+        // to complete, so use `StartSaga::saga_start`, rather than `saga_run`.
         self.sagas.saga_start(saga_dag).await
     }
 }

--- a/nexus/src/app/background/tasks/region_snapshot_replacement_garbage_collect.rs
+++ b/nexus/src/app/background/tasks/region_snapshot_replacement_garbage_collect.rs
@@ -56,6 +56,8 @@ impl RegionSnapshotReplacementGarbageCollect {
 
         let saga_dag =
             SagaRegionSnapshotReplacementGarbageCollect::prepare(&params)?;
+        // We only care that the saga was started, and don't wish to wait for it
+        // to complete, so use `StartSaga::saga_start`, rather than `saga_run`.
         self.sagas.saga_start(saga_dag).await
     }
 

--- a/nexus/src/app/background/tasks/region_snapshot_replacement_garbage_collect.rs
+++ b/nexus/src/app/background/tasks/region_snapshot_replacement_garbage_collect.rs
@@ -58,7 +58,8 @@ impl RegionSnapshotReplacementGarbageCollect {
             SagaRegionSnapshotReplacementGarbageCollect::prepare(&params)?;
         // We only care that the saga was started, and don't wish to wait for it
         // to complete, so use `StartSaga::saga_start`, rather than `saga_run`.
-        self.sagas.saga_start(saga_dag).await
+        self.sagas.saga_start(saga_dag).await?;
+        Ok(())
     }
 
     async fn clean_up_region_snapshot_replacement_volumes(

--- a/nexus/src/app/background/tasks/region_snapshot_replacement_start.rs
+++ b/nexus/src/app/background/tasks/region_snapshot_replacement_start.rs
@@ -51,7 +51,8 @@ impl RegionSnapshotReplacementDetector {
         let saga_dag = SagaRegionSnapshotReplacementStart::prepare(&params)?;
         // We only care that the saga was started, and don't wish to wait for it
         // to complete, so use `StartSaga::saga_start`, rather than `saga_run`.
-        self.sagas.saga_start(saga_dag).await
+        self.sagas.saga_start(saga_dag).await?;
+        Ok(())
     }
 
     /// Find region snapshots on expunged physical disks and create region

--- a/nexus/src/app/background/tasks/region_snapshot_replacement_start.rs
+++ b/nexus/src/app/background/tasks/region_snapshot_replacement_start.rs
@@ -49,6 +49,8 @@ impl RegionSnapshotReplacementDetector {
         };
 
         let saga_dag = SagaRegionSnapshotReplacementStart::prepare(&params)?;
+        // We only care that the saga was started, and don't wish to wait for it
+        // to complete, so use `StartSaga::saga_start`, rather than `saga_run`.
         self.sagas.saga_start(saga_dag).await
     }
 

--- a/nexus/src/app/background/tasks/region_snapshot_replacement_step.rs
+++ b/nexus/src/app/background/tasks/region_snapshot_replacement_step.rs
@@ -59,6 +59,8 @@ impl RegionSnapshotReplacementFindAffected {
         };
 
         let saga_dag = SagaRegionSnapshotReplacementStep::prepare(&params)?;
+        // We only care that the saga was started, and don't wish to wait for it
+        // to complete, so use `StartSaga::saga_start`, rather than `saga_run`.
         self.sagas.saga_start(saga_dag).await
     }
 
@@ -89,7 +91,12 @@ impl RegionSnapshotReplacementFindAffected {
 
         let saga_dag =
             SagaRegionSnapshotReplacementStepGarbageCollect::prepare(&params)?;
-        self.sagas.saga_start(saga_dag).await
+
+        // We only care that the saga was started, and don't wish to wait for it
+        // to complete, so throwing out the future returned by `saga_start` is
+        // fine. Dropping it will *not* cancel the saga itself.
+        self.sagas.saga_start(saga_dag).await?;
+        Ok(())
     }
 
     async fn clean_up_region_snapshot_replacement_step_volumes(

--- a/nexus/src/app/background/tasks/region_snapshot_replacement_step.rs
+++ b/nexus/src/app/background/tasks/region_snapshot_replacement_step.rs
@@ -61,7 +61,8 @@ impl RegionSnapshotReplacementFindAffected {
         let saga_dag = SagaRegionSnapshotReplacementStep::prepare(&params)?;
         // We only care that the saga was started, and don't wish to wait for it
         // to complete, so use `StartSaga::saga_start`, rather than `saga_run`.
-        self.sagas.saga_start(saga_dag).await
+        self.sagas.saga_start(saga_dag).await?;
+        Ok(())
     }
 
     async fn send_garbage_collect_request(


### PR DESCRIPTION
Nexus API handlers (and other sagas) that start sagas have the ability
to wait for the completion of the saga by `await`ing the `RunningSaga`
future returned by `RunnableSaga::start`. Background tasks, on the other
hand, cannot currently do this, as their only interface to the saga
executor is an `Arc<dyn StartSaga>`, which provides only the
[`saga_start` method][1]. This method throws away the `RunningSaga`
returned by `RunnableSaga::start`, so the completion of the saga cannot
be awaited. In some cases, it's desirable for background tasks to be
able to await a saga running to completion. I described some motivations
for this in #6569.

This commit adds a new `StartSaga::saga_run` method to the `StartSaga`
trait, which starts a saga *and* waits for it to finish. Since many
tests use a `NoopStartSaga` type which doesn't actually start sagas,
this interface still throws away most of the saga *outputs* provided by
`StoppedSaga`, to make it easier for the noop test implementation to
implement this method. If that's an issue in the future, we can revisit
the interface, and maybe make `NoopStartSaga` return fake saga results
or something.

I've updated the `instance_watcher` and `instance_updater` background
tasks to use the `saga_run` method, because they were written with the
intent to spawn tasks that run sagas to completion --- this is necessary
for how the number of concurrent update sagas is *supposed* to be
limited by `instance_watcher`. I left the region-replacement tasks using
`StartSaga::saga_start`, because --- as far as I can tell --- the "fire
and forget" behavior is desirable there. Perhaps @jmpesp can confirm
this?

Closes #6569

[1]: https://github.com/oxidecomputer/omicron/blob/8be99b0c0dd18495d4a98187145961eafdb17d8f/nexus/src/app/saga.rs#L96-L108