### PR TITLE
Enable ClickHouse query logs

### DIFF
--- a/clickhouse-admin/types/src/config.rs
+++ b/clickhouse-admin/types/src/config.rs
@@ -137,6 +137,13 @@ impl ReplicaConfig {
         </default>
     </quotas>
 
+    <query_log>
+        <database>system</database>
+        <table>query_log</table>
+        <engine>Engine = MergeTree ORDER BY event_time TTL event_date + INTERVAL 7 DAY</engine>
+        <flush_interval_milliseconds>10000</flush_interval_milliseconds>
+    </query_log>
+
     <tmp_path>{temp_files_path}</tmp_path>
     <user_files_path>{user_files_path}</user_files_path>
     <default_profile>default</default_profile>

--- a/package-manifest.toml
+++ b/package-manifest.toml
@@ -178,6 +178,7 @@ source.paths = [
   { from = "out/clickhouse", to = "/opt/oxide/clickhouse" },
   { from = "smf/clickhouse/manifest.xml", to = "/var/svc/manifest/site/clickhouse/manifest.xml" },
   { from = "smf/clickhouse/method_script.sh", to = "/opt/oxide/lib/svc/manifest/clickhouse.sh" },
+  { from = "smf/clickhouse/config.xml", to = "/opt/oxide/clickhouse/config.xml" },
 ]
 output.type = "zone"
 output.intermediate_only = true

--- a/smf/clickhouse/config.xml
+++ b/smf/clickhouse/config.xml
@@ -1,0 +1,39 @@
+<clickhouse>
+    <logger>
+        <level>trace</level>
+        <console>true</console>
+    </logger>
+
+    <query_log>
+        <database>system</database>
+        <table>query_log</table>
+        <engine>Engine = MergeTree ORDER BY event_time TTL event_date + INTERVAL 7 DAY</engine>
+        <flush_interval_milliseconds>10000</flush_interval_milliseconds>
+    </query_log>
+
+    <mlock_executable>true</mlock_executable>
+
+    <tcp_port>9000</tcp_port>
+
+    <users>
+        <default>
+            <password/>
+
+            <networks>
+                <ip>::/0</ip>
+            </networks>
+
+            <profile>default</profile>
+            <quota>default</quota>
+            <access_management>1</access_management>
+        </default>
+    </users>
+
+    <profiles>
+        <default/>
+    </profiles>
+
+    <quotas>
+        <default/>
+    </quotas>
+</clickhouse>

--- a/smf/clickhouse/method_script.sh
+++ b/smf/clickhouse/method_script.sh
@@ -13,6 +13,7 @@ DATASTORE="$(svcprop -c -p config/store "${SMF_FMRI}")"
 args=(
 "--log-file" "/var/tmp/clickhouse-server.log"
 "--errorlog-file" "/var/tmp/clickhouse-server.errlog"
+"--config-file" "/opt/oxide/clickhouse/config.xml"
 "--"
 "--path" "${DATASTORE}"
 "--listen_host" "$LISTEN_ADDR"


### PR DESCRIPTION
- Add config.xml for single-node ClickHouse that enables query log table
- Add stanza to generated replica configs in `clickhouse-admin` that also enables the log table
- Fixes #6734