### PR TITLE
Temporarily disable region snapshot replacement

### DIFF
--- a/nexus/src/app/background/init.rs
+++ b/nexus/src/app/background/init.rs
@@ -778,7 +778,7 @@ impl BackgroundTasksInitializer {
                 "detect if region snapshots need replacement and begin the \
                 process",
             period: config.region_snapshot_replacement_start.period_secs,
-            // XXX temporarily disabled
+            // XXX temporarily disabled, see oxidecomputer/omicron#6353
             task_impl: Box::new(RegionSnapshotReplacementDetector::disabled(
                 datastore.clone(),
                 sagas.clone(),
@@ -795,7 +795,7 @@ impl BackgroundTasksInitializer {
             period: config
                 .region_snapshot_replacement_garbage_collection
                 .period_secs,
-            // XXX temporarily disabled
+            // XXX temporarily disabled, see oxidecomputer/omicron#6353
             task_impl: Box::new(
                 RegionSnapshotReplacementGarbageCollect::disabled(
                     datastore.clone(),
@@ -813,7 +813,7 @@ impl BackgroundTasksInitializer {
                 "detect what volumes were affected by a region snapshot \
                 replacement, and run the step saga for them",
             period: config.region_snapshot_replacement_step.period_secs,
-            // XXX temporarily disabled
+            // XXX temporarily disabled, see oxidecomputer/omicron#6353
             task_impl: Box::new(
                 RegionSnapshotReplacementFindAffected::disabled(
                     datastore.clone(),
@@ -831,7 +831,7 @@ impl BackgroundTasksInitializer {
                 "complete a region snapshot replacement if all the steps are \
                 done",
             period: config.region_snapshot_replacement_finish.period_secs,
-            // XXX temporarily disabled
+            // XXX temporarily disabled, see oxidecomputer/omicron#6353
             task_impl: Box::new(
                 RegionSnapshotReplacementFinishDetector::disabled(datastore),
             ),

--- a/nexus/src/app/background/init.rs
+++ b/nexus/src/app/background/init.rs
@@ -778,7 +778,8 @@ impl BackgroundTasksInitializer {
                 "detect if region snapshots need replacement and begin the \
                 process",
             period: config.region_snapshot_replacement_start.period_secs,
-            task_impl: Box::new(RegionSnapshotReplacementDetector::new(
+            // XXX temporarily disabled
+            task_impl: Box::new(RegionSnapshotReplacementDetector::disabled(
                 datastore.clone(),
                 sagas.clone(),
             )),
@@ -794,10 +795,13 @@ impl BackgroundTasksInitializer {
             period: config
                 .region_snapshot_replacement_garbage_collection
                 .period_secs,
-            task_impl: Box::new(RegionSnapshotReplacementGarbageCollect::new(
-                datastore.clone(),
-                sagas.clone(),
-            )),
+            // XXX temporarily disabled
+            task_impl: Box::new(
+                RegionSnapshotReplacementGarbageCollect::disabled(
+                    datastore.clone(),
+                    sagas.clone(),
+                ),
+            ),
             opctx: opctx.child(BTreeMap::new()),
             watchers: vec![],
             activator: task_region_snapshot_replacement_garbage_collection,
@@ -809,10 +813,13 @@ impl BackgroundTasksInitializer {
                 "detect what volumes were affected by a region snapshot \
                 replacement, and run the step saga for them",
             period: config.region_snapshot_replacement_step.period_secs,
-            task_impl: Box::new(RegionSnapshotReplacementFindAffected::new(
-                datastore.clone(),
-                sagas.clone(),
-            )),
+            // XXX temporarily disabled
+            task_impl: Box::new(
+                RegionSnapshotReplacementFindAffected::disabled(
+                    datastore.clone(),
+                    sagas.clone(),
+                ),
+            ),
             opctx: opctx.child(BTreeMap::new()),
             watchers: vec![],
             activator: task_region_snapshot_replacement_step,
@@ -824,9 +831,10 @@ impl BackgroundTasksInitializer {
                 "complete a region snapshot replacement if all the steps are \
                 done",
             period: config.region_snapshot_replacement_finish.period_secs,
-            task_impl: Box::new(RegionSnapshotReplacementFinishDetector::new(
-                datastore,
-            )),
+            // XXX temporarily disabled
+            task_impl: Box::new(
+                RegionSnapshotReplacementFinishDetector::disabled(datastore),
+            ),
             opctx: opctx.child(BTreeMap::new()),
             watchers: vec![],
             activator: task_region_snapshot_replacement_finish,

--- a/nexus/src/app/background/tasks/region_snapshot_replacement_finish.rs
+++ b/nexus/src/app/background/tasks/region_snapshot_replacement_finish.rs
@@ -19,11 +19,17 @@ use std::sync::Arc;
 
 pub struct RegionSnapshotReplacementFinishDetector {
     datastore: Arc<DataStore>,
+    disabled: bool,
 }
 
 impl RegionSnapshotReplacementFinishDetector {
+    #[allow(dead_code)]
     pub fn new(datastore: Arc<DataStore>) -> Self {
-        RegionSnapshotReplacementFinishDetector { datastore }
+        RegionSnapshotReplacementFinishDetector { datastore, disabled: false }
+    }
+
+    pub fn disabled(datastore: Arc<DataStore>) -> Self {
+        RegionSnapshotReplacementFinishDetector { datastore, disabled: true }
     }
 
     async fn transition_requests_to_done(
@@ -152,6 +158,10 @@ impl BackgroundTask for RegionSnapshotReplacementFinishDetector {
     ) -> BoxFuture<'a, serde_json::Value> {
         async move {
             let mut status = RegionSnapshotReplacementFinishStatus::default();
+
+            if self.disabled {
+                return json!(status);
+            }
 
             self.transition_requests_to_done(opctx, &mut status).await;
 

--- a/nexus/src/app/background/tasks/region_snapshot_replacement_garbage_collect.rs
+++ b/nexus/src/app/background/tasks/region_snapshot_replacement_garbage_collect.rs
@@ -42,7 +42,7 @@ impl RegionSnapshotReplacementGarbageCollect {
         RegionSnapshotReplacementGarbageCollect {
             datastore,
             sagas,
-            disabled: false,
+            disabled: true,
         }
     }
 

--- a/nexus/src/app/background/tasks/region_snapshot_replacement_garbage_collect.rs
+++ b/nexus/src/app/background/tasks/region_snapshot_replacement_garbage_collect.rs
@@ -22,11 +22,28 @@ use std::sync::Arc;
 pub struct RegionSnapshotReplacementGarbageCollect {
     datastore: Arc<DataStore>,
     sagas: Arc<dyn StartSaga>,
+    disabled: bool,
 }
 
 impl RegionSnapshotReplacementGarbageCollect {
+    #[allow(dead_code)]
     pub fn new(datastore: Arc<DataStore>, sagas: Arc<dyn StartSaga>) -> Self {
-        RegionSnapshotReplacementGarbageCollect { datastore, sagas }
+        RegionSnapshotReplacementGarbageCollect {
+            datastore,
+            sagas,
+            disabled: false,
+        }
+    }
+
+    pub fn disabled(
+        datastore: Arc<DataStore>,
+        sagas: Arc<dyn StartSaga>,
+    ) -> Self {
+        RegionSnapshotReplacementGarbageCollect {
+            datastore,
+            sagas,
+            disabled: false,
+        }
     }
 
     async fn send_garbage_collect_request(
@@ -134,6 +151,10 @@ impl BackgroundTask for RegionSnapshotReplacementGarbageCollect {
         async move {
             let mut status =
                 RegionSnapshotReplacementGarbageCollectStatus::default();
+
+            if self.disabled {
+                return json!(status);
+            }
 
             self.clean_up_region_snapshot_replacement_volumes(
                 opctx,

--- a/nexus/src/app/background/tasks/region_snapshot_replacement_start.rs
+++ b/nexus/src/app/background/tasks/region_snapshot_replacement_start.rs
@@ -29,11 +29,20 @@ use std::sync::Arc;
 pub struct RegionSnapshotReplacementDetector {
     datastore: Arc<DataStore>,
     sagas: Arc<dyn StartSaga>,
+    disabled: bool,
 }
 
 impl RegionSnapshotReplacementDetector {
+    #[allow(dead_code)]
     pub fn new(datastore: Arc<DataStore>, sagas: Arc<dyn StartSaga>) -> Self {
-        RegionSnapshotReplacementDetector { datastore, sagas }
+        RegionSnapshotReplacementDetector { datastore, sagas, disabled: false }
+    }
+
+    pub fn disabled(
+        datastore: Arc<DataStore>,
+        sagas: Arc<dyn StartSaga>,
+    ) -> Self {
+        RegionSnapshotReplacementDetector { datastore, sagas, disabled: true }
     }
 
     async fn send_start_request(
@@ -236,6 +245,10 @@ impl BackgroundTask for RegionSnapshotReplacementDetector {
     ) -> BoxFuture<'a, serde_json::Value> {
         async {
             let mut status = RegionSnapshotReplacementStartStatus::default();
+
+            if self.disabled {
+                return json!(status);
+            }
 
             self.create_requests_for_region_snapshots_on_expunged_disks(
                 opctx,


### PR DESCRIPTION
Until read-only region reference counting is implemented, region snapshot replacement should be disabled - it is currently the only thing that creates read-only regions.