### PR TITLE
[easy] [sled-agent] make omicron_zones_list internally infallible

### DIFF
--- a/sled-agent/src/http_entrypoints.rs
+++ b/sled-agent/src/http_entrypoints.rs
@@ -259,7 +259,7 @@ impl SledAgentApi for SledAgentImpl {
         rqctx: RequestContext<Self::Context>,
     ) -> Result<HttpResponseOk<OmicronZonesConfig>, HttpError> {
         let sa = rqctx.context();
-        Ok(HttpResponseOk(sa.omicron_zones_list().await?))
+        Ok(HttpResponseOk(sa.omicron_zones_list().await))
     }
 
     async fn omicron_zones_put(

--- a/sled-agent/src/services.rs
+++ b/sled-agent/src/services.rs
@@ -3316,9 +3316,7 @@ impl ServiceManager {
     }
 
     /// Returns the current Omicron zone configuration
-    pub async fn omicron_zones_list(
-        &self,
-    ) -> Result<OmicronZonesConfig, Error> {
+    pub async fn omicron_zones_list(&self) -> OmicronZonesConfig {
         let log = &self.inner.log;
 
         // We need to take the lock in order for the information in the ledger
@@ -3337,7 +3335,7 @@ impl ServiceManager {
             None => OmicronZonesConfigLocal::initial(),
         };
 
-        Ok(ledger_data.to_omicron_zones_config())
+        ledger_data.to_omicron_zones_config()
     }
 
     /// Ensures that particular Omicron zones are running

--- a/sled-agent/src/sled_agent.rs
+++ b/sled-agent/src/sled_agent.rs
@@ -918,10 +918,8 @@ impl SledAgent {
     }
 
     /// List the Omicron zone configuration that's currently running
-    pub async fn omicron_zones_list(
-        &self,
-    ) -> Result<OmicronZonesConfig, Error> {
-        Ok(self.inner.services.omicron_zones_list().await?)
+    pub async fn omicron_zones_list(&self) -> OmicronZonesConfig {
+        self.inner.services.omicron_zones_list().await
     }
 
     /// Ensures that the specific set of Omicron zones are running as configured


### PR DESCRIPTION
Small cleanup -- we're not promising that it's infallible in the API, but
internally infallible makes some upcoming logic slightly easier.
