### PR TITLE
add `x-rust-type` to `ArtifactHash`

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3173,6 +3173,7 @@ dependencies = [
  "base64 0.22.1",
  "chrono",
  "gateway-messages",
+ "omicron-common",
  "omicron-workspace-hack",
  "progenitor",
  "rand",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -6992,7 +6992,6 @@ dependencies = [
  "bitflags 1.3.2",
  "bitflags 2.6.0",
  "bstr",
- "byteorder",
  "bytes",
  "cc",
  "chrono",

--- a/clients/gateway-client/Cargo.toml
+++ b/clients/gateway-client/Cargo.toml
@@ -11,6 +11,7 @@ workspace = true
 base64.workspace = true
 chrono.workspace = true
 gateway-messages.workspace = true
+omicron-common.workspace = true
 progenitor.workspace = true
 rand.workspace = true
 reqwest = { workspace = true, features = ["rustls-tls", "stream"] }

--- a/clients/gateway-client/src/lib.rs
+++ b/clients/gateway-client/src/lib.rs
@@ -58,6 +58,9 @@ progenitor::generate_api!(
         slog::debug!(log, "client response"; "result" => ?result);
     }),
     derives = [schemars::JsonSchema],
+    crates = {
+        "omicron-common" = "0.1.0",
+    },
     patch = {
         HostPhase2RecoveryImageId = { derives = [PartialEq, Eq, PartialOrd, Ord] },
         ImageVersion = { derives = [PartialEq, Eq, PartialOrd, Ord] },

--- a/clients/installinator-client/src/lib.rs
+++ b/clients/installinator-client/src/lib.rs
@@ -18,6 +18,9 @@ progenitor::generate_api!(
         slog::debug!(log, "client response"; "result" => ?result);
     }),
     derives = [schemars::JsonSchema],
+    crates = {
+        "omicron-common" = "0.1.0",
+    },
     replace = {
         Duration = std::time::Duration,
         EventReportForInstallinatorSpec = installinator_common::EventReport,

--- a/clients/wicketd-client/src/lib.rs
+++ b/clients/wicketd-client/src/lib.rs
@@ -18,6 +18,9 @@ progenitor::generate_api!(
         slog::debug!(log, "client response"; "result" => ?result);
     }),
     derives = [schemars::JsonSchema],
+    crates = {
+        "omicron-common" = "0.1.0",
+    },
     patch = {
         CurrentRssUserConfig = { derives = [PartialEq] },
         CurrentRssUserConfigSensitive = { derives = [PartialEq, Eq, PartialOrd, Ord] },

--- a/common/src/update.rs
+++ b/common/src/update.rs
@@ -288,7 +288,7 @@ impl FromStr for ArtifactKind {
 #[cfg_attr(feature = "testing", derive(test_strategy::Arbitrary))]
 pub struct ArtifactHash(
     #[serde(with = "serde_human_bytes::hex_array")]
-    #[schemars(schema_with = "hex_schema::<32>")]
+    #[schemars(schema_with = "artifact_hash_schema")]
     pub [u8; 32],
 );
 
@@ -325,6 +325,19 @@ impl FromStr for ArtifactHash {
 pub fn hex_schema<const N: usize>(gen: &mut SchemaGenerator) -> Schema {
     let mut schema: SchemaObject = <String>::json_schema(gen).into();
     schema.format = Some(format!("hex string ({N} bytes)"));
+    schema.into()
+}
+
+fn artifact_hash_schema(gen: &mut SchemaGenerator) -> Schema {
+    let mut schema: SchemaObject = hex_schema::<32>(gen).into();
+    schema.extensions.insert(
+        "x-rust-type".into(),
+        serde_json::json!({
+            "crate": env!("CARGO_PKG_NAME"),
+            "version": env!("CARGO_PKG_VERSION"),
+            "path": concat!(module_path!(), "::ArtifactHash"),
+        }),
+    );
     schema.into()
 }
 

--- a/gateway-cli/src/main.rs
+++ b/gateway-cli/src/main.rs
@@ -478,8 +478,8 @@ async fn main() -> Result<()> {
             } else {
                 // clap guarantees these are not `None` when `clear` is false.
                 let update_id = update_id.unwrap();
-                let host_phase_2 = host_phase_2.unwrap().to_string();
-                let control_plane = control_plane.unwrap().to_string();
+                let host_phase_2 = host_phase_2.unwrap();
+                let control_plane = control_plane.unwrap();
                 client
                     .sp_installinator_image_id_set(
                         sp.type_,

--- a/installinator/src/artifact.rs
+++ b/installinator/src/artifact.rs
@@ -93,7 +93,7 @@ impl ArtifactClient {
             .client
             .get_artifact_by_hash(
                 artifact_hash_id.kind.as_str(),
-                &artifact_hash_id.hash.to_string(),
+                &artifact_hash_id.hash,
             )
             .await?;
 

--- a/openapi/gateway.json
+++ b/openapi/gateway.json
@@ -1633,6 +1633,11 @@
         "type": "object",
         "properties": {
           "sha256_hash": {
+            "x-rust-type": {
+              "crate": "omicron-common",
+              "path": "omicron_common::update::ArtifactHash",
+              "version": "0.1.0"
+            },
             "type": "string",
             "format": "hex string (32 bytes)"
           }
@@ -1688,10 +1693,20 @@
         "type": "object",
         "properties": {
           "control_plane": {
+            "x-rust-type": {
+              "crate": "omicron-common",
+              "path": "omicron_common::update::ArtifactHash",
+              "version": "0.1.0"
+            },
             "type": "string",
             "format": "hex string (32 bytes)"
           },
           "host_phase_2": {
+            "x-rust-type": {
+              "crate": "omicron-common",
+              "path": "omicron_common::update::ArtifactHash",
+              "version": "0.1.0"
+            },
             "type": "string",
             "format": "hex string (32 bytes)"
           },

--- a/openapi/installinator.json
+++ b/openapi/installinator.json
@@ -21,6 +21,11 @@
             "description": "The hash of the artifact.",
             "required": true,
             "schema": {
+              "x-rust-type": {
+                "crate": "omicron-common",
+                "path": "omicron_common::update::ArtifactHash",
+                "version": "0.1.0"
+              },
               "type": "string",
               "format": "hex string (32 bytes)"
             }

--- a/openapi/wicketd.json
+++ b/openapi/wicketd.json
@@ -826,6 +826,11 @@
         "properties": {
           "hash": {
             "description": "The hash of the artifact.",
+            "x-rust-type": {
+              "crate": "omicron-common",
+              "path": "omicron_common::update::ArtifactHash",
+              "version": "0.1.0"
+            },
             "type": "string",
             "format": "hex string (32 bytes)"
           },
@@ -983,6 +988,11 @@
               },
               "sha256": {
                 "description": "A SHA-256 digest of the key.",
+                "x-rust-type": {
+                  "crate": "omicron-common",
+                  "path": "omicron_common::update::ArtifactHash",
+                  "version": "0.1.0"
+                },
                 "type": "string",
                 "format": "hex string (32 bytes)"
               }

--- a/wicketd/src/update_tracker.rs
+++ b/wicketd/src/update_tracker.rs
@@ -1362,8 +1362,8 @@ impl UpdateDriver {
                 "Setting installinator image ID",
                 move |_cx| async move {
                     let installinator_image_id = InstallinatorImageId {
-                        control_plane: plan.control_plane_hash.to_string(),
-                        host_phase_2: plan.host_phase_2_hash.to_string(),
+                        control_plane: plan.control_plane_hash,
+                        host_phase_2: plan.host_phase_2_hash,
                         update_id: update_cx.update_id,
                     };
                     update_cx

--- a/workspace-hack/Cargo.toml
+++ b/workspace-hack/Cargo.toml
@@ -28,7 +28,6 @@ bit-vec = { version = "0.6.3" }
 bitflags-dff4ba8e3ae991db = { package = "bitflags", version = "1.3.2" }
 bitflags-f595c2ba2a3f28df = { package = "bitflags", version = "2.6.0", default-features = false, features = ["serde", "std"] }
 bstr = { version = "1.9.1" }
-byteorder = { version = "1.5.0" }
 bytes = { version = "1.7.2", features = ["serde"] }
 chrono = { version = "0.4.38", features = ["serde"] }
 cipher = { version = "0.4.4", default-features = false, features = ["block-padding", "zeroize"] }
@@ -137,7 +136,6 @@ bit-vec = { version = "0.6.3" }
 bitflags-dff4ba8e3ae991db = { package = "bitflags", version = "1.3.2" }
 bitflags-f595c2ba2a3f28df = { package = "bitflags", version = "2.6.0", default-features = false, features = ["serde", "std"] }
 bstr = { version = "1.9.1" }
-byteorder = { version = "1.5.0" }
 bytes = { version = "1.7.2", features = ["serde"] }
 cc = { version = "1.0.97", default-features = false, features = ["parallel"] }
 chrono = { version = "0.4.38", features = ["serde"] }


### PR DESCRIPTION
While working on #6764 I found myself partially wanting this.

I'm not the biggest fan of the particulars of this implementation but it does do what I want, even though `ArtifactHash` is `#[serde(transparent)]`. This has the effect of moving the `to_string()` into the Progenitor-generated client, which can be nice if you're having a niche set of lifetime issues since `ArtifactHash` is `Copy`. But because Progenitor implements this on a crate-by-crate basis, adding `x-rust-type` to any additional types in omicron-common will mean making fixes across the tree wherever clients with `crates = { "omicron-common = "0.1.0 }` are used.

This is a sort of take-it-or-leave-it PR; it's here if we want it but I'd like to get consensus that we actually want it.