### PR TITLE
[test][omdb] Wait for producer registration before listing them

### DIFF
--- a/dev-tools/omdb/tests/test_all_output.rs
+++ b/dev-tools/omdb/tests/test_all_output.rs
@@ -10,6 +10,7 @@
 use dropshot::Method;
 use expectorate::assert_contents;
 use http::StatusCode;
+use nexus_test_utils::wait_for_producer;
 use nexus_test_utils::{OXIMETER_UUID, PRODUCER_UUID};
 use nexus_test_utils_macros::nexus_test;
 use nexus_types::deployment::Blueprint;
@@ -23,6 +24,7 @@ use std::fmt::Write;
 use std::net::IpAddr;
 use std::path::Path;
 use subprocess::Exec;
+use uuid::Uuid;
 
 /// name of the "omdb" executable
 const CMD_OMDB: &str = env!("CARGO_BIN_EXE_omdb");
@@ -274,6 +276,11 @@ async fn test_omdb_success_cases(cptestctx: &ControlPlaneTestContext) {
     let mut ox_output = String::new();
     let ox = ox_url.clone();
 
+    wait_for_producer(
+        &cptestctx.oximeter,
+        PRODUCER_UUID.parse::<Uuid>().unwrap(),
+    )
+    .await;
     do_run_no_redactions(
         &mut ox_output,
         move |exec| exec.env("OMDB_OXIMETER_URL", &ox),
@@ -423,6 +430,11 @@ async fn test_omdb_env_settings(cptestctx: &ControlPlaneTestContext) {
     // Case 2: is covered by the success tests above.
     let ox_args1 = &["oximeter", "--oximeter-url", &ox_url, "list-producers"];
     let mut ox_output1 = String::new();
+    wait_for_producer(
+        &cptestctx.oximeter,
+        PRODUCER_UUID.parse::<Uuid>().unwrap(),
+    )
+    .await;
     do_run_no_redactions(
         &mut ox_output1,
         move |exec| exec,

--- a/nexus/tests/integration_tests/disks.rs
+++ b/nexus/tests/integration_tests/disks.rs
@@ -4,8 +4,6 @@
 
 //! Tests basic disk support in the API
 
-use crate::integration_tests::metrics::wait_for_producer;
-
 use super::instances::instance_wait_for_state;
 use super::metrics::{get_latest_silo_metric, query_for_metrics};
 use chrono::Utc;
@@ -32,6 +30,7 @@ use nexus_test_utils::resource_helpers::create_instance;
 use nexus_test_utils::resource_helpers::create_instance_with;
 use nexus_test_utils::resource_helpers::create_project;
 use nexus_test_utils::resource_helpers::objects_list_page_authz;
+use nexus_test_utils::wait_for_producer;
 use nexus_test_utils::SLED_AGENT_UUID;
 use nexus_test_utils_macros::nexus_test;
 use nexus_types::external_api::params;

--- a/nexus/tests/integration_tests/instances.rs
+++ b/nexus/tests/integration_tests/instances.rs
@@ -4,8 +4,6 @@
 
 //! Tests basic instance support in the API
 
-use crate::integration_tests::metrics::wait_for_producer;
-
 use super::external_ips::floating_ip_get;
 use super::external_ips::get_floating_ip_by_id_url;
 use super::metrics::{get_latest_silo_metric, get_latest_system_metric};
@@ -39,6 +37,7 @@ use nexus_test_utils::resource_helpers::object_put;
 use nexus_test_utils::resource_helpers::objects_list_page_authz;
 use nexus_test_utils::resource_helpers::DiskTest;
 use nexus_test_utils::start_sled_agent;
+use nexus_test_utils::wait_for_producer;
 use nexus_types::external_api::params::SshKeyCreate;
 use nexus_types::external_api::shared::IpKind;
 use nexus_types::external_api::shared::IpRange;

--- a/nexus/tests/integration_tests/oximeter.rs
+++ b/nexus/tests/integration_tests/oximeter.rs
@@ -4,8 +4,8 @@
 
 //! Integration tests for oximeter collectors and producers.
 
-use crate::integration_tests::metrics::wait_for_producer;
 use nexus_test_interface::NexusServer;
+use nexus_test_utils::wait_for_producer;
 use nexus_test_utils_macros::nexus_test;
 use omicron_test_utils::dev::poll::{wait_for_condition, CondCheckError};
 use oximeter_db::DbWrite;


### PR DESCRIPTION
Refactors "wait_for_producer" into nexus-test-utils so it can be used by omdb, outside the nexus integration test suite.

Fixes https://github.com/oxidecomputer/omicron/issues/7182