### PR TITLE
[reconfigurator] Planner: partition external DNS IP allocation separately from other service IP allocation

### DIFF
--- a/nexus/reconfigurator/planning/src/blueprint_builder/builder.rs
+++ b/nexus/reconfigurator/planning/src/blueprint_builder/builder.rs
@@ -83,6 +83,7 @@ use std::net::SocketAddrV6;
 use thiserror::Error;
 
 use super::clickhouse::ClickhouseAllocator;
+use super::external_networking::ensure_input_networking_records_appear_in_parent_blueprint;
 use super::external_networking::BuilderExternalNetworking;
 use super::external_networking::ExternalNetworkingChoice;
 use super::external_networking::ExternalSnatNetworkingChoice;
@@ -434,15 +435,22 @@ impl<'a> BlueprintBuilder<'a> {
     ) -> Result<&mut BuilderExternalNetworking<'a>, Error> {
         self.external_networking
             .get_or_try_init(|| {
-                BuilderExternalNetworking::new(
+                // Check the planning input: there shouldn't be any external
+                // networking resources in the database (the source of `input`)
+                // that we don't know about from the parent blueprint.
+                ensure_input_networking_records_appear_in_parent_blueprint(
                     self.parent_blueprint,
+                    self.input,
+                )?;
+
+                BuilderExternalNetworking::new(
                     self.zones
                         .current_zones(BlueprintZoneFilter::ShouldBeRunning)
                         .flat_map(|(_sled_id, zone_config)| zone_config),
                     self.zones
                         .current_zones(BlueprintZoneFilter::Expunged)
                         .flat_map(|(_sled_id, zone_config)| zone_config),
-                    self.input,
+                    self.input.service_ip_pool_ranges(),
                 )
             })
             .map_err(Error::Planner)?;
@@ -2631,7 +2639,6 @@ pub mod test {
     use nexus_types::external_api::views::SledPolicy;
     use omicron_common::address::IpRange;
     use omicron_test_utils::dev::test_setup_log;
-    use slog_error_chain::InlineErrorChain;
     use std::collections::BTreeSet;
     use std::mem;
 
@@ -3557,180 +3564,6 @@ pub mod test {
         // `NEXUS_OPTE_*_SUBNET`. We could hack around that by creating the
         // `BlueprintBuilder` and mucking with its internals, but that doesn't
         // seem like a particularly useful test either.
-
-        logctx.cleanup_successful();
-    }
-
-    #[test]
-    fn test_invalid_parent_blueprint_two_zones_with_same_external_ip() {
-        static TEST_NAME: &str =
-            "blueprint_builder_test_invalid_parent_blueprint_\
-             two_zones_with_same_external_ip";
-        let logctx = test_setup_log(TEST_NAME);
-        let (collection, input, mut parent) = example(&logctx.log, TEST_NAME);
-
-        // We should fail if the parent blueprint claims to contain two
-        // zones with the same external IP. Skim through the zones, copy the
-        // external IP from one Nexus zone, then assign it to a later Nexus
-        // zone.
-        let mut found_second_nexus_zone = false;
-        let mut nexus_external_ip = None;
-
-        'outer: for zones in parent.blueprint_zones.values_mut() {
-            for z in zones.zones.iter_mut() {
-                if let BlueprintZoneType::Nexus(blueprint_zone_type::Nexus {
-                    external_ip,
-                    ..
-                }) = &mut z.zone_type
-                {
-                    if let Some(ip) = nexus_external_ip {
-                        *external_ip = ip;
-                        found_second_nexus_zone = true;
-                        break 'outer;
-                    } else {
-                        nexus_external_ip = Some(*external_ip);
-                        continue 'outer;
-                    }
-                }
-            }
-        }
-        assert!(found_second_nexus_zone, "only one Nexus zone present?");
-
-        let mut builder = BlueprintBuilder::new_based_on(
-            &logctx.log,
-            &parent,
-            &input,
-            &collection,
-            "test",
-        )
-        .expect("created builder");
-
-        match builder.external_networking() {
-            Ok(_) => panic!("unexpected success"),
-            Err(err) => {
-                let err = InlineErrorChain::new(&err).to_string();
-                assert!(
-                    err.contains("duplicate external IP"),
-                    "unexpected error: {err}"
-                );
-            }
-        };
-
-        logctx.cleanup_successful();
-    }
-
-    #[test]
-    fn test_invalid_parent_blueprint_two_nexus_zones_with_same_nic_ip() {
-        static TEST_NAME: &str =
-            "blueprint_builder_test_invalid_parent_blueprint_\
-             two_nexus_zones_with_same_nic_ip";
-        let logctx = test_setup_log(TEST_NAME);
-        let (collection, input, mut parent) = example(&logctx.log, TEST_NAME);
-
-        // We should fail if the parent blueprint claims to contain two
-        // Nexus zones with the same NIC IP. Skim through the zones, copy
-        // the NIC IP from one Nexus zone, then assign it to a later
-        // Nexus zone.
-        let mut found_second_nexus_zone = false;
-        let mut nexus_nic_ip = None;
-
-        'outer: for zones in parent.blueprint_zones.values_mut() {
-            for z in zones.zones.iter_mut() {
-                if let BlueprintZoneType::Nexus(blueprint_zone_type::Nexus {
-                    nic,
-                    ..
-                }) = &mut z.zone_type
-                {
-                    if let Some(ip) = nexus_nic_ip {
-                        nic.ip = ip;
-                        found_second_nexus_zone = true;
-                        break 'outer;
-                    } else {
-                        nexus_nic_ip = Some(nic.ip);
-                        continue 'outer;
-                    }
-                }
-            }
-        }
-        assert!(found_second_nexus_zone, "only one Nexus zone present?");
-
-        let mut builder = BlueprintBuilder::new_based_on(
-            &logctx.log,
-            &parent,
-            &input,
-            &collection,
-            "test",
-        )
-        .expect("created builder");
-
-        match builder.external_networking() {
-            Ok(_) => panic!("unexpected success"),
-            Err(err) => {
-                let err = InlineErrorChain::new(&err).to_string();
-                assert!(
-                    err.contains("duplicate Nexus NIC IP"),
-                    "unexpected error: {err}"
-                );
-            }
-        };
-
-        logctx.cleanup_successful();
-    }
-
-    #[test]
-    fn test_invalid_parent_blueprint_two_zones_with_same_vnic_mac() {
-        static TEST_NAME: &str =
-            "blueprint_builder_test_invalid_parent_blueprint_\
-             two_zones_with_same_vnic_mac";
-        let logctx = test_setup_log(TEST_NAME);
-        let (collection, input, mut parent) = example(&logctx.log, TEST_NAME);
-
-        // We should fail if the parent blueprint claims to contain two
-        // zones with the same service vNIC MAC address. Skim through the
-        // zones, copy the NIC MAC from one Nexus zone, then assign it to a
-        // later Nexus zone.
-        let mut found_second_nexus_zone = false;
-        let mut nexus_nic_mac = None;
-
-        'outer: for zones in parent.blueprint_zones.values_mut() {
-            for z in zones.zones.iter_mut() {
-                if let BlueprintZoneType::Nexus(blueprint_zone_type::Nexus {
-                    nic,
-                    ..
-                }) = &mut z.zone_type
-                {
-                    if let Some(mac) = nexus_nic_mac {
-                        nic.mac = mac;
-                        found_second_nexus_zone = true;
-                        break 'outer;
-                    } else {
-                        nexus_nic_mac = Some(nic.mac);
-                        continue 'outer;
-                    }
-                }
-            }
-        }
-        assert!(found_second_nexus_zone, "only one Nexus zone present?");
-
-        let mut builder = BlueprintBuilder::new_based_on(
-            &logctx.log,
-            &parent,
-            &input,
-            &collection,
-            "test",
-        )
-        .expect("created builder");
-
-        match builder.external_networking() {
-            Ok(_) => panic!("unexpected success"),
-            Err(err) => {
-                let err = InlineErrorChain::new(&err).to_string();
-                assert!(
-                    err.contains("duplicate service vNIC MAC"),
-                    "unexpected error: {err}"
-                );
-            }
-        };
 
         logctx.cleanup_successful();
     }

--- a/nexus/reconfigurator/planning/src/blueprint_builder/external_networking.rs
+++ b/nexus/reconfigurator/planning/src/blueprint_builder/external_networking.rs
@@ -592,14 +592,14 @@ impl<T: Hash + Eq> Iterator for AvailableIterator<'_, T> {
 // This struct keeps track of both kinds of IPs used by blueprints, allowing
 // allocation of either kind.
 #[derive(Debug)]
-struct ExternalIpAllocator<'a> {
+pub(super) struct ExternalIpAllocator<'a> {
     service_ip_pool_ips: DebugIgnore<Box<dyn Iterator<Item = IpAddr> + 'a>>,
     used_exclusive_ips: BTreeSet<IpAddr>,
     used_snat_ips: BTreeMap<IpAddr, BTreeSet<SnatPortRange>>,
 }
 
 #[derive(Debug, thiserror::Error)]
-enum ExternalIpAllocatorError {
+pub(super) enum ExternalIpAllocatorError {
     #[error("duplicate external IP: {0:?}")]
     DuplicateExternalIp(OmicronZoneExternalIp),
     #[error("invalid SNAT port range")]
@@ -607,7 +607,7 @@ enum ExternalIpAllocatorError {
 }
 
 impl<'a> ExternalIpAllocator<'a> {
-    fn new(service_pool_ranges: &'a [IpRange]) -> Self {
+    pub fn new(service_pool_ranges: &'a [IpRange]) -> Self {
         let service_ip_pool_ips =
             service_pool_ranges.iter().flat_map(|r| r.iter());
         Self {
@@ -617,7 +617,7 @@ impl<'a> ExternalIpAllocator<'a> {
         }
     }
 
-    fn mark_ip_used(
+    pub fn mark_ip_used(
         &mut self,
         external_ip: &OmicronZoneExternalIp,
     ) -> Result<(), ExternalIpAllocatorError> {


### PR DESCRIPTION
Fixes #7049; see it for context.