### PR TITLE
Add API for fetching details about an oximeter producer

### DIFF
--- a/dev-tools/omdb/src/bin/omdb/oximeter.rs
+++ b/dev-tools/omdb/src/bin/omdb/oximeter.rs
@@ -7,10 +7,14 @@
 use crate::helpers::CONNECTION_OPTIONS_HEADING;
 use crate::Omdb;
 use anyhow::Context;
+use chrono::DateTime;
+use chrono::SecondsFormat;
+use chrono::Utc;
 use clap::Args;
 use clap::Subcommand;
 use futures::TryStreamExt;
 use internal_dns_types::names::ServiceName;
+use oximeter_client::types::ProducerDetails;
 use oximeter_client::types::ProducerEndpoint;
 use oximeter_client::Client;
 use slog::Logger;
@@ -41,6 +45,11 @@ pub struct OximeterArgs {
 enum OximeterCommands {
     /// List the producers the collector is assigned to poll.
     ListProducers,
+    /// Fetch details about a single assigned producer.
+    ProducerDetails {
+        /// The ID of the producer to fetch.
+        producer_id: Uuid,
+    },
 }
 
 impl OximeterArgs {
@@ -81,7 +90,24 @@ impl OximeterArgs {
             OximeterCommands::ListProducers => {
                 self.list_producers(client).await
             }
+            OximeterCommands::ProducerDetails { producer_id } => {
+                self.producer_details(client, producer_id).await
+            }
         }
+    }
+
+    async fn producer_details(
+        &self,
+        client: Client,
+        producer_id: Uuid,
+    ) -> anyhow::Result<()> {
+        let details = client
+            .producer_details(&producer_id)
+            .await
+            .context("failed to fetch producer details")?
+            .into_inner();
+        print_producer_details(details);
+        Ok(())
     }
 
     async fn list_producers(&self, client: Client) -> anyhow::Result<()> {
@@ -120,11 +146,123 @@ struct Producer {
 
 impl From<ProducerEndpoint> for Producer {
     fn from(p: ProducerEndpoint) -> Self {
-        let interval = Duration::new(p.interval.secs, p.interval.nanos);
         Self {
             id: p.id,
             address: p.address.parse().unwrap(),
-            interval: humantime::format_duration(interval).to_string(),
+            interval: duration_to_humantime(&p.interval),
         }
+    }
+}
+
+fn duration_to_humantime(d: &oximeter_client::types::Duration) -> String {
+    let interval = Duration::new(d.secs, d.nanos);
+    humantime::format_duration(interval).to_string()
+}
+
+fn optional_datetime_to_string(maybe_d: &Option<DateTime<Utc>>) -> String {
+    maybe_d
+        .map(|d| d.to_rfc3339_opts(SecondsFormat::Millis, true))
+        .unwrap_or_else(|| String::from("Never"))
+}
+
+fn print_producer_details(details: ProducerDetails) {
+    const WIDTH: usize = 16;
+    println!("{:>WIDTH$}: {}", "ID", details.id);
+    println!("{:>WIDTH$}: {}", "Address", details.address);
+    println!(
+        "{:>WIDTH$}: {}",
+        "Registered",
+        details.registered.to_rfc3339_opts(SecondsFormat::Millis, true)
+    );
+    println!(
+        "{:>WIDTH$}: {}",
+        "Updated",
+        details.updated.to_rfc3339_opts(SecondsFormat::Millis, true)
+    );
+    println!(
+        "{:>WIDTH$}: {}",
+        "Interval",
+        duration_to_humantime(&details.interval)
+    );
+    println!(
+        "{:>WIDTH$}: {}",
+        "Last collection",
+        optional_datetime_to_string(&details.last_collection_started)
+    );
+    println!(
+        "{:>WIDTH$}: {} ({}, {} samples)",
+        "Last success",
+        optional_datetime_to_string(&details.last_successful_collection),
+        details
+            .last_collection_duration
+            .as_ref()
+            .map(|d| format!("{:?}", Duration::new(d.secs, d.nanos)))
+            .unwrap_or_else(|| String::from("0s")),
+        details
+            .n_samples_in_last_collection
+            .map(|n| n.to_string())
+            .unwrap_or_else(|| String::from("No")),
+    );
+    println!(
+        "{:>WIDTH$}: {}{}",
+        "Last failure",
+        optional_datetime_to_string(&details.last_failed_collection),
+        match details.last_failure_reason {
+            Some(reason) => format!(" ({reason})"),
+            None => String::new(),
+        },
+    );
+    println!("{:>WIDTH$}: {}", "Successes", details.n_collections);
+    println!("{:>WIDTH$}: {}", "Failures", details.n_failures);
+}
+
+#[cfg(test)]
+mod tests {
+    use super::print_producer_details;
+    use chrono::Utc;
+    use oximeter_client::types::ProducerDetails;
+    use std::time::Duration;
+    use uuid::Uuid;
+
+    #[test]
+    fn test_print_producer_details() {
+        let now = Utc::now();
+        let details = ProducerDetails {
+            id: Uuid::new_v4(),
+            address: "[::1]:12345".parse().unwrap(),
+            interval: Duration::from_secs(10).into(),
+            last_collection_duration: Some(Duration::from_millis(10).into()),
+            last_collection_started: Some(now),
+            last_failed_collection: None,
+            last_failure_reason: None,
+            last_successful_collection: Some(now + Duration::from_millis(10)),
+            n_collections: 1,
+            n_failures: 0,
+            n_samples_in_last_collection: Some(100),
+            registered: now,
+            updated: now,
+        };
+        print_producer_details(details);
+    }
+
+    #[test]
+    fn test_print_producer_details_with_failure() {
+        let now = Utc::now();
+        let details = ProducerDetails {
+            id: Uuid::new_v4(),
+            interval: Duration::from_secs(10).into(),
+            address: "[::1]:12345".parse().unwrap(),
+            last_collection_duration: None,
+            last_collection_started: Some(now),
+            last_failed_collection: Some(now + Duration::from_millis(10)),
+            last_failure_reason: Some("unreachable".to_string()),
+            last_successful_collection: None,
+            n_collections: 0,
+            n_failures: 1,
+            n_samples_in_last_collection: None,
+            registered: now,
+            updated: now,
+        };
+        print_producer_details(details);
     }
 }

--- a/dev-tools/omdb/tests/usage_errors.out
+++ b/dev-tools/omdb/tests/usage_errors.out
@@ -761,8 +761,9 @@ Query oximeter collector state
 Usage: omdb oximeter [OPTIONS] <COMMAND>
 
 Commands:
-  list-producers  List the producers the collector is assigned to poll
-  help            Print this message or the help of the given subcommand(s)
+  list-producers    List the producers the collector is assigned to poll
+  producer-details  Fetch details about a single assigned producer
+  help              Print this message or the help of the given subcommand(s)
 
 Options:
       --log-level <LOG_LEVEL>  log level filter [env: LOG_LEVEL=] [default: warn]

--- a/openapi/oximeter.json
+++ b/openapi/oximeter.json
@@ -84,6 +84,39 @@
       }
     },
     "/producers/{producer_id}": {
+      "get": {
+        "summary": "Get details about a producer by ID.",
+        "operationId": "producer_details",
+        "parameters": [
+          {
+            "in": "path",
+            "name": "producer_id",
+            "required": true,
+            "schema": {
+              "type": "string",
+              "format": "uuid"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "successful operation",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProducerDetails"
+                }
+              }
+            }
+          },
+          "4XX": {
+            "$ref": "#/components/responses/Error"
+          },
+          "5XX": {
+            "$ref": "#/components/responses/Error"
+          }
+        }
+      },
       "delete": {
         "summary": "Delete a producer by ID.",
         "operationId": "producer_delete",
@@ -169,6 +202,98 @@
         "required": [
           "message",
           "request_id"
+        ]
+      },
+      "ProducerDetails": {
+        "type": "object",
+        "properties": {
+          "address": {
+            "description": "The current collection address.",
+            "type": "string"
+          },
+          "id": {
+            "description": "The producer's ID.",
+            "type": "string",
+            "format": "uuid"
+          },
+          "interval": {
+            "description": "The current collection interval.",
+            "allOf": [
+              {
+                "$ref": "#/components/schemas/Duration"
+              }
+            ]
+          },
+          "last_collection_duration": {
+            "nullable": true,
+            "description": "The duration of the last successful collection.",
+            "allOf": [
+              {
+                "$ref": "#/components/schemas/Duration"
+              }
+            ]
+          },
+          "last_collection_started": {
+            "nullable": true,
+            "description": "The last time we started to collect from this producer.\n\nThis is None if we've never attempted to collect from the producer.",
+            "type": "string",
+            "format": "date-time"
+          },
+          "last_failed_collection": {
+            "nullable": true,
+            "description": "The last time we failed to collect from this producer.\n\nThis is None if we've never failed to collect from the producer. Note that this can be before `last_collection_started`, when we're in the middle of a collection or the last collection was successful.",
+            "type": "string",
+            "format": "date-time"
+          },
+          "last_failure_reason": {
+            "nullable": true,
+            "description": "A string describing why the last collection failed.",
+            "type": "string"
+          },
+          "last_successful_collection": {
+            "nullable": true,
+            "description": "The last time we successfully completed a collection from this producer.\n\nThis is None if we've never successfully collected from the producer. Note that this can be before `last_collection_started`, when we're in the middle of a collection or the last collection has failed.",
+            "type": "string",
+            "format": "date-time"
+          },
+          "n_collections": {
+            "description": "The total number of successful collections we've made.",
+            "type": "integer",
+            "format": "uint64",
+            "minimum": 0
+          },
+          "n_failures": {
+            "description": "The total number of failed collections.",
+            "type": "integer",
+            "format": "uint64",
+            "minimum": 0
+          },
+          "n_samples_in_last_collection": {
+            "nullable": true,
+            "description": "The number of samples collected in the last successful collection.",
+            "type": "integer",
+            "format": "uint64",
+            "minimum": 0
+          },
+          "registered": {
+            "description": "The time the producer was first registered with us.",
+            "type": "string",
+            "format": "date-time"
+          },
+          "updated": {
+            "description": "The last time the producer's information was updated.",
+            "type": "string",
+            "format": "date-time"
+          }
+        },
+        "required": [
+          "address",
+          "id",
+          "interval",
+          "n_collections",
+          "n_failures",
+          "registered",
+          "updated"
         ]
       },
       "ProducerEndpoint": {

--- a/openapi/oximeter.json
+++ b/openapi/oximeter.json
@@ -204,6 +204,43 @@
           "request_id"
         ]
       },
+      "FailedCollection": {
+        "description": "Details about a previous failed collection.",
+        "type": "object",
+        "properties": {
+          "reason": {
+            "description": "The reason the collection failed.",
+            "type": "string"
+          },
+          "started_at": {
+            "description": "The time at which we started a collection.\n\nNote that this is the time we queued a request to collect for processing by a background task. The `time_queued` can be added to this time to figure out when processing began, and `time_collecting` can be added to that to figure out how long the actual collection process took.",
+            "type": "string",
+            "format": "date-time"
+          },
+          "time_collecting": {
+            "description": "The time it took for the actual collection.",
+            "allOf": [
+              {
+                "$ref": "#/components/schemas/Duration"
+              }
+            ]
+          },
+          "time_queued": {
+            "description": "The time this request spent queued before being processed.",
+            "allOf": [
+              {
+                "$ref": "#/components/schemas/Duration"
+              }
+            ]
+          }
+        },
+        "required": [
+          "reason",
+          "started_at",
+          "time_collecting",
+          "time_queued"
+        ]
+      },
       "ProducerDetails": {
         "type": "object",
         "properties": {
@@ -224,37 +261,23 @@
               }
             ]
           },
-          "last_collection_duration": {
+          "last_failure": {
             "nullable": true,
-            "description": "The duration of the last successful collection.",
+            "description": "Details about the last failed collection.\n\nThis is None if we've never failed to collect from the producer.",
             "allOf": [
               {
-                "$ref": "#/components/schemas/Duration"
+                "$ref": "#/components/schemas/FailedCollection"
               }
             ]
           },
-          "last_collection_started": {
+          "last_success": {
             "nullable": true,
-            "description": "The last time we started to collect from this producer.\n\nThis is None if we've never attempted to collect from the producer.",
-            "type": "string",
-            "format": "date-time"
-          },
-          "last_failed_collection": {
-            "nullable": true,
-            "description": "The last time we failed to collect from this producer.\n\nThis is None if we've never failed to collect from the producer. Note that this can be before `last_collection_started`, when we're in the middle of a collection or the last collection was successful.",
-            "type": "string",
-            "format": "date-time"
-          },
-          "last_failure_reason": {
-            "nullable": true,
-            "description": "A string describing why the last collection failed.",
-            "type": "string"
-          },
-          "last_successful_collection": {
-            "nullable": true,
-            "description": "The last time we successfully completed a collection from this producer.\n\nThis is None if we've never successfully collected from the producer. Note that this can be before `last_collection_started`, when we're in the middle of a collection or the last collection has failed.",
-            "type": "string",
-            "format": "date-time"
+            "description": "Details about the last successful collection.\n\nThis is None if we've never successfully collected from the producer.",
+            "allOf": [
+              {
+                "$ref": "#/components/schemas/SuccessfulCollection"
+              }
+            ]
           },
           "n_collections": {
             "description": "The total number of successful collections we've made.",
@@ -264,13 +287,6 @@
           },
           "n_failures": {
             "description": "The total number of failed collections.",
-            "type": "integer",
-            "format": "uint64",
-            "minimum": 0
-          },
-          "n_samples_in_last_collection": {
-            "nullable": true,
-            "description": "The number of samples collected in the last successful collection.",
             "type": "integer",
             "format": "uint64",
             "minimum": 0
@@ -385,6 +401,45 @@
               "management_gateway"
             ]
           }
+        ]
+      },
+      "SuccessfulCollection": {
+        "description": "Details about a previous successful collection.",
+        "type": "object",
+        "properties": {
+          "n_samples": {
+            "description": "The number of samples collected.",
+            "type": "integer",
+            "format": "uint64",
+            "minimum": 0
+          },
+          "started_at": {
+            "description": "The time at which we started a collection.\n\nNote that this is the time we queued a request to collect for processing by a background task. The `time_queued` can be added to this time to figure out when processing began, and `time_collecting` can be added to that to figure out how long the actual collection process took.",
+            "type": "string",
+            "format": "date-time"
+          },
+          "time_collecting": {
+            "description": "The time it took for the actual collection.",
+            "allOf": [
+              {
+                "$ref": "#/components/schemas/Duration"
+              }
+            ]
+          },
+          "time_queued": {
+            "description": "The time this request spent queued before being processed.",
+            "allOf": [
+              {
+                "$ref": "#/components/schemas/Duration"
+              }
+            ]
+          }
+        },
+        "required": [
+          "n_samples",
+          "started_at",
+          "time_collecting",
+          "time_queued"
         ]
       }
     },

--- a/oximeter/api/src/lib.rs
+++ b/oximeter/api/src/lib.rs
@@ -10,6 +10,7 @@ use dropshot::{
 use omicron_common::api::internal::nexus::ProducerEndpoint;
 use schemars::JsonSchema;
 use serde::{Deserialize, Serialize};
+use std::{net::SocketAddr, time::Duration};
 use uuid::Uuid;
 
 #[dropshot::api_description]
@@ -25,6 +26,16 @@ pub trait OximeterApi {
         request_context: RequestContext<Self::Context>,
         query: Query<PaginationParams<EmptyScanParams, ProducerPage>>,
     ) -> Result<HttpResponseOk<ResultsPage<ProducerEndpoint>>, HttpError>;
+
+    /// Get details about a producer by ID.
+    #[endpoint {
+        method = GET,
+        path = "/producers/{producer_id}",
+    }]
+    async fn producer_details(
+        request_context: RequestContext<Self::Context>,
+        path: dropshot::Path<ProducerIdPathParams>,
+    ) -> Result<HttpResponseOk<ProducerDetails>, HttpError>;
 
     /// Delete a producer by ID.
     #[endpoint {
@@ -63,4 +74,121 @@ pub struct CollectorInfo {
     pub id: Uuid,
     /// Last time we refreshed our producer list with Nexus.
     pub last_refresh: Option<DateTime<Utc>>,
+}
+
+#[derive(Clone, Debug, Deserialize, JsonSchema, Serialize)]
+pub struct ProducerDetails {
+    /// The producer's ID.
+    pub id: Uuid,
+
+    /// The current collection interval.
+    pub interval: Duration,
+
+    /// The current collection address.
+    pub address: SocketAddr,
+
+    /// The time the producer was first registered with us.
+    pub registered: DateTime<Utc>,
+
+    /// The last time the producer's information was updated.
+    pub updated: DateTime<Utc>,
+
+    /// The last time we started to collect from this producer.
+    ///
+    /// This is None if we've never attempted to collect from the producer.
+    pub last_collection_started: Option<DateTime<Utc>>,
+
+    /// The last time we successfully completed a collection from this producer.
+    ///
+    /// This is None if we've never successfully collected from the producer.
+    /// Note that this can be before `last_collection_started`, when we're in
+    /// the middle of a collection or the last collection has failed.
+    pub last_successful_collection: Option<DateTime<Utc>>,
+
+    /// The number of samples collected in the last successful collection.
+    pub n_samples_in_last_collection: Option<u64>,
+
+    /// The duration of the last successful collection.
+    pub last_collection_duration: Option<Duration>,
+
+    /// The last time we failed to collect from this producer.
+    ///
+    /// This is None if we've never failed to collect from the producer. Note
+    /// that this can be before `last_collection_started`, when we're in the
+    /// middle of a collection or the last collection was successful.
+    pub last_failed_collection: Option<DateTime<Utc>>,
+
+    /// A string describing why the last collection failed.
+    pub last_failure_reason: Option<String>,
+
+    /// The total number of successful collections we've made.
+    pub n_collections: u64,
+
+    /// The total number of failed collections.
+    pub n_failures: u64,
+}
+
+impl ProducerDetails {
+    pub fn new(info: &ProducerEndpoint) -> Self {
+        let now = Utc::now();
+        Self {
+            id: info.id,
+            interval: info.interval,
+            address: info.address,
+            registered: now,
+            updated: now,
+            last_collection_started: None,
+            last_successful_collection: None,
+            n_samples_in_last_collection: None,
+            last_collection_duration: None,
+            last_failed_collection: None,
+            last_failure_reason: None,
+            n_collections: 0,
+            n_failures: 0,
+        }
+    }
+
+    /// Update with new producer information.
+    ///
+    /// # Panics
+    ///
+    /// This panics if the new information refers to a different ID.
+    pub fn update(&mut self, new: &ProducerEndpoint) {
+        assert_eq!(self.id, new.id);
+        self.updated = Utc::now();
+        self.address = new.address;
+        self.interval = new.interval;
+    }
+
+    /// Update when we start a collection
+    pub fn start_collection(&mut self) {
+        self.last_collection_started = Some(Utc::now());
+    }
+
+    /// Update when we successfully complete a collection.
+    ///
+    /// # Panics
+    ///
+    /// This panics if no collection was started.
+    pub fn on_success(&mut self, n_samples: u64) {
+        let start = self.last_collection_started.expect("Should have started");
+        let now = Utc::now();
+        self.last_successful_collection = Some(now);
+        self.n_samples_in_last_collection = Some(n_samples);
+        self.last_collection_duration =
+            Some((now - start).to_std().unwrap_or(Duration::ZERO));
+        self.n_collections += 1;
+    }
+
+    /// Update when we fail to complete a collection.
+    ///
+    /// # Panics
+    ///
+    /// This panics if no collection was started.
+    pub fn on_failure(&mut self, reason: impl Into<String>) {
+        assert!(self.last_collection_started.is_some());
+        self.last_failed_collection = Some(Utc::now());
+        self.last_failure_reason = Some(reason.into());
+        self.n_failures += 1;
+    }
 }

--- a/oximeter/collector/src/agent.rs
+++ b/oximeter/collector/src/agent.rs
@@ -989,17 +989,16 @@ impl OximeterAgent {
             return Err(Error::NoSuchProducer { id });
         };
         let (reply_tx, rx) = oneshot::channel();
-        task.inbox
-            .send(CollectionMessage::Details { reply_tx })
-            .await
-            .map_err(|_| {
+        task.inbox.try_send(CollectionMessage::Details { reply_tx }).map_err(
+            |_| {
                 Error::CollectionError(
                     id,
                     String::from(
                         "Failed to send detail request to collection task",
                     ),
                 )
-            })?;
+            },
+        )?;
         drop(tasks);
         rx.await.map_err(|_| {
             Error::CollectionError(

--- a/oximeter/collector/src/http_entrypoints.rs
+++ b/oximeter/collector/src/http_entrypoints.rs
@@ -52,6 +52,19 @@ impl OximeterApi for OximeterApiImpl {
         .map(HttpResponseOk)
     }
 
+    async fn producer_details(
+        request_context: RequestContext<Self::Context>,
+        path: dropshot::Path<ProducerIdPathParams>,
+    ) -> Result<HttpResponseOk<ProducerDetails>, HttpError> {
+        let agent = request_context.context();
+        let producer_id = path.into_inner().producer_id;
+        agent
+            .producer_details(producer_id)
+            .await
+            .map_err(HttpError::from)
+            .map(HttpResponseOk)
+    }
+
     async fn producer_delete(
         request_context: RequestContext<Self::Context>,
         path: dropshot::Path<ProducerIdPathParams>,

--- a/oximeter/collector/src/lib.rs
+++ b/oximeter/collector/src/lib.rs
@@ -65,11 +65,18 @@ pub enum Error {
 
     #[error("Error running standalone")]
     Standalone(#[from] anyhow::Error),
+
+    #[error("No registered producer with id '{id}'")]
+    NoSuchProducer { id: Uuid },
 }
 
 impl From<Error> for HttpError {
     fn from(e: Error) -> Self {
-        HttpError::for_internal_error(e.to_string())
+        if let Error::NoSuchProducer { .. } = e {
+            HttpError::for_not_found(None, e.to_string())
+        } else {
+            HttpError::for_internal_error(e.to_string())
+        }
     }
 }
 

--- a/oximeter/collector/src/self_stats.rs
+++ b/oximeter/collector/src/self_stats.rs
@@ -99,6 +99,21 @@ impl CollectionTaskStats {
         }
     }
 
+    /// Update this information with a new producer endpoint.
+    ///
+    /// # Panics
+    ///
+    /// This panics if `new_info` refers to a different ID.
+    pub fn update(&mut self, new_info: &ProducerEndpoint) {
+        assert_eq!(self.collections.producer_id, new_info.id);
+        self.collections.producer_ip = new_info.address.ip();
+        self.collections.producer_port = new_info.address.port();
+        for each in self.failed_collections.values_mut() {
+            each.producer_ip = new_info.address.ip();
+            each.producer_port = new_info.address.port();
+        }
+    }
+
     pub fn failures_for_reason(
         &mut self,
         reason: FailureReason,


### PR DESCRIPTION
- Add `producer_details` API to `oximeter` collector, which returns information about registration time, update time, and collection summaries.
- Update producer details during collections themselves
- Add `omdb oximeter producer-details` subcommand for printing
- Closes #7125