### PR TITLE
[tests] make instance reincarnation tests less racy

### DIFF
--- a/nexus/tests/integration_tests/instances.rs
+++ b/nexus/tests/integration_tests/instances.rs
@@ -1374,15 +1374,20 @@ async fn test_instance_failed_when_on_expunged_sled(
 
     // The restarted instance should now transition back to `Running`, on its
     // new sled.
-    instance_wait_for_vmm_registration(cptestctx, &instance2_id).await;
-    instance_simulate(nexus, &instance2_id).await;
-    instance_wait_for_state(client, instance2_id, InstanceState::Running).await;
+    instance_wait_for_simulated_transition(
+        &cptestctx,
+        &instance2_id,
+        InstanceState::Running,
+    )
+    .await;
 
     // The auto-restartable instance should be...restarted automatically.
-
-    instance_wait_for_vmm_registration(cptestctx, &instance3_id).await;
-    instance_simulate(nexus, &instance3_id).await;
-    instance_wait_for_state(client, instance3_id, InstanceState::Running).await;
+    instance_wait_for_simulated_transition(
+        &cptestctx,
+        &instance3_id,
+        InstanceState::Running,
+    )
+    .await;
 }
 
 // Verifies that the instance-watcher background task transitions an instance
@@ -1393,7 +1398,6 @@ async fn test_instance_failed_by_instance_watcher_automatically_reincarnates(
     cptestctx: &ControlPlaneTestContext,
 ) {
     let client = &cptestctx.external_client;
-    let nexus = &cptestctx.server.server_context().nexus;
     let instance_id = dbg!(
         make_forgotten_instance(
             &cptestctx,
@@ -1430,10 +1434,13 @@ async fn test_instance_failed_by_instance_watcher_automatically_reincarnates(
     // it.
     dbg!(instance_wait_for_vmm_registration(cptestctx, &instance_id).await);
     // Now, we can actually poke the instance.
-    dbg!(instance_simulate(nexus, &instance_id).await);
     dbg!(
-        instance_wait_for_state(client, instance_id, InstanceState::Running)
-            .await
+        instance_wait_for_simulated_transition(
+            &cptestctx,
+            &instance_id,
+            InstanceState::Running
+        )
+        .await
     );
 }
 
@@ -6670,6 +6677,67 @@ pub async fn instance_simulate_with_opctx(
         .expect("instance must be on a sled to simulate a state change");
 
     sled_info.sled_client.vmm_finish_transition(sled_info.propolis_id).await;
+}
+
+/// Wait for an instance to complete a simulated state transition, repeatedly
+/// poking the simulated sled-agent until the transition occurs.
+///
+/// This can be used to avoid races between Nexus processes (like sagas) which
+/// trigger a state transition but cannot be easily awaited by the test, and the
+/// actual request to simulate the state transition. However, it should be used
+/// cautiously to avoid simulating multiple state transitions accidentally.
+async fn instance_wait_for_simulated_transition(
+    cptestctx: &ControlPlaneTestContext,
+    id: &InstanceUuid,
+    state: InstanceState,
+) -> Instance {
+    const MAX_WAIT: Duration = Duration::from_secs(120);
+    let client = &cptestctx.external_client;
+    slog::info!(
+        &client.client_log,
+        "waiting for instance {id} transition to {state} \
+         (and poking simulated sled-agent)...";
+    );
+    let url = format!("/v1/instances/{id}");
+    let result = wait_for_condition(
+        || async {
+            let instance: Instance = NexusRequest::object_get(&client, &url)
+                .authn_as(AuthnMode::PrivilegedUser)
+                .execute()
+                .await?
+                .parsed_body()?;
+            if instance.runtime.run_state == state {
+                Ok(instance)
+            } else {
+                slog::info!(
+                    &client.client_log,
+                    "instance {id} has not transitioned to {state}, \
+                     poking sled-agent";
+                    "instance_id" => %instance.identity.id,
+                    "instance_runtime_state" => ?instance.runtime,
+                );
+                instance_simulate(&cptestctx.server.server_context().nexus, id)
+                    .await;
+                Err(CondCheckError::<anyhow::Error>::NotYet)
+            }
+        },
+        &Duration::from_secs(1),
+        &MAX_WAIT,
+    )
+    .await;
+    match result {
+        Ok(instance) => {
+            slog::info!(
+                &client.client_log,
+                "instance {id} has transitioned to {state}"
+            );
+            instance
+        }
+        Err(e) => panic!(
+            "instance {id} did not transition to {state:?} \
+             after {MAX_WAIT:?}: {e}"
+        ),
+    }
 }
 
 /// Simulates state transitions for the incarnation of the instance on the


### PR DESCRIPTION
A possible test flake exists in the tests for instance reincarnation. This is caused by a race that occurs when the request to simulate an instance's state transition is sent to the simulated sled-agent *before* an instance-start saga sends the request to start the instance to that sled-agent. When this occurs, the simulated state transition is lost, and the test keeps waiting for it forever. See [this comment][1] for details.

This commit resolves this by adding a new
`instance_wait_for_simulated_transition` helper, which is identical to `instance_wait_for_state`, but with the addition of `instance_poke` requests every time the instance is not observed to be in the desired state. This is a bit of a blunt instrument, but it ensures that the simulated sled-agent will always be told to simulate a state transition after it's requested by the control plane.

Hopefully fixes #6727

[1]: https://github.com/oxidecomputer/omicron/issues/6727#issuecomment-2557807360