### PR TITLE
Soft-delete volumes in a transaction, not CTE

### DIFF
--- a/nexus/db-queries/src/db/queries/volume.rs
+++ b/nexus/db-queries/src/db/queries/volume.rs
@@ -18,62 +18,6 @@ use diesel::Column;
 use diesel::Expression;
 use diesel::QueryResult;
 use diesel::RunQueryDsl;
-use uuid::Uuid;
-
-/// Produces a query fragment that will act as a filter for the data modifying
-/// sub-queries of the "decrease crucible resource count and soft delete volume" CTE.
-///
-/// The output should look like:
-///
-/// ```sql
-/// (SELECT CASE
-///   WHEN volume.resources_to_clean_up is null then true
-///   ELSE false
-/// END
-/// FROM volume WHERE id = '{}')
-/// ```
-#[must_use = "Queries must be executed"]
-struct ResourcesToCleanUpColumnIsNull {
-    volume_id: Uuid,
-}
-
-impl ResourcesToCleanUpColumnIsNull {
-    pub fn new(volume_id: Uuid) -> Self {
-        Self { volume_id }
-    }
-}
-
-impl QueryId for ResourcesToCleanUpColumnIsNull {
-    type QueryId = ();
-    const HAS_STATIC_QUERY_ID: bool = false;
-}
-
-impl QueryFragment<Pg> for ResourcesToCleanUpColumnIsNull {
-    fn walk_ast<'a>(&'a self, mut out: AstPass<'_, 'a, Pg>) -> QueryResult<()> {
-        use db::schema::volume;
-
-        out.push_sql("SELECT CASE WHEN ");
-        out.push_identifier(volume::dsl::resources_to_clean_up::NAME)?;
-        out.push_sql(" is null then true ELSE false END FROM ");
-        volume::dsl::volume.walk_ast(out.reborrow())?;
-        out.push_sql(" WHERE ");
-        out.push_identifier(volume::dsl::id::NAME)?;
-        out.push_sql(" = ");
-        out.push_bind_param::<sql_types::Uuid, Uuid>(&self.volume_id)?;
-
-        Ok(())
-    }
-}
-
-impl Expression for ResourcesToCleanUpColumnIsNull {
-    type SqlType = sql_types::Bool;
-}
-
-impl<GroupByClause> ValidGrouping<GroupByClause>
-    for ResourcesToCleanUpColumnIsNull
-{
-    type IsAggregate = is_aggregate::Never;
-}
 
 /// Produces a query fragment that will conditionally reduce the volume
 /// references for region_snapshot rows whose snapshot_addr column is part of a
@@ -91,23 +35,17 @@ impl<GroupByClause> ValidGrouping<GroupByClause>
 ///  where
 ///   snapshot_addr in ('a1', 'a2', 'a3') and
 ///   volume_references >= 1 and
-///   deleting = false and
-///   (<ResourcesToCleanUpColumnIsNull>)
+///   deleting = false
 ///  returning *
 /// ```
 #[must_use = "Queries must be executed"]
-struct ConditionallyDecreaseReferences {
-    resources_to_clean_up_column_is_null_clause: ResourcesToCleanUpColumnIsNull,
+pub struct ConditionallyDecreaseReferences {
     snapshot_addrs: Vec<String>,
 }
 
 impl ConditionallyDecreaseReferences {
-    pub fn new(volume_id: Uuid, snapshot_addrs: Vec<String>) -> Self {
-        Self {
-            resources_to_clean_up_column_is_null_clause:
-                ResourcesToCleanUpColumnIsNull::new(volume_id),
-            snapshot_addrs,
-        }
+    pub fn new(snapshot_addrs: Vec<String>) -> Self {
+        Self { snapshot_addrs }
     }
 }
 
@@ -134,8 +72,8 @@ impl QueryFragment<Pg> for ConditionallyDecreaseReferences {
         out.push_identifier(dsl::snapshot_addr::NAME)?;
         out.push_sql(" IN (");
 
-        // If self.snapshot_addrs is empty, this query fragment will intentionally not update any
-        // region_snapshot rows. The rest of the CTE should still run to completion.
+        // If self.snapshot_addrs is empty, this query fragment will
+        // intentionally not update any region_snapshot rows.
         for (i, snapshot_addr) in self.snapshot_addrs.iter().enumerate() {
             out.push_bind_param::<sql_types::Text, String>(snapshot_addr)?;
             if i == self.snapshot_addrs.len() - 1 {
@@ -149,10 +87,7 @@ impl QueryFragment<Pg> for ConditionallyDecreaseReferences {
         out.push_identifier(dsl::volume_references::NAME)?;
         out.push_sql(" >= 1 AND ");
         out.push_identifier(dsl::deleting::NAME)?;
-        out.push_sql(" = false AND ( ");
-        self.resources_to_clean_up_column_is_null_clause
-            .walk_ast(out.reborrow())?;
-        out.push_sql(") RETURNING *");
+        out.push_sql(" = false RETURNING *");
 
         Ok(())
     }
@@ -168,343 +103,12 @@ impl<GroupByClause> ValidGrouping<GroupByClause>
     type IsAggregate = is_aggregate::Never;
 }
 
-/// Produces a query fragment that will find all resources that can be cleaned
-/// up as a result of a volume delete, and build a serialized JSON struct that
-/// can be deserialized into a CrucibleResources::V3 variant. The output of this
-/// will be written into the 'resources_to_clean_up` column of the volume being
-/// soft-deleted.
-///
-/// The output should look like:
-///
-/// ```sql
-/// json_build_object('V3',
-///       json_build_object(
-///         'regions', (select json_agg(id) from region left join region_snapshot on region.id = region_snapshot.region_id where (region_snapshot.volume_references = 0 or region_snapshot.volume_references is null) and region.volume_id = '<volume_id>'),
-///         'region_snapshots', (select json_agg(json_build_object('dataset', dataset_id, 'region', region_id, 'snapshot', snapshot_id)) from t2 where t2.volume_references = 0)
-///       )
-///     )
-/// ```
-///
-/// Note that the query that populates the `region_snapshots` field is intended
-/// to use the output of `ConditionallyDecreaseReferences`, which only returns
-/// `region_snapshot` rows modified by the UPDATE statement in that query
-/// fragment. If the query that populates the `regions` field were to also use
-/// only the modified rows, it would never match the actual regions of the
-/// volume: the modified rows would be for parts of the read-only parent, where
-/// the regions are in the sub-volumes. This author can't imagine a volume where
-/// the read-only parent had region snapshots of its own regions...
-///
-/// The query that populates the `regions` field uses a LEFT JOIN in the case
-/// that there are no matching region snapshot rows.
-///
-/// Note if json_agg is executing over zero rows, then the output is `null`, not
-/// `[]`. For example, if the sub-query meant to return regions to clean up
-/// returned zero rows, the output of json_build_object would look like:
-///
-/// ```json
-/// {
-///   "V3": {
-///     "regions": null,
-///     ...
-///   }
-/// }
-/// ```
-///
-/// Correctly handling `null` here is done in the deserializer for
-/// CrucibleResourcesV3.
-///
-/// A populated object should look like:
-///
-/// ```json
-/// {
-///   "V3": {
-///     "regions": [
-///       "9caae5bb-a212-4496-882a-af1ee242c62f",
-///       "713c84ee-6b13-4301-b7a2-36debc7ee37e"
-///     ],
-///     "region_snapshots": [
-///       {
-///         "dataset": "33ec5f07-5e7f-481e-966a-0fbc50d9ed3b",
-///         "region": "1e2b1a75-9a58-4e5c-89a0-0cfd19ba055a",
-///         "snapshot": "f7c8ed87-a67e-4d2b-8f35-3e8034de1c6f"
-///       },
-///       {
-///         "dataset": "5a16b1d6-7381-4c51-b49c-997624d43ead",
-///         "region": "52b4c9bc-d1c9-4a3b-87c3-8e4501a883b0",
-///         "snapshot": "2dd912e4-74db-409a-8d55-9795496cb320"
-///       }
-///     ]
-///   }
-/// }
-/// ```
-#[must_use = "Queries must be executed"]
-struct BuildJsonResourcesToCleanUp {
-    table: &'static str,
-    volume_id: Uuid,
-}
-
-impl BuildJsonResourcesToCleanUp {
-    pub fn new(table: &'static str, volume_id: Uuid) -> Self {
-        Self { table, volume_id }
-    }
-}
-
-impl QueryId for BuildJsonResourcesToCleanUp {
-    type QueryId = ();
-    const HAS_STATIC_QUERY_ID: bool = false;
-}
-
-impl QueryFragment<Pg> for BuildJsonResourcesToCleanUp {
-    fn walk_ast<'a>(&'a self, mut out: AstPass<'_, 'a, Pg>) -> QueryResult<()> {
-        use db::schema::region::dsl as region_dsl;
-        use db::schema::region_snapshot::dsl as region_snapshot_dsl;
-        use db::schema::volume::dsl;
-
-        out.push_sql("json_build_object('V3', ");
-        out.push_sql("json_build_object('regions', ");
-        out.push_sql("(SELECT json_agg(");
-        out.push_identifier(dsl::id::NAME)?;
-        out.push_sql(") FROM ");
-        region_dsl::region.walk_ast(out.reborrow())?;
-        out.push_sql(" LEFT JOIN ");
-        out.push_sql("region_snapshot");
-        out.push_sql(" ON ");
-        out.push_identifier(region_dsl::id::NAME)?;
-        out.push_sql(" = ");
-        out.push_sql("region_snapshot");
-        out.push_sql(".");
-        out.push_identifier(region_snapshot_dsl::region_id::NAME)?; // table's schema is equivalent to region_snapshot
-        out.push_sql(" WHERE ( ");
-
-        out.push_sql("region_snapshot");
-        out.push_sql(".");
-        out.push_identifier(region_snapshot_dsl::volume_references::NAME)?;
-        out.push_sql(" = 0 OR ");
-        out.push_sql("region_snapshot");
-        out.push_sql(".");
-        out.push_identifier(region_snapshot_dsl::volume_references::NAME)?;
-        out.push_sql(" IS NULL");
-
-        out.push_sql(") AND ");
-        out.push_identifier(region_dsl::volume_id::NAME)?;
-        out.push_sql(" = ");
-        out.push_bind_param::<sql_types::Uuid, Uuid>(&self.volume_id)?;
-
-        out.push_sql("), 'region_snapshots', (");
-        out.push_sql("SELECT json_agg(json_build_object(");
-        out.push_sql("'dataset', ");
-        out.push_identifier(region_snapshot_dsl::dataset_id::NAME)?;
-        out.push_sql(", 'region', ");
-        out.push_identifier(region_snapshot_dsl::region_id::NAME)?;
-        out.push_sql(", 'snapshot', ");
-        out.push_identifier(region_snapshot_dsl::snapshot_id::NAME)?;
-        out.push_sql(")) from ");
-        out.push_sql(self.table);
-        out.push_sql(" where ");
-        out.push_sql(self.table);
-        out.push_sql(".");
-        out.push_identifier(region_snapshot_dsl::volume_references::NAME)?;
-        out.push_sql(" = 0)))");
-
-        Ok(())
-    }
-}
-
-impl<GroupByClause> ValidGrouping<GroupByClause>
-    for BuildJsonResourcesToCleanUp
-{
-    type IsAggregate = is_aggregate::Never;
-}
-
-/// Produces a query fragment that will set the `resources_to_clean_up` column
-/// of the volume being deleted if it is not set already.
-///
-/// The output should look like:
-///
-/// ```sql
-///   update volume set
-///    time_deleted = now(),
-///    resources_to_clean_up = ( select <BuildJsonResourcesToCleanUp> )
-///    where id = '<volume_id>' and
-///    (<ResourcesToCleanUpColumnIsNull>)
-///    returning volume.*
-/// ```
-#[must_use = "Queries must be executed"]
-struct ConditionallyUpdateVolume {
-    resources_to_clean_up_column_is_null_clause: ResourcesToCleanUpColumnIsNull,
-    build_json_resources_to_clean_up_query: BuildJsonResourcesToCleanUp,
-    volume_id: Uuid,
-}
-
-impl ConditionallyUpdateVolume {
-    pub fn new(volume_id: Uuid, table: &'static str) -> Self {
-        Self {
-            resources_to_clean_up_column_is_null_clause:
-                ResourcesToCleanUpColumnIsNull::new(volume_id),
-            build_json_resources_to_clean_up_query:
-                BuildJsonResourcesToCleanUp::new(table, volume_id),
-            volume_id,
-        }
-    }
-}
-
-impl QueryId for ConditionallyUpdateVolume {
-    type QueryId = ();
-    const HAS_STATIC_QUERY_ID: bool = false;
-}
-
-impl QueryFragment<Pg> for ConditionallyUpdateVolume {
-    fn walk_ast<'a>(&'a self, mut out: AstPass<'_, 'a, Pg>) -> QueryResult<()> {
-        use db::schema::volume::dsl;
-
-        out.push_sql("UPDATE ");
-        dsl::volume.walk_ast(out.reborrow())?;
-        out.push_sql(" SET ");
-        out.push_identifier(dsl::time_deleted::NAME)?;
-        out.push_sql(" = now(), ");
-        out.push_identifier(dsl::resources_to_clean_up::NAME)?;
-        out.push_sql(" = (SELECT ");
-
-        self.build_json_resources_to_clean_up_query.walk_ast(out.reborrow())?;
-
-        out.push_sql(") WHERE ");
-        out.push_identifier(dsl::id::NAME)?;
-        out.push_sql(" = ");
-        out.push_bind_param::<sql_types::Uuid, Uuid>(&self.volume_id)?;
-        out.push_sql(" AND (");
-
-        self.resources_to_clean_up_column_is_null_clause
-            .walk_ast(out.reborrow())?;
-
-        out.push_sql(") RETURNING volume.*");
-
-        Ok(())
-    }
-}
-
-impl Expression for ConditionallyUpdateVolume {
-    type SqlType = diesel::sql_types::Array<db::model::Volume>;
-}
-
-impl<GroupByClause> ValidGrouping<GroupByClause> for ConditionallyUpdateVolume {
-    type IsAggregate = is_aggregate::Never;
-}
-
-/// Produces a query fragment that will
-///
-/// 1. decrease the number of references for each region snapshot that
-///    a volume references
-/// 2. soft-delete the volume
-/// 3. record the resources to clean up as a serialized CrucibleResources
-///    struct in volume's `resources_to_clean_up` column.
-///
-/// The output should look like:
-///
-/// ```sql
-///  with UPDATED_REGION_SNAPSHOTS_TABLE as (
-///    UPDATE region_snapshot <ConditionallyDecreaseReferences>
-///  ),
-///  REGION_SNAPSHOTS_TO_CLEAN_UP_TABLE as (
-///    select * from UPDATED_REGION_SNAPSHOTS_TABLE where deleting = true and volume_references = 0
-///  ),
-///  UPDATED_VOLUME_TABLE as (
-///    UPDATE volume <ConditionallyUpdateVolume>
-///  )
-///  select case
-///   when volume.resources_to_clean_up is not null then volume.resources_to_clean_up
-///   else (select resources_to_clean_up from UPDATED_VOLUME_TABLE where id = '<volume id>')
-///  end
-///  from volume where id = '<volume id>';
-/// ```
-#[must_use = "Queries must be executed"]
-pub struct DecreaseCrucibleResourceCountAndSoftDeleteVolume {
-    conditionally_decrease_references: ConditionallyDecreaseReferences,
-    conditionally_update_volume_query: ConditionallyUpdateVolume,
-    volume_id: Uuid,
-}
-
-impl DecreaseCrucibleResourceCountAndSoftDeleteVolume {
-    const UPDATED_REGION_SNAPSHOTS_TABLE: &'static str =
-        "updated_region_snapshots";
-    const REGION_SNAPSHOTS_TO_CLEAN_UP_TABLE: &'static str =
-        "region_snapshots_to_clean_up";
-    const UPDATED_VOLUME_TABLE: &'static str = "updated_volume";
-
-    pub fn new(volume_id: Uuid, snapshot_addrs: Vec<String>) -> Self {
-        Self {
-            conditionally_decrease_references:
-                ConditionallyDecreaseReferences::new(volume_id, snapshot_addrs),
-            conditionally_update_volume_query: ConditionallyUpdateVolume::new(
-                volume_id,
-                Self::REGION_SNAPSHOTS_TO_CLEAN_UP_TABLE,
-            ),
-            volume_id,
-        }
-    }
-}
-
-impl QueryId for DecreaseCrucibleResourceCountAndSoftDeleteVolume {
-    type QueryId = ();
-    const HAS_STATIC_QUERY_ID: bool = false;
-}
-
-impl QueryFragment<Pg> for DecreaseCrucibleResourceCountAndSoftDeleteVolume {
-    fn walk_ast<'a>(&'a self, mut out: AstPass<'_, 'a, Pg>) -> QueryResult<()> {
-        use db::schema::region_snapshot::dsl as rs_dsl;
-        use db::schema::volume::dsl;
-
-        out.push_sql("WITH ");
-        out.push_sql(Self::UPDATED_REGION_SNAPSHOTS_TABLE);
-        out.push_sql(" as (");
-        self.conditionally_decrease_references.walk_ast(out.reborrow())?;
-        out.push_sql("), ");
-
-        out.push_sql(Self::REGION_SNAPSHOTS_TO_CLEAN_UP_TABLE);
-        out.push_sql(" AS (SELECT * FROM ");
-        out.push_sql(Self::UPDATED_REGION_SNAPSHOTS_TABLE);
-        out.push_sql(" WHERE ");
-        out.push_identifier(rs_dsl::deleting::NAME)?;
-        out.push_sql(" = TRUE AND ");
-        out.push_identifier(rs_dsl::volume_references::NAME)?;
-        out.push_sql(" = 0), ");
-
-        out.push_sql(Self::UPDATED_VOLUME_TABLE);
-        out.push_sql(" AS (");
-        self.conditionally_update_volume_query.walk_ast(out.reborrow())?;
-        out.push_sql(") ");
-
-        out.push_sql("SELECT ");
-        dsl::volume.walk_ast(out.reborrow())?;
-        out.push_sql(".* FROM ");
-        dsl::volume.walk_ast(out.reborrow())?;
-        out.push_sql(" WHERE ");
-        out.push_identifier(dsl::id::NAME)?;
-        out.push_sql(" = ");
-        out.push_bind_param::<sql_types::Uuid, Uuid>(&self.volume_id)?;
-
-        Ok(())
-    }
-}
-
-impl Expression for DecreaseCrucibleResourceCountAndSoftDeleteVolume {
-    type SqlType = diesel::sql_types::Array<db::model::Volume>;
-}
-
-impl<GroupByClause> ValidGrouping<GroupByClause>
-    for DecreaseCrucibleResourceCountAndSoftDeleteVolume
-{
-    type IsAggregate = is_aggregate::Never;
-}
-
-impl RunQueryDsl<DbConnection>
-    for DecreaseCrucibleResourceCountAndSoftDeleteVolume
-{
-}
+impl RunQueryDsl<DbConnection> for ConditionallyDecreaseReferences {}
 
 type SelectableSql<T> = <
     <T as diesel::Selectable<Pg>>::SelectExpression as diesel::Expression
 >::SqlType;
 
-impl Query for DecreaseCrucibleResourceCountAndSoftDeleteVolume {
-    type SqlType = SelectableSql<db::model::Volume>;
+impl Query for ConditionallyDecreaseReferences {
+    type SqlType = SelectableSql<db::model::RegionSnapshot>;
 }

--- a/nexus/src/app/sagas/disk_create.rs
+++ b/nexus/src/app/sagas/disk_create.rs
@@ -635,10 +635,7 @@ async fn sdc_create_volume_record_undo(
 
     // Depending on the read only parent, there will some read only resources
     // used, however this saga tracks them all.
-    osagactx
-        .datastore()
-        .decrease_crucible_resource_count_and_soft_delete_volume(volume_id)
-        .await?;
+    osagactx.datastore().soft_delete_volume(volume_id).await?;
 
     osagactx.datastore().volume_hard_delete(volume_id).await?;
 

--- a/nexus/src/app/sagas/snapshot_create.rs
+++ b/nexus/src/app/sagas/snapshot_create.rs
@@ -1564,15 +1564,9 @@ async fn ssc_create_volume_record_undo(
     // `volume_hard_delete` here: soft deleting volumes is necessary for
     // `find_deleted_volume_regions` to work.
 
-    info!(
-        log,
-        "calling decrease crucible resource count for volume {}", volume_id
-    );
+    info!(log, "calling soft delete for volume {}", volume_id);
 
-    osagactx
-        .datastore()
-        .decrease_crucible_resource_count_and_soft_delete_volume(volume_id)
-        .await?;
+    osagactx.datastore().soft_delete_volume(volume_id).await?;
 
     Ok(())
 }

--- a/nexus/src/app/sagas/volume_delete.rs
+++ b/nexus/src/app/sagas/volume_delete.rs
@@ -130,14 +130,14 @@ async fn svd_decrease_crucible_resource_count(
 
     let crucible_resources = osagactx
         .datastore()
-        .decrease_crucible_resource_count_and_soft_delete_volume(
-            params.volume_id,
-        )
+        .soft_delete_volume(params.volume_id)
         .await
-        .map_err(|e| ActionError::action_failed(format!(
-            "failed to decrease_crucible_resource_count_and_soft_delete_volume: {:?}",
-            e,
-        )))?;
+        .map_err(|e| {
+            ActionError::action_failed(format!(
+                "failed to soft_delete_volume: {:?}",
+                e,
+            ))
+        })?;
 
     Ok(crucible_resources)
 }

--- a/nexus/tests/integration_tests/snapshots.rs
+++ b/nexus/tests/integration_tests/snapshots.rs
@@ -1384,33 +1384,21 @@ async fn test_multiple_deletes_not_sent(cptestctx: &ControlPlaneTestContext) {
         .unwrap();
 
     // Continue pretending that each saga is executing concurrently: call
-    // `decrease_crucible_resource_count_and_soft_delete_volume` back to back.
-    // Make sure that each saga is deleting a unique set of resources, else they
-    // will be sending identical DELETE calls to Crucible agents. This is ok
-    // because the agents are idempotent, but if someone issues a DELETE for a
-    // read-only downstairs (called a "running snapshot") when the snapshot was
-    // deleted, they'll see a 404, which will cause the saga to fail.
+    // `soft_delete_volume` back to back.  Make sure that each saga is deleting
+    // a unique set of resources, else they will be sending identical DELETE
+    // calls to Crucible agents. This is ok because the agents are idempotent,
+    // but if someone issues a DELETE for a read-only downstairs (called a
+    // "running snapshot") when the snapshot was deleted, they'll see a 404,
+    // which will cause the saga to fail.
 
-    let resources_1 = datastore
-        .decrease_crucible_resource_count_and_soft_delete_volume(
-            db_snapshot_1.volume_id,
-        )
-        .await
-        .unwrap();
+    let resources_1 =
+        datastore.soft_delete_volume(db_snapshot_1.volume_id).await.unwrap();
 
-    let resources_2 = datastore
-        .decrease_crucible_resource_count_and_soft_delete_volume(
-            db_snapshot_2.volume_id,
-        )
-        .await
-        .unwrap();
+    let resources_2 =
+        datastore.soft_delete_volume(db_snapshot_2.volume_id).await.unwrap();
 
-    let resources_3 = datastore
-        .decrease_crucible_resource_count_and_soft_delete_volume(
-            db_snapshot_3.volume_id,
-        )
-        .await
-        .unwrap();
+    let resources_3 =
+        datastore.soft_delete_volume(db_snapshot_3.volume_id).await.unwrap();
 
     let resources_1_datasets_and_regions =
         datastore.regions_to_delete(&resources_1).await.unwrap();


### PR DESCRIPTION
Change the process of soft-deleting a volume from a CTE into a transaction. This is done to make changes easier to apply and review.

One part of the CTE that remains is the query fragment that conditionally reduces volume references for region_snapshot rows, then returns only the rows updated. It was easier to keep this than figure out how to get it to work in diesel!