### PR TITLE
Update Crucible to latest

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -693,7 +693,7 @@ dependencies = [
 [[package]]
 name = "bhyve_api"
 version = "0.0.0"
-source = "git+https://github.com/oxidecomputer/propolis?rev=aadc0998c0f07f08ab15a95c006074291734800f#aadc0998c0f07f08ab15a95c006074291734800f"
+source = "git+https://github.com/oxidecomputer/propolis?rev=8f8fbb74662b4e19b643c500d55d2d384a6cee5e#8f8fbb74662b4e19b643c500d55d2d384a6cee5e"
 dependencies = [
  "bhyve_api_sys",
  "libc",
@@ -703,7 +703,7 @@ dependencies = [
 [[package]]
 name = "bhyve_api_sys"
 version = "0.0.0"
-source = "git+https://github.com/oxidecomputer/propolis?rev=aadc0998c0f07f08ab15a95c006074291734800f#aadc0998c0f07f08ab15a95c006074291734800f"
+source = "git+https://github.com/oxidecomputer/propolis?rev=8f8fbb74662b4e19b643c500d55d2d384a6cee5e#8f8fbb74662b4e19b643c500d55d2d384a6cee5e"
 dependencies = [
  "libc",
  "strum",
@@ -1823,7 +1823,7 @@ dependencies = [
 [[package]]
 name = "crucible-client-types"
 version = "0.1.0"
-source = "git+https://github.com/oxidecomputer/crucible?rev=b7b9d5660b28ca5e865242b2bdecd032c0852d40#b7b9d5660b28ca5e865242b2bdecd032c0852d40"
+source = "git+https://github.com/oxidecomputer/crucible?rev=1d82cc9fd9925814d097d39f7cbafd62fb8cfb7e#1d82cc9fd9925814d097d39f7cbafd62fb8cfb7e"
 dependencies = [
  "base64 0.22.1",
  "crucible-workspace-hack",
@@ -6927,7 +6927,7 @@ dependencies = [
  "pq-sys",
  "pretty_assertions",
  "progenitor-client",
- "propolis-client 0.1.0 (git+https://github.com/oxidecomputer/propolis?rev=aadc0998c0f07f08ab15a95c006074291734800f)",
+ "propolis-client 0.1.0 (git+https://github.com/oxidecomputer/propolis?rev=8f8fbb74662b4e19b643c500d55d2d384a6cee5e)",
  "qorb",
  "rand",
  "rcgen",
@@ -7190,7 +7190,7 @@ dependencies = [
  "oximeter-producer",
  "oxnet",
  "pretty_assertions",
- "propolis-client 0.1.0 (git+https://github.com/oxidecomputer/propolis?rev=aadc0998c0f07f08ab15a95c006074291734800f)",
+ "propolis-client 0.1.0 (git+https://github.com/oxidecomputer/propolis?rev=8f8fbb74662b4e19b643c500d55d2d384a6cee5e)",
  "propolis-mock-server",
  "propolis_api_types",
  "rand",
@@ -8899,7 +8899,7 @@ dependencies = [
 [[package]]
 name = "propolis-client"
 version = "0.1.0"
-source = "git+https://github.com/oxidecomputer/propolis?rev=aadc0998c0f07f08ab15a95c006074291734800f#aadc0998c0f07f08ab15a95c006074291734800f"
+source = "git+https://github.com/oxidecomputer/propolis?rev=8f8fbb74662b4e19b643c500d55d2d384a6cee5e#8f8fbb74662b4e19b643c500d55d2d384a6cee5e"
 dependencies = [
  "async-trait",
  "base64 0.21.7",
@@ -8941,7 +8941,7 @@ dependencies = [
 [[package]]
 name = "propolis-mock-server"
 version = "0.0.0"
-source = "git+https://github.com/oxidecomputer/propolis?rev=aadc0998c0f07f08ab15a95c006074291734800f#aadc0998c0f07f08ab15a95c006074291734800f"
+source = "git+https://github.com/oxidecomputer/propolis?rev=8f8fbb74662b4e19b643c500d55d2d384a6cee5e#8f8fbb74662b4e19b643c500d55d2d384a6cee5e"
 dependencies = [
  "anyhow",
  "atty",
@@ -8983,7 +8983,7 @@ dependencies = [
 [[package]]
 name = "propolis_api_types"
 version = "0.0.0"
-source = "git+https://github.com/oxidecomputer/propolis?rev=aadc0998c0f07f08ab15a95c006074291734800f#aadc0998c0f07f08ab15a95c006074291734800f"
+source = "git+https://github.com/oxidecomputer/propolis?rev=8f8fbb74662b4e19b643c500d55d2d384a6cee5e#8f8fbb74662b4e19b643c500d55d2d384a6cee5e"
 dependencies = [
  "crucible-client-types",
  "propolis_types",
@@ -8996,7 +8996,7 @@ dependencies = [
 [[package]]
 name = "propolis_types"
 version = "0.0.0"
-source = "git+https://github.com/oxidecomputer/propolis?rev=aadc0998c0f07f08ab15a95c006074291734800f#aadc0998c0f07f08ab15a95c006074291734800f"
+source = "git+https://github.com/oxidecomputer/propolis?rev=8f8fbb74662b4e19b643c500d55d2d384a6cee5e#8f8fbb74662b4e19b643c500d55d2d384a6cee5e"
 dependencies = [
  "schemars",
  "serde",
@@ -10639,7 +10639,7 @@ dependencies = [
  "omicron-uuid-kinds",
  "omicron-workspace-hack",
  "oxnet",
- "propolis-client 0.1.0 (git+https://github.com/oxidecomputer/propolis?rev=aadc0998c0f07f08ab15a95c006074291734800f)",
+ "propolis-client 0.1.0 (git+https://github.com/oxidecomputer/propolis?rev=8f8fbb74662b4e19b643c500d55d2d384a6cee5e)",
  "rcgen",
  "schemars",
  "serde",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -532,10 +532,10 @@ prettyplease = { version = "0.2.25", features = ["verbatim"] }
 proc-macro2 = "1.0"
 progenitor = "0.8.0"
 progenitor-client = "0.8.0"
-bhyve_api = { git = "https://github.com/oxidecomputer/propolis", rev = "aadc0998c0f07f08ab15a95c006074291734800f" }
-propolis_api_types = { git = "https://github.com/oxidecomputer/propolis", rev = "aadc0998c0f07f08ab15a95c006074291734800f" }
-propolis-client = { git = "https://github.com/oxidecomputer/propolis", rev = "aadc0998c0f07f08ab15a95c006074291734800f" }
-propolis-mock-server = { git = "https://github.com/oxidecomputer/propolis", rev = "aadc0998c0f07f08ab15a95c006074291734800f" }
+bhyve_api = { git = "https://github.com/oxidecomputer/propolis", rev = "8f8fbb74662b4e19b643c500d55d2d384a6cee5e" }
+propolis_api_types = { git = "https://github.com/oxidecomputer/propolis", rev = "8f8fbb74662b4e19b643c500d55d2d384a6cee5e" }
+propolis-client = { git = "https://github.com/oxidecomputer/propolis", rev = "8f8fbb74662b4e19b643c500d55d2d384a6cee5e" }
+propolis-mock-server = { git = "https://github.com/oxidecomputer/propolis", rev = "8f8fbb74662b4e19b643c500d55d2d384a6cee5e" }
 proptest = "1.5.0"
 qorb = "0.2.0"
 quote = "1.0"

--- a/package-manifest.toml
+++ b/package-manifest.toml
@@ -578,10 +578,10 @@ only_for_targets.image = "standard"
 # 3. Use source.type = "manual" instead of "prebuilt"
 source.type = "prebuilt"
 source.repo = "crucible"
-source.commit = "b7b9d5660b28ca5e865242b2bdecd032c0852d40"
+source.commit = "1d82cc9fd9925814d097d39f7cbafd62fb8cfb7e"
 # The SHA256 digest is automatically posted to:
 # https://buildomat.eng.oxide.computer/public/file/oxidecomputer/crucible/image/<commit>/crucible.sha256.txt
-source.sha256 = "44e623730765f8fc0b702d107939552514530a33b306ca5e8bc8276ff0aaf79a"
+source.sha256 = "c66b3f7ef87e17533a3bbf7d0c0c6f01adab031f9acf173399b4a3dda32d097b"
 output.type = "zone"
 output.intermediate_only = true
 
@@ -590,10 +590,10 @@ service_name = "crucible_pantry_prebuilt"
 only_for_targets.image = "standard"
 source.type = "prebuilt"
 source.repo = "crucible"
-source.commit = "b7b9d5660b28ca5e865242b2bdecd032c0852d40"
+source.commit = "1d82cc9fd9925814d097d39f7cbafd62fb8cfb7e"
 # The SHA256 digest is automatically posted to:
 # https://buildomat.eng.oxide.computer/public/file/oxidecomputer/crucible/image/<commit>/crucible-pantry.sha256.txt
-source.sha256 = "bc0a41d349646ec2111bff346db2c300001d646a99f33b05b39b78188e34ae41"
+source.sha256 = "144d9a5846b1fddffbe1fc8c30db44b06934feb6bc726f26ceade43bfc38c2a0"
 output.type = "zone"
 output.intermediate_only = true
 
@@ -607,10 +607,10 @@ service_name = "crucible_dtrace"
 only_for_targets.image = "standard"
 source.type = "prebuilt"
 source.repo = "crucible"
-source.commit = "b7b9d5660b28ca5e865242b2bdecd032c0852d40"
+source.commit = "1d82cc9fd9925814d097d39f7cbafd62fb8cfb7e"
 # The SHA256 digest is automatically posted to:
 # https://buildomat.eng.oxide.computer/public/file/oxidecomputer/crucible/image/<commit>/crucible-dtrace.sha256.txt
-source.sha256 = "64e37f7a062f7c8941fac3b95a81d98475e5c02ff01111554b0ddb7fc232f40f"
+source.sha256 = "f6e304172b4a7af1dbd70d2506889e9364f61c488ff346f525256b3ce1e80eff"
 output.type = "tarball"
 
 # Refer to
@@ -621,10 +621,10 @@ service_name = "propolis-server"
 only_for_targets.image = "standard"
 source.type = "prebuilt"
 source.repo = "propolis"
-source.commit = "aadc0998c0f07f08ab15a95c006074291734800f"
+source.commit = "8f8fbb74662b4e19b643c500d55d2d384a6cee5e"
 # The SHA256 digest is automatically posted to:
 # https://buildomat.eng.oxide.computer/public/file/oxidecomputer/propolis/image/<commit>/propolis-server.sha256.txt
-source.sha256 = "3cd889201aaa8cc5b916fc8f8176ab5529e2fc1d5d57165ad9a660eb48affef9"
+source.sha256 = "5dc0c116d2463d17a64a91941bc3e664746ce0c4b7cf54c73ae72e410fba0757"
 output.type = "zone"
 
 [package.mg-ddm-gz]


### PR DESCRIPTION
No Propolis changes other than to update Crucible

Crucible changes are:
Add debug/timeout to test_memory.sh (#1563)
Consolidate ack checking (#1561)
Rename for crutest: RegionInfo -> DiskInfo (#1562) Fix dtrace system level scripts (#1560)
Remove `ackable_work`; ack immediately instead (#1552) No more New jobs, no more New jobs column (#1559)
Remove delay-based backpressure in favor of explicit queue limits (#1515) Only send flushes when Downstairs is idle; send Barrier otherwise (#1505) Update Rust crate reqwest to v0.12.9 (#1536)
Update Rust crate omicron-zone-package to 0.11.1 (#1535) Remove separate validation array (#1522)
Remove more unnecessary `DsState` variants (#1550) Consolidate `DownstairsClient::reinitialize` (#1549) Update Rust crate uuid to v1.11.0 (#1546)
Update Rust crate reedline to 0.36.0 (#1544)
Update Rust crate bytes to v1.8.0 (#1541)
Update Rust crate thiserror to v1.0.66 (#1539)
Update Rust crate serde_json to v1.0.132 (#1538)
Update Rust crate serde to v1.0.214 (#1537)
Remove transient states in `DsState` (#1526)
Update Rust crate libc to v0.2.161 (#1534)
Update Rust crate futures to v0.3.31 (#1532)
Update Rust crate clap to v4.5.20 (#1531)
Update Rust crate async-trait to 0.1.83 (#1530)
Update Rust crate anyhow to v1.0.92 (#1529)
Remove obsolete crutest perf test (#1528)
Update dependency rust to v1.82.0 (#1512)
Still more updates to support Volume layer activities. (#1508) Remove remaining IOPS/bandwidth limiting code (#1525) Add unit test for VersionMismatch (#1524)
Removing panic paths by only destructuring once (#1523) Update actions/checkout digest to 11bd719 (#1518)
Switch to using `Duration` for times (#1520)