### PR TITLE
clarify which filesystem "filesystem_pool" describes

### DIFF
--- a/nexus-sled-agent-shared/src/inventory.rs
+++ b/nexus-sled-agent-shared/src/inventory.rs
@@ -145,11 +145,10 @@ pub struct OmicronZoneConfig {
     pub id: Uuid,
     pub underlay_address: Ipv6Addr,
 
-    /// The pool on which we'll place this zone's filesystem.
+    /// The pool on which we'll place this zone's root filesystem.
     ///
-    /// Note that this is transient -- the sled agent is permitted to
-    /// destroy the zone's dataset on this pool each time the zone is
-    /// initialized.
+    /// Note that the root filesystem is transient -- the sled agent is
+    /// permitted to destroy this dataset each time the zone is initialized.
     pub filesystem_pool: Option<ZpoolName>,
     pub zone_type: OmicronZoneType,
 }

--- a/nexus/types/src/deployment.rs
+++ b/nexus/types/src/deployment.rs
@@ -628,6 +628,7 @@ pub struct BlueprintZoneConfig {
 
     pub id: OmicronZoneUuid,
     pub underlay_address: Ipv6Addr,
+    /// zpool used for the zone's (transient) root filesystem
     pub filesystem_pool: Option<ZpoolName>,
     pub zone_type: BlueprintZoneType,
 }

--- a/openapi/nexus-internal.json
+++ b/openapi/nexus-internal.json
@@ -2094,6 +2094,7 @@
           },
           "filesystem_pool": {
             "nullable": true,
+            "description": "zpool used for the zone's (transient) root filesystem",
             "allOf": [
               {
                 "$ref": "#/components/schemas/ZpoolName"

--- a/openapi/sled-agent.json
+++ b/openapi/sled-agent.json
@@ -3891,7 +3891,7 @@
         "properties": {
           "filesystem_pool": {
             "nullable": true,
-            "description": "The pool on which we'll place this zone's filesystem.\n\nNote that this is transient -- the sled agent is permitted to destroy the zone's dataset on this pool each time the zone is initialized.",
+            "description": "The pool on which we'll place this zone's root filesystem.\n\nNote that the root filesystem is transient -- the sled agent is permitted to destroy this dataset each time the zone is initialized.",
             "allOf": [
               {
                 "$ref": "#/components/schemas/ZpoolName"

--- a/schema/all-zones-requests.json
+++ b/schema/all-zones-requests.json
@@ -241,7 +241,7 @@
       ],
       "properties": {
         "filesystem_pool": {
-          "description": "The pool on which we'll place this zone's filesystem.\n\nNote that this is transient -- the sled agent is permitted to destroy the zone's dataset on this pool each time the zone is initialized.",
+          "description": "The pool on which we'll place this zone's root filesystem.\n\nNote that the root filesystem is transient -- the sled agent is permitted to destroy this dataset each time the zone is initialized.",
           "anyOf": [
             {
               "$ref": "#/definitions/ZpoolName"

--- a/schema/rss-service-plan-v4.json
+++ b/schema/rss-service-plan-v4.json
@@ -37,6 +37,7 @@
           ]
         },
         "filesystem_pool": {
+          "description": "zpool used for the zone's (transient) root filesystem",
           "anyOf": [
             {
               "$ref": "#/definitions/ZpoolName"


### PR DESCRIPTION
If I'm reading the code correctly, the `filesystem_pool` field in both inventory and blueprints identifies which zpool the zone's *root* filesystem will be constructed on.  It took me a little while to figure this out so I wanted to add/clarify the couple of comments here.

(I also think it would be clearer to call this `root_pool` or `root_filesystem_pool`.  Zones have many filesystems, and at least two that might come from a zpool.  But that's a much more invasive change I didn't want to make now, especially without asking people!)