### PR TITLE
[reconfigurator-cli] also store initial blueprint

### DIFF
--- a/dev-tools/reconfigurator-cli/src/main.rs
+++ b/dev-tools/reconfigurator-cli/src/main.rs
@@ -1364,6 +1364,8 @@ fn cmd_load_example(
             zones: vec![external_dns],
         },
     );
+    sim.blueprints
+        .insert(example.initial_blueprint.id, example.initial_blueprint);
     sim.blueprints.insert(blueprint.id, blueprint);
     sim.collection_id_rng =
         TypedUuidRng::from_seed(&args.seed, "reconfigurator-cli");

--- a/dev-tools/reconfigurator-cli/tests/output/cmd-example-stdout
+++ b/dev-tools/reconfigurator-cli/tests/output/cmd-example-stdout
@@ -30,6 +30,7 @@ ID                                   NERRORS TIME_DONE
 
 > blueprint-list
 ID                                   PARENT                               TIME_CREATED             
+02697f74-b14a-4418-90f0-c28b2a3a6aa9 <none>                               <REDACTED_TIMESTAMP> 
 ade5749d-bdf3-4fab-a8ae-00bea01b3a5a 02697f74-b14a-4418-90f0-c28b2a3a6aa9 <REDACTED_TIMESTAMP> 
 
 > 
@@ -483,6 +484,7 @@ ID                                   NERRORS TIME_DONE
 
 > blueprint-list
 ID                                   PARENT                               TIME_CREATED             
+02697f74-b14a-4418-90f0-c28b2a3a6aa9 <none>                               <REDACTED_TIMESTAMP> 
 ade5749d-bdf3-4fab-a8ae-00bea01b3a5a 02697f74-b14a-4418-90f0-c28b2a3a6aa9 <REDACTED_TIMESTAMP> 
 
 > 

--- a/nexus/reconfigurator/planning/src/example.rs
+++ b/nexus/reconfigurator/planning/src/example.rs
@@ -27,6 +27,9 @@ pub struct ExampleSystem {
     pub system: SystemDescription,
     pub input: PlanningInput,
     pub collection: Collection,
+    /// The initial blueprint that was used to describe the system. This
+    /// blueprint has sleds but no zones.
+    pub initial_blueprint: Blueprint,
     // If we add more types of RNGs than just sleds here, we'll need to
     // expand this to be similar to BlueprintBuilderRng where a root RNG
     // creates sub-RNGs.
@@ -388,6 +391,7 @@ impl ExampleSystemBuilder {
             system,
             input: input_builder.build(),
             collection: builder.build(),
+            initial_blueprint,
             sled_rng,
         };
         (example, blueprint)


### PR DESCRIPTION
Noticed that we had a dangling reference in the load-example command because we only stored the second blueprint, not the first one.
