### PR TITLE
Attempt to handle "kstat-based metrics produce samples from the 1980's"

### DIFF
--- a/oximeter/instruments/src/kstat/mod.rs
+++ b/oximeter/instruments/src/kstat/mod.rs
@@ -91,6 +91,7 @@ use std::time::Duration;
 pub mod link;
 mod sampler;
 
+pub use link::SledDataLink;
 pub use sampler::CollectionDetails;
 pub use sampler::ExpirationBehavior;
 pub use sampler::KstatSampler;

--- a/sled-agent/src/services.rs
+++ b/sled-agent/src/services.rs
@@ -954,6 +954,31 @@ impl ServiceManager {
         self.inner.sled_mode
     }
 
+    /// Returns the sled's identifier
+    fn sled_id(&self) -> Uuid {
+        self.inner
+            .sled_info
+            .get()
+            .expect("sled agent not started")
+            .config
+            .sled_id
+    }
+
+    /// Returns the metrics queue for the sled agent if it is running.
+    fn maybe_metrics_queue(&self) -> Option<&MetricsRequestQueue> {
+        self.inner.sled_info.get().map(|info| &info.metrics_queue)
+    }
+
+    /// Returns the metrics queue for the sled agent.
+    fn metrics_queue(&self) -> &MetricsRequestQueue {
+        &self
+            .inner
+            .sled_info
+            .get()
+            .expect("Sled agent should have started")
+            .metrics_queue
+    }
+
     // Advertise the /64 prefix of `address`, unless we already have.
     //
     // This method only blocks long enough to check our HashSet of
@@ -3105,9 +3130,7 @@ impl ServiceManager {
         // point. The only exception is the switch zone, during bootstrapping
         // but before we've either run RSS or unlocked the rack. In both those
         // cases, we have a `StartSledAgentRequest`, and so a metrics queue.
-        if let Some(queue) =
-            self.inner.sled_info.get().map(|sa| &sa.metrics_queue)
-        {
+        if let Some(queue) = self.maybe_metrics_queue() {
             if !queue.track_zone_links(&running_zone).await {
                 error!(
                     self.inner.log,
@@ -3484,9 +3507,7 @@ impl ServiceManager {
         };
         // Ensure that the sled agent's metrics task is not tracking the zone's
         // VNICs or OPTE ports.
-        if let Some(queue) =
-            self.inner.sled_info.get().map(|sa| &sa.metrics_queue)
-        {
+        if let Some(queue) = self.maybe_metrics_queue() {
             queue.untrack_zone_links(&zone.runtime).await;
         }
         debug!(
@@ -3712,17 +3733,8 @@ impl ServiceManager {
         Ok(())
     }
 
+    /// Adjust the system boot time to the latest boot time of all zones.
     pub fn boottime_rewrite(&self) {
-        if self
-            .inner
-            .time_synced
-            .compare_exchange(false, true, Ordering::Acquire, Ordering::Relaxed)
-            .is_err()
-        {
-            // Already done.
-            return;
-        }
-
         // Call out to the 'tmpx' utility program which will rewrite the wtmpx
         // and utmpx databases in every zone, including the global zone, to
         // reflect the adjusted system boot time.
@@ -3754,7 +3766,7 @@ impl ServiceManager {
 
         if skip_timesync {
             info!(self.inner.log, "Configured to skip timesync checks");
-            self.boottime_rewrite();
+            self.if_timesynced().await;
             return Ok(TimeSync {
                 sync: true,
                 ref_id: 0,
@@ -3809,7 +3821,7 @@ impl ServiceManager {
                         && correction.abs() <= 0.05;
 
                     if sync {
-                        self.boottime_rewrite();
+                        self.if_timesynced().await;
                     }
 
                     Ok(TimeSync {
@@ -3827,6 +3839,33 @@ impl ServiceManager {
             Err(e) => {
                 error!(self.inner.log, "chronyc command failed: {}", e);
                 Err(Error::NtpZoneNotReady)
+            }
+        }
+    }
+
+    /// Check if the system time is synchronized and if so, execute the
+    /// boottime_rewrite function and send messages.
+    async fn if_timesynced(&self) {
+        match self.inner.time_synced.compare_exchange(
+            false,
+            true,
+            Ordering::Acquire,
+            Ordering::Relaxed,
+        ) {
+            Err(_) => {
+                debug!(self.inner.log, "Time was already synchronized");
+            }
+            Ok(_) => {
+                debug!(self.inner.log, "Time is now synchronized");
+                // We only want to rewrite the boot time once, so we do it here
+                // when we know the time is synchronized.
+                self.boottime_rewrite();
+
+                // We expect to have a metrics queue by this point, so
+                // we can safely send a message on it to say the sled has
+                // been synchronized.
+                let queue = self.metrics_queue();
+                queue.synced_sled(self.sled_id(), true).await;
             }
         }
     }
@@ -4867,7 +4906,7 @@ mod test {
 
         // Also send a message to the metrics task that the VNIC has been
         // deleted.
-        let queue = &mgr.inner.sled_info.get().unwrap().metrics_queue;
+        let queue = mgr.metrics_queue();
         for zone in mgr.inner.zones.lock().await.values() {
             queue.untrack_zone_links(&zone.runtime).await;
         }
@@ -5047,8 +5086,22 @@ mod test {
         assert_eq!(found.zones.len(), 1);
         assert_eq!(found.zones[0].id, id);
 
-        // Check that we received a message about the zone's VNIC.
-        let message = tokio::time::timeout(
+        // First check that we received the synced sled notification
+        let synced_message = tokio::time::timeout(
+            LINK_NOTIFICATION_TIMEOUT,
+            metrics_rx.recv(),
+        ).await.expect("Should have received a message about the sled being synced within the timeout")
+            .expect("Should have received a message about the sled being synced");
+        assert_eq!(
+            synced_message,
+            metrics::Message::SyncedSled {
+                sled_id: mgr.sled_id(),
+                synced: true
+            },
+        );
+
+        // Then, check that we received a message about the zone's VNIC.
+        let vnic_message = tokio::time::timeout(
             LINK_NOTIFICATION_TIMEOUT,
             metrics_rx.recv(),
         )
@@ -5059,7 +5112,7 @@ mod test {
             .expect("Should have received a message about the zone's VNIC");
         let zone_name = format!("oxz_ntp_{}", id);
         assert_eq!(
-            message,
+            vnic_message,
             metrics::Message::TrackVnic {
                 zone_name,
                 name: "oxControlService0".into()
@@ -5189,10 +5242,24 @@ mod test {
         assert_eq!(found.zones.len(), 1);
         assert_eq!(found.zones[0].id, id);
 
+        // First, we will get a message about the sled being synced.
+        let synced_message = tokio::time::timeout(
+            LINK_NOTIFICATION_TIMEOUT,
+            metrics_rx.recv(),
+        ).await.expect("Should have received a message about the sled being synced within the timeout")
+            .expect("Should have received a message about the sled being synced");
+        assert_eq!(
+            synced_message,
+            metrics::Message::SyncedSled {
+                sled_id: mgr.sled_id(),
+                synced: true
+            }
+        );
+
         // In this case, the manager creates the zone once, and then "ensuring"
         // it a second time is a no-op. So we simply expect the same message
         // sequence as starting a zone for the first time.
-        let message = tokio::time::timeout(
+        let vnic_message = tokio::time::timeout(
             LINK_NOTIFICATION_TIMEOUT,
             metrics_rx.recv(),
         )
@@ -5203,7 +5270,7 @@ mod test {
             .expect("Should have received a message about the zone's VNIC");
         let zone_name = format!("oxz_ntp_{}", id);
         assert_eq!(
-            message,
+            vnic_message,
             metrics::Message::TrackVnic {
                 zone_name,
                 name: "oxControlService0".into()
@@ -5247,21 +5314,36 @@ mod test {
             String::from(test_config.config_dir.path().as_str()),
         )
         .await;
+
+        let sled_id = mgr.sled_id();
         drop_service_manager(mgr).await;
+
+        // First, we will get a message about the sled being synced.
+        let synced_message = tokio::time::timeout(
+            LINK_NOTIFICATION_TIMEOUT,
+            metrics_rx.recv(),
+        ).await.expect("Should have received a message about the sled being synced within the timeout")
+            .expect("Should have received a message about the sled being synced");
+        assert_eq!(
+            synced_message,
+            metrics::Message::SyncedSled { sled_id, synced: true }
+        );
 
         // Check that we received a message about the zone's VNIC. Since the
         // manager is being dropped, it should also send a message about the
         // VNIC being deleted.
         let zone_name = format!("oxz_ntp_{}", id);
-        for expected_message in [
+        for expected_vnic_message in [
             metrics::Message::TrackVnic {
                 zone_name,
                 name: "oxControlService0".into(),
             },
             metrics::Message::UntrackVnic { name: "oxControlService0".into() },
         ] {
-            println!("Expecting message from manager: {expected_message:#?}");
-            let message = tokio::time::timeout(
+            println!(
+                "Expecting message from manager: {expected_vnic_message:#?}"
+            );
+            let vnic_message = tokio::time::timeout(
                 LINK_NOTIFICATION_TIMEOUT,
                 metrics_rx.recv(),
             )
@@ -5270,7 +5352,7 @@ mod test {
                     "Should have received a message about the zone's VNIC within the timeout"
                 )
                 .expect("Should have received a message about the zone's VNIC");
-            assert_eq!(message, expected_message,);
+            assert_eq!(vnic_message, expected_vnic_message,);
         }
         // Note that the manager has been dropped, so we should get
         // disconnected, not empty.


### PR DESCRIPTION
Closes https://github.com/oxidecomputer/omicron/issues/5899.

Instead of checking for dates or anything based on the data sampled, this update starts collecting kstat samples (i.e. being interested in them) once the sled agent is synchronized with NTP.

We leverage the metrics manager associated with the agent to now look for a new message and update the tracked links we've added/tracked thus far.