### PR TITLE
[Reconfigurator] Blippy

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -6039,9 +6039,11 @@ dependencies = [
 name = "nexus-reconfigurator-blippy"
 version = "0.1.0"
 dependencies = [
+ "nexus-reconfigurator-planning",
  "nexus-sled-agent-shared",
  "nexus-types",
  "omicron-common",
+ "omicron-test-utils",
  "omicron-uuid-kinds",
  "omicron-workspace-hack",
 ]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -6036,6 +6036,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "nexus-reconfigurator-blippy"
+version = "0.1.0"
+dependencies = [
+ "nexus-sled-agent-shared",
+ "nexus-types",
+ "omicron-common",
+ "omicron-uuid-kinds",
+ "omicron-workspace-hack",
+]
+
+[[package]]
 name = "nexus-reconfigurator-execution"
 version = "0.1.0"
 dependencies = [

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -6112,6 +6112,7 @@ dependencies = [
  "maplit",
  "nexus-config",
  "nexus-inventory",
+ "nexus-reconfigurator-blippy",
  "nexus-sled-agent-shared",
  "nexus-types",
  "omicron-common",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -79,6 +79,7 @@ members = [
     "nexus/macros-common",
     "nexus/metrics-producer-gc",
     "nexus/networking",
+    "nexus/reconfigurator/blippy",
     "nexus/reconfigurator/execution",
     "nexus/reconfigurator/planning",
     "nexus/reconfigurator/preparation",
@@ -213,6 +214,7 @@ default-members = [
     "nexus/macros-common",
     "nexus/metrics-producer-gc",
     "nexus/networking",
+    "nexus/reconfigurator/blippy",
     "nexus/reconfigurator/execution",
     "nexus/reconfigurator/planning",
     "nexus/reconfigurator/preparation",
@@ -468,6 +470,7 @@ nexus-internal-api = { path = "nexus/internal-api" }
 nexus-macros-common = { path = "nexus/macros-common" }
 nexus-metrics-producer-gc = { path = "nexus/metrics-producer-gc" }
 nexus-networking = { path = "nexus/networking" }
+nexus-reconfigurator-blippy = { path = "nexus/reconfigurator/blippy" }
 nexus-reconfigurator-execution = { path = "nexus/reconfigurator/execution" }
 nexus-reconfigurator-planning = { path = "nexus/reconfigurator/planning" }
 nexus-reconfigurator-preparation = { path = "nexus/reconfigurator/preparation" }

--- a/common/src/api/external/mod.rs
+++ b/common/src/api/external/mod.rs
@@ -1930,6 +1930,8 @@ impl JsonSchema for L4PortRange {
     DeserializeFromStr,
     PartialEq,
     Eq,
+    PartialOrd,
+    Ord,
     SerializeDisplay,
     Hash,
 )]

--- a/common/src/api/internal/shared.rs
+++ b/common/src/api/internal/shared.rs
@@ -68,7 +68,18 @@ pub struct NetworkInterface {
 /// outbound network connections from guests or services.
 // Note that `Deserialize` is manually implemented; if you make any changes to
 // the fields of this structure, you must make them to that implementation too.
-#[derive(Debug, Clone, Copy, Serialize, JsonSchema, PartialEq, Eq, Hash)]
+#[derive(
+    Debug,
+    Clone,
+    Copy,
+    Serialize,
+    JsonSchema,
+    PartialEq,
+    Eq,
+    PartialOrd,
+    Ord,
+    Hash,
+)]
 pub struct SourceNatConfig {
     /// The external address provided to the instance or service.
     pub ip: IpAddr,

--- a/common/src/api/internal/shared.rs
+++ b/common/src/api/internal/shared.rs
@@ -48,7 +48,16 @@ pub enum NetworkInterfaceKind {
 
 /// Information required to construct a virtual network interface
 #[derive(
-    Clone, Debug, Deserialize, Serialize, JsonSchema, PartialEq, Eq, Hash,
+    Clone,
+    Debug,
+    Deserialize,
+    Serialize,
+    JsonSchema,
+    PartialEq,
+    Eq,
+    PartialOrd,
+    Ord,
+    Hash,
 )]
 pub struct NetworkInterface {
     pub id: Uuid,

--- a/nexus-sled-agent-shared/src/inventory.rs
+++ b/nexus-sled-agent-shared/src/inventory.rs
@@ -173,7 +173,16 @@ impl OmicronZoneConfig {
 
 /// Describes a persistent ZFS dataset associated with an Omicron zone
 #[derive(
-    Clone, Debug, Deserialize, Serialize, JsonSchema, PartialEq, Eq, Hash,
+    Clone,
+    Debug,
+    Deserialize,
+    Serialize,
+    JsonSchema,
+    PartialEq,
+    Eq,
+    PartialOrd,
+    Ord,
+    Hash,
 )]
 pub struct OmicronZoneDataset {
     pub pool_name: ZpoolName,

--- a/nexus/reconfigurator/blippy/Cargo.toml
+++ b/nexus/reconfigurator/blippy/Cargo.toml
@@ -1,0 +1,15 @@
+[package]
+name = "nexus-reconfigurator-blippy"
+version = "0.1.0"
+edition = "2021"
+
+[lints]
+workspace = true
+
+[dependencies]
+nexus-sled-agent-shared.workspace = true
+nexus-types.workspace = true
+omicron-common.workspace = true
+omicron-uuid-kinds.workspace = true
+
+omicron-workspace-hack.workspace = true

--- a/nexus/reconfigurator/blippy/Cargo.toml
+++ b/nexus/reconfigurator/blippy/Cargo.toml
@@ -13,3 +13,7 @@ omicron-common.workspace = true
 omicron-uuid-kinds.workspace = true
 
 omicron-workspace-hack.workspace = true
+
+[dev-dependencies]
+nexus-reconfigurator-planning.workspace = true
+omicron-test-utils.workspace = true

--- a/nexus/reconfigurator/blippy/src/blippy.rs
+++ b/nexus/reconfigurator/blippy/src/blippy.rs
@@ -138,7 +138,7 @@ pub enum SledKind {
         zpool: ZpoolName,
     },
     /// Two zones with the same filesystem dataset kind are on the same zpool.
-    ZpoolFilesystemDatasetCollision {
+    ZoneFilesystemDatasetCollision {
         zone1: BlueprintZoneConfig,
         zone2: BlueprintZoneConfig,
         zpool: ZpoolName,
@@ -263,7 +263,7 @@ impl fmt::Display for SledKind {
                     zone2.id,
                 )
             }
-            SledKind::ZpoolFilesystemDatasetCollision {
+            SledKind::ZoneFilesystemDatasetCollision {
                 zone1,
                 zone2,
                 zpool,

--- a/nexus/reconfigurator/blippy/src/blippy.rs
+++ b/nexus/reconfigurator/blippy/src/blippy.rs
@@ -29,13 +29,6 @@ pub struct Note {
 #[derive(Debug, Clone, PartialEq, Eq, PartialOrd, Ord)]
 pub enum Severity {
     /// Indicator of a serious problem that means the blueprint is invalid.
-    ///
-    /// Many common blueprint use cases are likely to fail in some way if
-    /// performed with a blueprint reporting a `Fatal` note:
-    ///
-    /// * Uploading the blueprint to Nexus
-    /// * Attempting to execute the blueprint
-    /// * Attempting to generate a new child blueprint
     Fatal,
 }
 

--- a/nexus/reconfigurator/blippy/src/blippy.rs
+++ b/nexus/reconfigurator/blippy/src/blippy.rs
@@ -1,0 +1,178 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at https://mozilla.org/MPL/2.0/.
+
+use nexus_types::deployment::Blueprint;
+use nexus_types::deployment::BlueprintDatasetConfig;
+use nexus_types::deployment::BlueprintZoneConfig;
+use nexus_types::inventory::ZpoolName;
+use omicron_common::address::DnsSubnet;
+use omicron_common::address::Ipv6Subnet;
+use omicron_common::address::SLED_PREFIX;
+use omicron_common::api::external::MacAddr;
+use omicron_uuid_kinds::SledUuid;
+use omicron_uuid_kinds::ZpoolUuid;
+use std::collections::BTreeSet;
+use std::net::IpAddr;
+use std::net::Ipv6Addr;
+
+use crate::checks;
+
+#[derive(Debug, Clone)]
+pub struct Note<'a> {
+    pub component: Component,
+    pub severity: Severity,
+    pub kind: Kind<'a>,
+}
+
+#[derive(Debug, Clone)]
+pub enum Severity {
+    /// Indicator of a serious problem that means the blueprint is invalid.
+    ///
+    /// Many common blueprint use cases are likely to fail in some way if
+    /// performed with a blueprint reporting a `Fatal` note:
+    ///
+    /// * Uploading the blueprint to Nexus
+    /// * Attempting to execute the blueprint
+    /// * Attempting to generate a new child blueprint
+    Fatal,
+}
+
+#[derive(Debug, Clone)]
+pub enum Component {
+    Sled(SledUuid),
+}
+
+#[derive(Debug, Clone)]
+pub enum Kind<'a> {
+    /// Two running zones have the same underlay IP address.
+    DuplicateUnderlayIp {
+        zone1: &'a BlueprintZoneConfig,
+        zone2: &'a BlueprintZoneConfig,
+        ip: Ipv6Addr,
+    },
+    /// A sled has two zones that are not members of the same sled subnet.
+    SledWithMixedUnderlaySubnets {
+        zone1: &'a BlueprintZoneConfig,
+        zone2: &'a BlueprintZoneConfig,
+    },
+    /// Two sleds are using the same sled subnet.
+    ConflictingSledSubnets {
+        sled1: SledUuid,
+        sled2: SledUuid,
+        subnet: Ipv6Subnet<SLED_PREFIX>,
+    },
+    /// An internal DNS zone has an IP that is not one of the expected rack DNS
+    /// subnets.
+    InternalDnsZoneBadSubnet {
+        zone: &'a BlueprintZoneConfig,
+        rack_dns_subnets: BTreeSet<DnsSubnet>,
+    },
+    /// Two running zones have the same external IP address.
+    DuplicateExternalIp {
+        zone1: &'a BlueprintZoneConfig,
+        zone2: &'a BlueprintZoneConfig,
+        ip: IpAddr,
+    },
+    /// Two running zones' NICs have the same IP address.
+    DuplicateNicIp {
+        zone1: &'a BlueprintZoneConfig,
+        zone2: &'a BlueprintZoneConfig,
+        ip: IpAddr,
+    },
+    /// Two running zones' NICs have the same MAC address.
+    DuplicateNicMac {
+        zone1: &'a BlueprintZoneConfig,
+        zone2: &'a BlueprintZoneConfig,
+        mac: MacAddr,
+    },
+    /// Two zones with the same durable dataset kind are on the same zpool.
+    ZoneDurableDatasetCollision {
+        zone1: &'a BlueprintZoneConfig,
+        zone2: &'a BlueprintZoneConfig,
+        zpool: ZpoolName,
+    },
+    /// Two zones with the same filesystem dataset kind are on the same zpool.
+    ZpoolFilesystemDatasetCollision {
+        zone1: &'a BlueprintZoneConfig,
+        zone2: &'a BlueprintZoneConfig,
+        zpool: ZpoolName,
+    },
+    /// One zpool has two datasets of the same kind.
+    ZpoolWithDuplicateDatasetKinds {
+        dataset1: &'a BlueprintDatasetConfig,
+        dataset2: &'a BlueprintDatasetConfig,
+        zpool: ZpoolUuid,
+    },
+    /// A zpool is missing its Debug dataset.
+    ZpoolMissingDebugDataset { zpool: ZpoolUuid },
+    /// A zpool is missing its Zone Root dataset.
+    ZpoolMissingZoneRootDataset { zpool: ZpoolUuid },
+    /// A zone's filesystem dataset is missing from `blueprint_datasets`.
+    ZoneMissingFilesystemDataset { zone: &'a BlueprintZoneConfig },
+    /// A zone's durable dataset is missing from `blueprint_datasets`.
+    ZoneMissingDurableDataset { zone: &'a BlueprintZoneConfig },
+    /// A zone's durable dataset and transient root dataset are on different
+    /// zpools.
+    ZoneWithDatasetsOnDifferentZpools {
+        zone: &'a BlueprintZoneConfig,
+        durable_zpool: ZpoolName,
+        transient_zpool: ZpoolName,
+    },
+    /// A sled is missing entries in `Blueprint::blueprint_datasets`.
+    SledMissingDatasets { sled_id: SledUuid },
+    /// A sled is missing entries in `Blueprint::blueprint_disks`.
+    SledMissingDisks { sled_id: SledUuid },
+    /// A dataset is present but not referenced by any in-service zone or disk.
+    OrphanedDataset { dataset: &'a BlueprintDatasetConfig },
+    /// A dataset claims to be on a zpool that does not exist.
+    DatasetOnNonexistentDisk { dataset: &'a BlueprintDatasetConfig },
+}
+
+#[derive(Debug)]
+pub struct Blippy<'a> {
+    blueprint: &'a Blueprint,
+    notes: Vec<Note<'a>>,
+}
+
+impl<'a> Blippy<'a> {
+    pub fn new(blueprint: &'a Blueprint) -> Self {
+        let mut slf = Self { blueprint, notes: Vec::new() };
+        checks::perform_all_blueprint_only_checks(&mut slf);
+        slf
+    }
+
+    pub fn blueprint(&self) -> &'a Blueprint {
+        self.blueprint
+    }
+
+    pub(crate) fn push_note(
+        &mut self,
+        component: Component,
+        severity: Severity,
+        kind: Kind<'a>,
+    ) {
+        self.notes.push(Note { component, severity, kind });
+    }
+
+    pub fn into_report(self) -> BlippyReport<'a> {
+        let Self { blueprint, notes } = self;
+        BlippyReport { blueprint, notes }
+    }
+}
+
+#[derive(Debug)]
+pub struct BlippyReport<'a> {
+    blueprint: &'a Blueprint,
+    notes: Vec<Note<'a>>,
+}
+
+impl<'a> BlippyReport<'a> {
+    pub fn blueprint(&self) -> &'a Blueprint {
+        self.blueprint
+    }
+
+    pub fn notes(&self) -> &[Note<'a>] {
+        &self.notes
+    }
+}

--- a/nexus/reconfigurator/blippy/src/blippy.rs
+++ b/nexus/reconfigurator/blippy/src/blippy.rs
@@ -2,6 +2,10 @@
 // License, v. 2.0. If a copy of the MPL was not distributed with this
 // file, You can obtain one at https://mozilla.org/MPL/2.0/.
 
+use crate::checks;
+use crate::report::BlippyReport;
+use crate::report::BlippyReportSortKey;
+use core::fmt;
 use nexus_types::deployment::Blueprint;
 use nexus_types::deployment::BlueprintDatasetConfig;
 use nexus_types::deployment::BlueprintZoneConfig;
@@ -10,13 +14,11 @@ use omicron_common::address::DnsSubnet;
 use omicron_common::address::Ipv6Subnet;
 use omicron_common::address::SLED_PREFIX;
 use omicron_common::api::external::MacAddr;
+use omicron_common::disk::DatasetKind;
 use omicron_uuid_kinds::SledUuid;
 use omicron_uuid_kinds::ZpoolUuid;
 use std::collections::BTreeSet;
 use std::net::IpAddr;
-use std::net::Ipv6Addr;
-
-use crate::checks;
 
 #[derive(Debug, Clone)]
 pub struct Note<'a> {
@@ -25,7 +27,7 @@ pub struct Note<'a> {
     pub kind: Kind<'a>,
 }
 
-#[derive(Debug, Clone)]
+#[derive(Debug, Clone, PartialEq, Eq, PartialOrd, Ord)]
 pub enum Severity {
     /// Indicator of a serious problem that means the blueprint is invalid.
     ///
@@ -38,18 +40,33 @@ pub enum Severity {
     Fatal,
 }
 
-#[derive(Debug, Clone)]
+impl fmt::Display for Severity {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self {
+            Severity::Fatal => write!(f, "FATAL"),
+        }
+    }
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, PartialOrd, Ord)]
 pub enum Component {
     Sled(SledUuid),
 }
 
-#[derive(Debug, Clone)]
+impl fmt::Display for Component {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self {
+            Component::Sled(id) => write!(f, "sled {id}"),
+        }
+    }
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, PartialOrd, Ord)]
 pub enum Kind<'a> {
     /// Two running zones have the same underlay IP address.
     DuplicateUnderlayIp {
         zone1: &'a BlueprintZoneConfig,
         zone2: &'a BlueprintZoneConfig,
-        ip: Ipv6Addr,
     },
     /// A sled has two zones that are not members of the same sled subnet.
     SledWithMixedUnderlaySubnets {
@@ -58,8 +75,7 @@ pub enum Kind<'a> {
     },
     /// Two sleds are using the same sled subnet.
     ConflictingSledSubnets {
-        sled1: SledUuid,
-        sled2: SledUuid,
+        other_sled: SledUuid,
         subnet: Ipv6Subnet<SLED_PREFIX>,
     },
     /// An internal DNS zone has an IP that is not one of the expected rack DNS
@@ -120,13 +136,231 @@ pub enum Kind<'a> {
         transient_zpool: ZpoolName,
     },
     /// A sled is missing entries in `Blueprint::blueprint_datasets`.
-    SledMissingDatasets { sled_id: SledUuid },
+    ///
+    /// `why` indicates why we expected this sled to have an entry.
+    SledMissingDatasets { why: &'static str },
     /// A sled is missing entries in `Blueprint::blueprint_disks`.
-    SledMissingDisks { sled_id: SledUuid },
+    ///
+    /// `why` indicates why we expected this sled to have an entry.
+    SledMissingDisks { why: &'static str },
     /// A dataset is present but not referenced by any in-service zone or disk.
     OrphanedDataset { dataset: &'a BlueprintDatasetConfig },
     /// A dataset claims to be on a zpool that does not exist.
-    DatasetOnNonexistentDisk { dataset: &'a BlueprintDatasetConfig },
+    DatasetOnNonexistentZpool { dataset: &'a BlueprintDatasetConfig },
+}
+
+impl fmt::Display for Kind<'_> {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self {
+            Kind::DuplicateUnderlayIp { zone1, zone2 } => {
+                write!(
+                    f,
+                    "duplicate underlay IP {} ({:?} {} and {:?} {})",
+                    zone1.underlay_ip(),
+                    zone1.zone_type.kind(),
+                    zone1.id,
+                    zone2.zone_type.kind(),
+                    zone2.id,
+                )
+            }
+            Kind::SledWithMixedUnderlaySubnets { zone1, zone2 } => {
+                write!(
+                    f,
+                    "zones have underlay IPs on two different sled subnets: \
+                     {:?} {} ({}) and {:?} {} ({})",
+                    zone1.zone_type.kind(),
+                    zone1.id,
+                    zone1.underlay_ip(),
+                    zone2.zone_type.kind(),
+                    zone2.id,
+                    zone2.underlay_ip(),
+                )
+            }
+            Kind::ConflictingSledSubnets { other_sled, subnet } => {
+                write!(
+                    f,
+                    "duplicate sled subnet {} with sled {other_sled}",
+                    subnet.net()
+                )
+            }
+            Kind::InternalDnsZoneBadSubnet { zone, rack_dns_subnets } => {
+                write!(
+                    f,
+                    "internal DNS zone {} underlay IP {} is not \
+                     one of the reserved rack DNS subnets ({:?})",
+                    zone.id,
+                    zone.underlay_ip(),
+                    rack_dns_subnets
+                )
+            }
+            Kind::DuplicateExternalIp { zone1, zone2, ip } => {
+                write!(
+                    f,
+                    "duplicate external IP {ip} ({:?} {} and {:?} {})",
+                    zone1.zone_type.kind(),
+                    zone1.id,
+                    zone2.zone_type.kind(),
+                    zone2.id,
+                )
+            }
+            Kind::DuplicateNicIp { zone1, zone2, ip } => {
+                write!(
+                    f,
+                    "duplicate NIC IP {ip} ({:?} {} and {:?} {})",
+                    zone1.zone_type.kind(),
+                    zone1.id,
+                    zone2.zone_type.kind(),
+                    zone2.id,
+                )
+            }
+            Kind::DuplicateNicMac { zone1, zone2, mac } => {
+                write!(
+                    f,
+                    "duplicate NIC MAC {mac} ({:?} {} and {:?} {})",
+                    zone1.zone_type.kind(),
+                    zone1.id,
+                    zone2.zone_type.kind(),
+                    zone2.id,
+                )
+            }
+            Kind::ZoneDurableDatasetCollision { zone1, zone2, zpool } => {
+                write!(
+                    f,
+                    "zpool {zpool} has two zone datasets of the same kind \
+                     ({:?} {} and {:?} {})",
+                    zone1.zone_type.kind(),
+                    zone1.id,
+                    zone2.zone_type.kind(),
+                    zone2.id,
+                )
+            }
+            Kind::ZpoolFilesystemDatasetCollision { zone1, zone2, zpool } => {
+                write!(
+                    f,
+                    "zpool {zpool} has two zone filesystems of the same kind \
+                     ({:?} {} and {:?} {})",
+                    zone1.zone_type.kind(),
+                    zone1.id,
+                    zone2.zone_type.kind(),
+                    zone2.id,
+                )
+            }
+            Kind::ZpoolWithDuplicateDatasetKinds {
+                dataset1,
+                dataset2,
+                zpool,
+            } => {
+                write!(
+                    f,
+                    "two datasets of the same kind on zpool {zpool} \
+                     ({:?} {} and {:?} {})",
+                    dataset1.kind, dataset1.id, dataset2.kind, dataset2.id,
+                )
+            }
+            Kind::ZpoolMissingDebugDataset { zpool } => {
+                write!(f, "zpool {zpool} is missing its Debug dataset")
+            }
+            Kind::ZpoolMissingZoneRootDataset { zpool } => {
+                write!(f, "zpool {zpool} is missing its Zone Root dataset")
+            }
+            Kind::ZoneMissingFilesystemDataset { zone } => {
+                write!(
+                    f,
+                    "in-service zone's filesytem dataset is missing: {:?} {}",
+                    zone.zone_type.kind(),
+                    zone.id,
+                )
+            }
+            Kind::ZoneMissingDurableDataset { zone } => {
+                write!(
+                    f,
+                    "in-service zone's durable dataset is missing: {:?} {}",
+                    zone.zone_type.kind(),
+                    zone.id,
+                )
+            }
+            Kind::ZoneWithDatasetsOnDifferentZpools {
+                zone,
+                durable_zpool,
+                transient_zpool,
+            } => {
+                write!(
+                    f,
+                    "zone {:?} {} has its durable dataset on \
+                     zpool {durable_zpool} but its root dataset on \
+                     zpool {transient_zpool}",
+                    zone.zone_type.kind(),
+                    zone.id,
+                )
+            }
+            Kind::SledMissingDatasets { why } => {
+                write!(f, "missing entry in blueprint_datasets ({why})")
+            }
+            Kind::SledMissingDisks { why } => {
+                write!(f, "missing entry in blueprint_disks ({why})")
+            }
+            Kind::OrphanedDataset { dataset } => {
+                let parent = match dataset.kind {
+                    DatasetKind::Cockroach
+                    | DatasetKind::Crucible
+                    | DatasetKind::Clickhouse
+                    | DatasetKind::ClickhouseKeeper
+                    | DatasetKind::ClickhouseServer
+                    | DatasetKind::ExternalDns
+                    | DatasetKind::InternalDns
+                    | DatasetKind::TransientZone { .. } => "zone",
+                    DatasetKind::TransientZoneRoot
+                    | DatasetKind::Debug
+                    | DatasetKind::Update => "disk",
+                };
+                write!(
+                    f,
+                    "in-service dataset ({:?} {}) with no associated {parent}",
+                    dataset.kind, dataset.id
+                )
+            }
+            Kind::DatasetOnNonexistentZpool { dataset } => {
+                write!(
+                    f,
+                    "in-service dataset ({:?} {}) on non-existent zpool {}",
+                    dataset.kind, dataset.id, dataset.pool
+                )
+            }
+        }
+    }
+}
+
+impl Note<'_> {
+    pub fn display(&self, sort_key: BlippyReportSortKey) -> NoteDisplay<'_> {
+        NoteDisplay { note: self, sort_key }
+    }
+}
+
+#[derive(Debug)]
+pub struct NoteDisplay<'a> {
+    note: &'a Note<'a>,
+    sort_key: BlippyReportSortKey,
+}
+
+impl fmt::Display for NoteDisplay<'_> {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self.sort_key {
+            BlippyReportSortKey::Component => {
+                write!(
+                    f,
+                    "{}: {} note: {}",
+                    self.note.component, self.note.severity, self.note.kind
+                )
+            }
+            BlippyReportSortKey::Severity => {
+                write!(
+                    f,
+                    "{} note: {}: {}",
+                    self.note.severity, self.note.component, self.note.kind
+                )
+            }
+        }
+    }
 }
 
 #[derive(Debug)]
@@ -155,24 +389,10 @@ impl<'a> Blippy<'a> {
         self.notes.push(Note { component, severity, kind });
     }
 
-    pub fn into_report(self) -> BlippyReport<'a> {
-        let Self { blueprint, notes } = self;
-        BlippyReport { blueprint, notes }
-    }
-}
-
-#[derive(Debug)]
-pub struct BlippyReport<'a> {
-    blueprint: &'a Blueprint,
-    notes: Vec<Note<'a>>,
-}
-
-impl<'a> BlippyReport<'a> {
-    pub fn blueprint(&self) -> &'a Blueprint {
-        self.blueprint
-    }
-
-    pub fn notes(&self) -> &[Note<'a>] {
-        &self.notes
+    pub fn into_report(
+        self,
+        sort_key: BlippyReportSortKey,
+    ) -> BlippyReport<'a> {
+        BlippyReport::new(self.blueprint, self.notes, sort_key)
     }
 }

--- a/nexus/reconfigurator/blippy/src/checks.rs
+++ b/nexus/reconfigurator/blippy/src/checks.rs
@@ -53,7 +53,10 @@ fn check_underlay_ips(blippy: &mut Blippy<'_>) {
             blippy.push_sled_note(
                 sled_id,
                 Severity::Fatal,
-                SledKind::DuplicateUnderlayIp { zone1: previous, zone2: zone },
+                SledKind::DuplicateUnderlayIp {
+                    zone1: previous.clone(),
+                    zone2: zone.clone(),
+                },
             );
         }
 
@@ -71,7 +74,7 @@ fn check_underlay_ips(blippy: &mut Blippy<'_>) {
                     sled_id,
                     Severity::Fatal,
                     SledKind::InternalDnsZoneBadSubnet {
-                        zone,
+                        zone: zone.clone(),
                         rack_dns_subnets: rack_dns_subnets.clone(),
                     },
                 );
@@ -113,8 +116,8 @@ fn check_underlay_ips(blippy: &mut Blippy<'_>) {
                             sled_id,
                             Severity::Fatal,
                             SledKind::SledWithMixedUnderlaySubnets {
-                                zone1: prev.get().1,
-                                zone2: zone,
+                                zone1: prev.get().1.clone(),
+                                zone2: zone.clone(),
                             },
                         );
                     }
@@ -147,8 +150,8 @@ fn check_external_networking(blippy: &mut Blippy<'_>) {
                 sled_id,
                 Severity::Fatal,
                 SledKind::DuplicateExternalIp {
-                    zone1: prev_zone,
-                    zone2: zone,
+                    zone1: prev_zone.clone(),
+                    zone2: zone.clone(),
                     ip: external_ip.ip(),
                 },
             );
@@ -173,8 +176,8 @@ fn check_external_networking(blippy: &mut Blippy<'_>) {
                 sled_id,
                 Severity::Fatal,
                 SledKind::DuplicateNicIp {
-                    zone1: prev_zone,
-                    zone2: zone,
+                    zone1: prev_zone.clone(),
+                    zone2: zone.clone(),
                     ip: nic.ip,
                 },
             );
@@ -184,8 +187,8 @@ fn check_external_networking(blippy: &mut Blippy<'_>) {
                 sled_id,
                 Severity::Fatal,
                 SledKind::DuplicateNicMac {
-                    zone1: prev_zone,
-                    zone2: zone,
+                    zone1: prev_zone.clone(),
+                    zone2: zone.clone(),
                     mac: nic.mac,
                 },
             );
@@ -196,11 +199,15 @@ fn check_external_networking(blippy: &mut Blippy<'_>) {
     // SNAT / Floating overlaps. For each SNAT IP, ensure we don't have a
     // floating IP at the same address.
     for (ip, (sled_id, zone2)) in used_external_snat_ips {
-        if let Some(zone1) = used_external_floating_ips.get(&ip) {
+        if let Some(&zone1) = used_external_floating_ips.get(&ip) {
             blippy.push_sled_note(
                 sled_id,
                 Severity::Fatal,
-                SledKind::DuplicateExternalIp { zone1, zone2, ip },
+                SledKind::DuplicateExternalIp {
+                    zone1: zone1.clone(),
+                    zone2: zone2.clone(),
+                    ip,
+                },
             );
         }
     }
@@ -237,8 +244,8 @@ fn check_dataset_zpool_uniqueness(blippy: &mut Blippy<'_>) {
                     sled_id,
                     Severity::Fatal,
                     SledKind::ZoneDurableDatasetCollision {
-                        zone1: previous,
-                        zone2: zone,
+                        zone1: previous.clone(),
+                        zone2: zone.clone(),
                         zpool: dataset.dataset.pool_name.clone(),
                     },
                 );
@@ -257,8 +264,8 @@ fn check_dataset_zpool_uniqueness(blippy: &mut Blippy<'_>) {
                     sled_id,
                     Severity::Fatal,
                     SledKind::ZpoolFilesystemDatasetCollision {
-                        zone1: previous,
-                        zone2: zone,
+                        zone1: previous.clone(),
+                        zone2: zone.clone(),
                         zpool: dataset.into_parts().0,
                     },
                 );
@@ -273,7 +280,7 @@ fn check_dataset_zpool_uniqueness(blippy: &mut Blippy<'_>) {
                     sled_id,
                     Severity::Fatal,
                     SledKind::ZoneWithDatasetsOnDifferentZpools {
-                        zone,
+                        zone: zone.clone(),
                         durable_zpool: durable.clone(),
                         transient_zpool: transient.clone(),
                     },
@@ -314,8 +321,8 @@ impl<'a> DatasetsBySled<'a> {
                             sled_id,
                             Severity::Fatal,
                             SledKind::ZpoolWithDuplicateDatasetKinds {
-                                dataset1: prev.get(),
-                                dataset2: dataset,
+                                dataset1: (*prev.get()).clone(),
+                                dataset2: dataset.clone(),
                                 zpool: dataset.pool.id(),
                             },
                         );
@@ -439,7 +446,7 @@ fn check_datasets(blippy: &mut Blippy<'_>) {
                             sled_id,
                             Severity::Fatal,
                             SledKind::ZoneMissingFilesystemDataset {
-                                zone: zone_config,
+                                zone: zone_config.clone(),
                             },
                         );
                     }
@@ -464,7 +471,7 @@ fn check_datasets(blippy: &mut Blippy<'_>) {
                         sled_id,
                         Severity::Fatal,
                         SledKind::ZoneMissingDurableDataset {
-                            zone: zone_config,
+                            zone: zone_config.clone(),
                         },
                     );
                 }
@@ -502,7 +509,7 @@ fn check_datasets(blippy: &mut Blippy<'_>) {
             blippy.push_sled_note(
                 sled_id,
                 Severity::Fatal,
-                SledKind::OrphanedDataset { dataset },
+                SledKind::OrphanedDataset { dataset: dataset.clone() },
             );
             continue;
         }
@@ -524,9 +531,228 @@ fn check_datasets(blippy: &mut Blippy<'_>) {
             blippy.push_sled_note(
                 sled_id,
                 Severity::Fatal,
-                SledKind::DatasetOnNonexistentZpool { dataset },
+                SledKind::DatasetOnNonexistentZpool {
+                    dataset: dataset.clone(),
+                },
             );
             continue;
         }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::blippy::Kind;
+    use crate::blippy::Note;
+    use crate::BlippyReportSortKey;
+    use nexus_reconfigurator_planning::example::example;
+    use nexus_types::deployment::blueprint_zone_type;
+    use nexus_types::deployment::BlueprintZoneType;
+    use omicron_test_utils::dev::test_setup_log;
+
+    // The tests below all take the example blueprint, mutate in some invalid
+    // way, and confirm that blippy reports the invalidity. This test confirms
+    // the unmutated blueprint has no blippy notes.
+    #[test]
+    fn test_example_blueprint_is_blippy_clean() {
+        static TEST_NAME: &str = "test_example_blueprint_is_blippy_clean";
+        let logctx = test_setup_log(TEST_NAME);
+        let (_, _, blueprint) = example(&logctx.log, TEST_NAME);
+
+        let report =
+            Blippy::new(&blueprint).into_report(BlippyReportSortKey::Kind);
+        if !report.notes().is_empty() {
+            eprintln!("{}", report.display());
+            panic!("example blueprint should have no blippy notes");
+        }
+
+        logctx.cleanup_successful();
+    }
+
+    #[test]
+    fn test_duplicate_underlay_ips() {
+        static TEST_NAME: &str = "test_duplicate_underlay_ips";
+        let logctx = test_setup_log(TEST_NAME);
+        let (_, _, mut blueprint) = example(&logctx.log, TEST_NAME);
+
+        // Copy the underlay IP from one Nexus to another.
+        let mut nexus_iter = blueprint.blueprint_zones.iter_mut().flat_map(
+            |(sled_id, zones_config)| {
+                zones_config.zones.iter_mut().filter_map(move |zone| {
+                    if zone.zone_type.is_nexus() {
+                        Some((*sled_id, zone))
+                    } else {
+                        None
+                    }
+                })
+            },
+        );
+        let (nexus0_sled_id, nexus0) =
+            nexus_iter.next().expect("at least one Nexus zone");
+        let (nexus1_sled_id, nexus1) =
+            nexus_iter.next().expect("at least two Nexus zones");
+        assert_ne!(nexus0_sled_id, nexus1_sled_id);
+
+        let dup_ip = nexus0.underlay_ip();
+        match &mut nexus1.zone_type {
+            BlueprintZoneType::Nexus(blueprint_zone_type::Nexus {
+                internal_address,
+                ..
+            }) => {
+                internal_address.set_ip(dup_ip);
+            }
+            _ => unreachable!("this is a Nexus zone"),
+        };
+
+        // This illegal modification should result in at least three notes: a
+        // duplicate underlay IP, duplicate sled subnets, and sled1 having mixed
+        // underlay subnets (the details of which depend on the ordering of
+        // zones, so we'll sort that out here).
+        let nexus0 = nexus0.clone();
+        let nexus1 = nexus1.clone();
+        let (mixed_underlay_zone1, mixed_underlay_zone2) = {
+            let mut sled1_zones = blueprint
+                .blueprint_zones
+                .get(&nexus1_sled_id)
+                .unwrap()
+                .zones
+                .iter();
+            let sled1_zone1 = sled1_zones.next().expect("at least one zone");
+            let sled1_zone2 = sled1_zones.next().expect("at least two zones");
+            if sled1_zone1.id == nexus1.id {
+                (nexus1.clone(), sled1_zone2.clone())
+            } else {
+                (sled1_zone1.clone(), nexus1.clone())
+            }
+        };
+        let expected_notes = [
+            Note {
+                severity: Severity::Fatal,
+                kind: Kind::Sled {
+                    sled_id: nexus1_sled_id,
+                    kind: SledKind::DuplicateUnderlayIp {
+                        zone1: nexus0.clone(),
+                        zone2: nexus1.clone(),
+                    },
+                },
+            },
+            Note {
+                severity: Severity::Fatal,
+                kind: Kind::Sled {
+                    sled_id: nexus1_sled_id,
+                    kind: SledKind::SledWithMixedUnderlaySubnets {
+                        zone1: mixed_underlay_zone1,
+                        zone2: mixed_underlay_zone2,
+                    },
+                },
+            },
+            Note {
+                severity: Severity::Fatal,
+                kind: Kind::Sled {
+                    sled_id: nexus1_sled_id,
+                    kind: SledKind::ConflictingSledSubnets {
+                        other_sled: nexus0_sled_id,
+                        subnet: Ipv6Subnet::new(dup_ip),
+                    },
+                },
+            },
+        ];
+
+        let report =
+            Blippy::new(&blueprint).into_report(BlippyReportSortKey::Kind);
+        eprintln!("{}", report.display());
+        for note in expected_notes {
+            assert!(
+                report.notes().contains(&note),
+                "did not find expected note {note:?}"
+            );
+        }
+
+        logctx.cleanup_successful();
+    }
+
+    #[test]
+    fn test_bad_internnal_dns_subnet() {
+        static TEST_NAME: &str = "test_bad_internnal_dns_subnet";
+        let logctx = test_setup_log(TEST_NAME);
+        let (_, _, mut blueprint) = example(&logctx.log, TEST_NAME);
+
+        // Change the second internal DNS zone to be from a different rack
+        // subnet.
+        let mut internal_dns_iter = blueprint
+            .blueprint_zones
+            .iter_mut()
+            .flat_map(|(sled_id, zones_config)| {
+                zones_config.zones.iter_mut().filter_map(move |zone| {
+                    if zone.zone_type.is_internal_dns() {
+                        Some((*sled_id, zone))
+                    } else {
+                        None
+                    }
+                })
+            });
+        let (dns0_sled_id, dns0) =
+            internal_dns_iter.next().expect("at least one internal DNS zone");
+        let (dns1_sled_id, dns1) =
+            internal_dns_iter.next().expect("at least two internal DNS zones");
+        assert_ne!(dns0_sled_id, dns1_sled_id);
+
+        let dns0_ip = dns0.underlay_ip();
+        let rack_subnet = DnsSubnet::from_addr(dns0_ip).rack_subnet();
+        let different_rack_subnet = {
+            // Flip the high bit of the existing underlay IP to guarantee a
+            // different rack subnet
+            let hi_bit = 1_u128 << 127;
+            let lo_bits = !hi_bit;
+            let hi_bit_ip = Ipv6Addr::from(hi_bit);
+            let lo_bits_ip = Ipv6Addr::from(lo_bits);
+            // Build XOR out of the operations we have...
+            let flipped_ip = if hi_bit_ip & dns0_ip == hi_bit_ip {
+                dns0_ip & lo_bits_ip
+            } else {
+                dns0_ip | hi_bit_ip
+            };
+            DnsSubnet::from_addr(flipped_ip).rack_subnet()
+        };
+        let different_dns_subnet = different_rack_subnet.get_dns_subnet(0);
+
+        match &mut dns1.zone_type {
+            BlueprintZoneType::InternalDns(
+                blueprint_zone_type::InternalDns {
+                    http_address,
+                    dns_address,
+                    ..
+                },
+            ) => {
+                http_address.set_ip(different_dns_subnet.dns_address());
+                dns_address.set_ip(different_dns_subnet.dns_address());
+            }
+            _ => unreachable!("this is an internal DNS zone"),
+        };
+
+        let expected_note = Note {
+            severity: Severity::Fatal,
+            kind: Kind::Sled {
+                sled_id: dns1_sled_id,
+                kind: SledKind::InternalDnsZoneBadSubnet {
+                    zone: dns1.clone(),
+                    rack_dns_subnets: rack_subnet
+                        .get_dns_subnets()
+                        .into_iter()
+                        .collect(),
+                },
+            },
+        };
+
+        let report =
+            Blippy::new(&blueprint).into_report(BlippyReportSortKey::Kind);
+        eprintln!("{}", report.display());
+        assert!(
+            report.notes().contains(&expected_note),
+            "did not find expected note {expected_note:?}"
+        );
+
+        logctx.cleanup_successful();
     }
 }

--- a/nexus/reconfigurator/blippy/src/checks.rs
+++ b/nexus/reconfigurator/blippy/src/checks.rs
@@ -1,0 +1,517 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at https://mozilla.org/MPL/2.0/.
+
+use nexus_sled_agent_shared::inventory::ZoneKind;
+use nexus_types::deployment::BlueprintDatasetConfig;
+use nexus_types::deployment::BlueprintDatasetFilter;
+use nexus_types::deployment::BlueprintZoneConfig;
+use nexus_types::deployment::BlueprintZoneFilter;
+use nexus_types::deployment::OmicronZoneExternalIp;
+use omicron_common::address::DnsSubnet;
+use omicron_common::address::Ipv6Subnet;
+use omicron_common::address::SLED_PREFIX;
+use omicron_common::disk::DatasetKind;
+use omicron_uuid_kinds::SledUuid;
+use omicron_uuid_kinds::ZpoolUuid;
+use std::collections::btree_map::Entry;
+use std::collections::BTreeMap;
+use std::collections::BTreeSet;
+use std::net::Ipv6Addr;
+
+use crate::Blippy;
+use crate::Component;
+use crate::Kind;
+use crate::Severity;
+
+pub(crate) fn perform_all_blueprint_only_checks(blippy: &mut Blippy<'_>) {
+    check_underlay_ips(blippy);
+    check_external_networking(blippy);
+    check_dataset_zpool_uniqueness(blippy);
+    check_datasets(blippy);
+}
+
+fn check_underlay_ips(blippy: &mut Blippy<'_>) {
+    let mut underlay_ips: BTreeMap<Ipv6Addr, &BlueprintZoneConfig> =
+        BTreeMap::new();
+    let mut inferred_sled_subnets_by_sled: BTreeMap<
+        SledUuid,
+        (Ipv6Subnet<SLED_PREFIX>, &BlueprintZoneConfig),
+    > = BTreeMap::new();
+    let mut inferred_sled_subnets_by_subnet: BTreeMap<
+        Ipv6Subnet<SLED_PREFIX>,
+        SledUuid,
+    > = BTreeMap::new();
+    let mut rack_dns_subnets: BTreeSet<DnsSubnet> = BTreeSet::new();
+
+    for (sled_id, zone) in blippy
+        .blueprint()
+        .all_omicron_zones(BlueprintZoneFilter::ShouldBeRunning)
+    {
+        let ip = zone.underlay_ip();
+
+        // There should be no duplicate underlay IPs.
+        if let Some(previous) = underlay_ips.insert(ip, zone) {
+            blippy.push_note(
+                Component::Sled(sled_id),
+                Severity::Fatal,
+                Kind::DuplicateUnderlayIp { zone1: previous, zone2: zone, ip },
+            );
+        }
+
+        if zone.zone_type.is_internal_dns() {
+            // Internal DNS zones should have IPs coming from the reserved rack
+            // DNS subnets.
+            let subnet = DnsSubnet::from_addr(ip);
+            if rack_dns_subnets.is_empty() {
+                // The blueprint doesn't store the rack subnet explicitly, so we
+                // infer it based on the first internal DNS zone we see.
+                rack_dns_subnets.extend(subnet.rack_subnet().get_dns_subnets());
+            }
+            if !rack_dns_subnets.contains(&subnet) {
+                blippy.push_note(
+                    Component::Sled(sled_id),
+                    Severity::Fatal,
+                    Kind::InternalDnsZoneBadSubnet {
+                        zone,
+                        rack_dns_subnets: rack_dns_subnets.clone(),
+                    },
+                );
+            }
+        } else {
+            let subnet = Ipv6Subnet::new(ip);
+
+            // Any given subnet should be used by at most one sled.
+            match inferred_sled_subnets_by_subnet.entry(subnet) {
+                Entry::Vacant(slot) => {
+                    slot.insert(sled_id);
+                }
+                Entry::Occupied(prev) => {
+                    if *prev.get() != sled_id {
+                        blippy.push_note(
+                            Component::Sled(sled_id),
+                            Severity::Fatal,
+                            Kind::ConflictingSledSubnets {
+                                sled1: *prev.get(),
+                                sled2: sled_id,
+                                subnet,
+                            },
+                        );
+                    }
+                }
+            }
+
+            // Any given sled should have IPs within at most one subnet.
+            //
+            // The blueprint doesn't store sled subnets explicitly, so we can't
+            // check that each sled is using the subnet it's supposed to. The
+            // best we can do is check that the sleds are internally consistent.
+            match inferred_sled_subnets_by_sled.entry(sled_id) {
+                Entry::Vacant(slot) => {
+                    slot.insert((subnet, zone));
+                }
+                Entry::Occupied(prev) => {
+                    if prev.get().0 != subnet {
+                        blippy.push_note(
+                            Component::Sled(sled_id),
+                            Severity::Fatal,
+                            Kind::SledWithMixedUnderlaySubnets {
+                                zone1: prev.get().1,
+                                zone2: zone,
+                            },
+                        );
+                    }
+                }
+            }
+        }
+    }
+}
+
+fn check_external_networking(blippy: &mut Blippy<'_>) {
+    let mut used_external_ips = BTreeMap::new();
+    let mut used_external_floating_ips = BTreeMap::new();
+    let mut used_external_snat_ips = BTreeMap::new();
+
+    let mut used_nic_ips = BTreeMap::new();
+    let mut used_nic_macs = BTreeMap::new();
+
+    for (sled_id, zone, external_ip, nic) in blippy
+        .blueprint()
+        .all_omicron_zones(BlueprintZoneFilter::ShouldBeRunning)
+        .filter_map(|(sled_id, zone)| {
+            zone.zone_type
+                .external_networking()
+                .map(|(external_ip, nic)| (sled_id, zone, external_ip, nic))
+        })
+    {
+        // There should be no duplicate external IPs.
+        if let Some(prev_zone) = used_external_ips.insert(external_ip, zone) {
+            blippy.push_note(
+                Component::Sled(sled_id),
+                Severity::Fatal,
+                Kind::DuplicateExternalIp {
+                    zone1: prev_zone,
+                    zone2: zone,
+                    ip: external_ip.ip(),
+                },
+            );
+        }
+
+        // See the loop below; we build up separate maps to check for
+        // Floating/SNAT overlap that wouldn't be caught by the exact
+        // `used_external_ips` map above.
+        match external_ip {
+            OmicronZoneExternalIp::Floating(floating) => {
+                used_external_floating_ips.insert(floating.ip, zone);
+            }
+            OmicronZoneExternalIp::Snat(snat) => {
+                used_external_snat_ips
+                    .insert(snat.snat_cfg.ip, (sled_id, zone));
+            }
+        }
+
+        // There should be no duplicate NIC IPs or MACs.
+        if let Some(prev_zone) = used_nic_ips.insert(nic.ip, zone) {
+            blippy.push_note(
+                Component::Sled(sled_id),
+                Severity::Fatal,
+                Kind::DuplicateNicIp {
+                    zone1: prev_zone,
+                    zone2: zone,
+                    ip: nic.ip,
+                },
+            );
+        }
+        if let Some(prev_zone) = used_nic_macs.insert(nic.mac, zone) {
+            blippy.push_note(
+                Component::Sled(sled_id),
+                Severity::Fatal,
+                Kind::DuplicateNicMac {
+                    zone1: prev_zone,
+                    zone2: zone,
+                    mac: nic.mac,
+                },
+            );
+        }
+    }
+
+    // The loop above noted any exact duplicates; we should also check for any
+    // SNAT / Floating overlaps. For each SNAT IP, ensure we don't have a
+    // floating IP at the same address.
+    for (ip, (sled_id, zone2)) in used_external_snat_ips {
+        if let Some(zone1) = used_external_floating_ips.get(&ip) {
+            blippy.push_note(
+                Component::Sled(sled_id),
+                Severity::Fatal,
+                Kind::DuplicateExternalIp { zone1, zone2, ip },
+            );
+        }
+    }
+}
+
+fn check_dataset_zpool_uniqueness(blippy: &mut Blippy<'_>) {
+    let mut durable_kinds_by_zpool: BTreeMap<ZpoolUuid, BTreeMap<ZoneKind, _>> =
+        BTreeMap::new();
+    let mut transient_kinds_by_zpool: BTreeMap<
+        ZpoolUuid,
+        BTreeMap<ZoneKind, _>,
+    > = BTreeMap::new();
+
+    // On any given zpool, we should have at most one zone of any given
+    // kind.
+    for (sled_id, zone) in
+        // TODO-john in `verify_blueprint` the filter here was `::All`, but I
+        // think that's wrong? It prevents (e.g.) a Nexus from running on a
+        // zpool where there was a previously-expunged Nexus. We only care about
+        // uniqueness-per-zpool for live zones, right?
+        blippy
+            .blueprint()
+            .all_omicron_zones(BlueprintZoneFilter::ShouldBeRunning)
+    {
+        // Check "one kind per zpool" for durable datasets...
+        if let Some(dataset) = zone.zone_type.durable_dataset() {
+            let kind = zone.zone_type.kind();
+            if let Some(previous) = durable_kinds_by_zpool
+                .entry(dataset.dataset.pool_name.id())
+                .or_default()
+                .insert(kind, zone)
+            {
+                blippy.push_note(
+                    Component::Sled(sled_id),
+                    Severity::Fatal,
+                    Kind::ZoneDurableDatasetCollision {
+                        zone1: previous,
+                        zone2: zone,
+                        zpool: dataset.dataset.pool_name.clone(),
+                    },
+                );
+            }
+        }
+
+        // ... and transient datasets.
+        if let Some(dataset) = zone.filesystem_dataset() {
+            let kind = zone.zone_type.kind();
+            if let Some(previous) = transient_kinds_by_zpool
+                .entry(dataset.pool().id())
+                .or_default()
+                .insert(kind, zone)
+            {
+                blippy.push_note(
+                    Component::Sled(sled_id),
+                    Severity::Fatal,
+                    Kind::ZpoolFilesystemDatasetCollision {
+                        zone1: previous,
+                        zone2: zone,
+                        zpool: dataset.into_parts().0,
+                    },
+                );
+            }
+        }
+
+        // If a zone has both durable and transient datasets, they should be on
+        // the same pool.
+        match (zone.zone_type.durable_zpool(), zone.filesystem_pool.as_ref()) {
+            (Some(durable), Some(transient)) if durable != transient => {
+                blippy.push_note(
+                    Component::Sled(sled_id),
+                    Severity::Fatal,
+                    Kind::ZoneWithDatasetsOnDifferentZpools {
+                        zone,
+                        durable_zpool: durable.clone(),
+                        transient_zpool: transient.clone(),
+                    },
+                );
+            }
+            _ => (),
+        }
+    }
+}
+
+type DatasetByKind<'a> = BTreeMap<DatasetKind, &'a BlueprintDatasetConfig>;
+type DatasetsByZpool<'a> = BTreeMap<ZpoolUuid, DatasetByKind<'a>>;
+
+#[derive(Debug)]
+struct DatasetsBySled<'a> {
+    by_sled: BTreeMap<SledUuid, DatasetsByZpool<'a>>,
+    noted_sleds_missing_datasets: BTreeSet<SledUuid>,
+}
+
+impl<'a> DatasetsBySled<'a> {
+    fn new(blippy: &mut Blippy<'a>) -> Self {
+        let mut by_sled = BTreeMap::new();
+
+        for (&sled_id, config) in &blippy.blueprint().blueprint_datasets {
+            let by_zpool: &mut BTreeMap<_, _> =
+                by_sled.entry(sled_id).or_default();
+
+            for dataset in config.datasets.values() {
+                let by_kind: &mut BTreeMap<_, _> =
+                    by_zpool.entry(dataset.pool.id()).or_default();
+
+                match by_kind.entry(dataset.kind.clone()) {
+                    Entry::Vacant(slot) => {
+                        slot.insert(dataset);
+                    }
+                    Entry::Occupied(prev) => {
+                        blippy.push_note(
+                            Component::Sled(sled_id),
+                            Severity::Fatal,
+                            Kind::ZpoolWithDuplicateDatasetKinds {
+                                dataset1: prev.get(),
+                                dataset2: dataset,
+                                zpool: dataset.pool.id(),
+                            },
+                        );
+                    }
+                }
+            }
+        }
+
+        Self { by_sled, noted_sleds_missing_datasets: BTreeSet::new() }
+    }
+
+    fn for_sled(
+        &mut self,
+        blippy: &mut Blippy<'_>,
+        sled_id: SledUuid,
+    ) -> Option<&DatasetsByZpool<'a>> {
+        let maybe_datasets = self.by_sled.get(&sled_id);
+        if maybe_datasets.is_none()
+            && self.noted_sleds_missing_datasets.insert(sled_id)
+        {
+            blippy.push_note(
+                Component::Sled(sled_id),
+                Severity::Fatal,
+                Kind::SledMissingDatasets { sled_id },
+            );
+        }
+        maybe_datasets
+    }
+}
+
+fn check_datasets(blippy: &mut Blippy<'_>) {
+    let mut datasets = DatasetsBySled::new(blippy);
+
+    // As we loop through all the datasets we expect to see, mark them down.
+    // Afterwards, we'll check for any datasets present that we _didn't_ expect
+    // to see.
+    let mut expected_datasets = BTreeSet::new();
+
+    // All disks should have debug and zone root datasets.
+    //
+    // TODO-correctness We currently only include in-service disks in the
+    // blueprint; once we include expunged or decommissioned disks too, we
+    // should filter here to only in-service.
+    for (&sled_id, disk_config) in &blippy.blueprint().blueprint_disks {
+        let Some(sled_datasets) = datasets.for_sled(blippy, sled_id) else {
+            continue;
+        };
+
+        for disk in &disk_config.disks {
+            let sled_datasets = sled_datasets.get(&disk.pool_id);
+
+            match sled_datasets
+                .and_then(|by_zpool| by_zpool.get(&DatasetKind::Debug))
+            {
+                Some(dataset) => {
+                    expected_datasets.insert(dataset.id);
+                }
+                None => {
+                    blippy.push_note(
+                        Component::Sled(sled_id),
+                        Severity::Fatal,
+                        Kind::ZpoolMissingDebugDataset { zpool: disk.pool_id },
+                    );
+                }
+            }
+
+            match sled_datasets.and_then(|by_zpool| {
+                by_zpool.get(&DatasetKind::TransientZoneRoot)
+            }) {
+                Some(dataset) => {
+                    expected_datasets.insert(dataset.id);
+                }
+                None => {
+                    blippy.push_note(
+                        Component::Sled(sled_id),
+                        Severity::Fatal,
+                        Kind::ZpoolMissingZoneRootDataset {
+                            zpool: disk.pool_id,
+                        },
+                    );
+                }
+            }
+        }
+    }
+
+    // There should be a dataset for every dataset referenced by a running zone
+    // (filesystem or durable).
+    for (sled_id, zone_config) in blippy
+        .blueprint()
+        .all_omicron_zones(BlueprintZoneFilter::ShouldBeRunning)
+    {
+        let Some(sled_datasets) = datasets.for_sled(blippy, sled_id) else {
+            continue;
+        };
+
+        match &zone_config.filesystem_dataset() {
+            Some(dataset) => {
+                match sled_datasets
+                    .get(&dataset.pool().id())
+                    .and_then(|by_zpool| by_zpool.get(dataset.dataset()))
+                {
+                    Some(dataset) => {
+                        expected_datasets.insert(dataset.id);
+                    }
+                    None => {
+                        blippy.push_note(
+                            Component::Sled(sled_id),
+                            Severity::Fatal,
+                            Kind::ZoneMissingFilesystemDataset {
+                                zone: zone_config,
+                            },
+                        );
+                    }
+                }
+            }
+            None => {
+                // TODO-john Add a Severity::BackwardsCompatibility and note the
+                // missing filesystem pool
+            }
+        }
+
+        if let Some(dataset) = zone_config.zone_type.durable_dataset() {
+            match sled_datasets
+                .get(&dataset.dataset.pool_name.id())
+                .and_then(|by_zpool| by_zpool.get(&dataset.kind))
+            {
+                Some(dataset) => {
+                    expected_datasets.insert(dataset.id);
+                }
+                None => {
+                    blippy.push_note(
+                        Component::Sled(sled_id),
+                        Severity::Fatal,
+                        Kind::ZoneMissingDurableDataset { zone: zone_config },
+                    );
+                }
+            }
+        }
+    }
+
+    // TODO-correctness We currently only include in-service disks in the
+    // blueprint; once we include expunged or decommissioned disks too, we
+    // should filter here to only in-service.
+    let in_service_sled_zpools = blippy
+        .blueprint()
+        .blueprint_disks
+        .iter()
+        .map(|(sled_id, disk_config)| {
+            (
+                sled_id,
+                disk_config
+                    .disks
+                    .iter()
+                    .map(|disk| disk.pool_id)
+                    .collect::<BTreeSet<_>>(),
+            )
+        })
+        .collect::<BTreeMap<_, _>>();
+    let mut noted_sleds_without_disks = BTreeSet::new();
+
+    // All datasets should be on zpools that have disk records, and all datasets
+    // should have been referenced by either a zone or a disk above.
+    for (sled_id, dataset) in blippy
+        .blueprint()
+        .all_omicron_datasets(BlueprintDatasetFilter::InService)
+    {
+        if !expected_datasets.contains(&dataset.id) {
+            blippy.push_note(
+                Component::Sled(sled_id),
+                Severity::Fatal,
+                Kind::OrphanedDataset { dataset },
+            );
+            continue;
+        }
+
+        let Some(sled_zpools) = in_service_sled_zpools.get(&sled_id) else {
+            if noted_sleds_without_disks.insert(sled_id) {
+                blippy.push_note(
+                    Component::Sled(sled_id),
+                    Severity::Fatal,
+                    Kind::SledMissingDisks { sled_id },
+                );
+            }
+            continue;
+        };
+
+        if !sled_zpools.contains(&dataset.pool.id()) {
+            blippy.push_note(
+                Component::Sled(sled_id),
+                Severity::Fatal,
+                Kind::DatasetOnNonexistentDisk { dataset },
+            );
+            continue;
+        }
+    }
+}

--- a/nexus/reconfigurator/blippy/src/checks.rs
+++ b/nexus/reconfigurator/blippy/src/checks.rs
@@ -223,14 +223,9 @@ fn check_dataset_zpool_uniqueness(blippy: &mut Blippy<'_>) {
 
     // On any given zpool, we should have at most one zone of any given
     // kind.
-    for (sled_id, zone) in
-        // TODO-john in `verify_blueprint` the filter here was `::All`, but I
-        // think that's wrong? It prevents (e.g.) a Nexus from running on a
-        // zpool where there was a previously-expunged Nexus. We only care about
-        // uniqueness-per-zpool for live zones, right?
-        blippy
-            .blueprint()
-            .all_omicron_zones(BlueprintZoneFilter::ShouldBeRunning)
+    for (sled_id, zone) in blippy
+        .blueprint()
+        .all_omicron_zones(BlueprintZoneFilter::ShouldBeRunning)
     {
         // Check "one kind per zpool" for durable datasets...
         if let Some(dataset) = zone.zone_type.durable_dataset() {
@@ -674,8 +669,8 @@ mod tests {
     }
 
     #[test]
-    fn test_bad_internnal_dns_subnet() {
-        static TEST_NAME: &str = "test_bad_internnal_dns_subnet";
+    fn test_bad_internal_dns_subnet() {
+        static TEST_NAME: &str = "test_bad_internal_dns_subnet";
         let logctx = test_setup_log(TEST_NAME);
         let (_, _, mut blueprint) = example(&logctx.log, TEST_NAME);
 
@@ -1370,7 +1365,11 @@ mod tests {
                 }
             }
         }
-        assert!(found_sled_missing_note, "found sled missing datasets note");
+        assert!(
+            found_sled_missing_note,
+            "did not find expected note for missing datasets entry for \
+             sled {removed_sled_id}"
+        );
 
         logctx.cleanup_successful();
     }
@@ -1408,7 +1407,11 @@ mod tests {
                 }
             }
         }
-        assert!(found_sled_missing_note, "found sled missing disks note");
+        assert!(
+            found_sled_missing_note,
+            "did not find expected note for missing disks entry for \
+             sled {removed_sled_id}"
+        );
 
         logctx.cleanup_successful();
     }

--- a/nexus/reconfigurator/blippy/src/lib.rs
+++ b/nexus/reconfigurator/blippy/src/lib.rs
@@ -1,0 +1,10 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at https://mozilla.org/MPL/2.0/.
+
+//! Blippy: the blueprint checker
+
+mod blippy;
+mod checks;
+
+pub use blippy::*;

--- a/nexus/reconfigurator/blippy/src/lib.rs
+++ b/nexus/reconfigurator/blippy/src/lib.rs
@@ -3,6 +3,13 @@
 // file, You can obtain one at https://mozilla.org/MPL/2.0/.
 
 //! Blippy: the blueprint checker
+//!
+//! [`Blippy`] performs a variety of checks on blueprints to ensure they are
+//! internally-consistent (e.g., "every in-service zone that should have one or
+//! more datasets do", or "any given external IP address is used by at most one
+//! in-service zone"). It emits [`BlippyReport`]s in the form of a list of
+//! [`BlippyNote`]s, each of which has an associated severity and parent
+//! component (typically a sled).
 
 mod blippy;
 mod checks;

--- a/nexus/reconfigurator/blippy/src/lib.rs
+++ b/nexus/reconfigurator/blippy/src/lib.rs
@@ -19,5 +19,6 @@ pub use blippy::Blippy;
 pub use blippy::Kind as BlippyKind;
 pub use blippy::Note as BlippyNote;
 pub use blippy::Severity as BlippySeverity;
+pub use blippy::SledKind as BlippySledKind;
 pub use report::BlippyReport;
 pub use report::BlippyReportSortKey;

--- a/nexus/reconfigurator/blippy/src/lib.rs
+++ b/nexus/reconfigurator/blippy/src/lib.rs
@@ -6,5 +6,11 @@
 
 mod blippy;
 mod checks;
+mod report;
 
-pub use blippy::*;
+pub use blippy::Blippy;
+pub use blippy::Kind as BlippyKind;
+pub use blippy::Note as BlippyNote;
+pub use blippy::Severity as BlippySeverity;
+pub use report::BlippyReport;
+pub use report::BlippyReportSortKey;

--- a/nexus/reconfigurator/blippy/src/report.rs
+++ b/nexus/reconfigurator/blippy/src/report.rs
@@ -15,14 +15,14 @@ pub enum BlippyReportSortKey {
 #[derive(Debug)]
 pub struct BlippyReport<'a> {
     blueprint: &'a Blueprint,
-    notes: Vec<Note<'a>>,
+    notes: Vec<Note>,
     sort_key: BlippyReportSortKey,
 }
 
 impl<'a> BlippyReport<'a> {
     pub(crate) fn new(
         blueprint: &'a Blueprint,
-        notes: Vec<Note<'a>>,
+        notes: Vec<Note>,
         sort_key: BlippyReportSortKey,
     ) -> Self {
         let mut slf = Self { blueprint, notes, sort_key };
@@ -54,7 +54,7 @@ impl<'a> BlippyReport<'a> {
         self.blueprint
     }
 
-    pub fn notes(&self) -> &[Note<'a>] {
+    pub fn notes(&self) -> &[Note] {
         &self.notes
     }
 

--- a/nexus/reconfigurator/blippy/src/report.rs
+++ b/nexus/reconfigurator/blippy/src/report.rs
@@ -1,0 +1,86 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at https://mozilla.org/MPL/2.0/.
+
+use crate::blippy::Note;
+use core::fmt;
+use nexus_types::deployment::Blueprint;
+
+#[derive(Debug, Clone, Copy)]
+pub enum BlippyReportSortKey {
+    Component,
+    Severity,
+}
+
+#[derive(Debug)]
+pub struct BlippyReport<'a> {
+    blueprint: &'a Blueprint,
+    notes: Vec<Note<'a>>,
+    sort_key: BlippyReportSortKey,
+}
+
+impl<'a> BlippyReport<'a> {
+    pub(crate) fn new(
+        blueprint: &'a Blueprint,
+        notes: Vec<Note<'a>>,
+        sort_key: BlippyReportSortKey,
+    ) -> Self {
+        let mut slf = Self { blueprint, notes, sort_key };
+        slf.sort_notes_by_key(sort_key);
+        slf
+    }
+
+    pub fn sort_notes_by_key(&mut self, key: BlippyReportSortKey) {
+        match key {
+            BlippyReportSortKey::Component => {
+                self.notes.sort_unstable_by(|a, b| {
+                    let a = (&a.component, &a.severity, &a.kind);
+                    let b = (&b.component, &b.severity, &b.kind);
+                    a.cmp(&b)
+                });
+            }
+            BlippyReportSortKey::Severity => {
+                self.notes.sort_unstable_by(|a, b| {
+                    let a = (&a.severity, &a.component, &a.kind);
+                    let b = (&b.severity, &b.component, &b.kind);
+                    a.cmp(&b)
+                });
+            }
+        }
+        self.sort_key = key;
+    }
+
+    pub fn blueprint(&self) -> &'a Blueprint {
+        self.blueprint
+    }
+
+    pub fn notes(&self) -> &[Note<'a>] {
+        &self.notes
+    }
+
+    pub fn display(&self) -> BlippyReportDisplay<'_> {
+        BlippyReportDisplay { report: self }
+    }
+}
+
+#[derive(Debug)]
+pub struct BlippyReportDisplay<'a> {
+    report: &'a BlippyReport<'a>,
+}
+
+impl<'a> fmt::Display for BlippyReportDisplay<'_> {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        let pluralize =
+            if self.report.notes.len() == 1 { "" } else { "s" };
+        writeln!(
+            f,
+            "blippy report for blueprint {}: {} note{pluralize}",
+            self.report.blueprint.id,
+            self.report.notes.len(),
+        )?;
+        for note in self.report.notes() {
+            writeln!(f, "  {}", note.display(self.report.sort_key))?;
+        }
+        Ok(())
+    }
+}

--- a/nexus/reconfigurator/blippy/src/report.rs
+++ b/nexus/reconfigurator/blippy/src/report.rs
@@ -8,7 +8,7 @@ use nexus_types::deployment::Blueprint;
 
 #[derive(Debug, Clone, Copy)]
 pub enum BlippyReportSortKey {
-    Component,
+    Kind,
     Severity,
 }
 
@@ -32,17 +32,17 @@ impl<'a> BlippyReport<'a> {
 
     pub fn sort_notes_by_key(&mut self, key: BlippyReportSortKey) {
         match key {
-            BlippyReportSortKey::Component => {
+            BlippyReportSortKey::Kind => {
                 self.notes.sort_unstable_by(|a, b| {
-                    let a = (&a.component, &a.severity, &a.kind);
-                    let b = (&b.component, &b.severity, &b.kind);
+                    let a = (&a.kind, &a.severity);
+                    let b = (&b.kind, &b.severity);
                     a.cmp(&b)
                 });
             }
             BlippyReportSortKey::Severity => {
                 self.notes.sort_unstable_by(|a, b| {
-                    let a = (&a.severity, &a.component, &a.kind);
-                    let b = (&b.severity, &b.component, &b.kind);
+                    let a = (&a.severity, &a.kind);
+                    let b = (&b.severity, &b.kind);
                     a.cmp(&b)
                 });
             }

--- a/nexus/reconfigurator/blippy/src/report.rs
+++ b/nexus/reconfigurator/blippy/src/report.rs
@@ -68,7 +68,7 @@ pub struct BlippyReportDisplay<'a> {
     report: &'a BlippyReport<'a>,
 }
 
-impl<'a> fmt::Display for BlippyReportDisplay<'_> {
+impl fmt::Display for BlippyReportDisplay<'_> {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         let pluralize =
             if self.report.notes.len() == 1 { "" } else { "s" };

--- a/nexus/reconfigurator/blippy/src/report.rs
+++ b/nexus/reconfigurator/blippy/src/report.rs
@@ -70,8 +70,7 @@ pub struct BlippyReportDisplay<'a> {
 
 impl fmt::Display for BlippyReportDisplay<'_> {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        let pluralize =
-            if self.report.notes.len() == 1 { "" } else { "s" };
+        let pluralize = if self.report.notes.len() == 1 { "" } else { "s" };
         writeln!(
             f,
             "blippy report for blueprint {}: {} note{pluralize}",

--- a/nexus/reconfigurator/execution/src/lib.rs
+++ b/nexus/reconfigurator/execution/src/lib.rs
@@ -400,7 +400,9 @@ fn register_dataset_records_step<'a>(
                     &opctx,
                     datastore,
                     bp_id,
-                    blueprint.all_omicron_datasets(BlueprintDatasetFilter::All),
+                    blueprint
+                        .all_omicron_datasets(BlueprintDatasetFilter::All)
+                        .map(|(_sled_id, dataset)| dataset),
                 )
                 .await?;
 

--- a/nexus/reconfigurator/planning/Cargo.toml
+++ b/nexus/reconfigurator/planning/Cargo.toml
@@ -19,6 +19,7 @@ ipnet.workspace = true
 itertools.workspace = true
 nexus-config.workspace = true
 nexus-inventory.workspace = true
+nexus-reconfigurator-blippy.workspace = true
 nexus-sled-agent-shared.workspace = true
 nexus-types.workspace = true
 omicron-common.workspace = true

--- a/nexus/reconfigurator/planning/src/blueprint_builder/builder.rs
+++ b/nexus/reconfigurator/planning/src/blueprint_builder/builder.rs
@@ -1925,7 +1925,7 @@ pub mod test {
     #[track_caller]
     pub fn verify_blueprint(blueprint: &Blueprint) {
         let blippy_report =
-            Blippy::new(blueprint).into_report(BlippyReportSortKey::Component);
+            Blippy::new(blueprint).into_report(BlippyReportSortKey::Kind);
         if !blippy_report.notes().is_empty() {
             eprintln!("{}", blueprint.display());
             eprintln!("---");

--- a/nexus/reconfigurator/planning/src/blueprint_builder/builder.rs
+++ b/nexus/reconfigurator/planning/src/blueprint_builder/builder.rs
@@ -1834,11 +1834,13 @@ impl<'a> BlueprintBuilder<'a> {
         let mut skip_zpools = BTreeSet::new();
         for zone_config in self
             .current_sled_zones(sled_id, BlueprintZoneFilter::ShouldBeRunning)
+            .filter(|z| z.zone_type.kind() == zone_kind)
         {
             if let Some(zpool) = zone_config.zone_type.durable_zpool() {
-                if zone_kind == zone_config.zone_type.kind() {
-                    skip_zpools.insert(zpool);
-                }
+                skip_zpools.insert(zpool);
+            }
+            if let Some(zpool) = &zone_config.filesystem_pool {
+                skip_zpools.insert(zpool);
             }
         }
 
@@ -1901,211 +1903,34 @@ impl<'a> BlueprintBuilder<'a> {
 #[cfg(test)]
 pub mod test {
     use super::*;
-    use crate::blueprint_builder::external_networking::ExternalIpAllocator;
     use crate::example::example;
     use crate::example::ExampleSystemBuilder;
     use crate::example::SimRngState;
     use crate::system::SledBuilder;
     use nexus_inventory::CollectionBuilder;
-    use nexus_types::deployment::BlueprintDatasetConfig;
+    use nexus_reconfigurator_blippy::Blippy;
+    use nexus_reconfigurator_blippy::BlippyReportSortKey;
     use nexus_types::deployment::BlueprintDatasetDisposition;
-    use nexus_types::deployment::BlueprintDatasetFilter;
     use nexus_types::deployment::BlueprintZoneFilter;
     use nexus_types::deployment::OmicronZoneNetworkResources;
     use nexus_types::external_api::views::SledPolicy;
     use omicron_common::address::IpRange;
-    use omicron_common::disk::DatasetKind;
     use omicron_test_utils::dev::test_setup_log;
-    use omicron_uuid_kinds::DatasetUuid;
     use std::collections::BTreeSet;
     use std::mem;
 
     pub const DEFAULT_N_SLEDS: usize = 3;
 
-    fn datasets_for_sled(
-        blueprint: &Blueprint,
-        sled_id: SledUuid,
-    ) -> &BTreeMap<DatasetUuid, BlueprintDatasetConfig> {
-        &blueprint
-            .blueprint_datasets
-            .get(&sled_id)
-            .unwrap_or_else(|| {
-                panic!("Cannot find datasets on missing sled: {sled_id}")
-            })
-            .datasets
-    }
-
-    fn find_dataset<'a>(
-        datasets: &'a BTreeMap<DatasetUuid, BlueprintDatasetConfig>,
-        zpool: &ZpoolName,
-        kind: DatasetKind,
-    ) -> &'a BlueprintDatasetConfig {
-        datasets.values().find(|dataset| {
-            &dataset.pool == zpool &&
-                dataset.kind == kind
-        }).unwrap_or_else(|| {
-            let kinds = datasets.values().map(|d| (&d.id, &d.pool, &d.kind)).collect::<Vec<_>>();
-            panic!("Cannot find dataset of type {kind}\nFound the following: {kinds:#?}")
-        })
-    }
-
     /// Checks various conditions that should be true for all blueprints
     #[track_caller]
     pub fn verify_blueprint(blueprint: &Blueprint) {
-        // There should be no duplicate underlay IPs.
-        let mut underlay_ips: BTreeMap<Ipv6Addr, &BlueprintZoneConfig> =
-            BTreeMap::new();
-        for (_, zone) in
-            blueprint.all_omicron_zones(BlueprintZoneFilter::ShouldBeRunning)
-        {
-            if let Some(previous) =
-                underlay_ips.insert(zone.underlay_ip(), zone)
-            {
-                panic!(
-                    "found duplicate underlay IP {} in zones {} and {}\
-                    \n\n\
-                    blueprint: {}",
-                    zone.underlay_ip(),
-                    zone.id,
-                    previous.id,
-                    blueprint.display(),
-                );
-            }
-        }
-
-        // There should be no duplicate external IPs.
-        //
-        // Checking this is slightly complicated due to SNAT IPs, so we'll
-        // delegate to an `ExternalIpAllocator`, which already contains the
-        // logic for dup checking. (`mark_ip_used` fails if the IP is _already_
-        // marked as used.)
-        //
-        // We create this with an empty set of service IP pool ranges; those are
-        // used for allocation, which we don't do, and aren't needed for
-        // duplicate checking.
-        let mut ip_allocator = ExternalIpAllocator::new(&[]);
-        for (external_ip, _nic) in blueprint
-            .all_omicron_zones(BlueprintZoneFilter::ShouldBeRunning)
-            .filter_map(|(_, zone)| zone.zone_type.external_networking())
-        {
-            ip_allocator
-                .mark_ip_used(&external_ip)
-                .expect("no duplicate external IPs in running zones");
-        }
-
-        // On any given zpool, we should have at most one zone of any given
-        // kind.
-        //
-        // TODO: we may want a similar check for non-durable datasets?
-        let mut kinds_by_zpool: BTreeMap<
-            ZpoolUuid,
-            BTreeMap<ZoneKind, OmicronZoneUuid>,
-        > = BTreeMap::new();
-        for (_, zone) in blueprint.all_omicron_zones(BlueprintZoneFilter::All) {
-            if let Some(dataset) = zone.zone_type.durable_dataset() {
-                let kind = zone.zone_type.kind();
-                if let Some(previous) = kinds_by_zpool
-                    .entry(dataset.dataset.pool_name.id())
-                    .or_default()
-                    .insert(kind, zone.id)
-                {
-                    panic!(
-                        "zpool {} has two zones of kind {kind:?}: {} and {}\
-                            \n\n\
-                            blueprint: {}",
-                        dataset.dataset.pool_name,
-                        zone.id,
-                        previous,
-                        blueprint.display(),
-                    );
-                }
-            }
-        }
-
-        // All disks should have debug and zone root datasets.
-        for (sled_id, disk_config) in &blueprint.blueprint_disks {
-            for disk in &disk_config.disks {
-                eprintln!(
-                    "checking datasets for sled {sled_id} disk {}",
-                    disk.id
-                );
-                let zpool = ZpoolName::new_external(disk.pool_id);
-                let datasets = datasets_for_sled(&blueprint, *sled_id);
-
-                let dataset =
-                    find_dataset(&datasets, &zpool, DatasetKind::Debug);
-                assert_eq!(
-                    dataset.disposition,
-                    BlueprintDatasetDisposition::InService
-                );
-                let dataset = find_dataset(
-                    &datasets,
-                    &zpool,
-                    DatasetKind::TransientZoneRoot,
-                );
-                assert_eq!(
-                    dataset.disposition,
-                    BlueprintDatasetDisposition::InService
-                );
-            }
-        }
-
-        // All zones should have dataset records.
-        for (sled_id, zone_config) in
-            blueprint.all_omicron_zones(BlueprintZoneFilter::ShouldBeRunning)
-        {
-            match blueprint.sled_state.get(&sled_id) {
-                // Decommissioned sleds don't keep dataset state around.
-                //
-                // Normally we wouldn't observe zones from decommissioned sleds
-                // anyway, but that's the responsibility of the Planner, not the
-                // BlueprintBuilder.
-                None | Some(SledState::Decommissioned) => continue,
-                Some(SledState::Active) => (),
-            }
-            let datasets = datasets_for_sled(&blueprint, sled_id);
-
-            let (zpool, kind) =
-                zone_config.filesystem_dataset().unwrap().into_parts();
-            let dataset = find_dataset(&datasets, &zpool, kind);
-            assert_eq!(
-                dataset.disposition,
-                BlueprintDatasetDisposition::InService
-            );
-
-            if let Some(durable_dataset) =
-                zone_config.zone_type.durable_dataset()
-            {
-                let zpool = &durable_dataset.dataset.pool_name;
-                let dataset =
-                    find_dataset(&datasets, &zpool, durable_dataset.kind);
-                assert_eq!(
-                    dataset.disposition,
-                    BlueprintDatasetDisposition::InService
-                );
-            }
-        }
-
-        // All datasets should be on zpools that have disk records.
-        for (sled_id, datasets) in &blueprint.blueprint_datasets {
-            let sled_disk_zpools = blueprint
-                .blueprint_disks
-                .get(&sled_id)
-                .expect("no disks for sled")
-                .disks
-                .iter()
-                .map(|disk| disk.pool_id)
-                .collect::<BTreeSet<_>>();
-
-            for dataset in datasets.datasets.values().filter(|dataset| {
-                dataset.disposition.matches(BlueprintDatasetFilter::InService)
-            }) {
-                assert!(
-                    sled_disk_zpools.contains(&dataset.pool.id()),
-                    "sled {sled_id} has dataset {dataset:?}, \
-                     which references a zpool without an associated disk",
-                );
-            }
+        let blippy_report =
+            Blippy::new(blueprint).into_report(BlippyReportSortKey::Component);
+        if !blippy_report.notes().is_empty() {
+            eprintln!("{}", blueprint.display());
+            eprintln!("---");
+            eprintln!("{}", blippy_report.display());
+            panic!("expected blippy report for blueprint to have no notes");
         }
     }
 
@@ -2313,6 +2138,20 @@ pub mod test {
             .expect("at least one sled");
         *blueprint1.sled_state.get_mut(&decommision_sled_id).unwrap() =
             SledState::Decommissioned;
+
+        // We're going under the hood of the blueprint here; a sled can only get
+        // to the decommissioned state if all its disks/datasets/zones have been
+        // expunged, so do that too.
+        for zone in &mut blueprint1
+            .blueprint_zones
+            .get_mut(&decommision_sled_id)
+            .expect("has zones")
+            .zones
+        {
+            zone.disposition = BlueprintZoneDisposition::Expunged;
+        }
+        blueprint1.blueprint_datasets.remove(&decommision_sled_id);
+        blueprint1.blueprint_disks.remove(&decommision_sled_id);
 
         // Change the input to note that the sled is expunged, but still active.
         let mut builder = input.into_builder();

--- a/nexus/reconfigurator/planning/src/blueprint_builder/internal_dns.rs
+++ b/nexus/reconfigurator/planning/src/blueprint_builder/internal_dns.rs
@@ -102,6 +102,7 @@ pub mod test {
     use crate::blueprint_builder::test::verify_blueprint;
     use crate::example::ExampleSystemBuilder;
     use nexus_types::deployment::BlueprintZoneFilter;
+    use omicron_common::disk::DatasetKind;
     use omicron_common::policy::INTERNAL_DNS_REDUNDANCY;
     use omicron_test_utils::dev::test_setup_log;
 
@@ -127,6 +128,24 @@ pub mod test {
         }
         let npruned = blueprint1.blueprint_zones.len() - 1;
         assert!(npruned > 0);
+
+        // Also prune out the zones' datasets, or we're left with an invalid
+        // blueprint.
+        for (_, dataset_config) in
+            blueprint1.blueprint_datasets.iter_mut().skip(1)
+        {
+            dataset_config.datasets.retain(|_id, dataset| {
+                // This is gross; once zone configs know explicit dataset IDs,
+                // we should retain by ID instead.
+                match &dataset.kind {
+                    DatasetKind::InternalDns => false,
+                    DatasetKind::TransientZone { name } => {
+                        !name.starts_with("oxz_internal_dns")
+                    }
+                    _ => true,
+                }
+            });
+        }
 
         verify_blueprint(&blueprint1);
 

--- a/nexus/reconfigurator/planning/src/planner.rs
+++ b/nexus/reconfigurator/planning/src/planner.rs
@@ -1253,6 +1253,21 @@ mod test {
         for (_sled_id, zones) in blueprint1.blueprint_zones.iter_mut().take(2) {
             zones.zones.retain(|z| !z.zone_type.is_internal_dns());
         }
+        for (_, dataset_config) in
+            blueprint1.blueprint_datasets.iter_mut().take(2)
+        {
+            dataset_config.datasets.retain(|_id, dataset| {
+                // This is gross; once zone configs know explicit dataset IDs,
+                // we should retain by ID instead.
+                match &dataset.kind {
+                    DatasetKind::InternalDns => false,
+                    DatasetKind::TransientZone { name } => {
+                        !name.starts_with("oxz_internal_dns")
+                    }
+                    _ => true,
+                }
+            });
+        }
 
         let blueprint2 = Planner::new_based_on(
             logctx.log.clone(),

--- a/nexus/reconfigurator/planning/tests/output/planner_dataset_settings_modified_in_place_1_2.txt
+++ b/nexus/reconfigurator/planning/tests/output/planner_dataset_settings_modified_in_place_1_2.txt
@@ -61,8 +61,8 @@ to:   blueprint fe13be30-94c2-4fa6-aad5-ae3c5028f6bb
     oxp_f843fb62-0f04-4c7d-a56f-62531104dc77/crypt/zone/oxz_crucible_fc4f1769-9611-42d3-b8c1-f2be9b5359f6          35fa6ec8-6b58-4fcc-a5a2-36e66736e9c1   none        none          off        
     oxp_96569b61-9e0c-4ee7-bd11-a5e0c541ca99/crypt/zone/oxz_crucible_fff71a84-09c2-4dab-bc18-8f4570f278bb          00abfe99-288d-4a63-abea-adfa62e74524   none        none          off        
     oxp_3b6e2ade-57fc-4f9d-85c3-38fca27f1df6/crypt/zone/oxz_crucible_pantry_197067bc-9a21-444e-9794-6051d9f78a00   19736dbd-1d01-41e9-a800-ffc450464c2d   none        none          off        
-    oxp_3b6e2ade-57fc-4f9d-85c3-38fca27f1df6/crypt/zone/oxz_crucible_pantry_350fba7f-b754-429e-a21d-e91d139713f2   8be4aa2f-1612-4bdf-a0f6-7458b151308f   none        none          off        
-    oxp_3b6e2ade-57fc-4f9d-85c3-38fca27f1df6/crypt/zone/oxz_crucible_pantry_504963cb-3077-477c-b4e5-2d69bf9caa0c   7fd439f9-dcef-4cfb-b1a1-d298be9d2e3b   none        none          off        
+    oxp_5192ef62-5a12-4a0c-829d-a409da87909c/crypt/zone/oxz_crucible_pantry_350fba7f-b754-429e-a21d-e91d139713f2   8be4aa2f-1612-4bdf-a0f6-7458b151308f   none        none          off        
+    oxp_8778bcc5-dddf-4345-9fdf-5c46a36497b0/crypt/zone/oxz_crucible_pantry_504963cb-3077-477c-b4e5-2d69bf9caa0c   7fd439f9-dcef-4cfb-b1a1-d298be9d2e3b   none        none          off        
     oxp_3b6e2ade-57fc-4f9d-85c3-38fca27f1df6/crypt/zone/oxz_internal_dns_1e9422ca-a3d9-4435-bb17-39d5ad22b4ba      5651c4fb-d146-4270-8794-6ed7ceb6f130   none        none          off        
     oxp_8778bcc5-dddf-4345-9fdf-5c46a36497b0/crypt/zone/oxz_internal_dns_4a0ec9f6-6ce6-4456-831e-5f8df7b57332      d2b9f103-8bf1-4603-873d-cec130430ba7   none        none          off        
     oxp_5192ef62-5a12-4a0c-829d-a409da87909c/crypt/zone/oxz_internal_dns_efecb8a2-ce0b-416f-958b-de1fad1bef02      158e226c-e44e-427f-93af-ee96d2cfb9be   none        none          off        

--- a/nexus/reconfigurator/planning/tests/output/planner_decommissions_sleds_1_2.txt
+++ b/nexus/reconfigurator/planning/tests/output/planner_decommissions_sleds_1_2.txt
@@ -177,8 +177,8 @@ to:   blueprint 1ac2d88f-27dd-4506-8585-6b2be832528e
     oxp_9d833141-18a1-4f24-8a34-6076c026aa87/crypt/debug                                                           f631d6a1-9db5-4fc7-978b-9ace485dfe16   100 GiB   none          gzip-9     
     oxp_a279461f-a7b9-413f-a79f-cb4dab4c3fce/crypt/debug                                                           1b9c97d6-c90d-4109-b99c-9ab799b3c3b9   100 GiB   none          gzip-9     
     oxp_ff7e002b-3ad8-4d45-b03a-c46ef0ac8e59/crypt/debug                                                           9427caff-29ec-4cd1-981b-26d4a7900052   100 GiB   none          gzip-9     
-+   oxp_1e2ec79e-9c11-4133-ac77-e0b994a507d5/crypt/zone/oxz_crucible_pantry_ff9ce09c-afbf-425b-bbfa-3d8fb254f98e   7d47e5d6-a1a5-451a-b4b4-3a9747f8154a   none      none          off        
-+   oxp_1e2ec79e-9c11-4133-ac77-e0b994a507d5/crypt/zone/oxz_nexus_845869e9-ecb2-4ec3-b6b8-2a836e459243             a759d2f3-003c-4fb8-b06b-f985e213b273   none      none          off        
++   oxp_440ae69d-5e2e-4539-91d0-e2930bdd7203/crypt/zone/oxz_crucible_pantry_ff9ce09c-afbf-425b-bbfa-3d8fb254f98e   7d47e5d6-a1a5-451a-b4b4-3a9747f8154a   none      none          off        
++   oxp_440ae69d-5e2e-4539-91d0-e2930bdd7203/crypt/zone/oxz_nexus_845869e9-ecb2-4ec3-b6b8-2a836e459243             a759d2f3-003c-4fb8-b06b-f985e213b273   none      none          off        
 
 
     omicron zones generation 2 -> 3:

--- a/nexus/reconfigurator/planning/tests/output/planner_expunge_clickhouse_clusters_3_4.txt
+++ b/nexus/reconfigurator/planning/tests/output/planner_expunge_clickhouse_clusters_3_4.txt
@@ -288,8 +288,8 @@ to:   blueprint 74f2e7fd-687e-4c9e-b5d8-e474a5bb8e7c
     oxp_fe379ac6-1938-4cc2-93a9-43b1447229ae/crypt/debug                                                             3a49dd24-8ead-4196-b453-8aa3273b77d1   100 GiB   none          gzip-9     
 +   oxp_21d60319-5fe1-4a3b-a4c0-6aa7465e7bde/crypt/clickhouse                                                        410eca9c-8eee-4a98-aea2-a363697974f7   none      none          off        
 +   oxp_21d60319-5fe1-4a3b-a4c0-6aa7465e7bde/crypt/zone/oxz_clickhouse_fa97835a-aabc-4fe9-9e85-3e50f207129c          08f15d4b-91dc-445d-88f4-cb9fa585444b   none      none          off        
-+   oxp_21d60319-5fe1-4a3b-a4c0-6aa7465e7bde/crypt/zone/oxz_crucible_pantry_7741bb11-0d99-4856-95ae-725b6b9ff4fa     4eb52e76-39fa-414d-ae9b-2dcb1c7737f9   none      none          off        
-+   oxp_21d60319-5fe1-4a3b-a4c0-6aa7465e7bde/crypt/zone/oxz_nexus_69789010-8689-43ab-9a68-a944afcba05a               e67b797b-a059-4c7e-a98b-fea18964bad6   none      none          off        
++   oxp_2acfbb84-5ce0-424e-8d73-44c5071d4430/crypt/zone/oxz_crucible_pantry_7741bb11-0d99-4856-95ae-725b6b9ff4fa     4eb52e76-39fa-414d-ae9b-2dcb1c7737f9   none      none          off        
++   oxp_2acfbb84-5ce0-424e-8d73-44c5071d4430/crypt/zone/oxz_nexus_69789010-8689-43ab-9a68-a944afcba05a               e67b797b-a059-4c7e-a98b-fea18964bad6   none      none          off        
 
 
     omicron zones generation 3 -> 4:

--- a/nexus/reconfigurator/planning/tests/output/planner_expunge_clickhouse_clusters_5_6.txt
+++ b/nexus/reconfigurator/planning/tests/output/planner_expunge_clickhouse_clusters_5_6.txt
@@ -188,9 +188,9 @@ to:   blueprint df68d4d4-5af4-4b56-95bb-1654a6957d4f
     oxp_427b2ccd-998f-4085-af21-e600604cf21e/crypt/zone/oxz_crucible_befe73dd-5970-49a4-9adf-7b4f453c45cf            95d72ef9-e070-49e4-a57b-2c392def6025   none      none          off        
     oxp_2fa34d8e-13d9-42d3-b8ba-ca9d74ac496a/crypt/zone/oxz_crucible_d9106a19-f267-48db-a82b-004e643feb49            9b9fb14e-cd17-4a7a-a74a-bfd9c7682831   none      none          off        
     oxp_21d60319-5fe1-4a3b-a4c0-6aa7465e7bde/crypt/zone/oxz_crucible_pantry_6c7f6a84-78b3-4dd9-878e-51bedfda471f     aa190e01-9a4e-4131-9fcf-240532108c7f   none      none          off        
-    oxp_21d60319-5fe1-4a3b-a4c0-6aa7465e7bde/crypt/zone/oxz_crucible_pantry_7741bb11-0d99-4856-95ae-725b6b9ff4fa     4eb52e76-39fa-414d-ae9b-2dcb1c7737f9   none      none          off        
+    oxp_2acfbb84-5ce0-424e-8d73-44c5071d4430/crypt/zone/oxz_crucible_pantry_7741bb11-0d99-4856-95ae-725b6b9ff4fa     4eb52e76-39fa-414d-ae9b-2dcb1c7737f9   none      none          off        
     oxp_21d60319-5fe1-4a3b-a4c0-6aa7465e7bde/crypt/zone/oxz_internal_dns_0c42ad01-b854-4e7d-bd6c-25fdc3eddef4        1de9cde7-6c1e-4865-bd3d-378e22f62fb8   none      none          off        
-    oxp_21d60319-5fe1-4a3b-a4c0-6aa7465e7bde/crypt/zone/oxz_nexus_69789010-8689-43ab-9a68-a944afcba05a               e67b797b-a059-4c7e-a98b-fea18964bad6   none      none          off        
+    oxp_2acfbb84-5ce0-424e-8d73-44c5071d4430/crypt/zone/oxz_nexus_69789010-8689-43ab-9a68-a944afcba05a               e67b797b-a059-4c7e-a98b-fea18964bad6   none      none          off        
     oxp_21d60319-5fe1-4a3b-a4c0-6aa7465e7bde/crypt/zone/oxz_nexus_7e763480-0f4f-43cb-ab9a-52b667d8fda5               5773e3b1-dde0-4b54-bc13-3c3bf816015e   none      none          off        
     oxp_21d60319-5fe1-4a3b-a4c0-6aa7465e7bde/crypt/zone/oxz_ntp_f34f8d36-7137-48d3-9d13-6a46c4edcef4                 c8c03dec-65d4-4c97-87c3-a43a8363c97c   none      none          off        
     oxp_21d60319-5fe1-4a3b-a4c0-6aa7465e7bde/crypt/debug                                                             f015e445-2e52-45c9-9f0a-49cb5ceae245   100 GiB   none          gzip-9     

--- a/nexus/reconfigurator/planning/tests/output/planner_nonprovisionable_1_2.txt
+++ b/nexus/reconfigurator/planning/tests/output/planner_nonprovisionable_1_2.txt
@@ -353,9 +353,9 @@ to:   blueprint 9f71f5d3-a272-4382-9154-6ea2e171a6c6
     oxp_cf32a1ce-2c9e-49f5-b1cf-4af7f2a28901/crypt/debug                                                    2dfc5c53-6618-4352-b754-86ef6463c20a   100 GiB   none          gzip-9     
     oxp_e405da11-cb6b-4ebc-bac1-9bc997352e10/crypt/debug                                                    61a653cf-44a6-43c0-90e1-bec539511703   100 GiB   none          gzip-9     
     oxp_f4d7f914-ec73-4b65-8696-5068591d9065/crypt/debug                                                    b803d901-7e43-42fa-8372-43c3c5b3c1a9   100 GiB   none          gzip-9     
-+   oxp_4069c804-c51a-4adc-8822-3cbbab56ed3f/crypt/zone/oxz_nexus_508abd03-cbfe-4654-9a6d-7f15a1ad32e5      b781d032-3149-4c44-a7d3-5f8d80e4a607   none      none          off        
-+   oxp_4069c804-c51a-4adc-8822-3cbbab56ed3f/crypt/zone/oxz_nexus_99f6d544-8599-4e2b-a55a-82d9e0034662      8a39677a-fbcf-4884-b000-63be3247fb63   none      none          off        
-+   oxp_4069c804-c51a-4adc-8822-3cbbab56ed3f/crypt/zone/oxz_nexus_c26b3bda-5561-44a1-a69f-22103fe209a1      c9c1a582-1fe0-4001-9301-97230387563a   none      none          off        
++   oxp_5248a306-4a03-449e-a8a3-6f86d26da755/crypt/zone/oxz_nexus_508abd03-cbfe-4654-9a6d-7f15a1ad32e5      b781d032-3149-4c44-a7d3-5f8d80e4a607   none      none          off        
++   oxp_55196665-ed61-4b23-9a74-0711bf2eaf90/crypt/zone/oxz_nexus_99f6d544-8599-4e2b-a55a-82d9e0034662      8a39677a-fbcf-4884-b000-63be3247fb63   none      none          off        
++   oxp_6b2a719a-35eb-469f-aa54-114a1f21f37d/crypt/zone/oxz_nexus_c26b3bda-5561-44a1-a69f-22103fe209a1      c9c1a582-1fe0-4001-9301-97230387563a   none      none          off        
 
 
     omicron zones generation 2 -> 3:
@@ -443,9 +443,9 @@ to:   blueprint 9f71f5d3-a272-4382-9154-6ea2e171a6c6
     oxp_cd62306a-aedf-47e8-93d5-92a358d64c7b/crypt/debug                                                    73674f4b-1d93-404a-bc9c-8395efac97fd   100 GiB   none          gzip-9     
     oxp_f1693454-aac1-4265-b8a0-4e9f3f41c7b3/crypt/debug                                                    938737fb-b72f-4727-8833-9697c518ca37   100 GiB   none          gzip-9     
     oxp_fe4fdfba-3b6d-47d3-8612-1fb2390b650a/crypt/debug                                                    8e58b91f-9ce2-4256-8dec-5f90f31a73fa   100 GiB   none          gzip-9     
-+   oxp_33d48d85-751e-4982-b738-eae4d9a05f01/crypt/zone/oxz_nexus_2ec75441-3d7d-4b4b-9614-af03de5a3666      cd15e9c9-0238-493a-8b32-926d1cd1bce6   none      none          off        
-+   oxp_33d48d85-751e-4982-b738-eae4d9a05f01/crypt/zone/oxz_nexus_3ca5292f-8a59-4475-bb72-0f43714d0fff      871b35e6-d234-4a96-bab4-d07314bc6ba2   none      none          off        
-+   oxp_33d48d85-751e-4982-b738-eae4d9a05f01/crypt/zone/oxz_nexus_59950bc8-1497-44dd-8cbf-b6502ba921b2      63ec1a21-2c77-41b5-ad3e-e7bf39207107   none      none          off        
++   oxp_39ca2e23-4c38-4743-afe0-26b0380b27db/crypt/zone/oxz_nexus_2ec75441-3d7d-4b4b-9614-af03de5a3666      cd15e9c9-0238-493a-8b32-926d1cd1bce6   none      none          off        
++   oxp_60131a33-1f12-4dbb-9435-bdd368db1f51/crypt/zone/oxz_nexus_3ca5292f-8a59-4475-bb72-0f43714d0fff      871b35e6-d234-4a96-bab4-d07314bc6ba2   none      none          off        
++   oxp_4fbd2fe0-2eac-41b8-8e8d-4fa46c3e8b6c/crypt/zone/oxz_nexus_59950bc8-1497-44dd-8cbf-b6502ba921b2      63ec1a21-2c77-41b5-ad3e-e7bf39207107   none      none          off        
 
 
     omicron zones generation 2 -> 3:

--- a/nexus/reconfigurator/planning/tests/output/planner_nonprovisionable_2_2a.txt
+++ b/nexus/reconfigurator/planning/tests/output/planner_nonprovisionable_2_2a.txt
@@ -55,10 +55,10 @@ to:   blueprint 9f71f5d3-a272-4382-9154-6ea2e171a6c6
     oxp_cf32a1ce-2c9e-49f5-b1cf-4af7f2a28901/crypt/zone/oxz_crucible_c60379ba-4e30-4628-a79a-0ae509aef4c5   a6fcf496-70a1-49bf-a951-62fcec8dd5e2   none      none          off        
     oxp_5248a306-4a03-449e-a8a3-6f86d26da755/crypt/zone/oxz_crucible_f0ff59e8-4105-4980-a4bb-a1f4c58de1e3   c596346d-4040-4103-b036-8fafdbaada00   none      none          off        
     oxp_6b2a719a-35eb-469f-aa54-114a1f21f37d/crypt/zone/oxz_crucible_f1a7b9a7-fc6a-4b23-b829-045ff33117ff   c864de0d-9859-4ad1-a30b-f5ac45ba03ed   none      none          off        
-    oxp_4069c804-c51a-4adc-8822-3cbbab56ed3f/crypt/zone/oxz_nexus_508abd03-cbfe-4654-9a6d-7f15a1ad32e5      b781d032-3149-4c44-a7d3-5f8d80e4a607   none      none          off        
-    oxp_4069c804-c51a-4adc-8822-3cbbab56ed3f/crypt/zone/oxz_nexus_99f6d544-8599-4e2b-a55a-82d9e0034662      8a39677a-fbcf-4884-b000-63be3247fb63   none      none          off        
+    oxp_5248a306-4a03-449e-a8a3-6f86d26da755/crypt/zone/oxz_nexus_508abd03-cbfe-4654-9a6d-7f15a1ad32e5      b781d032-3149-4c44-a7d3-5f8d80e4a607   none      none          off        
+    oxp_55196665-ed61-4b23-9a74-0711bf2eaf90/crypt/zone/oxz_nexus_99f6d544-8599-4e2b-a55a-82d9e0034662      8a39677a-fbcf-4884-b000-63be3247fb63   none      none          off        
     oxp_4069c804-c51a-4adc-8822-3cbbab56ed3f/crypt/zone/oxz_nexus_a732c489-d29a-4f75-b900-5966385943af      db6c139b-9028-4d8e-92c7-6cc1e9aa0131   none      none          off        
-    oxp_4069c804-c51a-4adc-8822-3cbbab56ed3f/crypt/zone/oxz_nexus_c26b3bda-5561-44a1-a69f-22103fe209a1      c9c1a582-1fe0-4001-9301-97230387563a   none      none          off        
+    oxp_6b2a719a-35eb-469f-aa54-114a1f21f37d/crypt/zone/oxz_nexus_c26b3bda-5561-44a1-a69f-22103fe209a1      c9c1a582-1fe0-4001-9301-97230387563a   none      none          off        
     oxp_4069c804-c51a-4adc-8822-3cbbab56ed3f/crypt/zone/oxz_ntp_621509d6-3772-4009-aca1-35eefd1098fb        3b5822d2-9918-4bd6-8b75-2f52bdd73189   none      none          off        
     oxp_4069c804-c51a-4adc-8822-3cbbab56ed3f/crypt/debug                                                    bf9b39db-5a6a-4b45-b2da-c37425271014   100 GiB   none          gzip-9     
     oxp_5248a306-4a03-449e-a8a3-6f86d26da755/crypt/debug                                                    1b4e8d9e-e447-4df1-8e0b-57edc318e8ad   100 GiB   none          gzip-9     
@@ -145,10 +145,10 @@ to:   blueprint 9f71f5d3-a272-4382-9154-6ea2e171a6c6
     oxp_cd62306a-aedf-47e8-93d5-92a358d64c7b/crypt/zone/oxz_crucible_be920398-024a-4655-8c49-69b5ac48dfff   87f757d6-fa4c-4423-995c-1eab5e7d09a2   none      none          off        
     oxp_39ca2e23-4c38-4743-afe0-26b0380b27db/crypt/zone/oxz_crucible_d47f4996-fac0-4657-bcea-01b1fee6404d   c1af262a-2595-4236-98c8-21c5b63c80c3   none      none          off        
     oxp_789d607d-d196-428e-a988-f7886a327859/crypt/zone/oxz_crucible_e001fea0-6594-4ece-97e3-6198c293e931   5e27b9bc-e69f-4258-83f2-5f9a1109a625   none      none          off        
-    oxp_33d48d85-751e-4982-b738-eae4d9a05f01/crypt/zone/oxz_nexus_2ec75441-3d7d-4b4b-9614-af03de5a3666      cd15e9c9-0238-493a-8b32-926d1cd1bce6   none      none          off        
-    oxp_33d48d85-751e-4982-b738-eae4d9a05f01/crypt/zone/oxz_nexus_3ca5292f-8a59-4475-bb72-0f43714d0fff      871b35e6-d234-4a96-bab4-d07314bc6ba2   none      none          off        
+    oxp_39ca2e23-4c38-4743-afe0-26b0380b27db/crypt/zone/oxz_nexus_2ec75441-3d7d-4b4b-9614-af03de5a3666      cd15e9c9-0238-493a-8b32-926d1cd1bce6   none      none          off        
+    oxp_60131a33-1f12-4dbb-9435-bdd368db1f51/crypt/zone/oxz_nexus_3ca5292f-8a59-4475-bb72-0f43714d0fff      871b35e6-d234-4a96-bab4-d07314bc6ba2   none      none          off        
     oxp_33d48d85-751e-4982-b738-eae4d9a05f01/crypt/zone/oxz_nexus_4ad0e9da-08f8-4d40-b4d3-d17e711b5bbf      45d32c13-cbbb-4382-a0ed-dc6574b827b7   none      none          off        
-    oxp_33d48d85-751e-4982-b738-eae4d9a05f01/crypt/zone/oxz_nexus_59950bc8-1497-44dd-8cbf-b6502ba921b2      63ec1a21-2c77-41b5-ad3e-e7bf39207107   none      none          off        
+    oxp_4fbd2fe0-2eac-41b8-8e8d-4fa46c3e8b6c/crypt/zone/oxz_nexus_59950bc8-1497-44dd-8cbf-b6502ba921b2      63ec1a21-2c77-41b5-ad3e-e7bf39207107   none      none          off        
     oxp_33d48d85-751e-4982-b738-eae4d9a05f01/crypt/zone/oxz_ntp_bf79a56a-97af-4cc4-94a5-8b20d64c2cda        a410308c-e2cb-4e4d-9da6-1879336f93f2   none      none          off        
     oxp_33d48d85-751e-4982-b738-eae4d9a05f01/crypt/debug                                                    755e24a8-67cc-44b1-8c25-2dcb3acd988f   100 GiB   none          gzip-9     
     oxp_39ca2e23-4c38-4743-afe0-26b0380b27db/crypt/debug                                                    c834f8cd-25ee-4c62-af03-49cef53fc4c1   100 GiB   none          gzip-9     

--- a/nexus/types/src/deployment.rs
+++ b/nexus/types/src/deployment.rs
@@ -244,11 +244,13 @@ impl Blueprint {
     pub fn all_omicron_datasets(
         &self,
         filter: BlueprintDatasetFilter,
-    ) -> impl Iterator<Item = &BlueprintDatasetConfig> {
+    ) -> impl Iterator<Item = (SledUuid, &BlueprintDatasetConfig)> {
         self.blueprint_datasets
             .iter()
-            .flat_map(move |(_, datasets)| datasets.datasets.values())
-            .filter(move |d| d.disposition.matches(filter))
+            .flat_map(move |(sled_id, datasets)| {
+                datasets.datasets.values().map(|dataset| (*sled_id, dataset))
+            })
+            .filter(move |(_, d)| d.disposition.matches(filter))
     }
 
     /// Iterate over the [`BlueprintZoneConfig`] instances in the blueprint

--- a/nexus/types/src/deployment.rs
+++ b/nexus/types/src/deployment.rs
@@ -632,7 +632,17 @@ fn zone_sort_key<T: ZoneSortKey>(z: &T) -> impl Ord {
 /// Describes one Omicron-managed zone in a blueprint.
 ///
 /// Part of [`BlueprintZonesConfig`].
-#[derive(Debug, Clone, Eq, PartialEq, JsonSchema, Deserialize, Serialize)]
+#[derive(
+    Debug,
+    Clone,
+    Eq,
+    PartialEq,
+    Ord,
+    PartialOrd,
+    JsonSchema,
+    Deserialize,
+    Serialize,
+)]
 pub struct BlueprintZoneConfig {
     /// The disposition (desired state) of this zone recorded in the blueprint.
     pub disposition: BlueprintZoneDisposition,
@@ -982,7 +992,17 @@ impl BlueprintDatasetDisposition {
 }
 
 /// Information about a dataset as recorded in a blueprint
-#[derive(Debug, Clone, Eq, PartialEq, JsonSchema, Deserialize, Serialize)]
+#[derive(
+    Debug,
+    Clone,
+    Eq,
+    PartialEq,
+    Ord,
+    PartialOrd,
+    JsonSchema,
+    Deserialize,
+    Serialize,
+)]
 pub struct BlueprintDatasetConfig {
     // TODO: Display this in diffs - leave for now, for backwards compat
     pub disposition: BlueprintDatasetDisposition,

--- a/nexus/types/src/deployment/network_resources.rs
+++ b/nexus/types/src/deployment/network_resources.rs
@@ -229,7 +229,16 @@ pub struct OmicronZoneExternalFloatingIp {
 
 /// Floating external address with port allocated to an Omicron-managed zone.
 #[derive(
-    Debug, Clone, Copy, PartialEq, Eq, JsonSchema, Serialize, Deserialize,
+    Debug,
+    Clone,
+    Copy,
+    PartialEq,
+    Eq,
+    PartialOrd,
+    Ord,
+    JsonSchema,
+    Serialize,
+    Deserialize,
 )]
 pub struct OmicronZoneExternalFloatingAddr {
     pub id: ExternalIpUuid,

--- a/nexus/types/src/deployment/network_resources.rs
+++ b/nexus/types/src/deployment/network_resources.rs
@@ -147,7 +147,18 @@ impl OmicronZoneNetworkResources {
 }
 
 /// External IP variants possible for Omicron-managed zones.
-#[derive(Debug, Clone, Copy, Hash, PartialEq, Eq, Serialize, Deserialize)]
+#[derive(
+    Debug,
+    Clone,
+    Copy,
+    Hash,
+    PartialOrd,
+    Ord,
+    PartialEq,
+    Eq,
+    Serialize,
+    Deserialize,
+)]
 pub enum OmicronZoneExternalIp {
     Floating(OmicronZoneExternalFloatingIp),
     Snat(OmicronZoneExternalSnatIp),
@@ -199,7 +210,17 @@ pub enum OmicronZoneExternalIpKey {
 /// necessary for blueprint planning, and requires that the zone have a single
 /// IP.
 #[derive(
-    Debug, Clone, Copy, Hash, PartialEq, Eq, JsonSchema, Serialize, Deserialize,
+    Debug,
+    Clone,
+    Copy,
+    Hash,
+    PartialOrd,
+    Ord,
+    PartialEq,
+    Eq,
+    JsonSchema,
+    Serialize,
+    Deserialize,
 )]
 pub struct OmicronZoneExternalFloatingIp {
     pub id: ExternalIpUuid,
@@ -227,7 +248,17 @@ impl OmicronZoneExternalFloatingAddr {
 /// necessary for blueprint planning, and requires that the zone have a single
 /// IP.
 #[derive(
-    Debug, Clone, Copy, Hash, PartialEq, Eq, JsonSchema, Serialize, Deserialize,
+    Debug,
+    Clone,
+    Copy,
+    Hash,
+    PartialOrd,
+    Ord,
+    PartialEq,
+    Eq,
+    JsonSchema,
+    Serialize,
+    Deserialize,
 )]
 pub struct OmicronZoneExternalSnatIp {
     pub id: ExternalIpUuid,

--- a/nexus/types/src/deployment/zone_type.rs
+++ b/nexus/types/src/deployment/zone_type.rs
@@ -21,7 +21,17 @@ use serde::Serialize;
 use std::net::Ipv6Addr;
 use std::net::SocketAddrV6;
 
-#[derive(Debug, Clone, Eq, PartialEq, JsonSchema, Deserialize, Serialize)]
+#[derive(
+    Debug,
+    Clone,
+    Eq,
+    PartialEq,
+    Ord,
+    PartialOrd,
+    JsonSchema,
+    Deserialize,
+    Serialize,
+)]
 #[serde(tag = "type", rename_all = "snake_case")]
 pub enum BlueprintZoneType {
     BoundaryNtp(blueprint_zone_type::BoundaryNtp),
@@ -335,7 +345,15 @@ pub mod blueprint_zone_type {
     use std::net::SocketAddrV6;
 
     #[derive(
-        Debug, Clone, Eq, PartialEq, JsonSchema, Deserialize, Serialize,
+        Debug,
+        Clone,
+        Eq,
+        PartialEq,
+        Ord,
+        PartialOrd,
+        JsonSchema,
+        Deserialize,
+        Serialize,
     )]
     pub struct BoundaryNtp {
         pub address: SocketAddrV6,
@@ -349,7 +367,15 @@ pub mod blueprint_zone_type {
 
     /// Used in single-node clickhouse setups
     #[derive(
-        Debug, Clone, Eq, PartialEq, JsonSchema, Deserialize, Serialize,
+        Debug,
+        Clone,
+        Eq,
+        PartialEq,
+        Ord,
+        PartialOrd,
+        JsonSchema,
+        Deserialize,
+        Serialize,
     )]
     pub struct Clickhouse {
         pub address: SocketAddrV6,
@@ -357,7 +383,15 @@ pub mod blueprint_zone_type {
     }
 
     #[derive(
-        Debug, Clone, Eq, PartialEq, JsonSchema, Deserialize, Serialize,
+        Debug,
+        Clone,
+        Eq,
+        PartialEq,
+        Ord,
+        PartialOrd,
+        JsonSchema,
+        Deserialize,
+        Serialize,
     )]
     pub struct ClickhouseKeeper {
         pub address: SocketAddrV6,
@@ -366,7 +400,15 @@ pub mod blueprint_zone_type {
 
     /// Used in replicated clickhouse setups
     #[derive(
-        Debug, Clone, Eq, PartialEq, JsonSchema, Deserialize, Serialize,
+        Debug,
+        Clone,
+        Eq,
+        PartialEq,
+        Ord,
+        PartialOrd,
+        JsonSchema,
+        Deserialize,
+        Serialize,
     )]
     pub struct ClickhouseServer {
         pub address: SocketAddrV6,
@@ -374,7 +416,15 @@ pub mod blueprint_zone_type {
     }
 
     #[derive(
-        Debug, Clone, Eq, PartialEq, JsonSchema, Deserialize, Serialize,
+        Debug,
+        Clone,
+        Eq,
+        PartialEq,
+        Ord,
+        PartialOrd,
+        JsonSchema,
+        Deserialize,
+        Serialize,
     )]
     pub struct CockroachDb {
         pub address: SocketAddrV6,
@@ -382,7 +432,15 @@ pub mod blueprint_zone_type {
     }
 
     #[derive(
-        Debug, Clone, Eq, PartialEq, JsonSchema, Deserialize, Serialize,
+        Debug,
+        Clone,
+        Eq,
+        PartialEq,
+        Ord,
+        PartialOrd,
+        JsonSchema,
+        Deserialize,
+        Serialize,
     )]
     pub struct Crucible {
         pub address: SocketAddrV6,
@@ -390,14 +448,30 @@ pub mod blueprint_zone_type {
     }
 
     #[derive(
-        Debug, Clone, Eq, PartialEq, JsonSchema, Deserialize, Serialize,
+        Debug,
+        Clone,
+        Eq,
+        PartialEq,
+        Ord,
+        PartialOrd,
+        JsonSchema,
+        Deserialize,
+        Serialize,
     )]
     pub struct CruciblePantry {
         pub address: SocketAddrV6,
     }
 
     #[derive(
-        Debug, Clone, Eq, PartialEq, JsonSchema, Deserialize, Serialize,
+        Debug,
+        Clone,
+        Eq,
+        PartialEq,
+        Ord,
+        PartialOrd,
+        JsonSchema,
+        Deserialize,
+        Serialize,
     )]
     pub struct ExternalDns {
         pub dataset: OmicronZoneDataset,
@@ -410,7 +484,15 @@ pub mod blueprint_zone_type {
     }
 
     #[derive(
-        Debug, Clone, Eq, PartialEq, JsonSchema, Deserialize, Serialize,
+        Debug,
+        Clone,
+        Eq,
+        PartialEq,
+        Ord,
+        PartialOrd,
+        JsonSchema,
+        Deserialize,
+        Serialize,
     )]
     pub struct InternalDns {
         pub dataset: OmicronZoneDataset,
@@ -430,14 +512,30 @@ pub mod blueprint_zone_type {
     }
 
     #[derive(
-        Debug, Clone, Eq, PartialEq, JsonSchema, Deserialize, Serialize,
+        Debug,
+        Clone,
+        Eq,
+        PartialEq,
+        Ord,
+        PartialOrd,
+        JsonSchema,
+        Deserialize,
+        Serialize,
     )]
     pub struct InternalNtp {
         pub address: SocketAddrV6,
     }
 
     #[derive(
-        Debug, Clone, Eq, PartialEq, JsonSchema, Deserialize, Serialize,
+        Debug,
+        Clone,
+        Eq,
+        PartialEq,
+        Ord,
+        PartialOrd,
+        JsonSchema,
+        Deserialize,
+        Serialize,
     )]
     pub struct Nexus {
         /// The address at which the internal nexus server is reachable.
@@ -453,7 +551,15 @@ pub mod blueprint_zone_type {
     }
 
     #[derive(
-        Debug, Clone, Eq, PartialEq, JsonSchema, Deserialize, Serialize,
+        Debug,
+        Clone,
+        Eq,
+        PartialEq,
+        Ord,
+        PartialOrd,
+        JsonSchema,
+        Deserialize,
+        Serialize,
     )]
     pub struct Oximeter {
         pub address: SocketAddrV6,


### PR DESCRIPTION
This PR introduces Blippy for linting blueprints (see #6987). It initially only reports `FATAL` errors associated with specific sleds, but hopefully provides enough structure to see how that can expand to include other severities and other components. (At a minimum, there will be some blueprint- or policy-level component for things like "there aren't enough Nexus zones" that aren't associated with any particular sled.)

As of this PR, the only user of Blippy is the builder test's `verify_blueprint`, from which I imported most of the checks that it current performs. I made a few of these checks slightly more strict, and from that I had to patch up a handful of tests that were doing weird things (e.g., manually expunging a zone without expunging its datasets) and also found one legitimate planner bug (I'll note in a separate comment below).

There aren't many doc comments (yet?) - the interface should be pretty straightforward, but I'm happy to add docs if folks are okay with the general structure of this. I'm not at all wedded to the `Note` / `Severity` / `Kind` / `Component` breakdown, so any feedback there is welcome.