### PR TITLE
Fix blueprint planner's validation of PlanningInput external networking

### DIFF
--- a/nexus/reconfigurator/planning/src/blueprint_builder/builder.rs
+++ b/nexus/reconfigurator/planning/src/blueprint_builder/builder.rs
@@ -1542,6 +1542,7 @@ pub mod test {
     pub const DEFAULT_N_SLEDS: usize = 3;
 
     /// Checks various conditions that should be true for all blueprints
+    #[track_caller]
     pub fn verify_blueprint(blueprint: &Blueprint) {
         // There should be no duplicate underlay IPs.
         let mut underlay_ips: BTreeMap<Ipv6Addr, &BlueprintZoneConfig> =
@@ -1592,6 +1593,28 @@ pub mod test {
         }
     }
 
+    #[track_caller]
+    pub fn assert_planning_makes_no_changes(
+        log: &Logger,
+        blueprint: &Blueprint,
+        input: &PlanningInput,
+        test_name: &'static str,
+    ) {
+        let builder =
+            BlueprintBuilder::new_based_on(&log, &blueprint, &input, test_name)
+                .expect("failed to create builder");
+        let child_blueprint = builder.build();
+        verify_blueprint(&child_blueprint);
+        let diff = child_blueprint.diff_since_blueprint(&blueprint);
+        println!(
+            "diff between blueprints (expected no changes):\n{}",
+            diff.display()
+        );
+        assert_eq!(diff.sleds_added.len(), 0);
+        assert_eq!(diff.sleds_removed.len(), 0);
+        assert_eq!(diff.sleds_modified.len(), 0);
+    }
+
     #[test]
     fn test_initial() {
         // Test creating a blueprint from a collection and verifying that it
@@ -1619,24 +1642,13 @@ pub mod test {
         assert_eq!(diff.sleds_removed.len(), 0);
         assert_eq!(diff.sleds_modified.len(), 0);
 
-        // Test a no-op blueprint.
-        let builder = BlueprintBuilder::new_based_on(
+        // Test a no-op planning iteration.
+        assert_planning_makes_no_changes(
             &logctx.log,
             &blueprint_initial,
             &input,
-            "test_basic",
-        )
-        .expect("failed to create builder");
-        let blueprint = builder.build();
-        verify_blueprint(&blueprint);
-        let diff = blueprint.diff_since_blueprint(&blueprint_initial);
-        println!(
-            "initial blueprint -> next blueprint (expected no changes):\n{}",
-            diff.display()
+            TEST_NAME,
         );
-        assert_eq!(diff.sleds_added.len(), 0);
-        assert_eq!(diff.sleds_removed.len(), 0);
-        assert_eq!(diff.sleds_modified.len(), 0);
 
         logctx.cleanup_successful();
     }
@@ -1783,6 +1795,14 @@ pub mod test {
                 .collect()
         );
 
+        // Test a no-op planning iteration.
+        assert_planning_makes_no_changes(
+            &logctx.log,
+            &blueprint3,
+            &input,
+            TEST_NAME,
+        );
+
         logctx.cleanup_successful();
     }
 
@@ -1858,6 +1878,14 @@ pub mod test {
         assert_eq!(
             blueprint3.sled_state.get(&decommision_sled_id).copied(),
             None,
+        );
+
+        // Test a no-op planning iteration.
+        assert_planning_makes_no_changes(
+            &logctx.log,
+            &blueprint3,
+            &input,
+            TEST_NAME,
         );
 
         logctx.cleanup_successful();
@@ -2365,6 +2393,14 @@ pub mod test {
                 })
                 .count(),
             num_sled_zpools
+        );
+
+        // Test a no-op planning iteration.
+        assert_planning_makes_no_changes(
+            &logctx.log,
+            &blueprint,
+            &input,
+            TEST_NAME,
         );
 
         // If we instead ask for one more zone than there are zpools, we should

--- a/nexus/reconfigurator/planning/src/example.rs
+++ b/nexus/reconfigurator/planning/src/example.rs
@@ -43,7 +43,7 @@ impl ExampleSystem {
             let _ = system.sled(SledBuilder::new().id(*sled_id)).unwrap();
         }
 
-        let mut input_builder = system
+        let input_builder = system
             .to_planning_input_builder()
             .expect("failed to make planning input builder");
         let base_input = input_builder.clone().build();
@@ -91,10 +91,6 @@ impl ExampleSystem {
         let mut builder =
             system.to_collection_builder().expect("failed to build collection");
         builder.set_rng_seed((test_name, "ExampleSystem collection"));
-
-        input_builder
-            .update_network_resources_from_blueprint(&blueprint)
-            .expect("failed to add network resources from blueprint");
 
         for (sled_id, zones) in &blueprint.blueprint_zones {
             builder

--- a/nexus/reconfigurator/planning/src/planner.rs
+++ b/nexus/reconfigurator/planning/src/planner.rs
@@ -1297,7 +1297,6 @@ mod test {
         // the service IP pool. This will force reuse of the IP that was
         // allocated to the expunged Nexus zone.
         let mut builder = input.into_builder();
-        builder.update_network_resources_from_blueprint(&blueprint2).unwrap();
         assert_eq!(builder.policy_mut().service_ip_pool_ranges.len(), 1);
         builder.policy_mut().target_nexus_zone_count =
             builder.policy_mut().service_ip_pool_ranges[0]
@@ -1697,10 +1696,6 @@ mod test {
         };
         println!("1 -> 2: decommissioned {decommissioned_sled_id}");
 
-        // Because we marked zones as expunged, we need to update the networking
-        // config in the planning input.
-        builder.update_network_resources_from_blueprint(&blueprint1).unwrap();
-
         // Now run the planner with a high number of target Nexus zones. The
         // number (9) is chosen such that:
         //
@@ -1975,7 +1970,6 @@ mod test {
 
         // Remove the now-decommissioned sled from the planning input.
         let mut builder = input.into_builder();
-        builder.update_network_resources_from_blueprint(&blueprint2).unwrap();
         builder.sleds_mut().remove(&expunged_sled_id);
         let input = builder.build();
 

--- a/nexus/types/src/deployment/network_resources.rs
+++ b/nexus/types/src/deployment/network_resources.rs
@@ -142,7 +142,7 @@ impl OmicronZoneNetworkResources {
 }
 
 /// External IP variants possible for Omicron-managed zones.
-#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+#[derive(Debug, Clone, Copy, Hash, PartialEq, Eq, Serialize, Deserialize)]
 pub enum OmicronZoneExternalIp {
     Floating(OmicronZoneExternalFloatingIp),
     Snat(OmicronZoneExternalSnatIp),
@@ -194,7 +194,7 @@ pub enum OmicronZoneExternalIpKey {
 /// necessary for blueprint planning, and requires that the zone have a single
 /// IP.
 #[derive(
-    Debug, Clone, Copy, PartialEq, Eq, JsonSchema, Serialize, Deserialize,
+    Debug, Clone, Copy, Hash, PartialEq, Eq, JsonSchema, Serialize, Deserialize,
 )]
 pub struct OmicronZoneExternalFloatingIp {
     pub id: ExternalIpUuid,
@@ -222,7 +222,7 @@ impl OmicronZoneExternalFloatingAddr {
 /// necessary for blueprint planning, and requires that the zone have a single
 /// IP.
 #[derive(
-    Debug, Clone, Copy, PartialEq, Eq, JsonSchema, Serialize, Deserialize,
+    Debug, Clone, Copy, Hash, PartialEq, Eq, JsonSchema, Serialize, Deserialize,
 )]
 pub struct OmicronZoneExternalSnatIp {
     pub id: ExternalIpUuid,

--- a/nexus/types/src/deployment/planning_input.rs
+++ b/nexus/types/src/deployment/planning_input.rs
@@ -6,8 +6,6 @@
 //! blueprints.
 
 use super::AddNetworkResourceError;
-use super::Blueprint;
-use super::BlueprintZoneFilter;
 use super::OmicronZoneExternalIp;
 use super::OmicronZoneNetworkResources;
 use super::OmicronZoneNic;
@@ -18,7 +16,6 @@ use crate::external_api::views::SledProvisionPolicy;
 use crate::external_api::views::SledState;
 use clap::ValueEnum;
 use ipnetwork::IpNetwork;
-use newtype_uuid::GenericUuid;
 use omicron_common::address::IpRange;
 use omicron_common::address::Ipv6Subnet;
 use omicron_common::address::SLED_PREFIX;
@@ -28,7 +25,6 @@ use omicron_common::disk::DiskIdentity;
 use omicron_uuid_kinds::OmicronZoneUuid;
 use omicron_uuid_kinds::PhysicalDiskUuid;
 use omicron_uuid_kinds::SledUuid;
-use omicron_uuid_kinds::VnicUuid;
 use omicron_uuid_kinds::ZpoolUuid;
 use schemars::JsonSchema;
 use serde::Deserialize;
@@ -861,35 +857,6 @@ impl PlanningInputBuilder {
         &mut self,
     ) -> &mut OmicronZoneNetworkResources {
         &mut self.network_resources
-    }
-
-    pub fn update_network_resources_from_blueprint(
-        &mut self,
-        blueprint: &Blueprint,
-    ) -> Result<(), PlanningInputBuildError> {
-        self.network_resources = OmicronZoneNetworkResources::new();
-        for (_, zone) in
-            blueprint.all_omicron_zones(BlueprintZoneFilter::ShouldBeRunning)
-        {
-            let service_id = zone.id;
-            if let Some((external_ip, nic)) =
-                zone.zone_type.external_networking()
-            {
-                self.add_omicron_zone_external_ip(service_id, external_ip)?;
-                self.add_omicron_zone_nic(
-                    service_id,
-                    OmicronZoneNic {
-                        // TODO-cleanup use `TypedUuid` everywhere
-                        id: VnicUuid::from_untyped_uuid(nic.id),
-                        mac: nic.mac,
-                        ip: nic.ip,
-                        slot: nic.slot,
-                        primary: nic.primary,
-                    },
-                )?;
-            }
-        }
-        Ok(())
     }
 
     pub fn policy_mut(&mut self) -> &mut Policy {


### PR DESCRIPTION
The "Check the planning input" block of code needs to consider _all_ zones in the parent blueprint, including expunged zones. #6483 fixed the planner's ability to reuse external IPs from expunged zones, but accidentally made these checks incorrect, because it's certainly valid for the planning input to still have records for expunged zones. See https://github.com/oxidecomputer/omicron/pull/6581#discussion_r1765326105 for more context.

We also get to remove the somewhat-awkward `update_network_resources_from_blueprint()` test helper that was needed  to make some tests pass (because we didn't realize the checks being performed here were wrong).