### PR TITLE
fix typo in disk detach error message

### DIFF
--- a/nexus/db-queries/src/db/datastore/disk.rs
+++ b/nexus/db-queries/src/db/datastore/disk.rs
@@ -379,7 +379,7 @@ impl DataStore {
                             if collection.runtime_state.propolis_id.is_some() {
                                 return Err(
                                     Error::invalid_request(
-                                        "cannot attach disk: instance is not \
+                                        "cannot detach disk: instance is not \
                                         fully stopped"
                                     )
                                 );


### PR DESCRIPTION
a POST to `/v1/instances/*/disks/detach` telling me about how i can't attach was very funny, i'll admit