### PR TITLE
[clickhouse] Retrieve distributed ddl queue info

### DIFF
--- a/clickhouse-admin/api/src/lib.rs
+++ b/clickhouse-admin/api/src/lib.rs
@@ -3,8 +3,8 @@
 // file, You can obtain one at https://mozilla.org/MPL/2.0/.
 
 use clickhouse_admin_types::{
-    ClickhouseKeeperClusterMembership, KeeperConf, KeeperConfig,
-    KeeperConfigurableSettings, Lgif, RaftConfig, ReplicaConfig,
+    ClickhouseKeeperClusterMembership, DistributedDdlQueue, KeeperConf,
+    KeeperConfig, KeeperConfigurableSettings, Lgif, RaftConfig, ReplicaConfig,
     ServerConfigurableSettings,
 };
 use dropshot::{
@@ -105,4 +105,14 @@ pub trait ClickhouseAdminServerApi {
         rqctx: RequestContext<Self::Context>,
         body: TypedBody<ServerConfigurableSettings>,
     ) -> Result<HttpResponseCreated<ReplicaConfig>, HttpError>;
+
+    /// Contains information about distributed ddl queries (ON CLUSTER clause)
+    /// that were executed on a cluster.
+    #[endpoint {
+        method = GET,
+        path = "/distributed-ddl-queue",
+    }]
+    async fn distributed_ddl_queue(
+        rqctx: RequestContext<Self::Context>,
+    ) -> Result<HttpResponseOk<DistributedDdlQueue>, HttpError>;
 }

--- a/clickhouse-admin/api/src/lib.rs
+++ b/clickhouse-admin/api/src/lib.rs
@@ -114,5 +114,5 @@ pub trait ClickhouseAdminServerApi {
     }]
     async fn distributed_ddl_queue(
         rqctx: RequestContext<Self::Context>,
-    ) -> Result<HttpResponseOk<DistributedDdlQueue>, HttpError>;
+    ) -> Result<HttpResponseOk<Vec<DistributedDdlQueue>>, HttpError>;
 }

--- a/clickhouse-admin/src/clickhouse_cli.rs
+++ b/clickhouse-admin/src/clickhouse_cli.rs
@@ -147,7 +147,8 @@ impl ClickhouseCli {
         self.client_non_interactive(
             ClickhouseClientType::Server,
             format!(
-                "SELECT * FROM system.distributed_ddl_queue WHERE cluster = '{}' FORMAT JSONEachRow", OXIMETER_CLUSTER
+                "SELECT * FROM system.distributed_ddl_queue WHERE cluster = '{}' FORMAT JSONEachRow",
+                OXIMETER_CLUSTER
             ).as_str(),
             "Retrieve information about distributed ddl queries (ON CLUSTER clause) 
             that were executed on a cluster",

--- a/clickhouse-admin/src/clickhouse_cli.rs
+++ b/clickhouse-admin/src/clickhouse_cli.rs
@@ -143,11 +143,11 @@ impl ClickhouseCli {
 
     pub async fn distributed_ddl_queue(
         &self,
-    ) -> Result<DistributedDdlQueue, ClickhouseCliError> {
+    ) -> Result<Vec<DistributedDdlQueue>, ClickhouseCliError> {
         self.client_non_interactive(
             ClickhouseClientType::Server,
             format!(
-                "SELECT * FROM system.distributed_ddl_queue WHERE cluster = '{}' FORMAT JSON", OXIMETER_CLUSTER
+                "SELECT * FROM system.distributed_ddl_queue WHERE cluster = '{}' FORMAT JSONEachRow", OXIMETER_CLUSTER
             ).as_str(),
             "Retrieve information about distributed ddl queries (ON CLUSTER clause) 
             that were executed on a cluster",

--- a/clickhouse-admin/src/http_entrypoints.rs
+++ b/clickhouse-admin/src/http_entrypoints.rs
@@ -5,8 +5,8 @@
 use crate::context::ServerContext;
 use clickhouse_admin_api::*;
 use clickhouse_admin_types::{
-    ClickhouseKeeperClusterMembership, KeeperConf, KeeperConfig,
-    KeeperConfigurableSettings, Lgif, RaftConfig, ReplicaConfig,
+    ClickhouseKeeperClusterMembership, DistributedDdlQueue, KeeperConf,
+    KeeperConfig, KeeperConfigurableSettings, Lgif, RaftConfig, ReplicaConfig,
     ServerConfigurableSettings,
 };
 use dropshot::{
@@ -46,6 +46,14 @@ impl ClickhouseAdminServerApi for ClickhouseAdminServerImpl {
         Svcadm::enable_service(fmri)?;
 
         Ok(HttpResponseCreated(output))
+    }
+
+    async fn distributed_ddl_queue(
+        rqctx: RequestContext<Self::Context>,
+    ) -> Result<HttpResponseOk<DistributedDdlQueue>, HttpError> {
+        let ctx = rqctx.context();
+        let output = ctx.clickhouse_cli().distributed_ddl_queue().await?;
+        Ok(HttpResponseOk(output))
     }
 }
 

--- a/clickhouse-admin/src/http_entrypoints.rs
+++ b/clickhouse-admin/src/http_entrypoints.rs
@@ -50,7 +50,7 @@ impl ClickhouseAdminServerApi for ClickhouseAdminServerImpl {
 
     async fn distributed_ddl_queue(
         rqctx: RequestContext<Self::Context>,
-    ) -> Result<HttpResponseOk<DistributedDdlQueue>, HttpError> {
+    ) -> Result<HttpResponseOk<Vec<DistributedDdlQueue>>, HttpError> {
         let ctx = rqctx.context();
         let output = ctx.clickhouse_cli().distributed_ddl_queue().await?;
         Ok(HttpResponseOk(output))

--- a/clickhouse-admin/types/src/lib.rs
+++ b/clickhouse-admin/types/src/lib.rs
@@ -965,6 +965,28 @@ pub struct ClickhouseKeeperClusterMembership {
     pub raft_config: BTreeSet<KeeperId>,
 }
 
+#[derive(
+    Clone,
+    Debug,
+    PartialEq,
+    Eq,
+    PartialOrd,
+    Ord,
+    Deserialize,
+    Serialize,
+    JsonSchema,
+)]
+#[serde(rename_all = "snake_case")]
+pub struct DistributedDdlQueue {
+    pub data: String,
+}
+
+impl DistributedDdlQueue {
+    pub fn parse(_log: &Logger, _data: &[u8]) -> Result<Self> {
+        Ok(Self { data: "dummy data".to_string() })
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use camino::Utf8PathBuf;

--- a/clickhouse-admin/types/src/lib.rs
+++ b/clickhouse-admin/types/src/lib.rs
@@ -977,21 +977,36 @@ pub struct ClickhouseKeeperClusterMembership {
     JsonSchema,
 )]
 #[serde(rename_all = "snake_case")]
+/// Contains information about distributed ddl queries (ON CLUSTER clause) that were
+/// executed on a cluster.
 pub struct DistributedDdlQueue {
+    /// Query id
     entry: String,
+    /// Version of the entry
     entry_version: u64,
+    /// Host that initiated the DDL operation
     initiator_host: String,
+    /// Port used by the initiator
     initiator_port: u16,
+    /// Cluster name
     cluster: String,
+    /// Query executed
     query: String,
+    /// Settings used in the DDL operation
     settings: BTreeMap<String,String>,
-    // TODO: Find a way to parse time better if possible
+    /// Query created time
     query_create_time: String,
+    /// Hostname
     host: Ipv6Addr,
+    /// Host Port
     port: u16,
+    /// Status of the query
     exception_code: u64,
+    /// Exception code
     exception_text: String,
+    /// Exception message
     query_finish_time: String,
+    /// Duration of query execution (in milliseconds)
     query_duration_ms: String,
 }
 
@@ -1021,13 +1036,12 @@ mod tests {
     use camino_tempfile::Builder;
     use slog::{o, Drain};
     use slog_term::{FullFormat, PlainDecorator, TestStdoutWriter};
+    use std::collections::BTreeMap;
     use std::net::{Ipv4Addr, Ipv6Addr};
     use std::str::FromStr;
 
     use crate::{
-        ClickhouseHost, KeeperConf, KeeperId, KeeperServerInfo,
-        KeeperServerType, KeeperSettings, Lgif, LogLevel, RaftConfig,
-        RaftServerSettings, ServerId, ServerSettings,
+        ClickhouseHost, DistributedDdlQueue, KeeperConf, KeeperId, KeeperServerInfo, KeeperServerType, KeeperSettings, Lgif, LogLevel, RaftConfig, RaftServerSettings, ServerId, ServerSettings
     };
 
     fn log() -> slog::Logger {
@@ -1785,5 +1799,57 @@ snapshot_storage_disk=LocalSnapshotDisk
             format!("{}", root_cause),
             "Extracted key `\"session_timeout_fake\"` from output differs from expected key `session_timeout_ms`"
         );
+    }
+
+    #[test]
+    fn test_distributed_ddl_queries_parse_success() {
+        let log = log();
+        let data =
+            "{\"entry\":\"query-0000000000\",\"entry_version\":5,\"initiator_host\":\"ixchel\",\"initiator_port\":22001,\"cluster\":\"oximeter_cluster\",\"query\":\"CREATE DATABASE IF NOT EXISTS db1 UUID 'a49757e4-179e-42bd-866f-93ac43136e2d' ON CLUSTER oximeter_cluster\",\"settings\":{\"load_balancing\":\"random\"},\"query_create_time\":\"2024-11-01 16:16:45\",\"host\":\"::1\",\"port\":22001,\"status\":\"Finished\",\"exception_code\":0,\"exception_text\":\"\",\"query_finish_time\":\"2024-11-01 16:16:45\",\"query_duration_ms\":\"4\"}
+{\"entry\":\"query-0000000000\",\"entry_version\":5,\"initiator_host\":\"ixchel\",\"initiator_port\":22001,\"cluster\":\"oximeter_cluster\",\"query\":\"CREATE DATABASE IF NOT EXISTS db1 UUID 'a49757e4-179e-42bd-866f-93ac43136e2d' ON CLUSTER oximeter_cluster\",\"settings\":{\"load_balancing\":\"random\"},\"query_create_time\":\"2024-11-01 16:16:45\",\"host\":\"::1\",\"port\":22002,\"status\":\"Finished\",\"exception_code\":0,\"exception_text\":\"\",\"query_finish_time\":\"2024-11-01 16:16:45\",\"query_duration_ms\":\"4\"}
+"
+            .as_bytes();
+        let ddl = DistributedDdlQueue::parse(&log, data).unwrap();
+
+        let expected_result = vec![
+            DistributedDdlQueue{
+                entry: "query-0000000000".to_string(),
+                entry_version: 5,
+                initiator_host: "ixchel".to_string(),
+                initiator_port: 22001,
+                cluster: "oximeter_cluster".to_string(),
+                query: "CREATE DATABASE IF NOT EXISTS db1 UUID 'a49757e4-179e-42bd-866f-93ac43136e2d' ON CLUSTER oximeter_cluster".to_string(),
+                settings: BTreeMap::from([
+    ("load_balancing".to_string(), "random".to_string()),
+]),
+                query_create_time: "2024-11-01 16:16:45".to_string(),
+                host: Ipv6Addr::from_str("::1").unwrap(),
+                port: 22001,
+                // TODO: Missing status
+                exception_code: 0,
+                exception_text: "".to_string(),
+                query_finish_time: "2024-11-01 16:16:45".to_string(),
+                query_duration_ms: "4".to_string(),
+            },
+            DistributedDdlQueue{
+                entry: "query-0000000000".to_string(),
+                entry_version: 5,
+                initiator_host: "ixchel".to_string(),
+                initiator_port: 22001,
+                cluster: "oximeter_cluster".to_string(),
+                query: "CREATE DATABASE IF NOT EXISTS db1 UUID 'a49757e4-179e-42bd-866f-93ac43136e2d' ON CLUSTER oximeter_cluster".to_string(),
+                settings: BTreeMap::from([
+    ("load_balancing".to_string(), "random".to_string()),
+]),
+                query_create_time: "2024-11-01 16:16:45".to_string(),
+                host: Ipv6Addr::from_str("::1").unwrap(),
+                port: 22002,
+                exception_code: 0,
+                exception_text: "".to_string(),
+                query_finish_time: "2024-11-01 16:16:45".to_string(),
+                query_duration_ms: "4".to_string(),
+            },
+            ];
+        assert!(ddl == expected_result);
     }
 }

--- a/clients/clickhouse-admin-server-client/src/lib.rs
+++ b/clients/clickhouse-admin-server-client/src/lib.rs
@@ -4,6 +4,7 @@
 
 //! Interface for making API requests to a clickhouse-admin-server server
 //! running in an omicron zone.
+use std::clone::Clone;
 
 progenitor::generate_api!(
     spec = "../../openapi/clickhouse-admin-server.json",

--- a/openapi/clickhouse-admin-server.json
+++ b/openapi/clickhouse-admin-server.json
@@ -44,6 +44,31 @@
           }
         }
       }
+    },
+    "/distributed-ddl-queue": {
+      "get": {
+        "summary": "Contains information about distributed ddl queries (ON CLUSTER clause)",
+        "description": "that were executed on a cluster.",
+        "operationId": "distributed_ddl_queue",
+        "responses": {
+          "200": {
+            "description": "successful operation",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/DistributedDdlQueue"
+                }
+              }
+            }
+          },
+          "4XX": {
+            "$ref": "#/components/responses/Error"
+          },
+          "5XX": {
+            "$ref": "#/components/responses/Error"
+          }
+        }
+      }
     }
   },
   "components": {
@@ -88,6 +113,17 @@
             ],
             "additionalProperties": false
           }
+        ]
+      },
+      "DistributedDdlQueue": {
+        "type": "object",
+        "properties": {
+          "data": {
+            "type": "string"
+          }
+        },
+        "required": [
+          "data"
         ]
       },
       "Error": {

--- a/openapi/clickhouse-admin-server.json
+++ b/openapi/clickhouse-admin-server.json
@@ -56,7 +56,11 @@
             "content": {
               "application/json": {
                 "schema": {
-                  "$ref": "#/components/schemas/DistributedDdlQueue"
+                  "title": "Array_of_DistributedDdlQueue",
+                  "type": "array",
+                  "items": {
+                    "$ref": "#/components/schemas/DistributedDdlQueue"
+                  }
                 }
               }
             }
@@ -118,12 +122,76 @@
       "DistributedDdlQueue": {
         "type": "object",
         "properties": {
-          "data": {
+          "cluster": {
             "type": "string"
+          },
+          "entry": {
+            "type": "string"
+          },
+          "entry_version": {
+            "type": "integer",
+            "format": "uint64",
+            "minimum": 0
+          },
+          "exception_code": {
+            "type": "integer",
+            "format": "uint64",
+            "minimum": 0
+          },
+          "exception_text": {
+            "type": "string"
+          },
+          "host": {
+            "type": "string",
+            "format": "ipv6"
+          },
+          "initiator_host": {
+            "type": "string"
+          },
+          "initiator_port": {
+            "type": "integer",
+            "format": "uint16",
+            "minimum": 0
+          },
+          "port": {
+            "type": "integer",
+            "format": "uint16",
+            "minimum": 0
+          },
+          "query": {
+            "type": "string"
+          },
+          "query_create_time": {
+            "type": "string"
+          },
+          "query_duration_ms": {
+            "type": "string"
+          },
+          "query_finish_time": {
+            "type": "string"
+          },
+          "settings": {
+            "type": "object",
+            "additionalProperties": {
+              "type": "string"
+            }
           }
         },
         "required": [
-          "data"
+          "cluster",
+          "entry",
+          "entry_version",
+          "exception_code",
+          "exception_text",
+          "host",
+          "initiator_host",
+          "initiator_port",
+          "port",
+          "query",
+          "query_create_time",
+          "query_duration_ms",
+          "query_finish_time",
+          "settings"
         ]
       },
       "Error": {

--- a/openapi/clickhouse-admin-server.json
+++ b/openapi/clickhouse-admin-server.json
@@ -120,61 +120,80 @@
         ]
       },
       "DistributedDdlQueue": {
+        "description": "Contains information about distributed ddl queries (ON CLUSTER clause) that were executed on a cluster.",
         "type": "object",
         "properties": {
           "cluster": {
+            "description": "Cluster name",
             "type": "string"
           },
           "entry": {
+            "description": "Query id",
             "type": "string"
           },
           "entry_version": {
+            "description": "Version of the entry",
             "type": "integer",
             "format": "uint64",
             "minimum": 0
           },
           "exception_code": {
+            "description": "Exception code",
             "type": "integer",
             "format": "uint64",
             "minimum": 0
           },
           "exception_text": {
+            "description": "Exception message",
             "type": "string"
           },
           "host": {
+            "description": "Hostname",
             "type": "string",
             "format": "ipv6"
           },
           "initiator_host": {
+            "description": "Host that initiated the DDL operation",
             "type": "string"
           },
           "initiator_port": {
+            "description": "Port used by the initiator",
             "type": "integer",
             "format": "uint16",
             "minimum": 0
           },
           "port": {
+            "description": "Host Port",
             "type": "integer",
             "format": "uint16",
             "minimum": 0
           },
           "query": {
+            "description": "Query executed",
             "type": "string"
           },
           "query_create_time": {
+            "description": "Query created time",
             "type": "string"
           },
           "query_duration_ms": {
+            "description": "Duration of query execution (in milliseconds)",
             "type": "string"
           },
           "query_finish_time": {
+            "description": "Query finish time",
             "type": "string"
           },
           "settings": {
+            "description": "Settings used in the DDL operation",
             "type": "object",
             "additionalProperties": {
               "type": "string"
             }
+          },
+          "status": {
+            "description": "Status of the query",
+            "type": "string"
           }
         },
         "required": [
@@ -191,7 +210,8 @@
           "query_create_time",
           "query_duration_ms",
           "query_finish_time",
-          "settings"
+          "settings",
+          "status"
         ]
       },
       "Error": {


### PR DESCRIPTION
## Overview

This commit implements a new clickhouse-admin endpoint to retrieve and parse information from `[system.distributed_ddl_queue](https://clickhouse.com/docs/en/operations/system-tables/distributed_ddl_queue)`.

## Purpose

As part of [stage 1](https://rfd.shared.oxide.computer/rfd/0468) of rolling out replicated ClickHouse, we'll be needing to monitor the installed but not visible replicated cluster on our dogfood rack. This endpoint will aid in said monitoring by providing information about distributed ddl queries.

## Testing

```console
$ cargo run --bin=clickhouse-admin-server -- run -c ./smf/clickhouse-admin-server/config.toml -a [::1]:8888 -l [::1]:22001 -b /Users/karcar/src/omicron/out/clickhouse/clickhouse
   Compiling omicron-clickhouse-admin v0.1.0 (/Users/karcar/src/omicron/clickhouse-admin)
    Finished `dev` profile [unoptimized + debuginfo] target(s) in 3.79s
     Running `target/debug/clickhouse-admin-server run -c ./smf/clickhouse-admin-server/config.toml -a '[::1]:8888' -l '[::1]:22001' -b /Users/karcar/src/omicron/out/clickhouse/clickhouse`
note: configured to log to "/dev/stdout"
{"msg":"listening","v":0,"name":"clickhouse-admin-server","level":30,"time":"2024-11-04T07:29:41.746887Z","hostname":"ixchel","pid":55286,"local_addr":"[::1]:8888","component":"dropshot","file":"/Users/karcar/.cargo/registry/src/index.crates.io-6f17d22bba15001f/dropshot-0.12.0/src/server.rs:197"}
{"msg":"accepted connection","v":0,"name":"clickhouse-admin-server","level":30,"time":"2024-11-04T07:29:55.674044Z","hostname":"ixchel","pid":55286,"local_addr":"[::1]:8888","component":"dropshot","file":"/Users/karcar/.cargo/registry/src/index.crates.io-6f17d22bba15001f/dropshot-0.12.0/src/server.rs:1105","remote_addr":"[::1]:59735"}
{"msg":"Retrieved data from `system.distributed_ddl_queue`","v":0,"name":"clickhouse-admin-server","level":30,"time":"2024-11-04T07:29:56.148241Z","hostname":"ixchel","pid":55286,"component":"ClickhouseCli","file":"clickhouse-admin/types/src/lib.rs:1018","output":"\"{\\\"entry\\\":\\\"query-0000000001\\\",\\\"entry_version\\\":5,\\\"initiator_host\\\":\\\"ixchel\\\",\\\"initiator_port\\\":22001,\\\"cluster\\\":\\\"oximeter_cluster\\\",\\\"query\\\":\\\"CREATE DATABASE IF NOT EXISTS db1 UUID '701a3dd3-10f0-4f5d-b5b2-0ad11bcf2b17' ON CLUSTER oximeter_cluster\\\",\\\"settings\\\":{\\\"load_balancing\\\":\\\"random\\\"},\\\"query_create_time\\\":\\\"2024-11-01 16:17:08\\\",\\\"host\\\":\\\"::1\\\",\\\"port\\\":22001,\\\"status\\\":\\\"Finished\\\",\\\"exception_code\\\":0,\\\"exception_text\\\":\\\"\\\",\\\"query_finish_time\\\":\\\"2024-11-01 16:17:08\\\",\\\"query_duration_ms\\\":\\\"3\\\"}\\n{\\\"entry\\\":\\\"query-0000000001\\\",\\\"entry_version\\\":5,\\\"initiator_host\\\":\\\"ixchel\\\",\\\"initiator_port\\\":22001,\\\"cluster\\\":\\\"oximeter_cluster\\\",\\\"query\\\":\\\"CREATE DATABASE IF NOT EXISTS db1 UUID '701a3dd3-10f0-4f5d-b5b2-0ad11bcf2b17' ON CLUSTER oximeter_cluster\\\",\\\"settings\\\":{\\\"load_balancing\\\":\\\"random\\\"},\\\"query_create_time\\\":\\\"2024-11-01 16:17:08\\\",\\\"host\\\":\\\"::1\\\",\\\"port\\\":22002,\\\"status\\\":\\\"Finished\\\",\\\"exception_code\\\":0,\\\"exception_text\\\":\\\"\\\",\\\"query_finish_time\\\":\\\"2024-11-01 16:17:08\\\",\\\"query_duration_ms\\\":\\\"4\\\"}\\n{\\\"entry\\\":\\\"query-0000000000\\\",\\\"entry_version\\\":5,\\\"initiator_host\\\":\\\"ixchel\\\",\\\"initiator_port\\\":22001,\\\"cluster\\\":\\\"oximeter_cluster\\\",\\\"query\\\":\\\"CREATE DATABASE IF NOT EXISTS db1 UUID 'a49757e4-179e-42bd-866f-93ac43136e2d' ON CLUSTER oximeter_cluster\\\",\\\"settings\\\":{\\\"load_balancing\\\":\\\"random\\\",\\\"output_format_json_quote_64bit_integers\\\":\\\"0\\\"},\\\"query_create_time\\\":\\\"2024-11-01 16:16:45\\\",\\\"host\\\":\\\"::1\\\",\\\"port\\\":22002,\\\"status\\\":\\\"Finished\\\",\\\"exception_code\\\":0,\\\"exception_text\\\":\\\"\\\",\\\"query_finish_time\\\":\\\"2024-11-01 16:16:45\\\",\\\"query_duration_ms\\\":\\\"4\\\"}\\n{\\\"entry\\\":\\\"query-0000000000\\\",\\\"entry_version\\\":5,\\\"initiator_host\\\":\\\"ixchel\\\",\\\"initiator_port\\\":22001,\\\"cluster\\\":\\\"oximeter_cluster\\\",\\\"query\\\":\\\"CREATE DATABASE IF NOT EXISTS db1 UUID 'a49757e4-179e-42bd-866f-93ac43136e2d' ON CLUSTER oximeter_cluster\\\",\\\"settings\\\":{\\\"load_balancing\\\":\\\"random\\\",\\\"output_format_json_quote_64bit_integers\\\":\\\"0\\\"},\\\"query_create_time\\\":\\\"2024-11-01 16:16:45\\\",\\\"host\\\":\\\"::1\\\",\\\"port\\\":22001,\\\"status\\\":\\\"Finished\\\",\\\"exception_code\\\":0,\\\"exception_text\\\":\\\"\\\",\\\"query_finish_time\\\":\\\"2024-11-01 16:16:45\\\",\\\"query_duration_ms\\\":\\\"4\\\"}\\n\""}
{"msg":"request completed","v":0,"name":"clickhouse-admin-server","level":30,"time":"2024-11-04T07:29:56.148459Z","hostname":"ixchel","pid":55286,"uri":"/distributed-ddl-queue","method":"GET","req_id":"fb46b182-2573-4daa-a791-118dad20a3c3","remote_addr":"[::1]:59735","local_addr":"[::1]:8888","component":"dropshot","file":"/Users/karcar/.cargo/registry/src/index.crates.io-6f17d22bba15001f/dropshot-0.12.0/src/server.rs:950","latency_us":473916,"response_code":"200"}
```

```console
$ curl http://[::1]:8888/distributed-ddl-queue
[{"entry":"query-0000000001","entry_version":5,"initiator_host":"ixchel","initiator_port":22001,"cluster":"oximeter_cluster","query":"CREATE DATABASE IF NOT EXISTS db1 UUID '701a3dd3-10f0-4f5d-b5b2-0ad11bcf2b17' ON CLUSTER oximeter_cluster","settings":{"load_balancing":"random"},"query_create_time":"2024-11-01 16:17:08","host":"::1","port":22001,"status":"Finished","exception_code":0,"exception_text":"","query_finish_time":"2024-11-01 16:17:08","query_duration_ms":"3"},{"entry":"query-0000000001","entry_version":5,"initiator_host":"ixchel","initiator_port":22001,"cluster":"oximeter_cluster","query":"CREATE DATABASE IF NOT EXISTS db1 UUID '701a3dd3-10f0-4f5d-b5b2-0ad11bcf2b17' ON CLUSTER oximeter_cluster","settings":{"load_balancing":"random"},"query_create_time":"2024-11-01 16:17:08","host":"::1","port":22002,"status":"Finished","exception_code":0,"exception_text":"","query_finish_time":"2024-11-01 16:17:08","query_duration_ms":"4"},{"entry":"query-0000000000","entry_version":5,"initiator_host":"ixchel","initiator_port":22001,"cluster":"oximeter_cluster","query":"CREATE DATABASE IF NOT EXISTS db1 UUID 'a49757e4-179e-42bd-866f-93ac43136e2d' ON CLUSTER oximeter_cluster","settings":{"load_balancing":"random","output_format_json_quote_64bit_integers":"0"},"query_create_time":"2024-11-01 16:16:45","host":"::1","port":22002,"status":"Finished","exception_code":0,"exception_text":"","query_finish_time":"2024-11-01 16:16:45","query_duration_ms":"4"},{"entry":"query-0000000000","entry_version":5,"initiator_host":"ixchel","initiator_port":22001,"cluster":"oximeter_cluster","query":"CREATE DATABASE IF NOT EXISTS db1 UUID 'a49757e4-179e-42bd-866f-93ac43136e2d' ON CLUSTER oximeter_cluster","settings":{"load_balancing":"random","output_format_json_quote_64bit_integers":"0"},"query_create_time":"2024-11-01 16:16:45","host":"::1","port":22001,"status":"Finished","exception_code":0,"exception_text":"","query_finish_time":"2024-11-01 16:16:45","query_duration_ms":"4"}]
```

### Caveat

I have purposely not written an integration test as the port situation is getting out of hand 😅 I'm working on a better implementation of running these integration tests that involves less hardcoded ports. I will include an integration test for this endpoint in that PR

Related: https://github.com/oxidecomputer/omicron/issues/6953
