### PR TITLE
[reconfigurator] Add support for oximeter

### DIFF
--- a/common/src/policy.rs
+++ b/common/src/policy.rs
@@ -13,6 +13,12 @@ pub const BOUNDARY_NTP_REDUNDANCY: usize = 2;
 /// Reconfigurator (to know whether to add new Nexus zones)
 pub const NEXUS_REDUNDANCY: usize = 3;
 
+// The amount of redundancy for Oximeter services.
+///
+/// This is used by both RSS (to distribute the initial set of services) and the
+/// Reconfigurator (to know whether to add new Oximeter zones)
+pub const OXIMETER_REDUNDANCY: usize = 1;
+
 /// The amount of redundancy for CockroachDb services.
 ///
 /// This is used by both RSS (to distribute the initial set of services) and the

--- a/nexus/db-queries/src/db/datastore/oximeter.rs
+++ b/nexus/db-queries/src/db/datastore/oximeter.rs
@@ -168,7 +168,13 @@ impl DataStore {
         }
     }
 
-    /// Create a record for a new producer endpoint
+    /// Create or update a record for a new producer endpoint
+    ///
+    /// If this producer record is being updated, this method does _not_ update
+    /// the assigned Oximeter to match `producer.oximeter_id` if it differs from
+    /// the existing record in the database. We currently only expect a single
+    /// Oximeter instance to be running at a time:
+    /// https://github.com/oxidecomputer/omicron/issues/323
     pub async fn producer_endpoint_create(
         &self,
         opctx: &OpContext,

--- a/nexus/db-queries/src/db/datastore/oximeter.rs
+++ b/nexus/db-queries/src/db/datastore/oximeter.rs
@@ -174,7 +174,7 @@ impl DataStore {
     /// the assigned Oximeter to match `producer.oximeter_id` if it differs from
     /// the existing record in the database. We currently only expect a single
     /// Oximeter instance to be running at a time:
-    /// https://github.com/oxidecomputer/omicron/issues/323
+    /// <https://github.com/oxidecomputer/omicron/issues/323>
     pub async fn producer_endpoint_create(
         &self,
         opctx: &OpContext,

--- a/nexus/reconfigurator/execution/src/dns.rs
+++ b/nexus/reconfigurator/execution/src/dns.rs
@@ -541,6 +541,7 @@ mod test {
     use omicron_common::policy::COCKROACHDB_REDUNDANCY;
     use omicron_common::policy::INTERNAL_DNS_REDUNDANCY;
     use omicron_common::policy::NEXUS_REDUNDANCY;
+    use omicron_common::policy::OXIMETER_REDUNDANCY;
     use omicron_common::zpool_name::ZpoolName;
     use omicron_test_utils::dev::test_setup_log;
     use omicron_uuid_kinds::ExternalIpUuid;
@@ -1548,6 +1549,7 @@ mod test {
                 target_boundary_ntp_zone_count: BOUNDARY_NTP_REDUNDANCY,
                 target_nexus_zone_count: NEXUS_REDUNDANCY,
                 target_internal_dns_zone_count: INTERNAL_DNS_REDUNDANCY,
+                target_oximeter_zone_count: OXIMETER_REDUNDANCY,
                 target_cockroachdb_zone_count: COCKROACHDB_REDUNDANCY,
                 target_cockroachdb_cluster_version:
                     CockroachDbClusterVersion::POLICY,

--- a/nexus/reconfigurator/execution/src/omicron_zones.rs
+++ b/nexus/reconfigurator/execution/src/omicron_zones.rs
@@ -189,7 +189,7 @@ async fn oximeter_cleanup(
 ) -> anyhow::Result<()> {
     // Record that this Oximeter instance is gone.
     datastore
-        .oximeter_delete(opctx, zone_id.into_untyped_uuid())
+        .oximeter_expunge(opctx, zone_id.into_untyped_uuid())
         .await
         .context("failed to mark Oximeter instance deleted")?;
 

--- a/nexus/reconfigurator/planning/src/planner.rs
+++ b/nexus/reconfigurator/planning/src/planner.rs
@@ -359,6 +359,7 @@ impl<'a> Planner<'a> {
             DiscretionaryOmicronZone::InternalDns,
             DiscretionaryOmicronZone::ExternalDns,
             DiscretionaryOmicronZone::Nexus,
+            DiscretionaryOmicronZone::Oximeter,
         ] {
             let num_zones_to_add = self.num_additional_zones_needed(zone_kind);
             if num_zones_to_add == 0 {
@@ -452,6 +453,9 @@ impl<'a> Planner<'a> {
             }
             DiscretionaryOmicronZone::Nexus => {
                 self.input.target_nexus_zone_count()
+            }
+            DiscretionaryOmicronZone::Oximeter => {
+                self.input.target_oximeter_zone_count()
             }
         };
 
@@ -558,6 +562,12 @@ impl<'a> Planner<'a> {
                 }
                 DiscretionaryOmicronZone::Nexus => {
                     self.blueprint.sled_ensure_zone_multiple_nexus(
+                        sled_id,
+                        new_total_zone_count,
+                    )?
+                }
+                DiscretionaryOmicronZone::Oximeter => {
+                    self.blueprint.sled_ensure_zone_multiple_oximeter(
                         sled_id,
                         new_total_zone_count,
                     )?

--- a/nexus/reconfigurator/planning/src/planner/omicron_zone_placement.rs
+++ b/nexus/reconfigurator/planning/src/planner/omicron_zone_placement.rs
@@ -21,6 +21,7 @@ pub(crate) enum DiscretionaryOmicronZone {
     InternalDns,
     ExternalDns,
     Nexus,
+    Oximeter,
     // TODO expand this enum as we start to place more services
 }
 
@@ -40,14 +41,14 @@ impl DiscretionaryOmicronZone {
             BlueprintZoneType::InternalDns(_) => Some(Self::InternalDns),
             BlueprintZoneType::ExternalDns(_) => Some(Self::ExternalDns),
             BlueprintZoneType::Nexus(_) => Some(Self::Nexus),
+            BlueprintZoneType::Oximeter(_) => Some(Self::Oximeter),
             // Zones that we should place but don't yet.
             BlueprintZoneType::Clickhouse(_)
             | BlueprintZoneType::CruciblePantry(_)
-            | BlueprintZoneType::Oximeter(_) => None,
             // Zones that get special handling for placement (all sleds get
             // them, although internal NTP has some interactions with boundary
-            // NTP that we don't yet handle, so this may change).
-            BlueprintZoneType::Crucible(_)
+            // NTP that are handled separately).
+            | BlueprintZoneType::Crucible(_)
             | BlueprintZoneType::InternalNtp(_) => None,
         }
     }
@@ -67,6 +68,7 @@ impl From<DiscretionaryOmicronZone> for ZoneKind {
             DiscretionaryOmicronZone::InternalDns => Self::InternalDns,
             DiscretionaryOmicronZone::ExternalDns => Self::ExternalDns,
             DiscretionaryOmicronZone::Nexus => Self::Nexus,
+            DiscretionaryOmicronZone::Oximeter => Self::Oximeter,
         }
     }
 }

--- a/nexus/reconfigurator/planning/src/system.rs
+++ b/nexus/reconfigurator/planning/src/system.rs
@@ -83,6 +83,7 @@ pub struct SystemDescription {
     target_boundary_ntp_zone_count: usize,
     target_nexus_zone_count: usize,
     target_internal_dns_zone_count: usize,
+    target_oximeter_zone_count: usize,
     target_cockroachdb_zone_count: usize,
     target_cockroachdb_cluster_version: CockroachDbClusterVersion,
     service_ip_pool_ranges: Vec<IpRange>,
@@ -136,11 +137,12 @@ impl SystemDescription {
         let target_internal_dns_zone_count = INTERNAL_DNS_REDUNDANCY;
 
         // TODO-cleanup These are wrong, but we don't currently set up any
-        // boundary NTP or CRDB nodes in our fake system, so this prevents
-        // downstream test issues with the planner thinking our system is out of
-        // date from the gate.
+        // of these zones in our fake system, so this prevents downstream test
+        // issues with the planner thinking our system is out of date from the
+        // gate.
         let target_boundary_ntp_zone_count = 0;
         let target_cockroachdb_zone_count = 0;
+        let target_oximeter_zone_count = 0;
 
         let target_cockroachdb_cluster_version =
             CockroachDbClusterVersion::POLICY;
@@ -161,6 +163,7 @@ impl SystemDescription {
             target_boundary_ntp_zone_count,
             target_nexus_zone_count,
             target_internal_dns_zone_count,
+            target_oximeter_zone_count,
             target_cockroachdb_zone_count,
             target_cockroachdb_cluster_version,
             service_ip_pool_ranges,
@@ -344,6 +347,7 @@ impl SystemDescription {
             target_boundary_ntp_zone_count: self.target_boundary_ntp_zone_count,
             target_nexus_zone_count: self.target_nexus_zone_count,
             target_internal_dns_zone_count: self.target_internal_dns_zone_count,
+            target_oximeter_zone_count: self.target_oximeter_zone_count,
             target_cockroachdb_zone_count: self.target_cockroachdb_zone_count,
             target_cockroachdb_cluster_version: self
                 .target_cockroachdb_cluster_version,

--- a/nexus/reconfigurator/preparation/src/lib.rs
+++ b/nexus/reconfigurator/preparation/src/lib.rs
@@ -42,6 +42,7 @@ use omicron_common::policy::BOUNDARY_NTP_REDUNDANCY;
 use omicron_common::policy::COCKROACHDB_REDUNDANCY;
 use omicron_common::policy::INTERNAL_DNS_REDUNDANCY;
 use omicron_common::policy::NEXUS_REDUNDANCY;
+use omicron_common::policy::OXIMETER_REDUNDANCY;
 use omicron_uuid_kinds::GenericUuid;
 use omicron_uuid_kinds::OmicronZoneUuid;
 use omicron_uuid_kinds::PhysicalDiskUuid;
@@ -66,6 +67,7 @@ pub struct PlanningInputFromDb<'a> {
     pub target_boundary_ntp_zone_count: usize,
     pub target_nexus_zone_count: usize,
     pub target_internal_dns_zone_count: usize,
+    pub target_oximeter_zone_count: usize,
     pub target_cockroachdb_zone_count: usize,
     pub target_cockroachdb_cluster_version: CockroachDbClusterVersion,
     pub internal_dns_version: nexus_db_model::Generation,
@@ -141,6 +143,7 @@ impl PlanningInputFromDb<'_> {
             target_boundary_ntp_zone_count: BOUNDARY_NTP_REDUNDANCY,
             target_nexus_zone_count: NEXUS_REDUNDANCY,
             target_internal_dns_zone_count: INTERNAL_DNS_REDUNDANCY,
+            target_oximeter_zone_count: OXIMETER_REDUNDANCY,
             target_cockroachdb_zone_count: COCKROACHDB_REDUNDANCY,
             target_cockroachdb_cluster_version:
                 CockroachDbClusterVersion::POLICY,
@@ -165,6 +168,7 @@ impl PlanningInputFromDb<'_> {
             target_boundary_ntp_zone_count: self.target_boundary_ntp_zone_count,
             target_nexus_zone_count: self.target_nexus_zone_count,
             target_internal_dns_zone_count: self.target_internal_dns_zone_count,
+            target_oximeter_zone_count: self.target_oximeter_zone_count,
             target_cockroachdb_zone_count: self.target_cockroachdb_zone_count,
             target_cockroachdb_cluster_version: self
                 .target_cockroachdb_cluster_version,

--- a/nexus/types/src/deployment/planning_input.rs
+++ b/nexus/types/src/deployment/planning_input.rs
@@ -103,6 +103,10 @@ impl PlanningInput {
         self.policy.target_internal_dns_zone_count
     }
 
+    pub fn target_oximeter_zone_count(&self) -> usize {
+        self.policy.target_oximeter_zone_count
+    }
+
     pub fn target_cockroachdb_zone_count(&self) -> usize {
         self.policy.target_cockroachdb_zone_count
     }
@@ -833,6 +837,9 @@ pub struct Policy {
     /// internal DNS server on each of the expected reserved addresses).
     pub target_internal_dns_zone_count: usize,
 
+    /// desired total number of deployed Oximeter zones
+    pub target_oximeter_zone_count: usize,
+
     /// desired total number of deployed CockroachDB zones
     pub target_cockroachdb_zone_count: usize,
 
@@ -913,6 +920,7 @@ impl PlanningInputBuilder {
                 target_boundary_ntp_zone_count: 0,
                 target_nexus_zone_count: 0,
                 target_internal_dns_zone_count: 0,
+                target_oximeter_zone_count: 0,
                 target_cockroachdb_zone_count: 0,
                 target_cockroachdb_cluster_version:
                     CockroachDbClusterVersion::POLICY,

--- a/sled-agent/src/rack_setup/plan/service.rs
+++ b/sled-agent/src/rack_setup/plan/service.rs
@@ -38,7 +38,7 @@ use omicron_common::disk::{
 use omicron_common::ledger::{self, Ledger, Ledgerable};
 use omicron_common::policy::{
     BOUNDARY_NTP_REDUNDANCY, COCKROACHDB_REDUNDANCY, INTERNAL_DNS_REDUNDANCY,
-    NEXUS_REDUNDANCY, RESERVED_INTERNAL_DNS_REDUNDANCY,
+    NEXUS_REDUNDANCY, OXIMETER_REDUNDANCY, RESERVED_INTERNAL_DNS_REDUNDANCY,
 };
 use omicron_uuid_kinds::{
     ExternalIpUuid, GenericUuid, OmicronZoneUuid, SledUuid, ZpoolUuid,
@@ -60,9 +60,6 @@ use std::num::Wrapping;
 use thiserror::Error;
 use uuid::Uuid;
 
-// TODO(https://github.com/oxidecomputer/omicron/issues/732): Remove
-// when Nexus provisions Oximeter.
-const OXIMETER_COUNT: usize = 1;
 // TODO(https://github.com/oxidecomputer/omicron/issues/732): Remove
 // when Nexus provisions Clickhouse.
 // TODO(https://github.com/oxidecomputer/omicron/issues/4000): Use
@@ -658,7 +655,7 @@ impl Plan {
 
         // Provision Oximeter zones, continuing to stripe across sleds.
         // TODO(https://github.com/oxidecomputer/omicron/issues/732): Remove
-        for _ in 0..OXIMETER_COUNT {
+        for _ in 0..OXIMETER_REDUNDANCY {
             let sled = {
                 let which_sled =
                     sled_allocator.next().ok_or(PlanError::NotEnoughSleds)?;


### PR DESCRIPTION
This PR teaches the blueprint planner how to add new Oximeter zones, and the blueprint executor how to clean up expunged Oximeter zones (mark it expunged and reassign any producers that were assigned to it).

Testing this branch on a4x2 looks mostly good, with one oddity noted below that I think is okay? After RSS, we have one oximeter instance and a handful of metric producers that are all assigned to it:

```
root@[fd00:1122:3344:101::3]:32221/omicron> select * from oximeter;
                   id                  |         time_created          |         time_modified         |          ip           | port  | time_expunged
---------------------------------------+-------------------------------+-------------------------------+-----------------------+-------+----------------
  f6d96f6f-181d-4201-b5b8-ed2dc65f0399 | 2024-10-01 18:46:16.043609+00 | 2024-10-01 18:46:16.043609+00 | fd00:1122:3344:102::6 | 12223 | NULL
(1 row)

root@[fd00:1122:3344:101::3]:32221/omicron> select * from metric_producer;
                   id                  |         time_created          |         time_modified         |        kind        |          ip           | port  | interval |             oximeter_id
---------------------------------------+-------------------------------+-------------------------------+--------------------+-----------------------+-------+----------+---------------------------------------
  0390de50-810f-432a-8eea-74427ff65c81 | 2024-10-01 18:48:15.152975+00 | 2024-10-02 15:32:02.046518+00 | service            | fd00:1122:3344:101::1 |  8001 |        1 | f6d96f6f-181d-4201-b5b8-ed2dc65f0399
  1568b481-5526-4a1a-b316-ffbfc39af6f9 | 2024-10-01 18:47:03.054941+00 | 2024-10-02 15:33:27.35854+00  | service            | fd00:1122:3344:102::5 | 42314 |       10 | f6d96f6f-181d-4201-b5b8-ed2dc65f0399
  35b90542-af39-4e69-ba5c-8cb0a5403058 | 2024-10-01 18:49:02.341616+00 | 2024-10-02 15:33:25.649369+00 | service            | fd00:1122:3344:101::2 |  4677 |        1 | f6d96f6f-181d-4201-b5b8-ed2dc65f0399
  3a6e579c-0884-4ba1-a089-b42c82c62b09 | 2024-10-01 18:46:43.387352+00 | 2024-10-02 15:31:56.540949+00 | service            | fd00:1122:3344:103::2 |  8001 |        1 | f6d96f6f-181d-4201-b5b8-ed2dc65f0399
  47bb4920-b59d-4591-a8eb-9bba32dafbb4 | 2024-10-01 18:48:58.00267+00  | 2024-10-02 15:32:00.470336+00 | sled_agent         | fd00:1122:3344:101::1 | 48308 |       30 | f6d96f6f-181d-4201-b5b8-ed2dc65f0399
  639b4789-e3f9-4fc8-a62a-a4a9d142a5a7 | 2024-10-01 18:49:26.549138+00 | 2024-10-02 15:31:59.225666+00 | sled_agent         | fd00:1122:3344:103::1 | 53355 |       30 | f6d96f6f-181d-4201-b5b8-ed2dc65f0399
  6f1b3049-7f6b-48f8-afe5-392527e919f8 | 2024-10-01 18:47:53.800591+00 | 2024-10-02 15:33:23.942499+00 | management_gateway | fd00:1122:3344:103::2 | 57856 |       10 | f6d96f6f-181d-4201-b5b8-ed2dc65f0399
  710c953b-6660-435d-8158-1c66fdf156b5 | 2024-10-01 18:47:11.323543+00 | 2024-10-02 15:33:25.719071+00 | service            | fd00:1122:3344:101::2 |  8001 |        1 | f6d96f6f-181d-4201-b5b8-ed2dc65f0399
  712d102a-9e66-4d42-8e37-5d487b21a044 | 2024-10-01 18:48:45.69256+00  | 2024-10-02 15:33:28.907927+00 | service            | fd00:1122:3344:103::2 | 35747 |       10 | f6d96f6f-181d-4201-b5b8-ed2dc65f0399
  a3adcf69-a609-402b-978d-ee6cb3128ec7 | 2024-10-01 18:47:47.12988+00  | 2024-10-02 15:32:17.575733+00 | service            | fd00:1122:3344:101::6 | 63088 |       10 | f6d96f6f-181d-4201-b5b8-ed2dc65f0399
  ac0d8193-6972-418e-bc9b-86a81090d7b8 | 2024-10-01 18:47:32.524823+00 | 2024-10-02 15:32:15.019474+00 | service            | fd00:1122:3344:103::5 | 62732 |       10 | f6d96f6f-181d-4201-b5b8-ed2dc65f0399
  b8510494-8e5b-4200-9170-0ab79fa726d5 | 2024-10-01 18:46:21.724235+00 | 2024-10-02 15:34:19.716822+00 | service            | fd00:1122:3344:102::1 |  8001 |        1 | f6d96f6f-181d-4201-b5b8-ed2dc65f0399
  d5b4b5e5-867a-46a6-9270-ec75d6c15d25 | 2024-10-01 18:48:47.474202+00 | 2024-10-02 15:32:02.122286+00 | service            | fd00:1122:3344:103::2 |  4677 |        1 | f6d96f6f-181d-4201-b5b8-ed2dc65f0399
  e13f22a6-d509-41da-baa5-f2c7d5003cb5 | 2024-10-01 18:48:10.207882+00 | 2024-10-02 15:33:22.691067+00 | service            | fd00:1122:3344:101::2 | 56724 |       10 | f6d96f6f-181d-4201-b5b8-ed2dc65f0399
  e5154568-28b2-488b-a150-bdaae37e0654 | 2024-10-01 18:46:42.964545+00 | 2024-10-02 15:33:13.409823+00 | service            | fd00:1122:3344:103::1 |  8001 |        1 | f6d96f6f-181d-4201-b5b8-ed2dc65f0399
  f361fd63-64ae-445a-a9ee-140555a81b93 | 2024-10-01 18:46:36.347276+00 | 2024-10-02 15:33:26.707624+00 | sled_agent         | fd00:1122:3344:102::1 | 53588 |       30 | f6d96f6f-181d-4201-b5b8-ed2dc65f0399
  f9b5c90a-f2ad-42c5-ab60-6866682c8b02 | 2024-10-01 18:47:11.747849+00 | 2024-10-02 15:34:23.450382+00 | management_gateway | fd00:1122:3344:101::2 | 46035 |       10 | f6d96f6f-181d-4201-b5b8-ed2dc65f0399
(17 rows)
```

I then used `reconfigurator-cli` to construct a child blueprint that expunges the oximeter zone:

```
root@oxz_switch:/tmp# omdb nexus blueprints diff current 53540387-0d2a-42b4-8e42-01745edf5a6d
... snip ...
 MODIFIED SLEDS:

  sled f361fd63-64ae-445a-a9ee-140555a81b93 (active):

    physical disks at generation 1:
    -------------------------------------------------------------
    vendor             model                serial
    -------------------------------------------------------------
    synthetic-vendor   synthetic-model-U2   synthetic-serial-g1_0
    synthetic-vendor   synthetic-model-U2   synthetic-serial-g1_1
    synthetic-vendor   synthetic-model-U2   synthetic-serial-g1_2
    synthetic-vendor   synthetic-model-U2   synthetic-serial-g1_3
    synthetic-vendor   synthetic-model-U2   synthetic-serial-g1_4


    omicron zones generation 5 -> 6:
    ---------------------------------------------------------------------------------------------
    zone type         zone id                                disposition    underlay IP
    ---------------------------------------------------------------------------------------------
    boundary_ntp      c0400fda-0fa1-43ae-8ee8-c28b1228a627   in service     fd00:1122:3344:102::d
    cockroach_db      d2b2f087-9cf3-4157-b4a1-542928835f90   in service     fd00:1122:3344:102::4
    cockroach_db      ff6cf097-a8dc-419b-8277-44ab921bcbf8   in service     fd00:1122:3344:102::3
    crucible          1c232e87-eff0-4f97-8869-11b0e9858cd1   in service     fd00:1122:3344:102::a
    crucible          2a728f1d-c3ed-49c0-a52d-131157af5208   in service     fd00:1122:3344:102::c
    crucible          3b0bf0fb-953a-407f-b3cd-1fce456600f1   in service     fd00:1122:3344:102::8
    crucible          3debf2f2-a5d6-4972-9ee3-888dc5278690   in service     fd00:1122:3344:102::b
    crucible          89836bda-1d17-41b6-8c81-baf71f8c8691   in service     fd00:1122:3344:102::9
    crucible_pantry   b3b7ea90-a54e-47c9-83ba-3ed35c9eba42   in service     fd00:1122:3344:102::7
    internal_dns      7c657bf7-784f-448a-9704-e129bcc24cd9   in service     fd00:1122:3344:2::1
    nexus             1568b481-5526-4a1a-b316-ffbfc39af6f9   in service     fd00:1122:3344:102::5
*   oximeter          f6d96f6f-181d-4201-b5b8-ed2dc65f0399   - in service   fd00:1122:3344:102::6
     └─                                                      + expunged
```

After making this blueprint the target, the one oximeter zone was shut down, and the db record was updated to mark its expungement:

```
root@[fd00:1122:3344:101::3]:32221/omicron> select * from oximeter;
                   id                  |         time_created          |         time_modified         |          ip           | port  |         time_expunged
---------------------------------------+-------------------------------+-------------------------------+-----------------------+-------+--------------------------------
  f6d96f6f-181d-4201-b5b8-ed2dc65f0399 | 2024-10-01 18:46:16.043609+00 | 2024-10-01 18:46:16.043609+00 | fd00:1122:3344:102::6 | 12223 | 2024-10-02 15:38:30.874666+00
(1 row)
```

At this point the `metric_producer` table is unchanged; they're all still assigned to the now-expunged oximeter, which effectively leaves them orphaned (i.e., there is no active collector polling them for metrics). This is expected: there is no oximeter running! The producers all attempt to reregister with Nexus periodically, and these attempts fail with a 503 as expected. On the producer side:

```
Oct 02 15:42:15.999 WARN failed to register as a producer with Nexus, will retry, error: "Error Response: status: 503 Service Unavailable; headers: {\"content-type\": \"application/json\", \"x-request-id\": \"5c776ed5-8bd1-4d8e-8c85-2057ac16be1c\", \"content-length\": \"133\", \"date\": \"Wed, 02 Oct 2024 15:42:15 GMT\"}; value: Error { error_code: Some(\"ServiceNotAvailable\"), message: \"Service Unavailable\", request_id: \"5c776ed5-8bd1-4d8e-8c85-2057ac16be1c\" }", delay: 241.996679066s, component: producer-registration-task, file: /home/build/.cargo/git/checkouts/omicron-d039c41f152bda83/66ac7b3/oximeter/producer/src/lib.rs:424
```

and on the Nexus side:

```
15:42:15.996Z INFO 1568b481-5526-4a1a-b316-ffbfc39af6f9 (dropshot_internal): request completed
    error_message_external = Service Unavailable
    error_message_internal = no oximeter collectors available
    file = /home/john/.cargo/registry/src/index.crates.io-6f17d22bba15001f/dropshot-0.12.0/src/server.rs:938
    latency_us = 4140
    local_addr = [fd00:1122:3344:102::5]:12221
    method = POST
    remote_addr = [fd00:1122:3344:102::1]:47999
    req_id = 5c776ed5-8bd1-4d8e-8c85-2057ac16be1c
    response_code = 503
    uri = /metrics/producers
```

This is the same error any new metric producer should see; registration hits the same Nexus endpoint as reregistration. (I'm not sure how to test this on a4x2 without the ability to create instances, but I'm pretty confident it's true!)

Generating a new blueprint via the planner, we see that it has placed a new oximeter instance:

```
root@oxz_switch:~# omdb -w nexus blueprints regenerate
note: Nexus URL not specified.  Will pick one from DNS.
note: using DNS server for subnet fd00:1122:3344::/48
note: (if this is not right, use --dns-server to specify an alternate DNS server)
note: using Nexus URL http://[fd00:1122:3344:101::6]:12221
generated new blueprint a087b307-a08d-4629-807c-3ac338997295
root@oxz_switch:~# omdb nexus blueprints diff current a087b307-a08d-4629-807c-3ac338997295
... snip ...
 MODIFIED SLEDS:

  sled 639b4789-e3f9-4fc8-a62a-a4a9d142a5a7 (active):

    physical disks at generation 1:
    -------------------------------------------------------------
    vendor             model                serial
    -------------------------------------------------------------
    synthetic-vendor   synthetic-model-U2   synthetic-serial-g3_0
    synthetic-vendor   synthetic-model-U2   synthetic-serial-g3_1
    synthetic-vendor   synthetic-model-U2   synthetic-serial-g3_2
    synthetic-vendor   synthetic-model-U2   synthetic-serial-g3_3
    synthetic-vendor   synthetic-model-U2   synthetic-serial-g3_4


    omicron zones generation 5 -> 6:
    ---------------------------------------------------------------------------------------------
    zone type         zone id                                disposition   underlay IP
    ---------------------------------------------------------------------------------------------
    clickhouse        edd9990d-de18-439c-8662-469de090d15e   in service    fd00:1122:3344:103::6
    cockroach_db      a1e6435b-9a4e-423b-ab8a-e914697f0b88   in service    fd00:1122:3344:103::3
    crucible          45c6f0b7-d83c-4fe8-a564-eddcc802eb75   in service    fd00:1122:3344:103::b
    crucible          6ef96d56-0a52-40c8-b238-9eec3412bee1   in service    fd00:1122:3344:103::c
    crucible          70a6e0b3-a8b5-4ab2-940a-427db39f495a   in service    fd00:1122:3344:103::8
    crucible          843759ff-4683-45bd-92c7-c64ad5b37af4   in service    fd00:1122:3344:103::9
    crucible          88f55074-fe2f-4952-ba8c-0ffd3f161d67   in service    fd00:1122:3344:103::a
    crucible_pantry   f846246b-9a04-408f-bb31-22ec5b66e018   in service    fd00:1122:3344:103::7
    external_dns      b82c1f78-a87b-4429-ba58-14b63ae3892f   in service    fd00:1122:3344:103::4
    internal_dns      a690976e-4a11-4373-9b5c-4c39854042f3   in service    fd00:1122:3344:3::1
    internal_ntp      e40053e1-1aa9-4203-93b5-c9356aaaeff3   in service    fd00:1122:3344:103::d
    nexus             ac0d8193-6972-418e-bc9b-86a81090d7b8   in service    fd00:1122:3344:103::5
+   oximeter          7ee9dec4-9839-4df2-b717-382c234b113f   in service    fd00:1122:3344:103::21
```

After waiting a bit, the new oximeter zone started and registered itself with Nexus, which created its entry in the `oximeter` table:

```
root@[fd00:1122:3344:101::3]:32221/omicron> select * from oximeter;
                   id                  |         time_created          |         time_modified         |           ip           | port  |         time_expunged
---------------------------------------+-------------------------------+-------------------------------+------------------------+-------+--------------------------------
  7ee9dec4-9839-4df2-b717-382c234b113f | 2024-10-02 15:52:43.356131+00 | 2024-10-02 15:52:43.356131+00 | fd00:1122:3344:103::21 | 12223 | NULL
  f6d96f6f-181d-4201-b5b8-ed2dc65f0399 | 2024-10-01 18:46:16.043609+00 | 2024-10-01 18:46:16.043609+00 | fd00:1122:3344:102::6  | 12223 | 2024-10-02 15:38:30.874666+00
(2 rows)
```

The contents of the metric_producer table are a little surprising:

```
root@[fd00:1122:3344:101::3]:32221/omicron> select * from metric_producer;
                   id                  |         time_created          |         time_modified         |        kind        |          ip           | port  | interval |             oximeter_id
---------------------------------------+-------------------------------+-------------------------------+--------------------+-----------------------+-------+----------+---------------------------------------
  35b90542-af39-4e69-ba5c-8cb0a5403058 | 2024-10-02 15:54:03.87167+00  | 2024-10-02 15:54:03.87167+00  | service            | fd00:1122:3344:101::2 |  4677 |        1 | 7ee9dec4-9839-4df2-b717-382c234b113f
  3a6e579c-0884-4ba1-a089-b42c82c62b09 | 2024-10-01 18:46:43.387352+00 | 2024-10-02 15:52:49.418766+00 | service            | fd00:1122:3344:103::2 |  8001 |        1 | 7ee9dec4-9839-4df2-b717-382c234b113f
  639b4789-e3f9-4fc8-a62a-a4a9d142a5a7 | 2024-10-01 18:49:26.549138+00 | 2024-10-02 15:52:50.821915+00 | sled_agent         | fd00:1122:3344:103::1 | 53355 |       30 | 7ee9dec4-9839-4df2-b717-382c234b113f
  6f1b3049-7f6b-48f8-afe5-392527e919f8 | 2024-10-02 15:53:14.750475+00 | 2024-10-02 15:53:14.750475+00 | management_gateway | fd00:1122:3344:103::2 | 57856 |       10 | 7ee9dec4-9839-4df2-b717-382c234b113f
  712d102a-9e66-4d42-8e37-5d487b21a044 | 2024-10-02 15:53:55.87496+00  | 2024-10-02 15:53:55.87496+00  | service            | fd00:1122:3344:103::2 | 35747 |       10 | 7ee9dec4-9839-4df2-b717-382c234b113f
  d5b4b5e5-867a-46a6-9270-ec75d6c15d25 | 2024-10-01 18:48:47.474202+00 | 2024-10-02 15:52:53.948688+00 | service            | fd00:1122:3344:103::2 |  4677 |        1 | 7ee9dec4-9839-4df2-b717-382c234b113f
(6 rows)
```

We're missing a bunch of producers from earlier. I think the explanation here is:

* Producers are supposed to reregister periodically; failure to reregister is how Nexus detects a dead producer.
* The existing producers are failing to reregister on the _Nexus_ side, so their timestamps aren't getting bumped to record liveness.
* The Nexus producer GC task eventually prunes them all.

However, they're all still running and still trying to reregister. Indeed, after waiting a few minutes, all the prior producers came back and were assigned to the new Oximeter. I think this is _basically_ fine? We could decide we want a producer that reregisters when there are no Oximeters to still get its timestamp bumped to avoid being GC'd, but all that does is shrink the window of time between when the new Oximeter exists and when it starts collecting by whatever the reregistration period is (a few minutes).

Finally, I confirmed that the new Oximeter was successfully collecting from various producers:

```
root@oxz_oximeter_7ee9dec4:~# tail -n 5 $(svcs -L oximeter) | looker
16:05:54.796Z DEBG oximeter (oximeter-agent): collected results from producer
    address = [fd00:1122:3344:101::2]:4677
    collector_id = 7ee9dec4-9839-4df2-b717-382c234b113f
    collector_ip = fd00:1122:3344:103::21
    n_results = 1
    producer_id = 35b90542-af39-4e69-ba5c-8cb0a5403058
16:05:54.888Z DEBG oximeter (oximeter-agent): collected results from producer
    address = [fd00:1122:3344:103::5]:62732
    collector_id = 7ee9dec4-9839-4df2-b717-382c234b113f
    collector_ip = fd00:1122:3344:103::21
    n_results = 5
    producer_id = ac0d8193-6972-418e-bc9b-86a81090d7b8
16:05:54.941Z DEBG oximeter (oximeter-agent): collecting from producer
    address = [fd00:1122:3344:103::1]:8001
    collector_id = 7ee9dec4-9839-4df2-b717-382c234b113f
    collector_ip = fd00:1122:3344:103::21
    producer_id = e5154568-28b2-488b-a150-bdaae37e0654
16:05:54.963Z DEBG oximeter (oximeter-agent): collecting from producer
    address = [fd00:1122:3344:101::1]:8001
    collector_id = 7ee9dec4-9839-4df2-b717-382c234b113f
    collector_ip = fd00:1122:3344:103::21
    producer_id = 0390de50-810f-432a-8eea-74427ff65c81
16:05:54.963Z DEBG oximeter (oximeter-agent): collected results from producer
    address = [fd00:1122:3344:103::1]:8001
    collector_id = 7ee9dec4-9839-4df2-b717-382c234b113f
    collector_ip = fd00:1122:3344:103::21
    n_results = 1
    producer_id = e5154568-28b2-488b-a150-bdaae37e0654
```