### PR TITLE
[omdb] Make `db instance info` less cryptic

### DIFF
--- a/dev-tools/omdb/src/bin/omdb/db.rs
+++ b/dev-tools/omdb/src/bin/omdb/db.rs
@@ -3161,10 +3161,14 @@ async fn cmd_db_instance_info(
     );
     match can_reincarnate {
         Reincarnatability::WillReincarnate => {
-            println!("    {KARMIC_STATUS:>WIDTH$}: bound to saṃsāra");
+            println!(
+                "    {KARMIC_STATUS:>WIDTH$}: saṃsāra (reincarnation enabled)"
+            );
         }
         Reincarnatability::Nirvana => {
-            println!("    {KARMIC_STATUS:>WIDTH$}: attained nirvāṇa");
+            println!(
+                "    {KARMIC_STATUS:>WIDTH$}: nirvāṇa (reincarnation disabled)"
+            );
         }
         Reincarnatability::CoolingDown(remaining) => {
             println!(


### PR DESCRIPTION
When displaying an instance's reincarnation status in `omdb db instance info`, I was a bit too cutesy with the Buddhism references --- currently, it prints that an instance is "bound to saṃsāra" or has "attained nirvāṇa", which is not the clearest description of the instance's reincarnation policy. This commit changes the `omdb db instance info` output a bit to try and make the instance's reincarnation policy clearer.