### PR TITLE
Avoid pruning oximeter producers registered during a refresh

### DIFF
--- a/oximeter/collector/src/lib.rs
+++ b/oximeter/collector/src/lib.rs
@@ -289,7 +289,6 @@ impl Oximeter {
                     http_resolver,
                     native_resolver,
                     &log,
-                    config.db.replicated,
                 )
                 .await?,
             ))


### PR DESCRIPTION
- Add generation numbers to the collection of oximeter producers, and assign the currrent generation to each producer as it is registered.
- Modify the refresh method to first take the generation number before starting to list current producers. Then use that to avoid pruning producers that are _new_ since we started refreshing our list.
- Fixes #6895 and possibly #6901