### PR TITLE
be precise in git dependency specification

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -663,7 +663,7 @@ dependencies = [
 [[package]]
 name = "bhyve_api"
 version = "0.0.0"
-source = "git+https://github.com/oxidecomputer/propolis?rev=11371b0f3743f8df5b047dc0edc2699f4bdf3927"
+source = "git+https://github.com/oxidecomputer/propolis?rev=11371b0f3743f8df5b047dc0edc2699f4bdf3927#11371b0f3743f8df5b047dc0edc2699f4bdf3927"
 dependencies = [
  "bhyve_api_sys",
  "libc",
@@ -673,7 +673,7 @@ dependencies = [
 [[package]]
 name = "bhyve_api_sys"
 version = "0.0.0"
-source = "git+https://github.com/oxidecomputer/propolis?rev=11371b0f3743f8df5b047dc0edc2699f4bdf3927"
+source = "git+https://github.com/oxidecomputer/propolis?rev=11371b0f3743f8df5b047dc0edc2699f4bdf3927#11371b0f3743f8df5b047dc0edc2699f4bdf3927"
 dependencies = [
  "libc",
  "strum",


### PR DESCRIPTION
in #6585 i'd unintentionally removed the fragment from `bhyve_api`'s source entry in Cargo.lock. it's not _wrong_, since it's still specifying the desired `11371b0...`, but without the fragment at the end of the source Cargo parses this as a [non-precise reference](https://github.com/rust-lang/cargo/blob/d9c14e664e994ea5cf28e49000231a4b2734d8e7/src/cargo/core/source_id.rs#L158-L165) and updates the  git repo tracking this dependency every time it resolves dependdencies. so, put the fragment back and be very clear to Cargo that once it has `11371b0...` it does not need to do more git operations to try getting a newer version of the commit.

(this makes a bit more sense if you imagine  source urls like `git+https://github.com/foo.git?rev=main#1234`: in the case where `rev` _is_ a commit it's arguably a bug to fetch from remotes when you already have the commit..)

Cargo generally handles this automatically, compare with [other version bumps](https://github.com/oxidecomputer/omicron/commit/2c79661a8144f52670f5fe9d8bf01fac220b45ce). i suspect i got the lockfile in this state by resolving a merge conflict incorrectly.