### PR TITLE
Update Propolis

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -656,7 +656,7 @@ dependencies = [
 [[package]]
 name = "bhyve_api"
 version = "0.0.0"
-source = "git+https://github.com/oxidecomputer/propolis?rev=e0c83fd0e0760eec1af306286c50081689d11a51#e0c83fd0e0760eec1af306286c50081689d11a51"
+source = "git+https://github.com/oxidecomputer/propolis?rev=86101eaf80b55e7f405b5cafe9b0de0e9f331656#86101eaf80b55e7f405b5cafe9b0de0e9f331656"
 dependencies = [
  "bhyve_api_sys",
  "libc",
@@ -666,7 +666,7 @@ dependencies = [
 [[package]]
 name = "bhyve_api_sys"
 version = "0.0.0"
-source = "git+https://github.com/oxidecomputer/propolis?rev=e0c83fd0e0760eec1af306286c50081689d11a51#e0c83fd0e0760eec1af306286c50081689d11a51"
+source = "git+https://github.com/oxidecomputer/propolis?rev=86101eaf80b55e7f405b5cafe9b0de0e9f331656#86101eaf80b55e7f405b5cafe9b0de0e9f331656"
 dependencies = [
  "libc",
  "strum",
@@ -6638,7 +6638,7 @@ dependencies = [
  "pq-sys",
  "pretty_assertions",
  "progenitor-client",
- "propolis-client 0.1.0 (git+https://github.com/oxidecomputer/propolis?rev=e0c83fd0e0760eec1af306286c50081689d11a51)",
+ "propolis-client 0.1.0 (git+https://github.com/oxidecomputer/propolis?rev=86101eaf80b55e7f405b5cafe9b0de0e9f331656)",
  "qorb",
  "rand",
  "rcgen",
@@ -6900,7 +6900,7 @@ dependencies = [
  "oximeter-producer",
  "oxnet",
  "pretty_assertions",
- "propolis-client 0.1.0 (git+https://github.com/oxidecomputer/propolis?rev=e0c83fd0e0760eec1af306286c50081689d11a51)",
+ "propolis-client 0.1.0 (git+https://github.com/oxidecomputer/propolis?rev=86101eaf80b55e7f405b5cafe9b0de0e9f331656)",
  "propolis-mock-server",
  "propolis_api_types",
  "rand",
@@ -8580,7 +8580,7 @@ dependencies = [
 [[package]]
 name = "propolis-client"
 version = "0.1.0"
-source = "git+https://github.com/oxidecomputer/propolis?rev=e0c83fd0e0760eec1af306286c50081689d11a51#e0c83fd0e0760eec1af306286c50081689d11a51"
+source = "git+https://github.com/oxidecomputer/propolis?rev=86101eaf80b55e7f405b5cafe9b0de0e9f331656#86101eaf80b55e7f405b5cafe9b0de0e9f331656"
 dependencies = [
  "async-trait",
  "base64 0.21.7",
@@ -8622,7 +8622,7 @@ dependencies = [
 [[package]]
 name = "propolis-mock-server"
 version = "0.0.0"
-source = "git+https://github.com/oxidecomputer/propolis?rev=e0c83fd0e0760eec1af306286c50081689d11a51#e0c83fd0e0760eec1af306286c50081689d11a51"
+source = "git+https://github.com/oxidecomputer/propolis?rev=86101eaf80b55e7f405b5cafe9b0de0e9f331656#86101eaf80b55e7f405b5cafe9b0de0e9f331656"
 dependencies = [
  "anyhow",
  "atty",
@@ -8664,7 +8664,7 @@ dependencies = [
 [[package]]
 name = "propolis_api_types"
 version = "0.0.0"
-source = "git+https://github.com/oxidecomputer/propolis?rev=e0c83fd0e0760eec1af306286c50081689d11a51#e0c83fd0e0760eec1af306286c50081689d11a51"
+source = "git+https://github.com/oxidecomputer/propolis?rev=86101eaf80b55e7f405b5cafe9b0de0e9f331656#86101eaf80b55e7f405b5cafe9b0de0e9f331656"
 dependencies = [
  "crucible-client-types",
  "propolis_types",
@@ -8677,7 +8677,7 @@ dependencies = [
 [[package]]
 name = "propolis_types"
 version = "0.0.0"
-source = "git+https://github.com/oxidecomputer/propolis?rev=e0c83fd0e0760eec1af306286c50081689d11a51#e0c83fd0e0760eec1af306286c50081689d11a51"
+source = "git+https://github.com/oxidecomputer/propolis?rev=86101eaf80b55e7f405b5cafe9b0de0e9f331656#86101eaf80b55e7f405b5cafe9b0de0e9f331656"
 dependencies = [
  "schemars",
  "serde",
@@ -10326,7 +10326,7 @@ dependencies = [
  "omicron-uuid-kinds",
  "omicron-workspace-hack",
  "oxnet",
- "propolis-client 0.1.0 (git+https://github.com/oxidecomputer/propolis?rev=e0c83fd0e0760eec1af306286c50081689d11a51)",
+ "propolis-client 0.1.0 (git+https://github.com/oxidecomputer/propolis?rev=86101eaf80b55e7f405b5cafe9b0de0e9f331656)",
  "rcgen",
  "schemars",
  "serde",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -515,10 +515,10 @@ prettyplease = { version = "0.2.22", features = ["verbatim"] }
 proc-macro2 = "1.0"
 progenitor = "0.8.0"
 progenitor-client = "0.8.0"
-bhyve_api = { git = "https://github.com/oxidecomputer/propolis", rev = "e0c83fd0e0760eec1af306286c50081689d11a51" }
-propolis_api_types = { git = "https://github.com/oxidecomputer/propolis", rev = "e0c83fd0e0760eec1af306286c50081689d11a51" }
-propolis-client = { git = "https://github.com/oxidecomputer/propolis", rev = "e0c83fd0e0760eec1af306286c50081689d11a51" }
-propolis-mock-server = { git = "https://github.com/oxidecomputer/propolis", rev = "e0c83fd0e0760eec1af306286c50081689d11a51" }
+bhyve_api = { git = "https://github.com/oxidecomputer/propolis", rev = "86101eaf80b55e7f405b5cafe9b0de0e9f331656" }
+propolis_api_types = { git = "https://github.com/oxidecomputer/propolis", rev = "86101eaf80b55e7f405b5cafe9b0de0e9f331656" }
+propolis-client = { git = "https://github.com/oxidecomputer/propolis", rev = "86101eaf80b55e7f405b5cafe9b0de0e9f331656" }
+propolis-mock-server = { git = "https://github.com/oxidecomputer/propolis", rev = "86101eaf80b55e7f405b5cafe9b0de0e9f331656" }
 proptest = "1.5.0"
 qorb = "0.1.2"
 quote = "1.0"

--- a/package-manifest.toml
+++ b/package-manifest.toml
@@ -621,10 +621,10 @@ service_name = "propolis-server"
 only_for_targets.image = "standard"
 source.type = "prebuilt"
 source.repo = "propolis"
-source.commit = "e0c83fd0e0760eec1af306286c50081689d11a51"
+source.commit = "86101eaf80b55e7f405b5cafe9b0de0e9f331656"
 # The SHA256 digest is automatically posted to:
 # https://buildomat.eng.oxide.computer/public/file/oxidecomputer/propolis/image/<commit>/propolis-server.sha256.txt
-source.sha256 = "05e3b3497d340f6a6a1eda6aebdca81979c1b2e0b99411b9a20af9e35bdf07de"
+source.sha256 = "8dd411d6f2db23f93c2340cce11aa194da8dcb8cfd20081a614a5722ffbfe255"
 output.type = "zone"
 
 [package.mg-ddm-gz]

--- a/sled-agent/src/common/disk.rs
+++ b/sled-agent/src/common/disk.rs
@@ -8,7 +8,6 @@ use chrono::Utc;
 use omicron_common::api::external::DiskState;
 use omicron_common::api::external::Error;
 use omicron_common::api::internal::nexus::DiskRuntimeState;
-use propolis_client::types::DiskAttachmentState as PropolisDiskState;
 use sled_agent_types::disk::DiskStateRequested;
 use uuid::Uuid;
 
@@ -47,15 +46,9 @@ impl DiskStates {
     /// Propolis.
     pub fn observe_transition(
         &mut self,
-        observed: &PropolisDiskState,
+        observed: &DiskState,
     ) -> Option<Action> {
-        let next = match observed {
-            PropolisDiskState::Attached(uuid) => DiskState::Attached(*uuid),
-            PropolisDiskState::Detached => DiskState::Detached,
-            PropolisDiskState::Destroyed => DiskState::Destroyed,
-            PropolisDiskState::Faulted => DiskState::Faulted,
-        };
-        self.transition(next, None);
+        self.transition(observed.clone(), None);
         None
     }
 

--- a/sled-agent/src/instance.rs
+++ b/sled-agent/src/instance.rs
@@ -418,6 +418,8 @@ struct InstanceRunner {
 
     // Properties visible to Propolis
     properties: propolis_client::types::InstanceProperties,
+    vcpus: u8,
+    memory_mib: u64,
 
     // The ID of the Propolis server (and zone) running this instance
     propolis_id: PropolisUuid,
@@ -911,6 +913,8 @@ impl InstanceRunner {
 
         let request = propolis_client::types::InstanceEnsureRequest {
             properties: self.properties.clone(),
+            vcpus: self.vcpus,
+            memory: self.memory_mib,
             nics,
             disks: self
                 .requested_disks
@@ -1366,15 +1370,13 @@ impl Instance {
                 id: id.into_untyped_uuid(),
                 name: hardware.properties.hostname.to_string(),
                 description: "Test description".to_string(),
-                image_id: Uuid::nil(),
-                bootrom_id: Uuid::nil(),
-                // TODO: Align the byte type w/propolis.
-                memory: hardware.properties.memory.to_whole_mebibytes(),
-                // TODO: we should probably make propolis aligned with
-                // InstanceCpuCount here, to avoid any casting...
-                vcpus: hardware.properties.ncpus.0 as u8,
                 metadata,
             },
+            // TODO: we should probably make propolis aligned with
+            // InstanceCpuCount here, to avoid any casting...
+            vcpus: hardware.properties.ncpus.0 as u8,
+            // TODO: Align the byte type w/propolis.
+            memory_mib: hardware.properties.memory.to_whole_mebibytes(),
             propolis_id,
             propolis_addr,
             vnic_allocator,

--- a/sled-agent/src/sim/disk.rs
+++ b/sled-agent/src/sim/disk.rs
@@ -18,7 +18,6 @@ use omicron_common::api::internal::nexus::ProducerEndpoint;
 use omicron_common::api::internal::nexus::ProducerKind;
 use oximeter_producer::LogConfig;
 use oximeter_producer::Server as ProducerServer;
-use propolis_client::types::DiskAttachmentState as PropolisDiskState;
 use sled_agent_types::disk::DiskStateRequested;
 use std::net::{Ipv6Addr, SocketAddr};
 use std::sync::Arc;
@@ -222,18 +221,13 @@ impl Simulatable for SimDisk {
 
     fn execute_desired_transition(&mut self) -> Option<DiskAction> {
         if let Some(desired) = self.state.desired() {
-            // These operations would typically be triggered via responses from
-            // Propolis, but for a simulated sled agent, this does not exist.
-            //
-            // Instead, we make transitions to new states based entirely on the
-            // value of "desired".
             let observed = match desired {
                 DiskStateRequested::Attached(uuid) => {
-                    PropolisDiskState::Attached(*uuid)
+                    DiskState::Attached(*uuid)
                 }
-                DiskStateRequested::Detached => PropolisDiskState::Detached,
-                DiskStateRequested::Destroyed => PropolisDiskState::Destroyed,
-                DiskStateRequested::Faulted => PropolisDiskState::Faulted,
+                DiskStateRequested::Detached => DiskState::Detached,
+                DiskStateRequested::Destroyed => DiskState::Destroyed,
+                DiskStateRequested::Faulted => DiskState::Faulted,
             };
             self.state.observe_transition(&observed)
         } else {

--- a/sled-agent/src/sim/sled_agent.rs
+++ b/sled-agent/src/sim/sled_agent.rs
@@ -338,14 +338,12 @@ impl SledAgent {
                     id: propolis_id.into_untyped_uuid(),
                     name: hardware.properties.hostname.to_string(),
                     description: "sled-agent-sim created instance".to_string(),
-                    image_id: Uuid::default(),
-                    bootrom_id: Uuid::default(),
-                    memory: hardware.properties.memory.to_whole_mebibytes(),
-                    vcpus: hardware.properties.ncpus.0 as u8,
                     metadata,
                 };
                 let body = propolis_client::types::InstanceEnsureRequest {
                     properties,
+                    memory: hardware.properties.memory.to_whole_mebibytes(),
+                    vcpus: hardware.properties.ncpus.0 as u8,
                     nics: vec![],
                     disks: vec![],
                     boot_settings: None,


### PR DESCRIPTION
Pick up Propolis commit 86101eaf80b55e7f405b5cafe9b0de0e9f331656, which contains oxidecomputer/propolis#803 (and nothing else, since we just picked up its parent commit!).

Tests: cargo nextest; booted a few VMs in a dev cluster.