### PR TITLE
fix up Cargo.lock

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -9281,13 +9281,13 @@ name = "range-requests"
 version = "0.1.0"
 dependencies = [
  "bytes",
- "dropshot",
+ "dropshot 0.13.0",
  "futures",
- "http 1.1.0",
- "http-body 1.0.1",
+ "http",
+ "http-body",
  "http-body-util",
  "http-range",
- "hyper 1.4.1",
+ "hyper",
  "omicron-workspace-hack",
  "proptest",
  "thiserror",


### PR DESCRIPTION
semantic merge conflict between #6963 and the hyper v1 / dropshot upgrades, i think