### PR TITLE
[Reconfigurator] Use per-sled RNGs

### DIFF
--- a/dev-tools/reconfigurator-cli/tests/output/cmd-example-stdout
+++ b/dev-tools/reconfigurator-cli/tests/output/cmd-example-stdout
@@ -88,21 +88,21 @@ parent:    02697f74-b14a-4418-90f0-c28b2a3a6aa9
     ---------------------------------------------------------------------------------------------
     zone type         zone id                                disposition   underlay IP           
     ---------------------------------------------------------------------------------------------
-    clickhouse        fe79023f-c5d5-4be5-ad2c-da4e9e9237e4   in service    fd00:1122:3344:102::23
-    crucible          054f64a5-182c-4c28-8994-d2e082550201   in service    fd00:1122:3344:102::26
-    crucible          3b5bffea-e5ed-44df-8468-fd4fa69757d8   in service    fd00:1122:3344:102::27
-    crucible          53dd7fa4-899e-49ed-9fc2-48222db3e20d   in service    fd00:1122:3344:102::2a
-    crucible          7db307d4-a6ed-4c47-bddf-6759161bf64a   in service    fd00:1122:3344:102::2c
-    crucible          95ad9a1d-4063-4874-974c-2fc92830be27   in service    fd00:1122:3344:102::29
-    crucible          bc095417-e2f0-4e95-b390-9cc3fc6e3c6d   in service    fd00:1122:3344:102::28
-    crucible          d90401f1-fbc2-42cb-bf17-309ee0f922fe   in service    fd00:1122:3344:102::2b
-    crucible          e8f994c0-0a1b-40e6-8db1-40a8ca89e503   in service    fd00:1122:3344:102::2d
-    crucible          e9bf481e-323e-466e-842f-8107078c7137   in service    fd00:1122:3344:102::2e
-    crucible          f97aa057-6485-45d0-9cb4-4af5b0831d48   in service    fd00:1122:3344:102::25
-    crucible_pantry   eaec16c0-0d44-4847-b2d6-31a5151bae52   in service    fd00:1122:3344:102::24
-    internal_dns      8b8f7c02-7a18-4268-b045-2e286b464c5d   in service    fd00:1122:3344:1::1   
-    internal_ntp      c67dd9a4-0d6c-4e9f-b28d-20003f211f7d   in service    fd00:1122:3344:102::21
-    nexus             94b45ce9-d3d8-413a-a76b-865da1f67930   in service    fd00:1122:3344:102::22
+    clickhouse        3a3f243b-7e9e-4818-bb7c-fe30966b2949   in service    fd00:1122:3344:102::23
+    crucible          279b230f-5e77-4960-b08e-594c6f2f57c0   in service    fd00:1122:3344:102::2a
+    crucible          4328425e-f5ba-436a-9e46-3f337f07671e   in service    fd00:1122:3344:102::2d
+    crucible          61282e88-43b3-4011-9314-b0929880895a   in service    fd00:1122:3344:102::2b
+    crucible          7537db8e-11c9-4a84-9dc7-b3ae7b657cc4   in service    fd00:1122:3344:102::2e
+    crucible          b37ebcb3-533b-4fd7-9960-bb1ac511bea2   in service    fd00:1122:3344:102::27
+    crucible          b4c3734e-b6d8-47d8-a695-5dad2c21622e   in service    fd00:1122:3344:102::25
+    crucible          b8aba012-d4b3-48e1-af2d-cf6265e02bd7   in service    fd00:1122:3344:102::2c
+    crucible          e1b405aa-a32c-4410-8335-59237a7bc9ad   in service    fd00:1122:3344:102::28
+    crucible          e696d6f8-c706-4ca7-8846-561f0323ccbf   in service    fd00:1122:3344:102::29
+    crucible          f69e36ff-ea67-4d1f-bc73-3d2a0315c77f   in service    fd00:1122:3344:102::26
+    crucible_pantry   c5fefafb-d65c-44e0-b45e-d2097dca02d1   in service    fd00:1122:3344:102::24
+    internal_dns      426face8-6cc4-4ba0-b3a3-8492876ecd37   in service    fd00:1122:3344:1::1   
+    internal_ntp      eaa48c21-f17c-41f7-9e85-fc6a10913b31   in service    fd00:1122:3344:102::21
+    nexus             db1aa26e-7608-4ce0-933e-9968489f8a46   in service    fd00:1122:3344:102::22
 
 
 
@@ -128,20 +128,20 @@ parent:    02697f74-b14a-4418-90f0-c28b2a3a6aa9
     ---------------------------------------------------------------------------------------------
     zone type         zone id                                disposition   underlay IP           
     ---------------------------------------------------------------------------------------------
-    crucible          09937ebb-bb6a-495b-bc97-b58076b70a78   in service    fd00:1122:3344:103::2c
-    crucible          a999e5fa-3edc-4dac-919a-d7b554cdae58   in service    fd00:1122:3344:103::26
-    crucible          b416f299-c23c-46c8-9820-be2b66ffea0a   in service    fd00:1122:3344:103::27
-    crucible          b5d5491d-b3aa-4727-8b55-f66e0581ea4f   in service    fd00:1122:3344:103::2b
-    crucible          cc1dc86d-bd6f-4929-aa4a-9619012e9393   in service    fd00:1122:3344:103::24
-    crucible          cd3bb540-e605-465f-8c62-177ac482d850   in service    fd00:1122:3344:103::29
-    crucible          e8971ab3-fb7d-4ad8-aae3-7f2fe87c51f3   in service    fd00:1122:3344:103::25
-    crucible          f3628f0a-2301-4fc8-bcbf-961199771731   in service    fd00:1122:3344:103::2d
-    crucible          f52aa245-7e1b-46c0-8a31-e09725f02caf   in service    fd00:1122:3344:103::2a
-    crucible          fae49024-6cec-444d-a6c4-83658ab015a4   in service    fd00:1122:3344:103::28
-    crucible_pantry   728db429-8621-4e1e-9915-282aadfa27d1   in service    fd00:1122:3344:103::23
-    internal_dns      e7dd3e98-7fe7-4827-be7f-395ff9a5f542   in service    fd00:1122:3344:2::1   
-    internal_ntp      4f2eb088-7d28-4c4e-a27c-746400ec65ba   in service    fd00:1122:3344:103::21
-    nexus             c8aa84a5-a802-46c9-adcd-d61e9c8393c9   in service    fd00:1122:3344:103::22
+    crucible          096964a1-a60b-4de9-b4b5-dada560870ca   in service    fd00:1122:3344:103::28
+    crucible          1a07a7f2-76ae-4670-8491-3383bb3e2d19   in service    fd00:1122:3344:103::2d
+    crucible          1a7ddc8f-90c7-4842-81a9-2abfc76e3cb4   in service    fd00:1122:3344:103::26
+    crucible          2f5dec78-6071-41c1-8f3f-2f4e98fdad0a   in service    fd00:1122:3344:103::25
+    crucible          41f7b32f-d85f-4cce-853c-144342cc8361   in service    fd00:1122:3344:103::24
+    crucible          52960cc6-af73-4ae6-b776-b4bcc371fd68   in service    fd00:1122:3344:103::2c
+    crucible          6914b9aa-5712-405c-817a-77b2e6c6a824   in service    fd00:1122:3344:103::27
+    crucible          8e92b0f0-77b7-4b95-905f-653ee962b932   in service    fd00:1122:3344:103::2b
+    crucible          d9ea5125-d6f0-4bfd-9ebd-497569d91adf   in service    fd00:1122:3344:103::2a
+    crucible          f7ced707-a517-4529-91fa-03dc7683f413   in service    fd00:1122:3344:103::29
+    crucible_pantry   25087c5b-58b9-46f2-9e4c-e9440c081111   in service    fd00:1122:3344:103::23
+    internal_dns      5c1386b0-ed6b-4e09-8a65-7d9f47c41839   in service    fd00:1122:3344:2::1   
+    internal_ntp      9ec70cc1-a22d-40df-9697-8a4db3c72d74   in service    fd00:1122:3344:103::21
+    nexus             3bfd90d6-0640-4f63-a578-76277ce9c7c6   in service    fd00:1122:3344:103::22
 
 
 
@@ -167,20 +167,20 @@ parent:    02697f74-b14a-4418-90f0-c28b2a3a6aa9
     ---------------------------------------------------------------------------------------------
     zone type         zone id                                disposition   underlay IP           
     ---------------------------------------------------------------------------------------------
-    crucible          413d3e02-e19f-400a-9718-a662347538f0   in service    fd00:1122:3344:101::24
-    crucible          6cb330f9-4609-4d6c-98ad-b5cc34245813   in service    fd00:1122:3344:101::29
-    crucible          6d725df0-0189-4429-b270-3eeb891d39c8   in service    fd00:1122:3344:101::28
-    crucible          b5443ebd-1f5b-448c-8edc-b4ca25c25db1   in service    fd00:1122:3344:101::25
-    crucible          bb55534c-1042-4af4-ad2f-9590803695ac   in service    fd00:1122:3344:101::27
-    crucible          c4296f9f-f902-4fc7-b896-178e56e60732   in service    fd00:1122:3344:101::2d
-    crucible          d14c165f-6370-4cce-9dba-3c6deb762cfc   in service    fd00:1122:3344:101::2c
-    crucible          de65f128-30f7-422b-a234-d1fc8dd6ef78   in service    fd00:1122:3344:101::2b
-    crucible          e135441d-637e-4de9-8023-5ea0096347f3   in service    fd00:1122:3344:101::26
-    crucible          fee71ee6-da42-4a7f-a00e-f56b6a3327ce   in service    fd00:1122:3344:101::2a
-    crucible_pantry   315a3670-d019-425c-b7a6-c9429428b671   in service    fd00:1122:3344:101::23
-    internal_dns      8b47e1e8-0396-4e44-a4a5-ea891405c9f2   in service    fd00:1122:3344:3::1   
-    internal_ntp      cbe91cdc-cbb6-4760-aece-6ce08b67e85a   in service    fd00:1122:3344:101::21
-    nexus             b43ce109-90d6-46f9-9df0-8c68bfe6d4a0   in service    fd00:1122:3344:101::22
+    crucible          157d5b03-6897-4e80-9357-3cf733efe4b5   in service    fd00:1122:3344:101::28
+    crucible          7341456c-4c6c-4bb7-8be4-2acac834886f   in service    fd00:1122:3344:101::2a
+    crucible          793a6315-a07b-4fcf-a0b4-633d5c53b8cf   in service    fd00:1122:3344:101::27
+    crucible          9915de3b-8104-40ca-a6b5-46132d26bb15   in service    fd00:1122:3344:101::29
+    crucible          a975d276-7434-4def-8f5b-f250657d1040   in service    fd00:1122:3344:101::2c
+    crucible          b41461de-6b60-4d35-ad90-336eb1fa9874   in service    fd00:1122:3344:101::26
+    crucible          d1374f2f-e9ba-4046-ba0b-83da927ba0d3   in service    fd00:1122:3344:101::2b
+    crucible          dc3c9584-44d8-4be6-b215-2df289f5763d   in service    fd00:1122:3344:101::25
+    crucible          e70d6f37-d0a6-4309-93b5-4f2f72b779a7   in service    fd00:1122:3344:101::2d
+    crucible          efa9fb1c-9431-4072-877d-ff33d9d926ba   in service    fd00:1122:3344:101::24
+    crucible_pantry   761999e7-cf90-412c-91d8-f3247507edbc   in service    fd00:1122:3344:101::23
+    internal_dns      a2708dbc-a751-4c26-a1ed-6eaadf3402cf   in service    fd00:1122:3344:3::1   
+    internal_ntp      4bb07cd6-dc94-4601-ac22-c7ad972735b3   in service    fd00:1122:3344:101::21
+    nexus             ba910747-f596-4088-a2d4-4372ee883dfd   in service    fd00:1122:3344:101::22
 
 
  COCKROACHDB SETTINGS:

--- a/nexus/reconfigurator/planning/src/blueprint_builder/builder.rs
+++ b/nexus/reconfigurator/planning/src/blueprint_builder/builder.rs
@@ -1062,7 +1062,7 @@ impl<'a> BlueprintBuilder<'a> {
                         id: disk_id,
                         pool_id: *zpool,
                     },
-                    &mut self.rng,
+                    self.rng.sled_rng(sled_id),
                 )
                 .map_err(|err| Error::SledEditError { sled_id, err })?;
         }
@@ -1106,7 +1106,7 @@ impl<'a> BlueprintBuilder<'a> {
 
         let initial_counts = editor.edit_counts();
         editor
-            .ensure_datasets_for_running_zones(&mut self.rng)
+            .ensure_datasets_for_running_zones(self.rng.sled_rng(sled_id))
             .map_err(|err| Error::SledEditError { sled_id, err })?;
         let final_counts = editor.edit_counts();
 
@@ -1170,7 +1170,7 @@ impl<'a> BlueprintBuilder<'a> {
 
         let zone = BlueprintZoneConfig {
             disposition: BlueprintZoneDisposition::InService,
-            id: self.rng.next_zone(),
+            id: self.rng.sled_rng(sled_id).next_zone(),
             filesystem_pool: Some(zpool),
             zone_type,
         };
@@ -1182,7 +1182,7 @@ impl<'a> BlueprintBuilder<'a> {
         &mut self,
         sled_id: SledUuid,
     ) -> Result<(), Error> {
-        let id = self.rng.next_zone();
+        let id = self.rng.sled_rng(sled_id).next_zone();
         let ExternalNetworkingChoice {
             external_ip,
             nic_ip,
@@ -1190,7 +1190,7 @@ impl<'a> BlueprintBuilder<'a> {
             nic_mac,
         } = self.external_networking()?.for_new_external_dns()?;
         let nic = NetworkInterface {
-            id: self.rng.next_network_interface(),
+            id: self.rng.sled_rng(sled_id).next_network_interface(),
             kind: NetworkInterfaceKind::Service { id: id.into_untyped_uuid() },
             name: format!("external-dns-{id}").parse().unwrap(),
             ip: nic_ip,
@@ -1206,7 +1206,7 @@ impl<'a> BlueprintBuilder<'a> {
         let http_address =
             SocketAddrV6::new(underlay_address, DNS_HTTP_PORT, 0, 0);
         let dns_address = OmicronZoneExternalFloatingAddr {
-            id: self.rng.next_external_ip(),
+            id: self.rng.sled_rng(sled_id).next_external_ip(),
             addr: SocketAddr::new(external_ip, DNS_PORT),
         };
         let pool_name =
@@ -1259,7 +1259,7 @@ impl<'a> BlueprintBuilder<'a> {
 
         let zone = BlueprintZoneConfig {
             disposition: BlueprintZoneDisposition::InService,
-            id: self.rng.next_zone(),
+            id: self.rng.sled_rng(sled_id).next_zone(),
             filesystem_pool: Some(filesystem_pool),
             zone_type,
         };
@@ -1319,7 +1319,7 @@ impl<'a> BlueprintBuilder<'a> {
 
         let zone = BlueprintZoneConfig {
             disposition: BlueprintZoneDisposition::InService,
-            id: self.rng.next_zone(),
+            id: self.rng.sled_rng(sled_id).next_zone(),
             filesystem_pool: Some(filesystem_pool),
             zone_type,
         };
@@ -1386,7 +1386,7 @@ impl<'a> BlueprintBuilder<'a> {
         external_tls: bool,
         external_dns_servers: Vec<IpAddr>,
     ) -> Result<(), Error> {
-        let nexus_id = self.rng.next_zone();
+        let nexus_id = self.rng.sled_rng(sled_id).next_zone();
         let ExternalNetworkingChoice {
             external_ip,
             nic_ip,
@@ -1394,12 +1394,12 @@ impl<'a> BlueprintBuilder<'a> {
             nic_mac,
         } = self.external_networking()?.for_new_nexus()?;
         let external_ip = OmicronZoneExternalFloatingIp {
-            id: self.rng.next_external_ip(),
+            id: self.rng.sled_rng(sled_id).next_external_ip(),
             ip: external_ip,
         };
 
         let nic = NetworkInterface {
-            id: self.rng.next_network_interface(),
+            id: self.rng.sled_rng(sled_id).next_network_interface(),
             kind: NetworkInterfaceKind::Service {
                 id: nexus_id.into_untyped_uuid(),
             },
@@ -1439,7 +1439,7 @@ impl<'a> BlueprintBuilder<'a> {
         &mut self,
         sled_id: SledUuid,
     ) -> Result<(), Error> {
-        let oximeter_id = self.rng.next_zone();
+        let oximeter_id = self.rng.sled_rng(sled_id).next_zone();
         let ip = self.sled_alloc_ip(sled_id)?;
         let port = omicron_common::address::OXIMETER_PORT;
         let address = SocketAddrV6::new(ip, port, 0, 0);
@@ -1463,7 +1463,7 @@ impl<'a> BlueprintBuilder<'a> {
         &mut self,
         sled_id: SledUuid,
     ) -> Result<(), Error> {
-        let pantry_id = self.rng.next_zone();
+        let pantry_id = self.rng.sled_rng(sled_id).next_zone();
         let ip = self.sled_alloc_ip(sled_id)?;
         let port = omicron_common::address::CRUCIBLE_PANTRY_PORT;
         let address = SocketAddrV6::new(ip, port, 0, 0);
@@ -1493,7 +1493,7 @@ impl<'a> BlueprintBuilder<'a> {
         &mut self,
         sled_id: SledUuid,
     ) -> Result<(), Error> {
-        let zone_id = self.rng.next_zone();
+        let zone_id = self.rng.sled_rng(sled_id).next_zone();
         let underlay_ip = self.sled_alloc_ip(sled_id)?;
         let pool_name =
             self.sled_select_zpool(sled_id, ZoneKind::CockroachDb)?;
@@ -1519,7 +1519,7 @@ impl<'a> BlueprintBuilder<'a> {
         &mut self,
         sled_id: SledUuid,
     ) -> Result<(), Error> {
-        let id = self.rng.next_zone();
+        let id = self.rng.sled_rng(sled_id).next_zone();
         let underlay_address = self.sled_alloc_ip(sled_id)?;
         let address =
             SocketAddrV6::new(underlay_address, CLICKHOUSE_HTTP_PORT, 0, 0);
@@ -1544,7 +1544,7 @@ impl<'a> BlueprintBuilder<'a> {
         &mut self,
         sled_id: SledUuid,
     ) -> Result<(), Error> {
-        let zone_id = self.rng.next_zone();
+        let zone_id = self.rng.sled_rng(sled_id).next_zone();
         let underlay_ip = self.sled_alloc_ip(sled_id)?;
         let pool_name =
             self.sled_select_zpool(sled_id, ZoneKind::ClickhouseServer)?;
@@ -1571,7 +1571,7 @@ impl<'a> BlueprintBuilder<'a> {
         &mut self,
         sled_id: SledUuid,
     ) -> Result<(), Error> {
-        let zone_id = self.rng.next_zone();
+        let zone_id = self.rng.sled_rng(sled_id).next_zone();
         let underlay_ip = self.sled_alloc_ip(sled_id)?;
         let pool_name =
             self.sled_select_zpool(sled_id, ZoneKind::ClickhouseKeeper)?;
@@ -1670,7 +1670,7 @@ impl<'a> BlueprintBuilder<'a> {
         })?;
 
         // Add the new boundary NTP zone.
-        let new_zone_id = self.rng.next_zone();
+        let new_zone_id = self.rng.sled_rng(sled_id).next_zone();
         let ExternalSnatNetworkingChoice {
             snat_cfg,
             nic_ip,
@@ -1678,11 +1678,11 @@ impl<'a> BlueprintBuilder<'a> {
             nic_mac,
         } = self.external_networking()?.for_new_boundary_ntp()?;
         let external_ip = OmicronZoneExternalSnatIp {
-            id: self.rng.next_external_ip(),
+            id: self.rng.sled_rng(sled_id).next_external_ip(),
             snat_cfg,
         };
         let nic = NetworkInterface {
-            id: self.rng.next_network_interface(),
+            id: self.rng.sled_rng(sled_id).next_network_interface(),
             kind: NetworkInterfaceKind::Service {
                 id: new_zone_id.into_untyped_uuid(),
             },
@@ -1751,7 +1751,7 @@ impl<'a> BlueprintBuilder<'a> {
             ))
         })?;
         editor
-            .add_zone(zone, &mut self.rng)
+            .add_zone(zone, self.rng.sled_rng(sled_id))
             .map_err(|err| Error::SledEditError { sled_id, err })
     }
 

--- a/nexus/reconfigurator/planning/src/blueprint_editor/sled_editor.rs
+++ b/nexus/reconfigurator/planning/src/blueprint_editor/sled_editor.rs
@@ -5,7 +5,7 @@
 //! Support for editing the blueprint details of a single sled.
 
 use crate::blueprint_builder::SledEditCounts;
-use crate::planner::PlannerRng;
+use crate::planner::SledPlannerRng;
 use illumos_utils::zpool::ZpoolName;
 use itertools::Either;
 use nexus_sled_agent_shared::inventory::ZoneKind;
@@ -256,7 +256,7 @@ impl SledEditor {
     pub fn ensure_disk(
         &mut self,
         disk: BlueprintPhysicalDiskConfig,
-        rng: &mut PlannerRng,
+        rng: &mut SledPlannerRng,
     ) -> Result<(), SledEditError> {
         self.as_active_mut()?.ensure_disk(disk, rng);
         Ok(())
@@ -272,7 +272,7 @@ impl SledEditor {
     pub fn add_zone(
         &mut self,
         zone: BlueprintZoneConfig,
-        rng: &mut PlannerRng,
+        rng: &mut SledPlannerRng,
     ) -> Result<(), SledEditError> {
         self.as_active_mut()?.add_zone(zone, rng)
     }
@@ -289,7 +289,7 @@ impl SledEditor {
     /// datasets for all its zones. This method backfills them.
     pub fn ensure_datasets_for_running_zones(
         &mut self,
-        rng: &mut PlannerRng,
+        rng: &mut SledPlannerRng,
     ) -> Result<(), SledEditError> {
         self.as_active_mut()?.ensure_datasets_for_running_zones(rng)
     }
@@ -395,7 +395,7 @@ impl ActiveSledEditor {
     pub fn ensure_disk(
         &mut self,
         disk: BlueprintPhysicalDiskConfig,
-        rng: &mut PlannerRng,
+        rng: &mut SledPlannerRng,
     ) {
         let zpool = ZpoolName::new_external(disk.pool_id);
 
@@ -427,7 +427,7 @@ impl ActiveSledEditor {
     pub fn add_zone(
         &mut self,
         zone: BlueprintZoneConfig,
-        rng: &mut PlannerRng,
+        rng: &mut SledPlannerRng,
     ) -> Result<(), SledEditError> {
         // Ensure we can construct the configs for the datasets for this zone.
         let datasets = ZoneDatasetConfigs::new(&self.disks, &zone)?;
@@ -475,7 +475,7 @@ impl ActiveSledEditor {
     /// datasets for all its zones. This method backfills them.
     pub fn ensure_datasets_for_running_zones(
         &mut self,
-        rng: &mut PlannerRng,
+        rng: &mut SledPlannerRng,
     ) -> Result<(), SledEditError> {
         for zone in self.zones.zones(BlueprintZoneFilter::ShouldBeRunning) {
             ZoneDatasetConfigs::new(&self.disks, zone)?
@@ -548,7 +548,7 @@ impl ZoneDatasetConfigs {
     fn ensure_in_service(
         self,
         datasets: &mut DatasetsEditor,
-        rng: &mut PlannerRng,
+        rng: &mut SledPlannerRng,
     ) {
         if let Some(dataset) = self.filesystem {
             datasets.ensure_in_service(dataset, rng);

--- a/nexus/reconfigurator/planning/src/blueprint_editor/sled_editor/datasets.rs
+++ b/nexus/reconfigurator/planning/src/blueprint_editor/sled_editor/datasets.rs
@@ -3,7 +3,7 @@
 // file, You can obtain one at https://mozilla.org/MPL/2.0/.
 
 use crate::blueprint_builder::EditCounts;
-use crate::planner::PlannerRng;
+use crate::planner::SledPlannerRng;
 use illumos_utils::zpool::ZpoolName;
 use nexus_types::deployment::BlueprintDatasetConfig;
 use nexus_types::deployment::BlueprintDatasetDisposition;
@@ -340,7 +340,7 @@ impl DatasetsEditor {
     pub fn ensure_in_service(
         &mut self,
         dataset: PartialDatasetConfig,
-        rng: &mut PlannerRng,
+        rng: &mut SledPlannerRng,
     ) -> &BlueprintDatasetConfig {
         // Convert the partial config into a full config by finding or
         // generating its ID.
@@ -429,8 +429,10 @@ impl DatasetsEditor {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::planner::PlannerRng;
     use nexus_types::deployment::BlueprintDatasetFilter;
     use omicron_uuid_kinds::GenericUuid;
+    use omicron_uuid_kinds::SledUuid;
     use proptest::prelude::*;
     use std::collections::BTreeSet;
     use test_strategy::proptest;
@@ -603,6 +605,12 @@ mod tests {
             "proptest_add_same_kind_after_expunging",
         ));
 
+        // We need a sled ID to get a sled-specific RNG from `rng`; we're not
+        // testing blueprints as a whole here, so steal a blueprint ID and use
+        // it as a sled ID to get reproducibility.
+        let sled_id = SledUuid::from_untyped_uuid(rng.next_blueprint());
+        let rng = rng.sled_rng(sled_id);
+
         // For each originally-in-service dataset:
         //
         // 1. Expunge that dataset
@@ -625,7 +633,7 @@ mod tests {
                 reservation: dataset.reservation,
                 compression: dataset.compression,
             };
-            let new_dataset = editor.ensure_in_service(new_dataset, &mut rng);
+            let new_dataset = editor.ensure_in_service(new_dataset, rng);
             assert_ne!(dataset.id, new_dataset.id);
         }
 
@@ -667,7 +675,7 @@ mod tests {
                 reservation: dataset.reservation,
                 compression: dataset.compression,
             };
-            let new_dataset = editor.ensure_in_service(new_dataset, &mut rng);
+            let new_dataset = editor.ensure_in_service(new_dataset, rng);
             assert_ne!(dataset.id, new_dataset.id);
         }
     }
@@ -693,6 +701,12 @@ mod tests {
             rng_seed,
             "proptest_add_same_kind_after_expunging",
         ));
+
+        // We need a sled ID to get a sled-specific RNG from `rng`; we're not
+        // testing blueprints as a whole here, so steal a blueprint ID and use
+        // it as a sled ID to get reproducibility.
+        let sled_id = SledUuid::from_untyped_uuid(rng.next_blueprint());
+        let rng = rng.sled_rng(sled_id);
 
         // Expunge all datasets on all zpools, by zpool.
         for zpool_id in &all_zpools {
@@ -723,7 +737,7 @@ mod tests {
                 reservation: dataset.reservation,
                 compression: dataset.compression,
             };
-            let new_dataset = editor.ensure_in_service(new_dataset, &mut rng);
+            let new_dataset = editor.ensure_in_service(new_dataset, rng);
             assert_ne!(dataset.id, new_dataset.id);
         }
 
@@ -771,7 +785,7 @@ mod tests {
                 reservation: dataset.reservation,
                 compression: dataset.compression,
             };
-            let new_dataset = editor.ensure_in_service(new_dataset, &mut rng);
+            let new_dataset = editor.ensure_in_service(new_dataset, rng);
             assert_ne!(dataset.id, new_dataset.id);
         }
     }

--- a/nexus/reconfigurator/planning/src/planner.rs
+++ b/nexus/reconfigurator/planning/src/planner.rs
@@ -37,6 +37,7 @@ pub(crate) use self::omicron_zone_placement::DiscretionaryOmicronZone;
 use self::omicron_zone_placement::OmicronZonePlacement;
 use self::omicron_zone_placement::OmicronZonePlacementSledState;
 pub use self::rng::PlannerRng;
+pub use self::rng::SledPlannerRng;
 
 mod omicron_zone_placement;
 pub(crate) mod rng;

--- a/nexus/reconfigurator/planning/src/planner/rng.rs
+++ b/nexus/reconfigurator/planning/src/planner/rng.rs
@@ -11,8 +11,10 @@ use omicron_uuid_kinds::ExternalIpKind;
 use omicron_uuid_kinds::ExternalIpUuid;
 use omicron_uuid_kinds::OmicronZoneKind;
 use omicron_uuid_kinds::OmicronZoneUuid;
+use omicron_uuid_kinds::SledUuid;
 use rand::rngs::StdRng;
 use rand::SeedableRng as _;
+use std::collections::BTreeMap;
 use std::hash::Hash;
 use typed_rng::TypedUuidRng;
 use typed_rng::UuidRng;
@@ -20,6 +22,7 @@ use uuid::Uuid;
 
 #[derive(Clone, Debug)]
 pub struct PlannerRng {
+    parent: StdRng,
     // Have separate RNGs for the different kinds of UUIDs we might add,
     // generated from the main RNG. This is so that e.g. adding a new network
     // interface doesn't alter the blueprint or sled UUID.
@@ -27,10 +30,10 @@ pub struct PlannerRng {
     // In the future, when we switch to typed UUIDs, each of these will be
     // associated with a specific `TypedUuidKind`.
     blueprint_rng: UuidRng,
-    zone_rng: TypedUuidRng<OmicronZoneKind>,
-    dataset_rng: TypedUuidRng<DatasetKind>,
-    network_interface_rng: UuidRng,
-    external_ip_rng: TypedUuidRng<ExternalIpKind>,
+    // Each sled gets its own set of RNGs to avoid test changes to one sled
+    // (e.g., adding an extra zone) perturbing all subsequent zone/dataset/etc.
+    // IDs on other sleds.
+    sled_rngs: BTreeMap<SledUuid, SledPlannerRng>,
     clickhouse_rng: UuidRng,
 }
 
@@ -48,27 +51,51 @@ impl PlannerRng {
 
     pub fn new_from_parent(mut parent: StdRng) -> Self {
         let blueprint_rng = UuidRng::from_parent_rng(&mut parent, "blueprint");
-        let zone_rng = TypedUuidRng::from_parent_rng(&mut parent, "zone");
-        let dataset_rng = TypedUuidRng::from_parent_rng(&mut parent, "dataset");
-        let network_interface_rng =
-            UuidRng::from_parent_rng(&mut parent, "network_interface");
-        let external_ip_rng =
-            TypedUuidRng::from_parent_rng(&mut parent, "external_ip");
         let clickhouse_rng =
             UuidRng::from_parent_rng(&mut parent, "clickhouse");
 
         Self {
+            parent,
             blueprint_rng,
-            zone_rng,
-            dataset_rng,
-            network_interface_rng,
-            external_ip_rng,
+            sled_rngs: BTreeMap::new(),
             clickhouse_rng,
         }
     }
 
+    pub fn sled_rng(&mut self, sled_id: SledUuid) -> &mut SledPlannerRng {
+        self.sled_rngs
+            .entry(sled_id)
+            .or_insert_with(|| SledPlannerRng::new(sled_id, &mut self.parent))
+    }
+
     pub fn next_blueprint(&mut self) -> Uuid {
         self.blueprint_rng.next()
+    }
+
+    pub fn next_clickhouse(&mut self) -> Uuid {
+        self.clickhouse_rng.next()
+    }
+}
+
+#[derive(Clone, Debug)]
+pub struct SledPlannerRng {
+    zone_rng: TypedUuidRng<OmicronZoneKind>,
+    dataset_rng: TypedUuidRng<DatasetKind>,
+    network_interface_rng: UuidRng,
+    external_ip_rng: TypedUuidRng<ExternalIpKind>,
+}
+
+impl SledPlannerRng {
+    fn new(sled_id: SledUuid, parent: &mut StdRng) -> Self {
+        let zone_rng = TypedUuidRng::from_parent_rng(parent, (sled_id, "zone"));
+        let dataset_rng =
+            TypedUuidRng::from_parent_rng(parent, (sled_id, "dataset"));
+        let network_interface_rng =
+            UuidRng::from_parent_rng(parent, (sled_id, "network_interface"));
+        let external_ip_rng =
+            TypedUuidRng::from_parent_rng(parent, (sled_id, "external_ip"));
+
+        Self { zone_rng, dataset_rng, network_interface_rng, external_ip_rng }
     }
 
     pub fn next_zone(&mut self) -> OmicronZoneUuid {
@@ -85,9 +112,5 @@ impl PlannerRng {
 
     pub fn next_external_ip(&mut self) -> ExternalIpUuid {
         self.external_ip_rng.next()
-    }
-
-    pub fn next_clickhouse(&mut self) -> Uuid {
-        self.clickhouse_rng.next()
     }
 }

--- a/nexus/reconfigurator/planning/tests/output/example_builder_zone_counts_blueprint.txt
+++ b/nexus/reconfigurator/planning/tests/output/example_builder_zone_counts_blueprint.txt
@@ -23,24 +23,24 @@ parent:    e35b2fdd-354d-48d9-acb5-703b2c269a54
     ---------------------------------------------------------------------------------------------
     zone type         zone id                                disposition   underlay IP           
     ---------------------------------------------------------------------------------------------
-    clickhouse        fadaa1c6-81a2-46ed-a10f-c42c29b85de9   in service    fd00:1122:3344:105::24
-    crucible          4f673614-7a9d-4860-859c-9627de33e03b   in service    fd00:1122:3344:105::2b
-    crucible          6422c22d-00bf-4826-9aeb-cf4e4dcae1c7   in service    fd00:1122:3344:105::2d
-    crucible          76edbb5e-7038-4160-833b-131abc2b2a12   in service    fd00:1122:3344:105::31
-    crucible          85631c30-4b81-4a22-a0e5-e110034cc980   in service    fd00:1122:3344:105::29
-    crucible          9334f86c-6555-499a-9ad7-5acc987e2b87   in service    fd00:1122:3344:105::2f
-    crucible          a0624221-da2b-4f45-862e-effec567dcd1   in service    fd00:1122:3344:105::2a
-    crucible          c33f069b-e412-4309-a62b-e1cbef3ec234   in service    fd00:1122:3344:105::30
-    crucible          c863bdbb-f270-47e1-bf7b-2220cf129266   in service    fd00:1122:3344:105::28
-    crucible          d42c15ed-d303-43d4-b9e9-c5772505c2d7   in service    fd00:1122:3344:105::2c
-    crucible          d660e9f0-2f8f-4540-bd59-a32845d002ce   in service    fd00:1122:3344:105::2e
-    crucible_pantry   a9980763-1f8c-452d-a542-551d1001131e   in service    fd00:1122:3344:105::27
-    external_dns      5002e44e-eef1-4f3c-81fc-78b62134400e   in service    fd00:1122:3344:105::26
-    external_dns      82db7bcc-9e4c-418f-a46a-eb8ff561de7b   in service    fd00:1122:3344:105::25
-    internal_dns      faac06c4-9aea-44a3-a94f-3da1adddb7b9   in service    fd00:1122:3344:1::1   
-    internal_ntp      a3a3fccb-1127-4e61-9bdf-13eb58365a8a   in service    fd00:1122:3344:105::21
-    nexus             1a741601-83b2-40b7-b59b-1a9b2c853411   in service    fd00:1122:3344:105::23
-    nexus             a7743bca-5056-479f-9151-6f2288c0ae28   in service    fd00:1122:3344:105::22
+    clickhouse        4365e906-7a33-4c8c-bf17-3b44445e333e   in service    fd00:1122:3344:105::24
+    crucible          1d8bbe29-01b8-4bc0-bcd0-ca9864d881df   in service    fd00:1122:3344:105::30
+    crucible          1f679ae9-d2c2-4d18-9258-a4ca59f34c2f   in service    fd00:1122:3344:105::2c
+    crucible          2098c2d8-fb3b-4514-a856-a89aca1d2086   in service    fd00:1122:3344:105::2f
+    crucible          5aff48ae-3661-473b-9098-e2d185871289   in service    fd00:1122:3344:105::2a
+    crucible          7ef24e88-d759-4d4d-b854-4a72e2e64999   in service    fd00:1122:3344:105::28
+    crucible          8f5f749a-12a0-4f65-a73f-7c05007ef8da   in service    fd00:1122:3344:105::2b
+    crucible          a8fdd554-28cd-44e5-93c3-5f07bb3e0cbc   in service    fd00:1122:3344:105::31
+    crucible          af336d4e-844d-44a9-87c2-295a51d4f26b   in service    fd00:1122:3344:105::2e
+    crucible          d10c1ac8-a352-4f02-a2f9-a9294ba358dd   in service    fd00:1122:3344:105::2d
+    crucible          ec1cac47-a611-4614-8615-9541d3f71709   in service    fd00:1122:3344:105::29
+    crucible_pantry   07b0ef64-1d33-496f-a964-57e6d786f8ce   in service    fd00:1122:3344:105::27
+    external_dns      5c7f05d1-e37f-4756-b678-643783385603   in service    fd00:1122:3344:105::26
+    external_dns      ab072f6a-5cd8-4ade-99a7-b3f24c2b40d5   in service    fd00:1122:3344:105::25
+    internal_dns      246fa3f9-f3bc-4fb8-bc58-8a3d3c483ecb   in service    fd00:1122:3344:1::1   
+    internal_ntp      37a536a6-9043-4f44-bbc1-187b3b7859b1   in service    fd00:1122:3344:105::21
+    nexus             0bbeda6e-de94-41db-ba09-8b55c541d53b   in service    fd00:1122:3344:105::22
+    nexus             23d4c822-51bd-4966-8dc2-0be4b9e760c1   in service    fd00:1122:3344:105::23
 
 
 
@@ -66,22 +66,22 @@ parent:    e35b2fdd-354d-48d9-acb5-703b2c269a54
     ---------------------------------------------------------------------------------------------
     zone type         zone id                                disposition   underlay IP           
     ---------------------------------------------------------------------------------------------
-    crucible          0dba037d-0b14-4e10-b430-c271f87d8e9a   in service    fd00:1122:3344:104::27
-    crucible          10f24d62-dec3-4f6f-9f42-722763e1fcbd   in service    fd00:1122:3344:104::2b
-    crucible          313bb913-2e8b-4c27-89e6-79c92db8c03c   in service    fd00:1122:3344:104::26
-    crucible          3c900bee-7455-4a41-8175-fe952484753c   in service    fd00:1122:3344:104::2f
-    crucible          68ff33cc-852b-4f2c-bc5c-9f7bdc32110e   in service    fd00:1122:3344:104::2e
-    crucible          69b59e77-9da3-49d3-bf83-a464570aea97   in service    fd00:1122:3344:104::28
-    crucible          7943dee3-d4ad-4ffb-93c7-2c1079e708a1   in service    fd00:1122:3344:104::2c
-    crucible          b2f90d4d-34ff-4aae-8cfd-4773a30c372f   in service    fd00:1122:3344:104::29
-    crucible          caf0bd1b-1da6-46b0-bb64-d6b780ad7a4c   in service    fd00:1122:3344:104::2d
-    crucible          f3c76e5a-779a-4c3c-87ce-dad309f612c4   in service    fd00:1122:3344:104::2a
-    crucible_pantry   362b181b-452e-4f54-a42f-04bef00fa272   in service    fd00:1122:3344:104::25
-    external_dns      60a0051f-d530-49e6-ab11-e2098856afba   in service    fd00:1122:3344:104::23
-    external_dns      8343556a-7827-4fdd-90df-a4b603b177cc   in service    fd00:1122:3344:104::24
-    internal_dns      1c0614f1-b653-43c2-b278-5372036a87c8   in service    fd00:1122:3344:2::1   
-    internal_ntp      35a629e9-5140-48bf-975d-ce66d9c3be59   in service    fd00:1122:3344:104::21
-    nexus             58d88005-e182-4463-96ed-9220e59facb7   in service    fd00:1122:3344:104::22
+    crucible          06f09ec9-17bf-412c-a39f-9d7dfaf357a4   in service    fd00:1122:3344:104::2c
+    crucible          0d903191-f7d9-4e03-9e8e-8c16a913279a   in service    fd00:1122:3344:104::2a
+    crucible          1d88c19b-5f8e-44dd-a9bd-c7d54710daba   in service    fd00:1122:3344:104::2f
+    crucible          2874301d-348d-4ec8-a907-3e9522e523f1   in service    fd00:1122:3344:104::2b
+    crucible          682a3145-d95b-4543-8683-25edea05cbc9   in service    fd00:1122:3344:104::27
+    crucible          73da1029-abcc-465a-b65d-8b15a43ef4f0   in service    fd00:1122:3344:104::26
+    crucible          d7886bb9-cf2f-46af-a9a7-3eda2a548c98   in service    fd00:1122:3344:104::28
+    crucible          d893603e-bbe6-4006-aebd-0cd96a160203   in service    fd00:1122:3344:104::2d
+    crucible          f4945957-e5ea-4b38-8344-e7bd610aa442   in service    fd00:1122:3344:104::2e
+    crucible          f7540a15-7960-4681-a202-443d5ccd80b0   in service    fd00:1122:3344:104::29
+    crucible_pantry   2d53e5bb-4265-4fe0-8ea4-f1a0a3bb9189   in service    fd00:1122:3344:104::25
+    external_dns      0eeabc44-5fc4-44e9-8884-68151571b217   in service    fd00:1122:3344:104::23
+    external_dns      aad293d7-74dc-48dc-bb50-1e1f972fda23   in service    fd00:1122:3344:104::24
+    internal_dns      a399df19-8b57-4727-ac5d-94fdf76d0888   in service    fd00:1122:3344:2::1   
+    internal_ntp      3e305e50-9192-4c0d-8fb6-bc539a37fc3e   in service    fd00:1122:3344:104::21
+    nexus             0a3ccdda-78e3-4a90-b79e-dd1c8954098f   in service    fd00:1122:3344:104::22
 
 
 
@@ -107,21 +107,21 @@ parent:    e35b2fdd-354d-48d9-acb5-703b2c269a54
     ---------------------------------------------------------------------------------------------
     zone type         zone id                                disposition   underlay IP           
     ---------------------------------------------------------------------------------------------
-    crucible          0d5f20e4-fdca-4611-ac07-053bc28c5088   in service    fd00:1122:3344:102::2c
-    crucible          234514a8-7a70-4dc5-905b-a29d1cfdee99   in service    fd00:1122:3344:102::29
-    crucible          29400193-6c20-4c41-8c9a-5259803c7bfd   in service    fd00:1122:3344:102::28
-    crucible          7cbc95ce-ab55-4b70-851d-33a0164ca362   in service    fd00:1122:3344:102::2e
-    crucible          7e6fa426-5200-47b4-b791-393dd17b09d9   in service    fd00:1122:3344:102::2f
-    crucible          a16b5904-5ba8-42db-940c-8b852b052995   in service    fd00:1122:3344:102::2d
-    crucible          a1a32afe-10db-4dbf-ac2d-6745f6f55417   in service    fd00:1122:3344:102::2b
-    crucible          bec70cc9-82f9-42d3-935b-4f141c3c3503   in service    fd00:1122:3344:102::2a
-    crucible          de2023c8-6976-40fa-80d7-a8b0ea9546a1   in service    fd00:1122:3344:102::27
-    crucible          ed528efc-4d32-43cc-a0a2-b412693a7eca   in service    fd00:1122:3344:102::26
-    crucible_pantry   a3333bac-4989-4d9a-8257-8c7a0614cef0   in service    fd00:1122:3344:102::25
-    external_dns      31fdc4e5-25f2-42c5-8c2c-7f8bf3a0b89e   in service    fd00:1122:3344:102::23
-    external_dns      e4aeecc2-f9ae-4b4f-963c-9c017e9df189   in service    fd00:1122:3344:102::24
-    internal_ntp      cb4a2547-7798-48d2-839d-29f7d33d1486   in service    fd00:1122:3344:102::21
-    nexus             5895eb4f-7132-4530-8fc1-f9b719981856   in service    fd00:1122:3344:102::22
+    crucible          0b5c74ed-0681-4112-ab22-e6aa282999ea   in service    fd00:1122:3344:102::29
+    crucible          2a71a664-3afc-4c9b-844a-838423a7ce6d   in service    fd00:1122:3344:102::27
+    crucible          377b5e5a-d8e5-407e-ad33-d11592a234ca   in service    fd00:1122:3344:102::2a
+    crucible          470086b8-d5d5-4349-a63c-8c70021c89ad   in service    fd00:1122:3344:102::2b
+    crucible          4f559858-1c4f-4014-86f1-c497936510bf   in service    fd00:1122:3344:102::28
+    crucible          7f73bce2-c685-4501-a4fe-34327f6a30a5   in service    fd00:1122:3344:102::2c
+    crucible          8971a3f0-32ed-4444-8b7c-c492f55f6464   in service    fd00:1122:3344:102::2e
+    crucible          95c4aca6-aab6-4bde-ab8c-94bbe3beef3f   in service    fd00:1122:3344:102::2d
+    crucible          d2b2710c-99a0-4d76-8c45-918fe7745d6a   in service    fd00:1122:3344:102::2f
+    crucible          dcdb2cf0-b347-49f4-a38d-0a2ce82d53ce   in service    fd00:1122:3344:102::26
+    crucible_pantry   6c856814-7dda-466a-8c40-18dc59f23167   in service    fd00:1122:3344:102::25
+    external_dns      a39f897f-d9a0-4193-aee4-f879d1cb8e2c   in service    fd00:1122:3344:102::23
+    external_dns      bff5eb61-89b4-49f1-8dd7-3bbf9f3ff4c1   in service    fd00:1122:3344:102::24
+    internal_ntp      ab44f8b2-4346-4cb2-bd4a-44063fa5df56   in service    fd00:1122:3344:102::21
+    nexus             eb1c79f7-1d99-42f6-b2cf-7d64419b2fed   in service    fd00:1122:3344:102::22
 
 
 
@@ -147,21 +147,21 @@ parent:    e35b2fdd-354d-48d9-acb5-703b2c269a54
     ---------------------------------------------------------------------------------------------
     zone type         zone id                                disposition   underlay IP           
     ---------------------------------------------------------------------------------------------
-    crucible          0a6c78bb-f778-4b6d-9d20-370ae7c89135   in service    fd00:1122:3344:103::29
-    crucible          19faa2c3-b077-470a-a424-6821dd49bd11   in service    fd00:1122:3344:103::2f
-    crucible          236e5a84-cebe-40b8-8832-56a8e06b08b0   in service    fd00:1122:3344:103::2c
-    crucible          590907c2-e61e-4c2f-8a36-e705a24600c8   in service    fd00:1122:3344:103::27
-    crucible          77511292-f3aa-4a07-970a-1159e2c38ec9   in service    fd00:1122:3344:103::2b
-    crucible          c3b6651b-6a62-4292-972c-481390f4a044   in service    fd00:1122:3344:103::26
-    crucible          dd9050e5-77ae-4dd0-98aa-d34fc2be78d4   in service    fd00:1122:3344:103::2d
-    crucible          e8ac4104-9789-4ba1-90c5-aded124cc079   in service    fd00:1122:3344:103::2e
-    crucible          ea723ef1-b23e-433d-bef5-90142476225d   in service    fd00:1122:3344:103::28
-    crucible          fbc67c83-773a-48ff-857c-61ddbf1ebf52   in service    fd00:1122:3344:103::2a
-    crucible_pantry   9ff080b2-7bf9-4fe3-8d5f-367adb3525c8   in service    fd00:1122:3344:103::25
-    external_dns      983ed36f-baed-4dd1-bec7-4780f070eeee   in service    fd00:1122:3344:103::24
-    external_dns      e8bb3c35-b1ee-4171-b8ff-924e6a560fbf   in service    fd00:1122:3344:103::23
-    internal_ntp      e8d99319-3796-4605-bd96-e17011d77016   in service    fd00:1122:3344:103::21
-    nexus             efa54182-a3e6-4600-9e88-044a6a8ae350   in service    fd00:1122:3344:103::22
+    crucible          154d09df-6ba2-4b2d-9593-aed966fa8edd   in service    fd00:1122:3344:103::2d
+    crucible          3c0d398b-e239-417e-94af-c0113f3b3df0   in service    fd00:1122:3344:103::2f
+    crucible          490b85bd-cb2a-4730-9586-7340c2b33290   in service    fd00:1122:3344:103::29
+    crucible          6dd7f36b-eb4c-4666-a5b3-8e4f7765f284   in service    fd00:1122:3344:103::26
+    crucible          72307d66-7b37-4bb5-a45b-1424bbd2db89   in service    fd00:1122:3344:103::2a
+    crucible          80df9448-d723-450b-a5a9-55f67279e45c   in service    fd00:1122:3344:103::2c
+    crucible          85078136-3cbf-4884-a44e-340c40cbd180   in service    fd00:1122:3344:103::28
+    crucible          dc841af2-b873-4a4b-a158-09a68db6445e   in service    fd00:1122:3344:103::27
+    crucible          e1f8a0ca-4bce-4925-abe7-bdc508fff8e3   in service    fd00:1122:3344:103::2b
+    crucible          f3ac0681-8f1e-4e57-a81c-a958f79fe9db   in service    fd00:1122:3344:103::2e
+    crucible_pantry   60d6c6b4-0754-413e-8a59-bcc3509d411a   in service    fd00:1122:3344:103::25
+    external_dns      70bb46c9-820a-4e5b-b1fc-392aea9057e8   in service    fd00:1122:3344:103::23
+    external_dns      e9aefa25-1524-4514-9a8d-075dc084c0a0   in service    fd00:1122:3344:103::24
+    internal_ntp      705fe10e-b41f-4de1-b712-3b9cd2a6cd3b   in service    fd00:1122:3344:103::21
+    nexus             0b93b21c-9914-4802-bb58-225c314bea37   in service    fd00:1122:3344:103::22
 
 
 
@@ -187,21 +187,21 @@ parent:    e35b2fdd-354d-48d9-acb5-703b2c269a54
     ---------------------------------------------------------------------------------------------
     zone type         zone id                                disposition   underlay IP           
     ---------------------------------------------------------------------------------------------
-    crucible          00e6f92a-997a-4c1f-8c84-be547eb012d3   in service    fd00:1122:3344:101::2a
-    crucible          0e12b408-dc46-4827-82e5-4589cb895b58   in service    fd00:1122:3344:101::2d
-    crucible          0ed1d110-0727-4a4c-9ef1-f74fa885dce2   in service    fd00:1122:3344:101::2e
-    crucible          7a520d9b-5f7d-4e5c-b1bc-7e65a35984b6   in service    fd00:1122:3344:101::2f
-    crucible          be3b1ad8-3de2-4ad7-89b8-d279558121ae   in service    fd00:1122:3344:101::28
-    crucible          c6192cad-a9c5-4b4d-bc8f-ce0fb066a0ed   in service    fd00:1122:3344:101::27
-    crucible          d3445179-d068-4406-9aae-255bd0008280   in service    fd00:1122:3344:101::2b
-    crucible          e8dea18b-1697-4349-ae54-47f95cb3d907   in service    fd00:1122:3344:101::26
-    crucible          f1f1ee53-a974-45f8-9173-211ed366ab7d   in service    fd00:1122:3344:101::2c
-    crucible          f4053fb9-ce8c-4dcf-8dd3-bf6d305c29fc   in service    fd00:1122:3344:101::29
-    crucible_pantry   25fb011b-ea9d-462c-a89e-5f7782858a4f   in service    fd00:1122:3344:101::25
-    external_dns      1b122e0d-8b22-464f-b1af-589246d636dc   in service    fd00:1122:3344:101::24
-    external_dns      808e6761-6ddc-42f0-a82f-fd2049c751dc   in service    fd00:1122:3344:101::23
-    internal_ntp      a1e77a19-9302-416a-afe9-cfdded5054d5   in service    fd00:1122:3344:101::21
-    nexus             d39f526b-9799-42a6-a610-f0f5605dac44   in service    fd00:1122:3344:101::22
+    crucible          39360f6b-69bc-4c7b-b24f-0a9d640e8e56   in service    fd00:1122:3344:101::2f
+    crucible          52074602-a8a5-47f0-90b6-5932b06034a2   in service    fd00:1122:3344:101::27
+    crucible          59da8225-2f80-41ae-afef-dce85dcb526d   in service    fd00:1122:3344:101::2e
+    crucible          5d3ec58b-746e-4f10-9998-5fd81dc34ef1   in service    fd00:1122:3344:101::28
+    crucible          65fc4eb5-51c3-4361-81a4-a216b4ed67a0   in service    fd00:1122:3344:101::2d
+    crucible          765252ef-de7d-4023-b271-7acd6299ba5f   in service    fd00:1122:3344:101::2b
+    crucible          7bc16ca6-36d7-4a7c-93e7-6d1f0aad41bb   in service    fd00:1122:3344:101::29
+    crucible          a6a695dc-0d62-4d4e-936a-8e7ee1e527e8   in service    fd00:1122:3344:101::2a
+    crucible          abf18c62-0342-450c-b646-7df9f2951b76   in service    fd00:1122:3344:101::26
+    crucible          c0f1485b-d707-4aec-8c87-3c5057018ef2   in service    fd00:1122:3344:101::2c
+    crucible_pantry   038ba0cf-de93-45b1-a0ae-b894b36bf92d   in service    fd00:1122:3344:101::25
+    external_dns      402719bf-c387-4979-8ae4-3a6f8eada5ab   in service    fd00:1122:3344:101::24
+    external_dns      9ee48a0d-66ac-4fc9-aaa8-8f939ebef705   in service    fd00:1122:3344:101::23
+    internal_ntp      4420e03b-4086-48c6-b27d-824bb5bb4758   in service    fd00:1122:3344:101::21
+    nexus             ec10317f-5c36-4092-827c-f2826c5572d5   in service    fd00:1122:3344:101::22
 
 
  COCKROACHDB SETTINGS:

--- a/nexus/reconfigurator/planning/tests/output/planner_basic_add_sled_2_3.txt
+++ b/nexus/reconfigurator/planning/tests/output/planner_basic_add_sled_2_3.txt
@@ -25,74 +25,74 @@ to:   blueprint 4171ad05-89dd-474b-846b-b007e4346366
     -----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
     dataset name                                                                                                   dataset uuid                           quota     reservation   compression
     -----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
-    oxp_014eb1e9-04fe-4f36-8339-0a090b053ada/crucible                                                              a9c330b0-1f48-4bd7-b82f-c3419131b69b   none      none          off        
-    oxp_31a3bc64-7a3b-496d-b644-785dc44b6e37/crucible                                                              2cd64120-ea51-450a-bac8-d419f9ff7570   none      none          off        
-    oxp_7bb40bd6-9c43-4b63-8337-18313c72aea2/crucible                                                              cd1cc777-1813-427a-bf3b-8b4cb372608c   none      none          off        
-    oxp_988aa8c2-cb5e-406b-9289-425dc2e5bc3a/crucible                                                              3aa68ad8-0539-4d41-a709-50fa4a0f97e5   none      none          off        
-    oxp_ad574c09-2ae0-4534-a2a4-f923ce20ae87/crucible                                                              eb598474-ce25-4878-87b9-3c26318fb192   none      none          off        
-    oxp_ad91e238-4901-4ff4-a91b-75233c936426/crucible                                                              7600ccdd-7b1a-46b6-85c2-800b2d4cf4d8   none      none          off        
-    oxp_ce58d463-d442-4c97-a6b4-f7d98c3fd902/crucible                                                              3243c276-0a62-4c1f-9976-c353618b2585   none      none          off        
-    oxp_f18f7689-0059-4b79-880e-34faf7a0fe0e/crucible                                                              f68ba9d0-a5cf-4148-a754-010656ae5f7b   none      none          off        
-    oxp_f1d6cea4-640f-415e-89fe-2b1784ce3db8/crucible                                                              cea3cbac-de83-4a0c-a003-e42086fd418c   none      none          off        
-    oxp_f4a96860-bdeb-4435-bdf5-2a10beb3d44a/crucible                                                              88143ddc-773c-43e6-9859-5033535b566c   none      none          off        
-    oxp_014eb1e9-04fe-4f36-8339-0a090b053ada/crypt/clickhouse                                                      7c20d4b3-b783-4ba7-94a9-a8b789b04674   none      none          off        
-    oxp_014eb1e9-04fe-4f36-8339-0a090b053ada/crypt/internal_dns                                                    e2a6246d-00f0-4526-a2ab-99b2db7e1d51   none      none          off        
-    oxp_014eb1e9-04fe-4f36-8339-0a090b053ada/crypt/zone                                                            1e7c17fa-63d5-4a62-8037-663745516d18   none      none          off        
-    oxp_31a3bc64-7a3b-496d-b644-785dc44b6e37/crypt/zone                                                            5e5c6b62-7785-4180-b901-6f33d676d657   none      none          off        
-    oxp_7bb40bd6-9c43-4b63-8337-18313c72aea2/crypt/zone                                                            536e5566-25b0-4df3-946e-3c59ca7d7921   none      none          off        
-    oxp_988aa8c2-cb5e-406b-9289-425dc2e5bc3a/crypt/zone                                                            14d03496-7ebd-4272-a58b-4c193ba0da82   none      none          off        
-    oxp_ad574c09-2ae0-4534-a2a4-f923ce20ae87/crypt/zone                                                            3fa2a825-bfec-42ca-801b-fc901f7a7729   none      none          off        
-    oxp_ad91e238-4901-4ff4-a91b-75233c936426/crypt/zone                                                            63720ef8-1aad-4f61-a20b-078a1eb4d436   none      none          off        
-    oxp_ce58d463-d442-4c97-a6b4-f7d98c3fd902/crypt/zone                                                            b58e8fae-21e3-4131-a37a-7c8bfaa242f5   none      none          off        
-    oxp_f18f7689-0059-4b79-880e-34faf7a0fe0e/crypt/zone                                                            e7e785bc-f3db-44ab-a4a2-71cca70507e4   none      none          off        
-    oxp_f1d6cea4-640f-415e-89fe-2b1784ce3db8/crypt/zone                                                            1e998426-2b49-4abc-877d-e7b972e5aadb   none      none          off        
-    oxp_f4a96860-bdeb-4435-bdf5-2a10beb3d44a/crypt/zone                                                            c02e8b44-3f25-4529-9d97-9a908e52af1d   none      none          off        
-    oxp_014eb1e9-04fe-4f36-8339-0a090b053ada/crypt/zone/oxz_clickhouse_b40f7c7b-526c-46c8-ae33-67280c280eb7        38af39e8-406d-4ffe-8afb-f15d80fbea27   none      none          off        
-    oxp_f18f7689-0059-4b79-880e-34faf7a0fe0e/crypt/zone/oxz_crucible_08c7f8aa-1ea9-469b-8cac-2fdbfc11ebcb          e78dca52-4122-428a-b8c5-911fcce624de   none      none          off        
-    oxp_f4a96860-bdeb-4435-bdf5-2a10beb3d44a/crypt/zone/oxz_crucible_3eda924f-22a9-4f3e-9a1b-91d1c47601ab          53c8cf89-1838-4638-8a27-683d134cbd9c   none      none          off        
-    oxp_ad574c09-2ae0-4534-a2a4-f923ce20ae87/crypt/zone/oxz_crucible_4ab1650f-32c5-447f-939d-64b8103a7645          e008db37-e6ad-433a-8aa1-ab06f8bad5b4   none      none          off        
-    oxp_31a3bc64-7a3b-496d-b644-785dc44b6e37/crypt/zone/oxz_crucible_64aa65f8-1ccb-4cd6-9953-027aebdac8ff          70a5b1f3-dbd7-4cc0-8a30-9a8c5ff33402   none      none          off        
-    oxp_ad91e238-4901-4ff4-a91b-75233c936426/crypt/zone/oxz_crucible_6e811d86-8aa7-4660-935b-84b4b7721b10          b833252f-8df1-4188-9282-0b4e90caec37   none      none          off        
-    oxp_ce58d463-d442-4c97-a6b4-f7d98c3fd902/crypt/zone/oxz_crucible_7fbd2c38-5dc3-48c4-b061-558a2041d70f          8a3cdc7a-802b-4b83-84bd-14f62c43ee7e   none      none          off        
-    oxp_988aa8c2-cb5e-406b-9289-425dc2e5bc3a/crypt/zone/oxz_crucible_8e9e923e-62b1-4cbc-9f59-d6397e338b6b          724bd053-39f3-4c24-8109-a4d8b4c27787   none      none          off        
-    oxp_7bb40bd6-9c43-4b63-8337-18313c72aea2/crypt/zone/oxz_crucible_b14d5478-1a0e-4b90-b526-36b06339dfc4          32f26a28-c25b-4706-9fc0-712ea55b8d88   none      none          off        
-    oxp_014eb1e9-04fe-4f36-8339-0a090b053ada/crypt/zone/oxz_crucible_be97b92b-38d6-422a-8c76-d37060f75bd2          574ac2b5-0233-488c-afd1-7ef4adc00b61   none      none          off        
-    oxp_f1d6cea4-640f-415e-89fe-2b1784ce3db8/crypt/zone/oxz_crucible_c66ab6d5-ff7a-46d1-9fd0-70cefa352d25          cc0d38c6-17f2-4861-889f-82398f0eade2   none      none          off        
-    oxp_014eb1e9-04fe-4f36-8339-0a090b053ada/crypt/zone/oxz_crucible_pantry_747d2426-68bf-4c22-8806-41d290b5d5f5   a820d4d1-87d3-419d-8ed3-0dda65f8e808   none      none          off        
-    oxp_014eb1e9-04fe-4f36-8339-0a090b053ada/crypt/zone/oxz_internal_dns_322ee9f1-8903-4542-a0a8-a54cefabdeca      d907b775-c3e6-4b0f-90e7-a2923c5790bf   none      none          off        
-    oxp_014eb1e9-04fe-4f36-8339-0a090b053ada/crypt/zone/oxz_nexus_cc816cfe-3869-4dde-b596-397d41198628             5f84acc5-e9f0-4f12-93e9-d2a271cb8ea0   none      none          off        
-    oxp_014eb1e9-04fe-4f36-8339-0a090b053ada/crypt/zone/oxz_ntp_267ed614-92af-4b9d-bdba-c2881c2e43a2               bf1b301a-436c-4cdc-b3cd-de08dfcadc86   none      none          off        
-    oxp_014eb1e9-04fe-4f36-8339-0a090b053ada/crypt/debug                                                           0a6be80b-87c5-41fd-bd3c-36275b4ec494   100 GiB   none          gzip-9     
-    oxp_31a3bc64-7a3b-496d-b644-785dc44b6e37/crypt/debug                                                           bbc7b434-12d0-441f-86c1-73d8355db38b   100 GiB   none          gzip-9     
-    oxp_7bb40bd6-9c43-4b63-8337-18313c72aea2/crypt/debug                                                           43858cf5-148f-48d8-9e52-b878d2efb6a5   100 GiB   none          gzip-9     
-    oxp_988aa8c2-cb5e-406b-9289-425dc2e5bc3a/crypt/debug                                                           bb0c5843-4fd2-4c5a-a7a1-2bc1e9180caf   100 GiB   none          gzip-9     
-    oxp_ad574c09-2ae0-4534-a2a4-f923ce20ae87/crypt/debug                                                           cb06ffe2-7f4d-4936-8310-ebf5e032a32c   100 GiB   none          gzip-9     
-    oxp_ad91e238-4901-4ff4-a91b-75233c936426/crypt/debug                                                           0a585f79-acdb-4de1-9e32-e54906b1cfb8   100 GiB   none          gzip-9     
-    oxp_ce58d463-d442-4c97-a6b4-f7d98c3fd902/crypt/debug                                                           e86ad99b-5040-4863-86db-0375ed3004f4   100 GiB   none          gzip-9     
-    oxp_f18f7689-0059-4b79-880e-34faf7a0fe0e/crypt/debug                                                           f0945e1c-9c5e-463c-bee9-bee695299a0b   100 GiB   none          gzip-9     
-    oxp_f1d6cea4-640f-415e-89fe-2b1784ce3db8/crypt/debug                                                           dd7111a0-555c-4b82-82b3-2cc93a2b1771   100 GiB   none          gzip-9     
-    oxp_f4a96860-bdeb-4435-bdf5-2a10beb3d44a/crypt/debug                                                           b8abfcc9-d636-4cee-b0a1-dd4b62ceade5   100 GiB   none          gzip-9     
+    oxp_014eb1e9-04fe-4f36-8339-0a090b053ada/crucible                                                              ea8bb9f4-ef14-4764-8713-299c94aee754   none      none          off        
+    oxp_31a3bc64-7a3b-496d-b644-785dc44b6e37/crucible                                                              7dcb9cca-dcac-4d95-92d1-f9ee376558ee   none      none          off        
+    oxp_7bb40bd6-9c43-4b63-8337-18313c72aea2/crucible                                                              87f012e5-1979-4d4f-abd7-5004e6a4de4a   none      none          off        
+    oxp_988aa8c2-cb5e-406b-9289-425dc2e5bc3a/crucible                                                              8a017cce-a6e3-4891-80d2-282134012f1f   none      none          off        
+    oxp_ad574c09-2ae0-4534-a2a4-f923ce20ae87/crucible                                                              51734f27-2839-481c-b11d-f59843297269   none      none          off        
+    oxp_ad91e238-4901-4ff4-a91b-75233c936426/crucible                                                              4ebb5c8c-77cc-4d9a-a66a-aab846d7f4d7   none      none          off        
+    oxp_ce58d463-d442-4c97-a6b4-f7d98c3fd902/crucible                                                              7e930ce3-f0e6-4188-940a-07dee8fc97cd   none      none          off        
+    oxp_f18f7689-0059-4b79-880e-34faf7a0fe0e/crucible                                                              e688234b-9854-4a4e-ae8e-5ec66a323784   none      none          off        
+    oxp_f1d6cea4-640f-415e-89fe-2b1784ce3db8/crucible                                                              48a12bd9-3d59-4151-adf1-ff703d71977c   none      none          off        
+    oxp_f4a96860-bdeb-4435-bdf5-2a10beb3d44a/crucible                                                              4a0ed488-8ab7-4a8b-90da-ab568081832b   none      none          off        
+    oxp_014eb1e9-04fe-4f36-8339-0a090b053ada/crypt/clickhouse                                                      87d67ac6-6079-4a4c-960e-44991410a64c   none      none          off        
+    oxp_014eb1e9-04fe-4f36-8339-0a090b053ada/crypt/internal_dns                                                    31caca18-3e69-4e95-a48e-1a3f9219a304   none      none          off        
+    oxp_014eb1e9-04fe-4f36-8339-0a090b053ada/crypt/zone                                                            8df851fd-0e0c-4069-ad4b-e8669051e42d   none      none          off        
+    oxp_31a3bc64-7a3b-496d-b644-785dc44b6e37/crypt/zone                                                            3c2b2846-d286-4ac7-9001-1dbc92d8ec52   none      none          off        
+    oxp_7bb40bd6-9c43-4b63-8337-18313c72aea2/crypt/zone                                                            d7519dd3-b371-4570-b474-e198d679bc47   none      none          off        
+    oxp_988aa8c2-cb5e-406b-9289-425dc2e5bc3a/crypt/zone                                                            da77f084-5fc9-477a-a5b1-e424f98aa53f   none      none          off        
+    oxp_ad574c09-2ae0-4534-a2a4-f923ce20ae87/crypt/zone                                                            8ffb3c67-d81d-4edc-b4fa-f829bc6d9fb5   none      none          off        
+    oxp_ad91e238-4901-4ff4-a91b-75233c936426/crypt/zone                                                            12c23a3b-389d-4f4f-950e-f7e36ae44262   none      none          off        
+    oxp_ce58d463-d442-4c97-a6b4-f7d98c3fd902/crypt/zone                                                            6614568a-a5a5-4db2-80f2-3e405fe35e17   none      none          off        
+    oxp_f18f7689-0059-4b79-880e-34faf7a0fe0e/crypt/zone                                                            a7d4d358-7935-4060-985f-280829de083c   none      none          off        
+    oxp_f1d6cea4-640f-415e-89fe-2b1784ce3db8/crypt/zone                                                            35decedb-c97e-4fde-9ee2-26680ccc7f7e   none      none          off        
+    oxp_f4a96860-bdeb-4435-bdf5-2a10beb3d44a/crypt/zone                                                            a0b8487f-b194-4583-ab31-3b02d85af60b   none      none          off        
+    oxp_014eb1e9-04fe-4f36-8339-0a090b053ada/crypt/zone/oxz_clickhouse_98229df2-6faf-45a4-8501-48e1ad25706e        0bda3f6e-6852-4476-8539-8d6315466ccb   none      none          off        
+    oxp_ad574c09-2ae0-4534-a2a4-f923ce20ae87/crypt/zone/oxz_crucible_3384bb31-72f2-46fc-9ada-b324580e2930          707c72de-e19c-4c7b-b2a1-4b028e1026c9   none      none          off        
+    oxp_f1d6cea4-640f-415e-89fe-2b1784ce3db8/crypt/zone/oxz_crucible_397f4188-68b0-4d82-aea4-5b950f6fc779          8cab65a0-26af-42e7-9f77-10a03096edf0   none      none          off        
+    oxp_988aa8c2-cb5e-406b-9289-425dc2e5bc3a/crypt/zone/oxz_crucible_4a35beea-a998-4ef1-845c-55d69d35108f          74aacf3e-7c5b-44d5-869c-ae04c9f70bf9   none      none          off        
+    oxp_ad91e238-4901-4ff4-a91b-75233c936426/crypt/zone/oxz_crucible_5710b56a-a07e-49e2-8dfb-34f1c87ca02e          1e1bfd91-4900-4869-9b17-d6ff94d95301   none      none          off        
+    oxp_f4a96860-bdeb-4435-bdf5-2a10beb3d44a/crypt/zone/oxz_crucible_62b70007-57c1-4086-8e35-e61443f0c259          b1217132-9894-472e-a763-626798f46cc2   none      none          off        
+    oxp_014eb1e9-04fe-4f36-8339-0a090b053ada/crypt/zone/oxz_crucible_8ca9bfdc-c3a6-4280-ad34-b5af8fd5187e          14b40d48-c5b1-4e8e-90ec-e374d824204d   none      none          off        
+    oxp_31a3bc64-7a3b-496d-b644-785dc44b6e37/crypt/zone/oxz_crucible_9c927800-ba15-4e84-b80e-781606bec308          eb2960e5-5b89-432f-a384-3009d3b3db5d   none      none          off        
+    oxp_ce58d463-d442-4c97-a6b4-f7d98c3fd902/crypt/zone/oxz_crucible_a7cab59f-59f2-4cb9-b559-551dc6c43aaf          8c16b33b-54f3-453d-a28a-baed87bd45da   none      none          off        
+    oxp_f18f7689-0059-4b79-880e-34faf7a0fe0e/crypt/zone/oxz_crucible_cb67f66d-37e3-40a6-adbd-69962fb6cf73          52036fa0-92ad-4444-8156-01d0b2e9b676   none      none          off        
+    oxp_7bb40bd6-9c43-4b63-8337-18313c72aea2/crypt/zone/oxz_crucible_da2fc172-8cb2-4d66-a92b-017a97842c27          3aa614f6-5a75-44a0-a950-6adb6c299299   none      none          off        
+    oxp_014eb1e9-04fe-4f36-8339-0a090b053ada/crypt/zone/oxz_crucible_pantry_be4a1d4a-093f-40e0-8e06-74cc1d786d1b   25438f31-b9e0-499f-a55f-9bfcb0a4194d   none      none          off        
+    oxp_014eb1e9-04fe-4f36-8339-0a090b053ada/crypt/zone/oxz_internal_dns_2a6f89a2-3476-4c3b-97b2-322f00f2fc9a      572f2970-46ed-46e1-b600-d021e080903e   none      none          off        
+    oxp_014eb1e9-04fe-4f36-8339-0a090b053ada/crypt/zone/oxz_nexus_fb07dee1-d608-451b-83eb-4ee913d6e1f8             0e2d27bc-01d7-4afd-82e2-973db6138e70   none      none          off        
+    oxp_014eb1e9-04fe-4f36-8339-0a090b053ada/crypt/zone/oxz_ntp_d7ffba91-8f9d-4168-89a4-26c6c4370cb0               63e6eeb0-e079-4165-9444-8aac3d50fef3   none      none          off        
+    oxp_014eb1e9-04fe-4f36-8339-0a090b053ada/crypt/debug                                                           9982db80-b762-4c5f-9916-35383d59b6df   100 GiB   none          gzip-9     
+    oxp_31a3bc64-7a3b-496d-b644-785dc44b6e37/crypt/debug                                                           fd25bb57-dc4b-42ea-a2ab-d6395b38334f   100 GiB   none          gzip-9     
+    oxp_7bb40bd6-9c43-4b63-8337-18313c72aea2/crypt/debug                                                           95f111d8-854f-4177-bcff-481e625dd73d   100 GiB   none          gzip-9     
+    oxp_988aa8c2-cb5e-406b-9289-425dc2e5bc3a/crypt/debug                                                           38903da8-c23d-4516-b0ca-6036e26c49e4   100 GiB   none          gzip-9     
+    oxp_ad574c09-2ae0-4534-a2a4-f923ce20ae87/crypt/debug                                                           216e74e6-691b-45f9-ad7f-037ae799a8c9   100 GiB   none          gzip-9     
+    oxp_ad91e238-4901-4ff4-a91b-75233c936426/crypt/debug                                                           e598cc97-90c4-403a-b7fc-741f8b93de87   100 GiB   none          gzip-9     
+    oxp_ce58d463-d442-4c97-a6b4-f7d98c3fd902/crypt/debug                                                           235746b2-5d3f-4608-9017-2bd8d1521d2b   100 GiB   none          gzip-9     
+    oxp_f18f7689-0059-4b79-880e-34faf7a0fe0e/crypt/debug                                                           08fdf2b1-430d-4a5c-adf3-b0a0f323ae9d   100 GiB   none          gzip-9     
+    oxp_f1d6cea4-640f-415e-89fe-2b1784ce3db8/crypt/debug                                                           ea7fa07f-f47b-4039-a0db-6ab9ca0f0e2c   100 GiB   none          gzip-9     
+    oxp_f4a96860-bdeb-4435-bdf5-2a10beb3d44a/crypt/debug                                                           547cb9ee-f196-4dfe-9f2c-aa4b2f114abe   100 GiB   none          gzip-9     
 
 
     omicron zones at generation 2:
     ---------------------------------------------------------------------------------------------
     zone type         zone id                                disposition   underlay IP           
     ---------------------------------------------------------------------------------------------
-    clickhouse        b40f7c7b-526c-46c8-ae33-67280c280eb7   in service    fd00:1122:3344:103::23
-    crucible          08c7f8aa-1ea9-469b-8cac-2fdbfc11ebcb   in service    fd00:1122:3344:103::2c
-    crucible          3eda924f-22a9-4f3e-9a1b-91d1c47601ab   in service    fd00:1122:3344:103::2e
-    crucible          4ab1650f-32c5-447f-939d-64b8103a7645   in service    fd00:1122:3344:103::29
-    crucible          64aa65f8-1ccb-4cd6-9953-027aebdac8ff   in service    fd00:1122:3344:103::26
-    crucible          6e811d86-8aa7-4660-935b-84b4b7721b10   in service    fd00:1122:3344:103::2a
-    crucible          7fbd2c38-5dc3-48c4-b061-558a2041d70f   in service    fd00:1122:3344:103::2b
-    crucible          8e9e923e-62b1-4cbc-9f59-d6397e338b6b   in service    fd00:1122:3344:103::28
-    crucible          b14d5478-1a0e-4b90-b526-36b06339dfc4   in service    fd00:1122:3344:103::27
-    crucible          be97b92b-38d6-422a-8c76-d37060f75bd2   in service    fd00:1122:3344:103::25
-    crucible          c66ab6d5-ff7a-46d1-9fd0-70cefa352d25   in service    fd00:1122:3344:103::2d
-    crucible_pantry   747d2426-68bf-4c22-8806-41d290b5d5f5   in service    fd00:1122:3344:103::24
-    internal_dns      322ee9f1-8903-4542-a0a8-a54cefabdeca   in service    fd00:1122:3344:1::1   
-    internal_ntp      267ed614-92af-4b9d-bdba-c2881c2e43a2   in service    fd00:1122:3344:103::21
-    nexus             cc816cfe-3869-4dde-b596-397d41198628   in service    fd00:1122:3344:103::22
+    clickhouse        98229df2-6faf-45a4-8501-48e1ad25706e   in service    fd00:1122:3344:103::23
+    crucible          3384bb31-72f2-46fc-9ada-b324580e2930   in service    fd00:1122:3344:103::29
+    crucible          397f4188-68b0-4d82-aea4-5b950f6fc779   in service    fd00:1122:3344:103::2d
+    crucible          4a35beea-a998-4ef1-845c-55d69d35108f   in service    fd00:1122:3344:103::28
+    crucible          5710b56a-a07e-49e2-8dfb-34f1c87ca02e   in service    fd00:1122:3344:103::2a
+    crucible          62b70007-57c1-4086-8e35-e61443f0c259   in service    fd00:1122:3344:103::2e
+    crucible          8ca9bfdc-c3a6-4280-ad34-b5af8fd5187e   in service    fd00:1122:3344:103::25
+    crucible          9c927800-ba15-4e84-b80e-781606bec308   in service    fd00:1122:3344:103::26
+    crucible          a7cab59f-59f2-4cb9-b559-551dc6c43aaf   in service    fd00:1122:3344:103::2b
+    crucible          cb67f66d-37e3-40a6-adbd-69962fb6cf73   in service    fd00:1122:3344:103::2c
+    crucible          da2fc172-8cb2-4d66-a92b-017a97842c27   in service    fd00:1122:3344:103::27
+    crucible_pantry   be4a1d4a-093f-40e0-8e06-74cc1d786d1b   in service    fd00:1122:3344:103::24
+    internal_dns      2a6f89a2-3476-4c3b-97b2-322f00f2fc9a   in service    fd00:1122:3344:1::1   
+    internal_ntp      d7ffba91-8f9d-4168-89a4-26c6c4370cb0   in service    fd00:1122:3344:103::21
+    nexus             fb07dee1-d608-451b-83eb-4ee913d6e1f8   in service    fd00:1122:3344:103::22
 
 
   sled 43677374-8d2f-4deb-8a41-eeea506db8e0 (active):
@@ -117,71 +117,71 @@ to:   blueprint 4171ad05-89dd-474b-846b-b007e4346366
     -----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
     dataset name                                                                                                   dataset uuid                           quota     reservation   compression
     -----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
-    oxp_12057b4a-0b06-4f70-ba22-336de2385bfe/crucible                                                              c333b519-9dde-4ada-b507-2bb0b6903d17   none      none          off        
-    oxp_29758363-6c77-40c3-8740-9c0c64f6e14a/crucible                                                              2e09fba5-0c1d-41db-a310-bef9290c6332   none      none          off        
-    oxp_3f331c10-7882-48ab-85d9-05108490b55b/crucible                                                              76ab0eb2-4356-4a8a-b555-a83930ef3dce   none      none          off        
-    oxp_5152d1aa-9045-4e06-9ef6-6eadac3696e4/crucible                                                              52255a04-77be-486f-a59f-f17de4916cc2   none      none          off        
-    oxp_5c0dd424-d905-4fc5-a73c-36254fdd470c/crucible                                                              ab598283-0338-4124-af32-71aaf478908d   none      none          off        
-    oxp_794df76f-bca0-4635-9eb6-773ad0108f7e/crucible                                                              e54385d1-cead-4fb6-a28e-c13db4e9561f   none      none          off        
-    oxp_9024d350-38a7-459b-8550-3b2c4a88b5c1/crucible                                                              8aa9c334-3980-4875-b858-b1739848474d   none      none          off        
-    oxp_95e86080-e162-4980-a589-db6bb1a95ca7/crucible                                                              de88d3ee-683a-4550-99de-aca94b4a276a   none      none          off        
-    oxp_d55d36d7-df92-4615-944d-440a1f8b5001/crucible                                                              f6df8087-1122-4715-851a-127309740840   none      none          off        
-    oxp_db6686c8-2dd9-4032-8444-2a06b43baa68/crucible                                                              882faa8a-7df8-4f67-abba-3d97a2615932   none      none          off        
-    oxp_12057b4a-0b06-4f70-ba22-336de2385bfe/crypt/internal_dns                                                    52de1771-5f5b-422d-89e9-96a708c66d47   none      none          off        
-    oxp_12057b4a-0b06-4f70-ba22-336de2385bfe/crypt/zone                                                            5a5afb9f-850c-4501-959a-8ff760eca117   none      none          off        
-    oxp_29758363-6c77-40c3-8740-9c0c64f6e14a/crypt/zone                                                            fe22839c-29a4-4711-8290-44dc001b9a4f   none      none          off        
-    oxp_3f331c10-7882-48ab-85d9-05108490b55b/crypt/zone                                                            3b733c7c-d0b0-427b-952a-200518837f87   none      none          off        
-    oxp_5152d1aa-9045-4e06-9ef6-6eadac3696e4/crypt/zone                                                            7aabaeaa-fd10-4686-bd7e-65a961ea3f87   none      none          off        
-    oxp_5c0dd424-d905-4fc5-a73c-36254fdd470c/crypt/zone                                                            e991d7ef-7ca9-444e-ad9d-6f9d165a3b80   none      none          off        
-    oxp_794df76f-bca0-4635-9eb6-773ad0108f7e/crypt/zone                                                            f06995fc-99ad-4184-80b4-3d0a42ac858f   none      none          off        
-    oxp_9024d350-38a7-459b-8550-3b2c4a88b5c1/crypt/zone                                                            61be50c0-fa4b-405a-86aa-51da8c92580a   none      none          off        
-    oxp_95e86080-e162-4980-a589-db6bb1a95ca7/crypt/zone                                                            15bb82a6-77c3-4c3c-ac8b-95c524526704   none      none          off        
-    oxp_d55d36d7-df92-4615-944d-440a1f8b5001/crypt/zone                                                            b7b7c0d6-b2dd-41eb-b5fe-3e131356552f   none      none          off        
-    oxp_db6686c8-2dd9-4032-8444-2a06b43baa68/crypt/zone                                                            51701069-af21-4697-8655-d2a8e455dceb   none      none          off        
-    oxp_29758363-6c77-40c3-8740-9c0c64f6e14a/crypt/zone/oxz_crucible_2a455c35-eb3c-4c73-ab6c-d0a706e25316          a3e5c0e0-3a73-4f7a-abd4-63f3434767aa   none      none          off        
-    oxp_794df76f-bca0-4635-9eb6-773ad0108f7e/crypt/zone/oxz_crucible_47199d48-534c-4267-a654-d2d90e64b498          3e03f4d9-b2e7-4176-91e4-dc5771ccc769   none      none          off        
-    oxp_5152d1aa-9045-4e06-9ef6-6eadac3696e4/crypt/zone/oxz_crucible_587be699-a320-4c79-b320-128d9ecddc0b          40cae2bc-0505-4d53-9d94-b199aaf5600a   none      none          off        
-    oxp_5c0dd424-d905-4fc5-a73c-36254fdd470c/crypt/zone/oxz_crucible_6fa06115-4959-4913-8e7b-dd70d7651f07          8879f080-4bd0-4073-ab2f-08e6f289bb4f   none      none          off        
-    oxp_9024d350-38a7-459b-8550-3b2c4a88b5c1/crypt/zone/oxz_crucible_704e1fed-f8d6-4cfa-a470-bad27fdc06d1          c1fc8d09-f44c-4a2e-b989-066f2787d4c1   none      none          off        
-    oxp_12057b4a-0b06-4f70-ba22-336de2385bfe/crypt/zone/oxz_crucible_8f3a1cc5-9195-4a30-ad02-b804278fe639          42a06863-188a-4755-99f7-659df14958f7   none      none          off        
-    oxp_3f331c10-7882-48ab-85d9-05108490b55b/crypt/zone/oxz_crucible_a2079cbc-a69e-41a1-b1e0-fbcb972d03f6          94407842-70fd-48cd-933f-b0d7768fa45b   none      none          off        
-    oxp_95e86080-e162-4980-a589-db6bb1a95ca7/crypt/zone/oxz_crucible_af322036-371f-437c-8c08-7f40f3f1403b          a9f4142b-b18d-4f1a-8274-6fbf12a10efd   none      none          off        
-    oxp_db6686c8-2dd9-4032-8444-2a06b43baa68/crypt/zone/oxz_crucible_d637264f-6f40-44c2-8b7e-a179430210d2          bde5f2d8-ac7d-40e8-b4b7-2cdf1cff6e57   none      none          off        
-    oxp_d55d36d7-df92-4615-944d-440a1f8b5001/crypt/zone/oxz_crucible_edabedf3-839c-488d-ad6f-508ffa864674          3b94580a-8ff4-4302-8d49-30ff90ef7edc   none      none          off        
-    oxp_12057b4a-0b06-4f70-ba22-336de2385bfe/crypt/zone/oxz_crucible_pantry_02acbe6a-1c88-47e3-94c3-94084cbde098   f7256e30-6e62-4d4b-ab06-8e9b3c9472a3   none      none          off        
-    oxp_12057b4a-0b06-4f70-ba22-336de2385bfe/crypt/zone/oxz_internal_dns_07c3c805-8888-4fe5-9543-3d2479dbe6f3      54774860-da9a-4ff5-8d63-242b353c3115   none      none          off        
-    oxp_12057b4a-0b06-4f70-ba22-336de2385bfe/crypt/zone/oxz_nexus_a1696cd4-588c-484a-b95b-66e824c0ce05             5dae2769-982f-485d-9776-57c2ae0a83b9   none      none          off        
-    oxp_12057b4a-0b06-4f70-ba22-336de2385bfe/crypt/zone/oxz_ntp_10d98a73-ec88-4aff-a7e8-7db6a87880e6               c5dc843c-fa8c-46a8-9998-aa0b0397cb0c   none      none          off        
-    oxp_12057b4a-0b06-4f70-ba22-336de2385bfe/crypt/debug                                                           438902f5-ff09-48f2-8cd1-56dc910d86e1   100 GiB   none          gzip-9     
-    oxp_29758363-6c77-40c3-8740-9c0c64f6e14a/crypt/debug                                                           bc7e5ae9-81f0-437b-9655-d11259f5037b   100 GiB   none          gzip-9     
-    oxp_3f331c10-7882-48ab-85d9-05108490b55b/crypt/debug                                                           70aadfba-de91-4157-ab8c-98609d278d08   100 GiB   none          gzip-9     
-    oxp_5152d1aa-9045-4e06-9ef6-6eadac3696e4/crypt/debug                                                           d6835e81-73e5-46cc-a188-93050a2e4d40   100 GiB   none          gzip-9     
-    oxp_5c0dd424-d905-4fc5-a73c-36254fdd470c/crypt/debug                                                           4939df35-a183-4c85-9872-5ced516bd154   100 GiB   none          gzip-9     
-    oxp_794df76f-bca0-4635-9eb6-773ad0108f7e/crypt/debug                                                           35f7f5fc-0d30-442d-b74a-7ef63b13bb6d   100 GiB   none          gzip-9     
-    oxp_9024d350-38a7-459b-8550-3b2c4a88b5c1/crypt/debug                                                           d6fee205-15ef-41f9-8719-bc0be41ca283   100 GiB   none          gzip-9     
-    oxp_95e86080-e162-4980-a589-db6bb1a95ca7/crypt/debug                                                           c2e8fc9e-40d5-4ba5-b9e6-bd4ac88b0e7b   100 GiB   none          gzip-9     
-    oxp_d55d36d7-df92-4615-944d-440a1f8b5001/crypt/debug                                                           05b52b8d-dd52-4a9e-b647-445959885d68   100 GiB   none          gzip-9     
-    oxp_db6686c8-2dd9-4032-8444-2a06b43baa68/crypt/debug                                                           f5e9ef79-2d90-4839-aeac-a1048516011e   100 GiB   none          gzip-9     
+    oxp_12057b4a-0b06-4f70-ba22-336de2385bfe/crucible                                                              55136aae-73db-46b2-bd32-e26634f865ed   none      none          off        
+    oxp_29758363-6c77-40c3-8740-9c0c64f6e14a/crucible                                                              5c4eda29-ed3e-4dc6-b756-afafa1c216b8   none      none          off        
+    oxp_3f331c10-7882-48ab-85d9-05108490b55b/crucible                                                              9b5d5293-2546-43f0-b953-73a696cad4bf   none      none          off        
+    oxp_5152d1aa-9045-4e06-9ef6-6eadac3696e4/crucible                                                              74c65a92-1d4a-44cc-9a55-cd540e9fb57e   none      none          off        
+    oxp_5c0dd424-d905-4fc5-a73c-36254fdd470c/crucible                                                              cc25055b-483e-46ab-a5bf-1d8838b846fd   none      none          off        
+    oxp_794df76f-bca0-4635-9eb6-773ad0108f7e/crucible                                                              8270e505-beff-480a-955b-bf96c4b1a9a3   none      none          off        
+    oxp_9024d350-38a7-459b-8550-3b2c4a88b5c1/crucible                                                              ea234d9d-291b-4adf-9d96-48b7945c2892   none      none          off        
+    oxp_95e86080-e162-4980-a589-db6bb1a95ca7/crucible                                                              d8d9a6d4-f6be-4044-8eac-b994aa166053   none      none          off        
+    oxp_d55d36d7-df92-4615-944d-440a1f8b5001/crucible                                                              64955a3e-2059-4d16-aee4-f63f9362b554   none      none          off        
+    oxp_db6686c8-2dd9-4032-8444-2a06b43baa68/crucible                                                              863c76ac-732e-4d10-b7a3-1d6ba02dc1f5   none      none          off        
+    oxp_12057b4a-0b06-4f70-ba22-336de2385bfe/crypt/internal_dns                                                    b4df380c-6cca-41c1-b79c-45671067d459   none      none          off        
+    oxp_12057b4a-0b06-4f70-ba22-336de2385bfe/crypt/zone                                                            9bcac944-9866-4251-b333-1cbdc137a03e   none      none          off        
+    oxp_29758363-6c77-40c3-8740-9c0c64f6e14a/crypt/zone                                                            0557de8a-45cf-44a0-a39d-4a7095e9045b   none      none          off        
+    oxp_3f331c10-7882-48ab-85d9-05108490b55b/crypt/zone                                                            5f5e1e10-1561-4556-aac1-6b6285df5cb2   none      none          off        
+    oxp_5152d1aa-9045-4e06-9ef6-6eadac3696e4/crypt/zone                                                            52d9152d-e80a-455e-b24a-70b5d2ffc372   none      none          off        
+    oxp_5c0dd424-d905-4fc5-a73c-36254fdd470c/crypt/zone                                                            1b990bb0-ea73-430c-bafa-6eb5647af125   none      none          off        
+    oxp_794df76f-bca0-4635-9eb6-773ad0108f7e/crypt/zone                                                            4fc058ac-95d8-4ea4-808c-6b976e95449e   none      none          off        
+    oxp_9024d350-38a7-459b-8550-3b2c4a88b5c1/crypt/zone                                                            208cd4b7-be74-4187-a4e3-21e518bc92a6   none      none          off        
+    oxp_95e86080-e162-4980-a589-db6bb1a95ca7/crypt/zone                                                            bf66b843-7c47-4e46-b629-267111de97b5   none      none          off        
+    oxp_d55d36d7-df92-4615-944d-440a1f8b5001/crypt/zone                                                            5672e912-aa12-4614-b79b-5fcf548e9d96   none      none          off        
+    oxp_db6686c8-2dd9-4032-8444-2a06b43baa68/crypt/zone                                                            99d7b142-b462-4a67-b84e-f3fc79e761fd   none      none          off        
+    oxp_95e86080-e162-4980-a589-db6bb1a95ca7/crypt/zone/oxz_crucible_1437bb47-a2d3-48e9-8902-021ff5057d26          3dd86436-a934-44a8-97b2-1848ab6ebbc9   none      none          off        
+    oxp_5c0dd424-d905-4fc5-a73c-36254fdd470c/crypt/zone/oxz_crucible_31f49108-cdda-4659-bf24-319bf99a9c20          faa7fe52-a532-4784-84f3-376dc8334fdd   none      none          off        
+    oxp_29758363-6c77-40c3-8740-9c0c64f6e14a/crypt/zone/oxz_crucible_5152e5e7-8615-407d-beed-37fd03852ad6          5def9f9d-7e1f-4ef0-94cf-b26f21e6da07   none      none          off        
+    oxp_3f331c10-7882-48ab-85d9-05108490b55b/crypt/zone/oxz_crucible_6593648a-53f3-4a0f-b902-ef6cd7eab43b          9651f8ed-ae45-476c-bca4-42ebe6ee1618   none      none          off        
+    oxp_d55d36d7-df92-4615-944d-440a1f8b5001/crypt/zone/oxz_crucible_754bae61-cbff-402f-b250-91bec499b449          8e72b070-ef13-4082-bcf8-2c54488a4ae1   none      none          off        
+    oxp_12057b4a-0b06-4f70-ba22-336de2385bfe/crypt/zone/oxz_crucible_8f316745-d46d-47cb-8c7e-678fd9021c40          d508ecc2-baf5-4299-9799-e6d30f83663e   none      none          off        
+    oxp_9024d350-38a7-459b-8550-3b2c4a88b5c1/crypt/zone/oxz_crucible_9fdb739d-b149-4f8f-b488-b97d16ea284a          96dc8dcd-700b-4dd7-8970-568e91b93948   none      none          off        
+    oxp_db6686c8-2dd9-4032-8444-2a06b43baa68/crypt/zone/oxz_crucible_b23471ff-b35a-4919-aa3f-3c3683fa3210          646e79ac-9828-4a8d-8173-e385f5e65a15   none      none          off        
+    oxp_794df76f-bca0-4635-9eb6-773ad0108f7e/crypt/zone/oxz_crucible_fa8963b6-dad1-4cf8-9243-c77b3f86d654          2dd82bf7-cad0-4725-ba7d-0cf40b725b39   none      none          off        
+    oxp_5152d1aa-9045-4e06-9ef6-6eadac3696e4/crypt/zone/oxz_crucible_ff5bf6ea-ab3e-40c5-a9a5-cb2bc89de9c8          ead9603d-c1ea-4ea8-9ca7-f3bc31718458   none      none          off        
+    oxp_12057b4a-0b06-4f70-ba22-336de2385bfe/crypt/zone/oxz_crucible_pantry_634fc0b7-9f95-494d-939b-28819cbcaa2b   be2863b0-0d23-4fd4-92e8-ffc4184e5742   none      none          off        
+    oxp_12057b4a-0b06-4f70-ba22-336de2385bfe/crypt/zone/oxz_internal_dns_92628102-eef4-4000-a061-1df796db3806      998bf38c-b6ec-4ddd-80ac-59fc1ee30ca2   none      none          off        
+    oxp_12057b4a-0b06-4f70-ba22-336de2385bfe/crypt/zone/oxz_nexus_7a3ea24a-85f4-4aad-a935-4e7b22766985             73e12d19-7957-4c44-b3e0-fef8d2ad4826   none      none          off        
+    oxp_12057b4a-0b06-4f70-ba22-336de2385bfe/crypt/zone/oxz_ntp_edd3fb4a-6ea7-49a5-82fb-444dfcf6fcc5               305f5727-4d83-4282-9efe-f776ad63aef9   none      none          off        
+    oxp_12057b4a-0b06-4f70-ba22-336de2385bfe/crypt/debug                                                           b3261747-8c28-4c02-8ab7-be1b8cab03fe   100 GiB   none          gzip-9     
+    oxp_29758363-6c77-40c3-8740-9c0c64f6e14a/crypt/debug                                                           be79f715-8cc9-475c-81dd-f3a8141df986   100 GiB   none          gzip-9     
+    oxp_3f331c10-7882-48ab-85d9-05108490b55b/crypt/debug                                                           b0f40911-5074-4dad-bcf9-269e20793f6f   100 GiB   none          gzip-9     
+    oxp_5152d1aa-9045-4e06-9ef6-6eadac3696e4/crypt/debug                                                           1f81c8ba-d0b2-4c24-b8b8-90a5a3148b2a   100 GiB   none          gzip-9     
+    oxp_5c0dd424-d905-4fc5-a73c-36254fdd470c/crypt/debug                                                           b489b3a7-eb94-481f-805d-c93958f566dd   100 GiB   none          gzip-9     
+    oxp_794df76f-bca0-4635-9eb6-773ad0108f7e/crypt/debug                                                           903e2867-5fc0-487b-9d9c-9afe60731a6c   100 GiB   none          gzip-9     
+    oxp_9024d350-38a7-459b-8550-3b2c4a88b5c1/crypt/debug                                                           a02260de-3336-4cbf-ba45-ff79586b40fa   100 GiB   none          gzip-9     
+    oxp_95e86080-e162-4980-a589-db6bb1a95ca7/crypt/debug                                                           667d664c-c5a1-4b77-a54c-6bbb1bcc2096   100 GiB   none          gzip-9     
+    oxp_d55d36d7-df92-4615-944d-440a1f8b5001/crypt/debug                                                           4f4ad767-8887-4892-b6c7-5bc652f3d673   100 GiB   none          gzip-9     
+    oxp_db6686c8-2dd9-4032-8444-2a06b43baa68/crypt/debug                                                           f5b987f9-0a34-4394-8fc5-2ee12bf3e9bf   100 GiB   none          gzip-9     
 
 
     omicron zones at generation 2:
     ---------------------------------------------------------------------------------------------
     zone type         zone id                                disposition   underlay IP           
     ---------------------------------------------------------------------------------------------
-    crucible          2a455c35-eb3c-4c73-ab6c-d0a706e25316   in service    fd00:1122:3344:101::25
-    crucible          47199d48-534c-4267-a654-d2d90e64b498   in service    fd00:1122:3344:101::29
-    crucible          587be699-a320-4c79-b320-128d9ecddc0b   in service    fd00:1122:3344:101::27
-    crucible          6fa06115-4959-4913-8e7b-dd70d7651f07   in service    fd00:1122:3344:101::28
-    crucible          704e1fed-f8d6-4cfa-a470-bad27fdc06d1   in service    fd00:1122:3344:101::2a
-    crucible          8f3a1cc5-9195-4a30-ad02-b804278fe639   in service    fd00:1122:3344:101::24
-    crucible          a2079cbc-a69e-41a1-b1e0-fbcb972d03f6   in service    fd00:1122:3344:101::26
-    crucible          af322036-371f-437c-8c08-7f40f3f1403b   in service    fd00:1122:3344:101::2b
-    crucible          d637264f-6f40-44c2-8b7e-a179430210d2   in service    fd00:1122:3344:101::2d
-    crucible          edabedf3-839c-488d-ad6f-508ffa864674   in service    fd00:1122:3344:101::2c
-    crucible_pantry   02acbe6a-1c88-47e3-94c3-94084cbde098   in service    fd00:1122:3344:101::23
-    internal_dns      07c3c805-8888-4fe5-9543-3d2479dbe6f3   in service    fd00:1122:3344:2::1   
-    internal_ntp      10d98a73-ec88-4aff-a7e8-7db6a87880e6   in service    fd00:1122:3344:101::21
-    nexus             a1696cd4-588c-484a-b95b-66e824c0ce05   in service    fd00:1122:3344:101::22
+    crucible          1437bb47-a2d3-48e9-8902-021ff5057d26   in service    fd00:1122:3344:101::2b
+    crucible          31f49108-cdda-4659-bf24-319bf99a9c20   in service    fd00:1122:3344:101::28
+    crucible          5152e5e7-8615-407d-beed-37fd03852ad6   in service    fd00:1122:3344:101::25
+    crucible          6593648a-53f3-4a0f-b902-ef6cd7eab43b   in service    fd00:1122:3344:101::26
+    crucible          754bae61-cbff-402f-b250-91bec499b449   in service    fd00:1122:3344:101::2c
+    crucible          8f316745-d46d-47cb-8c7e-678fd9021c40   in service    fd00:1122:3344:101::24
+    crucible          9fdb739d-b149-4f8f-b488-b97d16ea284a   in service    fd00:1122:3344:101::2a
+    crucible          b23471ff-b35a-4919-aa3f-3c3683fa3210   in service    fd00:1122:3344:101::2d
+    crucible          fa8963b6-dad1-4cf8-9243-c77b3f86d654   in service    fd00:1122:3344:101::29
+    crucible          ff5bf6ea-ab3e-40c5-a9a5-cb2bc89de9c8   in service    fd00:1122:3344:101::27
+    crucible_pantry   634fc0b7-9f95-494d-939b-28819cbcaa2b   in service    fd00:1122:3344:101::23
+    internal_dns      92628102-eef4-4000-a061-1df796db3806   in service    fd00:1122:3344:2::1   
+    internal_ntp      edd3fb4a-6ea7-49a5-82fb-444dfcf6fcc5   in service    fd00:1122:3344:101::21
+    nexus             7a3ea24a-85f4-4aad-a935-4e7b22766985   in service    fd00:1122:3344:101::22
 
 
   sled 590e3034-d946-4166-b0e5-2d0034197a07 (active):
@@ -206,71 +206,71 @@ to:   blueprint 4171ad05-89dd-474b-846b-b007e4346366
     -----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
     dataset name                                                                                                   dataset uuid                           quota     reservation   compression
     -----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
-    oxp_2a94863d-16e2-4535-973b-e98dd47fd18d/crucible                                                              35656b97-3eef-46f2-aab0-4d33a3548e62   none      none          off        
-    oxp_32456d15-f5b6-4efc-90c8-dbba979b69cb/crucible                                                              3b4f5bbb-cc50-49ae-a208-ca88dff1f361   none      none          off        
-    oxp_416fe9f9-5161-4b0f-9e11-c9d81563ded5/crucible                                                              8b82f804-50d1-4e6f-8899-181433d82299   none      none          off        
-    oxp_4c68800e-23f8-485b-b251-628fd151e445/crucible                                                              226cea90-799d-4f6c-90c6-459d2d7674c1   none      none          off        
-    oxp_9dd87c4d-5fb4-475a-86fa-c0da81a3e00a/crucible                                                              d5cd0c03-b555-46b2-b626-cc70bd931cee   none      none          off        
-    oxp_be93a517-445e-46c2-aa21-3dc526d4a413/crucible                                                              52fde46c-85f4-470e-8c1e-38b13c042620   none      none          off        
-    oxp_d9344e2b-84d2-4392-84ab-41b86ed02237/crucible                                                              4b593475-e809-4822-a2fe-c58b2f7964d5   none      none          off        
-    oxp_eab188d0-b34a-4673-b254-12e705597654/crucible                                                              444a65f5-d04e-4cb0-a29d-ba57e34143dd   none      none          off        
-    oxp_f1e0386f-11b6-4cdf-8250-826d256db6b5/crucible                                                              826e2ca8-f30d-4ca3-8360-f03ddd883a6a   none      none          off        
-    oxp_f8c9c9a9-d73e-4cdf-a9af-03cfbbbce12b/crucible                                                              2c6ade05-a626-4b25-a28c-551b91867dbe   none      none          off        
-    oxp_2a94863d-16e2-4535-973b-e98dd47fd18d/crypt/internal_dns                                                    b0fcbafd-55cc-49f1-9e02-20503673b34f   none      none          off        
-    oxp_2a94863d-16e2-4535-973b-e98dd47fd18d/crypt/zone                                                            0b216cae-701c-4341-a48a-690543b8e1e9   none      none          off        
-    oxp_32456d15-f5b6-4efc-90c8-dbba979b69cb/crypt/zone                                                            dce1da41-4cf0-4f70-a9e5-f4b7fad54228   none      none          off        
-    oxp_416fe9f9-5161-4b0f-9e11-c9d81563ded5/crypt/zone                                                            5dd03902-3f33-4f7e-896a-c08d7c6e37f1   none      none          off        
-    oxp_4c68800e-23f8-485b-b251-628fd151e445/crypt/zone                                                            447cc163-589e-479c-a73d-0071e5dc59bf   none      none          off        
-    oxp_9dd87c4d-5fb4-475a-86fa-c0da81a3e00a/crypt/zone                                                            0568d976-0079-4d6e-9d1f-a8cfc4b044df   none      none          off        
-    oxp_be93a517-445e-46c2-aa21-3dc526d4a413/crypt/zone                                                            f75ef0e7-663d-4418-99b6-71e2a77a27e3   none      none          off        
-    oxp_d9344e2b-84d2-4392-84ab-41b86ed02237/crypt/zone                                                            aa37e2bb-8d16-4dc2-a549-5f265fdad77c   none      none          off        
-    oxp_eab188d0-b34a-4673-b254-12e705597654/crypt/zone                                                            a79b0ad5-06b8-466c-928c-39e311ace5ff   none      none          off        
-    oxp_f1e0386f-11b6-4cdf-8250-826d256db6b5/crypt/zone                                                            1635dad8-971f-4409-aca3-6204eafec699   none      none          off        
-    oxp_f8c9c9a9-d73e-4cdf-a9af-03cfbbbce12b/crypt/zone                                                            1b5a2379-ec60-47f0-8def-fa3ab5c2487c   none      none          off        
-    oxp_9dd87c4d-5fb4-475a-86fa-c0da81a3e00a/crypt/zone/oxz_crucible_0565e7e4-f13a-4123-8928-d715f83e36aa          e2de5537-a289-49ac-8a61-65805a35755e   none      none          off        
-    oxp_d9344e2b-84d2-4392-84ab-41b86ed02237/crypt/zone/oxz_crucible_062ce37d-7448-4d44-b1f4-4937cd2eb174          bfbfe7dd-06b3-4d01-988d-488c7b9400ee   none      none          off        
-    oxp_f8c9c9a9-d73e-4cdf-a9af-03cfbbbce12b/crypt/zone/oxz_crucible_1211a68e-69a1-4ef4-b790-45b0279f9159          32a3e82a-b97a-455a-b428-1f934c59eb46   none      none          off        
-    oxp_2a94863d-16e2-4535-973b-e98dd47fd18d/crypt/zone/oxz_crucible_18f8fe40-646e-4962-b17a-20e201f3a6e5          eec6f425-d377-42b2-890f-c8c3efe173d1   none      none          off        
-    oxp_4c68800e-23f8-485b-b251-628fd151e445/crypt/zone/oxz_crucible_1cc3f503-2001-4d85-80e5-c7c40d2e3b10          5a210076-5d38-42f0-915c-c09f67ff38af   none      none          off        
-    oxp_be93a517-445e-46c2-aa21-3dc526d4a413/crypt/zone/oxz_crucible_62058f4c-c747-4e21-a8dc-2fd4a160c98c          0679ecb0-7759-4561-a81a-d8d7125ed693   none      none          off        
-    oxp_32456d15-f5b6-4efc-90c8-dbba979b69cb/crypt/zone/oxz_crucible_6af7f4d6-33b6-4eb3-a146-d8e9e4ae9d66          a33e3d63-6413-42b2-8cf0-02c774666916   none      none          off        
-    oxp_eab188d0-b34a-4673-b254-12e705597654/crypt/zone/oxz_crucible_78d6ab36-e8c8-4ff8-9f89-75c7fe2d32e6          ebc48adb-4dad-41dd-a547-13f2517a9db7   none      none          off        
-    oxp_416fe9f9-5161-4b0f-9e11-c9d81563ded5/crypt/zone/oxz_crucible_93f2f40c-5616-4d8d-8519-ec6debdcede0          4c0303d2-205d-4644-b55a-5c74bbce54c3   none      none          off        
-    oxp_f1e0386f-11b6-4cdf-8250-826d256db6b5/crypt/zone/oxz_crucible_9f824c30-6360-46b9-87c4-cd60586476fe          c4e2119e-4cd0-48e7-878f-fd676cb95094   none      none          off        
-    oxp_2a94863d-16e2-4535-973b-e98dd47fd18d/crypt/zone/oxz_crucible_pantry_56d5d7cf-db2c-40a3-a775-003241ad4820   ada776f0-dbb1-4430-a60a-f7462570a19c   none      none          off        
-    oxp_2a94863d-16e2-4535-973b-e98dd47fd18d/crypt/zone/oxz_internal_dns_ab7ba6df-d401-40bd-940e-faf57c57aa2a      2fe942e9-085c-4155-a415-c2dcc19dbd91   none      none          off        
-    oxp_2a94863d-16e2-4535-973b-e98dd47fd18d/crypt/zone/oxz_nexus_dce226c9-7373-4bfa-8a94-79dc472857a6             4abeefa4-e5ad-46e9-b056-79f5950a5639   none      none          off        
-    oxp_2a94863d-16e2-4535-973b-e98dd47fd18d/crypt/zone/oxz_ntp_7a9f60d3-2b66-4547-9b63-7d4f7a8b6382               63337e4d-61a8-4dc7-a322-1442bc19b347   none      none          off        
-    oxp_2a94863d-16e2-4535-973b-e98dd47fd18d/crypt/debug                                                           bdf9f107-3a76-4d6a-bea0-5cfb4d3cd6a6   100 GiB   none          gzip-9     
-    oxp_32456d15-f5b6-4efc-90c8-dbba979b69cb/crypt/debug                                                           cc56ea63-0ae3-48ce-8faf-1bd7d83eb148   100 GiB   none          gzip-9     
-    oxp_416fe9f9-5161-4b0f-9e11-c9d81563ded5/crypt/debug                                                           abe29a15-fef4-47ef-8f08-71645f396213   100 GiB   none          gzip-9     
-    oxp_4c68800e-23f8-485b-b251-628fd151e445/crypt/debug                                                           32535344-4e21-4fb3-9c43-f305ac367efb   100 GiB   none          gzip-9     
-    oxp_9dd87c4d-5fb4-475a-86fa-c0da81a3e00a/crypt/debug                                                           7d983611-ab39-4083-93d0-f57f3ada9a0f   100 GiB   none          gzip-9     
-    oxp_be93a517-445e-46c2-aa21-3dc526d4a413/crypt/debug                                                           731caeb5-c24f-45b7-aafa-4e747302eaa4   100 GiB   none          gzip-9     
-    oxp_d9344e2b-84d2-4392-84ab-41b86ed02237/crypt/debug                                                           19bdebd5-9757-409f-ac06-2b309379975e   100 GiB   none          gzip-9     
-    oxp_eab188d0-b34a-4673-b254-12e705597654/crypt/debug                                                           411e3457-3113-40d2-8a7d-747b108e0de7   100 GiB   none          gzip-9     
-    oxp_f1e0386f-11b6-4cdf-8250-826d256db6b5/crypt/debug                                                           79ce0088-d8a8-46ff-ac72-958b8db65e67   100 GiB   none          gzip-9     
-    oxp_f8c9c9a9-d73e-4cdf-a9af-03cfbbbce12b/crypt/debug                                                           2059b139-6510-4447-aa56-cf995ef469a2   100 GiB   none          gzip-9     
+    oxp_2a94863d-16e2-4535-973b-e98dd47fd18d/crucible                                                              852963f5-4c4b-4bd9-a5b6-25ea416c25fe   none      none          off        
+    oxp_32456d15-f5b6-4efc-90c8-dbba979b69cb/crucible                                                              d37faff5-a0a8-4b60-bb33-508c478fe1c9   none      none          off        
+    oxp_416fe9f9-5161-4b0f-9e11-c9d81563ded5/crucible                                                              c096ba5f-adbf-498d-8ea5-ba736454d9fb   none      none          off        
+    oxp_4c68800e-23f8-485b-b251-628fd151e445/crucible                                                              56661c11-0041-4ffd-8a0c-72b5fc0486b9   none      none          off        
+    oxp_9dd87c4d-5fb4-475a-86fa-c0da81a3e00a/crucible                                                              b6a3f4cf-27f4-4ba8-b063-b4b3c7b03cc3   none      none          off        
+    oxp_be93a517-445e-46c2-aa21-3dc526d4a413/crucible                                                              f32a5631-dd04-4e2d-a9f9-b5974253601d   none      none          off        
+    oxp_d9344e2b-84d2-4392-84ab-41b86ed02237/crucible                                                              a15aacbb-53de-45e0-a646-a88817c929c6   none      none          off        
+    oxp_eab188d0-b34a-4673-b254-12e705597654/crucible                                                              932f321c-10ae-476a-9721-33b5e76fb989   none      none          off        
+    oxp_f1e0386f-11b6-4cdf-8250-826d256db6b5/crucible                                                              ad47c2f1-68ea-413f-ad9e-0975d02a0e11   none      none          off        
+    oxp_f8c9c9a9-d73e-4cdf-a9af-03cfbbbce12b/crucible                                                              9861aeea-9a0c-4fc7-b3d7-e80f3e5c88a5   none      none          off        
+    oxp_2a94863d-16e2-4535-973b-e98dd47fd18d/crypt/internal_dns                                                    a8eea986-61ba-4723-a97c-61f911210031   none      none          off        
+    oxp_2a94863d-16e2-4535-973b-e98dd47fd18d/crypt/zone                                                            3938e220-b204-4f50-bd73-9c835eb4dea7   none      none          off        
+    oxp_32456d15-f5b6-4efc-90c8-dbba979b69cb/crypt/zone                                                            ba8d7bd5-7282-468c-bba6-28462b5400ff   none      none          off        
+    oxp_416fe9f9-5161-4b0f-9e11-c9d81563ded5/crypt/zone                                                            57497a15-47dd-4eca-a52a-1ee1a3a005b4   none      none          off        
+    oxp_4c68800e-23f8-485b-b251-628fd151e445/crypt/zone                                                            44a73f30-9601-4fbd-9699-deb600252cb1   none      none          off        
+    oxp_9dd87c4d-5fb4-475a-86fa-c0da81a3e00a/crypt/zone                                                            6ce8fc11-2f6e-4c7a-b026-d2f05ee49c8f   none      none          off        
+    oxp_be93a517-445e-46c2-aa21-3dc526d4a413/crypt/zone                                                            babe6a59-94f6-4fbb-b49e-2fda486cc39e   none      none          off        
+    oxp_d9344e2b-84d2-4392-84ab-41b86ed02237/crypt/zone                                                            69686d88-8e89-4137-9377-3e1b61995d79   none      none          off        
+    oxp_eab188d0-b34a-4673-b254-12e705597654/crypt/zone                                                            f1a436b2-d773-4b72-ad3a-fc5d03ae9855   none      none          off        
+    oxp_f1e0386f-11b6-4cdf-8250-826d256db6b5/crypt/zone                                                            8196e6fd-4094-4bc9-ad43-1d774de79b25   none      none          off        
+    oxp_f8c9c9a9-d73e-4cdf-a9af-03cfbbbce12b/crypt/zone                                                            de91df2d-b85b-4300-82f4-70ee5d0c8f71   none      none          off        
+    oxp_32456d15-f5b6-4efc-90c8-dbba979b69cb/crypt/zone/oxz_crucible_3b49c2c6-0b0b-4a11-be95-bf94c1cb54a8          e033c975-ab2f-4d39-96e1-02fc6d95e58f   none      none          off        
+    oxp_d9344e2b-84d2-4392-84ab-41b86ed02237/crypt/zone/oxz_crucible_4c65501d-a08d-4fe5-9c78-2694ce6b3a43          28c2eb82-e779-4629-91af-633e4460cd21   none      none          off        
+    oxp_eab188d0-b34a-4673-b254-12e705597654/crypt/zone/oxz_crucible_60e74b27-a7d7-475e-b5ce-2a92eff4fa63          362a51ca-7116-4df3-96bd-5383c32b33f3   none      none          off        
+    oxp_f1e0386f-11b6-4cdf-8250-826d256db6b5/crypt/zone/oxz_crucible_68f44e7e-8231-40c0-861e-2f4d0c2eb392          1db171be-4a44-473a-bfa0-c9dda78fed77   none      none          off        
+    oxp_2a94863d-16e2-4535-973b-e98dd47fd18d/crypt/zone/oxz_crucible_74fc3000-c4b7-4687-88b5-a27584b45434          00218e6a-5e1b-450c-ad38-624ad37d2fc4   none      none          off        
+    oxp_f8c9c9a9-d73e-4cdf-a9af-03cfbbbce12b/crypt/zone/oxz_crucible_83ae0625-2e61-4637-a1f9-473b21b94f72          418a8d5c-fbe8-46c0-b260-e77eb2235105   none      none          off        
+    oxp_416fe9f9-5161-4b0f-9e11-c9d81563ded5/crypt/zone/oxz_crucible_9b462d74-c05a-4a7e-8d24-449c848a7b13          bea24fa2-353f-4c13-844d-3ce58d682eb7   none      none          off        
+    oxp_be93a517-445e-46c2-aa21-3dc526d4a413/crypt/zone/oxz_crucible_a9ed9f72-e57d-4092-ab0e-bb2000a5459e          dda0482e-cffe-4230-9370-9eebfb9c7121   none      none          off        
+    oxp_4c68800e-23f8-485b-b251-628fd151e445/crypt/zone/oxz_crucible_d84bc314-4895-4331-8afb-22bffdd56699          17f7d94a-7734-4b3b-a108-dc11b114610e   none      none          off        
+    oxp_9dd87c4d-5fb4-475a-86fa-c0da81a3e00a/crypt/zone/oxz_crucible_f1f03b7d-916e-4c5f-8906-1e18e498184d          3f1fb9c9-8a05-44fc-af26-eb71bec3b890   none      none          off        
+    oxp_2a94863d-16e2-4535-973b-e98dd47fd18d/crypt/zone/oxz_crucible_pantry_ecdc7438-a007-4558-96b3-65bdab21a8a9   f48c22cc-5ff7-4170-bdbd-bd082c882de3   none      none          off        
+    oxp_2a94863d-16e2-4535-973b-e98dd47fd18d/crypt/zone/oxz_internal_dns_c1049e2e-7269-4de0-b96e-2e9f8edc90ea      67f5eef3-2c29-4a5c-9664-81dbd5ed55a5   none      none          off        
+    oxp_2a94863d-16e2-4535-973b-e98dd47fd18d/crypt/zone/oxz_nexus_785868d0-a003-4860-acc1-9beee9f39816             2a2e9b25-83b8-4bc3-b934-723c947f56d7   none      none          off        
+    oxp_2a94863d-16e2-4535-973b-e98dd47fd18d/crypt/zone/oxz_ntp_d5b390d3-7280-4d2b-b670-340f91d7ebd7               7b3fae75-9421-4a8d-8524-b17a540f994e   none      none          off        
+    oxp_2a94863d-16e2-4535-973b-e98dd47fd18d/crypt/debug                                                           5eb19f06-e5e9-4b96-b1c3-84355460b2ea   100 GiB   none          gzip-9     
+    oxp_32456d15-f5b6-4efc-90c8-dbba979b69cb/crypt/debug                                                           89ab2d4a-101f-46c5-8bb8-2c93dbe2d020   100 GiB   none          gzip-9     
+    oxp_416fe9f9-5161-4b0f-9e11-c9d81563ded5/crypt/debug                                                           12f242f1-44e6-449d-9dfd-b4c5c1bb5ddf   100 GiB   none          gzip-9     
+    oxp_4c68800e-23f8-485b-b251-628fd151e445/crypt/debug                                                           45d68f02-6f5a-4c8b-9a59-e4554ebbeff7   100 GiB   none          gzip-9     
+    oxp_9dd87c4d-5fb4-475a-86fa-c0da81a3e00a/crypt/debug                                                           e0e621f0-62f6-4425-a4b0-ff659c63ea11   100 GiB   none          gzip-9     
+    oxp_be93a517-445e-46c2-aa21-3dc526d4a413/crypt/debug                                                           b90bbe6c-15d2-4313-9fce-c1b9ccdf38d3   100 GiB   none          gzip-9     
+    oxp_d9344e2b-84d2-4392-84ab-41b86ed02237/crypt/debug                                                           3bae870d-ae7b-4e95-b4ea-419ba251839b   100 GiB   none          gzip-9     
+    oxp_eab188d0-b34a-4673-b254-12e705597654/crypt/debug                                                           b7284180-362b-42ba-b970-90c27a8468c5   100 GiB   none          gzip-9     
+    oxp_f1e0386f-11b6-4cdf-8250-826d256db6b5/crypt/debug                                                           d814aea1-475f-44c2-8dcc-e2cd2d335bf9   100 GiB   none          gzip-9     
+    oxp_f8c9c9a9-d73e-4cdf-a9af-03cfbbbce12b/crypt/debug                                                           fdd77b3a-5ec9-4e1a-bc62-379baa7c5552   100 GiB   none          gzip-9     
 
 
     omicron zones at generation 2:
     ---------------------------------------------------------------------------------------------
     zone type         zone id                                disposition   underlay IP           
     ---------------------------------------------------------------------------------------------
-    crucible          0565e7e4-f13a-4123-8928-d715f83e36aa   in service    fd00:1122:3344:102::28
-    crucible          062ce37d-7448-4d44-b1f4-4937cd2eb174   in service    fd00:1122:3344:102::2a
-    crucible          1211a68e-69a1-4ef4-b790-45b0279f9159   in service    fd00:1122:3344:102::2d
-    crucible          18f8fe40-646e-4962-b17a-20e201f3a6e5   in service    fd00:1122:3344:102::24
-    crucible          1cc3f503-2001-4d85-80e5-c7c40d2e3b10   in service    fd00:1122:3344:102::27
-    crucible          62058f4c-c747-4e21-a8dc-2fd4a160c98c   in service    fd00:1122:3344:102::29
-    crucible          6af7f4d6-33b6-4eb3-a146-d8e9e4ae9d66   in service    fd00:1122:3344:102::25
-    crucible          78d6ab36-e8c8-4ff8-9f89-75c7fe2d32e6   in service    fd00:1122:3344:102::2b
-    crucible          93f2f40c-5616-4d8d-8519-ec6debdcede0   in service    fd00:1122:3344:102::26
-    crucible          9f824c30-6360-46b9-87c4-cd60586476fe   in service    fd00:1122:3344:102::2c
-    crucible_pantry   56d5d7cf-db2c-40a3-a775-003241ad4820   in service    fd00:1122:3344:102::23
-    internal_dns      ab7ba6df-d401-40bd-940e-faf57c57aa2a   in service    fd00:1122:3344:3::1   
-    internal_ntp      7a9f60d3-2b66-4547-9b63-7d4f7a8b6382   in service    fd00:1122:3344:102::21
-    nexus             dce226c9-7373-4bfa-8a94-79dc472857a6   in service    fd00:1122:3344:102::22
+    crucible          3b49c2c6-0b0b-4a11-be95-bf94c1cb54a8   in service    fd00:1122:3344:102::25
+    crucible          4c65501d-a08d-4fe5-9c78-2694ce6b3a43   in service    fd00:1122:3344:102::2a
+    crucible          60e74b27-a7d7-475e-b5ce-2a92eff4fa63   in service    fd00:1122:3344:102::2b
+    crucible          68f44e7e-8231-40c0-861e-2f4d0c2eb392   in service    fd00:1122:3344:102::2c
+    crucible          74fc3000-c4b7-4687-88b5-a27584b45434   in service    fd00:1122:3344:102::24
+    crucible          83ae0625-2e61-4637-a1f9-473b21b94f72   in service    fd00:1122:3344:102::2d
+    crucible          9b462d74-c05a-4a7e-8d24-449c848a7b13   in service    fd00:1122:3344:102::26
+    crucible          a9ed9f72-e57d-4092-ab0e-bb2000a5459e   in service    fd00:1122:3344:102::29
+    crucible          d84bc314-4895-4331-8afb-22bffdd56699   in service    fd00:1122:3344:102::27
+    crucible          f1f03b7d-916e-4c5f-8906-1e18e498184d   in service    fd00:1122:3344:102::28
+    crucible_pantry   ecdc7438-a007-4558-96b3-65bdab21a8a9   in service    fd00:1122:3344:102::23
+    internal_dns      c1049e2e-7269-4de0-b96e-2e9f8edc90ea   in service    fd00:1122:3344:3::1   
+    internal_ntp      d5b390d3-7280-4d2b-b670-340f91d7ebd7   in service    fd00:1122:3344:102::21
+    nexus             785868d0-a003-4860-acc1-9beee9f39816   in service    fd00:1122:3344:102::22
 
 
  ADDED SLEDS:
@@ -297,34 +297,34 @@ to:   blueprint 4171ad05-89dd-474b-846b-b007e4346366
     -----------------------------------------------------------------------------------------------------------------------------------------------------------------------------
     dataset name                                                                                       dataset uuid                           quota     reservation   compression
     -----------------------------------------------------------------------------------------------------------------------------------------------------------------------------
-+   oxp_28699448-c5d9-49ea-bf7e-627800efe783/crypt/zone                                                07381a6a-e397-4ff9-a2a6-8f1e46c47eb3   none      none          off        
-+   oxp_2c490e96-27f2-4a7f-b440-04d4bfd1e4f6/crypt/zone                                                b4c23ac2-86af-4b47-9d8d-35eff7997788   none      none          off        
-+   oxp_4c3bb1c7-55b6-49b8-b212-516b8f2c26c2/crypt/zone                                                32143abb-e501-450b-9398-7d4dbebdf4a1   none      none          off        
-+   oxp_5db07562-31a8-43e3-b99e-7c7cb89754b7/crypt/zone                                                6ec35c5c-9d6c-4d72-8bec-af91069ef7a9   none      none          off        
-+   oxp_9451a5d5-b358-4719-b6c1-a0d187da217c/crypt/zone                                                8529e7f8-8c11-4869-b330-83ddc45ed17a   none      none          off        
-+   oxp_bb2e2869-9481-483a-bc49-2bdd62f515f5/crypt/zone                                                940f06cb-822f-4034-8d34-e14bcc6ea998   none      none          off        
-+   oxp_d5a36c66-4b2f-46e6-96f4-b82debee1a4a/crypt/zone                                                0507b005-e018-4b69-9d84-50faf61e792f   none      none          off        
-+   oxp_f99ec996-ec08-4ccf-9a6e-6c5cab440fb4/crypt/zone                                                1acaf776-970a-49cf-9f1c-7d8e3146ef11   none      none          off        
-+   oxp_faccbb39-d686-42a1-a50a-0eb59ba74a87/crypt/zone                                                1bd5ab24-2a54-438f-bae0-af1b06a3cc41   none      none          off        
-+   oxp_fdfd067b-1d86-444d-a21f-ed33709f3e4d/crypt/zone                                                b501adbf-be36-4724-9409-329f690fb09d   none      none          off        
-+   oxp_28699448-c5d9-49ea-bf7e-627800efe783/crypt/zone/oxz_ntp_2d73d30e-ca47-46a8-9c12-917d4ab824b6   15e9b1ea-8947-48a2-8d78-54665e4d2f03   none      none          off        
-+   oxp_28699448-c5d9-49ea-bf7e-627800efe783/crypt/debug                                               bbab775c-07b1-48b1-96a3-9aa155396112   100 GiB   none          gzip-9     
-+   oxp_2c490e96-27f2-4a7f-b440-04d4bfd1e4f6/crypt/debug                                               75c1432c-19e1-4c06-8393-9907a09efcbe   100 GiB   none          gzip-9     
-+   oxp_4c3bb1c7-55b6-49b8-b212-516b8f2c26c2/crypt/debug                                               5501c13c-0500-41a6-9c48-85924383fdcc   100 GiB   none          gzip-9     
-+   oxp_5db07562-31a8-43e3-b99e-7c7cb89754b7/crypt/debug                                               bcdd7a5a-59da-4a47-8a1c-79281428d71b   100 GiB   none          gzip-9     
-+   oxp_9451a5d5-b358-4719-b6c1-a0d187da217c/crypt/debug                                               8ed9d1a2-3c60-4f38-9e80-5c56d80e67c9   100 GiB   none          gzip-9     
-+   oxp_bb2e2869-9481-483a-bc49-2bdd62f515f5/crypt/debug                                               4aef9a3a-0829-4ada-a0e9-a45c91e74249   100 GiB   none          gzip-9     
-+   oxp_d5a36c66-4b2f-46e6-96f4-b82debee1a4a/crypt/debug                                               2b23d885-836a-4270-886d-08640aae90aa   100 GiB   none          gzip-9     
-+   oxp_f99ec996-ec08-4ccf-9a6e-6c5cab440fb4/crypt/debug                                               feac64a1-ade2-4f88-8c17-64d2863e2be6   100 GiB   none          gzip-9     
-+   oxp_faccbb39-d686-42a1-a50a-0eb59ba74a87/crypt/debug                                               91edd9a1-178d-4aa5-83a7-b2f4ef1fc44a   100 GiB   none          gzip-9     
-+   oxp_fdfd067b-1d86-444d-a21f-ed33709f3e4d/crypt/debug                                               8840ccd9-e8c9-48d9-affb-8587e468b204   100 GiB   none          gzip-9     
++   oxp_28699448-c5d9-49ea-bf7e-627800efe783/crypt/zone                                                bd515f95-ef75-4243-b279-5448e8c56693   none      none          off        
++   oxp_2c490e96-27f2-4a7f-b440-04d4bfd1e4f6/crypt/zone                                                a5ebe3b2-007d-4cb6-a01b-519eb696dd51   none      none          off        
++   oxp_4c3bb1c7-55b6-49b8-b212-516b8f2c26c2/crypt/zone                                                292da7cf-54f6-4d8c-a941-eebe5d47fe50   none      none          off        
++   oxp_5db07562-31a8-43e3-b99e-7c7cb89754b7/crypt/zone                                                58573ab1-3d00-4251-9e32-1c8c94d41689   none      none          off        
++   oxp_9451a5d5-b358-4719-b6c1-a0d187da217c/crypt/zone                                                823a6464-7317-41c4-88d1-317e6156da3b   none      none          off        
++   oxp_bb2e2869-9481-483a-bc49-2bdd62f515f5/crypt/zone                                                edf02038-6f07-4788-80f7-1c9ef4537956   none      none          off        
++   oxp_d5a36c66-4b2f-46e6-96f4-b82debee1a4a/crypt/zone                                                77234c3d-1877-4d9b-9885-cd70b05f6d3d   none      none          off        
++   oxp_f99ec996-ec08-4ccf-9a6e-6c5cab440fb4/crypt/zone                                                04ebd243-fe45-4222-a437-da51aa719c37   none      none          off        
++   oxp_faccbb39-d686-42a1-a50a-0eb59ba74a87/crypt/zone                                                b6c84399-0029-4eaa-af95-328e62813332   none      none          off        
++   oxp_fdfd067b-1d86-444d-a21f-ed33709f3e4d/crypt/zone                                                d1121115-497a-49a1-8908-2bc330bb5b98   none      none          off        
++   oxp_28699448-c5d9-49ea-bf7e-627800efe783/crypt/zone/oxz_ntp_f4a71d99-95e2-484a-ae67-6f98aacee92b   2178dce4-6fba-4b15-b5ce-ece8c54083b5   none      none          off        
++   oxp_28699448-c5d9-49ea-bf7e-627800efe783/crypt/debug                                               9c2fc653-d640-4d06-8fb0-a32ce35309b7   100 GiB   none          gzip-9     
++   oxp_2c490e96-27f2-4a7f-b440-04d4bfd1e4f6/crypt/debug                                               3544ad60-7696-44a4-812d-1e830e2de897   100 GiB   none          gzip-9     
++   oxp_4c3bb1c7-55b6-49b8-b212-516b8f2c26c2/crypt/debug                                               81d852cd-0bfd-4f3a-98b5-641657f2acda   100 GiB   none          gzip-9     
++   oxp_5db07562-31a8-43e3-b99e-7c7cb89754b7/crypt/debug                                               fa35030d-d14d-4969-9dbf-38dfb7bd4a4d   100 GiB   none          gzip-9     
++   oxp_9451a5d5-b358-4719-b6c1-a0d187da217c/crypt/debug                                               2110ad2b-9665-4427-b6fb-9059d3d65070   100 GiB   none          gzip-9     
++   oxp_bb2e2869-9481-483a-bc49-2bdd62f515f5/crypt/debug                                               c4f6dae6-d357-4ad3-becd-5e49c4dcf171   100 GiB   none          gzip-9     
++   oxp_d5a36c66-4b2f-46e6-96f4-b82debee1a4a/crypt/debug                                               25c84622-b39a-4c28-9dd5-1f9f33170150   100 GiB   none          gzip-9     
++   oxp_f99ec996-ec08-4ccf-9a6e-6c5cab440fb4/crypt/debug                                               1a88aed3-4f65-479a-8677-af5771feade4   100 GiB   none          gzip-9     
++   oxp_faccbb39-d686-42a1-a50a-0eb59ba74a87/crypt/debug                                               25eff656-ae3f-42bc-9bfb-8adbc9a1f146   100 GiB   none          gzip-9     
++   oxp_fdfd067b-1d86-444d-a21f-ed33709f3e4d/crypt/debug                                               ecba8219-9446-4f43-a2fd-098f54ebdfd2   100 GiB   none          gzip-9     
 
 
     omicron zones at generation 2:
     ------------------------------------------------------------------------------------------
     zone type      zone id                                disposition   underlay IP           
     ------------------------------------------------------------------------------------------
-+   internal_ntp   2d73d30e-ca47-46a8-9c12-917d4ab824b6   in service    fd00:1122:3344:104::21
++   internal_ntp   f4a71d99-95e2-484a-ae67-6f98aacee92b   in service    fd00:1122:3344:104::21
 
 
  COCKROACHDB SETTINGS:

--- a/nexus/reconfigurator/planning/tests/output/planner_basic_add_sled_3_5.txt
+++ b/nexus/reconfigurator/planning/tests/output/planner_basic_add_sled_3_5.txt
@@ -25,74 +25,74 @@ to:   blueprint f432fcd5-1284-4058-8b4a-9286a3de6163
     -----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
     dataset name                                                                                                   dataset uuid                           quota     reservation   compression
     -----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
-    oxp_014eb1e9-04fe-4f36-8339-0a090b053ada/crucible                                                              a9c330b0-1f48-4bd7-b82f-c3419131b69b   none      none          off        
-    oxp_31a3bc64-7a3b-496d-b644-785dc44b6e37/crucible                                                              2cd64120-ea51-450a-bac8-d419f9ff7570   none      none          off        
-    oxp_7bb40bd6-9c43-4b63-8337-18313c72aea2/crucible                                                              cd1cc777-1813-427a-bf3b-8b4cb372608c   none      none          off        
-    oxp_988aa8c2-cb5e-406b-9289-425dc2e5bc3a/crucible                                                              3aa68ad8-0539-4d41-a709-50fa4a0f97e5   none      none          off        
-    oxp_ad574c09-2ae0-4534-a2a4-f923ce20ae87/crucible                                                              eb598474-ce25-4878-87b9-3c26318fb192   none      none          off        
-    oxp_ad91e238-4901-4ff4-a91b-75233c936426/crucible                                                              7600ccdd-7b1a-46b6-85c2-800b2d4cf4d8   none      none          off        
-    oxp_ce58d463-d442-4c97-a6b4-f7d98c3fd902/crucible                                                              3243c276-0a62-4c1f-9976-c353618b2585   none      none          off        
-    oxp_f18f7689-0059-4b79-880e-34faf7a0fe0e/crucible                                                              f68ba9d0-a5cf-4148-a754-010656ae5f7b   none      none          off        
-    oxp_f1d6cea4-640f-415e-89fe-2b1784ce3db8/crucible                                                              cea3cbac-de83-4a0c-a003-e42086fd418c   none      none          off        
-    oxp_f4a96860-bdeb-4435-bdf5-2a10beb3d44a/crucible                                                              88143ddc-773c-43e6-9859-5033535b566c   none      none          off        
-    oxp_014eb1e9-04fe-4f36-8339-0a090b053ada/crypt/clickhouse                                                      7c20d4b3-b783-4ba7-94a9-a8b789b04674   none      none          off        
-    oxp_014eb1e9-04fe-4f36-8339-0a090b053ada/crypt/internal_dns                                                    e2a6246d-00f0-4526-a2ab-99b2db7e1d51   none      none          off        
-    oxp_014eb1e9-04fe-4f36-8339-0a090b053ada/crypt/zone                                                            1e7c17fa-63d5-4a62-8037-663745516d18   none      none          off        
-    oxp_31a3bc64-7a3b-496d-b644-785dc44b6e37/crypt/zone                                                            5e5c6b62-7785-4180-b901-6f33d676d657   none      none          off        
-    oxp_7bb40bd6-9c43-4b63-8337-18313c72aea2/crypt/zone                                                            536e5566-25b0-4df3-946e-3c59ca7d7921   none      none          off        
-    oxp_988aa8c2-cb5e-406b-9289-425dc2e5bc3a/crypt/zone                                                            14d03496-7ebd-4272-a58b-4c193ba0da82   none      none          off        
-    oxp_ad574c09-2ae0-4534-a2a4-f923ce20ae87/crypt/zone                                                            3fa2a825-bfec-42ca-801b-fc901f7a7729   none      none          off        
-    oxp_ad91e238-4901-4ff4-a91b-75233c936426/crypt/zone                                                            63720ef8-1aad-4f61-a20b-078a1eb4d436   none      none          off        
-    oxp_ce58d463-d442-4c97-a6b4-f7d98c3fd902/crypt/zone                                                            b58e8fae-21e3-4131-a37a-7c8bfaa242f5   none      none          off        
-    oxp_f18f7689-0059-4b79-880e-34faf7a0fe0e/crypt/zone                                                            e7e785bc-f3db-44ab-a4a2-71cca70507e4   none      none          off        
-    oxp_f1d6cea4-640f-415e-89fe-2b1784ce3db8/crypt/zone                                                            1e998426-2b49-4abc-877d-e7b972e5aadb   none      none          off        
-    oxp_f4a96860-bdeb-4435-bdf5-2a10beb3d44a/crypt/zone                                                            c02e8b44-3f25-4529-9d97-9a908e52af1d   none      none          off        
-    oxp_014eb1e9-04fe-4f36-8339-0a090b053ada/crypt/zone/oxz_clickhouse_b40f7c7b-526c-46c8-ae33-67280c280eb7        38af39e8-406d-4ffe-8afb-f15d80fbea27   none      none          off        
-    oxp_f18f7689-0059-4b79-880e-34faf7a0fe0e/crypt/zone/oxz_crucible_08c7f8aa-1ea9-469b-8cac-2fdbfc11ebcb          e78dca52-4122-428a-b8c5-911fcce624de   none      none          off        
-    oxp_f4a96860-bdeb-4435-bdf5-2a10beb3d44a/crypt/zone/oxz_crucible_3eda924f-22a9-4f3e-9a1b-91d1c47601ab          53c8cf89-1838-4638-8a27-683d134cbd9c   none      none          off        
-    oxp_ad574c09-2ae0-4534-a2a4-f923ce20ae87/crypt/zone/oxz_crucible_4ab1650f-32c5-447f-939d-64b8103a7645          e008db37-e6ad-433a-8aa1-ab06f8bad5b4   none      none          off        
-    oxp_31a3bc64-7a3b-496d-b644-785dc44b6e37/crypt/zone/oxz_crucible_64aa65f8-1ccb-4cd6-9953-027aebdac8ff          70a5b1f3-dbd7-4cc0-8a30-9a8c5ff33402   none      none          off        
-    oxp_ad91e238-4901-4ff4-a91b-75233c936426/crypt/zone/oxz_crucible_6e811d86-8aa7-4660-935b-84b4b7721b10          b833252f-8df1-4188-9282-0b4e90caec37   none      none          off        
-    oxp_ce58d463-d442-4c97-a6b4-f7d98c3fd902/crypt/zone/oxz_crucible_7fbd2c38-5dc3-48c4-b061-558a2041d70f          8a3cdc7a-802b-4b83-84bd-14f62c43ee7e   none      none          off        
-    oxp_988aa8c2-cb5e-406b-9289-425dc2e5bc3a/crypt/zone/oxz_crucible_8e9e923e-62b1-4cbc-9f59-d6397e338b6b          724bd053-39f3-4c24-8109-a4d8b4c27787   none      none          off        
-    oxp_7bb40bd6-9c43-4b63-8337-18313c72aea2/crypt/zone/oxz_crucible_b14d5478-1a0e-4b90-b526-36b06339dfc4          32f26a28-c25b-4706-9fc0-712ea55b8d88   none      none          off        
-    oxp_014eb1e9-04fe-4f36-8339-0a090b053ada/crypt/zone/oxz_crucible_be97b92b-38d6-422a-8c76-d37060f75bd2          574ac2b5-0233-488c-afd1-7ef4adc00b61   none      none          off        
-    oxp_f1d6cea4-640f-415e-89fe-2b1784ce3db8/crypt/zone/oxz_crucible_c66ab6d5-ff7a-46d1-9fd0-70cefa352d25          cc0d38c6-17f2-4861-889f-82398f0eade2   none      none          off        
-    oxp_014eb1e9-04fe-4f36-8339-0a090b053ada/crypt/zone/oxz_crucible_pantry_747d2426-68bf-4c22-8806-41d290b5d5f5   a820d4d1-87d3-419d-8ed3-0dda65f8e808   none      none          off        
-    oxp_014eb1e9-04fe-4f36-8339-0a090b053ada/crypt/zone/oxz_internal_dns_322ee9f1-8903-4542-a0a8-a54cefabdeca      d907b775-c3e6-4b0f-90e7-a2923c5790bf   none      none          off        
-    oxp_014eb1e9-04fe-4f36-8339-0a090b053ada/crypt/zone/oxz_nexus_cc816cfe-3869-4dde-b596-397d41198628             5f84acc5-e9f0-4f12-93e9-d2a271cb8ea0   none      none          off        
-    oxp_014eb1e9-04fe-4f36-8339-0a090b053ada/crypt/zone/oxz_ntp_267ed614-92af-4b9d-bdba-c2881c2e43a2               bf1b301a-436c-4cdc-b3cd-de08dfcadc86   none      none          off        
-    oxp_014eb1e9-04fe-4f36-8339-0a090b053ada/crypt/debug                                                           0a6be80b-87c5-41fd-bd3c-36275b4ec494   100 GiB   none          gzip-9     
-    oxp_31a3bc64-7a3b-496d-b644-785dc44b6e37/crypt/debug                                                           bbc7b434-12d0-441f-86c1-73d8355db38b   100 GiB   none          gzip-9     
-    oxp_7bb40bd6-9c43-4b63-8337-18313c72aea2/crypt/debug                                                           43858cf5-148f-48d8-9e52-b878d2efb6a5   100 GiB   none          gzip-9     
-    oxp_988aa8c2-cb5e-406b-9289-425dc2e5bc3a/crypt/debug                                                           bb0c5843-4fd2-4c5a-a7a1-2bc1e9180caf   100 GiB   none          gzip-9     
-    oxp_ad574c09-2ae0-4534-a2a4-f923ce20ae87/crypt/debug                                                           cb06ffe2-7f4d-4936-8310-ebf5e032a32c   100 GiB   none          gzip-9     
-    oxp_ad91e238-4901-4ff4-a91b-75233c936426/crypt/debug                                                           0a585f79-acdb-4de1-9e32-e54906b1cfb8   100 GiB   none          gzip-9     
-    oxp_ce58d463-d442-4c97-a6b4-f7d98c3fd902/crypt/debug                                                           e86ad99b-5040-4863-86db-0375ed3004f4   100 GiB   none          gzip-9     
-    oxp_f18f7689-0059-4b79-880e-34faf7a0fe0e/crypt/debug                                                           f0945e1c-9c5e-463c-bee9-bee695299a0b   100 GiB   none          gzip-9     
-    oxp_f1d6cea4-640f-415e-89fe-2b1784ce3db8/crypt/debug                                                           dd7111a0-555c-4b82-82b3-2cc93a2b1771   100 GiB   none          gzip-9     
-    oxp_f4a96860-bdeb-4435-bdf5-2a10beb3d44a/crypt/debug                                                           b8abfcc9-d636-4cee-b0a1-dd4b62ceade5   100 GiB   none          gzip-9     
+    oxp_014eb1e9-04fe-4f36-8339-0a090b053ada/crucible                                                              ea8bb9f4-ef14-4764-8713-299c94aee754   none      none          off        
+    oxp_31a3bc64-7a3b-496d-b644-785dc44b6e37/crucible                                                              7dcb9cca-dcac-4d95-92d1-f9ee376558ee   none      none          off        
+    oxp_7bb40bd6-9c43-4b63-8337-18313c72aea2/crucible                                                              87f012e5-1979-4d4f-abd7-5004e6a4de4a   none      none          off        
+    oxp_988aa8c2-cb5e-406b-9289-425dc2e5bc3a/crucible                                                              8a017cce-a6e3-4891-80d2-282134012f1f   none      none          off        
+    oxp_ad574c09-2ae0-4534-a2a4-f923ce20ae87/crucible                                                              51734f27-2839-481c-b11d-f59843297269   none      none          off        
+    oxp_ad91e238-4901-4ff4-a91b-75233c936426/crucible                                                              4ebb5c8c-77cc-4d9a-a66a-aab846d7f4d7   none      none          off        
+    oxp_ce58d463-d442-4c97-a6b4-f7d98c3fd902/crucible                                                              7e930ce3-f0e6-4188-940a-07dee8fc97cd   none      none          off        
+    oxp_f18f7689-0059-4b79-880e-34faf7a0fe0e/crucible                                                              e688234b-9854-4a4e-ae8e-5ec66a323784   none      none          off        
+    oxp_f1d6cea4-640f-415e-89fe-2b1784ce3db8/crucible                                                              48a12bd9-3d59-4151-adf1-ff703d71977c   none      none          off        
+    oxp_f4a96860-bdeb-4435-bdf5-2a10beb3d44a/crucible                                                              4a0ed488-8ab7-4a8b-90da-ab568081832b   none      none          off        
+    oxp_014eb1e9-04fe-4f36-8339-0a090b053ada/crypt/clickhouse                                                      87d67ac6-6079-4a4c-960e-44991410a64c   none      none          off        
+    oxp_014eb1e9-04fe-4f36-8339-0a090b053ada/crypt/internal_dns                                                    31caca18-3e69-4e95-a48e-1a3f9219a304   none      none          off        
+    oxp_014eb1e9-04fe-4f36-8339-0a090b053ada/crypt/zone                                                            8df851fd-0e0c-4069-ad4b-e8669051e42d   none      none          off        
+    oxp_31a3bc64-7a3b-496d-b644-785dc44b6e37/crypt/zone                                                            3c2b2846-d286-4ac7-9001-1dbc92d8ec52   none      none          off        
+    oxp_7bb40bd6-9c43-4b63-8337-18313c72aea2/crypt/zone                                                            d7519dd3-b371-4570-b474-e198d679bc47   none      none          off        
+    oxp_988aa8c2-cb5e-406b-9289-425dc2e5bc3a/crypt/zone                                                            da77f084-5fc9-477a-a5b1-e424f98aa53f   none      none          off        
+    oxp_ad574c09-2ae0-4534-a2a4-f923ce20ae87/crypt/zone                                                            8ffb3c67-d81d-4edc-b4fa-f829bc6d9fb5   none      none          off        
+    oxp_ad91e238-4901-4ff4-a91b-75233c936426/crypt/zone                                                            12c23a3b-389d-4f4f-950e-f7e36ae44262   none      none          off        
+    oxp_ce58d463-d442-4c97-a6b4-f7d98c3fd902/crypt/zone                                                            6614568a-a5a5-4db2-80f2-3e405fe35e17   none      none          off        
+    oxp_f18f7689-0059-4b79-880e-34faf7a0fe0e/crypt/zone                                                            a7d4d358-7935-4060-985f-280829de083c   none      none          off        
+    oxp_f1d6cea4-640f-415e-89fe-2b1784ce3db8/crypt/zone                                                            35decedb-c97e-4fde-9ee2-26680ccc7f7e   none      none          off        
+    oxp_f4a96860-bdeb-4435-bdf5-2a10beb3d44a/crypt/zone                                                            a0b8487f-b194-4583-ab31-3b02d85af60b   none      none          off        
+    oxp_014eb1e9-04fe-4f36-8339-0a090b053ada/crypt/zone/oxz_clickhouse_98229df2-6faf-45a4-8501-48e1ad25706e        0bda3f6e-6852-4476-8539-8d6315466ccb   none      none          off        
+    oxp_ad574c09-2ae0-4534-a2a4-f923ce20ae87/crypt/zone/oxz_crucible_3384bb31-72f2-46fc-9ada-b324580e2930          707c72de-e19c-4c7b-b2a1-4b028e1026c9   none      none          off        
+    oxp_f1d6cea4-640f-415e-89fe-2b1784ce3db8/crypt/zone/oxz_crucible_397f4188-68b0-4d82-aea4-5b950f6fc779          8cab65a0-26af-42e7-9f77-10a03096edf0   none      none          off        
+    oxp_988aa8c2-cb5e-406b-9289-425dc2e5bc3a/crypt/zone/oxz_crucible_4a35beea-a998-4ef1-845c-55d69d35108f          74aacf3e-7c5b-44d5-869c-ae04c9f70bf9   none      none          off        
+    oxp_ad91e238-4901-4ff4-a91b-75233c936426/crypt/zone/oxz_crucible_5710b56a-a07e-49e2-8dfb-34f1c87ca02e          1e1bfd91-4900-4869-9b17-d6ff94d95301   none      none          off        
+    oxp_f4a96860-bdeb-4435-bdf5-2a10beb3d44a/crypt/zone/oxz_crucible_62b70007-57c1-4086-8e35-e61443f0c259          b1217132-9894-472e-a763-626798f46cc2   none      none          off        
+    oxp_014eb1e9-04fe-4f36-8339-0a090b053ada/crypt/zone/oxz_crucible_8ca9bfdc-c3a6-4280-ad34-b5af8fd5187e          14b40d48-c5b1-4e8e-90ec-e374d824204d   none      none          off        
+    oxp_31a3bc64-7a3b-496d-b644-785dc44b6e37/crypt/zone/oxz_crucible_9c927800-ba15-4e84-b80e-781606bec308          eb2960e5-5b89-432f-a384-3009d3b3db5d   none      none          off        
+    oxp_ce58d463-d442-4c97-a6b4-f7d98c3fd902/crypt/zone/oxz_crucible_a7cab59f-59f2-4cb9-b559-551dc6c43aaf          8c16b33b-54f3-453d-a28a-baed87bd45da   none      none          off        
+    oxp_f18f7689-0059-4b79-880e-34faf7a0fe0e/crypt/zone/oxz_crucible_cb67f66d-37e3-40a6-adbd-69962fb6cf73          52036fa0-92ad-4444-8156-01d0b2e9b676   none      none          off        
+    oxp_7bb40bd6-9c43-4b63-8337-18313c72aea2/crypt/zone/oxz_crucible_da2fc172-8cb2-4d66-a92b-017a97842c27          3aa614f6-5a75-44a0-a950-6adb6c299299   none      none          off        
+    oxp_014eb1e9-04fe-4f36-8339-0a090b053ada/crypt/zone/oxz_crucible_pantry_be4a1d4a-093f-40e0-8e06-74cc1d786d1b   25438f31-b9e0-499f-a55f-9bfcb0a4194d   none      none          off        
+    oxp_014eb1e9-04fe-4f36-8339-0a090b053ada/crypt/zone/oxz_internal_dns_2a6f89a2-3476-4c3b-97b2-322f00f2fc9a      572f2970-46ed-46e1-b600-d021e080903e   none      none          off        
+    oxp_014eb1e9-04fe-4f36-8339-0a090b053ada/crypt/zone/oxz_nexus_fb07dee1-d608-451b-83eb-4ee913d6e1f8             0e2d27bc-01d7-4afd-82e2-973db6138e70   none      none          off        
+    oxp_014eb1e9-04fe-4f36-8339-0a090b053ada/crypt/zone/oxz_ntp_d7ffba91-8f9d-4168-89a4-26c6c4370cb0               63e6eeb0-e079-4165-9444-8aac3d50fef3   none      none          off        
+    oxp_014eb1e9-04fe-4f36-8339-0a090b053ada/crypt/debug                                                           9982db80-b762-4c5f-9916-35383d59b6df   100 GiB   none          gzip-9     
+    oxp_31a3bc64-7a3b-496d-b644-785dc44b6e37/crypt/debug                                                           fd25bb57-dc4b-42ea-a2ab-d6395b38334f   100 GiB   none          gzip-9     
+    oxp_7bb40bd6-9c43-4b63-8337-18313c72aea2/crypt/debug                                                           95f111d8-854f-4177-bcff-481e625dd73d   100 GiB   none          gzip-9     
+    oxp_988aa8c2-cb5e-406b-9289-425dc2e5bc3a/crypt/debug                                                           38903da8-c23d-4516-b0ca-6036e26c49e4   100 GiB   none          gzip-9     
+    oxp_ad574c09-2ae0-4534-a2a4-f923ce20ae87/crypt/debug                                                           216e74e6-691b-45f9-ad7f-037ae799a8c9   100 GiB   none          gzip-9     
+    oxp_ad91e238-4901-4ff4-a91b-75233c936426/crypt/debug                                                           e598cc97-90c4-403a-b7fc-741f8b93de87   100 GiB   none          gzip-9     
+    oxp_ce58d463-d442-4c97-a6b4-f7d98c3fd902/crypt/debug                                                           235746b2-5d3f-4608-9017-2bd8d1521d2b   100 GiB   none          gzip-9     
+    oxp_f18f7689-0059-4b79-880e-34faf7a0fe0e/crypt/debug                                                           08fdf2b1-430d-4a5c-adf3-b0a0f323ae9d   100 GiB   none          gzip-9     
+    oxp_f1d6cea4-640f-415e-89fe-2b1784ce3db8/crypt/debug                                                           ea7fa07f-f47b-4039-a0db-6ab9ca0f0e2c   100 GiB   none          gzip-9     
+    oxp_f4a96860-bdeb-4435-bdf5-2a10beb3d44a/crypt/debug                                                           547cb9ee-f196-4dfe-9f2c-aa4b2f114abe   100 GiB   none          gzip-9     
 
 
     omicron zones at generation 2:
     ---------------------------------------------------------------------------------------------
     zone type         zone id                                disposition   underlay IP           
     ---------------------------------------------------------------------------------------------
-    clickhouse        b40f7c7b-526c-46c8-ae33-67280c280eb7   in service    fd00:1122:3344:103::23
-    crucible          08c7f8aa-1ea9-469b-8cac-2fdbfc11ebcb   in service    fd00:1122:3344:103::2c
-    crucible          3eda924f-22a9-4f3e-9a1b-91d1c47601ab   in service    fd00:1122:3344:103::2e
-    crucible          4ab1650f-32c5-447f-939d-64b8103a7645   in service    fd00:1122:3344:103::29
-    crucible          64aa65f8-1ccb-4cd6-9953-027aebdac8ff   in service    fd00:1122:3344:103::26
-    crucible          6e811d86-8aa7-4660-935b-84b4b7721b10   in service    fd00:1122:3344:103::2a
-    crucible          7fbd2c38-5dc3-48c4-b061-558a2041d70f   in service    fd00:1122:3344:103::2b
-    crucible          8e9e923e-62b1-4cbc-9f59-d6397e338b6b   in service    fd00:1122:3344:103::28
-    crucible          b14d5478-1a0e-4b90-b526-36b06339dfc4   in service    fd00:1122:3344:103::27
-    crucible          be97b92b-38d6-422a-8c76-d37060f75bd2   in service    fd00:1122:3344:103::25
-    crucible          c66ab6d5-ff7a-46d1-9fd0-70cefa352d25   in service    fd00:1122:3344:103::2d
-    crucible_pantry   747d2426-68bf-4c22-8806-41d290b5d5f5   in service    fd00:1122:3344:103::24
-    internal_dns      322ee9f1-8903-4542-a0a8-a54cefabdeca   in service    fd00:1122:3344:1::1   
-    internal_ntp      267ed614-92af-4b9d-bdba-c2881c2e43a2   in service    fd00:1122:3344:103::21
-    nexus             cc816cfe-3869-4dde-b596-397d41198628   in service    fd00:1122:3344:103::22
+    clickhouse        98229df2-6faf-45a4-8501-48e1ad25706e   in service    fd00:1122:3344:103::23
+    crucible          3384bb31-72f2-46fc-9ada-b324580e2930   in service    fd00:1122:3344:103::29
+    crucible          397f4188-68b0-4d82-aea4-5b950f6fc779   in service    fd00:1122:3344:103::2d
+    crucible          4a35beea-a998-4ef1-845c-55d69d35108f   in service    fd00:1122:3344:103::28
+    crucible          5710b56a-a07e-49e2-8dfb-34f1c87ca02e   in service    fd00:1122:3344:103::2a
+    crucible          62b70007-57c1-4086-8e35-e61443f0c259   in service    fd00:1122:3344:103::2e
+    crucible          8ca9bfdc-c3a6-4280-ad34-b5af8fd5187e   in service    fd00:1122:3344:103::25
+    crucible          9c927800-ba15-4e84-b80e-781606bec308   in service    fd00:1122:3344:103::26
+    crucible          a7cab59f-59f2-4cb9-b559-551dc6c43aaf   in service    fd00:1122:3344:103::2b
+    crucible          cb67f66d-37e3-40a6-adbd-69962fb6cf73   in service    fd00:1122:3344:103::2c
+    crucible          da2fc172-8cb2-4d66-a92b-017a97842c27   in service    fd00:1122:3344:103::27
+    crucible_pantry   be4a1d4a-093f-40e0-8e06-74cc1d786d1b   in service    fd00:1122:3344:103::24
+    internal_dns      2a6f89a2-3476-4c3b-97b2-322f00f2fc9a   in service    fd00:1122:3344:1::1   
+    internal_ntp      d7ffba91-8f9d-4168-89a4-26c6c4370cb0   in service    fd00:1122:3344:103::21
+    nexus             fb07dee1-d608-451b-83eb-4ee913d6e1f8   in service    fd00:1122:3344:103::22
 
 
   sled 43677374-8d2f-4deb-8a41-eeea506db8e0 (active):
@@ -117,71 +117,71 @@ to:   blueprint f432fcd5-1284-4058-8b4a-9286a3de6163
     -----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
     dataset name                                                                                                   dataset uuid                           quota     reservation   compression
     -----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
-    oxp_12057b4a-0b06-4f70-ba22-336de2385bfe/crucible                                                              c333b519-9dde-4ada-b507-2bb0b6903d17   none      none          off        
-    oxp_29758363-6c77-40c3-8740-9c0c64f6e14a/crucible                                                              2e09fba5-0c1d-41db-a310-bef9290c6332   none      none          off        
-    oxp_3f331c10-7882-48ab-85d9-05108490b55b/crucible                                                              76ab0eb2-4356-4a8a-b555-a83930ef3dce   none      none          off        
-    oxp_5152d1aa-9045-4e06-9ef6-6eadac3696e4/crucible                                                              52255a04-77be-486f-a59f-f17de4916cc2   none      none          off        
-    oxp_5c0dd424-d905-4fc5-a73c-36254fdd470c/crucible                                                              ab598283-0338-4124-af32-71aaf478908d   none      none          off        
-    oxp_794df76f-bca0-4635-9eb6-773ad0108f7e/crucible                                                              e54385d1-cead-4fb6-a28e-c13db4e9561f   none      none          off        
-    oxp_9024d350-38a7-459b-8550-3b2c4a88b5c1/crucible                                                              8aa9c334-3980-4875-b858-b1739848474d   none      none          off        
-    oxp_95e86080-e162-4980-a589-db6bb1a95ca7/crucible                                                              de88d3ee-683a-4550-99de-aca94b4a276a   none      none          off        
-    oxp_d55d36d7-df92-4615-944d-440a1f8b5001/crucible                                                              f6df8087-1122-4715-851a-127309740840   none      none          off        
-    oxp_db6686c8-2dd9-4032-8444-2a06b43baa68/crucible                                                              882faa8a-7df8-4f67-abba-3d97a2615932   none      none          off        
-    oxp_12057b4a-0b06-4f70-ba22-336de2385bfe/crypt/internal_dns                                                    52de1771-5f5b-422d-89e9-96a708c66d47   none      none          off        
-    oxp_12057b4a-0b06-4f70-ba22-336de2385bfe/crypt/zone                                                            5a5afb9f-850c-4501-959a-8ff760eca117   none      none          off        
-    oxp_29758363-6c77-40c3-8740-9c0c64f6e14a/crypt/zone                                                            fe22839c-29a4-4711-8290-44dc001b9a4f   none      none          off        
-    oxp_3f331c10-7882-48ab-85d9-05108490b55b/crypt/zone                                                            3b733c7c-d0b0-427b-952a-200518837f87   none      none          off        
-    oxp_5152d1aa-9045-4e06-9ef6-6eadac3696e4/crypt/zone                                                            7aabaeaa-fd10-4686-bd7e-65a961ea3f87   none      none          off        
-    oxp_5c0dd424-d905-4fc5-a73c-36254fdd470c/crypt/zone                                                            e991d7ef-7ca9-444e-ad9d-6f9d165a3b80   none      none          off        
-    oxp_794df76f-bca0-4635-9eb6-773ad0108f7e/crypt/zone                                                            f06995fc-99ad-4184-80b4-3d0a42ac858f   none      none          off        
-    oxp_9024d350-38a7-459b-8550-3b2c4a88b5c1/crypt/zone                                                            61be50c0-fa4b-405a-86aa-51da8c92580a   none      none          off        
-    oxp_95e86080-e162-4980-a589-db6bb1a95ca7/crypt/zone                                                            15bb82a6-77c3-4c3c-ac8b-95c524526704   none      none          off        
-    oxp_d55d36d7-df92-4615-944d-440a1f8b5001/crypt/zone                                                            b7b7c0d6-b2dd-41eb-b5fe-3e131356552f   none      none          off        
-    oxp_db6686c8-2dd9-4032-8444-2a06b43baa68/crypt/zone                                                            51701069-af21-4697-8655-d2a8e455dceb   none      none          off        
-    oxp_29758363-6c77-40c3-8740-9c0c64f6e14a/crypt/zone/oxz_crucible_2a455c35-eb3c-4c73-ab6c-d0a706e25316          a3e5c0e0-3a73-4f7a-abd4-63f3434767aa   none      none          off        
-    oxp_794df76f-bca0-4635-9eb6-773ad0108f7e/crypt/zone/oxz_crucible_47199d48-534c-4267-a654-d2d90e64b498          3e03f4d9-b2e7-4176-91e4-dc5771ccc769   none      none          off        
-    oxp_5152d1aa-9045-4e06-9ef6-6eadac3696e4/crypt/zone/oxz_crucible_587be699-a320-4c79-b320-128d9ecddc0b          40cae2bc-0505-4d53-9d94-b199aaf5600a   none      none          off        
-    oxp_5c0dd424-d905-4fc5-a73c-36254fdd470c/crypt/zone/oxz_crucible_6fa06115-4959-4913-8e7b-dd70d7651f07          8879f080-4bd0-4073-ab2f-08e6f289bb4f   none      none          off        
-    oxp_9024d350-38a7-459b-8550-3b2c4a88b5c1/crypt/zone/oxz_crucible_704e1fed-f8d6-4cfa-a470-bad27fdc06d1          c1fc8d09-f44c-4a2e-b989-066f2787d4c1   none      none          off        
-    oxp_12057b4a-0b06-4f70-ba22-336de2385bfe/crypt/zone/oxz_crucible_8f3a1cc5-9195-4a30-ad02-b804278fe639          42a06863-188a-4755-99f7-659df14958f7   none      none          off        
-    oxp_3f331c10-7882-48ab-85d9-05108490b55b/crypt/zone/oxz_crucible_a2079cbc-a69e-41a1-b1e0-fbcb972d03f6          94407842-70fd-48cd-933f-b0d7768fa45b   none      none          off        
-    oxp_95e86080-e162-4980-a589-db6bb1a95ca7/crypt/zone/oxz_crucible_af322036-371f-437c-8c08-7f40f3f1403b          a9f4142b-b18d-4f1a-8274-6fbf12a10efd   none      none          off        
-    oxp_db6686c8-2dd9-4032-8444-2a06b43baa68/crypt/zone/oxz_crucible_d637264f-6f40-44c2-8b7e-a179430210d2          bde5f2d8-ac7d-40e8-b4b7-2cdf1cff6e57   none      none          off        
-    oxp_d55d36d7-df92-4615-944d-440a1f8b5001/crypt/zone/oxz_crucible_edabedf3-839c-488d-ad6f-508ffa864674          3b94580a-8ff4-4302-8d49-30ff90ef7edc   none      none          off        
-    oxp_12057b4a-0b06-4f70-ba22-336de2385bfe/crypt/zone/oxz_crucible_pantry_02acbe6a-1c88-47e3-94c3-94084cbde098   f7256e30-6e62-4d4b-ab06-8e9b3c9472a3   none      none          off        
-    oxp_12057b4a-0b06-4f70-ba22-336de2385bfe/crypt/zone/oxz_internal_dns_07c3c805-8888-4fe5-9543-3d2479dbe6f3      54774860-da9a-4ff5-8d63-242b353c3115   none      none          off        
-    oxp_12057b4a-0b06-4f70-ba22-336de2385bfe/crypt/zone/oxz_nexus_a1696cd4-588c-484a-b95b-66e824c0ce05             5dae2769-982f-485d-9776-57c2ae0a83b9   none      none          off        
-    oxp_12057b4a-0b06-4f70-ba22-336de2385bfe/crypt/zone/oxz_ntp_10d98a73-ec88-4aff-a7e8-7db6a87880e6               c5dc843c-fa8c-46a8-9998-aa0b0397cb0c   none      none          off        
-    oxp_12057b4a-0b06-4f70-ba22-336de2385bfe/crypt/debug                                                           438902f5-ff09-48f2-8cd1-56dc910d86e1   100 GiB   none          gzip-9     
-    oxp_29758363-6c77-40c3-8740-9c0c64f6e14a/crypt/debug                                                           bc7e5ae9-81f0-437b-9655-d11259f5037b   100 GiB   none          gzip-9     
-    oxp_3f331c10-7882-48ab-85d9-05108490b55b/crypt/debug                                                           70aadfba-de91-4157-ab8c-98609d278d08   100 GiB   none          gzip-9     
-    oxp_5152d1aa-9045-4e06-9ef6-6eadac3696e4/crypt/debug                                                           d6835e81-73e5-46cc-a188-93050a2e4d40   100 GiB   none          gzip-9     
-    oxp_5c0dd424-d905-4fc5-a73c-36254fdd470c/crypt/debug                                                           4939df35-a183-4c85-9872-5ced516bd154   100 GiB   none          gzip-9     
-    oxp_794df76f-bca0-4635-9eb6-773ad0108f7e/crypt/debug                                                           35f7f5fc-0d30-442d-b74a-7ef63b13bb6d   100 GiB   none          gzip-9     
-    oxp_9024d350-38a7-459b-8550-3b2c4a88b5c1/crypt/debug                                                           d6fee205-15ef-41f9-8719-bc0be41ca283   100 GiB   none          gzip-9     
-    oxp_95e86080-e162-4980-a589-db6bb1a95ca7/crypt/debug                                                           c2e8fc9e-40d5-4ba5-b9e6-bd4ac88b0e7b   100 GiB   none          gzip-9     
-    oxp_d55d36d7-df92-4615-944d-440a1f8b5001/crypt/debug                                                           05b52b8d-dd52-4a9e-b647-445959885d68   100 GiB   none          gzip-9     
-    oxp_db6686c8-2dd9-4032-8444-2a06b43baa68/crypt/debug                                                           f5e9ef79-2d90-4839-aeac-a1048516011e   100 GiB   none          gzip-9     
+    oxp_12057b4a-0b06-4f70-ba22-336de2385bfe/crucible                                                              55136aae-73db-46b2-bd32-e26634f865ed   none      none          off        
+    oxp_29758363-6c77-40c3-8740-9c0c64f6e14a/crucible                                                              5c4eda29-ed3e-4dc6-b756-afafa1c216b8   none      none          off        
+    oxp_3f331c10-7882-48ab-85d9-05108490b55b/crucible                                                              9b5d5293-2546-43f0-b953-73a696cad4bf   none      none          off        
+    oxp_5152d1aa-9045-4e06-9ef6-6eadac3696e4/crucible                                                              74c65a92-1d4a-44cc-9a55-cd540e9fb57e   none      none          off        
+    oxp_5c0dd424-d905-4fc5-a73c-36254fdd470c/crucible                                                              cc25055b-483e-46ab-a5bf-1d8838b846fd   none      none          off        
+    oxp_794df76f-bca0-4635-9eb6-773ad0108f7e/crucible                                                              8270e505-beff-480a-955b-bf96c4b1a9a3   none      none          off        
+    oxp_9024d350-38a7-459b-8550-3b2c4a88b5c1/crucible                                                              ea234d9d-291b-4adf-9d96-48b7945c2892   none      none          off        
+    oxp_95e86080-e162-4980-a589-db6bb1a95ca7/crucible                                                              d8d9a6d4-f6be-4044-8eac-b994aa166053   none      none          off        
+    oxp_d55d36d7-df92-4615-944d-440a1f8b5001/crucible                                                              64955a3e-2059-4d16-aee4-f63f9362b554   none      none          off        
+    oxp_db6686c8-2dd9-4032-8444-2a06b43baa68/crucible                                                              863c76ac-732e-4d10-b7a3-1d6ba02dc1f5   none      none          off        
+    oxp_12057b4a-0b06-4f70-ba22-336de2385bfe/crypt/internal_dns                                                    b4df380c-6cca-41c1-b79c-45671067d459   none      none          off        
+    oxp_12057b4a-0b06-4f70-ba22-336de2385bfe/crypt/zone                                                            9bcac944-9866-4251-b333-1cbdc137a03e   none      none          off        
+    oxp_29758363-6c77-40c3-8740-9c0c64f6e14a/crypt/zone                                                            0557de8a-45cf-44a0-a39d-4a7095e9045b   none      none          off        
+    oxp_3f331c10-7882-48ab-85d9-05108490b55b/crypt/zone                                                            5f5e1e10-1561-4556-aac1-6b6285df5cb2   none      none          off        
+    oxp_5152d1aa-9045-4e06-9ef6-6eadac3696e4/crypt/zone                                                            52d9152d-e80a-455e-b24a-70b5d2ffc372   none      none          off        
+    oxp_5c0dd424-d905-4fc5-a73c-36254fdd470c/crypt/zone                                                            1b990bb0-ea73-430c-bafa-6eb5647af125   none      none          off        
+    oxp_794df76f-bca0-4635-9eb6-773ad0108f7e/crypt/zone                                                            4fc058ac-95d8-4ea4-808c-6b976e95449e   none      none          off        
+    oxp_9024d350-38a7-459b-8550-3b2c4a88b5c1/crypt/zone                                                            208cd4b7-be74-4187-a4e3-21e518bc92a6   none      none          off        
+    oxp_95e86080-e162-4980-a589-db6bb1a95ca7/crypt/zone                                                            bf66b843-7c47-4e46-b629-267111de97b5   none      none          off        
+    oxp_d55d36d7-df92-4615-944d-440a1f8b5001/crypt/zone                                                            5672e912-aa12-4614-b79b-5fcf548e9d96   none      none          off        
+    oxp_db6686c8-2dd9-4032-8444-2a06b43baa68/crypt/zone                                                            99d7b142-b462-4a67-b84e-f3fc79e761fd   none      none          off        
+    oxp_95e86080-e162-4980-a589-db6bb1a95ca7/crypt/zone/oxz_crucible_1437bb47-a2d3-48e9-8902-021ff5057d26          3dd86436-a934-44a8-97b2-1848ab6ebbc9   none      none          off        
+    oxp_5c0dd424-d905-4fc5-a73c-36254fdd470c/crypt/zone/oxz_crucible_31f49108-cdda-4659-bf24-319bf99a9c20          faa7fe52-a532-4784-84f3-376dc8334fdd   none      none          off        
+    oxp_29758363-6c77-40c3-8740-9c0c64f6e14a/crypt/zone/oxz_crucible_5152e5e7-8615-407d-beed-37fd03852ad6          5def9f9d-7e1f-4ef0-94cf-b26f21e6da07   none      none          off        
+    oxp_3f331c10-7882-48ab-85d9-05108490b55b/crypt/zone/oxz_crucible_6593648a-53f3-4a0f-b902-ef6cd7eab43b          9651f8ed-ae45-476c-bca4-42ebe6ee1618   none      none          off        
+    oxp_d55d36d7-df92-4615-944d-440a1f8b5001/crypt/zone/oxz_crucible_754bae61-cbff-402f-b250-91bec499b449          8e72b070-ef13-4082-bcf8-2c54488a4ae1   none      none          off        
+    oxp_12057b4a-0b06-4f70-ba22-336de2385bfe/crypt/zone/oxz_crucible_8f316745-d46d-47cb-8c7e-678fd9021c40          d508ecc2-baf5-4299-9799-e6d30f83663e   none      none          off        
+    oxp_9024d350-38a7-459b-8550-3b2c4a88b5c1/crypt/zone/oxz_crucible_9fdb739d-b149-4f8f-b488-b97d16ea284a          96dc8dcd-700b-4dd7-8970-568e91b93948   none      none          off        
+    oxp_db6686c8-2dd9-4032-8444-2a06b43baa68/crypt/zone/oxz_crucible_b23471ff-b35a-4919-aa3f-3c3683fa3210          646e79ac-9828-4a8d-8173-e385f5e65a15   none      none          off        
+    oxp_794df76f-bca0-4635-9eb6-773ad0108f7e/crypt/zone/oxz_crucible_fa8963b6-dad1-4cf8-9243-c77b3f86d654          2dd82bf7-cad0-4725-ba7d-0cf40b725b39   none      none          off        
+    oxp_5152d1aa-9045-4e06-9ef6-6eadac3696e4/crypt/zone/oxz_crucible_ff5bf6ea-ab3e-40c5-a9a5-cb2bc89de9c8          ead9603d-c1ea-4ea8-9ca7-f3bc31718458   none      none          off        
+    oxp_12057b4a-0b06-4f70-ba22-336de2385bfe/crypt/zone/oxz_crucible_pantry_634fc0b7-9f95-494d-939b-28819cbcaa2b   be2863b0-0d23-4fd4-92e8-ffc4184e5742   none      none          off        
+    oxp_12057b4a-0b06-4f70-ba22-336de2385bfe/crypt/zone/oxz_internal_dns_92628102-eef4-4000-a061-1df796db3806      998bf38c-b6ec-4ddd-80ac-59fc1ee30ca2   none      none          off        
+    oxp_12057b4a-0b06-4f70-ba22-336de2385bfe/crypt/zone/oxz_nexus_7a3ea24a-85f4-4aad-a935-4e7b22766985             73e12d19-7957-4c44-b3e0-fef8d2ad4826   none      none          off        
+    oxp_12057b4a-0b06-4f70-ba22-336de2385bfe/crypt/zone/oxz_ntp_edd3fb4a-6ea7-49a5-82fb-444dfcf6fcc5               305f5727-4d83-4282-9efe-f776ad63aef9   none      none          off        
+    oxp_12057b4a-0b06-4f70-ba22-336de2385bfe/crypt/debug                                                           b3261747-8c28-4c02-8ab7-be1b8cab03fe   100 GiB   none          gzip-9     
+    oxp_29758363-6c77-40c3-8740-9c0c64f6e14a/crypt/debug                                                           be79f715-8cc9-475c-81dd-f3a8141df986   100 GiB   none          gzip-9     
+    oxp_3f331c10-7882-48ab-85d9-05108490b55b/crypt/debug                                                           b0f40911-5074-4dad-bcf9-269e20793f6f   100 GiB   none          gzip-9     
+    oxp_5152d1aa-9045-4e06-9ef6-6eadac3696e4/crypt/debug                                                           1f81c8ba-d0b2-4c24-b8b8-90a5a3148b2a   100 GiB   none          gzip-9     
+    oxp_5c0dd424-d905-4fc5-a73c-36254fdd470c/crypt/debug                                                           b489b3a7-eb94-481f-805d-c93958f566dd   100 GiB   none          gzip-9     
+    oxp_794df76f-bca0-4635-9eb6-773ad0108f7e/crypt/debug                                                           903e2867-5fc0-487b-9d9c-9afe60731a6c   100 GiB   none          gzip-9     
+    oxp_9024d350-38a7-459b-8550-3b2c4a88b5c1/crypt/debug                                                           a02260de-3336-4cbf-ba45-ff79586b40fa   100 GiB   none          gzip-9     
+    oxp_95e86080-e162-4980-a589-db6bb1a95ca7/crypt/debug                                                           667d664c-c5a1-4b77-a54c-6bbb1bcc2096   100 GiB   none          gzip-9     
+    oxp_d55d36d7-df92-4615-944d-440a1f8b5001/crypt/debug                                                           4f4ad767-8887-4892-b6c7-5bc652f3d673   100 GiB   none          gzip-9     
+    oxp_db6686c8-2dd9-4032-8444-2a06b43baa68/crypt/debug                                                           f5b987f9-0a34-4394-8fc5-2ee12bf3e9bf   100 GiB   none          gzip-9     
 
 
     omicron zones at generation 2:
     ---------------------------------------------------------------------------------------------
     zone type         zone id                                disposition   underlay IP           
     ---------------------------------------------------------------------------------------------
-    crucible          2a455c35-eb3c-4c73-ab6c-d0a706e25316   in service    fd00:1122:3344:101::25
-    crucible          47199d48-534c-4267-a654-d2d90e64b498   in service    fd00:1122:3344:101::29
-    crucible          587be699-a320-4c79-b320-128d9ecddc0b   in service    fd00:1122:3344:101::27
-    crucible          6fa06115-4959-4913-8e7b-dd70d7651f07   in service    fd00:1122:3344:101::28
-    crucible          704e1fed-f8d6-4cfa-a470-bad27fdc06d1   in service    fd00:1122:3344:101::2a
-    crucible          8f3a1cc5-9195-4a30-ad02-b804278fe639   in service    fd00:1122:3344:101::24
-    crucible          a2079cbc-a69e-41a1-b1e0-fbcb972d03f6   in service    fd00:1122:3344:101::26
-    crucible          af322036-371f-437c-8c08-7f40f3f1403b   in service    fd00:1122:3344:101::2b
-    crucible          d637264f-6f40-44c2-8b7e-a179430210d2   in service    fd00:1122:3344:101::2d
-    crucible          edabedf3-839c-488d-ad6f-508ffa864674   in service    fd00:1122:3344:101::2c
-    crucible_pantry   02acbe6a-1c88-47e3-94c3-94084cbde098   in service    fd00:1122:3344:101::23
-    internal_dns      07c3c805-8888-4fe5-9543-3d2479dbe6f3   in service    fd00:1122:3344:2::1   
-    internal_ntp      10d98a73-ec88-4aff-a7e8-7db6a87880e6   in service    fd00:1122:3344:101::21
-    nexus             a1696cd4-588c-484a-b95b-66e824c0ce05   in service    fd00:1122:3344:101::22
+    crucible          1437bb47-a2d3-48e9-8902-021ff5057d26   in service    fd00:1122:3344:101::2b
+    crucible          31f49108-cdda-4659-bf24-319bf99a9c20   in service    fd00:1122:3344:101::28
+    crucible          5152e5e7-8615-407d-beed-37fd03852ad6   in service    fd00:1122:3344:101::25
+    crucible          6593648a-53f3-4a0f-b902-ef6cd7eab43b   in service    fd00:1122:3344:101::26
+    crucible          754bae61-cbff-402f-b250-91bec499b449   in service    fd00:1122:3344:101::2c
+    crucible          8f316745-d46d-47cb-8c7e-678fd9021c40   in service    fd00:1122:3344:101::24
+    crucible          9fdb739d-b149-4f8f-b488-b97d16ea284a   in service    fd00:1122:3344:101::2a
+    crucible          b23471ff-b35a-4919-aa3f-3c3683fa3210   in service    fd00:1122:3344:101::2d
+    crucible          fa8963b6-dad1-4cf8-9243-c77b3f86d654   in service    fd00:1122:3344:101::29
+    crucible          ff5bf6ea-ab3e-40c5-a9a5-cb2bc89de9c8   in service    fd00:1122:3344:101::27
+    crucible_pantry   634fc0b7-9f95-494d-939b-28819cbcaa2b   in service    fd00:1122:3344:101::23
+    internal_dns      92628102-eef4-4000-a061-1df796db3806   in service    fd00:1122:3344:2::1   
+    internal_ntp      edd3fb4a-6ea7-49a5-82fb-444dfcf6fcc5   in service    fd00:1122:3344:101::21
+    nexus             7a3ea24a-85f4-4aad-a935-4e7b22766985   in service    fd00:1122:3344:101::22
 
 
   sled 590e3034-d946-4166-b0e5-2d0034197a07 (active):
@@ -206,71 +206,71 @@ to:   blueprint f432fcd5-1284-4058-8b4a-9286a3de6163
     -----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
     dataset name                                                                                                   dataset uuid                           quota     reservation   compression
     -----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
-    oxp_2a94863d-16e2-4535-973b-e98dd47fd18d/crucible                                                              35656b97-3eef-46f2-aab0-4d33a3548e62   none      none          off        
-    oxp_32456d15-f5b6-4efc-90c8-dbba979b69cb/crucible                                                              3b4f5bbb-cc50-49ae-a208-ca88dff1f361   none      none          off        
-    oxp_416fe9f9-5161-4b0f-9e11-c9d81563ded5/crucible                                                              8b82f804-50d1-4e6f-8899-181433d82299   none      none          off        
-    oxp_4c68800e-23f8-485b-b251-628fd151e445/crucible                                                              226cea90-799d-4f6c-90c6-459d2d7674c1   none      none          off        
-    oxp_9dd87c4d-5fb4-475a-86fa-c0da81a3e00a/crucible                                                              d5cd0c03-b555-46b2-b626-cc70bd931cee   none      none          off        
-    oxp_be93a517-445e-46c2-aa21-3dc526d4a413/crucible                                                              52fde46c-85f4-470e-8c1e-38b13c042620   none      none          off        
-    oxp_d9344e2b-84d2-4392-84ab-41b86ed02237/crucible                                                              4b593475-e809-4822-a2fe-c58b2f7964d5   none      none          off        
-    oxp_eab188d0-b34a-4673-b254-12e705597654/crucible                                                              444a65f5-d04e-4cb0-a29d-ba57e34143dd   none      none          off        
-    oxp_f1e0386f-11b6-4cdf-8250-826d256db6b5/crucible                                                              826e2ca8-f30d-4ca3-8360-f03ddd883a6a   none      none          off        
-    oxp_f8c9c9a9-d73e-4cdf-a9af-03cfbbbce12b/crucible                                                              2c6ade05-a626-4b25-a28c-551b91867dbe   none      none          off        
-    oxp_2a94863d-16e2-4535-973b-e98dd47fd18d/crypt/internal_dns                                                    b0fcbafd-55cc-49f1-9e02-20503673b34f   none      none          off        
-    oxp_2a94863d-16e2-4535-973b-e98dd47fd18d/crypt/zone                                                            0b216cae-701c-4341-a48a-690543b8e1e9   none      none          off        
-    oxp_32456d15-f5b6-4efc-90c8-dbba979b69cb/crypt/zone                                                            dce1da41-4cf0-4f70-a9e5-f4b7fad54228   none      none          off        
-    oxp_416fe9f9-5161-4b0f-9e11-c9d81563ded5/crypt/zone                                                            5dd03902-3f33-4f7e-896a-c08d7c6e37f1   none      none          off        
-    oxp_4c68800e-23f8-485b-b251-628fd151e445/crypt/zone                                                            447cc163-589e-479c-a73d-0071e5dc59bf   none      none          off        
-    oxp_9dd87c4d-5fb4-475a-86fa-c0da81a3e00a/crypt/zone                                                            0568d976-0079-4d6e-9d1f-a8cfc4b044df   none      none          off        
-    oxp_be93a517-445e-46c2-aa21-3dc526d4a413/crypt/zone                                                            f75ef0e7-663d-4418-99b6-71e2a77a27e3   none      none          off        
-    oxp_d9344e2b-84d2-4392-84ab-41b86ed02237/crypt/zone                                                            aa37e2bb-8d16-4dc2-a549-5f265fdad77c   none      none          off        
-    oxp_eab188d0-b34a-4673-b254-12e705597654/crypt/zone                                                            a79b0ad5-06b8-466c-928c-39e311ace5ff   none      none          off        
-    oxp_f1e0386f-11b6-4cdf-8250-826d256db6b5/crypt/zone                                                            1635dad8-971f-4409-aca3-6204eafec699   none      none          off        
-    oxp_f8c9c9a9-d73e-4cdf-a9af-03cfbbbce12b/crypt/zone                                                            1b5a2379-ec60-47f0-8def-fa3ab5c2487c   none      none          off        
-    oxp_9dd87c4d-5fb4-475a-86fa-c0da81a3e00a/crypt/zone/oxz_crucible_0565e7e4-f13a-4123-8928-d715f83e36aa          e2de5537-a289-49ac-8a61-65805a35755e   none      none          off        
-    oxp_d9344e2b-84d2-4392-84ab-41b86ed02237/crypt/zone/oxz_crucible_062ce37d-7448-4d44-b1f4-4937cd2eb174          bfbfe7dd-06b3-4d01-988d-488c7b9400ee   none      none          off        
-    oxp_f8c9c9a9-d73e-4cdf-a9af-03cfbbbce12b/crypt/zone/oxz_crucible_1211a68e-69a1-4ef4-b790-45b0279f9159          32a3e82a-b97a-455a-b428-1f934c59eb46   none      none          off        
-    oxp_2a94863d-16e2-4535-973b-e98dd47fd18d/crypt/zone/oxz_crucible_18f8fe40-646e-4962-b17a-20e201f3a6e5          eec6f425-d377-42b2-890f-c8c3efe173d1   none      none          off        
-    oxp_4c68800e-23f8-485b-b251-628fd151e445/crypt/zone/oxz_crucible_1cc3f503-2001-4d85-80e5-c7c40d2e3b10          5a210076-5d38-42f0-915c-c09f67ff38af   none      none          off        
-    oxp_be93a517-445e-46c2-aa21-3dc526d4a413/crypt/zone/oxz_crucible_62058f4c-c747-4e21-a8dc-2fd4a160c98c          0679ecb0-7759-4561-a81a-d8d7125ed693   none      none          off        
-    oxp_32456d15-f5b6-4efc-90c8-dbba979b69cb/crypt/zone/oxz_crucible_6af7f4d6-33b6-4eb3-a146-d8e9e4ae9d66          a33e3d63-6413-42b2-8cf0-02c774666916   none      none          off        
-    oxp_eab188d0-b34a-4673-b254-12e705597654/crypt/zone/oxz_crucible_78d6ab36-e8c8-4ff8-9f89-75c7fe2d32e6          ebc48adb-4dad-41dd-a547-13f2517a9db7   none      none          off        
-    oxp_416fe9f9-5161-4b0f-9e11-c9d81563ded5/crypt/zone/oxz_crucible_93f2f40c-5616-4d8d-8519-ec6debdcede0          4c0303d2-205d-4644-b55a-5c74bbce54c3   none      none          off        
-    oxp_f1e0386f-11b6-4cdf-8250-826d256db6b5/crypt/zone/oxz_crucible_9f824c30-6360-46b9-87c4-cd60586476fe          c4e2119e-4cd0-48e7-878f-fd676cb95094   none      none          off        
-    oxp_2a94863d-16e2-4535-973b-e98dd47fd18d/crypt/zone/oxz_crucible_pantry_56d5d7cf-db2c-40a3-a775-003241ad4820   ada776f0-dbb1-4430-a60a-f7462570a19c   none      none          off        
-    oxp_2a94863d-16e2-4535-973b-e98dd47fd18d/crypt/zone/oxz_internal_dns_ab7ba6df-d401-40bd-940e-faf57c57aa2a      2fe942e9-085c-4155-a415-c2dcc19dbd91   none      none          off        
-    oxp_2a94863d-16e2-4535-973b-e98dd47fd18d/crypt/zone/oxz_nexus_dce226c9-7373-4bfa-8a94-79dc472857a6             4abeefa4-e5ad-46e9-b056-79f5950a5639   none      none          off        
-    oxp_2a94863d-16e2-4535-973b-e98dd47fd18d/crypt/zone/oxz_ntp_7a9f60d3-2b66-4547-9b63-7d4f7a8b6382               63337e4d-61a8-4dc7-a322-1442bc19b347   none      none          off        
-    oxp_2a94863d-16e2-4535-973b-e98dd47fd18d/crypt/debug                                                           bdf9f107-3a76-4d6a-bea0-5cfb4d3cd6a6   100 GiB   none          gzip-9     
-    oxp_32456d15-f5b6-4efc-90c8-dbba979b69cb/crypt/debug                                                           cc56ea63-0ae3-48ce-8faf-1bd7d83eb148   100 GiB   none          gzip-9     
-    oxp_416fe9f9-5161-4b0f-9e11-c9d81563ded5/crypt/debug                                                           abe29a15-fef4-47ef-8f08-71645f396213   100 GiB   none          gzip-9     
-    oxp_4c68800e-23f8-485b-b251-628fd151e445/crypt/debug                                                           32535344-4e21-4fb3-9c43-f305ac367efb   100 GiB   none          gzip-9     
-    oxp_9dd87c4d-5fb4-475a-86fa-c0da81a3e00a/crypt/debug                                                           7d983611-ab39-4083-93d0-f57f3ada9a0f   100 GiB   none          gzip-9     
-    oxp_be93a517-445e-46c2-aa21-3dc526d4a413/crypt/debug                                                           731caeb5-c24f-45b7-aafa-4e747302eaa4   100 GiB   none          gzip-9     
-    oxp_d9344e2b-84d2-4392-84ab-41b86ed02237/crypt/debug                                                           19bdebd5-9757-409f-ac06-2b309379975e   100 GiB   none          gzip-9     
-    oxp_eab188d0-b34a-4673-b254-12e705597654/crypt/debug                                                           411e3457-3113-40d2-8a7d-747b108e0de7   100 GiB   none          gzip-9     
-    oxp_f1e0386f-11b6-4cdf-8250-826d256db6b5/crypt/debug                                                           79ce0088-d8a8-46ff-ac72-958b8db65e67   100 GiB   none          gzip-9     
-    oxp_f8c9c9a9-d73e-4cdf-a9af-03cfbbbce12b/crypt/debug                                                           2059b139-6510-4447-aa56-cf995ef469a2   100 GiB   none          gzip-9     
+    oxp_2a94863d-16e2-4535-973b-e98dd47fd18d/crucible                                                              852963f5-4c4b-4bd9-a5b6-25ea416c25fe   none      none          off        
+    oxp_32456d15-f5b6-4efc-90c8-dbba979b69cb/crucible                                                              d37faff5-a0a8-4b60-bb33-508c478fe1c9   none      none          off        
+    oxp_416fe9f9-5161-4b0f-9e11-c9d81563ded5/crucible                                                              c096ba5f-adbf-498d-8ea5-ba736454d9fb   none      none          off        
+    oxp_4c68800e-23f8-485b-b251-628fd151e445/crucible                                                              56661c11-0041-4ffd-8a0c-72b5fc0486b9   none      none          off        
+    oxp_9dd87c4d-5fb4-475a-86fa-c0da81a3e00a/crucible                                                              b6a3f4cf-27f4-4ba8-b063-b4b3c7b03cc3   none      none          off        
+    oxp_be93a517-445e-46c2-aa21-3dc526d4a413/crucible                                                              f32a5631-dd04-4e2d-a9f9-b5974253601d   none      none          off        
+    oxp_d9344e2b-84d2-4392-84ab-41b86ed02237/crucible                                                              a15aacbb-53de-45e0-a646-a88817c929c6   none      none          off        
+    oxp_eab188d0-b34a-4673-b254-12e705597654/crucible                                                              932f321c-10ae-476a-9721-33b5e76fb989   none      none          off        
+    oxp_f1e0386f-11b6-4cdf-8250-826d256db6b5/crucible                                                              ad47c2f1-68ea-413f-ad9e-0975d02a0e11   none      none          off        
+    oxp_f8c9c9a9-d73e-4cdf-a9af-03cfbbbce12b/crucible                                                              9861aeea-9a0c-4fc7-b3d7-e80f3e5c88a5   none      none          off        
+    oxp_2a94863d-16e2-4535-973b-e98dd47fd18d/crypt/internal_dns                                                    a8eea986-61ba-4723-a97c-61f911210031   none      none          off        
+    oxp_2a94863d-16e2-4535-973b-e98dd47fd18d/crypt/zone                                                            3938e220-b204-4f50-bd73-9c835eb4dea7   none      none          off        
+    oxp_32456d15-f5b6-4efc-90c8-dbba979b69cb/crypt/zone                                                            ba8d7bd5-7282-468c-bba6-28462b5400ff   none      none          off        
+    oxp_416fe9f9-5161-4b0f-9e11-c9d81563ded5/crypt/zone                                                            57497a15-47dd-4eca-a52a-1ee1a3a005b4   none      none          off        
+    oxp_4c68800e-23f8-485b-b251-628fd151e445/crypt/zone                                                            44a73f30-9601-4fbd-9699-deb600252cb1   none      none          off        
+    oxp_9dd87c4d-5fb4-475a-86fa-c0da81a3e00a/crypt/zone                                                            6ce8fc11-2f6e-4c7a-b026-d2f05ee49c8f   none      none          off        
+    oxp_be93a517-445e-46c2-aa21-3dc526d4a413/crypt/zone                                                            babe6a59-94f6-4fbb-b49e-2fda486cc39e   none      none          off        
+    oxp_d9344e2b-84d2-4392-84ab-41b86ed02237/crypt/zone                                                            69686d88-8e89-4137-9377-3e1b61995d79   none      none          off        
+    oxp_eab188d0-b34a-4673-b254-12e705597654/crypt/zone                                                            f1a436b2-d773-4b72-ad3a-fc5d03ae9855   none      none          off        
+    oxp_f1e0386f-11b6-4cdf-8250-826d256db6b5/crypt/zone                                                            8196e6fd-4094-4bc9-ad43-1d774de79b25   none      none          off        
+    oxp_f8c9c9a9-d73e-4cdf-a9af-03cfbbbce12b/crypt/zone                                                            de91df2d-b85b-4300-82f4-70ee5d0c8f71   none      none          off        
+    oxp_32456d15-f5b6-4efc-90c8-dbba979b69cb/crypt/zone/oxz_crucible_3b49c2c6-0b0b-4a11-be95-bf94c1cb54a8          e033c975-ab2f-4d39-96e1-02fc6d95e58f   none      none          off        
+    oxp_d9344e2b-84d2-4392-84ab-41b86ed02237/crypt/zone/oxz_crucible_4c65501d-a08d-4fe5-9c78-2694ce6b3a43          28c2eb82-e779-4629-91af-633e4460cd21   none      none          off        
+    oxp_eab188d0-b34a-4673-b254-12e705597654/crypt/zone/oxz_crucible_60e74b27-a7d7-475e-b5ce-2a92eff4fa63          362a51ca-7116-4df3-96bd-5383c32b33f3   none      none          off        
+    oxp_f1e0386f-11b6-4cdf-8250-826d256db6b5/crypt/zone/oxz_crucible_68f44e7e-8231-40c0-861e-2f4d0c2eb392          1db171be-4a44-473a-bfa0-c9dda78fed77   none      none          off        
+    oxp_2a94863d-16e2-4535-973b-e98dd47fd18d/crypt/zone/oxz_crucible_74fc3000-c4b7-4687-88b5-a27584b45434          00218e6a-5e1b-450c-ad38-624ad37d2fc4   none      none          off        
+    oxp_f8c9c9a9-d73e-4cdf-a9af-03cfbbbce12b/crypt/zone/oxz_crucible_83ae0625-2e61-4637-a1f9-473b21b94f72          418a8d5c-fbe8-46c0-b260-e77eb2235105   none      none          off        
+    oxp_416fe9f9-5161-4b0f-9e11-c9d81563ded5/crypt/zone/oxz_crucible_9b462d74-c05a-4a7e-8d24-449c848a7b13          bea24fa2-353f-4c13-844d-3ce58d682eb7   none      none          off        
+    oxp_be93a517-445e-46c2-aa21-3dc526d4a413/crypt/zone/oxz_crucible_a9ed9f72-e57d-4092-ab0e-bb2000a5459e          dda0482e-cffe-4230-9370-9eebfb9c7121   none      none          off        
+    oxp_4c68800e-23f8-485b-b251-628fd151e445/crypt/zone/oxz_crucible_d84bc314-4895-4331-8afb-22bffdd56699          17f7d94a-7734-4b3b-a108-dc11b114610e   none      none          off        
+    oxp_9dd87c4d-5fb4-475a-86fa-c0da81a3e00a/crypt/zone/oxz_crucible_f1f03b7d-916e-4c5f-8906-1e18e498184d          3f1fb9c9-8a05-44fc-af26-eb71bec3b890   none      none          off        
+    oxp_2a94863d-16e2-4535-973b-e98dd47fd18d/crypt/zone/oxz_crucible_pantry_ecdc7438-a007-4558-96b3-65bdab21a8a9   f48c22cc-5ff7-4170-bdbd-bd082c882de3   none      none          off        
+    oxp_2a94863d-16e2-4535-973b-e98dd47fd18d/crypt/zone/oxz_internal_dns_c1049e2e-7269-4de0-b96e-2e9f8edc90ea      67f5eef3-2c29-4a5c-9664-81dbd5ed55a5   none      none          off        
+    oxp_2a94863d-16e2-4535-973b-e98dd47fd18d/crypt/zone/oxz_nexus_785868d0-a003-4860-acc1-9beee9f39816             2a2e9b25-83b8-4bc3-b934-723c947f56d7   none      none          off        
+    oxp_2a94863d-16e2-4535-973b-e98dd47fd18d/crypt/zone/oxz_ntp_d5b390d3-7280-4d2b-b670-340f91d7ebd7               7b3fae75-9421-4a8d-8524-b17a540f994e   none      none          off        
+    oxp_2a94863d-16e2-4535-973b-e98dd47fd18d/crypt/debug                                                           5eb19f06-e5e9-4b96-b1c3-84355460b2ea   100 GiB   none          gzip-9     
+    oxp_32456d15-f5b6-4efc-90c8-dbba979b69cb/crypt/debug                                                           89ab2d4a-101f-46c5-8bb8-2c93dbe2d020   100 GiB   none          gzip-9     
+    oxp_416fe9f9-5161-4b0f-9e11-c9d81563ded5/crypt/debug                                                           12f242f1-44e6-449d-9dfd-b4c5c1bb5ddf   100 GiB   none          gzip-9     
+    oxp_4c68800e-23f8-485b-b251-628fd151e445/crypt/debug                                                           45d68f02-6f5a-4c8b-9a59-e4554ebbeff7   100 GiB   none          gzip-9     
+    oxp_9dd87c4d-5fb4-475a-86fa-c0da81a3e00a/crypt/debug                                                           e0e621f0-62f6-4425-a4b0-ff659c63ea11   100 GiB   none          gzip-9     
+    oxp_be93a517-445e-46c2-aa21-3dc526d4a413/crypt/debug                                                           b90bbe6c-15d2-4313-9fce-c1b9ccdf38d3   100 GiB   none          gzip-9     
+    oxp_d9344e2b-84d2-4392-84ab-41b86ed02237/crypt/debug                                                           3bae870d-ae7b-4e95-b4ea-419ba251839b   100 GiB   none          gzip-9     
+    oxp_eab188d0-b34a-4673-b254-12e705597654/crypt/debug                                                           b7284180-362b-42ba-b970-90c27a8468c5   100 GiB   none          gzip-9     
+    oxp_f1e0386f-11b6-4cdf-8250-826d256db6b5/crypt/debug                                                           d814aea1-475f-44c2-8dcc-e2cd2d335bf9   100 GiB   none          gzip-9     
+    oxp_f8c9c9a9-d73e-4cdf-a9af-03cfbbbce12b/crypt/debug                                                           fdd77b3a-5ec9-4e1a-bc62-379baa7c5552   100 GiB   none          gzip-9     
 
 
     omicron zones at generation 2:
     ---------------------------------------------------------------------------------------------
     zone type         zone id                                disposition   underlay IP           
     ---------------------------------------------------------------------------------------------
-    crucible          0565e7e4-f13a-4123-8928-d715f83e36aa   in service    fd00:1122:3344:102::28
-    crucible          062ce37d-7448-4d44-b1f4-4937cd2eb174   in service    fd00:1122:3344:102::2a
-    crucible          1211a68e-69a1-4ef4-b790-45b0279f9159   in service    fd00:1122:3344:102::2d
-    crucible          18f8fe40-646e-4962-b17a-20e201f3a6e5   in service    fd00:1122:3344:102::24
-    crucible          1cc3f503-2001-4d85-80e5-c7c40d2e3b10   in service    fd00:1122:3344:102::27
-    crucible          62058f4c-c747-4e21-a8dc-2fd4a160c98c   in service    fd00:1122:3344:102::29
-    crucible          6af7f4d6-33b6-4eb3-a146-d8e9e4ae9d66   in service    fd00:1122:3344:102::25
-    crucible          78d6ab36-e8c8-4ff8-9f89-75c7fe2d32e6   in service    fd00:1122:3344:102::2b
-    crucible          93f2f40c-5616-4d8d-8519-ec6debdcede0   in service    fd00:1122:3344:102::26
-    crucible          9f824c30-6360-46b9-87c4-cd60586476fe   in service    fd00:1122:3344:102::2c
-    crucible_pantry   56d5d7cf-db2c-40a3-a775-003241ad4820   in service    fd00:1122:3344:102::23
-    internal_dns      ab7ba6df-d401-40bd-940e-faf57c57aa2a   in service    fd00:1122:3344:3::1   
-    internal_ntp      7a9f60d3-2b66-4547-9b63-7d4f7a8b6382   in service    fd00:1122:3344:102::21
-    nexus             dce226c9-7373-4bfa-8a94-79dc472857a6   in service    fd00:1122:3344:102::22
+    crucible          3b49c2c6-0b0b-4a11-be95-bf94c1cb54a8   in service    fd00:1122:3344:102::25
+    crucible          4c65501d-a08d-4fe5-9c78-2694ce6b3a43   in service    fd00:1122:3344:102::2a
+    crucible          60e74b27-a7d7-475e-b5ce-2a92eff4fa63   in service    fd00:1122:3344:102::2b
+    crucible          68f44e7e-8231-40c0-861e-2f4d0c2eb392   in service    fd00:1122:3344:102::2c
+    crucible          74fc3000-c4b7-4687-88b5-a27584b45434   in service    fd00:1122:3344:102::24
+    crucible          83ae0625-2e61-4637-a1f9-473b21b94f72   in service    fd00:1122:3344:102::2d
+    crucible          9b462d74-c05a-4a7e-8d24-449c848a7b13   in service    fd00:1122:3344:102::26
+    crucible          a9ed9f72-e57d-4092-ab0e-bb2000a5459e   in service    fd00:1122:3344:102::29
+    crucible          d84bc314-4895-4331-8afb-22bffdd56699   in service    fd00:1122:3344:102::27
+    crucible          f1f03b7d-916e-4c5f-8906-1e18e498184d   in service    fd00:1122:3344:102::28
+    crucible_pantry   ecdc7438-a007-4558-96b3-65bdab21a8a9   in service    fd00:1122:3344:102::23
+    internal_dns      c1049e2e-7269-4de0-b96e-2e9f8edc90ea   in service    fd00:1122:3344:3::1   
+    internal_ntp      d5b390d3-7280-4d2b-b670-340f91d7ebd7   in service    fd00:1122:3344:102::21
+    nexus             785868d0-a003-4860-acc1-9beee9f39816   in service    fd00:1122:3344:102::22
 
 
  MODIFIED SLEDS:
@@ -297,64 +297,64 @@ to:   blueprint f432fcd5-1284-4058-8b4a-9286a3de6163
     ----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
     dataset name                                                                                            dataset uuid                           quota     reservation   compression
     ----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
-    oxp_28699448-c5d9-49ea-bf7e-627800efe783/crypt/zone                                                     07381a6a-e397-4ff9-a2a6-8f1e46c47eb3   none      none          off        
-    oxp_2c490e96-27f2-4a7f-b440-04d4bfd1e4f6/crypt/zone                                                     b4c23ac2-86af-4b47-9d8d-35eff7997788   none      none          off        
-    oxp_4c3bb1c7-55b6-49b8-b212-516b8f2c26c2/crypt/zone                                                     32143abb-e501-450b-9398-7d4dbebdf4a1   none      none          off        
-    oxp_5db07562-31a8-43e3-b99e-7c7cb89754b7/crypt/zone                                                     6ec35c5c-9d6c-4d72-8bec-af91069ef7a9   none      none          off        
-    oxp_9451a5d5-b358-4719-b6c1-a0d187da217c/crypt/zone                                                     8529e7f8-8c11-4869-b330-83ddc45ed17a   none      none          off        
-    oxp_bb2e2869-9481-483a-bc49-2bdd62f515f5/crypt/zone                                                     940f06cb-822f-4034-8d34-e14bcc6ea998   none      none          off        
-    oxp_d5a36c66-4b2f-46e6-96f4-b82debee1a4a/crypt/zone                                                     0507b005-e018-4b69-9d84-50faf61e792f   none      none          off        
-    oxp_f99ec996-ec08-4ccf-9a6e-6c5cab440fb4/crypt/zone                                                     1acaf776-970a-49cf-9f1c-7d8e3146ef11   none      none          off        
-    oxp_faccbb39-d686-42a1-a50a-0eb59ba74a87/crypt/zone                                                     1bd5ab24-2a54-438f-bae0-af1b06a3cc41   none      none          off        
-    oxp_fdfd067b-1d86-444d-a21f-ed33709f3e4d/crypt/zone                                                     b501adbf-be36-4724-9409-329f690fb09d   none      none          off        
-    oxp_28699448-c5d9-49ea-bf7e-627800efe783/crypt/zone/oxz_ntp_2d73d30e-ca47-46a8-9c12-917d4ab824b6        15e9b1ea-8947-48a2-8d78-54665e4d2f03   none      none          off        
-    oxp_28699448-c5d9-49ea-bf7e-627800efe783/crypt/debug                                                    bbab775c-07b1-48b1-96a3-9aa155396112   100 GiB   none          gzip-9     
-    oxp_2c490e96-27f2-4a7f-b440-04d4bfd1e4f6/crypt/debug                                                    75c1432c-19e1-4c06-8393-9907a09efcbe   100 GiB   none          gzip-9     
-    oxp_4c3bb1c7-55b6-49b8-b212-516b8f2c26c2/crypt/debug                                                    5501c13c-0500-41a6-9c48-85924383fdcc   100 GiB   none          gzip-9     
-    oxp_5db07562-31a8-43e3-b99e-7c7cb89754b7/crypt/debug                                                    bcdd7a5a-59da-4a47-8a1c-79281428d71b   100 GiB   none          gzip-9     
-    oxp_9451a5d5-b358-4719-b6c1-a0d187da217c/crypt/debug                                                    8ed9d1a2-3c60-4f38-9e80-5c56d80e67c9   100 GiB   none          gzip-9     
-    oxp_bb2e2869-9481-483a-bc49-2bdd62f515f5/crypt/debug                                                    4aef9a3a-0829-4ada-a0e9-a45c91e74249   100 GiB   none          gzip-9     
-    oxp_d5a36c66-4b2f-46e6-96f4-b82debee1a4a/crypt/debug                                                    2b23d885-836a-4270-886d-08640aae90aa   100 GiB   none          gzip-9     
-    oxp_f99ec996-ec08-4ccf-9a6e-6c5cab440fb4/crypt/debug                                                    feac64a1-ade2-4f88-8c17-64d2863e2be6   100 GiB   none          gzip-9     
-    oxp_faccbb39-d686-42a1-a50a-0eb59ba74a87/crypt/debug                                                    91edd9a1-178d-4aa5-83a7-b2f4ef1fc44a   100 GiB   none          gzip-9     
-    oxp_fdfd067b-1d86-444d-a21f-ed33709f3e4d/crypt/debug                                                    8840ccd9-e8c9-48d9-affb-8587e468b204   100 GiB   none          gzip-9     
-+   oxp_28699448-c5d9-49ea-bf7e-627800efe783/crucible                                                       c842fd37-6d1b-430c-83c5-bb49523434e3   none      none          off        
-+   oxp_2c490e96-27f2-4a7f-b440-04d4bfd1e4f6/crucible                                                       33b4b373-748a-44ce-bae3-d08a6f760f88   none      none          off        
-+   oxp_4c3bb1c7-55b6-49b8-b212-516b8f2c26c2/crucible                                                       6cd2973c-3e14-433f-ba9b-d06dc973814f   none      none          off        
-+   oxp_5db07562-31a8-43e3-b99e-7c7cb89754b7/crucible                                                       8f5bdd29-1382-42ea-9e3c-b1ac434b8356   none      none          off        
-+   oxp_9451a5d5-b358-4719-b6c1-a0d187da217c/crucible                                                       7cab9095-e83c-46d5-8290-db28ed5d6909   none      none          off        
-+   oxp_bb2e2869-9481-483a-bc49-2bdd62f515f5/crucible                                                       2503ac08-6839-43c5-a2c3-2b08c234ef5f   none      none          off        
-+   oxp_d5a36c66-4b2f-46e6-96f4-b82debee1a4a/crucible                                                       47880a38-bb35-4619-80fc-2f4578efb231   none      none          off        
-+   oxp_f99ec996-ec08-4ccf-9a6e-6c5cab440fb4/crucible                                                       f99ff9c5-e110-4972-a6d9-627bb6aae3b8   none      none          off        
-+   oxp_faccbb39-d686-42a1-a50a-0eb59ba74a87/crucible                                                       c6f0a0c8-8410-47ef-adb8-86e9edc688e5   none      none          off        
-+   oxp_fdfd067b-1d86-444d-a21f-ed33709f3e4d/crucible                                                       9aab84cf-3764-4611-892b-76e0570a1699   none      none          off        
-+   oxp_fdfd067b-1d86-444d-a21f-ed33709f3e4d/crypt/zone/oxz_crucible_1a20ee3c-f66e-4fca-ab85-2a248aa3d79d   9bbbccf0-a3e1-4d6c-becd-c74a91eef9e8   none      none          off        
-+   oxp_f99ec996-ec08-4ccf-9a6e-6c5cab440fb4/crypt/zone/oxz_crucible_28852beb-d0e5-4cba-9adb-e7f0cd4bb864   bfbfbd9d-c656-4f4c-80cd-c91d38d6bdc9   none      none          off        
-+   oxp_28699448-c5d9-49ea-bf7e-627800efe783/crypt/zone/oxz_crucible_45556184-7092-4a3d-873f-637976bb133b   88f174e0-09e5-4a04-a21f-4885fc7c776b   none      none          off        
-+   oxp_5db07562-31a8-43e3-b99e-7c7cb89754b7/crypt/zone/oxz_crucible_8215bf7a-10d6-4f40-aeb7-27a196307c37   5acdb519-bb18-4e82-ab44-f2dacfc64ce7   none      none          off        
-+   oxp_2c490e96-27f2-4a7f-b440-04d4bfd1e4f6/crypt/zone/oxz_crucible_9d75abfe-47ab-434a-93dd-af50dc0dddde   be00a599-be07-4eb1-8d83-c53a9cdc66cc   none      none          off        
-+   oxp_bb2e2869-9481-483a-bc49-2bdd62f515f5/crypt/zone/oxz_crucible_a36d291c-7f68-462f-830e-bc29e5841ce2   e079d4a4-8b51-4bf2-9f65-f13cb57584ea   none      none          off        
-+   oxp_faccbb39-d686-42a1-a50a-0eb59ba74a87/crypt/zone/oxz_crucible_b3a4d434-aaee-4752-8c99-69d88fbcb8c5   7a364d04-c4a2-4e2c-8081-c24a276621c5   none      none          off        
-+   oxp_d5a36c66-4b2f-46e6-96f4-b82debee1a4a/crypt/zone/oxz_crucible_cf5b636b-a505-4db6-bc32-baf9f53f4371   915d03a8-1902-4f81-9d46-0f1987d7a404   none      none          off        
-+   oxp_9451a5d5-b358-4719-b6c1-a0d187da217c/crypt/zone/oxz_crucible_f6125d45-b9cc-4721-ba60-ed4dbb177e41   42a16f5e-9510-48ca-82a7-7229c2cda8c2   none      none          off        
-+   oxp_4c3bb1c7-55b6-49b8-b212-516b8f2c26c2/crypt/zone/oxz_crucible_f86e19d2-9145-41cf-be89-6aaa34a73873   889580ca-b8a3-4b65-a162-5f5257f193c8   none      none          off        
+    oxp_28699448-c5d9-49ea-bf7e-627800efe783/crypt/zone                                                     bd515f95-ef75-4243-b279-5448e8c56693   none      none          off        
+    oxp_2c490e96-27f2-4a7f-b440-04d4bfd1e4f6/crypt/zone                                                     a5ebe3b2-007d-4cb6-a01b-519eb696dd51   none      none          off        
+    oxp_4c3bb1c7-55b6-49b8-b212-516b8f2c26c2/crypt/zone                                                     292da7cf-54f6-4d8c-a941-eebe5d47fe50   none      none          off        
+    oxp_5db07562-31a8-43e3-b99e-7c7cb89754b7/crypt/zone                                                     58573ab1-3d00-4251-9e32-1c8c94d41689   none      none          off        
+    oxp_9451a5d5-b358-4719-b6c1-a0d187da217c/crypt/zone                                                     823a6464-7317-41c4-88d1-317e6156da3b   none      none          off        
+    oxp_bb2e2869-9481-483a-bc49-2bdd62f515f5/crypt/zone                                                     edf02038-6f07-4788-80f7-1c9ef4537956   none      none          off        
+    oxp_d5a36c66-4b2f-46e6-96f4-b82debee1a4a/crypt/zone                                                     77234c3d-1877-4d9b-9885-cd70b05f6d3d   none      none          off        
+    oxp_f99ec996-ec08-4ccf-9a6e-6c5cab440fb4/crypt/zone                                                     04ebd243-fe45-4222-a437-da51aa719c37   none      none          off        
+    oxp_faccbb39-d686-42a1-a50a-0eb59ba74a87/crypt/zone                                                     b6c84399-0029-4eaa-af95-328e62813332   none      none          off        
+    oxp_fdfd067b-1d86-444d-a21f-ed33709f3e4d/crypt/zone                                                     d1121115-497a-49a1-8908-2bc330bb5b98   none      none          off        
+    oxp_28699448-c5d9-49ea-bf7e-627800efe783/crypt/zone/oxz_ntp_f4a71d99-95e2-484a-ae67-6f98aacee92b        2178dce4-6fba-4b15-b5ce-ece8c54083b5   none      none          off        
+    oxp_28699448-c5d9-49ea-bf7e-627800efe783/crypt/debug                                                    9c2fc653-d640-4d06-8fb0-a32ce35309b7   100 GiB   none          gzip-9     
+    oxp_2c490e96-27f2-4a7f-b440-04d4bfd1e4f6/crypt/debug                                                    3544ad60-7696-44a4-812d-1e830e2de897   100 GiB   none          gzip-9     
+    oxp_4c3bb1c7-55b6-49b8-b212-516b8f2c26c2/crypt/debug                                                    81d852cd-0bfd-4f3a-98b5-641657f2acda   100 GiB   none          gzip-9     
+    oxp_5db07562-31a8-43e3-b99e-7c7cb89754b7/crypt/debug                                                    fa35030d-d14d-4969-9dbf-38dfb7bd4a4d   100 GiB   none          gzip-9     
+    oxp_9451a5d5-b358-4719-b6c1-a0d187da217c/crypt/debug                                                    2110ad2b-9665-4427-b6fb-9059d3d65070   100 GiB   none          gzip-9     
+    oxp_bb2e2869-9481-483a-bc49-2bdd62f515f5/crypt/debug                                                    c4f6dae6-d357-4ad3-becd-5e49c4dcf171   100 GiB   none          gzip-9     
+    oxp_d5a36c66-4b2f-46e6-96f4-b82debee1a4a/crypt/debug                                                    25c84622-b39a-4c28-9dd5-1f9f33170150   100 GiB   none          gzip-9     
+    oxp_f99ec996-ec08-4ccf-9a6e-6c5cab440fb4/crypt/debug                                                    1a88aed3-4f65-479a-8677-af5771feade4   100 GiB   none          gzip-9     
+    oxp_faccbb39-d686-42a1-a50a-0eb59ba74a87/crypt/debug                                                    25eff656-ae3f-42bc-9bfb-8adbc9a1f146   100 GiB   none          gzip-9     
+    oxp_fdfd067b-1d86-444d-a21f-ed33709f3e4d/crypt/debug                                                    ecba8219-9446-4f43-a2fd-098f54ebdfd2   100 GiB   none          gzip-9     
++   oxp_28699448-c5d9-49ea-bf7e-627800efe783/crucible                                                       3b11b123-120d-49fd-a9fc-84527b75580d   none      none          off        
++   oxp_2c490e96-27f2-4a7f-b440-04d4bfd1e4f6/crucible                                                       eaff368e-4ef0-4afd-aaec-1a3d4f296c10   none      none          off        
++   oxp_4c3bb1c7-55b6-49b8-b212-516b8f2c26c2/crucible                                                       ff493493-2593-4864-9635-53d8bd7d1875   none      none          off        
++   oxp_5db07562-31a8-43e3-b99e-7c7cb89754b7/crucible                                                       8295c04b-0fe1-456b-aa4f-41aed656e041   none      none          off        
++   oxp_9451a5d5-b358-4719-b6c1-a0d187da217c/crucible                                                       50f55ff5-352e-44dd-9f6e-5294a49050af   none      none          off        
++   oxp_bb2e2869-9481-483a-bc49-2bdd62f515f5/crucible                                                       9a497b55-c55d-4e8c-ac67-fc51dc626b2b   none      none          off        
++   oxp_d5a36c66-4b2f-46e6-96f4-b82debee1a4a/crucible                                                       5fc3b305-20ca-4882-8222-00cb453e1370   none      none          off        
++   oxp_f99ec996-ec08-4ccf-9a6e-6c5cab440fb4/crucible                                                       027b5ae4-442d-4e44-a3af-41f1a369d2fd   none      none          off        
++   oxp_faccbb39-d686-42a1-a50a-0eb59ba74a87/crucible                                                       6e98176b-93c2-4e70-b982-715a4af7def3   none      none          off        
++   oxp_fdfd067b-1d86-444d-a21f-ed33709f3e4d/crucible                                                       4a66c4d8-5448-4a01-8b3e-5aa96a383f5f   none      none          off        
++   oxp_4c3bb1c7-55b6-49b8-b212-516b8f2c26c2/crypt/zone/oxz_crucible_199d6b91-4def-46d4-a629-6e462f149d2c   51acb6aa-a707-443d-a797-591efbaed739   none      none          off        
++   oxp_fdfd067b-1d86-444d-a21f-ed33709f3e4d/crypt/zone/oxz_crucible_1a42f499-42eb-4bbe-8248-df1432c20a44   99cd74fc-d598-4237-afe2-6099dd3e7f27   none      none          off        
++   oxp_bb2e2869-9481-483a-bc49-2bdd62f515f5/crypt/zone/oxz_crucible_2dac1d18-171c-4c27-b4f4-dd9a04b3cd4c   d3f32cce-77c1-45c9-b5fc-5946ce45d6ab   none      none          off        
++   oxp_9451a5d5-b358-4719-b6c1-a0d187da217c/crypt/zone/oxz_crucible_5cfcfcf1-fc41-4056-b681-28b822fc9ba9   cf93aa67-8057-486b-8117-fcb210113d78   none      none          off        
++   oxp_faccbb39-d686-42a1-a50a-0eb59ba74a87/crypt/zone/oxz_crucible_639c583f-fff1-488a-83ea-9f506de5eeff   f301a2d1-5a5c-4af5-92a2-eb4241b07e32   none      none          off        
++   oxp_d5a36c66-4b2f-46e6-96f4-b82debee1a4a/crypt/zone/oxz_crucible_6a1eeaa3-4106-4765-9883-0b481d112f2f   c7bc6bbf-cd8e-4d46-870a-c51269d3f938   none      none          off        
++   oxp_28699448-c5d9-49ea-bf7e-627800efe783/crypt/zone/oxz_crucible_7faa36f4-c38e-49d9-9e50-87a2c509d1c0   6de4f5f7-41aa-4ede-b742-b814306a33cb   none      none          off        
++   oxp_5db07562-31a8-43e3-b99e-7c7cb89754b7/crypt/zone/oxz_crucible_89d9477c-0a66-4297-9333-78d421265495   9efc87a2-2990-4e9d-8636-0cc5003c78df   none      none          off        
++   oxp_2c490e96-27f2-4a7f-b440-04d4bfd1e4f6/crypt/zone/oxz_crucible_b4ddca08-a1d7-4c1e-8c65-69376ff4dd6f   f9d13e2d-bcd0-416d-9a4a-fbee18fdd8d0   none      none          off        
++   oxp_f99ec996-ec08-4ccf-9a6e-6c5cab440fb4/crypt/zone/oxz_crucible_d70466d6-ace2-4913-a62c-ad9f42a52369   dc55d9bf-2b5c-4fc4-b0b3-df4a87d32688   none      none          off        
 
 
     omicron zones generation 2 -> 3:
     ------------------------------------------------------------------------------------------
     zone type      zone id                                disposition   underlay IP           
     ------------------------------------------------------------------------------------------
-    internal_ntp   2d73d30e-ca47-46a8-9c12-917d4ab824b6   in service    fd00:1122:3344:104::21
-+   crucible       1a20ee3c-f66e-4fca-ab85-2a248aa3d79d   in service    fd00:1122:3344:104::2b
-+   crucible       28852beb-d0e5-4cba-9adb-e7f0cd4bb864   in service    fd00:1122:3344:104::29
-+   crucible       45556184-7092-4a3d-873f-637976bb133b   in service    fd00:1122:3344:104::22
-+   crucible       8215bf7a-10d6-4f40-aeb7-27a196307c37   in service    fd00:1122:3344:104::25
-+   crucible       9d75abfe-47ab-434a-93dd-af50dc0dddde   in service    fd00:1122:3344:104::23
-+   crucible       a36d291c-7f68-462f-830e-bc29e5841ce2   in service    fd00:1122:3344:104::27
-+   crucible       b3a4d434-aaee-4752-8c99-69d88fbcb8c5   in service    fd00:1122:3344:104::2a
-+   crucible       cf5b636b-a505-4db6-bc32-baf9f53f4371   in service    fd00:1122:3344:104::28
-+   crucible       f6125d45-b9cc-4721-ba60-ed4dbb177e41   in service    fd00:1122:3344:104::26
-+   crucible       f86e19d2-9145-41cf-be89-6aaa34a73873   in service    fd00:1122:3344:104::24
+    internal_ntp   f4a71d99-95e2-484a-ae67-6f98aacee92b   in service    fd00:1122:3344:104::21
++   crucible       199d6b91-4def-46d4-a629-6e462f149d2c   in service    fd00:1122:3344:104::24
++   crucible       1a42f499-42eb-4bbe-8248-df1432c20a44   in service    fd00:1122:3344:104::2b
++   crucible       2dac1d18-171c-4c27-b4f4-dd9a04b3cd4c   in service    fd00:1122:3344:104::27
++   crucible       5cfcfcf1-fc41-4056-b681-28b822fc9ba9   in service    fd00:1122:3344:104::26
++   crucible       639c583f-fff1-488a-83ea-9f506de5eeff   in service    fd00:1122:3344:104::2a
++   crucible       6a1eeaa3-4106-4765-9883-0b481d112f2f   in service    fd00:1122:3344:104::28
++   crucible       7faa36f4-c38e-49d9-9e50-87a2c509d1c0   in service    fd00:1122:3344:104::22
++   crucible       89d9477c-0a66-4297-9333-78d421265495   in service    fd00:1122:3344:104::25
++   crucible       b4ddca08-a1d7-4c1e-8c65-69376ff4dd6f   in service    fd00:1122:3344:104::23
++   crucible       d70466d6-ace2-4913-a62c-ad9f42a52369   in service    fd00:1122:3344:104::29
 
 
  COCKROACHDB SETTINGS:

--- a/nexus/reconfigurator/planning/tests/output/planner_dataset_settings_modified_in_place_1_2.txt
+++ b/nexus/reconfigurator/planning/tests/output/planner_dataset_settings_modified_in_place_1_2.txt
@@ -25,59 +25,59 @@ to:   blueprint fe13be30-94c2-4fa6-aad5-ae3c5028f6bb
     -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
     dataset name                                                                                                   dataset uuid                           quota       reservation   compression
     -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
-    oxp_3b6e2ade-57fc-4f9d-85c3-38fca27f1df6/crucible                                                              37ca00f9-8c48-49dd-a511-1844366b9fc6   none        none          off        
-    oxp_5192ef62-5a12-4a0c-829d-a409da87909c/crucible                                                              f73617d5-cb8c-40d2-8079-6b9b17011b70   none        none          off        
-    oxp_8778bcc5-dddf-4345-9fdf-5c46a36497b0/crucible                                                              d11c234f-c617-4cfe-b61a-38ea70de8325   none        none          off        
-    oxp_9134de8d-9ba8-4ddc-9e84-eb00ec616b53/crucible                                                              5dc63025-10bf-4e78-80d8-aec0a884c931   none        none          off        
-    oxp_96569b61-9e0c-4ee7-bd11-a5e0c541ca99/crucible                                                              572474f0-3630-40d5-814f-9fc58261e8cd   none        none          off        
-    oxp_ba90170e-7399-4260-910a-376254a8a9bf/crucible                                                              a527de5a-e39c-4991-98fd-75fd5e567f91   none        none          off        
-    oxp_bc649720-926b-48f2-a62a-efdcff96b49e/crucible                                                              0821d5cd-e706-4e90-ba27-7820efeb3d6c   none        none          off        
-    oxp_d55da288-4f35-4e92-97b0-29a5e6009109/crucible                                                              67211a77-5b63-4487-aec8-087864f06a6a   none        none          off        
-    oxp_f83302fc-785c-4ab3-bcca-0d040b3c3062/crucible                                                              9e0bd909-0d35-4f03-8246-66a67b6cfbe4   none        none          off        
-    oxp_f843fb62-0f04-4c7d-a56f-62531104dc77/crucible                                                              9bf6d6ee-e7cd-4aad-a66c-343af08bea16   none        none          off        
-    oxp_3b6e2ade-57fc-4f9d-85c3-38fca27f1df6/crypt/clickhouse                                                      379a5c76-adde-40c7-a0b0-b7837ed4b1bf   none        none          off        
-    oxp_3b6e2ade-57fc-4f9d-85c3-38fca27f1df6/crypt/internal_dns                                                    7ba6b643-5113-43e9-ae33-de52c2b1d7c2   none        none          off        
-    oxp_5192ef62-5a12-4a0c-829d-a409da87909c/crypt/internal_dns                                                    4c4183bc-ed9f-4a8e-9f9f-73cabb6830d1   none        none          off        
-    oxp_8778bcc5-dddf-4345-9fdf-5c46a36497b0/crypt/internal_dns                                                    50cbcefa-0500-4cd2-b077-f4cda0ffce81   none        none          off        
-    oxp_3b6e2ade-57fc-4f9d-85c3-38fca27f1df6/crypt/zone                                                            4300bbd9-56b4-4735-9e6a-5c12ecd431eb   none        none          off        
-    oxp_5192ef62-5a12-4a0c-829d-a409da87909c/crypt/zone                                                            931a0291-5b7c-453b-8bd0-0b835ca8d879   none        none          off        
-    oxp_8778bcc5-dddf-4345-9fdf-5c46a36497b0/crypt/zone                                                            83954f81-3607-45e5-b380-6c19c0eafcb2   none        none          off        
-    oxp_9134de8d-9ba8-4ddc-9e84-eb00ec616b53/crypt/zone                                                            1d57c1bc-f3dc-4799-848e-ffab7e1a9704   none        none          off        
-    oxp_96569b61-9e0c-4ee7-bd11-a5e0c541ca99/crypt/zone                                                            269d597d-795f-4675-9210-3796379f082e   none        none          off        
-    oxp_ba90170e-7399-4260-910a-376254a8a9bf/crypt/zone                                                            a7b90e18-788d-47cc-91d8-4eb427c9c041   none        none          off        
-    oxp_bc649720-926b-48f2-a62a-efdcff96b49e/crypt/zone                                                            6901d663-862d-4893-8aa2-d75d94f78530   none        none          off        
-    oxp_d55da288-4f35-4e92-97b0-29a5e6009109/crypt/zone                                                            2e7f7b63-681f-490a-8a31-40bb196aa927   none        none          off        
-    oxp_f83302fc-785c-4ab3-bcca-0d040b3c3062/crypt/zone                                                            c56b51d9-6573-40fe-98f6-12b760a6f136   none        none          off        
-    oxp_f843fb62-0f04-4c7d-a56f-62531104dc77/crypt/zone                                                            e35ef3d9-5e22-42c7-8623-9f24c00b0677   none        none          off        
-    oxp_3b6e2ade-57fc-4f9d-85c3-38fca27f1df6/crypt/zone/oxz_clickhouse_5d62c22a-7ad0-439c-963b-a30ba8ff31bb        997e8452-11b8-4478-98fb-89fbd6abe9b4   none        none          off        
-    oxp_ba90170e-7399-4260-910a-376254a8a9bf/crypt/zone/oxz_crucible_1fcb5e9b-85f1-426d-ae88-6159804063fd          39a39559-055c-4c18-a02b-c963276b2171   none        none          off        
-    oxp_3b6e2ade-57fc-4f9d-85c3-38fca27f1df6/crypt/zone/oxz_crucible_449deb40-b01b-41ae-8167-7b7b47e2692e          e8fc9f62-9c90-4ec5-9a04-59d3dc4970cf   none        none          off        
-    oxp_9134de8d-9ba8-4ddc-9e84-eb00ec616b53/crypt/zone/oxz_crucible_729e375b-31a4-4cfc-b56c-afeef8d8adfc          476cc49e-29d1-4c3d-b4c0-c5ec01206b26   none        none          off        
-    oxp_5192ef62-5a12-4a0c-829d-a409da87909c/crypt/zone/oxz_crucible_92476a4a-7a95-4141-acc6-e0a42066edbd          426cd017-82e0-4078-a5dd-05c5b88c1e66   none        none          off        
-    oxp_d55da288-4f35-4e92-97b0-29a5e6009109/crypt/zone/oxz_crucible_adb88e8f-1299-4c8b-992b-2a54dbdd51ef          d1a2bb7d-1916-43ce-bad8-7dc78c86b89e   none        none          off        
-    oxp_f83302fc-785c-4ab3-bcca-0d040b3c3062/crypt/zone/oxz_crucible_b4e83ee5-a40e-4202-89cd-f2c1ede124d8          14ce9d7e-95ca-42e3-894a-2cec314959cb   none        none          off        
-    oxp_bc649720-926b-48f2-a62a-efdcff96b49e/crypt/zone/oxz_crucible_b9d0d20d-5ccf-4570-ad00-b5bf33a5a63e          634b6dfa-d1b4-4f90-808e-eba7cd093a1e   none        none          off        
-    oxp_8778bcc5-dddf-4345-9fdf-5c46a36497b0/crypt/zone/oxz_crucible_d0e39a63-1310-42a3-ba54-6624006c0d24          80d8fd68-b3e3-49ba-b758-d58271057bb7   none        none          off        
-    oxp_f843fb62-0f04-4c7d-a56f-62531104dc77/crypt/zone/oxz_crucible_fc4f1769-9611-42d3-b8c1-f2be9b5359f6          35fa6ec8-6b58-4fcc-a5a2-36e66736e9c1   none        none          off        
-    oxp_96569b61-9e0c-4ee7-bd11-a5e0c541ca99/crypt/zone/oxz_crucible_fff71a84-09c2-4dab-bc18-8f4570f278bb          00abfe99-288d-4a63-abea-adfa62e74524   none        none          off        
-    oxp_3b6e2ade-57fc-4f9d-85c3-38fca27f1df6/crypt/zone/oxz_crucible_pantry_197067bc-9a21-444e-9794-6051d9f78a00   19736dbd-1d01-41e9-a800-ffc450464c2d   none        none          off        
-    oxp_5192ef62-5a12-4a0c-829d-a409da87909c/crypt/zone/oxz_crucible_pantry_350fba7f-b754-429e-a21d-e91d139713f2   8be4aa2f-1612-4bdf-a0f6-7458b151308f   none        none          off        
-    oxp_8778bcc5-dddf-4345-9fdf-5c46a36497b0/crypt/zone/oxz_crucible_pantry_504963cb-3077-477c-b4e5-2d69bf9caa0c   7fd439f9-dcef-4cfb-b1a1-d298be9d2e3b   none        none          off        
-    oxp_3b6e2ade-57fc-4f9d-85c3-38fca27f1df6/crypt/zone/oxz_internal_dns_1e9422ca-a3d9-4435-bb17-39d5ad22b4ba      5651c4fb-d146-4270-8794-6ed7ceb6f130   none        none          off        
-    oxp_8778bcc5-dddf-4345-9fdf-5c46a36497b0/crypt/zone/oxz_internal_dns_4a0ec9f6-6ce6-4456-831e-5f8df7b57332      d2b9f103-8bf1-4603-873d-cec130430ba7   none        none          off        
-    oxp_5192ef62-5a12-4a0c-829d-a409da87909c/crypt/zone/oxz_internal_dns_efecb8a2-ce0b-416f-958b-de1fad1bef02      158e226c-e44e-427f-93af-ee96d2cfb9be   none        none          off        
-    oxp_3b6e2ade-57fc-4f9d-85c3-38fca27f1df6/crypt/zone/oxz_nexus_f9f52984-e6ad-4280-bf92-c88da12e8fdc             a0b438d3-b77b-4bb6-90c0-8fdf27ca6ea1   none        none          off        
-    oxp_3b6e2ade-57fc-4f9d-85c3-38fca27f1df6/crypt/zone/oxz_ntp_f7420bc3-7916-44fe-a66e-515ce09ff63f               530104ab-48b9-47fe-a9d8-00cc945d701a   none        none          off        
-    oxp_3b6e2ade-57fc-4f9d-85c3-38fca27f1df6/crypt/debug                                                           fe7f66a8-7605-4001-87f8-2357e95acb2a   100 GiB     none          gzip-9     
-    oxp_5192ef62-5a12-4a0c-829d-a409da87909c/crypt/debug                                                           7cf63429-3af0-4e74-a007-c24024a4c6db   100 GiB     none          gzip-9     
-    oxp_8778bcc5-dddf-4345-9fdf-5c46a36497b0/crypt/debug                                                           38570a1f-a96b-45dc-8cdd-91ec150657bf   100 GiB     none          gzip-9     
-    oxp_9134de8d-9ba8-4ddc-9e84-eb00ec616b53/crypt/debug                                                           f46e90fa-6f1c-40d4-813b-0b2dfbc8295d   100 GiB     none          gzip-9     
-    oxp_96569b61-9e0c-4ee7-bd11-a5e0c541ca99/crypt/debug                                                           72893a49-bd26-425f-a56e-ee09d6f634b1   100 GiB     none          gzip-9     
-    oxp_ba90170e-7399-4260-910a-376254a8a9bf/crypt/debug                                                           2280f30e-4f1b-45f2-a6fe-83098487637b   100 GiB     none          gzip-9     
-    oxp_bc649720-926b-48f2-a62a-efdcff96b49e/crypt/debug                                                           56542c75-0603-4fd4-af13-8af63a364e7c   100 GiB     none          gzip-9     
-    oxp_d55da288-4f35-4e92-97b0-29a5e6009109/crypt/debug                                                           855e6f57-c6c8-408d-bda0-7fdd220565a1   100 GiB     none          gzip-9     
-    oxp_f83302fc-785c-4ab3-bcca-0d040b3c3062/crypt/debug                                                           bf3ff0d1-497e-4411-b70d-d6faca5c8970   100 GiB     none          gzip-9     
-*   oxp_f843fb62-0f04-4c7d-a56f-62531104dc77/crypt/debug                                                           2011121d-b454-41c5-9062-18fa04ee1d52   - none      - 1 GiB       gzip-9     
+    oxp_3b6e2ade-57fc-4f9d-85c3-38fca27f1df6/crucible                                                              c2b2149b-1ad7-479f-bc9f-2404cf3eec0d   none        none          off        
+    oxp_5192ef62-5a12-4a0c-829d-a409da87909c/crucible                                                              74601f4f-d373-438c-808a-b9e6e94c0a67   none        none          off        
+    oxp_8778bcc5-dddf-4345-9fdf-5c46a36497b0/crucible                                                              f8ffebff-ffd1-4005-9803-3bd79dd5b012   none        none          off        
+    oxp_9134de8d-9ba8-4ddc-9e84-eb00ec616b53/crucible                                                              02ab12e1-26f0-4151-b2f3-e675b8f5be44   none        none          off        
+    oxp_96569b61-9e0c-4ee7-bd11-a5e0c541ca99/crucible                                                              56e4a163-8f97-4122-a2a2-38546daffbfc   none        none          off        
+    oxp_ba90170e-7399-4260-910a-376254a8a9bf/crucible                                                              25c1c3c4-88b2-4c7f-8069-1b9412d045e6   none        none          off        
+    oxp_bc649720-926b-48f2-a62a-efdcff96b49e/crucible                                                              8c3ff417-0e78-4946-b48f-f83a1a65526b   none        none          off        
+    oxp_d55da288-4f35-4e92-97b0-29a5e6009109/crucible                                                              27251d6c-990a-4537-ad6d-a23eb40a61e2   none        none          off        
+    oxp_f83302fc-785c-4ab3-bcca-0d040b3c3062/crucible                                                              707bf418-524a-4a44-aaf1-fc0fe903226b   none        none          off        
+    oxp_f843fb62-0f04-4c7d-a56f-62531104dc77/crucible                                                              54e1705b-2579-4319-9f96-717a4d0508da   none        none          off        
+    oxp_3b6e2ade-57fc-4f9d-85c3-38fca27f1df6/crypt/clickhouse                                                      06c210fe-97c6-40a9-b7e2-3ae2b8304523   none        none          off        
+    oxp_3b6e2ade-57fc-4f9d-85c3-38fca27f1df6/crypt/internal_dns                                                    f2999945-8940-4eea-9423-80972552a6a1   none        none          off        
+    oxp_5192ef62-5a12-4a0c-829d-a409da87909c/crypt/internal_dns                                                    86643402-4dbc-4d33-ba3e-2e475c3a9f47   none        none          off        
+    oxp_8778bcc5-dddf-4345-9fdf-5c46a36497b0/crypt/internal_dns                                                    1ddb78c9-40dd-406a-bcd0-80271360a43e   none        none          off        
+    oxp_3b6e2ade-57fc-4f9d-85c3-38fca27f1df6/crypt/zone                                                            80d1989b-2118-4b8f-887a-693c26901a63   none        none          off        
+    oxp_5192ef62-5a12-4a0c-829d-a409da87909c/crypt/zone                                                            95358c68-0461-4236-ac9a-31889f14d704   none        none          off        
+    oxp_8778bcc5-dddf-4345-9fdf-5c46a36497b0/crypt/zone                                                            11a0e954-7001-4b97-b521-2eafd179058c   none        none          off        
+    oxp_9134de8d-9ba8-4ddc-9e84-eb00ec616b53/crypt/zone                                                            ec5d1490-2ab1-446a-931a-83acb726fce9   none        none          off        
+    oxp_96569b61-9e0c-4ee7-bd11-a5e0c541ca99/crypt/zone                                                            b7aaee47-6098-4004-8cc1-0f6ffd27b314   none        none          off        
+    oxp_ba90170e-7399-4260-910a-376254a8a9bf/crypt/zone                                                            2ad4c1d4-a8c8-4757-9c4d-b2a74aebceb0   none        none          off        
+    oxp_bc649720-926b-48f2-a62a-efdcff96b49e/crypt/zone                                                            8cfbfb7d-b024-4459-aa92-fad02c3479e5   none        none          off        
+    oxp_d55da288-4f35-4e92-97b0-29a5e6009109/crypt/zone                                                            6d88208a-9cd6-4b1c-9367-0d7a7237d2ba   none        none          off        
+    oxp_f83302fc-785c-4ab3-bcca-0d040b3c3062/crypt/zone                                                            627fcb15-3896-4517-9848-6e14398ca33f   none        none          off        
+    oxp_f843fb62-0f04-4c7d-a56f-62531104dc77/crypt/zone                                                            b2bfbf22-be11-44c4-86ce-f4c9d7c61bca   none        none          off        
+    oxp_3b6e2ade-57fc-4f9d-85c3-38fca27f1df6/crypt/zone/oxz_clickhouse_2e7dca68-90bc-42a5-b516-8872899cc38f        d93a80f1-5f19-42f9-a24e-5a3bed2ecdd6   none        none          off        
+    oxp_bc649720-926b-48f2-a62a-efdcff96b49e/crypt/zone/oxz_crucible_017681e7-e03e-4fc9-94b7-9963f37a5251          285b3278-0bac-48a8-b718-75ee4393f5d2   none        none          off        
+    oxp_8778bcc5-dddf-4345-9fdf-5c46a36497b0/crypt/zone/oxz_crucible_0465511c-088d-45d3-8f1f-a59d196aa6c0          d6f0bfb0-b67f-474c-a45a-44f7f25c079a   none        none          off        
+    oxp_d55da288-4f35-4e92-97b0-29a5e6009109/crypt/zone/oxz_crucible_222b4052-a14c-435d-9d05-bd2acfb360d1          478428de-7aaf-40d7-9a50-f7a5f29ba4d6   none        none          off        
+    oxp_5192ef62-5a12-4a0c-829d-a409da87909c/crypt/zone/oxz_crucible_48b34cc7-0ea1-4c7f-a44b-576c2c9aae8d          95962f35-1a28-472c-b060-04213df9648f   none        none          off        
+    oxp_96569b61-9e0c-4ee7-bd11-a5e0c541ca99/crypt/zone/oxz_crucible_5ca82295-48f7-4ace-805e-bcf8ff1169e6          2ec7fb3f-1c91-4633-ae2c-1538e4ead7ef   none        none          off        
+    oxp_f843fb62-0f04-4c7d-a56f-62531104dc77/crypt/zone/oxz_crucible_6d4baeff-b0b2-48d4-9d57-98300ca470b0          36600c7a-1488-4b99-b697-95e3e057f701   none        none          off        
+    oxp_9134de8d-9ba8-4ddc-9e84-eb00ec616b53/crypt/zone/oxz_crucible_a4ed47c6-afc1-406a-a722-9c2ca18d8f15          983da03f-f39a-4c86-be8f-cd42187a0efb   none        none          off        
+    oxp_3b6e2ade-57fc-4f9d-85c3-38fca27f1df6/crypt/zone/oxz_crucible_b2bd58dd-4056-4418-9adc-99133fb7340d          472883c8-a687-415a-9400-963dc4ebfb23   none        none          off        
+    oxp_ba90170e-7399-4260-910a-376254a8a9bf/crypt/zone/oxz_crucible_b9871e7b-e158-4541-b590-f2388518a629          a0584b79-723b-47fb-a375-6270893e4034   none        none          off        
+    oxp_f83302fc-785c-4ab3-bcca-0d040b3c3062/crypt/zone/oxz_crucible_d845b03f-a140-46fd-b81a-3d930f804db2          391a1adf-4b07-4838-bc63-3f2ca17d54c7   none        none          off        
+    oxp_5192ef62-5a12-4a0c-829d-a409da87909c/crypt/zone/oxz_crucible_pantry_4ce5fadc-ed9a-4fc0-adc2-816ba38ac0ff   6ac03c83-58f0-4472-9946-fa8284d6ce22   none        none          off        
+    oxp_3b6e2ade-57fc-4f9d-85c3-38fca27f1df6/crypt/zone/oxz_crucible_pantry_62817fb3-3432-4d29-a7f0-0c430d91e70b   4fd8f841-8ced-4c14-9a54-1651b8c827b1   none        none          off        
+    oxp_8778bcc5-dddf-4345-9fdf-5c46a36497b0/crypt/zone/oxz_crucible_pantry_f40b4b52-a596-4c8b-ac14-a1a4608e48ad   82674874-7065-4219-903c-f9215896fb38   none        none          off        
+    oxp_8778bcc5-dddf-4345-9fdf-5c46a36497b0/crypt/zone/oxz_internal_dns_0f5fa763-0f32-4b4d-9160-ed03d92ae886      167519d0-d053-455b-a545-ad6f9b51856d   none        none          off        
+    oxp_3b6e2ade-57fc-4f9d-85c3-38fca27f1df6/crypt/zone/oxz_internal_dns_a2b1dbad-c401-434a-b1a3-d390e3d582c7      e32a6b3b-2cec-4213-bb19-bdd05730959c   none        none          off        
+    oxp_5192ef62-5a12-4a0c-829d-a409da87909c/crypt/zone/oxz_internal_dns_ed5dafdf-9ff6-47ef-a90a-c4d44ac225df      dd90bad1-a07d-4d19-920f-7adfa7c7277c   none        none          off        
+    oxp_3b6e2ade-57fc-4f9d-85c3-38fca27f1df6/crypt/zone/oxz_nexus_244029bd-c704-4894-8667-0c7af6bd62c1             c94b54db-b218-4cc5-938e-a12688dc1811   none        none          off        
+    oxp_3b6e2ade-57fc-4f9d-85c3-38fca27f1df6/crypt/zone/oxz_ntp_1bcf8d76-a533-4f21-a4e1-4b8af4b3e80a               301aaff5-4531-42a7-abec-be6169ad1922   none        none          off        
+    oxp_3b6e2ade-57fc-4f9d-85c3-38fca27f1df6/crypt/debug                                                           8674ab89-23a1-46b5-bb40-bfd938d3c026   100 GiB     none          gzip-9     
+    oxp_5192ef62-5a12-4a0c-829d-a409da87909c/crypt/debug                                                           3463b0a5-8e0f-41b5-bac9-1be5186ffe13   100 GiB     none          gzip-9     
+    oxp_8778bcc5-dddf-4345-9fdf-5c46a36497b0/crypt/debug                                                           435c0ab4-c566-4f0f-a8e3-399465075174   100 GiB     none          gzip-9     
+    oxp_9134de8d-9ba8-4ddc-9e84-eb00ec616b53/crypt/debug                                                           b2ba48cd-52b7-489d-a877-88da2392067b   100 GiB     none          gzip-9     
+    oxp_96569b61-9e0c-4ee7-bd11-a5e0c541ca99/crypt/debug                                                           702cbaf8-3e09-45b7-ba07-b610a95b3546   100 GiB     none          gzip-9     
+    oxp_ba90170e-7399-4260-910a-376254a8a9bf/crypt/debug                                                           5b1b49c7-83c4-44e4-8d54-4d1336cd5b6a   100 GiB     none          gzip-9     
+    oxp_bc649720-926b-48f2-a62a-efdcff96b49e/crypt/debug                                                           e70e6fa1-185f-4932-959f-8ddc1d52d995   100 GiB     none          gzip-9     
+    oxp_f83302fc-785c-4ab3-bcca-0d040b3c3062/crypt/debug                                                           35748580-b8b2-4882-ab41-cdc16ec52d05   100 GiB     none          gzip-9     
+    oxp_f843fb62-0f04-4c7d-a56f-62531104dc77/crypt/debug                                                           97b89a78-8a3b-4026-b3a9-88434389a2d7   100 GiB     none          gzip-9     
+*   oxp_d55da288-4f35-4e92-97b0-29a5e6009109/crypt/debug                                                           029a51d9-e7e7-418c-a55e-3f6982f1fe14   - none      - 1 GiB       gzip-9     
      └─                                                                                                                                                   + 100 GiB   + none                   
 
 
@@ -85,25 +85,25 @@ to:   blueprint fe13be30-94c2-4fa6-aad5-ae3c5028f6bb
     ---------------------------------------------------------------------------------------------
     zone type         zone id                                disposition   underlay IP           
     ---------------------------------------------------------------------------------------------
-    clickhouse        5d62c22a-7ad0-439c-963b-a30ba8ff31bb   in service    fd00:1122:3344:101::23
-    crucible          1fcb5e9b-85f1-426d-ae88-6159804063fd   in service    fd00:1122:3344:101::2c
-    crucible          449deb40-b01b-41ae-8167-7b7b47e2692e   in service    fd00:1122:3344:101::27
-    crucible          729e375b-31a4-4cfc-b56c-afeef8d8adfc   in service    fd00:1122:3344:101::2a
-    crucible          92476a4a-7a95-4141-acc6-e0a42066edbd   in service    fd00:1122:3344:101::28
-    crucible          adb88e8f-1299-4c8b-992b-2a54dbdd51ef   in service    fd00:1122:3344:101::2e
-    crucible          b4e83ee5-a40e-4202-89cd-f2c1ede124d8   in service    fd00:1122:3344:101::2f
-    crucible          b9d0d20d-5ccf-4570-ad00-b5bf33a5a63e   in service    fd00:1122:3344:101::2d
-    crucible          d0e39a63-1310-42a3-ba54-6624006c0d24   in service    fd00:1122:3344:101::29
-    crucible          fc4f1769-9611-42d3-b8c1-f2be9b5359f6   in service    fd00:1122:3344:101::30
-    crucible          fff71a84-09c2-4dab-bc18-8f4570f278bb   in service    fd00:1122:3344:101::2b
-    crucible_pantry   197067bc-9a21-444e-9794-6051d9f78a00   in service    fd00:1122:3344:101::24
-    crucible_pantry   350fba7f-b754-429e-a21d-e91d139713f2   in service    fd00:1122:3344:101::25
-    crucible_pantry   504963cb-3077-477c-b4e5-2d69bf9caa0c   in service    fd00:1122:3344:101::26
-    internal_dns      1e9422ca-a3d9-4435-bb17-39d5ad22b4ba   in service    fd00:1122:3344:1::1   
-    internal_dns      4a0ec9f6-6ce6-4456-831e-5f8df7b57332   in service    fd00:1122:3344:3::1   
-    internal_dns      efecb8a2-ce0b-416f-958b-de1fad1bef02   in service    fd00:1122:3344:2::1   
-    internal_ntp      f7420bc3-7916-44fe-a66e-515ce09ff63f   in service    fd00:1122:3344:101::21
-    nexus             f9f52984-e6ad-4280-bf92-c88da12e8fdc   in service    fd00:1122:3344:101::22
+    clickhouse        2e7dca68-90bc-42a5-b516-8872899cc38f   in service    fd00:1122:3344:101::23
+    crucible          017681e7-e03e-4fc9-94b7-9963f37a5251   in service    fd00:1122:3344:101::2d
+    crucible          0465511c-088d-45d3-8f1f-a59d196aa6c0   in service    fd00:1122:3344:101::29
+    crucible          222b4052-a14c-435d-9d05-bd2acfb360d1   in service    fd00:1122:3344:101::2e
+    crucible          48b34cc7-0ea1-4c7f-a44b-576c2c9aae8d   in service    fd00:1122:3344:101::28
+    crucible          5ca82295-48f7-4ace-805e-bcf8ff1169e6   in service    fd00:1122:3344:101::2b
+    crucible          6d4baeff-b0b2-48d4-9d57-98300ca470b0   in service    fd00:1122:3344:101::30
+    crucible          a4ed47c6-afc1-406a-a722-9c2ca18d8f15   in service    fd00:1122:3344:101::2a
+    crucible          b2bd58dd-4056-4418-9adc-99133fb7340d   in service    fd00:1122:3344:101::27
+    crucible          b9871e7b-e158-4541-b590-f2388518a629   in service    fd00:1122:3344:101::2c
+    crucible          d845b03f-a140-46fd-b81a-3d930f804db2   in service    fd00:1122:3344:101::2f
+    crucible_pantry   4ce5fadc-ed9a-4fc0-adc2-816ba38ac0ff   in service    fd00:1122:3344:101::25
+    crucible_pantry   62817fb3-3432-4d29-a7f0-0c430d91e70b   in service    fd00:1122:3344:101::24
+    crucible_pantry   f40b4b52-a596-4c8b-ac14-a1a4608e48ad   in service    fd00:1122:3344:101::26
+    internal_dns      0f5fa763-0f32-4b4d-9160-ed03d92ae886   in service    fd00:1122:3344:3::1   
+    internal_dns      a2b1dbad-c401-434a-b1a3-d390e3d582c7   in service    fd00:1122:3344:1::1   
+    internal_dns      ed5dafdf-9ff6-47ef-a90a-c4d44ac225df   in service    fd00:1122:3344:2::1   
+    internal_ntp      1bcf8d76-a533-4f21-a4e1-4b8af4b3e80a   in service    fd00:1122:3344:101::21
+    nexus             244029bd-c704-4894-8667-0c7af6bd62c1   in service    fd00:1122:3344:101::22
 
 
  COCKROACHDB SETTINGS:

--- a/nexus/reconfigurator/planning/tests/output/planner_decommissions_sleds_1_2.txt
+++ b/nexus/reconfigurator/planning/tests/output/planner_decommissions_sleds_1_2.txt
@@ -25,88 +25,88 @@ to:   blueprint 1ac2d88f-27dd-4506-8585-6b2be832528e
     -----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
     dataset name                                                                                                   dataset uuid                           quota     reservation   compression
     -----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
--   oxp_069446b4-7881-49dc-838a-63a782d4896d/crucible                                                              a9524f87-1bd8-4a3c-b7bd-e3c19a14fb50   none      none          off        
--   oxp_20eba316-dffe-4516-9703-af561da19b0b/crucible                                                              5743004a-db46-4e84-b826-d860619dc063   none      none          off        
--   oxp_426f4b6d-4a82-4106-bf4b-64ee86a2a5a4/crucible                                                              ed196541-0958-4fc0-8cf8-6da4c522e620   none      none          off        
--   oxp_82daeef2-8641-4bf5-ac66-f7b5f62c48b6/crucible                                                              ff266774-5999-4631-a516-3f2f9a05f688   none      none          off        
--   oxp_8e5feeb2-14f1-440f-a909-3c34aa8e129b/crucible                                                              db626d31-b4a3-4b81-970d-cfa469c5d2ff   none      none          off        
--   oxp_942e2123-7c4e-4f6b-9317-1341fe212647/crucible                                                              33c2c71f-d4d7-4357-ba2a-eb9d5d8aa0f5   none      none          off        
--   oxp_97a5ce17-df5b-47e7-baf8-80ae710ce18e/crucible                                                              040dc13c-0267-430a-b20d-89fd0f000f0b   none      none          off        
--   oxp_debc9fb6-bd58-4e4f-b8b8-6a9a07fcf25d/crucible                                                              454c71e8-ba8d-4afd-af1f-0ceb403e6b6b   none      none          off        
--   oxp_f63a32a9-0659-43cf-8efc-8f34e7af9d45/crucible                                                              e97a59e3-8f57-42f3-95f5-316f966c5efc   none      none          off        
--   oxp_ffea118f-7715-4e21-8fc5-bb23cd0f59e8/crucible                                                              7f4605b3-1caf-4751-9485-2e9554d9b3b5   none      none          off        
--   oxp_069446b4-7881-49dc-838a-63a782d4896d/crypt/clickhouse                                                      3cc40210-6bf9-45fb-ac4b-8cae1c1529af   none      none          off        
--   oxp_069446b4-7881-49dc-838a-63a782d4896d/crypt/internal_dns                                                    cf3c6633-2c48-4963-a40d-acac89939915   none      none          off        
--   oxp_069446b4-7881-49dc-838a-63a782d4896d/crypt/zone                                                            bf59eede-81b0-4acb-b923-33681a92a14f   none      none          off        
--   oxp_20eba316-dffe-4516-9703-af561da19b0b/crypt/zone                                                            4e2be862-e2c1-4d37-ac57-34ceea106a0c   none      none          off        
--   oxp_426f4b6d-4a82-4106-bf4b-64ee86a2a5a4/crypt/zone                                                            07f06a1f-bb55-4e72-a84f-bb1cfd5d18a6   none      none          off        
--   oxp_82daeef2-8641-4bf5-ac66-f7b5f62c48b6/crypt/zone                                                            3dda6519-98a6-4943-b4e0-daf82b36526a   none      none          off        
--   oxp_8e5feeb2-14f1-440f-a909-3c34aa8e129b/crypt/zone                                                            064e7ade-7e0a-471c-9743-752a215d7f5c   none      none          off        
--   oxp_942e2123-7c4e-4f6b-9317-1341fe212647/crypt/zone                                                            5d9ec6b2-c3ad-4588-a8e3-4ad1c0d83643   none      none          off        
--   oxp_97a5ce17-df5b-47e7-baf8-80ae710ce18e/crypt/zone                                                            0fe8f233-160a-421b-aba6-1274f95ba79c   none      none          off        
--   oxp_debc9fb6-bd58-4e4f-b8b8-6a9a07fcf25d/crypt/zone                                                            d8d25341-34f7-4b98-b6e9-252c06a079fc   none      none          off        
--   oxp_f63a32a9-0659-43cf-8efc-8f34e7af9d45/crypt/zone                                                            5073b1d2-6dcb-4a42-afb8-c6dd74f50201   none      none          off        
--   oxp_ffea118f-7715-4e21-8fc5-bb23cd0f59e8/crypt/zone                                                            af81321c-23c6-4491-88a8-8eb5534aa8d8   none      none          off        
--   oxp_069446b4-7881-49dc-838a-63a782d4896d/crypt/zone/oxz_clickhouse_4e36b7ef-5684-4304-b7c3-3c31aaf83d4f        418538c2-112c-4bd6-9d02-054b08a79438   none      none          off        
--   oxp_20eba316-dffe-4516-9703-af561da19b0b/crypt/zone/oxz_crucible_1e1ed0cc-1adc-410f-943a-d1a3107de619          88c2e536-57af-4402-99dd-cfaca1862b41   none      none          off        
--   oxp_426f4b6d-4a82-4106-bf4b-64ee86a2a5a4/crypt/zone/oxz_crucible_2307bbed-02ba-493b-89e3-46585c74c8fc          d3e92497-a1c6-4aae-a192-21762cb35207   none      none          off        
--   oxp_ffea118f-7715-4e21-8fc5-bb23cd0f59e8/crypt/zone/oxz_crucible_2e65b765-5c41-4519-bf4e-e2a68569afc1          a0459348-1ea1-4a5f-a821-677ed1c46aa6   none      none          off        
--   oxp_97a5ce17-df5b-47e7-baf8-80ae710ce18e/crypt/zone/oxz_crucible_603e629d-2599-400e-b879-4134d4cc426e          5c06fe50-9fe1-44e1-85c2-38ba11e4495b   none      none          off        
--   oxp_8e5feeb2-14f1-440f-a909-3c34aa8e129b/crypt/zone/oxz_crucible_9179d6dc-387d-424e-8d62-ed59b2c728f6          5d1bf2c0-daab-4ec6-91c1-cd405da49ab9   none      none          off        
--   oxp_debc9fb6-bd58-4e4f-b8b8-6a9a07fcf25d/crypt/zone/oxz_crucible_ad76d200-5675-444b-b19c-684689ff421f          ed7d0891-d558-4c30-8d73-9594ae70b061   none      none          off        
--   oxp_82daeef2-8641-4bf5-ac66-f7b5f62c48b6/crypt/zone/oxz_crucible_c28d7b4b-a259-45ad-945d-f19ca3c6964c          6f1e99c9-4934-48f5-8b63-e0836d784bdc   none      none          off        
--   oxp_069446b4-7881-49dc-838a-63a782d4896d/crypt/zone/oxz_crucible_e29998e7-9ed2-46b6-bb70-4118159fe07f          da2dd11a-9022-4c2b-ad8b-f5650f223449   none      none          off        
--   oxp_f63a32a9-0659-43cf-8efc-8f34e7af9d45/crypt/zone/oxz_crucible_e9bf2525-5fa0-4c1b-b52d-481225083845          cbece778-757f-435a-86b1-97a6f4ad5a70   none      none          off        
--   oxp_942e2123-7c4e-4f6b-9317-1341fe212647/crypt/zone/oxz_crucible_f06e91a1-0c17-4cca-adbc-1c9b67bdb11d          1cebd581-aab7-42d5-a8a2-15b3e2f55e23   none      none          off        
--   oxp_069446b4-7881-49dc-838a-63a782d4896d/crypt/zone/oxz_crucible_pantry_f11f5c60-1ac7-4630-9a3a-a9bc85c75203   2efbbe4f-8548-4890-9f40-1bf099cf795e   none      none          off        
--   oxp_069446b4-7881-49dc-838a-63a782d4896d/crypt/zone/oxz_internal_dns_f231e4eb-3fc9-4964-9d71-2c41644852d9      b181a265-ccea-42ca-9259-aa405fb48d6f   none      none          off        
--   oxp_069446b4-7881-49dc-838a-63a782d4896d/crypt/zone/oxz_nexus_6a70a233-1900-43c0-9c00-aa9d1f7adfbc             8ac37626-6bbc-4fe7-9c95-8dbbc91c0dbe   none      none          off        
--   oxp_069446b4-7881-49dc-838a-63a782d4896d/crypt/zone/oxz_ntp_c62b87b6-b98d-4d22-ba4f-cee4499e2ba8               a351cc88-3b88-4408-ba57-098c1b610ffb   none      none          off        
--   oxp_069446b4-7881-49dc-838a-63a782d4896d/crypt/debug                                                           d01cbfd4-5f98-4f95-b362-7145429d3228   100 GiB   none          gzip-9     
--   oxp_20eba316-dffe-4516-9703-af561da19b0b/crypt/debug                                                           2cd129ba-90d2-4e0a-8de9-8779430bfd52   100 GiB   none          gzip-9     
--   oxp_426f4b6d-4a82-4106-bf4b-64ee86a2a5a4/crypt/debug                                                           15227fcb-319a-491f-bb0c-8d245bec4e58   100 GiB   none          gzip-9     
--   oxp_82daeef2-8641-4bf5-ac66-f7b5f62c48b6/crypt/debug                                                           9dc58815-aa5b-409a-98e7-7cbf92b17819   100 GiB   none          gzip-9     
--   oxp_8e5feeb2-14f1-440f-a909-3c34aa8e129b/crypt/debug                                                           56e40972-948d-4900-9d19-9d62b1983f43   100 GiB   none          gzip-9     
--   oxp_942e2123-7c4e-4f6b-9317-1341fe212647/crypt/debug                                                           81489861-36ab-4513-a5bb-953d3980974d   100 GiB   none          gzip-9     
--   oxp_97a5ce17-df5b-47e7-baf8-80ae710ce18e/crypt/debug                                                           59d4773a-d49c-4c28-acc6-92d80beb18f6   100 GiB   none          gzip-9     
--   oxp_debc9fb6-bd58-4e4f-b8b8-6a9a07fcf25d/crypt/debug                                                           433a21ac-1830-42ed-991b-18976ebf312f   100 GiB   none          gzip-9     
--   oxp_f63a32a9-0659-43cf-8efc-8f34e7af9d45/crypt/debug                                                           3568368a-2a70-4300-b689-3ec8d0bc8f71   100 GiB   none          gzip-9     
--   oxp_ffea118f-7715-4e21-8fc5-bb23cd0f59e8/crypt/debug                                                           c84f4ae2-e449-4980-acdd-b3a5ac7e506a   100 GiB   none          gzip-9     
+-   oxp_069446b4-7881-49dc-838a-63a782d4896d/crucible                                                              6c3dbdf9-0871-48d5-b32d-f93dbc0adef9   none      none          off        
+-   oxp_20eba316-dffe-4516-9703-af561da19b0b/crucible                                                              16cedd55-3841-489b-8268-b60d42f3aa26   none      none          off        
+-   oxp_426f4b6d-4a82-4106-bf4b-64ee86a2a5a4/crucible                                                              64222170-0027-4f28-a934-387689d63ac8   none      none          off        
+-   oxp_82daeef2-8641-4bf5-ac66-f7b5f62c48b6/crucible                                                              b6b8607b-1639-458d-9c27-6adb9d6eaebd   none      none          off        
+-   oxp_8e5feeb2-14f1-440f-a909-3c34aa8e129b/crucible                                                              5191937e-a424-4b1b-aef9-2f8a1065b874   none      none          off        
+-   oxp_942e2123-7c4e-4f6b-9317-1341fe212647/crucible                                                              c3bb341f-09c5-4f6d-b4ed-6689f46ebf86   none      none          off        
+-   oxp_97a5ce17-df5b-47e7-baf8-80ae710ce18e/crucible                                                              5cee7433-4662-42a0-948c-26c96580bc27   none      none          off        
+-   oxp_debc9fb6-bd58-4e4f-b8b8-6a9a07fcf25d/crucible                                                              b6d4ceab-9815-4672-9359-073b6c5e5678   none      none          off        
+-   oxp_f63a32a9-0659-43cf-8efc-8f34e7af9d45/crucible                                                              7d3ce847-80bb-48cd-9e7a-588f67303326   none      none          off        
+-   oxp_ffea118f-7715-4e21-8fc5-bb23cd0f59e8/crucible                                                              28439e9e-4972-4c63-83e9-a6b575275361   none      none          off        
+-   oxp_069446b4-7881-49dc-838a-63a782d4896d/crypt/clickhouse                                                      dca7679a-b028-40fe-bf45-54f53d15850d   none      none          off        
+-   oxp_069446b4-7881-49dc-838a-63a782d4896d/crypt/internal_dns                                                    aa1b3c0b-2cde-4ed2-8a36-679aacb3f6f8   none      none          off        
+-   oxp_069446b4-7881-49dc-838a-63a782d4896d/crypt/zone                                                            dd41720e-4936-45d0-8fb2-926d8066ea02   none      none          off        
+-   oxp_20eba316-dffe-4516-9703-af561da19b0b/crypt/zone                                                            704d24de-9d71-4834-8cd5-72cda2745c62   none      none          off        
+-   oxp_426f4b6d-4a82-4106-bf4b-64ee86a2a5a4/crypt/zone                                                            bf13115d-7900-4f67-8071-ff7acc7fa30f   none      none          off        
+-   oxp_82daeef2-8641-4bf5-ac66-f7b5f62c48b6/crypt/zone                                                            b1adb353-1eb1-4093-b5e3-dda3baf09a27   none      none          off        
+-   oxp_8e5feeb2-14f1-440f-a909-3c34aa8e129b/crypt/zone                                                            214b02d1-d63e-49c4-acfb-3fff1254961e   none      none          off        
+-   oxp_942e2123-7c4e-4f6b-9317-1341fe212647/crypt/zone                                                            24778f3d-473d-4c03-8e33-cfef2c11f783   none      none          off        
+-   oxp_97a5ce17-df5b-47e7-baf8-80ae710ce18e/crypt/zone                                                            fe0dc780-8237-4eb5-b6ba-6e0dffdc90a8   none      none          off        
+-   oxp_debc9fb6-bd58-4e4f-b8b8-6a9a07fcf25d/crypt/zone                                                            752c2113-c084-4297-be5a-900abc9d091b   none      none          off        
+-   oxp_f63a32a9-0659-43cf-8efc-8f34e7af9d45/crypt/zone                                                            565a1a74-53a9-40b5-8de0-66c0b1cc5b24   none      none          off        
+-   oxp_ffea118f-7715-4e21-8fc5-bb23cd0f59e8/crypt/zone                                                            16d104de-5149-4a2f-90c4-517252ffa112   none      none          off        
+-   oxp_069446b4-7881-49dc-838a-63a782d4896d/crypt/zone/oxz_clickhouse_3fd081ea-93f1-417e-bcb1-405854435f28        426ee766-c13a-42cb-9a08-9c5af90cf559   none      none          off        
+-   oxp_ffea118f-7715-4e21-8fc5-bb23cd0f59e8/crypt/zone/oxz_crucible_290e7e97-c4b3-47da-9f40-8d909397fbae          4fa44ded-a308-4f69-b0ba-ea60e2a2319a   none      none          off        
+-   oxp_942e2123-7c4e-4f6b-9317-1341fe212647/crypt/zone/oxz_crucible_29bbe4ad-e6e8-4e05-b188-a811a793ccbb          c35c1a79-41a2-45dc-a0dd-a9bbabf34462   none      none          off        
+-   oxp_8e5feeb2-14f1-440f-a909-3c34aa8e129b/crypt/zone/oxz_crucible_8500a060-a426-4324-ba40-a66dd4b89bc6          8ef95c11-2ec4-4764-ba85-d78f3c4cacf0   none      none          off        
+-   oxp_069446b4-7881-49dc-838a-63a782d4896d/crypt/zone/oxz_crucible_92b7abd8-3e34-49dd-9c56-19a314e97d49          364f8c8d-4924-468e-851c-42b504ab87ae   none      none          off        
+-   oxp_20eba316-dffe-4516-9703-af561da19b0b/crypt/zone/oxz_crucible_b320954e-6c66-4540-9bf4-3d976f21ee1b          0059c701-30b8-4f30-85b1-60ce6265978b   none      none          off        
+-   oxp_426f4b6d-4a82-4106-bf4b-64ee86a2a5a4/crypt/zone/oxz_crucible_bc3e4495-7e51-46b6-9f55-026ea1da39dd          e46deb07-6509-4f5d-b0b7-fbeff03bdedf   none      none          off        
+-   oxp_82daeef2-8641-4bf5-ac66-f7b5f62c48b6/crypt/zone/oxz_crucible_cfb7595b-280c-40f5-b1aa-6e154adf280b          dbfdcc07-9c21-4231-bcc7-bb5933412e46   none      none          off        
+-   oxp_debc9fb6-bd58-4e4f-b8b8-6a9a07fcf25d/crypt/zone/oxz_crucible_d6b6ea5a-3f29-4815-aa42-b1afeb11dfc5          dd090f1e-bb4b-4f1b-a295-53e94fb880e7   none      none          off        
+-   oxp_97a5ce17-df5b-47e7-baf8-80ae710ce18e/crypt/zone/oxz_crucible_d6b77c1f-8c9e-406d-944e-c97a57b3984d          4b5e0d5a-b6ff-4ca7-821f-bc96a2686df7   none      none          off        
+-   oxp_f63a32a9-0659-43cf-8efc-8f34e7af9d45/crypt/zone/oxz_crucible_ecc03801-b315-4495-9b2c-49e0eead1283          56654da3-2657-4392-94f1-1d4f6853d178   none      none          off        
+-   oxp_069446b4-7881-49dc-838a-63a782d4896d/crypt/zone/oxz_crucible_pantry_ecebab45-11e7-47ab-8bc2-ab9114c6e2bc   42d694ba-0a83-4a27-96a5-166dbf0b2440   none      none          off        
+-   oxp_069446b4-7881-49dc-838a-63a782d4896d/crypt/zone/oxz_internal_dns_96b7a45b-be74-44e8-b68a-e530cfa81830      8a4183fd-c357-4857-9717-a577dbb8b5a4   none      none          off        
+-   oxp_069446b4-7881-49dc-838a-63a782d4896d/crypt/zone/oxz_nexus_bc0f4342-f88d-49cc-bb44-b555d9b8ca12             238cbec5-a63d-41b6-93d0-1fdd2b789872   none      none          off        
+-   oxp_069446b4-7881-49dc-838a-63a782d4896d/crypt/zone/oxz_ntp_b3dbc671-0e4d-49ff-9f4f-71b249d21f57               4ea6474a-6e19-487f-877a-8f18d085bfd3   none      none          off        
+-   oxp_069446b4-7881-49dc-838a-63a782d4896d/crypt/debug                                                           47b590b2-dba4-4cd6-b0ec-91ef84697d9c   100 GiB   none          gzip-9     
+-   oxp_20eba316-dffe-4516-9703-af561da19b0b/crypt/debug                                                           69c1e2e4-1038-4c8b-8c86-2b254e100915   100 GiB   none          gzip-9     
+-   oxp_426f4b6d-4a82-4106-bf4b-64ee86a2a5a4/crypt/debug                                                           f6d25d99-0ee3-4f25-a94f-e2b1353abe3f   100 GiB   none          gzip-9     
+-   oxp_82daeef2-8641-4bf5-ac66-f7b5f62c48b6/crypt/debug                                                           bdbefa26-d30a-480e-8a22-f7c93421d6e0   100 GiB   none          gzip-9     
+-   oxp_8e5feeb2-14f1-440f-a909-3c34aa8e129b/crypt/debug                                                           b5a777ab-6722-4511-b35a-8dbd099968c6   100 GiB   none          gzip-9     
+-   oxp_942e2123-7c4e-4f6b-9317-1341fe212647/crypt/debug                                                           48828e8f-eaf5-4ec4-a5ec-5cbf5d616cb3   100 GiB   none          gzip-9     
+-   oxp_97a5ce17-df5b-47e7-baf8-80ae710ce18e/crypt/debug                                                           e02c001d-9270-4788-ad91-576470e751de   100 GiB   none          gzip-9     
+-   oxp_debc9fb6-bd58-4e4f-b8b8-6a9a07fcf25d/crypt/debug                                                           7a39606c-fbed-4aec-ac06-6ad7d5a2c7d4   100 GiB   none          gzip-9     
+-   oxp_f63a32a9-0659-43cf-8efc-8f34e7af9d45/crypt/debug                                                           31802082-7903-4270-983e-5681228436be   100 GiB   none          gzip-9     
+-   oxp_ffea118f-7715-4e21-8fc5-bb23cd0f59e8/crypt/debug                                                           d7eaf6f8-440a-405e-9234-35ba00e09e85   100 GiB   none          gzip-9     
 
 
     omicron zones generation 2 -> 3:
     ----------------------------------------------------------------------------------------------
     zone type         zone id                                disposition    underlay IP           
     ----------------------------------------------------------------------------------------------
-*   clickhouse        4e36b7ef-5684-4304-b7c3-3c31aaf83d4f   - in service   fd00:1122:3344:103::23
+*   clickhouse        3fd081ea-93f1-417e-bcb1-405854435f28   - in service   fd00:1122:3344:103::23
      └─                                                      + expunged                           
-*   crucible          1e1ed0cc-1adc-410f-943a-d1a3107de619   - in service   fd00:1122:3344:103::26
+*   crucible          290e7e97-c4b3-47da-9f40-8d909397fbae   - in service   fd00:1122:3344:103::2e
      └─                                                      + expunged                           
-*   crucible          2307bbed-02ba-493b-89e3-46585c74c8fc   - in service   fd00:1122:3344:103::27
+*   crucible          29bbe4ad-e6e8-4e05-b188-a811a793ccbb   - in service   fd00:1122:3344:103::2a
      └─                                                      + expunged                           
-*   crucible          2e65b765-5c41-4519-bf4e-e2a68569afc1   - in service   fd00:1122:3344:103::2e
+*   crucible          8500a060-a426-4324-ba40-a66dd4b89bc6   - in service   fd00:1122:3344:103::29
      └─                                                      + expunged                           
-*   crucible          603e629d-2599-400e-b879-4134d4cc426e   - in service   fd00:1122:3344:103::2b
+*   crucible          92b7abd8-3e34-49dd-9c56-19a314e97d49   - in service   fd00:1122:3344:103::25
      └─                                                      + expunged                           
-*   crucible          9179d6dc-387d-424e-8d62-ed59b2c728f6   - in service   fd00:1122:3344:103::29
+*   crucible          b320954e-6c66-4540-9bf4-3d976f21ee1b   - in service   fd00:1122:3344:103::26
      └─                                                      + expunged                           
-*   crucible          ad76d200-5675-444b-b19c-684689ff421f   - in service   fd00:1122:3344:103::2c
+*   crucible          bc3e4495-7e51-46b6-9f55-026ea1da39dd   - in service   fd00:1122:3344:103::27
      └─                                                      + expunged                           
-*   crucible          c28d7b4b-a259-45ad-945d-f19ca3c6964c   - in service   fd00:1122:3344:103::28
+*   crucible          cfb7595b-280c-40f5-b1aa-6e154adf280b   - in service   fd00:1122:3344:103::28
      └─                                                      + expunged                           
-*   crucible          e29998e7-9ed2-46b6-bb70-4118159fe07f   - in service   fd00:1122:3344:103::25
+*   crucible          d6b6ea5a-3f29-4815-aa42-b1afeb11dfc5   - in service   fd00:1122:3344:103::2c
      └─                                                      + expunged                           
-*   crucible          e9bf2525-5fa0-4c1b-b52d-481225083845   - in service   fd00:1122:3344:103::2d
+*   crucible          d6b77c1f-8c9e-406d-944e-c97a57b3984d   - in service   fd00:1122:3344:103::2b
      └─                                                      + expunged                           
-*   crucible          f06e91a1-0c17-4cca-adbc-1c9b67bdb11d   - in service   fd00:1122:3344:103::2a
+*   crucible          ecc03801-b315-4495-9b2c-49e0eead1283   - in service   fd00:1122:3344:103::2d
      └─                                                      + expunged                           
-*   crucible_pantry   f11f5c60-1ac7-4630-9a3a-a9bc85c75203   - in service   fd00:1122:3344:103::24
+*   crucible_pantry   ecebab45-11e7-47ab-8bc2-ab9114c6e2bc   - in service   fd00:1122:3344:103::24
      └─                                                      + expunged                           
-*   internal_dns      f231e4eb-3fc9-4964-9d71-2c41644852d9   - in service   fd00:1122:3344:1::1   
+*   internal_dns      96b7a45b-be74-44e8-b68a-e530cfa81830   - in service   fd00:1122:3344:1::1   
      └─                                                      + expunged                           
-*   internal_ntp      c62b87b6-b98d-4d22-ba4f-cee4499e2ba8   - in service   fd00:1122:3344:103::21
+*   internal_ntp      b3dbc671-0e4d-49ff-9f4f-71b249d21f57   - in service   fd00:1122:3344:103::21
      └─                                                      + expunged                           
-*   nexus             6a70a233-1900-43c0-9c00-aa9d1f7adfbc   - in service   fd00:1122:3344:103::22
+*   nexus             bc0f4342-f88d-49cc-bb44-b555d9b8ca12   - in service   fd00:1122:3344:103::22
      └─                                                      + expunged                           
 
 
@@ -132,75 +132,75 @@ to:   blueprint 1ac2d88f-27dd-4506-8585-6b2be832528e
     -----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
     dataset name                                                                                                   dataset uuid                           quota     reservation   compression
     -----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
-    oxp_1e2ec79e-9c11-4133-ac77-e0b994a507d5/crucible                                                              3629f248-3fc1-4073-b21b-6a1529fa204e   none      none          off        
-    oxp_440ae69d-5e2e-4539-91d0-e2930bdd7203/crucible                                                              0cf030b7-7c47-4304-8247-1a20e6048554   none      none          off        
-    oxp_4e91d4a3-bb6c-44bb-bd4e-bf8913c1ba2b/crucible                                                              8ee49248-8d40-4637-8aad-049c9b312bf2   none      none          off        
-    oxp_67de3a80-29cb-4066-b743-e285a2ca1f4e/crucible                                                              fb826e91-9b48-433e-9fc4-dbe56982f94a   none      none          off        
-    oxp_9139b70f-c1d3-475d-8f02-7c9acba52b2b/crucible                                                              cbd086a5-8730-49ce-983f-a870416589e5   none      none          off        
-    oxp_95fbb110-5272-4646-ab50-21b31b7cde23/crucible                                                              cf4285e6-acd6-4bd6-80a7-4d28c1f1d543   none      none          off        
-    oxp_9bf35cd7-4938-4c34-8189-288b3195cb64/crucible                                                              5159978d-1d63-4c7a-935f-819c39c4b15b   none      none          off        
-    oxp_9d833141-18a1-4f24-8a34-6076c026aa87/crucible                                                              c358c3ef-daa8-4b2d-8c5d-fd760798fcd8   none      none          off        
-    oxp_a279461f-a7b9-413f-a79f-cb4dab4c3fce/crucible                                                              fbc90cb1-5616-48cc-8b13-89acd5209f4f   none      none          off        
-    oxp_ff7e002b-3ad8-4d45-b03a-c46ef0ac8e59/crucible                                                              0aa0ec68-c208-4d91-beec-cfb7fdc33895   none      none          off        
-    oxp_1e2ec79e-9c11-4133-ac77-e0b994a507d5/crypt/internal_dns                                                    1114a853-37f6-4933-8ab1-85ad855145ea   none      none          off        
-    oxp_1e2ec79e-9c11-4133-ac77-e0b994a507d5/crypt/zone                                                            7627711f-c877-4892-8bb9-2ab494673bab   none      none          off        
-    oxp_440ae69d-5e2e-4539-91d0-e2930bdd7203/crypt/zone                                                            fb4ac064-d11e-4afb-bfc8-b87c58b71977   none      none          off        
-    oxp_4e91d4a3-bb6c-44bb-bd4e-bf8913c1ba2b/crypt/zone                                                            d48badf3-3993-44a5-809c-4eacad8fb929   none      none          off        
-    oxp_67de3a80-29cb-4066-b743-e285a2ca1f4e/crypt/zone                                                            84488b5f-690c-4a21-b14a-9288eaa54488   none      none          off        
-    oxp_9139b70f-c1d3-475d-8f02-7c9acba52b2b/crypt/zone                                                            b1144b57-1e79-41a6-ae1b-9676d777f628   none      none          off        
-    oxp_95fbb110-5272-4646-ab50-21b31b7cde23/crypt/zone                                                            141811b6-c055-46b9-9a20-7c6265d507ee   none      none          off        
-    oxp_9bf35cd7-4938-4c34-8189-288b3195cb64/crypt/zone                                                            b55242c9-3e0c-4bb9-b702-0d94893388a3   none      none          off        
-    oxp_9d833141-18a1-4f24-8a34-6076c026aa87/crypt/zone                                                            2a72fbf4-ff92-47a2-a4b9-2a702215c946   none      none          off        
-    oxp_a279461f-a7b9-413f-a79f-cb4dab4c3fce/crypt/zone                                                            813c6cd2-b100-4481-aaf4-c008f2e81d6f   none      none          off        
-    oxp_ff7e002b-3ad8-4d45-b03a-c46ef0ac8e59/crypt/zone                                                            4ed5d6be-14cc-4bb5-b0d3-88a48b539751   none      none          off        
-    oxp_9d833141-18a1-4f24-8a34-6076c026aa87/crypt/zone/oxz_crucible_4f8ce495-21dd-48a1-859c-80d34ce394ed          eed07a8f-8a64-46fc-9ee8-dff2e610b655   none      none          off        
-    oxp_4e91d4a3-bb6c-44bb-bd4e-bf8913c1ba2b/crypt/zone/oxz_crucible_5d9d8fa7-8379-470b-90ba-fe84a3c45512          07f839aa-beb9-4730-b8eb-7b52a2e40872   none      none          off        
-    oxp_1e2ec79e-9c11-4133-ac77-e0b994a507d5/crypt/zone/oxz_crucible_70232a6d-6c9d-4fa6-a34d-9c73d940db33          b860f342-824e-4f30-960d-7e2fe519b72b   none      none          off        
-    oxp_9139b70f-c1d3-475d-8f02-7c9acba52b2b/crypt/zone/oxz_crucible_8567a616-a709-4c8c-a323-4474675dad5c          67c894bc-e684-42e7-8bc8-1fe86356165e   none      none          off        
-    oxp_440ae69d-5e2e-4539-91d0-e2930bdd7203/crypt/zone/oxz_crucible_8b0b8623-930a-41af-9f9b-ca28b1b11139          0d862983-16aa-4d85-a6f3-78de73b063bb   none      none          off        
-    oxp_9bf35cd7-4938-4c34-8189-288b3195cb64/crypt/zone/oxz_crucible_99c6401d-9796-4ae1-bf0c-9a097cf21c33          6dfbbad9-2860-4547-8962-35224ff3251a   none      none          off        
-    oxp_a279461f-a7b9-413f-a79f-cb4dab4c3fce/crypt/zone/oxz_crucible_a1ae92ac-e1f1-4654-ab54-5b75ba7c44d6          de262cbb-4a71-4f24-a483-1d190bb1fc49   none      none          off        
-    oxp_ff7e002b-3ad8-4d45-b03a-c46ef0ac8e59/crypt/zone/oxz_crucible_a308d3e1-118c-440a-947a-8b6ab7d833ab          1c597048-bc3f-46d5-94cb-3507ada774e3   none      none          off        
-    oxp_67de3a80-29cb-4066-b743-e285a2ca1f4e/crypt/zone/oxz_crucible_cf87d2a3-d323-44a3-a87e-adc4ef6c75f4          f39b842a-f73c-4aae-a5ac-fc707fa49dca   none      none          off        
-    oxp_95fbb110-5272-4646-ab50-21b31b7cde23/crypt/zone/oxz_crucible_f68846ad-4619-4747-8293-a2b4aeeafc5b          dcc8dea5-c5a2-4559-8629-0015a3b4820e   none      none          off        
-    oxp_1e2ec79e-9c11-4133-ac77-e0b994a507d5/crypt/zone/oxz_crucible_pantry_15dbaa30-1539-49d6-970d-ba5962960f33   6d4bc7b7-5f22-44e5-8578-fba855718b56   none      none          off        
-    oxp_1e2ec79e-9c11-4133-ac77-e0b994a507d5/crypt/zone/oxz_internal_dns_eac6c0a0-baa5-4490-9cee-65198b7fbd9c      13ef9dfc-1881-4517-b518-b94d8b8f196e   none      none          off        
-    oxp_1e2ec79e-9c11-4133-ac77-e0b994a507d5/crypt/zone/oxz_nexus_3d4143df-e212-4774-9258-7d9b421fac2e             aba6813b-e60b-44cb-b22f-934bd6e28cf9   none      none          off        
-    oxp_1e2ec79e-9c11-4133-ac77-e0b994a507d5/crypt/zone/oxz_ntp_1ec4cc7b-2f00-4d13-8176-3b9815533ae9               67169d16-1b64-4236-8cff-6d06a7ab84cd   none      none          off        
-    oxp_1e2ec79e-9c11-4133-ac77-e0b994a507d5/crypt/debug                                                           64793588-5ff8-42d8-af9d-f7b58a2d1431   100 GiB   none          gzip-9     
-    oxp_440ae69d-5e2e-4539-91d0-e2930bdd7203/crypt/debug                                                           54954ab8-0874-41f7-9382-02aae6831f4c   100 GiB   none          gzip-9     
-    oxp_4e91d4a3-bb6c-44bb-bd4e-bf8913c1ba2b/crypt/debug                                                           112a7b3e-f24f-4a14-94f2-32a1ad8cdbe3   100 GiB   none          gzip-9     
-    oxp_67de3a80-29cb-4066-b743-e285a2ca1f4e/crypt/debug                                                           73542884-3a70-4acc-a474-b7d361e79909   100 GiB   none          gzip-9     
-    oxp_9139b70f-c1d3-475d-8f02-7c9acba52b2b/crypt/debug                                                           d86839e1-e253-4ae2-b1ac-03b7020614cd   100 GiB   none          gzip-9     
-    oxp_95fbb110-5272-4646-ab50-21b31b7cde23/crypt/debug                                                           fe27d4c5-cb2b-461c-a03b-3cd163682098   100 GiB   none          gzip-9     
-    oxp_9bf35cd7-4938-4c34-8189-288b3195cb64/crypt/debug                                                           96883b04-1e79-4c38-a0e9-6eaa806df51e   100 GiB   none          gzip-9     
-    oxp_9d833141-18a1-4f24-8a34-6076c026aa87/crypt/debug                                                           f631d6a1-9db5-4fc7-978b-9ace485dfe16   100 GiB   none          gzip-9     
-    oxp_a279461f-a7b9-413f-a79f-cb4dab4c3fce/crypt/debug                                                           1b9c97d6-c90d-4109-b99c-9ab799b3c3b9   100 GiB   none          gzip-9     
-    oxp_ff7e002b-3ad8-4d45-b03a-c46ef0ac8e59/crypt/debug                                                           9427caff-29ec-4cd1-981b-26d4a7900052   100 GiB   none          gzip-9     
-+   oxp_440ae69d-5e2e-4539-91d0-e2930bdd7203/crypt/zone/oxz_crucible_pantry_ff9ce09c-afbf-425b-bbfa-3d8fb254f98e   7d47e5d6-a1a5-451a-b4b4-3a9747f8154a   none      none          off        
-+   oxp_440ae69d-5e2e-4539-91d0-e2930bdd7203/crypt/zone/oxz_nexus_845869e9-ecb2-4ec3-b6b8-2a836e459243             a759d2f3-003c-4fb8-b06b-f985e213b273   none      none          off        
+    oxp_1e2ec79e-9c11-4133-ac77-e0b994a507d5/crucible                                                              6faaf132-5e10-43a9-926c-abc32ad8b2fe   none      none          off        
+    oxp_440ae69d-5e2e-4539-91d0-e2930bdd7203/crucible                                                              cbb904a8-0871-4038-933c-7393bbc0738c   none      none          off        
+    oxp_4e91d4a3-bb6c-44bb-bd4e-bf8913c1ba2b/crucible                                                              75b0260f-d857-434f-b0a6-d1b0b23702e2   none      none          off        
+    oxp_67de3a80-29cb-4066-b743-e285a2ca1f4e/crucible                                                              80f92c60-b0f3-4841-ae1d-350f9263c51f   none      none          off        
+    oxp_9139b70f-c1d3-475d-8f02-7c9acba52b2b/crucible                                                              ec3fcfea-8287-4e80-8f53-7967a939db01   none      none          off        
+    oxp_95fbb110-5272-4646-ab50-21b31b7cde23/crucible                                                              9cc9e83b-d758-4be4-b9c5-5ab4e0d0c201   none      none          off        
+    oxp_9bf35cd7-4938-4c34-8189-288b3195cb64/crucible                                                              4e7dac6e-b754-4911-89c1-1c9cd6a68ace   none      none          off        
+    oxp_9d833141-18a1-4f24-8a34-6076c026aa87/crucible                                                              4f33ef0a-829e-48c1-b5b9-a4e11f0f38c3   none      none          off        
+    oxp_a279461f-a7b9-413f-a79f-cb4dab4c3fce/crucible                                                              259a9726-27bc-495e-b7d2-29c884561005   none      none          off        
+    oxp_ff7e002b-3ad8-4d45-b03a-c46ef0ac8e59/crucible                                                              df77d6ef-0910-433c-a7a5-baef6c34fc86   none      none          off        
+    oxp_1e2ec79e-9c11-4133-ac77-e0b994a507d5/crypt/internal_dns                                                    e43ceee2-3657-4145-8e8f-fac08f34573b   none      none          off        
+    oxp_1e2ec79e-9c11-4133-ac77-e0b994a507d5/crypt/zone                                                            dc72e5ba-059c-4075-9d2c-7c69116e17ec   none      none          off        
+    oxp_440ae69d-5e2e-4539-91d0-e2930bdd7203/crypt/zone                                                            64a09f6f-3aa2-416d-a133-bfa44af9e83c   none      none          off        
+    oxp_4e91d4a3-bb6c-44bb-bd4e-bf8913c1ba2b/crypt/zone                                                            48679db3-ca47-4bde-8ee7-6a6b2ab2afdb   none      none          off        
+    oxp_67de3a80-29cb-4066-b743-e285a2ca1f4e/crypt/zone                                                            4177690d-bf09-45a1-add0-6c25f4d4806e   none      none          off        
+    oxp_9139b70f-c1d3-475d-8f02-7c9acba52b2b/crypt/zone                                                            94e76685-337a-45ba-946f-e3ec5408c58a   none      none          off        
+    oxp_95fbb110-5272-4646-ab50-21b31b7cde23/crypt/zone                                                            bc07535b-996c-402d-b488-d6b959c7c267   none      none          off        
+    oxp_9bf35cd7-4938-4c34-8189-288b3195cb64/crypt/zone                                                            5e6eb3f4-a68a-418a-917b-3beafd068acd   none      none          off        
+    oxp_9d833141-18a1-4f24-8a34-6076c026aa87/crypt/zone                                                            34f23c48-7d0a-4d83-98f8-4746e14a3315   none      none          off        
+    oxp_a279461f-a7b9-413f-a79f-cb4dab4c3fce/crypt/zone                                                            70723c5d-41ba-47db-bb36-47ccc07325de   none      none          off        
+    oxp_ff7e002b-3ad8-4d45-b03a-c46ef0ac8e59/crypt/zone                                                            f33074db-c35d-4cd8-a701-c28334be71d8   none      none          off        
+    oxp_ff7e002b-3ad8-4d45-b03a-c46ef0ac8e59/crypt/zone/oxz_crucible_052553cb-8a1a-42a4-a6cb-97a913e78877          7f96c7eb-3117-4d62-92ff-04ca0b4d4a93   none      none          off        
+    oxp_67de3a80-29cb-4066-b743-e285a2ca1f4e/crypt/zone/oxz_crucible_1bd2301a-acd3-4a9c-82d7-b0c19a3c5597          973ab9e7-2437-4d00-b6d4-61f19e352a2e   none      none          off        
+    oxp_9d833141-18a1-4f24-8a34-6076c026aa87/crypt/zone/oxz_crucible_7975aa01-6fa9-4622-a8ba-8bfcf000f8eb          3c378515-facd-4c9f-b2b3-0920fe04456d   none      none          off        
+    oxp_9139b70f-c1d3-475d-8f02-7c9acba52b2b/crypt/zone/oxz_crucible_85286e23-2498-4034-9999-c5263fc0295f          5eaa35c8-c0b4-40ad-ba1d-2ba9286b1acd   none      none          off        
+    oxp_a279461f-a7b9-413f-a79f-cb4dab4c3fce/crypt/zone/oxz_crucible_a320b746-b5f6-4027-9c3c-d41e099f2def          0e65e617-9258-4b02-a0a5-76ce1b5c65d9   none      none          off        
+    oxp_440ae69d-5e2e-4539-91d0-e2930bdd7203/crypt/zone/oxz_crucible_dcd393d4-d16c-41a8-8c16-48e0ab80d2e2          c2de0977-abf7-4c6c-b8ce-425c10d8da09   none      none          off        
+    oxp_4e91d4a3-bb6c-44bb-bd4e-bf8913c1ba2b/crypt/zone/oxz_crucible_de34e868-675e-4291-a2f7-c0b24e2e18a1          6afaa452-d2ff-4ea9-ad6e-b0b59183ef2b   none      none          off        
+    oxp_1e2ec79e-9c11-4133-ac77-e0b994a507d5/crypt/zone/oxz_crucible_e11dd8a6-951a-4019-8775-bed3a2092aaa          b3cd735d-4d94-412a-9a25-06b9fab912e0   none      none          off        
+    oxp_9bf35cd7-4938-4c34-8189-288b3195cb64/crypt/zone/oxz_crucible_f8cdd98e-4ab4-46bb-b621-7590808582cc          4befe2e1-3d46-4b61-a92a-66f27db0df0e   none      none          off        
+    oxp_95fbb110-5272-4646-ab50-21b31b7cde23/crypt/zone/oxz_crucible_fcccf363-d190-441c-ba40-58e24f8a9cb3          82c66769-fc0d-49df-bb32-bc7f61892134   none      none          off        
+    oxp_1e2ec79e-9c11-4133-ac77-e0b994a507d5/crypt/zone/oxz_crucible_pantry_a22472df-5df2-4c1f-ad1f-439a4164984f   2b22a609-539c-478a-939e-ba25068d31ee   none      none          off        
+    oxp_1e2ec79e-9c11-4133-ac77-e0b994a507d5/crypt/zone/oxz_internal_dns_936b1cbb-84e5-48ab-bc59-3bbd7830a421      1f4d6d18-0bdf-4e39-b838-b82fb1eac0e0   none      none          off        
+    oxp_1e2ec79e-9c11-4133-ac77-e0b994a507d5/crypt/zone/oxz_nexus_33ef9872-ee9a-4478-89b9-b22b78e00d3a             7924cb4a-4be3-4346-820a-04bfdb3c03a8   none      none          off        
+    oxp_1e2ec79e-9c11-4133-ac77-e0b994a507d5/crypt/zone/oxz_ntp_52031fcc-eb18-45f5-ae6c-65c7858b5e93               44dce497-2648-40ab-9a0f-d896c9b61db1   none      none          off        
+    oxp_1e2ec79e-9c11-4133-ac77-e0b994a507d5/crypt/debug                                                           a5a387a4-2e8d-4038-b386-bf1dffc96d41   100 GiB   none          gzip-9     
+    oxp_440ae69d-5e2e-4539-91d0-e2930bdd7203/crypt/debug                                                           c61256ce-c152-4658-8e49-b31f65b615e8   100 GiB   none          gzip-9     
+    oxp_4e91d4a3-bb6c-44bb-bd4e-bf8913c1ba2b/crypt/debug                                                           52828e06-cdaf-4291-9d1c-b5b1f42515af   100 GiB   none          gzip-9     
+    oxp_67de3a80-29cb-4066-b743-e285a2ca1f4e/crypt/debug                                                           4173e69d-fb09-4068-a3f9-23638e968082   100 GiB   none          gzip-9     
+    oxp_9139b70f-c1d3-475d-8f02-7c9acba52b2b/crypt/debug                                                           bf42b426-4b74-433b-bc3e-7d4e7f1afba4   100 GiB   none          gzip-9     
+    oxp_95fbb110-5272-4646-ab50-21b31b7cde23/crypt/debug                                                           250aa09f-3953-4ce6-8160-67ecabc98add   100 GiB   none          gzip-9     
+    oxp_9bf35cd7-4938-4c34-8189-288b3195cb64/crypt/debug                                                           34a79944-be59-4246-afda-b676e91afddb   100 GiB   none          gzip-9     
+    oxp_9d833141-18a1-4f24-8a34-6076c026aa87/crypt/debug                                                           9d168de0-6b87-405d-b4fc-926b381b0c45   100 GiB   none          gzip-9     
+    oxp_a279461f-a7b9-413f-a79f-cb4dab4c3fce/crypt/debug                                                           9ace6e03-ed94-4444-b524-c3978461964c   100 GiB   none          gzip-9     
+    oxp_ff7e002b-3ad8-4d45-b03a-c46ef0ac8e59/crypt/debug                                                           f43393b3-98ce-48b7-9c97-cb25b5a93130   100 GiB   none          gzip-9     
++   oxp_440ae69d-5e2e-4539-91d0-e2930bdd7203/crypt/zone/oxz_crucible_pantry_6b6843d6-062c-4400-8fd9-d11b5d138fe6   204afeeb-fde3-400f-b809-e1acfc11bf7e   none      none          off        
++   oxp_440ae69d-5e2e-4539-91d0-e2930bdd7203/crypt/zone/oxz_nexus_75fb916b-4793-4cd0-873b-573768b1efe5             9a3ecdfc-970b-4376-8f89-7fe8751ae9f5   none      none          off        
 
 
     omicron zones generation 2 -> 3:
     ---------------------------------------------------------------------------------------------
     zone type         zone id                                disposition   underlay IP           
     ---------------------------------------------------------------------------------------------
-    crucible          4f8ce495-21dd-48a1-859c-80d34ce394ed   in service    fd00:1122:3344:101::2b
-    crucible          5d9d8fa7-8379-470b-90ba-fe84a3c45512   in service    fd00:1122:3344:101::26
-    crucible          70232a6d-6c9d-4fa6-a34d-9c73d940db33   in service    fd00:1122:3344:101::24
-    crucible          8567a616-a709-4c8c-a323-4474675dad5c   in service    fd00:1122:3344:101::28
-    crucible          8b0b8623-930a-41af-9f9b-ca28b1b11139   in service    fd00:1122:3344:101::25
-    crucible          99c6401d-9796-4ae1-bf0c-9a097cf21c33   in service    fd00:1122:3344:101::2a
-    crucible          a1ae92ac-e1f1-4654-ab54-5b75ba7c44d6   in service    fd00:1122:3344:101::2c
-    crucible          a308d3e1-118c-440a-947a-8b6ab7d833ab   in service    fd00:1122:3344:101::2d
-    crucible          cf87d2a3-d323-44a3-a87e-adc4ef6c75f4   in service    fd00:1122:3344:101::27
-    crucible          f68846ad-4619-4747-8293-a2b4aeeafc5b   in service    fd00:1122:3344:101::29
-    crucible_pantry   15dbaa30-1539-49d6-970d-ba5962960f33   in service    fd00:1122:3344:101::23
-    internal_dns      eac6c0a0-baa5-4490-9cee-65198b7fbd9c   in service    fd00:1122:3344:2::1   
-    internal_ntp      1ec4cc7b-2f00-4d13-8176-3b9815533ae9   in service    fd00:1122:3344:101::21
-    nexus             3d4143df-e212-4774-9258-7d9b421fac2e   in service    fd00:1122:3344:101::22
-+   crucible_pantry   ff9ce09c-afbf-425b-bbfa-3d8fb254f98e   in service    fd00:1122:3344:101::2e
-+   nexus             845869e9-ecb2-4ec3-b6b8-2a836e459243   in service    fd00:1122:3344:101::2f
+    crucible          052553cb-8a1a-42a4-a6cb-97a913e78877   in service    fd00:1122:3344:101::2d
+    crucible          1bd2301a-acd3-4a9c-82d7-b0c19a3c5597   in service    fd00:1122:3344:101::27
+    crucible          7975aa01-6fa9-4622-a8ba-8bfcf000f8eb   in service    fd00:1122:3344:101::2b
+    crucible          85286e23-2498-4034-9999-c5263fc0295f   in service    fd00:1122:3344:101::28
+    crucible          a320b746-b5f6-4027-9c3c-d41e099f2def   in service    fd00:1122:3344:101::2c
+    crucible          dcd393d4-d16c-41a8-8c16-48e0ab80d2e2   in service    fd00:1122:3344:101::25
+    crucible          de34e868-675e-4291-a2f7-c0b24e2e18a1   in service    fd00:1122:3344:101::26
+    crucible          e11dd8a6-951a-4019-8775-bed3a2092aaa   in service    fd00:1122:3344:101::24
+    crucible          f8cdd98e-4ab4-46bb-b621-7590808582cc   in service    fd00:1122:3344:101::2a
+    crucible          fcccf363-d190-441c-ba40-58e24f8a9cb3   in service    fd00:1122:3344:101::29
+    crucible_pantry   a22472df-5df2-4c1f-ad1f-439a4164984f   in service    fd00:1122:3344:101::23
+    internal_dns      936b1cbb-84e5-48ab-bc59-3bbd7830a421   in service    fd00:1122:3344:2::1   
+    internal_ntp      52031fcc-eb18-45f5-ae6c-65c7858b5e93   in service    fd00:1122:3344:101::21
+    nexus             33ef9872-ee9a-4478-89b9-b22b78e00d3a   in service    fd00:1122:3344:101::22
++   crucible_pantry   6b6843d6-062c-4400-8fd9-d11b5d138fe6   in service    fd00:1122:3344:101::2e
++   nexus             75fb916b-4793-4cd0-873b-573768b1efe5   in service    fd00:1122:3344:101::2f
 
 
   sled fefcf4cf-f7e7-46b3-b629-058526ce440e (active):
@@ -225,77 +225,77 @@ to:   blueprint 1ac2d88f-27dd-4506-8585-6b2be832528e
     -----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
     dataset name                                                                                                   dataset uuid                           quota     reservation   compression
     -----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
-    oxp_07068f19-1ff2-48da-8e72-874780df2339/crucible                                                              ea21aba9-6e79-4e20-8e35-92cd9fbba41c   none      none          off        
-    oxp_0f12e6ee-41d2-4eb0-813f-ba5240900ded/crucible                                                              b350b7d8-66cc-4d54-b480-1884c791a6d9   none      none          off        
-    oxp_0fdb4a39-3cd5-47a0-9064-e7f3c285af61/crucible                                                              9020f7d3-2bfc-4af4-a339-c60d233266cd   none      none          off        
-    oxp_13572832-83ad-40d6-896a-751f7e53f4f6/crucible                                                              87d29998-7d01-420b-97c6-f02067fb96ba   none      none          off        
-    oxp_3602bdd9-f7bb-4490-87a6-8f061f7712f5/crucible                                                              3b096c27-0a84-4335-be9f-e6104d709162   none      none          off        
-    oxp_65707837-95a4-45d7-84e6-8b9a4da215f1/crucible                                                              3409e636-fb7e-4699-967a-d7faad2fee27   none      none          off        
-    oxp_7a43b2b0-3846-401c-8317-d555715a00f7/crucible                                                              b89f0c5b-bb1f-43f1-8473-b697a63c565f   none      none          off        
-    oxp_855e3ef1-6929-4e21-8451-0e62bd93c7c9/crucible                                                              0daab3dc-5ef4-44dc-abf6-04b03560f726   none      none          off        
-    oxp_8adcf329-4cee-4075-b798-28b5add1edf5/crucible                                                              c6074d19-cb72-4fd1-b6f7-c2a017518ede   none      none          off        
-    oxp_99e926d6-bd42-4cde-9f63-5ecc7ea14322/crucible                                                              d5ad4cb2-723a-4ea4-8345-67438d9f1857   none      none          off        
-    oxp_07068f19-1ff2-48da-8e72-874780df2339/crypt/internal_dns                                                    af7470be-9bc4-4d4b-8634-66fb0771fecc   none      none          off        
-    oxp_07068f19-1ff2-48da-8e72-874780df2339/crypt/zone                                                            0a1e8f41-ffe6-4a4e-98de-a84217fddd4a   none      none          off        
-    oxp_0f12e6ee-41d2-4eb0-813f-ba5240900ded/crypt/zone                                                            7a3d49fb-56fd-4e30-b1ca-7c9d6a1fdbfc   none      none          off        
-    oxp_0fdb4a39-3cd5-47a0-9064-e7f3c285af61/crypt/zone                                                            caa4bf8a-ccd5-4ebf-b5c0-8c3664c69738   none      none          off        
-    oxp_13572832-83ad-40d6-896a-751f7e53f4f6/crypt/zone                                                            2a95cee2-ff4f-4400-81ac-46df69443c68   none      none          off        
-    oxp_3602bdd9-f7bb-4490-87a6-8f061f7712f5/crypt/zone                                                            6dcb997c-6e19-4c31-9c0e-a5d41f66963f   none      none          off        
-    oxp_65707837-95a4-45d7-84e6-8b9a4da215f1/crypt/zone                                                            f92429b2-b8fe-4a95-9a29-ca8ffe0d51f8   none      none          off        
-    oxp_7a43b2b0-3846-401c-8317-d555715a00f7/crypt/zone                                                            4dc29bec-f01c-4998-b755-46226bce0aa5   none      none          off        
-    oxp_855e3ef1-6929-4e21-8451-0e62bd93c7c9/crypt/zone                                                            8d86f556-b74e-43f9-87ab-13f0b8d38a66   none      none          off        
-    oxp_8adcf329-4cee-4075-b798-28b5add1edf5/crypt/zone                                                            bbd3ec95-304c-4e3a-af36-e30990c697a5   none      none          off        
-    oxp_99e926d6-bd42-4cde-9f63-5ecc7ea14322/crypt/zone                                                            9bdf76dc-8c49-4a8c-85e9-23b70d9d090e   none      none          off        
-    oxp_07068f19-1ff2-48da-8e72-874780df2339/crypt/zone/oxz_crucible_0e2b035e-1de1-48af-8ac0-5316418e3de1          67788d73-161d-4331-b68b-5799dc103acb   none      none          off        
-    oxp_7a43b2b0-3846-401c-8317-d555715a00f7/crypt/zone/oxz_crucible_15f29557-d4da-45ef-b435-a0a1cd586e0c          83759687-8f02-47ab-925e-82cc75e77819   none      none          off        
-    oxp_3602bdd9-f7bb-4490-87a6-8f061f7712f5/crypt/zone/oxz_crucible_2bf9ee97-90e1-48a7-bb06-a35cec63b7fe          85bee553-3b86-489f-9b90-d45a26de1a8b   none      none          off        
-    oxp_99e926d6-bd42-4cde-9f63-5ecc7ea14322/crypt/zone/oxz_crucible_5cf79919-b28e-4064-b6f8-8906c471b5ce          36996d69-9e96-4b35-b38c-ce4a3ec71634   none      none          off        
-    oxp_855e3ef1-6929-4e21-8451-0e62bd93c7c9/crypt/zone/oxz_crucible_751bc6fe-22ad-4ce1-bc51-cf31fdf02bfa          c059bd54-6bd4-4a2c-a2d7-cb530f18d016   none      none          off        
-    oxp_0f12e6ee-41d2-4eb0-813f-ba5240900ded/crypt/zone/oxz_crucible_b7ae596e-0c85-40b2-bb47-df9f76db3cca          66fd473e-6927-45fa-93e0-6bff82f9c3df   none      none          off        
-    oxp_0fdb4a39-3cd5-47a0-9064-e7f3c285af61/crypt/zone/oxz_crucible_cf13b878-47f1-4ba0-b8c2-9f3e15f2ee87          e45274bc-8d11-4ffc-89bd-3d17a9bb629e   none      none          off        
-    oxp_65707837-95a4-45d7-84e6-8b9a4da215f1/crypt/zone/oxz_crucible_e3bfcb1e-3708-45e7-a45a-2a2cab7ad829          47d54397-a793-404b-8293-3fc11184b525   none      none          off        
-    oxp_8adcf329-4cee-4075-b798-28b5add1edf5/crypt/zone/oxz_crucible_e5121f83-faf2-4928-b5a8-94a1da99e8eb          8b12688c-61f9-4ecb-b17f-00df7b60105c   none      none          off        
-    oxp_13572832-83ad-40d6-896a-751f7e53f4f6/crypt/zone/oxz_crucible_eb034526-1767-4cc4-8225-ec962265710b          b0ff583d-a6fd-4298-8093-ab54f1eaac30   none      none          off        
-    oxp_07068f19-1ff2-48da-8e72-874780df2339/crypt/zone/oxz_crucible_pantry_b7402110-d88f-4ca4-8391-4a2fda6ad271   f8eb44eb-00bd-416b-99e9-2539a7469963   none      none          off        
-    oxp_07068f19-1ff2-48da-8e72-874780df2339/crypt/zone/oxz_internal_dns_5c78756d-6182-4c27-a507-3419e8dbe76b      9428edca-e834-4512-b888-e399103343db   none      none          off        
-    oxp_07068f19-1ff2-48da-8e72-874780df2339/crypt/zone/oxz_nexus_e6d0df1f-9f98-4c5a-9540-8444d1185c7d             5f868bf8-8770-4f07-a620-af7dee8062d6   none      none          off        
-    oxp_07068f19-1ff2-48da-8e72-874780df2339/crypt/zone/oxz_ntp_c552280f-ba02-4f8d-9049-bd269e6b7845               a26ebbdb-38b4-4921-9186-3b1e1fb7cbc2   none      none          off        
-    oxp_07068f19-1ff2-48da-8e72-874780df2339/crypt/debug                                                           9ed7b9ab-dc13-4179-b867-08d23156253a   100 GiB   none          gzip-9     
-    oxp_0f12e6ee-41d2-4eb0-813f-ba5240900ded/crypt/debug                                                           3dad2cc1-25cc-401e-9763-47001a1acc17   100 GiB   none          gzip-9     
-    oxp_0fdb4a39-3cd5-47a0-9064-e7f3c285af61/crypt/debug                                                           55da940b-ae9a-4c93-87ea-4845c66dbe1c   100 GiB   none          gzip-9     
-    oxp_13572832-83ad-40d6-896a-751f7e53f4f6/crypt/debug                                                           f37b9916-d47a-4fda-9385-2031a73b7a0e   100 GiB   none          gzip-9     
-    oxp_3602bdd9-f7bb-4490-87a6-8f061f7712f5/crypt/debug                                                           aa333d9a-908b-4e2e-a476-a000e6f2fe25   100 GiB   none          gzip-9     
-    oxp_65707837-95a4-45d7-84e6-8b9a4da215f1/crypt/debug                                                           eb939b53-6b86-44ae-b3bb-f4fc3111278d   100 GiB   none          gzip-9     
-    oxp_7a43b2b0-3846-401c-8317-d555715a00f7/crypt/debug                                                           5a3f0c96-a125-4cc0-9e84-fb5551fe557e   100 GiB   none          gzip-9     
-    oxp_855e3ef1-6929-4e21-8451-0e62bd93c7c9/crypt/debug                                                           b5203528-903b-4e16-bd00-13147a83a712   100 GiB   none          gzip-9     
-    oxp_8adcf329-4cee-4075-b798-28b5add1edf5/crypt/debug                                                           23c24e8b-87ac-4462-a27d-1bbdb74b7ba3   100 GiB   none          gzip-9     
-    oxp_99e926d6-bd42-4cde-9f63-5ecc7ea14322/crypt/debug                                                           e9ae4c7d-4721-49de-bf6d-8ecec30c3ebb   100 GiB   none          gzip-9     
-+   oxp_07068f19-1ff2-48da-8e72-874780df2339/crypt/clickhouse                                                      b8054c80-65c3-4a44-ba95-f65e37fd2678   none      none          off        
-+   oxp_0f12e6ee-41d2-4eb0-813f-ba5240900ded/crypt/internal_dns                                                    4a5db72b-3b8d-4032-9507-524ba3843ed2   none      none          off        
-+   oxp_07068f19-1ff2-48da-8e72-874780df2339/crypt/zone/oxz_clickhouse_c8851a11-a4f7-4b21-9281-6182fd15dc8d        60d5c18d-6940-48eb-b36c-7f0b6ef55463   none      none          off        
-+   oxp_0f12e6ee-41d2-4eb0-813f-ba5240900ded/crypt/zone/oxz_internal_dns_e639b672-27c4-4ecb-82c1-d672eb1ccf4e      158cd75c-abe9-4891-af66-3c8d5e6d65f4   none      none          off        
+    oxp_07068f19-1ff2-48da-8e72-874780df2339/crucible                                                              43cd1a3a-7dcf-47a2-bf7f-1042c9ed4461   none      none          off        
+    oxp_0f12e6ee-41d2-4eb0-813f-ba5240900ded/crucible                                                              b934756b-aff6-4435-bf59-42fcdb5433ef   none      none          off        
+    oxp_0fdb4a39-3cd5-47a0-9064-e7f3c285af61/crucible                                                              476e6363-ef7a-4538-9906-61380605378a   none      none          off        
+    oxp_13572832-83ad-40d6-896a-751f7e53f4f6/crucible                                                              3b15616c-0339-4816-a057-1c9ca76bc5d9   none      none          off        
+    oxp_3602bdd9-f7bb-4490-87a6-8f061f7712f5/crucible                                                              3fa34ab2-ae9e-4633-bf8f-e0b985591f55   none      none          off        
+    oxp_65707837-95a4-45d7-84e6-8b9a4da215f1/crucible                                                              86cbb449-770b-4ef0-bbdd-e66c96abecb9   none      none          off        
+    oxp_7a43b2b0-3846-401c-8317-d555715a00f7/crucible                                                              912ebbe4-bef6-4cf7-92a5-e21eb72fbf87   none      none          off        
+    oxp_855e3ef1-6929-4e21-8451-0e62bd93c7c9/crucible                                                              4ff0cc73-4531-4717-a130-cb28345ddea2   none      none          off        
+    oxp_8adcf329-4cee-4075-b798-28b5add1edf5/crucible                                                              3d95ffb6-833e-4e1a-a660-6f1544221ed5   none      none          off        
+    oxp_99e926d6-bd42-4cde-9f63-5ecc7ea14322/crucible                                                              bc0f19c5-73af-4c32-97e4-51bee5a874de   none      none          off        
+    oxp_07068f19-1ff2-48da-8e72-874780df2339/crypt/internal_dns                                                    5fe43d44-e28d-4343-b09b-06115e410cfc   none      none          off        
+    oxp_07068f19-1ff2-48da-8e72-874780df2339/crypt/zone                                                            19c47885-6b4a-45c6-8dd6-8f3530737df1   none      none          off        
+    oxp_0f12e6ee-41d2-4eb0-813f-ba5240900ded/crypt/zone                                                            1ffa3016-9c49-47f1-a443-429cc5ee72ff   none      none          off        
+    oxp_0fdb4a39-3cd5-47a0-9064-e7f3c285af61/crypt/zone                                                            f21e6928-e9c2-4eff-a710-1e6034948aad   none      none          off        
+    oxp_13572832-83ad-40d6-896a-751f7e53f4f6/crypt/zone                                                            ec753ba9-fa33-4e83-9cd2-7a0eb75f3825   none      none          off        
+    oxp_3602bdd9-f7bb-4490-87a6-8f061f7712f5/crypt/zone                                                            08a7b1b4-2fe9-4412-b847-de67413835d8   none      none          off        
+    oxp_65707837-95a4-45d7-84e6-8b9a4da215f1/crypt/zone                                                            d1404c52-a67c-4d5a-82ee-381fc43e7906   none      none          off        
+    oxp_7a43b2b0-3846-401c-8317-d555715a00f7/crypt/zone                                                            ddef09d3-762e-40b1-b484-03bfa2da3bd9   none      none          off        
+    oxp_855e3ef1-6929-4e21-8451-0e62bd93c7c9/crypt/zone                                                            51d6f7a3-386d-4d17-9898-ccc9e8da2b2b   none      none          off        
+    oxp_8adcf329-4cee-4075-b798-28b5add1edf5/crypt/zone                                                            21095495-e67e-4f2f-ad5a-3382350b51b9   none      none          off        
+    oxp_99e926d6-bd42-4cde-9f63-5ecc7ea14322/crypt/zone                                                            36b5605c-d6c0-4963-a4eb-5090988da393   none      none          off        
+    oxp_07068f19-1ff2-48da-8e72-874780df2339/crypt/zone/oxz_crucible_40f9f06b-eed5-47b9-9925-8afd5540d9f5          73f22559-8377-43cf-b028-4164d68826c9   none      none          off        
+    oxp_13572832-83ad-40d6-896a-751f7e53f4f6/crypt/zone/oxz_crucible_4561a213-e297-41d2-b40d-995b35715ede          c49aa53a-775f-4d2f-bb60-931e82c9d837   none      none          off        
+    oxp_99e926d6-bd42-4cde-9f63-5ecc7ea14322/crypt/zone/oxz_crucible_5e41815b-3aa2-4507-b3ea-3694c0e05b34          da3da14c-05b9-4922-b7a4-be05f23d1da8   none      none          off        
+    oxp_7a43b2b0-3846-401c-8317-d555715a00f7/crypt/zone/oxz_crucible_619451af-30b4-4252-9688-379be6555534          da3ab91c-ffa8-46e4-8a4a-de8a56e02315   none      none          off        
+    oxp_0fdb4a39-3cd5-47a0-9064-e7f3c285af61/crypt/zone/oxz_crucible_64f9bfcb-c1d5-4f15-a877-778ba83c4ada          07c46767-93f4-43df-8dcd-25abf3aaf296   none      none          off        
+    oxp_8adcf329-4cee-4075-b798-28b5add1edf5/crypt/zone/oxz_crucible_a6ac7172-669b-4ac1-9532-2848bcb80545          dc27c769-7880-439e-84c7-29c92880a219   none      none          off        
+    oxp_65707837-95a4-45d7-84e6-8b9a4da215f1/crypt/zone/oxz_crucible_e65276c2-baeb-4ab1-9a37-e48786f14dad          dceafe94-f4df-4556-9a46-560c59069e46   none      none          off        
+    oxp_3602bdd9-f7bb-4490-87a6-8f061f7712f5/crypt/zone/oxz_crucible_e6788bd0-ac6e-4125-93d0-aacbc6380f04          d730d05e-7a17-442e-9959-2e0ea58860c5   none      none          off        
+    oxp_0f12e6ee-41d2-4eb0-813f-ba5240900ded/crypt/zone/oxz_crucible_ea37e4ab-65c6-463a-a2d4-9cf8f0ccbd00          4035218d-b1ed-422a-a202-4f4fd19767b6   none      none          off        
+    oxp_855e3ef1-6929-4e21-8451-0e62bd93c7c9/crypt/zone/oxz_crucible_f52b4e76-5989-42cf-9208-60548c34b487          a8d1ad8b-946f-46e9-8bc3-4aaae1ca31f6   none      none          off        
+    oxp_07068f19-1ff2-48da-8e72-874780df2339/crypt/zone/oxz_crucible_pantry_4c1e95a8-7fae-4a3a-8651-9272ef7c9a88   53123c3d-64d2-432d-b72c-9e0c41ffa805   none      none          off        
+    oxp_07068f19-1ff2-48da-8e72-874780df2339/crypt/zone/oxz_internal_dns_7b2bb1aa-639b-4aaa-bd80-9c680e4be5fc      f24ddc4e-2569-4447-ad1a-e1e0da2e7b41   none      none          off        
+    oxp_07068f19-1ff2-48da-8e72-874780df2339/crypt/zone/oxz_nexus_294379f6-502c-465b-b32d-771c415a38af             61bd7f63-49c5-481e-8f1e-075642b59fa9   none      none          off        
+    oxp_07068f19-1ff2-48da-8e72-874780df2339/crypt/zone/oxz_ntp_064ec0c2-a320-4efb-b006-9e0e1d942d8e               701a8f75-31f5-404f-ad44-1659106f80dd   none      none          off        
+    oxp_07068f19-1ff2-48da-8e72-874780df2339/crypt/debug                                                           ba8224f4-9d26-4fa8-89ac-830e5734c58e   100 GiB   none          gzip-9     
+    oxp_0f12e6ee-41d2-4eb0-813f-ba5240900ded/crypt/debug                                                           73d82f70-9ae4-4212-bc41-42aa7cd6d5c2   100 GiB   none          gzip-9     
+    oxp_0fdb4a39-3cd5-47a0-9064-e7f3c285af61/crypt/debug                                                           71bbed5f-6b13-41f8-87e1-1dff19e2680f   100 GiB   none          gzip-9     
+    oxp_13572832-83ad-40d6-896a-751f7e53f4f6/crypt/debug                                                           bd2e7c19-590f-476e-9eb1-b1cabe99600a   100 GiB   none          gzip-9     
+    oxp_3602bdd9-f7bb-4490-87a6-8f061f7712f5/crypt/debug                                                           12b10546-bc67-43c4-993b-adcc04aa2b3f   100 GiB   none          gzip-9     
+    oxp_65707837-95a4-45d7-84e6-8b9a4da215f1/crypt/debug                                                           08d9c58d-fe91-4b9c-9db8-0b32e3b7f4e0   100 GiB   none          gzip-9     
+    oxp_7a43b2b0-3846-401c-8317-d555715a00f7/crypt/debug                                                           e7e5170c-5547-4733-885b-3fc385e97941   100 GiB   none          gzip-9     
+    oxp_855e3ef1-6929-4e21-8451-0e62bd93c7c9/crypt/debug                                                           1097db6f-ea2d-46cb-9a1f-be933677f4ea   100 GiB   none          gzip-9     
+    oxp_8adcf329-4cee-4075-b798-28b5add1edf5/crypt/debug                                                           10e453e2-115f-42dd-a575-10a593b56762   100 GiB   none          gzip-9     
+    oxp_99e926d6-bd42-4cde-9f63-5ecc7ea14322/crypt/debug                                                           a5162371-5108-497f-a3de-2b95a0dfafbe   100 GiB   none          gzip-9     
++   oxp_07068f19-1ff2-48da-8e72-874780df2339/crypt/clickhouse                                                      dd8bc8e6-1103-4425-82da-0f7df6951581   none      none          off        
++   oxp_0f12e6ee-41d2-4eb0-813f-ba5240900ded/crypt/internal_dns                                                    a1b355d4-5b1d-406d-960f-e61e30c2aa2a   none      none          off        
++   oxp_07068f19-1ff2-48da-8e72-874780df2339/crypt/zone/oxz_clickhouse_a5813480-2b89-4e18-a09b-c9e5b6b317cc        c113e4ea-c33e-4df0-957b-5f7a856d5214   none      none          off        
++   oxp_0f12e6ee-41d2-4eb0-813f-ba5240900ded/crypt/zone/oxz_internal_dns_d74f14f1-0a19-4d92-b76f-1b3a6e630b2c      672e989c-aec3-4fd9-b7f9-f2af75b3bc01   none      none          off        
 
 
     omicron zones generation 2 -> 3:
     ---------------------------------------------------------------------------------------------
     zone type         zone id                                disposition   underlay IP           
     ---------------------------------------------------------------------------------------------
-    crucible          0e2b035e-1de1-48af-8ac0-5316418e3de1   in service    fd00:1122:3344:102::24
-    crucible          15f29557-d4da-45ef-b435-a0a1cd586e0c   in service    fd00:1122:3344:102::2a
-    crucible          2bf9ee97-90e1-48a7-bb06-a35cec63b7fe   in service    fd00:1122:3344:102::28
-    crucible          5cf79919-b28e-4064-b6f8-8906c471b5ce   in service    fd00:1122:3344:102::2d
-    crucible          751bc6fe-22ad-4ce1-bc51-cf31fdf02bfa   in service    fd00:1122:3344:102::2b
-    crucible          b7ae596e-0c85-40b2-bb47-df9f76db3cca   in service    fd00:1122:3344:102::25
-    crucible          cf13b878-47f1-4ba0-b8c2-9f3e15f2ee87   in service    fd00:1122:3344:102::26
-    crucible          e3bfcb1e-3708-45e7-a45a-2a2cab7ad829   in service    fd00:1122:3344:102::29
-    crucible          e5121f83-faf2-4928-b5a8-94a1da99e8eb   in service    fd00:1122:3344:102::2c
-    crucible          eb034526-1767-4cc4-8225-ec962265710b   in service    fd00:1122:3344:102::27
-    crucible_pantry   b7402110-d88f-4ca4-8391-4a2fda6ad271   in service    fd00:1122:3344:102::23
-    internal_dns      5c78756d-6182-4c27-a507-3419e8dbe76b   in service    fd00:1122:3344:3::1   
-    internal_ntp      c552280f-ba02-4f8d-9049-bd269e6b7845   in service    fd00:1122:3344:102::21
-    nexus             e6d0df1f-9f98-4c5a-9540-8444d1185c7d   in service    fd00:1122:3344:102::22
-+   clickhouse        c8851a11-a4f7-4b21-9281-6182fd15dc8d   in service    fd00:1122:3344:102::2e
-+   internal_dns      e639b672-27c4-4ecb-82c1-d672eb1ccf4e   in service    fd00:1122:3344:1::1   
+    crucible          40f9f06b-eed5-47b9-9925-8afd5540d9f5   in service    fd00:1122:3344:102::24
+    crucible          4561a213-e297-41d2-b40d-995b35715ede   in service    fd00:1122:3344:102::27
+    crucible          5e41815b-3aa2-4507-b3ea-3694c0e05b34   in service    fd00:1122:3344:102::2d
+    crucible          619451af-30b4-4252-9688-379be6555534   in service    fd00:1122:3344:102::2a
+    crucible          64f9bfcb-c1d5-4f15-a877-778ba83c4ada   in service    fd00:1122:3344:102::26
+    crucible          a6ac7172-669b-4ac1-9532-2848bcb80545   in service    fd00:1122:3344:102::2c
+    crucible          e65276c2-baeb-4ab1-9a37-e48786f14dad   in service    fd00:1122:3344:102::29
+    crucible          e6788bd0-ac6e-4125-93d0-aacbc6380f04   in service    fd00:1122:3344:102::28
+    crucible          ea37e4ab-65c6-463a-a2d4-9cf8f0ccbd00   in service    fd00:1122:3344:102::25
+    crucible          f52b4e76-5989-42cf-9208-60548c34b487   in service    fd00:1122:3344:102::2b
+    crucible_pantry   4c1e95a8-7fae-4a3a-8651-9272ef7c9a88   in service    fd00:1122:3344:102::23
+    internal_dns      7b2bb1aa-639b-4aaa-bd80-9c680e4be5fc   in service    fd00:1122:3344:3::1   
+    internal_ntp      064ec0c2-a320-4efb-b006-9e0e1d942d8e   in service    fd00:1122:3344:102::21
+    nexus             294379f6-502c-465b-b32d-771c415a38af   in service    fd00:1122:3344:102::22
++   clickhouse        a5813480-2b89-4e18-a09b-c9e5b6b317cc   in service    fd00:1122:3344:102::2e
++   internal_dns      d74f14f1-0a19-4d92-b76f-1b3a6e630b2c   in service    fd00:1122:3344:1::1   
 
 
  COCKROACHDB SETTINGS:

--- a/nexus/reconfigurator/planning/tests/output/planner_decommissions_sleds_bp2.txt
+++ b/nexus/reconfigurator/planning/tests/output/planner_decommissions_sleds_bp2.txt
@@ -23,22 +23,22 @@ parent:    516e80a3-b362-4fac-bd3c-4559717120dd
     ---------------------------------------------------------------------------------------------
     zone type         zone id                                disposition   underlay IP           
     ---------------------------------------------------------------------------------------------
-    crucible          4f8ce495-21dd-48a1-859c-80d34ce394ed   in service    fd00:1122:3344:101::2b
-    crucible          5d9d8fa7-8379-470b-90ba-fe84a3c45512   in service    fd00:1122:3344:101::26
-    crucible          70232a6d-6c9d-4fa6-a34d-9c73d940db33   in service    fd00:1122:3344:101::24
-    crucible          8567a616-a709-4c8c-a323-4474675dad5c   in service    fd00:1122:3344:101::28
-    crucible          8b0b8623-930a-41af-9f9b-ca28b1b11139   in service    fd00:1122:3344:101::25
-    crucible          99c6401d-9796-4ae1-bf0c-9a097cf21c33   in service    fd00:1122:3344:101::2a
-    crucible          a1ae92ac-e1f1-4654-ab54-5b75ba7c44d6   in service    fd00:1122:3344:101::2c
-    crucible          a308d3e1-118c-440a-947a-8b6ab7d833ab   in service    fd00:1122:3344:101::2d
-    crucible          cf87d2a3-d323-44a3-a87e-adc4ef6c75f4   in service    fd00:1122:3344:101::27
-    crucible          f68846ad-4619-4747-8293-a2b4aeeafc5b   in service    fd00:1122:3344:101::29
-    crucible_pantry   15dbaa30-1539-49d6-970d-ba5962960f33   in service    fd00:1122:3344:101::23
-    crucible_pantry   ff9ce09c-afbf-425b-bbfa-3d8fb254f98e   in service    fd00:1122:3344:101::2e
-    internal_dns      eac6c0a0-baa5-4490-9cee-65198b7fbd9c   in service    fd00:1122:3344:2::1   
-    internal_ntp      1ec4cc7b-2f00-4d13-8176-3b9815533ae9   in service    fd00:1122:3344:101::21
-    nexus             3d4143df-e212-4774-9258-7d9b421fac2e   in service    fd00:1122:3344:101::22
-    nexus             845869e9-ecb2-4ec3-b6b8-2a836e459243   in service    fd00:1122:3344:101::2f
+    crucible          052553cb-8a1a-42a4-a6cb-97a913e78877   in service    fd00:1122:3344:101::2d
+    crucible          1bd2301a-acd3-4a9c-82d7-b0c19a3c5597   in service    fd00:1122:3344:101::27
+    crucible          7975aa01-6fa9-4622-a8ba-8bfcf000f8eb   in service    fd00:1122:3344:101::2b
+    crucible          85286e23-2498-4034-9999-c5263fc0295f   in service    fd00:1122:3344:101::28
+    crucible          a320b746-b5f6-4027-9c3c-d41e099f2def   in service    fd00:1122:3344:101::2c
+    crucible          dcd393d4-d16c-41a8-8c16-48e0ab80d2e2   in service    fd00:1122:3344:101::25
+    crucible          de34e868-675e-4291-a2f7-c0b24e2e18a1   in service    fd00:1122:3344:101::26
+    crucible          e11dd8a6-951a-4019-8775-bed3a2092aaa   in service    fd00:1122:3344:101::24
+    crucible          f8cdd98e-4ab4-46bb-b621-7590808582cc   in service    fd00:1122:3344:101::2a
+    crucible          fcccf363-d190-441c-ba40-58e24f8a9cb3   in service    fd00:1122:3344:101::29
+    crucible_pantry   6b6843d6-062c-4400-8fd9-d11b5d138fe6   in service    fd00:1122:3344:101::2e
+    crucible_pantry   a22472df-5df2-4c1f-ad1f-439a4164984f   in service    fd00:1122:3344:101::23
+    internal_dns      936b1cbb-84e5-48ab-bc59-3bbd7830a421   in service    fd00:1122:3344:2::1   
+    internal_ntp      52031fcc-eb18-45f5-ae6c-65c7858b5e93   in service    fd00:1122:3344:101::21
+    nexus             33ef9872-ee9a-4478-89b9-b22b78e00d3a   in service    fd00:1122:3344:101::22
+    nexus             75fb916b-4793-4cd0-873b-573768b1efe5   in service    fd00:1122:3344:101::2f
 
 
 
@@ -64,22 +64,22 @@ parent:    516e80a3-b362-4fac-bd3c-4559717120dd
     ---------------------------------------------------------------------------------------------
     zone type         zone id                                disposition   underlay IP           
     ---------------------------------------------------------------------------------------------
-    clickhouse        c8851a11-a4f7-4b21-9281-6182fd15dc8d   in service    fd00:1122:3344:102::2e
-    crucible          0e2b035e-1de1-48af-8ac0-5316418e3de1   in service    fd00:1122:3344:102::24
-    crucible          15f29557-d4da-45ef-b435-a0a1cd586e0c   in service    fd00:1122:3344:102::2a
-    crucible          2bf9ee97-90e1-48a7-bb06-a35cec63b7fe   in service    fd00:1122:3344:102::28
-    crucible          5cf79919-b28e-4064-b6f8-8906c471b5ce   in service    fd00:1122:3344:102::2d
-    crucible          751bc6fe-22ad-4ce1-bc51-cf31fdf02bfa   in service    fd00:1122:3344:102::2b
-    crucible          b7ae596e-0c85-40b2-bb47-df9f76db3cca   in service    fd00:1122:3344:102::25
-    crucible          cf13b878-47f1-4ba0-b8c2-9f3e15f2ee87   in service    fd00:1122:3344:102::26
-    crucible          e3bfcb1e-3708-45e7-a45a-2a2cab7ad829   in service    fd00:1122:3344:102::29
-    crucible          e5121f83-faf2-4928-b5a8-94a1da99e8eb   in service    fd00:1122:3344:102::2c
-    crucible          eb034526-1767-4cc4-8225-ec962265710b   in service    fd00:1122:3344:102::27
-    crucible_pantry   b7402110-d88f-4ca4-8391-4a2fda6ad271   in service    fd00:1122:3344:102::23
-    internal_dns      5c78756d-6182-4c27-a507-3419e8dbe76b   in service    fd00:1122:3344:3::1   
-    internal_dns      e639b672-27c4-4ecb-82c1-d672eb1ccf4e   in service    fd00:1122:3344:1::1   
-    internal_ntp      c552280f-ba02-4f8d-9049-bd269e6b7845   in service    fd00:1122:3344:102::21
-    nexus             e6d0df1f-9f98-4c5a-9540-8444d1185c7d   in service    fd00:1122:3344:102::22
+    clickhouse        a5813480-2b89-4e18-a09b-c9e5b6b317cc   in service    fd00:1122:3344:102::2e
+    crucible          40f9f06b-eed5-47b9-9925-8afd5540d9f5   in service    fd00:1122:3344:102::24
+    crucible          4561a213-e297-41d2-b40d-995b35715ede   in service    fd00:1122:3344:102::27
+    crucible          5e41815b-3aa2-4507-b3ea-3694c0e05b34   in service    fd00:1122:3344:102::2d
+    crucible          619451af-30b4-4252-9688-379be6555534   in service    fd00:1122:3344:102::2a
+    crucible          64f9bfcb-c1d5-4f15-a877-778ba83c4ada   in service    fd00:1122:3344:102::26
+    crucible          a6ac7172-669b-4ac1-9532-2848bcb80545   in service    fd00:1122:3344:102::2c
+    crucible          e65276c2-baeb-4ab1-9a37-e48786f14dad   in service    fd00:1122:3344:102::29
+    crucible          e6788bd0-ac6e-4125-93d0-aacbc6380f04   in service    fd00:1122:3344:102::28
+    crucible          ea37e4ab-65c6-463a-a2d4-9cf8f0ccbd00   in service    fd00:1122:3344:102::25
+    crucible          f52b4e76-5989-42cf-9208-60548c34b487   in service    fd00:1122:3344:102::2b
+    crucible_pantry   4c1e95a8-7fae-4a3a-8651-9272ef7c9a88   in service    fd00:1122:3344:102::23
+    internal_dns      7b2bb1aa-639b-4aaa-bd80-9c680e4be5fc   in service    fd00:1122:3344:3::1   
+    internal_dns      d74f14f1-0a19-4d92-b76f-1b3a6e630b2c   in service    fd00:1122:3344:1::1   
+    internal_ntp      064ec0c2-a320-4efb-b006-9e0e1d942d8e   in service    fd00:1122:3344:102::21
+    nexus             294379f6-502c-465b-b32d-771c415a38af   in service    fd00:1122:3344:102::22
 
 
 
@@ -89,21 +89,21 @@ WARNING: Zones exist without physical disks!
     ---------------------------------------------------------------------------------------------
     zone type         zone id                                disposition   underlay IP           
     ---------------------------------------------------------------------------------------------
-    clickhouse        4e36b7ef-5684-4304-b7c3-3c31aaf83d4f   expunged      fd00:1122:3344:103::23
-    crucible          1e1ed0cc-1adc-410f-943a-d1a3107de619   expunged      fd00:1122:3344:103::26
-    crucible          2307bbed-02ba-493b-89e3-46585c74c8fc   expunged      fd00:1122:3344:103::27
-    crucible          2e65b765-5c41-4519-bf4e-e2a68569afc1   expunged      fd00:1122:3344:103::2e
-    crucible          603e629d-2599-400e-b879-4134d4cc426e   expunged      fd00:1122:3344:103::2b
-    crucible          9179d6dc-387d-424e-8d62-ed59b2c728f6   expunged      fd00:1122:3344:103::29
-    crucible          ad76d200-5675-444b-b19c-684689ff421f   expunged      fd00:1122:3344:103::2c
-    crucible          c28d7b4b-a259-45ad-945d-f19ca3c6964c   expunged      fd00:1122:3344:103::28
-    crucible          e29998e7-9ed2-46b6-bb70-4118159fe07f   expunged      fd00:1122:3344:103::25
-    crucible          e9bf2525-5fa0-4c1b-b52d-481225083845   expunged      fd00:1122:3344:103::2d
-    crucible          f06e91a1-0c17-4cca-adbc-1c9b67bdb11d   expunged      fd00:1122:3344:103::2a
-    crucible_pantry   f11f5c60-1ac7-4630-9a3a-a9bc85c75203   expunged      fd00:1122:3344:103::24
-    internal_dns      f231e4eb-3fc9-4964-9d71-2c41644852d9   expunged      fd00:1122:3344:1::1   
-    internal_ntp      c62b87b6-b98d-4d22-ba4f-cee4499e2ba8   expunged      fd00:1122:3344:103::21
-    nexus             6a70a233-1900-43c0-9c00-aa9d1f7adfbc   expunged      fd00:1122:3344:103::22
+    clickhouse        3fd081ea-93f1-417e-bcb1-405854435f28   expunged      fd00:1122:3344:103::23
+    crucible          290e7e97-c4b3-47da-9f40-8d909397fbae   expunged      fd00:1122:3344:103::2e
+    crucible          29bbe4ad-e6e8-4e05-b188-a811a793ccbb   expunged      fd00:1122:3344:103::2a
+    crucible          8500a060-a426-4324-ba40-a66dd4b89bc6   expunged      fd00:1122:3344:103::29
+    crucible          92b7abd8-3e34-49dd-9c56-19a314e97d49   expunged      fd00:1122:3344:103::25
+    crucible          b320954e-6c66-4540-9bf4-3d976f21ee1b   expunged      fd00:1122:3344:103::26
+    crucible          bc3e4495-7e51-46b6-9f55-026ea1da39dd   expunged      fd00:1122:3344:103::27
+    crucible          cfb7595b-280c-40f5-b1aa-6e154adf280b   expunged      fd00:1122:3344:103::28
+    crucible          d6b6ea5a-3f29-4815-aa42-b1afeb11dfc5   expunged      fd00:1122:3344:103::2c
+    crucible          d6b77c1f-8c9e-406d-944e-c97a57b3984d   expunged      fd00:1122:3344:103::2b
+    crucible          ecc03801-b315-4495-9b2c-49e0eead1283   expunged      fd00:1122:3344:103::2d
+    crucible_pantry   ecebab45-11e7-47ab-8bc2-ab9114c6e2bc   expunged      fd00:1122:3344:103::24
+    internal_dns      96b7a45b-be74-44e8-b68a-e530cfa81830   expunged      fd00:1122:3344:1::1   
+    internal_ntp      b3dbc671-0e4d-49ff-9f4f-71b249d21f57   expunged      fd00:1122:3344:103::21
+    nexus             bc0f4342-f88d-49cc-bb44-b555d9b8ca12   expunged      fd00:1122:3344:103::22
 
 
 

--- a/nexus/reconfigurator/planning/tests/output/planner_deploy_all_keeper_nodes_1_2.txt
+++ b/nexus/reconfigurator/planning/tests/output/planner_deploy_all_keeper_nodes_1_2.txt
@@ -25,77 +25,77 @@ to:   blueprint 31ef2071-2ec9-49d9-8827-fd83b17a0e3d
     -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
     dataset name                                                                                                     dataset uuid                           quota     reservation   compression
     -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
-    oxp_60e6b021-79d6-4a6b-917c-6637e0769558/crucible                                                                fcd7e842-2648-407a-8d13-197e67de9e9d   none      none          off        
-    oxp_71a07ac0-d24e-446c-a202-1998e7f6ac8c/crucible                                                                c770de28-6c33-4cc7-97d9-62ddafd963aa   none      none          off        
-    oxp_736d4cab-c262-485e-89c2-07e6543f0855/crucible                                                                ac9f4d69-3281-4774-a098-250755079068   none      none          off        
-    oxp_8ae56ca0-709d-4b8f-9869-51b62b542eef/crucible                                                                09781292-36f1-4310-82b4-ddfb4d287fa1   none      none          off        
-    oxp_8e0bcc4f-0799-450c-a0ad-80c1637f59e3/crucible                                                                81719897-4ae6-4d76-8282-fda91c347811   none      none          off        
-    oxp_8eeebb8e-6db6-43e8-a429-d26dde99882c/crucible                                                                a2399f57-62eb-4d7d-ac69-09cd6e5c2134   none      none          off        
-    oxp_a3e8de5b-c47a-49c0-b698-4d6955e1327f/crucible                                                                cd6b3952-2024-4310-b82e-abfd245ec1d6   none      none          off        
-    oxp_b32fa3da-4dec-4237-9776-e1a57ba15a21/crucible                                                                4f99dd21-d6ed-409a-af19-9886d1083762   none      none          off        
-    oxp_e9c238f6-87a3-4087-8ba4-aa594a82d012/crucible                                                                e88d6ff8-6b98-44c1-97a7-83f371ae62fe   none      none          off        
-    oxp_fbf997ef-52d3-438a-b036-b9117322e569/crucible                                                                d6a838c7-3ee9-4cca-9d8b-986b4de0ba1c   none      none          off        
-    oxp_60e6b021-79d6-4a6b-917c-6637e0769558/crypt/clickhouse                                                        5cb56dc7-6c56-4bbf-ae73-6f08e0c97cdf   none      none          off        
-    oxp_60e6b021-79d6-4a6b-917c-6637e0769558/crypt/internal_dns                                                      dd467397-efc5-4738-984e-77a0f3e3e678   none      none          off        
-    oxp_60e6b021-79d6-4a6b-917c-6637e0769558/crypt/zone                                                              8c4f4acd-8f6b-4296-81be-12d2eeae0483   none      none          off        
-    oxp_71a07ac0-d24e-446c-a202-1998e7f6ac8c/crypt/zone                                                              f83b1c8d-d252-4b35-a9d2-400e2e2cddf7   none      none          off        
-    oxp_736d4cab-c262-485e-89c2-07e6543f0855/crypt/zone                                                              a34f8204-9f17-4c8f-997b-e122c284ac9f   none      none          off        
-    oxp_8ae56ca0-709d-4b8f-9869-51b62b542eef/crypt/zone                                                              61bf628d-a78d-40a7-bad2-84e97e41b810   none      none          off        
-    oxp_8e0bcc4f-0799-450c-a0ad-80c1637f59e3/crypt/zone                                                              3f63ada8-d1f4-440d-8713-da45b0684520   none      none          off        
-    oxp_8eeebb8e-6db6-43e8-a429-d26dde99882c/crypt/zone                                                              a3284e6f-ee42-4fdb-8150-634f7f40c073   none      none          off        
-    oxp_a3e8de5b-c47a-49c0-b698-4d6955e1327f/crypt/zone                                                              8b7928fb-e5a0-49b0-81d0-89f627020c92   none      none          off        
-    oxp_b32fa3da-4dec-4237-9776-e1a57ba15a21/crypt/zone                                                              0e976e79-fe8c-4189-8a8c-279f42e0290f   none      none          off        
-    oxp_e9c238f6-87a3-4087-8ba4-aa594a82d012/crypt/zone                                                              f963f2a7-e9d1-4b80-b01a-ff4cecddf867   none      none          off        
-    oxp_fbf997ef-52d3-438a-b036-b9117322e569/crypt/zone                                                              a15e4260-d48c-4415-9315-c0f29234f359   none      none          off        
-    oxp_60e6b021-79d6-4a6b-917c-6637e0769558/crypt/zone/oxz_clickhouse_df79db1e-54ca-4048-b22a-da120ae4c8c4          b6cb0fe9-0b7a-4793-b6cd-1ee71fee464c   none      none          off        
-    oxp_8e0bcc4f-0799-450c-a0ad-80c1637f59e3/crypt/zone/oxz_crucible_08330c18-54e9-445b-81f3-8f1d6ad15cdd            ab255226-2c8c-4222-82c6-702af839a2d2   none      none          off        
-    oxp_fbf997ef-52d3-438a-b036-b9117322e569/crypt/zone/oxz_crucible_0ba018f0-4ff7-4bcc-a0c7-42cfec6bc9da            ba1a3aae-15ab-4364-8250-54a766331ef8   none      none          off        
-    oxp_60e6b021-79d6-4a6b-917c-6637e0769558/crypt/zone/oxz_crucible_1e485cda-b36e-4647-9125-c273fc7a9850            65c2e3cd-3d8e-43c6-9e2c-cb884511ec49   none      none          off        
-    oxp_a3e8de5b-c47a-49c0-b698-4d6955e1327f/crypt/zone/oxz_crucible_4d84fdb4-76fd-47a9-b033-7e1711d9125f            8dc07059-e8cd-4f89-abc7-0c5289b8ff0a   none      none          off        
-    oxp_e9c238f6-87a3-4087-8ba4-aa594a82d012/crypt/zone/oxz_crucible_577b0a64-6fa9-4302-bfaa-853b6e9e71ac            851cd90d-97f5-49b6-ad41-2e1c1faa3cc9   none      none          off        
-    oxp_8eeebb8e-6db6-43e8-a429-d26dde99882c/crypt/zone/oxz_crucible_5d296df4-4f2f-4896-8caa-42df00799bcb            25c5034b-83b2-4a90-a08a-7573ffb38119   none      none          off        
-    oxp_736d4cab-c262-485e-89c2-07e6543f0855/crypt/zone/oxz_crucible_65d597c5-86b9-43f6-84cd-67bb108df9f0            6de460bc-890d-4e7a-920f-607862440cfd   none      none          off        
-    oxp_b32fa3da-4dec-4237-9776-e1a57ba15a21/crypt/zone/oxz_crucible_a9f1d41e-c445-4783-af13-0095b2836f0f            b5d6cec1-c83f-4c41-9e79-8b9bf917f483   none      none          off        
-    oxp_71a07ac0-d24e-446c-a202-1998e7f6ac8c/crypt/zone/oxz_crucible_e9ab813f-0fff-4b41-a101-790f6d94b40a            7c459b4e-396b-497f-8094-f342939d1f9f   none      none          off        
-    oxp_8ae56ca0-709d-4b8f-9869-51b62b542eef/crypt/zone/oxz_crucible_f00c7a67-51a6-4d09-be39-f20b0e6da1c6            6ff911b9-a4a5-4986-ba04-c6b3f234d3b4   none      none          off        
-    oxp_60e6b021-79d6-4a6b-917c-6637e0769558/crypt/zone/oxz_crucible_pantry_840a4f34-0e53-469c-8c79-12b75bb42edc     7de8087e-602a-4a81-98ff-d766213d0f94   none      none          off        
-    oxp_60e6b021-79d6-4a6b-917c-6637e0769558/crypt/zone/oxz_internal_dns_c89ac05f-d9b2-47f4-9d48-2f38130e4ad9        dd1cdc17-808e-4e6d-99ed-84b2d0e220f1   none      none          off        
-    oxp_60e6b021-79d6-4a6b-917c-6637e0769558/crypt/zone/oxz_nexus_a6032c9e-a365-45d7-ad9f-07ac0fa7079a               198ff957-cce0-40cf-9048-f65cf9a6c671   none      none          off        
-    oxp_60e6b021-79d6-4a6b-917c-6637e0769558/crypt/zone/oxz_ntp_66695827-17c4-4885-b6c0-2cb6b6d3ad1c                 ccfb112d-c72e-4482-9bb0-f9cbbb034f7d   none      none          off        
-    oxp_60e6b021-79d6-4a6b-917c-6637e0769558/crypt/debug                                                             10610f76-51e8-4be4-a4ad-9af953f6bf4a   100 GiB   none          gzip-9     
-    oxp_71a07ac0-d24e-446c-a202-1998e7f6ac8c/crypt/debug                                                             e0bcc415-f8f9-401f-a507-cee5587756b1   100 GiB   none          gzip-9     
-    oxp_736d4cab-c262-485e-89c2-07e6543f0855/crypt/debug                                                             8bbc5419-7125-4cb1-b990-436af4bb8eb4   100 GiB   none          gzip-9     
-    oxp_8ae56ca0-709d-4b8f-9869-51b62b542eef/crypt/debug                                                             280dd773-35e2-4dda-ae2a-65c88f1b2a01   100 GiB   none          gzip-9     
-    oxp_8e0bcc4f-0799-450c-a0ad-80c1637f59e3/crypt/debug                                                             fecbd83d-7440-4900-b22b-6206e55b2920   100 GiB   none          gzip-9     
-    oxp_8eeebb8e-6db6-43e8-a429-d26dde99882c/crypt/debug                                                             e120c8f8-049f-40f0-8d70-4cfe409ef34d   100 GiB   none          gzip-9     
-    oxp_a3e8de5b-c47a-49c0-b698-4d6955e1327f/crypt/debug                                                             37eb0429-d620-40fb-a57a-62486d001738   100 GiB   none          gzip-9     
-    oxp_b32fa3da-4dec-4237-9776-e1a57ba15a21/crypt/debug                                                             d0f12057-da73-4c1d-bdec-32a0e7ab7107   100 GiB   none          gzip-9     
-    oxp_e9c238f6-87a3-4087-8ba4-aa594a82d012/crypt/debug                                                             2288ff91-8e52-4817-825f-2f8b8eb1681d   100 GiB   none          gzip-9     
-    oxp_fbf997ef-52d3-438a-b036-b9117322e569/crypt/debug                                                             17ffe1be-b38b-4f39-90af-57af25dbfe30   100 GiB   none          gzip-9     
-+   oxp_60e6b021-79d6-4a6b-917c-6637e0769558/crypt/clickhouse_keeper                                                 886f2522-8122-465f-8996-2d8c2acd9d0d   none      none          off        
-+   oxp_60e6b021-79d6-4a6b-917c-6637e0769558/crypt/zone/oxz_clickhouse_keeper_39fd3357-4de8-433e-9c07-1ec65de7ca59   095cf066-5a68-40b4-afc6-baf5bcbadd05   none      none          off        
+    oxp_60e6b021-79d6-4a6b-917c-6637e0769558/crucible                                                                723e4ec2-5f4a-48a9-a6a1-cb523dc47d3d   none      none          off        
+    oxp_71a07ac0-d24e-446c-a202-1998e7f6ac8c/crucible                                                                b2796e6b-ad7d-41a5-82a6-947b96e42d47   none      none          off        
+    oxp_736d4cab-c262-485e-89c2-07e6543f0855/crucible                                                                c993b4da-bea9-4010-a8d6-17d733698f07   none      none          off        
+    oxp_8ae56ca0-709d-4b8f-9869-51b62b542eef/crucible                                                                4f497ece-88c1-4557-a8b4-0e990f9941a9   none      none          off        
+    oxp_8e0bcc4f-0799-450c-a0ad-80c1637f59e3/crucible                                                                43a16c22-e79a-4bea-bcf6-682099a728dd   none      none          off        
+    oxp_8eeebb8e-6db6-43e8-a429-d26dde99882c/crucible                                                                b6bbb45b-68fc-4fa5-86cc-b59b0f797fb2   none      none          off        
+    oxp_a3e8de5b-c47a-49c0-b698-4d6955e1327f/crucible                                                                e4838ed0-304f-475e-a282-9f644f2ba3e5   none      none          off        
+    oxp_b32fa3da-4dec-4237-9776-e1a57ba15a21/crucible                                                                046f2730-768d-4bcc-8ebf-4b5f5597151c   none      none          off        
+    oxp_e9c238f6-87a3-4087-8ba4-aa594a82d012/crucible                                                                0830fc6d-ed82-41de-9389-0bd3fd4677ea   none      none          off        
+    oxp_fbf997ef-52d3-438a-b036-b9117322e569/crucible                                                                d9662141-585e-4e18-a461-9627097f02a2   none      none          off        
+    oxp_60e6b021-79d6-4a6b-917c-6637e0769558/crypt/clickhouse                                                        a4f84c49-4303-411f-bb1b-08877d828946   none      none          off        
+    oxp_60e6b021-79d6-4a6b-917c-6637e0769558/crypt/internal_dns                                                      2edca3dc-a0e5-4d34-b8a2-065be4cca767   none      none          off        
+    oxp_60e6b021-79d6-4a6b-917c-6637e0769558/crypt/zone                                                              87cd9f37-3de3-457c-9412-d0dc5678eda8   none      none          off        
+    oxp_71a07ac0-d24e-446c-a202-1998e7f6ac8c/crypt/zone                                                              3a164f36-1f53-45b3-b190-ad8a2817bc69   none      none          off        
+    oxp_736d4cab-c262-485e-89c2-07e6543f0855/crypt/zone                                                              407556ed-09ab-430e-bc8f-8291b8f8c8fe   none      none          off        
+    oxp_8ae56ca0-709d-4b8f-9869-51b62b542eef/crypt/zone                                                              99d57d61-f12a-4b56-8114-86ba92d07649   none      none          off        
+    oxp_8e0bcc4f-0799-450c-a0ad-80c1637f59e3/crypt/zone                                                              da1eb596-8764-4268-a60b-f4705b4f615b   none      none          off        
+    oxp_8eeebb8e-6db6-43e8-a429-d26dde99882c/crypt/zone                                                              d555bf19-887c-48d2-8144-47c2eac9a9e8   none      none          off        
+    oxp_a3e8de5b-c47a-49c0-b698-4d6955e1327f/crypt/zone                                                              9785e77a-9422-4b46-a4ae-8b9a155eb121   none      none          off        
+    oxp_b32fa3da-4dec-4237-9776-e1a57ba15a21/crypt/zone                                                              1192a37c-a871-4c48-905d-03c3d6035bdc   none      none          off        
+    oxp_e9c238f6-87a3-4087-8ba4-aa594a82d012/crypt/zone                                                              7bf1c7ec-5465-4bfd-b1d9-939f05336012   none      none          off        
+    oxp_fbf997ef-52d3-438a-b036-b9117322e569/crypt/zone                                                              be526b44-2c78-49ec-8ab4-73e161e27f22   none      none          off        
+    oxp_60e6b021-79d6-4a6b-917c-6637e0769558/crypt/zone/oxz_clickhouse_35e8d4b6-ea92-45cf-923c-3f566a0b1fe5          cd7e5c3a-2328-4568-b8f8-cf349f0cdd12   none      none          off        
+    oxp_e9c238f6-87a3-4087-8ba4-aa594a82d012/crypt/zone/oxz_crucible_044d074d-7905-4024-82ff-68d76221db68            98fd0f42-7337-4ce7-814e-f988304b8873   none      none          off        
+    oxp_71a07ac0-d24e-446c-a202-1998e7f6ac8c/crypt/zone/oxz_crucible_28826473-ac0b-41ea-8c54-72b782db1bcb            bbda84d8-c4ca-4f52-a766-681872fa06f0   none      none          off        
+    oxp_fbf997ef-52d3-438a-b036-b9117322e569/crypt/zone/oxz_crucible_2d3ff798-dda9-4ccf-8f91-070a20f06d55            e9c77dbd-c56a-404c-8ff9-6504b3f92556   none      none          off        
+    oxp_8eeebb8e-6db6-43e8-a429-d26dde99882c/crypt/zone/oxz_crucible_7538d29b-69f2-43e8-8509-505b25cb1c84            19110f8a-6267-41ed-ac7d-539cd0fe3511   none      none          off        
+    oxp_8ae56ca0-709d-4b8f-9869-51b62b542eef/crypt/zone/oxz_crucible_8234bbd2-4b31-4f6b-8dcc-4744b1d14e64            0fe4f647-ffd2-4845-805a-c069096560ee   none      none          off        
+    oxp_8e0bcc4f-0799-450c-a0ad-80c1637f59e3/crypt/zone/oxz_crucible_85358363-cee8-4bc3-af66-4d89e5cd714f            a1daa561-2448-4afb-8233-ec149d2bd7f4   none      none          off        
+    oxp_736d4cab-c262-485e-89c2-07e6543f0855/crypt/zone/oxz_crucible_9b58d04f-85bf-4f5e-8c6a-5d855062d5c4            69812f66-4b59-4590-9e1f-bce3e93b3b08   none      none          off        
+    oxp_60e6b021-79d6-4a6b-917c-6637e0769558/crypt/zone/oxz_crucible_e7da0aec-c6b6-4a56-9525-35385b9c62a2            36e58025-88e2-4eb9-8af0-ed9a98dda1b9   none      none          off        
+    oxp_a3e8de5b-c47a-49c0-b698-4d6955e1327f/crypt/zone/oxz_crucible_f3f977cc-7eca-4491-9b07-82b6284eb169            482fad9a-d83f-4025-8f0b-d3adea6ae2cf   none      none          off        
+    oxp_b32fa3da-4dec-4237-9776-e1a57ba15a21/crypt/zone/oxz_crucible_fef381d2-8368-4a2d-96a1-c956ed011f7b            b1937368-4019-40c4-af02-9811dc7eb143   none      none          off        
+    oxp_60e6b021-79d6-4a6b-917c-6637e0769558/crypt/zone/oxz_crucible_pantry_fe63bfd3-3128-4675-8118-cf6968293471     e3b31ef3-6b54-4901-aec4-0c672de62c7f   none      none          off        
+    oxp_60e6b021-79d6-4a6b-917c-6637e0769558/crypt/zone/oxz_internal_dns_b6b0689e-ef48-484d-b3c7-3c596edad20c        501e0672-2897-4992-8911-600e0283f04c   none      none          off        
+    oxp_60e6b021-79d6-4a6b-917c-6637e0769558/crypt/zone/oxz_nexus_46ecde76-fef7-4394-93dd-d22b003148e9               53655959-866b-4fee-bcf9-1e35504ad625   none      none          off        
+    oxp_60e6b021-79d6-4a6b-917c-6637e0769558/crypt/zone/oxz_ntp_4d009155-44fb-45b9-afed-f89cb57ce8da                 0590facf-202a-463b-81be-b6e88c47da76   none      none          off        
+    oxp_60e6b021-79d6-4a6b-917c-6637e0769558/crypt/debug                                                             8f7f16c1-d9fb-4405-9dcf-68bfbaa7bf8c   100 GiB   none          gzip-9     
+    oxp_71a07ac0-d24e-446c-a202-1998e7f6ac8c/crypt/debug                                                             6482f332-801a-473f-a77d-e07d30e2a5b7   100 GiB   none          gzip-9     
+    oxp_736d4cab-c262-485e-89c2-07e6543f0855/crypt/debug                                                             0bb0541f-2c64-487b-a8af-162454207504   100 GiB   none          gzip-9     
+    oxp_8ae56ca0-709d-4b8f-9869-51b62b542eef/crypt/debug                                                             902a6889-244f-4b67-baa4-b245f3d622c8   100 GiB   none          gzip-9     
+    oxp_8e0bcc4f-0799-450c-a0ad-80c1637f59e3/crypt/debug                                                             667ffd3c-6735-4b50-bc3b-cfa32fcc811e   100 GiB   none          gzip-9     
+    oxp_8eeebb8e-6db6-43e8-a429-d26dde99882c/crypt/debug                                                             cf48ba87-a4bb-435f-999b-bca46cfd6a89   100 GiB   none          gzip-9     
+    oxp_a3e8de5b-c47a-49c0-b698-4d6955e1327f/crypt/debug                                                             7d64cab3-7311-4519-ae4a-1af6b320fa9b   100 GiB   none          gzip-9     
+    oxp_b32fa3da-4dec-4237-9776-e1a57ba15a21/crypt/debug                                                             d3e957fd-5f26-498a-8fa3-deaea4dc5820   100 GiB   none          gzip-9     
+    oxp_e9c238f6-87a3-4087-8ba4-aa594a82d012/crypt/debug                                                             4da77f4a-5e41-4604-af30-8cf568c38428   100 GiB   none          gzip-9     
+    oxp_fbf997ef-52d3-438a-b036-b9117322e569/crypt/debug                                                             03935cb1-ce06-4594-b2fe-23e127d1cd9d   100 GiB   none          gzip-9     
++   oxp_60e6b021-79d6-4a6b-917c-6637e0769558/crypt/clickhouse_keeper                                                 04ee4b4b-fcbe-4224-86fd-30144a4f2592   none      none          off        
++   oxp_60e6b021-79d6-4a6b-917c-6637e0769558/crypt/zone/oxz_clickhouse_keeper_dd5ab8b1-e6e7-40e0-9ea6-b6a16f485b52   a51fb98f-3fff-4c0a-82f0-7a4aad82096b   none      none          off        
 
 
     omicron zones generation 2 -> 3:
     -----------------------------------------------------------------------------------------------
     zone type           zone id                                disposition   underlay IP           
     -----------------------------------------------------------------------------------------------
-    clickhouse          df79db1e-54ca-4048-b22a-da120ae4c8c4   in service    fd00:1122:3344:101::23
-    crucible            08330c18-54e9-445b-81f3-8f1d6ad15cdd   in service    fd00:1122:3344:101::29
-    crucible            0ba018f0-4ff7-4bcc-a0c7-42cfec6bc9da   in service    fd00:1122:3344:101::2e
-    crucible            1e485cda-b36e-4647-9125-c273fc7a9850   in service    fd00:1122:3344:101::25
-    crucible            4d84fdb4-76fd-47a9-b033-7e1711d9125f   in service    fd00:1122:3344:101::2b
-    crucible            577b0a64-6fa9-4302-bfaa-853b6e9e71ac   in service    fd00:1122:3344:101::2d
-    crucible            5d296df4-4f2f-4896-8caa-42df00799bcb   in service    fd00:1122:3344:101::2a
-    crucible            65d597c5-86b9-43f6-84cd-67bb108df9f0   in service    fd00:1122:3344:101::27
-    crucible            a9f1d41e-c445-4783-af13-0095b2836f0f   in service    fd00:1122:3344:101::2c
-    crucible            e9ab813f-0fff-4b41-a101-790f6d94b40a   in service    fd00:1122:3344:101::26
-    crucible            f00c7a67-51a6-4d09-be39-f20b0e6da1c6   in service    fd00:1122:3344:101::28
-    crucible_pantry     840a4f34-0e53-469c-8c79-12b75bb42edc   in service    fd00:1122:3344:101::24
-    internal_dns        c89ac05f-d9b2-47f4-9d48-2f38130e4ad9   in service    fd00:1122:3344:1::1   
-    internal_ntp        66695827-17c4-4885-b6c0-2cb6b6d3ad1c   in service    fd00:1122:3344:101::21
-    nexus               a6032c9e-a365-45d7-ad9f-07ac0fa7079a   in service    fd00:1122:3344:101::22
-+   clickhouse_keeper   39fd3357-4de8-433e-9c07-1ec65de7ca59   in service    fd00:1122:3344:101::2f
+    clickhouse          35e8d4b6-ea92-45cf-923c-3f566a0b1fe5   in service    fd00:1122:3344:101::23
+    crucible            044d074d-7905-4024-82ff-68d76221db68   in service    fd00:1122:3344:101::2d
+    crucible            28826473-ac0b-41ea-8c54-72b782db1bcb   in service    fd00:1122:3344:101::26
+    crucible            2d3ff798-dda9-4ccf-8f91-070a20f06d55   in service    fd00:1122:3344:101::2e
+    crucible            7538d29b-69f2-43e8-8509-505b25cb1c84   in service    fd00:1122:3344:101::2a
+    crucible            8234bbd2-4b31-4f6b-8dcc-4744b1d14e64   in service    fd00:1122:3344:101::28
+    crucible            85358363-cee8-4bc3-af66-4d89e5cd714f   in service    fd00:1122:3344:101::29
+    crucible            9b58d04f-85bf-4f5e-8c6a-5d855062d5c4   in service    fd00:1122:3344:101::27
+    crucible            e7da0aec-c6b6-4a56-9525-35385b9c62a2   in service    fd00:1122:3344:101::25
+    crucible            f3f977cc-7eca-4491-9b07-82b6284eb169   in service    fd00:1122:3344:101::2b
+    crucible            fef381d2-8368-4a2d-96a1-c956ed011f7b   in service    fd00:1122:3344:101::2c
+    crucible_pantry     fe63bfd3-3128-4675-8118-cf6968293471   in service    fd00:1122:3344:101::24
+    internal_dns        b6b0689e-ef48-484d-b3c7-3c596edad20c   in service    fd00:1122:3344:1::1   
+    internal_ntp        4d009155-44fb-45b9-afed-f89cb57ce8da   in service    fd00:1122:3344:101::21
+    nexus               46ecde76-fef7-4394-93dd-d22b003148e9   in service    fd00:1122:3344:101::22
++   clickhouse_keeper   dd5ab8b1-e6e7-40e0-9ea6-b6a16f485b52   in service    fd00:1122:3344:101::2f
 
 
   sled 6a4c45f6-e02f-490c-bbfa-b32fb89e8e86 (active):
@@ -120,77 +120,77 @@ to:   blueprint 31ef2071-2ec9-49d9-8827-fd83b17a0e3d
     -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
     dataset name                                                                                                     dataset uuid                           quota     reservation   compression
     -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
-    oxp_0bf9d028-2b4a-4bff-82a1-6eb5fcefd985/crucible                                                                f3b1d2f6-3cbc-4420-bc91-5eaaf00f85d0   none      none          off        
-    oxp_19293a1d-fddc-40a7-88a4-ccafdb6f66d3/crucible                                                                276f044e-dd34-4c1e-beef-174da4fcf53d   none      none          off        
-    oxp_44484c44-477a-4676-8266-b98a00e80d79/crucible                                                                e06b1670-5f34-42dc-a410-3129d69907ec   none      none          off        
-    oxp_79787cd4-92da-4de5-bfd8-30a635521e10/crucible                                                                9d32dd45-e3ee-47b9-ba69-0dc711bbf632   none      none          off        
-    oxp_9ae94c94-baae-477e-912a-60f0c4f3bd13/crucible                                                                7e72090d-7f79-4ecc-92cc-5eb7d9dee022   none      none          off        
-    oxp_af85eec8-36b3-4b88-966d-a717b9b58fe5/crucible                                                                43606b8e-384f-4412-a273-d4dde8f2e76d   none      none          off        
-    oxp_ddfaaba3-dafe-4103-b868-e9843d29d346/crucible                                                                2d7145e9-0029-4ae0-bb12-ee65a1738005   none      none          off        
-    oxp_ec458c3e-91ca-40f1-a2a3-3f4292c1f279/crucible                                                                dfadcc38-505a-4e9b-8674-27f8a2af13a2   none      none          off        
-    oxp_f2fc7c4c-7966-449d-8ec3-5a70f460501d/crucible                                                                72e2a1d6-09dd-43ba-9b8b-befa101f53ef   none      none          off        
-    oxp_f635c28a-e5ca-4d22-ac94-d8f278a6ea0e/crucible                                                                c7dfbe25-5b52-4ee5-8556-719e99bb5e4d   none      none          off        
-    oxp_0bf9d028-2b4a-4bff-82a1-6eb5fcefd985/crypt/internal_dns                                                      b8af3673-c60a-45fb-adc1-c36d0d325417   none      none          off        
-    oxp_0bf9d028-2b4a-4bff-82a1-6eb5fcefd985/crypt/zone                                                              1ab5529e-c3db-41e1-a561-9c767f980ad4   none      none          off        
-    oxp_19293a1d-fddc-40a7-88a4-ccafdb6f66d3/crypt/zone                                                              68490e52-279a-4609-ba0b-11d03f904c88   none      none          off        
-    oxp_44484c44-477a-4676-8266-b98a00e80d79/crypt/zone                                                              2a5e3a10-6ab5-4988-be84-46b527dc2d23   none      none          off        
-    oxp_79787cd4-92da-4de5-bfd8-30a635521e10/crypt/zone                                                              fd0f9778-c31a-40f4-9ce9-f5154535e75b   none      none          off        
-    oxp_9ae94c94-baae-477e-912a-60f0c4f3bd13/crypt/zone                                                              e4220797-15df-42c4-9df7-ad927711d565   none      none          off        
-    oxp_af85eec8-36b3-4b88-966d-a717b9b58fe5/crypt/zone                                                              39714005-313e-42be-90eb-000a0560669f   none      none          off        
-    oxp_ddfaaba3-dafe-4103-b868-e9843d29d346/crypt/zone                                                              a647238a-1689-46c9-b680-dfe1b7b68684   none      none          off        
-    oxp_ec458c3e-91ca-40f1-a2a3-3f4292c1f279/crypt/zone                                                              29038bb0-9af1-4b03-9c10-b8a6444a0bc2   none      none          off        
-    oxp_f2fc7c4c-7966-449d-8ec3-5a70f460501d/crypt/zone                                                              e49915c6-59ed-4bbe-abf9-375b9502772a   none      none          off        
-    oxp_f635c28a-e5ca-4d22-ac94-d8f278a6ea0e/crypt/zone                                                              fc9765c5-0a89-4050-ba3e-e0625dbefb5f   none      none          off        
-    oxp_ddfaaba3-dafe-4103-b868-e9843d29d346/crypt/zone/oxz_crucible_1a92bb17-6477-46fc-9784-1d2a418d6e14            257c57cd-8f2c-440d-9fa0-e92a312295ec   none      none          off        
-    oxp_af85eec8-36b3-4b88-966d-a717b9b58fe5/crypt/zone/oxz_crucible_26115267-8333-4711-924e-d05acf601827            3a39d5e8-ea73-4cf3-b9de-48045475151c   none      none          off        
-    oxp_9ae94c94-baae-477e-912a-60f0c4f3bd13/crypt/zone/oxz_crucible_41af4ef6-d21b-4271-bfcb-524f4146784a            1522207b-ea98-47cc-810c-44808796d743   none      none          off        
-    oxp_44484c44-477a-4676-8266-b98a00e80d79/crypt/zone/oxz_crucible_487bde8c-a692-416c-be70-efef7f169fce            008ba9b6-8d41-4f7a-8ff3-ec31a0c96cf9   none      none          off        
-    oxp_f2fc7c4c-7966-449d-8ec3-5a70f460501d/crypt/zone/oxz_crucible_704a17e0-bc9d-43b9-a91e-b1ca37a23d0d            5739948f-d984-48a5-a27a-0223a0af2035   none      none          off        
-    oxp_f635c28a-e5ca-4d22-ac94-d8f278a6ea0e/crypt/zone/oxz_crucible_93535f54-4919-4c4d-9a07-f7ab6245c01f            109f44de-d1ed-4ce3-9670-76aceb206ee4   none      none          off        
-    oxp_ec458c3e-91ca-40f1-a2a3-3f4292c1f279/crypt/zone/oxz_crucible_9b9d58bd-44e6-4b70-80a4-e6a9262893ff            0a5bade3-3f2f-4385-b064-554b56f8bf8c   none      none          off        
-    oxp_0bf9d028-2b4a-4bff-82a1-6eb5fcefd985/crypt/zone/oxz_crucible_aa74c1b2-b4c1-4f36-8f01-9459ef23786b            e1db255d-4793-46bd-a1f3-f207be6b2839   none      none          off        
-    oxp_79787cd4-92da-4de5-bfd8-30a635521e10/crypt/zone/oxz_crucible_b6956e34-3c21-44d1-9ee2-cb7ee2e77c4e            2d2f2665-d556-4e65-9c53-d7fe573848a2   none      none          off        
-    oxp_19293a1d-fddc-40a7-88a4-ccafdb6f66d3/crypt/zone/oxz_crucible_eb58427d-599b-45dc-b316-8e4db7eec65e            26722393-82bf-442d-9725-030801a4d64c   none      none          off        
-    oxp_0bf9d028-2b4a-4bff-82a1-6eb5fcefd985/crypt/zone/oxz_crucible_pantry_97a785b8-d909-4fd4-92c1-9ba14bae603b     7b248682-95a2-4411-98b3-79fe6cb1a857   none      none          off        
-    oxp_0bf9d028-2b4a-4bff-82a1-6eb5fcefd985/crypt/zone/oxz_internal_dns_c259e8b9-1086-453a-8636-050639edeffb        30161ca3-c2d8-474b-906e-bd38fc912f84   none      none          off        
-    oxp_0bf9d028-2b4a-4bff-82a1-6eb5fcefd985/crypt/zone/oxz_nexus_c3c7b0bd-dce3-467b-919d-668cc6b06711               05b6bbbe-4c07-493e-8b92-4c8d4aeb1d66   none      none          off        
-    oxp_0bf9d028-2b4a-4bff-82a1-6eb5fcefd985/crypt/zone/oxz_ntp_bba31b23-d112-4cde-bd4a-635812c28c0e                 fadbc503-b72d-4862-a1fd-628c7ff599d1   none      none          off        
-    oxp_0bf9d028-2b4a-4bff-82a1-6eb5fcefd985/crypt/debug                                                             fb722d83-ddc2-4880-95a4-1ab12f4b95be   100 GiB   none          gzip-9     
-    oxp_19293a1d-fddc-40a7-88a4-ccafdb6f66d3/crypt/debug                                                             891a1ff4-66b1-4dc9-871c-be4a757bbd0f   100 GiB   none          gzip-9     
-    oxp_44484c44-477a-4676-8266-b98a00e80d79/crypt/debug                                                             3e3e18ad-d527-4b2e-b758-1eefdcfca44b   100 GiB   none          gzip-9     
-    oxp_79787cd4-92da-4de5-bfd8-30a635521e10/crypt/debug                                                             bd4efdbe-7128-4423-aacf-6cf35e5a914d   100 GiB   none          gzip-9     
-    oxp_9ae94c94-baae-477e-912a-60f0c4f3bd13/crypt/debug                                                             708d4e8b-3acf-44cf-87a2-275bb8fa0d96   100 GiB   none          gzip-9     
-    oxp_af85eec8-36b3-4b88-966d-a717b9b58fe5/crypt/debug                                                             98d65e73-01df-4525-a45d-acb2fc8d4a74   100 GiB   none          gzip-9     
-    oxp_ddfaaba3-dafe-4103-b868-e9843d29d346/crypt/debug                                                             8005f7c0-bab3-4b0a-9568-a5861c0a09bb   100 GiB   none          gzip-9     
-    oxp_ec458c3e-91ca-40f1-a2a3-3f4292c1f279/crypt/debug                                                             dae242d1-9535-4b08-b249-f030dde2c2fd   100 GiB   none          gzip-9     
-    oxp_f2fc7c4c-7966-449d-8ec3-5a70f460501d/crypt/debug                                                             6cea3508-8341-4093-abbb-c57d83cd87b4   100 GiB   none          gzip-9     
-    oxp_f635c28a-e5ca-4d22-ac94-d8f278a6ea0e/crypt/debug                                                             765b4728-8d6e-4fac-9a1b-ae2258d5c52b   100 GiB   none          gzip-9     
-+   oxp_0bf9d028-2b4a-4bff-82a1-6eb5fcefd985/crypt/clickhouse_keeper                                                 a3eed313-d886-4c1d-8023-8d2ec9e97ddd   none      none          off        
-+   oxp_0bf9d028-2b4a-4bff-82a1-6eb5fcefd985/crypt/clickhouse_server                                                 3d339942-c2d0-4615-a099-433a8b5a1543   none      none          off        
-+   oxp_0bf9d028-2b4a-4bff-82a1-6eb5fcefd985/crypt/zone/oxz_clickhouse_keeper_b36c16d5-de6e-411a-a32a-d35a26f2e151   48720037-5b8e-4478-9bb5-c86ee8a6e250   none      none          off        
-+   oxp_0bf9d028-2b4a-4bff-82a1-6eb5fcefd985/crypt/zone/oxz_clickhouse_server_71be6bff-666a-4f2b-a7dc-d80a88a71af5   a9e2160a-688f-4bbd-9a77-b2e695df86f4   none      none          off        
+    oxp_0bf9d028-2b4a-4bff-82a1-6eb5fcefd985/crucible                                                                f18270c8-a39b-4579-be20-d2d1b80bba42   none      none          off        
+    oxp_19293a1d-fddc-40a7-88a4-ccafdb6f66d3/crucible                                                                06c2af14-055c-4041-aa26-9155f9f42661   none      none          off        
+    oxp_44484c44-477a-4676-8266-b98a00e80d79/crucible                                                                9deffea6-d340-4432-be3c-fad135dc29a5   none      none          off        
+    oxp_79787cd4-92da-4de5-bfd8-30a635521e10/crucible                                                                47ca08b9-b962-43e2-99d7-c2e0556c0f52   none      none          off        
+    oxp_9ae94c94-baae-477e-912a-60f0c4f3bd13/crucible                                                                b2e54e29-6915-4b6d-bc76-6f72e5c7c55a   none      none          off        
+    oxp_af85eec8-36b3-4b88-966d-a717b9b58fe5/crucible                                                                cb992d4e-7a69-4bcd-96c8-fe6e40989e24   none      none          off        
+    oxp_ddfaaba3-dafe-4103-b868-e9843d29d346/crucible                                                                68338fc3-2d8b-4419-b33d-4cce6fe9380d   none      none          off        
+    oxp_ec458c3e-91ca-40f1-a2a3-3f4292c1f279/crucible                                                                5294b99c-3eac-40e1-a35b-1f1cf2f0d6bf   none      none          off        
+    oxp_f2fc7c4c-7966-449d-8ec3-5a70f460501d/crucible                                                                31718dcf-ebd5-432c-a9e5-40abcb40931c   none      none          off        
+    oxp_f635c28a-e5ca-4d22-ac94-d8f278a6ea0e/crucible                                                                ff7ff4a9-21c4-499e-9ceb-8a00a4bb21bc   none      none          off        
+    oxp_0bf9d028-2b4a-4bff-82a1-6eb5fcefd985/crypt/internal_dns                                                      56a1af5d-de86-46c5-9504-2d1ee70587c5   none      none          off        
+    oxp_0bf9d028-2b4a-4bff-82a1-6eb5fcefd985/crypt/zone                                                              003c1d4e-15bb-4fca-aa71-a7dff507b124   none      none          off        
+    oxp_19293a1d-fddc-40a7-88a4-ccafdb6f66d3/crypt/zone                                                              bf35a148-62f0-4f88-8f60-0a13747daba2   none      none          off        
+    oxp_44484c44-477a-4676-8266-b98a00e80d79/crypt/zone                                                              9b1bf42e-6f06-44cc-af5b-bff65d929322   none      none          off        
+    oxp_79787cd4-92da-4de5-bfd8-30a635521e10/crypt/zone                                                              2c9d6bce-0293-4364-b8c9-4bdea345490e   none      none          off        
+    oxp_9ae94c94-baae-477e-912a-60f0c4f3bd13/crypt/zone                                                              11726c79-6590-4831-8480-cf50e6322c8a   none      none          off        
+    oxp_af85eec8-36b3-4b88-966d-a717b9b58fe5/crypt/zone                                                              b463f0c2-3ae4-45f7-a38c-110731fcc5cb   none      none          off        
+    oxp_ddfaaba3-dafe-4103-b868-e9843d29d346/crypt/zone                                                              626abe12-321d-439b-ad8f-f8dfb2022f25   none      none          off        
+    oxp_ec458c3e-91ca-40f1-a2a3-3f4292c1f279/crypt/zone                                                              4200e2a7-0fd6-4631-9d60-21fd821193fe   none      none          off        
+    oxp_f2fc7c4c-7966-449d-8ec3-5a70f460501d/crypt/zone                                                              85f34c02-a35d-404e-8cde-bedf3e193b1c   none      none          off        
+    oxp_f635c28a-e5ca-4d22-ac94-d8f278a6ea0e/crypt/zone                                                              dd19c2c5-0bc9-48de-a116-b92503569092   none      none          off        
+    oxp_f635c28a-e5ca-4d22-ac94-d8f278a6ea0e/crypt/zone/oxz_crucible_06b45c33-9a90-408b-8534-f94ab6df8a42            9e0a360d-c158-417f-a45f-9d29ee67cdce   none      none          off        
+    oxp_19293a1d-fddc-40a7-88a4-ccafdb6f66d3/crypt/zone/oxz_crucible_32999e20-ed5c-4c25-b4bd-41a3fbaf1445            dd7a45b8-3175-4744-8b99-ce19b22bb8ce   none      none          off        
+    oxp_9ae94c94-baae-477e-912a-60f0c4f3bd13/crypt/zone/oxz_crucible_4a037563-f969-4028-8384-164bdf308c3c            0d5b2580-7190-4bcc-9982-5012dac51f05   none      none          off        
+    oxp_44484c44-477a-4676-8266-b98a00e80d79/crypt/zone/oxz_crucible_6564394d-2c51-4252-b3b1-f5f88a72d7c3            26a1cc86-f717-4a12-b644-5acd168843aa   none      none          off        
+    oxp_0bf9d028-2b4a-4bff-82a1-6eb5fcefd985/crypt/zone/oxz_crucible_87427b40-5114-49cd-96bd-63edd61fce90            e7364079-58e3-4b36-81a7-b9e08f2a8fff   none      none          off        
+    oxp_ddfaaba3-dafe-4103-b868-e9843d29d346/crypt/zone/oxz_crucible_8acdc189-d4da-45a7-b306-23b43e86f695            6fa84a9c-0161-40c9-b596-f3b2c679ef99   none      none          off        
+    oxp_ec458c3e-91ca-40f1-a2a3-3f4292c1f279/crypt/zone/oxz_crucible_971ce633-cdc4-48cf-983e-dc272c1639eb            cb8ca8a6-6a00-4aae-8702-1493e1c3b166   none      none          off        
+    oxp_af85eec8-36b3-4b88-966d-a717b9b58fe5/crypt/zone/oxz_crucible_cfa6af7a-bf53-4fe6-bf1a-7ce3812d15c4            27323e49-f61e-4a73-bc87-f8d9f5082143   none      none          off        
+    oxp_f2fc7c4c-7966-449d-8ec3-5a70f460501d/crypt/zone/oxz_crucible_e145fb8e-df12-4df9-8049-b146ae0275be            35c46d33-4e08-4fad-90d2-3da719538ef2   none      none          off        
+    oxp_79787cd4-92da-4de5-bfd8-30a635521e10/crypt/zone/oxz_crucible_f1d08ae7-68fe-4799-8f31-f1100887c6f0            02863a62-7624-4017-9269-412910ab73f0   none      none          off        
+    oxp_0bf9d028-2b4a-4bff-82a1-6eb5fcefd985/crypt/zone/oxz_crucible_pantry_f9e18694-fdff-46a3-b40d-570d43206f48     3cb3f346-9879-4023-b919-55c4172bbf23   none      none          off        
+    oxp_0bf9d028-2b4a-4bff-82a1-6eb5fcefd985/crypt/zone/oxz_internal_dns_a00d8ae3-d1db-4aef-9174-3ff867af5e9e        c2d9b145-5e15-47be-a835-7e1f51f27679   none      none          off        
+    oxp_0bf9d028-2b4a-4bff-82a1-6eb5fcefd985/crypt/zone/oxz_nexus_8ccafc1f-97f9-4da7-bb04-d346213387ce               dcc3603b-b160-42d9-a743-11075c3b6941   none      none          off        
+    oxp_0bf9d028-2b4a-4bff-82a1-6eb5fcefd985/crypt/zone/oxz_ntp_a1797f1d-2d2a-4396-9ab5-044630b41c35                 5a70b3fe-9fad-4c17-982b-272b8595c2e8   none      none          off        
+    oxp_0bf9d028-2b4a-4bff-82a1-6eb5fcefd985/crypt/debug                                                             4e4b2f99-dc01-4793-a37a-072d942da264   100 GiB   none          gzip-9     
+    oxp_19293a1d-fddc-40a7-88a4-ccafdb6f66d3/crypt/debug                                                             8573903d-9610-4084-b0c6-ffcbb5d96c39   100 GiB   none          gzip-9     
+    oxp_44484c44-477a-4676-8266-b98a00e80d79/crypt/debug                                                             540272e1-99d2-4d2e-9d3d-032014b0e6d9   100 GiB   none          gzip-9     
+    oxp_79787cd4-92da-4de5-bfd8-30a635521e10/crypt/debug                                                             4adf2ef6-2694-4aac-aabe-688bca767092   100 GiB   none          gzip-9     
+    oxp_9ae94c94-baae-477e-912a-60f0c4f3bd13/crypt/debug                                                             7e9d012a-6d8e-475e-805e-65985a66ffcd   100 GiB   none          gzip-9     
+    oxp_af85eec8-36b3-4b88-966d-a717b9b58fe5/crypt/debug                                                             2189574d-9a73-4d25-858e-1084d57b59a8   100 GiB   none          gzip-9     
+    oxp_ddfaaba3-dafe-4103-b868-e9843d29d346/crypt/debug                                                             3cf0580b-4e1d-4ff9-bc22-4dc51ca9a53b   100 GiB   none          gzip-9     
+    oxp_ec458c3e-91ca-40f1-a2a3-3f4292c1f279/crypt/debug                                                             f499c5f8-b62f-493d-858a-8d33f7db81ff   100 GiB   none          gzip-9     
+    oxp_f2fc7c4c-7966-449d-8ec3-5a70f460501d/crypt/debug                                                             c16ff3c0-3282-46de-a620-49c6b1e3f882   100 GiB   none          gzip-9     
+    oxp_f635c28a-e5ca-4d22-ac94-d8f278a6ea0e/crypt/debug                                                             8dde6eee-f28e-4b55-8c11-525884ec81e5   100 GiB   none          gzip-9     
++   oxp_0bf9d028-2b4a-4bff-82a1-6eb5fcefd985/crypt/clickhouse_keeper                                                 473adeb2-a57a-4240-82e9-88f2bebc1245   none      none          off        
++   oxp_0bf9d028-2b4a-4bff-82a1-6eb5fcefd985/crypt/clickhouse_server                                                 4363b5f8-9a67-49af-b49d-585e532fa7bc   none      none          off        
++   oxp_0bf9d028-2b4a-4bff-82a1-6eb5fcefd985/crypt/zone/oxz_clickhouse_keeper_31a66e47-6252-4f38-aa92-f48637da152c   49f52cc5-74df-4cfa-b7f0-07c7e810940d   none      none          off        
++   oxp_0bf9d028-2b4a-4bff-82a1-6eb5fcefd985/crypt/zone/oxz_clickhouse_server_6fedfc94-2ae6-4cc7-a968-5185207284f4   f1143eb2-0685-4708-a471-968a58f93bad   none      none          off        
 
 
     omicron zones generation 2 -> 3:
     -----------------------------------------------------------------------------------------------
     zone type           zone id                                disposition   underlay IP           
     -----------------------------------------------------------------------------------------------
-    crucible            1a92bb17-6477-46fc-9784-1d2a418d6e14   in service    fd00:1122:3344:103::2a
-    crucible            26115267-8333-4711-924e-d05acf601827   in service    fd00:1122:3344:103::29
-    crucible            41af4ef6-d21b-4271-bfcb-524f4146784a   in service    fd00:1122:3344:103::28
-    crucible            487bde8c-a692-416c-be70-efef7f169fce   in service    fd00:1122:3344:103::26
-    crucible            704a17e0-bc9d-43b9-a91e-b1ca37a23d0d   in service    fd00:1122:3344:103::2c
-    crucible            93535f54-4919-4c4d-9a07-f7ab6245c01f   in service    fd00:1122:3344:103::2d
-    crucible            9b9d58bd-44e6-4b70-80a4-e6a9262893ff   in service    fd00:1122:3344:103::2b
-    crucible            aa74c1b2-b4c1-4f36-8f01-9459ef23786b   in service    fd00:1122:3344:103::24
-    crucible            b6956e34-3c21-44d1-9ee2-cb7ee2e77c4e   in service    fd00:1122:3344:103::27
-    crucible            eb58427d-599b-45dc-b316-8e4db7eec65e   in service    fd00:1122:3344:103::25
-    crucible_pantry     97a785b8-d909-4fd4-92c1-9ba14bae603b   in service    fd00:1122:3344:103::23
-    internal_dns        c259e8b9-1086-453a-8636-050639edeffb   in service    fd00:1122:3344:2::1   
-    internal_ntp        bba31b23-d112-4cde-bd4a-635812c28c0e   in service    fd00:1122:3344:103::21
-    nexus               c3c7b0bd-dce3-467b-919d-668cc6b06711   in service    fd00:1122:3344:103::22
-+   clickhouse_keeper   b36c16d5-de6e-411a-a32a-d35a26f2e151   in service    fd00:1122:3344:103::2e
-+   clickhouse_server   71be6bff-666a-4f2b-a7dc-d80a88a71af5   in service    fd00:1122:3344:103::2f
+    crucible            06b45c33-9a90-408b-8534-f94ab6df8a42   in service    fd00:1122:3344:103::2d
+    crucible            32999e20-ed5c-4c25-b4bd-41a3fbaf1445   in service    fd00:1122:3344:103::25
+    crucible            4a037563-f969-4028-8384-164bdf308c3c   in service    fd00:1122:3344:103::28
+    crucible            6564394d-2c51-4252-b3b1-f5f88a72d7c3   in service    fd00:1122:3344:103::26
+    crucible            87427b40-5114-49cd-96bd-63edd61fce90   in service    fd00:1122:3344:103::24
+    crucible            8acdc189-d4da-45a7-b306-23b43e86f695   in service    fd00:1122:3344:103::2a
+    crucible            971ce633-cdc4-48cf-983e-dc272c1639eb   in service    fd00:1122:3344:103::2b
+    crucible            cfa6af7a-bf53-4fe6-bf1a-7ce3812d15c4   in service    fd00:1122:3344:103::29
+    crucible            e145fb8e-df12-4df9-8049-b146ae0275be   in service    fd00:1122:3344:103::2c
+    crucible            f1d08ae7-68fe-4799-8f31-f1100887c6f0   in service    fd00:1122:3344:103::27
+    crucible_pantry     f9e18694-fdff-46a3-b40d-570d43206f48   in service    fd00:1122:3344:103::23
+    internal_dns        a00d8ae3-d1db-4aef-9174-3ff867af5e9e   in service    fd00:1122:3344:2::1   
+    internal_ntp        a1797f1d-2d2a-4396-9ab5-044630b41c35   in service    fd00:1122:3344:103::21
+    nexus               8ccafc1f-97f9-4da7-bb04-d346213387ce   in service    fd00:1122:3344:103::22
++   clickhouse_keeper   31a66e47-6252-4f38-aa92-f48637da152c   in service    fd00:1122:3344:103::2e
++   clickhouse_server   6fedfc94-2ae6-4cc7-a968-5185207284f4   in service    fd00:1122:3344:103::2f
 
 
   sled be531a62-9897-430d-acd2-ce14b4632627 (active):
@@ -215,77 +215,77 @@ to:   blueprint 31ef2071-2ec9-49d9-8827-fd83b17a0e3d
     -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
     dataset name                                                                                                     dataset uuid                           quota     reservation   compression
     -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
-    oxp_2a76ab1a-fb16-412d-93f9-b8cd9aa94e85/crucible                                                                431cfe4a-5756-40f4-8a9c-b70ae1227f1e   none      none          off        
-    oxp_2de2bf7e-c679-4b2b-b373-908e9d3ffbfc/crucible                                                                1123f86b-169c-40df-8ed1-95c3def65e30   none      none          off        
-    oxp_2f02a5c6-fcf5-4b5a-bc7d-7f65369918ba/crucible                                                                afa41d1a-3fc1-4723-835d-61d13db33cfe   none      none          off        
-    oxp_32041dbf-e58d-4f32-840d-923d3d3b68af/crucible                                                                da067282-0ae9-4861-8b78-b639622508af   none      none          off        
-    oxp_5f88adff-bb50-4dc1-bbfb-5a410c753ed5/crucible                                                                fcb937be-3b91-4ae7-9e25-a69808eeb07f   none      none          off        
-    oxp_74d64eb9-bf69-4782-af16-2d3a761ca171/crucible                                                                2854cb42-e5b9-4773-bd6e-6ec85d33a174   none      none          off        
-    oxp_b3c231c9-b2a5-4267-b4bf-9651881b91a5/crucible                                                                aa8f925e-6c3a-40d2-ae2d-946324a7d612   none      none          off        
-    oxp_bca80b95-8dca-4a3b-b24d-d44b6a9ff71b/crucible                                                                755ad19c-d29b-4e3c-9c13-63b56a407765   none      none          off        
-    oxp_db16345e-427a-4c8e-9032-17270f729308/crucible                                                                be3cf2f7-5388-4cd6-8119-ecf316c6052e   none      none          off        
-    oxp_e3b45593-8f0c-47b2-a381-802a7dad1f54/crucible                                                                a2391107-7408-4e0c-a694-3fd073fa09df   none      none          off        
-    oxp_2a76ab1a-fb16-412d-93f9-b8cd9aa94e85/crypt/internal_dns                                                      7be88e8f-06d3-49f7-a6d9-5c586f13716c   none      none          off        
-    oxp_2a76ab1a-fb16-412d-93f9-b8cd9aa94e85/crypt/zone                                                              37405860-deb4-4f2f-b770-ab8b83175d8c   none      none          off        
-    oxp_2de2bf7e-c679-4b2b-b373-908e9d3ffbfc/crypt/zone                                                              bbb78481-c7e5-44a6-85ae-37e363827e9f   none      none          off        
-    oxp_2f02a5c6-fcf5-4b5a-bc7d-7f65369918ba/crypt/zone                                                              38103edf-a98f-46ca-94ea-3404268ea935   none      none          off        
-    oxp_32041dbf-e58d-4f32-840d-923d3d3b68af/crypt/zone                                                              3f1adfcf-9a2a-41db-9e1a-a2e13ff8a7dd   none      none          off        
-    oxp_5f88adff-bb50-4dc1-bbfb-5a410c753ed5/crypt/zone                                                              5c620f9c-454b-451b-99ca-47c3d94df493   none      none          off        
-    oxp_74d64eb9-bf69-4782-af16-2d3a761ca171/crypt/zone                                                              13f8be82-85e9-43ac-985b-e7a51a910c41   none      none          off        
-    oxp_b3c231c9-b2a5-4267-b4bf-9651881b91a5/crypt/zone                                                              9f1f99c7-e6c5-4bbc-9de5-15252b532914   none      none          off        
-    oxp_bca80b95-8dca-4a3b-b24d-d44b6a9ff71b/crypt/zone                                                              2747bb48-2fb7-4999-a63c-5ba5e35e0a10   none      none          off        
-    oxp_db16345e-427a-4c8e-9032-17270f729308/crypt/zone                                                              f7ddacf4-edc7-46ba-9b74-d588bd62505e   none      none          off        
-    oxp_e3b45593-8f0c-47b2-a381-802a7dad1f54/crypt/zone                                                              64e62d15-e813-461d-9a50-403d9bd1df7c   none      none          off        
-    oxp_bca80b95-8dca-4a3b-b24d-d44b6a9ff71b/crypt/zone/oxz_crucible_0a160b89-6288-44f5-9908-33589094628e            53a623d2-9ffc-48fb-871d-23bd52e0f4dd   none      none          off        
-    oxp_2f02a5c6-fcf5-4b5a-bc7d-7f65369918ba/crypt/zone/oxz_crucible_2cb036bd-6056-4547-af65-aa6c0c1e4d6e            c6c9e491-ce4d-4dc4-82be-e394fa1e82e2   none      none          off        
-    oxp_2de2bf7e-c679-4b2b-b373-908e9d3ffbfc/crypt/zone/oxz_crucible_37c72edc-6acd-4c2d-ab76-d1c88e1f01f5            9b49fc13-4d2c-423e-9839-f6e1d0bffc6e   none      none          off        
-    oxp_db16345e-427a-4c8e-9032-17270f729308/crypt/zone/oxz_crucible_5fb4b72f-bf1b-47c7-a2e4-dbdafcdb47f5            1d73fc1f-81fc-4e06-9b52-686596ac0f6c   none      none          off        
-    oxp_5f88adff-bb50-4dc1-bbfb-5a410c753ed5/crypt/zone/oxz_crucible_6ae471b1-1dd8-460e-a2a5-3ea796f746d5            98b66132-d99e-42e2-8517-5860412c61b1   none      none          off        
-    oxp_2a76ab1a-fb16-412d-93f9-b8cd9aa94e85/crypt/zone/oxz_crucible_75cccfab-ea70-4596-a685-ab9bd5e540a1            e2ff081e-c5a4-42c3-8d95-969e2b9b7b31   none      none          off        
-    oxp_e3b45593-8f0c-47b2-a381-802a7dad1f54/crypt/zone/oxz_crucible_8a36ef67-bf66-40b9-a2f4-34ac70e90e39            c44e20e1-7cce-46df-ba71-db7fb3e3a5ff   none      none          off        
-    oxp_74d64eb9-bf69-4782-af16-2d3a761ca171/crypt/zone/oxz_crucible_b6a9674e-8b42-4d67-954f-3e957db298dd            e7c2d833-b6a1-469f-b52f-8bbb45e9a30e   none      none          off        
-    oxp_b3c231c9-b2a5-4267-b4bf-9651881b91a5/crypt/zone/oxz_crucible_c79e017b-7e27-4ff5-be14-3673f8cb2279            3544adde-a808-45c0-ae19-08b4f65e3ad4   none      none          off        
-    oxp_32041dbf-e58d-4f32-840d-923d3d3b68af/crypt/zone/oxz_crucible_e52381c1-d7ab-402f-a9a8-bb52fbb614af            a0251fdc-166b-4476-95d4-f7fd58fdaf76   none      none          off        
-    oxp_2a76ab1a-fb16-412d-93f9-b8cd9aa94e85/crypt/zone/oxz_crucible_pantry_1432df56-4a7b-4271-9b24-a8a3183a95a7     452dad91-0c11-4dfa-96fb-dfb0cfa1d17c   none      none          off        
-    oxp_2a76ab1a-fb16-412d-93f9-b8cd9aa94e85/crypt/zone/oxz_internal_dns_832c71a1-357d-482b-8661-3193d59ed776        08588a53-0f1d-4631-a1ef-8fa34098fbf6   none      none          off        
-    oxp_2a76ab1a-fb16-412d-93f9-b8cd9aa94e85/crypt/zone/oxz_nexus_da39dead-64e2-45b6-9d01-d99584504dfd               45dc03ec-d0e0-429a-a099-7fc6ea6dfb85   none      none          off        
-    oxp_2a76ab1a-fb16-412d-93f9-b8cd9aa94e85/crypt/zone/oxz_ntp_816afef9-e5cd-40ba-8cc5-71e783943e43                 6f5ba0fc-1b43-4a40-ba5a-3abf11eae62b   none      none          off        
-    oxp_2a76ab1a-fb16-412d-93f9-b8cd9aa94e85/crypt/debug                                                             c55ba154-4f4b-48a5-997b-2a1579671c74   100 GiB   none          gzip-9     
-    oxp_2de2bf7e-c679-4b2b-b373-908e9d3ffbfc/crypt/debug                                                             071d678d-9376-4c3b-8e1f-825d27bcae3a   100 GiB   none          gzip-9     
-    oxp_2f02a5c6-fcf5-4b5a-bc7d-7f65369918ba/crypt/debug                                                             daeded95-0145-4b97-b1fb-60d44856d1e4   100 GiB   none          gzip-9     
-    oxp_32041dbf-e58d-4f32-840d-923d3d3b68af/crypt/debug                                                             80d0697d-4ebe-4856-b7bf-78ff811eb00b   100 GiB   none          gzip-9     
-    oxp_5f88adff-bb50-4dc1-bbfb-5a410c753ed5/crypt/debug                                                             dd239ff5-a617-4eb1-ac6d-16eb76c2c849   100 GiB   none          gzip-9     
-    oxp_74d64eb9-bf69-4782-af16-2d3a761ca171/crypt/debug                                                             b9e71882-7f71-4a5e-be9c-7df560c75000   100 GiB   none          gzip-9     
-    oxp_b3c231c9-b2a5-4267-b4bf-9651881b91a5/crypt/debug                                                             bae0ee1b-b3a3-4c4c-96ee-53b8b4cd837b   100 GiB   none          gzip-9     
-    oxp_bca80b95-8dca-4a3b-b24d-d44b6a9ff71b/crypt/debug                                                             f2df23eb-672a-41b5-89e4-26c9feb50c7c   100 GiB   none          gzip-9     
-    oxp_db16345e-427a-4c8e-9032-17270f729308/crypt/debug                                                             e658be5b-df77-41fb-a000-5a924ac0b3da   100 GiB   none          gzip-9     
-    oxp_e3b45593-8f0c-47b2-a381-802a7dad1f54/crypt/debug                                                             96798a17-be94-44bb-9e12-2eb458e9a5ba   100 GiB   none          gzip-9     
-+   oxp_2a76ab1a-fb16-412d-93f9-b8cd9aa94e85/crypt/clickhouse_keeper                                                 c16a00f5-8830-400d-89e0-9a77cce8780e   none      none          off        
-+   oxp_2a76ab1a-fb16-412d-93f9-b8cd9aa94e85/crypt/clickhouse_server                                                 ce930007-8ed6-4675-a24a-57c227950d43   none      none          off        
-+   oxp_2a76ab1a-fb16-412d-93f9-b8cd9aa94e85/crypt/zone/oxz_clickhouse_keeper_f3279a8b-32fa-4426-b946-08aff9ded482   26c79a0e-a2e4-4093-ba43-5e7979609651   none      none          off        
-+   oxp_2a76ab1a-fb16-412d-93f9-b8cd9aa94e85/crypt/zone/oxz_clickhouse_server_122e30d3-d541-49b5-88de-1543b38123cc   748c9607-71dd-4f81-be08-c1eee262f69c   none      none          off        
+    oxp_2a76ab1a-fb16-412d-93f9-b8cd9aa94e85/crucible                                                                c73b47ac-ad1f-4cd1-b449-f220b5ad8104   none      none          off        
+    oxp_2de2bf7e-c679-4b2b-b373-908e9d3ffbfc/crucible                                                                813c7aac-695b-49ce-8bc5-f4cdbfc04b38   none      none          off        
+    oxp_2f02a5c6-fcf5-4b5a-bc7d-7f65369918ba/crucible                                                                e5da836d-fffb-4435-8500-889c05b04689   none      none          off        
+    oxp_32041dbf-e58d-4f32-840d-923d3d3b68af/crucible                                                                9f8d056c-3e84-4474-b9c7-5b7a890a8a7b   none      none          off        
+    oxp_5f88adff-bb50-4dc1-bbfb-5a410c753ed5/crucible                                                                e93cfc01-9581-4f6e-b77c-eb6300ca6ffb   none      none          off        
+    oxp_74d64eb9-bf69-4782-af16-2d3a761ca171/crucible                                                                f54d6e59-67a1-458b-8e66-6dc3b2adb755   none      none          off        
+    oxp_b3c231c9-b2a5-4267-b4bf-9651881b91a5/crucible                                                                6604dd1b-5f21-475d-952a-894717512d1b   none      none          off        
+    oxp_bca80b95-8dca-4a3b-b24d-d44b6a9ff71b/crucible                                                                05cb728f-f6b9-4132-922d-fe249b1ba736   none      none          off        
+    oxp_db16345e-427a-4c8e-9032-17270f729308/crucible                                                                500f8d46-a32d-4bd1-8f2c-cb9d36822660   none      none          off        
+    oxp_e3b45593-8f0c-47b2-a381-802a7dad1f54/crucible                                                                66c673a1-e8d8-4863-b368-a7ea292555fb   none      none          off        
+    oxp_2a76ab1a-fb16-412d-93f9-b8cd9aa94e85/crypt/internal_dns                                                      03de030d-d958-4ce5-86d2-368fa88e0bd8   none      none          off        
+    oxp_2a76ab1a-fb16-412d-93f9-b8cd9aa94e85/crypt/zone                                                              4c3c89bd-21cf-4986-b012-e89e4e1c1ac4   none      none          off        
+    oxp_2de2bf7e-c679-4b2b-b373-908e9d3ffbfc/crypt/zone                                                              ff4a77a2-528a-4c70-a5b9-f0093c95697b   none      none          off        
+    oxp_2f02a5c6-fcf5-4b5a-bc7d-7f65369918ba/crypt/zone                                                              676fc8c5-743b-48ca-99fd-2f2379c83890   none      none          off        
+    oxp_32041dbf-e58d-4f32-840d-923d3d3b68af/crypt/zone                                                              63362c89-4b42-4649-9ebe-43e19a5c0e51   none      none          off        
+    oxp_5f88adff-bb50-4dc1-bbfb-5a410c753ed5/crypt/zone                                                              6f83a31e-1181-418f-92b0-d0534e9ae6dd   none      none          off        
+    oxp_74d64eb9-bf69-4782-af16-2d3a761ca171/crypt/zone                                                              260ffd7d-4da5-4657-9158-ba7e1eae5971   none      none          off        
+    oxp_b3c231c9-b2a5-4267-b4bf-9651881b91a5/crypt/zone                                                              ed4c8570-3951-4f79-b27e-da73150609be   none      none          off        
+    oxp_bca80b95-8dca-4a3b-b24d-d44b6a9ff71b/crypt/zone                                                              e5dcf165-3ebb-40a2-b16f-a07b036a6533   none      none          off        
+    oxp_db16345e-427a-4c8e-9032-17270f729308/crypt/zone                                                              dd27be6b-214d-4022-a99d-2a7d12e7d8bb   none      none          off        
+    oxp_e3b45593-8f0c-47b2-a381-802a7dad1f54/crypt/zone                                                              b7500d95-2499-48fc-a7d6-2460d61e197a   none      none          off        
+    oxp_32041dbf-e58d-4f32-840d-923d3d3b68af/crypt/zone/oxz_crucible_0b0e12fd-2800-4203-acb6-24e6e976271c            cf46ee68-f945-4af6-a647-4d612c1f05be   none      none          off        
+    oxp_2de2bf7e-c679-4b2b-b373-908e9d3ffbfc/crypt/zone/oxz_crucible_1a02d419-10c4-4326-b34e-eb2b1bd90bd7            2a439799-3f16-46df-ba1b-7ea29edd392d   none      none          off        
+    oxp_2a76ab1a-fb16-412d-93f9-b8cd9aa94e85/crypt/zone/oxz_crucible_56e18c31-f630-4643-ad5c-1fede34f35de            c30be90e-20cf-46c6-bb4a-b65d2c407878   none      none          off        
+    oxp_b3c231c9-b2a5-4267-b4bf-9651881b91a5/crypt/zone/oxz_crucible_5ea86015-8f62-40aa-b3b2-c659f17ee510            6289ea03-b2c9-4470-b7ba-b935450aa764   none      none          off        
+    oxp_5f88adff-bb50-4dc1-bbfb-5a410c753ed5/crypt/zone/oxz_crucible_78965849-e6e3-4250-a66a-dc50512fad34            43b36ba3-e516-4732-be8b-8cd2ca9de93c   none      none          off        
+    oxp_74d64eb9-bf69-4782-af16-2d3a761ca171/crypt/zone/oxz_crucible_90c484e5-69d3-4636-9c64-6a878f593d33            7cc8018e-323f-4d35-bb33-fcf557b9dace   none      none          off        
+    oxp_db16345e-427a-4c8e-9032-17270f729308/crypt/zone/oxz_crucible_a3901043-fa2a-4ef7-a40e-6ef0e5fd189f            88fd4e5a-50fd-43c7-8a75-0ad4376bd564   none      none          off        
+    oxp_2f02a5c6-fcf5-4b5a-bc7d-7f65369918ba/crypt/zone/oxz_crucible_be9fd98a-6422-4890-a32b-42d42d1c8957            932cbb0d-b1d0-423d-87b6-9dce8ddb6338   none      none          off        
+    oxp_e3b45593-8f0c-47b2-a381-802a7dad1f54/crypt/zone/oxz_crucible_bf71d1a8-9e65-479d-8920-0be8e3422ac5            fd0ce816-4da0-4490-be32-4d38fb78c13c   none      none          off        
+    oxp_bca80b95-8dca-4a3b-b24d-d44b6a9ff71b/crypt/zone/oxz_crucible_eb4176ea-456b-48f6-b284-7b76da0bf4a1            704ea6b5-0ffc-443f-ae8a-482666f8277c   none      none          off        
+    oxp_2a76ab1a-fb16-412d-93f9-b8cd9aa94e85/crypt/zone/oxz_crucible_pantry_417c97a4-fe25-439d-8359-3f7062981923     8957a276-6d4e-4c58-a856-d7c5433806e1   none      none          off        
+    oxp_2a76ab1a-fb16-412d-93f9-b8cd9aa94e85/crypt/zone/oxz_internal_dns_f2bbaa79-0eab-4b91-a404-dad4c19b58c2        fe0f566f-3cff-43ef-960c-649c27746c56   none      none          off        
+    oxp_2a76ab1a-fb16-412d-93f9-b8cd9aa94e85/crypt/zone/oxz_nexus_33ba37c4-2535-4095-a7e9-c69937fc584d               77d0cd16-b6e3-484d-962f-0477cd242482   none      none          off        
+    oxp_2a76ab1a-fb16-412d-93f9-b8cd9aa94e85/crypt/zone/oxz_ntp_47eab17a-4dd4-4467-90b2-f643f465cf34                 4eaf1849-1fe4-415c-bdc7-4cc04cac20ce   none      none          off        
+    oxp_2a76ab1a-fb16-412d-93f9-b8cd9aa94e85/crypt/debug                                                             c5b8f4f9-bd10-45b8-a9f3-93adf1402ecc   100 GiB   none          gzip-9     
+    oxp_2de2bf7e-c679-4b2b-b373-908e9d3ffbfc/crypt/debug                                                             43abf982-d457-46d1-8566-8047d2a78a41   100 GiB   none          gzip-9     
+    oxp_2f02a5c6-fcf5-4b5a-bc7d-7f65369918ba/crypt/debug                                                             1b6a1722-d9f7-48ea-b351-5bc8bad4fd07   100 GiB   none          gzip-9     
+    oxp_32041dbf-e58d-4f32-840d-923d3d3b68af/crypt/debug                                                             8be43fb0-00e7-4748-9a1a-ace9772d8a83   100 GiB   none          gzip-9     
+    oxp_5f88adff-bb50-4dc1-bbfb-5a410c753ed5/crypt/debug                                                             2ccb3aa9-f0ef-4fd4-9fd7-43b4a88b8d6b   100 GiB   none          gzip-9     
+    oxp_74d64eb9-bf69-4782-af16-2d3a761ca171/crypt/debug                                                             56759eb6-69e9-46a3-b44c-fc748cd506aa   100 GiB   none          gzip-9     
+    oxp_b3c231c9-b2a5-4267-b4bf-9651881b91a5/crypt/debug                                                             76fffbd2-9c74-46b5-8033-f442be1256f5   100 GiB   none          gzip-9     
+    oxp_bca80b95-8dca-4a3b-b24d-d44b6a9ff71b/crypt/debug                                                             c13a3d71-1241-42d1-95a8-d720c20ee2c4   100 GiB   none          gzip-9     
+    oxp_db16345e-427a-4c8e-9032-17270f729308/crypt/debug                                                             f030ef33-cad2-4760-9431-1907b797161b   100 GiB   none          gzip-9     
+    oxp_e3b45593-8f0c-47b2-a381-802a7dad1f54/crypt/debug                                                             947b2823-3dca-4b56-9324-f476e2c1c6da   100 GiB   none          gzip-9     
++   oxp_2a76ab1a-fb16-412d-93f9-b8cd9aa94e85/crypt/clickhouse_keeper                                                 6c5a6622-5f75-45a0-a9e8-4b513f5ac352   none      none          off        
++   oxp_2a76ab1a-fb16-412d-93f9-b8cd9aa94e85/crypt/clickhouse_server                                                 f8706468-85ac-4f9f-b41d-ff7c3a17ee5f   none      none          off        
++   oxp_2a76ab1a-fb16-412d-93f9-b8cd9aa94e85/crypt/zone/oxz_clickhouse_keeper_7aa82b80-0c37-4f20-9398-bfce4707f327   0bf9cddb-1911-495b-8aad-09b7eea5fff4   none      none          off        
++   oxp_2a76ab1a-fb16-412d-93f9-b8cd9aa94e85/crypt/zone/oxz_clickhouse_server_812be70a-f237-47d5-ab49-f9450fe948db   292f53fc-27bb-4cc4-a61b-7d02c978149c   none      none          off        
 
 
     omicron zones generation 2 -> 3:
     -----------------------------------------------------------------------------------------------
     zone type           zone id                                disposition   underlay IP           
     -----------------------------------------------------------------------------------------------
-    crucible            0a160b89-6288-44f5-9908-33589094628e   in service    fd00:1122:3344:102::2b
-    crucible            2cb036bd-6056-4547-af65-aa6c0c1e4d6e   in service    fd00:1122:3344:102::26
-    crucible            37c72edc-6acd-4c2d-ab76-d1c88e1f01f5   in service    fd00:1122:3344:102::25
-    crucible            5fb4b72f-bf1b-47c7-a2e4-dbdafcdb47f5   in service    fd00:1122:3344:102::2c
-    crucible            6ae471b1-1dd8-460e-a2a5-3ea796f746d5   in service    fd00:1122:3344:102::28
-    crucible            75cccfab-ea70-4596-a685-ab9bd5e540a1   in service    fd00:1122:3344:102::24
-    crucible            8a36ef67-bf66-40b9-a2f4-34ac70e90e39   in service    fd00:1122:3344:102::2d
-    crucible            b6a9674e-8b42-4d67-954f-3e957db298dd   in service    fd00:1122:3344:102::29
-    crucible            c79e017b-7e27-4ff5-be14-3673f8cb2279   in service    fd00:1122:3344:102::2a
-    crucible            e52381c1-d7ab-402f-a9a8-bb52fbb614af   in service    fd00:1122:3344:102::27
-    crucible_pantry     1432df56-4a7b-4271-9b24-a8a3183a95a7   in service    fd00:1122:3344:102::23
-    internal_dns        832c71a1-357d-482b-8661-3193d59ed776   in service    fd00:1122:3344:3::1   
-    internal_ntp        816afef9-e5cd-40ba-8cc5-71e783943e43   in service    fd00:1122:3344:102::21
-    nexus               da39dead-64e2-45b6-9d01-d99584504dfd   in service    fd00:1122:3344:102::22
-+   clickhouse_keeper   f3279a8b-32fa-4426-b946-08aff9ded482   in service    fd00:1122:3344:102::2e
-+   clickhouse_server   122e30d3-d541-49b5-88de-1543b38123cc   in service    fd00:1122:3344:102::2f
+    crucible            0b0e12fd-2800-4203-acb6-24e6e976271c   in service    fd00:1122:3344:102::27
+    crucible            1a02d419-10c4-4326-b34e-eb2b1bd90bd7   in service    fd00:1122:3344:102::25
+    crucible            56e18c31-f630-4643-ad5c-1fede34f35de   in service    fd00:1122:3344:102::24
+    crucible            5ea86015-8f62-40aa-b3b2-c659f17ee510   in service    fd00:1122:3344:102::2a
+    crucible            78965849-e6e3-4250-a66a-dc50512fad34   in service    fd00:1122:3344:102::28
+    crucible            90c484e5-69d3-4636-9c64-6a878f593d33   in service    fd00:1122:3344:102::29
+    crucible            a3901043-fa2a-4ef7-a40e-6ef0e5fd189f   in service    fd00:1122:3344:102::2c
+    crucible            be9fd98a-6422-4890-a32b-42d42d1c8957   in service    fd00:1122:3344:102::26
+    crucible            bf71d1a8-9e65-479d-8920-0be8e3422ac5   in service    fd00:1122:3344:102::2d
+    crucible            eb4176ea-456b-48f6-b284-7b76da0bf4a1   in service    fd00:1122:3344:102::2b
+    crucible_pantry     417c97a4-fe25-439d-8359-3f7062981923   in service    fd00:1122:3344:102::23
+    internal_dns        f2bbaa79-0eab-4b91-a404-dad4c19b58c2   in service    fd00:1122:3344:3::1   
+    internal_ntp        47eab17a-4dd4-4467-90b2-f643f465cf34   in service    fd00:1122:3344:102::21
+    nexus               33ba37c4-2535-4095-a7e9-c69937fc584d   in service    fd00:1122:3344:102::22
++   clickhouse_keeper   7aa82b80-0c37-4f20-9398-bfce4707f327   in service    fd00:1122:3344:102::2e
++   clickhouse_server   812be70a-f237-47d5-ab49-f9450fe948db   in service    fd00:1122:3344:102::2f
 
 
  COCKROACHDB SETTINGS:
@@ -301,21 +301,21 @@ to:   blueprint 31ef2071-2ec9-49d9-8827-fd83b17a0e3d
 +   max used server id:::::::::::::::::::::::::::::   2
 +   max used keeper id:::::::::::::::::::::::::::::   3
 +   cluster name:::::::::::::::::::::::::::::::::::   oximeter_cluster
-+   cluster secret:::::::::::::::::::::::::::::::::   75ba7558-f7cf-431f-bba5-71c8e82fd4c1
++   cluster secret:::::::::::::::::::::::::::::::::   6a984e2e-20be-4ed9-b572-d7ef063c67f7
 +   highest seen keeper leader committed log index:   0
 
     clickhouse keepers at generation 2:
     ------------------------------------------------
     zone id                                keeper id
     ------------------------------------------------
-+   39fd3357-4de8-433e-9c07-1ec65de7ca59   1        
-+   b36c16d5-de6e-411a-a32a-d35a26f2e151   2        
-+   f3279a8b-32fa-4426-b946-08aff9ded482   3        
++   31a66e47-6252-4f38-aa92-f48637da152c   1        
++   7aa82b80-0c37-4f20-9398-bfce4707f327   2        
++   dd5ab8b1-e6e7-40e0-9ea6-b6a16f485b52   3        
 
     clickhouse servers at generation 2:
     ------------------------------------------------
     zone id                                server id
     ------------------------------------------------
-+   122e30d3-d541-49b5-88de-1543b38123cc   1        
-+   71be6bff-666a-4f2b-a7dc-d80a88a71af5   2        
++   6fedfc94-2ae6-4cc7-a968-5185207284f4   1        
++   812be70a-f237-47d5-ab49-f9450fe948db   2        
 

--- a/nexus/reconfigurator/planning/tests/output/planner_deploy_all_keeper_nodes_3_4.txt
+++ b/nexus/reconfigurator/planning/tests/output/planner_deploy_all_keeper_nodes_3_4.txt
@@ -25,77 +25,77 @@ to:   blueprint 92fa943c-7dd4-48c3-9447-c9d0665744b6
     -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
     dataset name                                                                                                     dataset uuid                           quota     reservation   compression
     -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
-    oxp_60e6b021-79d6-4a6b-917c-6637e0769558/crucible                                                                fcd7e842-2648-407a-8d13-197e67de9e9d   none      none          off        
-    oxp_71a07ac0-d24e-446c-a202-1998e7f6ac8c/crucible                                                                c770de28-6c33-4cc7-97d9-62ddafd963aa   none      none          off        
-    oxp_736d4cab-c262-485e-89c2-07e6543f0855/crucible                                                                ac9f4d69-3281-4774-a098-250755079068   none      none          off        
-    oxp_8ae56ca0-709d-4b8f-9869-51b62b542eef/crucible                                                                09781292-36f1-4310-82b4-ddfb4d287fa1   none      none          off        
-    oxp_8e0bcc4f-0799-450c-a0ad-80c1637f59e3/crucible                                                                81719897-4ae6-4d76-8282-fda91c347811   none      none          off        
-    oxp_8eeebb8e-6db6-43e8-a429-d26dde99882c/crucible                                                                a2399f57-62eb-4d7d-ac69-09cd6e5c2134   none      none          off        
-    oxp_a3e8de5b-c47a-49c0-b698-4d6955e1327f/crucible                                                                cd6b3952-2024-4310-b82e-abfd245ec1d6   none      none          off        
-    oxp_b32fa3da-4dec-4237-9776-e1a57ba15a21/crucible                                                                4f99dd21-d6ed-409a-af19-9886d1083762   none      none          off        
-    oxp_e9c238f6-87a3-4087-8ba4-aa594a82d012/crucible                                                                e88d6ff8-6b98-44c1-97a7-83f371ae62fe   none      none          off        
-    oxp_fbf997ef-52d3-438a-b036-b9117322e569/crucible                                                                d6a838c7-3ee9-4cca-9d8b-986b4de0ba1c   none      none          off        
-    oxp_60e6b021-79d6-4a6b-917c-6637e0769558/crypt/clickhouse                                                        5cb56dc7-6c56-4bbf-ae73-6f08e0c97cdf   none      none          off        
-    oxp_60e6b021-79d6-4a6b-917c-6637e0769558/crypt/clickhouse_keeper                                                 886f2522-8122-465f-8996-2d8c2acd9d0d   none      none          off        
-    oxp_60e6b021-79d6-4a6b-917c-6637e0769558/crypt/internal_dns                                                      dd467397-efc5-4738-984e-77a0f3e3e678   none      none          off        
-    oxp_60e6b021-79d6-4a6b-917c-6637e0769558/crypt/zone                                                              8c4f4acd-8f6b-4296-81be-12d2eeae0483   none      none          off        
-    oxp_71a07ac0-d24e-446c-a202-1998e7f6ac8c/crypt/zone                                                              f83b1c8d-d252-4b35-a9d2-400e2e2cddf7   none      none          off        
-    oxp_736d4cab-c262-485e-89c2-07e6543f0855/crypt/zone                                                              a34f8204-9f17-4c8f-997b-e122c284ac9f   none      none          off        
-    oxp_8ae56ca0-709d-4b8f-9869-51b62b542eef/crypt/zone                                                              61bf628d-a78d-40a7-bad2-84e97e41b810   none      none          off        
-    oxp_8e0bcc4f-0799-450c-a0ad-80c1637f59e3/crypt/zone                                                              3f63ada8-d1f4-440d-8713-da45b0684520   none      none          off        
-    oxp_8eeebb8e-6db6-43e8-a429-d26dde99882c/crypt/zone                                                              a3284e6f-ee42-4fdb-8150-634f7f40c073   none      none          off        
-    oxp_a3e8de5b-c47a-49c0-b698-4d6955e1327f/crypt/zone                                                              8b7928fb-e5a0-49b0-81d0-89f627020c92   none      none          off        
-    oxp_b32fa3da-4dec-4237-9776-e1a57ba15a21/crypt/zone                                                              0e976e79-fe8c-4189-8a8c-279f42e0290f   none      none          off        
-    oxp_e9c238f6-87a3-4087-8ba4-aa594a82d012/crypt/zone                                                              f963f2a7-e9d1-4b80-b01a-ff4cecddf867   none      none          off        
-    oxp_fbf997ef-52d3-438a-b036-b9117322e569/crypt/zone                                                              a15e4260-d48c-4415-9315-c0f29234f359   none      none          off        
-    oxp_60e6b021-79d6-4a6b-917c-6637e0769558/crypt/zone/oxz_clickhouse_df79db1e-54ca-4048-b22a-da120ae4c8c4          b6cb0fe9-0b7a-4793-b6cd-1ee71fee464c   none      none          off        
-    oxp_60e6b021-79d6-4a6b-917c-6637e0769558/crypt/zone/oxz_clickhouse_keeper_39fd3357-4de8-433e-9c07-1ec65de7ca59   095cf066-5a68-40b4-afc6-baf5bcbadd05   none      none          off        
-    oxp_8e0bcc4f-0799-450c-a0ad-80c1637f59e3/crypt/zone/oxz_crucible_08330c18-54e9-445b-81f3-8f1d6ad15cdd            ab255226-2c8c-4222-82c6-702af839a2d2   none      none          off        
-    oxp_fbf997ef-52d3-438a-b036-b9117322e569/crypt/zone/oxz_crucible_0ba018f0-4ff7-4bcc-a0c7-42cfec6bc9da            ba1a3aae-15ab-4364-8250-54a766331ef8   none      none          off        
-    oxp_60e6b021-79d6-4a6b-917c-6637e0769558/crypt/zone/oxz_crucible_1e485cda-b36e-4647-9125-c273fc7a9850            65c2e3cd-3d8e-43c6-9e2c-cb884511ec49   none      none          off        
-    oxp_a3e8de5b-c47a-49c0-b698-4d6955e1327f/crypt/zone/oxz_crucible_4d84fdb4-76fd-47a9-b033-7e1711d9125f            8dc07059-e8cd-4f89-abc7-0c5289b8ff0a   none      none          off        
-    oxp_e9c238f6-87a3-4087-8ba4-aa594a82d012/crypt/zone/oxz_crucible_577b0a64-6fa9-4302-bfaa-853b6e9e71ac            851cd90d-97f5-49b6-ad41-2e1c1faa3cc9   none      none          off        
-    oxp_8eeebb8e-6db6-43e8-a429-d26dde99882c/crypt/zone/oxz_crucible_5d296df4-4f2f-4896-8caa-42df00799bcb            25c5034b-83b2-4a90-a08a-7573ffb38119   none      none          off        
-    oxp_736d4cab-c262-485e-89c2-07e6543f0855/crypt/zone/oxz_crucible_65d597c5-86b9-43f6-84cd-67bb108df9f0            6de460bc-890d-4e7a-920f-607862440cfd   none      none          off        
-    oxp_b32fa3da-4dec-4237-9776-e1a57ba15a21/crypt/zone/oxz_crucible_a9f1d41e-c445-4783-af13-0095b2836f0f            b5d6cec1-c83f-4c41-9e79-8b9bf917f483   none      none          off        
-    oxp_71a07ac0-d24e-446c-a202-1998e7f6ac8c/crypt/zone/oxz_crucible_e9ab813f-0fff-4b41-a101-790f6d94b40a            7c459b4e-396b-497f-8094-f342939d1f9f   none      none          off        
-    oxp_8ae56ca0-709d-4b8f-9869-51b62b542eef/crypt/zone/oxz_crucible_f00c7a67-51a6-4d09-be39-f20b0e6da1c6            6ff911b9-a4a5-4986-ba04-c6b3f234d3b4   none      none          off        
-    oxp_60e6b021-79d6-4a6b-917c-6637e0769558/crypt/zone/oxz_crucible_pantry_840a4f34-0e53-469c-8c79-12b75bb42edc     7de8087e-602a-4a81-98ff-d766213d0f94   none      none          off        
-    oxp_60e6b021-79d6-4a6b-917c-6637e0769558/crypt/zone/oxz_internal_dns_c89ac05f-d9b2-47f4-9d48-2f38130e4ad9        dd1cdc17-808e-4e6d-99ed-84b2d0e220f1   none      none          off        
-    oxp_60e6b021-79d6-4a6b-917c-6637e0769558/crypt/zone/oxz_nexus_a6032c9e-a365-45d7-ad9f-07ac0fa7079a               198ff957-cce0-40cf-9048-f65cf9a6c671   none      none          off        
-    oxp_60e6b021-79d6-4a6b-917c-6637e0769558/crypt/zone/oxz_ntp_66695827-17c4-4885-b6c0-2cb6b6d3ad1c                 ccfb112d-c72e-4482-9bb0-f9cbbb034f7d   none      none          off        
-    oxp_60e6b021-79d6-4a6b-917c-6637e0769558/crypt/debug                                                             10610f76-51e8-4be4-a4ad-9af953f6bf4a   100 GiB   none          gzip-9     
-    oxp_71a07ac0-d24e-446c-a202-1998e7f6ac8c/crypt/debug                                                             e0bcc415-f8f9-401f-a507-cee5587756b1   100 GiB   none          gzip-9     
-    oxp_736d4cab-c262-485e-89c2-07e6543f0855/crypt/debug                                                             8bbc5419-7125-4cb1-b990-436af4bb8eb4   100 GiB   none          gzip-9     
-    oxp_8ae56ca0-709d-4b8f-9869-51b62b542eef/crypt/debug                                                             280dd773-35e2-4dda-ae2a-65c88f1b2a01   100 GiB   none          gzip-9     
-    oxp_8e0bcc4f-0799-450c-a0ad-80c1637f59e3/crypt/debug                                                             fecbd83d-7440-4900-b22b-6206e55b2920   100 GiB   none          gzip-9     
-    oxp_8eeebb8e-6db6-43e8-a429-d26dde99882c/crypt/debug                                                             e120c8f8-049f-40f0-8d70-4cfe409ef34d   100 GiB   none          gzip-9     
-    oxp_a3e8de5b-c47a-49c0-b698-4d6955e1327f/crypt/debug                                                             37eb0429-d620-40fb-a57a-62486d001738   100 GiB   none          gzip-9     
-    oxp_b32fa3da-4dec-4237-9776-e1a57ba15a21/crypt/debug                                                             d0f12057-da73-4c1d-bdec-32a0e7ab7107   100 GiB   none          gzip-9     
-    oxp_e9c238f6-87a3-4087-8ba4-aa594a82d012/crypt/debug                                                             2288ff91-8e52-4817-825f-2f8b8eb1681d   100 GiB   none          gzip-9     
-    oxp_fbf997ef-52d3-438a-b036-b9117322e569/crypt/debug                                                             17ffe1be-b38b-4f39-90af-57af25dbfe30   100 GiB   none          gzip-9     
+    oxp_60e6b021-79d6-4a6b-917c-6637e0769558/crucible                                                                723e4ec2-5f4a-48a9-a6a1-cb523dc47d3d   none      none          off        
+    oxp_71a07ac0-d24e-446c-a202-1998e7f6ac8c/crucible                                                                b2796e6b-ad7d-41a5-82a6-947b96e42d47   none      none          off        
+    oxp_736d4cab-c262-485e-89c2-07e6543f0855/crucible                                                                c993b4da-bea9-4010-a8d6-17d733698f07   none      none          off        
+    oxp_8ae56ca0-709d-4b8f-9869-51b62b542eef/crucible                                                                4f497ece-88c1-4557-a8b4-0e990f9941a9   none      none          off        
+    oxp_8e0bcc4f-0799-450c-a0ad-80c1637f59e3/crucible                                                                43a16c22-e79a-4bea-bcf6-682099a728dd   none      none          off        
+    oxp_8eeebb8e-6db6-43e8-a429-d26dde99882c/crucible                                                                b6bbb45b-68fc-4fa5-86cc-b59b0f797fb2   none      none          off        
+    oxp_a3e8de5b-c47a-49c0-b698-4d6955e1327f/crucible                                                                e4838ed0-304f-475e-a282-9f644f2ba3e5   none      none          off        
+    oxp_b32fa3da-4dec-4237-9776-e1a57ba15a21/crucible                                                                046f2730-768d-4bcc-8ebf-4b5f5597151c   none      none          off        
+    oxp_e9c238f6-87a3-4087-8ba4-aa594a82d012/crucible                                                                0830fc6d-ed82-41de-9389-0bd3fd4677ea   none      none          off        
+    oxp_fbf997ef-52d3-438a-b036-b9117322e569/crucible                                                                d9662141-585e-4e18-a461-9627097f02a2   none      none          off        
+    oxp_60e6b021-79d6-4a6b-917c-6637e0769558/crypt/clickhouse                                                        a4f84c49-4303-411f-bb1b-08877d828946   none      none          off        
+    oxp_60e6b021-79d6-4a6b-917c-6637e0769558/crypt/clickhouse_keeper                                                 04ee4b4b-fcbe-4224-86fd-30144a4f2592   none      none          off        
+    oxp_60e6b021-79d6-4a6b-917c-6637e0769558/crypt/internal_dns                                                      2edca3dc-a0e5-4d34-b8a2-065be4cca767   none      none          off        
+    oxp_60e6b021-79d6-4a6b-917c-6637e0769558/crypt/zone                                                              87cd9f37-3de3-457c-9412-d0dc5678eda8   none      none          off        
+    oxp_71a07ac0-d24e-446c-a202-1998e7f6ac8c/crypt/zone                                                              3a164f36-1f53-45b3-b190-ad8a2817bc69   none      none          off        
+    oxp_736d4cab-c262-485e-89c2-07e6543f0855/crypt/zone                                                              407556ed-09ab-430e-bc8f-8291b8f8c8fe   none      none          off        
+    oxp_8ae56ca0-709d-4b8f-9869-51b62b542eef/crypt/zone                                                              99d57d61-f12a-4b56-8114-86ba92d07649   none      none          off        
+    oxp_8e0bcc4f-0799-450c-a0ad-80c1637f59e3/crypt/zone                                                              da1eb596-8764-4268-a60b-f4705b4f615b   none      none          off        
+    oxp_8eeebb8e-6db6-43e8-a429-d26dde99882c/crypt/zone                                                              d555bf19-887c-48d2-8144-47c2eac9a9e8   none      none          off        
+    oxp_a3e8de5b-c47a-49c0-b698-4d6955e1327f/crypt/zone                                                              9785e77a-9422-4b46-a4ae-8b9a155eb121   none      none          off        
+    oxp_b32fa3da-4dec-4237-9776-e1a57ba15a21/crypt/zone                                                              1192a37c-a871-4c48-905d-03c3d6035bdc   none      none          off        
+    oxp_e9c238f6-87a3-4087-8ba4-aa594a82d012/crypt/zone                                                              7bf1c7ec-5465-4bfd-b1d9-939f05336012   none      none          off        
+    oxp_fbf997ef-52d3-438a-b036-b9117322e569/crypt/zone                                                              be526b44-2c78-49ec-8ab4-73e161e27f22   none      none          off        
+    oxp_60e6b021-79d6-4a6b-917c-6637e0769558/crypt/zone/oxz_clickhouse_35e8d4b6-ea92-45cf-923c-3f566a0b1fe5          cd7e5c3a-2328-4568-b8f8-cf349f0cdd12   none      none          off        
+    oxp_60e6b021-79d6-4a6b-917c-6637e0769558/crypt/zone/oxz_clickhouse_keeper_dd5ab8b1-e6e7-40e0-9ea6-b6a16f485b52   a51fb98f-3fff-4c0a-82f0-7a4aad82096b   none      none          off        
+    oxp_e9c238f6-87a3-4087-8ba4-aa594a82d012/crypt/zone/oxz_crucible_044d074d-7905-4024-82ff-68d76221db68            98fd0f42-7337-4ce7-814e-f988304b8873   none      none          off        
+    oxp_71a07ac0-d24e-446c-a202-1998e7f6ac8c/crypt/zone/oxz_crucible_28826473-ac0b-41ea-8c54-72b782db1bcb            bbda84d8-c4ca-4f52-a766-681872fa06f0   none      none          off        
+    oxp_fbf997ef-52d3-438a-b036-b9117322e569/crypt/zone/oxz_crucible_2d3ff798-dda9-4ccf-8f91-070a20f06d55            e9c77dbd-c56a-404c-8ff9-6504b3f92556   none      none          off        
+    oxp_8eeebb8e-6db6-43e8-a429-d26dde99882c/crypt/zone/oxz_crucible_7538d29b-69f2-43e8-8509-505b25cb1c84            19110f8a-6267-41ed-ac7d-539cd0fe3511   none      none          off        
+    oxp_8ae56ca0-709d-4b8f-9869-51b62b542eef/crypt/zone/oxz_crucible_8234bbd2-4b31-4f6b-8dcc-4744b1d14e64            0fe4f647-ffd2-4845-805a-c069096560ee   none      none          off        
+    oxp_8e0bcc4f-0799-450c-a0ad-80c1637f59e3/crypt/zone/oxz_crucible_85358363-cee8-4bc3-af66-4d89e5cd714f            a1daa561-2448-4afb-8233-ec149d2bd7f4   none      none          off        
+    oxp_736d4cab-c262-485e-89c2-07e6543f0855/crypt/zone/oxz_crucible_9b58d04f-85bf-4f5e-8c6a-5d855062d5c4            69812f66-4b59-4590-9e1f-bce3e93b3b08   none      none          off        
+    oxp_60e6b021-79d6-4a6b-917c-6637e0769558/crypt/zone/oxz_crucible_e7da0aec-c6b6-4a56-9525-35385b9c62a2            36e58025-88e2-4eb9-8af0-ed9a98dda1b9   none      none          off        
+    oxp_a3e8de5b-c47a-49c0-b698-4d6955e1327f/crypt/zone/oxz_crucible_f3f977cc-7eca-4491-9b07-82b6284eb169            482fad9a-d83f-4025-8f0b-d3adea6ae2cf   none      none          off        
+    oxp_b32fa3da-4dec-4237-9776-e1a57ba15a21/crypt/zone/oxz_crucible_fef381d2-8368-4a2d-96a1-c956ed011f7b            b1937368-4019-40c4-af02-9811dc7eb143   none      none          off        
+    oxp_60e6b021-79d6-4a6b-917c-6637e0769558/crypt/zone/oxz_crucible_pantry_fe63bfd3-3128-4675-8118-cf6968293471     e3b31ef3-6b54-4901-aec4-0c672de62c7f   none      none          off        
+    oxp_60e6b021-79d6-4a6b-917c-6637e0769558/crypt/zone/oxz_internal_dns_b6b0689e-ef48-484d-b3c7-3c596edad20c        501e0672-2897-4992-8911-600e0283f04c   none      none          off        
+    oxp_60e6b021-79d6-4a6b-917c-6637e0769558/crypt/zone/oxz_nexus_46ecde76-fef7-4394-93dd-d22b003148e9               53655959-866b-4fee-bcf9-1e35504ad625   none      none          off        
+    oxp_60e6b021-79d6-4a6b-917c-6637e0769558/crypt/zone/oxz_ntp_4d009155-44fb-45b9-afed-f89cb57ce8da                 0590facf-202a-463b-81be-b6e88c47da76   none      none          off        
+    oxp_60e6b021-79d6-4a6b-917c-6637e0769558/crypt/debug                                                             8f7f16c1-d9fb-4405-9dcf-68bfbaa7bf8c   100 GiB   none          gzip-9     
+    oxp_71a07ac0-d24e-446c-a202-1998e7f6ac8c/crypt/debug                                                             6482f332-801a-473f-a77d-e07d30e2a5b7   100 GiB   none          gzip-9     
+    oxp_736d4cab-c262-485e-89c2-07e6543f0855/crypt/debug                                                             0bb0541f-2c64-487b-a8af-162454207504   100 GiB   none          gzip-9     
+    oxp_8ae56ca0-709d-4b8f-9869-51b62b542eef/crypt/debug                                                             902a6889-244f-4b67-baa4-b245f3d622c8   100 GiB   none          gzip-9     
+    oxp_8e0bcc4f-0799-450c-a0ad-80c1637f59e3/crypt/debug                                                             667ffd3c-6735-4b50-bc3b-cfa32fcc811e   100 GiB   none          gzip-9     
+    oxp_8eeebb8e-6db6-43e8-a429-d26dde99882c/crypt/debug                                                             cf48ba87-a4bb-435f-999b-bca46cfd6a89   100 GiB   none          gzip-9     
+    oxp_a3e8de5b-c47a-49c0-b698-4d6955e1327f/crypt/debug                                                             7d64cab3-7311-4519-ae4a-1af6b320fa9b   100 GiB   none          gzip-9     
+    oxp_b32fa3da-4dec-4237-9776-e1a57ba15a21/crypt/debug                                                             d3e957fd-5f26-498a-8fa3-deaea4dc5820   100 GiB   none          gzip-9     
+    oxp_e9c238f6-87a3-4087-8ba4-aa594a82d012/crypt/debug                                                             4da77f4a-5e41-4604-af30-8cf568c38428   100 GiB   none          gzip-9     
+    oxp_fbf997ef-52d3-438a-b036-b9117322e569/crypt/debug                                                             03935cb1-ce06-4594-b2fe-23e127d1cd9d   100 GiB   none          gzip-9     
 
 
     omicron zones at generation 3:
     -----------------------------------------------------------------------------------------------
     zone type           zone id                                disposition   underlay IP           
     -----------------------------------------------------------------------------------------------
-    clickhouse          df79db1e-54ca-4048-b22a-da120ae4c8c4   in service    fd00:1122:3344:101::23
-    clickhouse_keeper   39fd3357-4de8-433e-9c07-1ec65de7ca59   in service    fd00:1122:3344:101::2f
-    crucible            08330c18-54e9-445b-81f3-8f1d6ad15cdd   in service    fd00:1122:3344:101::29
-    crucible            0ba018f0-4ff7-4bcc-a0c7-42cfec6bc9da   in service    fd00:1122:3344:101::2e
-    crucible            1e485cda-b36e-4647-9125-c273fc7a9850   in service    fd00:1122:3344:101::25
-    crucible            4d84fdb4-76fd-47a9-b033-7e1711d9125f   in service    fd00:1122:3344:101::2b
-    crucible            577b0a64-6fa9-4302-bfaa-853b6e9e71ac   in service    fd00:1122:3344:101::2d
-    crucible            5d296df4-4f2f-4896-8caa-42df00799bcb   in service    fd00:1122:3344:101::2a
-    crucible            65d597c5-86b9-43f6-84cd-67bb108df9f0   in service    fd00:1122:3344:101::27
-    crucible            a9f1d41e-c445-4783-af13-0095b2836f0f   in service    fd00:1122:3344:101::2c
-    crucible            e9ab813f-0fff-4b41-a101-790f6d94b40a   in service    fd00:1122:3344:101::26
-    crucible            f00c7a67-51a6-4d09-be39-f20b0e6da1c6   in service    fd00:1122:3344:101::28
-    crucible_pantry     840a4f34-0e53-469c-8c79-12b75bb42edc   in service    fd00:1122:3344:101::24
-    internal_dns        c89ac05f-d9b2-47f4-9d48-2f38130e4ad9   in service    fd00:1122:3344:1::1   
-    internal_ntp        66695827-17c4-4885-b6c0-2cb6b6d3ad1c   in service    fd00:1122:3344:101::21
-    nexus               a6032c9e-a365-45d7-ad9f-07ac0fa7079a   in service    fd00:1122:3344:101::22
+    clickhouse          35e8d4b6-ea92-45cf-923c-3f566a0b1fe5   in service    fd00:1122:3344:101::23
+    clickhouse_keeper   dd5ab8b1-e6e7-40e0-9ea6-b6a16f485b52   in service    fd00:1122:3344:101::2f
+    crucible            044d074d-7905-4024-82ff-68d76221db68   in service    fd00:1122:3344:101::2d
+    crucible            28826473-ac0b-41ea-8c54-72b782db1bcb   in service    fd00:1122:3344:101::26
+    crucible            2d3ff798-dda9-4ccf-8f91-070a20f06d55   in service    fd00:1122:3344:101::2e
+    crucible            7538d29b-69f2-43e8-8509-505b25cb1c84   in service    fd00:1122:3344:101::2a
+    crucible            8234bbd2-4b31-4f6b-8dcc-4744b1d14e64   in service    fd00:1122:3344:101::28
+    crucible            85358363-cee8-4bc3-af66-4d89e5cd714f   in service    fd00:1122:3344:101::29
+    crucible            9b58d04f-85bf-4f5e-8c6a-5d855062d5c4   in service    fd00:1122:3344:101::27
+    crucible            e7da0aec-c6b6-4a56-9525-35385b9c62a2   in service    fd00:1122:3344:101::25
+    crucible            f3f977cc-7eca-4491-9b07-82b6284eb169   in service    fd00:1122:3344:101::2b
+    crucible            fef381d2-8368-4a2d-96a1-c956ed011f7b   in service    fd00:1122:3344:101::2c
+    crucible_pantry     fe63bfd3-3128-4675-8118-cf6968293471   in service    fd00:1122:3344:101::24
+    internal_dns        b6b0689e-ef48-484d-b3c7-3c596edad20c   in service    fd00:1122:3344:1::1   
+    internal_ntp        4d009155-44fb-45b9-afed-f89cb57ce8da   in service    fd00:1122:3344:101::21
+    nexus               46ecde76-fef7-4394-93dd-d22b003148e9   in service    fd00:1122:3344:101::22
 
 
   sled 6a4c45f6-e02f-490c-bbfa-b32fb89e8e86 (active):
@@ -120,77 +120,77 @@ to:   blueprint 92fa943c-7dd4-48c3-9447-c9d0665744b6
     -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
     dataset name                                                                                                     dataset uuid                           quota     reservation   compression
     -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
-    oxp_0bf9d028-2b4a-4bff-82a1-6eb5fcefd985/crucible                                                                f3b1d2f6-3cbc-4420-bc91-5eaaf00f85d0   none      none          off        
-    oxp_19293a1d-fddc-40a7-88a4-ccafdb6f66d3/crucible                                                                276f044e-dd34-4c1e-beef-174da4fcf53d   none      none          off        
-    oxp_44484c44-477a-4676-8266-b98a00e80d79/crucible                                                                e06b1670-5f34-42dc-a410-3129d69907ec   none      none          off        
-    oxp_79787cd4-92da-4de5-bfd8-30a635521e10/crucible                                                                9d32dd45-e3ee-47b9-ba69-0dc711bbf632   none      none          off        
-    oxp_9ae94c94-baae-477e-912a-60f0c4f3bd13/crucible                                                                7e72090d-7f79-4ecc-92cc-5eb7d9dee022   none      none          off        
-    oxp_af85eec8-36b3-4b88-966d-a717b9b58fe5/crucible                                                                43606b8e-384f-4412-a273-d4dde8f2e76d   none      none          off        
-    oxp_ddfaaba3-dafe-4103-b868-e9843d29d346/crucible                                                                2d7145e9-0029-4ae0-bb12-ee65a1738005   none      none          off        
-    oxp_ec458c3e-91ca-40f1-a2a3-3f4292c1f279/crucible                                                                dfadcc38-505a-4e9b-8674-27f8a2af13a2   none      none          off        
-    oxp_f2fc7c4c-7966-449d-8ec3-5a70f460501d/crucible                                                                72e2a1d6-09dd-43ba-9b8b-befa101f53ef   none      none          off        
-    oxp_f635c28a-e5ca-4d22-ac94-d8f278a6ea0e/crucible                                                                c7dfbe25-5b52-4ee5-8556-719e99bb5e4d   none      none          off        
-    oxp_0bf9d028-2b4a-4bff-82a1-6eb5fcefd985/crypt/clickhouse_keeper                                                 a3eed313-d886-4c1d-8023-8d2ec9e97ddd   none      none          off        
-    oxp_0bf9d028-2b4a-4bff-82a1-6eb5fcefd985/crypt/clickhouse_server                                                 3d339942-c2d0-4615-a099-433a8b5a1543   none      none          off        
-    oxp_0bf9d028-2b4a-4bff-82a1-6eb5fcefd985/crypt/internal_dns                                                      b8af3673-c60a-45fb-adc1-c36d0d325417   none      none          off        
-    oxp_0bf9d028-2b4a-4bff-82a1-6eb5fcefd985/crypt/zone                                                              1ab5529e-c3db-41e1-a561-9c767f980ad4   none      none          off        
-    oxp_19293a1d-fddc-40a7-88a4-ccafdb6f66d3/crypt/zone                                                              68490e52-279a-4609-ba0b-11d03f904c88   none      none          off        
-    oxp_44484c44-477a-4676-8266-b98a00e80d79/crypt/zone                                                              2a5e3a10-6ab5-4988-be84-46b527dc2d23   none      none          off        
-    oxp_79787cd4-92da-4de5-bfd8-30a635521e10/crypt/zone                                                              fd0f9778-c31a-40f4-9ce9-f5154535e75b   none      none          off        
-    oxp_9ae94c94-baae-477e-912a-60f0c4f3bd13/crypt/zone                                                              e4220797-15df-42c4-9df7-ad927711d565   none      none          off        
-    oxp_af85eec8-36b3-4b88-966d-a717b9b58fe5/crypt/zone                                                              39714005-313e-42be-90eb-000a0560669f   none      none          off        
-    oxp_ddfaaba3-dafe-4103-b868-e9843d29d346/crypt/zone                                                              a647238a-1689-46c9-b680-dfe1b7b68684   none      none          off        
-    oxp_ec458c3e-91ca-40f1-a2a3-3f4292c1f279/crypt/zone                                                              29038bb0-9af1-4b03-9c10-b8a6444a0bc2   none      none          off        
-    oxp_f2fc7c4c-7966-449d-8ec3-5a70f460501d/crypt/zone                                                              e49915c6-59ed-4bbe-abf9-375b9502772a   none      none          off        
-    oxp_f635c28a-e5ca-4d22-ac94-d8f278a6ea0e/crypt/zone                                                              fc9765c5-0a89-4050-ba3e-e0625dbefb5f   none      none          off        
-    oxp_0bf9d028-2b4a-4bff-82a1-6eb5fcefd985/crypt/zone/oxz_clickhouse_keeper_b36c16d5-de6e-411a-a32a-d35a26f2e151   48720037-5b8e-4478-9bb5-c86ee8a6e250   none      none          off        
-    oxp_0bf9d028-2b4a-4bff-82a1-6eb5fcefd985/crypt/zone/oxz_clickhouse_server_71be6bff-666a-4f2b-a7dc-d80a88a71af5   a9e2160a-688f-4bbd-9a77-b2e695df86f4   none      none          off        
-    oxp_ddfaaba3-dafe-4103-b868-e9843d29d346/crypt/zone/oxz_crucible_1a92bb17-6477-46fc-9784-1d2a418d6e14            257c57cd-8f2c-440d-9fa0-e92a312295ec   none      none          off        
-    oxp_af85eec8-36b3-4b88-966d-a717b9b58fe5/crypt/zone/oxz_crucible_26115267-8333-4711-924e-d05acf601827            3a39d5e8-ea73-4cf3-b9de-48045475151c   none      none          off        
-    oxp_9ae94c94-baae-477e-912a-60f0c4f3bd13/crypt/zone/oxz_crucible_41af4ef6-d21b-4271-bfcb-524f4146784a            1522207b-ea98-47cc-810c-44808796d743   none      none          off        
-    oxp_44484c44-477a-4676-8266-b98a00e80d79/crypt/zone/oxz_crucible_487bde8c-a692-416c-be70-efef7f169fce            008ba9b6-8d41-4f7a-8ff3-ec31a0c96cf9   none      none          off        
-    oxp_f2fc7c4c-7966-449d-8ec3-5a70f460501d/crypt/zone/oxz_crucible_704a17e0-bc9d-43b9-a91e-b1ca37a23d0d            5739948f-d984-48a5-a27a-0223a0af2035   none      none          off        
-    oxp_f635c28a-e5ca-4d22-ac94-d8f278a6ea0e/crypt/zone/oxz_crucible_93535f54-4919-4c4d-9a07-f7ab6245c01f            109f44de-d1ed-4ce3-9670-76aceb206ee4   none      none          off        
-    oxp_ec458c3e-91ca-40f1-a2a3-3f4292c1f279/crypt/zone/oxz_crucible_9b9d58bd-44e6-4b70-80a4-e6a9262893ff            0a5bade3-3f2f-4385-b064-554b56f8bf8c   none      none          off        
-    oxp_0bf9d028-2b4a-4bff-82a1-6eb5fcefd985/crypt/zone/oxz_crucible_aa74c1b2-b4c1-4f36-8f01-9459ef23786b            e1db255d-4793-46bd-a1f3-f207be6b2839   none      none          off        
-    oxp_79787cd4-92da-4de5-bfd8-30a635521e10/crypt/zone/oxz_crucible_b6956e34-3c21-44d1-9ee2-cb7ee2e77c4e            2d2f2665-d556-4e65-9c53-d7fe573848a2   none      none          off        
-    oxp_19293a1d-fddc-40a7-88a4-ccafdb6f66d3/crypt/zone/oxz_crucible_eb58427d-599b-45dc-b316-8e4db7eec65e            26722393-82bf-442d-9725-030801a4d64c   none      none          off        
-    oxp_0bf9d028-2b4a-4bff-82a1-6eb5fcefd985/crypt/zone/oxz_crucible_pantry_97a785b8-d909-4fd4-92c1-9ba14bae603b     7b248682-95a2-4411-98b3-79fe6cb1a857   none      none          off        
-    oxp_0bf9d028-2b4a-4bff-82a1-6eb5fcefd985/crypt/zone/oxz_internal_dns_c259e8b9-1086-453a-8636-050639edeffb        30161ca3-c2d8-474b-906e-bd38fc912f84   none      none          off        
-    oxp_0bf9d028-2b4a-4bff-82a1-6eb5fcefd985/crypt/zone/oxz_nexus_c3c7b0bd-dce3-467b-919d-668cc6b06711               05b6bbbe-4c07-493e-8b92-4c8d4aeb1d66   none      none          off        
-    oxp_0bf9d028-2b4a-4bff-82a1-6eb5fcefd985/crypt/zone/oxz_ntp_bba31b23-d112-4cde-bd4a-635812c28c0e                 fadbc503-b72d-4862-a1fd-628c7ff599d1   none      none          off        
-    oxp_0bf9d028-2b4a-4bff-82a1-6eb5fcefd985/crypt/debug                                                             fb722d83-ddc2-4880-95a4-1ab12f4b95be   100 GiB   none          gzip-9     
-    oxp_19293a1d-fddc-40a7-88a4-ccafdb6f66d3/crypt/debug                                                             891a1ff4-66b1-4dc9-871c-be4a757bbd0f   100 GiB   none          gzip-9     
-    oxp_44484c44-477a-4676-8266-b98a00e80d79/crypt/debug                                                             3e3e18ad-d527-4b2e-b758-1eefdcfca44b   100 GiB   none          gzip-9     
-    oxp_79787cd4-92da-4de5-bfd8-30a635521e10/crypt/debug                                                             bd4efdbe-7128-4423-aacf-6cf35e5a914d   100 GiB   none          gzip-9     
-    oxp_9ae94c94-baae-477e-912a-60f0c4f3bd13/crypt/debug                                                             708d4e8b-3acf-44cf-87a2-275bb8fa0d96   100 GiB   none          gzip-9     
-    oxp_af85eec8-36b3-4b88-966d-a717b9b58fe5/crypt/debug                                                             98d65e73-01df-4525-a45d-acb2fc8d4a74   100 GiB   none          gzip-9     
-    oxp_ddfaaba3-dafe-4103-b868-e9843d29d346/crypt/debug                                                             8005f7c0-bab3-4b0a-9568-a5861c0a09bb   100 GiB   none          gzip-9     
-    oxp_ec458c3e-91ca-40f1-a2a3-3f4292c1f279/crypt/debug                                                             dae242d1-9535-4b08-b249-f030dde2c2fd   100 GiB   none          gzip-9     
-    oxp_f2fc7c4c-7966-449d-8ec3-5a70f460501d/crypt/debug                                                             6cea3508-8341-4093-abbb-c57d83cd87b4   100 GiB   none          gzip-9     
-    oxp_f635c28a-e5ca-4d22-ac94-d8f278a6ea0e/crypt/debug                                                             765b4728-8d6e-4fac-9a1b-ae2258d5c52b   100 GiB   none          gzip-9     
+    oxp_0bf9d028-2b4a-4bff-82a1-6eb5fcefd985/crucible                                                                f18270c8-a39b-4579-be20-d2d1b80bba42   none      none          off        
+    oxp_19293a1d-fddc-40a7-88a4-ccafdb6f66d3/crucible                                                                06c2af14-055c-4041-aa26-9155f9f42661   none      none          off        
+    oxp_44484c44-477a-4676-8266-b98a00e80d79/crucible                                                                9deffea6-d340-4432-be3c-fad135dc29a5   none      none          off        
+    oxp_79787cd4-92da-4de5-bfd8-30a635521e10/crucible                                                                47ca08b9-b962-43e2-99d7-c2e0556c0f52   none      none          off        
+    oxp_9ae94c94-baae-477e-912a-60f0c4f3bd13/crucible                                                                b2e54e29-6915-4b6d-bc76-6f72e5c7c55a   none      none          off        
+    oxp_af85eec8-36b3-4b88-966d-a717b9b58fe5/crucible                                                                cb992d4e-7a69-4bcd-96c8-fe6e40989e24   none      none          off        
+    oxp_ddfaaba3-dafe-4103-b868-e9843d29d346/crucible                                                                68338fc3-2d8b-4419-b33d-4cce6fe9380d   none      none          off        
+    oxp_ec458c3e-91ca-40f1-a2a3-3f4292c1f279/crucible                                                                5294b99c-3eac-40e1-a35b-1f1cf2f0d6bf   none      none          off        
+    oxp_f2fc7c4c-7966-449d-8ec3-5a70f460501d/crucible                                                                31718dcf-ebd5-432c-a9e5-40abcb40931c   none      none          off        
+    oxp_f635c28a-e5ca-4d22-ac94-d8f278a6ea0e/crucible                                                                ff7ff4a9-21c4-499e-9ceb-8a00a4bb21bc   none      none          off        
+    oxp_0bf9d028-2b4a-4bff-82a1-6eb5fcefd985/crypt/clickhouse_keeper                                                 473adeb2-a57a-4240-82e9-88f2bebc1245   none      none          off        
+    oxp_0bf9d028-2b4a-4bff-82a1-6eb5fcefd985/crypt/clickhouse_server                                                 4363b5f8-9a67-49af-b49d-585e532fa7bc   none      none          off        
+    oxp_0bf9d028-2b4a-4bff-82a1-6eb5fcefd985/crypt/internal_dns                                                      56a1af5d-de86-46c5-9504-2d1ee70587c5   none      none          off        
+    oxp_0bf9d028-2b4a-4bff-82a1-6eb5fcefd985/crypt/zone                                                              003c1d4e-15bb-4fca-aa71-a7dff507b124   none      none          off        
+    oxp_19293a1d-fddc-40a7-88a4-ccafdb6f66d3/crypt/zone                                                              bf35a148-62f0-4f88-8f60-0a13747daba2   none      none          off        
+    oxp_44484c44-477a-4676-8266-b98a00e80d79/crypt/zone                                                              9b1bf42e-6f06-44cc-af5b-bff65d929322   none      none          off        
+    oxp_79787cd4-92da-4de5-bfd8-30a635521e10/crypt/zone                                                              2c9d6bce-0293-4364-b8c9-4bdea345490e   none      none          off        
+    oxp_9ae94c94-baae-477e-912a-60f0c4f3bd13/crypt/zone                                                              11726c79-6590-4831-8480-cf50e6322c8a   none      none          off        
+    oxp_af85eec8-36b3-4b88-966d-a717b9b58fe5/crypt/zone                                                              b463f0c2-3ae4-45f7-a38c-110731fcc5cb   none      none          off        
+    oxp_ddfaaba3-dafe-4103-b868-e9843d29d346/crypt/zone                                                              626abe12-321d-439b-ad8f-f8dfb2022f25   none      none          off        
+    oxp_ec458c3e-91ca-40f1-a2a3-3f4292c1f279/crypt/zone                                                              4200e2a7-0fd6-4631-9d60-21fd821193fe   none      none          off        
+    oxp_f2fc7c4c-7966-449d-8ec3-5a70f460501d/crypt/zone                                                              85f34c02-a35d-404e-8cde-bedf3e193b1c   none      none          off        
+    oxp_f635c28a-e5ca-4d22-ac94-d8f278a6ea0e/crypt/zone                                                              dd19c2c5-0bc9-48de-a116-b92503569092   none      none          off        
+    oxp_0bf9d028-2b4a-4bff-82a1-6eb5fcefd985/crypt/zone/oxz_clickhouse_keeper_31a66e47-6252-4f38-aa92-f48637da152c   49f52cc5-74df-4cfa-b7f0-07c7e810940d   none      none          off        
+    oxp_0bf9d028-2b4a-4bff-82a1-6eb5fcefd985/crypt/zone/oxz_clickhouse_server_6fedfc94-2ae6-4cc7-a968-5185207284f4   f1143eb2-0685-4708-a471-968a58f93bad   none      none          off        
+    oxp_f635c28a-e5ca-4d22-ac94-d8f278a6ea0e/crypt/zone/oxz_crucible_06b45c33-9a90-408b-8534-f94ab6df8a42            9e0a360d-c158-417f-a45f-9d29ee67cdce   none      none          off        
+    oxp_19293a1d-fddc-40a7-88a4-ccafdb6f66d3/crypt/zone/oxz_crucible_32999e20-ed5c-4c25-b4bd-41a3fbaf1445            dd7a45b8-3175-4744-8b99-ce19b22bb8ce   none      none          off        
+    oxp_9ae94c94-baae-477e-912a-60f0c4f3bd13/crypt/zone/oxz_crucible_4a037563-f969-4028-8384-164bdf308c3c            0d5b2580-7190-4bcc-9982-5012dac51f05   none      none          off        
+    oxp_44484c44-477a-4676-8266-b98a00e80d79/crypt/zone/oxz_crucible_6564394d-2c51-4252-b3b1-f5f88a72d7c3            26a1cc86-f717-4a12-b644-5acd168843aa   none      none          off        
+    oxp_0bf9d028-2b4a-4bff-82a1-6eb5fcefd985/crypt/zone/oxz_crucible_87427b40-5114-49cd-96bd-63edd61fce90            e7364079-58e3-4b36-81a7-b9e08f2a8fff   none      none          off        
+    oxp_ddfaaba3-dafe-4103-b868-e9843d29d346/crypt/zone/oxz_crucible_8acdc189-d4da-45a7-b306-23b43e86f695            6fa84a9c-0161-40c9-b596-f3b2c679ef99   none      none          off        
+    oxp_ec458c3e-91ca-40f1-a2a3-3f4292c1f279/crypt/zone/oxz_crucible_971ce633-cdc4-48cf-983e-dc272c1639eb            cb8ca8a6-6a00-4aae-8702-1493e1c3b166   none      none          off        
+    oxp_af85eec8-36b3-4b88-966d-a717b9b58fe5/crypt/zone/oxz_crucible_cfa6af7a-bf53-4fe6-bf1a-7ce3812d15c4            27323e49-f61e-4a73-bc87-f8d9f5082143   none      none          off        
+    oxp_f2fc7c4c-7966-449d-8ec3-5a70f460501d/crypt/zone/oxz_crucible_e145fb8e-df12-4df9-8049-b146ae0275be            35c46d33-4e08-4fad-90d2-3da719538ef2   none      none          off        
+    oxp_79787cd4-92da-4de5-bfd8-30a635521e10/crypt/zone/oxz_crucible_f1d08ae7-68fe-4799-8f31-f1100887c6f0            02863a62-7624-4017-9269-412910ab73f0   none      none          off        
+    oxp_0bf9d028-2b4a-4bff-82a1-6eb5fcefd985/crypt/zone/oxz_crucible_pantry_f9e18694-fdff-46a3-b40d-570d43206f48     3cb3f346-9879-4023-b919-55c4172bbf23   none      none          off        
+    oxp_0bf9d028-2b4a-4bff-82a1-6eb5fcefd985/crypt/zone/oxz_internal_dns_a00d8ae3-d1db-4aef-9174-3ff867af5e9e        c2d9b145-5e15-47be-a835-7e1f51f27679   none      none          off        
+    oxp_0bf9d028-2b4a-4bff-82a1-6eb5fcefd985/crypt/zone/oxz_nexus_8ccafc1f-97f9-4da7-bb04-d346213387ce               dcc3603b-b160-42d9-a743-11075c3b6941   none      none          off        
+    oxp_0bf9d028-2b4a-4bff-82a1-6eb5fcefd985/crypt/zone/oxz_ntp_a1797f1d-2d2a-4396-9ab5-044630b41c35                 5a70b3fe-9fad-4c17-982b-272b8595c2e8   none      none          off        
+    oxp_0bf9d028-2b4a-4bff-82a1-6eb5fcefd985/crypt/debug                                                             4e4b2f99-dc01-4793-a37a-072d942da264   100 GiB   none          gzip-9     
+    oxp_19293a1d-fddc-40a7-88a4-ccafdb6f66d3/crypt/debug                                                             8573903d-9610-4084-b0c6-ffcbb5d96c39   100 GiB   none          gzip-9     
+    oxp_44484c44-477a-4676-8266-b98a00e80d79/crypt/debug                                                             540272e1-99d2-4d2e-9d3d-032014b0e6d9   100 GiB   none          gzip-9     
+    oxp_79787cd4-92da-4de5-bfd8-30a635521e10/crypt/debug                                                             4adf2ef6-2694-4aac-aabe-688bca767092   100 GiB   none          gzip-9     
+    oxp_9ae94c94-baae-477e-912a-60f0c4f3bd13/crypt/debug                                                             7e9d012a-6d8e-475e-805e-65985a66ffcd   100 GiB   none          gzip-9     
+    oxp_af85eec8-36b3-4b88-966d-a717b9b58fe5/crypt/debug                                                             2189574d-9a73-4d25-858e-1084d57b59a8   100 GiB   none          gzip-9     
+    oxp_ddfaaba3-dafe-4103-b868-e9843d29d346/crypt/debug                                                             3cf0580b-4e1d-4ff9-bc22-4dc51ca9a53b   100 GiB   none          gzip-9     
+    oxp_ec458c3e-91ca-40f1-a2a3-3f4292c1f279/crypt/debug                                                             f499c5f8-b62f-493d-858a-8d33f7db81ff   100 GiB   none          gzip-9     
+    oxp_f2fc7c4c-7966-449d-8ec3-5a70f460501d/crypt/debug                                                             c16ff3c0-3282-46de-a620-49c6b1e3f882   100 GiB   none          gzip-9     
+    oxp_f635c28a-e5ca-4d22-ac94-d8f278a6ea0e/crypt/debug                                                             8dde6eee-f28e-4b55-8c11-525884ec81e5   100 GiB   none          gzip-9     
 
 
     omicron zones at generation 3:
     -----------------------------------------------------------------------------------------------
     zone type           zone id                                disposition   underlay IP           
     -----------------------------------------------------------------------------------------------
-    clickhouse_keeper   b36c16d5-de6e-411a-a32a-d35a26f2e151   in service    fd00:1122:3344:103::2e
-    clickhouse_server   71be6bff-666a-4f2b-a7dc-d80a88a71af5   in service    fd00:1122:3344:103::2f
-    crucible            1a92bb17-6477-46fc-9784-1d2a418d6e14   in service    fd00:1122:3344:103::2a
-    crucible            26115267-8333-4711-924e-d05acf601827   in service    fd00:1122:3344:103::29
-    crucible            41af4ef6-d21b-4271-bfcb-524f4146784a   in service    fd00:1122:3344:103::28
-    crucible            487bde8c-a692-416c-be70-efef7f169fce   in service    fd00:1122:3344:103::26
-    crucible            704a17e0-bc9d-43b9-a91e-b1ca37a23d0d   in service    fd00:1122:3344:103::2c
-    crucible            93535f54-4919-4c4d-9a07-f7ab6245c01f   in service    fd00:1122:3344:103::2d
-    crucible            9b9d58bd-44e6-4b70-80a4-e6a9262893ff   in service    fd00:1122:3344:103::2b
-    crucible            aa74c1b2-b4c1-4f36-8f01-9459ef23786b   in service    fd00:1122:3344:103::24
-    crucible            b6956e34-3c21-44d1-9ee2-cb7ee2e77c4e   in service    fd00:1122:3344:103::27
-    crucible            eb58427d-599b-45dc-b316-8e4db7eec65e   in service    fd00:1122:3344:103::25
-    crucible_pantry     97a785b8-d909-4fd4-92c1-9ba14bae603b   in service    fd00:1122:3344:103::23
-    internal_dns        c259e8b9-1086-453a-8636-050639edeffb   in service    fd00:1122:3344:2::1   
-    internal_ntp        bba31b23-d112-4cde-bd4a-635812c28c0e   in service    fd00:1122:3344:103::21
-    nexus               c3c7b0bd-dce3-467b-919d-668cc6b06711   in service    fd00:1122:3344:103::22
+    clickhouse_keeper   31a66e47-6252-4f38-aa92-f48637da152c   in service    fd00:1122:3344:103::2e
+    clickhouse_server   6fedfc94-2ae6-4cc7-a968-5185207284f4   in service    fd00:1122:3344:103::2f
+    crucible            06b45c33-9a90-408b-8534-f94ab6df8a42   in service    fd00:1122:3344:103::2d
+    crucible            32999e20-ed5c-4c25-b4bd-41a3fbaf1445   in service    fd00:1122:3344:103::25
+    crucible            4a037563-f969-4028-8384-164bdf308c3c   in service    fd00:1122:3344:103::28
+    crucible            6564394d-2c51-4252-b3b1-f5f88a72d7c3   in service    fd00:1122:3344:103::26
+    crucible            87427b40-5114-49cd-96bd-63edd61fce90   in service    fd00:1122:3344:103::24
+    crucible            8acdc189-d4da-45a7-b306-23b43e86f695   in service    fd00:1122:3344:103::2a
+    crucible            971ce633-cdc4-48cf-983e-dc272c1639eb   in service    fd00:1122:3344:103::2b
+    crucible            cfa6af7a-bf53-4fe6-bf1a-7ce3812d15c4   in service    fd00:1122:3344:103::29
+    crucible            e145fb8e-df12-4df9-8049-b146ae0275be   in service    fd00:1122:3344:103::2c
+    crucible            f1d08ae7-68fe-4799-8f31-f1100887c6f0   in service    fd00:1122:3344:103::27
+    crucible_pantry     f9e18694-fdff-46a3-b40d-570d43206f48   in service    fd00:1122:3344:103::23
+    internal_dns        a00d8ae3-d1db-4aef-9174-3ff867af5e9e   in service    fd00:1122:3344:2::1   
+    internal_ntp        a1797f1d-2d2a-4396-9ab5-044630b41c35   in service    fd00:1122:3344:103::21
+    nexus               8ccafc1f-97f9-4da7-bb04-d346213387ce   in service    fd00:1122:3344:103::22
 
 
   sled be531a62-9897-430d-acd2-ce14b4632627 (active):
@@ -215,77 +215,77 @@ to:   blueprint 92fa943c-7dd4-48c3-9447-c9d0665744b6
     -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
     dataset name                                                                                                     dataset uuid                           quota     reservation   compression
     -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
-    oxp_2a76ab1a-fb16-412d-93f9-b8cd9aa94e85/crucible                                                                431cfe4a-5756-40f4-8a9c-b70ae1227f1e   none      none          off        
-    oxp_2de2bf7e-c679-4b2b-b373-908e9d3ffbfc/crucible                                                                1123f86b-169c-40df-8ed1-95c3def65e30   none      none          off        
-    oxp_2f02a5c6-fcf5-4b5a-bc7d-7f65369918ba/crucible                                                                afa41d1a-3fc1-4723-835d-61d13db33cfe   none      none          off        
-    oxp_32041dbf-e58d-4f32-840d-923d3d3b68af/crucible                                                                da067282-0ae9-4861-8b78-b639622508af   none      none          off        
-    oxp_5f88adff-bb50-4dc1-bbfb-5a410c753ed5/crucible                                                                fcb937be-3b91-4ae7-9e25-a69808eeb07f   none      none          off        
-    oxp_74d64eb9-bf69-4782-af16-2d3a761ca171/crucible                                                                2854cb42-e5b9-4773-bd6e-6ec85d33a174   none      none          off        
-    oxp_b3c231c9-b2a5-4267-b4bf-9651881b91a5/crucible                                                                aa8f925e-6c3a-40d2-ae2d-946324a7d612   none      none          off        
-    oxp_bca80b95-8dca-4a3b-b24d-d44b6a9ff71b/crucible                                                                755ad19c-d29b-4e3c-9c13-63b56a407765   none      none          off        
-    oxp_db16345e-427a-4c8e-9032-17270f729308/crucible                                                                be3cf2f7-5388-4cd6-8119-ecf316c6052e   none      none          off        
-    oxp_e3b45593-8f0c-47b2-a381-802a7dad1f54/crucible                                                                a2391107-7408-4e0c-a694-3fd073fa09df   none      none          off        
-    oxp_2a76ab1a-fb16-412d-93f9-b8cd9aa94e85/crypt/clickhouse_keeper                                                 c16a00f5-8830-400d-89e0-9a77cce8780e   none      none          off        
-    oxp_2a76ab1a-fb16-412d-93f9-b8cd9aa94e85/crypt/clickhouse_server                                                 ce930007-8ed6-4675-a24a-57c227950d43   none      none          off        
-    oxp_2a76ab1a-fb16-412d-93f9-b8cd9aa94e85/crypt/internal_dns                                                      7be88e8f-06d3-49f7-a6d9-5c586f13716c   none      none          off        
-    oxp_2a76ab1a-fb16-412d-93f9-b8cd9aa94e85/crypt/zone                                                              37405860-deb4-4f2f-b770-ab8b83175d8c   none      none          off        
-    oxp_2de2bf7e-c679-4b2b-b373-908e9d3ffbfc/crypt/zone                                                              bbb78481-c7e5-44a6-85ae-37e363827e9f   none      none          off        
-    oxp_2f02a5c6-fcf5-4b5a-bc7d-7f65369918ba/crypt/zone                                                              38103edf-a98f-46ca-94ea-3404268ea935   none      none          off        
-    oxp_32041dbf-e58d-4f32-840d-923d3d3b68af/crypt/zone                                                              3f1adfcf-9a2a-41db-9e1a-a2e13ff8a7dd   none      none          off        
-    oxp_5f88adff-bb50-4dc1-bbfb-5a410c753ed5/crypt/zone                                                              5c620f9c-454b-451b-99ca-47c3d94df493   none      none          off        
-    oxp_74d64eb9-bf69-4782-af16-2d3a761ca171/crypt/zone                                                              13f8be82-85e9-43ac-985b-e7a51a910c41   none      none          off        
-    oxp_b3c231c9-b2a5-4267-b4bf-9651881b91a5/crypt/zone                                                              9f1f99c7-e6c5-4bbc-9de5-15252b532914   none      none          off        
-    oxp_bca80b95-8dca-4a3b-b24d-d44b6a9ff71b/crypt/zone                                                              2747bb48-2fb7-4999-a63c-5ba5e35e0a10   none      none          off        
-    oxp_db16345e-427a-4c8e-9032-17270f729308/crypt/zone                                                              f7ddacf4-edc7-46ba-9b74-d588bd62505e   none      none          off        
-    oxp_e3b45593-8f0c-47b2-a381-802a7dad1f54/crypt/zone                                                              64e62d15-e813-461d-9a50-403d9bd1df7c   none      none          off        
-    oxp_2a76ab1a-fb16-412d-93f9-b8cd9aa94e85/crypt/zone/oxz_clickhouse_keeper_f3279a8b-32fa-4426-b946-08aff9ded482   26c79a0e-a2e4-4093-ba43-5e7979609651   none      none          off        
-    oxp_2a76ab1a-fb16-412d-93f9-b8cd9aa94e85/crypt/zone/oxz_clickhouse_server_122e30d3-d541-49b5-88de-1543b38123cc   748c9607-71dd-4f81-be08-c1eee262f69c   none      none          off        
-    oxp_bca80b95-8dca-4a3b-b24d-d44b6a9ff71b/crypt/zone/oxz_crucible_0a160b89-6288-44f5-9908-33589094628e            53a623d2-9ffc-48fb-871d-23bd52e0f4dd   none      none          off        
-    oxp_2f02a5c6-fcf5-4b5a-bc7d-7f65369918ba/crypt/zone/oxz_crucible_2cb036bd-6056-4547-af65-aa6c0c1e4d6e            c6c9e491-ce4d-4dc4-82be-e394fa1e82e2   none      none          off        
-    oxp_2de2bf7e-c679-4b2b-b373-908e9d3ffbfc/crypt/zone/oxz_crucible_37c72edc-6acd-4c2d-ab76-d1c88e1f01f5            9b49fc13-4d2c-423e-9839-f6e1d0bffc6e   none      none          off        
-    oxp_db16345e-427a-4c8e-9032-17270f729308/crypt/zone/oxz_crucible_5fb4b72f-bf1b-47c7-a2e4-dbdafcdb47f5            1d73fc1f-81fc-4e06-9b52-686596ac0f6c   none      none          off        
-    oxp_5f88adff-bb50-4dc1-bbfb-5a410c753ed5/crypt/zone/oxz_crucible_6ae471b1-1dd8-460e-a2a5-3ea796f746d5            98b66132-d99e-42e2-8517-5860412c61b1   none      none          off        
-    oxp_2a76ab1a-fb16-412d-93f9-b8cd9aa94e85/crypt/zone/oxz_crucible_75cccfab-ea70-4596-a685-ab9bd5e540a1            e2ff081e-c5a4-42c3-8d95-969e2b9b7b31   none      none          off        
-    oxp_e3b45593-8f0c-47b2-a381-802a7dad1f54/crypt/zone/oxz_crucible_8a36ef67-bf66-40b9-a2f4-34ac70e90e39            c44e20e1-7cce-46df-ba71-db7fb3e3a5ff   none      none          off        
-    oxp_74d64eb9-bf69-4782-af16-2d3a761ca171/crypt/zone/oxz_crucible_b6a9674e-8b42-4d67-954f-3e957db298dd            e7c2d833-b6a1-469f-b52f-8bbb45e9a30e   none      none          off        
-    oxp_b3c231c9-b2a5-4267-b4bf-9651881b91a5/crypt/zone/oxz_crucible_c79e017b-7e27-4ff5-be14-3673f8cb2279            3544adde-a808-45c0-ae19-08b4f65e3ad4   none      none          off        
-    oxp_32041dbf-e58d-4f32-840d-923d3d3b68af/crypt/zone/oxz_crucible_e52381c1-d7ab-402f-a9a8-bb52fbb614af            a0251fdc-166b-4476-95d4-f7fd58fdaf76   none      none          off        
-    oxp_2a76ab1a-fb16-412d-93f9-b8cd9aa94e85/crypt/zone/oxz_crucible_pantry_1432df56-4a7b-4271-9b24-a8a3183a95a7     452dad91-0c11-4dfa-96fb-dfb0cfa1d17c   none      none          off        
-    oxp_2a76ab1a-fb16-412d-93f9-b8cd9aa94e85/crypt/zone/oxz_internal_dns_832c71a1-357d-482b-8661-3193d59ed776        08588a53-0f1d-4631-a1ef-8fa34098fbf6   none      none          off        
-    oxp_2a76ab1a-fb16-412d-93f9-b8cd9aa94e85/crypt/zone/oxz_nexus_da39dead-64e2-45b6-9d01-d99584504dfd               45dc03ec-d0e0-429a-a099-7fc6ea6dfb85   none      none          off        
-    oxp_2a76ab1a-fb16-412d-93f9-b8cd9aa94e85/crypt/zone/oxz_ntp_816afef9-e5cd-40ba-8cc5-71e783943e43                 6f5ba0fc-1b43-4a40-ba5a-3abf11eae62b   none      none          off        
-    oxp_2a76ab1a-fb16-412d-93f9-b8cd9aa94e85/crypt/debug                                                             c55ba154-4f4b-48a5-997b-2a1579671c74   100 GiB   none          gzip-9     
-    oxp_2de2bf7e-c679-4b2b-b373-908e9d3ffbfc/crypt/debug                                                             071d678d-9376-4c3b-8e1f-825d27bcae3a   100 GiB   none          gzip-9     
-    oxp_2f02a5c6-fcf5-4b5a-bc7d-7f65369918ba/crypt/debug                                                             daeded95-0145-4b97-b1fb-60d44856d1e4   100 GiB   none          gzip-9     
-    oxp_32041dbf-e58d-4f32-840d-923d3d3b68af/crypt/debug                                                             80d0697d-4ebe-4856-b7bf-78ff811eb00b   100 GiB   none          gzip-9     
-    oxp_5f88adff-bb50-4dc1-bbfb-5a410c753ed5/crypt/debug                                                             dd239ff5-a617-4eb1-ac6d-16eb76c2c849   100 GiB   none          gzip-9     
-    oxp_74d64eb9-bf69-4782-af16-2d3a761ca171/crypt/debug                                                             b9e71882-7f71-4a5e-be9c-7df560c75000   100 GiB   none          gzip-9     
-    oxp_b3c231c9-b2a5-4267-b4bf-9651881b91a5/crypt/debug                                                             bae0ee1b-b3a3-4c4c-96ee-53b8b4cd837b   100 GiB   none          gzip-9     
-    oxp_bca80b95-8dca-4a3b-b24d-d44b6a9ff71b/crypt/debug                                                             f2df23eb-672a-41b5-89e4-26c9feb50c7c   100 GiB   none          gzip-9     
-    oxp_db16345e-427a-4c8e-9032-17270f729308/crypt/debug                                                             e658be5b-df77-41fb-a000-5a924ac0b3da   100 GiB   none          gzip-9     
-    oxp_e3b45593-8f0c-47b2-a381-802a7dad1f54/crypt/debug                                                             96798a17-be94-44bb-9e12-2eb458e9a5ba   100 GiB   none          gzip-9     
+    oxp_2a76ab1a-fb16-412d-93f9-b8cd9aa94e85/crucible                                                                c73b47ac-ad1f-4cd1-b449-f220b5ad8104   none      none          off        
+    oxp_2de2bf7e-c679-4b2b-b373-908e9d3ffbfc/crucible                                                                813c7aac-695b-49ce-8bc5-f4cdbfc04b38   none      none          off        
+    oxp_2f02a5c6-fcf5-4b5a-bc7d-7f65369918ba/crucible                                                                e5da836d-fffb-4435-8500-889c05b04689   none      none          off        
+    oxp_32041dbf-e58d-4f32-840d-923d3d3b68af/crucible                                                                9f8d056c-3e84-4474-b9c7-5b7a890a8a7b   none      none          off        
+    oxp_5f88adff-bb50-4dc1-bbfb-5a410c753ed5/crucible                                                                e93cfc01-9581-4f6e-b77c-eb6300ca6ffb   none      none          off        
+    oxp_74d64eb9-bf69-4782-af16-2d3a761ca171/crucible                                                                f54d6e59-67a1-458b-8e66-6dc3b2adb755   none      none          off        
+    oxp_b3c231c9-b2a5-4267-b4bf-9651881b91a5/crucible                                                                6604dd1b-5f21-475d-952a-894717512d1b   none      none          off        
+    oxp_bca80b95-8dca-4a3b-b24d-d44b6a9ff71b/crucible                                                                05cb728f-f6b9-4132-922d-fe249b1ba736   none      none          off        
+    oxp_db16345e-427a-4c8e-9032-17270f729308/crucible                                                                500f8d46-a32d-4bd1-8f2c-cb9d36822660   none      none          off        
+    oxp_e3b45593-8f0c-47b2-a381-802a7dad1f54/crucible                                                                66c673a1-e8d8-4863-b368-a7ea292555fb   none      none          off        
+    oxp_2a76ab1a-fb16-412d-93f9-b8cd9aa94e85/crypt/clickhouse_keeper                                                 6c5a6622-5f75-45a0-a9e8-4b513f5ac352   none      none          off        
+    oxp_2a76ab1a-fb16-412d-93f9-b8cd9aa94e85/crypt/clickhouse_server                                                 f8706468-85ac-4f9f-b41d-ff7c3a17ee5f   none      none          off        
+    oxp_2a76ab1a-fb16-412d-93f9-b8cd9aa94e85/crypt/internal_dns                                                      03de030d-d958-4ce5-86d2-368fa88e0bd8   none      none          off        
+    oxp_2a76ab1a-fb16-412d-93f9-b8cd9aa94e85/crypt/zone                                                              4c3c89bd-21cf-4986-b012-e89e4e1c1ac4   none      none          off        
+    oxp_2de2bf7e-c679-4b2b-b373-908e9d3ffbfc/crypt/zone                                                              ff4a77a2-528a-4c70-a5b9-f0093c95697b   none      none          off        
+    oxp_2f02a5c6-fcf5-4b5a-bc7d-7f65369918ba/crypt/zone                                                              676fc8c5-743b-48ca-99fd-2f2379c83890   none      none          off        
+    oxp_32041dbf-e58d-4f32-840d-923d3d3b68af/crypt/zone                                                              63362c89-4b42-4649-9ebe-43e19a5c0e51   none      none          off        
+    oxp_5f88adff-bb50-4dc1-bbfb-5a410c753ed5/crypt/zone                                                              6f83a31e-1181-418f-92b0-d0534e9ae6dd   none      none          off        
+    oxp_74d64eb9-bf69-4782-af16-2d3a761ca171/crypt/zone                                                              260ffd7d-4da5-4657-9158-ba7e1eae5971   none      none          off        
+    oxp_b3c231c9-b2a5-4267-b4bf-9651881b91a5/crypt/zone                                                              ed4c8570-3951-4f79-b27e-da73150609be   none      none          off        
+    oxp_bca80b95-8dca-4a3b-b24d-d44b6a9ff71b/crypt/zone                                                              e5dcf165-3ebb-40a2-b16f-a07b036a6533   none      none          off        
+    oxp_db16345e-427a-4c8e-9032-17270f729308/crypt/zone                                                              dd27be6b-214d-4022-a99d-2a7d12e7d8bb   none      none          off        
+    oxp_e3b45593-8f0c-47b2-a381-802a7dad1f54/crypt/zone                                                              b7500d95-2499-48fc-a7d6-2460d61e197a   none      none          off        
+    oxp_2a76ab1a-fb16-412d-93f9-b8cd9aa94e85/crypt/zone/oxz_clickhouse_keeper_7aa82b80-0c37-4f20-9398-bfce4707f327   0bf9cddb-1911-495b-8aad-09b7eea5fff4   none      none          off        
+    oxp_2a76ab1a-fb16-412d-93f9-b8cd9aa94e85/crypt/zone/oxz_clickhouse_server_812be70a-f237-47d5-ab49-f9450fe948db   292f53fc-27bb-4cc4-a61b-7d02c978149c   none      none          off        
+    oxp_32041dbf-e58d-4f32-840d-923d3d3b68af/crypt/zone/oxz_crucible_0b0e12fd-2800-4203-acb6-24e6e976271c            cf46ee68-f945-4af6-a647-4d612c1f05be   none      none          off        
+    oxp_2de2bf7e-c679-4b2b-b373-908e9d3ffbfc/crypt/zone/oxz_crucible_1a02d419-10c4-4326-b34e-eb2b1bd90bd7            2a439799-3f16-46df-ba1b-7ea29edd392d   none      none          off        
+    oxp_2a76ab1a-fb16-412d-93f9-b8cd9aa94e85/crypt/zone/oxz_crucible_56e18c31-f630-4643-ad5c-1fede34f35de            c30be90e-20cf-46c6-bb4a-b65d2c407878   none      none          off        
+    oxp_b3c231c9-b2a5-4267-b4bf-9651881b91a5/crypt/zone/oxz_crucible_5ea86015-8f62-40aa-b3b2-c659f17ee510            6289ea03-b2c9-4470-b7ba-b935450aa764   none      none          off        
+    oxp_5f88adff-bb50-4dc1-bbfb-5a410c753ed5/crypt/zone/oxz_crucible_78965849-e6e3-4250-a66a-dc50512fad34            43b36ba3-e516-4732-be8b-8cd2ca9de93c   none      none          off        
+    oxp_74d64eb9-bf69-4782-af16-2d3a761ca171/crypt/zone/oxz_crucible_90c484e5-69d3-4636-9c64-6a878f593d33            7cc8018e-323f-4d35-bb33-fcf557b9dace   none      none          off        
+    oxp_db16345e-427a-4c8e-9032-17270f729308/crypt/zone/oxz_crucible_a3901043-fa2a-4ef7-a40e-6ef0e5fd189f            88fd4e5a-50fd-43c7-8a75-0ad4376bd564   none      none          off        
+    oxp_2f02a5c6-fcf5-4b5a-bc7d-7f65369918ba/crypt/zone/oxz_crucible_be9fd98a-6422-4890-a32b-42d42d1c8957            932cbb0d-b1d0-423d-87b6-9dce8ddb6338   none      none          off        
+    oxp_e3b45593-8f0c-47b2-a381-802a7dad1f54/crypt/zone/oxz_crucible_bf71d1a8-9e65-479d-8920-0be8e3422ac5            fd0ce816-4da0-4490-be32-4d38fb78c13c   none      none          off        
+    oxp_bca80b95-8dca-4a3b-b24d-d44b6a9ff71b/crypt/zone/oxz_crucible_eb4176ea-456b-48f6-b284-7b76da0bf4a1            704ea6b5-0ffc-443f-ae8a-482666f8277c   none      none          off        
+    oxp_2a76ab1a-fb16-412d-93f9-b8cd9aa94e85/crypt/zone/oxz_crucible_pantry_417c97a4-fe25-439d-8359-3f7062981923     8957a276-6d4e-4c58-a856-d7c5433806e1   none      none          off        
+    oxp_2a76ab1a-fb16-412d-93f9-b8cd9aa94e85/crypt/zone/oxz_internal_dns_f2bbaa79-0eab-4b91-a404-dad4c19b58c2        fe0f566f-3cff-43ef-960c-649c27746c56   none      none          off        
+    oxp_2a76ab1a-fb16-412d-93f9-b8cd9aa94e85/crypt/zone/oxz_nexus_33ba37c4-2535-4095-a7e9-c69937fc584d               77d0cd16-b6e3-484d-962f-0477cd242482   none      none          off        
+    oxp_2a76ab1a-fb16-412d-93f9-b8cd9aa94e85/crypt/zone/oxz_ntp_47eab17a-4dd4-4467-90b2-f643f465cf34                 4eaf1849-1fe4-415c-bdc7-4cc04cac20ce   none      none          off        
+    oxp_2a76ab1a-fb16-412d-93f9-b8cd9aa94e85/crypt/debug                                                             c5b8f4f9-bd10-45b8-a9f3-93adf1402ecc   100 GiB   none          gzip-9     
+    oxp_2de2bf7e-c679-4b2b-b373-908e9d3ffbfc/crypt/debug                                                             43abf982-d457-46d1-8566-8047d2a78a41   100 GiB   none          gzip-9     
+    oxp_2f02a5c6-fcf5-4b5a-bc7d-7f65369918ba/crypt/debug                                                             1b6a1722-d9f7-48ea-b351-5bc8bad4fd07   100 GiB   none          gzip-9     
+    oxp_32041dbf-e58d-4f32-840d-923d3d3b68af/crypt/debug                                                             8be43fb0-00e7-4748-9a1a-ace9772d8a83   100 GiB   none          gzip-9     
+    oxp_5f88adff-bb50-4dc1-bbfb-5a410c753ed5/crypt/debug                                                             2ccb3aa9-f0ef-4fd4-9fd7-43b4a88b8d6b   100 GiB   none          gzip-9     
+    oxp_74d64eb9-bf69-4782-af16-2d3a761ca171/crypt/debug                                                             56759eb6-69e9-46a3-b44c-fc748cd506aa   100 GiB   none          gzip-9     
+    oxp_b3c231c9-b2a5-4267-b4bf-9651881b91a5/crypt/debug                                                             76fffbd2-9c74-46b5-8033-f442be1256f5   100 GiB   none          gzip-9     
+    oxp_bca80b95-8dca-4a3b-b24d-d44b6a9ff71b/crypt/debug                                                             c13a3d71-1241-42d1-95a8-d720c20ee2c4   100 GiB   none          gzip-9     
+    oxp_db16345e-427a-4c8e-9032-17270f729308/crypt/debug                                                             f030ef33-cad2-4760-9431-1907b797161b   100 GiB   none          gzip-9     
+    oxp_e3b45593-8f0c-47b2-a381-802a7dad1f54/crypt/debug                                                             947b2823-3dca-4b56-9324-f476e2c1c6da   100 GiB   none          gzip-9     
 
 
     omicron zones at generation 3:
     -----------------------------------------------------------------------------------------------
     zone type           zone id                                disposition   underlay IP           
     -----------------------------------------------------------------------------------------------
-    clickhouse_keeper   f3279a8b-32fa-4426-b946-08aff9ded482   in service    fd00:1122:3344:102::2e
-    clickhouse_server   122e30d3-d541-49b5-88de-1543b38123cc   in service    fd00:1122:3344:102::2f
-    crucible            0a160b89-6288-44f5-9908-33589094628e   in service    fd00:1122:3344:102::2b
-    crucible            2cb036bd-6056-4547-af65-aa6c0c1e4d6e   in service    fd00:1122:3344:102::26
-    crucible            37c72edc-6acd-4c2d-ab76-d1c88e1f01f5   in service    fd00:1122:3344:102::25
-    crucible            5fb4b72f-bf1b-47c7-a2e4-dbdafcdb47f5   in service    fd00:1122:3344:102::2c
-    crucible            6ae471b1-1dd8-460e-a2a5-3ea796f746d5   in service    fd00:1122:3344:102::28
-    crucible            75cccfab-ea70-4596-a685-ab9bd5e540a1   in service    fd00:1122:3344:102::24
-    crucible            8a36ef67-bf66-40b9-a2f4-34ac70e90e39   in service    fd00:1122:3344:102::2d
-    crucible            b6a9674e-8b42-4d67-954f-3e957db298dd   in service    fd00:1122:3344:102::29
-    crucible            c79e017b-7e27-4ff5-be14-3673f8cb2279   in service    fd00:1122:3344:102::2a
-    crucible            e52381c1-d7ab-402f-a9a8-bb52fbb614af   in service    fd00:1122:3344:102::27
-    crucible_pantry     1432df56-4a7b-4271-9b24-a8a3183a95a7   in service    fd00:1122:3344:102::23
-    internal_dns        832c71a1-357d-482b-8661-3193d59ed776   in service    fd00:1122:3344:3::1   
-    internal_ntp        816afef9-e5cd-40ba-8cc5-71e783943e43   in service    fd00:1122:3344:102::21
-    nexus               da39dead-64e2-45b6-9d01-d99584504dfd   in service    fd00:1122:3344:102::22
+    clickhouse_keeper   7aa82b80-0c37-4f20-9398-bfce4707f327   in service    fd00:1122:3344:102::2e
+    clickhouse_server   812be70a-f237-47d5-ab49-f9450fe948db   in service    fd00:1122:3344:102::2f
+    crucible            0b0e12fd-2800-4203-acb6-24e6e976271c   in service    fd00:1122:3344:102::27
+    crucible            1a02d419-10c4-4326-b34e-eb2b1bd90bd7   in service    fd00:1122:3344:102::25
+    crucible            56e18c31-f630-4643-ad5c-1fede34f35de   in service    fd00:1122:3344:102::24
+    crucible            5ea86015-8f62-40aa-b3b2-c659f17ee510   in service    fd00:1122:3344:102::2a
+    crucible            78965849-e6e3-4250-a66a-dc50512fad34   in service    fd00:1122:3344:102::28
+    crucible            90c484e5-69d3-4636-9c64-6a878f593d33   in service    fd00:1122:3344:102::29
+    crucible            a3901043-fa2a-4ef7-a40e-6ef0e5fd189f   in service    fd00:1122:3344:102::2c
+    crucible            be9fd98a-6422-4890-a32b-42d42d1c8957   in service    fd00:1122:3344:102::26
+    crucible            bf71d1a8-9e65-479d-8920-0be8e3422ac5   in service    fd00:1122:3344:102::2d
+    crucible            eb4176ea-456b-48f6-b284-7b76da0bf4a1   in service    fd00:1122:3344:102::2b
+    crucible_pantry     417c97a4-fe25-439d-8359-3f7062981923   in service    fd00:1122:3344:102::23
+    internal_dns        f2bbaa79-0eab-4b91-a404-dad4c19b58c2   in service    fd00:1122:3344:3::1   
+    internal_ntp        47eab17a-4dd4-4467-90b2-f643f465cf34   in service    fd00:1122:3344:102::21
+    nexus               33ba37c4-2535-4095-a7e9-c69937fc584d   in service    fd00:1122:3344:102::22
 
 
  COCKROACHDB SETTINGS:
@@ -301,21 +301,21 @@ to:   blueprint 92fa943c-7dd4-48c3-9447-c9d0665744b6
     max used server id:::::::::::::::::::::::::::::   2 (unchanged)
     max used keeper id:::::::::::::::::::::::::::::   3 (unchanged)
     cluster name:::::::::::::::::::::::::::::::::::   oximeter_cluster (unchanged)
-    cluster secret:::::::::::::::::::::::::::::::::   75ba7558-f7cf-431f-bba5-71c8e82fd4c1 (unchanged)
+    cluster secret:::::::::::::::::::::::::::::::::   6a984e2e-20be-4ed9-b572-d7ef063c67f7 (unchanged)
 *   highest seen keeper leader committed log index:   0 -> 1
 
     clickhouse keepers at generation 2:
     ------------------------------------------------
     zone id                                keeper id
     ------------------------------------------------
-    39fd3357-4de8-433e-9c07-1ec65de7ca59   1        
-    b36c16d5-de6e-411a-a32a-d35a26f2e151   2        
-    f3279a8b-32fa-4426-b946-08aff9ded482   3        
+    31a66e47-6252-4f38-aa92-f48637da152c   1        
+    7aa82b80-0c37-4f20-9398-bfce4707f327   2        
+    dd5ab8b1-e6e7-40e0-9ea6-b6a16f485b52   3        
 
     clickhouse servers at generation 2:
     ------------------------------------------------
     zone id                                server id
     ------------------------------------------------
-    122e30d3-d541-49b5-88de-1543b38123cc   1        
-    71be6bff-666a-4f2b-a7dc-d80a88a71af5   2        
+    6fedfc94-2ae6-4cc7-a968-5185207284f4   1        
+    812be70a-f237-47d5-ab49-f9450fe948db   2        
 

--- a/nexus/reconfigurator/planning/tests/output/planner_deploy_all_keeper_nodes_4_5.txt
+++ b/nexus/reconfigurator/planning/tests/output/planner_deploy_all_keeper_nodes_4_5.txt
@@ -25,77 +25,77 @@ to:   blueprint 2886dab5-61a2-46b4-87af-bc7aeb44cccb
     -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
     dataset name                                                                                                     dataset uuid                           quota     reservation   compression
     -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
-    oxp_60e6b021-79d6-4a6b-917c-6637e0769558/crucible                                                                fcd7e842-2648-407a-8d13-197e67de9e9d   none      none          off        
-    oxp_71a07ac0-d24e-446c-a202-1998e7f6ac8c/crucible                                                                c770de28-6c33-4cc7-97d9-62ddafd963aa   none      none          off        
-    oxp_736d4cab-c262-485e-89c2-07e6543f0855/crucible                                                                ac9f4d69-3281-4774-a098-250755079068   none      none          off        
-    oxp_8ae56ca0-709d-4b8f-9869-51b62b542eef/crucible                                                                09781292-36f1-4310-82b4-ddfb4d287fa1   none      none          off        
-    oxp_8e0bcc4f-0799-450c-a0ad-80c1637f59e3/crucible                                                                81719897-4ae6-4d76-8282-fda91c347811   none      none          off        
-    oxp_8eeebb8e-6db6-43e8-a429-d26dde99882c/crucible                                                                a2399f57-62eb-4d7d-ac69-09cd6e5c2134   none      none          off        
-    oxp_a3e8de5b-c47a-49c0-b698-4d6955e1327f/crucible                                                                cd6b3952-2024-4310-b82e-abfd245ec1d6   none      none          off        
-    oxp_b32fa3da-4dec-4237-9776-e1a57ba15a21/crucible                                                                4f99dd21-d6ed-409a-af19-9886d1083762   none      none          off        
-    oxp_e9c238f6-87a3-4087-8ba4-aa594a82d012/crucible                                                                e88d6ff8-6b98-44c1-97a7-83f371ae62fe   none      none          off        
-    oxp_fbf997ef-52d3-438a-b036-b9117322e569/crucible                                                                d6a838c7-3ee9-4cca-9d8b-986b4de0ba1c   none      none          off        
-    oxp_60e6b021-79d6-4a6b-917c-6637e0769558/crypt/clickhouse                                                        5cb56dc7-6c56-4bbf-ae73-6f08e0c97cdf   none      none          off        
-    oxp_60e6b021-79d6-4a6b-917c-6637e0769558/crypt/clickhouse_keeper                                                 886f2522-8122-465f-8996-2d8c2acd9d0d   none      none          off        
-    oxp_60e6b021-79d6-4a6b-917c-6637e0769558/crypt/internal_dns                                                      dd467397-efc5-4738-984e-77a0f3e3e678   none      none          off        
-    oxp_60e6b021-79d6-4a6b-917c-6637e0769558/crypt/zone                                                              8c4f4acd-8f6b-4296-81be-12d2eeae0483   none      none          off        
-    oxp_71a07ac0-d24e-446c-a202-1998e7f6ac8c/crypt/zone                                                              f83b1c8d-d252-4b35-a9d2-400e2e2cddf7   none      none          off        
-    oxp_736d4cab-c262-485e-89c2-07e6543f0855/crypt/zone                                                              a34f8204-9f17-4c8f-997b-e122c284ac9f   none      none          off        
-    oxp_8ae56ca0-709d-4b8f-9869-51b62b542eef/crypt/zone                                                              61bf628d-a78d-40a7-bad2-84e97e41b810   none      none          off        
-    oxp_8e0bcc4f-0799-450c-a0ad-80c1637f59e3/crypt/zone                                                              3f63ada8-d1f4-440d-8713-da45b0684520   none      none          off        
-    oxp_8eeebb8e-6db6-43e8-a429-d26dde99882c/crypt/zone                                                              a3284e6f-ee42-4fdb-8150-634f7f40c073   none      none          off        
-    oxp_a3e8de5b-c47a-49c0-b698-4d6955e1327f/crypt/zone                                                              8b7928fb-e5a0-49b0-81d0-89f627020c92   none      none          off        
-    oxp_b32fa3da-4dec-4237-9776-e1a57ba15a21/crypt/zone                                                              0e976e79-fe8c-4189-8a8c-279f42e0290f   none      none          off        
-    oxp_e9c238f6-87a3-4087-8ba4-aa594a82d012/crypt/zone                                                              f963f2a7-e9d1-4b80-b01a-ff4cecddf867   none      none          off        
-    oxp_fbf997ef-52d3-438a-b036-b9117322e569/crypt/zone                                                              a15e4260-d48c-4415-9315-c0f29234f359   none      none          off        
-    oxp_60e6b021-79d6-4a6b-917c-6637e0769558/crypt/zone/oxz_clickhouse_df79db1e-54ca-4048-b22a-da120ae4c8c4          b6cb0fe9-0b7a-4793-b6cd-1ee71fee464c   none      none          off        
-    oxp_60e6b021-79d6-4a6b-917c-6637e0769558/crypt/zone/oxz_clickhouse_keeper_39fd3357-4de8-433e-9c07-1ec65de7ca59   095cf066-5a68-40b4-afc6-baf5bcbadd05   none      none          off        
-    oxp_8e0bcc4f-0799-450c-a0ad-80c1637f59e3/crypt/zone/oxz_crucible_08330c18-54e9-445b-81f3-8f1d6ad15cdd            ab255226-2c8c-4222-82c6-702af839a2d2   none      none          off        
-    oxp_fbf997ef-52d3-438a-b036-b9117322e569/crypt/zone/oxz_crucible_0ba018f0-4ff7-4bcc-a0c7-42cfec6bc9da            ba1a3aae-15ab-4364-8250-54a766331ef8   none      none          off        
-    oxp_60e6b021-79d6-4a6b-917c-6637e0769558/crypt/zone/oxz_crucible_1e485cda-b36e-4647-9125-c273fc7a9850            65c2e3cd-3d8e-43c6-9e2c-cb884511ec49   none      none          off        
-    oxp_a3e8de5b-c47a-49c0-b698-4d6955e1327f/crypt/zone/oxz_crucible_4d84fdb4-76fd-47a9-b033-7e1711d9125f            8dc07059-e8cd-4f89-abc7-0c5289b8ff0a   none      none          off        
-    oxp_e9c238f6-87a3-4087-8ba4-aa594a82d012/crypt/zone/oxz_crucible_577b0a64-6fa9-4302-bfaa-853b6e9e71ac            851cd90d-97f5-49b6-ad41-2e1c1faa3cc9   none      none          off        
-    oxp_8eeebb8e-6db6-43e8-a429-d26dde99882c/crypt/zone/oxz_crucible_5d296df4-4f2f-4896-8caa-42df00799bcb            25c5034b-83b2-4a90-a08a-7573ffb38119   none      none          off        
-    oxp_736d4cab-c262-485e-89c2-07e6543f0855/crypt/zone/oxz_crucible_65d597c5-86b9-43f6-84cd-67bb108df9f0            6de460bc-890d-4e7a-920f-607862440cfd   none      none          off        
-    oxp_b32fa3da-4dec-4237-9776-e1a57ba15a21/crypt/zone/oxz_crucible_a9f1d41e-c445-4783-af13-0095b2836f0f            b5d6cec1-c83f-4c41-9e79-8b9bf917f483   none      none          off        
-    oxp_71a07ac0-d24e-446c-a202-1998e7f6ac8c/crypt/zone/oxz_crucible_e9ab813f-0fff-4b41-a101-790f6d94b40a            7c459b4e-396b-497f-8094-f342939d1f9f   none      none          off        
-    oxp_8ae56ca0-709d-4b8f-9869-51b62b542eef/crypt/zone/oxz_crucible_f00c7a67-51a6-4d09-be39-f20b0e6da1c6            6ff911b9-a4a5-4986-ba04-c6b3f234d3b4   none      none          off        
-    oxp_60e6b021-79d6-4a6b-917c-6637e0769558/crypt/zone/oxz_crucible_pantry_840a4f34-0e53-469c-8c79-12b75bb42edc     7de8087e-602a-4a81-98ff-d766213d0f94   none      none          off        
-    oxp_60e6b021-79d6-4a6b-917c-6637e0769558/crypt/zone/oxz_internal_dns_c89ac05f-d9b2-47f4-9d48-2f38130e4ad9        dd1cdc17-808e-4e6d-99ed-84b2d0e220f1   none      none          off        
-    oxp_60e6b021-79d6-4a6b-917c-6637e0769558/crypt/zone/oxz_nexus_a6032c9e-a365-45d7-ad9f-07ac0fa7079a               198ff957-cce0-40cf-9048-f65cf9a6c671   none      none          off        
-    oxp_60e6b021-79d6-4a6b-917c-6637e0769558/crypt/zone/oxz_ntp_66695827-17c4-4885-b6c0-2cb6b6d3ad1c                 ccfb112d-c72e-4482-9bb0-f9cbbb034f7d   none      none          off        
-    oxp_60e6b021-79d6-4a6b-917c-6637e0769558/crypt/debug                                                             10610f76-51e8-4be4-a4ad-9af953f6bf4a   100 GiB   none          gzip-9     
-    oxp_71a07ac0-d24e-446c-a202-1998e7f6ac8c/crypt/debug                                                             e0bcc415-f8f9-401f-a507-cee5587756b1   100 GiB   none          gzip-9     
-    oxp_736d4cab-c262-485e-89c2-07e6543f0855/crypt/debug                                                             8bbc5419-7125-4cb1-b990-436af4bb8eb4   100 GiB   none          gzip-9     
-    oxp_8ae56ca0-709d-4b8f-9869-51b62b542eef/crypt/debug                                                             280dd773-35e2-4dda-ae2a-65c88f1b2a01   100 GiB   none          gzip-9     
-    oxp_8e0bcc4f-0799-450c-a0ad-80c1637f59e3/crypt/debug                                                             fecbd83d-7440-4900-b22b-6206e55b2920   100 GiB   none          gzip-9     
-    oxp_8eeebb8e-6db6-43e8-a429-d26dde99882c/crypt/debug                                                             e120c8f8-049f-40f0-8d70-4cfe409ef34d   100 GiB   none          gzip-9     
-    oxp_a3e8de5b-c47a-49c0-b698-4d6955e1327f/crypt/debug                                                             37eb0429-d620-40fb-a57a-62486d001738   100 GiB   none          gzip-9     
-    oxp_b32fa3da-4dec-4237-9776-e1a57ba15a21/crypt/debug                                                             d0f12057-da73-4c1d-bdec-32a0e7ab7107   100 GiB   none          gzip-9     
-    oxp_e9c238f6-87a3-4087-8ba4-aa594a82d012/crypt/debug                                                             2288ff91-8e52-4817-825f-2f8b8eb1681d   100 GiB   none          gzip-9     
-    oxp_fbf997ef-52d3-438a-b036-b9117322e569/crypt/debug                                                             17ffe1be-b38b-4f39-90af-57af25dbfe30   100 GiB   none          gzip-9     
+    oxp_60e6b021-79d6-4a6b-917c-6637e0769558/crucible                                                                723e4ec2-5f4a-48a9-a6a1-cb523dc47d3d   none      none          off        
+    oxp_71a07ac0-d24e-446c-a202-1998e7f6ac8c/crucible                                                                b2796e6b-ad7d-41a5-82a6-947b96e42d47   none      none          off        
+    oxp_736d4cab-c262-485e-89c2-07e6543f0855/crucible                                                                c993b4da-bea9-4010-a8d6-17d733698f07   none      none          off        
+    oxp_8ae56ca0-709d-4b8f-9869-51b62b542eef/crucible                                                                4f497ece-88c1-4557-a8b4-0e990f9941a9   none      none          off        
+    oxp_8e0bcc4f-0799-450c-a0ad-80c1637f59e3/crucible                                                                43a16c22-e79a-4bea-bcf6-682099a728dd   none      none          off        
+    oxp_8eeebb8e-6db6-43e8-a429-d26dde99882c/crucible                                                                b6bbb45b-68fc-4fa5-86cc-b59b0f797fb2   none      none          off        
+    oxp_a3e8de5b-c47a-49c0-b698-4d6955e1327f/crucible                                                                e4838ed0-304f-475e-a282-9f644f2ba3e5   none      none          off        
+    oxp_b32fa3da-4dec-4237-9776-e1a57ba15a21/crucible                                                                046f2730-768d-4bcc-8ebf-4b5f5597151c   none      none          off        
+    oxp_e9c238f6-87a3-4087-8ba4-aa594a82d012/crucible                                                                0830fc6d-ed82-41de-9389-0bd3fd4677ea   none      none          off        
+    oxp_fbf997ef-52d3-438a-b036-b9117322e569/crucible                                                                d9662141-585e-4e18-a461-9627097f02a2   none      none          off        
+    oxp_60e6b021-79d6-4a6b-917c-6637e0769558/crypt/clickhouse                                                        a4f84c49-4303-411f-bb1b-08877d828946   none      none          off        
+    oxp_60e6b021-79d6-4a6b-917c-6637e0769558/crypt/clickhouse_keeper                                                 04ee4b4b-fcbe-4224-86fd-30144a4f2592   none      none          off        
+    oxp_60e6b021-79d6-4a6b-917c-6637e0769558/crypt/internal_dns                                                      2edca3dc-a0e5-4d34-b8a2-065be4cca767   none      none          off        
+    oxp_60e6b021-79d6-4a6b-917c-6637e0769558/crypt/zone                                                              87cd9f37-3de3-457c-9412-d0dc5678eda8   none      none          off        
+    oxp_71a07ac0-d24e-446c-a202-1998e7f6ac8c/crypt/zone                                                              3a164f36-1f53-45b3-b190-ad8a2817bc69   none      none          off        
+    oxp_736d4cab-c262-485e-89c2-07e6543f0855/crypt/zone                                                              407556ed-09ab-430e-bc8f-8291b8f8c8fe   none      none          off        
+    oxp_8ae56ca0-709d-4b8f-9869-51b62b542eef/crypt/zone                                                              99d57d61-f12a-4b56-8114-86ba92d07649   none      none          off        
+    oxp_8e0bcc4f-0799-450c-a0ad-80c1637f59e3/crypt/zone                                                              da1eb596-8764-4268-a60b-f4705b4f615b   none      none          off        
+    oxp_8eeebb8e-6db6-43e8-a429-d26dde99882c/crypt/zone                                                              d555bf19-887c-48d2-8144-47c2eac9a9e8   none      none          off        
+    oxp_a3e8de5b-c47a-49c0-b698-4d6955e1327f/crypt/zone                                                              9785e77a-9422-4b46-a4ae-8b9a155eb121   none      none          off        
+    oxp_b32fa3da-4dec-4237-9776-e1a57ba15a21/crypt/zone                                                              1192a37c-a871-4c48-905d-03c3d6035bdc   none      none          off        
+    oxp_e9c238f6-87a3-4087-8ba4-aa594a82d012/crypt/zone                                                              7bf1c7ec-5465-4bfd-b1d9-939f05336012   none      none          off        
+    oxp_fbf997ef-52d3-438a-b036-b9117322e569/crypt/zone                                                              be526b44-2c78-49ec-8ab4-73e161e27f22   none      none          off        
+    oxp_60e6b021-79d6-4a6b-917c-6637e0769558/crypt/zone/oxz_clickhouse_35e8d4b6-ea92-45cf-923c-3f566a0b1fe5          cd7e5c3a-2328-4568-b8f8-cf349f0cdd12   none      none          off        
+    oxp_60e6b021-79d6-4a6b-917c-6637e0769558/crypt/zone/oxz_clickhouse_keeper_dd5ab8b1-e6e7-40e0-9ea6-b6a16f485b52   a51fb98f-3fff-4c0a-82f0-7a4aad82096b   none      none          off        
+    oxp_e9c238f6-87a3-4087-8ba4-aa594a82d012/crypt/zone/oxz_crucible_044d074d-7905-4024-82ff-68d76221db68            98fd0f42-7337-4ce7-814e-f988304b8873   none      none          off        
+    oxp_71a07ac0-d24e-446c-a202-1998e7f6ac8c/crypt/zone/oxz_crucible_28826473-ac0b-41ea-8c54-72b782db1bcb            bbda84d8-c4ca-4f52-a766-681872fa06f0   none      none          off        
+    oxp_fbf997ef-52d3-438a-b036-b9117322e569/crypt/zone/oxz_crucible_2d3ff798-dda9-4ccf-8f91-070a20f06d55            e9c77dbd-c56a-404c-8ff9-6504b3f92556   none      none          off        
+    oxp_8eeebb8e-6db6-43e8-a429-d26dde99882c/crypt/zone/oxz_crucible_7538d29b-69f2-43e8-8509-505b25cb1c84            19110f8a-6267-41ed-ac7d-539cd0fe3511   none      none          off        
+    oxp_8ae56ca0-709d-4b8f-9869-51b62b542eef/crypt/zone/oxz_crucible_8234bbd2-4b31-4f6b-8dcc-4744b1d14e64            0fe4f647-ffd2-4845-805a-c069096560ee   none      none          off        
+    oxp_8e0bcc4f-0799-450c-a0ad-80c1637f59e3/crypt/zone/oxz_crucible_85358363-cee8-4bc3-af66-4d89e5cd714f            a1daa561-2448-4afb-8233-ec149d2bd7f4   none      none          off        
+    oxp_736d4cab-c262-485e-89c2-07e6543f0855/crypt/zone/oxz_crucible_9b58d04f-85bf-4f5e-8c6a-5d855062d5c4            69812f66-4b59-4590-9e1f-bce3e93b3b08   none      none          off        
+    oxp_60e6b021-79d6-4a6b-917c-6637e0769558/crypt/zone/oxz_crucible_e7da0aec-c6b6-4a56-9525-35385b9c62a2            36e58025-88e2-4eb9-8af0-ed9a98dda1b9   none      none          off        
+    oxp_a3e8de5b-c47a-49c0-b698-4d6955e1327f/crypt/zone/oxz_crucible_f3f977cc-7eca-4491-9b07-82b6284eb169            482fad9a-d83f-4025-8f0b-d3adea6ae2cf   none      none          off        
+    oxp_b32fa3da-4dec-4237-9776-e1a57ba15a21/crypt/zone/oxz_crucible_fef381d2-8368-4a2d-96a1-c956ed011f7b            b1937368-4019-40c4-af02-9811dc7eb143   none      none          off        
+    oxp_60e6b021-79d6-4a6b-917c-6637e0769558/crypt/zone/oxz_crucible_pantry_fe63bfd3-3128-4675-8118-cf6968293471     e3b31ef3-6b54-4901-aec4-0c672de62c7f   none      none          off        
+    oxp_60e6b021-79d6-4a6b-917c-6637e0769558/crypt/zone/oxz_internal_dns_b6b0689e-ef48-484d-b3c7-3c596edad20c        501e0672-2897-4992-8911-600e0283f04c   none      none          off        
+    oxp_60e6b021-79d6-4a6b-917c-6637e0769558/crypt/zone/oxz_nexus_46ecde76-fef7-4394-93dd-d22b003148e9               53655959-866b-4fee-bcf9-1e35504ad625   none      none          off        
+    oxp_60e6b021-79d6-4a6b-917c-6637e0769558/crypt/zone/oxz_ntp_4d009155-44fb-45b9-afed-f89cb57ce8da                 0590facf-202a-463b-81be-b6e88c47da76   none      none          off        
+    oxp_60e6b021-79d6-4a6b-917c-6637e0769558/crypt/debug                                                             8f7f16c1-d9fb-4405-9dcf-68bfbaa7bf8c   100 GiB   none          gzip-9     
+    oxp_71a07ac0-d24e-446c-a202-1998e7f6ac8c/crypt/debug                                                             6482f332-801a-473f-a77d-e07d30e2a5b7   100 GiB   none          gzip-9     
+    oxp_736d4cab-c262-485e-89c2-07e6543f0855/crypt/debug                                                             0bb0541f-2c64-487b-a8af-162454207504   100 GiB   none          gzip-9     
+    oxp_8ae56ca0-709d-4b8f-9869-51b62b542eef/crypt/debug                                                             902a6889-244f-4b67-baa4-b245f3d622c8   100 GiB   none          gzip-9     
+    oxp_8e0bcc4f-0799-450c-a0ad-80c1637f59e3/crypt/debug                                                             667ffd3c-6735-4b50-bc3b-cfa32fcc811e   100 GiB   none          gzip-9     
+    oxp_8eeebb8e-6db6-43e8-a429-d26dde99882c/crypt/debug                                                             cf48ba87-a4bb-435f-999b-bca46cfd6a89   100 GiB   none          gzip-9     
+    oxp_a3e8de5b-c47a-49c0-b698-4d6955e1327f/crypt/debug                                                             7d64cab3-7311-4519-ae4a-1af6b320fa9b   100 GiB   none          gzip-9     
+    oxp_b32fa3da-4dec-4237-9776-e1a57ba15a21/crypt/debug                                                             d3e957fd-5f26-498a-8fa3-deaea4dc5820   100 GiB   none          gzip-9     
+    oxp_e9c238f6-87a3-4087-8ba4-aa594a82d012/crypt/debug                                                             4da77f4a-5e41-4604-af30-8cf568c38428   100 GiB   none          gzip-9     
+    oxp_fbf997ef-52d3-438a-b036-b9117322e569/crypt/debug                                                             03935cb1-ce06-4594-b2fe-23e127d1cd9d   100 GiB   none          gzip-9     
 
 
     omicron zones at generation 3:
     -----------------------------------------------------------------------------------------------
     zone type           zone id                                disposition   underlay IP           
     -----------------------------------------------------------------------------------------------
-    clickhouse          df79db1e-54ca-4048-b22a-da120ae4c8c4   in service    fd00:1122:3344:101::23
-    clickhouse_keeper   39fd3357-4de8-433e-9c07-1ec65de7ca59   in service    fd00:1122:3344:101::2f
-    crucible            08330c18-54e9-445b-81f3-8f1d6ad15cdd   in service    fd00:1122:3344:101::29
-    crucible            0ba018f0-4ff7-4bcc-a0c7-42cfec6bc9da   in service    fd00:1122:3344:101::2e
-    crucible            1e485cda-b36e-4647-9125-c273fc7a9850   in service    fd00:1122:3344:101::25
-    crucible            4d84fdb4-76fd-47a9-b033-7e1711d9125f   in service    fd00:1122:3344:101::2b
-    crucible            577b0a64-6fa9-4302-bfaa-853b6e9e71ac   in service    fd00:1122:3344:101::2d
-    crucible            5d296df4-4f2f-4896-8caa-42df00799bcb   in service    fd00:1122:3344:101::2a
-    crucible            65d597c5-86b9-43f6-84cd-67bb108df9f0   in service    fd00:1122:3344:101::27
-    crucible            a9f1d41e-c445-4783-af13-0095b2836f0f   in service    fd00:1122:3344:101::2c
-    crucible            e9ab813f-0fff-4b41-a101-790f6d94b40a   in service    fd00:1122:3344:101::26
-    crucible            f00c7a67-51a6-4d09-be39-f20b0e6da1c6   in service    fd00:1122:3344:101::28
-    crucible_pantry     840a4f34-0e53-469c-8c79-12b75bb42edc   in service    fd00:1122:3344:101::24
-    internal_dns        c89ac05f-d9b2-47f4-9d48-2f38130e4ad9   in service    fd00:1122:3344:1::1   
-    internal_ntp        66695827-17c4-4885-b6c0-2cb6b6d3ad1c   in service    fd00:1122:3344:101::21
-    nexus               a6032c9e-a365-45d7-ad9f-07ac0fa7079a   in service    fd00:1122:3344:101::22
+    clickhouse          35e8d4b6-ea92-45cf-923c-3f566a0b1fe5   in service    fd00:1122:3344:101::23
+    clickhouse_keeper   dd5ab8b1-e6e7-40e0-9ea6-b6a16f485b52   in service    fd00:1122:3344:101::2f
+    crucible            044d074d-7905-4024-82ff-68d76221db68   in service    fd00:1122:3344:101::2d
+    crucible            28826473-ac0b-41ea-8c54-72b782db1bcb   in service    fd00:1122:3344:101::26
+    crucible            2d3ff798-dda9-4ccf-8f91-070a20f06d55   in service    fd00:1122:3344:101::2e
+    crucible            7538d29b-69f2-43e8-8509-505b25cb1c84   in service    fd00:1122:3344:101::2a
+    crucible            8234bbd2-4b31-4f6b-8dcc-4744b1d14e64   in service    fd00:1122:3344:101::28
+    crucible            85358363-cee8-4bc3-af66-4d89e5cd714f   in service    fd00:1122:3344:101::29
+    crucible            9b58d04f-85bf-4f5e-8c6a-5d855062d5c4   in service    fd00:1122:3344:101::27
+    crucible            e7da0aec-c6b6-4a56-9525-35385b9c62a2   in service    fd00:1122:3344:101::25
+    crucible            f3f977cc-7eca-4491-9b07-82b6284eb169   in service    fd00:1122:3344:101::2b
+    crucible            fef381d2-8368-4a2d-96a1-c956ed011f7b   in service    fd00:1122:3344:101::2c
+    crucible_pantry     fe63bfd3-3128-4675-8118-cf6968293471   in service    fd00:1122:3344:101::24
+    internal_dns        b6b0689e-ef48-484d-b3c7-3c596edad20c   in service    fd00:1122:3344:1::1   
+    internal_ntp        4d009155-44fb-45b9-afed-f89cb57ce8da   in service    fd00:1122:3344:101::21
+    nexus               46ecde76-fef7-4394-93dd-d22b003148e9   in service    fd00:1122:3344:101::22
 
 
  MODIFIED SLEDS:
@@ -122,80 +122,80 @@ to:   blueprint 2886dab5-61a2-46b4-87af-bc7aeb44cccb
     -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
     dataset name                                                                                                     dataset uuid                           quota     reservation   compression
     -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
-    oxp_0bf9d028-2b4a-4bff-82a1-6eb5fcefd985/crucible                                                                f3b1d2f6-3cbc-4420-bc91-5eaaf00f85d0   none      none          off        
-    oxp_19293a1d-fddc-40a7-88a4-ccafdb6f66d3/crucible                                                                276f044e-dd34-4c1e-beef-174da4fcf53d   none      none          off        
-    oxp_44484c44-477a-4676-8266-b98a00e80d79/crucible                                                                e06b1670-5f34-42dc-a410-3129d69907ec   none      none          off        
-    oxp_79787cd4-92da-4de5-bfd8-30a635521e10/crucible                                                                9d32dd45-e3ee-47b9-ba69-0dc711bbf632   none      none          off        
-    oxp_9ae94c94-baae-477e-912a-60f0c4f3bd13/crucible                                                                7e72090d-7f79-4ecc-92cc-5eb7d9dee022   none      none          off        
-    oxp_af85eec8-36b3-4b88-966d-a717b9b58fe5/crucible                                                                43606b8e-384f-4412-a273-d4dde8f2e76d   none      none          off        
-    oxp_ddfaaba3-dafe-4103-b868-e9843d29d346/crucible                                                                2d7145e9-0029-4ae0-bb12-ee65a1738005   none      none          off        
-    oxp_ec458c3e-91ca-40f1-a2a3-3f4292c1f279/crucible                                                                dfadcc38-505a-4e9b-8674-27f8a2af13a2   none      none          off        
-    oxp_f2fc7c4c-7966-449d-8ec3-5a70f460501d/crucible                                                                72e2a1d6-09dd-43ba-9b8b-befa101f53ef   none      none          off        
-    oxp_f635c28a-e5ca-4d22-ac94-d8f278a6ea0e/crucible                                                                c7dfbe25-5b52-4ee5-8556-719e99bb5e4d   none      none          off        
-    oxp_0bf9d028-2b4a-4bff-82a1-6eb5fcefd985/crypt/clickhouse_keeper                                                 a3eed313-d886-4c1d-8023-8d2ec9e97ddd   none      none          off        
-    oxp_0bf9d028-2b4a-4bff-82a1-6eb5fcefd985/crypt/clickhouse_server                                                 3d339942-c2d0-4615-a099-433a8b5a1543   none      none          off        
-    oxp_0bf9d028-2b4a-4bff-82a1-6eb5fcefd985/crypt/internal_dns                                                      b8af3673-c60a-45fb-adc1-c36d0d325417   none      none          off        
-    oxp_0bf9d028-2b4a-4bff-82a1-6eb5fcefd985/crypt/zone                                                              1ab5529e-c3db-41e1-a561-9c767f980ad4   none      none          off        
-    oxp_19293a1d-fddc-40a7-88a4-ccafdb6f66d3/crypt/zone                                                              68490e52-279a-4609-ba0b-11d03f904c88   none      none          off        
-    oxp_44484c44-477a-4676-8266-b98a00e80d79/crypt/zone                                                              2a5e3a10-6ab5-4988-be84-46b527dc2d23   none      none          off        
-    oxp_79787cd4-92da-4de5-bfd8-30a635521e10/crypt/zone                                                              fd0f9778-c31a-40f4-9ce9-f5154535e75b   none      none          off        
-    oxp_9ae94c94-baae-477e-912a-60f0c4f3bd13/crypt/zone                                                              e4220797-15df-42c4-9df7-ad927711d565   none      none          off        
-    oxp_af85eec8-36b3-4b88-966d-a717b9b58fe5/crypt/zone                                                              39714005-313e-42be-90eb-000a0560669f   none      none          off        
-    oxp_ddfaaba3-dafe-4103-b868-e9843d29d346/crypt/zone                                                              a647238a-1689-46c9-b680-dfe1b7b68684   none      none          off        
-    oxp_ec458c3e-91ca-40f1-a2a3-3f4292c1f279/crypt/zone                                                              29038bb0-9af1-4b03-9c10-b8a6444a0bc2   none      none          off        
-    oxp_f2fc7c4c-7966-449d-8ec3-5a70f460501d/crypt/zone                                                              e49915c6-59ed-4bbe-abf9-375b9502772a   none      none          off        
-    oxp_f635c28a-e5ca-4d22-ac94-d8f278a6ea0e/crypt/zone                                                              fc9765c5-0a89-4050-ba3e-e0625dbefb5f   none      none          off        
-    oxp_0bf9d028-2b4a-4bff-82a1-6eb5fcefd985/crypt/zone/oxz_clickhouse_keeper_b36c16d5-de6e-411a-a32a-d35a26f2e151   48720037-5b8e-4478-9bb5-c86ee8a6e250   none      none          off        
-    oxp_0bf9d028-2b4a-4bff-82a1-6eb5fcefd985/crypt/zone/oxz_clickhouse_server_71be6bff-666a-4f2b-a7dc-d80a88a71af5   a9e2160a-688f-4bbd-9a77-b2e695df86f4   none      none          off        
-    oxp_ddfaaba3-dafe-4103-b868-e9843d29d346/crypt/zone/oxz_crucible_1a92bb17-6477-46fc-9784-1d2a418d6e14            257c57cd-8f2c-440d-9fa0-e92a312295ec   none      none          off        
-    oxp_af85eec8-36b3-4b88-966d-a717b9b58fe5/crypt/zone/oxz_crucible_26115267-8333-4711-924e-d05acf601827            3a39d5e8-ea73-4cf3-b9de-48045475151c   none      none          off        
-    oxp_9ae94c94-baae-477e-912a-60f0c4f3bd13/crypt/zone/oxz_crucible_41af4ef6-d21b-4271-bfcb-524f4146784a            1522207b-ea98-47cc-810c-44808796d743   none      none          off        
-    oxp_44484c44-477a-4676-8266-b98a00e80d79/crypt/zone/oxz_crucible_487bde8c-a692-416c-be70-efef7f169fce            008ba9b6-8d41-4f7a-8ff3-ec31a0c96cf9   none      none          off        
-    oxp_f2fc7c4c-7966-449d-8ec3-5a70f460501d/crypt/zone/oxz_crucible_704a17e0-bc9d-43b9-a91e-b1ca37a23d0d            5739948f-d984-48a5-a27a-0223a0af2035   none      none          off        
-    oxp_f635c28a-e5ca-4d22-ac94-d8f278a6ea0e/crypt/zone/oxz_crucible_93535f54-4919-4c4d-9a07-f7ab6245c01f            109f44de-d1ed-4ce3-9670-76aceb206ee4   none      none          off        
-    oxp_ec458c3e-91ca-40f1-a2a3-3f4292c1f279/crypt/zone/oxz_crucible_9b9d58bd-44e6-4b70-80a4-e6a9262893ff            0a5bade3-3f2f-4385-b064-554b56f8bf8c   none      none          off        
-    oxp_0bf9d028-2b4a-4bff-82a1-6eb5fcefd985/crypt/zone/oxz_crucible_aa74c1b2-b4c1-4f36-8f01-9459ef23786b            e1db255d-4793-46bd-a1f3-f207be6b2839   none      none          off        
-    oxp_79787cd4-92da-4de5-bfd8-30a635521e10/crypt/zone/oxz_crucible_b6956e34-3c21-44d1-9ee2-cb7ee2e77c4e            2d2f2665-d556-4e65-9c53-d7fe573848a2   none      none          off        
-    oxp_19293a1d-fddc-40a7-88a4-ccafdb6f66d3/crypt/zone/oxz_crucible_eb58427d-599b-45dc-b316-8e4db7eec65e            26722393-82bf-442d-9725-030801a4d64c   none      none          off        
-    oxp_0bf9d028-2b4a-4bff-82a1-6eb5fcefd985/crypt/zone/oxz_crucible_pantry_97a785b8-d909-4fd4-92c1-9ba14bae603b     7b248682-95a2-4411-98b3-79fe6cb1a857   none      none          off        
-    oxp_0bf9d028-2b4a-4bff-82a1-6eb5fcefd985/crypt/zone/oxz_internal_dns_c259e8b9-1086-453a-8636-050639edeffb        30161ca3-c2d8-474b-906e-bd38fc912f84   none      none          off        
-    oxp_0bf9d028-2b4a-4bff-82a1-6eb5fcefd985/crypt/zone/oxz_nexus_c3c7b0bd-dce3-467b-919d-668cc6b06711               05b6bbbe-4c07-493e-8b92-4c8d4aeb1d66   none      none          off        
-    oxp_0bf9d028-2b4a-4bff-82a1-6eb5fcefd985/crypt/zone/oxz_ntp_bba31b23-d112-4cde-bd4a-635812c28c0e                 fadbc503-b72d-4862-a1fd-628c7ff599d1   none      none          off        
-    oxp_0bf9d028-2b4a-4bff-82a1-6eb5fcefd985/crypt/debug                                                             fb722d83-ddc2-4880-95a4-1ab12f4b95be   100 GiB   none          gzip-9     
-    oxp_19293a1d-fddc-40a7-88a4-ccafdb6f66d3/crypt/debug                                                             891a1ff4-66b1-4dc9-871c-be4a757bbd0f   100 GiB   none          gzip-9     
-    oxp_44484c44-477a-4676-8266-b98a00e80d79/crypt/debug                                                             3e3e18ad-d527-4b2e-b758-1eefdcfca44b   100 GiB   none          gzip-9     
-    oxp_79787cd4-92da-4de5-bfd8-30a635521e10/crypt/debug                                                             bd4efdbe-7128-4423-aacf-6cf35e5a914d   100 GiB   none          gzip-9     
-    oxp_9ae94c94-baae-477e-912a-60f0c4f3bd13/crypt/debug                                                             708d4e8b-3acf-44cf-87a2-275bb8fa0d96   100 GiB   none          gzip-9     
-    oxp_af85eec8-36b3-4b88-966d-a717b9b58fe5/crypt/debug                                                             98d65e73-01df-4525-a45d-acb2fc8d4a74   100 GiB   none          gzip-9     
-    oxp_ddfaaba3-dafe-4103-b868-e9843d29d346/crypt/debug                                                             8005f7c0-bab3-4b0a-9568-a5861c0a09bb   100 GiB   none          gzip-9     
-    oxp_ec458c3e-91ca-40f1-a2a3-3f4292c1f279/crypt/debug                                                             dae242d1-9535-4b08-b249-f030dde2c2fd   100 GiB   none          gzip-9     
-    oxp_f2fc7c4c-7966-449d-8ec3-5a70f460501d/crypt/debug                                                             6cea3508-8341-4093-abbb-c57d83cd87b4   100 GiB   none          gzip-9     
-    oxp_f635c28a-e5ca-4d22-ac94-d8f278a6ea0e/crypt/debug                                                             765b4728-8d6e-4fac-9a1b-ae2258d5c52b   100 GiB   none          gzip-9     
-+   oxp_19293a1d-fddc-40a7-88a4-ccafdb6f66d3/crypt/clickhouse_keeper                                                 cad1d0c3-ca80-4db4-ab36-b2034cf2383b   none      none          off        
-+   oxp_19293a1d-fddc-40a7-88a4-ccafdb6f66d3/crypt/zone/oxz_clickhouse_keeper_ad07794e-affa-4145-81fb-f45ed92e3fcd   d196c20e-0254-4716-8e04-c0c735d2ffaf   none      none          off        
+    oxp_0bf9d028-2b4a-4bff-82a1-6eb5fcefd985/crucible                                                                f18270c8-a39b-4579-be20-d2d1b80bba42   none      none          off        
+    oxp_19293a1d-fddc-40a7-88a4-ccafdb6f66d3/crucible                                                                06c2af14-055c-4041-aa26-9155f9f42661   none      none          off        
+    oxp_44484c44-477a-4676-8266-b98a00e80d79/crucible                                                                9deffea6-d340-4432-be3c-fad135dc29a5   none      none          off        
+    oxp_79787cd4-92da-4de5-bfd8-30a635521e10/crucible                                                                47ca08b9-b962-43e2-99d7-c2e0556c0f52   none      none          off        
+    oxp_9ae94c94-baae-477e-912a-60f0c4f3bd13/crucible                                                                b2e54e29-6915-4b6d-bc76-6f72e5c7c55a   none      none          off        
+    oxp_af85eec8-36b3-4b88-966d-a717b9b58fe5/crucible                                                                cb992d4e-7a69-4bcd-96c8-fe6e40989e24   none      none          off        
+    oxp_ddfaaba3-dafe-4103-b868-e9843d29d346/crucible                                                                68338fc3-2d8b-4419-b33d-4cce6fe9380d   none      none          off        
+    oxp_ec458c3e-91ca-40f1-a2a3-3f4292c1f279/crucible                                                                5294b99c-3eac-40e1-a35b-1f1cf2f0d6bf   none      none          off        
+    oxp_f2fc7c4c-7966-449d-8ec3-5a70f460501d/crucible                                                                31718dcf-ebd5-432c-a9e5-40abcb40931c   none      none          off        
+    oxp_f635c28a-e5ca-4d22-ac94-d8f278a6ea0e/crucible                                                                ff7ff4a9-21c4-499e-9ceb-8a00a4bb21bc   none      none          off        
+    oxp_0bf9d028-2b4a-4bff-82a1-6eb5fcefd985/crypt/clickhouse_keeper                                                 473adeb2-a57a-4240-82e9-88f2bebc1245   none      none          off        
+    oxp_0bf9d028-2b4a-4bff-82a1-6eb5fcefd985/crypt/clickhouse_server                                                 4363b5f8-9a67-49af-b49d-585e532fa7bc   none      none          off        
+    oxp_0bf9d028-2b4a-4bff-82a1-6eb5fcefd985/crypt/internal_dns                                                      56a1af5d-de86-46c5-9504-2d1ee70587c5   none      none          off        
+    oxp_0bf9d028-2b4a-4bff-82a1-6eb5fcefd985/crypt/zone                                                              003c1d4e-15bb-4fca-aa71-a7dff507b124   none      none          off        
+    oxp_19293a1d-fddc-40a7-88a4-ccafdb6f66d3/crypt/zone                                                              bf35a148-62f0-4f88-8f60-0a13747daba2   none      none          off        
+    oxp_44484c44-477a-4676-8266-b98a00e80d79/crypt/zone                                                              9b1bf42e-6f06-44cc-af5b-bff65d929322   none      none          off        
+    oxp_79787cd4-92da-4de5-bfd8-30a635521e10/crypt/zone                                                              2c9d6bce-0293-4364-b8c9-4bdea345490e   none      none          off        
+    oxp_9ae94c94-baae-477e-912a-60f0c4f3bd13/crypt/zone                                                              11726c79-6590-4831-8480-cf50e6322c8a   none      none          off        
+    oxp_af85eec8-36b3-4b88-966d-a717b9b58fe5/crypt/zone                                                              b463f0c2-3ae4-45f7-a38c-110731fcc5cb   none      none          off        
+    oxp_ddfaaba3-dafe-4103-b868-e9843d29d346/crypt/zone                                                              626abe12-321d-439b-ad8f-f8dfb2022f25   none      none          off        
+    oxp_ec458c3e-91ca-40f1-a2a3-3f4292c1f279/crypt/zone                                                              4200e2a7-0fd6-4631-9d60-21fd821193fe   none      none          off        
+    oxp_f2fc7c4c-7966-449d-8ec3-5a70f460501d/crypt/zone                                                              85f34c02-a35d-404e-8cde-bedf3e193b1c   none      none          off        
+    oxp_f635c28a-e5ca-4d22-ac94-d8f278a6ea0e/crypt/zone                                                              dd19c2c5-0bc9-48de-a116-b92503569092   none      none          off        
+    oxp_0bf9d028-2b4a-4bff-82a1-6eb5fcefd985/crypt/zone/oxz_clickhouse_keeper_31a66e47-6252-4f38-aa92-f48637da152c   49f52cc5-74df-4cfa-b7f0-07c7e810940d   none      none          off        
+    oxp_0bf9d028-2b4a-4bff-82a1-6eb5fcefd985/crypt/zone/oxz_clickhouse_server_6fedfc94-2ae6-4cc7-a968-5185207284f4   f1143eb2-0685-4708-a471-968a58f93bad   none      none          off        
+    oxp_f635c28a-e5ca-4d22-ac94-d8f278a6ea0e/crypt/zone/oxz_crucible_06b45c33-9a90-408b-8534-f94ab6df8a42            9e0a360d-c158-417f-a45f-9d29ee67cdce   none      none          off        
+    oxp_19293a1d-fddc-40a7-88a4-ccafdb6f66d3/crypt/zone/oxz_crucible_32999e20-ed5c-4c25-b4bd-41a3fbaf1445            dd7a45b8-3175-4744-8b99-ce19b22bb8ce   none      none          off        
+    oxp_9ae94c94-baae-477e-912a-60f0c4f3bd13/crypt/zone/oxz_crucible_4a037563-f969-4028-8384-164bdf308c3c            0d5b2580-7190-4bcc-9982-5012dac51f05   none      none          off        
+    oxp_44484c44-477a-4676-8266-b98a00e80d79/crypt/zone/oxz_crucible_6564394d-2c51-4252-b3b1-f5f88a72d7c3            26a1cc86-f717-4a12-b644-5acd168843aa   none      none          off        
+    oxp_0bf9d028-2b4a-4bff-82a1-6eb5fcefd985/crypt/zone/oxz_crucible_87427b40-5114-49cd-96bd-63edd61fce90            e7364079-58e3-4b36-81a7-b9e08f2a8fff   none      none          off        
+    oxp_ddfaaba3-dafe-4103-b868-e9843d29d346/crypt/zone/oxz_crucible_8acdc189-d4da-45a7-b306-23b43e86f695            6fa84a9c-0161-40c9-b596-f3b2c679ef99   none      none          off        
+    oxp_ec458c3e-91ca-40f1-a2a3-3f4292c1f279/crypt/zone/oxz_crucible_971ce633-cdc4-48cf-983e-dc272c1639eb            cb8ca8a6-6a00-4aae-8702-1493e1c3b166   none      none          off        
+    oxp_af85eec8-36b3-4b88-966d-a717b9b58fe5/crypt/zone/oxz_crucible_cfa6af7a-bf53-4fe6-bf1a-7ce3812d15c4            27323e49-f61e-4a73-bc87-f8d9f5082143   none      none          off        
+    oxp_f2fc7c4c-7966-449d-8ec3-5a70f460501d/crypt/zone/oxz_crucible_e145fb8e-df12-4df9-8049-b146ae0275be            35c46d33-4e08-4fad-90d2-3da719538ef2   none      none          off        
+    oxp_79787cd4-92da-4de5-bfd8-30a635521e10/crypt/zone/oxz_crucible_f1d08ae7-68fe-4799-8f31-f1100887c6f0            02863a62-7624-4017-9269-412910ab73f0   none      none          off        
+    oxp_0bf9d028-2b4a-4bff-82a1-6eb5fcefd985/crypt/zone/oxz_crucible_pantry_f9e18694-fdff-46a3-b40d-570d43206f48     3cb3f346-9879-4023-b919-55c4172bbf23   none      none          off        
+    oxp_0bf9d028-2b4a-4bff-82a1-6eb5fcefd985/crypt/zone/oxz_internal_dns_a00d8ae3-d1db-4aef-9174-3ff867af5e9e        c2d9b145-5e15-47be-a835-7e1f51f27679   none      none          off        
+    oxp_0bf9d028-2b4a-4bff-82a1-6eb5fcefd985/crypt/zone/oxz_nexus_8ccafc1f-97f9-4da7-bb04-d346213387ce               dcc3603b-b160-42d9-a743-11075c3b6941   none      none          off        
+    oxp_0bf9d028-2b4a-4bff-82a1-6eb5fcefd985/crypt/zone/oxz_ntp_a1797f1d-2d2a-4396-9ab5-044630b41c35                 5a70b3fe-9fad-4c17-982b-272b8595c2e8   none      none          off        
+    oxp_0bf9d028-2b4a-4bff-82a1-6eb5fcefd985/crypt/debug                                                             4e4b2f99-dc01-4793-a37a-072d942da264   100 GiB   none          gzip-9     
+    oxp_19293a1d-fddc-40a7-88a4-ccafdb6f66d3/crypt/debug                                                             8573903d-9610-4084-b0c6-ffcbb5d96c39   100 GiB   none          gzip-9     
+    oxp_44484c44-477a-4676-8266-b98a00e80d79/crypt/debug                                                             540272e1-99d2-4d2e-9d3d-032014b0e6d9   100 GiB   none          gzip-9     
+    oxp_79787cd4-92da-4de5-bfd8-30a635521e10/crypt/debug                                                             4adf2ef6-2694-4aac-aabe-688bca767092   100 GiB   none          gzip-9     
+    oxp_9ae94c94-baae-477e-912a-60f0c4f3bd13/crypt/debug                                                             7e9d012a-6d8e-475e-805e-65985a66ffcd   100 GiB   none          gzip-9     
+    oxp_af85eec8-36b3-4b88-966d-a717b9b58fe5/crypt/debug                                                             2189574d-9a73-4d25-858e-1084d57b59a8   100 GiB   none          gzip-9     
+    oxp_ddfaaba3-dafe-4103-b868-e9843d29d346/crypt/debug                                                             3cf0580b-4e1d-4ff9-bc22-4dc51ca9a53b   100 GiB   none          gzip-9     
+    oxp_ec458c3e-91ca-40f1-a2a3-3f4292c1f279/crypt/debug                                                             f499c5f8-b62f-493d-858a-8d33f7db81ff   100 GiB   none          gzip-9     
+    oxp_f2fc7c4c-7966-449d-8ec3-5a70f460501d/crypt/debug                                                             c16ff3c0-3282-46de-a620-49c6b1e3f882   100 GiB   none          gzip-9     
+    oxp_f635c28a-e5ca-4d22-ac94-d8f278a6ea0e/crypt/debug                                                             8dde6eee-f28e-4b55-8c11-525884ec81e5   100 GiB   none          gzip-9     
++   oxp_19293a1d-fddc-40a7-88a4-ccafdb6f66d3/crypt/clickhouse_keeper                                                 882d4fee-d6d4-455f-9dc1-de3637cd29d0   none      none          off        
++   oxp_19293a1d-fddc-40a7-88a4-ccafdb6f66d3/crypt/zone/oxz_clickhouse_keeper_e222f1c0-39ca-463a-88ad-ebfb6022fd1a   fbf9198e-996a-4194-af5b-c4e95ea4286d   none      none          off        
 
 
     omicron zones generation 3 -> 4:
     -----------------------------------------------------------------------------------------------
     zone type           zone id                                disposition   underlay IP           
     -----------------------------------------------------------------------------------------------
-    clickhouse_keeper   b36c16d5-de6e-411a-a32a-d35a26f2e151   in service    fd00:1122:3344:103::2e
-    clickhouse_server   71be6bff-666a-4f2b-a7dc-d80a88a71af5   in service    fd00:1122:3344:103::2f
-    crucible            1a92bb17-6477-46fc-9784-1d2a418d6e14   in service    fd00:1122:3344:103::2a
-    crucible            26115267-8333-4711-924e-d05acf601827   in service    fd00:1122:3344:103::29
-    crucible            41af4ef6-d21b-4271-bfcb-524f4146784a   in service    fd00:1122:3344:103::28
-    crucible            487bde8c-a692-416c-be70-efef7f169fce   in service    fd00:1122:3344:103::26
-    crucible            704a17e0-bc9d-43b9-a91e-b1ca37a23d0d   in service    fd00:1122:3344:103::2c
-    crucible            93535f54-4919-4c4d-9a07-f7ab6245c01f   in service    fd00:1122:3344:103::2d
-    crucible            9b9d58bd-44e6-4b70-80a4-e6a9262893ff   in service    fd00:1122:3344:103::2b
-    crucible            aa74c1b2-b4c1-4f36-8f01-9459ef23786b   in service    fd00:1122:3344:103::24
-    crucible            b6956e34-3c21-44d1-9ee2-cb7ee2e77c4e   in service    fd00:1122:3344:103::27
-    crucible            eb58427d-599b-45dc-b316-8e4db7eec65e   in service    fd00:1122:3344:103::25
-    crucible_pantry     97a785b8-d909-4fd4-92c1-9ba14bae603b   in service    fd00:1122:3344:103::23
-    internal_dns        c259e8b9-1086-453a-8636-050639edeffb   in service    fd00:1122:3344:2::1   
-    internal_ntp        bba31b23-d112-4cde-bd4a-635812c28c0e   in service    fd00:1122:3344:103::21
-    nexus               c3c7b0bd-dce3-467b-919d-668cc6b06711   in service    fd00:1122:3344:103::22
-+   clickhouse_keeper   ad07794e-affa-4145-81fb-f45ed92e3fcd   in service    fd00:1122:3344:103::30
+    clickhouse_keeper   31a66e47-6252-4f38-aa92-f48637da152c   in service    fd00:1122:3344:103::2e
+    clickhouse_server   6fedfc94-2ae6-4cc7-a968-5185207284f4   in service    fd00:1122:3344:103::2f
+    crucible            06b45c33-9a90-408b-8534-f94ab6df8a42   in service    fd00:1122:3344:103::2d
+    crucible            32999e20-ed5c-4c25-b4bd-41a3fbaf1445   in service    fd00:1122:3344:103::25
+    crucible            4a037563-f969-4028-8384-164bdf308c3c   in service    fd00:1122:3344:103::28
+    crucible            6564394d-2c51-4252-b3b1-f5f88a72d7c3   in service    fd00:1122:3344:103::26
+    crucible            87427b40-5114-49cd-96bd-63edd61fce90   in service    fd00:1122:3344:103::24
+    crucible            8acdc189-d4da-45a7-b306-23b43e86f695   in service    fd00:1122:3344:103::2a
+    crucible            971ce633-cdc4-48cf-983e-dc272c1639eb   in service    fd00:1122:3344:103::2b
+    crucible            cfa6af7a-bf53-4fe6-bf1a-7ce3812d15c4   in service    fd00:1122:3344:103::29
+    crucible            e145fb8e-df12-4df9-8049-b146ae0275be   in service    fd00:1122:3344:103::2c
+    crucible            f1d08ae7-68fe-4799-8f31-f1100887c6f0   in service    fd00:1122:3344:103::27
+    crucible_pantry     f9e18694-fdff-46a3-b40d-570d43206f48   in service    fd00:1122:3344:103::23
+    internal_dns        a00d8ae3-d1db-4aef-9174-3ff867af5e9e   in service    fd00:1122:3344:2::1   
+    internal_ntp        a1797f1d-2d2a-4396-9ab5-044630b41c35   in service    fd00:1122:3344:103::21
+    nexus               8ccafc1f-97f9-4da7-bb04-d346213387ce   in service    fd00:1122:3344:103::22
++   clickhouse_keeper   e222f1c0-39ca-463a-88ad-ebfb6022fd1a   in service    fd00:1122:3344:103::30
 
 
   sled be531a62-9897-430d-acd2-ce14b4632627 (active):
@@ -220,80 +220,80 @@ to:   blueprint 2886dab5-61a2-46b4-87af-bc7aeb44cccb
     -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
     dataset name                                                                                                     dataset uuid                           quota     reservation   compression
     -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
-    oxp_2a76ab1a-fb16-412d-93f9-b8cd9aa94e85/crucible                                                                431cfe4a-5756-40f4-8a9c-b70ae1227f1e   none      none          off        
-    oxp_2de2bf7e-c679-4b2b-b373-908e9d3ffbfc/crucible                                                                1123f86b-169c-40df-8ed1-95c3def65e30   none      none          off        
-    oxp_2f02a5c6-fcf5-4b5a-bc7d-7f65369918ba/crucible                                                                afa41d1a-3fc1-4723-835d-61d13db33cfe   none      none          off        
-    oxp_32041dbf-e58d-4f32-840d-923d3d3b68af/crucible                                                                da067282-0ae9-4861-8b78-b639622508af   none      none          off        
-    oxp_5f88adff-bb50-4dc1-bbfb-5a410c753ed5/crucible                                                                fcb937be-3b91-4ae7-9e25-a69808eeb07f   none      none          off        
-    oxp_74d64eb9-bf69-4782-af16-2d3a761ca171/crucible                                                                2854cb42-e5b9-4773-bd6e-6ec85d33a174   none      none          off        
-    oxp_b3c231c9-b2a5-4267-b4bf-9651881b91a5/crucible                                                                aa8f925e-6c3a-40d2-ae2d-946324a7d612   none      none          off        
-    oxp_bca80b95-8dca-4a3b-b24d-d44b6a9ff71b/crucible                                                                755ad19c-d29b-4e3c-9c13-63b56a407765   none      none          off        
-    oxp_db16345e-427a-4c8e-9032-17270f729308/crucible                                                                be3cf2f7-5388-4cd6-8119-ecf316c6052e   none      none          off        
-    oxp_e3b45593-8f0c-47b2-a381-802a7dad1f54/crucible                                                                a2391107-7408-4e0c-a694-3fd073fa09df   none      none          off        
-    oxp_2a76ab1a-fb16-412d-93f9-b8cd9aa94e85/crypt/clickhouse_keeper                                                 c16a00f5-8830-400d-89e0-9a77cce8780e   none      none          off        
-    oxp_2a76ab1a-fb16-412d-93f9-b8cd9aa94e85/crypt/clickhouse_server                                                 ce930007-8ed6-4675-a24a-57c227950d43   none      none          off        
-    oxp_2a76ab1a-fb16-412d-93f9-b8cd9aa94e85/crypt/internal_dns                                                      7be88e8f-06d3-49f7-a6d9-5c586f13716c   none      none          off        
-    oxp_2a76ab1a-fb16-412d-93f9-b8cd9aa94e85/crypt/zone                                                              37405860-deb4-4f2f-b770-ab8b83175d8c   none      none          off        
-    oxp_2de2bf7e-c679-4b2b-b373-908e9d3ffbfc/crypt/zone                                                              bbb78481-c7e5-44a6-85ae-37e363827e9f   none      none          off        
-    oxp_2f02a5c6-fcf5-4b5a-bc7d-7f65369918ba/crypt/zone                                                              38103edf-a98f-46ca-94ea-3404268ea935   none      none          off        
-    oxp_32041dbf-e58d-4f32-840d-923d3d3b68af/crypt/zone                                                              3f1adfcf-9a2a-41db-9e1a-a2e13ff8a7dd   none      none          off        
-    oxp_5f88adff-bb50-4dc1-bbfb-5a410c753ed5/crypt/zone                                                              5c620f9c-454b-451b-99ca-47c3d94df493   none      none          off        
-    oxp_74d64eb9-bf69-4782-af16-2d3a761ca171/crypt/zone                                                              13f8be82-85e9-43ac-985b-e7a51a910c41   none      none          off        
-    oxp_b3c231c9-b2a5-4267-b4bf-9651881b91a5/crypt/zone                                                              9f1f99c7-e6c5-4bbc-9de5-15252b532914   none      none          off        
-    oxp_bca80b95-8dca-4a3b-b24d-d44b6a9ff71b/crypt/zone                                                              2747bb48-2fb7-4999-a63c-5ba5e35e0a10   none      none          off        
-    oxp_db16345e-427a-4c8e-9032-17270f729308/crypt/zone                                                              f7ddacf4-edc7-46ba-9b74-d588bd62505e   none      none          off        
-    oxp_e3b45593-8f0c-47b2-a381-802a7dad1f54/crypt/zone                                                              64e62d15-e813-461d-9a50-403d9bd1df7c   none      none          off        
-    oxp_2a76ab1a-fb16-412d-93f9-b8cd9aa94e85/crypt/zone/oxz_clickhouse_keeper_f3279a8b-32fa-4426-b946-08aff9ded482   26c79a0e-a2e4-4093-ba43-5e7979609651   none      none          off        
-    oxp_2a76ab1a-fb16-412d-93f9-b8cd9aa94e85/crypt/zone/oxz_clickhouse_server_122e30d3-d541-49b5-88de-1543b38123cc   748c9607-71dd-4f81-be08-c1eee262f69c   none      none          off        
-    oxp_bca80b95-8dca-4a3b-b24d-d44b6a9ff71b/crypt/zone/oxz_crucible_0a160b89-6288-44f5-9908-33589094628e            53a623d2-9ffc-48fb-871d-23bd52e0f4dd   none      none          off        
-    oxp_2f02a5c6-fcf5-4b5a-bc7d-7f65369918ba/crypt/zone/oxz_crucible_2cb036bd-6056-4547-af65-aa6c0c1e4d6e            c6c9e491-ce4d-4dc4-82be-e394fa1e82e2   none      none          off        
-    oxp_2de2bf7e-c679-4b2b-b373-908e9d3ffbfc/crypt/zone/oxz_crucible_37c72edc-6acd-4c2d-ab76-d1c88e1f01f5            9b49fc13-4d2c-423e-9839-f6e1d0bffc6e   none      none          off        
-    oxp_db16345e-427a-4c8e-9032-17270f729308/crypt/zone/oxz_crucible_5fb4b72f-bf1b-47c7-a2e4-dbdafcdb47f5            1d73fc1f-81fc-4e06-9b52-686596ac0f6c   none      none          off        
-    oxp_5f88adff-bb50-4dc1-bbfb-5a410c753ed5/crypt/zone/oxz_crucible_6ae471b1-1dd8-460e-a2a5-3ea796f746d5            98b66132-d99e-42e2-8517-5860412c61b1   none      none          off        
-    oxp_2a76ab1a-fb16-412d-93f9-b8cd9aa94e85/crypt/zone/oxz_crucible_75cccfab-ea70-4596-a685-ab9bd5e540a1            e2ff081e-c5a4-42c3-8d95-969e2b9b7b31   none      none          off        
-    oxp_e3b45593-8f0c-47b2-a381-802a7dad1f54/crypt/zone/oxz_crucible_8a36ef67-bf66-40b9-a2f4-34ac70e90e39            c44e20e1-7cce-46df-ba71-db7fb3e3a5ff   none      none          off        
-    oxp_74d64eb9-bf69-4782-af16-2d3a761ca171/crypt/zone/oxz_crucible_b6a9674e-8b42-4d67-954f-3e957db298dd            e7c2d833-b6a1-469f-b52f-8bbb45e9a30e   none      none          off        
-    oxp_b3c231c9-b2a5-4267-b4bf-9651881b91a5/crypt/zone/oxz_crucible_c79e017b-7e27-4ff5-be14-3673f8cb2279            3544adde-a808-45c0-ae19-08b4f65e3ad4   none      none          off        
-    oxp_32041dbf-e58d-4f32-840d-923d3d3b68af/crypt/zone/oxz_crucible_e52381c1-d7ab-402f-a9a8-bb52fbb614af            a0251fdc-166b-4476-95d4-f7fd58fdaf76   none      none          off        
-    oxp_2a76ab1a-fb16-412d-93f9-b8cd9aa94e85/crypt/zone/oxz_crucible_pantry_1432df56-4a7b-4271-9b24-a8a3183a95a7     452dad91-0c11-4dfa-96fb-dfb0cfa1d17c   none      none          off        
-    oxp_2a76ab1a-fb16-412d-93f9-b8cd9aa94e85/crypt/zone/oxz_internal_dns_832c71a1-357d-482b-8661-3193d59ed776        08588a53-0f1d-4631-a1ef-8fa34098fbf6   none      none          off        
-    oxp_2a76ab1a-fb16-412d-93f9-b8cd9aa94e85/crypt/zone/oxz_nexus_da39dead-64e2-45b6-9d01-d99584504dfd               45dc03ec-d0e0-429a-a099-7fc6ea6dfb85   none      none          off        
-    oxp_2a76ab1a-fb16-412d-93f9-b8cd9aa94e85/crypt/zone/oxz_ntp_816afef9-e5cd-40ba-8cc5-71e783943e43                 6f5ba0fc-1b43-4a40-ba5a-3abf11eae62b   none      none          off        
-    oxp_2a76ab1a-fb16-412d-93f9-b8cd9aa94e85/crypt/debug                                                             c55ba154-4f4b-48a5-997b-2a1579671c74   100 GiB   none          gzip-9     
-    oxp_2de2bf7e-c679-4b2b-b373-908e9d3ffbfc/crypt/debug                                                             071d678d-9376-4c3b-8e1f-825d27bcae3a   100 GiB   none          gzip-9     
-    oxp_2f02a5c6-fcf5-4b5a-bc7d-7f65369918ba/crypt/debug                                                             daeded95-0145-4b97-b1fb-60d44856d1e4   100 GiB   none          gzip-9     
-    oxp_32041dbf-e58d-4f32-840d-923d3d3b68af/crypt/debug                                                             80d0697d-4ebe-4856-b7bf-78ff811eb00b   100 GiB   none          gzip-9     
-    oxp_5f88adff-bb50-4dc1-bbfb-5a410c753ed5/crypt/debug                                                             dd239ff5-a617-4eb1-ac6d-16eb76c2c849   100 GiB   none          gzip-9     
-    oxp_74d64eb9-bf69-4782-af16-2d3a761ca171/crypt/debug                                                             b9e71882-7f71-4a5e-be9c-7df560c75000   100 GiB   none          gzip-9     
-    oxp_b3c231c9-b2a5-4267-b4bf-9651881b91a5/crypt/debug                                                             bae0ee1b-b3a3-4c4c-96ee-53b8b4cd837b   100 GiB   none          gzip-9     
-    oxp_bca80b95-8dca-4a3b-b24d-d44b6a9ff71b/crypt/debug                                                             f2df23eb-672a-41b5-89e4-26c9feb50c7c   100 GiB   none          gzip-9     
-    oxp_db16345e-427a-4c8e-9032-17270f729308/crypt/debug                                                             e658be5b-df77-41fb-a000-5a924ac0b3da   100 GiB   none          gzip-9     
-    oxp_e3b45593-8f0c-47b2-a381-802a7dad1f54/crypt/debug                                                             96798a17-be94-44bb-9e12-2eb458e9a5ba   100 GiB   none          gzip-9     
-+   oxp_2de2bf7e-c679-4b2b-b373-908e9d3ffbfc/crypt/clickhouse_keeper                                                 3682c931-5332-45ef-9885-3d2dcfb325f6   none      none          off        
-+   oxp_2de2bf7e-c679-4b2b-b373-908e9d3ffbfc/crypt/zone/oxz_clickhouse_keeper_81a4f9fd-e502-42c2-bf9c-29dd6918fd46   6aaeeb8d-ee87-43a2-b1ef-22e5f5224842   none      none          off        
+    oxp_2a76ab1a-fb16-412d-93f9-b8cd9aa94e85/crucible                                                                c73b47ac-ad1f-4cd1-b449-f220b5ad8104   none      none          off        
+    oxp_2de2bf7e-c679-4b2b-b373-908e9d3ffbfc/crucible                                                                813c7aac-695b-49ce-8bc5-f4cdbfc04b38   none      none          off        
+    oxp_2f02a5c6-fcf5-4b5a-bc7d-7f65369918ba/crucible                                                                e5da836d-fffb-4435-8500-889c05b04689   none      none          off        
+    oxp_32041dbf-e58d-4f32-840d-923d3d3b68af/crucible                                                                9f8d056c-3e84-4474-b9c7-5b7a890a8a7b   none      none          off        
+    oxp_5f88adff-bb50-4dc1-bbfb-5a410c753ed5/crucible                                                                e93cfc01-9581-4f6e-b77c-eb6300ca6ffb   none      none          off        
+    oxp_74d64eb9-bf69-4782-af16-2d3a761ca171/crucible                                                                f54d6e59-67a1-458b-8e66-6dc3b2adb755   none      none          off        
+    oxp_b3c231c9-b2a5-4267-b4bf-9651881b91a5/crucible                                                                6604dd1b-5f21-475d-952a-894717512d1b   none      none          off        
+    oxp_bca80b95-8dca-4a3b-b24d-d44b6a9ff71b/crucible                                                                05cb728f-f6b9-4132-922d-fe249b1ba736   none      none          off        
+    oxp_db16345e-427a-4c8e-9032-17270f729308/crucible                                                                500f8d46-a32d-4bd1-8f2c-cb9d36822660   none      none          off        
+    oxp_e3b45593-8f0c-47b2-a381-802a7dad1f54/crucible                                                                66c673a1-e8d8-4863-b368-a7ea292555fb   none      none          off        
+    oxp_2a76ab1a-fb16-412d-93f9-b8cd9aa94e85/crypt/clickhouse_keeper                                                 6c5a6622-5f75-45a0-a9e8-4b513f5ac352   none      none          off        
+    oxp_2a76ab1a-fb16-412d-93f9-b8cd9aa94e85/crypt/clickhouse_server                                                 f8706468-85ac-4f9f-b41d-ff7c3a17ee5f   none      none          off        
+    oxp_2a76ab1a-fb16-412d-93f9-b8cd9aa94e85/crypt/internal_dns                                                      03de030d-d958-4ce5-86d2-368fa88e0bd8   none      none          off        
+    oxp_2a76ab1a-fb16-412d-93f9-b8cd9aa94e85/crypt/zone                                                              4c3c89bd-21cf-4986-b012-e89e4e1c1ac4   none      none          off        
+    oxp_2de2bf7e-c679-4b2b-b373-908e9d3ffbfc/crypt/zone                                                              ff4a77a2-528a-4c70-a5b9-f0093c95697b   none      none          off        
+    oxp_2f02a5c6-fcf5-4b5a-bc7d-7f65369918ba/crypt/zone                                                              676fc8c5-743b-48ca-99fd-2f2379c83890   none      none          off        
+    oxp_32041dbf-e58d-4f32-840d-923d3d3b68af/crypt/zone                                                              63362c89-4b42-4649-9ebe-43e19a5c0e51   none      none          off        
+    oxp_5f88adff-bb50-4dc1-bbfb-5a410c753ed5/crypt/zone                                                              6f83a31e-1181-418f-92b0-d0534e9ae6dd   none      none          off        
+    oxp_74d64eb9-bf69-4782-af16-2d3a761ca171/crypt/zone                                                              260ffd7d-4da5-4657-9158-ba7e1eae5971   none      none          off        
+    oxp_b3c231c9-b2a5-4267-b4bf-9651881b91a5/crypt/zone                                                              ed4c8570-3951-4f79-b27e-da73150609be   none      none          off        
+    oxp_bca80b95-8dca-4a3b-b24d-d44b6a9ff71b/crypt/zone                                                              e5dcf165-3ebb-40a2-b16f-a07b036a6533   none      none          off        
+    oxp_db16345e-427a-4c8e-9032-17270f729308/crypt/zone                                                              dd27be6b-214d-4022-a99d-2a7d12e7d8bb   none      none          off        
+    oxp_e3b45593-8f0c-47b2-a381-802a7dad1f54/crypt/zone                                                              b7500d95-2499-48fc-a7d6-2460d61e197a   none      none          off        
+    oxp_2a76ab1a-fb16-412d-93f9-b8cd9aa94e85/crypt/zone/oxz_clickhouse_keeper_7aa82b80-0c37-4f20-9398-bfce4707f327   0bf9cddb-1911-495b-8aad-09b7eea5fff4   none      none          off        
+    oxp_2a76ab1a-fb16-412d-93f9-b8cd9aa94e85/crypt/zone/oxz_clickhouse_server_812be70a-f237-47d5-ab49-f9450fe948db   292f53fc-27bb-4cc4-a61b-7d02c978149c   none      none          off        
+    oxp_32041dbf-e58d-4f32-840d-923d3d3b68af/crypt/zone/oxz_crucible_0b0e12fd-2800-4203-acb6-24e6e976271c            cf46ee68-f945-4af6-a647-4d612c1f05be   none      none          off        
+    oxp_2de2bf7e-c679-4b2b-b373-908e9d3ffbfc/crypt/zone/oxz_crucible_1a02d419-10c4-4326-b34e-eb2b1bd90bd7            2a439799-3f16-46df-ba1b-7ea29edd392d   none      none          off        
+    oxp_2a76ab1a-fb16-412d-93f9-b8cd9aa94e85/crypt/zone/oxz_crucible_56e18c31-f630-4643-ad5c-1fede34f35de            c30be90e-20cf-46c6-bb4a-b65d2c407878   none      none          off        
+    oxp_b3c231c9-b2a5-4267-b4bf-9651881b91a5/crypt/zone/oxz_crucible_5ea86015-8f62-40aa-b3b2-c659f17ee510            6289ea03-b2c9-4470-b7ba-b935450aa764   none      none          off        
+    oxp_5f88adff-bb50-4dc1-bbfb-5a410c753ed5/crypt/zone/oxz_crucible_78965849-e6e3-4250-a66a-dc50512fad34            43b36ba3-e516-4732-be8b-8cd2ca9de93c   none      none          off        
+    oxp_74d64eb9-bf69-4782-af16-2d3a761ca171/crypt/zone/oxz_crucible_90c484e5-69d3-4636-9c64-6a878f593d33            7cc8018e-323f-4d35-bb33-fcf557b9dace   none      none          off        
+    oxp_db16345e-427a-4c8e-9032-17270f729308/crypt/zone/oxz_crucible_a3901043-fa2a-4ef7-a40e-6ef0e5fd189f            88fd4e5a-50fd-43c7-8a75-0ad4376bd564   none      none          off        
+    oxp_2f02a5c6-fcf5-4b5a-bc7d-7f65369918ba/crypt/zone/oxz_crucible_be9fd98a-6422-4890-a32b-42d42d1c8957            932cbb0d-b1d0-423d-87b6-9dce8ddb6338   none      none          off        
+    oxp_e3b45593-8f0c-47b2-a381-802a7dad1f54/crypt/zone/oxz_crucible_bf71d1a8-9e65-479d-8920-0be8e3422ac5            fd0ce816-4da0-4490-be32-4d38fb78c13c   none      none          off        
+    oxp_bca80b95-8dca-4a3b-b24d-d44b6a9ff71b/crypt/zone/oxz_crucible_eb4176ea-456b-48f6-b284-7b76da0bf4a1            704ea6b5-0ffc-443f-ae8a-482666f8277c   none      none          off        
+    oxp_2a76ab1a-fb16-412d-93f9-b8cd9aa94e85/crypt/zone/oxz_crucible_pantry_417c97a4-fe25-439d-8359-3f7062981923     8957a276-6d4e-4c58-a856-d7c5433806e1   none      none          off        
+    oxp_2a76ab1a-fb16-412d-93f9-b8cd9aa94e85/crypt/zone/oxz_internal_dns_f2bbaa79-0eab-4b91-a404-dad4c19b58c2        fe0f566f-3cff-43ef-960c-649c27746c56   none      none          off        
+    oxp_2a76ab1a-fb16-412d-93f9-b8cd9aa94e85/crypt/zone/oxz_nexus_33ba37c4-2535-4095-a7e9-c69937fc584d               77d0cd16-b6e3-484d-962f-0477cd242482   none      none          off        
+    oxp_2a76ab1a-fb16-412d-93f9-b8cd9aa94e85/crypt/zone/oxz_ntp_47eab17a-4dd4-4467-90b2-f643f465cf34                 4eaf1849-1fe4-415c-bdc7-4cc04cac20ce   none      none          off        
+    oxp_2a76ab1a-fb16-412d-93f9-b8cd9aa94e85/crypt/debug                                                             c5b8f4f9-bd10-45b8-a9f3-93adf1402ecc   100 GiB   none          gzip-9     
+    oxp_2de2bf7e-c679-4b2b-b373-908e9d3ffbfc/crypt/debug                                                             43abf982-d457-46d1-8566-8047d2a78a41   100 GiB   none          gzip-9     
+    oxp_2f02a5c6-fcf5-4b5a-bc7d-7f65369918ba/crypt/debug                                                             1b6a1722-d9f7-48ea-b351-5bc8bad4fd07   100 GiB   none          gzip-9     
+    oxp_32041dbf-e58d-4f32-840d-923d3d3b68af/crypt/debug                                                             8be43fb0-00e7-4748-9a1a-ace9772d8a83   100 GiB   none          gzip-9     
+    oxp_5f88adff-bb50-4dc1-bbfb-5a410c753ed5/crypt/debug                                                             2ccb3aa9-f0ef-4fd4-9fd7-43b4a88b8d6b   100 GiB   none          gzip-9     
+    oxp_74d64eb9-bf69-4782-af16-2d3a761ca171/crypt/debug                                                             56759eb6-69e9-46a3-b44c-fc748cd506aa   100 GiB   none          gzip-9     
+    oxp_b3c231c9-b2a5-4267-b4bf-9651881b91a5/crypt/debug                                                             76fffbd2-9c74-46b5-8033-f442be1256f5   100 GiB   none          gzip-9     
+    oxp_bca80b95-8dca-4a3b-b24d-d44b6a9ff71b/crypt/debug                                                             c13a3d71-1241-42d1-95a8-d720c20ee2c4   100 GiB   none          gzip-9     
+    oxp_db16345e-427a-4c8e-9032-17270f729308/crypt/debug                                                             f030ef33-cad2-4760-9431-1907b797161b   100 GiB   none          gzip-9     
+    oxp_e3b45593-8f0c-47b2-a381-802a7dad1f54/crypt/debug                                                             947b2823-3dca-4b56-9324-f476e2c1c6da   100 GiB   none          gzip-9     
++   oxp_2de2bf7e-c679-4b2b-b373-908e9d3ffbfc/crypt/clickhouse_keeper                                                 f6464cd8-84bc-4bae-8386-c0a5a82aab95   none      none          off        
++   oxp_2de2bf7e-c679-4b2b-b373-908e9d3ffbfc/crypt/zone/oxz_clickhouse_keeper_60cf5091-670b-48c9-a729-b82c5e7683ca   8ee3f0bb-d102-4a00-af81-72e2f284878b   none      none          off        
 
 
     omicron zones generation 3 -> 4:
     -----------------------------------------------------------------------------------------------
     zone type           zone id                                disposition   underlay IP           
     -----------------------------------------------------------------------------------------------
-    clickhouse_keeper   f3279a8b-32fa-4426-b946-08aff9ded482   in service    fd00:1122:3344:102::2e
-    clickhouse_server   122e30d3-d541-49b5-88de-1543b38123cc   in service    fd00:1122:3344:102::2f
-    crucible            0a160b89-6288-44f5-9908-33589094628e   in service    fd00:1122:3344:102::2b
-    crucible            2cb036bd-6056-4547-af65-aa6c0c1e4d6e   in service    fd00:1122:3344:102::26
-    crucible            37c72edc-6acd-4c2d-ab76-d1c88e1f01f5   in service    fd00:1122:3344:102::25
-    crucible            5fb4b72f-bf1b-47c7-a2e4-dbdafcdb47f5   in service    fd00:1122:3344:102::2c
-    crucible            6ae471b1-1dd8-460e-a2a5-3ea796f746d5   in service    fd00:1122:3344:102::28
-    crucible            75cccfab-ea70-4596-a685-ab9bd5e540a1   in service    fd00:1122:3344:102::24
-    crucible            8a36ef67-bf66-40b9-a2f4-34ac70e90e39   in service    fd00:1122:3344:102::2d
-    crucible            b6a9674e-8b42-4d67-954f-3e957db298dd   in service    fd00:1122:3344:102::29
-    crucible            c79e017b-7e27-4ff5-be14-3673f8cb2279   in service    fd00:1122:3344:102::2a
-    crucible            e52381c1-d7ab-402f-a9a8-bb52fbb614af   in service    fd00:1122:3344:102::27
-    crucible_pantry     1432df56-4a7b-4271-9b24-a8a3183a95a7   in service    fd00:1122:3344:102::23
-    internal_dns        832c71a1-357d-482b-8661-3193d59ed776   in service    fd00:1122:3344:3::1   
-    internal_ntp        816afef9-e5cd-40ba-8cc5-71e783943e43   in service    fd00:1122:3344:102::21
-    nexus               da39dead-64e2-45b6-9d01-d99584504dfd   in service    fd00:1122:3344:102::22
-+   clickhouse_keeper   81a4f9fd-e502-42c2-bf9c-29dd6918fd46   in service    fd00:1122:3344:102::30
+    clickhouse_keeper   7aa82b80-0c37-4f20-9398-bfce4707f327   in service    fd00:1122:3344:102::2e
+    clickhouse_server   812be70a-f237-47d5-ab49-f9450fe948db   in service    fd00:1122:3344:102::2f
+    crucible            0b0e12fd-2800-4203-acb6-24e6e976271c   in service    fd00:1122:3344:102::27
+    crucible            1a02d419-10c4-4326-b34e-eb2b1bd90bd7   in service    fd00:1122:3344:102::25
+    crucible            56e18c31-f630-4643-ad5c-1fede34f35de   in service    fd00:1122:3344:102::24
+    crucible            5ea86015-8f62-40aa-b3b2-c659f17ee510   in service    fd00:1122:3344:102::2a
+    crucible            78965849-e6e3-4250-a66a-dc50512fad34   in service    fd00:1122:3344:102::28
+    crucible            90c484e5-69d3-4636-9c64-6a878f593d33   in service    fd00:1122:3344:102::29
+    crucible            a3901043-fa2a-4ef7-a40e-6ef0e5fd189f   in service    fd00:1122:3344:102::2c
+    crucible            be9fd98a-6422-4890-a32b-42d42d1c8957   in service    fd00:1122:3344:102::26
+    crucible            bf71d1a8-9e65-479d-8920-0be8e3422ac5   in service    fd00:1122:3344:102::2d
+    crucible            eb4176ea-456b-48f6-b284-7b76da0bf4a1   in service    fd00:1122:3344:102::2b
+    crucible_pantry     417c97a4-fe25-439d-8359-3f7062981923   in service    fd00:1122:3344:102::23
+    internal_dns        f2bbaa79-0eab-4b91-a404-dad4c19b58c2   in service    fd00:1122:3344:3::1   
+    internal_ntp        47eab17a-4dd4-4467-90b2-f643f465cf34   in service    fd00:1122:3344:102::21
+    nexus               33ba37c4-2535-4095-a7e9-c69937fc584d   in service    fd00:1122:3344:102::22
++   clickhouse_keeper   60cf5091-670b-48c9-a729-b82c5e7683ca   in service    fd00:1122:3344:102::30
 
 
  COCKROACHDB SETTINGS:
@@ -309,22 +309,22 @@ to:   blueprint 2886dab5-61a2-46b4-87af-bc7aeb44cccb
     max used server id:::::::::::::::::::::::::::::   2 (unchanged)
 *   max used keeper id:::::::::::::::::::::::::::::   3 -> 4
     cluster name:::::::::::::::::::::::::::::::::::   oximeter_cluster (unchanged)
-    cluster secret:::::::::::::::::::::::::::::::::   75ba7558-f7cf-431f-bba5-71c8e82fd4c1 (unchanged)
+    cluster secret:::::::::::::::::::::::::::::::::   6a984e2e-20be-4ed9-b572-d7ef063c67f7 (unchanged)
     highest seen keeper leader committed log index:   1 (unchanged)
 
     clickhouse keepers generation 2 -> 3:
     ------------------------------------------------
     zone id                                keeper id
     ------------------------------------------------
-    39fd3357-4de8-433e-9c07-1ec65de7ca59   1        
-+   81a4f9fd-e502-42c2-bf9c-29dd6918fd46   4        
-    b36c16d5-de6e-411a-a32a-d35a26f2e151   2        
-    f3279a8b-32fa-4426-b946-08aff9ded482   3        
+    31a66e47-6252-4f38-aa92-f48637da152c   1        
++   60cf5091-670b-48c9-a729-b82c5e7683ca   4        
+    7aa82b80-0c37-4f20-9398-bfce4707f327   2        
+    dd5ab8b1-e6e7-40e0-9ea6-b6a16f485b52   3        
 
     clickhouse servers generation 2 -> 3:
     ------------------------------------------------
     zone id                                server id
     ------------------------------------------------
-    122e30d3-d541-49b5-88de-1543b38123cc   1        
-    71be6bff-666a-4f2b-a7dc-d80a88a71af5   2        
+    6fedfc94-2ae6-4cc7-a968-5185207284f4   1        
+    812be70a-f237-47d5-ab49-f9450fe948db   2        
 

--- a/nexus/reconfigurator/planning/tests/output/planner_deploy_all_keeper_nodes_5_6.txt
+++ b/nexus/reconfigurator/planning/tests/output/planner_deploy_all_keeper_nodes_5_6.txt
@@ -25,77 +25,77 @@ to:   blueprint cb39be9d-5476-44fa-9edf-9938376219ef
     -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
     dataset name                                                                                                     dataset uuid                           quota     reservation   compression
     -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
-    oxp_60e6b021-79d6-4a6b-917c-6637e0769558/crucible                                                                fcd7e842-2648-407a-8d13-197e67de9e9d   none      none          off        
-    oxp_71a07ac0-d24e-446c-a202-1998e7f6ac8c/crucible                                                                c770de28-6c33-4cc7-97d9-62ddafd963aa   none      none          off        
-    oxp_736d4cab-c262-485e-89c2-07e6543f0855/crucible                                                                ac9f4d69-3281-4774-a098-250755079068   none      none          off        
-    oxp_8ae56ca0-709d-4b8f-9869-51b62b542eef/crucible                                                                09781292-36f1-4310-82b4-ddfb4d287fa1   none      none          off        
-    oxp_8e0bcc4f-0799-450c-a0ad-80c1637f59e3/crucible                                                                81719897-4ae6-4d76-8282-fda91c347811   none      none          off        
-    oxp_8eeebb8e-6db6-43e8-a429-d26dde99882c/crucible                                                                a2399f57-62eb-4d7d-ac69-09cd6e5c2134   none      none          off        
-    oxp_a3e8de5b-c47a-49c0-b698-4d6955e1327f/crucible                                                                cd6b3952-2024-4310-b82e-abfd245ec1d6   none      none          off        
-    oxp_b32fa3da-4dec-4237-9776-e1a57ba15a21/crucible                                                                4f99dd21-d6ed-409a-af19-9886d1083762   none      none          off        
-    oxp_e9c238f6-87a3-4087-8ba4-aa594a82d012/crucible                                                                e88d6ff8-6b98-44c1-97a7-83f371ae62fe   none      none          off        
-    oxp_fbf997ef-52d3-438a-b036-b9117322e569/crucible                                                                d6a838c7-3ee9-4cca-9d8b-986b4de0ba1c   none      none          off        
-    oxp_60e6b021-79d6-4a6b-917c-6637e0769558/crypt/clickhouse                                                        5cb56dc7-6c56-4bbf-ae73-6f08e0c97cdf   none      none          off        
-    oxp_60e6b021-79d6-4a6b-917c-6637e0769558/crypt/clickhouse_keeper                                                 886f2522-8122-465f-8996-2d8c2acd9d0d   none      none          off        
-    oxp_60e6b021-79d6-4a6b-917c-6637e0769558/crypt/internal_dns                                                      dd467397-efc5-4738-984e-77a0f3e3e678   none      none          off        
-    oxp_60e6b021-79d6-4a6b-917c-6637e0769558/crypt/zone                                                              8c4f4acd-8f6b-4296-81be-12d2eeae0483   none      none          off        
-    oxp_71a07ac0-d24e-446c-a202-1998e7f6ac8c/crypt/zone                                                              f83b1c8d-d252-4b35-a9d2-400e2e2cddf7   none      none          off        
-    oxp_736d4cab-c262-485e-89c2-07e6543f0855/crypt/zone                                                              a34f8204-9f17-4c8f-997b-e122c284ac9f   none      none          off        
-    oxp_8ae56ca0-709d-4b8f-9869-51b62b542eef/crypt/zone                                                              61bf628d-a78d-40a7-bad2-84e97e41b810   none      none          off        
-    oxp_8e0bcc4f-0799-450c-a0ad-80c1637f59e3/crypt/zone                                                              3f63ada8-d1f4-440d-8713-da45b0684520   none      none          off        
-    oxp_8eeebb8e-6db6-43e8-a429-d26dde99882c/crypt/zone                                                              a3284e6f-ee42-4fdb-8150-634f7f40c073   none      none          off        
-    oxp_a3e8de5b-c47a-49c0-b698-4d6955e1327f/crypt/zone                                                              8b7928fb-e5a0-49b0-81d0-89f627020c92   none      none          off        
-    oxp_b32fa3da-4dec-4237-9776-e1a57ba15a21/crypt/zone                                                              0e976e79-fe8c-4189-8a8c-279f42e0290f   none      none          off        
-    oxp_e9c238f6-87a3-4087-8ba4-aa594a82d012/crypt/zone                                                              f963f2a7-e9d1-4b80-b01a-ff4cecddf867   none      none          off        
-    oxp_fbf997ef-52d3-438a-b036-b9117322e569/crypt/zone                                                              a15e4260-d48c-4415-9315-c0f29234f359   none      none          off        
-    oxp_60e6b021-79d6-4a6b-917c-6637e0769558/crypt/zone/oxz_clickhouse_df79db1e-54ca-4048-b22a-da120ae4c8c4          b6cb0fe9-0b7a-4793-b6cd-1ee71fee464c   none      none          off        
-    oxp_60e6b021-79d6-4a6b-917c-6637e0769558/crypt/zone/oxz_clickhouse_keeper_39fd3357-4de8-433e-9c07-1ec65de7ca59   095cf066-5a68-40b4-afc6-baf5bcbadd05   none      none          off        
-    oxp_8e0bcc4f-0799-450c-a0ad-80c1637f59e3/crypt/zone/oxz_crucible_08330c18-54e9-445b-81f3-8f1d6ad15cdd            ab255226-2c8c-4222-82c6-702af839a2d2   none      none          off        
-    oxp_fbf997ef-52d3-438a-b036-b9117322e569/crypt/zone/oxz_crucible_0ba018f0-4ff7-4bcc-a0c7-42cfec6bc9da            ba1a3aae-15ab-4364-8250-54a766331ef8   none      none          off        
-    oxp_60e6b021-79d6-4a6b-917c-6637e0769558/crypt/zone/oxz_crucible_1e485cda-b36e-4647-9125-c273fc7a9850            65c2e3cd-3d8e-43c6-9e2c-cb884511ec49   none      none          off        
-    oxp_a3e8de5b-c47a-49c0-b698-4d6955e1327f/crypt/zone/oxz_crucible_4d84fdb4-76fd-47a9-b033-7e1711d9125f            8dc07059-e8cd-4f89-abc7-0c5289b8ff0a   none      none          off        
-    oxp_e9c238f6-87a3-4087-8ba4-aa594a82d012/crypt/zone/oxz_crucible_577b0a64-6fa9-4302-bfaa-853b6e9e71ac            851cd90d-97f5-49b6-ad41-2e1c1faa3cc9   none      none          off        
-    oxp_8eeebb8e-6db6-43e8-a429-d26dde99882c/crypt/zone/oxz_crucible_5d296df4-4f2f-4896-8caa-42df00799bcb            25c5034b-83b2-4a90-a08a-7573ffb38119   none      none          off        
-    oxp_736d4cab-c262-485e-89c2-07e6543f0855/crypt/zone/oxz_crucible_65d597c5-86b9-43f6-84cd-67bb108df9f0            6de460bc-890d-4e7a-920f-607862440cfd   none      none          off        
-    oxp_b32fa3da-4dec-4237-9776-e1a57ba15a21/crypt/zone/oxz_crucible_a9f1d41e-c445-4783-af13-0095b2836f0f            b5d6cec1-c83f-4c41-9e79-8b9bf917f483   none      none          off        
-    oxp_71a07ac0-d24e-446c-a202-1998e7f6ac8c/crypt/zone/oxz_crucible_e9ab813f-0fff-4b41-a101-790f6d94b40a            7c459b4e-396b-497f-8094-f342939d1f9f   none      none          off        
-    oxp_8ae56ca0-709d-4b8f-9869-51b62b542eef/crypt/zone/oxz_crucible_f00c7a67-51a6-4d09-be39-f20b0e6da1c6            6ff911b9-a4a5-4986-ba04-c6b3f234d3b4   none      none          off        
-    oxp_60e6b021-79d6-4a6b-917c-6637e0769558/crypt/zone/oxz_crucible_pantry_840a4f34-0e53-469c-8c79-12b75bb42edc     7de8087e-602a-4a81-98ff-d766213d0f94   none      none          off        
-    oxp_60e6b021-79d6-4a6b-917c-6637e0769558/crypt/zone/oxz_internal_dns_c89ac05f-d9b2-47f4-9d48-2f38130e4ad9        dd1cdc17-808e-4e6d-99ed-84b2d0e220f1   none      none          off        
-    oxp_60e6b021-79d6-4a6b-917c-6637e0769558/crypt/zone/oxz_nexus_a6032c9e-a365-45d7-ad9f-07ac0fa7079a               198ff957-cce0-40cf-9048-f65cf9a6c671   none      none          off        
-    oxp_60e6b021-79d6-4a6b-917c-6637e0769558/crypt/zone/oxz_ntp_66695827-17c4-4885-b6c0-2cb6b6d3ad1c                 ccfb112d-c72e-4482-9bb0-f9cbbb034f7d   none      none          off        
-    oxp_60e6b021-79d6-4a6b-917c-6637e0769558/crypt/debug                                                             10610f76-51e8-4be4-a4ad-9af953f6bf4a   100 GiB   none          gzip-9     
-    oxp_71a07ac0-d24e-446c-a202-1998e7f6ac8c/crypt/debug                                                             e0bcc415-f8f9-401f-a507-cee5587756b1   100 GiB   none          gzip-9     
-    oxp_736d4cab-c262-485e-89c2-07e6543f0855/crypt/debug                                                             8bbc5419-7125-4cb1-b990-436af4bb8eb4   100 GiB   none          gzip-9     
-    oxp_8ae56ca0-709d-4b8f-9869-51b62b542eef/crypt/debug                                                             280dd773-35e2-4dda-ae2a-65c88f1b2a01   100 GiB   none          gzip-9     
-    oxp_8e0bcc4f-0799-450c-a0ad-80c1637f59e3/crypt/debug                                                             fecbd83d-7440-4900-b22b-6206e55b2920   100 GiB   none          gzip-9     
-    oxp_8eeebb8e-6db6-43e8-a429-d26dde99882c/crypt/debug                                                             e120c8f8-049f-40f0-8d70-4cfe409ef34d   100 GiB   none          gzip-9     
-    oxp_a3e8de5b-c47a-49c0-b698-4d6955e1327f/crypt/debug                                                             37eb0429-d620-40fb-a57a-62486d001738   100 GiB   none          gzip-9     
-    oxp_b32fa3da-4dec-4237-9776-e1a57ba15a21/crypt/debug                                                             d0f12057-da73-4c1d-bdec-32a0e7ab7107   100 GiB   none          gzip-9     
-    oxp_e9c238f6-87a3-4087-8ba4-aa594a82d012/crypt/debug                                                             2288ff91-8e52-4817-825f-2f8b8eb1681d   100 GiB   none          gzip-9     
-    oxp_fbf997ef-52d3-438a-b036-b9117322e569/crypt/debug                                                             17ffe1be-b38b-4f39-90af-57af25dbfe30   100 GiB   none          gzip-9     
+    oxp_60e6b021-79d6-4a6b-917c-6637e0769558/crucible                                                                723e4ec2-5f4a-48a9-a6a1-cb523dc47d3d   none      none          off        
+    oxp_71a07ac0-d24e-446c-a202-1998e7f6ac8c/crucible                                                                b2796e6b-ad7d-41a5-82a6-947b96e42d47   none      none          off        
+    oxp_736d4cab-c262-485e-89c2-07e6543f0855/crucible                                                                c993b4da-bea9-4010-a8d6-17d733698f07   none      none          off        
+    oxp_8ae56ca0-709d-4b8f-9869-51b62b542eef/crucible                                                                4f497ece-88c1-4557-a8b4-0e990f9941a9   none      none          off        
+    oxp_8e0bcc4f-0799-450c-a0ad-80c1637f59e3/crucible                                                                43a16c22-e79a-4bea-bcf6-682099a728dd   none      none          off        
+    oxp_8eeebb8e-6db6-43e8-a429-d26dde99882c/crucible                                                                b6bbb45b-68fc-4fa5-86cc-b59b0f797fb2   none      none          off        
+    oxp_a3e8de5b-c47a-49c0-b698-4d6955e1327f/crucible                                                                e4838ed0-304f-475e-a282-9f644f2ba3e5   none      none          off        
+    oxp_b32fa3da-4dec-4237-9776-e1a57ba15a21/crucible                                                                046f2730-768d-4bcc-8ebf-4b5f5597151c   none      none          off        
+    oxp_e9c238f6-87a3-4087-8ba4-aa594a82d012/crucible                                                                0830fc6d-ed82-41de-9389-0bd3fd4677ea   none      none          off        
+    oxp_fbf997ef-52d3-438a-b036-b9117322e569/crucible                                                                d9662141-585e-4e18-a461-9627097f02a2   none      none          off        
+    oxp_60e6b021-79d6-4a6b-917c-6637e0769558/crypt/clickhouse                                                        a4f84c49-4303-411f-bb1b-08877d828946   none      none          off        
+    oxp_60e6b021-79d6-4a6b-917c-6637e0769558/crypt/clickhouse_keeper                                                 04ee4b4b-fcbe-4224-86fd-30144a4f2592   none      none          off        
+    oxp_60e6b021-79d6-4a6b-917c-6637e0769558/crypt/internal_dns                                                      2edca3dc-a0e5-4d34-b8a2-065be4cca767   none      none          off        
+    oxp_60e6b021-79d6-4a6b-917c-6637e0769558/crypt/zone                                                              87cd9f37-3de3-457c-9412-d0dc5678eda8   none      none          off        
+    oxp_71a07ac0-d24e-446c-a202-1998e7f6ac8c/crypt/zone                                                              3a164f36-1f53-45b3-b190-ad8a2817bc69   none      none          off        
+    oxp_736d4cab-c262-485e-89c2-07e6543f0855/crypt/zone                                                              407556ed-09ab-430e-bc8f-8291b8f8c8fe   none      none          off        
+    oxp_8ae56ca0-709d-4b8f-9869-51b62b542eef/crypt/zone                                                              99d57d61-f12a-4b56-8114-86ba92d07649   none      none          off        
+    oxp_8e0bcc4f-0799-450c-a0ad-80c1637f59e3/crypt/zone                                                              da1eb596-8764-4268-a60b-f4705b4f615b   none      none          off        
+    oxp_8eeebb8e-6db6-43e8-a429-d26dde99882c/crypt/zone                                                              d555bf19-887c-48d2-8144-47c2eac9a9e8   none      none          off        
+    oxp_a3e8de5b-c47a-49c0-b698-4d6955e1327f/crypt/zone                                                              9785e77a-9422-4b46-a4ae-8b9a155eb121   none      none          off        
+    oxp_b32fa3da-4dec-4237-9776-e1a57ba15a21/crypt/zone                                                              1192a37c-a871-4c48-905d-03c3d6035bdc   none      none          off        
+    oxp_e9c238f6-87a3-4087-8ba4-aa594a82d012/crypt/zone                                                              7bf1c7ec-5465-4bfd-b1d9-939f05336012   none      none          off        
+    oxp_fbf997ef-52d3-438a-b036-b9117322e569/crypt/zone                                                              be526b44-2c78-49ec-8ab4-73e161e27f22   none      none          off        
+    oxp_60e6b021-79d6-4a6b-917c-6637e0769558/crypt/zone/oxz_clickhouse_35e8d4b6-ea92-45cf-923c-3f566a0b1fe5          cd7e5c3a-2328-4568-b8f8-cf349f0cdd12   none      none          off        
+    oxp_60e6b021-79d6-4a6b-917c-6637e0769558/crypt/zone/oxz_clickhouse_keeper_dd5ab8b1-e6e7-40e0-9ea6-b6a16f485b52   a51fb98f-3fff-4c0a-82f0-7a4aad82096b   none      none          off        
+    oxp_e9c238f6-87a3-4087-8ba4-aa594a82d012/crypt/zone/oxz_crucible_044d074d-7905-4024-82ff-68d76221db68            98fd0f42-7337-4ce7-814e-f988304b8873   none      none          off        
+    oxp_71a07ac0-d24e-446c-a202-1998e7f6ac8c/crypt/zone/oxz_crucible_28826473-ac0b-41ea-8c54-72b782db1bcb            bbda84d8-c4ca-4f52-a766-681872fa06f0   none      none          off        
+    oxp_fbf997ef-52d3-438a-b036-b9117322e569/crypt/zone/oxz_crucible_2d3ff798-dda9-4ccf-8f91-070a20f06d55            e9c77dbd-c56a-404c-8ff9-6504b3f92556   none      none          off        
+    oxp_8eeebb8e-6db6-43e8-a429-d26dde99882c/crypt/zone/oxz_crucible_7538d29b-69f2-43e8-8509-505b25cb1c84            19110f8a-6267-41ed-ac7d-539cd0fe3511   none      none          off        
+    oxp_8ae56ca0-709d-4b8f-9869-51b62b542eef/crypt/zone/oxz_crucible_8234bbd2-4b31-4f6b-8dcc-4744b1d14e64            0fe4f647-ffd2-4845-805a-c069096560ee   none      none          off        
+    oxp_8e0bcc4f-0799-450c-a0ad-80c1637f59e3/crypt/zone/oxz_crucible_85358363-cee8-4bc3-af66-4d89e5cd714f            a1daa561-2448-4afb-8233-ec149d2bd7f4   none      none          off        
+    oxp_736d4cab-c262-485e-89c2-07e6543f0855/crypt/zone/oxz_crucible_9b58d04f-85bf-4f5e-8c6a-5d855062d5c4            69812f66-4b59-4590-9e1f-bce3e93b3b08   none      none          off        
+    oxp_60e6b021-79d6-4a6b-917c-6637e0769558/crypt/zone/oxz_crucible_e7da0aec-c6b6-4a56-9525-35385b9c62a2            36e58025-88e2-4eb9-8af0-ed9a98dda1b9   none      none          off        
+    oxp_a3e8de5b-c47a-49c0-b698-4d6955e1327f/crypt/zone/oxz_crucible_f3f977cc-7eca-4491-9b07-82b6284eb169            482fad9a-d83f-4025-8f0b-d3adea6ae2cf   none      none          off        
+    oxp_b32fa3da-4dec-4237-9776-e1a57ba15a21/crypt/zone/oxz_crucible_fef381d2-8368-4a2d-96a1-c956ed011f7b            b1937368-4019-40c4-af02-9811dc7eb143   none      none          off        
+    oxp_60e6b021-79d6-4a6b-917c-6637e0769558/crypt/zone/oxz_crucible_pantry_fe63bfd3-3128-4675-8118-cf6968293471     e3b31ef3-6b54-4901-aec4-0c672de62c7f   none      none          off        
+    oxp_60e6b021-79d6-4a6b-917c-6637e0769558/crypt/zone/oxz_internal_dns_b6b0689e-ef48-484d-b3c7-3c596edad20c        501e0672-2897-4992-8911-600e0283f04c   none      none          off        
+    oxp_60e6b021-79d6-4a6b-917c-6637e0769558/crypt/zone/oxz_nexus_46ecde76-fef7-4394-93dd-d22b003148e9               53655959-866b-4fee-bcf9-1e35504ad625   none      none          off        
+    oxp_60e6b021-79d6-4a6b-917c-6637e0769558/crypt/zone/oxz_ntp_4d009155-44fb-45b9-afed-f89cb57ce8da                 0590facf-202a-463b-81be-b6e88c47da76   none      none          off        
+    oxp_60e6b021-79d6-4a6b-917c-6637e0769558/crypt/debug                                                             8f7f16c1-d9fb-4405-9dcf-68bfbaa7bf8c   100 GiB   none          gzip-9     
+    oxp_71a07ac0-d24e-446c-a202-1998e7f6ac8c/crypt/debug                                                             6482f332-801a-473f-a77d-e07d30e2a5b7   100 GiB   none          gzip-9     
+    oxp_736d4cab-c262-485e-89c2-07e6543f0855/crypt/debug                                                             0bb0541f-2c64-487b-a8af-162454207504   100 GiB   none          gzip-9     
+    oxp_8ae56ca0-709d-4b8f-9869-51b62b542eef/crypt/debug                                                             902a6889-244f-4b67-baa4-b245f3d622c8   100 GiB   none          gzip-9     
+    oxp_8e0bcc4f-0799-450c-a0ad-80c1637f59e3/crypt/debug                                                             667ffd3c-6735-4b50-bc3b-cfa32fcc811e   100 GiB   none          gzip-9     
+    oxp_8eeebb8e-6db6-43e8-a429-d26dde99882c/crypt/debug                                                             cf48ba87-a4bb-435f-999b-bca46cfd6a89   100 GiB   none          gzip-9     
+    oxp_a3e8de5b-c47a-49c0-b698-4d6955e1327f/crypt/debug                                                             7d64cab3-7311-4519-ae4a-1af6b320fa9b   100 GiB   none          gzip-9     
+    oxp_b32fa3da-4dec-4237-9776-e1a57ba15a21/crypt/debug                                                             d3e957fd-5f26-498a-8fa3-deaea4dc5820   100 GiB   none          gzip-9     
+    oxp_e9c238f6-87a3-4087-8ba4-aa594a82d012/crypt/debug                                                             4da77f4a-5e41-4604-af30-8cf568c38428   100 GiB   none          gzip-9     
+    oxp_fbf997ef-52d3-438a-b036-b9117322e569/crypt/debug                                                             03935cb1-ce06-4594-b2fe-23e127d1cd9d   100 GiB   none          gzip-9     
 
 
     omicron zones at generation 3:
     -----------------------------------------------------------------------------------------------
     zone type           zone id                                disposition   underlay IP           
     -----------------------------------------------------------------------------------------------
-    clickhouse          df79db1e-54ca-4048-b22a-da120ae4c8c4   in service    fd00:1122:3344:101::23
-    clickhouse_keeper   39fd3357-4de8-433e-9c07-1ec65de7ca59   in service    fd00:1122:3344:101::2f
-    crucible            08330c18-54e9-445b-81f3-8f1d6ad15cdd   in service    fd00:1122:3344:101::29
-    crucible            0ba018f0-4ff7-4bcc-a0c7-42cfec6bc9da   in service    fd00:1122:3344:101::2e
-    crucible            1e485cda-b36e-4647-9125-c273fc7a9850   in service    fd00:1122:3344:101::25
-    crucible            4d84fdb4-76fd-47a9-b033-7e1711d9125f   in service    fd00:1122:3344:101::2b
-    crucible            577b0a64-6fa9-4302-bfaa-853b6e9e71ac   in service    fd00:1122:3344:101::2d
-    crucible            5d296df4-4f2f-4896-8caa-42df00799bcb   in service    fd00:1122:3344:101::2a
-    crucible            65d597c5-86b9-43f6-84cd-67bb108df9f0   in service    fd00:1122:3344:101::27
-    crucible            a9f1d41e-c445-4783-af13-0095b2836f0f   in service    fd00:1122:3344:101::2c
-    crucible            e9ab813f-0fff-4b41-a101-790f6d94b40a   in service    fd00:1122:3344:101::26
-    crucible            f00c7a67-51a6-4d09-be39-f20b0e6da1c6   in service    fd00:1122:3344:101::28
-    crucible_pantry     840a4f34-0e53-469c-8c79-12b75bb42edc   in service    fd00:1122:3344:101::24
-    internal_dns        c89ac05f-d9b2-47f4-9d48-2f38130e4ad9   in service    fd00:1122:3344:1::1   
-    internal_ntp        66695827-17c4-4885-b6c0-2cb6b6d3ad1c   in service    fd00:1122:3344:101::21
-    nexus               a6032c9e-a365-45d7-ad9f-07ac0fa7079a   in service    fd00:1122:3344:101::22
+    clickhouse          35e8d4b6-ea92-45cf-923c-3f566a0b1fe5   in service    fd00:1122:3344:101::23
+    clickhouse_keeper   dd5ab8b1-e6e7-40e0-9ea6-b6a16f485b52   in service    fd00:1122:3344:101::2f
+    crucible            044d074d-7905-4024-82ff-68d76221db68   in service    fd00:1122:3344:101::2d
+    crucible            28826473-ac0b-41ea-8c54-72b782db1bcb   in service    fd00:1122:3344:101::26
+    crucible            2d3ff798-dda9-4ccf-8f91-070a20f06d55   in service    fd00:1122:3344:101::2e
+    crucible            7538d29b-69f2-43e8-8509-505b25cb1c84   in service    fd00:1122:3344:101::2a
+    crucible            8234bbd2-4b31-4f6b-8dcc-4744b1d14e64   in service    fd00:1122:3344:101::28
+    crucible            85358363-cee8-4bc3-af66-4d89e5cd714f   in service    fd00:1122:3344:101::29
+    crucible            9b58d04f-85bf-4f5e-8c6a-5d855062d5c4   in service    fd00:1122:3344:101::27
+    crucible            e7da0aec-c6b6-4a56-9525-35385b9c62a2   in service    fd00:1122:3344:101::25
+    crucible            f3f977cc-7eca-4491-9b07-82b6284eb169   in service    fd00:1122:3344:101::2b
+    crucible            fef381d2-8368-4a2d-96a1-c956ed011f7b   in service    fd00:1122:3344:101::2c
+    crucible_pantry     fe63bfd3-3128-4675-8118-cf6968293471   in service    fd00:1122:3344:101::24
+    internal_dns        b6b0689e-ef48-484d-b3c7-3c596edad20c   in service    fd00:1122:3344:1::1   
+    internal_ntp        4d009155-44fb-45b9-afed-f89cb57ce8da   in service    fd00:1122:3344:101::21
+    nexus               46ecde76-fef7-4394-93dd-d22b003148e9   in service    fd00:1122:3344:101::22
 
 
   sled 6a4c45f6-e02f-490c-bbfa-b32fb89e8e86 (active):
@@ -120,80 +120,80 @@ to:   blueprint cb39be9d-5476-44fa-9edf-9938376219ef
     -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
     dataset name                                                                                                     dataset uuid                           quota     reservation   compression
     -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
-    oxp_0bf9d028-2b4a-4bff-82a1-6eb5fcefd985/crucible                                                                f3b1d2f6-3cbc-4420-bc91-5eaaf00f85d0   none      none          off        
-    oxp_19293a1d-fddc-40a7-88a4-ccafdb6f66d3/crucible                                                                276f044e-dd34-4c1e-beef-174da4fcf53d   none      none          off        
-    oxp_44484c44-477a-4676-8266-b98a00e80d79/crucible                                                                e06b1670-5f34-42dc-a410-3129d69907ec   none      none          off        
-    oxp_79787cd4-92da-4de5-bfd8-30a635521e10/crucible                                                                9d32dd45-e3ee-47b9-ba69-0dc711bbf632   none      none          off        
-    oxp_9ae94c94-baae-477e-912a-60f0c4f3bd13/crucible                                                                7e72090d-7f79-4ecc-92cc-5eb7d9dee022   none      none          off        
-    oxp_af85eec8-36b3-4b88-966d-a717b9b58fe5/crucible                                                                43606b8e-384f-4412-a273-d4dde8f2e76d   none      none          off        
-    oxp_ddfaaba3-dafe-4103-b868-e9843d29d346/crucible                                                                2d7145e9-0029-4ae0-bb12-ee65a1738005   none      none          off        
-    oxp_ec458c3e-91ca-40f1-a2a3-3f4292c1f279/crucible                                                                dfadcc38-505a-4e9b-8674-27f8a2af13a2   none      none          off        
-    oxp_f2fc7c4c-7966-449d-8ec3-5a70f460501d/crucible                                                                72e2a1d6-09dd-43ba-9b8b-befa101f53ef   none      none          off        
-    oxp_f635c28a-e5ca-4d22-ac94-d8f278a6ea0e/crucible                                                                c7dfbe25-5b52-4ee5-8556-719e99bb5e4d   none      none          off        
-    oxp_0bf9d028-2b4a-4bff-82a1-6eb5fcefd985/crypt/clickhouse_keeper                                                 a3eed313-d886-4c1d-8023-8d2ec9e97ddd   none      none          off        
-    oxp_19293a1d-fddc-40a7-88a4-ccafdb6f66d3/crypt/clickhouse_keeper                                                 cad1d0c3-ca80-4db4-ab36-b2034cf2383b   none      none          off        
-    oxp_0bf9d028-2b4a-4bff-82a1-6eb5fcefd985/crypt/clickhouse_server                                                 3d339942-c2d0-4615-a099-433a8b5a1543   none      none          off        
-    oxp_0bf9d028-2b4a-4bff-82a1-6eb5fcefd985/crypt/internal_dns                                                      b8af3673-c60a-45fb-adc1-c36d0d325417   none      none          off        
-    oxp_0bf9d028-2b4a-4bff-82a1-6eb5fcefd985/crypt/zone                                                              1ab5529e-c3db-41e1-a561-9c767f980ad4   none      none          off        
-    oxp_19293a1d-fddc-40a7-88a4-ccafdb6f66d3/crypt/zone                                                              68490e52-279a-4609-ba0b-11d03f904c88   none      none          off        
-    oxp_44484c44-477a-4676-8266-b98a00e80d79/crypt/zone                                                              2a5e3a10-6ab5-4988-be84-46b527dc2d23   none      none          off        
-    oxp_79787cd4-92da-4de5-bfd8-30a635521e10/crypt/zone                                                              fd0f9778-c31a-40f4-9ce9-f5154535e75b   none      none          off        
-    oxp_9ae94c94-baae-477e-912a-60f0c4f3bd13/crypt/zone                                                              e4220797-15df-42c4-9df7-ad927711d565   none      none          off        
-    oxp_af85eec8-36b3-4b88-966d-a717b9b58fe5/crypt/zone                                                              39714005-313e-42be-90eb-000a0560669f   none      none          off        
-    oxp_ddfaaba3-dafe-4103-b868-e9843d29d346/crypt/zone                                                              a647238a-1689-46c9-b680-dfe1b7b68684   none      none          off        
-    oxp_ec458c3e-91ca-40f1-a2a3-3f4292c1f279/crypt/zone                                                              29038bb0-9af1-4b03-9c10-b8a6444a0bc2   none      none          off        
-    oxp_f2fc7c4c-7966-449d-8ec3-5a70f460501d/crypt/zone                                                              e49915c6-59ed-4bbe-abf9-375b9502772a   none      none          off        
-    oxp_f635c28a-e5ca-4d22-ac94-d8f278a6ea0e/crypt/zone                                                              fc9765c5-0a89-4050-ba3e-e0625dbefb5f   none      none          off        
-    oxp_19293a1d-fddc-40a7-88a4-ccafdb6f66d3/crypt/zone/oxz_clickhouse_keeper_ad07794e-affa-4145-81fb-f45ed92e3fcd   d196c20e-0254-4716-8e04-c0c735d2ffaf   none      none          off        
-    oxp_0bf9d028-2b4a-4bff-82a1-6eb5fcefd985/crypt/zone/oxz_clickhouse_keeper_b36c16d5-de6e-411a-a32a-d35a26f2e151   48720037-5b8e-4478-9bb5-c86ee8a6e250   none      none          off        
-    oxp_0bf9d028-2b4a-4bff-82a1-6eb5fcefd985/crypt/zone/oxz_clickhouse_server_71be6bff-666a-4f2b-a7dc-d80a88a71af5   a9e2160a-688f-4bbd-9a77-b2e695df86f4   none      none          off        
-    oxp_ddfaaba3-dafe-4103-b868-e9843d29d346/crypt/zone/oxz_crucible_1a92bb17-6477-46fc-9784-1d2a418d6e14            257c57cd-8f2c-440d-9fa0-e92a312295ec   none      none          off        
-    oxp_af85eec8-36b3-4b88-966d-a717b9b58fe5/crypt/zone/oxz_crucible_26115267-8333-4711-924e-d05acf601827            3a39d5e8-ea73-4cf3-b9de-48045475151c   none      none          off        
-    oxp_9ae94c94-baae-477e-912a-60f0c4f3bd13/crypt/zone/oxz_crucible_41af4ef6-d21b-4271-bfcb-524f4146784a            1522207b-ea98-47cc-810c-44808796d743   none      none          off        
-    oxp_44484c44-477a-4676-8266-b98a00e80d79/crypt/zone/oxz_crucible_487bde8c-a692-416c-be70-efef7f169fce            008ba9b6-8d41-4f7a-8ff3-ec31a0c96cf9   none      none          off        
-    oxp_f2fc7c4c-7966-449d-8ec3-5a70f460501d/crypt/zone/oxz_crucible_704a17e0-bc9d-43b9-a91e-b1ca37a23d0d            5739948f-d984-48a5-a27a-0223a0af2035   none      none          off        
-    oxp_f635c28a-e5ca-4d22-ac94-d8f278a6ea0e/crypt/zone/oxz_crucible_93535f54-4919-4c4d-9a07-f7ab6245c01f            109f44de-d1ed-4ce3-9670-76aceb206ee4   none      none          off        
-    oxp_ec458c3e-91ca-40f1-a2a3-3f4292c1f279/crypt/zone/oxz_crucible_9b9d58bd-44e6-4b70-80a4-e6a9262893ff            0a5bade3-3f2f-4385-b064-554b56f8bf8c   none      none          off        
-    oxp_0bf9d028-2b4a-4bff-82a1-6eb5fcefd985/crypt/zone/oxz_crucible_aa74c1b2-b4c1-4f36-8f01-9459ef23786b            e1db255d-4793-46bd-a1f3-f207be6b2839   none      none          off        
-    oxp_79787cd4-92da-4de5-bfd8-30a635521e10/crypt/zone/oxz_crucible_b6956e34-3c21-44d1-9ee2-cb7ee2e77c4e            2d2f2665-d556-4e65-9c53-d7fe573848a2   none      none          off        
-    oxp_19293a1d-fddc-40a7-88a4-ccafdb6f66d3/crypt/zone/oxz_crucible_eb58427d-599b-45dc-b316-8e4db7eec65e            26722393-82bf-442d-9725-030801a4d64c   none      none          off        
-    oxp_0bf9d028-2b4a-4bff-82a1-6eb5fcefd985/crypt/zone/oxz_crucible_pantry_97a785b8-d909-4fd4-92c1-9ba14bae603b     7b248682-95a2-4411-98b3-79fe6cb1a857   none      none          off        
-    oxp_0bf9d028-2b4a-4bff-82a1-6eb5fcefd985/crypt/zone/oxz_internal_dns_c259e8b9-1086-453a-8636-050639edeffb        30161ca3-c2d8-474b-906e-bd38fc912f84   none      none          off        
-    oxp_0bf9d028-2b4a-4bff-82a1-6eb5fcefd985/crypt/zone/oxz_nexus_c3c7b0bd-dce3-467b-919d-668cc6b06711               05b6bbbe-4c07-493e-8b92-4c8d4aeb1d66   none      none          off        
-    oxp_0bf9d028-2b4a-4bff-82a1-6eb5fcefd985/crypt/zone/oxz_ntp_bba31b23-d112-4cde-bd4a-635812c28c0e                 fadbc503-b72d-4862-a1fd-628c7ff599d1   none      none          off        
-    oxp_0bf9d028-2b4a-4bff-82a1-6eb5fcefd985/crypt/debug                                                             fb722d83-ddc2-4880-95a4-1ab12f4b95be   100 GiB   none          gzip-9     
-    oxp_19293a1d-fddc-40a7-88a4-ccafdb6f66d3/crypt/debug                                                             891a1ff4-66b1-4dc9-871c-be4a757bbd0f   100 GiB   none          gzip-9     
-    oxp_44484c44-477a-4676-8266-b98a00e80d79/crypt/debug                                                             3e3e18ad-d527-4b2e-b758-1eefdcfca44b   100 GiB   none          gzip-9     
-    oxp_79787cd4-92da-4de5-bfd8-30a635521e10/crypt/debug                                                             bd4efdbe-7128-4423-aacf-6cf35e5a914d   100 GiB   none          gzip-9     
-    oxp_9ae94c94-baae-477e-912a-60f0c4f3bd13/crypt/debug                                                             708d4e8b-3acf-44cf-87a2-275bb8fa0d96   100 GiB   none          gzip-9     
-    oxp_af85eec8-36b3-4b88-966d-a717b9b58fe5/crypt/debug                                                             98d65e73-01df-4525-a45d-acb2fc8d4a74   100 GiB   none          gzip-9     
-    oxp_ddfaaba3-dafe-4103-b868-e9843d29d346/crypt/debug                                                             8005f7c0-bab3-4b0a-9568-a5861c0a09bb   100 GiB   none          gzip-9     
-    oxp_ec458c3e-91ca-40f1-a2a3-3f4292c1f279/crypt/debug                                                             dae242d1-9535-4b08-b249-f030dde2c2fd   100 GiB   none          gzip-9     
-    oxp_f2fc7c4c-7966-449d-8ec3-5a70f460501d/crypt/debug                                                             6cea3508-8341-4093-abbb-c57d83cd87b4   100 GiB   none          gzip-9     
-    oxp_f635c28a-e5ca-4d22-ac94-d8f278a6ea0e/crypt/debug                                                             765b4728-8d6e-4fac-9a1b-ae2258d5c52b   100 GiB   none          gzip-9     
+    oxp_0bf9d028-2b4a-4bff-82a1-6eb5fcefd985/crucible                                                                f18270c8-a39b-4579-be20-d2d1b80bba42   none      none          off        
+    oxp_19293a1d-fddc-40a7-88a4-ccafdb6f66d3/crucible                                                                06c2af14-055c-4041-aa26-9155f9f42661   none      none          off        
+    oxp_44484c44-477a-4676-8266-b98a00e80d79/crucible                                                                9deffea6-d340-4432-be3c-fad135dc29a5   none      none          off        
+    oxp_79787cd4-92da-4de5-bfd8-30a635521e10/crucible                                                                47ca08b9-b962-43e2-99d7-c2e0556c0f52   none      none          off        
+    oxp_9ae94c94-baae-477e-912a-60f0c4f3bd13/crucible                                                                b2e54e29-6915-4b6d-bc76-6f72e5c7c55a   none      none          off        
+    oxp_af85eec8-36b3-4b88-966d-a717b9b58fe5/crucible                                                                cb992d4e-7a69-4bcd-96c8-fe6e40989e24   none      none          off        
+    oxp_ddfaaba3-dafe-4103-b868-e9843d29d346/crucible                                                                68338fc3-2d8b-4419-b33d-4cce6fe9380d   none      none          off        
+    oxp_ec458c3e-91ca-40f1-a2a3-3f4292c1f279/crucible                                                                5294b99c-3eac-40e1-a35b-1f1cf2f0d6bf   none      none          off        
+    oxp_f2fc7c4c-7966-449d-8ec3-5a70f460501d/crucible                                                                31718dcf-ebd5-432c-a9e5-40abcb40931c   none      none          off        
+    oxp_f635c28a-e5ca-4d22-ac94-d8f278a6ea0e/crucible                                                                ff7ff4a9-21c4-499e-9ceb-8a00a4bb21bc   none      none          off        
+    oxp_0bf9d028-2b4a-4bff-82a1-6eb5fcefd985/crypt/clickhouse_keeper                                                 473adeb2-a57a-4240-82e9-88f2bebc1245   none      none          off        
+    oxp_19293a1d-fddc-40a7-88a4-ccafdb6f66d3/crypt/clickhouse_keeper                                                 882d4fee-d6d4-455f-9dc1-de3637cd29d0   none      none          off        
+    oxp_0bf9d028-2b4a-4bff-82a1-6eb5fcefd985/crypt/clickhouse_server                                                 4363b5f8-9a67-49af-b49d-585e532fa7bc   none      none          off        
+    oxp_0bf9d028-2b4a-4bff-82a1-6eb5fcefd985/crypt/internal_dns                                                      56a1af5d-de86-46c5-9504-2d1ee70587c5   none      none          off        
+    oxp_0bf9d028-2b4a-4bff-82a1-6eb5fcefd985/crypt/zone                                                              003c1d4e-15bb-4fca-aa71-a7dff507b124   none      none          off        
+    oxp_19293a1d-fddc-40a7-88a4-ccafdb6f66d3/crypt/zone                                                              bf35a148-62f0-4f88-8f60-0a13747daba2   none      none          off        
+    oxp_44484c44-477a-4676-8266-b98a00e80d79/crypt/zone                                                              9b1bf42e-6f06-44cc-af5b-bff65d929322   none      none          off        
+    oxp_79787cd4-92da-4de5-bfd8-30a635521e10/crypt/zone                                                              2c9d6bce-0293-4364-b8c9-4bdea345490e   none      none          off        
+    oxp_9ae94c94-baae-477e-912a-60f0c4f3bd13/crypt/zone                                                              11726c79-6590-4831-8480-cf50e6322c8a   none      none          off        
+    oxp_af85eec8-36b3-4b88-966d-a717b9b58fe5/crypt/zone                                                              b463f0c2-3ae4-45f7-a38c-110731fcc5cb   none      none          off        
+    oxp_ddfaaba3-dafe-4103-b868-e9843d29d346/crypt/zone                                                              626abe12-321d-439b-ad8f-f8dfb2022f25   none      none          off        
+    oxp_ec458c3e-91ca-40f1-a2a3-3f4292c1f279/crypt/zone                                                              4200e2a7-0fd6-4631-9d60-21fd821193fe   none      none          off        
+    oxp_f2fc7c4c-7966-449d-8ec3-5a70f460501d/crypt/zone                                                              85f34c02-a35d-404e-8cde-bedf3e193b1c   none      none          off        
+    oxp_f635c28a-e5ca-4d22-ac94-d8f278a6ea0e/crypt/zone                                                              dd19c2c5-0bc9-48de-a116-b92503569092   none      none          off        
+    oxp_0bf9d028-2b4a-4bff-82a1-6eb5fcefd985/crypt/zone/oxz_clickhouse_keeper_31a66e47-6252-4f38-aa92-f48637da152c   49f52cc5-74df-4cfa-b7f0-07c7e810940d   none      none          off        
+    oxp_19293a1d-fddc-40a7-88a4-ccafdb6f66d3/crypt/zone/oxz_clickhouse_keeper_e222f1c0-39ca-463a-88ad-ebfb6022fd1a   fbf9198e-996a-4194-af5b-c4e95ea4286d   none      none          off        
+    oxp_0bf9d028-2b4a-4bff-82a1-6eb5fcefd985/crypt/zone/oxz_clickhouse_server_6fedfc94-2ae6-4cc7-a968-5185207284f4   f1143eb2-0685-4708-a471-968a58f93bad   none      none          off        
+    oxp_f635c28a-e5ca-4d22-ac94-d8f278a6ea0e/crypt/zone/oxz_crucible_06b45c33-9a90-408b-8534-f94ab6df8a42            9e0a360d-c158-417f-a45f-9d29ee67cdce   none      none          off        
+    oxp_19293a1d-fddc-40a7-88a4-ccafdb6f66d3/crypt/zone/oxz_crucible_32999e20-ed5c-4c25-b4bd-41a3fbaf1445            dd7a45b8-3175-4744-8b99-ce19b22bb8ce   none      none          off        
+    oxp_9ae94c94-baae-477e-912a-60f0c4f3bd13/crypt/zone/oxz_crucible_4a037563-f969-4028-8384-164bdf308c3c            0d5b2580-7190-4bcc-9982-5012dac51f05   none      none          off        
+    oxp_44484c44-477a-4676-8266-b98a00e80d79/crypt/zone/oxz_crucible_6564394d-2c51-4252-b3b1-f5f88a72d7c3            26a1cc86-f717-4a12-b644-5acd168843aa   none      none          off        
+    oxp_0bf9d028-2b4a-4bff-82a1-6eb5fcefd985/crypt/zone/oxz_crucible_87427b40-5114-49cd-96bd-63edd61fce90            e7364079-58e3-4b36-81a7-b9e08f2a8fff   none      none          off        
+    oxp_ddfaaba3-dafe-4103-b868-e9843d29d346/crypt/zone/oxz_crucible_8acdc189-d4da-45a7-b306-23b43e86f695            6fa84a9c-0161-40c9-b596-f3b2c679ef99   none      none          off        
+    oxp_ec458c3e-91ca-40f1-a2a3-3f4292c1f279/crypt/zone/oxz_crucible_971ce633-cdc4-48cf-983e-dc272c1639eb            cb8ca8a6-6a00-4aae-8702-1493e1c3b166   none      none          off        
+    oxp_af85eec8-36b3-4b88-966d-a717b9b58fe5/crypt/zone/oxz_crucible_cfa6af7a-bf53-4fe6-bf1a-7ce3812d15c4            27323e49-f61e-4a73-bc87-f8d9f5082143   none      none          off        
+    oxp_f2fc7c4c-7966-449d-8ec3-5a70f460501d/crypt/zone/oxz_crucible_e145fb8e-df12-4df9-8049-b146ae0275be            35c46d33-4e08-4fad-90d2-3da719538ef2   none      none          off        
+    oxp_79787cd4-92da-4de5-bfd8-30a635521e10/crypt/zone/oxz_crucible_f1d08ae7-68fe-4799-8f31-f1100887c6f0            02863a62-7624-4017-9269-412910ab73f0   none      none          off        
+    oxp_0bf9d028-2b4a-4bff-82a1-6eb5fcefd985/crypt/zone/oxz_crucible_pantry_f9e18694-fdff-46a3-b40d-570d43206f48     3cb3f346-9879-4023-b919-55c4172bbf23   none      none          off        
+    oxp_0bf9d028-2b4a-4bff-82a1-6eb5fcefd985/crypt/zone/oxz_internal_dns_a00d8ae3-d1db-4aef-9174-3ff867af5e9e        c2d9b145-5e15-47be-a835-7e1f51f27679   none      none          off        
+    oxp_0bf9d028-2b4a-4bff-82a1-6eb5fcefd985/crypt/zone/oxz_nexus_8ccafc1f-97f9-4da7-bb04-d346213387ce               dcc3603b-b160-42d9-a743-11075c3b6941   none      none          off        
+    oxp_0bf9d028-2b4a-4bff-82a1-6eb5fcefd985/crypt/zone/oxz_ntp_a1797f1d-2d2a-4396-9ab5-044630b41c35                 5a70b3fe-9fad-4c17-982b-272b8595c2e8   none      none          off        
+    oxp_0bf9d028-2b4a-4bff-82a1-6eb5fcefd985/crypt/debug                                                             4e4b2f99-dc01-4793-a37a-072d942da264   100 GiB   none          gzip-9     
+    oxp_19293a1d-fddc-40a7-88a4-ccafdb6f66d3/crypt/debug                                                             8573903d-9610-4084-b0c6-ffcbb5d96c39   100 GiB   none          gzip-9     
+    oxp_44484c44-477a-4676-8266-b98a00e80d79/crypt/debug                                                             540272e1-99d2-4d2e-9d3d-032014b0e6d9   100 GiB   none          gzip-9     
+    oxp_79787cd4-92da-4de5-bfd8-30a635521e10/crypt/debug                                                             4adf2ef6-2694-4aac-aabe-688bca767092   100 GiB   none          gzip-9     
+    oxp_9ae94c94-baae-477e-912a-60f0c4f3bd13/crypt/debug                                                             7e9d012a-6d8e-475e-805e-65985a66ffcd   100 GiB   none          gzip-9     
+    oxp_af85eec8-36b3-4b88-966d-a717b9b58fe5/crypt/debug                                                             2189574d-9a73-4d25-858e-1084d57b59a8   100 GiB   none          gzip-9     
+    oxp_ddfaaba3-dafe-4103-b868-e9843d29d346/crypt/debug                                                             3cf0580b-4e1d-4ff9-bc22-4dc51ca9a53b   100 GiB   none          gzip-9     
+    oxp_ec458c3e-91ca-40f1-a2a3-3f4292c1f279/crypt/debug                                                             f499c5f8-b62f-493d-858a-8d33f7db81ff   100 GiB   none          gzip-9     
+    oxp_f2fc7c4c-7966-449d-8ec3-5a70f460501d/crypt/debug                                                             c16ff3c0-3282-46de-a620-49c6b1e3f882   100 GiB   none          gzip-9     
+    oxp_f635c28a-e5ca-4d22-ac94-d8f278a6ea0e/crypt/debug                                                             8dde6eee-f28e-4b55-8c11-525884ec81e5   100 GiB   none          gzip-9     
 
 
     omicron zones at generation 4:
     -----------------------------------------------------------------------------------------------
     zone type           zone id                                disposition   underlay IP           
     -----------------------------------------------------------------------------------------------
-    clickhouse_keeper   ad07794e-affa-4145-81fb-f45ed92e3fcd   in service    fd00:1122:3344:103::30
-    clickhouse_keeper   b36c16d5-de6e-411a-a32a-d35a26f2e151   in service    fd00:1122:3344:103::2e
-    clickhouse_server   71be6bff-666a-4f2b-a7dc-d80a88a71af5   in service    fd00:1122:3344:103::2f
-    crucible            1a92bb17-6477-46fc-9784-1d2a418d6e14   in service    fd00:1122:3344:103::2a
-    crucible            26115267-8333-4711-924e-d05acf601827   in service    fd00:1122:3344:103::29
-    crucible            41af4ef6-d21b-4271-bfcb-524f4146784a   in service    fd00:1122:3344:103::28
-    crucible            487bde8c-a692-416c-be70-efef7f169fce   in service    fd00:1122:3344:103::26
-    crucible            704a17e0-bc9d-43b9-a91e-b1ca37a23d0d   in service    fd00:1122:3344:103::2c
-    crucible            93535f54-4919-4c4d-9a07-f7ab6245c01f   in service    fd00:1122:3344:103::2d
-    crucible            9b9d58bd-44e6-4b70-80a4-e6a9262893ff   in service    fd00:1122:3344:103::2b
-    crucible            aa74c1b2-b4c1-4f36-8f01-9459ef23786b   in service    fd00:1122:3344:103::24
-    crucible            b6956e34-3c21-44d1-9ee2-cb7ee2e77c4e   in service    fd00:1122:3344:103::27
-    crucible            eb58427d-599b-45dc-b316-8e4db7eec65e   in service    fd00:1122:3344:103::25
-    crucible_pantry     97a785b8-d909-4fd4-92c1-9ba14bae603b   in service    fd00:1122:3344:103::23
-    internal_dns        c259e8b9-1086-453a-8636-050639edeffb   in service    fd00:1122:3344:2::1   
-    internal_ntp        bba31b23-d112-4cde-bd4a-635812c28c0e   in service    fd00:1122:3344:103::21
-    nexus               c3c7b0bd-dce3-467b-919d-668cc6b06711   in service    fd00:1122:3344:103::22
+    clickhouse_keeper   31a66e47-6252-4f38-aa92-f48637da152c   in service    fd00:1122:3344:103::2e
+    clickhouse_keeper   e222f1c0-39ca-463a-88ad-ebfb6022fd1a   in service    fd00:1122:3344:103::30
+    clickhouse_server   6fedfc94-2ae6-4cc7-a968-5185207284f4   in service    fd00:1122:3344:103::2f
+    crucible            06b45c33-9a90-408b-8534-f94ab6df8a42   in service    fd00:1122:3344:103::2d
+    crucible            32999e20-ed5c-4c25-b4bd-41a3fbaf1445   in service    fd00:1122:3344:103::25
+    crucible            4a037563-f969-4028-8384-164bdf308c3c   in service    fd00:1122:3344:103::28
+    crucible            6564394d-2c51-4252-b3b1-f5f88a72d7c3   in service    fd00:1122:3344:103::26
+    crucible            87427b40-5114-49cd-96bd-63edd61fce90   in service    fd00:1122:3344:103::24
+    crucible            8acdc189-d4da-45a7-b306-23b43e86f695   in service    fd00:1122:3344:103::2a
+    crucible            971ce633-cdc4-48cf-983e-dc272c1639eb   in service    fd00:1122:3344:103::2b
+    crucible            cfa6af7a-bf53-4fe6-bf1a-7ce3812d15c4   in service    fd00:1122:3344:103::29
+    crucible            e145fb8e-df12-4df9-8049-b146ae0275be   in service    fd00:1122:3344:103::2c
+    crucible            f1d08ae7-68fe-4799-8f31-f1100887c6f0   in service    fd00:1122:3344:103::27
+    crucible_pantry     f9e18694-fdff-46a3-b40d-570d43206f48   in service    fd00:1122:3344:103::23
+    internal_dns        a00d8ae3-d1db-4aef-9174-3ff867af5e9e   in service    fd00:1122:3344:2::1   
+    internal_ntp        a1797f1d-2d2a-4396-9ab5-044630b41c35   in service    fd00:1122:3344:103::21
+    nexus               8ccafc1f-97f9-4da7-bb04-d346213387ce   in service    fd00:1122:3344:103::22
 
 
   sled be531a62-9897-430d-acd2-ce14b4632627 (active):
@@ -218,80 +218,80 @@ to:   blueprint cb39be9d-5476-44fa-9edf-9938376219ef
     -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
     dataset name                                                                                                     dataset uuid                           quota     reservation   compression
     -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
-    oxp_2a76ab1a-fb16-412d-93f9-b8cd9aa94e85/crucible                                                                431cfe4a-5756-40f4-8a9c-b70ae1227f1e   none      none          off        
-    oxp_2de2bf7e-c679-4b2b-b373-908e9d3ffbfc/crucible                                                                1123f86b-169c-40df-8ed1-95c3def65e30   none      none          off        
-    oxp_2f02a5c6-fcf5-4b5a-bc7d-7f65369918ba/crucible                                                                afa41d1a-3fc1-4723-835d-61d13db33cfe   none      none          off        
-    oxp_32041dbf-e58d-4f32-840d-923d3d3b68af/crucible                                                                da067282-0ae9-4861-8b78-b639622508af   none      none          off        
-    oxp_5f88adff-bb50-4dc1-bbfb-5a410c753ed5/crucible                                                                fcb937be-3b91-4ae7-9e25-a69808eeb07f   none      none          off        
-    oxp_74d64eb9-bf69-4782-af16-2d3a761ca171/crucible                                                                2854cb42-e5b9-4773-bd6e-6ec85d33a174   none      none          off        
-    oxp_b3c231c9-b2a5-4267-b4bf-9651881b91a5/crucible                                                                aa8f925e-6c3a-40d2-ae2d-946324a7d612   none      none          off        
-    oxp_bca80b95-8dca-4a3b-b24d-d44b6a9ff71b/crucible                                                                755ad19c-d29b-4e3c-9c13-63b56a407765   none      none          off        
-    oxp_db16345e-427a-4c8e-9032-17270f729308/crucible                                                                be3cf2f7-5388-4cd6-8119-ecf316c6052e   none      none          off        
-    oxp_e3b45593-8f0c-47b2-a381-802a7dad1f54/crucible                                                                a2391107-7408-4e0c-a694-3fd073fa09df   none      none          off        
-    oxp_2a76ab1a-fb16-412d-93f9-b8cd9aa94e85/crypt/clickhouse_keeper                                                 c16a00f5-8830-400d-89e0-9a77cce8780e   none      none          off        
-    oxp_2de2bf7e-c679-4b2b-b373-908e9d3ffbfc/crypt/clickhouse_keeper                                                 3682c931-5332-45ef-9885-3d2dcfb325f6   none      none          off        
-    oxp_2a76ab1a-fb16-412d-93f9-b8cd9aa94e85/crypt/clickhouse_server                                                 ce930007-8ed6-4675-a24a-57c227950d43   none      none          off        
-    oxp_2a76ab1a-fb16-412d-93f9-b8cd9aa94e85/crypt/internal_dns                                                      7be88e8f-06d3-49f7-a6d9-5c586f13716c   none      none          off        
-    oxp_2a76ab1a-fb16-412d-93f9-b8cd9aa94e85/crypt/zone                                                              37405860-deb4-4f2f-b770-ab8b83175d8c   none      none          off        
-    oxp_2de2bf7e-c679-4b2b-b373-908e9d3ffbfc/crypt/zone                                                              bbb78481-c7e5-44a6-85ae-37e363827e9f   none      none          off        
-    oxp_2f02a5c6-fcf5-4b5a-bc7d-7f65369918ba/crypt/zone                                                              38103edf-a98f-46ca-94ea-3404268ea935   none      none          off        
-    oxp_32041dbf-e58d-4f32-840d-923d3d3b68af/crypt/zone                                                              3f1adfcf-9a2a-41db-9e1a-a2e13ff8a7dd   none      none          off        
-    oxp_5f88adff-bb50-4dc1-bbfb-5a410c753ed5/crypt/zone                                                              5c620f9c-454b-451b-99ca-47c3d94df493   none      none          off        
-    oxp_74d64eb9-bf69-4782-af16-2d3a761ca171/crypt/zone                                                              13f8be82-85e9-43ac-985b-e7a51a910c41   none      none          off        
-    oxp_b3c231c9-b2a5-4267-b4bf-9651881b91a5/crypt/zone                                                              9f1f99c7-e6c5-4bbc-9de5-15252b532914   none      none          off        
-    oxp_bca80b95-8dca-4a3b-b24d-d44b6a9ff71b/crypt/zone                                                              2747bb48-2fb7-4999-a63c-5ba5e35e0a10   none      none          off        
-    oxp_db16345e-427a-4c8e-9032-17270f729308/crypt/zone                                                              f7ddacf4-edc7-46ba-9b74-d588bd62505e   none      none          off        
-    oxp_e3b45593-8f0c-47b2-a381-802a7dad1f54/crypt/zone                                                              64e62d15-e813-461d-9a50-403d9bd1df7c   none      none          off        
-    oxp_2de2bf7e-c679-4b2b-b373-908e9d3ffbfc/crypt/zone/oxz_clickhouse_keeper_81a4f9fd-e502-42c2-bf9c-29dd6918fd46   6aaeeb8d-ee87-43a2-b1ef-22e5f5224842   none      none          off        
-    oxp_2a76ab1a-fb16-412d-93f9-b8cd9aa94e85/crypt/zone/oxz_clickhouse_keeper_f3279a8b-32fa-4426-b946-08aff9ded482   26c79a0e-a2e4-4093-ba43-5e7979609651   none      none          off        
-    oxp_2a76ab1a-fb16-412d-93f9-b8cd9aa94e85/crypt/zone/oxz_clickhouse_server_122e30d3-d541-49b5-88de-1543b38123cc   748c9607-71dd-4f81-be08-c1eee262f69c   none      none          off        
-    oxp_bca80b95-8dca-4a3b-b24d-d44b6a9ff71b/crypt/zone/oxz_crucible_0a160b89-6288-44f5-9908-33589094628e            53a623d2-9ffc-48fb-871d-23bd52e0f4dd   none      none          off        
-    oxp_2f02a5c6-fcf5-4b5a-bc7d-7f65369918ba/crypt/zone/oxz_crucible_2cb036bd-6056-4547-af65-aa6c0c1e4d6e            c6c9e491-ce4d-4dc4-82be-e394fa1e82e2   none      none          off        
-    oxp_2de2bf7e-c679-4b2b-b373-908e9d3ffbfc/crypt/zone/oxz_crucible_37c72edc-6acd-4c2d-ab76-d1c88e1f01f5            9b49fc13-4d2c-423e-9839-f6e1d0bffc6e   none      none          off        
-    oxp_db16345e-427a-4c8e-9032-17270f729308/crypt/zone/oxz_crucible_5fb4b72f-bf1b-47c7-a2e4-dbdafcdb47f5            1d73fc1f-81fc-4e06-9b52-686596ac0f6c   none      none          off        
-    oxp_5f88adff-bb50-4dc1-bbfb-5a410c753ed5/crypt/zone/oxz_crucible_6ae471b1-1dd8-460e-a2a5-3ea796f746d5            98b66132-d99e-42e2-8517-5860412c61b1   none      none          off        
-    oxp_2a76ab1a-fb16-412d-93f9-b8cd9aa94e85/crypt/zone/oxz_crucible_75cccfab-ea70-4596-a685-ab9bd5e540a1            e2ff081e-c5a4-42c3-8d95-969e2b9b7b31   none      none          off        
-    oxp_e3b45593-8f0c-47b2-a381-802a7dad1f54/crypt/zone/oxz_crucible_8a36ef67-bf66-40b9-a2f4-34ac70e90e39            c44e20e1-7cce-46df-ba71-db7fb3e3a5ff   none      none          off        
-    oxp_74d64eb9-bf69-4782-af16-2d3a761ca171/crypt/zone/oxz_crucible_b6a9674e-8b42-4d67-954f-3e957db298dd            e7c2d833-b6a1-469f-b52f-8bbb45e9a30e   none      none          off        
-    oxp_b3c231c9-b2a5-4267-b4bf-9651881b91a5/crypt/zone/oxz_crucible_c79e017b-7e27-4ff5-be14-3673f8cb2279            3544adde-a808-45c0-ae19-08b4f65e3ad4   none      none          off        
-    oxp_32041dbf-e58d-4f32-840d-923d3d3b68af/crypt/zone/oxz_crucible_e52381c1-d7ab-402f-a9a8-bb52fbb614af            a0251fdc-166b-4476-95d4-f7fd58fdaf76   none      none          off        
-    oxp_2a76ab1a-fb16-412d-93f9-b8cd9aa94e85/crypt/zone/oxz_crucible_pantry_1432df56-4a7b-4271-9b24-a8a3183a95a7     452dad91-0c11-4dfa-96fb-dfb0cfa1d17c   none      none          off        
-    oxp_2a76ab1a-fb16-412d-93f9-b8cd9aa94e85/crypt/zone/oxz_internal_dns_832c71a1-357d-482b-8661-3193d59ed776        08588a53-0f1d-4631-a1ef-8fa34098fbf6   none      none          off        
-    oxp_2a76ab1a-fb16-412d-93f9-b8cd9aa94e85/crypt/zone/oxz_nexus_da39dead-64e2-45b6-9d01-d99584504dfd               45dc03ec-d0e0-429a-a099-7fc6ea6dfb85   none      none          off        
-    oxp_2a76ab1a-fb16-412d-93f9-b8cd9aa94e85/crypt/zone/oxz_ntp_816afef9-e5cd-40ba-8cc5-71e783943e43                 6f5ba0fc-1b43-4a40-ba5a-3abf11eae62b   none      none          off        
-    oxp_2a76ab1a-fb16-412d-93f9-b8cd9aa94e85/crypt/debug                                                             c55ba154-4f4b-48a5-997b-2a1579671c74   100 GiB   none          gzip-9     
-    oxp_2de2bf7e-c679-4b2b-b373-908e9d3ffbfc/crypt/debug                                                             071d678d-9376-4c3b-8e1f-825d27bcae3a   100 GiB   none          gzip-9     
-    oxp_2f02a5c6-fcf5-4b5a-bc7d-7f65369918ba/crypt/debug                                                             daeded95-0145-4b97-b1fb-60d44856d1e4   100 GiB   none          gzip-9     
-    oxp_32041dbf-e58d-4f32-840d-923d3d3b68af/crypt/debug                                                             80d0697d-4ebe-4856-b7bf-78ff811eb00b   100 GiB   none          gzip-9     
-    oxp_5f88adff-bb50-4dc1-bbfb-5a410c753ed5/crypt/debug                                                             dd239ff5-a617-4eb1-ac6d-16eb76c2c849   100 GiB   none          gzip-9     
-    oxp_74d64eb9-bf69-4782-af16-2d3a761ca171/crypt/debug                                                             b9e71882-7f71-4a5e-be9c-7df560c75000   100 GiB   none          gzip-9     
-    oxp_b3c231c9-b2a5-4267-b4bf-9651881b91a5/crypt/debug                                                             bae0ee1b-b3a3-4c4c-96ee-53b8b4cd837b   100 GiB   none          gzip-9     
-    oxp_bca80b95-8dca-4a3b-b24d-d44b6a9ff71b/crypt/debug                                                             f2df23eb-672a-41b5-89e4-26c9feb50c7c   100 GiB   none          gzip-9     
-    oxp_db16345e-427a-4c8e-9032-17270f729308/crypt/debug                                                             e658be5b-df77-41fb-a000-5a924ac0b3da   100 GiB   none          gzip-9     
-    oxp_e3b45593-8f0c-47b2-a381-802a7dad1f54/crypt/debug                                                             96798a17-be94-44bb-9e12-2eb458e9a5ba   100 GiB   none          gzip-9     
+    oxp_2a76ab1a-fb16-412d-93f9-b8cd9aa94e85/crucible                                                                c73b47ac-ad1f-4cd1-b449-f220b5ad8104   none      none          off        
+    oxp_2de2bf7e-c679-4b2b-b373-908e9d3ffbfc/crucible                                                                813c7aac-695b-49ce-8bc5-f4cdbfc04b38   none      none          off        
+    oxp_2f02a5c6-fcf5-4b5a-bc7d-7f65369918ba/crucible                                                                e5da836d-fffb-4435-8500-889c05b04689   none      none          off        
+    oxp_32041dbf-e58d-4f32-840d-923d3d3b68af/crucible                                                                9f8d056c-3e84-4474-b9c7-5b7a890a8a7b   none      none          off        
+    oxp_5f88adff-bb50-4dc1-bbfb-5a410c753ed5/crucible                                                                e93cfc01-9581-4f6e-b77c-eb6300ca6ffb   none      none          off        
+    oxp_74d64eb9-bf69-4782-af16-2d3a761ca171/crucible                                                                f54d6e59-67a1-458b-8e66-6dc3b2adb755   none      none          off        
+    oxp_b3c231c9-b2a5-4267-b4bf-9651881b91a5/crucible                                                                6604dd1b-5f21-475d-952a-894717512d1b   none      none          off        
+    oxp_bca80b95-8dca-4a3b-b24d-d44b6a9ff71b/crucible                                                                05cb728f-f6b9-4132-922d-fe249b1ba736   none      none          off        
+    oxp_db16345e-427a-4c8e-9032-17270f729308/crucible                                                                500f8d46-a32d-4bd1-8f2c-cb9d36822660   none      none          off        
+    oxp_e3b45593-8f0c-47b2-a381-802a7dad1f54/crucible                                                                66c673a1-e8d8-4863-b368-a7ea292555fb   none      none          off        
+    oxp_2a76ab1a-fb16-412d-93f9-b8cd9aa94e85/crypt/clickhouse_keeper                                                 6c5a6622-5f75-45a0-a9e8-4b513f5ac352   none      none          off        
+    oxp_2de2bf7e-c679-4b2b-b373-908e9d3ffbfc/crypt/clickhouse_keeper                                                 f6464cd8-84bc-4bae-8386-c0a5a82aab95   none      none          off        
+    oxp_2a76ab1a-fb16-412d-93f9-b8cd9aa94e85/crypt/clickhouse_server                                                 f8706468-85ac-4f9f-b41d-ff7c3a17ee5f   none      none          off        
+    oxp_2a76ab1a-fb16-412d-93f9-b8cd9aa94e85/crypt/internal_dns                                                      03de030d-d958-4ce5-86d2-368fa88e0bd8   none      none          off        
+    oxp_2a76ab1a-fb16-412d-93f9-b8cd9aa94e85/crypt/zone                                                              4c3c89bd-21cf-4986-b012-e89e4e1c1ac4   none      none          off        
+    oxp_2de2bf7e-c679-4b2b-b373-908e9d3ffbfc/crypt/zone                                                              ff4a77a2-528a-4c70-a5b9-f0093c95697b   none      none          off        
+    oxp_2f02a5c6-fcf5-4b5a-bc7d-7f65369918ba/crypt/zone                                                              676fc8c5-743b-48ca-99fd-2f2379c83890   none      none          off        
+    oxp_32041dbf-e58d-4f32-840d-923d3d3b68af/crypt/zone                                                              63362c89-4b42-4649-9ebe-43e19a5c0e51   none      none          off        
+    oxp_5f88adff-bb50-4dc1-bbfb-5a410c753ed5/crypt/zone                                                              6f83a31e-1181-418f-92b0-d0534e9ae6dd   none      none          off        
+    oxp_74d64eb9-bf69-4782-af16-2d3a761ca171/crypt/zone                                                              260ffd7d-4da5-4657-9158-ba7e1eae5971   none      none          off        
+    oxp_b3c231c9-b2a5-4267-b4bf-9651881b91a5/crypt/zone                                                              ed4c8570-3951-4f79-b27e-da73150609be   none      none          off        
+    oxp_bca80b95-8dca-4a3b-b24d-d44b6a9ff71b/crypt/zone                                                              e5dcf165-3ebb-40a2-b16f-a07b036a6533   none      none          off        
+    oxp_db16345e-427a-4c8e-9032-17270f729308/crypt/zone                                                              dd27be6b-214d-4022-a99d-2a7d12e7d8bb   none      none          off        
+    oxp_e3b45593-8f0c-47b2-a381-802a7dad1f54/crypt/zone                                                              b7500d95-2499-48fc-a7d6-2460d61e197a   none      none          off        
+    oxp_2de2bf7e-c679-4b2b-b373-908e9d3ffbfc/crypt/zone/oxz_clickhouse_keeper_60cf5091-670b-48c9-a729-b82c5e7683ca   8ee3f0bb-d102-4a00-af81-72e2f284878b   none      none          off        
+    oxp_2a76ab1a-fb16-412d-93f9-b8cd9aa94e85/crypt/zone/oxz_clickhouse_keeper_7aa82b80-0c37-4f20-9398-bfce4707f327   0bf9cddb-1911-495b-8aad-09b7eea5fff4   none      none          off        
+    oxp_2a76ab1a-fb16-412d-93f9-b8cd9aa94e85/crypt/zone/oxz_clickhouse_server_812be70a-f237-47d5-ab49-f9450fe948db   292f53fc-27bb-4cc4-a61b-7d02c978149c   none      none          off        
+    oxp_32041dbf-e58d-4f32-840d-923d3d3b68af/crypt/zone/oxz_crucible_0b0e12fd-2800-4203-acb6-24e6e976271c            cf46ee68-f945-4af6-a647-4d612c1f05be   none      none          off        
+    oxp_2de2bf7e-c679-4b2b-b373-908e9d3ffbfc/crypt/zone/oxz_crucible_1a02d419-10c4-4326-b34e-eb2b1bd90bd7            2a439799-3f16-46df-ba1b-7ea29edd392d   none      none          off        
+    oxp_2a76ab1a-fb16-412d-93f9-b8cd9aa94e85/crypt/zone/oxz_crucible_56e18c31-f630-4643-ad5c-1fede34f35de            c30be90e-20cf-46c6-bb4a-b65d2c407878   none      none          off        
+    oxp_b3c231c9-b2a5-4267-b4bf-9651881b91a5/crypt/zone/oxz_crucible_5ea86015-8f62-40aa-b3b2-c659f17ee510            6289ea03-b2c9-4470-b7ba-b935450aa764   none      none          off        
+    oxp_5f88adff-bb50-4dc1-bbfb-5a410c753ed5/crypt/zone/oxz_crucible_78965849-e6e3-4250-a66a-dc50512fad34            43b36ba3-e516-4732-be8b-8cd2ca9de93c   none      none          off        
+    oxp_74d64eb9-bf69-4782-af16-2d3a761ca171/crypt/zone/oxz_crucible_90c484e5-69d3-4636-9c64-6a878f593d33            7cc8018e-323f-4d35-bb33-fcf557b9dace   none      none          off        
+    oxp_db16345e-427a-4c8e-9032-17270f729308/crypt/zone/oxz_crucible_a3901043-fa2a-4ef7-a40e-6ef0e5fd189f            88fd4e5a-50fd-43c7-8a75-0ad4376bd564   none      none          off        
+    oxp_2f02a5c6-fcf5-4b5a-bc7d-7f65369918ba/crypt/zone/oxz_crucible_be9fd98a-6422-4890-a32b-42d42d1c8957            932cbb0d-b1d0-423d-87b6-9dce8ddb6338   none      none          off        
+    oxp_e3b45593-8f0c-47b2-a381-802a7dad1f54/crypt/zone/oxz_crucible_bf71d1a8-9e65-479d-8920-0be8e3422ac5            fd0ce816-4da0-4490-be32-4d38fb78c13c   none      none          off        
+    oxp_bca80b95-8dca-4a3b-b24d-d44b6a9ff71b/crypt/zone/oxz_crucible_eb4176ea-456b-48f6-b284-7b76da0bf4a1            704ea6b5-0ffc-443f-ae8a-482666f8277c   none      none          off        
+    oxp_2a76ab1a-fb16-412d-93f9-b8cd9aa94e85/crypt/zone/oxz_crucible_pantry_417c97a4-fe25-439d-8359-3f7062981923     8957a276-6d4e-4c58-a856-d7c5433806e1   none      none          off        
+    oxp_2a76ab1a-fb16-412d-93f9-b8cd9aa94e85/crypt/zone/oxz_internal_dns_f2bbaa79-0eab-4b91-a404-dad4c19b58c2        fe0f566f-3cff-43ef-960c-649c27746c56   none      none          off        
+    oxp_2a76ab1a-fb16-412d-93f9-b8cd9aa94e85/crypt/zone/oxz_nexus_33ba37c4-2535-4095-a7e9-c69937fc584d               77d0cd16-b6e3-484d-962f-0477cd242482   none      none          off        
+    oxp_2a76ab1a-fb16-412d-93f9-b8cd9aa94e85/crypt/zone/oxz_ntp_47eab17a-4dd4-4467-90b2-f643f465cf34                 4eaf1849-1fe4-415c-bdc7-4cc04cac20ce   none      none          off        
+    oxp_2a76ab1a-fb16-412d-93f9-b8cd9aa94e85/crypt/debug                                                             c5b8f4f9-bd10-45b8-a9f3-93adf1402ecc   100 GiB   none          gzip-9     
+    oxp_2de2bf7e-c679-4b2b-b373-908e9d3ffbfc/crypt/debug                                                             43abf982-d457-46d1-8566-8047d2a78a41   100 GiB   none          gzip-9     
+    oxp_2f02a5c6-fcf5-4b5a-bc7d-7f65369918ba/crypt/debug                                                             1b6a1722-d9f7-48ea-b351-5bc8bad4fd07   100 GiB   none          gzip-9     
+    oxp_32041dbf-e58d-4f32-840d-923d3d3b68af/crypt/debug                                                             8be43fb0-00e7-4748-9a1a-ace9772d8a83   100 GiB   none          gzip-9     
+    oxp_5f88adff-bb50-4dc1-bbfb-5a410c753ed5/crypt/debug                                                             2ccb3aa9-f0ef-4fd4-9fd7-43b4a88b8d6b   100 GiB   none          gzip-9     
+    oxp_74d64eb9-bf69-4782-af16-2d3a761ca171/crypt/debug                                                             56759eb6-69e9-46a3-b44c-fc748cd506aa   100 GiB   none          gzip-9     
+    oxp_b3c231c9-b2a5-4267-b4bf-9651881b91a5/crypt/debug                                                             76fffbd2-9c74-46b5-8033-f442be1256f5   100 GiB   none          gzip-9     
+    oxp_bca80b95-8dca-4a3b-b24d-d44b6a9ff71b/crypt/debug                                                             c13a3d71-1241-42d1-95a8-d720c20ee2c4   100 GiB   none          gzip-9     
+    oxp_db16345e-427a-4c8e-9032-17270f729308/crypt/debug                                                             f030ef33-cad2-4760-9431-1907b797161b   100 GiB   none          gzip-9     
+    oxp_e3b45593-8f0c-47b2-a381-802a7dad1f54/crypt/debug                                                             947b2823-3dca-4b56-9324-f476e2c1c6da   100 GiB   none          gzip-9     
 
 
     omicron zones at generation 4:
     -----------------------------------------------------------------------------------------------
     zone type           zone id                                disposition   underlay IP           
     -----------------------------------------------------------------------------------------------
-    clickhouse_keeper   81a4f9fd-e502-42c2-bf9c-29dd6918fd46   in service    fd00:1122:3344:102::30
-    clickhouse_keeper   f3279a8b-32fa-4426-b946-08aff9ded482   in service    fd00:1122:3344:102::2e
-    clickhouse_server   122e30d3-d541-49b5-88de-1543b38123cc   in service    fd00:1122:3344:102::2f
-    crucible            0a160b89-6288-44f5-9908-33589094628e   in service    fd00:1122:3344:102::2b
-    crucible            2cb036bd-6056-4547-af65-aa6c0c1e4d6e   in service    fd00:1122:3344:102::26
-    crucible            37c72edc-6acd-4c2d-ab76-d1c88e1f01f5   in service    fd00:1122:3344:102::25
-    crucible            5fb4b72f-bf1b-47c7-a2e4-dbdafcdb47f5   in service    fd00:1122:3344:102::2c
-    crucible            6ae471b1-1dd8-460e-a2a5-3ea796f746d5   in service    fd00:1122:3344:102::28
-    crucible            75cccfab-ea70-4596-a685-ab9bd5e540a1   in service    fd00:1122:3344:102::24
-    crucible            8a36ef67-bf66-40b9-a2f4-34ac70e90e39   in service    fd00:1122:3344:102::2d
-    crucible            b6a9674e-8b42-4d67-954f-3e957db298dd   in service    fd00:1122:3344:102::29
-    crucible            c79e017b-7e27-4ff5-be14-3673f8cb2279   in service    fd00:1122:3344:102::2a
-    crucible            e52381c1-d7ab-402f-a9a8-bb52fbb614af   in service    fd00:1122:3344:102::27
-    crucible_pantry     1432df56-4a7b-4271-9b24-a8a3183a95a7   in service    fd00:1122:3344:102::23
-    internal_dns        832c71a1-357d-482b-8661-3193d59ed776   in service    fd00:1122:3344:3::1   
-    internal_ntp        816afef9-e5cd-40ba-8cc5-71e783943e43   in service    fd00:1122:3344:102::21
-    nexus               da39dead-64e2-45b6-9d01-d99584504dfd   in service    fd00:1122:3344:102::22
+    clickhouse_keeper   60cf5091-670b-48c9-a729-b82c5e7683ca   in service    fd00:1122:3344:102::30
+    clickhouse_keeper   7aa82b80-0c37-4f20-9398-bfce4707f327   in service    fd00:1122:3344:102::2e
+    clickhouse_server   812be70a-f237-47d5-ab49-f9450fe948db   in service    fd00:1122:3344:102::2f
+    crucible            0b0e12fd-2800-4203-acb6-24e6e976271c   in service    fd00:1122:3344:102::27
+    crucible            1a02d419-10c4-4326-b34e-eb2b1bd90bd7   in service    fd00:1122:3344:102::25
+    crucible            56e18c31-f630-4643-ad5c-1fede34f35de   in service    fd00:1122:3344:102::24
+    crucible            5ea86015-8f62-40aa-b3b2-c659f17ee510   in service    fd00:1122:3344:102::2a
+    crucible            78965849-e6e3-4250-a66a-dc50512fad34   in service    fd00:1122:3344:102::28
+    crucible            90c484e5-69d3-4636-9c64-6a878f593d33   in service    fd00:1122:3344:102::29
+    crucible            a3901043-fa2a-4ef7-a40e-6ef0e5fd189f   in service    fd00:1122:3344:102::2c
+    crucible            be9fd98a-6422-4890-a32b-42d42d1c8957   in service    fd00:1122:3344:102::26
+    crucible            bf71d1a8-9e65-479d-8920-0be8e3422ac5   in service    fd00:1122:3344:102::2d
+    crucible            eb4176ea-456b-48f6-b284-7b76da0bf4a1   in service    fd00:1122:3344:102::2b
+    crucible_pantry     417c97a4-fe25-439d-8359-3f7062981923   in service    fd00:1122:3344:102::23
+    internal_dns        f2bbaa79-0eab-4b91-a404-dad4c19b58c2   in service    fd00:1122:3344:3::1   
+    internal_ntp        47eab17a-4dd4-4467-90b2-f643f465cf34   in service    fd00:1122:3344:102::21
+    nexus               33ba37c4-2535-4095-a7e9-c69937fc584d   in service    fd00:1122:3344:102::22
 
 
  COCKROACHDB SETTINGS:
@@ -307,22 +307,22 @@ to:   blueprint cb39be9d-5476-44fa-9edf-9938376219ef
     max used server id:::::::::::::::::::::::::::::   2 (unchanged)
     max used keeper id:::::::::::::::::::::::::::::   4 (unchanged)
     cluster name:::::::::::::::::::::::::::::::::::   oximeter_cluster (unchanged)
-    cluster secret:::::::::::::::::::::::::::::::::   75ba7558-f7cf-431f-bba5-71c8e82fd4c1 (unchanged)
+    cluster secret:::::::::::::::::::::::::::::::::   6a984e2e-20be-4ed9-b572-d7ef063c67f7 (unchanged)
     highest seen keeper leader committed log index:   1 (unchanged)
 
     clickhouse keepers at generation 3:
     ------------------------------------------------
     zone id                                keeper id
     ------------------------------------------------
-    39fd3357-4de8-433e-9c07-1ec65de7ca59   1        
-    81a4f9fd-e502-42c2-bf9c-29dd6918fd46   4        
-    b36c16d5-de6e-411a-a32a-d35a26f2e151   2        
-    f3279a8b-32fa-4426-b946-08aff9ded482   3        
+    31a66e47-6252-4f38-aa92-f48637da152c   1        
+    60cf5091-670b-48c9-a729-b82c5e7683ca   4        
+    7aa82b80-0c37-4f20-9398-bfce4707f327   2        
+    dd5ab8b1-e6e7-40e0-9ea6-b6a16f485b52   3        
 
     clickhouse servers at generation 3:
     ------------------------------------------------
     zone id                                server id
     ------------------------------------------------
-    122e30d3-d541-49b5-88de-1543b38123cc   1        
-    71be6bff-666a-4f2b-a7dc-d80a88a71af5   2        
+    6fedfc94-2ae6-4cc7-a968-5185207284f4   1        
+    812be70a-f237-47d5-ab49-f9450fe948db   2        
 

--- a/nexus/reconfigurator/planning/tests/output/planner_expunge_clickhouse_clusters_3_4.txt
+++ b/nexus/reconfigurator/planning/tests/output/planner_expunge_clickhouse_clusters_3_4.txt
@@ -25,92 +25,92 @@ to:   blueprint 74f2e7fd-687e-4c9e-b5d8-e474a5bb8e7c
     -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
     dataset name                                                                                                     dataset uuid                           quota     reservation   compression
     -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
--   oxp_03a84dd2-e0a4-435d-96de-67bfe2674f4e/crucible                                                                1e845ee8-701d-44bf-884a-d49d537633aa   none      none          off        
--   oxp_188c3b95-16fa-45ea-b9f7-e987560b4d62/crucible                                                                2f72eaac-c969-492c-9f46-80f57d0bd429   none      none          off        
--   oxp_1f3bbc7c-888f-40fa-b705-fab3f148b147/crucible                                                                1463de0a-26e5-43e0-9f2e-3de0689adb98   none      none          off        
--   oxp_45a81e70-03bb-4c53-bf49-d598c9fb8d34/crucible                                                                eb61fcb5-80fb-4902-9256-d4921e8b91a4   none      none          off        
--   oxp_56c3f0ef-fac1-473d-9317-0e3668aa7e88/crucible                                                                b52fe96e-02dd-4ffb-a363-ec8e9f94cb49   none      none          off        
--   oxp_96f1615c-3dda-427f-8132-408b2fad24e0/crucible                                                                5a8efbe2-7191-40e5-b694-33f6ab5f20de   none      none          off        
--   oxp_a9ef71b2-ec22-421c-adc9-bddc4c0641c4/crucible                                                                3f0e3222-de30-4741-99f2-bd8cf6ecab41   none      none          off        
--   oxp_b9f9c626-3293-48eb-a475-1debaaccdf6c/crucible                                                                10ed346b-d1f7-43c7-88fd-8e7ad66db8e2   none      none          off        
--   oxp_d563fd5f-9306-49b4-8511-78a2f64733ce/crucible                                                                3f81e4d8-fefc-4586-a626-15c728242b05   none      none          off        
--   oxp_fcca32b6-9629-468f-a282-63d7da992447/crucible                                                                abbef5ad-6cae-4e18-822f-4a4d7980b1f3   none      none          off        
--   oxp_03a84dd2-e0a4-435d-96de-67bfe2674f4e/crypt/clickhouse                                                        af4a8ac4-7941-4051-bdbb-979ae82dceaa   none      none          off        
--   oxp_03a84dd2-e0a4-435d-96de-67bfe2674f4e/crypt/clickhouse_keeper                                                 90935183-8ac3-4474-aaf4-d7f29979c873   none      none          off        
--   oxp_03a84dd2-e0a4-435d-96de-67bfe2674f4e/crypt/internal_dns                                                      3262c08c-12a1-4f38-93f0-e3f53a1087aa   none      none          off        
--   oxp_03a84dd2-e0a4-435d-96de-67bfe2674f4e/crypt/zone                                                              44f9d5f4-fd7b-4684-b9c9-71cf888c79a8   none      none          off        
--   oxp_188c3b95-16fa-45ea-b9f7-e987560b4d62/crypt/zone                                                              b8d4c72d-f610-4236-8cc0-28c6c0ea5343   none      none          off        
--   oxp_1f3bbc7c-888f-40fa-b705-fab3f148b147/crypt/zone                                                              95e1d916-93b9-424a-9784-1cece05597cf   none      none          off        
--   oxp_45a81e70-03bb-4c53-bf49-d598c9fb8d34/crypt/zone                                                              92fd48ca-0e93-425e-b2cf-8b822cae7e3f   none      none          off        
--   oxp_56c3f0ef-fac1-473d-9317-0e3668aa7e88/crypt/zone                                                              995c2f94-ddc4-4de9-894b-23d813c33711   none      none          off        
--   oxp_96f1615c-3dda-427f-8132-408b2fad24e0/crypt/zone                                                              d56d2757-818a-4302-82e8-be4aac08fd66   none      none          off        
--   oxp_a9ef71b2-ec22-421c-adc9-bddc4c0641c4/crypt/zone                                                              4d802712-5773-4464-a8d9-748cca6d75c0   none      none          off        
--   oxp_b9f9c626-3293-48eb-a475-1debaaccdf6c/crypt/zone                                                              b244161f-e944-46d8-962e-5bc5a56575b7   none      none          off        
--   oxp_d563fd5f-9306-49b4-8511-78a2f64733ce/crypt/zone                                                              e9d64fda-0229-4f0b-b407-6e9f1a05e619   none      none          off        
--   oxp_fcca32b6-9629-468f-a282-63d7da992447/crypt/zone                                                              368f9afa-ceaa-4f34-a488-b64d945c1b77   none      none          off        
--   oxp_03a84dd2-e0a4-435d-96de-67bfe2674f4e/crypt/zone/oxz_clickhouse_f2c54229-d192-41bd-babc-9ca02c1206d6          783cd7d4-ce73-4fe1-8665-b0c813406f52   none      none          off        
--   oxp_03a84dd2-e0a4-435d-96de-67bfe2674f4e/crypt/zone/oxz_clickhouse_keeper_94abd717-9240-4a27-ac14-5666c1f3f3ab   e94a67fe-79b0-45b2-8cb8-0f00dd2c0c52   none      none          off        
--   oxp_45a81e70-03bb-4c53-bf49-d598c9fb8d34/crypt/zone/oxz_crucible_133e50ce-39e1-4647-8ea8-8f171a1b6471            961b3fd4-d40c-4503-90a6-8ee32a5f5315   none      none          off        
--   oxp_96f1615c-3dda-427f-8132-408b2fad24e0/crypt/zone/oxz_crucible_5078d1c7-9bc5-46a1-94e1-47ceb6f81580            530c8ac3-9a19-47c2-9057-4ae12a4377a5   none      none          off        
--   oxp_b9f9c626-3293-48eb-a475-1debaaccdf6c/crypt/zone/oxz_crucible_58a60190-35da-4ce1-b0da-298b3d64458d            6ffd174d-1b54-4de3-9654-f50df5df6953   none      none          off        
--   oxp_fcca32b6-9629-468f-a282-63d7da992447/crypt/zone/oxz_crucible_5a0af13f-c815-4df4-a7a3-c1ddfc1fc4f0            fea35514-09e5-4df1-91c1-5a186032b293   none      none          off        
--   oxp_a9ef71b2-ec22-421c-adc9-bddc4c0641c4/crypt/zone/oxz_crucible_6a703437-f546-4848-8a0a-94d4c3b20e7c            e2d4e003-2c43-40dd-b283-0b5df91a3c32   none      none          off        
--   oxp_d563fd5f-9306-49b4-8511-78a2f64733ce/crypt/zone/oxz_crucible_893d890c-4b9f-4944-a245-90ac5dab82b6            b65a7b48-f785-4481-898e-c0b49d96d706   none      none          off        
--   oxp_56c3f0ef-fac1-473d-9317-0e3668aa7e88/crypt/zone/oxz_crucible_975d60ed-46ff-4f4c-b02e-01e3cd331a6f            281d3fdc-9ed5-44f6-865b-6f03c9e7540f   none      none          off        
--   oxp_188c3b95-16fa-45ea-b9f7-e987560b4d62/crypt/zone/oxz_crucible_b5f91973-5e8e-4e58-9ebf-1b0ad3e4758e            b5109aa2-75d5-4381-96bc-15b76cf12591   none      none          off        
--   oxp_1f3bbc7c-888f-40fa-b705-fab3f148b147/crypt/zone/oxz_crucible_c0098649-b9d4-4072-9dc0-0da3e5791f1f            ac483768-9c41-409c-aec8-23bcb0917375   none      none          off        
--   oxp_03a84dd2-e0a4-435d-96de-67bfe2674f4e/crypt/zone/oxz_crucible_c3dee582-3b04-4981-90ac-e2f617c6a1ce            15772401-8406-4938-801e-6ddff28ffb32   none      none          off        
--   oxp_03a84dd2-e0a4-435d-96de-67bfe2674f4e/crypt/zone/oxz_crucible_pantry_1ee0a9f1-503c-4e38-bf76-e026afb9ac5b     cad9cbd9-6988-4ca6-97c4-ac7daeb86f28   none      none          off        
--   oxp_03a84dd2-e0a4-435d-96de-67bfe2674f4e/crypt/zone/oxz_internal_dns_9975245b-9c63-41be-8043-31117f85f905        6d2f4bb2-0b19-4751-aacc-ca8baf298960   none      none          off        
--   oxp_03a84dd2-e0a4-435d-96de-67bfe2674f4e/crypt/zone/oxz_nexus_b8f4453e-6917-4f7f-8a29-220d333bb27d               8298db30-e5f8-4004-b077-3a74abb84bb3   none      none          off        
--   oxp_03a84dd2-e0a4-435d-96de-67bfe2674f4e/crypt/zone/oxz_ntp_765ffd29-670e-4d95-aa97-8d244b6412d7                 8050d31c-aecd-44e8-9d51-31933c18ded9   none      none          off        
--   oxp_03a84dd2-e0a4-435d-96de-67bfe2674f4e/crypt/debug                                                             1d0c553a-4229-4175-9c11-22ef68191eb1   100 GiB   none          gzip-9     
--   oxp_188c3b95-16fa-45ea-b9f7-e987560b4d62/crypt/debug                                                             3f11692d-50b2-4d86-b03c-530068ac7d77   100 GiB   none          gzip-9     
--   oxp_1f3bbc7c-888f-40fa-b705-fab3f148b147/crypt/debug                                                             28bac96b-a65e-46f1-8b8d-721245314298   100 GiB   none          gzip-9     
--   oxp_45a81e70-03bb-4c53-bf49-d598c9fb8d34/crypt/debug                                                             c9ecd62c-2208-4ffb-9510-f050d299d209   100 GiB   none          gzip-9     
--   oxp_56c3f0ef-fac1-473d-9317-0e3668aa7e88/crypt/debug                                                             72fb1d98-9f11-492f-8e5a-094b686a3ad2   100 GiB   none          gzip-9     
--   oxp_96f1615c-3dda-427f-8132-408b2fad24e0/crypt/debug                                                             b38bd0a3-106f-4771-a50a-8dae79e2db48   100 GiB   none          gzip-9     
--   oxp_a9ef71b2-ec22-421c-adc9-bddc4c0641c4/crypt/debug                                                             1bac2a69-8575-4247-8f78-94b4ca69f7a2   100 GiB   none          gzip-9     
--   oxp_b9f9c626-3293-48eb-a475-1debaaccdf6c/crypt/debug                                                             1d77d74d-1fa8-4e8c-a64f-f1a38f6c81ea   100 GiB   none          gzip-9     
--   oxp_d563fd5f-9306-49b4-8511-78a2f64733ce/crypt/debug                                                             43b14456-1b4a-4afe-bf5d-cf31124e0d18   100 GiB   none          gzip-9     
--   oxp_fcca32b6-9629-468f-a282-63d7da992447/crypt/debug                                                             b17bf396-1fc8-4cfc-ad16-445bbc105688   100 GiB   none          gzip-9     
+-   oxp_03a84dd2-e0a4-435d-96de-67bfe2674f4e/crucible                                                                d40442a5-6bc0-47e2-b856-eaf133d1e304   none      none          off        
+-   oxp_188c3b95-16fa-45ea-b9f7-e987560b4d62/crucible                                                                3c535eee-1560-47b0-be54-ae5a72f81ed7   none      none          off        
+-   oxp_1f3bbc7c-888f-40fa-b705-fab3f148b147/crucible                                                                1cc83d94-5150-4c1b-9e60-5520e5dedfbb   none      none          off        
+-   oxp_45a81e70-03bb-4c53-bf49-d598c9fb8d34/crucible                                                                240113d4-845f-4183-b4a7-e8c994e062b7   none      none          off        
+-   oxp_56c3f0ef-fac1-473d-9317-0e3668aa7e88/crucible                                                                01887c83-946b-463c-a58a-8398019e5a2c   none      none          off        
+-   oxp_96f1615c-3dda-427f-8132-408b2fad24e0/crucible                                                                e9dc86e8-1628-4168-88fc-274b0698d692   none      none          off        
+-   oxp_a9ef71b2-ec22-421c-adc9-bddc4c0641c4/crucible                                                                3891477e-b97e-4917-a8e0-558852169291   none      none          off        
+-   oxp_b9f9c626-3293-48eb-a475-1debaaccdf6c/crucible                                                                3c1cb24a-963a-448e-a7a1-7c701e3c9b2a   none      none          off        
+-   oxp_d563fd5f-9306-49b4-8511-78a2f64733ce/crucible                                                                bae3e304-87d5-49b5-aeac-8d6ad6849893   none      none          off        
+-   oxp_fcca32b6-9629-468f-a282-63d7da992447/crucible                                                                61f460f4-0afe-4be7-8021-be98ebf8e6a7   none      none          off        
+-   oxp_03a84dd2-e0a4-435d-96de-67bfe2674f4e/crypt/clickhouse                                                        dc455819-f15b-410e-bcf1-8c2f728d2c28   none      none          off        
+-   oxp_03a84dd2-e0a4-435d-96de-67bfe2674f4e/crypt/clickhouse_keeper                                                 4b06dacf-0426-4474-8f23-d2cc89cebf79   none      none          off        
+-   oxp_03a84dd2-e0a4-435d-96de-67bfe2674f4e/crypt/internal_dns                                                      4bb9b134-29cc-48f7-ab87-fe8d848d3bcb   none      none          off        
+-   oxp_03a84dd2-e0a4-435d-96de-67bfe2674f4e/crypt/zone                                                              f60180c7-5adc-46cd-95bf-eada188126d5   none      none          off        
+-   oxp_188c3b95-16fa-45ea-b9f7-e987560b4d62/crypt/zone                                                              7b71a19c-0787-4289-8758-62e730b8eea7   none      none          off        
+-   oxp_1f3bbc7c-888f-40fa-b705-fab3f148b147/crypt/zone                                                              5d7b3a35-7748-4add-9c45-8c13fffa6242   none      none          off        
+-   oxp_45a81e70-03bb-4c53-bf49-d598c9fb8d34/crypt/zone                                                              4468c7cd-c756-42c5-8974-5b2fd12fe7d8   none      none          off        
+-   oxp_56c3f0ef-fac1-473d-9317-0e3668aa7e88/crypt/zone                                                              063e51c0-4b74-45f3-899e-4f47e405c885   none      none          off        
+-   oxp_96f1615c-3dda-427f-8132-408b2fad24e0/crypt/zone                                                              1c629490-3edb-45ad-a45e-30a6fa049dc5   none      none          off        
+-   oxp_a9ef71b2-ec22-421c-adc9-bddc4c0641c4/crypt/zone                                                              85569c4c-044f-4f6f-a25d-137a53ed52c1   none      none          off        
+-   oxp_b9f9c626-3293-48eb-a475-1debaaccdf6c/crypt/zone                                                              40e94b66-4686-48f3-b606-6ba7d992c8f2   none      none          off        
+-   oxp_d563fd5f-9306-49b4-8511-78a2f64733ce/crypt/zone                                                              626ecfdb-dfd7-4ff6-bec6-391c9c44b0e4   none      none          off        
+-   oxp_fcca32b6-9629-468f-a282-63d7da992447/crypt/zone                                                              e61020a5-742a-4ee8-bda3-08e6f0a776be   none      none          off        
+-   oxp_03a84dd2-e0a4-435d-96de-67bfe2674f4e/crypt/zone/oxz_clickhouse_96dcbb7a-0140-4590-801c-406866500995          87252c34-5d73-4d3a-bce6-6a27dad3fdf6   none      none          off        
+-   oxp_03a84dd2-e0a4-435d-96de-67bfe2674f4e/crypt/zone/oxz_clickhouse_keeper_1998de68-a305-44f7-8ebc-cc5613c9e6fb   485f09fd-df18-4d81-a4e7-ba7109c56f86   none      none          off        
+-   oxp_a9ef71b2-ec22-421c-adc9-bddc4c0641c4/crypt/zone/oxz_crucible_5366862d-0c9e-4c21-bd16-5599298e75bc            3aa44cc5-0d66-48c3-b4ca-2bf69f9b885e   none      none          off        
+-   oxp_45a81e70-03bb-4c53-bf49-d598c9fb8d34/crypt/zone/oxz_crucible_63dcf460-2794-434c-b0e7-4e09ba0f3a3c            80773e28-95b8-4c87-8066-96217d4f91fc   none      none          off        
+-   oxp_fcca32b6-9629-468f-a282-63d7da992447/crypt/zone/oxz_crucible_71f24994-337b-4c5f-9826-75f885a669e7            f41aa130-536c-419f-841b-6b70f5d7f04e   none      none          off        
+-   oxp_188c3b95-16fa-45ea-b9f7-e987560b4d62/crypt/zone/oxz_crucible_726f6522-a359-4e6e-abe9-0de41979de91            e536abb6-5358-42a9-bda0-ccdd4040bc76   none      none          off        
+-   oxp_d563fd5f-9306-49b4-8511-78a2f64733ce/crypt/zone/oxz_crucible_a794a5cd-ec63-4fe4-a813-720d79dcd2ca            46694e7d-bce7-4b0e-a900-a192b4091435   none      none          off        
+-   oxp_03a84dd2-e0a4-435d-96de-67bfe2674f4e/crypt/zone/oxz_crucible_ab480489-af1c-4446-8e95-da4a7e58df59            90052aeb-7130-4ff2-aa27-5cf3b04fbb8c   none      none          off        
+-   oxp_b9f9c626-3293-48eb-a475-1debaaccdf6c/crypt/zone/oxz_crucible_cc6e2a17-ba9b-4332-b869-e0ce204915cf            98b4a865-2894-4cd2-ac6b-e738281c58bb   none      none          off        
+-   oxp_56c3f0ef-fac1-473d-9317-0e3668aa7e88/crypt/zone/oxz_crucible_e5cd215f-19c6-43ca-b31a-039319dd5dcf            36ff569c-9c13-49ea-9326-475045f720b0   none      none          off        
+-   oxp_96f1615c-3dda-427f-8132-408b2fad24e0/crypt/zone/oxz_crucible_e7bc709c-4ef2-4f1f-be78-494f53169554            97bb7eaf-90b4-4a0b-802a-fa8505ec75bd   none      none          off        
+-   oxp_1f3bbc7c-888f-40fa-b705-fab3f148b147/crypt/zone/oxz_crucible_fbaea242-74a6-490f-9bc0-0710a40768f4            c9cbc06f-28a0-4599-9871-34d1412af931   none      none          off        
+-   oxp_03a84dd2-e0a4-435d-96de-67bfe2674f4e/crypt/zone/oxz_crucible_pantry_ed79fef8-6124-4ecc-aaa4-51cf9fcf58db     9dd5432c-c9fc-4d94-8536-f17d51179351   none      none          off        
+-   oxp_03a84dd2-e0a4-435d-96de-67bfe2674f4e/crypt/zone/oxz_internal_dns_4d152a2b-089e-4fe2-89fa-76b53fa58773        c4e8da9a-abce-419c-ad1f-3e5ba3277bbd   none      none          off        
+-   oxp_03a84dd2-e0a4-435d-96de-67bfe2674f4e/crypt/zone/oxz_nexus_4cb9b6d5-fd52-4cfb-b630-59f80bd26615               fcf013e5-369d-46a8-b613-827c09a19609   none      none          off        
+-   oxp_03a84dd2-e0a4-435d-96de-67bfe2674f4e/crypt/zone/oxz_ntp_89d38277-9743-491b-af94-714776657ce2                 d7c7f6d8-8cbf-4e89-9910-beeddeced77d   none      none          off        
+-   oxp_03a84dd2-e0a4-435d-96de-67bfe2674f4e/crypt/debug                                                             bc75e6c5-7133-4fcb-8331-e14094471da3   100 GiB   none          gzip-9     
+-   oxp_188c3b95-16fa-45ea-b9f7-e987560b4d62/crypt/debug                                                             2682e3a1-a848-4e3c-93f0-3fd6f0d9bb42   100 GiB   none          gzip-9     
+-   oxp_1f3bbc7c-888f-40fa-b705-fab3f148b147/crypt/debug                                                             3ce1e570-2d1f-4898-ab97-de7984c655ea   100 GiB   none          gzip-9     
+-   oxp_45a81e70-03bb-4c53-bf49-d598c9fb8d34/crypt/debug                                                             c01b1d43-aa78-4faf-a8ca-dcc06af33a6c   100 GiB   none          gzip-9     
+-   oxp_56c3f0ef-fac1-473d-9317-0e3668aa7e88/crypt/debug                                                             8246cb67-ed7a-4116-a3d7-565ac65f93b6   100 GiB   none          gzip-9     
+-   oxp_96f1615c-3dda-427f-8132-408b2fad24e0/crypt/debug                                                             56460589-94e8-4f23-9a19-e33394556f15   100 GiB   none          gzip-9     
+-   oxp_a9ef71b2-ec22-421c-adc9-bddc4c0641c4/crypt/debug                                                             3e4f8418-ecac-487d-8ee6-fda164388f77   100 GiB   none          gzip-9     
+-   oxp_b9f9c626-3293-48eb-a475-1debaaccdf6c/crypt/debug                                                             f93f289f-6d12-477c-a2d3-28a8d6d71413   100 GiB   none          gzip-9     
+-   oxp_d563fd5f-9306-49b4-8511-78a2f64733ce/crypt/debug                                                             71bee626-79e5-4bc7-98af-e0cf412bbcba   100 GiB   none          gzip-9     
+-   oxp_fcca32b6-9629-468f-a282-63d7da992447/crypt/debug                                                             402246fc-dfe5-410c-92c0-d9d497c03188   100 GiB   none          gzip-9     
 
 
     omicron zones generation 3 -> 4:
     ------------------------------------------------------------------------------------------------
     zone type           zone id                                disposition    underlay IP           
     ------------------------------------------------------------------------------------------------
-*   clickhouse          f2c54229-d192-41bd-babc-9ca02c1206d6   - in service   fd00:1122:3344:101::23
+*   clickhouse          96dcbb7a-0140-4590-801c-406866500995   - in service   fd00:1122:3344:101::23
      └─                                                        + expunged                           
-*   clickhouse_keeper   94abd717-9240-4a27-ac14-5666c1f3f3ab   - in service   fd00:1122:3344:101::2f
+*   clickhouse_keeper   1998de68-a305-44f7-8ebc-cc5613c9e6fb   - in service   fd00:1122:3344:101::2f
      └─                                                        + expunged                           
-*   crucible            133e50ce-39e1-4647-8ea8-8f171a1b6471   - in service   fd00:1122:3344:101::28
+*   crucible            5366862d-0c9e-4c21-bd16-5599298e75bc   - in service   fd00:1122:3344:101::2b
      └─                                                        + expunged                           
-*   crucible            5078d1c7-9bc5-46a1-94e1-47ceb6f81580   - in service   fd00:1122:3344:101::2a
+*   crucible            63dcf460-2794-434c-b0e7-4e09ba0f3a3c   - in service   fd00:1122:3344:101::28
      └─                                                        + expunged                           
-*   crucible            58a60190-35da-4ce1-b0da-298b3d64458d   - in service   fd00:1122:3344:101::2c
+*   crucible            71f24994-337b-4c5f-9826-75f885a669e7   - in service   fd00:1122:3344:101::2e
      └─                                                        + expunged                           
-*   crucible            5a0af13f-c815-4df4-a7a3-c1ddfc1fc4f0   - in service   fd00:1122:3344:101::2e
+*   crucible            726f6522-a359-4e6e-abe9-0de41979de91   - in service   fd00:1122:3344:101::26
      └─                                                        + expunged                           
-*   crucible            6a703437-f546-4848-8a0a-94d4c3b20e7c   - in service   fd00:1122:3344:101::2b
+*   crucible            a794a5cd-ec63-4fe4-a813-720d79dcd2ca   - in service   fd00:1122:3344:101::2d
      └─                                                        + expunged                           
-*   crucible            893d890c-4b9f-4944-a245-90ac5dab82b6   - in service   fd00:1122:3344:101::2d
+*   crucible            ab480489-af1c-4446-8e95-da4a7e58df59   - in service   fd00:1122:3344:101::25
      └─                                                        + expunged                           
-*   crucible            975d60ed-46ff-4f4c-b02e-01e3cd331a6f   - in service   fd00:1122:3344:101::29
+*   crucible            cc6e2a17-ba9b-4332-b869-e0ce204915cf   - in service   fd00:1122:3344:101::2c
      └─                                                        + expunged                           
-*   crucible            b5f91973-5e8e-4e58-9ebf-1b0ad3e4758e   - in service   fd00:1122:3344:101::26
+*   crucible            e5cd215f-19c6-43ca-b31a-039319dd5dcf   - in service   fd00:1122:3344:101::29
      └─                                                        + expunged                           
-*   crucible            c0098649-b9d4-4072-9dc0-0da3e5791f1f   - in service   fd00:1122:3344:101::27
+*   crucible            e7bc709c-4ef2-4f1f-be78-494f53169554   - in service   fd00:1122:3344:101::2a
      └─                                                        + expunged                           
-*   crucible            c3dee582-3b04-4981-90ac-e2f617c6a1ce   - in service   fd00:1122:3344:101::25
+*   crucible            fbaea242-74a6-490f-9bc0-0710a40768f4   - in service   fd00:1122:3344:101::27
      └─                                                        + expunged                           
-*   crucible_pantry     1ee0a9f1-503c-4e38-bf76-e026afb9ac5b   - in service   fd00:1122:3344:101::24
+*   crucible_pantry     ed79fef8-6124-4ecc-aaa4-51cf9fcf58db   - in service   fd00:1122:3344:101::24
      └─                                                        + expunged                           
-*   internal_dns        9975245b-9c63-41be-8043-31117f85f905   - in service   fd00:1122:3344:1::1   
+*   internal_dns        4d152a2b-089e-4fe2-89fa-76b53fa58773   - in service   fd00:1122:3344:1::1   
      └─                                                        + expunged                           
-*   internal_ntp        765ffd29-670e-4d95-aa97-8d244b6412d7   - in service   fd00:1122:3344:101::21
+*   internal_ntp        89d38277-9743-491b-af94-714776657ce2   - in service   fd00:1122:3344:101::21
      └─                                                        + expunged                           
-*   nexus               b8f4453e-6917-4f7f-8a29-220d333bb27d   - in service   fd00:1122:3344:101::22
+*   nexus               4cb9b6d5-fd52-4cfb-b630-59f80bd26615   - in service   fd00:1122:3344:101::22
      └─                                                        + expunged                           
 
 
@@ -136,83 +136,83 @@ to:   blueprint 74f2e7fd-687e-4c9e-b5d8-e474a5bb8e7c
     -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
     dataset name                                                                                                     dataset uuid                           quota     reservation   compression
     -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
-    oxp_08616473-ded4-4785-9b53-b6ccc1efb67a/crucible                                                                3d575592-90d1-4f09-8ebd-cfb0d7348492   none      none          off        
-    oxp_2d44b756-94df-45ec-a644-50021248682d/crucible                                                                6875e6ae-d773-4c38-b075-74d54c7664c5   none      none          off        
-    oxp_2dce7cf0-3097-485d-aaf6-9fc51f99eae5/crucible                                                                1afdddf6-2c5d-4b57-b732-d451fe9d339a   none      none          off        
-    oxp_3b9d69e5-aa80-4fc8-9d2e-a2a24bd0f1d7/crucible                                                                99df049c-d495-4cdc-800e-a0deb8a12407   none      none          off        
-    oxp_44342c41-75a7-4708-8004-eb2ca5c5a3c2/crucible                                                                97bcdcd3-c71f-4a6a-8dbe-fb79f0e0cd8c   none      none          off        
-    oxp_650b4eff-80a2-430a-97c8-f837248480a1/crucible                                                                5d445c3a-92ff-4951-964d-cbb35dce0ffb   none      none          off        
-    oxp_6e418b8c-cadd-4fb8-8370-f351a07e1eed/crucible                                                                efce20c8-c6ad-4e1a-a489-1391a02ff73e   none      none          off        
-    oxp_6e5772a5-8234-46d1-ba5a-503a83d9d2fb/crucible                                                                9292d1a7-786c-448b-86ea-4cdb7c29df73   none      none          off        
-    oxp_c1da692e-7713-43a0-b6bb-5c182084c09d/crucible                                                                5967609a-83a6-4feb-8d46-25c3ca7fce12   none      none          off        
-    oxp_e35766ef-789a-4b2f-9a6c-e6626d5ab195/crucible                                                                97ff78ad-4939-4308-9dde-7bd94dc55741   none      none          off        
-    oxp_08616473-ded4-4785-9b53-b6ccc1efb67a/crypt/clickhouse_keeper                                                 dda523f9-2078-42b1-a581-bad8349bb592   none      none          off        
-    oxp_08616473-ded4-4785-9b53-b6ccc1efb67a/crypt/clickhouse_server                                                 14389e8b-952f-4e20-aabd-3741493fb444   none      none          off        
-    oxp_08616473-ded4-4785-9b53-b6ccc1efb67a/crypt/internal_dns                                                      1e34af87-308a-4192-be38-193f0c89390a   none      none          off        
-    oxp_08616473-ded4-4785-9b53-b6ccc1efb67a/crypt/zone                                                              a27426fd-6f66-475d-bb6e-4422618ae009   none      none          off        
-    oxp_2d44b756-94df-45ec-a644-50021248682d/crypt/zone                                                              a38bec7e-50fc-4a0d-b0de-15023a542367   none      none          off        
-    oxp_2dce7cf0-3097-485d-aaf6-9fc51f99eae5/crypt/zone                                                              1cee8f96-b8e2-4983-8c65-ba8338eb781c   none      none          off        
-    oxp_3b9d69e5-aa80-4fc8-9d2e-a2a24bd0f1d7/crypt/zone                                                              b265dd36-3a93-4ad9-bca1-8e76abea9f90   none      none          off        
-    oxp_44342c41-75a7-4708-8004-eb2ca5c5a3c2/crypt/zone                                                              caa97a7b-1c7d-4a2b-a9e7-12588f942a8c   none      none          off        
-    oxp_650b4eff-80a2-430a-97c8-f837248480a1/crypt/zone                                                              0921cbb1-02ad-4de5-9c60-c4a8aca25579   none      none          off        
-    oxp_6e418b8c-cadd-4fb8-8370-f351a07e1eed/crypt/zone                                                              7197059c-e461-43b1-a050-95740f239dc7   none      none          off        
-    oxp_6e5772a5-8234-46d1-ba5a-503a83d9d2fb/crypt/zone                                                              0292217f-5be3-440f-976b-6bab7043992f   none      none          off        
-    oxp_c1da692e-7713-43a0-b6bb-5c182084c09d/crypt/zone                                                              c7345d22-765f-4892-993f-de910ac5055b   none      none          off        
-    oxp_e35766ef-789a-4b2f-9a6c-e6626d5ab195/crypt/zone                                                              d37c8162-c363-447f-b4be-da14fb97b181   none      none          off        
-    oxp_08616473-ded4-4785-9b53-b6ccc1efb67a/crypt/zone/oxz_clickhouse_keeper_fe395a2c-219b-4ad7-9f51-f536de60a9e4   1331d93d-4191-48ea-ae98-9554f9aabcd8   none      none          off        
-    oxp_08616473-ded4-4785-9b53-b6ccc1efb67a/crypt/zone/oxz_clickhouse_server_23ee16e1-7f1f-4a76-b4fc-32921eead60e   fef210d9-1473-4294-afa4-90e1f1836b86   none      none          off        
-    oxp_650b4eff-80a2-430a-97c8-f837248480a1/crypt/zone/oxz_crucible_0c50f6a6-55f0-4d9e-920e-c16b4e2f3b4f            34c4fcb0-c6d4-4f47-8153-a8b16e8c9c09   none      none          off        
-    oxp_44342c41-75a7-4708-8004-eb2ca5c5a3c2/crypt/zone/oxz_crucible_377d8477-7608-4248-b925-6a2c5e04fee3            3000bfbb-7faa-4439-914c-84815c5d75ea   none      none          off        
-    oxp_2dce7cf0-3097-485d-aaf6-9fc51f99eae5/crypt/zone/oxz_crucible_42ec7ad4-4a8a-4e7f-8291-bcc3a141647b            8e2fc466-8b2a-4be6-ba66-2bd8ef658a5d   none      none          off        
-    oxp_2d44b756-94df-45ec-a644-50021248682d/crypt/zone/oxz_crucible_4a152e9b-240b-4213-92fc-d205bc67c138            3a96f6b5-bf00-4f0d-b9d9-f718ac8c8672   none      none          off        
-    oxp_e35766ef-789a-4b2f-9a6c-e6626d5ab195/crypt/zone/oxz_crucible_5135c26c-5118-4dd0-a9a7-e2c46bd32b91            83321216-d04c-4dfc-99de-36dc1216c566   none      none          off        
-    oxp_c1da692e-7713-43a0-b6bb-5c182084c09d/crypt/zone/oxz_crucible_6d8c8a4f-82fc-47a9-b894-3c1dddd86343            a205bb5f-d9d9-43c1-aafb-fc872ca159b8   none      none          off        
-    oxp_6e5772a5-8234-46d1-ba5a-503a83d9d2fb/crypt/zone/oxz_crucible_9dce96c1-4f76-4e17-96de-aa867344581f            2d590e4c-8b2a-4021-baf1-3fc1a33a6130   none      none          off        
-    oxp_6e418b8c-cadd-4fb8-8370-f351a07e1eed/crypt/zone/oxz_crucible_cf0943f4-1f4c-4531-8412-ecab1d1df36f            a9cc6710-a9c1-44f0-aebb-26c708718918   none      none          off        
-    oxp_3b9d69e5-aa80-4fc8-9d2e-a2a24bd0f1d7/crypt/zone/oxz_crucible_e432e610-e600-4d1c-9427-e965afe2d54a            9d7b361b-ed6e-4bdb-a8b7-1f6736026e11   none      none          off        
-    oxp_08616473-ded4-4785-9b53-b6ccc1efb67a/crypt/zone/oxz_crucible_e83d6088-9e82-40dd-b8e9-b5bafe23d358            d989e55b-60c1-44c6-a37b-e081d9d49313   none      none          off        
-    oxp_08616473-ded4-4785-9b53-b6ccc1efb67a/crypt/zone/oxz_crucible_pantry_67e03ab1-90ac-45b5-9487-d892752201e1     26980dc7-7079-4a88-b01b-d75881aee578   none      none          off        
-    oxp_08616473-ded4-4785-9b53-b6ccc1efb67a/crypt/zone/oxz_internal_dns_b5e0f928-60cd-4040-a6f2-5ad45ac50814        00e9e911-b36e-4371-b55a-b67a885c1650   none      none          off        
-    oxp_08616473-ded4-4785-9b53-b6ccc1efb67a/crypt/zone/oxz_nexus_3150ecb4-973e-4467-b194-632539bbdf07               2441284a-c8b4-4eb9-8988-5f7f64fcb7cc   none      none          off        
-    oxp_08616473-ded4-4785-9b53-b6ccc1efb67a/crypt/zone/oxz_ntp_663835e0-d8bc-41ea-b79f-bd85997777ce                 6c266f89-6820-45ba-8d53-8e2952a89f70   none      none          off        
-    oxp_08616473-ded4-4785-9b53-b6ccc1efb67a/crypt/debug                                                             c619b70f-4542-40ba-8cb6-1641df0b1a11   100 GiB   none          gzip-9     
-    oxp_2d44b756-94df-45ec-a644-50021248682d/crypt/debug                                                             c4f52f42-f6d1-40a3-bb3e-0a684ce06338   100 GiB   none          gzip-9     
-    oxp_2dce7cf0-3097-485d-aaf6-9fc51f99eae5/crypt/debug                                                             c857ccb3-eb0a-4220-aa80-e7c22d2f7be4   100 GiB   none          gzip-9     
-    oxp_3b9d69e5-aa80-4fc8-9d2e-a2a24bd0f1d7/crypt/debug                                                             f0808ff2-ce3a-4434-971b-055acb097d8d   100 GiB   none          gzip-9     
-    oxp_44342c41-75a7-4708-8004-eb2ca5c5a3c2/crypt/debug                                                             e6c0e102-f69d-4e14-bc52-7e03ae82cd0a   100 GiB   none          gzip-9     
-    oxp_650b4eff-80a2-430a-97c8-f837248480a1/crypt/debug                                                             0b84fd36-2a53-4420-b580-8a7ab5e44adb   100 GiB   none          gzip-9     
-    oxp_6e418b8c-cadd-4fb8-8370-f351a07e1eed/crypt/debug                                                             52d22143-4c25-45cf-a443-62e63052e385   100 GiB   none          gzip-9     
-    oxp_6e5772a5-8234-46d1-ba5a-503a83d9d2fb/crypt/debug                                                             ef0c1012-a349-4868-9175-e0a5e117614b   100 GiB   none          gzip-9     
-    oxp_c1da692e-7713-43a0-b6bb-5c182084c09d/crypt/debug                                                             0bf0d153-d9fb-42ed-a98f-839ca7c272bc   100 GiB   none          gzip-9     
-    oxp_e35766ef-789a-4b2f-9a6c-e6626d5ab195/crypt/debug                                                             3588412a-4f56-419c-b10c-0eef2c6a2c31   100 GiB   none          gzip-9     
-+   oxp_2d44b756-94df-45ec-a644-50021248682d/crypt/clickhouse_keeper                                                 f2bbe72f-ae6c-4ee2-a2f3-eae54527048d   none      none          off        
-+   oxp_2d44b756-94df-45ec-a644-50021248682d/crypt/internal_dns                                                      0dc5f030-0bde-4fff-a0b6-f7c8fcc3e532   none      none          off        
-+   oxp_2d44b756-94df-45ec-a644-50021248682d/crypt/zone/oxz_clickhouse_keeper_e4052979-f949-44bf-91de-17b371d3e518   da028e64-33e1-4380-8544-19e6ce754b20   none      none          off        
-+   oxp_2d44b756-94df-45ec-a644-50021248682d/crypt/zone/oxz_internal_dns_1cd50cc3-c098-4fe3-ae5b-af0344f0b6ec        46273d48-d966-4cee-8af9-d3e7f5f38ac3   none      none          off        
+    oxp_08616473-ded4-4785-9b53-b6ccc1efb67a/crucible                                                                7576ef1f-3e41-44cc-b750-9b397374e234   none      none          off        
+    oxp_2d44b756-94df-45ec-a644-50021248682d/crucible                                                                4c886e70-05ef-437c-a7ab-ba8a1b5cf9af   none      none          off        
+    oxp_2dce7cf0-3097-485d-aaf6-9fc51f99eae5/crucible                                                                ec7693f9-a469-48ad-8f8d-6d0bc0138be8   none      none          off        
+    oxp_3b9d69e5-aa80-4fc8-9d2e-a2a24bd0f1d7/crucible                                                                b3ad0776-d6f0-4cbd-a382-a1b78576753b   none      none          off        
+    oxp_44342c41-75a7-4708-8004-eb2ca5c5a3c2/crucible                                                                8d7eebdb-c82f-4a29-b3c3-290bd343814a   none      none          off        
+    oxp_650b4eff-80a2-430a-97c8-f837248480a1/crucible                                                                a30613bb-70dd-43dd-b23c-c8759df0acdd   none      none          off        
+    oxp_6e418b8c-cadd-4fb8-8370-f351a07e1eed/crucible                                                                251a271a-0469-4309-ba94-7ecd827e3425   none      none          off        
+    oxp_6e5772a5-8234-46d1-ba5a-503a83d9d2fb/crucible                                                                8a62b925-a1cf-493a-a05e-67fc73605d82   none      none          off        
+    oxp_c1da692e-7713-43a0-b6bb-5c182084c09d/crucible                                                                649edc79-adc6-4391-a105-a54be7143259   none      none          off        
+    oxp_e35766ef-789a-4b2f-9a6c-e6626d5ab195/crucible                                                                8f1039b4-fd76-4444-802c-96385e68abde   none      none          off        
+    oxp_08616473-ded4-4785-9b53-b6ccc1efb67a/crypt/clickhouse_keeper                                                 00f7bc76-5861-485e-a7a7-8bc475950804   none      none          off        
+    oxp_08616473-ded4-4785-9b53-b6ccc1efb67a/crypt/clickhouse_server                                                 12e71b76-b549-4357-8209-215144d61723   none      none          off        
+    oxp_08616473-ded4-4785-9b53-b6ccc1efb67a/crypt/internal_dns                                                      f2c56628-2b29-42da-9ce3-ca705a0e4a97   none      none          off        
+    oxp_08616473-ded4-4785-9b53-b6ccc1efb67a/crypt/zone                                                              6c76a56e-edc0-46e8-92b4-162920f7de33   none      none          off        
+    oxp_2d44b756-94df-45ec-a644-50021248682d/crypt/zone                                                              ce9648f6-3e8f-4c4f-a116-d57aff785b51   none      none          off        
+    oxp_2dce7cf0-3097-485d-aaf6-9fc51f99eae5/crypt/zone                                                              0c0b9b34-0f11-480b-bc42-83ab3cfb3667   none      none          off        
+    oxp_3b9d69e5-aa80-4fc8-9d2e-a2a24bd0f1d7/crypt/zone                                                              cb900fc0-fd1e-42fd-8e0b-491454d70d5e   none      none          off        
+    oxp_44342c41-75a7-4708-8004-eb2ca5c5a3c2/crypt/zone                                                              cae317ef-de63-4265-a0d7-777c5a70dd4e   none      none          off        
+    oxp_650b4eff-80a2-430a-97c8-f837248480a1/crypt/zone                                                              fec03736-ce6e-444e-b7dc-30ae3d00e502   none      none          off        
+    oxp_6e418b8c-cadd-4fb8-8370-f351a07e1eed/crypt/zone                                                              c22dfc9e-b068-4b85-ae0a-e81bc67f679a   none      none          off        
+    oxp_6e5772a5-8234-46d1-ba5a-503a83d9d2fb/crypt/zone                                                              8b954de0-88d8-4a00-902f-e612eed9da0c   none      none          off        
+    oxp_c1da692e-7713-43a0-b6bb-5c182084c09d/crypt/zone                                                              27d840dc-67e6-4795-8bb1-427213d0df3e   none      none          off        
+    oxp_e35766ef-789a-4b2f-9a6c-e6626d5ab195/crypt/zone                                                              b8e322e8-fe4f-43e8-b51a-d08b12f7e515   none      none          off        
+    oxp_08616473-ded4-4785-9b53-b6ccc1efb67a/crypt/zone/oxz_clickhouse_keeper_3f78fa04-0b7e-4959-9718-c232c76500e1   cbe9ab91-b85c-490d-8561-739c66bd2bee   none      none          off        
+    oxp_08616473-ded4-4785-9b53-b6ccc1efb67a/crypt/zone/oxz_clickhouse_server_f0341fc6-6a73-4318-8787-dd0c6b26c385   39e58c15-5cb4-4f89-9bb3-adef453e9e3d   none      none          off        
+    oxp_650b4eff-80a2-430a-97c8-f837248480a1/crypt/zone/oxz_crucible_49afbe38-6b68-4764-afae-a279a7b9b1ab            3d258387-fe93-49c1-8cad-135b3f3556bf   none      none          off        
+    oxp_6e418b8c-cadd-4fb8-8370-f351a07e1eed/crypt/zone/oxz_crucible_4a223081-0985-45c7-b60e-478c371fde4b            69e7fb35-ff48-4d47-986f-374ce7ebac71   none      none          off        
+    oxp_2d44b756-94df-45ec-a644-50021248682d/crypt/zone/oxz_crucible_4e11460c-cfd2-4fa3-a7a7-25c976accece            6b5f0710-4fab-4921-b1ba-05de5d9ff2c3   none      none          off        
+    oxp_c1da692e-7713-43a0-b6bb-5c182084c09d/crypt/zone/oxz_crucible_4f7d1ee4-bd7b-48a5-99e0-e61fc8e6e58e            45831cd5-d578-4473-a97a-f737aedd9903   none      none          off        
+    oxp_08616473-ded4-4785-9b53-b6ccc1efb67a/crypt/zone/oxz_crucible_7cc30ab4-c566-42d4-8fb0-31a8a27156ff            df1af4ad-ec0e-4094-b8f2-d7ce592f40c0   none      none          off        
+    oxp_6e5772a5-8234-46d1-ba5a-503a83d9d2fb/crypt/zone/oxz_crucible_a50a59b8-b59a-4f1d-b5d4-41f113802b5f            c2832f18-d620-49d0-9c8e-b2fc9871e06f   none      none          off        
+    oxp_44342c41-75a7-4708-8004-eb2ca5c5a3c2/crypt/zone/oxz_crucible_a8839f9e-93f8-42a2-ac3a-9b804a5316f9            fdbdb20f-3a77-4da9-afff-96e7ac54f297   none      none          off        
+    oxp_3b9d69e5-aa80-4fc8-9d2e-a2a24bd0f1d7/crypt/zone/oxz_crucible_da1d617e-6450-4bb8-8696-d1518b2f0731            458a4d6e-83ee-4e74-85e7-69b35dc8045c   none      none          off        
+    oxp_e35766ef-789a-4b2f-9a6c-e6626d5ab195/crypt/zone/oxz_crucible_e71169cf-ee83-47b2-85ec-3396a20b4e02            97f033d1-1878-4429-81cf-9da9dc36bd95   none      none          off        
+    oxp_2dce7cf0-3097-485d-aaf6-9fc51f99eae5/crypt/zone/oxz_crucible_eeab4659-62e8-467f-a6f7-690854db89b5            854c1daf-e3bf-4b0a-84ef-3a1b9912f3df   none      none          off        
+    oxp_08616473-ded4-4785-9b53-b6ccc1efb67a/crypt/zone/oxz_crucible_pantry_2a8f8547-7c9a-4e79-8608-3c925fa3e4b7     74856b03-a612-43b4-94e7-6250cf56fba0   none      none          off        
+    oxp_08616473-ded4-4785-9b53-b6ccc1efb67a/crypt/zone/oxz_internal_dns_e8014d8f-0620-4dde-9fab-435cf4c0c321        2d7179ba-92a0-4bd1-8d5c-eba85fe540d3   none      none          off        
+    oxp_08616473-ded4-4785-9b53-b6ccc1efb67a/crypt/zone/oxz_nexus_d52405a5-debc-4682-8f32-8a3faee16b69               3fab12f1-b0ca-47e2-8865-9710e7e37117   none      none          off        
+    oxp_08616473-ded4-4785-9b53-b6ccc1efb67a/crypt/zone/oxz_ntp_a3e9eacd-48af-4333-aeb8-e7528042e664                 e56af4f5-a7ba-4ff1-a44d-d955f21755b6   none      none          off        
+    oxp_08616473-ded4-4785-9b53-b6ccc1efb67a/crypt/debug                                                             fdd71393-adb7-45c9-8a88-f3ce8d2bb93e   100 GiB   none          gzip-9     
+    oxp_2d44b756-94df-45ec-a644-50021248682d/crypt/debug                                                             c9b2026d-e9fd-4076-9a8c-32b06e34f0a3   100 GiB   none          gzip-9     
+    oxp_2dce7cf0-3097-485d-aaf6-9fc51f99eae5/crypt/debug                                                             3325118f-1ebc-48cd-9ade-cf2d319211b3   100 GiB   none          gzip-9     
+    oxp_3b9d69e5-aa80-4fc8-9d2e-a2a24bd0f1d7/crypt/debug                                                             d0213d2b-116c-4329-a93d-02c69c44c598   100 GiB   none          gzip-9     
+    oxp_44342c41-75a7-4708-8004-eb2ca5c5a3c2/crypt/debug                                                             247e51dd-fe88-43f2-b2bc-366e1b85c12b   100 GiB   none          gzip-9     
+    oxp_650b4eff-80a2-430a-97c8-f837248480a1/crypt/debug                                                             9321a17c-709d-44df-a4e3-8ca09bb3665f   100 GiB   none          gzip-9     
+    oxp_6e418b8c-cadd-4fb8-8370-f351a07e1eed/crypt/debug                                                             ee28398d-301c-4661-85a5-ddf27cff28b4   100 GiB   none          gzip-9     
+    oxp_6e5772a5-8234-46d1-ba5a-503a83d9d2fb/crypt/debug                                                             e74f80f2-5369-4647-8bd0-35b7d8b2a0b0   100 GiB   none          gzip-9     
+    oxp_c1da692e-7713-43a0-b6bb-5c182084c09d/crypt/debug                                                             d0a324c8-9de3-414a-8c8c-3fe301549cdb   100 GiB   none          gzip-9     
+    oxp_e35766ef-789a-4b2f-9a6c-e6626d5ab195/crypt/debug                                                             820def87-14ab-43c9-8f7d-b2be75a2570a   100 GiB   none          gzip-9     
++   oxp_2d44b756-94df-45ec-a644-50021248682d/crypt/clickhouse_keeper                                                 3b45a02a-3f37-4deb-93c6-0cba30538645   none      none          off        
++   oxp_2d44b756-94df-45ec-a644-50021248682d/crypt/internal_dns                                                      2bd9382d-ab49-4570-8ec8-c4da8c822693   none      none          off        
++   oxp_2d44b756-94df-45ec-a644-50021248682d/crypt/zone/oxz_clickhouse_keeper_bbba3c50-ff89-4a7f-96c1-d40ee996c417   ca2a30ab-baf8-4bb9-af14-3d41f6df6bf7   none      none          off        
++   oxp_2d44b756-94df-45ec-a644-50021248682d/crypt/zone/oxz_internal_dns_7f707d70-deef-42dc-96cc-a76cf6366386        40610ea8-b288-408c-91fd-e40edbba09cf   none      none          off        
 
 
     omicron zones generation 3 -> 4:
     -----------------------------------------------------------------------------------------------
     zone type           zone id                                disposition   underlay IP           
     -----------------------------------------------------------------------------------------------
-    clickhouse_keeper   fe395a2c-219b-4ad7-9f51-f536de60a9e4   in service    fd00:1122:3344:102::2e
-    clickhouse_server   23ee16e1-7f1f-4a76-b4fc-32921eead60e   in service    fd00:1122:3344:102::2f
-    crucible            0c50f6a6-55f0-4d9e-920e-c16b4e2f3b4f   in service    fd00:1122:3344:102::29
-    crucible            377d8477-7608-4248-b925-6a2c5e04fee3   in service    fd00:1122:3344:102::28
-    crucible            42ec7ad4-4a8a-4e7f-8291-bcc3a141647b   in service    fd00:1122:3344:102::26
-    crucible            4a152e9b-240b-4213-92fc-d205bc67c138   in service    fd00:1122:3344:102::25
-    crucible            5135c26c-5118-4dd0-a9a7-e2c46bd32b91   in service    fd00:1122:3344:102::2d
-    crucible            6d8c8a4f-82fc-47a9-b894-3c1dddd86343   in service    fd00:1122:3344:102::2c
-    crucible            9dce96c1-4f76-4e17-96de-aa867344581f   in service    fd00:1122:3344:102::2b
-    crucible            cf0943f4-1f4c-4531-8412-ecab1d1df36f   in service    fd00:1122:3344:102::2a
-    crucible            e432e610-e600-4d1c-9427-e965afe2d54a   in service    fd00:1122:3344:102::27
-    crucible            e83d6088-9e82-40dd-b8e9-b5bafe23d358   in service    fd00:1122:3344:102::24
-    crucible_pantry     67e03ab1-90ac-45b5-9487-d892752201e1   in service    fd00:1122:3344:102::23
-    internal_dns        b5e0f928-60cd-4040-a6f2-5ad45ac50814   in service    fd00:1122:3344:2::1   
-    internal_ntp        663835e0-d8bc-41ea-b79f-bd85997777ce   in service    fd00:1122:3344:102::21
-    nexus               3150ecb4-973e-4467-b194-632539bbdf07   in service    fd00:1122:3344:102::22
-+   clickhouse_keeper   e4052979-f949-44bf-91de-17b371d3e518   in service    fd00:1122:3344:102::30
-+   internal_dns        1cd50cc3-c098-4fe3-ae5b-af0344f0b6ec   in service    fd00:1122:3344:1::1   
+    clickhouse_keeper   3f78fa04-0b7e-4959-9718-c232c76500e1   in service    fd00:1122:3344:102::2e
+    clickhouse_server   f0341fc6-6a73-4318-8787-dd0c6b26c385   in service    fd00:1122:3344:102::2f
+    crucible            49afbe38-6b68-4764-afae-a279a7b9b1ab   in service    fd00:1122:3344:102::29
+    crucible            4a223081-0985-45c7-b60e-478c371fde4b   in service    fd00:1122:3344:102::2a
+    crucible            4e11460c-cfd2-4fa3-a7a7-25c976accece   in service    fd00:1122:3344:102::25
+    crucible            4f7d1ee4-bd7b-48a5-99e0-e61fc8e6e58e   in service    fd00:1122:3344:102::2c
+    crucible            7cc30ab4-c566-42d4-8fb0-31a8a27156ff   in service    fd00:1122:3344:102::24
+    crucible            a50a59b8-b59a-4f1d-b5d4-41f113802b5f   in service    fd00:1122:3344:102::2b
+    crucible            a8839f9e-93f8-42a2-ac3a-9b804a5316f9   in service    fd00:1122:3344:102::28
+    crucible            da1d617e-6450-4bb8-8696-d1518b2f0731   in service    fd00:1122:3344:102::27
+    crucible            e71169cf-ee83-47b2-85ec-3396a20b4e02   in service    fd00:1122:3344:102::2d
+    crucible            eeab4659-62e8-467f-a6f7-690854db89b5   in service    fd00:1122:3344:102::26
+    crucible_pantry     2a8f8547-7c9a-4e79-8608-3c925fa3e4b7   in service    fd00:1122:3344:102::23
+    internal_dns        e8014d8f-0620-4dde-9fab-435cf4c0c321   in service    fd00:1122:3344:2::1   
+    internal_ntp        a3e9eacd-48af-4333-aeb8-e7528042e664   in service    fd00:1122:3344:102::21
+    nexus               d52405a5-debc-4682-8f32-8a3faee16b69   in service    fd00:1122:3344:102::22
++   clickhouse_keeper   bbba3c50-ff89-4a7f-96c1-d40ee996c417   in service    fd00:1122:3344:102::30
++   internal_dns        7f707d70-deef-42dc-96cc-a76cf6366386   in service    fd00:1122:3344:1::1   
 
 
   sled fe7b9b01-e803-41ea-9e39-db240dcd9029 (active):
@@ -237,84 +237,84 @@ to:   blueprint 74f2e7fd-687e-4c9e-b5d8-e474a5bb8e7c
     -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
     dataset name                                                                                                     dataset uuid                           quota     reservation   compression
     -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
-    oxp_21d60319-5fe1-4a3b-a4c0-6aa7465e7bde/crucible                                                                83697259-f910-49de-8c15-83605c086a5d   none      none          off        
-    oxp_2acfbb84-5ce0-424e-8d73-44c5071d4430/crucible                                                                46ea917a-f99f-4078-8f45-8e92512ba42c   none      none          off        
-    oxp_2db7f3b4-ed19-4229-b42c-44f49eeb8a91/crucible                                                                d26ad281-5420-42c4-be19-013d7d44e2e9   none      none          off        
-    oxp_2fa34d8e-13d9-42d3-b8ba-ca9d74ac496a/crucible                                                                9ba7194a-0e9e-485f-b4ba-e58c39bc90da   none      none          off        
-    oxp_355e268c-c932-4f32-841c-f3ec88fe0495/crucible                                                                a1cb2b30-ca4f-4b9d-840d-4deef5993b79   none      none          off        
-    oxp_427b2ccd-998f-4085-af21-e600604cf21e/crucible                                                                0c6d24b8-e64b-4f97-a4ae-19bc998214fe   none      none          off        
-    oxp_588058f2-f51b-4800-a211-1c5dbb32296b/crucible                                                                97e6171d-523c-4c4a-9fa6-daead00d71a5   none      none          off        
-    oxp_736f6f07-2aa2-4658-8b5c-3bf409ea747a/crucible                                                                035b55e9-a0fc-48e5-8cd0-a862e7a7fe47   none      none          off        
-    oxp_bcfcdede-7084-4a31-97a8-ac4299c268f9/crucible                                                                01def6ad-ddd9-4b28-b337-137a16734021   none      none          off        
-    oxp_fe379ac6-1938-4cc2-93a9-43b1447229ae/crucible                                                                5818a803-eb2c-44eb-8818-bd98bfa29da9   none      none          off        
-    oxp_21d60319-5fe1-4a3b-a4c0-6aa7465e7bde/crypt/clickhouse_keeper                                                 35a2dc24-0853-4a06-b5b9-90b8ba83e0b0   none      none          off        
-    oxp_21d60319-5fe1-4a3b-a4c0-6aa7465e7bde/crypt/clickhouse_server                                                 e1236796-4a4f-48fe-b274-9c6c251d60b7   none      none          off        
-    oxp_21d60319-5fe1-4a3b-a4c0-6aa7465e7bde/crypt/internal_dns                                                      8d423173-09c9-4ca5-a21c-b7c3123aa1af   none      none          off        
-    oxp_21d60319-5fe1-4a3b-a4c0-6aa7465e7bde/crypt/zone                                                              d5d2ddf7-2eb3-40f3-b149-aee5699b7bf1   none      none          off        
-    oxp_2acfbb84-5ce0-424e-8d73-44c5071d4430/crypt/zone                                                              988c82cc-aed4-4207-96a8-f844ede70a5c   none      none          off        
-    oxp_2db7f3b4-ed19-4229-b42c-44f49eeb8a91/crypt/zone                                                              0c6b2002-2cec-478f-9eb3-239069f42dbc   none      none          off        
-    oxp_2fa34d8e-13d9-42d3-b8ba-ca9d74ac496a/crypt/zone                                                              8b6d2ff8-4f40-4776-b461-29e0a3d3dd97   none      none          off        
-    oxp_355e268c-c932-4f32-841c-f3ec88fe0495/crypt/zone                                                              cf7a9405-cf77-49cd-b3d4-528d9ad5ce48   none      none          off        
-    oxp_427b2ccd-998f-4085-af21-e600604cf21e/crypt/zone                                                              a03487ed-4b03-4856-a670-9fa703b0b850   none      none          off        
-    oxp_588058f2-f51b-4800-a211-1c5dbb32296b/crypt/zone                                                              86009a86-7c47-477d-bb17-c38689f5b337   none      none          off        
-    oxp_736f6f07-2aa2-4658-8b5c-3bf409ea747a/crypt/zone                                                              f3df6efd-e689-4aaa-b4ed-76de319a1fe4   none      none          off        
-    oxp_bcfcdede-7084-4a31-97a8-ac4299c268f9/crypt/zone                                                              d8d8dc6c-cd76-4d17-b530-25f3f3f52d33   none      none          off        
-    oxp_fe379ac6-1938-4cc2-93a9-43b1447229ae/crypt/zone                                                              9327960e-a9a3-4b26-9bd4-65afb1737bd4   none      none          off        
-    oxp_21d60319-5fe1-4a3b-a4c0-6aa7465e7bde/crypt/zone/oxz_clickhouse_keeper_ceea23ec-1cb4-46be-bfa6-de9025ad5737   abb56278-58c2-4e0c-8cc8-417f57100de0   none      none          off        
-    oxp_21d60319-5fe1-4a3b-a4c0-6aa7465e7bde/crypt/zone/oxz_clickhouse_server_02ef9ddc-a012-4d15-8f45-8282f58c9a11   2315a796-5038-4003-b5e0-099a29f7ebb1   none      none          off        
-    oxp_2db7f3b4-ed19-4229-b42c-44f49eeb8a91/crypt/zone/oxz_crucible_02aecfb8-91a9-4db8-8cb2-4252bf15d6ac            7e11890f-b1ce-497a-9672-f95d3452eb7b   none      none          off        
-    oxp_355e268c-c932-4f32-841c-f3ec88fe0495/crypt/zone/oxz_crucible_0a3cfe7c-414d-40f0-8f63-a7c0b26b7627            e1396508-5d99-4802-8d3f-cc3db33f0341   none      none          off        
-    oxp_bcfcdede-7084-4a31-97a8-ac4299c268f9/crypt/zone/oxz_crucible_109820d7-b6ef-4574-b5e4-9f193c9d2a9e            75f329ff-4f3b-4cc5-8027-dd61d05e7323   none      none          off        
-    oxp_21d60319-5fe1-4a3b-a4c0-6aa7465e7bde/crypt/zone/oxz_crucible_3801ce73-9986-491a-a623-8ae2cea1678b            d0d28f34-55ba-400e-9dce-a8c3d25c09e9   none      none          off        
-    oxp_fe379ac6-1938-4cc2-93a9-43b1447229ae/crypt/zone/oxz_crucible_43aa521b-eb86-4c3d-a58c-83c733f2fec3            c7a57806-05b3-4e38-9bc4-07fd6b30cccd   none      none          off        
-    oxp_736f6f07-2aa2-4658-8b5c-3bf409ea747a/crypt/zone/oxz_crucible_79164b60-fbb4-46d4-9a42-eafbaeddd672            ebf1a36b-ab94-4a5d-a777-937991a60396   none      none          off        
-    oxp_2acfbb84-5ce0-424e-8d73-44c5071d4430/crypt/zone/oxz_crucible_93fe2a9b-3ce9-4bf0-852d-c36171988c71            6fafdcb1-b246-44ca-8e8e-2101ce3cbdf7   none      none          off        
-    oxp_588058f2-f51b-4800-a211-1c5dbb32296b/crypt/zone/oxz_crucible_a91714d7-33b4-40d6-93cf-1b278bc9f1c6            f4c0087b-c746-4440-82e7-82ff5e40c6ab   none      none          off        
-    oxp_427b2ccd-998f-4085-af21-e600604cf21e/crypt/zone/oxz_crucible_befe73dd-5970-49a4-9adf-7b4f453c45cf            95d72ef9-e070-49e4-a57b-2c392def6025   none      none          off        
-    oxp_2fa34d8e-13d9-42d3-b8ba-ca9d74ac496a/crypt/zone/oxz_crucible_d9106a19-f267-48db-a82b-004e643feb49            9b9fb14e-cd17-4a7a-a74a-bfd9c7682831   none      none          off        
-    oxp_21d60319-5fe1-4a3b-a4c0-6aa7465e7bde/crypt/zone/oxz_crucible_pantry_6c7f6a84-78b3-4dd9-878e-51bedfda471f     aa190e01-9a4e-4131-9fcf-240532108c7f   none      none          off        
-    oxp_21d60319-5fe1-4a3b-a4c0-6aa7465e7bde/crypt/zone/oxz_internal_dns_0c42ad01-b854-4e7d-bd6c-25fdc3eddef4        1de9cde7-6c1e-4865-bd3d-378e22f62fb8   none      none          off        
-    oxp_21d60319-5fe1-4a3b-a4c0-6aa7465e7bde/crypt/zone/oxz_nexus_7e763480-0f4f-43cb-ab9a-52b667d8fda5               5773e3b1-dde0-4b54-bc13-3c3bf816015e   none      none          off        
-    oxp_21d60319-5fe1-4a3b-a4c0-6aa7465e7bde/crypt/zone/oxz_ntp_f34f8d36-7137-48d3-9d13-6a46c4edcef4                 c8c03dec-65d4-4c97-87c3-a43a8363c97c   none      none          off        
-    oxp_21d60319-5fe1-4a3b-a4c0-6aa7465e7bde/crypt/debug                                                             f015e445-2e52-45c9-9f0a-49cb5ceae245   100 GiB   none          gzip-9     
-    oxp_2acfbb84-5ce0-424e-8d73-44c5071d4430/crypt/debug                                                             a86eda4a-2346-4990-8393-6692c81f9f37   100 GiB   none          gzip-9     
-    oxp_2db7f3b4-ed19-4229-b42c-44f49eeb8a91/crypt/debug                                                             f3c93847-6a22-4f95-97cd-766358663b2a   100 GiB   none          gzip-9     
-    oxp_2fa34d8e-13d9-42d3-b8ba-ca9d74ac496a/crypt/debug                                                             ec40dcf8-085f-4277-8d96-657a1e7fb0c8   100 GiB   none          gzip-9     
-    oxp_355e268c-c932-4f32-841c-f3ec88fe0495/crypt/debug                                                             85d345b5-04d4-4bdf-9e6f-c10b3f21208d   100 GiB   none          gzip-9     
-    oxp_427b2ccd-998f-4085-af21-e600604cf21e/crypt/debug                                                             f7cccd71-efb1-4bee-bcdf-7e7133c3e5da   100 GiB   none          gzip-9     
-    oxp_588058f2-f51b-4800-a211-1c5dbb32296b/crypt/debug                                                             2ab9c443-5ea3-4ab1-b2ed-d57abbfde4be   100 GiB   none          gzip-9     
-    oxp_736f6f07-2aa2-4658-8b5c-3bf409ea747a/crypt/debug                                                             0f785b1f-3f7a-4ae7-8a32-4412b781d245   100 GiB   none          gzip-9     
-    oxp_bcfcdede-7084-4a31-97a8-ac4299c268f9/crypt/debug                                                             6fdd4ca2-022f-4ef3-9a83-1e18e620e9dc   100 GiB   none          gzip-9     
-    oxp_fe379ac6-1938-4cc2-93a9-43b1447229ae/crypt/debug                                                             3a49dd24-8ead-4196-b453-8aa3273b77d1   100 GiB   none          gzip-9     
-+   oxp_21d60319-5fe1-4a3b-a4c0-6aa7465e7bde/crypt/clickhouse                                                        410eca9c-8eee-4a98-aea2-a363697974f7   none      none          off        
-+   oxp_21d60319-5fe1-4a3b-a4c0-6aa7465e7bde/crypt/zone/oxz_clickhouse_fa97835a-aabc-4fe9-9e85-3e50f207129c          08f15d4b-91dc-445d-88f4-cb9fa585444b   none      none          off        
-+   oxp_2acfbb84-5ce0-424e-8d73-44c5071d4430/crypt/zone/oxz_crucible_pantry_7741bb11-0d99-4856-95ae-725b6b9ff4fa     4eb52e76-39fa-414d-ae9b-2dcb1c7737f9   none      none          off        
-+   oxp_2acfbb84-5ce0-424e-8d73-44c5071d4430/crypt/zone/oxz_nexus_69789010-8689-43ab-9a68-a944afcba05a               e67b797b-a059-4c7e-a98b-fea18964bad6   none      none          off        
+    oxp_21d60319-5fe1-4a3b-a4c0-6aa7465e7bde/crucible                                                                b97110cd-9c9d-47d8-ac3e-38b2a5fbf4bb   none      none          off        
+    oxp_2acfbb84-5ce0-424e-8d73-44c5071d4430/crucible                                                                b07b36ec-f27e-4bef-bd0e-adbab3dbded0   none      none          off        
+    oxp_2db7f3b4-ed19-4229-b42c-44f49eeb8a91/crucible                                                                50904cf3-e571-42ee-9be7-40e0d293be12   none      none          off        
+    oxp_2fa34d8e-13d9-42d3-b8ba-ca9d74ac496a/crucible                                                                e3ed0aa2-a4bf-4619-a276-ff287c23f260   none      none          off        
+    oxp_355e268c-c932-4f32-841c-f3ec88fe0495/crucible                                                                c5a79172-3a48-4ecc-a814-77f4a0ac87c3   none      none          off        
+    oxp_427b2ccd-998f-4085-af21-e600604cf21e/crucible                                                                0490a48d-59be-412f-8db8-8a8778f5bdce   none      none          off        
+    oxp_588058f2-f51b-4800-a211-1c5dbb32296b/crucible                                                                d148662e-1244-416e-9043-2c6e5bc3391c   none      none          off        
+    oxp_736f6f07-2aa2-4658-8b5c-3bf409ea747a/crucible                                                                55340375-5d36-475d-99d6-8c8dc38a8421   none      none          off        
+    oxp_bcfcdede-7084-4a31-97a8-ac4299c268f9/crucible                                                                cdf74236-d6b4-4872-ab29-3ef21b1f9e9e   none      none          off        
+    oxp_fe379ac6-1938-4cc2-93a9-43b1447229ae/crucible                                                                98085696-2290-4467-b2de-cecd1ab6255e   none      none          off        
+    oxp_21d60319-5fe1-4a3b-a4c0-6aa7465e7bde/crypt/clickhouse_keeper                                                 56624401-f56f-4fd2-88fb-cfd56df535aa   none      none          off        
+    oxp_21d60319-5fe1-4a3b-a4c0-6aa7465e7bde/crypt/clickhouse_server                                                 67e873d4-5ee2-4fcd-bd1f-9311ad2ed23c   none      none          off        
+    oxp_21d60319-5fe1-4a3b-a4c0-6aa7465e7bde/crypt/internal_dns                                                      eba7c3d8-af0f-4de7-9b07-8e63ff8c9a34   none      none          off        
+    oxp_21d60319-5fe1-4a3b-a4c0-6aa7465e7bde/crypt/zone                                                              a27fb298-e263-4560-965a-2c56292ea19a   none      none          off        
+    oxp_2acfbb84-5ce0-424e-8d73-44c5071d4430/crypt/zone                                                              03dfbeda-a138-45c2-975f-05a9af2ef2b9   none      none          off        
+    oxp_2db7f3b4-ed19-4229-b42c-44f49eeb8a91/crypt/zone                                                              40986d49-c197-462c-baac-ba937da44571   none      none          off        
+    oxp_2fa34d8e-13d9-42d3-b8ba-ca9d74ac496a/crypt/zone                                                              006eede7-d6b6-4af2-a2ff-37b94386b421   none      none          off        
+    oxp_355e268c-c932-4f32-841c-f3ec88fe0495/crypt/zone                                                              18279e0e-4f67-4e87-bc5a-2eb3927ec023   none      none          off        
+    oxp_427b2ccd-998f-4085-af21-e600604cf21e/crypt/zone                                                              491b337c-3c25-4284-ae13-443206ff696f   none      none          off        
+    oxp_588058f2-f51b-4800-a211-1c5dbb32296b/crypt/zone                                                              5aa2c795-468a-45df-8769-16f4d5d0e42a   none      none          off        
+    oxp_736f6f07-2aa2-4658-8b5c-3bf409ea747a/crypt/zone                                                              89c95288-774f-480c-ab14-a0327bec365b   none      none          off        
+    oxp_bcfcdede-7084-4a31-97a8-ac4299c268f9/crypt/zone                                                              e7569f72-580c-417b-b223-0e5f998dd9c1   none      none          off        
+    oxp_fe379ac6-1938-4cc2-93a9-43b1447229ae/crypt/zone                                                              2aae5bf8-7c17-43c4-9183-4c1956571243   none      none          off        
+    oxp_21d60319-5fe1-4a3b-a4c0-6aa7465e7bde/crypt/zone/oxz_clickhouse_keeper_2b368dcd-bb4b-4415-9daf-0d36fd769fed   c22caa52-6179-49a7-95dc-5cf0d9f3f827   none      none          off        
+    oxp_21d60319-5fe1-4a3b-a4c0-6aa7465e7bde/crypt/zone/oxz_clickhouse_server_097ab295-aec4-427f-9124-bb4e8aecfeca   e21880d2-f6f9-4e97-b7da-5a8a934845ab   none      none          off        
+    oxp_736f6f07-2aa2-4658-8b5c-3bf409ea747a/crypt/zone/oxz_crucible_308c592a-b022-4790-9824-7a5e10b83d1b            4e514d61-b9d3-4e8c-b528-4b9577d8ad84   none      none          off        
+    oxp_2fa34d8e-13d9-42d3-b8ba-ca9d74ac496a/crypt/zone/oxz_crucible_7233139a-ad5b-4c0e-be80-759fbd5cb262            2c3d31cf-9a06-4f47-8f30-97884d06de8f   none      none          off        
+    oxp_2acfbb84-5ce0-424e-8d73-44c5071d4430/crypt/zone/oxz_crucible_8c43faff-54c7-4b91-820c-ff130b7049e9            9155b21a-1803-44b3-b80e-6d22f7af2e07   none      none          off        
+    oxp_fe379ac6-1938-4cc2-93a9-43b1447229ae/crypt/zone/oxz_crucible_8ddbafde-d699-4e37-b70d-dcd803f0898e            a46724b6-7ca0-4d70-9dd2-6fd22d1e6150   none      none          off        
+    oxp_427b2ccd-998f-4085-af21-e600604cf21e/crypt/zone/oxz_crucible_955bd7eb-8cc2-4128-a636-19bde11ab251            44153191-15ac-4206-b153-167261b232fe   none      none          off        
+    oxp_21d60319-5fe1-4a3b-a4c0-6aa7465e7bde/crypt/zone/oxz_crucible_a6192358-d6e1-4483-a3c6-755a05911f22            5fd12d35-d258-42ca-8fe3-dc5788bdc66c   none      none          off        
+    oxp_bcfcdede-7084-4a31-97a8-ac4299c268f9/crypt/zone/oxz_crucible_a68bc085-0ad5-4c42-a9f7-0b540de24ced            1de186f8-a37f-42fa-9e70-05aa05641c7e   none      none          off        
+    oxp_355e268c-c932-4f32-841c-f3ec88fe0495/crypt/zone/oxz_crucible_cdc00fbb-5ac7-4667-9fc8-926ea73a002a            510ecf2a-6a98-40f2-b387-3bab22da2bf7   none      none          off        
+    oxp_2db7f3b4-ed19-4229-b42c-44f49eeb8a91/crypt/zone/oxz_crucible_d04ed118-4eb8-4ba4-8f05-7714060291e2            282ed619-0004-4647-9d60-85509d68170e   none      none          off        
+    oxp_588058f2-f51b-4800-a211-1c5dbb32296b/crypt/zone/oxz_crucible_e5347768-7d4d-4862-b78e-38291aca675a            ba5652ea-a567-4e7f-a62d-616fd9ab2aff   none      none          off        
+    oxp_21d60319-5fe1-4a3b-a4c0-6aa7465e7bde/crypt/zone/oxz_crucible_pantry_0af27834-4e26-4417-9cc3-9a04105b1cbc     8d62e551-9775-4ac8-a830-15e1f3aabb46   none      none          off        
+    oxp_21d60319-5fe1-4a3b-a4c0-6aa7465e7bde/crypt/zone/oxz_internal_dns_a6212313-b0c0-4a69-9ca6-5ea9c7e3e947        38daea72-c487-4f80-9e27-ef67e6b2d05d   none      none          off        
+    oxp_21d60319-5fe1-4a3b-a4c0-6aa7465e7bde/crypt/zone/oxz_nexus_e786e397-2ccc-4112-bf26-45ca1de89f3b               a26d8d3b-1483-4e98-bb4b-1680c75c2956   none      none          off        
+    oxp_21d60319-5fe1-4a3b-a4c0-6aa7465e7bde/crypt/zone/oxz_ntp_0991f26b-97a1-4033-af5d-df7e56c2189a                 a6f0a3f1-aff9-45d9-8e70-610780c75c73   none      none          off        
+    oxp_21d60319-5fe1-4a3b-a4c0-6aa7465e7bde/crypt/debug                                                             c2868186-4510-4c56-9374-13a4fda781be   100 GiB   none          gzip-9     
+    oxp_2acfbb84-5ce0-424e-8d73-44c5071d4430/crypt/debug                                                             80bb6683-3e89-4652-9b4d-a2adc6dc05c3   100 GiB   none          gzip-9     
+    oxp_2db7f3b4-ed19-4229-b42c-44f49eeb8a91/crypt/debug                                                             35abcc8e-8fae-4e0f-9db7-457c21c27244   100 GiB   none          gzip-9     
+    oxp_2fa34d8e-13d9-42d3-b8ba-ca9d74ac496a/crypt/debug                                                             ae45ae89-0fc5-4c82-8e38-bdc4efb2a4cd   100 GiB   none          gzip-9     
+    oxp_355e268c-c932-4f32-841c-f3ec88fe0495/crypt/debug                                                             f567b79a-c05c-4ba5-85a6-87f217687c9b   100 GiB   none          gzip-9     
+    oxp_427b2ccd-998f-4085-af21-e600604cf21e/crypt/debug                                                             da15e9ee-d60c-4b9d-a383-52c8c82f8bad   100 GiB   none          gzip-9     
+    oxp_588058f2-f51b-4800-a211-1c5dbb32296b/crypt/debug                                                             f8390042-25a5-43db-9d6c-336223c5210f   100 GiB   none          gzip-9     
+    oxp_736f6f07-2aa2-4658-8b5c-3bf409ea747a/crypt/debug                                                             68191fe0-2606-4d82-833e-e467ff129a19   100 GiB   none          gzip-9     
+    oxp_bcfcdede-7084-4a31-97a8-ac4299c268f9/crypt/debug                                                             2755f94e-a5e8-4bf8-8cdc-2645e5b21578   100 GiB   none          gzip-9     
+    oxp_fe379ac6-1938-4cc2-93a9-43b1447229ae/crypt/debug                                                             68b11f7e-4258-483b-a75a-4243ca7ede6f   100 GiB   none          gzip-9     
++   oxp_21d60319-5fe1-4a3b-a4c0-6aa7465e7bde/crypt/clickhouse                                                        650004ee-2360-47a3-ba98-b07dd9873c06   none      none          off        
++   oxp_21d60319-5fe1-4a3b-a4c0-6aa7465e7bde/crypt/zone/oxz_clickhouse_ca54c155-5e4c-42e6-96f2-b70448019418          b760c1d2-fa43-441d-8b79-d1fde01a8753   none      none          off        
++   oxp_2acfbb84-5ce0-424e-8d73-44c5071d4430/crypt/zone/oxz_crucible_pantry_84fc3bdc-a8f6-4ceb-8fcf-59a003bc91c0     96d231ab-baee-465f-a584-6eedcc3e14cc   none      none          off        
++   oxp_2acfbb84-5ce0-424e-8d73-44c5071d4430/crypt/zone/oxz_nexus_b2e9a34b-7b15-4f56-836d-b39e474afbc5               a89cea5b-db88-4f12-a2f4-700a04803af1   none      none          off        
 
 
     omicron zones generation 3 -> 4:
     -----------------------------------------------------------------------------------------------
     zone type           zone id                                disposition   underlay IP           
     -----------------------------------------------------------------------------------------------
-    clickhouse_keeper   ceea23ec-1cb4-46be-bfa6-de9025ad5737   in service    fd00:1122:3344:103::2e
-    clickhouse_server   02ef9ddc-a012-4d15-8f45-8282f58c9a11   in service    fd00:1122:3344:103::2f
-    crucible            02aecfb8-91a9-4db8-8cb2-4252bf15d6ac   in service    fd00:1122:3344:103::26
-    crucible            0a3cfe7c-414d-40f0-8f63-a7c0b26b7627   in service    fd00:1122:3344:103::28
-    crucible            109820d7-b6ef-4574-b5e4-9f193c9d2a9e   in service    fd00:1122:3344:103::2c
-    crucible            3801ce73-9986-491a-a623-8ae2cea1678b   in service    fd00:1122:3344:103::24
-    crucible            43aa521b-eb86-4c3d-a58c-83c733f2fec3   in service    fd00:1122:3344:103::2d
-    crucible            79164b60-fbb4-46d4-9a42-eafbaeddd672   in service    fd00:1122:3344:103::2b
-    crucible            93fe2a9b-3ce9-4bf0-852d-c36171988c71   in service    fd00:1122:3344:103::25
-    crucible            a91714d7-33b4-40d6-93cf-1b278bc9f1c6   in service    fd00:1122:3344:103::2a
-    crucible            befe73dd-5970-49a4-9adf-7b4f453c45cf   in service    fd00:1122:3344:103::29
-    crucible            d9106a19-f267-48db-a82b-004e643feb49   in service    fd00:1122:3344:103::27
-    crucible_pantry     6c7f6a84-78b3-4dd9-878e-51bedfda471f   in service    fd00:1122:3344:103::23
-    internal_dns        0c42ad01-b854-4e7d-bd6c-25fdc3eddef4   in service    fd00:1122:3344:3::1   
-    internal_ntp        f34f8d36-7137-48d3-9d13-6a46c4edcef4   in service    fd00:1122:3344:103::21
-    nexus               7e763480-0f4f-43cb-ab9a-52b667d8fda5   in service    fd00:1122:3344:103::22
-+   clickhouse          fa97835a-aabc-4fe9-9e85-3e50f207129c   in service    fd00:1122:3344:103::30
-+   crucible_pantry     7741bb11-0d99-4856-95ae-725b6b9ff4fa   in service    fd00:1122:3344:103::31
-+   nexus               69789010-8689-43ab-9a68-a944afcba05a   in service    fd00:1122:3344:103::32
+    clickhouse_keeper   2b368dcd-bb4b-4415-9daf-0d36fd769fed   in service    fd00:1122:3344:103::2e
+    clickhouse_server   097ab295-aec4-427f-9124-bb4e8aecfeca   in service    fd00:1122:3344:103::2f
+    crucible            308c592a-b022-4790-9824-7a5e10b83d1b   in service    fd00:1122:3344:103::2b
+    crucible            7233139a-ad5b-4c0e-be80-759fbd5cb262   in service    fd00:1122:3344:103::27
+    crucible            8c43faff-54c7-4b91-820c-ff130b7049e9   in service    fd00:1122:3344:103::25
+    crucible            8ddbafde-d699-4e37-b70d-dcd803f0898e   in service    fd00:1122:3344:103::2d
+    crucible            955bd7eb-8cc2-4128-a636-19bde11ab251   in service    fd00:1122:3344:103::29
+    crucible            a6192358-d6e1-4483-a3c6-755a05911f22   in service    fd00:1122:3344:103::24
+    crucible            a68bc085-0ad5-4c42-a9f7-0b540de24ced   in service    fd00:1122:3344:103::2c
+    crucible            cdc00fbb-5ac7-4667-9fc8-926ea73a002a   in service    fd00:1122:3344:103::28
+    crucible            d04ed118-4eb8-4ba4-8f05-7714060291e2   in service    fd00:1122:3344:103::26
+    crucible            e5347768-7d4d-4862-b78e-38291aca675a   in service    fd00:1122:3344:103::2a
+    crucible_pantry     0af27834-4e26-4417-9cc3-9a04105b1cbc   in service    fd00:1122:3344:103::23
+    internal_dns        a6212313-b0c0-4a69-9ca6-5ea9c7e3e947   in service    fd00:1122:3344:3::1   
+    internal_ntp        0991f26b-97a1-4033-af5d-df7e56c2189a   in service    fd00:1122:3344:103::21
+    nexus               e786e397-2ccc-4112-bf26-45ca1de89f3b   in service    fd00:1122:3344:103::22
++   clickhouse          ca54c155-5e4c-42e6-96f2-b70448019418   in service    fd00:1122:3344:103::30
++   crucible_pantry     84fc3bdc-a8f6-4ceb-8fcf-59a003bc91c0   in service    fd00:1122:3344:103::31
++   nexus               b2e9a34b-7b15-4f56-836d-b39e474afbc5   in service    fd00:1122:3344:103::32
 
 
  COCKROACHDB SETTINGS:
@@ -330,21 +330,21 @@ to:   blueprint 74f2e7fd-687e-4c9e-b5d8-e474a5bb8e7c
     max used server id:::::::::::::::::::::::::::::   2 (unchanged)
     max used keeper id:::::::::::::::::::::::::::::   3 (unchanged)
     cluster name:::::::::::::::::::::::::::::::::::   oximeter_cluster (unchanged)
-    cluster secret:::::::::::::::::::::::::::::::::   9b56c0da-33d7-41a6-b411-6d00e71bea9b (unchanged)
+    cluster secret:::::::::::::::::::::::::::::::::   61731868-2fb2-48cc-b135-1eebcfbff058 (unchanged)
     highest seen keeper leader committed log index:   1 (unchanged)
 
     clickhouse keepers generation 2 -> 3:
     ------------------------------------------------
     zone id                                keeper id
     ------------------------------------------------
-    ceea23ec-1cb4-46be-bfa6-de9025ad5737   1        
-    fe395a2c-219b-4ad7-9f51-f536de60a9e4   2        
--   94abd717-9240-4a27-ac14-5666c1f3f3ab   0        
+    2b368dcd-bb4b-4415-9daf-0d36fd769fed   1        
+    3f78fa04-0b7e-4959-9718-c232c76500e1   2        
+-   1998de68-a305-44f7-8ebc-cc5613c9e6fb   0        
 
     clickhouse servers generation 2 -> 3:
     ------------------------------------------------
     zone id                                server id
     ------------------------------------------------
-    02ef9ddc-a012-4d15-8f45-8282f58c9a11   1        
-    23ee16e1-7f1f-4a76-b4fc-32921eead60e   2        
+    097ab295-aec4-427f-9124-bb4e8aecfeca   1        
+    f0341fc6-6a73-4318-8787-dd0c6b26c385   2        
 

--- a/nexus/reconfigurator/planning/tests/output/planner_expunge_clickhouse_clusters_5_6.txt
+++ b/nexus/reconfigurator/planning/tests/output/planner_expunge_clickhouse_clusters_5_6.txt
@@ -9,22 +9,22 @@ to:   blueprint df68d4d4-5af4-4b56-95bb-1654a6957d4f
     -----------------------------------------------------------------------------------------------
     zone type           zone id                                disposition   underlay IP           
     -----------------------------------------------------------------------------------------------
-    clickhouse          f2c54229-d192-41bd-babc-9ca02c1206d6   expunged      fd00:1122:3344:101::23
-    clickhouse_keeper   94abd717-9240-4a27-ac14-5666c1f3f3ab   expunged      fd00:1122:3344:101::2f
-    crucible            133e50ce-39e1-4647-8ea8-8f171a1b6471   expunged      fd00:1122:3344:101::28
-    crucible            5078d1c7-9bc5-46a1-94e1-47ceb6f81580   expunged      fd00:1122:3344:101::2a
-    crucible            58a60190-35da-4ce1-b0da-298b3d64458d   expunged      fd00:1122:3344:101::2c
-    crucible            5a0af13f-c815-4df4-a7a3-c1ddfc1fc4f0   expunged      fd00:1122:3344:101::2e
-    crucible            6a703437-f546-4848-8a0a-94d4c3b20e7c   expunged      fd00:1122:3344:101::2b
-    crucible            893d890c-4b9f-4944-a245-90ac5dab82b6   expunged      fd00:1122:3344:101::2d
-    crucible            975d60ed-46ff-4f4c-b02e-01e3cd331a6f   expunged      fd00:1122:3344:101::29
-    crucible            b5f91973-5e8e-4e58-9ebf-1b0ad3e4758e   expunged      fd00:1122:3344:101::26
-    crucible            c0098649-b9d4-4072-9dc0-0da3e5791f1f   expunged      fd00:1122:3344:101::27
-    crucible            c3dee582-3b04-4981-90ac-e2f617c6a1ce   expunged      fd00:1122:3344:101::25
-    crucible_pantry     1ee0a9f1-503c-4e38-bf76-e026afb9ac5b   expunged      fd00:1122:3344:101::24
-    internal_dns        9975245b-9c63-41be-8043-31117f85f905   expunged      fd00:1122:3344:1::1   
-    internal_ntp        765ffd29-670e-4d95-aa97-8d244b6412d7   expunged      fd00:1122:3344:101::21
-    nexus               b8f4453e-6917-4f7f-8a29-220d333bb27d   expunged      fd00:1122:3344:101::22
+    clickhouse          96dcbb7a-0140-4590-801c-406866500995   expunged      fd00:1122:3344:101::23
+    clickhouse_keeper   1998de68-a305-44f7-8ebc-cc5613c9e6fb   expunged      fd00:1122:3344:101::2f
+    crucible            5366862d-0c9e-4c21-bd16-5599298e75bc   expunged      fd00:1122:3344:101::2b
+    crucible            63dcf460-2794-434c-b0e7-4e09ba0f3a3c   expunged      fd00:1122:3344:101::28
+    crucible            71f24994-337b-4c5f-9826-75f885a669e7   expunged      fd00:1122:3344:101::2e
+    crucible            726f6522-a359-4e6e-abe9-0de41979de91   expunged      fd00:1122:3344:101::26
+    crucible            a794a5cd-ec63-4fe4-a813-720d79dcd2ca   expunged      fd00:1122:3344:101::2d
+    crucible            ab480489-af1c-4446-8e95-da4a7e58df59   expunged      fd00:1122:3344:101::25
+    crucible            cc6e2a17-ba9b-4332-b869-e0ce204915cf   expunged      fd00:1122:3344:101::2c
+    crucible            e5cd215f-19c6-43ca-b31a-039319dd5dcf   expunged      fd00:1122:3344:101::29
+    crucible            e7bc709c-4ef2-4f1f-be78-494f53169554   expunged      fd00:1122:3344:101::2a
+    crucible            fbaea242-74a6-490f-9bc0-0710a40768f4   expunged      fd00:1122:3344:101::27
+    crucible_pantry     ed79fef8-6124-4ecc-aaa4-51cf9fcf58db   expunged      fd00:1122:3344:101::24
+    internal_dns        4d152a2b-089e-4fe2-89fa-76b53fa58773   expunged      fd00:1122:3344:1::1   
+    internal_ntp        89d38277-9743-491b-af94-714776657ce2   expunged      fd00:1122:3344:101::21
+    nexus               4cb9b6d5-fd52-4cfb-b630-59f80bd26615   expunged      fd00:1122:3344:101::22
 
 
   sled cdba3bea-3407-4b6e-a029-19bf4a02fca7 (active):
@@ -49,83 +49,83 @@ to:   blueprint df68d4d4-5af4-4b56-95bb-1654a6957d4f
     -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
     dataset name                                                                                                     dataset uuid                           quota     reservation   compression
     -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
-    oxp_08616473-ded4-4785-9b53-b6ccc1efb67a/crucible                                                                3d575592-90d1-4f09-8ebd-cfb0d7348492   none      none          off        
-    oxp_2d44b756-94df-45ec-a644-50021248682d/crucible                                                                6875e6ae-d773-4c38-b075-74d54c7664c5   none      none          off        
-    oxp_2dce7cf0-3097-485d-aaf6-9fc51f99eae5/crucible                                                                1afdddf6-2c5d-4b57-b732-d451fe9d339a   none      none          off        
-    oxp_3b9d69e5-aa80-4fc8-9d2e-a2a24bd0f1d7/crucible                                                                99df049c-d495-4cdc-800e-a0deb8a12407   none      none          off        
-    oxp_44342c41-75a7-4708-8004-eb2ca5c5a3c2/crucible                                                                97bcdcd3-c71f-4a6a-8dbe-fb79f0e0cd8c   none      none          off        
-    oxp_650b4eff-80a2-430a-97c8-f837248480a1/crucible                                                                5d445c3a-92ff-4951-964d-cbb35dce0ffb   none      none          off        
-    oxp_6e418b8c-cadd-4fb8-8370-f351a07e1eed/crucible                                                                efce20c8-c6ad-4e1a-a489-1391a02ff73e   none      none          off        
-    oxp_6e5772a5-8234-46d1-ba5a-503a83d9d2fb/crucible                                                                9292d1a7-786c-448b-86ea-4cdb7c29df73   none      none          off        
-    oxp_c1da692e-7713-43a0-b6bb-5c182084c09d/crucible                                                                5967609a-83a6-4feb-8d46-25c3ca7fce12   none      none          off        
-    oxp_e35766ef-789a-4b2f-9a6c-e6626d5ab195/crucible                                                                97ff78ad-4939-4308-9dde-7bd94dc55741   none      none          off        
-    oxp_08616473-ded4-4785-9b53-b6ccc1efb67a/crypt/clickhouse_keeper                                                 dda523f9-2078-42b1-a581-bad8349bb592   none      none          off        
-    oxp_2d44b756-94df-45ec-a644-50021248682d/crypt/clickhouse_keeper                                                 f2bbe72f-ae6c-4ee2-a2f3-eae54527048d   none      none          off        
-    oxp_08616473-ded4-4785-9b53-b6ccc1efb67a/crypt/clickhouse_server                                                 14389e8b-952f-4e20-aabd-3741493fb444   none      none          off        
-    oxp_08616473-ded4-4785-9b53-b6ccc1efb67a/crypt/internal_dns                                                      1e34af87-308a-4192-be38-193f0c89390a   none      none          off        
-    oxp_2d44b756-94df-45ec-a644-50021248682d/crypt/internal_dns                                                      0dc5f030-0bde-4fff-a0b6-f7c8fcc3e532   none      none          off        
-    oxp_08616473-ded4-4785-9b53-b6ccc1efb67a/crypt/zone                                                              a27426fd-6f66-475d-bb6e-4422618ae009   none      none          off        
-    oxp_2d44b756-94df-45ec-a644-50021248682d/crypt/zone                                                              a38bec7e-50fc-4a0d-b0de-15023a542367   none      none          off        
-    oxp_2dce7cf0-3097-485d-aaf6-9fc51f99eae5/crypt/zone                                                              1cee8f96-b8e2-4983-8c65-ba8338eb781c   none      none          off        
-    oxp_3b9d69e5-aa80-4fc8-9d2e-a2a24bd0f1d7/crypt/zone                                                              b265dd36-3a93-4ad9-bca1-8e76abea9f90   none      none          off        
-    oxp_44342c41-75a7-4708-8004-eb2ca5c5a3c2/crypt/zone                                                              caa97a7b-1c7d-4a2b-a9e7-12588f942a8c   none      none          off        
-    oxp_650b4eff-80a2-430a-97c8-f837248480a1/crypt/zone                                                              0921cbb1-02ad-4de5-9c60-c4a8aca25579   none      none          off        
-    oxp_6e418b8c-cadd-4fb8-8370-f351a07e1eed/crypt/zone                                                              7197059c-e461-43b1-a050-95740f239dc7   none      none          off        
-    oxp_6e5772a5-8234-46d1-ba5a-503a83d9d2fb/crypt/zone                                                              0292217f-5be3-440f-976b-6bab7043992f   none      none          off        
-    oxp_c1da692e-7713-43a0-b6bb-5c182084c09d/crypt/zone                                                              c7345d22-765f-4892-993f-de910ac5055b   none      none          off        
-    oxp_e35766ef-789a-4b2f-9a6c-e6626d5ab195/crypt/zone                                                              d37c8162-c363-447f-b4be-da14fb97b181   none      none          off        
-    oxp_2d44b756-94df-45ec-a644-50021248682d/crypt/zone/oxz_clickhouse_keeper_e4052979-f949-44bf-91de-17b371d3e518   da028e64-33e1-4380-8544-19e6ce754b20   none      none          off        
-    oxp_08616473-ded4-4785-9b53-b6ccc1efb67a/crypt/zone/oxz_clickhouse_keeper_fe395a2c-219b-4ad7-9f51-f536de60a9e4   1331d93d-4191-48ea-ae98-9554f9aabcd8   none      none          off        
-    oxp_08616473-ded4-4785-9b53-b6ccc1efb67a/crypt/zone/oxz_clickhouse_server_23ee16e1-7f1f-4a76-b4fc-32921eead60e   fef210d9-1473-4294-afa4-90e1f1836b86   none      none          off        
-    oxp_650b4eff-80a2-430a-97c8-f837248480a1/crypt/zone/oxz_crucible_0c50f6a6-55f0-4d9e-920e-c16b4e2f3b4f            34c4fcb0-c6d4-4f47-8153-a8b16e8c9c09   none      none          off        
-    oxp_44342c41-75a7-4708-8004-eb2ca5c5a3c2/crypt/zone/oxz_crucible_377d8477-7608-4248-b925-6a2c5e04fee3            3000bfbb-7faa-4439-914c-84815c5d75ea   none      none          off        
-    oxp_2dce7cf0-3097-485d-aaf6-9fc51f99eae5/crypt/zone/oxz_crucible_42ec7ad4-4a8a-4e7f-8291-bcc3a141647b            8e2fc466-8b2a-4be6-ba66-2bd8ef658a5d   none      none          off        
-    oxp_2d44b756-94df-45ec-a644-50021248682d/crypt/zone/oxz_crucible_4a152e9b-240b-4213-92fc-d205bc67c138            3a96f6b5-bf00-4f0d-b9d9-f718ac8c8672   none      none          off        
-    oxp_e35766ef-789a-4b2f-9a6c-e6626d5ab195/crypt/zone/oxz_crucible_5135c26c-5118-4dd0-a9a7-e2c46bd32b91            83321216-d04c-4dfc-99de-36dc1216c566   none      none          off        
-    oxp_c1da692e-7713-43a0-b6bb-5c182084c09d/crypt/zone/oxz_crucible_6d8c8a4f-82fc-47a9-b894-3c1dddd86343            a205bb5f-d9d9-43c1-aafb-fc872ca159b8   none      none          off        
-    oxp_6e5772a5-8234-46d1-ba5a-503a83d9d2fb/crypt/zone/oxz_crucible_9dce96c1-4f76-4e17-96de-aa867344581f            2d590e4c-8b2a-4021-baf1-3fc1a33a6130   none      none          off        
-    oxp_6e418b8c-cadd-4fb8-8370-f351a07e1eed/crypt/zone/oxz_crucible_cf0943f4-1f4c-4531-8412-ecab1d1df36f            a9cc6710-a9c1-44f0-aebb-26c708718918   none      none          off        
-    oxp_3b9d69e5-aa80-4fc8-9d2e-a2a24bd0f1d7/crypt/zone/oxz_crucible_e432e610-e600-4d1c-9427-e965afe2d54a            9d7b361b-ed6e-4bdb-a8b7-1f6736026e11   none      none          off        
-    oxp_08616473-ded4-4785-9b53-b6ccc1efb67a/crypt/zone/oxz_crucible_e83d6088-9e82-40dd-b8e9-b5bafe23d358            d989e55b-60c1-44c6-a37b-e081d9d49313   none      none          off        
-    oxp_08616473-ded4-4785-9b53-b6ccc1efb67a/crypt/zone/oxz_crucible_pantry_67e03ab1-90ac-45b5-9487-d892752201e1     26980dc7-7079-4a88-b01b-d75881aee578   none      none          off        
-    oxp_2d44b756-94df-45ec-a644-50021248682d/crypt/zone/oxz_internal_dns_1cd50cc3-c098-4fe3-ae5b-af0344f0b6ec        46273d48-d966-4cee-8af9-d3e7f5f38ac3   none      none          off        
-    oxp_08616473-ded4-4785-9b53-b6ccc1efb67a/crypt/zone/oxz_internal_dns_b5e0f928-60cd-4040-a6f2-5ad45ac50814        00e9e911-b36e-4371-b55a-b67a885c1650   none      none          off        
-    oxp_08616473-ded4-4785-9b53-b6ccc1efb67a/crypt/zone/oxz_nexus_3150ecb4-973e-4467-b194-632539bbdf07               2441284a-c8b4-4eb9-8988-5f7f64fcb7cc   none      none          off        
-    oxp_08616473-ded4-4785-9b53-b6ccc1efb67a/crypt/zone/oxz_ntp_663835e0-d8bc-41ea-b79f-bd85997777ce                 6c266f89-6820-45ba-8d53-8e2952a89f70   none      none          off        
-    oxp_08616473-ded4-4785-9b53-b6ccc1efb67a/crypt/debug                                                             c619b70f-4542-40ba-8cb6-1641df0b1a11   100 GiB   none          gzip-9     
-    oxp_2d44b756-94df-45ec-a644-50021248682d/crypt/debug                                                             c4f52f42-f6d1-40a3-bb3e-0a684ce06338   100 GiB   none          gzip-9     
-    oxp_2dce7cf0-3097-485d-aaf6-9fc51f99eae5/crypt/debug                                                             c857ccb3-eb0a-4220-aa80-e7c22d2f7be4   100 GiB   none          gzip-9     
-    oxp_3b9d69e5-aa80-4fc8-9d2e-a2a24bd0f1d7/crypt/debug                                                             f0808ff2-ce3a-4434-971b-055acb097d8d   100 GiB   none          gzip-9     
-    oxp_44342c41-75a7-4708-8004-eb2ca5c5a3c2/crypt/debug                                                             e6c0e102-f69d-4e14-bc52-7e03ae82cd0a   100 GiB   none          gzip-9     
-    oxp_650b4eff-80a2-430a-97c8-f837248480a1/crypt/debug                                                             0b84fd36-2a53-4420-b580-8a7ab5e44adb   100 GiB   none          gzip-9     
-    oxp_6e418b8c-cadd-4fb8-8370-f351a07e1eed/crypt/debug                                                             52d22143-4c25-45cf-a443-62e63052e385   100 GiB   none          gzip-9     
-    oxp_6e5772a5-8234-46d1-ba5a-503a83d9d2fb/crypt/debug                                                             ef0c1012-a349-4868-9175-e0a5e117614b   100 GiB   none          gzip-9     
-    oxp_c1da692e-7713-43a0-b6bb-5c182084c09d/crypt/debug                                                             0bf0d153-d9fb-42ed-a98f-839ca7c272bc   100 GiB   none          gzip-9     
-    oxp_e35766ef-789a-4b2f-9a6c-e6626d5ab195/crypt/debug                                                             3588412a-4f56-419c-b10c-0eef2c6a2c31   100 GiB   none          gzip-9     
+    oxp_08616473-ded4-4785-9b53-b6ccc1efb67a/crucible                                                                7576ef1f-3e41-44cc-b750-9b397374e234   none      none          off        
+    oxp_2d44b756-94df-45ec-a644-50021248682d/crucible                                                                4c886e70-05ef-437c-a7ab-ba8a1b5cf9af   none      none          off        
+    oxp_2dce7cf0-3097-485d-aaf6-9fc51f99eae5/crucible                                                                ec7693f9-a469-48ad-8f8d-6d0bc0138be8   none      none          off        
+    oxp_3b9d69e5-aa80-4fc8-9d2e-a2a24bd0f1d7/crucible                                                                b3ad0776-d6f0-4cbd-a382-a1b78576753b   none      none          off        
+    oxp_44342c41-75a7-4708-8004-eb2ca5c5a3c2/crucible                                                                8d7eebdb-c82f-4a29-b3c3-290bd343814a   none      none          off        
+    oxp_650b4eff-80a2-430a-97c8-f837248480a1/crucible                                                                a30613bb-70dd-43dd-b23c-c8759df0acdd   none      none          off        
+    oxp_6e418b8c-cadd-4fb8-8370-f351a07e1eed/crucible                                                                251a271a-0469-4309-ba94-7ecd827e3425   none      none          off        
+    oxp_6e5772a5-8234-46d1-ba5a-503a83d9d2fb/crucible                                                                8a62b925-a1cf-493a-a05e-67fc73605d82   none      none          off        
+    oxp_c1da692e-7713-43a0-b6bb-5c182084c09d/crucible                                                                649edc79-adc6-4391-a105-a54be7143259   none      none          off        
+    oxp_e35766ef-789a-4b2f-9a6c-e6626d5ab195/crucible                                                                8f1039b4-fd76-4444-802c-96385e68abde   none      none          off        
+    oxp_08616473-ded4-4785-9b53-b6ccc1efb67a/crypt/clickhouse_keeper                                                 00f7bc76-5861-485e-a7a7-8bc475950804   none      none          off        
+    oxp_2d44b756-94df-45ec-a644-50021248682d/crypt/clickhouse_keeper                                                 3b45a02a-3f37-4deb-93c6-0cba30538645   none      none          off        
+    oxp_08616473-ded4-4785-9b53-b6ccc1efb67a/crypt/clickhouse_server                                                 12e71b76-b549-4357-8209-215144d61723   none      none          off        
+    oxp_08616473-ded4-4785-9b53-b6ccc1efb67a/crypt/internal_dns                                                      f2c56628-2b29-42da-9ce3-ca705a0e4a97   none      none          off        
+    oxp_2d44b756-94df-45ec-a644-50021248682d/crypt/internal_dns                                                      2bd9382d-ab49-4570-8ec8-c4da8c822693   none      none          off        
+    oxp_08616473-ded4-4785-9b53-b6ccc1efb67a/crypt/zone                                                              6c76a56e-edc0-46e8-92b4-162920f7de33   none      none          off        
+    oxp_2d44b756-94df-45ec-a644-50021248682d/crypt/zone                                                              ce9648f6-3e8f-4c4f-a116-d57aff785b51   none      none          off        
+    oxp_2dce7cf0-3097-485d-aaf6-9fc51f99eae5/crypt/zone                                                              0c0b9b34-0f11-480b-bc42-83ab3cfb3667   none      none          off        
+    oxp_3b9d69e5-aa80-4fc8-9d2e-a2a24bd0f1d7/crypt/zone                                                              cb900fc0-fd1e-42fd-8e0b-491454d70d5e   none      none          off        
+    oxp_44342c41-75a7-4708-8004-eb2ca5c5a3c2/crypt/zone                                                              cae317ef-de63-4265-a0d7-777c5a70dd4e   none      none          off        
+    oxp_650b4eff-80a2-430a-97c8-f837248480a1/crypt/zone                                                              fec03736-ce6e-444e-b7dc-30ae3d00e502   none      none          off        
+    oxp_6e418b8c-cadd-4fb8-8370-f351a07e1eed/crypt/zone                                                              c22dfc9e-b068-4b85-ae0a-e81bc67f679a   none      none          off        
+    oxp_6e5772a5-8234-46d1-ba5a-503a83d9d2fb/crypt/zone                                                              8b954de0-88d8-4a00-902f-e612eed9da0c   none      none          off        
+    oxp_c1da692e-7713-43a0-b6bb-5c182084c09d/crypt/zone                                                              27d840dc-67e6-4795-8bb1-427213d0df3e   none      none          off        
+    oxp_e35766ef-789a-4b2f-9a6c-e6626d5ab195/crypt/zone                                                              b8e322e8-fe4f-43e8-b51a-d08b12f7e515   none      none          off        
+    oxp_08616473-ded4-4785-9b53-b6ccc1efb67a/crypt/zone/oxz_clickhouse_keeper_3f78fa04-0b7e-4959-9718-c232c76500e1   cbe9ab91-b85c-490d-8561-739c66bd2bee   none      none          off        
+    oxp_2d44b756-94df-45ec-a644-50021248682d/crypt/zone/oxz_clickhouse_keeper_bbba3c50-ff89-4a7f-96c1-d40ee996c417   ca2a30ab-baf8-4bb9-af14-3d41f6df6bf7   none      none          off        
+    oxp_08616473-ded4-4785-9b53-b6ccc1efb67a/crypt/zone/oxz_clickhouse_server_f0341fc6-6a73-4318-8787-dd0c6b26c385   39e58c15-5cb4-4f89-9bb3-adef453e9e3d   none      none          off        
+    oxp_650b4eff-80a2-430a-97c8-f837248480a1/crypt/zone/oxz_crucible_49afbe38-6b68-4764-afae-a279a7b9b1ab            3d258387-fe93-49c1-8cad-135b3f3556bf   none      none          off        
+    oxp_6e418b8c-cadd-4fb8-8370-f351a07e1eed/crypt/zone/oxz_crucible_4a223081-0985-45c7-b60e-478c371fde4b            69e7fb35-ff48-4d47-986f-374ce7ebac71   none      none          off        
+    oxp_2d44b756-94df-45ec-a644-50021248682d/crypt/zone/oxz_crucible_4e11460c-cfd2-4fa3-a7a7-25c976accece            6b5f0710-4fab-4921-b1ba-05de5d9ff2c3   none      none          off        
+    oxp_c1da692e-7713-43a0-b6bb-5c182084c09d/crypt/zone/oxz_crucible_4f7d1ee4-bd7b-48a5-99e0-e61fc8e6e58e            45831cd5-d578-4473-a97a-f737aedd9903   none      none          off        
+    oxp_08616473-ded4-4785-9b53-b6ccc1efb67a/crypt/zone/oxz_crucible_7cc30ab4-c566-42d4-8fb0-31a8a27156ff            df1af4ad-ec0e-4094-b8f2-d7ce592f40c0   none      none          off        
+    oxp_6e5772a5-8234-46d1-ba5a-503a83d9d2fb/crypt/zone/oxz_crucible_a50a59b8-b59a-4f1d-b5d4-41f113802b5f            c2832f18-d620-49d0-9c8e-b2fc9871e06f   none      none          off        
+    oxp_44342c41-75a7-4708-8004-eb2ca5c5a3c2/crypt/zone/oxz_crucible_a8839f9e-93f8-42a2-ac3a-9b804a5316f9            fdbdb20f-3a77-4da9-afff-96e7ac54f297   none      none          off        
+    oxp_3b9d69e5-aa80-4fc8-9d2e-a2a24bd0f1d7/crypt/zone/oxz_crucible_da1d617e-6450-4bb8-8696-d1518b2f0731            458a4d6e-83ee-4e74-85e7-69b35dc8045c   none      none          off        
+    oxp_e35766ef-789a-4b2f-9a6c-e6626d5ab195/crypt/zone/oxz_crucible_e71169cf-ee83-47b2-85ec-3396a20b4e02            97f033d1-1878-4429-81cf-9da9dc36bd95   none      none          off        
+    oxp_2dce7cf0-3097-485d-aaf6-9fc51f99eae5/crypt/zone/oxz_crucible_eeab4659-62e8-467f-a6f7-690854db89b5            854c1daf-e3bf-4b0a-84ef-3a1b9912f3df   none      none          off        
+    oxp_08616473-ded4-4785-9b53-b6ccc1efb67a/crypt/zone/oxz_crucible_pantry_2a8f8547-7c9a-4e79-8608-3c925fa3e4b7     74856b03-a612-43b4-94e7-6250cf56fba0   none      none          off        
+    oxp_2d44b756-94df-45ec-a644-50021248682d/crypt/zone/oxz_internal_dns_7f707d70-deef-42dc-96cc-a76cf6366386        40610ea8-b288-408c-91fd-e40edbba09cf   none      none          off        
+    oxp_08616473-ded4-4785-9b53-b6ccc1efb67a/crypt/zone/oxz_internal_dns_e8014d8f-0620-4dde-9fab-435cf4c0c321        2d7179ba-92a0-4bd1-8d5c-eba85fe540d3   none      none          off        
+    oxp_08616473-ded4-4785-9b53-b6ccc1efb67a/crypt/zone/oxz_nexus_d52405a5-debc-4682-8f32-8a3faee16b69               3fab12f1-b0ca-47e2-8865-9710e7e37117   none      none          off        
+    oxp_08616473-ded4-4785-9b53-b6ccc1efb67a/crypt/zone/oxz_ntp_a3e9eacd-48af-4333-aeb8-e7528042e664                 e56af4f5-a7ba-4ff1-a44d-d955f21755b6   none      none          off        
+    oxp_08616473-ded4-4785-9b53-b6ccc1efb67a/crypt/debug                                                             fdd71393-adb7-45c9-8a88-f3ce8d2bb93e   100 GiB   none          gzip-9     
+    oxp_2d44b756-94df-45ec-a644-50021248682d/crypt/debug                                                             c9b2026d-e9fd-4076-9a8c-32b06e34f0a3   100 GiB   none          gzip-9     
+    oxp_2dce7cf0-3097-485d-aaf6-9fc51f99eae5/crypt/debug                                                             3325118f-1ebc-48cd-9ade-cf2d319211b3   100 GiB   none          gzip-9     
+    oxp_3b9d69e5-aa80-4fc8-9d2e-a2a24bd0f1d7/crypt/debug                                                             d0213d2b-116c-4329-a93d-02c69c44c598   100 GiB   none          gzip-9     
+    oxp_44342c41-75a7-4708-8004-eb2ca5c5a3c2/crypt/debug                                                             247e51dd-fe88-43f2-b2bc-366e1b85c12b   100 GiB   none          gzip-9     
+    oxp_650b4eff-80a2-430a-97c8-f837248480a1/crypt/debug                                                             9321a17c-709d-44df-a4e3-8ca09bb3665f   100 GiB   none          gzip-9     
+    oxp_6e418b8c-cadd-4fb8-8370-f351a07e1eed/crypt/debug                                                             ee28398d-301c-4661-85a5-ddf27cff28b4   100 GiB   none          gzip-9     
+    oxp_6e5772a5-8234-46d1-ba5a-503a83d9d2fb/crypt/debug                                                             e74f80f2-5369-4647-8bd0-35b7d8b2a0b0   100 GiB   none          gzip-9     
+    oxp_c1da692e-7713-43a0-b6bb-5c182084c09d/crypt/debug                                                             d0a324c8-9de3-414a-8c8c-3fe301549cdb   100 GiB   none          gzip-9     
+    oxp_e35766ef-789a-4b2f-9a6c-e6626d5ab195/crypt/debug                                                             820def87-14ab-43c9-8f7d-b2be75a2570a   100 GiB   none          gzip-9     
 
 
     omicron zones at generation 4:
     -----------------------------------------------------------------------------------------------
     zone type           zone id                                disposition   underlay IP           
     -----------------------------------------------------------------------------------------------
-    clickhouse_keeper   e4052979-f949-44bf-91de-17b371d3e518   in service    fd00:1122:3344:102::30
-    clickhouse_keeper   fe395a2c-219b-4ad7-9f51-f536de60a9e4   in service    fd00:1122:3344:102::2e
-    clickhouse_server   23ee16e1-7f1f-4a76-b4fc-32921eead60e   in service    fd00:1122:3344:102::2f
-    crucible            0c50f6a6-55f0-4d9e-920e-c16b4e2f3b4f   in service    fd00:1122:3344:102::29
-    crucible            377d8477-7608-4248-b925-6a2c5e04fee3   in service    fd00:1122:3344:102::28
-    crucible            42ec7ad4-4a8a-4e7f-8291-bcc3a141647b   in service    fd00:1122:3344:102::26
-    crucible            4a152e9b-240b-4213-92fc-d205bc67c138   in service    fd00:1122:3344:102::25
-    crucible            5135c26c-5118-4dd0-a9a7-e2c46bd32b91   in service    fd00:1122:3344:102::2d
-    crucible            6d8c8a4f-82fc-47a9-b894-3c1dddd86343   in service    fd00:1122:3344:102::2c
-    crucible            9dce96c1-4f76-4e17-96de-aa867344581f   in service    fd00:1122:3344:102::2b
-    crucible            cf0943f4-1f4c-4531-8412-ecab1d1df36f   in service    fd00:1122:3344:102::2a
-    crucible            e432e610-e600-4d1c-9427-e965afe2d54a   in service    fd00:1122:3344:102::27
-    crucible            e83d6088-9e82-40dd-b8e9-b5bafe23d358   in service    fd00:1122:3344:102::24
-    crucible_pantry     67e03ab1-90ac-45b5-9487-d892752201e1   in service    fd00:1122:3344:102::23
-    internal_dns        1cd50cc3-c098-4fe3-ae5b-af0344f0b6ec   in service    fd00:1122:3344:1::1   
-    internal_dns        b5e0f928-60cd-4040-a6f2-5ad45ac50814   in service    fd00:1122:3344:2::1   
-    internal_ntp        663835e0-d8bc-41ea-b79f-bd85997777ce   in service    fd00:1122:3344:102::21
-    nexus               3150ecb4-973e-4467-b194-632539bbdf07   in service    fd00:1122:3344:102::22
+    clickhouse_keeper   3f78fa04-0b7e-4959-9718-c232c76500e1   in service    fd00:1122:3344:102::2e
+    clickhouse_keeper   bbba3c50-ff89-4a7f-96c1-d40ee996c417   in service    fd00:1122:3344:102::30
+    clickhouse_server   f0341fc6-6a73-4318-8787-dd0c6b26c385   in service    fd00:1122:3344:102::2f
+    crucible            49afbe38-6b68-4764-afae-a279a7b9b1ab   in service    fd00:1122:3344:102::29
+    crucible            4a223081-0985-45c7-b60e-478c371fde4b   in service    fd00:1122:3344:102::2a
+    crucible            4e11460c-cfd2-4fa3-a7a7-25c976accece   in service    fd00:1122:3344:102::25
+    crucible            4f7d1ee4-bd7b-48a5-99e0-e61fc8e6e58e   in service    fd00:1122:3344:102::2c
+    crucible            7cc30ab4-c566-42d4-8fb0-31a8a27156ff   in service    fd00:1122:3344:102::24
+    crucible            a50a59b8-b59a-4f1d-b5d4-41f113802b5f   in service    fd00:1122:3344:102::2b
+    crucible            a8839f9e-93f8-42a2-ac3a-9b804a5316f9   in service    fd00:1122:3344:102::28
+    crucible            da1d617e-6450-4bb8-8696-d1518b2f0731   in service    fd00:1122:3344:102::27
+    crucible            e71169cf-ee83-47b2-85ec-3396a20b4e02   in service    fd00:1122:3344:102::2d
+    crucible            eeab4659-62e8-467f-a6f7-690854db89b5   in service    fd00:1122:3344:102::26
+    crucible_pantry     2a8f8547-7c9a-4e79-8608-3c925fa3e4b7   in service    fd00:1122:3344:102::23
+    internal_dns        7f707d70-deef-42dc-96cc-a76cf6366386   in service    fd00:1122:3344:1::1   
+    internal_dns        e8014d8f-0620-4dde-9fab-435cf4c0c321   in service    fd00:1122:3344:2::1   
+    internal_ntp        a3e9eacd-48af-4333-aeb8-e7528042e664   in service    fd00:1122:3344:102::21
+    nexus               d52405a5-debc-4682-8f32-8a3faee16b69   in service    fd00:1122:3344:102::22
 
 
   sled fe7b9b01-e803-41ea-9e39-db240dcd9029 (active):
@@ -150,84 +150,84 @@ to:   blueprint df68d4d4-5af4-4b56-95bb-1654a6957d4f
     -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
     dataset name                                                                                                     dataset uuid                           quota     reservation   compression
     -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
-    oxp_21d60319-5fe1-4a3b-a4c0-6aa7465e7bde/crucible                                                                83697259-f910-49de-8c15-83605c086a5d   none      none          off        
-    oxp_2acfbb84-5ce0-424e-8d73-44c5071d4430/crucible                                                                46ea917a-f99f-4078-8f45-8e92512ba42c   none      none          off        
-    oxp_2db7f3b4-ed19-4229-b42c-44f49eeb8a91/crucible                                                                d26ad281-5420-42c4-be19-013d7d44e2e9   none      none          off        
-    oxp_2fa34d8e-13d9-42d3-b8ba-ca9d74ac496a/crucible                                                                9ba7194a-0e9e-485f-b4ba-e58c39bc90da   none      none          off        
-    oxp_355e268c-c932-4f32-841c-f3ec88fe0495/crucible                                                                a1cb2b30-ca4f-4b9d-840d-4deef5993b79   none      none          off        
-    oxp_427b2ccd-998f-4085-af21-e600604cf21e/crucible                                                                0c6d24b8-e64b-4f97-a4ae-19bc998214fe   none      none          off        
-    oxp_588058f2-f51b-4800-a211-1c5dbb32296b/crucible                                                                97e6171d-523c-4c4a-9fa6-daead00d71a5   none      none          off        
-    oxp_736f6f07-2aa2-4658-8b5c-3bf409ea747a/crucible                                                                035b55e9-a0fc-48e5-8cd0-a862e7a7fe47   none      none          off        
-    oxp_bcfcdede-7084-4a31-97a8-ac4299c268f9/crucible                                                                01def6ad-ddd9-4b28-b337-137a16734021   none      none          off        
-    oxp_fe379ac6-1938-4cc2-93a9-43b1447229ae/crucible                                                                5818a803-eb2c-44eb-8818-bd98bfa29da9   none      none          off        
-    oxp_21d60319-5fe1-4a3b-a4c0-6aa7465e7bde/crypt/clickhouse                                                        410eca9c-8eee-4a98-aea2-a363697974f7   none      none          off        
-    oxp_21d60319-5fe1-4a3b-a4c0-6aa7465e7bde/crypt/clickhouse_keeper                                                 35a2dc24-0853-4a06-b5b9-90b8ba83e0b0   none      none          off        
-    oxp_21d60319-5fe1-4a3b-a4c0-6aa7465e7bde/crypt/clickhouse_server                                                 e1236796-4a4f-48fe-b274-9c6c251d60b7   none      none          off        
-    oxp_21d60319-5fe1-4a3b-a4c0-6aa7465e7bde/crypt/internal_dns                                                      8d423173-09c9-4ca5-a21c-b7c3123aa1af   none      none          off        
-    oxp_21d60319-5fe1-4a3b-a4c0-6aa7465e7bde/crypt/zone                                                              d5d2ddf7-2eb3-40f3-b149-aee5699b7bf1   none      none          off        
-    oxp_2acfbb84-5ce0-424e-8d73-44c5071d4430/crypt/zone                                                              988c82cc-aed4-4207-96a8-f844ede70a5c   none      none          off        
-    oxp_2db7f3b4-ed19-4229-b42c-44f49eeb8a91/crypt/zone                                                              0c6b2002-2cec-478f-9eb3-239069f42dbc   none      none          off        
-    oxp_2fa34d8e-13d9-42d3-b8ba-ca9d74ac496a/crypt/zone                                                              8b6d2ff8-4f40-4776-b461-29e0a3d3dd97   none      none          off        
-    oxp_355e268c-c932-4f32-841c-f3ec88fe0495/crypt/zone                                                              cf7a9405-cf77-49cd-b3d4-528d9ad5ce48   none      none          off        
-    oxp_427b2ccd-998f-4085-af21-e600604cf21e/crypt/zone                                                              a03487ed-4b03-4856-a670-9fa703b0b850   none      none          off        
-    oxp_588058f2-f51b-4800-a211-1c5dbb32296b/crypt/zone                                                              86009a86-7c47-477d-bb17-c38689f5b337   none      none          off        
-    oxp_736f6f07-2aa2-4658-8b5c-3bf409ea747a/crypt/zone                                                              f3df6efd-e689-4aaa-b4ed-76de319a1fe4   none      none          off        
-    oxp_bcfcdede-7084-4a31-97a8-ac4299c268f9/crypt/zone                                                              d8d8dc6c-cd76-4d17-b530-25f3f3f52d33   none      none          off        
-    oxp_fe379ac6-1938-4cc2-93a9-43b1447229ae/crypt/zone                                                              9327960e-a9a3-4b26-9bd4-65afb1737bd4   none      none          off        
-    oxp_21d60319-5fe1-4a3b-a4c0-6aa7465e7bde/crypt/zone/oxz_clickhouse_fa97835a-aabc-4fe9-9e85-3e50f207129c          08f15d4b-91dc-445d-88f4-cb9fa585444b   none      none          off        
-    oxp_21d60319-5fe1-4a3b-a4c0-6aa7465e7bde/crypt/zone/oxz_clickhouse_keeper_ceea23ec-1cb4-46be-bfa6-de9025ad5737   abb56278-58c2-4e0c-8cc8-417f57100de0   none      none          off        
-    oxp_21d60319-5fe1-4a3b-a4c0-6aa7465e7bde/crypt/zone/oxz_clickhouse_server_02ef9ddc-a012-4d15-8f45-8282f58c9a11   2315a796-5038-4003-b5e0-099a29f7ebb1   none      none          off        
-    oxp_2db7f3b4-ed19-4229-b42c-44f49eeb8a91/crypt/zone/oxz_crucible_02aecfb8-91a9-4db8-8cb2-4252bf15d6ac            7e11890f-b1ce-497a-9672-f95d3452eb7b   none      none          off        
-    oxp_355e268c-c932-4f32-841c-f3ec88fe0495/crypt/zone/oxz_crucible_0a3cfe7c-414d-40f0-8f63-a7c0b26b7627            e1396508-5d99-4802-8d3f-cc3db33f0341   none      none          off        
-    oxp_bcfcdede-7084-4a31-97a8-ac4299c268f9/crypt/zone/oxz_crucible_109820d7-b6ef-4574-b5e4-9f193c9d2a9e            75f329ff-4f3b-4cc5-8027-dd61d05e7323   none      none          off        
-    oxp_21d60319-5fe1-4a3b-a4c0-6aa7465e7bde/crypt/zone/oxz_crucible_3801ce73-9986-491a-a623-8ae2cea1678b            d0d28f34-55ba-400e-9dce-a8c3d25c09e9   none      none          off        
-    oxp_fe379ac6-1938-4cc2-93a9-43b1447229ae/crypt/zone/oxz_crucible_43aa521b-eb86-4c3d-a58c-83c733f2fec3            c7a57806-05b3-4e38-9bc4-07fd6b30cccd   none      none          off        
-    oxp_736f6f07-2aa2-4658-8b5c-3bf409ea747a/crypt/zone/oxz_crucible_79164b60-fbb4-46d4-9a42-eafbaeddd672            ebf1a36b-ab94-4a5d-a777-937991a60396   none      none          off        
-    oxp_2acfbb84-5ce0-424e-8d73-44c5071d4430/crypt/zone/oxz_crucible_93fe2a9b-3ce9-4bf0-852d-c36171988c71            6fafdcb1-b246-44ca-8e8e-2101ce3cbdf7   none      none          off        
-    oxp_588058f2-f51b-4800-a211-1c5dbb32296b/crypt/zone/oxz_crucible_a91714d7-33b4-40d6-93cf-1b278bc9f1c6            f4c0087b-c746-4440-82e7-82ff5e40c6ab   none      none          off        
-    oxp_427b2ccd-998f-4085-af21-e600604cf21e/crypt/zone/oxz_crucible_befe73dd-5970-49a4-9adf-7b4f453c45cf            95d72ef9-e070-49e4-a57b-2c392def6025   none      none          off        
-    oxp_2fa34d8e-13d9-42d3-b8ba-ca9d74ac496a/crypt/zone/oxz_crucible_d9106a19-f267-48db-a82b-004e643feb49            9b9fb14e-cd17-4a7a-a74a-bfd9c7682831   none      none          off        
-    oxp_21d60319-5fe1-4a3b-a4c0-6aa7465e7bde/crypt/zone/oxz_crucible_pantry_6c7f6a84-78b3-4dd9-878e-51bedfda471f     aa190e01-9a4e-4131-9fcf-240532108c7f   none      none          off        
-    oxp_2acfbb84-5ce0-424e-8d73-44c5071d4430/crypt/zone/oxz_crucible_pantry_7741bb11-0d99-4856-95ae-725b6b9ff4fa     4eb52e76-39fa-414d-ae9b-2dcb1c7737f9   none      none          off        
-    oxp_21d60319-5fe1-4a3b-a4c0-6aa7465e7bde/crypt/zone/oxz_internal_dns_0c42ad01-b854-4e7d-bd6c-25fdc3eddef4        1de9cde7-6c1e-4865-bd3d-378e22f62fb8   none      none          off        
-    oxp_2acfbb84-5ce0-424e-8d73-44c5071d4430/crypt/zone/oxz_nexus_69789010-8689-43ab-9a68-a944afcba05a               e67b797b-a059-4c7e-a98b-fea18964bad6   none      none          off        
-    oxp_21d60319-5fe1-4a3b-a4c0-6aa7465e7bde/crypt/zone/oxz_nexus_7e763480-0f4f-43cb-ab9a-52b667d8fda5               5773e3b1-dde0-4b54-bc13-3c3bf816015e   none      none          off        
-    oxp_21d60319-5fe1-4a3b-a4c0-6aa7465e7bde/crypt/zone/oxz_ntp_f34f8d36-7137-48d3-9d13-6a46c4edcef4                 c8c03dec-65d4-4c97-87c3-a43a8363c97c   none      none          off        
-    oxp_21d60319-5fe1-4a3b-a4c0-6aa7465e7bde/crypt/debug                                                             f015e445-2e52-45c9-9f0a-49cb5ceae245   100 GiB   none          gzip-9     
-    oxp_2acfbb84-5ce0-424e-8d73-44c5071d4430/crypt/debug                                                             a86eda4a-2346-4990-8393-6692c81f9f37   100 GiB   none          gzip-9     
-    oxp_2db7f3b4-ed19-4229-b42c-44f49eeb8a91/crypt/debug                                                             f3c93847-6a22-4f95-97cd-766358663b2a   100 GiB   none          gzip-9     
-    oxp_2fa34d8e-13d9-42d3-b8ba-ca9d74ac496a/crypt/debug                                                             ec40dcf8-085f-4277-8d96-657a1e7fb0c8   100 GiB   none          gzip-9     
-    oxp_355e268c-c932-4f32-841c-f3ec88fe0495/crypt/debug                                                             85d345b5-04d4-4bdf-9e6f-c10b3f21208d   100 GiB   none          gzip-9     
-    oxp_427b2ccd-998f-4085-af21-e600604cf21e/crypt/debug                                                             f7cccd71-efb1-4bee-bcdf-7e7133c3e5da   100 GiB   none          gzip-9     
-    oxp_588058f2-f51b-4800-a211-1c5dbb32296b/crypt/debug                                                             2ab9c443-5ea3-4ab1-b2ed-d57abbfde4be   100 GiB   none          gzip-9     
-    oxp_736f6f07-2aa2-4658-8b5c-3bf409ea747a/crypt/debug                                                             0f785b1f-3f7a-4ae7-8a32-4412b781d245   100 GiB   none          gzip-9     
-    oxp_bcfcdede-7084-4a31-97a8-ac4299c268f9/crypt/debug                                                             6fdd4ca2-022f-4ef3-9a83-1e18e620e9dc   100 GiB   none          gzip-9     
-    oxp_fe379ac6-1938-4cc2-93a9-43b1447229ae/crypt/debug                                                             3a49dd24-8ead-4196-b453-8aa3273b77d1   100 GiB   none          gzip-9     
+    oxp_21d60319-5fe1-4a3b-a4c0-6aa7465e7bde/crucible                                                                b97110cd-9c9d-47d8-ac3e-38b2a5fbf4bb   none      none          off        
+    oxp_2acfbb84-5ce0-424e-8d73-44c5071d4430/crucible                                                                b07b36ec-f27e-4bef-bd0e-adbab3dbded0   none      none          off        
+    oxp_2db7f3b4-ed19-4229-b42c-44f49eeb8a91/crucible                                                                50904cf3-e571-42ee-9be7-40e0d293be12   none      none          off        
+    oxp_2fa34d8e-13d9-42d3-b8ba-ca9d74ac496a/crucible                                                                e3ed0aa2-a4bf-4619-a276-ff287c23f260   none      none          off        
+    oxp_355e268c-c932-4f32-841c-f3ec88fe0495/crucible                                                                c5a79172-3a48-4ecc-a814-77f4a0ac87c3   none      none          off        
+    oxp_427b2ccd-998f-4085-af21-e600604cf21e/crucible                                                                0490a48d-59be-412f-8db8-8a8778f5bdce   none      none          off        
+    oxp_588058f2-f51b-4800-a211-1c5dbb32296b/crucible                                                                d148662e-1244-416e-9043-2c6e5bc3391c   none      none          off        
+    oxp_736f6f07-2aa2-4658-8b5c-3bf409ea747a/crucible                                                                55340375-5d36-475d-99d6-8c8dc38a8421   none      none          off        
+    oxp_bcfcdede-7084-4a31-97a8-ac4299c268f9/crucible                                                                cdf74236-d6b4-4872-ab29-3ef21b1f9e9e   none      none          off        
+    oxp_fe379ac6-1938-4cc2-93a9-43b1447229ae/crucible                                                                98085696-2290-4467-b2de-cecd1ab6255e   none      none          off        
+    oxp_21d60319-5fe1-4a3b-a4c0-6aa7465e7bde/crypt/clickhouse                                                        650004ee-2360-47a3-ba98-b07dd9873c06   none      none          off        
+    oxp_21d60319-5fe1-4a3b-a4c0-6aa7465e7bde/crypt/clickhouse_keeper                                                 56624401-f56f-4fd2-88fb-cfd56df535aa   none      none          off        
+    oxp_21d60319-5fe1-4a3b-a4c0-6aa7465e7bde/crypt/clickhouse_server                                                 67e873d4-5ee2-4fcd-bd1f-9311ad2ed23c   none      none          off        
+    oxp_21d60319-5fe1-4a3b-a4c0-6aa7465e7bde/crypt/internal_dns                                                      eba7c3d8-af0f-4de7-9b07-8e63ff8c9a34   none      none          off        
+    oxp_21d60319-5fe1-4a3b-a4c0-6aa7465e7bde/crypt/zone                                                              a27fb298-e263-4560-965a-2c56292ea19a   none      none          off        
+    oxp_2acfbb84-5ce0-424e-8d73-44c5071d4430/crypt/zone                                                              03dfbeda-a138-45c2-975f-05a9af2ef2b9   none      none          off        
+    oxp_2db7f3b4-ed19-4229-b42c-44f49eeb8a91/crypt/zone                                                              40986d49-c197-462c-baac-ba937da44571   none      none          off        
+    oxp_2fa34d8e-13d9-42d3-b8ba-ca9d74ac496a/crypt/zone                                                              006eede7-d6b6-4af2-a2ff-37b94386b421   none      none          off        
+    oxp_355e268c-c932-4f32-841c-f3ec88fe0495/crypt/zone                                                              18279e0e-4f67-4e87-bc5a-2eb3927ec023   none      none          off        
+    oxp_427b2ccd-998f-4085-af21-e600604cf21e/crypt/zone                                                              491b337c-3c25-4284-ae13-443206ff696f   none      none          off        
+    oxp_588058f2-f51b-4800-a211-1c5dbb32296b/crypt/zone                                                              5aa2c795-468a-45df-8769-16f4d5d0e42a   none      none          off        
+    oxp_736f6f07-2aa2-4658-8b5c-3bf409ea747a/crypt/zone                                                              89c95288-774f-480c-ab14-a0327bec365b   none      none          off        
+    oxp_bcfcdede-7084-4a31-97a8-ac4299c268f9/crypt/zone                                                              e7569f72-580c-417b-b223-0e5f998dd9c1   none      none          off        
+    oxp_fe379ac6-1938-4cc2-93a9-43b1447229ae/crypt/zone                                                              2aae5bf8-7c17-43c4-9183-4c1956571243   none      none          off        
+    oxp_21d60319-5fe1-4a3b-a4c0-6aa7465e7bde/crypt/zone/oxz_clickhouse_ca54c155-5e4c-42e6-96f2-b70448019418          b760c1d2-fa43-441d-8b79-d1fde01a8753   none      none          off        
+    oxp_21d60319-5fe1-4a3b-a4c0-6aa7465e7bde/crypt/zone/oxz_clickhouse_keeper_2b368dcd-bb4b-4415-9daf-0d36fd769fed   c22caa52-6179-49a7-95dc-5cf0d9f3f827   none      none          off        
+    oxp_21d60319-5fe1-4a3b-a4c0-6aa7465e7bde/crypt/zone/oxz_clickhouse_server_097ab295-aec4-427f-9124-bb4e8aecfeca   e21880d2-f6f9-4e97-b7da-5a8a934845ab   none      none          off        
+    oxp_736f6f07-2aa2-4658-8b5c-3bf409ea747a/crypt/zone/oxz_crucible_308c592a-b022-4790-9824-7a5e10b83d1b            4e514d61-b9d3-4e8c-b528-4b9577d8ad84   none      none          off        
+    oxp_2fa34d8e-13d9-42d3-b8ba-ca9d74ac496a/crypt/zone/oxz_crucible_7233139a-ad5b-4c0e-be80-759fbd5cb262            2c3d31cf-9a06-4f47-8f30-97884d06de8f   none      none          off        
+    oxp_2acfbb84-5ce0-424e-8d73-44c5071d4430/crypt/zone/oxz_crucible_8c43faff-54c7-4b91-820c-ff130b7049e9            9155b21a-1803-44b3-b80e-6d22f7af2e07   none      none          off        
+    oxp_fe379ac6-1938-4cc2-93a9-43b1447229ae/crypt/zone/oxz_crucible_8ddbafde-d699-4e37-b70d-dcd803f0898e            a46724b6-7ca0-4d70-9dd2-6fd22d1e6150   none      none          off        
+    oxp_427b2ccd-998f-4085-af21-e600604cf21e/crypt/zone/oxz_crucible_955bd7eb-8cc2-4128-a636-19bde11ab251            44153191-15ac-4206-b153-167261b232fe   none      none          off        
+    oxp_21d60319-5fe1-4a3b-a4c0-6aa7465e7bde/crypt/zone/oxz_crucible_a6192358-d6e1-4483-a3c6-755a05911f22            5fd12d35-d258-42ca-8fe3-dc5788bdc66c   none      none          off        
+    oxp_bcfcdede-7084-4a31-97a8-ac4299c268f9/crypt/zone/oxz_crucible_a68bc085-0ad5-4c42-a9f7-0b540de24ced            1de186f8-a37f-42fa-9e70-05aa05641c7e   none      none          off        
+    oxp_355e268c-c932-4f32-841c-f3ec88fe0495/crypt/zone/oxz_crucible_cdc00fbb-5ac7-4667-9fc8-926ea73a002a            510ecf2a-6a98-40f2-b387-3bab22da2bf7   none      none          off        
+    oxp_2db7f3b4-ed19-4229-b42c-44f49eeb8a91/crypt/zone/oxz_crucible_d04ed118-4eb8-4ba4-8f05-7714060291e2            282ed619-0004-4647-9d60-85509d68170e   none      none          off        
+    oxp_588058f2-f51b-4800-a211-1c5dbb32296b/crypt/zone/oxz_crucible_e5347768-7d4d-4862-b78e-38291aca675a            ba5652ea-a567-4e7f-a62d-616fd9ab2aff   none      none          off        
+    oxp_21d60319-5fe1-4a3b-a4c0-6aa7465e7bde/crypt/zone/oxz_crucible_pantry_0af27834-4e26-4417-9cc3-9a04105b1cbc     8d62e551-9775-4ac8-a830-15e1f3aabb46   none      none          off        
+    oxp_2acfbb84-5ce0-424e-8d73-44c5071d4430/crypt/zone/oxz_crucible_pantry_84fc3bdc-a8f6-4ceb-8fcf-59a003bc91c0     96d231ab-baee-465f-a584-6eedcc3e14cc   none      none          off        
+    oxp_21d60319-5fe1-4a3b-a4c0-6aa7465e7bde/crypt/zone/oxz_internal_dns_a6212313-b0c0-4a69-9ca6-5ea9c7e3e947        38daea72-c487-4f80-9e27-ef67e6b2d05d   none      none          off        
+    oxp_2acfbb84-5ce0-424e-8d73-44c5071d4430/crypt/zone/oxz_nexus_b2e9a34b-7b15-4f56-836d-b39e474afbc5               a89cea5b-db88-4f12-a2f4-700a04803af1   none      none          off        
+    oxp_21d60319-5fe1-4a3b-a4c0-6aa7465e7bde/crypt/zone/oxz_nexus_e786e397-2ccc-4112-bf26-45ca1de89f3b               a26d8d3b-1483-4e98-bb4b-1680c75c2956   none      none          off        
+    oxp_21d60319-5fe1-4a3b-a4c0-6aa7465e7bde/crypt/zone/oxz_ntp_0991f26b-97a1-4033-af5d-df7e56c2189a                 a6f0a3f1-aff9-45d9-8e70-610780c75c73   none      none          off        
+    oxp_21d60319-5fe1-4a3b-a4c0-6aa7465e7bde/crypt/debug                                                             c2868186-4510-4c56-9374-13a4fda781be   100 GiB   none          gzip-9     
+    oxp_2acfbb84-5ce0-424e-8d73-44c5071d4430/crypt/debug                                                             80bb6683-3e89-4652-9b4d-a2adc6dc05c3   100 GiB   none          gzip-9     
+    oxp_2db7f3b4-ed19-4229-b42c-44f49eeb8a91/crypt/debug                                                             35abcc8e-8fae-4e0f-9db7-457c21c27244   100 GiB   none          gzip-9     
+    oxp_2fa34d8e-13d9-42d3-b8ba-ca9d74ac496a/crypt/debug                                                             ae45ae89-0fc5-4c82-8e38-bdc4efb2a4cd   100 GiB   none          gzip-9     
+    oxp_355e268c-c932-4f32-841c-f3ec88fe0495/crypt/debug                                                             f567b79a-c05c-4ba5-85a6-87f217687c9b   100 GiB   none          gzip-9     
+    oxp_427b2ccd-998f-4085-af21-e600604cf21e/crypt/debug                                                             da15e9ee-d60c-4b9d-a383-52c8c82f8bad   100 GiB   none          gzip-9     
+    oxp_588058f2-f51b-4800-a211-1c5dbb32296b/crypt/debug                                                             f8390042-25a5-43db-9d6c-336223c5210f   100 GiB   none          gzip-9     
+    oxp_736f6f07-2aa2-4658-8b5c-3bf409ea747a/crypt/debug                                                             68191fe0-2606-4d82-833e-e467ff129a19   100 GiB   none          gzip-9     
+    oxp_bcfcdede-7084-4a31-97a8-ac4299c268f9/crypt/debug                                                             2755f94e-a5e8-4bf8-8cdc-2645e5b21578   100 GiB   none          gzip-9     
+    oxp_fe379ac6-1938-4cc2-93a9-43b1447229ae/crypt/debug                                                             68b11f7e-4258-483b-a75a-4243ca7ede6f   100 GiB   none          gzip-9     
 
 
     omicron zones at generation 4:
     -----------------------------------------------------------------------------------------------
     zone type           zone id                                disposition   underlay IP           
     -----------------------------------------------------------------------------------------------
-    clickhouse          fa97835a-aabc-4fe9-9e85-3e50f207129c   in service    fd00:1122:3344:103::30
-    clickhouse_keeper   ceea23ec-1cb4-46be-bfa6-de9025ad5737   in service    fd00:1122:3344:103::2e
-    clickhouse_server   02ef9ddc-a012-4d15-8f45-8282f58c9a11   in service    fd00:1122:3344:103::2f
-    crucible            02aecfb8-91a9-4db8-8cb2-4252bf15d6ac   in service    fd00:1122:3344:103::26
-    crucible            0a3cfe7c-414d-40f0-8f63-a7c0b26b7627   in service    fd00:1122:3344:103::28
-    crucible            109820d7-b6ef-4574-b5e4-9f193c9d2a9e   in service    fd00:1122:3344:103::2c
-    crucible            3801ce73-9986-491a-a623-8ae2cea1678b   in service    fd00:1122:3344:103::24
-    crucible            43aa521b-eb86-4c3d-a58c-83c733f2fec3   in service    fd00:1122:3344:103::2d
-    crucible            79164b60-fbb4-46d4-9a42-eafbaeddd672   in service    fd00:1122:3344:103::2b
-    crucible            93fe2a9b-3ce9-4bf0-852d-c36171988c71   in service    fd00:1122:3344:103::25
-    crucible            a91714d7-33b4-40d6-93cf-1b278bc9f1c6   in service    fd00:1122:3344:103::2a
-    crucible            befe73dd-5970-49a4-9adf-7b4f453c45cf   in service    fd00:1122:3344:103::29
-    crucible            d9106a19-f267-48db-a82b-004e643feb49   in service    fd00:1122:3344:103::27
-    crucible_pantry     6c7f6a84-78b3-4dd9-878e-51bedfda471f   in service    fd00:1122:3344:103::23
-    crucible_pantry     7741bb11-0d99-4856-95ae-725b6b9ff4fa   in service    fd00:1122:3344:103::31
-    internal_dns        0c42ad01-b854-4e7d-bd6c-25fdc3eddef4   in service    fd00:1122:3344:3::1   
-    internal_ntp        f34f8d36-7137-48d3-9d13-6a46c4edcef4   in service    fd00:1122:3344:103::21
-    nexus               69789010-8689-43ab-9a68-a944afcba05a   in service    fd00:1122:3344:103::32
-    nexus               7e763480-0f4f-43cb-ab9a-52b667d8fda5   in service    fd00:1122:3344:103::22
+    clickhouse          ca54c155-5e4c-42e6-96f2-b70448019418   in service    fd00:1122:3344:103::30
+    clickhouse_keeper   2b368dcd-bb4b-4415-9daf-0d36fd769fed   in service    fd00:1122:3344:103::2e
+    clickhouse_server   097ab295-aec4-427f-9124-bb4e8aecfeca   in service    fd00:1122:3344:103::2f
+    crucible            308c592a-b022-4790-9824-7a5e10b83d1b   in service    fd00:1122:3344:103::2b
+    crucible            7233139a-ad5b-4c0e-be80-759fbd5cb262   in service    fd00:1122:3344:103::27
+    crucible            8c43faff-54c7-4b91-820c-ff130b7049e9   in service    fd00:1122:3344:103::25
+    crucible            8ddbafde-d699-4e37-b70d-dcd803f0898e   in service    fd00:1122:3344:103::2d
+    crucible            955bd7eb-8cc2-4128-a636-19bde11ab251   in service    fd00:1122:3344:103::29
+    crucible            a6192358-d6e1-4483-a3c6-755a05911f22   in service    fd00:1122:3344:103::24
+    crucible            a68bc085-0ad5-4c42-a9f7-0b540de24ced   in service    fd00:1122:3344:103::2c
+    crucible            cdc00fbb-5ac7-4667-9fc8-926ea73a002a   in service    fd00:1122:3344:103::28
+    crucible            d04ed118-4eb8-4ba4-8f05-7714060291e2   in service    fd00:1122:3344:103::26
+    crucible            e5347768-7d4d-4862-b78e-38291aca675a   in service    fd00:1122:3344:103::2a
+    crucible_pantry     0af27834-4e26-4417-9cc3-9a04105b1cbc   in service    fd00:1122:3344:103::23
+    crucible_pantry     84fc3bdc-a8f6-4ceb-8fcf-59a003bc91c0   in service    fd00:1122:3344:103::31
+    internal_dns        a6212313-b0c0-4a69-9ca6-5ea9c7e3e947   in service    fd00:1122:3344:3::1   
+    internal_ntp        0991f26b-97a1-4033-af5d-df7e56c2189a   in service    fd00:1122:3344:103::21
+    nexus               b2e9a34b-7b15-4f56-836d-b39e474afbc5   in service    fd00:1122:3344:103::32
+    nexus               e786e397-2ccc-4112-bf26-45ca1de89f3b   in service    fd00:1122:3344:103::22
 
 
  COCKROACHDB SETTINGS:
@@ -243,21 +243,21 @@ to:   blueprint df68d4d4-5af4-4b56-95bb-1654a6957d4f
     max used server id:::::::::::::::::::::::::::::   2 (unchanged)
 *   max used keeper id:::::::::::::::::::::::::::::   3 -> 4
     cluster name:::::::::::::::::::::::::::::::::::   oximeter_cluster (unchanged)
-    cluster secret:::::::::::::::::::::::::::::::::   9b56c0da-33d7-41a6-b411-6d00e71bea9b (unchanged)
+    cluster secret:::::::::::::::::::::::::::::::::   61731868-2fb2-48cc-b135-1eebcfbff058 (unchanged)
 *   highest seen keeper leader committed log index:   1 -> 3
 
     clickhouse keepers generation 3 -> 4:
     ------------------------------------------------
     zone id                                keeper id
     ------------------------------------------------
-    ceea23ec-1cb4-46be-bfa6-de9025ad5737   1        
-+   e4052979-f949-44bf-91de-17b371d3e518   4        
-    fe395a2c-219b-4ad7-9f51-f536de60a9e4   2        
+    2b368dcd-bb4b-4415-9daf-0d36fd769fed   1        
+    3f78fa04-0b7e-4959-9718-c232c76500e1   2        
++   bbba3c50-ff89-4a7f-96c1-d40ee996c417   4        
 
     clickhouse servers generation 3 -> 4:
     ------------------------------------------------
     zone id                                server id
     ------------------------------------------------
-    02ef9ddc-a012-4d15-8f45-8282f58c9a11   1        
-    23ee16e1-7f1f-4a76-b4fc-32921eead60e   2        
+    097ab295-aec4-427f-9124-bb4e8aecfeca   1        
+    f0341fc6-6a73-4318-8787-dd0c6b26c385   2        
 

--- a/nexus/reconfigurator/planning/tests/output/planner_expunge_clickhouse_zones_after_policy_is_changed_3_4.txt
+++ b/nexus/reconfigurator/planning/tests/output/planner_expunge_clickhouse_zones_after_policy_is_changed_3_4.txt
@@ -25,77 +25,77 @@ to:   blueprint d895ef50-9978-454c-bdfb-b8dbe2c9a918
     -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
     dataset name                                                                                                     dataset uuid                           quota     reservation   compression
     -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
-    oxp_41eaf63b-4fa9-443e-8da1-78d1e79aac7d/crucible                                                                5403ab59-fbc4-4747-a0a4-2e086d4611fd   none      none          off        
-    oxp_5b04e3d3-7a8b-466e-ab63-6ca89a93e100/crucible                                                                5e25ca72-7721-46a9-ac11-a71042f17198   none      none          off        
-    oxp_6e8fdb9f-c47a-47b0-b7ee-9a2adc7e4af5/crucible                                                                177ee9e2-0605-4656-839d-664f7481b06b   none      none          off        
-    oxp_8e2c9e92-e35e-494c-8e14-dcf5f5009656/crucible                                                                b6518271-24f3-4fd5-a371-5b840bd7b9db   none      none          off        
-    oxp_a4c575b4-934b-49b9-9c47-9c1241a33607/crucible                                                                632ea7a7-8a14-47ec-8cee-d7bd167d8d3d   none      none          off        
-    oxp_a9a8a692-d2d7-4b3e-a297-d648faf8c7cf/crucible                                                                50adbc61-76de-483a-8be7-00039aaa23ff   none      none          off        
-    oxp_b65c8376-0084-4d6f-9891-9d6a413d4e56/crucible                                                                8a159a8e-c9b8-4497-a89a-c6244cefc180   none      none          off        
-    oxp_bc61cdae-c96f-4886-b8bd-f9fd69d51e3a/crucible                                                                5b64d326-883e-4182-a78d-9b4db76b04e9   none      none          off        
-    oxp_e9f68306-460a-4b11-b904-f752633bf1fc/crucible                                                                2b84da4f-094b-4b2d-a15c-cda870045b07   none      none          off        
-    oxp_fbc5bdf2-9644-4d0a-b349-f490486da25d/crucible                                                                7f74ed80-0101-4b75-8515-aa80e82ee5fe   none      none          off        
-    oxp_41eaf63b-4fa9-443e-8da1-78d1e79aac7d/crypt/clickhouse                                                        595df8fe-7319-44ea-9170-83236f87b146   none      none          off        
-    oxp_41eaf63b-4fa9-443e-8da1-78d1e79aac7d/crypt/internal_dns                                                      0125252e-c9c2-4998-81e2-a82e534f7e3b   none      none          off        
-    oxp_41eaf63b-4fa9-443e-8da1-78d1e79aac7d/crypt/zone                                                              ddf90bf7-d58c-4f9c-9263-14cf354935a2   none      none          off        
-    oxp_5b04e3d3-7a8b-466e-ab63-6ca89a93e100/crypt/zone                                                              406b3824-685f-44c6-9878-175afc0ce17d   none      none          off        
-    oxp_6e8fdb9f-c47a-47b0-b7ee-9a2adc7e4af5/crypt/zone                                                              3b9b3439-8f1c-4c15-bac6-26cda5005369   none      none          off        
-    oxp_8e2c9e92-e35e-494c-8e14-dcf5f5009656/crypt/zone                                                              07f7066f-2644-4ca0-95f4-c1c8b88f3aef   none      none          off        
-    oxp_a4c575b4-934b-49b9-9c47-9c1241a33607/crypt/zone                                                              29c4d7a0-a184-4cf0-8efb-8ce4e54460f8   none      none          off        
-    oxp_a9a8a692-d2d7-4b3e-a297-d648faf8c7cf/crypt/zone                                                              35b11905-8c74-4104-901f-62ee66901985   none      none          off        
-    oxp_b65c8376-0084-4d6f-9891-9d6a413d4e56/crypt/zone                                                              867e4fc5-2312-4a0c-ad85-52b3790d49b1   none      none          off        
-    oxp_bc61cdae-c96f-4886-b8bd-f9fd69d51e3a/crypt/zone                                                              bccfa224-0485-486c-a3fc-619cac293640   none      none          off        
-    oxp_e9f68306-460a-4b11-b904-f752633bf1fc/crypt/zone                                                              c9a4c16a-c7ac-47ab-9633-6bdd924b7c58   none      none          off        
-    oxp_fbc5bdf2-9644-4d0a-b349-f490486da25d/crypt/zone                                                              a45173d1-377c-4466-b392-76660653d2ce   none      none          off        
-    oxp_41eaf63b-4fa9-443e-8da1-78d1e79aac7d/crypt/zone/oxz_clickhouse_6394624c-3aba-4be5-a6a2-68d9b5e506e4          8ab9adbc-d236-4167-b503-581ae9dc0136   none      none          off        
-    oxp_fbc5bdf2-9644-4d0a-b349-f490486da25d/crypt/zone/oxz_crucible_289ece63-1c43-45d8-9731-411abaf62cfb            79cc327b-76da-40fb-b9f2-ca53af257d38   none      none          off        
-    oxp_6e8fdb9f-c47a-47b0-b7ee-9a2adc7e4af5/crypt/zone/oxz_crucible_340d690d-52d6-4bd7-96a7-57989c3dd973            9e54a544-74dd-4a35-8cf5-dd78b9b79cef   none      none          off        
-    oxp_a4c575b4-934b-49b9-9c47-9c1241a33607/crypt/zone/oxz_crucible_512f26d7-2e46-4189-9c5a-ffbfb5d0a4e9            b6ac1d96-7b2c-4c13-82ea-5e9d96c85d5f   none      none          off        
-    oxp_8e2c9e92-e35e-494c-8e14-dcf5f5009656/crypt/zone/oxz_crucible_6809081c-a6ca-4f44-91cc-bde241475188            2291e434-3194-4001-a59a-25f1db01cef4   none      none          off        
-    oxp_a9a8a692-d2d7-4b3e-a297-d648faf8c7cf/crypt/zone/oxz_crucible_7d884e93-9f4e-4063-84c8-802bb7262fd6            7237b67d-84cf-4465-b914-3c9dbe1c8d86   none      none          off        
-    oxp_b65c8376-0084-4d6f-9891-9d6a413d4e56/crypt/zone/oxz_crucible_9bf902be-b1ca-44b9-9a09-ca6e68d022e3            76e3a199-4483-40e9-bd70-717ec354ebe1   none      none          off        
-    oxp_5b04e3d3-7a8b-466e-ab63-6ca89a93e100/crypt/zone/oxz_crucible_c57f188f-c51b-45d3-be4c-9e023d80e194            a9f4b44e-2e81-4047-8656-b9227fa3fdbb   none      none          off        
-    oxp_41eaf63b-4fa9-443e-8da1-78d1e79aac7d/crypt/zone/oxz_crucible_d2646147-0310-450a-a43b-8a1a9c513188            028e8d90-8472-49ad-90c8-83bef4a6a2e7   none      none          off        
-    oxp_e9f68306-460a-4b11-b904-f752633bf1fc/crypt/zone/oxz_crucible_d34a3d41-8442-4981-8362-1e449c2c0154            113c2fd9-47b7-41e8-bd9d-0066fd3ac9ff   none      none          off        
-    oxp_bc61cdae-c96f-4886-b8bd-f9fd69d51e3a/crypt/zone/oxz_crucible_d5f97416-8c36-4148-8e22-0684fee6e85a            6c15dd01-680f-42f5-b25a-7c591daa22ea   none      none          off        
-    oxp_41eaf63b-4fa9-443e-8da1-78d1e79aac7d/crypt/zone/oxz_crucible_pantry_6a5b8df1-d85f-4c96-ba7d-6efebd72f92a     c6ccafeb-9666-465c-b8eb-49902ea6d741   none      none          off        
-    oxp_41eaf63b-4fa9-443e-8da1-78d1e79aac7d/crypt/zone/oxz_internal_dns_83f907f2-a0d7-46d8-842e-8603a3ef393f        18ee8146-de2e-4f83-bb61-201311c82ec2   none      none          off        
-    oxp_41eaf63b-4fa9-443e-8da1-78d1e79aac7d/crypt/zone/oxz_nexus_a9043563-4a85-47a1-9478-db57d31b53c0               1c96cf42-5a62-42c4-9830-349583d93260   none      none          off        
-    oxp_41eaf63b-4fa9-443e-8da1-78d1e79aac7d/crypt/zone/oxz_ntp_4fd636ec-8c85-4d2f-b514-36f3190df8d8                 1e1db58f-2dda-4f28-a23d-90431e2cc11f   none      none          off        
-    oxp_41eaf63b-4fa9-443e-8da1-78d1e79aac7d/crypt/debug                                                             ed00cbfa-3426-4072-a763-0facc8cd9c2f   100 GiB   none          gzip-9     
-    oxp_5b04e3d3-7a8b-466e-ab63-6ca89a93e100/crypt/debug                                                             2b28e830-b329-469c-85ed-f15cd6cf5416   100 GiB   none          gzip-9     
-    oxp_6e8fdb9f-c47a-47b0-b7ee-9a2adc7e4af5/crypt/debug                                                             0791e4d8-9e17-425b-8400-888a46f4ce96   100 GiB   none          gzip-9     
-    oxp_8e2c9e92-e35e-494c-8e14-dcf5f5009656/crypt/debug                                                             c75ba2f4-5491-4d31-bee6-6054c0c829e4   100 GiB   none          gzip-9     
-    oxp_a4c575b4-934b-49b9-9c47-9c1241a33607/crypt/debug                                                             b79cfade-ef8d-494c-8e46-5ac6f7d5a180   100 GiB   none          gzip-9     
-    oxp_a9a8a692-d2d7-4b3e-a297-d648faf8c7cf/crypt/debug                                                             e3929bba-ff30-4750-9190-1c507c62aad1   100 GiB   none          gzip-9     
-    oxp_b65c8376-0084-4d6f-9891-9d6a413d4e56/crypt/debug                                                             a23c8851-f5c7-4458-8311-95ab7f97f859   100 GiB   none          gzip-9     
-    oxp_bc61cdae-c96f-4886-b8bd-f9fd69d51e3a/crypt/debug                                                             48eac7a6-4484-4f24-9b48-b4b9c2d0869d   100 GiB   none          gzip-9     
-    oxp_e9f68306-460a-4b11-b904-f752633bf1fc/crypt/debug                                                             e4e743bf-81d3-43fb-9255-c1ffc679b585   100 GiB   none          gzip-9     
-    oxp_fbc5bdf2-9644-4d0a-b349-f490486da25d/crypt/debug                                                             060fd4d2-006b-4096-88e1-57ad8d8726da   100 GiB   none          gzip-9     
-*   oxp_41eaf63b-4fa9-443e-8da1-78d1e79aac7d/crypt/clickhouse_keeper                                                 f8e1c7d5-00cf-4d71-93eb-bec0af2ffa3b   none      none          off        
-*   oxp_41eaf63b-4fa9-443e-8da1-78d1e79aac7d/crypt/zone/oxz_clickhouse_keeper_b8f84002-e213-4311-9d0a-f5a100735ea5   736579c3-0687-43d1-9dd5-cd44add5b932   none      none          off        
+    oxp_41eaf63b-4fa9-443e-8da1-78d1e79aac7d/crucible                                                                2995233a-0449-4072-b509-76033ef98ba6   none      none          off        
+    oxp_5b04e3d3-7a8b-466e-ab63-6ca89a93e100/crucible                                                                af187db0-8de0-4d0f-93f6-df8aecedac9b   none      none          off        
+    oxp_6e8fdb9f-c47a-47b0-b7ee-9a2adc7e4af5/crucible                                                                cbdac478-a890-4b3f-9201-48a4ab393e1b   none      none          off        
+    oxp_8e2c9e92-e35e-494c-8e14-dcf5f5009656/crucible                                                                32d14ae0-68ee-4bcc-bfa1-135cc3221765   none      none          off        
+    oxp_a4c575b4-934b-49b9-9c47-9c1241a33607/crucible                                                                f998be6f-0965-4e91-8bca-19924f5d4fdd   none      none          off        
+    oxp_a9a8a692-d2d7-4b3e-a297-d648faf8c7cf/crucible                                                                31ef6da6-6d72-4b16-b66e-de5919248fa1   none      none          off        
+    oxp_b65c8376-0084-4d6f-9891-9d6a413d4e56/crucible                                                                e47bdf6e-29d5-4a43-8909-a4b60aea8c88   none      none          off        
+    oxp_bc61cdae-c96f-4886-b8bd-f9fd69d51e3a/crucible                                                                e8025577-6780-42cb-a6a4-c0d462e7e726   none      none          off        
+    oxp_e9f68306-460a-4b11-b904-f752633bf1fc/crucible                                                                e636f409-22a1-4e85-a180-275d1c586350   none      none          off        
+    oxp_fbc5bdf2-9644-4d0a-b349-f490486da25d/crucible                                                                5b79a673-5132-4781-a33f-732e564ac40c   none      none          off        
+    oxp_41eaf63b-4fa9-443e-8da1-78d1e79aac7d/crypt/clickhouse                                                        ed9a1f42-6aec-4bf8-ae48-0bc25d8a2be2   none      none          off        
+    oxp_41eaf63b-4fa9-443e-8da1-78d1e79aac7d/crypt/internal_dns                                                      fe4d67a2-5fb8-4096-97b2-12cf077ae41e   none      none          off        
+    oxp_41eaf63b-4fa9-443e-8da1-78d1e79aac7d/crypt/zone                                                              567b450c-835e-4622-8fd9-3e41bff04b99   none      none          off        
+    oxp_5b04e3d3-7a8b-466e-ab63-6ca89a93e100/crypt/zone                                                              7771428a-e7a9-40fe-89f2-deb92f8b77eb   none      none          off        
+    oxp_6e8fdb9f-c47a-47b0-b7ee-9a2adc7e4af5/crypt/zone                                                              88131d15-f49e-467c-9241-7236f5b14e0b   none      none          off        
+    oxp_8e2c9e92-e35e-494c-8e14-dcf5f5009656/crypt/zone                                                              033c5679-6241-4502-99f1-50f685f57403   none      none          off        
+    oxp_a4c575b4-934b-49b9-9c47-9c1241a33607/crypt/zone                                                              39c3d488-3bd7-48c0-a965-d8e0b77a3dea   none      none          off        
+    oxp_a9a8a692-d2d7-4b3e-a297-d648faf8c7cf/crypt/zone                                                              9e18151a-63b1-4715-bb5c-e2088b1fcd57   none      none          off        
+    oxp_b65c8376-0084-4d6f-9891-9d6a413d4e56/crypt/zone                                                              5ea593b7-5882-47db-986a-570362ea7180   none      none          off        
+    oxp_bc61cdae-c96f-4886-b8bd-f9fd69d51e3a/crypt/zone                                                              01e0e8fc-a101-4e55-ab67-6a2d6472f5c2   none      none          off        
+    oxp_e9f68306-460a-4b11-b904-f752633bf1fc/crypt/zone                                                              4b14443d-d9bf-4c9b-9c74-1f434c467b8a   none      none          off        
+    oxp_fbc5bdf2-9644-4d0a-b349-f490486da25d/crypt/zone                                                              49b5c150-d615-487b-bda2-00d8d5fa85fc   none      none          off        
+    oxp_41eaf63b-4fa9-443e-8da1-78d1e79aac7d/crypt/zone/oxz_clickhouse_c3d4b77c-2e77-45ef-9764-5f45723f1e6e          5782d4d4-614c-4521-ba76-64d146ff4086   none      none          off        
+    oxp_8e2c9e92-e35e-494c-8e14-dcf5f5009656/crypt/zone/oxz_crucible_060bee8a-a830-4db9-b43f-d2d4d651460f            1b994560-5065-495b-8f52-089a66023db9   none      none          off        
+    oxp_bc61cdae-c96f-4886-b8bd-f9fd69d51e3a/crypt/zone/oxz_crucible_14b40b41-0679-4a97-abb9-670d4a014168            4e7d5a46-7ae5-4065-86b6-d6e549a86381   none      none          off        
+    oxp_fbc5bdf2-9644-4d0a-b349-f490486da25d/crypt/zone/oxz_crucible_2d00b429-277a-4670-9841-59dfe36418f5            ba483769-2ff7-469a-8bd5-9d0069c98f3a   none      none          off        
+    oxp_41eaf63b-4fa9-443e-8da1-78d1e79aac7d/crypt/zone/oxz_crucible_6667f342-3f4d-498f-852b-af58fe6cfe4d            12468ab7-b48d-401c-9ef9-26b2d50cd9aa   none      none          off        
+    oxp_e9f68306-460a-4b11-b904-f752633bf1fc/crypt/zone/oxz_crucible_6acddc3a-7c18-4bed-9bee-06179a16b511            636854c7-673f-4a5c-8841-a4ea7d669856   none      none          off        
+    oxp_6e8fdb9f-c47a-47b0-b7ee-9a2adc7e4af5/crypt/zone/oxz_crucible_6d91fce2-b64b-4778-bc7d-3a3ee4fc050f            e8d9ad3c-b77a-4ae9-bd7a-8717663d4732   none      none          off        
+    oxp_a9a8a692-d2d7-4b3e-a297-d648faf8c7cf/crypt/zone/oxz_crucible_743f2573-1cd6-418b-a0e0-7fb6d5dc65c9            0a19c469-38a3-4ad1-acff-a2eec66d039b   none      none          off        
+    oxp_5b04e3d3-7a8b-466e-ab63-6ca89a93e100/crypt/zone/oxz_crucible_9bb3f4a7-3699-481f-928a-f57cbe505f12            7fec29ed-8f6f-4f72-af7a-1603f74ae3e6   none      none          off        
+    oxp_b65c8376-0084-4d6f-9891-9d6a413d4e56/crypt/zone/oxz_crucible_9bcc969f-8a33-4c30-8608-ad9e0048035a            4c0d8c8a-ddb6-4a88-be7f-1bf5685adafa   none      none          off        
+    oxp_a4c575b4-934b-49b9-9c47-9c1241a33607/crypt/zone/oxz_crucible_f50159f9-2c73-4ea6-9e03-296e158a3af4            8f7c7096-7cd3-4a79-b24b-dc0e7fa3e3ec   none      none          off        
+    oxp_41eaf63b-4fa9-443e-8da1-78d1e79aac7d/crypt/zone/oxz_crucible_pantry_c9e73f39-4dd7-4a87-828b-58c4fcf60d4a     786f9c46-8818-4811-a816-65be22187e13   none      none          off        
+    oxp_41eaf63b-4fa9-443e-8da1-78d1e79aac7d/crypt/zone/oxz_internal_dns_42bf3233-3a94-4f47-8c51-7ac3524ea1f5        923f9064-ee22-42f2-a75f-c7da7dde3acc   none      none          off        
+    oxp_41eaf63b-4fa9-443e-8da1-78d1e79aac7d/crypt/zone/oxz_nexus_254bd45b-ef24-4ce2-812b-9e825d11da65               5b7c73f6-8e61-4160-b747-d69aad5af1ac   none      none          off        
+    oxp_41eaf63b-4fa9-443e-8da1-78d1e79aac7d/crypt/zone/oxz_ntp_ac14e7ae-b9d4-455b-9400-89931771987c                 49673924-48da-4afb-85f8-8c92c32c06f0   none      none          off        
+    oxp_41eaf63b-4fa9-443e-8da1-78d1e79aac7d/crypt/debug                                                             e271927c-4565-48f7-b983-721b5e46a1e6   100 GiB   none          gzip-9     
+    oxp_5b04e3d3-7a8b-466e-ab63-6ca89a93e100/crypt/debug                                                             901ce577-ae12-461a-99a9-f8e972f7cc5d   100 GiB   none          gzip-9     
+    oxp_6e8fdb9f-c47a-47b0-b7ee-9a2adc7e4af5/crypt/debug                                                             c2b2e20a-b273-4b7c-b2d9-142447e5fc69   100 GiB   none          gzip-9     
+    oxp_8e2c9e92-e35e-494c-8e14-dcf5f5009656/crypt/debug                                                             2891a537-17ea-4d83-b2ea-af36a6d22d2d   100 GiB   none          gzip-9     
+    oxp_a4c575b4-934b-49b9-9c47-9c1241a33607/crypt/debug                                                             dc614216-2b34-4659-bfbe-55462fe203f0   100 GiB   none          gzip-9     
+    oxp_a9a8a692-d2d7-4b3e-a297-d648faf8c7cf/crypt/debug                                                             872f53ed-6dc6-43e1-8a52-9c87938e2330   100 GiB   none          gzip-9     
+    oxp_b65c8376-0084-4d6f-9891-9d6a413d4e56/crypt/debug                                                             2f0c179c-d7dd-4450-9163-e799de0aef90   100 GiB   none          gzip-9     
+    oxp_bc61cdae-c96f-4886-b8bd-f9fd69d51e3a/crypt/debug                                                             8b49dee0-2726-4261-aabd-331752764e91   100 GiB   none          gzip-9     
+    oxp_e9f68306-460a-4b11-b904-f752633bf1fc/crypt/debug                                                             f6dae5d2-fff9-4562-9fd4-be99ff888afc   100 GiB   none          gzip-9     
+    oxp_fbc5bdf2-9644-4d0a-b349-f490486da25d/crypt/debug                                                             e0a59564-f99b-47a6-b1ca-b83001fe6908   100 GiB   none          gzip-9     
+*   oxp_41eaf63b-4fa9-443e-8da1-78d1e79aac7d/crypt/clickhouse_keeper                                                 04cdeda2-c4f7-4f76-bfbf-f946dcdefda3   none      none          off        
+*   oxp_41eaf63b-4fa9-443e-8da1-78d1e79aac7d/crypt/zone/oxz_clickhouse_keeper_14b84b08-598b-4756-99ec-eea98f8fa46e   1b4c5dcd-24e9-4076-9219-e9559ae49857   none      none          off        
 
 
     omicron zones generation 4 -> 5:
     ------------------------------------------------------------------------------------------------
     zone type           zone id                                disposition    underlay IP           
     ------------------------------------------------------------------------------------------------
-    clickhouse          6394624c-3aba-4be5-a6a2-68d9b5e506e4   expunged       fd00:1122:3344:102::23
-    crucible            289ece63-1c43-45d8-9731-411abaf62cfb   in service     fd00:1122:3344:102::2e
-    crucible            340d690d-52d6-4bd7-96a7-57989c3dd973   in service     fd00:1122:3344:102::27
-    crucible            512f26d7-2e46-4189-9c5a-ffbfb5d0a4e9   in service     fd00:1122:3344:102::29
-    crucible            6809081c-a6ca-4f44-91cc-bde241475188   in service     fd00:1122:3344:102::28
-    crucible            7d884e93-9f4e-4063-84c8-802bb7262fd6   in service     fd00:1122:3344:102::2a
-    crucible            9bf902be-b1ca-44b9-9a09-ca6e68d022e3   in service     fd00:1122:3344:102::2b
-    crucible            c57f188f-c51b-45d3-be4c-9e023d80e194   in service     fd00:1122:3344:102::26
-    crucible            d2646147-0310-450a-a43b-8a1a9c513188   in service     fd00:1122:3344:102::25
-    crucible            d34a3d41-8442-4981-8362-1e449c2c0154   in service     fd00:1122:3344:102::2d
-    crucible            d5f97416-8c36-4148-8e22-0684fee6e85a   in service     fd00:1122:3344:102::2c
-    crucible_pantry     6a5b8df1-d85f-4c96-ba7d-6efebd72f92a   in service     fd00:1122:3344:102::24
-    internal_dns        83f907f2-a0d7-46d8-842e-8603a3ef393f   in service     fd00:1122:3344:1::1   
-    internal_ntp        4fd636ec-8c85-4d2f-b514-36f3190df8d8   in service     fd00:1122:3344:102::21
-    nexus               a9043563-4a85-47a1-9478-db57d31b53c0   in service     fd00:1122:3344:102::22
-*   clickhouse_keeper   b8f84002-e213-4311-9d0a-f5a100735ea5   - in service   fd00:1122:3344:102::2f
+    clickhouse          c3d4b77c-2e77-45ef-9764-5f45723f1e6e   expunged       fd00:1122:3344:102::23
+    crucible            060bee8a-a830-4db9-b43f-d2d4d651460f   in service     fd00:1122:3344:102::28
+    crucible            14b40b41-0679-4a97-abb9-670d4a014168   in service     fd00:1122:3344:102::2c
+    crucible            2d00b429-277a-4670-9841-59dfe36418f5   in service     fd00:1122:3344:102::2e
+    crucible            6667f342-3f4d-498f-852b-af58fe6cfe4d   in service     fd00:1122:3344:102::25
+    crucible            6acddc3a-7c18-4bed-9bee-06179a16b511   in service     fd00:1122:3344:102::2d
+    crucible            6d91fce2-b64b-4778-bc7d-3a3ee4fc050f   in service     fd00:1122:3344:102::27
+    crucible            743f2573-1cd6-418b-a0e0-7fb6d5dc65c9   in service     fd00:1122:3344:102::2a
+    crucible            9bb3f4a7-3699-481f-928a-f57cbe505f12   in service     fd00:1122:3344:102::26
+    crucible            9bcc969f-8a33-4c30-8608-ad9e0048035a   in service     fd00:1122:3344:102::2b
+    crucible            f50159f9-2c73-4ea6-9e03-296e158a3af4   in service     fd00:1122:3344:102::29
+    crucible_pantry     c9e73f39-4dd7-4a87-828b-58c4fcf60d4a   in service     fd00:1122:3344:102::24
+    internal_dns        42bf3233-3a94-4f47-8c51-7ac3524ea1f5   in service     fd00:1122:3344:1::1   
+    internal_ntp        ac14e7ae-b9d4-455b-9400-89931771987c   in service     fd00:1122:3344:102::21
+    nexus               254bd45b-ef24-4ce2-812b-9e825d11da65   in service     fd00:1122:3344:102::22
+*   clickhouse_keeper   14b84b08-598b-4756-99ec-eea98f8fa46e   - in service   fd00:1122:3344:102::2f
      └─                                                        + expunged                           
 
 
@@ -121,78 +121,78 @@ to:   blueprint d895ef50-9978-454c-bdfb-b8dbe2c9a918
     -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
     dataset name                                                                                                     dataset uuid                           quota     reservation   compression
     -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
-    oxp_21b01477-48d0-4b65-9089-4a48277af033/crucible                                                                5cfe414e-d8a1-411c-a249-984e7eb70964   none      none          off        
-    oxp_2704e66b-3d5c-4b64-951c-a051fa15e4a8/crucible                                                                775d2e5e-915f-4dba-9c67-37bfbedaf91e   none      none          off        
-    oxp_27a22f7e-754a-43ea-8ec4-e9cbd9b62e08/crucible                                                                847b284a-be4f-4405-a93f-5b5cff4ee31b   none      none          off        
-    oxp_51c788ff-de33-43f7-b9c5-f5f56bf80736/crucible                                                                0bbf7ff9-f6a6-49d8-8dc4-c75b2fdb5531   none      none          off        
-    oxp_5fe54077-c016-49a9-becb-14993f133d43/crucible                                                                2a41b700-5494-4aa1-900b-20618125c1d0   none      none          off        
-    oxp_7e2644a1-bec7-433c-8168-8898d7140aab/crucible                                                                fb04e4c9-9fbc-490c-9096-f3adfd6e1223   none      none          off        
-    oxp_9825ff38-f07d-44a1-9efc-55a25e72015b/crucible                                                                34de0f9d-ab3a-4047-bbf3-d2bf4beb2995   none      none          off        
-    oxp_cc585a73-ec86-4f8e-a327-901b947a4c69/crucible                                                                cac5b0cb-c944-4c26-b016-c7556a2fd9ea   none      none          off        
-    oxp_d2801671-bb69-408e-93f7-ac2b05d992f8/crucible                                                                0ab453de-947c-4d5a-a3ee-bf26ed85396f   none      none          off        
-    oxp_f52832ea-60d7-443b-9847-df5384bfc8e2/crucible                                                                cc43cb24-2e55-415d-9a2a-49a6b924b284   none      none          off        
-    oxp_21b01477-48d0-4b65-9089-4a48277af033/crypt/internal_dns                                                      18abe482-6dda-45be-a9e6-ff215c6919f1   none      none          off        
-    oxp_21b01477-48d0-4b65-9089-4a48277af033/crypt/zone                                                              37fc74a2-7d29-48bf-8ab2-ef0c1286df1e   none      none          off        
-    oxp_2704e66b-3d5c-4b64-951c-a051fa15e4a8/crypt/zone                                                              92b1330a-f258-47a7-97a1-e1c79628ad1b   none      none          off        
-    oxp_27a22f7e-754a-43ea-8ec4-e9cbd9b62e08/crypt/zone                                                              f94213ab-5c96-476d-85c9-bf0801cc4941   none      none          off        
-    oxp_51c788ff-de33-43f7-b9c5-f5f56bf80736/crypt/zone                                                              0160fea9-34cb-4b54-92fc-f6780f4b64c5   none      none          off        
-    oxp_5fe54077-c016-49a9-becb-14993f133d43/crypt/zone                                                              122bd71a-d4dd-4838-a64a-1a7f22413224   none      none          off        
-    oxp_7e2644a1-bec7-433c-8168-8898d7140aab/crypt/zone                                                              c6ad1efa-745b-42d4-8554-9eb8567a1396   none      none          off        
-    oxp_9825ff38-f07d-44a1-9efc-55a25e72015b/crypt/zone                                                              1e27b440-2e30-477e-99fe-be13e2d17d64   none      none          off        
-    oxp_cc585a73-ec86-4f8e-a327-901b947a4c69/crypt/zone                                                              892e2f2a-0792-4634-b24d-fca1a0b8c434   none      none          off        
-    oxp_d2801671-bb69-408e-93f7-ac2b05d992f8/crypt/zone                                                              3b4b2059-de0b-4912-a57b-36b3858947a9   none      none          off        
-    oxp_f52832ea-60d7-443b-9847-df5384bfc8e2/crypt/zone                                                              55895da4-4e66-403e-b723-a76b1c2f907e   none      none          off        
-    oxp_7e2644a1-bec7-433c-8168-8898d7140aab/crypt/zone/oxz_crucible_057daeb5-798b-439c-aab8-004b54343323            5929490a-4a7f-4b00-af68-550087145c2d   none      none          off        
-    oxp_f52832ea-60d7-443b-9847-df5384bfc8e2/crypt/zone/oxz_crucible_0c59cc2b-00e8-4243-bf24-1cfc25a212a3            445423d9-3331-48ef-b98b-156c234b290c   none      none          off        
-    oxp_27a22f7e-754a-43ea-8ec4-e9cbd9b62e08/crypt/zone/oxz_crucible_13efd31e-52f3-4914-bc30-45f22828631a            45ba838b-e725-4e92-82e7-fb39dbd1d00d   none      none          off        
-    oxp_21b01477-48d0-4b65-9089-4a48277af033/crypt/zone/oxz_crucible_45644bcc-ea79-4a03-b829-43a27acd5c90            94ec0204-f723-45a1-8521-78d2eb3c8538   none      none          off        
-    oxp_d2801671-bb69-408e-93f7-ac2b05d992f8/crypt/zone/oxz_crucible_9da97e85-7aff-4815-8fac-a48bed2b8bd0            554557ea-949c-4e34-8031-93ab5369f587   none      none          off        
-    oxp_2704e66b-3d5c-4b64-951c-a051fa15e4a8/crypt/zone/oxz_crucible_c6d063b8-9faa-42af-a216-bc4dff420804            9e223845-6f8a-425f-bb40-b6de25bc4695   none      none          off        
-    oxp_cc585a73-ec86-4f8e-a327-901b947a4c69/crypt/zone/oxz_crucible_d85f10cc-ea8d-4d9a-a198-9fcc999bb577            c2ced1b7-2df1-496e-8701-74d4c05446ce   none      none          off        
-    oxp_5fe54077-c016-49a9-becb-14993f133d43/crypt/zone/oxz_crucible_deb1efa8-c55a-438e-9e32-15a9f1dde9c5            f4f8f6c7-a7f9-4f03-bbf4-3583ccdeaae3   none      none          off        
-    oxp_9825ff38-f07d-44a1-9efc-55a25e72015b/crypt/zone/oxz_crucible_eb9571d1-cfd2-4115-8f30-373edd25573e            e005f612-8e9e-4278-8441-7737b7c0c0ba   none      none          off        
-    oxp_51c788ff-de33-43f7-b9c5-f5f56bf80736/crypt/zone/oxz_crucible_fdb62b4e-d73b-4988-8780-9252f04f540f            f2e5b170-cb96-4a1b-98fd-0deae86cf059   none      none          off        
-    oxp_21b01477-48d0-4b65-9089-4a48277af033/crypt/zone/oxz_crucible_pantry_c1c9fd43-8a57-4e43-9b09-abe849743076     82276fd0-1da4-446a-918e-3c0f9a859d6c   none      none          off        
-    oxp_21b01477-48d0-4b65-9089-4a48277af033/crypt/zone/oxz_internal_dns_68c89612-31f2-4509-b757-44f8e65f2168        fb72c758-0fad-461e-9b7a-43fe8d59075a   none      none          off        
-    oxp_21b01477-48d0-4b65-9089-4a48277af033/crypt/zone/oxz_nexus_7cebfab2-4453-4614-b904-96939bc339d3               3593d78f-42f7-477a-bee7-3219a6bd919a   none      none          off        
-    oxp_21b01477-48d0-4b65-9089-4a48277af033/crypt/zone/oxz_ntp_036a57cf-b759-4c24-af45-d15c60883e9f                 79417983-7d87-4258-9fc8-2b92a65c6f96   none      none          off        
-    oxp_21b01477-48d0-4b65-9089-4a48277af033/crypt/debug                                                             2e4a20b0-00f0-4ac6-aef6-46bc64781f1b   100 GiB   none          gzip-9     
-    oxp_2704e66b-3d5c-4b64-951c-a051fa15e4a8/crypt/debug                                                             c51575aa-f374-4aba-89d6-69cbf63969d3   100 GiB   none          gzip-9     
-    oxp_27a22f7e-754a-43ea-8ec4-e9cbd9b62e08/crypt/debug                                                             d7176bdc-894c-4656-bdb8-3a65f1608bc6   100 GiB   none          gzip-9     
-    oxp_51c788ff-de33-43f7-b9c5-f5f56bf80736/crypt/debug                                                             7aa3d413-7191-41f2-9f38-5feaff97bcfb   100 GiB   none          gzip-9     
-    oxp_5fe54077-c016-49a9-becb-14993f133d43/crypt/debug                                                             0705afaa-1e13-4cc6-8f6b-d3a7e93a5cca   100 GiB   none          gzip-9     
-    oxp_7e2644a1-bec7-433c-8168-8898d7140aab/crypt/debug                                                             9290f161-49cd-46ec-8387-d3896602fd68   100 GiB   none          gzip-9     
-    oxp_9825ff38-f07d-44a1-9efc-55a25e72015b/crypt/debug                                                             5683120b-7824-404c-9204-ad9592fbf562   100 GiB   none          gzip-9     
-    oxp_cc585a73-ec86-4f8e-a327-901b947a4c69/crypt/debug                                                             e8e97c2d-c628-4310-b1b9-fe5b7e4537ea   100 GiB   none          gzip-9     
-    oxp_d2801671-bb69-408e-93f7-ac2b05d992f8/crypt/debug                                                             5ab29fd5-a360-4699-9abd-c24c8a529009   100 GiB   none          gzip-9     
-    oxp_f52832ea-60d7-443b-9847-df5384bfc8e2/crypt/debug                                                             010b0156-d194-4b68-b415-be289435d37e   100 GiB   none          gzip-9     
-*   oxp_21b01477-48d0-4b65-9089-4a48277af033/crypt/clickhouse_keeper                                                 6236e227-f345-4ec5-af7f-47c3dbe3eb2c   none      none          off        
-*   oxp_21b01477-48d0-4b65-9089-4a48277af033/crypt/clickhouse_server                                                 b0d669e6-1faf-4562-82fa-040422a06c9b   none      none          off        
-*   oxp_21b01477-48d0-4b65-9089-4a48277af033/crypt/zone/oxz_clickhouse_keeper_2bae8ad4-3d1f-43aa-8c9b-5dcce65c0480   0a04d1c9-57c7-43c8-b46f-f428f0549575   none      none          off        
-*   oxp_21b01477-48d0-4b65-9089-4a48277af033/crypt/zone/oxz_clickhouse_server_c3c0a7b9-2829-4b2d-a2d9-bd2bab02af0f   4aeb359a-4f04-4267-8316-291871cbf89b   none      none          off        
+    oxp_21b01477-48d0-4b65-9089-4a48277af033/crucible                                                                84bb55f1-1bb2-43e8-876e-6ea25177c441   none      none          off        
+    oxp_2704e66b-3d5c-4b64-951c-a051fa15e4a8/crucible                                                                458ad495-6e68-4c37-92f1-fe95b4793d34   none      none          off        
+    oxp_27a22f7e-754a-43ea-8ec4-e9cbd9b62e08/crucible                                                                a76905d1-b8fa-4fe4-9d92-a6cb6dfb2a52   none      none          off        
+    oxp_51c788ff-de33-43f7-b9c5-f5f56bf80736/crucible                                                                560e9d58-5ec1-48ee-bb54-de7195c87105   none      none          off        
+    oxp_5fe54077-c016-49a9-becb-14993f133d43/crucible                                                                1e4af81b-d9fd-4098-8407-7a02ded667a6   none      none          off        
+    oxp_7e2644a1-bec7-433c-8168-8898d7140aab/crucible                                                                4a10912d-26ef-40be-b53d-ebd1be2511d8   none      none          off        
+    oxp_9825ff38-f07d-44a1-9efc-55a25e72015b/crucible                                                                170c77e2-33d8-420e-95d9-f844cf92b669   none      none          off        
+    oxp_cc585a73-ec86-4f8e-a327-901b947a4c69/crucible                                                                e41db0f3-9cf0-40d7-974e-2bc52e2cb423   none      none          off        
+    oxp_d2801671-bb69-408e-93f7-ac2b05d992f8/crucible                                                                443efd4a-56e8-4cf6-a937-fd9b88c6726f   none      none          off        
+    oxp_f52832ea-60d7-443b-9847-df5384bfc8e2/crucible                                                                b5e0fa95-c29f-4a40-9aed-a6ba784011db   none      none          off        
+    oxp_21b01477-48d0-4b65-9089-4a48277af033/crypt/internal_dns                                                      2b28cc6f-9331-4ebc-ae96-722dbbe50787   none      none          off        
+    oxp_21b01477-48d0-4b65-9089-4a48277af033/crypt/zone                                                              8ed08c10-262a-431d-899a-fd1cd9ef7b7a   none      none          off        
+    oxp_2704e66b-3d5c-4b64-951c-a051fa15e4a8/crypt/zone                                                              513e31d7-ad8e-4d14-ac09-22ccda3e09a0   none      none          off        
+    oxp_27a22f7e-754a-43ea-8ec4-e9cbd9b62e08/crypt/zone                                                              24f9f357-065a-4d0e-8d26-3bc8bf6b7e4d   none      none          off        
+    oxp_51c788ff-de33-43f7-b9c5-f5f56bf80736/crypt/zone                                                              d64352bf-f0cc-4045-9ed2-b28f7ba60b30   none      none          off        
+    oxp_5fe54077-c016-49a9-becb-14993f133d43/crypt/zone                                                              70cb8400-e02f-4c3f-8c50-ed9dc631b144   none      none          off        
+    oxp_7e2644a1-bec7-433c-8168-8898d7140aab/crypt/zone                                                              e8163cfc-097a-486a-ae53-a5704c02b71f   none      none          off        
+    oxp_9825ff38-f07d-44a1-9efc-55a25e72015b/crypt/zone                                                              0f6ed045-ff2e-4bec-91aa-298c11427ad1   none      none          off        
+    oxp_cc585a73-ec86-4f8e-a327-901b947a4c69/crypt/zone                                                              e9a8bebe-0d55-438b-83c5-8177c6ff5338   none      none          off        
+    oxp_d2801671-bb69-408e-93f7-ac2b05d992f8/crypt/zone                                                              f6c82983-cefd-4ce2-aa70-a31e8ce01fb9   none      none          off        
+    oxp_f52832ea-60d7-443b-9847-df5384bfc8e2/crypt/zone                                                              de7c7a98-40a6-427b-ad10-ba86092d0063   none      none          off        
+    oxp_7e2644a1-bec7-433c-8168-8898d7140aab/crypt/zone/oxz_crucible_219b9a45-ed13-4b8c-8c11-4dc050e20622            9b67b652-271f-4f3b-aec8-da672954c7d0   none      none          off        
+    oxp_9825ff38-f07d-44a1-9efc-55a25e72015b/crypt/zone/oxz_crucible_27ccb886-b2d4-417e-80d5-48aca47b1af4            ee782292-53a4-4e79-a0de-2dc161b86c9d   none      none          off        
+    oxp_51c788ff-de33-43f7-b9c5-f5f56bf80736/crypt/zone/oxz_crucible_289b3a22-d704-4463-9ffb-0f6d28f3375c            0fff2deb-36aa-4cc1-b137-8c8e257b6bde   none      none          off        
+    oxp_21b01477-48d0-4b65-9089-4a48277af033/crypt/zone/oxz_crucible_426ca71b-a99b-438d-ab68-aadc572e091d            2569e010-759a-404e-bf2c-5d078b236a98   none      none          off        
+    oxp_f52832ea-60d7-443b-9847-df5384bfc8e2/crypt/zone/oxz_crucible_49ac37b2-44ab-4dc0-95e2-94aeb02feac1            adf11973-c20d-4716-8b43-85362547abb4   none      none          off        
+    oxp_5fe54077-c016-49a9-becb-14993f133d43/crypt/zone/oxz_crucible_4aec3ce0-42c3-4517-9824-d586b0573995            94b5c89a-4cd4-42e3-b58f-46b9ac5144cb   none      none          off        
+    oxp_cc585a73-ec86-4f8e-a327-901b947a4c69/crypt/zone/oxz_crucible_524ac4e1-4450-42c8-b3c2-be1543719114            0af0283c-ff72-4653-9081-2e9736b77b42   none      none          off        
+    oxp_d2801671-bb69-408e-93f7-ac2b05d992f8/crypt/zone/oxz_crucible_74efcbfe-af9b-4725-afe0-cd7be749259c            7fb4dbdd-06fa-41ae-b3f3-8bb1beec4d6a   none      none          off        
+    oxp_27a22f7e-754a-43ea-8ec4-e9cbd9b62e08/crypt/zone/oxz_crucible_b9de2375-60b4-493a-afc3-b39037e39e61            99a7b0dc-e71d-4972-b02b-9cd52504d37d   none      none          off        
+    oxp_2704e66b-3d5c-4b64-951c-a051fa15e4a8/crypt/zone/oxz_crucible_fb520cbc-e538-4e68-99e5-d3815dfa8eda            18a1222c-c627-4cc4-bed2-a7ad09f67401   none      none          off        
+    oxp_21b01477-48d0-4b65-9089-4a48277af033/crypt/zone/oxz_crucible_pantry_7ad82737-6993-41c9-a756-1115d84a9a4c     ddb61eb2-a252-40cb-ba2f-d89819e50b2a   none      none          off        
+    oxp_21b01477-48d0-4b65-9089-4a48277af033/crypt/zone/oxz_internal_dns_edceecb5-d6a2-4da3-abed-51d36c44588b        1174e0b7-3343-43ce-9357-6fd52b5847ca   none      none          off        
+    oxp_21b01477-48d0-4b65-9089-4a48277af033/crypt/zone/oxz_nexus_5e3bbe2e-34ed-4461-bb25-d0e9773a6b17               d6952149-15d8-440f-a7d0-16a842e3cda8   none      none          off        
+    oxp_21b01477-48d0-4b65-9089-4a48277af033/crypt/zone/oxz_ntp_b03bea01-5e98-4aaf-a886-c7498ff42012                 d247b879-8e1f-4ade-a71a-55a715b0f750   none      none          off        
+    oxp_21b01477-48d0-4b65-9089-4a48277af033/crypt/debug                                                             b8b68350-ab5b-497f-896a-1e40f8b1110c   100 GiB   none          gzip-9     
+    oxp_2704e66b-3d5c-4b64-951c-a051fa15e4a8/crypt/debug                                                             2e5f5bf1-224c-48f1-a388-85f0ccdc26b3   100 GiB   none          gzip-9     
+    oxp_27a22f7e-754a-43ea-8ec4-e9cbd9b62e08/crypt/debug                                                             928de1b9-33d6-4529-9c28-baaabde0158b   100 GiB   none          gzip-9     
+    oxp_51c788ff-de33-43f7-b9c5-f5f56bf80736/crypt/debug                                                             e9c16c98-cce5-4171-8605-b9453de85cd3   100 GiB   none          gzip-9     
+    oxp_5fe54077-c016-49a9-becb-14993f133d43/crypt/debug                                                             2313cf25-da1e-4ddb-b1ca-3c37f76b5579   100 GiB   none          gzip-9     
+    oxp_7e2644a1-bec7-433c-8168-8898d7140aab/crypt/debug                                                             883d3371-ed4f-4c13-8162-5d555b322cd4   100 GiB   none          gzip-9     
+    oxp_9825ff38-f07d-44a1-9efc-55a25e72015b/crypt/debug                                                             0239ed9a-4439-40d4-a6d7-4e9bbbcbb8c3   100 GiB   none          gzip-9     
+    oxp_cc585a73-ec86-4f8e-a327-901b947a4c69/crypt/debug                                                             1bac8756-a4cb-42a6-a2a6-2bb4aec66f1c   100 GiB   none          gzip-9     
+    oxp_d2801671-bb69-408e-93f7-ac2b05d992f8/crypt/debug                                                             96bd6ec7-2830-4715-8416-5628d10f726c   100 GiB   none          gzip-9     
+    oxp_f52832ea-60d7-443b-9847-df5384bfc8e2/crypt/debug                                                             99fd5841-618c-45a0-88e0-048839bf19c8   100 GiB   none          gzip-9     
+*   oxp_21b01477-48d0-4b65-9089-4a48277af033/crypt/clickhouse_keeper                                                 89c1fd47-d4b7-4948-b2f8-2b2621fdb892   none      none          off        
+*   oxp_21b01477-48d0-4b65-9089-4a48277af033/crypt/clickhouse_server                                                 231c7aa0-8206-47a7-8b3e-e88548565081   none      none          off        
+*   oxp_21b01477-48d0-4b65-9089-4a48277af033/crypt/zone/oxz_clickhouse_keeper_10db7ee4-04bb-430a-836d-c4308716e995   716b7f3a-718e-41e4-86e2-f55c3bf288d7   none      none          off        
+*   oxp_21b01477-48d0-4b65-9089-4a48277af033/crypt/zone/oxz_clickhouse_server_fe8b84ef-ee63-4dd9-9110-4a8dd696b5c4   273770ea-58d1-4dfe-af91-2bb1e7bfc5b3   none      none          off        
 
 
     omicron zones generation 3 -> 4:
     ------------------------------------------------------------------------------------------------
     zone type           zone id                                disposition    underlay IP           
     ------------------------------------------------------------------------------------------------
-    crucible            057daeb5-798b-439c-aab8-004b54343323   in service     fd00:1122:3344:103::29
-    crucible            0c59cc2b-00e8-4243-bf24-1cfc25a212a3   in service     fd00:1122:3344:103::2d
-    crucible            13efd31e-52f3-4914-bc30-45f22828631a   in service     fd00:1122:3344:103::26
-    crucible            45644bcc-ea79-4a03-b829-43a27acd5c90   in service     fd00:1122:3344:103::24
-    crucible            9da97e85-7aff-4815-8fac-a48bed2b8bd0   in service     fd00:1122:3344:103::2c
-    crucible            c6d063b8-9faa-42af-a216-bc4dff420804   in service     fd00:1122:3344:103::25
-    crucible            d85f10cc-ea8d-4d9a-a198-9fcc999bb577   in service     fd00:1122:3344:103::2b
-    crucible            deb1efa8-c55a-438e-9e32-15a9f1dde9c5   in service     fd00:1122:3344:103::28
-    crucible            eb9571d1-cfd2-4115-8f30-373edd25573e   in service     fd00:1122:3344:103::2a
-    crucible            fdb62b4e-d73b-4988-8780-9252f04f540f   in service     fd00:1122:3344:103::27
-    crucible_pantry     c1c9fd43-8a57-4e43-9b09-abe849743076   in service     fd00:1122:3344:103::23
-    internal_dns        68c89612-31f2-4509-b757-44f8e65f2168   in service     fd00:1122:3344:2::1   
-    internal_ntp        036a57cf-b759-4c24-af45-d15c60883e9f   in service     fd00:1122:3344:103::21
-    nexus               7cebfab2-4453-4614-b904-96939bc339d3   in service     fd00:1122:3344:103::22
-*   clickhouse_keeper   2bae8ad4-3d1f-43aa-8c9b-5dcce65c0480   - in service   fd00:1122:3344:103::2e
+    crucible            219b9a45-ed13-4b8c-8c11-4dc050e20622   in service     fd00:1122:3344:103::29
+    crucible            27ccb886-b2d4-417e-80d5-48aca47b1af4   in service     fd00:1122:3344:103::2a
+    crucible            289b3a22-d704-4463-9ffb-0f6d28f3375c   in service     fd00:1122:3344:103::27
+    crucible            426ca71b-a99b-438d-ab68-aadc572e091d   in service     fd00:1122:3344:103::24
+    crucible            49ac37b2-44ab-4dc0-95e2-94aeb02feac1   in service     fd00:1122:3344:103::2d
+    crucible            4aec3ce0-42c3-4517-9824-d586b0573995   in service     fd00:1122:3344:103::28
+    crucible            524ac4e1-4450-42c8-b3c2-be1543719114   in service     fd00:1122:3344:103::2b
+    crucible            74efcbfe-af9b-4725-afe0-cd7be749259c   in service     fd00:1122:3344:103::2c
+    crucible            b9de2375-60b4-493a-afc3-b39037e39e61   in service     fd00:1122:3344:103::26
+    crucible            fb520cbc-e538-4e68-99e5-d3815dfa8eda   in service     fd00:1122:3344:103::25
+    crucible_pantry     7ad82737-6993-41c9-a756-1115d84a9a4c   in service     fd00:1122:3344:103::23
+    internal_dns        edceecb5-d6a2-4da3-abed-51d36c44588b   in service     fd00:1122:3344:2::1   
+    internal_ntp        b03bea01-5e98-4aaf-a886-c7498ff42012   in service     fd00:1122:3344:103::21
+    nexus               5e3bbe2e-34ed-4461-bb25-d0e9773a6b17   in service     fd00:1122:3344:103::22
+*   clickhouse_keeper   10db7ee4-04bb-430a-836d-c4308716e995   - in service   fd00:1122:3344:103::2e
      └─                                                        + expunged                           
-*   clickhouse_server   c3c0a7b9-2829-4b2d-a2d9-bd2bab02af0f   - in service   fd00:1122:3344:103::2f
+*   clickhouse_server   fe8b84ef-ee63-4dd9-9110-4a8dd696b5c4   - in service   fd00:1122:3344:103::2f
      └─                                                        + expunged                           
 
 
@@ -218,82 +218,82 @@ to:   blueprint d895ef50-9978-454c-bdfb-b8dbe2c9a918
     -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
     dataset name                                                                                                     dataset uuid                           quota     reservation   compression
     -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
-    oxp_288d864c-3a9e-4f21-8c6e-720702c82a29/crucible                                                                d76f6218-ca13-40d6-bea4-fc7ceeb2926b   none      none          off        
-    oxp_5f877424-eca4-4c5d-af7f-41627382cfd8/crucible                                                                ddcd2927-1cc7-4aa1-8d90-0ac8ec13f64a   none      none          off        
-    oxp_65ebc532-cbb7-43e1-923b-37c5cb7236d7/crucible                                                                e9203f73-5fdd-4902-9f75-cbb9f3b176b8   none      none          off        
-    oxp_8277a18f-3187-4893-8ef1-5cbfe2284616/crucible                                                                b462ccdb-a0d9-44cc-953a-4fe1b4037c9a   none      none          off        
-    oxp_83592889-d746-4c5d-98e8-582d9c34a15f/crucible                                                                efd08a8a-2110-4cf8-ba3f-49a525b24adb   none      none          off        
-    oxp_88e423b5-98c9-4e78-992a-5d01e1c33272/crucible                                                                d4fa3bc4-799f-4c1d-a57f-58b7daf7abc0   none      none          off        
-    oxp_a5553017-9991-4ffb-ae37-f9c0e3428562/crucible                                                                96b5bbc7-ea73-48ac-8533-96a6c1c2f59f   none      none          off        
-    oxp_b2c5a75b-9f72-405a-8134-691c0f45a1fd/crucible                                                                5b37edae-1bf4-4b0e-aba8-0111c831eac5   none      none          off        
-    oxp_d4d665fc-df4d-4a13-b9c2-ad13549c0845/crucible                                                                032746d6-e276-4b59-a17e-349c98ace522   none      none          off        
-    oxp_facb28ca-94fd-47a0-bf63-ee394d32c43b/crucible                                                                2b1819c1-a30e-42c4-b5fa-67f71e496ba1   none      none          off        
-    oxp_288d864c-3a9e-4f21-8c6e-720702c82a29/crypt/internal_dns                                                      a3ce0f4d-a253-4284-907b-f59e777564df   none      none          off        
-    oxp_288d864c-3a9e-4f21-8c6e-720702c82a29/crypt/zone                                                              10877dd7-7567-4226-9033-b2af0d88529e   none      none          off        
-    oxp_5f877424-eca4-4c5d-af7f-41627382cfd8/crypt/zone                                                              df1cff74-0dba-465b-a5ac-97638d129c97   none      none          off        
-    oxp_65ebc532-cbb7-43e1-923b-37c5cb7236d7/crypt/zone                                                              6c044af3-8312-4239-b74b-d62bff4c2335   none      none          off        
-    oxp_8277a18f-3187-4893-8ef1-5cbfe2284616/crypt/zone                                                              c7726fd7-bee1-473c-b392-5c32bc59bd9a   none      none          off        
-    oxp_83592889-d746-4c5d-98e8-582d9c34a15f/crypt/zone                                                              f93193ae-e6b5-4d89-b85e-7eec27ff1e20   none      none          off        
-    oxp_88e423b5-98c9-4e78-992a-5d01e1c33272/crypt/zone                                                              9fcbb996-0ec9-41ea-bd0b-94663faeabea   none      none          off        
-    oxp_a5553017-9991-4ffb-ae37-f9c0e3428562/crypt/zone                                                              a6ddc1e2-f6d0-4524-a745-b3d6416f8b5f   none      none          off        
-    oxp_b2c5a75b-9f72-405a-8134-691c0f45a1fd/crypt/zone                                                              c937194c-05d5-4f53-9078-d3a6f07cbe5e   none      none          off        
-    oxp_d4d665fc-df4d-4a13-b9c2-ad13549c0845/crypt/zone                                                              dc23d8ef-b503-4ac3-ae28-5bf78c4ebc70   none      none          off        
-    oxp_facb28ca-94fd-47a0-bf63-ee394d32c43b/crypt/zone                                                              6ad4f8be-cd3b-4950-8a86-f854dc96580f   none      none          off        
-    oxp_83592889-d746-4c5d-98e8-582d9c34a15f/crypt/zone/oxz_crucible_26d3f8d0-228a-4f89-aa4a-fa33aeba4fd0            6f2af271-d4e4-46e1-9220-22c3f9718852   none      none          off        
-    oxp_a5553017-9991-4ffb-ae37-f9c0e3428562/crypt/zone/oxz_crucible_446a395a-2f8b-4849-a0d5-bbdca403b095            bee9e11b-1beb-4984-bfca-54fb82015ec9   none      none          off        
-    oxp_8277a18f-3187-4893-8ef1-5cbfe2284616/crypt/zone/oxz_crucible_6a31350d-eb6c-4b61-97ff-0d673c07fee3            a94317df-b46f-431b-b5af-023dad4e8bd5   none      none          off        
-    oxp_b2c5a75b-9f72-405a-8134-691c0f45a1fd/crypt/zone/oxz_crucible_6afd4461-ef10-48b3-83c9-7dcbddee6595            a2078b28-9e04-4076-868e-fee483108252   none      none          off        
-    oxp_facb28ca-94fd-47a0-bf63-ee394d32c43b/crypt/zone/oxz_crucible_7e6977aa-6e27-4a9f-9d82-e42f883ffb8d            dfd64a35-1573-49c6-a542-a057c7a5ae20   none      none          off        
-    oxp_88e423b5-98c9-4e78-992a-5d01e1c33272/crypt/zone/oxz_crucible_b1546506-c538-4c74-9f5d-8e9c8e68896e            7d782152-aac5-4604-86d8-303bb9e9b42c   none      none          off        
-    oxp_5f877424-eca4-4c5d-af7f-41627382cfd8/crypt/zone/oxz_crucible_b37afa7c-2ff1-4f5f-9040-4099ed12906b            c6a6fc32-0fe5-4b91-9a32-7acb0b74231e   none      none          off        
-    oxp_65ebc532-cbb7-43e1-923b-37c5cb7236d7/crypt/zone/oxz_crucible_d70acd67-a84c-418e-8867-799ed9b856ef            039974e3-aeb5-472f-bfa9-ddbdbc417a96   none      none          off        
-    oxp_288d864c-3a9e-4f21-8c6e-720702c82a29/crypt/zone/oxz_crucible_f25ab7b4-e3e7-4cad-aae3-3cefd2040506            fcea9a6f-5b9c-45c7-953d-feceb00a2e9a   none      none          off        
-    oxp_d4d665fc-df4d-4a13-b9c2-ad13549c0845/crypt/zone/oxz_crucible_f84c9d55-5c9d-43a1-a6e5-f769eeaae158            2b866c41-827e-4e98-bd5b-f6d20d839f9d   none      none          off        
-    oxp_288d864c-3a9e-4f21-8c6e-720702c82a29/crypt/zone/oxz_crucible_pantry_61386aeb-5feb-4cae-9da2-9a169dd79a09     8da2ea7c-1fdc-40d3-a9ac-aa7792969525   none      none          off        
-    oxp_288d864c-3a9e-4f21-8c6e-720702c82a29/crypt/zone/oxz_internal_dns_f2ec46c3-3ab4-426f-823a-eb7b4b57fd53        b00cc455-04aa-4fee-81a3-fe7e16720381   none      none          off        
-    oxp_288d864c-3a9e-4f21-8c6e-720702c82a29/crypt/zone/oxz_nexus_7ac3bbd8-bbdd-4acd-9957-efbb43354f70               52db4583-1028-4908-989c-9024fb5c9159   none      none          off        
-    oxp_288d864c-3a9e-4f21-8c6e-720702c82a29/crypt/zone/oxz_ntp_df6e43a7-ad9b-41c8-bea4-421b1b52e059                 75576295-3742-45c5-b5d5-7bc045b3e451   none      none          off        
-    oxp_288d864c-3a9e-4f21-8c6e-720702c82a29/crypt/debug                                                             2de28d6e-987e-42bd-9323-10e4bc772d33   100 GiB   none          gzip-9     
-    oxp_5f877424-eca4-4c5d-af7f-41627382cfd8/crypt/debug                                                             e6ec4e00-713e-4b9c-a156-df22f5019dab   100 GiB   none          gzip-9     
-    oxp_65ebc532-cbb7-43e1-923b-37c5cb7236d7/crypt/debug                                                             2bf3bf5c-4136-40b9-833e-4f4e0a0028c0   100 GiB   none          gzip-9     
-    oxp_8277a18f-3187-4893-8ef1-5cbfe2284616/crypt/debug                                                             b58ebe62-ffb9-45eb-be29-9211a74f5369   100 GiB   none          gzip-9     
-    oxp_83592889-d746-4c5d-98e8-582d9c34a15f/crypt/debug                                                             a17ba250-f11d-42f1-8cc5-ed35a662bfc2   100 GiB   none          gzip-9     
-    oxp_88e423b5-98c9-4e78-992a-5d01e1c33272/crypt/debug                                                             ade46ccb-5a1b-4461-bbf8-ad99fc47580f   100 GiB   none          gzip-9     
-    oxp_a5553017-9991-4ffb-ae37-f9c0e3428562/crypt/debug                                                             e36f06e6-b3a8-45ea-9b01-0e3e9b43d54a   100 GiB   none          gzip-9     
-    oxp_b2c5a75b-9f72-405a-8134-691c0f45a1fd/crypt/debug                                                             9cf0f2dc-c6f6-43ba-b508-85990f8cecf4   100 GiB   none          gzip-9     
-    oxp_d4d665fc-df4d-4a13-b9c2-ad13549c0845/crypt/debug                                                             80ecfdaf-b5a9-4e3f-a187-15ac2cb1db16   100 GiB   none          gzip-9     
-    oxp_facb28ca-94fd-47a0-bf63-ee394d32c43b/crypt/debug                                                             b375cde4-ff30-4f27-9561-3e9f83d671da   100 GiB   none          gzip-9     
-*   oxp_288d864c-3a9e-4f21-8c6e-720702c82a29/crypt/clickhouse_keeper                                                 c949b5ca-05fe-4c0a-95d0-11c8fd18675b   none      none          off        
-*   oxp_288d864c-3a9e-4f21-8c6e-720702c82a29/crypt/clickhouse_server                                                 e181ab51-2eb2-4552-a38c-9bafcaf7765b   none      none          off        
-*   oxp_288d864c-3a9e-4f21-8c6e-720702c82a29/crypt/zone/oxz_clickhouse_keeper_15f8164a-63e5-404e-81a5-c13e5855f7ca   6ca0e723-77fd-4859-90b8-b12601f21bde   none      none          off        
-*   oxp_288d864c-3a9e-4f21-8c6e-720702c82a29/crypt/zone/oxz_clickhouse_server_c0951435-7d95-4356-bcd3-9d92756d911a   849d2000-dab1-4f5f-b9b9-79294aefe298   none      none          off        
-+   oxp_288d864c-3a9e-4f21-8c6e-720702c82a29/crypt/clickhouse                                                        b642a90a-32e9-48a8-b5e7-aede02141b67   none      none          off        
-+   oxp_288d864c-3a9e-4f21-8c6e-720702c82a29/crypt/zone/oxz_clickhouse_729bb1a1-20e6-42b1-9a42-d495c6697823          19df5137-af48-4224-91bb-b00c7460c42a   none      none          off        
+    oxp_288d864c-3a9e-4f21-8c6e-720702c82a29/crucible                                                                7a03c6b4-1ad5-4345-a698-e8ec846570b8   none      none          off        
+    oxp_5f877424-eca4-4c5d-af7f-41627382cfd8/crucible                                                                69633ed3-7ae3-44c8-b18f-9185be5e8b16   none      none          off        
+    oxp_65ebc532-cbb7-43e1-923b-37c5cb7236d7/crucible                                                                25eab6da-bb9d-4d85-9416-5d9ecb15fcb0   none      none          off        
+    oxp_8277a18f-3187-4893-8ef1-5cbfe2284616/crucible                                                                ecec4ffc-28d5-467c-bfef-40b78ef90578   none      none          off        
+    oxp_83592889-d746-4c5d-98e8-582d9c34a15f/crucible                                                                f7bb8bb0-af54-470c-a43a-15368a7ee3ea   none      none          off        
+    oxp_88e423b5-98c9-4e78-992a-5d01e1c33272/crucible                                                                2d7b9c72-0af0-4a4a-8aa9-0d9af1ceb031   none      none          off        
+    oxp_a5553017-9991-4ffb-ae37-f9c0e3428562/crucible                                                                ed2876ea-e461-4ad9-a18f-b96898761a74   none      none          off        
+    oxp_b2c5a75b-9f72-405a-8134-691c0f45a1fd/crucible                                                                d649a820-d5bc-47c8-8f09-a153fea0cae6   none      none          off        
+    oxp_d4d665fc-df4d-4a13-b9c2-ad13549c0845/crucible                                                                23bc903a-73d5-401d-9701-ccb4b5620f6d   none      none          off        
+    oxp_facb28ca-94fd-47a0-bf63-ee394d32c43b/crucible                                                                fa87edd8-3150-49e3-a3c1-ad11b82a428e   none      none          off        
+    oxp_288d864c-3a9e-4f21-8c6e-720702c82a29/crypt/internal_dns                                                      b5e9c350-d032-4854-9445-38af42b6da6c   none      none          off        
+    oxp_288d864c-3a9e-4f21-8c6e-720702c82a29/crypt/zone                                                              523f0aaa-c792-417b-88fa-eddfad1c96e1   none      none          off        
+    oxp_5f877424-eca4-4c5d-af7f-41627382cfd8/crypt/zone                                                              fd0ad3de-0bc6-4524-8132-856dea1574a5   none      none          off        
+    oxp_65ebc532-cbb7-43e1-923b-37c5cb7236d7/crypt/zone                                                              767a46bc-9cb2-4ff6-9969-9798bff46115   none      none          off        
+    oxp_8277a18f-3187-4893-8ef1-5cbfe2284616/crypt/zone                                                              2f047175-93b1-4827-890b-ad4df41dc908   none      none          off        
+    oxp_83592889-d746-4c5d-98e8-582d9c34a15f/crypt/zone                                                              5edb9668-3ca5-4416-8e0d-b07e374fc510   none      none          off        
+    oxp_88e423b5-98c9-4e78-992a-5d01e1c33272/crypt/zone                                                              c0a7a1cf-a47d-45ab-8249-bd147f9e78fa   none      none          off        
+    oxp_a5553017-9991-4ffb-ae37-f9c0e3428562/crypt/zone                                                              924d9c1f-021d-494d-acf7-31afcdc6dfd6   none      none          off        
+    oxp_b2c5a75b-9f72-405a-8134-691c0f45a1fd/crypt/zone                                                              923fd3c8-9e2d-46a8-9d64-040adb4f97aa   none      none          off        
+    oxp_d4d665fc-df4d-4a13-b9c2-ad13549c0845/crypt/zone                                                              e0469419-68c7-4f33-ba83-5dd63ad35e82   none      none          off        
+    oxp_facb28ca-94fd-47a0-bf63-ee394d32c43b/crypt/zone                                                              b0e61094-c730-4f49-a2a9-fc257eab77d7   none      none          off        
+    oxp_facb28ca-94fd-47a0-bf63-ee394d32c43b/crypt/zone/oxz_crucible_0b3c14a3-2ebc-465f-bea0-36dafe72b645            536689a3-5791-4c4b-bc59-f20c52653647   none      none          off        
+    oxp_a5553017-9991-4ffb-ae37-f9c0e3428562/crypt/zone/oxz_crucible_196e0925-a8bd-4b24-a8d1-8786dceaed24            52857ff2-3f93-4023-a1d9-bab881b273fb   none      none          off        
+    oxp_8277a18f-3187-4893-8ef1-5cbfe2284616/crypt/zone/oxz_crucible_2fde7a41-f139-4bd8-9617-328de00b69b6            f399a80d-d344-47c2-90e3-79516ad322c8   none      none          off        
+    oxp_65ebc532-cbb7-43e1-923b-37c5cb7236d7/crypt/zone/oxz_crucible_37f4b29c-1a9a-4747-8baf-ee9ac8cba5f4            aa74afec-728d-4d14-ae52-731cb0c437dc   none      none          off        
+    oxp_5f877424-eca4-4c5d-af7f-41627382cfd8/crypt/zone/oxz_crucible_4dc70ea3-fc77-43d4-8b23-b3e22b777292            f2174337-2580-4b41-9c14-7e0efcee0e2d   none      none          off        
+    oxp_88e423b5-98c9-4e78-992a-5d01e1c33272/crypt/zone/oxz_crucible_671d516f-43f5-4b17-856e-65c08bdc7821            3785f450-eab8-485c-bae6-970a722d045c   none      none          off        
+    oxp_83592889-d746-4c5d-98e8-582d9c34a15f/crypt/zone/oxz_crucible_8048791b-05f9-447f-aa0c-1a25cec2a012            6d4d1083-ff28-4fca-8593-6884dc5c86bd   none      none          off        
+    oxp_288d864c-3a9e-4f21-8c6e-720702c82a29/crypt/zone/oxz_crucible_837842a8-ad59-4654-a83d-b13a68a30a92            7fc41833-5f1b-4565-999d-dfe3faaba5ec   none      none          off        
+    oxp_b2c5a75b-9f72-405a-8134-691c0f45a1fd/crypt/zone/oxz_crucible_a6cebeb0-12cf-433d-adaf-7e5e635054bc            7dfa1f54-6587-4d09-8f8f-7eb0402ec1d7   none      none          off        
+    oxp_d4d665fc-df4d-4a13-b9c2-ad13549c0845/crypt/zone/oxz_crucible_b51501a5-50be-439c-bbcd-47e85ac03f68            706dbdb1-086b-4db5-a8e1-5270e65848ac   none      none          off        
+    oxp_288d864c-3a9e-4f21-8c6e-720702c82a29/crypt/zone/oxz_crucible_pantry_511cbb04-ff55-48d3-a1fd-5c2bbbd10ba7     92d0dbde-6a18-48d8-9c70-6bc5d73425d6   none      none          off        
+    oxp_288d864c-3a9e-4f21-8c6e-720702c82a29/crypt/zone/oxz_internal_dns_aae73b3c-14cf-485b-ab97-ebeffcf3fbdc        cb5d97eb-c0d6-4006-a747-7971634a58cf   none      none          off        
+    oxp_288d864c-3a9e-4f21-8c6e-720702c82a29/crypt/zone/oxz_nexus_5424157d-fb7c-4816-9fd1-fedea5eaa4d8               e4504980-52c5-4345-b2d6-3c40d95ec378   none      none          off        
+    oxp_288d864c-3a9e-4f21-8c6e-720702c82a29/crypt/zone/oxz_ntp_db6ac8f4-eeba-4dad-81b5-dbac0dbf3529                 522e92c9-748e-4e46-9e22-5f85e70bf039   none      none          off        
+    oxp_288d864c-3a9e-4f21-8c6e-720702c82a29/crypt/debug                                                             472c10e2-8919-4b4a-a17b-27d886ef8b28   100 GiB   none          gzip-9     
+    oxp_5f877424-eca4-4c5d-af7f-41627382cfd8/crypt/debug                                                             8c119af1-d840-4b9d-827e-8064501f0c7a   100 GiB   none          gzip-9     
+    oxp_65ebc532-cbb7-43e1-923b-37c5cb7236d7/crypt/debug                                                             c227c948-b83f-44c0-9e2d-2b65237b0e8d   100 GiB   none          gzip-9     
+    oxp_8277a18f-3187-4893-8ef1-5cbfe2284616/crypt/debug                                                             8ef34a90-1e48-4d2e-b49e-e84200a5143b   100 GiB   none          gzip-9     
+    oxp_83592889-d746-4c5d-98e8-582d9c34a15f/crypt/debug                                                             ed1845c2-e1a4-481d-b569-de693c8cf267   100 GiB   none          gzip-9     
+    oxp_88e423b5-98c9-4e78-992a-5d01e1c33272/crypt/debug                                                             e3566f33-41c7-4aff-a790-adc53e2a94cc   100 GiB   none          gzip-9     
+    oxp_a5553017-9991-4ffb-ae37-f9c0e3428562/crypt/debug                                                             decc30a9-2c66-4bbd-9388-c711f7233f0e   100 GiB   none          gzip-9     
+    oxp_b2c5a75b-9f72-405a-8134-691c0f45a1fd/crypt/debug                                                             38bc5f30-17f4-4610-b87d-918f04c859ed   100 GiB   none          gzip-9     
+    oxp_d4d665fc-df4d-4a13-b9c2-ad13549c0845/crypt/debug                                                             a84a2e72-8032-451a-862d-06f4eb18db24   100 GiB   none          gzip-9     
+    oxp_facb28ca-94fd-47a0-bf63-ee394d32c43b/crypt/debug                                                             dd44015d-6b42-4970-9080-49267bf44c48   100 GiB   none          gzip-9     
+*   oxp_288d864c-3a9e-4f21-8c6e-720702c82a29/crypt/clickhouse_keeper                                                 1589e72c-6719-46bf-bd6b-496eb5bdded5   none      none          off        
+*   oxp_288d864c-3a9e-4f21-8c6e-720702c82a29/crypt/clickhouse_server                                                 bd823ad1-bcd2-4bfb-9f98-4080f8c5a6d0   none      none          off        
+*   oxp_288d864c-3a9e-4f21-8c6e-720702c82a29/crypt/zone/oxz_clickhouse_keeper_0326e8e8-1d52-495e-9773-cd3fa559edbe   579beffb-3093-445a-823c-3dbd96e882ff   none      none          off        
+*   oxp_288d864c-3a9e-4f21-8c6e-720702c82a29/crypt/zone/oxz_clickhouse_server_1b6b784b-d157-4544-b7ff-6c71f3622a0f   af0cfce5-065b-4444-a1aa-fe6f82ab3f3f   none      none          off        
++   oxp_288d864c-3a9e-4f21-8c6e-720702c82a29/crypt/clickhouse                                                        3514fa60-ee1a-4917-9893-def35dd0043d   none      none          off        
++   oxp_288d864c-3a9e-4f21-8c6e-720702c82a29/crypt/zone/oxz_clickhouse_bf9a0f08-fd0d-480c-ae73-3d7507a52b1d          9ef55ba9-8462-424e-a0ff-d4ba686a0bca   none      none          off        
 
 
     omicron zones generation 3 -> 4:
     ------------------------------------------------------------------------------------------------
     zone type           zone id                                disposition    underlay IP           
     ------------------------------------------------------------------------------------------------
-    crucible            26d3f8d0-228a-4f89-aa4a-fa33aeba4fd0   in service     fd00:1122:3344:101::28
-    crucible            446a395a-2f8b-4849-a0d5-bbdca403b095   in service     fd00:1122:3344:101::2a
-    crucible            6a31350d-eb6c-4b61-97ff-0d673c07fee3   in service     fd00:1122:3344:101::27
-    crucible            6afd4461-ef10-48b3-83c9-7dcbddee6595   in service     fd00:1122:3344:101::2b
-    crucible            7e6977aa-6e27-4a9f-9d82-e42f883ffb8d   in service     fd00:1122:3344:101::2d
-    crucible            b1546506-c538-4c74-9f5d-8e9c8e68896e   in service     fd00:1122:3344:101::29
-    crucible            b37afa7c-2ff1-4f5f-9040-4099ed12906b   in service     fd00:1122:3344:101::25
-    crucible            d70acd67-a84c-418e-8867-799ed9b856ef   in service     fd00:1122:3344:101::26
-    crucible            f25ab7b4-e3e7-4cad-aae3-3cefd2040506   in service     fd00:1122:3344:101::24
-    crucible            f84c9d55-5c9d-43a1-a6e5-f769eeaae158   in service     fd00:1122:3344:101::2c
-    crucible_pantry     61386aeb-5feb-4cae-9da2-9a169dd79a09   in service     fd00:1122:3344:101::23
-    internal_dns        f2ec46c3-3ab4-426f-823a-eb7b4b57fd53   in service     fd00:1122:3344:3::1   
-    internal_ntp        df6e43a7-ad9b-41c8-bea4-421b1b52e059   in service     fd00:1122:3344:101::21
-    nexus               7ac3bbd8-bbdd-4acd-9957-efbb43354f70   in service     fd00:1122:3344:101::22
-*   clickhouse_keeper   15f8164a-63e5-404e-81a5-c13e5855f7ca   - in service   fd00:1122:3344:101::2e
+    crucible            0b3c14a3-2ebc-465f-bea0-36dafe72b645   in service     fd00:1122:3344:101::2d
+    crucible            196e0925-a8bd-4b24-a8d1-8786dceaed24   in service     fd00:1122:3344:101::2a
+    crucible            2fde7a41-f139-4bd8-9617-328de00b69b6   in service     fd00:1122:3344:101::27
+    crucible            37f4b29c-1a9a-4747-8baf-ee9ac8cba5f4   in service     fd00:1122:3344:101::26
+    crucible            4dc70ea3-fc77-43d4-8b23-b3e22b777292   in service     fd00:1122:3344:101::25
+    crucible            671d516f-43f5-4b17-856e-65c08bdc7821   in service     fd00:1122:3344:101::29
+    crucible            8048791b-05f9-447f-aa0c-1a25cec2a012   in service     fd00:1122:3344:101::28
+    crucible            837842a8-ad59-4654-a83d-b13a68a30a92   in service     fd00:1122:3344:101::24
+    crucible            a6cebeb0-12cf-433d-adaf-7e5e635054bc   in service     fd00:1122:3344:101::2b
+    crucible            b51501a5-50be-439c-bbcd-47e85ac03f68   in service     fd00:1122:3344:101::2c
+    crucible_pantry     511cbb04-ff55-48d3-a1fd-5c2bbbd10ba7   in service     fd00:1122:3344:101::23
+    internal_dns        aae73b3c-14cf-485b-ab97-ebeffcf3fbdc   in service     fd00:1122:3344:3::1   
+    internal_ntp        db6ac8f4-eeba-4dad-81b5-dbac0dbf3529   in service     fd00:1122:3344:101::21
+    nexus               5424157d-fb7c-4816-9fd1-fedea5eaa4d8   in service     fd00:1122:3344:101::22
+*   clickhouse_keeper   0326e8e8-1d52-495e-9773-cd3fa559edbe   - in service   fd00:1122:3344:101::2e
      └─                                                        + expunged                           
-*   clickhouse_server   c0951435-7d95-4356-bcd3-9d92756d911a   - in service   fd00:1122:3344:101::2f
+*   clickhouse_server   1b6b784b-d157-4544-b7ff-6c71f3622a0f   - in service   fd00:1122:3344:101::2f
      └─                                                        + expunged                           
-+   clickhouse          729bb1a1-20e6-42b1-9a42-d495c6697823   in service     fd00:1122:3344:101::30
++   clickhouse          bf9a0f08-fd0d-480c-ae73-3d7507a52b1d   in service     fd00:1122:3344:101::30
 
 
  COCKROACHDB SETTINGS:
@@ -309,21 +309,21 @@ to:   blueprint d895ef50-9978-454c-bdfb-b8dbe2c9a918
 -   max used server id:::::::::::::::::::::::::::::   2
 -   max used keeper id:::::::::::::::::::::::::::::   3
 -   cluster name:::::::::::::::::::::::::::::::::::   oximeter_cluster
--   cluster secret:::::::::::::::::::::::::::::::::   7470cfb0-bfbf-49d0-b37b-13747463c865
+-   cluster secret:::::::::::::::::::::::::::::::::   7894a059-89b5-407b-ad17-1d8d885e2f67
 -   highest seen keeper leader committed log index:   0
 
     clickhouse keepers at generation 2:
     ------------------------------------------------
     zone id                                keeper id
     ------------------------------------------------
--   15f8164a-63e5-404e-81a5-c13e5855f7ca   1        
--   2bae8ad4-3d1f-43aa-8c9b-5dcce65c0480   2        
--   b8f84002-e213-4311-9d0a-f5a100735ea5   3        
+-   0326e8e8-1d52-495e-9773-cd3fa559edbe   1        
+-   10db7ee4-04bb-430a-836d-c4308716e995   2        
+-   14b84b08-598b-4756-99ec-eea98f8fa46e   3        
 
     clickhouse servers at generation 2:
     ------------------------------------------------
     zone id                                server id
     ------------------------------------------------
--   c0951435-7d95-4356-bcd3-9d92756d911a   1        
--   c3c0a7b9-2829-4b2d-a2d9-bd2bab02af0f   2        
+-   1b6b784b-d157-4544-b7ff-6c71f3622a0f   1        
+-   fe8b84ef-ee63-4dd9-9110-4a8dd696b5c4   2        
 

--- a/nexus/reconfigurator/planning/tests/output/planner_nonprovisionable_1_2.txt
+++ b/nexus/reconfigurator/planning/tests/output/planner_nonprovisionable_1_2.txt
@@ -25,74 +25,74 @@ to:   blueprint 9f71f5d3-a272-4382-9154-6ea2e171a6c6
     -----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
     dataset name                                                                                                   dataset uuid                           quota     reservation   compression
     -----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
-    oxp_13e6503b-5300-4ccd-abc4-c1512b435929/crucible                                                              79a16369-70ab-4f63-af6d-1c7f088eeee3   none      none          off        
-    oxp_44cdb6f2-fa6c-4b69-bab2-3ae4e1ec4b34/crucible                                                              ac31a04c-1f3a-43f4-b45a-cf4b5176e7f6   none      none          off        
-    oxp_4de5fc8e-0e41-4ab9-ba12-2dc63882c96a/crucible                                                              b92bba84-9437-4f93-8ad0-80bf7ecdae5f   none      none          off        
-    oxp_51564e7a-d69f-4942-bcfe-330224633ca6/crucible                                                              dedbf4e7-32fb-406e-a5cc-a2f5281aa6d8   none      none          off        
-    oxp_5ca23cb3-cc90-41c5-a474-01898cdd0796/crucible                                                              b2c9f282-e767-4df1-941e-b7cea21b1a02   none      none          off        
-    oxp_6a23a532-0712-4a8d-be9b-e8c17e97aa4b/crucible                                                              47cf951d-ca5c-4ae0-baa3-94472efbcf03   none      none          off        
-    oxp_6f1a330e-e8d4-4c09-97fc-8918b69b2a3c/crucible                                                              9390bde4-2073-44b4-a496-5129c7e5ca40   none      none          off        
-    oxp_7113d104-fb55-4299-bf53-b3c59d258e44/crucible                                                              5ffb2b84-4a3f-444a-aebf-381f8c58b7ae   none      none          off        
-    oxp_8c10be49-3a66-40d4-a082-64d09d916f14/crucible                                                              d72ffc3a-4665-40bc-a099-ebe628622636   none      none          off        
-    oxp_d1ebfd7b-3842-4ad7-be31-2b9c031209a9/crucible                                                              39185a78-064c-49d5-b716-93f1a312c0c1   none      none          off        
-    oxp_13e6503b-5300-4ccd-abc4-c1512b435929/crypt/clickhouse                                                      d577ac11-62ac-4a71-bed7-e7327148bd33   none      none          off        
-    oxp_13e6503b-5300-4ccd-abc4-c1512b435929/crypt/internal_dns                                                    b9aa1175-2640-4923-81b3-1e1469b15abf   none      none          off        
-    oxp_13e6503b-5300-4ccd-abc4-c1512b435929/crypt/zone                                                            18e2a336-9b65-421e-8409-04d9abce8cd6   none      none          off        
-    oxp_44cdb6f2-fa6c-4b69-bab2-3ae4e1ec4b34/crypt/zone                                                            c37902cf-d1fe-4370-baef-b7de8731dffe   none      none          off        
-    oxp_4de5fc8e-0e41-4ab9-ba12-2dc63882c96a/crypt/zone                                                            00c2d1d6-94da-4985-a144-2194588afecf   none      none          off        
-    oxp_51564e7a-d69f-4942-bcfe-330224633ca6/crypt/zone                                                            3527b52f-f1d4-4e2f-b41e-559f58657839   none      none          off        
-    oxp_5ca23cb3-cc90-41c5-a474-01898cdd0796/crypt/zone                                                            22581703-157c-474f-bbf3-34f076dd7bca   none      none          off        
-    oxp_6a23a532-0712-4a8d-be9b-e8c17e97aa4b/crypt/zone                                                            4d6e70b1-ff91-4133-b65f-6fcd5bda2568   none      none          off        
-    oxp_6f1a330e-e8d4-4c09-97fc-8918b69b2a3c/crypt/zone                                                            41e55e8a-ca4b-4c27-8337-57d42cc36fb5   none      none          off        
-    oxp_7113d104-fb55-4299-bf53-b3c59d258e44/crypt/zone                                                            ae6c87ea-dc50-4a15-855a-224300f20c74   none      none          off        
-    oxp_8c10be49-3a66-40d4-a082-64d09d916f14/crypt/zone                                                            3fc37e5a-3bf3-476f-8a8f-6d32a533cfc0   none      none          off        
-    oxp_d1ebfd7b-3842-4ad7-be31-2b9c031209a9/crypt/zone                                                            64a64a7b-0d29-4470-bc96-4796ca357507   none      none          off        
-    oxp_13e6503b-5300-4ccd-abc4-c1512b435929/crypt/zone/oxz_clickhouse_93b137a1-a1d6-4b5b-b2cb-21a9f11e2883        d1a755ac-dafc-4087-a0ce-ee8b3f882ac1   none      none          off        
-    oxp_13e6503b-5300-4ccd-abc4-c1512b435929/crypt/zone/oxz_crucible_19fbc4f8-a683-4f22-8f5a-e74782b935be          68724637-d228-4faa-a19f-b5df857ff4ab   none      none          off        
-    oxp_8c10be49-3a66-40d4-a082-64d09d916f14/crypt/zone/oxz_crucible_2aa0ea4f-3561-4989-a98c-9ab7d9a240fb          05a77359-0a07-4976-8fbb-5f1eee688e47   none      none          off        
-    oxp_6f1a330e-e8d4-4c09-97fc-8918b69b2a3c/crypt/zone/oxz_crucible_4f1ce8a2-d3a5-4a38-be4c-9817de52db37          ef14767b-6be7-44cb-833d-27d9f523dcdb   none      none          off        
-    oxp_d1ebfd7b-3842-4ad7-be31-2b9c031209a9/crypt/zone/oxz_crucible_67622d61-2df4-414d-aa0e-d1277265f405          6dbd0e11-89af-4464-bd84-c20cb818a9d5   none      none          off        
-    oxp_7113d104-fb55-4299-bf53-b3c59d258e44/crypt/zone/oxz_crucible_67d913e0-0005-4599-9b28-0abbf6cc2916          d63be5b2-5471-4f4d-accc-82e2a0d7276f   none      none          off        
-    oxp_44cdb6f2-fa6c-4b69-bab2-3ae4e1ec4b34/crypt/zone/oxz_crucible_6b53ab2e-d98c-485f-87a3-4d5df595390f          51229ad8-cda3-40c4-b0f3-b1af669abcd4   none      none          off        
-    oxp_4de5fc8e-0e41-4ab9-ba12-2dc63882c96a/crypt/zone/oxz_crucible_b0c63f48-01ea-4aae-bb26-fb0dd59d1662          5d8788c0-13df-4c07-a8b2-b9365fec9796   none      none          off        
-    oxp_5ca23cb3-cc90-41c5-a474-01898cdd0796/crypt/zone/oxz_crucible_d660d7ed-28c0-45ae-9ace-dc3ecf7e8786          68217627-4519-4cfa-85b9-25efb4dad71a   none      none          off        
-    oxp_6a23a532-0712-4a8d-be9b-e8c17e97aa4b/crypt/zone/oxz_crucible_e98cc0de-abf6-4da4-a20d-d05c7a9bb1d7          a602c9d4-16a9-4e55-b5de-76fb33cc4ca9   none      none          off        
-    oxp_51564e7a-d69f-4942-bcfe-330224633ca6/crypt/zone/oxz_crucible_f55e6aaf-e8fc-4913-9e3c-8cd1bd4bdad3          82fc150e-d6f5-4bb6-8eee-17a0728aadb5   none      none          off        
-    oxp_13e6503b-5300-4ccd-abc4-c1512b435929/crypt/zone/oxz_crucible_pantry_9f0abbad-dbd3-4d43-9675-78092217ffd9   da62be58-643f-4497-a9d7-e259de6c7a12   none      none          off        
-    oxp_13e6503b-5300-4ccd-abc4-c1512b435929/crypt/zone/oxz_internal_dns_c406da50-34b9-4bb4-a460-8f49875d2a6a      f47f67f6-e315-4272-b93a-b467cfdfbb7a   none      none          off        
-    oxp_13e6503b-5300-4ccd-abc4-c1512b435929/crypt/zone/oxz_nexus_6dff7633-66bb-4924-a6ff-2c896e66964b             9dce1e52-8e3b-4641-9982-69deb049f647   none      none          off        
-    oxp_13e6503b-5300-4ccd-abc4-c1512b435929/crypt/zone/oxz_ntp_7f4e9f9f-08f8-4d14-885d-e977c05525ad               7773ffbd-1842-4425-aff5-88f577cd8955   none      none          off        
-    oxp_13e6503b-5300-4ccd-abc4-c1512b435929/crypt/debug                                                           d6d36f6b-35ff-4766-99de-44abe46932d1   100 GiB   none          gzip-9     
-    oxp_44cdb6f2-fa6c-4b69-bab2-3ae4e1ec4b34/crypt/debug                                                           26154290-91f7-4f35-bcd0-ec7a8f398d82   100 GiB   none          gzip-9     
-    oxp_4de5fc8e-0e41-4ab9-ba12-2dc63882c96a/crypt/debug                                                           6dc5df73-7e44-4065-9f14-70a0d965a853   100 GiB   none          gzip-9     
-    oxp_51564e7a-d69f-4942-bcfe-330224633ca6/crypt/debug                                                           3063bdcc-4363-495b-a81f-67c6cc437a75   100 GiB   none          gzip-9     
-    oxp_5ca23cb3-cc90-41c5-a474-01898cdd0796/crypt/debug                                                           53deebeb-3952-483a-afd2-2202cee9c33b   100 GiB   none          gzip-9     
-    oxp_6a23a532-0712-4a8d-be9b-e8c17e97aa4b/crypt/debug                                                           e315743d-53e3-4505-9364-657c2486a1bb   100 GiB   none          gzip-9     
-    oxp_6f1a330e-e8d4-4c09-97fc-8918b69b2a3c/crypt/debug                                                           2e901ffa-895b-4405-b59a-2bcdfabda681   100 GiB   none          gzip-9     
-    oxp_7113d104-fb55-4299-bf53-b3c59d258e44/crypt/debug                                                           ee20f8cb-7d24-422b-9dff-ca4c9596191f   100 GiB   none          gzip-9     
-    oxp_8c10be49-3a66-40d4-a082-64d09d916f14/crypt/debug                                                           84bc6d3f-2d9c-42b3-9982-7394630a0928   100 GiB   none          gzip-9     
-    oxp_d1ebfd7b-3842-4ad7-be31-2b9c031209a9/crypt/debug                                                           0c11d380-038c-4b68-b9f4-1775f6fec1e8   100 GiB   none          gzip-9     
+    oxp_13e6503b-5300-4ccd-abc4-c1512b435929/crucible                                                              01b78855-bc58-45bd-937e-49221a71b875   none      none          off        
+    oxp_44cdb6f2-fa6c-4b69-bab2-3ae4e1ec4b34/crucible                                                              99ddb9cf-a52c-4b59-884e-dea52e6b4f5d   none      none          off        
+    oxp_4de5fc8e-0e41-4ab9-ba12-2dc63882c96a/crucible                                                              354e3bc2-e6c8-49c0-bf1d-c136e499037c   none      none          off        
+    oxp_51564e7a-d69f-4942-bcfe-330224633ca6/crucible                                                              7f36c891-2cf8-4e94-b12a-24199b83462b   none      none          off        
+    oxp_5ca23cb3-cc90-41c5-a474-01898cdd0796/crucible                                                              8dd12603-6cfc-42dd-8912-2a16cb7a748d   none      none          off        
+    oxp_6a23a532-0712-4a8d-be9b-e8c17e97aa4b/crucible                                                              8ff2aecd-a1e8-47bd-8001-97c3e5efb99b   none      none          off        
+    oxp_6f1a330e-e8d4-4c09-97fc-8918b69b2a3c/crucible                                                              dab52576-17e4-4bf8-b87e-c49983a388c2   none      none          off        
+    oxp_7113d104-fb55-4299-bf53-b3c59d258e44/crucible                                                              d2c5b427-f956-4cd1-b174-6caca3685e6f   none      none          off        
+    oxp_8c10be49-3a66-40d4-a082-64d09d916f14/crucible                                                              e2e73bed-32f9-4111-803b-561cbd7faa1a   none      none          off        
+    oxp_d1ebfd7b-3842-4ad7-be31-2b9c031209a9/crucible                                                              5ba5e79d-0a13-41e5-b4d2-6c7cb468cb26   none      none          off        
+    oxp_13e6503b-5300-4ccd-abc4-c1512b435929/crypt/clickhouse                                                      37aac368-1b57-4934-b771-5802ae6d6606   none      none          off        
+    oxp_13e6503b-5300-4ccd-abc4-c1512b435929/crypt/internal_dns                                                    2f276f3f-ad8c-458e-bb62-03f5ec7643f3   none      none          off        
+    oxp_13e6503b-5300-4ccd-abc4-c1512b435929/crypt/zone                                                            a8381430-0bf6-49fd-8e5a-4e7c7eb4edf4   none      none          off        
+    oxp_44cdb6f2-fa6c-4b69-bab2-3ae4e1ec4b34/crypt/zone                                                            34fb7c7c-17c2-4cbb-af27-12b693965a4b   none      none          off        
+    oxp_4de5fc8e-0e41-4ab9-ba12-2dc63882c96a/crypt/zone                                                            a6f2fa57-1161-4b49-b591-2a9cd5a992f3   none      none          off        
+    oxp_51564e7a-d69f-4942-bcfe-330224633ca6/crypt/zone                                                            df22d065-beb6-45e4-984e-874dfdd3b285   none      none          off        
+    oxp_5ca23cb3-cc90-41c5-a474-01898cdd0796/crypt/zone                                                            59656ee4-d86f-49ff-b4b8-39e1021642f4   none      none          off        
+    oxp_6a23a532-0712-4a8d-be9b-e8c17e97aa4b/crypt/zone                                                            ea5ee557-cc4e-4a9b-87a7-7bb9b30589da   none      none          off        
+    oxp_6f1a330e-e8d4-4c09-97fc-8918b69b2a3c/crypt/zone                                                            5b0f2d79-6120-4b28-8fd6-919a121f5875   none      none          off        
+    oxp_7113d104-fb55-4299-bf53-b3c59d258e44/crypt/zone                                                            dd56b58b-871e-4f55-bcf5-0bd4e8184761   none      none          off        
+    oxp_8c10be49-3a66-40d4-a082-64d09d916f14/crypt/zone                                                            bafeb8db-cb8e-45fc-8030-3a85a26e2feb   none      none          off        
+    oxp_d1ebfd7b-3842-4ad7-be31-2b9c031209a9/crypt/zone                                                            b567319c-bb7a-4ac0-a95b-20bd88c26579   none      none          off        
+    oxp_13e6503b-5300-4ccd-abc4-c1512b435929/crypt/zone/oxz_clickhouse_5fbb489a-141d-4de2-86c4-4fd7b9d9f315        648fecf4-8ce6-4bce-9020-789057c92f95   none      none          off        
+    oxp_13e6503b-5300-4ccd-abc4-c1512b435929/crypt/zone/oxz_crucible_0ce2b998-f5ad-4dc5-b2ec-5250a308506d          4fe9bcd8-399f-444e-aa01-f8cb285de102   none      none          off        
+    oxp_7113d104-fb55-4299-bf53-b3c59d258e44/crypt/zone/oxz_crucible_0e8e9f2d-291d-47fc-ba0f-84cb50e713fd          ff5a6a51-2797-4016-903f-69ec69e59ef9   none      none          off        
+    oxp_51564e7a-d69f-4942-bcfe-330224633ca6/crypt/zone/oxz_crucible_11fc3b08-2470-4f1b-9187-acff1fc4c5ea          32b45c55-cc53-4635-ae2b-559821b409fe   none      none          off        
+    oxp_6f1a330e-e8d4-4c09-97fc-8918b69b2a3c/crypt/zone/oxz_crucible_673ecd68-d12a-46d9-9126-0a6be6245f84          0377cfc0-2bf6-4906-87f7-031121797594   none      none          off        
+    oxp_6a23a532-0712-4a8d-be9b-e8c17e97aa4b/crypt/zone/oxz_crucible_966c4f15-0aa8-4bef-95e4-49d686cffdfc          9ef1c45c-753a-4ecf-9145-72889ece2ad2   none      none          off        
+    oxp_8c10be49-3a66-40d4-a082-64d09d916f14/crypt/zone/oxz_crucible_979a7b5b-81a5-49bc-82e5-d88b6eaf7d96          b075b63e-f072-4f35-86d1-a81e50065994   none      none          off        
+    oxp_5ca23cb3-cc90-41c5-a474-01898cdd0796/crypt/zone/oxz_crucible_b6beadb1-351b-461d-a887-e7641d976a9e          9d2477db-7dea-4e19-b563-60a18a659cca   none      none          off        
+    oxp_4de5fc8e-0e41-4ab9-ba12-2dc63882c96a/crypt/zone/oxz_crucible_cf7add30-1c49-4d49-a2d2-1c46a60cd884          3b71883e-8704-468e-96fa-7b4fd85d37e8   none      none          off        
+    oxp_d1ebfd7b-3842-4ad7-be31-2b9c031209a9/crypt/zone/oxz_crucible_d0d4a23e-45fa-4f80-9bdf-a348de3f7b8f          5888130a-54bf-4358-bb1b-099347648757   none      none          off        
+    oxp_44cdb6f2-fa6c-4b69-bab2-3ae4e1ec4b34/crypt/zone/oxz_crucible_e46d1442-2a63-44e3-a6aa-e88150b85d92          c4739101-dd65-4649-8e99-e221dc9ce93e   none      none          off        
+    oxp_13e6503b-5300-4ccd-abc4-c1512b435929/crypt/zone/oxz_crucible_pantry_45b6f382-3590-4281-b65d-083ba7aff2d3   f07a8f89-a4e1-4c71-b223-a4c09af0e443   none      none          off        
+    oxp_13e6503b-5300-4ccd-abc4-c1512b435929/crypt/zone/oxz_internal_dns_4fd906d8-94cd-44b3-ad5e-34b4d193bd3c      3681f68d-2840-47be-8bb7-8c7354daf8a7   none      none          off        
+    oxp_13e6503b-5300-4ccd-abc4-c1512b435929/crypt/zone/oxz_nexus_88602518-f176-49a1-af12-02fac36214c3             99c53b55-b716-414d-b8ff-a9d56bd9cd6c   none      none          off        
+    oxp_13e6503b-5300-4ccd-abc4-c1512b435929/crypt/zone/oxz_ntp_b0a48e5a-e2bd-46b2-9bc6-8babbbdc0adc               ed9b8ac9-88f4-46fa-8ecf-5a7534d4f020   none      none          off        
+    oxp_13e6503b-5300-4ccd-abc4-c1512b435929/crypt/debug                                                           97bc5b54-dd6a-4b98-b9e0-081657a3db89   100 GiB   none          gzip-9     
+    oxp_44cdb6f2-fa6c-4b69-bab2-3ae4e1ec4b34/crypt/debug                                                           8d054703-b940-4395-8c46-2ff519f5133a   100 GiB   none          gzip-9     
+    oxp_4de5fc8e-0e41-4ab9-ba12-2dc63882c96a/crypt/debug                                                           bb388082-2d09-4a4b-bb22-ee3f4b7b5025   100 GiB   none          gzip-9     
+    oxp_51564e7a-d69f-4942-bcfe-330224633ca6/crypt/debug                                                           fe2005ba-7f3d-4fc3-b324-09a258fc4a4b   100 GiB   none          gzip-9     
+    oxp_5ca23cb3-cc90-41c5-a474-01898cdd0796/crypt/debug                                                           e20df72b-3d75-48ad-8349-3e39cc886886   100 GiB   none          gzip-9     
+    oxp_6a23a532-0712-4a8d-be9b-e8c17e97aa4b/crypt/debug                                                           cf2b245f-c667-49a9-bbc2-ada9a51e63f0   100 GiB   none          gzip-9     
+    oxp_6f1a330e-e8d4-4c09-97fc-8918b69b2a3c/crypt/debug                                                           1c606d5c-ce8c-42e8-9359-d2e0fe31d525   100 GiB   none          gzip-9     
+    oxp_7113d104-fb55-4299-bf53-b3c59d258e44/crypt/debug                                                           1f3f9209-c380-40ab-a2f0-16ecddb6d4a8   100 GiB   none          gzip-9     
+    oxp_8c10be49-3a66-40d4-a082-64d09d916f14/crypt/debug                                                           89b81a7c-3bc3-455d-97e3-75067de991d5   100 GiB   none          gzip-9     
+    oxp_d1ebfd7b-3842-4ad7-be31-2b9c031209a9/crypt/debug                                                           1e581e94-bb9d-4514-8dbb-3a882e342d1b   100 GiB   none          gzip-9     
 
 
     omicron zones at generation 2:
     ---------------------------------------------------------------------------------------------
     zone type         zone id                                disposition   underlay IP           
     ---------------------------------------------------------------------------------------------
-    clickhouse        93b137a1-a1d6-4b5b-b2cb-21a9f11e2883   in service    fd00:1122:3344:105::23
-    crucible          19fbc4f8-a683-4f22-8f5a-e74782b935be   in service    fd00:1122:3344:105::25
-    crucible          2aa0ea4f-3561-4989-a98c-9ab7d9a240fb   in service    fd00:1122:3344:105::2d
-    crucible          4f1ce8a2-d3a5-4a38-be4c-9817de52db37   in service    fd00:1122:3344:105::2b
-    crucible          67622d61-2df4-414d-aa0e-d1277265f405   in service    fd00:1122:3344:105::2e
-    crucible          67d913e0-0005-4599-9b28-0abbf6cc2916   in service    fd00:1122:3344:105::2c
-    crucible          6b53ab2e-d98c-485f-87a3-4d5df595390f   in service    fd00:1122:3344:105::26
-    crucible          b0c63f48-01ea-4aae-bb26-fb0dd59d1662   in service    fd00:1122:3344:105::27
-    crucible          d660d7ed-28c0-45ae-9ace-dc3ecf7e8786   in service    fd00:1122:3344:105::29
-    crucible          e98cc0de-abf6-4da4-a20d-d05c7a9bb1d7   in service    fd00:1122:3344:105::2a
-    crucible          f55e6aaf-e8fc-4913-9e3c-8cd1bd4bdad3   in service    fd00:1122:3344:105::28
-    crucible_pantry   9f0abbad-dbd3-4d43-9675-78092217ffd9   in service    fd00:1122:3344:105::24
-    internal_dns      c406da50-34b9-4bb4-a460-8f49875d2a6a   in service    fd00:1122:3344:1::1   
-    internal_ntp      7f4e9f9f-08f8-4d14-885d-e977c05525ad   in service    fd00:1122:3344:105::21
-    nexus             6dff7633-66bb-4924-a6ff-2c896e66964b   in service    fd00:1122:3344:105::22
+    clickhouse        5fbb489a-141d-4de2-86c4-4fd7b9d9f315   in service    fd00:1122:3344:105::23
+    crucible          0ce2b998-f5ad-4dc5-b2ec-5250a308506d   in service    fd00:1122:3344:105::25
+    crucible          0e8e9f2d-291d-47fc-ba0f-84cb50e713fd   in service    fd00:1122:3344:105::2c
+    crucible          11fc3b08-2470-4f1b-9187-acff1fc4c5ea   in service    fd00:1122:3344:105::28
+    crucible          673ecd68-d12a-46d9-9126-0a6be6245f84   in service    fd00:1122:3344:105::2b
+    crucible          966c4f15-0aa8-4bef-95e4-49d686cffdfc   in service    fd00:1122:3344:105::2a
+    crucible          979a7b5b-81a5-49bc-82e5-d88b6eaf7d96   in service    fd00:1122:3344:105::2d
+    crucible          b6beadb1-351b-461d-a887-e7641d976a9e   in service    fd00:1122:3344:105::29
+    crucible          cf7add30-1c49-4d49-a2d2-1c46a60cd884   in service    fd00:1122:3344:105::27
+    crucible          d0d4a23e-45fa-4f80-9bdf-a348de3f7b8f   in service    fd00:1122:3344:105::2e
+    crucible          e46d1442-2a63-44e3-a6aa-e88150b85d92   in service    fd00:1122:3344:105::26
+    crucible_pantry   45b6f382-3590-4281-b65d-083ba7aff2d3   in service    fd00:1122:3344:105::24
+    internal_dns      4fd906d8-94cd-44b3-ad5e-34b4d193bd3c   in service    fd00:1122:3344:1::1   
+    internal_ntp      b0a48e5a-e2bd-46b2-9bc6-8babbbdc0adc   in service    fd00:1122:3344:105::21
+    nexus             88602518-f176-49a1-af12-02fac36214c3   in service    fd00:1122:3344:105::22
 
 
  MODIFIED SLEDS:
@@ -119,84 +119,84 @@ to:   blueprint 9f71f5d3-a272-4382-9154-6ea2e171a6c6
     -----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
     dataset name                                                                                                   dataset uuid                           quota     reservation   compression
     -----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
--   oxp_22930645-144a-415c-bceb-2dbfafb9c29e/crucible                                                              8dead13f-23ec-47db-95bf-8ac7c15ec0bf   none      none          off        
--   oxp_24155070-8a43-4244-a3ba-853d8c71972d/crucible                                                              8a70b0f8-2021-46ac-b57e-62ed57442c2e   none      none          off        
--   oxp_494782c7-3821-4f49-918b-ce42cc4d18ad/crucible                                                              0c7a0040-a420-4c46-a43f-cf531b30218b   none      none          off        
--   oxp_6ea8a67f-d27d-472b-844c-6c8245b00e2b/crucible                                                              b47d4afb-fa04-4f3a-9816-fa83714b211f   none      none          off        
--   oxp_77565d57-c235-4905-b3c7-32d1c2ca2c44/crucible                                                              56f99204-06fc-41fb-8f0c-456c7e97b034   none      none          off        
--   oxp_8746874c-dc3b-4454-93cd-2a8fc13720fe/crucible                                                              c310b273-8e72-40e1-8f07-a52d2b7532f3   none      none          off        
--   oxp_a42c5a67-6e10-4586-a56e-48bb8260e75f/crucible                                                              b5844aab-20fe-47c8-8b1d-d2e4b2e75702   none      none          off        
--   oxp_ca89b120-7bcd-4eeb-baa7-71031fbd103b/crucible                                                              f6d614eb-b40d-431b-8a15-f29b7434e702   none      none          off        
--   oxp_ef61aa97-c862-428c-82f3-0a69a50d6155/crucible                                                              4ee918f4-7f38-4759-9cea-00208b404c09   none      none          off        
--   oxp_ef64ff6d-250d-47ac-8686-e696cfb46966/crucible                                                              50faf412-62e6-4cb9-a965-d07b7b035da7   none      none          off        
--   oxp_22930645-144a-415c-bceb-2dbfafb9c29e/crypt/internal_dns                                                    6f1c7df6-6a3b-433e-b376-d1b8b5cf4d5e   none      none          off        
--   oxp_22930645-144a-415c-bceb-2dbfafb9c29e/crypt/zone                                                            5884d02b-a463-45ba-8e99-660ec63d2779   none      none          off        
--   oxp_24155070-8a43-4244-a3ba-853d8c71972d/crypt/zone                                                            2b630e70-1cd8-4142-aee9-7067b6fe3ef3   none      none          off        
--   oxp_494782c7-3821-4f49-918b-ce42cc4d18ad/crypt/zone                                                            04c9bd23-0d9f-4a36-a442-42b9e3c54179   none      none          off        
--   oxp_6ea8a67f-d27d-472b-844c-6c8245b00e2b/crypt/zone                                                            38e45596-3b96-4ab9-bf80-274dded9157a   none      none          off        
--   oxp_77565d57-c235-4905-b3c7-32d1c2ca2c44/crypt/zone                                                            dc86fcab-2838-4b6c-bea3-3cb0fcec846a   none      none          off        
--   oxp_8746874c-dc3b-4454-93cd-2a8fc13720fe/crypt/zone                                                            97735f9a-4a36-4f9a-97f5-900204167d44   none      none          off        
--   oxp_a42c5a67-6e10-4586-a56e-48bb8260e75f/crypt/zone                                                            619c6140-1d63-495b-a5e4-be8f1fefe5ed   none      none          off        
--   oxp_ca89b120-7bcd-4eeb-baa7-71031fbd103b/crypt/zone                                                            b916b8aa-73b5-433d-ab69-fe3166cc6574   none      none          off        
--   oxp_ef61aa97-c862-428c-82f3-0a69a50d6155/crypt/zone                                                            6551d496-8da9-4d11-9be2-7fc3a49f4759   none      none          off        
--   oxp_ef64ff6d-250d-47ac-8686-e696cfb46966/crypt/zone                                                            db457b0d-72f5-47c9-a86c-f9c2c4d3064b   none      none          off        
--   oxp_a42c5a67-6e10-4586-a56e-48bb8260e75f/crypt/zone/oxz_crucible_01d58626-e1b0-480f-96be-ac784863c7dc          ff5950ed-1acc-477f-a9c1-f660161943f4   none      none          off        
--   oxp_77565d57-c235-4905-b3c7-32d1c2ca2c44/crypt/zone/oxz_crucible_094f27af-1acb-4d1e-ba97-1fc1377d4bf2          035d0068-1470-4491-900a-e8812e10376f   none      none          off        
--   oxp_ca89b120-7bcd-4eeb-baa7-71031fbd103b/crypt/zone/oxz_crucible_47a87c6e-ef45-4d52-9a3e-69cdd96737cc          51c0f16b-1ca5-48e6-b2e9-0069cbe9c48b   none      none          off        
--   oxp_22930645-144a-415c-bceb-2dbfafb9c29e/crypt/zone/oxz_crucible_4a9a0a9d-87f0-4f1d-9181-27f6b435e637          c36945af-cdba-45d8-941f-09c5bea2658e   none      none          off        
--   oxp_ef61aa97-c862-428c-82f3-0a69a50d6155/crypt/zone/oxz_crucible_6464d025-4652-4948-919e-740bec5699b1          9f67b263-7a55-44a2-b0a0-e738b89fb472   none      none          off        
--   oxp_ef64ff6d-250d-47ac-8686-e696cfb46966/crypt/zone/oxz_crucible_878dfddd-3113-4197-a3ea-e0d4dbe9b476          f95cc7aa-db18-4277-ad08-528c02d267e4   none      none          off        
--   oxp_494782c7-3821-4f49-918b-ce42cc4d18ad/crypt/zone/oxz_crucible_b91b271d-8d80-4f49-99a0-34006ae86063          73830784-d10d-489b-9e08-41f96e8ae130   none      none          off        
--   oxp_24155070-8a43-4244-a3ba-853d8c71972d/crypt/zone/oxz_crucible_e39d7c9e-182b-48af-af87-58079d723583          f49fa95b-4d2d-4ea3-a9ff-5ed73bf29a7f   none      none          off        
--   oxp_8746874c-dc3b-4454-93cd-2a8fc13720fe/crypt/zone/oxz_crucible_f3f2e4f3-0985-4ef6-8336-ce479382d05d          a916c527-eca0-4df7-b38e-76f4f7915656   none      none          off        
--   oxp_6ea8a67f-d27d-472b-844c-6c8245b00e2b/crypt/zone/oxz_crucible_f69f92a1-5007-4bb0-a85b-604dc217154b          4dc23347-b0aa-4705-a309-1baf57f222f2   none      none          off        
--   oxp_22930645-144a-415c-bceb-2dbfafb9c29e/crypt/zone/oxz_crucible_pantry_2f5e8010-a94d-43a4-9c5c-3f52832f5f7f   8d1d1315-00a3-4cb0-b3c2-7f3f224d63ba   none      none          off        
--   oxp_22930645-144a-415c-bceb-2dbfafb9c29e/crypt/zone/oxz_internal_dns_d6ee1338-3127-43ec-9aaa-b973ccf05496      b79f5a18-1ea5-46cd-b002-3d7f860bd444   none      none          off        
--   oxp_22930645-144a-415c-bceb-2dbfafb9c29e/crypt/zone/oxz_nexus_0dcfdfc5-481e-4153-b97c-11cf02b648ea             23d48cd2-e829-496c-b4df-a05d30d4fcad   none      none          off        
--   oxp_22930645-144a-415c-bceb-2dbfafb9c29e/crypt/zone/oxz_ntp_56ac1706-9e2a-49ba-bd6f-a99c44cb2ccb               11a058db-758a-4fda-beb8-be18fcf2df25   none      none          off        
--   oxp_22930645-144a-415c-bceb-2dbfafb9c29e/crypt/debug                                                           2277b21f-9c43-4537-b63b-82b9c66bc022   100 GiB   none          gzip-9     
--   oxp_24155070-8a43-4244-a3ba-853d8c71972d/crypt/debug                                                           cadb7c95-f233-4033-b0fe-a7b997245722   100 GiB   none          gzip-9     
--   oxp_494782c7-3821-4f49-918b-ce42cc4d18ad/crypt/debug                                                           988e1f23-ecca-487a-aec7-089593a043cc   100 GiB   none          gzip-9     
--   oxp_6ea8a67f-d27d-472b-844c-6c8245b00e2b/crypt/debug                                                           b26bab43-3760-4418-a6ab-47e01b267a1d   100 GiB   none          gzip-9     
--   oxp_77565d57-c235-4905-b3c7-32d1c2ca2c44/crypt/debug                                                           f1299161-15fd-424f-a739-6263c314ba90   100 GiB   none          gzip-9     
--   oxp_8746874c-dc3b-4454-93cd-2a8fc13720fe/crypt/debug                                                           86573b1f-e557-4da1-b7e2-3f3b42dba8de   100 GiB   none          gzip-9     
--   oxp_a42c5a67-6e10-4586-a56e-48bb8260e75f/crypt/debug                                                           86a8f677-e4d5-466a-bffb-60d653e91ce5   100 GiB   none          gzip-9     
--   oxp_ca89b120-7bcd-4eeb-baa7-71031fbd103b/crypt/debug                                                           0043d0b0-c24e-4858-afa3-2e3ae2a99a78   100 GiB   none          gzip-9     
--   oxp_ef61aa97-c862-428c-82f3-0a69a50d6155/crypt/debug                                                           941ef258-4015-4176-bbc0-5fa323fe2802   100 GiB   none          gzip-9     
--   oxp_ef64ff6d-250d-47ac-8686-e696cfb46966/crypt/debug                                                           98a2efcf-db1a-46a1-a4b9-01cf83b48e56   100 GiB   none          gzip-9     
+-   oxp_22930645-144a-415c-bceb-2dbfafb9c29e/crucible                                                              4393326c-f79e-497e-8539-e8268de235ae   none      none          off        
+-   oxp_24155070-8a43-4244-a3ba-853d8c71972d/crucible                                                              6bcb7a19-f5e8-49a2-b2ff-35a97be53a4e   none      none          off        
+-   oxp_494782c7-3821-4f49-918b-ce42cc4d18ad/crucible                                                              ee61b0d0-a302-41c0-aba7-1fc4bc9c1f29   none      none          off        
+-   oxp_6ea8a67f-d27d-472b-844c-6c8245b00e2b/crucible                                                              6d5d6e6a-d1cd-4ca2-aaf9-1db561847e58   none      none          off        
+-   oxp_77565d57-c235-4905-b3c7-32d1c2ca2c44/crucible                                                              0ae3e100-879c-4aed-9671-51405148857c   none      none          off        
+-   oxp_8746874c-dc3b-4454-93cd-2a8fc13720fe/crucible                                                              0e520292-0605-4508-8b87-bc9f4bdb2d17   none      none          off        
+-   oxp_a42c5a67-6e10-4586-a56e-48bb8260e75f/crucible                                                              baf9409f-9730-4c3b-9969-6d0af7abfa96   none      none          off        
+-   oxp_ca89b120-7bcd-4eeb-baa7-71031fbd103b/crucible                                                              87efc84a-b983-4c40-8dcf-711348dfab9a   none      none          off        
+-   oxp_ef61aa97-c862-428c-82f3-0a69a50d6155/crucible                                                              4a0fdd0e-ae77-45d3-b3b9-889898179f86   none      none          off        
+-   oxp_ef64ff6d-250d-47ac-8686-e696cfb46966/crucible                                                              84296646-39b7-4329-8c7b-83651c0501f9   none      none          off        
+-   oxp_22930645-144a-415c-bceb-2dbfafb9c29e/crypt/internal_dns                                                    50eb638f-21eb-41f1-bb0b-fc8e3adbf516   none      none          off        
+-   oxp_22930645-144a-415c-bceb-2dbfafb9c29e/crypt/zone                                                            6348353d-db1d-4016-9686-ea46eb9ffafe   none      none          off        
+-   oxp_24155070-8a43-4244-a3ba-853d8c71972d/crypt/zone                                                            6760b9f3-b130-4604-8212-964507005533   none      none          off        
+-   oxp_494782c7-3821-4f49-918b-ce42cc4d18ad/crypt/zone                                                            81a147f6-4f29-490d-862f-09333e6c0331   none      none          off        
+-   oxp_6ea8a67f-d27d-472b-844c-6c8245b00e2b/crypt/zone                                                            7ba4cc5a-05d5-48f8-bf1f-c19431c02e21   none      none          off        
+-   oxp_77565d57-c235-4905-b3c7-32d1c2ca2c44/crypt/zone                                                            d2b96129-68b8-428c-9041-f92a28b231d2   none      none          off        
+-   oxp_8746874c-dc3b-4454-93cd-2a8fc13720fe/crypt/zone                                                            edce7c97-7d0e-4da9-9d34-86b577bb5477   none      none          off        
+-   oxp_a42c5a67-6e10-4586-a56e-48bb8260e75f/crypt/zone                                                            02c0a9a5-0b9b-4421-9643-4e8b9c5ff39e   none      none          off        
+-   oxp_ca89b120-7bcd-4eeb-baa7-71031fbd103b/crypt/zone                                                            ddb27eda-8f02-438d-8956-87aa3d11ae9a   none      none          off        
+-   oxp_ef61aa97-c862-428c-82f3-0a69a50d6155/crypt/zone                                                            54f218fb-6023-4693-ad38-8e8fb2056a36   none      none          off        
+-   oxp_ef64ff6d-250d-47ac-8686-e696cfb46966/crypt/zone                                                            c1b62139-e0fe-4458-a7fd-593d6fc0b7a0   none      none          off        
+-   oxp_ef64ff6d-250d-47ac-8686-e696cfb46966/crypt/zone/oxz_crucible_085d10cb-a6f0-46de-86bc-ad2f7f1defcf          e365431d-2c6b-4ab8-ac38-66bda9a09c58   none      none          off        
+-   oxp_ca89b120-7bcd-4eeb-baa7-71031fbd103b/crypt/zone/oxz_crucible_2bf62dfa-537a-4616-aad5-64447faaec53          30584efb-cb2a-4446-8e92-979e1e3ad21c   none      none          off        
+-   oxp_6ea8a67f-d27d-472b-844c-6c8245b00e2b/crypt/zone/oxz_crucible_50d43a78-e9af-4051-9f5d-85410f44214b          f165f189-8f8d-4e75-b947-8cde0b3b9d1a   none      none          off        
+-   oxp_a42c5a67-6e10-4586-a56e-48bb8260e75f/crypt/zone/oxz_crucible_6e7b5239-0d2e-42a5-80aa-51a3bc859318          9d9170ef-3f05-4893-a322-31d80038fcbc   none      none          off        
+-   oxp_494782c7-3821-4f49-918b-ce42cc4d18ad/crypt/zone/oxz_crucible_8d87b485-3fb4-480b-97ce-02d066b799d7          51767a5b-953f-4333-b123-630d38803e98   none      none          off        
+-   oxp_24155070-8a43-4244-a3ba-853d8c71972d/crypt/zone/oxz_crucible_b3d757b8-033f-4a68-82db-6ff5331b9739          ac210527-730a-41a7-bb39-b5ab118b0176   none      none          off        
+-   oxp_77565d57-c235-4905-b3c7-32d1c2ca2c44/crypt/zone/oxz_crucible_bcd98cf5-a798-4aa0-81cc-8972a376073c          36312983-f969-4f3e-9008-23439cfdf85b   none      none          off        
+-   oxp_8746874c-dc3b-4454-93cd-2a8fc13720fe/crypt/zone/oxz_crucible_bd12d9d5-bccf-433a-b078-794a69aeb89a          112c4751-37b3-4dd1-9669-9d78eb778221   none      none          off        
+-   oxp_ef61aa97-c862-428c-82f3-0a69a50d6155/crypt/zone/oxz_crucible_d283707c-1b8f-4cb9-946d-041b25a83967          4a35ecb6-9930-499b-a784-7f423a7d1975   none      none          off        
+-   oxp_22930645-144a-415c-bceb-2dbfafb9c29e/crypt/zone/oxz_crucible_e362415d-2d54-4574-b823-3f01b9b751de          7991a9e3-04df-42f3-9ce5-ad6d9f54a308   none      none          off        
+-   oxp_22930645-144a-415c-bceb-2dbfafb9c29e/crypt/zone/oxz_crucible_pantry_208c987a-ab33-47a3-a103-6108dd6dc4cb   d8a25751-04a7-4f92-920d-e4294cd0d9f5   none      none          off        
+-   oxp_22930645-144a-415c-bceb-2dbfafb9c29e/crypt/zone/oxz_internal_dns_c428175e-6a1c-40bf-aa36-f608a57431f5      c9e9ec7e-68d6-4d78-88ae-144336a5f68d   none      none          off        
+-   oxp_22930645-144a-415c-bceb-2dbfafb9c29e/crypt/zone/oxz_nexus_533416e6-d0bd-482d-b592-29346c8a3471             e3638c01-8669-41a4-a4a6-9b981bf478ed   none      none          off        
+-   oxp_22930645-144a-415c-bceb-2dbfafb9c29e/crypt/zone/oxz_ntp_a8f1b53a-4231-4f04-9939-29e50a0f0e2c               a943567c-1e12-48b9-80f3-a1c48242191c   none      none          off        
+-   oxp_22930645-144a-415c-bceb-2dbfafb9c29e/crypt/debug                                                           3dfdb70d-6884-4143-939b-3a973ae7314e   100 GiB   none          gzip-9     
+-   oxp_24155070-8a43-4244-a3ba-853d8c71972d/crypt/debug                                                           e6fe9880-110a-4e55-8390-5a7d9205aea0   100 GiB   none          gzip-9     
+-   oxp_494782c7-3821-4f49-918b-ce42cc4d18ad/crypt/debug                                                           730e9778-32bb-4eb9-9488-5412e8c00e9a   100 GiB   none          gzip-9     
+-   oxp_6ea8a67f-d27d-472b-844c-6c8245b00e2b/crypt/debug                                                           38509c13-7948-4bf3-b34b-8f51862b135a   100 GiB   none          gzip-9     
+-   oxp_77565d57-c235-4905-b3c7-32d1c2ca2c44/crypt/debug                                                           aff03579-cf55-4e57-b22c-84e54788bcfe   100 GiB   none          gzip-9     
+-   oxp_8746874c-dc3b-4454-93cd-2a8fc13720fe/crypt/debug                                                           f8b506cf-c947-4579-a852-dc017f59e092   100 GiB   none          gzip-9     
+-   oxp_a42c5a67-6e10-4586-a56e-48bb8260e75f/crypt/debug                                                           06ee31c6-5e75-444b-af7d-49695a1fbff4   100 GiB   none          gzip-9     
+-   oxp_ca89b120-7bcd-4eeb-baa7-71031fbd103b/crypt/debug                                                           20745882-62c8-48db-a8fd-c0b0dc967897   100 GiB   none          gzip-9     
+-   oxp_ef61aa97-c862-428c-82f3-0a69a50d6155/crypt/debug                                                           a6ca9c24-86cc-4e94-b921-38c0f1c922d4   100 GiB   none          gzip-9     
+-   oxp_ef64ff6d-250d-47ac-8686-e696cfb46966/crypt/debug                                                           5d4ce100-3838-401c-8f2e-46b5b5374115   100 GiB   none          gzip-9     
 
 
     omicron zones generation 2 -> 3:
     ----------------------------------------------------------------------------------------------
     zone type         zone id                                disposition    underlay IP           
     ----------------------------------------------------------------------------------------------
-*   crucible          01d58626-e1b0-480f-96be-ac784863c7dc   - in service   fd00:1122:3344:103::2a
+*   crucible          085d10cb-a6f0-46de-86bc-ad2f7f1defcf   - in service   fd00:1122:3344:103::2d
      └─                                                      + expunged                           
-*   crucible          094f27af-1acb-4d1e-ba97-1fc1377d4bf2   - in service   fd00:1122:3344:103::28
+*   crucible          2bf62dfa-537a-4616-aad5-64447faaec53   - in service   fd00:1122:3344:103::2b
      └─                                                      + expunged                           
-*   crucible          47a87c6e-ef45-4d52-9a3e-69cdd96737cc   - in service   fd00:1122:3344:103::2b
+*   crucible          50d43a78-e9af-4051-9f5d-85410f44214b   - in service   fd00:1122:3344:103::27
      └─                                                      + expunged                           
-*   crucible          4a9a0a9d-87f0-4f1d-9181-27f6b435e637   - in service   fd00:1122:3344:103::24
+*   crucible          6e7b5239-0d2e-42a5-80aa-51a3bc859318   - in service   fd00:1122:3344:103::2a
      └─                                                      + expunged                           
-*   crucible          6464d025-4652-4948-919e-740bec5699b1   - in service   fd00:1122:3344:103::2c
+*   crucible          8d87b485-3fb4-480b-97ce-02d066b799d7   - in service   fd00:1122:3344:103::26
      └─                                                      + expunged                           
-*   crucible          878dfddd-3113-4197-a3ea-e0d4dbe9b476   - in service   fd00:1122:3344:103::2d
+*   crucible          b3d757b8-033f-4a68-82db-6ff5331b9739   - in service   fd00:1122:3344:103::25
      └─                                                      + expunged                           
-*   crucible          b91b271d-8d80-4f49-99a0-34006ae86063   - in service   fd00:1122:3344:103::26
+*   crucible          bcd98cf5-a798-4aa0-81cc-8972a376073c   - in service   fd00:1122:3344:103::28
      └─                                                      + expunged                           
-*   crucible          e39d7c9e-182b-48af-af87-58079d723583   - in service   fd00:1122:3344:103::25
+*   crucible          bd12d9d5-bccf-433a-b078-794a69aeb89a   - in service   fd00:1122:3344:103::29
      └─                                                      + expunged                           
-*   crucible          f3f2e4f3-0985-4ef6-8336-ce479382d05d   - in service   fd00:1122:3344:103::29
+*   crucible          d283707c-1b8f-4cb9-946d-041b25a83967   - in service   fd00:1122:3344:103::2c
      └─                                                      + expunged                           
-*   crucible          f69f92a1-5007-4bb0-a85b-604dc217154b   - in service   fd00:1122:3344:103::27
+*   crucible          e362415d-2d54-4574-b823-3f01b9b751de   - in service   fd00:1122:3344:103::24
      └─                                                      + expunged                           
-*   crucible_pantry   2f5e8010-a94d-43a4-9c5c-3f52832f5f7f   - in service   fd00:1122:3344:103::23
+*   crucible_pantry   208c987a-ab33-47a3-a103-6108dd6dc4cb   - in service   fd00:1122:3344:103::23
      └─                                                      + expunged                           
-*   internal_dns      d6ee1338-3127-43ec-9aaa-b973ccf05496   - in service   fd00:1122:3344:2::1   
+*   internal_dns      c428175e-6a1c-40bf-aa36-f608a57431f5   - in service   fd00:1122:3344:2::1   
      └─                                                      + expunged                           
-*   internal_ntp      56ac1706-9e2a-49ba-bd6f-a99c44cb2ccb   - in service   fd00:1122:3344:103::21
+*   internal_ntp      a8f1b53a-4231-4f04-9939-29e50a0f0e2c   - in service   fd00:1122:3344:103::21
      └─                                                      + expunged                           
-*   nexus             0dcfdfc5-481e-4153-b97c-11cf02b648ea   - in service   fd00:1122:3344:103::22
+*   nexus             533416e6-d0bd-482d-b592-29346c8a3471   - in service   fd00:1122:3344:103::22
      └─                                                      + expunged                           
 
 
@@ -222,71 +222,71 @@ to:   blueprint 9f71f5d3-a272-4382-9154-6ea2e171a6c6
     -----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
     dataset name                                                                                                   dataset uuid                           quota     reservation   compression
     -----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
--   oxp_09a5de95-c15f-486e-b776-fca62bf5e179/crucible                                                              a68daa64-5586-4806-8aaf-3b87601d7439   none      none          off        
--   oxp_11b8eccf-7c78-4bde-8639-b35a83082a95/crucible                                                              703b5340-55ff-4053-af0b-fd5d20f8c47f   none      none          off        
--   oxp_1931c422-4c6a-4597-8ae7-ecb44718462c/crucible                                                              c674cb78-2509-4a6a-86a9-57dcd8b59dfb   none      none          off        
--   oxp_21a8a87e-73a4-42d4-a426-f6eec94004e3/crucible                                                              a0f3bb4d-67e5-4384-9d17-fbe562f8605a   none      none          off        
--   oxp_222c0b55-2966-46b6-816c-9063a7587806/crucible                                                              f4d87d35-e308-41f9-af74-6f7169295160   none      none          off        
--   oxp_3676f688-f41c-4f89-936a-6b04c3011b2a/crucible                                                              6439fca6-e8ae-4eff-b9a5-04dd674b1743   none      none          off        
--   oxp_5e9e14c4-d60d-4b5c-a11c-bba54eb24c9f/crucible                                                              f89c2279-d18a-4f57-98cc-b48267835008   none      none          off        
--   oxp_74f7b89e-88f5-4336-ba8b-22283a6966c5/crucible                                                              ff77f150-ae89-4483-872a-d269e06c807c   none      none          off        
--   oxp_a787cac8-b5e3-49e3-aaab-20d8eadd8a63/crucible                                                              3648ccea-b4ff-4087-9cf4-8291096ef1b3   none      none          off        
--   oxp_d56b0c9f-0e57-43d8-a1ac-8b4d2c303c29/crucible                                                              a073286c-c538-421f-855b-ba7bca328900   none      none          off        
--   oxp_09a5de95-c15f-486e-b776-fca62bf5e179/crypt/internal_dns                                                    fa80f286-3de6-4042-907a-398973c726ef   none      none          off        
--   oxp_09a5de95-c15f-486e-b776-fca62bf5e179/crypt/zone                                                            bec5341c-bcb2-4e7c-92e1-d6c47f435ea2   none      none          off        
--   oxp_11b8eccf-7c78-4bde-8639-b35a83082a95/crypt/zone                                                            34c338eb-b4ea-4c8f-b60e-d3ec612f662c   none      none          off        
--   oxp_1931c422-4c6a-4597-8ae7-ecb44718462c/crypt/zone                                                            c575e10d-30ff-4201-9e3a-892fc8f2fc51   none      none          off        
--   oxp_21a8a87e-73a4-42d4-a426-f6eec94004e3/crypt/zone                                                            c32b8e04-6296-49d8-bf08-16a249890867   none      none          off        
--   oxp_222c0b55-2966-46b6-816c-9063a7587806/crypt/zone                                                            a08d5c26-4524-4b70-888e-a8db7f2883cb   none      none          off        
--   oxp_3676f688-f41c-4f89-936a-6b04c3011b2a/crypt/zone                                                            5b3537cb-5cd4-48f8-bb9b-222f8287b990   none      none          off        
--   oxp_5e9e14c4-d60d-4b5c-a11c-bba54eb24c9f/crypt/zone                                                            1ed89b99-e4e5-4873-8ab3-f68285365c8c   none      none          off        
--   oxp_74f7b89e-88f5-4336-ba8b-22283a6966c5/crypt/zone                                                            b7dab9eb-f509-4e87-976a-aba0d11578a8   none      none          off        
--   oxp_a787cac8-b5e3-49e3-aaab-20d8eadd8a63/crypt/zone                                                            bf566572-3446-46c4-ba77-88b57f59dc99   none      none          off        
--   oxp_d56b0c9f-0e57-43d8-a1ac-8b4d2c303c29/crypt/zone                                                            422f8e78-ab9d-4a60-b859-a036db2979a7   none      none          off        
--   oxp_74f7b89e-88f5-4336-ba8b-22283a6966c5/crypt/zone/oxz_crucible_15bb9def-69b8-4d2e-b04f-9fee1143387c          d9b8254c-75fa-45b6-8816-e3e6da18f49f   none      none          off        
--   oxp_1931c422-4c6a-4597-8ae7-ecb44718462c/crypt/zone/oxz_crucible_3b3c14b6-a8e2-4054-a577-8d96cb576230          93d7d978-cfe4-4637-8809-1b234ca7784d   none      none          off        
--   oxp_21a8a87e-73a4-42d4-a426-f6eec94004e3/crypt/zone/oxz_crucible_57b96d5c-b71e-43e4-8869-7d514003d00d          07a1540e-5775-4768-9938-e8a9031ace4f   none      none          off        
--   oxp_11b8eccf-7c78-4bde-8639-b35a83082a95/crypt/zone/oxz_crucible_8d4d2b28-82bb-4e36-80da-1408d8c35d82          458ce5af-7d1b-4484-a11d-3c5f8e01bc9a   none      none          off        
--   oxp_a787cac8-b5e3-49e3-aaab-20d8eadd8a63/crypt/zone/oxz_crucible_996d7570-b0df-46d5-aaa4-0c97697cf484          c5d41993-88ce-471d-bd89-6ffd35dc8f61   none      none          off        
--   oxp_5e9e14c4-d60d-4b5c-a11c-bba54eb24c9f/crypt/zone/oxz_crucible_b1783e95-9598-451d-b6ba-c50b52b428c3          0bad1d7b-9fa4-4f29-9374-0b2aa2ebcda3   none      none          off        
--   oxp_222c0b55-2966-46b6-816c-9063a7587806/crypt/zone/oxz_crucible_b4947d31-f70e-4ee0-8817-0ca6cea9b16b          b4ec6b4d-cac2-44ca-8592-b2951398bd9d   none      none          off        
--   oxp_09a5de95-c15f-486e-b776-fca62bf5e179/crypt/zone/oxz_crucible_c407795c-6c8b-428e-8ab8-b962913c447f          99ad09ef-da25-4187-b83a-3e95fc8898f7   none      none          off        
--   oxp_d56b0c9f-0e57-43d8-a1ac-8b4d2c303c29/crypt/zone/oxz_crucible_c6dd531e-2d1d-423b-acc8-358533dab78c          e2105178-7bec-4e0f-95a9-91f0e698cca5   none      none          off        
--   oxp_3676f688-f41c-4f89-936a-6b04c3011b2a/crypt/zone/oxz_crucible_e4b3e159-3dbe-48cb-8497-e3da92a90e5a          231ab7ea-48cd-45f4-b359-d9ff54732688   none      none          off        
--   oxp_09a5de95-c15f-486e-b776-fca62bf5e179/crypt/zone/oxz_crucible_pantry_6939ce48-b17c-4616-b176-8a419a7697be   35fda90e-04f2-4a3e-89ee-92f9b6047956   none      none          off        
--   oxp_09a5de95-c15f-486e-b776-fca62bf5e179/crypt/zone/oxz_internal_dns_b6b759d0-f60d-42b7-bbbc-9d61c9e895a9      577d3d90-d609-418b-9278-0cbf605294c6   none      none          off        
--   oxp_09a5de95-c15f-486e-b776-fca62bf5e179/crypt/zone/oxz_nexus_b44cdbc0-0ce0-46eb-8b21-a09e113aa1d0             c9208413-484e-47bf-9d54-ec7977cccd81   none      none          off        
--   oxp_09a5de95-c15f-486e-b776-fca62bf5e179/crypt/zone/oxz_ntp_9fd52961-426f-4e62-a644-b70871103fca               2f54bd95-c1d7-4aaa-95e2-7ecacb4be6e3   none      none          off        
--   oxp_09a5de95-c15f-486e-b776-fca62bf5e179/crypt/debug                                                           c0485a6d-fe97-47b0-bf93-eb58308fc3c1   100 GiB   none          gzip-9     
--   oxp_11b8eccf-7c78-4bde-8639-b35a83082a95/crypt/debug                                                           571edc71-daed-4b47-b4ba-0dc0e29e5e9d   100 GiB   none          gzip-9     
--   oxp_1931c422-4c6a-4597-8ae7-ecb44718462c/crypt/debug                                                           5c8d8475-6f8a-4a4a-bc30-d6fdb6d057f2   100 GiB   none          gzip-9     
--   oxp_21a8a87e-73a4-42d4-a426-f6eec94004e3/crypt/debug                                                           21e32545-8f60-412f-9f0f-384c00a8c3c7   100 GiB   none          gzip-9     
--   oxp_222c0b55-2966-46b6-816c-9063a7587806/crypt/debug                                                           d9c04df5-0f09-4f6f-883b-29137611d89b   100 GiB   none          gzip-9     
--   oxp_3676f688-f41c-4f89-936a-6b04c3011b2a/crypt/debug                                                           222b4387-2804-4d53-ba2f-4a32777d0b72   100 GiB   none          gzip-9     
--   oxp_5e9e14c4-d60d-4b5c-a11c-bba54eb24c9f/crypt/debug                                                           d5497445-1e12-4497-94e5-087fc82cce67   100 GiB   none          gzip-9     
--   oxp_74f7b89e-88f5-4336-ba8b-22283a6966c5/crypt/debug                                                           ac76ddfb-dafd-47fb-87c7-abee8b82f6bd   100 GiB   none          gzip-9     
--   oxp_a787cac8-b5e3-49e3-aaab-20d8eadd8a63/crypt/debug                                                           a3152a55-6fe7-4b34-90ee-e2370860b197   100 GiB   none          gzip-9     
--   oxp_d56b0c9f-0e57-43d8-a1ac-8b4d2c303c29/crypt/debug                                                           5d5eedcd-8193-40ed-9018-7faab9df80c0   100 GiB   none          gzip-9     
+-   oxp_09a5de95-c15f-486e-b776-fca62bf5e179/crucible                                                              b77e647a-9173-499a-854a-6c0b4968b7e0   none      none          off        
+-   oxp_11b8eccf-7c78-4bde-8639-b35a83082a95/crucible                                                              58fdafab-31e5-4fa2-89c6-322e3a2b482e   none      none          off        
+-   oxp_1931c422-4c6a-4597-8ae7-ecb44718462c/crucible                                                              d0437bf1-8860-49d3-8fb3-da4c67a5a08b   none      none          off        
+-   oxp_21a8a87e-73a4-42d4-a426-f6eec94004e3/crucible                                                              55406728-458a-4768-8c60-4bda237e5eee   none      none          off        
+-   oxp_222c0b55-2966-46b6-816c-9063a7587806/crucible                                                              541775da-bd2a-47da-b3a7-0554f1b318d7   none      none          off        
+-   oxp_3676f688-f41c-4f89-936a-6b04c3011b2a/crucible                                                              cf342d78-595a-4871-badc-4b4abf86df59   none      none          off        
+-   oxp_5e9e14c4-d60d-4b5c-a11c-bba54eb24c9f/crucible                                                              f90acbe5-1565-4f3d-bab7-c82dbc5d88e0   none      none          off        
+-   oxp_74f7b89e-88f5-4336-ba8b-22283a6966c5/crucible                                                              572b2277-6c1c-45b7-afaa-85c6838c4fb1   none      none          off        
+-   oxp_a787cac8-b5e3-49e3-aaab-20d8eadd8a63/crucible                                                              46699296-d0e9-4fdd-bd1a-f6f7e23bf14e   none      none          off        
+-   oxp_d56b0c9f-0e57-43d8-a1ac-8b4d2c303c29/crucible                                                              17e494d7-7797-4f2f-9f0e-f01340c5d20c   none      none          off        
+-   oxp_09a5de95-c15f-486e-b776-fca62bf5e179/crypt/internal_dns                                                    6b3c8095-3f2e-4844-adad-58c2a9672b0f   none      none          off        
+-   oxp_09a5de95-c15f-486e-b776-fca62bf5e179/crypt/zone                                                            0a15e4d5-df40-4084-b60d-cdf7ee46ab4e   none      none          off        
+-   oxp_11b8eccf-7c78-4bde-8639-b35a83082a95/crypt/zone                                                            5d9f6772-bda9-4ad1-af28-06fe072d49ce   none      none          off        
+-   oxp_1931c422-4c6a-4597-8ae7-ecb44718462c/crypt/zone                                                            22a21aab-ef00-4741-b1af-83628f9176ed   none      none          off        
+-   oxp_21a8a87e-73a4-42d4-a426-f6eec94004e3/crypt/zone                                                            7d4d36bb-db99-44a8-9542-c18644925ecd   none      none          off        
+-   oxp_222c0b55-2966-46b6-816c-9063a7587806/crypt/zone                                                            d9255b0c-5115-4b4c-9a15-20b7abc6a625   none      none          off        
+-   oxp_3676f688-f41c-4f89-936a-6b04c3011b2a/crypt/zone                                                            5bd021b1-e4dd-4dfb-af5d-30a5d5fc6de6   none      none          off        
+-   oxp_5e9e14c4-d60d-4b5c-a11c-bba54eb24c9f/crypt/zone                                                            1c0a27d1-5feb-4c88-8ef5-ad438e2e337b   none      none          off        
+-   oxp_74f7b89e-88f5-4336-ba8b-22283a6966c5/crypt/zone                                                            378cde4a-b2e0-4c04-8a77-c8a333b21e79   none      none          off        
+-   oxp_a787cac8-b5e3-49e3-aaab-20d8eadd8a63/crypt/zone                                                            6982b864-f299-4a0c-bc1c-b05cfd923ad4   none      none          off        
+-   oxp_d56b0c9f-0e57-43d8-a1ac-8b4d2c303c29/crypt/zone                                                            21aba03d-0506-4ded-992c-2198a9df8db8   none      none          off        
+-   oxp_11b8eccf-7c78-4bde-8639-b35a83082a95/crypt/zone/oxz_crucible_258c5106-ebcd-4651-96e4-d5b0895691f6          d3b4685c-6b3c-4547-8f31-914760b52b6f   none      none          off        
+-   oxp_5e9e14c4-d60d-4b5c-a11c-bba54eb24c9f/crypt/zone/oxz_crucible_2b046f65-00f5-46da-988c-90c1de32a1dd          68670f81-967f-410a-89f5-5aeed7725f18   none      none          off        
+-   oxp_d56b0c9f-0e57-43d8-a1ac-8b4d2c303c29/crypt/zone/oxz_crucible_30c770a8-625e-4864-8977-d83a11c1c596          bf61091c-be19-4e3c-9665-61fe5d3f984f   none      none          off        
+-   oxp_21a8a87e-73a4-42d4-a426-f6eec94004e3/crypt/zone/oxz_crucible_35e3587d-25d3-4234-822f-2d68713b8cbf          ac9ca46f-4a0a-4cd0-ad58-e89609ebb241   none      none          off        
+-   oxp_222c0b55-2966-46b6-816c-9063a7587806/crypt/zone/oxz_crucible_46293b15-fd26-48f9-9ccb-122fa0ef41b4          d406c3ce-a277-42c2-beac-9fe311e7a2f9   none      none          off        
+-   oxp_09a5de95-c15f-486e-b776-fca62bf5e179/crypt/zone/oxz_crucible_462c6b8d-1872-4671-b84a-bdcbb69e3baf          83c9535d-cf93-440a-bfda-e7d17d5ad31e   none      none          off        
+-   oxp_1931c422-4c6a-4597-8ae7-ecb44718462c/crypt/zone/oxz_crucible_a046c5f9-25e7-47c3-9c67-43d68fb39c5e          e485343e-cf15-4484-82eb-7913b388cdf0   none      none          off        
+-   oxp_a787cac8-b5e3-49e3-aaab-20d8eadd8a63/crypt/zone/oxz_crucible_a49d4037-506e-4732-8e21-1f8c136a3c17          45e58d60-6bb9-4bc0-a925-a13952eef7bb   none      none          off        
+-   oxp_74f7b89e-88f5-4336-ba8b-22283a6966c5/crypt/zone/oxz_crucible_df94dc9a-74d9-43a9-8879-199740665f29          1db67d8d-5443-4304-a4fc-22ee0ecf9a14   none      none          off        
+-   oxp_3676f688-f41c-4f89-936a-6b04c3011b2a/crypt/zone/oxz_crucible_f1622981-7f0b-4a9f-9a70-6b46ab9d5e86          8d49a774-0f12-41ad-acd5-2853553044e4   none      none          off        
+-   oxp_09a5de95-c15f-486e-b776-fca62bf5e179/crypt/zone/oxz_crucible_pantry_b217d3a5-4ebb-45e3-b5be-2ebb2c57d8fa   03429538-a04b-453e-85e0-4495f18d80c9   none      none          off        
+-   oxp_09a5de95-c15f-486e-b776-fca62bf5e179/crypt/zone/oxz_internal_dns_0efed95e-f052-4535-b45a-fac1148c0e6a      0be7365d-2d85-4d99-a186-e404eb93ef59   none      none          off        
+-   oxp_09a5de95-c15f-486e-b776-fca62bf5e179/crypt/zone/oxz_nexus_ee146b15-bc59-43a3-9567-bb8596e6188d             14cd103e-65f0-42f6-a03d-c03b1e865b4c   none      none          off        
+-   oxp_09a5de95-c15f-486e-b776-fca62bf5e179/crypt/zone/oxz_ntp_61a79cb4-7fcb-432d-bbe9-3f9882452db2               0af1fd16-7dde-4bf5-8da6-dceb05bf4aef   none      none          off        
+-   oxp_09a5de95-c15f-486e-b776-fca62bf5e179/crypt/debug                                                           455486dc-8ab4-4405-99fc-862d6dbfcda3   100 GiB   none          gzip-9     
+-   oxp_11b8eccf-7c78-4bde-8639-b35a83082a95/crypt/debug                                                           de5f06bb-1d18-4dec-b8ca-e0947efd7605   100 GiB   none          gzip-9     
+-   oxp_1931c422-4c6a-4597-8ae7-ecb44718462c/crypt/debug                                                           000775a7-f52a-4b4c-845e-f9ec8b27e32c   100 GiB   none          gzip-9     
+-   oxp_21a8a87e-73a4-42d4-a426-f6eec94004e3/crypt/debug                                                           cd6d3991-5be5-49e3-8d2d-b0a29acc479c   100 GiB   none          gzip-9     
+-   oxp_222c0b55-2966-46b6-816c-9063a7587806/crypt/debug                                                           5cfe962a-ff3d-4ab7-8c1b-8979dba15bb0   100 GiB   none          gzip-9     
+-   oxp_3676f688-f41c-4f89-936a-6b04c3011b2a/crypt/debug                                                           0d918a12-c470-472e-9711-7e79ddd9b90b   100 GiB   none          gzip-9     
+-   oxp_5e9e14c4-d60d-4b5c-a11c-bba54eb24c9f/crypt/debug                                                           56d77912-628f-4a06-8e60-ae83e0bd7292   100 GiB   none          gzip-9     
+-   oxp_74f7b89e-88f5-4336-ba8b-22283a6966c5/crypt/debug                                                           54b2745f-9c22-4407-858e-31ea0c9db415   100 GiB   none          gzip-9     
+-   oxp_a787cac8-b5e3-49e3-aaab-20d8eadd8a63/crypt/debug                                                           69c359cd-15e4-485f-8f32-e84c1a19eec8   100 GiB   none          gzip-9     
+-   oxp_d56b0c9f-0e57-43d8-a1ac-8b4d2c303c29/crypt/debug                                                           34d0a7d0-56f8-4a8e-9e71-657c9ebc71f3   100 GiB   none          gzip-9     
 
 
     omicron zones at generation 2:
     ---------------------------------------------------------------------------------------------
     zone type         zone id                                disposition   underlay IP           
     ---------------------------------------------------------------------------------------------
-    crucible          15bb9def-69b8-4d2e-b04f-9fee1143387c   expunged      fd00:1122:3344:102::2b
-    crucible          3b3c14b6-a8e2-4054-a577-8d96cb576230   expunged      fd00:1122:3344:102::26
-    crucible          57b96d5c-b71e-43e4-8869-7d514003d00d   expunged      fd00:1122:3344:102::27
-    crucible          8d4d2b28-82bb-4e36-80da-1408d8c35d82   expunged      fd00:1122:3344:102::25
-    crucible          996d7570-b0df-46d5-aaa4-0c97697cf484   expunged      fd00:1122:3344:102::2c
-    crucible          b1783e95-9598-451d-b6ba-c50b52b428c3   expunged      fd00:1122:3344:102::2a
-    crucible          b4947d31-f70e-4ee0-8817-0ca6cea9b16b   expunged      fd00:1122:3344:102::28
-    crucible          c407795c-6c8b-428e-8ab8-b962913c447f   expunged      fd00:1122:3344:102::24
-    crucible          c6dd531e-2d1d-423b-acc8-358533dab78c   expunged      fd00:1122:3344:102::2d
-    crucible          e4b3e159-3dbe-48cb-8497-e3da92a90e5a   expunged      fd00:1122:3344:102::29
-    crucible_pantry   6939ce48-b17c-4616-b176-8a419a7697be   expunged      fd00:1122:3344:102::23
-    internal_dns      b6b759d0-f60d-42b7-bbbc-9d61c9e895a9   expunged      fd00:1122:3344:3::1   
-    internal_ntp      9fd52961-426f-4e62-a644-b70871103fca   expunged      fd00:1122:3344:102::21
-    nexus             b44cdbc0-0ce0-46eb-8b21-a09e113aa1d0   expunged      fd00:1122:3344:102::22
+    crucible          258c5106-ebcd-4651-96e4-d5b0895691f6   expunged      fd00:1122:3344:102::25
+    crucible          2b046f65-00f5-46da-988c-90c1de32a1dd   expunged      fd00:1122:3344:102::2a
+    crucible          30c770a8-625e-4864-8977-d83a11c1c596   expunged      fd00:1122:3344:102::2d
+    crucible          35e3587d-25d3-4234-822f-2d68713b8cbf   expunged      fd00:1122:3344:102::27
+    crucible          46293b15-fd26-48f9-9ccb-122fa0ef41b4   expunged      fd00:1122:3344:102::28
+    crucible          462c6b8d-1872-4671-b84a-bdcbb69e3baf   expunged      fd00:1122:3344:102::24
+    crucible          a046c5f9-25e7-47c3-9c67-43d68fb39c5e   expunged      fd00:1122:3344:102::26
+    crucible          a49d4037-506e-4732-8e21-1f8c136a3c17   expunged      fd00:1122:3344:102::2c
+    crucible          df94dc9a-74d9-43a9-8879-199740665f29   expunged      fd00:1122:3344:102::2b
+    crucible          f1622981-7f0b-4a9f-9a70-6b46ab9d5e86   expunged      fd00:1122:3344:102::29
+    crucible_pantry   b217d3a5-4ebb-45e3-b5be-2ebb2c57d8fa   expunged      fd00:1122:3344:102::23
+    internal_dns      0efed95e-f052-4535-b45a-fac1148c0e6a   expunged      fd00:1122:3344:3::1   
+    internal_ntp      61a79cb4-7fcb-432d-bbe9-3f9882452db2   expunged      fd00:1122:3344:102::21
+    nexus             ee146b15-bc59-43a3-9567-bb8596e6188d   expunged      fd00:1122:3344:102::22
 
 
   sled 75bc286f-2b4b-482c-9431-59272af529da (active):
@@ -311,72 +311,72 @@ to:   blueprint 9f71f5d3-a272-4382-9154-6ea2e171a6c6
     ----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
     dataset name                                                                                            dataset uuid                           quota     reservation   compression
     ----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
-    oxp_4069c804-c51a-4adc-8822-3cbbab56ed3f/crucible                                                       5c9ef84c-434c-4406-b68a-70e9af65b5a5   none      none          off        
-    oxp_5248a306-4a03-449e-a8a3-6f86d26da755/crucible                                                       182f7cbb-ea53-4057-b85c-667e5d949db5   none      none          off        
-    oxp_55196665-ed61-4b23-9a74-0711bf2eaf90/crucible                                                       931c4336-5ff9-45ce-b71b-9b6e81e16e53   none      none          off        
-    oxp_6b2a719a-35eb-469f-aa54-114a1f21f37d/crucible                                                       11e2e73b-93a1-47f1-aff3-c4dc7667f4f1   none      none          off        
-    oxp_7ed4296a-66d1-4fb2-bc56-9b23b8f27d7e/crucible                                                       bdc3e42b-b28f-42c9-99fa-3f92e8b30a3c   none      none          off        
-    oxp_984e2389-e7fd-4af9-ab02-e3caf77f95b5/crucible                                                       5c956b09-323e-476c-9a71-352154b1f841   none      none          off        
-    oxp_a5f75431-3795-426c-8f80-176f658281a5/crucible                                                       7b4f5c33-6a5a-42f9-8199-69f72761b24d   none      none          off        
-    oxp_cf32a1ce-2c9e-49f5-b1cf-4af7f2a28901/crucible                                                       77279948-9fe2-46f2-af39-0d5b692f5984   none      none          off        
-    oxp_e405da11-cb6b-4ebc-bac1-9bc997352e10/crucible                                                       0f6d5b5f-674d-465e-9b40-d09c6865416a   none      none          off        
-    oxp_f4d7f914-ec73-4b65-8696-5068591d9065/crucible                                                       e7ca75fe-d59c-4324-9053-a6a1566958e2   none      none          off        
-    oxp_4069c804-c51a-4adc-8822-3cbbab56ed3f/crypt/zone                                                     fc0b9a2c-4002-4fff-92f4-b541b7dd18c4   none      none          off        
-    oxp_5248a306-4a03-449e-a8a3-6f86d26da755/crypt/zone                                                     5f097047-8290-438a-b85a-80bc9450b26c   none      none          off        
-    oxp_55196665-ed61-4b23-9a74-0711bf2eaf90/crypt/zone                                                     b19e4e13-79e3-481d-ad80-db076a26b7eb   none      none          off        
-    oxp_6b2a719a-35eb-469f-aa54-114a1f21f37d/crypt/zone                                                     7ab2c8a5-3135-4a51-a232-7af8c72b9d3c   none      none          off        
-    oxp_7ed4296a-66d1-4fb2-bc56-9b23b8f27d7e/crypt/zone                                                     4b69a9a9-2994-433c-9733-05de50d9c2a1   none      none          off        
-    oxp_984e2389-e7fd-4af9-ab02-e3caf77f95b5/crypt/zone                                                     b27f6972-47f0-43e9-a7cb-3a2fcd93798b   none      none          off        
-    oxp_a5f75431-3795-426c-8f80-176f658281a5/crypt/zone                                                     4d913be5-fa91-4b22-b714-53babe093654   none      none          off        
-    oxp_cf32a1ce-2c9e-49f5-b1cf-4af7f2a28901/crypt/zone                                                     e79fbff1-f7fb-4912-9f5c-faca57a6a9c4   none      none          off        
-    oxp_e405da11-cb6b-4ebc-bac1-9bc997352e10/crypt/zone                                                     ffc0cb27-54e5-4d28-8f3d-5f7730fed34a   none      none          off        
-    oxp_f4d7f914-ec73-4b65-8696-5068591d9065/crypt/zone                                                     ccf69d3f-87be-4f8c-9191-9dde56547b21   none      none          off        
-    oxp_f4d7f914-ec73-4b65-8696-5068591d9065/crypt/zone/oxz_crucible_0dfbf374-9ef9-430f-b06d-f271bf7f84c4   f72e1f0d-0acd-4cde-9acd-f25663592558   none      none          off        
-    oxp_7ed4296a-66d1-4fb2-bc56-9b23b8f27d7e/crypt/zone/oxz_crucible_15c103f0-ac63-423b-ba5d-1b5fcd563ba3   02deac75-eb1a-423e-9b64-d20ca921fc25   none      none          off        
-    oxp_55196665-ed61-4b23-9a74-0711bf2eaf90/crypt/zone/oxz_crucible_23a8fa2b-ef3e-4017-a43f-f7a83953bd7c   3c7c5190-92dd-4d3b-9222-95d82a530d9e   none      none          off        
-    oxp_a5f75431-3795-426c-8f80-176f658281a5/crypt/zone/oxz_crucible_3aa07966-5899-4789-ace5-f8eeb375c6c3   23ff87ad-3d52-4c7e-a9a3-be288d08835c   none      none          off        
-    oxp_e405da11-cb6b-4ebc-bac1-9bc997352e10/crypt/zone/oxz_crucible_72c5a909-077d-4ec1-a9d5-ae64ef9d716e   4f3e0a2b-43df-43f1-9244-a67fe65a4856   none      none          off        
-    oxp_4069c804-c51a-4adc-8822-3cbbab56ed3f/crypt/zone/oxz_crucible_85b8c68a-160d-461d-94dd-1baf175fa75c   7b00d896-de30-48f8-bcb7-b140ffab2781   none      none          off        
-    oxp_984e2389-e7fd-4af9-ab02-e3caf77f95b5/crypt/zone/oxz_crucible_95482c25-1e7f-43e8-adf1-e3548a1b3ae0   5c5d822f-d696-4b6a-a075-286c437deba1   none      none          off        
-    oxp_cf32a1ce-2c9e-49f5-b1cf-4af7f2a28901/crypt/zone/oxz_crucible_c60379ba-4e30-4628-a79a-0ae509aef4c5   a6fcf496-70a1-49bf-a951-62fcec8dd5e2   none      none          off        
-    oxp_5248a306-4a03-449e-a8a3-6f86d26da755/crypt/zone/oxz_crucible_f0ff59e8-4105-4980-a4bb-a1f4c58de1e3   c596346d-4040-4103-b036-8fafdbaada00   none      none          off        
-    oxp_6b2a719a-35eb-469f-aa54-114a1f21f37d/crypt/zone/oxz_crucible_f1a7b9a7-fc6a-4b23-b829-045ff33117ff   c864de0d-9859-4ad1-a30b-f5ac45ba03ed   none      none          off        
-    oxp_4069c804-c51a-4adc-8822-3cbbab56ed3f/crypt/zone/oxz_nexus_a732c489-d29a-4f75-b900-5966385943af      db6c139b-9028-4d8e-92c7-6cc1e9aa0131   none      none          off        
-    oxp_4069c804-c51a-4adc-8822-3cbbab56ed3f/crypt/zone/oxz_ntp_621509d6-3772-4009-aca1-35eefd1098fb        3b5822d2-9918-4bd6-8b75-2f52bdd73189   none      none          off        
-    oxp_4069c804-c51a-4adc-8822-3cbbab56ed3f/crypt/debug                                                    bf9b39db-5a6a-4b45-b2da-c37425271014   100 GiB   none          gzip-9     
-    oxp_5248a306-4a03-449e-a8a3-6f86d26da755/crypt/debug                                                    1b4e8d9e-e447-4df1-8e0b-57edc318e8ad   100 GiB   none          gzip-9     
-    oxp_55196665-ed61-4b23-9a74-0711bf2eaf90/crypt/debug                                                    ae4f4e83-0bd1-48dc-bfe3-f1082e8f357a   100 GiB   none          gzip-9     
-    oxp_6b2a719a-35eb-469f-aa54-114a1f21f37d/crypt/debug                                                    be833d4e-3439-41ac-b3ad-3e4d14a66360   100 GiB   none          gzip-9     
-    oxp_7ed4296a-66d1-4fb2-bc56-9b23b8f27d7e/crypt/debug                                                    a02b70bf-b069-4fec-9f53-1976ba462c45   100 GiB   none          gzip-9     
-    oxp_984e2389-e7fd-4af9-ab02-e3caf77f95b5/crypt/debug                                                    5c79ad9d-1aef-407d-804c-ace1d0e069a4   100 GiB   none          gzip-9     
-    oxp_a5f75431-3795-426c-8f80-176f658281a5/crypt/debug                                                    dbc27904-c6dd-4cdc-96c8-32a24bdba0a1   100 GiB   none          gzip-9     
-    oxp_cf32a1ce-2c9e-49f5-b1cf-4af7f2a28901/crypt/debug                                                    2dfc5c53-6618-4352-b754-86ef6463c20a   100 GiB   none          gzip-9     
-    oxp_e405da11-cb6b-4ebc-bac1-9bc997352e10/crypt/debug                                                    61a653cf-44a6-43c0-90e1-bec539511703   100 GiB   none          gzip-9     
-    oxp_f4d7f914-ec73-4b65-8696-5068591d9065/crypt/debug                                                    b803d901-7e43-42fa-8372-43c3c5b3c1a9   100 GiB   none          gzip-9     
-+   oxp_5248a306-4a03-449e-a8a3-6f86d26da755/crypt/zone/oxz_nexus_508abd03-cbfe-4654-9a6d-7f15a1ad32e5      b781d032-3149-4c44-a7d3-5f8d80e4a607   none      none          off        
-+   oxp_55196665-ed61-4b23-9a74-0711bf2eaf90/crypt/zone/oxz_nexus_99f6d544-8599-4e2b-a55a-82d9e0034662      8a39677a-fbcf-4884-b000-63be3247fb63   none      none          off        
-+   oxp_6b2a719a-35eb-469f-aa54-114a1f21f37d/crypt/zone/oxz_nexus_c26b3bda-5561-44a1-a69f-22103fe209a1      c9c1a582-1fe0-4001-9301-97230387563a   none      none          off        
+    oxp_4069c804-c51a-4adc-8822-3cbbab56ed3f/crucible                                                       081aff15-bc64-4b57-bbcc-287d7267caa4   none      none          off        
+    oxp_5248a306-4a03-449e-a8a3-6f86d26da755/crucible                                                       0beeebcf-b558-47e9-9274-bc3dd4a475b8   none      none          off        
+    oxp_55196665-ed61-4b23-9a74-0711bf2eaf90/crucible                                                       757dd9e5-74db-4860-a87e-0aafd6795b91   none      none          off        
+    oxp_6b2a719a-35eb-469f-aa54-114a1f21f37d/crucible                                                       bd64099e-57f0-447f-9c21-e493e2809372   none      none          off        
+    oxp_7ed4296a-66d1-4fb2-bc56-9b23b8f27d7e/crucible                                                       3bd0565c-1170-4727-824b-f180454e4ff1   none      none          off        
+    oxp_984e2389-e7fd-4af9-ab02-e3caf77f95b5/crucible                                                       010c6c12-6ea3-4bbd-9a69-90209dab73ab   none      none          off        
+    oxp_a5f75431-3795-426c-8f80-176f658281a5/crucible                                                       2dbc8272-64ae-4d2d-ac1f-92f120204ddd   none      none          off        
+    oxp_cf32a1ce-2c9e-49f5-b1cf-4af7f2a28901/crucible                                                       b4e4e724-ddfb-4d0a-bf6b-edd6dd91172d   none      none          off        
+    oxp_e405da11-cb6b-4ebc-bac1-9bc997352e10/crucible                                                       8fdfaea0-1da2-429f-b64e-ef0107f2884d   none      none          off        
+    oxp_f4d7f914-ec73-4b65-8696-5068591d9065/crucible                                                       74dc30b1-2c84-4e9d-910c-938d33f9a537   none      none          off        
+    oxp_4069c804-c51a-4adc-8822-3cbbab56ed3f/crypt/zone                                                     f282431f-2ed2-4386-bc0f-0f3130b175bf   none      none          off        
+    oxp_5248a306-4a03-449e-a8a3-6f86d26da755/crypt/zone                                                     ee3f0e38-23ac-45c6-8157-e611887572a6   none      none          off        
+    oxp_55196665-ed61-4b23-9a74-0711bf2eaf90/crypt/zone                                                     acf672d0-effd-491a-bde8-a4253e078f14   none      none          off        
+    oxp_6b2a719a-35eb-469f-aa54-114a1f21f37d/crypt/zone                                                     d5be658f-367a-4703-a377-7d8067aade3a   none      none          off        
+    oxp_7ed4296a-66d1-4fb2-bc56-9b23b8f27d7e/crypt/zone                                                     adbebdd0-4d0d-4794-9bb5-6681b5119624   none      none          off        
+    oxp_984e2389-e7fd-4af9-ab02-e3caf77f95b5/crypt/zone                                                     1e063fbb-083c-4e2e-a4f5-c40ce854f1d0   none      none          off        
+    oxp_a5f75431-3795-426c-8f80-176f658281a5/crypt/zone                                                     6b476700-d002-4173-8a83-fb24d49be32f   none      none          off        
+    oxp_cf32a1ce-2c9e-49f5-b1cf-4af7f2a28901/crypt/zone                                                     abaa13f5-c3ec-45b2-86da-2be74a259878   none      none          off        
+    oxp_e405da11-cb6b-4ebc-bac1-9bc997352e10/crypt/zone                                                     d8c2da98-ef6d-4746-ae4b-ed537c78fc89   none      none          off        
+    oxp_f4d7f914-ec73-4b65-8696-5068591d9065/crypt/zone                                                     b1c8156e-7490-46d2-a4af-7fc5dd39991d   none      none          off        
+    oxp_6b2a719a-35eb-469f-aa54-114a1f21f37d/crypt/zone/oxz_crucible_05ba6d6e-90a7-402a-aaba-fd92190a9f48   6a6e744c-c4a9-4e58-b0ed-ef44eef0c6e0   none      none          off        
+    oxp_f4d7f914-ec73-4b65-8696-5068591d9065/crypt/zone/oxz_crucible_2097bad3-ee65-4a1c-8fe2-75ed52e69ac8   54941545-0cee-4c36-8516-c63b3cbd02fb   none      none          off        
+    oxp_4069c804-c51a-4adc-8822-3cbbab56ed3f/crypt/zone/oxz_crucible_430c8fe1-7296-4a73-b260-fc185260ec5e   d0ee4ede-c9a6-4d6a-9dbe-63b4c07a9cdd   none      none          off        
+    oxp_cf32a1ce-2c9e-49f5-b1cf-4af7f2a28901/crypt/zone/oxz_crucible_a720288d-3e5b-44b7-9dab-a69a10768e0b   3fa16efe-c488-4d45-92ee-18eeb8b9453f   none      none          off        
+    oxp_a5f75431-3795-426c-8f80-176f658281a5/crypt/zone/oxz_crucible_b2170eef-aa6f-4ec5-aaa9-2b4289eae65c   e20a6e28-7a52-480a-9d36-33f8d4474bf5   none      none          off        
+    oxp_984e2389-e7fd-4af9-ab02-e3caf77f95b5/crypt/zone/oxz_crucible_b505d6e1-07b9-48bf-bc8a-d4081c25b12a   6b965329-4398-4738-84e6-b893f21a724c   none      none          off        
+    oxp_5248a306-4a03-449e-a8a3-6f86d26da755/crypt/zone/oxz_crucible_cbe34d65-017e-4c26-966d-b1ce27bc1d94   8ad4a9ed-7be5-4f49-8a38-1686144ceaf6   none      none          off        
+    oxp_e405da11-cb6b-4ebc-bac1-9bc997352e10/crypt/zone/oxz_crucible_e01462d1-5173-4d95-8477-78ca2157efbb   03fbd010-e16e-48a9-a9a9-5be665c0bdff   none      none          off        
+    oxp_55196665-ed61-4b23-9a74-0711bf2eaf90/crypt/zone/oxz_crucible_e49b0403-3d7c-480f-9113-4bc0fca74a8a   62053fe9-281c-4949-9357-bf818004aef2   none      none          off        
+    oxp_7ed4296a-66d1-4fb2-bc56-9b23b8f27d7e/crypt/zone/oxz_crucible_e6ec9399-b81b-4bdd-8e6e-b0f043aad942   f761d5be-fef1-47d7-850c-1f28a1f8a8b3   none      none          off        
+    oxp_4069c804-c51a-4adc-8822-3cbbab56ed3f/crypt/zone/oxz_nexus_81f79040-bcf7-4eff-9a87-8e7bcb5a6db9      2694f256-cd46-4841-a009-6460f4ca0616   none      none          off        
+    oxp_4069c804-c51a-4adc-8822-3cbbab56ed3f/crypt/zone/oxz_ntp_8f94a160-67ab-4ed5-bc3f-01e19fdd7e9b        225c385b-de3e-4262-a5c4-0250abc910f9   none      none          off        
+    oxp_4069c804-c51a-4adc-8822-3cbbab56ed3f/crypt/debug                                                    041c4e17-e958-41aa-b621-03dd3b3e7da8   100 GiB   none          gzip-9     
+    oxp_5248a306-4a03-449e-a8a3-6f86d26da755/crypt/debug                                                    7e551f2b-ac22-4637-bd2a-188f106b57c0   100 GiB   none          gzip-9     
+    oxp_55196665-ed61-4b23-9a74-0711bf2eaf90/crypt/debug                                                    1e4208d8-041e-49eb-ab6d-dcedceee170c   100 GiB   none          gzip-9     
+    oxp_6b2a719a-35eb-469f-aa54-114a1f21f37d/crypt/debug                                                    0872720b-c454-45f6-8816-2835d595894e   100 GiB   none          gzip-9     
+    oxp_7ed4296a-66d1-4fb2-bc56-9b23b8f27d7e/crypt/debug                                                    fc7195f4-4472-4283-9094-2f6f7db01e71   100 GiB   none          gzip-9     
+    oxp_984e2389-e7fd-4af9-ab02-e3caf77f95b5/crypt/debug                                                    baa19cce-f379-427c-9b5e-c413b050c2d5   100 GiB   none          gzip-9     
+    oxp_a5f75431-3795-426c-8f80-176f658281a5/crypt/debug                                                    5828eb26-b03b-4481-b88d-027a90a24c50   100 GiB   none          gzip-9     
+    oxp_cf32a1ce-2c9e-49f5-b1cf-4af7f2a28901/crypt/debug                                                    5e7deb25-14c2-4633-8728-6eff7833e14f   100 GiB   none          gzip-9     
+    oxp_e405da11-cb6b-4ebc-bac1-9bc997352e10/crypt/debug                                                    e02c1929-a38a-49c2-8909-555c3e046d18   100 GiB   none          gzip-9     
+    oxp_f4d7f914-ec73-4b65-8696-5068591d9065/crypt/debug                                                    0aeb1237-4ad7-41ae-abd2-45789a3ab2f2   100 GiB   none          gzip-9     
++   oxp_6b2a719a-35eb-469f-aa54-114a1f21f37d/crypt/zone/oxz_nexus_2ed23118-6137-45ca-824c-04df3bc3d085      047b92e1-2286-44bb-988e-403f20973ee4   none      none          off        
++   oxp_5248a306-4a03-449e-a8a3-6f86d26da755/crypt/zone/oxz_nexus_33365de5-8a83-46c0-9d34-eddd68e54c6f      4f6d72db-de32-4a55-ae9d-30d776580c33   none      none          off        
++   oxp_55196665-ed61-4b23-9a74-0711bf2eaf90/crypt/zone/oxz_nexus_80e4964b-a8c8-41ef-ae23-f86cfe5f3a7b      6944260c-23fd-47db-8a2c-02196b399f57   none      none          off        
 
 
     omicron zones generation 2 -> 3:
     ------------------------------------------------------------------------------------------
     zone type      zone id                                disposition   underlay IP           
     ------------------------------------------------------------------------------------------
-    crucible       0dfbf374-9ef9-430f-b06d-f271bf7f84c4   in service    fd00:1122:3344:104::2c
-    crucible       15c103f0-ac63-423b-ba5d-1b5fcd563ba3   in service    fd00:1122:3344:104::27
-    crucible       23a8fa2b-ef3e-4017-a43f-f7a83953bd7c   in service    fd00:1122:3344:104::25
-    crucible       3aa07966-5899-4789-ace5-f8eeb375c6c3   in service    fd00:1122:3344:104::29
-    crucible       72c5a909-077d-4ec1-a9d5-ae64ef9d716e   in service    fd00:1122:3344:104::2b
-    crucible       85b8c68a-160d-461d-94dd-1baf175fa75c   in service    fd00:1122:3344:104::23
-    crucible       95482c25-1e7f-43e8-adf1-e3548a1b3ae0   in service    fd00:1122:3344:104::28
-    crucible       c60379ba-4e30-4628-a79a-0ae509aef4c5   in service    fd00:1122:3344:104::2a
-    crucible       f0ff59e8-4105-4980-a4bb-a1f4c58de1e3   in service    fd00:1122:3344:104::24
-    crucible       f1a7b9a7-fc6a-4b23-b829-045ff33117ff   in service    fd00:1122:3344:104::26
-    internal_ntp   621509d6-3772-4009-aca1-35eefd1098fb   in service    fd00:1122:3344:104::21
-    nexus          a732c489-d29a-4f75-b900-5966385943af   in service    fd00:1122:3344:104::22
-+   nexus          508abd03-cbfe-4654-9a6d-7f15a1ad32e5   in service    fd00:1122:3344:104::2d
-+   nexus          99f6d544-8599-4e2b-a55a-82d9e0034662   in service    fd00:1122:3344:104::2e
-+   nexus          c26b3bda-5561-44a1-a69f-22103fe209a1   in service    fd00:1122:3344:104::2f
+    crucible       05ba6d6e-90a7-402a-aaba-fd92190a9f48   in service    fd00:1122:3344:104::26
+    crucible       2097bad3-ee65-4a1c-8fe2-75ed52e69ac8   in service    fd00:1122:3344:104::2c
+    crucible       430c8fe1-7296-4a73-b260-fc185260ec5e   in service    fd00:1122:3344:104::23
+    crucible       a720288d-3e5b-44b7-9dab-a69a10768e0b   in service    fd00:1122:3344:104::2a
+    crucible       b2170eef-aa6f-4ec5-aaa9-2b4289eae65c   in service    fd00:1122:3344:104::29
+    crucible       b505d6e1-07b9-48bf-bc8a-d4081c25b12a   in service    fd00:1122:3344:104::28
+    crucible       cbe34d65-017e-4c26-966d-b1ce27bc1d94   in service    fd00:1122:3344:104::24
+    crucible       e01462d1-5173-4d95-8477-78ca2157efbb   in service    fd00:1122:3344:104::2b
+    crucible       e49b0403-3d7c-480f-9113-4bc0fca74a8a   in service    fd00:1122:3344:104::25
+    crucible       e6ec9399-b81b-4bdd-8e6e-b0f043aad942   in service    fd00:1122:3344:104::27
+    internal_ntp   8f94a160-67ab-4ed5-bc3f-01e19fdd7e9b   in service    fd00:1122:3344:104::21
+    nexus          81f79040-bcf7-4eff-9a87-8e7bcb5a6db9   in service    fd00:1122:3344:104::22
++   nexus          2ed23118-6137-45ca-824c-04df3bc3d085   in service    fd00:1122:3344:104::2f
++   nexus          33365de5-8a83-46c0-9d34-eddd68e54c6f   in service    fd00:1122:3344:104::2d
++   nexus          80e4964b-a8c8-41ef-ae23-f86cfe5f3a7b   in service    fd00:1122:3344:104::2e
 
 
   sled affab35f-600a-4109-8ea0-34a067a4e0bc (active):
@@ -401,72 +401,72 @@ to:   blueprint 9f71f5d3-a272-4382-9154-6ea2e171a6c6
     ----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
     dataset name                                                                                            dataset uuid                           quota     reservation   compression
     ----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
-    oxp_33d48d85-751e-4982-b738-eae4d9a05f01/crucible                                                       cefe1de4-bebb-4ac1-8871-09585baf593d   none      none          off        
-    oxp_39ca2e23-4c38-4743-afe0-26b0380b27db/crucible                                                       3bf64d72-e015-4377-b02a-a094f8f96d57   none      none          off        
-    oxp_4fbd2fe0-2eac-41b8-8e8d-4fa46c3e8b6c/crucible                                                       c35cac80-eb26-4d90-ac3e-879b9d80c04c   none      none          off        
-    oxp_60131a33-1f12-4dbb-9435-bdd368db1f51/crucible                                                       30d7609e-1c74-4002-8558-b62246ee9600   none      none          off        
-    oxp_77e45b5b-869f-4e78-8ce3-28bbe8cf37e9/crucible                                                       eff3d661-6ab1-4966-ab0a-6f94fda0bd39   none      none          off        
-    oxp_789d607d-d196-428e-a988-f7886a327859/crucible                                                       7253d7b0-8954-41f0-b788-9efc41f42742   none      none          off        
-    oxp_b104b94c-2197-4e76-bfbd-6f966bd5af66/crucible                                                       70b8bba8-802a-462a-9aa7-3dcd20a1fbbf   none      none          off        
-    oxp_cd62306a-aedf-47e8-93d5-92a358d64c7b/crucible                                                       3acdbfe5-1226-4752-a14e-9f1e468ade71   none      none          off        
-    oxp_f1693454-aac1-4265-b8a0-4e9f3f41c7b3/crucible                                                       f45ef5d4-14b2-4346-8297-20919d6ee9da   none      none          off        
-    oxp_fe4fdfba-3b6d-47d3-8612-1fb2390b650a/crucible                                                       fa262c74-8870-4038-8b71-b8dfa4adda12   none      none          off        
-    oxp_33d48d85-751e-4982-b738-eae4d9a05f01/crypt/zone                                                     29246ffd-11d0-4afd-8324-4727380185a3   none      none          off        
-    oxp_39ca2e23-4c38-4743-afe0-26b0380b27db/crypt/zone                                                     212dad15-885a-45f6-b7ea-5e2ed8d9186f   none      none          off        
-    oxp_4fbd2fe0-2eac-41b8-8e8d-4fa46c3e8b6c/crypt/zone                                                     e1e73d4f-0138-42dc-9e10-3432b26098f4   none      none          off        
-    oxp_60131a33-1f12-4dbb-9435-bdd368db1f51/crypt/zone                                                     48e191ca-1498-4381-b2dd-675b022d9a86   none      none          off        
-    oxp_77e45b5b-869f-4e78-8ce3-28bbe8cf37e9/crypt/zone                                                     1ce1d218-9f8d-4c13-a1bf-e085c569a4b8   none      none          off        
-    oxp_789d607d-d196-428e-a988-f7886a327859/crypt/zone                                                     d3ae6bfa-bdfd-4a36-9009-4e061be33c0b   none      none          off        
-    oxp_b104b94c-2197-4e76-bfbd-6f966bd5af66/crypt/zone                                                     474256d1-bab1-499a-9679-566accf12f3f   none      none          off        
-    oxp_cd62306a-aedf-47e8-93d5-92a358d64c7b/crypt/zone                                                     6e415c23-e85d-4f5b-b993-43a8f1c56763   none      none          off        
-    oxp_f1693454-aac1-4265-b8a0-4e9f3f41c7b3/crypt/zone                                                     35a43943-68f5-44f8-83a9-c69423b1ab04   none      none          off        
-    oxp_fe4fdfba-3b6d-47d3-8612-1fb2390b650a/crypt/zone                                                     7ec7d64c-c0f8-48fc-905d-fdd9de487672   none      none          off        
-    oxp_b104b94c-2197-4e76-bfbd-6f966bd5af66/crypt/zone/oxz_crucible_414830dc-c8c1-4748-9e9e-bc3a6435a93c   a9351df9-851e-4c85-a7f2-74490471e876   none      none          off        
-    oxp_fe4fdfba-3b6d-47d3-8612-1fb2390b650a/crypt/zone/oxz_crucible_66ecd4a6-73a7-4e26-9711-17abdd67a66e   db8c9c71-bad4-4a12-8ec7-4fe5d63b13ff   none      none          off        
-    oxp_60131a33-1f12-4dbb-9435-bdd368db1f51/crypt/zone/oxz_crucible_772cbcbd-58be-4158-be85-be744871fa22   a7228ebc-840f-4393-94d7-b338dab3d459   none      none          off        
-    oxp_33d48d85-751e-4982-b738-eae4d9a05f01/crypt/zone/oxz_crucible_a1c03689-fc62-4ea5-bb72-4d01f5138614   951bc0b6-8136-4ec3-870b-ffaa4d2ff2f9   none      none          off        
-    oxp_4fbd2fe0-2eac-41b8-8e8d-4fa46c3e8b6c/crypt/zone/oxz_crucible_a568e92e-4fbd-4b69-acd8-f16277073031   b8868d0c-960d-4ae4-b340-2c5970c8d530   none      none          off        
-    oxp_f1693454-aac1-4265-b8a0-4e9f3f41c7b3/crypt/zone/oxz_crucible_a73f322a-9463-4d18-8f60-7ddf6f59f231   c4fa8f96-497e-47ad-9953-6ca3c9a90d25   none      none          off        
-    oxp_77e45b5b-869f-4e78-8ce3-28bbe8cf37e9/crypt/zone/oxz_crucible_be75764a-491b-4aec-992e-1c39e25de975   09d557a8-4a28-4434-bcca-8fa593cc2fec   none      none          off        
-    oxp_cd62306a-aedf-47e8-93d5-92a358d64c7b/crypt/zone/oxz_crucible_be920398-024a-4655-8c49-69b5ac48dfff   87f757d6-fa4c-4423-995c-1eab5e7d09a2   none      none          off        
-    oxp_39ca2e23-4c38-4743-afe0-26b0380b27db/crypt/zone/oxz_crucible_d47f4996-fac0-4657-bcea-01b1fee6404d   c1af262a-2595-4236-98c8-21c5b63c80c3   none      none          off        
-    oxp_789d607d-d196-428e-a988-f7886a327859/crypt/zone/oxz_crucible_e001fea0-6594-4ece-97e3-6198c293e931   5e27b9bc-e69f-4258-83f2-5f9a1109a625   none      none          off        
-    oxp_33d48d85-751e-4982-b738-eae4d9a05f01/crypt/zone/oxz_nexus_4ad0e9da-08f8-4d40-b4d3-d17e711b5bbf      45d32c13-cbbb-4382-a0ed-dc6574b827b7   none      none          off        
-    oxp_33d48d85-751e-4982-b738-eae4d9a05f01/crypt/zone/oxz_ntp_bf79a56a-97af-4cc4-94a5-8b20d64c2cda        a410308c-e2cb-4e4d-9da6-1879336f93f2   none      none          off        
-    oxp_33d48d85-751e-4982-b738-eae4d9a05f01/crypt/debug                                                    755e24a8-67cc-44b1-8c25-2dcb3acd988f   100 GiB   none          gzip-9     
-    oxp_39ca2e23-4c38-4743-afe0-26b0380b27db/crypt/debug                                                    c834f8cd-25ee-4c62-af03-49cef53fc4c1   100 GiB   none          gzip-9     
-    oxp_4fbd2fe0-2eac-41b8-8e8d-4fa46c3e8b6c/crypt/debug                                                    5a288f52-a84e-45a6-873a-3d9c81d67380   100 GiB   none          gzip-9     
-    oxp_60131a33-1f12-4dbb-9435-bdd368db1f51/crypt/debug                                                    078134ea-f776-4283-ae17-116869f304b4   100 GiB   none          gzip-9     
-    oxp_77e45b5b-869f-4e78-8ce3-28bbe8cf37e9/crypt/debug                                                    60a98875-ee39-49d8-b4b8-1f5d168e39e2   100 GiB   none          gzip-9     
-    oxp_789d607d-d196-428e-a988-f7886a327859/crypt/debug                                                    1f7f6932-ed14-482a-816e-b0f76d96603d   100 GiB   none          gzip-9     
-    oxp_b104b94c-2197-4e76-bfbd-6f966bd5af66/crypt/debug                                                    c2eba705-dd3c-49f1-9d7d-abb951cbc722   100 GiB   none          gzip-9     
-    oxp_cd62306a-aedf-47e8-93d5-92a358d64c7b/crypt/debug                                                    73674f4b-1d93-404a-bc9c-8395efac97fd   100 GiB   none          gzip-9     
-    oxp_f1693454-aac1-4265-b8a0-4e9f3f41c7b3/crypt/debug                                                    938737fb-b72f-4727-8833-9697c518ca37   100 GiB   none          gzip-9     
-    oxp_fe4fdfba-3b6d-47d3-8612-1fb2390b650a/crypt/debug                                                    8e58b91f-9ce2-4256-8dec-5f90f31a73fa   100 GiB   none          gzip-9     
-+   oxp_39ca2e23-4c38-4743-afe0-26b0380b27db/crypt/zone/oxz_nexus_2ec75441-3d7d-4b4b-9614-af03de5a3666      cd15e9c9-0238-493a-8b32-926d1cd1bce6   none      none          off        
-+   oxp_60131a33-1f12-4dbb-9435-bdd368db1f51/crypt/zone/oxz_nexus_3ca5292f-8a59-4475-bb72-0f43714d0fff      871b35e6-d234-4a96-bab4-d07314bc6ba2   none      none          off        
-+   oxp_4fbd2fe0-2eac-41b8-8e8d-4fa46c3e8b6c/crypt/zone/oxz_nexus_59950bc8-1497-44dd-8cbf-b6502ba921b2      63ec1a21-2c77-41b5-ad3e-e7bf39207107   none      none          off        
+    oxp_33d48d85-751e-4982-b738-eae4d9a05f01/crucible                                                       e7187a07-3759-4185-8893-36b01e1a7295   none      none          off        
+    oxp_39ca2e23-4c38-4743-afe0-26b0380b27db/crucible                                                       f9901e16-a9e4-4c49-a3b9-464405830043   none      none          off        
+    oxp_4fbd2fe0-2eac-41b8-8e8d-4fa46c3e8b6c/crucible                                                       024a9e5e-f8a8-4b8f-b75e-5b05509fa69a   none      none          off        
+    oxp_60131a33-1f12-4dbb-9435-bdd368db1f51/crucible                                                       22547c0a-a710-4d4c-8984-32445fbf993b   none      none          off        
+    oxp_77e45b5b-869f-4e78-8ce3-28bbe8cf37e9/crucible                                                       dec5883c-1abd-4425-8cc4-b2f57c85cdd4   none      none          off        
+    oxp_789d607d-d196-428e-a988-f7886a327859/crucible                                                       fda176fb-2cea-4646-8601-8d719bcdbda0   none      none          off        
+    oxp_b104b94c-2197-4e76-bfbd-6f966bd5af66/crucible                                                       4ded36d4-7e98-47fe-a0f4-c580e7d1eb21   none      none          off        
+    oxp_cd62306a-aedf-47e8-93d5-92a358d64c7b/crucible                                                       623c87b5-8848-4e42-aa5e-6e706e11cf63   none      none          off        
+    oxp_f1693454-aac1-4265-b8a0-4e9f3f41c7b3/crucible                                                       e98d07df-27a8-4868-a3f9-066ac235516c   none      none          off        
+    oxp_fe4fdfba-3b6d-47d3-8612-1fb2390b650a/crucible                                                       639c96d6-265a-45dc-b03f-c145d2ea8c43   none      none          off        
+    oxp_33d48d85-751e-4982-b738-eae4d9a05f01/crypt/zone                                                     64c4eb2e-82bf-450c-9379-594af3a4794b   none      none          off        
+    oxp_39ca2e23-4c38-4743-afe0-26b0380b27db/crypt/zone                                                     f6c13b9c-4e22-448d-b7b8-04652f06423c   none      none          off        
+    oxp_4fbd2fe0-2eac-41b8-8e8d-4fa46c3e8b6c/crypt/zone                                                     a15671b5-d3f3-43d9-b143-81bcd5170edf   none      none          off        
+    oxp_60131a33-1f12-4dbb-9435-bdd368db1f51/crypt/zone                                                     dd78cd99-4aa3-4946-b4c3-b9fad49c6da6   none      none          off        
+    oxp_77e45b5b-869f-4e78-8ce3-28bbe8cf37e9/crypt/zone                                                     1c30ecb3-32ba-49e7-a3dd-771a75d38c3a   none      none          off        
+    oxp_789d607d-d196-428e-a988-f7886a327859/crypt/zone                                                     7ac707a2-5bcf-49d1-88eb-1c09841082cf   none      none          off        
+    oxp_b104b94c-2197-4e76-bfbd-6f966bd5af66/crypt/zone                                                     b0d96454-0a1d-47ac-9a13-5c4866131c37   none      none          off        
+    oxp_cd62306a-aedf-47e8-93d5-92a358d64c7b/crypt/zone                                                     082509f2-115a-4a71-b8f8-86be21efc081   none      none          off        
+    oxp_f1693454-aac1-4265-b8a0-4e9f3f41c7b3/crypt/zone                                                     01b79cba-881c-4bda-a48d-baaef2fcb122   none      none          off        
+    oxp_fe4fdfba-3b6d-47d3-8612-1fb2390b650a/crypt/zone                                                     32d3d763-0665-4945-a3d0-e3d862f7a718   none      none          off        
+    oxp_b104b94c-2197-4e76-bfbd-6f966bd5af66/crypt/zone/oxz_crucible_1b38728b-8552-435b-b621-359ba20d465b   c02c8635-e2f5-4974-a8b9-f4fdfe231365   none      none          off        
+    oxp_39ca2e23-4c38-4743-afe0-26b0380b27db/crypt/zone/oxz_crucible_31c42e26-3cdf-41a8-8826-ce71a513ed04   4876b95c-457b-4e81-9a04-ca1319429627   none      none          off        
+    oxp_f1693454-aac1-4265-b8a0-4e9f3f41c7b3/crypt/zone/oxz_crucible_4f38e475-396a-4650-a49c-c3cc4acc3ab9   2aff7d20-2a2b-4ded-9e03-eb0d72d29e35   none      none          off        
+    oxp_cd62306a-aedf-47e8-93d5-92a358d64c7b/crypt/zone/oxz_crucible_5cd47e9f-1faf-4afd-970a-18b9076b3407   686fcd72-5da5-4f8c-a740-88866e30b8da   none      none          off        
+    oxp_fe4fdfba-3b6d-47d3-8612-1fb2390b650a/crypt/zone/oxz_crucible_768ab86c-d5d2-4734-a381-02df1032d5e9   d1bbe8aa-aeda-496b-93cd-f330f85da352   none      none          off        
+    oxp_4fbd2fe0-2eac-41b8-8e8d-4fa46c3e8b6c/crypt/zone/oxz_crucible_abbf71e1-6568-42cf-9526-7e31549ba934   782adc3d-3a2f-400d-a6ce-531edc8cf546   none      none          off        
+    oxp_789d607d-d196-428e-a988-f7886a327859/crypt/zone/oxz_crucible_e37d04f9-ed3f-4665-800e-b51ba7d5d306   6c55265b-7515-4259-adf1-ac07f847c2fb   none      none          off        
+    oxp_33d48d85-751e-4982-b738-eae4d9a05f01/crypt/zone/oxz_crucible_e6c28c27-39d2-4aec-bf34-5d9f6b3cbd7f   803ed7a0-bb24-489f-8737-b01ff28e3278   none      none          off        
+    oxp_77e45b5b-869f-4e78-8ce3-28bbe8cf37e9/crypt/zone/oxz_crucible_f19f884a-3e97-458d-b8fb-533882750cd6   b1044d62-0afd-473e-8719-ca3ecb57d801   none      none          off        
+    oxp_60131a33-1f12-4dbb-9435-bdd368db1f51/crypt/zone/oxz_crucible_f54c359e-a980-4996-9462-25a548d96265   518e80f5-3074-44ec-8da3-ea64f3c0ad3e   none      none          off        
+    oxp_33d48d85-751e-4982-b738-eae4d9a05f01/crypt/zone/oxz_nexus_b854f752-383d-4e0b-8557-8c62d22ba994      537edbee-609e-40df-9a10-4c6f57c5f15f   none      none          off        
+    oxp_33d48d85-751e-4982-b738-eae4d9a05f01/crypt/zone/oxz_ntp_706286e2-8b09-42ff-9841-eaef65635eee        617a44e3-250b-4db1-a8e7-e42da46a0a0f   none      none          off        
+    oxp_33d48d85-751e-4982-b738-eae4d9a05f01/crypt/debug                                                    856e98db-f5c6-4cbd-a8ad-c02f59f207d7   100 GiB   none          gzip-9     
+    oxp_39ca2e23-4c38-4743-afe0-26b0380b27db/crypt/debug                                                    f14ef549-31db-4fae-a540-3a50f0fba233   100 GiB   none          gzip-9     
+    oxp_4fbd2fe0-2eac-41b8-8e8d-4fa46c3e8b6c/crypt/debug                                                    e44949f2-403b-4944-b966-de77d4b9365c   100 GiB   none          gzip-9     
+    oxp_60131a33-1f12-4dbb-9435-bdd368db1f51/crypt/debug                                                    425255d5-c1e8-44eb-855f-fe1770e83362   100 GiB   none          gzip-9     
+    oxp_77e45b5b-869f-4e78-8ce3-28bbe8cf37e9/crypt/debug                                                    dc613555-a790-45af-9af4-0127d376f3c6   100 GiB   none          gzip-9     
+    oxp_789d607d-d196-428e-a988-f7886a327859/crypt/debug                                                    4f359243-9639-431f-a0d1-5b2f2d6b5b0d   100 GiB   none          gzip-9     
+    oxp_b104b94c-2197-4e76-bfbd-6f966bd5af66/crypt/debug                                                    1315d3d7-e347-4e68-8381-8c010be44ef0   100 GiB   none          gzip-9     
+    oxp_cd62306a-aedf-47e8-93d5-92a358d64c7b/crypt/debug                                                    0e8321af-4634-4d31-aa79-145f8e171674   100 GiB   none          gzip-9     
+    oxp_f1693454-aac1-4265-b8a0-4e9f3f41c7b3/crypt/debug                                                    5a0f4402-7d87-4b6b-b4d2-72f48000627c   100 GiB   none          gzip-9     
+    oxp_fe4fdfba-3b6d-47d3-8612-1fb2390b650a/crypt/debug                                                    a2120fee-01bd-4f49-8c58-720384b1cbde   100 GiB   none          gzip-9     
++   oxp_4fbd2fe0-2eac-41b8-8e8d-4fa46c3e8b6c/crypt/zone/oxz_nexus_b539cea9-c37c-49ef-874f-170d898187b2      113c40a7-e9fd-492f-814e-528db4fd0e83   none      none          off        
++   oxp_60131a33-1f12-4dbb-9435-bdd368db1f51/crypt/zone/oxz_nexus_c5a0c592-319e-44df-9d00-1ddb1d5ad6aa      61e536fd-043c-4741-aed7-640d18d32b26   none      none          off        
++   oxp_39ca2e23-4c38-4743-afe0-26b0380b27db/crypt/zone/oxz_nexus_cab211e1-3ab1-475f-81fa-984748044d8c      92f259d0-cda4-44e4-bb22-8b82d025d502   none      none          off        
 
 
     omicron zones generation 2 -> 3:
     ------------------------------------------------------------------------------------------
     zone type      zone id                                disposition   underlay IP           
     ------------------------------------------------------------------------------------------
-    crucible       414830dc-c8c1-4748-9e9e-bc3a6435a93c   in service    fd00:1122:3344:101::29
-    crucible       66ecd4a6-73a7-4e26-9711-17abdd67a66e   in service    fd00:1122:3344:101::2c
-    crucible       772cbcbd-58be-4158-be85-be744871fa22   in service    fd00:1122:3344:101::26
-    crucible       a1c03689-fc62-4ea5-bb72-4d01f5138614   in service    fd00:1122:3344:101::23
-    crucible       a568e92e-4fbd-4b69-acd8-f16277073031   in service    fd00:1122:3344:101::25
-    crucible       a73f322a-9463-4d18-8f60-7ddf6f59f231   in service    fd00:1122:3344:101::2b
-    crucible       be75764a-491b-4aec-992e-1c39e25de975   in service    fd00:1122:3344:101::27
-    crucible       be920398-024a-4655-8c49-69b5ac48dfff   in service    fd00:1122:3344:101::2a
-    crucible       d47f4996-fac0-4657-bcea-01b1fee6404d   in service    fd00:1122:3344:101::24
-    crucible       e001fea0-6594-4ece-97e3-6198c293e931   in service    fd00:1122:3344:101::28
-    internal_ntp   bf79a56a-97af-4cc4-94a5-8b20d64c2cda   in service    fd00:1122:3344:101::21
-    nexus          4ad0e9da-08f8-4d40-b4d3-d17e711b5bbf   in service    fd00:1122:3344:101::22
-+   nexus          2ec75441-3d7d-4b4b-9614-af03de5a3666   in service    fd00:1122:3344:101::2d
-+   nexus          3ca5292f-8a59-4475-bb72-0f43714d0fff   in service    fd00:1122:3344:101::2f
-+   nexus          59950bc8-1497-44dd-8cbf-b6502ba921b2   in service    fd00:1122:3344:101::2e
+    crucible       1b38728b-8552-435b-b621-359ba20d465b   in service    fd00:1122:3344:101::29
+    crucible       31c42e26-3cdf-41a8-8826-ce71a513ed04   in service    fd00:1122:3344:101::24
+    crucible       4f38e475-396a-4650-a49c-c3cc4acc3ab9   in service    fd00:1122:3344:101::2b
+    crucible       5cd47e9f-1faf-4afd-970a-18b9076b3407   in service    fd00:1122:3344:101::2a
+    crucible       768ab86c-d5d2-4734-a381-02df1032d5e9   in service    fd00:1122:3344:101::2c
+    crucible       abbf71e1-6568-42cf-9526-7e31549ba934   in service    fd00:1122:3344:101::25
+    crucible       e37d04f9-ed3f-4665-800e-b51ba7d5d306   in service    fd00:1122:3344:101::28
+    crucible       e6c28c27-39d2-4aec-bf34-5d9f6b3cbd7f   in service    fd00:1122:3344:101::23
+    crucible       f19f884a-3e97-458d-b8fb-533882750cd6   in service    fd00:1122:3344:101::27
+    crucible       f54c359e-a980-4996-9462-25a548d96265   in service    fd00:1122:3344:101::26
+    internal_ntp   706286e2-8b09-42ff-9841-eaef65635eee   in service    fd00:1122:3344:101::21
+    nexus          b854f752-383d-4e0b-8557-8c62d22ba994   in service    fd00:1122:3344:101::22
++   nexus          b539cea9-c37c-49ef-874f-170d898187b2   in service    fd00:1122:3344:101::2e
++   nexus          c5a0c592-319e-44df-9d00-1ddb1d5ad6aa   in service    fd00:1122:3344:101::2f
++   nexus          cab211e1-3ab1-475f-81fa-984748044d8c   in service    fd00:1122:3344:101::2d
 
 
  COCKROACHDB SETTINGS:

--- a/nexus/reconfigurator/planning/tests/output/planner_nonprovisionable_2_2a.txt
+++ b/nexus/reconfigurator/planning/tests/output/planner_nonprovisionable_2_2a.txt
@@ -25,72 +25,72 @@ to:   blueprint 9f71f5d3-a272-4382-9154-6ea2e171a6c6
     ----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
     dataset name                                                                                            dataset uuid                           quota     reservation   compression
     ----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
-    oxp_4069c804-c51a-4adc-8822-3cbbab56ed3f/crucible                                                       5c9ef84c-434c-4406-b68a-70e9af65b5a5   none      none          off        
-    oxp_5248a306-4a03-449e-a8a3-6f86d26da755/crucible                                                       182f7cbb-ea53-4057-b85c-667e5d949db5   none      none          off        
-    oxp_55196665-ed61-4b23-9a74-0711bf2eaf90/crucible                                                       931c4336-5ff9-45ce-b71b-9b6e81e16e53   none      none          off        
-    oxp_6b2a719a-35eb-469f-aa54-114a1f21f37d/crucible                                                       11e2e73b-93a1-47f1-aff3-c4dc7667f4f1   none      none          off        
-    oxp_7ed4296a-66d1-4fb2-bc56-9b23b8f27d7e/crucible                                                       bdc3e42b-b28f-42c9-99fa-3f92e8b30a3c   none      none          off        
-    oxp_984e2389-e7fd-4af9-ab02-e3caf77f95b5/crucible                                                       5c956b09-323e-476c-9a71-352154b1f841   none      none          off        
-    oxp_a5f75431-3795-426c-8f80-176f658281a5/crucible                                                       7b4f5c33-6a5a-42f9-8199-69f72761b24d   none      none          off        
-    oxp_cf32a1ce-2c9e-49f5-b1cf-4af7f2a28901/crucible                                                       77279948-9fe2-46f2-af39-0d5b692f5984   none      none          off        
-    oxp_e405da11-cb6b-4ebc-bac1-9bc997352e10/crucible                                                       0f6d5b5f-674d-465e-9b40-d09c6865416a   none      none          off        
-    oxp_f4d7f914-ec73-4b65-8696-5068591d9065/crucible                                                       e7ca75fe-d59c-4324-9053-a6a1566958e2   none      none          off        
-    oxp_4069c804-c51a-4adc-8822-3cbbab56ed3f/crypt/zone                                                     fc0b9a2c-4002-4fff-92f4-b541b7dd18c4   none      none          off        
-    oxp_5248a306-4a03-449e-a8a3-6f86d26da755/crypt/zone                                                     5f097047-8290-438a-b85a-80bc9450b26c   none      none          off        
-    oxp_55196665-ed61-4b23-9a74-0711bf2eaf90/crypt/zone                                                     b19e4e13-79e3-481d-ad80-db076a26b7eb   none      none          off        
-    oxp_6b2a719a-35eb-469f-aa54-114a1f21f37d/crypt/zone                                                     7ab2c8a5-3135-4a51-a232-7af8c72b9d3c   none      none          off        
-    oxp_7ed4296a-66d1-4fb2-bc56-9b23b8f27d7e/crypt/zone                                                     4b69a9a9-2994-433c-9733-05de50d9c2a1   none      none          off        
-    oxp_984e2389-e7fd-4af9-ab02-e3caf77f95b5/crypt/zone                                                     b27f6972-47f0-43e9-a7cb-3a2fcd93798b   none      none          off        
-    oxp_a5f75431-3795-426c-8f80-176f658281a5/crypt/zone                                                     4d913be5-fa91-4b22-b714-53babe093654   none      none          off        
-    oxp_cf32a1ce-2c9e-49f5-b1cf-4af7f2a28901/crypt/zone                                                     e79fbff1-f7fb-4912-9f5c-faca57a6a9c4   none      none          off        
-    oxp_e405da11-cb6b-4ebc-bac1-9bc997352e10/crypt/zone                                                     ffc0cb27-54e5-4d28-8f3d-5f7730fed34a   none      none          off        
-    oxp_f4d7f914-ec73-4b65-8696-5068591d9065/crypt/zone                                                     ccf69d3f-87be-4f8c-9191-9dde56547b21   none      none          off        
-    oxp_f4d7f914-ec73-4b65-8696-5068591d9065/crypt/zone/oxz_crucible_0dfbf374-9ef9-430f-b06d-f271bf7f84c4   f72e1f0d-0acd-4cde-9acd-f25663592558   none      none          off        
-    oxp_7ed4296a-66d1-4fb2-bc56-9b23b8f27d7e/crypt/zone/oxz_crucible_15c103f0-ac63-423b-ba5d-1b5fcd563ba3   02deac75-eb1a-423e-9b64-d20ca921fc25   none      none          off        
-    oxp_55196665-ed61-4b23-9a74-0711bf2eaf90/crypt/zone/oxz_crucible_23a8fa2b-ef3e-4017-a43f-f7a83953bd7c   3c7c5190-92dd-4d3b-9222-95d82a530d9e   none      none          off        
-    oxp_a5f75431-3795-426c-8f80-176f658281a5/crypt/zone/oxz_crucible_3aa07966-5899-4789-ace5-f8eeb375c6c3   23ff87ad-3d52-4c7e-a9a3-be288d08835c   none      none          off        
-    oxp_e405da11-cb6b-4ebc-bac1-9bc997352e10/crypt/zone/oxz_crucible_72c5a909-077d-4ec1-a9d5-ae64ef9d716e   4f3e0a2b-43df-43f1-9244-a67fe65a4856   none      none          off        
-    oxp_4069c804-c51a-4adc-8822-3cbbab56ed3f/crypt/zone/oxz_crucible_85b8c68a-160d-461d-94dd-1baf175fa75c   7b00d896-de30-48f8-bcb7-b140ffab2781   none      none          off        
-    oxp_984e2389-e7fd-4af9-ab02-e3caf77f95b5/crypt/zone/oxz_crucible_95482c25-1e7f-43e8-adf1-e3548a1b3ae0   5c5d822f-d696-4b6a-a075-286c437deba1   none      none          off        
-    oxp_cf32a1ce-2c9e-49f5-b1cf-4af7f2a28901/crypt/zone/oxz_crucible_c60379ba-4e30-4628-a79a-0ae509aef4c5   a6fcf496-70a1-49bf-a951-62fcec8dd5e2   none      none          off        
-    oxp_5248a306-4a03-449e-a8a3-6f86d26da755/crypt/zone/oxz_crucible_f0ff59e8-4105-4980-a4bb-a1f4c58de1e3   c596346d-4040-4103-b036-8fafdbaada00   none      none          off        
-    oxp_6b2a719a-35eb-469f-aa54-114a1f21f37d/crypt/zone/oxz_crucible_f1a7b9a7-fc6a-4b23-b829-045ff33117ff   c864de0d-9859-4ad1-a30b-f5ac45ba03ed   none      none          off        
-    oxp_5248a306-4a03-449e-a8a3-6f86d26da755/crypt/zone/oxz_nexus_508abd03-cbfe-4654-9a6d-7f15a1ad32e5      b781d032-3149-4c44-a7d3-5f8d80e4a607   none      none          off        
-    oxp_55196665-ed61-4b23-9a74-0711bf2eaf90/crypt/zone/oxz_nexus_99f6d544-8599-4e2b-a55a-82d9e0034662      8a39677a-fbcf-4884-b000-63be3247fb63   none      none          off        
-    oxp_4069c804-c51a-4adc-8822-3cbbab56ed3f/crypt/zone/oxz_nexus_a732c489-d29a-4f75-b900-5966385943af      db6c139b-9028-4d8e-92c7-6cc1e9aa0131   none      none          off        
-    oxp_6b2a719a-35eb-469f-aa54-114a1f21f37d/crypt/zone/oxz_nexus_c26b3bda-5561-44a1-a69f-22103fe209a1      c9c1a582-1fe0-4001-9301-97230387563a   none      none          off        
-    oxp_4069c804-c51a-4adc-8822-3cbbab56ed3f/crypt/zone/oxz_ntp_621509d6-3772-4009-aca1-35eefd1098fb        3b5822d2-9918-4bd6-8b75-2f52bdd73189   none      none          off        
-    oxp_4069c804-c51a-4adc-8822-3cbbab56ed3f/crypt/debug                                                    bf9b39db-5a6a-4b45-b2da-c37425271014   100 GiB   none          gzip-9     
-    oxp_5248a306-4a03-449e-a8a3-6f86d26da755/crypt/debug                                                    1b4e8d9e-e447-4df1-8e0b-57edc318e8ad   100 GiB   none          gzip-9     
-    oxp_55196665-ed61-4b23-9a74-0711bf2eaf90/crypt/debug                                                    ae4f4e83-0bd1-48dc-bfe3-f1082e8f357a   100 GiB   none          gzip-9     
-    oxp_6b2a719a-35eb-469f-aa54-114a1f21f37d/crypt/debug                                                    be833d4e-3439-41ac-b3ad-3e4d14a66360   100 GiB   none          gzip-9     
-    oxp_7ed4296a-66d1-4fb2-bc56-9b23b8f27d7e/crypt/debug                                                    a02b70bf-b069-4fec-9f53-1976ba462c45   100 GiB   none          gzip-9     
-    oxp_984e2389-e7fd-4af9-ab02-e3caf77f95b5/crypt/debug                                                    5c79ad9d-1aef-407d-804c-ace1d0e069a4   100 GiB   none          gzip-9     
-    oxp_a5f75431-3795-426c-8f80-176f658281a5/crypt/debug                                                    dbc27904-c6dd-4cdc-96c8-32a24bdba0a1   100 GiB   none          gzip-9     
-    oxp_cf32a1ce-2c9e-49f5-b1cf-4af7f2a28901/crypt/debug                                                    2dfc5c53-6618-4352-b754-86ef6463c20a   100 GiB   none          gzip-9     
-    oxp_e405da11-cb6b-4ebc-bac1-9bc997352e10/crypt/debug                                                    61a653cf-44a6-43c0-90e1-bec539511703   100 GiB   none          gzip-9     
-    oxp_f4d7f914-ec73-4b65-8696-5068591d9065/crypt/debug                                                    b803d901-7e43-42fa-8372-43c3c5b3c1a9   100 GiB   none          gzip-9     
+    oxp_4069c804-c51a-4adc-8822-3cbbab56ed3f/crucible                                                       081aff15-bc64-4b57-bbcc-287d7267caa4   none      none          off        
+    oxp_5248a306-4a03-449e-a8a3-6f86d26da755/crucible                                                       0beeebcf-b558-47e9-9274-bc3dd4a475b8   none      none          off        
+    oxp_55196665-ed61-4b23-9a74-0711bf2eaf90/crucible                                                       757dd9e5-74db-4860-a87e-0aafd6795b91   none      none          off        
+    oxp_6b2a719a-35eb-469f-aa54-114a1f21f37d/crucible                                                       bd64099e-57f0-447f-9c21-e493e2809372   none      none          off        
+    oxp_7ed4296a-66d1-4fb2-bc56-9b23b8f27d7e/crucible                                                       3bd0565c-1170-4727-824b-f180454e4ff1   none      none          off        
+    oxp_984e2389-e7fd-4af9-ab02-e3caf77f95b5/crucible                                                       010c6c12-6ea3-4bbd-9a69-90209dab73ab   none      none          off        
+    oxp_a5f75431-3795-426c-8f80-176f658281a5/crucible                                                       2dbc8272-64ae-4d2d-ac1f-92f120204ddd   none      none          off        
+    oxp_cf32a1ce-2c9e-49f5-b1cf-4af7f2a28901/crucible                                                       b4e4e724-ddfb-4d0a-bf6b-edd6dd91172d   none      none          off        
+    oxp_e405da11-cb6b-4ebc-bac1-9bc997352e10/crucible                                                       8fdfaea0-1da2-429f-b64e-ef0107f2884d   none      none          off        
+    oxp_f4d7f914-ec73-4b65-8696-5068591d9065/crucible                                                       74dc30b1-2c84-4e9d-910c-938d33f9a537   none      none          off        
+    oxp_4069c804-c51a-4adc-8822-3cbbab56ed3f/crypt/zone                                                     f282431f-2ed2-4386-bc0f-0f3130b175bf   none      none          off        
+    oxp_5248a306-4a03-449e-a8a3-6f86d26da755/crypt/zone                                                     ee3f0e38-23ac-45c6-8157-e611887572a6   none      none          off        
+    oxp_55196665-ed61-4b23-9a74-0711bf2eaf90/crypt/zone                                                     acf672d0-effd-491a-bde8-a4253e078f14   none      none          off        
+    oxp_6b2a719a-35eb-469f-aa54-114a1f21f37d/crypt/zone                                                     d5be658f-367a-4703-a377-7d8067aade3a   none      none          off        
+    oxp_7ed4296a-66d1-4fb2-bc56-9b23b8f27d7e/crypt/zone                                                     adbebdd0-4d0d-4794-9bb5-6681b5119624   none      none          off        
+    oxp_984e2389-e7fd-4af9-ab02-e3caf77f95b5/crypt/zone                                                     1e063fbb-083c-4e2e-a4f5-c40ce854f1d0   none      none          off        
+    oxp_a5f75431-3795-426c-8f80-176f658281a5/crypt/zone                                                     6b476700-d002-4173-8a83-fb24d49be32f   none      none          off        
+    oxp_cf32a1ce-2c9e-49f5-b1cf-4af7f2a28901/crypt/zone                                                     abaa13f5-c3ec-45b2-86da-2be74a259878   none      none          off        
+    oxp_e405da11-cb6b-4ebc-bac1-9bc997352e10/crypt/zone                                                     d8c2da98-ef6d-4746-ae4b-ed537c78fc89   none      none          off        
+    oxp_f4d7f914-ec73-4b65-8696-5068591d9065/crypt/zone                                                     b1c8156e-7490-46d2-a4af-7fc5dd39991d   none      none          off        
+    oxp_6b2a719a-35eb-469f-aa54-114a1f21f37d/crypt/zone/oxz_crucible_05ba6d6e-90a7-402a-aaba-fd92190a9f48   6a6e744c-c4a9-4e58-b0ed-ef44eef0c6e0   none      none          off        
+    oxp_f4d7f914-ec73-4b65-8696-5068591d9065/crypt/zone/oxz_crucible_2097bad3-ee65-4a1c-8fe2-75ed52e69ac8   54941545-0cee-4c36-8516-c63b3cbd02fb   none      none          off        
+    oxp_4069c804-c51a-4adc-8822-3cbbab56ed3f/crypt/zone/oxz_crucible_430c8fe1-7296-4a73-b260-fc185260ec5e   d0ee4ede-c9a6-4d6a-9dbe-63b4c07a9cdd   none      none          off        
+    oxp_cf32a1ce-2c9e-49f5-b1cf-4af7f2a28901/crypt/zone/oxz_crucible_a720288d-3e5b-44b7-9dab-a69a10768e0b   3fa16efe-c488-4d45-92ee-18eeb8b9453f   none      none          off        
+    oxp_a5f75431-3795-426c-8f80-176f658281a5/crypt/zone/oxz_crucible_b2170eef-aa6f-4ec5-aaa9-2b4289eae65c   e20a6e28-7a52-480a-9d36-33f8d4474bf5   none      none          off        
+    oxp_984e2389-e7fd-4af9-ab02-e3caf77f95b5/crypt/zone/oxz_crucible_b505d6e1-07b9-48bf-bc8a-d4081c25b12a   6b965329-4398-4738-84e6-b893f21a724c   none      none          off        
+    oxp_5248a306-4a03-449e-a8a3-6f86d26da755/crypt/zone/oxz_crucible_cbe34d65-017e-4c26-966d-b1ce27bc1d94   8ad4a9ed-7be5-4f49-8a38-1686144ceaf6   none      none          off        
+    oxp_e405da11-cb6b-4ebc-bac1-9bc997352e10/crypt/zone/oxz_crucible_e01462d1-5173-4d95-8477-78ca2157efbb   03fbd010-e16e-48a9-a9a9-5be665c0bdff   none      none          off        
+    oxp_55196665-ed61-4b23-9a74-0711bf2eaf90/crypt/zone/oxz_crucible_e49b0403-3d7c-480f-9113-4bc0fca74a8a   62053fe9-281c-4949-9357-bf818004aef2   none      none          off        
+    oxp_7ed4296a-66d1-4fb2-bc56-9b23b8f27d7e/crypt/zone/oxz_crucible_e6ec9399-b81b-4bdd-8e6e-b0f043aad942   f761d5be-fef1-47d7-850c-1f28a1f8a8b3   none      none          off        
+    oxp_6b2a719a-35eb-469f-aa54-114a1f21f37d/crypt/zone/oxz_nexus_2ed23118-6137-45ca-824c-04df3bc3d085      047b92e1-2286-44bb-988e-403f20973ee4   none      none          off        
+    oxp_5248a306-4a03-449e-a8a3-6f86d26da755/crypt/zone/oxz_nexus_33365de5-8a83-46c0-9d34-eddd68e54c6f      4f6d72db-de32-4a55-ae9d-30d776580c33   none      none          off        
+    oxp_55196665-ed61-4b23-9a74-0711bf2eaf90/crypt/zone/oxz_nexus_80e4964b-a8c8-41ef-ae23-f86cfe5f3a7b      6944260c-23fd-47db-8a2c-02196b399f57   none      none          off        
+    oxp_4069c804-c51a-4adc-8822-3cbbab56ed3f/crypt/zone/oxz_nexus_81f79040-bcf7-4eff-9a87-8e7bcb5a6db9      2694f256-cd46-4841-a009-6460f4ca0616   none      none          off        
+    oxp_4069c804-c51a-4adc-8822-3cbbab56ed3f/crypt/zone/oxz_ntp_8f94a160-67ab-4ed5-bc3f-01e19fdd7e9b        225c385b-de3e-4262-a5c4-0250abc910f9   none      none          off        
+    oxp_4069c804-c51a-4adc-8822-3cbbab56ed3f/crypt/debug                                                    041c4e17-e958-41aa-b621-03dd3b3e7da8   100 GiB   none          gzip-9     
+    oxp_5248a306-4a03-449e-a8a3-6f86d26da755/crypt/debug                                                    7e551f2b-ac22-4637-bd2a-188f106b57c0   100 GiB   none          gzip-9     
+    oxp_55196665-ed61-4b23-9a74-0711bf2eaf90/crypt/debug                                                    1e4208d8-041e-49eb-ab6d-dcedceee170c   100 GiB   none          gzip-9     
+    oxp_6b2a719a-35eb-469f-aa54-114a1f21f37d/crypt/debug                                                    0872720b-c454-45f6-8816-2835d595894e   100 GiB   none          gzip-9     
+    oxp_7ed4296a-66d1-4fb2-bc56-9b23b8f27d7e/crypt/debug                                                    fc7195f4-4472-4283-9094-2f6f7db01e71   100 GiB   none          gzip-9     
+    oxp_984e2389-e7fd-4af9-ab02-e3caf77f95b5/crypt/debug                                                    baa19cce-f379-427c-9b5e-c413b050c2d5   100 GiB   none          gzip-9     
+    oxp_a5f75431-3795-426c-8f80-176f658281a5/crypt/debug                                                    5828eb26-b03b-4481-b88d-027a90a24c50   100 GiB   none          gzip-9     
+    oxp_cf32a1ce-2c9e-49f5-b1cf-4af7f2a28901/crypt/debug                                                    5e7deb25-14c2-4633-8728-6eff7833e14f   100 GiB   none          gzip-9     
+    oxp_e405da11-cb6b-4ebc-bac1-9bc997352e10/crypt/debug                                                    e02c1929-a38a-49c2-8909-555c3e046d18   100 GiB   none          gzip-9     
+    oxp_f4d7f914-ec73-4b65-8696-5068591d9065/crypt/debug                                                    0aeb1237-4ad7-41ae-abd2-45789a3ab2f2   100 GiB   none          gzip-9     
 
 
     omicron zones at generation 3:
     ------------------------------------------------------------------------------------------
     zone type      zone id                                disposition   underlay IP           
     ------------------------------------------------------------------------------------------
-    crucible       0dfbf374-9ef9-430f-b06d-f271bf7f84c4   in service    fd00:1122:3344:104::2c
-    crucible       15c103f0-ac63-423b-ba5d-1b5fcd563ba3   in service    fd00:1122:3344:104::27
-    crucible       23a8fa2b-ef3e-4017-a43f-f7a83953bd7c   in service    fd00:1122:3344:104::25
-    crucible       3aa07966-5899-4789-ace5-f8eeb375c6c3   in service    fd00:1122:3344:104::29
-    crucible       72c5a909-077d-4ec1-a9d5-ae64ef9d716e   in service    fd00:1122:3344:104::2b
-    crucible       85b8c68a-160d-461d-94dd-1baf175fa75c   in service    fd00:1122:3344:104::23
-    crucible       95482c25-1e7f-43e8-adf1-e3548a1b3ae0   in service    fd00:1122:3344:104::28
-    crucible       c60379ba-4e30-4628-a79a-0ae509aef4c5   in service    fd00:1122:3344:104::2a
-    crucible       f0ff59e8-4105-4980-a4bb-a1f4c58de1e3   in service    fd00:1122:3344:104::24
-    crucible       f1a7b9a7-fc6a-4b23-b829-045ff33117ff   in service    fd00:1122:3344:104::26
-    internal_ntp   621509d6-3772-4009-aca1-35eefd1098fb   in service    fd00:1122:3344:104::21
-    nexus          508abd03-cbfe-4654-9a6d-7f15a1ad32e5   in service    fd00:1122:3344:104::2d
-    nexus          99f6d544-8599-4e2b-a55a-82d9e0034662   in service    fd00:1122:3344:104::2e
-    nexus          a732c489-d29a-4f75-b900-5966385943af   in service    fd00:1122:3344:104::22
-    nexus          c26b3bda-5561-44a1-a69f-22103fe209a1   in service    fd00:1122:3344:104::2f
+    crucible       05ba6d6e-90a7-402a-aaba-fd92190a9f48   in service    fd00:1122:3344:104::26
+    crucible       2097bad3-ee65-4a1c-8fe2-75ed52e69ac8   in service    fd00:1122:3344:104::2c
+    crucible       430c8fe1-7296-4a73-b260-fc185260ec5e   in service    fd00:1122:3344:104::23
+    crucible       a720288d-3e5b-44b7-9dab-a69a10768e0b   in service    fd00:1122:3344:104::2a
+    crucible       b2170eef-aa6f-4ec5-aaa9-2b4289eae65c   in service    fd00:1122:3344:104::29
+    crucible       b505d6e1-07b9-48bf-bc8a-d4081c25b12a   in service    fd00:1122:3344:104::28
+    crucible       cbe34d65-017e-4c26-966d-b1ce27bc1d94   in service    fd00:1122:3344:104::24
+    crucible       e01462d1-5173-4d95-8477-78ca2157efbb   in service    fd00:1122:3344:104::2b
+    crucible       e49b0403-3d7c-480f-9113-4bc0fca74a8a   in service    fd00:1122:3344:104::25
+    crucible       e6ec9399-b81b-4bdd-8e6e-b0f043aad942   in service    fd00:1122:3344:104::27
+    internal_ntp   8f94a160-67ab-4ed5-bc3f-01e19fdd7e9b   in service    fd00:1122:3344:104::21
+    nexus          2ed23118-6137-45ca-824c-04df3bc3d085   in service    fd00:1122:3344:104::2f
+    nexus          33365de5-8a83-46c0-9d34-eddd68e54c6f   in service    fd00:1122:3344:104::2d
+    nexus          80e4964b-a8c8-41ef-ae23-f86cfe5f3a7b   in service    fd00:1122:3344:104::2e
+    nexus          81f79040-bcf7-4eff-9a87-8e7bcb5a6db9   in service    fd00:1122:3344:104::22
 
 
   sled affab35f-600a-4109-8ea0-34a067a4e0bc (active):
@@ -115,72 +115,72 @@ to:   blueprint 9f71f5d3-a272-4382-9154-6ea2e171a6c6
     ----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
     dataset name                                                                                            dataset uuid                           quota     reservation   compression
     ----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
-    oxp_33d48d85-751e-4982-b738-eae4d9a05f01/crucible                                                       cefe1de4-bebb-4ac1-8871-09585baf593d   none      none          off        
-    oxp_39ca2e23-4c38-4743-afe0-26b0380b27db/crucible                                                       3bf64d72-e015-4377-b02a-a094f8f96d57   none      none          off        
-    oxp_4fbd2fe0-2eac-41b8-8e8d-4fa46c3e8b6c/crucible                                                       c35cac80-eb26-4d90-ac3e-879b9d80c04c   none      none          off        
-    oxp_60131a33-1f12-4dbb-9435-bdd368db1f51/crucible                                                       30d7609e-1c74-4002-8558-b62246ee9600   none      none          off        
-    oxp_77e45b5b-869f-4e78-8ce3-28bbe8cf37e9/crucible                                                       eff3d661-6ab1-4966-ab0a-6f94fda0bd39   none      none          off        
-    oxp_789d607d-d196-428e-a988-f7886a327859/crucible                                                       7253d7b0-8954-41f0-b788-9efc41f42742   none      none          off        
-    oxp_b104b94c-2197-4e76-bfbd-6f966bd5af66/crucible                                                       70b8bba8-802a-462a-9aa7-3dcd20a1fbbf   none      none          off        
-    oxp_cd62306a-aedf-47e8-93d5-92a358d64c7b/crucible                                                       3acdbfe5-1226-4752-a14e-9f1e468ade71   none      none          off        
-    oxp_f1693454-aac1-4265-b8a0-4e9f3f41c7b3/crucible                                                       f45ef5d4-14b2-4346-8297-20919d6ee9da   none      none          off        
-    oxp_fe4fdfba-3b6d-47d3-8612-1fb2390b650a/crucible                                                       fa262c74-8870-4038-8b71-b8dfa4adda12   none      none          off        
-    oxp_33d48d85-751e-4982-b738-eae4d9a05f01/crypt/zone                                                     29246ffd-11d0-4afd-8324-4727380185a3   none      none          off        
-    oxp_39ca2e23-4c38-4743-afe0-26b0380b27db/crypt/zone                                                     212dad15-885a-45f6-b7ea-5e2ed8d9186f   none      none          off        
-    oxp_4fbd2fe0-2eac-41b8-8e8d-4fa46c3e8b6c/crypt/zone                                                     e1e73d4f-0138-42dc-9e10-3432b26098f4   none      none          off        
-    oxp_60131a33-1f12-4dbb-9435-bdd368db1f51/crypt/zone                                                     48e191ca-1498-4381-b2dd-675b022d9a86   none      none          off        
-    oxp_77e45b5b-869f-4e78-8ce3-28bbe8cf37e9/crypt/zone                                                     1ce1d218-9f8d-4c13-a1bf-e085c569a4b8   none      none          off        
-    oxp_789d607d-d196-428e-a988-f7886a327859/crypt/zone                                                     d3ae6bfa-bdfd-4a36-9009-4e061be33c0b   none      none          off        
-    oxp_b104b94c-2197-4e76-bfbd-6f966bd5af66/crypt/zone                                                     474256d1-bab1-499a-9679-566accf12f3f   none      none          off        
-    oxp_cd62306a-aedf-47e8-93d5-92a358d64c7b/crypt/zone                                                     6e415c23-e85d-4f5b-b993-43a8f1c56763   none      none          off        
-    oxp_f1693454-aac1-4265-b8a0-4e9f3f41c7b3/crypt/zone                                                     35a43943-68f5-44f8-83a9-c69423b1ab04   none      none          off        
-    oxp_fe4fdfba-3b6d-47d3-8612-1fb2390b650a/crypt/zone                                                     7ec7d64c-c0f8-48fc-905d-fdd9de487672   none      none          off        
-    oxp_b104b94c-2197-4e76-bfbd-6f966bd5af66/crypt/zone/oxz_crucible_414830dc-c8c1-4748-9e9e-bc3a6435a93c   a9351df9-851e-4c85-a7f2-74490471e876   none      none          off        
-    oxp_fe4fdfba-3b6d-47d3-8612-1fb2390b650a/crypt/zone/oxz_crucible_66ecd4a6-73a7-4e26-9711-17abdd67a66e   db8c9c71-bad4-4a12-8ec7-4fe5d63b13ff   none      none          off        
-    oxp_60131a33-1f12-4dbb-9435-bdd368db1f51/crypt/zone/oxz_crucible_772cbcbd-58be-4158-be85-be744871fa22   a7228ebc-840f-4393-94d7-b338dab3d459   none      none          off        
-    oxp_33d48d85-751e-4982-b738-eae4d9a05f01/crypt/zone/oxz_crucible_a1c03689-fc62-4ea5-bb72-4d01f5138614   951bc0b6-8136-4ec3-870b-ffaa4d2ff2f9   none      none          off        
-    oxp_4fbd2fe0-2eac-41b8-8e8d-4fa46c3e8b6c/crypt/zone/oxz_crucible_a568e92e-4fbd-4b69-acd8-f16277073031   b8868d0c-960d-4ae4-b340-2c5970c8d530   none      none          off        
-    oxp_f1693454-aac1-4265-b8a0-4e9f3f41c7b3/crypt/zone/oxz_crucible_a73f322a-9463-4d18-8f60-7ddf6f59f231   c4fa8f96-497e-47ad-9953-6ca3c9a90d25   none      none          off        
-    oxp_77e45b5b-869f-4e78-8ce3-28bbe8cf37e9/crypt/zone/oxz_crucible_be75764a-491b-4aec-992e-1c39e25de975   09d557a8-4a28-4434-bcca-8fa593cc2fec   none      none          off        
-    oxp_cd62306a-aedf-47e8-93d5-92a358d64c7b/crypt/zone/oxz_crucible_be920398-024a-4655-8c49-69b5ac48dfff   87f757d6-fa4c-4423-995c-1eab5e7d09a2   none      none          off        
-    oxp_39ca2e23-4c38-4743-afe0-26b0380b27db/crypt/zone/oxz_crucible_d47f4996-fac0-4657-bcea-01b1fee6404d   c1af262a-2595-4236-98c8-21c5b63c80c3   none      none          off        
-    oxp_789d607d-d196-428e-a988-f7886a327859/crypt/zone/oxz_crucible_e001fea0-6594-4ece-97e3-6198c293e931   5e27b9bc-e69f-4258-83f2-5f9a1109a625   none      none          off        
-    oxp_39ca2e23-4c38-4743-afe0-26b0380b27db/crypt/zone/oxz_nexus_2ec75441-3d7d-4b4b-9614-af03de5a3666      cd15e9c9-0238-493a-8b32-926d1cd1bce6   none      none          off        
-    oxp_60131a33-1f12-4dbb-9435-bdd368db1f51/crypt/zone/oxz_nexus_3ca5292f-8a59-4475-bb72-0f43714d0fff      871b35e6-d234-4a96-bab4-d07314bc6ba2   none      none          off        
-    oxp_33d48d85-751e-4982-b738-eae4d9a05f01/crypt/zone/oxz_nexus_4ad0e9da-08f8-4d40-b4d3-d17e711b5bbf      45d32c13-cbbb-4382-a0ed-dc6574b827b7   none      none          off        
-    oxp_4fbd2fe0-2eac-41b8-8e8d-4fa46c3e8b6c/crypt/zone/oxz_nexus_59950bc8-1497-44dd-8cbf-b6502ba921b2      63ec1a21-2c77-41b5-ad3e-e7bf39207107   none      none          off        
-    oxp_33d48d85-751e-4982-b738-eae4d9a05f01/crypt/zone/oxz_ntp_bf79a56a-97af-4cc4-94a5-8b20d64c2cda        a410308c-e2cb-4e4d-9da6-1879336f93f2   none      none          off        
-    oxp_33d48d85-751e-4982-b738-eae4d9a05f01/crypt/debug                                                    755e24a8-67cc-44b1-8c25-2dcb3acd988f   100 GiB   none          gzip-9     
-    oxp_39ca2e23-4c38-4743-afe0-26b0380b27db/crypt/debug                                                    c834f8cd-25ee-4c62-af03-49cef53fc4c1   100 GiB   none          gzip-9     
-    oxp_4fbd2fe0-2eac-41b8-8e8d-4fa46c3e8b6c/crypt/debug                                                    5a288f52-a84e-45a6-873a-3d9c81d67380   100 GiB   none          gzip-9     
-    oxp_60131a33-1f12-4dbb-9435-bdd368db1f51/crypt/debug                                                    078134ea-f776-4283-ae17-116869f304b4   100 GiB   none          gzip-9     
-    oxp_77e45b5b-869f-4e78-8ce3-28bbe8cf37e9/crypt/debug                                                    60a98875-ee39-49d8-b4b8-1f5d168e39e2   100 GiB   none          gzip-9     
-    oxp_789d607d-d196-428e-a988-f7886a327859/crypt/debug                                                    1f7f6932-ed14-482a-816e-b0f76d96603d   100 GiB   none          gzip-9     
-    oxp_b104b94c-2197-4e76-bfbd-6f966bd5af66/crypt/debug                                                    c2eba705-dd3c-49f1-9d7d-abb951cbc722   100 GiB   none          gzip-9     
-    oxp_cd62306a-aedf-47e8-93d5-92a358d64c7b/crypt/debug                                                    73674f4b-1d93-404a-bc9c-8395efac97fd   100 GiB   none          gzip-9     
-    oxp_f1693454-aac1-4265-b8a0-4e9f3f41c7b3/crypt/debug                                                    938737fb-b72f-4727-8833-9697c518ca37   100 GiB   none          gzip-9     
-    oxp_fe4fdfba-3b6d-47d3-8612-1fb2390b650a/crypt/debug                                                    8e58b91f-9ce2-4256-8dec-5f90f31a73fa   100 GiB   none          gzip-9     
+    oxp_33d48d85-751e-4982-b738-eae4d9a05f01/crucible                                                       e7187a07-3759-4185-8893-36b01e1a7295   none      none          off        
+    oxp_39ca2e23-4c38-4743-afe0-26b0380b27db/crucible                                                       f9901e16-a9e4-4c49-a3b9-464405830043   none      none          off        
+    oxp_4fbd2fe0-2eac-41b8-8e8d-4fa46c3e8b6c/crucible                                                       024a9e5e-f8a8-4b8f-b75e-5b05509fa69a   none      none          off        
+    oxp_60131a33-1f12-4dbb-9435-bdd368db1f51/crucible                                                       22547c0a-a710-4d4c-8984-32445fbf993b   none      none          off        
+    oxp_77e45b5b-869f-4e78-8ce3-28bbe8cf37e9/crucible                                                       dec5883c-1abd-4425-8cc4-b2f57c85cdd4   none      none          off        
+    oxp_789d607d-d196-428e-a988-f7886a327859/crucible                                                       fda176fb-2cea-4646-8601-8d719bcdbda0   none      none          off        
+    oxp_b104b94c-2197-4e76-bfbd-6f966bd5af66/crucible                                                       4ded36d4-7e98-47fe-a0f4-c580e7d1eb21   none      none          off        
+    oxp_cd62306a-aedf-47e8-93d5-92a358d64c7b/crucible                                                       623c87b5-8848-4e42-aa5e-6e706e11cf63   none      none          off        
+    oxp_f1693454-aac1-4265-b8a0-4e9f3f41c7b3/crucible                                                       e98d07df-27a8-4868-a3f9-066ac235516c   none      none          off        
+    oxp_fe4fdfba-3b6d-47d3-8612-1fb2390b650a/crucible                                                       639c96d6-265a-45dc-b03f-c145d2ea8c43   none      none          off        
+    oxp_33d48d85-751e-4982-b738-eae4d9a05f01/crypt/zone                                                     64c4eb2e-82bf-450c-9379-594af3a4794b   none      none          off        
+    oxp_39ca2e23-4c38-4743-afe0-26b0380b27db/crypt/zone                                                     f6c13b9c-4e22-448d-b7b8-04652f06423c   none      none          off        
+    oxp_4fbd2fe0-2eac-41b8-8e8d-4fa46c3e8b6c/crypt/zone                                                     a15671b5-d3f3-43d9-b143-81bcd5170edf   none      none          off        
+    oxp_60131a33-1f12-4dbb-9435-bdd368db1f51/crypt/zone                                                     dd78cd99-4aa3-4946-b4c3-b9fad49c6da6   none      none          off        
+    oxp_77e45b5b-869f-4e78-8ce3-28bbe8cf37e9/crypt/zone                                                     1c30ecb3-32ba-49e7-a3dd-771a75d38c3a   none      none          off        
+    oxp_789d607d-d196-428e-a988-f7886a327859/crypt/zone                                                     7ac707a2-5bcf-49d1-88eb-1c09841082cf   none      none          off        
+    oxp_b104b94c-2197-4e76-bfbd-6f966bd5af66/crypt/zone                                                     b0d96454-0a1d-47ac-9a13-5c4866131c37   none      none          off        
+    oxp_cd62306a-aedf-47e8-93d5-92a358d64c7b/crypt/zone                                                     082509f2-115a-4a71-b8f8-86be21efc081   none      none          off        
+    oxp_f1693454-aac1-4265-b8a0-4e9f3f41c7b3/crypt/zone                                                     01b79cba-881c-4bda-a48d-baaef2fcb122   none      none          off        
+    oxp_fe4fdfba-3b6d-47d3-8612-1fb2390b650a/crypt/zone                                                     32d3d763-0665-4945-a3d0-e3d862f7a718   none      none          off        
+    oxp_b104b94c-2197-4e76-bfbd-6f966bd5af66/crypt/zone/oxz_crucible_1b38728b-8552-435b-b621-359ba20d465b   c02c8635-e2f5-4974-a8b9-f4fdfe231365   none      none          off        
+    oxp_39ca2e23-4c38-4743-afe0-26b0380b27db/crypt/zone/oxz_crucible_31c42e26-3cdf-41a8-8826-ce71a513ed04   4876b95c-457b-4e81-9a04-ca1319429627   none      none          off        
+    oxp_f1693454-aac1-4265-b8a0-4e9f3f41c7b3/crypt/zone/oxz_crucible_4f38e475-396a-4650-a49c-c3cc4acc3ab9   2aff7d20-2a2b-4ded-9e03-eb0d72d29e35   none      none          off        
+    oxp_cd62306a-aedf-47e8-93d5-92a358d64c7b/crypt/zone/oxz_crucible_5cd47e9f-1faf-4afd-970a-18b9076b3407   686fcd72-5da5-4f8c-a740-88866e30b8da   none      none          off        
+    oxp_fe4fdfba-3b6d-47d3-8612-1fb2390b650a/crypt/zone/oxz_crucible_768ab86c-d5d2-4734-a381-02df1032d5e9   d1bbe8aa-aeda-496b-93cd-f330f85da352   none      none          off        
+    oxp_4fbd2fe0-2eac-41b8-8e8d-4fa46c3e8b6c/crypt/zone/oxz_crucible_abbf71e1-6568-42cf-9526-7e31549ba934   782adc3d-3a2f-400d-a6ce-531edc8cf546   none      none          off        
+    oxp_789d607d-d196-428e-a988-f7886a327859/crypt/zone/oxz_crucible_e37d04f9-ed3f-4665-800e-b51ba7d5d306   6c55265b-7515-4259-adf1-ac07f847c2fb   none      none          off        
+    oxp_33d48d85-751e-4982-b738-eae4d9a05f01/crypt/zone/oxz_crucible_e6c28c27-39d2-4aec-bf34-5d9f6b3cbd7f   803ed7a0-bb24-489f-8737-b01ff28e3278   none      none          off        
+    oxp_77e45b5b-869f-4e78-8ce3-28bbe8cf37e9/crypt/zone/oxz_crucible_f19f884a-3e97-458d-b8fb-533882750cd6   b1044d62-0afd-473e-8719-ca3ecb57d801   none      none          off        
+    oxp_60131a33-1f12-4dbb-9435-bdd368db1f51/crypt/zone/oxz_crucible_f54c359e-a980-4996-9462-25a548d96265   518e80f5-3074-44ec-8da3-ea64f3c0ad3e   none      none          off        
+    oxp_4fbd2fe0-2eac-41b8-8e8d-4fa46c3e8b6c/crypt/zone/oxz_nexus_b539cea9-c37c-49ef-874f-170d898187b2      113c40a7-e9fd-492f-814e-528db4fd0e83   none      none          off        
+    oxp_33d48d85-751e-4982-b738-eae4d9a05f01/crypt/zone/oxz_nexus_b854f752-383d-4e0b-8557-8c62d22ba994      537edbee-609e-40df-9a10-4c6f57c5f15f   none      none          off        
+    oxp_60131a33-1f12-4dbb-9435-bdd368db1f51/crypt/zone/oxz_nexus_c5a0c592-319e-44df-9d00-1ddb1d5ad6aa      61e536fd-043c-4741-aed7-640d18d32b26   none      none          off        
+    oxp_39ca2e23-4c38-4743-afe0-26b0380b27db/crypt/zone/oxz_nexus_cab211e1-3ab1-475f-81fa-984748044d8c      92f259d0-cda4-44e4-bb22-8b82d025d502   none      none          off        
+    oxp_33d48d85-751e-4982-b738-eae4d9a05f01/crypt/zone/oxz_ntp_706286e2-8b09-42ff-9841-eaef65635eee        617a44e3-250b-4db1-a8e7-e42da46a0a0f   none      none          off        
+    oxp_33d48d85-751e-4982-b738-eae4d9a05f01/crypt/debug                                                    856e98db-f5c6-4cbd-a8ad-c02f59f207d7   100 GiB   none          gzip-9     
+    oxp_39ca2e23-4c38-4743-afe0-26b0380b27db/crypt/debug                                                    f14ef549-31db-4fae-a540-3a50f0fba233   100 GiB   none          gzip-9     
+    oxp_4fbd2fe0-2eac-41b8-8e8d-4fa46c3e8b6c/crypt/debug                                                    e44949f2-403b-4944-b966-de77d4b9365c   100 GiB   none          gzip-9     
+    oxp_60131a33-1f12-4dbb-9435-bdd368db1f51/crypt/debug                                                    425255d5-c1e8-44eb-855f-fe1770e83362   100 GiB   none          gzip-9     
+    oxp_77e45b5b-869f-4e78-8ce3-28bbe8cf37e9/crypt/debug                                                    dc613555-a790-45af-9af4-0127d376f3c6   100 GiB   none          gzip-9     
+    oxp_789d607d-d196-428e-a988-f7886a327859/crypt/debug                                                    4f359243-9639-431f-a0d1-5b2f2d6b5b0d   100 GiB   none          gzip-9     
+    oxp_b104b94c-2197-4e76-bfbd-6f966bd5af66/crypt/debug                                                    1315d3d7-e347-4e68-8381-8c010be44ef0   100 GiB   none          gzip-9     
+    oxp_cd62306a-aedf-47e8-93d5-92a358d64c7b/crypt/debug                                                    0e8321af-4634-4d31-aa79-145f8e171674   100 GiB   none          gzip-9     
+    oxp_f1693454-aac1-4265-b8a0-4e9f3f41c7b3/crypt/debug                                                    5a0f4402-7d87-4b6b-b4d2-72f48000627c   100 GiB   none          gzip-9     
+    oxp_fe4fdfba-3b6d-47d3-8612-1fb2390b650a/crypt/debug                                                    a2120fee-01bd-4f49-8c58-720384b1cbde   100 GiB   none          gzip-9     
 
 
     omicron zones at generation 3:
     ------------------------------------------------------------------------------------------
     zone type      zone id                                disposition   underlay IP           
     ------------------------------------------------------------------------------------------
-    crucible       414830dc-c8c1-4748-9e9e-bc3a6435a93c   in service    fd00:1122:3344:101::29
-    crucible       66ecd4a6-73a7-4e26-9711-17abdd67a66e   in service    fd00:1122:3344:101::2c
-    crucible       772cbcbd-58be-4158-be85-be744871fa22   in service    fd00:1122:3344:101::26
-    crucible       a1c03689-fc62-4ea5-bb72-4d01f5138614   in service    fd00:1122:3344:101::23
-    crucible       a568e92e-4fbd-4b69-acd8-f16277073031   in service    fd00:1122:3344:101::25
-    crucible       a73f322a-9463-4d18-8f60-7ddf6f59f231   in service    fd00:1122:3344:101::2b
-    crucible       be75764a-491b-4aec-992e-1c39e25de975   in service    fd00:1122:3344:101::27
-    crucible       be920398-024a-4655-8c49-69b5ac48dfff   in service    fd00:1122:3344:101::2a
-    crucible       d47f4996-fac0-4657-bcea-01b1fee6404d   in service    fd00:1122:3344:101::24
-    crucible       e001fea0-6594-4ece-97e3-6198c293e931   in service    fd00:1122:3344:101::28
-    internal_ntp   bf79a56a-97af-4cc4-94a5-8b20d64c2cda   in service    fd00:1122:3344:101::21
-    nexus          2ec75441-3d7d-4b4b-9614-af03de5a3666   in service    fd00:1122:3344:101::2d
-    nexus          3ca5292f-8a59-4475-bb72-0f43714d0fff   in service    fd00:1122:3344:101::2f
-    nexus          4ad0e9da-08f8-4d40-b4d3-d17e711b5bbf   in service    fd00:1122:3344:101::22
-    nexus          59950bc8-1497-44dd-8cbf-b6502ba921b2   in service    fd00:1122:3344:101::2e
+    crucible       1b38728b-8552-435b-b621-359ba20d465b   in service    fd00:1122:3344:101::29
+    crucible       31c42e26-3cdf-41a8-8826-ce71a513ed04   in service    fd00:1122:3344:101::24
+    crucible       4f38e475-396a-4650-a49c-c3cc4acc3ab9   in service    fd00:1122:3344:101::2b
+    crucible       5cd47e9f-1faf-4afd-970a-18b9076b3407   in service    fd00:1122:3344:101::2a
+    crucible       768ab86c-d5d2-4734-a381-02df1032d5e9   in service    fd00:1122:3344:101::2c
+    crucible       abbf71e1-6568-42cf-9526-7e31549ba934   in service    fd00:1122:3344:101::25
+    crucible       e37d04f9-ed3f-4665-800e-b51ba7d5d306   in service    fd00:1122:3344:101::28
+    crucible       e6c28c27-39d2-4aec-bf34-5d9f6b3cbd7f   in service    fd00:1122:3344:101::23
+    crucible       f19f884a-3e97-458d-b8fb-533882750cd6   in service    fd00:1122:3344:101::27
+    crucible       f54c359e-a980-4996-9462-25a548d96265   in service    fd00:1122:3344:101::26
+    internal_ntp   706286e2-8b09-42ff-9841-eaef65635eee   in service    fd00:1122:3344:101::21
+    nexus          b539cea9-c37c-49ef-874f-170d898187b2   in service    fd00:1122:3344:101::2e
+    nexus          b854f752-383d-4e0b-8557-8c62d22ba994   in service    fd00:1122:3344:101::22
+    nexus          c5a0c592-319e-44df-9d00-1ddb1d5ad6aa   in service    fd00:1122:3344:101::2f
+    nexus          cab211e1-3ab1-475f-81fa-984748044d8c   in service    fd00:1122:3344:101::2d
 
 
  REMOVED SLEDS:
@@ -191,20 +191,20 @@ to:   blueprint 9f71f5d3-a272-4382-9154-6ea2e171a6c6
     ---------------------------------------------------------------------------------------------
     zone type         zone id                                disposition   underlay IP           
     ---------------------------------------------------------------------------------------------
--   crucible          15bb9def-69b8-4d2e-b04f-9fee1143387c   expunged      fd00:1122:3344:102::2b
--   crucible          3b3c14b6-a8e2-4054-a577-8d96cb576230   expunged      fd00:1122:3344:102::26
--   crucible          57b96d5c-b71e-43e4-8869-7d514003d00d   expunged      fd00:1122:3344:102::27
--   crucible          8d4d2b28-82bb-4e36-80da-1408d8c35d82   expunged      fd00:1122:3344:102::25
--   crucible          996d7570-b0df-46d5-aaa4-0c97697cf484   expunged      fd00:1122:3344:102::2c
--   crucible          b1783e95-9598-451d-b6ba-c50b52b428c3   expunged      fd00:1122:3344:102::2a
--   crucible          b4947d31-f70e-4ee0-8817-0ca6cea9b16b   expunged      fd00:1122:3344:102::28
--   crucible          c407795c-6c8b-428e-8ab8-b962913c447f   expunged      fd00:1122:3344:102::24
--   crucible          c6dd531e-2d1d-423b-acc8-358533dab78c   expunged      fd00:1122:3344:102::2d
--   crucible          e4b3e159-3dbe-48cb-8497-e3da92a90e5a   expunged      fd00:1122:3344:102::29
--   crucible_pantry   6939ce48-b17c-4616-b176-8a419a7697be   expunged      fd00:1122:3344:102::23
--   internal_dns      b6b759d0-f60d-42b7-bbbc-9d61c9e895a9   expunged      fd00:1122:3344:3::1   
--   internal_ntp      9fd52961-426f-4e62-a644-b70871103fca   expunged      fd00:1122:3344:102::21
--   nexus             b44cdbc0-0ce0-46eb-8b21-a09e113aa1d0   expunged      fd00:1122:3344:102::22
+-   crucible          258c5106-ebcd-4651-96e4-d5b0895691f6   expunged      fd00:1122:3344:102::25
+-   crucible          2b046f65-00f5-46da-988c-90c1de32a1dd   expunged      fd00:1122:3344:102::2a
+-   crucible          30c770a8-625e-4864-8977-d83a11c1c596   expunged      fd00:1122:3344:102::2d
+-   crucible          35e3587d-25d3-4234-822f-2d68713b8cbf   expunged      fd00:1122:3344:102::27
+-   crucible          46293b15-fd26-48f9-9ccb-122fa0ef41b4   expunged      fd00:1122:3344:102::28
+-   crucible          462c6b8d-1872-4671-b84a-bdcbb69e3baf   expunged      fd00:1122:3344:102::24
+-   crucible          a046c5f9-25e7-47c3-9c67-43d68fb39c5e   expunged      fd00:1122:3344:102::26
+-   crucible          a49d4037-506e-4732-8e21-1f8c136a3c17   expunged      fd00:1122:3344:102::2c
+-   crucible          df94dc9a-74d9-43a9-8879-199740665f29   expunged      fd00:1122:3344:102::2b
+-   crucible          f1622981-7f0b-4a9f-9a70-6b46ab9d5e86   expunged      fd00:1122:3344:102::29
+-   crucible_pantry   b217d3a5-4ebb-45e3-b5be-2ebb2c57d8fa   expunged      fd00:1122:3344:102::23
+-   internal_dns      0efed95e-f052-4535-b45a-fac1148c0e6a   expunged      fd00:1122:3344:3::1   
+-   internal_ntp      61a79cb4-7fcb-432d-bbe9-3f9882452db2   expunged      fd00:1122:3344:102::21
+-   nexus             ee146b15-bc59-43a3-9567-bb8596e6188d   expunged      fd00:1122:3344:102::22
 
 
  MODIFIED SLEDS:
@@ -231,72 +231,72 @@ to:   blueprint 9f71f5d3-a272-4382-9154-6ea2e171a6c6
     -----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
     dataset name                                                                                                   dataset uuid                           quota     reservation   compression
     -----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
-    oxp_13e6503b-5300-4ccd-abc4-c1512b435929/crucible                                                              79a16369-70ab-4f63-af6d-1c7f088eeee3   none      none          off        
-    oxp_44cdb6f2-fa6c-4b69-bab2-3ae4e1ec4b34/crucible                                                              ac31a04c-1f3a-43f4-b45a-cf4b5176e7f6   none      none          off        
-    oxp_4de5fc8e-0e41-4ab9-ba12-2dc63882c96a/crucible                                                              b92bba84-9437-4f93-8ad0-80bf7ecdae5f   none      none          off        
-    oxp_51564e7a-d69f-4942-bcfe-330224633ca6/crucible                                                              dedbf4e7-32fb-406e-a5cc-a2f5281aa6d8   none      none          off        
-    oxp_5ca23cb3-cc90-41c5-a474-01898cdd0796/crucible                                                              b2c9f282-e767-4df1-941e-b7cea21b1a02   none      none          off        
-    oxp_6a23a532-0712-4a8d-be9b-e8c17e97aa4b/crucible                                                              47cf951d-ca5c-4ae0-baa3-94472efbcf03   none      none          off        
-    oxp_6f1a330e-e8d4-4c09-97fc-8918b69b2a3c/crucible                                                              9390bde4-2073-44b4-a496-5129c7e5ca40   none      none          off        
-    oxp_7113d104-fb55-4299-bf53-b3c59d258e44/crucible                                                              5ffb2b84-4a3f-444a-aebf-381f8c58b7ae   none      none          off        
-    oxp_8c10be49-3a66-40d4-a082-64d09d916f14/crucible                                                              d72ffc3a-4665-40bc-a099-ebe628622636   none      none          off        
-    oxp_d1ebfd7b-3842-4ad7-be31-2b9c031209a9/crucible                                                              39185a78-064c-49d5-b716-93f1a312c0c1   none      none          off        
-    oxp_13e6503b-5300-4ccd-abc4-c1512b435929/crypt/clickhouse                                                      d577ac11-62ac-4a71-bed7-e7327148bd33   none      none          off        
-    oxp_13e6503b-5300-4ccd-abc4-c1512b435929/crypt/internal_dns                                                    b9aa1175-2640-4923-81b3-1e1469b15abf   none      none          off        
-    oxp_13e6503b-5300-4ccd-abc4-c1512b435929/crypt/zone                                                            18e2a336-9b65-421e-8409-04d9abce8cd6   none      none          off        
-    oxp_44cdb6f2-fa6c-4b69-bab2-3ae4e1ec4b34/crypt/zone                                                            c37902cf-d1fe-4370-baef-b7de8731dffe   none      none          off        
-    oxp_4de5fc8e-0e41-4ab9-ba12-2dc63882c96a/crypt/zone                                                            00c2d1d6-94da-4985-a144-2194588afecf   none      none          off        
-    oxp_51564e7a-d69f-4942-bcfe-330224633ca6/crypt/zone                                                            3527b52f-f1d4-4e2f-b41e-559f58657839   none      none          off        
-    oxp_5ca23cb3-cc90-41c5-a474-01898cdd0796/crypt/zone                                                            22581703-157c-474f-bbf3-34f076dd7bca   none      none          off        
-    oxp_6a23a532-0712-4a8d-be9b-e8c17e97aa4b/crypt/zone                                                            4d6e70b1-ff91-4133-b65f-6fcd5bda2568   none      none          off        
-    oxp_6f1a330e-e8d4-4c09-97fc-8918b69b2a3c/crypt/zone                                                            41e55e8a-ca4b-4c27-8337-57d42cc36fb5   none      none          off        
-    oxp_7113d104-fb55-4299-bf53-b3c59d258e44/crypt/zone                                                            ae6c87ea-dc50-4a15-855a-224300f20c74   none      none          off        
-    oxp_8c10be49-3a66-40d4-a082-64d09d916f14/crypt/zone                                                            3fc37e5a-3bf3-476f-8a8f-6d32a533cfc0   none      none          off        
-    oxp_d1ebfd7b-3842-4ad7-be31-2b9c031209a9/crypt/zone                                                            64a64a7b-0d29-4470-bc96-4796ca357507   none      none          off        
-    oxp_13e6503b-5300-4ccd-abc4-c1512b435929/crypt/zone/oxz_clickhouse_93b137a1-a1d6-4b5b-b2cb-21a9f11e2883        d1a755ac-dafc-4087-a0ce-ee8b3f882ac1   none      none          off        
-    oxp_13e6503b-5300-4ccd-abc4-c1512b435929/crypt/zone/oxz_crucible_19fbc4f8-a683-4f22-8f5a-e74782b935be          68724637-d228-4faa-a19f-b5df857ff4ab   none      none          off        
-    oxp_8c10be49-3a66-40d4-a082-64d09d916f14/crypt/zone/oxz_crucible_2aa0ea4f-3561-4989-a98c-9ab7d9a240fb          05a77359-0a07-4976-8fbb-5f1eee688e47   none      none          off        
-    oxp_6f1a330e-e8d4-4c09-97fc-8918b69b2a3c/crypt/zone/oxz_crucible_4f1ce8a2-d3a5-4a38-be4c-9817de52db37          ef14767b-6be7-44cb-833d-27d9f523dcdb   none      none          off        
-    oxp_d1ebfd7b-3842-4ad7-be31-2b9c031209a9/crypt/zone/oxz_crucible_67622d61-2df4-414d-aa0e-d1277265f405          6dbd0e11-89af-4464-bd84-c20cb818a9d5   none      none          off        
-    oxp_7113d104-fb55-4299-bf53-b3c59d258e44/crypt/zone/oxz_crucible_67d913e0-0005-4599-9b28-0abbf6cc2916          d63be5b2-5471-4f4d-accc-82e2a0d7276f   none      none          off        
-    oxp_44cdb6f2-fa6c-4b69-bab2-3ae4e1ec4b34/crypt/zone/oxz_crucible_6b53ab2e-d98c-485f-87a3-4d5df595390f          51229ad8-cda3-40c4-b0f3-b1af669abcd4   none      none          off        
-    oxp_4de5fc8e-0e41-4ab9-ba12-2dc63882c96a/crypt/zone/oxz_crucible_b0c63f48-01ea-4aae-bb26-fb0dd59d1662          5d8788c0-13df-4c07-a8b2-b9365fec9796   none      none          off        
-    oxp_5ca23cb3-cc90-41c5-a474-01898cdd0796/crypt/zone/oxz_crucible_d660d7ed-28c0-45ae-9ace-dc3ecf7e8786          68217627-4519-4cfa-85b9-25efb4dad71a   none      none          off        
-    oxp_6a23a532-0712-4a8d-be9b-e8c17e97aa4b/crypt/zone/oxz_crucible_e98cc0de-abf6-4da4-a20d-d05c7a9bb1d7          a602c9d4-16a9-4e55-b5de-76fb33cc4ca9   none      none          off        
-    oxp_51564e7a-d69f-4942-bcfe-330224633ca6/crypt/zone/oxz_crucible_f55e6aaf-e8fc-4913-9e3c-8cd1bd4bdad3          82fc150e-d6f5-4bb6-8eee-17a0728aadb5   none      none          off        
-    oxp_13e6503b-5300-4ccd-abc4-c1512b435929/crypt/zone/oxz_crucible_pantry_9f0abbad-dbd3-4d43-9675-78092217ffd9   da62be58-643f-4497-a9d7-e259de6c7a12   none      none          off        
-    oxp_13e6503b-5300-4ccd-abc4-c1512b435929/crypt/zone/oxz_internal_dns_c406da50-34b9-4bb4-a460-8f49875d2a6a      f47f67f6-e315-4272-b93a-b467cfdfbb7a   none      none          off        
-    oxp_13e6503b-5300-4ccd-abc4-c1512b435929/crypt/zone/oxz_nexus_6dff7633-66bb-4924-a6ff-2c896e66964b             9dce1e52-8e3b-4641-9982-69deb049f647   none      none          off        
-    oxp_13e6503b-5300-4ccd-abc4-c1512b435929/crypt/zone/oxz_ntp_7f4e9f9f-08f8-4d14-885d-e977c05525ad               7773ffbd-1842-4425-aff5-88f577cd8955   none      none          off        
-    oxp_13e6503b-5300-4ccd-abc4-c1512b435929/crypt/debug                                                           d6d36f6b-35ff-4766-99de-44abe46932d1   100 GiB   none          gzip-9     
-    oxp_44cdb6f2-fa6c-4b69-bab2-3ae4e1ec4b34/crypt/debug                                                           26154290-91f7-4f35-bcd0-ec7a8f398d82   100 GiB   none          gzip-9     
-    oxp_4de5fc8e-0e41-4ab9-ba12-2dc63882c96a/crypt/debug                                                           6dc5df73-7e44-4065-9f14-70a0d965a853   100 GiB   none          gzip-9     
-    oxp_51564e7a-d69f-4942-bcfe-330224633ca6/crypt/debug                                                           3063bdcc-4363-495b-a81f-67c6cc437a75   100 GiB   none          gzip-9     
-    oxp_5ca23cb3-cc90-41c5-a474-01898cdd0796/crypt/debug                                                           53deebeb-3952-483a-afd2-2202cee9c33b   100 GiB   none          gzip-9     
-    oxp_6a23a532-0712-4a8d-be9b-e8c17e97aa4b/crypt/debug                                                           e315743d-53e3-4505-9364-657c2486a1bb   100 GiB   none          gzip-9     
-    oxp_6f1a330e-e8d4-4c09-97fc-8918b69b2a3c/crypt/debug                                                           2e901ffa-895b-4405-b59a-2bcdfabda681   100 GiB   none          gzip-9     
-    oxp_7113d104-fb55-4299-bf53-b3c59d258e44/crypt/debug                                                           ee20f8cb-7d24-422b-9dff-ca4c9596191f   100 GiB   none          gzip-9     
-    oxp_8c10be49-3a66-40d4-a082-64d09d916f14/crypt/debug                                                           84bc6d3f-2d9c-42b3-9982-7394630a0928   100 GiB   none          gzip-9     
-    oxp_d1ebfd7b-3842-4ad7-be31-2b9c031209a9/crypt/debug                                                           0c11d380-038c-4b68-b9f4-1775f6fec1e8   100 GiB   none          gzip-9     
+    oxp_13e6503b-5300-4ccd-abc4-c1512b435929/crucible                                                              01b78855-bc58-45bd-937e-49221a71b875   none      none          off        
+    oxp_44cdb6f2-fa6c-4b69-bab2-3ae4e1ec4b34/crucible                                                              99ddb9cf-a52c-4b59-884e-dea52e6b4f5d   none      none          off        
+    oxp_4de5fc8e-0e41-4ab9-ba12-2dc63882c96a/crucible                                                              354e3bc2-e6c8-49c0-bf1d-c136e499037c   none      none          off        
+    oxp_51564e7a-d69f-4942-bcfe-330224633ca6/crucible                                                              7f36c891-2cf8-4e94-b12a-24199b83462b   none      none          off        
+    oxp_5ca23cb3-cc90-41c5-a474-01898cdd0796/crucible                                                              8dd12603-6cfc-42dd-8912-2a16cb7a748d   none      none          off        
+    oxp_6a23a532-0712-4a8d-be9b-e8c17e97aa4b/crucible                                                              8ff2aecd-a1e8-47bd-8001-97c3e5efb99b   none      none          off        
+    oxp_6f1a330e-e8d4-4c09-97fc-8918b69b2a3c/crucible                                                              dab52576-17e4-4bf8-b87e-c49983a388c2   none      none          off        
+    oxp_7113d104-fb55-4299-bf53-b3c59d258e44/crucible                                                              d2c5b427-f956-4cd1-b174-6caca3685e6f   none      none          off        
+    oxp_8c10be49-3a66-40d4-a082-64d09d916f14/crucible                                                              e2e73bed-32f9-4111-803b-561cbd7faa1a   none      none          off        
+    oxp_d1ebfd7b-3842-4ad7-be31-2b9c031209a9/crucible                                                              5ba5e79d-0a13-41e5-b4d2-6c7cb468cb26   none      none          off        
+    oxp_13e6503b-5300-4ccd-abc4-c1512b435929/crypt/clickhouse                                                      37aac368-1b57-4934-b771-5802ae6d6606   none      none          off        
+    oxp_13e6503b-5300-4ccd-abc4-c1512b435929/crypt/internal_dns                                                    2f276f3f-ad8c-458e-bb62-03f5ec7643f3   none      none          off        
+    oxp_13e6503b-5300-4ccd-abc4-c1512b435929/crypt/zone                                                            a8381430-0bf6-49fd-8e5a-4e7c7eb4edf4   none      none          off        
+    oxp_44cdb6f2-fa6c-4b69-bab2-3ae4e1ec4b34/crypt/zone                                                            34fb7c7c-17c2-4cbb-af27-12b693965a4b   none      none          off        
+    oxp_4de5fc8e-0e41-4ab9-ba12-2dc63882c96a/crypt/zone                                                            a6f2fa57-1161-4b49-b591-2a9cd5a992f3   none      none          off        
+    oxp_51564e7a-d69f-4942-bcfe-330224633ca6/crypt/zone                                                            df22d065-beb6-45e4-984e-874dfdd3b285   none      none          off        
+    oxp_5ca23cb3-cc90-41c5-a474-01898cdd0796/crypt/zone                                                            59656ee4-d86f-49ff-b4b8-39e1021642f4   none      none          off        
+    oxp_6a23a532-0712-4a8d-be9b-e8c17e97aa4b/crypt/zone                                                            ea5ee557-cc4e-4a9b-87a7-7bb9b30589da   none      none          off        
+    oxp_6f1a330e-e8d4-4c09-97fc-8918b69b2a3c/crypt/zone                                                            5b0f2d79-6120-4b28-8fd6-919a121f5875   none      none          off        
+    oxp_7113d104-fb55-4299-bf53-b3c59d258e44/crypt/zone                                                            dd56b58b-871e-4f55-bcf5-0bd4e8184761   none      none          off        
+    oxp_8c10be49-3a66-40d4-a082-64d09d916f14/crypt/zone                                                            bafeb8db-cb8e-45fc-8030-3a85a26e2feb   none      none          off        
+    oxp_d1ebfd7b-3842-4ad7-be31-2b9c031209a9/crypt/zone                                                            b567319c-bb7a-4ac0-a95b-20bd88c26579   none      none          off        
+    oxp_13e6503b-5300-4ccd-abc4-c1512b435929/crypt/zone/oxz_clickhouse_5fbb489a-141d-4de2-86c4-4fd7b9d9f315        648fecf4-8ce6-4bce-9020-789057c92f95   none      none          off        
+    oxp_13e6503b-5300-4ccd-abc4-c1512b435929/crypt/zone/oxz_crucible_0ce2b998-f5ad-4dc5-b2ec-5250a308506d          4fe9bcd8-399f-444e-aa01-f8cb285de102   none      none          off        
+    oxp_7113d104-fb55-4299-bf53-b3c59d258e44/crypt/zone/oxz_crucible_0e8e9f2d-291d-47fc-ba0f-84cb50e713fd          ff5a6a51-2797-4016-903f-69ec69e59ef9   none      none          off        
+    oxp_51564e7a-d69f-4942-bcfe-330224633ca6/crypt/zone/oxz_crucible_11fc3b08-2470-4f1b-9187-acff1fc4c5ea          32b45c55-cc53-4635-ae2b-559821b409fe   none      none          off        
+    oxp_6f1a330e-e8d4-4c09-97fc-8918b69b2a3c/crypt/zone/oxz_crucible_673ecd68-d12a-46d9-9126-0a6be6245f84          0377cfc0-2bf6-4906-87f7-031121797594   none      none          off        
+    oxp_6a23a532-0712-4a8d-be9b-e8c17e97aa4b/crypt/zone/oxz_crucible_966c4f15-0aa8-4bef-95e4-49d686cffdfc          9ef1c45c-753a-4ecf-9145-72889ece2ad2   none      none          off        
+    oxp_8c10be49-3a66-40d4-a082-64d09d916f14/crypt/zone/oxz_crucible_979a7b5b-81a5-49bc-82e5-d88b6eaf7d96          b075b63e-f072-4f35-86d1-a81e50065994   none      none          off        
+    oxp_5ca23cb3-cc90-41c5-a474-01898cdd0796/crypt/zone/oxz_crucible_b6beadb1-351b-461d-a887-e7641d976a9e          9d2477db-7dea-4e19-b563-60a18a659cca   none      none          off        
+    oxp_4de5fc8e-0e41-4ab9-ba12-2dc63882c96a/crypt/zone/oxz_crucible_cf7add30-1c49-4d49-a2d2-1c46a60cd884          3b71883e-8704-468e-96fa-7b4fd85d37e8   none      none          off        
+    oxp_d1ebfd7b-3842-4ad7-be31-2b9c031209a9/crypt/zone/oxz_crucible_d0d4a23e-45fa-4f80-9bdf-a348de3f7b8f          5888130a-54bf-4358-bb1b-099347648757   none      none          off        
+    oxp_44cdb6f2-fa6c-4b69-bab2-3ae4e1ec4b34/crypt/zone/oxz_crucible_e46d1442-2a63-44e3-a6aa-e88150b85d92          c4739101-dd65-4649-8e99-e221dc9ce93e   none      none          off        
+    oxp_13e6503b-5300-4ccd-abc4-c1512b435929/crypt/zone/oxz_crucible_pantry_45b6f382-3590-4281-b65d-083ba7aff2d3   f07a8f89-a4e1-4c71-b223-a4c09af0e443   none      none          off        
+    oxp_13e6503b-5300-4ccd-abc4-c1512b435929/crypt/zone/oxz_internal_dns_4fd906d8-94cd-44b3-ad5e-34b4d193bd3c      3681f68d-2840-47be-8bb7-8c7354daf8a7   none      none          off        
+    oxp_13e6503b-5300-4ccd-abc4-c1512b435929/crypt/zone/oxz_nexus_88602518-f176-49a1-af12-02fac36214c3             99c53b55-b716-414d-b8ff-a9d56bd9cd6c   none      none          off        
+    oxp_13e6503b-5300-4ccd-abc4-c1512b435929/crypt/zone/oxz_ntp_b0a48e5a-e2bd-46b2-9bc6-8babbbdc0adc               ed9b8ac9-88f4-46fa-8ecf-5a7534d4f020   none      none          off        
+    oxp_13e6503b-5300-4ccd-abc4-c1512b435929/crypt/debug                                                           97bc5b54-dd6a-4b98-b9e0-081657a3db89   100 GiB   none          gzip-9     
+    oxp_44cdb6f2-fa6c-4b69-bab2-3ae4e1ec4b34/crypt/debug                                                           8d054703-b940-4395-8c46-2ff519f5133a   100 GiB   none          gzip-9     
+    oxp_4de5fc8e-0e41-4ab9-ba12-2dc63882c96a/crypt/debug                                                           bb388082-2d09-4a4b-bb22-ee3f4b7b5025   100 GiB   none          gzip-9     
+    oxp_51564e7a-d69f-4942-bcfe-330224633ca6/crypt/debug                                                           fe2005ba-7f3d-4fc3-b324-09a258fc4a4b   100 GiB   none          gzip-9     
+    oxp_5ca23cb3-cc90-41c5-a474-01898cdd0796/crypt/debug                                                           e20df72b-3d75-48ad-8349-3e39cc886886   100 GiB   none          gzip-9     
+    oxp_6a23a532-0712-4a8d-be9b-e8c17e97aa4b/crypt/debug                                                           cf2b245f-c667-49a9-bbc2-ada9a51e63f0   100 GiB   none          gzip-9     
+    oxp_6f1a330e-e8d4-4c09-97fc-8918b69b2a3c/crypt/debug                                                           1c606d5c-ce8c-42e8-9359-d2e0fe31d525   100 GiB   none          gzip-9     
+    oxp_7113d104-fb55-4299-bf53-b3c59d258e44/crypt/debug                                                           1f3f9209-c380-40ab-a2f0-16ecddb6d4a8   100 GiB   none          gzip-9     
+    oxp_8c10be49-3a66-40d4-a082-64d09d916f14/crypt/debug                                                           89b81a7c-3bc3-455d-97e3-75067de991d5   100 GiB   none          gzip-9     
+    oxp_d1ebfd7b-3842-4ad7-be31-2b9c031209a9/crypt/debug                                                           1e581e94-bb9d-4514-8dbb-3a882e342d1b   100 GiB   none          gzip-9     
 
 
     omicron zones at generation 2:
     ----------------------------------------------------------------------------------------------
     zone type         zone id                                disposition    underlay IP           
     ----------------------------------------------------------------------------------------------
-    clickhouse        93b137a1-a1d6-4b5b-b2cb-21a9f11e2883   in service     fd00:1122:3344:105::23
-    crucible          4f1ce8a2-d3a5-4a38-be4c-9817de52db37   in service     fd00:1122:3344:105::2b
-    crucible          67622d61-2df4-414d-aa0e-d1277265f405   in service     fd00:1122:3344:105::2e
-    crucible          67d913e0-0005-4599-9b28-0abbf6cc2916   in service     fd00:1122:3344:105::2c
-    crucible          6b53ab2e-d98c-485f-87a3-4d5df595390f   in service     fd00:1122:3344:105::26
-    crucible          b0c63f48-01ea-4aae-bb26-fb0dd59d1662   in service     fd00:1122:3344:105::27
-    crucible          d660d7ed-28c0-45ae-9ace-dc3ecf7e8786   in service     fd00:1122:3344:105::29
-    crucible          e98cc0de-abf6-4da4-a20d-d05c7a9bb1d7   in service     fd00:1122:3344:105::2a
-    crucible          f55e6aaf-e8fc-4913-9e3c-8cd1bd4bdad3   in service     fd00:1122:3344:105::28
-    crucible_pantry   9f0abbad-dbd3-4d43-9675-78092217ffd9   in service     fd00:1122:3344:105::24
-    internal_dns      c406da50-34b9-4bb4-a460-8f49875d2a6a   in service     fd00:1122:3344:1::1   
--   crucible          2aa0ea4f-3561-4989-a98c-9ab7d9a240fb   in service     fd00:1122:3344:105::2d
-*   crucible          19fbc4f8-a683-4f22-8f5a-e74782b935be   - in service   fd00:1122:3344:105::25
+    clickhouse        5fbb489a-141d-4de2-86c4-4fd7b9d9f315   in service     fd00:1122:3344:105::23
+    crucible          11fc3b08-2470-4f1b-9187-acff1fc4c5ea   in service     fd00:1122:3344:105::28
+    crucible          673ecd68-d12a-46d9-9126-0a6be6245f84   in service     fd00:1122:3344:105::2b
+    crucible          966c4f15-0aa8-4bef-95e4-49d686cffdfc   in service     fd00:1122:3344:105::2a
+    crucible          979a7b5b-81a5-49bc-82e5-d88b6eaf7d96   in service     fd00:1122:3344:105::2d
+    crucible          b6beadb1-351b-461d-a887-e7641d976a9e   in service     fd00:1122:3344:105::29
+    crucible          cf7add30-1c49-4d49-a2d2-1c46a60cd884   in service     fd00:1122:3344:105::27
+    crucible          d0d4a23e-45fa-4f80-9bdf-a348de3f7b8f   in service     fd00:1122:3344:105::2e
+    crucible          e46d1442-2a63-44e3-a6aa-e88150b85d92   in service     fd00:1122:3344:105::26
+    crucible_pantry   45b6f382-3590-4281-b65d-083ba7aff2d3   in service     fd00:1122:3344:105::24
+    internal_dns      4fd906d8-94cd-44b3-ad5e-34b4d193bd3c   in service     fd00:1122:3344:1::1   
+-   crucible          0e8e9f2d-291d-47fc-ba0f-84cb50e713fd   in service     fd00:1122:3344:105::2c
+*   crucible          0ce2b998-f5ad-4dc5-b2ec-5250a308506d   - in service   fd00:1122:3344:105::25
      └─                                                      + quiesced                           
 
 
@@ -306,20 +306,20 @@ to:   blueprint 9f71f5d3-a272-4382-9154-6ea2e171a6c6
     ---------------------------------------------------------------------------------------------
     zone type         zone id                                disposition   underlay IP           
     ---------------------------------------------------------------------------------------------
--   crucible          01d58626-e1b0-480f-96be-ac784863c7dc   expunged      fd00:1122:3344:103::2a
--   crucible          094f27af-1acb-4d1e-ba97-1fc1377d4bf2   expunged      fd00:1122:3344:103::28
--   crucible          47a87c6e-ef45-4d52-9a3e-69cdd96737cc   expunged      fd00:1122:3344:103::2b
--   crucible          4a9a0a9d-87f0-4f1d-9181-27f6b435e637   expunged      fd00:1122:3344:103::24
--   crucible          6464d025-4652-4948-919e-740bec5699b1   expunged      fd00:1122:3344:103::2c
--   crucible          878dfddd-3113-4197-a3ea-e0d4dbe9b476   expunged      fd00:1122:3344:103::2d
--   crucible          b91b271d-8d80-4f49-99a0-34006ae86063   expunged      fd00:1122:3344:103::26
--   crucible          e39d7c9e-182b-48af-af87-58079d723583   expunged      fd00:1122:3344:103::25
--   crucible          f3f2e4f3-0985-4ef6-8336-ce479382d05d   expunged      fd00:1122:3344:103::29
--   crucible          f69f92a1-5007-4bb0-a85b-604dc217154b   expunged      fd00:1122:3344:103::27
--   crucible_pantry   2f5e8010-a94d-43a4-9c5c-3f52832f5f7f   expunged      fd00:1122:3344:103::23
--   internal_dns      d6ee1338-3127-43ec-9aaa-b973ccf05496   expunged      fd00:1122:3344:2::1   
--   internal_ntp      56ac1706-9e2a-49ba-bd6f-a99c44cb2ccb   expunged      fd00:1122:3344:103::21
--   nexus             0dcfdfc5-481e-4153-b97c-11cf02b648ea   expunged      fd00:1122:3344:103::22
+-   crucible          085d10cb-a6f0-46de-86bc-ad2f7f1defcf   expunged      fd00:1122:3344:103::2d
+-   crucible          2bf62dfa-537a-4616-aad5-64447faaec53   expunged      fd00:1122:3344:103::2b
+-   crucible          50d43a78-e9af-4051-9f5d-85410f44214b   expunged      fd00:1122:3344:103::27
+-   crucible          6e7b5239-0d2e-42a5-80aa-51a3bc859318   expunged      fd00:1122:3344:103::2a
+-   crucible          8d87b485-3fb4-480b-97ce-02d066b799d7   expunged      fd00:1122:3344:103::26
+-   crucible          b3d757b8-033f-4a68-82db-6ff5331b9739   expunged      fd00:1122:3344:103::25
+-   crucible          bcd98cf5-a798-4aa0-81cc-8972a376073c   expunged      fd00:1122:3344:103::28
+-   crucible          bd12d9d5-bccf-433a-b078-794a69aeb89a   expunged      fd00:1122:3344:103::29
+-   crucible          d283707c-1b8f-4cb9-946d-041b25a83967   expunged      fd00:1122:3344:103::2c
+-   crucible          e362415d-2d54-4574-b823-3f01b9b751de   expunged      fd00:1122:3344:103::24
+-   crucible_pantry   208c987a-ab33-47a3-a103-6108dd6dc4cb   expunged      fd00:1122:3344:103::23
+-   internal_dns      c428175e-6a1c-40bf-aa36-f608a57431f5   expunged      fd00:1122:3344:2::1   
+-   internal_ntp      a8f1b53a-4231-4f04-9939-29e50a0f0e2c   expunged      fd00:1122:3344:103::21
+-   nexus             533416e6-d0bd-482d-b592-29346c8a3471   expunged      fd00:1122:3344:103::22
 
 
 ERRORS:
@@ -328,22 +328,22 @@ ERRORS:
 
     zone diff errors: before gen 2, after gen 2
 
-      zone id: 6dff7633-66bb-4924-a6ff-2c896e66964b
+      zone id: 88602518-f176-49a1-af12-02fac36214c3
       reason: mismatched underlay IP: before: fd00:1122:3344:105::22, after: fd01:1122:3344:105::22
 mismatched zone type: after: Nexus(
     Nexus {
         internal_address: [fd01:1122:3344:105::22]:12221,
         external_ip: OmicronZoneExternalFloatingIp {
-            id: a6c185b0-b470-4631-b6c8-373349430abb (external_ip),
+            id: cc0d03f3-64b0-45c2-8fff-08f77c993590 (external_ip),
             ip: 192.0.2.2,
         },
         nic: NetworkInterface {
-            id: 4e187c77-f123-4738-80d5-410b6a416438,
+            id: 3eadc40f-d6ec-4bd0-8824-9dc47ca61302,
             kind: Service {
-                id: 6dff7633-66bb-4924-a6ff-2c896e66964b,
+                id: 88602518-f176-49a1-af12-02fac36214c3,
             },
             name: Name(
-                "nexus-6dff7633-66bb-4924-a6ff-2c896e66964b",
+                "nexus-88602518-f176-49a1-af12-02fac36214c3",
             ),
             ip: 172.30.2.5,
             mac: MacAddr(
@@ -376,7 +376,7 @@ mismatched zone type: after: Nexus(
     },
 )
 
-      zone id: 7f4e9f9f-08f8-4d14-885d-e977c05525ad
+      zone id: b0a48e5a-e2bd-46b2-9bc6-8babbbdc0adc
       reason: mismatched underlay IP: before: fd00:1122:3344:105::21, after: fd01:1122:3344:105::21
 mismatched zone type: after: InternalNtp(
     InternalNtp {

--- a/nexus/reconfigurator/planning/tests/output/planner_nonprovisionable_bp2.txt
+++ b/nexus/reconfigurator/planning/tests/output/planner_nonprovisionable_bp2.txt
@@ -23,21 +23,21 @@ parent:    4d4e6c38-cd95-4c4e-8f45-6af4d686964b
     ---------------------------------------------------------------------------------------------
     zone type         zone id                                disposition   underlay IP           
     ---------------------------------------------------------------------------------------------
-    clickhouse        93b137a1-a1d6-4b5b-b2cb-21a9f11e2883   in service    fd00:1122:3344:105::23
-    crucible          19fbc4f8-a683-4f22-8f5a-e74782b935be   in service    fd00:1122:3344:105::25
-    crucible          2aa0ea4f-3561-4989-a98c-9ab7d9a240fb   in service    fd00:1122:3344:105::2d
-    crucible          4f1ce8a2-d3a5-4a38-be4c-9817de52db37   in service    fd00:1122:3344:105::2b
-    crucible          67622d61-2df4-414d-aa0e-d1277265f405   in service    fd00:1122:3344:105::2e
-    crucible          67d913e0-0005-4599-9b28-0abbf6cc2916   in service    fd00:1122:3344:105::2c
-    crucible          6b53ab2e-d98c-485f-87a3-4d5df595390f   in service    fd00:1122:3344:105::26
-    crucible          b0c63f48-01ea-4aae-bb26-fb0dd59d1662   in service    fd00:1122:3344:105::27
-    crucible          d660d7ed-28c0-45ae-9ace-dc3ecf7e8786   in service    fd00:1122:3344:105::29
-    crucible          e98cc0de-abf6-4da4-a20d-d05c7a9bb1d7   in service    fd00:1122:3344:105::2a
-    crucible          f55e6aaf-e8fc-4913-9e3c-8cd1bd4bdad3   in service    fd00:1122:3344:105::28
-    crucible_pantry   9f0abbad-dbd3-4d43-9675-78092217ffd9   in service    fd00:1122:3344:105::24
-    internal_dns      c406da50-34b9-4bb4-a460-8f49875d2a6a   in service    fd00:1122:3344:1::1   
-    internal_ntp      7f4e9f9f-08f8-4d14-885d-e977c05525ad   in service    fd00:1122:3344:105::21
-    nexus             6dff7633-66bb-4924-a6ff-2c896e66964b   in service    fd00:1122:3344:105::22
+    clickhouse        5fbb489a-141d-4de2-86c4-4fd7b9d9f315   in service    fd00:1122:3344:105::23
+    crucible          0ce2b998-f5ad-4dc5-b2ec-5250a308506d   in service    fd00:1122:3344:105::25
+    crucible          0e8e9f2d-291d-47fc-ba0f-84cb50e713fd   in service    fd00:1122:3344:105::2c
+    crucible          11fc3b08-2470-4f1b-9187-acff1fc4c5ea   in service    fd00:1122:3344:105::28
+    crucible          673ecd68-d12a-46d9-9126-0a6be6245f84   in service    fd00:1122:3344:105::2b
+    crucible          966c4f15-0aa8-4bef-95e4-49d686cffdfc   in service    fd00:1122:3344:105::2a
+    crucible          979a7b5b-81a5-49bc-82e5-d88b6eaf7d96   in service    fd00:1122:3344:105::2d
+    crucible          b6beadb1-351b-461d-a887-e7641d976a9e   in service    fd00:1122:3344:105::29
+    crucible          cf7add30-1c49-4d49-a2d2-1c46a60cd884   in service    fd00:1122:3344:105::27
+    crucible          d0d4a23e-45fa-4f80-9bdf-a348de3f7b8f   in service    fd00:1122:3344:105::2e
+    crucible          e46d1442-2a63-44e3-a6aa-e88150b85d92   in service    fd00:1122:3344:105::26
+    crucible_pantry   45b6f382-3590-4281-b65d-083ba7aff2d3   in service    fd00:1122:3344:105::24
+    internal_dns      4fd906d8-94cd-44b3-ad5e-34b4d193bd3c   in service    fd00:1122:3344:1::1   
+    internal_ntp      b0a48e5a-e2bd-46b2-9bc6-8babbbdc0adc   in service    fd00:1122:3344:105::21
+    nexus             88602518-f176-49a1-af12-02fac36214c3   in service    fd00:1122:3344:105::22
 
 
 
@@ -63,21 +63,21 @@ parent:    4d4e6c38-cd95-4c4e-8f45-6af4d686964b
     ------------------------------------------------------------------------------------------
     zone type      zone id                                disposition   underlay IP           
     ------------------------------------------------------------------------------------------
-    crucible       0dfbf374-9ef9-430f-b06d-f271bf7f84c4   in service    fd00:1122:3344:104::2c
-    crucible       15c103f0-ac63-423b-ba5d-1b5fcd563ba3   in service    fd00:1122:3344:104::27
-    crucible       23a8fa2b-ef3e-4017-a43f-f7a83953bd7c   in service    fd00:1122:3344:104::25
-    crucible       3aa07966-5899-4789-ace5-f8eeb375c6c3   in service    fd00:1122:3344:104::29
-    crucible       72c5a909-077d-4ec1-a9d5-ae64ef9d716e   in service    fd00:1122:3344:104::2b
-    crucible       85b8c68a-160d-461d-94dd-1baf175fa75c   in service    fd00:1122:3344:104::23
-    crucible       95482c25-1e7f-43e8-adf1-e3548a1b3ae0   in service    fd00:1122:3344:104::28
-    crucible       c60379ba-4e30-4628-a79a-0ae509aef4c5   in service    fd00:1122:3344:104::2a
-    crucible       f0ff59e8-4105-4980-a4bb-a1f4c58de1e3   in service    fd00:1122:3344:104::24
-    crucible       f1a7b9a7-fc6a-4b23-b829-045ff33117ff   in service    fd00:1122:3344:104::26
-    internal_ntp   621509d6-3772-4009-aca1-35eefd1098fb   in service    fd00:1122:3344:104::21
-    nexus          508abd03-cbfe-4654-9a6d-7f15a1ad32e5   in service    fd00:1122:3344:104::2d
-    nexus          99f6d544-8599-4e2b-a55a-82d9e0034662   in service    fd00:1122:3344:104::2e
-    nexus          a732c489-d29a-4f75-b900-5966385943af   in service    fd00:1122:3344:104::22
-    nexus          c26b3bda-5561-44a1-a69f-22103fe209a1   in service    fd00:1122:3344:104::2f
+    crucible       05ba6d6e-90a7-402a-aaba-fd92190a9f48   in service    fd00:1122:3344:104::26
+    crucible       2097bad3-ee65-4a1c-8fe2-75ed52e69ac8   in service    fd00:1122:3344:104::2c
+    crucible       430c8fe1-7296-4a73-b260-fc185260ec5e   in service    fd00:1122:3344:104::23
+    crucible       a720288d-3e5b-44b7-9dab-a69a10768e0b   in service    fd00:1122:3344:104::2a
+    crucible       b2170eef-aa6f-4ec5-aaa9-2b4289eae65c   in service    fd00:1122:3344:104::29
+    crucible       b505d6e1-07b9-48bf-bc8a-d4081c25b12a   in service    fd00:1122:3344:104::28
+    crucible       cbe34d65-017e-4c26-966d-b1ce27bc1d94   in service    fd00:1122:3344:104::24
+    crucible       e01462d1-5173-4d95-8477-78ca2157efbb   in service    fd00:1122:3344:104::2b
+    crucible       e49b0403-3d7c-480f-9113-4bc0fca74a8a   in service    fd00:1122:3344:104::25
+    crucible       e6ec9399-b81b-4bdd-8e6e-b0f043aad942   in service    fd00:1122:3344:104::27
+    internal_ntp   8f94a160-67ab-4ed5-bc3f-01e19fdd7e9b   in service    fd00:1122:3344:104::21
+    nexus          2ed23118-6137-45ca-824c-04df3bc3d085   in service    fd00:1122:3344:104::2f
+    nexus          33365de5-8a83-46c0-9d34-eddd68e54c6f   in service    fd00:1122:3344:104::2d
+    nexus          80e4964b-a8c8-41ef-ae23-f86cfe5f3a7b   in service    fd00:1122:3344:104::2e
+    nexus          81f79040-bcf7-4eff-9a87-8e7bcb5a6db9   in service    fd00:1122:3344:104::22
 
 
 
@@ -103,21 +103,21 @@ parent:    4d4e6c38-cd95-4c4e-8f45-6af4d686964b
     ------------------------------------------------------------------------------------------
     zone type      zone id                                disposition   underlay IP           
     ------------------------------------------------------------------------------------------
-    crucible       414830dc-c8c1-4748-9e9e-bc3a6435a93c   in service    fd00:1122:3344:101::29
-    crucible       66ecd4a6-73a7-4e26-9711-17abdd67a66e   in service    fd00:1122:3344:101::2c
-    crucible       772cbcbd-58be-4158-be85-be744871fa22   in service    fd00:1122:3344:101::26
-    crucible       a1c03689-fc62-4ea5-bb72-4d01f5138614   in service    fd00:1122:3344:101::23
-    crucible       a568e92e-4fbd-4b69-acd8-f16277073031   in service    fd00:1122:3344:101::25
-    crucible       a73f322a-9463-4d18-8f60-7ddf6f59f231   in service    fd00:1122:3344:101::2b
-    crucible       be75764a-491b-4aec-992e-1c39e25de975   in service    fd00:1122:3344:101::27
-    crucible       be920398-024a-4655-8c49-69b5ac48dfff   in service    fd00:1122:3344:101::2a
-    crucible       d47f4996-fac0-4657-bcea-01b1fee6404d   in service    fd00:1122:3344:101::24
-    crucible       e001fea0-6594-4ece-97e3-6198c293e931   in service    fd00:1122:3344:101::28
-    internal_ntp   bf79a56a-97af-4cc4-94a5-8b20d64c2cda   in service    fd00:1122:3344:101::21
-    nexus          2ec75441-3d7d-4b4b-9614-af03de5a3666   in service    fd00:1122:3344:101::2d
-    nexus          3ca5292f-8a59-4475-bb72-0f43714d0fff   in service    fd00:1122:3344:101::2f
-    nexus          4ad0e9da-08f8-4d40-b4d3-d17e711b5bbf   in service    fd00:1122:3344:101::22
-    nexus          59950bc8-1497-44dd-8cbf-b6502ba921b2   in service    fd00:1122:3344:101::2e
+    crucible       1b38728b-8552-435b-b621-359ba20d465b   in service    fd00:1122:3344:101::29
+    crucible       31c42e26-3cdf-41a8-8826-ce71a513ed04   in service    fd00:1122:3344:101::24
+    crucible       4f38e475-396a-4650-a49c-c3cc4acc3ab9   in service    fd00:1122:3344:101::2b
+    crucible       5cd47e9f-1faf-4afd-970a-18b9076b3407   in service    fd00:1122:3344:101::2a
+    crucible       768ab86c-d5d2-4734-a381-02df1032d5e9   in service    fd00:1122:3344:101::2c
+    crucible       abbf71e1-6568-42cf-9526-7e31549ba934   in service    fd00:1122:3344:101::25
+    crucible       e37d04f9-ed3f-4665-800e-b51ba7d5d306   in service    fd00:1122:3344:101::28
+    crucible       e6c28c27-39d2-4aec-bf34-5d9f6b3cbd7f   in service    fd00:1122:3344:101::23
+    crucible       f19f884a-3e97-458d-b8fb-533882750cd6   in service    fd00:1122:3344:101::27
+    crucible       f54c359e-a980-4996-9462-25a548d96265   in service    fd00:1122:3344:101::26
+    internal_ntp   706286e2-8b09-42ff-9841-eaef65635eee   in service    fd00:1122:3344:101::21
+    nexus          b539cea9-c37c-49ef-874f-170d898187b2   in service    fd00:1122:3344:101::2e
+    nexus          b854f752-383d-4e0b-8557-8c62d22ba994   in service    fd00:1122:3344:101::22
+    nexus          c5a0c592-319e-44df-9d00-1ddb1d5ad6aa   in service    fd00:1122:3344:101::2f
+    nexus          cab211e1-3ab1-475f-81fa-984748044d8c   in service    fd00:1122:3344:101::2d
 
 
 
@@ -127,20 +127,20 @@ WARNING: Zones exist without physical disks!
     ---------------------------------------------------------------------------------------------
     zone type         zone id                                disposition   underlay IP           
     ---------------------------------------------------------------------------------------------
-    crucible          01d58626-e1b0-480f-96be-ac784863c7dc   expunged      fd00:1122:3344:103::2a
-    crucible          094f27af-1acb-4d1e-ba97-1fc1377d4bf2   expunged      fd00:1122:3344:103::28
-    crucible          47a87c6e-ef45-4d52-9a3e-69cdd96737cc   expunged      fd00:1122:3344:103::2b
-    crucible          4a9a0a9d-87f0-4f1d-9181-27f6b435e637   expunged      fd00:1122:3344:103::24
-    crucible          6464d025-4652-4948-919e-740bec5699b1   expunged      fd00:1122:3344:103::2c
-    crucible          878dfddd-3113-4197-a3ea-e0d4dbe9b476   expunged      fd00:1122:3344:103::2d
-    crucible          b91b271d-8d80-4f49-99a0-34006ae86063   expunged      fd00:1122:3344:103::26
-    crucible          e39d7c9e-182b-48af-af87-58079d723583   expunged      fd00:1122:3344:103::25
-    crucible          f3f2e4f3-0985-4ef6-8336-ce479382d05d   expunged      fd00:1122:3344:103::29
-    crucible          f69f92a1-5007-4bb0-a85b-604dc217154b   expunged      fd00:1122:3344:103::27
-    crucible_pantry   2f5e8010-a94d-43a4-9c5c-3f52832f5f7f   expunged      fd00:1122:3344:103::23
-    internal_dns      d6ee1338-3127-43ec-9aaa-b973ccf05496   expunged      fd00:1122:3344:2::1   
-    internal_ntp      56ac1706-9e2a-49ba-bd6f-a99c44cb2ccb   expunged      fd00:1122:3344:103::21
-    nexus             0dcfdfc5-481e-4153-b97c-11cf02b648ea   expunged      fd00:1122:3344:103::22
+    crucible          085d10cb-a6f0-46de-86bc-ad2f7f1defcf   expunged      fd00:1122:3344:103::2d
+    crucible          2bf62dfa-537a-4616-aad5-64447faaec53   expunged      fd00:1122:3344:103::2b
+    crucible          50d43a78-e9af-4051-9f5d-85410f44214b   expunged      fd00:1122:3344:103::27
+    crucible          6e7b5239-0d2e-42a5-80aa-51a3bc859318   expunged      fd00:1122:3344:103::2a
+    crucible          8d87b485-3fb4-480b-97ce-02d066b799d7   expunged      fd00:1122:3344:103::26
+    crucible          b3d757b8-033f-4a68-82db-6ff5331b9739   expunged      fd00:1122:3344:103::25
+    crucible          bcd98cf5-a798-4aa0-81cc-8972a376073c   expunged      fd00:1122:3344:103::28
+    crucible          bd12d9d5-bccf-433a-b078-794a69aeb89a   expunged      fd00:1122:3344:103::29
+    crucible          d283707c-1b8f-4cb9-946d-041b25a83967   expunged      fd00:1122:3344:103::2c
+    crucible          e362415d-2d54-4574-b823-3f01b9b751de   expunged      fd00:1122:3344:103::24
+    crucible_pantry   208c987a-ab33-47a3-a103-6108dd6dc4cb   expunged      fd00:1122:3344:103::23
+    internal_dns      c428175e-6a1c-40bf-aa36-f608a57431f5   expunged      fd00:1122:3344:2::1   
+    internal_ntp      a8f1b53a-4231-4f04-9939-29e50a0f0e2c   expunged      fd00:1122:3344:103::21
+    nexus             533416e6-d0bd-482d-b592-29346c8a3471   expunged      fd00:1122:3344:103::22
 
 
 
@@ -151,20 +151,20 @@ WARNING: Zones exist without physical disks!
     ---------------------------------------------------------------------------------------------
     zone type         zone id                                disposition   underlay IP           
     ---------------------------------------------------------------------------------------------
-    crucible          15bb9def-69b8-4d2e-b04f-9fee1143387c   expunged      fd00:1122:3344:102::2b
-    crucible          3b3c14b6-a8e2-4054-a577-8d96cb576230   expunged      fd00:1122:3344:102::26
-    crucible          57b96d5c-b71e-43e4-8869-7d514003d00d   expunged      fd00:1122:3344:102::27
-    crucible          8d4d2b28-82bb-4e36-80da-1408d8c35d82   expunged      fd00:1122:3344:102::25
-    crucible          996d7570-b0df-46d5-aaa4-0c97697cf484   expunged      fd00:1122:3344:102::2c
-    crucible          b1783e95-9598-451d-b6ba-c50b52b428c3   expunged      fd00:1122:3344:102::2a
-    crucible          b4947d31-f70e-4ee0-8817-0ca6cea9b16b   expunged      fd00:1122:3344:102::28
-    crucible          c407795c-6c8b-428e-8ab8-b962913c447f   expunged      fd00:1122:3344:102::24
-    crucible          c6dd531e-2d1d-423b-acc8-358533dab78c   expunged      fd00:1122:3344:102::2d
-    crucible          e4b3e159-3dbe-48cb-8497-e3da92a90e5a   expunged      fd00:1122:3344:102::29
-    crucible_pantry   6939ce48-b17c-4616-b176-8a419a7697be   expunged      fd00:1122:3344:102::23
-    internal_dns      b6b759d0-f60d-42b7-bbbc-9d61c9e895a9   expunged      fd00:1122:3344:3::1   
-    internal_ntp      9fd52961-426f-4e62-a644-b70871103fca   expunged      fd00:1122:3344:102::21
-    nexus             b44cdbc0-0ce0-46eb-8b21-a09e113aa1d0   expunged      fd00:1122:3344:102::22
+    crucible          258c5106-ebcd-4651-96e4-d5b0895691f6   expunged      fd00:1122:3344:102::25
+    crucible          2b046f65-00f5-46da-988c-90c1de32a1dd   expunged      fd00:1122:3344:102::2a
+    crucible          30c770a8-625e-4864-8977-d83a11c1c596   expunged      fd00:1122:3344:102::2d
+    crucible          35e3587d-25d3-4234-822f-2d68713b8cbf   expunged      fd00:1122:3344:102::27
+    crucible          46293b15-fd26-48f9-9ccb-122fa0ef41b4   expunged      fd00:1122:3344:102::28
+    crucible          462c6b8d-1872-4671-b84a-bdcbb69e3baf   expunged      fd00:1122:3344:102::24
+    crucible          a046c5f9-25e7-47c3-9c67-43d68fb39c5e   expunged      fd00:1122:3344:102::26
+    crucible          a49d4037-506e-4732-8e21-1f8c136a3c17   expunged      fd00:1122:3344:102::2c
+    crucible          df94dc9a-74d9-43a9-8879-199740665f29   expunged      fd00:1122:3344:102::2b
+    crucible          f1622981-7f0b-4a9f-9a70-6b46ab9d5e86   expunged      fd00:1122:3344:102::29
+    crucible_pantry   b217d3a5-4ebb-45e3-b5be-2ebb2c57d8fa   expunged      fd00:1122:3344:102::23
+    internal_dns      0efed95e-f052-4535-b45a-fac1148c0e6a   expunged      fd00:1122:3344:3::1   
+    internal_ntp      61a79cb4-7fcb-432d-bbe9-3f9882452db2   expunged      fd00:1122:3344:102::21
+    nexus             ee146b15-bc59-43a3-9567-bb8596e6188d   expunged      fd00:1122:3344:102::22
 
 
 


### PR DESCRIPTION
Suggested by @sunshowers
(https://github.com/oxidecomputer/omicron/pull/7307#discussion_r1904731682). This should prevent changes to one sled (e.g., adding a new zone) from perturbing IDs on all subsequent sleds in otherwise-stable tests. (I took a stab at combining this with #7307 and confirmed the diff output is much more reasonable; will update #7307 after this lands.)

The actual code changes here are small and mostly-mechanical; the changes in `rng.rs` are the driver (moving the sled-specific RNGs into a per-sled RNG container and dealing with handing those out keyed by sled ID), and everything else fell out from that. Unfortunately this changes _all_ zone/dataset/NIC/IP UUIDs in expectorate tests, so the diff volume is... quite large.