### PR TITLE
Update Crucible and Propolis

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -656,7 +656,7 @@ dependencies = [
 [[package]]
 name = "bhyve_api"
 version = "0.0.0"
-source = "git+https://github.com/oxidecomputer/propolis?rev=b3d6c6c0f59c70c7e999456c17163518fe2440c8#b3d6c6c0f59c70c7e999456c17163518fe2440c8"
+source = "git+https://github.com/oxidecomputer/propolis?rev=e0c83fd0e0760eec1af306286c50081689d11a51#e0c83fd0e0760eec1af306286c50081689d11a51"
 dependencies = [
  "bhyve_api_sys",
  "libc",
@@ -666,7 +666,7 @@ dependencies = [
 [[package]]
 name = "bhyve_api_sys"
 version = "0.0.0"
-source = "git+https://github.com/oxidecomputer/propolis?rev=b3d6c6c0f59c70c7e999456c17163518fe2440c8#b3d6c6c0f59c70c7e999456c17163518fe2440c8"
+source = "git+https://github.com/oxidecomputer/propolis?rev=e0c83fd0e0760eec1af306286c50081689d11a51#e0c83fd0e0760eec1af306286c50081689d11a51"
 dependencies = [
  "libc",
  "strum",
@@ -6637,7 +6637,7 @@ dependencies = [
  "pq-sys",
  "pretty_assertions",
  "progenitor-client",
- "propolis-client 0.1.0 (git+https://github.com/oxidecomputer/propolis?rev=b3d6c6c0f59c70c7e999456c17163518fe2440c8)",
+ "propolis-client 0.1.0 (git+https://github.com/oxidecomputer/propolis?rev=e0c83fd0e0760eec1af306286c50081689d11a51)",
  "qorb",
  "rand",
  "rcgen",
@@ -6899,7 +6899,7 @@ dependencies = [
  "oximeter-producer",
  "oxnet",
  "pretty_assertions",
- "propolis-client 0.1.0 (git+https://github.com/oxidecomputer/propolis?rev=b3d6c6c0f59c70c7e999456c17163518fe2440c8)",
+ "propolis-client 0.1.0 (git+https://github.com/oxidecomputer/propolis?rev=e0c83fd0e0760eec1af306286c50081689d11a51)",
  "propolis-mock-server",
  "propolis_api_types",
  "rand",
@@ -8579,7 +8579,7 @@ dependencies = [
 [[package]]
 name = "propolis-client"
 version = "0.1.0"
-source = "git+https://github.com/oxidecomputer/propolis?rev=b3d6c6c0f59c70c7e999456c17163518fe2440c8#b3d6c6c0f59c70c7e999456c17163518fe2440c8"
+source = "git+https://github.com/oxidecomputer/propolis?rev=e0c83fd0e0760eec1af306286c50081689d11a51#e0c83fd0e0760eec1af306286c50081689d11a51"
 dependencies = [
  "async-trait",
  "base64 0.21.7",
@@ -8621,7 +8621,7 @@ dependencies = [
 [[package]]
 name = "propolis-mock-server"
 version = "0.0.0"
-source = "git+https://github.com/oxidecomputer/propolis?rev=b3d6c6c0f59c70c7e999456c17163518fe2440c8#b3d6c6c0f59c70c7e999456c17163518fe2440c8"
+source = "git+https://github.com/oxidecomputer/propolis?rev=e0c83fd0e0760eec1af306286c50081689d11a51#e0c83fd0e0760eec1af306286c50081689d11a51"
 dependencies = [
  "anyhow",
  "atty",
@@ -8663,7 +8663,7 @@ dependencies = [
 [[package]]
 name = "propolis_api_types"
 version = "0.0.0"
-source = "git+https://github.com/oxidecomputer/propolis?rev=b3d6c6c0f59c70c7e999456c17163518fe2440c8#b3d6c6c0f59c70c7e999456c17163518fe2440c8"
+source = "git+https://github.com/oxidecomputer/propolis?rev=e0c83fd0e0760eec1af306286c50081689d11a51#e0c83fd0e0760eec1af306286c50081689d11a51"
 dependencies = [
  "crucible-client-types",
  "propolis_types",
@@ -8676,7 +8676,7 @@ dependencies = [
 [[package]]
 name = "propolis_types"
 version = "0.0.0"
-source = "git+https://github.com/oxidecomputer/propolis?rev=b3d6c6c0f59c70c7e999456c17163518fe2440c8#b3d6c6c0f59c70c7e999456c17163518fe2440c8"
+source = "git+https://github.com/oxidecomputer/propolis?rev=e0c83fd0e0760eec1af306286c50081689d11a51#e0c83fd0e0760eec1af306286c50081689d11a51"
 dependencies = [
  "schemars",
  "serde",
@@ -10325,7 +10325,7 @@ dependencies = [
  "omicron-uuid-kinds",
  "omicron-workspace-hack",
  "oxnet",
- "propolis-client 0.1.0 (git+https://github.com/oxidecomputer/propolis?rev=b3d6c6c0f59c70c7e999456c17163518fe2440c8)",
+ "propolis-client 0.1.0 (git+https://github.com/oxidecomputer/propolis?rev=e0c83fd0e0760eec1af306286c50081689d11a51)",
  "rcgen",
  "schemars",
  "serde",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -656,7 +656,7 @@ dependencies = [
 [[package]]
 name = "bhyve_api"
 version = "0.0.0"
-source = "git+https://github.com/oxidecomputer/propolis?rev=11371b0f3743f8df5b047dc0edc2699f4bdf3927#11371b0f3743f8df5b047dc0edc2699f4bdf3927"
+source = "git+https://github.com/oxidecomputer/propolis?rev=b3d6c6c0f59c70c7e999456c17163518fe2440c8#b3d6c6c0f59c70c7e999456c17163518fe2440c8"
 dependencies = [
  "bhyve_api_sys",
  "libc",
@@ -666,7 +666,7 @@ dependencies = [
 [[package]]
 name = "bhyve_api_sys"
 version = "0.0.0"
-source = "git+https://github.com/oxidecomputer/propolis?rev=11371b0f3743f8df5b047dc0edc2699f4bdf3927#11371b0f3743f8df5b047dc0edc2699f4bdf3927"
+source = "git+https://github.com/oxidecomputer/propolis?rev=b3d6c6c0f59c70c7e999456c17163518fe2440c8#b3d6c6c0f59c70c7e999456c17163518fe2440c8"
 dependencies = [
  "libc",
  "strum",
@@ -1735,7 +1735,7 @@ dependencies = [
 [[package]]
 name = "crucible-agent-client"
 version = "0.0.1"
-source = "git+https://github.com/oxidecomputer/crucible?rev=2b88ab88461fb06aaf2aab11c5e381a3cad25eac#2b88ab88461fb06aaf2aab11c5e381a3cad25eac"
+source = "git+https://github.com/oxidecomputer/crucible?rev=b7b9d5660b28ca5e865242b2bdecd032c0852d40#b7b9d5660b28ca5e865242b2bdecd032c0852d40"
 dependencies = [
  "anyhow",
  "chrono",
@@ -1751,7 +1751,7 @@ dependencies = [
 [[package]]
 name = "crucible-client-types"
 version = "0.1.0"
-source = "git+https://github.com/oxidecomputer/crucible?rev=2b88ab88461fb06aaf2aab11c5e381a3cad25eac#2b88ab88461fb06aaf2aab11c5e381a3cad25eac"
+source = "git+https://github.com/oxidecomputer/crucible?rev=b7b9d5660b28ca5e865242b2bdecd032c0852d40#b7b9d5660b28ca5e865242b2bdecd032c0852d40"
 dependencies = [
  "base64 0.22.1",
  "crucible-workspace-hack",
@@ -1764,7 +1764,7 @@ dependencies = [
 [[package]]
 name = "crucible-common"
 version = "0.0.1"
-source = "git+https://github.com/oxidecomputer/crucible?rev=2b88ab88461fb06aaf2aab11c5e381a3cad25eac#2b88ab88461fb06aaf2aab11c5e381a3cad25eac"
+source = "git+https://github.com/oxidecomputer/crucible?rev=b7b9d5660b28ca5e865242b2bdecd032c0852d40#b7b9d5660b28ca5e865242b2bdecd032c0852d40"
 dependencies = [
  "anyhow",
  "atty",
@@ -1794,7 +1794,7 @@ dependencies = [
 [[package]]
 name = "crucible-pantry-client"
 version = "0.0.1"
-source = "git+https://github.com/oxidecomputer/crucible?rev=2b88ab88461fb06aaf2aab11c5e381a3cad25eac#2b88ab88461fb06aaf2aab11c5e381a3cad25eac"
+source = "git+https://github.com/oxidecomputer/crucible?rev=b7b9d5660b28ca5e865242b2bdecd032c0852d40#b7b9d5660b28ca5e865242b2bdecd032c0852d40"
 dependencies = [
  "anyhow",
  "chrono",
@@ -1811,7 +1811,7 @@ dependencies = [
 [[package]]
 name = "crucible-smf"
 version = "0.0.0"
-source = "git+https://github.com/oxidecomputer/crucible?rev=2b88ab88461fb06aaf2aab11c5e381a3cad25eac#2b88ab88461fb06aaf2aab11c5e381a3cad25eac"
+source = "git+https://github.com/oxidecomputer/crucible?rev=b7b9d5660b28ca5e865242b2bdecd032c0852d40#b7b9d5660b28ca5e865242b2bdecd032c0852d40"
 dependencies = [
  "crucible-workspace-hack",
  "libc",
@@ -6637,7 +6637,7 @@ dependencies = [
  "pq-sys",
  "pretty_assertions",
  "progenitor-client",
- "propolis-client 0.1.0 (git+https://github.com/oxidecomputer/propolis?rev=11371b0f3743f8df5b047dc0edc2699f4bdf3927)",
+ "propolis-client 0.1.0 (git+https://github.com/oxidecomputer/propolis?rev=b3d6c6c0f59c70c7e999456c17163518fe2440c8)",
  "qorb",
  "rand",
  "rcgen",
@@ -6899,7 +6899,7 @@ dependencies = [
  "oximeter-producer",
  "oxnet",
  "pretty_assertions",
- "propolis-client 0.1.0 (git+https://github.com/oxidecomputer/propolis?rev=11371b0f3743f8df5b047dc0edc2699f4bdf3927)",
+ "propolis-client 0.1.0 (git+https://github.com/oxidecomputer/propolis?rev=b3d6c6c0f59c70c7e999456c17163518fe2440c8)",
  "propolis-mock-server",
  "propolis_api_types",
  "rand",
@@ -8579,7 +8579,7 @@ dependencies = [
 [[package]]
 name = "propolis-client"
 version = "0.1.0"
-source = "git+https://github.com/oxidecomputer/propolis?rev=11371b0f3743f8df5b047dc0edc2699f4bdf3927#11371b0f3743f8df5b047dc0edc2699f4bdf3927"
+source = "git+https://github.com/oxidecomputer/propolis?rev=b3d6c6c0f59c70c7e999456c17163518fe2440c8#b3d6c6c0f59c70c7e999456c17163518fe2440c8"
 dependencies = [
  "async-trait",
  "base64 0.21.7",
@@ -8621,7 +8621,7 @@ dependencies = [
 [[package]]
 name = "propolis-mock-server"
 version = "0.0.0"
-source = "git+https://github.com/oxidecomputer/propolis?rev=11371b0f3743f8df5b047dc0edc2699f4bdf3927#11371b0f3743f8df5b047dc0edc2699f4bdf3927"
+source = "git+https://github.com/oxidecomputer/propolis?rev=b3d6c6c0f59c70c7e999456c17163518fe2440c8#b3d6c6c0f59c70c7e999456c17163518fe2440c8"
 dependencies = [
  "anyhow",
  "atty",
@@ -8663,7 +8663,7 @@ dependencies = [
 [[package]]
 name = "propolis_api_types"
 version = "0.0.0"
-source = "git+https://github.com/oxidecomputer/propolis?rev=11371b0f3743f8df5b047dc0edc2699f4bdf3927#11371b0f3743f8df5b047dc0edc2699f4bdf3927"
+source = "git+https://github.com/oxidecomputer/propolis?rev=b3d6c6c0f59c70c7e999456c17163518fe2440c8#b3d6c6c0f59c70c7e999456c17163518fe2440c8"
 dependencies = [
  "crucible-client-types",
  "propolis_types",
@@ -8676,7 +8676,7 @@ dependencies = [
 [[package]]
 name = "propolis_types"
 version = "0.0.0"
-source = "git+https://github.com/oxidecomputer/propolis?rev=11371b0f3743f8df5b047dc0edc2699f4bdf3927#11371b0f3743f8df5b047dc0edc2699f4bdf3927"
+source = "git+https://github.com/oxidecomputer/propolis?rev=b3d6c6c0f59c70c7e999456c17163518fe2440c8#b3d6c6c0f59c70c7e999456c17163518fe2440c8"
 dependencies = [
  "schemars",
  "serde",
@@ -10325,7 +10325,7 @@ dependencies = [
  "omicron-uuid-kinds",
  "omicron-workspace-hack",
  "oxnet",
- "propolis-client 0.1.0 (git+https://github.com/oxidecomputer/propolis?rev=11371b0f3743f8df5b047dc0edc2699f4bdf3927)",
+ "propolis-client 0.1.0 (git+https://github.com/oxidecomputer/propolis?rev=b3d6c6c0f59c70c7e999456c17163518fe2440c8)",
  "rcgen",
  "schemars",
  "serde",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -329,10 +329,10 @@ cookie = "0.18"
 criterion = { version = "0.5.1", features = [ "async_tokio" ] }
 crossbeam = "0.8"
 crossterm = { version = "0.28.1", features = ["event-stream"] }
-crucible-agent-client = { git = "https://github.com/oxidecomputer/crucible", rev = "2b88ab88461fb06aaf2aab11c5e381a3cad25eac" }
-crucible-pantry-client = { git = "https://github.com/oxidecomputer/crucible", rev = "2b88ab88461fb06aaf2aab11c5e381a3cad25eac" }
-crucible-smf = { git = "https://github.com/oxidecomputer/crucible", rev = "2b88ab88461fb06aaf2aab11c5e381a3cad25eac" }
-crucible-common = { git = "https://github.com/oxidecomputer/crucible", rev = "2b88ab88461fb06aaf2aab11c5e381a3cad25eac" }
+crucible-agent-client = { git = "https://github.com/oxidecomputer/crucible", rev = "b7b9d5660b28ca5e865242b2bdecd032c0852d40" }
+crucible-pantry-client = { git = "https://github.com/oxidecomputer/crucible", rev = "b7b9d5660b28ca5e865242b2bdecd032c0852d40" }
+crucible-smf = { git = "https://github.com/oxidecomputer/crucible", rev = "b7b9d5660b28ca5e865242b2bdecd032c0852d40" }
+crucible-common = { git = "https://github.com/oxidecomputer/crucible", rev = "b7b9d5660b28ca5e865242b2bdecd032c0852d40" }
 csv = "1.3.0"
 curve25519-dalek = "4"
 datatest-stable = "0.2.9"
@@ -515,10 +515,10 @@ prettyplease = { version = "0.2.22", features = ["verbatim"] }
 proc-macro2 = "1.0"
 progenitor = "0.8.0"
 progenitor-client = "0.8.0"
-bhyve_api = { git = "https://github.com/oxidecomputer/propolis", rev = "11371b0f3743f8df5b047dc0edc2699f4bdf3927" }
-propolis_api_types = { git = "https://github.com/oxidecomputer/propolis", rev = "11371b0f3743f8df5b047dc0edc2699f4bdf3927" }
-propolis-client = { git = "https://github.com/oxidecomputer/propolis", rev = "11371b0f3743f8df5b047dc0edc2699f4bdf3927" }
-propolis-mock-server = { git = "https://github.com/oxidecomputer/propolis", rev = "11371b0f3743f8df5b047dc0edc2699f4bdf3927" }
+bhyve_api = { git = "https://github.com/oxidecomputer/propolis", rev = "b3d6c6c0f59c70c7e999456c17163518fe2440c8" }
+propolis_api_types = { git = "https://github.com/oxidecomputer/propolis", rev = "b3d6c6c0f59c70c7e999456c17163518fe2440c8" }
+propolis-client = { git = "https://github.com/oxidecomputer/propolis", rev = "b3d6c6c0f59c70c7e999456c17163518fe2440c8" }
+propolis-mock-server = { git = "https://github.com/oxidecomputer/propolis", rev = "b3d6c6c0f59c70c7e999456c17163518fe2440c8" }
 proptest = "1.5.0"
 qorb = "0.1.2"
 quote = "1.0"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -515,10 +515,10 @@ prettyplease = { version = "0.2.22", features = ["verbatim"] }
 proc-macro2 = "1.0"
 progenitor = "0.8.0"
 progenitor-client = "0.8.0"
-bhyve_api = { git = "https://github.com/oxidecomputer/propolis", rev = "b3d6c6c0f59c70c7e999456c17163518fe2440c8" }
-propolis_api_types = { git = "https://github.com/oxidecomputer/propolis", rev = "b3d6c6c0f59c70c7e999456c17163518fe2440c8" }
-propolis-client = { git = "https://github.com/oxidecomputer/propolis", rev = "b3d6c6c0f59c70c7e999456c17163518fe2440c8" }
-propolis-mock-server = { git = "https://github.com/oxidecomputer/propolis", rev = "b3d6c6c0f59c70c7e999456c17163518fe2440c8" }
+bhyve_api = { git = "https://github.com/oxidecomputer/propolis", rev = "e0c83fd0e0760eec1af306286c50081689d11a51" }
+propolis_api_types = { git = "https://github.com/oxidecomputer/propolis", rev = "e0c83fd0e0760eec1af306286c50081689d11a51" }
+propolis-client = { git = "https://github.com/oxidecomputer/propolis", rev = "e0c83fd0e0760eec1af306286c50081689d11a51" }
+propolis-mock-server = { git = "https://github.com/oxidecomputer/propolis", rev = "e0c83fd0e0760eec1af306286c50081689d11a51" }
 proptest = "1.5.0"
 qorb = "0.1.2"
 quote = "1.0"

--- a/openapi/sled-agent.json
+++ b/openapi/sled-agent.json
@@ -1883,11 +1883,11 @@
         ]
       },
       "BootOrderEntry": {
-        "description": "An entry in a list of boot options.\n\n<details><summary>JSON schema</summary>\n\n```json { \"description\": \"An entry in a list of boot options.\", \"type\": \"object\", \"required\": [ \"name\" ], \"properties\": { \"name\": { \"description\": \"The name of the device to attempt booting from.\", \"type\": \"string\" } } } ``` </details>",
+        "description": "An entry in the boot order stored in a [`BootSettings`] component.\n\n<details><summary>JSON schema</summary>\n\n```json { \"description\": \"An entry in the boot order stored in a [`BootSettings`] component.\", \"type\": \"object\", \"required\": [ \"name\" ], \"properties\": { \"name\": { \"description\": \"The name of another component in the spec that Propolis should try to boot from.\\n\\nCurrently, only disk device components are supported.\", \"type\": \"string\" } } } ``` </details>",
         "type": "object",
         "properties": {
           "name": {
-            "description": "The name of the device to attempt booting from.",
+            "description": "The name of another component in the spec that Propolis should try to boot from.\n\nCurrently, only disk device components are supported.",
             "type": "string"
           }
         },
@@ -1896,10 +1896,11 @@
         ]
       },
       "BootSettings": {
-        "description": "BootSettings\n\n<details><summary>JSON schema</summary>\n\n```json { \"type\": \"object\", \"required\": [ \"order\" ], \"properties\": { \"order\": { \"type\": \"array\", \"items\": { \"$ref\": \"#/components/schemas/BootOrderEntry\" } } } } ``` </details>",
+        "description": "Settings supplied to the guest's firmware image that specify the order in which it should consider its options when selecting a device to try to boot from.\n\n<details><summary>JSON schema</summary>\n\n```json { \"description\": \"Settings supplied to the guest's firmware image that specify the order in which it should consider its options when selecting a device to try to boot from.\", \"type\": \"object\", \"required\": [ \"order\" ], \"properties\": { \"order\": { \"description\": \"An ordered list of components to attempt to boot from.\", \"type\": \"array\", \"items\": { \"$ref\": \"#/components/schemas/BootOrderEntry\" } } }, \"additionalProperties\": false } ``` </details>",
         "type": "object",
         "properties": {
           "order": {
+            "description": "An ordered list of components to attempt to boot from.",
             "type": "array",
             "items": {
               "$ref": "#/components/schemas/BootOrderEntry"
@@ -1908,7 +1909,8 @@
         },
         "required": [
           "order"
-        ]
+        ],
+        "additionalProperties": false
       },
       "BootstoreStatus": {
         "type": "object",

--- a/package-manifest.toml
+++ b/package-manifest.toml
@@ -619,10 +619,10 @@ service_name = "propolis-server"
 only_for_targets.image = "standard"
 source.type = "prebuilt"
 source.repo = "propolis"
-source.commit = "b3d6c6c0f59c70c7e999456c17163518fe2440c8"
+source.commit = "e0c83fd0e0760eec1af306286c50081689d11a51"
 # The SHA256 digest is automatically posted to:
 # https://buildomat.eng.oxide.computer/public/file/oxidecomputer/propolis/image/<commit>/propolis-server.sha256.txt
-source.sha256 = "27344f26ad545345a3edf8e8d44468040650377cde601190ea06e245736aa60e"
+source.sha256 = "05e3b3497d340f6a6a1eda6aebdca81979c1b2e0b99411b9a20af9e35bdf07de"
 output.type = "zone"
 
 [package.mg-ddm-gz]

--- a/package-manifest.toml
+++ b/package-manifest.toml
@@ -576,10 +576,10 @@ only_for_targets.image = "standard"
 # 3. Use source.type = "manual" instead of "prebuilt"
 source.type = "prebuilt"
 source.repo = "crucible"
-source.commit = "2b88ab88461fb06aaf2aab11c5e381a3cad25eac"
+source.commit = "b7b9d5660b28ca5e865242b2bdecd032c0852d40"
 # The SHA256 digest is automatically posted to:
 # https://buildomat.eng.oxide.computer/public/file/oxidecomputer/crucible/image/<commit>/crucible.sha256.txt
-source.sha256 = "0927e7211f645ef8c3f715c7b6a8be81a0f4b6250a3ff352348ae701e89713f5"
+source.sha256 = "44e623730765f8fc0b702d107939552514530a33b306ca5e8bc8276ff0aaf79a"
 output.type = "zone"
 output.intermediate_only = true
 
@@ -588,10 +588,10 @@ service_name = "crucible_pantry_prebuilt"
 only_for_targets.image = "standard"
 source.type = "prebuilt"
 source.repo = "crucible"
-source.commit = "2b88ab88461fb06aaf2aab11c5e381a3cad25eac"
+source.commit = "b7b9d5660b28ca5e865242b2bdecd032c0852d40"
 # The SHA256 digest is automatically posted to:
 # https://buildomat.eng.oxide.computer/public/file/oxidecomputer/crucible/image/<commit>/crucible-pantry.sha256.txt
-source.sha256 = "c273dd273cb09cbd8007925b41fcc6df9807dd93e395347b36ce8306a8dc93e4"
+source.sha256 = "bc0a41d349646ec2111bff346db2c300001d646a99f33b05b39b78188e34ae41"
 output.type = "zone"
 output.intermediate_only = true
 
@@ -605,10 +605,10 @@ service_name = "crucible_dtrace"
 only_for_targets.image = "standard"
 source.type = "prebuilt"
 source.repo = "crucible"
-source.commit = "2b88ab88461fb06aaf2aab11c5e381a3cad25eac"
+source.commit = "b7b9d5660b28ca5e865242b2bdecd032c0852d40"
 # The SHA256 digest is automatically posted to:
 # https://buildomat.eng.oxide.computer/public/file/oxidecomputer/crucible/image/<commit>/crucible-dtrace.sha256.txt
-source.sha256 = "972a713eb02bc1aeaa7b16db24fef7f82afcfc4546abe998792c85f4a48269c0"
+source.sha256 = "64e37f7a062f7c8941fac3b95a81d98475e5c02ff01111554b0ddb7fc232f40f"
 output.type = "tarball"
 
 # Refer to
@@ -619,10 +619,10 @@ service_name = "propolis-server"
 only_for_targets.image = "standard"
 source.type = "prebuilt"
 source.repo = "propolis"
-source.commit = "11371b0f3743f8df5b047dc0edc2699f4bdf3927"
+source.commit = "b3d6c6c0f59c70c7e999456c17163518fe2440c8"
 # The SHA256 digest is automatically posted to:
 # https://buildomat.eng.oxide.computer/public/file/oxidecomputer/propolis/image/<commit>/propolis-server.sha256.txt
-source.sha256 = "07383cbad45bc032de1b65d3553839751fde96342cc76249ca4a45b89872aae9"
+source.sha256 = "27344f26ad545345a3edf8e8d44468040650377cde601190ea06e245736aa60e"
 output.type = "zone"
 
 [package.mg-ddm-gz]

--- a/smf/sled-agent/non-gimlet/config.toml
+++ b/smf/sled-agent/non-gimlet/config.toml
@@ -39,8 +39,6 @@ vdevs = [
   "u2_4.vdev",
   "u2_5.vdev",
   "u2_6.vdev",
-  "u2_7.vdev",
-  "u2_8.vdev",
 ]
 
 # Percentage of usable physical DRAM to use for the VMM reservoir, which
@@ -64,7 +62,7 @@ swap_device_size_gb = 64
 #
 # If empty, this will be equivalent to the first result from:
 # $ dladm show-phys -p -o LINK
-# data_link = "igb0"
+data_link = "igb0"
 
 # On a multi-sled system, transit-mode Maghemite runs in the `oxz_switch` zone
 # to configure routes between sleds.  This runs over the Sidecar's rear ports

--- a/smf/sled-agent/non-gimlet/config.toml
+++ b/smf/sled-agent/non-gimlet/config.toml
@@ -39,6 +39,8 @@ vdevs = [
   "u2_4.vdev",
   "u2_5.vdev",
   "u2_6.vdev",
+  "u2_7.vdev",
+  "u2_8.vdev",
 ]
 
 # Percentage of usable physical DRAM to use for the VMM reservoir, which
@@ -62,7 +64,7 @@ swap_device_size_gb = 64
 #
 # If empty, this will be equivalent to the first result from:
 # $ dladm show-phys -p -o LINK
-data_link = "igb0"
+# data_link = "igb0"
 
 # On a multi-sled system, transit-mode Maghemite runs in the `oxz_switch` zone
 # to configure routes between sleds.  This runs over the Sidecar's rear ports


### PR DESCRIPTION
Crucible changes
Add test and fix for replay race condition (#1519) Fix clippy warnings (#1517)
Add edition to `crucible-workspace-hack` (#1516)
Split out Downstairs-specific stats (#1511)
Move remaining `GuestWork` functionality into `Downstairs` (#1510) Track both jobs and bytes in each IO state (#1507) Fix new `rustc` and `clippy` warnings (#1509)
Remove IOP/BW limits (for now) (#1506)
Move `GuestBlockRes` into `DownstairsIO` (#1502)
Update actions/checkout digest to eef6144 (#1499)
Update Rust crate hyper-staticfile to 0.10.1 (#1411) Turn off test-up-2region-encrypted.sh (#1504)
Add `IOop::Barrier` (#1494)
Fix IPv6 addresses in `crutest` (#1503)
Add region set options to more tests. (#1496)
Simplify `CompleteJobs` (#1493)
Removed ignored CI jobs (#1497)
Minor cleanups to `print_last_completed` (#1501)
Remove remaining `Arc<Volume>` instances (#1500)
Add `VolumeBuilder` type (#1492)
remove old unused scripts (#1495)
More multiple region support. (#1484)
Simplify matches (#1490)
Move complete job tracker to a helper object (#1489) Expand summary and add documentation references to the README. (#1486) Remove `GuestWorkId` (2/2) (#1482)
Remove `JobId` from `DownstairsIO` (1/2) (#1481)
Remove unused `#[derive(..)]` (#1483)
Update more tests to use dsc (#1480)
Crutest now Volume only (#1479)

Propolis changes
manually impl Deserialize for PciPath for validation purposes (#801) phd: gate OS-specific tests, make others more OS-agnostic (#799) lib: log vCPU diagnostics on triple fault and for some unhandled exit types (#795) add marker trait to help check safety of guest memory reads (#794) clippy fixes for 1.82 (#796)
lib: move cpuid::Set to cpuid_utils; prevent semantic subleaf conflicts (#782) PHD: write efivars in one go (#786)
PHD: support guest-initiated reboot (#785)
server: accept CPUID values in instance specs and plumb them to bhyve (#780) PHD: allow patched Crucible dependencies (#778)
server: add a first-class error type to machine init (#777) PciPath to Bdf conversion is infallible; prove it and refactor (#774) instance spec rework: flatten InstanceSpecV0 (#767) Make PUT /instance/state 503 when waiting to init
Less anxiety-inducing `Vm::{get, state_watcher}`