### PR TITLE
Remove unnecessary LD_LIBRARY_PATH

### DIFF
--- a/smf/nexus/manifest.xml
+++ b/smf/nexus/manifest.xml
@@ -31,11 +31,6 @@
   <service_fmri value='svc:/oxide/opte-interface-setup:default' />
   </dependency>
 
-  <method_context>
-    <method_environment>
-      <envvar name="LD_LIBRARY_PATH" value="/opt/ooce/pgsql-13/lib/amd64" />
-    </method_environment>
-  </method_context>
   <exec_method type='method' name='start'
     exec='ctrun -l child -o noorphan,regent /opt/oxide/omicron-nexus/bin/nexus /var/svc/manifest/site/nexus/config.toml &amp;'
     timeout_seconds='0' />

--- a/smf/oximeter/manifest.xml
+++ b/smf/oximeter/manifest.xml
@@ -16,11 +16,6 @@
   <service_fmri value='svc:/oxide/zone-network-setup:default' />
   </dependency>
 
-  <method_context>
-    <method_environment>
-      <envvar name="LD_LIBRARY_PATH" value="/opt/ooce/pgsql-13/lib/amd64" />
-    </method_environment>
-  </method_context>
   <exec_method type='method' name='start'
     exec='ctrun -l child -o noorphan,regent /opt/oxide/oximeter-collector/bin/oximeter run /var/svc/manifest/site/oximeter/config.toml --address %{config/address} --id %{config/id} &amp;'
     timeout_seconds='0'>

--- a/smf/sled-agent/manifest.xml
+++ b/smf/sled-agent/manifest.xml
@@ -37,11 +37,6 @@
         <service_fmri value='svc:/system/t6init' />
   </dependency>
 
-  <method_context>
-    <method_environment>
-      <envvar name="LD_LIBRARY_PATH" value="/opt/ooce/pgsql-13/lib/amd64" />
-    </method_environment>
-  </method_context>
   <exec_method type='method' name='start'
     exec='ctrun -l child -o noorphan,regent /opt/oxide/sled-agent/sled-agent run /opt/oxide/sled-agent/pkg/config.toml &amp;'
     timeout_seconds='0' />


### PR DESCRIPTION
- Remove path from SMF manifests for oximeter, sled-agent, and nexus
- Fixes #6625