### PR TITLE
Clickhouse cluster reconfigurator execution

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1300,6 +1300,7 @@ name = "clickhouse-admin-client"
 version = "0.1.0"
 dependencies = [
  "chrono",
+ "clickhouse-admin-api",
  "clickhouse-admin-types",
  "omicron-uuid-kinds",
  "omicron-workspace-hack",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1296,6 +1296,21 @@ dependencies = [
 ]
 
 [[package]]
+name = "clickhouse-admin-client"
+version = "0.1.0"
+dependencies = [
+ "chrono",
+ "clickhouse-admin-types",
+ "omicron-uuid-kinds",
+ "omicron-workspace-hack",
+ "progenitor",
+ "reqwest 0.12.7",
+ "schemars",
+ "serde",
+ "slog",
+]
+
+[[package]]
 name = "clickhouse-admin-types"
 version = "0.1.0"
 dependencies = [
@@ -5711,6 +5726,7 @@ dependencies = [
  "camino",
  "chrono",
  "clickhouse-admin-api",
+ "clickhouse-admin-client",
  "clickhouse-admin-types",
  "cockroach-admin-client",
  "diesel",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5708,7 +5708,10 @@ version = "0.1.0"
 dependencies = [
  "anyhow",
  "async-bb8-diesel",
+ "camino",
  "chrono",
+ "clickhouse-admin-api",
+ "clickhouse-admin-types",
  "cockroach-admin-client",
  "diesel",
  "dns-service-client",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -6,6 +6,7 @@ members = [
     "clickhouse-admin",
     "clickhouse-admin/api",
     "clients/bootstrap-agent-client",
+    "clients/clickhouse-admin-client",
     "clients/cockroach-admin-client",
     "clients/ddm-admin-client",
     "clients/dns-service-client",
@@ -126,6 +127,7 @@ default-members = [
     "clickhouse-admin/api",
     "clickhouse-admin/types",
     "clients/bootstrap-agent-client",
+    "clients/clickhouse-admin-client",
     "clients/cockroach-admin-client",
     "clients/ddm-admin-client",
     "clients/dns-service-client",
@@ -314,6 +316,7 @@ chrono = { version = "0.4", features = [ "serde" ] }
 ciborium = "0.2.2"
 clap = { version = "4.5", features = ["cargo", "derive", "env", "wrap_help"] }
 clickhouse-admin-api = { path = "clickhouse-admin/api" }
+clickhouse-admin-client = { path = "clients/clickhouse-admin-client" }
 clickhouse-admin-types = { path = "clickhouse-admin/types" }
 clickward = { git = "https://github.com/oxidecomputer/clickward", rev = "ceec762e6a87d2a22bf56792a3025e145caa095e" }
 cockroach-admin-api = { path = "cockroach-admin/api" }

--- a/clickhouse-admin/api/src/lib.rs
+++ b/clickhouse-admin/api/src/lib.rs
@@ -21,7 +21,7 @@ pub struct ServerConfigurableSettings {
     pub settings: ServerSettings,
 }
 
-#[derive(Debug, Clone, Serialize, Deserialize, JsonSchema)]
+#[derive(Debug, Serialize, Deserialize, JsonSchema)]
 pub struct KeeperConfigurableSettings {
     /// A unique identifier for the configuration generation.
     pub generation: Generation,

--- a/clickhouse-admin/api/src/lib.rs
+++ b/clickhouse-admin/api/src/lib.rs
@@ -11,9 +11,9 @@ use dropshot::{
 };
 use omicron_common::api::external::Generation;
 use schemars::JsonSchema;
-use serde::Deserialize;
+use serde::{Deserialize, Serialize};
 
-#[derive(Debug, Deserialize, JsonSchema)]
+#[derive(Debug, Serialize, Deserialize, JsonSchema)]
 pub struct ServerConfigurableSettings {
     /// A unique identifier for the configuration generation.
     pub generation: Generation,
@@ -21,7 +21,7 @@ pub struct ServerConfigurableSettings {
     pub settings: ServerSettings,
 }
 
-#[derive(Debug, Deserialize, JsonSchema)]
+#[derive(Debug, Serialize, Deserialize, JsonSchema)]
 pub struct KeeperConfigurableSettings {
     /// A unique identifier for the configuration generation.
     pub generation: Generation,

--- a/clickhouse-admin/api/src/lib.rs
+++ b/clickhouse-admin/api/src/lib.rs
@@ -21,7 +21,7 @@ pub struct ServerConfigurableSettings {
     pub settings: ServerSettings,
 }
 
-#[derive(Debug, Serialize, Deserialize, JsonSchema)]
+#[derive(Debug, Clone, Serialize, Deserialize, JsonSchema)]
 pub struct KeeperConfigurableSettings {
     /// A unique identifier for the configuration generation.
     pub generation: Generation,

--- a/clients/clickhouse-admin-client/Cargo.toml
+++ b/clients/clickhouse-admin-client/Cargo.toml
@@ -6,6 +6,7 @@ edition = "2021"
 [dependencies]
 chrono.workspace = true
 clickhouse-admin-types.workspace = true
+clickhouse-admin-api.workspace = true
 omicron-uuid-kinds.workspace = true
 progenitor.workspace = true
 reqwest = { workspace = true, features = [ "json", "rustls-tls", "stream" ] }

--- a/clients/clickhouse-admin-client/Cargo.toml
+++ b/clients/clickhouse-admin-client/Cargo.toml
@@ -1,0 +1,18 @@
+[package]
+name = "clickhouse-admin-client"
+version = "0.1.0"
+edition = "2021"
+
+[dependencies]
+chrono.workspace = true
+clickhouse-admin-types.workspace = true
+omicron-uuid-kinds.workspace = true
+progenitor.workspace = true
+reqwest = { workspace = true, features = [ "json", "rustls-tls", "stream" ] }
+schemars.workspace = true
+serde.workspace = true
+slog.workspace = true
+omicron-workspace-hack.workspace = true
+
+[lints]
+workspace = true

--- a/clients/clickhouse-admin-client/src/lib.rs
+++ b/clients/clickhouse-admin-client/src/lib.rs
@@ -1,0 +1,25 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at https://mozilla.org/MPL/2.0/.
+
+//! Interface for making API requests to a clickhouse-admin server running in
+//! an omicron zone.
+
+progenitor::generate_api!(
+    spec = "../../openapi/clickhouse-admin.json",
+    inner_type = slog::Logger,
+    pre_hook = (|log: &slog::Logger, request: &reqwest::Request| {
+        slog::debug!(log, "client request";
+            "method" => %request.method(),
+            "uri" => %request.url(),
+            "body" => ?&request.body(),
+        );
+    }),
+    post_hook = (|log: &slog::Logger, result: &Result<_, _>| {
+        slog::debug!(log, "client response"; "result" => ?result);
+    }),
+    derives = [schemars::JsonSchema],
+    replace = {
+        TypedUuidForOmicronZoneKind = omicron_uuid_kinds::OmicronZoneUuid,
+    }
+);

--- a/clients/clickhouse-admin-client/src/lib.rs
+++ b/clients/clickhouse-admin-client/src/lib.rs
@@ -21,5 +21,7 @@ progenitor::generate_api!(
     derives = [schemars::JsonSchema],
     replace = {
         TypedUuidForOmicronZoneKind = omicron_uuid_kinds::OmicronZoneUuid,
+        KeeperConfigurableSettings = clickhouse_admin_api::KeeperConfigurableSettings,
+        ServerConfigurableSettings = clickhouse_admin_api::ServerConfigurableSettings,
     }
 );

--- a/nexus/reconfigurator/execution/Cargo.toml
+++ b/nexus/reconfigurator/execution/Cargo.toml
@@ -13,6 +13,7 @@ omicron-rpaths.workspace = true
 anyhow.workspace = true
 camino.workspace = true
 clickhouse-admin-api.workspace = true
+clickhouse-admin-client.workspace = true
 clickhouse-admin-types.workspace = true
 cockroach-admin-client.workspace = true
 dns-service-client.workspace = true

--- a/nexus/reconfigurator/execution/Cargo.toml
+++ b/nexus/reconfigurator/execution/Cargo.toml
@@ -11,6 +11,9 @@ omicron-rpaths.workspace = true
 
 [dependencies]
 anyhow.workspace = true
+camino.workspace = true
+clickhouse-admin-api.workspace = true
+clickhouse-admin-types.workspace = true
 cockroach-admin-client.workspace = true
 dns-service-client.workspace = true
 chrono.workspace = true

--- a/nexus/reconfigurator/execution/src/clickhouse.rs
+++ b/nexus/reconfigurator/execution/src/clickhouse.rs
@@ -1,0 +1,104 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at https://mozilla.org/MPL/2.0/.
+
+//! Deployment of Clickhouse keeper and server nodes via clickhouse-admin running in
+//! deployed clickhouse zones.
+
+use anyhow::anyhow;
+use anyhow::Context;
+use camino::Utf8PathBuf;
+use clickhouse_admin_api::KeeperConfigurableSettings;
+use clickhouse_admin_types::config::ClickhouseHost;
+use clickhouse_admin_types::config::RaftServerSettings;
+use clickhouse_admin_types::KeeperId;
+use clickhouse_admin_types::KeeperSettings;
+use nexus_db_queries::context::OpContext;
+use nexus_reconfigurator_planning::blueprint_builder::ClickhouseZonesThatShouldBeRunning;
+use nexus_types::deployment::BlueprintZoneConfig;
+use nexus_types::deployment::BlueprintZonesConfig;
+use nexus_types::deployment::ClickhouseClusterConfig;
+use omicron_common::address::CLICKHOUSE_ADMIN_PORT;
+use omicron_common::api::external::Generation;
+use omicron_uuid_kinds::OmicronZoneUuid;
+use omicron_uuid_kinds::SledUuid;
+use std::collections::BTreeMap;
+use std::net::Ipv6Addr;
+use std::str::FromStr;
+
+const CLICKHOUSE_SERVER_CONFIG_DIR: &str =
+    "/opt/oxide/clickhouse_server/config.d";
+const CLICKHOUSE_KEEPER_CONFIG_DIR: &str =
+    "/opt/oxide/clickhouse_keeper/config.d";
+const CLICKHOUSE_DATA_DIR: &str = "/data";
+
+pub(crate) async fn deploy_nodes(
+    opctx: &OpContext,
+    zones: &BTreeMap<SledUuid, BlueprintZonesConfig>,
+    clickhouse_cluster_config: &ClickhouseClusterConfig,
+) -> Result<(), anyhow::Error> {
+    todo!()
+}
+
+fn keeper_configs(
+    zones: &BTreeMap<SledUuid, BlueprintZonesConfig>,
+    clickhouse_cluster_config: &ClickhouseClusterConfig,
+) -> Result<Vec<KeeperConfigurableSettings>, anyhow::Error> {
+    let keeper_ips: BTreeMap<OmicronZoneUuid, Ipv6Addr> = zones
+        .values()
+        .flat_map(|zones_config| {
+            zones_config
+                .zones
+                .iter()
+                .filter(|zone_config| {
+                    clickhouse_cluster_config
+                        .keepers
+                        .contains_key(&zone_config.id)
+                })
+                .cloned()
+                .map(|zone_config| {
+                    (zone_config.id, zone_config.underlay_address)
+                })
+        })
+        .collect();
+
+    let mut raft_servers =
+        Vec::with_capacity(clickhouse_cluster_config.keepers.len());
+
+    for (zone_id, keeper_id) in &clickhouse_cluster_config.keepers {
+        raft_servers.push(RaftServerSettings {
+            id: *keeper_id,
+            host: ClickhouseHost::Ipv6(*keeper_ips.get(zone_id).ok_or_else(
+                || {
+                    anyhow!(
+                        "Failed to retrieve zone {} for keeper id {}",
+                        zone_id,
+                        keeper_id
+                    )
+                },
+            )?),
+        });
+    }
+
+    let mut keeper_configs =
+        Vec::with_capacity(clickhouse_cluster_config.keepers.len());
+
+    for (zone_id, keeper_id) in &clickhouse_cluster_config.keepers {
+        keeper_configs.push(KeeperConfigurableSettings {
+            generation: clickhouse_cluster_config.generation,
+            settings: KeeperSettings {
+                config_dir: Utf8PathBuf::from_str(CLICKHOUSE_KEEPER_CONFIG_DIR)
+                    .unwrap(),
+                id: *keeper_id,
+                raft_servers: raft_servers.clone(),
+                datastore_path: Utf8PathBuf::from_str(CLICKHOUSE_DATA_DIR)
+                    .unwrap(),
+                // SAFETY: We already successfully performed the same lookup to compute
+                // `raft_servers` above.
+                listen_addr: *keeper_ips.get(zone_id).unwrap(),
+            },
+        });
+    }
+
+    Ok(keeper_configs)
+}

--- a/nexus/reconfigurator/execution/src/clickhouse.rs
+++ b/nexus/reconfigurator/execution/src/clickhouse.rs
@@ -21,6 +21,7 @@ use omicron_common::address::CLICKHOUSE_ADMIN_PORT;
 use omicron_uuid_kinds::OmicronZoneUuid;
 use omicron_uuid_kinds::SledUuid;
 use slog::error;
+use slog::info;
 use slog::warn;
 use std::collections::BTreeMap;
 use std::net::Ipv6Addr;
@@ -136,6 +137,11 @@ pub(crate) async fn deploy_nodes(
     if !errors.is_empty() {
         return Err(errors);
     }
+
+    info!(
+        opctx.log,
+        "Successfully deployed all clickhouse server and keeper configs"
+    );
 
     Ok(())
 }

--- a/nexus/reconfigurator/execution/src/clickhouse.rs
+++ b/nexus/reconfigurator/execution/src/clickhouse.rs
@@ -34,8 +34,7 @@ use std::str::FromStr;
 
 const CLICKHOUSE_SERVER_CONFIG_DIR: &str =
     "/opt/oxide/clickhouse_server/config.d";
-const CLICKHOUSE_KEEPER_CONFIG_DIR: &str =
-    "/opt/oxide/clickhouse_keeper/config.d";
+const CLICKHOUSE_KEEPER_CONFIG_DIR: &str = "/opt/oxide/clickhouse_keeper";
 const CLICKHOUSE_DATA_DIR: &str = "/data";
 
 pub(crate) async fn deploy_nodes(

--- a/nexus/reconfigurator/execution/src/clickhouse.rs
+++ b/nexus/reconfigurator/execution/src/clickhouse.rs
@@ -410,7 +410,7 @@ mod test {
                     panic!("bad host");
                 };
                 keeper_ips_last_octet_as_keeper_id
-                    .insert(KeeperId(*ip.octets().last().unwrap() as u64));
+                    .insert(KeeperId(u64::from(*ip.octets().last().unwrap())));
             }
         }
         assert_eq!(keeper_ids, expected_keeper_ids);
@@ -449,7 +449,7 @@ mod test {
                     panic!("bad host");
                 };
                 keeper_ips_last_octet_as_keeper_id
-                    .insert(KeeperId(*ip.octets().last().unwrap() as u64));
+                    .insert(KeeperId(u64::from(*ip.octets().last().unwrap())));
             }
             assert_eq!(keeper_ips_last_octet_as_keeper_id, expected_keeper_ids);
 

--- a/nexus/reconfigurator/execution/src/clickhouse.rs
+++ b/nexus/reconfigurator/execution/src/clickhouse.rs
@@ -3,7 +3,7 @@
 // file, You can obtain one at https://mozilla.org/MPL/2.0/.
 
 //! Deployment of Clickhouse keeper and server nodes via clickhouse-admin running in
-//! deployed omicron zones.
+//! deployed clickhouse zones.
 
 use anyhow::anyhow;
 use camino::Utf8PathBuf;

--- a/nexus/reconfigurator/execution/src/clickhouse.rs
+++ b/nexus/reconfigurator/execution/src/clickhouse.rs
@@ -93,10 +93,7 @@ pub(crate) async fn deploy_nodes(
         let log = log.new(slog::o!("admin_url" => admin_url.clone()));
         futs.push(Either::Left(async move {
             let client = Client::new(&admin_url, log.clone());
-            let res = client
-                .generate_keeper_config(&config.clone())
-                .await
-                .map(|_| ());
+            let res = client.generate_keeper_config(&config).await.map(|_| ());
             (res, config.settings.id.0, admin_url)
         }));
     }

--- a/nexus/reconfigurator/execution/src/lib.rs
+++ b/nexus/reconfigurator/execution/src/lib.rs
@@ -207,6 +207,12 @@ pub async fn realize_blueprint_with_overrides(
         deploy_disks_done,
     );
 
+    register_deploy_clickhouse_cluster_nodes_step(
+        &engine.for_component(ExecutionComponent::Clickhouse),
+        &opctx,
+        blueprint,
+    );
+
     let reassign_saga_output = register_reassign_sagas_step(
         &engine.for_component(ExecutionComponent::OmicronZones),
         &opctx,
@@ -513,6 +519,34 @@ fn register_decommission_expunged_disks_step<'a>(
                 )
                 .await
                 .map_err(merge_anyhow_list)?;
+
+                StepSuccess::new(()).into()
+            },
+        )
+        .register();
+}
+
+fn register_deploy_clickhouse_cluster_nodes_step<'a>(
+    registrar: &ComponentRegistrar<'_, 'a>,
+    opctx: &'a OpContext,
+    blueprint: &'a Blueprint,
+) {
+    registrar
+        .new_step(
+            ExecutionStepId::Ensure,
+            "Deploy clickhouse cluster nodes",
+            move |_cx| async move {
+                if let Some(clickhouse_cluster_config) =
+                    &blueprint.clickhouse_cluster_config
+                {
+                    clickhouse::deploy_nodes(
+                        &opctx,
+                        &blueprint.blueprint_zones,
+                        &clickhouse_cluster_config,
+                    )
+                    .await
+                    .map_err(merge_anyhow_list)?;
+                }
 
                 StepSuccess::new(()).into()
             },

--- a/nexus/reconfigurator/execution/src/lib.rs
+++ b/nexus/reconfigurator/execution/src/lib.rs
@@ -31,6 +31,7 @@ use std::sync::Arc;
 use tokio::sync::mpsc;
 use update_engine::merge_anyhow_list;
 
+mod clickhouse;
 mod cockroachdb;
 mod datasets;
 mod dns;

--- a/nexus/types/src/deployment/execution.rs
+++ b/nexus/types/src/deployment/execution.rs
@@ -35,6 +35,7 @@ pub enum ExecutionComponent {
     DatasetRecords,
     Dns,
     Cockroach,
+    Clickhouse,
 }
 
 /// Steps for reconfigurator execution.


### PR DESCRIPTION
 Create a clickhouse-admin-client and use it in reconfigurator execution for clickhouse keepers and servers.

Note that since the policy is disabled, there won't be a `Some(clickhouse_cluster_config)` in the blueprint and the execution will be skipped.