### PR TITLE
Fix: use correct primary NIC for External IP add/delete/refresh

### DIFF
--- a/sled-agent/src/instance.rs
+++ b/sled-agent/src/instance.rs
@@ -988,7 +988,7 @@ impl InstanceRunner {
             }
         }
 
-        let Some(primary_nic) = self.requested_nics.get(0) else {
+        let Some(primary_nic) = self.primary_nic() else {
             return Err(Error::Opte(illumos_utils::opte::Error::NoPrimaryNic));
         };
 
@@ -1004,7 +1004,7 @@ impl InstanceRunner {
     }
 
     fn refresh_external_ips_inner(&mut self) -> Result<(), Error> {
-        let Some(primary_nic) = self.requested_nics.get(0) else {
+        let Some(primary_nic) = self.primary_nic() else {
             return Err(Error::Opte(illumos_utils::opte::Error::NoPrimaryNic));
         };
 
@@ -1052,7 +1052,7 @@ impl InstanceRunner {
             }
         }
 
-        let Some(primary_nic) = self.requested_nics.get(0) else {
+        let Some(primary_nic) = self.primary_nic() else {
             return Err(Error::Opte(illumos_utils::opte::Error::NoPrimaryNic));
         };
 
@@ -1065,6 +1065,10 @@ impl InstanceRunner {
         )?;
 
         Ok(())
+    }
+
+    fn primary_nic(&self) -> Option<&NetworkInterface> {
+        self.requested_nics.iter().find(|nic| nic.primary)
     }
 }
 


### PR DESCRIPTION
`InstanceRunner` has been using the wrong primary NIC for Ephemeral/Floating IP addition/removal for some time, assuming that the Slot 0 NIC is always the primary. Now that External IP state is regularly re-asserted to keep Internet Gateway tags up-to-date, this led to OPTE ports reporting the use of external IPs on both the primary and slot0 nic, when multiple NICs are present and external IP state is changed on the instance.

This PR makes the correct NIC selection for all three operations.