### PR TITLE
Clean up usage of `usdt::register_probes()`

### DIFF
--- a/nexus/db-queries/src/db/datastore/deployment/external_networking.rs
+++ b/nexus/db-queries/src/db/datastore/deployment/external_networking.rs
@@ -869,8 +869,7 @@ mod tests {
     #[tokio::test]
     async fn test_allocate_external_networking() {
         // Set up.
-        usdt::register_probes().unwrap();
-        let logctx = dev::test_setup_log("test_service_ip_list");
+        let logctx = dev::test_setup_log("test_allocate_external_networking");
         let db = TestDatabase::new_with_datastore(&logctx.log).await;
         let (opctx, datastore) = (db.opctx(), db.datastore());
 
@@ -1130,8 +1129,7 @@ mod tests {
     #[tokio::test]
     async fn test_deallocate_external_networking() {
         // Set up.
-        usdt::register_probes().unwrap();
-        let logctx = dev::test_setup_log("test_service_ip_list");
+        let logctx = dev::test_setup_log("test_deallocate_external_networking");
         let db = TestDatabase::new_with_datastore(&logctx.log).await;
         let (opctx, datastore) = (db.opctx(), db.datastore());
 

--- a/nexus/db-queries/src/db/datastore/external_ip.rs
+++ b/nexus/db-queries/src/db/datastore/external_ip.rs
@@ -1161,7 +1161,6 @@ mod tests {
 
     #[tokio::test]
     async fn test_service_ip_list() {
-        usdt::register_probes().unwrap();
         let logctx = dev::test_setup_log("test_service_ip_list");
         let db = TestDatabase::new_with_datastore(&logctx.log).await;
         let (opctx, datastore) = (db.opctx(), db.datastore());

--- a/nexus/db-queries/src/db/datastore/network_interface.rs
+++ b/nexus/db-queries/src/db/datastore/network_interface.rs
@@ -920,7 +920,6 @@ mod tests {
 
     #[tokio::test]
     async fn test_service_network_interfaces_list() {
-        usdt::register_probes().unwrap();
         let logctx =
             dev::test_setup_log("test_service_network_interfaces_list");
         let db = TestDatabase::new_with_datastore(&logctx.log).await;

--- a/nexus/db-queries/src/db/datastore/vpc.rs
+++ b/nexus/db-queries/src/db/datastore/vpc.rs
@@ -2792,7 +2792,6 @@ mod tests {
     // `project_create_vpc_raw` call.
     #[tokio::test]
     async fn test_project_create_vpc_raw_returns_none_on_vni_exhaustion() {
-        usdt::register_probes().unwrap();
         let logctx = dev::test_setup_log(
             "test_project_create_vpc_raw_returns_none_on_vni_exhaustion",
         );
@@ -2898,7 +2897,6 @@ mod tests {
     // and then check that we correctly retry
     #[tokio::test]
     async fn test_project_create_vpc_retries() {
-        usdt::register_probes().unwrap();
         let logctx = dev::test_setup_log("test_project_create_vpc_retries");
         let log = &logctx.log;
         let db = TestDatabase::new_with_datastore(log).await;
@@ -3042,7 +3040,6 @@ mod tests {
     #[tokio::test]
     async fn test_vpc_resolve_to_sleds_uses_current_target_blueprint() {
         // Test setup.
-        usdt::register_probes().unwrap();
         let logctx = dev::test_setup_log(
             "test_vpc_resolve_to_sleds_uses_current_target_blueprint",
         );
@@ -3404,7 +3401,6 @@ mod tests {
     // and that these resolve to the v4/6 subnets of each.
     #[tokio::test]
     async fn test_vpc_system_router_sync_to_subnets() {
-        usdt::register_probes().unwrap();
         let logctx =
             dev::test_setup_log("test_vpc_system_router_sync_to_subnets");
         let log = &logctx.log;
@@ -3631,7 +3627,6 @@ mod tests {
     // of an instance NIC.
     #[tokio::test]
     async fn test_vpc_router_rule_instance_resolve() {
-        usdt::register_probes().unwrap();
         let logctx =
             dev::test_setup_log("test_vpc_router_rule_instance_resolve");
         let log = &logctx.log;

--- a/nexus/db-queries/src/db/pool.rs
+++ b/nexus/db-queries/src/db/pool.rs
@@ -84,9 +84,6 @@ impl Pool {
     /// Creating this pool does not necessarily wait for connections to become
     /// available, as backends may shift over time.
     pub fn new(log: &Logger, resolver: &QorbResolver) -> Self {
-        // Make sure diesel-dtrace's USDT probes are enabled.
-        usdt::register_probes().expect("Failed to register USDT DTrace probes");
-
         let resolver = resolver.for_service(ServiceName::Cockroach);
         let connector = make_postgres_connector(log);
         let policy = Policy::default();
@@ -111,9 +108,6 @@ impl Pool {
     ///
     /// In production, [Self::new] should be preferred.
     pub fn new_single_host(log: &Logger, db_config: &DbConfig) -> Self {
-        // Make sure diesel-dtrace's USDT probes are enabled.
-        usdt::register_probes().expect("Failed to register USDT DTrace probes");
-
         let resolver = make_single_host_resolver(db_config);
         let connector = make_postgres_connector(log);
         let policy = Policy::default();
@@ -141,9 +135,6 @@ impl Pool {
         log: &Logger,
         db_config: &DbConfig,
     ) -> Self {
-        // Make sure diesel-dtrace's USDT probes are enabled.
-        usdt::register_probes().expect("Failed to register USDT DTrace probes");
-
         let resolver = make_single_host_resolver(db_config);
         let connector = make_postgres_connector(log);
         let policy = Policy {

--- a/oximeter/db/src/bin/oxdb/main.rs
+++ b/oximeter/db/src/bin/oxdb/main.rs
@@ -311,8 +311,6 @@ async fn query(
 
 #[tokio::main]
 async fn main() -> anyhow::Result<()> {
-    usdt::register_probes().context("Failed to register USDT probes")?;
-
     let args = OxDb::parse();
     let decorator = slog_term::TermDecorator::new().build();
     let drain = slog_term::FullFormat::new(decorator)

--- a/oximeter/db/src/client/mod.rs
+++ b/oximeter/db/src/client/mod.rs
@@ -3746,7 +3746,6 @@ mod tests {
         _: &ClickHouseDeployment,
         client: Client,
     ) {
-        usdt::register_probes().unwrap();
         let samples = [oximeter_test_utils::make_sample()];
         client.insert_samples(&samples).await.unwrap();
 
@@ -3806,7 +3805,6 @@ mod tests {
         client: Client,
     ) {
         use strum::IntoEnumIterator;
-        usdt::register_probes().unwrap();
         // Attempt to select all schema with each datum type.
         for ty in oximeter::DatumType::iter() {
             let sql = format!(
@@ -3847,7 +3845,6 @@ mod tests {
         db: &ClickHouseDeployment,
         client: Client,
     ) {
-        usdt::register_probes().unwrap();
         let samples = [oximeter_test_utils::make_sample()];
 
         // We're using the components of the `insert_samples()` method here,
@@ -4453,7 +4450,6 @@ mod tests {
     #[tokio::test]
     async fn test_select_all_field_types() {
         use strum::IntoEnumIterator;
-        usdt::register_probes().unwrap();
         let logctx = test_setup_log("test_select_all_field_types");
         let log = &logctx.log;
 
@@ -4872,7 +4868,6 @@ mod tests {
         native_address: SocketAddr,
         replicated: bool,
     ) {
-        usdt::register_probes().unwrap();
         let client = Client::new(http_address, native_address, &log);
 
         const STARTING_VERSION: u64 = 1;

--- a/oximeter/db/src/client/oxql.rs
+++ b/oximeter/db/src/client/oxql.rs
@@ -1385,7 +1385,6 @@ mod tests {
     // fetching different sets of fields at different times.
     #[tokio::test]
     async fn test_get_entire_timeseries_and_part_of_another() {
-        usdt::register_probes().unwrap();
         let ctx =
             setup_oxql_test("test_get_entire_timeseries_and_part_of_another")
                 .await;

--- a/oximeter/db/src/shells/native.rs
+++ b/oximeter/db/src/shells/native.rs
@@ -16,7 +16,6 @@ use tabled::{builder::Builder, settings::Style};
 
 /// Run the native SQL shell.
 pub async fn shell(addr: IpAddr, port: u16) -> anyhow::Result<()> {
-    usdt::register_probes()?;
     let addr = SocketAddr::new(addr, port);
     let mut conn = native::Connection::new(addr)
         .await

--- a/oximeter/db/tests/integration_test.rs
+++ b/oximeter/db/tests/integration_test.rs
@@ -123,7 +123,7 @@ async fn test_schemas_disjoint() -> anyhow::Result<()> {
 /// doesn't make much sense in an integration test.
 #[tokio::test]
 async fn test_cluster() -> anyhow::Result<()> {
-    usdt::register_probes().unwrap();
+    usdt::register_probes().expect("Failed to register USDT probes");
     let request_timeout = Duration::from_secs(15);
     let start = tokio::time::Instant::now();
     let logctx = test_setup_log("test_cluster");


### PR DESCRIPTION
- Removes lots of now-superfluous calls, since `qorb` does this internally.
- Closes #6971