### PR TITLE
hyper v1: work around the current maghemite / omicron lag

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1975,12 +1975,12 @@ dependencies = [
 [[package]]
 name = "ddm-admin-client"
 version = "0.1.0"
-source = "git+https://github.com/oxidecomputer/maghemite?rev=9e0fe45ca3862176dc31ad8cc83f605f8a7e1a42#9e0fe45ca3862176dc31ad8cc83f605f8a7e1a42"
+source = "git+https://github.com/oxidecomputer/maghemite?branch=hyper-v1-no-merge#b13b5b240f3967de753fd589b1036745d2770b52"
 dependencies = [
  "oxnet",
  "percent-encoding",
- "progenitor 0.7.0",
- "reqwest 0.11.27",
+ "progenitor 0.8.0",
+ "reqwest 0.12.7",
  "serde",
  "serde_json",
  "slog",
@@ -5156,13 +5156,13 @@ dependencies = [
 [[package]]
 name = "mg-admin-client"
 version = "0.1.0"
-source = "git+https://github.com/oxidecomputer/maghemite?rev=9e0fe45ca3862176dc31ad8cc83f605f8a7e1a42#9e0fe45ca3862176dc31ad8cc83f605f8a7e1a42"
+source = "git+https://github.com/oxidecomputer/maghemite?branch=hyper-v1-no-merge#b13b5b240f3967de753fd589b1036745d2770b52"
 dependencies = [
  "anyhow",
  "chrono",
  "percent-encoding",
- "progenitor 0.7.0",
- "reqwest 0.11.27",
+ "progenitor 0.8.0",
+ "reqwest 0.12.7",
  "schemars",
  "serde",
  "serde_json",
@@ -6415,7 +6415,6 @@ dependencies = [
  "omicron-common",
  "omicron-workspace-hack",
  "progenitor-client 0.8.0",
- "reqwest 0.11.27",
  "reqwest 0.12.7",
  "serde",
  "sled-hardware-types",
@@ -7095,6 +7094,7 @@ dependencies = [
  "ring 0.17.8",
  "rsa",
  "rustix",
+ "rustls 0.21.12",
  "rustls 0.23.10",
  "schemars",
  "scopeguard",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -422,8 +422,10 @@ macaddr = { version = "1.0.1", features = ["serde_std"] }
 maplit = "1.0.2"
 mockall = "0.13"
 newtype_derive = "0.1.6"
-mg-admin-client = { git = "https://github.com/oxidecomputer/maghemite", rev = "9e0fe45ca3862176dc31ad8cc83f605f8a7e1a42" }
-ddm-admin-client = { git = "https://github.com/oxidecomputer/maghemite", rev = "9e0fe45ca3862176dc31ad8cc83f605f8a7e1a42" }
+# mg-admin-client = { git = "https://github.com/oxidecomputer/maghemite", rev = "9e0fe45ca3862176dc31ad8cc83f605f8a7e1a42" }
+# ddm-admin-client = { git = "https://github.com/oxidecomputer/maghemite", rev = "9e0fe45ca3862176dc31ad8cc83f605f8a7e1a42" }
+mg-admin-client = { git = "https://github.com/oxidecomputer/maghemite", branch = "hyper-v1-no-merge" }
+ddm-admin-client = { git = "https://github.com/oxidecomputer/maghemite", branch = "hyper-v1-no-merge" }
 multimap = "0.10.0"
 nexus-auth = { path = "nexus/auth" }
 nexus-client = { path = "clients/nexus-client" }
@@ -527,7 +529,6 @@ ref-cast = "1.0"
 regex = "1.10.6"
 regress = "0.9.1"
 reqwest = { version = "0.12", default-features = false }
-reqwest11 = { package = "reqwest", version = "0.11", default-features = false }
 ring = "0.17.8"
 rpassword = "7.3.1"
 rstest = "0.22.0"

--- a/clients/ddm-admin-client/Cargo.toml
+++ b/clients/ddm-admin-client/Cargo.toml
@@ -11,7 +11,6 @@ workspace = true
 either.workspace = true
 progenitor-client.workspace = true
 reqwest = { workspace = true, features = ["json", "stream", "rustls-tls"] }
-reqwest11 = { workspace = true, features = ["json", "stream", "rustls-tls"] }
 serde.workspace = true
 slog.workspace = true
 thiserror.workspace = true

--- a/clients/ddm-admin-client/src/lib.rs
+++ b/clients/ddm-admin-client/src/lib.rs
@@ -38,7 +38,7 @@ const DDMD_PORT: u16 = 8000;
 #[derive(Debug, Error)]
 pub enum DdmError {
     #[error("Failed to construct an HTTP client: {0}")]
-    HttpClient(#[from] reqwest11::Error),
+    HttpClient(#[from] reqwest::Error),
 
     #[error("Failed making HTTP request to ddmd: {0}")]
     DdmdApi(#[from] Error<types::Error>),
@@ -64,7 +64,7 @@ impl Client {
         let log =
             log.new(slog::o!("DdmAdminClient" => SocketAddr::V6(ddmd_addr)));
 
-        let inner = reqwest11::ClientBuilder::new()
+        let inner = reqwest::ClientBuilder::new()
             .connect_timeout(dur)
             .timeout(dur)
             .build()?;

--- a/workspace-hack/Cargo.toml
+++ b/workspace-hack/Cargo.toml
@@ -91,7 +91,7 @@ regex = { version = "1.10.6" }
 regex-automata = { version = "0.4.6", default-features = false, features = ["dfa", "hybrid", "meta", "nfa", "perf", "unicode"] }
 regex-syntax = { version = "0.8.4" }
 reqwest-5ef9efb8ec2df382 = { package = "reqwest", version = "0.12.7", features = ["blocking", "cookies", "json", "rustls-tls", "stream"] }
-reqwest-a6292c17cd707f01 = { package = "reqwest", version = "0.11.27", features = ["json", "rustls-tls", "stream"] }
+reqwest-a6292c17cd707f01 = { package = "reqwest", version = "0.11.27", default-features = false, features = ["rustls-tls", "stream"] }
 ring = { version = "0.17.8", features = ["std"] }
 rsa = { version = "0.9.6", features = ["serde", "sha2"] }
 schemars = { version = "0.8.21", features = ["bytes", "chrono", "uuid1"] }
@@ -202,7 +202,7 @@ regex = { version = "1.10.6" }
 regex-automata = { version = "0.4.6", default-features = false, features = ["dfa", "hybrid", "meta", "nfa", "perf", "unicode"] }
 regex-syntax = { version = "0.8.4" }
 reqwest-5ef9efb8ec2df382 = { package = "reqwest", version = "0.12.7", features = ["blocking", "cookies", "json", "rustls-tls", "stream"] }
-reqwest-a6292c17cd707f01 = { package = "reqwest", version = "0.11.27", features = ["json", "rustls-tls", "stream"] }
+reqwest-a6292c17cd707f01 = { package = "reqwest", version = "0.11.27", default-features = false, features = ["rustls-tls", "stream"] }
 ring = { version = "0.17.8", features = ["std"] }
 rsa = { version = "0.9.6", features = ["serde", "sha2"] }
 schemars = { version = "0.8.21", features = ["bytes", "chrono", "uuid1"] }
@@ -250,7 +250,8 @@ linux-raw-sys = { version = "0.4.13", default-features = false, features = ["elf
 mio = { version = "1.0.2", features = ["net", "os-ext"] }
 once_cell = { version = "1.19.0" }
 rustix = { version = "0.38.34", features = ["event", "fs", "net", "pipe", "process", "stdio", "system", "termios", "time"] }
-rustls = { version = "0.23.10", default-features = false, features = ["logging", "ring", "std", "tls12"] }
+rustls-2b5c6dc72f624058 = { package = "rustls", version = "0.23.10", default-features = false, features = ["logging", "ring", "std", "tls12"] }
+rustls-647d43efb71741da = { package = "rustls", version = "0.21.12", features = ["dangerous_configuration"] }
 signal-hook-mio = { version = "0.2.4", default-features = false, features = ["support-v0_8", "support-v1_0"] }
 tokio-rustls = { version = "0.26.0", default-features = false, features = ["logging", "ring", "tls12"] }
 
@@ -264,7 +265,8 @@ linux-raw-sys = { version = "0.4.13", default-features = false, features = ["elf
 mio = { version = "1.0.2", features = ["net", "os-ext"] }
 once_cell = { version = "1.19.0" }
 rustix = { version = "0.38.34", features = ["event", "fs", "net", "pipe", "process", "stdio", "system", "termios", "time"] }
-rustls = { version = "0.23.10", default-features = false, features = ["logging", "ring", "std", "tls12"] }
+rustls-2b5c6dc72f624058 = { package = "rustls", version = "0.23.10", default-features = false, features = ["logging", "ring", "std", "tls12"] }
+rustls-647d43efb71741da = { package = "rustls", version = "0.21.12", features = ["dangerous_configuration"] }
 signal-hook-mio = { version = "0.2.4", default-features = false, features = ["support-v0_8", "support-v1_0"] }
 tokio-rustls = { version = "0.26.0", default-features = false, features = ["logging", "ring", "tls12"] }
 
@@ -276,7 +278,8 @@ hyper-util = { version = "0.1.9", features = ["full"] }
 mio = { version = "1.0.2", features = ["net", "os-ext"] }
 once_cell = { version = "1.19.0" }
 rustix = { version = "0.38.34", features = ["event", "fs", "net", "pipe", "process", "stdio", "system", "termios", "time"] }
-rustls = { version = "0.23.10", default-features = false, features = ["logging", "ring", "std", "tls12"] }
+rustls-2b5c6dc72f624058 = { package = "rustls", version = "0.23.10", default-features = false, features = ["logging", "ring", "std", "tls12"] }
+rustls-647d43efb71741da = { package = "rustls", version = "0.21.12", features = ["dangerous_configuration"] }
 signal-hook-mio = { version = "0.2.4", default-features = false, features = ["support-v0_8", "support-v1_0"] }
 tokio-rustls = { version = "0.26.0", default-features = false, features = ["logging", "ring", "tls12"] }
 
@@ -288,7 +291,8 @@ hyper-util = { version = "0.1.9", features = ["full"] }
 mio = { version = "1.0.2", features = ["net", "os-ext"] }
 once_cell = { version = "1.19.0" }
 rustix = { version = "0.38.34", features = ["event", "fs", "net", "pipe", "process", "stdio", "system", "termios", "time"] }
-rustls = { version = "0.23.10", default-features = false, features = ["logging", "ring", "std", "tls12"] }
+rustls-2b5c6dc72f624058 = { package = "rustls", version = "0.23.10", default-features = false, features = ["logging", "ring", "std", "tls12"] }
+rustls-647d43efb71741da = { package = "rustls", version = "0.21.12", features = ["dangerous_configuration"] }
 signal-hook-mio = { version = "0.2.4", default-features = false, features = ["support-v0_8", "support-v1_0"] }
 tokio-rustls = { version = "0.26.0", default-features = false, features = ["logging", "ring", "tls12"] }
 
@@ -300,7 +304,8 @@ hyper-util = { version = "0.1.9", features = ["full"] }
 mio = { version = "1.0.2", features = ["net", "os-ext"] }
 once_cell = { version = "1.19.0" }
 rustix = { version = "0.38.34", features = ["event", "fs", "net", "pipe", "process", "stdio", "system", "termios", "time"] }
-rustls = { version = "0.23.10", default-features = false, features = ["logging", "ring", "std", "tls12"] }
+rustls-2b5c6dc72f624058 = { package = "rustls", version = "0.23.10", default-features = false, features = ["logging", "ring", "std", "tls12"] }
+rustls-647d43efb71741da = { package = "rustls", version = "0.21.12", features = ["dangerous_configuration"] }
 signal-hook-mio = { version = "0.2.4", default-features = false, features = ["support-v0_8", "support-v1_0"] }
 tokio-rustls = { version = "0.26.0", default-features = false, features = ["logging", "ring", "tls12"] }
 
@@ -312,7 +317,8 @@ hyper-util = { version = "0.1.9", features = ["full"] }
 mio = { version = "1.0.2", features = ["net", "os-ext"] }
 once_cell = { version = "1.19.0" }
 rustix = { version = "0.38.34", features = ["event", "fs", "net", "pipe", "process", "stdio", "system", "termios", "time"] }
-rustls = { version = "0.23.10", default-features = false, features = ["logging", "ring", "std", "tls12"] }
+rustls-2b5c6dc72f624058 = { package = "rustls", version = "0.23.10", default-features = false, features = ["logging", "ring", "std", "tls12"] }
+rustls-647d43efb71741da = { package = "rustls", version = "0.21.12", features = ["dangerous_configuration"] }
 signal-hook-mio = { version = "0.2.4", default-features = false, features = ["support-v0_8", "support-v1_0"] }
 tokio-rustls = { version = "0.26.0", default-features = false, features = ["logging", "ring", "tls12"] }
 
@@ -325,8 +331,10 @@ hyper-util = { version = "0.1.9", features = ["full"] }
 indicatif = { version = "0.17.8", features = ["rayon"] }
 mio = { version = "1.0.2", features = ["net", "os-ext"] }
 once_cell = { version = "1.19.0" }
+reqwest-a6292c17cd707f01 = { package = "reqwest", version = "0.11.27", features = ["json"] }
 rustix = { version = "0.38.34", features = ["event", "fs", "net", "pipe", "process", "stdio", "system", "termios", "time"] }
-rustls = { version = "0.23.10", default-features = false, features = ["logging", "ring", "std", "tls12"] }
+rustls-2b5c6dc72f624058 = { package = "rustls", version = "0.23.10", default-features = false, features = ["logging", "ring", "std", "tls12"] }
+rustls-647d43efb71741da = { package = "rustls", version = "0.21.12", features = ["dangerous_configuration"] }
 signal-hook-mio = { version = "0.2.4", default-features = false, features = ["support-v0_8", "support-v1_0"] }
 tokio-rustls = { version = "0.26.0", default-features = false, features = ["logging", "ring", "tls12"] }
 toml_edit-cdcf2f9584511fe6 = { package = "toml_edit", version = "0.19.15", features = ["serde"] }
@@ -340,8 +348,10 @@ hyper-util = { version = "0.1.9", features = ["full"] }
 indicatif = { version = "0.17.8", features = ["rayon"] }
 mio = { version = "1.0.2", features = ["net", "os-ext"] }
 once_cell = { version = "1.19.0" }
+reqwest-a6292c17cd707f01 = { package = "reqwest", version = "0.11.27", features = ["json"] }
 rustix = { version = "0.38.34", features = ["event", "fs", "net", "pipe", "process", "stdio", "system", "termios", "time"] }
-rustls = { version = "0.23.10", default-features = false, features = ["logging", "ring", "std", "tls12"] }
+rustls-2b5c6dc72f624058 = { package = "rustls", version = "0.23.10", default-features = false, features = ["logging", "ring", "std", "tls12"] }
+rustls-647d43efb71741da = { package = "rustls", version = "0.21.12", features = ["dangerous_configuration"] }
 signal-hook-mio = { version = "0.2.4", default-features = false, features = ["support-v0_8", "support-v1_0"] }
 tokio-rustls = { version = "0.26.0", default-features = false, features = ["logging", "ring", "tls12"] }
 toml_edit-cdcf2f9584511fe6 = { package = "toml_edit", version = "0.19.15", features = ["serde"] }


### PR DESCRIPTION
This is kind of gross.

Omicron currently is out of sync with maghemite, see #6693 and the two maghemite pushes that require synchronization: https://github.com/oxidecomputer/maghemite/pull/359 and https://github.com/oxidecomputer/maghemite/pull/360. I'd like to make forward progress with the hyper v1 migration, and that's blocked on updating the omicron dependency of maghemite which pulls in old hyper (reqwest, progenitor, etc). This gets pull into other repos via omicron-common.

It's worth noting that this circular arrangement seems lousy. The "vassal crates" (crucible, propolis, maghemite, (and dendrite to a lesser degree)) depend on omicron-common, but omicron-common pulls in maghemite's `mg-admin-client` which in turn pulls in... lots... including progenitor, hyper, reqwest, etc.

My goal here is to have a temporary dependency on a branch of maghemite (https://github.com/oxidecomputer/maghemite/pull/378); once #6693 is integrated, we can then pin the dependency on maghemite's HEAD rev.