### PR TITLE
[omdb] Add `omdb instance info` command

### DIFF
--- a/dev-tools/omdb/src/bin/omdb/db.rs
+++ b/dev-tools/omdb/src/bin/omdb/db.rs
@@ -313,7 +313,7 @@ enum DbCommands {
     Sleds(SledsArgs),
     /// Print information about customer instances.
     Instance(InstanceArgs),
-    /// Alias to `omdb instances list`.
+    /// Alias to `omdb instance list`.
     Instances(InstanceListArgs),
     /// Print information about the network
     Network(NetworkArgs),

--- a/dev-tools/omdb/src/bin/omdb/db.rs
+++ b/dev-tools/omdb/src/bin/omdb/db.rs
@@ -2943,22 +2943,12 @@ async fn cmd_db_instance_info(
         MIGRATION_ID,
         UPDATER_LOCK,
     ]);
-    let mut has_conditions = false;
 
     if instance.time_deleted().is_some() {
-        println!("(i) instance has been deleted");
-        has_conditions = true;
-    }
-    if instance.runtime_state.migration_id.is_some() {
-        println!("(i) instance is migrating");
-        has_conditions = true;
+        println!("\n (i) instance has been deleted");
     }
     if instance.updater_id.is_some() {
-        println!("(i) instance is being updated...");
-        has_conditions = true;
-    }
-    if has_conditions {
-        println!();
+        println!("\n (i) instance is being updated...");
     }
 
     println!("\nINSTANCE\n");

--- a/dev-tools/omdb/src/bin/omdb/db.rs
+++ b/dev-tools/omdb/src/bin/omdb/db.rs
@@ -420,9 +420,6 @@ enum InstanceCommands {
     #[clap(alias = "ls")]
     List(InstanceListArgs),
     /// show detailed output for the selected instance.
-    ///
-    /// instances can be selected either by their UUID or by the instance and
-    /// project name.
     #[clap(alias = "show")]
     Info(InstanceInfoArgs),
 }

--- a/dev-tools/omdb/src/bin/omdb/db.rs
+++ b/dev-tools/omdb/src/bin/omdb/db.rs
@@ -85,7 +85,6 @@ use nexus_db_model::Vmm;
 use nexus_db_model::Volume;
 use nexus_db_model::VpcSubnet;
 use nexus_db_model::Zpool;
-use nexus_db_queries::authz;
 use nexus_db_queries::context::OpContext;
 use nexus_db_queries::db;
 use nexus_db_queries::db::datastore::read_only_resources_associated_with_volume;

--- a/dev-tools/omdb/src/bin/omdb/db.rs
+++ b/dev-tools/omdb/src/bin/omdb/db.rs
@@ -2906,11 +2906,11 @@ async fn cmd_db_instance_info(
     // code as well. Unfortunately, we can't just destructure the struct here to
     // make sure this code breaks, since the `identity` field isn't public.
     // So...just don't forget to do that, I  guess.
-    println!("instance: {}", instance.id());
-    println!("name: {}", instance.name());
-    println!("description: {}", instance.description());
-    println!("created: {}", instance.time_created());
-    println!("last modified: {}", instance.time_modified());
+    println!("\ninstance: {}", instance.id());
+    println!("  name: {}", instance.name());
+    println!("  description: {}", instance.description());
+    println!("  created: {}", instance.time_created());
+    println!("  last modified: {}", instance.time_modified());
     println!("configuration:");
     println!("  vCPUs: {}", instance.ncpus.0 .0);
     println!("  memory: {}", instance.memory.0);
@@ -2927,27 +2927,21 @@ async fn cmd_db_instance_info(
     } = instance.runtime();
     println!("  state: {nexus_state:?}");
     println!("  generation: {}", r#gen.0);
-    println!("  last updated: {time_updated:?}\n");
+    println!("  last updated: {time_updated:?}");
     println!("  active VMM ID: {propolis_id:?}");
-    if let Some(ref vmm) = active_vmm {
-        println!(
-            "    |\n{}\n",
-            textwrap::indent("    ", &format!("+---> {vmm:#?}"))
-        );
-    }
     println!("  migration target VMM ID: {dst_propolis_id:?}");
-    if let Some(ref vmm) = target_vmm {
-        println!(
-            "    |\n{}\n",
-            textwrap::indent("    ", &format!("+---> {vmm:#?}"))
-        );
-    }
     println!("  migration ID: {migration_id:?}");
+
+    if let Some(ref vmm) = active_vmm {
+        println!("\nactive VMM: {vmm:#?}");
+    }
+
+    if let Some(ref vmm) = target_vmm {
+        println!("\nmigration target VMM: {vmm:#?}");
+    }
+
     if let Some(ref migration) = migration {
-        println!(
-            "    |\n{}\n",
-            textwrap::indent("    ", &format!("+---> {migration:#?}"))
-        );
+        println!("\ncurrent active migration: {migration:#?}");
     }
 
     // Check for weirdness.

--- a/dev-tools/omdb/src/bin/omdb/db.rs
+++ b/dev-tools/omdb/src/bin/omdb/db.rs
@@ -2970,7 +2970,7 @@ async fn cmd_db_instance_info(
         MIGRATION_RECORD,
         TARGET_VMM_RECORD,
     ]);
-    println!("\nINSTANCE");
+    println!("\n{:=<80}", "== INSTANCE ");
     println!("    {ID:>WIDTH$}: {}", instance.id());
     println!("    {PROJECT_ID:>WIDTH$}: {}", instance.project_id);
     println!("    {NAME:>WIDTH$}: {}", instance.name());
@@ -2981,12 +2981,12 @@ async fn cmd_db_instance_info(
         println!("/!\\ {DELETED:>WIDTH$}: {deleted}");
     }
 
-    println!("\nCONFIGURATION");
+    println!("\n{:=<80}", "== CONFIGURATION ");
     println!("    {VCPUS:>WIDTH$}: {}", instance.ncpus.0 .0);
     println!("    {MEMORY:>WIDTH$}: {}", instance.memory.0);
     println!("    {HOSTNAME:>WIDTH$}: {}", instance.hostname);
     println!("    {AUTO_RESTART:>WIDTH$}: {:?}", instance.auto_restart_policy);
-    println!("\nRUNTIME STATE");
+    println!("\n{:=<80}", "== RUNTIME STATE ");
     let InstanceRuntimeState {
         time_updated,
         propolis_id,
@@ -3132,7 +3132,7 @@ async fn cmd_db_instance_info(
             .with(tabled::settings::Padding::new(4, 1, 0, 0))
             .to_string();
 
-        println!("\nMIGRATION HISTORY\n\n{table}");
+        println!("\n{:=<80}\n\n{table}", "== MIGRATION HISTORY");
     }
 
     Ok(())

--- a/dev-tools/omdb/src/bin/omdb/db.rs
+++ b/dev-tools/omdb/src/bin/omdb/db.rs
@@ -2926,11 +2926,18 @@ async fn cmd_db_instance_info(
         r#gen,
     } = instance.runtime();
     println!("  state: {nexus_state:?}");
-    println!("  generation: {}", r#gen.0);
+    println!("  at generation: {}", r#gen.0);
     println!("  last updated: {time_updated:?}");
     println!("  active VMM ID: {propolis_id:?}");
     println!("  migration target VMM ID: {dst_propolis_id:?}");
     println!("  migration ID: {migration_id:?}");
+    println!("updater lock:");
+    if let Some(id) = instance.updater_id {
+        println!("  state: LOCKED by {id}")
+    } else {
+        println!("  state: UNLOCKED");
+    }
+    println!("  at generation: {}", instance.updater_gen.0);
 
     if let Some(ref vmm) = active_vmm {
         println!("\nactive VMM: {vmm:#?}");

--- a/dev-tools/omdb/src/bin/omdb/helpers.rs
+++ b/dev-tools/omdb/src/bin/omdb/helpers.rs
@@ -18,3 +18,16 @@ pub(crate) fn should_colorize(color: ColorChoice, stream: Stream) -> bool {
         ColorChoice::Never => false,
     }
 }
+
+pub(crate) const fn const_max_len(strs: &[&str]) -> usize {
+    let mut max = 0;
+    let mut i = 0;
+    while i < strs.len() {
+        let len = strs[i].len();
+        if len > max {
+            max = len;
+        }
+        i += 1;
+    }
+    max
+}

--- a/dev-tools/omdb/src/bin/omdb/nexus.rs
+++ b/dev-tools/omdb/src/bin/omdb/nexus.rs
@@ -6,6 +6,7 @@
 
 use crate::check_allow_destructive::DestructiveOperationToken;
 use crate::db::DbUrlOptions;
+use crate::helpers::const_max_len;
 use crate::helpers::should_colorize;
 use crate::helpers::CONNECTION_OPTIONS_HEADING;
 use crate::Omdb;
@@ -2663,17 +2664,4 @@ async fn cmd_nexus_sled_expunge_disk(
         .context("expunging disk")?;
     eprintln!("expunged disk {}", args.physical_disk_id);
     Ok(())
-}
-
-const fn const_max_len(strs: &[&str]) -> usize {
-    let mut max = 0;
-    let mut i = 0;
-    while i < strs.len() {
-        let len = strs[i].len();
-        if len > max {
-            max = len;
-        }
-        i += 1;
-    }
-    max
 }

--- a/dev-tools/omdb/tests/usage_errors.out
+++ b/dev-tools/omdb/tests/usage_errors.out
@@ -124,7 +124,7 @@ Commands:
                                manually triggering one
   sleds                        Print information about sleds
   instance                     Print information about customer instances
-  instances                    Alias to `omdb instances list`
+  instances                    Alias to `omdb instance list`
   network                      Print information about the network
   migrations                   Print information about migrations
   snapshots                    Print information about snapshots
@@ -172,7 +172,7 @@ Commands:
                                manually triggering one
   sleds                        Print information about sleds
   instance                     Print information about customer instances
-  instances                    Alias to `omdb instances list`
+  instances                    Alias to `omdb instance list`
   network                      Print information about the network
   migrations                   Print information about migrations
   snapshots                    Print information about snapshots

--- a/dev-tools/omdb/tests/usage_errors.out
+++ b/dev-tools/omdb/tests/usage_errors.out
@@ -123,7 +123,8 @@ Commands:
   region-snapshot-replacement  Query for information about region snapshot replacements, optionally
                                manually triggering one
   sleds                        Print information about sleds
-  instances                    Print information about customer instances
+  instance                     Print information about customer instances
+  instances                    Alias to `omdb instances list`
   network                      Print information about the network
   migrations                   Print information about migrations
   snapshots                    Print information about snapshots
@@ -170,7 +171,8 @@ Commands:
   region-snapshot-replacement  Query for information about region snapshot replacements, optionally
                                manually triggering one
   sleds                        Print information about sleds
-  instances                    Print information about customer instances
+  instance                     Print information about customer instances
+  instances                    Alias to `omdb instances list`
   network                      Print information about the network
   migrations                   Print information about migrations
   snapshots                    Print information about snapshots

--- a/nexus/db-queries/src/db/datastore/instance.rs
+++ b/nexus/db-queries/src/db/datastore/instance.rs
@@ -517,7 +517,7 @@ impl DataStore {
         let conn = self.pool_connection_authorized(opctx).await?;
 
         self.instance_fetch_all_on_connection(
-            conn,
+            &conn,
             &InstanceUuid::from_untyped_uuid(authz_instance.id()),
         )
         .await

--- a/nexus/db-queries/src/db/datastore/instance.rs
+++ b/nexus/db-queries/src/db/datastore/instance.rs
@@ -517,7 +517,7 @@ impl DataStore {
         let conn = self.pool_connection_authorized(opctx).await?;
 
         self.instance_fetch_all_on_connection(
-            &*conn,
+            conn,
             &InstanceUuid::from_untyped_uuid(authz_instance.id()),
         )
         .await

--- a/nexus/db-queries/src/db/datastore/instance.rs
+++ b/nexus/db-queries/src/db/datastore/instance.rs
@@ -30,6 +30,7 @@ use crate::db::model::Vmm;
 use crate::db::model::VmmState;
 use crate::db::pagination::paginated;
 use crate::db::pagination::paginated_multicolumn;
+use crate::db::pool::DbConnection;
 use crate::db::update_and_check::UpdateAndCheck;
 use crate::db::update_and_check::UpdateAndQueryResult;
 use crate::db::update_and_check::UpdateStatus;
@@ -513,10 +514,29 @@ impl DataStore {
         authz_instance: &authz::Instance,
     ) -> LookupResult<InstanceGestalt> {
         opctx.authorize(authz::Action::Read, authz_instance).await?;
+        let conn = self.pool_connection_authorized(opctx).await?;
 
+        self.instance_fetch_all_on_connection(
+            &*conn,
+            &InstanceUuid::from_untyped_uuid(authz_instance.id()),
+        )
+        .await
+    }
+
+    /// The inner workings of `instance_fetch_all`, unauthorized version for
+    /// OMDB use.
+    ///
+    /// The rest of Nexus should use [`DataStore::instance_fetch_all`] instead.
+    pub async fn instance_fetch_all_on_connection(
+        &self,
+        conn: &async_bb8_diesel::Connection<DbConnection>,
+        instance_id: &InstanceUuid,
+    ) -> LookupResult<InstanceGestalt> {
         use db::schema::instance::dsl as instance_dsl;
         use db::schema::migration::dsl as migration_dsl;
         use db::schema::vmm;
+
+        let id = instance_id.into_untyped_uuid();
 
         // Create a Diesel alias to allow us to LEFT JOIN the `instance` table
         // with the `vmm` table twice; once on the `active_propolis_id` and once
@@ -527,7 +547,7 @@ impl DataStore {
             <Vmm as Selectable<diesel::pg::Pg>>::construct_selection();
 
         let query = instance_dsl::instance
-            .filter(instance_dsl::id.eq(authz_instance.id()))
+            .filter(instance_dsl::id.eq(id))
             .filter(instance_dsl::time_deleted.is_null())
             .left_join(
                 active_vmm.on(active_vmm
@@ -564,7 +584,7 @@ impl DataStore {
                     Option<Vmm>,
                     Option<Migration>,
                 )>(
-                    &*self.pool_connection_authorized(opctx).await?
+                    conn,
                 )
                 .await
                 .map_err(|e| {
@@ -572,7 +592,7 @@ impl DataStore {
                         e,
                         ErrorHandler::NotFoundByLookup(
                             ResourceType::Instance,
-                            LookupType::ById(authz_instance.id()),
+                            LookupType::ById(id),
                         ),
                     )
                 })?;


### PR DESCRIPTION
Presently, `omdb` can be used to query the database for instance records
using the `omdb instances` command. However, this command does not
output all the database state associated with an instance. Instead, it
displays the instance's name, UUID, effective state, active Propolis
UUID, sled UUID, and sled serial (the last three only if the instance is
running).

This is some of the most useful information about a customer instance,
but it's not *all* of the information we have about it. Debugging issues
related to instance state management may require other information from
the instance record, as well as from the instance's active VMM record,
and its target VMM and active migration records (if it is migrating).
Adding all of these additional details to the `omdb db instances`
command is a bit of a non-starter, though. Since that command outputs a
table of all instances, with one line per instance, the output is
already *much* wider than 80 columns, and requires a pretty wide
terminal to be readable --- once the table has line wrapped, it's much
harder to interpret. Therefore, I've added an `omdb db instance info`
command that outputs a complete dump of the state of a *single*
instance. Since this command is no longer constrained to putting all
salient details about the instance on a single line in a table, we can
show every field in the instance's DB representation without having to
worry about wrapping.

Output from `omdb db instance info` looks like this (yes, I spent
entirely too long tweaking the formatting :sweat_smile:):

```console
root@oxz_switch1:~# /var/tmp/omdb-eliza-test-12 db instance info 3e9f7bcb-1ae8-4708-af4f-4b6452af3d1f
note: database URL not specified.  Will search DNS.
note: (override with --db-url or OMDB_DB_URL)
note: using DNS server for subnet fd00:1122:3344::/48
note: (if this is not right, use --dns-server to specify an alternate DNS server)
note: using database URL postgresql://root@[fd00:1122:3344:109::3]:32221,[fd00:1122:3344:105::3]:32221,[fd00:1122:3344:10b::3]:32221,[fd00:1122:3344:107::3]:32221,[fd00:1122:3344:108::3]:32221/omicron?sslmode=disable
note: database schema version matches expected (98.0.0)

INSTANCE

                  ID: 3e9f7bcb-1ae8-4708-af4f-4b6452af3d1f
                name: rocky9-0
         description: application instance
          created at: 2024-08-13 16:22:18.303110 UTC
    last modified at: 2024-08-13 16:22:18.303110 UTC

CONFIGURATION

               vCPUs: 32
              memory: 96 GiB
            hostname: node0
 auto-restart policy: None

RUNTIME STATE

               state: Vmm
     last updated at: 2024-09-19T00:32:23.871767Z (generation 16)
       active VMM ID: Some(e1a87a49-7ab7-40ff-965e-4d55cc6db394)
       target VMM ID: None
        migration ID: None
        updater lock: UNLOCKED at generation: 16

   active VMM record:
     Vmm {
         id: e1a87a49-7ab7-40ff-965e-4d55cc6db394,
         time_created: 2024-09-19T00:32:23.816650Z,
         time_deleted: None,
         instance_id: 3e9f7bcb-1ae8-4708-af4f-4b6452af3d1f,
         sled_id: f15774c1-b8e5-434f-a493-ec43f96cba06,
         propolis_ip: V6(
             Ipv6Network {
                 addr: fd00:1122:3344:105::1:580,
                 prefix: 128,
             },
         ),
         propolis_port: SqlU16(
             12400,
         ),
         runtime: VmmRuntimeState {
             time_state_updated: 2024-09-19T00:32:34.197708Z,
             gen: Generation(
                 Generation(
                     4,
                 ),
             ),
             state: Running,
         },
     }
root@oxz_switch1:~#
```

I've also added `omdb db instance list` (or `instance ls`) as a subcommand of
`omdb db instance`, but these are simply aliased to the current `db instances`
command. It just seemed nice to have additional verbs. 