### PR TITLE
[nexus] Reincarnate instances with `SagaUnwound` VMMs

### DIFF
--- a/dev-tools/omdb/src/bin/omdb/db.rs
+++ b/dev-tools/omdb/src/bin/omdb/db.rs
@@ -2882,7 +2882,8 @@ async fn cmd_db_instance_info(
         vmm::dsl as vmm_dsl,
     };
     use nexus_db_model::{
-        Instance, InstanceKarmicStatus, InstanceRuntimeState, Migration, Vmm,
+        Instance, InstanceKarmicStatus, InstanceRuntimeState, Migration,
+        Reincarnatability, Vmm,
     };
     let InstanceInfoArgs { id } = args;
 
@@ -2943,8 +2944,9 @@ async fn cmd_db_instance_info(
     const STATE: &'static str = "nexus state";
     const LAST_MODIFIED: &'static str = "last modified at";
     const LAST_UPDATED: &'static str = "last updated at";
-    const LAST_AUTO_RESTART: &'static str = "last auto-restarted at";
-    const KARMIC_STATUS: &'static str = "karmic status";
+    const LAST_AUTO_RESTART: &'static str = "  last reincarnated at";
+    const KARMIC_STATUS: &'static str = "  karmic status";
+    const NEEDS_REINCARNATION: &'static str = "needs reincarnation";
     const ACTIVE_VMM: &'static str = "active VMM ID";
     const TARGET_VMM: &'static str = "target VMM ID";
     const MIGRATION_ID: &'static str = "migration ID";
@@ -2968,6 +2970,7 @@ async fn cmd_db_instance_info(
         LAST_MODIFIED,
         LAST_AUTO_RESTART,
         KARMIC_STATUS,
+        NEEDS_REINCARNATION,
         ACTIVE_VMM,
         TARGET_VMM,
         MIGRATION_ID,
@@ -3026,25 +3029,32 @@ async fn cmd_db_instance_info(
         "    {LAST_UPDATED:>WIDTH$}: {time_updated:?} (generation {})",
         r#gen.0
     );
-    println!("    {LAST_AUTO_RESTART:>WIDTH$}: {time_last_auto_restarted:?}");
-    match instance
-        .auto_restart
-        .status(&instance.runtime_state, active_vmm.as_ref())
-    {
-        InstanceKarmicStatus::NotFailed => {}
-        InstanceKarmicStatus::Ready => {
-            println!("(i) {KARMIC_STATUS:>WIDTH$}: ready to reincarnate!");
+
+    // Reincarnation status
+    let InstanceKarmicStatus { needs_reincarnation, can_reincarnate } =
+        instance
+            .auto_restart
+            .status(&instance.runtime_state, active_vmm.as_ref());
+    println!(
+        "{} {NEEDS_REINCARNATION:>WIDTH$}: {needs_reincarnation}",
+        if needs_reincarnation { "(i)" } else { "   " }
+    );
+    match can_reincarnate {
+        Reincarnatability::WillReincarnate => {
+            println!("    {KARMIC_STATUS:>WIDTH$}: bound to saṃsāra");
         }
-        InstanceKarmicStatus::Forbidden => {
-            println!("(i) {KARMIC_STATUS:>WIDTH$}: reincarnation forbidden");
+        Reincarnatability::Nirvana => {
+            println!("    {KARMIC_STATUS:>WIDTH$}: attained nirvāṇa");
         }
-        InstanceKarmicStatus::CoolingDown(remaining) => {
+        Reincarnatability::CoolingDown(remaining) => {
             println!(
                 "/!\\ {KARMIC_STATUS:>WIDTH$}: cooling down \
                  ({remaining:?} remaining)"
             );
         }
     }
+    println!("    {LAST_AUTO_RESTART:>WIDTH$}: {time_last_auto_restarted:?}");
+
     println!("    {ACTIVE_VMM:>WIDTH$}: {propolis_id:?}");
     println!("    {TARGET_VMM:>WIDTH$}: {dst_propolis_id:?}");
     println!(

--- a/dev-tools/omdb/src/bin/omdb/db.rs
+++ b/dev-tools/omdb/src/bin/omdb/db.rs
@@ -3027,7 +3027,10 @@ async fn cmd_db_instance_info(
         r#gen.0
     );
     println!("    {LAST_AUTO_RESTART:>WIDTH$}: {time_last_auto_restarted:?}");
-    match instance.auto_restart.status(&instance.runtime_state) {
+    match instance
+        .auto_restart
+        .status(&instance.runtime_state, active_vmm.as_ref())
+    {
         InstanceKarmicStatus::NotFailed => {}
         InstanceKarmicStatus::Ready => {
             println!("(i) {KARMIC_STATUS:>WIDTH$}: ready to reincarnate!");

--- a/dev-tools/omdb/src/bin/omdb/nexus.rs
+++ b/dev-tools/omdb/src/bin/omdb/nexus.rs
@@ -1790,58 +1790,67 @@ fn print_task_details(bgtask: &BackgroundTask, details: &serde_json::Value) {
                 "warning: failed to interpret task details: {:?}: {:?}",
                 error, details
             ),
-            Ok(InstanceReincarnationStatus {
-                disabled,
-                instances_found,
-                instances_reincarnated,
-                changed_state,
-                errors,
-                restart_errors,
-            }) => {
+            Ok(status) => {
                 const FOUND: &'static str =
                     "instances eligible for reincarnation:";
-                const REINCARNATED: &'static str = "  instances reincarnated:";
+                const REINCARNATED: &'static str =
+                    "instances reincarnated successfully:";
                 const CHANGED_STATE: &'static str =
-                    "  instances which changed state before they could be reincarnated:";
+                    "instances which changed state before they could reincarnate:";
                 const ERRORS: &'static str =
-                    "  instances which failed to be reincarnated:";
-                const COOLDOWN_PERIOD: &'static str =
-                    "default cooldown period:";
+                    "instances which failed to reincarnate:";
                 const WIDTH: usize = const_max_len(&[
                     FOUND,
                     REINCARNATED,
                     CHANGED_STATE,
                     ERRORS,
-                    COOLDOWN_PERIOD,
                 ]);
-                let n_restart_errors = restart_errors.len();
-                let n_restarted = instances_reincarnated.len();
-                let n_changed_state = changed_state.len();
-                println!("    {FOUND:<WIDTH$} {instances_found:>3}");
+                if status.disabled {
+                    println!(
+                        "    instance reincarnation explicitly disabled \
+                         by config!"
+                    );
+                    return;
+                }
+
+                if !status.errors.is_empty() {
+                    println!(
+                        "    errors occurred while finding instances to \
+                          reincarnate:"
+                    );
+                    for error in &status.errors {
+                        println!("    > {error}")
+                    }
+                }
+
+                let n_restart_errors = status.restart_errors.len();
+                let n_restarted = status.instances_reincarnated.len();
+                let n_changed_state = status.changed_state.len();
+                println!(
+                    "    {FOUND:<WIDTH$} {:>3}",
+                    status.total_instances_found()
+                );
+                for (reason, count) in &status.instances_found {
+                    let reason = format!("  {reason} instances:");
+                    println!("    {reason:<WIDTH$} {count:>3}",);
+                }
                 println!("    {REINCARNATED:<WIDTH$} {n_restarted:>3}");
                 println!("    {CHANGED_STATE:<WIDTH$} {n_changed_state:>3}",);
                 println!("    {ERRORS:<WIDTH$} {n_restart_errors:>3}");
-
-                // if let Some(e) = query_error {
-                //     println!(
-                //         "    an error occurred while searching for instances \
-                //          to reincarnate:\n      {e}",
-                //     );
-                // }
 
                 if n_restart_errors > 0 {
                     println!(
                         "    errors occurred while restarting the following \
                          instances:"
                     );
-                    for (id, error) in restart_errors {
+                    for (id, error) in status.restart_errors {
                         println!("    > {id}: {error}");
                     }
                 }
 
                 if n_restarted > 0 {
                     println!("    the following instances have reincarnated:");
-                    for id in instances_reincarnated {
+                    for id in status.instances_reincarnated {
                         println!("    > {id}")
                     }
                 }
@@ -1851,7 +1860,7 @@ fn print_task_details(bgtask: &BackgroundTask, details: &serde_json::Value) {
                         "    the following instances states changed before \
                          they could be reincarnated:"
                     );
-                    for id in changed_state {
+                    for id in status.changed_state {
                         println!("    > {id}")
                     }
                 }

--- a/dev-tools/omdb/src/bin/omdb/nexus.rs
+++ b/dev-tools/omdb/src/bin/omdb/nexus.rs
@@ -1791,10 +1791,11 @@ fn print_task_details(bgtask: &BackgroundTask, details: &serde_json::Value) {
                 error, details
             ),
             Ok(InstanceReincarnationStatus {
+                disabled,
                 instances_found,
                 instances_reincarnated,
                 changed_state,
-                query_error,
+                errors,
                 restart_errors,
             }) => {
                 const FOUND: &'static str =
@@ -1821,12 +1822,12 @@ fn print_task_details(bgtask: &BackgroundTask, details: &serde_json::Value) {
                 println!("    {CHANGED_STATE:<WIDTH$} {n_changed_state:>3}",);
                 println!("    {ERRORS:<WIDTH$} {n_restart_errors:>3}");
 
-                if let Some(e) = query_error {
-                    println!(
-                        "    an error occurred while searching for instances \
-                         to reincarnate:\n      {e}",
-                    );
-                }
+                // if let Some(e) = query_error {
+                //     println!(
+                //         "    an error occurred while searching for instances \
+                //          to reincarnate:\n      {e}",
+                //     );
+                // }
 
                 if n_restart_errors > 0 {
                     println!(

--- a/dev-tools/omdb/tests/successes.out
+++ b/dev-tools/omdb/tests/successes.out
@@ -528,10 +528,12 @@ task: "instance_reincarnation"
   currently executing: no
   last completed activation: <REDACTED ITERATIONS>, triggered by a periodic timer firing
     started at <REDACTED_TIMESTAMP> (<REDACTED DURATION>s ago) and ran for <REDACTED DURATION>ms
-    instances eligible for reincarnation:                                0
-      instances reincarnated:                                            0
-      instances which changed state before they could be reincarnated:   0
-      instances which failed to be reincarnated:                         0
+    instances eligible for reincarnation:                          0
+      failed instances:                                            0
+      start saga unwound instances:                                0
+    instances reincarnated successfully:                           0
+    instances which changed state before they could reincarnate:   0
+    instances which failed to reincarnate:                         0
 
 task: "instance_updater"
   configured period: every <REDACTED_DURATION>s
@@ -968,10 +970,12 @@ task: "instance_reincarnation"
   currently executing: no
   last completed activation: <REDACTED ITERATIONS>, triggered by a periodic timer firing
     started at <REDACTED_TIMESTAMP> (<REDACTED DURATION>s ago) and ran for <REDACTED DURATION>ms
-    instances eligible for reincarnation:                                0
-      instances reincarnated:                                            0
-      instances which changed state before they could be reincarnated:   0
-      instances which failed to be reincarnated:                         0
+    instances eligible for reincarnation:                          0
+      failed instances:                                            0
+      start saga unwound instances:                                0
+    instances reincarnated successfully:                           0
+    instances which changed state before they could reincarnate:   0
+    instances which failed to reincarnate:                         0
 
 task: "instance_updater"
   configured period: every <REDACTED_DURATION>s

--- a/dev-tools/omdb/tests/successes.out
+++ b/dev-tools/omdb/tests/successes.out
@@ -524,7 +524,7 @@ task: "external_endpoints"
     TLS certificates: 0
 
 task: "instance_reincarnation"
-  configured period: every 1m
+  configured period: every 10m
   currently executing: no
   last completed activation: <REDACTED ITERATIONS>, triggered by a periodic timer firing
     started at <REDACTED_TIMESTAMP> (<REDACTED DURATION>s ago) and ran for <REDACTED DURATION>ms
@@ -966,7 +966,7 @@ task: "external_endpoints"
     TLS certificates: 0
 
 task: "instance_reincarnation"
-  configured period: every 1m
+  configured period: every 10m
   currently executing: no
   last completed activation: <REDACTED ITERATIONS>, triggered by a periodic timer firing
     started at <REDACTED_TIMESTAMP> (<REDACTED DURATION>s ago) and ran for <REDACTED DURATION>ms

--- a/dev-tools/omdb/tests/successes.out
+++ b/dev-tools/omdb/tests/successes.out
@@ -529,8 +529,8 @@ task: "instance_reincarnation"
   last completed activation: <REDACTED ITERATIONS>, triggered by a periodic timer firing
     started at <REDACTED_TIMESTAMP> (<REDACTED DURATION>s ago) and ran for <REDACTED DURATION>ms
     instances eligible for reincarnation:                          0
-      failed instances:                                            0
-      start saga unwound instances:                                0
+      instance failed instances:                                   0
+      start saga failed instances:                                 0
     instances reincarnated successfully:                           0
     instances which changed state before they could reincarnate:   0
     instances which failed to reincarnate:                         0
@@ -971,8 +971,8 @@ task: "instance_reincarnation"
   last completed activation: <REDACTED ITERATIONS>, triggered by a periodic timer firing
     started at <REDACTED_TIMESTAMP> (<REDACTED DURATION>s ago) and ran for <REDACTED DURATION>ms
     instances eligible for reincarnation:                          0
-      failed instances:                                            0
-      start saga unwound instances:                                0
+      instance failed instances:                                   0
+      start saga failed instances:                                 0
     instances reincarnated successfully:                           0
     instances which changed state before they could reincarnate:   0
     instances which failed to reincarnate:                         0

--- a/nexus/db-queries/src/db/datastore/instance.rs
+++ b/nexus/db-queries/src/db/datastore/instance.rs
@@ -495,24 +495,60 @@ impl DataStore {
     /// result set. Randomizing the order in which instances are returned allows
     /// a nicer distribution of work across multiple Nexus replicas'
     /// `instance_reincarnation` tasks.
-    pub async fn find_reincarnatable_instances(
+    pub async fn find_reincarnatable_failed_instances(
         &self,
         opctx: &OpContext,
         pagparams: &DataPageParams<'_, Uuid>,
     ) -> ListResultVec<Instance> {
         use db::schema::instance::dsl;
 
-        define_sql_function!(fn random() -> sql_types::Float);
-
         paginated(dsl::instance, dsl::id, &pagparams)
+            // Only attempt to restart Failed instances.
+            .filter(dsl::state.eq(InstanceState::Failed))
             // Select only those instances which may be reincarnated.
             .filter(InstanceAutoRestart::filter_reincarnatable())
-            // Deleted instances may not be reincarnated.
-            .filter(dsl::time_deleted.is_null())
-            // If the instance is currently in the process of being updated,
-            // let's not mess with it for now and try to restart it on another
-            // pass.
-            .filter(dsl::updater_id.is_null())
+            .filter(dsl::active_propolis_id.is_null())
+            .select(Instance::as_select())
+            .load_async::<Instance>(
+                &*self.pool_connection_authorized(opctx).await?,
+            )
+            .await
+            .map_err(|e| public_error_from_diesel(e, ErrorHandler::Server))
+    }
+
+    /// List all instances in the [`Failed`](InstanceState::Failed) state with an
+    /// auto-restart policy that permits them to be automatically restarted by
+    /// the control plane.
+    ///
+    /// This is used by the `instance_reincarnation` RPW to ensure that that any
+    /// such instances are restarted.
+    ///
+    /// This query returns `n` randomly-ordered instances which are eligible for
+    /// reincarnation. Because reincarnating an instance changes its state so
+    /// that it no longer matches this query, it isn't necessary to use
+    /// pagination to avoid the query returning the same instance multiple
+    /// times: instead, we just actually reincarnate it to remove it from the
+    /// result set. Randomizing the order in which instances are returned allows
+    /// a nicer distribution of work across multiple Nexus replicas'
+    /// `instance_reincarnation` tasks.
+    pub async fn find_reincarnatable_saga_unwound_instances(
+        &self,
+        opctx: &OpContext,
+        pagparams: &DataPageParams<'_, Uuid>,
+    ) -> ListResultVec<Instance> {
+        use db::schema::instance::dsl;
+        use db::schema::vmm::dsl as vmm_dsl;
+
+        paginated(dsl::instance, dsl::id, &pagparams)
+            .filter(dsl::state.eq(InstanceState::Vmm))
+            // Select only those instances which may be reincarnated.
+            .filter(InstanceAutoRestart::filter_reincarnatable())
+            // The instance's active VMM must be in the `SagaUnwound` state.
+            .inner_join(
+                vmm_dsl::vmm
+                    .on(dsl::active_propolis_id.eq(vmm_dsl::id.nullable())),
+            )
+            .filter(vmm_dsl::state.eq(VmmState::SagaUnwound))
             // N.B. that it's tempting to also filter out instances that have no
             // active VMM, since they're only valid targets for instance-start
             // sagas once the active VMM is unlinked, *or* if the active VMM is

--- a/nexus/db-queries/src/db/datastore/instance.rs
+++ b/nexus/db-queries/src/db/datastore/instance.rs
@@ -41,6 +41,7 @@ use async_bb8_diesel::AsyncRunQueryDsl;
 use chrono::Utc;
 use diesel::prelude::*;
 use nexus_db_model::Disk;
+use nexus_types::internal_api::background::ReincarnationReason;
 use omicron_common::api;
 use omicron_common::api::external;
 use omicron_common::api::external::http_pagination::PaginatedBy;
@@ -300,13 +301,6 @@ pub enum UpdaterLockError {
     /// An error occurred executing the query.
     #[error("error locking instance: {0}")]
     Query(#[from] Error),
-}
-
-/// Describes a reason why an instance needs reincarnation.
-#[derive(Debug, Copy, Clone, Eq, PartialEq)]
-pub enum ReincarnationReason {
-    Failed,
-    SagaUnwound,
 }
 
 impl DataStore {

--- a/nexus/src/app/background/tasks/instance_reincarnation.rs
+++ b/nexus/src/app/background/tasks/instance_reincarnation.rs
@@ -36,6 +36,8 @@ const DEFAULT_MAX_CONCURRENT_REINCARNATIONS: NonZeroU32 =
         None => unreachable!(), // 16 > 0
     };
 
+type RunningSaga = (Uuid, SagaId, BoxFuture<'static, Result<(), Error>>);
+
 impl BackgroundTask for InstanceReincarnation {
     fn activate<'a>(
         &'a mut self,
@@ -148,11 +150,7 @@ impl InstanceReincarnation {
         &mut self,
         log: &slog::Logger,
         status: &mut InstanceReincarnationStatus,
-        running_sagas: &mut Vec<(
-            Uuid,
-            SagaId,
-            BoxFuture<'_, Result<(), Error>>,
-        )>,
+        running_sagas: &mut Vec<RunningSaga>,
         serialized_authn: &authn::saga::Serialized,
         batch: Vec<db::model::Instance>,
     ) {

--- a/nexus/src/app/background/tasks/instance_reincarnation.rs
+++ b/nexus/src/app/background/tasks/instance_reincarnation.rs
@@ -5,7 +5,6 @@
 //! Background task for automatically restarting failed instances.
 
 use crate::app::background::BackgroundTask;
-use crate::app::db;
 use crate::app::saga::StartSaga;
 use crate::app::sagas::instance_start;
 use crate::app::sagas::NexusSaga;
@@ -59,7 +58,65 @@ impl BackgroundTask for InstanceReincarnation {
             let mut running_sagas =
                 Vec::with_capacity(self.concurrency_limit.get() as usize);
 
-            if !status.errors.is_empty() {}
+            if let Err(error) = self
+                .reincarnate_all(
+                    &opctx,
+                    instance::ReincarnationReason::Failed,
+                    &mut status,
+                    &mut running_sagas,
+                )
+                .await
+            {
+                error!(
+                    opctx.log,
+                    "failed to find all Failed instances in need of \
+                     reincarnation";
+                    "error" => %error,
+                );
+                status
+                    .errors
+                    .push(format!("finding Failed instances: {error}"));
+            }
+
+            if let Err(error) = self
+                .reincarnate_all(
+                    &opctx,
+                    instance::ReincarnationReason::SagaUnwound,
+                    &mut status,
+                    &mut running_sagas,
+                )
+                .await
+            {
+                error!(
+                    opctx.log,
+                    "failed to find all instances with unwound start sagas \
+                     in need of reincarnation";
+                    "error" => %error,
+                );
+                status.errors.push(format!(
+                    "finding instances with unwound start sagas: {error}"
+                ));
+            }
+
+            if !status.total_errors() > 0 {
+                warn!(
+                    &opctx.log,
+                    "instance reincarnation completed with errors";
+                    "instances_found" => status.total_instances_found(),
+                    "instances_reincarnated" => status.instances_reincarnated.len(),
+                    "instances_changed_state" => status.changed_state.len(),
+                    "query_errors" => status.errors.len(),
+                    "restart_errors" => status.restart_errors.len(),
+                );
+            } else {
+                info!(
+                    &opctx.log,
+                    "instance reincarnation completed successfully";
+                    "instances_found" => status.total_instances_found(),
+                    "instances_reincarnated" => status.instances_reincarnated.len(),
+                    "instances_changed_state" => status.changed_state.len(),
+                );
+            }
 
             serde_json::json!(status)
         })
@@ -90,6 +147,16 @@ impl InstanceReincarnation {
         let serialized_authn = authn::saga::Serialized::for_opctx(opctx);
 
         let mut paginator = Paginator::new(self.concurrency_limit);
+        let instances_found = status
+            .instances_found
+            .entry(match reason {
+                instance::ReincarnationReason::Failed => "failed".to_string(),
+                instance::ReincarnationReason::SagaUnwound => {
+                    "start saga unwound".to_string()
+                }
+            })
+            .or_insert(0);
+        let mut sagas_started = 0;
         while let Some(p) = paginator.next() {
             let batch = self
                 .datastore
@@ -102,12 +169,12 @@ impl InstanceReincarnation {
             paginator = p.found_batch(&batch, &|instance| instance.id());
 
             let found = batch.len();
-            status.instances_found += found;
+            *instances_found += found;
             if found == 0 {
                 trace!(
                     opctx.log,
                     "no more instances in need of reincarnation";
-                    "total_found" => status.instances_found,
+                    "total_found" => *instances_found,
                     "reincarnation_reason" => ?reason,
                 );
                 break;
@@ -167,15 +234,15 @@ impl InstanceReincarnation {
                 };
             }
 
+            sagas_started += running_sagas.len();
             debug!(
                 opctx.log,
                 "found {reason:?} instances in need of reincarnation";
                 "reincarnation_reason" => ?reason,
                 "instances_found" => found,
-                "total_found" => status.instances_found,
+                "total_found" => *instances_found,
                 "sagas_started" => running_sagas.len(),
-                "total_sagas_started" => running_sagas.len() +
-                    status.total_sagas_started(),
+                "total_sagas_started" => sagas_started,
             );
 
             // All sagas started, wait for them to come back before moving on to
@@ -253,8 +320,12 @@ mod test {
     use crate::app::sagas::test_helpers;
     use crate::external_api::params;
     use chrono::Utc;
+    use nexus_db_model::Generation;
     use nexus_db_model::InstanceRuntimeState;
     use nexus_db_model::InstanceState;
+    use nexus_db_model::Vmm;
+    use nexus_db_model::VmmRuntimeState;
+    use nexus_db_model::VmmState;
     use nexus_db_queries::authz;
     use nexus_db_queries::db::lookup::LookupPath;
     use nexus_test_utils::resource_helpers::{
@@ -297,7 +368,7 @@ mod test {
         name: &str,
         auto_restart: InstanceAutoRestartPolicy,
         state: InstanceState,
-    ) -> InstanceUuid {
+    ) -> authz::Instance {
         let instances_url = format!("/v1/instances?project={}", PROJECT_NAME);
         // Use the first chunk of the UUID as the name, to avoid conflicts.
         // Start with a lower ascii character to satisfy the name constraints.
@@ -333,14 +404,76 @@ mod test {
             .await;
 
         let id = InstanceUuid::from_untyped_uuid(instance.identity.id);
-        if state != InstanceState::Vmm {
-            put_instance_in_state(cptestctx, opctx, id, state).await;
-        }
+        let authz_instance = if state != InstanceState::Vmm
+            && state != InstanceState::NoVmm
+        {
+            put_instance_in_state(cptestctx, opctx, id, state).await
+        } else {
+            let datastore = cptestctx.server.server_context().nexus.datastore();
+            let (_, _, authz_instance) = LookupPath::new(&opctx, datastore)
+                .instance_id(id.into_untyped_uuid())
+                .lookup_for(authz::Action::Modify)
+                .await
+                .expect("instance must exist");
+            authz_instance
+        };
 
         eprintln!(
             "instance {id}: auto_restart_policy={auto_restart:?}; state={state:?}"
         );
-        id
+        authz_instance
+    }
+
+    async fn attach_saga_unwound_vmm(
+        cptestctx: &ControlPlaneTestContext,
+        opctx: &OpContext,
+        authz_instance: &authz::Instance,
+    ) {
+        let datastore = cptestctx.server.server_context().nexus.datastore();
+        let instance_id = InstanceUuid::from_untyped_uuid(authz_instance.id());
+        let vmm = datastore
+            .vmm_insert(
+                &opctx,
+                Vmm {
+                    id: Uuid::new_v4(),
+                    time_created: Utc::now(),
+                    time_deleted: None,
+                    instance_id: authz_instance.id(),
+                    sled_id: Uuid::new_v4(),
+                    propolis_ip: "10.1.9.42".parse().unwrap(),
+                    propolis_port: 420.into(),
+                    runtime: VmmRuntimeState {
+                        time_state_updated: Utc::now(),
+                        r#gen: Generation::new(),
+                        state: VmmState::SagaUnwound,
+                    },
+                },
+            )
+            .await
+            .expect("SagaUnwound VMM should be inserted");
+        let vmm_id = vmm.id;
+        let prev_state = datastore
+            .instance_refetch(&opctx, &authz_instance)
+            .await
+            .expect("instance must exist")
+            .runtime_state;
+        let updated = datastore
+            .instance_update_runtime(
+                &instance_id,
+                &InstanceRuntimeState {
+                    time_updated: Utc::now(),
+                    r#gen: Generation(prev_state.r#gen.next()),
+                    nexus_state: InstanceState::Vmm,
+                    propolis_id: Some(vmm_id),
+                    ..prev_state
+                },
+            )
+            .await
+            .expect("instance update should succeed");
+        assert!(updated, "instance {instance_id} was not updated");
+        eprintln!(
+            "instance {instance_id}: attached SagaUnwound active VMM {vmm_id}"
+        );
     }
 
     async fn put_instance_in_state(
@@ -348,7 +481,7 @@ mod test {
         opctx: &OpContext,
         id: InstanceUuid,
         state: InstanceState,
-    ) {
+    ) -> authz::Instance {
         info!(
             &cptestctx.logctx.log,
             "putting instance {id} in state {state:?}"
@@ -359,11 +492,11 @@ mod test {
             .instance_id(id.into_untyped_uuid())
             .lookup_for(authz::Action::Modify)
             .await
-            .expect("instance 2 must exist");
+            .expect("instance must exist");
         let prev_state = datastore
             .instance_refetch(&opctx, &authz_instance)
             .await
-            .expect("instance 2 must exist")
+            .expect("instance must exist")
             .runtime_state;
         let propolis_id = if state == InstanceState::Vmm {
             prev_state.propolis_id
@@ -377,12 +510,13 @@ mod test {
                     time_updated: Utc::now(),
                     nexus_state: state,
                     propolis_id,
-                    r#gen: nexus_db_model::Generation(prev_state.r#gen.next()),
+                    r#gen: Generation(prev_state.r#gen.next()),
                     ..prev_state
                 },
             )
             .await
             .expect("instance runtime state should update");
+        authz_instance
     }
 
     // Boilerplate reducer.
@@ -397,7 +531,7 @@ mod test {
                 serde_json::from_value::<InstanceReincarnationStatus>($result)
                     .expect("JSON must be correctly shaped");
             let status = dbg!(activation);
-            assert_eq!(status.query_error, None);
+            assert_eq!(status.errors, Vec::<String>::new());
             assert_eq!(status.restart_errors, HashMap::new());
             status
         }};
@@ -424,13 +558,13 @@ mod test {
 
         // Noop test
         let status = assert_activation_ok!(task.activate(&opctx).await);
-        assert_eq!(status.instances_found, 0);
+        assert_eq!(status.total_instances_found(), 0);
         assert_eq!(status.instances_reincarnated, Vec::new());
         assert_eq!(status.changed_state, Vec::new());
 
         // Create an instance in the `Failed` state that's eligible to be
         // restarted.
-        let instance_id = create_instance(
+        let instance = create_instance(
             &cptestctx,
             &opctx,
             "my-cool-instance",
@@ -442,16 +576,13 @@ mod test {
         // Activate the task again, and check that our instance had an
         // instance-start saga started.
         let status = assert_activation_ok!(task.activate(&opctx).await);
-        assert_eq!(status.instances_found, 1);
-        assert_eq!(
-            status.instances_reincarnated,
-            vec![instance_id.into_untyped_uuid()]
-        );
+        assert_eq!(status.total_instances_found(), 1);
+        assert_eq!(status.instances_reincarnated, vec![instance.id()]);
         assert_eq!(status.changed_state, Vec::new());
 
         test_helpers::instance_wait_for_state(
             &cptestctx,
-            instance_id,
+            InstanceUuid::from_untyped_uuid(instance.id()),
             InstanceState::Vmm,
         )
         .await;
@@ -479,8 +610,9 @@ mod test {
         // Create instances in the `Failed` state that are eligible to be
         // restarted.
         let mut will_reincarnate = std::collections::BTreeSet::new();
-        for i in 0..3 {
-            let id = create_instance(
+        let num_failed = 3;
+        for i in 0..num_failed {
+            let instance = create_instance(
                 &cptestctx,
                 &opctx,
                 &format!("sotapanna-{i}"),
@@ -488,15 +620,32 @@ mod test {
                 InstanceState::Failed,
             )
             .await;
-            will_reincarnate.insert(id.into_untyped_uuid());
+            will_reincarnate.insert(instance.id());
+        }
+        // Create instances with SagaUnwound active VMMs that are eligible to be
+        // reincarnated.
+        let num_saga_unwound = 2;
+        for i in 0..num_saga_unwound {
+            // Make the instance record.
+            let instance = create_instance(
+                &cptestctx,
+                &opctx,
+                &format!("sadakagami-{i}"),
+                InstanceAutoRestartPolicy::BestEffort,
+                InstanceState::NoVmm,
+            )
+            .await;
+            // Now, give the instance an active VMM which is SagaUnwound.
+            attach_saga_unwound_vmm(&cptestctx, &opctx, &instance).await;
+            will_reincarnate.insert(instance.id());
         }
 
-        // Create some instances that will not reicnarnate.
+        // Create some instances that will not reincarnate.
         let mut will_not_reincarnate = std::collections::BTreeSet::new();
         // Some instances which are `Failed` but don't have policies permitting
         // them to be reincarnated.
         for i in 0..3 {
-            let id = create_instance(
+            let instance = create_instance(
                 &cptestctx,
                 &opctx,
                 &format!("arahant-{i}"),
@@ -504,7 +653,24 @@ mod test {
                 InstanceState::Failed,
             )
             .await;
-            will_not_reincarnate.insert(id.into_untyped_uuid());
+
+            will_not_reincarnate.insert(instance.id());
+        }
+
+        // Some instances which have `SagaUnwound VMMs` but don't have policies
+        // permitting them to be reincarnated.
+        for i in 3..5 {
+            let instance = create_instance(
+                &cptestctx,
+                &opctx,
+                &format!("arahant-{i}"),
+                InstanceAutoRestartPolicy::Never,
+                InstanceState::NoVmm,
+            )
+            .await;
+
+            attach_saga_unwound_vmm(&cptestctx, &opctx, &instance).await;
+            will_not_reincarnate.insert(instance.id());
         }
 
         // Some instances with policies permitting them to be reincarnated, but
@@ -514,7 +680,7 @@ mod test {
                 .iter()
                 .enumerate()
         {
-            let id = create_instance(
+            let instance = create_instance(
                 &cptestctx,
                 &opctx,
                 &format!("anagami-{i}"),
@@ -522,16 +688,21 @@ mod test {
                 state,
             )
             .await;
-            will_not_reincarnate.insert(id.into_untyped_uuid());
+            will_not_reincarnate.insert(instance.id());
         }
 
         // Activate the task again, and check that our instance had an
         // instance-start saga started.
         let status = assert_activation_ok!(task.activate(&opctx).await);
-        assert_eq!(status.instances_found, will_reincarnate.len());
+        assert_eq!(status.total_instances_found(), will_reincarnate.len());
+        assert_eq!(status.instances_found.get("failed"), Some(&num_failed));
+        assert_eq!(
+            status.instances_found.get("start saga unwound"),
+            Some(&num_saga_unwound)
+        );
         assert_eq!(status.instances_reincarnated.len(), will_reincarnate.len());
         assert_eq!(status.changed_state, Vec::new());
-        assert_eq!(status.query_error, None);
+        assert_eq!(status.errors, Vec::<String>::new());
         assert_eq!(status.restart_errors, HashMap::new());
 
         for id in &status.instances_reincarnated {
@@ -578,7 +749,7 @@ mod test {
             false,
         );
 
-        let instance1_id = create_instance(
+        let instance1 = create_instance(
             &cptestctx,
             &opctx,
             "victor",
@@ -586,6 +757,8 @@ mod test {
             InstanceState::Failed,
         )
         .await;
+        let instance1_id = InstanceUuid::from_untyped_uuid(instance1.id());
+
         // Use the test-only API to set the cooldown period for instance 1 to ten
         // seconds, so that we don't have to make the test run for an hour to wait
         // out the default cooldown.
@@ -599,7 +772,7 @@ mod test {
             .await
             .expect("we must be able to set the cooldown period");
 
-        let instance2_id = create_instance(
+        let instance2 = create_instance(
             &cptestctx,
             &opctx,
             "frankenstein",
@@ -607,10 +780,11 @@ mod test {
             InstanceState::Vmm,
         )
         .await;
+        let instance2_id = InstanceUuid::from_untyped_uuid(instance2.id());
 
         // On the first activation, instance 1 should be restarted.
         let status = assert_activation_ok!(task.activate(&opctx).await);
-        assert_eq!(status.instances_found, 1);
+        assert_eq!(status.total_instances_found(), 1);
         assert_eq!(
             status.instances_reincarnated,
             &[instance1_id.into_untyped_uuid()]
@@ -645,7 +819,7 @@ mod test {
         // Activate the background task again. Now, only instance 2 should be
         // restarted.
         let status = assert_activation_ok!(task.activate(&opctx).await);
-        assert_eq!(status.instances_found, 1);
+        assert_eq!(status.total_instances_found(), 1);
         assert_eq!(
             status.instances_reincarnated,
             &[instance2_id.into_untyped_uuid()]
@@ -665,7 +839,7 @@ mod test {
         tokio::time::sleep(Duration::from_secs(COOLDOWN_SECS + 1)).await;
 
         let status = assert_activation_ok!(task.activate(&opctx).await);
-        assert_eq!(status.instances_found, 1);
+        assert_eq!(status.total_instances_found(), 1);
         assert_eq!(
             status.instances_reincarnated,
             &[instance1_id.into_untyped_uuid()]

--- a/nexus/src/app/background/tasks/instance_reincarnation.rs
+++ b/nexus/src/app/background/tasks/instance_reincarnation.rs
@@ -172,7 +172,6 @@ impl InstanceReincarnation {
                 );
                 break;
             }
-            let found = batch.len();
             for db_instance in batch {
                 let instance_id = db_instance.id();
                 info!(

--- a/nexus/src/app/sagas/instance_update/mod.rs
+++ b/nexus/src/app/sagas/instance_update/mod.rs
@@ -1289,7 +1289,10 @@ async fn siu_chain_successor_saga(
             // it does, activate the instance-reincarnation background task to
             // automatically restart it.
             let auto_restart = new_state.instance.auto_restart;
-            match auto_restart.status(&new_state.instance.runtime_state) {
+            match auto_restart.status(
+                &new_state.instance.runtime_state,
+                new_state.active_vmm.as_ref(),
+            ) {
                 InstanceKarmicStatus::Ready => {
                     info!(
                         log,

--- a/nexus/src/app/sagas/instance_update/mod.rs
+++ b/nexus/src/app/sagas/instance_update/mod.rs
@@ -350,7 +350,6 @@ use crate::app::db::datastore::VmmStateUpdateResult;
 use crate::app::db::lookup::LookupPath;
 use crate::app::db::model::ByteCount;
 use crate::app::db::model::Generation;
-use crate::app::db::model::InstanceKarmicStatus;
 use crate::app::db::model::InstanceRuntimeState;
 use crate::app::db::model::InstanceState;
 use crate::app::db::model::MigrationState;
@@ -1288,40 +1287,30 @@ async fn siu_chain_successor_saga(
             // auto-restart policy allows it to be automatically restarted. If
             // it does, activate the instance-reincarnation background task to
             // automatically restart it.
-            let auto_restart = new_state.instance.auto_restart;
-            match auto_restart.status(
+            let karmic_state = new_state.instance.auto_restart.status(
                 &new_state.instance.runtime_state,
                 new_state.active_vmm.as_ref(),
-            ) {
-                InstanceKarmicStatus::Ready => {
-                    info!(
-                        log,
-                        "instance update: instance transitioned to Failed, \
-                         but can be automatically restarted; activating \
-                         reincarnation.";
-                        "instance_id" => %instance_id,
-                        "auto_restart" => ?auto_restart,
-                        "runtime_state" => ?new_state.instance.runtime_state,
-                    );
-                    nexus
-                        .background_tasks
-                        .task_instance_reincarnation
-                        .activate();
-                }
-                InstanceKarmicStatus::CoolingDown(remaining) => {
-                    info!(
-                        log,
-                        "instance update: instance transitioned to Failed, \
-                         but is still in cooldown from a previous \
-                         reincarnation";
-                        "instance_id" => %instance_id,
-                        "auto_restart" => ?auto_restart,
-                        "cooldown_remaining" => ?remaining,
-                        "runtime_state" => ?new_state.instance.runtime_state,
-                    );
-                }
-                InstanceKarmicStatus::Forbidden
-                | InstanceKarmicStatus::NotFailed => {}
+            );
+            if karmic_state.should_reincarnate() {
+                info!(
+                    log,
+                    "instance update: instance transitioned to Failed, \
+                     but can be automatically restarted; activating \
+                     reincarnation.";
+                    "instance_id" => %instance_id,
+                    "auto_restart_config" => ?new_state.instance.auto_restart,
+                    "runtime_state" => ?new_state.instance.runtime_state,
+                );
+                nexus.background_tasks.task_instance_reincarnation.activate();
+            } else {
+                debug!(
+                    log,
+                    "instance update: instance will not reincarnate";
+                    "instance_id" => %instance_id,
+                    "auto_restart_config" => ?new_state.instance.auto_restart,
+                    "needs_reincarnation" => karmic_state.needs_reincarnation,
+                    "karmic_state" => ?karmic_state.can_reincarnate,
+                )
             }
         }
 

--- a/nexus/tests/config.test.toml
+++ b/nexus/tests/config.test.toml
@@ -138,7 +138,15 @@ lookup_region_port.period_secs = 60
 instance_updater.disable = true
 instance_updater.period_secs = 60
 # How frequently to attempt to restart Failed instances?
-instance_reincarnation.period_secs = 60
+#
+# The default activation period for this task is once every sixty seconds.
+# However, the task's unit tests rely on explicit activations of the task
+# finding all instances eligible for reincarnation. Thus, we don't want the
+# periodic activation to occur whilst running those tests, since it may
+# reincarnate instances that we expect an explicit activation to reincarnate,
+# removing them from the set of instances eligible for reincarnation. Thus, set
+# the period much longer than the default for test purposes.
+instance_reincarnation.period_secs = 600
 region_snapshot_replacement_start.period_secs = 30
 region_snapshot_replacement_garbage_collection.period_secs = 30
 region_snapshot_replacement_step.period_secs = 30

--- a/nexus/types/src/internal_api/background.rs
+++ b/nexus/types/src/internal_api/background.rs
@@ -4,7 +4,7 @@
 
 use serde::Deserialize;
 use serde::Serialize;
-use std::collections::HashMap;
+use std::collections::BTreeMap;
 use uuid::Uuid;
 
 /// The status of a `region_replacement` background task activation
@@ -125,7 +125,7 @@ pub struct InstanceReincarnationStatus {
     /// Total number of instances in need of reincarnation on this activation.
     /// This is broken down by the reason that the instance needed
     /// reincarnation.
-    pub instances_found: HashMap<String, usize>,
+    pub instances_found: BTreeMap<String, usize>,
     /// UUIDs of instances reincarnated successfully by this activation.
     pub instances_reincarnated: Vec<Uuid>,
     /// UUIDs of instances which changed state before they could be
@@ -134,7 +134,7 @@ pub struct InstanceReincarnationStatus {
     /// Any errors that occured while finding instances in need of reincarnation.
     pub errors: Vec<String>,
     /// Errors that occurred while restarting individual instances.
-    pub restart_errors: HashMap<Uuid, String>,
+    pub restart_errors: BTreeMap<Uuid, String>,
 }
 
 impl InstanceReincarnationStatus {

--- a/nexus/types/src/internal_api/background.rs
+++ b/nexus/types/src/internal_api/background.rs
@@ -131,3 +131,11 @@ pub struct InstanceReincarnationStatus {
     /// Errors that occurred while restarting individual instances.
     pub restart_errors: HashMap<Uuid, String>,
 }
+
+impl InstanceReincarnationStatus {
+    pub fn total_sagas_started(&self) -> usize {
+        self.instances_reincarnated.len()
+            + self.changed_state.len()
+            + self.restart_errors.len()
+    }
+}

--- a/nexus/types/src/internal_api/background.rs
+++ b/nexus/types/src/internal_api/background.rs
@@ -122,9 +122,10 @@ pub struct InstanceReincarnationStatus {
     /// If `true`, then instance reincarnation has been explicitly disabled by
     /// the config file.
     pub disabled: bool,
-
     /// Total number of instances in need of reincarnation on this activation.
-    pub instances_found: usize,
+    /// This is broken down by the reason that the instance needed
+    /// reincarnation.
+    pub instances_found: HashMap<String, usize>,
     /// UUIDs of instances reincarnated successfully by this activation.
     pub instances_reincarnated: Vec<Uuid>,
     /// UUIDs of instances which changed state before they could be
@@ -137,6 +138,14 @@ pub struct InstanceReincarnationStatus {
 }
 
 impl InstanceReincarnationStatus {
+    pub fn total_instances_found(&self) -> usize {
+        self.instances_found.values().sum()
+    }
+
+    pub fn total_errors(&self) -> usize {
+        self.errors.len() + self.restart_errors.len()
+    }
+
     pub fn total_sagas_started(&self) -> usize {
         self.instances_reincarnated.len()
             + self.changed_state.len()

--- a/nexus/types/src/internal_api/background.rs
+++ b/nexus/types/src/internal_api/background.rs
@@ -119,6 +119,10 @@ impl InstanceUpdaterStatus {
 /// The status of an `instance_reincarnation` background task activation.
 #[derive(Default, Serialize, Deserialize, Debug)]
 pub struct InstanceReincarnationStatus {
+    /// If `true`, then instance reincarnation has been explicitly disabled by
+    /// the config file.
+    pub disabled: bool,
+
     /// Total number of instances in need of reincarnation on this activation.
     pub instances_found: usize,
     /// UUIDs of instances reincarnated successfully by this activation.
@@ -126,8 +130,8 @@ pub struct InstanceReincarnationStatus {
     /// UUIDs of instances which changed state before they could be
     /// reincarnated.
     pub changed_state: Vec<Uuid>,
-    /// Any error that occured while finding instances in need of reincarnation.
-    pub query_error: Option<String>,
+    /// Any errors that occured while finding instances in need of reincarnation.
+    pub errors: Vec<String>,
     /// Errors that occurred while restarting individual instances.
     pub restart_errors: HashMap<Uuid, String>,
 }


### PR DESCRIPTION
When an `instance-start` saga unwinds, any VMM it created transitions to
the `SagaUnwound` state. This causes the instance's effective state to
appear as `Failed` in the external API. PR #6503 added functionality to
Nexus to automatically restart instances that are in the `Failed` state
("instance reincarnation"). However, the current instance-reincarnation
task will _not_ automatically restart instances whose instance-start
sagas have unwound, because such instances are not actually in the
`Failed` state from Nexus' perspective.

This PR implements reincarnation for instances whose `instance-start`
sagas have failed. This is done by changing the `instance_reincarnation`
background task to query the database for instances which have
`SagaUnwound` active VMMs, and then run `instance-start` sagas for them
identically to how it runs start sagas for `Failed` instances.

I decided to perform two separate queries to list `Failed` instances and
to list instances with `SagaUnwound` VMMs, because the `SagaUnwound`
query requires a join with the `vmm` table, and I thought it was a bit
nicer to be able to find `Failed` instances without having to do the
join, and only do it when looking for `SagaUnwound` ones. Also, having
two queries makes it easier to distinguish between `Failed` and
`SagaUnwound` instances in logging and the OMDB status output. This
ended up being implemented by adding a parameter to the
`DataStore::find_reincarnatable_instances` method that indicates which
category of instances to select; I had previously considered making the
method on the `InstanceReincarnation` struct that finds instances and
reincarnates them take the query as a `Fn` taking the datastore and 
`DataPageParams` and returning an `impl Future` outputting
`Result<Vec<Instance>, ...>`,but figuring out generic lifetimes for the 
pagination stuff was annoying enough that this felt like the simpler
choice.

Fixes #6638