### PR TITLE
[omdb] More concise timestamp formatting

### DIFF
--- a/dev-tools/omdb/src/bin/omdb/db.rs
+++ b/dev-tools/omdb/src/bin/omdb/db.rs
@@ -2552,6 +2552,7 @@ async fn cmd_db_region_replacement_list(
     #[tabled(rename_all = "SCREAMING_SNAKE_CASE")]
     struct Row {
         pub id: Uuid,
+        #[tabled(display_with = "datetime_rfc3339_concise")]
         pub request_time: DateTime<Utc>,
         pub replacement_state: String,
     }
@@ -2677,6 +2678,7 @@ async fn cmd_db_region_replacement_info(
         #[derive(Tabled)]
         #[tabled(rename_all = "SCREAMING_SNAKE_CASE")]
         struct Row {
+            #[tabled(display_with = "datetime_rfc3339_concise")]
             pub time: DateTime<Utc>,
 
             pub repair_id: String,
@@ -2752,6 +2754,7 @@ async fn cmd_db_region_replacement_info(
         #[derive(Tabled)]
         #[tabled(rename_all = "SCREAMING_SNAKE_CASE")]
         struct StepRow {
+            #[tabled(display_with = "datetime_rfc3339_concise")]
             pub time: DateTime<Utc>,
             pub step_type: String,
             pub details: String,
@@ -3929,6 +3932,7 @@ async fn cmd_db_region_snapshot_replacement_list(
     #[tabled(rename_all = "SCREAMING_SNAKE_CASE")]
     struct Row {
         pub id: Uuid,
+        #[tabled(display_with = "datetime_rfc3339_concise")]
         pub request_time: DateTime<Utc>,
         pub replacement_state: String,
     }
@@ -5345,16 +5349,17 @@ async fn cmd_db_migrations_list(
         #[derive(Tabled)]
         #[tabled(rename_all = "SCREAMING_SNAKE_CASE")]
         struct VerboseMigrationRow {
+            #[tabled(display_with = "datetime_rfc3339_concise")]
             created: chrono::DateTime<Utc>,
             id: Uuid,
             instance: Uuid,
             #[tabled(inline)]
             vmms: MigrationVmms,
-            #[tabled(display_with = "display_option_blank")]
+            #[tabled(display_with = "datetime_opt_rfc3339_concise")]
             src_updated: Option<chrono::DateTime<Utc>>,
-            #[tabled(display_with = "display_option_blank")]
+            #[tabled(display_with = "datetime_opt_rfc3339_concise")]
             tgt_updated: Option<chrono::DateTime<Utc>>,
-            #[tabled(display_with = "display_option_blank")]
+            #[tabled(display_with = "datetime_opt_rfc3339_concise")]
             deleted: Option<chrono::DateTime<Utc>>,
         }
 
@@ -5390,6 +5395,7 @@ async fn cmd_db_migrations_list(
         #[derive(Tabled)]
         #[tabled(rename_all = "SCREAMING_SNAKE_CASE")]
         struct MigrationRow {
+            #[tabled(display_with = "datetime_rfc3339_concise")]
             created: chrono::DateTime<Utc>,
             instance: Uuid,
             #[tabled(inline)]
@@ -5416,6 +5422,7 @@ async fn cmd_db_migrations_list(
 #[derive(Tabled)]
 #[tabled(rename_all = "SCREAMING_SNAKE_CASE")]
 struct SingleInstanceMigrationRow {
+    #[tabled(display_with = "datetime_rfc3339_concise")]
     created: chrono::DateTime<Utc>,
     #[tabled(inline)]
     vmms: MigrationVmms,
@@ -5451,4 +5458,19 @@ impl From<&'_ Migration> for MigrationVmms {
 // Display an empty cell for an Option<T> if it's None.
 fn display_option_blank<T: Display>(opt: &Option<T>) -> String {
     opt.as_ref().map(|x| x.to_string()).unwrap_or_else(|| "".to_string())
+}
+
+// Format a `chrono::DateTime` in RFC3339 with milliseconds precision and using
+// `Z` rather than the UTC offset for UTC timestamps, to save a few characters
+// of line width in tabular output.
+fn datetime_rfc3339_concise(t: &DateTime<Utc>) -> String {
+    t.to_rfc3339_opts(chrono::format::SecondsFormat::Millis, true)
+}
+
+// Format an optional `chrono::DateTime` in RFC3339 with milliseconds precision
+// and using `Z` rather than the UTC offset for UTC timestamps, to save a few
+// characters of line width in tabular output.
+fn datetime_opt_rfc3339_concise(t: &Option<DateTime<Utc>>) -> String {
+    t.map(|t| t.to_rfc3339_opts(chrono::format::SecondsFormat::Millis, true))
+        .unwrap_or_else(|| "-".to_string())
 }


### PR DESCRIPTION
Currently, `omdb` formats `chrono::DateTime`s using the default `fmt::Display` format. This uses a bunch of characters of line width, which becomes important for `omdb` commands which output tabular data with a large number of columns --- avoiding line wrapping wherever possible makes it substantially easier to read such output. @iximeow pointed out to me that we could save several characters of line width by using a more concise timestamp format.

This commit changes tabular output in `omdb db` commands to format timestamps using `chrono`'s RFC 3339 formatter with millisecond precision, rather than nanosecond precision. This saves us a few characters. RFC 3339 permits the use of `Z` rather than `+00:00` (the UTC offset) for UTC timestamps, and since all our timestamps are UTC, that saves us another four characters (also relative to the default format, which uses ` UTC ` for UTC timestamps). Together, this makes timestamp columns substantially shorter in `omdb db` output.

For example, consider `omdb db region-replacement list`:

```console
root@oxz_switch1:~# omdb db region-replacement list
note: database URL not specified.  Will search DNS.
note: (override with --db-url or OMDB_DB_URL)
note: using DNS server for subnet fd00:1122:3344::/48
note: (if this is not right, use --dns-server to specify an alternate DNS server)
note: using database URL postgresql://root@[fd00:1122:3344:109::3]:32221,[fd00:1122:3344:105::3]:32221,[fd00:1122:3344:10b::3]:32221,[fd00:1122:3344:107::3]:32221,[fd00:1122:3344:108::3]:32221/omicron?sslmode=disable
WARN: found schema version 110.0.0, expected 111.0.0
It's possible the database is running a version that's different from what this
tool understands.  This may result in errors or incorrect output.
Region replacement requests
ID                                   REQUEST_TIME                   REPLACEMENT_STATE
07a289e6-af50-42f1-8888-062229547888 2024-08-14 19:43:13.318246 UTC Complete
08c449a6-25c1-46f8-b070-9223cb924cb0 2024-08-14 19:43:13.245003 UTC Complete
1ed5e8e1-1d98-4420-bef0-135cba510238 2024-08-14 19:43:13.227734 UTC Complete
20811f9d-f6ed-40fe-8403-305edc4b3e8c 2024-08-14 19:43:13.291419 UTC Complete
52bd1034-2a77-4a17-8871-77e535b509d5 2024-08-14 19:43:13.259033 UTC Complete
5c43d936-d5c4-4d4e-b1ca-890aabeeae87 2024-08-14 19:43:13.357786 UTC Complete
915f8726-a882-4960-9e5c-dfe359f54911 2024-08-14 19:43:13.279 UTC    Complete
a4e697b6-5f02-4f75-ad41-f5bc3e906f0b 2024-08-14 19:43:13.344742 UTC Complete
c2b5ef9d-a89a-46c8-b57e-1eebb5487804 2024-08-14 19:43:13.331527 UTC Complete
f0e009b5-1575-42f0-bca5-7df6db846ef0 2024-08-14 19:43:13.304655 UTC Complete
root@oxz_switch1:~# /var/tmp/omdb-eliza-test-concise db region-replacement list
note: database URL not specified.  Will search DNS.
note: (override with --db-url or OMDB_DB_URL)
note: using DNS server for subnet fd00:1122:3344::/48
note: (if this is not right, use --dns-server to specify an alternate DNS server)
note: using database URL postgresql://root@[fd00:1122:3344:109::3]:32221,[fd00:1122:3344:105::3]:32221,[fd00:1122:3344:10b::3]:32221,[fd00:1122:3344:107::3]:32221,[fd00:1122:3344:108::3]:32221/omicron?sslmode=disable
WARN: found schema version 110.0.0, expected 111.0.0
It's possible the database is running a version that's different from what this
tool understands.  This may result in errors or incorrect output.
Region replacement requests
ID                                   REQUEST_TIME             REPLACEMENT_STATE
07a289e6-af50-42f1-8888-062229547888 2024-08-14T19:43:13.318Z Complete
08c449a6-25c1-46f8-b070-9223cb924cb0 2024-08-14T19:43:13.245Z Complete
1ed5e8e1-1d98-4420-bef0-135cba510238 2024-08-14T19:43:13.227Z Complete
20811f9d-f6ed-40fe-8403-305edc4b3e8c 2024-08-14T19:43:13.291Z Complete
52bd1034-2a77-4a17-8871-77e535b509d5 2024-08-14T19:43:13.259Z Complete
5c43d936-d5c4-4d4e-b1ca-890aabeeae87 2024-08-14T19:43:13.357Z Complete
915f8726-a882-4960-9e5c-dfe359f54911 2024-08-14T19:43:13.279Z Complete
a4e697b6-5f02-4f75-ad41-f5bc3e906f0b 2024-08-14T19:43:13.344Z Complete
c2b5ef9d-a89a-46c8-b57e-1eebb5487804 2024-08-14T19:43:13.331Z Complete
f0e009b5-1575-42f0-bca5-7df6db846ef0 2024-08-14T19:43:13.304Z Complete
root@oxz_switch1:~#
```

Although the output from the `region-replacement list` command is not *that* wide, I'm presently working on an instance VMM history command that displays three timestamps, and the width saving becomes quite significant there.