### PR TITLE
quasi-lock dependencies in omicron-common job

### DIFF
--- a/.github/buildomat/jobs/omicron-common.sh
+++ b/.github/buildomat/jobs/omicron-common.sh
@@ -21,6 +21,16 @@ cd /tmp
 cargo new --lib test-project
 cd test-project
 cargo add omicron-common --path /work/oxidecomputer/omicron/common
+# Bootstrap `test-project`'s dependencies from the checked-in Cargo.lock.
+# This means that `test-project` builds with the same commits as the main repo
+# for any dependencies referenced as `{ git = "...", ref = "<branch>" }`. If we
+# do not prepopulate `Cargo.lock` like this, an update in a dependency might get
+# picked up here and be incompatible with `omicron-common`, causing it to fail
+# to build (see Omicron issue #6691).
+#
+# The extra dependencies in `omicron` will get pruned by Cargo when it
+# recalculates dependencies, but any dependencies that match will stay at the
+# commit/version/etc already indicated in the lockfile.
 cp /work/oxidecomputer/omicron/Cargo.lock Cargo.lock
 cargo check
 cargo build --release

--- a/.github/buildomat/jobs/omicron-common.sh
+++ b/.github/buildomat/jobs/omicron-common.sh
@@ -21,5 +21,6 @@ cd /tmp
 cargo new --lib test-project
 cd test-project
 cargo add omicron-common --path /work/oxidecomputer/omicron/common
+cp /work/oxidecomputer/omicron/Cargo.lock Cargo.lock
 cargo check
 cargo build --release


### PR DESCRIPTION
"fixes" https://github.com/oxidecomputer/omicron/issues/6691 by stealing the checked-in Cargo.lock when building the standalone `omicron-common` crate created for this job. this lets us keep the specific refs of git dependencies that are `ref="main"` and similar, which might otherwise resolve to different commits than the rest of the tree (and its `omicron-common`) can actually build with.

it'd be nice to have fewer git dependencies using branch names for refs, either by using a cratesio crate or specific commit or _something_, but this seems to make things a bit less brittle in the mean time.

https://github.com/oxidecomputer/omicron/runs/30726055679 passes here while failing to build on main :tada: 