### PR TITLE
Add and use built-in users for OMDB

### DIFF
--- a/dev-tools/omdb/src/bin/omdb/nexus.rs
+++ b/dev-tools/omdb/src/bin/omdb/nexus.rs
@@ -2743,7 +2743,12 @@ async fn cmd_nexus_sled_expunge_with_datastore(
     //    most recent inventory collection
     use nexus_db_queries::context::OpContext;
 
-    let opctx = OpContext::for_tests(log.clone(), datastore.clone());
+    let opctx = OpContext::for_background(
+        log.clone(),
+        Arc::new(nexus_db_queries::authz::Authz::new(log)),
+        nexus_db_queries::authn::Context::omdb_user(),
+        datastore.clone(),
+    );
     let opctx = &opctx;
 
     // First, we need to look up the sled so we know its serial number.
@@ -2846,7 +2851,12 @@ async fn cmd_nexus_sled_expunge_disk_with_datastore(
 ) -> Result<(), anyhow::Error> {
     use nexus_db_queries::context::OpContext;
 
-    let opctx = OpContext::for_tests(log.clone(), datastore.clone());
+    let opctx = OpContext::for_background(
+        log.clone(),
+        Arc::new(nexus_db_queries::authz::Authz::new(log)),
+        nexus_db_queries::authn::Context::omdb_user(),
+        datastore.clone(),
+    );
     let opctx = &opctx;
 
     // First, we need to look up the disk so we can lookup identity information.

--- a/nexus/auth/src/authn/mod.rs
+++ b/nexus/auth/src/authn/mod.rs
@@ -34,6 +34,8 @@ pub use nexus_db_fixed_data::user_builtin::USER_DB_INIT;
 pub use nexus_db_fixed_data::user_builtin::USER_EXTERNAL_AUTHN;
 pub use nexus_db_fixed_data::user_builtin::USER_INTERNAL_API;
 pub use nexus_db_fixed_data::user_builtin::USER_INTERNAL_READ;
+pub use nexus_db_fixed_data::user_builtin::USER_OMDB;
+pub use nexus_db_fixed_data::user_builtin::USER_OMDB_READ;
 pub use nexus_db_fixed_data::user_builtin::USER_SAGA_RECOVERY;
 pub use nexus_db_fixed_data::user_builtin::USER_SERVICE_BALANCER;
 
@@ -171,6 +173,16 @@ impl Context {
         Context::context_for_builtin_user(USER_INTERNAL_READ.id)
     }
 
+    /// Returns an authenticated context for use by the debugger
+    pub fn omdb_user() -> Context {
+        Context::context_for_builtin_user(USER_OMDB.id)
+    }
+
+    /// Returns an authenticated context for use by the debugger (read-only)
+    pub fn omdb_read() -> Context {
+        Context::context_for_builtin_user(USER_OMDB_READ.id)
+    }
+
     /// Returns an authenticated context for use for authenticating external
     /// requests
     pub fn external_authn() -> Context {
@@ -284,6 +296,8 @@ mod test {
     use super::USER_DB_INIT;
     use super::USER_INTERNAL_API;
     use super::USER_INTERNAL_READ;
+    use super::USER_OMDB;
+    use super::USER_OMDB_READ;
     use super::USER_SAGA_RECOVERY;
     use super::USER_SERVICE_BALANCER;
     use super::USER_TEST_PRIVILEGED;
@@ -311,6 +325,14 @@ mod test {
         let authn = Context::internal_read();
         let actor = authn.actor().unwrap();
         assert_eq!(actor.actor_id(), USER_INTERNAL_READ.id);
+
+        let authn = Context::omdb_user();
+        let actor = authn.actor().unwrap();
+        assert_eq!(actor.actor_id(), USER_OMDB.id);
+
+        let authn = Context::omdb_read();
+        let actor = authn.actor().unwrap();
+        assert_eq!(actor.actor_id(), USER_OMDB_READ.id);
 
         let authn = Context::external_authn();
         let actor = authn.actor().unwrap();

--- a/nexus/auth/src/authz/actor.rs
+++ b/nexus/auth/src/authz/actor.rs
@@ -122,6 +122,15 @@ impl oso::PolarClass for AuthenticatedActor {
                 },
                 "USER_INTERNAL_API",
             )
+            .add_constant(
+                AuthenticatedActor {
+                    actor_id: authn::USER_OMDB.id,
+                    silo_id: None,
+                    roles: RoleSet::new(),
+                    silo_policy: None,
+                },
+                "USER_OMDB",
+            )
             .add_attribute_getter("silo", |a: &AuthenticatedActor| {
                 a.silo_id.map(|silo_id| {
                     super::Silo::new(

--- a/nexus/auth/src/authz/omicron.polar
+++ b/nexus/auth/src/authz/omicron.polar
@@ -579,3 +579,6 @@ has_role(USER_DB_INIT: AuthenticatedActor, "admin", _silo: Silo);
 
 # Allow the internal API admin permissions on all silos.
 has_role(USER_INTERNAL_API: AuthenticatedActor, "admin", _silo: Silo);
+
+# Allow the debugger API admin permissions on all silos.
+has_role(USER_OMDB: AuthenticatedActor, "admin", _silo: Silo);

--- a/nexus/db-fixed-data/src/role_assignment.rs
+++ b/nexus/db-fixed-data/src/role_assignment.rs
@@ -48,6 +48,26 @@ pub static BUILTIN_ROLE_ASSIGNMENTS: Lazy<Vec<RoleAssignment>> =
                 *FLEET_ID,
                 role_builtin::FLEET_VIEWER.role_name,
             ),
+            // The OMDB user gets the "admin" role on the Fleet.
+            // This is needed to access siloed resources from all silos instead
+            // of reimplementing authenticated queries specifically for OMDB's use
+            RoleAssignment::new(
+                IdentityType::UserBuiltin,
+                user_builtin::USER_OMDB.id,
+                role_builtin::FLEET_ADMIN.resource_type,
+                *FLEET_ID,
+                role_builtin::FLEET_ADMIN.role_name,
+            ),
+            // The "USER_OMDB_READ" user gets the "viewer" role on the fleet. This is
+            // needed as a user separate from the read-write OMDB to avoid destructive
+            // actions unless forced to.
+            RoleAssignment::new(
+                IdentityType::UserBuiltin,
+                user_builtin::USER_OMDB_READ.id,
+                role_builtin::FLEET_VIEWER.resource_type,
+                *FLEET_ID,
+                role_builtin::FLEET_VIEWER.role_name,
+            ),
             // The "external-authenticator" user gets the "authenticator" role
             // on the sole fleet.  This grants them the ability to create
             // sessions.

--- a/nexus/db-fixed-data/src/user_builtin.rs
+++ b/nexus/db-fixed-data/src/user_builtin.rs
@@ -68,6 +68,24 @@ pub static USER_INTERNAL_READ: Lazy<UserBuiltinConfig> = Lazy::new(|| {
     )
 });
 
+/// Internal user used by OMDB
+pub static USER_OMDB: Lazy<UserBuiltinConfig> = Lazy::new(|| {
+    UserBuiltinConfig::new_static(
+        "001de000-05e4-4000-8000-0000000009db",
+        "omdb-user",
+        "used by OMDB",
+    )
+});
+
+/// Internal user used by OMDB to read privileged resources
+pub static USER_OMDB_READ: Lazy<UserBuiltinConfig> = Lazy::new(|| {
+    UserBuiltinConfig::new_static(
+        "001de000-05e4-4000-8000-0000000003db",
+        "omdb-read",
+        "used by OMDB",
+    )
+});
+
 /// Internal user used by Nexus when recovering sagas
 pub static USER_SAGA_RECOVERY: Lazy<UserBuiltinConfig> = Lazy::new(|| {
     UserBuiltinConfig::new_static(
@@ -94,6 +112,8 @@ mod test {
     use super::USER_EXTERNAL_AUTHN;
     use super::USER_INTERNAL_API;
     use super::USER_INTERNAL_READ;
+    use super::USER_OMDB;
+    use super::USER_OMDB_READ;
     use super::USER_SAGA_RECOVERY;
     use super::USER_SERVICE_BALANCER;
 
@@ -104,6 +124,8 @@ mod test {
         assert_valid_uuid(&USER_INTERNAL_API.id);
         assert_valid_uuid(&USER_EXTERNAL_AUTHN.id);
         assert_valid_uuid(&USER_INTERNAL_READ.id);
+        assert_valid_uuid(&USER_OMDB.id);
+        assert_valid_uuid(&USER_OMDB_READ.id);
         assert_valid_uuid(&USER_SAGA_RECOVERY.id);
     }
 }

--- a/nexus/db-queries/src/db/datastore/mod.rs
+++ b/nexus/db-queries/src/db/datastore/mod.rs
@@ -328,7 +328,7 @@ impl DataStore {
     }
 
     /// Returns a connection to a connection from the database connection pool.
-    pub(super) async fn pool_connection_authorized(
+    pub async fn pool_connection_authorized(
         &self,
         opctx: &OpContext,
     ) -> Result<DataStoreConnection, Error> {

--- a/nexus/db-queries/src/db/datastore/silo_user.rs
+++ b/nexus/db-queries/src/db/datastore/silo_user.rs
@@ -366,6 +366,8 @@ impl DataStore {
             &authn::USER_SERVICE_BALANCER,
             &authn::USER_INTERNAL_API,
             &authn::USER_INTERNAL_READ,
+            &authn::USER_OMDB,
+            &authn::USER_OMDB_READ,
             &authn::USER_EXTERNAL_AUTHN,
             &authn::USER_SAGA_RECOVERY,
         ]

--- a/nexus/tests/integration_tests/users_builtin.rs
+++ b/nexus/tests/integration_tests/users_builtin.rs
@@ -37,6 +37,10 @@ async fn test_users_builtin(cptestctx: &ControlPlaneTestContext) {
     assert_eq!(u.identity.id, authn::USER_INTERNAL_API.id);
     let u = users.remove(&authn::USER_INTERNAL_READ.name.to_string()).unwrap();
     assert_eq!(u.identity.id, authn::USER_INTERNAL_READ.id);
+    let u = users.remove(&authn::USER_OMDB.name.to_string()).unwrap();
+    assert_eq!(u.identity.id, authn::USER_OMDB.id);
+    let u = users.remove(&authn::USER_OMDB_READ.name.to_string()).unwrap();
+    assert_eq!(u.identity.id, authn::USER_OMDB_READ.id);
     let u = users.remove(&authn::USER_EXTERNAL_AUTHN.name.to_string()).unwrap();
     assert_eq!(u.identity.id, authn::USER_EXTERNAL_AUTHN.id);
     let u = users.remove(&authn::USER_SAGA_RECOVERY.name.to_string()).unwrap();


### PR DESCRIPTION
**[nexus] Create read-write and read-only built-in users for OMDB**
    
As described and suggested in #6600, create two built-in users to
replace the test user for OMDB's purposes. Follows USER_INTERNAL_API and its
read-only counterpart.

---

**[omdb] Use properly authenticated OpContext**
    
Use OMDB-specific users for establishing DB connections and doing DB queries.
Use the read-only user by default, only use the read-write user when the
"--destructive" argument is provided.