### PR TITLE
[test-util] Embiggen SP-sim discovery timeout

### DIFF
--- a/gateway-test-utils/src/setup.rs
+++ b/gateway-test-utils/src/setup.rs
@@ -197,7 +197,11 @@ pub async fn test_setup_with_config(
             future::ready(result)
         },
         &Duration::from_millis(100),
-        &Duration::from_secs(1),
+        // This seems like a pretty long time to wait for MGS to discover the
+        // simulated SPs, but we've seen tests fail due to timeouts here in the
+        // past, so we may as well be generous:
+        // https://github.com/oxidecomputer/omicron/issues/6877
+        &Duration::from_secs(30),
     )
     .await
     .unwrap();


### PR DESCRIPTION
Presently, the `gateway_test_utils::setup::test_setup_with_config` function will give MGS up to one second to discover the simulated SPs while setting up to perform a MGS test. This is probably not long enough, as we've seen tests fail spuriously here (c.f. #6877).

This commit changes the one-second timeout to a 30-second timeout. Thirty seconds seems overly generous here, but it's probably good to be overly generous, since in most cases, it will finish in substantially less than that, and being generous reduces the risk of spurious test failures.

We would hope this fixes the flakiness issue I cited above. Unfortunately, the [problem of induction][1] exists, making it technically impossible to definitively prove that a test, once shown to be flaky, is unflaky. So, if we choose to adhere strictly to [falsifiability][2], a prevailing notion in the philosophy of science, no "flaky test" issue should never be closed once it has been opened. :)

[1]: https://en.wikipedia.org/wiki/Problem_of_induction
[2]: https://en.wikipedia.org/wiki/Falsifiability#Basic_statements_and_the_definition_of_falsifiability