### PR TITLE
releng: run omicron-package with `--only` (and other small fixes)

### DIFF
--- a/.github/buildomat/jobs/tuf-repo.sh
+++ b/.github/buildomat/jobs/tuf-repo.sh
@@ -58,6 +58,8 @@ rustc --version
 # runs without `--locked` and will update the lockfile.
 cargo tree --locked >/dev/null
 
+export CARGO_INCREMENTAL=0
+
 ptime -m ./tools/install_builder_prerequisites.sh -yp
 source ./tools/include/force-git-over-https.sh
 

--- a/dev-tools/releng/src/main.rs
+++ b/dev-tools/releng/src/main.rs
@@ -460,20 +460,23 @@ async fn main() -> Result<()> {
         )
         .after("omicron-package");
 
-        // omicron-package package
-        jobs.push_command(
-            format!("{}-package", target),
-            Command::new(&omicron_package)
-                .args([
-                    "--target",
-                    target.as_str(),
-                    "--artifacts",
-                    artifacts_path.as_str(),
-                    "package",
-                ])
-                .env_remove("CARGO_MANIFEST_DIR"),
-        )
-        .after(format!("{}-target", target));
+        // `omicron-package package`. We limit this only to the packages
+        // necessary to build the proto area; the rest of the zones are built in
+        // the "zone-package" job.
+        let mut command = Command::new(&omicron_package)
+            .args([
+                "--target",
+                target.as_str(),
+                "--artifacts",
+                artifacts_path.as_str(),
+                "package",
+            ])
+            .env_remove("CARGO_MANIFEST_DIR");
+        for package in target.proto_package_names() {
+            command = command.arg("--only").arg(package);
+        }
+        jobs.push_command(format!("{}-package", target), command)
+            .after(format!("{}-target", target));
 
         // omicron-package stamp
         stamp_packages!(
@@ -541,11 +544,31 @@ async fn main() -> Result<()> {
             .after("helios-setup")
             .after(format!("{}-proto", target));
     }
-    // Build the recovery target after we build the host target. Only one
-    // of these will build at a time since Cargo locks its target directory;
-    // since host-package and host-image both take longer than their recovery
-    // counterparts, this should be the fastest option to go first.
+
+    // Build the recovery image packages after we build the host image packages.
+    // Only one of these will build at a time since Cargo locks its target
+    // directory; since host-package and host-image both take longer than their
+    // recovery counterparts, this should be the fastest option to go first.
     jobs.select("recovery-package").after("host-package");
+    // After that, build the remainder of the zones.
+    let mut command = Command::new(&omicron_package)
+        .args([
+            "--target",
+            Target::Host.as_str(),
+            "--artifacts",
+            Target::Host.artifacts_path(&args).as_str(),
+            "package",
+        ])
+        .env_remove("CARGO_MANIFEST_DIR");
+    for package in TUF_PACKAGES {
+        command = command.arg("--only").arg(package);
+    }
+    jobs.push_command("zone-package", command).after("recovery-package");
+    stamp_packages!("zone-stamp", Target::Host, TUF_PACKAGES)
+        .after("zone-package")
+        .after("host-stamp")
+        .after("recovery-stamp");
+
     if args.host_dataset == args.recovery_dataset {
         // If the datasets are the same, we can't parallelize these.
         jobs.select("recovery-image").after("host-image");
@@ -559,19 +582,17 @@ async fn main() -> Result<()> {
     .after("host-proto");
     jobs.select("host-image").after("host-profile");
 
-    stamp_packages!("tuf-stamp", Target::Host, TUF_PACKAGES)
-        .after("host-stamp")
-        .after("recovery-stamp");
-
-    // Run `cargo xtask verify-libraries --release`. (This was formerly run in
-    // the build-and-test Buildomat job, but this fits better here where we've
-    // already built most of the binaries.)
+    // Run `cargo xtask verify-libraries --release`. This ends up building all
+    // the remaining binaries in the workspace that are not shipped. (This was
+    // formerly run in the build-and-test Buildomat job, but this fits better
+    // here where we've already built most of the binaries.)
     jobs.push_command(
         "verify-libraries",
         Command::new(&cargo).args(["xtask", "verify-libraries", "--release"]),
     )
     .after("host-package")
-    .after("recovery-package");
+    .after("recovery-package")
+    .after("zone-package");
 
     for (name, base_url) in [
         ("staging", "https://permslip-staging.corp.oxide.computer"),
@@ -599,7 +620,7 @@ async fn main() -> Result<()> {
             args.extra_manifest,
         ),
     )
-    .after("tuf-stamp")
+    .after("zone-stamp")
     .after("host-image")
     .after("recovery-image")
     .after("hubris-staging")

--- a/dev-tools/xtask/src/main.rs
+++ b/dev-tools/xtask/src/main.rs
@@ -142,6 +142,8 @@ fn main() -> Result<()> {
         Cmds::Openapi(external) => external.exec_bin("openapi-manager"),
         #[cfg(target_os = "illumos")]
         Cmds::Releng(external) => {
+            // Build releng with the release profile, as most of its deps will
+            // be built with `--release` by build tooling anyway.
             external.cargo_args(["--release"]).exec_bin("omicron-releng")
         }
         #[cfg(target_os = "illumos")]

--- a/nexus/tests/test_all.rs
+++ b/nexus/tests/test_all.rs
@@ -5,9 +5,10 @@
 //! Integration test driver
 //!
 //! All integration tests are driven from this top-level integration test so
-//! that we only have to build one target and so that Cargo can run the tests
-//! concurrently.  (Currently, Cargo runs separate integration tests
-//! sequentially.)
+//! that we only have to build one target. This was originally done because
+//! `cargo test` does not parallelize across targets. We continue to do this
+//! because any targets depending on omicron-nexus as a library are very
+//! expensive to link, and it is better to only have to do that once.
 
 #[macro_use]
 extern crate slog;


### PR DESCRIPTION
This is a late follow-up to #5799 that I've had lying around in a branch for a while. We now instruct omicron-package to instruct Cargo to only build the binaries we actually want for that particular stage of the releng process. This has the effect of allowing the OS images to build while Cargo is busy building Nexus, for instance.

This does not improve the speed for the CI job significantly, but does show some improvements in local incremental rebuilds. There is some straggling time once the TUF repo is built running `cargo xtask verify-libraries --release` that can reduce time-to-TUF-repo by a few more minutes by making our check there more correct (see #7149).