### PR TITLE
[trivial] Fix test name

### DIFF
--- a/nexus/tests/integration_tests/updates.rs
+++ b/nexus/tests/integration_tests/updates.rs
@@ -51,7 +51,7 @@ async fn test_update_uninitialized() -> Result<()> {
     args.exec(&logctx.log).await.context("error executing assemble command")?;
 
     let cptestctx = test_setup_with_config::<omicron_nexus::Server>(
-        "test_update_end_to_end",
+        "test_update_uninitialized",
         &mut config,
         sim::SimMode::Explicit,
         None,


### PR DESCRIPTION
While looking into https://github.com/oxidecomputer/omicron/issues/4949, I noticed that the test name was wrong. While I haven't solved this issue, this will at least make the failure a bit less confusing since the logs will be named correctly.