### PR TITLE
[nexus] Use retryable transactions more extensively

### DIFF
--- a/clippy.toml
+++ b/clippy.toml
@@ -10,4 +10,10 @@ disallowed-methods = [
     # `IncompleteOnConflictExt::as_partial_index` in `nexus-db-queries`.
     # See the documentation of that method for more.
     "diesel::upsert::DecoratableTarget::filter_target",
+
+    # This form of transaction is susceptible to serialization failures,
+    # and can fail spuriously.
+    # Instead, the "transaction_retry_wrapper" should be preferred, as it
+    # automatically retries transactions experiencing contention.
+    { path = "async_bb8_diesel::AsyncConnection::transaction_async", reason = "Prefer to use transaction_retry_wrapper, if possible. Feel free to override this for tests and nested transactions." },
 ]

--- a/dev-tools/omdb/src/bin/omdb/db.rs
+++ b/dev-tools/omdb/src/bin/omdb/db.rs
@@ -14,6 +14,8 @@
 
 // NOTE: emanates from Tabled macros
 #![allow(clippy::useless_vec)]
+// NOTE: allowing "transaction_async" without retry
+#![allow(clippy::disallowed_methods)]
 
 use crate::check_allow_destructive::DestructiveOperationToken;
 use crate::helpers::const_max_len;

--- a/nexus/db-queries/src/db/datastore/deployment.rs
+++ b/nexus/db-queries/src/db/datastore/deployment.rs
@@ -335,6 +335,11 @@ impl DataStore {
         // batch rather than making a bunch of round-trips to the database.
         // We'd do that if we had an interface for doing that with bound
         // parameters, etc.  See oxidecomputer/omicron#973.
+
+        // The risk of a serialization error is possible here, but low,
+        // as most of the operations should be insertions rather than in-place
+        // modifications of existing tables.
+        #[allow(clippy::disallowed_methods)]
         conn.transaction_async(|conn| async move {
             // Insert the row for the blueprint.
             {
@@ -1087,6 +1092,7 @@ impl DataStore {
         // start removing it and we'd also need to make sure we didn't leak a
         // collection if we crash while deleting it.
         let conn = self.pool_connection_authorized(opctx).await?;
+        let err = OptionalError::new();
 
         let (
             nblueprints,
@@ -1101,19 +1107,23 @@ impl DataStore {
             nclickhouse_cluster_configs,
             nclickhouse_keepers,
             nclickhouse_servers,
-        ) = conn
-            .transaction_async(|conn| async move {
+        ) = self.transaction_retry_wrapper("blueprint_delete")
+            .transaction(&conn, |conn| {
+                let err = err.clone();
+                async move {
                 // Ensure that blueprint we're about to delete is not the
                 // current target.
-                let current_target =
-                    Self::blueprint_current_target_only(&conn).await?;
+                let current_target = Self::blueprint_current_target_only(&conn)
+                    .await
+                    .map_err(|txn_err| txn_err.into_diesel(&err))?;
+
                 if current_target.target_id == blueprint_id {
-                    return Err(TransactionError::CustomError(
+                    return Err(err.bail(TransactionError::CustomError(
                         Error::conflict(format!(
                             "blueprint {blueprint_id} is the \
                              current target and cannot be deleted",
                         )),
-                    ));
+                    )));
                 }
 
                 // Remove the record describing the blueprint itself.
@@ -1130,9 +1140,9 @@ impl DataStore {
                 // references to it in any of the remaining tables either, since
                 // deletion always goes through this transaction.
                 if nblueprints == 0 {
-                    return Err(TransactionError::CustomError(
+                    return Err(err.bail(TransactionError::CustomError(
                         authz_blueprint.not_found(),
-                    ));
+                    )));
                 }
 
                 // Remove rows associated with sled states.
@@ -1259,13 +1269,12 @@ impl DataStore {
                     nclickhouse_keepers,
                     nclickhouse_servers,
                 ))
+                }
             })
             .await
-            .map_err(|error| match error {
-                TransactionError::CustomError(e) => e,
-                TransactionError::Database(e) => {
-                    public_error_from_diesel(e, ErrorHandler::Server)
-                }
+            .map_err(|e| match err.take() {
+                Some(err) => err.into(),
+                None => public_error_from_diesel(e, ErrorHandler::Server),
             })?;
 
         info!(&opctx.log, "removed blueprint";

--- a/nexus/db-queries/src/db/datastore/rack.rs
+++ b/nexus/db-queries/src/db/datastore/rack.rs
@@ -674,8 +674,9 @@ impl DataStore {
         let log = opctx.log.clone();
         let err = Arc::new(OnceLock::new());
 
-        // NOTE: This transaction cannot yet be made retryable, as it uses
-        // nested transactions.
+        // This method uses nested transactions, which are not supported
+        // with retryable transactions.
+        #[allow(clippy::disallowed_methods)]
         let rack = self
             .pool_connection_authorized(opctx)
             .await?

--- a/nexus/db-queries/src/db/datastore/region_replacement.rs
+++ b/nexus/db-queries/src/db/datastore/region_replacement.rs
@@ -21,7 +21,7 @@ use crate::db::pagination::Paginator;
 use crate::db::update_and_check::UpdateAndCheck;
 use crate::db::update_and_check::UpdateStatus;
 use crate::db::TransactionError;
-use async_bb8_diesel::AsyncConnection;
+use crate::transaction_retry::OptionalError;
 use async_bb8_diesel::AsyncRunQueryDsl;
 use diesel::prelude::*;
 use omicron_common::api::external::Error;
@@ -52,21 +52,28 @@ impl DataStore {
         opctx: &OpContext,
         request: RegionReplacement,
     ) -> Result<(), Error> {
-        self.pool_connection_authorized(opctx)
-            .await?
-            .transaction_async(|conn| async move {
-                use db::schema::region_replacement::dsl;
+        let conn = self.pool_connection_authorized(opctx).await?;
 
-                Self::volume_repair_insert_query(request.volume_id, request.id)
+        self.transaction_retry_wrapper("insert_region_replacement_request")
+            .transaction(&conn, |conn| {
+                let request = request.clone();
+                async move {
+                    use db::schema::region_replacement::dsl;
+
+                    Self::volume_repair_insert_query(
+                        request.volume_id,
+                        request.id,
+                    )
                     .execute_async(&conn)
                     .await?;
 
-                diesel::insert_into(dsl::region_replacement)
-                    .values(request)
-                    .execute_async(&conn)
-                    .await?;
+                    diesel::insert_into(dsl::region_replacement)
+                        .values(request)
+                        .execute_async(&conn)
+                        .await?;
 
-                Ok(())
+                    Ok(())
+                }
             })
             .await
             .map_err(|e| public_error_from_diesel(e, ErrorHandler::Server))
@@ -666,60 +673,62 @@ impl DataStore {
     ) -> Result<(), Error> {
         type TxnError = TransactionError<Error>;
 
-        self.pool_connection_authorized(opctx)
-            .await?
-            .transaction_async(|conn| async move {
-                Self::volume_repair_delete_query(
-                    request.volume_id,
-                    request.id,
-                )
-                .execute_async(&conn)
-                .await?;
+        let err = OptionalError::new();
+        let conn = self.pool_connection_authorized(opctx).await?;
 
-                use db::schema::region_replacement::dsl;
-
-                let result = diesel::update(dsl::region_replacement)
-                    .filter(dsl::id.eq(request.id))
-                    .filter(
-                        dsl::replacement_state.eq(RegionReplacementState::Completing),
+        self.transaction_retry_wrapper("set_region_replacement_complete")
+            .transaction(&conn, |conn| {
+                let err = err.clone();
+                async move {
+                    Self::volume_repair_delete_query(
+                        request.volume_id,
+                        request.id,
                     )
-                    .filter(dsl::operating_saga_id.eq(operating_saga_id))
-                    .set((
-                        dsl::replacement_state.eq(RegionReplacementState::Complete),
-                        dsl::operating_saga_id.eq(Option::<Uuid>::None),
-                    ))
-                    .check_if_exists::<RegionReplacement>(request.id)
-                    .execute_and_check(&conn)
+                    .execute_async(&conn)
                     .await?;
 
-                match result.status {
-                    UpdateStatus::Updated => Ok(()),
-                    UpdateStatus::NotUpdatedButExists => {
-                        let record = result.found;
+                    use db::schema::region_replacement::dsl;
 
-                        if record.operating_saga_id == None
-                            && record.replacement_state
-                                == RegionReplacementState::Complete
-                        {
-                            Ok(())
-                        } else {
-                            Err(TxnError::CustomError(Error::conflict(format!(
-                                "region replacement {} set to {:?} (operating saga id {:?})",
-                                request.id,
-                                record.replacement_state,
-                                record.operating_saga_id,
-                            ))))
+                    let result = diesel::update(dsl::region_replacement)
+                        .filter(dsl::id.eq(request.id))
+                        .filter(
+                            dsl::replacement_state.eq(RegionReplacementState::Completing),
+                        )
+                        .filter(dsl::operating_saga_id.eq(operating_saga_id))
+                        .set((
+                            dsl::replacement_state.eq(RegionReplacementState::Complete),
+                            dsl::operating_saga_id.eq(Option::<Uuid>::None),
+                        ))
+                        .check_if_exists::<RegionReplacement>(request.id)
+                        .execute_and_check(&conn)
+                        .await?;
+
+                    match result.status {
+                        UpdateStatus::Updated => Ok(()),
+                        UpdateStatus::NotUpdatedButExists => {
+                            let record = result.found;
+
+                            if record.operating_saga_id == None
+                                && record.replacement_state
+                                    == RegionReplacementState::Complete
+                            {
+                                Ok(())
+                            } else {
+                                Err(err.bail(TxnError::from(Error::conflict(format!(
+                                    "region replacement {} set to {:?} (operating saga id {:?})",
+                                    request.id,
+                                    record.replacement_state,
+                                    record.operating_saga_id,
+                                )))))
+                            }
                         }
                     }
                 }
             })
             .await
-            .map_err(|e| match e {
-                TxnError::CustomError(error) => error,
-
-                TxnError::Database(error) => {
-                    public_error_from_diesel(error, ErrorHandler::Server)
-                }
+            .map_err(|e| match err.take() {
+                Some(err) => err.into(),
+                None => public_error_from_diesel(e, ErrorHandler::Server),
             })
     }
 
@@ -738,57 +747,59 @@ impl DataStore {
             RegionReplacementState::Requested,
         );
 
-        self.pool_connection_authorized(opctx)
-            .await?
-            .transaction_async(|conn| async move {
-                Self::volume_repair_delete_query(
-                    request.volume_id,
-                    request.id,
-                )
-                .execute_async(&conn)
-                .await?;
+        let err = OptionalError::new();
+        let conn = self.pool_connection_authorized(opctx).await?;
 
-                use db::schema::region_replacement::dsl;
-
-                let result = diesel::update(dsl::region_replacement)
-                    .filter(dsl::id.eq(request.id))
-                    .filter(
-                        dsl::replacement_state.eq(RegionReplacementState::Requested),
+        self.transaction_retry_wrapper("set_region_replacement_complete_from_requested")
+            .transaction(&conn, |conn| {
+                let err = err.clone();
+                async move {
+                    Self::volume_repair_delete_query(
+                        request.volume_id,
+                        request.id,
                     )
-                    .filter(dsl::operating_saga_id.is_null())
-                    .set((
-                        dsl::replacement_state.eq(RegionReplacementState::Complete),
-                    ))
-                    .check_if_exists::<RegionReplacement>(request.id)
-                    .execute_and_check(&conn)
+                    .execute_async(&conn)
                     .await?;
 
-                match result.status {
-                    UpdateStatus::Updated => Ok(()),
+                    use db::schema::region_replacement::dsl;
 
-                    UpdateStatus::NotUpdatedButExists => {
-                        let record = result.found;
+                    let result = diesel::update(dsl::region_replacement)
+                        .filter(dsl::id.eq(request.id))
+                        .filter(
+                            dsl::replacement_state.eq(RegionReplacementState::Requested),
+                        )
+                        .filter(dsl::operating_saga_id.is_null())
+                        .set((
+                            dsl::replacement_state.eq(RegionReplacementState::Complete),
+                        ))
+                        .check_if_exists::<RegionReplacement>(request.id)
+                        .execute_and_check(&conn)
+                        .await?;
 
-                        if record.replacement_state == RegionReplacementState::Complete {
-                            Ok(())
-                        } else {
-                            Err(TxnError::CustomError(Error::conflict(format!(
-                                "region replacement {} set to {:?} (operating saga id {:?})",
-                                request.id,
-                                record.replacement_state,
-                                record.operating_saga_id,
-                            ))))
+                    match result.status {
+                        UpdateStatus::Updated => Ok(()),
+
+                        UpdateStatus::NotUpdatedButExists => {
+                            let record = result.found;
+
+                            if record.replacement_state == RegionReplacementState::Complete {
+                                Ok(())
+                            } else {
+                                Err(err.bail(TxnError::from(Error::conflict(format!(
+                                    "region replacement {} set to {:?} (operating saga id {:?})",
+                                    request.id,
+                                    record.replacement_state,
+                                    record.operating_saga_id,
+                                )))))
+                            }
                         }
                     }
                 }
             })
             .await
-            .map_err(|e| match e {
-                TxnError::CustomError(error) => error,
-
-                TxnError::Database(error) => {
-                    public_error_from_diesel(error, ErrorHandler::Server)
-                }
+            .map_err(|e| match err.take() {
+                Some(err) => err.into(),
+                None => public_error_from_diesel(e, ErrorHandler::Server),
             })
     }
 

--- a/nexus/db-queries/src/db/datastore/role.rs
+++ b/nexus/db-queries/src/db/datastore/role.rs
@@ -209,6 +209,11 @@ impl DataStore {
         // We might instead want to first-class the idea of Policies in the
         // database so that we can build up a whole new Policy in batches and
         // then flip the resource over to using it.
+
+        // This method should probably be retryable, but this is slightly
+        // complicated by the cloning semantics of the queries, which
+        // must be Clone to be retried.
+        #[allow(clippy::disallowed_methods)]
         self.pool_connection_authorized(opctx)
             .await?
             .transaction_async(|conn| async move {

--- a/nexus/db-queries/src/db/datastore/saga.rs
+++ b/nexus/db-queries/src/db/datastore/saga.rs
@@ -654,6 +654,7 @@ mod test {
             .expect("failed to re-assign sagas");
 
         // Fetch all the sagas and check their states.
+        #[allow(clippy::disallowed_methods)]
         let all_sagas: Vec<_> = datastore
             .pool_connection_for_tests()
             .await

--- a/nexus/db-queries/src/db/datastore/silo_group.rs
+++ b/nexus/db-queries/src/db/datastore/silo_group.rs
@@ -199,6 +199,8 @@ impl DataStore {
 
         let group_id = authz_silo_group.id();
 
+        // Prefer to use "transaction_retry_wrapper"
+        #[allow(clippy::disallowed_methods)]
         self.pool_connection_authorized(opctx)
             .await?
             .transaction_async(|conn| async move {

--- a/nexus/db-queries/src/db/pagination.rs
+++ b/nexus/db-queries/src/db/pagination.rs
@@ -679,6 +679,7 @@ mod test {
             pagparams: &DataPageParams<'_, (i64, i64)>,
         ) -> Vec<UserAndPhoneNumber> {
             let conn = pool.claim().await.unwrap();
+            #[allow(clippy::disallowed_methods)]
             conn.transaction_async(|conn| async move {
                 // I couldn't figure out how to make this work without requiring a full
                 // table scan, and I just want the test to work so that I can get on

--- a/nexus/src/app/sagas/region_snapshot_replacement_start.rs
+++ b/nexus/src/app/sagas/region_snapshot_replacement_start.rs
@@ -1041,6 +1041,7 @@ pub(crate) mod test {
 
         let conn = datastore.pool_connection_for_tests().await.unwrap();
 
+        #[allow(clippy::disallowed_methods)]
         conn.transaction_async(|conn| async move {
             // Selecting all regions requires a full table scan
             conn.batch_execute_async(ALLOW_FULL_TABLE_SCAN_SQL).await.unwrap();


### PR DESCRIPTION
This PR finds spots where we use `transaction_async` and makes them use `transaction_retry_wrapper` instead.

This means that under contention, we'll avoid wasting work, and can make use of CockroachDB's automated retry mechanisms.

Additionally, this PR adds a clippy lint to help future usage avoid the "non-retryable" transaction variant.
There are some use cases where avoiding retries is still reasonable:

1. Test-only code
2. Transactions which have truly minimal contention, or which can fail with serialization errors without issue
3. Nested transactions