### PR TITLE
Abstract over kinds of ClickHouse deployments in tests

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -6953,6 +6953,7 @@ dependencies = [
  "dropshot 0.10.2-dev",
  "expectorate",
  "filetime",
+ "futures",
  "gethostname",
  "headers 0.3.9",
  "hex",

--- a/dev-tools/omdb/tests/test_all_output.rs
+++ b/dev-tools/omdb/tests/test_all_output.rs
@@ -130,7 +130,7 @@ async fn test_omdb_success_cases(cptestctx: &ControlPlaneTestContext) {
     let mgs_url = format!("http://{}/", gwtestctx.client.bind_address);
     let ox_url = format!("http://{}/", cptestctx.oximeter.server_address());
     let ox_test_producer = cptestctx.producer.address().ip();
-    let ch_url = format!("http://{}/", cptestctx.clickhouse.address);
+    let ch_url = format!("http://{}/", cptestctx.clickhouse.http_address());
 
     let tmpdir = camino_tempfile::tempdir()
         .expect("failed to create temporary directory");
@@ -308,7 +308,7 @@ async fn test_omdb_env_settings(cptestctx: &ControlPlaneTestContext) {
         format!("http://{}", cptestctx.internal_client.bind_address);
     let ox_url = format!("http://{}/", cptestctx.oximeter.server_address());
     let ox_test_producer = cptestctx.producer.address().ip();
-    let ch_url = format!("http://{}/", cptestctx.clickhouse.address);
+    let ch_url = format!("http://{}/", cptestctx.clickhouse.http_address());
     let dns_sockaddr = cptestctx.internal_dns.dns_server.local_address();
     let mut output = String::new();
 

--- a/nexus/benches/setup_benchmark.rs
+++ b/nexus/benches/setup_benchmark.rs
@@ -31,7 +31,7 @@ async fn do_clickhouse_setup() {
     let cfg = nexus_test_utils::load_test_config();
     let logctx = LogContext::new("clickhouse_setup", &cfg.pkg.log);
     let mut clickhouse =
-        dev::clickhouse::ClickHouseInstance::new_single_node(&logctx, 0)
+        dev::clickhouse::ClickHouseDeployment::new_single_node(&logctx, 0)
             .await
             .unwrap();
     clickhouse.cleanup().await.unwrap();

--- a/oximeter/db/src/client/oxql.rs
+++ b/oximeter/db/src/client/oxql.rs
@@ -1114,7 +1114,7 @@ mod tests {
     use crate::{Metric, Target};
     use chrono::{DateTime, Utc};
     use dropshot::test_util::LogContext;
-    use omicron_test_utils::dev::clickhouse::ClickHouseInstance;
+    use omicron_test_utils::dev::clickhouse::ClickHouseDeployment;
     use omicron_test_utils::dev::test_setup_log;
     use oximeter::{types::Cumulative, FieldValue};
     use oximeter::{DatumType, Sample};
@@ -1148,7 +1148,7 @@ mod tests {
 
     struct TestContext {
         logctx: LogContext,
-        clickhouse: ClickHouseInstance,
+        clickhouse: ClickHouseDeployment,
         client: Client,
         test_data: TestData,
     }
@@ -1236,10 +1236,10 @@ mod tests {
 
     async fn setup_oxql_test(name: &str) -> TestContext {
         let logctx = test_setup_log(name);
-        let db = ClickHouseInstance::new_single_node(&logctx, 0)
+        let db = ClickHouseDeployment::new_single_node(&logctx, 0)
             .await
             .expect("Failed to start ClickHouse");
-        let client = Client::new(db.address, &logctx.log);
+        let client = Client::new(db.http_address().into(), &logctx.log);
         client
             .init_single_node_db()
             .await

--- a/test-utils/Cargo.toml
+++ b/test-utils/Cargo.toml
@@ -14,6 +14,7 @@ camino.workspace = true
 camino-tempfile.workspace = true
 dropshot.workspace = true
 filetime = { workspace = true, optional = true }
+futures.workspace = true
 headers.workspace = true
 hex.workspace = true
 http.workspace = true

--- a/test-utils/src/dev/clickhouse.rs
+++ b/test-utils/src/dev/clickhouse.rs
@@ -127,7 +127,7 @@ impl ClickHouseDeployment {
         }
     }
 
-    /// Return the path to the replica configuration files.
+    /// Return the path to the keeper configuration files.
     ///
     /// This is only Some(_) in a cluster deployment. In a single-node, there
     /// are no Keepers, and so no config file for them.
@@ -206,13 +206,6 @@ impl std::ops::Deref for ClickHouseKeeper {
 impl std::ops::DerefMut for ClickHouseKeeper {
     fn deref_mut(&mut self) -> &mut Self::Target {
         &mut self.0
-    }
-}
-
-impl ClickHouseKeeper {
-    /// Construct a new Keeper.
-    pub fn new() -> Result<Self, anyhow::Error> {
-        todo!()
     }
 }
 


### PR DESCRIPTION
- Add the `ClickHouseDeployment` enum, which manages an entire ClickHouse deployment in test code, either a single-node for most tests, or a cluster where relevant. For the cluster variant, this adds a way to wait for the first child or all children, to be shutdown. This fixes a bug in the logic for managing child processes, where failures of one of the process could make zombies out of all the others. This also collects the nodes into arrays, so we can resize the cluster easily if we want, which fixes #4460.
- Use the new enum in the `ControlPlaneTestContext` for all Nexus integration tests.
- Rework the `ch-dev` binary to use the new enum, and also print much more verbose information about what it's doing when starting ClickHouse. This fixes #3011.