### PR TITLE
semantic merge conflict: #6627 vs #6758

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5626,6 +5626,7 @@ dependencies = [
  "anyhow",
  "base64 0.22.1",
  "chrono",
+ "clickhouse-admin-types",
  "expectorate",
  "futures",
  "gateway-client",

--- a/nexus/inventory/Cargo.toml
+++ b/nexus/inventory/Cargo.toml
@@ -11,6 +11,7 @@ workspace = true
 anyhow.workspace = true
 base64.workspace = true
 chrono.workspace = true
+clickhouse-admin-types.workspace = true
 futures.workspace = true
 gateway-client.workspace = true
 gateway-messages.workspace = true

--- a/nexus/inventory/src/builder.rs
+++ b/nexus/inventory/src/builder.rs
@@ -11,6 +11,7 @@
 use anyhow::anyhow;
 use chrono::DateTime;
 use chrono::Utc;
+use clickhouse_admin_types::ClickhouseKeeperClusterMembership;
 use gateway_client::types::SpComponentCaboose;
 use gateway_client::types::SpState;
 use gateway_client::types::SpType;
@@ -21,7 +22,6 @@ use nexus_types::inventory::BaseboardId;
 use nexus_types::inventory::Caboose;
 use nexus_types::inventory::CabooseFound;
 use nexus_types::inventory::CabooseWhich;
-use nexus_types::inventory::ClickhouseKeeperClusterMembership;
 use nexus_types::inventory::Collection;
 use nexus_types::inventory::OmicronZonesFound;
 use nexus_types::inventory::RotPage;

--- a/nexus/reconfigurator/planning/src/planner.rs
+++ b/nexus/reconfigurator/planning/src/planner.rs
@@ -779,6 +779,7 @@ mod test {
     use chrono::NaiveDateTime;
     use chrono::TimeZone;
     use chrono::Utc;
+    use clickhouse_admin_types::ClickhouseKeeperClusterMembership;
     use clickhouse_admin_types::KeeperId;
     use expectorate::assert_contents;
     use nexus_inventory::now_db_precision;
@@ -799,7 +800,6 @@ mod test {
     use nexus_types::external_api::views::SledPolicy;
     use nexus_types::external_api::views::SledProvisionPolicy;
     use nexus_types::external_api::views::SledState;
-    use nexus_types::inventory::ClickhouseKeeperClusterMembership;
     use nexus_types::inventory::OmicronZonesFound;
     use omicron_common::api::external::Generation;
     use omicron_common::disk::DiskIdentity;


### PR DESCRIPTION
#6758 moved `ClickhouseKeeperClusterMembership` from `nexus-types` to `clickhouse-admin-types`, but #6627 added new references to the `ClickhouseKeeperClusterMembership` in `nexus-types` earlier.