### PR TITLE
[repo depot 1/n] add `DatasetKind::Update`

### DIFF
--- a/common/src/api/internal/shared.rs
+++ b/common/src/api/internal/shared.rs
@@ -860,6 +860,8 @@ pub enum DatasetKind {
 
     // Other datasets
     Debug,
+    // Stores update artifacts (the "TUF Repo Depot")
+    Update,
 }
 
 impl Serialize for DatasetKind {
@@ -920,7 +922,7 @@ impl DatasetKind {
         match self {
             Cockroach | Crucible | Clickhouse | ClickhouseKeeper
             | ClickhouseServer | ExternalDns | InternalDns => true,
-            ZoneRoot | Zone { .. } | Debug => false,
+            ZoneRoot | Zone { .. } | Debug | Update => false,
         }
     }
 
@@ -958,6 +960,7 @@ impl fmt::Display for DatasetKind {
                 return Ok(());
             }
             Debug => "debug",
+            Update => "update",
         };
         write!(f, "{}", s)
     }
@@ -984,6 +987,7 @@ impl FromStr for DatasetKind {
             "internal_dns" => InternalDns,
             "zone" => ZoneRoot,
             "debug" => Debug,
+            "update" => Update,
             other => {
                 if let Some(name) = other.strip_prefix("zone/") {
                     Zone { name: name.to_string() }
@@ -1079,6 +1083,7 @@ mod tests {
             DatasetKind::ZoneRoot,
             DatasetKind::Zone { name: String::from("myzone") },
             DatasetKind::Debug,
+            DatasetKind::Update,
         ];
 
         assert_eq!(kinds.len(), DatasetKind::COUNT);

--- a/nexus/db-model/src/dataset_kind.rs
+++ b/nexus/db-model/src/dataset_kind.rs
@@ -26,6 +26,7 @@ impl_enum_type!(
     ZoneRoot => b"zone_root"
     Zone => b"zone"
     Debug => b"debug"
+    Update => b"update"
 );
 
 impl From<&internal::shared::DatasetKind> for DatasetKind {
@@ -55,6 +56,7 @@ impl From<&internal::shared::DatasetKind> for DatasetKind {
             // The zone name, if it exists, is stored in a separate column.
             internal::shared::DatasetKind::Zone { .. } => DatasetKind::Zone,
             internal::shared::DatasetKind::Debug => DatasetKind::Debug,
+            internal::shared::DatasetKind::Update => DatasetKind::Update,
         }
     }
 }

--- a/nexus/db-model/src/schema_versions.rs
+++ b/nexus/db-model/src/schema_versions.rs
@@ -17,7 +17,7 @@ use std::collections::BTreeMap;
 ///
 /// This must be updated when you change the database schema.  Refer to
 /// schema/crdb/README.adoc in the root of this repository for details.
-pub const SCHEMA_VERSION: SemverVersion = SemverVersion::new(104, 0, 0);
+pub const SCHEMA_VERSION: SemverVersion = SemverVersion::new(105, 0, 0);
 
 /// List of all past database schema versions, in *reverse* order
 ///
@@ -29,6 +29,7 @@ static KNOWN_VERSIONS: Lazy<Vec<KnownVersion>> = Lazy::new(|| {
         // |  leaving the first copy as an example for the next person.
         // v
         // KnownVersion::new(next_int, "unique-dirname-with-the-sql-files"),
+        KnownVersion::new(105, "dataset-kinds-update"),
         KnownVersion::new(104, "lookup-bgp-config-indexes"),
         KnownVersion::new(103, "lookup-instances-by-state-index"),
         KnownVersion::new(102, "add-instance-auto-restart-cooldown"),

--- a/schema/crdb/dataset-kinds-update/up.sql
+++ b/schema/crdb/dataset-kinds-update/up.sql
@@ -1,0 +1,1 @@
+ALTER TYPE omicron.public.dataset_kind ADD VALUE IF NOT EXISTS 'update' AFTER 'debug';

--- a/schema/crdb/dbinit.sql
+++ b/schema/crdb/dbinit.sql
@@ -512,7 +512,8 @@ CREATE TYPE IF NOT EXISTS omicron.public.dataset_kind AS ENUM (
   'internal_dns',
   'zone_root',
   'zone',
-  'debug'
+  'debug',
+  'update'
 );
 
 /*
@@ -4382,7 +4383,7 @@ INSERT INTO omicron.public.db_metadata (
     version,
     target_version
 ) VALUES
-    (TRUE, NOW(), NOW(), '104.0.0', NULL)
+    (TRUE, NOW(), NOW(), '105.0.0', NULL)
 ON CONFLICT DO NOTHING;
 
 COMMIT;


### PR DESCRIPTION
This is a relatively trivial changeset, but I think this is the only database schema change I will need to make for the initial repo depot work so I wanted to get it out of the way early.

The TUF Repo Depot ([RFD 424](https://rfd.shared.oxide.computer/rfd/424)) is how we store update artifacts on the rack. RFD 424's determination is that we will take the simplest approach of replicating update artifacts across all sleds:
- Nexus will ensure there is an `Update` dataset on each sled
- Sled Agent will grow endpoints to manage artifacts in the `Update` dataset, and serve the artifacts on the underlay network
- Nexus will ensure all artifacts its aware of are replicated across all sleds