### PR TITLE
add `DatasetName::mountpoint` function; fix inconsistent mountpoints for nexus-managed datasets

### DIFF
--- a/common/src/disk.rs
+++ b/common/src/disk.rs
@@ -129,17 +129,23 @@ impl DatasetName {
 
     /// Returns the mountpoint of the dataset.
     ///
-    /// If this dataset should be encrypted, this automatically adds the
-    /// "crypt" dataset component.
+    /// If this dataset is delegated to a non-global zone, returns "/data".
+    ///
+    /// If this dataset is intended for the global zone and should be encrypted,
+    /// this automatically adds the "crypt" dataset component.
     pub fn mountpoint(&self, root: &Utf8Path) -> Utf8PathBuf {
-        self.pool_name.dataset_mountpoint(
-            root,
-            &if self.kind.dataset_should_be_encrypted() {
-                format!("crypt/{}", self.kind)
-            } else {
-                self.kind.to_string()
-            },
-        )
+        if self.kind.zoned() {
+            Utf8PathBuf::from("/data")
+        } else {
+            self.pool_name.dataset_mountpoint(
+                root,
+                &if self.kind.dataset_should_be_encrypted() {
+                    format!("crypt/{}", self.kind)
+                } else {
+                    self.kind.to_string()
+                },
+            )
+        }
     }
 
     fn full_encrypted_name(&self) -> String {

--- a/common/src/disk.rs
+++ b/common/src/disk.rs
@@ -5,6 +5,7 @@
 //! Disk related types shared among crates
 
 use anyhow::bail;
+use camino::{Utf8Path, Utf8PathBuf};
 use omicron_uuid_kinds::DatasetUuid;
 use omicron_uuid_kinds::ZpoolUuid;
 use schemars::JsonSchema;
@@ -124,6 +125,21 @@ impl DatasetName {
         } else {
             self.full_unencrypted_name()
         }
+    }
+
+    /// Returns the mountpoint of the dataset.
+    ///
+    /// If this dataset should be encrypted, this automatically adds the
+    /// "crypt" dataset component.
+    pub fn mountpoint(&self, root: &Utf8Path) -> Utf8PathBuf {
+        self.pool_name.dataset_mountpoint(
+            root,
+            &if self.kind.dataset_should_be_encrypted() {
+                format!("crypt/{}", self.kind)
+            } else {
+                self.kind.to_string()
+            },
+        )
     }
 
     fn full_encrypted_name(&self) -> String {

--- a/sled-storage/src/manager.rs
+++ b/sled-storage/src/manager.rs
@@ -11,7 +11,7 @@ use crate::dataset::CONFIG_DATASET;
 use crate::disk::RawDisk;
 use crate::error::Error;
 use crate::resources::{AllDisks, StorageResources};
-use camino::Utf8PathBuf;
+use camino::{Utf8Path, Utf8PathBuf};
 use debug_ignore::DebugIgnore;
 use futures::future::FutureExt;
 use illumos_utils::zfs::{Mountpoint, Zfs};
@@ -1012,10 +1012,7 @@ impl StorageManager {
         let mountpoint_path = if zoned {
             Utf8PathBuf::from("/data")
         } else {
-            config.name.pool().dataset_mountpoint(
-                &Utf8PathBuf::from("/"),
-                &config.name.dataset().to_string(),
-            )
+            config.name.mountpoint(Utf8Path::new("/"))
         };
         let mountpoint = Mountpoint::Path(mountpoint_path);
 

--- a/sled-storage/src/manager.rs
+++ b/sled-storage/src/manager.rs
@@ -11,11 +11,11 @@ use crate::dataset::CONFIG_DATASET;
 use crate::disk::RawDisk;
 use crate::error::Error;
 use crate::resources::{AllDisks, StorageResources};
-use camino::{Utf8Path, Utf8PathBuf};
+use camino::Utf8PathBuf;
 use debug_ignore::DebugIgnore;
 use futures::future::FutureExt;
 use illumos_utils::zfs::{Mountpoint, Zfs};
-use illumos_utils::zpool::ZpoolName;
+use illumos_utils::zpool::{ZpoolName, ZPOOL_MOUNTPOINT_ROOT};
 use key_manager::StorageKeyRequester;
 use omicron_common::disk::{
     DatasetConfig, DatasetManagementStatus, DatasetName, DatasetsConfig,
@@ -1009,11 +1009,8 @@ impl StorageManager {
         }
 
         let zoned = config.name.dataset().zoned();
-        let mountpoint_path = if zoned {
-            Utf8PathBuf::from("/data")
-        } else {
-            config.name.mountpoint(Utf8Path::new("/"))
-        };
+        let mountpoint_path =
+            config.name.mountpoint(ZPOOL_MOUNTPOINT_ROOT.into());
         let mountpoint = Mountpoint::Path(mountpoint_path);
 
         let fs_name = &config.name.full_name();


### PR DESCRIPTION
While working in related code I spotted a bug in the `ensure_dataset` handler: the mountpoint for encrypted datasets is not under the `crypt` directory. This wouldn't keep the dataset from being encrypted since it was still had the `crypt` dataset as its parent, but it would make mountpoints different depending on whether it was created directly by Sled Agent or created by request of Nexus.

`DatasetName` now has a method for getting the mountpoint which handles adding the `crypt` path segment if needed.