### PR TITLE
[clickhouse] Fix integration test setup script

### DIFF
--- a/dev-tools/clickhouse-cluster-dev/src/main.rs
+++ b/dev-tools/clickhouse-cluster-dev/src/main.rs
@@ -22,6 +22,12 @@ use std::time::Duration;
 async fn main() -> Result<()> {
     let request_timeout = Duration::from_secs(15);
     let (logctx, path) = default_clickhouse_log_ctx_and_path();
+    
+    if path.exists() {
+        slog::info!(logctx.log, "Removing previous temporary test directory");
+        std::fs::remove_dir_all(&path)?;
+    }
+
     std::fs::create_dir(&path)?;
 
     slog::info!(logctx.log, "Setting up a ClickHouse cluster");

--- a/dev-tools/clickhouse-cluster-dev/src/main.rs
+++ b/dev-tools/clickhouse-cluster-dev/src/main.rs
@@ -24,6 +24,10 @@ async fn main() -> Result<()> {
     let (logctx, path) = default_clickhouse_log_ctx_and_path();
 
     if path.exists() {
+        let deployment =
+            default_clickhouse_cluster_test_deployment(path.clone());
+        slog::info!(logctx.log, "Stopping test clickhouse nodes");
+        deployment.teardown()?;
         slog::info!(logctx.log, "Removing previous temporary test directory");
         std::fs::remove_dir_all(&path)?;
     }

--- a/dev-tools/clickhouse-cluster-dev/src/main.rs
+++ b/dev-tools/clickhouse-cluster-dev/src/main.rs
@@ -22,7 +22,7 @@ use std::time::Duration;
 async fn main() -> Result<()> {
     let request_timeout = Duration::from_secs(15);
     let (logctx, path) = default_clickhouse_log_ctx_and_path();
-    
+
     if path.exists() {
         slog::info!(logctx.log, "Removing previous temporary test directory");
         std::fs::remove_dir_all(&path)?;


### PR DESCRIPTION
Tested this manually by running the tests first to make sure happy path doesn't change:

```console
$ cargo nextest run -p omicron-clickhouse-admin
info: experimental features enabled: setup-scripts
    Finished `test` profile [unoptimized + debuginfo] target(s) in 5.86s
------------
 Nextest run ID 700e33bd-e5dc-43fe-9fe7-4c79e4cf3884 with nextest profile: default
    Starting 5 tests across 5 binaries
       SETUP [      1/1] clickhouse-cluster: cargo run -p clickhouse-cluster-dev
             [ 00:00:00] [                                                                                                                        ] 0/5:         Compiling clickhouse-cluster-dev v0.1.0 (/Users/karcar/src/omicron/dev-tools/clickhouse-cluster-dev)
    Finished `dev` profile [unoptimized + debuginfo] target(s) in 0.91s
     Running `target/debug/clickhouse-cluster-dev`
Dec 03 22:41:25.258 INFO Setting up a ClickHouse cluster
Deploying keeper: /var/folders/mk/l_57z4w97xlc7wymyvc7mwzr0000gn/T/clickward_test/keeper-1
Deploying keeper: /var/folders/mk/l_57z4w97xlc7wymyvc7mwzr0000gn/T/clickward_test/keeper-3
Deploying keeper: /var/folders/mk/l_57z4w97xlc7wymyvc7mwzr0000gn/T/clickward_test/keeper-2
Deploying clickhouse server: /var/folders/mk/l_57z4w97xlc7wymyvc7mwzr0000gn/T/clickward_test/clickhouse-1
Deploying clickhouse server: /var/folders/mk/l_57z4w97xlc7wymyvc7mwzr0000gn/T/clickward_test/clickhouse-2
Dec 03 22:41:26.348 INFO ClickHouse server ready
Dec 03 22:41:26.348 INFO ClickHouse server ready
Dec 03 22:41:28.594 INFO Keepers ready: [KeeperId(1), KeeperId(2), KeeperId(3)]
  SETUP PASS [      1/1] clickhouse-cluster: cargo run -p clickhouse-cluster-dev
        PASS [   1.324s] omicron-clickhouse-admin::integration_test test_keeper_cluster_membership
        PASS [   0.446s] omicron-clickhouse-admin::integration_test test_keeper_conf_parsing
        PASS [   0.441s] omicron-clickhouse-admin::integration_test test_lgif_parsing
        PASS [   0.452s] omicron-clickhouse-admin::integration_test test_raft_config_parsing
        PASS [   0.039s] omicron-clickhouse-admin::integration_test test_teardown
------------
     Summary [   7.298s] 5 tests run: 5 passed, 0 skipped

```

Then interrupted a test run to make sure to leave the directory and files behind

```console
$ cargo nextest run -p omicron-clickhouse-admin
info: experimental features enabled: setup-scripts
   Compiling omicron-clickhouse-admin v0.1.0 (/Users/karcar/src/omicron/clickhouse-admin)
    Finished `test` profile [unoptimized + debuginfo] target(s) in 0.96s
------------
 Nextest run ID 787a3f0e-b480-4433-9570-9c61bd9ea08e with nextest profile: default
    Starting 5 tests across 5 binaries
       SETUP [      1/1] clickhouse-cluster: cargo run -p clickhouse-cluster-dev
             [ 00:00:00] [                                                                                                                        ] 0/5:          Finished `dev` profile [unoptimized + debuginfo] target(s) in 0.32s
     Running `target/debug/clickhouse-cluster-dev`
Dec 03 22:42:55.011 INFO Setting up a ClickHouse cluster
Deploying keeper: /var/folders/mk/l_57z4w97xlc7wymyvc7mwzr0000gn/T/clickward_test/keeper-1
Deploying keeper: /var/folders/mk/l_57z4w97xlc7wymyvc7mwzr0000gn/T/clickward_test/keeper-3
Deploying keeper: /var/folders/mk/l_57z4w97xlc7wymyvc7mwzr0000gn/T/clickward_test/keeper-2
Deploying clickhouse server: /var/folders/mk/l_57z4w97xlc7wymyvc7mwzr0000gn/T/clickward_test/clickhouse-1
Deploying clickhouse server: /var/folders/mk/l_57z4w97xlc7wymyvc7mwzr0000gn/T/clickward_test/clickhouse-2
Dec 03 22:42:55.993 INFO ClickHouse server ready
Dec 03 22:42:56.130 INFO ClickHouse server ready
Dec 03 22:42:57.925 INFO Keepers ready: [KeeperId(1), KeeperId(2), KeeperId(3)]
  SETUP PASS [      1/1] clickhouse-cluster: cargo run -p clickhouse-cluster-dev
     Running [ 00:00:04] [                                                                                          ] 0/5: 1 running, 0 passed, 0 skipped        Canceling due to interrupt: 1 test still running
      SIGINT [   0.906s] omicron-clickhouse-admin::integration_test test_keeper_cluster_membership
------------
     Summary [   4.460s] 1/5 tests run: 0 passed, 1 failed, 0 skipped
warning: 4/5 tests were not run due to interrupt
error: test run failed
```

Ran the tests again and expected to see in the log that the directory is being removed

```console
$ cargo nextest run -p omicron-clickhouse-admin
info: experimental features enabled: setup-scripts
    Finished `test` profile [unoptimized + debuginfo] target(s) in 0.34s
------------
 Nextest run ID 0302644b-d97b-4bd2-bae3-edc4976a9298 with nextest profile: default
    Starting 5 tests across 5 binaries
       SETUP [      1/1] clickhouse-cluster: cargo run -p clickhouse-cluster-dev
             [ 00:00:00] [                                                                                                                        ] 0/5:          Finished `dev` profile [unoptimized + debuginfo] target(s) in 0.32s
     Running `target/debug/clickhouse-cluster-dev`
Dec 03 22:44:10.996 INFO Removing previous temporary test directory
Dec 03 22:44:11.019 INFO Setting up a ClickHouse cluster
Deploying keeper: /var/folders/mk/l_57z4w97xlc7wymyvc7mwzr0000gn/T/clickward_test/keeper-1
Deploying keeper: /var/folders/mk/l_57z4w97xlc7wymyvc7mwzr0000gn/T/clickward_test/keeper-3
Deploying keeper: /var/folders/mk/l_57z4w97xlc7wymyvc7mwzr0000gn/T/clickward_test/keeper-2
Deploying clickhouse server: /var/folders/mk/l_57z4w97xlc7wymyvc7mwzr0000gn/T/clickward_test/clickhouse-1
Deploying clickhouse server: /var/folders/mk/l_57z4w97xlc7wymyvc7mwzr0000gn/T/clickward_test/clickhouse-2
Dec 03 22:44:12.016 INFO ClickHouse server ready
Dec 03 22:44:12.018 INFO ClickHouse server ready
Dec 03 22:44:13.806 INFO Keepers ready: [KeeperId(1), KeeperId(2), KeeperId(3)]
  SETUP PASS [      1/1] clickhouse-cluster: cargo run -p clickhouse-cluster-dev
        PASS [   1.324s] omicron-clickhouse-admin::integration_test test_keeper_cluster_membership
        PASS [   0.444s] omicron-clickhouse-admin::integration_test test_keeper_conf_parsing
        PASS [   0.445s] omicron-clickhouse-admin::integration_test test_lgif_parsing
        PASS [   0.441s] omicron-clickhouse-admin::integration_test test_raft_config_parsing
        PASS [   0.035s] omicron-clickhouse-admin::integration_test test_teardown
------------
     Summary [   6.116s] 5 tests run: 5 passed, 0 skipped

```

Closes: https://github.com/oxidecomputer/omicron/issues/7198