### PR TITLE
Use ClickHouse bools and disable sparse serialization

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -7012,6 +7012,7 @@ dependencies = [
  "reqwest 0.12.8",
  "ring 0.17.8",
  "rustls 0.22.4",
+ "serde",
  "slog",
  "subprocess",
  "tar",

--- a/clickhouse-admin/types/src/config.rs
+++ b/clickhouse-admin/types/src/config.rs
@@ -154,6 +154,11 @@ impl ReplicaConfig {
         <!-- Controls how many tasks could be in the queue -->
         <max_tasks_in_queue>1000</max_tasks_in_queue>
      </distributed_ddl>
+
+     <!-- Disable sparse column serialization, which we expect to not need -->
+     <merge_tree>
+        <ratio_of_defaults_for_sparse_serialization>1.0</ratio_of_defaults_for_sparse_serialization>
+    </merge_tree>
 {macros}
 {remote_servers}
 {keepers}

--- a/oximeter/db/schema/replicated/13/up1.sql
+++ b/oximeter/db/schema/replicated/13/up1.sql
@@ -1,0 +1,4 @@
+ALTER TABLE oximeter.fields_bool_local
+ON CLUSTER oximeter_cluster
+ALTER COLUMN IF EXISTS
+field_value TYPE Bool;

--- a/oximeter/db/schema/replicated/13/up2.sql
+++ b/oximeter/db/schema/replicated/13/up2.sql
@@ -1,0 +1,4 @@
+ALTER TABLE oximeter.measurements_bool_local
+ON CLUSTER oximeter_cluster
+ALTER COLUMN IF EXISTS
+datum TYPE Nullable(Bool);

--- a/oximeter/db/schema/replicated/13/up3.sql
+++ b/oximeter/db/schema/replicated/13/up3.sql
@@ -1,0 +1,4 @@
+ALTER TABLE oximeter.fields_bool
+ON CLUSTER oximeter_cluster
+ALTER COLUMN IF EXISTS
+field_value TYPE Bool;

--- a/oximeter/db/schema/replicated/13/up4.sql
+++ b/oximeter/db/schema/replicated/13/up4.sql
@@ -1,0 +1,4 @@
+ALTER TABLE oximeter.measurements_bool
+ON CLUSTER oximeter_cluster
+ALTER COLUMN IF EXISTS
+datum TYPE Nullable(Bool);

--- a/oximeter/db/schema/replicated/db-init-2.sql
+++ b/oximeter/db/schema/replicated/db-init-2.sql
@@ -35,7 +35,7 @@ CREATE TABLE IF NOT EXISTS oximeter.measurements_bool_local ON CLUSTER oximeter_
     timeseries_name String,
     timeseries_key UInt64,
     timestamp DateTime64(9, 'UTC'),
-    datum Nullable(UInt8)
+    datum Nullable(Bool)
 )
 ENGINE = ReplicatedMergeTree('/clickhouse/tables/{shard}/measurements_bool_local', '{replica}')
 ORDER BY (timeseries_name, timeseries_key, timestamp)
@@ -595,7 +595,7 @@ CREATE TABLE IF NOT EXISTS oximeter.fields_bool_local ON CLUSTER oximeter_cluste
     timeseries_name String,
     timeseries_key UInt64,
     field_name String,
-    field_value UInt8,
+    field_value Bool,
     last_updated_at DateTime MATERIALIZED now()
 )
 ENGINE = ReplicatedReplacingMergeTree('/clickhouse/tables/{shard}/fields_bool_local', '{replica}')

--- a/oximeter/db/schema/single-node/13/up1.sql
+++ b/oximeter/db/schema/single-node/13/up1.sql
@@ -1,0 +1,1 @@
+ALTER TABLE oximeter.fields_bool ALTER COLUMN IF EXISTS field_value TYPE Bool;

--- a/oximeter/db/schema/single-node/13/up2.sql
+++ b/oximeter/db/schema/single-node/13/up2.sql
@@ -1,0 +1,1 @@
+ALTER TABLE oximeter.measurements_bool ALTER COLUMN IF EXISTS datum TYPE Nullable(Bool);

--- a/oximeter/db/schema/single-node/db-init.sql
+++ b/oximeter/db/schema/single-node/db-init.sql
@@ -24,7 +24,7 @@ CREATE TABLE IF NOT EXISTS oximeter.measurements_bool
     timeseries_name String,
     timeseries_key UInt64,
     timestamp DateTime64(9, 'UTC'),
-    datum Nullable(UInt8)
+    datum Nullable(Bool)
 )
 ENGINE = MergeTree()
 ORDER BY (timeseries_name, timeseries_key, timestamp)
@@ -518,7 +518,7 @@ CREATE TABLE IF NOT EXISTS oximeter.fields_bool
     timeseries_name String,
     timeseries_key UInt64,
     field_name String,
-    field_value UInt8,
+    field_value Bool,
     last_updated_at DateTime MATERIALIZED now()
 )
 ENGINE = ReplacingMergeTree()

--- a/oximeter/db/src/client/mod.rs
+++ b/oximeter/db/src/client/mod.rs
@@ -3039,7 +3039,7 @@ mod tests {
         client: &Client,
     ) -> Result<(), Error> {
         let field = FieldValue::Bool(true);
-        let as_json = serde_json::Value::from(1_u64);
+        let as_json = serde_json::Value::from(true);
         test_recall_field_value_impl(field, as_json, client).await?;
         Ok(())
     }

--- a/oximeter/db/src/configs/replica_config.xml
+++ b/oximeter/db/src/configs/replica_config.xml
@@ -484,4 +484,9 @@
         <enabled>false</enabled>
         <anonymize>false</anonymize>
     </send_crash_reports>
+
+    <!-- Disable sparse column serialization -->
+    <merge_tree>
+        <ratio_of_defaults_for_sparse_serialization>1.0</ratio_of_defaults_for_sparse_serialization>
+    </merge_tree>
 </clickhouse>

--- a/smf/clickhouse/config.xml
+++ b/smf/clickhouse/config.xml
@@ -38,4 +38,8 @@
     <quotas>
         <default/>
     </quotas>
+
+    <merge_tree>
+        <ratio_of_defaults_for_sparse_serialization>1.0</ratio_of_defaults_for_sparse_serialization>
+    </merge_tree>
 </clickhouse>

--- a/test-utils/Cargo.toml
+++ b/test-utils/Cargo.toml
@@ -43,6 +43,7 @@ uuid.workspace = true
 chrono.workspace = true
 expectorate.workspace = true
 gethostname.workspace = true
+serde.workspace = true
 
 [features]
 seed-gen = ["dep:filetime"]


### PR DESCRIPTION
- Use `Bool` data type in the `oximeter` database tables. Fixes #6994.
- Disable "sparse serialization" optimization for ClickHouse columns, which are unlikely to help us an use an undocumented data format. This turns off sparse serialization for test and deployed versions of ClickHouse, both single-node and replicated. Fixes #6995.