### PR TITLE
[reconfigurator] `BlueprintBuilder` cleanup 2/5 - move `BlueprintDatasetsEditor` to its own module

### DIFF
--- a/common/src/disk.rs
+++ b/common/src/disk.rs
@@ -107,7 +107,8 @@ impl DatasetName {
         &self.pool_name
     }
 
-    // TODO: Maybe rename this to "kind"?
+    // TODO(https://github.com/oxidecomputer/omicron/issues/7115): Rename
+    // this to "kind?
     pub fn dataset(&self) -> &DatasetKind {
         &self.kind
     }

--- a/dev-tools/reconfigurator-cli/tests/output/cmd-example-stdout
+++ b/dev-tools/reconfigurator-cli/tests/output/cmd-example-stdout
@@ -221,15 +221,15 @@ to:   blueprint  ade5749d-bdf3-4fab-a8ae-00bea01b3a5a
     fake-vendor   fake-model   serial-d792c8cb-7490-40cb-bb1c-d4917242edf4
 
 
-    datasets at generation 1:
+    datasets at generation 2:
     -----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
     dataset name                                                                                                   dataset uuid                           quota     reservation   compression
     -----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
     oxp_088ed702-551e-453b-80d7-57700372a844/crucible                                                              10eea692-add6-4430-ba17-2c9ca58082b5   none      none          off        
     oxp_088ed702-551e-453b-80d7-57700372a844/crypt/clickhouse                                                      e5ed5cac-9580-4016-84c2-dc6b8464b9ce   none      none          off        
-    oxp_088ed702-551e-453b-80d7-57700372a844/crypt/debug                                                           6fb8df45-63f4-4f51-972a-29904a575c6e   100 GiB   none          gzip-9     
+    oxp_088ed702-551e-453b-80d7-57700372a844/crypt/debug                                                           dbf4924f-cdb3-4d1c-8e32-5c566c3e4a98   100 GiB   none          gzip-9     
     oxp_088ed702-551e-453b-80d7-57700372a844/crypt/internal_dns                                                    64053399-514e-4e01-822c-e81e7187ef64   none      none          off        
-    oxp_088ed702-551e-453b-80d7-57700372a844/crypt/zone                                                            9e68dbfc-4ccb-4bff-ba97-5d81425fc584   none      none          off        
+    oxp_088ed702-551e-453b-80d7-57700372a844/crypt/zone                                                            70c3efb9-1f72-42d4-a0e1-c8c573c833af   none      none          off        
     oxp_088ed702-551e-453b-80d7-57700372a844/crypt/zone/oxz_clickhouse_fe79023f-c5d5-4be5-ad2c-da4e9e9237e4        ac51a283-2d5d-4b96-a922-9688cd489315   none      none          off        
     oxp_088ed702-551e-453b-80d7-57700372a844/crypt/zone/oxz_crucible_f97aa057-6485-45d0-9cb4-4af5b0831d48          e4ef7aab-4a43-4ce0-a5cf-1436735ee712   none      none          off        
     oxp_088ed702-551e-453b-80d7-57700372a844/crypt/zone/oxz_crucible_pantry_eaec16c0-0d44-4847-b2d6-31a5151bae52   02df7e3b-b094-4c0e-9292-2e874ea8382c   none      none          off        
@@ -237,40 +237,40 @@ to:   blueprint  ade5749d-bdf3-4fab-a8ae-00bea01b3a5a
     oxp_088ed702-551e-453b-80d7-57700372a844/crypt/zone/oxz_nexus_94b45ce9-d3d8-413a-a76b-865da1f67930             a892e4f7-1893-44b1-92bd-bbc080850c9e   none      none          off        
     oxp_088ed702-551e-453b-80d7-57700372a844/crypt/zone/oxz_ntp_c67dd9a4-0d6c-4e9f-b28d-20003f211f7d               701c81e2-41fa-490a-aa2e-0387aeb210ed   none      none          off        
     oxp_09e51697-abad-47c0-a193-eaf74bc5d3cd/crucible                                                              9edffe2a-5df5-4f42-9421-82ba7c9416ab   none      none          off        
-    oxp_09e51697-abad-47c0-a193-eaf74bc5d3cd/crypt/debug                                                           63433fe0-87aa-4189-ad00-72bfa9923d28   100 GiB   none          gzip-9     
-    oxp_09e51697-abad-47c0-a193-eaf74bc5d3cd/crypt/zone                                                            2a69ae17-3329-429e-b99b-e4d607451490   none      none          off        
+    oxp_09e51697-abad-47c0-a193-eaf74bc5d3cd/crypt/debug                                                           6735caf5-1dd2-464b-93e2-f9080f9ff58d   100 GiB   none          gzip-9     
+    oxp_09e51697-abad-47c0-a193-eaf74bc5d3cd/crypt/zone                                                            76f5cbd5-9e1f-4ccb-b4a8-65cc8bcc4afc   none      none          off        
     oxp_09e51697-abad-47c0-a193-eaf74bc5d3cd/crypt/zone/oxz_crucible_054f64a5-182c-4c28-8994-d2e082550201          31c95682-7bae-4182-8e43-54c403a2a35c   none      none          off        
     oxp_3a512d49-edbe-47f3-8d0b-6051bfdc4044/crucible                                                              8fac3fae-eadc-4391-ba80-2f3b8d6cb708   none      none          off        
-    oxp_3a512d49-edbe-47f3-8d0b-6051bfdc4044/crypt/debug                                                           476cb7b1-06a2-4abc-9b59-157eba6b4fa9   100 GiB   none          gzip-9     
-    oxp_3a512d49-edbe-47f3-8d0b-6051bfdc4044/crypt/zone                                                            290f96c3-031b-496c-937d-9b157ecdc0fb   none      none          off        
+    oxp_3a512d49-edbe-47f3-8d0b-6051bfdc4044/crypt/debug                                                           63433fe0-87aa-4189-ad00-72bfa9923d28   100 GiB   none          gzip-9     
+    oxp_3a512d49-edbe-47f3-8d0b-6051bfdc4044/crypt/zone                                                            2a69ae17-3329-429e-b99b-e4d607451490   none      none          off        
     oxp_3a512d49-edbe-47f3-8d0b-6051bfdc4044/crypt/zone/oxz_crucible_3b5bffea-e5ed-44df-8468-fd4fa69757d8          9df6db90-95c6-45bc-aba7-70bb72d87c7c   none      none          off        
     oxp_40517680-aa77-413c-bcf4-b9041dcf6612/crucible                                                              fec44f34-a838-4a3d-9fa2-70133f3db3a1   none      none          off        
-    oxp_40517680-aa77-413c-bcf4-b9041dcf6612/crypt/debug                                                           cf3dc221-a35a-4f16-935f-635cb87dc399   100 GiB   none          gzip-9     
-    oxp_40517680-aa77-413c-bcf4-b9041dcf6612/crypt/zone                                                            751bad28-e0f5-494e-91c1-432ded709c2f   none      none          off        
+    oxp_40517680-aa77-413c-bcf4-b9041dcf6612/crypt/debug                                                           476cb7b1-06a2-4abc-9b59-157eba6b4fa9   100 GiB   none          gzip-9     
+    oxp_40517680-aa77-413c-bcf4-b9041dcf6612/crypt/zone                                                            290f96c3-031b-496c-937d-9b157ecdc0fb   none      none          off        
     oxp_40517680-aa77-413c-bcf4-b9041dcf6612/crypt/zone/oxz_crucible_bc095417-e2f0-4e95-b390-9cc3fc6e3c6d          6169ada0-c238-44e8-a67b-d50eecb419ea   none      none          off        
     oxp_78d3cb96-9295-4644-bf78-2e32191c71f9/crucible                                                              8d4092ca-d9fd-4fa3-9d12-a44f638fccc6   none      none          off        
-    oxp_78d3cb96-9295-4644-bf78-2e32191c71f9/crypt/debug                                                           dbdb5ae6-9064-427f-850f-8c45d07c6af4   100 GiB   none          gzip-9     
-    oxp_78d3cb96-9295-4644-bf78-2e32191c71f9/crypt/zone                                                            90efb135-dded-4acf-81b5-9ee75669b1d8   none      none          off        
+    oxp_78d3cb96-9295-4644-bf78-2e32191c71f9/crypt/debug                                                           32713f0b-b162-4e23-bd9e-2cc4b208f98f   100 GiB   none          gzip-9     
+    oxp_78d3cb96-9295-4644-bf78-2e32191c71f9/crypt/zone                                                            b9360096-7b96-450b-b6d8-33fc06dd3f07   none      none          off        
     oxp_78d3cb96-9295-4644-bf78-2e32191c71f9/crypt/zone/oxz_crucible_95ad9a1d-4063-4874-974c-2fc92830be27          923c27c2-0687-4799-9cba-a439e5c56854   none      none          off        
     oxp_853595e7-77da-404e-bc35-aba77478d55c/crucible                                                              8bf51c09-0d33-42d9-9ac0-2761d2f84378   none      none          off        
-    oxp_853595e7-77da-404e-bc35-aba77478d55c/crypt/debug                                                           32713f0b-b162-4e23-bd9e-2cc4b208f98f   100 GiB   none          gzip-9     
-    oxp_853595e7-77da-404e-bc35-aba77478d55c/crypt/zone                                                            b9360096-7b96-450b-b6d8-33fc06dd3f07   none      none          off        
+    oxp_853595e7-77da-404e-bc35-aba77478d55c/crypt/debug                                                           dbdb5ae6-9064-427f-850f-8c45d07c6af4   100 GiB   none          gzip-9     
+    oxp_853595e7-77da-404e-bc35-aba77478d55c/crypt/zone                                                            90efb135-dded-4acf-81b5-9ee75669b1d8   none      none          off        
     oxp_853595e7-77da-404e-bc35-aba77478d55c/crypt/zone/oxz_crucible_53dd7fa4-899e-49ed-9fc2-48222db3e20d          5475d130-9244-4e3b-8e21-bc3233bc3074   none      none          off        
     oxp_8926e0e7-65d9-4e2e-ac6d-f1298af81ef1/crucible                                                              fe743e12-6be9-48c6-a1e8-c129f00b43d9   none      none          off        
-    oxp_8926e0e7-65d9-4e2e-ac6d-f1298af81ef1/crypt/debug                                                           dbf4924f-cdb3-4d1c-8e32-5c566c3e4a98   100 GiB   none          gzip-9     
-    oxp_8926e0e7-65d9-4e2e-ac6d-f1298af81ef1/crypt/zone                                                            70c3efb9-1f72-42d4-a0e1-c8c573c833af   none      none          off        
+    oxp_8926e0e7-65d9-4e2e-ac6d-f1298af81ef1/crypt/debug                                                           6fb8df45-63f4-4f51-972a-29904a575c6e   100 GiB   none          gzip-9     
+    oxp_8926e0e7-65d9-4e2e-ac6d-f1298af81ef1/crypt/zone                                                            9e68dbfc-4ccb-4bff-ba97-5d81425fc584   none      none          off        
     oxp_8926e0e7-65d9-4e2e-ac6d-f1298af81ef1/crypt/zone/oxz_crucible_d90401f1-fbc2-42cb-bf17-309ee0f922fe          2db8cea6-9af5-4b9f-8db1-d59006b8fca6   none      none          off        
     oxp_9c0b9151-17f3-4857-94cc-b5bfcd402326/crucible                                                              b4a8e70b-dfe8-4392-9518-8fe6dd952b94   none      none          off        
-    oxp_9c0b9151-17f3-4857-94cc-b5bfcd402326/crypt/debug                                                           abab81af-ef4d-4832-862d-1760b2fe6e65   100 GiB   none          gzip-9     
-    oxp_9c0b9151-17f3-4857-94cc-b5bfcd402326/crypt/zone                                                            f7dee56f-2cb0-470c-8fba-8c60c56d6bb9   none      none          off        
+    oxp_9c0b9151-17f3-4857-94cc-b5bfcd402326/crypt/debug                                                           cf3dc221-a35a-4f16-935f-635cb87dc399   100 GiB   none          gzip-9     
+    oxp_9c0b9151-17f3-4857-94cc-b5bfcd402326/crypt/zone                                                            751bad28-e0f5-494e-91c1-432ded709c2f   none      none          off        
     oxp_9c0b9151-17f3-4857-94cc-b5bfcd402326/crypt/zone/oxz_crucible_7db307d4-a6ed-4c47-bddf-6759161bf64a          3c5a1b55-b719-4c61-9865-46aeb8736164   none      none          off        
     oxp_d61354fa-48d2-47c6-90bf-546e3ed1708b/crucible                                                              ff0d3669-e237-4797-854b-dcb51d6c289d   none      none          off        
-    oxp_d61354fa-48d2-47c6-90bf-546e3ed1708b/crypt/debug                                                           6735caf5-1dd2-464b-93e2-f9080f9ff58d   100 GiB   none          gzip-9     
-    oxp_d61354fa-48d2-47c6-90bf-546e3ed1708b/crypt/zone                                                            76f5cbd5-9e1f-4ccb-b4a8-65cc8bcc4afc   none      none          off        
+    oxp_d61354fa-48d2-47c6-90bf-546e3ed1708b/crypt/debug                                                           edaad63c-f9ae-4552-8197-2c95d138da93   100 GiB   none          gzip-9     
+    oxp_d61354fa-48d2-47c6-90bf-546e3ed1708b/crypt/zone                                                            bc098466-0717-42ce-9c42-5da3b5c8de4a   none      none          off        
     oxp_d61354fa-48d2-47c6-90bf-546e3ed1708b/crypt/zone/oxz_crucible_e8f994c0-0a1b-40e6-8db1-40a8ca89e503          25e14454-4215-46a2-9c24-50aed0d1b131   none      none          off        
     oxp_d792c8cb-7490-40cb-bb1c-d4917242edf4/crucible                                                              cfa8cf24-8dc1-43c8-bf88-3e8d4b058f7a   none      none          off        
-    oxp_d792c8cb-7490-40cb-bb1c-d4917242edf4/crypt/debug                                                           edaad63c-f9ae-4552-8197-2c95d138da93   100 GiB   none          gzip-9     
-    oxp_d792c8cb-7490-40cb-bb1c-d4917242edf4/crypt/zone                                                            bc098466-0717-42ce-9c42-5da3b5c8de4a   none      none          off        
+    oxp_d792c8cb-7490-40cb-bb1c-d4917242edf4/crypt/debug                                                           abab81af-ef4d-4832-862d-1760b2fe6e65   100 GiB   none          gzip-9     
+    oxp_d792c8cb-7490-40cb-bb1c-d4917242edf4/crypt/zone                                                            f7dee56f-2cb0-470c-8fba-8c60c56d6bb9   none      none          off        
     oxp_d792c8cb-7490-40cb-bb1c-d4917242edf4/crypt/zone/oxz_crucible_e9bf481e-323e-466e-842f-8107078c7137          d81cd9b7-7df5-4cb5-86d1-126a9a700fb8   none      none          off        
 
 
@@ -313,54 +313,54 @@ to:   blueprint  ade5749d-bdf3-4fab-a8ae-00bea01b3a5a
     fake-vendor   fake-model   serial-d7410a1c-e01d-49a4-be9c-f861f086760a
 
 
-    datasets at generation 1:
+    datasets at generation 2:
     -----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
     dataset name                                                                                                   dataset uuid                           quota     reservation   compression
     -----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
     oxp_128b0f04-229b-48dc-9c5c-555cb5723ed8/crucible                                                              dddf5d66-838c-4253-a42f-075c8e264bf1   none      none          off        
-    oxp_128b0f04-229b-48dc-9c5c-555cb5723ed8/crypt/debug                                                           ea2cc4fe-93ce-437e-9a1f-1d203bca8784   100 GiB   none          gzip-9     
+    oxp_128b0f04-229b-48dc-9c5c-555cb5723ed8/crypt/debug                                                           11eedda2-f710-49db-b358-6a763e530643   100 GiB   none          gzip-9     
     oxp_128b0f04-229b-48dc-9c5c-555cb5723ed8/crypt/internal_dns                                                    393388ac-4fbe-4e3b-840f-17afed583ee8   none      none          off        
-    oxp_128b0f04-229b-48dc-9c5c-555cb5723ed8/crypt/zone                                                            2dc77339-9cbf-4d86-89a8-e65a64f35673   none      none          off        
+    oxp_128b0f04-229b-48dc-9c5c-555cb5723ed8/crypt/zone                                                            d1549ccd-d9a8-4899-9dc2-5991ae3e0300   none      none          off        
     oxp_128b0f04-229b-48dc-9c5c-555cb5723ed8/crypt/zone/oxz_crucible_cc1dc86d-bd6f-4929-aa4a-9619012e9393          965c1e70-f075-4dcb-b25a-d856bb44551b   none      none          off        
     oxp_128b0f04-229b-48dc-9c5c-555cb5723ed8/crypt/zone/oxz_crucible_pantry_728db429-8621-4e1e-9915-282aadfa27d1   d2434e6c-1c0d-4443-a756-db277c0fd684   none      none          off        
     oxp_128b0f04-229b-48dc-9c5c-555cb5723ed8/crypt/zone/oxz_internal_dns_e7dd3e98-7fe7-4827-be7f-395ff9a5f542      5da5c7e8-b603-4eb9-acc2-3e137e9c9b8f   none      none          off        
     oxp_128b0f04-229b-48dc-9c5c-555cb5723ed8/crypt/zone/oxz_nexus_c8aa84a5-a802-46c9-adcd-d61e9c8393c9             cfff8484-c5a9-4430-a46d-92e62577b3bb   none      none          off        
     oxp_128b0f04-229b-48dc-9c5c-555cb5723ed8/crypt/zone/oxz_ntp_4f2eb088-7d28-4c4e-a27c-746400ec65ba               ebf8caa8-c75d-4318-9759-41dea4572e8b   none      none          off        
     oxp_43ae0f4e-b0cf-4d74-8636-df0567ba01e6/crucible                                                              4b6e313b-839a-405f-b7b2-c85456f77d6e   none      none          off        
-    oxp_43ae0f4e-b0cf-4d74-8636-df0567ba01e6/crypt/debug                                                           11eedda2-f710-49db-b358-6a763e530643   100 GiB   none          gzip-9     
-    oxp_43ae0f4e-b0cf-4d74-8636-df0567ba01e6/crypt/zone                                                            d1549ccd-d9a8-4899-9dc2-5991ae3e0300   none      none          off        
+    oxp_43ae0f4e-b0cf-4d74-8636-df0567ba01e6/crypt/debug                                                           1c8bff2b-a7ca-4852-b94b-7cff9026bb2d   100 GiB   none          gzip-9     
+    oxp_43ae0f4e-b0cf-4d74-8636-df0567ba01e6/crypt/zone                                                            82ff9ea6-429c-449a-89d9-c3a42a5ecb06   none      none          off        
     oxp_43ae0f4e-b0cf-4d74-8636-df0567ba01e6/crypt/zone/oxz_crucible_e8971ab3-fb7d-4ad8-aae3-7f2fe87c51f3          6e8c587e-b25b-43d3-b05f-72713da53cd0   none      none          off        
     oxp_4e9806d0-41cd-48c2-86ef-7f815c3ce3b1/crucible                                                              3759d324-78ac-4855-a89f-cdf28d6bff92   none      none          off        
-    oxp_4e9806d0-41cd-48c2-86ef-7f815c3ce3b1/crypt/debug                                                           6a8adc00-8b5a-4135-b20a-c862c509a7d7   100 GiB   none          gzip-9     
-    oxp_4e9806d0-41cd-48c2-86ef-7f815c3ce3b1/crypt/zone                                                            b3de9a5e-01e0-48e6-b032-f53de00285c1   none      none          off        
+    oxp_4e9806d0-41cd-48c2-86ef-7f815c3ce3b1/crypt/debug                                                           523fd0cd-8d22-4f7a-a3b0-3fd0f4f88852   100 GiB   none          gzip-9     
+    oxp_4e9806d0-41cd-48c2-86ef-7f815c3ce3b1/crypt/zone                                                            9e78cb9f-d533-44e5-8641-d6be0fb5868b   none      none          off        
     oxp_4e9806d0-41cd-48c2-86ef-7f815c3ce3b1/crypt/zone/oxz_crucible_a999e5fa-3edc-4dac-919a-d7b554cdae58          f7da941d-47da-40ad-9d21-1a36a83c9d48   none      none          off        
     oxp_70bb6d98-111f-4015-9d97-9ef1b2d6dcac/crucible                                                              9c53961d-4259-4215-a083-669234e4ed33   none      none          off        
-    oxp_70bb6d98-111f-4015-9d97-9ef1b2d6dcac/crypt/debug                                                           c784968a-27ca-40a3-9570-736593bba5ab   100 GiB   none          gzip-9     
-    oxp_70bb6d98-111f-4015-9d97-9ef1b2d6dcac/crypt/zone                                                            609f9bcf-d01e-4d0b-89f6-96e75397b7f6   none      none          off        
+    oxp_70bb6d98-111f-4015-9d97-9ef1b2d6dcac/crypt/debug                                                           6a8adc00-8b5a-4135-b20a-c862c509a7d7   100 GiB   none          gzip-9     
+    oxp_70bb6d98-111f-4015-9d97-9ef1b2d6dcac/crypt/zone                                                            b3de9a5e-01e0-48e6-b032-f53de00285c1   none      none          off        
     oxp_70bb6d98-111f-4015-9d97-9ef1b2d6dcac/crypt/zone/oxz_crucible_b416f299-c23c-46c8-9820-be2b66ffea0a          2de47948-bd82-46b5-8341-f9381d1817cf   none      none          off        
     oxp_7ce5029f-703c-4c08-8164-9af9cf1acf23/crucible                                                              50a7450d-4069-4f18-9d80-de273e801af8   none      none          off        
-    oxp_7ce5029f-703c-4c08-8164-9af9cf1acf23/crypt/debug                                                           71d6b4d8-1204-4f0f-b0e3-f47946fb7a8c   100 GiB   none          gzip-9     
-    oxp_7ce5029f-703c-4c08-8164-9af9cf1acf23/crypt/zone                                                            3e6a4121-1ea9-4361-ad1c-14c7dd945f37   none      none          off        
+    oxp_7ce5029f-703c-4c08-8164-9af9cf1acf23/crypt/debug                                                           c784968a-27ca-40a3-9570-736593bba5ab   100 GiB   none          gzip-9     
+    oxp_7ce5029f-703c-4c08-8164-9af9cf1acf23/crypt/zone                                                            609f9bcf-d01e-4d0b-89f6-96e75397b7f6   none      none          off        
     oxp_7ce5029f-703c-4c08-8164-9af9cf1acf23/crypt/zone/oxz_crucible_fae49024-6cec-444d-a6c4-83658ab015a4          b49a89b5-7aad-4dac-be75-e10960fcb530   none      none          off        
     oxp_b113c11f-44e6-4fb4-a56e-1d91bd652faf/crucible                                                              d4b204bb-9b37-463b-b5d4-fb0573b87988   none      none          off        
-    oxp_b113c11f-44e6-4fb4-a56e-1d91bd652faf/crypt/debug                                                           1c8bff2b-a7ca-4852-b94b-7cff9026bb2d   100 GiB   none          gzip-9     
-    oxp_b113c11f-44e6-4fb4-a56e-1d91bd652faf/crypt/zone                                                            82ff9ea6-429c-449a-89d9-c3a42a5ecb06   none      none          off        
+    oxp_b113c11f-44e6-4fb4-a56e-1d91bd652faf/crypt/debug                                                           71d6b4d8-1204-4f0f-b0e3-f47946fb7a8c   100 GiB   none          gzip-9     
+    oxp_b113c11f-44e6-4fb4-a56e-1d91bd652faf/crypt/zone                                                            3e6a4121-1ea9-4361-ad1c-14c7dd945f37   none      none          off        
     oxp_b113c11f-44e6-4fb4-a56e-1d91bd652faf/crypt/zone/oxz_crucible_cd3bb540-e605-465f-8c62-177ac482d850          eae5919a-5b33-4ec7-bd27-163120ba55a4   none      none          off        
     oxp_bf149c80-2498-481c-9989-6344da914081/crucible                                                              4af3d49c-22c1-4ea5-9992-bdff0467d023   none      none          off        
     oxp_bf149c80-2498-481c-9989-6344da914081/crypt/debug                                                           badbe224-0a39-4ccf-92d5-847905b00bc5   100 GiB   none          gzip-9     
     oxp_bf149c80-2498-481c-9989-6344da914081/crypt/zone                                                            49a3e230-e22a-4bc3-8bb4-f188e5b23c19   none      none          off        
     oxp_bf149c80-2498-481c-9989-6344da914081/crypt/zone/oxz_crucible_f52aa245-7e1b-46c0-8a31-e09725f02caf          4ffbef53-46e9-4698-afc9-12fc9e22e6af   none      none          off        
     oxp_c69b6237-09f9-45aa-962c-5dbdd1d894be/crucible                                                              c7bdd567-1585-4e5d-8e00-9fc8a582b9a8   none      none          off        
-    oxp_c69b6237-09f9-45aa-962c-5dbdd1d894be/crypt/debug                                                           b2b44420-be84-4974-99a2-60b03c895811   100 GiB   none          gzip-9     
-    oxp_c69b6237-09f9-45aa-962c-5dbdd1d894be/crypt/zone                                                            8b47156e-0faa-4cba-ba05-d1e0d1d3c382   none      none          off        
+    oxp_c69b6237-09f9-45aa-962c-5dbdd1d894be/crypt/debug                                                           ea2cc4fe-93ce-437e-9a1f-1d203bca8784   100 GiB   none          gzip-9     
+    oxp_c69b6237-09f9-45aa-962c-5dbdd1d894be/crypt/zone                                                            2dc77339-9cbf-4d86-89a8-e65a64f35673   none      none          off        
     oxp_c69b6237-09f9-45aa-962c-5dbdd1d894be/crypt/zone/oxz_crucible_b5d5491d-b3aa-4727-8b55-f66e0581ea4f          962343a7-2374-4d3e-b8df-99dded0f1bc9   none      none          off        
     oxp_ccd5a87b-00ae-42ad-85da-b37d70436cb1/crucible                                                              b058857e-6b86-474c-ac69-2851f9cd00c9   none      none          off        
-    oxp_ccd5a87b-00ae-42ad-85da-b37d70436cb1/crypt/debug                                                           523fd0cd-8d22-4f7a-a3b0-3fd0f4f88852   100 GiB   none          gzip-9     
-    oxp_ccd5a87b-00ae-42ad-85da-b37d70436cb1/crypt/zone                                                            9e78cb9f-d533-44e5-8641-d6be0fb5868b   none      none          off        
+    oxp_ccd5a87b-00ae-42ad-85da-b37d70436cb1/crypt/debug                                                           d8246b47-51dc-44c0-8a74-edbb80330f19   100 GiB   none          gzip-9     
+    oxp_ccd5a87b-00ae-42ad-85da-b37d70436cb1/crypt/zone                                                            8915abc3-13c9-4ad2-86cd-f6dcf933aca9   none      none          off        
     oxp_ccd5a87b-00ae-42ad-85da-b37d70436cb1/crypt/zone/oxz_crucible_09937ebb-bb6a-495b-bc97-b58076b70a78          819b9236-ad12-45ea-8dbf-d06c394003d7   none      none          off        
     oxp_d7410a1c-e01d-49a4-be9c-f861f086760a/crucible                                                              ab8c57d6-494c-4845-b9bb-9d7e3ff5f43d   none      none          off        
-    oxp_d7410a1c-e01d-49a4-be9c-f861f086760a/crypt/debug                                                           d8246b47-51dc-44c0-8a74-edbb80330f19   100 GiB   none          gzip-9     
-    oxp_d7410a1c-e01d-49a4-be9c-f861f086760a/crypt/zone                                                            8915abc3-13c9-4ad2-86cd-f6dcf933aca9   none      none          off        
+    oxp_d7410a1c-e01d-49a4-be9c-f861f086760a/crypt/debug                                                           b2b44420-be84-4974-99a2-60b03c895811   100 GiB   none          gzip-9     
+    oxp_d7410a1c-e01d-49a4-be9c-f861f086760a/crypt/zone                                                            8b47156e-0faa-4cba-ba05-d1e0d1d3c382   none      none          off        
     oxp_d7410a1c-e01d-49a4-be9c-f861f086760a/crypt/zone/oxz_crucible_f3628f0a-2301-4fc8-bcbf-961199771731          32706642-7c88-4dde-b2e5-2c66237051ef   none      none          off        
 
 
@@ -402,54 +402,54 @@ to:   blueprint  ade5749d-bdf3-4fab-a8ae-00bea01b3a5a
     fake-vendor   fake-model   serial-fe1d5b9f-8db7-4e2d-bf17-c4b80e1f897c
 
 
-    datasets at generation 1:
+    datasets at generation 2:
     -----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
     dataset name                                                                                                   dataset uuid                           quota     reservation   compression
     -----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
     oxp_44fa7024-c2bc-4d2c-b478-c4997e4aece8/crucible                                                              0c44736d-76e8-464f-9c5b-1df35743d849   none      none          off        
-    oxp_44fa7024-c2bc-4d2c-b478-c4997e4aece8/crypt/debug                                                           5caa41ff-a043-44bd-ac2f-6bd35f686953   100 GiB   none          gzip-9     
+    oxp_44fa7024-c2bc-4d2c-b478-c4997e4aece8/crypt/debug                                                           aa9d2a0b-37bc-450a-a18b-53ac178dfa9a   100 GiB   none          gzip-9     
     oxp_44fa7024-c2bc-4d2c-b478-c4997e4aece8/crypt/internal_dns                                                    d10b2deb-f770-40d3-8b4f-03a14e47ccde   none      none          off        
-    oxp_44fa7024-c2bc-4d2c-b478-c4997e4aece8/crypt/zone                                                            01d56c05-8fd5-48f0-8fde-7b8a4df1f1e5   none      none          off        
+    oxp_44fa7024-c2bc-4d2c-b478-c4997e4aece8/crypt/zone                                                            4ca68409-860f-4606-9118-223a99784048   none      none          off        
     oxp_44fa7024-c2bc-4d2c-b478-c4997e4aece8/crypt/zone/oxz_crucible_413d3e02-e19f-400a-9718-a662347538f0          ba98af8c-d358-4a22-b172-767b17075307   none      none          off        
     oxp_44fa7024-c2bc-4d2c-b478-c4997e4aece8/crypt/zone/oxz_crucible_pantry_315a3670-d019-425c-b7a6-c9429428b671   8426cb5d-176f-46f0-8111-f1792f20833c   none      none          off        
     oxp_44fa7024-c2bc-4d2c-b478-c4997e4aece8/crypt/zone/oxz_internal_dns_8b47e1e8-0396-4e44-a4a5-ea891405c9f2      fee2f9a5-fef1-4217-ae29-822983085f71   none      none          off        
     oxp_44fa7024-c2bc-4d2c-b478-c4997e4aece8/crypt/zone/oxz_nexus_b43ce109-90d6-46f9-9df0-8c68bfe6d4a0             eeee1d0d-cc48-45c2-8718-2bebfdf4d5e3   none      none          off        
     oxp_44fa7024-c2bc-4d2c-b478-c4997e4aece8/crypt/zone/oxz_ntp_cbe91cdc-cbb6-4760-aece-6ce08b67e85a               668b7c91-1466-43e3-bb8f-becdb1c20493   none      none          off        
     oxp_5265edc6-debf-4687-a758-a9746893ebd3/crucible                                                              64a69811-e0a8-427d-8f4b-2fe77f4eaaef   none      none          off        
-    oxp_5265edc6-debf-4687-a758-a9746893ebd3/crypt/debug                                                           e21195e1-d410-4ba0-a78c-2fb91310ab9e   100 GiB   none          gzip-9     
-    oxp_5265edc6-debf-4687-a758-a9746893ebd3/crypt/zone                                                            30e61fef-5a8c-498a-835e-ffada88d73b7   none      none          off        
+    oxp_5265edc6-debf-4687-a758-a9746893ebd3/crypt/debug                                                           3fd90a28-4348-4331-b52d-ad933520add3   100 GiB   none          gzip-9     
+    oxp_5265edc6-debf-4687-a758-a9746893ebd3/crypt/zone                                                            6cd435eb-07d5-40bc-a50b-c9bf61fc3de2   none      none          off        
     oxp_5265edc6-debf-4687-a758-a9746893ebd3/crypt/zone/oxz_crucible_b5443ebd-1f5b-448c-8edc-b4ca25c25db1          037fc003-d941-4639-8ab8-ce67926b107d   none      none          off        
     oxp_532fbd69-b472-4445-86af-4c4c85afb313/crucible                                                              6ca42c2b-ac96-4d42-bfb4-120bbab62fe8   none      none          off        
-    oxp_532fbd69-b472-4445-86af-4c4c85afb313/crypt/debug                                                           aa9d2a0b-37bc-450a-a18b-53ac178dfa9a   100 GiB   none          gzip-9     
-    oxp_532fbd69-b472-4445-86af-4c4c85afb313/crypt/zone                                                            4ca68409-860f-4606-9118-223a99784048   none      none          off        
+    oxp_532fbd69-b472-4445-86af-4c4c85afb313/crypt/debug                                                           e21195e1-d410-4ba0-a78c-2fb91310ab9e   100 GiB   none          gzip-9     
+    oxp_532fbd69-b472-4445-86af-4c4c85afb313/crypt/zone                                                            30e61fef-5a8c-498a-835e-ffada88d73b7   none      none          off        
     oxp_532fbd69-b472-4445-86af-4c4c85afb313/crypt/zone/oxz_crucible_e135441d-637e-4de9-8023-5ea0096347f3          bb5be931-233b-4741-a9cd-951f5977ac57   none      none          off        
     oxp_54fd6fa6-ce3c-4abe-8c9d-7e107e159e84/crucible                                                              ecfa453d-3c6c-4ac2-8be1-439208df2eac   none      none          off        
-    oxp_54fd6fa6-ce3c-4abe-8c9d-7e107e159e84/crypt/debug                                                           3fd90a28-4348-4331-b52d-ad933520add3   100 GiB   none          gzip-9     
-    oxp_54fd6fa6-ce3c-4abe-8c9d-7e107e159e84/crypt/zone                                                            6cd435eb-07d5-40bc-a50b-c9bf61fc3de2   none      none          off        
+    oxp_54fd6fa6-ce3c-4abe-8c9d-7e107e159e84/crypt/debug                                                           89eef0ca-8367-4343-9390-c17d53beb0e1   100 GiB   none          gzip-9     
+    oxp_54fd6fa6-ce3c-4abe-8c9d-7e107e159e84/crypt/zone                                                            101a1e8b-362a-49bf-b209-dcd4aedaa3fb   none      none          off        
     oxp_54fd6fa6-ce3c-4abe-8c9d-7e107e159e84/crypt/zone/oxz_crucible_bb55534c-1042-4af4-ad2f-9590803695ac          e67687c5-2699-4630-9092-9a42d2ff160f   none      none          off        
     oxp_8562317c-4736-4cfc-9292-7dcab96a6fee/crucible                                                              abbbaf81-fd62-498b-8e18-221c68065b2c   none      none          off        
-    oxp_8562317c-4736-4cfc-9292-7dcab96a6fee/crypt/debug                                                           ce331e9e-8f0c-4c3a-9565-561d6760710d   100 GiB   none          gzip-9     
-    oxp_8562317c-4736-4cfc-9292-7dcab96a6fee/crypt/zone                                                            40fb0fd8-3ad0-4fb3-a22f-59c628905e93   none      none          off        
+    oxp_8562317c-4736-4cfc-9292-7dcab96a6fee/crypt/debug                                                           abb97aa4-9deb-45b5-8844-51200e8e190d   100 GiB   none          gzip-9     
+    oxp_8562317c-4736-4cfc-9292-7dcab96a6fee/crypt/zone                                                            bcf1d9c3-3c77-4f80-9f07-52d0abf4cd25   none      none          off        
     oxp_8562317c-4736-4cfc-9292-7dcab96a6fee/crypt/zone/oxz_crucible_6d725df0-0189-4429-b270-3eeb891d39c8          46135910-450d-4949-9fab-a9b0a54a68c1   none      none          off        
     oxp_9a1327e4-d11b-4d98-8454-8c41862e9832/crucible                                                              5afdb92a-28ab-4de1-954d-6192fea1a18b   none      none          off        
-    oxp_9a1327e4-d11b-4d98-8454-8c41862e9832/crypt/debug                                                           f166a5e8-6790-42eb-8bff-6856d4471247   100 GiB   none          gzip-9     
-    oxp_9a1327e4-d11b-4d98-8454-8c41862e9832/crypt/zone                                                            430ebbbf-a9ef-488e-9e1b-54e74ff73922   none      none          off        
+    oxp_9a1327e4-d11b-4d98-8454-8c41862e9832/crypt/debug                                                           95a0e096-5120-43a1-9b6d-ab685ce100c6   100 GiB   none          gzip-9     
+    oxp_9a1327e4-d11b-4d98-8454-8c41862e9832/crypt/zone                                                            455e96ed-bdc6-4d46-9774-22a299a513b2   none      none          off        
     oxp_9a1327e4-d11b-4d98-8454-8c41862e9832/crypt/zone/oxz_crucible_6cb330f9-4609-4d6c-98ad-b5cc34245813          943211c9-063e-4860-8d94-54d55c499349   none      none          off        
     oxp_bf9d6692-64bc-459a-87dd-e7a83080a210/crucible                                                              d0f2d2a4-95f6-4767-92b7-05a5a3b2822c   none      none          off        
-    oxp_bf9d6692-64bc-459a-87dd-e7a83080a210/crypt/debug                                                           89eef0ca-8367-4343-9390-c17d53beb0e1   100 GiB   none          gzip-9     
-    oxp_bf9d6692-64bc-459a-87dd-e7a83080a210/crypt/zone                                                            101a1e8b-362a-49bf-b209-dcd4aedaa3fb   none      none          off        
+    oxp_bf9d6692-64bc-459a-87dd-e7a83080a210/crypt/debug                                                           f166a5e8-6790-42eb-8bff-6856d4471247   100 GiB   none          gzip-9     
+    oxp_bf9d6692-64bc-459a-87dd-e7a83080a210/crypt/zone                                                            430ebbbf-a9ef-488e-9e1b-54e74ff73922   none      none          off        
     oxp_bf9d6692-64bc-459a-87dd-e7a83080a210/crypt/zone/oxz_crucible_fee71ee6-da42-4a7f-a00e-f56b6a3327ce          bdd191e4-cd8f-49c5-b887-7e7c9ba81051   none      none          off        
     oxp_ce1c13f3-bef2-4306-b0f2-4e39bd4a18b6/crucible                                                              d8a968b5-8cc3-4dbc-a22d-723adce3d82f   none      none          off        
     oxp_ce1c13f3-bef2-4306-b0f2-4e39bd4a18b6/crypt/debug                                                           93255645-6328-4f3f-83df-a67f1206fdbf   100 GiB   none          gzip-9     
     oxp_ce1c13f3-bef2-4306-b0f2-4e39bd4a18b6/crypt/zone                                                            358ef33b-11da-4ba6-b0a2-6d881e4d3b29   none      none          off        
     oxp_ce1c13f3-bef2-4306-b0f2-4e39bd4a18b6/crypt/zone/oxz_crucible_de65f128-30f7-422b-a234-d1fc8dd6ef78          65569fd8-0748-4bf6-9ee9-c9cb6fbbb43b   none      none          off        
     oxp_f931ec80-a3e3-4adb-a8ba-fa5adbd2294c/crucible                                                              82c773a2-9a18-4c31-8a65-fb5419f9b853   none      none          off        
-    oxp_f931ec80-a3e3-4adb-a8ba-fa5adbd2294c/crypt/debug                                                           95a0e096-5120-43a1-9b6d-ab685ce100c6   100 GiB   none          gzip-9     
-    oxp_f931ec80-a3e3-4adb-a8ba-fa5adbd2294c/crypt/zone                                                            455e96ed-bdc6-4d46-9774-22a299a513b2   none      none          off        
+    oxp_f931ec80-a3e3-4adb-a8ba-fa5adbd2294c/crypt/debug                                                           ce331e9e-8f0c-4c3a-9565-561d6760710d   100 GiB   none          gzip-9     
+    oxp_f931ec80-a3e3-4adb-a8ba-fa5adbd2294c/crypt/zone                                                            40fb0fd8-3ad0-4fb3-a22f-59c628905e93   none      none          off        
     oxp_f931ec80-a3e3-4adb-a8ba-fa5adbd2294c/crypt/zone/oxz_crucible_d14c165f-6370-4cce-9dba-3c6deb762cfc          3eeca505-f147-4afa-a032-1643c2ef87ef   none      none          off        
     oxp_fe1d5b9f-8db7-4e2d-bf17-c4b80e1f897c/crucible                                                              317e2495-e4b4-4fe5-9e46-a582b797f0f1   none      none          off        
-    oxp_fe1d5b9f-8db7-4e2d-bf17-c4b80e1f897c/crypt/debug                                                           abb97aa4-9deb-45b5-8844-51200e8e190d   100 GiB   none          gzip-9     
-    oxp_fe1d5b9f-8db7-4e2d-bf17-c4b80e1f897c/crypt/zone                                                            bcf1d9c3-3c77-4f80-9f07-52d0abf4cd25   none      none          off        
+    oxp_fe1d5b9f-8db7-4e2d-bf17-c4b80e1f897c/crypt/debug                                                           5caa41ff-a043-44bd-ac2f-6bd35f686953   100 GiB   none          gzip-9     
+    oxp_fe1d5b9f-8db7-4e2d-bf17-c4b80e1f897c/crypt/zone                                                            01d56c05-8fd5-48f0-8fde-7b8a4df1f1e5   none      none          off        
     oxp_fe1d5b9f-8db7-4e2d-bf17-c4b80e1f897c/crypt/zone/oxz_crucible_c4296f9f-f902-4fc7-b896-178e56e60732          13f5b476-412a-4879-903b-5a9ac4ca6fd3   none      none          off        
 
 
@@ -511,15 +511,15 @@ to:   blueprint  ade5749d-bdf3-4fab-a8ae-00bea01b3a5a
     fake-vendor   fake-model   serial-d792c8cb-7490-40cb-bb1c-d4917242edf4
 
 
-    datasets at generation 1:
+    datasets at generation 2:
     -----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
     dataset name                                                                                                   dataset uuid                           quota     reservation   compression
     -----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
     oxp_088ed702-551e-453b-80d7-57700372a844/crucible                                                              10eea692-add6-4430-ba17-2c9ca58082b5   none      none          off        
     oxp_088ed702-551e-453b-80d7-57700372a844/crypt/clickhouse                                                      e5ed5cac-9580-4016-84c2-dc6b8464b9ce   none      none          off        
-    oxp_088ed702-551e-453b-80d7-57700372a844/crypt/debug                                                           6fb8df45-63f4-4f51-972a-29904a575c6e   100 GiB   none          gzip-9     
+    oxp_088ed702-551e-453b-80d7-57700372a844/crypt/debug                                                           dbf4924f-cdb3-4d1c-8e32-5c566c3e4a98   100 GiB   none          gzip-9     
     oxp_088ed702-551e-453b-80d7-57700372a844/crypt/internal_dns                                                    64053399-514e-4e01-822c-e81e7187ef64   none      none          off        
-    oxp_088ed702-551e-453b-80d7-57700372a844/crypt/zone                                                            9e68dbfc-4ccb-4bff-ba97-5d81425fc584   none      none          off        
+    oxp_088ed702-551e-453b-80d7-57700372a844/crypt/zone                                                            70c3efb9-1f72-42d4-a0e1-c8c573c833af   none      none          off        
     oxp_088ed702-551e-453b-80d7-57700372a844/crypt/zone/oxz_clickhouse_fe79023f-c5d5-4be5-ad2c-da4e9e9237e4        ac51a283-2d5d-4b96-a922-9688cd489315   none      none          off        
     oxp_088ed702-551e-453b-80d7-57700372a844/crypt/zone/oxz_crucible_f97aa057-6485-45d0-9cb4-4af5b0831d48          e4ef7aab-4a43-4ce0-a5cf-1436735ee712   none      none          off        
     oxp_088ed702-551e-453b-80d7-57700372a844/crypt/zone/oxz_crucible_pantry_eaec16c0-0d44-4847-b2d6-31a5151bae52   02df7e3b-b094-4c0e-9292-2e874ea8382c   none      none          off        
@@ -527,40 +527,40 @@ to:   blueprint  ade5749d-bdf3-4fab-a8ae-00bea01b3a5a
     oxp_088ed702-551e-453b-80d7-57700372a844/crypt/zone/oxz_nexus_94b45ce9-d3d8-413a-a76b-865da1f67930             a892e4f7-1893-44b1-92bd-bbc080850c9e   none      none          off        
     oxp_088ed702-551e-453b-80d7-57700372a844/crypt/zone/oxz_ntp_c67dd9a4-0d6c-4e9f-b28d-20003f211f7d               701c81e2-41fa-490a-aa2e-0387aeb210ed   none      none          off        
     oxp_09e51697-abad-47c0-a193-eaf74bc5d3cd/crucible                                                              9edffe2a-5df5-4f42-9421-82ba7c9416ab   none      none          off        
-    oxp_09e51697-abad-47c0-a193-eaf74bc5d3cd/crypt/debug                                                           63433fe0-87aa-4189-ad00-72bfa9923d28   100 GiB   none          gzip-9     
-    oxp_09e51697-abad-47c0-a193-eaf74bc5d3cd/crypt/zone                                                            2a69ae17-3329-429e-b99b-e4d607451490   none      none          off        
+    oxp_09e51697-abad-47c0-a193-eaf74bc5d3cd/crypt/debug                                                           6735caf5-1dd2-464b-93e2-f9080f9ff58d   100 GiB   none          gzip-9     
+    oxp_09e51697-abad-47c0-a193-eaf74bc5d3cd/crypt/zone                                                            76f5cbd5-9e1f-4ccb-b4a8-65cc8bcc4afc   none      none          off        
     oxp_09e51697-abad-47c0-a193-eaf74bc5d3cd/crypt/zone/oxz_crucible_054f64a5-182c-4c28-8994-d2e082550201          31c95682-7bae-4182-8e43-54c403a2a35c   none      none          off        
     oxp_3a512d49-edbe-47f3-8d0b-6051bfdc4044/crucible                                                              8fac3fae-eadc-4391-ba80-2f3b8d6cb708   none      none          off        
-    oxp_3a512d49-edbe-47f3-8d0b-6051bfdc4044/crypt/debug                                                           476cb7b1-06a2-4abc-9b59-157eba6b4fa9   100 GiB   none          gzip-9     
-    oxp_3a512d49-edbe-47f3-8d0b-6051bfdc4044/crypt/zone                                                            290f96c3-031b-496c-937d-9b157ecdc0fb   none      none          off        
+    oxp_3a512d49-edbe-47f3-8d0b-6051bfdc4044/crypt/debug                                                           63433fe0-87aa-4189-ad00-72bfa9923d28   100 GiB   none          gzip-9     
+    oxp_3a512d49-edbe-47f3-8d0b-6051bfdc4044/crypt/zone                                                            2a69ae17-3329-429e-b99b-e4d607451490   none      none          off        
     oxp_3a512d49-edbe-47f3-8d0b-6051bfdc4044/crypt/zone/oxz_crucible_3b5bffea-e5ed-44df-8468-fd4fa69757d8          9df6db90-95c6-45bc-aba7-70bb72d87c7c   none      none          off        
     oxp_40517680-aa77-413c-bcf4-b9041dcf6612/crucible                                                              fec44f34-a838-4a3d-9fa2-70133f3db3a1   none      none          off        
-    oxp_40517680-aa77-413c-bcf4-b9041dcf6612/crypt/debug                                                           cf3dc221-a35a-4f16-935f-635cb87dc399   100 GiB   none          gzip-9     
-    oxp_40517680-aa77-413c-bcf4-b9041dcf6612/crypt/zone                                                            751bad28-e0f5-494e-91c1-432ded709c2f   none      none          off        
+    oxp_40517680-aa77-413c-bcf4-b9041dcf6612/crypt/debug                                                           476cb7b1-06a2-4abc-9b59-157eba6b4fa9   100 GiB   none          gzip-9     
+    oxp_40517680-aa77-413c-bcf4-b9041dcf6612/crypt/zone                                                            290f96c3-031b-496c-937d-9b157ecdc0fb   none      none          off        
     oxp_40517680-aa77-413c-bcf4-b9041dcf6612/crypt/zone/oxz_crucible_bc095417-e2f0-4e95-b390-9cc3fc6e3c6d          6169ada0-c238-44e8-a67b-d50eecb419ea   none      none          off        
     oxp_78d3cb96-9295-4644-bf78-2e32191c71f9/crucible                                                              8d4092ca-d9fd-4fa3-9d12-a44f638fccc6   none      none          off        
-    oxp_78d3cb96-9295-4644-bf78-2e32191c71f9/crypt/debug                                                           dbdb5ae6-9064-427f-850f-8c45d07c6af4   100 GiB   none          gzip-9     
-    oxp_78d3cb96-9295-4644-bf78-2e32191c71f9/crypt/zone                                                            90efb135-dded-4acf-81b5-9ee75669b1d8   none      none          off        
+    oxp_78d3cb96-9295-4644-bf78-2e32191c71f9/crypt/debug                                                           32713f0b-b162-4e23-bd9e-2cc4b208f98f   100 GiB   none          gzip-9     
+    oxp_78d3cb96-9295-4644-bf78-2e32191c71f9/crypt/zone                                                            b9360096-7b96-450b-b6d8-33fc06dd3f07   none      none          off        
     oxp_78d3cb96-9295-4644-bf78-2e32191c71f9/crypt/zone/oxz_crucible_95ad9a1d-4063-4874-974c-2fc92830be27          923c27c2-0687-4799-9cba-a439e5c56854   none      none          off        
     oxp_853595e7-77da-404e-bc35-aba77478d55c/crucible                                                              8bf51c09-0d33-42d9-9ac0-2761d2f84378   none      none          off        
-    oxp_853595e7-77da-404e-bc35-aba77478d55c/crypt/debug                                                           32713f0b-b162-4e23-bd9e-2cc4b208f98f   100 GiB   none          gzip-9     
-    oxp_853595e7-77da-404e-bc35-aba77478d55c/crypt/zone                                                            b9360096-7b96-450b-b6d8-33fc06dd3f07   none      none          off        
+    oxp_853595e7-77da-404e-bc35-aba77478d55c/crypt/debug                                                           dbdb5ae6-9064-427f-850f-8c45d07c6af4   100 GiB   none          gzip-9     
+    oxp_853595e7-77da-404e-bc35-aba77478d55c/crypt/zone                                                            90efb135-dded-4acf-81b5-9ee75669b1d8   none      none          off        
     oxp_853595e7-77da-404e-bc35-aba77478d55c/crypt/zone/oxz_crucible_53dd7fa4-899e-49ed-9fc2-48222db3e20d          5475d130-9244-4e3b-8e21-bc3233bc3074   none      none          off        
     oxp_8926e0e7-65d9-4e2e-ac6d-f1298af81ef1/crucible                                                              fe743e12-6be9-48c6-a1e8-c129f00b43d9   none      none          off        
-    oxp_8926e0e7-65d9-4e2e-ac6d-f1298af81ef1/crypt/debug                                                           dbf4924f-cdb3-4d1c-8e32-5c566c3e4a98   100 GiB   none          gzip-9     
-    oxp_8926e0e7-65d9-4e2e-ac6d-f1298af81ef1/crypt/zone                                                            70c3efb9-1f72-42d4-a0e1-c8c573c833af   none      none          off        
+    oxp_8926e0e7-65d9-4e2e-ac6d-f1298af81ef1/crypt/debug                                                           6fb8df45-63f4-4f51-972a-29904a575c6e   100 GiB   none          gzip-9     
+    oxp_8926e0e7-65d9-4e2e-ac6d-f1298af81ef1/crypt/zone                                                            9e68dbfc-4ccb-4bff-ba97-5d81425fc584   none      none          off        
     oxp_8926e0e7-65d9-4e2e-ac6d-f1298af81ef1/crypt/zone/oxz_crucible_d90401f1-fbc2-42cb-bf17-309ee0f922fe          2db8cea6-9af5-4b9f-8db1-d59006b8fca6   none      none          off        
     oxp_9c0b9151-17f3-4857-94cc-b5bfcd402326/crucible                                                              b4a8e70b-dfe8-4392-9518-8fe6dd952b94   none      none          off        
-    oxp_9c0b9151-17f3-4857-94cc-b5bfcd402326/crypt/debug                                                           abab81af-ef4d-4832-862d-1760b2fe6e65   100 GiB   none          gzip-9     
-    oxp_9c0b9151-17f3-4857-94cc-b5bfcd402326/crypt/zone                                                            f7dee56f-2cb0-470c-8fba-8c60c56d6bb9   none      none          off        
+    oxp_9c0b9151-17f3-4857-94cc-b5bfcd402326/crypt/debug                                                           cf3dc221-a35a-4f16-935f-635cb87dc399   100 GiB   none          gzip-9     
+    oxp_9c0b9151-17f3-4857-94cc-b5bfcd402326/crypt/zone                                                            751bad28-e0f5-494e-91c1-432ded709c2f   none      none          off        
     oxp_9c0b9151-17f3-4857-94cc-b5bfcd402326/crypt/zone/oxz_crucible_7db307d4-a6ed-4c47-bddf-6759161bf64a          3c5a1b55-b719-4c61-9865-46aeb8736164   none      none          off        
     oxp_d61354fa-48d2-47c6-90bf-546e3ed1708b/crucible                                                              ff0d3669-e237-4797-854b-dcb51d6c289d   none      none          off        
-    oxp_d61354fa-48d2-47c6-90bf-546e3ed1708b/crypt/debug                                                           6735caf5-1dd2-464b-93e2-f9080f9ff58d   100 GiB   none          gzip-9     
-    oxp_d61354fa-48d2-47c6-90bf-546e3ed1708b/crypt/zone                                                            76f5cbd5-9e1f-4ccb-b4a8-65cc8bcc4afc   none      none          off        
+    oxp_d61354fa-48d2-47c6-90bf-546e3ed1708b/crypt/debug                                                           edaad63c-f9ae-4552-8197-2c95d138da93   100 GiB   none          gzip-9     
+    oxp_d61354fa-48d2-47c6-90bf-546e3ed1708b/crypt/zone                                                            bc098466-0717-42ce-9c42-5da3b5c8de4a   none      none          off        
     oxp_d61354fa-48d2-47c6-90bf-546e3ed1708b/crypt/zone/oxz_crucible_e8f994c0-0a1b-40e6-8db1-40a8ca89e503          25e14454-4215-46a2-9c24-50aed0d1b131   none      none          off        
     oxp_d792c8cb-7490-40cb-bb1c-d4917242edf4/crucible                                                              cfa8cf24-8dc1-43c8-bf88-3e8d4b058f7a   none      none          off        
-    oxp_d792c8cb-7490-40cb-bb1c-d4917242edf4/crypt/debug                                                           edaad63c-f9ae-4552-8197-2c95d138da93   100 GiB   none          gzip-9     
-    oxp_d792c8cb-7490-40cb-bb1c-d4917242edf4/crypt/zone                                                            bc098466-0717-42ce-9c42-5da3b5c8de4a   none      none          off        
+    oxp_d792c8cb-7490-40cb-bb1c-d4917242edf4/crypt/debug                                                           abab81af-ef4d-4832-862d-1760b2fe6e65   100 GiB   none          gzip-9     
+    oxp_d792c8cb-7490-40cb-bb1c-d4917242edf4/crypt/zone                                                            f7dee56f-2cb0-470c-8fba-8c60c56d6bb9   none      none          off        
     oxp_d792c8cb-7490-40cb-bb1c-d4917242edf4/crypt/zone/oxz_crucible_e9bf481e-323e-466e-842f-8107078c7137          d81cd9b7-7df5-4cb5-86d1-126a9a700fb8   none      none          off        
 
 
@@ -603,54 +603,54 @@ to:   blueprint  ade5749d-bdf3-4fab-a8ae-00bea01b3a5a
     fake-vendor   fake-model   serial-d7410a1c-e01d-49a4-be9c-f861f086760a
 
 
-    datasets at generation 1:
+    datasets at generation 2:
     -----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
     dataset name                                                                                                   dataset uuid                           quota     reservation   compression
     -----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
     oxp_128b0f04-229b-48dc-9c5c-555cb5723ed8/crucible                                                              dddf5d66-838c-4253-a42f-075c8e264bf1   none      none          off        
-    oxp_128b0f04-229b-48dc-9c5c-555cb5723ed8/crypt/debug                                                           ea2cc4fe-93ce-437e-9a1f-1d203bca8784   100 GiB   none          gzip-9     
+    oxp_128b0f04-229b-48dc-9c5c-555cb5723ed8/crypt/debug                                                           11eedda2-f710-49db-b358-6a763e530643   100 GiB   none          gzip-9     
     oxp_128b0f04-229b-48dc-9c5c-555cb5723ed8/crypt/internal_dns                                                    393388ac-4fbe-4e3b-840f-17afed583ee8   none      none          off        
-    oxp_128b0f04-229b-48dc-9c5c-555cb5723ed8/crypt/zone                                                            2dc77339-9cbf-4d86-89a8-e65a64f35673   none      none          off        
+    oxp_128b0f04-229b-48dc-9c5c-555cb5723ed8/crypt/zone                                                            d1549ccd-d9a8-4899-9dc2-5991ae3e0300   none      none          off        
     oxp_128b0f04-229b-48dc-9c5c-555cb5723ed8/crypt/zone/oxz_crucible_cc1dc86d-bd6f-4929-aa4a-9619012e9393          965c1e70-f075-4dcb-b25a-d856bb44551b   none      none          off        
     oxp_128b0f04-229b-48dc-9c5c-555cb5723ed8/crypt/zone/oxz_crucible_pantry_728db429-8621-4e1e-9915-282aadfa27d1   d2434e6c-1c0d-4443-a756-db277c0fd684   none      none          off        
     oxp_128b0f04-229b-48dc-9c5c-555cb5723ed8/crypt/zone/oxz_internal_dns_e7dd3e98-7fe7-4827-be7f-395ff9a5f542      5da5c7e8-b603-4eb9-acc2-3e137e9c9b8f   none      none          off        
     oxp_128b0f04-229b-48dc-9c5c-555cb5723ed8/crypt/zone/oxz_nexus_c8aa84a5-a802-46c9-adcd-d61e9c8393c9             cfff8484-c5a9-4430-a46d-92e62577b3bb   none      none          off        
     oxp_128b0f04-229b-48dc-9c5c-555cb5723ed8/crypt/zone/oxz_ntp_4f2eb088-7d28-4c4e-a27c-746400ec65ba               ebf8caa8-c75d-4318-9759-41dea4572e8b   none      none          off        
     oxp_43ae0f4e-b0cf-4d74-8636-df0567ba01e6/crucible                                                              4b6e313b-839a-405f-b7b2-c85456f77d6e   none      none          off        
-    oxp_43ae0f4e-b0cf-4d74-8636-df0567ba01e6/crypt/debug                                                           11eedda2-f710-49db-b358-6a763e530643   100 GiB   none          gzip-9     
-    oxp_43ae0f4e-b0cf-4d74-8636-df0567ba01e6/crypt/zone                                                            d1549ccd-d9a8-4899-9dc2-5991ae3e0300   none      none          off        
+    oxp_43ae0f4e-b0cf-4d74-8636-df0567ba01e6/crypt/debug                                                           1c8bff2b-a7ca-4852-b94b-7cff9026bb2d   100 GiB   none          gzip-9     
+    oxp_43ae0f4e-b0cf-4d74-8636-df0567ba01e6/crypt/zone                                                            82ff9ea6-429c-449a-89d9-c3a42a5ecb06   none      none          off        
     oxp_43ae0f4e-b0cf-4d74-8636-df0567ba01e6/crypt/zone/oxz_crucible_e8971ab3-fb7d-4ad8-aae3-7f2fe87c51f3          6e8c587e-b25b-43d3-b05f-72713da53cd0   none      none          off        
     oxp_4e9806d0-41cd-48c2-86ef-7f815c3ce3b1/crucible                                                              3759d324-78ac-4855-a89f-cdf28d6bff92   none      none          off        
-    oxp_4e9806d0-41cd-48c2-86ef-7f815c3ce3b1/crypt/debug                                                           6a8adc00-8b5a-4135-b20a-c862c509a7d7   100 GiB   none          gzip-9     
-    oxp_4e9806d0-41cd-48c2-86ef-7f815c3ce3b1/crypt/zone                                                            b3de9a5e-01e0-48e6-b032-f53de00285c1   none      none          off        
+    oxp_4e9806d0-41cd-48c2-86ef-7f815c3ce3b1/crypt/debug                                                           523fd0cd-8d22-4f7a-a3b0-3fd0f4f88852   100 GiB   none          gzip-9     
+    oxp_4e9806d0-41cd-48c2-86ef-7f815c3ce3b1/crypt/zone                                                            9e78cb9f-d533-44e5-8641-d6be0fb5868b   none      none          off        
     oxp_4e9806d0-41cd-48c2-86ef-7f815c3ce3b1/crypt/zone/oxz_crucible_a999e5fa-3edc-4dac-919a-d7b554cdae58          f7da941d-47da-40ad-9d21-1a36a83c9d48   none      none          off        
     oxp_70bb6d98-111f-4015-9d97-9ef1b2d6dcac/crucible                                                              9c53961d-4259-4215-a083-669234e4ed33   none      none          off        
-    oxp_70bb6d98-111f-4015-9d97-9ef1b2d6dcac/crypt/debug                                                           c784968a-27ca-40a3-9570-736593bba5ab   100 GiB   none          gzip-9     
-    oxp_70bb6d98-111f-4015-9d97-9ef1b2d6dcac/crypt/zone                                                            609f9bcf-d01e-4d0b-89f6-96e75397b7f6   none      none          off        
+    oxp_70bb6d98-111f-4015-9d97-9ef1b2d6dcac/crypt/debug                                                           6a8adc00-8b5a-4135-b20a-c862c509a7d7   100 GiB   none          gzip-9     
+    oxp_70bb6d98-111f-4015-9d97-9ef1b2d6dcac/crypt/zone                                                            b3de9a5e-01e0-48e6-b032-f53de00285c1   none      none          off        
     oxp_70bb6d98-111f-4015-9d97-9ef1b2d6dcac/crypt/zone/oxz_crucible_b416f299-c23c-46c8-9820-be2b66ffea0a          2de47948-bd82-46b5-8341-f9381d1817cf   none      none          off        
     oxp_7ce5029f-703c-4c08-8164-9af9cf1acf23/crucible                                                              50a7450d-4069-4f18-9d80-de273e801af8   none      none          off        
-    oxp_7ce5029f-703c-4c08-8164-9af9cf1acf23/crypt/debug                                                           71d6b4d8-1204-4f0f-b0e3-f47946fb7a8c   100 GiB   none          gzip-9     
-    oxp_7ce5029f-703c-4c08-8164-9af9cf1acf23/crypt/zone                                                            3e6a4121-1ea9-4361-ad1c-14c7dd945f37   none      none          off        
+    oxp_7ce5029f-703c-4c08-8164-9af9cf1acf23/crypt/debug                                                           c784968a-27ca-40a3-9570-736593bba5ab   100 GiB   none          gzip-9     
+    oxp_7ce5029f-703c-4c08-8164-9af9cf1acf23/crypt/zone                                                            609f9bcf-d01e-4d0b-89f6-96e75397b7f6   none      none          off        
     oxp_7ce5029f-703c-4c08-8164-9af9cf1acf23/crypt/zone/oxz_crucible_fae49024-6cec-444d-a6c4-83658ab015a4          b49a89b5-7aad-4dac-be75-e10960fcb530   none      none          off        
     oxp_b113c11f-44e6-4fb4-a56e-1d91bd652faf/crucible                                                              d4b204bb-9b37-463b-b5d4-fb0573b87988   none      none          off        
-    oxp_b113c11f-44e6-4fb4-a56e-1d91bd652faf/crypt/debug                                                           1c8bff2b-a7ca-4852-b94b-7cff9026bb2d   100 GiB   none          gzip-9     
-    oxp_b113c11f-44e6-4fb4-a56e-1d91bd652faf/crypt/zone                                                            82ff9ea6-429c-449a-89d9-c3a42a5ecb06   none      none          off        
+    oxp_b113c11f-44e6-4fb4-a56e-1d91bd652faf/crypt/debug                                                           71d6b4d8-1204-4f0f-b0e3-f47946fb7a8c   100 GiB   none          gzip-9     
+    oxp_b113c11f-44e6-4fb4-a56e-1d91bd652faf/crypt/zone                                                            3e6a4121-1ea9-4361-ad1c-14c7dd945f37   none      none          off        
     oxp_b113c11f-44e6-4fb4-a56e-1d91bd652faf/crypt/zone/oxz_crucible_cd3bb540-e605-465f-8c62-177ac482d850          eae5919a-5b33-4ec7-bd27-163120ba55a4   none      none          off        
     oxp_bf149c80-2498-481c-9989-6344da914081/crucible                                                              4af3d49c-22c1-4ea5-9992-bdff0467d023   none      none          off        
     oxp_bf149c80-2498-481c-9989-6344da914081/crypt/debug                                                           badbe224-0a39-4ccf-92d5-847905b00bc5   100 GiB   none          gzip-9     
     oxp_bf149c80-2498-481c-9989-6344da914081/crypt/zone                                                            49a3e230-e22a-4bc3-8bb4-f188e5b23c19   none      none          off        
     oxp_bf149c80-2498-481c-9989-6344da914081/crypt/zone/oxz_crucible_f52aa245-7e1b-46c0-8a31-e09725f02caf          4ffbef53-46e9-4698-afc9-12fc9e22e6af   none      none          off        
     oxp_c69b6237-09f9-45aa-962c-5dbdd1d894be/crucible                                                              c7bdd567-1585-4e5d-8e00-9fc8a582b9a8   none      none          off        
-    oxp_c69b6237-09f9-45aa-962c-5dbdd1d894be/crypt/debug                                                           b2b44420-be84-4974-99a2-60b03c895811   100 GiB   none          gzip-9     
-    oxp_c69b6237-09f9-45aa-962c-5dbdd1d894be/crypt/zone                                                            8b47156e-0faa-4cba-ba05-d1e0d1d3c382   none      none          off        
+    oxp_c69b6237-09f9-45aa-962c-5dbdd1d894be/crypt/debug                                                           ea2cc4fe-93ce-437e-9a1f-1d203bca8784   100 GiB   none          gzip-9     
+    oxp_c69b6237-09f9-45aa-962c-5dbdd1d894be/crypt/zone                                                            2dc77339-9cbf-4d86-89a8-e65a64f35673   none      none          off        
     oxp_c69b6237-09f9-45aa-962c-5dbdd1d894be/crypt/zone/oxz_crucible_b5d5491d-b3aa-4727-8b55-f66e0581ea4f          962343a7-2374-4d3e-b8df-99dded0f1bc9   none      none          off        
     oxp_ccd5a87b-00ae-42ad-85da-b37d70436cb1/crucible                                                              b058857e-6b86-474c-ac69-2851f9cd00c9   none      none          off        
-    oxp_ccd5a87b-00ae-42ad-85da-b37d70436cb1/crypt/debug                                                           523fd0cd-8d22-4f7a-a3b0-3fd0f4f88852   100 GiB   none          gzip-9     
-    oxp_ccd5a87b-00ae-42ad-85da-b37d70436cb1/crypt/zone                                                            9e78cb9f-d533-44e5-8641-d6be0fb5868b   none      none          off        
+    oxp_ccd5a87b-00ae-42ad-85da-b37d70436cb1/crypt/debug                                                           d8246b47-51dc-44c0-8a74-edbb80330f19   100 GiB   none          gzip-9     
+    oxp_ccd5a87b-00ae-42ad-85da-b37d70436cb1/crypt/zone                                                            8915abc3-13c9-4ad2-86cd-f6dcf933aca9   none      none          off        
     oxp_ccd5a87b-00ae-42ad-85da-b37d70436cb1/crypt/zone/oxz_crucible_09937ebb-bb6a-495b-bc97-b58076b70a78          819b9236-ad12-45ea-8dbf-d06c394003d7   none      none          off        
     oxp_d7410a1c-e01d-49a4-be9c-f861f086760a/crucible                                                              ab8c57d6-494c-4845-b9bb-9d7e3ff5f43d   none      none          off        
-    oxp_d7410a1c-e01d-49a4-be9c-f861f086760a/crypt/debug                                                           d8246b47-51dc-44c0-8a74-edbb80330f19   100 GiB   none          gzip-9     
-    oxp_d7410a1c-e01d-49a4-be9c-f861f086760a/crypt/zone                                                            8915abc3-13c9-4ad2-86cd-f6dcf933aca9   none      none          off        
+    oxp_d7410a1c-e01d-49a4-be9c-f861f086760a/crypt/debug                                                           b2b44420-be84-4974-99a2-60b03c895811   100 GiB   none          gzip-9     
+    oxp_d7410a1c-e01d-49a4-be9c-f861f086760a/crypt/zone                                                            8b47156e-0faa-4cba-ba05-d1e0d1d3c382   none      none          off        
     oxp_d7410a1c-e01d-49a4-be9c-f861f086760a/crypt/zone/oxz_crucible_f3628f0a-2301-4fc8-bcbf-961199771731          32706642-7c88-4dde-b2e5-2c66237051ef   none      none          off        
 
 
@@ -692,54 +692,54 @@ to:   blueprint  ade5749d-bdf3-4fab-a8ae-00bea01b3a5a
     fake-vendor   fake-model   serial-fe1d5b9f-8db7-4e2d-bf17-c4b80e1f897c
 
 
-    datasets at generation 1:
+    datasets at generation 2:
     -----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
     dataset name                                                                                                   dataset uuid                           quota     reservation   compression
     -----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
     oxp_44fa7024-c2bc-4d2c-b478-c4997e4aece8/crucible                                                              0c44736d-76e8-464f-9c5b-1df35743d849   none      none          off        
-    oxp_44fa7024-c2bc-4d2c-b478-c4997e4aece8/crypt/debug                                                           5caa41ff-a043-44bd-ac2f-6bd35f686953   100 GiB   none          gzip-9     
+    oxp_44fa7024-c2bc-4d2c-b478-c4997e4aece8/crypt/debug                                                           aa9d2a0b-37bc-450a-a18b-53ac178dfa9a   100 GiB   none          gzip-9     
     oxp_44fa7024-c2bc-4d2c-b478-c4997e4aece8/crypt/internal_dns                                                    d10b2deb-f770-40d3-8b4f-03a14e47ccde   none      none          off        
-    oxp_44fa7024-c2bc-4d2c-b478-c4997e4aece8/crypt/zone                                                            01d56c05-8fd5-48f0-8fde-7b8a4df1f1e5   none      none          off        
+    oxp_44fa7024-c2bc-4d2c-b478-c4997e4aece8/crypt/zone                                                            4ca68409-860f-4606-9118-223a99784048   none      none          off        
     oxp_44fa7024-c2bc-4d2c-b478-c4997e4aece8/crypt/zone/oxz_crucible_413d3e02-e19f-400a-9718-a662347538f0          ba98af8c-d358-4a22-b172-767b17075307   none      none          off        
     oxp_44fa7024-c2bc-4d2c-b478-c4997e4aece8/crypt/zone/oxz_crucible_pantry_315a3670-d019-425c-b7a6-c9429428b671   8426cb5d-176f-46f0-8111-f1792f20833c   none      none          off        
     oxp_44fa7024-c2bc-4d2c-b478-c4997e4aece8/crypt/zone/oxz_internal_dns_8b47e1e8-0396-4e44-a4a5-ea891405c9f2      fee2f9a5-fef1-4217-ae29-822983085f71   none      none          off        
     oxp_44fa7024-c2bc-4d2c-b478-c4997e4aece8/crypt/zone/oxz_nexus_b43ce109-90d6-46f9-9df0-8c68bfe6d4a0             eeee1d0d-cc48-45c2-8718-2bebfdf4d5e3   none      none          off        
     oxp_44fa7024-c2bc-4d2c-b478-c4997e4aece8/crypt/zone/oxz_ntp_cbe91cdc-cbb6-4760-aece-6ce08b67e85a               668b7c91-1466-43e3-bb8f-becdb1c20493   none      none          off        
     oxp_5265edc6-debf-4687-a758-a9746893ebd3/crucible                                                              64a69811-e0a8-427d-8f4b-2fe77f4eaaef   none      none          off        
-    oxp_5265edc6-debf-4687-a758-a9746893ebd3/crypt/debug                                                           e21195e1-d410-4ba0-a78c-2fb91310ab9e   100 GiB   none          gzip-9     
-    oxp_5265edc6-debf-4687-a758-a9746893ebd3/crypt/zone                                                            30e61fef-5a8c-498a-835e-ffada88d73b7   none      none          off        
+    oxp_5265edc6-debf-4687-a758-a9746893ebd3/crypt/debug                                                           3fd90a28-4348-4331-b52d-ad933520add3   100 GiB   none          gzip-9     
+    oxp_5265edc6-debf-4687-a758-a9746893ebd3/crypt/zone                                                            6cd435eb-07d5-40bc-a50b-c9bf61fc3de2   none      none          off        
     oxp_5265edc6-debf-4687-a758-a9746893ebd3/crypt/zone/oxz_crucible_b5443ebd-1f5b-448c-8edc-b4ca25c25db1          037fc003-d941-4639-8ab8-ce67926b107d   none      none          off        
     oxp_532fbd69-b472-4445-86af-4c4c85afb313/crucible                                                              6ca42c2b-ac96-4d42-bfb4-120bbab62fe8   none      none          off        
-    oxp_532fbd69-b472-4445-86af-4c4c85afb313/crypt/debug                                                           aa9d2a0b-37bc-450a-a18b-53ac178dfa9a   100 GiB   none          gzip-9     
-    oxp_532fbd69-b472-4445-86af-4c4c85afb313/crypt/zone                                                            4ca68409-860f-4606-9118-223a99784048   none      none          off        
+    oxp_532fbd69-b472-4445-86af-4c4c85afb313/crypt/debug                                                           e21195e1-d410-4ba0-a78c-2fb91310ab9e   100 GiB   none          gzip-9     
+    oxp_532fbd69-b472-4445-86af-4c4c85afb313/crypt/zone                                                            30e61fef-5a8c-498a-835e-ffada88d73b7   none      none          off        
     oxp_532fbd69-b472-4445-86af-4c4c85afb313/crypt/zone/oxz_crucible_e135441d-637e-4de9-8023-5ea0096347f3          bb5be931-233b-4741-a9cd-951f5977ac57   none      none          off        
     oxp_54fd6fa6-ce3c-4abe-8c9d-7e107e159e84/crucible                                                              ecfa453d-3c6c-4ac2-8be1-439208df2eac   none      none          off        
-    oxp_54fd6fa6-ce3c-4abe-8c9d-7e107e159e84/crypt/debug                                                           3fd90a28-4348-4331-b52d-ad933520add3   100 GiB   none          gzip-9     
-    oxp_54fd6fa6-ce3c-4abe-8c9d-7e107e159e84/crypt/zone                                                            6cd435eb-07d5-40bc-a50b-c9bf61fc3de2   none      none          off        
+    oxp_54fd6fa6-ce3c-4abe-8c9d-7e107e159e84/crypt/debug                                                           89eef0ca-8367-4343-9390-c17d53beb0e1   100 GiB   none          gzip-9     
+    oxp_54fd6fa6-ce3c-4abe-8c9d-7e107e159e84/crypt/zone                                                            101a1e8b-362a-49bf-b209-dcd4aedaa3fb   none      none          off        
     oxp_54fd6fa6-ce3c-4abe-8c9d-7e107e159e84/crypt/zone/oxz_crucible_bb55534c-1042-4af4-ad2f-9590803695ac          e67687c5-2699-4630-9092-9a42d2ff160f   none      none          off        
     oxp_8562317c-4736-4cfc-9292-7dcab96a6fee/crucible                                                              abbbaf81-fd62-498b-8e18-221c68065b2c   none      none          off        
-    oxp_8562317c-4736-4cfc-9292-7dcab96a6fee/crypt/debug                                                           ce331e9e-8f0c-4c3a-9565-561d6760710d   100 GiB   none          gzip-9     
-    oxp_8562317c-4736-4cfc-9292-7dcab96a6fee/crypt/zone                                                            40fb0fd8-3ad0-4fb3-a22f-59c628905e93   none      none          off        
+    oxp_8562317c-4736-4cfc-9292-7dcab96a6fee/crypt/debug                                                           abb97aa4-9deb-45b5-8844-51200e8e190d   100 GiB   none          gzip-9     
+    oxp_8562317c-4736-4cfc-9292-7dcab96a6fee/crypt/zone                                                            bcf1d9c3-3c77-4f80-9f07-52d0abf4cd25   none      none          off        
     oxp_8562317c-4736-4cfc-9292-7dcab96a6fee/crypt/zone/oxz_crucible_6d725df0-0189-4429-b270-3eeb891d39c8          46135910-450d-4949-9fab-a9b0a54a68c1   none      none          off        
     oxp_9a1327e4-d11b-4d98-8454-8c41862e9832/crucible                                                              5afdb92a-28ab-4de1-954d-6192fea1a18b   none      none          off        
-    oxp_9a1327e4-d11b-4d98-8454-8c41862e9832/crypt/debug                                                           f166a5e8-6790-42eb-8bff-6856d4471247   100 GiB   none          gzip-9     
-    oxp_9a1327e4-d11b-4d98-8454-8c41862e9832/crypt/zone                                                            430ebbbf-a9ef-488e-9e1b-54e74ff73922   none      none          off        
+    oxp_9a1327e4-d11b-4d98-8454-8c41862e9832/crypt/debug                                                           95a0e096-5120-43a1-9b6d-ab685ce100c6   100 GiB   none          gzip-9     
+    oxp_9a1327e4-d11b-4d98-8454-8c41862e9832/crypt/zone                                                            455e96ed-bdc6-4d46-9774-22a299a513b2   none      none          off        
     oxp_9a1327e4-d11b-4d98-8454-8c41862e9832/crypt/zone/oxz_crucible_6cb330f9-4609-4d6c-98ad-b5cc34245813          943211c9-063e-4860-8d94-54d55c499349   none      none          off        
     oxp_bf9d6692-64bc-459a-87dd-e7a83080a210/crucible                                                              d0f2d2a4-95f6-4767-92b7-05a5a3b2822c   none      none          off        
-    oxp_bf9d6692-64bc-459a-87dd-e7a83080a210/crypt/debug                                                           89eef0ca-8367-4343-9390-c17d53beb0e1   100 GiB   none          gzip-9     
-    oxp_bf9d6692-64bc-459a-87dd-e7a83080a210/crypt/zone                                                            101a1e8b-362a-49bf-b209-dcd4aedaa3fb   none      none          off        
+    oxp_bf9d6692-64bc-459a-87dd-e7a83080a210/crypt/debug                                                           f166a5e8-6790-42eb-8bff-6856d4471247   100 GiB   none          gzip-9     
+    oxp_bf9d6692-64bc-459a-87dd-e7a83080a210/crypt/zone                                                            430ebbbf-a9ef-488e-9e1b-54e74ff73922   none      none          off        
     oxp_bf9d6692-64bc-459a-87dd-e7a83080a210/crypt/zone/oxz_crucible_fee71ee6-da42-4a7f-a00e-f56b6a3327ce          bdd191e4-cd8f-49c5-b887-7e7c9ba81051   none      none          off        
     oxp_ce1c13f3-bef2-4306-b0f2-4e39bd4a18b6/crucible                                                              d8a968b5-8cc3-4dbc-a22d-723adce3d82f   none      none          off        
     oxp_ce1c13f3-bef2-4306-b0f2-4e39bd4a18b6/crypt/debug                                                           93255645-6328-4f3f-83df-a67f1206fdbf   100 GiB   none          gzip-9     
     oxp_ce1c13f3-bef2-4306-b0f2-4e39bd4a18b6/crypt/zone                                                            358ef33b-11da-4ba6-b0a2-6d881e4d3b29   none      none          off        
     oxp_ce1c13f3-bef2-4306-b0f2-4e39bd4a18b6/crypt/zone/oxz_crucible_de65f128-30f7-422b-a234-d1fc8dd6ef78          65569fd8-0748-4bf6-9ee9-c9cb6fbbb43b   none      none          off        
     oxp_f931ec80-a3e3-4adb-a8ba-fa5adbd2294c/crucible                                                              82c773a2-9a18-4c31-8a65-fb5419f9b853   none      none          off        
-    oxp_f931ec80-a3e3-4adb-a8ba-fa5adbd2294c/crypt/debug                                                           95a0e096-5120-43a1-9b6d-ab685ce100c6   100 GiB   none          gzip-9     
-    oxp_f931ec80-a3e3-4adb-a8ba-fa5adbd2294c/crypt/zone                                                            455e96ed-bdc6-4d46-9774-22a299a513b2   none      none          off        
+    oxp_f931ec80-a3e3-4adb-a8ba-fa5adbd2294c/crypt/debug                                                           ce331e9e-8f0c-4c3a-9565-561d6760710d   100 GiB   none          gzip-9     
+    oxp_f931ec80-a3e3-4adb-a8ba-fa5adbd2294c/crypt/zone                                                            40fb0fd8-3ad0-4fb3-a22f-59c628905e93   none      none          off        
     oxp_f931ec80-a3e3-4adb-a8ba-fa5adbd2294c/crypt/zone/oxz_crucible_d14c165f-6370-4cce-9dba-3c6deb762cfc          3eeca505-f147-4afa-a032-1643c2ef87ef   none      none          off        
     oxp_fe1d5b9f-8db7-4e2d-bf17-c4b80e1f897c/crucible                                                              317e2495-e4b4-4fe5-9e46-a582b797f0f1   none      none          off        
-    oxp_fe1d5b9f-8db7-4e2d-bf17-c4b80e1f897c/crypt/debug                                                           abb97aa4-9deb-45b5-8844-51200e8e190d   100 GiB   none          gzip-9     
-    oxp_fe1d5b9f-8db7-4e2d-bf17-c4b80e1f897c/crypt/zone                                                            bcf1d9c3-3c77-4f80-9f07-52d0abf4cd25   none      none          off        
+    oxp_fe1d5b9f-8db7-4e2d-bf17-c4b80e1f897c/crypt/debug                                                           5caa41ff-a043-44bd-ac2f-6bd35f686953   100 GiB   none          gzip-9     
+    oxp_fe1d5b9f-8db7-4e2d-bf17-c4b80e1f897c/crypt/zone                                                            01d56c05-8fd5-48f0-8fde-7b8a4df1f1e5   none      none          off        
     oxp_fe1d5b9f-8db7-4e2d-bf17-c4b80e1f897c/crypt/zone/oxz_crucible_c4296f9f-f902-4fc7-b896-178e56e60732          13f5b476-412a-4879-903b-5a9ac4ca6fd3   none      none          off        
 
 

--- a/nexus/reconfigurator/planning/src/blueprint_builder/builder/datasets_editor.rs
+++ b/nexus/reconfigurator/planning/src/blueprint_builder/builder/datasets_editor.rs
@@ -246,7 +246,7 @@ impl<'a> SledDatasetsEditor<'a> {
     /// - If the dataset exists in the blueprint already, use it.
     /// - Otherwise, if the dataset exists in the database, re-use the UUID, but
     ///   add it to the blueprint.
-    /// - Otherwse, create a new dataset in the blueprint, which will propagate
+    /// - Otherwise, create a new dataset in the blueprint, which will propagate
     ///   to the database during execution.
     pub fn ensure_dataset(
         &mut self,

--- a/nexus/reconfigurator/planning/src/blueprint_builder/builder/datasets_editor.rs
+++ b/nexus/reconfigurator/planning/src/blueprint_builder/builder/datasets_editor.rs
@@ -1,0 +1,358 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at https://mozilla.org/MPL/2.0/.
+
+//! Helper for editing the datasets of a Blueprint
+
+use crate::planner::PlannerRng;
+
+use super::Ensure;
+use illumos_utils::zpool::ZpoolName;
+use nexus_types::deployment::BlueprintDatasetConfig;
+use nexus_types::deployment::BlueprintDatasetDisposition;
+use nexus_types::deployment::BlueprintDatasetsConfig;
+use nexus_types::deployment::SledResources;
+use nexus_types::deployment::ZpoolFilter;
+use omicron_common::api::external::ByteCount;
+use omicron_common::api::external::Generation;
+use omicron_common::disk::CompressionAlgorithm;
+use omicron_common::disk::DatasetKind;
+use omicron_common::disk::DatasetName;
+use omicron_common::disk::GzipLevel;
+use omicron_uuid_kinds::DatasetUuid;
+use omicron_uuid_kinds::SledUuid;
+use omicron_uuid_kinds::ZpoolUuid;
+use std::collections::btree_map::Entry;
+use std::collections::BTreeMap;
+use std::collections::BTreeSet;
+use std::net::SocketAddrV6;
+
+#[derive(Debug, thiserror::Error)]
+pub enum BlueprintDatasetsEditError {
+    #[error(
+        "internal inconsistency: multiple datasets with kind {kind:?} \
+         on zpool {zpool_id}: {id1}, {id2}"
+    )]
+    MultipleDatasetsOfKind {
+        zpool_id: ZpoolUuid,
+        kind: DatasetKind,
+        id1: DatasetUuid,
+        id2: DatasetUuid,
+    },
+}
+
+/// Helper for working with sets of datasets on each sled
+///
+/// Tracking the set of datasets is slightly non-trivial because we need to
+/// bump the per-sled generation number iff the datasets are changed.  So
+/// we need to keep track of whether we've changed the datasets relative
+/// to the parent blueprint.
+#[derive(Debug)]
+pub(super) struct BlueprintDatasetsEditor {
+    current: BTreeMap<SledUuid, BlueprintDatasetsConfig>,
+    changed: BTreeSet<SledUuid>,
+}
+
+impl BlueprintDatasetsEditor {
+    pub fn new(current: BTreeMap<SledUuid, BlueprintDatasetsConfig>) -> Self {
+        Self { current, changed: BTreeSet::new() }
+    }
+
+    /// Get a helper to edit the datasets of a specific sled.
+    ///
+    /// If any changes are made via the returned editor, the sled will be
+    /// recorded as needing a generation bump in its dataset config when the
+    /// editor is dropped.
+    pub fn sled_datasets_editor<'a>(
+        &'a mut self,
+        sled_id: SledUuid,
+        sled_resources: &SledResources,
+        rng: &'a mut PlannerRng,
+    ) -> Result<SledDatasetsEditor<'a>, BlueprintDatasetsEditError> {
+        let config = self
+            .current
+            .entry(sled_id)
+            .or_insert_with(empty_blueprint_datasets_config);
+
+        // Gather all dataset IDs known to the blueprint and to the database.
+        let blueprint_dataset_ids =
+            build_dataset_kind_id_map(config.datasets.values().map(
+                |dataset| (dataset.pool.id(), dataset.kind.clone(), dataset.id),
+            ))?;
+        let database_dataset_ids = build_dataset_kind_id_map(
+            sled_resources.all_datasets(ZpoolFilter::InService).flat_map(
+                |(&zpool_id, configs)| {
+                    configs.iter().map(move |config| {
+                        (zpool_id, config.name.dataset().clone(), config.id)
+                    })
+                },
+            ),
+        )?;
+
+        Ok(SledDatasetsEditor::new(
+            rng,
+            blueprint_dataset_ids,
+            database_dataset_ids,
+            sled_id,
+            config,
+            &mut self.changed,
+        ))
+    }
+
+    pub fn build(
+        mut self,
+        sled_ids: impl Iterator<Item = SledUuid>,
+    ) -> BTreeMap<SledUuid, BlueprintDatasetsConfig> {
+        sled_ids
+            .map(|sled_id| {
+                let config = match self.current.remove(&sled_id) {
+                    Some(mut config) => {
+                        // Bump generation number for any sled whose
+                        // DatasetsConfig changed
+                        if self.changed.contains(&sled_id) {
+                            config.generation = config.generation.next()
+                        }
+                        config
+                    }
+                    None => empty_blueprint_datasets_config(),
+                };
+                (sled_id, config)
+            })
+            .collect()
+    }
+}
+
+#[derive(Debug)]
+pub(super) struct SledDatasetsEditor<'a> {
+    rng: &'a mut PlannerRng,
+    blueprint_dataset_ids:
+        BTreeMap<ZpoolUuid, BTreeMap<DatasetKind, DatasetUuid>>,
+    database_dataset_ids:
+        BTreeMap<ZpoolUuid, BTreeMap<DatasetKind, DatasetUuid>>,
+    config: &'a mut BlueprintDatasetsConfig,
+    changed: bool,
+    sled_id: SledUuid,
+    parent_changed_set: &'a mut BTreeSet<SledUuid>,
+}
+
+impl Drop for SledDatasetsEditor<'_> {
+    fn drop(&mut self) {
+        if self.changed {
+            self.parent_changed_set.insert(self.sled_id);
+        }
+    }
+}
+
+impl<'a> SledDatasetsEditor<'a> {
+    fn new(
+        rng: &'a mut PlannerRng,
+        blueprint_dataset_ids: BTreeMap<
+            ZpoolUuid,
+            BTreeMap<DatasetKind, DatasetUuid>,
+        >,
+        database_dataset_ids: BTreeMap<
+            ZpoolUuid,
+            BTreeMap<DatasetKind, DatasetUuid>,
+        >,
+        sled_id: SledUuid,
+        config: &'a mut BlueprintDatasetsConfig,
+        parent_changed_set: &'a mut BTreeSet<SledUuid>,
+    ) -> Self {
+        Self {
+            rng,
+            blueprint_dataset_ids,
+            database_dataset_ids,
+            config,
+            changed: false,
+            sled_id,
+            parent_changed_set,
+        }
+    }
+
+    pub fn database_dataset_ids(
+        &self,
+    ) -> &BTreeMap<ZpoolUuid, BTreeMap<DatasetKind, DatasetUuid>> {
+        &self.database_dataset_ids
+    }
+
+    pub fn datasets(&self) -> impl Iterator<Item = &BlueprintDatasetConfig> {
+        self.config.datasets.values()
+    }
+
+    pub fn expunge_datasets_if<F>(&mut self, mut expunge_if: F) -> usize
+    where
+        F: FnMut(&BlueprintDatasetConfig) -> bool,
+    {
+        let mut num_expunged = 0;
+
+        for dataset in self.config.datasets.values_mut() {
+            match dataset.disposition {
+                // Already expunged; ignore
+                BlueprintDatasetDisposition::Expunged => continue,
+                // Potentially expungeable
+                BlueprintDatasetDisposition::InService => (),
+            }
+            if expunge_if(&*dataset) {
+                dataset.disposition = BlueprintDatasetDisposition::Expunged;
+                num_expunged += 1;
+                self.changed = true;
+            }
+        }
+
+        num_expunged
+    }
+
+    pub fn ensure_debug_dataset(
+        &mut self,
+        zpool: ZpoolName,
+    ) -> (DatasetUuid, Ensure) {
+        const DEBUG_QUOTA_SIZE_GB: u32 = 100;
+
+        let address = None;
+        let quota = Some(ByteCount::from_gibibytes_u32(DEBUG_QUOTA_SIZE_GB));
+        let reservation = None;
+
+        self.ensure_dataset(
+            DatasetName::new(zpool, DatasetKind::Debug),
+            address,
+            quota,
+            reservation,
+            CompressionAlgorithm::GzipN { level: GzipLevel::new::<9>() },
+        )
+    }
+
+    pub fn ensure_zone_root_dataset(
+        &mut self,
+        zpool: ZpoolName,
+    ) -> (DatasetUuid, Ensure) {
+        let address = None;
+        let quota = None;
+        let reservation = None;
+
+        self.ensure_dataset(
+            DatasetName::new(zpool, DatasetKind::TransientZoneRoot),
+            address,
+            quota,
+            reservation,
+            CompressionAlgorithm::Off,
+        )
+    }
+
+    /// Ensures a dataset exists on this sled.
+    ///
+    /// - If the dataset exists in the blueprint already, use it.
+    /// - Otherwise, if the dataset exists in the database, re-use the UUID, but
+    ///   add it to the blueprint.
+    /// - Otherwse, create a new dataset in the blueprint, which will propagate
+    ///   to the database during execution.
+    pub fn ensure_dataset(
+        &mut self,
+        dataset: DatasetName,
+        address: Option<SocketAddrV6>,
+        quota: Option<ByteCount>,
+        reservation: Option<ByteCount>,
+        compression: CompressionAlgorithm,
+    ) -> (DatasetUuid, Ensure) {
+        let zpool_id = dataset.pool().id();
+        let kind = dataset.dataset();
+
+        let make_config = |id: DatasetUuid| BlueprintDatasetConfig {
+            disposition: BlueprintDatasetDisposition::InService,
+            id,
+            pool: dataset.pool().clone(),
+            kind: kind.clone(),
+            address,
+            quota,
+            reservation,
+            compression,
+        };
+
+        // Is this dataset already in the blueprint? If so, update it if it's
+        // changed.
+        if let Some(existing_id) = self
+            .blueprint_dataset_ids
+            .get(&zpool_id)
+            .and_then(|kind_to_id| kind_to_id.get(kind))
+        {
+            let old_config = self.config.datasets.get_mut(existing_id).expect(
+                "internal inconsistency: \
+                 entry in blueprint_dataset_ids but not current",
+            );
+            let new_config = make_config(*existing_id);
+
+            let ensure = if new_config != *old_config {
+                *old_config = new_config;
+                self.changed = true;
+                Ensure::Updated
+            } else {
+                Ensure::NotNeeded
+            };
+
+            return (old_config.id, ensure);
+        }
+
+        // Is there a dataset ID matching this one in the database? If so, use
+        // that.
+        //
+        // TODO(https://github.com/oxidecomputer/omicron/issues/6645): We
+        // could avoid reading from the datastore if we were confident all
+        // provisioned datasets existed in the parent blueprint.
+        let id = self
+            .database_dataset_ids
+            .get(&zpool_id)
+            .and_then(|kind_to_id| kind_to_id.get(kind))
+            .copied()
+            .unwrap_or_else(|| self.rng.next_dataset());
+
+        self.config.datasets.insert(id, make_config(id));
+        self.changed = true;
+
+        // We updated our config, so also record this ID in our "present in
+        // the blueprint" map. We know the entry doesn't exist or we would have
+        // found it when we checked above.
+        self.blueprint_dataset_ids
+            .entry(zpool_id)
+            .or_default()
+            .insert(kind.clone(), id);
+
+        (id, Ensure::Added)
+    }
+}
+
+fn build_dataset_kind_id_map(
+    iter: impl Iterator<Item = (ZpoolUuid, DatasetKind, DatasetUuid)>,
+) -> Result<
+    BTreeMap<ZpoolUuid, BTreeMap<DatasetKind, DatasetUuid>>,
+    BlueprintDatasetsEditError,
+> {
+    let mut kind_id_map: BTreeMap<
+        ZpoolUuid,
+        BTreeMap<DatasetKind, DatasetUuid>,
+    > = BTreeMap::new();
+    for (zpool_id, kind, dataset_id) in iter {
+        let dataset_ids_by_kind = kind_id_map.entry(zpool_id).or_default();
+        match dataset_ids_by_kind.entry(kind) {
+            Entry::Vacant(slot) => {
+                slot.insert(dataset_id);
+            }
+            Entry::Occupied(prev) => {
+                return Err(
+                    BlueprintDatasetsEditError::MultipleDatasetsOfKind {
+                        zpool_id,
+                        kind: prev.key().clone(),
+                        id1: *prev.get(),
+                        id2: dataset_id,
+                    },
+                );
+            }
+        }
+    }
+    Ok(kind_id_map)
+}
+
+fn empty_blueprint_datasets_config() -> BlueprintDatasetsConfig {
+    BlueprintDatasetsConfig {
+        generation: Generation::new(),
+        datasets: BTreeMap::new(),
+    }
+}

--- a/nexus/reconfigurator/planning/tests/output/blueprint_builder_initial_diff.txt
+++ b/nexus/reconfigurator/planning/tests/output/blueprint_builder_initial_diff.txt
@@ -20,15 +20,15 @@ to:   blueprint  e4aeb3b3-272f-4967-be34-2d34daa46aa1
     fake-vendor   fake-model   serial-f9bcdb70-6846-4330-9d37-bfdd5583aea6
 
 
-    datasets at generation 1:
+    datasets at generation 2:
     -----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
     dataset name                                                                                                   dataset uuid                           quota     reservation   compression
     -----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
     oxp_3fb05590-2632-413e-989f-aaaabaf01fab/crucible                                                              750b5b15-b541-4506-9244-b93b277a9646   none      none          off        
     oxp_3fb05590-2632-413e-989f-aaaabaf01fab/crypt/clickhouse                                                      1123460d-14bc-4651-8e92-b71a4cb1320a   none      none          off        
-    oxp_3fb05590-2632-413e-989f-aaaabaf01fab/crypt/debug                                                           613c5d20-d3c3-4d43-ae5a-dda783ae87ba   100 GiB   none          gzip-9     
+    oxp_3fb05590-2632-413e-989f-aaaabaf01fab/crypt/debug                                                           a51f6079-d3e1-4c1e-b93f-b5d406ea37d6   100 GiB   none          gzip-9     
     oxp_3fb05590-2632-413e-989f-aaaabaf01fab/crypt/internal_dns                                                    1b14ab69-234b-456e-a253-5309c45d0cdd   none      none          off        
-    oxp_3fb05590-2632-413e-989f-aaaabaf01fab/crypt/zone                                                            70b3a51d-a3bf-4019-ad3d-04c5ce992ffe   none      none          off        
+    oxp_3fb05590-2632-413e-989f-aaaabaf01fab/crypt/zone                                                            c28e6261-80ed-4553-828a-f6031a2fa866   none      none          off        
     oxp_3fb05590-2632-413e-989f-aaaabaf01fab/crypt/zone/oxz_clickhouse_44afce85-3377-4b20-a398-517c1579df4d        7ef76726-083e-4f84-a818-8394b820f862   none      none          off        
     oxp_3fb05590-2632-413e-989f-aaaabaf01fab/crypt/zone/oxz_crucible_79552859-fbd3-43bb-a9d3-6baba25558f8          43b758fe-e7e6-4bed-bcb6-64789c180fe1   none      none          off        
     oxp_3fb05590-2632-413e-989f-aaaabaf01fab/crypt/zone/oxz_crucible_pantry_55f4d117-0b9d-4256-a2c0-f46d3ed5fff9   f22149ee-144a-4c39-89bb-c6cea2a5173e   none      none          off        
@@ -36,40 +36,40 @@ to:   blueprint  e4aeb3b3-272f-4967-be34-2d34daa46aa1
     oxp_3fb05590-2632-413e-989f-aaaabaf01fab/crypt/zone/oxz_nexus_b2573120-9c91-4ed7-8b4f-a7bfe8dbc807             170a525e-dda8-4ce6-9cf1-fbe1b8e8b69d   none      none          off        
     oxp_3fb05590-2632-413e-989f-aaaabaf01fab/crypt/zone/oxz_ntp_c81c9d4a-36d7-4796-9151-f564d3735152               a605a65f-1430-4e04-8d39-74f3f9ecd99c   none      none          off        
     oxp_4711ce46-43f6-4732-9769-a69ea519b62d/crucible                                                              73deef16-ed89-4217-b4ee-245208ccddbc   none      none          off        
-    oxp_4711ce46-43f6-4732-9769-a69ea519b62d/crypt/debug                                                           5f11f7e2-c868-4494-bb58-9f5d1691624e   100 GiB   none          gzip-9     
-    oxp_4711ce46-43f6-4732-9769-a69ea519b62d/crypt/zone                                                            da15dac3-157f-428c-b114-0f151ab8e3d5   none      none          off        
+    oxp_4711ce46-43f6-4732-9769-a69ea519b62d/crypt/debug                                                           b4e82f4d-bc70-49f0-b0aa-194aa2dc6b23   100 GiB   none          gzip-9     
+    oxp_4711ce46-43f6-4732-9769-a69ea519b62d/crypt/zone                                                            22d59c0d-1687-432c-a847-5ef3c4ea1707   none      none          off        
     oxp_4711ce46-43f6-4732-9769-a69ea519b62d/crypt/zone/oxz_crucible_90696819-9b53-485a-9c65-ca63602e843e          8539d147-7b9f-4746-a00f-b61bafa3a46e   none      none          off        
     oxp_4a2cc08d-8e18-4f0e-8fc6-443cb2016858/crucible                                                              6afc575c-d188-45ee-9f8e-4b67f4328fdc   none      none          off        
-    oxp_4a2cc08d-8e18-4f0e-8fc6-443cb2016858/crypt/debug                                                           d52b83be-2c94-495c-baae-f9a051db37d2   100 GiB   none          gzip-9     
-    oxp_4a2cc08d-8e18-4f0e-8fc6-443cb2016858/crypt/zone                                                            03ad2792-8fac-4c2a-8e81-0d5de681a4ba   none      none          off        
+    oxp_4a2cc08d-8e18-4f0e-8fc6-443cb2016858/crypt/debug                                                           d048b1c6-4730-4005-a964-fce3d86e76ad   100 GiB   none          gzip-9     
+    oxp_4a2cc08d-8e18-4f0e-8fc6-443cb2016858/crypt/zone                                                            7857daa4-ef48-4e7d-9961-d0d34a344746   none      none          off        
     oxp_4a2cc08d-8e18-4f0e-8fc6-443cb2016858/crypt/zone/oxz_crucible_5c6a4628-8831-483b-995f-79b9126c4d04          c479e900-76d3-460f-82f1-eb6467becd91   none      none          off        
     oxp_7032a67e-2ff6-45cc-af34-8b3502965cc9/crucible                                                              fd3fee94-220f-46e1-b60c-2db3c484dd89   none      none          off        
-    oxp_7032a67e-2ff6-45cc-af34-8b3502965cc9/crypt/debug                                                           04440028-c8bf-484f-929e-c2811db1d6c4   100 GiB   none          gzip-9     
-    oxp_7032a67e-2ff6-45cc-af34-8b3502965cc9/crypt/zone                                                            5c40200b-a261-40fc-8e82-1741ffa4d7c5   none      none          off        
+    oxp_7032a67e-2ff6-45cc-af34-8b3502965cc9/crypt/debug                                                           f26fd0f8-03ce-459b-8309-785e8c306d83   100 GiB   none          gzip-9     
+    oxp_7032a67e-2ff6-45cc-af34-8b3502965cc9/crypt/zone                                                            43fbca70-69af-4c55-af3f-7ff3326a99d2   none      none          off        
     oxp_7032a67e-2ff6-45cc-af34-8b3502965cc9/crypt/zone/oxz_crucible_6a01210c-45ed-41a5-9230-8e05ecf5dd8f          6b879024-3f61-4272-a022-05fb63bd75aa   none      none          off        
     oxp_908218e9-26ea-4d75-86f9-4b99ff72dcb5/crucible                                                              d5b0ab35-b0c0-4a4b-929d-f907ac927638   none      none          off        
-    oxp_908218e9-26ea-4d75-86f9-4b99ff72dcb5/crypt/debug                                                           c57d915c-9e21-4177-ba19-f58846ac3946   100 GiB   none          gzip-9     
-    oxp_908218e9-26ea-4d75-86f9-4b99ff72dcb5/crypt/zone                                                            2b7326fa-d02e-4c08-baa8-5eaf2d20b33b   none      none          off        
+    oxp_908218e9-26ea-4d75-86f9-4b99ff72dcb5/crypt/debug                                                           5f11f7e2-c868-4494-bb58-9f5d1691624e   100 GiB   none          gzip-9     
+    oxp_908218e9-26ea-4d75-86f9-4b99ff72dcb5/crypt/zone                                                            da15dac3-157f-428c-b114-0f151ab8e3d5   none      none          off        
     oxp_908218e9-26ea-4d75-86f9-4b99ff72dcb5/crypt/zone/oxz_crucible_c99525b3-3680-4df6-9214-2ee3e1020e8b          14da6b65-4e17-4974-9e05-345bd8e48dfb   none      none          off        
     oxp_9bc4e63d-b8fe-4ac6-ac3a-cf097d06cc6d/crucible                                                              3d181bb0-dfb8-460c-9fdd-81d45451f751   none      none          off        
-    oxp_9bc4e63d-b8fe-4ac6-ac3a-cf097d06cc6d/crypt/debug                                                           218ba88a-838f-4397-9dfb-49f67099d48b   100 GiB   none          gzip-9     
-    oxp_9bc4e63d-b8fe-4ac6-ac3a-cf097d06cc6d/crypt/zone                                                            32c80edc-5ccd-4f02-98bb-8e891b09e683   none      none          off        
+    oxp_9bc4e63d-b8fe-4ac6-ac3a-cf097d06cc6d/crypt/debug                                                           c57d915c-9e21-4177-ba19-f58846ac3946   100 GiB   none          gzip-9     
+    oxp_9bc4e63d-b8fe-4ac6-ac3a-cf097d06cc6d/crypt/zone                                                            2b7326fa-d02e-4c08-baa8-5eaf2d20b33b   none      none          off        
     oxp_9bc4e63d-b8fe-4ac6-ac3a-cf097d06cc6d/crypt/zone/oxz_crucible_f42959d3-9eef-4e3b-b404-6177ce3ec7a1          4d7a3506-392e-429a-9295-10d14e7c3ae7   none      none          off        
     oxp_9f343299-ef7a-46aa-9904-061be15abfeb/crucible                                                              10e97a60-9424-4332-9f36-1f7d7adfcc16   none      none          off        
-    oxp_9f343299-ef7a-46aa-9904-061be15abfeb/crypt/debug                                                           d048b1c6-4730-4005-a964-fce3d86e76ad   100 GiB   none          gzip-9     
-    oxp_9f343299-ef7a-46aa-9904-061be15abfeb/crypt/zone                                                            7857daa4-ef48-4e7d-9961-d0d34a344746   none      none          off        
+    oxp_9f343299-ef7a-46aa-9904-061be15abfeb/crypt/debug                                                           04440028-c8bf-484f-929e-c2811db1d6c4   100 GiB   none          gzip-9     
+    oxp_9f343299-ef7a-46aa-9904-061be15abfeb/crypt/zone                                                            5c40200b-a261-40fc-8e82-1741ffa4d7c5   none      none          off        
     oxp_9f343299-ef7a-46aa-9904-061be15abfeb/crypt/zone/oxz_crucible_4644ea0c-0ec3-41be-a356-660308e1c3fc          c1e703f4-5547-4cac-bd3b-938364961df7   none      none          off        
     oxp_c8523dd7-4e87-4e4b-8e46-04b806f0763c/crucible                                                              cbe0b7c1-326d-4c7e-a871-eb8b08653fc9   none      none          off        
-    oxp_c8523dd7-4e87-4e4b-8e46-04b806f0763c/crypt/debug                                                           b4e82f4d-bc70-49f0-b0aa-194aa2dc6b23   100 GiB   none          gzip-9     
-    oxp_c8523dd7-4e87-4e4b-8e46-04b806f0763c/crypt/zone                                                            22d59c0d-1687-432c-a847-5ef3c4ea1707   none      none          off        
+    oxp_c8523dd7-4e87-4e4b-8e46-04b806f0763c/crypt/debug                                                           218ba88a-838f-4397-9dfb-49f67099d48b   100 GiB   none          gzip-9     
+    oxp_c8523dd7-4e87-4e4b-8e46-04b806f0763c/crypt/zone                                                            32c80edc-5ccd-4f02-98bb-8e891b09e683   none      none          off        
     oxp_c8523dd7-4e87-4e4b-8e46-04b806f0763c/crypt/zone/oxz_crucible_38b047ea-e3de-4859-b8e0-70cac5871446          8c98392d-df57-4c21-a0d3-85bd81438049   none      none          off        
     oxp_e02245bc-ca0d-4f08-ac1e-870c4fa2a17c/crucible                                                              49c827a1-3125-451d-9213-3276118a5a44   none      none          off        
-    oxp_e02245bc-ca0d-4f08-ac1e-870c4fa2a17c/crypt/debug                                                           a51f6079-d3e1-4c1e-b93f-b5d406ea37d6   100 GiB   none          gzip-9     
-    oxp_e02245bc-ca0d-4f08-ac1e-870c4fa2a17c/crypt/zone                                                            c28e6261-80ed-4553-828a-f6031a2fa866   none      none          off        
+    oxp_e02245bc-ca0d-4f08-ac1e-870c4fa2a17c/crypt/debug                                                           d52b83be-2c94-495c-baae-f9a051db37d2   100 GiB   none          gzip-9     
+    oxp_e02245bc-ca0d-4f08-ac1e-870c4fa2a17c/crypt/zone                                                            03ad2792-8fac-4c2a-8e81-0d5de681a4ba   none      none          off        
     oxp_e02245bc-ca0d-4f08-ac1e-870c4fa2a17c/crypt/zone/oxz_crucible_fb36b9dc-273a-4bc3-aaa9-19ee4d0ef552          26378c99-c953-45ba-a045-37d4f8b91173   none      none          off        
     oxp_f9bcdb70-6846-4330-9d37-bfdd5583aea6/crucible                                                              48885295-bb47-4090-983a-1c444e5399d1   none      none          off        
-    oxp_f9bcdb70-6846-4330-9d37-bfdd5583aea6/crypt/debug                                                           f26fd0f8-03ce-459b-8309-785e8c306d83   100 GiB   none          gzip-9     
-    oxp_f9bcdb70-6846-4330-9d37-bfdd5583aea6/crypt/zone                                                            43fbca70-69af-4c55-af3f-7ff3326a99d2   none      none          off        
+    oxp_f9bcdb70-6846-4330-9d37-bfdd5583aea6/crypt/debug                                                           613c5d20-d3c3-4d43-ae5a-dda783ae87ba   100 GiB   none          gzip-9     
+    oxp_f9bcdb70-6846-4330-9d37-bfdd5583aea6/crypt/zone                                                            70b3a51d-a3bf-4019-ad3d-04c5ce992ffe   none      none          off        
     oxp_f9bcdb70-6846-4330-9d37-bfdd5583aea6/crypt/zone/oxz_crucible_a9a6a974-8953-4783-b815-da46884f2c02          ff93df28-7830-43f8-b4bc-0bd328679411   none      none          off        
 
 
@@ -112,7 +112,7 @@ to:   blueprint  e4aeb3b3-272f-4967-be34-2d34daa46aa1
     fake-vendor   fake-model   serial-ff66a45c-38a8-4b62-825e-e7c9470bc8bc
 
 
-    datasets at generation 1:
+    datasets at generation 2:
     -----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
     dataset name                                                                                                   dataset uuid                           quota     reservation   compression
     -----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
@@ -130,32 +130,32 @@ to:   blueprint  e4aeb3b3-272f-4967-be34-2d34daa46aa1
     oxp_3195b46a-d32d-458e-ad7f-b0b2f91af483/crypt/zone                                                            7905fda4-3c4f-4621-94a0-8c5be4f779e4   none      none          off        
     oxp_3195b46a-d32d-458e-ad7f-b0b2f91af483/crypt/zone/oxz_crucible_943fea7a-9458-4935-9dc7-01ee5cfe5a02          f72eb456-23b9-4414-adc5-c4bd3f983022   none      none          off        
     oxp_327bdbbb-c40e-4784-888e-18492a753708/crucible                                                              0974afa0-87d2-4f03-b623-50cc687603e3   none      none          off        
-    oxp_327bdbbb-c40e-4784-888e-18492a753708/crypt/debug                                                           fa0a338a-13fb-4e2d-b42d-657751c90fa4   100 GiB   none          gzip-9     
-    oxp_327bdbbb-c40e-4784-888e-18492a753708/crypt/zone                                                            7ddb052f-24d9-4616-93fd-9fee744ac811   none      none          off        
+    oxp_327bdbbb-c40e-4784-888e-18492a753708/crypt/debug                                                           9862e4af-f588-4957-b3a6-2d8ea7e55b87   100 GiB   none          gzip-9     
+    oxp_327bdbbb-c40e-4784-888e-18492a753708/crypt/zone                                                            ff8b51f9-b765-447e-ac95-e8c822183598   none      none          off        
     oxp_327bdbbb-c40e-4784-888e-18492a753708/crypt/zone/oxz_crucible_aa25add8-60b0-4ace-ac60-15adcdd32d50          267cfac7-9559-41ea-9f0c-f72b46b6cc50   none      none          off        
     oxp_4f067c20-2860-49b1-8a03-6715a3c12c0e/crucible                                                              9b7cdf59-fa1e-4815-9108-3c2e00757e93   none      none          off        
-    oxp_4f067c20-2860-49b1-8a03-6715a3c12c0e/crypt/debug                                                           9862e4af-f588-4957-b3a6-2d8ea7e55b87   100 GiB   none          gzip-9     
-    oxp_4f067c20-2860-49b1-8a03-6715a3c12c0e/crypt/zone                                                            ff8b51f9-b765-447e-ac95-e8c822183598   none      none          off        
+    oxp_4f067c20-2860-49b1-8a03-6715a3c12c0e/crypt/debug                                                           5827cf48-90f2-456a-a5f1-e03aef056b1d   100 GiB   none          gzip-9     
+    oxp_4f067c20-2860-49b1-8a03-6715a3c12c0e/crypt/zone                                                            cff02d61-c543-49f1-9109-e81c68cefd83   none      none          off        
     oxp_4f067c20-2860-49b1-8a03-6715a3c12c0e/crypt/zone/oxz_crucible_a5a0b7a9-37c9-4dbd-8393-ec7748ada3b0          47c4203e-6fb4-4e6b-9514-4bdfa2b134bb   none      none          off        
     oxp_564460fe-7357-4883-a3af-1c931f473e83/crucible                                                              6c89c1a5-1716-4758-b63d-09e8672ca3cb   none      none          off        
-    oxp_564460fe-7357-4883-a3af-1c931f473e83/crypt/debug                                                           3c0027e3-68b5-4c7e-a508-50ffc47371cd   100 GiB   none          gzip-9     
-    oxp_564460fe-7357-4883-a3af-1c931f473e83/crypt/zone                                                            9ad3f33b-7789-4e9d-95c5-cc3b33868722   none      none          off        
+    oxp_564460fe-7357-4883-a3af-1c931f473e83/crypt/debug                                                           d08c6f7e-553f-4024-8958-41cdfb2f3e04   100 GiB   none          gzip-9     
+    oxp_564460fe-7357-4883-a3af-1c931f473e83/crypt/zone                                                            8cf86314-701b-4ba6-8f03-ed1bf6a353af   none      none          off        
     oxp_564460fe-7357-4883-a3af-1c931f473e83/crypt/zone/oxz_crucible_0faa9350-2c02-47c7-a0a6-9f4afd69152c          be03d0f5-4769-423f-b06e-5f5f9aad6cd3   none      none          off        
     oxp_66f85be6-1143-48a1-a898-504c6b540035/crucible                                                              92a5bf2e-c559-4ae4-8aca-eff0069ff95d   none      none          off        
-    oxp_66f85be6-1143-48a1-a898-504c6b540035/crypt/debug                                                           5827cf48-90f2-456a-a5f1-e03aef056b1d   100 GiB   none          gzip-9     
-    oxp_66f85be6-1143-48a1-a898-504c6b540035/crypt/zone                                                            cff02d61-c543-49f1-9109-e81c68cefd83   none      none          off        
+    oxp_66f85be6-1143-48a1-a898-504c6b540035/crypt/debug                                                           fa0a338a-13fb-4e2d-b42d-657751c90fa4   100 GiB   none          gzip-9     
+    oxp_66f85be6-1143-48a1-a898-504c6b540035/crypt/zone                                                            7ddb052f-24d9-4616-93fd-9fee744ac811   none      none          off        
     oxp_66f85be6-1143-48a1-a898-504c6b540035/crypt/zone/oxz_crucible_aac3ab51-9e2b-4605-9bf6-e3eb3681c2b5          f179fdef-52ce-4cff-8a97-89148f43b6b8   none      none          off        
     oxp_97b3f199-b488-4ce0-bd34-484d4d3bd194/crucible                                                              08ebb666-a034-4645-be11-975e628dc24b   none      none          off        
-    oxp_97b3f199-b488-4ce0-bd34-484d4d3bd194/crypt/debug                                                           d08c6f7e-553f-4024-8958-41cdfb2f3e04   100 GiB   none          gzip-9     
-    oxp_97b3f199-b488-4ce0-bd34-484d4d3bd194/crypt/zone                                                            8cf86314-701b-4ba6-8f03-ed1bf6a353af   none      none          off        
+    oxp_97b3f199-b488-4ce0-bd34-484d4d3bd194/crypt/debug                                                           3354cd57-f010-468c-bf03-8fee73f9cbd4   100 GiB   none          gzip-9     
+    oxp_97b3f199-b488-4ce0-bd34-484d4d3bd194/crypt/zone                                                            953584c2-3e10-49f2-b3e0-731334ace4ba   none      none          off        
     oxp_97b3f199-b488-4ce0-bd34-484d4d3bd194/crypt/zone/oxz_crucible_29278a22-1ba1-4117-bfdb-39fcb9ae7fd1          ccb37b34-455c-4131-b2d5-2afa86844af7   none      none          off        
     oxp_a38f8150-2efd-4b55-9ffb-3c98e2939e13/crucible                                                              f6286214-eee2-4d21-9beb-d56d6a9ff647   none      none          off        
-    oxp_a38f8150-2efd-4b55-9ffb-3c98e2939e13/crypt/debug                                                           3354cd57-f010-468c-bf03-8fee73f9cbd4   100 GiB   none          gzip-9     
-    oxp_a38f8150-2efd-4b55-9ffb-3c98e2939e13/crypt/zone                                                            953584c2-3e10-49f2-b3e0-731334ace4ba   none      none          off        
+    oxp_a38f8150-2efd-4b55-9ffb-3c98e2939e13/crypt/debug                                                           76fb829c-faf6-482a-8cee-ad65fbf90061   100 GiB   none          gzip-9     
+    oxp_a38f8150-2efd-4b55-9ffb-3c98e2939e13/crypt/zone                                                            301df8ce-ca9a-40d8-bf0c-a894f05a07c6   none      none          off        
     oxp_a38f8150-2efd-4b55-9ffb-3c98e2939e13/crypt/zone/oxz_crucible_9b722fea-a186-4bc3-bc37-ce7f6de6a796          b8b9edf8-61ad-4be9-9158-d19dc0d55c8e   none      none          off        
     oxp_d788bf53-35dd-4fa7-a820-c1233e859d03/crucible                                                              69afa9b4-0b5b-44b7-959b-2e0c919a902c   none      none          off        
-    oxp_d788bf53-35dd-4fa7-a820-c1233e859d03/crypt/debug                                                           76fb829c-faf6-482a-8cee-ad65fbf90061   100 GiB   none          gzip-9     
-    oxp_d788bf53-35dd-4fa7-a820-c1233e859d03/crypt/zone                                                            301df8ce-ca9a-40d8-bf0c-a894f05a07c6   none      none          off        
+    oxp_d788bf53-35dd-4fa7-a820-c1233e859d03/crypt/debug                                                           3c0027e3-68b5-4c7e-a508-50ffc47371cd   100 GiB   none          gzip-9     
+    oxp_d788bf53-35dd-4fa7-a820-c1233e859d03/crypt/zone                                                            9ad3f33b-7789-4e9d-95c5-cc3b33868722   none      none          off        
     oxp_d788bf53-35dd-4fa7-a820-c1233e859d03/crypt/zone/oxz_crucible_4330134c-41b9-4097-aa0b-3eaefa06d473          b62ae708-bda3-4e55-aeec-4f6ebde36147   none      none          off        
     oxp_ff66a45c-38a8-4b62-825e-e7c9470bc8bc/crucible                                                              f48b7d15-5deb-43c4-a60e-3e0fbcf97181   none      none          off        
     oxp_ff66a45c-38a8-4b62-825e-e7c9470bc8bc/crypt/debug                                                           a86deb8c-63b7-4b0f-9684-b7bec755ee93   100 GiB   none          gzip-9     
@@ -201,54 +201,54 @@ to:   blueprint  e4aeb3b3-272f-4967-be34-2d34daa46aa1
     fake-vendor   fake-model   serial-e90056a4-dd19-4ebb-b484-c677aea31d80
 
 
-    datasets at generation 1:
+    datasets at generation 2:
     -----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
     dataset name                                                                                                   dataset uuid                           quota     reservation   compression
     -----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
     oxp_29867b4d-f12b-40ea-b59e-5169d0b2a831/crucible                                                              d662f33a-ad6e-464a-8bab-789e94cf52c6   none      none          off        
-    oxp_29867b4d-f12b-40ea-b59e-5169d0b2a831/crypt/debug                                                           4cda93d9-ceb2-4dab-8ded-146338f74201   100 GiB   none          gzip-9     
+    oxp_29867b4d-f12b-40ea-b59e-5169d0b2a831/crypt/debug                                                           1565d6ec-e8e8-48fa-a278-466eba9242fd   100 GiB   none          gzip-9     
     oxp_29867b4d-f12b-40ea-b59e-5169d0b2a831/crypt/internal_dns                                                    9e1fe3b4-5a48-45ba-b940-8d57446ea9b1   none      none          off        
-    oxp_29867b4d-f12b-40ea-b59e-5169d0b2a831/crypt/zone                                                            9824b691-56a2-4969-b2bb-86434fcffb63   none      none          off        
+    oxp_29867b4d-f12b-40ea-b59e-5169d0b2a831/crypt/zone                                                            56c84928-1960-4e9d-b3f1-be1e471eee29   none      none          off        
     oxp_29867b4d-f12b-40ea-b59e-5169d0b2a831/crypt/zone/oxz_crucible_b3583b5f-4a62-4471-9be7-41e61578de4c          9739aee2-e6e2-49de-8d28-04c225c73620   none      none          off        
     oxp_29867b4d-f12b-40ea-b59e-5169d0b2a831/crypt/zone/oxz_crucible_pantry_353b0aff-4c71-4fae-a6bd-adcb1d2a1a1d   2a240d7d-a428-4ff5-8ded-3206ef2cec95   none      none          off        
     oxp_29867b4d-f12b-40ea-b59e-5169d0b2a831/crypt/zone/oxz_internal_dns_bac92034-b9e6-4e8b-9ffb-dbba9caec88d      cee2172a-5d28-43e1-abcd-a8e615a6ee6b   none      none          off        
     oxp_29867b4d-f12b-40ea-b59e-5169d0b2a831/crypt/zone/oxz_nexus_6a5901b1-f9d7-425c-8ecb-a786c900f217             de3fa3f8-d348-4520-9025-d8e21ae467d4   none      none          off        
     oxp_29867b4d-f12b-40ea-b59e-5169d0b2a831/crypt/zone/oxz_ntp_edaca77e-5806-446a-b00c-125962cd551d               0153190b-60fb-438c-9635-2d979c7ebe62   none      none          off        
     oxp_54b3613b-a80e-4eda-aa1c-0d92050de367/crucible                                                              c6b9b0cf-3f83-4893-acfe-302e20e1cced   none      none          off        
-    oxp_54b3613b-a80e-4eda-aa1c-0d92050de367/crypt/debug                                                           b71328f5-ec79-4655-a46d-ca65b97737eb   100 GiB   none          gzip-9     
-    oxp_54b3613b-a80e-4eda-aa1c-0d92050de367/crypt/zone                                                            ccba4005-6b82-4ad7-896c-486f921f11c7   none      none          off        
+    oxp_54b3613b-a80e-4eda-aa1c-0d92050de367/crypt/debug                                                           6af89615-bdf5-4f35-9b17-c121184d055c   100 GiB   none          gzip-9     
+    oxp_54b3613b-a80e-4eda-aa1c-0d92050de367/crypt/zone                                                            4cd0d29c-fc49-4264-958b-63d0d58b1bfc   none      none          off        
     oxp_54b3613b-a80e-4eda-aa1c-0d92050de367/crypt/zone/oxz_crucible_d9653001-f671-4905-a410-6a7abc358318          0a6e84ba-dbda-46c6-b464-c503c446908c   none      none          off        
     oxp_75939bd0-28f6-428b-8ce2-e55241d201ce/crucible                                                              2f200dce-e6f6-414c-a974-c4d57b911e65   none      none          off        
-    oxp_75939bd0-28f6-428b-8ce2-e55241d201ce/crypt/debug                                                           74883587-3810-4b3a-8b96-b75c0d175790   100 GiB   none          gzip-9     
-    oxp_75939bd0-28f6-428b-8ce2-e55241d201ce/crypt/zone                                                            eeacb046-ceb7-46be-a500-d0895285c8e8   none      none          off        
+    oxp_75939bd0-28f6-428b-8ce2-e55241d201ce/crypt/debug                                                           4cda93d9-ceb2-4dab-8ded-146338f74201   100 GiB   none          gzip-9     
+    oxp_75939bd0-28f6-428b-8ce2-e55241d201ce/crypt/zone                                                            9824b691-56a2-4969-b2bb-86434fcffb63   none      none          off        
     oxp_75939bd0-28f6-428b-8ce2-e55241d201ce/crypt/zone/oxz_crucible_248db330-56e6-4c7e-b5ff-9cd6cbcb210a          12ea5763-4588-44d7-9729-9d68717a737e   none      none          off        
     oxp_7bcb41c3-6fc7-4cab-ac5f-b2e09f62567d/crucible                                                              0682d710-685d-4ad6-a450-ac664f3b04e7   none      none          off        
-    oxp_7bcb41c3-6fc7-4cab-ac5f-b2e09f62567d/crypt/debug                                                           a90f2686-9ab9-475b-b266-3068ce3daf2e   100 GiB   none          gzip-9     
-    oxp_7bcb41c3-6fc7-4cab-ac5f-b2e09f62567d/crypt/zone                                                            97e91593-1d0a-44b4-a858-217bf649101d   none      none          off        
+    oxp_7bcb41c3-6fc7-4cab-ac5f-b2e09f62567d/crypt/debug                                                           ddc5e970-52e6-4318-b8ff-4dcce27f019f   100 GiB   none          gzip-9     
+    oxp_7bcb41c3-6fc7-4cab-ac5f-b2e09f62567d/crypt/zone                                                            f25c3f52-5701-477d-86da-2c223b58d6c9   none      none          off        
     oxp_7bcb41c3-6fc7-4cab-ac5f-b2e09f62567d/crypt/zone/oxz_crucible_cf766535-9b6f-4263-a83a-86f45f7b005b          8eaf41af-a705-4205-a700-47df8245a9fb   none      none          off        
     oxp_92aeebc3-4154-4147-b721-0ccf5e337d8d/crucible                                                              127e27ba-4500-4c26-b165-cb128dae596a   none      none          off        
-    oxp_92aeebc3-4154-4147-b721-0ccf5e337d8d/crypt/debug                                                           1565d6ec-e8e8-48fa-a278-466eba9242fd   100 GiB   none          gzip-9     
-    oxp_92aeebc3-4154-4147-b721-0ccf5e337d8d/crypt/zone                                                            56c84928-1960-4e9d-b3f1-be1e471eee29   none      none          off        
+    oxp_92aeebc3-4154-4147-b721-0ccf5e337d8d/crypt/debug                                                           a90f2686-9ab9-475b-b266-3068ce3daf2e   100 GiB   none          gzip-9     
+    oxp_92aeebc3-4154-4147-b721-0ccf5e337d8d/crypt/zone                                                            97e91593-1d0a-44b4-a858-217bf649101d   none      none          off        
     oxp_92aeebc3-4154-4147-b721-0ccf5e337d8d/crypt/zone/oxz_crucible_c240ec8c-cec5-4117-944d-faeb5672d568          dd816da2-4f69-4f5f-a68e-25707508b7e8   none      none          off        
     oxp_960229b6-dbb2-4df0-ad93-83ddb28484bc/crucible                                                              b50d5d5a-f963-4527-9374-c625782b98d7   none      none          off        
-    oxp_960229b6-dbb2-4df0-ad93-83ddb28484bc/crypt/debug                                                           2551466c-2832-43cf-819f-c4a5d38f8649   100 GiB   none          gzip-9     
-    oxp_960229b6-dbb2-4df0-ad93-83ddb28484bc/crypt/zone                                                            3731ccdd-e64a-40ff-aa8a-d80e2a99cc18   none      none          off        
+    oxp_960229b6-dbb2-4df0-ad93-83ddb28484bc/crypt/debug                                                           1952c1a0-a291-4c9c-b671-5b9bc26cebdd   100 GiB   none          gzip-9     
+    oxp_960229b6-dbb2-4df0-ad93-83ddb28484bc/crypt/zone                                                            91b21b39-f0f0-4844-ae69-ffb20c8fef3c   none      none          off        
     oxp_960229b6-dbb2-4df0-ad93-83ddb28484bc/crypt/zone/oxz_crucible_b97bdef5-ed14-4e11-9d3b-3379c18ea694          327b3447-1dd6-4e62-8315-284751de6169   none      none          off        
     oxp_9e1428de-ad48-4655-8ccc-bbf4cb1badda/crucible                                                              4e988aef-33a7-41b4-8542-7139906e3aca   none      none          off        
-    oxp_9e1428de-ad48-4655-8ccc-bbf4cb1badda/crypt/debug                                                           ddc5e970-52e6-4318-b8ff-4dcce27f019f   100 GiB   none          gzip-9     
-    oxp_9e1428de-ad48-4655-8ccc-bbf4cb1badda/crypt/zone                                                            f25c3f52-5701-477d-86da-2c223b58d6c9   none      none          off        
+    oxp_9e1428de-ad48-4655-8ccc-bbf4cb1badda/crypt/debug                                                           74883587-3810-4b3a-8b96-b75c0d175790   100 GiB   none          gzip-9     
+    oxp_9e1428de-ad48-4655-8ccc-bbf4cb1badda/crypt/zone                                                            eeacb046-ceb7-46be-a500-d0895285c8e8   none      none          off        
     oxp_9e1428de-ad48-4655-8ccc-bbf4cb1badda/crypt/zone/oxz_crucible_b7bf29a5-ef5f-4942-a3be-e943f7e6be80          3461362c-c93f-456d-ae57-c9f7e23b830e   none      none          off        
     oxp_e03fee18-20c9-4c61-8927-bf80525f9b78/crucible                                                              ba32b0ca-d1de-4dec-b5f4-a83265f52497   none      none          off        
     oxp_e03fee18-20c9-4c61-8927-bf80525f9b78/crypt/debug                                                           60758be8-1109-4a6c-86e4-4f94570f9b75   100 GiB   none          gzip-9     
     oxp_e03fee18-20c9-4c61-8927-bf80525f9b78/crypt/zone                                                            22055c6e-87c5-4843-a270-b839de792db2   none      none          off        
     oxp_e03fee18-20c9-4c61-8927-bf80525f9b78/crypt/zone/oxz_crucible_75b0a160-7923-4f87-b7f3-f2d40b340e27          0c3ee3c8-82c5-43e3-9e91-cb168d35d1a8   none      none          off        
     oxp_e25482d4-7111-4acf-b621-4aab851ffda5/crucible                                                              ec84038d-6764-4e92-984e-bdc5fce4bef2   none      none          off        
-    oxp_e25482d4-7111-4acf-b621-4aab851ffda5/crypt/debug                                                           1952c1a0-a291-4c9c-b671-5b9bc26cebdd   100 GiB   none          gzip-9     
-    oxp_e25482d4-7111-4acf-b621-4aab851ffda5/crypt/zone                                                            91b21b39-f0f0-4844-ae69-ffb20c8fef3c   none      none          off        
+    oxp_e25482d4-7111-4acf-b621-4aab851ffda5/crypt/debug                                                           2551466c-2832-43cf-819f-c4a5d38f8649   100 GiB   none          gzip-9     
+    oxp_e25482d4-7111-4acf-b621-4aab851ffda5/crypt/zone                                                            3731ccdd-e64a-40ff-aa8a-d80e2a99cc18   none      none          off        
     oxp_e25482d4-7111-4acf-b621-4aab851ffda5/crypt/zone/oxz_crucible_3bff7b8a-1737-4f13-ba1c-713785f00c69          e236af3f-9926-46fe-be8e-99d7c91710f2   none      none          off        
     oxp_e90056a4-dd19-4ebb-b484-c677aea31d80/crucible                                                              305fee2f-d06e-4cff-8a6a-044bb8771f4e   none      none          off        
-    oxp_e90056a4-dd19-4ebb-b484-c677aea31d80/crypt/debug                                                           6af89615-bdf5-4f35-9b17-c121184d055c   100 GiB   none          gzip-9     
-    oxp_e90056a4-dd19-4ebb-b484-c677aea31d80/crypt/zone                                                            4cd0d29c-fc49-4264-958b-63d0d58b1bfc   none      none          off        
+    oxp_e90056a4-dd19-4ebb-b484-c677aea31d80/crypt/debug                                                           b71328f5-ec79-4655-a46d-ca65b97737eb   100 GiB   none          gzip-9     
+    oxp_e90056a4-dd19-4ebb-b484-c677aea31d80/crypt/zone                                                            ccba4005-6b82-4ad7-896c-486f921f11c7   none      none          off        
     oxp_e90056a4-dd19-4ebb-b484-c677aea31d80/crypt/zone/oxz_crucible_d9f181c5-bda0-409f-ae72-a46a906ca931          b578393a-4e0d-4be5-9f6f-f1220d28a376   none      none          off        
 
 

--- a/nexus/reconfigurator/planning/tests/output/planner_basic_add_sled_2_3.txt
+++ b/nexus/reconfigurator/planning/tests/output/planner_basic_add_sled_2_3.txt
@@ -21,15 +21,15 @@ to:   blueprint 4171ad05-89dd-474b-846b-b007e4346366
     fake-vendor   fake-model   serial-f4a96860-bdeb-4435-bdf5-2a10beb3d44a
 
 
-    datasets at generation 1:
+    datasets at generation 2:
     -----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
     dataset name                                                                                                   dataset uuid                           quota     reservation   compression
     -----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
     oxp_014eb1e9-04fe-4f36-8339-0a090b053ada/crucible                                                              a9c330b0-1f48-4bd7-b82f-c3419131b69b   none      none          off        
     oxp_014eb1e9-04fe-4f36-8339-0a090b053ada/crypt/clickhouse                                                      7c20d4b3-b783-4ba7-94a9-a8b789b04674   none      none          off        
-    oxp_014eb1e9-04fe-4f36-8339-0a090b053ada/crypt/debug                                                           0a6be80b-87c5-41fd-bd3c-36275b4ec494   100 GiB   none          gzip-9     
+    oxp_014eb1e9-04fe-4f36-8339-0a090b053ada/crypt/debug                                                           e86ad99b-5040-4863-86db-0375ed3004f4   100 GiB   none          gzip-9     
     oxp_014eb1e9-04fe-4f36-8339-0a090b053ada/crypt/internal_dns                                                    e2a6246d-00f0-4526-a2ab-99b2db7e1d51   none      none          off        
-    oxp_014eb1e9-04fe-4f36-8339-0a090b053ada/crypt/zone                                                            1e7c17fa-63d5-4a62-8037-663745516d18   none      none          off        
+    oxp_014eb1e9-04fe-4f36-8339-0a090b053ada/crypt/zone                                                            b58e8fae-21e3-4131-a37a-7c8bfaa242f5   none      none          off        
     oxp_014eb1e9-04fe-4f36-8339-0a090b053ada/crypt/zone/oxz_clickhouse_b40f7c7b-526c-46c8-ae33-67280c280eb7        38af39e8-406d-4ffe-8afb-f15d80fbea27   none      none          off        
     oxp_014eb1e9-04fe-4f36-8339-0a090b053ada/crypt/zone/oxz_crucible_be97b92b-38d6-422a-8c76-d37060f75bd2          574ac2b5-0233-488c-afd1-7ef4adc00b61   none      none          off        
     oxp_014eb1e9-04fe-4f36-8339-0a090b053ada/crypt/zone/oxz_crucible_pantry_747d2426-68bf-4c22-8806-41d290b5d5f5   a820d4d1-87d3-419d-8ed3-0dda65f8e808   none      none          off        
@@ -37,40 +37,40 @@ to:   blueprint 4171ad05-89dd-474b-846b-b007e4346366
     oxp_014eb1e9-04fe-4f36-8339-0a090b053ada/crypt/zone/oxz_nexus_cc816cfe-3869-4dde-b596-397d41198628             5f84acc5-e9f0-4f12-93e9-d2a271cb8ea0   none      none          off        
     oxp_014eb1e9-04fe-4f36-8339-0a090b053ada/crypt/zone/oxz_ntp_267ed614-92af-4b9d-bdba-c2881c2e43a2               bf1b301a-436c-4cdc-b3cd-de08dfcadc86   none      none          off        
     oxp_31a3bc64-7a3b-496d-b644-785dc44b6e37/crucible                                                              2cd64120-ea51-450a-bac8-d419f9ff7570   none      none          off        
-    oxp_31a3bc64-7a3b-496d-b644-785dc44b6e37/crypt/debug                                                           bbc7b434-12d0-441f-86c1-73d8355db38b   100 GiB   none          gzip-9     
-    oxp_31a3bc64-7a3b-496d-b644-785dc44b6e37/crypt/zone                                                            5e5c6b62-7785-4180-b901-6f33d676d657   none      none          off        
+    oxp_31a3bc64-7a3b-496d-b644-785dc44b6e37/crypt/debug                                                           f0945e1c-9c5e-463c-bee9-bee695299a0b   100 GiB   none          gzip-9     
+    oxp_31a3bc64-7a3b-496d-b644-785dc44b6e37/crypt/zone                                                            e7e785bc-f3db-44ab-a4a2-71cca70507e4   none      none          off        
     oxp_31a3bc64-7a3b-496d-b644-785dc44b6e37/crypt/zone/oxz_crucible_64aa65f8-1ccb-4cd6-9953-027aebdac8ff          70a5b1f3-dbd7-4cc0-8a30-9a8c5ff33402   none      none          off        
     oxp_7bb40bd6-9c43-4b63-8337-18313c72aea2/crucible                                                              cd1cc777-1813-427a-bf3b-8b4cb372608c   none      none          off        
-    oxp_7bb40bd6-9c43-4b63-8337-18313c72aea2/crypt/debug                                                           43858cf5-148f-48d8-9e52-b878d2efb6a5   100 GiB   none          gzip-9     
-    oxp_7bb40bd6-9c43-4b63-8337-18313c72aea2/crypt/zone                                                            536e5566-25b0-4df3-946e-3c59ca7d7921   none      none          off        
+    oxp_7bb40bd6-9c43-4b63-8337-18313c72aea2/crypt/debug                                                           bbc7b434-12d0-441f-86c1-73d8355db38b   100 GiB   none          gzip-9     
+    oxp_7bb40bd6-9c43-4b63-8337-18313c72aea2/crypt/zone                                                            5e5c6b62-7785-4180-b901-6f33d676d657   none      none          off        
     oxp_7bb40bd6-9c43-4b63-8337-18313c72aea2/crypt/zone/oxz_crucible_b14d5478-1a0e-4b90-b526-36b06339dfc4          32f26a28-c25b-4706-9fc0-712ea55b8d88   none      none          off        
     oxp_988aa8c2-cb5e-406b-9289-425dc2e5bc3a/crucible                                                              3aa68ad8-0539-4d41-a709-50fa4a0f97e5   none      none          off        
-    oxp_988aa8c2-cb5e-406b-9289-425dc2e5bc3a/crypt/debug                                                           bb0c5843-4fd2-4c5a-a7a1-2bc1e9180caf   100 GiB   none          gzip-9     
-    oxp_988aa8c2-cb5e-406b-9289-425dc2e5bc3a/crypt/zone                                                            14d03496-7ebd-4272-a58b-4c193ba0da82   none      none          off        
+    oxp_988aa8c2-cb5e-406b-9289-425dc2e5bc3a/crypt/debug                                                           0a585f79-acdb-4de1-9e32-e54906b1cfb8   100 GiB   none          gzip-9     
+    oxp_988aa8c2-cb5e-406b-9289-425dc2e5bc3a/crypt/zone                                                            63720ef8-1aad-4f61-a20b-078a1eb4d436   none      none          off        
     oxp_988aa8c2-cb5e-406b-9289-425dc2e5bc3a/crypt/zone/oxz_crucible_8e9e923e-62b1-4cbc-9f59-d6397e338b6b          724bd053-39f3-4c24-8109-a4d8b4c27787   none      none          off        
     oxp_ad574c09-2ae0-4534-a2a4-f923ce20ae87/crucible                                                              eb598474-ce25-4878-87b9-3c26318fb192   none      none          off        
-    oxp_ad574c09-2ae0-4534-a2a4-f923ce20ae87/crypt/debug                                                           cb06ffe2-7f4d-4936-8310-ebf5e032a32c   100 GiB   none          gzip-9     
-    oxp_ad574c09-2ae0-4534-a2a4-f923ce20ae87/crypt/zone                                                            3fa2a825-bfec-42ca-801b-fc901f7a7729   none      none          off        
+    oxp_ad574c09-2ae0-4534-a2a4-f923ce20ae87/crypt/debug                                                           b8abfcc9-d636-4cee-b0a1-dd4b62ceade5   100 GiB   none          gzip-9     
+    oxp_ad574c09-2ae0-4534-a2a4-f923ce20ae87/crypt/zone                                                            c02e8b44-3f25-4529-9d97-9a908e52af1d   none      none          off        
     oxp_ad574c09-2ae0-4534-a2a4-f923ce20ae87/crypt/zone/oxz_crucible_4ab1650f-32c5-447f-939d-64b8103a7645          e008db37-e6ad-433a-8aa1-ab06f8bad5b4   none      none          off        
     oxp_ad91e238-4901-4ff4-a91b-75233c936426/crucible                                                              7600ccdd-7b1a-46b6-85c2-800b2d4cf4d8   none      none          off        
-    oxp_ad91e238-4901-4ff4-a91b-75233c936426/crypt/debug                                                           0a585f79-acdb-4de1-9e32-e54906b1cfb8   100 GiB   none          gzip-9     
-    oxp_ad91e238-4901-4ff4-a91b-75233c936426/crypt/zone                                                            63720ef8-1aad-4f61-a20b-078a1eb4d436   none      none          off        
+    oxp_ad91e238-4901-4ff4-a91b-75233c936426/crypt/debug                                                           43858cf5-148f-48d8-9e52-b878d2efb6a5   100 GiB   none          gzip-9     
+    oxp_ad91e238-4901-4ff4-a91b-75233c936426/crypt/zone                                                            536e5566-25b0-4df3-946e-3c59ca7d7921   none      none          off        
     oxp_ad91e238-4901-4ff4-a91b-75233c936426/crypt/zone/oxz_crucible_6e811d86-8aa7-4660-935b-84b4b7721b10          b833252f-8df1-4188-9282-0b4e90caec37   none      none          off        
     oxp_ce58d463-d442-4c97-a6b4-f7d98c3fd902/crucible                                                              3243c276-0a62-4c1f-9976-c353618b2585   none      none          off        
-    oxp_ce58d463-d442-4c97-a6b4-f7d98c3fd902/crypt/debug                                                           e86ad99b-5040-4863-86db-0375ed3004f4   100 GiB   none          gzip-9     
-    oxp_ce58d463-d442-4c97-a6b4-f7d98c3fd902/crypt/zone                                                            b58e8fae-21e3-4131-a37a-7c8bfaa242f5   none      none          off        
+    oxp_ce58d463-d442-4c97-a6b4-f7d98c3fd902/crypt/debug                                                           0a6be80b-87c5-41fd-bd3c-36275b4ec494   100 GiB   none          gzip-9     
+    oxp_ce58d463-d442-4c97-a6b4-f7d98c3fd902/crypt/zone                                                            1e7c17fa-63d5-4a62-8037-663745516d18   none      none          off        
     oxp_ce58d463-d442-4c97-a6b4-f7d98c3fd902/crypt/zone/oxz_crucible_7fbd2c38-5dc3-48c4-b061-558a2041d70f          8a3cdc7a-802b-4b83-84bd-14f62c43ee7e   none      none          off        
     oxp_f18f7689-0059-4b79-880e-34faf7a0fe0e/crucible                                                              f68ba9d0-a5cf-4148-a754-010656ae5f7b   none      none          off        
-    oxp_f18f7689-0059-4b79-880e-34faf7a0fe0e/crypt/debug                                                           f0945e1c-9c5e-463c-bee9-bee695299a0b   100 GiB   none          gzip-9     
-    oxp_f18f7689-0059-4b79-880e-34faf7a0fe0e/crypt/zone                                                            e7e785bc-f3db-44ab-a4a2-71cca70507e4   none      none          off        
+    oxp_f18f7689-0059-4b79-880e-34faf7a0fe0e/crypt/debug                                                           cb06ffe2-7f4d-4936-8310-ebf5e032a32c   100 GiB   none          gzip-9     
+    oxp_f18f7689-0059-4b79-880e-34faf7a0fe0e/crypt/zone                                                            3fa2a825-bfec-42ca-801b-fc901f7a7729   none      none          off        
     oxp_f18f7689-0059-4b79-880e-34faf7a0fe0e/crypt/zone/oxz_crucible_08c7f8aa-1ea9-469b-8cac-2fdbfc11ebcb          e78dca52-4122-428a-b8c5-911fcce624de   none      none          off        
     oxp_f1d6cea4-640f-415e-89fe-2b1784ce3db8/crucible                                                              cea3cbac-de83-4a0c-a003-e42086fd418c   none      none          off        
     oxp_f1d6cea4-640f-415e-89fe-2b1784ce3db8/crypt/debug                                                           dd7111a0-555c-4b82-82b3-2cc93a2b1771   100 GiB   none          gzip-9     
     oxp_f1d6cea4-640f-415e-89fe-2b1784ce3db8/crypt/zone                                                            1e998426-2b49-4abc-877d-e7b972e5aadb   none      none          off        
     oxp_f1d6cea4-640f-415e-89fe-2b1784ce3db8/crypt/zone/oxz_crucible_c66ab6d5-ff7a-46d1-9fd0-70cefa352d25          cc0d38c6-17f2-4861-889f-82398f0eade2   none      none          off        
     oxp_f4a96860-bdeb-4435-bdf5-2a10beb3d44a/crucible                                                              88143ddc-773c-43e6-9859-5033535b566c   none      none          off        
-    oxp_f4a96860-bdeb-4435-bdf5-2a10beb3d44a/crypt/debug                                                           b8abfcc9-d636-4cee-b0a1-dd4b62ceade5   100 GiB   none          gzip-9     
-    oxp_f4a96860-bdeb-4435-bdf5-2a10beb3d44a/crypt/zone                                                            c02e8b44-3f25-4529-9d97-9a908e52af1d   none      none          off        
+    oxp_f4a96860-bdeb-4435-bdf5-2a10beb3d44a/crypt/debug                                                           bb0c5843-4fd2-4c5a-a7a1-2bc1e9180caf   100 GiB   none          gzip-9     
+    oxp_f4a96860-bdeb-4435-bdf5-2a10beb3d44a/crypt/zone                                                            14d03496-7ebd-4272-a58b-4c193ba0da82   none      none          off        
     oxp_f4a96860-bdeb-4435-bdf5-2a10beb3d44a/crypt/zone/oxz_crucible_3eda924f-22a9-4f3e-9a1b-91d1c47601ab          53c8cf89-1838-4638-8a27-683d134cbd9c   none      none          off        
 
 
@@ -113,34 +113,34 @@ to:   blueprint 4171ad05-89dd-474b-846b-b007e4346366
     fake-vendor   fake-model   serial-db6686c8-2dd9-4032-8444-2a06b43baa68
 
 
-    datasets at generation 1:
+    datasets at generation 2:
     -----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
     dataset name                                                                                                   dataset uuid                           quota     reservation   compression
     -----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
     oxp_12057b4a-0b06-4f70-ba22-336de2385bfe/crucible                                                              c333b519-9dde-4ada-b507-2bb0b6903d17   none      none          off        
-    oxp_12057b4a-0b06-4f70-ba22-336de2385bfe/crypt/debug                                                           438902f5-ff09-48f2-8cd1-56dc910d86e1   100 GiB   none          gzip-9     
+    oxp_12057b4a-0b06-4f70-ba22-336de2385bfe/crypt/debug                                                           bc7e5ae9-81f0-437b-9655-d11259f5037b   100 GiB   none          gzip-9     
     oxp_12057b4a-0b06-4f70-ba22-336de2385bfe/crypt/internal_dns                                                    52de1771-5f5b-422d-89e9-96a708c66d47   none      none          off        
-    oxp_12057b4a-0b06-4f70-ba22-336de2385bfe/crypt/zone                                                            5a5afb9f-850c-4501-959a-8ff760eca117   none      none          off        
+    oxp_12057b4a-0b06-4f70-ba22-336de2385bfe/crypt/zone                                                            fe22839c-29a4-4711-8290-44dc001b9a4f   none      none          off        
     oxp_12057b4a-0b06-4f70-ba22-336de2385bfe/crypt/zone/oxz_crucible_8f3a1cc5-9195-4a30-ad02-b804278fe639          42a06863-188a-4755-99f7-659df14958f7   none      none          off        
     oxp_12057b4a-0b06-4f70-ba22-336de2385bfe/crypt/zone/oxz_crucible_pantry_02acbe6a-1c88-47e3-94c3-94084cbde098   f7256e30-6e62-4d4b-ab06-8e9b3c9472a3   none      none          off        
     oxp_12057b4a-0b06-4f70-ba22-336de2385bfe/crypt/zone/oxz_internal_dns_07c3c805-8888-4fe5-9543-3d2479dbe6f3      54774860-da9a-4ff5-8d63-242b353c3115   none      none          off        
     oxp_12057b4a-0b06-4f70-ba22-336de2385bfe/crypt/zone/oxz_nexus_a1696cd4-588c-484a-b95b-66e824c0ce05             5dae2769-982f-485d-9776-57c2ae0a83b9   none      none          off        
     oxp_12057b4a-0b06-4f70-ba22-336de2385bfe/crypt/zone/oxz_ntp_10d98a73-ec88-4aff-a7e8-7db6a87880e6               c5dc843c-fa8c-46a8-9998-aa0b0397cb0c   none      none          off        
     oxp_29758363-6c77-40c3-8740-9c0c64f6e14a/crucible                                                              2e09fba5-0c1d-41db-a310-bef9290c6332   none      none          off        
-    oxp_29758363-6c77-40c3-8740-9c0c64f6e14a/crypt/debug                                                           bc7e5ae9-81f0-437b-9655-d11259f5037b   100 GiB   none          gzip-9     
-    oxp_29758363-6c77-40c3-8740-9c0c64f6e14a/crypt/zone                                                            fe22839c-29a4-4711-8290-44dc001b9a4f   none      none          off        
+    oxp_29758363-6c77-40c3-8740-9c0c64f6e14a/crypt/debug                                                           438902f5-ff09-48f2-8cd1-56dc910d86e1   100 GiB   none          gzip-9     
+    oxp_29758363-6c77-40c3-8740-9c0c64f6e14a/crypt/zone                                                            5a5afb9f-850c-4501-959a-8ff760eca117   none      none          off        
     oxp_29758363-6c77-40c3-8740-9c0c64f6e14a/crypt/zone/oxz_crucible_2a455c35-eb3c-4c73-ab6c-d0a706e25316          a3e5c0e0-3a73-4f7a-abd4-63f3434767aa   none      none          off        
     oxp_3f331c10-7882-48ab-85d9-05108490b55b/crucible                                                              76ab0eb2-4356-4a8a-b555-a83930ef3dce   none      none          off        
-    oxp_3f331c10-7882-48ab-85d9-05108490b55b/crypt/debug                                                           70aadfba-de91-4157-ab8c-98609d278d08   100 GiB   none          gzip-9     
-    oxp_3f331c10-7882-48ab-85d9-05108490b55b/crypt/zone                                                            3b733c7c-d0b0-427b-952a-200518837f87   none      none          off        
+    oxp_3f331c10-7882-48ab-85d9-05108490b55b/crypt/debug                                                           4939df35-a183-4c85-9872-5ced516bd154   100 GiB   none          gzip-9     
+    oxp_3f331c10-7882-48ab-85d9-05108490b55b/crypt/zone                                                            e991d7ef-7ca9-444e-ad9d-6f9d165a3b80   none      none          off        
     oxp_3f331c10-7882-48ab-85d9-05108490b55b/crypt/zone/oxz_crucible_a2079cbc-a69e-41a1-b1e0-fbcb972d03f6          94407842-70fd-48cd-933f-b0d7768fa45b   none      none          off        
     oxp_5152d1aa-9045-4e06-9ef6-6eadac3696e4/crucible                                                              52255a04-77be-486f-a59f-f17de4916cc2   none      none          off        
-    oxp_5152d1aa-9045-4e06-9ef6-6eadac3696e4/crypt/debug                                                           d6835e81-73e5-46cc-a188-93050a2e4d40   100 GiB   none          gzip-9     
-    oxp_5152d1aa-9045-4e06-9ef6-6eadac3696e4/crypt/zone                                                            7aabaeaa-fd10-4686-bd7e-65a961ea3f87   none      none          off        
+    oxp_5152d1aa-9045-4e06-9ef6-6eadac3696e4/crypt/debug                                                           70aadfba-de91-4157-ab8c-98609d278d08   100 GiB   none          gzip-9     
+    oxp_5152d1aa-9045-4e06-9ef6-6eadac3696e4/crypt/zone                                                            3b733c7c-d0b0-427b-952a-200518837f87   none      none          off        
     oxp_5152d1aa-9045-4e06-9ef6-6eadac3696e4/crypt/zone/oxz_crucible_587be699-a320-4c79-b320-128d9ecddc0b          40cae2bc-0505-4d53-9d94-b199aaf5600a   none      none          off        
     oxp_5c0dd424-d905-4fc5-a73c-36254fdd470c/crucible                                                              ab598283-0338-4124-af32-71aaf478908d   none      none          off        
-    oxp_5c0dd424-d905-4fc5-a73c-36254fdd470c/crypt/debug                                                           4939df35-a183-4c85-9872-5ced516bd154   100 GiB   none          gzip-9     
-    oxp_5c0dd424-d905-4fc5-a73c-36254fdd470c/crypt/zone                                                            e991d7ef-7ca9-444e-ad9d-6f9d165a3b80   none      none          off        
+    oxp_5c0dd424-d905-4fc5-a73c-36254fdd470c/crypt/debug                                                           f5e9ef79-2d90-4839-aeac-a1048516011e   100 GiB   none          gzip-9     
+    oxp_5c0dd424-d905-4fc5-a73c-36254fdd470c/crypt/zone                                                            51701069-af21-4697-8655-d2a8e455dceb   none      none          off        
     oxp_5c0dd424-d905-4fc5-a73c-36254fdd470c/crypt/zone/oxz_crucible_6fa06115-4959-4913-8e7b-dd70d7651f07          8879f080-4bd0-4073-ab2f-08e6f289bb4f   none      none          off        
     oxp_794df76f-bca0-4635-9eb6-773ad0108f7e/crucible                                                              e54385d1-cead-4fb6-a28e-c13db4e9561f   none      none          off        
     oxp_794df76f-bca0-4635-9eb6-773ad0108f7e/crypt/debug                                                           35f7f5fc-0d30-442d-b74a-7ef63b13bb6d   100 GiB   none          gzip-9     
@@ -159,8 +159,8 @@ to:   blueprint 4171ad05-89dd-474b-846b-b007e4346366
     oxp_d55d36d7-df92-4615-944d-440a1f8b5001/crypt/zone                                                            b7b7c0d6-b2dd-41eb-b5fe-3e131356552f   none      none          off        
     oxp_d55d36d7-df92-4615-944d-440a1f8b5001/crypt/zone/oxz_crucible_edabedf3-839c-488d-ad6f-508ffa864674          3b94580a-8ff4-4302-8d49-30ff90ef7edc   none      none          off        
     oxp_db6686c8-2dd9-4032-8444-2a06b43baa68/crucible                                                              882faa8a-7df8-4f67-abba-3d97a2615932   none      none          off        
-    oxp_db6686c8-2dd9-4032-8444-2a06b43baa68/crypt/debug                                                           f5e9ef79-2d90-4839-aeac-a1048516011e   100 GiB   none          gzip-9     
-    oxp_db6686c8-2dd9-4032-8444-2a06b43baa68/crypt/zone                                                            51701069-af21-4697-8655-d2a8e455dceb   none      none          off        
+    oxp_db6686c8-2dd9-4032-8444-2a06b43baa68/crypt/debug                                                           d6835e81-73e5-46cc-a188-93050a2e4d40   100 GiB   none          gzip-9     
+    oxp_db6686c8-2dd9-4032-8444-2a06b43baa68/crypt/zone                                                            7aabaeaa-fd10-4686-bd7e-65a961ea3f87   none      none          off        
     oxp_db6686c8-2dd9-4032-8444-2a06b43baa68/crypt/zone/oxz_crucible_d637264f-6f40-44c2-8b7e-a179430210d2          bde5f2d8-ac7d-40e8-b4b7-2cdf1cff6e57   none      none          off        
 
 
@@ -202,54 +202,54 @@ to:   blueprint 4171ad05-89dd-474b-846b-b007e4346366
     fake-vendor   fake-model   serial-f8c9c9a9-d73e-4cdf-a9af-03cfbbbce12b
 
 
-    datasets at generation 1:
+    datasets at generation 2:
     -----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
     dataset name                                                                                                   dataset uuid                           quota     reservation   compression
     -----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
     oxp_2a94863d-16e2-4535-973b-e98dd47fd18d/crucible                                                              35656b97-3eef-46f2-aab0-4d33a3548e62   none      none          off        
-    oxp_2a94863d-16e2-4535-973b-e98dd47fd18d/crypt/debug                                                           bdf9f107-3a76-4d6a-bea0-5cfb4d3cd6a6   100 GiB   none          gzip-9     
+    oxp_2a94863d-16e2-4535-973b-e98dd47fd18d/crypt/debug                                                           abe29a15-fef4-47ef-8f08-71645f396213   100 GiB   none          gzip-9     
     oxp_2a94863d-16e2-4535-973b-e98dd47fd18d/crypt/internal_dns                                                    b0fcbafd-55cc-49f1-9e02-20503673b34f   none      none          off        
-    oxp_2a94863d-16e2-4535-973b-e98dd47fd18d/crypt/zone                                                            0b216cae-701c-4341-a48a-690543b8e1e9   none      none          off        
+    oxp_2a94863d-16e2-4535-973b-e98dd47fd18d/crypt/zone                                                            5dd03902-3f33-4f7e-896a-c08d7c6e37f1   none      none          off        
     oxp_2a94863d-16e2-4535-973b-e98dd47fd18d/crypt/zone/oxz_crucible_18f8fe40-646e-4962-b17a-20e201f3a6e5          eec6f425-d377-42b2-890f-c8c3efe173d1   none      none          off        
     oxp_2a94863d-16e2-4535-973b-e98dd47fd18d/crypt/zone/oxz_crucible_pantry_56d5d7cf-db2c-40a3-a775-003241ad4820   ada776f0-dbb1-4430-a60a-f7462570a19c   none      none          off        
     oxp_2a94863d-16e2-4535-973b-e98dd47fd18d/crypt/zone/oxz_internal_dns_ab7ba6df-d401-40bd-940e-faf57c57aa2a      2fe942e9-085c-4155-a415-c2dcc19dbd91   none      none          off        
     oxp_2a94863d-16e2-4535-973b-e98dd47fd18d/crypt/zone/oxz_nexus_dce226c9-7373-4bfa-8a94-79dc472857a6             4abeefa4-e5ad-46e9-b056-79f5950a5639   none      none          off        
     oxp_2a94863d-16e2-4535-973b-e98dd47fd18d/crypt/zone/oxz_ntp_7a9f60d3-2b66-4547-9b63-7d4f7a8b6382               63337e4d-61a8-4dc7-a322-1442bc19b347   none      none          off        
     oxp_32456d15-f5b6-4efc-90c8-dbba979b69cb/crucible                                                              3b4f5bbb-cc50-49ae-a208-ca88dff1f361   none      none          off        
-    oxp_32456d15-f5b6-4efc-90c8-dbba979b69cb/crypt/debug                                                           cc56ea63-0ae3-48ce-8faf-1bd7d83eb148   100 GiB   none          gzip-9     
-    oxp_32456d15-f5b6-4efc-90c8-dbba979b69cb/crypt/zone                                                            dce1da41-4cf0-4f70-a9e5-f4b7fad54228   none      none          off        
+    oxp_32456d15-f5b6-4efc-90c8-dbba979b69cb/crypt/debug                                                           411e3457-3113-40d2-8a7d-747b108e0de7   100 GiB   none          gzip-9     
+    oxp_32456d15-f5b6-4efc-90c8-dbba979b69cb/crypt/zone                                                            a79b0ad5-06b8-466c-928c-39e311ace5ff   none      none          off        
     oxp_32456d15-f5b6-4efc-90c8-dbba979b69cb/crypt/zone/oxz_crucible_6af7f4d6-33b6-4eb3-a146-d8e9e4ae9d66          a33e3d63-6413-42b2-8cf0-02c774666916   none      none          off        
     oxp_416fe9f9-5161-4b0f-9e11-c9d81563ded5/crucible                                                              8b82f804-50d1-4e6f-8899-181433d82299   none      none          off        
-    oxp_416fe9f9-5161-4b0f-9e11-c9d81563ded5/crypt/debug                                                           abe29a15-fef4-47ef-8f08-71645f396213   100 GiB   none          gzip-9     
-    oxp_416fe9f9-5161-4b0f-9e11-c9d81563ded5/crypt/zone                                                            5dd03902-3f33-4f7e-896a-c08d7c6e37f1   none      none          off        
+    oxp_416fe9f9-5161-4b0f-9e11-c9d81563ded5/crypt/debug                                                           79ce0088-d8a8-46ff-ac72-958b8db65e67   100 GiB   none          gzip-9     
+    oxp_416fe9f9-5161-4b0f-9e11-c9d81563ded5/crypt/zone                                                            1635dad8-971f-4409-aca3-6204eafec699   none      none          off        
     oxp_416fe9f9-5161-4b0f-9e11-c9d81563ded5/crypt/zone/oxz_crucible_93f2f40c-5616-4d8d-8519-ec6debdcede0          4c0303d2-205d-4644-b55a-5c74bbce54c3   none      none          off        
     oxp_4c68800e-23f8-485b-b251-628fd151e445/crucible                                                              226cea90-799d-4f6c-90c6-459d2d7674c1   none      none          off        
-    oxp_4c68800e-23f8-485b-b251-628fd151e445/crypt/debug                                                           32535344-4e21-4fb3-9c43-f305ac367efb   100 GiB   none          gzip-9     
-    oxp_4c68800e-23f8-485b-b251-628fd151e445/crypt/zone                                                            447cc163-589e-479c-a73d-0071e5dc59bf   none      none          off        
+    oxp_4c68800e-23f8-485b-b251-628fd151e445/crypt/debug                                                           19bdebd5-9757-409f-ac06-2b309379975e   100 GiB   none          gzip-9     
+    oxp_4c68800e-23f8-485b-b251-628fd151e445/crypt/zone                                                            aa37e2bb-8d16-4dc2-a549-5f265fdad77c   none      none          off        
     oxp_4c68800e-23f8-485b-b251-628fd151e445/crypt/zone/oxz_crucible_1cc3f503-2001-4d85-80e5-c7c40d2e3b10          5a210076-5d38-42f0-915c-c09f67ff38af   none      none          off        
     oxp_9dd87c4d-5fb4-475a-86fa-c0da81a3e00a/crucible                                                              d5cd0c03-b555-46b2-b626-cc70bd931cee   none      none          off        
-    oxp_9dd87c4d-5fb4-475a-86fa-c0da81a3e00a/crypt/debug                                                           7d983611-ab39-4083-93d0-f57f3ada9a0f   100 GiB   none          gzip-9     
-    oxp_9dd87c4d-5fb4-475a-86fa-c0da81a3e00a/crypt/zone                                                            0568d976-0079-4d6e-9d1f-a8cfc4b044df   none      none          off        
+    oxp_9dd87c4d-5fb4-475a-86fa-c0da81a3e00a/crypt/debug                                                           32535344-4e21-4fb3-9c43-f305ac367efb   100 GiB   none          gzip-9     
+    oxp_9dd87c4d-5fb4-475a-86fa-c0da81a3e00a/crypt/zone                                                            447cc163-589e-479c-a73d-0071e5dc59bf   none      none          off        
     oxp_9dd87c4d-5fb4-475a-86fa-c0da81a3e00a/crypt/zone/oxz_crucible_0565e7e4-f13a-4123-8928-d715f83e36aa          e2de5537-a289-49ac-8a61-65805a35755e   none      none          off        
     oxp_be93a517-445e-46c2-aa21-3dc526d4a413/crucible                                                              52fde46c-85f4-470e-8c1e-38b13c042620   none      none          off        
-    oxp_be93a517-445e-46c2-aa21-3dc526d4a413/crypt/debug                                                           731caeb5-c24f-45b7-aafa-4e747302eaa4   100 GiB   none          gzip-9     
-    oxp_be93a517-445e-46c2-aa21-3dc526d4a413/crypt/zone                                                            f75ef0e7-663d-4418-99b6-71e2a77a27e3   none      none          off        
+    oxp_be93a517-445e-46c2-aa21-3dc526d4a413/crypt/debug                                                           bdf9f107-3a76-4d6a-bea0-5cfb4d3cd6a6   100 GiB   none          gzip-9     
+    oxp_be93a517-445e-46c2-aa21-3dc526d4a413/crypt/zone                                                            0b216cae-701c-4341-a48a-690543b8e1e9   none      none          off        
     oxp_be93a517-445e-46c2-aa21-3dc526d4a413/crypt/zone/oxz_crucible_62058f4c-c747-4e21-a8dc-2fd4a160c98c          0679ecb0-7759-4561-a81a-d8d7125ed693   none      none          off        
     oxp_d9344e2b-84d2-4392-84ab-41b86ed02237/crucible                                                              4b593475-e809-4822-a2fe-c58b2f7964d5   none      none          off        
-    oxp_d9344e2b-84d2-4392-84ab-41b86ed02237/crypt/debug                                                           19bdebd5-9757-409f-ac06-2b309379975e   100 GiB   none          gzip-9     
-    oxp_d9344e2b-84d2-4392-84ab-41b86ed02237/crypt/zone                                                            aa37e2bb-8d16-4dc2-a549-5f265fdad77c   none      none          off        
+    oxp_d9344e2b-84d2-4392-84ab-41b86ed02237/crypt/debug                                                           2059b139-6510-4447-aa56-cf995ef469a2   100 GiB   none          gzip-9     
+    oxp_d9344e2b-84d2-4392-84ab-41b86ed02237/crypt/zone                                                            1b5a2379-ec60-47f0-8def-fa3ab5c2487c   none      none          off        
     oxp_d9344e2b-84d2-4392-84ab-41b86ed02237/crypt/zone/oxz_crucible_062ce37d-7448-4d44-b1f4-4937cd2eb174          bfbfe7dd-06b3-4d01-988d-488c7b9400ee   none      none          off        
     oxp_eab188d0-b34a-4673-b254-12e705597654/crucible                                                              444a65f5-d04e-4cb0-a29d-ba57e34143dd   none      none          off        
-    oxp_eab188d0-b34a-4673-b254-12e705597654/crypt/debug                                                           411e3457-3113-40d2-8a7d-747b108e0de7   100 GiB   none          gzip-9     
-    oxp_eab188d0-b34a-4673-b254-12e705597654/crypt/zone                                                            a79b0ad5-06b8-466c-928c-39e311ace5ff   none      none          off        
+    oxp_eab188d0-b34a-4673-b254-12e705597654/crypt/debug                                                           731caeb5-c24f-45b7-aafa-4e747302eaa4   100 GiB   none          gzip-9     
+    oxp_eab188d0-b34a-4673-b254-12e705597654/crypt/zone                                                            f75ef0e7-663d-4418-99b6-71e2a77a27e3   none      none          off        
     oxp_eab188d0-b34a-4673-b254-12e705597654/crypt/zone/oxz_crucible_78d6ab36-e8c8-4ff8-9f89-75c7fe2d32e6          ebc48adb-4dad-41dd-a547-13f2517a9db7   none      none          off        
     oxp_f1e0386f-11b6-4cdf-8250-826d256db6b5/crucible                                                              826e2ca8-f30d-4ca3-8360-f03ddd883a6a   none      none          off        
-    oxp_f1e0386f-11b6-4cdf-8250-826d256db6b5/crypt/debug                                                           79ce0088-d8a8-46ff-ac72-958b8db65e67   100 GiB   none          gzip-9     
-    oxp_f1e0386f-11b6-4cdf-8250-826d256db6b5/crypt/zone                                                            1635dad8-971f-4409-aca3-6204eafec699   none      none          off        
+    oxp_f1e0386f-11b6-4cdf-8250-826d256db6b5/crypt/debug                                                           cc56ea63-0ae3-48ce-8faf-1bd7d83eb148   100 GiB   none          gzip-9     
+    oxp_f1e0386f-11b6-4cdf-8250-826d256db6b5/crypt/zone                                                            dce1da41-4cf0-4f70-a9e5-f4b7fad54228   none      none          off        
     oxp_f1e0386f-11b6-4cdf-8250-826d256db6b5/crypt/zone/oxz_crucible_9f824c30-6360-46b9-87c4-cd60586476fe          c4e2119e-4cd0-48e7-878f-fd676cb95094   none      none          off        
     oxp_f8c9c9a9-d73e-4cdf-a9af-03cfbbbce12b/crucible                                                              2c6ade05-a626-4b25-a28c-551b91867dbe   none      none          off        
-    oxp_f8c9c9a9-d73e-4cdf-a9af-03cfbbbce12b/crypt/debug                                                           2059b139-6510-4447-aa56-cf995ef469a2   100 GiB   none          gzip-9     
-    oxp_f8c9c9a9-d73e-4cdf-a9af-03cfbbbce12b/crypt/zone                                                            1b5a2379-ec60-47f0-8def-fa3ab5c2487c   none      none          off        
+    oxp_f8c9c9a9-d73e-4cdf-a9af-03cfbbbce12b/crypt/debug                                                           7d983611-ab39-4083-93d0-f57f3ada9a0f   100 GiB   none          gzip-9     
+    oxp_f8c9c9a9-d73e-4cdf-a9af-03cfbbbce12b/crypt/zone                                                            0568d976-0079-4d6e-9d1f-a8cfc4b044df   none      none          off        
     oxp_f8c9c9a9-d73e-4cdf-a9af-03cfbbbce12b/crypt/zone/oxz_crucible_1211a68e-69a1-4ef4-b790-45b0279f9159          32a3e82a-b97a-455a-b428-1f934c59eb46   none      none          off        
 
 
@@ -293,31 +293,31 @@ to:   blueprint 4171ad05-89dd-474b-846b-b007e4346366
 +   fake-vendor   fake-model   serial-fdfd067b-1d86-444d-a21f-ed33709f3e4d
 
 
-    datasets at generation 1:
+    datasets at generation 2:
     -----------------------------------------------------------------------------------------------------------------------------------------------------------------------------
     dataset name                                                                                       dataset uuid                           quota     reservation   compression
     -----------------------------------------------------------------------------------------------------------------------------------------------------------------------------
-+   oxp_28699448-c5d9-49ea-bf7e-627800efe783/crypt/debug                                               bbab775c-07b1-48b1-96a3-9aa155396112   100 GiB   none          gzip-9     
-+   oxp_28699448-c5d9-49ea-bf7e-627800efe783/crypt/zone                                                07381a6a-e397-4ff9-a2a6-8f1e46c47eb3   none      none          off        
++   oxp_28699448-c5d9-49ea-bf7e-627800efe783/crypt/debug                                               91edd9a1-178d-4aa5-83a7-b2f4ef1fc44a   100 GiB   none          gzip-9     
++   oxp_28699448-c5d9-49ea-bf7e-627800efe783/crypt/zone                                                1bd5ab24-2a54-438f-bae0-af1b06a3cc41   none      none          off        
 +   oxp_28699448-c5d9-49ea-bf7e-627800efe783/crypt/zone/oxz_ntp_2d73d30e-ca47-46a8-9c12-917d4ab824b6   15e9b1ea-8947-48a2-8d78-54665e4d2f03   none      none          off        
-+   oxp_2c490e96-27f2-4a7f-b440-04d4bfd1e4f6/crypt/debug                                               75c1432c-19e1-4c06-8393-9907a09efcbe   100 GiB   none          gzip-9     
-+   oxp_2c490e96-27f2-4a7f-b440-04d4bfd1e4f6/crypt/zone                                                b4c23ac2-86af-4b47-9d8d-35eff7997788   none      none          off        
-+   oxp_4c3bb1c7-55b6-49b8-b212-516b8f2c26c2/crypt/debug                                               5501c13c-0500-41a6-9c48-85924383fdcc   100 GiB   none          gzip-9     
-+   oxp_4c3bb1c7-55b6-49b8-b212-516b8f2c26c2/crypt/zone                                                32143abb-e501-450b-9398-7d4dbebdf4a1   none      none          off        
-+   oxp_5db07562-31a8-43e3-b99e-7c7cb89754b7/crypt/debug                                               bcdd7a5a-59da-4a47-8a1c-79281428d71b   100 GiB   none          gzip-9     
-+   oxp_5db07562-31a8-43e3-b99e-7c7cb89754b7/crypt/zone                                                6ec35c5c-9d6c-4d72-8bec-af91069ef7a9   none      none          off        
-+   oxp_9451a5d5-b358-4719-b6c1-a0d187da217c/crypt/debug                                               8ed9d1a2-3c60-4f38-9e80-5c56d80e67c9   100 GiB   none          gzip-9     
-+   oxp_9451a5d5-b358-4719-b6c1-a0d187da217c/crypt/zone                                                8529e7f8-8c11-4869-b330-83ddc45ed17a   none      none          off        
-+   oxp_bb2e2869-9481-483a-bc49-2bdd62f515f5/crypt/debug                                               4aef9a3a-0829-4ada-a0e9-a45c91e74249   100 GiB   none          gzip-9     
-+   oxp_bb2e2869-9481-483a-bc49-2bdd62f515f5/crypt/zone                                                940f06cb-822f-4034-8d34-e14bcc6ea998   none      none          off        
++   oxp_2c490e96-27f2-4a7f-b440-04d4bfd1e4f6/crypt/debug                                               bcdd7a5a-59da-4a47-8a1c-79281428d71b   100 GiB   none          gzip-9     
++   oxp_2c490e96-27f2-4a7f-b440-04d4bfd1e4f6/crypt/zone                                                6ec35c5c-9d6c-4d72-8bec-af91069ef7a9   none      none          off        
++   oxp_4c3bb1c7-55b6-49b8-b212-516b8f2c26c2/crypt/debug                                               4aef9a3a-0829-4ada-a0e9-a45c91e74249   100 GiB   none          gzip-9     
++   oxp_4c3bb1c7-55b6-49b8-b212-516b8f2c26c2/crypt/zone                                                940f06cb-822f-4034-8d34-e14bcc6ea998   none      none          off        
++   oxp_5db07562-31a8-43e3-b99e-7c7cb89754b7/crypt/debug                                               8ed9d1a2-3c60-4f38-9e80-5c56d80e67c9   100 GiB   none          gzip-9     
++   oxp_5db07562-31a8-43e3-b99e-7c7cb89754b7/crypt/zone                                                8529e7f8-8c11-4869-b330-83ddc45ed17a   none      none          off        
++   oxp_9451a5d5-b358-4719-b6c1-a0d187da217c/crypt/debug                                               feac64a1-ade2-4f88-8c17-64d2863e2be6   100 GiB   none          gzip-9     
++   oxp_9451a5d5-b358-4719-b6c1-a0d187da217c/crypt/zone                                                1acaf776-970a-49cf-9f1c-7d8e3146ef11   none      none          off        
++   oxp_bb2e2869-9481-483a-bc49-2bdd62f515f5/crypt/debug                                               5501c13c-0500-41a6-9c48-85924383fdcc   100 GiB   none          gzip-9     
++   oxp_bb2e2869-9481-483a-bc49-2bdd62f515f5/crypt/zone                                                32143abb-e501-450b-9398-7d4dbebdf4a1   none      none          off        
 +   oxp_d5a36c66-4b2f-46e6-96f4-b82debee1a4a/crypt/debug                                               2b23d885-836a-4270-886d-08640aae90aa   100 GiB   none          gzip-9     
 +   oxp_d5a36c66-4b2f-46e6-96f4-b82debee1a4a/crypt/zone                                                0507b005-e018-4b69-9d84-50faf61e792f   none      none          off        
-+   oxp_f99ec996-ec08-4ccf-9a6e-6c5cab440fb4/crypt/debug                                               feac64a1-ade2-4f88-8c17-64d2863e2be6   100 GiB   none          gzip-9     
-+   oxp_f99ec996-ec08-4ccf-9a6e-6c5cab440fb4/crypt/zone                                                1acaf776-970a-49cf-9f1c-7d8e3146ef11   none      none          off        
-+   oxp_faccbb39-d686-42a1-a50a-0eb59ba74a87/crypt/debug                                               91edd9a1-178d-4aa5-83a7-b2f4ef1fc44a   100 GiB   none          gzip-9     
-+   oxp_faccbb39-d686-42a1-a50a-0eb59ba74a87/crypt/zone                                                1bd5ab24-2a54-438f-bae0-af1b06a3cc41   none      none          off        
-+   oxp_fdfd067b-1d86-444d-a21f-ed33709f3e4d/crypt/debug                                               8840ccd9-e8c9-48d9-affb-8587e468b204   100 GiB   none          gzip-9     
-+   oxp_fdfd067b-1d86-444d-a21f-ed33709f3e4d/crypt/zone                                                b501adbf-be36-4724-9409-329f690fb09d   none      none          off        
++   oxp_f99ec996-ec08-4ccf-9a6e-6c5cab440fb4/crypt/debug                                               8840ccd9-e8c9-48d9-affb-8587e468b204   100 GiB   none          gzip-9     
++   oxp_f99ec996-ec08-4ccf-9a6e-6c5cab440fb4/crypt/zone                                                b501adbf-be36-4724-9409-329f690fb09d   none      none          off        
++   oxp_faccbb39-d686-42a1-a50a-0eb59ba74a87/crypt/debug                                               75c1432c-19e1-4c06-8393-9907a09efcbe   100 GiB   none          gzip-9     
++   oxp_faccbb39-d686-42a1-a50a-0eb59ba74a87/crypt/zone                                                b4c23ac2-86af-4b47-9d8d-35eff7997788   none      none          off        
++   oxp_fdfd067b-1d86-444d-a21f-ed33709f3e4d/crypt/debug                                               bbab775c-07b1-48b1-96a3-9aa155396112   100 GiB   none          gzip-9     
++   oxp_fdfd067b-1d86-444d-a21f-ed33709f3e4d/crypt/zone                                                07381a6a-e397-4ff9-a2a6-8f1e46c47eb3   none      none          off        
 
 
     omicron zones at generation 2:

--- a/nexus/reconfigurator/planning/tests/output/planner_basic_add_sled_3_5.txt
+++ b/nexus/reconfigurator/planning/tests/output/planner_basic_add_sled_3_5.txt
@@ -21,15 +21,15 @@ to:   blueprint f432fcd5-1284-4058-8b4a-9286a3de6163
     fake-vendor   fake-model   serial-f4a96860-bdeb-4435-bdf5-2a10beb3d44a
 
 
-    datasets at generation 1:
+    datasets at generation 2:
     -----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
     dataset name                                                                                                   dataset uuid                           quota     reservation   compression
     -----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
     oxp_014eb1e9-04fe-4f36-8339-0a090b053ada/crucible                                                              a9c330b0-1f48-4bd7-b82f-c3419131b69b   none      none          off        
     oxp_014eb1e9-04fe-4f36-8339-0a090b053ada/crypt/clickhouse                                                      7c20d4b3-b783-4ba7-94a9-a8b789b04674   none      none          off        
-    oxp_014eb1e9-04fe-4f36-8339-0a090b053ada/crypt/debug                                                           0a6be80b-87c5-41fd-bd3c-36275b4ec494   100 GiB   none          gzip-9     
+    oxp_014eb1e9-04fe-4f36-8339-0a090b053ada/crypt/debug                                                           e86ad99b-5040-4863-86db-0375ed3004f4   100 GiB   none          gzip-9     
     oxp_014eb1e9-04fe-4f36-8339-0a090b053ada/crypt/internal_dns                                                    e2a6246d-00f0-4526-a2ab-99b2db7e1d51   none      none          off        
-    oxp_014eb1e9-04fe-4f36-8339-0a090b053ada/crypt/zone                                                            1e7c17fa-63d5-4a62-8037-663745516d18   none      none          off        
+    oxp_014eb1e9-04fe-4f36-8339-0a090b053ada/crypt/zone                                                            b58e8fae-21e3-4131-a37a-7c8bfaa242f5   none      none          off        
     oxp_014eb1e9-04fe-4f36-8339-0a090b053ada/crypt/zone/oxz_clickhouse_b40f7c7b-526c-46c8-ae33-67280c280eb7        38af39e8-406d-4ffe-8afb-f15d80fbea27   none      none          off        
     oxp_014eb1e9-04fe-4f36-8339-0a090b053ada/crypt/zone/oxz_crucible_be97b92b-38d6-422a-8c76-d37060f75bd2          574ac2b5-0233-488c-afd1-7ef4adc00b61   none      none          off        
     oxp_014eb1e9-04fe-4f36-8339-0a090b053ada/crypt/zone/oxz_crucible_pantry_747d2426-68bf-4c22-8806-41d290b5d5f5   a820d4d1-87d3-419d-8ed3-0dda65f8e808   none      none          off        
@@ -37,40 +37,40 @@ to:   blueprint f432fcd5-1284-4058-8b4a-9286a3de6163
     oxp_014eb1e9-04fe-4f36-8339-0a090b053ada/crypt/zone/oxz_nexus_cc816cfe-3869-4dde-b596-397d41198628             5f84acc5-e9f0-4f12-93e9-d2a271cb8ea0   none      none          off        
     oxp_014eb1e9-04fe-4f36-8339-0a090b053ada/crypt/zone/oxz_ntp_267ed614-92af-4b9d-bdba-c2881c2e43a2               bf1b301a-436c-4cdc-b3cd-de08dfcadc86   none      none          off        
     oxp_31a3bc64-7a3b-496d-b644-785dc44b6e37/crucible                                                              2cd64120-ea51-450a-bac8-d419f9ff7570   none      none          off        
-    oxp_31a3bc64-7a3b-496d-b644-785dc44b6e37/crypt/debug                                                           bbc7b434-12d0-441f-86c1-73d8355db38b   100 GiB   none          gzip-9     
-    oxp_31a3bc64-7a3b-496d-b644-785dc44b6e37/crypt/zone                                                            5e5c6b62-7785-4180-b901-6f33d676d657   none      none          off        
+    oxp_31a3bc64-7a3b-496d-b644-785dc44b6e37/crypt/debug                                                           f0945e1c-9c5e-463c-bee9-bee695299a0b   100 GiB   none          gzip-9     
+    oxp_31a3bc64-7a3b-496d-b644-785dc44b6e37/crypt/zone                                                            e7e785bc-f3db-44ab-a4a2-71cca70507e4   none      none          off        
     oxp_31a3bc64-7a3b-496d-b644-785dc44b6e37/crypt/zone/oxz_crucible_64aa65f8-1ccb-4cd6-9953-027aebdac8ff          70a5b1f3-dbd7-4cc0-8a30-9a8c5ff33402   none      none          off        
     oxp_7bb40bd6-9c43-4b63-8337-18313c72aea2/crucible                                                              cd1cc777-1813-427a-bf3b-8b4cb372608c   none      none          off        
-    oxp_7bb40bd6-9c43-4b63-8337-18313c72aea2/crypt/debug                                                           43858cf5-148f-48d8-9e52-b878d2efb6a5   100 GiB   none          gzip-9     
-    oxp_7bb40bd6-9c43-4b63-8337-18313c72aea2/crypt/zone                                                            536e5566-25b0-4df3-946e-3c59ca7d7921   none      none          off        
+    oxp_7bb40bd6-9c43-4b63-8337-18313c72aea2/crypt/debug                                                           bbc7b434-12d0-441f-86c1-73d8355db38b   100 GiB   none          gzip-9     
+    oxp_7bb40bd6-9c43-4b63-8337-18313c72aea2/crypt/zone                                                            5e5c6b62-7785-4180-b901-6f33d676d657   none      none          off        
     oxp_7bb40bd6-9c43-4b63-8337-18313c72aea2/crypt/zone/oxz_crucible_b14d5478-1a0e-4b90-b526-36b06339dfc4          32f26a28-c25b-4706-9fc0-712ea55b8d88   none      none          off        
     oxp_988aa8c2-cb5e-406b-9289-425dc2e5bc3a/crucible                                                              3aa68ad8-0539-4d41-a709-50fa4a0f97e5   none      none          off        
-    oxp_988aa8c2-cb5e-406b-9289-425dc2e5bc3a/crypt/debug                                                           bb0c5843-4fd2-4c5a-a7a1-2bc1e9180caf   100 GiB   none          gzip-9     
-    oxp_988aa8c2-cb5e-406b-9289-425dc2e5bc3a/crypt/zone                                                            14d03496-7ebd-4272-a58b-4c193ba0da82   none      none          off        
+    oxp_988aa8c2-cb5e-406b-9289-425dc2e5bc3a/crypt/debug                                                           0a585f79-acdb-4de1-9e32-e54906b1cfb8   100 GiB   none          gzip-9     
+    oxp_988aa8c2-cb5e-406b-9289-425dc2e5bc3a/crypt/zone                                                            63720ef8-1aad-4f61-a20b-078a1eb4d436   none      none          off        
     oxp_988aa8c2-cb5e-406b-9289-425dc2e5bc3a/crypt/zone/oxz_crucible_8e9e923e-62b1-4cbc-9f59-d6397e338b6b          724bd053-39f3-4c24-8109-a4d8b4c27787   none      none          off        
     oxp_ad574c09-2ae0-4534-a2a4-f923ce20ae87/crucible                                                              eb598474-ce25-4878-87b9-3c26318fb192   none      none          off        
-    oxp_ad574c09-2ae0-4534-a2a4-f923ce20ae87/crypt/debug                                                           cb06ffe2-7f4d-4936-8310-ebf5e032a32c   100 GiB   none          gzip-9     
-    oxp_ad574c09-2ae0-4534-a2a4-f923ce20ae87/crypt/zone                                                            3fa2a825-bfec-42ca-801b-fc901f7a7729   none      none          off        
+    oxp_ad574c09-2ae0-4534-a2a4-f923ce20ae87/crypt/debug                                                           b8abfcc9-d636-4cee-b0a1-dd4b62ceade5   100 GiB   none          gzip-9     
+    oxp_ad574c09-2ae0-4534-a2a4-f923ce20ae87/crypt/zone                                                            c02e8b44-3f25-4529-9d97-9a908e52af1d   none      none          off        
     oxp_ad574c09-2ae0-4534-a2a4-f923ce20ae87/crypt/zone/oxz_crucible_4ab1650f-32c5-447f-939d-64b8103a7645          e008db37-e6ad-433a-8aa1-ab06f8bad5b4   none      none          off        
     oxp_ad91e238-4901-4ff4-a91b-75233c936426/crucible                                                              7600ccdd-7b1a-46b6-85c2-800b2d4cf4d8   none      none          off        
-    oxp_ad91e238-4901-4ff4-a91b-75233c936426/crypt/debug                                                           0a585f79-acdb-4de1-9e32-e54906b1cfb8   100 GiB   none          gzip-9     
-    oxp_ad91e238-4901-4ff4-a91b-75233c936426/crypt/zone                                                            63720ef8-1aad-4f61-a20b-078a1eb4d436   none      none          off        
+    oxp_ad91e238-4901-4ff4-a91b-75233c936426/crypt/debug                                                           43858cf5-148f-48d8-9e52-b878d2efb6a5   100 GiB   none          gzip-9     
+    oxp_ad91e238-4901-4ff4-a91b-75233c936426/crypt/zone                                                            536e5566-25b0-4df3-946e-3c59ca7d7921   none      none          off        
     oxp_ad91e238-4901-4ff4-a91b-75233c936426/crypt/zone/oxz_crucible_6e811d86-8aa7-4660-935b-84b4b7721b10          b833252f-8df1-4188-9282-0b4e90caec37   none      none          off        
     oxp_ce58d463-d442-4c97-a6b4-f7d98c3fd902/crucible                                                              3243c276-0a62-4c1f-9976-c353618b2585   none      none          off        
-    oxp_ce58d463-d442-4c97-a6b4-f7d98c3fd902/crypt/debug                                                           e86ad99b-5040-4863-86db-0375ed3004f4   100 GiB   none          gzip-9     
-    oxp_ce58d463-d442-4c97-a6b4-f7d98c3fd902/crypt/zone                                                            b58e8fae-21e3-4131-a37a-7c8bfaa242f5   none      none          off        
+    oxp_ce58d463-d442-4c97-a6b4-f7d98c3fd902/crypt/debug                                                           0a6be80b-87c5-41fd-bd3c-36275b4ec494   100 GiB   none          gzip-9     
+    oxp_ce58d463-d442-4c97-a6b4-f7d98c3fd902/crypt/zone                                                            1e7c17fa-63d5-4a62-8037-663745516d18   none      none          off        
     oxp_ce58d463-d442-4c97-a6b4-f7d98c3fd902/crypt/zone/oxz_crucible_7fbd2c38-5dc3-48c4-b061-558a2041d70f          8a3cdc7a-802b-4b83-84bd-14f62c43ee7e   none      none          off        
     oxp_f18f7689-0059-4b79-880e-34faf7a0fe0e/crucible                                                              f68ba9d0-a5cf-4148-a754-010656ae5f7b   none      none          off        
-    oxp_f18f7689-0059-4b79-880e-34faf7a0fe0e/crypt/debug                                                           f0945e1c-9c5e-463c-bee9-bee695299a0b   100 GiB   none          gzip-9     
-    oxp_f18f7689-0059-4b79-880e-34faf7a0fe0e/crypt/zone                                                            e7e785bc-f3db-44ab-a4a2-71cca70507e4   none      none          off        
+    oxp_f18f7689-0059-4b79-880e-34faf7a0fe0e/crypt/debug                                                           cb06ffe2-7f4d-4936-8310-ebf5e032a32c   100 GiB   none          gzip-9     
+    oxp_f18f7689-0059-4b79-880e-34faf7a0fe0e/crypt/zone                                                            3fa2a825-bfec-42ca-801b-fc901f7a7729   none      none          off        
     oxp_f18f7689-0059-4b79-880e-34faf7a0fe0e/crypt/zone/oxz_crucible_08c7f8aa-1ea9-469b-8cac-2fdbfc11ebcb          e78dca52-4122-428a-b8c5-911fcce624de   none      none          off        
     oxp_f1d6cea4-640f-415e-89fe-2b1784ce3db8/crucible                                                              cea3cbac-de83-4a0c-a003-e42086fd418c   none      none          off        
     oxp_f1d6cea4-640f-415e-89fe-2b1784ce3db8/crypt/debug                                                           dd7111a0-555c-4b82-82b3-2cc93a2b1771   100 GiB   none          gzip-9     
     oxp_f1d6cea4-640f-415e-89fe-2b1784ce3db8/crypt/zone                                                            1e998426-2b49-4abc-877d-e7b972e5aadb   none      none          off        
     oxp_f1d6cea4-640f-415e-89fe-2b1784ce3db8/crypt/zone/oxz_crucible_c66ab6d5-ff7a-46d1-9fd0-70cefa352d25          cc0d38c6-17f2-4861-889f-82398f0eade2   none      none          off        
     oxp_f4a96860-bdeb-4435-bdf5-2a10beb3d44a/crucible                                                              88143ddc-773c-43e6-9859-5033535b566c   none      none          off        
-    oxp_f4a96860-bdeb-4435-bdf5-2a10beb3d44a/crypt/debug                                                           b8abfcc9-d636-4cee-b0a1-dd4b62ceade5   100 GiB   none          gzip-9     
-    oxp_f4a96860-bdeb-4435-bdf5-2a10beb3d44a/crypt/zone                                                            c02e8b44-3f25-4529-9d97-9a908e52af1d   none      none          off        
+    oxp_f4a96860-bdeb-4435-bdf5-2a10beb3d44a/crypt/debug                                                           bb0c5843-4fd2-4c5a-a7a1-2bc1e9180caf   100 GiB   none          gzip-9     
+    oxp_f4a96860-bdeb-4435-bdf5-2a10beb3d44a/crypt/zone                                                            14d03496-7ebd-4272-a58b-4c193ba0da82   none      none          off        
     oxp_f4a96860-bdeb-4435-bdf5-2a10beb3d44a/crypt/zone/oxz_crucible_3eda924f-22a9-4f3e-9a1b-91d1c47601ab          53c8cf89-1838-4638-8a27-683d134cbd9c   none      none          off        
 
 
@@ -113,34 +113,34 @@ to:   blueprint f432fcd5-1284-4058-8b4a-9286a3de6163
     fake-vendor   fake-model   serial-db6686c8-2dd9-4032-8444-2a06b43baa68
 
 
-    datasets at generation 1:
+    datasets at generation 2:
     -----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
     dataset name                                                                                                   dataset uuid                           quota     reservation   compression
     -----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
     oxp_12057b4a-0b06-4f70-ba22-336de2385bfe/crucible                                                              c333b519-9dde-4ada-b507-2bb0b6903d17   none      none          off        
-    oxp_12057b4a-0b06-4f70-ba22-336de2385bfe/crypt/debug                                                           438902f5-ff09-48f2-8cd1-56dc910d86e1   100 GiB   none          gzip-9     
+    oxp_12057b4a-0b06-4f70-ba22-336de2385bfe/crypt/debug                                                           bc7e5ae9-81f0-437b-9655-d11259f5037b   100 GiB   none          gzip-9     
     oxp_12057b4a-0b06-4f70-ba22-336de2385bfe/crypt/internal_dns                                                    52de1771-5f5b-422d-89e9-96a708c66d47   none      none          off        
-    oxp_12057b4a-0b06-4f70-ba22-336de2385bfe/crypt/zone                                                            5a5afb9f-850c-4501-959a-8ff760eca117   none      none          off        
+    oxp_12057b4a-0b06-4f70-ba22-336de2385bfe/crypt/zone                                                            fe22839c-29a4-4711-8290-44dc001b9a4f   none      none          off        
     oxp_12057b4a-0b06-4f70-ba22-336de2385bfe/crypt/zone/oxz_crucible_8f3a1cc5-9195-4a30-ad02-b804278fe639          42a06863-188a-4755-99f7-659df14958f7   none      none          off        
     oxp_12057b4a-0b06-4f70-ba22-336de2385bfe/crypt/zone/oxz_crucible_pantry_02acbe6a-1c88-47e3-94c3-94084cbde098   f7256e30-6e62-4d4b-ab06-8e9b3c9472a3   none      none          off        
     oxp_12057b4a-0b06-4f70-ba22-336de2385bfe/crypt/zone/oxz_internal_dns_07c3c805-8888-4fe5-9543-3d2479dbe6f3      54774860-da9a-4ff5-8d63-242b353c3115   none      none          off        
     oxp_12057b4a-0b06-4f70-ba22-336de2385bfe/crypt/zone/oxz_nexus_a1696cd4-588c-484a-b95b-66e824c0ce05             5dae2769-982f-485d-9776-57c2ae0a83b9   none      none          off        
     oxp_12057b4a-0b06-4f70-ba22-336de2385bfe/crypt/zone/oxz_ntp_10d98a73-ec88-4aff-a7e8-7db6a87880e6               c5dc843c-fa8c-46a8-9998-aa0b0397cb0c   none      none          off        
     oxp_29758363-6c77-40c3-8740-9c0c64f6e14a/crucible                                                              2e09fba5-0c1d-41db-a310-bef9290c6332   none      none          off        
-    oxp_29758363-6c77-40c3-8740-9c0c64f6e14a/crypt/debug                                                           bc7e5ae9-81f0-437b-9655-d11259f5037b   100 GiB   none          gzip-9     
-    oxp_29758363-6c77-40c3-8740-9c0c64f6e14a/crypt/zone                                                            fe22839c-29a4-4711-8290-44dc001b9a4f   none      none          off        
+    oxp_29758363-6c77-40c3-8740-9c0c64f6e14a/crypt/debug                                                           438902f5-ff09-48f2-8cd1-56dc910d86e1   100 GiB   none          gzip-9     
+    oxp_29758363-6c77-40c3-8740-9c0c64f6e14a/crypt/zone                                                            5a5afb9f-850c-4501-959a-8ff760eca117   none      none          off        
     oxp_29758363-6c77-40c3-8740-9c0c64f6e14a/crypt/zone/oxz_crucible_2a455c35-eb3c-4c73-ab6c-d0a706e25316          a3e5c0e0-3a73-4f7a-abd4-63f3434767aa   none      none          off        
     oxp_3f331c10-7882-48ab-85d9-05108490b55b/crucible                                                              76ab0eb2-4356-4a8a-b555-a83930ef3dce   none      none          off        
-    oxp_3f331c10-7882-48ab-85d9-05108490b55b/crypt/debug                                                           70aadfba-de91-4157-ab8c-98609d278d08   100 GiB   none          gzip-9     
-    oxp_3f331c10-7882-48ab-85d9-05108490b55b/crypt/zone                                                            3b733c7c-d0b0-427b-952a-200518837f87   none      none          off        
+    oxp_3f331c10-7882-48ab-85d9-05108490b55b/crypt/debug                                                           4939df35-a183-4c85-9872-5ced516bd154   100 GiB   none          gzip-9     
+    oxp_3f331c10-7882-48ab-85d9-05108490b55b/crypt/zone                                                            e991d7ef-7ca9-444e-ad9d-6f9d165a3b80   none      none          off        
     oxp_3f331c10-7882-48ab-85d9-05108490b55b/crypt/zone/oxz_crucible_a2079cbc-a69e-41a1-b1e0-fbcb972d03f6          94407842-70fd-48cd-933f-b0d7768fa45b   none      none          off        
     oxp_5152d1aa-9045-4e06-9ef6-6eadac3696e4/crucible                                                              52255a04-77be-486f-a59f-f17de4916cc2   none      none          off        
-    oxp_5152d1aa-9045-4e06-9ef6-6eadac3696e4/crypt/debug                                                           d6835e81-73e5-46cc-a188-93050a2e4d40   100 GiB   none          gzip-9     
-    oxp_5152d1aa-9045-4e06-9ef6-6eadac3696e4/crypt/zone                                                            7aabaeaa-fd10-4686-bd7e-65a961ea3f87   none      none          off        
+    oxp_5152d1aa-9045-4e06-9ef6-6eadac3696e4/crypt/debug                                                           70aadfba-de91-4157-ab8c-98609d278d08   100 GiB   none          gzip-9     
+    oxp_5152d1aa-9045-4e06-9ef6-6eadac3696e4/crypt/zone                                                            3b733c7c-d0b0-427b-952a-200518837f87   none      none          off        
     oxp_5152d1aa-9045-4e06-9ef6-6eadac3696e4/crypt/zone/oxz_crucible_587be699-a320-4c79-b320-128d9ecddc0b          40cae2bc-0505-4d53-9d94-b199aaf5600a   none      none          off        
     oxp_5c0dd424-d905-4fc5-a73c-36254fdd470c/crucible                                                              ab598283-0338-4124-af32-71aaf478908d   none      none          off        
-    oxp_5c0dd424-d905-4fc5-a73c-36254fdd470c/crypt/debug                                                           4939df35-a183-4c85-9872-5ced516bd154   100 GiB   none          gzip-9     
-    oxp_5c0dd424-d905-4fc5-a73c-36254fdd470c/crypt/zone                                                            e991d7ef-7ca9-444e-ad9d-6f9d165a3b80   none      none          off        
+    oxp_5c0dd424-d905-4fc5-a73c-36254fdd470c/crypt/debug                                                           f5e9ef79-2d90-4839-aeac-a1048516011e   100 GiB   none          gzip-9     
+    oxp_5c0dd424-d905-4fc5-a73c-36254fdd470c/crypt/zone                                                            51701069-af21-4697-8655-d2a8e455dceb   none      none          off        
     oxp_5c0dd424-d905-4fc5-a73c-36254fdd470c/crypt/zone/oxz_crucible_6fa06115-4959-4913-8e7b-dd70d7651f07          8879f080-4bd0-4073-ab2f-08e6f289bb4f   none      none          off        
     oxp_794df76f-bca0-4635-9eb6-773ad0108f7e/crucible                                                              e54385d1-cead-4fb6-a28e-c13db4e9561f   none      none          off        
     oxp_794df76f-bca0-4635-9eb6-773ad0108f7e/crypt/debug                                                           35f7f5fc-0d30-442d-b74a-7ef63b13bb6d   100 GiB   none          gzip-9     
@@ -159,8 +159,8 @@ to:   blueprint f432fcd5-1284-4058-8b4a-9286a3de6163
     oxp_d55d36d7-df92-4615-944d-440a1f8b5001/crypt/zone                                                            b7b7c0d6-b2dd-41eb-b5fe-3e131356552f   none      none          off        
     oxp_d55d36d7-df92-4615-944d-440a1f8b5001/crypt/zone/oxz_crucible_edabedf3-839c-488d-ad6f-508ffa864674          3b94580a-8ff4-4302-8d49-30ff90ef7edc   none      none          off        
     oxp_db6686c8-2dd9-4032-8444-2a06b43baa68/crucible                                                              882faa8a-7df8-4f67-abba-3d97a2615932   none      none          off        
-    oxp_db6686c8-2dd9-4032-8444-2a06b43baa68/crypt/debug                                                           f5e9ef79-2d90-4839-aeac-a1048516011e   100 GiB   none          gzip-9     
-    oxp_db6686c8-2dd9-4032-8444-2a06b43baa68/crypt/zone                                                            51701069-af21-4697-8655-d2a8e455dceb   none      none          off        
+    oxp_db6686c8-2dd9-4032-8444-2a06b43baa68/crypt/debug                                                           d6835e81-73e5-46cc-a188-93050a2e4d40   100 GiB   none          gzip-9     
+    oxp_db6686c8-2dd9-4032-8444-2a06b43baa68/crypt/zone                                                            7aabaeaa-fd10-4686-bd7e-65a961ea3f87   none      none          off        
     oxp_db6686c8-2dd9-4032-8444-2a06b43baa68/crypt/zone/oxz_crucible_d637264f-6f40-44c2-8b7e-a179430210d2          bde5f2d8-ac7d-40e8-b4b7-2cdf1cff6e57   none      none          off        
 
 
@@ -202,54 +202,54 @@ to:   blueprint f432fcd5-1284-4058-8b4a-9286a3de6163
     fake-vendor   fake-model   serial-f8c9c9a9-d73e-4cdf-a9af-03cfbbbce12b
 
 
-    datasets at generation 1:
+    datasets at generation 2:
     -----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
     dataset name                                                                                                   dataset uuid                           quota     reservation   compression
     -----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
     oxp_2a94863d-16e2-4535-973b-e98dd47fd18d/crucible                                                              35656b97-3eef-46f2-aab0-4d33a3548e62   none      none          off        
-    oxp_2a94863d-16e2-4535-973b-e98dd47fd18d/crypt/debug                                                           bdf9f107-3a76-4d6a-bea0-5cfb4d3cd6a6   100 GiB   none          gzip-9     
+    oxp_2a94863d-16e2-4535-973b-e98dd47fd18d/crypt/debug                                                           abe29a15-fef4-47ef-8f08-71645f396213   100 GiB   none          gzip-9     
     oxp_2a94863d-16e2-4535-973b-e98dd47fd18d/crypt/internal_dns                                                    b0fcbafd-55cc-49f1-9e02-20503673b34f   none      none          off        
-    oxp_2a94863d-16e2-4535-973b-e98dd47fd18d/crypt/zone                                                            0b216cae-701c-4341-a48a-690543b8e1e9   none      none          off        
+    oxp_2a94863d-16e2-4535-973b-e98dd47fd18d/crypt/zone                                                            5dd03902-3f33-4f7e-896a-c08d7c6e37f1   none      none          off        
     oxp_2a94863d-16e2-4535-973b-e98dd47fd18d/crypt/zone/oxz_crucible_18f8fe40-646e-4962-b17a-20e201f3a6e5          eec6f425-d377-42b2-890f-c8c3efe173d1   none      none          off        
     oxp_2a94863d-16e2-4535-973b-e98dd47fd18d/crypt/zone/oxz_crucible_pantry_56d5d7cf-db2c-40a3-a775-003241ad4820   ada776f0-dbb1-4430-a60a-f7462570a19c   none      none          off        
     oxp_2a94863d-16e2-4535-973b-e98dd47fd18d/crypt/zone/oxz_internal_dns_ab7ba6df-d401-40bd-940e-faf57c57aa2a      2fe942e9-085c-4155-a415-c2dcc19dbd91   none      none          off        
     oxp_2a94863d-16e2-4535-973b-e98dd47fd18d/crypt/zone/oxz_nexus_dce226c9-7373-4bfa-8a94-79dc472857a6             4abeefa4-e5ad-46e9-b056-79f5950a5639   none      none          off        
     oxp_2a94863d-16e2-4535-973b-e98dd47fd18d/crypt/zone/oxz_ntp_7a9f60d3-2b66-4547-9b63-7d4f7a8b6382               63337e4d-61a8-4dc7-a322-1442bc19b347   none      none          off        
     oxp_32456d15-f5b6-4efc-90c8-dbba979b69cb/crucible                                                              3b4f5bbb-cc50-49ae-a208-ca88dff1f361   none      none          off        
-    oxp_32456d15-f5b6-4efc-90c8-dbba979b69cb/crypt/debug                                                           cc56ea63-0ae3-48ce-8faf-1bd7d83eb148   100 GiB   none          gzip-9     
-    oxp_32456d15-f5b6-4efc-90c8-dbba979b69cb/crypt/zone                                                            dce1da41-4cf0-4f70-a9e5-f4b7fad54228   none      none          off        
+    oxp_32456d15-f5b6-4efc-90c8-dbba979b69cb/crypt/debug                                                           411e3457-3113-40d2-8a7d-747b108e0de7   100 GiB   none          gzip-9     
+    oxp_32456d15-f5b6-4efc-90c8-dbba979b69cb/crypt/zone                                                            a79b0ad5-06b8-466c-928c-39e311ace5ff   none      none          off        
     oxp_32456d15-f5b6-4efc-90c8-dbba979b69cb/crypt/zone/oxz_crucible_6af7f4d6-33b6-4eb3-a146-d8e9e4ae9d66          a33e3d63-6413-42b2-8cf0-02c774666916   none      none          off        
     oxp_416fe9f9-5161-4b0f-9e11-c9d81563ded5/crucible                                                              8b82f804-50d1-4e6f-8899-181433d82299   none      none          off        
-    oxp_416fe9f9-5161-4b0f-9e11-c9d81563ded5/crypt/debug                                                           abe29a15-fef4-47ef-8f08-71645f396213   100 GiB   none          gzip-9     
-    oxp_416fe9f9-5161-4b0f-9e11-c9d81563ded5/crypt/zone                                                            5dd03902-3f33-4f7e-896a-c08d7c6e37f1   none      none          off        
+    oxp_416fe9f9-5161-4b0f-9e11-c9d81563ded5/crypt/debug                                                           79ce0088-d8a8-46ff-ac72-958b8db65e67   100 GiB   none          gzip-9     
+    oxp_416fe9f9-5161-4b0f-9e11-c9d81563ded5/crypt/zone                                                            1635dad8-971f-4409-aca3-6204eafec699   none      none          off        
     oxp_416fe9f9-5161-4b0f-9e11-c9d81563ded5/crypt/zone/oxz_crucible_93f2f40c-5616-4d8d-8519-ec6debdcede0          4c0303d2-205d-4644-b55a-5c74bbce54c3   none      none          off        
     oxp_4c68800e-23f8-485b-b251-628fd151e445/crucible                                                              226cea90-799d-4f6c-90c6-459d2d7674c1   none      none          off        
-    oxp_4c68800e-23f8-485b-b251-628fd151e445/crypt/debug                                                           32535344-4e21-4fb3-9c43-f305ac367efb   100 GiB   none          gzip-9     
-    oxp_4c68800e-23f8-485b-b251-628fd151e445/crypt/zone                                                            447cc163-589e-479c-a73d-0071e5dc59bf   none      none          off        
+    oxp_4c68800e-23f8-485b-b251-628fd151e445/crypt/debug                                                           19bdebd5-9757-409f-ac06-2b309379975e   100 GiB   none          gzip-9     
+    oxp_4c68800e-23f8-485b-b251-628fd151e445/crypt/zone                                                            aa37e2bb-8d16-4dc2-a549-5f265fdad77c   none      none          off        
     oxp_4c68800e-23f8-485b-b251-628fd151e445/crypt/zone/oxz_crucible_1cc3f503-2001-4d85-80e5-c7c40d2e3b10          5a210076-5d38-42f0-915c-c09f67ff38af   none      none          off        
     oxp_9dd87c4d-5fb4-475a-86fa-c0da81a3e00a/crucible                                                              d5cd0c03-b555-46b2-b626-cc70bd931cee   none      none          off        
-    oxp_9dd87c4d-5fb4-475a-86fa-c0da81a3e00a/crypt/debug                                                           7d983611-ab39-4083-93d0-f57f3ada9a0f   100 GiB   none          gzip-9     
-    oxp_9dd87c4d-5fb4-475a-86fa-c0da81a3e00a/crypt/zone                                                            0568d976-0079-4d6e-9d1f-a8cfc4b044df   none      none          off        
+    oxp_9dd87c4d-5fb4-475a-86fa-c0da81a3e00a/crypt/debug                                                           32535344-4e21-4fb3-9c43-f305ac367efb   100 GiB   none          gzip-9     
+    oxp_9dd87c4d-5fb4-475a-86fa-c0da81a3e00a/crypt/zone                                                            447cc163-589e-479c-a73d-0071e5dc59bf   none      none          off        
     oxp_9dd87c4d-5fb4-475a-86fa-c0da81a3e00a/crypt/zone/oxz_crucible_0565e7e4-f13a-4123-8928-d715f83e36aa          e2de5537-a289-49ac-8a61-65805a35755e   none      none          off        
     oxp_be93a517-445e-46c2-aa21-3dc526d4a413/crucible                                                              52fde46c-85f4-470e-8c1e-38b13c042620   none      none          off        
-    oxp_be93a517-445e-46c2-aa21-3dc526d4a413/crypt/debug                                                           731caeb5-c24f-45b7-aafa-4e747302eaa4   100 GiB   none          gzip-9     
-    oxp_be93a517-445e-46c2-aa21-3dc526d4a413/crypt/zone                                                            f75ef0e7-663d-4418-99b6-71e2a77a27e3   none      none          off        
+    oxp_be93a517-445e-46c2-aa21-3dc526d4a413/crypt/debug                                                           bdf9f107-3a76-4d6a-bea0-5cfb4d3cd6a6   100 GiB   none          gzip-9     
+    oxp_be93a517-445e-46c2-aa21-3dc526d4a413/crypt/zone                                                            0b216cae-701c-4341-a48a-690543b8e1e9   none      none          off        
     oxp_be93a517-445e-46c2-aa21-3dc526d4a413/crypt/zone/oxz_crucible_62058f4c-c747-4e21-a8dc-2fd4a160c98c          0679ecb0-7759-4561-a81a-d8d7125ed693   none      none          off        
     oxp_d9344e2b-84d2-4392-84ab-41b86ed02237/crucible                                                              4b593475-e809-4822-a2fe-c58b2f7964d5   none      none          off        
-    oxp_d9344e2b-84d2-4392-84ab-41b86ed02237/crypt/debug                                                           19bdebd5-9757-409f-ac06-2b309379975e   100 GiB   none          gzip-9     
-    oxp_d9344e2b-84d2-4392-84ab-41b86ed02237/crypt/zone                                                            aa37e2bb-8d16-4dc2-a549-5f265fdad77c   none      none          off        
+    oxp_d9344e2b-84d2-4392-84ab-41b86ed02237/crypt/debug                                                           2059b139-6510-4447-aa56-cf995ef469a2   100 GiB   none          gzip-9     
+    oxp_d9344e2b-84d2-4392-84ab-41b86ed02237/crypt/zone                                                            1b5a2379-ec60-47f0-8def-fa3ab5c2487c   none      none          off        
     oxp_d9344e2b-84d2-4392-84ab-41b86ed02237/crypt/zone/oxz_crucible_062ce37d-7448-4d44-b1f4-4937cd2eb174          bfbfe7dd-06b3-4d01-988d-488c7b9400ee   none      none          off        
     oxp_eab188d0-b34a-4673-b254-12e705597654/crucible                                                              444a65f5-d04e-4cb0-a29d-ba57e34143dd   none      none          off        
-    oxp_eab188d0-b34a-4673-b254-12e705597654/crypt/debug                                                           411e3457-3113-40d2-8a7d-747b108e0de7   100 GiB   none          gzip-9     
-    oxp_eab188d0-b34a-4673-b254-12e705597654/crypt/zone                                                            a79b0ad5-06b8-466c-928c-39e311ace5ff   none      none          off        
+    oxp_eab188d0-b34a-4673-b254-12e705597654/crypt/debug                                                           731caeb5-c24f-45b7-aafa-4e747302eaa4   100 GiB   none          gzip-9     
+    oxp_eab188d0-b34a-4673-b254-12e705597654/crypt/zone                                                            f75ef0e7-663d-4418-99b6-71e2a77a27e3   none      none          off        
     oxp_eab188d0-b34a-4673-b254-12e705597654/crypt/zone/oxz_crucible_78d6ab36-e8c8-4ff8-9f89-75c7fe2d32e6          ebc48adb-4dad-41dd-a547-13f2517a9db7   none      none          off        
     oxp_f1e0386f-11b6-4cdf-8250-826d256db6b5/crucible                                                              826e2ca8-f30d-4ca3-8360-f03ddd883a6a   none      none          off        
-    oxp_f1e0386f-11b6-4cdf-8250-826d256db6b5/crypt/debug                                                           79ce0088-d8a8-46ff-ac72-958b8db65e67   100 GiB   none          gzip-9     
-    oxp_f1e0386f-11b6-4cdf-8250-826d256db6b5/crypt/zone                                                            1635dad8-971f-4409-aca3-6204eafec699   none      none          off        
+    oxp_f1e0386f-11b6-4cdf-8250-826d256db6b5/crypt/debug                                                           cc56ea63-0ae3-48ce-8faf-1bd7d83eb148   100 GiB   none          gzip-9     
+    oxp_f1e0386f-11b6-4cdf-8250-826d256db6b5/crypt/zone                                                            dce1da41-4cf0-4f70-a9e5-f4b7fad54228   none      none          off        
     oxp_f1e0386f-11b6-4cdf-8250-826d256db6b5/crypt/zone/oxz_crucible_9f824c30-6360-46b9-87c4-cd60586476fe          c4e2119e-4cd0-48e7-878f-fd676cb95094   none      none          off        
     oxp_f8c9c9a9-d73e-4cdf-a9af-03cfbbbce12b/crucible                                                              2c6ade05-a626-4b25-a28c-551b91867dbe   none      none          off        
-    oxp_f8c9c9a9-d73e-4cdf-a9af-03cfbbbce12b/crypt/debug                                                           2059b139-6510-4447-aa56-cf995ef469a2   100 GiB   none          gzip-9     
-    oxp_f8c9c9a9-d73e-4cdf-a9af-03cfbbbce12b/crypt/zone                                                            1b5a2379-ec60-47f0-8def-fa3ab5c2487c   none      none          off        
+    oxp_f8c9c9a9-d73e-4cdf-a9af-03cfbbbce12b/crypt/debug                                                           7d983611-ab39-4083-93d0-f57f3ada9a0f   100 GiB   none          gzip-9     
+    oxp_f8c9c9a9-d73e-4cdf-a9af-03cfbbbce12b/crypt/zone                                                            0568d976-0079-4d6e-9d1f-a8cfc4b044df   none      none          off        
     oxp_f8c9c9a9-d73e-4cdf-a9af-03cfbbbce12b/crypt/zone/oxz_crucible_1211a68e-69a1-4ef4-b790-45b0279f9159          32a3e82a-b97a-455a-b428-1f934c59eb46   none      none          off        
 
 
@@ -293,31 +293,31 @@ to:   blueprint f432fcd5-1284-4058-8b4a-9286a3de6163
     fake-vendor   fake-model   serial-fdfd067b-1d86-444d-a21f-ed33709f3e4d
 
 
-    datasets generation 1 -> 2:
+    datasets generation 2 -> 3:
     ----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
     dataset name                                                                                            dataset uuid                           quota     reservation   compression
     ----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
-    oxp_28699448-c5d9-49ea-bf7e-627800efe783/crypt/debug                                                    bbab775c-07b1-48b1-96a3-9aa155396112   100 GiB   none          gzip-9     
-    oxp_28699448-c5d9-49ea-bf7e-627800efe783/crypt/zone                                                     07381a6a-e397-4ff9-a2a6-8f1e46c47eb3   none      none          off        
+    oxp_28699448-c5d9-49ea-bf7e-627800efe783/crypt/debug                                                    91edd9a1-178d-4aa5-83a7-b2f4ef1fc44a   100 GiB   none          gzip-9     
+    oxp_28699448-c5d9-49ea-bf7e-627800efe783/crypt/zone                                                     1bd5ab24-2a54-438f-bae0-af1b06a3cc41   none      none          off        
     oxp_28699448-c5d9-49ea-bf7e-627800efe783/crypt/zone/oxz_ntp_2d73d30e-ca47-46a8-9c12-917d4ab824b6        15e9b1ea-8947-48a2-8d78-54665e4d2f03   none      none          off        
-    oxp_2c490e96-27f2-4a7f-b440-04d4bfd1e4f6/crypt/debug                                                    75c1432c-19e1-4c06-8393-9907a09efcbe   100 GiB   none          gzip-9     
-    oxp_2c490e96-27f2-4a7f-b440-04d4bfd1e4f6/crypt/zone                                                     b4c23ac2-86af-4b47-9d8d-35eff7997788   none      none          off        
-    oxp_4c3bb1c7-55b6-49b8-b212-516b8f2c26c2/crypt/debug                                                    5501c13c-0500-41a6-9c48-85924383fdcc   100 GiB   none          gzip-9     
-    oxp_4c3bb1c7-55b6-49b8-b212-516b8f2c26c2/crypt/zone                                                     32143abb-e501-450b-9398-7d4dbebdf4a1   none      none          off        
-    oxp_5db07562-31a8-43e3-b99e-7c7cb89754b7/crypt/debug                                                    bcdd7a5a-59da-4a47-8a1c-79281428d71b   100 GiB   none          gzip-9     
-    oxp_5db07562-31a8-43e3-b99e-7c7cb89754b7/crypt/zone                                                     6ec35c5c-9d6c-4d72-8bec-af91069ef7a9   none      none          off        
-    oxp_9451a5d5-b358-4719-b6c1-a0d187da217c/crypt/debug                                                    8ed9d1a2-3c60-4f38-9e80-5c56d80e67c9   100 GiB   none          gzip-9     
-    oxp_9451a5d5-b358-4719-b6c1-a0d187da217c/crypt/zone                                                     8529e7f8-8c11-4869-b330-83ddc45ed17a   none      none          off        
-    oxp_bb2e2869-9481-483a-bc49-2bdd62f515f5/crypt/debug                                                    4aef9a3a-0829-4ada-a0e9-a45c91e74249   100 GiB   none          gzip-9     
-    oxp_bb2e2869-9481-483a-bc49-2bdd62f515f5/crypt/zone                                                     940f06cb-822f-4034-8d34-e14bcc6ea998   none      none          off        
+    oxp_2c490e96-27f2-4a7f-b440-04d4bfd1e4f6/crypt/debug                                                    bcdd7a5a-59da-4a47-8a1c-79281428d71b   100 GiB   none          gzip-9     
+    oxp_2c490e96-27f2-4a7f-b440-04d4bfd1e4f6/crypt/zone                                                     6ec35c5c-9d6c-4d72-8bec-af91069ef7a9   none      none          off        
+    oxp_4c3bb1c7-55b6-49b8-b212-516b8f2c26c2/crypt/debug                                                    4aef9a3a-0829-4ada-a0e9-a45c91e74249   100 GiB   none          gzip-9     
+    oxp_4c3bb1c7-55b6-49b8-b212-516b8f2c26c2/crypt/zone                                                     940f06cb-822f-4034-8d34-e14bcc6ea998   none      none          off        
+    oxp_5db07562-31a8-43e3-b99e-7c7cb89754b7/crypt/debug                                                    8ed9d1a2-3c60-4f38-9e80-5c56d80e67c9   100 GiB   none          gzip-9     
+    oxp_5db07562-31a8-43e3-b99e-7c7cb89754b7/crypt/zone                                                     8529e7f8-8c11-4869-b330-83ddc45ed17a   none      none          off        
+    oxp_9451a5d5-b358-4719-b6c1-a0d187da217c/crypt/debug                                                    feac64a1-ade2-4f88-8c17-64d2863e2be6   100 GiB   none          gzip-9     
+    oxp_9451a5d5-b358-4719-b6c1-a0d187da217c/crypt/zone                                                     1acaf776-970a-49cf-9f1c-7d8e3146ef11   none      none          off        
+    oxp_bb2e2869-9481-483a-bc49-2bdd62f515f5/crypt/debug                                                    5501c13c-0500-41a6-9c48-85924383fdcc   100 GiB   none          gzip-9     
+    oxp_bb2e2869-9481-483a-bc49-2bdd62f515f5/crypt/zone                                                     32143abb-e501-450b-9398-7d4dbebdf4a1   none      none          off        
     oxp_d5a36c66-4b2f-46e6-96f4-b82debee1a4a/crypt/debug                                                    2b23d885-836a-4270-886d-08640aae90aa   100 GiB   none          gzip-9     
     oxp_d5a36c66-4b2f-46e6-96f4-b82debee1a4a/crypt/zone                                                     0507b005-e018-4b69-9d84-50faf61e792f   none      none          off        
-    oxp_f99ec996-ec08-4ccf-9a6e-6c5cab440fb4/crypt/debug                                                    feac64a1-ade2-4f88-8c17-64d2863e2be6   100 GiB   none          gzip-9     
-    oxp_f99ec996-ec08-4ccf-9a6e-6c5cab440fb4/crypt/zone                                                     1acaf776-970a-49cf-9f1c-7d8e3146ef11   none      none          off        
-    oxp_faccbb39-d686-42a1-a50a-0eb59ba74a87/crypt/debug                                                    91edd9a1-178d-4aa5-83a7-b2f4ef1fc44a   100 GiB   none          gzip-9     
-    oxp_faccbb39-d686-42a1-a50a-0eb59ba74a87/crypt/zone                                                     1bd5ab24-2a54-438f-bae0-af1b06a3cc41   none      none          off        
-    oxp_fdfd067b-1d86-444d-a21f-ed33709f3e4d/crypt/debug                                                    8840ccd9-e8c9-48d9-affb-8587e468b204   100 GiB   none          gzip-9     
-    oxp_fdfd067b-1d86-444d-a21f-ed33709f3e4d/crypt/zone                                                     b501adbf-be36-4724-9409-329f690fb09d   none      none          off        
+    oxp_f99ec996-ec08-4ccf-9a6e-6c5cab440fb4/crypt/debug                                                    8840ccd9-e8c9-48d9-affb-8587e468b204   100 GiB   none          gzip-9     
+    oxp_f99ec996-ec08-4ccf-9a6e-6c5cab440fb4/crypt/zone                                                     b501adbf-be36-4724-9409-329f690fb09d   none      none          off        
+    oxp_faccbb39-d686-42a1-a50a-0eb59ba74a87/crypt/debug                                                    75c1432c-19e1-4c06-8393-9907a09efcbe   100 GiB   none          gzip-9     
+    oxp_faccbb39-d686-42a1-a50a-0eb59ba74a87/crypt/zone                                                     b4c23ac2-86af-4b47-9d8d-35eff7997788   none      none          off        
+    oxp_fdfd067b-1d86-444d-a21f-ed33709f3e4d/crypt/debug                                                    bbab775c-07b1-48b1-96a3-9aa155396112   100 GiB   none          gzip-9     
+    oxp_fdfd067b-1d86-444d-a21f-ed33709f3e4d/crypt/zone                                                     07381a6a-e397-4ff9-a2a6-8f1e46c47eb3   none      none          off        
 +   oxp_28699448-c5d9-49ea-bf7e-627800efe783/crucible                                                       c842fd37-6d1b-430c-83c5-bb49523434e3   none      none          off        
 +   oxp_28699448-c5d9-49ea-bf7e-627800efe783/crypt/zone/oxz_crucible_45556184-7092-4a3d-873f-637976bb133b   88f174e0-09e5-4a04-a21f-4885fc7c776b   none      none          off        
 +   oxp_2c490e96-27f2-4a7f-b440-04d4bfd1e4f6/crucible                                                       33b4b373-748a-44ce-bae3-d08a6f760f88   none      none          off        

--- a/nexus/reconfigurator/planning/tests/output/planner_dataset_settings_modified_in_place_1_2.txt
+++ b/nexus/reconfigurator/planning/tests/output/planner_dataset_settings_modified_in_place_1_2.txt
@@ -21,15 +21,15 @@ to:   blueprint fe13be30-94c2-4fa6-aad5-ae3c5028f6bb
     fake-vendor   fake-model   serial-f843fb62-0f04-4c7d-a56f-62531104dc77
 
 
-    datasets generation 1 -> 2:
+    datasets generation 2 -> 3:
     -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
     dataset name                                                                                                   dataset uuid                           quota       reservation   compression
     -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
     oxp_3b6e2ade-57fc-4f9d-85c3-38fca27f1df6/crucible                                                              37ca00f9-8c48-49dd-a511-1844366b9fc6   none        none          off        
     oxp_3b6e2ade-57fc-4f9d-85c3-38fca27f1df6/crypt/clickhouse                                                      379a5c76-adde-40c7-a0b0-b7837ed4b1bf   none        none          off        
-    oxp_3b6e2ade-57fc-4f9d-85c3-38fca27f1df6/crypt/debug                                                           fe7f66a8-7605-4001-87f8-2357e95acb2a   100 GiB     none          gzip-9     
+    oxp_3b6e2ade-57fc-4f9d-85c3-38fca27f1df6/crypt/debug                                                           72893a49-bd26-425f-a56e-ee09d6f634b1   100 GiB     none          gzip-9     
     oxp_3b6e2ade-57fc-4f9d-85c3-38fca27f1df6/crypt/internal_dns                                                    7ba6b643-5113-43e9-ae33-de52c2b1d7c2   none        none          off        
-    oxp_3b6e2ade-57fc-4f9d-85c3-38fca27f1df6/crypt/zone                                                            4300bbd9-56b4-4735-9e6a-5c12ecd431eb   none        none          off        
+    oxp_3b6e2ade-57fc-4f9d-85c3-38fca27f1df6/crypt/zone                                                            269d597d-795f-4675-9210-3796379f082e   none        none          off        
     oxp_3b6e2ade-57fc-4f9d-85c3-38fca27f1df6/crypt/zone/oxz_clickhouse_5d62c22a-7ad0-439c-963b-a30ba8ff31bb        997e8452-11b8-4478-98fb-89fbd6abe9b4   none        none          off        
     oxp_3b6e2ade-57fc-4f9d-85c3-38fca27f1df6/crypt/zone/oxz_crucible_449deb40-b01b-41ae-8167-7b7b47e2692e          e8fc9f62-9c90-4ec5-9a04-59d3dc4970cf   none        none          off        
     oxp_3b6e2ade-57fc-4f9d-85c3-38fca27f1df6/crypt/zone/oxz_crucible_pantry_197067bc-9a21-444e-9794-6051d9f78a00   19736dbd-1d01-41e9-a800-ffc450464c2d   none        none          off        
@@ -45,39 +45,39 @@ to:   blueprint fe13be30-94c2-4fa6-aad5-ae3c5028f6bb
     oxp_5192ef62-5a12-4a0c-829d-a409da87909c/crypt/zone/oxz_crucible_92476a4a-7a95-4141-acc6-e0a42066edbd          426cd017-82e0-4078-a5dd-05c5b88c1e66   none        none          off        
     oxp_5192ef62-5a12-4a0c-829d-a409da87909c/crypt/zone/oxz_internal_dns_efecb8a2-ce0b-416f-958b-de1fad1bef02      158e226c-e44e-427f-93af-ee96d2cfb9be   none        none          off        
     oxp_8778bcc5-dddf-4345-9fdf-5c46a36497b0/crucible                                                              d11c234f-c617-4cfe-b61a-38ea70de8325   none        none          off        
-    oxp_8778bcc5-dddf-4345-9fdf-5c46a36497b0/crypt/debug                                                           38570a1f-a96b-45dc-8cdd-91ec150657bf   100 GiB     none          gzip-9     
+    oxp_8778bcc5-dddf-4345-9fdf-5c46a36497b0/crypt/debug                                                           855e6f57-c6c8-408d-bda0-7fdd220565a1   100 GiB     none          gzip-9     
     oxp_8778bcc5-dddf-4345-9fdf-5c46a36497b0/crypt/internal_dns                                                    50cbcefa-0500-4cd2-b077-f4cda0ffce81   none        none          off        
-    oxp_8778bcc5-dddf-4345-9fdf-5c46a36497b0/crypt/zone                                                            83954f81-3607-45e5-b380-6c19c0eafcb2   none        none          off        
+    oxp_8778bcc5-dddf-4345-9fdf-5c46a36497b0/crypt/zone                                                            2e7f7b63-681f-490a-8a31-40bb196aa927   none        none          off        
     oxp_8778bcc5-dddf-4345-9fdf-5c46a36497b0/crypt/zone/oxz_crucible_d0e39a63-1310-42a3-ba54-6624006c0d24          80d8fd68-b3e3-49ba-b758-d58271057bb7   none        none          off        
     oxp_8778bcc5-dddf-4345-9fdf-5c46a36497b0/crypt/zone/oxz_internal_dns_4a0ec9f6-6ce6-4456-831e-5f8df7b57332      d2b9f103-8bf1-4603-873d-cec130430ba7   none        none          off        
     oxp_9134de8d-9ba8-4ddc-9e84-eb00ec616b53/crucible                                                              5dc63025-10bf-4e78-80d8-aec0a884c931   none        none          off        
-    oxp_9134de8d-9ba8-4ddc-9e84-eb00ec616b53/crypt/debug                                                           f46e90fa-6f1c-40d4-813b-0b2dfbc8295d   100 GiB     none          gzip-9     
-    oxp_9134de8d-9ba8-4ddc-9e84-eb00ec616b53/crypt/zone                                                            1d57c1bc-f3dc-4799-848e-ffab7e1a9704   none        none          off        
+    oxp_9134de8d-9ba8-4ddc-9e84-eb00ec616b53/crypt/debug                                                           2280f30e-4f1b-45f2-a6fe-83098487637b   100 GiB     none          gzip-9     
+    oxp_9134de8d-9ba8-4ddc-9e84-eb00ec616b53/crypt/zone                                                            a7b90e18-788d-47cc-91d8-4eb427c9c041   none        none          off        
     oxp_9134de8d-9ba8-4ddc-9e84-eb00ec616b53/crypt/zone/oxz_crucible_729e375b-31a4-4cfc-b56c-afeef8d8adfc          476cc49e-29d1-4c3d-b4c0-c5ec01206b26   none        none          off        
     oxp_96569b61-9e0c-4ee7-bd11-a5e0c541ca99/crucible                                                              572474f0-3630-40d5-814f-9fc58261e8cd   none        none          off        
-    oxp_96569b61-9e0c-4ee7-bd11-a5e0c541ca99/crypt/debug                                                           72893a49-bd26-425f-a56e-ee09d6f634b1   100 GiB     none          gzip-9     
-    oxp_96569b61-9e0c-4ee7-bd11-a5e0c541ca99/crypt/zone                                                            269d597d-795f-4675-9210-3796379f082e   none        none          off        
+    oxp_96569b61-9e0c-4ee7-bd11-a5e0c541ca99/crypt/debug                                                           f46e90fa-6f1c-40d4-813b-0b2dfbc8295d   100 GiB     none          gzip-9     
+    oxp_96569b61-9e0c-4ee7-bd11-a5e0c541ca99/crypt/zone                                                            1d57c1bc-f3dc-4799-848e-ffab7e1a9704   none        none          off        
     oxp_96569b61-9e0c-4ee7-bd11-a5e0c541ca99/crypt/zone/oxz_crucible_fff71a84-09c2-4dab-bc18-8f4570f278bb          00abfe99-288d-4a63-abea-adfa62e74524   none        none          off        
     oxp_ba90170e-7399-4260-910a-376254a8a9bf/crucible                                                              a527de5a-e39c-4991-98fd-75fd5e567f91   none        none          off        
-    oxp_ba90170e-7399-4260-910a-376254a8a9bf/crypt/debug                                                           2280f30e-4f1b-45f2-a6fe-83098487637b   100 GiB     none          gzip-9     
-    oxp_ba90170e-7399-4260-910a-376254a8a9bf/crypt/zone                                                            a7b90e18-788d-47cc-91d8-4eb427c9c041   none        none          off        
+    oxp_ba90170e-7399-4260-910a-376254a8a9bf/crypt/debug                                                           fe7f66a8-7605-4001-87f8-2357e95acb2a   100 GiB     none          gzip-9     
+    oxp_ba90170e-7399-4260-910a-376254a8a9bf/crypt/zone                                                            4300bbd9-56b4-4735-9e6a-5c12ecd431eb   none        none          off        
     oxp_ba90170e-7399-4260-910a-376254a8a9bf/crypt/zone/oxz_crucible_1fcb5e9b-85f1-426d-ae88-6159804063fd          39a39559-055c-4c18-a02b-c963276b2171   none        none          off        
     oxp_bc649720-926b-48f2-a62a-efdcff96b49e/crucible                                                              0821d5cd-e706-4e90-ba27-7820efeb3d6c   none        none          off        
-    oxp_bc649720-926b-48f2-a62a-efdcff96b49e/crypt/debug                                                           56542c75-0603-4fd4-af13-8af63a364e7c   100 GiB     none          gzip-9     
-    oxp_bc649720-926b-48f2-a62a-efdcff96b49e/crypt/zone                                                            6901d663-862d-4893-8aa2-d75d94f78530   none        none          off        
+    oxp_bc649720-926b-48f2-a62a-efdcff96b49e/crypt/debug                                                           38570a1f-a96b-45dc-8cdd-91ec150657bf   100 GiB     none          gzip-9     
+    oxp_bc649720-926b-48f2-a62a-efdcff96b49e/crypt/zone                                                            83954f81-3607-45e5-b380-6c19c0eafcb2   none        none          off        
     oxp_bc649720-926b-48f2-a62a-efdcff96b49e/crypt/zone/oxz_crucible_b9d0d20d-5ccf-4570-ad00-b5bf33a5a63e          634b6dfa-d1b4-4f90-808e-eba7cd093a1e   none        none          off        
     oxp_d55da288-4f35-4e92-97b0-29a5e6009109/crucible                                                              67211a77-5b63-4487-aec8-087864f06a6a   none        none          off        
-    oxp_d55da288-4f35-4e92-97b0-29a5e6009109/crypt/debug                                                           855e6f57-c6c8-408d-bda0-7fdd220565a1   100 GiB     none          gzip-9     
-    oxp_d55da288-4f35-4e92-97b0-29a5e6009109/crypt/zone                                                            2e7f7b63-681f-490a-8a31-40bb196aa927   none        none          off        
+    oxp_d55da288-4f35-4e92-97b0-29a5e6009109/crypt/debug                                                           56542c75-0603-4fd4-af13-8af63a364e7c   100 GiB     none          gzip-9     
+    oxp_d55da288-4f35-4e92-97b0-29a5e6009109/crypt/zone                                                            6901d663-862d-4893-8aa2-d75d94f78530   none        none          off        
     oxp_d55da288-4f35-4e92-97b0-29a5e6009109/crypt/zone/oxz_crucible_adb88e8f-1299-4c8b-992b-2a54dbdd51ef          d1a2bb7d-1916-43ce-bad8-7dc78c86b89e   none        none          off        
     oxp_f83302fc-785c-4ab3-bcca-0d040b3c3062/crucible                                                              9e0bd909-0d35-4f03-8246-66a67b6cfbe4   none        none          off        
-    oxp_f83302fc-785c-4ab3-bcca-0d040b3c3062/crypt/debug                                                           bf3ff0d1-497e-4411-b70d-d6faca5c8970   100 GiB     none          gzip-9     
-    oxp_f83302fc-785c-4ab3-bcca-0d040b3c3062/crypt/zone                                                            c56b51d9-6573-40fe-98f6-12b760a6f136   none        none          off        
+    oxp_f83302fc-785c-4ab3-bcca-0d040b3c3062/crypt/zone                                                            e35ef3d9-5e22-42c7-8623-9f24c00b0677   none        none          off        
     oxp_f83302fc-785c-4ab3-bcca-0d040b3c3062/crypt/zone/oxz_crucible_b4e83ee5-a40e-4202-89cd-f2c1ede124d8          14ce9d7e-95ca-42e3-894a-2cec314959cb   none        none          off        
     oxp_f843fb62-0f04-4c7d-a56f-62531104dc77/crucible                                                              9bf6d6ee-e7cd-4aad-a66c-343af08bea16   none        none          off        
-    oxp_f843fb62-0f04-4c7d-a56f-62531104dc77/crypt/zone                                                            e35ef3d9-5e22-42c7-8623-9f24c00b0677   none        none          off        
+    oxp_f843fb62-0f04-4c7d-a56f-62531104dc77/crypt/debug                                                           bf3ff0d1-497e-4411-b70d-d6faca5c8970   100 GiB     none          gzip-9     
+    oxp_f843fb62-0f04-4c7d-a56f-62531104dc77/crypt/zone                                                            c56b51d9-6573-40fe-98f6-12b760a6f136   none        none          off        
     oxp_f843fb62-0f04-4c7d-a56f-62531104dc77/crypt/zone/oxz_crucible_fc4f1769-9611-42d3-b8c1-f2be9b5359f6          35fa6ec8-6b58-4fcc-a5a2-36e66736e9c1   none        none          off        
-*   oxp_f843fb62-0f04-4c7d-a56f-62531104dc77/crypt/debug                                                           2011121d-b454-41c5-9062-18fa04ee1d52   - none      - 1 GiB       gzip-9     
+*   oxp_f83302fc-785c-4ab3-bcca-0d040b3c3062/crypt/debug                                                           2011121d-b454-41c5-9062-18fa04ee1d52   - none      - 1 GiB       gzip-9     
      └─                                                                                                                                                   + 100 GiB   + none                   
 
 

--- a/nexus/reconfigurator/planning/tests/output/planner_decommissions_sleds_1_2.txt
+++ b/nexus/reconfigurator/planning/tests/output/planner_decommissions_sleds_1_2.txt
@@ -21,15 +21,15 @@ to:   blueprint 1ac2d88f-27dd-4506-8585-6b2be832528e
 -   fake-vendor   fake-model   serial-ffea118f-7715-4e21-8fc5-bb23cd0f59e8
 
 
-    datasets from generation 1:
+    datasets from generation 2:
     -----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
     dataset name                                                                                                   dataset uuid                           quota     reservation   compression
     -----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
 -   oxp_069446b4-7881-49dc-838a-63a782d4896d/crucible                                                              a9524f87-1bd8-4a3c-b7bd-e3c19a14fb50   none      none          off        
 -   oxp_069446b4-7881-49dc-838a-63a782d4896d/crypt/clickhouse                                                      3cc40210-6bf9-45fb-ac4b-8cae1c1529af   none      none          off        
--   oxp_069446b4-7881-49dc-838a-63a782d4896d/crypt/debug                                                           d01cbfd4-5f98-4f95-b362-7145429d3228   100 GiB   none          gzip-9     
+-   oxp_069446b4-7881-49dc-838a-63a782d4896d/crypt/debug                                                           59d4773a-d49c-4c28-acc6-92d80beb18f6   100 GiB   none          gzip-9     
 -   oxp_069446b4-7881-49dc-838a-63a782d4896d/crypt/internal_dns                                                    cf3c6633-2c48-4963-a40d-acac89939915   none      none          off        
--   oxp_069446b4-7881-49dc-838a-63a782d4896d/crypt/zone                                                            bf59eede-81b0-4acb-b923-33681a92a14f   none      none          off        
+-   oxp_069446b4-7881-49dc-838a-63a782d4896d/crypt/zone                                                            0fe8f233-160a-421b-aba6-1274f95ba79c   none      none          off        
 -   oxp_069446b4-7881-49dc-838a-63a782d4896d/crypt/zone/oxz_clickhouse_4e36b7ef-5684-4304-b7c3-3c31aaf83d4f        418538c2-112c-4bd6-9d02-054b08a79438   none      none          off        
 -   oxp_069446b4-7881-49dc-838a-63a782d4896d/crypt/zone/oxz_crucible_e29998e7-9ed2-46b6-bb70-4118159fe07f          da2dd11a-9022-4c2b-ad8b-f5650f223449   none      none          off        
 -   oxp_069446b4-7881-49dc-838a-63a782d4896d/crypt/zone/oxz_crucible_pantry_f11f5c60-1ac7-4630-9a3a-a9bc85c75203   2efbbe4f-8548-4890-9f40-1bf099cf795e   none      none          off        
@@ -37,40 +37,40 @@ to:   blueprint 1ac2d88f-27dd-4506-8585-6b2be832528e
 -   oxp_069446b4-7881-49dc-838a-63a782d4896d/crypt/zone/oxz_nexus_6a70a233-1900-43c0-9c00-aa9d1f7adfbc             8ac37626-6bbc-4fe7-9c95-8dbbc91c0dbe   none      none          off        
 -   oxp_069446b4-7881-49dc-838a-63a782d4896d/crypt/zone/oxz_ntp_c62b87b6-b98d-4d22-ba4f-cee4499e2ba8               a351cc88-3b88-4408-ba57-098c1b610ffb   none      none          off        
 -   oxp_20eba316-dffe-4516-9703-af561da19b0b/crucible                                                              5743004a-db46-4e84-b826-d860619dc063   none      none          off        
--   oxp_20eba316-dffe-4516-9703-af561da19b0b/crypt/debug                                                           2cd129ba-90d2-4e0a-8de9-8779430bfd52   100 GiB   none          gzip-9     
--   oxp_20eba316-dffe-4516-9703-af561da19b0b/crypt/zone                                                            4e2be862-e2c1-4d37-ac57-34ceea106a0c   none      none          off        
+-   oxp_20eba316-dffe-4516-9703-af561da19b0b/crypt/debug                                                           d01cbfd4-5f98-4f95-b362-7145429d3228   100 GiB   none          gzip-9     
+-   oxp_20eba316-dffe-4516-9703-af561da19b0b/crypt/zone                                                            bf59eede-81b0-4acb-b923-33681a92a14f   none      none          off        
 -   oxp_20eba316-dffe-4516-9703-af561da19b0b/crypt/zone/oxz_crucible_1e1ed0cc-1adc-410f-943a-d1a3107de619          88c2e536-57af-4402-99dd-cfaca1862b41   none      none          off        
 -   oxp_426f4b6d-4a82-4106-bf4b-64ee86a2a5a4/crucible                                                              ed196541-0958-4fc0-8cf8-6da4c522e620   none      none          off        
--   oxp_426f4b6d-4a82-4106-bf4b-64ee86a2a5a4/crypt/debug                                                           15227fcb-319a-491f-bb0c-8d245bec4e58   100 GiB   none          gzip-9     
--   oxp_426f4b6d-4a82-4106-bf4b-64ee86a2a5a4/crypt/zone                                                            07f06a1f-bb55-4e72-a84f-bb1cfd5d18a6   none      none          off        
+-   oxp_426f4b6d-4a82-4106-bf4b-64ee86a2a5a4/crypt/debug                                                           56e40972-948d-4900-9d19-9d62b1983f43   100 GiB   none          gzip-9     
+-   oxp_426f4b6d-4a82-4106-bf4b-64ee86a2a5a4/crypt/zone                                                            064e7ade-7e0a-471c-9743-752a215d7f5c   none      none          off        
 -   oxp_426f4b6d-4a82-4106-bf4b-64ee86a2a5a4/crypt/zone/oxz_crucible_2307bbed-02ba-493b-89e3-46585c74c8fc          d3e92497-a1c6-4aae-a192-21762cb35207   none      none          off        
 -   oxp_82daeef2-8641-4bf5-ac66-f7b5f62c48b6/crucible                                                              ff266774-5999-4631-a516-3f2f9a05f688   none      none          off        
--   oxp_82daeef2-8641-4bf5-ac66-f7b5f62c48b6/crypt/debug                                                           9dc58815-aa5b-409a-98e7-7cbf92b17819   100 GiB   none          gzip-9     
--   oxp_82daeef2-8641-4bf5-ac66-f7b5f62c48b6/crypt/zone                                                            3dda6519-98a6-4943-b4e0-daf82b36526a   none      none          off        
+-   oxp_82daeef2-8641-4bf5-ac66-f7b5f62c48b6/crypt/debug                                                           81489861-36ab-4513-a5bb-953d3980974d   100 GiB   none          gzip-9     
+-   oxp_82daeef2-8641-4bf5-ac66-f7b5f62c48b6/crypt/zone                                                            5d9ec6b2-c3ad-4588-a8e3-4ad1c0d83643   none      none          off        
 -   oxp_82daeef2-8641-4bf5-ac66-f7b5f62c48b6/crypt/zone/oxz_crucible_c28d7b4b-a259-45ad-945d-f19ca3c6964c          6f1e99c9-4934-48f5-8b63-e0836d784bdc   none      none          off        
 -   oxp_8e5feeb2-14f1-440f-a909-3c34aa8e129b/crucible                                                              db626d31-b4a3-4b81-970d-cfa469c5d2ff   none      none          off        
--   oxp_8e5feeb2-14f1-440f-a909-3c34aa8e129b/crypt/debug                                                           56e40972-948d-4900-9d19-9d62b1983f43   100 GiB   none          gzip-9     
--   oxp_8e5feeb2-14f1-440f-a909-3c34aa8e129b/crypt/zone                                                            064e7ade-7e0a-471c-9743-752a215d7f5c   none      none          off        
+-   oxp_8e5feeb2-14f1-440f-a909-3c34aa8e129b/crypt/debug                                                           c84f4ae2-e449-4980-acdd-b3a5ac7e506a   100 GiB   none          gzip-9     
+-   oxp_8e5feeb2-14f1-440f-a909-3c34aa8e129b/crypt/zone                                                            af81321c-23c6-4491-88a8-8eb5534aa8d8   none      none          off        
 -   oxp_8e5feeb2-14f1-440f-a909-3c34aa8e129b/crypt/zone/oxz_crucible_9179d6dc-387d-424e-8d62-ed59b2c728f6          5d1bf2c0-daab-4ec6-91c1-cd405da49ab9   none      none          off        
 -   oxp_942e2123-7c4e-4f6b-9317-1341fe212647/crucible                                                              33c2c71f-d4d7-4357-ba2a-eb9d5d8aa0f5   none      none          off        
--   oxp_942e2123-7c4e-4f6b-9317-1341fe212647/crypt/debug                                                           81489861-36ab-4513-a5bb-953d3980974d   100 GiB   none          gzip-9     
--   oxp_942e2123-7c4e-4f6b-9317-1341fe212647/crypt/zone                                                            5d9ec6b2-c3ad-4588-a8e3-4ad1c0d83643   none      none          off        
+-   oxp_942e2123-7c4e-4f6b-9317-1341fe212647/crypt/debug                                                           9dc58815-aa5b-409a-98e7-7cbf92b17819   100 GiB   none          gzip-9     
+-   oxp_942e2123-7c4e-4f6b-9317-1341fe212647/crypt/zone                                                            3dda6519-98a6-4943-b4e0-daf82b36526a   none      none          off        
 -   oxp_942e2123-7c4e-4f6b-9317-1341fe212647/crypt/zone/oxz_crucible_f06e91a1-0c17-4cca-adbc-1c9b67bdb11d          1cebd581-aab7-42d5-a8a2-15b3e2f55e23   none      none          off        
 -   oxp_97a5ce17-df5b-47e7-baf8-80ae710ce18e/crucible                                                              040dc13c-0267-430a-b20d-89fd0f000f0b   none      none          off        
--   oxp_97a5ce17-df5b-47e7-baf8-80ae710ce18e/crypt/debug                                                           59d4773a-d49c-4c28-acc6-92d80beb18f6   100 GiB   none          gzip-9     
--   oxp_97a5ce17-df5b-47e7-baf8-80ae710ce18e/crypt/zone                                                            0fe8f233-160a-421b-aba6-1274f95ba79c   none      none          off        
+-   oxp_97a5ce17-df5b-47e7-baf8-80ae710ce18e/crypt/debug                                                           2cd129ba-90d2-4e0a-8de9-8779430bfd52   100 GiB   none          gzip-9     
+-   oxp_97a5ce17-df5b-47e7-baf8-80ae710ce18e/crypt/zone                                                            4e2be862-e2c1-4d37-ac57-34ceea106a0c   none      none          off        
 -   oxp_97a5ce17-df5b-47e7-baf8-80ae710ce18e/crypt/zone/oxz_crucible_603e629d-2599-400e-b879-4134d4cc426e          5c06fe50-9fe1-44e1-85c2-38ba11e4495b   none      none          off        
 -   oxp_debc9fb6-bd58-4e4f-b8b8-6a9a07fcf25d/crucible                                                              454c71e8-ba8d-4afd-af1f-0ceb403e6b6b   none      none          off        
--   oxp_debc9fb6-bd58-4e4f-b8b8-6a9a07fcf25d/crypt/debug                                                           433a21ac-1830-42ed-991b-18976ebf312f   100 GiB   none          gzip-9     
--   oxp_debc9fb6-bd58-4e4f-b8b8-6a9a07fcf25d/crypt/zone                                                            d8d25341-34f7-4b98-b6e9-252c06a079fc   none      none          off        
+-   oxp_debc9fb6-bd58-4e4f-b8b8-6a9a07fcf25d/crypt/debug                                                           3568368a-2a70-4300-b689-3ec8d0bc8f71   100 GiB   none          gzip-9     
+-   oxp_debc9fb6-bd58-4e4f-b8b8-6a9a07fcf25d/crypt/zone                                                            5073b1d2-6dcb-4a42-afb8-c6dd74f50201   none      none          off        
 -   oxp_debc9fb6-bd58-4e4f-b8b8-6a9a07fcf25d/crypt/zone/oxz_crucible_ad76d200-5675-444b-b19c-684689ff421f          ed7d0891-d558-4c30-8d73-9594ae70b061   none      none          off        
 -   oxp_f63a32a9-0659-43cf-8efc-8f34e7af9d45/crucible                                                              e97a59e3-8f57-42f3-95f5-316f966c5efc   none      none          off        
--   oxp_f63a32a9-0659-43cf-8efc-8f34e7af9d45/crypt/debug                                                           3568368a-2a70-4300-b689-3ec8d0bc8f71   100 GiB   none          gzip-9     
--   oxp_f63a32a9-0659-43cf-8efc-8f34e7af9d45/crypt/zone                                                            5073b1d2-6dcb-4a42-afb8-c6dd74f50201   none      none          off        
+-   oxp_f63a32a9-0659-43cf-8efc-8f34e7af9d45/crypt/debug                                                           15227fcb-319a-491f-bb0c-8d245bec4e58   100 GiB   none          gzip-9     
+-   oxp_f63a32a9-0659-43cf-8efc-8f34e7af9d45/crypt/zone                                                            07f06a1f-bb55-4e72-a84f-bb1cfd5d18a6   none      none          off        
 -   oxp_f63a32a9-0659-43cf-8efc-8f34e7af9d45/crypt/zone/oxz_crucible_e9bf2525-5fa0-4c1b-b52d-481225083845          cbece778-757f-435a-86b1-97a6f4ad5a70   none      none          off        
 -   oxp_ffea118f-7715-4e21-8fc5-bb23cd0f59e8/crucible                                                              7f4605b3-1caf-4751-9485-2e9554d9b3b5   none      none          off        
--   oxp_ffea118f-7715-4e21-8fc5-bb23cd0f59e8/crypt/debug                                                           c84f4ae2-e449-4980-acdd-b3a5ac7e506a   100 GiB   none          gzip-9     
--   oxp_ffea118f-7715-4e21-8fc5-bb23cd0f59e8/crypt/zone                                                            af81321c-23c6-4491-88a8-8eb5534aa8d8   none      none          off        
+-   oxp_ffea118f-7715-4e21-8fc5-bb23cd0f59e8/crypt/debug                                                           433a21ac-1830-42ed-991b-18976ebf312f   100 GiB   none          gzip-9     
+-   oxp_ffea118f-7715-4e21-8fc5-bb23cd0f59e8/crypt/zone                                                            d8d25341-34f7-4b98-b6e9-252c06a079fc   none      none          off        
 -   oxp_ffea118f-7715-4e21-8fc5-bb23cd0f59e8/crypt/zone/oxz_crucible_2e65b765-5c41-4519-bf4e-e2a68569afc1          a0459348-1ea1-4a5f-a821-677ed1c46aa6   none      none          off        
 
 
@@ -128,34 +128,34 @@ to:   blueprint 1ac2d88f-27dd-4506-8585-6b2be832528e
     fake-vendor   fake-model   serial-ff7e002b-3ad8-4d45-b03a-c46ef0ac8e59
 
 
-    datasets generation 1 -> 2:
+    datasets generation 2 -> 3:
     -----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
     dataset name                                                                                                   dataset uuid                           quota     reservation   compression
     -----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
     oxp_1e2ec79e-9c11-4133-ac77-e0b994a507d5/crucible                                                              3629f248-3fc1-4073-b21b-6a1529fa204e   none      none          off        
-    oxp_1e2ec79e-9c11-4133-ac77-e0b994a507d5/crypt/debug                                                           64793588-5ff8-42d8-af9d-f7b58a2d1431   100 GiB   none          gzip-9     
+    oxp_1e2ec79e-9c11-4133-ac77-e0b994a507d5/crypt/debug                                                           9427caff-29ec-4cd1-981b-26d4a7900052   100 GiB   none          gzip-9     
     oxp_1e2ec79e-9c11-4133-ac77-e0b994a507d5/crypt/internal_dns                                                    1114a853-37f6-4933-8ab1-85ad855145ea   none      none          off        
-    oxp_1e2ec79e-9c11-4133-ac77-e0b994a507d5/crypt/zone                                                            7627711f-c877-4892-8bb9-2ab494673bab   none      none          off        
+    oxp_1e2ec79e-9c11-4133-ac77-e0b994a507d5/crypt/zone                                                            4ed5d6be-14cc-4bb5-b0d3-88a48b539751   none      none          off        
     oxp_1e2ec79e-9c11-4133-ac77-e0b994a507d5/crypt/zone/oxz_crucible_70232a6d-6c9d-4fa6-a34d-9c73d940db33          b860f342-824e-4f30-960d-7e2fe519b72b   none      none          off        
     oxp_1e2ec79e-9c11-4133-ac77-e0b994a507d5/crypt/zone/oxz_crucible_pantry_15dbaa30-1539-49d6-970d-ba5962960f33   6d4bc7b7-5f22-44e5-8578-fba855718b56   none      none          off        
     oxp_1e2ec79e-9c11-4133-ac77-e0b994a507d5/crypt/zone/oxz_internal_dns_eac6c0a0-baa5-4490-9cee-65198b7fbd9c      13ef9dfc-1881-4517-b518-b94d8b8f196e   none      none          off        
     oxp_1e2ec79e-9c11-4133-ac77-e0b994a507d5/crypt/zone/oxz_nexus_3d4143df-e212-4774-9258-7d9b421fac2e             aba6813b-e60b-44cb-b22f-934bd6e28cf9   none      none          off        
     oxp_1e2ec79e-9c11-4133-ac77-e0b994a507d5/crypt/zone/oxz_ntp_1ec4cc7b-2f00-4d13-8176-3b9815533ae9               67169d16-1b64-4236-8cff-6d06a7ab84cd   none      none          off        
     oxp_440ae69d-5e2e-4539-91d0-e2930bdd7203/crucible                                                              0cf030b7-7c47-4304-8247-1a20e6048554   none      none          off        
-    oxp_440ae69d-5e2e-4539-91d0-e2930bdd7203/crypt/debug                                                           54954ab8-0874-41f7-9382-02aae6831f4c   100 GiB   none          gzip-9     
-    oxp_440ae69d-5e2e-4539-91d0-e2930bdd7203/crypt/zone                                                            fb4ac064-d11e-4afb-bfc8-b87c58b71977   none      none          off        
+    oxp_440ae69d-5e2e-4539-91d0-e2930bdd7203/crypt/debug                                                           d86839e1-e253-4ae2-b1ac-03b7020614cd   100 GiB   none          gzip-9     
+    oxp_440ae69d-5e2e-4539-91d0-e2930bdd7203/crypt/zone                                                            b1144b57-1e79-41a6-ae1b-9676d777f628   none      none          off        
     oxp_440ae69d-5e2e-4539-91d0-e2930bdd7203/crypt/zone/oxz_crucible_8b0b8623-930a-41af-9f9b-ca28b1b11139          0d862983-16aa-4d85-a6f3-78de73b063bb   none      none          off        
     oxp_4e91d4a3-bb6c-44bb-bd4e-bf8913c1ba2b/crucible                                                              8ee49248-8d40-4637-8aad-049c9b312bf2   none      none          off        
-    oxp_4e91d4a3-bb6c-44bb-bd4e-bf8913c1ba2b/crypt/debug                                                           112a7b3e-f24f-4a14-94f2-32a1ad8cdbe3   100 GiB   none          gzip-9     
-    oxp_4e91d4a3-bb6c-44bb-bd4e-bf8913c1ba2b/crypt/zone                                                            d48badf3-3993-44a5-809c-4eacad8fb929   none      none          off        
+    oxp_4e91d4a3-bb6c-44bb-bd4e-bf8913c1ba2b/crypt/debug                                                           64793588-5ff8-42d8-af9d-f7b58a2d1431   100 GiB   none          gzip-9     
+    oxp_4e91d4a3-bb6c-44bb-bd4e-bf8913c1ba2b/crypt/zone                                                            7627711f-c877-4892-8bb9-2ab494673bab   none      none          off        
     oxp_4e91d4a3-bb6c-44bb-bd4e-bf8913c1ba2b/crypt/zone/oxz_crucible_5d9d8fa7-8379-470b-90ba-fe84a3c45512          07f839aa-beb9-4730-b8eb-7b52a2e40872   none      none          off        
     oxp_67de3a80-29cb-4066-b743-e285a2ca1f4e/crucible                                                              fb826e91-9b48-433e-9fc4-dbe56982f94a   none      none          off        
-    oxp_67de3a80-29cb-4066-b743-e285a2ca1f4e/crypt/debug                                                           73542884-3a70-4acc-a474-b7d361e79909   100 GiB   none          gzip-9     
-    oxp_67de3a80-29cb-4066-b743-e285a2ca1f4e/crypt/zone                                                            84488b5f-690c-4a21-b14a-9288eaa54488   none      none          off        
+    oxp_67de3a80-29cb-4066-b743-e285a2ca1f4e/crypt/debug                                                           f631d6a1-9db5-4fc7-978b-9ace485dfe16   100 GiB   none          gzip-9     
+    oxp_67de3a80-29cb-4066-b743-e285a2ca1f4e/crypt/zone                                                            2a72fbf4-ff92-47a2-a4b9-2a702215c946   none      none          off        
     oxp_67de3a80-29cb-4066-b743-e285a2ca1f4e/crypt/zone/oxz_crucible_cf87d2a3-d323-44a3-a87e-adc4ef6c75f4          f39b842a-f73c-4aae-a5ac-fc707fa49dca   none      none          off        
     oxp_9139b70f-c1d3-475d-8f02-7c9acba52b2b/crucible                                                              cbd086a5-8730-49ce-983f-a870416589e5   none      none          off        
-    oxp_9139b70f-c1d3-475d-8f02-7c9acba52b2b/crypt/debug                                                           d86839e1-e253-4ae2-b1ac-03b7020614cd   100 GiB   none          gzip-9     
-    oxp_9139b70f-c1d3-475d-8f02-7c9acba52b2b/crypt/zone                                                            b1144b57-1e79-41a6-ae1b-9676d777f628   none      none          off        
+    oxp_9139b70f-c1d3-475d-8f02-7c9acba52b2b/crypt/debug                                                           73542884-3a70-4acc-a474-b7d361e79909   100 GiB   none          gzip-9     
+    oxp_9139b70f-c1d3-475d-8f02-7c9acba52b2b/crypt/zone                                                            84488b5f-690c-4a21-b14a-9288eaa54488   none      none          off        
     oxp_9139b70f-c1d3-475d-8f02-7c9acba52b2b/crypt/zone/oxz_crucible_8567a616-a709-4c8c-a323-4474675dad5c          67c894bc-e684-42e7-8bc8-1fe86356165e   none      none          off        
     oxp_95fbb110-5272-4646-ab50-21b31b7cde23/crucible                                                              cf4285e6-acd6-4bd6-80a7-4d28c1f1d543   none      none          off        
     oxp_95fbb110-5272-4646-ab50-21b31b7cde23/crypt/debug                                                           fe27d4c5-cb2b-461c-a03b-3cd163682098   100 GiB   none          gzip-9     
@@ -166,16 +166,16 @@ to:   blueprint 1ac2d88f-27dd-4506-8585-6b2be832528e
     oxp_9bf35cd7-4938-4c34-8189-288b3195cb64/crypt/zone                                                            b55242c9-3e0c-4bb9-b702-0d94893388a3   none      none          off        
     oxp_9bf35cd7-4938-4c34-8189-288b3195cb64/crypt/zone/oxz_crucible_99c6401d-9796-4ae1-bf0c-9a097cf21c33          6dfbbad9-2860-4547-8962-35224ff3251a   none      none          off        
     oxp_9d833141-18a1-4f24-8a34-6076c026aa87/crucible                                                              c358c3ef-daa8-4b2d-8c5d-fd760798fcd8   none      none          off        
-    oxp_9d833141-18a1-4f24-8a34-6076c026aa87/crypt/debug                                                           f631d6a1-9db5-4fc7-978b-9ace485dfe16   100 GiB   none          gzip-9     
-    oxp_9d833141-18a1-4f24-8a34-6076c026aa87/crypt/zone                                                            2a72fbf4-ff92-47a2-a4b9-2a702215c946   none      none          off        
+    oxp_9d833141-18a1-4f24-8a34-6076c026aa87/crypt/debug                                                           54954ab8-0874-41f7-9382-02aae6831f4c   100 GiB   none          gzip-9     
+    oxp_9d833141-18a1-4f24-8a34-6076c026aa87/crypt/zone                                                            fb4ac064-d11e-4afb-bfc8-b87c58b71977   none      none          off        
     oxp_9d833141-18a1-4f24-8a34-6076c026aa87/crypt/zone/oxz_crucible_4f8ce495-21dd-48a1-859c-80d34ce394ed          eed07a8f-8a64-46fc-9ee8-dff2e610b655   none      none          off        
     oxp_a279461f-a7b9-413f-a79f-cb4dab4c3fce/crucible                                                              fbc90cb1-5616-48cc-8b13-89acd5209f4f   none      none          off        
-    oxp_a279461f-a7b9-413f-a79f-cb4dab4c3fce/crypt/debug                                                           1b9c97d6-c90d-4109-b99c-9ab799b3c3b9   100 GiB   none          gzip-9     
-    oxp_a279461f-a7b9-413f-a79f-cb4dab4c3fce/crypt/zone                                                            813c6cd2-b100-4481-aaf4-c008f2e81d6f   none      none          off        
+    oxp_a279461f-a7b9-413f-a79f-cb4dab4c3fce/crypt/debug                                                           112a7b3e-f24f-4a14-94f2-32a1ad8cdbe3   100 GiB   none          gzip-9     
+    oxp_a279461f-a7b9-413f-a79f-cb4dab4c3fce/crypt/zone                                                            d48badf3-3993-44a5-809c-4eacad8fb929   none      none          off        
     oxp_a279461f-a7b9-413f-a79f-cb4dab4c3fce/crypt/zone/oxz_crucible_a1ae92ac-e1f1-4654-ab54-5b75ba7c44d6          de262cbb-4a71-4f24-a483-1d190bb1fc49   none      none          off        
     oxp_ff7e002b-3ad8-4d45-b03a-c46ef0ac8e59/crucible                                                              0aa0ec68-c208-4d91-beec-cfb7fdc33895   none      none          off        
-    oxp_ff7e002b-3ad8-4d45-b03a-c46ef0ac8e59/crypt/debug                                                           9427caff-29ec-4cd1-981b-26d4a7900052   100 GiB   none          gzip-9     
-    oxp_ff7e002b-3ad8-4d45-b03a-c46ef0ac8e59/crypt/zone                                                            4ed5d6be-14cc-4bb5-b0d3-88a48b539751   none      none          off        
+    oxp_ff7e002b-3ad8-4d45-b03a-c46ef0ac8e59/crypt/debug                                                           1b9c97d6-c90d-4109-b99c-9ab799b3c3b9   100 GiB   none          gzip-9     
+    oxp_ff7e002b-3ad8-4d45-b03a-c46ef0ac8e59/crypt/zone                                                            813c6cd2-b100-4481-aaf4-c008f2e81d6f   none      none          off        
     oxp_ff7e002b-3ad8-4d45-b03a-c46ef0ac8e59/crypt/zone/oxz_crucible_a308d3e1-118c-440a-947a-8b6ab7d833ab          1c597048-bc3f-46d5-94cb-3507ada774e3   none      none          off        
 +   oxp_1e2ec79e-9c11-4133-ac77-e0b994a507d5/crypt/zone/oxz_crucible_pantry_ff9ce09c-afbf-425b-bbfa-3d8fb254f98e   60d5c18d-6940-48eb-b36c-7f0b6ef55463   none      none          off        
 +   oxp_1e2ec79e-9c11-4133-ac77-e0b994a507d5/crypt/zone/oxz_nexus_845869e9-ecb2-4ec3-b6b8-2a836e459243             b8054c80-65c3-4a44-ba95-f65e37fd2678   none      none          off        
@@ -221,50 +221,50 @@ to:   blueprint 1ac2d88f-27dd-4506-8585-6b2be832528e
     fake-vendor   fake-model   serial-99e926d6-bd42-4cde-9f63-5ecc7ea14322
 
 
-    datasets generation 1 -> 2:
+    datasets generation 2 -> 3:
     -----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
     dataset name                                                                                                   dataset uuid                           quota     reservation   compression
     -----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
     oxp_07068f19-1ff2-48da-8e72-874780df2339/crucible                                                              ea21aba9-6e79-4e20-8e35-92cd9fbba41c   none      none          off        
-    oxp_07068f19-1ff2-48da-8e72-874780df2339/crypt/debug                                                           9ed7b9ab-dc13-4179-b867-08d23156253a   100 GiB   none          gzip-9     
+    oxp_07068f19-1ff2-48da-8e72-874780df2339/crypt/debug                                                           eb939b53-6b86-44ae-b3bb-f4fc3111278d   100 GiB   none          gzip-9     
     oxp_07068f19-1ff2-48da-8e72-874780df2339/crypt/internal_dns                                                    af7470be-9bc4-4d4b-8634-66fb0771fecc   none      none          off        
-    oxp_07068f19-1ff2-48da-8e72-874780df2339/crypt/zone                                                            0a1e8f41-ffe6-4a4e-98de-a84217fddd4a   none      none          off        
+    oxp_07068f19-1ff2-48da-8e72-874780df2339/crypt/zone                                                            f92429b2-b8fe-4a95-9a29-ca8ffe0d51f8   none      none          off        
     oxp_07068f19-1ff2-48da-8e72-874780df2339/crypt/zone/oxz_crucible_0e2b035e-1de1-48af-8ac0-5316418e3de1          67788d73-161d-4331-b68b-5799dc103acb   none      none          off        
     oxp_07068f19-1ff2-48da-8e72-874780df2339/crypt/zone/oxz_crucible_pantry_b7402110-d88f-4ca4-8391-4a2fda6ad271   f8eb44eb-00bd-416b-99e9-2539a7469963   none      none          off        
     oxp_07068f19-1ff2-48da-8e72-874780df2339/crypt/zone/oxz_internal_dns_5c78756d-6182-4c27-a507-3419e8dbe76b      9428edca-e834-4512-b888-e399103343db   none      none          off        
     oxp_07068f19-1ff2-48da-8e72-874780df2339/crypt/zone/oxz_nexus_e6d0df1f-9f98-4c5a-9540-8444d1185c7d             5f868bf8-8770-4f07-a620-af7dee8062d6   none      none          off        
     oxp_07068f19-1ff2-48da-8e72-874780df2339/crypt/zone/oxz_ntp_c552280f-ba02-4f8d-9049-bd269e6b7845               a26ebbdb-38b4-4921-9186-3b1e1fb7cbc2   none      none          off        
     oxp_0f12e6ee-41d2-4eb0-813f-ba5240900ded/crucible                                                              b350b7d8-66cc-4d54-b480-1884c791a6d9   none      none          off        
-    oxp_0f12e6ee-41d2-4eb0-813f-ba5240900ded/crypt/debug                                                           3dad2cc1-25cc-401e-9763-47001a1acc17   100 GiB   none          gzip-9     
-    oxp_0f12e6ee-41d2-4eb0-813f-ba5240900ded/crypt/zone                                                            7a3d49fb-56fd-4e30-b1ca-7c9d6a1fdbfc   none      none          off        
+    oxp_0f12e6ee-41d2-4eb0-813f-ba5240900ded/crypt/debug                                                           b5203528-903b-4e16-bd00-13147a83a712   100 GiB   none          gzip-9     
+    oxp_0f12e6ee-41d2-4eb0-813f-ba5240900ded/crypt/zone                                                            8d86f556-b74e-43f9-87ab-13f0b8d38a66   none      none          off        
     oxp_0f12e6ee-41d2-4eb0-813f-ba5240900ded/crypt/zone/oxz_crucible_b7ae596e-0c85-40b2-bb47-df9f76db3cca          66fd473e-6927-45fa-93e0-6bff82f9c3df   none      none          off        
     oxp_0fdb4a39-3cd5-47a0-9064-e7f3c285af61/crucible                                                              9020f7d3-2bfc-4af4-a339-c60d233266cd   none      none          off        
     oxp_0fdb4a39-3cd5-47a0-9064-e7f3c285af61/crypt/debug                                                           55da940b-ae9a-4c93-87ea-4845c66dbe1c   100 GiB   none          gzip-9     
     oxp_0fdb4a39-3cd5-47a0-9064-e7f3c285af61/crypt/zone                                                            caa4bf8a-ccd5-4ebf-b5c0-8c3664c69738   none      none          off        
     oxp_0fdb4a39-3cd5-47a0-9064-e7f3c285af61/crypt/zone/oxz_crucible_cf13b878-47f1-4ba0-b8c2-9f3e15f2ee87          e45274bc-8d11-4ffc-89bd-3d17a9bb629e   none      none          off        
     oxp_13572832-83ad-40d6-896a-751f7e53f4f6/crucible                                                              87d29998-7d01-420b-97c6-f02067fb96ba   none      none          off        
-    oxp_13572832-83ad-40d6-896a-751f7e53f4f6/crypt/debug                                                           f37b9916-d47a-4fda-9385-2031a73b7a0e   100 GiB   none          gzip-9     
-    oxp_13572832-83ad-40d6-896a-751f7e53f4f6/crypt/zone                                                            2a95cee2-ff4f-4400-81ac-46df69443c68   none      none          off        
+    oxp_13572832-83ad-40d6-896a-751f7e53f4f6/crypt/debug                                                           5a3f0c96-a125-4cc0-9e84-fb5551fe557e   100 GiB   none          gzip-9     
+    oxp_13572832-83ad-40d6-896a-751f7e53f4f6/crypt/zone                                                            4dc29bec-f01c-4998-b755-46226bce0aa5   none      none          off        
     oxp_13572832-83ad-40d6-896a-751f7e53f4f6/crypt/zone/oxz_crucible_eb034526-1767-4cc4-8225-ec962265710b          b0ff583d-a6fd-4298-8093-ab54f1eaac30   none      none          off        
     oxp_3602bdd9-f7bb-4490-87a6-8f061f7712f5/crucible                                                              3b096c27-0a84-4335-be9f-e6104d709162   none      none          off        
-    oxp_3602bdd9-f7bb-4490-87a6-8f061f7712f5/crypt/debug                                                           aa333d9a-908b-4e2e-a476-a000e6f2fe25   100 GiB   none          gzip-9     
-    oxp_3602bdd9-f7bb-4490-87a6-8f061f7712f5/crypt/zone                                                            6dcb997c-6e19-4c31-9c0e-a5d41f66963f   none      none          off        
+    oxp_3602bdd9-f7bb-4490-87a6-8f061f7712f5/crypt/debug                                                           23c24e8b-87ac-4462-a27d-1bbdb74b7ba3   100 GiB   none          gzip-9     
+    oxp_3602bdd9-f7bb-4490-87a6-8f061f7712f5/crypt/zone                                                            bbd3ec95-304c-4e3a-af36-e30990c697a5   none      none          off        
     oxp_3602bdd9-f7bb-4490-87a6-8f061f7712f5/crypt/zone/oxz_crucible_2bf9ee97-90e1-48a7-bb06-a35cec63b7fe          85bee553-3b86-489f-9b90-d45a26de1a8b   none      none          off        
     oxp_65707837-95a4-45d7-84e6-8b9a4da215f1/crucible                                                              3409e636-fb7e-4699-967a-d7faad2fee27   none      none          off        
-    oxp_65707837-95a4-45d7-84e6-8b9a4da215f1/crypt/debug                                                           eb939b53-6b86-44ae-b3bb-f4fc3111278d   100 GiB   none          gzip-9     
-    oxp_65707837-95a4-45d7-84e6-8b9a4da215f1/crypt/zone                                                            f92429b2-b8fe-4a95-9a29-ca8ffe0d51f8   none      none          off        
+    oxp_65707837-95a4-45d7-84e6-8b9a4da215f1/crypt/debug                                                           9ed7b9ab-dc13-4179-b867-08d23156253a   100 GiB   none          gzip-9     
+    oxp_65707837-95a4-45d7-84e6-8b9a4da215f1/crypt/zone                                                            0a1e8f41-ffe6-4a4e-98de-a84217fddd4a   none      none          off        
     oxp_65707837-95a4-45d7-84e6-8b9a4da215f1/crypt/zone/oxz_crucible_e3bfcb1e-3708-45e7-a45a-2a2cab7ad829          47d54397-a793-404b-8293-3fc11184b525   none      none          off        
     oxp_7a43b2b0-3846-401c-8317-d555715a00f7/crucible                                                              b89f0c5b-bb1f-43f1-8473-b697a63c565f   none      none          off        
-    oxp_7a43b2b0-3846-401c-8317-d555715a00f7/crypt/debug                                                           5a3f0c96-a125-4cc0-9e84-fb5551fe557e   100 GiB   none          gzip-9     
-    oxp_7a43b2b0-3846-401c-8317-d555715a00f7/crypt/zone                                                            4dc29bec-f01c-4998-b755-46226bce0aa5   none      none          off        
+    oxp_7a43b2b0-3846-401c-8317-d555715a00f7/crypt/debug                                                           f37b9916-d47a-4fda-9385-2031a73b7a0e   100 GiB   none          gzip-9     
+    oxp_7a43b2b0-3846-401c-8317-d555715a00f7/crypt/zone                                                            2a95cee2-ff4f-4400-81ac-46df69443c68   none      none          off        
     oxp_7a43b2b0-3846-401c-8317-d555715a00f7/crypt/zone/oxz_crucible_15f29557-d4da-45ef-b435-a0a1cd586e0c          83759687-8f02-47ab-925e-82cc75e77819   none      none          off        
     oxp_855e3ef1-6929-4e21-8451-0e62bd93c7c9/crucible                                                              0daab3dc-5ef4-44dc-abf6-04b03560f726   none      none          off        
-    oxp_855e3ef1-6929-4e21-8451-0e62bd93c7c9/crypt/debug                                                           b5203528-903b-4e16-bd00-13147a83a712   100 GiB   none          gzip-9     
-    oxp_855e3ef1-6929-4e21-8451-0e62bd93c7c9/crypt/zone                                                            8d86f556-b74e-43f9-87ab-13f0b8d38a66   none      none          off        
+    oxp_855e3ef1-6929-4e21-8451-0e62bd93c7c9/crypt/debug                                                           aa333d9a-908b-4e2e-a476-a000e6f2fe25   100 GiB   none          gzip-9     
+    oxp_855e3ef1-6929-4e21-8451-0e62bd93c7c9/crypt/zone                                                            6dcb997c-6e19-4c31-9c0e-a5d41f66963f   none      none          off        
     oxp_855e3ef1-6929-4e21-8451-0e62bd93c7c9/crypt/zone/oxz_crucible_751bc6fe-22ad-4ce1-bc51-cf31fdf02bfa          c059bd54-6bd4-4a2c-a2d7-cb530f18d016   none      none          off        
     oxp_8adcf329-4cee-4075-b798-28b5add1edf5/crucible                                                              c6074d19-cb72-4fd1-b6f7-c2a017518ede   none      none          off        
-    oxp_8adcf329-4cee-4075-b798-28b5add1edf5/crypt/debug                                                           23c24e8b-87ac-4462-a27d-1bbdb74b7ba3   100 GiB   none          gzip-9     
-    oxp_8adcf329-4cee-4075-b798-28b5add1edf5/crypt/zone                                                            bbd3ec95-304c-4e3a-af36-e30990c697a5   none      none          off        
+    oxp_8adcf329-4cee-4075-b798-28b5add1edf5/crypt/debug                                                           3dad2cc1-25cc-401e-9763-47001a1acc17   100 GiB   none          gzip-9     
+    oxp_8adcf329-4cee-4075-b798-28b5add1edf5/crypt/zone                                                            7a3d49fb-56fd-4e30-b1ca-7c9d6a1fdbfc   none      none          off        
     oxp_8adcf329-4cee-4075-b798-28b5add1edf5/crypt/zone/oxz_crucible_e5121f83-faf2-4928-b5a8-94a1da99e8eb          8b12688c-61f9-4ecb-b17f-00df7b60105c   none      none          off        
     oxp_99e926d6-bd42-4cde-9f63-5ecc7ea14322/crucible                                                              d5ad4cb2-723a-4ea4-8345-67438d9f1857   none      none          off        
     oxp_99e926d6-bd42-4cde-9f63-5ecc7ea14322/crypt/debug                                                           e9ae4c7d-4721-49de-bf6d-8ecec30c3ebb   100 GiB   none          gzip-9     

--- a/nexus/reconfigurator/planning/tests/output/planner_deploy_all_keeper_nodes_1_2.txt
+++ b/nexus/reconfigurator/planning/tests/output/planner_deploy_all_keeper_nodes_1_2.txt
@@ -21,15 +21,15 @@ to:   blueprint 31ef2071-2ec9-49d9-8827-fd83b17a0e3d
     fake-vendor   fake-model   serial-fbf997ef-52d3-438a-b036-b9117322e569
 
 
-    datasets generation 1 -> 2:
+    datasets generation 2 -> 3:
     -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
     dataset name                                                                                                     dataset uuid                           quota     reservation   compression
     -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
     oxp_60e6b021-79d6-4a6b-917c-6637e0769558/crucible                                                                fcd7e842-2648-407a-8d13-197e67de9e9d   none      none          off        
     oxp_60e6b021-79d6-4a6b-917c-6637e0769558/crypt/clickhouse                                                        5cb56dc7-6c56-4bbf-ae73-6f08e0c97cdf   none      none          off        
-    oxp_60e6b021-79d6-4a6b-917c-6637e0769558/crypt/debug                                                             10610f76-51e8-4be4-a4ad-9af953f6bf4a   100 GiB   none          gzip-9     
+    oxp_60e6b021-79d6-4a6b-917c-6637e0769558/crypt/debug                                                             8bbc5419-7125-4cb1-b990-436af4bb8eb4   100 GiB   none          gzip-9     
     oxp_60e6b021-79d6-4a6b-917c-6637e0769558/crypt/internal_dns                                                      dd467397-efc5-4738-984e-77a0f3e3e678   none      none          off        
-    oxp_60e6b021-79d6-4a6b-917c-6637e0769558/crypt/zone                                                              8c4f4acd-8f6b-4296-81be-12d2eeae0483   none      none          off        
+    oxp_60e6b021-79d6-4a6b-917c-6637e0769558/crypt/zone                                                              a34f8204-9f17-4c8f-997b-e122c284ac9f   none      none          off        
     oxp_60e6b021-79d6-4a6b-917c-6637e0769558/crypt/zone/oxz_clickhouse_df79db1e-54ca-4048-b22a-da120ae4c8c4          b6cb0fe9-0b7a-4793-b6cd-1ee71fee464c   none      none          off        
     oxp_60e6b021-79d6-4a6b-917c-6637e0769558/crypt/zone/oxz_crucible_1e485cda-b36e-4647-9125-c273fc7a9850            65c2e3cd-3d8e-43c6-9e2c-cb884511ec49   none      none          off        
     oxp_60e6b021-79d6-4a6b-917c-6637e0769558/crypt/zone/oxz_crucible_pantry_840a4f34-0e53-469c-8c79-12b75bb42edc     7de8087e-602a-4a81-98ff-d766213d0f94   none      none          off        
@@ -37,40 +37,40 @@ to:   blueprint 31ef2071-2ec9-49d9-8827-fd83b17a0e3d
     oxp_60e6b021-79d6-4a6b-917c-6637e0769558/crypt/zone/oxz_nexus_a6032c9e-a365-45d7-ad9f-07ac0fa7079a               198ff957-cce0-40cf-9048-f65cf9a6c671   none      none          off        
     oxp_60e6b021-79d6-4a6b-917c-6637e0769558/crypt/zone/oxz_ntp_66695827-17c4-4885-b6c0-2cb6b6d3ad1c                 ccfb112d-c72e-4482-9bb0-f9cbbb034f7d   none      none          off        
     oxp_71a07ac0-d24e-446c-a202-1998e7f6ac8c/crucible                                                                c770de28-6c33-4cc7-97d9-62ddafd963aa   none      none          off        
-    oxp_71a07ac0-d24e-446c-a202-1998e7f6ac8c/crypt/debug                                                             e0bcc415-f8f9-401f-a507-cee5587756b1   100 GiB   none          gzip-9     
-    oxp_71a07ac0-d24e-446c-a202-1998e7f6ac8c/crypt/zone                                                              f83b1c8d-d252-4b35-a9d2-400e2e2cddf7   none      none          off        
+    oxp_71a07ac0-d24e-446c-a202-1998e7f6ac8c/crypt/debug                                                             2288ff91-8e52-4817-825f-2f8b8eb1681d   100 GiB   none          gzip-9     
+    oxp_71a07ac0-d24e-446c-a202-1998e7f6ac8c/crypt/zone                                                              f963f2a7-e9d1-4b80-b01a-ff4cecddf867   none      none          off        
     oxp_71a07ac0-d24e-446c-a202-1998e7f6ac8c/crypt/zone/oxz_crucible_e9ab813f-0fff-4b41-a101-790f6d94b40a            7c459b4e-396b-497f-8094-f342939d1f9f   none      none          off        
     oxp_736d4cab-c262-485e-89c2-07e6543f0855/crucible                                                                ac9f4d69-3281-4774-a098-250755079068   none      none          off        
-    oxp_736d4cab-c262-485e-89c2-07e6543f0855/crypt/debug                                                             8bbc5419-7125-4cb1-b990-436af4bb8eb4   100 GiB   none          gzip-9     
-    oxp_736d4cab-c262-485e-89c2-07e6543f0855/crypt/zone                                                              a34f8204-9f17-4c8f-997b-e122c284ac9f   none      none          off        
+    oxp_736d4cab-c262-485e-89c2-07e6543f0855/crypt/debug                                                             d0f12057-da73-4c1d-bdec-32a0e7ab7107   100 GiB   none          gzip-9     
+    oxp_736d4cab-c262-485e-89c2-07e6543f0855/crypt/zone                                                              0e976e79-fe8c-4189-8a8c-279f42e0290f   none      none          off        
     oxp_736d4cab-c262-485e-89c2-07e6543f0855/crypt/zone/oxz_crucible_65d597c5-86b9-43f6-84cd-67bb108df9f0            6de460bc-890d-4e7a-920f-607862440cfd   none      none          off        
     oxp_8ae56ca0-709d-4b8f-9869-51b62b542eef/crucible                                                                09781292-36f1-4310-82b4-ddfb4d287fa1   none      none          off        
-    oxp_8ae56ca0-709d-4b8f-9869-51b62b542eef/crypt/debug                                                             280dd773-35e2-4dda-ae2a-65c88f1b2a01   100 GiB   none          gzip-9     
-    oxp_8ae56ca0-709d-4b8f-9869-51b62b542eef/crypt/zone                                                              61bf628d-a78d-40a7-bad2-84e97e41b810   none      none          off        
+    oxp_8ae56ca0-709d-4b8f-9869-51b62b542eef/crypt/debug                                                             fecbd83d-7440-4900-b22b-6206e55b2920   100 GiB   none          gzip-9     
+    oxp_8ae56ca0-709d-4b8f-9869-51b62b542eef/crypt/zone                                                              3f63ada8-d1f4-440d-8713-da45b0684520   none      none          off        
     oxp_8ae56ca0-709d-4b8f-9869-51b62b542eef/crypt/zone/oxz_crucible_f00c7a67-51a6-4d09-be39-f20b0e6da1c6            6ff911b9-a4a5-4986-ba04-c6b3f234d3b4   none      none          off        
     oxp_8e0bcc4f-0799-450c-a0ad-80c1637f59e3/crucible                                                                81719897-4ae6-4d76-8282-fda91c347811   none      none          off        
-    oxp_8e0bcc4f-0799-450c-a0ad-80c1637f59e3/crypt/debug                                                             fecbd83d-7440-4900-b22b-6206e55b2920   100 GiB   none          gzip-9     
-    oxp_8e0bcc4f-0799-450c-a0ad-80c1637f59e3/crypt/zone                                                              3f63ada8-d1f4-440d-8713-da45b0684520   none      none          off        
+    oxp_8e0bcc4f-0799-450c-a0ad-80c1637f59e3/crypt/debug                                                             10610f76-51e8-4be4-a4ad-9af953f6bf4a   100 GiB   none          gzip-9     
+    oxp_8e0bcc4f-0799-450c-a0ad-80c1637f59e3/crypt/zone                                                              8c4f4acd-8f6b-4296-81be-12d2eeae0483   none      none          off        
     oxp_8e0bcc4f-0799-450c-a0ad-80c1637f59e3/crypt/zone/oxz_crucible_08330c18-54e9-445b-81f3-8f1d6ad15cdd            ab255226-2c8c-4222-82c6-702af839a2d2   none      none          off        
     oxp_8eeebb8e-6db6-43e8-a429-d26dde99882c/crucible                                                                a2399f57-62eb-4d7d-ac69-09cd6e5c2134   none      none          off        
-    oxp_8eeebb8e-6db6-43e8-a429-d26dde99882c/crypt/debug                                                             e120c8f8-049f-40f0-8d70-4cfe409ef34d   100 GiB   none          gzip-9     
-    oxp_8eeebb8e-6db6-43e8-a429-d26dde99882c/crypt/zone                                                              a3284e6f-ee42-4fdb-8150-634f7f40c073   none      none          off        
+    oxp_8eeebb8e-6db6-43e8-a429-d26dde99882c/crypt/debug                                                             37eb0429-d620-40fb-a57a-62486d001738   100 GiB   none          gzip-9     
+    oxp_8eeebb8e-6db6-43e8-a429-d26dde99882c/crypt/zone                                                              8b7928fb-e5a0-49b0-81d0-89f627020c92   none      none          off        
     oxp_8eeebb8e-6db6-43e8-a429-d26dde99882c/crypt/zone/oxz_crucible_5d296df4-4f2f-4896-8caa-42df00799bcb            25c5034b-83b2-4a90-a08a-7573ffb38119   none      none          off        
     oxp_a3e8de5b-c47a-49c0-b698-4d6955e1327f/crucible                                                                cd6b3952-2024-4310-b82e-abfd245ec1d6   none      none          off        
-    oxp_a3e8de5b-c47a-49c0-b698-4d6955e1327f/crypt/debug                                                             37eb0429-d620-40fb-a57a-62486d001738   100 GiB   none          gzip-9     
-    oxp_a3e8de5b-c47a-49c0-b698-4d6955e1327f/crypt/zone                                                              8b7928fb-e5a0-49b0-81d0-89f627020c92   none      none          off        
+    oxp_a3e8de5b-c47a-49c0-b698-4d6955e1327f/crypt/debug                                                             e0bcc415-f8f9-401f-a507-cee5587756b1   100 GiB   none          gzip-9     
+    oxp_a3e8de5b-c47a-49c0-b698-4d6955e1327f/crypt/zone                                                              f83b1c8d-d252-4b35-a9d2-400e2e2cddf7   none      none          off        
     oxp_a3e8de5b-c47a-49c0-b698-4d6955e1327f/crypt/zone/oxz_crucible_4d84fdb4-76fd-47a9-b033-7e1711d9125f            8dc07059-e8cd-4f89-abc7-0c5289b8ff0a   none      none          off        
     oxp_b32fa3da-4dec-4237-9776-e1a57ba15a21/crucible                                                                4f99dd21-d6ed-409a-af19-9886d1083762   none      none          off        
-    oxp_b32fa3da-4dec-4237-9776-e1a57ba15a21/crypt/debug                                                             d0f12057-da73-4c1d-bdec-32a0e7ab7107   100 GiB   none          gzip-9     
-    oxp_b32fa3da-4dec-4237-9776-e1a57ba15a21/crypt/zone                                                              0e976e79-fe8c-4189-8a8c-279f42e0290f   none      none          off        
+    oxp_b32fa3da-4dec-4237-9776-e1a57ba15a21/crypt/debug                                                             280dd773-35e2-4dda-ae2a-65c88f1b2a01   100 GiB   none          gzip-9     
+    oxp_b32fa3da-4dec-4237-9776-e1a57ba15a21/crypt/zone                                                              61bf628d-a78d-40a7-bad2-84e97e41b810   none      none          off        
     oxp_b32fa3da-4dec-4237-9776-e1a57ba15a21/crypt/zone/oxz_crucible_a9f1d41e-c445-4783-af13-0095b2836f0f            b5d6cec1-c83f-4c41-9e79-8b9bf917f483   none      none          off        
     oxp_e9c238f6-87a3-4087-8ba4-aa594a82d012/crucible                                                                e88d6ff8-6b98-44c1-97a7-83f371ae62fe   none      none          off        
-    oxp_e9c238f6-87a3-4087-8ba4-aa594a82d012/crypt/debug                                                             2288ff91-8e52-4817-825f-2f8b8eb1681d   100 GiB   none          gzip-9     
-    oxp_e9c238f6-87a3-4087-8ba4-aa594a82d012/crypt/zone                                                              f963f2a7-e9d1-4b80-b01a-ff4cecddf867   none      none          off        
+    oxp_e9c238f6-87a3-4087-8ba4-aa594a82d012/crypt/debug                                                             17ffe1be-b38b-4f39-90af-57af25dbfe30   100 GiB   none          gzip-9     
+    oxp_e9c238f6-87a3-4087-8ba4-aa594a82d012/crypt/zone                                                              a15e4260-d48c-4415-9315-c0f29234f359   none      none          off        
     oxp_e9c238f6-87a3-4087-8ba4-aa594a82d012/crypt/zone/oxz_crucible_577b0a64-6fa9-4302-bfaa-853b6e9e71ac            851cd90d-97f5-49b6-ad41-2e1c1faa3cc9   none      none          off        
     oxp_fbf997ef-52d3-438a-b036-b9117322e569/crucible                                                                d6a838c7-3ee9-4cca-9d8b-986b4de0ba1c   none      none          off        
-    oxp_fbf997ef-52d3-438a-b036-b9117322e569/crypt/debug                                                             17ffe1be-b38b-4f39-90af-57af25dbfe30   100 GiB   none          gzip-9     
-    oxp_fbf997ef-52d3-438a-b036-b9117322e569/crypt/zone                                                              a15e4260-d48c-4415-9315-c0f29234f359   none      none          off        
+    oxp_fbf997ef-52d3-438a-b036-b9117322e569/crypt/debug                                                             e120c8f8-049f-40f0-8d70-4cfe409ef34d   100 GiB   none          gzip-9     
+    oxp_fbf997ef-52d3-438a-b036-b9117322e569/crypt/zone                                                              a3284e6f-ee42-4fdb-8150-634f7f40c073   none      none          off        
     oxp_fbf997ef-52d3-438a-b036-b9117322e569/crypt/zone/oxz_crucible_0ba018f0-4ff7-4bcc-a0c7-42cfec6bc9da            ba1a3aae-15ab-4364-8250-54a766331ef8   none      none          off        
 +   oxp_60e6b021-79d6-4a6b-917c-6637e0769558/crypt/clickhouse_keeper                                                 c16a00f5-8830-400d-89e0-9a77cce8780e   none      none          off        
 +   oxp_60e6b021-79d6-4a6b-917c-6637e0769558/crypt/zone/oxz_clickhouse_keeper_f3279a8b-32fa-4426-b946-08aff9ded482   26c79a0e-a2e4-4093-ba43-5e7979609651   none      none          off        
@@ -116,54 +116,54 @@ to:   blueprint 31ef2071-2ec9-49d9-8827-fd83b17a0e3d
     fake-vendor   fake-model   serial-f635c28a-e5ca-4d22-ac94-d8f278a6ea0e
 
 
-    datasets generation 1 -> 2:
+    datasets generation 2 -> 3:
     -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
     dataset name                                                                                                     dataset uuid                           quota     reservation   compression
     -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
     oxp_0bf9d028-2b4a-4bff-82a1-6eb5fcefd985/crucible                                                                f3b1d2f6-3cbc-4420-bc91-5eaaf00f85d0   none      none          off        
-    oxp_0bf9d028-2b4a-4bff-82a1-6eb5fcefd985/crypt/debug                                                             fb722d83-ddc2-4880-95a4-1ab12f4b95be   100 GiB   none          gzip-9     
+    oxp_0bf9d028-2b4a-4bff-82a1-6eb5fcefd985/crypt/debug                                                             8005f7c0-bab3-4b0a-9568-a5861c0a09bb   100 GiB   none          gzip-9     
     oxp_0bf9d028-2b4a-4bff-82a1-6eb5fcefd985/crypt/internal_dns                                                      b8af3673-c60a-45fb-adc1-c36d0d325417   none      none          off        
-    oxp_0bf9d028-2b4a-4bff-82a1-6eb5fcefd985/crypt/zone                                                              1ab5529e-c3db-41e1-a561-9c767f980ad4   none      none          off        
+    oxp_0bf9d028-2b4a-4bff-82a1-6eb5fcefd985/crypt/zone                                                              a647238a-1689-46c9-b680-dfe1b7b68684   none      none          off        
     oxp_0bf9d028-2b4a-4bff-82a1-6eb5fcefd985/crypt/zone/oxz_crucible_aa74c1b2-b4c1-4f36-8f01-9459ef23786b            e1db255d-4793-46bd-a1f3-f207be6b2839   none      none          off        
     oxp_0bf9d028-2b4a-4bff-82a1-6eb5fcefd985/crypt/zone/oxz_crucible_pantry_97a785b8-d909-4fd4-92c1-9ba14bae603b     7b248682-95a2-4411-98b3-79fe6cb1a857   none      none          off        
     oxp_0bf9d028-2b4a-4bff-82a1-6eb5fcefd985/crypt/zone/oxz_internal_dns_c259e8b9-1086-453a-8636-050639edeffb        30161ca3-c2d8-474b-906e-bd38fc912f84   none      none          off        
     oxp_0bf9d028-2b4a-4bff-82a1-6eb5fcefd985/crypt/zone/oxz_nexus_c3c7b0bd-dce3-467b-919d-668cc6b06711               05b6bbbe-4c07-493e-8b92-4c8d4aeb1d66   none      none          off        
     oxp_0bf9d028-2b4a-4bff-82a1-6eb5fcefd985/crypt/zone/oxz_ntp_bba31b23-d112-4cde-bd4a-635812c28c0e                 fadbc503-b72d-4862-a1fd-628c7ff599d1   none      none          off        
     oxp_19293a1d-fddc-40a7-88a4-ccafdb6f66d3/crucible                                                                276f044e-dd34-4c1e-beef-174da4fcf53d   none      none          off        
-    oxp_19293a1d-fddc-40a7-88a4-ccafdb6f66d3/crypt/debug                                                             891a1ff4-66b1-4dc9-871c-be4a757bbd0f   100 GiB   none          gzip-9     
-    oxp_19293a1d-fddc-40a7-88a4-ccafdb6f66d3/crypt/zone                                                              68490e52-279a-4609-ba0b-11d03f904c88   none      none          off        
+    oxp_19293a1d-fddc-40a7-88a4-ccafdb6f66d3/crypt/debug                                                             98d65e73-01df-4525-a45d-acb2fc8d4a74   100 GiB   none          gzip-9     
+    oxp_19293a1d-fddc-40a7-88a4-ccafdb6f66d3/crypt/zone                                                              39714005-313e-42be-90eb-000a0560669f   none      none          off        
     oxp_19293a1d-fddc-40a7-88a4-ccafdb6f66d3/crypt/zone/oxz_crucible_eb58427d-599b-45dc-b316-8e4db7eec65e            26722393-82bf-442d-9725-030801a4d64c   none      none          off        
     oxp_44484c44-477a-4676-8266-b98a00e80d79/crucible                                                                e06b1670-5f34-42dc-a410-3129d69907ec   none      none          off        
-    oxp_44484c44-477a-4676-8266-b98a00e80d79/crypt/debug                                                             3e3e18ad-d527-4b2e-b758-1eefdcfca44b   100 GiB   none          gzip-9     
-    oxp_44484c44-477a-4676-8266-b98a00e80d79/crypt/zone                                                              2a5e3a10-6ab5-4988-be84-46b527dc2d23   none      none          off        
+    oxp_44484c44-477a-4676-8266-b98a00e80d79/crypt/debug                                                             6cea3508-8341-4093-abbb-c57d83cd87b4   100 GiB   none          gzip-9     
+    oxp_44484c44-477a-4676-8266-b98a00e80d79/crypt/zone                                                              e49915c6-59ed-4bbe-abf9-375b9502772a   none      none          off        
     oxp_44484c44-477a-4676-8266-b98a00e80d79/crypt/zone/oxz_crucible_487bde8c-a692-416c-be70-efef7f169fce            008ba9b6-8d41-4f7a-8ff3-ec31a0c96cf9   none      none          off        
     oxp_79787cd4-92da-4de5-bfd8-30a635521e10/crucible                                                                9d32dd45-e3ee-47b9-ba69-0dc711bbf632   none      none          off        
-    oxp_79787cd4-92da-4de5-bfd8-30a635521e10/crypt/debug                                                             bd4efdbe-7128-4423-aacf-6cf35e5a914d   100 GiB   none          gzip-9     
-    oxp_79787cd4-92da-4de5-bfd8-30a635521e10/crypt/zone                                                              fd0f9778-c31a-40f4-9ce9-f5154535e75b   none      none          off        
+    oxp_79787cd4-92da-4de5-bfd8-30a635521e10/crypt/debug                                                             dae242d1-9535-4b08-b249-f030dde2c2fd   100 GiB   none          gzip-9     
+    oxp_79787cd4-92da-4de5-bfd8-30a635521e10/crypt/zone                                                              29038bb0-9af1-4b03-9c10-b8a6444a0bc2   none      none          off        
     oxp_79787cd4-92da-4de5-bfd8-30a635521e10/crypt/zone/oxz_crucible_b6956e34-3c21-44d1-9ee2-cb7ee2e77c4e            2d2f2665-d556-4e65-9c53-d7fe573848a2   none      none          off        
     oxp_9ae94c94-baae-477e-912a-60f0c4f3bd13/crucible                                                                7e72090d-7f79-4ecc-92cc-5eb7d9dee022   none      none          off        
     oxp_9ae94c94-baae-477e-912a-60f0c4f3bd13/crypt/debug                                                             708d4e8b-3acf-44cf-87a2-275bb8fa0d96   100 GiB   none          gzip-9     
     oxp_9ae94c94-baae-477e-912a-60f0c4f3bd13/crypt/zone                                                              e4220797-15df-42c4-9df7-ad927711d565   none      none          off        
     oxp_9ae94c94-baae-477e-912a-60f0c4f3bd13/crypt/zone/oxz_crucible_41af4ef6-d21b-4271-bfcb-524f4146784a            1522207b-ea98-47cc-810c-44808796d743   none      none          off        
     oxp_af85eec8-36b3-4b88-966d-a717b9b58fe5/crucible                                                                43606b8e-384f-4412-a273-d4dde8f2e76d   none      none          off        
-    oxp_af85eec8-36b3-4b88-966d-a717b9b58fe5/crypt/debug                                                             98d65e73-01df-4525-a45d-acb2fc8d4a74   100 GiB   none          gzip-9     
-    oxp_af85eec8-36b3-4b88-966d-a717b9b58fe5/crypt/zone                                                              39714005-313e-42be-90eb-000a0560669f   none      none          off        
+    oxp_af85eec8-36b3-4b88-966d-a717b9b58fe5/crypt/debug                                                             765b4728-8d6e-4fac-9a1b-ae2258d5c52b   100 GiB   none          gzip-9     
+    oxp_af85eec8-36b3-4b88-966d-a717b9b58fe5/crypt/zone                                                              fc9765c5-0a89-4050-ba3e-e0625dbefb5f   none      none          off        
     oxp_af85eec8-36b3-4b88-966d-a717b9b58fe5/crypt/zone/oxz_crucible_26115267-8333-4711-924e-d05acf601827            3a39d5e8-ea73-4cf3-b9de-48045475151c   none      none          off        
     oxp_ddfaaba3-dafe-4103-b868-e9843d29d346/crucible                                                                2d7145e9-0029-4ae0-bb12-ee65a1738005   none      none          off        
-    oxp_ddfaaba3-dafe-4103-b868-e9843d29d346/crypt/debug                                                             8005f7c0-bab3-4b0a-9568-a5861c0a09bb   100 GiB   none          gzip-9     
-    oxp_ddfaaba3-dafe-4103-b868-e9843d29d346/crypt/zone                                                              a647238a-1689-46c9-b680-dfe1b7b68684   none      none          off        
+    oxp_ddfaaba3-dafe-4103-b868-e9843d29d346/crypt/debug                                                             bd4efdbe-7128-4423-aacf-6cf35e5a914d   100 GiB   none          gzip-9     
+    oxp_ddfaaba3-dafe-4103-b868-e9843d29d346/crypt/zone                                                              fd0f9778-c31a-40f4-9ce9-f5154535e75b   none      none          off        
     oxp_ddfaaba3-dafe-4103-b868-e9843d29d346/crypt/zone/oxz_crucible_1a92bb17-6477-46fc-9784-1d2a418d6e14            257c57cd-8f2c-440d-9fa0-e92a312295ec   none      none          off        
     oxp_ec458c3e-91ca-40f1-a2a3-3f4292c1f279/crucible                                                                dfadcc38-505a-4e9b-8674-27f8a2af13a2   none      none          off        
-    oxp_ec458c3e-91ca-40f1-a2a3-3f4292c1f279/crypt/debug                                                             dae242d1-9535-4b08-b249-f030dde2c2fd   100 GiB   none          gzip-9     
-    oxp_ec458c3e-91ca-40f1-a2a3-3f4292c1f279/crypt/zone                                                              29038bb0-9af1-4b03-9c10-b8a6444a0bc2   none      none          off        
+    oxp_ec458c3e-91ca-40f1-a2a3-3f4292c1f279/crypt/debug                                                             3e3e18ad-d527-4b2e-b758-1eefdcfca44b   100 GiB   none          gzip-9     
+    oxp_ec458c3e-91ca-40f1-a2a3-3f4292c1f279/crypt/zone                                                              2a5e3a10-6ab5-4988-be84-46b527dc2d23   none      none          off        
     oxp_ec458c3e-91ca-40f1-a2a3-3f4292c1f279/crypt/zone/oxz_crucible_9b9d58bd-44e6-4b70-80a4-e6a9262893ff            0a5bade3-3f2f-4385-b064-554b56f8bf8c   none      none          off        
     oxp_f2fc7c4c-7966-449d-8ec3-5a70f460501d/crucible                                                                72e2a1d6-09dd-43ba-9b8b-befa101f53ef   none      none          off        
-    oxp_f2fc7c4c-7966-449d-8ec3-5a70f460501d/crypt/debug                                                             6cea3508-8341-4093-abbb-c57d83cd87b4   100 GiB   none          gzip-9     
-    oxp_f2fc7c4c-7966-449d-8ec3-5a70f460501d/crypt/zone                                                              e49915c6-59ed-4bbe-abf9-375b9502772a   none      none          off        
+    oxp_f2fc7c4c-7966-449d-8ec3-5a70f460501d/crypt/debug                                                             fb722d83-ddc2-4880-95a4-1ab12f4b95be   100 GiB   none          gzip-9     
+    oxp_f2fc7c4c-7966-449d-8ec3-5a70f460501d/crypt/zone                                                              1ab5529e-c3db-41e1-a561-9c767f980ad4   none      none          off        
     oxp_f2fc7c4c-7966-449d-8ec3-5a70f460501d/crypt/zone/oxz_crucible_704a17e0-bc9d-43b9-a91e-b1ca37a23d0d            5739948f-d984-48a5-a27a-0223a0af2035   none      none          off        
     oxp_f635c28a-e5ca-4d22-ac94-d8f278a6ea0e/crucible                                                                c7dfbe25-5b52-4ee5-8556-719e99bb5e4d   none      none          off        
-    oxp_f635c28a-e5ca-4d22-ac94-d8f278a6ea0e/crypt/debug                                                             765b4728-8d6e-4fac-9a1b-ae2258d5c52b   100 GiB   none          gzip-9     
-    oxp_f635c28a-e5ca-4d22-ac94-d8f278a6ea0e/crypt/zone                                                              fc9765c5-0a89-4050-ba3e-e0625dbefb5f   none      none          off        
+    oxp_f635c28a-e5ca-4d22-ac94-d8f278a6ea0e/crypt/debug                                                             891a1ff4-66b1-4dc9-871c-be4a757bbd0f   100 GiB   none          gzip-9     
+    oxp_f635c28a-e5ca-4d22-ac94-d8f278a6ea0e/crypt/zone                                                              68490e52-279a-4609-ba0b-11d03f904c88   none      none          off        
     oxp_f635c28a-e5ca-4d22-ac94-d8f278a6ea0e/crypt/zone/oxz_crucible_93535f54-4919-4c4d-9a07-f7ab6245c01f            109f44de-d1ed-4ce3-9670-76aceb206ee4   none      none          off        
 +   oxp_0bf9d028-2b4a-4bff-82a1-6eb5fcefd985/crypt/clickhouse_keeper                                                 a3eed313-d886-4c1d-8023-8d2ec9e97ddd   none      none          off        
 +   oxp_0bf9d028-2b4a-4bff-82a1-6eb5fcefd985/crypt/clickhouse_server                                                 886f2522-8122-465f-8996-2d8c2acd9d0d   none      none          off        
@@ -211,54 +211,54 @@ to:   blueprint 31ef2071-2ec9-49d9-8827-fd83b17a0e3d
     fake-vendor   fake-model   serial-e3b45593-8f0c-47b2-a381-802a7dad1f54
 
 
-    datasets generation 1 -> 2:
+    datasets generation 2 -> 3:
     -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
     dataset name                                                                                                     dataset uuid                           quota     reservation   compression
     -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
     oxp_2a76ab1a-fb16-412d-93f9-b8cd9aa94e85/crucible                                                                431cfe4a-5756-40f4-8a9c-b70ae1227f1e   none      none          off        
-    oxp_2a76ab1a-fb16-412d-93f9-b8cd9aa94e85/crypt/debug                                                             c55ba154-4f4b-48a5-997b-2a1579671c74   100 GiB   none          gzip-9     
+    oxp_2a76ab1a-fb16-412d-93f9-b8cd9aa94e85/crypt/debug                                                             dd239ff5-a617-4eb1-ac6d-16eb76c2c849   100 GiB   none          gzip-9     
     oxp_2a76ab1a-fb16-412d-93f9-b8cd9aa94e85/crypt/internal_dns                                                      7be88e8f-06d3-49f7-a6d9-5c586f13716c   none      none          off        
-    oxp_2a76ab1a-fb16-412d-93f9-b8cd9aa94e85/crypt/zone                                                              37405860-deb4-4f2f-b770-ab8b83175d8c   none      none          off        
+    oxp_2a76ab1a-fb16-412d-93f9-b8cd9aa94e85/crypt/zone                                                              5c620f9c-454b-451b-99ca-47c3d94df493   none      none          off        
     oxp_2a76ab1a-fb16-412d-93f9-b8cd9aa94e85/crypt/zone/oxz_crucible_75cccfab-ea70-4596-a685-ab9bd5e540a1            e2ff081e-c5a4-42c3-8d95-969e2b9b7b31   none      none          off        
     oxp_2a76ab1a-fb16-412d-93f9-b8cd9aa94e85/crypt/zone/oxz_crucible_pantry_1432df56-4a7b-4271-9b24-a8a3183a95a7     452dad91-0c11-4dfa-96fb-dfb0cfa1d17c   none      none          off        
     oxp_2a76ab1a-fb16-412d-93f9-b8cd9aa94e85/crypt/zone/oxz_internal_dns_832c71a1-357d-482b-8661-3193d59ed776        08588a53-0f1d-4631-a1ef-8fa34098fbf6   none      none          off        
     oxp_2a76ab1a-fb16-412d-93f9-b8cd9aa94e85/crypt/zone/oxz_nexus_da39dead-64e2-45b6-9d01-d99584504dfd               45dc03ec-d0e0-429a-a099-7fc6ea6dfb85   none      none          off        
     oxp_2a76ab1a-fb16-412d-93f9-b8cd9aa94e85/crypt/zone/oxz_ntp_816afef9-e5cd-40ba-8cc5-71e783943e43                 6f5ba0fc-1b43-4a40-ba5a-3abf11eae62b   none      none          off        
     oxp_2de2bf7e-c679-4b2b-b373-908e9d3ffbfc/crucible                                                                1123f86b-169c-40df-8ed1-95c3def65e30   none      none          off        
-    oxp_2de2bf7e-c679-4b2b-b373-908e9d3ffbfc/crypt/debug                                                             071d678d-9376-4c3b-8e1f-825d27bcae3a   100 GiB   none          gzip-9     
-    oxp_2de2bf7e-c679-4b2b-b373-908e9d3ffbfc/crypt/zone                                                              bbb78481-c7e5-44a6-85ae-37e363827e9f   none      none          off        
+    oxp_2de2bf7e-c679-4b2b-b373-908e9d3ffbfc/crypt/debug                                                             f2df23eb-672a-41b5-89e4-26c9feb50c7c   100 GiB   none          gzip-9     
+    oxp_2de2bf7e-c679-4b2b-b373-908e9d3ffbfc/crypt/zone                                                              2747bb48-2fb7-4999-a63c-5ba5e35e0a10   none      none          off        
     oxp_2de2bf7e-c679-4b2b-b373-908e9d3ffbfc/crypt/zone/oxz_crucible_37c72edc-6acd-4c2d-ab76-d1c88e1f01f5            9b49fc13-4d2c-423e-9839-f6e1d0bffc6e   none      none          off        
     oxp_2f02a5c6-fcf5-4b5a-bc7d-7f65369918ba/crucible                                                                afa41d1a-3fc1-4723-835d-61d13db33cfe   none      none          off        
-    oxp_2f02a5c6-fcf5-4b5a-bc7d-7f65369918ba/crypt/debug                                                             daeded95-0145-4b97-b1fb-60d44856d1e4   100 GiB   none          gzip-9     
-    oxp_2f02a5c6-fcf5-4b5a-bc7d-7f65369918ba/crypt/zone                                                              38103edf-a98f-46ca-94ea-3404268ea935   none      none          off        
+    oxp_2f02a5c6-fcf5-4b5a-bc7d-7f65369918ba/crypt/debug                                                             b9e71882-7f71-4a5e-be9c-7df560c75000   100 GiB   none          gzip-9     
+    oxp_2f02a5c6-fcf5-4b5a-bc7d-7f65369918ba/crypt/zone                                                              13f8be82-85e9-43ac-985b-e7a51a910c41   none      none          off        
     oxp_2f02a5c6-fcf5-4b5a-bc7d-7f65369918ba/crypt/zone/oxz_crucible_2cb036bd-6056-4547-af65-aa6c0c1e4d6e            c6c9e491-ce4d-4dc4-82be-e394fa1e82e2   none      none          off        
     oxp_32041dbf-e58d-4f32-840d-923d3d3b68af/crucible                                                                da067282-0ae9-4861-8b78-b639622508af   none      none          off        
-    oxp_32041dbf-e58d-4f32-840d-923d3d3b68af/crypt/debug                                                             80d0697d-4ebe-4856-b7bf-78ff811eb00b   100 GiB   none          gzip-9     
-    oxp_32041dbf-e58d-4f32-840d-923d3d3b68af/crypt/zone                                                              3f1adfcf-9a2a-41db-9e1a-a2e13ff8a7dd   none      none          off        
+    oxp_32041dbf-e58d-4f32-840d-923d3d3b68af/crypt/debug                                                             96798a17-be94-44bb-9e12-2eb458e9a5ba   100 GiB   none          gzip-9     
+    oxp_32041dbf-e58d-4f32-840d-923d3d3b68af/crypt/zone                                                              64e62d15-e813-461d-9a50-403d9bd1df7c   none      none          off        
     oxp_32041dbf-e58d-4f32-840d-923d3d3b68af/crypt/zone/oxz_crucible_e52381c1-d7ab-402f-a9a8-bb52fbb614af            a0251fdc-166b-4476-95d4-f7fd58fdaf76   none      none          off        
     oxp_5f88adff-bb50-4dc1-bbfb-5a410c753ed5/crucible                                                                fcb937be-3b91-4ae7-9e25-a69808eeb07f   none      none          off        
-    oxp_5f88adff-bb50-4dc1-bbfb-5a410c753ed5/crypt/debug                                                             dd239ff5-a617-4eb1-ac6d-16eb76c2c849   100 GiB   none          gzip-9     
-    oxp_5f88adff-bb50-4dc1-bbfb-5a410c753ed5/crypt/zone                                                              5c620f9c-454b-451b-99ca-47c3d94df493   none      none          off        
+    oxp_5f88adff-bb50-4dc1-bbfb-5a410c753ed5/crypt/debug                                                             daeded95-0145-4b97-b1fb-60d44856d1e4   100 GiB   none          gzip-9     
+    oxp_5f88adff-bb50-4dc1-bbfb-5a410c753ed5/crypt/zone                                                              38103edf-a98f-46ca-94ea-3404268ea935   none      none          off        
     oxp_5f88adff-bb50-4dc1-bbfb-5a410c753ed5/crypt/zone/oxz_crucible_6ae471b1-1dd8-460e-a2a5-3ea796f746d5            98b66132-d99e-42e2-8517-5860412c61b1   none      none          off        
     oxp_74d64eb9-bf69-4782-af16-2d3a761ca171/crucible                                                                2854cb42-e5b9-4773-bd6e-6ec85d33a174   none      none          off        
-    oxp_74d64eb9-bf69-4782-af16-2d3a761ca171/crypt/debug                                                             b9e71882-7f71-4a5e-be9c-7df560c75000   100 GiB   none          gzip-9     
-    oxp_74d64eb9-bf69-4782-af16-2d3a761ca171/crypt/zone                                                              13f8be82-85e9-43ac-985b-e7a51a910c41   none      none          off        
+    oxp_74d64eb9-bf69-4782-af16-2d3a761ca171/crypt/debug                                                             80d0697d-4ebe-4856-b7bf-78ff811eb00b   100 GiB   none          gzip-9     
+    oxp_74d64eb9-bf69-4782-af16-2d3a761ca171/crypt/zone                                                              3f1adfcf-9a2a-41db-9e1a-a2e13ff8a7dd   none      none          off        
     oxp_74d64eb9-bf69-4782-af16-2d3a761ca171/crypt/zone/oxz_crucible_b6a9674e-8b42-4d67-954f-3e957db298dd            e7c2d833-b6a1-469f-b52f-8bbb45e9a30e   none      none          off        
     oxp_b3c231c9-b2a5-4267-b4bf-9651881b91a5/crucible                                                                aa8f925e-6c3a-40d2-ae2d-946324a7d612   none      none          off        
-    oxp_b3c231c9-b2a5-4267-b4bf-9651881b91a5/crypt/debug                                                             bae0ee1b-b3a3-4c4c-96ee-53b8b4cd837b   100 GiB   none          gzip-9     
-    oxp_b3c231c9-b2a5-4267-b4bf-9651881b91a5/crypt/zone                                                              9f1f99c7-e6c5-4bbc-9de5-15252b532914   none      none          off        
+    oxp_b3c231c9-b2a5-4267-b4bf-9651881b91a5/crypt/debug                                                             c55ba154-4f4b-48a5-997b-2a1579671c74   100 GiB   none          gzip-9     
+    oxp_b3c231c9-b2a5-4267-b4bf-9651881b91a5/crypt/zone                                                              37405860-deb4-4f2f-b770-ab8b83175d8c   none      none          off        
     oxp_b3c231c9-b2a5-4267-b4bf-9651881b91a5/crypt/zone/oxz_crucible_c79e017b-7e27-4ff5-be14-3673f8cb2279            3544adde-a808-45c0-ae19-08b4f65e3ad4   none      none          off        
     oxp_bca80b95-8dca-4a3b-b24d-d44b6a9ff71b/crucible                                                                755ad19c-d29b-4e3c-9c13-63b56a407765   none      none          off        
-    oxp_bca80b95-8dca-4a3b-b24d-d44b6a9ff71b/crypt/debug                                                             f2df23eb-672a-41b5-89e4-26c9feb50c7c   100 GiB   none          gzip-9     
-    oxp_bca80b95-8dca-4a3b-b24d-d44b6a9ff71b/crypt/zone                                                              2747bb48-2fb7-4999-a63c-5ba5e35e0a10   none      none          off        
+    oxp_bca80b95-8dca-4a3b-b24d-d44b6a9ff71b/crypt/debug                                                             e658be5b-df77-41fb-a000-5a924ac0b3da   100 GiB   none          gzip-9     
+    oxp_bca80b95-8dca-4a3b-b24d-d44b6a9ff71b/crypt/zone                                                              f7ddacf4-edc7-46ba-9b74-d588bd62505e   none      none          off        
     oxp_bca80b95-8dca-4a3b-b24d-d44b6a9ff71b/crypt/zone/oxz_crucible_0a160b89-6288-44f5-9908-33589094628e            53a623d2-9ffc-48fb-871d-23bd52e0f4dd   none      none          off        
     oxp_db16345e-427a-4c8e-9032-17270f729308/crucible                                                                be3cf2f7-5388-4cd6-8119-ecf316c6052e   none      none          off        
-    oxp_db16345e-427a-4c8e-9032-17270f729308/crypt/debug                                                             e658be5b-df77-41fb-a000-5a924ac0b3da   100 GiB   none          gzip-9     
-    oxp_db16345e-427a-4c8e-9032-17270f729308/crypt/zone                                                              f7ddacf4-edc7-46ba-9b74-d588bd62505e   none      none          off        
+    oxp_db16345e-427a-4c8e-9032-17270f729308/crypt/debug                                                             071d678d-9376-4c3b-8e1f-825d27bcae3a   100 GiB   none          gzip-9     
+    oxp_db16345e-427a-4c8e-9032-17270f729308/crypt/zone                                                              bbb78481-c7e5-44a6-85ae-37e363827e9f   none      none          off        
     oxp_db16345e-427a-4c8e-9032-17270f729308/crypt/zone/oxz_crucible_5fb4b72f-bf1b-47c7-a2e4-dbdafcdb47f5            1d73fc1f-81fc-4e06-9b52-686596ac0f6c   none      none          off        
     oxp_e3b45593-8f0c-47b2-a381-802a7dad1f54/crucible                                                                a2391107-7408-4e0c-a694-3fd073fa09df   none      none          off        
-    oxp_e3b45593-8f0c-47b2-a381-802a7dad1f54/crypt/debug                                                             96798a17-be94-44bb-9e12-2eb458e9a5ba   100 GiB   none          gzip-9     
-    oxp_e3b45593-8f0c-47b2-a381-802a7dad1f54/crypt/zone                                                              64e62d15-e813-461d-9a50-403d9bd1df7c   none      none          off        
+    oxp_e3b45593-8f0c-47b2-a381-802a7dad1f54/crypt/debug                                                             bae0ee1b-b3a3-4c4c-96ee-53b8b4cd837b   100 GiB   none          gzip-9     
+    oxp_e3b45593-8f0c-47b2-a381-802a7dad1f54/crypt/zone                                                              9f1f99c7-e6c5-4bbc-9de5-15252b532914   none      none          off        
     oxp_e3b45593-8f0c-47b2-a381-802a7dad1f54/crypt/zone/oxz_crucible_8a36ef67-bf66-40b9-a2f4-34ac70e90e39            c44e20e1-7cce-46df-ba71-db7fb3e3a5ff   none      none          off        
 +   oxp_2a76ab1a-fb16-412d-93f9-b8cd9aa94e85/crypt/clickhouse_keeper                                                 ce930007-8ed6-4675-a24a-57c227950d43   none      none          off        
 +   oxp_2a76ab1a-fb16-412d-93f9-b8cd9aa94e85/crypt/clickhouse_server                                                 3d339942-c2d0-4615-a099-433a8b5a1543   none      none          off        

--- a/nexus/reconfigurator/planning/tests/output/planner_deploy_all_keeper_nodes_3_4.txt
+++ b/nexus/reconfigurator/planning/tests/output/planner_deploy_all_keeper_nodes_3_4.txt
@@ -21,16 +21,16 @@ to:   blueprint 92fa943c-7dd4-48c3-9447-c9d0665744b6
     fake-vendor   fake-model   serial-fbf997ef-52d3-438a-b036-b9117322e569
 
 
-    datasets at generation 2:
+    datasets at generation 3:
     -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
     dataset name                                                                                                     dataset uuid                           quota     reservation   compression
     -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
     oxp_60e6b021-79d6-4a6b-917c-6637e0769558/crucible                                                                fcd7e842-2648-407a-8d13-197e67de9e9d   none      none          off        
     oxp_60e6b021-79d6-4a6b-917c-6637e0769558/crypt/clickhouse                                                        5cb56dc7-6c56-4bbf-ae73-6f08e0c97cdf   none      none          off        
     oxp_60e6b021-79d6-4a6b-917c-6637e0769558/crypt/clickhouse_keeper                                                 c16a00f5-8830-400d-89e0-9a77cce8780e   none      none          off        
-    oxp_60e6b021-79d6-4a6b-917c-6637e0769558/crypt/debug                                                             10610f76-51e8-4be4-a4ad-9af953f6bf4a   100 GiB   none          gzip-9     
+    oxp_60e6b021-79d6-4a6b-917c-6637e0769558/crypt/debug                                                             8bbc5419-7125-4cb1-b990-436af4bb8eb4   100 GiB   none          gzip-9     
     oxp_60e6b021-79d6-4a6b-917c-6637e0769558/crypt/internal_dns                                                      dd467397-efc5-4738-984e-77a0f3e3e678   none      none          off        
-    oxp_60e6b021-79d6-4a6b-917c-6637e0769558/crypt/zone                                                              8c4f4acd-8f6b-4296-81be-12d2eeae0483   none      none          off        
+    oxp_60e6b021-79d6-4a6b-917c-6637e0769558/crypt/zone                                                              a34f8204-9f17-4c8f-997b-e122c284ac9f   none      none          off        
     oxp_60e6b021-79d6-4a6b-917c-6637e0769558/crypt/zone/oxz_clickhouse_df79db1e-54ca-4048-b22a-da120ae4c8c4          b6cb0fe9-0b7a-4793-b6cd-1ee71fee464c   none      none          off        
     oxp_60e6b021-79d6-4a6b-917c-6637e0769558/crypt/zone/oxz_clickhouse_keeper_f3279a8b-32fa-4426-b946-08aff9ded482   26c79a0e-a2e4-4093-ba43-5e7979609651   none      none          off        
     oxp_60e6b021-79d6-4a6b-917c-6637e0769558/crypt/zone/oxz_crucible_1e485cda-b36e-4647-9125-c273fc7a9850            65c2e3cd-3d8e-43c6-9e2c-cb884511ec49   none      none          off        
@@ -39,40 +39,40 @@ to:   blueprint 92fa943c-7dd4-48c3-9447-c9d0665744b6
     oxp_60e6b021-79d6-4a6b-917c-6637e0769558/crypt/zone/oxz_nexus_a6032c9e-a365-45d7-ad9f-07ac0fa7079a               198ff957-cce0-40cf-9048-f65cf9a6c671   none      none          off        
     oxp_60e6b021-79d6-4a6b-917c-6637e0769558/crypt/zone/oxz_ntp_66695827-17c4-4885-b6c0-2cb6b6d3ad1c                 ccfb112d-c72e-4482-9bb0-f9cbbb034f7d   none      none          off        
     oxp_71a07ac0-d24e-446c-a202-1998e7f6ac8c/crucible                                                                c770de28-6c33-4cc7-97d9-62ddafd963aa   none      none          off        
-    oxp_71a07ac0-d24e-446c-a202-1998e7f6ac8c/crypt/debug                                                             e0bcc415-f8f9-401f-a507-cee5587756b1   100 GiB   none          gzip-9     
-    oxp_71a07ac0-d24e-446c-a202-1998e7f6ac8c/crypt/zone                                                              f83b1c8d-d252-4b35-a9d2-400e2e2cddf7   none      none          off        
+    oxp_71a07ac0-d24e-446c-a202-1998e7f6ac8c/crypt/debug                                                             2288ff91-8e52-4817-825f-2f8b8eb1681d   100 GiB   none          gzip-9     
+    oxp_71a07ac0-d24e-446c-a202-1998e7f6ac8c/crypt/zone                                                              f963f2a7-e9d1-4b80-b01a-ff4cecddf867   none      none          off        
     oxp_71a07ac0-d24e-446c-a202-1998e7f6ac8c/crypt/zone/oxz_crucible_e9ab813f-0fff-4b41-a101-790f6d94b40a            7c459b4e-396b-497f-8094-f342939d1f9f   none      none          off        
     oxp_736d4cab-c262-485e-89c2-07e6543f0855/crucible                                                                ac9f4d69-3281-4774-a098-250755079068   none      none          off        
-    oxp_736d4cab-c262-485e-89c2-07e6543f0855/crypt/debug                                                             8bbc5419-7125-4cb1-b990-436af4bb8eb4   100 GiB   none          gzip-9     
-    oxp_736d4cab-c262-485e-89c2-07e6543f0855/crypt/zone                                                              a34f8204-9f17-4c8f-997b-e122c284ac9f   none      none          off        
+    oxp_736d4cab-c262-485e-89c2-07e6543f0855/crypt/debug                                                             d0f12057-da73-4c1d-bdec-32a0e7ab7107   100 GiB   none          gzip-9     
+    oxp_736d4cab-c262-485e-89c2-07e6543f0855/crypt/zone                                                              0e976e79-fe8c-4189-8a8c-279f42e0290f   none      none          off        
     oxp_736d4cab-c262-485e-89c2-07e6543f0855/crypt/zone/oxz_crucible_65d597c5-86b9-43f6-84cd-67bb108df9f0            6de460bc-890d-4e7a-920f-607862440cfd   none      none          off        
     oxp_8ae56ca0-709d-4b8f-9869-51b62b542eef/crucible                                                                09781292-36f1-4310-82b4-ddfb4d287fa1   none      none          off        
-    oxp_8ae56ca0-709d-4b8f-9869-51b62b542eef/crypt/debug                                                             280dd773-35e2-4dda-ae2a-65c88f1b2a01   100 GiB   none          gzip-9     
-    oxp_8ae56ca0-709d-4b8f-9869-51b62b542eef/crypt/zone                                                              61bf628d-a78d-40a7-bad2-84e97e41b810   none      none          off        
+    oxp_8ae56ca0-709d-4b8f-9869-51b62b542eef/crypt/debug                                                             fecbd83d-7440-4900-b22b-6206e55b2920   100 GiB   none          gzip-9     
+    oxp_8ae56ca0-709d-4b8f-9869-51b62b542eef/crypt/zone                                                              3f63ada8-d1f4-440d-8713-da45b0684520   none      none          off        
     oxp_8ae56ca0-709d-4b8f-9869-51b62b542eef/crypt/zone/oxz_crucible_f00c7a67-51a6-4d09-be39-f20b0e6da1c6            6ff911b9-a4a5-4986-ba04-c6b3f234d3b4   none      none          off        
     oxp_8e0bcc4f-0799-450c-a0ad-80c1637f59e3/crucible                                                                81719897-4ae6-4d76-8282-fda91c347811   none      none          off        
-    oxp_8e0bcc4f-0799-450c-a0ad-80c1637f59e3/crypt/debug                                                             fecbd83d-7440-4900-b22b-6206e55b2920   100 GiB   none          gzip-9     
-    oxp_8e0bcc4f-0799-450c-a0ad-80c1637f59e3/crypt/zone                                                              3f63ada8-d1f4-440d-8713-da45b0684520   none      none          off        
+    oxp_8e0bcc4f-0799-450c-a0ad-80c1637f59e3/crypt/debug                                                             10610f76-51e8-4be4-a4ad-9af953f6bf4a   100 GiB   none          gzip-9     
+    oxp_8e0bcc4f-0799-450c-a0ad-80c1637f59e3/crypt/zone                                                              8c4f4acd-8f6b-4296-81be-12d2eeae0483   none      none          off        
     oxp_8e0bcc4f-0799-450c-a0ad-80c1637f59e3/crypt/zone/oxz_crucible_08330c18-54e9-445b-81f3-8f1d6ad15cdd            ab255226-2c8c-4222-82c6-702af839a2d2   none      none          off        
     oxp_8eeebb8e-6db6-43e8-a429-d26dde99882c/crucible                                                                a2399f57-62eb-4d7d-ac69-09cd6e5c2134   none      none          off        
-    oxp_8eeebb8e-6db6-43e8-a429-d26dde99882c/crypt/debug                                                             e120c8f8-049f-40f0-8d70-4cfe409ef34d   100 GiB   none          gzip-9     
-    oxp_8eeebb8e-6db6-43e8-a429-d26dde99882c/crypt/zone                                                              a3284e6f-ee42-4fdb-8150-634f7f40c073   none      none          off        
+    oxp_8eeebb8e-6db6-43e8-a429-d26dde99882c/crypt/debug                                                             37eb0429-d620-40fb-a57a-62486d001738   100 GiB   none          gzip-9     
+    oxp_8eeebb8e-6db6-43e8-a429-d26dde99882c/crypt/zone                                                              8b7928fb-e5a0-49b0-81d0-89f627020c92   none      none          off        
     oxp_8eeebb8e-6db6-43e8-a429-d26dde99882c/crypt/zone/oxz_crucible_5d296df4-4f2f-4896-8caa-42df00799bcb            25c5034b-83b2-4a90-a08a-7573ffb38119   none      none          off        
     oxp_a3e8de5b-c47a-49c0-b698-4d6955e1327f/crucible                                                                cd6b3952-2024-4310-b82e-abfd245ec1d6   none      none          off        
-    oxp_a3e8de5b-c47a-49c0-b698-4d6955e1327f/crypt/debug                                                             37eb0429-d620-40fb-a57a-62486d001738   100 GiB   none          gzip-9     
-    oxp_a3e8de5b-c47a-49c0-b698-4d6955e1327f/crypt/zone                                                              8b7928fb-e5a0-49b0-81d0-89f627020c92   none      none          off        
+    oxp_a3e8de5b-c47a-49c0-b698-4d6955e1327f/crypt/debug                                                             e0bcc415-f8f9-401f-a507-cee5587756b1   100 GiB   none          gzip-9     
+    oxp_a3e8de5b-c47a-49c0-b698-4d6955e1327f/crypt/zone                                                              f83b1c8d-d252-4b35-a9d2-400e2e2cddf7   none      none          off        
     oxp_a3e8de5b-c47a-49c0-b698-4d6955e1327f/crypt/zone/oxz_crucible_4d84fdb4-76fd-47a9-b033-7e1711d9125f            8dc07059-e8cd-4f89-abc7-0c5289b8ff0a   none      none          off        
     oxp_b32fa3da-4dec-4237-9776-e1a57ba15a21/crucible                                                                4f99dd21-d6ed-409a-af19-9886d1083762   none      none          off        
-    oxp_b32fa3da-4dec-4237-9776-e1a57ba15a21/crypt/debug                                                             d0f12057-da73-4c1d-bdec-32a0e7ab7107   100 GiB   none          gzip-9     
-    oxp_b32fa3da-4dec-4237-9776-e1a57ba15a21/crypt/zone                                                              0e976e79-fe8c-4189-8a8c-279f42e0290f   none      none          off        
+    oxp_b32fa3da-4dec-4237-9776-e1a57ba15a21/crypt/debug                                                             280dd773-35e2-4dda-ae2a-65c88f1b2a01   100 GiB   none          gzip-9     
+    oxp_b32fa3da-4dec-4237-9776-e1a57ba15a21/crypt/zone                                                              61bf628d-a78d-40a7-bad2-84e97e41b810   none      none          off        
     oxp_b32fa3da-4dec-4237-9776-e1a57ba15a21/crypt/zone/oxz_crucible_a9f1d41e-c445-4783-af13-0095b2836f0f            b5d6cec1-c83f-4c41-9e79-8b9bf917f483   none      none          off        
     oxp_e9c238f6-87a3-4087-8ba4-aa594a82d012/crucible                                                                e88d6ff8-6b98-44c1-97a7-83f371ae62fe   none      none          off        
-    oxp_e9c238f6-87a3-4087-8ba4-aa594a82d012/crypt/debug                                                             2288ff91-8e52-4817-825f-2f8b8eb1681d   100 GiB   none          gzip-9     
-    oxp_e9c238f6-87a3-4087-8ba4-aa594a82d012/crypt/zone                                                              f963f2a7-e9d1-4b80-b01a-ff4cecddf867   none      none          off        
+    oxp_e9c238f6-87a3-4087-8ba4-aa594a82d012/crypt/debug                                                             17ffe1be-b38b-4f39-90af-57af25dbfe30   100 GiB   none          gzip-9     
+    oxp_e9c238f6-87a3-4087-8ba4-aa594a82d012/crypt/zone                                                              a15e4260-d48c-4415-9315-c0f29234f359   none      none          off        
     oxp_e9c238f6-87a3-4087-8ba4-aa594a82d012/crypt/zone/oxz_crucible_577b0a64-6fa9-4302-bfaa-853b6e9e71ac            851cd90d-97f5-49b6-ad41-2e1c1faa3cc9   none      none          off        
     oxp_fbf997ef-52d3-438a-b036-b9117322e569/crucible                                                                d6a838c7-3ee9-4cca-9d8b-986b4de0ba1c   none      none          off        
-    oxp_fbf997ef-52d3-438a-b036-b9117322e569/crypt/debug                                                             17ffe1be-b38b-4f39-90af-57af25dbfe30   100 GiB   none          gzip-9     
-    oxp_fbf997ef-52d3-438a-b036-b9117322e569/crypt/zone                                                              a15e4260-d48c-4415-9315-c0f29234f359   none      none          off        
+    oxp_fbf997ef-52d3-438a-b036-b9117322e569/crypt/debug                                                             e120c8f8-049f-40f0-8d70-4cfe409ef34d   100 GiB   none          gzip-9     
+    oxp_fbf997ef-52d3-438a-b036-b9117322e569/crypt/zone                                                              a3284e6f-ee42-4fdb-8150-634f7f40c073   none      none          off        
     oxp_fbf997ef-52d3-438a-b036-b9117322e569/crypt/zone/oxz_crucible_0ba018f0-4ff7-4bcc-a0c7-42cfec6bc9da            ba1a3aae-15ab-4364-8250-54a766331ef8   none      none          off        
 
 
@@ -116,16 +116,16 @@ to:   blueprint 92fa943c-7dd4-48c3-9447-c9d0665744b6
     fake-vendor   fake-model   serial-f635c28a-e5ca-4d22-ac94-d8f278a6ea0e
 
 
-    datasets at generation 2:
+    datasets at generation 3:
     -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
     dataset name                                                                                                     dataset uuid                           quota     reservation   compression
     -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
     oxp_0bf9d028-2b4a-4bff-82a1-6eb5fcefd985/crucible                                                                f3b1d2f6-3cbc-4420-bc91-5eaaf00f85d0   none      none          off        
     oxp_0bf9d028-2b4a-4bff-82a1-6eb5fcefd985/crypt/clickhouse_keeper                                                 a3eed313-d886-4c1d-8023-8d2ec9e97ddd   none      none          off        
     oxp_0bf9d028-2b4a-4bff-82a1-6eb5fcefd985/crypt/clickhouse_server                                                 886f2522-8122-465f-8996-2d8c2acd9d0d   none      none          off        
-    oxp_0bf9d028-2b4a-4bff-82a1-6eb5fcefd985/crypt/debug                                                             fb722d83-ddc2-4880-95a4-1ab12f4b95be   100 GiB   none          gzip-9     
+    oxp_0bf9d028-2b4a-4bff-82a1-6eb5fcefd985/crypt/debug                                                             8005f7c0-bab3-4b0a-9568-a5861c0a09bb   100 GiB   none          gzip-9     
     oxp_0bf9d028-2b4a-4bff-82a1-6eb5fcefd985/crypt/internal_dns                                                      b8af3673-c60a-45fb-adc1-c36d0d325417   none      none          off        
-    oxp_0bf9d028-2b4a-4bff-82a1-6eb5fcefd985/crypt/zone                                                              1ab5529e-c3db-41e1-a561-9c767f980ad4   none      none          off        
+    oxp_0bf9d028-2b4a-4bff-82a1-6eb5fcefd985/crypt/zone                                                              a647238a-1689-46c9-b680-dfe1b7b68684   none      none          off        
     oxp_0bf9d028-2b4a-4bff-82a1-6eb5fcefd985/crypt/zone/oxz_clickhouse_keeper_b36c16d5-de6e-411a-a32a-d35a26f2e151   48720037-5b8e-4478-9bb5-c86ee8a6e250   none      none          off        
     oxp_0bf9d028-2b4a-4bff-82a1-6eb5fcefd985/crypt/zone/oxz_clickhouse_server_122e30d3-d541-49b5-88de-1543b38123cc   095cf066-5a68-40b4-afc6-baf5bcbadd05   none      none          off        
     oxp_0bf9d028-2b4a-4bff-82a1-6eb5fcefd985/crypt/zone/oxz_crucible_aa74c1b2-b4c1-4f36-8f01-9459ef23786b            e1db255d-4793-46bd-a1f3-f207be6b2839   none      none          off        
@@ -134,40 +134,40 @@ to:   blueprint 92fa943c-7dd4-48c3-9447-c9d0665744b6
     oxp_0bf9d028-2b4a-4bff-82a1-6eb5fcefd985/crypt/zone/oxz_nexus_c3c7b0bd-dce3-467b-919d-668cc6b06711               05b6bbbe-4c07-493e-8b92-4c8d4aeb1d66   none      none          off        
     oxp_0bf9d028-2b4a-4bff-82a1-6eb5fcefd985/crypt/zone/oxz_ntp_bba31b23-d112-4cde-bd4a-635812c28c0e                 fadbc503-b72d-4862-a1fd-628c7ff599d1   none      none          off        
     oxp_19293a1d-fddc-40a7-88a4-ccafdb6f66d3/crucible                                                                276f044e-dd34-4c1e-beef-174da4fcf53d   none      none          off        
-    oxp_19293a1d-fddc-40a7-88a4-ccafdb6f66d3/crypt/debug                                                             891a1ff4-66b1-4dc9-871c-be4a757bbd0f   100 GiB   none          gzip-9     
-    oxp_19293a1d-fddc-40a7-88a4-ccafdb6f66d3/crypt/zone                                                              68490e52-279a-4609-ba0b-11d03f904c88   none      none          off        
+    oxp_19293a1d-fddc-40a7-88a4-ccafdb6f66d3/crypt/debug                                                             98d65e73-01df-4525-a45d-acb2fc8d4a74   100 GiB   none          gzip-9     
+    oxp_19293a1d-fddc-40a7-88a4-ccafdb6f66d3/crypt/zone                                                              39714005-313e-42be-90eb-000a0560669f   none      none          off        
     oxp_19293a1d-fddc-40a7-88a4-ccafdb6f66d3/crypt/zone/oxz_crucible_eb58427d-599b-45dc-b316-8e4db7eec65e            26722393-82bf-442d-9725-030801a4d64c   none      none          off        
     oxp_44484c44-477a-4676-8266-b98a00e80d79/crucible                                                                e06b1670-5f34-42dc-a410-3129d69907ec   none      none          off        
-    oxp_44484c44-477a-4676-8266-b98a00e80d79/crypt/debug                                                             3e3e18ad-d527-4b2e-b758-1eefdcfca44b   100 GiB   none          gzip-9     
-    oxp_44484c44-477a-4676-8266-b98a00e80d79/crypt/zone                                                              2a5e3a10-6ab5-4988-be84-46b527dc2d23   none      none          off        
+    oxp_44484c44-477a-4676-8266-b98a00e80d79/crypt/debug                                                             6cea3508-8341-4093-abbb-c57d83cd87b4   100 GiB   none          gzip-9     
+    oxp_44484c44-477a-4676-8266-b98a00e80d79/crypt/zone                                                              e49915c6-59ed-4bbe-abf9-375b9502772a   none      none          off        
     oxp_44484c44-477a-4676-8266-b98a00e80d79/crypt/zone/oxz_crucible_487bde8c-a692-416c-be70-efef7f169fce            008ba9b6-8d41-4f7a-8ff3-ec31a0c96cf9   none      none          off        
     oxp_79787cd4-92da-4de5-bfd8-30a635521e10/crucible                                                                9d32dd45-e3ee-47b9-ba69-0dc711bbf632   none      none          off        
-    oxp_79787cd4-92da-4de5-bfd8-30a635521e10/crypt/debug                                                             bd4efdbe-7128-4423-aacf-6cf35e5a914d   100 GiB   none          gzip-9     
-    oxp_79787cd4-92da-4de5-bfd8-30a635521e10/crypt/zone                                                              fd0f9778-c31a-40f4-9ce9-f5154535e75b   none      none          off        
+    oxp_79787cd4-92da-4de5-bfd8-30a635521e10/crypt/debug                                                             dae242d1-9535-4b08-b249-f030dde2c2fd   100 GiB   none          gzip-9     
+    oxp_79787cd4-92da-4de5-bfd8-30a635521e10/crypt/zone                                                              29038bb0-9af1-4b03-9c10-b8a6444a0bc2   none      none          off        
     oxp_79787cd4-92da-4de5-bfd8-30a635521e10/crypt/zone/oxz_crucible_b6956e34-3c21-44d1-9ee2-cb7ee2e77c4e            2d2f2665-d556-4e65-9c53-d7fe573848a2   none      none          off        
     oxp_9ae94c94-baae-477e-912a-60f0c4f3bd13/crucible                                                                7e72090d-7f79-4ecc-92cc-5eb7d9dee022   none      none          off        
     oxp_9ae94c94-baae-477e-912a-60f0c4f3bd13/crypt/debug                                                             708d4e8b-3acf-44cf-87a2-275bb8fa0d96   100 GiB   none          gzip-9     
     oxp_9ae94c94-baae-477e-912a-60f0c4f3bd13/crypt/zone                                                              e4220797-15df-42c4-9df7-ad927711d565   none      none          off        
     oxp_9ae94c94-baae-477e-912a-60f0c4f3bd13/crypt/zone/oxz_crucible_41af4ef6-d21b-4271-bfcb-524f4146784a            1522207b-ea98-47cc-810c-44808796d743   none      none          off        
     oxp_af85eec8-36b3-4b88-966d-a717b9b58fe5/crucible                                                                43606b8e-384f-4412-a273-d4dde8f2e76d   none      none          off        
-    oxp_af85eec8-36b3-4b88-966d-a717b9b58fe5/crypt/debug                                                             98d65e73-01df-4525-a45d-acb2fc8d4a74   100 GiB   none          gzip-9     
-    oxp_af85eec8-36b3-4b88-966d-a717b9b58fe5/crypt/zone                                                              39714005-313e-42be-90eb-000a0560669f   none      none          off        
+    oxp_af85eec8-36b3-4b88-966d-a717b9b58fe5/crypt/debug                                                             765b4728-8d6e-4fac-9a1b-ae2258d5c52b   100 GiB   none          gzip-9     
+    oxp_af85eec8-36b3-4b88-966d-a717b9b58fe5/crypt/zone                                                              fc9765c5-0a89-4050-ba3e-e0625dbefb5f   none      none          off        
     oxp_af85eec8-36b3-4b88-966d-a717b9b58fe5/crypt/zone/oxz_crucible_26115267-8333-4711-924e-d05acf601827            3a39d5e8-ea73-4cf3-b9de-48045475151c   none      none          off        
     oxp_ddfaaba3-dafe-4103-b868-e9843d29d346/crucible                                                                2d7145e9-0029-4ae0-bb12-ee65a1738005   none      none          off        
-    oxp_ddfaaba3-dafe-4103-b868-e9843d29d346/crypt/debug                                                             8005f7c0-bab3-4b0a-9568-a5861c0a09bb   100 GiB   none          gzip-9     
-    oxp_ddfaaba3-dafe-4103-b868-e9843d29d346/crypt/zone                                                              a647238a-1689-46c9-b680-dfe1b7b68684   none      none          off        
+    oxp_ddfaaba3-dafe-4103-b868-e9843d29d346/crypt/debug                                                             bd4efdbe-7128-4423-aacf-6cf35e5a914d   100 GiB   none          gzip-9     
+    oxp_ddfaaba3-dafe-4103-b868-e9843d29d346/crypt/zone                                                              fd0f9778-c31a-40f4-9ce9-f5154535e75b   none      none          off        
     oxp_ddfaaba3-dafe-4103-b868-e9843d29d346/crypt/zone/oxz_crucible_1a92bb17-6477-46fc-9784-1d2a418d6e14            257c57cd-8f2c-440d-9fa0-e92a312295ec   none      none          off        
     oxp_ec458c3e-91ca-40f1-a2a3-3f4292c1f279/crucible                                                                dfadcc38-505a-4e9b-8674-27f8a2af13a2   none      none          off        
-    oxp_ec458c3e-91ca-40f1-a2a3-3f4292c1f279/crypt/debug                                                             dae242d1-9535-4b08-b249-f030dde2c2fd   100 GiB   none          gzip-9     
-    oxp_ec458c3e-91ca-40f1-a2a3-3f4292c1f279/crypt/zone                                                              29038bb0-9af1-4b03-9c10-b8a6444a0bc2   none      none          off        
+    oxp_ec458c3e-91ca-40f1-a2a3-3f4292c1f279/crypt/debug                                                             3e3e18ad-d527-4b2e-b758-1eefdcfca44b   100 GiB   none          gzip-9     
+    oxp_ec458c3e-91ca-40f1-a2a3-3f4292c1f279/crypt/zone                                                              2a5e3a10-6ab5-4988-be84-46b527dc2d23   none      none          off        
     oxp_ec458c3e-91ca-40f1-a2a3-3f4292c1f279/crypt/zone/oxz_crucible_9b9d58bd-44e6-4b70-80a4-e6a9262893ff            0a5bade3-3f2f-4385-b064-554b56f8bf8c   none      none          off        
     oxp_f2fc7c4c-7966-449d-8ec3-5a70f460501d/crucible                                                                72e2a1d6-09dd-43ba-9b8b-befa101f53ef   none      none          off        
-    oxp_f2fc7c4c-7966-449d-8ec3-5a70f460501d/crypt/debug                                                             6cea3508-8341-4093-abbb-c57d83cd87b4   100 GiB   none          gzip-9     
-    oxp_f2fc7c4c-7966-449d-8ec3-5a70f460501d/crypt/zone                                                              e49915c6-59ed-4bbe-abf9-375b9502772a   none      none          off        
+    oxp_f2fc7c4c-7966-449d-8ec3-5a70f460501d/crypt/debug                                                             fb722d83-ddc2-4880-95a4-1ab12f4b95be   100 GiB   none          gzip-9     
+    oxp_f2fc7c4c-7966-449d-8ec3-5a70f460501d/crypt/zone                                                              1ab5529e-c3db-41e1-a561-9c767f980ad4   none      none          off        
     oxp_f2fc7c4c-7966-449d-8ec3-5a70f460501d/crypt/zone/oxz_crucible_704a17e0-bc9d-43b9-a91e-b1ca37a23d0d            5739948f-d984-48a5-a27a-0223a0af2035   none      none          off        
     oxp_f635c28a-e5ca-4d22-ac94-d8f278a6ea0e/crucible                                                                c7dfbe25-5b52-4ee5-8556-719e99bb5e4d   none      none          off        
-    oxp_f635c28a-e5ca-4d22-ac94-d8f278a6ea0e/crypt/debug                                                             765b4728-8d6e-4fac-9a1b-ae2258d5c52b   100 GiB   none          gzip-9     
-    oxp_f635c28a-e5ca-4d22-ac94-d8f278a6ea0e/crypt/zone                                                              fc9765c5-0a89-4050-ba3e-e0625dbefb5f   none      none          off        
+    oxp_f635c28a-e5ca-4d22-ac94-d8f278a6ea0e/crypt/debug                                                             891a1ff4-66b1-4dc9-871c-be4a757bbd0f   100 GiB   none          gzip-9     
+    oxp_f635c28a-e5ca-4d22-ac94-d8f278a6ea0e/crypt/zone                                                              68490e52-279a-4609-ba0b-11d03f904c88   none      none          off        
     oxp_f635c28a-e5ca-4d22-ac94-d8f278a6ea0e/crypt/zone/oxz_crucible_93535f54-4919-4c4d-9a07-f7ab6245c01f            109f44de-d1ed-4ce3-9670-76aceb206ee4   none      none          off        
 
 
@@ -211,16 +211,16 @@ to:   blueprint 92fa943c-7dd4-48c3-9447-c9d0665744b6
     fake-vendor   fake-model   serial-e3b45593-8f0c-47b2-a381-802a7dad1f54
 
 
-    datasets at generation 2:
+    datasets at generation 3:
     -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
     dataset name                                                                                                     dataset uuid                           quota     reservation   compression
     -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
     oxp_2a76ab1a-fb16-412d-93f9-b8cd9aa94e85/crucible                                                                431cfe4a-5756-40f4-8a9c-b70ae1227f1e   none      none          off        
     oxp_2a76ab1a-fb16-412d-93f9-b8cd9aa94e85/crypt/clickhouse_keeper                                                 ce930007-8ed6-4675-a24a-57c227950d43   none      none          off        
     oxp_2a76ab1a-fb16-412d-93f9-b8cd9aa94e85/crypt/clickhouse_server                                                 3d339942-c2d0-4615-a099-433a8b5a1543   none      none          off        
-    oxp_2a76ab1a-fb16-412d-93f9-b8cd9aa94e85/crypt/debug                                                             c55ba154-4f4b-48a5-997b-2a1579671c74   100 GiB   none          gzip-9     
+    oxp_2a76ab1a-fb16-412d-93f9-b8cd9aa94e85/crypt/debug                                                             dd239ff5-a617-4eb1-ac6d-16eb76c2c849   100 GiB   none          gzip-9     
     oxp_2a76ab1a-fb16-412d-93f9-b8cd9aa94e85/crypt/internal_dns                                                      7be88e8f-06d3-49f7-a6d9-5c586f13716c   none      none          off        
-    oxp_2a76ab1a-fb16-412d-93f9-b8cd9aa94e85/crypt/zone                                                              37405860-deb4-4f2f-b770-ab8b83175d8c   none      none          off        
+    oxp_2a76ab1a-fb16-412d-93f9-b8cd9aa94e85/crypt/zone                                                              5c620f9c-454b-451b-99ca-47c3d94df493   none      none          off        
     oxp_2a76ab1a-fb16-412d-93f9-b8cd9aa94e85/crypt/zone/oxz_clickhouse_keeper_39fd3357-4de8-433e-9c07-1ec65de7ca59   748c9607-71dd-4f81-be08-c1eee262f69c   none      none          off        
     oxp_2a76ab1a-fb16-412d-93f9-b8cd9aa94e85/crypt/zone/oxz_clickhouse_server_71be6bff-666a-4f2b-a7dc-d80a88a71af5   a9e2160a-688f-4bbd-9a77-b2e695df86f4   none      none          off        
     oxp_2a76ab1a-fb16-412d-93f9-b8cd9aa94e85/crypt/zone/oxz_crucible_75cccfab-ea70-4596-a685-ab9bd5e540a1            e2ff081e-c5a4-42c3-8d95-969e2b9b7b31   none      none          off        
@@ -229,40 +229,40 @@ to:   blueprint 92fa943c-7dd4-48c3-9447-c9d0665744b6
     oxp_2a76ab1a-fb16-412d-93f9-b8cd9aa94e85/crypt/zone/oxz_nexus_da39dead-64e2-45b6-9d01-d99584504dfd               45dc03ec-d0e0-429a-a099-7fc6ea6dfb85   none      none          off        
     oxp_2a76ab1a-fb16-412d-93f9-b8cd9aa94e85/crypt/zone/oxz_ntp_816afef9-e5cd-40ba-8cc5-71e783943e43                 6f5ba0fc-1b43-4a40-ba5a-3abf11eae62b   none      none          off        
     oxp_2de2bf7e-c679-4b2b-b373-908e9d3ffbfc/crucible                                                                1123f86b-169c-40df-8ed1-95c3def65e30   none      none          off        
-    oxp_2de2bf7e-c679-4b2b-b373-908e9d3ffbfc/crypt/debug                                                             071d678d-9376-4c3b-8e1f-825d27bcae3a   100 GiB   none          gzip-9     
-    oxp_2de2bf7e-c679-4b2b-b373-908e9d3ffbfc/crypt/zone                                                              bbb78481-c7e5-44a6-85ae-37e363827e9f   none      none          off        
+    oxp_2de2bf7e-c679-4b2b-b373-908e9d3ffbfc/crypt/debug                                                             f2df23eb-672a-41b5-89e4-26c9feb50c7c   100 GiB   none          gzip-9     
+    oxp_2de2bf7e-c679-4b2b-b373-908e9d3ffbfc/crypt/zone                                                              2747bb48-2fb7-4999-a63c-5ba5e35e0a10   none      none          off        
     oxp_2de2bf7e-c679-4b2b-b373-908e9d3ffbfc/crypt/zone/oxz_crucible_37c72edc-6acd-4c2d-ab76-d1c88e1f01f5            9b49fc13-4d2c-423e-9839-f6e1d0bffc6e   none      none          off        
     oxp_2f02a5c6-fcf5-4b5a-bc7d-7f65369918ba/crucible                                                                afa41d1a-3fc1-4723-835d-61d13db33cfe   none      none          off        
-    oxp_2f02a5c6-fcf5-4b5a-bc7d-7f65369918ba/crypt/debug                                                             daeded95-0145-4b97-b1fb-60d44856d1e4   100 GiB   none          gzip-9     
-    oxp_2f02a5c6-fcf5-4b5a-bc7d-7f65369918ba/crypt/zone                                                              38103edf-a98f-46ca-94ea-3404268ea935   none      none          off        
+    oxp_2f02a5c6-fcf5-4b5a-bc7d-7f65369918ba/crypt/debug                                                             b9e71882-7f71-4a5e-be9c-7df560c75000   100 GiB   none          gzip-9     
+    oxp_2f02a5c6-fcf5-4b5a-bc7d-7f65369918ba/crypt/zone                                                              13f8be82-85e9-43ac-985b-e7a51a910c41   none      none          off        
     oxp_2f02a5c6-fcf5-4b5a-bc7d-7f65369918ba/crypt/zone/oxz_crucible_2cb036bd-6056-4547-af65-aa6c0c1e4d6e            c6c9e491-ce4d-4dc4-82be-e394fa1e82e2   none      none          off        
     oxp_32041dbf-e58d-4f32-840d-923d3d3b68af/crucible                                                                da067282-0ae9-4861-8b78-b639622508af   none      none          off        
-    oxp_32041dbf-e58d-4f32-840d-923d3d3b68af/crypt/debug                                                             80d0697d-4ebe-4856-b7bf-78ff811eb00b   100 GiB   none          gzip-9     
-    oxp_32041dbf-e58d-4f32-840d-923d3d3b68af/crypt/zone                                                              3f1adfcf-9a2a-41db-9e1a-a2e13ff8a7dd   none      none          off        
+    oxp_32041dbf-e58d-4f32-840d-923d3d3b68af/crypt/debug                                                             96798a17-be94-44bb-9e12-2eb458e9a5ba   100 GiB   none          gzip-9     
+    oxp_32041dbf-e58d-4f32-840d-923d3d3b68af/crypt/zone                                                              64e62d15-e813-461d-9a50-403d9bd1df7c   none      none          off        
     oxp_32041dbf-e58d-4f32-840d-923d3d3b68af/crypt/zone/oxz_crucible_e52381c1-d7ab-402f-a9a8-bb52fbb614af            a0251fdc-166b-4476-95d4-f7fd58fdaf76   none      none          off        
     oxp_5f88adff-bb50-4dc1-bbfb-5a410c753ed5/crucible                                                                fcb937be-3b91-4ae7-9e25-a69808eeb07f   none      none          off        
-    oxp_5f88adff-bb50-4dc1-bbfb-5a410c753ed5/crypt/debug                                                             dd239ff5-a617-4eb1-ac6d-16eb76c2c849   100 GiB   none          gzip-9     
-    oxp_5f88adff-bb50-4dc1-bbfb-5a410c753ed5/crypt/zone                                                              5c620f9c-454b-451b-99ca-47c3d94df493   none      none          off        
+    oxp_5f88adff-bb50-4dc1-bbfb-5a410c753ed5/crypt/debug                                                             daeded95-0145-4b97-b1fb-60d44856d1e4   100 GiB   none          gzip-9     
+    oxp_5f88adff-bb50-4dc1-bbfb-5a410c753ed5/crypt/zone                                                              38103edf-a98f-46ca-94ea-3404268ea935   none      none          off        
     oxp_5f88adff-bb50-4dc1-bbfb-5a410c753ed5/crypt/zone/oxz_crucible_6ae471b1-1dd8-460e-a2a5-3ea796f746d5            98b66132-d99e-42e2-8517-5860412c61b1   none      none          off        
     oxp_74d64eb9-bf69-4782-af16-2d3a761ca171/crucible                                                                2854cb42-e5b9-4773-bd6e-6ec85d33a174   none      none          off        
-    oxp_74d64eb9-bf69-4782-af16-2d3a761ca171/crypt/debug                                                             b9e71882-7f71-4a5e-be9c-7df560c75000   100 GiB   none          gzip-9     
-    oxp_74d64eb9-bf69-4782-af16-2d3a761ca171/crypt/zone                                                              13f8be82-85e9-43ac-985b-e7a51a910c41   none      none          off        
+    oxp_74d64eb9-bf69-4782-af16-2d3a761ca171/crypt/debug                                                             80d0697d-4ebe-4856-b7bf-78ff811eb00b   100 GiB   none          gzip-9     
+    oxp_74d64eb9-bf69-4782-af16-2d3a761ca171/crypt/zone                                                              3f1adfcf-9a2a-41db-9e1a-a2e13ff8a7dd   none      none          off        
     oxp_74d64eb9-bf69-4782-af16-2d3a761ca171/crypt/zone/oxz_crucible_b6a9674e-8b42-4d67-954f-3e957db298dd            e7c2d833-b6a1-469f-b52f-8bbb45e9a30e   none      none          off        
     oxp_b3c231c9-b2a5-4267-b4bf-9651881b91a5/crucible                                                                aa8f925e-6c3a-40d2-ae2d-946324a7d612   none      none          off        
-    oxp_b3c231c9-b2a5-4267-b4bf-9651881b91a5/crypt/debug                                                             bae0ee1b-b3a3-4c4c-96ee-53b8b4cd837b   100 GiB   none          gzip-9     
-    oxp_b3c231c9-b2a5-4267-b4bf-9651881b91a5/crypt/zone                                                              9f1f99c7-e6c5-4bbc-9de5-15252b532914   none      none          off        
+    oxp_b3c231c9-b2a5-4267-b4bf-9651881b91a5/crypt/debug                                                             c55ba154-4f4b-48a5-997b-2a1579671c74   100 GiB   none          gzip-9     
+    oxp_b3c231c9-b2a5-4267-b4bf-9651881b91a5/crypt/zone                                                              37405860-deb4-4f2f-b770-ab8b83175d8c   none      none          off        
     oxp_b3c231c9-b2a5-4267-b4bf-9651881b91a5/crypt/zone/oxz_crucible_c79e017b-7e27-4ff5-be14-3673f8cb2279            3544adde-a808-45c0-ae19-08b4f65e3ad4   none      none          off        
     oxp_bca80b95-8dca-4a3b-b24d-d44b6a9ff71b/crucible                                                                755ad19c-d29b-4e3c-9c13-63b56a407765   none      none          off        
-    oxp_bca80b95-8dca-4a3b-b24d-d44b6a9ff71b/crypt/debug                                                             f2df23eb-672a-41b5-89e4-26c9feb50c7c   100 GiB   none          gzip-9     
-    oxp_bca80b95-8dca-4a3b-b24d-d44b6a9ff71b/crypt/zone                                                              2747bb48-2fb7-4999-a63c-5ba5e35e0a10   none      none          off        
+    oxp_bca80b95-8dca-4a3b-b24d-d44b6a9ff71b/crypt/debug                                                             e658be5b-df77-41fb-a000-5a924ac0b3da   100 GiB   none          gzip-9     
+    oxp_bca80b95-8dca-4a3b-b24d-d44b6a9ff71b/crypt/zone                                                              f7ddacf4-edc7-46ba-9b74-d588bd62505e   none      none          off        
     oxp_bca80b95-8dca-4a3b-b24d-d44b6a9ff71b/crypt/zone/oxz_crucible_0a160b89-6288-44f5-9908-33589094628e            53a623d2-9ffc-48fb-871d-23bd52e0f4dd   none      none          off        
     oxp_db16345e-427a-4c8e-9032-17270f729308/crucible                                                                be3cf2f7-5388-4cd6-8119-ecf316c6052e   none      none          off        
-    oxp_db16345e-427a-4c8e-9032-17270f729308/crypt/debug                                                             e658be5b-df77-41fb-a000-5a924ac0b3da   100 GiB   none          gzip-9     
-    oxp_db16345e-427a-4c8e-9032-17270f729308/crypt/zone                                                              f7ddacf4-edc7-46ba-9b74-d588bd62505e   none      none          off        
+    oxp_db16345e-427a-4c8e-9032-17270f729308/crypt/debug                                                             071d678d-9376-4c3b-8e1f-825d27bcae3a   100 GiB   none          gzip-9     
+    oxp_db16345e-427a-4c8e-9032-17270f729308/crypt/zone                                                              bbb78481-c7e5-44a6-85ae-37e363827e9f   none      none          off        
     oxp_db16345e-427a-4c8e-9032-17270f729308/crypt/zone/oxz_crucible_5fb4b72f-bf1b-47c7-a2e4-dbdafcdb47f5            1d73fc1f-81fc-4e06-9b52-686596ac0f6c   none      none          off        
     oxp_e3b45593-8f0c-47b2-a381-802a7dad1f54/crucible                                                                a2391107-7408-4e0c-a694-3fd073fa09df   none      none          off        
-    oxp_e3b45593-8f0c-47b2-a381-802a7dad1f54/crypt/debug                                                             96798a17-be94-44bb-9e12-2eb458e9a5ba   100 GiB   none          gzip-9     
-    oxp_e3b45593-8f0c-47b2-a381-802a7dad1f54/crypt/zone                                                              64e62d15-e813-461d-9a50-403d9bd1df7c   none      none          off        
+    oxp_e3b45593-8f0c-47b2-a381-802a7dad1f54/crypt/debug                                                             bae0ee1b-b3a3-4c4c-96ee-53b8b4cd837b   100 GiB   none          gzip-9     
+    oxp_e3b45593-8f0c-47b2-a381-802a7dad1f54/crypt/zone                                                              9f1f99c7-e6c5-4bbc-9de5-15252b532914   none      none          off        
     oxp_e3b45593-8f0c-47b2-a381-802a7dad1f54/crypt/zone/oxz_crucible_8a36ef67-bf66-40b9-a2f4-34ac70e90e39            c44e20e1-7cce-46df-ba71-db7fb3e3a5ff   none      none          off        
 
 

--- a/nexus/reconfigurator/planning/tests/output/planner_deploy_all_keeper_nodes_4_5.txt
+++ b/nexus/reconfigurator/planning/tests/output/planner_deploy_all_keeper_nodes_4_5.txt
@@ -21,16 +21,16 @@ to:   blueprint 2886dab5-61a2-46b4-87af-bc7aeb44cccb
     fake-vendor   fake-model   serial-fbf997ef-52d3-438a-b036-b9117322e569
 
 
-    datasets at generation 2:
+    datasets at generation 3:
     -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
     dataset name                                                                                                     dataset uuid                           quota     reservation   compression
     -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
     oxp_60e6b021-79d6-4a6b-917c-6637e0769558/crucible                                                                fcd7e842-2648-407a-8d13-197e67de9e9d   none      none          off        
     oxp_60e6b021-79d6-4a6b-917c-6637e0769558/crypt/clickhouse                                                        5cb56dc7-6c56-4bbf-ae73-6f08e0c97cdf   none      none          off        
     oxp_60e6b021-79d6-4a6b-917c-6637e0769558/crypt/clickhouse_keeper                                                 c16a00f5-8830-400d-89e0-9a77cce8780e   none      none          off        
-    oxp_60e6b021-79d6-4a6b-917c-6637e0769558/crypt/debug                                                             10610f76-51e8-4be4-a4ad-9af953f6bf4a   100 GiB   none          gzip-9     
+    oxp_60e6b021-79d6-4a6b-917c-6637e0769558/crypt/debug                                                             8bbc5419-7125-4cb1-b990-436af4bb8eb4   100 GiB   none          gzip-9     
     oxp_60e6b021-79d6-4a6b-917c-6637e0769558/crypt/internal_dns                                                      dd467397-efc5-4738-984e-77a0f3e3e678   none      none          off        
-    oxp_60e6b021-79d6-4a6b-917c-6637e0769558/crypt/zone                                                              8c4f4acd-8f6b-4296-81be-12d2eeae0483   none      none          off        
+    oxp_60e6b021-79d6-4a6b-917c-6637e0769558/crypt/zone                                                              a34f8204-9f17-4c8f-997b-e122c284ac9f   none      none          off        
     oxp_60e6b021-79d6-4a6b-917c-6637e0769558/crypt/zone/oxz_clickhouse_df79db1e-54ca-4048-b22a-da120ae4c8c4          b6cb0fe9-0b7a-4793-b6cd-1ee71fee464c   none      none          off        
     oxp_60e6b021-79d6-4a6b-917c-6637e0769558/crypt/zone/oxz_clickhouse_keeper_f3279a8b-32fa-4426-b946-08aff9ded482   26c79a0e-a2e4-4093-ba43-5e7979609651   none      none          off        
     oxp_60e6b021-79d6-4a6b-917c-6637e0769558/crypt/zone/oxz_crucible_1e485cda-b36e-4647-9125-c273fc7a9850            65c2e3cd-3d8e-43c6-9e2c-cb884511ec49   none      none          off        
@@ -39,40 +39,40 @@ to:   blueprint 2886dab5-61a2-46b4-87af-bc7aeb44cccb
     oxp_60e6b021-79d6-4a6b-917c-6637e0769558/crypt/zone/oxz_nexus_a6032c9e-a365-45d7-ad9f-07ac0fa7079a               198ff957-cce0-40cf-9048-f65cf9a6c671   none      none          off        
     oxp_60e6b021-79d6-4a6b-917c-6637e0769558/crypt/zone/oxz_ntp_66695827-17c4-4885-b6c0-2cb6b6d3ad1c                 ccfb112d-c72e-4482-9bb0-f9cbbb034f7d   none      none          off        
     oxp_71a07ac0-d24e-446c-a202-1998e7f6ac8c/crucible                                                                c770de28-6c33-4cc7-97d9-62ddafd963aa   none      none          off        
-    oxp_71a07ac0-d24e-446c-a202-1998e7f6ac8c/crypt/debug                                                             e0bcc415-f8f9-401f-a507-cee5587756b1   100 GiB   none          gzip-9     
-    oxp_71a07ac0-d24e-446c-a202-1998e7f6ac8c/crypt/zone                                                              f83b1c8d-d252-4b35-a9d2-400e2e2cddf7   none      none          off        
+    oxp_71a07ac0-d24e-446c-a202-1998e7f6ac8c/crypt/debug                                                             2288ff91-8e52-4817-825f-2f8b8eb1681d   100 GiB   none          gzip-9     
+    oxp_71a07ac0-d24e-446c-a202-1998e7f6ac8c/crypt/zone                                                              f963f2a7-e9d1-4b80-b01a-ff4cecddf867   none      none          off        
     oxp_71a07ac0-d24e-446c-a202-1998e7f6ac8c/crypt/zone/oxz_crucible_e9ab813f-0fff-4b41-a101-790f6d94b40a            7c459b4e-396b-497f-8094-f342939d1f9f   none      none          off        
     oxp_736d4cab-c262-485e-89c2-07e6543f0855/crucible                                                                ac9f4d69-3281-4774-a098-250755079068   none      none          off        
-    oxp_736d4cab-c262-485e-89c2-07e6543f0855/crypt/debug                                                             8bbc5419-7125-4cb1-b990-436af4bb8eb4   100 GiB   none          gzip-9     
-    oxp_736d4cab-c262-485e-89c2-07e6543f0855/crypt/zone                                                              a34f8204-9f17-4c8f-997b-e122c284ac9f   none      none          off        
+    oxp_736d4cab-c262-485e-89c2-07e6543f0855/crypt/debug                                                             d0f12057-da73-4c1d-bdec-32a0e7ab7107   100 GiB   none          gzip-9     
+    oxp_736d4cab-c262-485e-89c2-07e6543f0855/crypt/zone                                                              0e976e79-fe8c-4189-8a8c-279f42e0290f   none      none          off        
     oxp_736d4cab-c262-485e-89c2-07e6543f0855/crypt/zone/oxz_crucible_65d597c5-86b9-43f6-84cd-67bb108df9f0            6de460bc-890d-4e7a-920f-607862440cfd   none      none          off        
     oxp_8ae56ca0-709d-4b8f-9869-51b62b542eef/crucible                                                                09781292-36f1-4310-82b4-ddfb4d287fa1   none      none          off        
-    oxp_8ae56ca0-709d-4b8f-9869-51b62b542eef/crypt/debug                                                             280dd773-35e2-4dda-ae2a-65c88f1b2a01   100 GiB   none          gzip-9     
-    oxp_8ae56ca0-709d-4b8f-9869-51b62b542eef/crypt/zone                                                              61bf628d-a78d-40a7-bad2-84e97e41b810   none      none          off        
+    oxp_8ae56ca0-709d-4b8f-9869-51b62b542eef/crypt/debug                                                             fecbd83d-7440-4900-b22b-6206e55b2920   100 GiB   none          gzip-9     
+    oxp_8ae56ca0-709d-4b8f-9869-51b62b542eef/crypt/zone                                                              3f63ada8-d1f4-440d-8713-da45b0684520   none      none          off        
     oxp_8ae56ca0-709d-4b8f-9869-51b62b542eef/crypt/zone/oxz_crucible_f00c7a67-51a6-4d09-be39-f20b0e6da1c6            6ff911b9-a4a5-4986-ba04-c6b3f234d3b4   none      none          off        
     oxp_8e0bcc4f-0799-450c-a0ad-80c1637f59e3/crucible                                                                81719897-4ae6-4d76-8282-fda91c347811   none      none          off        
-    oxp_8e0bcc4f-0799-450c-a0ad-80c1637f59e3/crypt/debug                                                             fecbd83d-7440-4900-b22b-6206e55b2920   100 GiB   none          gzip-9     
-    oxp_8e0bcc4f-0799-450c-a0ad-80c1637f59e3/crypt/zone                                                              3f63ada8-d1f4-440d-8713-da45b0684520   none      none          off        
+    oxp_8e0bcc4f-0799-450c-a0ad-80c1637f59e3/crypt/debug                                                             10610f76-51e8-4be4-a4ad-9af953f6bf4a   100 GiB   none          gzip-9     
+    oxp_8e0bcc4f-0799-450c-a0ad-80c1637f59e3/crypt/zone                                                              8c4f4acd-8f6b-4296-81be-12d2eeae0483   none      none          off        
     oxp_8e0bcc4f-0799-450c-a0ad-80c1637f59e3/crypt/zone/oxz_crucible_08330c18-54e9-445b-81f3-8f1d6ad15cdd            ab255226-2c8c-4222-82c6-702af839a2d2   none      none          off        
     oxp_8eeebb8e-6db6-43e8-a429-d26dde99882c/crucible                                                                a2399f57-62eb-4d7d-ac69-09cd6e5c2134   none      none          off        
-    oxp_8eeebb8e-6db6-43e8-a429-d26dde99882c/crypt/debug                                                             e120c8f8-049f-40f0-8d70-4cfe409ef34d   100 GiB   none          gzip-9     
-    oxp_8eeebb8e-6db6-43e8-a429-d26dde99882c/crypt/zone                                                              a3284e6f-ee42-4fdb-8150-634f7f40c073   none      none          off        
+    oxp_8eeebb8e-6db6-43e8-a429-d26dde99882c/crypt/debug                                                             37eb0429-d620-40fb-a57a-62486d001738   100 GiB   none          gzip-9     
+    oxp_8eeebb8e-6db6-43e8-a429-d26dde99882c/crypt/zone                                                              8b7928fb-e5a0-49b0-81d0-89f627020c92   none      none          off        
     oxp_8eeebb8e-6db6-43e8-a429-d26dde99882c/crypt/zone/oxz_crucible_5d296df4-4f2f-4896-8caa-42df00799bcb            25c5034b-83b2-4a90-a08a-7573ffb38119   none      none          off        
     oxp_a3e8de5b-c47a-49c0-b698-4d6955e1327f/crucible                                                                cd6b3952-2024-4310-b82e-abfd245ec1d6   none      none          off        
-    oxp_a3e8de5b-c47a-49c0-b698-4d6955e1327f/crypt/debug                                                             37eb0429-d620-40fb-a57a-62486d001738   100 GiB   none          gzip-9     
-    oxp_a3e8de5b-c47a-49c0-b698-4d6955e1327f/crypt/zone                                                              8b7928fb-e5a0-49b0-81d0-89f627020c92   none      none          off        
+    oxp_a3e8de5b-c47a-49c0-b698-4d6955e1327f/crypt/debug                                                             e0bcc415-f8f9-401f-a507-cee5587756b1   100 GiB   none          gzip-9     
+    oxp_a3e8de5b-c47a-49c0-b698-4d6955e1327f/crypt/zone                                                              f83b1c8d-d252-4b35-a9d2-400e2e2cddf7   none      none          off        
     oxp_a3e8de5b-c47a-49c0-b698-4d6955e1327f/crypt/zone/oxz_crucible_4d84fdb4-76fd-47a9-b033-7e1711d9125f            8dc07059-e8cd-4f89-abc7-0c5289b8ff0a   none      none          off        
     oxp_b32fa3da-4dec-4237-9776-e1a57ba15a21/crucible                                                                4f99dd21-d6ed-409a-af19-9886d1083762   none      none          off        
-    oxp_b32fa3da-4dec-4237-9776-e1a57ba15a21/crypt/debug                                                             d0f12057-da73-4c1d-bdec-32a0e7ab7107   100 GiB   none          gzip-9     
-    oxp_b32fa3da-4dec-4237-9776-e1a57ba15a21/crypt/zone                                                              0e976e79-fe8c-4189-8a8c-279f42e0290f   none      none          off        
+    oxp_b32fa3da-4dec-4237-9776-e1a57ba15a21/crypt/debug                                                             280dd773-35e2-4dda-ae2a-65c88f1b2a01   100 GiB   none          gzip-9     
+    oxp_b32fa3da-4dec-4237-9776-e1a57ba15a21/crypt/zone                                                              61bf628d-a78d-40a7-bad2-84e97e41b810   none      none          off        
     oxp_b32fa3da-4dec-4237-9776-e1a57ba15a21/crypt/zone/oxz_crucible_a9f1d41e-c445-4783-af13-0095b2836f0f            b5d6cec1-c83f-4c41-9e79-8b9bf917f483   none      none          off        
     oxp_e9c238f6-87a3-4087-8ba4-aa594a82d012/crucible                                                                e88d6ff8-6b98-44c1-97a7-83f371ae62fe   none      none          off        
-    oxp_e9c238f6-87a3-4087-8ba4-aa594a82d012/crypt/debug                                                             2288ff91-8e52-4817-825f-2f8b8eb1681d   100 GiB   none          gzip-9     
-    oxp_e9c238f6-87a3-4087-8ba4-aa594a82d012/crypt/zone                                                              f963f2a7-e9d1-4b80-b01a-ff4cecddf867   none      none          off        
+    oxp_e9c238f6-87a3-4087-8ba4-aa594a82d012/crypt/debug                                                             17ffe1be-b38b-4f39-90af-57af25dbfe30   100 GiB   none          gzip-9     
+    oxp_e9c238f6-87a3-4087-8ba4-aa594a82d012/crypt/zone                                                              a15e4260-d48c-4415-9315-c0f29234f359   none      none          off        
     oxp_e9c238f6-87a3-4087-8ba4-aa594a82d012/crypt/zone/oxz_crucible_577b0a64-6fa9-4302-bfaa-853b6e9e71ac            851cd90d-97f5-49b6-ad41-2e1c1faa3cc9   none      none          off        
     oxp_fbf997ef-52d3-438a-b036-b9117322e569/crucible                                                                d6a838c7-3ee9-4cca-9d8b-986b4de0ba1c   none      none          off        
-    oxp_fbf997ef-52d3-438a-b036-b9117322e569/crypt/debug                                                             17ffe1be-b38b-4f39-90af-57af25dbfe30   100 GiB   none          gzip-9     
-    oxp_fbf997ef-52d3-438a-b036-b9117322e569/crypt/zone                                                              a15e4260-d48c-4415-9315-c0f29234f359   none      none          off        
+    oxp_fbf997ef-52d3-438a-b036-b9117322e569/crypt/debug                                                             e120c8f8-049f-40f0-8d70-4cfe409ef34d   100 GiB   none          gzip-9     
+    oxp_fbf997ef-52d3-438a-b036-b9117322e569/crypt/zone                                                              a3284e6f-ee42-4fdb-8150-634f7f40c073   none      none          off        
     oxp_fbf997ef-52d3-438a-b036-b9117322e569/crypt/zone/oxz_crucible_0ba018f0-4ff7-4bcc-a0c7-42cfec6bc9da            ba1a3aae-15ab-4364-8250-54a766331ef8   none      none          off        
 
 
@@ -118,16 +118,16 @@ to:   blueprint 2886dab5-61a2-46b4-87af-bc7aeb44cccb
     fake-vendor   fake-model   serial-f635c28a-e5ca-4d22-ac94-d8f278a6ea0e
 
 
-    datasets generation 2 -> 3:
+    datasets generation 3 -> 4:
     -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
     dataset name                                                                                                     dataset uuid                           quota     reservation   compression
     -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
     oxp_0bf9d028-2b4a-4bff-82a1-6eb5fcefd985/crucible                                                                f3b1d2f6-3cbc-4420-bc91-5eaaf00f85d0   none      none          off        
     oxp_0bf9d028-2b4a-4bff-82a1-6eb5fcefd985/crypt/clickhouse_keeper                                                 a3eed313-d886-4c1d-8023-8d2ec9e97ddd   none      none          off        
     oxp_0bf9d028-2b4a-4bff-82a1-6eb5fcefd985/crypt/clickhouse_server                                                 886f2522-8122-465f-8996-2d8c2acd9d0d   none      none          off        
-    oxp_0bf9d028-2b4a-4bff-82a1-6eb5fcefd985/crypt/debug                                                             fb722d83-ddc2-4880-95a4-1ab12f4b95be   100 GiB   none          gzip-9     
+    oxp_0bf9d028-2b4a-4bff-82a1-6eb5fcefd985/crypt/debug                                                             8005f7c0-bab3-4b0a-9568-a5861c0a09bb   100 GiB   none          gzip-9     
     oxp_0bf9d028-2b4a-4bff-82a1-6eb5fcefd985/crypt/internal_dns                                                      b8af3673-c60a-45fb-adc1-c36d0d325417   none      none          off        
-    oxp_0bf9d028-2b4a-4bff-82a1-6eb5fcefd985/crypt/zone                                                              1ab5529e-c3db-41e1-a561-9c767f980ad4   none      none          off        
+    oxp_0bf9d028-2b4a-4bff-82a1-6eb5fcefd985/crypt/zone                                                              a647238a-1689-46c9-b680-dfe1b7b68684   none      none          off        
     oxp_0bf9d028-2b4a-4bff-82a1-6eb5fcefd985/crypt/zone/oxz_clickhouse_keeper_b36c16d5-de6e-411a-a32a-d35a26f2e151   48720037-5b8e-4478-9bb5-c86ee8a6e250   none      none          off        
     oxp_0bf9d028-2b4a-4bff-82a1-6eb5fcefd985/crypt/zone/oxz_clickhouse_server_122e30d3-d541-49b5-88de-1543b38123cc   095cf066-5a68-40b4-afc6-baf5bcbadd05   none      none          off        
     oxp_0bf9d028-2b4a-4bff-82a1-6eb5fcefd985/crypt/zone/oxz_crucible_aa74c1b2-b4c1-4f36-8f01-9459ef23786b            e1db255d-4793-46bd-a1f3-f207be6b2839   none      none          off        
@@ -136,40 +136,40 @@ to:   blueprint 2886dab5-61a2-46b4-87af-bc7aeb44cccb
     oxp_0bf9d028-2b4a-4bff-82a1-6eb5fcefd985/crypt/zone/oxz_nexus_c3c7b0bd-dce3-467b-919d-668cc6b06711               05b6bbbe-4c07-493e-8b92-4c8d4aeb1d66   none      none          off        
     oxp_0bf9d028-2b4a-4bff-82a1-6eb5fcefd985/crypt/zone/oxz_ntp_bba31b23-d112-4cde-bd4a-635812c28c0e                 fadbc503-b72d-4862-a1fd-628c7ff599d1   none      none          off        
     oxp_19293a1d-fddc-40a7-88a4-ccafdb6f66d3/crucible                                                                276f044e-dd34-4c1e-beef-174da4fcf53d   none      none          off        
-    oxp_19293a1d-fddc-40a7-88a4-ccafdb6f66d3/crypt/debug                                                             891a1ff4-66b1-4dc9-871c-be4a757bbd0f   100 GiB   none          gzip-9     
-    oxp_19293a1d-fddc-40a7-88a4-ccafdb6f66d3/crypt/zone                                                              68490e52-279a-4609-ba0b-11d03f904c88   none      none          off        
+    oxp_19293a1d-fddc-40a7-88a4-ccafdb6f66d3/crypt/debug                                                             98d65e73-01df-4525-a45d-acb2fc8d4a74   100 GiB   none          gzip-9     
+    oxp_19293a1d-fddc-40a7-88a4-ccafdb6f66d3/crypt/zone                                                              39714005-313e-42be-90eb-000a0560669f   none      none          off        
     oxp_19293a1d-fddc-40a7-88a4-ccafdb6f66d3/crypt/zone/oxz_crucible_eb58427d-599b-45dc-b316-8e4db7eec65e            26722393-82bf-442d-9725-030801a4d64c   none      none          off        
     oxp_44484c44-477a-4676-8266-b98a00e80d79/crucible                                                                e06b1670-5f34-42dc-a410-3129d69907ec   none      none          off        
-    oxp_44484c44-477a-4676-8266-b98a00e80d79/crypt/debug                                                             3e3e18ad-d527-4b2e-b758-1eefdcfca44b   100 GiB   none          gzip-9     
-    oxp_44484c44-477a-4676-8266-b98a00e80d79/crypt/zone                                                              2a5e3a10-6ab5-4988-be84-46b527dc2d23   none      none          off        
+    oxp_44484c44-477a-4676-8266-b98a00e80d79/crypt/debug                                                             6cea3508-8341-4093-abbb-c57d83cd87b4   100 GiB   none          gzip-9     
+    oxp_44484c44-477a-4676-8266-b98a00e80d79/crypt/zone                                                              e49915c6-59ed-4bbe-abf9-375b9502772a   none      none          off        
     oxp_44484c44-477a-4676-8266-b98a00e80d79/crypt/zone/oxz_crucible_487bde8c-a692-416c-be70-efef7f169fce            008ba9b6-8d41-4f7a-8ff3-ec31a0c96cf9   none      none          off        
     oxp_79787cd4-92da-4de5-bfd8-30a635521e10/crucible                                                                9d32dd45-e3ee-47b9-ba69-0dc711bbf632   none      none          off        
-    oxp_79787cd4-92da-4de5-bfd8-30a635521e10/crypt/debug                                                             bd4efdbe-7128-4423-aacf-6cf35e5a914d   100 GiB   none          gzip-9     
-    oxp_79787cd4-92da-4de5-bfd8-30a635521e10/crypt/zone                                                              fd0f9778-c31a-40f4-9ce9-f5154535e75b   none      none          off        
+    oxp_79787cd4-92da-4de5-bfd8-30a635521e10/crypt/debug                                                             dae242d1-9535-4b08-b249-f030dde2c2fd   100 GiB   none          gzip-9     
+    oxp_79787cd4-92da-4de5-bfd8-30a635521e10/crypt/zone                                                              29038bb0-9af1-4b03-9c10-b8a6444a0bc2   none      none          off        
     oxp_79787cd4-92da-4de5-bfd8-30a635521e10/crypt/zone/oxz_crucible_b6956e34-3c21-44d1-9ee2-cb7ee2e77c4e            2d2f2665-d556-4e65-9c53-d7fe573848a2   none      none          off        
     oxp_9ae94c94-baae-477e-912a-60f0c4f3bd13/crucible                                                                7e72090d-7f79-4ecc-92cc-5eb7d9dee022   none      none          off        
     oxp_9ae94c94-baae-477e-912a-60f0c4f3bd13/crypt/debug                                                             708d4e8b-3acf-44cf-87a2-275bb8fa0d96   100 GiB   none          gzip-9     
     oxp_9ae94c94-baae-477e-912a-60f0c4f3bd13/crypt/zone                                                              e4220797-15df-42c4-9df7-ad927711d565   none      none          off        
     oxp_9ae94c94-baae-477e-912a-60f0c4f3bd13/crypt/zone/oxz_crucible_41af4ef6-d21b-4271-bfcb-524f4146784a            1522207b-ea98-47cc-810c-44808796d743   none      none          off        
     oxp_af85eec8-36b3-4b88-966d-a717b9b58fe5/crucible                                                                43606b8e-384f-4412-a273-d4dde8f2e76d   none      none          off        
-    oxp_af85eec8-36b3-4b88-966d-a717b9b58fe5/crypt/debug                                                             98d65e73-01df-4525-a45d-acb2fc8d4a74   100 GiB   none          gzip-9     
-    oxp_af85eec8-36b3-4b88-966d-a717b9b58fe5/crypt/zone                                                              39714005-313e-42be-90eb-000a0560669f   none      none          off        
+    oxp_af85eec8-36b3-4b88-966d-a717b9b58fe5/crypt/debug                                                             765b4728-8d6e-4fac-9a1b-ae2258d5c52b   100 GiB   none          gzip-9     
+    oxp_af85eec8-36b3-4b88-966d-a717b9b58fe5/crypt/zone                                                              fc9765c5-0a89-4050-ba3e-e0625dbefb5f   none      none          off        
     oxp_af85eec8-36b3-4b88-966d-a717b9b58fe5/crypt/zone/oxz_crucible_26115267-8333-4711-924e-d05acf601827            3a39d5e8-ea73-4cf3-b9de-48045475151c   none      none          off        
     oxp_ddfaaba3-dafe-4103-b868-e9843d29d346/crucible                                                                2d7145e9-0029-4ae0-bb12-ee65a1738005   none      none          off        
-    oxp_ddfaaba3-dafe-4103-b868-e9843d29d346/crypt/debug                                                             8005f7c0-bab3-4b0a-9568-a5861c0a09bb   100 GiB   none          gzip-9     
-    oxp_ddfaaba3-dafe-4103-b868-e9843d29d346/crypt/zone                                                              a647238a-1689-46c9-b680-dfe1b7b68684   none      none          off        
+    oxp_ddfaaba3-dafe-4103-b868-e9843d29d346/crypt/debug                                                             bd4efdbe-7128-4423-aacf-6cf35e5a914d   100 GiB   none          gzip-9     
+    oxp_ddfaaba3-dafe-4103-b868-e9843d29d346/crypt/zone                                                              fd0f9778-c31a-40f4-9ce9-f5154535e75b   none      none          off        
     oxp_ddfaaba3-dafe-4103-b868-e9843d29d346/crypt/zone/oxz_crucible_1a92bb17-6477-46fc-9784-1d2a418d6e14            257c57cd-8f2c-440d-9fa0-e92a312295ec   none      none          off        
     oxp_ec458c3e-91ca-40f1-a2a3-3f4292c1f279/crucible                                                                dfadcc38-505a-4e9b-8674-27f8a2af13a2   none      none          off        
-    oxp_ec458c3e-91ca-40f1-a2a3-3f4292c1f279/crypt/debug                                                             dae242d1-9535-4b08-b249-f030dde2c2fd   100 GiB   none          gzip-9     
-    oxp_ec458c3e-91ca-40f1-a2a3-3f4292c1f279/crypt/zone                                                              29038bb0-9af1-4b03-9c10-b8a6444a0bc2   none      none          off        
+    oxp_ec458c3e-91ca-40f1-a2a3-3f4292c1f279/crypt/debug                                                             3e3e18ad-d527-4b2e-b758-1eefdcfca44b   100 GiB   none          gzip-9     
+    oxp_ec458c3e-91ca-40f1-a2a3-3f4292c1f279/crypt/zone                                                              2a5e3a10-6ab5-4988-be84-46b527dc2d23   none      none          off        
     oxp_ec458c3e-91ca-40f1-a2a3-3f4292c1f279/crypt/zone/oxz_crucible_9b9d58bd-44e6-4b70-80a4-e6a9262893ff            0a5bade3-3f2f-4385-b064-554b56f8bf8c   none      none          off        
     oxp_f2fc7c4c-7966-449d-8ec3-5a70f460501d/crucible                                                                72e2a1d6-09dd-43ba-9b8b-befa101f53ef   none      none          off        
-    oxp_f2fc7c4c-7966-449d-8ec3-5a70f460501d/crypt/debug                                                             6cea3508-8341-4093-abbb-c57d83cd87b4   100 GiB   none          gzip-9     
-    oxp_f2fc7c4c-7966-449d-8ec3-5a70f460501d/crypt/zone                                                              e49915c6-59ed-4bbe-abf9-375b9502772a   none      none          off        
+    oxp_f2fc7c4c-7966-449d-8ec3-5a70f460501d/crypt/debug                                                             fb722d83-ddc2-4880-95a4-1ab12f4b95be   100 GiB   none          gzip-9     
+    oxp_f2fc7c4c-7966-449d-8ec3-5a70f460501d/crypt/zone                                                              1ab5529e-c3db-41e1-a561-9c767f980ad4   none      none          off        
     oxp_f2fc7c4c-7966-449d-8ec3-5a70f460501d/crypt/zone/oxz_crucible_704a17e0-bc9d-43b9-a91e-b1ca37a23d0d            5739948f-d984-48a5-a27a-0223a0af2035   none      none          off        
     oxp_f635c28a-e5ca-4d22-ac94-d8f278a6ea0e/crucible                                                                c7dfbe25-5b52-4ee5-8556-719e99bb5e4d   none      none          off        
-    oxp_f635c28a-e5ca-4d22-ac94-d8f278a6ea0e/crypt/debug                                                             765b4728-8d6e-4fac-9a1b-ae2258d5c52b   100 GiB   none          gzip-9     
-    oxp_f635c28a-e5ca-4d22-ac94-d8f278a6ea0e/crypt/zone                                                              fc9765c5-0a89-4050-ba3e-e0625dbefb5f   none      none          off        
+    oxp_f635c28a-e5ca-4d22-ac94-d8f278a6ea0e/crypt/debug                                                             891a1ff4-66b1-4dc9-871c-be4a757bbd0f   100 GiB   none          gzip-9     
+    oxp_f635c28a-e5ca-4d22-ac94-d8f278a6ea0e/crypt/zone                                                              68490e52-279a-4609-ba0b-11d03f904c88   none      none          off        
     oxp_f635c28a-e5ca-4d22-ac94-d8f278a6ea0e/crypt/zone/oxz_crucible_93535f54-4919-4c4d-9a07-f7ab6245c01f            109f44de-d1ed-4ce3-9670-76aceb206ee4   none      none          off        
 +   oxp_19293a1d-fddc-40a7-88a4-ccafdb6f66d3/crypt/clickhouse_keeper                                                 3682c931-5332-45ef-9885-3d2dcfb325f6   none      none          off        
 +   oxp_19293a1d-fddc-40a7-88a4-ccafdb6f66d3/crypt/zone/oxz_clickhouse_keeper_81a4f9fd-e502-42c2-bf9c-29dd6918fd46   6aaeeb8d-ee87-43a2-b1ef-22e5f5224842   none      none          off        
@@ -216,16 +216,16 @@ to:   blueprint 2886dab5-61a2-46b4-87af-bc7aeb44cccb
     fake-vendor   fake-model   serial-e3b45593-8f0c-47b2-a381-802a7dad1f54
 
 
-    datasets generation 2 -> 3:
+    datasets generation 3 -> 4:
     -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
     dataset name                                                                                                     dataset uuid                           quota     reservation   compression
     -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
     oxp_2a76ab1a-fb16-412d-93f9-b8cd9aa94e85/crucible                                                                431cfe4a-5756-40f4-8a9c-b70ae1227f1e   none      none          off        
     oxp_2a76ab1a-fb16-412d-93f9-b8cd9aa94e85/crypt/clickhouse_keeper                                                 ce930007-8ed6-4675-a24a-57c227950d43   none      none          off        
     oxp_2a76ab1a-fb16-412d-93f9-b8cd9aa94e85/crypt/clickhouse_server                                                 3d339942-c2d0-4615-a099-433a8b5a1543   none      none          off        
-    oxp_2a76ab1a-fb16-412d-93f9-b8cd9aa94e85/crypt/debug                                                             c55ba154-4f4b-48a5-997b-2a1579671c74   100 GiB   none          gzip-9     
+    oxp_2a76ab1a-fb16-412d-93f9-b8cd9aa94e85/crypt/debug                                                             dd239ff5-a617-4eb1-ac6d-16eb76c2c849   100 GiB   none          gzip-9     
     oxp_2a76ab1a-fb16-412d-93f9-b8cd9aa94e85/crypt/internal_dns                                                      7be88e8f-06d3-49f7-a6d9-5c586f13716c   none      none          off        
-    oxp_2a76ab1a-fb16-412d-93f9-b8cd9aa94e85/crypt/zone                                                              37405860-deb4-4f2f-b770-ab8b83175d8c   none      none          off        
+    oxp_2a76ab1a-fb16-412d-93f9-b8cd9aa94e85/crypt/zone                                                              5c620f9c-454b-451b-99ca-47c3d94df493   none      none          off        
     oxp_2a76ab1a-fb16-412d-93f9-b8cd9aa94e85/crypt/zone/oxz_clickhouse_keeper_39fd3357-4de8-433e-9c07-1ec65de7ca59   748c9607-71dd-4f81-be08-c1eee262f69c   none      none          off        
     oxp_2a76ab1a-fb16-412d-93f9-b8cd9aa94e85/crypt/zone/oxz_clickhouse_server_71be6bff-666a-4f2b-a7dc-d80a88a71af5   a9e2160a-688f-4bbd-9a77-b2e695df86f4   none      none          off        
     oxp_2a76ab1a-fb16-412d-93f9-b8cd9aa94e85/crypt/zone/oxz_crucible_75cccfab-ea70-4596-a685-ab9bd5e540a1            e2ff081e-c5a4-42c3-8d95-969e2b9b7b31   none      none          off        
@@ -234,40 +234,40 @@ to:   blueprint 2886dab5-61a2-46b4-87af-bc7aeb44cccb
     oxp_2a76ab1a-fb16-412d-93f9-b8cd9aa94e85/crypt/zone/oxz_nexus_da39dead-64e2-45b6-9d01-d99584504dfd               45dc03ec-d0e0-429a-a099-7fc6ea6dfb85   none      none          off        
     oxp_2a76ab1a-fb16-412d-93f9-b8cd9aa94e85/crypt/zone/oxz_ntp_816afef9-e5cd-40ba-8cc5-71e783943e43                 6f5ba0fc-1b43-4a40-ba5a-3abf11eae62b   none      none          off        
     oxp_2de2bf7e-c679-4b2b-b373-908e9d3ffbfc/crucible                                                                1123f86b-169c-40df-8ed1-95c3def65e30   none      none          off        
-    oxp_2de2bf7e-c679-4b2b-b373-908e9d3ffbfc/crypt/debug                                                             071d678d-9376-4c3b-8e1f-825d27bcae3a   100 GiB   none          gzip-9     
-    oxp_2de2bf7e-c679-4b2b-b373-908e9d3ffbfc/crypt/zone                                                              bbb78481-c7e5-44a6-85ae-37e363827e9f   none      none          off        
+    oxp_2de2bf7e-c679-4b2b-b373-908e9d3ffbfc/crypt/debug                                                             f2df23eb-672a-41b5-89e4-26c9feb50c7c   100 GiB   none          gzip-9     
+    oxp_2de2bf7e-c679-4b2b-b373-908e9d3ffbfc/crypt/zone                                                              2747bb48-2fb7-4999-a63c-5ba5e35e0a10   none      none          off        
     oxp_2de2bf7e-c679-4b2b-b373-908e9d3ffbfc/crypt/zone/oxz_crucible_37c72edc-6acd-4c2d-ab76-d1c88e1f01f5            9b49fc13-4d2c-423e-9839-f6e1d0bffc6e   none      none          off        
     oxp_2f02a5c6-fcf5-4b5a-bc7d-7f65369918ba/crucible                                                                afa41d1a-3fc1-4723-835d-61d13db33cfe   none      none          off        
-    oxp_2f02a5c6-fcf5-4b5a-bc7d-7f65369918ba/crypt/debug                                                             daeded95-0145-4b97-b1fb-60d44856d1e4   100 GiB   none          gzip-9     
-    oxp_2f02a5c6-fcf5-4b5a-bc7d-7f65369918ba/crypt/zone                                                              38103edf-a98f-46ca-94ea-3404268ea935   none      none          off        
+    oxp_2f02a5c6-fcf5-4b5a-bc7d-7f65369918ba/crypt/debug                                                             b9e71882-7f71-4a5e-be9c-7df560c75000   100 GiB   none          gzip-9     
+    oxp_2f02a5c6-fcf5-4b5a-bc7d-7f65369918ba/crypt/zone                                                              13f8be82-85e9-43ac-985b-e7a51a910c41   none      none          off        
     oxp_2f02a5c6-fcf5-4b5a-bc7d-7f65369918ba/crypt/zone/oxz_crucible_2cb036bd-6056-4547-af65-aa6c0c1e4d6e            c6c9e491-ce4d-4dc4-82be-e394fa1e82e2   none      none          off        
     oxp_32041dbf-e58d-4f32-840d-923d3d3b68af/crucible                                                                da067282-0ae9-4861-8b78-b639622508af   none      none          off        
-    oxp_32041dbf-e58d-4f32-840d-923d3d3b68af/crypt/debug                                                             80d0697d-4ebe-4856-b7bf-78ff811eb00b   100 GiB   none          gzip-9     
-    oxp_32041dbf-e58d-4f32-840d-923d3d3b68af/crypt/zone                                                              3f1adfcf-9a2a-41db-9e1a-a2e13ff8a7dd   none      none          off        
+    oxp_32041dbf-e58d-4f32-840d-923d3d3b68af/crypt/debug                                                             96798a17-be94-44bb-9e12-2eb458e9a5ba   100 GiB   none          gzip-9     
+    oxp_32041dbf-e58d-4f32-840d-923d3d3b68af/crypt/zone                                                              64e62d15-e813-461d-9a50-403d9bd1df7c   none      none          off        
     oxp_32041dbf-e58d-4f32-840d-923d3d3b68af/crypt/zone/oxz_crucible_e52381c1-d7ab-402f-a9a8-bb52fbb614af            a0251fdc-166b-4476-95d4-f7fd58fdaf76   none      none          off        
     oxp_5f88adff-bb50-4dc1-bbfb-5a410c753ed5/crucible                                                                fcb937be-3b91-4ae7-9e25-a69808eeb07f   none      none          off        
-    oxp_5f88adff-bb50-4dc1-bbfb-5a410c753ed5/crypt/debug                                                             dd239ff5-a617-4eb1-ac6d-16eb76c2c849   100 GiB   none          gzip-9     
-    oxp_5f88adff-bb50-4dc1-bbfb-5a410c753ed5/crypt/zone                                                              5c620f9c-454b-451b-99ca-47c3d94df493   none      none          off        
+    oxp_5f88adff-bb50-4dc1-bbfb-5a410c753ed5/crypt/debug                                                             daeded95-0145-4b97-b1fb-60d44856d1e4   100 GiB   none          gzip-9     
+    oxp_5f88adff-bb50-4dc1-bbfb-5a410c753ed5/crypt/zone                                                              38103edf-a98f-46ca-94ea-3404268ea935   none      none          off        
     oxp_5f88adff-bb50-4dc1-bbfb-5a410c753ed5/crypt/zone/oxz_crucible_6ae471b1-1dd8-460e-a2a5-3ea796f746d5            98b66132-d99e-42e2-8517-5860412c61b1   none      none          off        
     oxp_74d64eb9-bf69-4782-af16-2d3a761ca171/crucible                                                                2854cb42-e5b9-4773-bd6e-6ec85d33a174   none      none          off        
-    oxp_74d64eb9-bf69-4782-af16-2d3a761ca171/crypt/debug                                                             b9e71882-7f71-4a5e-be9c-7df560c75000   100 GiB   none          gzip-9     
-    oxp_74d64eb9-bf69-4782-af16-2d3a761ca171/crypt/zone                                                              13f8be82-85e9-43ac-985b-e7a51a910c41   none      none          off        
+    oxp_74d64eb9-bf69-4782-af16-2d3a761ca171/crypt/debug                                                             80d0697d-4ebe-4856-b7bf-78ff811eb00b   100 GiB   none          gzip-9     
+    oxp_74d64eb9-bf69-4782-af16-2d3a761ca171/crypt/zone                                                              3f1adfcf-9a2a-41db-9e1a-a2e13ff8a7dd   none      none          off        
     oxp_74d64eb9-bf69-4782-af16-2d3a761ca171/crypt/zone/oxz_crucible_b6a9674e-8b42-4d67-954f-3e957db298dd            e7c2d833-b6a1-469f-b52f-8bbb45e9a30e   none      none          off        
     oxp_b3c231c9-b2a5-4267-b4bf-9651881b91a5/crucible                                                                aa8f925e-6c3a-40d2-ae2d-946324a7d612   none      none          off        
-    oxp_b3c231c9-b2a5-4267-b4bf-9651881b91a5/crypt/debug                                                             bae0ee1b-b3a3-4c4c-96ee-53b8b4cd837b   100 GiB   none          gzip-9     
-    oxp_b3c231c9-b2a5-4267-b4bf-9651881b91a5/crypt/zone                                                              9f1f99c7-e6c5-4bbc-9de5-15252b532914   none      none          off        
+    oxp_b3c231c9-b2a5-4267-b4bf-9651881b91a5/crypt/debug                                                             c55ba154-4f4b-48a5-997b-2a1579671c74   100 GiB   none          gzip-9     
+    oxp_b3c231c9-b2a5-4267-b4bf-9651881b91a5/crypt/zone                                                              37405860-deb4-4f2f-b770-ab8b83175d8c   none      none          off        
     oxp_b3c231c9-b2a5-4267-b4bf-9651881b91a5/crypt/zone/oxz_crucible_c79e017b-7e27-4ff5-be14-3673f8cb2279            3544adde-a808-45c0-ae19-08b4f65e3ad4   none      none          off        
     oxp_bca80b95-8dca-4a3b-b24d-d44b6a9ff71b/crucible                                                                755ad19c-d29b-4e3c-9c13-63b56a407765   none      none          off        
-    oxp_bca80b95-8dca-4a3b-b24d-d44b6a9ff71b/crypt/debug                                                             f2df23eb-672a-41b5-89e4-26c9feb50c7c   100 GiB   none          gzip-9     
-    oxp_bca80b95-8dca-4a3b-b24d-d44b6a9ff71b/crypt/zone                                                              2747bb48-2fb7-4999-a63c-5ba5e35e0a10   none      none          off        
+    oxp_bca80b95-8dca-4a3b-b24d-d44b6a9ff71b/crypt/debug                                                             e658be5b-df77-41fb-a000-5a924ac0b3da   100 GiB   none          gzip-9     
+    oxp_bca80b95-8dca-4a3b-b24d-d44b6a9ff71b/crypt/zone                                                              f7ddacf4-edc7-46ba-9b74-d588bd62505e   none      none          off        
     oxp_bca80b95-8dca-4a3b-b24d-d44b6a9ff71b/crypt/zone/oxz_crucible_0a160b89-6288-44f5-9908-33589094628e            53a623d2-9ffc-48fb-871d-23bd52e0f4dd   none      none          off        
     oxp_db16345e-427a-4c8e-9032-17270f729308/crucible                                                                be3cf2f7-5388-4cd6-8119-ecf316c6052e   none      none          off        
-    oxp_db16345e-427a-4c8e-9032-17270f729308/crypt/debug                                                             e658be5b-df77-41fb-a000-5a924ac0b3da   100 GiB   none          gzip-9     
-    oxp_db16345e-427a-4c8e-9032-17270f729308/crypt/zone                                                              f7ddacf4-edc7-46ba-9b74-d588bd62505e   none      none          off        
+    oxp_db16345e-427a-4c8e-9032-17270f729308/crypt/debug                                                             071d678d-9376-4c3b-8e1f-825d27bcae3a   100 GiB   none          gzip-9     
+    oxp_db16345e-427a-4c8e-9032-17270f729308/crypt/zone                                                              bbb78481-c7e5-44a6-85ae-37e363827e9f   none      none          off        
     oxp_db16345e-427a-4c8e-9032-17270f729308/crypt/zone/oxz_crucible_5fb4b72f-bf1b-47c7-a2e4-dbdafcdb47f5            1d73fc1f-81fc-4e06-9b52-686596ac0f6c   none      none          off        
     oxp_e3b45593-8f0c-47b2-a381-802a7dad1f54/crucible                                                                a2391107-7408-4e0c-a694-3fd073fa09df   none      none          off        
-    oxp_e3b45593-8f0c-47b2-a381-802a7dad1f54/crypt/debug                                                             96798a17-be94-44bb-9e12-2eb458e9a5ba   100 GiB   none          gzip-9     
-    oxp_e3b45593-8f0c-47b2-a381-802a7dad1f54/crypt/zone                                                              64e62d15-e813-461d-9a50-403d9bd1df7c   none      none          off        
+    oxp_e3b45593-8f0c-47b2-a381-802a7dad1f54/crypt/debug                                                             bae0ee1b-b3a3-4c4c-96ee-53b8b4cd837b   100 GiB   none          gzip-9     
+    oxp_e3b45593-8f0c-47b2-a381-802a7dad1f54/crypt/zone                                                              9f1f99c7-e6c5-4bbc-9de5-15252b532914   none      none          off        
     oxp_e3b45593-8f0c-47b2-a381-802a7dad1f54/crypt/zone/oxz_crucible_8a36ef67-bf66-40b9-a2f4-34ac70e90e39            c44e20e1-7cce-46df-ba71-db7fb3e3a5ff   none      none          off        
 +   oxp_2de2bf7e-c679-4b2b-b373-908e9d3ffbfc/crypt/clickhouse_keeper                                                 cad1d0c3-ca80-4db4-ab36-b2034cf2383b   none      none          off        
 +   oxp_2de2bf7e-c679-4b2b-b373-908e9d3ffbfc/crypt/zone/oxz_clickhouse_keeper_ad07794e-affa-4145-81fb-f45ed92e3fcd   d196c20e-0254-4716-8e04-c0c735d2ffaf   none      none          off        

--- a/nexus/reconfigurator/planning/tests/output/planner_deploy_all_keeper_nodes_4_collection.txt
+++ b/nexus/reconfigurator/planning/tests/output/planner_deploy_all_keeper_nodes_4_collection.txt
@@ -20,15 +20,15 @@ to:   blueprint  92fa943c-7dd4-48c3-9447-c9d0665744b6
     fake-vendor   fake-model   serial-fbf997ef-52d3-438a-b036-b9117322e569
 
 
-    datasets at generation 2:
+    datasets at generation 3:
     -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
     dataset name                                                                                                     dataset uuid                           quota     reservation   compression
     -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
     oxp_60e6b021-79d6-4a6b-917c-6637e0769558/crucible                                                                fcd7e842-2648-407a-8d13-197e67de9e9d   none      none          off        
     oxp_60e6b021-79d6-4a6b-917c-6637e0769558/crypt/clickhouse                                                        5cb56dc7-6c56-4bbf-ae73-6f08e0c97cdf   none      none          off        
-    oxp_60e6b021-79d6-4a6b-917c-6637e0769558/crypt/debug                                                             10610f76-51e8-4be4-a4ad-9af953f6bf4a   100 GiB   none          gzip-9     
+    oxp_60e6b021-79d6-4a6b-917c-6637e0769558/crypt/debug                                                             8bbc5419-7125-4cb1-b990-436af4bb8eb4   100 GiB   none          gzip-9     
     oxp_60e6b021-79d6-4a6b-917c-6637e0769558/crypt/internal_dns                                                      dd467397-efc5-4738-984e-77a0f3e3e678   none      none          off        
-    oxp_60e6b021-79d6-4a6b-917c-6637e0769558/crypt/zone                                                              8c4f4acd-8f6b-4296-81be-12d2eeae0483   none      none          off        
+    oxp_60e6b021-79d6-4a6b-917c-6637e0769558/crypt/zone                                                              a34f8204-9f17-4c8f-997b-e122c284ac9f   none      none          off        
     oxp_60e6b021-79d6-4a6b-917c-6637e0769558/crypt/zone/oxz_clickhouse_df79db1e-54ca-4048-b22a-da120ae4c8c4          b6cb0fe9-0b7a-4793-b6cd-1ee71fee464c   none      none          off        
     oxp_60e6b021-79d6-4a6b-917c-6637e0769558/crypt/zone/oxz_crucible_1e485cda-b36e-4647-9125-c273fc7a9850            65c2e3cd-3d8e-43c6-9e2c-cb884511ec49   none      none          off        
     oxp_60e6b021-79d6-4a6b-917c-6637e0769558/crypt/zone/oxz_crucible_pantry_840a4f34-0e53-469c-8c79-12b75bb42edc     7de8087e-602a-4a81-98ff-d766213d0f94   none      none          off        
@@ -36,40 +36,40 @@ to:   blueprint  92fa943c-7dd4-48c3-9447-c9d0665744b6
     oxp_60e6b021-79d6-4a6b-917c-6637e0769558/crypt/zone/oxz_nexus_a6032c9e-a365-45d7-ad9f-07ac0fa7079a               198ff957-cce0-40cf-9048-f65cf9a6c671   none      none          off        
     oxp_60e6b021-79d6-4a6b-917c-6637e0769558/crypt/zone/oxz_ntp_66695827-17c4-4885-b6c0-2cb6b6d3ad1c                 ccfb112d-c72e-4482-9bb0-f9cbbb034f7d   none      none          off        
     oxp_71a07ac0-d24e-446c-a202-1998e7f6ac8c/crucible                                                                c770de28-6c33-4cc7-97d9-62ddafd963aa   none      none          off        
-    oxp_71a07ac0-d24e-446c-a202-1998e7f6ac8c/crypt/debug                                                             e0bcc415-f8f9-401f-a507-cee5587756b1   100 GiB   none          gzip-9     
-    oxp_71a07ac0-d24e-446c-a202-1998e7f6ac8c/crypt/zone                                                              f83b1c8d-d252-4b35-a9d2-400e2e2cddf7   none      none          off        
+    oxp_71a07ac0-d24e-446c-a202-1998e7f6ac8c/crypt/debug                                                             2288ff91-8e52-4817-825f-2f8b8eb1681d   100 GiB   none          gzip-9     
+    oxp_71a07ac0-d24e-446c-a202-1998e7f6ac8c/crypt/zone                                                              f963f2a7-e9d1-4b80-b01a-ff4cecddf867   none      none          off        
     oxp_71a07ac0-d24e-446c-a202-1998e7f6ac8c/crypt/zone/oxz_crucible_e9ab813f-0fff-4b41-a101-790f6d94b40a            7c459b4e-396b-497f-8094-f342939d1f9f   none      none          off        
     oxp_736d4cab-c262-485e-89c2-07e6543f0855/crucible                                                                ac9f4d69-3281-4774-a098-250755079068   none      none          off        
-    oxp_736d4cab-c262-485e-89c2-07e6543f0855/crypt/debug                                                             8bbc5419-7125-4cb1-b990-436af4bb8eb4   100 GiB   none          gzip-9     
-    oxp_736d4cab-c262-485e-89c2-07e6543f0855/crypt/zone                                                              a34f8204-9f17-4c8f-997b-e122c284ac9f   none      none          off        
+    oxp_736d4cab-c262-485e-89c2-07e6543f0855/crypt/debug                                                             d0f12057-da73-4c1d-bdec-32a0e7ab7107   100 GiB   none          gzip-9     
+    oxp_736d4cab-c262-485e-89c2-07e6543f0855/crypt/zone                                                              0e976e79-fe8c-4189-8a8c-279f42e0290f   none      none          off        
     oxp_736d4cab-c262-485e-89c2-07e6543f0855/crypt/zone/oxz_crucible_65d597c5-86b9-43f6-84cd-67bb108df9f0            6de460bc-890d-4e7a-920f-607862440cfd   none      none          off        
     oxp_8ae56ca0-709d-4b8f-9869-51b62b542eef/crucible                                                                09781292-36f1-4310-82b4-ddfb4d287fa1   none      none          off        
-    oxp_8ae56ca0-709d-4b8f-9869-51b62b542eef/crypt/debug                                                             280dd773-35e2-4dda-ae2a-65c88f1b2a01   100 GiB   none          gzip-9     
-    oxp_8ae56ca0-709d-4b8f-9869-51b62b542eef/crypt/zone                                                              61bf628d-a78d-40a7-bad2-84e97e41b810   none      none          off        
+    oxp_8ae56ca0-709d-4b8f-9869-51b62b542eef/crypt/debug                                                             fecbd83d-7440-4900-b22b-6206e55b2920   100 GiB   none          gzip-9     
+    oxp_8ae56ca0-709d-4b8f-9869-51b62b542eef/crypt/zone                                                              3f63ada8-d1f4-440d-8713-da45b0684520   none      none          off        
     oxp_8ae56ca0-709d-4b8f-9869-51b62b542eef/crypt/zone/oxz_crucible_f00c7a67-51a6-4d09-be39-f20b0e6da1c6            6ff911b9-a4a5-4986-ba04-c6b3f234d3b4   none      none          off        
     oxp_8e0bcc4f-0799-450c-a0ad-80c1637f59e3/crucible                                                                81719897-4ae6-4d76-8282-fda91c347811   none      none          off        
-    oxp_8e0bcc4f-0799-450c-a0ad-80c1637f59e3/crypt/debug                                                             fecbd83d-7440-4900-b22b-6206e55b2920   100 GiB   none          gzip-9     
-    oxp_8e0bcc4f-0799-450c-a0ad-80c1637f59e3/crypt/zone                                                              3f63ada8-d1f4-440d-8713-da45b0684520   none      none          off        
+    oxp_8e0bcc4f-0799-450c-a0ad-80c1637f59e3/crypt/debug                                                             10610f76-51e8-4be4-a4ad-9af953f6bf4a   100 GiB   none          gzip-9     
+    oxp_8e0bcc4f-0799-450c-a0ad-80c1637f59e3/crypt/zone                                                              8c4f4acd-8f6b-4296-81be-12d2eeae0483   none      none          off        
     oxp_8e0bcc4f-0799-450c-a0ad-80c1637f59e3/crypt/zone/oxz_crucible_08330c18-54e9-445b-81f3-8f1d6ad15cdd            ab255226-2c8c-4222-82c6-702af839a2d2   none      none          off        
     oxp_8eeebb8e-6db6-43e8-a429-d26dde99882c/crucible                                                                a2399f57-62eb-4d7d-ac69-09cd6e5c2134   none      none          off        
-    oxp_8eeebb8e-6db6-43e8-a429-d26dde99882c/crypt/debug                                                             e120c8f8-049f-40f0-8d70-4cfe409ef34d   100 GiB   none          gzip-9     
-    oxp_8eeebb8e-6db6-43e8-a429-d26dde99882c/crypt/zone                                                              a3284e6f-ee42-4fdb-8150-634f7f40c073   none      none          off        
+    oxp_8eeebb8e-6db6-43e8-a429-d26dde99882c/crypt/debug                                                             37eb0429-d620-40fb-a57a-62486d001738   100 GiB   none          gzip-9     
+    oxp_8eeebb8e-6db6-43e8-a429-d26dde99882c/crypt/zone                                                              8b7928fb-e5a0-49b0-81d0-89f627020c92   none      none          off        
     oxp_8eeebb8e-6db6-43e8-a429-d26dde99882c/crypt/zone/oxz_crucible_5d296df4-4f2f-4896-8caa-42df00799bcb            25c5034b-83b2-4a90-a08a-7573ffb38119   none      none          off        
     oxp_a3e8de5b-c47a-49c0-b698-4d6955e1327f/crucible                                                                cd6b3952-2024-4310-b82e-abfd245ec1d6   none      none          off        
-    oxp_a3e8de5b-c47a-49c0-b698-4d6955e1327f/crypt/debug                                                             37eb0429-d620-40fb-a57a-62486d001738   100 GiB   none          gzip-9     
-    oxp_a3e8de5b-c47a-49c0-b698-4d6955e1327f/crypt/zone                                                              8b7928fb-e5a0-49b0-81d0-89f627020c92   none      none          off        
+    oxp_a3e8de5b-c47a-49c0-b698-4d6955e1327f/crypt/debug                                                             e0bcc415-f8f9-401f-a507-cee5587756b1   100 GiB   none          gzip-9     
+    oxp_a3e8de5b-c47a-49c0-b698-4d6955e1327f/crypt/zone                                                              f83b1c8d-d252-4b35-a9d2-400e2e2cddf7   none      none          off        
     oxp_a3e8de5b-c47a-49c0-b698-4d6955e1327f/crypt/zone/oxz_crucible_4d84fdb4-76fd-47a9-b033-7e1711d9125f            8dc07059-e8cd-4f89-abc7-0c5289b8ff0a   none      none          off        
     oxp_b32fa3da-4dec-4237-9776-e1a57ba15a21/crucible                                                                4f99dd21-d6ed-409a-af19-9886d1083762   none      none          off        
-    oxp_b32fa3da-4dec-4237-9776-e1a57ba15a21/crypt/debug                                                             d0f12057-da73-4c1d-bdec-32a0e7ab7107   100 GiB   none          gzip-9     
-    oxp_b32fa3da-4dec-4237-9776-e1a57ba15a21/crypt/zone                                                              0e976e79-fe8c-4189-8a8c-279f42e0290f   none      none          off        
+    oxp_b32fa3da-4dec-4237-9776-e1a57ba15a21/crypt/debug                                                             280dd773-35e2-4dda-ae2a-65c88f1b2a01   100 GiB   none          gzip-9     
+    oxp_b32fa3da-4dec-4237-9776-e1a57ba15a21/crypt/zone                                                              61bf628d-a78d-40a7-bad2-84e97e41b810   none      none          off        
     oxp_b32fa3da-4dec-4237-9776-e1a57ba15a21/crypt/zone/oxz_crucible_a9f1d41e-c445-4783-af13-0095b2836f0f            b5d6cec1-c83f-4c41-9e79-8b9bf917f483   none      none          off        
     oxp_e9c238f6-87a3-4087-8ba4-aa594a82d012/crucible                                                                e88d6ff8-6b98-44c1-97a7-83f371ae62fe   none      none          off        
-    oxp_e9c238f6-87a3-4087-8ba4-aa594a82d012/crypt/debug                                                             2288ff91-8e52-4817-825f-2f8b8eb1681d   100 GiB   none          gzip-9     
-    oxp_e9c238f6-87a3-4087-8ba4-aa594a82d012/crypt/zone                                                              f963f2a7-e9d1-4b80-b01a-ff4cecddf867   none      none          off        
+    oxp_e9c238f6-87a3-4087-8ba4-aa594a82d012/crypt/debug                                                             17ffe1be-b38b-4f39-90af-57af25dbfe30   100 GiB   none          gzip-9     
+    oxp_e9c238f6-87a3-4087-8ba4-aa594a82d012/crypt/zone                                                              a15e4260-d48c-4415-9315-c0f29234f359   none      none          off        
     oxp_e9c238f6-87a3-4087-8ba4-aa594a82d012/crypt/zone/oxz_crucible_577b0a64-6fa9-4302-bfaa-853b6e9e71ac            851cd90d-97f5-49b6-ad41-2e1c1faa3cc9   none      none          off        
     oxp_fbf997ef-52d3-438a-b036-b9117322e569/crucible                                                                d6a838c7-3ee9-4cca-9d8b-986b4de0ba1c   none      none          off        
-    oxp_fbf997ef-52d3-438a-b036-b9117322e569/crypt/debug                                                             17ffe1be-b38b-4f39-90af-57af25dbfe30   100 GiB   none          gzip-9     
-    oxp_fbf997ef-52d3-438a-b036-b9117322e569/crypt/zone                                                              a15e4260-d48c-4415-9315-c0f29234f359   none      none          off        
+    oxp_fbf997ef-52d3-438a-b036-b9117322e569/crypt/debug                                                             e120c8f8-049f-40f0-8d70-4cfe409ef34d   100 GiB   none          gzip-9     
+    oxp_fbf997ef-52d3-438a-b036-b9117322e569/crypt/zone                                                              a3284e6f-ee42-4fdb-8150-634f7f40c073   none      none          off        
     oxp_fbf997ef-52d3-438a-b036-b9117322e569/crypt/zone/oxz_crucible_0ba018f0-4ff7-4bcc-a0c7-42cfec6bc9da            ba1a3aae-15ab-4364-8250-54a766331ef8   none      none          off        
 +   oxp_60e6b021-79d6-4a6b-917c-6637e0769558/crypt/clickhouse_keeper                                                 c16a00f5-8830-400d-89e0-9a77cce8780e   none      none          off        
 +   oxp_60e6b021-79d6-4a6b-917c-6637e0769558/crypt/zone/oxz_clickhouse_keeper_f3279a8b-32fa-4426-b946-08aff9ded482   26c79a0e-a2e4-4093-ba43-5e7979609651   none      none          off        
@@ -115,54 +115,54 @@ to:   blueprint  92fa943c-7dd4-48c3-9447-c9d0665744b6
     fake-vendor   fake-model   serial-f635c28a-e5ca-4d22-ac94-d8f278a6ea0e
 
 
-    datasets at generation 2:
+    datasets at generation 3:
     -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
     dataset name                                                                                                     dataset uuid                           quota     reservation   compression
     -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
     oxp_0bf9d028-2b4a-4bff-82a1-6eb5fcefd985/crucible                                                                f3b1d2f6-3cbc-4420-bc91-5eaaf00f85d0   none      none          off        
-    oxp_0bf9d028-2b4a-4bff-82a1-6eb5fcefd985/crypt/debug                                                             fb722d83-ddc2-4880-95a4-1ab12f4b95be   100 GiB   none          gzip-9     
+    oxp_0bf9d028-2b4a-4bff-82a1-6eb5fcefd985/crypt/debug                                                             8005f7c0-bab3-4b0a-9568-a5861c0a09bb   100 GiB   none          gzip-9     
     oxp_0bf9d028-2b4a-4bff-82a1-6eb5fcefd985/crypt/internal_dns                                                      b8af3673-c60a-45fb-adc1-c36d0d325417   none      none          off        
-    oxp_0bf9d028-2b4a-4bff-82a1-6eb5fcefd985/crypt/zone                                                              1ab5529e-c3db-41e1-a561-9c767f980ad4   none      none          off        
+    oxp_0bf9d028-2b4a-4bff-82a1-6eb5fcefd985/crypt/zone                                                              a647238a-1689-46c9-b680-dfe1b7b68684   none      none          off        
     oxp_0bf9d028-2b4a-4bff-82a1-6eb5fcefd985/crypt/zone/oxz_crucible_aa74c1b2-b4c1-4f36-8f01-9459ef23786b            e1db255d-4793-46bd-a1f3-f207be6b2839   none      none          off        
     oxp_0bf9d028-2b4a-4bff-82a1-6eb5fcefd985/crypt/zone/oxz_crucible_pantry_97a785b8-d909-4fd4-92c1-9ba14bae603b     7b248682-95a2-4411-98b3-79fe6cb1a857   none      none          off        
     oxp_0bf9d028-2b4a-4bff-82a1-6eb5fcefd985/crypt/zone/oxz_internal_dns_c259e8b9-1086-453a-8636-050639edeffb        30161ca3-c2d8-474b-906e-bd38fc912f84   none      none          off        
     oxp_0bf9d028-2b4a-4bff-82a1-6eb5fcefd985/crypt/zone/oxz_nexus_c3c7b0bd-dce3-467b-919d-668cc6b06711               05b6bbbe-4c07-493e-8b92-4c8d4aeb1d66   none      none          off        
     oxp_0bf9d028-2b4a-4bff-82a1-6eb5fcefd985/crypt/zone/oxz_ntp_bba31b23-d112-4cde-bd4a-635812c28c0e                 fadbc503-b72d-4862-a1fd-628c7ff599d1   none      none          off        
     oxp_19293a1d-fddc-40a7-88a4-ccafdb6f66d3/crucible                                                                276f044e-dd34-4c1e-beef-174da4fcf53d   none      none          off        
-    oxp_19293a1d-fddc-40a7-88a4-ccafdb6f66d3/crypt/debug                                                             891a1ff4-66b1-4dc9-871c-be4a757bbd0f   100 GiB   none          gzip-9     
-    oxp_19293a1d-fddc-40a7-88a4-ccafdb6f66d3/crypt/zone                                                              68490e52-279a-4609-ba0b-11d03f904c88   none      none          off        
+    oxp_19293a1d-fddc-40a7-88a4-ccafdb6f66d3/crypt/debug                                                             98d65e73-01df-4525-a45d-acb2fc8d4a74   100 GiB   none          gzip-9     
+    oxp_19293a1d-fddc-40a7-88a4-ccafdb6f66d3/crypt/zone                                                              39714005-313e-42be-90eb-000a0560669f   none      none          off        
     oxp_19293a1d-fddc-40a7-88a4-ccafdb6f66d3/crypt/zone/oxz_crucible_eb58427d-599b-45dc-b316-8e4db7eec65e            26722393-82bf-442d-9725-030801a4d64c   none      none          off        
     oxp_44484c44-477a-4676-8266-b98a00e80d79/crucible                                                                e06b1670-5f34-42dc-a410-3129d69907ec   none      none          off        
-    oxp_44484c44-477a-4676-8266-b98a00e80d79/crypt/debug                                                             3e3e18ad-d527-4b2e-b758-1eefdcfca44b   100 GiB   none          gzip-9     
-    oxp_44484c44-477a-4676-8266-b98a00e80d79/crypt/zone                                                              2a5e3a10-6ab5-4988-be84-46b527dc2d23   none      none          off        
+    oxp_44484c44-477a-4676-8266-b98a00e80d79/crypt/debug                                                             6cea3508-8341-4093-abbb-c57d83cd87b4   100 GiB   none          gzip-9     
+    oxp_44484c44-477a-4676-8266-b98a00e80d79/crypt/zone                                                              e49915c6-59ed-4bbe-abf9-375b9502772a   none      none          off        
     oxp_44484c44-477a-4676-8266-b98a00e80d79/crypt/zone/oxz_crucible_487bde8c-a692-416c-be70-efef7f169fce            008ba9b6-8d41-4f7a-8ff3-ec31a0c96cf9   none      none          off        
     oxp_79787cd4-92da-4de5-bfd8-30a635521e10/crucible                                                                9d32dd45-e3ee-47b9-ba69-0dc711bbf632   none      none          off        
-    oxp_79787cd4-92da-4de5-bfd8-30a635521e10/crypt/debug                                                             bd4efdbe-7128-4423-aacf-6cf35e5a914d   100 GiB   none          gzip-9     
-    oxp_79787cd4-92da-4de5-bfd8-30a635521e10/crypt/zone                                                              fd0f9778-c31a-40f4-9ce9-f5154535e75b   none      none          off        
+    oxp_79787cd4-92da-4de5-bfd8-30a635521e10/crypt/debug                                                             dae242d1-9535-4b08-b249-f030dde2c2fd   100 GiB   none          gzip-9     
+    oxp_79787cd4-92da-4de5-bfd8-30a635521e10/crypt/zone                                                              29038bb0-9af1-4b03-9c10-b8a6444a0bc2   none      none          off        
     oxp_79787cd4-92da-4de5-bfd8-30a635521e10/crypt/zone/oxz_crucible_b6956e34-3c21-44d1-9ee2-cb7ee2e77c4e            2d2f2665-d556-4e65-9c53-d7fe573848a2   none      none          off        
     oxp_9ae94c94-baae-477e-912a-60f0c4f3bd13/crucible                                                                7e72090d-7f79-4ecc-92cc-5eb7d9dee022   none      none          off        
     oxp_9ae94c94-baae-477e-912a-60f0c4f3bd13/crypt/debug                                                             708d4e8b-3acf-44cf-87a2-275bb8fa0d96   100 GiB   none          gzip-9     
     oxp_9ae94c94-baae-477e-912a-60f0c4f3bd13/crypt/zone                                                              e4220797-15df-42c4-9df7-ad927711d565   none      none          off        
     oxp_9ae94c94-baae-477e-912a-60f0c4f3bd13/crypt/zone/oxz_crucible_41af4ef6-d21b-4271-bfcb-524f4146784a            1522207b-ea98-47cc-810c-44808796d743   none      none          off        
     oxp_af85eec8-36b3-4b88-966d-a717b9b58fe5/crucible                                                                43606b8e-384f-4412-a273-d4dde8f2e76d   none      none          off        
-    oxp_af85eec8-36b3-4b88-966d-a717b9b58fe5/crypt/debug                                                             98d65e73-01df-4525-a45d-acb2fc8d4a74   100 GiB   none          gzip-9     
-    oxp_af85eec8-36b3-4b88-966d-a717b9b58fe5/crypt/zone                                                              39714005-313e-42be-90eb-000a0560669f   none      none          off        
+    oxp_af85eec8-36b3-4b88-966d-a717b9b58fe5/crypt/debug                                                             765b4728-8d6e-4fac-9a1b-ae2258d5c52b   100 GiB   none          gzip-9     
+    oxp_af85eec8-36b3-4b88-966d-a717b9b58fe5/crypt/zone                                                              fc9765c5-0a89-4050-ba3e-e0625dbefb5f   none      none          off        
     oxp_af85eec8-36b3-4b88-966d-a717b9b58fe5/crypt/zone/oxz_crucible_26115267-8333-4711-924e-d05acf601827            3a39d5e8-ea73-4cf3-b9de-48045475151c   none      none          off        
     oxp_ddfaaba3-dafe-4103-b868-e9843d29d346/crucible                                                                2d7145e9-0029-4ae0-bb12-ee65a1738005   none      none          off        
-    oxp_ddfaaba3-dafe-4103-b868-e9843d29d346/crypt/debug                                                             8005f7c0-bab3-4b0a-9568-a5861c0a09bb   100 GiB   none          gzip-9     
-    oxp_ddfaaba3-dafe-4103-b868-e9843d29d346/crypt/zone                                                              a647238a-1689-46c9-b680-dfe1b7b68684   none      none          off        
+    oxp_ddfaaba3-dafe-4103-b868-e9843d29d346/crypt/debug                                                             bd4efdbe-7128-4423-aacf-6cf35e5a914d   100 GiB   none          gzip-9     
+    oxp_ddfaaba3-dafe-4103-b868-e9843d29d346/crypt/zone                                                              fd0f9778-c31a-40f4-9ce9-f5154535e75b   none      none          off        
     oxp_ddfaaba3-dafe-4103-b868-e9843d29d346/crypt/zone/oxz_crucible_1a92bb17-6477-46fc-9784-1d2a418d6e14            257c57cd-8f2c-440d-9fa0-e92a312295ec   none      none          off        
     oxp_ec458c3e-91ca-40f1-a2a3-3f4292c1f279/crucible                                                                dfadcc38-505a-4e9b-8674-27f8a2af13a2   none      none          off        
-    oxp_ec458c3e-91ca-40f1-a2a3-3f4292c1f279/crypt/debug                                                             dae242d1-9535-4b08-b249-f030dde2c2fd   100 GiB   none          gzip-9     
-    oxp_ec458c3e-91ca-40f1-a2a3-3f4292c1f279/crypt/zone                                                              29038bb0-9af1-4b03-9c10-b8a6444a0bc2   none      none          off        
+    oxp_ec458c3e-91ca-40f1-a2a3-3f4292c1f279/crypt/debug                                                             3e3e18ad-d527-4b2e-b758-1eefdcfca44b   100 GiB   none          gzip-9     
+    oxp_ec458c3e-91ca-40f1-a2a3-3f4292c1f279/crypt/zone                                                              2a5e3a10-6ab5-4988-be84-46b527dc2d23   none      none          off        
     oxp_ec458c3e-91ca-40f1-a2a3-3f4292c1f279/crypt/zone/oxz_crucible_9b9d58bd-44e6-4b70-80a4-e6a9262893ff            0a5bade3-3f2f-4385-b064-554b56f8bf8c   none      none          off        
     oxp_f2fc7c4c-7966-449d-8ec3-5a70f460501d/crucible                                                                72e2a1d6-09dd-43ba-9b8b-befa101f53ef   none      none          off        
-    oxp_f2fc7c4c-7966-449d-8ec3-5a70f460501d/crypt/debug                                                             6cea3508-8341-4093-abbb-c57d83cd87b4   100 GiB   none          gzip-9     
-    oxp_f2fc7c4c-7966-449d-8ec3-5a70f460501d/crypt/zone                                                              e49915c6-59ed-4bbe-abf9-375b9502772a   none      none          off        
+    oxp_f2fc7c4c-7966-449d-8ec3-5a70f460501d/crypt/debug                                                             fb722d83-ddc2-4880-95a4-1ab12f4b95be   100 GiB   none          gzip-9     
+    oxp_f2fc7c4c-7966-449d-8ec3-5a70f460501d/crypt/zone                                                              1ab5529e-c3db-41e1-a561-9c767f980ad4   none      none          off        
     oxp_f2fc7c4c-7966-449d-8ec3-5a70f460501d/crypt/zone/oxz_crucible_704a17e0-bc9d-43b9-a91e-b1ca37a23d0d            5739948f-d984-48a5-a27a-0223a0af2035   none      none          off        
     oxp_f635c28a-e5ca-4d22-ac94-d8f278a6ea0e/crucible                                                                c7dfbe25-5b52-4ee5-8556-719e99bb5e4d   none      none          off        
-    oxp_f635c28a-e5ca-4d22-ac94-d8f278a6ea0e/crypt/debug                                                             765b4728-8d6e-4fac-9a1b-ae2258d5c52b   100 GiB   none          gzip-9     
-    oxp_f635c28a-e5ca-4d22-ac94-d8f278a6ea0e/crypt/zone                                                              fc9765c5-0a89-4050-ba3e-e0625dbefb5f   none      none          off        
+    oxp_f635c28a-e5ca-4d22-ac94-d8f278a6ea0e/crypt/debug                                                             891a1ff4-66b1-4dc9-871c-be4a757bbd0f   100 GiB   none          gzip-9     
+    oxp_f635c28a-e5ca-4d22-ac94-d8f278a6ea0e/crypt/zone                                                              68490e52-279a-4609-ba0b-11d03f904c88   none      none          off        
     oxp_f635c28a-e5ca-4d22-ac94-d8f278a6ea0e/crypt/zone/oxz_crucible_93535f54-4919-4c4d-9a07-f7ab6245c01f            109f44de-d1ed-4ce3-9670-76aceb206ee4   none      none          off        
 +   oxp_0bf9d028-2b4a-4bff-82a1-6eb5fcefd985/crypt/clickhouse_keeper                                                 a3eed313-d886-4c1d-8023-8d2ec9e97ddd   none      none          off        
 +   oxp_0bf9d028-2b4a-4bff-82a1-6eb5fcefd985/crypt/clickhouse_server                                                 886f2522-8122-465f-8996-2d8c2acd9d0d   none      none          off        
@@ -210,54 +210,54 @@ to:   blueprint  92fa943c-7dd4-48c3-9447-c9d0665744b6
     fake-vendor   fake-model   serial-e3b45593-8f0c-47b2-a381-802a7dad1f54
 
 
-    datasets at generation 2:
+    datasets at generation 3:
     -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
     dataset name                                                                                                     dataset uuid                           quota     reservation   compression
     -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
     oxp_2a76ab1a-fb16-412d-93f9-b8cd9aa94e85/crucible                                                                431cfe4a-5756-40f4-8a9c-b70ae1227f1e   none      none          off        
-    oxp_2a76ab1a-fb16-412d-93f9-b8cd9aa94e85/crypt/debug                                                             c55ba154-4f4b-48a5-997b-2a1579671c74   100 GiB   none          gzip-9     
+    oxp_2a76ab1a-fb16-412d-93f9-b8cd9aa94e85/crypt/debug                                                             dd239ff5-a617-4eb1-ac6d-16eb76c2c849   100 GiB   none          gzip-9     
     oxp_2a76ab1a-fb16-412d-93f9-b8cd9aa94e85/crypt/internal_dns                                                      7be88e8f-06d3-49f7-a6d9-5c586f13716c   none      none          off        
-    oxp_2a76ab1a-fb16-412d-93f9-b8cd9aa94e85/crypt/zone                                                              37405860-deb4-4f2f-b770-ab8b83175d8c   none      none          off        
+    oxp_2a76ab1a-fb16-412d-93f9-b8cd9aa94e85/crypt/zone                                                              5c620f9c-454b-451b-99ca-47c3d94df493   none      none          off        
     oxp_2a76ab1a-fb16-412d-93f9-b8cd9aa94e85/crypt/zone/oxz_crucible_75cccfab-ea70-4596-a685-ab9bd5e540a1            e2ff081e-c5a4-42c3-8d95-969e2b9b7b31   none      none          off        
     oxp_2a76ab1a-fb16-412d-93f9-b8cd9aa94e85/crypt/zone/oxz_crucible_pantry_1432df56-4a7b-4271-9b24-a8a3183a95a7     452dad91-0c11-4dfa-96fb-dfb0cfa1d17c   none      none          off        
     oxp_2a76ab1a-fb16-412d-93f9-b8cd9aa94e85/crypt/zone/oxz_internal_dns_832c71a1-357d-482b-8661-3193d59ed776        08588a53-0f1d-4631-a1ef-8fa34098fbf6   none      none          off        
     oxp_2a76ab1a-fb16-412d-93f9-b8cd9aa94e85/crypt/zone/oxz_nexus_da39dead-64e2-45b6-9d01-d99584504dfd               45dc03ec-d0e0-429a-a099-7fc6ea6dfb85   none      none          off        
     oxp_2a76ab1a-fb16-412d-93f9-b8cd9aa94e85/crypt/zone/oxz_ntp_816afef9-e5cd-40ba-8cc5-71e783943e43                 6f5ba0fc-1b43-4a40-ba5a-3abf11eae62b   none      none          off        
     oxp_2de2bf7e-c679-4b2b-b373-908e9d3ffbfc/crucible                                                                1123f86b-169c-40df-8ed1-95c3def65e30   none      none          off        
-    oxp_2de2bf7e-c679-4b2b-b373-908e9d3ffbfc/crypt/debug                                                             071d678d-9376-4c3b-8e1f-825d27bcae3a   100 GiB   none          gzip-9     
-    oxp_2de2bf7e-c679-4b2b-b373-908e9d3ffbfc/crypt/zone                                                              bbb78481-c7e5-44a6-85ae-37e363827e9f   none      none          off        
+    oxp_2de2bf7e-c679-4b2b-b373-908e9d3ffbfc/crypt/debug                                                             f2df23eb-672a-41b5-89e4-26c9feb50c7c   100 GiB   none          gzip-9     
+    oxp_2de2bf7e-c679-4b2b-b373-908e9d3ffbfc/crypt/zone                                                              2747bb48-2fb7-4999-a63c-5ba5e35e0a10   none      none          off        
     oxp_2de2bf7e-c679-4b2b-b373-908e9d3ffbfc/crypt/zone/oxz_crucible_37c72edc-6acd-4c2d-ab76-d1c88e1f01f5            9b49fc13-4d2c-423e-9839-f6e1d0bffc6e   none      none          off        
     oxp_2f02a5c6-fcf5-4b5a-bc7d-7f65369918ba/crucible                                                                afa41d1a-3fc1-4723-835d-61d13db33cfe   none      none          off        
-    oxp_2f02a5c6-fcf5-4b5a-bc7d-7f65369918ba/crypt/debug                                                             daeded95-0145-4b97-b1fb-60d44856d1e4   100 GiB   none          gzip-9     
-    oxp_2f02a5c6-fcf5-4b5a-bc7d-7f65369918ba/crypt/zone                                                              38103edf-a98f-46ca-94ea-3404268ea935   none      none          off        
+    oxp_2f02a5c6-fcf5-4b5a-bc7d-7f65369918ba/crypt/debug                                                             b9e71882-7f71-4a5e-be9c-7df560c75000   100 GiB   none          gzip-9     
+    oxp_2f02a5c6-fcf5-4b5a-bc7d-7f65369918ba/crypt/zone                                                              13f8be82-85e9-43ac-985b-e7a51a910c41   none      none          off        
     oxp_2f02a5c6-fcf5-4b5a-bc7d-7f65369918ba/crypt/zone/oxz_crucible_2cb036bd-6056-4547-af65-aa6c0c1e4d6e            c6c9e491-ce4d-4dc4-82be-e394fa1e82e2   none      none          off        
     oxp_32041dbf-e58d-4f32-840d-923d3d3b68af/crucible                                                                da067282-0ae9-4861-8b78-b639622508af   none      none          off        
-    oxp_32041dbf-e58d-4f32-840d-923d3d3b68af/crypt/debug                                                             80d0697d-4ebe-4856-b7bf-78ff811eb00b   100 GiB   none          gzip-9     
-    oxp_32041dbf-e58d-4f32-840d-923d3d3b68af/crypt/zone                                                              3f1adfcf-9a2a-41db-9e1a-a2e13ff8a7dd   none      none          off        
+    oxp_32041dbf-e58d-4f32-840d-923d3d3b68af/crypt/debug                                                             96798a17-be94-44bb-9e12-2eb458e9a5ba   100 GiB   none          gzip-9     
+    oxp_32041dbf-e58d-4f32-840d-923d3d3b68af/crypt/zone                                                              64e62d15-e813-461d-9a50-403d9bd1df7c   none      none          off        
     oxp_32041dbf-e58d-4f32-840d-923d3d3b68af/crypt/zone/oxz_crucible_e52381c1-d7ab-402f-a9a8-bb52fbb614af            a0251fdc-166b-4476-95d4-f7fd58fdaf76   none      none          off        
     oxp_5f88adff-bb50-4dc1-bbfb-5a410c753ed5/crucible                                                                fcb937be-3b91-4ae7-9e25-a69808eeb07f   none      none          off        
-    oxp_5f88adff-bb50-4dc1-bbfb-5a410c753ed5/crypt/debug                                                             dd239ff5-a617-4eb1-ac6d-16eb76c2c849   100 GiB   none          gzip-9     
-    oxp_5f88adff-bb50-4dc1-bbfb-5a410c753ed5/crypt/zone                                                              5c620f9c-454b-451b-99ca-47c3d94df493   none      none          off        
+    oxp_5f88adff-bb50-4dc1-bbfb-5a410c753ed5/crypt/debug                                                             daeded95-0145-4b97-b1fb-60d44856d1e4   100 GiB   none          gzip-9     
+    oxp_5f88adff-bb50-4dc1-bbfb-5a410c753ed5/crypt/zone                                                              38103edf-a98f-46ca-94ea-3404268ea935   none      none          off        
     oxp_5f88adff-bb50-4dc1-bbfb-5a410c753ed5/crypt/zone/oxz_crucible_6ae471b1-1dd8-460e-a2a5-3ea796f746d5            98b66132-d99e-42e2-8517-5860412c61b1   none      none          off        
     oxp_74d64eb9-bf69-4782-af16-2d3a761ca171/crucible                                                                2854cb42-e5b9-4773-bd6e-6ec85d33a174   none      none          off        
-    oxp_74d64eb9-bf69-4782-af16-2d3a761ca171/crypt/debug                                                             b9e71882-7f71-4a5e-be9c-7df560c75000   100 GiB   none          gzip-9     
-    oxp_74d64eb9-bf69-4782-af16-2d3a761ca171/crypt/zone                                                              13f8be82-85e9-43ac-985b-e7a51a910c41   none      none          off        
+    oxp_74d64eb9-bf69-4782-af16-2d3a761ca171/crypt/debug                                                             80d0697d-4ebe-4856-b7bf-78ff811eb00b   100 GiB   none          gzip-9     
+    oxp_74d64eb9-bf69-4782-af16-2d3a761ca171/crypt/zone                                                              3f1adfcf-9a2a-41db-9e1a-a2e13ff8a7dd   none      none          off        
     oxp_74d64eb9-bf69-4782-af16-2d3a761ca171/crypt/zone/oxz_crucible_b6a9674e-8b42-4d67-954f-3e957db298dd            e7c2d833-b6a1-469f-b52f-8bbb45e9a30e   none      none          off        
     oxp_b3c231c9-b2a5-4267-b4bf-9651881b91a5/crucible                                                                aa8f925e-6c3a-40d2-ae2d-946324a7d612   none      none          off        
-    oxp_b3c231c9-b2a5-4267-b4bf-9651881b91a5/crypt/debug                                                             bae0ee1b-b3a3-4c4c-96ee-53b8b4cd837b   100 GiB   none          gzip-9     
-    oxp_b3c231c9-b2a5-4267-b4bf-9651881b91a5/crypt/zone                                                              9f1f99c7-e6c5-4bbc-9de5-15252b532914   none      none          off        
+    oxp_b3c231c9-b2a5-4267-b4bf-9651881b91a5/crypt/debug                                                             c55ba154-4f4b-48a5-997b-2a1579671c74   100 GiB   none          gzip-9     
+    oxp_b3c231c9-b2a5-4267-b4bf-9651881b91a5/crypt/zone                                                              37405860-deb4-4f2f-b770-ab8b83175d8c   none      none          off        
     oxp_b3c231c9-b2a5-4267-b4bf-9651881b91a5/crypt/zone/oxz_crucible_c79e017b-7e27-4ff5-be14-3673f8cb2279            3544adde-a808-45c0-ae19-08b4f65e3ad4   none      none          off        
     oxp_bca80b95-8dca-4a3b-b24d-d44b6a9ff71b/crucible                                                                755ad19c-d29b-4e3c-9c13-63b56a407765   none      none          off        
-    oxp_bca80b95-8dca-4a3b-b24d-d44b6a9ff71b/crypt/debug                                                             f2df23eb-672a-41b5-89e4-26c9feb50c7c   100 GiB   none          gzip-9     
-    oxp_bca80b95-8dca-4a3b-b24d-d44b6a9ff71b/crypt/zone                                                              2747bb48-2fb7-4999-a63c-5ba5e35e0a10   none      none          off        
+    oxp_bca80b95-8dca-4a3b-b24d-d44b6a9ff71b/crypt/debug                                                             e658be5b-df77-41fb-a000-5a924ac0b3da   100 GiB   none          gzip-9     
+    oxp_bca80b95-8dca-4a3b-b24d-d44b6a9ff71b/crypt/zone                                                              f7ddacf4-edc7-46ba-9b74-d588bd62505e   none      none          off        
     oxp_bca80b95-8dca-4a3b-b24d-d44b6a9ff71b/crypt/zone/oxz_crucible_0a160b89-6288-44f5-9908-33589094628e            53a623d2-9ffc-48fb-871d-23bd52e0f4dd   none      none          off        
     oxp_db16345e-427a-4c8e-9032-17270f729308/crucible                                                                be3cf2f7-5388-4cd6-8119-ecf316c6052e   none      none          off        
-    oxp_db16345e-427a-4c8e-9032-17270f729308/crypt/debug                                                             e658be5b-df77-41fb-a000-5a924ac0b3da   100 GiB   none          gzip-9     
-    oxp_db16345e-427a-4c8e-9032-17270f729308/crypt/zone                                                              f7ddacf4-edc7-46ba-9b74-d588bd62505e   none      none          off        
+    oxp_db16345e-427a-4c8e-9032-17270f729308/crypt/debug                                                             071d678d-9376-4c3b-8e1f-825d27bcae3a   100 GiB   none          gzip-9     
+    oxp_db16345e-427a-4c8e-9032-17270f729308/crypt/zone                                                              bbb78481-c7e5-44a6-85ae-37e363827e9f   none      none          off        
     oxp_db16345e-427a-4c8e-9032-17270f729308/crypt/zone/oxz_crucible_5fb4b72f-bf1b-47c7-a2e4-dbdafcdb47f5            1d73fc1f-81fc-4e06-9b52-686596ac0f6c   none      none          off        
     oxp_e3b45593-8f0c-47b2-a381-802a7dad1f54/crucible                                                                a2391107-7408-4e0c-a694-3fd073fa09df   none      none          off        
-    oxp_e3b45593-8f0c-47b2-a381-802a7dad1f54/crypt/debug                                                             96798a17-be94-44bb-9e12-2eb458e9a5ba   100 GiB   none          gzip-9     
-    oxp_e3b45593-8f0c-47b2-a381-802a7dad1f54/crypt/zone                                                              64e62d15-e813-461d-9a50-403d9bd1df7c   none      none          off        
+    oxp_e3b45593-8f0c-47b2-a381-802a7dad1f54/crypt/debug                                                             bae0ee1b-b3a3-4c4c-96ee-53b8b4cd837b   100 GiB   none          gzip-9     
+    oxp_e3b45593-8f0c-47b2-a381-802a7dad1f54/crypt/zone                                                              9f1f99c7-e6c5-4bbc-9de5-15252b532914   none      none          off        
     oxp_e3b45593-8f0c-47b2-a381-802a7dad1f54/crypt/zone/oxz_crucible_8a36ef67-bf66-40b9-a2f4-34ac70e90e39            c44e20e1-7cce-46df-ba71-db7fb3e3a5ff   none      none          off        
 +   oxp_2a76ab1a-fb16-412d-93f9-b8cd9aa94e85/crypt/clickhouse_keeper                                                 ce930007-8ed6-4675-a24a-57c227950d43   none      none          off        
 +   oxp_2a76ab1a-fb16-412d-93f9-b8cd9aa94e85/crypt/clickhouse_server                                                 3d339942-c2d0-4615-a099-433a8b5a1543   none      none          off        

--- a/nexus/reconfigurator/planning/tests/output/planner_deploy_all_keeper_nodes_5_6.txt
+++ b/nexus/reconfigurator/planning/tests/output/planner_deploy_all_keeper_nodes_5_6.txt
@@ -21,16 +21,16 @@ to:   blueprint cb39be9d-5476-44fa-9edf-9938376219ef
     fake-vendor   fake-model   serial-fbf997ef-52d3-438a-b036-b9117322e569
 
 
-    datasets at generation 2:
+    datasets at generation 3:
     -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
     dataset name                                                                                                     dataset uuid                           quota     reservation   compression
     -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
     oxp_60e6b021-79d6-4a6b-917c-6637e0769558/crucible                                                                fcd7e842-2648-407a-8d13-197e67de9e9d   none      none          off        
     oxp_60e6b021-79d6-4a6b-917c-6637e0769558/crypt/clickhouse                                                        5cb56dc7-6c56-4bbf-ae73-6f08e0c97cdf   none      none          off        
     oxp_60e6b021-79d6-4a6b-917c-6637e0769558/crypt/clickhouse_keeper                                                 c16a00f5-8830-400d-89e0-9a77cce8780e   none      none          off        
-    oxp_60e6b021-79d6-4a6b-917c-6637e0769558/crypt/debug                                                             10610f76-51e8-4be4-a4ad-9af953f6bf4a   100 GiB   none          gzip-9     
+    oxp_60e6b021-79d6-4a6b-917c-6637e0769558/crypt/debug                                                             8bbc5419-7125-4cb1-b990-436af4bb8eb4   100 GiB   none          gzip-9     
     oxp_60e6b021-79d6-4a6b-917c-6637e0769558/crypt/internal_dns                                                      dd467397-efc5-4738-984e-77a0f3e3e678   none      none          off        
-    oxp_60e6b021-79d6-4a6b-917c-6637e0769558/crypt/zone                                                              8c4f4acd-8f6b-4296-81be-12d2eeae0483   none      none          off        
+    oxp_60e6b021-79d6-4a6b-917c-6637e0769558/crypt/zone                                                              a34f8204-9f17-4c8f-997b-e122c284ac9f   none      none          off        
     oxp_60e6b021-79d6-4a6b-917c-6637e0769558/crypt/zone/oxz_clickhouse_df79db1e-54ca-4048-b22a-da120ae4c8c4          b6cb0fe9-0b7a-4793-b6cd-1ee71fee464c   none      none          off        
     oxp_60e6b021-79d6-4a6b-917c-6637e0769558/crypt/zone/oxz_clickhouse_keeper_f3279a8b-32fa-4426-b946-08aff9ded482   26c79a0e-a2e4-4093-ba43-5e7979609651   none      none          off        
     oxp_60e6b021-79d6-4a6b-917c-6637e0769558/crypt/zone/oxz_crucible_1e485cda-b36e-4647-9125-c273fc7a9850            65c2e3cd-3d8e-43c6-9e2c-cb884511ec49   none      none          off        
@@ -39,40 +39,40 @@ to:   blueprint cb39be9d-5476-44fa-9edf-9938376219ef
     oxp_60e6b021-79d6-4a6b-917c-6637e0769558/crypt/zone/oxz_nexus_a6032c9e-a365-45d7-ad9f-07ac0fa7079a               198ff957-cce0-40cf-9048-f65cf9a6c671   none      none          off        
     oxp_60e6b021-79d6-4a6b-917c-6637e0769558/crypt/zone/oxz_ntp_66695827-17c4-4885-b6c0-2cb6b6d3ad1c                 ccfb112d-c72e-4482-9bb0-f9cbbb034f7d   none      none          off        
     oxp_71a07ac0-d24e-446c-a202-1998e7f6ac8c/crucible                                                                c770de28-6c33-4cc7-97d9-62ddafd963aa   none      none          off        
-    oxp_71a07ac0-d24e-446c-a202-1998e7f6ac8c/crypt/debug                                                             e0bcc415-f8f9-401f-a507-cee5587756b1   100 GiB   none          gzip-9     
-    oxp_71a07ac0-d24e-446c-a202-1998e7f6ac8c/crypt/zone                                                              f83b1c8d-d252-4b35-a9d2-400e2e2cddf7   none      none          off        
+    oxp_71a07ac0-d24e-446c-a202-1998e7f6ac8c/crypt/debug                                                             2288ff91-8e52-4817-825f-2f8b8eb1681d   100 GiB   none          gzip-9     
+    oxp_71a07ac0-d24e-446c-a202-1998e7f6ac8c/crypt/zone                                                              f963f2a7-e9d1-4b80-b01a-ff4cecddf867   none      none          off        
     oxp_71a07ac0-d24e-446c-a202-1998e7f6ac8c/crypt/zone/oxz_crucible_e9ab813f-0fff-4b41-a101-790f6d94b40a            7c459b4e-396b-497f-8094-f342939d1f9f   none      none          off        
     oxp_736d4cab-c262-485e-89c2-07e6543f0855/crucible                                                                ac9f4d69-3281-4774-a098-250755079068   none      none          off        
-    oxp_736d4cab-c262-485e-89c2-07e6543f0855/crypt/debug                                                             8bbc5419-7125-4cb1-b990-436af4bb8eb4   100 GiB   none          gzip-9     
-    oxp_736d4cab-c262-485e-89c2-07e6543f0855/crypt/zone                                                              a34f8204-9f17-4c8f-997b-e122c284ac9f   none      none          off        
+    oxp_736d4cab-c262-485e-89c2-07e6543f0855/crypt/debug                                                             d0f12057-da73-4c1d-bdec-32a0e7ab7107   100 GiB   none          gzip-9     
+    oxp_736d4cab-c262-485e-89c2-07e6543f0855/crypt/zone                                                              0e976e79-fe8c-4189-8a8c-279f42e0290f   none      none          off        
     oxp_736d4cab-c262-485e-89c2-07e6543f0855/crypt/zone/oxz_crucible_65d597c5-86b9-43f6-84cd-67bb108df9f0            6de460bc-890d-4e7a-920f-607862440cfd   none      none          off        
     oxp_8ae56ca0-709d-4b8f-9869-51b62b542eef/crucible                                                                09781292-36f1-4310-82b4-ddfb4d287fa1   none      none          off        
-    oxp_8ae56ca0-709d-4b8f-9869-51b62b542eef/crypt/debug                                                             280dd773-35e2-4dda-ae2a-65c88f1b2a01   100 GiB   none          gzip-9     
-    oxp_8ae56ca0-709d-4b8f-9869-51b62b542eef/crypt/zone                                                              61bf628d-a78d-40a7-bad2-84e97e41b810   none      none          off        
+    oxp_8ae56ca0-709d-4b8f-9869-51b62b542eef/crypt/debug                                                             fecbd83d-7440-4900-b22b-6206e55b2920   100 GiB   none          gzip-9     
+    oxp_8ae56ca0-709d-4b8f-9869-51b62b542eef/crypt/zone                                                              3f63ada8-d1f4-440d-8713-da45b0684520   none      none          off        
     oxp_8ae56ca0-709d-4b8f-9869-51b62b542eef/crypt/zone/oxz_crucible_f00c7a67-51a6-4d09-be39-f20b0e6da1c6            6ff911b9-a4a5-4986-ba04-c6b3f234d3b4   none      none          off        
     oxp_8e0bcc4f-0799-450c-a0ad-80c1637f59e3/crucible                                                                81719897-4ae6-4d76-8282-fda91c347811   none      none          off        
-    oxp_8e0bcc4f-0799-450c-a0ad-80c1637f59e3/crypt/debug                                                             fecbd83d-7440-4900-b22b-6206e55b2920   100 GiB   none          gzip-9     
-    oxp_8e0bcc4f-0799-450c-a0ad-80c1637f59e3/crypt/zone                                                              3f63ada8-d1f4-440d-8713-da45b0684520   none      none          off        
+    oxp_8e0bcc4f-0799-450c-a0ad-80c1637f59e3/crypt/debug                                                             10610f76-51e8-4be4-a4ad-9af953f6bf4a   100 GiB   none          gzip-9     
+    oxp_8e0bcc4f-0799-450c-a0ad-80c1637f59e3/crypt/zone                                                              8c4f4acd-8f6b-4296-81be-12d2eeae0483   none      none          off        
     oxp_8e0bcc4f-0799-450c-a0ad-80c1637f59e3/crypt/zone/oxz_crucible_08330c18-54e9-445b-81f3-8f1d6ad15cdd            ab255226-2c8c-4222-82c6-702af839a2d2   none      none          off        
     oxp_8eeebb8e-6db6-43e8-a429-d26dde99882c/crucible                                                                a2399f57-62eb-4d7d-ac69-09cd6e5c2134   none      none          off        
-    oxp_8eeebb8e-6db6-43e8-a429-d26dde99882c/crypt/debug                                                             e120c8f8-049f-40f0-8d70-4cfe409ef34d   100 GiB   none          gzip-9     
-    oxp_8eeebb8e-6db6-43e8-a429-d26dde99882c/crypt/zone                                                              a3284e6f-ee42-4fdb-8150-634f7f40c073   none      none          off        
+    oxp_8eeebb8e-6db6-43e8-a429-d26dde99882c/crypt/debug                                                             37eb0429-d620-40fb-a57a-62486d001738   100 GiB   none          gzip-9     
+    oxp_8eeebb8e-6db6-43e8-a429-d26dde99882c/crypt/zone                                                              8b7928fb-e5a0-49b0-81d0-89f627020c92   none      none          off        
     oxp_8eeebb8e-6db6-43e8-a429-d26dde99882c/crypt/zone/oxz_crucible_5d296df4-4f2f-4896-8caa-42df00799bcb            25c5034b-83b2-4a90-a08a-7573ffb38119   none      none          off        
     oxp_a3e8de5b-c47a-49c0-b698-4d6955e1327f/crucible                                                                cd6b3952-2024-4310-b82e-abfd245ec1d6   none      none          off        
-    oxp_a3e8de5b-c47a-49c0-b698-4d6955e1327f/crypt/debug                                                             37eb0429-d620-40fb-a57a-62486d001738   100 GiB   none          gzip-9     
-    oxp_a3e8de5b-c47a-49c0-b698-4d6955e1327f/crypt/zone                                                              8b7928fb-e5a0-49b0-81d0-89f627020c92   none      none          off        
+    oxp_a3e8de5b-c47a-49c0-b698-4d6955e1327f/crypt/debug                                                             e0bcc415-f8f9-401f-a507-cee5587756b1   100 GiB   none          gzip-9     
+    oxp_a3e8de5b-c47a-49c0-b698-4d6955e1327f/crypt/zone                                                              f83b1c8d-d252-4b35-a9d2-400e2e2cddf7   none      none          off        
     oxp_a3e8de5b-c47a-49c0-b698-4d6955e1327f/crypt/zone/oxz_crucible_4d84fdb4-76fd-47a9-b033-7e1711d9125f            8dc07059-e8cd-4f89-abc7-0c5289b8ff0a   none      none          off        
     oxp_b32fa3da-4dec-4237-9776-e1a57ba15a21/crucible                                                                4f99dd21-d6ed-409a-af19-9886d1083762   none      none          off        
-    oxp_b32fa3da-4dec-4237-9776-e1a57ba15a21/crypt/debug                                                             d0f12057-da73-4c1d-bdec-32a0e7ab7107   100 GiB   none          gzip-9     
-    oxp_b32fa3da-4dec-4237-9776-e1a57ba15a21/crypt/zone                                                              0e976e79-fe8c-4189-8a8c-279f42e0290f   none      none          off        
+    oxp_b32fa3da-4dec-4237-9776-e1a57ba15a21/crypt/debug                                                             280dd773-35e2-4dda-ae2a-65c88f1b2a01   100 GiB   none          gzip-9     
+    oxp_b32fa3da-4dec-4237-9776-e1a57ba15a21/crypt/zone                                                              61bf628d-a78d-40a7-bad2-84e97e41b810   none      none          off        
     oxp_b32fa3da-4dec-4237-9776-e1a57ba15a21/crypt/zone/oxz_crucible_a9f1d41e-c445-4783-af13-0095b2836f0f            b5d6cec1-c83f-4c41-9e79-8b9bf917f483   none      none          off        
     oxp_e9c238f6-87a3-4087-8ba4-aa594a82d012/crucible                                                                e88d6ff8-6b98-44c1-97a7-83f371ae62fe   none      none          off        
-    oxp_e9c238f6-87a3-4087-8ba4-aa594a82d012/crypt/debug                                                             2288ff91-8e52-4817-825f-2f8b8eb1681d   100 GiB   none          gzip-9     
-    oxp_e9c238f6-87a3-4087-8ba4-aa594a82d012/crypt/zone                                                              f963f2a7-e9d1-4b80-b01a-ff4cecddf867   none      none          off        
+    oxp_e9c238f6-87a3-4087-8ba4-aa594a82d012/crypt/debug                                                             17ffe1be-b38b-4f39-90af-57af25dbfe30   100 GiB   none          gzip-9     
+    oxp_e9c238f6-87a3-4087-8ba4-aa594a82d012/crypt/zone                                                              a15e4260-d48c-4415-9315-c0f29234f359   none      none          off        
     oxp_e9c238f6-87a3-4087-8ba4-aa594a82d012/crypt/zone/oxz_crucible_577b0a64-6fa9-4302-bfaa-853b6e9e71ac            851cd90d-97f5-49b6-ad41-2e1c1faa3cc9   none      none          off        
     oxp_fbf997ef-52d3-438a-b036-b9117322e569/crucible                                                                d6a838c7-3ee9-4cca-9d8b-986b4de0ba1c   none      none          off        
-    oxp_fbf997ef-52d3-438a-b036-b9117322e569/crypt/debug                                                             17ffe1be-b38b-4f39-90af-57af25dbfe30   100 GiB   none          gzip-9     
-    oxp_fbf997ef-52d3-438a-b036-b9117322e569/crypt/zone                                                              a15e4260-d48c-4415-9315-c0f29234f359   none      none          off        
+    oxp_fbf997ef-52d3-438a-b036-b9117322e569/crypt/debug                                                             e120c8f8-049f-40f0-8d70-4cfe409ef34d   100 GiB   none          gzip-9     
+    oxp_fbf997ef-52d3-438a-b036-b9117322e569/crypt/zone                                                              a3284e6f-ee42-4fdb-8150-634f7f40c073   none      none          off        
     oxp_fbf997ef-52d3-438a-b036-b9117322e569/crypt/zone/oxz_crucible_0ba018f0-4ff7-4bcc-a0c7-42cfec6bc9da            ba1a3aae-15ab-4364-8250-54a766331ef8   none      none          off        
 
 
@@ -116,16 +116,16 @@ to:   blueprint cb39be9d-5476-44fa-9edf-9938376219ef
     fake-vendor   fake-model   serial-f635c28a-e5ca-4d22-ac94-d8f278a6ea0e
 
 
-    datasets at generation 3:
+    datasets at generation 4:
     -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
     dataset name                                                                                                     dataset uuid                           quota     reservation   compression
     -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
     oxp_0bf9d028-2b4a-4bff-82a1-6eb5fcefd985/crucible                                                                f3b1d2f6-3cbc-4420-bc91-5eaaf00f85d0   none      none          off        
     oxp_0bf9d028-2b4a-4bff-82a1-6eb5fcefd985/crypt/clickhouse_keeper                                                 a3eed313-d886-4c1d-8023-8d2ec9e97ddd   none      none          off        
     oxp_0bf9d028-2b4a-4bff-82a1-6eb5fcefd985/crypt/clickhouse_server                                                 886f2522-8122-465f-8996-2d8c2acd9d0d   none      none          off        
-    oxp_0bf9d028-2b4a-4bff-82a1-6eb5fcefd985/crypt/debug                                                             fb722d83-ddc2-4880-95a4-1ab12f4b95be   100 GiB   none          gzip-9     
+    oxp_0bf9d028-2b4a-4bff-82a1-6eb5fcefd985/crypt/debug                                                             8005f7c0-bab3-4b0a-9568-a5861c0a09bb   100 GiB   none          gzip-9     
     oxp_0bf9d028-2b4a-4bff-82a1-6eb5fcefd985/crypt/internal_dns                                                      b8af3673-c60a-45fb-adc1-c36d0d325417   none      none          off        
-    oxp_0bf9d028-2b4a-4bff-82a1-6eb5fcefd985/crypt/zone                                                              1ab5529e-c3db-41e1-a561-9c767f980ad4   none      none          off        
+    oxp_0bf9d028-2b4a-4bff-82a1-6eb5fcefd985/crypt/zone                                                              a647238a-1689-46c9-b680-dfe1b7b68684   none      none          off        
     oxp_0bf9d028-2b4a-4bff-82a1-6eb5fcefd985/crypt/zone/oxz_clickhouse_keeper_b36c16d5-de6e-411a-a32a-d35a26f2e151   48720037-5b8e-4478-9bb5-c86ee8a6e250   none      none          off        
     oxp_0bf9d028-2b4a-4bff-82a1-6eb5fcefd985/crypt/zone/oxz_clickhouse_server_122e30d3-d541-49b5-88de-1543b38123cc   095cf066-5a68-40b4-afc6-baf5bcbadd05   none      none          off        
     oxp_0bf9d028-2b4a-4bff-82a1-6eb5fcefd985/crypt/zone/oxz_crucible_aa74c1b2-b4c1-4f36-8f01-9459ef23786b            e1db255d-4793-46bd-a1f3-f207be6b2839   none      none          off        
@@ -135,41 +135,41 @@ to:   blueprint cb39be9d-5476-44fa-9edf-9938376219ef
     oxp_0bf9d028-2b4a-4bff-82a1-6eb5fcefd985/crypt/zone/oxz_ntp_bba31b23-d112-4cde-bd4a-635812c28c0e                 fadbc503-b72d-4862-a1fd-628c7ff599d1   none      none          off        
     oxp_19293a1d-fddc-40a7-88a4-ccafdb6f66d3/crucible                                                                276f044e-dd34-4c1e-beef-174da4fcf53d   none      none          off        
     oxp_19293a1d-fddc-40a7-88a4-ccafdb6f66d3/crypt/clickhouse_keeper                                                 3682c931-5332-45ef-9885-3d2dcfb325f6   none      none          off        
-    oxp_19293a1d-fddc-40a7-88a4-ccafdb6f66d3/crypt/debug                                                             891a1ff4-66b1-4dc9-871c-be4a757bbd0f   100 GiB   none          gzip-9     
-    oxp_19293a1d-fddc-40a7-88a4-ccafdb6f66d3/crypt/zone                                                              68490e52-279a-4609-ba0b-11d03f904c88   none      none          off        
+    oxp_19293a1d-fddc-40a7-88a4-ccafdb6f66d3/crypt/debug                                                             98d65e73-01df-4525-a45d-acb2fc8d4a74   100 GiB   none          gzip-9     
+    oxp_19293a1d-fddc-40a7-88a4-ccafdb6f66d3/crypt/zone                                                              39714005-313e-42be-90eb-000a0560669f   none      none          off        
     oxp_19293a1d-fddc-40a7-88a4-ccafdb6f66d3/crypt/zone/oxz_clickhouse_keeper_81a4f9fd-e502-42c2-bf9c-29dd6918fd46   6aaeeb8d-ee87-43a2-b1ef-22e5f5224842   none      none          off        
     oxp_19293a1d-fddc-40a7-88a4-ccafdb6f66d3/crypt/zone/oxz_crucible_eb58427d-599b-45dc-b316-8e4db7eec65e            26722393-82bf-442d-9725-030801a4d64c   none      none          off        
     oxp_44484c44-477a-4676-8266-b98a00e80d79/crucible                                                                e06b1670-5f34-42dc-a410-3129d69907ec   none      none          off        
-    oxp_44484c44-477a-4676-8266-b98a00e80d79/crypt/debug                                                             3e3e18ad-d527-4b2e-b758-1eefdcfca44b   100 GiB   none          gzip-9     
-    oxp_44484c44-477a-4676-8266-b98a00e80d79/crypt/zone                                                              2a5e3a10-6ab5-4988-be84-46b527dc2d23   none      none          off        
+    oxp_44484c44-477a-4676-8266-b98a00e80d79/crypt/debug                                                             6cea3508-8341-4093-abbb-c57d83cd87b4   100 GiB   none          gzip-9     
+    oxp_44484c44-477a-4676-8266-b98a00e80d79/crypt/zone                                                              e49915c6-59ed-4bbe-abf9-375b9502772a   none      none          off        
     oxp_44484c44-477a-4676-8266-b98a00e80d79/crypt/zone/oxz_crucible_487bde8c-a692-416c-be70-efef7f169fce            008ba9b6-8d41-4f7a-8ff3-ec31a0c96cf9   none      none          off        
     oxp_79787cd4-92da-4de5-bfd8-30a635521e10/crucible                                                                9d32dd45-e3ee-47b9-ba69-0dc711bbf632   none      none          off        
-    oxp_79787cd4-92da-4de5-bfd8-30a635521e10/crypt/debug                                                             bd4efdbe-7128-4423-aacf-6cf35e5a914d   100 GiB   none          gzip-9     
-    oxp_79787cd4-92da-4de5-bfd8-30a635521e10/crypt/zone                                                              fd0f9778-c31a-40f4-9ce9-f5154535e75b   none      none          off        
+    oxp_79787cd4-92da-4de5-bfd8-30a635521e10/crypt/debug                                                             dae242d1-9535-4b08-b249-f030dde2c2fd   100 GiB   none          gzip-9     
+    oxp_79787cd4-92da-4de5-bfd8-30a635521e10/crypt/zone                                                              29038bb0-9af1-4b03-9c10-b8a6444a0bc2   none      none          off        
     oxp_79787cd4-92da-4de5-bfd8-30a635521e10/crypt/zone/oxz_crucible_b6956e34-3c21-44d1-9ee2-cb7ee2e77c4e            2d2f2665-d556-4e65-9c53-d7fe573848a2   none      none          off        
     oxp_9ae94c94-baae-477e-912a-60f0c4f3bd13/crucible                                                                7e72090d-7f79-4ecc-92cc-5eb7d9dee022   none      none          off        
     oxp_9ae94c94-baae-477e-912a-60f0c4f3bd13/crypt/debug                                                             708d4e8b-3acf-44cf-87a2-275bb8fa0d96   100 GiB   none          gzip-9     
     oxp_9ae94c94-baae-477e-912a-60f0c4f3bd13/crypt/zone                                                              e4220797-15df-42c4-9df7-ad927711d565   none      none          off        
     oxp_9ae94c94-baae-477e-912a-60f0c4f3bd13/crypt/zone/oxz_crucible_41af4ef6-d21b-4271-bfcb-524f4146784a            1522207b-ea98-47cc-810c-44808796d743   none      none          off        
     oxp_af85eec8-36b3-4b88-966d-a717b9b58fe5/crucible                                                                43606b8e-384f-4412-a273-d4dde8f2e76d   none      none          off        
-    oxp_af85eec8-36b3-4b88-966d-a717b9b58fe5/crypt/debug                                                             98d65e73-01df-4525-a45d-acb2fc8d4a74   100 GiB   none          gzip-9     
-    oxp_af85eec8-36b3-4b88-966d-a717b9b58fe5/crypt/zone                                                              39714005-313e-42be-90eb-000a0560669f   none      none          off        
+    oxp_af85eec8-36b3-4b88-966d-a717b9b58fe5/crypt/debug                                                             765b4728-8d6e-4fac-9a1b-ae2258d5c52b   100 GiB   none          gzip-9     
+    oxp_af85eec8-36b3-4b88-966d-a717b9b58fe5/crypt/zone                                                              fc9765c5-0a89-4050-ba3e-e0625dbefb5f   none      none          off        
     oxp_af85eec8-36b3-4b88-966d-a717b9b58fe5/crypt/zone/oxz_crucible_26115267-8333-4711-924e-d05acf601827            3a39d5e8-ea73-4cf3-b9de-48045475151c   none      none          off        
     oxp_ddfaaba3-dafe-4103-b868-e9843d29d346/crucible                                                                2d7145e9-0029-4ae0-bb12-ee65a1738005   none      none          off        
-    oxp_ddfaaba3-dafe-4103-b868-e9843d29d346/crypt/debug                                                             8005f7c0-bab3-4b0a-9568-a5861c0a09bb   100 GiB   none          gzip-9     
-    oxp_ddfaaba3-dafe-4103-b868-e9843d29d346/crypt/zone                                                              a647238a-1689-46c9-b680-dfe1b7b68684   none      none          off        
+    oxp_ddfaaba3-dafe-4103-b868-e9843d29d346/crypt/debug                                                             bd4efdbe-7128-4423-aacf-6cf35e5a914d   100 GiB   none          gzip-9     
+    oxp_ddfaaba3-dafe-4103-b868-e9843d29d346/crypt/zone                                                              fd0f9778-c31a-40f4-9ce9-f5154535e75b   none      none          off        
     oxp_ddfaaba3-dafe-4103-b868-e9843d29d346/crypt/zone/oxz_crucible_1a92bb17-6477-46fc-9784-1d2a418d6e14            257c57cd-8f2c-440d-9fa0-e92a312295ec   none      none          off        
     oxp_ec458c3e-91ca-40f1-a2a3-3f4292c1f279/crucible                                                                dfadcc38-505a-4e9b-8674-27f8a2af13a2   none      none          off        
-    oxp_ec458c3e-91ca-40f1-a2a3-3f4292c1f279/crypt/debug                                                             dae242d1-9535-4b08-b249-f030dde2c2fd   100 GiB   none          gzip-9     
-    oxp_ec458c3e-91ca-40f1-a2a3-3f4292c1f279/crypt/zone                                                              29038bb0-9af1-4b03-9c10-b8a6444a0bc2   none      none          off        
+    oxp_ec458c3e-91ca-40f1-a2a3-3f4292c1f279/crypt/debug                                                             3e3e18ad-d527-4b2e-b758-1eefdcfca44b   100 GiB   none          gzip-9     
+    oxp_ec458c3e-91ca-40f1-a2a3-3f4292c1f279/crypt/zone                                                              2a5e3a10-6ab5-4988-be84-46b527dc2d23   none      none          off        
     oxp_ec458c3e-91ca-40f1-a2a3-3f4292c1f279/crypt/zone/oxz_crucible_9b9d58bd-44e6-4b70-80a4-e6a9262893ff            0a5bade3-3f2f-4385-b064-554b56f8bf8c   none      none          off        
     oxp_f2fc7c4c-7966-449d-8ec3-5a70f460501d/crucible                                                                72e2a1d6-09dd-43ba-9b8b-befa101f53ef   none      none          off        
-    oxp_f2fc7c4c-7966-449d-8ec3-5a70f460501d/crypt/debug                                                             6cea3508-8341-4093-abbb-c57d83cd87b4   100 GiB   none          gzip-9     
-    oxp_f2fc7c4c-7966-449d-8ec3-5a70f460501d/crypt/zone                                                              e49915c6-59ed-4bbe-abf9-375b9502772a   none      none          off        
+    oxp_f2fc7c4c-7966-449d-8ec3-5a70f460501d/crypt/debug                                                             fb722d83-ddc2-4880-95a4-1ab12f4b95be   100 GiB   none          gzip-9     
+    oxp_f2fc7c4c-7966-449d-8ec3-5a70f460501d/crypt/zone                                                              1ab5529e-c3db-41e1-a561-9c767f980ad4   none      none          off        
     oxp_f2fc7c4c-7966-449d-8ec3-5a70f460501d/crypt/zone/oxz_crucible_704a17e0-bc9d-43b9-a91e-b1ca37a23d0d            5739948f-d984-48a5-a27a-0223a0af2035   none      none          off        
     oxp_f635c28a-e5ca-4d22-ac94-d8f278a6ea0e/crucible                                                                c7dfbe25-5b52-4ee5-8556-719e99bb5e4d   none      none          off        
-    oxp_f635c28a-e5ca-4d22-ac94-d8f278a6ea0e/crypt/debug                                                             765b4728-8d6e-4fac-9a1b-ae2258d5c52b   100 GiB   none          gzip-9     
-    oxp_f635c28a-e5ca-4d22-ac94-d8f278a6ea0e/crypt/zone                                                              fc9765c5-0a89-4050-ba3e-e0625dbefb5f   none      none          off        
+    oxp_f635c28a-e5ca-4d22-ac94-d8f278a6ea0e/crypt/debug                                                             891a1ff4-66b1-4dc9-871c-be4a757bbd0f   100 GiB   none          gzip-9     
+    oxp_f635c28a-e5ca-4d22-ac94-d8f278a6ea0e/crypt/zone                                                              68490e52-279a-4609-ba0b-11d03f904c88   none      none          off        
     oxp_f635c28a-e5ca-4d22-ac94-d8f278a6ea0e/crypt/zone/oxz_crucible_93535f54-4919-4c4d-9a07-f7ab6245c01f            109f44de-d1ed-4ce3-9670-76aceb206ee4   none      none          off        
 
 
@@ -214,16 +214,16 @@ to:   blueprint cb39be9d-5476-44fa-9edf-9938376219ef
     fake-vendor   fake-model   serial-e3b45593-8f0c-47b2-a381-802a7dad1f54
 
 
-    datasets at generation 3:
+    datasets at generation 4:
     -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
     dataset name                                                                                                     dataset uuid                           quota     reservation   compression
     -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
     oxp_2a76ab1a-fb16-412d-93f9-b8cd9aa94e85/crucible                                                                431cfe4a-5756-40f4-8a9c-b70ae1227f1e   none      none          off        
     oxp_2a76ab1a-fb16-412d-93f9-b8cd9aa94e85/crypt/clickhouse_keeper                                                 ce930007-8ed6-4675-a24a-57c227950d43   none      none          off        
     oxp_2a76ab1a-fb16-412d-93f9-b8cd9aa94e85/crypt/clickhouse_server                                                 3d339942-c2d0-4615-a099-433a8b5a1543   none      none          off        
-    oxp_2a76ab1a-fb16-412d-93f9-b8cd9aa94e85/crypt/debug                                                             c55ba154-4f4b-48a5-997b-2a1579671c74   100 GiB   none          gzip-9     
+    oxp_2a76ab1a-fb16-412d-93f9-b8cd9aa94e85/crypt/debug                                                             dd239ff5-a617-4eb1-ac6d-16eb76c2c849   100 GiB   none          gzip-9     
     oxp_2a76ab1a-fb16-412d-93f9-b8cd9aa94e85/crypt/internal_dns                                                      7be88e8f-06d3-49f7-a6d9-5c586f13716c   none      none          off        
-    oxp_2a76ab1a-fb16-412d-93f9-b8cd9aa94e85/crypt/zone                                                              37405860-deb4-4f2f-b770-ab8b83175d8c   none      none          off        
+    oxp_2a76ab1a-fb16-412d-93f9-b8cd9aa94e85/crypt/zone                                                              5c620f9c-454b-451b-99ca-47c3d94df493   none      none          off        
     oxp_2a76ab1a-fb16-412d-93f9-b8cd9aa94e85/crypt/zone/oxz_clickhouse_keeper_39fd3357-4de8-433e-9c07-1ec65de7ca59   748c9607-71dd-4f81-be08-c1eee262f69c   none      none          off        
     oxp_2a76ab1a-fb16-412d-93f9-b8cd9aa94e85/crypt/zone/oxz_clickhouse_server_71be6bff-666a-4f2b-a7dc-d80a88a71af5   a9e2160a-688f-4bbd-9a77-b2e695df86f4   none      none          off        
     oxp_2a76ab1a-fb16-412d-93f9-b8cd9aa94e85/crypt/zone/oxz_crucible_75cccfab-ea70-4596-a685-ab9bd5e540a1            e2ff081e-c5a4-42c3-8d95-969e2b9b7b31   none      none          off        
@@ -233,41 +233,41 @@ to:   blueprint cb39be9d-5476-44fa-9edf-9938376219ef
     oxp_2a76ab1a-fb16-412d-93f9-b8cd9aa94e85/crypt/zone/oxz_ntp_816afef9-e5cd-40ba-8cc5-71e783943e43                 6f5ba0fc-1b43-4a40-ba5a-3abf11eae62b   none      none          off        
     oxp_2de2bf7e-c679-4b2b-b373-908e9d3ffbfc/crucible                                                                1123f86b-169c-40df-8ed1-95c3def65e30   none      none          off        
     oxp_2de2bf7e-c679-4b2b-b373-908e9d3ffbfc/crypt/clickhouse_keeper                                                 cad1d0c3-ca80-4db4-ab36-b2034cf2383b   none      none          off        
-    oxp_2de2bf7e-c679-4b2b-b373-908e9d3ffbfc/crypt/debug                                                             071d678d-9376-4c3b-8e1f-825d27bcae3a   100 GiB   none          gzip-9     
-    oxp_2de2bf7e-c679-4b2b-b373-908e9d3ffbfc/crypt/zone                                                              bbb78481-c7e5-44a6-85ae-37e363827e9f   none      none          off        
+    oxp_2de2bf7e-c679-4b2b-b373-908e9d3ffbfc/crypt/debug                                                             f2df23eb-672a-41b5-89e4-26c9feb50c7c   100 GiB   none          gzip-9     
+    oxp_2de2bf7e-c679-4b2b-b373-908e9d3ffbfc/crypt/zone                                                              2747bb48-2fb7-4999-a63c-5ba5e35e0a10   none      none          off        
     oxp_2de2bf7e-c679-4b2b-b373-908e9d3ffbfc/crypt/zone/oxz_clickhouse_keeper_ad07794e-affa-4145-81fb-f45ed92e3fcd   d196c20e-0254-4716-8e04-c0c735d2ffaf   none      none          off        
     oxp_2de2bf7e-c679-4b2b-b373-908e9d3ffbfc/crypt/zone/oxz_crucible_37c72edc-6acd-4c2d-ab76-d1c88e1f01f5            9b49fc13-4d2c-423e-9839-f6e1d0bffc6e   none      none          off        
     oxp_2f02a5c6-fcf5-4b5a-bc7d-7f65369918ba/crucible                                                                afa41d1a-3fc1-4723-835d-61d13db33cfe   none      none          off        
-    oxp_2f02a5c6-fcf5-4b5a-bc7d-7f65369918ba/crypt/debug                                                             daeded95-0145-4b97-b1fb-60d44856d1e4   100 GiB   none          gzip-9     
-    oxp_2f02a5c6-fcf5-4b5a-bc7d-7f65369918ba/crypt/zone                                                              38103edf-a98f-46ca-94ea-3404268ea935   none      none          off        
+    oxp_2f02a5c6-fcf5-4b5a-bc7d-7f65369918ba/crypt/debug                                                             b9e71882-7f71-4a5e-be9c-7df560c75000   100 GiB   none          gzip-9     
+    oxp_2f02a5c6-fcf5-4b5a-bc7d-7f65369918ba/crypt/zone                                                              13f8be82-85e9-43ac-985b-e7a51a910c41   none      none          off        
     oxp_2f02a5c6-fcf5-4b5a-bc7d-7f65369918ba/crypt/zone/oxz_crucible_2cb036bd-6056-4547-af65-aa6c0c1e4d6e            c6c9e491-ce4d-4dc4-82be-e394fa1e82e2   none      none          off        
     oxp_32041dbf-e58d-4f32-840d-923d3d3b68af/crucible                                                                da067282-0ae9-4861-8b78-b639622508af   none      none          off        
-    oxp_32041dbf-e58d-4f32-840d-923d3d3b68af/crypt/debug                                                             80d0697d-4ebe-4856-b7bf-78ff811eb00b   100 GiB   none          gzip-9     
-    oxp_32041dbf-e58d-4f32-840d-923d3d3b68af/crypt/zone                                                              3f1adfcf-9a2a-41db-9e1a-a2e13ff8a7dd   none      none          off        
+    oxp_32041dbf-e58d-4f32-840d-923d3d3b68af/crypt/debug                                                             96798a17-be94-44bb-9e12-2eb458e9a5ba   100 GiB   none          gzip-9     
+    oxp_32041dbf-e58d-4f32-840d-923d3d3b68af/crypt/zone                                                              64e62d15-e813-461d-9a50-403d9bd1df7c   none      none          off        
     oxp_32041dbf-e58d-4f32-840d-923d3d3b68af/crypt/zone/oxz_crucible_e52381c1-d7ab-402f-a9a8-bb52fbb614af            a0251fdc-166b-4476-95d4-f7fd58fdaf76   none      none          off        
     oxp_5f88adff-bb50-4dc1-bbfb-5a410c753ed5/crucible                                                                fcb937be-3b91-4ae7-9e25-a69808eeb07f   none      none          off        
-    oxp_5f88adff-bb50-4dc1-bbfb-5a410c753ed5/crypt/debug                                                             dd239ff5-a617-4eb1-ac6d-16eb76c2c849   100 GiB   none          gzip-9     
-    oxp_5f88adff-bb50-4dc1-bbfb-5a410c753ed5/crypt/zone                                                              5c620f9c-454b-451b-99ca-47c3d94df493   none      none          off        
+    oxp_5f88adff-bb50-4dc1-bbfb-5a410c753ed5/crypt/debug                                                             daeded95-0145-4b97-b1fb-60d44856d1e4   100 GiB   none          gzip-9     
+    oxp_5f88adff-bb50-4dc1-bbfb-5a410c753ed5/crypt/zone                                                              38103edf-a98f-46ca-94ea-3404268ea935   none      none          off        
     oxp_5f88adff-bb50-4dc1-bbfb-5a410c753ed5/crypt/zone/oxz_crucible_6ae471b1-1dd8-460e-a2a5-3ea796f746d5            98b66132-d99e-42e2-8517-5860412c61b1   none      none          off        
     oxp_74d64eb9-bf69-4782-af16-2d3a761ca171/crucible                                                                2854cb42-e5b9-4773-bd6e-6ec85d33a174   none      none          off        
-    oxp_74d64eb9-bf69-4782-af16-2d3a761ca171/crypt/debug                                                             b9e71882-7f71-4a5e-be9c-7df560c75000   100 GiB   none          gzip-9     
-    oxp_74d64eb9-bf69-4782-af16-2d3a761ca171/crypt/zone                                                              13f8be82-85e9-43ac-985b-e7a51a910c41   none      none          off        
+    oxp_74d64eb9-bf69-4782-af16-2d3a761ca171/crypt/debug                                                             80d0697d-4ebe-4856-b7bf-78ff811eb00b   100 GiB   none          gzip-9     
+    oxp_74d64eb9-bf69-4782-af16-2d3a761ca171/crypt/zone                                                              3f1adfcf-9a2a-41db-9e1a-a2e13ff8a7dd   none      none          off        
     oxp_74d64eb9-bf69-4782-af16-2d3a761ca171/crypt/zone/oxz_crucible_b6a9674e-8b42-4d67-954f-3e957db298dd            e7c2d833-b6a1-469f-b52f-8bbb45e9a30e   none      none          off        
     oxp_b3c231c9-b2a5-4267-b4bf-9651881b91a5/crucible                                                                aa8f925e-6c3a-40d2-ae2d-946324a7d612   none      none          off        
-    oxp_b3c231c9-b2a5-4267-b4bf-9651881b91a5/crypt/debug                                                             bae0ee1b-b3a3-4c4c-96ee-53b8b4cd837b   100 GiB   none          gzip-9     
-    oxp_b3c231c9-b2a5-4267-b4bf-9651881b91a5/crypt/zone                                                              9f1f99c7-e6c5-4bbc-9de5-15252b532914   none      none          off        
+    oxp_b3c231c9-b2a5-4267-b4bf-9651881b91a5/crypt/debug                                                             c55ba154-4f4b-48a5-997b-2a1579671c74   100 GiB   none          gzip-9     
+    oxp_b3c231c9-b2a5-4267-b4bf-9651881b91a5/crypt/zone                                                              37405860-deb4-4f2f-b770-ab8b83175d8c   none      none          off        
     oxp_b3c231c9-b2a5-4267-b4bf-9651881b91a5/crypt/zone/oxz_crucible_c79e017b-7e27-4ff5-be14-3673f8cb2279            3544adde-a808-45c0-ae19-08b4f65e3ad4   none      none          off        
     oxp_bca80b95-8dca-4a3b-b24d-d44b6a9ff71b/crucible                                                                755ad19c-d29b-4e3c-9c13-63b56a407765   none      none          off        
-    oxp_bca80b95-8dca-4a3b-b24d-d44b6a9ff71b/crypt/debug                                                             f2df23eb-672a-41b5-89e4-26c9feb50c7c   100 GiB   none          gzip-9     
-    oxp_bca80b95-8dca-4a3b-b24d-d44b6a9ff71b/crypt/zone                                                              2747bb48-2fb7-4999-a63c-5ba5e35e0a10   none      none          off        
+    oxp_bca80b95-8dca-4a3b-b24d-d44b6a9ff71b/crypt/debug                                                             e658be5b-df77-41fb-a000-5a924ac0b3da   100 GiB   none          gzip-9     
+    oxp_bca80b95-8dca-4a3b-b24d-d44b6a9ff71b/crypt/zone                                                              f7ddacf4-edc7-46ba-9b74-d588bd62505e   none      none          off        
     oxp_bca80b95-8dca-4a3b-b24d-d44b6a9ff71b/crypt/zone/oxz_crucible_0a160b89-6288-44f5-9908-33589094628e            53a623d2-9ffc-48fb-871d-23bd52e0f4dd   none      none          off        
     oxp_db16345e-427a-4c8e-9032-17270f729308/crucible                                                                be3cf2f7-5388-4cd6-8119-ecf316c6052e   none      none          off        
-    oxp_db16345e-427a-4c8e-9032-17270f729308/crypt/debug                                                             e658be5b-df77-41fb-a000-5a924ac0b3da   100 GiB   none          gzip-9     
-    oxp_db16345e-427a-4c8e-9032-17270f729308/crypt/zone                                                              f7ddacf4-edc7-46ba-9b74-d588bd62505e   none      none          off        
+    oxp_db16345e-427a-4c8e-9032-17270f729308/crypt/debug                                                             071d678d-9376-4c3b-8e1f-825d27bcae3a   100 GiB   none          gzip-9     
+    oxp_db16345e-427a-4c8e-9032-17270f729308/crypt/zone                                                              bbb78481-c7e5-44a6-85ae-37e363827e9f   none      none          off        
     oxp_db16345e-427a-4c8e-9032-17270f729308/crypt/zone/oxz_crucible_5fb4b72f-bf1b-47c7-a2e4-dbdafcdb47f5            1d73fc1f-81fc-4e06-9b52-686596ac0f6c   none      none          off        
     oxp_e3b45593-8f0c-47b2-a381-802a7dad1f54/crucible                                                                a2391107-7408-4e0c-a694-3fd073fa09df   none      none          off        
-    oxp_e3b45593-8f0c-47b2-a381-802a7dad1f54/crypt/debug                                                             96798a17-be94-44bb-9e12-2eb458e9a5ba   100 GiB   none          gzip-9     
-    oxp_e3b45593-8f0c-47b2-a381-802a7dad1f54/crypt/zone                                                              64e62d15-e813-461d-9a50-403d9bd1df7c   none      none          off        
+    oxp_e3b45593-8f0c-47b2-a381-802a7dad1f54/crypt/debug                                                             bae0ee1b-b3a3-4c4c-96ee-53b8b4cd837b   100 GiB   none          gzip-9     
+    oxp_e3b45593-8f0c-47b2-a381-802a7dad1f54/crypt/zone                                                              9f1f99c7-e6c5-4bbc-9de5-15252b532914   none      none          off        
     oxp_e3b45593-8f0c-47b2-a381-802a7dad1f54/crypt/zone/oxz_crucible_8a36ef67-bf66-40b9-a2f4-34ac70e90e39            c44e20e1-7cce-46df-ba71-db7fb3e3a5ff   none      none          off        
 
 

--- a/nexus/reconfigurator/planning/tests/output/planner_expunge_clickhouse_clusters_3_4.txt
+++ b/nexus/reconfigurator/planning/tests/output/planner_expunge_clickhouse_clusters_3_4.txt
@@ -21,16 +21,16 @@ to:   blueprint 74f2e7fd-687e-4c9e-b5d8-e474a5bb8e7c
 -   fake-vendor   fake-model   serial-fcca32b6-9629-468f-a282-63d7da992447
 
 
-    datasets from generation 2:
+    datasets from generation 3:
     -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
     dataset name                                                                                                     dataset uuid                           quota     reservation   compression
     -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
 -   oxp_03a84dd2-e0a4-435d-96de-67bfe2674f4e/crucible                                                                1e845ee8-701d-44bf-884a-d49d537633aa   none      none          off        
 -   oxp_03a84dd2-e0a4-435d-96de-67bfe2674f4e/crypt/clickhouse                                                        af4a8ac4-7941-4051-bdbb-979ae82dceaa   none      none          off        
 -   oxp_03a84dd2-e0a4-435d-96de-67bfe2674f4e/crypt/clickhouse_keeper                                                 35a2dc24-0853-4a06-b5b9-90b8ba83e0b0   none      none          off        
--   oxp_03a84dd2-e0a4-435d-96de-67bfe2674f4e/crypt/debug                                                             1d0c553a-4229-4175-9c11-22ef68191eb1   100 GiB   none          gzip-9     
+-   oxp_03a84dd2-e0a4-435d-96de-67bfe2674f4e/crypt/debug                                                             1d77d74d-1fa8-4e8c-a64f-f1a38f6c81ea   100 GiB   none          gzip-9     
 -   oxp_03a84dd2-e0a4-435d-96de-67bfe2674f4e/crypt/internal_dns                                                      3262c08c-12a1-4f38-93f0-e3f53a1087aa   none      none          off        
--   oxp_03a84dd2-e0a4-435d-96de-67bfe2674f4e/crypt/zone                                                              44f9d5f4-fd7b-4684-b9c9-71cf888c79a8   none      none          off        
+-   oxp_03a84dd2-e0a4-435d-96de-67bfe2674f4e/crypt/zone                                                              b244161f-e944-46d8-962e-5bc5a56575b7   none      none          off        
 -   oxp_03a84dd2-e0a4-435d-96de-67bfe2674f4e/crypt/zone/oxz_clickhouse_f2c54229-d192-41bd-babc-9ca02c1206d6          783cd7d4-ce73-4fe1-8665-b0c813406f52   none      none          off        
 -   oxp_03a84dd2-e0a4-435d-96de-67bfe2674f4e/crypt/zone/oxz_clickhouse_keeper_ceea23ec-1cb4-46be-bfa6-de9025ad5737   abb56278-58c2-4e0c-8cc8-417f57100de0   none      none          off        
 -   oxp_03a84dd2-e0a4-435d-96de-67bfe2674f4e/crypt/zone/oxz_crucible_c3dee582-3b04-4981-90ac-e2f617c6a1ce            15772401-8406-4938-801e-6ddff28ffb32   none      none          off        
@@ -43,36 +43,36 @@ to:   blueprint 74f2e7fd-687e-4c9e-b5d8-e474a5bb8e7c
 -   oxp_188c3b95-16fa-45ea-b9f7-e987560b4d62/crypt/zone                                                              b8d4c72d-f610-4236-8cc0-28c6c0ea5343   none      none          off        
 -   oxp_188c3b95-16fa-45ea-b9f7-e987560b4d62/crypt/zone/oxz_crucible_b5f91973-5e8e-4e58-9ebf-1b0ad3e4758e            b5109aa2-75d5-4381-96bc-15b76cf12591   none      none          off        
 -   oxp_1f3bbc7c-888f-40fa-b705-fab3f148b147/crucible                                                                1463de0a-26e5-43e0-9f2e-3de0689adb98   none      none          off        
--   oxp_1f3bbc7c-888f-40fa-b705-fab3f148b147/crypt/debug                                                             28bac96b-a65e-46f1-8b8d-721245314298   100 GiB   none          gzip-9     
--   oxp_1f3bbc7c-888f-40fa-b705-fab3f148b147/crypt/zone                                                              95e1d916-93b9-424a-9784-1cece05597cf   none      none          off        
+-   oxp_1f3bbc7c-888f-40fa-b705-fab3f148b147/crypt/debug                                                             43b14456-1b4a-4afe-bf5d-cf31124e0d18   100 GiB   none          gzip-9     
+-   oxp_1f3bbc7c-888f-40fa-b705-fab3f148b147/crypt/zone                                                              e9d64fda-0229-4f0b-b407-6e9f1a05e619   none      none          off        
 -   oxp_1f3bbc7c-888f-40fa-b705-fab3f148b147/crypt/zone/oxz_crucible_c0098649-b9d4-4072-9dc0-0da3e5791f1f            ac483768-9c41-409c-aec8-23bcb0917375   none      none          off        
 -   oxp_45a81e70-03bb-4c53-bf49-d598c9fb8d34/crucible                                                                eb61fcb5-80fb-4902-9256-d4921e8b91a4   none      none          off        
--   oxp_45a81e70-03bb-4c53-bf49-d598c9fb8d34/crypt/debug                                                             c9ecd62c-2208-4ffb-9510-f050d299d209   100 GiB   none          gzip-9     
--   oxp_45a81e70-03bb-4c53-bf49-d598c9fb8d34/crypt/zone                                                              92fd48ca-0e93-425e-b2cf-8b822cae7e3f   none      none          off        
+-   oxp_45a81e70-03bb-4c53-bf49-d598c9fb8d34/crypt/debug                                                             28bac96b-a65e-46f1-8b8d-721245314298   100 GiB   none          gzip-9     
+-   oxp_45a81e70-03bb-4c53-bf49-d598c9fb8d34/crypt/zone                                                              95e1d916-93b9-424a-9784-1cece05597cf   none      none          off        
 -   oxp_45a81e70-03bb-4c53-bf49-d598c9fb8d34/crypt/zone/oxz_crucible_133e50ce-39e1-4647-8ea8-8f171a1b6471            961b3fd4-d40c-4503-90a6-8ee32a5f5315   none      none          off        
 -   oxp_56c3f0ef-fac1-473d-9317-0e3668aa7e88/crucible                                                                b52fe96e-02dd-4ffb-a363-ec8e9f94cb49   none      none          off        
--   oxp_56c3f0ef-fac1-473d-9317-0e3668aa7e88/crypt/debug                                                             72fb1d98-9f11-492f-8e5a-094b686a3ad2   100 GiB   none          gzip-9     
--   oxp_56c3f0ef-fac1-473d-9317-0e3668aa7e88/crypt/zone                                                              995c2f94-ddc4-4de9-894b-23d813c33711   none      none          off        
+-   oxp_56c3f0ef-fac1-473d-9317-0e3668aa7e88/crypt/debug                                                             b17bf396-1fc8-4cfc-ad16-445bbc105688   100 GiB   none          gzip-9     
+-   oxp_56c3f0ef-fac1-473d-9317-0e3668aa7e88/crypt/zone                                                              368f9afa-ceaa-4f34-a488-b64d945c1b77   none      none          off        
 -   oxp_56c3f0ef-fac1-473d-9317-0e3668aa7e88/crypt/zone/oxz_crucible_975d60ed-46ff-4f4c-b02e-01e3cd331a6f            281d3fdc-9ed5-44f6-865b-6f03c9e7540f   none      none          off        
 -   oxp_96f1615c-3dda-427f-8132-408b2fad24e0/crucible                                                                5a8efbe2-7191-40e5-b694-33f6ab5f20de   none      none          off        
--   oxp_96f1615c-3dda-427f-8132-408b2fad24e0/crypt/debug                                                             b38bd0a3-106f-4771-a50a-8dae79e2db48   100 GiB   none          gzip-9     
--   oxp_96f1615c-3dda-427f-8132-408b2fad24e0/crypt/zone                                                              d56d2757-818a-4302-82e8-be4aac08fd66   none      none          off        
+-   oxp_96f1615c-3dda-427f-8132-408b2fad24e0/crypt/debug                                                             c9ecd62c-2208-4ffb-9510-f050d299d209   100 GiB   none          gzip-9     
+-   oxp_96f1615c-3dda-427f-8132-408b2fad24e0/crypt/zone                                                              92fd48ca-0e93-425e-b2cf-8b822cae7e3f   none      none          off        
 -   oxp_96f1615c-3dda-427f-8132-408b2fad24e0/crypt/zone/oxz_crucible_5078d1c7-9bc5-46a1-94e1-47ceb6f81580            530c8ac3-9a19-47c2-9057-4ae12a4377a5   none      none          off        
 -   oxp_a9ef71b2-ec22-421c-adc9-bddc4c0641c4/crucible                                                                3f0e3222-de30-4741-99f2-bd8cf6ecab41   none      none          off        
--   oxp_a9ef71b2-ec22-421c-adc9-bddc4c0641c4/crypt/debug                                                             1bac2a69-8575-4247-8f78-94b4ca69f7a2   100 GiB   none          gzip-9     
--   oxp_a9ef71b2-ec22-421c-adc9-bddc4c0641c4/crypt/zone                                                              4d802712-5773-4464-a8d9-748cca6d75c0   none      none          off        
+-   oxp_a9ef71b2-ec22-421c-adc9-bddc4c0641c4/crypt/debug                                                             72fb1d98-9f11-492f-8e5a-094b686a3ad2   100 GiB   none          gzip-9     
+-   oxp_a9ef71b2-ec22-421c-adc9-bddc4c0641c4/crypt/zone                                                              995c2f94-ddc4-4de9-894b-23d813c33711   none      none          off        
 -   oxp_a9ef71b2-ec22-421c-adc9-bddc4c0641c4/crypt/zone/oxz_crucible_6a703437-f546-4848-8a0a-94d4c3b20e7c            e2d4e003-2c43-40dd-b283-0b5df91a3c32   none      none          off        
 -   oxp_b9f9c626-3293-48eb-a475-1debaaccdf6c/crucible                                                                10ed346b-d1f7-43c7-88fd-8e7ad66db8e2   none      none          off        
--   oxp_b9f9c626-3293-48eb-a475-1debaaccdf6c/crypt/debug                                                             1d77d74d-1fa8-4e8c-a64f-f1a38f6c81ea   100 GiB   none          gzip-9     
--   oxp_b9f9c626-3293-48eb-a475-1debaaccdf6c/crypt/zone                                                              b244161f-e944-46d8-962e-5bc5a56575b7   none      none          off        
+-   oxp_b9f9c626-3293-48eb-a475-1debaaccdf6c/crypt/debug                                                             b38bd0a3-106f-4771-a50a-8dae79e2db48   100 GiB   none          gzip-9     
+-   oxp_b9f9c626-3293-48eb-a475-1debaaccdf6c/crypt/zone                                                              d56d2757-818a-4302-82e8-be4aac08fd66   none      none          off        
 -   oxp_b9f9c626-3293-48eb-a475-1debaaccdf6c/crypt/zone/oxz_crucible_58a60190-35da-4ce1-b0da-298b3d64458d            6ffd174d-1b54-4de3-9654-f50df5df6953   none      none          off        
 -   oxp_d563fd5f-9306-49b4-8511-78a2f64733ce/crucible                                                                3f81e4d8-fefc-4586-a626-15c728242b05   none      none          off        
--   oxp_d563fd5f-9306-49b4-8511-78a2f64733ce/crypt/debug                                                             43b14456-1b4a-4afe-bf5d-cf31124e0d18   100 GiB   none          gzip-9     
--   oxp_d563fd5f-9306-49b4-8511-78a2f64733ce/crypt/zone                                                              e9d64fda-0229-4f0b-b407-6e9f1a05e619   none      none          off        
+-   oxp_d563fd5f-9306-49b4-8511-78a2f64733ce/crypt/debug                                                             1bac2a69-8575-4247-8f78-94b4ca69f7a2   100 GiB   none          gzip-9     
+-   oxp_d563fd5f-9306-49b4-8511-78a2f64733ce/crypt/zone                                                              4d802712-5773-4464-a8d9-748cca6d75c0   none      none          off        
 -   oxp_d563fd5f-9306-49b4-8511-78a2f64733ce/crypt/zone/oxz_crucible_893d890c-4b9f-4944-a245-90ac5dab82b6            b65a7b48-f785-4481-898e-c0b49d96d706   none      none          off        
 -   oxp_fcca32b6-9629-468f-a282-63d7da992447/crucible                                                                abbef5ad-6cae-4e18-822f-4a4d7980b1f3   none      none          off        
--   oxp_fcca32b6-9629-468f-a282-63d7da992447/crypt/debug                                                             b17bf396-1fc8-4cfc-ad16-445bbc105688   100 GiB   none          gzip-9     
--   oxp_fcca32b6-9629-468f-a282-63d7da992447/crypt/zone                                                              368f9afa-ceaa-4f34-a488-b64d945c1b77   none      none          off        
+-   oxp_fcca32b6-9629-468f-a282-63d7da992447/crypt/debug                                                             1d0c553a-4229-4175-9c11-22ef68191eb1   100 GiB   none          gzip-9     
+-   oxp_fcca32b6-9629-468f-a282-63d7da992447/crypt/zone                                                              44f9d5f4-fd7b-4684-b9c9-71cf888c79a8   none      none          off        
 -   oxp_fcca32b6-9629-468f-a282-63d7da992447/crypt/zone/oxz_crucible_5a0af13f-c815-4df4-a7a3-c1ddfc1fc4f0            fea35514-09e5-4df1-91c1-5a186032b293   none      none          off        
 
 
@@ -132,16 +132,16 @@ to:   blueprint 74f2e7fd-687e-4c9e-b5d8-e474a5bb8e7c
     fake-vendor   fake-model   serial-e35766ef-789a-4b2f-9a6c-e6626d5ab195
 
 
-    datasets generation 2 -> 3:
+    datasets generation 3 -> 4:
     -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
     dataset name                                                                                                     dataset uuid                           quota     reservation   compression
     -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
     oxp_08616473-ded4-4785-9b53-b6ccc1efb67a/crucible                                                                3d575592-90d1-4f09-8ebd-cfb0d7348492   none      none          off        
     oxp_08616473-ded4-4785-9b53-b6ccc1efb67a/crypt/clickhouse_keeper                                                 dda523f9-2078-42b1-a581-bad8349bb592   none      none          off        
     oxp_08616473-ded4-4785-9b53-b6ccc1efb67a/crypt/clickhouse_server                                                 90935183-8ac3-4474-aaf4-d7f29979c873   none      none          off        
-    oxp_08616473-ded4-4785-9b53-b6ccc1efb67a/crypt/debug                                                             c619b70f-4542-40ba-8cb6-1641df0b1a11   100 GiB   none          gzip-9     
+    oxp_08616473-ded4-4785-9b53-b6ccc1efb67a/crypt/debug                                                             e6c0e102-f69d-4e14-bc52-7e03ae82cd0a   100 GiB   none          gzip-9     
     oxp_08616473-ded4-4785-9b53-b6ccc1efb67a/crypt/internal_dns                                                      1e34af87-308a-4192-be38-193f0c89390a   none      none          off        
-    oxp_08616473-ded4-4785-9b53-b6ccc1efb67a/crypt/zone                                                              a27426fd-6f66-475d-bb6e-4422618ae009   none      none          off        
+    oxp_08616473-ded4-4785-9b53-b6ccc1efb67a/crypt/zone                                                              caa97a7b-1c7d-4a2b-a9e7-12588f942a8c   none      none          off        
     oxp_08616473-ded4-4785-9b53-b6ccc1efb67a/crypt/zone/oxz_clickhouse_keeper_fe395a2c-219b-4ad7-9f51-f536de60a9e4   1331d93d-4191-48ea-ae98-9554f9aabcd8   none      none          off        
     oxp_08616473-ded4-4785-9b53-b6ccc1efb67a/crypt/zone/oxz_clickhouse_server_02ef9ddc-a012-4d15-8f45-8282f58c9a11   e94a67fe-79b0-45b2-8cb8-0f00dd2c0c52   none      none          off        
     oxp_08616473-ded4-4785-9b53-b6ccc1efb67a/crypt/zone/oxz_crucible_e83d6088-9e82-40dd-b8e9-b5bafe23d358            d989e55b-60c1-44c6-a37b-e081d9d49313   none      none          off        
@@ -150,40 +150,40 @@ to:   blueprint 74f2e7fd-687e-4c9e-b5d8-e474a5bb8e7c
     oxp_08616473-ded4-4785-9b53-b6ccc1efb67a/crypt/zone/oxz_nexus_3150ecb4-973e-4467-b194-632539bbdf07               2441284a-c8b4-4eb9-8988-5f7f64fcb7cc   none      none          off        
     oxp_08616473-ded4-4785-9b53-b6ccc1efb67a/crypt/zone/oxz_ntp_663835e0-d8bc-41ea-b79f-bd85997777ce                 6c266f89-6820-45ba-8d53-8e2952a89f70   none      none          off        
     oxp_2d44b756-94df-45ec-a644-50021248682d/crucible                                                                6875e6ae-d773-4c38-b075-74d54c7664c5   none      none          off        
-    oxp_2d44b756-94df-45ec-a644-50021248682d/crypt/debug                                                             c4f52f42-f6d1-40a3-bb3e-0a684ce06338   100 GiB   none          gzip-9     
-    oxp_2d44b756-94df-45ec-a644-50021248682d/crypt/zone                                                              a38bec7e-50fc-4a0d-b0de-15023a542367   none      none          off        
+    oxp_2d44b756-94df-45ec-a644-50021248682d/crypt/debug                                                             f0808ff2-ce3a-4434-971b-055acb097d8d   100 GiB   none          gzip-9     
+    oxp_2d44b756-94df-45ec-a644-50021248682d/crypt/zone                                                              b265dd36-3a93-4ad9-bca1-8e76abea9f90   none      none          off        
     oxp_2d44b756-94df-45ec-a644-50021248682d/crypt/zone/oxz_crucible_4a152e9b-240b-4213-92fc-d205bc67c138            3a96f6b5-bf00-4f0d-b9d9-f718ac8c8672   none      none          off        
     oxp_2dce7cf0-3097-485d-aaf6-9fc51f99eae5/crucible                                                                1afdddf6-2c5d-4b57-b732-d451fe9d339a   none      none          off        
-    oxp_2dce7cf0-3097-485d-aaf6-9fc51f99eae5/crypt/debug                                                             c857ccb3-eb0a-4220-aa80-e7c22d2f7be4   100 GiB   none          gzip-9     
-    oxp_2dce7cf0-3097-485d-aaf6-9fc51f99eae5/crypt/zone                                                              1cee8f96-b8e2-4983-8c65-ba8338eb781c   none      none          off        
+    oxp_2dce7cf0-3097-485d-aaf6-9fc51f99eae5/crypt/debug                                                             52d22143-4c25-45cf-a443-62e63052e385   100 GiB   none          gzip-9     
+    oxp_2dce7cf0-3097-485d-aaf6-9fc51f99eae5/crypt/zone                                                              7197059c-e461-43b1-a050-95740f239dc7   none      none          off        
     oxp_2dce7cf0-3097-485d-aaf6-9fc51f99eae5/crypt/zone/oxz_crucible_42ec7ad4-4a8a-4e7f-8291-bcc3a141647b            8e2fc466-8b2a-4be6-ba66-2bd8ef658a5d   none      none          off        
     oxp_3b9d69e5-aa80-4fc8-9d2e-a2a24bd0f1d7/crucible                                                                99df049c-d495-4cdc-800e-a0deb8a12407   none      none          off        
-    oxp_3b9d69e5-aa80-4fc8-9d2e-a2a24bd0f1d7/crypt/debug                                                             f0808ff2-ce3a-4434-971b-055acb097d8d   100 GiB   none          gzip-9     
-    oxp_3b9d69e5-aa80-4fc8-9d2e-a2a24bd0f1d7/crypt/zone                                                              b265dd36-3a93-4ad9-bca1-8e76abea9f90   none      none          off        
+    oxp_3b9d69e5-aa80-4fc8-9d2e-a2a24bd0f1d7/crypt/debug                                                             0bf0d153-d9fb-42ed-a98f-839ca7c272bc   100 GiB   none          gzip-9     
+    oxp_3b9d69e5-aa80-4fc8-9d2e-a2a24bd0f1d7/crypt/zone                                                              c7345d22-765f-4892-993f-de910ac5055b   none      none          off        
     oxp_3b9d69e5-aa80-4fc8-9d2e-a2a24bd0f1d7/crypt/zone/oxz_crucible_e432e610-e600-4d1c-9427-e965afe2d54a            9d7b361b-ed6e-4bdb-a8b7-1f6736026e11   none      none          off        
     oxp_44342c41-75a7-4708-8004-eb2ca5c5a3c2/crucible                                                                97bcdcd3-c71f-4a6a-8dbe-fb79f0e0cd8c   none      none          off        
-    oxp_44342c41-75a7-4708-8004-eb2ca5c5a3c2/crypt/debug                                                             e6c0e102-f69d-4e14-bc52-7e03ae82cd0a   100 GiB   none          gzip-9     
-    oxp_44342c41-75a7-4708-8004-eb2ca5c5a3c2/crypt/zone                                                              caa97a7b-1c7d-4a2b-a9e7-12588f942a8c   none      none          off        
+    oxp_44342c41-75a7-4708-8004-eb2ca5c5a3c2/crypt/debug                                                             c619b70f-4542-40ba-8cb6-1641df0b1a11   100 GiB   none          gzip-9     
+    oxp_44342c41-75a7-4708-8004-eb2ca5c5a3c2/crypt/zone                                                              a27426fd-6f66-475d-bb6e-4422618ae009   none      none          off        
     oxp_44342c41-75a7-4708-8004-eb2ca5c5a3c2/crypt/zone/oxz_crucible_377d8477-7608-4248-b925-6a2c5e04fee3            3000bfbb-7faa-4439-914c-84815c5d75ea   none      none          off        
     oxp_650b4eff-80a2-430a-97c8-f837248480a1/crucible                                                                5d445c3a-92ff-4951-964d-cbb35dce0ffb   none      none          off        
-    oxp_650b4eff-80a2-430a-97c8-f837248480a1/crypt/debug                                                             0b84fd36-2a53-4420-b580-8a7ab5e44adb   100 GiB   none          gzip-9     
-    oxp_650b4eff-80a2-430a-97c8-f837248480a1/crypt/zone                                                              0921cbb1-02ad-4de5-9c60-c4a8aca25579   none      none          off        
+    oxp_650b4eff-80a2-430a-97c8-f837248480a1/crypt/debug                                                             c857ccb3-eb0a-4220-aa80-e7c22d2f7be4   100 GiB   none          gzip-9     
+    oxp_650b4eff-80a2-430a-97c8-f837248480a1/crypt/zone                                                              1cee8f96-b8e2-4983-8c65-ba8338eb781c   none      none          off        
     oxp_650b4eff-80a2-430a-97c8-f837248480a1/crypt/zone/oxz_crucible_0c50f6a6-55f0-4d9e-920e-c16b4e2f3b4f            34c4fcb0-c6d4-4f47-8153-a8b16e8c9c09   none      none          off        
     oxp_6e418b8c-cadd-4fb8-8370-f351a07e1eed/crucible                                                                efce20c8-c6ad-4e1a-a489-1391a02ff73e   none      none          off        
-    oxp_6e418b8c-cadd-4fb8-8370-f351a07e1eed/crypt/debug                                                             52d22143-4c25-45cf-a443-62e63052e385   100 GiB   none          gzip-9     
-    oxp_6e418b8c-cadd-4fb8-8370-f351a07e1eed/crypt/zone                                                              7197059c-e461-43b1-a050-95740f239dc7   none      none          off        
+    oxp_6e418b8c-cadd-4fb8-8370-f351a07e1eed/crypt/debug                                                             ef0c1012-a349-4868-9175-e0a5e117614b   100 GiB   none          gzip-9     
+    oxp_6e418b8c-cadd-4fb8-8370-f351a07e1eed/crypt/zone                                                              0292217f-5be3-440f-976b-6bab7043992f   none      none          off        
     oxp_6e418b8c-cadd-4fb8-8370-f351a07e1eed/crypt/zone/oxz_crucible_cf0943f4-1f4c-4531-8412-ecab1d1df36f            a9cc6710-a9c1-44f0-aebb-26c708718918   none      none          off        
     oxp_6e5772a5-8234-46d1-ba5a-503a83d9d2fb/crucible                                                                9292d1a7-786c-448b-86ea-4cdb7c29df73   none      none          off        
-    oxp_6e5772a5-8234-46d1-ba5a-503a83d9d2fb/crypt/debug                                                             ef0c1012-a349-4868-9175-e0a5e117614b   100 GiB   none          gzip-9     
-    oxp_6e5772a5-8234-46d1-ba5a-503a83d9d2fb/crypt/zone                                                              0292217f-5be3-440f-976b-6bab7043992f   none      none          off        
+    oxp_6e5772a5-8234-46d1-ba5a-503a83d9d2fb/crypt/debug                                                             0b84fd36-2a53-4420-b580-8a7ab5e44adb   100 GiB   none          gzip-9     
+    oxp_6e5772a5-8234-46d1-ba5a-503a83d9d2fb/crypt/zone                                                              0921cbb1-02ad-4de5-9c60-c4a8aca25579   none      none          off        
     oxp_6e5772a5-8234-46d1-ba5a-503a83d9d2fb/crypt/zone/oxz_crucible_9dce96c1-4f76-4e17-96de-aa867344581f            2d590e4c-8b2a-4021-baf1-3fc1a33a6130   none      none          off        
     oxp_c1da692e-7713-43a0-b6bb-5c182084c09d/crucible                                                                5967609a-83a6-4feb-8d46-25c3ca7fce12   none      none          off        
-    oxp_c1da692e-7713-43a0-b6bb-5c182084c09d/crypt/debug                                                             0bf0d153-d9fb-42ed-a98f-839ca7c272bc   100 GiB   none          gzip-9     
-    oxp_c1da692e-7713-43a0-b6bb-5c182084c09d/crypt/zone                                                              c7345d22-765f-4892-993f-de910ac5055b   none      none          off        
+    oxp_c1da692e-7713-43a0-b6bb-5c182084c09d/crypt/debug                                                             3588412a-4f56-419c-b10c-0eef2c6a2c31   100 GiB   none          gzip-9     
+    oxp_c1da692e-7713-43a0-b6bb-5c182084c09d/crypt/zone                                                              d37c8162-c363-447f-b4be-da14fb97b181   none      none          off        
     oxp_c1da692e-7713-43a0-b6bb-5c182084c09d/crypt/zone/oxz_crucible_6d8c8a4f-82fc-47a9-b894-3c1dddd86343            a205bb5f-d9d9-43c1-aafb-fc872ca159b8   none      none          off        
     oxp_e35766ef-789a-4b2f-9a6c-e6626d5ab195/crucible                                                                97ff78ad-4939-4308-9dde-7bd94dc55741   none      none          off        
-    oxp_e35766ef-789a-4b2f-9a6c-e6626d5ab195/crypt/debug                                                             3588412a-4f56-419c-b10c-0eef2c6a2c31   100 GiB   none          gzip-9     
-    oxp_e35766ef-789a-4b2f-9a6c-e6626d5ab195/crypt/zone                                                              d37c8162-c363-447f-b4be-da14fb97b181   none      none          off        
+    oxp_e35766ef-789a-4b2f-9a6c-e6626d5ab195/crypt/debug                                                             c4f52f42-f6d1-40a3-bb3e-0a684ce06338   100 GiB   none          gzip-9     
+    oxp_e35766ef-789a-4b2f-9a6c-e6626d5ab195/crypt/zone                                                              a38bec7e-50fc-4a0d-b0de-15023a542367   none      none          off        
     oxp_e35766ef-789a-4b2f-9a6c-e6626d5ab195/crypt/zone/oxz_crucible_5135c26c-5118-4dd0-a9a7-e2c46bd32b91            83321216-d04c-4dfc-99de-36dc1216c566   none      none          off        
 +   oxp_2d44b756-94df-45ec-a644-50021248682d/crypt/clickhouse_keeper                                                 410eca9c-8eee-4a98-aea2-a363697974f7   none      none          off        
 +   oxp_2d44b756-94df-45ec-a644-50021248682d/crypt/internal_dns                                                      f2bbe72f-ae6c-4ee2-a2f3-eae54527048d   none      none          off        
@@ -233,16 +233,16 @@ to:   blueprint 74f2e7fd-687e-4c9e-b5d8-e474a5bb8e7c
     fake-vendor   fake-model   serial-fe379ac6-1938-4cc2-93a9-43b1447229ae
 
 
-    datasets generation 2 -> 3:
+    datasets generation 3 -> 4:
     -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
     dataset name                                                                                                     dataset uuid                           quota     reservation   compression
     -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
     oxp_21d60319-5fe1-4a3b-a4c0-6aa7465e7bde/crucible                                                                83697259-f910-49de-8c15-83605c086a5d   none      none          off        
     oxp_21d60319-5fe1-4a3b-a4c0-6aa7465e7bde/crypt/clickhouse_keeper                                                 e1236796-4a4f-48fe-b274-9c6c251d60b7   none      none          off        
     oxp_21d60319-5fe1-4a3b-a4c0-6aa7465e7bde/crypt/clickhouse_server                                                 14389e8b-952f-4e20-aabd-3741493fb444   none      none          off        
-    oxp_21d60319-5fe1-4a3b-a4c0-6aa7465e7bde/crypt/debug                                                             f015e445-2e52-45c9-9f0a-49cb5ceae245   100 GiB   none          gzip-9     
+    oxp_21d60319-5fe1-4a3b-a4c0-6aa7465e7bde/crypt/debug                                                             6fdd4ca2-022f-4ef3-9a83-1e18e620e9dc   100 GiB   none          gzip-9     
     oxp_21d60319-5fe1-4a3b-a4c0-6aa7465e7bde/crypt/internal_dns                                                      8d423173-09c9-4ca5-a21c-b7c3123aa1af   none      none          off        
-    oxp_21d60319-5fe1-4a3b-a4c0-6aa7465e7bde/crypt/zone                                                              d5d2ddf7-2eb3-40f3-b149-aee5699b7bf1   none      none          off        
+    oxp_21d60319-5fe1-4a3b-a4c0-6aa7465e7bde/crypt/zone                                                              d8d8dc6c-cd76-4d17-b530-25f3f3f52d33   none      none          off        
     oxp_21d60319-5fe1-4a3b-a4c0-6aa7465e7bde/crypt/zone/oxz_clickhouse_keeper_94abd717-9240-4a27-ac14-5666c1f3f3ab   2315a796-5038-4003-b5e0-099a29f7ebb1   none      none          off        
     oxp_21d60319-5fe1-4a3b-a4c0-6aa7465e7bde/crypt/zone/oxz_clickhouse_server_23ee16e1-7f1f-4a76-b4fc-32921eead60e   fef210d9-1473-4294-afa4-90e1f1836b86   none      none          off        
     oxp_21d60319-5fe1-4a3b-a4c0-6aa7465e7bde/crypt/zone/oxz_crucible_3801ce73-9986-491a-a623-8ae2cea1678b            d0d28f34-55ba-400e-9dce-a8c3d25c09e9   none      none          off        
@@ -251,40 +251,40 @@ to:   blueprint 74f2e7fd-687e-4c9e-b5d8-e474a5bb8e7c
     oxp_21d60319-5fe1-4a3b-a4c0-6aa7465e7bde/crypt/zone/oxz_nexus_7e763480-0f4f-43cb-ab9a-52b667d8fda5               5773e3b1-dde0-4b54-bc13-3c3bf816015e   none      none          off        
     oxp_21d60319-5fe1-4a3b-a4c0-6aa7465e7bde/crypt/zone/oxz_ntp_f34f8d36-7137-48d3-9d13-6a46c4edcef4                 c8c03dec-65d4-4c97-87c3-a43a8363c97c   none      none          off        
     oxp_2acfbb84-5ce0-424e-8d73-44c5071d4430/crucible                                                                46ea917a-f99f-4078-8f45-8e92512ba42c   none      none          off        
-    oxp_2acfbb84-5ce0-424e-8d73-44c5071d4430/crypt/debug                                                             a86eda4a-2346-4990-8393-6692c81f9f37   100 GiB   none          gzip-9     
-    oxp_2acfbb84-5ce0-424e-8d73-44c5071d4430/crypt/zone                                                              988c82cc-aed4-4207-96a8-f844ede70a5c   none      none          off        
+    oxp_2acfbb84-5ce0-424e-8d73-44c5071d4430/crypt/debug                                                             85d345b5-04d4-4bdf-9e6f-c10b3f21208d   100 GiB   none          gzip-9     
+    oxp_2acfbb84-5ce0-424e-8d73-44c5071d4430/crypt/zone                                                              cf7a9405-cf77-49cd-b3d4-528d9ad5ce48   none      none          off        
     oxp_2acfbb84-5ce0-424e-8d73-44c5071d4430/crypt/zone/oxz_crucible_93fe2a9b-3ce9-4bf0-852d-c36171988c71            6fafdcb1-b246-44ca-8e8e-2101ce3cbdf7   none      none          off        
     oxp_2db7f3b4-ed19-4229-b42c-44f49eeb8a91/crucible                                                                d26ad281-5420-42c4-be19-013d7d44e2e9   none      none          off        
     oxp_2db7f3b4-ed19-4229-b42c-44f49eeb8a91/crypt/debug                                                             f3c93847-6a22-4f95-97cd-766358663b2a   100 GiB   none          gzip-9     
     oxp_2db7f3b4-ed19-4229-b42c-44f49eeb8a91/crypt/zone                                                              0c6b2002-2cec-478f-9eb3-239069f42dbc   none      none          off        
     oxp_2db7f3b4-ed19-4229-b42c-44f49eeb8a91/crypt/zone/oxz_crucible_02aecfb8-91a9-4db8-8cb2-4252bf15d6ac            7e11890f-b1ce-497a-9672-f95d3452eb7b   none      none          off        
     oxp_2fa34d8e-13d9-42d3-b8ba-ca9d74ac496a/crucible                                                                9ba7194a-0e9e-485f-b4ba-e58c39bc90da   none      none          off        
-    oxp_2fa34d8e-13d9-42d3-b8ba-ca9d74ac496a/crypt/debug                                                             ec40dcf8-085f-4277-8d96-657a1e7fb0c8   100 GiB   none          gzip-9     
-    oxp_2fa34d8e-13d9-42d3-b8ba-ca9d74ac496a/crypt/zone                                                              8b6d2ff8-4f40-4776-b461-29e0a3d3dd97   none      none          off        
+    oxp_2fa34d8e-13d9-42d3-b8ba-ca9d74ac496a/crypt/debug                                                             f7cccd71-efb1-4bee-bcdf-7e7133c3e5da   100 GiB   none          gzip-9     
+    oxp_2fa34d8e-13d9-42d3-b8ba-ca9d74ac496a/crypt/zone                                                              a03487ed-4b03-4856-a670-9fa703b0b850   none      none          off        
     oxp_2fa34d8e-13d9-42d3-b8ba-ca9d74ac496a/crypt/zone/oxz_crucible_d9106a19-f267-48db-a82b-004e643feb49            9b9fb14e-cd17-4a7a-a74a-bfd9c7682831   none      none          off        
     oxp_355e268c-c932-4f32-841c-f3ec88fe0495/crucible                                                                a1cb2b30-ca4f-4b9d-840d-4deef5993b79   none      none          off        
-    oxp_355e268c-c932-4f32-841c-f3ec88fe0495/crypt/debug                                                             85d345b5-04d4-4bdf-9e6f-c10b3f21208d   100 GiB   none          gzip-9     
-    oxp_355e268c-c932-4f32-841c-f3ec88fe0495/crypt/zone                                                              cf7a9405-cf77-49cd-b3d4-528d9ad5ce48   none      none          off        
+    oxp_355e268c-c932-4f32-841c-f3ec88fe0495/crypt/debug                                                             0f785b1f-3f7a-4ae7-8a32-4412b781d245   100 GiB   none          gzip-9     
+    oxp_355e268c-c932-4f32-841c-f3ec88fe0495/crypt/zone                                                              f3df6efd-e689-4aaa-b4ed-76de319a1fe4   none      none          off        
     oxp_355e268c-c932-4f32-841c-f3ec88fe0495/crypt/zone/oxz_crucible_0a3cfe7c-414d-40f0-8f63-a7c0b26b7627            e1396508-5d99-4802-8d3f-cc3db33f0341   none      none          off        
     oxp_427b2ccd-998f-4085-af21-e600604cf21e/crucible                                                                0c6d24b8-e64b-4f97-a4ae-19bc998214fe   none      none          off        
-    oxp_427b2ccd-998f-4085-af21-e600604cf21e/crypt/debug                                                             f7cccd71-efb1-4bee-bcdf-7e7133c3e5da   100 GiB   none          gzip-9     
-    oxp_427b2ccd-998f-4085-af21-e600604cf21e/crypt/zone                                                              a03487ed-4b03-4856-a670-9fa703b0b850   none      none          off        
+    oxp_427b2ccd-998f-4085-af21-e600604cf21e/crypt/debug                                                             a86eda4a-2346-4990-8393-6692c81f9f37   100 GiB   none          gzip-9     
+    oxp_427b2ccd-998f-4085-af21-e600604cf21e/crypt/zone                                                              988c82cc-aed4-4207-96a8-f844ede70a5c   none      none          off        
     oxp_427b2ccd-998f-4085-af21-e600604cf21e/crypt/zone/oxz_crucible_befe73dd-5970-49a4-9adf-7b4f453c45cf            95d72ef9-e070-49e4-a57b-2c392def6025   none      none          off        
     oxp_588058f2-f51b-4800-a211-1c5dbb32296b/crucible                                                                97e6171d-523c-4c4a-9fa6-daead00d71a5   none      none          off        
-    oxp_588058f2-f51b-4800-a211-1c5dbb32296b/crypt/debug                                                             2ab9c443-5ea3-4ab1-b2ed-d57abbfde4be   100 GiB   none          gzip-9     
-    oxp_588058f2-f51b-4800-a211-1c5dbb32296b/crypt/zone                                                              86009a86-7c47-477d-bb17-c38689f5b337   none      none          off        
+    oxp_588058f2-f51b-4800-a211-1c5dbb32296b/crypt/debug                                                             3a49dd24-8ead-4196-b453-8aa3273b77d1   100 GiB   none          gzip-9     
+    oxp_588058f2-f51b-4800-a211-1c5dbb32296b/crypt/zone                                                              9327960e-a9a3-4b26-9bd4-65afb1737bd4   none      none          off        
     oxp_588058f2-f51b-4800-a211-1c5dbb32296b/crypt/zone/oxz_crucible_a91714d7-33b4-40d6-93cf-1b278bc9f1c6            f4c0087b-c746-4440-82e7-82ff5e40c6ab   none      none          off        
     oxp_736f6f07-2aa2-4658-8b5c-3bf409ea747a/crucible                                                                035b55e9-a0fc-48e5-8cd0-a862e7a7fe47   none      none          off        
-    oxp_736f6f07-2aa2-4658-8b5c-3bf409ea747a/crypt/debug                                                             0f785b1f-3f7a-4ae7-8a32-4412b781d245   100 GiB   none          gzip-9     
-    oxp_736f6f07-2aa2-4658-8b5c-3bf409ea747a/crypt/zone                                                              f3df6efd-e689-4aaa-b4ed-76de319a1fe4   none      none          off        
+    oxp_736f6f07-2aa2-4658-8b5c-3bf409ea747a/crypt/debug                                                             2ab9c443-5ea3-4ab1-b2ed-d57abbfde4be   100 GiB   none          gzip-9     
+    oxp_736f6f07-2aa2-4658-8b5c-3bf409ea747a/crypt/zone                                                              86009a86-7c47-477d-bb17-c38689f5b337   none      none          off        
     oxp_736f6f07-2aa2-4658-8b5c-3bf409ea747a/crypt/zone/oxz_crucible_79164b60-fbb4-46d4-9a42-eafbaeddd672            ebf1a36b-ab94-4a5d-a777-937991a60396   none      none          off        
     oxp_bcfcdede-7084-4a31-97a8-ac4299c268f9/crucible                                                                01def6ad-ddd9-4b28-b337-137a16734021   none      none          off        
-    oxp_bcfcdede-7084-4a31-97a8-ac4299c268f9/crypt/debug                                                             6fdd4ca2-022f-4ef3-9a83-1e18e620e9dc   100 GiB   none          gzip-9     
-    oxp_bcfcdede-7084-4a31-97a8-ac4299c268f9/crypt/zone                                                              d8d8dc6c-cd76-4d17-b530-25f3f3f52d33   none      none          off        
+    oxp_bcfcdede-7084-4a31-97a8-ac4299c268f9/crypt/debug                                                             ec40dcf8-085f-4277-8d96-657a1e7fb0c8   100 GiB   none          gzip-9     
+    oxp_bcfcdede-7084-4a31-97a8-ac4299c268f9/crypt/zone                                                              8b6d2ff8-4f40-4776-b461-29e0a3d3dd97   none      none          off        
     oxp_bcfcdede-7084-4a31-97a8-ac4299c268f9/crypt/zone/oxz_crucible_109820d7-b6ef-4574-b5e4-9f193c9d2a9e            75f329ff-4f3b-4cc5-8027-dd61d05e7323   none      none          off        
     oxp_fe379ac6-1938-4cc2-93a9-43b1447229ae/crucible                                                                5818a803-eb2c-44eb-8818-bd98bfa29da9   none      none          off        
-    oxp_fe379ac6-1938-4cc2-93a9-43b1447229ae/crypt/debug                                                             3a49dd24-8ead-4196-b453-8aa3273b77d1   100 GiB   none          gzip-9     
-    oxp_fe379ac6-1938-4cc2-93a9-43b1447229ae/crypt/zone                                                              9327960e-a9a3-4b26-9bd4-65afb1737bd4   none      none          off        
+    oxp_fe379ac6-1938-4cc2-93a9-43b1447229ae/crypt/debug                                                             f015e445-2e52-45c9-9f0a-49cb5ceae245   100 GiB   none          gzip-9     
+    oxp_fe379ac6-1938-4cc2-93a9-43b1447229ae/crypt/zone                                                              d5d2ddf7-2eb3-40f3-b149-aee5699b7bf1   none      none          off        
     oxp_fe379ac6-1938-4cc2-93a9-43b1447229ae/crypt/zone/oxz_crucible_43aa521b-eb86-4c3d-a58c-83c733f2fec3            c7a57806-05b3-4e38-9bc4-07fd6b30cccd   none      none          off        
 +   oxp_21d60319-5fe1-4a3b-a4c0-6aa7465e7bde/crypt/clickhouse                                                        46273d48-d966-4cee-8af9-d3e7f5f38ac3   none      none          off        
 +   oxp_21d60319-5fe1-4a3b-a4c0-6aa7465e7bde/crypt/zone/oxz_clickhouse_fa97835a-aabc-4fe9-9e85-3e50f207129c          4eb52e76-39fa-414d-ae9b-2dcb1c7737f9   none      none          off        

--- a/nexus/reconfigurator/planning/tests/output/planner_expunge_clickhouse_clusters_5_6.txt
+++ b/nexus/reconfigurator/planning/tests/output/planner_expunge_clickhouse_clusters_5_6.txt
@@ -45,16 +45,16 @@ to:   blueprint df68d4d4-5af4-4b56-95bb-1654a6957d4f
     fake-vendor   fake-model   serial-e35766ef-789a-4b2f-9a6c-e6626d5ab195
 
 
-    datasets at generation 3:
+    datasets at generation 4:
     -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
     dataset name                                                                                                     dataset uuid                           quota     reservation   compression
     -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
     oxp_08616473-ded4-4785-9b53-b6ccc1efb67a/crucible                                                                3d575592-90d1-4f09-8ebd-cfb0d7348492   none      none          off        
     oxp_08616473-ded4-4785-9b53-b6ccc1efb67a/crypt/clickhouse_keeper                                                 dda523f9-2078-42b1-a581-bad8349bb592   none      none          off        
     oxp_08616473-ded4-4785-9b53-b6ccc1efb67a/crypt/clickhouse_server                                                 90935183-8ac3-4474-aaf4-d7f29979c873   none      none          off        
-    oxp_08616473-ded4-4785-9b53-b6ccc1efb67a/crypt/debug                                                             c619b70f-4542-40ba-8cb6-1641df0b1a11   100 GiB   none          gzip-9     
+    oxp_08616473-ded4-4785-9b53-b6ccc1efb67a/crypt/debug                                                             e6c0e102-f69d-4e14-bc52-7e03ae82cd0a   100 GiB   none          gzip-9     
     oxp_08616473-ded4-4785-9b53-b6ccc1efb67a/crypt/internal_dns                                                      1e34af87-308a-4192-be38-193f0c89390a   none      none          off        
-    oxp_08616473-ded4-4785-9b53-b6ccc1efb67a/crypt/zone                                                              a27426fd-6f66-475d-bb6e-4422618ae009   none      none          off        
+    oxp_08616473-ded4-4785-9b53-b6ccc1efb67a/crypt/zone                                                              caa97a7b-1c7d-4a2b-a9e7-12588f942a8c   none      none          off        
     oxp_08616473-ded4-4785-9b53-b6ccc1efb67a/crypt/zone/oxz_clickhouse_keeper_fe395a2c-219b-4ad7-9f51-f536de60a9e4   1331d93d-4191-48ea-ae98-9554f9aabcd8   none      none          off        
     oxp_08616473-ded4-4785-9b53-b6ccc1efb67a/crypt/zone/oxz_clickhouse_server_02ef9ddc-a012-4d15-8f45-8282f58c9a11   e94a67fe-79b0-45b2-8cb8-0f00dd2c0c52   none      none          off        
     oxp_08616473-ded4-4785-9b53-b6ccc1efb67a/crypt/zone/oxz_crucible_e83d6088-9e82-40dd-b8e9-b5bafe23d358            d989e55b-60c1-44c6-a37b-e081d9d49313   none      none          off        
@@ -64,43 +64,43 @@ to:   blueprint df68d4d4-5af4-4b56-95bb-1654a6957d4f
     oxp_08616473-ded4-4785-9b53-b6ccc1efb67a/crypt/zone/oxz_ntp_663835e0-d8bc-41ea-b79f-bd85997777ce                 6c266f89-6820-45ba-8d53-8e2952a89f70   none      none          off        
     oxp_2d44b756-94df-45ec-a644-50021248682d/crucible                                                                6875e6ae-d773-4c38-b075-74d54c7664c5   none      none          off        
     oxp_2d44b756-94df-45ec-a644-50021248682d/crypt/clickhouse_keeper                                                 410eca9c-8eee-4a98-aea2-a363697974f7   none      none          off        
-    oxp_2d44b756-94df-45ec-a644-50021248682d/crypt/debug                                                             c4f52f42-f6d1-40a3-bb3e-0a684ce06338   100 GiB   none          gzip-9     
+    oxp_2d44b756-94df-45ec-a644-50021248682d/crypt/debug                                                             f0808ff2-ce3a-4434-971b-055acb097d8d   100 GiB   none          gzip-9     
     oxp_2d44b756-94df-45ec-a644-50021248682d/crypt/internal_dns                                                      f2bbe72f-ae6c-4ee2-a2f3-eae54527048d   none      none          off        
-    oxp_2d44b756-94df-45ec-a644-50021248682d/crypt/zone                                                              a38bec7e-50fc-4a0d-b0de-15023a542367   none      none          off        
+    oxp_2d44b756-94df-45ec-a644-50021248682d/crypt/zone                                                              b265dd36-3a93-4ad9-bca1-8e76abea9f90   none      none          off        
     oxp_2d44b756-94df-45ec-a644-50021248682d/crypt/zone/oxz_clickhouse_keeper_e4052979-f949-44bf-91de-17b371d3e518   08f15d4b-91dc-445d-88f4-cb9fa585444b   none      none          off        
     oxp_2d44b756-94df-45ec-a644-50021248682d/crypt/zone/oxz_crucible_4a152e9b-240b-4213-92fc-d205bc67c138            3a96f6b5-bf00-4f0d-b9d9-f718ac8c8672   none      none          off        
     oxp_2d44b756-94df-45ec-a644-50021248682d/crypt/zone/oxz_internal_dns_1cd50cc3-c098-4fe3-ae5b-af0344f0b6ec        da028e64-33e1-4380-8544-19e6ce754b20   none      none          off        
     oxp_2dce7cf0-3097-485d-aaf6-9fc51f99eae5/crucible                                                                1afdddf6-2c5d-4b57-b732-d451fe9d339a   none      none          off        
-    oxp_2dce7cf0-3097-485d-aaf6-9fc51f99eae5/crypt/debug                                                             c857ccb3-eb0a-4220-aa80-e7c22d2f7be4   100 GiB   none          gzip-9     
-    oxp_2dce7cf0-3097-485d-aaf6-9fc51f99eae5/crypt/zone                                                              1cee8f96-b8e2-4983-8c65-ba8338eb781c   none      none          off        
+    oxp_2dce7cf0-3097-485d-aaf6-9fc51f99eae5/crypt/debug                                                             52d22143-4c25-45cf-a443-62e63052e385   100 GiB   none          gzip-9     
+    oxp_2dce7cf0-3097-485d-aaf6-9fc51f99eae5/crypt/zone                                                              7197059c-e461-43b1-a050-95740f239dc7   none      none          off        
     oxp_2dce7cf0-3097-485d-aaf6-9fc51f99eae5/crypt/zone/oxz_crucible_42ec7ad4-4a8a-4e7f-8291-bcc3a141647b            8e2fc466-8b2a-4be6-ba66-2bd8ef658a5d   none      none          off        
     oxp_3b9d69e5-aa80-4fc8-9d2e-a2a24bd0f1d7/crucible                                                                99df049c-d495-4cdc-800e-a0deb8a12407   none      none          off        
-    oxp_3b9d69e5-aa80-4fc8-9d2e-a2a24bd0f1d7/crypt/debug                                                             f0808ff2-ce3a-4434-971b-055acb097d8d   100 GiB   none          gzip-9     
-    oxp_3b9d69e5-aa80-4fc8-9d2e-a2a24bd0f1d7/crypt/zone                                                              b265dd36-3a93-4ad9-bca1-8e76abea9f90   none      none          off        
+    oxp_3b9d69e5-aa80-4fc8-9d2e-a2a24bd0f1d7/crypt/debug                                                             0bf0d153-d9fb-42ed-a98f-839ca7c272bc   100 GiB   none          gzip-9     
+    oxp_3b9d69e5-aa80-4fc8-9d2e-a2a24bd0f1d7/crypt/zone                                                              c7345d22-765f-4892-993f-de910ac5055b   none      none          off        
     oxp_3b9d69e5-aa80-4fc8-9d2e-a2a24bd0f1d7/crypt/zone/oxz_crucible_e432e610-e600-4d1c-9427-e965afe2d54a            9d7b361b-ed6e-4bdb-a8b7-1f6736026e11   none      none          off        
     oxp_44342c41-75a7-4708-8004-eb2ca5c5a3c2/crucible                                                                97bcdcd3-c71f-4a6a-8dbe-fb79f0e0cd8c   none      none          off        
-    oxp_44342c41-75a7-4708-8004-eb2ca5c5a3c2/crypt/debug                                                             e6c0e102-f69d-4e14-bc52-7e03ae82cd0a   100 GiB   none          gzip-9     
-    oxp_44342c41-75a7-4708-8004-eb2ca5c5a3c2/crypt/zone                                                              caa97a7b-1c7d-4a2b-a9e7-12588f942a8c   none      none          off        
+    oxp_44342c41-75a7-4708-8004-eb2ca5c5a3c2/crypt/debug                                                             c619b70f-4542-40ba-8cb6-1641df0b1a11   100 GiB   none          gzip-9     
+    oxp_44342c41-75a7-4708-8004-eb2ca5c5a3c2/crypt/zone                                                              a27426fd-6f66-475d-bb6e-4422618ae009   none      none          off        
     oxp_44342c41-75a7-4708-8004-eb2ca5c5a3c2/crypt/zone/oxz_crucible_377d8477-7608-4248-b925-6a2c5e04fee3            3000bfbb-7faa-4439-914c-84815c5d75ea   none      none          off        
     oxp_650b4eff-80a2-430a-97c8-f837248480a1/crucible                                                                5d445c3a-92ff-4951-964d-cbb35dce0ffb   none      none          off        
-    oxp_650b4eff-80a2-430a-97c8-f837248480a1/crypt/debug                                                             0b84fd36-2a53-4420-b580-8a7ab5e44adb   100 GiB   none          gzip-9     
-    oxp_650b4eff-80a2-430a-97c8-f837248480a1/crypt/zone                                                              0921cbb1-02ad-4de5-9c60-c4a8aca25579   none      none          off        
+    oxp_650b4eff-80a2-430a-97c8-f837248480a1/crypt/debug                                                             c857ccb3-eb0a-4220-aa80-e7c22d2f7be4   100 GiB   none          gzip-9     
+    oxp_650b4eff-80a2-430a-97c8-f837248480a1/crypt/zone                                                              1cee8f96-b8e2-4983-8c65-ba8338eb781c   none      none          off        
     oxp_650b4eff-80a2-430a-97c8-f837248480a1/crypt/zone/oxz_crucible_0c50f6a6-55f0-4d9e-920e-c16b4e2f3b4f            34c4fcb0-c6d4-4f47-8153-a8b16e8c9c09   none      none          off        
     oxp_6e418b8c-cadd-4fb8-8370-f351a07e1eed/crucible                                                                efce20c8-c6ad-4e1a-a489-1391a02ff73e   none      none          off        
-    oxp_6e418b8c-cadd-4fb8-8370-f351a07e1eed/crypt/debug                                                             52d22143-4c25-45cf-a443-62e63052e385   100 GiB   none          gzip-9     
-    oxp_6e418b8c-cadd-4fb8-8370-f351a07e1eed/crypt/zone                                                              7197059c-e461-43b1-a050-95740f239dc7   none      none          off        
+    oxp_6e418b8c-cadd-4fb8-8370-f351a07e1eed/crypt/debug                                                             ef0c1012-a349-4868-9175-e0a5e117614b   100 GiB   none          gzip-9     
+    oxp_6e418b8c-cadd-4fb8-8370-f351a07e1eed/crypt/zone                                                              0292217f-5be3-440f-976b-6bab7043992f   none      none          off        
     oxp_6e418b8c-cadd-4fb8-8370-f351a07e1eed/crypt/zone/oxz_crucible_cf0943f4-1f4c-4531-8412-ecab1d1df36f            a9cc6710-a9c1-44f0-aebb-26c708718918   none      none          off        
     oxp_6e5772a5-8234-46d1-ba5a-503a83d9d2fb/crucible                                                                9292d1a7-786c-448b-86ea-4cdb7c29df73   none      none          off        
-    oxp_6e5772a5-8234-46d1-ba5a-503a83d9d2fb/crypt/debug                                                             ef0c1012-a349-4868-9175-e0a5e117614b   100 GiB   none          gzip-9     
-    oxp_6e5772a5-8234-46d1-ba5a-503a83d9d2fb/crypt/zone                                                              0292217f-5be3-440f-976b-6bab7043992f   none      none          off        
+    oxp_6e5772a5-8234-46d1-ba5a-503a83d9d2fb/crypt/debug                                                             0b84fd36-2a53-4420-b580-8a7ab5e44adb   100 GiB   none          gzip-9     
+    oxp_6e5772a5-8234-46d1-ba5a-503a83d9d2fb/crypt/zone                                                              0921cbb1-02ad-4de5-9c60-c4a8aca25579   none      none          off        
     oxp_6e5772a5-8234-46d1-ba5a-503a83d9d2fb/crypt/zone/oxz_crucible_9dce96c1-4f76-4e17-96de-aa867344581f            2d590e4c-8b2a-4021-baf1-3fc1a33a6130   none      none          off        
     oxp_c1da692e-7713-43a0-b6bb-5c182084c09d/crucible                                                                5967609a-83a6-4feb-8d46-25c3ca7fce12   none      none          off        
-    oxp_c1da692e-7713-43a0-b6bb-5c182084c09d/crypt/debug                                                             0bf0d153-d9fb-42ed-a98f-839ca7c272bc   100 GiB   none          gzip-9     
-    oxp_c1da692e-7713-43a0-b6bb-5c182084c09d/crypt/zone                                                              c7345d22-765f-4892-993f-de910ac5055b   none      none          off        
+    oxp_c1da692e-7713-43a0-b6bb-5c182084c09d/crypt/debug                                                             3588412a-4f56-419c-b10c-0eef2c6a2c31   100 GiB   none          gzip-9     
+    oxp_c1da692e-7713-43a0-b6bb-5c182084c09d/crypt/zone                                                              d37c8162-c363-447f-b4be-da14fb97b181   none      none          off        
     oxp_c1da692e-7713-43a0-b6bb-5c182084c09d/crypt/zone/oxz_crucible_6d8c8a4f-82fc-47a9-b894-3c1dddd86343            a205bb5f-d9d9-43c1-aafb-fc872ca159b8   none      none          off        
     oxp_e35766ef-789a-4b2f-9a6c-e6626d5ab195/crucible                                                                97ff78ad-4939-4308-9dde-7bd94dc55741   none      none          off        
-    oxp_e35766ef-789a-4b2f-9a6c-e6626d5ab195/crypt/debug                                                             3588412a-4f56-419c-b10c-0eef2c6a2c31   100 GiB   none          gzip-9     
-    oxp_e35766ef-789a-4b2f-9a6c-e6626d5ab195/crypt/zone                                                              d37c8162-c363-447f-b4be-da14fb97b181   none      none          off        
+    oxp_e35766ef-789a-4b2f-9a6c-e6626d5ab195/crypt/debug                                                             c4f52f42-f6d1-40a3-bb3e-0a684ce06338   100 GiB   none          gzip-9     
+    oxp_e35766ef-789a-4b2f-9a6c-e6626d5ab195/crypt/zone                                                              a38bec7e-50fc-4a0d-b0de-15023a542367   none      none          off        
     oxp_e35766ef-789a-4b2f-9a6c-e6626d5ab195/crypt/zone/oxz_crucible_5135c26c-5118-4dd0-a9a7-e2c46bd32b91            83321216-d04c-4dfc-99de-36dc1216c566   none      none          off        
 
 
@@ -146,7 +146,7 @@ to:   blueprint df68d4d4-5af4-4b56-95bb-1654a6957d4f
     fake-vendor   fake-model   serial-fe379ac6-1938-4cc2-93a9-43b1447229ae
 
 
-    datasets at generation 3:
+    datasets at generation 4:
     -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
     dataset name                                                                                                     dataset uuid                           quota     reservation   compression
     -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
@@ -154,9 +154,9 @@ to:   blueprint df68d4d4-5af4-4b56-95bb-1654a6957d4f
     oxp_21d60319-5fe1-4a3b-a4c0-6aa7465e7bde/crypt/clickhouse                                                        46273d48-d966-4cee-8af9-d3e7f5f38ac3   none      none          off        
     oxp_21d60319-5fe1-4a3b-a4c0-6aa7465e7bde/crypt/clickhouse_keeper                                                 e1236796-4a4f-48fe-b274-9c6c251d60b7   none      none          off        
     oxp_21d60319-5fe1-4a3b-a4c0-6aa7465e7bde/crypt/clickhouse_server                                                 14389e8b-952f-4e20-aabd-3741493fb444   none      none          off        
-    oxp_21d60319-5fe1-4a3b-a4c0-6aa7465e7bde/crypt/debug                                                             f015e445-2e52-45c9-9f0a-49cb5ceae245   100 GiB   none          gzip-9     
+    oxp_21d60319-5fe1-4a3b-a4c0-6aa7465e7bde/crypt/debug                                                             6fdd4ca2-022f-4ef3-9a83-1e18e620e9dc   100 GiB   none          gzip-9     
     oxp_21d60319-5fe1-4a3b-a4c0-6aa7465e7bde/crypt/internal_dns                                                      8d423173-09c9-4ca5-a21c-b7c3123aa1af   none      none          off        
-    oxp_21d60319-5fe1-4a3b-a4c0-6aa7465e7bde/crypt/zone                                                              d5d2ddf7-2eb3-40f3-b149-aee5699b7bf1   none      none          off        
+    oxp_21d60319-5fe1-4a3b-a4c0-6aa7465e7bde/crypt/zone                                                              d8d8dc6c-cd76-4d17-b530-25f3f3f52d33   none      none          off        
     oxp_21d60319-5fe1-4a3b-a4c0-6aa7465e7bde/crypt/zone/oxz_clickhouse_fa97835a-aabc-4fe9-9e85-3e50f207129c          4eb52e76-39fa-414d-ae9b-2dcb1c7737f9   none      none          off        
     oxp_21d60319-5fe1-4a3b-a4c0-6aa7465e7bde/crypt/zone/oxz_clickhouse_keeper_94abd717-9240-4a27-ac14-5666c1f3f3ab   2315a796-5038-4003-b5e0-099a29f7ebb1   none      none          off        
     oxp_21d60319-5fe1-4a3b-a4c0-6aa7465e7bde/crypt/zone/oxz_clickhouse_server_23ee16e1-7f1f-4a76-b4fc-32921eead60e   fef210d9-1473-4294-afa4-90e1f1836b86   none      none          off        
@@ -168,40 +168,40 @@ to:   blueprint df68d4d4-5af4-4b56-95bb-1654a6957d4f
     oxp_21d60319-5fe1-4a3b-a4c0-6aa7465e7bde/crypt/zone/oxz_nexus_7e763480-0f4f-43cb-ab9a-52b667d8fda5               5773e3b1-dde0-4b54-bc13-3c3bf816015e   none      none          off        
     oxp_21d60319-5fe1-4a3b-a4c0-6aa7465e7bde/crypt/zone/oxz_ntp_f34f8d36-7137-48d3-9d13-6a46c4edcef4                 c8c03dec-65d4-4c97-87c3-a43a8363c97c   none      none          off        
     oxp_2acfbb84-5ce0-424e-8d73-44c5071d4430/crucible                                                                46ea917a-f99f-4078-8f45-8e92512ba42c   none      none          off        
-    oxp_2acfbb84-5ce0-424e-8d73-44c5071d4430/crypt/debug                                                             a86eda4a-2346-4990-8393-6692c81f9f37   100 GiB   none          gzip-9     
-    oxp_2acfbb84-5ce0-424e-8d73-44c5071d4430/crypt/zone                                                              988c82cc-aed4-4207-96a8-f844ede70a5c   none      none          off        
+    oxp_2acfbb84-5ce0-424e-8d73-44c5071d4430/crypt/debug                                                             85d345b5-04d4-4bdf-9e6f-c10b3f21208d   100 GiB   none          gzip-9     
+    oxp_2acfbb84-5ce0-424e-8d73-44c5071d4430/crypt/zone                                                              cf7a9405-cf77-49cd-b3d4-528d9ad5ce48   none      none          off        
     oxp_2acfbb84-5ce0-424e-8d73-44c5071d4430/crypt/zone/oxz_crucible_93fe2a9b-3ce9-4bf0-852d-c36171988c71            6fafdcb1-b246-44ca-8e8e-2101ce3cbdf7   none      none          off        
     oxp_2db7f3b4-ed19-4229-b42c-44f49eeb8a91/crucible                                                                d26ad281-5420-42c4-be19-013d7d44e2e9   none      none          off        
     oxp_2db7f3b4-ed19-4229-b42c-44f49eeb8a91/crypt/debug                                                             f3c93847-6a22-4f95-97cd-766358663b2a   100 GiB   none          gzip-9     
     oxp_2db7f3b4-ed19-4229-b42c-44f49eeb8a91/crypt/zone                                                              0c6b2002-2cec-478f-9eb3-239069f42dbc   none      none          off        
     oxp_2db7f3b4-ed19-4229-b42c-44f49eeb8a91/crypt/zone/oxz_crucible_02aecfb8-91a9-4db8-8cb2-4252bf15d6ac            7e11890f-b1ce-497a-9672-f95d3452eb7b   none      none          off        
     oxp_2fa34d8e-13d9-42d3-b8ba-ca9d74ac496a/crucible                                                                9ba7194a-0e9e-485f-b4ba-e58c39bc90da   none      none          off        
-    oxp_2fa34d8e-13d9-42d3-b8ba-ca9d74ac496a/crypt/debug                                                             ec40dcf8-085f-4277-8d96-657a1e7fb0c8   100 GiB   none          gzip-9     
-    oxp_2fa34d8e-13d9-42d3-b8ba-ca9d74ac496a/crypt/zone                                                              8b6d2ff8-4f40-4776-b461-29e0a3d3dd97   none      none          off        
+    oxp_2fa34d8e-13d9-42d3-b8ba-ca9d74ac496a/crypt/debug                                                             f7cccd71-efb1-4bee-bcdf-7e7133c3e5da   100 GiB   none          gzip-9     
+    oxp_2fa34d8e-13d9-42d3-b8ba-ca9d74ac496a/crypt/zone                                                              a03487ed-4b03-4856-a670-9fa703b0b850   none      none          off        
     oxp_2fa34d8e-13d9-42d3-b8ba-ca9d74ac496a/crypt/zone/oxz_crucible_d9106a19-f267-48db-a82b-004e643feb49            9b9fb14e-cd17-4a7a-a74a-bfd9c7682831   none      none          off        
     oxp_355e268c-c932-4f32-841c-f3ec88fe0495/crucible                                                                a1cb2b30-ca4f-4b9d-840d-4deef5993b79   none      none          off        
-    oxp_355e268c-c932-4f32-841c-f3ec88fe0495/crypt/debug                                                             85d345b5-04d4-4bdf-9e6f-c10b3f21208d   100 GiB   none          gzip-9     
-    oxp_355e268c-c932-4f32-841c-f3ec88fe0495/crypt/zone                                                              cf7a9405-cf77-49cd-b3d4-528d9ad5ce48   none      none          off        
+    oxp_355e268c-c932-4f32-841c-f3ec88fe0495/crypt/debug                                                             0f785b1f-3f7a-4ae7-8a32-4412b781d245   100 GiB   none          gzip-9     
+    oxp_355e268c-c932-4f32-841c-f3ec88fe0495/crypt/zone                                                              f3df6efd-e689-4aaa-b4ed-76de319a1fe4   none      none          off        
     oxp_355e268c-c932-4f32-841c-f3ec88fe0495/crypt/zone/oxz_crucible_0a3cfe7c-414d-40f0-8f63-a7c0b26b7627            e1396508-5d99-4802-8d3f-cc3db33f0341   none      none          off        
     oxp_427b2ccd-998f-4085-af21-e600604cf21e/crucible                                                                0c6d24b8-e64b-4f97-a4ae-19bc998214fe   none      none          off        
-    oxp_427b2ccd-998f-4085-af21-e600604cf21e/crypt/debug                                                             f7cccd71-efb1-4bee-bcdf-7e7133c3e5da   100 GiB   none          gzip-9     
-    oxp_427b2ccd-998f-4085-af21-e600604cf21e/crypt/zone                                                              a03487ed-4b03-4856-a670-9fa703b0b850   none      none          off        
+    oxp_427b2ccd-998f-4085-af21-e600604cf21e/crypt/debug                                                             a86eda4a-2346-4990-8393-6692c81f9f37   100 GiB   none          gzip-9     
+    oxp_427b2ccd-998f-4085-af21-e600604cf21e/crypt/zone                                                              988c82cc-aed4-4207-96a8-f844ede70a5c   none      none          off        
     oxp_427b2ccd-998f-4085-af21-e600604cf21e/crypt/zone/oxz_crucible_befe73dd-5970-49a4-9adf-7b4f453c45cf            95d72ef9-e070-49e4-a57b-2c392def6025   none      none          off        
     oxp_588058f2-f51b-4800-a211-1c5dbb32296b/crucible                                                                97e6171d-523c-4c4a-9fa6-daead00d71a5   none      none          off        
-    oxp_588058f2-f51b-4800-a211-1c5dbb32296b/crypt/debug                                                             2ab9c443-5ea3-4ab1-b2ed-d57abbfde4be   100 GiB   none          gzip-9     
-    oxp_588058f2-f51b-4800-a211-1c5dbb32296b/crypt/zone                                                              86009a86-7c47-477d-bb17-c38689f5b337   none      none          off        
+    oxp_588058f2-f51b-4800-a211-1c5dbb32296b/crypt/debug                                                             3a49dd24-8ead-4196-b453-8aa3273b77d1   100 GiB   none          gzip-9     
+    oxp_588058f2-f51b-4800-a211-1c5dbb32296b/crypt/zone                                                              9327960e-a9a3-4b26-9bd4-65afb1737bd4   none      none          off        
     oxp_588058f2-f51b-4800-a211-1c5dbb32296b/crypt/zone/oxz_crucible_a91714d7-33b4-40d6-93cf-1b278bc9f1c6            f4c0087b-c746-4440-82e7-82ff5e40c6ab   none      none          off        
     oxp_736f6f07-2aa2-4658-8b5c-3bf409ea747a/crucible                                                                035b55e9-a0fc-48e5-8cd0-a862e7a7fe47   none      none          off        
-    oxp_736f6f07-2aa2-4658-8b5c-3bf409ea747a/crypt/debug                                                             0f785b1f-3f7a-4ae7-8a32-4412b781d245   100 GiB   none          gzip-9     
-    oxp_736f6f07-2aa2-4658-8b5c-3bf409ea747a/crypt/zone                                                              f3df6efd-e689-4aaa-b4ed-76de319a1fe4   none      none          off        
+    oxp_736f6f07-2aa2-4658-8b5c-3bf409ea747a/crypt/debug                                                             2ab9c443-5ea3-4ab1-b2ed-d57abbfde4be   100 GiB   none          gzip-9     
+    oxp_736f6f07-2aa2-4658-8b5c-3bf409ea747a/crypt/zone                                                              86009a86-7c47-477d-bb17-c38689f5b337   none      none          off        
     oxp_736f6f07-2aa2-4658-8b5c-3bf409ea747a/crypt/zone/oxz_crucible_79164b60-fbb4-46d4-9a42-eafbaeddd672            ebf1a36b-ab94-4a5d-a777-937991a60396   none      none          off        
     oxp_bcfcdede-7084-4a31-97a8-ac4299c268f9/crucible                                                                01def6ad-ddd9-4b28-b337-137a16734021   none      none          off        
-    oxp_bcfcdede-7084-4a31-97a8-ac4299c268f9/crypt/debug                                                             6fdd4ca2-022f-4ef3-9a83-1e18e620e9dc   100 GiB   none          gzip-9     
-    oxp_bcfcdede-7084-4a31-97a8-ac4299c268f9/crypt/zone                                                              d8d8dc6c-cd76-4d17-b530-25f3f3f52d33   none      none          off        
+    oxp_bcfcdede-7084-4a31-97a8-ac4299c268f9/crypt/debug                                                             ec40dcf8-085f-4277-8d96-657a1e7fb0c8   100 GiB   none          gzip-9     
+    oxp_bcfcdede-7084-4a31-97a8-ac4299c268f9/crypt/zone                                                              8b6d2ff8-4f40-4776-b461-29e0a3d3dd97   none      none          off        
     oxp_bcfcdede-7084-4a31-97a8-ac4299c268f9/crypt/zone/oxz_crucible_109820d7-b6ef-4574-b5e4-9f193c9d2a9e            75f329ff-4f3b-4cc5-8027-dd61d05e7323   none      none          off        
     oxp_fe379ac6-1938-4cc2-93a9-43b1447229ae/crucible                                                                5818a803-eb2c-44eb-8818-bd98bfa29da9   none      none          off        
-    oxp_fe379ac6-1938-4cc2-93a9-43b1447229ae/crypt/debug                                                             3a49dd24-8ead-4196-b453-8aa3273b77d1   100 GiB   none          gzip-9     
-    oxp_fe379ac6-1938-4cc2-93a9-43b1447229ae/crypt/zone                                                              9327960e-a9a3-4b26-9bd4-65afb1737bd4   none      none          off        
+    oxp_fe379ac6-1938-4cc2-93a9-43b1447229ae/crypt/debug                                                             f015e445-2e52-45c9-9f0a-49cb5ceae245   100 GiB   none          gzip-9     
+    oxp_fe379ac6-1938-4cc2-93a9-43b1447229ae/crypt/zone                                                              d5d2ddf7-2eb3-40f3-b149-aee5699b7bf1   none      none          off        
     oxp_fe379ac6-1938-4cc2-93a9-43b1447229ae/crypt/zone/oxz_crucible_43aa521b-eb86-4c3d-a58c-83c733f2fec3            c7a57806-05b3-4e38-9bc4-07fd6b30cccd   none      none          off        
 
 

--- a/nexus/reconfigurator/planning/tests/output/planner_expunge_clickhouse_zones_after_policy_is_changed_3_4.txt
+++ b/nexus/reconfigurator/planning/tests/output/planner_expunge_clickhouse_zones_after_policy_is_changed_3_4.txt
@@ -21,16 +21,16 @@ to:   blueprint d895ef50-9978-454c-bdfb-b8dbe2c9a918
     fake-vendor   fake-model   serial-fbc5bdf2-9644-4d0a-b349-f490486da25d
 
 
-    datasets generation 3 -> 4:
+    datasets generation 4 -> 5:
     -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
     dataset name                                                                                                     dataset uuid                           quota     reservation   compression
     -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
     oxp_41eaf63b-4fa9-443e-8da1-78d1e79aac7d/crucible                                                                5403ab59-fbc4-4747-a0a4-2e086d4611fd   none      none          off        
     oxp_41eaf63b-4fa9-443e-8da1-78d1e79aac7d/crypt/clickhouse                                                        595df8fe-7319-44ea-9170-83236f87b146   none      none          off        
     oxp_41eaf63b-4fa9-443e-8da1-78d1e79aac7d/crypt/clickhouse_keeper                                                 c949b5ca-05fe-4c0a-95d0-11c8fd18675b   none      none          off        
-    oxp_41eaf63b-4fa9-443e-8da1-78d1e79aac7d/crypt/debug                                                             ed00cbfa-3426-4072-a763-0facc8cd9c2f   100 GiB   none          gzip-9     
+    oxp_41eaf63b-4fa9-443e-8da1-78d1e79aac7d/crypt/debug                                                             c75ba2f4-5491-4d31-bee6-6054c0c829e4   100 GiB   none          gzip-9     
     oxp_41eaf63b-4fa9-443e-8da1-78d1e79aac7d/crypt/internal_dns                                                      0125252e-c9c2-4998-81e2-a82e534f7e3b   none      none          off        
-    oxp_41eaf63b-4fa9-443e-8da1-78d1e79aac7d/crypt/zone                                                              ddf90bf7-d58c-4f9c-9263-14cf354935a2   none      none          off        
+    oxp_41eaf63b-4fa9-443e-8da1-78d1e79aac7d/crypt/zone                                                              07f7066f-2644-4ca0-95f4-c1c8b88f3aef   none      none          off        
     oxp_41eaf63b-4fa9-443e-8da1-78d1e79aac7d/crypt/zone/oxz_clickhouse_6394624c-3aba-4be5-a6a2-68d9b5e506e4          8ab9adbc-d236-4167-b503-581ae9dc0136   none      none          off        
     oxp_41eaf63b-4fa9-443e-8da1-78d1e79aac7d/crypt/zone/oxz_clickhouse_keeper_15f8164a-63e5-404e-81a5-c13e5855f7ca   6ca0e723-77fd-4859-90b8-b12601f21bde   none      none          off        
     oxp_41eaf63b-4fa9-443e-8da1-78d1e79aac7d/crypt/zone/oxz_crucible_d2646147-0310-450a-a43b-8a1a9c513188            028e8d90-8472-49ad-90c8-83bef4a6a2e7   none      none          off        
@@ -43,36 +43,36 @@ to:   blueprint d895ef50-9978-454c-bdfb-b8dbe2c9a918
     oxp_5b04e3d3-7a8b-466e-ab63-6ca89a93e100/crypt/zone                                                              406b3824-685f-44c6-9878-175afc0ce17d   none      none          off        
     oxp_5b04e3d3-7a8b-466e-ab63-6ca89a93e100/crypt/zone/oxz_crucible_c57f188f-c51b-45d3-be4c-9e023d80e194            a9f4b44e-2e81-4047-8656-b9227fa3fdbb   none      none          off        
     oxp_6e8fdb9f-c47a-47b0-b7ee-9a2adc7e4af5/crucible                                                                177ee9e2-0605-4656-839d-664f7481b06b   none      none          off        
-    oxp_6e8fdb9f-c47a-47b0-b7ee-9a2adc7e4af5/crypt/debug                                                             0791e4d8-9e17-425b-8400-888a46f4ce96   100 GiB   none          gzip-9     
-    oxp_6e8fdb9f-c47a-47b0-b7ee-9a2adc7e4af5/crypt/zone                                                              3b9b3439-8f1c-4c15-bac6-26cda5005369   none      none          off        
+    oxp_6e8fdb9f-c47a-47b0-b7ee-9a2adc7e4af5/crypt/debug                                                             ed00cbfa-3426-4072-a763-0facc8cd9c2f   100 GiB   none          gzip-9     
+    oxp_6e8fdb9f-c47a-47b0-b7ee-9a2adc7e4af5/crypt/zone                                                              ddf90bf7-d58c-4f9c-9263-14cf354935a2   none      none          off        
     oxp_6e8fdb9f-c47a-47b0-b7ee-9a2adc7e4af5/crypt/zone/oxz_crucible_340d690d-52d6-4bd7-96a7-57989c3dd973            9e54a544-74dd-4a35-8cf5-dd78b9b79cef   none      none          off        
     oxp_8e2c9e92-e35e-494c-8e14-dcf5f5009656/crucible                                                                b6518271-24f3-4fd5-a371-5b840bd7b9db   none      none          off        
-    oxp_8e2c9e92-e35e-494c-8e14-dcf5f5009656/crypt/debug                                                             c75ba2f4-5491-4d31-bee6-6054c0c829e4   100 GiB   none          gzip-9     
-    oxp_8e2c9e92-e35e-494c-8e14-dcf5f5009656/crypt/zone                                                              07f7066f-2644-4ca0-95f4-c1c8b88f3aef   none      none          off        
+    oxp_8e2c9e92-e35e-494c-8e14-dcf5f5009656/crypt/debug                                                             e3929bba-ff30-4750-9190-1c507c62aad1   100 GiB   none          gzip-9     
+    oxp_8e2c9e92-e35e-494c-8e14-dcf5f5009656/crypt/zone                                                              35b11905-8c74-4104-901f-62ee66901985   none      none          off        
     oxp_8e2c9e92-e35e-494c-8e14-dcf5f5009656/crypt/zone/oxz_crucible_6809081c-a6ca-4f44-91cc-bde241475188            2291e434-3194-4001-a59a-25f1db01cef4   none      none          off        
     oxp_a4c575b4-934b-49b9-9c47-9c1241a33607/crucible                                                                632ea7a7-8a14-47ec-8cee-d7bd167d8d3d   none      none          off        
     oxp_a4c575b4-934b-49b9-9c47-9c1241a33607/crypt/debug                                                             b79cfade-ef8d-494c-8e46-5ac6f7d5a180   100 GiB   none          gzip-9     
     oxp_a4c575b4-934b-49b9-9c47-9c1241a33607/crypt/zone                                                              29c4d7a0-a184-4cf0-8efb-8ce4e54460f8   none      none          off        
     oxp_a4c575b4-934b-49b9-9c47-9c1241a33607/crypt/zone/oxz_crucible_512f26d7-2e46-4189-9c5a-ffbfb5d0a4e9            b6ac1d96-7b2c-4c13-82ea-5e9d96c85d5f   none      none          off        
     oxp_a9a8a692-d2d7-4b3e-a297-d648faf8c7cf/crucible                                                                50adbc61-76de-483a-8be7-00039aaa23ff   none      none          off        
-    oxp_a9a8a692-d2d7-4b3e-a297-d648faf8c7cf/crypt/debug                                                             e3929bba-ff30-4750-9190-1c507c62aad1   100 GiB   none          gzip-9     
-    oxp_a9a8a692-d2d7-4b3e-a297-d648faf8c7cf/crypt/zone                                                              35b11905-8c74-4104-901f-62ee66901985   none      none          off        
+    oxp_a9a8a692-d2d7-4b3e-a297-d648faf8c7cf/crypt/debug                                                             060fd4d2-006b-4096-88e1-57ad8d8726da   100 GiB   none          gzip-9     
+    oxp_a9a8a692-d2d7-4b3e-a297-d648faf8c7cf/crypt/zone                                                              a45173d1-377c-4466-b392-76660653d2ce   none      none          off        
     oxp_a9a8a692-d2d7-4b3e-a297-d648faf8c7cf/crypt/zone/oxz_crucible_7d884e93-9f4e-4063-84c8-802bb7262fd6            7237b67d-84cf-4465-b914-3c9dbe1c8d86   none      none          off        
     oxp_b65c8376-0084-4d6f-9891-9d6a413d4e56/crucible                                                                8a159a8e-c9b8-4497-a89a-c6244cefc180   none      none          off        
-    oxp_b65c8376-0084-4d6f-9891-9d6a413d4e56/crypt/debug                                                             a23c8851-f5c7-4458-8311-95ab7f97f859   100 GiB   none          gzip-9     
-    oxp_b65c8376-0084-4d6f-9891-9d6a413d4e56/crypt/zone                                                              867e4fc5-2312-4a0c-ad85-52b3790d49b1   none      none          off        
+    oxp_b65c8376-0084-4d6f-9891-9d6a413d4e56/crypt/debug                                                             0791e4d8-9e17-425b-8400-888a46f4ce96   100 GiB   none          gzip-9     
+    oxp_b65c8376-0084-4d6f-9891-9d6a413d4e56/crypt/zone                                                              3b9b3439-8f1c-4c15-bac6-26cda5005369   none      none          off        
     oxp_b65c8376-0084-4d6f-9891-9d6a413d4e56/crypt/zone/oxz_crucible_9bf902be-b1ca-44b9-9a09-ca6e68d022e3            76e3a199-4483-40e9-bd70-717ec354ebe1   none      none          off        
     oxp_bc61cdae-c96f-4886-b8bd-f9fd69d51e3a/crucible                                                                5b64d326-883e-4182-a78d-9b4db76b04e9   none      none          off        
-    oxp_bc61cdae-c96f-4886-b8bd-f9fd69d51e3a/crypt/debug                                                             48eac7a6-4484-4f24-9b48-b4b9c2d0869d   100 GiB   none          gzip-9     
-    oxp_bc61cdae-c96f-4886-b8bd-f9fd69d51e3a/crypt/zone                                                              bccfa224-0485-486c-a3fc-619cac293640   none      none          off        
+    oxp_bc61cdae-c96f-4886-b8bd-f9fd69d51e3a/crypt/debug                                                             e4e743bf-81d3-43fb-9255-c1ffc679b585   100 GiB   none          gzip-9     
+    oxp_bc61cdae-c96f-4886-b8bd-f9fd69d51e3a/crypt/zone                                                              c9a4c16a-c7ac-47ab-9633-6bdd924b7c58   none      none          off        
     oxp_bc61cdae-c96f-4886-b8bd-f9fd69d51e3a/crypt/zone/oxz_crucible_d5f97416-8c36-4148-8e22-0684fee6e85a            6c15dd01-680f-42f5-b25a-7c591daa22ea   none      none          off        
     oxp_e9f68306-460a-4b11-b904-f752633bf1fc/crucible                                                                2b84da4f-094b-4b2d-a15c-cda870045b07   none      none          off        
-    oxp_e9f68306-460a-4b11-b904-f752633bf1fc/crypt/debug                                                             e4e743bf-81d3-43fb-9255-c1ffc679b585   100 GiB   none          gzip-9     
-    oxp_e9f68306-460a-4b11-b904-f752633bf1fc/crypt/zone                                                              c9a4c16a-c7ac-47ab-9633-6bdd924b7c58   none      none          off        
+    oxp_e9f68306-460a-4b11-b904-f752633bf1fc/crypt/debug                                                             48eac7a6-4484-4f24-9b48-b4b9c2d0869d   100 GiB   none          gzip-9     
+    oxp_e9f68306-460a-4b11-b904-f752633bf1fc/crypt/zone                                                              bccfa224-0485-486c-a3fc-619cac293640   none      none          off        
     oxp_e9f68306-460a-4b11-b904-f752633bf1fc/crypt/zone/oxz_crucible_d34a3d41-8442-4981-8362-1e449c2c0154            113c2fd9-47b7-41e8-bd9d-0066fd3ac9ff   none      none          off        
     oxp_fbc5bdf2-9644-4d0a-b349-f490486da25d/crucible                                                                7f74ed80-0101-4b75-8515-aa80e82ee5fe   none      none          off        
-    oxp_fbc5bdf2-9644-4d0a-b349-f490486da25d/crypt/debug                                                             060fd4d2-006b-4096-88e1-57ad8d8726da   100 GiB   none          gzip-9     
-    oxp_fbc5bdf2-9644-4d0a-b349-f490486da25d/crypt/zone                                                              a45173d1-377c-4466-b392-76660653d2ce   none      none          off        
+    oxp_fbc5bdf2-9644-4d0a-b349-f490486da25d/crypt/debug                                                             a23c8851-f5c7-4458-8311-95ab7f97f859   100 GiB   none          gzip-9     
+    oxp_fbc5bdf2-9644-4d0a-b349-f490486da25d/crypt/zone                                                              867e4fc5-2312-4a0c-ad85-52b3790d49b1   none      none          off        
     oxp_fbc5bdf2-9644-4d0a-b349-f490486da25d/crypt/zone/oxz_crucible_289ece63-1c43-45d8-9731-411abaf62cfb            79cc327b-76da-40fb-b9f2-ca53af257d38   none      none          off        
 
 
@@ -117,7 +117,7 @@ to:   blueprint d895ef50-9978-454c-bdfb-b8dbe2c9a918
     fake-vendor   fake-model   serial-f52832ea-60d7-443b-9847-df5384bfc8e2
 
 
-    datasets generation 2 -> 3:
+    datasets generation 3 -> 4:
     -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
     dataset name                                                                                                     dataset uuid                           quota     reservation   compression
     -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
@@ -135,40 +135,40 @@ to:   blueprint d895ef50-9978-454c-bdfb-b8dbe2c9a918
     oxp_21b01477-48d0-4b65-9089-4a48277af033/crypt/zone/oxz_nexus_7cebfab2-4453-4614-b904-96939bc339d3               3593d78f-42f7-477a-bee7-3219a6bd919a   none      none          off        
     oxp_21b01477-48d0-4b65-9089-4a48277af033/crypt/zone/oxz_ntp_036a57cf-b759-4c24-af45-d15c60883e9f                 79417983-7d87-4258-9fc8-2b92a65c6f96   none      none          off        
     oxp_2704e66b-3d5c-4b64-951c-a051fa15e4a8/crucible                                                                775d2e5e-915f-4dba-9c67-37bfbedaf91e   none      none          off        
-    oxp_2704e66b-3d5c-4b64-951c-a051fa15e4a8/crypt/debug                                                             c51575aa-f374-4aba-89d6-69cbf63969d3   100 GiB   none          gzip-9     
-    oxp_2704e66b-3d5c-4b64-951c-a051fa15e4a8/crypt/zone                                                              92b1330a-f258-47a7-97a1-e1c79628ad1b   none      none          off        
+    oxp_2704e66b-3d5c-4b64-951c-a051fa15e4a8/crypt/debug                                                             9290f161-49cd-46ec-8387-d3896602fd68   100 GiB   none          gzip-9     
+    oxp_2704e66b-3d5c-4b64-951c-a051fa15e4a8/crypt/zone                                                              c6ad1efa-745b-42d4-8554-9eb8567a1396   none      none          off        
     oxp_2704e66b-3d5c-4b64-951c-a051fa15e4a8/crypt/zone/oxz_crucible_c6d063b8-9faa-42af-a216-bc4dff420804            9e223845-6f8a-425f-bb40-b6de25bc4695   none      none          off        
     oxp_27a22f7e-754a-43ea-8ec4-e9cbd9b62e08/crucible                                                                847b284a-be4f-4405-a93f-5b5cff4ee31b   none      none          off        
-    oxp_27a22f7e-754a-43ea-8ec4-e9cbd9b62e08/crypt/debug                                                             d7176bdc-894c-4656-bdb8-3a65f1608bc6   100 GiB   none          gzip-9     
-    oxp_27a22f7e-754a-43ea-8ec4-e9cbd9b62e08/crypt/zone                                                              f94213ab-5c96-476d-85c9-bf0801cc4941   none      none          off        
+    oxp_27a22f7e-754a-43ea-8ec4-e9cbd9b62e08/crypt/debug                                                             010b0156-d194-4b68-b415-be289435d37e   100 GiB   none          gzip-9     
+    oxp_27a22f7e-754a-43ea-8ec4-e9cbd9b62e08/crypt/zone                                                              55895da4-4e66-403e-b723-a76b1c2f907e   none      none          off        
     oxp_27a22f7e-754a-43ea-8ec4-e9cbd9b62e08/crypt/zone/oxz_crucible_13efd31e-52f3-4914-bc30-45f22828631a            45ba838b-e725-4e92-82e7-fb39dbd1d00d   none      none          off        
     oxp_51c788ff-de33-43f7-b9c5-f5f56bf80736/crucible                                                                0bbf7ff9-f6a6-49d8-8dc4-c75b2fdb5531   none      none          off        
-    oxp_51c788ff-de33-43f7-b9c5-f5f56bf80736/crypt/debug                                                             7aa3d413-7191-41f2-9f38-5feaff97bcfb   100 GiB   none          gzip-9     
-    oxp_51c788ff-de33-43f7-b9c5-f5f56bf80736/crypt/zone                                                              0160fea9-34cb-4b54-92fc-f6780f4b64c5   none      none          off        
+    oxp_51c788ff-de33-43f7-b9c5-f5f56bf80736/crypt/debug                                                             5683120b-7824-404c-9204-ad9592fbf562   100 GiB   none          gzip-9     
+    oxp_51c788ff-de33-43f7-b9c5-f5f56bf80736/crypt/zone                                                              1e27b440-2e30-477e-99fe-be13e2d17d64   none      none          off        
     oxp_51c788ff-de33-43f7-b9c5-f5f56bf80736/crypt/zone/oxz_crucible_fdb62b4e-d73b-4988-8780-9252f04f540f            f2e5b170-cb96-4a1b-98fd-0deae86cf059   none      none          off        
     oxp_5fe54077-c016-49a9-becb-14993f133d43/crucible                                                                2a41b700-5494-4aa1-900b-20618125c1d0   none      none          off        
-    oxp_5fe54077-c016-49a9-becb-14993f133d43/crypt/debug                                                             0705afaa-1e13-4cc6-8f6b-d3a7e93a5cca   100 GiB   none          gzip-9     
-    oxp_5fe54077-c016-49a9-becb-14993f133d43/crypt/zone                                                              122bd71a-d4dd-4838-a64a-1a7f22413224   none      none          off        
+    oxp_5fe54077-c016-49a9-becb-14993f133d43/crypt/debug                                                             d7176bdc-894c-4656-bdb8-3a65f1608bc6   100 GiB   none          gzip-9     
+    oxp_5fe54077-c016-49a9-becb-14993f133d43/crypt/zone                                                              f94213ab-5c96-476d-85c9-bf0801cc4941   none      none          off        
     oxp_5fe54077-c016-49a9-becb-14993f133d43/crypt/zone/oxz_crucible_deb1efa8-c55a-438e-9e32-15a9f1dde9c5            f4f8f6c7-a7f9-4f03-bbf4-3583ccdeaae3   none      none          off        
     oxp_7e2644a1-bec7-433c-8168-8898d7140aab/crucible                                                                fb04e4c9-9fbc-490c-9096-f3adfd6e1223   none      none          off        
-    oxp_7e2644a1-bec7-433c-8168-8898d7140aab/crypt/debug                                                             9290f161-49cd-46ec-8387-d3896602fd68   100 GiB   none          gzip-9     
-    oxp_7e2644a1-bec7-433c-8168-8898d7140aab/crypt/zone                                                              c6ad1efa-745b-42d4-8554-9eb8567a1396   none      none          off        
+    oxp_7e2644a1-bec7-433c-8168-8898d7140aab/crypt/debug                                                             0705afaa-1e13-4cc6-8f6b-d3a7e93a5cca   100 GiB   none          gzip-9     
+    oxp_7e2644a1-bec7-433c-8168-8898d7140aab/crypt/zone                                                              122bd71a-d4dd-4838-a64a-1a7f22413224   none      none          off        
     oxp_7e2644a1-bec7-433c-8168-8898d7140aab/crypt/zone/oxz_crucible_057daeb5-798b-439c-aab8-004b54343323            5929490a-4a7f-4b00-af68-550087145c2d   none      none          off        
     oxp_9825ff38-f07d-44a1-9efc-55a25e72015b/crucible                                                                34de0f9d-ab3a-4047-bbf3-d2bf4beb2995   none      none          off        
-    oxp_9825ff38-f07d-44a1-9efc-55a25e72015b/crypt/debug                                                             5683120b-7824-404c-9204-ad9592fbf562   100 GiB   none          gzip-9     
-    oxp_9825ff38-f07d-44a1-9efc-55a25e72015b/crypt/zone                                                              1e27b440-2e30-477e-99fe-be13e2d17d64   none      none          off        
+    oxp_9825ff38-f07d-44a1-9efc-55a25e72015b/crypt/debug                                                             7aa3d413-7191-41f2-9f38-5feaff97bcfb   100 GiB   none          gzip-9     
+    oxp_9825ff38-f07d-44a1-9efc-55a25e72015b/crypt/zone                                                              0160fea9-34cb-4b54-92fc-f6780f4b64c5   none      none          off        
     oxp_9825ff38-f07d-44a1-9efc-55a25e72015b/crypt/zone/oxz_crucible_eb9571d1-cfd2-4115-8f30-373edd25573e            e005f612-8e9e-4278-8441-7737b7c0c0ba   none      none          off        
     oxp_cc585a73-ec86-4f8e-a327-901b947a4c69/crucible                                                                cac5b0cb-c944-4c26-b016-c7556a2fd9ea   none      none          off        
-    oxp_cc585a73-ec86-4f8e-a327-901b947a4c69/crypt/debug                                                             e8e97c2d-c628-4310-b1b9-fe5b7e4537ea   100 GiB   none          gzip-9     
-    oxp_cc585a73-ec86-4f8e-a327-901b947a4c69/crypt/zone                                                              892e2f2a-0792-4634-b24d-fca1a0b8c434   none      none          off        
+    oxp_cc585a73-ec86-4f8e-a327-901b947a4c69/crypt/debug                                                             c51575aa-f374-4aba-89d6-69cbf63969d3   100 GiB   none          gzip-9     
+    oxp_cc585a73-ec86-4f8e-a327-901b947a4c69/crypt/zone                                                              92b1330a-f258-47a7-97a1-e1c79628ad1b   none      none          off        
     oxp_cc585a73-ec86-4f8e-a327-901b947a4c69/crypt/zone/oxz_crucible_d85f10cc-ea8d-4d9a-a198-9fcc999bb577            c2ced1b7-2df1-496e-8701-74d4c05446ce   none      none          off        
     oxp_d2801671-bb69-408e-93f7-ac2b05d992f8/crucible                                                                0ab453de-947c-4d5a-a3ee-bf26ed85396f   none      none          off        
-    oxp_d2801671-bb69-408e-93f7-ac2b05d992f8/crypt/debug                                                             5ab29fd5-a360-4699-9abd-c24c8a529009   100 GiB   none          gzip-9     
-    oxp_d2801671-bb69-408e-93f7-ac2b05d992f8/crypt/zone                                                              3b4b2059-de0b-4912-a57b-36b3858947a9   none      none          off        
+    oxp_d2801671-bb69-408e-93f7-ac2b05d992f8/crypt/debug                                                             e8e97c2d-c628-4310-b1b9-fe5b7e4537ea   100 GiB   none          gzip-9     
+    oxp_d2801671-bb69-408e-93f7-ac2b05d992f8/crypt/zone                                                              892e2f2a-0792-4634-b24d-fca1a0b8c434   none      none          off        
     oxp_d2801671-bb69-408e-93f7-ac2b05d992f8/crypt/zone/oxz_crucible_9da97e85-7aff-4815-8fac-a48bed2b8bd0            554557ea-949c-4e34-8031-93ab5369f587   none      none          off        
     oxp_f52832ea-60d7-443b-9847-df5384bfc8e2/crucible                                                                cc43cb24-2e55-415d-9a2a-49a6b924b284   none      none          off        
-    oxp_f52832ea-60d7-443b-9847-df5384bfc8e2/crypt/debug                                                             010b0156-d194-4b68-b415-be289435d37e   100 GiB   none          gzip-9     
-    oxp_f52832ea-60d7-443b-9847-df5384bfc8e2/crypt/zone                                                              55895da4-4e66-403e-b723-a76b1c2f907e   none      none          off        
+    oxp_f52832ea-60d7-443b-9847-df5384bfc8e2/crypt/debug                                                             5ab29fd5-a360-4699-9abd-c24c8a529009   100 GiB   none          gzip-9     
+    oxp_f52832ea-60d7-443b-9847-df5384bfc8e2/crypt/zone                                                              3b4b2059-de0b-4912-a57b-36b3858947a9   none      none          off        
     oxp_f52832ea-60d7-443b-9847-df5384bfc8e2/crypt/zone/oxz_crucible_0c59cc2b-00e8-4243-bf24-1cfc25a212a3            445423d9-3331-48ef-b98b-156c234b290c   none      none          off        
 
 
@@ -214,16 +214,16 @@ to:   blueprint d895ef50-9978-454c-bdfb-b8dbe2c9a918
     fake-vendor   fake-model   serial-facb28ca-94fd-47a0-bf63-ee394d32c43b
 
 
-    datasets generation 2 -> 3:
+    datasets generation 3 -> 4:
     -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
     dataset name                                                                                                     dataset uuid                           quota     reservation   compression
     -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
     oxp_288d864c-3a9e-4f21-8c6e-720702c82a29/crucible                                                                d76f6218-ca13-40d6-bea4-fc7ceeb2926b   none      none          off        
     oxp_288d864c-3a9e-4f21-8c6e-720702c82a29/crypt/clickhouse_keeper                                                 e181ab51-2eb2-4552-a38c-9bafcaf7765b   none      none          off        
     oxp_288d864c-3a9e-4f21-8c6e-720702c82a29/crypt/clickhouse_server                                                 b0d669e6-1faf-4562-82fa-040422a06c9b   none      none          off        
-    oxp_288d864c-3a9e-4f21-8c6e-720702c82a29/crypt/debug                                                             2de28d6e-987e-42bd-9323-10e4bc772d33   100 GiB   none          gzip-9     
+    oxp_288d864c-3a9e-4f21-8c6e-720702c82a29/crypt/debug                                                             9cf0f2dc-c6f6-43ba-b508-85990f8cecf4   100 GiB   none          gzip-9     
     oxp_288d864c-3a9e-4f21-8c6e-720702c82a29/crypt/internal_dns                                                      a3ce0f4d-a253-4284-907b-f59e777564df   none      none          off        
-    oxp_288d864c-3a9e-4f21-8c6e-720702c82a29/crypt/zone                                                              10877dd7-7567-4226-9033-b2af0d88529e   none      none          off        
+    oxp_288d864c-3a9e-4f21-8c6e-720702c82a29/crypt/zone                                                              c937194c-05d5-4f53-9078-d3a6f07cbe5e   none      none          off        
     oxp_288d864c-3a9e-4f21-8c6e-720702c82a29/crypt/zone/oxz_clickhouse_keeper_b8f84002-e213-4311-9d0a-f5a100735ea5   849d2000-dab1-4f5f-b9b9-79294aefe298   none      none          off        
     oxp_288d864c-3a9e-4f21-8c6e-720702c82a29/crypt/zone/oxz_clickhouse_server_c3c0a7b9-2829-4b2d-a2d9-bd2bab02af0f   4aeb359a-4f04-4267-8316-291871cbf89b   none      none          off        
     oxp_288d864c-3a9e-4f21-8c6e-720702c82a29/crypt/zone/oxz_crucible_f25ab7b4-e3e7-4cad-aae3-3cefd2040506            fcea9a6f-5b9c-45c7-953d-feceb00a2e9a   none      none          off        
@@ -232,40 +232,40 @@ to:   blueprint d895ef50-9978-454c-bdfb-b8dbe2c9a918
     oxp_288d864c-3a9e-4f21-8c6e-720702c82a29/crypt/zone/oxz_nexus_7ac3bbd8-bbdd-4acd-9957-efbb43354f70               52db4583-1028-4908-989c-9024fb5c9159   none      none          off        
     oxp_288d864c-3a9e-4f21-8c6e-720702c82a29/crypt/zone/oxz_ntp_df6e43a7-ad9b-41c8-bea4-421b1b52e059                 75576295-3742-45c5-b5d5-7bc045b3e451   none      none          off        
     oxp_5f877424-eca4-4c5d-af7f-41627382cfd8/crucible                                                                ddcd2927-1cc7-4aa1-8d90-0ac8ec13f64a   none      none          off        
-    oxp_5f877424-eca4-4c5d-af7f-41627382cfd8/crypt/debug                                                             e6ec4e00-713e-4b9c-a156-df22f5019dab   100 GiB   none          gzip-9     
-    oxp_5f877424-eca4-4c5d-af7f-41627382cfd8/crypt/zone                                                              df1cff74-0dba-465b-a5ac-97638d129c97   none      none          off        
+    oxp_5f877424-eca4-4c5d-af7f-41627382cfd8/crypt/debug                                                             2bf3bf5c-4136-40b9-833e-4f4e0a0028c0   100 GiB   none          gzip-9     
+    oxp_5f877424-eca4-4c5d-af7f-41627382cfd8/crypt/zone                                                              6c044af3-8312-4239-b74b-d62bff4c2335   none      none          off        
     oxp_5f877424-eca4-4c5d-af7f-41627382cfd8/crypt/zone/oxz_crucible_b37afa7c-2ff1-4f5f-9040-4099ed12906b            c6a6fc32-0fe5-4b91-9a32-7acb0b74231e   none      none          off        
     oxp_65ebc532-cbb7-43e1-923b-37c5cb7236d7/crucible                                                                e9203f73-5fdd-4902-9f75-cbb9f3b176b8   none      none          off        
-    oxp_65ebc532-cbb7-43e1-923b-37c5cb7236d7/crypt/debug                                                             2bf3bf5c-4136-40b9-833e-4f4e0a0028c0   100 GiB   none          gzip-9     
-    oxp_65ebc532-cbb7-43e1-923b-37c5cb7236d7/crypt/zone                                                              6c044af3-8312-4239-b74b-d62bff4c2335   none      none          off        
+    oxp_65ebc532-cbb7-43e1-923b-37c5cb7236d7/crypt/debug                                                             b58ebe62-ffb9-45eb-be29-9211a74f5369   100 GiB   none          gzip-9     
+    oxp_65ebc532-cbb7-43e1-923b-37c5cb7236d7/crypt/zone                                                              c7726fd7-bee1-473c-b392-5c32bc59bd9a   none      none          off        
     oxp_65ebc532-cbb7-43e1-923b-37c5cb7236d7/crypt/zone/oxz_crucible_d70acd67-a84c-418e-8867-799ed9b856ef            039974e3-aeb5-472f-bfa9-ddbdbc417a96   none      none          off        
     oxp_8277a18f-3187-4893-8ef1-5cbfe2284616/crucible                                                                b462ccdb-a0d9-44cc-953a-4fe1b4037c9a   none      none          off        
-    oxp_8277a18f-3187-4893-8ef1-5cbfe2284616/crypt/debug                                                             b58ebe62-ffb9-45eb-be29-9211a74f5369   100 GiB   none          gzip-9     
-    oxp_8277a18f-3187-4893-8ef1-5cbfe2284616/crypt/zone                                                              c7726fd7-bee1-473c-b392-5c32bc59bd9a   none      none          off        
+    oxp_8277a18f-3187-4893-8ef1-5cbfe2284616/crypt/debug                                                             a17ba250-f11d-42f1-8cc5-ed35a662bfc2   100 GiB   none          gzip-9     
+    oxp_8277a18f-3187-4893-8ef1-5cbfe2284616/crypt/zone                                                              f93193ae-e6b5-4d89-b85e-7eec27ff1e20   none      none          off        
     oxp_8277a18f-3187-4893-8ef1-5cbfe2284616/crypt/zone/oxz_crucible_6a31350d-eb6c-4b61-97ff-0d673c07fee3            a94317df-b46f-431b-b5af-023dad4e8bd5   none      none          off        
     oxp_83592889-d746-4c5d-98e8-582d9c34a15f/crucible                                                                efd08a8a-2110-4cf8-ba3f-49a525b24adb   none      none          off        
-    oxp_83592889-d746-4c5d-98e8-582d9c34a15f/crypt/debug                                                             a17ba250-f11d-42f1-8cc5-ed35a662bfc2   100 GiB   none          gzip-9     
-    oxp_83592889-d746-4c5d-98e8-582d9c34a15f/crypt/zone                                                              f93193ae-e6b5-4d89-b85e-7eec27ff1e20   none      none          off        
+    oxp_83592889-d746-4c5d-98e8-582d9c34a15f/crypt/debug                                                             e36f06e6-b3a8-45ea-9b01-0e3e9b43d54a   100 GiB   none          gzip-9     
+    oxp_83592889-d746-4c5d-98e8-582d9c34a15f/crypt/zone                                                              a6ddc1e2-f6d0-4524-a745-b3d6416f8b5f   none      none          off        
     oxp_83592889-d746-4c5d-98e8-582d9c34a15f/crypt/zone/oxz_crucible_26d3f8d0-228a-4f89-aa4a-fa33aeba4fd0            6f2af271-d4e4-46e1-9220-22c3f9718852   none      none          off        
     oxp_88e423b5-98c9-4e78-992a-5d01e1c33272/crucible                                                                d4fa3bc4-799f-4c1d-a57f-58b7daf7abc0   none      none          off        
-    oxp_88e423b5-98c9-4e78-992a-5d01e1c33272/crypt/debug                                                             ade46ccb-5a1b-4461-bbf8-ad99fc47580f   100 GiB   none          gzip-9     
-    oxp_88e423b5-98c9-4e78-992a-5d01e1c33272/crypt/zone                                                              9fcbb996-0ec9-41ea-bd0b-94663faeabea   none      none          off        
+    oxp_88e423b5-98c9-4e78-992a-5d01e1c33272/crypt/debug                                                             b375cde4-ff30-4f27-9561-3e9f83d671da   100 GiB   none          gzip-9     
+    oxp_88e423b5-98c9-4e78-992a-5d01e1c33272/crypt/zone                                                              6ad4f8be-cd3b-4950-8a86-f854dc96580f   none      none          off        
     oxp_88e423b5-98c9-4e78-992a-5d01e1c33272/crypt/zone/oxz_crucible_b1546506-c538-4c74-9f5d-8e9c8e68896e            7d782152-aac5-4604-86d8-303bb9e9b42c   none      none          off        
     oxp_a5553017-9991-4ffb-ae37-f9c0e3428562/crucible                                                                96b5bbc7-ea73-48ac-8533-96a6c1c2f59f   none      none          off        
-    oxp_a5553017-9991-4ffb-ae37-f9c0e3428562/crypt/debug                                                             e36f06e6-b3a8-45ea-9b01-0e3e9b43d54a   100 GiB   none          gzip-9     
-    oxp_a5553017-9991-4ffb-ae37-f9c0e3428562/crypt/zone                                                              a6ddc1e2-f6d0-4524-a745-b3d6416f8b5f   none      none          off        
+    oxp_a5553017-9991-4ffb-ae37-f9c0e3428562/crypt/debug                                                             ade46ccb-5a1b-4461-bbf8-ad99fc47580f   100 GiB   none          gzip-9     
+    oxp_a5553017-9991-4ffb-ae37-f9c0e3428562/crypt/zone                                                              9fcbb996-0ec9-41ea-bd0b-94663faeabea   none      none          off        
     oxp_a5553017-9991-4ffb-ae37-f9c0e3428562/crypt/zone/oxz_crucible_446a395a-2f8b-4849-a0d5-bbdca403b095            bee9e11b-1beb-4984-bfca-54fb82015ec9   none      none          off        
     oxp_b2c5a75b-9f72-405a-8134-691c0f45a1fd/crucible                                                                5b37edae-1bf4-4b0e-aba8-0111c831eac5   none      none          off        
-    oxp_b2c5a75b-9f72-405a-8134-691c0f45a1fd/crypt/debug                                                             9cf0f2dc-c6f6-43ba-b508-85990f8cecf4   100 GiB   none          gzip-9     
-    oxp_b2c5a75b-9f72-405a-8134-691c0f45a1fd/crypt/zone                                                              c937194c-05d5-4f53-9078-d3a6f07cbe5e   none      none          off        
+    oxp_b2c5a75b-9f72-405a-8134-691c0f45a1fd/crypt/debug                                                             2de28d6e-987e-42bd-9323-10e4bc772d33   100 GiB   none          gzip-9     
+    oxp_b2c5a75b-9f72-405a-8134-691c0f45a1fd/crypt/zone                                                              10877dd7-7567-4226-9033-b2af0d88529e   none      none          off        
     oxp_b2c5a75b-9f72-405a-8134-691c0f45a1fd/crypt/zone/oxz_crucible_6afd4461-ef10-48b3-83c9-7dcbddee6595            a2078b28-9e04-4076-868e-fee483108252   none      none          off        
     oxp_d4d665fc-df4d-4a13-b9c2-ad13549c0845/crucible                                                                032746d6-e276-4b59-a17e-349c98ace522   none      none          off        
     oxp_d4d665fc-df4d-4a13-b9c2-ad13549c0845/crypt/debug                                                             80ecfdaf-b5a9-4e3f-a187-15ac2cb1db16   100 GiB   none          gzip-9     
     oxp_d4d665fc-df4d-4a13-b9c2-ad13549c0845/crypt/zone                                                              dc23d8ef-b503-4ac3-ae28-5bf78c4ebc70   none      none          off        
     oxp_d4d665fc-df4d-4a13-b9c2-ad13549c0845/crypt/zone/oxz_crucible_f84c9d55-5c9d-43a1-a6e5-f769eeaae158            2b866c41-827e-4e98-bd5b-f6d20d839f9d   none      none          off        
     oxp_facb28ca-94fd-47a0-bf63-ee394d32c43b/crucible                                                                2b1819c1-a30e-42c4-b5fa-67f71e496ba1   none      none          off        
-    oxp_facb28ca-94fd-47a0-bf63-ee394d32c43b/crypt/debug                                                             b375cde4-ff30-4f27-9561-3e9f83d671da   100 GiB   none          gzip-9     
-    oxp_facb28ca-94fd-47a0-bf63-ee394d32c43b/crypt/zone                                                              6ad4f8be-cd3b-4950-8a86-f854dc96580f   none      none          off        
+    oxp_facb28ca-94fd-47a0-bf63-ee394d32c43b/crypt/debug                                                             e6ec4e00-713e-4b9c-a156-df22f5019dab   100 GiB   none          gzip-9     
+    oxp_facb28ca-94fd-47a0-bf63-ee394d32c43b/crypt/zone                                                              df1cff74-0dba-465b-a5ac-97638d129c97   none      none          off        
     oxp_facb28ca-94fd-47a0-bf63-ee394d32c43b/crypt/zone/oxz_crucible_7e6977aa-6e27-4a9f-9d82-e42f883ffb8d            dfd64a35-1573-49c6-a542-a057c7a5ae20   none      none          off        
 +   oxp_288d864c-3a9e-4f21-8c6e-720702c82a29/crypt/clickhouse                                                        b642a90a-32e9-48a8-b5e7-aede02141b67   none      none          off        
 +   oxp_288d864c-3a9e-4f21-8c6e-720702c82a29/crypt/zone/oxz_clickhouse_729bb1a1-20e6-42b1-9a42-d495c6697823          19df5137-af48-4224-91bb-b00c7460c42a   none      none          off        

--- a/nexus/reconfigurator/planning/tests/output/planner_nonprovisionable_1_2.txt
+++ b/nexus/reconfigurator/planning/tests/output/planner_nonprovisionable_1_2.txt
@@ -21,15 +21,15 @@ to:   blueprint 9f71f5d3-a272-4382-9154-6ea2e171a6c6
     fake-vendor   fake-model   serial-d1ebfd7b-3842-4ad7-be31-2b9c031209a9
 
 
-    datasets at generation 1:
+    datasets at generation 2:
     -----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
     dataset name                                                                                                   dataset uuid                           quota     reservation   compression
     -----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
     oxp_13e6503b-5300-4ccd-abc4-c1512b435929/crucible                                                              79a16369-70ab-4f63-af6d-1c7f088eeee3   none      none          off        
     oxp_13e6503b-5300-4ccd-abc4-c1512b435929/crypt/clickhouse                                                      d577ac11-62ac-4a71-bed7-e7327148bd33   none      none          off        
-    oxp_13e6503b-5300-4ccd-abc4-c1512b435929/crypt/debug                                                           d6d36f6b-35ff-4766-99de-44abe46932d1   100 GiB   none          gzip-9     
+    oxp_13e6503b-5300-4ccd-abc4-c1512b435929/crypt/debug                                                           26154290-91f7-4f35-bcd0-ec7a8f398d82   100 GiB   none          gzip-9     
     oxp_13e6503b-5300-4ccd-abc4-c1512b435929/crypt/internal_dns                                                    b9aa1175-2640-4923-81b3-1e1469b15abf   none      none          off        
-    oxp_13e6503b-5300-4ccd-abc4-c1512b435929/crypt/zone                                                            18e2a336-9b65-421e-8409-04d9abce8cd6   none      none          off        
+    oxp_13e6503b-5300-4ccd-abc4-c1512b435929/crypt/zone                                                            c37902cf-d1fe-4370-baef-b7de8731dffe   none      none          off        
     oxp_13e6503b-5300-4ccd-abc4-c1512b435929/crypt/zone/oxz_clickhouse_93b137a1-a1d6-4b5b-b2cb-21a9f11e2883        d1a755ac-dafc-4087-a0ce-ee8b3f882ac1   none      none          off        
     oxp_13e6503b-5300-4ccd-abc4-c1512b435929/crypt/zone/oxz_crucible_19fbc4f8-a683-4f22-8f5a-e74782b935be          68724637-d228-4faa-a19f-b5df857ff4ab   none      none          off        
     oxp_13e6503b-5300-4ccd-abc4-c1512b435929/crypt/zone/oxz_crucible_pantry_9f0abbad-dbd3-4d43-9675-78092217ffd9   da62be58-643f-4497-a9d7-e259de6c7a12   none      none          off        
@@ -37,40 +37,40 @@ to:   blueprint 9f71f5d3-a272-4382-9154-6ea2e171a6c6
     oxp_13e6503b-5300-4ccd-abc4-c1512b435929/crypt/zone/oxz_nexus_6dff7633-66bb-4924-a6ff-2c896e66964b             9dce1e52-8e3b-4641-9982-69deb049f647   none      none          off        
     oxp_13e6503b-5300-4ccd-abc4-c1512b435929/crypt/zone/oxz_ntp_7f4e9f9f-08f8-4d14-885d-e977c05525ad               7773ffbd-1842-4425-aff5-88f577cd8955   none      none          off        
     oxp_44cdb6f2-fa6c-4b69-bab2-3ae4e1ec4b34/crucible                                                              ac31a04c-1f3a-43f4-b45a-cf4b5176e7f6   none      none          off        
-    oxp_44cdb6f2-fa6c-4b69-bab2-3ae4e1ec4b34/crypt/debug                                                           26154290-91f7-4f35-bcd0-ec7a8f398d82   100 GiB   none          gzip-9     
-    oxp_44cdb6f2-fa6c-4b69-bab2-3ae4e1ec4b34/crypt/zone                                                            c37902cf-d1fe-4370-baef-b7de8731dffe   none      none          off        
+    oxp_44cdb6f2-fa6c-4b69-bab2-3ae4e1ec4b34/crypt/debug                                                           2e901ffa-895b-4405-b59a-2bcdfabda681   100 GiB   none          gzip-9     
+    oxp_44cdb6f2-fa6c-4b69-bab2-3ae4e1ec4b34/crypt/zone                                                            41e55e8a-ca4b-4c27-8337-57d42cc36fb5   none      none          off        
     oxp_44cdb6f2-fa6c-4b69-bab2-3ae4e1ec4b34/crypt/zone/oxz_crucible_6b53ab2e-d98c-485f-87a3-4d5df595390f          51229ad8-cda3-40c4-b0f3-b1af669abcd4   none      none          off        
     oxp_4de5fc8e-0e41-4ab9-ba12-2dc63882c96a/crucible                                                              b92bba84-9437-4f93-8ad0-80bf7ecdae5f   none      none          off        
-    oxp_4de5fc8e-0e41-4ab9-ba12-2dc63882c96a/crypt/debug                                                           6dc5df73-7e44-4065-9f14-70a0d965a853   100 GiB   none          gzip-9     
-    oxp_4de5fc8e-0e41-4ab9-ba12-2dc63882c96a/crypt/zone                                                            00c2d1d6-94da-4985-a144-2194588afecf   none      none          off        
+    oxp_4de5fc8e-0e41-4ab9-ba12-2dc63882c96a/crypt/debug                                                           d6d36f6b-35ff-4766-99de-44abe46932d1   100 GiB   none          gzip-9     
+    oxp_4de5fc8e-0e41-4ab9-ba12-2dc63882c96a/crypt/zone                                                            18e2a336-9b65-421e-8409-04d9abce8cd6   none      none          off        
     oxp_4de5fc8e-0e41-4ab9-ba12-2dc63882c96a/crypt/zone/oxz_crucible_b0c63f48-01ea-4aae-bb26-fb0dd59d1662          5d8788c0-13df-4c07-a8b2-b9365fec9796   none      none          off        
     oxp_51564e7a-d69f-4942-bcfe-330224633ca6/crucible                                                              dedbf4e7-32fb-406e-a5cc-a2f5281aa6d8   none      none          off        
-    oxp_51564e7a-d69f-4942-bcfe-330224633ca6/crypt/debug                                                           3063bdcc-4363-495b-a81f-67c6cc437a75   100 GiB   none          gzip-9     
-    oxp_51564e7a-d69f-4942-bcfe-330224633ca6/crypt/zone                                                            3527b52f-f1d4-4e2f-b41e-559f58657839   none      none          off        
+    oxp_51564e7a-d69f-4942-bcfe-330224633ca6/crypt/debug                                                           ee20f8cb-7d24-422b-9dff-ca4c9596191f   100 GiB   none          gzip-9     
+    oxp_51564e7a-d69f-4942-bcfe-330224633ca6/crypt/zone                                                            ae6c87ea-dc50-4a15-855a-224300f20c74   none      none          off        
     oxp_51564e7a-d69f-4942-bcfe-330224633ca6/crypt/zone/oxz_crucible_f55e6aaf-e8fc-4913-9e3c-8cd1bd4bdad3          82fc150e-d6f5-4bb6-8eee-17a0728aadb5   none      none          off        
     oxp_5ca23cb3-cc90-41c5-a474-01898cdd0796/crucible                                                              b2c9f282-e767-4df1-941e-b7cea21b1a02   none      none          off        
-    oxp_5ca23cb3-cc90-41c5-a474-01898cdd0796/crypt/debug                                                           53deebeb-3952-483a-afd2-2202cee9c33b   100 GiB   none          gzip-9     
-    oxp_5ca23cb3-cc90-41c5-a474-01898cdd0796/crypt/zone                                                            22581703-157c-474f-bbf3-34f076dd7bca   none      none          off        
+    oxp_5ca23cb3-cc90-41c5-a474-01898cdd0796/crypt/debug                                                           3063bdcc-4363-495b-a81f-67c6cc437a75   100 GiB   none          gzip-9     
+    oxp_5ca23cb3-cc90-41c5-a474-01898cdd0796/crypt/zone                                                            3527b52f-f1d4-4e2f-b41e-559f58657839   none      none          off        
     oxp_5ca23cb3-cc90-41c5-a474-01898cdd0796/crypt/zone/oxz_crucible_d660d7ed-28c0-45ae-9ace-dc3ecf7e8786          68217627-4519-4cfa-85b9-25efb4dad71a   none      none          off        
     oxp_6a23a532-0712-4a8d-be9b-e8c17e97aa4b/crucible                                                              47cf951d-ca5c-4ae0-baa3-94472efbcf03   none      none          off        
-    oxp_6a23a532-0712-4a8d-be9b-e8c17e97aa4b/crypt/debug                                                           e315743d-53e3-4505-9364-657c2486a1bb   100 GiB   none          gzip-9     
-    oxp_6a23a532-0712-4a8d-be9b-e8c17e97aa4b/crypt/zone                                                            4d6e70b1-ff91-4133-b65f-6fcd5bda2568   none      none          off        
+    oxp_6a23a532-0712-4a8d-be9b-e8c17e97aa4b/crypt/debug                                                           84bc6d3f-2d9c-42b3-9982-7394630a0928   100 GiB   none          gzip-9     
+    oxp_6a23a532-0712-4a8d-be9b-e8c17e97aa4b/crypt/zone                                                            3fc37e5a-3bf3-476f-8a8f-6d32a533cfc0   none      none          off        
     oxp_6a23a532-0712-4a8d-be9b-e8c17e97aa4b/crypt/zone/oxz_crucible_e98cc0de-abf6-4da4-a20d-d05c7a9bb1d7          a602c9d4-16a9-4e55-b5de-76fb33cc4ca9   none      none          off        
     oxp_6f1a330e-e8d4-4c09-97fc-8918b69b2a3c/crucible                                                              9390bde4-2073-44b4-a496-5129c7e5ca40   none      none          off        
-    oxp_6f1a330e-e8d4-4c09-97fc-8918b69b2a3c/crypt/debug                                                           2e901ffa-895b-4405-b59a-2bcdfabda681   100 GiB   none          gzip-9     
-    oxp_6f1a330e-e8d4-4c09-97fc-8918b69b2a3c/crypt/zone                                                            41e55e8a-ca4b-4c27-8337-57d42cc36fb5   none      none          off        
+    oxp_6f1a330e-e8d4-4c09-97fc-8918b69b2a3c/crypt/debug                                                           e315743d-53e3-4505-9364-657c2486a1bb   100 GiB   none          gzip-9     
+    oxp_6f1a330e-e8d4-4c09-97fc-8918b69b2a3c/crypt/zone                                                            4d6e70b1-ff91-4133-b65f-6fcd5bda2568   none      none          off        
     oxp_6f1a330e-e8d4-4c09-97fc-8918b69b2a3c/crypt/zone/oxz_crucible_4f1ce8a2-d3a5-4a38-be4c-9817de52db37          ef14767b-6be7-44cb-833d-27d9f523dcdb   none      none          off        
     oxp_7113d104-fb55-4299-bf53-b3c59d258e44/crucible                                                              5ffb2b84-4a3f-444a-aebf-381f8c58b7ae   none      none          off        
-    oxp_7113d104-fb55-4299-bf53-b3c59d258e44/crypt/debug                                                           ee20f8cb-7d24-422b-9dff-ca4c9596191f   100 GiB   none          gzip-9     
-    oxp_7113d104-fb55-4299-bf53-b3c59d258e44/crypt/zone                                                            ae6c87ea-dc50-4a15-855a-224300f20c74   none      none          off        
+    oxp_7113d104-fb55-4299-bf53-b3c59d258e44/crypt/debug                                                           0c11d380-038c-4b68-b9f4-1775f6fec1e8   100 GiB   none          gzip-9     
+    oxp_7113d104-fb55-4299-bf53-b3c59d258e44/crypt/zone                                                            64a64a7b-0d29-4470-bc96-4796ca357507   none      none          off        
     oxp_7113d104-fb55-4299-bf53-b3c59d258e44/crypt/zone/oxz_crucible_67d913e0-0005-4599-9b28-0abbf6cc2916          d63be5b2-5471-4f4d-accc-82e2a0d7276f   none      none          off        
     oxp_8c10be49-3a66-40d4-a082-64d09d916f14/crucible                                                              d72ffc3a-4665-40bc-a099-ebe628622636   none      none          off        
-    oxp_8c10be49-3a66-40d4-a082-64d09d916f14/crypt/debug                                                           84bc6d3f-2d9c-42b3-9982-7394630a0928   100 GiB   none          gzip-9     
-    oxp_8c10be49-3a66-40d4-a082-64d09d916f14/crypt/zone                                                            3fc37e5a-3bf3-476f-8a8f-6d32a533cfc0   none      none          off        
+    oxp_8c10be49-3a66-40d4-a082-64d09d916f14/crypt/debug                                                           53deebeb-3952-483a-afd2-2202cee9c33b   100 GiB   none          gzip-9     
+    oxp_8c10be49-3a66-40d4-a082-64d09d916f14/crypt/zone                                                            22581703-157c-474f-bbf3-34f076dd7bca   none      none          off        
     oxp_8c10be49-3a66-40d4-a082-64d09d916f14/crypt/zone/oxz_crucible_2aa0ea4f-3561-4989-a98c-9ab7d9a240fb          05a77359-0a07-4976-8fbb-5f1eee688e47   none      none          off        
     oxp_d1ebfd7b-3842-4ad7-be31-2b9c031209a9/crucible                                                              39185a78-064c-49d5-b716-93f1a312c0c1   none      none          off        
-    oxp_d1ebfd7b-3842-4ad7-be31-2b9c031209a9/crypt/debug                                                           0c11d380-038c-4b68-b9f4-1775f6fec1e8   100 GiB   none          gzip-9     
-    oxp_d1ebfd7b-3842-4ad7-be31-2b9c031209a9/crypt/zone                                                            64a64a7b-0d29-4470-bc96-4796ca357507   none      none          off        
+    oxp_d1ebfd7b-3842-4ad7-be31-2b9c031209a9/crypt/debug                                                           6dc5df73-7e44-4065-9f14-70a0d965a853   100 GiB   none          gzip-9     
+    oxp_d1ebfd7b-3842-4ad7-be31-2b9c031209a9/crypt/zone                                                            00c2d1d6-94da-4985-a144-2194588afecf   none      none          off        
     oxp_d1ebfd7b-3842-4ad7-be31-2b9c031209a9/crypt/zone/oxz_crucible_67622d61-2df4-414d-aa0e-d1277265f405          6dbd0e11-89af-4464-bd84-c20cb818a9d5   none      none          off        
 
 
@@ -115,7 +115,7 @@ to:   blueprint 9f71f5d3-a272-4382-9154-6ea2e171a6c6
 -   fake-vendor   fake-model   serial-ef64ff6d-250d-47ac-8686-e696cfb46966
 
 
-    datasets from generation 1:
+    datasets from generation 2:
     -----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
     dataset name                                                                                                   dataset uuid                           quota     reservation   compression
     -----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
@@ -133,36 +133,36 @@ to:   blueprint 9f71f5d3-a272-4382-9154-6ea2e171a6c6
 -   oxp_24155070-8a43-4244-a3ba-853d8c71972d/crypt/zone                                                            2b630e70-1cd8-4142-aee9-7067b6fe3ef3   none      none          off        
 -   oxp_24155070-8a43-4244-a3ba-853d8c71972d/crypt/zone/oxz_crucible_e39d7c9e-182b-48af-af87-58079d723583          f49fa95b-4d2d-4ea3-a9ff-5ed73bf29a7f   none      none          off        
 -   oxp_494782c7-3821-4f49-918b-ce42cc4d18ad/crucible                                                              0c7a0040-a420-4c46-a43f-cf531b30218b   none      none          off        
--   oxp_494782c7-3821-4f49-918b-ce42cc4d18ad/crypt/debug                                                           988e1f23-ecca-487a-aec7-089593a043cc   100 GiB   none          gzip-9     
--   oxp_494782c7-3821-4f49-918b-ce42cc4d18ad/crypt/zone                                                            04c9bd23-0d9f-4a36-a442-42b9e3c54179   none      none          off        
+-   oxp_494782c7-3821-4f49-918b-ce42cc4d18ad/crypt/debug                                                           0043d0b0-c24e-4858-afa3-2e3ae2a99a78   100 GiB   none          gzip-9     
+-   oxp_494782c7-3821-4f49-918b-ce42cc4d18ad/crypt/zone                                                            b916b8aa-73b5-433d-ab69-fe3166cc6574   none      none          off        
 -   oxp_494782c7-3821-4f49-918b-ce42cc4d18ad/crypt/zone/oxz_crucible_b91b271d-8d80-4f49-99a0-34006ae86063          73830784-d10d-489b-9e08-41f96e8ae130   none      none          off        
 -   oxp_6ea8a67f-d27d-472b-844c-6c8245b00e2b/crucible                                                              b47d4afb-fa04-4f3a-9816-fa83714b211f   none      none          off        
--   oxp_6ea8a67f-d27d-472b-844c-6c8245b00e2b/crypt/debug                                                           b26bab43-3760-4418-a6ab-47e01b267a1d   100 GiB   none          gzip-9     
--   oxp_6ea8a67f-d27d-472b-844c-6c8245b00e2b/crypt/zone                                                            38e45596-3b96-4ab9-bf80-274dded9157a   none      none          off        
+-   oxp_6ea8a67f-d27d-472b-844c-6c8245b00e2b/crypt/debug                                                           941ef258-4015-4176-bbc0-5fa323fe2802   100 GiB   none          gzip-9     
+-   oxp_6ea8a67f-d27d-472b-844c-6c8245b00e2b/crypt/zone                                                            6551d496-8da9-4d11-9be2-7fc3a49f4759   none      none          off        
 -   oxp_6ea8a67f-d27d-472b-844c-6c8245b00e2b/crypt/zone/oxz_crucible_f69f92a1-5007-4bb0-a85b-604dc217154b          4dc23347-b0aa-4705-a309-1baf57f222f2   none      none          off        
 -   oxp_77565d57-c235-4905-b3c7-32d1c2ca2c44/crucible                                                              56f99204-06fc-41fb-8f0c-456c7e97b034   none      none          off        
--   oxp_77565d57-c235-4905-b3c7-32d1c2ca2c44/crypt/debug                                                           f1299161-15fd-424f-a739-6263c314ba90   100 GiB   none          gzip-9     
--   oxp_77565d57-c235-4905-b3c7-32d1c2ca2c44/crypt/zone                                                            dc86fcab-2838-4b6c-bea3-3cb0fcec846a   none      none          off        
+-   oxp_77565d57-c235-4905-b3c7-32d1c2ca2c44/crypt/debug                                                           86a8f677-e4d5-466a-bffb-60d653e91ce5   100 GiB   none          gzip-9     
+-   oxp_77565d57-c235-4905-b3c7-32d1c2ca2c44/crypt/zone                                                            619c6140-1d63-495b-a5e4-be8f1fefe5ed   none      none          off        
 -   oxp_77565d57-c235-4905-b3c7-32d1c2ca2c44/crypt/zone/oxz_crucible_094f27af-1acb-4d1e-ba97-1fc1377d4bf2          035d0068-1470-4491-900a-e8812e10376f   none      none          off        
 -   oxp_8746874c-dc3b-4454-93cd-2a8fc13720fe/crucible                                                              c310b273-8e72-40e1-8f07-a52d2b7532f3   none      none          off        
--   oxp_8746874c-dc3b-4454-93cd-2a8fc13720fe/crypt/debug                                                           86573b1f-e557-4da1-b7e2-3f3b42dba8de   100 GiB   none          gzip-9     
--   oxp_8746874c-dc3b-4454-93cd-2a8fc13720fe/crypt/zone                                                            97735f9a-4a36-4f9a-97f5-900204167d44   none      none          off        
+-   oxp_8746874c-dc3b-4454-93cd-2a8fc13720fe/crypt/debug                                                           b26bab43-3760-4418-a6ab-47e01b267a1d   100 GiB   none          gzip-9     
+-   oxp_8746874c-dc3b-4454-93cd-2a8fc13720fe/crypt/zone                                                            38e45596-3b96-4ab9-bf80-274dded9157a   none      none          off        
 -   oxp_8746874c-dc3b-4454-93cd-2a8fc13720fe/crypt/zone/oxz_crucible_f3f2e4f3-0985-4ef6-8336-ce479382d05d          a916c527-eca0-4df7-b38e-76f4f7915656   none      none          off        
 -   oxp_a42c5a67-6e10-4586-a56e-48bb8260e75f/crucible                                                              b5844aab-20fe-47c8-8b1d-d2e4b2e75702   none      none          off        
--   oxp_a42c5a67-6e10-4586-a56e-48bb8260e75f/crypt/debug                                                           86a8f677-e4d5-466a-bffb-60d653e91ce5   100 GiB   none          gzip-9     
--   oxp_a42c5a67-6e10-4586-a56e-48bb8260e75f/crypt/zone                                                            619c6140-1d63-495b-a5e4-be8f1fefe5ed   none      none          off        
+-   oxp_a42c5a67-6e10-4586-a56e-48bb8260e75f/crypt/debug                                                           988e1f23-ecca-487a-aec7-089593a043cc   100 GiB   none          gzip-9     
+-   oxp_a42c5a67-6e10-4586-a56e-48bb8260e75f/crypt/zone                                                            04c9bd23-0d9f-4a36-a442-42b9e3c54179   none      none          off        
 -   oxp_a42c5a67-6e10-4586-a56e-48bb8260e75f/crypt/zone/oxz_crucible_01d58626-e1b0-480f-96be-ac784863c7dc          ff5950ed-1acc-477f-a9c1-f660161943f4   none      none          off        
 -   oxp_ca89b120-7bcd-4eeb-baa7-71031fbd103b/crucible                                                              f6d614eb-b40d-431b-8a15-f29b7434e702   none      none          off        
--   oxp_ca89b120-7bcd-4eeb-baa7-71031fbd103b/crypt/debug                                                           0043d0b0-c24e-4858-afa3-2e3ae2a99a78   100 GiB   none          gzip-9     
--   oxp_ca89b120-7bcd-4eeb-baa7-71031fbd103b/crypt/zone                                                            b916b8aa-73b5-433d-ab69-fe3166cc6574   none      none          off        
+-   oxp_ca89b120-7bcd-4eeb-baa7-71031fbd103b/crypt/debug                                                           86573b1f-e557-4da1-b7e2-3f3b42dba8de   100 GiB   none          gzip-9     
+-   oxp_ca89b120-7bcd-4eeb-baa7-71031fbd103b/crypt/zone                                                            97735f9a-4a36-4f9a-97f5-900204167d44   none      none          off        
 -   oxp_ca89b120-7bcd-4eeb-baa7-71031fbd103b/crypt/zone/oxz_crucible_47a87c6e-ef45-4d52-9a3e-69cdd96737cc          51c0f16b-1ca5-48e6-b2e9-0069cbe9c48b   none      none          off        
 -   oxp_ef61aa97-c862-428c-82f3-0a69a50d6155/crucible                                                              4ee918f4-7f38-4759-9cea-00208b404c09   none      none          off        
--   oxp_ef61aa97-c862-428c-82f3-0a69a50d6155/crypt/debug                                                           941ef258-4015-4176-bbc0-5fa323fe2802   100 GiB   none          gzip-9     
--   oxp_ef61aa97-c862-428c-82f3-0a69a50d6155/crypt/zone                                                            6551d496-8da9-4d11-9be2-7fc3a49f4759   none      none          off        
+-   oxp_ef61aa97-c862-428c-82f3-0a69a50d6155/crypt/debug                                                           98a2efcf-db1a-46a1-a4b9-01cf83b48e56   100 GiB   none          gzip-9     
+-   oxp_ef61aa97-c862-428c-82f3-0a69a50d6155/crypt/zone                                                            db457b0d-72f5-47c9-a86c-f9c2c4d3064b   none      none          off        
 -   oxp_ef61aa97-c862-428c-82f3-0a69a50d6155/crypt/zone/oxz_crucible_6464d025-4652-4948-919e-740bec5699b1          9f67b263-7a55-44a2-b0a0-e738b89fb472   none      none          off        
 -   oxp_ef64ff6d-250d-47ac-8686-e696cfb46966/crucible                                                              50faf412-62e6-4cb9-a965-d07b7b035da7   none      none          off        
--   oxp_ef64ff6d-250d-47ac-8686-e696cfb46966/crypt/debug                                                           98a2efcf-db1a-46a1-a4b9-01cf83b48e56   100 GiB   none          gzip-9     
--   oxp_ef64ff6d-250d-47ac-8686-e696cfb46966/crypt/zone                                                            db457b0d-72f5-47c9-a86c-f9c2c4d3064b   none      none          off        
+-   oxp_ef64ff6d-250d-47ac-8686-e696cfb46966/crypt/debug                                                           f1299161-15fd-424f-a739-6263c314ba90   100 GiB   none          gzip-9     
+-   oxp_ef64ff6d-250d-47ac-8686-e696cfb46966/crypt/zone                                                            dc86fcab-2838-4b6c-bea3-3cb0fcec846a   none      none          off        
 -   oxp_ef64ff6d-250d-47ac-8686-e696cfb46966/crypt/zone/oxz_crucible_878dfddd-3113-4197-a3ea-e0d4dbe9b476          f95cc7aa-db18-4277-ad08-528c02d267e4   none      none          off        
 
 
@@ -218,54 +218,54 @@ to:   blueprint 9f71f5d3-a272-4382-9154-6ea2e171a6c6
 -   fake-vendor   fake-model   serial-d56b0c9f-0e57-43d8-a1ac-8b4d2c303c29
 
 
-    datasets from generation 1:
+    datasets from generation 2:
     -----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
     dataset name                                                                                                   dataset uuid                           quota     reservation   compression
     -----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
 -   oxp_09a5de95-c15f-486e-b776-fca62bf5e179/crucible                                                              a68daa64-5586-4806-8aaf-3b87601d7439   none      none          off        
--   oxp_09a5de95-c15f-486e-b776-fca62bf5e179/crypt/debug                                                           c0485a6d-fe97-47b0-bf93-eb58308fc3c1   100 GiB   none          gzip-9     
+-   oxp_09a5de95-c15f-486e-b776-fca62bf5e179/crypt/debug                                                           5d5eedcd-8193-40ed-9018-7faab9df80c0   100 GiB   none          gzip-9     
 -   oxp_09a5de95-c15f-486e-b776-fca62bf5e179/crypt/internal_dns                                                    fa80f286-3de6-4042-907a-398973c726ef   none      none          off        
--   oxp_09a5de95-c15f-486e-b776-fca62bf5e179/crypt/zone                                                            bec5341c-bcb2-4e7c-92e1-d6c47f435ea2   none      none          off        
+-   oxp_09a5de95-c15f-486e-b776-fca62bf5e179/crypt/zone                                                            422f8e78-ab9d-4a60-b859-a036db2979a7   none      none          off        
 -   oxp_09a5de95-c15f-486e-b776-fca62bf5e179/crypt/zone/oxz_crucible_c407795c-6c8b-428e-8ab8-b962913c447f          99ad09ef-da25-4187-b83a-3e95fc8898f7   none      none          off        
 -   oxp_09a5de95-c15f-486e-b776-fca62bf5e179/crypt/zone/oxz_crucible_pantry_6939ce48-b17c-4616-b176-8a419a7697be   35fda90e-04f2-4a3e-89ee-92f9b6047956   none      none          off        
 -   oxp_09a5de95-c15f-486e-b776-fca62bf5e179/crypt/zone/oxz_internal_dns_b6b759d0-f60d-42b7-bbbc-9d61c9e895a9      577d3d90-d609-418b-9278-0cbf605294c6   none      none          off        
 -   oxp_09a5de95-c15f-486e-b776-fca62bf5e179/crypt/zone/oxz_nexus_b44cdbc0-0ce0-46eb-8b21-a09e113aa1d0             c9208413-484e-47bf-9d54-ec7977cccd81   none      none          off        
 -   oxp_09a5de95-c15f-486e-b776-fca62bf5e179/crypt/zone/oxz_ntp_9fd52961-426f-4e62-a644-b70871103fca               2f54bd95-c1d7-4aaa-95e2-7ecacb4be6e3   none      none          off        
 -   oxp_11b8eccf-7c78-4bde-8639-b35a83082a95/crucible                                                              703b5340-55ff-4053-af0b-fd5d20f8c47f   none      none          off        
--   oxp_11b8eccf-7c78-4bde-8639-b35a83082a95/crypt/debug                                                           571edc71-daed-4b47-b4ba-0dc0e29e5e9d   100 GiB   none          gzip-9     
--   oxp_11b8eccf-7c78-4bde-8639-b35a83082a95/crypt/zone                                                            34c338eb-b4ea-4c8f-b60e-d3ec612f662c   none      none          off        
+-   oxp_11b8eccf-7c78-4bde-8639-b35a83082a95/crypt/debug                                                           a3152a55-6fe7-4b34-90ee-e2370860b197   100 GiB   none          gzip-9     
+-   oxp_11b8eccf-7c78-4bde-8639-b35a83082a95/crypt/zone                                                            bf566572-3446-46c4-ba77-88b57f59dc99   none      none          off        
 -   oxp_11b8eccf-7c78-4bde-8639-b35a83082a95/crypt/zone/oxz_crucible_8d4d2b28-82bb-4e36-80da-1408d8c35d82          458ce5af-7d1b-4484-a11d-3c5f8e01bc9a   none      none          off        
 -   oxp_1931c422-4c6a-4597-8ae7-ecb44718462c/crucible                                                              c674cb78-2509-4a6a-86a9-57dcd8b59dfb   none      none          off        
--   oxp_1931c422-4c6a-4597-8ae7-ecb44718462c/crypt/debug                                                           5c8d8475-6f8a-4a4a-bc30-d6fdb6d057f2   100 GiB   none          gzip-9     
--   oxp_1931c422-4c6a-4597-8ae7-ecb44718462c/crypt/zone                                                            c575e10d-30ff-4201-9e3a-892fc8f2fc51   none      none          off        
+-   oxp_1931c422-4c6a-4597-8ae7-ecb44718462c/crypt/debug                                                           d5497445-1e12-4497-94e5-087fc82cce67   100 GiB   none          gzip-9     
+-   oxp_1931c422-4c6a-4597-8ae7-ecb44718462c/crypt/zone                                                            1ed89b99-e4e5-4873-8ab3-f68285365c8c   none      none          off        
 -   oxp_1931c422-4c6a-4597-8ae7-ecb44718462c/crypt/zone/oxz_crucible_3b3c14b6-a8e2-4054-a577-8d96cb576230          93d7d978-cfe4-4637-8809-1b234ca7784d   none      none          off        
 -   oxp_21a8a87e-73a4-42d4-a426-f6eec94004e3/crucible                                                              a0f3bb4d-67e5-4384-9d17-fbe562f8605a   none      none          off        
--   oxp_21a8a87e-73a4-42d4-a426-f6eec94004e3/crypt/debug                                                           21e32545-8f60-412f-9f0f-384c00a8c3c7   100 GiB   none          gzip-9     
--   oxp_21a8a87e-73a4-42d4-a426-f6eec94004e3/crypt/zone                                                            c32b8e04-6296-49d8-bf08-16a249890867   none      none          off        
+-   oxp_21a8a87e-73a4-42d4-a426-f6eec94004e3/crypt/debug                                                           c0485a6d-fe97-47b0-bf93-eb58308fc3c1   100 GiB   none          gzip-9     
+-   oxp_21a8a87e-73a4-42d4-a426-f6eec94004e3/crypt/zone                                                            bec5341c-bcb2-4e7c-92e1-d6c47f435ea2   none      none          off        
 -   oxp_21a8a87e-73a4-42d4-a426-f6eec94004e3/crypt/zone/oxz_crucible_57b96d5c-b71e-43e4-8869-7d514003d00d          07a1540e-5775-4768-9938-e8a9031ace4f   none      none          off        
 -   oxp_222c0b55-2966-46b6-816c-9063a7587806/crucible                                                              f4d87d35-e308-41f9-af74-6f7169295160   none      none          off        
--   oxp_222c0b55-2966-46b6-816c-9063a7587806/crypt/debug                                                           d9c04df5-0f09-4f6f-883b-29137611d89b   100 GiB   none          gzip-9     
--   oxp_222c0b55-2966-46b6-816c-9063a7587806/crypt/zone                                                            a08d5c26-4524-4b70-888e-a8db7f2883cb   none      none          off        
+-   oxp_222c0b55-2966-46b6-816c-9063a7587806/crypt/debug                                                           5c8d8475-6f8a-4a4a-bc30-d6fdb6d057f2   100 GiB   none          gzip-9     
+-   oxp_222c0b55-2966-46b6-816c-9063a7587806/crypt/zone                                                            c575e10d-30ff-4201-9e3a-892fc8f2fc51   none      none          off        
 -   oxp_222c0b55-2966-46b6-816c-9063a7587806/crypt/zone/oxz_crucible_b4947d31-f70e-4ee0-8817-0ca6cea9b16b          b4ec6b4d-cac2-44ca-8592-b2951398bd9d   none      none          off        
 -   oxp_3676f688-f41c-4f89-936a-6b04c3011b2a/crucible                                                              6439fca6-e8ae-4eff-b9a5-04dd674b1743   none      none          off        
 -   oxp_3676f688-f41c-4f89-936a-6b04c3011b2a/crypt/debug                                                           222b4387-2804-4d53-ba2f-4a32777d0b72   100 GiB   none          gzip-9     
 -   oxp_3676f688-f41c-4f89-936a-6b04c3011b2a/crypt/zone                                                            5b3537cb-5cd4-48f8-bb9b-222f8287b990   none      none          off        
 -   oxp_3676f688-f41c-4f89-936a-6b04c3011b2a/crypt/zone/oxz_crucible_e4b3e159-3dbe-48cb-8497-e3da92a90e5a          231ab7ea-48cd-45f4-b359-d9ff54732688   none      none          off        
 -   oxp_5e9e14c4-d60d-4b5c-a11c-bba54eb24c9f/crucible                                                              f89c2279-d18a-4f57-98cc-b48267835008   none      none          off        
--   oxp_5e9e14c4-d60d-4b5c-a11c-bba54eb24c9f/crypt/debug                                                           d5497445-1e12-4497-94e5-087fc82cce67   100 GiB   none          gzip-9     
--   oxp_5e9e14c4-d60d-4b5c-a11c-bba54eb24c9f/crypt/zone                                                            1ed89b99-e4e5-4873-8ab3-f68285365c8c   none      none          off        
+-   oxp_5e9e14c4-d60d-4b5c-a11c-bba54eb24c9f/crypt/debug                                                           571edc71-daed-4b47-b4ba-0dc0e29e5e9d   100 GiB   none          gzip-9     
+-   oxp_5e9e14c4-d60d-4b5c-a11c-bba54eb24c9f/crypt/zone                                                            34c338eb-b4ea-4c8f-b60e-d3ec612f662c   none      none          off        
 -   oxp_5e9e14c4-d60d-4b5c-a11c-bba54eb24c9f/crypt/zone/oxz_crucible_b1783e95-9598-451d-b6ba-c50b52b428c3          0bad1d7b-9fa4-4f29-9374-0b2aa2ebcda3   none      none          off        
 -   oxp_74f7b89e-88f5-4336-ba8b-22283a6966c5/crucible                                                              ff77f150-ae89-4483-872a-d269e06c807c   none      none          off        
--   oxp_74f7b89e-88f5-4336-ba8b-22283a6966c5/crypt/debug                                                           ac76ddfb-dafd-47fb-87c7-abee8b82f6bd   100 GiB   none          gzip-9     
--   oxp_74f7b89e-88f5-4336-ba8b-22283a6966c5/crypt/zone                                                            b7dab9eb-f509-4e87-976a-aba0d11578a8   none      none          off        
+-   oxp_74f7b89e-88f5-4336-ba8b-22283a6966c5/crypt/debug                                                           d9c04df5-0f09-4f6f-883b-29137611d89b   100 GiB   none          gzip-9     
+-   oxp_74f7b89e-88f5-4336-ba8b-22283a6966c5/crypt/zone                                                            a08d5c26-4524-4b70-888e-a8db7f2883cb   none      none          off        
 -   oxp_74f7b89e-88f5-4336-ba8b-22283a6966c5/crypt/zone/oxz_crucible_15bb9def-69b8-4d2e-b04f-9fee1143387c          d9b8254c-75fa-45b6-8816-e3e6da18f49f   none      none          off        
 -   oxp_a787cac8-b5e3-49e3-aaab-20d8eadd8a63/crucible                                                              3648ccea-b4ff-4087-9cf4-8291096ef1b3   none      none          off        
--   oxp_a787cac8-b5e3-49e3-aaab-20d8eadd8a63/crypt/debug                                                           a3152a55-6fe7-4b34-90ee-e2370860b197   100 GiB   none          gzip-9     
--   oxp_a787cac8-b5e3-49e3-aaab-20d8eadd8a63/crypt/zone                                                            bf566572-3446-46c4-ba77-88b57f59dc99   none      none          off        
+-   oxp_a787cac8-b5e3-49e3-aaab-20d8eadd8a63/crypt/debug                                                           21e32545-8f60-412f-9f0f-384c00a8c3c7   100 GiB   none          gzip-9     
+-   oxp_a787cac8-b5e3-49e3-aaab-20d8eadd8a63/crypt/zone                                                            c32b8e04-6296-49d8-bf08-16a249890867   none      none          off        
 -   oxp_a787cac8-b5e3-49e3-aaab-20d8eadd8a63/crypt/zone/oxz_crucible_996d7570-b0df-46d5-aaa4-0c97697cf484          c5d41993-88ce-471d-bd89-6ffd35dc8f61   none      none          off        
 -   oxp_d56b0c9f-0e57-43d8-a1ac-8b4d2c303c29/crucible                                                              a073286c-c538-421f-855b-ba7bca328900   none      none          off        
--   oxp_d56b0c9f-0e57-43d8-a1ac-8b4d2c303c29/crypt/debug                                                           5d5eedcd-8193-40ed-9018-7faab9df80c0   100 GiB   none          gzip-9     
--   oxp_d56b0c9f-0e57-43d8-a1ac-8b4d2c303c29/crypt/zone                                                            422f8e78-ab9d-4a60-b859-a036db2979a7   none      none          off        
+-   oxp_d56b0c9f-0e57-43d8-a1ac-8b4d2c303c29/crypt/debug                                                           ac76ddfb-dafd-47fb-87c7-abee8b82f6bd   100 GiB   none          gzip-9     
+-   oxp_d56b0c9f-0e57-43d8-a1ac-8b4d2c303c29/crypt/zone                                                            b7dab9eb-f509-4e87-976a-aba0d11578a8   none      none          off        
 -   oxp_d56b0c9f-0e57-43d8-a1ac-8b4d2c303c29/crypt/zone/oxz_crucible_c6dd531e-2d1d-423b-acc8-358533dab78c          e2105178-7bec-4e0f-95a9-91f0e698cca5   none      none          off        
 
 
@@ -307,51 +307,51 @@ to:   blueprint 9f71f5d3-a272-4382-9154-6ea2e171a6c6
     fake-vendor   fake-model   serial-f4d7f914-ec73-4b65-8696-5068591d9065
 
 
-    datasets generation 1 -> 2:
+    datasets generation 2 -> 3:
     ----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
     dataset name                                                                                            dataset uuid                           quota     reservation   compression
     ----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
     oxp_4069c804-c51a-4adc-8822-3cbbab56ed3f/crucible                                                       5c9ef84c-434c-4406-b68a-70e9af65b5a5   none      none          off        
-    oxp_4069c804-c51a-4adc-8822-3cbbab56ed3f/crypt/debug                                                    bf9b39db-5a6a-4b45-b2da-c37425271014   100 GiB   none          gzip-9     
-    oxp_4069c804-c51a-4adc-8822-3cbbab56ed3f/crypt/zone                                                     fc0b9a2c-4002-4fff-92f4-b541b7dd18c4   none      none          off        
+    oxp_4069c804-c51a-4adc-8822-3cbbab56ed3f/crypt/debug                                                    b803d901-7e43-42fa-8372-43c3c5b3c1a9   100 GiB   none          gzip-9     
+    oxp_4069c804-c51a-4adc-8822-3cbbab56ed3f/crypt/zone                                                     ccf69d3f-87be-4f8c-9191-9dde56547b21   none      none          off        
     oxp_4069c804-c51a-4adc-8822-3cbbab56ed3f/crypt/zone/oxz_crucible_85b8c68a-160d-461d-94dd-1baf175fa75c   7b00d896-de30-48f8-bcb7-b140ffab2781   none      none          off        
     oxp_4069c804-c51a-4adc-8822-3cbbab56ed3f/crypt/zone/oxz_nexus_a732c489-d29a-4f75-b900-5966385943af      db6c139b-9028-4d8e-92c7-6cc1e9aa0131   none      none          off        
     oxp_4069c804-c51a-4adc-8822-3cbbab56ed3f/crypt/zone/oxz_ntp_621509d6-3772-4009-aca1-35eefd1098fb        3b5822d2-9918-4bd6-8b75-2f52bdd73189   none      none          off        
     oxp_5248a306-4a03-449e-a8a3-6f86d26da755/crucible                                                       182f7cbb-ea53-4057-b85c-667e5d949db5   none      none          off        
-    oxp_5248a306-4a03-449e-a8a3-6f86d26da755/crypt/debug                                                    1b4e8d9e-e447-4df1-8e0b-57edc318e8ad   100 GiB   none          gzip-9     
-    oxp_5248a306-4a03-449e-a8a3-6f86d26da755/crypt/zone                                                     5f097047-8290-438a-b85a-80bc9450b26c   none      none          off        
+    oxp_5248a306-4a03-449e-a8a3-6f86d26da755/crypt/debug                                                    ae4f4e83-0bd1-48dc-bfe3-f1082e8f357a   100 GiB   none          gzip-9     
+    oxp_5248a306-4a03-449e-a8a3-6f86d26da755/crypt/zone                                                     b19e4e13-79e3-481d-ad80-db076a26b7eb   none      none          off        
     oxp_5248a306-4a03-449e-a8a3-6f86d26da755/crypt/zone/oxz_crucible_f0ff59e8-4105-4980-a4bb-a1f4c58de1e3   c596346d-4040-4103-b036-8fafdbaada00   none      none          off        
     oxp_55196665-ed61-4b23-9a74-0711bf2eaf90/crucible                                                       931c4336-5ff9-45ce-b71b-9b6e81e16e53   none      none          off        
-    oxp_55196665-ed61-4b23-9a74-0711bf2eaf90/crypt/debug                                                    ae4f4e83-0bd1-48dc-bfe3-f1082e8f357a   100 GiB   none          gzip-9     
-    oxp_55196665-ed61-4b23-9a74-0711bf2eaf90/crypt/zone                                                     b19e4e13-79e3-481d-ad80-db076a26b7eb   none      none          off        
+    oxp_55196665-ed61-4b23-9a74-0711bf2eaf90/crypt/debug                                                    bf9b39db-5a6a-4b45-b2da-c37425271014   100 GiB   none          gzip-9     
+    oxp_55196665-ed61-4b23-9a74-0711bf2eaf90/crypt/zone                                                     fc0b9a2c-4002-4fff-92f4-b541b7dd18c4   none      none          off        
     oxp_55196665-ed61-4b23-9a74-0711bf2eaf90/crypt/zone/oxz_crucible_23a8fa2b-ef3e-4017-a43f-f7a83953bd7c   3c7c5190-92dd-4d3b-9222-95d82a530d9e   none      none          off        
     oxp_6b2a719a-35eb-469f-aa54-114a1f21f37d/crucible                                                       11e2e73b-93a1-47f1-aff3-c4dc7667f4f1   none      none          off        
-    oxp_6b2a719a-35eb-469f-aa54-114a1f21f37d/crypt/debug                                                    be833d4e-3439-41ac-b3ad-3e4d14a66360   100 GiB   none          gzip-9     
-    oxp_6b2a719a-35eb-469f-aa54-114a1f21f37d/crypt/zone                                                     7ab2c8a5-3135-4a51-a232-7af8c72b9d3c   none      none          off        
+    oxp_6b2a719a-35eb-469f-aa54-114a1f21f37d/crypt/debug                                                    2dfc5c53-6618-4352-b754-86ef6463c20a   100 GiB   none          gzip-9     
+    oxp_6b2a719a-35eb-469f-aa54-114a1f21f37d/crypt/zone                                                     e79fbff1-f7fb-4912-9f5c-faca57a6a9c4   none      none          off        
     oxp_6b2a719a-35eb-469f-aa54-114a1f21f37d/crypt/zone/oxz_crucible_f1a7b9a7-fc6a-4b23-b829-045ff33117ff   c864de0d-9859-4ad1-a30b-f5ac45ba03ed   none      none          off        
     oxp_7ed4296a-66d1-4fb2-bc56-9b23b8f27d7e/crucible                                                       bdc3e42b-b28f-42c9-99fa-3f92e8b30a3c   none      none          off        
-    oxp_7ed4296a-66d1-4fb2-bc56-9b23b8f27d7e/crypt/debug                                                    a02b70bf-b069-4fec-9f53-1976ba462c45   100 GiB   none          gzip-9     
-    oxp_7ed4296a-66d1-4fb2-bc56-9b23b8f27d7e/crypt/zone                                                     4b69a9a9-2994-433c-9733-05de50d9c2a1   none      none          off        
+    oxp_7ed4296a-66d1-4fb2-bc56-9b23b8f27d7e/crypt/debug                                                    1b4e8d9e-e447-4df1-8e0b-57edc318e8ad   100 GiB   none          gzip-9     
+    oxp_7ed4296a-66d1-4fb2-bc56-9b23b8f27d7e/crypt/zone                                                     5f097047-8290-438a-b85a-80bc9450b26c   none      none          off        
     oxp_7ed4296a-66d1-4fb2-bc56-9b23b8f27d7e/crypt/zone/oxz_crucible_15c103f0-ac63-423b-ba5d-1b5fcd563ba3   02deac75-eb1a-423e-9b64-d20ca921fc25   none      none          off        
     oxp_984e2389-e7fd-4af9-ab02-e3caf77f95b5/crucible                                                       5c956b09-323e-476c-9a71-352154b1f841   none      none          off        
-    oxp_984e2389-e7fd-4af9-ab02-e3caf77f95b5/crypt/debug                                                    5c79ad9d-1aef-407d-804c-ace1d0e069a4   100 GiB   none          gzip-9     
-    oxp_984e2389-e7fd-4af9-ab02-e3caf77f95b5/crypt/zone                                                     b27f6972-47f0-43e9-a7cb-3a2fcd93798b   none      none          off        
+    oxp_984e2389-e7fd-4af9-ab02-e3caf77f95b5/crypt/debug                                                    a02b70bf-b069-4fec-9f53-1976ba462c45   100 GiB   none          gzip-9     
+    oxp_984e2389-e7fd-4af9-ab02-e3caf77f95b5/crypt/zone                                                     4b69a9a9-2994-433c-9733-05de50d9c2a1   none      none          off        
     oxp_984e2389-e7fd-4af9-ab02-e3caf77f95b5/crypt/zone/oxz_crucible_95482c25-1e7f-43e8-adf1-e3548a1b3ae0   5c5d822f-d696-4b6a-a075-286c437deba1   none      none          off        
     oxp_a5f75431-3795-426c-8f80-176f658281a5/crucible                                                       7b4f5c33-6a5a-42f9-8199-69f72761b24d   none      none          off        
     oxp_a5f75431-3795-426c-8f80-176f658281a5/crypt/debug                                                    dbc27904-c6dd-4cdc-96c8-32a24bdba0a1   100 GiB   none          gzip-9     
     oxp_a5f75431-3795-426c-8f80-176f658281a5/crypt/zone                                                     4d913be5-fa91-4b22-b714-53babe093654   none      none          off        
     oxp_a5f75431-3795-426c-8f80-176f658281a5/crypt/zone/oxz_crucible_3aa07966-5899-4789-ace5-f8eeb375c6c3   23ff87ad-3d52-4c7e-a9a3-be288d08835c   none      none          off        
     oxp_cf32a1ce-2c9e-49f5-b1cf-4af7f2a28901/crucible                                                       77279948-9fe2-46f2-af39-0d5b692f5984   none      none          off        
-    oxp_cf32a1ce-2c9e-49f5-b1cf-4af7f2a28901/crypt/debug                                                    2dfc5c53-6618-4352-b754-86ef6463c20a   100 GiB   none          gzip-9     
-    oxp_cf32a1ce-2c9e-49f5-b1cf-4af7f2a28901/crypt/zone                                                     e79fbff1-f7fb-4912-9f5c-faca57a6a9c4   none      none          off        
+    oxp_cf32a1ce-2c9e-49f5-b1cf-4af7f2a28901/crypt/debug                                                    be833d4e-3439-41ac-b3ad-3e4d14a66360   100 GiB   none          gzip-9     
+    oxp_cf32a1ce-2c9e-49f5-b1cf-4af7f2a28901/crypt/zone                                                     7ab2c8a5-3135-4a51-a232-7af8c72b9d3c   none      none          off        
     oxp_cf32a1ce-2c9e-49f5-b1cf-4af7f2a28901/crypt/zone/oxz_crucible_c60379ba-4e30-4628-a79a-0ae509aef4c5   a6fcf496-70a1-49bf-a951-62fcec8dd5e2   none      none          off        
     oxp_e405da11-cb6b-4ebc-bac1-9bc997352e10/crucible                                                       0f6d5b5f-674d-465e-9b40-d09c6865416a   none      none          off        
-    oxp_e405da11-cb6b-4ebc-bac1-9bc997352e10/crypt/debug                                                    61a653cf-44a6-43c0-90e1-bec539511703   100 GiB   none          gzip-9     
-    oxp_e405da11-cb6b-4ebc-bac1-9bc997352e10/crypt/zone                                                     ffc0cb27-54e5-4d28-8f3d-5f7730fed34a   none      none          off        
+    oxp_e405da11-cb6b-4ebc-bac1-9bc997352e10/crypt/debug                                                    5c79ad9d-1aef-407d-804c-ace1d0e069a4   100 GiB   none          gzip-9     
+    oxp_e405da11-cb6b-4ebc-bac1-9bc997352e10/crypt/zone                                                     b27f6972-47f0-43e9-a7cb-3a2fcd93798b   none      none          off        
     oxp_e405da11-cb6b-4ebc-bac1-9bc997352e10/crypt/zone/oxz_crucible_72c5a909-077d-4ec1-a9d5-ae64ef9d716e   4f3e0a2b-43df-43f1-9244-a67fe65a4856   none      none          off        
     oxp_f4d7f914-ec73-4b65-8696-5068591d9065/crucible                                                       e7ca75fe-d59c-4324-9053-a6a1566958e2   none      none          off        
-    oxp_f4d7f914-ec73-4b65-8696-5068591d9065/crypt/debug                                                    b803d901-7e43-42fa-8372-43c3c5b3c1a9   100 GiB   none          gzip-9     
-    oxp_f4d7f914-ec73-4b65-8696-5068591d9065/crypt/zone                                                     ccf69d3f-87be-4f8c-9191-9dde56547b21   none      none          off        
+    oxp_f4d7f914-ec73-4b65-8696-5068591d9065/crypt/debug                                                    61a653cf-44a6-43c0-90e1-bec539511703   100 GiB   none          gzip-9     
+    oxp_f4d7f914-ec73-4b65-8696-5068591d9065/crypt/zone                                                     ffc0cb27-54e5-4d28-8f3d-5f7730fed34a   none      none          off        
     oxp_f4d7f914-ec73-4b65-8696-5068591d9065/crypt/zone/oxz_crucible_0dfbf374-9ef9-430f-b06d-f271bf7f84c4   f72e1f0d-0acd-4cde-9acd-f25663592558   none      none          off        
 +   oxp_4069c804-c51a-4adc-8822-3cbbab56ed3f/crypt/zone/oxz_nexus_2ec75441-3d7d-4b4b-9614-af03de5a3666      cd15e9c9-0238-493a-8b32-926d1cd1bce6   none      none          off        
 +   oxp_4069c804-c51a-4adc-8822-3cbbab56ed3f/crypt/zone/oxz_nexus_508abd03-cbfe-4654-9a6d-7f15a1ad32e5      b781d032-3149-4c44-a7d3-5f8d80e4a607   none      none          off        
@@ -397,47 +397,47 @@ to:   blueprint 9f71f5d3-a272-4382-9154-6ea2e171a6c6
     fake-vendor   fake-model   serial-fe4fdfba-3b6d-47d3-8612-1fb2390b650a
 
 
-    datasets generation 1 -> 2:
+    datasets generation 2 -> 3:
     ----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
     dataset name                                                                                            dataset uuid                           quota     reservation   compression
     ----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
     oxp_33d48d85-751e-4982-b738-eae4d9a05f01/crucible                                                       cefe1de4-bebb-4ac1-8871-09585baf593d   none      none          off        
-    oxp_33d48d85-751e-4982-b738-eae4d9a05f01/crypt/debug                                                    755e24a8-67cc-44b1-8c25-2dcb3acd988f   100 GiB   none          gzip-9     
-    oxp_33d48d85-751e-4982-b738-eae4d9a05f01/crypt/zone                                                     29246ffd-11d0-4afd-8324-4727380185a3   none      none          off        
+    oxp_33d48d85-751e-4982-b738-eae4d9a05f01/crypt/debug                                                    938737fb-b72f-4727-8833-9697c518ca37   100 GiB   none          gzip-9     
+    oxp_33d48d85-751e-4982-b738-eae4d9a05f01/crypt/zone                                                     35a43943-68f5-44f8-83a9-c69423b1ab04   none      none          off        
     oxp_33d48d85-751e-4982-b738-eae4d9a05f01/crypt/zone/oxz_crucible_a1c03689-fc62-4ea5-bb72-4d01f5138614   951bc0b6-8136-4ec3-870b-ffaa4d2ff2f9   none      none          off        
     oxp_33d48d85-751e-4982-b738-eae4d9a05f01/crypt/zone/oxz_nexus_4ad0e9da-08f8-4d40-b4d3-d17e711b5bbf      45d32c13-cbbb-4382-a0ed-dc6574b827b7   none      none          off        
     oxp_33d48d85-751e-4982-b738-eae4d9a05f01/crypt/zone/oxz_ntp_bf79a56a-97af-4cc4-94a5-8b20d64c2cda        a410308c-e2cb-4e4d-9da6-1879336f93f2   none      none          off        
     oxp_39ca2e23-4c38-4743-afe0-26b0380b27db/crucible                                                       3bf64d72-e015-4377-b02a-a094f8f96d57   none      none          off        
-    oxp_39ca2e23-4c38-4743-afe0-26b0380b27db/crypt/debug                                                    c834f8cd-25ee-4c62-af03-49cef53fc4c1   100 GiB   none          gzip-9     
-    oxp_39ca2e23-4c38-4743-afe0-26b0380b27db/crypt/zone                                                     212dad15-885a-45f6-b7ea-5e2ed8d9186f   none      none          off        
+    oxp_39ca2e23-4c38-4743-afe0-26b0380b27db/crypt/debug                                                    1f7f6932-ed14-482a-816e-b0f76d96603d   100 GiB   none          gzip-9     
+    oxp_39ca2e23-4c38-4743-afe0-26b0380b27db/crypt/zone                                                     d3ae6bfa-bdfd-4a36-9009-4e061be33c0b   none      none          off        
     oxp_39ca2e23-4c38-4743-afe0-26b0380b27db/crypt/zone/oxz_crucible_d47f4996-fac0-4657-bcea-01b1fee6404d   c1af262a-2595-4236-98c8-21c5b63c80c3   none      none          off        
     oxp_4fbd2fe0-2eac-41b8-8e8d-4fa46c3e8b6c/crucible                                                       c35cac80-eb26-4d90-ac3e-879b9d80c04c   none      none          off        
-    oxp_4fbd2fe0-2eac-41b8-8e8d-4fa46c3e8b6c/crypt/debug                                                    5a288f52-a84e-45a6-873a-3d9c81d67380   100 GiB   none          gzip-9     
-    oxp_4fbd2fe0-2eac-41b8-8e8d-4fa46c3e8b6c/crypt/zone                                                     e1e73d4f-0138-42dc-9e10-3432b26098f4   none      none          off        
+    oxp_4fbd2fe0-2eac-41b8-8e8d-4fa46c3e8b6c/crypt/debug                                                    c2eba705-dd3c-49f1-9d7d-abb951cbc722   100 GiB   none          gzip-9     
+    oxp_4fbd2fe0-2eac-41b8-8e8d-4fa46c3e8b6c/crypt/zone                                                     474256d1-bab1-499a-9679-566accf12f3f   none      none          off        
     oxp_4fbd2fe0-2eac-41b8-8e8d-4fa46c3e8b6c/crypt/zone/oxz_crucible_a568e92e-4fbd-4b69-acd8-f16277073031   b8868d0c-960d-4ae4-b340-2c5970c8d530   none      none          off        
     oxp_60131a33-1f12-4dbb-9435-bdd368db1f51/crucible                                                       30d7609e-1c74-4002-8558-b62246ee9600   none      none          off        
     oxp_60131a33-1f12-4dbb-9435-bdd368db1f51/crypt/debug                                                    078134ea-f776-4283-ae17-116869f304b4   100 GiB   none          gzip-9     
     oxp_60131a33-1f12-4dbb-9435-bdd368db1f51/crypt/zone                                                     48e191ca-1498-4381-b2dd-675b022d9a86   none      none          off        
     oxp_60131a33-1f12-4dbb-9435-bdd368db1f51/crypt/zone/oxz_crucible_772cbcbd-58be-4158-be85-be744871fa22   a7228ebc-840f-4393-94d7-b338dab3d459   none      none          off        
     oxp_77e45b5b-869f-4e78-8ce3-28bbe8cf37e9/crucible                                                       eff3d661-6ab1-4966-ab0a-6f94fda0bd39   none      none          off        
-    oxp_77e45b5b-869f-4e78-8ce3-28bbe8cf37e9/crypt/debug                                                    60a98875-ee39-49d8-b4b8-1f5d168e39e2   100 GiB   none          gzip-9     
-    oxp_77e45b5b-869f-4e78-8ce3-28bbe8cf37e9/crypt/zone                                                     1ce1d218-9f8d-4c13-a1bf-e085c569a4b8   none      none          off        
+    oxp_77e45b5b-869f-4e78-8ce3-28bbe8cf37e9/crypt/debug                                                    5a288f52-a84e-45a6-873a-3d9c81d67380   100 GiB   none          gzip-9     
+    oxp_77e45b5b-869f-4e78-8ce3-28bbe8cf37e9/crypt/zone                                                     e1e73d4f-0138-42dc-9e10-3432b26098f4   none      none          off        
     oxp_77e45b5b-869f-4e78-8ce3-28bbe8cf37e9/crypt/zone/oxz_crucible_be75764a-491b-4aec-992e-1c39e25de975   09d557a8-4a28-4434-bcca-8fa593cc2fec   none      none          off        
     oxp_789d607d-d196-428e-a988-f7886a327859/crucible                                                       7253d7b0-8954-41f0-b788-9efc41f42742   none      none          off        
-    oxp_789d607d-d196-428e-a988-f7886a327859/crypt/debug                                                    1f7f6932-ed14-482a-816e-b0f76d96603d   100 GiB   none          gzip-9     
-    oxp_789d607d-d196-428e-a988-f7886a327859/crypt/zone                                                     d3ae6bfa-bdfd-4a36-9009-4e061be33c0b   none      none          off        
+    oxp_789d607d-d196-428e-a988-f7886a327859/crypt/debug                                                    c834f8cd-25ee-4c62-af03-49cef53fc4c1   100 GiB   none          gzip-9     
+    oxp_789d607d-d196-428e-a988-f7886a327859/crypt/zone                                                     212dad15-885a-45f6-b7ea-5e2ed8d9186f   none      none          off        
     oxp_789d607d-d196-428e-a988-f7886a327859/crypt/zone/oxz_crucible_e001fea0-6594-4ece-97e3-6198c293e931   5e27b9bc-e69f-4258-83f2-5f9a1109a625   none      none          off        
     oxp_b104b94c-2197-4e76-bfbd-6f966bd5af66/crucible                                                       70b8bba8-802a-462a-9aa7-3dcd20a1fbbf   none      none          off        
-    oxp_b104b94c-2197-4e76-bfbd-6f966bd5af66/crypt/debug                                                    c2eba705-dd3c-49f1-9d7d-abb951cbc722   100 GiB   none          gzip-9     
-    oxp_b104b94c-2197-4e76-bfbd-6f966bd5af66/crypt/zone                                                     474256d1-bab1-499a-9679-566accf12f3f   none      none          off        
+    oxp_b104b94c-2197-4e76-bfbd-6f966bd5af66/crypt/debug                                                    73674f4b-1d93-404a-bc9c-8395efac97fd   100 GiB   none          gzip-9     
+    oxp_b104b94c-2197-4e76-bfbd-6f966bd5af66/crypt/zone                                                     6e415c23-e85d-4f5b-b993-43a8f1c56763   none      none          off        
     oxp_b104b94c-2197-4e76-bfbd-6f966bd5af66/crypt/zone/oxz_crucible_414830dc-c8c1-4748-9e9e-bc3a6435a93c   a9351df9-851e-4c85-a7f2-74490471e876   none      none          off        
     oxp_cd62306a-aedf-47e8-93d5-92a358d64c7b/crucible                                                       3acdbfe5-1226-4752-a14e-9f1e468ade71   none      none          off        
-    oxp_cd62306a-aedf-47e8-93d5-92a358d64c7b/crypt/debug                                                    73674f4b-1d93-404a-bc9c-8395efac97fd   100 GiB   none          gzip-9     
-    oxp_cd62306a-aedf-47e8-93d5-92a358d64c7b/crypt/zone                                                     6e415c23-e85d-4f5b-b993-43a8f1c56763   none      none          off        
+    oxp_cd62306a-aedf-47e8-93d5-92a358d64c7b/crypt/debug                                                    60a98875-ee39-49d8-b4b8-1f5d168e39e2   100 GiB   none          gzip-9     
+    oxp_cd62306a-aedf-47e8-93d5-92a358d64c7b/crypt/zone                                                     1ce1d218-9f8d-4c13-a1bf-e085c569a4b8   none      none          off        
     oxp_cd62306a-aedf-47e8-93d5-92a358d64c7b/crypt/zone/oxz_crucible_be920398-024a-4655-8c49-69b5ac48dfff   87f757d6-fa4c-4423-995c-1eab5e7d09a2   none      none          off        
     oxp_f1693454-aac1-4265-b8a0-4e9f3f41c7b3/crucible                                                       f45ef5d4-14b2-4346-8297-20919d6ee9da   none      none          off        
-    oxp_f1693454-aac1-4265-b8a0-4e9f3f41c7b3/crypt/debug                                                    938737fb-b72f-4727-8833-9697c518ca37   100 GiB   none          gzip-9     
-    oxp_f1693454-aac1-4265-b8a0-4e9f3f41c7b3/crypt/zone                                                     35a43943-68f5-44f8-83a9-c69423b1ab04   none      none          off        
+    oxp_f1693454-aac1-4265-b8a0-4e9f3f41c7b3/crypt/debug                                                    755e24a8-67cc-44b1-8c25-2dcb3acd988f   100 GiB   none          gzip-9     
+    oxp_f1693454-aac1-4265-b8a0-4e9f3f41c7b3/crypt/zone                                                     29246ffd-11d0-4afd-8324-4727380185a3   none      none          off        
     oxp_f1693454-aac1-4265-b8a0-4e9f3f41c7b3/crypt/zone/oxz_crucible_a73f322a-9463-4d18-8f60-7ddf6f59f231   c4fa8f96-497e-47ad-9953-6ca3c9a90d25   none      none          off        
     oxp_fe4fdfba-3b6d-47d3-8612-1fb2390b650a/crucible                                                       fa262c74-8870-4038-8b71-b8dfa4adda12   none      none          off        
     oxp_fe4fdfba-3b6d-47d3-8612-1fb2390b650a/crypt/debug                                                    8e58b91f-9ce2-4256-8dec-5f90f31a73fa   100 GiB   none          gzip-9     

--- a/nexus/reconfigurator/planning/tests/output/planner_nonprovisionable_2_2a.txt
+++ b/nexus/reconfigurator/planning/tests/output/planner_nonprovisionable_2_2a.txt
@@ -21,13 +21,13 @@ to:   blueprint 9f71f5d3-a272-4382-9154-6ea2e171a6c6
     fake-vendor   fake-model   serial-f4d7f914-ec73-4b65-8696-5068591d9065
 
 
-    datasets at generation 2:
+    datasets at generation 3:
     ----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
     dataset name                                                                                            dataset uuid                           quota     reservation   compression
     ----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
     oxp_4069c804-c51a-4adc-8822-3cbbab56ed3f/crucible                                                       5c9ef84c-434c-4406-b68a-70e9af65b5a5   none      none          off        
-    oxp_4069c804-c51a-4adc-8822-3cbbab56ed3f/crypt/debug                                                    bf9b39db-5a6a-4b45-b2da-c37425271014   100 GiB   none          gzip-9     
-    oxp_4069c804-c51a-4adc-8822-3cbbab56ed3f/crypt/zone                                                     fc0b9a2c-4002-4fff-92f4-b541b7dd18c4   none      none          off        
+    oxp_4069c804-c51a-4adc-8822-3cbbab56ed3f/crypt/debug                                                    b803d901-7e43-42fa-8372-43c3c5b3c1a9   100 GiB   none          gzip-9     
+    oxp_4069c804-c51a-4adc-8822-3cbbab56ed3f/crypt/zone                                                     ccf69d3f-87be-4f8c-9191-9dde56547b21   none      none          off        
     oxp_4069c804-c51a-4adc-8822-3cbbab56ed3f/crypt/zone/oxz_crucible_85b8c68a-160d-461d-94dd-1baf175fa75c   7b00d896-de30-48f8-bcb7-b140ffab2781   none      none          off        
     oxp_4069c804-c51a-4adc-8822-3cbbab56ed3f/crypt/zone/oxz_nexus_2ec75441-3d7d-4b4b-9614-af03de5a3666      cd15e9c9-0238-493a-8b32-926d1cd1bce6   none      none          off        
     oxp_4069c804-c51a-4adc-8822-3cbbab56ed3f/crypt/zone/oxz_nexus_508abd03-cbfe-4654-9a6d-7f15a1ad32e5      b781d032-3149-4c44-a7d3-5f8d80e4a607   none      none          off        
@@ -35,40 +35,40 @@ to:   blueprint 9f71f5d3-a272-4382-9154-6ea2e171a6c6
     oxp_4069c804-c51a-4adc-8822-3cbbab56ed3f/crypt/zone/oxz_nexus_a732c489-d29a-4f75-b900-5966385943af      db6c139b-9028-4d8e-92c7-6cc1e9aa0131   none      none          off        
     oxp_4069c804-c51a-4adc-8822-3cbbab56ed3f/crypt/zone/oxz_ntp_621509d6-3772-4009-aca1-35eefd1098fb        3b5822d2-9918-4bd6-8b75-2f52bdd73189   none      none          off        
     oxp_5248a306-4a03-449e-a8a3-6f86d26da755/crucible                                                       182f7cbb-ea53-4057-b85c-667e5d949db5   none      none          off        
-    oxp_5248a306-4a03-449e-a8a3-6f86d26da755/crypt/debug                                                    1b4e8d9e-e447-4df1-8e0b-57edc318e8ad   100 GiB   none          gzip-9     
-    oxp_5248a306-4a03-449e-a8a3-6f86d26da755/crypt/zone                                                     5f097047-8290-438a-b85a-80bc9450b26c   none      none          off        
+    oxp_5248a306-4a03-449e-a8a3-6f86d26da755/crypt/debug                                                    ae4f4e83-0bd1-48dc-bfe3-f1082e8f357a   100 GiB   none          gzip-9     
+    oxp_5248a306-4a03-449e-a8a3-6f86d26da755/crypt/zone                                                     b19e4e13-79e3-481d-ad80-db076a26b7eb   none      none          off        
     oxp_5248a306-4a03-449e-a8a3-6f86d26da755/crypt/zone/oxz_crucible_f0ff59e8-4105-4980-a4bb-a1f4c58de1e3   c596346d-4040-4103-b036-8fafdbaada00   none      none          off        
     oxp_55196665-ed61-4b23-9a74-0711bf2eaf90/crucible                                                       931c4336-5ff9-45ce-b71b-9b6e81e16e53   none      none          off        
-    oxp_55196665-ed61-4b23-9a74-0711bf2eaf90/crypt/debug                                                    ae4f4e83-0bd1-48dc-bfe3-f1082e8f357a   100 GiB   none          gzip-9     
-    oxp_55196665-ed61-4b23-9a74-0711bf2eaf90/crypt/zone                                                     b19e4e13-79e3-481d-ad80-db076a26b7eb   none      none          off        
+    oxp_55196665-ed61-4b23-9a74-0711bf2eaf90/crypt/debug                                                    bf9b39db-5a6a-4b45-b2da-c37425271014   100 GiB   none          gzip-9     
+    oxp_55196665-ed61-4b23-9a74-0711bf2eaf90/crypt/zone                                                     fc0b9a2c-4002-4fff-92f4-b541b7dd18c4   none      none          off        
     oxp_55196665-ed61-4b23-9a74-0711bf2eaf90/crypt/zone/oxz_crucible_23a8fa2b-ef3e-4017-a43f-f7a83953bd7c   3c7c5190-92dd-4d3b-9222-95d82a530d9e   none      none          off        
     oxp_6b2a719a-35eb-469f-aa54-114a1f21f37d/crucible                                                       11e2e73b-93a1-47f1-aff3-c4dc7667f4f1   none      none          off        
-    oxp_6b2a719a-35eb-469f-aa54-114a1f21f37d/crypt/debug                                                    be833d4e-3439-41ac-b3ad-3e4d14a66360   100 GiB   none          gzip-9     
-    oxp_6b2a719a-35eb-469f-aa54-114a1f21f37d/crypt/zone                                                     7ab2c8a5-3135-4a51-a232-7af8c72b9d3c   none      none          off        
+    oxp_6b2a719a-35eb-469f-aa54-114a1f21f37d/crypt/debug                                                    2dfc5c53-6618-4352-b754-86ef6463c20a   100 GiB   none          gzip-9     
+    oxp_6b2a719a-35eb-469f-aa54-114a1f21f37d/crypt/zone                                                     e79fbff1-f7fb-4912-9f5c-faca57a6a9c4   none      none          off        
     oxp_6b2a719a-35eb-469f-aa54-114a1f21f37d/crypt/zone/oxz_crucible_f1a7b9a7-fc6a-4b23-b829-045ff33117ff   c864de0d-9859-4ad1-a30b-f5ac45ba03ed   none      none          off        
     oxp_7ed4296a-66d1-4fb2-bc56-9b23b8f27d7e/crucible                                                       bdc3e42b-b28f-42c9-99fa-3f92e8b30a3c   none      none          off        
-    oxp_7ed4296a-66d1-4fb2-bc56-9b23b8f27d7e/crypt/debug                                                    a02b70bf-b069-4fec-9f53-1976ba462c45   100 GiB   none          gzip-9     
-    oxp_7ed4296a-66d1-4fb2-bc56-9b23b8f27d7e/crypt/zone                                                     4b69a9a9-2994-433c-9733-05de50d9c2a1   none      none          off        
+    oxp_7ed4296a-66d1-4fb2-bc56-9b23b8f27d7e/crypt/debug                                                    1b4e8d9e-e447-4df1-8e0b-57edc318e8ad   100 GiB   none          gzip-9     
+    oxp_7ed4296a-66d1-4fb2-bc56-9b23b8f27d7e/crypt/zone                                                     5f097047-8290-438a-b85a-80bc9450b26c   none      none          off        
     oxp_7ed4296a-66d1-4fb2-bc56-9b23b8f27d7e/crypt/zone/oxz_crucible_15c103f0-ac63-423b-ba5d-1b5fcd563ba3   02deac75-eb1a-423e-9b64-d20ca921fc25   none      none          off        
     oxp_984e2389-e7fd-4af9-ab02-e3caf77f95b5/crucible                                                       5c956b09-323e-476c-9a71-352154b1f841   none      none          off        
-    oxp_984e2389-e7fd-4af9-ab02-e3caf77f95b5/crypt/debug                                                    5c79ad9d-1aef-407d-804c-ace1d0e069a4   100 GiB   none          gzip-9     
-    oxp_984e2389-e7fd-4af9-ab02-e3caf77f95b5/crypt/zone                                                     b27f6972-47f0-43e9-a7cb-3a2fcd93798b   none      none          off        
+    oxp_984e2389-e7fd-4af9-ab02-e3caf77f95b5/crypt/debug                                                    a02b70bf-b069-4fec-9f53-1976ba462c45   100 GiB   none          gzip-9     
+    oxp_984e2389-e7fd-4af9-ab02-e3caf77f95b5/crypt/zone                                                     4b69a9a9-2994-433c-9733-05de50d9c2a1   none      none          off        
     oxp_984e2389-e7fd-4af9-ab02-e3caf77f95b5/crypt/zone/oxz_crucible_95482c25-1e7f-43e8-adf1-e3548a1b3ae0   5c5d822f-d696-4b6a-a075-286c437deba1   none      none          off        
     oxp_a5f75431-3795-426c-8f80-176f658281a5/crucible                                                       7b4f5c33-6a5a-42f9-8199-69f72761b24d   none      none          off        
     oxp_a5f75431-3795-426c-8f80-176f658281a5/crypt/debug                                                    dbc27904-c6dd-4cdc-96c8-32a24bdba0a1   100 GiB   none          gzip-9     
     oxp_a5f75431-3795-426c-8f80-176f658281a5/crypt/zone                                                     4d913be5-fa91-4b22-b714-53babe093654   none      none          off        
     oxp_a5f75431-3795-426c-8f80-176f658281a5/crypt/zone/oxz_crucible_3aa07966-5899-4789-ace5-f8eeb375c6c3   23ff87ad-3d52-4c7e-a9a3-be288d08835c   none      none          off        
     oxp_cf32a1ce-2c9e-49f5-b1cf-4af7f2a28901/crucible                                                       77279948-9fe2-46f2-af39-0d5b692f5984   none      none          off        
-    oxp_cf32a1ce-2c9e-49f5-b1cf-4af7f2a28901/crypt/debug                                                    2dfc5c53-6618-4352-b754-86ef6463c20a   100 GiB   none          gzip-9     
-    oxp_cf32a1ce-2c9e-49f5-b1cf-4af7f2a28901/crypt/zone                                                     e79fbff1-f7fb-4912-9f5c-faca57a6a9c4   none      none          off        
+    oxp_cf32a1ce-2c9e-49f5-b1cf-4af7f2a28901/crypt/debug                                                    be833d4e-3439-41ac-b3ad-3e4d14a66360   100 GiB   none          gzip-9     
+    oxp_cf32a1ce-2c9e-49f5-b1cf-4af7f2a28901/crypt/zone                                                     7ab2c8a5-3135-4a51-a232-7af8c72b9d3c   none      none          off        
     oxp_cf32a1ce-2c9e-49f5-b1cf-4af7f2a28901/crypt/zone/oxz_crucible_c60379ba-4e30-4628-a79a-0ae509aef4c5   a6fcf496-70a1-49bf-a951-62fcec8dd5e2   none      none          off        
     oxp_e405da11-cb6b-4ebc-bac1-9bc997352e10/crucible                                                       0f6d5b5f-674d-465e-9b40-d09c6865416a   none      none          off        
-    oxp_e405da11-cb6b-4ebc-bac1-9bc997352e10/crypt/debug                                                    61a653cf-44a6-43c0-90e1-bec539511703   100 GiB   none          gzip-9     
-    oxp_e405da11-cb6b-4ebc-bac1-9bc997352e10/crypt/zone                                                     ffc0cb27-54e5-4d28-8f3d-5f7730fed34a   none      none          off        
+    oxp_e405da11-cb6b-4ebc-bac1-9bc997352e10/crypt/debug                                                    5c79ad9d-1aef-407d-804c-ace1d0e069a4   100 GiB   none          gzip-9     
+    oxp_e405da11-cb6b-4ebc-bac1-9bc997352e10/crypt/zone                                                     b27f6972-47f0-43e9-a7cb-3a2fcd93798b   none      none          off        
     oxp_e405da11-cb6b-4ebc-bac1-9bc997352e10/crypt/zone/oxz_crucible_72c5a909-077d-4ec1-a9d5-ae64ef9d716e   4f3e0a2b-43df-43f1-9244-a67fe65a4856   none      none          off        
     oxp_f4d7f914-ec73-4b65-8696-5068591d9065/crucible                                                       e7ca75fe-d59c-4324-9053-a6a1566958e2   none      none          off        
-    oxp_f4d7f914-ec73-4b65-8696-5068591d9065/crypt/debug                                                    b803d901-7e43-42fa-8372-43c3c5b3c1a9   100 GiB   none          gzip-9     
-    oxp_f4d7f914-ec73-4b65-8696-5068591d9065/crypt/zone                                                     ccf69d3f-87be-4f8c-9191-9dde56547b21   none      none          off        
+    oxp_f4d7f914-ec73-4b65-8696-5068591d9065/crypt/debug                                                    61a653cf-44a6-43c0-90e1-bec539511703   100 GiB   none          gzip-9     
+    oxp_f4d7f914-ec73-4b65-8696-5068591d9065/crypt/zone                                                     ffc0cb27-54e5-4d28-8f3d-5f7730fed34a   none      none          off        
     oxp_f4d7f914-ec73-4b65-8696-5068591d9065/crypt/zone/oxz_crucible_0dfbf374-9ef9-430f-b06d-f271bf7f84c4   f72e1f0d-0acd-4cde-9acd-f25663592558   none      none          off        
 
 
@@ -111,13 +111,13 @@ to:   blueprint 9f71f5d3-a272-4382-9154-6ea2e171a6c6
     fake-vendor   fake-model   serial-fe4fdfba-3b6d-47d3-8612-1fb2390b650a
 
 
-    datasets at generation 2:
+    datasets at generation 3:
     ----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
     dataset name                                                                                            dataset uuid                           quota     reservation   compression
     ----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
     oxp_33d48d85-751e-4982-b738-eae4d9a05f01/crucible                                                       cefe1de4-bebb-4ac1-8871-09585baf593d   none      none          off        
-    oxp_33d48d85-751e-4982-b738-eae4d9a05f01/crypt/debug                                                    755e24a8-67cc-44b1-8c25-2dcb3acd988f   100 GiB   none          gzip-9     
-    oxp_33d48d85-751e-4982-b738-eae4d9a05f01/crypt/zone                                                     29246ffd-11d0-4afd-8324-4727380185a3   none      none          off        
+    oxp_33d48d85-751e-4982-b738-eae4d9a05f01/crypt/debug                                                    938737fb-b72f-4727-8833-9697c518ca37   100 GiB   none          gzip-9     
+    oxp_33d48d85-751e-4982-b738-eae4d9a05f01/crypt/zone                                                     35a43943-68f5-44f8-83a9-c69423b1ab04   none      none          off        
     oxp_33d48d85-751e-4982-b738-eae4d9a05f01/crypt/zone/oxz_crucible_a1c03689-fc62-4ea5-bb72-4d01f5138614   951bc0b6-8136-4ec3-870b-ffaa4d2ff2f9   none      none          off        
     oxp_33d48d85-751e-4982-b738-eae4d9a05f01/crypt/zone/oxz_nexus_3ca5292f-8a59-4475-bb72-0f43714d0fff      871b35e6-d234-4a96-bab4-d07314bc6ba2   none      none          off        
     oxp_33d48d85-751e-4982-b738-eae4d9a05f01/crypt/zone/oxz_nexus_4ad0e9da-08f8-4d40-b4d3-d17e711b5bbf      45d32c13-cbbb-4382-a0ed-dc6574b827b7   none      none          off        
@@ -125,36 +125,36 @@ to:   blueprint 9f71f5d3-a272-4382-9154-6ea2e171a6c6
     oxp_33d48d85-751e-4982-b738-eae4d9a05f01/crypt/zone/oxz_nexus_c26b3bda-5561-44a1-a69f-22103fe209a1      c9c1a582-1fe0-4001-9301-97230387563a   none      none          off        
     oxp_33d48d85-751e-4982-b738-eae4d9a05f01/crypt/zone/oxz_ntp_bf79a56a-97af-4cc4-94a5-8b20d64c2cda        a410308c-e2cb-4e4d-9da6-1879336f93f2   none      none          off        
     oxp_39ca2e23-4c38-4743-afe0-26b0380b27db/crucible                                                       3bf64d72-e015-4377-b02a-a094f8f96d57   none      none          off        
-    oxp_39ca2e23-4c38-4743-afe0-26b0380b27db/crypt/debug                                                    c834f8cd-25ee-4c62-af03-49cef53fc4c1   100 GiB   none          gzip-9     
-    oxp_39ca2e23-4c38-4743-afe0-26b0380b27db/crypt/zone                                                     212dad15-885a-45f6-b7ea-5e2ed8d9186f   none      none          off        
+    oxp_39ca2e23-4c38-4743-afe0-26b0380b27db/crypt/debug                                                    1f7f6932-ed14-482a-816e-b0f76d96603d   100 GiB   none          gzip-9     
+    oxp_39ca2e23-4c38-4743-afe0-26b0380b27db/crypt/zone                                                     d3ae6bfa-bdfd-4a36-9009-4e061be33c0b   none      none          off        
     oxp_39ca2e23-4c38-4743-afe0-26b0380b27db/crypt/zone/oxz_crucible_d47f4996-fac0-4657-bcea-01b1fee6404d   c1af262a-2595-4236-98c8-21c5b63c80c3   none      none          off        
     oxp_4fbd2fe0-2eac-41b8-8e8d-4fa46c3e8b6c/crucible                                                       c35cac80-eb26-4d90-ac3e-879b9d80c04c   none      none          off        
-    oxp_4fbd2fe0-2eac-41b8-8e8d-4fa46c3e8b6c/crypt/debug                                                    5a288f52-a84e-45a6-873a-3d9c81d67380   100 GiB   none          gzip-9     
-    oxp_4fbd2fe0-2eac-41b8-8e8d-4fa46c3e8b6c/crypt/zone                                                     e1e73d4f-0138-42dc-9e10-3432b26098f4   none      none          off        
+    oxp_4fbd2fe0-2eac-41b8-8e8d-4fa46c3e8b6c/crypt/debug                                                    c2eba705-dd3c-49f1-9d7d-abb951cbc722   100 GiB   none          gzip-9     
+    oxp_4fbd2fe0-2eac-41b8-8e8d-4fa46c3e8b6c/crypt/zone                                                     474256d1-bab1-499a-9679-566accf12f3f   none      none          off        
     oxp_4fbd2fe0-2eac-41b8-8e8d-4fa46c3e8b6c/crypt/zone/oxz_crucible_a568e92e-4fbd-4b69-acd8-f16277073031   b8868d0c-960d-4ae4-b340-2c5970c8d530   none      none          off        
     oxp_60131a33-1f12-4dbb-9435-bdd368db1f51/crucible                                                       30d7609e-1c74-4002-8558-b62246ee9600   none      none          off        
     oxp_60131a33-1f12-4dbb-9435-bdd368db1f51/crypt/debug                                                    078134ea-f776-4283-ae17-116869f304b4   100 GiB   none          gzip-9     
     oxp_60131a33-1f12-4dbb-9435-bdd368db1f51/crypt/zone                                                     48e191ca-1498-4381-b2dd-675b022d9a86   none      none          off        
     oxp_60131a33-1f12-4dbb-9435-bdd368db1f51/crypt/zone/oxz_crucible_772cbcbd-58be-4158-be85-be744871fa22   a7228ebc-840f-4393-94d7-b338dab3d459   none      none          off        
     oxp_77e45b5b-869f-4e78-8ce3-28bbe8cf37e9/crucible                                                       eff3d661-6ab1-4966-ab0a-6f94fda0bd39   none      none          off        
-    oxp_77e45b5b-869f-4e78-8ce3-28bbe8cf37e9/crypt/debug                                                    60a98875-ee39-49d8-b4b8-1f5d168e39e2   100 GiB   none          gzip-9     
-    oxp_77e45b5b-869f-4e78-8ce3-28bbe8cf37e9/crypt/zone                                                     1ce1d218-9f8d-4c13-a1bf-e085c569a4b8   none      none          off        
+    oxp_77e45b5b-869f-4e78-8ce3-28bbe8cf37e9/crypt/debug                                                    5a288f52-a84e-45a6-873a-3d9c81d67380   100 GiB   none          gzip-9     
+    oxp_77e45b5b-869f-4e78-8ce3-28bbe8cf37e9/crypt/zone                                                     e1e73d4f-0138-42dc-9e10-3432b26098f4   none      none          off        
     oxp_77e45b5b-869f-4e78-8ce3-28bbe8cf37e9/crypt/zone/oxz_crucible_be75764a-491b-4aec-992e-1c39e25de975   09d557a8-4a28-4434-bcca-8fa593cc2fec   none      none          off        
     oxp_789d607d-d196-428e-a988-f7886a327859/crucible                                                       7253d7b0-8954-41f0-b788-9efc41f42742   none      none          off        
-    oxp_789d607d-d196-428e-a988-f7886a327859/crypt/debug                                                    1f7f6932-ed14-482a-816e-b0f76d96603d   100 GiB   none          gzip-9     
-    oxp_789d607d-d196-428e-a988-f7886a327859/crypt/zone                                                     d3ae6bfa-bdfd-4a36-9009-4e061be33c0b   none      none          off        
+    oxp_789d607d-d196-428e-a988-f7886a327859/crypt/debug                                                    c834f8cd-25ee-4c62-af03-49cef53fc4c1   100 GiB   none          gzip-9     
+    oxp_789d607d-d196-428e-a988-f7886a327859/crypt/zone                                                     212dad15-885a-45f6-b7ea-5e2ed8d9186f   none      none          off        
     oxp_789d607d-d196-428e-a988-f7886a327859/crypt/zone/oxz_crucible_e001fea0-6594-4ece-97e3-6198c293e931   5e27b9bc-e69f-4258-83f2-5f9a1109a625   none      none          off        
     oxp_b104b94c-2197-4e76-bfbd-6f966bd5af66/crucible                                                       70b8bba8-802a-462a-9aa7-3dcd20a1fbbf   none      none          off        
-    oxp_b104b94c-2197-4e76-bfbd-6f966bd5af66/crypt/debug                                                    c2eba705-dd3c-49f1-9d7d-abb951cbc722   100 GiB   none          gzip-9     
-    oxp_b104b94c-2197-4e76-bfbd-6f966bd5af66/crypt/zone                                                     474256d1-bab1-499a-9679-566accf12f3f   none      none          off        
+    oxp_b104b94c-2197-4e76-bfbd-6f966bd5af66/crypt/debug                                                    73674f4b-1d93-404a-bc9c-8395efac97fd   100 GiB   none          gzip-9     
+    oxp_b104b94c-2197-4e76-bfbd-6f966bd5af66/crypt/zone                                                     6e415c23-e85d-4f5b-b993-43a8f1c56763   none      none          off        
     oxp_b104b94c-2197-4e76-bfbd-6f966bd5af66/crypt/zone/oxz_crucible_414830dc-c8c1-4748-9e9e-bc3a6435a93c   a9351df9-851e-4c85-a7f2-74490471e876   none      none          off        
     oxp_cd62306a-aedf-47e8-93d5-92a358d64c7b/crucible                                                       3acdbfe5-1226-4752-a14e-9f1e468ade71   none      none          off        
-    oxp_cd62306a-aedf-47e8-93d5-92a358d64c7b/crypt/debug                                                    73674f4b-1d93-404a-bc9c-8395efac97fd   100 GiB   none          gzip-9     
-    oxp_cd62306a-aedf-47e8-93d5-92a358d64c7b/crypt/zone                                                     6e415c23-e85d-4f5b-b993-43a8f1c56763   none      none          off        
+    oxp_cd62306a-aedf-47e8-93d5-92a358d64c7b/crypt/debug                                                    60a98875-ee39-49d8-b4b8-1f5d168e39e2   100 GiB   none          gzip-9     
+    oxp_cd62306a-aedf-47e8-93d5-92a358d64c7b/crypt/zone                                                     1ce1d218-9f8d-4c13-a1bf-e085c569a4b8   none      none          off        
     oxp_cd62306a-aedf-47e8-93d5-92a358d64c7b/crypt/zone/oxz_crucible_be920398-024a-4655-8c49-69b5ac48dfff   87f757d6-fa4c-4423-995c-1eab5e7d09a2   none      none          off        
     oxp_f1693454-aac1-4265-b8a0-4e9f3f41c7b3/crucible                                                       f45ef5d4-14b2-4346-8297-20919d6ee9da   none      none          off        
-    oxp_f1693454-aac1-4265-b8a0-4e9f3f41c7b3/crypt/debug                                                    938737fb-b72f-4727-8833-9697c518ca37   100 GiB   none          gzip-9     
-    oxp_f1693454-aac1-4265-b8a0-4e9f3f41c7b3/crypt/zone                                                     35a43943-68f5-44f8-83a9-c69423b1ab04   none      none          off        
+    oxp_f1693454-aac1-4265-b8a0-4e9f3f41c7b3/crypt/debug                                                    755e24a8-67cc-44b1-8c25-2dcb3acd988f   100 GiB   none          gzip-9     
+    oxp_f1693454-aac1-4265-b8a0-4e9f3f41c7b3/crypt/zone                                                     29246ffd-11d0-4afd-8324-4727380185a3   none      none          off        
     oxp_f1693454-aac1-4265-b8a0-4e9f3f41c7b3/crypt/zone/oxz_crucible_a73f322a-9463-4d18-8f60-7ddf6f59f231   c4fa8f96-497e-47ad-9953-6ca3c9a90d25   none      none          off        
     oxp_fe4fdfba-3b6d-47d3-8612-1fb2390b650a/crucible                                                       fa262c74-8870-4038-8b71-b8dfa4adda12   none      none          off        
     oxp_fe4fdfba-3b6d-47d3-8612-1fb2390b650a/crypt/debug                                                    8e58b91f-9ce2-4256-8dec-5f90f31a73fa   100 GiB   none          gzip-9     
@@ -227,15 +227,15 @@ to:   blueprint 9f71f5d3-a272-4382-9154-6ea2e171a6c6
     fake-vendor   fake-model   serial-d1ebfd7b-3842-4ad7-be31-2b9c031209a9
 
 
-    datasets at generation 1:
+    datasets at generation 2:
     -----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
     dataset name                                                                                                   dataset uuid                           quota     reservation   compression
     -----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
     oxp_13e6503b-5300-4ccd-abc4-c1512b435929/crucible                                                              79a16369-70ab-4f63-af6d-1c7f088eeee3   none      none          off        
     oxp_13e6503b-5300-4ccd-abc4-c1512b435929/crypt/clickhouse                                                      d577ac11-62ac-4a71-bed7-e7327148bd33   none      none          off        
-    oxp_13e6503b-5300-4ccd-abc4-c1512b435929/crypt/debug                                                           d6d36f6b-35ff-4766-99de-44abe46932d1   100 GiB   none          gzip-9     
+    oxp_13e6503b-5300-4ccd-abc4-c1512b435929/crypt/debug                                                           26154290-91f7-4f35-bcd0-ec7a8f398d82   100 GiB   none          gzip-9     
     oxp_13e6503b-5300-4ccd-abc4-c1512b435929/crypt/internal_dns                                                    b9aa1175-2640-4923-81b3-1e1469b15abf   none      none          off        
-    oxp_13e6503b-5300-4ccd-abc4-c1512b435929/crypt/zone                                                            18e2a336-9b65-421e-8409-04d9abce8cd6   none      none          off        
+    oxp_13e6503b-5300-4ccd-abc4-c1512b435929/crypt/zone                                                            c37902cf-d1fe-4370-baef-b7de8731dffe   none      none          off        
     oxp_13e6503b-5300-4ccd-abc4-c1512b435929/crypt/zone/oxz_clickhouse_93b137a1-a1d6-4b5b-b2cb-21a9f11e2883        d1a755ac-dafc-4087-a0ce-ee8b3f882ac1   none      none          off        
     oxp_13e6503b-5300-4ccd-abc4-c1512b435929/crypt/zone/oxz_crucible_19fbc4f8-a683-4f22-8f5a-e74782b935be          68724637-d228-4faa-a19f-b5df857ff4ab   none      none          off        
     oxp_13e6503b-5300-4ccd-abc4-c1512b435929/crypt/zone/oxz_crucible_pantry_9f0abbad-dbd3-4d43-9675-78092217ffd9   da62be58-643f-4497-a9d7-e259de6c7a12   none      none          off        
@@ -243,40 +243,40 @@ to:   blueprint 9f71f5d3-a272-4382-9154-6ea2e171a6c6
     oxp_13e6503b-5300-4ccd-abc4-c1512b435929/crypt/zone/oxz_nexus_6dff7633-66bb-4924-a6ff-2c896e66964b             9dce1e52-8e3b-4641-9982-69deb049f647   none      none          off        
     oxp_13e6503b-5300-4ccd-abc4-c1512b435929/crypt/zone/oxz_ntp_7f4e9f9f-08f8-4d14-885d-e977c05525ad               7773ffbd-1842-4425-aff5-88f577cd8955   none      none          off        
     oxp_44cdb6f2-fa6c-4b69-bab2-3ae4e1ec4b34/crucible                                                              ac31a04c-1f3a-43f4-b45a-cf4b5176e7f6   none      none          off        
-    oxp_44cdb6f2-fa6c-4b69-bab2-3ae4e1ec4b34/crypt/debug                                                           26154290-91f7-4f35-bcd0-ec7a8f398d82   100 GiB   none          gzip-9     
-    oxp_44cdb6f2-fa6c-4b69-bab2-3ae4e1ec4b34/crypt/zone                                                            c37902cf-d1fe-4370-baef-b7de8731dffe   none      none          off        
+    oxp_44cdb6f2-fa6c-4b69-bab2-3ae4e1ec4b34/crypt/debug                                                           2e901ffa-895b-4405-b59a-2bcdfabda681   100 GiB   none          gzip-9     
+    oxp_44cdb6f2-fa6c-4b69-bab2-3ae4e1ec4b34/crypt/zone                                                            41e55e8a-ca4b-4c27-8337-57d42cc36fb5   none      none          off        
     oxp_44cdb6f2-fa6c-4b69-bab2-3ae4e1ec4b34/crypt/zone/oxz_crucible_6b53ab2e-d98c-485f-87a3-4d5df595390f          51229ad8-cda3-40c4-b0f3-b1af669abcd4   none      none          off        
     oxp_4de5fc8e-0e41-4ab9-ba12-2dc63882c96a/crucible                                                              b92bba84-9437-4f93-8ad0-80bf7ecdae5f   none      none          off        
-    oxp_4de5fc8e-0e41-4ab9-ba12-2dc63882c96a/crypt/debug                                                           6dc5df73-7e44-4065-9f14-70a0d965a853   100 GiB   none          gzip-9     
-    oxp_4de5fc8e-0e41-4ab9-ba12-2dc63882c96a/crypt/zone                                                            00c2d1d6-94da-4985-a144-2194588afecf   none      none          off        
+    oxp_4de5fc8e-0e41-4ab9-ba12-2dc63882c96a/crypt/debug                                                           d6d36f6b-35ff-4766-99de-44abe46932d1   100 GiB   none          gzip-9     
+    oxp_4de5fc8e-0e41-4ab9-ba12-2dc63882c96a/crypt/zone                                                            18e2a336-9b65-421e-8409-04d9abce8cd6   none      none          off        
     oxp_4de5fc8e-0e41-4ab9-ba12-2dc63882c96a/crypt/zone/oxz_crucible_b0c63f48-01ea-4aae-bb26-fb0dd59d1662          5d8788c0-13df-4c07-a8b2-b9365fec9796   none      none          off        
     oxp_51564e7a-d69f-4942-bcfe-330224633ca6/crucible                                                              dedbf4e7-32fb-406e-a5cc-a2f5281aa6d8   none      none          off        
-    oxp_51564e7a-d69f-4942-bcfe-330224633ca6/crypt/debug                                                           3063bdcc-4363-495b-a81f-67c6cc437a75   100 GiB   none          gzip-9     
-    oxp_51564e7a-d69f-4942-bcfe-330224633ca6/crypt/zone                                                            3527b52f-f1d4-4e2f-b41e-559f58657839   none      none          off        
+    oxp_51564e7a-d69f-4942-bcfe-330224633ca6/crypt/debug                                                           ee20f8cb-7d24-422b-9dff-ca4c9596191f   100 GiB   none          gzip-9     
+    oxp_51564e7a-d69f-4942-bcfe-330224633ca6/crypt/zone                                                            ae6c87ea-dc50-4a15-855a-224300f20c74   none      none          off        
     oxp_51564e7a-d69f-4942-bcfe-330224633ca6/crypt/zone/oxz_crucible_f55e6aaf-e8fc-4913-9e3c-8cd1bd4bdad3          82fc150e-d6f5-4bb6-8eee-17a0728aadb5   none      none          off        
     oxp_5ca23cb3-cc90-41c5-a474-01898cdd0796/crucible                                                              b2c9f282-e767-4df1-941e-b7cea21b1a02   none      none          off        
-    oxp_5ca23cb3-cc90-41c5-a474-01898cdd0796/crypt/debug                                                           53deebeb-3952-483a-afd2-2202cee9c33b   100 GiB   none          gzip-9     
-    oxp_5ca23cb3-cc90-41c5-a474-01898cdd0796/crypt/zone                                                            22581703-157c-474f-bbf3-34f076dd7bca   none      none          off        
+    oxp_5ca23cb3-cc90-41c5-a474-01898cdd0796/crypt/debug                                                           3063bdcc-4363-495b-a81f-67c6cc437a75   100 GiB   none          gzip-9     
+    oxp_5ca23cb3-cc90-41c5-a474-01898cdd0796/crypt/zone                                                            3527b52f-f1d4-4e2f-b41e-559f58657839   none      none          off        
     oxp_5ca23cb3-cc90-41c5-a474-01898cdd0796/crypt/zone/oxz_crucible_d660d7ed-28c0-45ae-9ace-dc3ecf7e8786          68217627-4519-4cfa-85b9-25efb4dad71a   none      none          off        
     oxp_6a23a532-0712-4a8d-be9b-e8c17e97aa4b/crucible                                                              47cf951d-ca5c-4ae0-baa3-94472efbcf03   none      none          off        
-    oxp_6a23a532-0712-4a8d-be9b-e8c17e97aa4b/crypt/debug                                                           e315743d-53e3-4505-9364-657c2486a1bb   100 GiB   none          gzip-9     
-    oxp_6a23a532-0712-4a8d-be9b-e8c17e97aa4b/crypt/zone                                                            4d6e70b1-ff91-4133-b65f-6fcd5bda2568   none      none          off        
+    oxp_6a23a532-0712-4a8d-be9b-e8c17e97aa4b/crypt/debug                                                           84bc6d3f-2d9c-42b3-9982-7394630a0928   100 GiB   none          gzip-9     
+    oxp_6a23a532-0712-4a8d-be9b-e8c17e97aa4b/crypt/zone                                                            3fc37e5a-3bf3-476f-8a8f-6d32a533cfc0   none      none          off        
     oxp_6a23a532-0712-4a8d-be9b-e8c17e97aa4b/crypt/zone/oxz_crucible_e98cc0de-abf6-4da4-a20d-d05c7a9bb1d7          a602c9d4-16a9-4e55-b5de-76fb33cc4ca9   none      none          off        
     oxp_6f1a330e-e8d4-4c09-97fc-8918b69b2a3c/crucible                                                              9390bde4-2073-44b4-a496-5129c7e5ca40   none      none          off        
-    oxp_6f1a330e-e8d4-4c09-97fc-8918b69b2a3c/crypt/debug                                                           2e901ffa-895b-4405-b59a-2bcdfabda681   100 GiB   none          gzip-9     
-    oxp_6f1a330e-e8d4-4c09-97fc-8918b69b2a3c/crypt/zone                                                            41e55e8a-ca4b-4c27-8337-57d42cc36fb5   none      none          off        
+    oxp_6f1a330e-e8d4-4c09-97fc-8918b69b2a3c/crypt/debug                                                           e315743d-53e3-4505-9364-657c2486a1bb   100 GiB   none          gzip-9     
+    oxp_6f1a330e-e8d4-4c09-97fc-8918b69b2a3c/crypt/zone                                                            4d6e70b1-ff91-4133-b65f-6fcd5bda2568   none      none          off        
     oxp_6f1a330e-e8d4-4c09-97fc-8918b69b2a3c/crypt/zone/oxz_crucible_4f1ce8a2-d3a5-4a38-be4c-9817de52db37          ef14767b-6be7-44cb-833d-27d9f523dcdb   none      none          off        
     oxp_7113d104-fb55-4299-bf53-b3c59d258e44/crucible                                                              5ffb2b84-4a3f-444a-aebf-381f8c58b7ae   none      none          off        
-    oxp_7113d104-fb55-4299-bf53-b3c59d258e44/crypt/debug                                                           ee20f8cb-7d24-422b-9dff-ca4c9596191f   100 GiB   none          gzip-9     
-    oxp_7113d104-fb55-4299-bf53-b3c59d258e44/crypt/zone                                                            ae6c87ea-dc50-4a15-855a-224300f20c74   none      none          off        
+    oxp_7113d104-fb55-4299-bf53-b3c59d258e44/crypt/debug                                                           0c11d380-038c-4b68-b9f4-1775f6fec1e8   100 GiB   none          gzip-9     
+    oxp_7113d104-fb55-4299-bf53-b3c59d258e44/crypt/zone                                                            64a64a7b-0d29-4470-bc96-4796ca357507   none      none          off        
     oxp_7113d104-fb55-4299-bf53-b3c59d258e44/crypt/zone/oxz_crucible_67d913e0-0005-4599-9b28-0abbf6cc2916          d63be5b2-5471-4f4d-accc-82e2a0d7276f   none      none          off        
     oxp_8c10be49-3a66-40d4-a082-64d09d916f14/crucible                                                              d72ffc3a-4665-40bc-a099-ebe628622636   none      none          off        
-    oxp_8c10be49-3a66-40d4-a082-64d09d916f14/crypt/debug                                                           84bc6d3f-2d9c-42b3-9982-7394630a0928   100 GiB   none          gzip-9     
-    oxp_8c10be49-3a66-40d4-a082-64d09d916f14/crypt/zone                                                            3fc37e5a-3bf3-476f-8a8f-6d32a533cfc0   none      none          off        
+    oxp_8c10be49-3a66-40d4-a082-64d09d916f14/crypt/debug                                                           53deebeb-3952-483a-afd2-2202cee9c33b   100 GiB   none          gzip-9     
+    oxp_8c10be49-3a66-40d4-a082-64d09d916f14/crypt/zone                                                            22581703-157c-474f-bbf3-34f076dd7bca   none      none          off        
     oxp_8c10be49-3a66-40d4-a082-64d09d916f14/crypt/zone/oxz_crucible_2aa0ea4f-3561-4989-a98c-9ab7d9a240fb          05a77359-0a07-4976-8fbb-5f1eee688e47   none      none          off        
     oxp_d1ebfd7b-3842-4ad7-be31-2b9c031209a9/crucible                                                              39185a78-064c-49d5-b716-93f1a312c0c1   none      none          off        
-    oxp_d1ebfd7b-3842-4ad7-be31-2b9c031209a9/crypt/debug                                                           0c11d380-038c-4b68-b9f4-1775f6fec1e8   100 GiB   none          gzip-9     
-    oxp_d1ebfd7b-3842-4ad7-be31-2b9c031209a9/crypt/zone                                                            64a64a7b-0d29-4470-bc96-4796ca357507   none      none          off        
+    oxp_d1ebfd7b-3842-4ad7-be31-2b9c031209a9/crypt/debug                                                           6dc5df73-7e44-4065-9f14-70a0d965a853   100 GiB   none          gzip-9     
+    oxp_d1ebfd7b-3842-4ad7-be31-2b9c031209a9/crypt/zone                                                            00c2d1d6-94da-4985-a144-2194588afecf   none      none          off        
     oxp_d1ebfd7b-3842-4ad7-be31-2b9c031209a9/crypt/zone/oxz_crucible_67622d61-2df4-414d-aa0e-d1277265f405          6dbd0e11-89af-4464-bd84-c20cb818a9d5   none      none          off        
 
 


### PR DESCRIPTION
Followup to (and staged on top of) #7103, and makes similar changes for datasets as that PR did for disks.

Much more expectorate churn in this one, but it should all still be stable.