### PR TITLE
Properly return an error from `SprocketsClient::connect`

### DIFF
--- a/sled-agent/src/bootstrap/client.rs
+++ b/sled-agent/src/bootstrap/client.rs
@@ -24,7 +24,7 @@ use tokio::io::AsyncWriteExt;
 #[derive(Debug, Error)]
 pub enum Error {
     #[error("Could not connect to {addr}: {err}")]
-    Connect { addr: SocketAddrV6, err: io::Error },
+    Connect { addr: SocketAddrV6, err: sprockets_tls::Error },
 
     #[error("Failed serializing request: {0}")]
     Serialize(serde_json::Error),
@@ -115,7 +115,7 @@ impl Client {
             log.clone(),
         )
         .await
-        .unwrap();
+        .map_err(|err| Error::Connect { addr: self.addr, err })?;
 
         let mut stream = Box::new(tokio::io::BufStream::new(stream));
 


### PR DESCRIPTION
This inadvertnetly got turned into an `.unwrap()` which wasn't caught in other testing. On the `a4x2` setup, the first connect fails which is expected. Just give the error back.