### PR TITLE
[nexus] allow reconfiguring auto-restart policies

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -663,7 +663,7 @@ dependencies = [
 [[package]]
 name = "bhyve_api"
 version = "0.0.0"
-source = "git+https://github.com/oxidecomputer/propolis?rev=11371b0f3743f8df5b047dc0edc2699f4bdf3927"
+source = "git+https://github.com/oxidecomputer/propolis?rev=11371b0f3743f8df5b047dc0edc2699f4bdf3927#11371b0f3743f8df5b047dc0edc2699f4bdf3927"
 dependencies = [
  "bhyve_api_sys",
  "libc",
@@ -673,7 +673,7 @@ dependencies = [
 [[package]]
 name = "bhyve_api_sys"
 version = "0.0.0"
-source = "git+https://github.com/oxidecomputer/propolis?rev=11371b0f3743f8df5b047dc0edc2699f4bdf3927"
+source = "git+https://github.com/oxidecomputer/propolis?rev=11371b0f3743f8df5b047dc0edc2699f4bdf3927#11371b0f3743f8df5b047dc0edc2699f4bdf3927"
 dependencies = [
  "libc",
  "strum",

--- a/common/src/api/external/mod.rs
+++ b/common/src/api/external/mod.rs
@@ -1247,7 +1247,9 @@ pub struct InstanceAutoRestartStatus {
 
 /// A policy determining when an instance should be automatically restarted by
 /// the control plane.
-#[derive(Copy, Clone, Debug, Deserialize, Serialize, JsonSchema)]
+#[derive(
+    Copy, Clone, Debug, Deserialize, Serialize, JsonSchema, Eq, PartialEq,
+)]
 #[serde(rename_all = "snake_case")]
 pub enum InstanceAutoRestartPolicy {
     /// The instance should not be automatically restarted by the control plane

--- a/common/src/api/external/mod.rs
+++ b/common/src/api/external/mod.rs
@@ -1215,6 +1215,20 @@ pub struct InstanceAutoRestartStatus {
     #[serde(rename = "auto_restart_enabled")]
     pub enabled: bool,
 
+    /// The auto-restart policy configured for this instance, or `None` if no
+    /// explicit policy is configured.
+    ///
+    /// If this is not present, then this instance uses the default auto-restart
+    /// policy, which may or may not allow it to be restarted. The
+    /// `auto_restart_enabled` field indicates whether the instance will be
+    /// automatically restarted.
+    //
+    // Rename this field, as the struct is `#[serde(flatten)]`ed into the
+    // `Instance` type, and we would like the field to be prefixed with
+    // `auto_restart`.
+    #[serde(rename = "auto_restart_policy")]
+    pub policy: Option<InstanceAutoRestartPolicy>,
+
     /// The time at which the auto-restart cooldown period for this instance
     /// completes, permitting it to be automatically restarted again. If the
     /// instance enters the `Failed` state, it will not be restarted until after

--- a/nexus/db-model/src/instance.rs
+++ b/nexus/db-model/src/instance.rs
@@ -537,4 +537,9 @@ mod optional_time_delta {
 pub struct InstanceUpdate {
     #[diesel(column_name = boot_disk_id)]
     pub boot_disk_id: Option<Uuid>,
+
+    /// The auto-restart policy for this instance. If this is `None`, it will
+    /// set the instance's auto-restart policy to `NULL`.
+    #[diesel(column_name = auto_restart_policy)]
+    pub auto_restart_policy: Option<InstanceAutoRestartPolicy>,
 }

--- a/nexus/db-queries/src/db/datastore/instance.rs
+++ b/nexus/db-queries/src/db/datastore/instance.rs
@@ -1177,8 +1177,6 @@ impl DataStore {
         authz_instance: &authz::Instance,
         boot_disk_id: Option<Uuid>,
     ) -> Result<(), diesel::result::Error> {
-        use crate::db::model::InstanceState;
-
         use db::schema::disk::dsl as disk_dsl;
         use db::schema::instance::dsl as instance_dsl;
 

--- a/nexus/db-queries/src/db/datastore/instance.rs
+++ b/nexus/db-queries/src/db/datastore/instance.rs
@@ -1038,14 +1038,15 @@ impl DataStore {
             .transaction_retry_wrapper("reconfigure_instance")
             .transaction(&conn, |conn| {
                 let err = err.clone();
-                let update = update.clone();
+                let InstanceUpdate { boot_disk_id, auto_restart_policy } =
+                    update.clone();
                 async move {
                     // Set the boot disk.
                     self.instance_set_boot_disk_on_conn(
                         &conn,
                         &err,
                         authz_instance,
-                        update.boot_disk_id,
+                        boot_disk_id,
                     )
                     .await?;
 
@@ -1054,7 +1055,7 @@ impl DataStore {
                         .filter(instance_dsl::id.eq(authz_instance.id()))
                         .set(
                             instance_dsl::auto_restart_policy
-                                .eq(update.auto_restart_policy),
+                                .eq(auto_restart_policy),
                         )
                         .execute_async(&conn)
                         .await?;

--- a/nexus/src/app/instance.rs
+++ b/nexus/src/app/instance.rs
@@ -330,7 +330,9 @@ impl super::Nexus {
             None => None,
         };
 
-        let update = InstanceUpdate { boot_disk_id };
+        let auto_restart_policy = params.auto_restart_policy.map(Into::into);
+
+        let update = InstanceUpdate { boot_disk_id, auto_restart_policy };
         self.datastore()
             .instance_reconfigure(opctx, &authz_instance, update)
             .await

--- a/nexus/tests/integration_tests/endpoints.rs
+++ b/nexus/tests/integration_tests/endpoints.rs
@@ -434,7 +434,10 @@ pub static DEMO_INSTANCE_CREATE: Lazy<params::InstanceCreate> =
         auto_restart_policy: Default::default(),
     });
 pub static DEMO_INSTANCE_UPDATE: Lazy<params::InstanceUpdate> =
-    Lazy::new(|| params::InstanceUpdate { boot_disk: None });
+    Lazy::new(|| params::InstanceUpdate {
+        boot_disk: None,
+        auto_restart_policy: None,
+    });
 
 // The instance needs a network interface, too.
 pub static DEMO_INSTANCE_NIC_NAME: Lazy<Name> =

--- a/nexus/tests/integration_tests/instances.rs
+++ b/nexus/tests/integration_tests/instances.rs
@@ -4158,21 +4158,12 @@ async fn test_cannot_detach_boot_disk(cptestctx: &ControlPlaneTestContext) {
 
     // Change the instance's boot disk.
     let url_instance_update = format!("/v1/instances/{}", instance.identity.id);
-
-    let builder =
-        RequestBuilder::new(client, http::Method::PUT, &url_instance_update)
-            .body(Some(&params::InstanceUpdate {
-                boot_disk: None,
-                auto_restart_policy: None,
-            }))
-            .expect_status(Some(http::StatusCode::OK));
-    let response = NexusRequest::new(builder)
-        .authn_as(AuthnMode::PrivilegedUser)
-        .execute()
-        .await
-        .expect("can attempt to reconfigure the instance");
-
-    let instance = response.parsed_body::<Instance>().unwrap();
+    let instance = expect_instance_reconfigure_ok(
+        &client,
+        &instance.identity.id,
+        params::InstanceUpdate { boot_disk: None, auto_restart_policy: None },
+    )
+    .await;
     assert_eq!(instance.boot_disk_id, None);
 
     // Now try to detach `disks[0]` again. This should succeed.

--- a/nexus/tests/integration_tests/instances.rs
+++ b/nexus/tests/integration_tests/instances.rs
@@ -4339,7 +4339,7 @@ async fn test_auto_restart_policy_can_be_changed(
         external_ips: vec![],
         boot_disk: None,
         disks: Vec::new(),
-        start: false,
+        start: true,
         // Start out with None
         auto_restart_policy: None,
     };

--- a/nexus/tests/integration_tests/instances.rs
+++ b/nexus/tests/integration_tests/instances.rs
@@ -4157,7 +4157,6 @@ async fn test_cannot_detach_boot_disk(cptestctx: &ControlPlaneTestContext) {
     assert_eq!(err.message, "boot disk cannot be detached");
 
     // Change the instance's boot disk.
-    let url_instance_update = format!("/v1/instances/{}", instance.identity.id);
     let instance = expect_instance_reconfigure_ok(
         &client,
         &instance.identity.id,

--- a/nexus/tests/integration_tests/instances.rs
+++ b/nexus/tests/integration_tests/instances.rs
@@ -4161,7 +4161,10 @@ async fn test_cannot_detach_boot_disk(cptestctx: &ControlPlaneTestContext) {
 
     let builder =
         RequestBuilder::new(client, http::Method::PUT, &url_instance_update)
-            .body(Some(&params::InstanceUpdate { boot_disk: None }))
+            .body(Some(&params::InstanceUpdate {
+                boot_disk: None,
+                auto_restart_policy: None,
+            }))
             .expect_status(Some(http::StatusCode::OK));
     let response = NexusRequest::new(builder)
         .authn_as(AuthnMode::PrivilegedUser)
@@ -4238,7 +4241,10 @@ async fn test_updating_running_instance_is_conflict(
 
     let builder =
         RequestBuilder::new(client, http::Method::PUT, &url_instance_update)
-            .body(Some(&params::InstanceUpdate { boot_disk: None }))
+            .body(Some(&params::InstanceUpdate {
+                boot_disk: None,
+                auto_restart_policy: None,
+            }))
             .expect_status(Some(http::StatusCode::CONFLICT));
 
     let response = NexusRequest::new(builder)
@@ -4264,7 +4270,10 @@ async fn test_updating_missing_instance_is_not_found(
 
     let builder =
         RequestBuilder::new(client, http::Method::PUT, &url_instance_update)
-            .body(Some(&params::InstanceUpdate { boot_disk: None }))
+            .body(Some(&params::InstanceUpdate {
+                boot_disk: None,
+                auto_restart_policy: None,
+            }))
             .expect_status(Some(http::StatusCode::NOT_FOUND));
 
     let response = NexusRequest::new(builder)
@@ -4353,6 +4362,7 @@ async fn test_boot_disk_can_be_changed(cptestctx: &ControlPlaneTestContext) {
         RequestBuilder::new(client, http::Method::PUT, &url_instance_update)
             .body(Some(&params::InstanceUpdate {
                 boot_disk: Some(disks[1].identity.id.into()),
+                auto_restart_policy: None,
             }))
             .expect_status(Some(http::StatusCode::OK));
 
@@ -4424,6 +4434,7 @@ async fn test_boot_disk_must_be_attached(cptestctx: &ControlPlaneTestContext) {
         RequestBuilder::new(client, http::Method::PUT, &url_instance_update)
             .body(Some(&params::InstanceUpdate {
                 boot_disk: Some(disks[0].identity.id.into()),
+                auto_restart_policy: None,
             }))
             .expect_status(Some(http::StatusCode::CONFLICT));
     let response = NexusRequest::new(builder)
@@ -4459,6 +4470,7 @@ async fn test_boot_disk_must_be_attached(cptestctx: &ControlPlaneTestContext) {
         RequestBuilder::new(client, http::Method::PUT, &url_instance_update)
             .body(Some(&params::InstanceUpdate {
                 boot_disk: Some(disks[0].identity.id.into()),
+                auto_restart_policy: None,
             }))
             .expect_status(Some(http::StatusCode::OK));
     let response = NexusRequest::new(builder)

--- a/nexus/types/src/external_api/params.rs
+++ b/nexus/types/src/external_api/params.rs
@@ -1079,6 +1079,11 @@ pub struct InstanceUpdate {
     ///
     /// If not provided, unset the instance's boot disk.
     pub boot_disk: Option<NameOrId>,
+
+    /// The auto-restart policy for this instance.
+    ///
+    /// If not provided, unset the instance's auto-restart policy.
+    pub auto_restart_policy: Option<InstanceAutoRestartPolicy>,
 }
 
 #[inline]

--- a/openapi/nexus-internal.json
+++ b/openapi/nexus-internal.json
@@ -3382,6 +3382,15 @@
             "description": "`true` if this instance's auto-restart policy will permit the control plane to automatically restart it if it enters the `Failed` state.",
             "type": "boolean"
           },
+          "auto_restart_policy": {
+            "nullable": true,
+            "description": "The auto-restart policy configured for this instance, or `None` if no explicit policy is configured.\n\nIf this is not present, then this instance uses the default auto-restart policy, which may or may not allow it to be restarted. The `auto_restart_enabled` field indicates whether the instance will be automatically restarted.",
+            "allOf": [
+              {
+                "$ref": "#/components/schemas/InstanceAutoRestartPolicy"
+              }
+            ]
+          },
           "boot_disk_id": {
             "nullable": true,
             "description": "the ID of the disk used to boot this Instance, if a specific one is assigned.",
@@ -3467,6 +3476,25 @@
           "time_created",
           "time_modified",
           "time_run_state_updated"
+        ]
+      },
+      "InstanceAutoRestartPolicy": {
+        "description": "A policy determining when an instance should be automatically restarted by the control plane.",
+        "oneOf": [
+          {
+            "description": "The instance should not be automatically restarted by the control plane if it fails.",
+            "type": "string",
+            "enum": [
+              "never"
+            ]
+          },
+          {
+            "description": "If this instance is running and unexpectedly fails (e.g. due to a host software crash or unexpected host reboot), the control plane will make a best-effort attempt to restart it. The control plane may choose not to restart the instance to preserve the overall availability of the system.",
+            "type": "string",
+            "enum": [
+              "best_effort"
+            ]
+          }
         ]
       },
       "InstanceCpuCount": {

--- a/openapi/nexus.json
+++ b/openapi/nexus.json
@@ -15156,6 +15156,15 @@
             "description": "`true` if this instance's auto-restart policy will permit the control plane to automatically restart it if it enters the `Failed` state.",
             "type": "boolean"
           },
+          "auto_restart_policy": {
+            "nullable": true,
+            "description": "The auto-restart policy configured for this instance, or `None` if no explicit policy is configured.\n\nIf this is not present, then this instance uses the default auto-restart policy, which may or may not allow it to be restarted. The `auto_restart_enabled` field indicates whether the instance will be automatically restarted.",
+            "allOf": [
+              {
+                "$ref": "#/components/schemas/InstanceAutoRestartPolicy"
+              }
+            ]
+          },
           "boot_disk_id": {
             "nullable": true,
             "description": "the ID of the disk used to boot this Instance, if a specific one is assigned.",
@@ -15807,6 +15816,15 @@
         "description": "Parameters of an `Instance` that can be reconfigured after creation.",
         "type": "object",
         "properties": {
+          "auto_restart_policy": {
+            "nullable": true,
+            "description": "The auto-restart policy for this instance.\n\nIf not provided, unset the instance's auto-restart policy.",
+            "allOf": [
+              {
+                "$ref": "#/components/schemas/InstanceAutoRestartPolicy"
+              }
+            ]
+          },
           "boot_disk": {
             "nullable": true,
             "description": "Name or ID of the disk the instance should be instructed to boot from.\n\nIf not provided, unset the instance's boot disk.",


### PR DESCRIPTION
This commit extends the `instance-reconfigure` API endpoint added in
#6585 to also allow setting instance auto-restart policies (as added in
#6503).

I've also added the actual auto-restart policy to the external API
instance view, along with the boolean `auto_restart_enabled` added in
#6503. This way, it's possible to change just the boot disk by providing
the current auto-restart policy in an instance POST.