### PR TITLE
Delay starting zone-network-service until in.ndpd is online

### DIFF
--- a/smf/zone-network-setup/manifest.xml
+++ b/smf/zone-network-setup/manifest.xml
@@ -12,6 +12,12 @@
   <service_fmri value='svc:/milestone/network:default' />
   </dependency>
 
+  <!-- Run after the NDP daemon is online.. -->
+  <dependency name='ndp' grouping='require_all' restart_on='none'
+    type='service'>
+  <service_fmri value='svc:/network/routing/ndp:default' />
+  </dependency>
+
   <!-- The zone-setup binary is not ready to run until its initial properties
           have been set by the sled-agent, which happens after the
           `manifest-import` service is running.


### PR DESCRIPTION
There is a race condition between being able to configure an
addrconf address on an interface, and the NDP daemon starting up.
If they start in parallel, there is a chance that configuring
network interfaces will fail resulting in a broken zone. There
is a fix to implement better handling of the conflict in stlouis
but we should also just wait for the NDP service to come up before
attempting to configure interfaces.

Fixes #6947 (along with [stlouis#650](https://github.com/oxidecomputer/stlouis/issues/650))
