### PR TITLE
Add ClickHouse native TCP ports to internal DNS

### DIFF
--- a/dev-tools/reconfigurator-cli/src/main.rs
+++ b/dev-tools/reconfigurator-cli/src/main.rs
@@ -837,12 +837,12 @@ fn cmd_blueprint_diff(
         &blueprint1,
         &sleds_by_id,
         &Default::default(),
-    );
+    )?;
     let internal_dns_config2 = blueprint_internal_dns_config(
         &blueprint2,
         &sleds_by_id,
         &Default::default(),
-    );
+    )?;
     let dns_diff = DnsDiff::new(&internal_dns_config1, &internal_dns_config2)
         .context("failed to assemble DNS diff")?;
     swriteln!(rv, "internal DNS:\n{}", dns_diff);
@@ -916,7 +916,7 @@ fn cmd_blueprint_diff_dns(
                 blueprint,
                 &sleds_by_id,
                 &Default::default(),
-            )
+            )?
         }
         CliDnsGroup::External => blueprint_external_dns_config(
             blueprint,

--- a/internal-dns/src/config.rs
+++ b/internal-dns/src/config.rs
@@ -406,7 +406,6 @@ impl DnsConfigBuilder {
     /// a simple HTTP interface as well as a lower-level protocol over TCP,
     /// called the "Native protocol". This method inserts a zone and the related
     /// records for both of these services.
-    /// these services.
     ///
     /// `http_service` is the `ServiceName` for the HTTP service that belongs in
     /// this zone, and `http_port` is the associated port for that service. The

--- a/internal-dns/src/config.rs
+++ b/internal-dns/src/config.rs
@@ -64,6 +64,7 @@ use crate::names::{ServiceName, BOUNDARY_NTP_DNS_NAME, DNS_ZONE};
 use anyhow::{anyhow, ensure};
 use core::fmt;
 use dns_service_client::types::{DnsConfigParams, DnsConfigZone, DnsRecord};
+use omicron_common::address::CLICKHOUSE_TCP_PORT;
 use omicron_common::api::external::Generation;
 use omicron_uuid_kinds::{OmicronZoneUuid, SledUuid};
 use std::collections::BTreeMap;
@@ -396,6 +397,46 @@ impl DnsConfigBuilder {
             mgs_port,
         )?;
         self.service_backend_zone(ServiceName::Mgd, &zone, mgd_port)
+    }
+
+    /// Higher-level shorthand for adding a ClickHouse zone with several
+    /// services.
+    ///
+    /// ClickHouse servers expose several interfaces on the network. We use both
+    /// a simple HTTP interface as well as a lower-level protocol over TCP,
+    /// called the "Native protocol". This method inserts a zone and the related
+    /// records for both of these services.
+    /// these services.
+    ///
+    /// `http_service` is the `ServiceName` for the HTTP service that belongs in
+    /// this zone, and `http_port` is the associated port for that service. The
+    /// native service is added automatically, using its default port.
+    ///
+    /// # Errors
+    ///
+    /// This fails if the provided `http_service` is not for a ClickHouse
+    /// replica server. It also fails if the given zone has already been added
+    /// to the configuration.
+    pub fn host_zone_clickhouse(
+        &mut self,
+        zone_id: OmicronZoneUuid,
+        underlay_address: Ipv6Addr,
+        http_service: ServiceName,
+        http_port: u16,
+    ) -> anyhow::Result<()> {
+        anyhow::ensure!(
+            http_service == ServiceName::Clickhouse
+                || http_service == ServiceName::ClickhouseServer,
+            "This method is only valid for ClickHouse replica servers, \
+            but we were provided the service '{http_service:?}'",
+        );
+        let zone = self.host_zone(zone_id, underlay_address)?;
+        self.service_backend_zone(http_service, &zone, http_port)?;
+        self.service_backend_zone(
+            ServiceName::ClickhouseNative,
+            &zone,
+            CLICKHOUSE_TCP_PORT,
+        )
     }
 
     /// Construct a `DnsConfigZone` describing the control plane zone described

--- a/internal-dns/src/names.rs
+++ b/internal-dns/src/names.rs
@@ -23,8 +23,15 @@ pub const DNS_ZONE_EXTERNAL_TESTING: &str = "oxide-dev.test";
 /// Names of services within the control plane
 #[derive(Clone, Copy, Debug, Hash, Eq, Ord, PartialEq, PartialOrd)]
 pub enum ServiceName {
+    /// The HTTP interface to a single-node ClickHouse server.
     Clickhouse,
+    /// The native TCP interface to a ClickHouse server.
+    ///
+    /// NOTE: This is used for either single-node or a replicated cluster.
+    ClickhouseNative,
+    /// The TCP interface to a ClickHouse Keeper server.
     ClickhouseKeeper,
+    /// The HTTP interface to a replicated ClickHouse server.
     ClickhouseServer,
     Cockroach,
     InternalDns,
@@ -48,6 +55,7 @@ impl ServiceName {
     fn service_kind(&self) -> &'static str {
         match self {
             ServiceName::Clickhouse => "clickhouse",
+            ServiceName::ClickhouseNative => "clickhouse-native",
             ServiceName::ClickhouseKeeper => "clickhouse-keeper",
             ServiceName::ClickhouseServer => "clickhouse-server",
             ServiceName::Cockroach => "cockroach",
@@ -74,6 +82,7 @@ impl ServiceName {
     pub fn dns_name(&self) -> String {
         match self {
             ServiceName::Clickhouse
+            | ServiceName::ClickhouseNative
             | ServiceName::ClickhouseKeeper
             | ServiceName::ClickhouseServer
             | ServiceName::Cockroach

--- a/nexus/reconfigurator/execution/src/dns.rs
+++ b/nexus/reconfigurator/execution/src/dns.rs
@@ -288,8 +288,13 @@ pub fn blueprint_internal_dns_config(
                     ServiceName::ClickhouseServer
                 };
 
-                // Safety: This only fails if we provide the same zone id more
-                // than once, which should not be possible here.
+                // Safety: This only fails if the ServiceName isn't one of the
+                // ClickHouse types, which is guaranteed by this match arm. It
+                // may also fail if we add a zone with the same ID more than
+                // once, but as with the call to `host_zone_with_one_backend()`
+                // below, that should not be possible at this point in the
+                // code, since the IDs of the zones in the blueprint should be
+                // unique.
                 dns_builder
                     .host_zone_clickhouse(
                         zone.id,

--- a/nexus/test-utils/src/lib.rs
+++ b/nexus/test-utils/src/lib.rs
@@ -453,29 +453,41 @@ impl<'a, N: NexusServer> ControlPlaneTestContextBuilder<'a, N> {
             )
             .await
             .unwrap();
-        let port = clickhouse.http_address().port();
 
         let zpool_id = ZpoolUuid::new_v4();
         let dataset_id = Uuid::new_v4();
-        let address = SocketAddrV6::new(Ipv6Addr::LOCALHOST, port, 0, 0);
+        let http_address = clickhouse.http_address();
+        let http_port = http_address.port();
         self.rack_init_builder.add_dataset(
             zpool_id,
             dataset_id,
-            address,
+            http_address,
             DatasetKind::Clickhouse,
             internal_dns::ServiceName::Clickhouse,
+        );
+
+        // Add the native protocol address to DNS as well.
+        //
+        // NOTE: The internals of `RackInitBuilder` use the dataset_id as the
+        // zone_id.
+        self.rack_init_builder.add_service_to_dns(
+            OmicronZoneUuid::from_untyped_uuid(dataset_id),
+            clickhouse.native_address(),
+            internal_dns::ServiceName::ClickhouseNative,
         );
         self.clickhouse = Some(clickhouse);
 
         // NOTE: We could pass this port information via DNS, rather than
         // requiring it to be known before Nexus starts.
+        //
+        // See https://github.com/oxidecomputer/omicron/issues/6407.
         self.config
             .pkg
             .timeseries_db
             .address
             .as_mut()
             .expect("Tests expect to set a port of Clickhouse")
-            .set_port(port);
+            .set_port(http_port);
 
         let pool_name = illumos_utils::zpool::ZpoolName::new_external(zpool_id)
             .to_string()
@@ -484,11 +496,11 @@ impl<'a, N: NexusServer> ControlPlaneTestContextBuilder<'a, N> {
         self.blueprint_zones.push(BlueprintZoneConfig {
             disposition: BlueprintZoneDisposition::InService,
             id: OmicronZoneUuid::from_untyped_uuid(dataset_id),
-            underlay_address: *address.ip(),
+            underlay_address: *http_address.ip(),
             filesystem_pool: Some(ZpoolName::new_external(zpool_id)),
             zone_type: BlueprintZoneType::Clickhouse(
                 blueprint_zone_type::Clickhouse {
-                    address,
+                    address: http_address,
                     dataset: OmicronZoneDataset { pool_name },
                 },
             ),

--- a/sled-agent/src/rack_setup/plan/service.rs
+++ b/sled-agent/src/rack_setup/plan/service.rs
@@ -708,14 +708,14 @@ impl Plan {
             };
             let id = OmicronZoneUuid::new_v4();
             let ip = sled.addr_alloc.next().expect("Not enough addrs");
-            let port = omicron_common::address::CLICKHOUSE_HTTP_PORT;
-            let address = SocketAddrV6::new(ip, port, 0, 0);
+            let http_port = omicron_common::address::CLICKHOUSE_HTTP_PORT;
+            let http_address = SocketAddrV6::new(ip, http_port, 0, 0);
             dns_builder
-                .host_zone_with_one_backend(
+                .host_zone_clickhouse(
                     id,
                     ip,
                     ServiceName::Clickhouse,
-                    port,
+                    http_port,
                 )
                 .unwrap();
             let dataset_name =
@@ -727,7 +727,7 @@ impl Plan {
                 underlay_address: ip,
                 zone_type: BlueprintZoneType::Clickhouse(
                     blueprint_zone_type::Clickhouse {
-                        address,
+                        address: http_address,
                         dataset: OmicronZoneDataset {
                             pool_name: dataset_name.pool().clone(),
                         },
@@ -751,14 +751,14 @@ impl Plan {
             let ip = sled.addr_alloc.next().expect("Not enough addrs");
             // TODO: This may need to be a different port if/when to have single node
             // and replicated running side by side as per stage 1 of RFD 468.
-            let port = omicron_common::address::CLICKHOUSE_HTTP_PORT;
-            let address = SocketAddrV6::new(ip, port, 0, 0);
+            let http_port = omicron_common::address::CLICKHOUSE_HTTP_PORT;
+            let http_address = SocketAddrV6::new(ip, http_port, 0, 0);
             dns_builder
-                .host_zone_with_one_backend(
+                .host_zone_clickhouse(
                     id,
                     ip,
                     ServiceName::ClickhouseServer,
-                    port,
+                    http_port,
                 )
                 .unwrap();
             let dataset_name =
@@ -770,7 +770,7 @@ impl Plan {
                 underlay_address: ip,
                 zone_type: BlueprintZoneType::ClickhouseServer(
                     blueprint_zone_type::ClickhouseServer {
-                        address,
+                        address: http_address,
                         dataset: OmicronZoneDataset {
                             pool_name: dataset_name.pool().clone(),
                         },


### PR DESCRIPTION
- Add a new DNS service for the ClickHouse Native TCP protocol, `ServiceName::ClickhouseNative.
- Add a helper method to the DnsConfigBuilder for creating expected ClickHouse replica records in internal DNS. This is used to ensure we correctly make the records for _both_ the HTTP server and Native TCP server, pointing to the same Omicron zone in the blueprint.
- Use this method in the DNS generation for a blueprint, and add the native service to the tests to check that we include the SRV record for it.
- Fixes #6598