### PR TITLE
[easy] removed unused bootstrap-agent-api -> nexus-client dependency

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -877,7 +877,6 @@ name = "bootstrap-agent-api"
 version = "0.1.0"
 dependencies = [
  "dropshot",
- "nexus-client",
  "omicron-common",
  "omicron-uuid-kinds",
  "omicron-workspace-hack",

--- a/sled-agent/bootstrap-agent-api/Cargo.toml
+++ b/sled-agent/bootstrap-agent-api/Cargo.toml
@@ -9,7 +9,6 @@ workspace = true
 
 [dependencies]
 dropshot.workspace = true
-nexus-client.workspace = true
 omicron-common.workspace = true
 omicron-uuid-kinds.workspace = true
 omicron-workspace-hack.workspace = true


### PR DESCRIPTION
I think this dependency went away as part of moving Omicron over to Dropshot
API traits.
