### PR TITLE
Crucible and Propolis update

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -693,7 +693,7 @@ dependencies = [
 [[package]]
 name = "bhyve_api"
 version = "0.0.0"
-source = "git+https://github.com/oxidecomputer/propolis?rev=6936f1a949d155da38d3148abd42caef337dea04#6936f1a949d155da38d3148abd42caef337dea04"
+source = "git+https://github.com/oxidecomputer/propolis?rev=19a421dceac7756aef26a8771f258af9cc21fc37#19a421dceac7756aef26a8771f258af9cc21fc37"
 dependencies = [
  "bhyve_api_sys",
  "libc",
@@ -703,7 +703,7 @@ dependencies = [
 [[package]]
 name = "bhyve_api_sys"
 version = "0.0.0"
-source = "git+https://github.com/oxidecomputer/propolis?rev=6936f1a949d155da38d3148abd42caef337dea04#6936f1a949d155da38d3148abd42caef337dea04"
+source = "git+https://github.com/oxidecomputer/propolis?rev=19a421dceac7756aef26a8771f258af9cc21fc37#19a421dceac7756aef26a8771f258af9cc21fc37"
 dependencies = [
  "libc",
  "strum",
@@ -1822,7 +1822,7 @@ dependencies = [
 [[package]]
 name = "crucible-agent-client"
 version = "0.0.1"
-source = "git+https://github.com/oxidecomputer/crucible?rev=2cfc7e0c8572b3bfafbfc838c4e6d658f442d239#2cfc7e0c8572b3bfafbfc838c4e6d658f442d239"
+source = "git+https://github.com/oxidecomputer/crucible?rev=5a41b826171c7d2a8412fa833377ab1df25ee8ec#5a41b826171c7d2a8412fa833377ab1df25ee8ec"
 dependencies = [
  "anyhow",
  "chrono",
@@ -1838,7 +1838,7 @@ dependencies = [
 [[package]]
 name = "crucible-client-types"
 version = "0.1.0"
-source = "git+https://github.com/oxidecomputer/crucible?rev=2cfc7e0c8572b3bfafbfc838c4e6d658f442d239#2cfc7e0c8572b3bfafbfc838c4e6d658f442d239"
+source = "git+https://github.com/oxidecomputer/crucible?rev=5a41b826171c7d2a8412fa833377ab1df25ee8ec#5a41b826171c7d2a8412fa833377ab1df25ee8ec"
 dependencies = [
  "base64 0.22.1",
  "crucible-workspace-hack",
@@ -1851,7 +1851,7 @@ dependencies = [
 [[package]]
 name = "crucible-common"
 version = "0.0.1"
-source = "git+https://github.com/oxidecomputer/crucible?rev=2cfc7e0c8572b3bfafbfc838c4e6d658f442d239#2cfc7e0c8572b3bfafbfc838c4e6d658f442d239"
+source = "git+https://github.com/oxidecomputer/crucible?rev=5a41b826171c7d2a8412fa833377ab1df25ee8ec#5a41b826171c7d2a8412fa833377ab1df25ee8ec"
 dependencies = [
  "anyhow",
  "atty",
@@ -1881,7 +1881,7 @@ dependencies = [
 [[package]]
 name = "crucible-pantry-client"
 version = "0.0.1"
-source = "git+https://github.com/oxidecomputer/crucible?rev=2cfc7e0c8572b3bfafbfc838c4e6d658f442d239#2cfc7e0c8572b3bfafbfc838c4e6d658f442d239"
+source = "git+https://github.com/oxidecomputer/crucible?rev=5a41b826171c7d2a8412fa833377ab1df25ee8ec#5a41b826171c7d2a8412fa833377ab1df25ee8ec"
 dependencies = [
  "anyhow",
  "chrono",
@@ -1898,7 +1898,7 @@ dependencies = [
 [[package]]
 name = "crucible-smf"
 version = "0.0.0"
-source = "git+https://github.com/oxidecomputer/crucible?rev=2cfc7e0c8572b3bfafbfc838c4e6d658f442d239#2cfc7e0c8572b3bfafbfc838c4e6d658f442d239"
+source = "git+https://github.com/oxidecomputer/crucible?rev=5a41b826171c7d2a8412fa833377ab1df25ee8ec#5a41b826171c7d2a8412fa833377ab1df25ee8ec"
 dependencies = [
  "crucible-workspace-hack",
  "libc",
@@ -6980,7 +6980,7 @@ dependencies = [
  "pq-sys",
  "pretty_assertions",
  "progenitor-client",
- "propolis-client 0.1.0 (git+https://github.com/oxidecomputer/propolis?rev=6936f1a949d155da38d3148abd42caef337dea04)",
+ "propolis-client 0.1.0 (git+https://github.com/oxidecomputer/propolis?rev=19a421dceac7756aef26a8771f258af9cc21fc37)",
  "qorb",
  "rand",
  "rcgen",
@@ -7245,7 +7245,7 @@ dependencies = [
  "oximeter-producer",
  "oxnet",
  "pretty_assertions",
- "propolis-client 0.1.0 (git+https://github.com/oxidecomputer/propolis?rev=6936f1a949d155da38d3148abd42caef337dea04)",
+ "propolis-client 0.1.0 (git+https://github.com/oxidecomputer/propolis?rev=19a421dceac7756aef26a8771f258af9cc21fc37)",
  "propolis-mock-server",
  "propolis_api_types",
  "rand",
@@ -8959,7 +8959,7 @@ dependencies = [
 [[package]]
 name = "propolis-client"
 version = "0.1.0"
-source = "git+https://github.com/oxidecomputer/propolis?rev=6936f1a949d155da38d3148abd42caef337dea04#6936f1a949d155da38d3148abd42caef337dea04"
+source = "git+https://github.com/oxidecomputer/propolis?rev=19a421dceac7756aef26a8771f258af9cc21fc37#19a421dceac7756aef26a8771f258af9cc21fc37"
 dependencies = [
  "async-trait",
  "base64 0.21.7",
@@ -9001,7 +9001,7 @@ dependencies = [
 [[package]]
 name = "propolis-mock-server"
 version = "0.0.0"
-source = "git+https://github.com/oxidecomputer/propolis?rev=6936f1a949d155da38d3148abd42caef337dea04#6936f1a949d155da38d3148abd42caef337dea04"
+source = "git+https://github.com/oxidecomputer/propolis?rev=19a421dceac7756aef26a8771f258af9cc21fc37#19a421dceac7756aef26a8771f258af9cc21fc37"
 dependencies = [
  "anyhow",
  "atty",
@@ -9043,7 +9043,7 @@ dependencies = [
 [[package]]
 name = "propolis_api_types"
 version = "0.0.0"
-source = "git+https://github.com/oxidecomputer/propolis?rev=6936f1a949d155da38d3148abd42caef337dea04#6936f1a949d155da38d3148abd42caef337dea04"
+source = "git+https://github.com/oxidecomputer/propolis?rev=19a421dceac7756aef26a8771f258af9cc21fc37#19a421dceac7756aef26a8771f258af9cc21fc37"
 dependencies = [
  "crucible-client-types",
  "propolis_types",
@@ -9056,7 +9056,7 @@ dependencies = [
 [[package]]
 name = "propolis_types"
 version = "0.0.0"
-source = "git+https://github.com/oxidecomputer/propolis?rev=6936f1a949d155da38d3148abd42caef337dea04#6936f1a949d155da38d3148abd42caef337dea04"
+source = "git+https://github.com/oxidecomputer/propolis?rev=19a421dceac7756aef26a8771f258af9cc21fc37#19a421dceac7756aef26a8771f258af9cc21fc37"
 dependencies = [
  "schemars",
  "serde",
@@ -10719,7 +10719,7 @@ dependencies = [
  "omicron-uuid-kinds",
  "omicron-workspace-hack",
  "oxnet",
- "propolis-client 0.1.0 (git+https://github.com/oxidecomputer/propolis?rev=6936f1a949d155da38d3148abd42caef337dea04)",
+ "propolis-client 0.1.0 (git+https://github.com/oxidecomputer/propolis?rev=19a421dceac7756aef26a8771f258af9cc21fc37)",
  "rcgen",
  "schemars",
  "serde",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -346,10 +346,10 @@ cookie = "0.18"
 criterion = { version = "0.5.1", features = [ "async_tokio" ] }
 crossbeam = "0.8"
 crossterm = { version = "0.28.1", features = ["event-stream"] }
-crucible-agent-client = { git = "https://github.com/oxidecomputer/crucible", rev = "2cfc7e0c8572b3bfafbfc838c4e6d658f442d239" }
-crucible-pantry-client = { git = "https://github.com/oxidecomputer/crucible", rev = "2cfc7e0c8572b3bfafbfc838c4e6d658f442d239" }
-crucible-smf = { git = "https://github.com/oxidecomputer/crucible", rev = "2cfc7e0c8572b3bfafbfc838c4e6d658f442d239" }
-crucible-common = { git = "https://github.com/oxidecomputer/crucible", rev = "2cfc7e0c8572b3bfafbfc838c4e6d658f442d239" }
+crucible-agent-client = { git = "https://github.com/oxidecomputer/crucible", rev = "5a41b826171c7d2a8412fa833377ab1df25ee8ec" }
+crucible-pantry-client = { git = "https://github.com/oxidecomputer/crucible", rev = "5a41b826171c7d2a8412fa833377ab1df25ee8ec" }
+crucible-smf = { git = "https://github.com/oxidecomputer/crucible", rev = "5a41b826171c7d2a8412fa833377ab1df25ee8ec" }
+crucible-common = { git = "https://github.com/oxidecomputer/crucible", rev = "5a41b826171c7d2a8412fa833377ab1df25ee8ec" }
 csv = "1.3.0"
 curve25519-dalek = "4"
 datatest-stable = "0.2.9"
@@ -539,10 +539,10 @@ prettyplease = { version = "0.2.25", features = ["verbatim"] }
 proc-macro2 = "1.0"
 progenitor = "0.8.0"
 progenitor-client = "0.8.0"
-bhyve_api = { git = "https://github.com/oxidecomputer/propolis", rev = "6936f1a949d155da38d3148abd42caef337dea04" }
-propolis_api_types = { git = "https://github.com/oxidecomputer/propolis", rev = "6936f1a949d155da38d3148abd42caef337dea04" }
-propolis-client = { git = "https://github.com/oxidecomputer/propolis", rev = "6936f1a949d155da38d3148abd42caef337dea04" }
-propolis-mock-server = { git = "https://github.com/oxidecomputer/propolis", rev = "6936f1a949d155da38d3148abd42caef337dea04" }
+bhyve_api = { git = "https://github.com/oxidecomputer/propolis", rev = "19a421dceac7756aef26a8771f258af9cc21fc37" }
+propolis_api_types = { git = "https://github.com/oxidecomputer/propolis", rev = "19a421dceac7756aef26a8771f258af9cc21fc37" }
+propolis-client = { git = "https://github.com/oxidecomputer/propolis", rev = "19a421dceac7756aef26a8771f258af9cc21fc37" }
+propolis-mock-server = { git = "https://github.com/oxidecomputer/propolis", rev = "19a421dceac7756aef26a8771f258af9cc21fc37" }
 proptest = "1.5.0"
 qorb = "0.2.1"
 quote = "1.0"

--- a/package-manifest.toml
+++ b/package-manifest.toml
@@ -578,10 +578,10 @@ only_for_targets.image = "standard"
 # 3. Use source.type = "manual" instead of "prebuilt"
 source.type = "prebuilt"
 source.repo = "crucible"
-source.commit = "2cfc7e0c8572b3bfafbfc838c4e6d658f442d239"
+source.commit = "5a41b826171c7d2a8412fa833377ab1df25ee8ec"
 # The SHA256 digest is automatically posted to:
 # https://buildomat.eng.oxide.computer/public/file/oxidecomputer/crucible/image/<commit>/crucible.sha256.txt
-source.sha256 = "0276c1513b33c61c866eb31756879e9d079534f43af90b01c0a2dd152c6ce18d"
+source.sha256 = "bcccfb03a68e46bb958410faf6f619e25f5ec9ccc65c503aeb87bb7ad456e517"
 output.type = "zone"
 output.intermediate_only = true
 
@@ -590,10 +590,10 @@ service_name = "crucible_pantry_prebuilt"
 only_for_targets.image = "standard"
 source.type = "prebuilt"
 source.repo = "crucible"
-source.commit = "2cfc7e0c8572b3bfafbfc838c4e6d658f442d239"
+source.commit = "5a41b826171c7d2a8412fa833377ab1df25ee8ec"
 # The SHA256 digest is automatically posted to:
 # https://buildomat.eng.oxide.computer/public/file/oxidecomputer/crucible/image/<commit>/crucible-pantry.sha256.txt
-source.sha256 = "7ad4f84df681f5ccd90bd74473a17a0e1310f562bfd0c08047aad6adbd131903"
+source.sha256 = "96326422f79413fe31bb1c7df6173b2991b463cabc5b1fb4182db703500c8882"
 output.type = "zone"
 output.intermediate_only = true
 
@@ -607,10 +607,10 @@ service_name = "crucible_dtrace"
 only_for_targets.image = "standard"
 source.type = "prebuilt"
 source.repo = "crucible"
-source.commit = "2cfc7e0c8572b3bfafbfc838c4e6d658f442d239"
+source.commit = "5a41b826171c7d2a8412fa833377ab1df25ee8ec"
 # The SHA256 digest is automatically posted to:
 # https://buildomat.eng.oxide.computer/public/file/oxidecomputer/crucible/image/<commit>/crucible-dtrace.sha256.txt
-source.sha256 = "dac88622ecf6e3529b9d83390607c921723eca26de68b0801efd66c36acfa629"
+source.sha256 = "d35ed81a1e58ec66b621938f4b57513c1a3eb0b66e21834e000e0ace9624b462"
 output.type = "tarball"
 
 # Refer to
@@ -621,10 +621,10 @@ service_name = "propolis-server"
 only_for_targets.image = "standard"
 source.type = "prebuilt"
 source.repo = "propolis"
-source.commit = "6936f1a949d155da38d3148abd42caef337dea04"
+source.commit = "19a421dceac7756aef26a8771f258af9cc21fc37"
 # The SHA256 digest is automatically posted to:
 # https://buildomat.eng.oxide.computer/public/file/oxidecomputer/propolis/image/<commit>/propolis-server.sha256.txt
-source.sha256 = "a3a45292bd45938a785b84afee39f690a5f05d1920b78b8fc0512a131857d7ee"
+source.sha256 = "fbb52fed6312db047a7f56d43162e5d4c5072886a23b5e6a0096f6db78c5d2ba"
 output.type = "zone"
 
 [package.mg-ddm-gz]


### PR DESCRIPTION
Crucible:
Skip jobs when reinitializing to `Faulted` (#1583)
Clear `repair_check_deadline` if repair is successfully started (#1581)
Update rust-version reqs to reflect reality (#1580)

Propolis:
Update nvme-trace.d to match current probe definitions (#821) 
Fix clippy lints for Rust 1.83
PHD: use stty to widen the effective terminal for Linux guests (#818)