### PR TITLE
Don't call `pool_connection_authorized` here!

### DIFF
--- a/nexus/db-queries/src/db/datastore/region_snapshot_replacement.rs
+++ b/nexus/db-queries/src/db/datastore/region_snapshot_replacement.rs
@@ -894,9 +894,7 @@ impl DataStore {
                         .check_if_exists::<RegionSnapshotReplacementStep>(
                             region_snapshot_replacement_step_id,
                         )
-                        .execute_and_check(
-                            &*self.pool_connection_authorized(opctx).await?,
-                        )
+                        .execute_and_check(&conn)
                         .await?;
 
                 match result.status {


### PR DESCRIPTION
Don't use `pool_connection_authorized` from within `transaction_async`'s function, use the `conn` that is supplied for this purpose.

I don't know how bad this is (will CRDB just nest things?) but it strikes me as wrong, so here's the PR!