### PR TITLE
Fix several `oximeter` bugs

### DIFF
--- a/common/src/api/internal/nexus.rs
+++ b/common/src/api/internal/nexus.rs
@@ -218,7 +218,7 @@ pub enum ProducerKind {
 
 /// Information announced by a metric server, used so that clients can contact it and collect
 /// available metric data from it.
-#[derive(Clone, Debug, Deserialize, JsonSchema, Serialize, PartialEq)]
+#[derive(Clone, Copy, Debug, Deserialize, JsonSchema, Serialize, PartialEq)]
 pub struct ProducerEndpoint {
     /// A unique ID for this producer.
     pub id: Uuid,

--- a/oximeter/collector/src/agent.rs
+++ b/oximeter/collector/src/agent.rs
@@ -698,7 +698,7 @@ impl OximeterAgent {
             .await
             .range((start, Bound::Unbounded))
             .take(limit)
-            .map(|(_id, (info, _t))| info.clone())
+            .map(|(_id, (info, _t))| *info)
             .collect()
     }
 

--- a/oximeter/collector/src/standalone.rs
+++ b/oximeter/collector/src/standalone.rs
@@ -112,7 +112,7 @@ impl StandaloneNexus {
                     ));
                 };
                 let assignment =
-                    ProducerAssignment { producer: info.clone(), collector_id };
+                    ProducerAssignment { producer: *info, collector_id };
                 assignment
             }
             Some(existing_assignment) => {
@@ -126,7 +126,7 @@ impl StandaloneNexus {
                 // changed its IP address. The collector will learn of this when
                 // it next fetches its list.
                 let collector_id = existing_assignment.collector_id;
-                ProducerAssignment { producer: info.clone(), collector_id }
+                ProducerAssignment { producer: *info, collector_id }
             }
         };
         inner.producers.insert(info.id, assignment);

--- a/oximeter/producer/src/lib.rs
+++ b/oximeter/producer/src/lib.rs
@@ -130,7 +130,7 @@ impl Server {
     ) -> Result<Self, Error> {
         Self::new_impl(
             registry,
-            config.server_info.clone(),
+            config.server_info,
             config.registration_address.as_ref(),
             config.request_body_max_bytes,
             &config.log,


### PR DESCRIPTION
- Only update producer information if it's actually changed. This fixes #7120, since we no longer indefinitely delay a collection timer just by refreshing our list of producers from Nexus.
- Bail from a producer refresh on any error contacting Nexus. This should fix #7124. If we get a progenitor-level error refreshing our list from Nexus, which should mostly be a communcation error like `ECONNREFUSED`, we don't want to blow away our entire state. Instead, break out of the refresh function entirely, and continue collecting from our last known-good set of producers. Only proceed with the update when we are confident we have a full, valid list from Nexus.
- Change the missed tick behavior for refreshing producer list from "burst" to "skip". This isn't strictly necessary, but better reflects what we want, which is "reasonably often" updates, without causing undue churn.