### PR TITLE
live-tests: avoid relying on poorly-behaving DNS

### DIFF
--- a/internal-dns/resolver/src/resolver.rs
+++ b/internal-dns/resolver/src/resolver.rs
@@ -12,7 +12,7 @@ use omicron_common::address::{
     get_internal_dns_server_addresses, Ipv6Subnet, AZ_PREFIX, DNS_PORT,
 };
 use slog::{debug, error, info, trace};
-use std::net::{IpAddr, Ipv6Addr, SocketAddr, SocketAddrV6};
+use std::net::{Ipv6Addr, SocketAddr, SocketAddrV6};
 
 #[derive(Debug, Clone, thiserror::Error)]
 pub enum ResolveError {
@@ -323,20 +323,6 @@ impl Resolver {
         }
     }
 
-    pub async fn lookup_ip(
-        &self,
-        srv: ServiceName,
-    ) -> Result<IpAddr, ResolveError> {
-        let name = srv.srv_name();
-        debug!(self.log, "lookup srv"; "dns_name" => &name);
-        let response = self.resolver.lookup_ip(&name).await?;
-        let address = response
-            .iter()
-            .next()
-            .ok_or_else(|| ResolveError::NotFound(srv))?;
-        Ok(address)
-    }
-
     /// Returns an iterator of [`SocketAddrV6`]'s for the targets of the given
     /// SRV lookup response.
     // SRV records have a target, which is itself another DNS name that needs
@@ -534,7 +520,7 @@ mod test {
         let resolver = dns_server.resolver().unwrap();
 
         let err = resolver
-            .lookup_ip(ServiceName::Cockroach)
+            .lookup_srv(ServiceName::Cockroach)
             .await
             .expect_err("Looking up non-existent service should fail");
 

--- a/live-tests/tests/common/mod.rs
+++ b/live-tests/tests/common/mod.rs
@@ -157,7 +157,7 @@ async fn check_execution_environment(
     // The only real requirement for these tests is that they're run from a
     // place with connectivity to the underlay network of a deployed control
     // plane.  The easiest way to tell is to look up something in internal DNS.
-    resolver.lookup_ip(ServiceName::InternalDns).await.map_err(|e| {
+    resolver.lookup_srv(ServiceName::InternalDns).await.map_err(|e| {
         let text = format!(
             "check_execution_environment(): failed to look up internal DNS \
                  in the internal DNS servers.\n\n \


### PR DESCRIPTION
1. Live tests don't currently run because the check that you are on an underlay network asks internal DNS for A/AAAA records for internal DNS (via `hickory_resolver::Resolver::lookup_ip`). We don't have those, but prior to #6308 we responded with whatever records we had for a given name regardless of what type the query asked for. Live tests aren't run in CI so we missed it.
2. `internal_dns_resolver::Resolver::lookup_ip` is now only used here and in a unit test that is arguably doing something similar, so we remove the function altogether.