### PR TITLE
fix `ls-apis` breakage

### DIFF
--- a/dev-tools/ls-apis/api-manifest.toml
+++ b/dev-tools/ls-apis/api-manifest.toml
@@ -96,11 +96,14 @@ label = "Crucible Pantry"
 packages = [ "crucible-pantry" ]
 
 [[deployment_units]]
-label = "Cockroach Admin"
+label = "Cockroach"
 packages = [ "omicron-cockroach-admin" ]
 
+# These are really three distinct deployment units, but they behave the same for
+# our purposes, and the tooling doesn't support multiple deployment units
+# that each expose a particular service.
 [[deployment_units]]
-label = "Clickhouse Admin"
+label = "Clickhouse (single-node) / Clickhouse Server (multi-node) / Clickhouse Keeper (multi-node)"
 packages = [ "omicron-clickhouse-admin" ]
 
 [[deployment_units]]
@@ -312,6 +315,7 @@ Exposed by Crucible upstairs for debugging via the `cmon` debugging tool.
 client_package_name = "dsc-client"
 label = "Downstairs Controller (debugging only)"
 server_package_name = "dsc"
+dev_only = true
 notes = """
 `dsc` is a control program for spinning up and controlling instances of Crucible
 downstairs for testing.  You can use the same program to control a running `dsc`

--- a/dev-tools/ls-apis/src/api_metadata.rs
+++ b/dev-tools/ls-apis/src/api_metadata.rs
@@ -199,11 +199,16 @@ pub struct ApiMetadata {
     pub server_package_name: ServerPackageName,
     /// human-readable notes about this API
     pub notes: Option<String>,
-    /// whether this package is ever expected to be deployed in a real system
+    /// If `dev_only` is true, then this API's server is not deployed in a
+    /// production system.  It's only used in development environments.  The
+    /// default (if unspecified and this comes in as `None`) is that APIs *are*
+    /// deployed (equivalent to `dev_only = Some(false)`).
     dev_only: Option<bool>,
 }
 
 impl ApiMetadata {
+    /// Returns whether this API's server component gets deployed on real
+    /// systems
     pub fn deployed(&self) -> bool {
         !(self.dev_only.unwrap_or(false))
     }

--- a/dev-tools/ls-apis/src/api_metadata.rs
+++ b/dev-tools/ls-apis/src/api_metadata.rs
@@ -199,6 +199,14 @@ pub struct ApiMetadata {
     pub server_package_name: ServerPackageName,
     /// human-readable notes about this API
     pub notes: Option<String>,
+    /// whether this package is ever expected to be deployed in a real system
+    dev_only: Option<bool>,
+}
+
+impl ApiMetadata {
+    pub fn deployed(&self) -> bool {
+        !(self.dev_only.unwrap_or(false))
+    }
 }
 
 /// Describes a unit that combines one or more servers that get deployed

--- a/dev-tools/ls-apis/src/system_apis.rs
+++ b/dev-tools/ls-apis/src/system_apis.rs
@@ -170,8 +170,8 @@ impl SystemApis {
                 if found_producer.is_none() {
                     bail!(
                         "error: found no producer for API with client package \
-                     name {:?} in any deployment unit (should have been one \
-                     that contains server package {:?})",
+                         name {:?} in any deployment unit (should have been \
+                         one that contains server package {:?})",
                         api.client_package_name,
                         api.server_package_name,
                     );
@@ -386,13 +386,7 @@ impl SystemApis {
             let consumed_apis =
                 self.component_apis_consumed(server_component, filter)?;
             for (client_pkg, _) in consumed_apis {
-                let other_component =
-                    self.api_producer(client_pkg).ok_or_else(|| {
-                        anyhow!(
-                            "missing producer for API with client package {:?}",
-                            client_pkg
-                        )
-                    })?;
+                let other_component = self.api_producer(client_pkg).unwrap();
                 let other_node = nodes.get(other_component).unwrap();
                 graph.add_edge(*my_node, *other_node, client_pkg.clone());
             }


### PR DESCRIPTION
This PR:

- Fixes the problem described in #7121.
- Adds a new check that the tool found a producer for every API in the metadata.  (I had to add an exception for "dsc" because it's not deployed.  But the exception is driven by metadata, not hardcoded.)  This ensures that we catch similar problems in CI in the future.

These are separated into two commits if you want to see which part is which.  They're in the reverse order -- I added the test first to make sure it would fail without the fix.

Fixes #7121.