### PR TITLE
Fix IP address create on Internet Gateway

### DIFF
--- a/nexus/external-api/src/lib.rs
+++ b/nexus/external-api/src/lib.rs
@@ -2313,7 +2313,7 @@ pub trait NexusExternalApi {
         HttpError,
     >;
 
-    /// Attach IP pool to internet gateway
+    /// Attach IP address to internet gateway
     #[endpoint {
         method = POST,
         path = "/v1/internet-gateway-ip-addresses",
@@ -2325,7 +2325,7 @@ pub trait NexusExternalApi {
         create_params: TypedBody<params::InternetGatewayIpAddressCreate>,
     ) -> Result<HttpResponseCreated<views::InternetGatewayIpAddress>, HttpError>;
 
-    /// Detach IP pool from internet gateway
+    /// Detach IP address from internet gateway
     #[endpoint {
         method = DELETE,
         path = "/v1/internet-gateway-ip-addresses/{address}",

--- a/nexus/test-utils/src/resource_helpers.rs
+++ b/nexus/test-utils/src/resource_helpers.rs
@@ -861,7 +861,6 @@ pub async fn attach_ip_address_to_igw(
         project_name, vpc_name, igw_name,
     );
 
-    let gateway: Name = igw_name.parse().unwrap();
     NexusRequest::objects_post(
         &client,
         url.as_str(),
@@ -870,7 +869,6 @@ pub async fn attach_ip_address_to_igw(
                 name: attachment_name.parse().unwrap(),
                 description: String::from("attached pool descriptoion"),
             },
-            gateway: NameOrId::Name(gateway),
             address,
         },
     )

--- a/nexus/tests/integration_tests/endpoints.rs
+++ b/nexus/tests/integration_tests/endpoints.rs
@@ -291,7 +291,6 @@ pub static DEMO_INTERNET_GATEWAY_IP_ADDRESS_CREATE: Lazy<
         name: DEMO_INTERNET_GATEWAY_NAME.clone(),
         description: String::from(""),
     },
-    gateway: NameOrId::Id(uuid::Uuid::new_v4()),
     address: IpAddr::V4(Ipv4Addr::UNSPECIFIED),
 });
 pub static DEMO_INTERNET_GATEWAY_IP_POOLS_URL: Lazy<String> = Lazy::new(|| {

--- a/nexus/types/src/external_api/params.rs
+++ b/nexus/types/src/external_api/params.rs
@@ -1394,7 +1394,6 @@ pub struct InternetGatewayIpPoolCreate {
 pub struct InternetGatewayIpAddressCreate {
     #[serde(flatten)]
     pub identity: IdentityMetadataCreateParams,
-    pub gateway: NameOrId,
     pub address: IpAddr,
 }
 

--- a/openapi/nexus.json
+++ b/openapi/nexus.json
@@ -2764,7 +2764,7 @@
         "tags": [
           "vpcs"
         ],
-        "summary": "Attach IP pool to internet gateway",
+        "summary": "Attach IP address to internet gateway",
         "operationId": "internet_gateway_ip_address_create",
         "parameters": [
           {
@@ -2828,7 +2828,7 @@
         "tags": [
           "vpcs"
         ],
-        "summary": "Detach IP pool from internet gateway",
+        "summary": "Detach IP address from internet gateway",
         "operationId": "internet_gateway_ip_address_delete",
         "parameters": [
           {
@@ -16619,9 +16619,6 @@
           "description": {
             "type": "string"
           },
-          "gateway": {
-            "$ref": "#/components/schemas/NameOrId"
-          },
           "name": {
             "$ref": "#/components/schemas/Name"
           }
@@ -16629,7 +16626,6 @@
         "required": [
           "address",
           "description",
-          "gateway",
           "name"
         ]
       },


### PR DESCRIPTION
During testing we observed an issue with IGW pool linking on the CLI where the error 'gateway was not initialized' cropped up. As it turns out, this was down to a duplicated (and unnecessary) gateway parameter in both the query string and the request body.

We had missed this on IP address create for individual IP address creation/linking. This PR quickly removes this parameter from `InternetGatewayIpAddressCreate`, and fixes some copy-paste description mismatches for the same APIs.