### PR TITLE
[clickhouse-admin] Modify endpoints to avoid redundancy

### DIFF
--- a/clickhouse-admin/api/src/lib.rs
+++ b/clickhouse-admin/api/src/lib.rs
@@ -33,7 +33,7 @@ pub trait ClickhouseAdminKeeperApi {
     /// configuration set via this endpoint.
     #[endpoint {
         method = PUT,
-        path = "/gen-config-and-enable",
+        path = "/config",
     }]
     async fn generate_config_and_enable_svc(
         rqctx: RequestContext<Self::Context>,
@@ -45,7 +45,7 @@ pub trait ClickhouseAdminKeeperApi {
     /// and logs for consistency and recovery.
     #[endpoint {
         method = GET,
-        path = "/lgif",
+        path = "/4lw-lgif",
     }]
     async fn lgif(
         rqctx: RequestContext<Self::Context>,
@@ -64,7 +64,7 @@ pub trait ClickhouseAdminKeeperApi {
     /// Retrieve configuration information from a keeper node.
     #[endpoint {
         method = GET,
-        path = "/conf",
+        path = "/4lw-conf",
     }]
     async fn keeper_conf(
         rqctx: RequestContext<Self::Context>,

--- a/clickhouse-admin/api/src/lib.rs
+++ b/clickhouse-admin/api/src/lib.rs
@@ -33,9 +33,9 @@ pub trait ClickhouseAdminKeeperApi {
     /// configuration set via this endpoint.
     #[endpoint {
         method = PUT,
-        path = "/config",
+        path = "/gen-config-and-enable",
     }]
-    async fn generate_config(
+    async fn generate_config_and_enable_svc(
         rqctx: RequestContext<Self::Context>,
         body: TypedBody<KeeperConfigurableSettings>,
     ) -> Result<HttpResponseCreated<KeeperConfig>, HttpError>;
@@ -45,7 +45,7 @@ pub trait ClickhouseAdminKeeperApi {
     /// and logs for consistency and recovery.
     #[endpoint {
         method = GET,
-        path = "/keeper/lgif",
+        path = "/lgif",
     }]
     async fn lgif(
         rqctx: RequestContext<Self::Context>,
@@ -55,7 +55,7 @@ pub trait ClickhouseAdminKeeperApi {
     /// contains last committed cluster configuration.
     #[endpoint {
         method = GET,
-        path = "/keeper/raft-config",
+        path = "/raft-config",
     }]
     async fn raft_config(
         rqctx: RequestContext<Self::Context>,
@@ -64,7 +64,7 @@ pub trait ClickhouseAdminKeeperApi {
     /// Retrieve configuration information from a keeper node.
     #[endpoint {
         method = GET,
-        path = "/keeper/conf",
+        path = "/conf",
     }]
     async fn keeper_conf(
         rqctx: RequestContext<Self::Context>,
@@ -73,7 +73,7 @@ pub trait ClickhouseAdminKeeperApi {
     /// Retrieve cluster membership information from a keeper node.
     #[endpoint {
         method = GET,
-        path = "/keeper/cluster-membership",
+        path = "/cluster-membership",
     }]
     async fn keeper_cluster_membership(
         rqctx: RequestContext<Self::Context>,
@@ -99,9 +99,9 @@ pub trait ClickhouseAdminServerApi {
     /// directory and enable the SMF service.
     #[endpoint {
         method = PUT,
-        path = "/config"
+        path = "/gen-config-and-enable"
     }]
-    async fn generate_config(
+    async fn generate_config_and_enable_svc(
         rqctx: RequestContext<Self::Context>,
         body: TypedBody<ServerConfigurableSettings>,
     ) -> Result<HttpResponseCreated<ReplicaConfig>, HttpError>;

--- a/clickhouse-admin/api/src/lib.rs
+++ b/clickhouse-admin/api/src/lib.rs
@@ -99,7 +99,7 @@ pub trait ClickhouseAdminServerApi {
     /// directory and enable the SMF service.
     #[endpoint {
         method = PUT,
-        path = "/gen-config-and-enable"
+        path = "/config"
     }]
     async fn generate_config_and_enable_svc(
         rqctx: RequestContext<Self::Context>,

--- a/clickhouse-admin/src/http_entrypoints.rs
+++ b/clickhouse-admin/src/http_entrypoints.rs
@@ -32,7 +32,7 @@ enum ClickhouseAdminServerImpl {}
 impl ClickhouseAdminServerApi for ClickhouseAdminServerImpl {
     type Context = Arc<ServerContext>;
 
-    async fn generate_config(
+    async fn generate_config_and_enable_svc(
         rqctx: RequestContext<Self::Context>,
         body: TypedBody<ServerConfigurableSettings>,
     ) -> Result<HttpResponseCreated<ReplicaConfig>, HttpError> {
@@ -62,7 +62,7 @@ enum ClickhouseAdminKeeperImpl {}
 impl ClickhouseAdminKeeperApi for ClickhouseAdminKeeperImpl {
     type Context = Arc<ServerContext>;
 
-    async fn generate_config(
+    async fn generate_config_and_enable_svc(
         rqctx: RequestContext<Self::Context>,
         body: TypedBody<KeeperConfigurableSettings>,
     ) -> Result<HttpResponseCreated<KeeperConfig>, HttpError> {

--- a/nexus/reconfigurator/execution/src/clickhouse.rs
+++ b/nexus/reconfigurator/execution/src/clickhouse.rs
@@ -93,18 +93,22 @@ pub(crate) async fn deploy_nodes(
         let log = log.new(slog::o!("admin_url" => admin_url.clone()));
         futs.push(Either::Left(async move {
             let client = ClickhouseKeeperClient::new(&admin_url, log.clone());
-            client.generate_config(&config).await.map(|_| ()).map_err(|e| {
-                anyhow!(
-                    concat!(
+            client
+                .generate_config_and_enable_svc(&config)
+                .await
+                .map(|_| ())
+                .map_err(|e| {
+                    anyhow!(
+                        concat!(
                         "failed to send config for clickhouse keeper ",
                         "with id {} to clickhouse-admin-keeper; admin_url = {}",
                         "error = {}"
                     ),
-                    config.settings.id,
-                    admin_url,
-                    e
-                )
-            })
+                        config.settings.id,
+                        admin_url,
+                        e
+                    )
+                })
         }));
     }
     for config in server_configs {
@@ -118,18 +122,22 @@ pub(crate) async fn deploy_nodes(
         let log = opctx.log.new(slog::o!("admin_url" => admin_url.clone()));
         futs.push(Either::Right(async move {
             let client = ClickhouseServerClient::new(&admin_url, log.clone());
-            client.generate_config(&config).await.map(|_| ()).map_err(|e| {
-                anyhow!(
-                    concat!(
+            client
+                .generate_config_and_enable_svc(&config)
+                .await
+                .map(|_| ())
+                .map_err(|e| {
+                    anyhow!(
+                        concat!(
                         "failed to send config for clickhouse server ",
                         "with id {} to clickhouse-admin-server; admin_url = {}",
                         "error = {}"
                     ),
-                    config.settings.id,
-                    admin_url,
-                    e
-                )
-            })
+                        config.settings.id,
+                        admin_url,
+                        e
+                    )
+                })
         }));
     }
 

--- a/openapi/clickhouse-admin-keeper.json
+++ b/openapi/clickhouse-admin-keeper.json
@@ -10,6 +10,55 @@
     "version": "0.0.1"
   },
   "paths": {
+    "/4lw-conf": {
+      "get": {
+        "summary": "Retrieve configuration information from a keeper node.",
+        "operationId": "keeper_conf",
+        "responses": {
+          "200": {
+            "description": "successful operation",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/KeeperConf"
+                }
+              }
+            }
+          },
+          "4XX": {
+            "$ref": "#/components/responses/Error"
+          },
+          "5XX": {
+            "$ref": "#/components/responses/Error"
+          }
+        }
+      }
+    },
+    "/4lw-lgif": {
+      "get": {
+        "summary": "Retrieve a logically grouped information file from a keeper node.",
+        "description": "This information is used internally by ZooKeeper to manage snapshots and logs for consistency and recovery.",
+        "operationId": "lgif",
+        "responses": {
+          "200": {
+            "description": "successful operation",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Lgif"
+                }
+              }
+            }
+          },
+          "4XX": {
+            "$ref": "#/components/responses/Error"
+          },
+          "5XX": {
+            "$ref": "#/components/responses/Error"
+          }
+        }
+      }
+    },
     "/cluster-membership": {
       "get": {
         "summary": "Retrieve cluster membership information from a keeper node.",
@@ -34,31 +83,7 @@
         }
       }
     },
-    "/conf": {
-      "get": {
-        "summary": "Retrieve configuration information from a keeper node.",
-        "operationId": "keeper_conf",
-        "responses": {
-          "200": {
-            "description": "successful operation",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/KeeperConf"
-                }
-              }
-            }
-          },
-          "4XX": {
-            "$ref": "#/components/responses/Error"
-          },
-          "5XX": {
-            "$ref": "#/components/responses/Error"
-          }
-        }
-      }
-    },
-    "/gen-config-and-enable": {
+    "/config": {
       "put": {
         "summary": "Generate a ClickHouse configuration file for a keeper node on a specified",
         "description": "directory and enable the SMF service if not currently enabled.\n\nNote that we cannot start the keeper service until there is an initial configuration set via this endpoint.",
@@ -80,31 +105,6 @@
               "application/json": {
                 "schema": {
                   "$ref": "#/components/schemas/KeeperConfig"
-                }
-              }
-            }
-          },
-          "4XX": {
-            "$ref": "#/components/responses/Error"
-          },
-          "5XX": {
-            "$ref": "#/components/responses/Error"
-          }
-        }
-      }
-    },
-    "/lgif": {
-      "get": {
-        "summary": "Retrieve a logically grouped information file from a keeper node.",
-        "description": "This information is used internally by ZooKeeper to manage snapshots and logs for consistency and recovery.",
-        "operationId": "lgif",
-        "responses": {
-          "200": {
-            "description": "successful operation",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/Lgif"
                 }
               }
             }

--- a/openapi/clickhouse-admin-keeper.json
+++ b/openapi/clickhouse-admin-keeper.json
@@ -10,11 +10,59 @@
     "version": "0.0.1"
   },
   "paths": {
-    "/config": {
+    "/cluster-membership": {
+      "get": {
+        "summary": "Retrieve cluster membership information from a keeper node.",
+        "operationId": "keeper_cluster_membership",
+        "responses": {
+          "200": {
+            "description": "successful operation",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ClickhouseKeeperClusterMembership"
+                }
+              }
+            }
+          },
+          "4XX": {
+            "$ref": "#/components/responses/Error"
+          },
+          "5XX": {
+            "$ref": "#/components/responses/Error"
+          }
+        }
+      }
+    },
+    "/conf": {
+      "get": {
+        "summary": "Retrieve configuration information from a keeper node.",
+        "operationId": "keeper_conf",
+        "responses": {
+          "200": {
+            "description": "successful operation",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/KeeperConf"
+                }
+              }
+            }
+          },
+          "4XX": {
+            "$ref": "#/components/responses/Error"
+          },
+          "5XX": {
+            "$ref": "#/components/responses/Error"
+          }
+        }
+      }
+    },
+    "/gen-config-and-enable": {
       "put": {
         "summary": "Generate a ClickHouse configuration file for a keeper node on a specified",
         "description": "directory and enable the SMF service if not currently enabled.\n\nNote that we cannot start the keeper service until there is an initial configuration set via this endpoint.",
-        "operationId": "generate_config",
+        "operationId": "generate_config_and_enable_svc",
         "requestBody": {
           "content": {
             "application/json": {
@@ -45,55 +93,7 @@
         }
       }
     },
-    "/keeper/cluster-membership": {
-      "get": {
-        "summary": "Retrieve cluster membership information from a keeper node.",
-        "operationId": "keeper_cluster_membership",
-        "responses": {
-          "200": {
-            "description": "successful operation",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/ClickhouseKeeperClusterMembership"
-                }
-              }
-            }
-          },
-          "4XX": {
-            "$ref": "#/components/responses/Error"
-          },
-          "5XX": {
-            "$ref": "#/components/responses/Error"
-          }
-        }
-      }
-    },
-    "/keeper/conf": {
-      "get": {
-        "summary": "Retrieve configuration information from a keeper node.",
-        "operationId": "keeper_conf",
-        "responses": {
-          "200": {
-            "description": "successful operation",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/KeeperConf"
-                }
-              }
-            }
-          },
-          "4XX": {
-            "$ref": "#/components/responses/Error"
-          },
-          "5XX": {
-            "$ref": "#/components/responses/Error"
-          }
-        }
-      }
-    },
-    "/keeper/lgif": {
+    "/lgif": {
       "get": {
         "summary": "Retrieve a logically grouped information file from a keeper node.",
         "description": "This information is used internally by ZooKeeper to manage snapshots and logs for consistency and recovery.",
@@ -118,7 +118,7 @@
         }
       }
     },
-    "/keeper/raft-config": {
+    "/raft-config": {
       "get": {
         "summary": "Retrieve information from ClickHouse virtual node /keeper/config which",
         "description": "contains last committed cluster configuration.",

--- a/openapi/clickhouse-admin-server.json
+++ b/openapi/clickhouse-admin-server.json
@@ -10,36 +10,7 @@
     "version": "0.0.1"
   },
   "paths": {
-    "/distributed-ddl-queue": {
-      "get": {
-        "summary": "Contains information about distributed ddl queries (ON CLUSTER clause)",
-        "description": "that were executed on a cluster.",
-        "operationId": "distributed_ddl_queue",
-        "responses": {
-          "200": {
-            "description": "successful operation",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "title": "Array_of_DistributedDdlQueue",
-                  "type": "array",
-                  "items": {
-                    "$ref": "#/components/schemas/DistributedDdlQueue"
-                  }
-                }
-              }
-            }
-          },
-          "4XX": {
-            "$ref": "#/components/responses/Error"
-          },
-          "5XX": {
-            "$ref": "#/components/responses/Error"
-          }
-        }
-      }
-    },
-    "/gen-config-and-enable": {
+    "/config": {
       "put": {
         "summary": "Generate a ClickHouse configuration file for a server node on a specified",
         "description": "directory and enable the SMF service.",
@@ -61,6 +32,35 @@
               "application/json": {
                 "schema": {
                   "$ref": "#/components/schemas/ReplicaConfig"
+                }
+              }
+            }
+          },
+          "4XX": {
+            "$ref": "#/components/responses/Error"
+          },
+          "5XX": {
+            "$ref": "#/components/responses/Error"
+          }
+        }
+      }
+    },
+    "/distributed-ddl-queue": {
+      "get": {
+        "summary": "Contains information about distributed ddl queries (ON CLUSTER clause)",
+        "description": "that were executed on a cluster.",
+        "operationId": "distributed_ddl_queue",
+        "responses": {
+          "200": {
+            "description": "successful operation",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "title": "Array_of_DistributedDdlQueue",
+                  "type": "array",
+                  "items": {
+                    "$ref": "#/components/schemas/DistributedDdlQueue"
+                  }
                 }
               }
             }

--- a/openapi/clickhouse-admin-server.json
+++ b/openapi/clickhouse-admin-server.json
@@ -10,11 +10,40 @@
     "version": "0.0.1"
   },
   "paths": {
-    "/config": {
+    "/distributed-ddl-queue": {
+      "get": {
+        "summary": "Contains information about distributed ddl queries (ON CLUSTER clause)",
+        "description": "that were executed on a cluster.",
+        "operationId": "distributed_ddl_queue",
+        "responses": {
+          "200": {
+            "description": "successful operation",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "title": "Array_of_DistributedDdlQueue",
+                  "type": "array",
+                  "items": {
+                    "$ref": "#/components/schemas/DistributedDdlQueue"
+                  }
+                }
+              }
+            }
+          },
+          "4XX": {
+            "$ref": "#/components/responses/Error"
+          },
+          "5XX": {
+            "$ref": "#/components/responses/Error"
+          }
+        }
+      }
+    },
+    "/gen-config-and-enable": {
       "put": {
         "summary": "Generate a ClickHouse configuration file for a server node on a specified",
         "description": "directory and enable the SMF service.",
-        "operationId": "generate_config",
+        "operationId": "generate_config_and_enable_svc",
         "requestBody": {
           "content": {
             "application/json": {
@@ -32,35 +61,6 @@
               "application/json": {
                 "schema": {
                   "$ref": "#/components/schemas/ReplicaConfig"
-                }
-              }
-            }
-          },
-          "4XX": {
-            "$ref": "#/components/responses/Error"
-          },
-          "5XX": {
-            "$ref": "#/components/responses/Error"
-          }
-        }
-      }
-    },
-    "/distributed-ddl-queue": {
-      "get": {
-        "summary": "Contains information about distributed ddl queries (ON CLUSTER clause)",
-        "description": "that were executed on a cluster.",
-        "operationId": "distributed_ddl_queue",
-        "responses": {
-          "200": {
-            "description": "successful operation",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "title": "Array_of_DistributedDdlQueue",
-                  "type": "array",
-                  "items": {
-                    "$ref": "#/components/schemas/DistributedDdlQueue"
-                  }
                 }
               }
             }


### PR DESCRIPTION
Now that clickhouse-admin has been separated into two APIs, some endpoint names that started with `/keeper/` have become redundant. This commit fixes that.

Additionally, the `generate_config` endpoint was a little misleading as it infers only generating the files. Since this method also enables the service, I have changed the name to reflect that.