### PR TITLE
Update Propolis

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -693,7 +693,7 @@ dependencies = [
 [[package]]
 name = "bhyve_api"
 version = "0.0.0"
-source = "git+https://github.com/oxidecomputer/propolis?rev=19a421dceac7756aef26a8771f258af9cc21fc37#19a421dceac7756aef26a8771f258af9cc21fc37"
+source = "git+https://github.com/oxidecomputer/propolis?rev=220a6f367c18f2452dbc4fa9086f3fe73b961739#220a6f367c18f2452dbc4fa9086f3fe73b961739"
 dependencies = [
  "bhyve_api_sys",
  "libc",
@@ -703,7 +703,7 @@ dependencies = [
 [[package]]
 name = "bhyve_api_sys"
 version = "0.0.0"
-source = "git+https://github.com/oxidecomputer/propolis?rev=19a421dceac7756aef26a8771f258af9cc21fc37#19a421dceac7756aef26a8771f258af9cc21fc37"
+source = "git+https://github.com/oxidecomputer/propolis?rev=220a6f367c18f2452dbc4fa9086f3fe73b961739#220a6f367c18f2452dbc4fa9086f3fe73b961739"
 dependencies = [
  "libc",
  "strum",
@@ -6980,7 +6980,7 @@ dependencies = [
  "pq-sys",
  "pretty_assertions",
  "progenitor-client",
- "propolis-client 0.1.0 (git+https://github.com/oxidecomputer/propolis?rev=19a421dceac7756aef26a8771f258af9cc21fc37)",
+ "propolis-client 0.1.0 (git+https://github.com/oxidecomputer/propolis?rev=220a6f367c18f2452dbc4fa9086f3fe73b961739)",
  "qorb",
  "rand",
  "rcgen",
@@ -7245,7 +7245,7 @@ dependencies = [
  "oximeter-producer",
  "oxnet",
  "pretty_assertions",
- "propolis-client 0.1.0 (git+https://github.com/oxidecomputer/propolis?rev=19a421dceac7756aef26a8771f258af9cc21fc37)",
+ "propolis-client 0.1.0 (git+https://github.com/oxidecomputer/propolis?rev=220a6f367c18f2452dbc4fa9086f3fe73b961739)",
  "propolis-mock-server",
  "propolis_api_types",
  "rand",
@@ -8959,7 +8959,7 @@ dependencies = [
 [[package]]
 name = "propolis-client"
 version = "0.1.0"
-source = "git+https://github.com/oxidecomputer/propolis?rev=19a421dceac7756aef26a8771f258af9cc21fc37#19a421dceac7756aef26a8771f258af9cc21fc37"
+source = "git+https://github.com/oxidecomputer/propolis?rev=220a6f367c18f2452dbc4fa9086f3fe73b961739#220a6f367c18f2452dbc4fa9086f3fe73b961739"
 dependencies = [
  "async-trait",
  "base64 0.21.7",
@@ -9001,7 +9001,7 @@ dependencies = [
 [[package]]
 name = "propolis-mock-server"
 version = "0.0.0"
-source = "git+https://github.com/oxidecomputer/propolis?rev=19a421dceac7756aef26a8771f258af9cc21fc37#19a421dceac7756aef26a8771f258af9cc21fc37"
+source = "git+https://github.com/oxidecomputer/propolis?rev=220a6f367c18f2452dbc4fa9086f3fe73b961739#220a6f367c18f2452dbc4fa9086f3fe73b961739"
 dependencies = [
  "anyhow",
  "atty",
@@ -9043,7 +9043,7 @@ dependencies = [
 [[package]]
 name = "propolis_api_types"
 version = "0.0.0"
-source = "git+https://github.com/oxidecomputer/propolis?rev=19a421dceac7756aef26a8771f258af9cc21fc37#19a421dceac7756aef26a8771f258af9cc21fc37"
+source = "git+https://github.com/oxidecomputer/propolis?rev=220a6f367c18f2452dbc4fa9086f3fe73b961739#220a6f367c18f2452dbc4fa9086f3fe73b961739"
 dependencies = [
  "crucible-client-types",
  "propolis_types",
@@ -9056,7 +9056,7 @@ dependencies = [
 [[package]]
 name = "propolis_types"
 version = "0.0.0"
-source = "git+https://github.com/oxidecomputer/propolis?rev=19a421dceac7756aef26a8771f258af9cc21fc37#19a421dceac7756aef26a8771f258af9cc21fc37"
+source = "git+https://github.com/oxidecomputer/propolis?rev=220a6f367c18f2452dbc4fa9086f3fe73b961739#220a6f367c18f2452dbc4fa9086f3fe73b961739"
 dependencies = [
  "schemars",
  "serde",
@@ -10719,7 +10719,7 @@ dependencies = [
  "omicron-uuid-kinds",
  "omicron-workspace-hack",
  "oxnet",
- "propolis-client 0.1.0 (git+https://github.com/oxidecomputer/propolis?rev=19a421dceac7756aef26a8771f258af9cc21fc37)",
+ "propolis-client 0.1.0 (git+https://github.com/oxidecomputer/propolis?rev=220a6f367c18f2452dbc4fa9086f3fe73b961739)",
  "rcgen",
  "schemars",
  "serde",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -539,10 +539,10 @@ prettyplease = { version = "0.2.25", features = ["verbatim"] }
 proc-macro2 = "1.0"
 progenitor = "0.8.0"
 progenitor-client = "0.8.0"
-bhyve_api = { git = "https://github.com/oxidecomputer/propolis", rev = "19a421dceac7756aef26a8771f258af9cc21fc37" }
-propolis_api_types = { git = "https://github.com/oxidecomputer/propolis", rev = "19a421dceac7756aef26a8771f258af9cc21fc37" }
-propolis-client = { git = "https://github.com/oxidecomputer/propolis", rev = "19a421dceac7756aef26a8771f258af9cc21fc37" }
-propolis-mock-server = { git = "https://github.com/oxidecomputer/propolis", rev = "19a421dceac7756aef26a8771f258af9cc21fc37" }
+bhyve_api = { git = "https://github.com/oxidecomputer/propolis", rev = "220a6f367c18f2452dbc4fa9086f3fe73b961739" }
+propolis_api_types = { git = "https://github.com/oxidecomputer/propolis", rev = "220a6f367c18f2452dbc4fa9086f3fe73b961739" }
+propolis-client = { git = "https://github.com/oxidecomputer/propolis", rev = "220a6f367c18f2452dbc4fa9086f3fe73b961739" }
+propolis-mock-server = { git = "https://github.com/oxidecomputer/propolis", rev = "220a6f367c18f2452dbc4fa9086f3fe73b961739" }
 proptest = "1.5.0"
 qorb = "0.2.1"
 quote = "1.0"

--- a/package-manifest.toml
+++ b/package-manifest.toml
@@ -621,10 +621,10 @@ service_name = "propolis-server"
 only_for_targets.image = "standard"
 source.type = "prebuilt"
 source.repo = "propolis"
-source.commit = "19a421dceac7756aef26a8771f258af9cc21fc37"
+source.commit = "220a6f367c18f2452dbc4fa9086f3fe73b961739"
 # The SHA256 digest is automatically posted to:
 # https://buildomat.eng.oxide.computer/public/file/oxidecomputer/propolis/image/<commit>/propolis-server.sha256.txt
-source.sha256 = "fbb52fed6312db047a7f56d43162e5d4c5072886a23b5e6a0096f6db78c5d2ba"
+source.sha256 = "964bf262677496118f8cea95c257d0a57c76ddca70733217b0666657b53bd6e6"
 output.type = "zone"
 
 [package.mg-ddm-gz]


### PR DESCRIPTION
Propolis: Switch viona back to packet copying for now #823

This is a workaround for https://github.com/oxidecomputer/omicron/issues/7189
I turns off new work that we think is causing the slow performance until we can get
a better idea of what exactly the problem is and if/how we might want to fix it.