### PR TITLE
update to Rust 1.82.0

### DIFF
--- a/nexus/db-queries/src/db/on_conflict_ext.rs
+++ b/nexus/db-queries/src/db/on_conflict_ext.rs
@@ -127,8 +127,8 @@ pub trait IncompleteOnConflictExt {
     /// _logically implies_ the condition on the partial index. With something
     /// like `time_deleted IS NULL` the value of that is not exactly clear, but
     /// you can imagine a partial index on something like `col >= 10`, and
-    /// write `ON CONFLICT (...) WHERE col >= 20`. This is allowed because `col
-    /// >= 20` implies `col >= 10`. (But `WHERE col >= 5` is not allowed.)
+    /// write `ON CONFLICT (...) WHERE col >= 20`. This is allowed because
+    /// `col >= 20` implies `col >= 10`. (But `WHERE col >= 5` is not allowed.)
     ///
     /// ## 4. A similar syntax with a different meaning
     ///

--- a/nexus/db-queries/src/db/pool_connection.rs
+++ b/nexus/db-queries/src/db/pool_connection.rs
@@ -92,14 +92,13 @@ impl backend::Connector for DieselPgConnector {
         })
         .await
         .expect("Task panicked establishing connection")
-        .map_err(|e| {
+        .inspect_err(|e| {
             warn!(
                 self.log,
                 "Failed to make connection";
                 "error" => e.to_string(),
                 "backend" => backend.address,
             );
-            e
         })?;
         Ok(conn)
     }

--- a/oximeter/db/src/client/mod.rs
+++ b/oximeter/db/src/client/mod.rs
@@ -1185,17 +1185,16 @@ impl Client {
             })?;
 
         // Convert the HTTP response into a database response.
-        let response = handle_db_response(response).await.map_err(|err| {
-            probes::sql__query__done!(|| (&id));
-            err
-        })?;
+        let response =
+            handle_db_response(response).await.inspect_err(|_| {
+                probes::sql__query__done!(|| (&id));
+            })?;
 
         // Extract the query summary, measuring resource usage and duration.
         let summary =
             QuerySummary::from_headers(start.elapsed(), response.headers())
-                .map_err(|err| {
+                .inspect_err(|_| {
                     probes::sql__query__done!(|| (&id));
-                    err
                 })?;
 
         // Extract the actual text of the response.

--- a/oximeter/types/src/histogram.rs
+++ b/oximeter/types/src/histogram.rs
@@ -1061,7 +1061,7 @@ where
                 let lo = base.pow(lo as _);
                 let hi = base.pow(hi as _);
                 let distance = hi - lo;
-                distance.is_multiple_of(&count)
+                Integer::is_multiple_of(&distance, &count)
             })
         }
 

--- a/package/src/bin/omicron-package.rs
+++ b/package/src/bin/omicron-package.rs
@@ -1069,22 +1069,20 @@ async fn main() -> Result<()> {
     let get_config = || -> Result<Config> {
         let target_path = args.artifact_dir.join("target").join(&args.target);
         let raw_target =
-            std::fs::read_to_string(&target_path).map_err(|e| {
+            std::fs::read_to_string(&target_path).inspect_err(|_| {
                 eprintln!(
                     "Failed to read build target: {}\n{}",
                     target_path,
                     target_help_str()
                 );
-                e
             })?;
         let target: Target = KnownTarget::from_str(&raw_target)
-            .map_err(|e| {
+            .inspect_err(|_| {
                 eprintln!(
                     "Failed to parse {} as target\n{}",
                     target_path,
                     target_help_str()
                 );
-                e
             })?
             .into();
         debug!(log, "target[{}]: {:?}", args.target, target);

--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -1,5 +1,5 @@
 [toolchain]
 # We choose a specific toolchain (rather than "stable") for repeatability.  The
 # intent is to keep this up-to-date with recently-released stable Rust.
-channel = "1.80.1"
+channel = "1.82.0"
 profile = "default"

--- a/workspace-hack/Cargo.toml
+++ b/workspace-hack/Cargo.toml
@@ -5,6 +5,7 @@
 [package]
 name = "omicron-workspace-hack"
 version = "0.1.0"
+edition = "2021"
 description = "workspace-hack package, managed by hakari"
 # You can choose to publish this crate: see https://docs.rs/cargo-hakari/latest/cargo_hakari/publishing.
 publish = false


### PR DESCRIPTION
Not sure what changed between 1.81 and 1.82 but Clippy is once again complaining about `InstanceManagerRequest::EnsureRegistered`:

```
warning: large size difference between variants
   --> sled-agent/src/instance_manager.rs:335:1
    |
335 | /   enum InstanceManagerRequest {
336 | | /     EnsureRegistered {
337 | | |         propolis_id: PropolisUuid,
338 | | |         instance: InstanceEnsureBody,
339 | | |         // These are boxed because they are, apparently, quite large, and Clippy
...   | |
345 | | |         tx: oneshot::Sender<Result<SledVmmState, Error>>,
346 | | |     },
    | | |_____- the largest variant contains at least 448 bytes
...   |
351 | | /     EnsureState {
352 | | |         propolis_id: PropolisUuid,
353 | | |         target: VmmStateRequested,
354 | | |         tx: oneshot::Sender<Result<VmmPutStateResponse, Error>>,
355 | | |     },
    | | |_____- the second-largest variant contains at least 64 bytes
...   |
387 | |       },
388 | |   }
    | |___^ the entire enum is at least 0 bytes
    |
    = help: for further information visit https://rust-lang.github.io/rust-clippy/master/index.html#large_enum_variant
    = note: `#[warn(clippy::large_enum_variant)]` on by default
help: consider boxing the large fields to reduce the total size of the enum
    |
338 |         instance: Box<InstanceEnsureBody>,
    |                   ~~~~~~~~~~~~~~~~~~~~~~~
```

Everything else is pretty minimal.