### PR TITLE
xtask ls-apis: try SSH access for dendrite

### DIFF
--- a/.github/buildomat/build-and-test.sh
+++ b/.github/buildomat/build-and-test.sh
@@ -41,6 +41,21 @@ mkdir -p "$OUTPUT_DIR"
 banner prerequisites
 ptime -m bash ./tools/install_builder_prerequisites.sh -y
 
+# Do some test runs of the `ls-apis` command.
+#
+# This may require cloning some dependent private repos.  We do this before the
+# main battery of tests because the GitHub tokens required for this only last
+# for an hour so we want to get this done early.
+#
+# (TODO: This makes the build timings we record inaccurate.)
+banner ls-apis
+(
+    source ./tools/include/force-git-over-https.sh;
+    ptime -m cargo xtask ls-apis apis &&
+        ptime -m cargo xtask ls-apis deployment-units &&
+        ptime -m cargo xtask ls-apis servers
+)
+
 #
 # We build with:
 #
@@ -81,19 +96,6 @@ export RUSTC_BOOTSTRAP=1
 # Build all the packages and tests, and keep track of how long each took to build.
 # We report build progress to stderr, and the "--timings=json" output goes to stdout.
 ptime -m cargo build -Z unstable-options --timings=json --workspace --tests --locked --verbose 1> "$OUTPUT_DIR/crate-build-timings.json"
-
-# Do some test runs of the `ls-apis` command.
-#
-# This may require cloning some dependent private repos.  We do this before the
-# main battery of tests because the GitHub tokens required for this only last
-# for an hour so we want to get this done early.
-banner ls-apis
-(
-    source ./tools/include/force-git-over-https.sh;
-    ptime -m cargo xtask ls-apis apis &&
-        ptime -m cargo xtask ls-apis deployment-units &&
-        ptime -m cargo xtask ls-apis servers
-)
 
 #
 # We apply our own timeout to ensure that we get a normal failure on timeout

--- a/dev-tools/ls-apis/src/cargo.rs
+++ b/dev-tools/ls-apis/src/cargo.rs
@@ -384,13 +384,18 @@ impl DepPath {
 }
 
 // Dendrite is not (yet) a public repository, but it's a dependency of
-// Maghemite. We call this function when trying to fetch the Dendrite repository
-// over HTTPS but don't have any authentication credentials (in e.g. ~/netrc).
-// To make local builds as convenient as possible, we will attempt to use SSH
-// to fetch the repository by setting `GIT_CONFIG_*` environment variables to
-// rewrite the repository URL to an SSH URL. If that fails, we'll wrap that
-// error with a helpful message informing the user to either have access via
-// HTTPS or SSH.
+// Maghemite. There are two expected cases for running Omicron tests locally
+// that we know of:
+// - The developer has a Git credential helper of some kind set up to
+//   successfully clone private repositories over HTTPS.
+// - The developer has an SSH agent or other local SSH key that they use to
+//   clone repositories over SSH.
+// We call this function when we fail to fetch the Dendrite repository over
+// HTTPS. Under the assumption that the user falls in the second group.
+// we attempt to use SSH to fetch the repository by setting `GIT_CONFIG_*`
+// environment variables to rewrite the repository URL to an SSH URL. If that
+// fails, we'll verbosely inform the user as to how both methods failed and
+// provide some context.
 //
 // This entire workaround can and very much should go away once Dendrite is
 // public.
@@ -454,7 +459,6 @@ More context: https://github.com/oxidecomputer/omicron/issues/6839
 {original_err:?}
 
 ===== The error that occurred while fetching using SSH (fallback): =====
-{err:?}
-")
+{err:?}")
     })
 }

--- a/dev-tools/ls-apis/src/cargo.rs
+++ b/dev-tools/ls-apis/src/cargo.rs
@@ -65,7 +65,14 @@ impl Workspace {
         if let Some(manifest_path) = manifest_path {
             cmd.manifest_path(manifest_path);
         }
-        let metadata = cmd.exec().context("loading metadata")?;
+        let metadata = match cmd.exec() {
+            Err(original_err) if name == "maghemite" => {
+                dendrite_workaround(cmd, original_err)?
+            }
+            otherwise => otherwise.with_context(|| {
+                format!("failed to load metadata for {name}")
+            })?,
+        };
         let workspace_root = metadata.workspace_root;
 
         // Build an index of all packages by id.  Identify duplicates because we
@@ -374,4 +381,80 @@ impl DepPath {
     pub fn contains_any(&self, pkgids: &BTreeSet<&PackageId>) -> bool {
         self.0.iter().any(|p| pkgids.contains(p))
     }
+}
+
+// Dendrite is not (yet) a public repository, but it's a dependency of
+// Maghemite. We call this function when trying to fetch the Dendrite repository
+// over HTTPS but don't have any authentication credentials (in e.g. ~/netrc).
+// To make local builds as convenient as possible, we will attempt to use SSH
+// to fetch the repository by setting `GIT_CONFIG_*` environment variables to
+// rewrite the repository URL to an SSH URL. If that fails, we'll wrap that
+// error with a helpful message informing the user to either have access via
+// HTTPS or SSH.
+//
+// This entire workaround can and very much should go away once Dendrite is
+// public.
+fn dendrite_workaround(
+    mut cmd: cargo_metadata::MetadataCommand,
+    original_err: cargo_metadata::Error,
+) -> Result<cargo_metadata::Metadata> {
+    eprintln!(
+        "warning: failed to load metadata for maghemite; \
+        trying dendrite workaround"
+    );
+
+    let count = std::env::var_os("GIT_CONFIG_COUNT")
+        .map(|s| -> Result<u64> {
+            s.into_string()
+                .map_err(|_| anyhow!("$GIT_CONFIG_COUNT is not an integer"))?
+                .parse()
+                .context("$GIT_CONFIG_COUNT is not an integer")
+        })
+        .transpose()?
+        .unwrap_or_default();
+    cmd.env("CARGO_NET_GIT_FETCH_WITH_CLI", "true");
+    cmd.env(
+        format!("GIT_CONFIG_KEY_{count}"),
+        "url.git@github.com:oxidecomputer/dendrite.insteadOf",
+    );
+    cmd.env(
+        format!("GIT_CONFIG_VALUE_{count}"),
+        "https://github.com/oxidecomputer/dendrite",
+    );
+    cmd.env("GIT_CONFIG_COUNT", (count + 1).to_string());
+    cmd.exec().map_err(|err| {
+        let cmd = cmd.cargo_command();
+        let original_err = anyhow::Error::from(original_err);
+        let err = anyhow::Error::from(err);
+        anyhow::anyhow!("failed to load metadata for maghemite
+
+`cargo xtask ls-apis` expects to be able to run `cargo metadata` on the
+Maghemite workspace that Omicron depends on. Maghemite has a dependency on a
+private repository (Dendrite), so `cargo metadata` can fail if you are unable
+to clone Dendrite via an HTTPS URL. As a fallback, we also tried to run `cargo
+metadata` with environment variables that force `cargo metadata` to use an SSH
+URL; unfortunately that also failed.
+
+To successfully run this command (or expectorate test), your environment needs
+to be set up to clone a private Oxide repository from GitHub. This can be done
+with either a Git credential helper or an SSH key:
+
+https://doc.rust-lang.org/cargo/appendix/git-authentication.html
+https://docs.github.com/en/get-started/getting-started-with-git/caching-your-github-credentials-in-git
+
+(If you don't have access to private Oxide repos, you won't be able to
+successfully run this command or test.)
+
+More context: https://github.com/oxidecomputer/omicron/issues/6839
+
+===== The fallback command that failed: =====
+{cmd:?}
+
+===== The error that occurred while fetching using HTTPS: =====
+{original_err:?}
+
+===== The error that occurred while fetching using SSH (fallback): =====
+{err:?}
+")
+    })
 }


### PR DESCRIPTION
Fixes #6839, at least from my perspective.

1. If running `cargo metadata` on the Maghemite workspace manifest fails, try re-running it with a set of environment variables that replaces Dendrite's Git URL with an SSH one. This removes the requirement to have a functioning ~/.netrc in order to run the full test suite locally; having a functioning SSH agent is significantly less hassle than fiddling with GitHub tokens.
2. Move the `cargo xtask ls-apis` exercising out of the already-quite-long build-and-test jobs. We've seen [a flake on main](https://buildomat.eng.oxide.computer/wg/0/details/01J9YK8K5ASNHCKRDKBKD97KFT/DbLBuHhEEklJzGRMi7NxyxdZmoqz8wsZNyoMVGTIZVnvCvch/01J9YK99F56A9R34C76TTFCE0Y#S4415) where it took just over an hour to get to the `ls-apis` bits by which time the GitHub token had already expired. build-and-test is already the longest required step to merge and it's not ideal to add more things to it.