### PR TITLE
Use local properties when querying oxide values

### DIFF
--- a/sled-agent/src/services.rs
+++ b/sled-agent/src/services.rs
@@ -3619,6 +3619,7 @@ impl ServiceManager {
                 illumos_utils::zfs::Zfs::get_values(
                     &dataset.full_name(),
                     &["zoned", "canmount", "encryption"],
+                    None,
                 )
                 .map_err(|err| Error::GetZfsValue {
                     zone: zone.zone_name(),


### PR DESCRIPTION
We use Oxide-specific ZFS properties to attach additional metadata to datasets, such as UUIDs.

Unfortunately, by default, when we query these properties, the information is inherited.

This means that, for example, if we try to set the "oxide:uuid" property on a transient zone filesystem root, say,

```
oxp_7b24095a-72df-45e3-984f-2b795e052ac7/crypt/zone
```

And we have a dataset within that existing dataset which **does not** have the "oxide:uuid" property set, at, say:

```
oxp_7b24095a-72df-45e3-984f-2b795e052ac7/crypt/zone/oxz_crucible_01f93020-7e7d-4185-93fb-6ca234056c82
```

Then when we query `zfs get oxide:uuid` on each of these datasets, we'll see the UUID of the transient root for **both** datasets.

By using the `-s local` argument to ZFS get, we prevent this from happening - now, these properties will only be accessible for the dataset where they are directly set.