### PR TITLE
[reconfigurator] BlueprintBuilder cleanup 5/5 - Convert discretionary ensure_zone_multiple_* to add_zone_*

### DIFF
--- a/dev-tools/reconfigurator-cli/src/main.rs
+++ b/dev-tools/reconfigurator-cli/src/main.rs
@@ -14,14 +14,12 @@ use indent_write::fmt::IndentWriter;
 use internal_dns_types::diff::DnsDiff;
 use nexus_inventory::CollectionBuilder;
 use nexus_reconfigurator_planning::blueprint_builder::BlueprintBuilder;
-use nexus_reconfigurator_planning::blueprint_builder::EnsureMultiple;
 use nexus_reconfigurator_planning::example::ExampleSystemBuilder;
 use nexus_reconfigurator_planning::planner::Planner;
 use nexus_reconfigurator_planning::system::{SledBuilder, SystemDescription};
 use nexus_reconfigurator_simulation::SimState;
 use nexus_reconfigurator_simulation::SimStateBuilder;
 use nexus_reconfigurator_simulation::Simulator;
-use nexus_sled_agent_shared::inventory::ZoneKind;
 use nexus_types::deployment::execution;
 use nexus_types::deployment::execution::blueprint_external_dns_config;
 use nexus_types::deployment::execution::blueprint_internal_dns_config;
@@ -819,37 +817,15 @@ fn cmd_blueprint_edit(
 
     let label = match args.edit_command {
         BlueprintEditCommands::AddNexus { sled_id } => {
-            let current = builder
-                .sled_num_running_zones_of_kind(sled_id, ZoneKind::Nexus);
-            let added = builder
-                .sled_ensure_zone_multiple_nexus(sled_id, current + 1)
+            builder
+                .sled_add_zone_nexus(sled_id)
                 .context("failed to add Nexus zone")?;
-            assert_matches::assert_matches!(
-                added,
-                EnsureMultiple::Changed {
-                    added: 1,
-                    updated: 0,
-                    expunged: 0,
-                    removed: 0
-                }
-            );
             format!("added Nexus zone to sled {}", sled_id)
         }
         BlueprintEditCommands::AddCockroach { sled_id } => {
-            let current = builder
-                .sled_num_running_zones_of_kind(sled_id, ZoneKind::CockroachDb);
-            let added = builder
-                .sled_ensure_zone_multiple_cockroachdb(sled_id, current + 1)
+            builder
+                .sled_add_zone_cockroachdb(sled_id)
                 .context("failed to add CockroachDB zone")?;
-            assert_matches::assert_matches!(
-                added,
-                EnsureMultiple::Changed {
-                    added: 1,
-                    updated: 0,
-                    expunged: 0,
-                    removed: 0
-                }
-            );
             format!("added CockroachDB zone to sled {}", sled_id)
         }
         BlueprintEditCommands::ExpungeZone { sled_id, zone_id } => {

--- a/live-tests/tests/test_nexus_add_remove.rs
+++ b/live-tests/tests/test_nexus_add_remove.rs
@@ -5,7 +5,6 @@
 mod common;
 
 use anyhow::Context;
-use assert_matches::assert_matches;
 use common::reconfigurator::blueprint_edit_current_target;
 use common::LiveTestContext;
 use futures::TryStreamExt;
@@ -14,7 +13,6 @@ use nexus_client::types::Saga;
 use nexus_client::types::SagaState;
 use nexus_inventory::CollectionBuilder;
 use nexus_reconfigurator_planning::blueprint_builder::BlueprintBuilder;
-use nexus_reconfigurator_planning::blueprint_builder::EnsureMultiple;
 use nexus_reconfigurator_preparation::PlanningInputFromDb;
 use nexus_sled_agent_shared::inventory::ZoneKind;
 use nexus_types::deployment::SledFilter;
@@ -63,20 +61,9 @@ async fn test_nexus_add_remove(lc: &LiveTestContext) {
         &collection,
         &nexus,
         &|builder: &mut BlueprintBuilder| {
-            let nnexus = builder
-                .sled_num_running_zones_of_kind(sled_id, ZoneKind::Nexus);
-            let count = builder
-                .sled_ensure_zone_multiple_nexus(sled_id, nnexus + 1)
+            builder
+                .sled_add_zone_nexus(sled_id)
                 .context("adding Nexus zone")?;
-            assert_matches!(
-                count,
-                EnsureMultiple::Changed {
-                    added: 1,
-                    removed: 0,
-                    updated: 0,
-                    expunged: 0
-                }
-            );
             Ok(())
         },
     )

--- a/nexus/db-queries/src/db/datastore/vpc.rs
+++ b/nexus/db-queries/src/db/datastore/vpc.rs
@@ -3130,12 +3130,7 @@ mod tests {
                     .expect("ensured disks");
             }
             builder
-                .sled_ensure_zone_multiple_nexus_with_config(
-                    sled_ids[2],
-                    1,
-                    false,
-                    Vec::new(),
-                )
+                .sled_add_zone_nexus_with_config(sled_ids[2], false, Vec::new())
                 .expect("added nexus to third sled");
             builder.build()
         };
@@ -3201,12 +3196,7 @@ mod tests {
             .expect("created blueprint builder");
             for &sled_id in &sled_ids {
                 builder
-                    .sled_ensure_zone_multiple_nexus_with_config(
-                        sled_id,
-                        1,
-                        false,
-                        Vec::new(),
-                    )
+                    .sled_add_zone_nexus_with_config(sled_id, false, Vec::new())
                     .expect("added nexus to third sled");
             }
             builder.build()

--- a/nexus/reconfigurator/execution/src/dns.rs
+++ b/nexus/reconfigurator/execution/src/dns.rs
@@ -315,7 +315,6 @@ mod test {
     use nexus_inventory::now_db_precision;
     use nexus_inventory::CollectionBuilder;
     use nexus_reconfigurator_planning::blueprint_builder::BlueprintBuilder;
-    use nexus_reconfigurator_planning::blueprint_builder::EnsureMultiple;
     use nexus_reconfigurator_planning::example::ExampleSystemBuilder;
     use nexus_reconfigurator_preparation::PlanningInputFromDb;
     use nexus_sled_agent_shared::inventory::OmicronZoneConfig;
@@ -1384,30 +1383,7 @@ mod test {
         .unwrap();
         let sled_id =
             blueprint.sleds().next().expect("expected at least one sled");
-        let nalready =
-            builder.sled_num_running_zones_of_kind(sled_id, ZoneKind::Nexus);
-        let rv = builder
-            .sled_ensure_zone_multiple_nexus(sled_id, nalready + 1)
-            .unwrap();
-        assert_eq!(
-            rv,
-            EnsureMultiple::Changed {
-                added: 1,
-                updated: 0,
-                expunged: 0,
-                removed: 0
-            }
-        );
-        builder
-            .sled_ensure_zone_datasets(
-                sled_id,
-                &planning_input
-                    .sled_lookup(SledFilter::InService, sled_id)
-                    .expect("found sled")
-                    .resources,
-            )
-            .expect("ensured datasets");
-
+        builder.sled_add_zone_nexus(sled_id).unwrap();
         let blueprint2 = builder.build();
         eprintln!("blueprint2: {}", blueprint2.display());
         // Figure out the id of the new zone.

--- a/nexus/reconfigurator/planning/src/example.rs
+++ b/nexus/reconfigurator/planning/src/example.rs
@@ -428,36 +428,23 @@ impl ExampleSystemBuilder {
             }
             if self.create_zones {
                 let _ = builder.sled_ensure_zone_ntp(sled_id).unwrap();
-                let _ = builder
-                    .sled_ensure_zone_multiple_nexus_with_config(
-                        sled_id,
-                        nexus_count.on(i, self.nsleds),
-                        false,
-                        vec![],
-                    )
-                    .unwrap();
-                if i == 0 {
-                    let _ = builder
-                        .sled_ensure_zone_multiple_clickhouse(sled_id, 1);
+                for _ in 0..nexus_count.on(i, self.nsleds) {
+                    builder
+                        .sled_add_zone_nexus_with_config(sled_id, false, vec![])
+                        .unwrap();
                 }
-                let _ = builder
-                    .sled_ensure_zone_multiple_internal_dns(
-                        sled_id,
-                        self.internal_dns_count.on(i, self.nsleds),
-                    )
-                    .unwrap();
-                let _ = builder
-                    .sled_ensure_zone_multiple_external_dns(
-                        sled_id,
-                        self.external_dns_count.on(i, self.nsleds),
-                    )
-                    .unwrap();
-                let _ = builder
-                    .sled_ensure_zone_multiple_crucible_pantry(
-                        sled_id,
-                        self.crucible_pantry_count.on(i, self.nsleds),
-                    )
-                    .unwrap();
+                if i == 0 {
+                    builder.sled_add_zone_clickhouse(sled_id).unwrap();
+                }
+                for _ in 0..self.internal_dns_count.on(i, self.nsleds) {
+                    builder.sled_add_zone_internal_dns(sled_id).unwrap();
+                }
+                for _ in 0..self.external_dns_count.on(i, self.nsleds) {
+                    builder.sled_add_zone_external_dns(sled_id).unwrap();
+                }
+                for _ in 0..self.crucible_pantry_count.on(i, self.nsleds) {
+                    builder.sled_add_zone_crucible_pantry(sled_id).unwrap();
+                }
             }
             if self.create_zones {
                 for pool_name in sled_resources.zpools.keys() {

--- a/nexus/reconfigurator/planning/src/planner.rs
+++ b/nexus/reconfigurator/planning/src/planner.rs
@@ -30,7 +30,6 @@ use nexus_types::inventory::Collection;
 use omicron_uuid_kinds::SledUuid;
 use slog::error;
 use slog::{info, warn, Logger};
-use std::collections::BTreeMap;
 use std::collections::BTreeSet;
 use std::str::FromStr;
 
@@ -544,16 +543,11 @@ impl<'a> Planner<'a> {
         &mut self,
         zone_placement: &mut OmicronZonePlacement,
         kind: DiscretionaryOmicronZone,
-        mut num_zones_to_add: usize,
+        num_zones_to_add: usize,
     ) -> Result<(), Error> {
-        // Build a map of sled -> new zones to add.
-        let mut sleds_to_change: BTreeMap<SledUuid, usize> = BTreeMap::new();
-
         for i in 0..num_zones_to_add {
-            match zone_placement.place_zone(kind) {
-                Ok(sled_id) => {
-                    *sleds_to_change.entry(sled_id).or_default() += 1;
-                }
+            let sled_id = match zone_placement.place_zone(kind) {
+                Ok(sled_id) => sled_id,
                 Err(PlacementError::NoSledsEligible { .. }) => {
                     // We won't treat this as a hard error; it's possible
                     // (albeit unlikely?) we're in a weird state where we need
@@ -566,120 +560,48 @@ impl<'a> Planner<'a> {
                         "wanted_to_place" => num_zones_to_add,
                     );
 
-                    // Adjust `num_zones_to_add` downward so it's consistent
-                    // with the number of zones we're actually adding.
-                    num_zones_to_add = i;
-
                     break;
                 }
-            }
-        }
+            };
 
-        // For each sled we need to change, actually do so.
-        let mut new_zones_added = 0;
-        for (sled_id, additional_zone_count) in sleds_to_change {
-            // TODO-cleanup This is awkward: the builder wants to know how many
-            // total zones go on a given sled, but we have a count of how many
-            // we want to add. Construct a new target count. Maybe the builder
-            // should provide a different interface here?
-            let new_total_zone_count = self
-                .blueprint
-                .sled_num_running_zones_of_kind(sled_id, kind.into())
-                + additional_zone_count;
-
-            let result = match kind {
+            match kind {
                 DiscretionaryOmicronZone::BoundaryNtp => self
                     .blueprint
                     .sled_promote_internal_ntp_to_boundary_ntp(sled_id)?,
                 DiscretionaryOmicronZone::Clickhouse => {
-                    self.blueprint.sled_ensure_zone_multiple_clickhouse(
-                        sled_id,
-                        new_total_zone_count,
-                    )?
+                    self.blueprint.sled_add_zone_clickhouse(sled_id)?
                 }
                 DiscretionaryOmicronZone::ClickhouseKeeper => {
-                    self.blueprint.sled_ensure_zone_multiple_clickhouse_keeper(
-                        sled_id,
-                        new_total_zone_count,
-                    )?
+                    self.blueprint.sled_add_zone_clickhouse_keeper(sled_id)?
                 }
                 DiscretionaryOmicronZone::ClickhouseServer => {
-                    self.blueprint.sled_ensure_zone_multiple_clickhouse_server(
-                        sled_id,
-                        new_total_zone_count,
-                    )?
+                    self.blueprint.sled_add_zone_clickhouse_server(sled_id)?
                 }
                 DiscretionaryOmicronZone::CockroachDb => {
-                    self.blueprint.sled_ensure_zone_multiple_cockroachdb(
-                        sled_id,
-                        new_total_zone_count,
-                    )?
+                    self.blueprint.sled_add_zone_cockroachdb(sled_id)?
                 }
                 DiscretionaryOmicronZone::CruciblePantry => {
-                    self.blueprint.sled_ensure_zone_multiple_crucible_pantry(
-                        sled_id,
-                        new_total_zone_count,
-                    )?
+                    self.blueprint.sled_add_zone_crucible_pantry(sled_id)?
                 }
                 DiscretionaryOmicronZone::InternalDns => {
-                    self.blueprint.sled_ensure_zone_multiple_internal_dns(
-                        sled_id,
-                        new_total_zone_count,
-                    )?
+                    self.blueprint.sled_add_zone_internal_dns(sled_id)?
                 }
                 DiscretionaryOmicronZone::ExternalDns => {
-                    self.blueprint.sled_ensure_zone_multiple_external_dns(
-                        sled_id,
-                        new_total_zone_count,
-                    )?
+                    self.blueprint.sled_add_zone_external_dns(sled_id)?
                 }
                 DiscretionaryOmicronZone::Nexus => {
-                    self.blueprint.sled_ensure_zone_multiple_nexus(
-                        sled_id,
-                        new_total_zone_count,
-                    )?
+                    self.blueprint.sled_add_zone_nexus(sled_id)?
                 }
                 DiscretionaryOmicronZone::Oximeter => {
-                    self.blueprint.sled_ensure_zone_multiple_oximeter(
-                        sled_id,
-                        new_total_zone_count,
-                    )?
+                    self.blueprint.sled_add_zone_oximeter(sled_id)?
                 }
             };
-            match result {
-                EnsureMultiple::Changed {
-                    added,
-                    updated,
-                    expunged,
-                    removed,
-                } => {
-                    info!(
-                        self.log, "modified zones on sled";
-                        "sled_id" => %sled_id,
-                        "kind" => ?kind,
-                        "added" => added,
-                        "updated" => updated,
-                        "expunged" => expunged,
-                        "removed" => removed,
-                    );
-                    new_zones_added += added;
-                }
-                // This is only possible if we asked the sled to ensure the same
-                // number of zones it already has, but that's impossible based
-                // on the way we built up `sleds_to_change`.
-                EnsureMultiple::NotNeeded => unreachable!(
-                    "sled on which we added {kind:?} zones did not add any"
-                ),
-            }
+            info!(
+                self.log, "added zone to sled";
+                "sled_id" => %sled_id,
+                "kind" => ?kind,
+            );
         }
-
-        // Double check that we didn't make any arithmetic mistakes. If we've
-        // arrived here, we think we've added the number of `kind` zones we
-        // needed to.
-        assert_eq!(
-            new_zones_added, num_zones_to_add,
-            "internal error counting {kind:?} zones"
-        );
 
         Ok(())
     }
@@ -870,7 +792,6 @@ mod test {
     use crate::blueprint_builder::test::assert_planning_makes_no_changes;
     use crate::blueprint_builder::test::verify_blueprint;
     use crate::blueprint_builder::BlueprintBuilder;
-    use crate::blueprint_builder::EnsureMultiple;
     use crate::example::example;
     use crate::example::ExampleSystemBuilder;
     use crate::example::SimRngState;
@@ -1516,17 +1437,9 @@ mod test {
         )
         .expect("failed to build blueprint builder");
         let sled_id = builder.sled_ids_with_zones().next().expect("no sleds");
-        assert_eq!(
-            builder
-                .sled_ensure_zone_multiple_external_dns(sled_id, 3)
-                .expect("can't add external DNS zones"),
-            EnsureMultiple::Changed {
-                added: 0,
-                updated: 0,
-                removed: 0,
-                expunged: 0
-            },
-        );
+        builder
+            .sled_add_zone_external_dns(sled_id)
+            .expect_err("can't add external DNS zones");
 
         // Build a builder for a modfied blueprint that will include
         // some external DNS addresses.
@@ -1560,28 +1473,15 @@ mod test {
                 sleds.next().expect("no second sled"),
             )
         };
-        assert!(matches!(
-            blueprint_builder
-                .sled_ensure_zone_multiple_external_dns(sled_1, 2)
-                .expect("can't add external DNS zones to blueprint"),
-            EnsureMultiple::Changed {
-                added: 2,
-                updated: 0,
-                removed: 0,
-                expunged: 0
-            }
-        ));
-        assert!(matches!(
-            blueprint_builder
-                .sled_ensure_zone_multiple_external_dns(sled_2, 1)
-                .expect("can't add external DNS zones to blueprint"),
-            EnsureMultiple::Changed {
-                added: 1,
-                updated: 0,
-                removed: 0,
-                expunged: 0
-            }
-        ));
+        blueprint_builder
+            .sled_add_zone_external_dns(sled_1)
+            .expect("added external DNS zone");
+        blueprint_builder
+            .sled_add_zone_external_dns(sled_1)
+            .expect("added external DNS zone");
+        blueprint_builder
+            .sled_add_zone_external_dns(sled_2)
+            .expect("added external DNS zone");
 
         let blueprint1a = blueprint_builder.build();
         assert_eq!(

--- a/nexus/reconfigurator/planning/tests/output/planner_deploy_all_keeper_nodes_1_2.txt
+++ b/nexus/reconfigurator/planning/tests/output/planner_deploy_all_keeper_nodes_1_2.txt
@@ -72,8 +72,8 @@ to:   blueprint 31ef2071-2ec9-49d9-8827-fd83b17a0e3d
     oxp_fbf997ef-52d3-438a-b036-b9117322e569/crypt/debug                                                             17ffe1be-b38b-4f39-90af-57af25dbfe30   100 GiB   none          gzip-9     
     oxp_e9c238f6-87a3-4087-8ba4-aa594a82d012/crypt/debug                                                             2288ff91-8e52-4817-825f-2f8b8eb1681d   100 GiB   none          gzip-9     
     oxp_71a07ac0-d24e-446c-a202-1998e7f6ac8c/crypt/debug                                                             e0bcc415-f8f9-401f-a507-cee5587756b1   100 GiB   none          gzip-9     
-+   oxp_60e6b021-79d6-4a6b-917c-6637e0769558/crypt/clickhouse_keeper                                                 c16a00f5-8830-400d-89e0-9a77cce8780e   none      none          off        
-+   oxp_60e6b021-79d6-4a6b-917c-6637e0769558/crypt/zone/oxz_clickhouse_keeper_f3279a8b-32fa-4426-b946-08aff9ded482   26c79a0e-a2e4-4093-ba43-5e7979609651   none      none          off        
++   oxp_60e6b021-79d6-4a6b-917c-6637e0769558/crypt/clickhouse_keeper                                                 886f2522-8122-465f-8996-2d8c2acd9d0d   none      none          off        
++   oxp_60e6b021-79d6-4a6b-917c-6637e0769558/crypt/zone/oxz_clickhouse_keeper_39fd3357-4de8-433e-9c07-1ec65de7ca59   095cf066-5a68-40b4-afc6-baf5bcbadd05   none      none          off        
 
 
     omicron zones generation 2 -> 3:
@@ -95,7 +95,7 @@ to:   blueprint 31ef2071-2ec9-49d9-8827-fd83b17a0e3d
     internal_dns        c89ac05f-d9b2-47f4-9d48-2f38130e4ad9   in service    fd00:1122:3344:1::1   
     internal_ntp        66695827-17c4-4885-b6c0-2cb6b6d3ad1c   in service    fd00:1122:3344:101::21
     nexus               a6032c9e-a365-45d7-ad9f-07ac0fa7079a   in service    fd00:1122:3344:101::22
-+   clickhouse_keeper   f3279a8b-32fa-4426-b946-08aff9ded482   in service    fd00:1122:3344:101::2f
++   clickhouse_keeper   39fd3357-4de8-433e-9c07-1ec65de7ca59   in service    fd00:1122:3344:101::2f
 
 
   sled 6a4c45f6-e02f-490c-bbfa-b32fb89e8e86 (active):
@@ -166,9 +166,9 @@ to:   blueprint 31ef2071-2ec9-49d9-8827-fd83b17a0e3d
     oxp_f635c28a-e5ca-4d22-ac94-d8f278a6ea0e/crypt/debug                                                             765b4728-8d6e-4fac-9a1b-ae2258d5c52b   100 GiB   none          gzip-9     
     oxp_af85eec8-36b3-4b88-966d-a717b9b58fe5/crypt/debug                                                             98d65e73-01df-4525-a45d-acb2fc8d4a74   100 GiB   none          gzip-9     
 +   oxp_0bf9d028-2b4a-4bff-82a1-6eb5fcefd985/crypt/clickhouse_keeper                                                 a3eed313-d886-4c1d-8023-8d2ec9e97ddd   none      none          off        
-+   oxp_0bf9d028-2b4a-4bff-82a1-6eb5fcefd985/crypt/clickhouse_server                                                 ce930007-8ed6-4675-a24a-57c227950d43   none      none          off        
++   oxp_0bf9d028-2b4a-4bff-82a1-6eb5fcefd985/crypt/clickhouse_server                                                 3d339942-c2d0-4615-a099-433a8b5a1543   none      none          off        
 +   oxp_0bf9d028-2b4a-4bff-82a1-6eb5fcefd985/crypt/zone/oxz_clickhouse_keeper_b36c16d5-de6e-411a-a32a-d35a26f2e151   48720037-5b8e-4478-9bb5-c86ee8a6e250   none      none          off        
-+   oxp_0bf9d028-2b4a-4bff-82a1-6eb5fcefd985/crypt/zone/oxz_clickhouse_server_122e30d3-d541-49b5-88de-1543b38123cc   748c9607-71dd-4f81-be08-c1eee262f69c   none      none          off        
++   oxp_0bf9d028-2b4a-4bff-82a1-6eb5fcefd985/crypt/zone/oxz_clickhouse_server_71be6bff-666a-4f2b-a7dc-d80a88a71af5   a9e2160a-688f-4bbd-9a77-b2e695df86f4   none      none          off        
 
 
     omicron zones generation 2 -> 3:
@@ -190,7 +190,7 @@ to:   blueprint 31ef2071-2ec9-49d9-8827-fd83b17a0e3d
     internal_ntp        bba31b23-d112-4cde-bd4a-635812c28c0e   in service    fd00:1122:3344:103::21
     nexus               c3c7b0bd-dce3-467b-919d-668cc6b06711   in service    fd00:1122:3344:103::22
 +   clickhouse_keeper   b36c16d5-de6e-411a-a32a-d35a26f2e151   in service    fd00:1122:3344:103::2e
-+   clickhouse_server   122e30d3-d541-49b5-88de-1543b38123cc   in service    fd00:1122:3344:103::2f
++   clickhouse_server   71be6bff-666a-4f2b-a7dc-d80a88a71af5   in service    fd00:1122:3344:103::2f
 
 
   sled be531a62-9897-430d-acd2-ce14b4632627 (active):
@@ -260,10 +260,10 @@ to:   blueprint 31ef2071-2ec9-49d9-8827-fd83b17a0e3d
     oxp_e3b45593-8f0c-47b2-a381-802a7dad1f54/crypt/debug                                                             96798a17-be94-44bb-9e12-2eb458e9a5ba   100 GiB   none          gzip-9     
     oxp_2f02a5c6-fcf5-4b5a-bc7d-7f65369918ba/crypt/debug                                                             daeded95-0145-4b97-b1fb-60d44856d1e4   100 GiB   none          gzip-9     
     oxp_2a76ab1a-fb16-412d-93f9-b8cd9aa94e85/crypt/debug                                                             c55ba154-4f4b-48a5-997b-2a1579671c74   100 GiB   none          gzip-9     
-+   oxp_2a76ab1a-fb16-412d-93f9-b8cd9aa94e85/crypt/clickhouse_keeper                                                 886f2522-8122-465f-8996-2d8c2acd9d0d   none      none          off        
-+   oxp_2a76ab1a-fb16-412d-93f9-b8cd9aa94e85/crypt/clickhouse_server                                                 3d339942-c2d0-4615-a099-433a8b5a1543   none      none          off        
-+   oxp_2a76ab1a-fb16-412d-93f9-b8cd9aa94e85/crypt/zone/oxz_clickhouse_keeper_39fd3357-4de8-433e-9c07-1ec65de7ca59   095cf066-5a68-40b4-afc6-baf5bcbadd05   none      none          off        
-+   oxp_2a76ab1a-fb16-412d-93f9-b8cd9aa94e85/crypt/zone/oxz_clickhouse_server_71be6bff-666a-4f2b-a7dc-d80a88a71af5   a9e2160a-688f-4bbd-9a77-b2e695df86f4   none      none          off        
++   oxp_2a76ab1a-fb16-412d-93f9-b8cd9aa94e85/crypt/clickhouse_keeper                                                 c16a00f5-8830-400d-89e0-9a77cce8780e   none      none          off        
++   oxp_2a76ab1a-fb16-412d-93f9-b8cd9aa94e85/crypt/clickhouse_server                                                 ce930007-8ed6-4675-a24a-57c227950d43   none      none          off        
++   oxp_2a76ab1a-fb16-412d-93f9-b8cd9aa94e85/crypt/zone/oxz_clickhouse_keeper_f3279a8b-32fa-4426-b946-08aff9ded482   26c79a0e-a2e4-4093-ba43-5e7979609651   none      none          off        
++   oxp_2a76ab1a-fb16-412d-93f9-b8cd9aa94e85/crypt/zone/oxz_clickhouse_server_122e30d3-d541-49b5-88de-1543b38123cc   748c9607-71dd-4f81-be08-c1eee262f69c   none      none          off        
 
 
     omicron zones generation 2 -> 3:
@@ -284,8 +284,8 @@ to:   blueprint 31ef2071-2ec9-49d9-8827-fd83b17a0e3d
     internal_dns        832c71a1-357d-482b-8661-3193d59ed776   in service    fd00:1122:3344:3::1   
     internal_ntp        816afef9-e5cd-40ba-8cc5-71e783943e43   in service    fd00:1122:3344:102::21
     nexus               da39dead-64e2-45b6-9d01-d99584504dfd   in service    fd00:1122:3344:102::22
-+   clickhouse_keeper   39fd3357-4de8-433e-9c07-1ec65de7ca59   in service    fd00:1122:3344:102::2e
-+   clickhouse_server   71be6bff-666a-4f2b-a7dc-d80a88a71af5   in service    fd00:1122:3344:102::2f
++   clickhouse_keeper   f3279a8b-32fa-4426-b946-08aff9ded482   in service    fd00:1122:3344:102::2e
++   clickhouse_server   122e30d3-d541-49b5-88de-1543b38123cc   in service    fd00:1122:3344:102::2f
 
 
  COCKROACHDB SETTINGS:

--- a/nexus/reconfigurator/planning/tests/output/planner_deploy_all_keeper_nodes_3_4.txt
+++ b/nexus/reconfigurator/planning/tests/output/planner_deploy_all_keeper_nodes_3_4.txt
@@ -36,7 +36,7 @@ to:   blueprint 92fa943c-7dd4-48c3-9447-c9d0665744b6
     oxp_e9c238f6-87a3-4087-8ba4-aa594a82d012/crucible                                                                e88d6ff8-6b98-44c1-97a7-83f371ae62fe   none      none          off        
     oxp_fbf997ef-52d3-438a-b036-b9117322e569/crucible                                                                d6a838c7-3ee9-4cca-9d8b-986b4de0ba1c   none      none          off        
     oxp_60e6b021-79d6-4a6b-917c-6637e0769558/crypt/clickhouse                                                        5cb56dc7-6c56-4bbf-ae73-6f08e0c97cdf   none      none          off        
-    oxp_60e6b021-79d6-4a6b-917c-6637e0769558/crypt/clickhouse_keeper                                                 c16a00f5-8830-400d-89e0-9a77cce8780e   none      none          off        
+    oxp_60e6b021-79d6-4a6b-917c-6637e0769558/crypt/clickhouse_keeper                                                 886f2522-8122-465f-8996-2d8c2acd9d0d   none      none          off        
     oxp_60e6b021-79d6-4a6b-917c-6637e0769558/crypt/internal_dns                                                      dd467397-efc5-4738-984e-77a0f3e3e678   none      none          off        
     oxp_e9c238f6-87a3-4087-8ba4-aa594a82d012/crypt/zone                                                              f963f2a7-e9d1-4b80-b01a-ff4cecddf867   none      none          off        
     oxp_8ae56ca0-709d-4b8f-9869-51b62b542eef/crypt/zone                                                              61bf628d-a78d-40a7-bad2-84e97e41b810   none      none          off        
@@ -49,7 +49,7 @@ to:   blueprint 92fa943c-7dd4-48c3-9447-c9d0665744b6
     oxp_fbf997ef-52d3-438a-b036-b9117322e569/crypt/zone                                                              a15e4260-d48c-4415-9315-c0f29234f359   none      none          off        
     oxp_736d4cab-c262-485e-89c2-07e6543f0855/crypt/zone                                                              a34f8204-9f17-4c8f-997b-e122c284ac9f   none      none          off        
     oxp_60e6b021-79d6-4a6b-917c-6637e0769558/crypt/zone/oxz_clickhouse_df79db1e-54ca-4048-b22a-da120ae4c8c4          b6cb0fe9-0b7a-4793-b6cd-1ee71fee464c   none      none          off        
-    oxp_60e6b021-79d6-4a6b-917c-6637e0769558/crypt/zone/oxz_clickhouse_keeper_f3279a8b-32fa-4426-b946-08aff9ded482   26c79a0e-a2e4-4093-ba43-5e7979609651   none      none          off        
+    oxp_60e6b021-79d6-4a6b-917c-6637e0769558/crypt/zone/oxz_clickhouse_keeper_39fd3357-4de8-433e-9c07-1ec65de7ca59   095cf066-5a68-40b4-afc6-baf5bcbadd05   none      none          off        
     oxp_8e0bcc4f-0799-450c-a0ad-80c1637f59e3/crypt/zone/oxz_crucible_08330c18-54e9-445b-81f3-8f1d6ad15cdd            ab255226-2c8c-4222-82c6-702af839a2d2   none      none          off        
     oxp_fbf997ef-52d3-438a-b036-b9117322e569/crypt/zone/oxz_crucible_0ba018f0-4ff7-4bcc-a0c7-42cfec6bc9da            ba1a3aae-15ab-4364-8250-54a766331ef8   none      none          off        
     oxp_60e6b021-79d6-4a6b-917c-6637e0769558/crypt/zone/oxz_crucible_1e485cda-b36e-4647-9125-c273fc7a9850            65c2e3cd-3d8e-43c6-9e2c-cb884511ec49   none      none          off        
@@ -81,7 +81,7 @@ to:   blueprint 92fa943c-7dd4-48c3-9447-c9d0665744b6
     zone type           zone id                                disposition   underlay IP           
     -----------------------------------------------------------------------------------------------
     clickhouse          df79db1e-54ca-4048-b22a-da120ae4c8c4   in service    fd00:1122:3344:101::23
-    clickhouse_keeper   f3279a8b-32fa-4426-b946-08aff9ded482   in service    fd00:1122:3344:101::2f
+    clickhouse_keeper   39fd3357-4de8-433e-9c07-1ec65de7ca59   in service    fd00:1122:3344:101::2f
     crucible            08330c18-54e9-445b-81f3-8f1d6ad15cdd   in service    fd00:1122:3344:101::29
     crucible            0ba018f0-4ff7-4bcc-a0c7-42cfec6bc9da   in service    fd00:1122:3344:101::2e
     crucible            1e485cda-b36e-4647-9125-c273fc7a9850   in service    fd00:1122:3344:101::25
@@ -131,7 +131,7 @@ to:   blueprint 92fa943c-7dd4-48c3-9447-c9d0665744b6
     oxp_ddfaaba3-dafe-4103-b868-e9843d29d346/crucible                                                                2d7145e9-0029-4ae0-bb12-ee65a1738005   none      none          off        
     oxp_ec458c3e-91ca-40f1-a2a3-3f4292c1f279/crucible                                                                dfadcc38-505a-4e9b-8674-27f8a2af13a2   none      none          off        
     oxp_0bf9d028-2b4a-4bff-82a1-6eb5fcefd985/crypt/clickhouse_keeper                                                 a3eed313-d886-4c1d-8023-8d2ec9e97ddd   none      none          off        
-    oxp_0bf9d028-2b4a-4bff-82a1-6eb5fcefd985/crypt/clickhouse_server                                                 ce930007-8ed6-4675-a24a-57c227950d43   none      none          off        
+    oxp_0bf9d028-2b4a-4bff-82a1-6eb5fcefd985/crypt/clickhouse_server                                                 3d339942-c2d0-4615-a099-433a8b5a1543   none      none          off        
     oxp_0bf9d028-2b4a-4bff-82a1-6eb5fcefd985/crypt/internal_dns                                                      b8af3673-c60a-45fb-adc1-c36d0d325417   none      none          off        
     oxp_f2fc7c4c-7966-449d-8ec3-5a70f460501d/crypt/zone                                                              e49915c6-59ed-4bbe-abf9-375b9502772a   none      none          off        
     oxp_9ae94c94-baae-477e-912a-60f0c4f3bd13/crypt/zone                                                              e4220797-15df-42c4-9df7-ad927711d565   none      none          off        
@@ -144,7 +144,7 @@ to:   blueprint 92fa943c-7dd4-48c3-9447-c9d0665744b6
     oxp_ec458c3e-91ca-40f1-a2a3-3f4292c1f279/crypt/zone                                                              29038bb0-9af1-4b03-9c10-b8a6444a0bc2   none      none          off        
     oxp_f635c28a-e5ca-4d22-ac94-d8f278a6ea0e/crypt/zone                                                              fc9765c5-0a89-4050-ba3e-e0625dbefb5f   none      none          off        
     oxp_0bf9d028-2b4a-4bff-82a1-6eb5fcefd985/crypt/zone/oxz_clickhouse_keeper_b36c16d5-de6e-411a-a32a-d35a26f2e151   48720037-5b8e-4478-9bb5-c86ee8a6e250   none      none          off        
-    oxp_0bf9d028-2b4a-4bff-82a1-6eb5fcefd985/crypt/zone/oxz_clickhouse_server_122e30d3-d541-49b5-88de-1543b38123cc   748c9607-71dd-4f81-be08-c1eee262f69c   none      none          off        
+    oxp_0bf9d028-2b4a-4bff-82a1-6eb5fcefd985/crypt/zone/oxz_clickhouse_server_71be6bff-666a-4f2b-a7dc-d80a88a71af5   a9e2160a-688f-4bbd-9a77-b2e695df86f4   none      none          off        
     oxp_ddfaaba3-dafe-4103-b868-e9843d29d346/crypt/zone/oxz_crucible_1a92bb17-6477-46fc-9784-1d2a418d6e14            257c57cd-8f2c-440d-9fa0-e92a312295ec   none      none          off        
     oxp_af85eec8-36b3-4b88-966d-a717b9b58fe5/crypt/zone/oxz_crucible_26115267-8333-4711-924e-d05acf601827            3a39d5e8-ea73-4cf3-b9de-48045475151c   none      none          off        
     oxp_9ae94c94-baae-477e-912a-60f0c4f3bd13/crypt/zone/oxz_crucible_41af4ef6-d21b-4271-bfcb-524f4146784a            1522207b-ea98-47cc-810c-44808796d743   none      none          off        
@@ -176,7 +176,7 @@ to:   blueprint 92fa943c-7dd4-48c3-9447-c9d0665744b6
     zone type           zone id                                disposition   underlay IP           
     -----------------------------------------------------------------------------------------------
     clickhouse_keeper   b36c16d5-de6e-411a-a32a-d35a26f2e151   in service    fd00:1122:3344:103::2e
-    clickhouse_server   122e30d3-d541-49b5-88de-1543b38123cc   in service    fd00:1122:3344:103::2f
+    clickhouse_server   71be6bff-666a-4f2b-a7dc-d80a88a71af5   in service    fd00:1122:3344:103::2f
     crucible            1a92bb17-6477-46fc-9784-1d2a418d6e14   in service    fd00:1122:3344:103::2a
     crucible            26115267-8333-4711-924e-d05acf601827   in service    fd00:1122:3344:103::29
     crucible            41af4ef6-d21b-4271-bfcb-524f4146784a   in service    fd00:1122:3344:103::28
@@ -225,8 +225,8 @@ to:   blueprint 92fa943c-7dd4-48c3-9447-c9d0665744b6
     oxp_b3c231c9-b2a5-4267-b4bf-9651881b91a5/crucible                                                                aa8f925e-6c3a-40d2-ae2d-946324a7d612   none      none          off        
     oxp_db16345e-427a-4c8e-9032-17270f729308/crucible                                                                be3cf2f7-5388-4cd6-8119-ecf316c6052e   none      none          off        
     oxp_e3b45593-8f0c-47b2-a381-802a7dad1f54/crucible                                                                a2391107-7408-4e0c-a694-3fd073fa09df   none      none          off        
-    oxp_2a76ab1a-fb16-412d-93f9-b8cd9aa94e85/crypt/clickhouse_keeper                                                 886f2522-8122-465f-8996-2d8c2acd9d0d   none      none          off        
-    oxp_2a76ab1a-fb16-412d-93f9-b8cd9aa94e85/crypt/clickhouse_server                                                 3d339942-c2d0-4615-a099-433a8b5a1543   none      none          off        
+    oxp_2a76ab1a-fb16-412d-93f9-b8cd9aa94e85/crypt/clickhouse_keeper                                                 c16a00f5-8830-400d-89e0-9a77cce8780e   none      none          off        
+    oxp_2a76ab1a-fb16-412d-93f9-b8cd9aa94e85/crypt/clickhouse_server                                                 ce930007-8ed6-4675-a24a-57c227950d43   none      none          off        
     oxp_2a76ab1a-fb16-412d-93f9-b8cd9aa94e85/crypt/internal_dns                                                      7be88e8f-06d3-49f7-a6d9-5c586f13716c   none      none          off        
     oxp_db16345e-427a-4c8e-9032-17270f729308/crypt/zone                                                              f7ddacf4-edc7-46ba-9b74-d588bd62505e   none      none          off        
     oxp_32041dbf-e58d-4f32-840d-923d3d3b68af/crypt/zone                                                              3f1adfcf-9a2a-41db-9e1a-a2e13ff8a7dd   none      none          off        
@@ -238,8 +238,8 @@ to:   blueprint 92fa943c-7dd4-48c3-9447-c9d0665744b6
     oxp_bca80b95-8dca-4a3b-b24d-d44b6a9ff71b/crypt/zone                                                              2747bb48-2fb7-4999-a63c-5ba5e35e0a10   none      none          off        
     oxp_e3b45593-8f0c-47b2-a381-802a7dad1f54/crypt/zone                                                              64e62d15-e813-461d-9a50-403d9bd1df7c   none      none          off        
     oxp_2f02a5c6-fcf5-4b5a-bc7d-7f65369918ba/crypt/zone                                                              38103edf-a98f-46ca-94ea-3404268ea935   none      none          off        
-    oxp_2a76ab1a-fb16-412d-93f9-b8cd9aa94e85/crypt/zone/oxz_clickhouse_keeper_39fd3357-4de8-433e-9c07-1ec65de7ca59   095cf066-5a68-40b4-afc6-baf5bcbadd05   none      none          off        
-    oxp_2a76ab1a-fb16-412d-93f9-b8cd9aa94e85/crypt/zone/oxz_clickhouse_server_71be6bff-666a-4f2b-a7dc-d80a88a71af5   a9e2160a-688f-4bbd-9a77-b2e695df86f4   none      none          off        
+    oxp_2a76ab1a-fb16-412d-93f9-b8cd9aa94e85/crypt/zone/oxz_clickhouse_keeper_f3279a8b-32fa-4426-b946-08aff9ded482   26c79a0e-a2e4-4093-ba43-5e7979609651   none      none          off        
+    oxp_2a76ab1a-fb16-412d-93f9-b8cd9aa94e85/crypt/zone/oxz_clickhouse_server_122e30d3-d541-49b5-88de-1543b38123cc   748c9607-71dd-4f81-be08-c1eee262f69c   none      none          off        
     oxp_bca80b95-8dca-4a3b-b24d-d44b6a9ff71b/crypt/zone/oxz_crucible_0a160b89-6288-44f5-9908-33589094628e            53a623d2-9ffc-48fb-871d-23bd52e0f4dd   none      none          off        
     oxp_2f02a5c6-fcf5-4b5a-bc7d-7f65369918ba/crypt/zone/oxz_crucible_2cb036bd-6056-4547-af65-aa6c0c1e4d6e            c6c9e491-ce4d-4dc4-82be-e394fa1e82e2   none      none          off        
     oxp_2de2bf7e-c679-4b2b-b373-908e9d3ffbfc/crypt/zone/oxz_crucible_37c72edc-6acd-4c2d-ab76-d1c88e1f01f5            9b49fc13-4d2c-423e-9839-f6e1d0bffc6e   none      none          off        
@@ -270,8 +270,8 @@ to:   blueprint 92fa943c-7dd4-48c3-9447-c9d0665744b6
     -----------------------------------------------------------------------------------------------
     zone type           zone id                                disposition   underlay IP           
     -----------------------------------------------------------------------------------------------
-    clickhouse_keeper   39fd3357-4de8-433e-9c07-1ec65de7ca59   in service    fd00:1122:3344:102::2e
-    clickhouse_server   71be6bff-666a-4f2b-a7dc-d80a88a71af5   in service    fd00:1122:3344:102::2f
+    clickhouse_keeper   f3279a8b-32fa-4426-b946-08aff9ded482   in service    fd00:1122:3344:102::2e
+    clickhouse_server   122e30d3-d541-49b5-88de-1543b38123cc   in service    fd00:1122:3344:102::2f
     crucible            0a160b89-6288-44f5-9908-33589094628e   in service    fd00:1122:3344:102::2b
     crucible            2cb036bd-6056-4547-af65-aa6c0c1e4d6e   in service    fd00:1122:3344:102::26
     crucible            37c72edc-6acd-4c2d-ab76-d1c88e1f01f5   in service    fd00:1122:3344:102::25

--- a/nexus/reconfigurator/planning/tests/output/planner_deploy_all_keeper_nodes_4_5.txt
+++ b/nexus/reconfigurator/planning/tests/output/planner_deploy_all_keeper_nodes_4_5.txt
@@ -36,7 +36,7 @@ to:   blueprint 2886dab5-61a2-46b4-87af-bc7aeb44cccb
     oxp_e9c238f6-87a3-4087-8ba4-aa594a82d012/crucible                                                                e88d6ff8-6b98-44c1-97a7-83f371ae62fe   none      none          off        
     oxp_fbf997ef-52d3-438a-b036-b9117322e569/crucible                                                                d6a838c7-3ee9-4cca-9d8b-986b4de0ba1c   none      none          off        
     oxp_60e6b021-79d6-4a6b-917c-6637e0769558/crypt/clickhouse                                                        5cb56dc7-6c56-4bbf-ae73-6f08e0c97cdf   none      none          off        
-    oxp_60e6b021-79d6-4a6b-917c-6637e0769558/crypt/clickhouse_keeper                                                 c16a00f5-8830-400d-89e0-9a77cce8780e   none      none          off        
+    oxp_60e6b021-79d6-4a6b-917c-6637e0769558/crypt/clickhouse_keeper                                                 886f2522-8122-465f-8996-2d8c2acd9d0d   none      none          off        
     oxp_60e6b021-79d6-4a6b-917c-6637e0769558/crypt/internal_dns                                                      dd467397-efc5-4738-984e-77a0f3e3e678   none      none          off        
     oxp_e9c238f6-87a3-4087-8ba4-aa594a82d012/crypt/zone                                                              f963f2a7-e9d1-4b80-b01a-ff4cecddf867   none      none          off        
     oxp_8ae56ca0-709d-4b8f-9869-51b62b542eef/crypt/zone                                                              61bf628d-a78d-40a7-bad2-84e97e41b810   none      none          off        
@@ -49,7 +49,7 @@ to:   blueprint 2886dab5-61a2-46b4-87af-bc7aeb44cccb
     oxp_fbf997ef-52d3-438a-b036-b9117322e569/crypt/zone                                                              a15e4260-d48c-4415-9315-c0f29234f359   none      none          off        
     oxp_736d4cab-c262-485e-89c2-07e6543f0855/crypt/zone                                                              a34f8204-9f17-4c8f-997b-e122c284ac9f   none      none          off        
     oxp_60e6b021-79d6-4a6b-917c-6637e0769558/crypt/zone/oxz_clickhouse_df79db1e-54ca-4048-b22a-da120ae4c8c4          b6cb0fe9-0b7a-4793-b6cd-1ee71fee464c   none      none          off        
-    oxp_60e6b021-79d6-4a6b-917c-6637e0769558/crypt/zone/oxz_clickhouse_keeper_f3279a8b-32fa-4426-b946-08aff9ded482   26c79a0e-a2e4-4093-ba43-5e7979609651   none      none          off        
+    oxp_60e6b021-79d6-4a6b-917c-6637e0769558/crypt/zone/oxz_clickhouse_keeper_39fd3357-4de8-433e-9c07-1ec65de7ca59   095cf066-5a68-40b4-afc6-baf5bcbadd05   none      none          off        
     oxp_8e0bcc4f-0799-450c-a0ad-80c1637f59e3/crypt/zone/oxz_crucible_08330c18-54e9-445b-81f3-8f1d6ad15cdd            ab255226-2c8c-4222-82c6-702af839a2d2   none      none          off        
     oxp_fbf997ef-52d3-438a-b036-b9117322e569/crypt/zone/oxz_crucible_0ba018f0-4ff7-4bcc-a0c7-42cfec6bc9da            ba1a3aae-15ab-4364-8250-54a766331ef8   none      none          off        
     oxp_60e6b021-79d6-4a6b-917c-6637e0769558/crypt/zone/oxz_crucible_1e485cda-b36e-4647-9125-c273fc7a9850            65c2e3cd-3d8e-43c6-9e2c-cb884511ec49   none      none          off        
@@ -81,7 +81,7 @@ to:   blueprint 2886dab5-61a2-46b4-87af-bc7aeb44cccb
     zone type           zone id                                disposition   underlay IP           
     -----------------------------------------------------------------------------------------------
     clickhouse          df79db1e-54ca-4048-b22a-da120ae4c8c4   in service    fd00:1122:3344:101::23
-    clickhouse_keeper   f3279a8b-32fa-4426-b946-08aff9ded482   in service    fd00:1122:3344:101::2f
+    clickhouse_keeper   39fd3357-4de8-433e-9c07-1ec65de7ca59   in service    fd00:1122:3344:101::2f
     crucible            08330c18-54e9-445b-81f3-8f1d6ad15cdd   in service    fd00:1122:3344:101::29
     crucible            0ba018f0-4ff7-4bcc-a0c7-42cfec6bc9da   in service    fd00:1122:3344:101::2e
     crucible            1e485cda-b36e-4647-9125-c273fc7a9850   in service    fd00:1122:3344:101::25
@@ -133,7 +133,7 @@ to:   blueprint 2886dab5-61a2-46b4-87af-bc7aeb44cccb
     oxp_ddfaaba3-dafe-4103-b868-e9843d29d346/crucible                                                                2d7145e9-0029-4ae0-bb12-ee65a1738005   none      none          off        
     oxp_ec458c3e-91ca-40f1-a2a3-3f4292c1f279/crucible                                                                dfadcc38-505a-4e9b-8674-27f8a2af13a2   none      none          off        
     oxp_0bf9d028-2b4a-4bff-82a1-6eb5fcefd985/crypt/clickhouse_keeper                                                 a3eed313-d886-4c1d-8023-8d2ec9e97ddd   none      none          off        
-    oxp_0bf9d028-2b4a-4bff-82a1-6eb5fcefd985/crypt/clickhouse_server                                                 ce930007-8ed6-4675-a24a-57c227950d43   none      none          off        
+    oxp_0bf9d028-2b4a-4bff-82a1-6eb5fcefd985/crypt/clickhouse_server                                                 3d339942-c2d0-4615-a099-433a8b5a1543   none      none          off        
     oxp_0bf9d028-2b4a-4bff-82a1-6eb5fcefd985/crypt/internal_dns                                                      b8af3673-c60a-45fb-adc1-c36d0d325417   none      none          off        
     oxp_f2fc7c4c-7966-449d-8ec3-5a70f460501d/crypt/zone                                                              e49915c6-59ed-4bbe-abf9-375b9502772a   none      none          off        
     oxp_9ae94c94-baae-477e-912a-60f0c4f3bd13/crypt/zone                                                              e4220797-15df-42c4-9df7-ad927711d565   none      none          off        
@@ -146,7 +146,7 @@ to:   blueprint 2886dab5-61a2-46b4-87af-bc7aeb44cccb
     oxp_ec458c3e-91ca-40f1-a2a3-3f4292c1f279/crypt/zone                                                              29038bb0-9af1-4b03-9c10-b8a6444a0bc2   none      none          off        
     oxp_f635c28a-e5ca-4d22-ac94-d8f278a6ea0e/crypt/zone                                                              fc9765c5-0a89-4050-ba3e-e0625dbefb5f   none      none          off        
     oxp_0bf9d028-2b4a-4bff-82a1-6eb5fcefd985/crypt/zone/oxz_clickhouse_keeper_b36c16d5-de6e-411a-a32a-d35a26f2e151   48720037-5b8e-4478-9bb5-c86ee8a6e250   none      none          off        
-    oxp_0bf9d028-2b4a-4bff-82a1-6eb5fcefd985/crypt/zone/oxz_clickhouse_server_122e30d3-d541-49b5-88de-1543b38123cc   748c9607-71dd-4f81-be08-c1eee262f69c   none      none          off        
+    oxp_0bf9d028-2b4a-4bff-82a1-6eb5fcefd985/crypt/zone/oxz_clickhouse_server_71be6bff-666a-4f2b-a7dc-d80a88a71af5   a9e2160a-688f-4bbd-9a77-b2e695df86f4   none      none          off        
     oxp_ddfaaba3-dafe-4103-b868-e9843d29d346/crypt/zone/oxz_crucible_1a92bb17-6477-46fc-9784-1d2a418d6e14            257c57cd-8f2c-440d-9fa0-e92a312295ec   none      none          off        
     oxp_af85eec8-36b3-4b88-966d-a717b9b58fe5/crypt/zone/oxz_crucible_26115267-8333-4711-924e-d05acf601827            3a39d5e8-ea73-4cf3-b9de-48045475151c   none      none          off        
     oxp_9ae94c94-baae-477e-912a-60f0c4f3bd13/crypt/zone/oxz_crucible_41af4ef6-d21b-4271-bfcb-524f4146784a            1522207b-ea98-47cc-810c-44808796d743   none      none          off        
@@ -171,8 +171,8 @@ to:   blueprint 2886dab5-61a2-46b4-87af-bc7aeb44cccb
     oxp_f635c28a-e5ca-4d22-ac94-d8f278a6ea0e/crypt/debug                                                             765b4728-8d6e-4fac-9a1b-ae2258d5c52b   100 GiB   none          gzip-9     
     oxp_0bf9d028-2b4a-4bff-82a1-6eb5fcefd985/crypt/debug                                                             fb722d83-ddc2-4880-95a4-1ab12f4b95be   100 GiB   none          gzip-9     
     oxp_79787cd4-92da-4de5-bfd8-30a635521e10/crypt/debug                                                             bd4efdbe-7128-4423-aacf-6cf35e5a914d   100 GiB   none          gzip-9     
-+   oxp_19293a1d-fddc-40a7-88a4-ccafdb6f66d3/crypt/clickhouse_keeper                                                 3682c931-5332-45ef-9885-3d2dcfb325f6   none      none          off        
-+   oxp_19293a1d-fddc-40a7-88a4-ccafdb6f66d3/crypt/zone/oxz_clickhouse_keeper_81a4f9fd-e502-42c2-bf9c-29dd6918fd46   6aaeeb8d-ee87-43a2-b1ef-22e5f5224842   none      none          off        
++   oxp_19293a1d-fddc-40a7-88a4-ccafdb6f66d3/crypt/clickhouse_keeper                                                 cad1d0c3-ca80-4db4-ab36-b2034cf2383b   none      none          off        
++   oxp_19293a1d-fddc-40a7-88a4-ccafdb6f66d3/crypt/zone/oxz_clickhouse_keeper_ad07794e-affa-4145-81fb-f45ed92e3fcd   d196c20e-0254-4716-8e04-c0c735d2ffaf   none      none          off        
 
 
     omicron zones generation 3 -> 4:
@@ -180,7 +180,7 @@ to:   blueprint 2886dab5-61a2-46b4-87af-bc7aeb44cccb
     zone type           zone id                                disposition   underlay IP           
     -----------------------------------------------------------------------------------------------
     clickhouse_keeper   b36c16d5-de6e-411a-a32a-d35a26f2e151   in service    fd00:1122:3344:103::2e
-    clickhouse_server   122e30d3-d541-49b5-88de-1543b38123cc   in service    fd00:1122:3344:103::2f
+    clickhouse_server   71be6bff-666a-4f2b-a7dc-d80a88a71af5   in service    fd00:1122:3344:103::2f
     crucible            1a92bb17-6477-46fc-9784-1d2a418d6e14   in service    fd00:1122:3344:103::2a
     crucible            26115267-8333-4711-924e-d05acf601827   in service    fd00:1122:3344:103::29
     crucible            41af4ef6-d21b-4271-bfcb-524f4146784a   in service    fd00:1122:3344:103::28
@@ -195,7 +195,7 @@ to:   blueprint 2886dab5-61a2-46b4-87af-bc7aeb44cccb
     internal_dns        c259e8b9-1086-453a-8636-050639edeffb   in service    fd00:1122:3344:2::1   
     internal_ntp        bba31b23-d112-4cde-bd4a-635812c28c0e   in service    fd00:1122:3344:103::21
     nexus               c3c7b0bd-dce3-467b-919d-668cc6b06711   in service    fd00:1122:3344:103::22
-+   clickhouse_keeper   81a4f9fd-e502-42c2-bf9c-29dd6918fd46   in service    fd00:1122:3344:103::30
++   clickhouse_keeper   ad07794e-affa-4145-81fb-f45ed92e3fcd   in service    fd00:1122:3344:103::30
 
 
   sled be531a62-9897-430d-acd2-ce14b4632627 (active):
@@ -230,8 +230,8 @@ to:   blueprint 2886dab5-61a2-46b4-87af-bc7aeb44cccb
     oxp_b3c231c9-b2a5-4267-b4bf-9651881b91a5/crucible                                                                aa8f925e-6c3a-40d2-ae2d-946324a7d612   none      none          off        
     oxp_db16345e-427a-4c8e-9032-17270f729308/crucible                                                                be3cf2f7-5388-4cd6-8119-ecf316c6052e   none      none          off        
     oxp_e3b45593-8f0c-47b2-a381-802a7dad1f54/crucible                                                                a2391107-7408-4e0c-a694-3fd073fa09df   none      none          off        
-    oxp_2a76ab1a-fb16-412d-93f9-b8cd9aa94e85/crypt/clickhouse_keeper                                                 886f2522-8122-465f-8996-2d8c2acd9d0d   none      none          off        
-    oxp_2a76ab1a-fb16-412d-93f9-b8cd9aa94e85/crypt/clickhouse_server                                                 3d339942-c2d0-4615-a099-433a8b5a1543   none      none          off        
+    oxp_2a76ab1a-fb16-412d-93f9-b8cd9aa94e85/crypt/clickhouse_keeper                                                 c16a00f5-8830-400d-89e0-9a77cce8780e   none      none          off        
+    oxp_2a76ab1a-fb16-412d-93f9-b8cd9aa94e85/crypt/clickhouse_server                                                 ce930007-8ed6-4675-a24a-57c227950d43   none      none          off        
     oxp_2a76ab1a-fb16-412d-93f9-b8cd9aa94e85/crypt/internal_dns                                                      7be88e8f-06d3-49f7-a6d9-5c586f13716c   none      none          off        
     oxp_db16345e-427a-4c8e-9032-17270f729308/crypt/zone                                                              f7ddacf4-edc7-46ba-9b74-d588bd62505e   none      none          off        
     oxp_32041dbf-e58d-4f32-840d-923d3d3b68af/crypt/zone                                                              3f1adfcf-9a2a-41db-9e1a-a2e13ff8a7dd   none      none          off        
@@ -243,8 +243,8 @@ to:   blueprint 2886dab5-61a2-46b4-87af-bc7aeb44cccb
     oxp_bca80b95-8dca-4a3b-b24d-d44b6a9ff71b/crypt/zone                                                              2747bb48-2fb7-4999-a63c-5ba5e35e0a10   none      none          off        
     oxp_e3b45593-8f0c-47b2-a381-802a7dad1f54/crypt/zone                                                              64e62d15-e813-461d-9a50-403d9bd1df7c   none      none          off        
     oxp_2f02a5c6-fcf5-4b5a-bc7d-7f65369918ba/crypt/zone                                                              38103edf-a98f-46ca-94ea-3404268ea935   none      none          off        
-    oxp_2a76ab1a-fb16-412d-93f9-b8cd9aa94e85/crypt/zone/oxz_clickhouse_keeper_39fd3357-4de8-433e-9c07-1ec65de7ca59   095cf066-5a68-40b4-afc6-baf5bcbadd05   none      none          off        
-    oxp_2a76ab1a-fb16-412d-93f9-b8cd9aa94e85/crypt/zone/oxz_clickhouse_server_71be6bff-666a-4f2b-a7dc-d80a88a71af5   a9e2160a-688f-4bbd-9a77-b2e695df86f4   none      none          off        
+    oxp_2a76ab1a-fb16-412d-93f9-b8cd9aa94e85/crypt/zone/oxz_clickhouse_keeper_f3279a8b-32fa-4426-b946-08aff9ded482   26c79a0e-a2e4-4093-ba43-5e7979609651   none      none          off        
+    oxp_2a76ab1a-fb16-412d-93f9-b8cd9aa94e85/crypt/zone/oxz_clickhouse_server_122e30d3-d541-49b5-88de-1543b38123cc   748c9607-71dd-4f81-be08-c1eee262f69c   none      none          off        
     oxp_bca80b95-8dca-4a3b-b24d-d44b6a9ff71b/crypt/zone/oxz_crucible_0a160b89-6288-44f5-9908-33589094628e            53a623d2-9ffc-48fb-871d-23bd52e0f4dd   none      none          off        
     oxp_2f02a5c6-fcf5-4b5a-bc7d-7f65369918ba/crypt/zone/oxz_crucible_2cb036bd-6056-4547-af65-aa6c0c1e4d6e            c6c9e491-ce4d-4dc4-82be-e394fa1e82e2   none      none          off        
     oxp_2de2bf7e-c679-4b2b-b373-908e9d3ffbfc/crypt/zone/oxz_crucible_37c72edc-6acd-4c2d-ab76-d1c88e1f01f5            9b49fc13-4d2c-423e-9839-f6e1d0bffc6e   none      none          off        
@@ -269,16 +269,16 @@ to:   blueprint 2886dab5-61a2-46b4-87af-bc7aeb44cccb
     oxp_74d64eb9-bf69-4782-af16-2d3a761ca171/crypt/debug                                                             b9e71882-7f71-4a5e-be9c-7df560c75000   100 GiB   none          gzip-9     
     oxp_e3b45593-8f0c-47b2-a381-802a7dad1f54/crypt/debug                                                             96798a17-be94-44bb-9e12-2eb458e9a5ba   100 GiB   none          gzip-9     
     oxp_b3c231c9-b2a5-4267-b4bf-9651881b91a5/crypt/debug                                                             bae0ee1b-b3a3-4c4c-96ee-53b8b4cd837b   100 GiB   none          gzip-9     
-+   oxp_2de2bf7e-c679-4b2b-b373-908e9d3ffbfc/crypt/clickhouse_keeper                                                 cad1d0c3-ca80-4db4-ab36-b2034cf2383b   none      none          off        
-+   oxp_2de2bf7e-c679-4b2b-b373-908e9d3ffbfc/crypt/zone/oxz_clickhouse_keeper_ad07794e-affa-4145-81fb-f45ed92e3fcd   d196c20e-0254-4716-8e04-c0c735d2ffaf   none      none          off        
++   oxp_2de2bf7e-c679-4b2b-b373-908e9d3ffbfc/crypt/clickhouse_keeper                                                 3682c931-5332-45ef-9885-3d2dcfb325f6   none      none          off        
++   oxp_2de2bf7e-c679-4b2b-b373-908e9d3ffbfc/crypt/zone/oxz_clickhouse_keeper_81a4f9fd-e502-42c2-bf9c-29dd6918fd46   6aaeeb8d-ee87-43a2-b1ef-22e5f5224842   none      none          off        
 
 
     omicron zones generation 3 -> 4:
     -----------------------------------------------------------------------------------------------
     zone type           zone id                                disposition   underlay IP           
     -----------------------------------------------------------------------------------------------
-    clickhouse_keeper   39fd3357-4de8-433e-9c07-1ec65de7ca59   in service    fd00:1122:3344:102::2e
-    clickhouse_server   71be6bff-666a-4f2b-a7dc-d80a88a71af5   in service    fd00:1122:3344:102::2f
+    clickhouse_keeper   f3279a8b-32fa-4426-b946-08aff9ded482   in service    fd00:1122:3344:102::2e
+    clickhouse_server   122e30d3-d541-49b5-88de-1543b38123cc   in service    fd00:1122:3344:102::2f
     crucible            0a160b89-6288-44f5-9908-33589094628e   in service    fd00:1122:3344:102::2b
     crucible            2cb036bd-6056-4547-af65-aa6c0c1e4d6e   in service    fd00:1122:3344:102::26
     crucible            37c72edc-6acd-4c2d-ab76-d1c88e1f01f5   in service    fd00:1122:3344:102::25
@@ -293,7 +293,7 @@ to:   blueprint 2886dab5-61a2-46b4-87af-bc7aeb44cccb
     internal_dns        832c71a1-357d-482b-8661-3193d59ed776   in service    fd00:1122:3344:3::1   
     internal_ntp        816afef9-e5cd-40ba-8cc5-71e783943e43   in service    fd00:1122:3344:102::21
     nexus               da39dead-64e2-45b6-9d01-d99584504dfd   in service    fd00:1122:3344:102::22
-+   clickhouse_keeper   ad07794e-affa-4145-81fb-f45ed92e3fcd   in service    fd00:1122:3344:102::30
++   clickhouse_keeper   81a4f9fd-e502-42c2-bf9c-29dd6918fd46   in service    fd00:1122:3344:102::30
 
 
  COCKROACHDB SETTINGS:

--- a/nexus/reconfigurator/planning/tests/output/planner_deploy_all_keeper_nodes_4_collection.txt
+++ b/nexus/reconfigurator/planning/tests/output/planner_deploy_all_keeper_nodes_4_collection.txt
@@ -71,8 +71,8 @@ to:   blueprint  92fa943c-7dd4-48c3-9447-c9d0665744b6
     oxp_fbf997ef-52d3-438a-b036-b9117322e569/crypt/debug                                                             17ffe1be-b38b-4f39-90af-57af25dbfe30   100 GiB   none          gzip-9     
     oxp_e9c238f6-87a3-4087-8ba4-aa594a82d012/crypt/debug                                                             2288ff91-8e52-4817-825f-2f8b8eb1681d   100 GiB   none          gzip-9     
     oxp_71a07ac0-d24e-446c-a202-1998e7f6ac8c/crypt/debug                                                             e0bcc415-f8f9-401f-a507-cee5587756b1   100 GiB   none          gzip-9     
-+   oxp_60e6b021-79d6-4a6b-917c-6637e0769558/crypt/clickhouse_keeper                                                 c16a00f5-8830-400d-89e0-9a77cce8780e   none      none          off        
-+   oxp_60e6b021-79d6-4a6b-917c-6637e0769558/crypt/zone/oxz_clickhouse_keeper_f3279a8b-32fa-4426-b946-08aff9ded482   26c79a0e-a2e4-4093-ba43-5e7979609651   none      none          off        
++   oxp_60e6b021-79d6-4a6b-917c-6637e0769558/crypt/clickhouse_keeper                                                 886f2522-8122-465f-8996-2d8c2acd9d0d   none      none          off        
++   oxp_60e6b021-79d6-4a6b-917c-6637e0769558/crypt/zone/oxz_clickhouse_keeper_39fd3357-4de8-433e-9c07-1ec65de7ca59   095cf066-5a68-40b4-afc6-baf5bcbadd05   none      none          off        
 
 
     omicron zones generation 2 -> 3:
@@ -94,7 +94,7 @@ to:   blueprint  92fa943c-7dd4-48c3-9447-c9d0665744b6
     internal_dns        c89ac05f-d9b2-47f4-9d48-2f38130e4ad9   in service    fd00:1122:3344:1::1   
     internal_ntp        66695827-17c4-4885-b6c0-2cb6b6d3ad1c   in service    fd00:1122:3344:101::21
     nexus               a6032c9e-a365-45d7-ad9f-07ac0fa7079a   in service    fd00:1122:3344:101::22
-+   clickhouse_keeper   f3279a8b-32fa-4426-b946-08aff9ded482   in service    fd00:1122:3344:101::2f
++   clickhouse_keeper   39fd3357-4de8-433e-9c07-1ec65de7ca59   in service    fd00:1122:3344:101::2f
 
 
   sled 6a4c45f6-e02f-490c-bbfa-b32fb89e8e86 (active):
@@ -165,9 +165,9 @@ to:   blueprint  92fa943c-7dd4-48c3-9447-c9d0665744b6
     oxp_f635c28a-e5ca-4d22-ac94-d8f278a6ea0e/crypt/debug                                                             765b4728-8d6e-4fac-9a1b-ae2258d5c52b   100 GiB   none          gzip-9     
     oxp_af85eec8-36b3-4b88-966d-a717b9b58fe5/crypt/debug                                                             98d65e73-01df-4525-a45d-acb2fc8d4a74   100 GiB   none          gzip-9     
 +   oxp_0bf9d028-2b4a-4bff-82a1-6eb5fcefd985/crypt/clickhouse_keeper                                                 a3eed313-d886-4c1d-8023-8d2ec9e97ddd   none      none          off        
-+   oxp_0bf9d028-2b4a-4bff-82a1-6eb5fcefd985/crypt/clickhouse_server                                                 ce930007-8ed6-4675-a24a-57c227950d43   none      none          off        
++   oxp_0bf9d028-2b4a-4bff-82a1-6eb5fcefd985/crypt/clickhouse_server                                                 3d339942-c2d0-4615-a099-433a8b5a1543   none      none          off        
 +   oxp_0bf9d028-2b4a-4bff-82a1-6eb5fcefd985/crypt/zone/oxz_clickhouse_keeper_b36c16d5-de6e-411a-a32a-d35a26f2e151   48720037-5b8e-4478-9bb5-c86ee8a6e250   none      none          off        
-+   oxp_0bf9d028-2b4a-4bff-82a1-6eb5fcefd985/crypt/zone/oxz_clickhouse_server_122e30d3-d541-49b5-88de-1543b38123cc   748c9607-71dd-4f81-be08-c1eee262f69c   none      none          off        
++   oxp_0bf9d028-2b4a-4bff-82a1-6eb5fcefd985/crypt/zone/oxz_clickhouse_server_71be6bff-666a-4f2b-a7dc-d80a88a71af5   a9e2160a-688f-4bbd-9a77-b2e695df86f4   none      none          off        
 
 
     omicron zones generation 2 -> 3:
@@ -189,7 +189,7 @@ to:   blueprint  92fa943c-7dd4-48c3-9447-c9d0665744b6
     internal_ntp        bba31b23-d112-4cde-bd4a-635812c28c0e   in service    fd00:1122:3344:103::21
     nexus               c3c7b0bd-dce3-467b-919d-668cc6b06711   in service    fd00:1122:3344:103::22
 +   clickhouse_keeper   b36c16d5-de6e-411a-a32a-d35a26f2e151   in service    fd00:1122:3344:103::2e
-+   clickhouse_server   122e30d3-d541-49b5-88de-1543b38123cc   in service    fd00:1122:3344:103::2f
++   clickhouse_server   71be6bff-666a-4f2b-a7dc-d80a88a71af5   in service    fd00:1122:3344:103::2f
 
 
   sled be531a62-9897-430d-acd2-ce14b4632627 (active):
@@ -259,10 +259,10 @@ to:   blueprint  92fa943c-7dd4-48c3-9447-c9d0665744b6
     oxp_e3b45593-8f0c-47b2-a381-802a7dad1f54/crypt/debug                                                             96798a17-be94-44bb-9e12-2eb458e9a5ba   100 GiB   none          gzip-9     
     oxp_2f02a5c6-fcf5-4b5a-bc7d-7f65369918ba/crypt/debug                                                             daeded95-0145-4b97-b1fb-60d44856d1e4   100 GiB   none          gzip-9     
     oxp_2a76ab1a-fb16-412d-93f9-b8cd9aa94e85/crypt/debug                                                             c55ba154-4f4b-48a5-997b-2a1579671c74   100 GiB   none          gzip-9     
-+   oxp_2a76ab1a-fb16-412d-93f9-b8cd9aa94e85/crypt/clickhouse_keeper                                                 886f2522-8122-465f-8996-2d8c2acd9d0d   none      none          off        
-+   oxp_2a76ab1a-fb16-412d-93f9-b8cd9aa94e85/crypt/clickhouse_server                                                 3d339942-c2d0-4615-a099-433a8b5a1543   none      none          off        
-+   oxp_2a76ab1a-fb16-412d-93f9-b8cd9aa94e85/crypt/zone/oxz_clickhouse_keeper_39fd3357-4de8-433e-9c07-1ec65de7ca59   095cf066-5a68-40b4-afc6-baf5bcbadd05   none      none          off        
-+   oxp_2a76ab1a-fb16-412d-93f9-b8cd9aa94e85/crypt/zone/oxz_clickhouse_server_71be6bff-666a-4f2b-a7dc-d80a88a71af5   a9e2160a-688f-4bbd-9a77-b2e695df86f4   none      none          off        
++   oxp_2a76ab1a-fb16-412d-93f9-b8cd9aa94e85/crypt/clickhouse_keeper                                                 c16a00f5-8830-400d-89e0-9a77cce8780e   none      none          off        
++   oxp_2a76ab1a-fb16-412d-93f9-b8cd9aa94e85/crypt/clickhouse_server                                                 ce930007-8ed6-4675-a24a-57c227950d43   none      none          off        
++   oxp_2a76ab1a-fb16-412d-93f9-b8cd9aa94e85/crypt/zone/oxz_clickhouse_keeper_f3279a8b-32fa-4426-b946-08aff9ded482   26c79a0e-a2e4-4093-ba43-5e7979609651   none      none          off        
++   oxp_2a76ab1a-fb16-412d-93f9-b8cd9aa94e85/crypt/zone/oxz_clickhouse_server_122e30d3-d541-49b5-88de-1543b38123cc   748c9607-71dd-4f81-be08-c1eee262f69c   none      none          off        
 
 
     omicron zones generation 2 -> 3:
@@ -283,8 +283,8 @@ to:   blueprint  92fa943c-7dd4-48c3-9447-c9d0665744b6
     internal_dns        832c71a1-357d-482b-8661-3193d59ed776   in service    fd00:1122:3344:3::1   
     internal_ntp        816afef9-e5cd-40ba-8cc5-71e783943e43   in service    fd00:1122:3344:102::21
     nexus               da39dead-64e2-45b6-9d01-d99584504dfd   in service    fd00:1122:3344:102::22
-+   clickhouse_keeper   39fd3357-4de8-433e-9c07-1ec65de7ca59   in service    fd00:1122:3344:102::2e
-+   clickhouse_server   71be6bff-666a-4f2b-a7dc-d80a88a71af5   in service    fd00:1122:3344:102::2f
++   clickhouse_keeper   f3279a8b-32fa-4426-b946-08aff9ded482   in service    fd00:1122:3344:102::2e
++   clickhouse_server   122e30d3-d541-49b5-88de-1543b38123cc   in service    fd00:1122:3344:102::2f
 
 
  COCKROACHDB SETTINGS:

--- a/nexus/reconfigurator/planning/tests/output/planner_deploy_all_keeper_nodes_5_6.txt
+++ b/nexus/reconfigurator/planning/tests/output/planner_deploy_all_keeper_nodes_5_6.txt
@@ -36,7 +36,7 @@ to:   blueprint cb39be9d-5476-44fa-9edf-9938376219ef
     oxp_e9c238f6-87a3-4087-8ba4-aa594a82d012/crucible                                                                e88d6ff8-6b98-44c1-97a7-83f371ae62fe   none      none          off        
     oxp_fbf997ef-52d3-438a-b036-b9117322e569/crucible                                                                d6a838c7-3ee9-4cca-9d8b-986b4de0ba1c   none      none          off        
     oxp_60e6b021-79d6-4a6b-917c-6637e0769558/crypt/clickhouse                                                        5cb56dc7-6c56-4bbf-ae73-6f08e0c97cdf   none      none          off        
-    oxp_60e6b021-79d6-4a6b-917c-6637e0769558/crypt/clickhouse_keeper                                                 c16a00f5-8830-400d-89e0-9a77cce8780e   none      none          off        
+    oxp_60e6b021-79d6-4a6b-917c-6637e0769558/crypt/clickhouse_keeper                                                 886f2522-8122-465f-8996-2d8c2acd9d0d   none      none          off        
     oxp_60e6b021-79d6-4a6b-917c-6637e0769558/crypt/internal_dns                                                      dd467397-efc5-4738-984e-77a0f3e3e678   none      none          off        
     oxp_e9c238f6-87a3-4087-8ba4-aa594a82d012/crypt/zone                                                              f963f2a7-e9d1-4b80-b01a-ff4cecddf867   none      none          off        
     oxp_8ae56ca0-709d-4b8f-9869-51b62b542eef/crypt/zone                                                              61bf628d-a78d-40a7-bad2-84e97e41b810   none      none          off        
@@ -49,7 +49,7 @@ to:   blueprint cb39be9d-5476-44fa-9edf-9938376219ef
     oxp_fbf997ef-52d3-438a-b036-b9117322e569/crypt/zone                                                              a15e4260-d48c-4415-9315-c0f29234f359   none      none          off        
     oxp_736d4cab-c262-485e-89c2-07e6543f0855/crypt/zone                                                              a34f8204-9f17-4c8f-997b-e122c284ac9f   none      none          off        
     oxp_60e6b021-79d6-4a6b-917c-6637e0769558/crypt/zone/oxz_clickhouse_df79db1e-54ca-4048-b22a-da120ae4c8c4          b6cb0fe9-0b7a-4793-b6cd-1ee71fee464c   none      none          off        
-    oxp_60e6b021-79d6-4a6b-917c-6637e0769558/crypt/zone/oxz_clickhouse_keeper_f3279a8b-32fa-4426-b946-08aff9ded482   26c79a0e-a2e4-4093-ba43-5e7979609651   none      none          off        
+    oxp_60e6b021-79d6-4a6b-917c-6637e0769558/crypt/zone/oxz_clickhouse_keeper_39fd3357-4de8-433e-9c07-1ec65de7ca59   095cf066-5a68-40b4-afc6-baf5bcbadd05   none      none          off        
     oxp_8e0bcc4f-0799-450c-a0ad-80c1637f59e3/crypt/zone/oxz_crucible_08330c18-54e9-445b-81f3-8f1d6ad15cdd            ab255226-2c8c-4222-82c6-702af839a2d2   none      none          off        
     oxp_fbf997ef-52d3-438a-b036-b9117322e569/crypt/zone/oxz_crucible_0ba018f0-4ff7-4bcc-a0c7-42cfec6bc9da            ba1a3aae-15ab-4364-8250-54a766331ef8   none      none          off        
     oxp_60e6b021-79d6-4a6b-917c-6637e0769558/crypt/zone/oxz_crucible_1e485cda-b36e-4647-9125-c273fc7a9850            65c2e3cd-3d8e-43c6-9e2c-cb884511ec49   none      none          off        
@@ -81,7 +81,7 @@ to:   blueprint cb39be9d-5476-44fa-9edf-9938376219ef
     zone type           zone id                                disposition   underlay IP           
     -----------------------------------------------------------------------------------------------
     clickhouse          df79db1e-54ca-4048-b22a-da120ae4c8c4   in service    fd00:1122:3344:101::23
-    clickhouse_keeper   f3279a8b-32fa-4426-b946-08aff9ded482   in service    fd00:1122:3344:101::2f
+    clickhouse_keeper   39fd3357-4de8-433e-9c07-1ec65de7ca59   in service    fd00:1122:3344:101::2f
     crucible            08330c18-54e9-445b-81f3-8f1d6ad15cdd   in service    fd00:1122:3344:101::29
     crucible            0ba018f0-4ff7-4bcc-a0c7-42cfec6bc9da   in service    fd00:1122:3344:101::2e
     crucible            1e485cda-b36e-4647-9125-c273fc7a9850   in service    fd00:1122:3344:101::25
@@ -130,9 +130,9 @@ to:   blueprint cb39be9d-5476-44fa-9edf-9938376219ef
     oxp_ec458c3e-91ca-40f1-a2a3-3f4292c1f279/crucible                                                                dfadcc38-505a-4e9b-8674-27f8a2af13a2   none      none          off        
     oxp_ddfaaba3-dafe-4103-b868-e9843d29d346/crucible                                                                2d7145e9-0029-4ae0-bb12-ee65a1738005   none      none          off        
     oxp_f635c28a-e5ca-4d22-ac94-d8f278a6ea0e/crucible                                                                c7dfbe25-5b52-4ee5-8556-719e99bb5e4d   none      none          off        
-    oxp_19293a1d-fddc-40a7-88a4-ccafdb6f66d3/crypt/clickhouse_keeper                                                 3682c931-5332-45ef-9885-3d2dcfb325f6   none      none          off        
+    oxp_19293a1d-fddc-40a7-88a4-ccafdb6f66d3/crypt/clickhouse_keeper                                                 cad1d0c3-ca80-4db4-ab36-b2034cf2383b   none      none          off        
     oxp_0bf9d028-2b4a-4bff-82a1-6eb5fcefd985/crypt/clickhouse_keeper                                                 a3eed313-d886-4c1d-8023-8d2ec9e97ddd   none      none          off        
-    oxp_0bf9d028-2b4a-4bff-82a1-6eb5fcefd985/crypt/clickhouse_server                                                 ce930007-8ed6-4675-a24a-57c227950d43   none      none          off        
+    oxp_0bf9d028-2b4a-4bff-82a1-6eb5fcefd985/crypt/clickhouse_server                                                 3d339942-c2d0-4615-a099-433a8b5a1543   none      none          off        
     oxp_0bf9d028-2b4a-4bff-82a1-6eb5fcefd985/crypt/internal_dns                                                      b8af3673-c60a-45fb-adc1-c36d0d325417   none      none          off        
     oxp_f2fc7c4c-7966-449d-8ec3-5a70f460501d/crypt/zone                                                              e49915c6-59ed-4bbe-abf9-375b9502772a   none      none          off        
     oxp_19293a1d-fddc-40a7-88a4-ccafdb6f66d3/crypt/zone                                                              68490e52-279a-4609-ba0b-11d03f904c88   none      none          off        
@@ -144,9 +144,9 @@ to:   blueprint cb39be9d-5476-44fa-9edf-9938376219ef
     oxp_44484c44-477a-4676-8266-b98a00e80d79/crypt/zone                                                              2a5e3a10-6ab5-4988-be84-46b527dc2d23   none      none          off        
     oxp_79787cd4-92da-4de5-bfd8-30a635521e10/crypt/zone                                                              fd0f9778-c31a-40f4-9ce9-f5154535e75b   none      none          off        
     oxp_0bf9d028-2b4a-4bff-82a1-6eb5fcefd985/crypt/zone                                                              1ab5529e-c3db-41e1-a561-9c767f980ad4   none      none          off        
-    oxp_19293a1d-fddc-40a7-88a4-ccafdb6f66d3/crypt/zone/oxz_clickhouse_keeper_81a4f9fd-e502-42c2-bf9c-29dd6918fd46   6aaeeb8d-ee87-43a2-b1ef-22e5f5224842   none      none          off        
+    oxp_19293a1d-fddc-40a7-88a4-ccafdb6f66d3/crypt/zone/oxz_clickhouse_keeper_ad07794e-affa-4145-81fb-f45ed92e3fcd   d196c20e-0254-4716-8e04-c0c735d2ffaf   none      none          off        
     oxp_0bf9d028-2b4a-4bff-82a1-6eb5fcefd985/crypt/zone/oxz_clickhouse_keeper_b36c16d5-de6e-411a-a32a-d35a26f2e151   48720037-5b8e-4478-9bb5-c86ee8a6e250   none      none          off        
-    oxp_0bf9d028-2b4a-4bff-82a1-6eb5fcefd985/crypt/zone/oxz_clickhouse_server_122e30d3-d541-49b5-88de-1543b38123cc   748c9607-71dd-4f81-be08-c1eee262f69c   none      none          off        
+    oxp_0bf9d028-2b4a-4bff-82a1-6eb5fcefd985/crypt/zone/oxz_clickhouse_server_71be6bff-666a-4f2b-a7dc-d80a88a71af5   a9e2160a-688f-4bbd-9a77-b2e695df86f4   none      none          off        
     oxp_ddfaaba3-dafe-4103-b868-e9843d29d346/crypt/zone/oxz_crucible_1a92bb17-6477-46fc-9784-1d2a418d6e14            257c57cd-8f2c-440d-9fa0-e92a312295ec   none      none          off        
     oxp_af85eec8-36b3-4b88-966d-a717b9b58fe5/crypt/zone/oxz_crucible_26115267-8333-4711-924e-d05acf601827            3a39d5e8-ea73-4cf3-b9de-48045475151c   none      none          off        
     oxp_9ae94c94-baae-477e-912a-60f0c4f3bd13/crypt/zone/oxz_crucible_41af4ef6-d21b-4271-bfcb-524f4146784a            1522207b-ea98-47cc-810c-44808796d743   none      none          off        
@@ -177,9 +177,9 @@ to:   blueprint cb39be9d-5476-44fa-9edf-9938376219ef
     -----------------------------------------------------------------------------------------------
     zone type           zone id                                disposition   underlay IP           
     -----------------------------------------------------------------------------------------------
-    clickhouse_keeper   81a4f9fd-e502-42c2-bf9c-29dd6918fd46   in service    fd00:1122:3344:103::30
+    clickhouse_keeper   ad07794e-affa-4145-81fb-f45ed92e3fcd   in service    fd00:1122:3344:103::30
     clickhouse_keeper   b36c16d5-de6e-411a-a32a-d35a26f2e151   in service    fd00:1122:3344:103::2e
-    clickhouse_server   122e30d3-d541-49b5-88de-1543b38123cc   in service    fd00:1122:3344:103::2f
+    clickhouse_server   71be6bff-666a-4f2b-a7dc-d80a88a71af5   in service    fd00:1122:3344:103::2f
     crucible            1a92bb17-6477-46fc-9784-1d2a418d6e14   in service    fd00:1122:3344:103::2a
     crucible            26115267-8333-4711-924e-d05acf601827   in service    fd00:1122:3344:103::29
     crucible            41af4ef6-d21b-4271-bfcb-524f4146784a   in service    fd00:1122:3344:103::28
@@ -228,9 +228,9 @@ to:   blueprint cb39be9d-5476-44fa-9edf-9938376219ef
     oxp_bca80b95-8dca-4a3b-b24d-d44b6a9ff71b/crucible                                                                755ad19c-d29b-4e3c-9c13-63b56a407765   none      none          off        
     oxp_b3c231c9-b2a5-4267-b4bf-9651881b91a5/crucible                                                                aa8f925e-6c3a-40d2-ae2d-946324a7d612   none      none          off        
     oxp_db16345e-427a-4c8e-9032-17270f729308/crucible                                                                be3cf2f7-5388-4cd6-8119-ecf316c6052e   none      none          off        
-    oxp_2de2bf7e-c679-4b2b-b373-908e9d3ffbfc/crypt/clickhouse_keeper                                                 cad1d0c3-ca80-4db4-ab36-b2034cf2383b   none      none          off        
-    oxp_2a76ab1a-fb16-412d-93f9-b8cd9aa94e85/crypt/clickhouse_keeper                                                 886f2522-8122-465f-8996-2d8c2acd9d0d   none      none          off        
-    oxp_2a76ab1a-fb16-412d-93f9-b8cd9aa94e85/crypt/clickhouse_server                                                 3d339942-c2d0-4615-a099-433a8b5a1543   none      none          off        
+    oxp_2de2bf7e-c679-4b2b-b373-908e9d3ffbfc/crypt/clickhouse_keeper                                                 3682c931-5332-45ef-9885-3d2dcfb325f6   none      none          off        
+    oxp_2a76ab1a-fb16-412d-93f9-b8cd9aa94e85/crypt/clickhouse_keeper                                                 c16a00f5-8830-400d-89e0-9a77cce8780e   none      none          off        
+    oxp_2a76ab1a-fb16-412d-93f9-b8cd9aa94e85/crypt/clickhouse_server                                                 ce930007-8ed6-4675-a24a-57c227950d43   none      none          off        
     oxp_2a76ab1a-fb16-412d-93f9-b8cd9aa94e85/crypt/internal_dns                                                      7be88e8f-06d3-49f7-a6d9-5c586f13716c   none      none          off        
     oxp_2f02a5c6-fcf5-4b5a-bc7d-7f65369918ba/crypt/zone                                                              38103edf-a98f-46ca-94ea-3404268ea935   none      none          off        
     oxp_2a76ab1a-fb16-412d-93f9-b8cd9aa94e85/crypt/zone                                                              37405860-deb4-4f2f-b770-ab8b83175d8c   none      none          off        
@@ -242,9 +242,9 @@ to:   blueprint cb39be9d-5476-44fa-9edf-9938376219ef
     oxp_db16345e-427a-4c8e-9032-17270f729308/crypt/zone                                                              f7ddacf4-edc7-46ba-9b74-d588bd62505e   none      none          off        
     oxp_32041dbf-e58d-4f32-840d-923d3d3b68af/crypt/zone                                                              3f1adfcf-9a2a-41db-9e1a-a2e13ff8a7dd   none      none          off        
     oxp_e3b45593-8f0c-47b2-a381-802a7dad1f54/crypt/zone                                                              64e62d15-e813-461d-9a50-403d9bd1df7c   none      none          off        
-    oxp_2a76ab1a-fb16-412d-93f9-b8cd9aa94e85/crypt/zone/oxz_clickhouse_keeper_39fd3357-4de8-433e-9c07-1ec65de7ca59   095cf066-5a68-40b4-afc6-baf5bcbadd05   none      none          off        
-    oxp_2de2bf7e-c679-4b2b-b373-908e9d3ffbfc/crypt/zone/oxz_clickhouse_keeper_ad07794e-affa-4145-81fb-f45ed92e3fcd   d196c20e-0254-4716-8e04-c0c735d2ffaf   none      none          off        
-    oxp_2a76ab1a-fb16-412d-93f9-b8cd9aa94e85/crypt/zone/oxz_clickhouse_server_71be6bff-666a-4f2b-a7dc-d80a88a71af5   a9e2160a-688f-4bbd-9a77-b2e695df86f4   none      none          off        
+    oxp_2de2bf7e-c679-4b2b-b373-908e9d3ffbfc/crypt/zone/oxz_clickhouse_keeper_81a4f9fd-e502-42c2-bf9c-29dd6918fd46   6aaeeb8d-ee87-43a2-b1ef-22e5f5224842   none      none          off        
+    oxp_2a76ab1a-fb16-412d-93f9-b8cd9aa94e85/crypt/zone/oxz_clickhouse_keeper_f3279a8b-32fa-4426-b946-08aff9ded482   26c79a0e-a2e4-4093-ba43-5e7979609651   none      none          off        
+    oxp_2a76ab1a-fb16-412d-93f9-b8cd9aa94e85/crypt/zone/oxz_clickhouse_server_122e30d3-d541-49b5-88de-1543b38123cc   748c9607-71dd-4f81-be08-c1eee262f69c   none      none          off        
     oxp_bca80b95-8dca-4a3b-b24d-d44b6a9ff71b/crypt/zone/oxz_crucible_0a160b89-6288-44f5-9908-33589094628e            53a623d2-9ffc-48fb-871d-23bd52e0f4dd   none      none          off        
     oxp_2f02a5c6-fcf5-4b5a-bc7d-7f65369918ba/crypt/zone/oxz_crucible_2cb036bd-6056-4547-af65-aa6c0c1e4d6e            c6c9e491-ce4d-4dc4-82be-e394fa1e82e2   none      none          off        
     oxp_2de2bf7e-c679-4b2b-b373-908e9d3ffbfc/crypt/zone/oxz_crucible_37c72edc-6acd-4c2d-ab76-d1c88e1f01f5            9b49fc13-4d2c-423e-9839-f6e1d0bffc6e   none      none          off        
@@ -275,9 +275,9 @@ to:   blueprint cb39be9d-5476-44fa-9edf-9938376219ef
     -----------------------------------------------------------------------------------------------
     zone type           zone id                                disposition   underlay IP           
     -----------------------------------------------------------------------------------------------
-    clickhouse_keeper   39fd3357-4de8-433e-9c07-1ec65de7ca59   in service    fd00:1122:3344:102::2e
-    clickhouse_keeper   ad07794e-affa-4145-81fb-f45ed92e3fcd   in service    fd00:1122:3344:102::30
-    clickhouse_server   71be6bff-666a-4f2b-a7dc-d80a88a71af5   in service    fd00:1122:3344:102::2f
+    clickhouse_keeper   81a4f9fd-e502-42c2-bf9c-29dd6918fd46   in service    fd00:1122:3344:102::30
+    clickhouse_keeper   f3279a8b-32fa-4426-b946-08aff9ded482   in service    fd00:1122:3344:102::2e
+    clickhouse_server   122e30d3-d541-49b5-88de-1543b38123cc   in service    fd00:1122:3344:102::2f
     crucible            0a160b89-6288-44f5-9908-33589094628e   in service    fd00:1122:3344:102::2b
     crucible            2cb036bd-6056-4547-af65-aa6c0c1e4d6e   in service    fd00:1122:3344:102::26
     crucible            37c72edc-6acd-4c2d-ab76-d1c88e1f01f5   in service    fd00:1122:3344:102::25

--- a/nexus/reconfigurator/planning/tests/output/planner_expunge_clickhouse_clusters_3_4.txt
+++ b/nexus/reconfigurator/planning/tests/output/planner_expunge_clickhouse_clusters_3_4.txt
@@ -36,7 +36,7 @@ to:   blueprint 74f2e7fd-687e-4c9e-b5d8-e474a5bb8e7c
 -   oxp_a9ef71b2-ec22-421c-adc9-bddc4c0641c4/crucible                                                                3f0e3222-de30-4741-99f2-bd8cf6ecab41   none      none          off        
 -   oxp_b9f9c626-3293-48eb-a475-1debaaccdf6c/crucible                                                                10ed346b-d1f7-43c7-88fd-8e7ad66db8e2   none      none          off        
 -   oxp_03a84dd2-e0a4-435d-96de-67bfe2674f4e/crypt/clickhouse                                                        af4a8ac4-7941-4051-bdbb-979ae82dceaa   none      none          off        
--   oxp_03a84dd2-e0a4-435d-96de-67bfe2674f4e/crypt/clickhouse_keeper                                                 35a2dc24-0853-4a06-b5b9-90b8ba83e0b0   none      none          off        
+-   oxp_03a84dd2-e0a4-435d-96de-67bfe2674f4e/crypt/clickhouse_keeper                                                 90935183-8ac3-4474-aaf4-d7f29979c873   none      none          off        
 -   oxp_03a84dd2-e0a4-435d-96de-67bfe2674f4e/crypt/internal_dns                                                      3262c08c-12a1-4f38-93f0-e3f53a1087aa   none      none          off        
 -   oxp_03a84dd2-e0a4-435d-96de-67bfe2674f4e/crypt/zone                                                              44f9d5f4-fd7b-4684-b9c9-71cf888c79a8   none      none          off        
 -   oxp_188c3b95-16fa-45ea-b9f7-e987560b4d62/crypt/zone                                                              b8d4c72d-f610-4236-8cc0-28c6c0ea5343   none      none          off        
@@ -49,7 +49,7 @@ to:   blueprint 74f2e7fd-687e-4c9e-b5d8-e474a5bb8e7c
 -   oxp_96f1615c-3dda-427f-8132-408b2fad24e0/crypt/zone                                                              d56d2757-818a-4302-82e8-be4aac08fd66   none      none          off        
 -   oxp_fcca32b6-9629-468f-a282-63d7da992447/crypt/zone                                                              368f9afa-ceaa-4f34-a488-b64d945c1b77   none      none          off        
 -   oxp_03a84dd2-e0a4-435d-96de-67bfe2674f4e/crypt/zone/oxz_clickhouse_f2c54229-d192-41bd-babc-9ca02c1206d6          783cd7d4-ce73-4fe1-8665-b0c813406f52   none      none          off        
--   oxp_03a84dd2-e0a4-435d-96de-67bfe2674f4e/crypt/zone/oxz_clickhouse_keeper_ceea23ec-1cb4-46be-bfa6-de9025ad5737   abb56278-58c2-4e0c-8cc8-417f57100de0   none      none          off        
+-   oxp_03a84dd2-e0a4-435d-96de-67bfe2674f4e/crypt/zone/oxz_clickhouse_keeper_94abd717-9240-4a27-ac14-5666c1f3f3ab   e94a67fe-79b0-45b2-8cb8-0f00dd2c0c52   none      none          off        
 -   oxp_45a81e70-03bb-4c53-bf49-d598c9fb8d34/crypt/zone/oxz_crucible_133e50ce-39e1-4647-8ea8-8f171a1b6471            961b3fd4-d40c-4503-90a6-8ee32a5f5315   none      none          off        
 -   oxp_96f1615c-3dda-427f-8132-408b2fad24e0/crypt/zone/oxz_crucible_5078d1c7-9bc5-46a1-94e1-47ceb6f81580            530c8ac3-9a19-47c2-9057-4ae12a4377a5   none      none          off        
 -   oxp_b9f9c626-3293-48eb-a475-1debaaccdf6c/crypt/zone/oxz_crucible_58a60190-35da-4ce1-b0da-298b3d64458d            6ffd174d-1b54-4de3-9654-f50df5df6953   none      none          off        
@@ -82,7 +82,7 @@ to:   blueprint 74f2e7fd-687e-4c9e-b5d8-e474a5bb8e7c
     ------------------------------------------------------------------------------------------------
 *   clickhouse          f2c54229-d192-41bd-babc-9ca02c1206d6   - in service   fd00:1122:3344:101::23
      └─                                                        + expunged                           
-*   clickhouse_keeper   ceea23ec-1cb4-46be-bfa6-de9025ad5737   - in service   fd00:1122:3344:101::2f
+*   clickhouse_keeper   94abd717-9240-4a27-ac14-5666c1f3f3ab   - in service   fd00:1122:3344:101::2f
      └─                                                        + expunged                           
 *   crucible            133e50ce-39e1-4647-8ea8-8f171a1b6471   - in service   fd00:1122:3344:101::28
      └─                                                        + expunged                           
@@ -147,7 +147,7 @@ to:   blueprint 74f2e7fd-687e-4c9e-b5d8-e474a5bb8e7c
     oxp_6e418b8c-cadd-4fb8-8370-f351a07e1eed/crucible                                                                efce20c8-c6ad-4e1a-a489-1391a02ff73e   none      none          off        
     oxp_6e5772a5-8234-46d1-ba5a-503a83d9d2fb/crucible                                                                9292d1a7-786c-448b-86ea-4cdb7c29df73   none      none          off        
     oxp_08616473-ded4-4785-9b53-b6ccc1efb67a/crypt/clickhouse_keeper                                                 dda523f9-2078-42b1-a581-bad8349bb592   none      none          off        
-    oxp_08616473-ded4-4785-9b53-b6ccc1efb67a/crypt/clickhouse_server                                                 e1236796-4a4f-48fe-b274-9c6c251d60b7   none      none          off        
+    oxp_08616473-ded4-4785-9b53-b6ccc1efb67a/crypt/clickhouse_server                                                 14389e8b-952f-4e20-aabd-3741493fb444   none      none          off        
     oxp_08616473-ded4-4785-9b53-b6ccc1efb67a/crypt/internal_dns                                                      1e34af87-308a-4192-be38-193f0c89390a   none      none          off        
     oxp_c1da692e-7713-43a0-b6bb-5c182084c09d/crypt/zone                                                              c7345d22-765f-4892-993f-de910ac5055b   none      none          off        
     oxp_08616473-ded4-4785-9b53-b6ccc1efb67a/crypt/zone                                                              a27426fd-6f66-475d-bb6e-4422618ae009   none      none          off        
@@ -160,7 +160,7 @@ to:   blueprint 74f2e7fd-687e-4c9e-b5d8-e474a5bb8e7c
     oxp_6e5772a5-8234-46d1-ba5a-503a83d9d2fb/crypt/zone                                                              0292217f-5be3-440f-976b-6bab7043992f   none      none          off        
     oxp_e35766ef-789a-4b2f-9a6c-e6626d5ab195/crypt/zone                                                              d37c8162-c363-447f-b4be-da14fb97b181   none      none          off        
     oxp_08616473-ded4-4785-9b53-b6ccc1efb67a/crypt/zone/oxz_clickhouse_keeper_fe395a2c-219b-4ad7-9f51-f536de60a9e4   1331d93d-4191-48ea-ae98-9554f9aabcd8   none      none          off        
-    oxp_08616473-ded4-4785-9b53-b6ccc1efb67a/crypt/zone/oxz_clickhouse_server_02ef9ddc-a012-4d15-8f45-8282f58c9a11   2315a796-5038-4003-b5e0-099a29f7ebb1   none      none          off        
+    oxp_08616473-ded4-4785-9b53-b6ccc1efb67a/crypt/zone/oxz_clickhouse_server_23ee16e1-7f1f-4a76-b4fc-32921eead60e   fef210d9-1473-4294-afa4-90e1f1836b86   none      none          off        
     oxp_650b4eff-80a2-430a-97c8-f837248480a1/crypt/zone/oxz_crucible_0c50f6a6-55f0-4d9e-920e-c16b4e2f3b4f            34c4fcb0-c6d4-4f47-8153-a8b16e8c9c09   none      none          off        
     oxp_44342c41-75a7-4708-8004-eb2ca5c5a3c2/crypt/zone/oxz_crucible_377d8477-7608-4248-b925-6a2c5e04fee3            3000bfbb-7faa-4439-914c-84815c5d75ea   none      none          off        
     oxp_2dce7cf0-3097-485d-aaf6-9fc51f99eae5/crypt/zone/oxz_crucible_42ec7ad4-4a8a-4e7f-8291-bcc3a141647b            8e2fc466-8b2a-4be6-ba66-2bd8ef658a5d   none      none          off        
@@ -196,7 +196,7 @@ to:   blueprint 74f2e7fd-687e-4c9e-b5d8-e474a5bb8e7c
     zone type           zone id                                disposition   underlay IP           
     -----------------------------------------------------------------------------------------------
     clickhouse_keeper   fe395a2c-219b-4ad7-9f51-f536de60a9e4   in service    fd00:1122:3344:102::2e
-    clickhouse_server   02ef9ddc-a012-4d15-8f45-8282f58c9a11   in service    fd00:1122:3344:102::2f
+    clickhouse_server   23ee16e1-7f1f-4a76-b4fc-32921eead60e   in service    fd00:1122:3344:102::2f
     crucible            0c50f6a6-55f0-4d9e-920e-c16b4e2f3b4f   in service    fd00:1122:3344:102::29
     crucible            377d8477-7608-4248-b925-6a2c5e04fee3   in service    fd00:1122:3344:102::28
     crucible            42ec7ad4-4a8a-4e7f-8291-bcc3a141647b   in service    fd00:1122:3344:102::26
@@ -247,8 +247,8 @@ to:   blueprint 74f2e7fd-687e-4c9e-b5d8-e474a5bb8e7c
     oxp_588058f2-f51b-4800-a211-1c5dbb32296b/crucible                                                                97e6171d-523c-4c4a-9fa6-daead00d71a5   none      none          off        
     oxp_bcfcdede-7084-4a31-97a8-ac4299c268f9/crucible                                                                01def6ad-ddd9-4b28-b337-137a16734021   none      none          off        
     oxp_fe379ac6-1938-4cc2-93a9-43b1447229ae/crucible                                                                5818a803-eb2c-44eb-8818-bd98bfa29da9   none      none          off        
-    oxp_21d60319-5fe1-4a3b-a4c0-6aa7465e7bde/crypt/clickhouse_keeper                                                 90935183-8ac3-4474-aaf4-d7f29979c873   none      none          off        
-    oxp_21d60319-5fe1-4a3b-a4c0-6aa7465e7bde/crypt/clickhouse_server                                                 14389e8b-952f-4e20-aabd-3741493fb444   none      none          off        
+    oxp_21d60319-5fe1-4a3b-a4c0-6aa7465e7bde/crypt/clickhouse_keeper                                                 35a2dc24-0853-4a06-b5b9-90b8ba83e0b0   none      none          off        
+    oxp_21d60319-5fe1-4a3b-a4c0-6aa7465e7bde/crypt/clickhouse_server                                                 e1236796-4a4f-48fe-b274-9c6c251d60b7   none      none          off        
     oxp_21d60319-5fe1-4a3b-a4c0-6aa7465e7bde/crypt/internal_dns                                                      8d423173-09c9-4ca5-a21c-b7c3123aa1af   none      none          off        
     oxp_bcfcdede-7084-4a31-97a8-ac4299c268f9/crypt/zone                                                              d8d8dc6c-cd76-4d17-b530-25f3f3f52d33   none      none          off        
     oxp_2fa34d8e-13d9-42d3-b8ba-ca9d74ac496a/crypt/zone                                                              8b6d2ff8-4f40-4776-b461-29e0a3d3dd97   none      none          off        
@@ -260,8 +260,8 @@ to:   blueprint 74f2e7fd-687e-4c9e-b5d8-e474a5bb8e7c
     oxp_736f6f07-2aa2-4658-8b5c-3bf409ea747a/crypt/zone                                                              f3df6efd-e689-4aaa-b4ed-76de319a1fe4   none      none          off        
     oxp_fe379ac6-1938-4cc2-93a9-43b1447229ae/crypt/zone                                                              9327960e-a9a3-4b26-9bd4-65afb1737bd4   none      none          off        
     oxp_2db7f3b4-ed19-4229-b42c-44f49eeb8a91/crypt/zone                                                              0c6b2002-2cec-478f-9eb3-239069f42dbc   none      none          off        
-    oxp_21d60319-5fe1-4a3b-a4c0-6aa7465e7bde/crypt/zone/oxz_clickhouse_keeper_94abd717-9240-4a27-ac14-5666c1f3f3ab   e94a67fe-79b0-45b2-8cb8-0f00dd2c0c52   none      none          off        
-    oxp_21d60319-5fe1-4a3b-a4c0-6aa7465e7bde/crypt/zone/oxz_clickhouse_server_23ee16e1-7f1f-4a76-b4fc-32921eead60e   fef210d9-1473-4294-afa4-90e1f1836b86   none      none          off        
+    oxp_21d60319-5fe1-4a3b-a4c0-6aa7465e7bde/crypt/zone/oxz_clickhouse_keeper_ceea23ec-1cb4-46be-bfa6-de9025ad5737   abb56278-58c2-4e0c-8cc8-417f57100de0   none      none          off        
+    oxp_21d60319-5fe1-4a3b-a4c0-6aa7465e7bde/crypt/zone/oxz_clickhouse_server_02ef9ddc-a012-4d15-8f45-8282f58c9a11   2315a796-5038-4003-b5e0-099a29f7ebb1   none      none          off        
     oxp_2db7f3b4-ed19-4229-b42c-44f49eeb8a91/crypt/zone/oxz_crucible_02aecfb8-91a9-4db8-8cb2-4252bf15d6ac            7e11890f-b1ce-497a-9672-f95d3452eb7b   none      none          off        
     oxp_355e268c-c932-4f32-841c-f3ec88fe0495/crypt/zone/oxz_crucible_0a3cfe7c-414d-40f0-8f63-a7c0b26b7627            e1396508-5d99-4802-8d3f-cc3db33f0341   none      none          off        
     oxp_bcfcdede-7084-4a31-97a8-ac4299c268f9/crypt/zone/oxz_crucible_109820d7-b6ef-4574-b5e4-9f193c9d2a9e            75f329ff-4f3b-4cc5-8027-dd61d05e7323   none      none          off        
@@ -296,8 +296,8 @@ to:   blueprint 74f2e7fd-687e-4c9e-b5d8-e474a5bb8e7c
     -----------------------------------------------------------------------------------------------
     zone type           zone id                                disposition   underlay IP           
     -----------------------------------------------------------------------------------------------
-    clickhouse_keeper   94abd717-9240-4a27-ac14-5666c1f3f3ab   in service    fd00:1122:3344:103::2e
-    clickhouse_server   23ee16e1-7f1f-4a76-b4fc-32921eead60e   in service    fd00:1122:3344:103::2f
+    clickhouse_keeper   ceea23ec-1cb4-46be-bfa6-de9025ad5737   in service    fd00:1122:3344:103::2e
+    clickhouse_server   02ef9ddc-a012-4d15-8f45-8282f58c9a11   in service    fd00:1122:3344:103::2f
     crucible            02aecfb8-91a9-4db8-8cb2-4252bf15d6ac   in service    fd00:1122:3344:103::26
     crucible            0a3cfe7c-414d-40f0-8f63-a7c0b26b7627   in service    fd00:1122:3344:103::28
     crucible            109820d7-b6ef-4574-b5e4-9f193c9d2a9e   in service    fd00:1122:3344:103::2c
@@ -337,9 +337,9 @@ to:   blueprint 74f2e7fd-687e-4c9e-b5d8-e474a5bb8e7c
     ------------------------------------------------
     zone id                                keeper id
     ------------------------------------------------
-    94abd717-9240-4a27-ac14-5666c1f3f3ab   0        
+    ceea23ec-1cb4-46be-bfa6-de9025ad5737   1        
     fe395a2c-219b-4ad7-9f51-f536de60a9e4   2        
--   ceea23ec-1cb4-46be-bfa6-de9025ad5737   1        
+-   94abd717-9240-4a27-ac14-5666c1f3f3ab   0        
 
     clickhouse servers generation 2 -> 3:
     ------------------------------------------------

--- a/nexus/reconfigurator/planning/tests/output/planner_expunge_clickhouse_clusters_5_6.txt
+++ b/nexus/reconfigurator/planning/tests/output/planner_expunge_clickhouse_clusters_5_6.txt
@@ -10,7 +10,7 @@ to:   blueprint df68d4d4-5af4-4b56-95bb-1654a6957d4f
     zone type           zone id                                disposition   underlay IP           
     -----------------------------------------------------------------------------------------------
     clickhouse          f2c54229-d192-41bd-babc-9ca02c1206d6   expunged      fd00:1122:3344:101::23
-    clickhouse_keeper   ceea23ec-1cb4-46be-bfa6-de9025ad5737   expunged      fd00:1122:3344:101::2f
+    clickhouse_keeper   94abd717-9240-4a27-ac14-5666c1f3f3ab   expunged      fd00:1122:3344:101::2f
     crucible            133e50ce-39e1-4647-8ea8-8f171a1b6471   expunged      fd00:1122:3344:101::28
     crucible            5078d1c7-9bc5-46a1-94e1-47ceb6f81580   expunged      fd00:1122:3344:101::2a
     crucible            58a60190-35da-4ce1-b0da-298b3d64458d   expunged      fd00:1122:3344:101::2c
@@ -61,7 +61,7 @@ to:   blueprint df68d4d4-5af4-4b56-95bb-1654a6957d4f
     oxp_e35766ef-789a-4b2f-9a6c-e6626d5ab195/crucible                                                                97ff78ad-4939-4308-9dde-7bd94dc55741   none      none          off        
     oxp_2d44b756-94df-45ec-a644-50021248682d/crypt/clickhouse_keeper                                                 f2bbe72f-ae6c-4ee2-a2f3-eae54527048d   none      none          off        
     oxp_08616473-ded4-4785-9b53-b6ccc1efb67a/crypt/clickhouse_keeper                                                 dda523f9-2078-42b1-a581-bad8349bb592   none      none          off        
-    oxp_08616473-ded4-4785-9b53-b6ccc1efb67a/crypt/clickhouse_server                                                 e1236796-4a4f-48fe-b274-9c6c251d60b7   none      none          off        
+    oxp_08616473-ded4-4785-9b53-b6ccc1efb67a/crypt/clickhouse_server                                                 14389e8b-952f-4e20-aabd-3741493fb444   none      none          off        
     oxp_08616473-ded4-4785-9b53-b6ccc1efb67a/crypt/internal_dns                                                      1e34af87-308a-4192-be38-193f0c89390a   none      none          off        
     oxp_2d44b756-94df-45ec-a644-50021248682d/crypt/internal_dns                                                      0dc5f030-0bde-4fff-a0b6-f7c8fcc3e532   none      none          off        
     oxp_2dce7cf0-3097-485d-aaf6-9fc51f99eae5/crypt/zone                                                              1cee8f96-b8e2-4983-8c65-ba8338eb781c   none      none          off        
@@ -76,7 +76,7 @@ to:   blueprint df68d4d4-5af4-4b56-95bb-1654a6957d4f
     oxp_e35766ef-789a-4b2f-9a6c-e6626d5ab195/crypt/zone                                                              d37c8162-c363-447f-b4be-da14fb97b181   none      none          off        
     oxp_2d44b756-94df-45ec-a644-50021248682d/crypt/zone/oxz_clickhouse_keeper_e4052979-f949-44bf-91de-17b371d3e518   da028e64-33e1-4380-8544-19e6ce754b20   none      none          off        
     oxp_08616473-ded4-4785-9b53-b6ccc1efb67a/crypt/zone/oxz_clickhouse_keeper_fe395a2c-219b-4ad7-9f51-f536de60a9e4   1331d93d-4191-48ea-ae98-9554f9aabcd8   none      none          off        
-    oxp_08616473-ded4-4785-9b53-b6ccc1efb67a/crypt/zone/oxz_clickhouse_server_02ef9ddc-a012-4d15-8f45-8282f58c9a11   2315a796-5038-4003-b5e0-099a29f7ebb1   none      none          off        
+    oxp_08616473-ded4-4785-9b53-b6ccc1efb67a/crypt/zone/oxz_clickhouse_server_23ee16e1-7f1f-4a76-b4fc-32921eead60e   fef210d9-1473-4294-afa4-90e1f1836b86   none      none          off        
     oxp_650b4eff-80a2-430a-97c8-f837248480a1/crypt/zone/oxz_crucible_0c50f6a6-55f0-4d9e-920e-c16b4e2f3b4f            34c4fcb0-c6d4-4f47-8153-a8b16e8c9c09   none      none          off        
     oxp_44342c41-75a7-4708-8004-eb2ca5c5a3c2/crypt/zone/oxz_crucible_377d8477-7608-4248-b925-6a2c5e04fee3            3000bfbb-7faa-4439-914c-84815c5d75ea   none      none          off        
     oxp_2dce7cf0-3097-485d-aaf6-9fc51f99eae5/crypt/zone/oxz_crucible_42ec7ad4-4a8a-4e7f-8291-bcc3a141647b            8e2fc466-8b2a-4be6-ba66-2bd8ef658a5d   none      none          off        
@@ -110,7 +110,7 @@ to:   blueprint df68d4d4-5af4-4b56-95bb-1654a6957d4f
     -----------------------------------------------------------------------------------------------
     clickhouse_keeper   e4052979-f949-44bf-91de-17b371d3e518   in service    fd00:1122:3344:102::30
     clickhouse_keeper   fe395a2c-219b-4ad7-9f51-f536de60a9e4   in service    fd00:1122:3344:102::2e
-    clickhouse_server   02ef9ddc-a012-4d15-8f45-8282f58c9a11   in service    fd00:1122:3344:102::2f
+    clickhouse_server   23ee16e1-7f1f-4a76-b4fc-32921eead60e   in service    fd00:1122:3344:102::2f
     crucible            0c50f6a6-55f0-4d9e-920e-c16b4e2f3b4f   in service    fd00:1122:3344:102::29
     crucible            377d8477-7608-4248-b925-6a2c5e04fee3   in service    fd00:1122:3344:102::28
     crucible            42ec7ad4-4a8a-4e7f-8291-bcc3a141647b   in service    fd00:1122:3344:102::26
@@ -161,8 +161,8 @@ to:   blueprint df68d4d4-5af4-4b56-95bb-1654a6957d4f
     oxp_736f6f07-2aa2-4658-8b5c-3bf409ea747a/crucible                                                                035b55e9-a0fc-48e5-8cd0-a862e7a7fe47   none      none          off        
     oxp_fe379ac6-1938-4cc2-93a9-43b1447229ae/crucible                                                                5818a803-eb2c-44eb-8818-bd98bfa29da9   none      none          off        
     oxp_21d60319-5fe1-4a3b-a4c0-6aa7465e7bde/crypt/clickhouse                                                        410eca9c-8eee-4a98-aea2-a363697974f7   none      none          off        
-    oxp_21d60319-5fe1-4a3b-a4c0-6aa7465e7bde/crypt/clickhouse_keeper                                                 90935183-8ac3-4474-aaf4-d7f29979c873   none      none          off        
-    oxp_21d60319-5fe1-4a3b-a4c0-6aa7465e7bde/crypt/clickhouse_server                                                 14389e8b-952f-4e20-aabd-3741493fb444   none      none          off        
+    oxp_21d60319-5fe1-4a3b-a4c0-6aa7465e7bde/crypt/clickhouse_keeper                                                 35a2dc24-0853-4a06-b5b9-90b8ba83e0b0   none      none          off        
+    oxp_21d60319-5fe1-4a3b-a4c0-6aa7465e7bde/crypt/clickhouse_server                                                 e1236796-4a4f-48fe-b274-9c6c251d60b7   none      none          off        
     oxp_21d60319-5fe1-4a3b-a4c0-6aa7465e7bde/crypt/internal_dns                                                      8d423173-09c9-4ca5-a21c-b7c3123aa1af   none      none          off        
     oxp_2db7f3b4-ed19-4229-b42c-44f49eeb8a91/crypt/zone                                                              0c6b2002-2cec-478f-9eb3-239069f42dbc   none      none          off        
     oxp_21d60319-5fe1-4a3b-a4c0-6aa7465e7bde/crypt/zone                                                              d5d2ddf7-2eb3-40f3-b149-aee5699b7bf1   none      none          off        
@@ -175,8 +175,8 @@ to:   blueprint df68d4d4-5af4-4b56-95bb-1654a6957d4f
     oxp_bcfcdede-7084-4a31-97a8-ac4299c268f9/crypt/zone                                                              d8d8dc6c-cd76-4d17-b530-25f3f3f52d33   none      none          off        
     oxp_fe379ac6-1938-4cc2-93a9-43b1447229ae/crypt/zone                                                              9327960e-a9a3-4b26-9bd4-65afb1737bd4   none      none          off        
     oxp_21d60319-5fe1-4a3b-a4c0-6aa7465e7bde/crypt/zone/oxz_clickhouse_fa97835a-aabc-4fe9-9e85-3e50f207129c          08f15d4b-91dc-445d-88f4-cb9fa585444b   none      none          off        
-    oxp_21d60319-5fe1-4a3b-a4c0-6aa7465e7bde/crypt/zone/oxz_clickhouse_keeper_94abd717-9240-4a27-ac14-5666c1f3f3ab   e94a67fe-79b0-45b2-8cb8-0f00dd2c0c52   none      none          off        
-    oxp_21d60319-5fe1-4a3b-a4c0-6aa7465e7bde/crypt/zone/oxz_clickhouse_server_23ee16e1-7f1f-4a76-b4fc-32921eead60e   fef210d9-1473-4294-afa4-90e1f1836b86   none      none          off        
+    oxp_21d60319-5fe1-4a3b-a4c0-6aa7465e7bde/crypt/zone/oxz_clickhouse_keeper_ceea23ec-1cb4-46be-bfa6-de9025ad5737   abb56278-58c2-4e0c-8cc8-417f57100de0   none      none          off        
+    oxp_21d60319-5fe1-4a3b-a4c0-6aa7465e7bde/crypt/zone/oxz_clickhouse_server_02ef9ddc-a012-4d15-8f45-8282f58c9a11   2315a796-5038-4003-b5e0-099a29f7ebb1   none      none          off        
     oxp_2db7f3b4-ed19-4229-b42c-44f49eeb8a91/crypt/zone/oxz_crucible_02aecfb8-91a9-4db8-8cb2-4252bf15d6ac            7e11890f-b1ce-497a-9672-f95d3452eb7b   none      none          off        
     oxp_355e268c-c932-4f32-841c-f3ec88fe0495/crypt/zone/oxz_crucible_0a3cfe7c-414d-40f0-8f63-a7c0b26b7627            e1396508-5d99-4802-8d3f-cc3db33f0341   none      none          off        
     oxp_bcfcdede-7084-4a31-97a8-ac4299c268f9/crypt/zone/oxz_crucible_109820d7-b6ef-4574-b5e4-9f193c9d2a9e            75f329ff-4f3b-4cc5-8027-dd61d05e7323   none      none          off        
@@ -210,8 +210,8 @@ to:   blueprint df68d4d4-5af4-4b56-95bb-1654a6957d4f
     zone type           zone id                                disposition   underlay IP           
     -----------------------------------------------------------------------------------------------
     clickhouse          fa97835a-aabc-4fe9-9e85-3e50f207129c   in service    fd00:1122:3344:103::30
-    clickhouse_keeper   94abd717-9240-4a27-ac14-5666c1f3f3ab   in service    fd00:1122:3344:103::2e
-    clickhouse_server   23ee16e1-7f1f-4a76-b4fc-32921eead60e   in service    fd00:1122:3344:103::2f
+    clickhouse_keeper   ceea23ec-1cb4-46be-bfa6-de9025ad5737   in service    fd00:1122:3344:103::2e
+    clickhouse_server   02ef9ddc-a012-4d15-8f45-8282f58c9a11   in service    fd00:1122:3344:103::2f
     crucible            02aecfb8-91a9-4db8-8cb2-4252bf15d6ac   in service    fd00:1122:3344:103::26
     crucible            0a3cfe7c-414d-40f0-8f63-a7c0b26b7627   in service    fd00:1122:3344:103::28
     crucible            109820d7-b6ef-4574-b5e4-9f193c9d2a9e   in service    fd00:1122:3344:103::2c
@@ -250,7 +250,7 @@ to:   blueprint df68d4d4-5af4-4b56-95bb-1654a6957d4f
     ------------------------------------------------
     zone id                                keeper id
     ------------------------------------------------
-    94abd717-9240-4a27-ac14-5666c1f3f3ab   0        
+    ceea23ec-1cb4-46be-bfa6-de9025ad5737   1        
 +   e4052979-f949-44bf-91de-17b371d3e518   4        
     fe395a2c-219b-4ad7-9f51-f536de60a9e4   2        
 

--- a/nexus/reconfigurator/planning/tests/output/planner_expunge_clickhouse_zones_after_policy_is_changed_3_4.txt
+++ b/nexus/reconfigurator/planning/tests/output/planner_expunge_clickhouse_zones_after_policy_is_changed_3_4.txt
@@ -36,7 +36,7 @@ to:   blueprint d895ef50-9978-454c-bdfb-b8dbe2c9a918
     oxp_fbc5bdf2-9644-4d0a-b349-f490486da25d/crucible                                                                7f74ed80-0101-4b75-8515-aa80e82ee5fe   none      none          off        
     oxp_bc61cdae-c96f-4886-b8bd-f9fd69d51e3a/crucible                                                                5b64d326-883e-4182-a78d-9b4db76b04e9   none      none          off        
     oxp_41eaf63b-4fa9-443e-8da1-78d1e79aac7d/crypt/clickhouse                                                        595df8fe-7319-44ea-9170-83236f87b146   none      none          off        
-    oxp_41eaf63b-4fa9-443e-8da1-78d1e79aac7d/crypt/clickhouse_keeper                                                 c949b5ca-05fe-4c0a-95d0-11c8fd18675b   none      none          off        
+    oxp_41eaf63b-4fa9-443e-8da1-78d1e79aac7d/crypt/clickhouse_keeper                                                 f8e1c7d5-00cf-4d71-93eb-bec0af2ffa3b   none      none          off        
     oxp_41eaf63b-4fa9-443e-8da1-78d1e79aac7d/crypt/internal_dns                                                      0125252e-c9c2-4998-81e2-a82e534f7e3b   none      none          off        
     oxp_8e2c9e92-e35e-494c-8e14-dcf5f5009656/crypt/zone                                                              07f7066f-2644-4ca0-95f4-c1c8b88f3aef   none      none          off        
     oxp_41eaf63b-4fa9-443e-8da1-78d1e79aac7d/crypt/zone                                                              ddf90bf7-d58c-4f9c-9263-14cf354935a2   none      none          off        
@@ -49,7 +49,7 @@ to:   blueprint d895ef50-9978-454c-bdfb-b8dbe2c9a918
     oxp_fbc5bdf2-9644-4d0a-b349-f490486da25d/crypt/zone                                                              a45173d1-377c-4466-b392-76660653d2ce   none      none          off        
     oxp_a9a8a692-d2d7-4b3e-a297-d648faf8c7cf/crypt/zone                                                              35b11905-8c74-4104-901f-62ee66901985   none      none          off        
     oxp_41eaf63b-4fa9-443e-8da1-78d1e79aac7d/crypt/zone/oxz_clickhouse_6394624c-3aba-4be5-a6a2-68d9b5e506e4          8ab9adbc-d236-4167-b503-581ae9dc0136   none      none          off        
-    oxp_41eaf63b-4fa9-443e-8da1-78d1e79aac7d/crypt/zone/oxz_clickhouse_keeper_15f8164a-63e5-404e-81a5-c13e5855f7ca   6ca0e723-77fd-4859-90b8-b12601f21bde   none      none          off        
+    oxp_41eaf63b-4fa9-443e-8da1-78d1e79aac7d/crypt/zone/oxz_clickhouse_keeper_b8f84002-e213-4311-9d0a-f5a100735ea5   736579c3-0687-43d1-9dd5-cd44add5b932   none      none          off        
     oxp_fbc5bdf2-9644-4d0a-b349-f490486da25d/crypt/zone/oxz_crucible_289ece63-1c43-45d8-9731-411abaf62cfb            79cc327b-76da-40fb-b9f2-ca53af257d38   none      none          off        
     oxp_6e8fdb9f-c47a-47b0-b7ee-9a2adc7e4af5/crypt/zone/oxz_crucible_340d690d-52d6-4bd7-96a7-57989c3dd973            9e54a544-74dd-4a35-8cf5-dd78b9b79cef   none      none          off        
     oxp_a4c575b4-934b-49b9-9c47-9c1241a33607/crypt/zone/oxz_crucible_512f26d7-2e46-4189-9c5a-ffbfb5d0a4e9            b6ac1d96-7b2c-4c13-82ea-5e9d96c85d5f   none      none          off        
@@ -95,7 +95,7 @@ to:   blueprint d895ef50-9978-454c-bdfb-b8dbe2c9a918
     internal_dns        83f907f2-a0d7-46d8-842e-8603a3ef393f   in service     fd00:1122:3344:1::1   
     internal_ntp        4fd636ec-8c85-4d2f-b514-36f3190df8d8   in service     fd00:1122:3344:102::21
     nexus               a9043563-4a85-47a1-9478-db57d31b53c0   in service     fd00:1122:3344:102::22
-*   clickhouse_keeper   15f8164a-63e5-404e-81a5-c13e5855f7ca   - in service   fd00:1122:3344:102::2f
+*   clickhouse_keeper   b8f84002-e213-4311-9d0a-f5a100735ea5   - in service   fd00:1122:3344:102::2f
      └─                                                        + expunged                           
 
 
@@ -132,7 +132,7 @@ to:   blueprint d895ef50-9978-454c-bdfb-b8dbe2c9a918
     oxp_d2801671-bb69-408e-93f7-ac2b05d992f8/crucible                                                                0ab453de-947c-4d5a-a3ee-bf26ed85396f   none      none          off        
     oxp_f52832ea-60d7-443b-9847-df5384bfc8e2/crucible                                                                cc43cb24-2e55-415d-9a2a-49a6b924b284   none      none          off        
     oxp_21b01477-48d0-4b65-9089-4a48277af033/crypt/clickhouse_keeper                                                 6236e227-f345-4ec5-af7f-47c3dbe3eb2c   none      none          off        
-    oxp_21b01477-48d0-4b65-9089-4a48277af033/crypt/clickhouse_server                                                 e181ab51-2eb2-4552-a38c-9bafcaf7765b   none      none          off        
+    oxp_21b01477-48d0-4b65-9089-4a48277af033/crypt/clickhouse_server                                                 b0d669e6-1faf-4562-82fa-040422a06c9b   none      none          off        
     oxp_21b01477-48d0-4b65-9089-4a48277af033/crypt/internal_dns                                                      18abe482-6dda-45be-a9e6-ff215c6919f1   none      none          off        
     oxp_d2801671-bb69-408e-93f7-ac2b05d992f8/crypt/zone                                                              3b4b2059-de0b-4912-a57b-36b3858947a9   none      none          off        
     oxp_51c788ff-de33-43f7-b9c5-f5f56bf80736/crypt/zone                                                              0160fea9-34cb-4b54-92fc-f6780f4b64c5   none      none          off        
@@ -145,7 +145,7 @@ to:   blueprint d895ef50-9978-454c-bdfb-b8dbe2c9a918
     oxp_f52832ea-60d7-443b-9847-df5384bfc8e2/crypt/zone                                                              55895da4-4e66-403e-b723-a76b1c2f907e   none      none          off        
     oxp_27a22f7e-754a-43ea-8ec4-e9cbd9b62e08/crypt/zone                                                              f94213ab-5c96-476d-85c9-bf0801cc4941   none      none          off        
     oxp_21b01477-48d0-4b65-9089-4a48277af033/crypt/zone/oxz_clickhouse_keeper_2bae8ad4-3d1f-43aa-8c9b-5dcce65c0480   0a04d1c9-57c7-43c8-b46f-f428f0549575   none      none          off        
-    oxp_21b01477-48d0-4b65-9089-4a48277af033/crypt/zone/oxz_clickhouse_server_c0951435-7d95-4356-bcd3-9d92756d911a   849d2000-dab1-4f5f-b9b9-79294aefe298   none      none          off        
+    oxp_21b01477-48d0-4b65-9089-4a48277af033/crypt/zone/oxz_clickhouse_server_c3c0a7b9-2829-4b2d-a2d9-bd2bab02af0f   4aeb359a-4f04-4267-8316-291871cbf89b   none      none          off        
     oxp_7e2644a1-bec7-433c-8168-8898d7140aab/crypt/zone/oxz_crucible_057daeb5-798b-439c-aab8-004b54343323            5929490a-4a7f-4b00-af68-550087145c2d   none      none          off        
     oxp_f52832ea-60d7-443b-9847-df5384bfc8e2/crypt/zone/oxz_crucible_0c59cc2b-00e8-4243-bf24-1cfc25a212a3            445423d9-3331-48ef-b98b-156c234b290c   none      none          off        
     oxp_27a22f7e-754a-43ea-8ec4-e9cbd9b62e08/crypt/zone/oxz_crucible_13efd31e-52f3-4914-bc30-45f22828631a            45ba838b-e725-4e92-82e7-fb39dbd1d00d   none      none          off        
@@ -192,7 +192,7 @@ to:   blueprint d895ef50-9978-454c-bdfb-b8dbe2c9a918
     nexus               7cebfab2-4453-4614-b904-96939bc339d3   in service     fd00:1122:3344:103::22
 *   clickhouse_keeper   2bae8ad4-3d1f-43aa-8c9b-5dcce65c0480   - in service   fd00:1122:3344:103::2e
      └─                                                        + expunged                           
-*   clickhouse_server   c0951435-7d95-4356-bcd3-9d92756d911a   - in service   fd00:1122:3344:103::2f
+*   clickhouse_server   c3c0a7b9-2829-4b2d-a2d9-bd2bab02af0f   - in service   fd00:1122:3344:103::2f
      └─                                                        + expunged                           
 
 
@@ -228,8 +228,8 @@ to:   blueprint d895ef50-9978-454c-bdfb-b8dbe2c9a918
     oxp_b2c5a75b-9f72-405a-8134-691c0f45a1fd/crucible                                                                5b37edae-1bf4-4b0e-aba8-0111c831eac5   none      none          off        
     oxp_a5553017-9991-4ffb-ae37-f9c0e3428562/crucible                                                                96b5bbc7-ea73-48ac-8533-96a6c1c2f59f   none      none          off        
     oxp_facb28ca-94fd-47a0-bf63-ee394d32c43b/crucible                                                                2b1819c1-a30e-42c4-b5fa-67f71e496ba1   none      none          off        
-    oxp_288d864c-3a9e-4f21-8c6e-720702c82a29/crypt/clickhouse_keeper                                                 f8e1c7d5-00cf-4d71-93eb-bec0af2ffa3b   none      none          off        
-    oxp_288d864c-3a9e-4f21-8c6e-720702c82a29/crypt/clickhouse_server                                                 b0d669e6-1faf-4562-82fa-040422a06c9b   none      none          off        
+    oxp_288d864c-3a9e-4f21-8c6e-720702c82a29/crypt/clickhouse_keeper                                                 c949b5ca-05fe-4c0a-95d0-11c8fd18675b   none      none          off        
+    oxp_288d864c-3a9e-4f21-8c6e-720702c82a29/crypt/clickhouse_server                                                 e181ab51-2eb2-4552-a38c-9bafcaf7765b   none      none          off        
     oxp_288d864c-3a9e-4f21-8c6e-720702c82a29/crypt/internal_dns                                                      a3ce0f4d-a253-4284-907b-f59e777564df   none      none          off        
     oxp_5f877424-eca4-4c5d-af7f-41627382cfd8/crypt/zone                                                              df1cff74-0dba-465b-a5ac-97638d129c97   none      none          off        
     oxp_288d864c-3a9e-4f21-8c6e-720702c82a29/crypt/zone                                                              10877dd7-7567-4226-9033-b2af0d88529e   none      none          off        
@@ -241,8 +241,8 @@ to:   blueprint d895ef50-9978-454c-bdfb-b8dbe2c9a918
     oxp_83592889-d746-4c5d-98e8-582d9c34a15f/crypt/zone                                                              f93193ae-e6b5-4d89-b85e-7eec27ff1e20   none      none          off        
     oxp_d4d665fc-df4d-4a13-b9c2-ad13549c0845/crypt/zone                                                              dc23d8ef-b503-4ac3-ae28-5bf78c4ebc70   none      none          off        
     oxp_facb28ca-94fd-47a0-bf63-ee394d32c43b/crypt/zone                                                              6ad4f8be-cd3b-4950-8a86-f854dc96580f   none      none          off        
-    oxp_288d864c-3a9e-4f21-8c6e-720702c82a29/crypt/zone/oxz_clickhouse_keeper_b8f84002-e213-4311-9d0a-f5a100735ea5   736579c3-0687-43d1-9dd5-cd44add5b932   none      none          off        
-    oxp_288d864c-3a9e-4f21-8c6e-720702c82a29/crypt/zone/oxz_clickhouse_server_c3c0a7b9-2829-4b2d-a2d9-bd2bab02af0f   4aeb359a-4f04-4267-8316-291871cbf89b   none      none          off        
+    oxp_288d864c-3a9e-4f21-8c6e-720702c82a29/crypt/zone/oxz_clickhouse_keeper_15f8164a-63e5-404e-81a5-c13e5855f7ca   6ca0e723-77fd-4859-90b8-b12601f21bde   none      none          off        
+    oxp_288d864c-3a9e-4f21-8c6e-720702c82a29/crypt/zone/oxz_clickhouse_server_c0951435-7d95-4356-bcd3-9d92756d911a   849d2000-dab1-4f5f-b9b9-79294aefe298   none      none          off        
     oxp_83592889-d746-4c5d-98e8-582d9c34a15f/crypt/zone/oxz_crucible_26d3f8d0-228a-4f89-aa4a-fa33aeba4fd0            6f2af271-d4e4-46e1-9220-22c3f9718852   none      none          off        
     oxp_a5553017-9991-4ffb-ae37-f9c0e3428562/crypt/zone/oxz_crucible_446a395a-2f8b-4849-a0d5-bbdca403b095            bee9e11b-1beb-4984-bfca-54fb82015ec9   none      none          off        
     oxp_8277a18f-3187-4893-8ef1-5cbfe2284616/crypt/zone/oxz_crucible_6a31350d-eb6c-4b61-97ff-0d673c07fee3            a94317df-b46f-431b-b5af-023dad4e8bd5   none      none          off        
@@ -289,9 +289,9 @@ to:   blueprint d895ef50-9978-454c-bdfb-b8dbe2c9a918
     internal_dns        f2ec46c3-3ab4-426f-823a-eb7b4b57fd53   in service     fd00:1122:3344:3::1   
     internal_ntp        df6e43a7-ad9b-41c8-bea4-421b1b52e059   in service     fd00:1122:3344:101::21
     nexus               7ac3bbd8-bbdd-4acd-9957-efbb43354f70   in service     fd00:1122:3344:101::22
-*   clickhouse_keeper   b8f84002-e213-4311-9d0a-f5a100735ea5   - in service   fd00:1122:3344:101::2e
+*   clickhouse_keeper   15f8164a-63e5-404e-81a5-c13e5855f7ca   - in service   fd00:1122:3344:101::2e
      └─                                                        + expunged                           
-*   clickhouse_server   c3c0a7b9-2829-4b2d-a2d9-bd2bab02af0f   - in service   fd00:1122:3344:101::2f
+*   clickhouse_server   c0951435-7d95-4356-bcd3-9d92756d911a   - in service   fd00:1122:3344:101::2f
      └─                                                        + expunged                           
 +   clickhouse          729bb1a1-20e6-42b1-9a42-d495c6697823   in service     fd00:1122:3344:101::30
 

--- a/nexus/reconfigurator/planning/tests/output/planner_nonprovisionable_1_2.txt
+++ b/nexus/reconfigurator/planning/tests/output/planner_nonprovisionable_1_2.txt
@@ -353,9 +353,9 @@ to:   blueprint 9f71f5d3-a272-4382-9154-6ea2e171a6c6
     oxp_cf32a1ce-2c9e-49f5-b1cf-4af7f2a28901/crypt/debug                                                    2dfc5c53-6618-4352-b754-86ef6463c20a   100 GiB   none          gzip-9     
     oxp_55196665-ed61-4b23-9a74-0711bf2eaf90/crypt/debug                                                    ae4f4e83-0bd1-48dc-bfe3-f1082e8f357a   100 GiB   none          gzip-9     
     oxp_f4d7f914-ec73-4b65-8696-5068591d9065/crypt/debug                                                    b803d901-7e43-42fa-8372-43c3c5b3c1a9   100 GiB   none          gzip-9     
-+   oxp_4069c804-c51a-4adc-8822-3cbbab56ed3f/crypt/zone/oxz_nexus_2ec75441-3d7d-4b4b-9614-af03de5a3666      cd15e9c9-0238-493a-8b32-926d1cd1bce6   none      none          off        
 +   oxp_4069c804-c51a-4adc-8822-3cbbab56ed3f/crypt/zone/oxz_nexus_508abd03-cbfe-4654-9a6d-7f15a1ad32e5      b781d032-3149-4c44-a7d3-5f8d80e4a607   none      none          off        
-+   oxp_4069c804-c51a-4adc-8822-3cbbab56ed3f/crypt/zone/oxz_nexus_59950bc8-1497-44dd-8cbf-b6502ba921b2      63ec1a21-2c77-41b5-ad3e-e7bf39207107   none      none          off        
++   oxp_4069c804-c51a-4adc-8822-3cbbab56ed3f/crypt/zone/oxz_nexus_99f6d544-8599-4e2b-a55a-82d9e0034662      8a39677a-fbcf-4884-b000-63be3247fb63   none      none          off        
++   oxp_4069c804-c51a-4adc-8822-3cbbab56ed3f/crypt/zone/oxz_nexus_c26b3bda-5561-44a1-a69f-22103fe209a1      c9c1a582-1fe0-4001-9301-97230387563a   none      none          off        
 
 
     omicron zones generation 2 -> 3:
@@ -374,9 +374,9 @@ to:   blueprint 9f71f5d3-a272-4382-9154-6ea2e171a6c6
     crucible       f1a7b9a7-fc6a-4b23-b829-045ff33117ff   in service    fd00:1122:3344:104::26
     internal_ntp   621509d6-3772-4009-aca1-35eefd1098fb   in service    fd00:1122:3344:104::21
     nexus          a732c489-d29a-4f75-b900-5966385943af   in service    fd00:1122:3344:104::22
-+   nexus          2ec75441-3d7d-4b4b-9614-af03de5a3666   in service    fd00:1122:3344:104::2d
-+   nexus          508abd03-cbfe-4654-9a6d-7f15a1ad32e5   in service    fd00:1122:3344:104::2e
-+   nexus          59950bc8-1497-44dd-8cbf-b6502ba921b2   in service    fd00:1122:3344:104::2f
++   nexus          508abd03-cbfe-4654-9a6d-7f15a1ad32e5   in service    fd00:1122:3344:104::2d
++   nexus          99f6d544-8599-4e2b-a55a-82d9e0034662   in service    fd00:1122:3344:104::2e
++   nexus          c26b3bda-5561-44a1-a69f-22103fe209a1   in service    fd00:1122:3344:104::2f
 
 
   sled affab35f-600a-4109-8ea0-34a067a4e0bc (active):
@@ -443,9 +443,9 @@ to:   blueprint 9f71f5d3-a272-4382-9154-6ea2e171a6c6
     oxp_cd62306a-aedf-47e8-93d5-92a358d64c7b/crypt/debug                                                    73674f4b-1d93-404a-bc9c-8395efac97fd   100 GiB   none          gzip-9     
     oxp_4fbd2fe0-2eac-41b8-8e8d-4fa46c3e8b6c/crypt/debug                                                    5a288f52-a84e-45a6-873a-3d9c81d67380   100 GiB   none          gzip-9     
     oxp_fe4fdfba-3b6d-47d3-8612-1fb2390b650a/crypt/debug                                                    8e58b91f-9ce2-4256-8dec-5f90f31a73fa   100 GiB   none          gzip-9     
++   oxp_33d48d85-751e-4982-b738-eae4d9a05f01/crypt/zone/oxz_nexus_2ec75441-3d7d-4b4b-9614-af03de5a3666      cd15e9c9-0238-493a-8b32-926d1cd1bce6   none      none          off        
 +   oxp_33d48d85-751e-4982-b738-eae4d9a05f01/crypt/zone/oxz_nexus_3ca5292f-8a59-4475-bb72-0f43714d0fff      871b35e6-d234-4a96-bab4-d07314bc6ba2   none      none          off        
-+   oxp_33d48d85-751e-4982-b738-eae4d9a05f01/crypt/zone/oxz_nexus_99f6d544-8599-4e2b-a55a-82d9e0034662      8a39677a-fbcf-4884-b000-63be3247fb63   none      none          off        
-+   oxp_33d48d85-751e-4982-b738-eae4d9a05f01/crypt/zone/oxz_nexus_c26b3bda-5561-44a1-a69f-22103fe209a1      c9c1a582-1fe0-4001-9301-97230387563a   none      none          off        
++   oxp_33d48d85-751e-4982-b738-eae4d9a05f01/crypt/zone/oxz_nexus_59950bc8-1497-44dd-8cbf-b6502ba921b2      63ec1a21-2c77-41b5-ad3e-e7bf39207107   none      none          off        
 
 
     omicron zones generation 2 -> 3:
@@ -464,9 +464,9 @@ to:   blueprint 9f71f5d3-a272-4382-9154-6ea2e171a6c6
     crucible       e001fea0-6594-4ece-97e3-6198c293e931   in service    fd00:1122:3344:101::28
     internal_ntp   bf79a56a-97af-4cc4-94a5-8b20d64c2cda   in service    fd00:1122:3344:101::21
     nexus          4ad0e9da-08f8-4d40-b4d3-d17e711b5bbf   in service    fd00:1122:3344:101::22
-+   nexus          3ca5292f-8a59-4475-bb72-0f43714d0fff   in service    fd00:1122:3344:101::2e
-+   nexus          99f6d544-8599-4e2b-a55a-82d9e0034662   in service    fd00:1122:3344:101::2d
-+   nexus          c26b3bda-5561-44a1-a69f-22103fe209a1   in service    fd00:1122:3344:101::2f
++   nexus          2ec75441-3d7d-4b4b-9614-af03de5a3666   in service    fd00:1122:3344:101::2d
++   nexus          3ca5292f-8a59-4475-bb72-0f43714d0fff   in service    fd00:1122:3344:101::2f
++   nexus          59950bc8-1497-44dd-8cbf-b6502ba921b2   in service    fd00:1122:3344:101::2e
 
 
  COCKROACHDB SETTINGS:

--- a/nexus/reconfigurator/planning/tests/output/planner_nonprovisionable_2_2a.txt
+++ b/nexus/reconfigurator/planning/tests/output/planner_nonprovisionable_2_2a.txt
@@ -55,10 +55,10 @@ to:   blueprint 9f71f5d3-a272-4382-9154-6ea2e171a6c6
     oxp_cf32a1ce-2c9e-49f5-b1cf-4af7f2a28901/crypt/zone/oxz_crucible_c60379ba-4e30-4628-a79a-0ae509aef4c5   a6fcf496-70a1-49bf-a951-62fcec8dd5e2   none      none          off        
     oxp_5248a306-4a03-449e-a8a3-6f86d26da755/crypt/zone/oxz_crucible_f0ff59e8-4105-4980-a4bb-a1f4c58de1e3   c596346d-4040-4103-b036-8fafdbaada00   none      none          off        
     oxp_6b2a719a-35eb-469f-aa54-114a1f21f37d/crypt/zone/oxz_crucible_f1a7b9a7-fc6a-4b23-b829-045ff33117ff   c864de0d-9859-4ad1-a30b-f5ac45ba03ed   none      none          off        
-    oxp_4069c804-c51a-4adc-8822-3cbbab56ed3f/crypt/zone/oxz_nexus_2ec75441-3d7d-4b4b-9614-af03de5a3666      cd15e9c9-0238-493a-8b32-926d1cd1bce6   none      none          off        
     oxp_4069c804-c51a-4adc-8822-3cbbab56ed3f/crypt/zone/oxz_nexus_508abd03-cbfe-4654-9a6d-7f15a1ad32e5      b781d032-3149-4c44-a7d3-5f8d80e4a607   none      none          off        
-    oxp_4069c804-c51a-4adc-8822-3cbbab56ed3f/crypt/zone/oxz_nexus_59950bc8-1497-44dd-8cbf-b6502ba921b2      63ec1a21-2c77-41b5-ad3e-e7bf39207107   none      none          off        
+    oxp_4069c804-c51a-4adc-8822-3cbbab56ed3f/crypt/zone/oxz_nexus_99f6d544-8599-4e2b-a55a-82d9e0034662      8a39677a-fbcf-4884-b000-63be3247fb63   none      none          off        
     oxp_4069c804-c51a-4adc-8822-3cbbab56ed3f/crypt/zone/oxz_nexus_a732c489-d29a-4f75-b900-5966385943af      db6c139b-9028-4d8e-92c7-6cc1e9aa0131   none      none          off        
+    oxp_4069c804-c51a-4adc-8822-3cbbab56ed3f/crypt/zone/oxz_nexus_c26b3bda-5561-44a1-a69f-22103fe209a1      c9c1a582-1fe0-4001-9301-97230387563a   none      none          off        
     oxp_4069c804-c51a-4adc-8822-3cbbab56ed3f/crypt/zone/oxz_ntp_621509d6-3772-4009-aca1-35eefd1098fb        3b5822d2-9918-4bd6-8b75-2f52bdd73189   none      none          off        
     oxp_984e2389-e7fd-4af9-ab02-e3caf77f95b5/crypt/debug                                                    5c79ad9d-1aef-407d-804c-ace1d0e069a4   100 GiB   none          gzip-9     
     oxp_7ed4296a-66d1-4fb2-bc56-9b23b8f27d7e/crypt/debug                                                    a02b70bf-b069-4fec-9f53-1976ba462c45   100 GiB   none          gzip-9     
@@ -87,10 +87,10 @@ to:   blueprint 9f71f5d3-a272-4382-9154-6ea2e171a6c6
     crucible       f0ff59e8-4105-4980-a4bb-a1f4c58de1e3   in service    fd00:1122:3344:104::24
     crucible       f1a7b9a7-fc6a-4b23-b829-045ff33117ff   in service    fd00:1122:3344:104::26
     internal_ntp   621509d6-3772-4009-aca1-35eefd1098fb   in service    fd00:1122:3344:104::21
-    nexus          2ec75441-3d7d-4b4b-9614-af03de5a3666   in service    fd00:1122:3344:104::2d
-    nexus          508abd03-cbfe-4654-9a6d-7f15a1ad32e5   in service    fd00:1122:3344:104::2e
-    nexus          59950bc8-1497-44dd-8cbf-b6502ba921b2   in service    fd00:1122:3344:104::2f
+    nexus          508abd03-cbfe-4654-9a6d-7f15a1ad32e5   in service    fd00:1122:3344:104::2d
+    nexus          99f6d544-8599-4e2b-a55a-82d9e0034662   in service    fd00:1122:3344:104::2e
     nexus          a732c489-d29a-4f75-b900-5966385943af   in service    fd00:1122:3344:104::22
+    nexus          c26b3bda-5561-44a1-a69f-22103fe209a1   in service    fd00:1122:3344:104::2f
 
 
   sled affab35f-600a-4109-8ea0-34a067a4e0bc (active):
@@ -145,10 +145,10 @@ to:   blueprint 9f71f5d3-a272-4382-9154-6ea2e171a6c6
     oxp_cd62306a-aedf-47e8-93d5-92a358d64c7b/crypt/zone/oxz_crucible_be920398-024a-4655-8c49-69b5ac48dfff   87f757d6-fa4c-4423-995c-1eab5e7d09a2   none      none          off        
     oxp_39ca2e23-4c38-4743-afe0-26b0380b27db/crypt/zone/oxz_crucible_d47f4996-fac0-4657-bcea-01b1fee6404d   c1af262a-2595-4236-98c8-21c5b63c80c3   none      none          off        
     oxp_789d607d-d196-428e-a988-f7886a327859/crypt/zone/oxz_crucible_e001fea0-6594-4ece-97e3-6198c293e931   5e27b9bc-e69f-4258-83f2-5f9a1109a625   none      none          off        
+    oxp_33d48d85-751e-4982-b738-eae4d9a05f01/crypt/zone/oxz_nexus_2ec75441-3d7d-4b4b-9614-af03de5a3666      cd15e9c9-0238-493a-8b32-926d1cd1bce6   none      none          off        
     oxp_33d48d85-751e-4982-b738-eae4d9a05f01/crypt/zone/oxz_nexus_3ca5292f-8a59-4475-bb72-0f43714d0fff      871b35e6-d234-4a96-bab4-d07314bc6ba2   none      none          off        
     oxp_33d48d85-751e-4982-b738-eae4d9a05f01/crypt/zone/oxz_nexus_4ad0e9da-08f8-4d40-b4d3-d17e711b5bbf      45d32c13-cbbb-4382-a0ed-dc6574b827b7   none      none          off        
-    oxp_33d48d85-751e-4982-b738-eae4d9a05f01/crypt/zone/oxz_nexus_99f6d544-8599-4e2b-a55a-82d9e0034662      8a39677a-fbcf-4884-b000-63be3247fb63   none      none          off        
-    oxp_33d48d85-751e-4982-b738-eae4d9a05f01/crypt/zone/oxz_nexus_c26b3bda-5561-44a1-a69f-22103fe209a1      c9c1a582-1fe0-4001-9301-97230387563a   none      none          off        
+    oxp_33d48d85-751e-4982-b738-eae4d9a05f01/crypt/zone/oxz_nexus_59950bc8-1497-44dd-8cbf-b6502ba921b2      63ec1a21-2c77-41b5-ad3e-e7bf39207107   none      none          off        
     oxp_33d48d85-751e-4982-b738-eae4d9a05f01/crypt/zone/oxz_ntp_bf79a56a-97af-4cc4-94a5-8b20d64c2cda        a410308c-e2cb-4e4d-9da6-1879336f93f2   none      none          off        
     oxp_789d607d-d196-428e-a988-f7886a327859/crypt/debug                                                    1f7f6932-ed14-482a-816e-b0f76d96603d   100 GiB   none          gzip-9     
     oxp_77e45b5b-869f-4e78-8ce3-28bbe8cf37e9/crypt/debug                                                    60a98875-ee39-49d8-b4b8-1f5d168e39e2   100 GiB   none          gzip-9     
@@ -177,10 +177,10 @@ to:   blueprint 9f71f5d3-a272-4382-9154-6ea2e171a6c6
     crucible       d47f4996-fac0-4657-bcea-01b1fee6404d   in service    fd00:1122:3344:101::24
     crucible       e001fea0-6594-4ece-97e3-6198c293e931   in service    fd00:1122:3344:101::28
     internal_ntp   bf79a56a-97af-4cc4-94a5-8b20d64c2cda   in service    fd00:1122:3344:101::21
-    nexus          3ca5292f-8a59-4475-bb72-0f43714d0fff   in service    fd00:1122:3344:101::2e
+    nexus          2ec75441-3d7d-4b4b-9614-af03de5a3666   in service    fd00:1122:3344:101::2d
+    nexus          3ca5292f-8a59-4475-bb72-0f43714d0fff   in service    fd00:1122:3344:101::2f
     nexus          4ad0e9da-08f8-4d40-b4d3-d17e711b5bbf   in service    fd00:1122:3344:101::22
-    nexus          99f6d544-8599-4e2b-a55a-82d9e0034662   in service    fd00:1122:3344:101::2d
-    nexus          c26b3bda-5561-44a1-a69f-22103fe209a1   in service    fd00:1122:3344:101::2f
+    nexus          59950bc8-1497-44dd-8cbf-b6502ba921b2   in service    fd00:1122:3344:101::2e
 
 
  REMOVED SLEDS:

--- a/nexus/reconfigurator/planning/tests/output/planner_nonprovisionable_bp2.txt
+++ b/nexus/reconfigurator/planning/tests/output/planner_nonprovisionable_bp2.txt
@@ -74,10 +74,10 @@ parent:    4d4e6c38-cd95-4c4e-8f45-6af4d686964b
     crucible       f0ff59e8-4105-4980-a4bb-a1f4c58de1e3   in service    fd00:1122:3344:104::24
     crucible       f1a7b9a7-fc6a-4b23-b829-045ff33117ff   in service    fd00:1122:3344:104::26
     internal_ntp   621509d6-3772-4009-aca1-35eefd1098fb   in service    fd00:1122:3344:104::21
-    nexus          2ec75441-3d7d-4b4b-9614-af03de5a3666   in service    fd00:1122:3344:104::2d
-    nexus          508abd03-cbfe-4654-9a6d-7f15a1ad32e5   in service    fd00:1122:3344:104::2e
-    nexus          59950bc8-1497-44dd-8cbf-b6502ba921b2   in service    fd00:1122:3344:104::2f
+    nexus          508abd03-cbfe-4654-9a6d-7f15a1ad32e5   in service    fd00:1122:3344:104::2d
+    nexus          99f6d544-8599-4e2b-a55a-82d9e0034662   in service    fd00:1122:3344:104::2e
     nexus          a732c489-d29a-4f75-b900-5966385943af   in service    fd00:1122:3344:104::22
+    nexus          c26b3bda-5561-44a1-a69f-22103fe209a1   in service    fd00:1122:3344:104::2f
 
 
 
@@ -114,10 +114,10 @@ parent:    4d4e6c38-cd95-4c4e-8f45-6af4d686964b
     crucible       d47f4996-fac0-4657-bcea-01b1fee6404d   in service    fd00:1122:3344:101::24
     crucible       e001fea0-6594-4ece-97e3-6198c293e931   in service    fd00:1122:3344:101::28
     internal_ntp   bf79a56a-97af-4cc4-94a5-8b20d64c2cda   in service    fd00:1122:3344:101::21
-    nexus          3ca5292f-8a59-4475-bb72-0f43714d0fff   in service    fd00:1122:3344:101::2e
+    nexus          2ec75441-3d7d-4b4b-9614-af03de5a3666   in service    fd00:1122:3344:101::2d
+    nexus          3ca5292f-8a59-4475-bb72-0f43714d0fff   in service    fd00:1122:3344:101::2f
     nexus          4ad0e9da-08f8-4d40-b4d3-d17e711b5bbf   in service    fd00:1122:3344:101::22
-    nexus          99f6d544-8599-4e2b-a55a-82d9e0034662   in service    fd00:1122:3344:101::2d
-    nexus          c26b3bda-5561-44a1-a69f-22103fe209a1   in service    fd00:1122:3344:101::2f
+    nexus          59950bc8-1497-44dd-8cbf-b6502ba921b2   in service    fd00:1122:3344:101::2e
 
 
 


### PR DESCRIPTION
All of the callers of the `ensure_zone_multiple_*` methods to add discretionary zones were, in practice, wanting to _add_ a specific number of zones. This rewords all of those methods to be imperative, allowing us to remove a pretty significant chunk of now-unnecessary checks and logic.

Builds on and is staged on top of #7106.