### PR TITLE
Document IDP key format requirement

### DIFF
--- a/nexus/types/src/external_api/params.rs
+++ b/nexus/types/src/external_api/params.rs
@@ -584,7 +584,7 @@ pub struct DerEncodedKeyPair {
     #[serde(deserialize_with = "x509_cert_from_base64_encoded_der")]
     pub public_cert: String,
 
-    /// request signing private key (base64 encoded der file)
+    /// request signing RSA private key in PKCS#1 format (base64 encoded der file)
     #[serde(deserialize_with = "key_from_base64_encoded_der")]
     pub private_key: String,
 }

--- a/openapi/nexus.json
+++ b/openapi/nexus.json
@@ -13217,7 +13217,7 @@
         "type": "object",
         "properties": {
           "private_key": {
-            "description": "request signing private key (base64 encoded der file)",
+            "description": "request signing RSA private key in PKCS#1 format (base64 encoded der file)",
             "type": "string"
           },
           "public_cert": {


### PR DESCRIPTION
We currently require SAML private keys to be in RSA PKCS#1 format, but do not mention this in our doc string.

Update the doc string to explicitly list the required format.