### PR TITLE
bump rustls@0.23 to 0.23.19

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -718,7 +718,7 @@ dependencies = [
  "bitflags 2.6.0",
  "cexpr",
  "clang-sys",
- "itertools 0.12.1",
+ "itertools 0.10.5",
  "lazy_static",
  "lazycell",
  "log",
@@ -4162,7 +4162,7 @@ dependencies = [
  "http",
  "hyper",
  "hyper-util",
- "rustls 0.23.14",
+ "rustls 0.23.19",
  "rustls-pki-types",
  "tokio",
  "tokio-rustls 0.26.0",
@@ -5103,7 +5103,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4979f22fdb869068da03c9f7528f8297c6fd2606bc3a4affe42e6a823fdb8da4"
 dependencies = [
  "cfg-if",
- "windows-targets 0.52.6",
+ "windows-targets 0.48.5",
 ]
 
 [[package]]
@@ -7406,7 +7406,6 @@ dependencies = [
  "indicatif",
  "inout",
  "itertools 0.10.5",
- "itertools 0.12.1",
  "lalrpop-util",
  "lazy_static",
  "libc",
@@ -7441,7 +7440,7 @@ dependencies = [
  "reqwest",
  "rsa",
  "rustix",
- "rustls 0.23.14",
+ "rustls 0.23.19",
  "rustls-webpki 0.102.8",
  "schemars",
  "scopeguard",
@@ -9151,7 +9150,7 @@ dependencies = [
  "quinn-proto",
  "quinn-udp",
  "rustc-hash 2.0.0",
- "rustls 0.23.14",
+ "rustls 0.23.19",
  "socket2",
  "thiserror 1.0.69",
  "tokio",
@@ -9168,7 +9167,7 @@ dependencies = [
  "rand",
  "ring 0.17.8",
  "rustc-hash 2.0.0",
- "rustls 0.23.14",
+ "rustls 0.23.19",
  "slab",
  "thiserror 1.0.69",
  "tinyvec",
@@ -9582,7 +9581,7 @@ dependencies = [
  "percent-encoding",
  "pin-project-lite",
  "quinn",
- "rustls 0.23.14",
+ "rustls 0.23.19",
  "rustls-pemfile 2.2.0",
  "rustls-pki-types",
  "serde",
@@ -9969,9 +9968,9 @@ dependencies = [
 
 [[package]]
 name = "rustls"
-version = "0.23.14"
+version = "0.23.19"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "415d9944693cb90382053259f89fbb077ea730ad7273047ec63b19bc9b160ba8"
+checksum = "934b404430bb06b3fae2cba809eb45a1ab1aecd64491213d7c3301b88393f8d1"
 dependencies = [
  "aws-lc-rs",
  "log",
@@ -10016,9 +10015,9 @@ dependencies = [
 
 [[package]]
 name = "rustls-pki-types"
-version = "1.9.0"
+version = "1.10.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0e696e35370c65c9c541198af4543ccd580cf17fc25d8e05c5a242b202488c55"
+checksum = "16f1201b3c9a7ee8039bcadc17b7e605e2945b27eee7631788c1bd2b0643674b"
 
 [[package]]
 name = "rustls-webpki"
@@ -11085,7 +11084,7 @@ dependencies = [
  "ed25519-dalek",
  "libipcc",
  "pem-rfc7468",
- "rustls 0.23.14",
+ "rustls 0.23.19",
  "secrecy",
  "serde",
  "sha2",
@@ -11938,7 +11937,7 @@ version = "0.26.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0c7bc40d0e5a97695bb96e27995cd3a08538541b0a846f65bba7a359f36700d4"
 dependencies = [
- "rustls 0.23.14",
+ "rustls 0.23.19",
  "rustls-pki-types",
  "tokio",
 ]
@@ -12103,7 +12102,7 @@ dependencies = [
  "pem",
  "percent-encoding",
  "reqwest",
- "rustls 0.23.14",
+ "rustls 0.23.19",
  "serde",
  "serde_json",
  "serde_plain",

--- a/workspace-hack/Cargo.toml
+++ b/workspace-hack/Cargo.toml
@@ -69,8 +69,7 @@ hmac = { version = "0.12.1", default-features = false, features = ["reset"] }
 hyper = { version = "1.5.0", features = ["full"] }
 indexmap = { version = "2.6.0", features = ["serde"] }
 inout = { version = "0.1.3", default-features = false, features = ["std"] }
-itertools-5ef9efb8ec2df382 = { package = "itertools", version = "0.12.1" }
-itertools-93f6ce9d446188ac = { package = "itertools", version = "0.10.5" }
+itertools = { version = "0.10.5" }
 lalrpop-util = { version = "0.19.12" }
 lazy_static = { version = "1.5.0", default-features = false, features = ["spin_no_std"] }
 libc = { version = "0.2.162", features = ["extra_traits"] }
@@ -101,7 +100,7 @@ regex-automata = { version = "0.4.8", default-features = false, features = ["dfa
 regex-syntax = { version = "0.8.5" }
 reqwest = { version = "0.12.9", features = ["blocking", "cookies", "json", "rustls-tls", "stream"] }
 rsa = { version = "0.9.6", features = ["serde", "sha2"] }
-rustls = { version = "0.23.14", features = ["ring"] }
+rustls = { version = "0.23.19", features = ["ring"] }
 rustls-webpki = { version = "0.102.8", default-features = false, features = ["aws_lc_rs", "ring", "std"] }
 schemars = { version = "0.8.21", features = ["bytes", "chrono", "uuid1"] }
 scopeguard = { version = "1.2.0" }
@@ -189,8 +188,7 @@ hmac = { version = "0.12.1", default-features = false, features = ["reset"] }
 hyper = { version = "1.5.0", features = ["full"] }
 indexmap = { version = "2.6.0", features = ["serde"] }
 inout = { version = "0.1.3", default-features = false, features = ["std"] }
-itertools-5ef9efb8ec2df382 = { package = "itertools", version = "0.12.1" }
-itertools-93f6ce9d446188ac = { package = "itertools", version = "0.10.5" }
+itertools = { version = "0.10.5" }
 lalrpop-util = { version = "0.19.12" }
 lazy_static = { version = "1.5.0", default-features = false, features = ["spin_no_std"] }
 libc = { version = "0.2.162", features = ["extra_traits"] }
@@ -221,7 +219,7 @@ regex-automata = { version = "0.4.8", default-features = false, features = ["dfa
 regex-syntax = { version = "0.8.5" }
 reqwest = { version = "0.12.9", features = ["blocking", "cookies", "json", "rustls-tls", "stream"] }
 rsa = { version = "0.9.6", features = ["serde", "sha2"] }
-rustls = { version = "0.23.14", features = ["ring"] }
+rustls = { version = "0.23.19", features = ["ring"] }
 rustls-webpki = { version = "0.102.8", default-features = false, features = ["aws_lc_rs", "ring", "std"] }
 schemars = { version = "0.8.21", features = ["bytes", "chrono", "uuid1"] }
 scopeguard = { version = "1.2.0" }


### PR DESCRIPTION
Resolves https://github.com/advisories/GHSA-qg5g-gv98-5ffh. The last Omicron release used rustls@0.23 prior to the affected versions.