### PR TITLE
[reconfigurator] Add planner support for starting new Crucible pantries

### DIFF
--- a/common/src/policy.rs
+++ b/common/src/policy.rs
@@ -25,6 +25,12 @@ pub const OXIMETER_REDUNDANCY: usize = 1;
 /// Reconfigurator (to know whether to add new crdb zones)
 pub const COCKROACHDB_REDUNDANCY: usize = 5;
 
+/// The amount of redundancy for Crucible Pantry services.
+///
+/// This is used by both RSS (to distribute the initial set of services) and the
+/// Reconfigurator (to know whether to add new pantry zones)
+pub const CRUCIBLE_PANTRY_REDUNDANCY: usize = 3;
+
 /// The amount of redundancy for internal DNS servers.
 ///
 /// Must be less than or equal to RESERVED_INTERNAL_DNS_REDUNDANCY.

--- a/nexus/reconfigurator/execution/src/dns.rs
+++ b/nexus/reconfigurator/execution/src/dns.rs
@@ -363,6 +363,7 @@ mod test {
     use omicron_common::api::external::IdentityMetadataCreateParams;
     use omicron_common::policy::BOUNDARY_NTP_REDUNDANCY;
     use omicron_common::policy::COCKROACHDB_REDUNDANCY;
+    use omicron_common::policy::CRUCIBLE_PANTRY_REDUNDANCY;
     use omicron_common::policy::INTERNAL_DNS_REDUNDANCY;
     use omicron_common::policy::NEXUS_REDUNDANCY;
     use omicron_common::policy::OXIMETER_REDUNDANCY;
@@ -1376,6 +1377,7 @@ mod test {
                 target_cockroachdb_zone_count: COCKROACHDB_REDUNDANCY,
                 target_cockroachdb_cluster_version:
                     CockroachDbClusterVersion::POLICY,
+                target_crucible_pantry_zone_count: CRUCIBLE_PANTRY_REDUNDANCY,
                 log,
             }
             .build()

--- a/nexus/reconfigurator/planning/src/blueprint_builder/builder.rs
+++ b/nexus/reconfigurator/planning/src/blueprint_builder/builder.rs
@@ -1193,6 +1193,51 @@ impl<'a> BlueprintBuilder<'a> {
         Ok(EnsureMultiple::Changed { added: num_oximeter_to_add, removed: 0 })
     }
 
+    pub fn sled_ensure_zone_multiple_crucible_pantry(
+        &mut self,
+        sled_id: SledUuid,
+        desired_zone_count: usize,
+    ) -> Result<EnsureMultiple, Error> {
+        // How many zones do we need to add?
+        let pantry_count = self
+            .sled_num_running_zones_of_kind(sled_id, ZoneKind::CruciblePantry);
+        let num_pantry_to_add =
+            match desired_zone_count.checked_sub(pantry_count) {
+                Some(0) => return Ok(EnsureMultiple::NotNeeded),
+                Some(n) => n,
+                None => {
+                    return Err(Error::Planner(anyhow!(
+                        "removing a Crucible pantry zone not yet supported \
+                         (sled {sled_id} has {pantry_count}; \
+                         planner wants {desired_zone_count})"
+                    )));
+                }
+            };
+
+        for _ in 0..num_pantry_to_add {
+            let pantry_id = self.rng.zone_rng.next();
+            let ip = self.sled_alloc_ip(sled_id)?;
+            let port = omicron_common::address::CRUCIBLE_PANTRY_PORT;
+            let address = SocketAddrV6::new(ip, port, 0, 0);
+            let zone_type = BlueprintZoneType::CruciblePantry(
+                blueprint_zone_type::CruciblePantry { address },
+            );
+            let filesystem_pool =
+                self.sled_select_zpool(sled_id, zone_type.kind())?;
+
+            let zone = BlueprintZoneConfig {
+                disposition: BlueprintZoneDisposition::InService,
+                id: pantry_id,
+                underlay_address: ip,
+                filesystem_pool: Some(filesystem_pool),
+                zone_type,
+            };
+            self.sled_add_zone(sled_id, zone)?;
+        }
+
+        Ok(EnsureMultiple::Changed { added: num_pantry_to_add, removed: 0 })
+    }
+
     pub fn cockroachdb_preserve_downgrade(
         &mut self,
         version: CockroachDbPreserveDowngrade,

--- a/nexus/reconfigurator/planning/src/example.rs
+++ b/nexus/reconfigurator/planning/src/example.rs
@@ -16,6 +16,7 @@ use nexus_types::deployment::OmicronZoneNic;
 use nexus_types::deployment::PlanningInput;
 use nexus_types::deployment::SledFilter;
 use nexus_types::inventory::Collection;
+use omicron_common::policy::CRUCIBLE_PANTRY_REDUNDANCY;
 use omicron_common::policy::INTERNAL_DNS_REDUNDANCY;
 use omicron_uuid_kinds::GenericUuid;
 use omicron_uuid_kinds::SledKind;
@@ -62,6 +63,7 @@ pub struct ExampleSystemBuilder {
     nexus_count: Option<ZoneCount>,
     internal_dns_count: ZoneCount,
     external_dns_count: ZoneCount,
+    crucible_pantry_count: ZoneCount,
     create_zones: bool,
     create_disks_in_blueprint: bool,
 }
@@ -85,6 +87,7 @@ impl ExampleSystemBuilder {
             nexus_count: None,
             internal_dns_count: ZoneCount(INTERNAL_DNS_REDUNDANCY),
             external_dns_count: ZoneCount(Self::DEFAULT_EXTERNAL_DNS_COUNT),
+            crucible_pantry_count: ZoneCount(CRUCIBLE_PANTRY_REDUNDANCY),
             create_zones: true,
             create_disks_in_blueprint: true,
         }
@@ -163,6 +166,17 @@ impl ExampleSystemBuilder {
         Ok(self)
     }
 
+    /// Set the number of Crucible pantry instances in the example system.
+    ///
+    /// If [`Self::create_zones`] is set to `false`, this is ignored.
+    pub fn crucible_pantry_count(
+        mut self,
+        crucible_pantry_count: usize,
+    ) -> Self {
+        self.crucible_pantry_count = ZoneCount(crucible_pantry_count);
+        self
+    }
+
     /// Create zones in the example system.
     ///
     /// The default is `true`.
@@ -200,6 +214,7 @@ impl ExampleSystemBuilder {
             "nexus_count" => nexus_count.0,
             "internal_dns_count" => self.internal_dns_count.0,
             "external_dns_count" => self.external_dns_count.0,
+            "crucible_pantry_count" => self.crucible_pantry_count.0,
             "create_zones" => self.create_zones,
             "create_disks_in_blueprint" => self.create_disks_in_blueprint,
         );
@@ -209,7 +224,8 @@ impl ExampleSystemBuilder {
         // there's no external DNS count.)
         system
             .target_nexus_zone_count(nexus_count.0)
-            .target_internal_dns_zone_count(self.internal_dns_count.0);
+            .target_internal_dns_zone_count(self.internal_dns_count.0)
+            .target_crucible_pantry_zone_count(self.crucible_pantry_count.0);
         let mut sled_rng =
             TypedUuidRng::from_seed(&self.test_name, "ExampleSystem");
         let sled_ids: Vec<_> =
@@ -299,6 +315,12 @@ impl ExampleSystemBuilder {
                     .sled_ensure_zone_multiple_external_dns(
                         sled_id,
                         self.external_dns_count.on(i, self.nsleds),
+                    )
+                    .unwrap();
+                let _ = builder
+                    .sled_ensure_zone_multiple_crucible_pantry(
+                        sled_id,
+                        self.crucible_pantry_count.on(i, self.nsleds),
                     )
                     .unwrap();
             }
@@ -427,6 +449,7 @@ mod tests {
             ExampleSystemBuilder::new(&logctx.log, TEST_NAME)
                 .nsleds(5)
                 .nexus_count(6)
+                .crucible_pantry_count(5)
                 .internal_dns_count(2)
                 .unwrap()
                 .external_dns_count(10)
@@ -445,9 +468,10 @@ mod tests {
         // Check that the system's target counts are set correctly.
         assert_eq!(example.system.get_target_nexus_zone_count(), 6);
         assert_eq!(example.system.get_target_internal_dns_zone_count(), 2);
+        assert_eq!(example.system.get_target_crucible_pantry_zone_count(), 5);
 
-        // Check that the right number of internal and external DNS zones are
-        // present in both the blueprint and in the collection.
+        // Check that the right number of zones are present in both the
+        // blueprint and in the collection.
         let nexus_zones = blueprint_zones_of_kind(&blueprint, ZoneKind::Nexus);
         assert_eq!(
             nexus_zones.len(),
@@ -506,6 +530,27 @@ mod tests {
             "expected 10 external DNS zones in collection, got {}: {:#?}",
             external_dns_zones.len(),
             external_dns_zones,
+        );
+
+        let crucible_pantry_zones =
+            blueprint_zones_of_kind(&blueprint, ZoneKind::CruciblePantry);
+        assert_eq!(
+            crucible_pantry_zones.len(),
+            5,
+            "expected 5 Crucible pantry zones in blueprint, got {}: {:#?}",
+            crucible_pantry_zones.len(),
+            crucible_pantry_zones,
+        );
+        let crucible_pantry_zones = collection_zones_of_kind(
+            &example.collection,
+            ZoneKind::CruciblePantry,
+        );
+        assert_eq!(
+            crucible_pantry_zones.len(),
+            5,
+            "expected 5 Crucible pantry zones in collection, got {}: {:#?}",
+            crucible_pantry_zones.len(),
+            crucible_pantry_zones,
         );
 
         logctx.cleanup_successful();

--- a/nexus/reconfigurator/planning/src/planner.rs
+++ b/nexus/reconfigurator/planning/src/planner.rs
@@ -447,6 +447,9 @@ impl<'a> Planner<'a> {
             DiscretionaryOmicronZone::CockroachDb => {
                 self.input.target_cockroachdb_zone_count()
             }
+            DiscretionaryOmicronZone::CruciblePantry => {
+                self.input.target_crucible_pantry_zone_count()
+            }
             DiscretionaryOmicronZone::InternalDns => {
                 self.input.target_internal_dns_zone_count()
             }
@@ -557,6 +560,9 @@ impl<'a> Planner<'a> {
                         sled_id,
                         new_total_zone_count,
                     )?
+                }
+                DiscretionaryOmicronZone::CruciblePantry => {
+                    todo!("add {additional_zone_count} pantries")
                 }
                 DiscretionaryOmicronZone::InternalDns => {
                     self.blueprint.sled_ensure_zone_multiple_internal_dns(

--- a/nexus/reconfigurator/planning/src/planner/omicron_zone_placement.rs
+++ b/nexus/reconfigurator/planning/src/planner/omicron_zone_placement.rs
@@ -19,11 +19,11 @@ pub(crate) enum DiscretionaryOmicronZone {
     ClickhouseKeeper,
     ClickhouseServer,
     CockroachDb,
+    CruciblePantry,
     InternalDns,
     ExternalDns,
     Nexus,
     Oximeter,
-    // TODO expand this enum as we start to place more services
 }
 
 impl DiscretionaryOmicronZone {
@@ -40,16 +40,15 @@ impl DiscretionaryOmicronZone {
                 Some(Self::ClickhouseServer)
             }
             BlueprintZoneType::CockroachDb(_) => Some(Self::CockroachDb),
+            BlueprintZoneType::CruciblePantry(_) => Some(Self::CruciblePantry),
             BlueprintZoneType::InternalDns(_) => Some(Self::InternalDns),
             BlueprintZoneType::ExternalDns(_) => Some(Self::ExternalDns),
             BlueprintZoneType::Nexus(_) => Some(Self::Nexus),
             BlueprintZoneType::Oximeter(_) => Some(Self::Oximeter),
-            // Zones that we should place but don't yet.
-            | BlueprintZoneType::CruciblePantry(_)
             // Zones that get special handling for placement (all sleds get
             // them, although internal NTP has some interactions with boundary
             // NTP that are handled separately).
-            | BlueprintZoneType::Crucible(_)
+            BlueprintZoneType::Crucible(_)
             | BlueprintZoneType::InternalNtp(_) => None,
         }
     }
@@ -67,6 +66,7 @@ impl From<DiscretionaryOmicronZone> for ZoneKind {
                 Self::ClickhouseServer
             }
             DiscretionaryOmicronZone::CockroachDb => Self::CockroachDb,
+            DiscretionaryOmicronZone::CruciblePantry => Self::CruciblePantry,
             DiscretionaryOmicronZone::InternalDns => Self::InternalDns,
             DiscretionaryOmicronZone::ExternalDns => Self::ExternalDns,
             DiscretionaryOmicronZone::Nexus => Self::Nexus,

--- a/nexus/reconfigurator/planning/src/system.rs
+++ b/nexus/reconfigurator/planning/src/system.rs
@@ -86,6 +86,7 @@ pub struct SystemDescription {
     target_oximeter_zone_count: usize,
     target_cockroachdb_zone_count: usize,
     target_cockroachdb_cluster_version: CockroachDbClusterVersion,
+    target_crucible_pantry_zone_count: usize,
     service_ip_pool_ranges: Vec<IpRange>,
     internal_dns_version: Generation,
     external_dns_version: Generation,
@@ -143,6 +144,7 @@ impl SystemDescription {
         let target_boundary_ntp_zone_count = 0;
         let target_cockroachdb_zone_count = 0;
         let target_oximeter_zone_count = 0;
+        let target_crucible_pantry_zone_count = 0;
 
         let target_cockroachdb_cluster_version =
             CockroachDbClusterVersion::POLICY;
@@ -166,6 +168,7 @@ impl SystemDescription {
             target_oximeter_zone_count,
             target_cockroachdb_zone_count,
             target_cockroachdb_cluster_version,
+            target_crucible_pantry_zone_count,
             service_ip_pool_ranges,
             internal_dns_version: Generation::new(),
             external_dns_version: Generation::new(),
@@ -367,6 +370,8 @@ impl SystemDescription {
             target_cockroachdb_zone_count: self.target_cockroachdb_zone_count,
             target_cockroachdb_cluster_version: self
                 .target_cockroachdb_cluster_version,
+            target_crucible_pantry_zone_count: self
+                .target_crucible_pantry_zone_count,
             clickhouse_policy: self.clickhouse_policy.clone(),
         };
         let mut builder = PlanningInputBuilder::new(

--- a/nexus/reconfigurator/planning/src/system.rs
+++ b/nexus/reconfigurator/planning/src/system.rs
@@ -214,6 +214,18 @@ impl SystemDescription {
         self.target_nexus_zone_count
     }
 
+    pub fn target_crucible_pantry_zone_count(
+        &mut self,
+        count: usize,
+    ) -> &mut Self {
+        self.target_crucible_pantry_zone_count = count;
+        self
+    }
+
+    pub fn get_target_crucible_pantry_zone_count(&self) -> usize {
+        self.target_crucible_pantry_zone_count
+    }
+
     pub fn target_internal_dns_zone_count(
         &mut self,
         count: usize,

--- a/nexus/reconfigurator/planning/tests/output/blueprint_builder_initial_diff.txt
+++ b/nexus/reconfigurator/planning/tests/output/blueprint_builder_initial_diff.txt
@@ -21,23 +21,24 @@ to:   blueprint  e4aeb3b3-272f-4967-be34-2d34daa46aa1
 
 
     omicron zones at generation 2:
-    ------------------------------------------------------------------------------------------
-    zone type      zone id                                disposition   underlay IP           
-    ------------------------------------------------------------------------------------------
-    clickhouse     44afce85-3377-4b20-a398-517c1579df4d   in service    fd00:1122:3344:103::23
-    crucible       38b047ea-e3de-4859-b8e0-70cac5871446   in service    fd00:1122:3344:103::2c
-    crucible       4644ea0c-0ec3-41be-a356-660308e1c3fc   in service    fd00:1122:3344:103::2b
-    crucible       55f4d117-0b9d-4256-a2c0-f46d3ed5fff9   in service    fd00:1122:3344:103::24
-    crucible       5c6a4628-8831-483b-995f-79b9126c4d04   in service    fd00:1122:3344:103::27
-    crucible       6a01210c-45ed-41a5-9230-8e05ecf5dd8f   in service    fd00:1122:3344:103::28
-    crucible       79552859-fbd3-43bb-a9d3-6baba25558f8   in service    fd00:1122:3344:103::25
-    crucible       90696819-9b53-485a-9c65-ca63602e843e   in service    fd00:1122:3344:103::26
-    crucible       c99525b3-3680-4df6-9214-2ee3e1020e8b   in service    fd00:1122:3344:103::29
-    crucible       f42959d3-9eef-4e3b-b404-6177ce3ec7a1   in service    fd00:1122:3344:103::2a
-    crucible       fb36b9dc-273a-4bc3-aaa9-19ee4d0ef552   in service    fd00:1122:3344:103::2d
-    internal_dns   7004cab9-dfc0-43ba-92d3-58d4ced66025   in service    fd00:1122:3344:1::1   
-    internal_ntp   c81c9d4a-36d7-4796-9151-f564d3735152   in service    fd00:1122:3344:103::21
-    nexus          b2573120-9c91-4ed7-8b4f-a7bfe8dbc807   in service    fd00:1122:3344:103::22
+    ---------------------------------------------------------------------------------------------
+    zone type         zone id                                disposition   underlay IP           
+    ---------------------------------------------------------------------------------------------
+    clickhouse        44afce85-3377-4b20-a398-517c1579df4d   in service    fd00:1122:3344:103::23
+    crucible          38b047ea-e3de-4859-b8e0-70cac5871446   in service    fd00:1122:3344:103::2c
+    crucible          4644ea0c-0ec3-41be-a356-660308e1c3fc   in service    fd00:1122:3344:103::2b
+    crucible          5c6a4628-8831-483b-995f-79b9126c4d04   in service    fd00:1122:3344:103::27
+    crucible          6a01210c-45ed-41a5-9230-8e05ecf5dd8f   in service    fd00:1122:3344:103::28
+    crucible          79552859-fbd3-43bb-a9d3-6baba25558f8   in service    fd00:1122:3344:103::25
+    crucible          90696819-9b53-485a-9c65-ca63602e843e   in service    fd00:1122:3344:103::26
+    crucible          a9a6a974-8953-4783-b815-da46884f2c02   in service    fd00:1122:3344:103::2e
+    crucible          c99525b3-3680-4df6-9214-2ee3e1020e8b   in service    fd00:1122:3344:103::29
+    crucible          f42959d3-9eef-4e3b-b404-6177ce3ec7a1   in service    fd00:1122:3344:103::2a
+    crucible          fb36b9dc-273a-4bc3-aaa9-19ee4d0ef552   in service    fd00:1122:3344:103::2d
+    crucible_pantry   55f4d117-0b9d-4256-a2c0-f46d3ed5fff9   in service    fd00:1122:3344:103::24
+    internal_dns      7004cab9-dfc0-43ba-92d3-58d4ced66025   in service    fd00:1122:3344:1::1   
+    internal_ntp      c81c9d4a-36d7-4796-9151-f564d3735152   in service    fd00:1122:3344:103::21
+    nexus             b2573120-9c91-4ed7-8b4f-a7bfe8dbc807   in service    fd00:1122:3344:103::22
 
 
   sled 84ac367e-9b03-4e9d-a846-df1a08deee6c (active):
@@ -59,22 +60,23 @@ to:   blueprint  e4aeb3b3-272f-4967-be34-2d34daa46aa1
 
 
     omicron zones at generation 2:
-    ------------------------------------------------------------------------------------------
-    zone type      zone id                                disposition   underlay IP           
-    ------------------------------------------------------------------------------------------
-    crucible       0faa9350-2c02-47c7-a0a6-9f4afd69152c   in service    fd00:1122:3344:101::29
-    crucible       29278a22-1ba1-4117-bfdb-39fcb9ae7fd1   in service    fd00:1122:3344:101::2b
-    crucible       943fea7a-9458-4935-9dc7-01ee5cfe5a02   in service    fd00:1122:3344:101::26
-    crucible       9b722fea-a186-4bc3-bc37-ce7f6de6a796   in service    fd00:1122:3344:101::2c
-    crucible       a5a0b7a9-37c9-4dbd-8393-ec7748ada3b0   in service    fd00:1122:3344:101::28
-    crucible       aa25add8-60b0-4ace-ac60-15adcdd32d50   in service    fd00:1122:3344:101::27
-    crucible       aac3ab51-9e2b-4605-9bf6-e3eb3681c2b5   in service    fd00:1122:3344:101::2a
-    crucible       b6f2dd1e-7f98-4a68-9df2-b33c69d1f7ea   in service    fd00:1122:3344:101::24
-    crucible       dc22d470-dc46-436b-9750-25c8d7d369e2   in service    fd00:1122:3344:101::23
-    crucible       f7e434f9-6d4a-476b-a9e2-48d6ee28a08e   in service    fd00:1122:3344:101::25
-    internal_dns   5b44003e-1a3d-4152-b606-872c72efce0e   in service    fd00:1122:3344:2::1   
-    internal_ntp   a9a6a974-8953-4783-b815-da46884f2c02   in service    fd00:1122:3344:101::21
-    nexus          95c3b6d1-2592-4252-b5c1-5d0faf3ce9c9   in service    fd00:1122:3344:101::22
+    ---------------------------------------------------------------------------------------------
+    zone type         zone id                                disposition   underlay IP           
+    ---------------------------------------------------------------------------------------------
+    crucible          0faa9350-2c02-47c7-a0a6-9f4afd69152c   in service    fd00:1122:3344:101::28
+    crucible          29278a22-1ba1-4117-bfdb-39fcb9ae7fd1   in service    fd00:1122:3344:101::2a
+    crucible          4330134c-41b9-4097-aa0b-3eaefa06d473   in service    fd00:1122:3344:101::2c
+    crucible          65d03287-e43f-45f4-902e-0a5e4638f31a   in service    fd00:1122:3344:101::2d
+    crucible          943fea7a-9458-4935-9dc7-01ee5cfe5a02   in service    fd00:1122:3344:101::25
+    crucible          9b722fea-a186-4bc3-bc37-ce7f6de6a796   in service    fd00:1122:3344:101::2b
+    crucible          a5a0b7a9-37c9-4dbd-8393-ec7748ada3b0   in service    fd00:1122:3344:101::27
+    crucible          aa25add8-60b0-4ace-ac60-15adcdd32d50   in service    fd00:1122:3344:101::26
+    crucible          aac3ab51-9e2b-4605-9bf6-e3eb3681c2b5   in service    fd00:1122:3344:101::29
+    crucible          f7e434f9-6d4a-476b-a9e2-48d6ee28a08e   in service    fd00:1122:3344:101::24
+    crucible_pantry   b6f2dd1e-7f98-4a68-9df2-b33c69d1f7ea   in service    fd00:1122:3344:101::23
+    internal_dns      dc22d470-dc46-436b-9750-25c8d7d369e2   in service    fd00:1122:3344:2::1   
+    internal_ntp      95c3b6d1-2592-4252-b5c1-5d0faf3ce9c9   in service    fd00:1122:3344:101::21
+    nexus             5b44003e-1a3d-4152-b606-872c72efce0e   in service    fd00:1122:3344:101::22
 
 
   sled be7f4375-2a6b-457f-b1a4-3074a715e5fe (active):
@@ -96,22 +98,23 @@ to:   blueprint  e4aeb3b3-272f-4967-be34-2d34daa46aa1
 
 
     omicron zones at generation 2:
-    ------------------------------------------------------------------------------------------
-    zone type      zone id                                disposition   underlay IP           
-    ------------------------------------------------------------------------------------------
-    crucible       248db330-56e6-4c7e-b5ff-9cd6cbcb210a   in service    fd00:1122:3344:102::28
-    crucible       353b0aff-4c71-4fae-a6bd-adcb1d2a1a1d   in service    fd00:1122:3344:102::25
-    crucible       6a5901b1-f9d7-425c-8ecb-a786c900f217   in service    fd00:1122:3344:102::23
-    crucible       b3583b5f-4a62-4471-9be7-41e61578de4c   in service    fd00:1122:3344:102::26
-    crucible       b7bf29a5-ef5f-4942-a3be-e943f7e6be80   in service    fd00:1122:3344:102::2c
-    crucible       b97bdef5-ed14-4e11-9d3b-3379c18ea694   in service    fd00:1122:3344:102::2b
-    crucible       bac92034-b9e6-4e8b-9ffb-dbba9caec88d   in service    fd00:1122:3344:102::24
-    crucible       c240ec8c-cec5-4117-944d-faeb5672d568   in service    fd00:1122:3344:102::2a
-    crucible       cf766535-9b6f-4263-a83a-86f45f7b005b   in service    fd00:1122:3344:102::29
-    crucible       d9653001-f671-4905-a410-6a7abc358318   in service    fd00:1122:3344:102::27
-    internal_dns   edaca77e-5806-446a-b00c-125962cd551d   in service    fd00:1122:3344:3::1   
-    internal_ntp   4330134c-41b9-4097-aa0b-3eaefa06d473   in service    fd00:1122:3344:102::21
-    nexus          65d03287-e43f-45f4-902e-0a5e4638f31a   in service    fd00:1122:3344:102::22
+    ---------------------------------------------------------------------------------------------
+    zone type         zone id                                disposition   underlay IP           
+    ---------------------------------------------------------------------------------------------
+    crucible          248db330-56e6-4c7e-b5ff-9cd6cbcb210a   in service    fd00:1122:3344:102::26
+    crucible          3bff7b8a-1737-4f13-ba1c-713785f00c69   in service    fd00:1122:3344:102::2c
+    crucible          75b0a160-7923-4f87-b7f3-f2d40b340e27   in service    fd00:1122:3344:102::2b
+    crucible          b3583b5f-4a62-4471-9be7-41e61578de4c   in service    fd00:1122:3344:102::24
+    crucible          b7bf29a5-ef5f-4942-a3be-e943f7e6be80   in service    fd00:1122:3344:102::2a
+    crucible          b97bdef5-ed14-4e11-9d3b-3379c18ea694   in service    fd00:1122:3344:102::29
+    crucible          c240ec8c-cec5-4117-944d-faeb5672d568   in service    fd00:1122:3344:102::28
+    crucible          cf766535-9b6f-4263-a83a-86f45f7b005b   in service    fd00:1122:3344:102::27
+    crucible          d9653001-f671-4905-a410-6a7abc358318   in service    fd00:1122:3344:102::25
+    crucible          d9f181c5-bda0-409f-ae72-a46a906ca931   in service    fd00:1122:3344:102::2d
+    crucible_pantry   353b0aff-4c71-4fae-a6bd-adcb1d2a1a1d   in service    fd00:1122:3344:102::23
+    internal_dns      bac92034-b9e6-4e8b-9ffb-dbba9caec88d   in service    fd00:1122:3344:3::1   
+    internal_ntp      edaca77e-5806-446a-b00c-125962cd551d   in service    fd00:1122:3344:102::21
+    nexus             6a5901b1-f9d7-425c-8ecb-a786c900f217   in service    fd00:1122:3344:102::22
 
 
  COCKROACHDB SETTINGS:

--- a/nexus/reconfigurator/planning/tests/output/example_builder_zone_counts_blueprint.txt
+++ b/nexus/reconfigurator/planning/tests/output/example_builder_zone_counts_blueprint.txt
@@ -20,26 +20,27 @@ parent:    e35b2fdd-354d-48d9-acb5-703b2c269a54
 
 
     omicron zones at generation 2:
-    ------------------------------------------------------------------------------------------
-    zone type      zone id                                disposition   underlay IP           
-    ------------------------------------------------------------------------------------------
-    clickhouse     fadaa1c6-81a2-46ed-a10f-c42c29b85de9   in service    fd00:1122:3344:105::24
-    crucible       4f673614-7a9d-4860-859c-9627de33e03b   in service    fd00:1122:3344:105::2b
-    crucible       6422c22d-00bf-4826-9aeb-cf4e4dcae1c7   in service    fd00:1122:3344:105::2d
-    crucible       85631c30-4b81-4a22-a0e5-e110034cc980   in service    fd00:1122:3344:105::29
-    crucible       9334f86c-6555-499a-9ad7-5acc987e2b87   in service    fd00:1122:3344:105::2f
-    crucible       a0624221-da2b-4f45-862e-effec567dcd1   in service    fd00:1122:3344:105::2a
-    crucible       a9980763-1f8c-452d-a542-551d1001131e   in service    fd00:1122:3344:105::27
-    crucible       c33f069b-e412-4309-a62b-e1cbef3ec234   in service    fd00:1122:3344:105::30
-    crucible       c863bdbb-f270-47e1-bf7b-2220cf129266   in service    fd00:1122:3344:105::28
-    crucible       d42c15ed-d303-43d4-b9e9-c5772505c2d7   in service    fd00:1122:3344:105::2c
-    crucible       d660e9f0-2f8f-4540-bd59-a32845d002ce   in service    fd00:1122:3344:105::2e
-    external_dns   5002e44e-eef1-4f3c-81fc-78b62134400e   in service    fd00:1122:3344:105::26
-    external_dns   82db7bcc-9e4c-418f-a46a-eb8ff561de7b   in service    fd00:1122:3344:105::25
-    internal_dns   faac06c4-9aea-44a3-a94f-3da1adddb7b9   in service    fd00:1122:3344:1::1   
-    internal_ntp   a3a3fccb-1127-4e61-9bdf-13eb58365a8a   in service    fd00:1122:3344:105::21
-    nexus          1a741601-83b2-40b7-b59b-1a9b2c853411   in service    fd00:1122:3344:105::23
-    nexus          a7743bca-5056-479f-9151-6f2288c0ae28   in service    fd00:1122:3344:105::22
+    ---------------------------------------------------------------------------------------------
+    zone type         zone id                                disposition   underlay IP           
+    ---------------------------------------------------------------------------------------------
+    clickhouse        fadaa1c6-81a2-46ed-a10f-c42c29b85de9   in service    fd00:1122:3344:105::24
+    crucible          4f673614-7a9d-4860-859c-9627de33e03b   in service    fd00:1122:3344:105::2b
+    crucible          6422c22d-00bf-4826-9aeb-cf4e4dcae1c7   in service    fd00:1122:3344:105::2d
+    crucible          76edbb5e-7038-4160-833b-131abc2b2a12   in service    fd00:1122:3344:105::31
+    crucible          85631c30-4b81-4a22-a0e5-e110034cc980   in service    fd00:1122:3344:105::29
+    crucible          9334f86c-6555-499a-9ad7-5acc987e2b87   in service    fd00:1122:3344:105::2f
+    crucible          a0624221-da2b-4f45-862e-effec567dcd1   in service    fd00:1122:3344:105::2a
+    crucible          c33f069b-e412-4309-a62b-e1cbef3ec234   in service    fd00:1122:3344:105::30
+    crucible          c863bdbb-f270-47e1-bf7b-2220cf129266   in service    fd00:1122:3344:105::28
+    crucible          d42c15ed-d303-43d4-b9e9-c5772505c2d7   in service    fd00:1122:3344:105::2c
+    crucible          d660e9f0-2f8f-4540-bd59-a32845d002ce   in service    fd00:1122:3344:105::2e
+    crucible_pantry   a9980763-1f8c-452d-a542-551d1001131e   in service    fd00:1122:3344:105::27
+    external_dns      5002e44e-eef1-4f3c-81fc-78b62134400e   in service    fd00:1122:3344:105::26
+    external_dns      82db7bcc-9e4c-418f-a46a-eb8ff561de7b   in service    fd00:1122:3344:105::25
+    internal_dns      faac06c4-9aea-44a3-a94f-3da1adddb7b9   in service    fd00:1122:3344:1::1   
+    internal_ntp      a3a3fccb-1127-4e61-9bdf-13eb58365a8a   in service    fd00:1122:3344:105::21
+    nexus             1a741601-83b2-40b7-b59b-1a9b2c853411   in service    fd00:1122:3344:105::23
+    nexus             a7743bca-5056-479f-9151-6f2288c0ae28   in service    fd00:1122:3344:105::22
 
 
 
@@ -62,24 +63,25 @@ parent:    e35b2fdd-354d-48d9-acb5-703b2c269a54
 
 
     omicron zones at generation 2:
-    ------------------------------------------------------------------------------------------
-    zone type      zone id                                disposition   underlay IP           
-    ------------------------------------------------------------------------------------------
-    crucible       0dba037d-0b14-4e10-b430-c271f87d8e9a   in service    fd00:1122:3344:104::28
-    crucible       10f24d62-dec3-4f6f-9f42-722763e1fcbd   in service    fd00:1122:3344:104::2c
-    crucible       313bb913-2e8b-4c27-89e6-79c92db8c03c   in service    fd00:1122:3344:104::27
-    crucible       362b181b-452e-4f54-a42f-04bef00fa272   in service    fd00:1122:3344:104::26
-    crucible       69b59e77-9da3-49d3-bf83-a464570aea97   in service    fd00:1122:3344:104::29
-    crucible       7943dee3-d4ad-4ffb-93c7-2c1079e708a1   in service    fd00:1122:3344:104::2d
-    crucible       8343556a-7827-4fdd-90df-a4b603b177cc   in service    fd00:1122:3344:104::25
-    crucible       b2f90d4d-34ff-4aae-8cfd-4773a30c372f   in service    fd00:1122:3344:104::2a
-    crucible       caf0bd1b-1da6-46b0-bb64-d6b780ad7a4c   in service    fd00:1122:3344:104::2e
-    crucible       f3c76e5a-779a-4c3c-87ce-dad309f612c4   in service    fd00:1122:3344:104::2b
-    external_dns   1c0614f1-b653-43c2-b278-5372036a87c8   in service    fd00:1122:3344:104::23
-    external_dns   60a0051f-d530-49e6-ab11-e2098856afba   in service    fd00:1122:3344:104::24
-    internal_dns   58d88005-e182-4463-96ed-9220e59facb7   in service    fd00:1122:3344:2::1   
-    internal_ntp   76edbb5e-7038-4160-833b-131abc2b2a12   in service    fd00:1122:3344:104::21
-    nexus          35a629e9-5140-48bf-975d-ce66d9c3be59   in service    fd00:1122:3344:104::22
+    ---------------------------------------------------------------------------------------------
+    zone type         zone id                                disposition   underlay IP           
+    ---------------------------------------------------------------------------------------------
+    crucible          0dba037d-0b14-4e10-b430-c271f87d8e9a   in service    fd00:1122:3344:104::27
+    crucible          10f24d62-dec3-4f6f-9f42-722763e1fcbd   in service    fd00:1122:3344:104::2b
+    crucible          313bb913-2e8b-4c27-89e6-79c92db8c03c   in service    fd00:1122:3344:104::26
+    crucible          3c900bee-7455-4a41-8175-fe952484753c   in service    fd00:1122:3344:104::2f
+    crucible          68ff33cc-852b-4f2c-bc5c-9f7bdc32110e   in service    fd00:1122:3344:104::2e
+    crucible          69b59e77-9da3-49d3-bf83-a464570aea97   in service    fd00:1122:3344:104::28
+    crucible          7943dee3-d4ad-4ffb-93c7-2c1079e708a1   in service    fd00:1122:3344:104::2c
+    crucible          b2f90d4d-34ff-4aae-8cfd-4773a30c372f   in service    fd00:1122:3344:104::29
+    crucible          caf0bd1b-1da6-46b0-bb64-d6b780ad7a4c   in service    fd00:1122:3344:104::2d
+    crucible          f3c76e5a-779a-4c3c-87ce-dad309f612c4   in service    fd00:1122:3344:104::2a
+    crucible_pantry   362b181b-452e-4f54-a42f-04bef00fa272   in service    fd00:1122:3344:104::25
+    external_dns      60a0051f-d530-49e6-ab11-e2098856afba   in service    fd00:1122:3344:104::23
+    external_dns      8343556a-7827-4fdd-90df-a4b603b177cc   in service    fd00:1122:3344:104::24
+    internal_dns      1c0614f1-b653-43c2-b278-5372036a87c8   in service    fd00:1122:3344:2::1   
+    internal_ntp      35a629e9-5140-48bf-975d-ce66d9c3be59   in service    fd00:1122:3344:104::21
+    nexus             58d88005-e182-4463-96ed-9220e59facb7   in service    fd00:1122:3344:104::22
 
 
 
@@ -102,23 +104,24 @@ parent:    e35b2fdd-354d-48d9-acb5-703b2c269a54
 
 
     omicron zones at generation 2:
-    ------------------------------------------------------------------------------------------
-    zone type      zone id                                disposition   underlay IP           
-    ------------------------------------------------------------------------------------------
-    crucible       0d5f20e4-fdca-4611-ac07-053bc28c5088   in service    fd00:1122:3344:102::2e
-    crucible       234514a8-7a70-4dc5-905b-a29d1cfdee99   in service    fd00:1122:3344:102::2b
-    crucible       29400193-6c20-4c41-8c9a-5259803c7bfd   in service    fd00:1122:3344:102::2a
-    crucible       31fdc4e5-25f2-42c5-8c2c-7f8bf3a0b89e   in service    fd00:1122:3344:102::25
-    crucible       a1a32afe-10db-4dbf-ac2d-6745f6f55417   in service    fd00:1122:3344:102::2d
-    crucible       a3333bac-4989-4d9a-8257-8c7a0614cef0   in service    fd00:1122:3344:102::27
-    crucible       bec70cc9-82f9-42d3-935b-4f141c3c3503   in service    fd00:1122:3344:102::2c
-    crucible       de2023c8-6976-40fa-80d7-a8b0ea9546a1   in service    fd00:1122:3344:102::29
-    crucible       e4aeecc2-f9ae-4b4f-963c-9c017e9df189   in service    fd00:1122:3344:102::26
-    crucible       ed528efc-4d32-43cc-a0a2-b412693a7eca   in service    fd00:1122:3344:102::28
-    external_dns   5895eb4f-7132-4530-8fc1-f9b719981856   in service    fd00:1122:3344:102::24
-    external_dns   cb4a2547-7798-48d2-839d-29f7d33d1486   in service    fd00:1122:3344:102::23
-    internal_ntp   68ff33cc-852b-4f2c-bc5c-9f7bdc32110e   in service    fd00:1122:3344:102::21
-    nexus          3c900bee-7455-4a41-8175-fe952484753c   in service    fd00:1122:3344:102::22
+    ---------------------------------------------------------------------------------------------
+    zone type         zone id                                disposition   underlay IP           
+    ---------------------------------------------------------------------------------------------
+    crucible          0d5f20e4-fdca-4611-ac07-053bc28c5088   in service    fd00:1122:3344:102::2c
+    crucible          234514a8-7a70-4dc5-905b-a29d1cfdee99   in service    fd00:1122:3344:102::29
+    crucible          29400193-6c20-4c41-8c9a-5259803c7bfd   in service    fd00:1122:3344:102::28
+    crucible          7cbc95ce-ab55-4b70-851d-33a0164ca362   in service    fd00:1122:3344:102::2e
+    crucible          7e6fa426-5200-47b4-b791-393dd17b09d9   in service    fd00:1122:3344:102::2f
+    crucible          a16b5904-5ba8-42db-940c-8b852b052995   in service    fd00:1122:3344:102::2d
+    crucible          a1a32afe-10db-4dbf-ac2d-6745f6f55417   in service    fd00:1122:3344:102::2b
+    crucible          bec70cc9-82f9-42d3-935b-4f141c3c3503   in service    fd00:1122:3344:102::2a
+    crucible          de2023c8-6976-40fa-80d7-a8b0ea9546a1   in service    fd00:1122:3344:102::27
+    crucible          ed528efc-4d32-43cc-a0a2-b412693a7eca   in service    fd00:1122:3344:102::26
+    crucible_pantry   a3333bac-4989-4d9a-8257-8c7a0614cef0   in service    fd00:1122:3344:102::25
+    external_dns      31fdc4e5-25f2-42c5-8c2c-7f8bf3a0b89e   in service    fd00:1122:3344:102::23
+    external_dns      e4aeecc2-f9ae-4b4f-963c-9c017e9df189   in service    fd00:1122:3344:102::24
+    internal_ntp      cb4a2547-7798-48d2-839d-29f7d33d1486   in service    fd00:1122:3344:102::21
+    nexus             5895eb4f-7132-4530-8fc1-f9b719981856   in service    fd00:1122:3344:102::22
 
 
 
@@ -141,23 +144,24 @@ parent:    e35b2fdd-354d-48d9-acb5-703b2c269a54
 
 
     omicron zones at generation 2:
-    ------------------------------------------------------------------------------------------
-    zone type      zone id                                disposition   underlay IP           
-    ------------------------------------------------------------------------------------------
-    crucible       0a6c78bb-f778-4b6d-9d20-370ae7c89135   in service    fd00:1122:3344:103::2c
-    crucible       590907c2-e61e-4c2f-8a36-e705a24600c8   in service    fd00:1122:3344:103::2a
-    crucible       77511292-f3aa-4a07-970a-1159e2c38ec9   in service    fd00:1122:3344:103::2e
-    crucible       983ed36f-baed-4dd1-bec7-4780f070eeee   in service    fd00:1122:3344:103::27
-    crucible       9ff080b2-7bf9-4fe3-8d5f-367adb3525c8   in service    fd00:1122:3344:103::28
-    crucible       c3b6651b-6a62-4292-972c-481390f4a044   in service    fd00:1122:3344:103::29
-    crucible       e8bb3c35-b1ee-4171-b8ff-924e6a560fbf   in service    fd00:1122:3344:103::26
-    crucible       ea723ef1-b23e-433d-bef5-90142476225d   in service    fd00:1122:3344:103::2b
-    crucible       efa54182-a3e6-4600-9e88-044a6a8ae350   in service    fd00:1122:3344:103::25
-    crucible       fbc67c83-773a-48ff-857c-61ddbf1ebf52   in service    fd00:1122:3344:103::2d
-    external_dns   7e6fa426-5200-47b4-b791-393dd17b09d9   in service    fd00:1122:3344:103::23
-    external_dns   e8d99319-3796-4605-bd96-e17011d77016   in service    fd00:1122:3344:103::24
-    internal_ntp   a16b5904-5ba8-42db-940c-8b852b052995   in service    fd00:1122:3344:103::21
-    nexus          7cbc95ce-ab55-4b70-851d-33a0164ca362   in service    fd00:1122:3344:103::22
+    ---------------------------------------------------------------------------------------------
+    zone type         zone id                                disposition   underlay IP           
+    ---------------------------------------------------------------------------------------------
+    crucible          0a6c78bb-f778-4b6d-9d20-370ae7c89135   in service    fd00:1122:3344:103::29
+    crucible          19faa2c3-b077-470a-a424-6821dd49bd11   in service    fd00:1122:3344:103::2f
+    crucible          236e5a84-cebe-40b8-8832-56a8e06b08b0   in service    fd00:1122:3344:103::2c
+    crucible          590907c2-e61e-4c2f-8a36-e705a24600c8   in service    fd00:1122:3344:103::27
+    crucible          77511292-f3aa-4a07-970a-1159e2c38ec9   in service    fd00:1122:3344:103::2b
+    crucible          c3b6651b-6a62-4292-972c-481390f4a044   in service    fd00:1122:3344:103::26
+    crucible          dd9050e5-77ae-4dd0-98aa-d34fc2be78d4   in service    fd00:1122:3344:103::2d
+    crucible          e8ac4104-9789-4ba1-90c5-aded124cc079   in service    fd00:1122:3344:103::2e
+    crucible          ea723ef1-b23e-433d-bef5-90142476225d   in service    fd00:1122:3344:103::28
+    crucible          fbc67c83-773a-48ff-857c-61ddbf1ebf52   in service    fd00:1122:3344:103::2a
+    crucible_pantry   9ff080b2-7bf9-4fe3-8d5f-367adb3525c8   in service    fd00:1122:3344:103::25
+    external_dns      983ed36f-baed-4dd1-bec7-4780f070eeee   in service    fd00:1122:3344:103::24
+    external_dns      e8bb3c35-b1ee-4171-b8ff-924e6a560fbf   in service    fd00:1122:3344:103::23
+    internal_ntp      e8d99319-3796-4605-bd96-e17011d77016   in service    fd00:1122:3344:103::21
+    nexus             efa54182-a3e6-4600-9e88-044a6a8ae350   in service    fd00:1122:3344:103::22
 
 
 
@@ -180,23 +184,24 @@ parent:    e35b2fdd-354d-48d9-acb5-703b2c269a54
 
 
     omicron zones at generation 2:
-    ------------------------------------------------------------------------------------------
-    zone type      zone id                                disposition   underlay IP           
-    ------------------------------------------------------------------------------------------
-    crucible       00e6f92a-997a-4c1f-8c84-be547eb012d3   in service    fd00:1122:3344:101::2e
-    crucible       1b122e0d-8b22-464f-b1af-589246d636dc   in service    fd00:1122:3344:101::28
-    crucible       25fb011b-ea9d-462c-a89e-5f7782858a4f   in service    fd00:1122:3344:101::29
-    crucible       808e6761-6ddc-42f0-a82f-fd2049c751dc   in service    fd00:1122:3344:101::27
-    crucible       a1e77a19-9302-416a-afe9-cfdded5054d5   in service    fd00:1122:3344:101::25
-    crucible       be3b1ad8-3de2-4ad7-89b8-d279558121ae   in service    fd00:1122:3344:101::2c
-    crucible       c6192cad-a9c5-4b4d-bc8f-ce0fb066a0ed   in service    fd00:1122:3344:101::2b
-    crucible       d39f526b-9799-42a6-a610-f0f5605dac44   in service    fd00:1122:3344:101::26
-    crucible       e8dea18b-1697-4349-ae54-47f95cb3d907   in service    fd00:1122:3344:101::2a
-    crucible       f4053fb9-ce8c-4dcf-8dd3-bf6d305c29fc   in service    fd00:1122:3344:101::2d
-    external_dns   19faa2c3-b077-470a-a424-6821dd49bd11   in service    fd00:1122:3344:101::24
-    external_dns   e8ac4104-9789-4ba1-90c5-aded124cc079   in service    fd00:1122:3344:101::23
-    internal_ntp   236e5a84-cebe-40b8-8832-56a8e06b08b0   in service    fd00:1122:3344:101::21
-    nexus          dd9050e5-77ae-4dd0-98aa-d34fc2be78d4   in service    fd00:1122:3344:101::22
+    ---------------------------------------------------------------------------------------------
+    zone type         zone id                                disposition   underlay IP           
+    ---------------------------------------------------------------------------------------------
+    crucible          00e6f92a-997a-4c1f-8c84-be547eb012d3   in service    fd00:1122:3344:101::2a
+    crucible          0e12b408-dc46-4827-82e5-4589cb895b58   in service    fd00:1122:3344:101::2d
+    crucible          0ed1d110-0727-4a4c-9ef1-f74fa885dce2   in service    fd00:1122:3344:101::2e
+    crucible          7a520d9b-5f7d-4e5c-b1bc-7e65a35984b6   in service    fd00:1122:3344:101::2f
+    crucible          be3b1ad8-3de2-4ad7-89b8-d279558121ae   in service    fd00:1122:3344:101::28
+    crucible          c6192cad-a9c5-4b4d-bc8f-ce0fb066a0ed   in service    fd00:1122:3344:101::27
+    crucible          d3445179-d068-4406-9aae-255bd0008280   in service    fd00:1122:3344:101::2b
+    crucible          e8dea18b-1697-4349-ae54-47f95cb3d907   in service    fd00:1122:3344:101::26
+    crucible          f1f1ee53-a974-45f8-9173-211ed366ab7d   in service    fd00:1122:3344:101::2c
+    crucible          f4053fb9-ce8c-4dcf-8dd3-bf6d305c29fc   in service    fd00:1122:3344:101::29
+    crucible_pantry   25fb011b-ea9d-462c-a89e-5f7782858a4f   in service    fd00:1122:3344:101::25
+    external_dns      1b122e0d-8b22-464f-b1af-589246d636dc   in service    fd00:1122:3344:101::24
+    external_dns      808e6761-6ddc-42f0-a82f-fd2049c751dc   in service    fd00:1122:3344:101::23
+    internal_ntp      a1e77a19-9302-416a-afe9-cfdded5054d5   in service    fd00:1122:3344:101::21
+    nexus             d39f526b-9799-42a6-a610-f0f5605dac44   in service    fd00:1122:3344:101::22
 
 
  COCKROACHDB SETTINGS:

--- a/nexus/reconfigurator/planning/tests/output/planner_basic_add_sled_2_3.txt
+++ b/nexus/reconfigurator/planning/tests/output/planner_basic_add_sled_2_3.txt
@@ -22,23 +22,24 @@ to:   blueprint 4171ad05-89dd-474b-846b-b007e4346366
 
 
     omicron zones at generation 2:
-    ------------------------------------------------------------------------------------------
-    zone type      zone id                                disposition   underlay IP           
-    ------------------------------------------------------------------------------------------
-    clickhouse     b40f7c7b-526c-46c8-ae33-67280c280eb7   in service    fd00:1122:3344:103::23
-    crucible       08c7f8aa-1ea9-469b-8cac-2fdbfc11ebcb   in service    fd00:1122:3344:103::2c
-    crucible       4ab1650f-32c5-447f-939d-64b8103a7645   in service    fd00:1122:3344:103::29
-    crucible       64aa65f8-1ccb-4cd6-9953-027aebdac8ff   in service    fd00:1122:3344:103::26
-    crucible       6e811d86-8aa7-4660-935b-84b4b7721b10   in service    fd00:1122:3344:103::2a
-    crucible       747d2426-68bf-4c22-8806-41d290b5d5f5   in service    fd00:1122:3344:103::24
-    crucible       7fbd2c38-5dc3-48c4-b061-558a2041d70f   in service    fd00:1122:3344:103::2b
-    crucible       8e9e923e-62b1-4cbc-9f59-d6397e338b6b   in service    fd00:1122:3344:103::28
-    crucible       b14d5478-1a0e-4b90-b526-36b06339dfc4   in service    fd00:1122:3344:103::27
-    crucible       be97b92b-38d6-422a-8c76-d37060f75bd2   in service    fd00:1122:3344:103::25
-    crucible       c66ab6d5-ff7a-46d1-9fd0-70cefa352d25   in service    fd00:1122:3344:103::2d
-    internal_dns   322ee9f1-8903-4542-a0a8-a54cefabdeca   in service    fd00:1122:3344:1::1   
-    internal_ntp   267ed614-92af-4b9d-bdba-c2881c2e43a2   in service    fd00:1122:3344:103::21
-    nexus          cc816cfe-3869-4dde-b596-397d41198628   in service    fd00:1122:3344:103::22
+    ---------------------------------------------------------------------------------------------
+    zone type         zone id                                disposition   underlay IP           
+    ---------------------------------------------------------------------------------------------
+    clickhouse        b40f7c7b-526c-46c8-ae33-67280c280eb7   in service    fd00:1122:3344:103::23
+    crucible          08c7f8aa-1ea9-469b-8cac-2fdbfc11ebcb   in service    fd00:1122:3344:103::2c
+    crucible          3eda924f-22a9-4f3e-9a1b-91d1c47601ab   in service    fd00:1122:3344:103::2e
+    crucible          4ab1650f-32c5-447f-939d-64b8103a7645   in service    fd00:1122:3344:103::29
+    crucible          64aa65f8-1ccb-4cd6-9953-027aebdac8ff   in service    fd00:1122:3344:103::26
+    crucible          6e811d86-8aa7-4660-935b-84b4b7721b10   in service    fd00:1122:3344:103::2a
+    crucible          7fbd2c38-5dc3-48c4-b061-558a2041d70f   in service    fd00:1122:3344:103::2b
+    crucible          8e9e923e-62b1-4cbc-9f59-d6397e338b6b   in service    fd00:1122:3344:103::28
+    crucible          b14d5478-1a0e-4b90-b526-36b06339dfc4   in service    fd00:1122:3344:103::27
+    crucible          be97b92b-38d6-422a-8c76-d37060f75bd2   in service    fd00:1122:3344:103::25
+    crucible          c66ab6d5-ff7a-46d1-9fd0-70cefa352d25   in service    fd00:1122:3344:103::2d
+    crucible_pantry   747d2426-68bf-4c22-8806-41d290b5d5f5   in service    fd00:1122:3344:103::24
+    internal_dns      322ee9f1-8903-4542-a0a8-a54cefabdeca   in service    fd00:1122:3344:1::1   
+    internal_ntp      267ed614-92af-4b9d-bdba-c2881c2e43a2   in service    fd00:1122:3344:103::21
+    nexus             cc816cfe-3869-4dde-b596-397d41198628   in service    fd00:1122:3344:103::22
 
 
   sled 43677374-8d2f-4deb-8a41-eeea506db8e0 (active):
@@ -60,22 +61,23 @@ to:   blueprint 4171ad05-89dd-474b-846b-b007e4346366
 
 
     omicron zones at generation 2:
-    ------------------------------------------------------------------------------------------
-    zone type      zone id                                disposition   underlay IP           
-    ------------------------------------------------------------------------------------------
-    crucible       02acbe6a-1c88-47e3-94c3-94084cbde098   in service    fd00:1122:3344:101::24
-    crucible       07c3c805-8888-4fe5-9543-3d2479dbe6f3   in service    fd00:1122:3344:101::23
-    crucible       2a455c35-eb3c-4c73-ab6c-d0a706e25316   in service    fd00:1122:3344:101::26
-    crucible       47199d48-534c-4267-a654-d2d90e64b498   in service    fd00:1122:3344:101::2a
-    crucible       587be699-a320-4c79-b320-128d9ecddc0b   in service    fd00:1122:3344:101::28
-    crucible       6fa06115-4959-4913-8e7b-dd70d7651f07   in service    fd00:1122:3344:101::29
-    crucible       704e1fed-f8d6-4cfa-a470-bad27fdc06d1   in service    fd00:1122:3344:101::2b
-    crucible       8f3a1cc5-9195-4a30-ad02-b804278fe639   in service    fd00:1122:3344:101::25
-    crucible       a2079cbc-a69e-41a1-b1e0-fbcb972d03f6   in service    fd00:1122:3344:101::27
-    crucible       af322036-371f-437c-8c08-7f40f3f1403b   in service    fd00:1122:3344:101::2c
-    internal_dns   a1696cd4-588c-484a-b95b-66e824c0ce05   in service    fd00:1122:3344:2::1   
-    internal_ntp   3eda924f-22a9-4f3e-9a1b-91d1c47601ab   in service    fd00:1122:3344:101::21
-    nexus          10d98a73-ec88-4aff-a7e8-7db6a87880e6   in service    fd00:1122:3344:101::22
+    ---------------------------------------------------------------------------------------------
+    zone type         zone id                                disposition   underlay IP           
+    ---------------------------------------------------------------------------------------------
+    crucible          2a455c35-eb3c-4c73-ab6c-d0a706e25316   in service    fd00:1122:3344:101::25
+    crucible          47199d48-534c-4267-a654-d2d90e64b498   in service    fd00:1122:3344:101::29
+    crucible          587be699-a320-4c79-b320-128d9ecddc0b   in service    fd00:1122:3344:101::27
+    crucible          6fa06115-4959-4913-8e7b-dd70d7651f07   in service    fd00:1122:3344:101::28
+    crucible          704e1fed-f8d6-4cfa-a470-bad27fdc06d1   in service    fd00:1122:3344:101::2a
+    crucible          8f3a1cc5-9195-4a30-ad02-b804278fe639   in service    fd00:1122:3344:101::24
+    crucible          a2079cbc-a69e-41a1-b1e0-fbcb972d03f6   in service    fd00:1122:3344:101::26
+    crucible          af322036-371f-437c-8c08-7f40f3f1403b   in service    fd00:1122:3344:101::2b
+    crucible          d637264f-6f40-44c2-8b7e-a179430210d2   in service    fd00:1122:3344:101::2d
+    crucible          edabedf3-839c-488d-ad6f-508ffa864674   in service    fd00:1122:3344:101::2c
+    crucible_pantry   02acbe6a-1c88-47e3-94c3-94084cbde098   in service    fd00:1122:3344:101::23
+    internal_dns      07c3c805-8888-4fe5-9543-3d2479dbe6f3   in service    fd00:1122:3344:2::1   
+    internal_ntp      10d98a73-ec88-4aff-a7e8-7db6a87880e6   in service    fd00:1122:3344:101::21
+    nexus             a1696cd4-588c-484a-b95b-66e824c0ce05   in service    fd00:1122:3344:101::22
 
 
   sled 590e3034-d946-4166-b0e5-2d0034197a07 (active):
@@ -97,22 +99,23 @@ to:   blueprint 4171ad05-89dd-474b-846b-b007e4346366
 
 
     omicron zones at generation 2:
-    ------------------------------------------------------------------------------------------
-    zone type      zone id                                disposition   underlay IP           
-    ------------------------------------------------------------------------------------------
-    crucible       0565e7e4-f13a-4123-8928-d715f83e36aa   in service    fd00:1122:3344:102::2a
-    crucible       062ce37d-7448-4d44-b1f4-4937cd2eb174   in service    fd00:1122:3344:102::2c
-    crucible       18f8fe40-646e-4962-b17a-20e201f3a6e5   in service    fd00:1122:3344:102::26
-    crucible       1cc3f503-2001-4d85-80e5-c7c40d2e3b10   in service    fd00:1122:3344:102::29
-    crucible       56d5d7cf-db2c-40a3-a775-003241ad4820   in service    fd00:1122:3344:102::25
-    crucible       62058f4c-c747-4e21-a8dc-2fd4a160c98c   in service    fd00:1122:3344:102::2b
-    crucible       6af7f4d6-33b6-4eb3-a146-d8e9e4ae9d66   in service    fd00:1122:3344:102::27
-    crucible       93f2f40c-5616-4d8d-8519-ec6debdcede0   in service    fd00:1122:3344:102::28
-    crucible       ab7ba6df-d401-40bd-940e-faf57c57aa2a   in service    fd00:1122:3344:102::24
-    crucible       dce226c9-7373-4bfa-8a94-79dc472857a6   in service    fd00:1122:3344:102::23
-    internal_dns   7a9f60d3-2b66-4547-9b63-7d4f7a8b6382   in service    fd00:1122:3344:3::1   
-    internal_ntp   edabedf3-839c-488d-ad6f-508ffa864674   in service    fd00:1122:3344:102::21
-    nexus          d637264f-6f40-44c2-8b7e-a179430210d2   in service    fd00:1122:3344:102::22
+    ---------------------------------------------------------------------------------------------
+    zone type         zone id                                disposition   underlay IP           
+    ---------------------------------------------------------------------------------------------
+    crucible          0565e7e4-f13a-4123-8928-d715f83e36aa   in service    fd00:1122:3344:102::28
+    crucible          062ce37d-7448-4d44-b1f4-4937cd2eb174   in service    fd00:1122:3344:102::2a
+    crucible          1211a68e-69a1-4ef4-b790-45b0279f9159   in service    fd00:1122:3344:102::2d
+    crucible          18f8fe40-646e-4962-b17a-20e201f3a6e5   in service    fd00:1122:3344:102::24
+    crucible          1cc3f503-2001-4d85-80e5-c7c40d2e3b10   in service    fd00:1122:3344:102::27
+    crucible          62058f4c-c747-4e21-a8dc-2fd4a160c98c   in service    fd00:1122:3344:102::29
+    crucible          6af7f4d6-33b6-4eb3-a146-d8e9e4ae9d66   in service    fd00:1122:3344:102::25
+    crucible          78d6ab36-e8c8-4ff8-9f89-75c7fe2d32e6   in service    fd00:1122:3344:102::2b
+    crucible          93f2f40c-5616-4d8d-8519-ec6debdcede0   in service    fd00:1122:3344:102::26
+    crucible          9f824c30-6360-46b9-87c4-cd60586476fe   in service    fd00:1122:3344:102::2c
+    crucible_pantry   56d5d7cf-db2c-40a3-a775-003241ad4820   in service    fd00:1122:3344:102::23
+    internal_dns      ab7ba6df-d401-40bd-940e-faf57c57aa2a   in service    fd00:1122:3344:3::1   
+    internal_ntp      7a9f60d3-2b66-4547-9b63-7d4f7a8b6382   in service    fd00:1122:3344:102::21
+    nexus             dce226c9-7373-4bfa-8a94-79dc472857a6   in service    fd00:1122:3344:102::22
 
 
  ADDED SLEDS:

--- a/nexus/reconfigurator/planning/tests/output/planner_basic_add_sled_3_5.txt
+++ b/nexus/reconfigurator/planning/tests/output/planner_basic_add_sled_3_5.txt
@@ -22,23 +22,24 @@ to:   blueprint f432fcd5-1284-4058-8b4a-9286a3de6163
 
 
     omicron zones at generation 2:
-    ------------------------------------------------------------------------------------------
-    zone type      zone id                                disposition   underlay IP           
-    ------------------------------------------------------------------------------------------
-    clickhouse     b40f7c7b-526c-46c8-ae33-67280c280eb7   in service    fd00:1122:3344:103::23
-    crucible       08c7f8aa-1ea9-469b-8cac-2fdbfc11ebcb   in service    fd00:1122:3344:103::2c
-    crucible       4ab1650f-32c5-447f-939d-64b8103a7645   in service    fd00:1122:3344:103::29
-    crucible       64aa65f8-1ccb-4cd6-9953-027aebdac8ff   in service    fd00:1122:3344:103::26
-    crucible       6e811d86-8aa7-4660-935b-84b4b7721b10   in service    fd00:1122:3344:103::2a
-    crucible       747d2426-68bf-4c22-8806-41d290b5d5f5   in service    fd00:1122:3344:103::24
-    crucible       7fbd2c38-5dc3-48c4-b061-558a2041d70f   in service    fd00:1122:3344:103::2b
-    crucible       8e9e923e-62b1-4cbc-9f59-d6397e338b6b   in service    fd00:1122:3344:103::28
-    crucible       b14d5478-1a0e-4b90-b526-36b06339dfc4   in service    fd00:1122:3344:103::27
-    crucible       be97b92b-38d6-422a-8c76-d37060f75bd2   in service    fd00:1122:3344:103::25
-    crucible       c66ab6d5-ff7a-46d1-9fd0-70cefa352d25   in service    fd00:1122:3344:103::2d
-    internal_dns   322ee9f1-8903-4542-a0a8-a54cefabdeca   in service    fd00:1122:3344:1::1   
-    internal_ntp   267ed614-92af-4b9d-bdba-c2881c2e43a2   in service    fd00:1122:3344:103::21
-    nexus          cc816cfe-3869-4dde-b596-397d41198628   in service    fd00:1122:3344:103::22
+    ---------------------------------------------------------------------------------------------
+    zone type         zone id                                disposition   underlay IP           
+    ---------------------------------------------------------------------------------------------
+    clickhouse        b40f7c7b-526c-46c8-ae33-67280c280eb7   in service    fd00:1122:3344:103::23
+    crucible          08c7f8aa-1ea9-469b-8cac-2fdbfc11ebcb   in service    fd00:1122:3344:103::2c
+    crucible          3eda924f-22a9-4f3e-9a1b-91d1c47601ab   in service    fd00:1122:3344:103::2e
+    crucible          4ab1650f-32c5-447f-939d-64b8103a7645   in service    fd00:1122:3344:103::29
+    crucible          64aa65f8-1ccb-4cd6-9953-027aebdac8ff   in service    fd00:1122:3344:103::26
+    crucible          6e811d86-8aa7-4660-935b-84b4b7721b10   in service    fd00:1122:3344:103::2a
+    crucible          7fbd2c38-5dc3-48c4-b061-558a2041d70f   in service    fd00:1122:3344:103::2b
+    crucible          8e9e923e-62b1-4cbc-9f59-d6397e338b6b   in service    fd00:1122:3344:103::28
+    crucible          b14d5478-1a0e-4b90-b526-36b06339dfc4   in service    fd00:1122:3344:103::27
+    crucible          be97b92b-38d6-422a-8c76-d37060f75bd2   in service    fd00:1122:3344:103::25
+    crucible          c66ab6d5-ff7a-46d1-9fd0-70cefa352d25   in service    fd00:1122:3344:103::2d
+    crucible_pantry   747d2426-68bf-4c22-8806-41d290b5d5f5   in service    fd00:1122:3344:103::24
+    internal_dns      322ee9f1-8903-4542-a0a8-a54cefabdeca   in service    fd00:1122:3344:1::1   
+    internal_ntp      267ed614-92af-4b9d-bdba-c2881c2e43a2   in service    fd00:1122:3344:103::21
+    nexus             cc816cfe-3869-4dde-b596-397d41198628   in service    fd00:1122:3344:103::22
 
 
   sled 43677374-8d2f-4deb-8a41-eeea506db8e0 (active):
@@ -60,22 +61,23 @@ to:   blueprint f432fcd5-1284-4058-8b4a-9286a3de6163
 
 
     omicron zones at generation 2:
-    ------------------------------------------------------------------------------------------
-    zone type      zone id                                disposition   underlay IP           
-    ------------------------------------------------------------------------------------------
-    crucible       02acbe6a-1c88-47e3-94c3-94084cbde098   in service    fd00:1122:3344:101::24
-    crucible       07c3c805-8888-4fe5-9543-3d2479dbe6f3   in service    fd00:1122:3344:101::23
-    crucible       2a455c35-eb3c-4c73-ab6c-d0a706e25316   in service    fd00:1122:3344:101::26
-    crucible       47199d48-534c-4267-a654-d2d90e64b498   in service    fd00:1122:3344:101::2a
-    crucible       587be699-a320-4c79-b320-128d9ecddc0b   in service    fd00:1122:3344:101::28
-    crucible       6fa06115-4959-4913-8e7b-dd70d7651f07   in service    fd00:1122:3344:101::29
-    crucible       704e1fed-f8d6-4cfa-a470-bad27fdc06d1   in service    fd00:1122:3344:101::2b
-    crucible       8f3a1cc5-9195-4a30-ad02-b804278fe639   in service    fd00:1122:3344:101::25
-    crucible       a2079cbc-a69e-41a1-b1e0-fbcb972d03f6   in service    fd00:1122:3344:101::27
-    crucible       af322036-371f-437c-8c08-7f40f3f1403b   in service    fd00:1122:3344:101::2c
-    internal_dns   a1696cd4-588c-484a-b95b-66e824c0ce05   in service    fd00:1122:3344:2::1   
-    internal_ntp   3eda924f-22a9-4f3e-9a1b-91d1c47601ab   in service    fd00:1122:3344:101::21
-    nexus          10d98a73-ec88-4aff-a7e8-7db6a87880e6   in service    fd00:1122:3344:101::22
+    ---------------------------------------------------------------------------------------------
+    zone type         zone id                                disposition   underlay IP           
+    ---------------------------------------------------------------------------------------------
+    crucible          2a455c35-eb3c-4c73-ab6c-d0a706e25316   in service    fd00:1122:3344:101::25
+    crucible          47199d48-534c-4267-a654-d2d90e64b498   in service    fd00:1122:3344:101::29
+    crucible          587be699-a320-4c79-b320-128d9ecddc0b   in service    fd00:1122:3344:101::27
+    crucible          6fa06115-4959-4913-8e7b-dd70d7651f07   in service    fd00:1122:3344:101::28
+    crucible          704e1fed-f8d6-4cfa-a470-bad27fdc06d1   in service    fd00:1122:3344:101::2a
+    crucible          8f3a1cc5-9195-4a30-ad02-b804278fe639   in service    fd00:1122:3344:101::24
+    crucible          a2079cbc-a69e-41a1-b1e0-fbcb972d03f6   in service    fd00:1122:3344:101::26
+    crucible          af322036-371f-437c-8c08-7f40f3f1403b   in service    fd00:1122:3344:101::2b
+    crucible          d637264f-6f40-44c2-8b7e-a179430210d2   in service    fd00:1122:3344:101::2d
+    crucible          edabedf3-839c-488d-ad6f-508ffa864674   in service    fd00:1122:3344:101::2c
+    crucible_pantry   02acbe6a-1c88-47e3-94c3-94084cbde098   in service    fd00:1122:3344:101::23
+    internal_dns      07c3c805-8888-4fe5-9543-3d2479dbe6f3   in service    fd00:1122:3344:2::1   
+    internal_ntp      10d98a73-ec88-4aff-a7e8-7db6a87880e6   in service    fd00:1122:3344:101::21
+    nexus             a1696cd4-588c-484a-b95b-66e824c0ce05   in service    fd00:1122:3344:101::22
 
 
   sled 590e3034-d946-4166-b0e5-2d0034197a07 (active):
@@ -97,22 +99,23 @@ to:   blueprint f432fcd5-1284-4058-8b4a-9286a3de6163
 
 
     omicron zones at generation 2:
-    ------------------------------------------------------------------------------------------
-    zone type      zone id                                disposition   underlay IP           
-    ------------------------------------------------------------------------------------------
-    crucible       0565e7e4-f13a-4123-8928-d715f83e36aa   in service    fd00:1122:3344:102::2a
-    crucible       062ce37d-7448-4d44-b1f4-4937cd2eb174   in service    fd00:1122:3344:102::2c
-    crucible       18f8fe40-646e-4962-b17a-20e201f3a6e5   in service    fd00:1122:3344:102::26
-    crucible       1cc3f503-2001-4d85-80e5-c7c40d2e3b10   in service    fd00:1122:3344:102::29
-    crucible       56d5d7cf-db2c-40a3-a775-003241ad4820   in service    fd00:1122:3344:102::25
-    crucible       62058f4c-c747-4e21-a8dc-2fd4a160c98c   in service    fd00:1122:3344:102::2b
-    crucible       6af7f4d6-33b6-4eb3-a146-d8e9e4ae9d66   in service    fd00:1122:3344:102::27
-    crucible       93f2f40c-5616-4d8d-8519-ec6debdcede0   in service    fd00:1122:3344:102::28
-    crucible       ab7ba6df-d401-40bd-940e-faf57c57aa2a   in service    fd00:1122:3344:102::24
-    crucible       dce226c9-7373-4bfa-8a94-79dc472857a6   in service    fd00:1122:3344:102::23
-    internal_dns   7a9f60d3-2b66-4547-9b63-7d4f7a8b6382   in service    fd00:1122:3344:3::1   
-    internal_ntp   edabedf3-839c-488d-ad6f-508ffa864674   in service    fd00:1122:3344:102::21
-    nexus          d637264f-6f40-44c2-8b7e-a179430210d2   in service    fd00:1122:3344:102::22
+    ---------------------------------------------------------------------------------------------
+    zone type         zone id                                disposition   underlay IP           
+    ---------------------------------------------------------------------------------------------
+    crucible          0565e7e4-f13a-4123-8928-d715f83e36aa   in service    fd00:1122:3344:102::28
+    crucible          062ce37d-7448-4d44-b1f4-4937cd2eb174   in service    fd00:1122:3344:102::2a
+    crucible          1211a68e-69a1-4ef4-b790-45b0279f9159   in service    fd00:1122:3344:102::2d
+    crucible          18f8fe40-646e-4962-b17a-20e201f3a6e5   in service    fd00:1122:3344:102::24
+    crucible          1cc3f503-2001-4d85-80e5-c7c40d2e3b10   in service    fd00:1122:3344:102::27
+    crucible          62058f4c-c747-4e21-a8dc-2fd4a160c98c   in service    fd00:1122:3344:102::29
+    crucible          6af7f4d6-33b6-4eb3-a146-d8e9e4ae9d66   in service    fd00:1122:3344:102::25
+    crucible          78d6ab36-e8c8-4ff8-9f89-75c7fe2d32e6   in service    fd00:1122:3344:102::2b
+    crucible          93f2f40c-5616-4d8d-8519-ec6debdcede0   in service    fd00:1122:3344:102::26
+    crucible          9f824c30-6360-46b9-87c4-cd60586476fe   in service    fd00:1122:3344:102::2c
+    crucible_pantry   56d5d7cf-db2c-40a3-a775-003241ad4820   in service    fd00:1122:3344:102::23
+    internal_dns      ab7ba6df-d401-40bd-940e-faf57c57aa2a   in service    fd00:1122:3344:3::1   
+    internal_ntp      7a9f60d3-2b66-4547-9b63-7d4f7a8b6382   in service    fd00:1122:3344:102::21
+    nexus             dce226c9-7373-4bfa-8a94-79dc472857a6   in service    fd00:1122:3344:102::22
 
 
  MODIFIED SLEDS:

--- a/nexus/reconfigurator/planning/tests/output/planner_decommissions_sleds_1_2.txt
+++ b/nexus/reconfigurator/planning/tests/output/planner_decommissions_sleds_1_2.txt
@@ -22,37 +22,39 @@ to:   blueprint 1ac2d88f-27dd-4506-8585-6b2be832528e
 
 
     omicron zones generation 2 -> 3:
-    -------------------------------------------------------------------------------------------
-    zone type      zone id                                disposition    underlay IP           
-    -------------------------------------------------------------------------------------------
-*   clickhouse     4e36b7ef-5684-4304-b7c3-3c31aaf83d4f   - in service   fd00:1122:3344:103::23
-     └─                                                   + expunged                           
-*   crucible       1e1ed0cc-1adc-410f-943a-d1a3107de619   - in service   fd00:1122:3344:103::26
-     └─                                                   + expunged                           
-*   crucible       2307bbed-02ba-493b-89e3-46585c74c8fc   - in service   fd00:1122:3344:103::27
-     └─                                                   + expunged                           
-*   crucible       603e629d-2599-400e-b879-4134d4cc426e   - in service   fd00:1122:3344:103::2b
-     └─                                                   + expunged                           
-*   crucible       9179d6dc-387d-424e-8d62-ed59b2c728f6   - in service   fd00:1122:3344:103::29
-     └─                                                   + expunged                           
-*   crucible       ad76d200-5675-444b-b19c-684689ff421f   - in service   fd00:1122:3344:103::2c
-     └─                                                   + expunged                           
-*   crucible       c28d7b4b-a259-45ad-945d-f19ca3c6964c   - in service   fd00:1122:3344:103::28
-     └─                                                   + expunged                           
-*   crucible       e29998e7-9ed2-46b6-bb70-4118159fe07f   - in service   fd00:1122:3344:103::25
-     └─                                                   + expunged                           
-*   crucible       e9bf2525-5fa0-4c1b-b52d-481225083845   - in service   fd00:1122:3344:103::2d
-     └─                                                   + expunged                           
-*   crucible       f06e91a1-0c17-4cca-adbc-1c9b67bdb11d   - in service   fd00:1122:3344:103::2a
-     └─                                                   + expunged                           
-*   crucible       f11f5c60-1ac7-4630-9a3a-a9bc85c75203   - in service   fd00:1122:3344:103::24
-     └─                                                   + expunged                           
-*   internal_dns   f231e4eb-3fc9-4964-9d71-2c41644852d9   - in service   fd00:1122:3344:1::1   
-     └─                                                   + expunged                           
-*   internal_ntp   c62b87b6-b98d-4d22-ba4f-cee4499e2ba8   - in service   fd00:1122:3344:103::21
-     └─                                                   + expunged                           
-*   nexus          6a70a233-1900-43c0-9c00-aa9d1f7adfbc   - in service   fd00:1122:3344:103::22
-     └─                                                   + expunged                           
+    ----------------------------------------------------------------------------------------------
+    zone type         zone id                                disposition    underlay IP           
+    ----------------------------------------------------------------------------------------------
+*   clickhouse        4e36b7ef-5684-4304-b7c3-3c31aaf83d4f   - in service   fd00:1122:3344:103::23
+     └─                                                      + expunged                           
+*   crucible          1e1ed0cc-1adc-410f-943a-d1a3107de619   - in service   fd00:1122:3344:103::26
+     └─                                                      + expunged                           
+*   crucible          2307bbed-02ba-493b-89e3-46585c74c8fc   - in service   fd00:1122:3344:103::27
+     └─                                                      + expunged                           
+*   crucible          2e65b765-5c41-4519-bf4e-e2a68569afc1   - in service   fd00:1122:3344:103::2e
+     └─                                                      + expunged                           
+*   crucible          603e629d-2599-400e-b879-4134d4cc426e   - in service   fd00:1122:3344:103::2b
+     └─                                                      + expunged                           
+*   crucible          9179d6dc-387d-424e-8d62-ed59b2c728f6   - in service   fd00:1122:3344:103::29
+     └─                                                      + expunged                           
+*   crucible          ad76d200-5675-444b-b19c-684689ff421f   - in service   fd00:1122:3344:103::2c
+     └─                                                      + expunged                           
+*   crucible          c28d7b4b-a259-45ad-945d-f19ca3c6964c   - in service   fd00:1122:3344:103::28
+     └─                                                      + expunged                           
+*   crucible          e29998e7-9ed2-46b6-bb70-4118159fe07f   - in service   fd00:1122:3344:103::25
+     └─                                                      + expunged                           
+*   crucible          e9bf2525-5fa0-4c1b-b52d-481225083845   - in service   fd00:1122:3344:103::2d
+     └─                                                      + expunged                           
+*   crucible          f06e91a1-0c17-4cca-adbc-1c9b67bdb11d   - in service   fd00:1122:3344:103::2a
+     └─                                                      + expunged                           
+*   crucible_pantry   f11f5c60-1ac7-4630-9a3a-a9bc85c75203   - in service   fd00:1122:3344:103::24
+     └─                                                      + expunged                           
+*   internal_dns      f231e4eb-3fc9-4964-9d71-2c41644852d9   - in service   fd00:1122:3344:1::1   
+     └─                                                      + expunged                           
+*   internal_ntp      c62b87b6-b98d-4d22-ba4f-cee4499e2ba8   - in service   fd00:1122:3344:103::21
+     └─                                                      + expunged                           
+*   nexus             6a70a233-1900-43c0-9c00-aa9d1f7adfbc   - in service   fd00:1122:3344:103::22
+     └─                                                      + expunged                           
 
 
   sled d67ce8f0-a691-4010-b414-420d82e80527 (active):
@@ -74,23 +76,24 @@ to:   blueprint 1ac2d88f-27dd-4506-8585-6b2be832528e
 
 
     omicron zones generation 2 -> 3:
-    ------------------------------------------------------------------------------------------
-    zone type      zone id                                disposition   underlay IP           
-    ------------------------------------------------------------------------------------------
-    crucible       15dbaa30-1539-49d6-970d-ba5962960f33   in service    fd00:1122:3344:101::24
-    crucible       4f8ce495-21dd-48a1-859c-80d34ce394ed   in service    fd00:1122:3344:101::2c
-    crucible       5d9d8fa7-8379-470b-90ba-fe84a3c45512   in service    fd00:1122:3344:101::27
-    crucible       70232a6d-6c9d-4fa6-a34d-9c73d940db33   in service    fd00:1122:3344:101::25
-    crucible       8567a616-a709-4c8c-a323-4474675dad5c   in service    fd00:1122:3344:101::29
-    crucible       8b0b8623-930a-41af-9f9b-ca28b1b11139   in service    fd00:1122:3344:101::26
-    crucible       99c6401d-9796-4ae1-bf0c-9a097cf21c33   in service    fd00:1122:3344:101::2b
-    crucible       cf87d2a3-d323-44a3-a87e-adc4ef6c75f4   in service    fd00:1122:3344:101::28
-    crucible       eac6c0a0-baa5-4490-9cee-65198b7fbd9c   in service    fd00:1122:3344:101::23
-    crucible       f68846ad-4619-4747-8293-a2b4aeeafc5b   in service    fd00:1122:3344:101::2a
-    internal_dns   3d4143df-e212-4774-9258-7d9b421fac2e   in service    fd00:1122:3344:2::1   
-    internal_ntp   2e65b765-5c41-4519-bf4e-e2a68569afc1   in service    fd00:1122:3344:101::21
-    nexus          1ec4cc7b-2f00-4d13-8176-3b9815533ae9   in service    fd00:1122:3344:101::22
-+   internal_dns   ff9ce09c-afbf-425b-bbfa-3d8fb254f98e   in service    fd00:1122:3344:1::1   
+    ---------------------------------------------------------------------------------------------
+    zone type         zone id                                disposition   underlay IP           
+    ---------------------------------------------------------------------------------------------
+    crucible          4f8ce495-21dd-48a1-859c-80d34ce394ed   in service    fd00:1122:3344:101::2b
+    crucible          5d9d8fa7-8379-470b-90ba-fe84a3c45512   in service    fd00:1122:3344:101::26
+    crucible          70232a6d-6c9d-4fa6-a34d-9c73d940db33   in service    fd00:1122:3344:101::24
+    crucible          8567a616-a709-4c8c-a323-4474675dad5c   in service    fd00:1122:3344:101::28
+    crucible          8b0b8623-930a-41af-9f9b-ca28b1b11139   in service    fd00:1122:3344:101::25
+    crucible          99c6401d-9796-4ae1-bf0c-9a097cf21c33   in service    fd00:1122:3344:101::2a
+    crucible          a1ae92ac-e1f1-4654-ab54-5b75ba7c44d6   in service    fd00:1122:3344:101::2c
+    crucible          a308d3e1-118c-440a-947a-8b6ab7d833ab   in service    fd00:1122:3344:101::2d
+    crucible          cf87d2a3-d323-44a3-a87e-adc4ef6c75f4   in service    fd00:1122:3344:101::27
+    crucible          f68846ad-4619-4747-8293-a2b4aeeafc5b   in service    fd00:1122:3344:101::29
+    crucible_pantry   15dbaa30-1539-49d6-970d-ba5962960f33   in service    fd00:1122:3344:101::23
+    internal_dns      eac6c0a0-baa5-4490-9cee-65198b7fbd9c   in service    fd00:1122:3344:2::1   
+    internal_ntp      1ec4cc7b-2f00-4d13-8176-3b9815533ae9   in service    fd00:1122:3344:101::21
+    nexus             3d4143df-e212-4774-9258-7d9b421fac2e   in service    fd00:1122:3344:101::22
++   internal_dns      ff9ce09c-afbf-425b-bbfa-3d8fb254f98e   in service    fd00:1122:3344:1::1   
 
 
   sled fefcf4cf-f7e7-46b3-b629-058526ce440e (active):
@@ -112,24 +115,25 @@ to:   blueprint 1ac2d88f-27dd-4506-8585-6b2be832528e
 
 
     omicron zones generation 2 -> 3:
-    ------------------------------------------------------------------------------------------
-    zone type      zone id                                disposition   underlay IP           
-    ------------------------------------------------------------------------------------------
-    crucible       0e2b035e-1de1-48af-8ac0-5316418e3de1   in service    fd00:1122:3344:102::26
-    crucible       15f29557-d4da-45ef-b435-a0a1cd586e0c   in service    fd00:1122:3344:102::2c
-    crucible       2bf9ee97-90e1-48a7-bb06-a35cec63b7fe   in service    fd00:1122:3344:102::2a
-    crucible       5c78756d-6182-4c27-a507-3419e8dbe76b   in service    fd00:1122:3344:102::24
-    crucible       b7402110-d88f-4ca4-8391-4a2fda6ad271   in service    fd00:1122:3344:102::25
-    crucible       b7ae596e-0c85-40b2-bb47-df9f76db3cca   in service    fd00:1122:3344:102::27
-    crucible       cf13b878-47f1-4ba0-b8c2-9f3e15f2ee87   in service    fd00:1122:3344:102::28
-    crucible       e3bfcb1e-3708-45e7-a45a-2a2cab7ad829   in service    fd00:1122:3344:102::2b
-    crucible       e6d0df1f-9f98-4c5a-9540-8444d1185c7d   in service    fd00:1122:3344:102::23
-    crucible       eb034526-1767-4cc4-8225-ec962265710b   in service    fd00:1122:3344:102::29
-    internal_dns   c552280f-ba02-4f8d-9049-bd269e6b7845   in service    fd00:1122:3344:3::1   
-    internal_ntp   a1ae92ac-e1f1-4654-ab54-5b75ba7c44d6   in service    fd00:1122:3344:102::21
-    nexus          a308d3e1-118c-440a-947a-8b6ab7d833ab   in service    fd00:1122:3344:102::22
-+   clickhouse     c8851a11-a4f7-4b21-9281-6182fd15dc8d   in service    fd00:1122:3344:102::2d
-+   nexus          e639b672-27c4-4ecb-82c1-d672eb1ccf4e   in service    fd00:1122:3344:102::2e
+    ---------------------------------------------------------------------------------------------
+    zone type         zone id                                disposition   underlay IP           
+    ---------------------------------------------------------------------------------------------
+    crucible          0e2b035e-1de1-48af-8ac0-5316418e3de1   in service    fd00:1122:3344:102::24
+    crucible          15f29557-d4da-45ef-b435-a0a1cd586e0c   in service    fd00:1122:3344:102::2a
+    crucible          2bf9ee97-90e1-48a7-bb06-a35cec63b7fe   in service    fd00:1122:3344:102::28
+    crucible          5cf79919-b28e-4064-b6f8-8906c471b5ce   in service    fd00:1122:3344:102::2d
+    crucible          751bc6fe-22ad-4ce1-bc51-cf31fdf02bfa   in service    fd00:1122:3344:102::2b
+    crucible          b7ae596e-0c85-40b2-bb47-df9f76db3cca   in service    fd00:1122:3344:102::25
+    crucible          cf13b878-47f1-4ba0-b8c2-9f3e15f2ee87   in service    fd00:1122:3344:102::26
+    crucible          e3bfcb1e-3708-45e7-a45a-2a2cab7ad829   in service    fd00:1122:3344:102::29
+    crucible          e5121f83-faf2-4928-b5a8-94a1da99e8eb   in service    fd00:1122:3344:102::2c
+    crucible          eb034526-1767-4cc4-8225-ec962265710b   in service    fd00:1122:3344:102::27
+    crucible_pantry   b7402110-d88f-4ca4-8391-4a2fda6ad271   in service    fd00:1122:3344:102::23
+    internal_dns      5c78756d-6182-4c27-a507-3419e8dbe76b   in service    fd00:1122:3344:3::1   
+    internal_ntp      c552280f-ba02-4f8d-9049-bd269e6b7845   in service    fd00:1122:3344:102::21
+    nexus             e6d0df1f-9f98-4c5a-9540-8444d1185c7d   in service    fd00:1122:3344:102::22
++   clickhouse        c8851a11-a4f7-4b21-9281-6182fd15dc8d   in service    fd00:1122:3344:102::2e
++   nexus             e639b672-27c4-4ecb-82c1-d672eb1ccf4e   in service    fd00:1122:3344:102::2f
 
 
  COCKROACHDB SETTINGS:

--- a/nexus/reconfigurator/planning/tests/output/planner_decommissions_sleds_1_2.txt
+++ b/nexus/reconfigurator/planning/tests/output/planner_decommissions_sleds_1_2.txt
@@ -93,7 +93,8 @@ to:   blueprint 1ac2d88f-27dd-4506-8585-6b2be832528e
     internal_dns      eac6c0a0-baa5-4490-9cee-65198b7fbd9c   in service    fd00:1122:3344:2::1   
     internal_ntp      1ec4cc7b-2f00-4d13-8176-3b9815533ae9   in service    fd00:1122:3344:101::21
     nexus             3d4143df-e212-4774-9258-7d9b421fac2e   in service    fd00:1122:3344:101::22
-+   internal_dns      ff9ce09c-afbf-425b-bbfa-3d8fb254f98e   in service    fd00:1122:3344:1::1   
++   crucible_pantry   ff9ce09c-afbf-425b-bbfa-3d8fb254f98e   in service    fd00:1122:3344:101::2e
++   nexus             845869e9-ecb2-4ec3-b6b8-2a836e459243   in service    fd00:1122:3344:101::2f
 
 
   sled fefcf4cf-f7e7-46b3-b629-058526ce440e (active):
@@ -133,7 +134,7 @@ to:   blueprint 1ac2d88f-27dd-4506-8585-6b2be832528e
     internal_ntp      c552280f-ba02-4f8d-9049-bd269e6b7845   in service    fd00:1122:3344:102::21
     nexus             e6d0df1f-9f98-4c5a-9540-8444d1185c7d   in service    fd00:1122:3344:102::22
 +   clickhouse        c8851a11-a4f7-4b21-9281-6182fd15dc8d   in service    fd00:1122:3344:102::2e
-+   nexus             e639b672-27c4-4ecb-82c1-d672eb1ccf4e   in service    fd00:1122:3344:102::2f
++   internal_dns      e639b672-27c4-4ecb-82c1-d672eb1ccf4e   in service    fd00:1122:3344:1::1   
 
 
  COCKROACHDB SETTINGS:

--- a/nexus/reconfigurator/planning/tests/output/planner_decommissions_sleds_bp2.txt
+++ b/nexus/reconfigurator/planning/tests/output/planner_decommissions_sleds_bp2.txt
@@ -34,10 +34,11 @@ parent:    516e80a3-b362-4fac-bd3c-4559717120dd
     crucible          cf87d2a3-d323-44a3-a87e-adc4ef6c75f4   in service    fd00:1122:3344:101::27
     crucible          f68846ad-4619-4747-8293-a2b4aeeafc5b   in service    fd00:1122:3344:101::29
     crucible_pantry   15dbaa30-1539-49d6-970d-ba5962960f33   in service    fd00:1122:3344:101::23
+    crucible_pantry   ff9ce09c-afbf-425b-bbfa-3d8fb254f98e   in service    fd00:1122:3344:101::2e
     internal_dns      eac6c0a0-baa5-4490-9cee-65198b7fbd9c   in service    fd00:1122:3344:2::1   
-    internal_dns      ff9ce09c-afbf-425b-bbfa-3d8fb254f98e   in service    fd00:1122:3344:1::1   
     internal_ntp      1ec4cc7b-2f00-4d13-8176-3b9815533ae9   in service    fd00:1122:3344:101::21
     nexus             3d4143df-e212-4774-9258-7d9b421fac2e   in service    fd00:1122:3344:101::22
+    nexus             845869e9-ecb2-4ec3-b6b8-2a836e459243   in service    fd00:1122:3344:101::2f
 
 
 
@@ -76,8 +77,8 @@ parent:    516e80a3-b362-4fac-bd3c-4559717120dd
     crucible          eb034526-1767-4cc4-8225-ec962265710b   in service    fd00:1122:3344:102::27
     crucible_pantry   b7402110-d88f-4ca4-8391-4a2fda6ad271   in service    fd00:1122:3344:102::23
     internal_dns      5c78756d-6182-4c27-a507-3419e8dbe76b   in service    fd00:1122:3344:3::1   
+    internal_dns      e639b672-27c4-4ecb-82c1-d672eb1ccf4e   in service    fd00:1122:3344:1::1   
     internal_ntp      c552280f-ba02-4f8d-9049-bd269e6b7845   in service    fd00:1122:3344:102::21
-    nexus             e639b672-27c4-4ecb-82c1-d672eb1ccf4e   in service    fd00:1122:3344:102::2f
     nexus             e6d0df1f-9f98-4c5a-9540-8444d1185c7d   in service    fd00:1122:3344:102::22
 
 

--- a/nexus/reconfigurator/planning/tests/output/planner_decommissions_sleds_bp2.txt
+++ b/nexus/reconfigurator/planning/tests/output/planner_decommissions_sleds_bp2.txt
@@ -20,23 +20,24 @@ parent:    516e80a3-b362-4fac-bd3c-4559717120dd
 
 
     omicron zones at generation 3:
-    ------------------------------------------------------------------------------------------
-    zone type      zone id                                disposition   underlay IP           
-    ------------------------------------------------------------------------------------------
-    crucible       15dbaa30-1539-49d6-970d-ba5962960f33   in service    fd00:1122:3344:101::24
-    crucible       4f8ce495-21dd-48a1-859c-80d34ce394ed   in service    fd00:1122:3344:101::2c
-    crucible       5d9d8fa7-8379-470b-90ba-fe84a3c45512   in service    fd00:1122:3344:101::27
-    crucible       70232a6d-6c9d-4fa6-a34d-9c73d940db33   in service    fd00:1122:3344:101::25
-    crucible       8567a616-a709-4c8c-a323-4474675dad5c   in service    fd00:1122:3344:101::29
-    crucible       8b0b8623-930a-41af-9f9b-ca28b1b11139   in service    fd00:1122:3344:101::26
-    crucible       99c6401d-9796-4ae1-bf0c-9a097cf21c33   in service    fd00:1122:3344:101::2b
-    crucible       cf87d2a3-d323-44a3-a87e-adc4ef6c75f4   in service    fd00:1122:3344:101::28
-    crucible       eac6c0a0-baa5-4490-9cee-65198b7fbd9c   in service    fd00:1122:3344:101::23
-    crucible       f68846ad-4619-4747-8293-a2b4aeeafc5b   in service    fd00:1122:3344:101::2a
-    internal_dns   3d4143df-e212-4774-9258-7d9b421fac2e   in service    fd00:1122:3344:2::1   
-    internal_dns   ff9ce09c-afbf-425b-bbfa-3d8fb254f98e   in service    fd00:1122:3344:1::1   
-    internal_ntp   2e65b765-5c41-4519-bf4e-e2a68569afc1   in service    fd00:1122:3344:101::21
-    nexus          1ec4cc7b-2f00-4d13-8176-3b9815533ae9   in service    fd00:1122:3344:101::22
+    ---------------------------------------------------------------------------------------------
+    zone type         zone id                                disposition   underlay IP           
+    ---------------------------------------------------------------------------------------------
+    crucible          4f8ce495-21dd-48a1-859c-80d34ce394ed   in service    fd00:1122:3344:101::2b
+    crucible          5d9d8fa7-8379-470b-90ba-fe84a3c45512   in service    fd00:1122:3344:101::26
+    crucible          70232a6d-6c9d-4fa6-a34d-9c73d940db33   in service    fd00:1122:3344:101::24
+    crucible          8567a616-a709-4c8c-a323-4474675dad5c   in service    fd00:1122:3344:101::28
+    crucible          8b0b8623-930a-41af-9f9b-ca28b1b11139   in service    fd00:1122:3344:101::25
+    crucible          99c6401d-9796-4ae1-bf0c-9a097cf21c33   in service    fd00:1122:3344:101::2a
+    crucible          a1ae92ac-e1f1-4654-ab54-5b75ba7c44d6   in service    fd00:1122:3344:101::2c
+    crucible          a308d3e1-118c-440a-947a-8b6ab7d833ab   in service    fd00:1122:3344:101::2d
+    crucible          cf87d2a3-d323-44a3-a87e-adc4ef6c75f4   in service    fd00:1122:3344:101::27
+    crucible          f68846ad-4619-4747-8293-a2b4aeeafc5b   in service    fd00:1122:3344:101::29
+    crucible_pantry   15dbaa30-1539-49d6-970d-ba5962960f33   in service    fd00:1122:3344:101::23
+    internal_dns      eac6c0a0-baa5-4490-9cee-65198b7fbd9c   in service    fd00:1122:3344:2::1   
+    internal_dns      ff9ce09c-afbf-425b-bbfa-3d8fb254f98e   in service    fd00:1122:3344:1::1   
+    internal_ntp      1ec4cc7b-2f00-4d13-8176-3b9815533ae9   in service    fd00:1122:3344:101::21
+    nexus             3d4143df-e212-4774-9258-7d9b421fac2e   in service    fd00:1122:3344:101::22
 
 
 
@@ -59,47 +60,49 @@ parent:    516e80a3-b362-4fac-bd3c-4559717120dd
 
 
     omicron zones at generation 3:
-    ------------------------------------------------------------------------------------------
-    zone type      zone id                                disposition   underlay IP           
-    ------------------------------------------------------------------------------------------
-    clickhouse     c8851a11-a4f7-4b21-9281-6182fd15dc8d   in service    fd00:1122:3344:102::2d
-    crucible       0e2b035e-1de1-48af-8ac0-5316418e3de1   in service    fd00:1122:3344:102::26
-    crucible       15f29557-d4da-45ef-b435-a0a1cd586e0c   in service    fd00:1122:3344:102::2c
-    crucible       2bf9ee97-90e1-48a7-bb06-a35cec63b7fe   in service    fd00:1122:3344:102::2a
-    crucible       5c78756d-6182-4c27-a507-3419e8dbe76b   in service    fd00:1122:3344:102::24
-    crucible       b7402110-d88f-4ca4-8391-4a2fda6ad271   in service    fd00:1122:3344:102::25
-    crucible       b7ae596e-0c85-40b2-bb47-df9f76db3cca   in service    fd00:1122:3344:102::27
-    crucible       cf13b878-47f1-4ba0-b8c2-9f3e15f2ee87   in service    fd00:1122:3344:102::28
-    crucible       e3bfcb1e-3708-45e7-a45a-2a2cab7ad829   in service    fd00:1122:3344:102::2b
-    crucible       e6d0df1f-9f98-4c5a-9540-8444d1185c7d   in service    fd00:1122:3344:102::23
-    crucible       eb034526-1767-4cc4-8225-ec962265710b   in service    fd00:1122:3344:102::29
-    internal_dns   c552280f-ba02-4f8d-9049-bd269e6b7845   in service    fd00:1122:3344:3::1   
-    internal_ntp   a1ae92ac-e1f1-4654-ab54-5b75ba7c44d6   in service    fd00:1122:3344:102::21
-    nexus          a308d3e1-118c-440a-947a-8b6ab7d833ab   in service    fd00:1122:3344:102::22
-    nexus          e639b672-27c4-4ecb-82c1-d672eb1ccf4e   in service    fd00:1122:3344:102::2e
+    ---------------------------------------------------------------------------------------------
+    zone type         zone id                                disposition   underlay IP           
+    ---------------------------------------------------------------------------------------------
+    clickhouse        c8851a11-a4f7-4b21-9281-6182fd15dc8d   in service    fd00:1122:3344:102::2e
+    crucible          0e2b035e-1de1-48af-8ac0-5316418e3de1   in service    fd00:1122:3344:102::24
+    crucible          15f29557-d4da-45ef-b435-a0a1cd586e0c   in service    fd00:1122:3344:102::2a
+    crucible          2bf9ee97-90e1-48a7-bb06-a35cec63b7fe   in service    fd00:1122:3344:102::28
+    crucible          5cf79919-b28e-4064-b6f8-8906c471b5ce   in service    fd00:1122:3344:102::2d
+    crucible          751bc6fe-22ad-4ce1-bc51-cf31fdf02bfa   in service    fd00:1122:3344:102::2b
+    crucible          b7ae596e-0c85-40b2-bb47-df9f76db3cca   in service    fd00:1122:3344:102::25
+    crucible          cf13b878-47f1-4ba0-b8c2-9f3e15f2ee87   in service    fd00:1122:3344:102::26
+    crucible          e3bfcb1e-3708-45e7-a45a-2a2cab7ad829   in service    fd00:1122:3344:102::29
+    crucible          e5121f83-faf2-4928-b5a8-94a1da99e8eb   in service    fd00:1122:3344:102::2c
+    crucible          eb034526-1767-4cc4-8225-ec962265710b   in service    fd00:1122:3344:102::27
+    crucible_pantry   b7402110-d88f-4ca4-8391-4a2fda6ad271   in service    fd00:1122:3344:102::23
+    internal_dns      5c78756d-6182-4c27-a507-3419e8dbe76b   in service    fd00:1122:3344:3::1   
+    internal_ntp      c552280f-ba02-4f8d-9049-bd269e6b7845   in service    fd00:1122:3344:102::21
+    nexus             e639b672-27c4-4ecb-82c1-d672eb1ccf4e   in service    fd00:1122:3344:102::2f
+    nexus             e6d0df1f-9f98-4c5a-9540-8444d1185c7d   in service    fd00:1122:3344:102::22
 
 
 
 !a1b477db-b629-48eb-911d-1ccdafca75b9
 WARNING: Zones exist without physical disks!
     omicron zones at generation 3:
-    ------------------------------------------------------------------------------------------
-    zone type      zone id                                disposition   underlay IP           
-    ------------------------------------------------------------------------------------------
-    clickhouse     4e36b7ef-5684-4304-b7c3-3c31aaf83d4f   expunged      fd00:1122:3344:103::23
-    crucible       1e1ed0cc-1adc-410f-943a-d1a3107de619   expunged      fd00:1122:3344:103::26
-    crucible       2307bbed-02ba-493b-89e3-46585c74c8fc   expunged      fd00:1122:3344:103::27
-    crucible       603e629d-2599-400e-b879-4134d4cc426e   expunged      fd00:1122:3344:103::2b
-    crucible       9179d6dc-387d-424e-8d62-ed59b2c728f6   expunged      fd00:1122:3344:103::29
-    crucible       ad76d200-5675-444b-b19c-684689ff421f   expunged      fd00:1122:3344:103::2c
-    crucible       c28d7b4b-a259-45ad-945d-f19ca3c6964c   expunged      fd00:1122:3344:103::28
-    crucible       e29998e7-9ed2-46b6-bb70-4118159fe07f   expunged      fd00:1122:3344:103::25
-    crucible       e9bf2525-5fa0-4c1b-b52d-481225083845   expunged      fd00:1122:3344:103::2d
-    crucible       f06e91a1-0c17-4cca-adbc-1c9b67bdb11d   expunged      fd00:1122:3344:103::2a
-    crucible       f11f5c60-1ac7-4630-9a3a-a9bc85c75203   expunged      fd00:1122:3344:103::24
-    internal_dns   f231e4eb-3fc9-4964-9d71-2c41644852d9   expunged      fd00:1122:3344:1::1   
-    internal_ntp   c62b87b6-b98d-4d22-ba4f-cee4499e2ba8   expunged      fd00:1122:3344:103::21
-    nexus          6a70a233-1900-43c0-9c00-aa9d1f7adfbc   expunged      fd00:1122:3344:103::22
+    ---------------------------------------------------------------------------------------------
+    zone type         zone id                                disposition   underlay IP           
+    ---------------------------------------------------------------------------------------------
+    clickhouse        4e36b7ef-5684-4304-b7c3-3c31aaf83d4f   expunged      fd00:1122:3344:103::23
+    crucible          1e1ed0cc-1adc-410f-943a-d1a3107de619   expunged      fd00:1122:3344:103::26
+    crucible          2307bbed-02ba-493b-89e3-46585c74c8fc   expunged      fd00:1122:3344:103::27
+    crucible          2e65b765-5c41-4519-bf4e-e2a68569afc1   expunged      fd00:1122:3344:103::2e
+    crucible          603e629d-2599-400e-b879-4134d4cc426e   expunged      fd00:1122:3344:103::2b
+    crucible          9179d6dc-387d-424e-8d62-ed59b2c728f6   expunged      fd00:1122:3344:103::29
+    crucible          ad76d200-5675-444b-b19c-684689ff421f   expunged      fd00:1122:3344:103::2c
+    crucible          c28d7b4b-a259-45ad-945d-f19ca3c6964c   expunged      fd00:1122:3344:103::28
+    crucible          e29998e7-9ed2-46b6-bb70-4118159fe07f   expunged      fd00:1122:3344:103::25
+    crucible          e9bf2525-5fa0-4c1b-b52d-481225083845   expunged      fd00:1122:3344:103::2d
+    crucible          f06e91a1-0c17-4cca-adbc-1c9b67bdb11d   expunged      fd00:1122:3344:103::2a
+    crucible_pantry   f11f5c60-1ac7-4630-9a3a-a9bc85c75203   expunged      fd00:1122:3344:103::24
+    internal_dns      f231e4eb-3fc9-4964-9d71-2c41644852d9   expunged      fd00:1122:3344:1::1   
+    internal_ntp      c62b87b6-b98d-4d22-ba4f-cee4499e2ba8   expunged      fd00:1122:3344:103::21
+    nexus             6a70a233-1900-43c0-9c00-aa9d1f7adfbc   expunged      fd00:1122:3344:103::22
 
 
 
@@ -110,7 +113,7 @@ WARNING: Zones exist without physical disks!
  METADATA:
     created by:::::::::::   test_blueprint2
     created at:::::::::::   1970-01-01T00:00:00.000Z
-    comment::::::::::::::   sled a1b477db-b629-48eb-911d-1ccdafca75b9: expunged 14 zones because: sled policy is expunged
+    comment::::::::::::::   sled a1b477db-b629-48eb-911d-1ccdafca75b9: expunged 15 zones because: sled policy is expunged
     internal DNS version:   1
     external DNS version:   1
 

--- a/nexus/reconfigurator/planning/tests/output/planner_nonprovisionable_1_2.txt
+++ b/nexus/reconfigurator/planning/tests/output/planner_nonprovisionable_1_2.txt
@@ -22,23 +22,24 @@ to:   blueprint 9f71f5d3-a272-4382-9154-6ea2e171a6c6
 
 
     omicron zones at generation 2:
-    ------------------------------------------------------------------------------------------
-    zone type      zone id                                disposition   underlay IP           
-    ------------------------------------------------------------------------------------------
-    clickhouse     93b137a1-a1d6-4b5b-b2cb-21a9f11e2883   in service    fd00:1122:3344:105::23
-    crucible       19fbc4f8-a683-4f22-8f5a-e74782b935be   in service    fd00:1122:3344:105::25
-    crucible       2aa0ea4f-3561-4989-a98c-9ab7d9a240fb   in service    fd00:1122:3344:105::2d
-    crucible       4f1ce8a2-d3a5-4a38-be4c-9817de52db37   in service    fd00:1122:3344:105::2b
-    crucible       67d913e0-0005-4599-9b28-0abbf6cc2916   in service    fd00:1122:3344:105::2c
-    crucible       6b53ab2e-d98c-485f-87a3-4d5df595390f   in service    fd00:1122:3344:105::26
-    crucible       9f0abbad-dbd3-4d43-9675-78092217ffd9   in service    fd00:1122:3344:105::24
-    crucible       b0c63f48-01ea-4aae-bb26-fb0dd59d1662   in service    fd00:1122:3344:105::27
-    crucible       d660d7ed-28c0-45ae-9ace-dc3ecf7e8786   in service    fd00:1122:3344:105::29
-    crucible       e98cc0de-abf6-4da4-a20d-d05c7a9bb1d7   in service    fd00:1122:3344:105::2a
-    crucible       f55e6aaf-e8fc-4913-9e3c-8cd1bd4bdad3   in service    fd00:1122:3344:105::28
-    internal_dns   c406da50-34b9-4bb4-a460-8f49875d2a6a   in service    fd00:1122:3344:1::1   
-    internal_ntp   7f4e9f9f-08f8-4d14-885d-e977c05525ad   in service    fd00:1122:3344:105::21
-    nexus          6dff7633-66bb-4924-a6ff-2c896e66964b   in service    fd00:1122:3344:105::22
+    ---------------------------------------------------------------------------------------------
+    zone type         zone id                                disposition   underlay IP           
+    ---------------------------------------------------------------------------------------------
+    clickhouse        93b137a1-a1d6-4b5b-b2cb-21a9f11e2883   in service    fd00:1122:3344:105::23
+    crucible          19fbc4f8-a683-4f22-8f5a-e74782b935be   in service    fd00:1122:3344:105::25
+    crucible          2aa0ea4f-3561-4989-a98c-9ab7d9a240fb   in service    fd00:1122:3344:105::2d
+    crucible          4f1ce8a2-d3a5-4a38-be4c-9817de52db37   in service    fd00:1122:3344:105::2b
+    crucible          67622d61-2df4-414d-aa0e-d1277265f405   in service    fd00:1122:3344:105::2e
+    crucible          67d913e0-0005-4599-9b28-0abbf6cc2916   in service    fd00:1122:3344:105::2c
+    crucible          6b53ab2e-d98c-485f-87a3-4d5df595390f   in service    fd00:1122:3344:105::26
+    crucible          b0c63f48-01ea-4aae-bb26-fb0dd59d1662   in service    fd00:1122:3344:105::27
+    crucible          d660d7ed-28c0-45ae-9ace-dc3ecf7e8786   in service    fd00:1122:3344:105::29
+    crucible          e98cc0de-abf6-4da4-a20d-d05c7a9bb1d7   in service    fd00:1122:3344:105::2a
+    crucible          f55e6aaf-e8fc-4913-9e3c-8cd1bd4bdad3   in service    fd00:1122:3344:105::28
+    crucible_pantry   9f0abbad-dbd3-4d43-9675-78092217ffd9   in service    fd00:1122:3344:105::24
+    internal_dns      c406da50-34b9-4bb4-a460-8f49875d2a6a   in service    fd00:1122:3344:1::1   
+    internal_ntp      7f4e9f9f-08f8-4d14-885d-e977c05525ad   in service    fd00:1122:3344:105::21
+    nexus             6dff7633-66bb-4924-a6ff-2c896e66964b   in service    fd00:1122:3344:105::22
 
 
  MODIFIED SLEDS:
@@ -62,35 +63,37 @@ to:   blueprint 9f71f5d3-a272-4382-9154-6ea2e171a6c6
 
 
     omicron zones generation 2 -> 3:
-    -------------------------------------------------------------------------------------------
-    zone type      zone id                                disposition    underlay IP           
-    -------------------------------------------------------------------------------------------
-*   crucible       01d58626-e1b0-480f-96be-ac784863c7dc   - in service   fd00:1122:3344:103::2b
-     └─                                                   + expunged                           
-*   crucible       094f27af-1acb-4d1e-ba97-1fc1377d4bf2   - in service   fd00:1122:3344:103::29
-     └─                                                   + expunged                           
-*   crucible       2f5e8010-a94d-43a4-9c5c-3f52832f5f7f   - in service   fd00:1122:3344:103::24
-     └─                                                   + expunged                           
-*   crucible       47a87c6e-ef45-4d52-9a3e-69cdd96737cc   - in service   fd00:1122:3344:103::2c
-     └─                                                   + expunged                           
-*   crucible       4a9a0a9d-87f0-4f1d-9181-27f6b435e637   - in service   fd00:1122:3344:103::25
-     └─                                                   + expunged                           
-*   crucible       b91b271d-8d80-4f49-99a0-34006ae86063   - in service   fd00:1122:3344:103::27
-     └─                                                   + expunged                           
-*   crucible       d6ee1338-3127-43ec-9aaa-b973ccf05496   - in service   fd00:1122:3344:103::23
-     └─                                                   + expunged                           
-*   crucible       e39d7c9e-182b-48af-af87-58079d723583   - in service   fd00:1122:3344:103::26
-     └─                                                   + expunged                           
-*   crucible       f3f2e4f3-0985-4ef6-8336-ce479382d05d   - in service   fd00:1122:3344:103::2a
-     └─                                                   + expunged                           
-*   crucible       f69f92a1-5007-4bb0-a85b-604dc217154b   - in service   fd00:1122:3344:103::28
-     └─                                                   + expunged                           
-*   internal_dns   0dcfdfc5-481e-4153-b97c-11cf02b648ea   - in service   fd00:1122:3344:2::1   
-     └─                                                   + expunged                           
-*   internal_ntp   67622d61-2df4-414d-aa0e-d1277265f405   - in service   fd00:1122:3344:103::21
-     └─                                                   + expunged                           
-*   nexus          56ac1706-9e2a-49ba-bd6f-a99c44cb2ccb   - in service   fd00:1122:3344:103::22
-     └─                                                   + expunged                           
+    ----------------------------------------------------------------------------------------------
+    zone type         zone id                                disposition    underlay IP           
+    ----------------------------------------------------------------------------------------------
+*   crucible          01d58626-e1b0-480f-96be-ac784863c7dc   - in service   fd00:1122:3344:103::2a
+     └─                                                      + expunged                           
+*   crucible          094f27af-1acb-4d1e-ba97-1fc1377d4bf2   - in service   fd00:1122:3344:103::28
+     └─                                                      + expunged                           
+*   crucible          47a87c6e-ef45-4d52-9a3e-69cdd96737cc   - in service   fd00:1122:3344:103::2b
+     └─                                                      + expunged                           
+*   crucible          4a9a0a9d-87f0-4f1d-9181-27f6b435e637   - in service   fd00:1122:3344:103::24
+     └─                                                      + expunged                           
+*   crucible          6464d025-4652-4948-919e-740bec5699b1   - in service   fd00:1122:3344:103::2c
+     └─                                                      + expunged                           
+*   crucible          878dfddd-3113-4197-a3ea-e0d4dbe9b476   - in service   fd00:1122:3344:103::2d
+     └─                                                      + expunged                           
+*   crucible          b91b271d-8d80-4f49-99a0-34006ae86063   - in service   fd00:1122:3344:103::26
+     └─                                                      + expunged                           
+*   crucible          e39d7c9e-182b-48af-af87-58079d723583   - in service   fd00:1122:3344:103::25
+     └─                                                      + expunged                           
+*   crucible          f3f2e4f3-0985-4ef6-8336-ce479382d05d   - in service   fd00:1122:3344:103::29
+     └─                                                      + expunged                           
+*   crucible          f69f92a1-5007-4bb0-a85b-604dc217154b   - in service   fd00:1122:3344:103::27
+     └─                                                      + expunged                           
+*   crucible_pantry   2f5e8010-a94d-43a4-9c5c-3f52832f5f7f   - in service   fd00:1122:3344:103::23
+     └─                                                      + expunged                           
+*   internal_dns      d6ee1338-3127-43ec-9aaa-b973ccf05496   - in service   fd00:1122:3344:2::1   
+     └─                                                      + expunged                           
+*   internal_ntp      56ac1706-9e2a-49ba-bd6f-a99c44cb2ccb   - in service   fd00:1122:3344:103::21
+     └─                                                      + expunged                           
+*   nexus             0dcfdfc5-481e-4153-b97c-11cf02b648ea   - in service   fd00:1122:3344:103::22
+     └─                                                      + expunged                           
 
 
   sled 68d24ac5-f341-49ea-a92a-0381b52ab387 (active):
@@ -112,22 +115,23 @@ to:   blueprint 9f71f5d3-a272-4382-9154-6ea2e171a6c6
 
 
     omicron zones at generation 2:
-    ------------------------------------------------------------------------------------------
-    zone type      zone id                                disposition   underlay IP           
-    ------------------------------------------------------------------------------------------
-    crucible       3b3c14b6-a8e2-4054-a577-8d96cb576230   expunged      fd00:1122:3344:102::28
-    crucible       57b96d5c-b71e-43e4-8869-7d514003d00d   expunged      fd00:1122:3344:102::29
-    crucible       6939ce48-b17c-4616-b176-8a419a7697be   expunged      fd00:1122:3344:102::25
-    crucible       8d4d2b28-82bb-4e36-80da-1408d8c35d82   expunged      fd00:1122:3344:102::27
-    crucible       b1783e95-9598-451d-b6ba-c50b52b428c3   expunged      fd00:1122:3344:102::2c
-    crucible       b44cdbc0-0ce0-46eb-8b21-a09e113aa1d0   expunged      fd00:1122:3344:102::23
-    crucible       b4947d31-f70e-4ee0-8817-0ca6cea9b16b   expunged      fd00:1122:3344:102::2a
-    crucible       b6b759d0-f60d-42b7-bbbc-9d61c9e895a9   expunged      fd00:1122:3344:102::24
-    crucible       c407795c-6c8b-428e-8ab8-b962913c447f   expunged      fd00:1122:3344:102::26
-    crucible       e4b3e159-3dbe-48cb-8497-e3da92a90e5a   expunged      fd00:1122:3344:102::2b
-    internal_dns   9fd52961-426f-4e62-a644-b70871103fca   expunged      fd00:1122:3344:3::1   
-    internal_ntp   6464d025-4652-4948-919e-740bec5699b1   expunged      fd00:1122:3344:102::21
-    nexus          878dfddd-3113-4197-a3ea-e0d4dbe9b476   expunged      fd00:1122:3344:102::22
+    ---------------------------------------------------------------------------------------------
+    zone type         zone id                                disposition   underlay IP           
+    ---------------------------------------------------------------------------------------------
+    crucible          15bb9def-69b8-4d2e-b04f-9fee1143387c   expunged      fd00:1122:3344:102::2b
+    crucible          3b3c14b6-a8e2-4054-a577-8d96cb576230   expunged      fd00:1122:3344:102::26
+    crucible          57b96d5c-b71e-43e4-8869-7d514003d00d   expunged      fd00:1122:3344:102::27
+    crucible          8d4d2b28-82bb-4e36-80da-1408d8c35d82   expunged      fd00:1122:3344:102::25
+    crucible          996d7570-b0df-46d5-aaa4-0c97697cf484   expunged      fd00:1122:3344:102::2c
+    crucible          b1783e95-9598-451d-b6ba-c50b52b428c3   expunged      fd00:1122:3344:102::2a
+    crucible          b4947d31-f70e-4ee0-8817-0ca6cea9b16b   expunged      fd00:1122:3344:102::28
+    crucible          c407795c-6c8b-428e-8ab8-b962913c447f   expunged      fd00:1122:3344:102::24
+    crucible          c6dd531e-2d1d-423b-acc8-358533dab78c   expunged      fd00:1122:3344:102::2d
+    crucible          e4b3e159-3dbe-48cb-8497-e3da92a90e5a   expunged      fd00:1122:3344:102::29
+    crucible_pantry   6939ce48-b17c-4616-b176-8a419a7697be   expunged      fd00:1122:3344:102::23
+    internal_dns      b6b759d0-f60d-42b7-bbbc-9d61c9e895a9   expunged      fd00:1122:3344:3::1   
+    internal_ntp      9fd52961-426f-4e62-a644-b70871103fca   expunged      fd00:1122:3344:102::21
+    nexus             b44cdbc0-0ce0-46eb-8b21-a09e113aa1d0   expunged      fd00:1122:3344:102::22
 
 
   sled 75bc286f-2b4b-482c-9431-59272af529da (active):
@@ -152,18 +156,18 @@ to:   blueprint 9f71f5d3-a272-4382-9154-6ea2e171a6c6
     ------------------------------------------------------------------------------------------
     zone type      zone id                                disposition   underlay IP           
     ------------------------------------------------------------------------------------------
-    crucible       15c103f0-ac63-423b-ba5d-1b5fcd563ba3   in service    fd00:1122:3344:104::2a
-    crucible       23a8fa2b-ef3e-4017-a43f-f7a83953bd7c   in service    fd00:1122:3344:104::28
-    crucible       3aa07966-5899-4789-ace5-f8eeb375c6c3   in service    fd00:1122:3344:104::2c
-    crucible       621509d6-3772-4009-aca1-35eefd1098fb   in service    fd00:1122:3344:104::24
-    crucible       85b8c68a-160d-461d-94dd-1baf175fa75c   in service    fd00:1122:3344:104::26
-    crucible       95482c25-1e7f-43e8-adf1-e3548a1b3ae0   in service    fd00:1122:3344:104::2b
-    crucible       a732c489-d29a-4f75-b900-5966385943af   in service    fd00:1122:3344:104::25
-    crucible       c6dd531e-2d1d-423b-acc8-358533dab78c   in service    fd00:1122:3344:104::23
-    crucible       f0ff59e8-4105-4980-a4bb-a1f4c58de1e3   in service    fd00:1122:3344:104::27
-    crucible       f1a7b9a7-fc6a-4b23-b829-045ff33117ff   in service    fd00:1122:3344:104::29
-    internal_ntp   15bb9def-69b8-4d2e-b04f-9fee1143387c   in service    fd00:1122:3344:104::21
-    nexus          996d7570-b0df-46d5-aaa4-0c97697cf484   in service    fd00:1122:3344:104::22
+    crucible       0dfbf374-9ef9-430f-b06d-f271bf7f84c4   in service    fd00:1122:3344:104::2c
+    crucible       15c103f0-ac63-423b-ba5d-1b5fcd563ba3   in service    fd00:1122:3344:104::27
+    crucible       23a8fa2b-ef3e-4017-a43f-f7a83953bd7c   in service    fd00:1122:3344:104::25
+    crucible       3aa07966-5899-4789-ace5-f8eeb375c6c3   in service    fd00:1122:3344:104::29
+    crucible       72c5a909-077d-4ec1-a9d5-ae64ef9d716e   in service    fd00:1122:3344:104::2b
+    crucible       85b8c68a-160d-461d-94dd-1baf175fa75c   in service    fd00:1122:3344:104::23
+    crucible       95482c25-1e7f-43e8-adf1-e3548a1b3ae0   in service    fd00:1122:3344:104::28
+    crucible       c60379ba-4e30-4628-a79a-0ae509aef4c5   in service    fd00:1122:3344:104::2a
+    crucible       f0ff59e8-4105-4980-a4bb-a1f4c58de1e3   in service    fd00:1122:3344:104::24
+    crucible       f1a7b9a7-fc6a-4b23-b829-045ff33117ff   in service    fd00:1122:3344:104::26
+    internal_ntp   621509d6-3772-4009-aca1-35eefd1098fb   in service    fd00:1122:3344:104::21
+    nexus          a732c489-d29a-4f75-b900-5966385943af   in service    fd00:1122:3344:104::22
 +   nexus          2ec75441-3d7d-4b4b-9614-af03de5a3666   in service    fd00:1122:3344:104::2d
 +   nexus          508abd03-cbfe-4654-9a6d-7f15a1ad32e5   in service    fd00:1122:3344:104::2e
 +   nexus          59950bc8-1497-44dd-8cbf-b6502ba921b2   in service    fd00:1122:3344:104::2f
@@ -191,18 +195,18 @@ to:   blueprint 9f71f5d3-a272-4382-9154-6ea2e171a6c6
     ------------------------------------------------------------------------------------------
     zone type      zone id                                disposition   underlay IP           
     ------------------------------------------------------------------------------------------
-    crucible       0dfbf374-9ef9-430f-b06d-f271bf7f84c4   in service    fd00:1122:3344:101::23
-    crucible       414830dc-c8c1-4748-9e9e-bc3a6435a93c   in service    fd00:1122:3344:101::2c
-    crucible       4ad0e9da-08f8-4d40-b4d3-d17e711b5bbf   in service    fd00:1122:3344:101::25
-    crucible       772cbcbd-58be-4158-be85-be744871fa22   in service    fd00:1122:3344:101::29
-    crucible       a1c03689-fc62-4ea5-bb72-4d01f5138614   in service    fd00:1122:3344:101::26
-    crucible       a568e92e-4fbd-4b69-acd8-f16277073031   in service    fd00:1122:3344:101::28
-    crucible       be75764a-491b-4aec-992e-1c39e25de975   in service    fd00:1122:3344:101::2a
-    crucible       bf79a56a-97af-4cc4-94a5-8b20d64c2cda   in service    fd00:1122:3344:101::24
-    crucible       d47f4996-fac0-4657-bcea-01b1fee6404d   in service    fd00:1122:3344:101::27
-    crucible       e001fea0-6594-4ece-97e3-6198c293e931   in service    fd00:1122:3344:101::2b
-    internal_ntp   c60379ba-4e30-4628-a79a-0ae509aef4c5   in service    fd00:1122:3344:101::21
-    nexus          72c5a909-077d-4ec1-a9d5-ae64ef9d716e   in service    fd00:1122:3344:101::22
+    crucible       414830dc-c8c1-4748-9e9e-bc3a6435a93c   in service    fd00:1122:3344:101::29
+    crucible       66ecd4a6-73a7-4e26-9711-17abdd67a66e   in service    fd00:1122:3344:101::2c
+    crucible       772cbcbd-58be-4158-be85-be744871fa22   in service    fd00:1122:3344:101::26
+    crucible       a1c03689-fc62-4ea5-bb72-4d01f5138614   in service    fd00:1122:3344:101::23
+    crucible       a568e92e-4fbd-4b69-acd8-f16277073031   in service    fd00:1122:3344:101::25
+    crucible       a73f322a-9463-4d18-8f60-7ddf6f59f231   in service    fd00:1122:3344:101::2b
+    crucible       be75764a-491b-4aec-992e-1c39e25de975   in service    fd00:1122:3344:101::27
+    crucible       be920398-024a-4655-8c49-69b5ac48dfff   in service    fd00:1122:3344:101::2a
+    crucible       d47f4996-fac0-4657-bcea-01b1fee6404d   in service    fd00:1122:3344:101::24
+    crucible       e001fea0-6594-4ece-97e3-6198c293e931   in service    fd00:1122:3344:101::28
+    internal_ntp   bf79a56a-97af-4cc4-94a5-8b20d64c2cda   in service    fd00:1122:3344:101::21
+    nexus          4ad0e9da-08f8-4d40-b4d3-d17e711b5bbf   in service    fd00:1122:3344:101::22
 +   nexus          3ca5292f-8a59-4475-bb72-0f43714d0fff   in service    fd00:1122:3344:101::2e
 +   nexus          99f6d544-8599-4e2b-a55a-82d9e0034662   in service    fd00:1122:3344:101::2d
 +   nexus          c26b3bda-5561-44a1-a69f-22103fe209a1   in service    fd00:1122:3344:101::2f

--- a/nexus/reconfigurator/planning/tests/output/planner_nonprovisionable_2_2a.txt
+++ b/nexus/reconfigurator/planning/tests/output/planner_nonprovisionable_2_2a.txt
@@ -25,21 +25,21 @@ to:   blueprint 9f71f5d3-a272-4382-9154-6ea2e171a6c6
     ------------------------------------------------------------------------------------------
     zone type      zone id                                disposition   underlay IP           
     ------------------------------------------------------------------------------------------
-    crucible       15c103f0-ac63-423b-ba5d-1b5fcd563ba3   in service    fd00:1122:3344:104::2a
-    crucible       23a8fa2b-ef3e-4017-a43f-f7a83953bd7c   in service    fd00:1122:3344:104::28
-    crucible       3aa07966-5899-4789-ace5-f8eeb375c6c3   in service    fd00:1122:3344:104::2c
-    crucible       621509d6-3772-4009-aca1-35eefd1098fb   in service    fd00:1122:3344:104::24
-    crucible       85b8c68a-160d-461d-94dd-1baf175fa75c   in service    fd00:1122:3344:104::26
-    crucible       95482c25-1e7f-43e8-adf1-e3548a1b3ae0   in service    fd00:1122:3344:104::2b
-    crucible       a732c489-d29a-4f75-b900-5966385943af   in service    fd00:1122:3344:104::25
-    crucible       c6dd531e-2d1d-423b-acc8-358533dab78c   in service    fd00:1122:3344:104::23
-    crucible       f0ff59e8-4105-4980-a4bb-a1f4c58de1e3   in service    fd00:1122:3344:104::27
-    crucible       f1a7b9a7-fc6a-4b23-b829-045ff33117ff   in service    fd00:1122:3344:104::29
-    internal_ntp   15bb9def-69b8-4d2e-b04f-9fee1143387c   in service    fd00:1122:3344:104::21
+    crucible       0dfbf374-9ef9-430f-b06d-f271bf7f84c4   in service    fd00:1122:3344:104::2c
+    crucible       15c103f0-ac63-423b-ba5d-1b5fcd563ba3   in service    fd00:1122:3344:104::27
+    crucible       23a8fa2b-ef3e-4017-a43f-f7a83953bd7c   in service    fd00:1122:3344:104::25
+    crucible       3aa07966-5899-4789-ace5-f8eeb375c6c3   in service    fd00:1122:3344:104::29
+    crucible       72c5a909-077d-4ec1-a9d5-ae64ef9d716e   in service    fd00:1122:3344:104::2b
+    crucible       85b8c68a-160d-461d-94dd-1baf175fa75c   in service    fd00:1122:3344:104::23
+    crucible       95482c25-1e7f-43e8-adf1-e3548a1b3ae0   in service    fd00:1122:3344:104::28
+    crucible       c60379ba-4e30-4628-a79a-0ae509aef4c5   in service    fd00:1122:3344:104::2a
+    crucible       f0ff59e8-4105-4980-a4bb-a1f4c58de1e3   in service    fd00:1122:3344:104::24
+    crucible       f1a7b9a7-fc6a-4b23-b829-045ff33117ff   in service    fd00:1122:3344:104::26
+    internal_ntp   621509d6-3772-4009-aca1-35eefd1098fb   in service    fd00:1122:3344:104::21
     nexus          2ec75441-3d7d-4b4b-9614-af03de5a3666   in service    fd00:1122:3344:104::2d
     nexus          508abd03-cbfe-4654-9a6d-7f15a1ad32e5   in service    fd00:1122:3344:104::2e
     nexus          59950bc8-1497-44dd-8cbf-b6502ba921b2   in service    fd00:1122:3344:104::2f
-    nexus          996d7570-b0df-46d5-aaa4-0c97697cf484   in service    fd00:1122:3344:104::22
+    nexus          a732c489-d29a-4f75-b900-5966385943af   in service    fd00:1122:3344:104::22
 
 
   sled affab35f-600a-4109-8ea0-34a067a4e0bc (active):
@@ -64,19 +64,19 @@ to:   blueprint 9f71f5d3-a272-4382-9154-6ea2e171a6c6
     ------------------------------------------------------------------------------------------
     zone type      zone id                                disposition   underlay IP           
     ------------------------------------------------------------------------------------------
-    crucible       0dfbf374-9ef9-430f-b06d-f271bf7f84c4   in service    fd00:1122:3344:101::23
-    crucible       414830dc-c8c1-4748-9e9e-bc3a6435a93c   in service    fd00:1122:3344:101::2c
-    crucible       4ad0e9da-08f8-4d40-b4d3-d17e711b5bbf   in service    fd00:1122:3344:101::25
-    crucible       772cbcbd-58be-4158-be85-be744871fa22   in service    fd00:1122:3344:101::29
-    crucible       a1c03689-fc62-4ea5-bb72-4d01f5138614   in service    fd00:1122:3344:101::26
-    crucible       a568e92e-4fbd-4b69-acd8-f16277073031   in service    fd00:1122:3344:101::28
-    crucible       be75764a-491b-4aec-992e-1c39e25de975   in service    fd00:1122:3344:101::2a
-    crucible       bf79a56a-97af-4cc4-94a5-8b20d64c2cda   in service    fd00:1122:3344:101::24
-    crucible       d47f4996-fac0-4657-bcea-01b1fee6404d   in service    fd00:1122:3344:101::27
-    crucible       e001fea0-6594-4ece-97e3-6198c293e931   in service    fd00:1122:3344:101::2b
-    internal_ntp   c60379ba-4e30-4628-a79a-0ae509aef4c5   in service    fd00:1122:3344:101::21
+    crucible       414830dc-c8c1-4748-9e9e-bc3a6435a93c   in service    fd00:1122:3344:101::29
+    crucible       66ecd4a6-73a7-4e26-9711-17abdd67a66e   in service    fd00:1122:3344:101::2c
+    crucible       772cbcbd-58be-4158-be85-be744871fa22   in service    fd00:1122:3344:101::26
+    crucible       a1c03689-fc62-4ea5-bb72-4d01f5138614   in service    fd00:1122:3344:101::23
+    crucible       a568e92e-4fbd-4b69-acd8-f16277073031   in service    fd00:1122:3344:101::25
+    crucible       a73f322a-9463-4d18-8f60-7ddf6f59f231   in service    fd00:1122:3344:101::2b
+    crucible       be75764a-491b-4aec-992e-1c39e25de975   in service    fd00:1122:3344:101::27
+    crucible       be920398-024a-4655-8c49-69b5ac48dfff   in service    fd00:1122:3344:101::2a
+    crucible       d47f4996-fac0-4657-bcea-01b1fee6404d   in service    fd00:1122:3344:101::24
+    crucible       e001fea0-6594-4ece-97e3-6198c293e931   in service    fd00:1122:3344:101::28
+    internal_ntp   bf79a56a-97af-4cc4-94a5-8b20d64c2cda   in service    fd00:1122:3344:101::21
     nexus          3ca5292f-8a59-4475-bb72-0f43714d0fff   in service    fd00:1122:3344:101::2e
-    nexus          72c5a909-077d-4ec1-a9d5-ae64ef9d716e   in service    fd00:1122:3344:101::22
+    nexus          4ad0e9da-08f8-4d40-b4d3-d17e711b5bbf   in service    fd00:1122:3344:101::22
     nexus          99f6d544-8599-4e2b-a55a-82d9e0034662   in service    fd00:1122:3344:101::2d
     nexus          c26b3bda-5561-44a1-a69f-22103fe209a1   in service    fd00:1122:3344:101::2f
 
@@ -86,22 +86,23 @@ to:   blueprint 9f71f5d3-a272-4382-9154-6ea2e171a6c6
   sled 68d24ac5-f341-49ea-a92a-0381b52ab387 (was active):
 
     omicron zones from generation 2:
-    ------------------------------------------------------------------------------------------
-    zone type      zone id                                disposition   underlay IP           
-    ------------------------------------------------------------------------------------------
--   crucible       3b3c14b6-a8e2-4054-a577-8d96cb576230   expunged      fd00:1122:3344:102::28
--   crucible       57b96d5c-b71e-43e4-8869-7d514003d00d   expunged      fd00:1122:3344:102::29
--   crucible       6939ce48-b17c-4616-b176-8a419a7697be   expunged      fd00:1122:3344:102::25
--   crucible       8d4d2b28-82bb-4e36-80da-1408d8c35d82   expunged      fd00:1122:3344:102::27
--   crucible       b1783e95-9598-451d-b6ba-c50b52b428c3   expunged      fd00:1122:3344:102::2c
--   crucible       b44cdbc0-0ce0-46eb-8b21-a09e113aa1d0   expunged      fd00:1122:3344:102::23
--   crucible       b4947d31-f70e-4ee0-8817-0ca6cea9b16b   expunged      fd00:1122:3344:102::2a
--   crucible       b6b759d0-f60d-42b7-bbbc-9d61c9e895a9   expunged      fd00:1122:3344:102::24
--   crucible       c407795c-6c8b-428e-8ab8-b962913c447f   expunged      fd00:1122:3344:102::26
--   crucible       e4b3e159-3dbe-48cb-8497-e3da92a90e5a   expunged      fd00:1122:3344:102::2b
--   internal_dns   9fd52961-426f-4e62-a644-b70871103fca   expunged      fd00:1122:3344:3::1   
--   internal_ntp   6464d025-4652-4948-919e-740bec5699b1   expunged      fd00:1122:3344:102::21
--   nexus          878dfddd-3113-4197-a3ea-e0d4dbe9b476   expunged      fd00:1122:3344:102::22
+    ---------------------------------------------------------------------------------------------
+    zone type         zone id                                disposition   underlay IP           
+    ---------------------------------------------------------------------------------------------
+-   crucible          15bb9def-69b8-4d2e-b04f-9fee1143387c   expunged      fd00:1122:3344:102::2b
+-   crucible          3b3c14b6-a8e2-4054-a577-8d96cb576230   expunged      fd00:1122:3344:102::26
+-   crucible          57b96d5c-b71e-43e4-8869-7d514003d00d   expunged      fd00:1122:3344:102::27
+-   crucible          8d4d2b28-82bb-4e36-80da-1408d8c35d82   expunged      fd00:1122:3344:102::25
+-   crucible          996d7570-b0df-46d5-aaa4-0c97697cf484   expunged      fd00:1122:3344:102::2c
+-   crucible          b1783e95-9598-451d-b6ba-c50b52b428c3   expunged      fd00:1122:3344:102::2a
+-   crucible          b4947d31-f70e-4ee0-8817-0ca6cea9b16b   expunged      fd00:1122:3344:102::28
+-   crucible          c407795c-6c8b-428e-8ab8-b962913c447f   expunged      fd00:1122:3344:102::24
+-   crucible          c6dd531e-2d1d-423b-acc8-358533dab78c   expunged      fd00:1122:3344:102::2d
+-   crucible          e4b3e159-3dbe-48cb-8497-e3da92a90e5a   expunged      fd00:1122:3344:102::29
+-   crucible_pantry   6939ce48-b17c-4616-b176-8a419a7697be   expunged      fd00:1122:3344:102::23
+-   internal_dns      b6b759d0-f60d-42b7-bbbc-9d61c9e895a9   expunged      fd00:1122:3344:3::1   
+-   internal_ntp      9fd52961-426f-4e62-a644-b70871103fca   expunged      fd00:1122:3344:102::21
+-   nexus             b44cdbc0-0ce0-46eb-8b21-a09e113aa1d0   expunged      fd00:1122:3344:102::22
 
 
  MODIFIED SLEDS:
@@ -125,43 +126,45 @@ to:   blueprint 9f71f5d3-a272-4382-9154-6ea2e171a6c6
 
 
     omicron zones at generation 2:
-    -------------------------------------------------------------------------------------------
-    zone type      zone id                                disposition    underlay IP           
-    -------------------------------------------------------------------------------------------
-    clickhouse     93b137a1-a1d6-4b5b-b2cb-21a9f11e2883   in service     fd00:1122:3344:105::23
-    crucible       4f1ce8a2-d3a5-4a38-be4c-9817de52db37   in service     fd00:1122:3344:105::2b
-    crucible       67d913e0-0005-4599-9b28-0abbf6cc2916   in service     fd00:1122:3344:105::2c
-    crucible       6b53ab2e-d98c-485f-87a3-4d5df595390f   in service     fd00:1122:3344:105::26
-    crucible       9f0abbad-dbd3-4d43-9675-78092217ffd9   in service     fd00:1122:3344:105::24
-    crucible       b0c63f48-01ea-4aae-bb26-fb0dd59d1662   in service     fd00:1122:3344:105::27
-    crucible       d660d7ed-28c0-45ae-9ace-dc3ecf7e8786   in service     fd00:1122:3344:105::29
-    crucible       e98cc0de-abf6-4da4-a20d-d05c7a9bb1d7   in service     fd00:1122:3344:105::2a
-    crucible       f55e6aaf-e8fc-4913-9e3c-8cd1bd4bdad3   in service     fd00:1122:3344:105::28
-    internal_dns   c406da50-34b9-4bb4-a460-8f49875d2a6a   in service     fd00:1122:3344:1::1   
--   crucible       2aa0ea4f-3561-4989-a98c-9ab7d9a240fb   in service     fd00:1122:3344:105::2d
-*   crucible       19fbc4f8-a683-4f22-8f5a-e74782b935be   - in service   fd00:1122:3344:105::25
-     └─                                                   + quiesced                           
+    ----------------------------------------------------------------------------------------------
+    zone type         zone id                                disposition    underlay IP           
+    ----------------------------------------------------------------------------------------------
+    clickhouse        93b137a1-a1d6-4b5b-b2cb-21a9f11e2883   in service     fd00:1122:3344:105::23
+    crucible          4f1ce8a2-d3a5-4a38-be4c-9817de52db37   in service     fd00:1122:3344:105::2b
+    crucible          67622d61-2df4-414d-aa0e-d1277265f405   in service     fd00:1122:3344:105::2e
+    crucible          67d913e0-0005-4599-9b28-0abbf6cc2916   in service     fd00:1122:3344:105::2c
+    crucible          6b53ab2e-d98c-485f-87a3-4d5df595390f   in service     fd00:1122:3344:105::26
+    crucible          b0c63f48-01ea-4aae-bb26-fb0dd59d1662   in service     fd00:1122:3344:105::27
+    crucible          d660d7ed-28c0-45ae-9ace-dc3ecf7e8786   in service     fd00:1122:3344:105::29
+    crucible          e98cc0de-abf6-4da4-a20d-d05c7a9bb1d7   in service     fd00:1122:3344:105::2a
+    crucible          f55e6aaf-e8fc-4913-9e3c-8cd1bd4bdad3   in service     fd00:1122:3344:105::28
+    crucible_pantry   9f0abbad-dbd3-4d43-9675-78092217ffd9   in service     fd00:1122:3344:105::24
+    internal_dns      c406da50-34b9-4bb4-a460-8f49875d2a6a   in service     fd00:1122:3344:1::1   
+-   crucible          2aa0ea4f-3561-4989-a98c-9ab7d9a240fb   in service     fd00:1122:3344:105::2d
+*   crucible          19fbc4f8-a683-4f22-8f5a-e74782b935be   - in service   fd00:1122:3344:105::25
+     └─                                                      + quiesced                           
 
 
   sled 48d95fef-bc9f-4f50-9a53-1e075836291d (decommissioned):
 
     omicron zones generation 3 -> 4:
-    ------------------------------------------------------------------------------------------
-    zone type      zone id                                disposition   underlay IP           
-    ------------------------------------------------------------------------------------------
--   crucible       01d58626-e1b0-480f-96be-ac784863c7dc   expunged      fd00:1122:3344:103::2b
--   crucible       094f27af-1acb-4d1e-ba97-1fc1377d4bf2   expunged      fd00:1122:3344:103::29
--   crucible       2f5e8010-a94d-43a4-9c5c-3f52832f5f7f   expunged      fd00:1122:3344:103::24
--   crucible       47a87c6e-ef45-4d52-9a3e-69cdd96737cc   expunged      fd00:1122:3344:103::2c
--   crucible       4a9a0a9d-87f0-4f1d-9181-27f6b435e637   expunged      fd00:1122:3344:103::25
--   crucible       b91b271d-8d80-4f49-99a0-34006ae86063   expunged      fd00:1122:3344:103::27
--   crucible       d6ee1338-3127-43ec-9aaa-b973ccf05496   expunged      fd00:1122:3344:103::23
--   crucible       e39d7c9e-182b-48af-af87-58079d723583   expunged      fd00:1122:3344:103::26
--   crucible       f3f2e4f3-0985-4ef6-8336-ce479382d05d   expunged      fd00:1122:3344:103::2a
--   crucible       f69f92a1-5007-4bb0-a85b-604dc217154b   expunged      fd00:1122:3344:103::28
--   internal_dns   0dcfdfc5-481e-4153-b97c-11cf02b648ea   expunged      fd00:1122:3344:2::1   
--   internal_ntp   67622d61-2df4-414d-aa0e-d1277265f405   expunged      fd00:1122:3344:103::21
--   nexus          56ac1706-9e2a-49ba-bd6f-a99c44cb2ccb   expunged      fd00:1122:3344:103::22
+    ---------------------------------------------------------------------------------------------
+    zone type         zone id                                disposition   underlay IP           
+    ---------------------------------------------------------------------------------------------
+-   crucible          01d58626-e1b0-480f-96be-ac784863c7dc   expunged      fd00:1122:3344:103::2a
+-   crucible          094f27af-1acb-4d1e-ba97-1fc1377d4bf2   expunged      fd00:1122:3344:103::28
+-   crucible          47a87c6e-ef45-4d52-9a3e-69cdd96737cc   expunged      fd00:1122:3344:103::2b
+-   crucible          4a9a0a9d-87f0-4f1d-9181-27f6b435e637   expunged      fd00:1122:3344:103::24
+-   crucible          6464d025-4652-4948-919e-740bec5699b1   expunged      fd00:1122:3344:103::2c
+-   crucible          878dfddd-3113-4197-a3ea-e0d4dbe9b476   expunged      fd00:1122:3344:103::2d
+-   crucible          b91b271d-8d80-4f49-99a0-34006ae86063   expunged      fd00:1122:3344:103::26
+-   crucible          e39d7c9e-182b-48af-af87-58079d723583   expunged      fd00:1122:3344:103::25
+-   crucible          f3f2e4f3-0985-4ef6-8336-ce479382d05d   expunged      fd00:1122:3344:103::29
+-   crucible          f69f92a1-5007-4bb0-a85b-604dc217154b   expunged      fd00:1122:3344:103::27
+-   crucible_pantry   2f5e8010-a94d-43a4-9c5c-3f52832f5f7f   expunged      fd00:1122:3344:103::23
+-   internal_dns      d6ee1338-3127-43ec-9aaa-b973ccf05496   expunged      fd00:1122:3344:2::1   
+-   internal_ntp      56ac1706-9e2a-49ba-bd6f-a99c44cb2ccb   expunged      fd00:1122:3344:103::21
+-   nexus             0dcfdfc5-481e-4153-b97c-11cf02b648ea   expunged      fd00:1122:3344:103::22
 
 
 ERRORS:

--- a/nexus/reconfigurator/planning/tests/output/planner_nonprovisionable_bp2.txt
+++ b/nexus/reconfigurator/planning/tests/output/planner_nonprovisionable_bp2.txt
@@ -20,23 +20,24 @@ parent:    4d4e6c38-cd95-4c4e-8f45-6af4d686964b
 
 
     omicron zones at generation 2:
-    ------------------------------------------------------------------------------------------
-    zone type      zone id                                disposition   underlay IP           
-    ------------------------------------------------------------------------------------------
-    clickhouse     93b137a1-a1d6-4b5b-b2cb-21a9f11e2883   in service    fd00:1122:3344:105::23
-    crucible       19fbc4f8-a683-4f22-8f5a-e74782b935be   in service    fd00:1122:3344:105::25
-    crucible       2aa0ea4f-3561-4989-a98c-9ab7d9a240fb   in service    fd00:1122:3344:105::2d
-    crucible       4f1ce8a2-d3a5-4a38-be4c-9817de52db37   in service    fd00:1122:3344:105::2b
-    crucible       67d913e0-0005-4599-9b28-0abbf6cc2916   in service    fd00:1122:3344:105::2c
-    crucible       6b53ab2e-d98c-485f-87a3-4d5df595390f   in service    fd00:1122:3344:105::26
-    crucible       9f0abbad-dbd3-4d43-9675-78092217ffd9   in service    fd00:1122:3344:105::24
-    crucible       b0c63f48-01ea-4aae-bb26-fb0dd59d1662   in service    fd00:1122:3344:105::27
-    crucible       d660d7ed-28c0-45ae-9ace-dc3ecf7e8786   in service    fd00:1122:3344:105::29
-    crucible       e98cc0de-abf6-4da4-a20d-d05c7a9bb1d7   in service    fd00:1122:3344:105::2a
-    crucible       f55e6aaf-e8fc-4913-9e3c-8cd1bd4bdad3   in service    fd00:1122:3344:105::28
-    internal_dns   c406da50-34b9-4bb4-a460-8f49875d2a6a   in service    fd00:1122:3344:1::1   
-    internal_ntp   7f4e9f9f-08f8-4d14-885d-e977c05525ad   in service    fd00:1122:3344:105::21
-    nexus          6dff7633-66bb-4924-a6ff-2c896e66964b   in service    fd00:1122:3344:105::22
+    ---------------------------------------------------------------------------------------------
+    zone type         zone id                                disposition   underlay IP           
+    ---------------------------------------------------------------------------------------------
+    clickhouse        93b137a1-a1d6-4b5b-b2cb-21a9f11e2883   in service    fd00:1122:3344:105::23
+    crucible          19fbc4f8-a683-4f22-8f5a-e74782b935be   in service    fd00:1122:3344:105::25
+    crucible          2aa0ea4f-3561-4989-a98c-9ab7d9a240fb   in service    fd00:1122:3344:105::2d
+    crucible          4f1ce8a2-d3a5-4a38-be4c-9817de52db37   in service    fd00:1122:3344:105::2b
+    crucible          67622d61-2df4-414d-aa0e-d1277265f405   in service    fd00:1122:3344:105::2e
+    crucible          67d913e0-0005-4599-9b28-0abbf6cc2916   in service    fd00:1122:3344:105::2c
+    crucible          6b53ab2e-d98c-485f-87a3-4d5df595390f   in service    fd00:1122:3344:105::26
+    crucible          b0c63f48-01ea-4aae-bb26-fb0dd59d1662   in service    fd00:1122:3344:105::27
+    crucible          d660d7ed-28c0-45ae-9ace-dc3ecf7e8786   in service    fd00:1122:3344:105::29
+    crucible          e98cc0de-abf6-4da4-a20d-d05c7a9bb1d7   in service    fd00:1122:3344:105::2a
+    crucible          f55e6aaf-e8fc-4913-9e3c-8cd1bd4bdad3   in service    fd00:1122:3344:105::28
+    crucible_pantry   9f0abbad-dbd3-4d43-9675-78092217ffd9   in service    fd00:1122:3344:105::24
+    internal_dns      c406da50-34b9-4bb4-a460-8f49875d2a6a   in service    fd00:1122:3344:1::1   
+    internal_ntp      7f4e9f9f-08f8-4d14-885d-e977c05525ad   in service    fd00:1122:3344:105::21
+    nexus             6dff7633-66bb-4924-a6ff-2c896e66964b   in service    fd00:1122:3344:105::22
 
 
 
@@ -62,21 +63,21 @@ parent:    4d4e6c38-cd95-4c4e-8f45-6af4d686964b
     ------------------------------------------------------------------------------------------
     zone type      zone id                                disposition   underlay IP           
     ------------------------------------------------------------------------------------------
-    crucible       15c103f0-ac63-423b-ba5d-1b5fcd563ba3   in service    fd00:1122:3344:104::2a
-    crucible       23a8fa2b-ef3e-4017-a43f-f7a83953bd7c   in service    fd00:1122:3344:104::28
-    crucible       3aa07966-5899-4789-ace5-f8eeb375c6c3   in service    fd00:1122:3344:104::2c
-    crucible       621509d6-3772-4009-aca1-35eefd1098fb   in service    fd00:1122:3344:104::24
-    crucible       85b8c68a-160d-461d-94dd-1baf175fa75c   in service    fd00:1122:3344:104::26
-    crucible       95482c25-1e7f-43e8-adf1-e3548a1b3ae0   in service    fd00:1122:3344:104::2b
-    crucible       a732c489-d29a-4f75-b900-5966385943af   in service    fd00:1122:3344:104::25
-    crucible       c6dd531e-2d1d-423b-acc8-358533dab78c   in service    fd00:1122:3344:104::23
-    crucible       f0ff59e8-4105-4980-a4bb-a1f4c58de1e3   in service    fd00:1122:3344:104::27
-    crucible       f1a7b9a7-fc6a-4b23-b829-045ff33117ff   in service    fd00:1122:3344:104::29
-    internal_ntp   15bb9def-69b8-4d2e-b04f-9fee1143387c   in service    fd00:1122:3344:104::21
+    crucible       0dfbf374-9ef9-430f-b06d-f271bf7f84c4   in service    fd00:1122:3344:104::2c
+    crucible       15c103f0-ac63-423b-ba5d-1b5fcd563ba3   in service    fd00:1122:3344:104::27
+    crucible       23a8fa2b-ef3e-4017-a43f-f7a83953bd7c   in service    fd00:1122:3344:104::25
+    crucible       3aa07966-5899-4789-ace5-f8eeb375c6c3   in service    fd00:1122:3344:104::29
+    crucible       72c5a909-077d-4ec1-a9d5-ae64ef9d716e   in service    fd00:1122:3344:104::2b
+    crucible       85b8c68a-160d-461d-94dd-1baf175fa75c   in service    fd00:1122:3344:104::23
+    crucible       95482c25-1e7f-43e8-adf1-e3548a1b3ae0   in service    fd00:1122:3344:104::28
+    crucible       c60379ba-4e30-4628-a79a-0ae509aef4c5   in service    fd00:1122:3344:104::2a
+    crucible       f0ff59e8-4105-4980-a4bb-a1f4c58de1e3   in service    fd00:1122:3344:104::24
+    crucible       f1a7b9a7-fc6a-4b23-b829-045ff33117ff   in service    fd00:1122:3344:104::26
+    internal_ntp   621509d6-3772-4009-aca1-35eefd1098fb   in service    fd00:1122:3344:104::21
     nexus          2ec75441-3d7d-4b4b-9614-af03de5a3666   in service    fd00:1122:3344:104::2d
     nexus          508abd03-cbfe-4654-9a6d-7f15a1ad32e5   in service    fd00:1122:3344:104::2e
     nexus          59950bc8-1497-44dd-8cbf-b6502ba921b2   in service    fd00:1122:3344:104::2f
-    nexus          996d7570-b0df-46d5-aaa4-0c97697cf484   in service    fd00:1122:3344:104::22
+    nexus          a732c489-d29a-4f75-b900-5966385943af   in service    fd00:1122:3344:104::22
 
 
 
@@ -102,19 +103,19 @@ parent:    4d4e6c38-cd95-4c4e-8f45-6af4d686964b
     ------------------------------------------------------------------------------------------
     zone type      zone id                                disposition   underlay IP           
     ------------------------------------------------------------------------------------------
-    crucible       0dfbf374-9ef9-430f-b06d-f271bf7f84c4   in service    fd00:1122:3344:101::23
-    crucible       414830dc-c8c1-4748-9e9e-bc3a6435a93c   in service    fd00:1122:3344:101::2c
-    crucible       4ad0e9da-08f8-4d40-b4d3-d17e711b5bbf   in service    fd00:1122:3344:101::25
-    crucible       772cbcbd-58be-4158-be85-be744871fa22   in service    fd00:1122:3344:101::29
-    crucible       a1c03689-fc62-4ea5-bb72-4d01f5138614   in service    fd00:1122:3344:101::26
-    crucible       a568e92e-4fbd-4b69-acd8-f16277073031   in service    fd00:1122:3344:101::28
-    crucible       be75764a-491b-4aec-992e-1c39e25de975   in service    fd00:1122:3344:101::2a
-    crucible       bf79a56a-97af-4cc4-94a5-8b20d64c2cda   in service    fd00:1122:3344:101::24
-    crucible       d47f4996-fac0-4657-bcea-01b1fee6404d   in service    fd00:1122:3344:101::27
-    crucible       e001fea0-6594-4ece-97e3-6198c293e931   in service    fd00:1122:3344:101::2b
-    internal_ntp   c60379ba-4e30-4628-a79a-0ae509aef4c5   in service    fd00:1122:3344:101::21
+    crucible       414830dc-c8c1-4748-9e9e-bc3a6435a93c   in service    fd00:1122:3344:101::29
+    crucible       66ecd4a6-73a7-4e26-9711-17abdd67a66e   in service    fd00:1122:3344:101::2c
+    crucible       772cbcbd-58be-4158-be85-be744871fa22   in service    fd00:1122:3344:101::26
+    crucible       a1c03689-fc62-4ea5-bb72-4d01f5138614   in service    fd00:1122:3344:101::23
+    crucible       a568e92e-4fbd-4b69-acd8-f16277073031   in service    fd00:1122:3344:101::25
+    crucible       a73f322a-9463-4d18-8f60-7ddf6f59f231   in service    fd00:1122:3344:101::2b
+    crucible       be75764a-491b-4aec-992e-1c39e25de975   in service    fd00:1122:3344:101::27
+    crucible       be920398-024a-4655-8c49-69b5ac48dfff   in service    fd00:1122:3344:101::2a
+    crucible       d47f4996-fac0-4657-bcea-01b1fee6404d   in service    fd00:1122:3344:101::24
+    crucible       e001fea0-6594-4ece-97e3-6198c293e931   in service    fd00:1122:3344:101::28
+    internal_ntp   bf79a56a-97af-4cc4-94a5-8b20d64c2cda   in service    fd00:1122:3344:101::21
     nexus          3ca5292f-8a59-4475-bb72-0f43714d0fff   in service    fd00:1122:3344:101::2e
-    nexus          72c5a909-077d-4ec1-a9d5-ae64ef9d716e   in service    fd00:1122:3344:101::22
+    nexus          4ad0e9da-08f8-4d40-b4d3-d17e711b5bbf   in service    fd00:1122:3344:101::22
     nexus          99f6d544-8599-4e2b-a55a-82d9e0034662   in service    fd00:1122:3344:101::2d
     nexus          c26b3bda-5561-44a1-a69f-22103fe209a1   in service    fd00:1122:3344:101::2f
 
@@ -123,22 +124,23 @@ parent:    4d4e6c38-cd95-4c4e-8f45-6af4d686964b
 !48d95fef-bc9f-4f50-9a53-1e075836291d
 WARNING: Zones exist without physical disks!
     omicron zones at generation 3:
-    ------------------------------------------------------------------------------------------
-    zone type      zone id                                disposition   underlay IP           
-    ------------------------------------------------------------------------------------------
-    crucible       01d58626-e1b0-480f-96be-ac784863c7dc   expunged      fd00:1122:3344:103::2b
-    crucible       094f27af-1acb-4d1e-ba97-1fc1377d4bf2   expunged      fd00:1122:3344:103::29
-    crucible       2f5e8010-a94d-43a4-9c5c-3f52832f5f7f   expunged      fd00:1122:3344:103::24
-    crucible       47a87c6e-ef45-4d52-9a3e-69cdd96737cc   expunged      fd00:1122:3344:103::2c
-    crucible       4a9a0a9d-87f0-4f1d-9181-27f6b435e637   expunged      fd00:1122:3344:103::25
-    crucible       b91b271d-8d80-4f49-99a0-34006ae86063   expunged      fd00:1122:3344:103::27
-    crucible       d6ee1338-3127-43ec-9aaa-b973ccf05496   expunged      fd00:1122:3344:103::23
-    crucible       e39d7c9e-182b-48af-af87-58079d723583   expunged      fd00:1122:3344:103::26
-    crucible       f3f2e4f3-0985-4ef6-8336-ce479382d05d   expunged      fd00:1122:3344:103::2a
-    crucible       f69f92a1-5007-4bb0-a85b-604dc217154b   expunged      fd00:1122:3344:103::28
-    internal_dns   0dcfdfc5-481e-4153-b97c-11cf02b648ea   expunged      fd00:1122:3344:2::1   
-    internal_ntp   67622d61-2df4-414d-aa0e-d1277265f405   expunged      fd00:1122:3344:103::21
-    nexus          56ac1706-9e2a-49ba-bd6f-a99c44cb2ccb   expunged      fd00:1122:3344:103::22
+    ---------------------------------------------------------------------------------------------
+    zone type         zone id                                disposition   underlay IP           
+    ---------------------------------------------------------------------------------------------
+    crucible          01d58626-e1b0-480f-96be-ac784863c7dc   expunged      fd00:1122:3344:103::2a
+    crucible          094f27af-1acb-4d1e-ba97-1fc1377d4bf2   expunged      fd00:1122:3344:103::28
+    crucible          47a87c6e-ef45-4d52-9a3e-69cdd96737cc   expunged      fd00:1122:3344:103::2b
+    crucible          4a9a0a9d-87f0-4f1d-9181-27f6b435e637   expunged      fd00:1122:3344:103::24
+    crucible          6464d025-4652-4948-919e-740bec5699b1   expunged      fd00:1122:3344:103::2c
+    crucible          878dfddd-3113-4197-a3ea-e0d4dbe9b476   expunged      fd00:1122:3344:103::2d
+    crucible          b91b271d-8d80-4f49-99a0-34006ae86063   expunged      fd00:1122:3344:103::26
+    crucible          e39d7c9e-182b-48af-af87-58079d723583   expunged      fd00:1122:3344:103::25
+    crucible          f3f2e4f3-0985-4ef6-8336-ce479382d05d   expunged      fd00:1122:3344:103::29
+    crucible          f69f92a1-5007-4bb0-a85b-604dc217154b   expunged      fd00:1122:3344:103::27
+    crucible_pantry   2f5e8010-a94d-43a4-9c5c-3f52832f5f7f   expunged      fd00:1122:3344:103::23
+    internal_dns      d6ee1338-3127-43ec-9aaa-b973ccf05496   expunged      fd00:1122:3344:2::1   
+    internal_ntp      56ac1706-9e2a-49ba-bd6f-a99c44cb2ccb   expunged      fd00:1122:3344:103::21
+    nexus             0dcfdfc5-481e-4153-b97c-11cf02b648ea   expunged      fd00:1122:3344:103::22
 
 
 
@@ -146,22 +148,23 @@ WARNING: Zones exist without physical disks!
 !68d24ac5-f341-49ea-a92a-0381b52ab387
 WARNING: Zones exist without physical disks!
     omicron zones at generation 2:
-    ------------------------------------------------------------------------------------------
-    zone type      zone id                                disposition   underlay IP           
-    ------------------------------------------------------------------------------------------
-    crucible       3b3c14b6-a8e2-4054-a577-8d96cb576230   expunged      fd00:1122:3344:102::28
-    crucible       57b96d5c-b71e-43e4-8869-7d514003d00d   expunged      fd00:1122:3344:102::29
-    crucible       6939ce48-b17c-4616-b176-8a419a7697be   expunged      fd00:1122:3344:102::25
-    crucible       8d4d2b28-82bb-4e36-80da-1408d8c35d82   expunged      fd00:1122:3344:102::27
-    crucible       b1783e95-9598-451d-b6ba-c50b52b428c3   expunged      fd00:1122:3344:102::2c
-    crucible       b44cdbc0-0ce0-46eb-8b21-a09e113aa1d0   expunged      fd00:1122:3344:102::23
-    crucible       b4947d31-f70e-4ee0-8817-0ca6cea9b16b   expunged      fd00:1122:3344:102::2a
-    crucible       b6b759d0-f60d-42b7-bbbc-9d61c9e895a9   expunged      fd00:1122:3344:102::24
-    crucible       c407795c-6c8b-428e-8ab8-b962913c447f   expunged      fd00:1122:3344:102::26
-    crucible       e4b3e159-3dbe-48cb-8497-e3da92a90e5a   expunged      fd00:1122:3344:102::2b
-    internal_dns   9fd52961-426f-4e62-a644-b70871103fca   expunged      fd00:1122:3344:3::1   
-    internal_ntp   6464d025-4652-4948-919e-740bec5699b1   expunged      fd00:1122:3344:102::21
-    nexus          878dfddd-3113-4197-a3ea-e0d4dbe9b476   expunged      fd00:1122:3344:102::22
+    ---------------------------------------------------------------------------------------------
+    zone type         zone id                                disposition   underlay IP           
+    ---------------------------------------------------------------------------------------------
+    crucible          15bb9def-69b8-4d2e-b04f-9fee1143387c   expunged      fd00:1122:3344:102::2b
+    crucible          3b3c14b6-a8e2-4054-a577-8d96cb576230   expunged      fd00:1122:3344:102::26
+    crucible          57b96d5c-b71e-43e4-8869-7d514003d00d   expunged      fd00:1122:3344:102::27
+    crucible          8d4d2b28-82bb-4e36-80da-1408d8c35d82   expunged      fd00:1122:3344:102::25
+    crucible          996d7570-b0df-46d5-aaa4-0c97697cf484   expunged      fd00:1122:3344:102::2c
+    crucible          b1783e95-9598-451d-b6ba-c50b52b428c3   expunged      fd00:1122:3344:102::2a
+    crucible          b4947d31-f70e-4ee0-8817-0ca6cea9b16b   expunged      fd00:1122:3344:102::28
+    crucible          c407795c-6c8b-428e-8ab8-b962913c447f   expunged      fd00:1122:3344:102::24
+    crucible          c6dd531e-2d1d-423b-acc8-358533dab78c   expunged      fd00:1122:3344:102::2d
+    crucible          e4b3e159-3dbe-48cb-8497-e3da92a90e5a   expunged      fd00:1122:3344:102::29
+    crucible_pantry   6939ce48-b17c-4616-b176-8a419a7697be   expunged      fd00:1122:3344:102::23
+    internal_dns      b6b759d0-f60d-42b7-bbbc-9d61c9e895a9   expunged      fd00:1122:3344:3::1   
+    internal_ntp      9fd52961-426f-4e62-a644-b70871103fca   expunged      fd00:1122:3344:102::21
+    nexus             b44cdbc0-0ce0-46eb-8b21-a09e113aa1d0   expunged      fd00:1122:3344:102::22
 
 
 
@@ -172,7 +175,7 @@ WARNING: Zones exist without physical disks!
  METADATA:
     created by:::::::::::   test_blueprint2
     created at:::::::::::   1970-01-01T00:00:00.000Z
-    comment::::::::::::::   sled 48d95fef-bc9f-4f50-9a53-1e075836291d: expunged 13 zones because: sled policy is expunged
+    comment::::::::::::::   sled 48d95fef-bc9f-4f50-9a53-1e075836291d: expunged 14 zones because: sled policy is expunged
     internal DNS version:   1
     external DNS version:   1
 

--- a/nexus/reconfigurator/preparation/src/lib.rs
+++ b/nexus/reconfigurator/preparation/src/lib.rs
@@ -40,6 +40,7 @@ use omicron_common::api::external::LookupType;
 use omicron_common::disk::DiskIdentity;
 use omicron_common::policy::BOUNDARY_NTP_REDUNDANCY;
 use omicron_common::policy::COCKROACHDB_REDUNDANCY;
+use omicron_common::policy::CRUCIBLE_PANTRY_REDUNDANCY;
 use omicron_common::policy::INTERNAL_DNS_REDUNDANCY;
 use omicron_common::policy::NEXUS_REDUNDANCY;
 use omicron_common::policy::OXIMETER_REDUNDANCY;
@@ -70,6 +71,7 @@ pub struct PlanningInputFromDb<'a> {
     pub target_oximeter_zone_count: usize,
     pub target_cockroachdb_zone_count: usize,
     pub target_cockroachdb_cluster_version: CockroachDbClusterVersion,
+    pub target_crucible_pantry_zone_count: usize,
     pub internal_dns_version: nexus_db_model::Generation,
     pub external_dns_version: nexus_db_model::Generation,
     pub cockroachdb_settings: &'a CockroachDbSettings,
@@ -147,6 +149,7 @@ impl PlanningInputFromDb<'_> {
             target_cockroachdb_zone_count: COCKROACHDB_REDUNDANCY,
             target_cockroachdb_cluster_version:
                 CockroachDbClusterVersion::POLICY,
+            target_crucible_pantry_zone_count: CRUCIBLE_PANTRY_REDUNDANCY,
             external_ip_rows: &external_ip_rows,
             service_nic_rows: &service_nic_rows,
             log: &opctx.log,
@@ -172,6 +175,8 @@ impl PlanningInputFromDb<'_> {
             target_cockroachdb_zone_count: self.target_cockroachdb_zone_count,
             target_cockroachdb_cluster_version: self
                 .target_cockroachdb_cluster_version,
+            target_crucible_pantry_zone_count: self
+                .target_crucible_pantry_zone_count,
             clickhouse_policy: None,
         };
         let mut builder = PlanningInputBuilder::new(

--- a/nexus/types/src/deployment/planning_input.rs
+++ b/nexus/types/src/deployment/planning_input.rs
@@ -118,6 +118,10 @@ impl PlanningInput {
         self.policy.target_cockroachdb_cluster_version
     }
 
+    pub fn target_crucible_pantry_zone_count(&self) -> usize {
+        self.policy.target_crucible_pantry_zone_count
+    }
+
     pub fn target_clickhouse_zone_count(&self) -> usize {
         if let Some(policy) = &self.policy.clickhouse_policy {
             if policy.deploy_with_standalone {
@@ -856,6 +860,9 @@ pub struct Policy {
     /// desired total number of deployed CockroachDB zones
     pub target_cockroachdb_zone_count: usize,
 
+    /// desired total number of deployed CruciblePantry zones
+    pub target_crucible_pantry_zone_count: usize,
+
     /// desired CockroachDB `cluster.preserve_downgrade_option` setting.
     /// at present this is hardcoded based on the version of CockroachDB we
     /// presently ship and the tick-tock pattern described in RFD 469.
@@ -937,6 +944,7 @@ impl PlanningInputBuilder {
                 target_cockroachdb_zone_count: 0,
                 target_cockroachdb_cluster_version:
                     CockroachDbClusterVersion::POLICY,
+                target_crucible_pantry_zone_count: 0,
                 clickhouse_policy: None,
             },
             internal_dns_version: Generation::new(),

--- a/nexus/types/src/deployment/zone_type.rs
+++ b/nexus/types/src/deployment/zone_type.rs
@@ -100,6 +100,11 @@ impl BlueprintZoneType {
         matches!(self, BlueprintZoneType::Crucible(_))
     }
 
+    /// Identifies whether this is a Crucible pantry zone
+    pub fn is_crucible_pantry(&self) -> bool {
+        matches!(self, BlueprintZoneType::CruciblePantry(_))
+    }
+
     /// Identifies whether this is a clickhouse keeper zone
     pub fn is_clickhouse_keeper(&self) -> bool {
         matches!(self, BlueprintZoneType::ClickhouseKeeper(_))

--- a/sled-agent/src/rack_setup/plan/service.rs
+++ b/sled-agent/src/rack_setup/plan/service.rs
@@ -38,8 +38,9 @@ use omicron_common::disk::{
 };
 use omicron_common::ledger::{self, Ledger, Ledgerable};
 use omicron_common::policy::{
-    BOUNDARY_NTP_REDUNDANCY, COCKROACHDB_REDUNDANCY, INTERNAL_DNS_REDUNDANCY,
-    NEXUS_REDUNDANCY, OXIMETER_REDUNDANCY, RESERVED_INTERNAL_DNS_REDUNDANCY,
+    BOUNDARY_NTP_REDUNDANCY, COCKROACHDB_REDUNDANCY,
+    CRUCIBLE_PANTRY_REDUNDANCY, INTERNAL_DNS_REDUNDANCY, NEXUS_REDUNDANCY,
+    OXIMETER_REDUNDANCY, RESERVED_INTERNAL_DNS_REDUNDANCY,
     SINGLE_NODE_CLICKHOUSE_REDUNDANCY,
 };
 use omicron_uuid_kinds::{
@@ -63,9 +64,6 @@ use thiserror::Error;
 use uuid::Uuid;
 
 const MINIMUM_U2_COUNT: usize = 3;
-// TODO(https://github.com/oxidecomputer/omicron/issues/732): Remove.
-// when Nexus provisions the Pantry.
-const PANTRY_COUNT: usize = 3;
 
 /// Describes errors which may occur while generating a plan for services.
 #[derive(Error, Debug)]
@@ -710,7 +708,7 @@ impl Plan {
 
         // Provision Crucible Pantry zones, continuing to stripe across sleds.
         // TODO(https://github.com/oxidecomputer/omicron/issues/732): Remove
-        for _ in 0..PANTRY_COUNT {
+        for _ in 0..CRUCIBLE_PANTRY_REDUNDANCY {
             let sled = {
                 let which_sled =
                     sled_allocator.next().ok_or(PlanError::NotEnoughSleds)?;


### PR DESCRIPTION
This is a much smaller change than the diff stat implies; most of the changes are expectorate outputs because the example system we set up for tests now includes Crucible pantry zones, which shifted a bunch of other zone UUIDs.

Fully supporting Crucible pantry replacement depends on #3763, which I'm continuing to work on. But the reconfigurator side of "start new pantries" is about as trivial as things go and does not depend on #3763, hence this PR.