### PR TITLE
resolve #6624 vs #6581 semantic merge conflict

### DIFF
--- a/nexus/reconfigurator/planning/src/planner.rs
+++ b/nexus/reconfigurator/planning/src/planner.rs
@@ -1406,6 +1406,7 @@ mod test {
             &logctx.log,
             &blueprint1,
             &input,
+            &collection,
             TEST_NAME,
         )
         .expect("failed to build blueprint builder");
@@ -1423,6 +1424,7 @@ mod test {
             &logctx.log,
             &blueprint1,
             &input,
+            &collection,
             TEST_NAME,
         )
         .expect("failed to build blueprint builder");


### PR DESCRIPTION
💥 #6624 added a collection parameter to `BlueprintBuilder::new_based_on`. #6581 added new calls to `new_based_on` in tests without having those changes present.