### PR TITLE
driver test timeout is probably too short

### DIFF
--- a/nexus/src/app/background/driver.rs
+++ b/nexus/src/app/background/driver.rs
@@ -571,8 +571,9 @@ mod test {
         let duration = start.elapsed();
         println!("rx1 -> 3 took {:?}", duration);
         assert!(
-            duration.as_millis() < 1000,
-            "took longer than 1s to activate our every-100ms-task three times"
+            duration.as_millis() < 1250,
+            "took longer than 1.25s to activate our \
+             every-100ms-task three times"
         );
         assert!(duration.as_millis() >= 300);
         // Check how the last activation was reported.


### PR DESCRIPTION
See #6613.  As always, I'm a little skeptical of bumping timeouts for tests.  In this case, we know the thing _did_ complete in just barely longer than the current timeout.  Given that we hadn't seen this flake before, I'm hoping that 1.02s was a somewhat extreme outlier and 1.25s will be enough.  (On the other hand, maybe we've grown some CPU-hungry tests that compete with this one and we may start seeing longer timeouts more regularly, in which case we can probably bump this a fair bit more.  All we're really trying to do in this test is verify that periodic tasks do get activated periodically, ideally somewhat close to their intended period.)

Fixes #6613.