### PR TITLE
[datastore] Rework metric producer upsertion

### DIFF
--- a/nexus/db-model/src/oximeter_info.rs
+++ b/nexus/db-model/src/oximeter_info.rs
@@ -9,7 +9,9 @@ use nexus_types::internal_api;
 use uuid::Uuid;
 
 /// A record representing a registered `oximeter` collector.
-#[derive(Queryable, Insertable, Debug, Clone, Copy, PartialEq, Eq)]
+#[derive(
+    Queryable, Insertable, Selectable, Debug, Clone, Copy, PartialEq, Eq,
+)]
 #[diesel(table_name = oximeter)]
 pub struct OximeterInfo {
     /// The ID for this oximeter instance.

--- a/nexus/db-queries/src/db/datastore/oximeter.rs
+++ b/nexus/db-queries/src/db/datastore/oximeter.rs
@@ -176,7 +176,7 @@ impl DataStore {
     /// Returns the oximeter ID assigned to this producer (either the
     /// randomly-chosen one, if newly inserted, or the previously-chosen, if
     /// updated).
-    pub async fn producer_endpoint_create(
+    pub async fn producer_endpoint_upsert_and_assign(
         &self,
         opctx: &OpContext,
         producer: &internal::nexus::ProducerEndpoint,
@@ -482,7 +482,7 @@ mod tests {
             interval: Duration::from_secs(0),
         };
         let chosen_oximeter = datastore
-            .producer_endpoint_create(&opctx, &producer)
+            .producer_endpoint_upsert_and_assign(&opctx, &producer)
             .await
             .expect("inserted producer");
         assert_eq!(chosen_oximeter.id, oximeter1_id);
@@ -510,7 +510,7 @@ mod tests {
         // Attempting to upsert our producer again should fail; our oximeter has
         // been expunged, and our time modified should be unchanged.
         let err = datastore
-            .producer_endpoint_create(&opctx, &producer)
+            .producer_endpoint_upsert_and_assign(&opctx, &producer)
             .await
             .expect_err("producer upsert failed")
             .to_string();
@@ -551,7 +551,7 @@ mod tests {
         // Retry updating our existing producer; it should get reassigned to a
         // the new Oximeter.
         let chosen_oximeter = datastore
-            .producer_endpoint_create(&opctx, &producer)
+            .producer_endpoint_upsert_and_assign(&opctx, &producer)
             .await
             .expect("inserted producer");
         assert_eq!(chosen_oximeter.id, oximeter2_id);
@@ -579,10 +579,10 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn test_producer_endpoint_create_rejects_expunged_oximeters() {
+    async fn test_producer_endpoint_upsert_rejects_expunged_oximeters() {
         // Setup
         let logctx = dev::test_setup_log(
-            "test_producer_endpoint_create_rejects_expunged_oximeters",
+            "test_producer_endpoint_upsert_rejects_expunged_oximeters",
         );
         let mut db = test_setup_database(&logctx.log).await;
         let (opctx, datastore) =
@@ -612,7 +612,7 @@ mod tests {
                 interval: Duration::from_secs(0),    // unused
             };
             let collector_id = datastore
-                .producer_endpoint_create(&opctx, &producer)
+                .producer_endpoint_upsert_and_assign(&opctx, &producer)
                 .await
                 .expect("inserted producer")
                 .id;
@@ -643,7 +643,7 @@ mod tests {
                 interval: Duration::from_secs(0),    // unused
             };
             let collector_id = datastore
-                .producer_endpoint_create(&opctx, &producer)
+                .producer_endpoint_upsert_and_assign(&opctx, &producer)
                 .await
                 .expect("inserted producer")
                 .id;
@@ -674,7 +674,7 @@ mod tests {
             interval: Duration::from_secs(0),    // unused
         };
         let err = datastore
-            .producer_endpoint_create(&opctx, &producer)
+            .producer_endpoint_upsert_and_assign(&opctx, &producer)
             .await
             .expect_err("unexpected success - all oximeters expunged")
             .to_string();
@@ -719,7 +719,7 @@ mod tests {
                 interval: Duration::from_secs(0),    // unused
             };
             let collector_id = datastore
-                .producer_endpoint_create(&opctx, &producer)
+                .producer_endpoint_upsert_and_assign(&opctx, &producer)
                 .await
                 .expect("inserted producer")
                 .id;
@@ -825,7 +825,7 @@ mod tests {
                 interval: Duration::from_secs(0),    // unused
             };
             let collector_id = datastore
-                .producer_endpoint_create(&opctx, &producer)
+                .producer_endpoint_upsert_and_assign(&opctx, &producer)
                 .await
                 .expect("inserted producer")
                 .id;
@@ -925,7 +925,7 @@ mod tests {
             interval: Duration::from_secs(0),    // unused
         };
         datastore
-            .producer_endpoint_create(&opctx, &producer)
+            .producer_endpoint_upsert_and_assign(&opctx, &producer)
             .await
             .expect("failed to insert producer");
 

--- a/nexus/db-queries/src/db/datastore/oximeter.rs
+++ b/nexus/db-queries/src/db/datastore/oximeter.rs
@@ -461,7 +461,7 @@ mod tests {
         let (opctx, datastore) =
             datastore_test(&logctx, &db, Uuid::new_v4()).await;
 
-        // Insert a couple Oximeter collectors.
+        // Insert a few Oximeter collectors.
         let collector_ids = (0..4).map(|_| Uuid::new_v4()).collect::<Vec<_>>();
         for &collector_id in &collector_ids {
             let info = OximeterInfo::new(&params::OximeterInfo {

--- a/nexus/db-queries/src/db/datastore/oximeter.rs
+++ b/nexus/db-queries/src/db/datastore/oximeter.rs
@@ -180,12 +180,12 @@ impl DataStore {
         &self,
         opctx: &OpContext,
         producer: &internal::nexus::ProducerEndpoint,
-    ) -> Result<Uuid, Error> {
+    ) -> Result<OximeterInfo, Error> {
         match queries::oximeter::upsert_producer(producer)
             .get_result_async(&*self.pool_connection_authorized(opctx).await?)
             .await
         {
-            Ok(id) => Ok(id),
+            Ok(info) => Ok(info),
             Err(DieselError::NotFound) => Err(Error::unavail(
                 "no Oximeter instances available for assignment",
             )),
@@ -487,7 +487,8 @@ mod tests {
             let collector_id = datastore
                 .producer_endpoint_create(&opctx, &producer)
                 .await
-                .expect("inserted producer");
+                .expect("inserted producer")
+                .id;
             let i = collector_ids
                 .iter()
                 .position(|id| *id == collector_id)
@@ -517,7 +518,8 @@ mod tests {
             let collector_id = datastore
                 .producer_endpoint_create(&opctx, &producer)
                 .await
-                .expect("inserted producer");
+                .expect("inserted producer")
+                .id;
             let i = collector_ids
                 .iter()
                 .position(|id| *id == collector_id)
@@ -592,7 +594,8 @@ mod tests {
             let collector_id = datastore
                 .producer_endpoint_create(&opctx, &producer)
                 .await
-                .expect("inserted producer");
+                .expect("inserted producer")
+                .id;
             let i = collector_ids
                 .iter()
                 .position(|id| *id == collector_id)
@@ -697,7 +700,8 @@ mod tests {
             let collector_id = datastore
                 .producer_endpoint_create(&opctx, &producer)
                 .await
-                .expect("inserted producer");
+                .expect("inserted producer")
+                .id;
             let i = collector_ids
                 .iter()
                 .position(|id| *id == collector_id)

--- a/nexus/db-queries/src/db/queries/oximeter.rs
+++ b/nexus/db-queries/src/db/queries/oximeter.rs
@@ -18,9 +18,13 @@ use uuid::Uuid;
 ///
 /// If this query succeeds but returns 0 rows inserted/updated, there are no
 /// non-expunged `Oximeter` instances to choose.
+///
+/// Returns the oximeter ID assigned to this producer (either the
+/// randomly-chosen one, if newly inserted, or the previously-chosen, if
+/// updated).
 pub fn upsert_producer(
     producer: &internal::nexus::ProducerEndpoint,
-) -> TypedSqlQuery<()> {
+) -> TypedSqlQuery<sql_types::Uuid> {
     let builder = QueryBuilder::new();
 
     // Choose a random non-expunged Oximeter instance.
@@ -85,6 +89,13 @@ pub fn upsert_producer(
           ip = excluded.ip,
           port = excluded.port,
           interval = excluded.interval
+    "#,
+    );
+
+    // Finally, return this producer's assigned collector ID.
+    let builder = builder.sql(
+        r#"
+        RETURNING oximeter_id
     "#,
     );
 

--- a/nexus/db-queries/tests/output/oximeter_upsert_producer.sql
+++ b/nexus/db-queries/tests/output/oximeter_upsert_producer.sql
@@ -1,7 +1,21 @@
 WITH
+  existing_oximeter
+    AS (
+      SELECT
+        oximeter.id
+      FROM
+        metric_producer INNER JOIN oximeter ON metric_producer.oximeter_id = oximeter.id
+      WHERE
+        oximeter.time_expunged IS NULL AND metric_producer.id = $1
+    ),
+  random_oximeter
+    AS (SELECT id FROM oximeter WHERE time_expunged IS NULL ORDER BY random() LIMIT 1),
   chosen_oximeter
     AS (
-      SELECT id AS oximeter_id FROM oximeter WHERE time_expunged IS NULL ORDER BY random() LIMIT 1
+      SELECT
+        COALESCE(existing_oximeter.id, random_oximeter.id) AS oximeter_id
+      FROM
+        random_oximeter LEFT JOIN existing_oximeter ON true
     ),
   inserted_producer
     AS (
@@ -9,7 +23,7 @@ WITH
       INTO
         metric_producer (id, time_created, time_modified, kind, ip, port, "interval", oximeter_id)
       SELECT
-        $1, now(), now(), $2, $3, $4, $5, oximeter_id
+        $2, now(), now(), $3, $4, $5, $6, oximeter_id
       FROM
         chosen_oximeter
       ON CONFLICT
@@ -20,7 +34,8 @@ WITH
           kind = excluded.kind,
           ip = excluded.ip,
           port = excluded.port,
-          "interval" = excluded.interval
+          "interval" = excluded.interval,
+          oximeter_id = excluded.oximeter_id
       RETURNING
         oximeter_id
     )
@@ -33,3 +48,5 @@ SELECT
   oximeter.port
 FROM
   oximeter INNER JOIN inserted_producer ON oximeter.id = inserted_producer.oximeter_id
+WHERE
+  oximeter.time_expunged IS NULL

--- a/nexus/db-queries/tests/output/oximeter_upsert_producer.sql
+++ b/nexus/db-queries/tests/output/oximeter_upsert_producer.sql
@@ -1,0 +1,21 @@
+WITH
+  chosen_oximeter
+    AS (
+      SELECT id AS oximeter_id FROM oximeter WHERE time_expunged IS NULL ORDER BY random() LIMIT 1
+    )
+INSERT
+INTO
+  metric_producer (id, time_created, time_modified, kind, ip, port, "interval", oximeter_id)
+SELECT
+  $1, now(), now(), $2, $3, $4, $5, oximeter_id
+FROM
+  chosen_oximeter
+ON CONFLICT
+  (id)
+DO
+  UPDATE SET
+    time_modified = now(),
+    kind = excluded.kind,
+    ip = excluded.ip,
+    port = excluded.port,
+    "interval" = excluded.interval

--- a/nexus/db-queries/tests/output/oximeter_upsert_producer.sql
+++ b/nexus/db-queries/tests/output/oximeter_upsert_producer.sql
@@ -19,3 +19,5 @@ DO
     ip = excluded.ip,
     port = excluded.port,
     "interval" = excluded.interval
+RETURNING
+  oximeter_id

--- a/nexus/db-queries/tests/output/oximeter_upsert_producer.sql
+++ b/nexus/db-queries/tests/output/oximeter_upsert_producer.sql
@@ -2,22 +2,34 @@ WITH
   chosen_oximeter
     AS (
       SELECT id AS oximeter_id FROM oximeter WHERE time_expunged IS NULL ORDER BY random() LIMIT 1
+    ),
+  inserted_producer
+    AS (
+      INSERT
+      INTO
+        metric_producer (id, time_created, time_modified, kind, ip, port, "interval", oximeter_id)
+      SELECT
+        $1, now(), now(), $2, $3, $4, $5, oximeter_id
+      FROM
+        chosen_oximeter
+      ON CONFLICT
+        (id)
+      DO
+        UPDATE SET
+          time_modified = now(),
+          kind = excluded.kind,
+          ip = excluded.ip,
+          port = excluded.port,
+          "interval" = excluded.interval
+      RETURNING
+        oximeter_id
     )
-INSERT
-INTO
-  metric_producer (id, time_created, time_modified, kind, ip, port, "interval", oximeter_id)
 SELECT
-  $1, now(), now(), $2, $3, $4, $5, oximeter_id
+  oximeter.id,
+  oximeter.time_created,
+  oximeter.time_modified,
+  oximeter.time_expunged,
+  oximeter.ip,
+  oximeter.port
 FROM
-  chosen_oximeter
-ON CONFLICT
-  (id)
-DO
-  UPDATE SET
-    time_modified = now(),
-    kind = excluded.kind,
-    ip = excluded.ip,
-    port = excluded.port,
-    "interval" = excluded.interval
-RETURNING
-  oximeter_id
+  oximeter INNER JOIN inserted_producer ON oximeter.id = inserted_producer.oximeter_id

--- a/nexus/metrics-producer-gc/src/lib.rs
+++ b/nexus/metrics-producer-gc/src/lib.rs
@@ -246,7 +246,7 @@ mod tests {
             interval: Duration::from_secs(0),    // unused
         };
         datastore
-            .producer_endpoint_create(&opctx, &producer)
+            .producer_endpoint_upsert_and_assign(&opctx, &producer)
             .await
             .expect("failed to insert producer");
 
@@ -325,7 +325,7 @@ mod tests {
             interval: Duration::from_secs(0),    // unused
         };
         datastore
-            .producer_endpoint_create(&opctx, &producer)
+            .producer_endpoint_upsert_and_assign(&opctx, &producer)
             .await
             .expect("failed to insert producer");
 

--- a/nexus/metrics-producer-gc/src/lib.rs
+++ b/nexus/metrics-producer-gc/src/lib.rs
@@ -240,11 +240,11 @@ mod tests {
 
         // Insert a producer.
         let producer = nexus::ProducerEndpoint {
-                id: Uuid::new_v4(),
-                kind: nexus::ProducerKind::Service,
-                address: "[::1]:0".parse().unwrap(), // unused
-                interval: Duration::from_secs(0),    // unused
-            };
+            id: Uuid::new_v4(),
+            kind: nexus::ProducerKind::Service,
+            address: "[::1]:0".parse().unwrap(), // unused
+            interval: Duration::from_secs(0),    // unused
+        };
         datastore
             .producer_endpoint_create(&opctx, &producer)
             .await
@@ -319,11 +319,11 @@ mod tests {
 
         // Insert a producer.
         let producer = nexus::ProducerEndpoint {
-                id: Uuid::new_v4(),
-                kind: nexus::ProducerKind::Service,
-                address: "[::1]:0".parse().unwrap(), // unused
-                interval: Duration::from_secs(0),    // unused
-            };
+            id: Uuid::new_v4(),
+            kind: nexus::ProducerKind::Service,
+            address: "[::1]:0".parse().unwrap(), // unused
+            interval: Duration::from_secs(0),    // unused
+        };
         datastore
             .producer_endpoint_create(&opctx, &producer)
             .await

--- a/nexus/metrics-producer-gc/src/lib.rs
+++ b/nexus/metrics-producer-gc/src/lib.rs
@@ -239,22 +239,19 @@ mod tests {
         assert!(pruned.failures.is_empty());
 
         // Insert a producer.
-        let producer = ProducerEndpoint::new(
-            &nexus::ProducerEndpoint {
+        let producer = nexus::ProducerEndpoint {
                 id: Uuid::new_v4(),
                 kind: nexus::ProducerKind::Service,
                 address: "[::1]:0".parse().unwrap(), // unused
                 interval: Duration::from_secs(0),    // unused
-            },
-            collector_info.id,
-        );
+            };
         datastore
             .producer_endpoint_create(&opctx, &producer)
             .await
             .expect("failed to insert producer");
 
         let producer_time_modified =
-            read_time_modified(&datastore, producer.id()).await;
+            read_time_modified(&datastore, producer.id).await;
 
         // GC'ing expired producers with an expiration time older than our
         // producer's `time_modified` should not prune anything.
@@ -278,7 +275,7 @@ mod tests {
         .await
         .expect("failed to prune expired producers");
         let expected_success =
-            [producer.id()].into_iter().collect::<BTreeSet<_>>();
+            [producer.id].into_iter().collect::<BTreeSet<_>>();
         assert_eq!(pruned.successes, expected_success);
         assert!(pruned.failures.is_empty());
 
@@ -321,22 +318,19 @@ mod tests {
             .expect("failed to insert collector");
 
         // Insert a producer.
-        let producer = ProducerEndpoint::new(
-            &nexus::ProducerEndpoint {
+        let producer = nexus::ProducerEndpoint {
                 id: Uuid::new_v4(),
                 kind: nexus::ProducerKind::Service,
                 address: "[::1]:0".parse().unwrap(), // unused
                 interval: Duration::from_secs(0),    // unused
-            },
-            collector_info.id,
-        );
+            };
         datastore
             .producer_endpoint_create(&opctx, &producer)
             .await
             .expect("failed to insert producer");
 
         let producer_time_modified =
-            read_time_modified(&datastore, producer.id()).await;
+            read_time_modified(&datastore, producer.id).await;
 
         // GC'ing expired producers with an expiration time _newer_ than our
         // producer's `time_modified` should prune our one producer and notify
@@ -344,7 +338,7 @@ mod tests {
         collector.expect(
             Expectation::matching(request::method_path(
                 "DELETE",
-                format!("/producers/{}", producer.id()),
+                format!("/producers/{}", producer.id),
             ))
             .respond_with(status_code(204)),
         );
@@ -357,7 +351,7 @@ mod tests {
         .await
         .expect("failed to prune expired producers");
         let expected_success =
-            [producer.id()].into_iter().collect::<BTreeSet<_>>();
+            [producer.id].into_iter().collect::<BTreeSet<_>>();
         assert_eq!(pruned.successes, expected_success);
         assert!(pruned.failures.is_empty());
 

--- a/nexus/src/app/background/tasks/metrics_producer_gc.rs
+++ b/nexus/src/app/background/tasks/metrics_producer_gc.rs
@@ -190,7 +190,7 @@ mod tests {
             interval: Duration::from_secs(0),    // unused
         };
         datastore
-            .producer_endpoint_create(&opctx, &producer)
+            .producer_endpoint_upsert_and_assign(&opctx, &producer)
             .await
             .expect("failed to insert producer");
 

--- a/nexus/src/app/oximeter.rs
+++ b/nexus/src/app/oximeter.rs
@@ -114,7 +114,7 @@ impl super::Nexus {
     ) -> Result<(), Error> {
         let collector_info = self
             .db_datastore
-            .producer_endpoint_create(opctx, &producer_info)
+            .producer_endpoint_upsert_and_assign(opctx, &producer_info)
             .await?;
 
         let address = SocketAddr::from((

--- a/nexus/src/app/oximeter.rs
+++ b/nexus/src/app/oximeter.rs
@@ -13,8 +13,7 @@ use nexus_db_queries::context::OpContext;
 use nexus_db_queries::db;
 use nexus_db_queries::db::DataStore;
 use omicron_common::address::CLICKHOUSE_HTTP_PORT;
-use omicron_common::api::external::{DataPageParams, ListResultVec};
-use omicron_common::api::external::{Error, LookupType, ResourceType};
+use omicron_common::api::external::{DataPageParams, Error, ListResultVec};
 use omicron_common::api::internal::nexus::{self, ProducerEndpoint};
 use oximeter_client::Client as OximeterClient;
 use oximeter_db::query::Timestamp;
@@ -113,55 +112,42 @@ impl super::Nexus {
         opctx: &OpContext,
         producer_info: nexus::ProducerEndpoint,
     ) -> Result<(), Error> {
-        for attempt in 0.. {
-            let (collector, id) = self.next_collector(opctx).await?;
-            let db_info = db::model::ProducerEndpoint::new(&producer_info, id);
+        let collector_id = self
+            .db_datastore
+            .producer_endpoint_create(opctx, &producer_info)
+            .await?;
 
-            // We chose the collector in `self.next_collector` above; if we get
-            // an "Oximeter not found" error when we try to create a producer
-            // assigned to that collector, we've lost an extremely rare race
-            // where the collector we chose was deleted in between when we chose
-            // it and when we tried to assign it. If we hit this, we should just
-            // pick another collector and try again.
-            //
-            // To safeguard against some other bug forcing us into an infinite
-            // loop here, we'll only retry once. Losing this particular race
-            // once is exceedingly unlikely; losing it twice probably means
-            // something else is wrong, so we'll just return the error.
-            match self
-                .db_datastore
-                .producer_endpoint_create(opctx, &db_info)
-                .await
-            {
-                Ok(()) => (), // fallthrough
-                Err(Error::ObjectNotFound {
-                    type_name: ResourceType::Oximeter,
-                    lookup_type: LookupType::ById(bad_id),
-                }) if id == bad_id && attempt == 0 => {
-                    // We lost the race on our first try; try again.
-                    continue;
-                }
-                // Any other error or we lost the race twice; fail.
-                Err(err) => return Err(err),
-            }
+        // It's possible (albeit quite unlikely) that the collector we chose in
+        // the query above was expunged between then and when we execute this
+        // query to look up its information. In such a case, we've now assigned
+        // this producer to an expunged collector, so failing is fine - we'll
+        // rely on reconfigurator to come back in and reassign this producer
+        // once a new oximeter is available (just like it would have to do for
+        // for any producers that were assigned to this collector already).
+        let collector_info =
+            self.db_datastore.oximeter_lookup(opctx, &collector_id).await?;
 
-            collector
-                .producers_post(
-                    &oximeter_client::types::ProducerEndpoint::from(
-                        &producer_info,
-                    ),
-                )
-                .await
-                .map_err(Error::from)?;
-            info!(
-                self.log,
-                "assigned collector to new producer";
-                "producer_id" => ?producer_info.id,
-                "collector_id" => ?id,
-            );
-            return Ok(());
-        }
-        unreachable!("for loop always returns after at most two iterations")
+        let address = SocketAddr::from((
+            collector_info.ip.ip(),
+            collector_info.port.try_into().unwrap(),
+        ));
+        let collector =
+            build_oximeter_client(&self.log, &collector_id, address);
+
+        collector
+            .producers_post(&oximeter_client::types::ProducerEndpoint::from(
+                &producer_info,
+            ))
+            .await
+            .map_err(Error::from)?;
+        info!(
+            self.log,
+            "assigned collector to new producer";
+            "producer_id" => %producer_info.id,
+            "collector_id" => %collector_id,
+        );
+
+        Ok(())
     }
 
     /// Returns a results from the timeseries DB based on the provided query
@@ -271,27 +257,6 @@ impl super::Nexus {
             },
         )
         .unwrap())
-    }
-
-    // Return an oximeter collector to assign a newly-registered producer
-    async fn next_collector(
-        &self,
-        opctx: &OpContext,
-    ) -> Result<(OximeterClient, Uuid), Error> {
-        // TODO-robustness Replace with a real load-balancing strategy.
-        let page_params = DataPageParams {
-            marker: None,
-            direction: dropshot::PaginationOrder::Ascending,
-            limit: std::num::NonZeroU32::new(1).unwrap(),
-        };
-        let oxs = self.db_datastore.oximeter_list(opctx, &page_params).await?;
-        let info = oxs.first().ok_or_else(|| Error::ServiceUnavailable {
-            internal_message: String::from("no oximeter collectors available"),
-        })?;
-        let address =
-            SocketAddr::from((info.ip.ip(), info.port.try_into().unwrap()));
-        let id = info.id;
-        Ok((build_oximeter_client(&self.log, &id, address), id))
     }
 }
 


### PR DESCRIPTION
This is staged on top of #6748 and is based on @bnaecker's [suggestion on that PR](https://github.com/oxidecomputer/omicron/pull/6748#discussion_r1784938335).

This changes `DataStore::producer_endpoint_create()` from "the caller must specify the Oximeter ID they want to be assigned to the new producer" (which required them to first list and choose an Oximeter) to "the caller does _not_ provide an Oximeter ID, and instead we choose one randomly in a CTE".

I don't think this _fixes_ #323, per se, but maybe it reworks this area enough that we can close it as no longer relevant?