### PR TITLE
omdb / reconfigurator-cli: Sort blueprint lists by `time_created`

### DIFF
--- a/dev-tools/omdb/src/bin/omdb/nexus.rs
+++ b/dev-tools/omdb/src/bin/omdb/nexus.rs
@@ -2148,11 +2148,15 @@ async fn cmd_nexus_blueprints_list(
         }
     };
 
-    let rows: Vec<BlueprintRow> = client
+    let mut rows = client
         .blueprint_list_stream(None, None)
         .try_collect::<Vec<_>>()
         .await
-        .context("listing blueprints")?
+        .context("listing blueprints")?;
+
+    rows.sort_unstable_by_key(|blueprint| blueprint.time_created);
+
+    let rows: Vec<_> = rows
         .into_iter()
         .map(|blueprint| {
             let (is_target, enabled) = match &target {

--- a/dev-tools/reconfigurator-cli/src/main.rs
+++ b/dev-tools/reconfigurator-cli/src/main.rs
@@ -40,6 +40,7 @@ use omicron_uuid_kinds::OmicronZoneUuid;
 use omicron_uuid_kinds::SledUuid;
 use omicron_uuid_kinds::VnicUuid;
 use reedline::{Reedline, Signal};
+use std::borrow::Cow;
 use std::collections::BTreeMap;
 use std::io::BufRead;
 use swrite::{swriteln, SWrite};
@@ -690,12 +691,23 @@ fn cmd_blueprint_list(
     #[tabled(rename_all = "SCREAMING_SNAKE_CASE")]
     struct BlueprintRow {
         id: Uuid,
+        parent: Cow<'static, str>,
+        time_created: String,
     }
 
-    let rows = sim
-        .blueprints
-        .values()
-        .map(|blueprint| BlueprintRow { id: blueprint.id });
+    let mut rows = sim.blueprints.values().collect::<Vec<_>>();
+    rows.sort_unstable_by_key(|blueprint| blueprint.time_created);
+    let rows = rows.into_iter().map(|blueprint| BlueprintRow {
+        id: blueprint.id,
+        parent: blueprint
+            .parent_blueprint_id
+            .map(|s| Cow::Owned(s.to_string()))
+            .unwrap_or(Cow::Borrowed("<none>")),
+        time_created: humantime::format_rfc3339_millis(
+            blueprint.time_created.into(),
+        )
+        .to_string(),
+    });
     let table = tabled::Table::new(rows)
         .with(tabled::settings::Style::empty())
         .with(tabled::settings::Padding::new(0, 1, 0, 0))

--- a/dev-tools/reconfigurator-cli/tests/output/cmd-stdout
+++ b/dev-tools/reconfigurator-cli/tests/output/cmd-stdout
@@ -5,7 +5,7 @@ ID NZPOOLS SUBNET
 ID NERRORS TIME_DONE 
 
 > blueprint-list
-ID 
+ID PARENT TIME_CREATED 
 
 > 
 


### PR DESCRIPTION
`omdb` on main:

```
root@oxz_switch0:/tmp# omdb nexus blueprints list
note: Nexus URL not specified.  Will pick one from DNS.
note: using DNS server for subnet fd00:1122:3344::/48
note: (if this is not right, use --dns-server to specify an alternate DNS server)
note: using Nexus URL http://[fd00:1122:3344:104::3]:12221
T ENA ID                                   PARENT                               TIME_CREATED
      00756b7a-a563-4061-9ece-8ffc692a2d28 3eb67393-bdbc-4957-98c2-36cc60e3e901 2024-09-23T18:41:36.196Z
      0ff40c05-188e-4690-ab15-a63d737d550f 95c3f06b-4dbf-4614-ae7c-507c1193bde9 2024-04-10T21:08:55.829Z
      1366c843-a75c-45a4-b40a-743e7d609af1 3eb67393-bdbc-4957-98c2-36cc60e3e901 2024-09-09T16:24:53.070Z
      170395d7-517a-4272-abcd-0e96b051522c 430f5c6b-3156-4921-8ddc-74560989c8f4 2024-07-07T21:39:25.997Z
* yes 3eb67393-bdbc-4957-98c2-36cc60e3e901 430f5c6b-3156-4921-8ddc-74560989c8f4 2024-09-06T21:42:08.133Z
      430f5c6b-3156-4921-8ddc-74560989c8f4 864b1f48-68dd-478d-be0a-c3c8e811dac2 2024-06-06T17:19:30.827Z
      451fe6ad-a87f-4447-95da-d4d8b632d0c5 a187d811-0037-47eb-83ab-950d374317e1 2024-04-18T23:10:10.454Z
      864b1f48-68dd-478d-be0a-c3c8e811dac2 e48511bd-8d9f-47d7-8108-216b7868fdec 2024-04-22T20:34:19.369Z
      95c3f06b-4dbf-4614-ae7c-507c1193bde9 <none>                               2024-03-22T18:37:17.291Z
      a187d811-0037-47eb-83ab-950d374317e1 0ff40c05-188e-4690-ab15-a63d737d550f 2024-04-18T23:03:37.348Z
      e48511bd-8d9f-47d7-8108-216b7868fdec 451fe6ad-a87f-4447-95da-d4d8b632d0c5 2024-04-22T20:23:48.417Z
```

This branch:

```
root@oxz_switch0:/tmp# ./john-omdb nexus blueprints list
note: Nexus URL not specified.  Will pick one from DNS.
note: using DNS server for subnet fd00:1122:3344::/48
note: (if this is not right, use --dns-server to specify an alternate DNS server)
note: using Nexus URL http://[fd00:1122:3344:104::3]:12221
T ENA ID                                   PARENT                               TIME_CREATED
      95c3f06b-4dbf-4614-ae7c-507c1193bde9 <none>                               2024-03-22T18:37:17.291Z
      0ff40c05-188e-4690-ab15-a63d737d550f 95c3f06b-4dbf-4614-ae7c-507c1193bde9 2024-04-10T21:08:55.829Z
      a187d811-0037-47eb-83ab-950d374317e1 0ff40c05-188e-4690-ab15-a63d737d550f 2024-04-18T23:03:37.348Z
      451fe6ad-a87f-4447-95da-d4d8b632d0c5 a187d811-0037-47eb-83ab-950d374317e1 2024-04-18T23:10:10.454Z
      e48511bd-8d9f-47d7-8108-216b7868fdec 451fe6ad-a87f-4447-95da-d4d8b632d0c5 2024-04-22T20:23:48.417Z
      864b1f48-68dd-478d-be0a-c3c8e811dac2 e48511bd-8d9f-47d7-8108-216b7868fdec 2024-04-22T20:34:19.369Z
      430f5c6b-3156-4921-8ddc-74560989c8f4 864b1f48-68dd-478d-be0a-c3c8e811dac2 2024-06-06T17:19:30.827Z
      170395d7-517a-4272-abcd-0e96b051522c 430f5c6b-3156-4921-8ddc-74560989c8f4 2024-07-07T21:39:25.997Z
* yes 3eb67393-bdbc-4957-98c2-36cc60e3e901 430f5c6b-3156-4921-8ddc-74560989c8f4 2024-09-06T21:42:08.133Z
      1366c843-a75c-45a4-b40a-743e7d609af1 3eb67393-bdbc-4957-98c2-36cc60e3e901 2024-09-09T16:24:53.070Z
      00756b7a-a563-4061-9ece-8ffc692a2d28 3eb67393-bdbc-4957-98c2-36cc60e3e901 2024-09-23T18:41:36.196Z
```

`reconfigurator-cli` on main (using a state file that's older than the newest blueprint from the above omdb output; sorry for the slight discrepancy):

```
〉blueprint-list
ID
0ff40c05-188e-4690-ab15-a63d737d550f
1366c843-a75c-45a4-b40a-743e7d609af1
170395d7-517a-4272-abcd-0e96b051522c
3eb67393-bdbc-4957-98c2-36cc60e3e901
430f5c6b-3156-4921-8ddc-74560989c8f4
451fe6ad-a87f-4447-95da-d4d8b632d0c5
864b1f48-68dd-478d-be0a-c3c8e811dac2
95c3f06b-4dbf-4614-ae7c-507c1193bde9
a187d811-0037-47eb-83ab-950d374317e1
e48511bd-8d9f-47d7-8108-216b7868fdec
```

This branch:

```
〉blueprint-list
ID                                   PARENT                               TIME_CREATED
95c3f06b-4dbf-4614-ae7c-507c1193bde9 <none>                               2024-03-22T18:37:17.291Z
0ff40c05-188e-4690-ab15-a63d737d550f 95c3f06b-4dbf-4614-ae7c-507c1193bde9 2024-04-10T21:08:55.829Z
a187d811-0037-47eb-83ab-950d374317e1 0ff40c05-188e-4690-ab15-a63d737d550f 2024-04-18T23:03:37.348Z
451fe6ad-a87f-4447-95da-d4d8b632d0c5 a187d811-0037-47eb-83ab-950d374317e1 2024-04-18T23:10:10.454Z
e48511bd-8d9f-47d7-8108-216b7868fdec 451fe6ad-a87f-4447-95da-d4d8b632d0c5 2024-04-22T20:23:48.417Z
864b1f48-68dd-478d-be0a-c3c8e811dac2 e48511bd-8d9f-47d7-8108-216b7868fdec 2024-04-22T20:34:19.369Z
430f5c6b-3156-4921-8ddc-74560989c8f4 864b1f48-68dd-478d-be0a-c3c8e811dac2 2024-06-06T17:19:30.827Z
170395d7-517a-4272-abcd-0e96b051522c 430f5c6b-3156-4921-8ddc-74560989c8f4 2024-07-07T21:39:25.997Z
3eb67393-bdbc-4957-98c2-36cc60e3e901 430f5c6b-3156-4921-8ddc-74560989c8f4 2024-09-06T21:42:08.133Z
1366c843-a75c-45a4-b40a-743e7d609af1 3eb67393-bdbc-4957-98c2-36cc60e3e901 2024-09-09T16:24:53.070Z
```

I don't believe `reconfigurator-cli` knows which blueprint is (or was?) the target. Should it? (If yes, I'll just file a separate issue, not do that work on this PR, since it will require slightly more work to export the additional info.)

I'll claim this fixes #6639. There's probably more we can do here (e.g., flagging or hiding blueprints that were never made the target, or using ascii trees to make them stand out), but this is probably enough for now with minimal effort required.