### PR TITLE
Update InsertVpcSubnetQuery IP Block conflict detection logic

### DIFF
--- a/nexus/db-queries/src/db/queries/vpc_subnet.rs
+++ b/nexus/db-queries/src/db/queries/vpc_subnet.rs
@@ -107,16 +107,11 @@ impl QueryFragment<Pg> for InsertVpcSubnetQuery {
         &'a self,
         mut out: AstPass<'_, 'a, Pg>,
     ) -> diesel::QueryResult<()> {
-        out.push_sql("WITH overlap AS MATERIALIZED (SELECT CAST(IF((inet_contains_or_equals(");
+        out.push_sql("WITH overlap AS MATERIALIZED (SELECT CAST(IF((");
         out.push_identifier(dsl::ipv4_block::NAME)?;
-        out.push_sql(", ");
+        out.push_sql(" && ");
         out.push_bind_param::<sql_types::Inet, _>(&self.ipv4_block)?;
-        out.push_sql(")");
-        out.push_sql("OR inet_contains_or_equals(");
-        out.push_bind_param::<sql_types::Inet, _>(&self.ipv4_block)?;
-        out.push_sql(", ");
-        out.push_identifier(dsl::ipv4_block::NAME)?;
-        out.push_sql(")), ");
+        out.push_sql("), ");
         out.push_bind_param::<sql_types::Text, _>(
             InsertVpcSubnetError::OVERLAPPING_IPV4_BLOCK_SENTINEL,
         )?;
@@ -136,22 +131,14 @@ impl QueryFragment<Pg> for InsertVpcSubnetQuery {
         out.push_identifier(dsl::id::NAME)?;
         out.push_sql(" != ");
         out.push_bind_param::<sql_types::Uuid, Uuid>(&self.subnet.identity.id)?;
-        out.push_sql(" AND (inet_contains_or_equals(");
+        out.push_sql(" AND ((");
         out.push_identifier(dsl::ipv4_block::NAME)?;
-        out.push_sql(", ");
+        out.push_sql(" && ");
         out.push_bind_param::<sql_types::Inet, IpNetwork>(&self.ipv4_block)?;
-        out.push_sql(") OR inet_contains_or_equals(");
-        out.push_bind_param::<sql_types::Inet, IpNetwork>(&self.ipv4_block)?;
-        out.push_sql(", ");
-        out.push_identifier(dsl::ipv4_block::NAME)?;
-        out.push_sql(") OR inet_contains_or_equals(");
+        out.push_sql(") OR (");
         out.push_identifier(dsl::ipv6_block::NAME)?;
-        out.push_sql(", ");
+        out.push_sql(" && ");
         out.push_bind_param::<sql_types::Inet, IpNetwork>(&self.ipv6_block)?;
-        out.push_sql(") OR inet_contains_or_equals(");
-        out.push_bind_param::<sql_types::Inet, IpNetwork>(&self.ipv6_block)?;
-        out.push_sql(", ");
-        out.push_identifier(dsl::ipv6_block::NAME)?;
 
         out.push_sql("))) INSERT INTO ");
         VPC_SUBNET_FROM_CLAUSE.walk_ast(out.reborrow())?;

--- a/nexus/db-queries/src/db/queries/vpc_subnet.rs
+++ b/nexus/db-queries/src/db/queries/vpc_subnet.rs
@@ -106,11 +106,16 @@ impl QueryFragment<Pg> for InsertVpcSubnetQuery {
         &'a self,
         mut out: AstPass<'_, 'a, Pg>,
     ) -> diesel::QueryResult<()> {
-        out.push_sql("WITH overlap AS MATERIALIZED (SELECT CAST(IF(inet_contains_or_equals(");
+        out.push_sql("WITH overlap AS MATERIALIZED (SELECT CAST(IF((inet_contains_or_equals(");
         out.push_identifier(dsl::ipv4_block::NAME)?;
         out.push_sql(", ");
         out.push_bind_param::<sql_types::Inet, _>(&self.ipv4_block)?;
-        out.push_sql("), ");
+        out.push_sql(")");
+        out.push_sql("OR inet_contains_or_equals(");
+        out.push_bind_param::<sql_types::Inet, _>(&self.ipv4_block)?;
+        out.push_sql(", ");
+        out.push_identifier(dsl::ipv4_block::NAME)?;
+        out.push_sql(")), ");
         out.push_bind_param::<sql_types::Text, _>(
             InsertVpcSubnetError::OVERLAPPING_IPV4_BLOCK_SENTINEL,
         )?;

--- a/nexus/db-queries/src/db/queries/vpc_subnet.rs
+++ b/nexus/db-queries/src/db/queries/vpc_subnet.rs
@@ -47,8 +47,7 @@ use uuid::Uuid;
 ///         -- we're trying to cacth.
 ///         CAST(
 ///             IF(
-///                (inet_contains_or_equals(ipv4_block, <ipv4_block>) OR
-///                 inet_contains_or_equals(<ipv4_block>, ipv4_block)),
+///                (<ipv4_block> && ipv4_block),
 ///                'ipv4',
 ///                'ipv6'
 ///             )
@@ -61,10 +60,8 @@ use uuid::Uuid;
 ///         time_deleted IS NULL AND
 ///         id != <id> AND
 ///         (
-///             inet_contains_or_equals(ipv4_block, <ipv4_block>) OR
-///             inet_contains_or_equals(<ipv4_block>, ipv4_block) OR
-///             inet_contains_or_equals(ipv6_block, <ipv6_block>) OR
-///             inet_contains_or_equals(<ipv6_block>, ipv6_block)
+///             (ipv4_block && <ipv4_block>) OR
+///             (ipv6_block && <ipv6_block>)
 ///         )
 /// )
 /// INSERT INTO

--- a/nexus/db-queries/src/db/queries/vpc_subnet.rs
+++ b/nexus/db-queries/src/db/queries/vpc_subnet.rs
@@ -419,10 +419,10 @@ mod test {
             overlapping_ipv4_block_longer,
             other_ipv6_block,
         );
-        let err = db_datastore
-            .vpc_create_subnet_raw(new_row)
-            .await
-            .expect_err("Should not be able to insert VPC Subnet with overlapping IPv4 range {overlapping_ipv4_block_longer}");
+        let err = db_datastore.vpc_create_subnet_raw(new_row).await.expect_err(
+            "Should not be able to insert VPC Subnet with \
+                overlapping IPv4 range {overlapping_ipv4_block_longer}",
+        );
         assert_eq!(
             err,
             InsertVpcSubnetError::OverlappingIpRange(
@@ -437,10 +437,10 @@ mod test {
             overlapping_ipv4_block_shorter,
             other_ipv6_block,
         );
-        let err = db_datastore
-            .vpc_create_subnet_raw(new_row)
-            .await
-            .expect_err("Should not be able to insert VPC Subnet with overlapping IPv4 range {overlapping_ipv4_block_shorter}");
+        let err = db_datastore.vpc_create_subnet_raw(new_row).await.expect_err(
+            "Should not be able to insert VPC Subnet with \
+                overlapping IPv4 range {overlapping_ipv4_block_shorter}",
+        );
         assert_eq!(
             err,
             InsertVpcSubnetError::OverlappingIpRange(
@@ -455,10 +455,10 @@ mod test {
             other_ipv4_block,
             overlapping_ipv6_block_longer,
         );
-        let err = db_datastore
-            .vpc_create_subnet_raw(new_row)
-            .await
-            .expect_err("Should not be able to insert VPC Subnet with overlapping IPv6 range {overlapping_ipv6_block_longer}");
+        let err = db_datastore.vpc_create_subnet_raw(new_row).await.expect_err(
+            "Should not be able to insert VPC Subnet with \
+                overlapping IPv6 range {overlapping_ipv6_block_longer}",
+        );
         assert_eq!(
             err,
             InsertVpcSubnetError::OverlappingIpRange(
@@ -473,10 +473,10 @@ mod test {
             other_ipv4_block,
             overlapping_ipv6_block_shorter,
         );
-        let err = db_datastore
-            .vpc_create_subnet_raw(new_row)
-            .await
-            .expect_err("Should not be able to insert VPC Subnet with overlapping IPv6 range {overlapping_ipv6_block_shorter}");
+        let err = db_datastore.vpc_create_subnet_raw(new_row).await.expect_err(
+            "Should not be able to insert VPC Subnet with \
+                overlapping IPv6 range {overlapping_ipv6_block_shorter}",
+        );
         assert_eq!(
             err,
             InsertVpcSubnetError::OverlappingIpRange(
@@ -494,10 +494,10 @@ mod test {
             other_ipv4_block,
             ipv6_block,
         );
-        let err = db_datastore
-            .vpc_create_subnet_raw(new_row)
-            .await
-            .expect_err("Should not be able to insert VPC Subnet with overlapping IPv6 range");
+        let err = db_datastore.vpc_create_subnet_raw(new_row).await.expect_err(
+            "Should not be able to insert VPC Subnet with \
+                overlapping IPv6 range",
+        );
         assert_eq!(
             err,
             InsertVpcSubnetError::OverlappingIpRange(ipv6_block.into()),

--- a/nexus/db-queries/src/db/queries/vpc_subnet.rs
+++ b/nexus/db-queries/src/db/queries/vpc_subnet.rs
@@ -47,7 +47,8 @@ use uuid::Uuid;
 ///         -- we're trying to cacth.
 ///         CAST(
 ///             IF(
-///                 inet_contains_or_equals(ipv4_block, <ipv4_block>),
+///                (inet_contains_or_equals(ipv4_block, <ipv4_block>) OR
+///                 inet_contains_or_equals(<ipv4_block>, ipv4_block)),
 ///                'ipv4',
 ///                'ipv6'
 ///             )

--- a/nexus/db-queries/src/db/queries/vpc_subnet.rs
+++ b/nexus/db-queries/src/db/queries/vpc_subnet.rs
@@ -61,7 +61,9 @@ use uuid::Uuid;
 ///         id != <id> AND
 ///         (
 ///             inet_contains_or_equals(ipv4_block, <ipv4_block>) OR
-///             inet_contains_or_equals(ipv6_block, <ipv6_block>)
+///             inet_contains_or_equals(<ipv4_block>, ipv4_block) OR
+///             inet_contains_or_equals(ipv6_block, <ipv6_block>) OR
+///             inet_contains_or_equals(<ipv6_block>, ipv6_block)
 ///         )
 /// )
 /// INSERT INTO
@@ -133,9 +135,17 @@ impl QueryFragment<Pg> for InsertVpcSubnetQuery {
         out.push_sql(", ");
         out.push_bind_param::<sql_types::Inet, IpNetwork>(&self.ipv4_block)?;
         out.push_sql(") OR inet_contains_or_equals(");
+        out.push_bind_param::<sql_types::Inet, IpNetwork>(&self.ipv4_block)?;
+        out.push_sql(", ");
+        out.push_identifier(dsl::ipv4_block::NAME)?;
+        out.push_sql(") OR inet_contains_or_equals(");
         out.push_identifier(dsl::ipv6_block::NAME)?;
         out.push_sql(", ");
         out.push_bind_param::<sql_types::Inet, IpNetwork>(&self.ipv6_block)?;
+        out.push_sql(") OR inet_contains_or_equals(");
+        out.push_bind_param::<sql_types::Inet, IpNetwork>(&self.ipv6_block)?;
+        out.push_sql(", ");
+        out.push_identifier(dsl::ipv6_block::NAME)?;
 
         out.push_sql("))) INSERT INTO ");
         VPC_SUBNET_FROM_CLAUSE.walk_ast(out.reborrow())?;


### PR DESCRIPTION
Updates the logic to detect an IP Block collision when attempting to add a new VPC Subnet.
Initial approach was to call `inet_contains_or_equals()` twice (switching order of arguments to ensure the test is run bidirectionally), which did work.
However, Ben suggested we instead use `&&` to do the testing since it works bidirectionally and reduces the amount of function/operator calls in the query.

The first commit in this series is an addition to the VPC Subnet insertion tests, which fail (correctly) without the subsequent commits that address the bad collision detection logic.

Fixes: #6870