### PR TITLE
Pick a non-expunged clone source

### DIFF
--- a/nexus/src/app/sagas/region_snapshot_replacement_start.rs
+++ b/nexus/src/app/sagas/region_snapshot_replacement_start.rs
@@ -271,7 +271,7 @@ async fn rsrss_set_saga_id_undo(
 }
 
 #[derive(Debug, Deserialize, Serialize, PartialEq, Eq)]
-pub enum CloneSource {
+enum CloneSource {
     RegionSnapshot { dataset_id: DatasetUuid, region_id: Uuid },
     Region { region_id: Uuid },
 }

--- a/sled-agent/src/sim/storage.rs
+++ b/sled-agent/src/sim/storage.rs
@@ -117,6 +117,8 @@ impl CrucibleDataInner {
             bail!("region creation error!");
         }
 
+        let read_only = params.source.is_some();
+
         let region = Region {
             id: params.id,
             block_size: params.block_size,
@@ -129,8 +131,8 @@ impl CrucibleDataInner {
             cert_pem: None,
             key_pem: None,
             root_pem: None,
-            source: None,
-            read_only: params.source.is_some(),
+            source: params.source,
+            read_only,
         };
 
         let old = self.regions.insert(id, region.clone());
@@ -1364,29 +1366,41 @@ pub struct PantryVolume {
     activate_job: Option<String>,
 }
 
+pub struct PantryInner {
+    /// Map Volume UUID to PantryVolume struct
+    volumes: HashMap<String, PantryVolume>,
+
+    jobs: HashSet<String>,
+
+    /// Auto activate volumes attached in the background
+    auto_activate_volumes: bool,
+}
+
 /// Simulated crucible pantry
 pub struct Pantry {
     pub id: OmicronZoneUuid,
-    /// Map Volume UUID to PantryVolume struct
-    volumes: Mutex<HashMap<String, PantryVolume>>,
     sled_agent: Arc<SledAgent>,
-    jobs: Mutex<HashSet<String>>,
+    inner: Mutex<PantryInner>,
 }
 
 impl Pantry {
     pub fn new(sled_agent: Arc<SledAgent>) -> Self {
         Self {
             id: OmicronZoneUuid::new_v4(),
-            volumes: Mutex::new(HashMap::default()),
             sled_agent,
-            jobs: Mutex::new(HashSet::default()),
+            inner: Mutex::new(PantryInner {
+                volumes: HashMap::default(),
+                jobs: HashSet::default(),
+                auto_activate_volumes: false,
+            }),
         }
     }
 
     pub async fn status(&self) -> Result<PantryStatus, HttpError> {
+        let inner = self.inner.lock().await;
         Ok(PantryStatus {
-            volumes: self.volumes.lock().await.keys().cloned().collect(),
-            num_job_handles: self.jobs.lock().await.len(),
+            volumes: inner.volumes.keys().cloned().collect(),
+            num_job_handles: inner.jobs.len(),
         })
     }
 
@@ -1394,8 +1408,9 @@ impl Pantry {
         &self,
         volume_id: String,
     ) -> Result<VolumeConstructionRequest, HttpError> {
-        let volumes = self.volumes.lock().await;
-        match volumes.get(&volume_id) {
+        let inner = self.inner.lock().await;
+
+        match inner.volumes.get(&volume_id) {
             Some(entry) => Ok(entry.vcr.clone()),
 
             None => Err(HttpError::for_not_found(None, volume_id)),
@@ -1407,9 +1422,9 @@ impl Pantry {
         volume_id: String,
         volume_construction_request: VolumeConstructionRequest,
     ) -> Result<()> {
-        let mut volumes = self.volumes.lock().await;
+        let mut inner = self.inner.lock().await;
 
-        volumes.insert(
+        inner.volumes.insert(
             volume_id,
             PantryVolume {
                 vcr: volume_construction_request,
@@ -1425,29 +1440,34 @@ impl Pantry {
         Ok(())
     }
 
+    pub async fn set_auto_activate_volumes(&self) {
+        self.inner.lock().await.auto_activate_volumes = true;
+    }
+
     pub async fn attach_activate_background(
         &self,
         volume_id: String,
         activate_job_id: String,
         volume_construction_request: VolumeConstructionRequest,
     ) -> Result<(), HttpError> {
-        let mut volumes = self.volumes.lock().await;
-        let mut jobs = self.jobs.lock().await;
+        let mut inner = self.inner.lock().await;
 
-        volumes.insert(
+        let auto_activate_volumes = inner.auto_activate_volumes;
+
+        inner.volumes.insert(
             volume_id,
             PantryVolume {
                 vcr: volume_construction_request,
                 status: VolumeStatus {
-                    active: false,
-                    seen_active: false,
+                    active: auto_activate_volumes,
+                    seen_active: auto_activate_volumes,
                     num_job_handles: 1,
                 },
                 activate_job: Some(activate_job_id.clone()),
             },
         );
 
-        jobs.insert(activate_job_id);
+        inner.jobs.insert(activate_job_id);
 
         Ok(())
     }
@@ -1457,8 +1477,8 @@ impl Pantry {
         volume_id: String,
     ) -> Result<String, HttpError> {
         let activate_job = {
-            let volumes = self.volumes.lock().await;
-            volumes.get(&volume_id).unwrap().activate_job.clone().unwrap()
+            let inner = self.inner.lock().await;
+            inner.volumes.get(&volume_id).unwrap().activate_job.clone().unwrap()
         };
 
         let mut status = self.volume_status(volume_id.clone()).await?;
@@ -1475,9 +1495,9 @@ impl Pantry {
         &self,
         volume_id: String,
     ) -> Result<VolumeStatus, HttpError> {
-        let volumes = self.volumes.lock().await;
+        let inner = self.inner.lock().await;
 
-        match volumes.get(&volume_id) {
+        match inner.volumes.get(&volume_id) {
             Some(pantry_volume) => Ok(pantry_volume.status.clone()),
 
             None => Err(HttpError::for_not_found(None, volume_id)),
@@ -1489,9 +1509,9 @@ impl Pantry {
         volume_id: String,
         status: VolumeStatus,
     ) -> Result<(), HttpError> {
-        let mut volumes = self.volumes.lock().await;
+        let mut inner = self.inner.lock().await;
 
-        match volumes.get_mut(&volume_id) {
+        match inner.volumes.get_mut(&volume_id) {
             Some(pantry_volume) => {
                 pantry_volume.status = status;
                 Ok(())
@@ -1505,8 +1525,8 @@ impl Pantry {
         &self,
         job_id: String,
     ) -> Result<bool, HttpError> {
-        let jobs = self.jobs.lock().await;
-        if !jobs.contains(&job_id) {
+        let inner = self.inner.lock().await;
+        if !inner.jobs.contains(&job_id) {
             return Err(HttpError::for_not_found(None, job_id));
         }
         Ok(true)
@@ -1516,11 +1536,11 @@ impl Pantry {
         &self,
         job_id: String,
     ) -> Result<Result<bool>, HttpError> {
-        let mut jobs = self.jobs.lock().await;
-        if !jobs.contains(&job_id) {
+        let mut inner = self.inner.lock().await;
+        if !inner.jobs.contains(&job_id) {
             return Err(HttpError::for_not_found(None, job_id));
         }
-        jobs.remove(&job_id);
+        inner.jobs.remove(&job_id);
         Ok(Ok(true))
     }
 
@@ -1533,9 +1553,9 @@ impl Pantry {
         self.entry(volume_id).await?;
 
         // Make up job
-        let mut jobs = self.jobs.lock().await;
+        let mut inner = self.inner.lock().await;
         let job_id = Uuid::new_v4().to_string();
-        jobs.insert(job_id.clone());
+        inner.jobs.insert(job_id.clone());
 
         Ok(job_id)
     }
@@ -1549,8 +1569,9 @@ impl Pantry {
         // the simulated instance ensure, then call
         // [`instance_issue_disk_snapshot_request`] as the snapshot logic is the
         // same.
-        let volumes = self.volumes.lock().await;
-        let volume_construction_request = &volumes.get(&volume_id).unwrap().vcr;
+        let inner = self.inner.lock().await;
+        let volume_construction_request =
+            &inner.volumes.get(&volume_id).unwrap().vcr;
 
         self.sled_agent
             .map_disk_ids_to_region_ids(volume_construction_request)
@@ -1630,16 +1651,16 @@ impl Pantry {
         self.entry(volume_id).await?;
 
         // Make up job
-        let mut jobs = self.jobs.lock().await;
+        let mut inner = self.inner.lock().await;
         let job_id = Uuid::new_v4().to_string();
-        jobs.insert(job_id.clone());
+        inner.jobs.insert(job_id.clone());
 
         Ok(job_id)
     }
 
     pub async fn detach(&self, volume_id: String) -> Result<()> {
-        let mut volumes = self.volumes.lock().await;
-        volumes.remove(&volume_id);
+        let mut inner = self.inner.lock().await;
+        inner.volumes.remove(&volume_id);
         Ok(())
     }
 }


### PR DESCRIPTION
When performing region snapshot replacement, the associated start saga chose the request's region snapshot as the clone source, but if that region snapshot was backed by an expunged dataset then it may be gone.

This commit adds logic to choose another clone source, either another region snapshot from the same snapshot, or one of the read-only regions for that snapshot.

Basic sanity tests were added for ensuring that region replacements and region snapshot replacements resulting from expungement can occur. It was an oversight not to originally include these! Rn order to support these new sanity tests, the simulated pantry has to fake activating volumes in the background. This commit also refactors the simulated Pantry to have one Mutex around an "inner" struct instead of many Mutexes.

Fixes #7209