### PR TITLE
[reconfigurator] preserve sled state in example systems

### DIFF
--- a/dev-tools/reconfigurator-cli/src/main.rs
+++ b/dev-tools/reconfigurator-cli/src/main.rs
@@ -1202,6 +1202,7 @@ fn cmd_load(
         let result = sim.system.sled_full(
             sled_id,
             sled_details.policy,
+            sled_details.state,
             sled_details.resources.clone(),
             inventory_sp,
             inventory_sled_agent,


### PR DESCRIPTION
While working on tests for decommissioned sled cleanup, I noticed that we
weren't preserving sled state in the `SystemDescription` used for example
systems.

There's another small change in here to store a `SledResources` in here rather
than its disaggregated form. This change makes some upcoming tests easier to
write.
