### PR TITLE
[sled-storage] Use test-configured mountpoint root for datasets

### DIFF
--- a/sled-storage/src/manager.rs
+++ b/sled-storage/src/manager.rs
@@ -955,8 +955,8 @@ impl StorageManager {
             err: None,
         };
 
-        let mountpoint_path =
-            config.name.mountpoint(ZPOOL_MOUNTPOINT_ROOT.into());
+        let mountpoint_root = &self.resources.disks().mount_config().root;
+        let mountpoint_path = config.name.mountpoint(mountpoint_root);
         let details = DatasetCreationDetails {
             zoned: config.name.dataset().zoned(),
             mountpoint: Mountpoint::Path(mountpoint_path),


### PR DESCRIPTION
This change should only impact tests.

The "mountpoint" configuration, by default, uses the `ZPOOL_MOUNTPOINT_ROOT` as a root path where datasets
may be located:

https://github.com/oxidecomputer/omicron/blob/48790e52a9b76ec91c315ca44f5c462d639e62f7/sled-storage/src/config.rs#L33-L35

In prod, this value is "/". Under tests,  however, we may want more isolation between datasets, hence this configuration option.

This PR respects that configuration option when configuring datasets. This will be relevant for Sled Agent tests, and otherwise effectively acts as a no-op.