### PR TITLE
Ensure services do not start in /root

### DIFF
--- a/smf/chrony-setup/manifest.xml
+++ b/smf/chrony-setup/manifest.xml
@@ -14,7 +14,7 @@
   <exec_method type='method' name='start'
     exec='/opt/oxide/zone-setup-cli/bin/zone-setup chrony-setup -b %{config/boundary} -p %{config/boundary_pool} -s %{config/server} -a %{config/allow}'
     timeout_seconds='0'>
-  <method_context security_flags="aslr">
+  <method_context security_flags="aslr" working_directory="/">
   <method_credential user="root" group="root"
     privileges="basic,file_chown" />
   </method_context>

--- a/smf/cockroachdb/manifest.xml
+++ b/smf/cockroachdb/manifest.xml
@@ -19,7 +19,7 @@
   <exec_method type='method' name='start'
     exec='/opt/oxide/lib/svc/manifest/cockroachdb.sh'
     timeout_seconds='0'>
-    <method_context>
+    <method_context working_directory="/">
       <method_environment>
         <envvar name="GOTRACEBACK" value="crash" />
       </method_environment>

--- a/smf/ntp/manifest/manifest.xml
+++ b/smf/ntp/manifest/manifest.xml
@@ -66,7 +66,7 @@
   <exec_method type="method" name="start"
     exec='/usr/sbin/chronyd -d &amp;'
     timeout_seconds="60">
-  <method_context security_flags="aslr">
+  <method_context security_flags="aslr" working_directory="/">
   <method_credential user="root" group="root"
     privileges="basic,!file_link_any,!proc_info,!proc_session,file_chown_self,file_dac_search,file_dac_write,net_privaddr,proc_lock_memory,proc_priocntl,proc_setid,sys_time" />
   </method_context>


### PR DESCRIPTION
By default, an SMF service which has a non-trivial context will start
in the user's home directory. For services started as 'root' this means
/root. While a lot of services will subsequently chdir elsewhere, we
want to avoid anything using /root, even briefly, as it will soon be a
separate ZFS dataset on an Oxide system.
