### PR TITLE
[oximeter] Don't stop refreshing producers forever if one attempt fails

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -7839,6 +7839,7 @@ dependencies = [
  "slog",
  "slog-async",
  "slog-dtrace",
+ "slog-error-chain",
  "slog-term",
  "strum",
  "subprocess",

--- a/oximeter/collector/Cargo.toml
+++ b/oximeter/collector/Cargo.toml
@@ -32,6 +32,7 @@ semver.workspace = true
 serde.workspace = true
 slog.workspace = true
 slog-async.workspace = true
+slog-error-chain.workspace = true
 slog-dtrace.workspace = true
 slog-term.workspace = true
 strum.workspace = true


### PR DESCRIPTION
#7126 introduced a `return;` inside `refresh_producer_list` to avoid clobbering our producer list on an error talking to Nexus, but `refresh_producer_list` had _two_ loops: it was both "do one refresh" (from which `return`ing is correct) and also "periodically refresh" (from which `return`ing is incorrect: it causes us to never refresh again).

This PR splits `refresh_producer_list` into `refresh_producer_list_{task,once}`; strongly recommend looking at the diff with whitespace ignored, as it's basically a no-op other than this split (which makes the `return` correct, as it only terminates a single refresh and not all future ones).

I also added some `InlineErrorChain` bits to try to get more info from logged errors.

Fixes #7190.