### PR TITLE
add expectorate tests to manage changes to API dependencies

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -6511,11 +6511,14 @@ dependencies = [
  "camino",
  "cargo_metadata",
  "clap",
+ "expectorate",
  "newtype_derive",
+ "omicron-test-utils",
  "omicron-workspace-hack",
  "parse-display",
  "petgraph",
  "serde",
+ "subprocess",
  "toml 0.8.19",
 ]
 

--- a/dev-tools/ls-apis/Cargo.toml
+++ b/dev-tools/ls-apis/Cargo.toml
@@ -18,3 +18,8 @@ petgraph.workspace = true
 serde.workspace = true
 toml.workspace = true
 omicron-workspace-hack.workspace = true
+
+[dev-dependencies]
+expectorate.workspace = true
+omicron-test-utils.workspace = true
+subprocess.workspace = true

--- a/dev-tools/ls-apis/api-manifest.toml
+++ b/dev-tools/ls-apis/api-manifest.toml
@@ -139,6 +139,15 @@ label = "Bootstrap Agent"
 server_package_name = "bootstrap-agent-api"
 
 [[apis]]
+client_package_name = "clickhouse-admin-client"
+label = "Clickhouse Cluster Admin"
+server_package_name = "clickhouse-admin-api"
+notes = """
+This is the server running inside multi-node Clickhouse zones that's \
+responsible for local configuration and monitoring.
+"""
+
+[[apis]]
 client_package_name = "cockroach-admin-client"
 label = "CockroachDB Cluster Admin"
 server_package_name = "cockroach-admin-api"

--- a/dev-tools/ls-apis/src/system_apis.rs
+++ b/dev-tools/ls-apis/src/system_apis.rs
@@ -67,9 +67,17 @@ impl SystemApis {
         // Load Cargo metadata and validate it against the manifest.
         let (workspaces, warnings) = Workspaces::load(&api_metadata)?;
         if !warnings.is_empty() {
+            // We treat these warnings as fatal here.
             for e in warnings {
-                eprintln!("warning: {:#}", e);
+                eprintln!("error: {:#}", e);
             }
+
+            bail!(
+                "found inconsistency between API manifest ({}) and \
+                 information found from the Cargo dependency tree \
+                 (see above)",
+                &args.api_manifest_path
+            );
         }
 
         // Create an index of server package names, mapping each one to the API
@@ -428,6 +436,22 @@ impl<'a> ServerComponentsTracker<'a> {
         // "dependency_filter_rules" metadata.
         if **server_pkgname == "crucible-pantry"
             && *api.client_package_name == "crucible-control-client"
+        {
+            eprintln!(
+                "note: ignoring Cargo dependency from crucible-pantry -> \
+                 ... -> crucible-control-client",
+            );
+            return;
+        }
+
+        // TODO Work around omicron#6829.
+        // Through the dependency tree, omicron-nexus appears to export the
+        // clickhouse-admin-api, but it doesn't really.
+        // This is just like the Crucible Pantry one above in that we can't
+        // build our data model unless we ignore it so we have to hardcode this
+        // here rather than use "dependency_filter_rules".
+        if **server_pkgname == "omicron-nexus"
+            && *api.client_package_name == "clickhouse-admin-client"
         {
             eprintln!(
                 "note: ignoring Cargo dependency from crucible-pantry -> \

--- a/dev-tools/ls-apis/src/workspaces.rs
+++ b/dev-tools/ls-apis/src/workspaces.rs
@@ -28,7 +28,7 @@ impl Workspaces {
     /// The data found is validated against `api_metadata`.
     ///
     /// On success, returns `(workspaces, warnings)`, where `warnings` is a list
-    /// of potential inconsistencies between API metadata and Cargo metadata.
+    /// of inconsistencies between API metadata and Cargo metadata.
     pub fn load(
         api_metadata: &AllApiMetadata,
     ) -> Result<(Workspaces, Vec<anyhow::Error>)> {
@@ -114,8 +114,8 @@ impl Workspaces {
                     client_pkgnames_unused.remove(client_pkgname);
                 } else {
                     warnings.push(anyhow!(
-                        "workspace {}: found client package missing from API \
-                         manifest: {}",
+                        "workspace {}: found Progenitor-based client package \
+                         missing from API manifest: {}",
                         workspace.name(),
                         client_pkgname
                     ));

--- a/dev-tools/ls-apis/tests/api_dependencies.out
+++ b/dev-tools/ls-apis/tests/api_dependencies.out
@@ -1,0 +1,77 @@
+Bootstrap Agent (client: bootstrap-agent-client)
+    consumed by: omicron-sled-agent (omicron/sled-agent)
+    consumed by: wicketd (omicron/wicketd)
+
+Clickhouse Cluster Admin (client: clickhouse-admin-client)
+    consumed by: omicron-nexus (omicron/nexus)
+
+CockroachDB Cluster Admin (client: cockroach-admin-client)
+    consumed by: omicron-nexus (omicron/nexus)
+
+Crucible Agent (client: crucible-agent-client)
+    consumed by: omicron-nexus (omicron/nexus)
+
+Crucible Control (for testing only) (client: crucible-control-client)
+
+Crucible Pantry (client: crucible-pantry-client)
+    consumed by: omicron-nexus (omicron/nexus)
+
+Maghemite DDM Admin (client: ddm-admin-client)
+    consumed by: installinator (omicron/installinator)
+    consumed by: mgd (maghemite/mgd)
+    consumed by: omicron-sled-agent (omicron/sled-agent)
+    consumed by: wicketd (omicron/wicketd)
+
+DNS Server (client: dns-service-client)
+    consumed by: omicron-nexus (omicron/nexus)
+    consumed by: omicron-sled-agent (omicron/sled-agent)
+
+Dendrite DPD (client: dpd-client)
+    consumed by: ddmd (maghemite/ddmd)
+    consumed by: mgd (maghemite/mgd)
+    consumed by: omicron-nexus (omicron/nexus)
+    consumed by: omicron-sled-agent (omicron/sled-agent)
+    consumed by: tfportd (dendrite/tfportd)
+    consumed by: wicketd (omicron/wicketd)
+
+Downstairs Controller (debugging only) (client: dsc-client)
+
+Management Gateway Service (client: gateway-client)
+    consumed by: dpd (dendrite/dpd)
+    consumed by: omicron-nexus (omicron/nexus)
+    consumed by: omicron-sled-agent (omicron/sled-agent)
+    consumed by: wicketd (omicron/wicketd)
+
+Wicketd Installinator (client: installinator-client)
+    consumed by: installinator (omicron/installinator)
+
+Maghemite MG Admin (client: mg-admin-client)
+    consumed by: omicron-nexus (omicron/nexus)
+    consumed by: omicron-sled-agent (omicron/sled-agent)
+
+Nexus Internal API (client: nexus-client)
+    consumed by: dpd (dendrite/dpd)
+    consumed by: omicron-nexus (omicron/nexus)
+    consumed by: omicron-sled-agent (omicron/sled-agent)
+    consumed by: oximeter-collector (omicron/oximeter/collector)
+    consumed by: propolis-server (propolis/bin/propolis-server)
+
+External API (client: oxide-client)
+
+Oximeter (client: oximeter-client)
+    consumed by: omicron-nexus (omicron/nexus)
+
+Propolis (client: propolis-client)
+    consumed by: omicron-nexus (omicron/nexus)
+    consumed by: omicron-sled-agent (omicron/sled-agent)
+
+Crucible Repair (client: repair-client)
+    consumed by: crucible-downstairs (crucible/downstairs)
+
+Sled Agent (client: sled-agent-client)
+    consumed by: dpd (dendrite/dpd)
+    consumed by: omicron-nexus (omicron/nexus)
+    consumed by: omicron-sled-agent (omicron/sled-agent)
+
+Wicketd (client: wicketd-client)
+

--- a/dev-tools/ls-apis/tests/test_dependencies.rs
+++ b/dev-tools/ls-apis/tests/test_dependencies.rs
@@ -1,0 +1,29 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at https://mozilla.org/MPL/2.0/.
+
+//! The tests here are intended help us catch cases where we're introducing new
+//! API dependencies, and particular circular API dependencies.  It's okay if
+//! API dependencies change, but it's important to make sure we're not
+//! introducing new barriers to online upgrade.
+//!
+//! This isn't (supposed to be) a test for the `ls-apis` tool itself.
+
+use omicron_test_utils::dev::test_cmds::assert_exit_code;
+use omicron_test_utils::dev::test_cmds::path_to_executable;
+use omicron_test_utils::dev::test_cmds::run_command;
+use omicron_test_utils::dev::test_cmds::EXIT_SUCCESS;
+
+/// name of the "ls-apis" executable
+const CMD_LS_APIS: &str = env!("CARGO_BIN_EXE_ls-apis");
+
+#[test]
+fn test_api_dependencies() {
+    let cmd_path = path_to_executable(CMD_LS_APIS);
+    let exec = subprocess::Exec::cmd(cmd_path).arg("apis");
+    let (exit_status, stdout_text, stderr_text) = run_command(exec);
+    assert_exit_code(exit_status, EXIT_SUCCESS, &stderr_text);
+
+    println!("stderr:\n------\n{}\n-----", stderr_text);
+    expectorate::assert_contents("tests/api_dependencies.out", &stdout_text);
+}


### PR DESCRIPTION
Depends on #6830.

This might be overly aggressive but we can always relax it or remove it if so.