### PR TITLE
remove unnecessary third-party actions from hakari workflow

### DIFF
--- a/.github/workflows/hakari.yml
+++ b/.github/workflows/hakari.yml
@@ -16,23 +16,14 @@ jobs:
     env:
       RUSTFLAGS: -D warnings
     steps:
-      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4
+      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
         with:
           ref: ${{ github.event.pull_request.head.sha }} # see omicron#4461
-      - uses: actions-rs/toolchain@16499b5e05bf2e26879000db0c1d13f7e13fa3af # v1
-        with:
-          toolchain: stable
       - name: Install cargo-hakari
-        uses: taiki-e/install-action@15d8c416d16bd924ecd41f97bb1a90d2cfa695f4 # v2
-        with:
-          tool: cargo-hakari
+        env:
+          version: 0.9.33
+        run: curl -L "https://github.com/guppy-rs/guppy/releases/download/cargo-hakari-$version/cargo-hakari-$version-x86_64-unknown-linux-gnu.tar.gz" | tar -xzC ~/.cargo/bin
       - name: Check workspace-hack Cargo.toml is up-to-date
-        uses: actions-rs/cargo@844f36862e911db73fe0815f00a4a2602c279505 # v1
-        with:
-          command: hakari
-          args: generate --diff
+        run: cargo hakari generate --diff
       - name: Check all crates depend on workspace-hack
-        uses: actions-rs/cargo@844f36862e911db73fe0815f00a4a2602c279505 # v1
-        with:
-          command: hakari
-          args: manage-deps --dry-run
+        run: cargo hakari manage-deps --dry-run


### PR DESCRIPTION
A relatively significant amount of CI compute time is spent on Renovate updating **taiki-e/install-action** once per week. This action is the documented method of using cargo-hakari in CI.

[install-action](https://github.com/taiki-e/install-action/releases) updates several times per week, but none of these updates significantly change what is occurring; install-action does not directly handle the installation of cargo-hakari, and instead installs cargo-binstall to do it. cargo-binstall directly pulls from the latest GitHub Release for cargo-hakari.

It seems sensible, to me, to replace it with a single line of Bash, with the additional advantage of locking to a given release. cargo-hakari updates as-needed, and we can update the workflow as-needed too. (But if we want to always pull the latest I can write a tool to search for the latest release.)

**actions-rs/toolchain** is redundant here as we have a rust-toolchain.toml, and **actions-rs/cargo** was archived a year ago.