### PR TITLE
move back to Rust 1.81

### DIFF
--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -1,5 +1,11 @@
 [toolchain]
 # We choose a specific toolchain (rather than "stable") for repeatability.  The
 # intent is to keep this up-to-date with recently-released stable Rust.
-channel = "1.82.0"
+#
+# NOTE: Rust 1.82 has a large compile time regression in Diesel-generated
+# code: https://github.com/rust-lang/rust/issues/132064. Before moving to a
+# newer Rust, ensure that the regression is addressed and that nexus-db-queries
+# and omicron-nexus don't take much longer to compile!
+
+channel = "1.81.0"
 profile = "default"


### PR DESCRIPTION
Rust 1.82 has a rather serious compile time regression in Diesel-generated
code: https://github.com/rust-lang/rust/issues/132064. This makes Omicron
builds up to twice as slow.

We used to be on 1.80 before moving to 1.82, but 1.81 has some nice things like
`#[expect]`. So move to 1.81.

Thanks to @jmpesp for tracking this down!