### PR TITLE
[sled-agent] Correctly install nat/router IGW tags during create.

### DIFF
--- a/sled-agent/src/instance.rs
+++ b/sled-agent/src/instance.rs
@@ -1708,7 +1708,6 @@ impl InstanceRunner {
                 floating_ips,
                 firewall_rules: &self.firewall_rules,
                 dhcp_config: self.dhcp_config.clone(),
-                is_service: false,
             })?;
             opte_port_names.push(port.0.name().to_string());
             opte_ports.push(port);

--- a/sled-agent/src/probe_manager.rs
+++ b/sled-agent/src/probe_manager.rs
@@ -321,7 +321,6 @@ impl ProbeManagerInner {
                 priority: VpcFirewallRulePriority(100),
             }],
             dhcp_config: DhcpCfg::default(),
-            is_service: false,
         })?;
 
         let installed_zone = ZoneBuilderFactory::default()

--- a/sled-agent/src/services.rs
+++ b/sled-agent/src/services.rs
@@ -1239,7 +1239,6 @@ impl ServiceManager {
                 floating_ips,
                 firewall_rules: &[],
                 dhcp_config: DhcpCfg::default(),
-                is_service: true,
             })
             .map_err(|err| Error::ServicePortCreation {
                 service: zone_kind,


### PR DESCRIPTION
Instances could come up with inconsistently tagged Internet Gateway mappings between their `nat` and `router` OPTE port layers. This manifested in two ways.

1) All ports were deliberately created without IGW tags in the router
   layer iff. an existing router was found. The expectation was that the
   control plane would send a router update with the correct values and
   update them if the port belonged to an instance. However it never did
   so -- the version would not have increased, as the baseline router
   was already complete and accurate.
2) There are cases where a stopped and restarted instance may have an
   existing EIP<->IGW mapping that is not removed in time. Thus, no change
   is detected when Nexus informs sled-agent of its new NIC's state. We
   were not filling this information during creation under the
   assumption that Nexus's insert would always be accepted.

In both cases, it should be stressed that we cannot just insert either state every minute via task -- this constitutes a port lock on OPTE (holding up all packets and possibly invalidating UFT entries).

This PR closes both those holes by amending the first oversight and filling `nat` mpping information at create-time.

Fixes #7165.