### PR TITLE
[sled-agent] Unbreak handling of Propolis error codes

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1721,6 +1721,19 @@ dependencies = [
 ]
 
 [[package]]
+name = "crucible-client-types"
+version = "0.1.0"
+source = "git+https://github.com/oxidecomputer/crucible?rev=2b88ab88461fb06aaf2aab11c5e381a3cad25eac#2b88ab88461fb06aaf2aab11c5e381a3cad25eac"
+dependencies = [
+ "base64 0.22.1",
+ "crucible-workspace-hack",
+ "schemars",
+ "serde",
+ "serde_json",
+ "uuid",
+]
+
+[[package]]
 name = "crucible-common"
 version = "0.0.1"
 source = "git+https://github.com/oxidecomputer/crucible?rev=2b88ab88461fb06aaf2aab11c5e381a3cad25eac#2b88ab88461fb06aaf2aab11c5e381a3cad25eac"
@@ -3983,7 +3996,7 @@ dependencies = [
  "httpdate",
  "itoa",
  "pin-project-lite",
- "socket2 0.5.7",
+ "socket2 0.4.10",
  "tokio",
  "tower-service",
  "tracing",
@@ -6881,6 +6894,7 @@ dependencies = [
  "pretty_assertions",
  "propolis-client",
  "propolis-mock-server",
+ "propolis_api_types",
  "rand",
  "rcgen",
  "reqwest 0.12.7",
@@ -8569,6 +8583,19 @@ dependencies = [
  "serde_derive",
  "thiserror",
  "toml 0.7.8",
+]
+
+[[package]]
+name = "propolis_api_types"
+version = "0.0.0"
+source = "git+https://github.com/oxidecomputer/propolis?rev=fae5334bcad5e864794332c6fed5e6bb9ec88831#fae5334bcad5e864794332c6fed5e6bb9ec88831"
+dependencies = [
+ "crucible-client-types",
+ "propolis_types",
+ "schemars",
+ "serde",
+ "thiserror",
+ "uuid",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -514,7 +514,7 @@ progenitor-client = "0.8.0"
 bhyve_api = { git = "https://github.com/oxidecomputer/propolis", rev = "fae5334bcad5e864794332c6fed5e6bb9ec88831" }
 # TODO(eliza): `propolis-client` should maybe re-export the needed types from
 # this crate?
-propolis-api-types = { git = "https://github.com/oxidecomputer/propolis", rev = "fae5334bcad5e864794332c6fed5e6bb9ec88831" }
+propolis_api_types = { git = "https://github.com/oxidecomputer/propolis", rev = "fae5334bcad5e864794332c6fed5e6bb9ec88831" }
 propolis-client = { git = "https://github.com/oxidecomputer/propolis", rev = "fae5334bcad5e864794332c6fed5e6bb9ec88831" }
 propolis-mock-server = { git = "https://github.com/oxidecomputer/propolis", rev = "fae5334bcad5e864794332c6fed5e6bb9ec88831" }
 proptest = "1.5.0"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -512,8 +512,6 @@ proc-macro2 = "1.0"
 progenitor = "0.8.0"
 progenitor-client = "0.8.0"
 bhyve_api = { git = "https://github.com/oxidecomputer/propolis", rev = "fae5334bcad5e864794332c6fed5e6bb9ec88831" }
-# TODO(eliza): `propolis-client` should maybe re-export the needed types from
-# this crate?
 propolis_api_types = { git = "https://github.com/oxidecomputer/propolis", rev = "fae5334bcad5e864794332c6fed5e6bb9ec88831" }
 propolis-client = { git = "https://github.com/oxidecomputer/propolis", rev = "fae5334bcad5e864794332c6fed5e6bb9ec88831" }
 propolis-mock-server = { git = "https://github.com/oxidecomputer/propolis", rev = "fae5334bcad5e864794332c6fed5e6bb9ec88831" }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -512,6 +512,9 @@ proc-macro2 = "1.0"
 progenitor = "0.8.0"
 progenitor-client = "0.8.0"
 bhyve_api = { git = "https://github.com/oxidecomputer/propolis", rev = "fae5334bcad5e864794332c6fed5e6bb9ec88831" }
+# TODO(eliza): `propolis-client` should maybe re-export the needed types from
+# this crate?
+propolis-api-types = { git = "https://github.com/oxidecomputer/propolis", rev = "fae5334bcad5e864794332c6fed5e6bb9ec88831" }
 propolis-client = { git = "https://github.com/oxidecomputer/propolis", rev = "fae5334bcad5e864794332c6fed5e6bb9ec88831" }
 propolis-mock-server = { git = "https://github.com/oxidecomputer/propolis", rev = "fae5334bcad5e864794332c6fed5e6bb9ec88831" }
 proptest = "1.5.0"

--- a/sled-agent/Cargo.toml
+++ b/sled-agent/Cargo.toml
@@ -59,7 +59,7 @@ oximeter.workspace = true
 oximeter-instruments.workspace = true
 oximeter-producer.workspace = true
 oxnet.workspace = true
-propolis-api-types.workspace = true
+propolis_api_types.workspace = true
 propolis-client.workspace = true
 propolis-mock-server.workspace = true # Only used by the simulated sled agent
 rand = { workspace = true, features = ["getrandom"] }

--- a/sled-agent/Cargo.toml
+++ b/sled-agent/Cargo.toml
@@ -59,6 +59,7 @@ oximeter.workspace = true
 oximeter-instruments.workspace = true
 oximeter-producer.workspace = true
 oxnet.workspace = true
+propolis-api-types.workspace = true
 propolis-client.workspace = true
 propolis-mock-server.workspace = true # Only used by the simulated sled agent
 rand = { workspace = true, features = ["getrandom"] }

--- a/sled-agent/src/instance.rs
+++ b/sled-agent/src/instance.rs
@@ -286,9 +286,7 @@ impl InstanceMonitorRunner {
             // It will decide the new state, provide that info to Nexus,
             // and possibly identify if we should terminate.
             let (tx, rx) = oneshot::channel();
-            self.tx_monitor
-                .send(InstanceMonitorRequest { update, tx })
-                .await?;
+            self.tx_monitor.send(InstanceMonitorRequest { update, tx }).await?;
 
             if let Reaction::Terminate = rx.await? {
                 return Ok(());
@@ -299,8 +297,7 @@ impl InstanceMonitorRunner {
     async fn monitor(
         &self,
         generation: u64,
-    ) -> Result<InstanceMonitorUpdate, BackoffError<PropolisClientError>>
-    {
+    ) -> Result<InstanceMonitorUpdate, BackoffError<PropolisClientError>> {
         // State monitoring always returns the most recent state/gen pair
         // known to Propolis.
         let result = self

--- a/sled-agent/src/instance.rs
+++ b/sled-agent/src/instance.rs
@@ -268,7 +268,7 @@ impl InstanceMonitorRunner {
                     warn!(
                         self.log,
                         "failed to poll Propolis state";
-                        "error" => %error
+                        "error" => %error,
                         "retry_in" => ?delay,
                     );
                 },

--- a/sled-agent/src/instance.rs
+++ b/sled-agent/src/instance.rs
@@ -131,7 +131,6 @@ pub enum Error {
     Terminating,
 }
 
-// Make this less gross.
 type PropolisClientError =
     propolis_client::Error<propolis_client::types::Error>;
 
@@ -1476,7 +1475,8 @@ impl InstanceRunner {
                         // We've transitioned to `Failed`, so just return the
                         // failed state normally. We return early here instead
                         // of falling through because we don't want to overwrite
-                        // that with the published VMM state determined above.
+                        // `self.state` with the published VMM state determined
+                        // above.
                         return Ok(self.state.sled_instance_state());
                     }
                     _ => {


### PR DESCRIPTION
At present, sled-agent's handling of the error codes used by Propolis to
indicate that it has crashed and been restarted is woefully incorrect.
In particular, there are two cases where such an error may be
encountered by a sled-agent:

1. When attempting to ask the VMM to change state (e.g. reboot or stop
   the instance)
2. When hitting Propolis' `instance-state-monitor` API endpoint to
   proactively check the VM's current state

Neither of these are handled correctly today,

In the first case, if a sled-agent operation on behalf of Nexus
encounters a client error from Propolis, it will forward that error code
to Nexus...but, _Nexus_ only moves instances to `Failed` in the face of
sled-agent's `410 NO_SUCH_INSTANCE`, and _not_ [if it sees the
`NoInstance` error code from Propolis][1], which means that the ghosts
left behind by crashed and restarted Propolii still won't be moved to
`Failed`. Agh. Furthermore, in that case, sled-agent itself will not
perform the necessary cleanup actions to deal with the now-defunct
Propolis zone (e.g. collecting a zone bundle and then destroying the
zone).

In the second case, where we hit the instance-state-monitor endpoint and
get back a `NoInstance` error, things are equally dire. The
`InstanceMonitorRunner` task, which is responsible for polling the state
monitor endpoint, will just bail out on receipt of any error from
Propolis:
https://github.com/oxidecomputer/omicron/blob/888f6a1eae91e5e7091f2e174dec7a8ee5bd04b5/sled-agent/src/instance.rs#L253-L289

We would _expect_ this to drop the send-side of the channel it uses to
communicate with the `InstanceRunner`, closing the channel, and hitting
this select, which would correctly mark the VMM as failed and do what we
want, despite eating the actual error message from propolis:
https://github.com/oxidecomputer/omicron/blob/888f6a1eae91e5e7091f2e174dec7a8ee5bd04b5/sled-agent/src/instance.rs#L388-L394

HOWEVER, as the comment points out, the `InstanceRunner` is _also_
holding its own clone of the channel sender, keeping us from ever
hitting that case:
https://github.com/oxidecomputer/omicron/blob/888f6a1eae91e5e7091f2e174dec7a8ee5bd04b5/sled-agent/src/instance.rs#L308-L309

AFAICT, this means we'll just totally give up on monitoring the instance
as soon as we hit any error here, which seems...quite bad. I *think*
that this actually means that when a Propolis process crashes
unexpectedly, we'll get an error when the TCP connection closes, bail
out, and then _never try hitting the instance monitor endpoint ever
again_[^1]. So, we won't notice that the Propolis is actually out to
lunch until we try to ask it to change state. **This Is Not Great!**

This commit fixes both of these cases, by making sled-agent actually
handle Propolis' error codes correctly. I've added a dependency on the
`propolis_api_types` crate, which is where the error code lives, and
some code in sled-agent to attempt to parse these codes when receiving
an error response from the Propolis client. Now, when we try to PUT a
new state to the instance, we'll look at the error code that comes back,
mark it as `Failed` if the error indicates that we should do so, and
publish the `Failed` VMM state to Nexus before tearing down the zone.
The `InstanceMonitorTask` now behaves similarly, and I've changed it to
retry all other errors with a backoff, rather than just bailing out
immediately on receipt fo the first error.

I've manually tested this on `london` as discussed here:
https://github.com/oxidecomputer/omicron/pull/6726#issuecomment-2384012654

Unfortunately, it's hard to do any kind of automated testing of this
with the current test situation, as none of this code is exercised by
the simulated sled-agent.

Fixes #3209
Fixes #3238

[^1]: Although I've not actually verified that this is what happens.

[1]:
    https://github.com/oxidecomputer/propolis/blob/516dabe473cecdc3baea1db98a80441968c144cf/crates/propolis-api-types/src/lib.rs#L434-L441