### PR TITLE
Retry OxQL queries in integration tests

### DIFF
--- a/nexus/tests/integration_tests/metrics.rs
+++ b/nexus/tests/integration_tests/metrics.rs
@@ -313,10 +313,12 @@ pub async fn timeseries_query_until_success(
         &Duration::from_secs(30),
     )
     .await
-    .expect(&format!(
-        "Timeseries named in query are not available, query: '{}'",
-        query.to_string(),
-    ))
+    .unwrap_or_else(|_| {
+        panic!(
+            "Timeseries named in query are not available, query: '{}'",
+            query.to_string(),
+        )
+    })
 }
 
 /// Run an OxQL query.


### PR DESCRIPTION
Adds a small `wait_for_condition()` loop to OxQL queries in integration tests. This tries to catch the error where the query fails specifically because the timeseries it names is not yet available, and return `None` in these cases. We expect it to appear soon, so this isn't immediately fatal.

Fixes #7154 and #7084.