### PR TITLE
generate and publish a junit.xml for the test suite

### DIFF
--- a/.config/nextest.toml
+++ b/.config/nextest.toml
@@ -18,6 +18,9 @@ setup = 'crdb-seed'
 [profile.ci]
 fail-fast = false
 
+[profile.ci.junit]
+path = "junit.xml"
+
 [script.crdb-seed]
 # Use the test profile for this executable since that's how almost all
 # invocations of nextest happen.

--- a/.github/buildomat/build-and-test.sh
+++ b/.github/buildomat/build-and-test.sh
@@ -41,6 +41,22 @@ mkdir -p "$OUTPUT_DIR"
 banner prerequisites
 ptime -m bash ./tools/install_builder_prerequisites.sh -y
 
+#
+# Write a machine-readable file with information about our build environment for
+# later analysis of test results.
+#
+jq --null-input >/work/environment.json \
+    --arg bmat_factory_name "$(bmat factory name)" \
+    --arg bmat_factory_private "$(bmat factory private)" \
+    '{
+        buildomat: {
+            factory: {
+                name: $bmat_factory_name,
+                private: $bmat_factory_private,
+            },
+        },
+    }'
+
 # Do some test runs of the `ls-apis` command.
 #
 # This may require cloning some dependent private repos.  We do this before the

--- a/.github/buildomat/jobs/build-and-test-helios.sh
+++ b/.github/buildomat/jobs/build-and-test-helios.sh
@@ -6,6 +6,7 @@
 #: rust_toolchain = true
 #: output_rules = [
 #:	"%/work/*",
+#:	"%/work/oxidecomputer/omicron/target/nextest/ci/junit.xml",
 #:	"%/var/tmp/omicron_tmp/**/*",
 #:	"!/var/tmp/omicron_tmp/crdb-base*",
 #:	"!/var/tmp/omicron_tmp/rustc*",
@@ -13,5 +14,10 @@
 #: access_repos = [
 #:	"oxidecomputer/dendrite",
 #: ]
+#:
+#: [[publish]]
+#: series = "junit-helios"
+#: name = "junit.xml"
+#: from_output = "/work/oxidecomputer/omicron/target/nextest/ci/junit.xml"
 
 exec .github/buildomat/build-and-test.sh illumos

--- a/.github/buildomat/jobs/build-and-test-helios.sh
+++ b/.github/buildomat/jobs/build-and-test-helios.sh
@@ -19,5 +19,11 @@
 #: series = "junit-helios"
 #: name = "junit.xml"
 #: from_output = "/work/oxidecomputer/omicron/target/nextest/ci/junit.xml"
+#:
+#: [[publish]]
+#: series = "junit-linux"
+#: name = "environment.json"
+#: from_output = "/work/environment.json"
+#:
 
 exec .github/buildomat/build-and-test.sh illumos

--- a/.github/buildomat/jobs/build-and-test-linux.sh
+++ b/.github/buildomat/jobs/build-and-test-linux.sh
@@ -19,5 +19,12 @@
 #: series = "junit-linux"
 #: name = "junit.xml"
 #: from_output = "/work/oxidecomputer/omicron/target/nextest/ci/junit.xml"
+#:
+#: [[publish]]
+#: series = "junit-linux"
+#: name = "environment.json"
+#: from_output = "/work/environment.json"
+#:
 
+sudo apt-get install -y jq
 exec .github/buildomat/build-and-test.sh linux

--- a/.github/buildomat/jobs/build-and-test-linux.sh
+++ b/.github/buildomat/jobs/build-and-test-linux.sh
@@ -6,6 +6,7 @@
 #: rust_toolchain = true
 #: output_rules = [
 #:	"%/work/*",
+#:	"%/work/oxidecomputer/omicron/target/nextest/ci/junit.xml",
 #:	"%/var/tmp/omicron_tmp/**/*",
 #:	"!/var/tmp/omicron_tmp/crdb-base*",
 #:	"!/var/tmp/omicron_tmp/rustc*",
@@ -13,5 +14,10 @@
 #: access_repos = [
 #:	"oxidecomputer/dendrite",
 #: ]
+#:
+#: [[publish]]
+#: series = "junit-linux"
+#: name = "junit.xml"
+#: from_output = "/work/oxidecomputer/omicron/target/nextest/ci/junit.xml"
 
 exec .github/buildomat/build-and-test.sh linux


### PR DESCRIPTION
This is intended for writing tools to analyze test flakes over time.

Because this artefact is `[[publish]]`ed, you can use a URL like this to fetch the junit.xml based on the commit hash: https://buildomat.eng.oxide.computer/public/file/oxidecomputer/omicron/junit-linux/a93a7f911d23fbdde50ab475dd3a0595bc915234/junit.xml (using `junit-helios` for the helios test).