### PR TITLE
Fix DNS port typo in RSS

### DIFF
--- a/sled-agent/src/rack_setup/plan/service.rs
+++ b/sled-agent/src/rack_setup/plan/service.rs
@@ -465,7 +465,7 @@ impl Plan {
                 .host_zone_with_one_backend(
                     id,
                     ServiceName::InternalDns,
-                    dns_address,
+                    http_address,
                 )
                 .unwrap();
             let dataset_name =


### PR DESCRIPTION
I'm still waiting for a4x2 to come all the way up to confirm Nexus can update internal DNS, but based on the serialized RSS plan, I believe this should be all that's required; the port numbers are correct with this change:

```json
          "_nameservice._tcp": [
            {
              "type": "SRV",
              "data": {
                "prio": 0,
                "weight": 0,
                "port": 5353,
                "target": "9340319c-02e3-4bed-9a58-761e6dba81c4.host.control-plane.oxide.internal"
              }
            },
            {
              "type": "SRV",
              "data": {
                "prio": 0,
                "weight": 0,
                "port": 5353,
                "target": "dc93338b-b6f2-42c6-b70d-ae4b62d04c90.host.control-plane.oxide.internal"
              }
            },
            {
              "type": "SRV",
              "data": {
                "prio": 0,
                "weight": 0,
                "port": 5353,
                "target": "dd8536a6-9736-4a84-bee8-43db57303f12.host.control-plane.oxide.internal"
              }
            }
```

Fixes #6951.