### PR TITLE
[sled-agent] Avoid causing UUID conflicts

### DIFF
--- a/sled-agent/src/sled_agent.rs
+++ b/sled-agent/src/sled_agent.rs
@@ -972,7 +972,8 @@ impl SledAgent {
             //
             // This means that:
             // - If the dataset exists and has a UUID, this will be a no-op
-            // - If the dataset doesn't exist, it'll be created
+            // - If the dataset doesn't exist, it'll be created without its
+            // oxide:uuid zfs property set
             // - If a subsequent call to "datasets_ensure" tries to set a UUID,
             // it should be able to get set (once).
             self.inner.storage.upsert_filesystem(None, dataset_name).await?;

--- a/sled-storage/src/manager.rs
+++ b/sled-storage/src/manager.rs
@@ -28,6 +28,7 @@ use omicron_common::disk::{
 };
 use omicron_common::ledger::Ledger;
 use omicron_uuid_kinds::DatasetUuid;
+use omicron_uuid_kinds::GenericUuid;
 use slog::{error, info, o, warn, Logger};
 use std::collections::BTreeMap;
 use std::collections::HashSet;
@@ -999,17 +1000,11 @@ impl StorageManager {
         };
 
         if old_id != config.id {
-            // NOTE(https://github.com/oxidecomputer/omicron/issues/7265):
-            //
-            // This should potentially return a "UuidMismatch" error in the
-            // future, rather than overwriting the existing dataset UUID.
-            warn!(
-                log,
-                "Dataset UUID mismatch. Choosing to take new value.";
-                "old" => ?old_id,
-                "new" => ?config.id
-            );
-            return Ok(false);
+            return Err(Error::UuidMismatch {
+                name: config.name.full_name(),
+                old: old_id.into_untyped_uuid(),
+                new: config.id.into_untyped_uuid(),
+            });
         }
 
         let old_props = match SharedDatasetConfig::try_from(old_dataset) {


### PR DESCRIPTION
- Avoids overwriting the value of "dataset UUID" when creating datasets from `omicron_zones_ensure`. Instead, don't set any dataset UUID, which lets subsequent calls to `datasets_ensure` set the right value here. 

Fixes https://github.com/oxidecomputer/omicron/issues/7265