### PR TITLE
Add doc comments for InstanceCreate

### DIFF
--- a/nexus/types/src/external_api/params.rs
+++ b/nexus/types/src/external_api/params.rs
@@ -998,8 +998,11 @@ pub enum ExternalIpDetach {
 pub struct InstanceCreate {
     #[serde(flatten)]
     pub identity: IdentityMetadataCreateParams,
+    /// The number of vCPUs to be allocated to the instance.
     pub ncpus: InstanceCpuCount,
+    /// The amount of RAM (in bytes) to be allocated to the instance.
     pub memory: ByteCount,
+    /// The hostname to be assigned to the instance.
     pub hostname: Hostname,
 
     /// User data for instance initialization systems (such as cloud-init).
@@ -1406,12 +1409,12 @@ pub enum DiskSource {
 /// Create-time parameters for a `Disk`
 #[derive(Clone, Debug, Deserialize, Serialize, JsonSchema)]
 pub struct DiskCreate {
-    /// common identifying metadata
+    /// The common identifying metadata for the disk.
     #[serde(flatten)]
     pub identity: IdentityMetadataCreateParams,
-    /// initial source for this disk
+    /// The initial source for this disk.
     pub disk_source: DiskSource,
-    /// total size of the Disk in bytes
+    /// The total size of the Disk (in bytes).
     pub size: ByteCount,
 }
 

--- a/nexus/types/src/external_api/params.rs
+++ b/nexus/types/src/external_api/params.rs
@@ -998,11 +998,11 @@ pub enum ExternalIpDetach {
 pub struct InstanceCreate {
     #[serde(flatten)]
     pub identity: IdentityMetadataCreateParams,
-    /// The number of vCPUs to be allocated to the instance.
+    /// The number of vCPUs to be allocated to the instance
     pub ncpus: InstanceCpuCount,
-    /// The amount of RAM (in bytes) to be allocated to the instance.
+    /// The amount of RAM (in bytes) to be allocated to the instance
     pub memory: ByteCount,
-    /// The hostname to be assigned to the instance.
+    /// The hostname to be assigned to the instance
     pub hostname: Hostname,
 
     /// User data for instance initialization systems (such as cloud-init).
@@ -1409,12 +1409,12 @@ pub enum DiskSource {
 /// Create-time parameters for a `Disk`
 #[derive(Clone, Debug, Deserialize, Serialize, JsonSchema)]
 pub struct DiskCreate {
-    /// The common identifying metadata for the disk.
+    /// The common identifying metadata for the disk
     #[serde(flatten)]
     pub identity: IdentityMetadataCreateParams,
-    /// The initial source for this disk.
+    /// The initial source for this disk
     pub disk_source: DiskSource,
-    /// The total size of the Disk (in bytes).
+    /// The total size of the Disk (in bytes)
     pub size: ByteCount,
 }
 

--- a/openapi/nexus.json
+++ b/openapi/nexus.json
@@ -12718,7 +12718,7 @@
             "type": "string"
           },
           "disk_source": {
-            "description": "initial source for this disk",
+            "description": "The initial source for this disk.",
             "allOf": [
               {
                 "$ref": "#/components/schemas/DiskSource"
@@ -12729,7 +12729,7 @@
             "$ref": "#/components/schemas/Name"
           },
           "size": {
-            "description": "total size of the Disk in bytes",
+            "description": "The total size of the Disk (in bytes).",
             "allOf": [
               {
                 "$ref": "#/components/schemas/ByteCount"
@@ -15312,16 +15312,31 @@
             }
           },
           "hostname": {
-            "$ref": "#/components/schemas/Hostname"
+            "description": "The hostname to be assigned to the instance.",
+            "allOf": [
+              {
+                "$ref": "#/components/schemas/Hostname"
+              }
+            ]
           },
           "memory": {
-            "$ref": "#/components/schemas/ByteCount"
+            "description": "The amount of RAM (in bytes) to be allocated to the instance.",
+            "allOf": [
+              {
+                "$ref": "#/components/schemas/ByteCount"
+              }
+            ]
           },
           "name": {
             "$ref": "#/components/schemas/Name"
           },
           "ncpus": {
-            "$ref": "#/components/schemas/InstanceCpuCount"
+            "description": "The number of vCPUs to be allocated to the instance.",
+            "allOf": [
+              {
+                "$ref": "#/components/schemas/InstanceCpuCount"
+              }
+            ]
           },
           "network_interfaces": {
             "description": "The network interfaces to be created for this instance.",
@@ -15373,7 +15388,7 @@
                 "type": "string"
               },
               "disk_source": {
-                "description": "initial source for this disk",
+                "description": "The initial source for this disk.",
                 "allOf": [
                   {
                     "$ref": "#/components/schemas/DiskSource"
@@ -15384,7 +15399,7 @@
                 "$ref": "#/components/schemas/Name"
               },
               "size": {
-                "description": "total size of the Disk in bytes",
+                "description": "The total size of the Disk (in bytes).",
                 "allOf": [
                   {
                     "$ref": "#/components/schemas/ByteCount"

--- a/openapi/nexus.json
+++ b/openapi/nexus.json
@@ -12718,7 +12718,7 @@
             "type": "string"
           },
           "disk_source": {
-            "description": "The initial source for this disk.",
+            "description": "The initial source for this disk",
             "allOf": [
               {
                 "$ref": "#/components/schemas/DiskSource"
@@ -12729,7 +12729,7 @@
             "$ref": "#/components/schemas/Name"
           },
           "size": {
-            "description": "The total size of the Disk (in bytes).",
+            "description": "The total size of the Disk (in bytes)",
             "allOf": [
               {
                 "$ref": "#/components/schemas/ByteCount"
@@ -15312,7 +15312,7 @@
             }
           },
           "hostname": {
-            "description": "The hostname to be assigned to the instance.",
+            "description": "The hostname to be assigned to the instance",
             "allOf": [
               {
                 "$ref": "#/components/schemas/Hostname"
@@ -15320,7 +15320,7 @@
             ]
           },
           "memory": {
-            "description": "The amount of RAM (in bytes) to be allocated to the instance.",
+            "description": "The amount of RAM (in bytes) to be allocated to the instance",
             "allOf": [
               {
                 "$ref": "#/components/schemas/ByteCount"
@@ -15331,7 +15331,7 @@
             "$ref": "#/components/schemas/Name"
           },
           "ncpus": {
-            "description": "The number of vCPUs to be allocated to the instance.",
+            "description": "The number of vCPUs to be allocated to the instance",
             "allOf": [
               {
                 "$ref": "#/components/schemas/InstanceCpuCount"
@@ -15388,7 +15388,7 @@
                 "type": "string"
               },
               "disk_source": {
-                "description": "The initial source for this disk.",
+                "description": "The initial source for this disk",
                 "allOf": [
                   {
                     "$ref": "#/components/schemas/DiskSource"
@@ -15399,7 +15399,7 @@
                 "$ref": "#/components/schemas/Name"
               },
               "size": {
-                "description": "The total size of the Disk (in bytes).",
+                "description": "The total size of the Disk (in bytes)",
                 "allOf": [
                   {
                     "$ref": "#/components/schemas/ByteCount"


### PR DESCRIPTION
Add doc comments for the `InstanceCreate` external API for consumption downstream. While we're at it, fix up the comments on `DiskCreate` as well.

Related to https://github.com/oxidecomputer/oxide.rs/issues/854