### PR TITLE
[clickhouse] Use chrono::UTC for distributed_ddl_queue endpoint

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1355,6 +1355,7 @@ dependencies = [
  "atomicwrites",
  "camino",
  "camino-tempfile",
+ "chrono",
  "derive_more",
  "expectorate",
  "itertools 0.13.0",

--- a/clickhouse-admin/src/clickhouse_cli.rs
+++ b/clickhouse-admin/src/clickhouse_cli.rs
@@ -147,10 +147,8 @@ impl ClickhouseCli {
         self.client_non_interactive(
             ClickhouseClientType::Server,
             format!(
-                "SELECT *, 
-                formatDateTime(query_create_time, '%Y-%m-%dT%H:%i:%s') AS formatted_query_create_time,
-                formatDateTime(query_finish_time, '%Y-%m-%dT%H:%i:%s') AS formatted_query_finish_time
-                FROM system.distributed_ddl_queue WHERE cluster = '{}' FORMAT JSONEachRow",
+                "SELECT * FROM system.distributed_ddl_queue WHERE cluster = '{}'
+                SETTINGS date_time_output_format = 'iso' FORMAT JSONEachRow",
                 OXIMETER_CLUSTER
             ).as_str(),
             "Retrieve information about distributed ddl queries (ON CLUSTER clause) 

--- a/clickhouse-admin/src/clickhouse_cli.rs
+++ b/clickhouse-admin/src/clickhouse_cli.rs
@@ -148,7 +148,9 @@ impl ClickhouseCli {
             ClickhouseClientType::Server,
             format!(
                 "SELECT * FROM system.distributed_ddl_queue WHERE cluster = '{}'
-                SETTINGS date_time_output_format = 'iso' FORMAT JSONEachRow",
+                SETTINGS date_time_output_format = 'iso',
+                output_format_json_quote_64bit_integers = '0'
+                FORMAT JSONEachRow",
                 OXIMETER_CLUSTER
             ).as_str(),
             "Retrieve information about distributed ddl queries (ON CLUSTER clause) 

--- a/clickhouse-admin/src/clickhouse_cli.rs
+++ b/clickhouse-admin/src/clickhouse_cli.rs
@@ -147,7 +147,9 @@ impl ClickhouseCli {
         self.client_non_interactive(
             ClickhouseClientType::Server,
             format!(
-                "SELECT * FROM system.distributed_ddl_queue WHERE cluster = '{}' FORMAT JSONEachRow",
+                "SELECT *, 
+                formatDateTime(query_finish_time, '%Y-%m-%dT%H:%i:%s') AS formatted_query_finish_time
+                FROM system.distributed_ddl_queue WHERE cluster = '{}' FORMAT JSONEachRow",
                 OXIMETER_CLUSTER
             ).as_str(),
             "Retrieve information about distributed ddl queries (ON CLUSTER clause) 

--- a/clickhouse-admin/src/clickhouse_cli.rs
+++ b/clickhouse-admin/src/clickhouse_cli.rs
@@ -148,6 +148,7 @@ impl ClickhouseCli {
             ClickhouseClientType::Server,
             format!(
                 "SELECT *, 
+                formatDateTime(query_create_time, '%Y-%m-%dT%H:%i:%s') AS formatted_query_create_time,
                 formatDateTime(query_finish_time, '%Y-%m-%dT%H:%i:%s') AS formatted_query_finish_time
                 FROM system.distributed_ddl_queue WHERE cluster = '{}' FORMAT JSONEachRow",
                 OXIMETER_CLUSTER

--- a/clickhouse-admin/types/Cargo.toml
+++ b/clickhouse-admin/types/Cargo.toml
@@ -12,6 +12,7 @@ anyhow.workspace = true
 atomicwrites.workspace = true
 camino.workspace = true
 camino-tempfile.workspace = true
+chrono.workspace = true
 derive_more.workspace = true
 itertools.workspace = true
 omicron-common.workspace = true

--- a/clickhouse-admin/types/src/lib.rs
+++ b/clickhouse-admin/types/src/lib.rs
@@ -1010,7 +1010,7 @@ pub struct DistributedDdlQueue {
     /// Query finish time
     pub query_finish_time: DateTime<Utc>,
     /// Duration of query execution (in milliseconds)
-    pub query_duration_ms: String,
+    pub query_duration_ms: u64,
 }
 
 impl DistributedDdlQueue {
@@ -1811,8 +1811,8 @@ snapshot_storage_disk=LocalSnapshotDisk
     fn test_distributed_ddl_queries_parse_success() {
         let log = log();
         let data =
-            "{\"entry\":\"query-0000000000\",\"entry_version\":5,\"initiator_host\":\"ixchel\",\"initiator_port\":22001,\"cluster\":\"oximeter_cluster\",\"query\":\"CREATE DATABASE IF NOT EXISTS db1 UUID 'a49757e4-179e-42bd-866f-93ac43136e2d' ON CLUSTER oximeter_cluster\",\"settings\":{\"load_balancing\":\"random\"},\"query_create_time\":\"2024-11-01T16:16:45Z\",\"host\":\"::1\",\"port\":22001,\"status\":\"Finished\",\"exception_code\":0,\"exception_text\":\"\",\"query_finish_time\":\"2024-11-01T16:16:45Z\",\"query_duration_ms\":\"4\"}
-{\"entry\":\"query-0000000000\",\"entry_version\":5,\"initiator_host\":\"ixchel\",\"initiator_port\":22001,\"cluster\":\"oximeter_cluster\",\"query\":\"CREATE DATABASE IF NOT EXISTS db1 UUID 'a49757e4-179e-42bd-866f-93ac43136e2d' ON CLUSTER oximeter_cluster\",\"settings\":{\"load_balancing\":\"random\"},\"query_create_time\":\"2024-11-01T16:16:45Z\",\"host\":\"::1\",\"port\":22002,\"status\":\"Finished\",\"exception_code\":0,\"exception_text\":\"\",\"query_finish_time\":\"2024-11-01T16:16:45Z\",\"query_duration_ms\":\"4\"}
+            "{\"entry\":\"query-0000000000\",\"entry_version\":5,\"initiator_host\":\"ixchel\",\"initiator_port\":22001,\"cluster\":\"oximeter_cluster\",\"query\":\"CREATE DATABASE IF NOT EXISTS db1 UUID 'a49757e4-179e-42bd-866f-93ac43136e2d' ON CLUSTER oximeter_cluster\",\"settings\":{\"load_balancing\":\"random\"},\"query_create_time\":\"2024-11-01T16:16:45Z\",\"host\":\"::1\",\"port\":22001,\"status\":\"Finished\",\"exception_code\":0,\"exception_text\":\"\",\"query_finish_time\":\"2024-11-01T16:16:45Z\",\"query_duration_ms\":4}
+{\"entry\":\"query-0000000000\",\"entry_version\":5,\"initiator_host\":\"ixchel\",\"initiator_port\":22001,\"cluster\":\"oximeter_cluster\",\"query\":\"CREATE DATABASE IF NOT EXISTS db1 UUID 'a49757e4-179e-42bd-866f-93ac43136e2d' ON CLUSTER oximeter_cluster\",\"settings\":{\"load_balancing\":\"random\"},\"query_create_time\":\"2024-11-01T16:16:45Z\",\"host\":\"::1\",\"port\":22002,\"status\":\"Finished\",\"exception_code\":0,\"exception_text\":\"\",\"query_finish_time\":\"2024-11-01T16:16:45Z\",\"query_duration_ms\":4}
 "
             .as_bytes();
         let ddl = DistributedDdlQueue::parse(&log, data).unwrap();
@@ -1835,7 +1835,7 @@ snapshot_storage_disk=LocalSnapshotDisk
                 exception_text: "".to_string(),
                 status: "Finished".to_string(),
                 query_finish_time: "2024-11-01T16:16:45Z".parse::<DateTime::<Utc>>().unwrap(),
-                query_duration_ms: "4".to_string(),
+                query_duration_ms: 4,
             },
             DistributedDdlQueue{
                 entry: "query-0000000000".to_string(),
@@ -1854,7 +1854,7 @@ snapshot_storage_disk=LocalSnapshotDisk
                 exception_text: "".to_string(),
                 status: "Finished".to_string(),
                 query_finish_time: "2024-11-01T16:16:45Z".parse::<DateTime::<Utc>>().unwrap(),
-                query_duration_ms: "4".to_string(),
+                query_duration_ms: 4,
             },
         ];
         assert!(ddl == expected_result);
@@ -1874,7 +1874,7 @@ snapshot_storage_disk=LocalSnapshotDisk
     fn test_misshapen_distributed_ddl_queries_parse_fail() {
         let log = log();
         let data =
-        "{\"entry\":\"query-0000000000\",\"initiator_host\":\"ixchel\",\"initiator_port\":22001,\"cluster\":\"oximeter_cluster\",\"query\":\"CREATE DATABASE IF NOT EXISTS db1 UUID 'a49757e4-179e-42bd-866f-93ac43136e2d' ON CLUSTER oximeter_cluster\",\"settings\":{\"load_balancing\":\"random\"},\"query_create_time\":\"2024-11-01T16:16:45Z\",\"host\":\"::1\",\"port\":22001,\"status\":\"Finished\",\"exception_code\":0,\"exception_text\":\"\",\"query_finish_time\":\"2024-11-01T16:16:45Z\",\"query_duration_ms\":\"4\"}
+        "{\"entry\":\"query-0000000000\",\"initiator_host\":\"ixchel\",\"initiator_port\":22001,\"cluster\":\"oximeter_cluster\",\"query\":\"CREATE DATABASE IF NOT EXISTS db1 UUID 'a49757e4-179e-42bd-866f-93ac43136e2d' ON CLUSTER oximeter_cluster\",\"settings\":{\"load_balancing\":\"random\"},\"query_create_time\":\"2024-11-01T16:16:45Z\",\"host\":\"::1\",\"port\":22001,\"status\":\"Finished\",\"exception_code\":0,\"exception_text\":\"\",\"query_finish_time\":\"2024-11-01T16:16:45Z\",\"query_duration_ms\":4}
 "
 .as_bytes();
         let result = DistributedDdlQueue::parse(&log, data);
@@ -1884,7 +1884,7 @@ snapshot_storage_disk=LocalSnapshotDisk
 
         assert_eq!(
             format!("{}", root_cause),
-            "missing field `entry_version` at line 1 column 456",
+            "missing field `entry_version` at line 1 column 454",
         );
     }
 }

--- a/clickhouse-admin/types/src/lib.rs
+++ b/clickhouse-admin/types/src/lib.rs
@@ -1011,7 +1011,9 @@ pub struct DistributedDdlQueue {
     pub query_finish_time: String,
     /// Duration of query execution (in milliseconds)
     pub query_duration_ms: String,
-    // TODO: Add formatted times here
+    /// Formatted query created time
+    pub formatted_query_create_time: NaiveDateTime,
+    /// Formatted query finish time
     pub formatted_query_finish_time: NaiveDateTime,
 }
 
@@ -1039,6 +1041,7 @@ impl DistributedDdlQueue {
 mod tests {
     use camino::Utf8PathBuf;
     use camino_tempfile::Builder;
+    use chrono::NaiveDateTime;
     use slog::{o, Drain};
     use slog_term::{FullFormat, PlainDecorator, TestStdoutWriter};
     use std::collections::BTreeMap;
@@ -1812,8 +1815,8 @@ snapshot_storage_disk=LocalSnapshotDisk
     fn test_distributed_ddl_queries_parse_success() {
         let log = log();
         let data =
-            "{\"entry\":\"query-0000000000\",\"entry_version\":5,\"initiator_host\":\"ixchel\",\"initiator_port\":22001,\"cluster\":\"oximeter_cluster\",\"query\":\"CREATE DATABASE IF NOT EXISTS db1 UUID 'a49757e4-179e-42bd-866f-93ac43136e2d' ON CLUSTER oximeter_cluster\",\"settings\":{\"load_balancing\":\"random\"},\"query_create_time\":\"2024-11-01 16:16:45\",\"host\":\"::1\",\"port\":22001,\"status\":\"Finished\",\"exception_code\":0,\"exception_text\":\"\",\"query_finish_time\":\"2024-11-01 16:16:45\",\"query_duration_ms\":\"4\"}
-{\"entry\":\"query-0000000000\",\"entry_version\":5,\"initiator_host\":\"ixchel\",\"initiator_port\":22001,\"cluster\":\"oximeter_cluster\",\"query\":\"CREATE DATABASE IF NOT EXISTS db1 UUID 'a49757e4-179e-42bd-866f-93ac43136e2d' ON CLUSTER oximeter_cluster\",\"settings\":{\"load_balancing\":\"random\"},\"query_create_time\":\"2024-11-01 16:16:45\",\"host\":\"::1\",\"port\":22002,\"status\":\"Finished\",\"exception_code\":0,\"exception_text\":\"\",\"query_finish_time\":\"2024-11-01 16:16:45\",\"query_duration_ms\":\"4\"}
+            "{\"entry\":\"query-0000000000\",\"entry_version\":5,\"initiator_host\":\"ixchel\",\"initiator_port\":22001,\"cluster\":\"oximeter_cluster\",\"query\":\"CREATE DATABASE IF NOT EXISTS db1 UUID 'a49757e4-179e-42bd-866f-93ac43136e2d' ON CLUSTER oximeter_cluster\",\"settings\":{\"load_balancing\":\"random\"},\"query_create_time\":\"2024-11-01 16:16:45\",\"host\":\"::1\",\"port\":22001,\"status\":\"Finished\",\"exception_code\":0,\"exception_text\":\"\",\"query_finish_time\":\"2024-11-01 16:16:45\",\"query_duration_ms\":\"4\",\"formatted_query_create_time\":\"2024-11-01T16:16:45\",\"formatted_query_finish_time\":\"2024-11-01T16:16:45\"}
+{\"entry\":\"query-0000000000\",\"entry_version\":5,\"initiator_host\":\"ixchel\",\"initiator_port\":22001,\"cluster\":\"oximeter_cluster\",\"query\":\"CREATE DATABASE IF NOT EXISTS db1 UUID 'a49757e4-179e-42bd-866f-93ac43136e2d' ON CLUSTER oximeter_cluster\",\"settings\":{\"load_balancing\":\"random\"},\"query_create_time\":\"2024-11-01 16:16:45\",\"host\":\"::1\",\"port\":22002,\"status\":\"Finished\",\"exception_code\":0,\"exception_text\":\"\",\"query_finish_time\":\"2024-11-01 16:16:45\",\"query_duration_ms\":\"4\",\"formatted_query_create_time\":\"2024-11-01T16:16:45\",\"formatted_query_finish_time\":\"2024-11-01T16:16:45\"}
 "
             .as_bytes();
         let ddl = DistributedDdlQueue::parse(&log, data).unwrap();
@@ -1837,6 +1840,8 @@ snapshot_storage_disk=LocalSnapshotDisk
                 status: "Finished".to_string(),
                 query_finish_time: "2024-11-01 16:16:45".to_string(),
                 query_duration_ms: "4".to_string(),
+                formatted_query_create_time: NaiveDateTime::parse_from_str("2024-11-01 16:16:45", "%Y-%m-%d %H:%M:%S").unwrap(),
+                formatted_query_finish_time: NaiveDateTime::parse_from_str("2024-11-01 16:16:45", "%Y-%m-%d %H:%M:%S").unwrap(),
             },
             DistributedDdlQueue{
                 entry: "query-0000000000".to_string(),
@@ -1856,8 +1861,10 @@ snapshot_storage_disk=LocalSnapshotDisk
                 status: "Finished".to_string(),
                 query_finish_time: "2024-11-01 16:16:45".to_string(),
                 query_duration_ms: "4".to_string(),
+                formatted_query_create_time: NaiveDateTime::parse_from_str("2024-11-01 16:16:45", "%Y-%m-%d %H:%M:%S").unwrap(),
+                formatted_query_finish_time: NaiveDateTime::parse_from_str("2024-11-01 16:16:45", "%Y-%m-%d %H:%M:%S").unwrap(),
             },
-            ];
+        ];
         assert!(ddl == expected_result);
     }
 

--- a/clickhouse-admin/types/src/lib.rs
+++ b/clickhouse-admin/types/src/lib.rs
@@ -1840,8 +1840,12 @@ snapshot_storage_disk=LocalSnapshotDisk
                 status: "Finished".to_string(),
                 query_finish_time: "2024-11-01 16:16:45".to_string(),
                 query_duration_ms: "4".to_string(),
-                formatted_query_create_time: NaiveDateTime::parse_from_str("2024-11-01 16:16:45", "%Y-%m-%d %H:%M:%S").unwrap(),
-                formatted_query_finish_time: NaiveDateTime::parse_from_str("2024-11-01 16:16:45", "%Y-%m-%d %H:%M:%S").unwrap(),
+                formatted_query_create_time: NaiveDateTime::parse_from_str(
+                    "2024-11-01 16:16:45", "%Y-%m-%d %H:%M:%S"
+                ).unwrap(),
+                formatted_query_finish_time: NaiveDateTime::parse_from_str(
+                    "2024-11-01 16:16:45", "%Y-%m-%d %H:%M:%S"
+                ).unwrap(),
             },
             DistributedDdlQueue{
                 entry: "query-0000000000".to_string(),
@@ -1861,8 +1865,12 @@ snapshot_storage_disk=LocalSnapshotDisk
                 status: "Finished".to_string(),
                 query_finish_time: "2024-11-01 16:16:45".to_string(),
                 query_duration_ms: "4".to_string(),
-                formatted_query_create_time: NaiveDateTime::parse_from_str("2024-11-01 16:16:45", "%Y-%m-%d %H:%M:%S").unwrap(),
-                formatted_query_finish_time: NaiveDateTime::parse_from_str("2024-11-01 16:16:45", "%Y-%m-%d %H:%M:%S").unwrap(),
+                formatted_query_create_time: NaiveDateTime::parse_from_str(
+                    "2024-11-01 16:16:45", "%Y-%m-%d %H:%M:%S"
+                ).unwrap(),
+                formatted_query_finish_time: NaiveDateTime::parse_from_str(
+                    "2024-11-01 16:16:45", "%Y-%m-%d %H:%M:%S"
+                ).unwrap(),
             },
         ];
         assert!(ddl == expected_result);

--- a/clickhouse-admin/types/src/lib.rs
+++ b/clickhouse-admin/types/src/lib.rs
@@ -1884,7 +1884,7 @@ snapshot_storage_disk=LocalSnapshotDisk
 
         assert_eq!(
             format!("{}", root_cause),
-            "missing field `entry_version` at line 1 column 454",
+            "missing field `entry_version` at line 1 column 456",
         );
     }
 }

--- a/clickhouse-admin/types/src/lib.rs
+++ b/clickhouse-admin/types/src/lib.rs
@@ -5,6 +5,7 @@
 use anyhow::{bail, Context, Error, Result};
 use atomicwrites::AtomicFile;
 use camino::Utf8PathBuf;
+use chrono::NaiveDateTime;
 use derive_more::{Add, AddAssign, Display, From};
 use itertools::Itertools;
 use omicron_common::api::external::Generation;
@@ -1010,6 +1011,8 @@ pub struct DistributedDdlQueue {
     pub query_finish_time: String,
     /// Duration of query execution (in milliseconds)
     pub query_duration_ms: String,
+    // TODO: Add formatted times here
+    pub formatted_query_finish_time: NaiveDateTime,
 }
 
 impl DistributedDdlQueue {

--- a/clickhouse-admin/types/src/lib.rs
+++ b/clickhouse-admin/types/src/lib.rs
@@ -5,7 +5,7 @@
 use anyhow::{bail, Context, Error, Result};
 use atomicwrites::AtomicFile;
 use camino::Utf8PathBuf;
-use chrono::NaiveDateTime;
+use chrono::{DateTime, Utc};
 use derive_more::{Add, AddAssign, Display, From};
 use itertools::Itertools;
 use omicron_common::api::external::Generation;
@@ -996,7 +996,7 @@ pub struct DistributedDdlQueue {
     /// Settings used in the DDL operation
     pub settings: BTreeMap<String, String>,
     /// Query created time
-    pub query_create_time: String,
+    pub query_create_time: DateTime<Utc>,
     /// Hostname
     pub host: Ipv6Addr,
     /// Host Port
@@ -1008,13 +1008,9 @@ pub struct DistributedDdlQueue {
     /// Exception message
     pub exception_text: String,
     /// Query finish time
-    pub query_finish_time: String,
+    pub query_finish_time: DateTime<Utc>,
     /// Duration of query execution (in milliseconds)
     pub query_duration_ms: String,
-    /// Formatted query created time
-    pub formatted_query_create_time: NaiveDateTime,
-    /// Formatted query finish time
-    pub formatted_query_finish_time: NaiveDateTime,
 }
 
 impl DistributedDdlQueue {
@@ -1041,7 +1037,7 @@ impl DistributedDdlQueue {
 mod tests {
     use camino::Utf8PathBuf;
     use camino_tempfile::Builder;
-    use chrono::NaiveDateTime;
+    use chrono::{DateTime, Utc};
     use slog::{o, Drain};
     use slog_term::{FullFormat, PlainDecorator, TestStdoutWriter};
     use std::collections::BTreeMap;
@@ -1815,8 +1811,8 @@ snapshot_storage_disk=LocalSnapshotDisk
     fn test_distributed_ddl_queries_parse_success() {
         let log = log();
         let data =
-            "{\"entry\":\"query-0000000000\",\"entry_version\":5,\"initiator_host\":\"ixchel\",\"initiator_port\":22001,\"cluster\":\"oximeter_cluster\",\"query\":\"CREATE DATABASE IF NOT EXISTS db1 UUID 'a49757e4-179e-42bd-866f-93ac43136e2d' ON CLUSTER oximeter_cluster\",\"settings\":{\"load_balancing\":\"random\"},\"query_create_time\":\"2024-11-01 16:16:45\",\"host\":\"::1\",\"port\":22001,\"status\":\"Finished\",\"exception_code\":0,\"exception_text\":\"\",\"query_finish_time\":\"2024-11-01 16:16:45\",\"query_duration_ms\":\"4\",\"formatted_query_create_time\":\"2024-11-01T16:16:45\",\"formatted_query_finish_time\":\"2024-11-01T16:16:45\"}
-{\"entry\":\"query-0000000000\",\"entry_version\":5,\"initiator_host\":\"ixchel\",\"initiator_port\":22001,\"cluster\":\"oximeter_cluster\",\"query\":\"CREATE DATABASE IF NOT EXISTS db1 UUID 'a49757e4-179e-42bd-866f-93ac43136e2d' ON CLUSTER oximeter_cluster\",\"settings\":{\"load_balancing\":\"random\"},\"query_create_time\":\"2024-11-01 16:16:45\",\"host\":\"::1\",\"port\":22002,\"status\":\"Finished\",\"exception_code\":0,\"exception_text\":\"\",\"query_finish_time\":\"2024-11-01 16:16:45\",\"query_duration_ms\":\"4\",\"formatted_query_create_time\":\"2024-11-01T16:16:45\",\"formatted_query_finish_time\":\"2024-11-01T16:16:45\"}
+            "{\"entry\":\"query-0000000000\",\"entry_version\":5,\"initiator_host\":\"ixchel\",\"initiator_port\":22001,\"cluster\":\"oximeter_cluster\",\"query\":\"CREATE DATABASE IF NOT EXISTS db1 UUID 'a49757e4-179e-42bd-866f-93ac43136e2d' ON CLUSTER oximeter_cluster\",\"settings\":{\"load_balancing\":\"random\"},\"query_create_time\":\"2024-11-01T16:16:45Z\",\"host\":\"::1\",\"port\":22001,\"status\":\"Finished\",\"exception_code\":0,\"exception_text\":\"\",\"query_finish_time\":\"2024-11-01T16:16:45Z\",\"query_duration_ms\":\"4\"}
+{\"entry\":\"query-0000000000\",\"entry_version\":5,\"initiator_host\":\"ixchel\",\"initiator_port\":22001,\"cluster\":\"oximeter_cluster\",\"query\":\"CREATE DATABASE IF NOT EXISTS db1 UUID 'a49757e4-179e-42bd-866f-93ac43136e2d' ON CLUSTER oximeter_cluster\",\"settings\":{\"load_balancing\":\"random\"},\"query_create_time\":\"2024-11-01T16:16:45Z\",\"host\":\"::1\",\"port\":22002,\"status\":\"Finished\",\"exception_code\":0,\"exception_text\":\"\",\"query_finish_time\":\"2024-11-01T16:16:45Z\",\"query_duration_ms\":\"4\"}
 "
             .as_bytes();
         let ddl = DistributedDdlQueue::parse(&log, data).unwrap();
@@ -1832,20 +1828,14 @@ snapshot_storage_disk=LocalSnapshotDisk
                 settings: BTreeMap::from([
     ("load_balancing".to_string(), "random".to_string()),
 ]),
-                query_create_time: "2024-11-01 16:16:45".to_string(),
+                query_create_time: "2024-11-01T16:16:45Z".parse::<DateTime::<Utc>>().unwrap(),
                 host: Ipv6Addr::from_str("::1").unwrap(),
                 port: 22001,
                 exception_code: 0,
                 exception_text: "".to_string(),
                 status: "Finished".to_string(),
-                query_finish_time: "2024-11-01 16:16:45".to_string(),
+                query_finish_time: "2024-11-01T16:16:45Z".parse::<DateTime::<Utc>>().unwrap(),
                 query_duration_ms: "4".to_string(),
-                formatted_query_create_time: NaiveDateTime::parse_from_str(
-                    "2024-11-01 16:16:45", "%Y-%m-%d %H:%M:%S"
-                ).unwrap(),
-                formatted_query_finish_time: NaiveDateTime::parse_from_str(
-                    "2024-11-01 16:16:45", "%Y-%m-%d %H:%M:%S"
-                ).unwrap(),
             },
             DistributedDdlQueue{
                 entry: "query-0000000000".to_string(),
@@ -1857,20 +1847,14 @@ snapshot_storage_disk=LocalSnapshotDisk
                 settings: BTreeMap::from([
     ("load_balancing".to_string(), "random".to_string()),
 ]),
-                query_create_time: "2024-11-01 16:16:45".to_string(),
+                query_create_time: "2024-11-01T16:16:45Z".parse::<DateTime::<Utc>>().unwrap(),
                 host: Ipv6Addr::from_str("::1").unwrap(),
                 port: 22002,
                 exception_code: 0,
                 exception_text: "".to_string(),
                 status: "Finished".to_string(),
-                query_finish_time: "2024-11-01 16:16:45".to_string(),
+                query_finish_time: "2024-11-01T16:16:45Z".parse::<DateTime::<Utc>>().unwrap(),
                 query_duration_ms: "4".to_string(),
-                formatted_query_create_time: NaiveDateTime::parse_from_str(
-                    "2024-11-01 16:16:45", "%Y-%m-%d %H:%M:%S"
-                ).unwrap(),
-                formatted_query_finish_time: NaiveDateTime::parse_from_str(
-                    "2024-11-01 16:16:45", "%Y-%m-%d %H:%M:%S"
-                ).unwrap(),
             },
         ];
         assert!(ddl == expected_result);
@@ -1890,7 +1874,7 @@ snapshot_storage_disk=LocalSnapshotDisk
     fn test_misshapen_distributed_ddl_queries_parse_fail() {
         let log = log();
         let data =
-        "{\"entry\":\"query-0000000000\",\"initiator_host\":\"ixchel\",\"initiator_port\":22001,\"cluster\":\"oximeter_cluster\",\"query\":\"CREATE DATABASE IF NOT EXISTS db1 UUID 'a49757e4-179e-42bd-866f-93ac43136e2d' ON CLUSTER oximeter_cluster\",\"settings\":{\"load_balancing\":\"random\"},\"query_create_time\":\"2024-11-01 16:16:45\",\"host\":\"::1\",\"port\":22001,\"status\":\"Finished\",\"exception_code\":0,\"exception_text\":\"\",\"query_finish_time\":\"2024-11-01 16:16:45\",\"query_duration_ms\":\"4\"}
+        "{\"entry\":\"query-0000000000\",\"initiator_host\":\"ixchel\",\"initiator_port\":22001,\"cluster\":\"oximeter_cluster\",\"query\":\"CREATE DATABASE IF NOT EXISTS db1 UUID 'a49757e4-179e-42bd-866f-93ac43136e2d' ON CLUSTER oximeter_cluster\",\"settings\":{\"load_balancing\":\"random\"},\"query_create_time\":\"2024-11-01T16:16:45Z\",\"host\":\"::1\",\"port\":22001,\"status\":\"Finished\",\"exception_code\":0,\"exception_text\":\"\",\"query_finish_time\":\"2024-11-01T16:16:45Z\",\"query_duration_ms\":\"4\"}
 "
 .as_bytes();
         let result = DistributedDdlQueue::parse(&log, data);

--- a/openapi/clickhouse-admin-server.json
+++ b/openapi/clickhouse-admin-server.json
@@ -147,6 +147,16 @@
             "description": "Exception message",
             "type": "string"
           },
+          "formatted_query_create_time": {
+            "description": "Formatted query created time",
+            "type": "string",
+            "format": "partial-date-time"
+          },
+          "formatted_query_finish_time": {
+            "description": "Formatted query finish time",
+            "type": "string",
+            "format": "partial-date-time"
+          },
           "host": {
             "description": "Hostname",
             "type": "string",
@@ -202,6 +212,8 @@
           "entry_version",
           "exception_code",
           "exception_text",
+          "formatted_query_create_time",
+          "formatted_query_finish_time",
           "host",
           "initiator_host",
           "initiator_port",

--- a/openapi/clickhouse-admin-server.json
+++ b/openapi/clickhouse-admin-server.json
@@ -179,7 +179,9 @@
           },
           "query_duration_ms": {
             "description": "Duration of query execution (in milliseconds)",
-            "type": "string"
+            "type": "integer",
+            "format": "uint64",
+            "minimum": 0
           },
           "query_finish_time": {
             "description": "Query finish time",

--- a/openapi/clickhouse-admin-server.json
+++ b/openapi/clickhouse-admin-server.json
@@ -147,16 +147,6 @@
             "description": "Exception message",
             "type": "string"
           },
-          "formatted_query_create_time": {
-            "description": "Formatted query created time",
-            "type": "string",
-            "format": "partial-date-time"
-          },
-          "formatted_query_finish_time": {
-            "description": "Formatted query finish time",
-            "type": "string",
-            "format": "partial-date-time"
-          },
           "host": {
             "description": "Hostname",
             "type": "string",
@@ -184,7 +174,8 @@
           },
           "query_create_time": {
             "description": "Query created time",
-            "type": "string"
+            "type": "string",
+            "format": "date-time"
           },
           "query_duration_ms": {
             "description": "Duration of query execution (in milliseconds)",
@@ -192,7 +183,8 @@
           },
           "query_finish_time": {
             "description": "Query finish time",
-            "type": "string"
+            "type": "string",
+            "format": "date-time"
           },
           "settings": {
             "description": "Settings used in the DDL operation",
@@ -212,8 +204,6 @@
           "entry_version",
           "exception_code",
           "exception_text",
-          "formatted_query_create_time",
-          "formatted_query_finish_time",
           "host",
           "initiator_host",
           "initiator_port",


### PR DESCRIPTION
Modified the SQL query to set the date/time format to one we can parse.

```console
$ curl http://[::1]:8888/distributed-ddl-queue | jq
  % Total    % Received % Xferd  Average Speed   Time    Time     Time  Current
                                 Dload  Upload   Total   Spent    Left  Speed
100  1993  100  1993    0     0   4203      0 --:--:-- --:--:-- --:--:--  4213
[
  {
    "entry": "query-0000000001",
    "entry_version": 5,
    "initiator_host": "ixchel",
    "initiator_port": 22001,
    "cluster": "oximeter_cluster",
    "query": "CREATE DATABASE IF NOT EXISTS db1 UUID '701a3dd3-10f0-4f5d-b5b2-0ad11bcf2b17' ON CLUSTER oximeter_cluster",
    "settings": {
      "load_balancing": "random"
    },
    "query_create_time": "2024-11-01T03:17:08Z",
    "host": "::1",
    "port": 22001,
    "status": "Finished",
    "exception_code": 0,
    "exception_text": "",
    "query_finish_time": "2024-11-01T03:17:08Z",
    "query_duration_ms": 3
  },
```