### PR TITLE
remove Nexus dependency on nexus-client and use serde(default) in ls-apis

### DIFF
--- a/dev-tools/ls-apis/src/api_metadata.rs
+++ b/dev-tools/ls-apis/src/api_metadata.rs
@@ -201,16 +201,16 @@ pub struct ApiMetadata {
     pub notes: Option<String>,
     /// If `dev_only` is true, then this API's server is not deployed in a
     /// production system.  It's only used in development environments.  The
-    /// default (if unspecified and this comes in as `None`) is that APIs *are*
-    /// deployed (equivalent to `dev_only = Some(false)`).
-    dev_only: Option<bool>,
+    /// default is that APIs *are* deployed.
+    #[serde(default)]
+    dev_only: bool,
 }
 
 impl ApiMetadata {
     /// Returns whether this API's server component gets deployed on real
     /// systems
     pub fn deployed(&self) -> bool {
-        !(self.dev_only.unwrap_or(false))
+        !self.dev_only
     }
 }
 

--- a/dev-tools/ls-apis/tests/api_dependencies.out
+++ b/dev-tools/ls-apis/tests/api_dependencies.out
@@ -57,7 +57,6 @@ Maghemite MG Admin (client: mg-admin-client)
 
 Nexus Internal API (client: nexus-client)
     consumed by: dpd (dendrite/dpd) via 1 path
-    consumed by: omicron-nexus (omicron/nexus) via 1 path
     consumed by: omicron-sled-agent (omicron/sled-agent) via 1 path
     consumed by: oximeter-collector (omicron/oximeter/collector) via 1 path
     consumed by: propolis-server (propolis/bin/propolis-server) via 3 paths

--- a/nexus/Cargo.toml
+++ b/nexus/Cargo.toml
@@ -50,7 +50,6 @@ itertools.workspace = true
 macaddr.workspace = true
 # Not under "dev-dependencies"; these also need to be implemented for
 # integration tests.
-nexus-client.workspace = true
 nexus-config.workspace = true
 nexus-external-api.workspace = true
 nexus-internal-api.workspace = true
@@ -133,6 +132,7 @@ gateway-messages.workspace = true
 gateway-test-utils.workspace = true
 hubtools.workspace = true
 nexus-db-queries = { workspace = true, features = ["testing"] }
+nexus-client.workspace = true
 nexus-test-utils-macros.workspace = true
 nexus-test-utils.workspace = true
 omicron-sled-agent.workspace = true


### PR DESCRIPTION
This PR contains two unrelated but tiny fixes:

* Removes the Cargo dependency in `omicron-nexus` on `nexus-client`.  This looks spurious and it causes `ls-apis` to think Nexus depends on itself.
* Changes the new `dev_only` flag to use `serde(default)` instead of hand-rolling similar behavior (suggested by @sunshowers [here](https://github.com/oxidecomputer/omicron/pull/7122#discussion_r1851231528)).