### PR TITLE
[reconfigurator] Retrieve keeper cluster config information

### DIFF
--- a/clickhouse-admin/api/src/lib.rs
+++ b/clickhouse-admin/api/src/lib.rs
@@ -3,7 +3,9 @@
 // file, You can obtain one at https://mozilla.org/MPL/2.0/.
 
 use clickhouse_admin_types::config::{KeeperConfig, ReplicaConfig};
-use clickhouse_admin_types::{KeeperSettings, Lgif, ServerSettings};
+use clickhouse_admin_types::{
+    KeeperSettings, Lgif, RaftConfig, ServerSettings,
+};
 use dropshot::{
     HttpError, HttpResponseCreated, HttpResponseOk, RequestContext, TypedBody,
 };
@@ -63,4 +65,14 @@ pub trait ClickhouseAdminApi {
     async fn lgif(
         rqctx: RequestContext<Self::Context>,
     ) -> Result<HttpResponseOk<Lgif>, HttpError>;
+
+    /// Retrieve information from ClickHouse virtual node /keeper/config which
+    /// contains last committed cluster configuration.
+    #[endpoint {
+        method = GET,
+        path = "/keeper/raft-config",
+    }]
+    async fn raft_config(
+        rqctx: RequestContext<Self::Context>,
+    ) -> Result<HttpResponseOk<RaftConfig>, HttpError>;
 }

--- a/clickhouse-admin/src/clickhouse_cli.rs
+++ b/clickhouse-admin/src/clickhouse_cli.rs
@@ -4,7 +4,7 @@
 
 use anyhow::Result;
 use camino::Utf8PathBuf;
-use clickhouse_admin_types::Lgif;
+use clickhouse_admin_types::{Lgif, RaftConfig};
 use dropshot::HttpError;
 use illumos_utils::{output_to_exec_error, ExecutionError};
 use slog::Logger;
@@ -77,6 +77,16 @@ impl ClickhouseCli {
             "lgif",
             "Retrieve logically grouped information file",
             Lgif::parse,
+            self.log.clone().unwrap(),
+        )
+        .await
+    }
+
+    pub async fn raft_config(&self) -> Result<RaftConfig, ClickhouseCliError> {
+        self.keeper_client_non_interactive(
+            "get /keeper/config",
+            "Retrieve raft configuration information",
+            RaftConfig::parse,
             self.log.clone().unwrap(),
         )
         .await

--- a/clickhouse-admin/src/http_entrypoints.rs
+++ b/clickhouse-admin/src/http_entrypoints.rs
@@ -5,7 +5,7 @@
 use crate::context::ServerContext;
 use clickhouse_admin_api::*;
 use clickhouse_admin_types::config::{KeeperConfig, ReplicaConfig};
-use clickhouse_admin_types::Lgif;
+use clickhouse_admin_types::{Lgif, RaftConfig};
 use dropshot::{
     HttpError, HttpResponseCreated, HttpResponseOk, RequestContext, TypedBody,
 };
@@ -53,6 +53,14 @@ impl ClickhouseAdminApi for ClickhouseAdminImpl {
     ) -> Result<HttpResponseOk<Lgif>, HttpError> {
         let ctx = rqctx.context();
         let output = ctx.clickhouse_cli().lgif().await?;
+        Ok(HttpResponseOk(output))
+    }
+
+    async fn raft_config(
+        rqctx: RequestContext<Self::Context>,
+    ) -> Result<HttpResponseOk<RaftConfig>, HttpError> {
+        let ctx = rqctx.context();
+        let output = ctx.clickhouse_cli().raft_config().await?;
         Ok(HttpResponseOk(output))
     }
 }

--- a/clickhouse-admin/tests/integration_test.rs
+++ b/clickhouse-admin/tests/integration_test.rs
@@ -25,8 +25,8 @@ async fn test_lgif_parsing() -> anyhow::Result<()> {
     let path = parent_dir.join(format!("{prefix}-oximeter-clickward-test"));
     std::fs::create_dir(&path)?;
 
-    // We use the default ports in `test_schemas_disjoint` and must use a
-    // separate set here in case the two tests run concurrently.
+    // We spin up several replicated clusters and must use a
+    // separate set of ports in case the tests run concurrently.
     let base_ports = BasePorts {
         keeper: 29000,
         raft: 29100,
@@ -80,8 +80,8 @@ async fn test_raft_config_parsing() -> anyhow::Result<()> {
     let path = parent_dir.join(format!("{prefix}-oximeter-clickward-test"));
     std::fs::create_dir(&path)?;
 
-    // We use the default ports in `test_schemas_disjoint` and must use a
-    // separate set here in case the two tests run concurrently.
+    // We spin up several replicated clusters and must use a
+    // separate set of ports in case the tests run concurrently.
     let base_ports = BasePorts {
         keeper: 39000,
         raft: 39100,

--- a/clickhouse-admin/tests/integration_test.rs
+++ b/clickhouse-admin/tests/integration_test.rs
@@ -4,12 +4,15 @@
 
 use anyhow::Context;
 use camino::Utf8PathBuf;
+use clickhouse_admin_types::config::ClickhouseHost;
+use clickhouse_admin_types::{KeeperServerInfo, KeeperServerType, RaftConfig};
 use clickward::{BasePorts, Deployment, DeploymentConfig, KeeperId};
 use dropshot::test_util::log_prefix_for_test;
 use omicron_clickhouse_admin::ClickhouseCli;
 use omicron_test_utils::dev::test_setup_log;
 use oximeter_test_utils::wait_for_keepers;
 use slog::info;
+use std::collections::BTreeSet;
 use std::net::{Ipv6Addr, SocketAddrV6};
 use std::str::FromStr;
 
@@ -60,6 +63,79 @@ async fn test_lgif_parsing() -> anyhow::Result<()> {
 
     // The first log index from a newly created cluster should always be 1
     assert_eq!(lgif.first_log_idx, 1);
+
+    info!(&log, "Cleaning up test");
+    deployment.teardown()?;
+    std::fs::remove_dir_all(path)?;
+    logctx.cleanup_successful();
+    Ok(())
+}
+
+#[tokio::test]
+async fn test_raft_config_parsing() -> anyhow::Result<()> {
+    let logctx = test_setup_log("test_raft_config_parsing");
+    let log = logctx.log.clone();
+
+    let (parent_dir, prefix) = log_prefix_for_test(logctx.test_name());
+    let path = parent_dir.join(format!("{prefix}-oximeter-clickward-test"));
+    std::fs::create_dir(&path)?;
+
+    // We use the default ports in `test_schemas_disjoint` and must use a
+    // separate set here in case the two tests run concurrently.
+    let base_ports = BasePorts {
+        keeper: 39000,
+        raft: 39100,
+        clickhouse_tcp: 39200,
+        clickhouse_http: 39300,
+        clickhouse_interserver_http: 39400,
+    };
+
+    let config = DeploymentConfig {
+        path: path.clone(),
+        base_ports,
+        cluster_name: "oximeter_cluster".to_string(),
+    };
+
+    let mut deployment = Deployment::new(config);
+
+    let num_keepers = 3;
+    let num_replicas = 1;
+    deployment
+        .generate_config(num_keepers, num_replicas)
+        .context("failed to generate config")?;
+    deployment.deploy().context("failed to deploy")?;
+
+    wait_for_keepers(
+        &log,
+        &deployment,
+        (1..=num_keepers).map(KeeperId).collect(),
+    )
+    .await?;
+
+    let clickhouse_cli = ClickhouseCli::new(
+        Utf8PathBuf::from_str("clickhouse").unwrap(),
+        SocketAddrV6::new(Ipv6Addr::LOCALHOST, 39001, 0, 0),
+    )
+    .with_log(log.clone());
+
+    let raft_config = clickhouse_cli.raft_config().await.unwrap();
+
+    let mut keeper_servers = BTreeSet::new();
+
+    for i in 1..=num_keepers {
+        let raft_port = u16::try_from(39100 + i).unwrap();
+        keeper_servers.insert(KeeperServerInfo {
+            server_id: clickhouse_admin_types::KeeperId(i),
+            host: ClickhouseHost::Ipv6("::1".parse().unwrap()),
+            raft_port,
+            server_type: KeeperServerType::Participant,
+            priority: 1,
+        });
+    }
+
+    let expected_raft_config = RaftConfig { keeper_servers };
+
+    assert_eq!(raft_config, expected_raft_config);
 
     info!(&log, "Cleaning up test");
     deployment.teardown()?;

--- a/clickhouse-admin/types/src/config.rs
+++ b/clickhouse-admin/types/src/config.rs
@@ -294,7 +294,17 @@ impl KeeperConfigsForReplica {
     }
 }
 
-#[derive(Debug, Clone, PartialEq, Eq, Deserialize, Serialize, JsonSchema)]
+#[derive(
+    Debug,
+    Clone,
+    PartialEq,
+    Eq,
+    Deserialize,
+    PartialOrd,
+    Ord,
+    Serialize,
+    JsonSchema,
+)]
 #[serde(rename_all = "snake_case")]
 pub enum ClickhouseHost {
     Ipv6(Ipv6Addr),

--- a/clickhouse-admin/types/src/lib.rs
+++ b/clickhouse-admin/types/src/lib.rs
@@ -362,9 +362,11 @@ pub struct KeeperServerInfo {
     pub host: ClickhouseHost,
     /// Keeper server raft port
     pub raft_port: u16,
-    /// A keeper server either participant or learner (learner does not participate in leader elections).
+    /// A keeper server either participant or learner
+    /// (learner does not participate in leader elections).
     pub server_type: KeeperServerType,
-    /// non-negative integer telling which nodes should be prioritised on leader elections.
+    /// non-negative integer telling which nodes should be
+    /// prioritised on leader elections.
     /// Priority of 0 means server will never be a leader.
     pub priority: u16,
 }

--- a/clickhouse-admin/types/src/lib.rs
+++ b/clickhouse-admin/types/src/lib.rs
@@ -326,7 +326,7 @@ impl Lgif {
     JsonSchema,
 )]
 #[serde(rename_all = "snake_case")]
-enum KeeperServerType {
+pub enum KeeperServerType {
     Participant,
     Learner,
 }
@@ -357,16 +357,16 @@ impl FromStr for KeeperServerType {
 #[serde(rename_all = "snake_case")]
 pub struct KeeperServerInfo {
     /// Unique, immutable ID of the keeper server
-    server_id: KeeperId,
+    pub server_id: KeeperId,
     /// Host of the keeper server
-    host: ClickhouseHost,
+    pub host: ClickhouseHost,
     /// Keeper server raft port
-    raft_port: u16,
+    pub raft_port: u16,
     /// A keeper server either participant or learner (learner does not participate in leader elections).
-    server_type: KeeperServerType,
+    pub server_type: KeeperServerType,
     /// non-negative integer telling which nodes should be prioritised on leader elections.
     /// Priority of 0 means server will never be a leader.
-    priority: u16,
+    pub priority: u16,
 }
 
 #[derive(
@@ -383,7 +383,7 @@ pub struct KeeperServerInfo {
 #[serde(rename_all = "snake_case")]
 /// Keeper raft configuration information
 pub struct RaftConfig {
-    keeper_servers: BTreeSet<KeeperServerInfo>,
+    pub keeper_servers: BTreeSet<KeeperServerInfo>,
 }
 
 impl RaftConfig {

--- a/clickhouse-admin/types/src/lib.rs
+++ b/clickhouse-admin/types/src/lib.rs
@@ -444,11 +444,9 @@ impl RaftConfig {
 
             // Retrieve port
             let Some(address) = split_info.next() else {
-                // Test this error
                 bail!("Returned None while attempting to retrieve address")
             };
             let Some(port) = address.split(':').last() else {
-                // Test this error
                 bail!("A port could not be extracted from {address}")
             };
             let raft_port = match u16::from_str(port) {
@@ -461,7 +459,6 @@ impl RaftConfig {
             // Retrieve host
             let p = format!(":{}", port);
             let Some(h) = address.split(&p).next() else {
-                // Test this error
                 bail!("A host could not be extracted from {address}. Missing port {port}")
             };
             // The ouput we get from running the clickhouse keeper-client
@@ -472,14 +469,12 @@ impl RaftConfig {
 
             // Retrieve server_type
             let Some(s_type) = split_info.next() else {
-                // Test this error
                 bail!("Returned None while attempting to retrieve server type")
             };
             let server_type = KeeperServerType::from_str(s_type)?;
 
             // Retrieve priority
             let Some(s_priority) = split_info.next() else {
-                // Test this error
                 bail!("Returned None while attempting to retrieve priority")
             };
             let priority = match u16::from_str(s_priority) {

--- a/openapi/clickhouse-admin.json
+++ b/openapi/clickhouse-admin.json
@@ -70,6 +70,31 @@
         }
       }
     },
+    "/keeper/raft-config": {
+      "get": {
+        "summary": "Retrieve information from ClickHouse virtual node /keeper/config which",
+        "description": "contains last committed cluster configuration.",
+        "operationId": "raft_config",
+        "responses": {
+          "200": {
+            "description": "successful operation",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/RaftConfig"
+                }
+              }
+            }
+          },
+          "4XX": {
+            "$ref": "#/components/responses/Error"
+          },
+          "5XX": {
+            "$ref": "#/components/responses/Error"
+          }
+        }
+      }
+    },
     "/server/config": {
       "put": {
         "summary": "Generate a ClickHouse configuration file for a server node on a specified",
@@ -335,6 +360,61 @@
           "port"
         ]
       },
+      "KeeperServerInfo": {
+        "type": "object",
+        "properties": {
+          "host": {
+            "description": "Host of the keeper server",
+            "allOf": [
+              {
+                "$ref": "#/components/schemas/ClickhouseHost"
+              }
+            ]
+          },
+          "priority": {
+            "description": "non-negative integer telling which nodes should be prioritised on leader elections. Priority of 0 means server will never be a leader.",
+            "type": "integer",
+            "format": "uint16",
+            "minimum": 0
+          },
+          "raft_port": {
+            "description": "Keeper server raft port",
+            "type": "integer",
+            "format": "uint16",
+            "minimum": 0
+          },
+          "server_id": {
+            "description": "Unique, immutable ID of the keeper server",
+            "allOf": [
+              {
+                "$ref": "#/components/schemas/KeeperId"
+              }
+            ]
+          },
+          "server_type": {
+            "description": "A keeper server either participant or learner (learner does not participate in leader elections).",
+            "allOf": [
+              {
+                "$ref": "#/components/schemas/KeeperServerType"
+              }
+            ]
+          }
+        },
+        "required": [
+          "host",
+          "priority",
+          "raft_port",
+          "server_id",
+          "server_type"
+        ]
+      },
+      "KeeperServerType": {
+        "type": "string",
+        "enum": [
+          "participant",
+          "learner"
+        ]
+      },
       "KeeperSettings": {
         "description": "Configurable settings for a ClickHouse keeper node.",
         "type": "object",
@@ -501,6 +581,22 @@
           "cluster",
           "replica",
           "shard"
+        ]
+      },
+      "RaftConfig": {
+        "description": "Keeper raft configuration information",
+        "type": "object",
+        "properties": {
+          "keeper_servers": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/KeeperServerInfo"
+            },
+            "uniqueItems": true
+          }
+        },
+        "required": [
+          "keeper_servers"
         ]
       },
       "RaftServerConfig": {


### PR DESCRIPTION
## Overview

This commit implements a new clickhouse-admin endpoint to retrieve and parse information from the ClickHouse virtual node `/keeper/config` which contains the last committed cluster configuration.

## Purpose

The main purpose of retrieving this information is to have the ability to populate the inventory's `raft_config`  in `ClickhouseKeeperClusterMembership`. 

https://github.com/oxidecomputer/omicron/blob/453311a880075b9f89626bb20cca1c1cd85ffb4f/nexus/types/src/inventory.rs#L499-L503

In a follow up PR an endpoint that specifically retrieves all information to populate `ClickhouseKeeperClusterMembership`. This will be done by making several calls to the `clickhouse keeper-client` and using the parsing function here to populate `raft_config`.

The endpoint itself will be useful to retrieve information for debugging.

## Manual testing

```console
$ curl http://[::1]:8888/keeper/raft-config
{"keeper_servers":[{"server_id":1,"host":{"ipv6":"::1"},"raft_port":21001,"server_type":"participant","priority":1},{"server_id":2,"host":{"ipv6":"::1"},"raft_port":21002,"server_type":"participant","priority":1},{"server_id":3,"host":{"ipv6":"::1"},"raft_port":21003,"server_type":"participant","priority":1}]}
```

Related: #5999 