### PR TITLE
Inline the sole consumer of omicron_common::generate_logging_api

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -6383,7 +6383,6 @@ dependencies = [
  "once_cell",
  "oxnet",
  "parse-display",
- "progenitor 0.8.0",
  "progenitor-client 0.8.0",
  "proptest",
  "rand",

--- a/clients/gateway-client/src/lib.rs
+++ b/clients/gateway-client/src/lib.rs
@@ -9,9 +9,7 @@
 pub use gateway_messages::SpComponent;
 
 // We specifically want to allow consumers, such as `wicketd`, to embed
-// inventory datatypes into their own APIs, rather than recreate structs. For
-// this purpose, we copied the `omicron_common::generate_logging_api!` macro
-// body and added a  `derives = [schemars::JsonSchema]` line at the bottom.
+// inventory datatypes into their own APIs, rather than recreate structs.
 //
 // We did not add this functionality to `omicron_common` because, in the common
 // case, we want to prohibit users from accidentally exposing implementation

--- a/clients/oximeter-client/src/lib.rs
+++ b/clients/oximeter-client/src/lib.rs
@@ -6,7 +6,20 @@
 
 //! Interface for API requests to an Oximeter metric collection server
 
-omicron_common::generate_logging_api!("../../openapi/oximeter.json");
+progenitor::generate_api!(
+    spec = "../../openapi/oximeter.json",
+    inner_type = slog::Logger,
+    pre_hook = (|log: &slog::Logger, request: &reqwest::Request| {
+        slog::debug!(log, "client request";
+            "method" => %request.method(),
+            "uri" => %request.url(),
+            "body" => ?&request.body(),
+        );
+    }),
+    post_hook = (|log: &slog::Logger, result: &Result<_, _>| {
+        slog::debug!(log, "client response"; "result" => ?result);
+    }),
+);
 
 impl omicron_common::api::external::ClientError for types::Error {
     fn message(&self) -> String {

--- a/common/Cargo.toml
+++ b/common/Cargo.toml
@@ -46,7 +46,6 @@ thiserror.workspace = true
 tokio = { workspace = true, features = ["full"] }
 uuid.workspace = true
 parse-display.workspace = true
-progenitor.workspace = true
 progenitor-client.workspace = true
 omicron-workspace-hack.workspace = true
 once_cell.workspace = true

--- a/common/src/api/external/error.rs
+++ b/common/src/api/external/error.rs
@@ -540,25 +540,23 @@ pub trait ClientError: std::fmt::Debug {
 // external client, others may require, for example, retries with an alternate
 // service instance or additional interpretation to sanitize the output error.
 // This should be removed to avoid leaking data.
-impl<T: ClientError> From<progenitor::progenitor_client::Error<T>> for Error {
-    fn from(e: progenitor::progenitor_client::Error<T>) -> Self {
+impl<T: ClientError> From<progenitor_client::Error<T>> for Error {
+    fn from(e: progenitor_client::Error<T>) -> Self {
         match e {
             // For most error variants, we delegate to the display impl for the
             // Progenitor error type, but we pick apart an error response more
             // carefully.
-            progenitor::progenitor_client::Error::InvalidRequest(_)
-            | progenitor::progenitor_client::Error::CommunicationError(_)
-            | progenitor::progenitor_client::Error::InvalidResponsePayload(
-                ..,
-            )
-            | progenitor::progenitor_client::Error::UnexpectedResponse(_)
-            | progenitor::progenitor_client::Error::InvalidUpgrade(_)
-            | progenitor::progenitor_client::Error::ResponseBodyError(_)
-            | progenitor::progenitor_client::Error::PreHookError(_) => {
+            progenitor_client::Error::InvalidRequest(_)
+            | progenitor_client::Error::CommunicationError(_)
+            | progenitor_client::Error::InvalidResponsePayload(..)
+            | progenitor_client::Error::UnexpectedResponse(_)
+            | progenitor_client::Error::InvalidUpgrade(_)
+            | progenitor_client::Error::ResponseBodyError(_)
+            | progenitor_client::Error::PreHookError(_) => {
                 Error::internal_error(&e.to_string())
             }
             // This error represents an expected error from the remote service.
-            progenitor::progenitor_client::Error::ErrorResponse(rv) => {
+            progenitor_client::Error::ErrorResponse(rv) => {
                 let message = rv.message();
 
                 match rv.status() {

--- a/common/src/lib.rs
+++ b/common/src/lib.rs
@@ -34,26 +34,6 @@ pub mod zpool_name;
 
 pub use update::hex_schema;
 
-#[macro_export]
-macro_rules! generate_logging_api {
-    ($path:literal) => {
-        progenitor::generate_api!(
-            spec = $path,
-            inner_type = slog::Logger,
-            pre_hook = (|log: &slog::Logger, request: &reqwest::Request| {
-                slog::debug!(log, "client request";
-                    "method" => %request.method(),
-                    "uri" => %request.url(),
-                    "body" => ?&request.body(),
-                );
-            }),
-            post_hook = (|log: &slog::Logger, result: &Result<_, _>| {
-                slog::debug!(log, "client response"; "result" => ?result);
-            }),
-        );
-    };
-}
-
 /// A type that allows adding file and line numbers to log messages
 /// automatically. It should be instantiated at the root logger of each
 /// executable that desires this functionality, as in the following example.


### PR DESCRIPTION
This can simplify omicron-common at least a little by removing its direct dependency on progenitor (and all its sundry transitive dependencies).

Before:
```console
$ cargo tree -p omicron-common | wc -l
    1471
```
After:
```console
$ cargo tree -p omicron-common | wc -l
    1418
```

... it's not nothin'?