### PR TITLE
[nexus] Move existing OxQL endpoints under `/v1/system/*`

### DIFF
--- a/nexus/external-api/output/nexus_tags.txt
+++ b/nexus/external-api/output/nexus_tags.txt
@@ -169,7 +169,7 @@ API operations found with tag "system/metrics"
 OPERATION ID                             METHOD   URL PATH
 system_metric                            GET      /v1/system/metrics/{metric_name}
 system_timeseries_query                  POST     /v1/system/timeseries/query
-system_timeseries_schema_list            GET      /v1/system/timeseries/schema
+system_timeseries_schema_list            GET      /v1/system/timeseries/schemas
 
 API operations found with tag "system/networking"
 OPERATION ID                             METHOD   URL PATH

--- a/nexus/external-api/output/nexus_tags.txt
+++ b/nexus/external-api/output/nexus_tags.txt
@@ -73,8 +73,6 @@ login_saml                               POST     /login/{silo_name}/saml/{provi
 API operations found with tag "metrics"
 OPERATION ID                             METHOD   URL PATH
 silo_metric                              GET      /v1/metrics/{metric_name}
-timeseries_query                         POST     /v1/timeseries/query
-timeseries_schema_list                   GET      /v1/timeseries/schema
 
 API operations found with tag "policy"
 OPERATION ID                             METHOD   URL PATH
@@ -170,6 +168,8 @@ ip_pool_view                             GET      /v1/system/ip-pools/{pool}
 API operations found with tag "system/metrics"
 OPERATION ID                             METHOD   URL PATH
 system_metric                            GET      /v1/system/metrics/{metric_name}
+system_timeseries_query                  POST     /v1/system/timeseries/query
+system_timeseries_schema_list            GET      /v1/system/timeseries/schema
 
 API operations found with tag "system/networking"
 OPERATION ID                             METHOD   URL PATH

--- a/nexus/external-api/src/lib.rs
+++ b/nexus/external-api/src/lib.rs
@@ -2541,10 +2541,10 @@ pub trait NexusExternalApi {
     /// List timeseries schemas
     #[endpoint {
         method = GET,
-        path = "/v1/timeseries/schema",
-        tags = ["metrics"],
+        path = "/v1/system/timeseries/schema",
+        tags = ["system/metrics"],
     }]
-    async fn timeseries_schema_list(
+    async fn system_timeseries_schema_list(
         rqctx: RequestContext<Self::Context>,
         pag_params: Query<TimeseriesSchemaPaginationParams>,
     ) -> Result<
@@ -2559,10 +2559,10 @@ pub trait NexusExternalApi {
     /// Queries are written in OxQL.
     #[endpoint {
         method = POST,
-        path = "/v1/timeseries/query",
-        tags = ["metrics"],
+        path = "/v1/system/timeseries/query",
+        tags = ["system/metrics"],
     }]
-    async fn timeseries_query(
+    async fn system_timeseries_query(
         rqctx: RequestContext<Self::Context>,
         body: TypedBody<params::TimeseriesQuery>,
     ) -> Result<HttpResponseOk<views::OxqlQueryResult>, HttpError>;

--- a/nexus/external-api/src/lib.rs
+++ b/nexus/external-api/src/lib.rs
@@ -2541,7 +2541,7 @@ pub trait NexusExternalApi {
     /// List timeseries schemas
     #[endpoint {
         method = GET,
-        path = "/v1/system/timeseries/schema",
+        path = "/v1/system/timeseries/schemas",
         tags = ["system/metrics"],
     }]
     async fn system_timeseries_schema_list(

--- a/nexus/src/external_api/http_entrypoints.rs
+++ b/nexus/src/external_api/http_entrypoints.rs
@@ -5494,7 +5494,7 @@ impl NexusExternalApi for NexusExternalApiImpl {
             .await
     }
 
-    async fn timeseries_schema_list(
+    async fn system_timeseries_schema_list(
         rqctx: RequestContext<ApiContext>,
         pag_params: Query<TimeseriesSchemaPaginationParams>,
     ) -> Result<
@@ -5521,7 +5521,7 @@ impl NexusExternalApi for NexusExternalApiImpl {
             .await
     }
 
-    async fn timeseries_query(
+    async fn system_timeseries_query(
         rqctx: RequestContext<ApiContext>,
         body: TypedBody<params::TimeseriesQuery>,
     ) -> Result<HttpResponseOk<views::OxqlQueryResult>, HttpError> {

--- a/nexus/tests/integration_tests/endpoints.rs
+++ b/nexus/tests/integration_tests/endpoints.rs
@@ -947,7 +947,7 @@ pub static DEMO_SILO_METRICS_URL: Lazy<String> = Lazy::new(|| {
 });
 
 pub static TIMESERIES_LIST_URL: Lazy<String> =
-    Lazy::new(|| String::from("/v1/system/timeseries/schema"));
+    Lazy::new(|| String::from("/v1/system/timeseries/schemas"));
 
 pub static TIMESERIES_QUERY_URL: Lazy<String> =
     Lazy::new(|| String::from("/v1/system/timeseries/query"));

--- a/nexus/tests/integration_tests/endpoints.rs
+++ b/nexus/tests/integration_tests/endpoints.rs
@@ -947,10 +947,10 @@ pub static DEMO_SILO_METRICS_URL: Lazy<String> = Lazy::new(|| {
 });
 
 pub static TIMESERIES_LIST_URL: Lazy<String> =
-    Lazy::new(|| String::from("/v1/timeseries/schema"));
+    Lazy::new(|| String::from("/v1/system/timeseries/schema"));
 
 pub static TIMESERIES_QUERY_URL: Lazy<String> =
-    Lazy::new(|| String::from("/v1/timeseries/query"));
+    Lazy::new(|| String::from("/v1/system/timeseries/query"));
 
 pub static DEMO_TIMESERIES_QUERY: Lazy<params::TimeseriesQuery> =
     Lazy::new(|| params::TimeseriesQuery {

--- a/nexus/tests/integration_tests/metrics.rs
+++ b/nexus/tests/integration_tests/metrics.rs
@@ -272,7 +272,7 @@ async fn test_timeseries_schema_list(
     // producing data. Force a collection to ensure that happens.
     cptestctx.oximeter.force_collect().await;
     let client = &cptestctx.external_client;
-    let url = "/v1/system/timeseries/schema";
+    let url = "/v1/system/timeseries/schemas";
     let schema =
         objects_list_page_authz::<TimeseriesSchema>(client, &url).await;
     schema

--- a/nexus/tests/integration_tests/metrics.rs
+++ b/nexus/tests/integration_tests/metrics.rs
@@ -272,7 +272,7 @@ async fn test_timeseries_schema_list(
     // producing data. Force a collection to ensure that happens.
     cptestctx.oximeter.force_collect().await;
     let client = &cptestctx.external_client;
-    let url = "/v1/timeseries/schema";
+    let url = "/v1/system/timeseries/schema";
     let schema =
         objects_list_page_authz::<TimeseriesSchema>(client, &url).await;
     schema
@@ -300,7 +300,7 @@ pub async fn timeseries_query(
         nexus_test_utils::http_testing::RequestBuilder::new(
             &cptestctx.external_client,
             http::Method::POST,
-            "/v1/timeseries/query",
+            "/v1/system/timeseries/query",
         )
         .body(Some(&body)),
     )

--- a/openapi/nexus.json
+++ b/openapi/nexus.json
@@ -8490,6 +8490,96 @@
         }
       }
     },
+    "/v1/system/timeseries/query": {
+      "post": {
+        "tags": [
+          "system/metrics"
+        ],
+        "summary": "Run timeseries query",
+        "description": "Queries are written in OxQL.",
+        "operationId": "system_timeseries_query",
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/TimeseriesQuery"
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "200": {
+            "description": "successful operation",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/OxqlQueryResult"
+                }
+              }
+            }
+          },
+          "4XX": {
+            "$ref": "#/components/responses/Error"
+          },
+          "5XX": {
+            "$ref": "#/components/responses/Error"
+          }
+        }
+      }
+    },
+    "/v1/system/timeseries/schema": {
+      "get": {
+        "tags": [
+          "system/metrics"
+        ],
+        "summary": "List timeseries schemas",
+        "operationId": "system_timeseries_schema_list",
+        "parameters": [
+          {
+            "in": "query",
+            "name": "limit",
+            "description": "Maximum number of items returned by a single call",
+            "schema": {
+              "nullable": true,
+              "type": "integer",
+              "format": "uint32",
+              "minimum": 1
+            }
+          },
+          {
+            "in": "query",
+            "name": "page_token",
+            "description": "Token returned by previous call to retrieve the subsequent page",
+            "schema": {
+              "nullable": true,
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "successful operation",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/TimeseriesSchemaResultsPage"
+                }
+              }
+            }
+          },
+          "4XX": {
+            "$ref": "#/components/responses/Error"
+          },
+          "5XX": {
+            "$ref": "#/components/responses/Error"
+          }
+        },
+        "x-dropshot-pagination": {
+          "required": []
+        }
+      }
+    },
     "/v1/system/users": {
       "get": {
         "tags": [
@@ -8797,96 +8887,6 @@
           "5XX": {
             "$ref": "#/components/responses/Error"
           }
-        }
-      }
-    },
-    "/v1/timeseries/query": {
-      "post": {
-        "tags": [
-          "metrics"
-        ],
-        "summary": "Run timeseries query",
-        "description": "Queries are written in OxQL.",
-        "operationId": "timeseries_query",
-        "requestBody": {
-          "content": {
-            "application/json": {
-              "schema": {
-                "$ref": "#/components/schemas/TimeseriesQuery"
-              }
-            }
-          },
-          "required": true
-        },
-        "responses": {
-          "200": {
-            "description": "successful operation",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/OxqlQueryResult"
-                }
-              }
-            }
-          },
-          "4XX": {
-            "$ref": "#/components/responses/Error"
-          },
-          "5XX": {
-            "$ref": "#/components/responses/Error"
-          }
-        }
-      }
-    },
-    "/v1/timeseries/schema": {
-      "get": {
-        "tags": [
-          "metrics"
-        ],
-        "summary": "List timeseries schemas",
-        "operationId": "timeseries_schema_list",
-        "parameters": [
-          {
-            "in": "query",
-            "name": "limit",
-            "description": "Maximum number of items returned by a single call",
-            "schema": {
-              "nullable": true,
-              "type": "integer",
-              "format": "uint32",
-              "minimum": 1
-            }
-          },
-          {
-            "in": "query",
-            "name": "page_token",
-            "description": "Token returned by previous call to retrieve the subsequent page",
-            "schema": {
-              "nullable": true,
-              "type": "string"
-            }
-          }
-        ],
-        "responses": {
-          "200": {
-            "description": "successful operation",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/TimeseriesSchemaResultsPage"
-                }
-              }
-            }
-          },
-          "4XX": {
-            "$ref": "#/components/responses/Error"
-          },
-          "5XX": {
-            "$ref": "#/components/responses/Error"
-          }
-        },
-        "x-dropshot-pagination": {
-          "required": []
         }
       }
     },

--- a/openapi/nexus.json
+++ b/openapi/nexus.json
@@ -8528,7 +8528,7 @@
         }
       }
     },
-    "/v1/system/timeseries/schema": {
+    "/v1/system/timeseries/schemas": {
       "get": {
         "tags": [
           "system/metrics"


### PR DESCRIPTION
Discussed this with @bnaecker a couple of weeks ago. Was going to do this in #6873 but I decided to split it out because it's just noise. The idea here is that (for now) rather than getting elaborate with permissions on the OxQL endpoint a la #5298, we just keep the existing endpoint fleet-viewer scoped and move it to `/v1/system/timeseries/query` with all the other operator endpoints. #6873 goes on top of this one and adds a project-scoped endpoint at `/v1/timeseries/query?project=my-proj`.