### PR TITLE
[reconfigurator] Introduce `IdMap` and use it in `BlueprintZonesConfig`

### DIFF
--- a/nexus/db-queries/src/db/datastore/deployment.rs
+++ b/nexus/db-queries/src/db/datastore/deployment.rs
@@ -267,7 +267,7 @@ impl DataStore {
             .blueprint_zones
             .iter()
             .flat_map(|(sled_id, zones_config)| {
-                zones_config.zones.values().map(move |zone| {
+                zones_config.zones.iter().map(move |zone| {
                     BpOmicronZone::new(blueprint_id, *sled_id, zone)
                         .map_err(|e| Error::internal_error(&format!("{:#}", e)))
                 })
@@ -277,7 +277,7 @@ impl DataStore {
             .blueprint_zones
             .values()
             .flat_map(|zones_config| {
-                zones_config.zones.values().filter_map(|zone| {
+                zones_config.zones.iter().filter_map(|zone| {
                     BpOmicronZoneNic::new(blueprint_id, zone)
                         .with_context(|| format!("zone {}", zone.id))
                         .map_err(|e| Error::internal_error(&format!("{:#}", e)))

--- a/nexus/db-queries/src/db/datastore/deployment.rs
+++ b/nexus/db-queries/src/db/datastore/deployment.rs
@@ -51,6 +51,7 @@ use nexus_db_model::BpSledOmicronPhysicalDisks;
 use nexus_db_model::BpSledOmicronZones;
 use nexus_db_model::BpSledState;
 use nexus_db_model::BpTarget;
+use nexus_types::deployment::id_map::IdMap;
 use nexus_types::deployment::Blueprint;
 use nexus_types::deployment::BlueprintDatasetsConfig;
 use nexus_types::deployment::BlueprintMetadata;
@@ -587,7 +588,7 @@ impl DataStore {
                         s.sled_id.into(),
                         BlueprintZonesConfig {
                             generation: *s.generation,
-                            zones: BTreeMap::new(),
+                            zones: IdMap::new(),
                         },
                     );
                     bail_unless!(
@@ -794,7 +795,7 @@ impl DataStore {
                                 e.to_string()
                             ))
                         })?;
-                    sled_zones.zones.insert(zone.id, zone);
+                    sled_zones.zones.insert(zone);
                 }
             }
         }
@@ -2840,7 +2841,6 @@ mod tests {
                     ),
                 }]
                 .into_iter()
-                .map(|z| (z.id, z))
                 .collect(),
             },
         );

--- a/nexus/db-queries/src/db/datastore/rack.rs
+++ b/nexus/db-queries/src/db/datastore/rack.rs
@@ -1439,7 +1439,6 @@ mod test {
                     },
                 ]
                 .into_iter()
-                .map(|z| (z.id, z))
                 .collect(),
             },
         );
@@ -1516,7 +1515,6 @@ mod test {
                     },
                 ]
                 .into_iter()
-                .map(|z| (z.id, z))
                 .collect(),
             },
         );
@@ -1535,7 +1533,6 @@ mod test {
                     ),
                 }]
                 .into_iter()
-                .map(|z| (z.id, z))
                 .collect(),
             },
         );
@@ -1771,7 +1768,6 @@ mod test {
                     },
                 ]
                 .into_iter()
-                .map(|z| (z.id, z))
                 .collect(),
             },
         );
@@ -2008,7 +2004,6 @@ mod test {
                     ),
                 }]
                 .into_iter()
-                .map(|z| (z.id, z))
                 .collect(),
             },
         );
@@ -2150,7 +2145,6 @@ mod test {
                     },
                 ]
                 .into_iter()
-                .map(|z| (z.id, z))
                 .collect(),
             },
         );

--- a/nexus/db-queries/src/db/datastore/support_bundle.rs
+++ b/nexus/db-queries/src/db/datastore/support_bundle.rs
@@ -957,7 +957,7 @@ mod test {
 
     fn expunge_nexus_for_bundle(bp: &mut Blueprint, bundle: &SupportBundle) {
         for zones in bp.blueprint_zones.values_mut() {
-            for (_, zone) in &mut zones.zones {
+            for mut zone in &mut zones.zones {
                 if zone.id == bundle.assigned_nexus.unwrap().into() {
                     zone.disposition = BlueprintZoneDisposition::Expunged;
                 }

--- a/nexus/db-queries/src/db/datastore/support_bundle.rs
+++ b/nexus/db-queries/src/db/datastore/support_bundle.rs
@@ -913,7 +913,7 @@ mod test {
             .values()
             .flat_map(|zones_config| {
                 let mut nexus_zones = vec![];
-                for (_, zone) in &zones_config.zones {
+                for zone in &zones_config.zones {
                     if matches!(zone.zone_type, BlueprintZoneType::Nexus(_))
                         && zone.disposition.matches(filter)
                     {

--- a/nexus/db-queries/src/db/datastore/vpc.rs
+++ b/nexus/db-queries/src/db/datastore/vpc.rs
@@ -3274,7 +3274,7 @@ mod tests {
                 .blueprint_zones
                 .get_mut(&sled_ids[2])
                 .expect("zones for sled");
-            sled2.zones.values_mut().next().unwrap().disposition =
+            sled2.zones.iter_mut().next().unwrap().disposition =
                 BlueprintZoneDisposition::Quiesced;
             sled2.generation = sled2.generation.next();
 
@@ -3283,7 +3283,7 @@ mod tests {
                 .blueprint_zones
                 .get_mut(&sled_ids[3])
                 .expect("zones for sled");
-            sled3.zones.values_mut().next().unwrap().disposition =
+            sled3.zones.iter_mut().next().unwrap().disposition =
                 BlueprintZoneDisposition::Expunged;
             sled3.generation = sled3.generation.next();
 

--- a/nexus/db-queries/src/db/datastore/vpc.rs
+++ b/nexus/db-queries/src/db/datastore/vpc.rs
@@ -3148,9 +3148,8 @@ mod tests {
                 db_nic_from_zone(
                     bp1.blueprint_zones[&sled_ids[2]]
                         .zones
-                        .first_key_value()
-                        .unwrap()
-                        .1,
+                        .first_value()
+                        .unwrap(),
                 ),
             )
             .await
@@ -3184,9 +3183,8 @@ mod tests {
                 &opctx,
                 bp1.blueprint_zones[&sled_ids[2]]
                     .zones
-                    .first_key_value()
+                    .first_value()
                     .unwrap()
-                    .1
                     .id
                     .into_untyped_uuid(),
                 bp1_nic.id(),
@@ -3220,9 +3218,8 @@ mod tests {
                     db_nic_from_zone(
                         bp3.blueprint_zones[&sled_id]
                             .zones
-                            .first_key_value()
-                            .unwrap()
-                            .1,
+                            .first_value()
+                            .unwrap(),
                     ),
                 )
                 .await

--- a/nexus/db-queries/src/db/datastore/vpc.rs
+++ b/nexus/db-queries/src/db/datastore/vpc.rs
@@ -3148,7 +3148,7 @@ mod tests {
                 db_nic_from_zone(
                     bp1.blueprint_zones[&sled_ids[2]]
                         .zones
-                        .first_value()
+                        .first()
                         .unwrap(),
                 ),
             )
@@ -3183,7 +3183,7 @@ mod tests {
                 &opctx,
                 bp1.blueprint_zones[&sled_ids[2]]
                     .zones
-                    .first_value()
+                    .first()
                     .unwrap()
                     .id
                     .into_untyped_uuid(),
@@ -3218,7 +3218,7 @@ mod tests {
                     db_nic_from_zone(
                         bp3.blueprint_zones[&sled_id]
                             .zones
-                            .first_value()
+                            .first()
                             .unwrap(),
                     ),
                 )

--- a/nexus/db-queries/src/db/datastore/vpc.rs
+++ b/nexus/db-queries/src/db/datastore/vpc.rs
@@ -3146,10 +3146,7 @@ mod tests {
             .service_create_network_interface_raw(
                 &opctx,
                 db_nic_from_zone(
-                    bp1.blueprint_zones[&sled_ids[2]]
-                        .zones
-                        .first()
-                        .unwrap(),
+                    bp1.blueprint_zones[&sled_ids[2]].zones.first().unwrap(),
                 ),
             )
             .await
@@ -3216,10 +3213,7 @@ mod tests {
                 .service_create_network_interface_raw(
                     &opctx,
                     db_nic_from_zone(
-                        bp3.blueprint_zones[&sled_id]
-                            .zones
-                            .first()
-                            .unwrap(),
+                        bp3.blueprint_zones[&sled_id].zones.first().unwrap(),
                     ),
                 )
                 .await

--- a/nexus/reconfigurator/blippy/src/checks.rs
+++ b/nexus/reconfigurator/blippy/src/checks.rs
@@ -679,7 +679,7 @@ mod tests {
                 .get(&nexus1_sled_id)
                 .unwrap()
                 .zones
-                .values();
+                .iter();
             let sled1_zone1 = sled1_zones.next().expect("at least one zone");
             let sled1_zone2 = sled1_zones.next().expect("at least two zones");
             if sled1_zone1.id == nexus1.id {
@@ -1353,7 +1353,7 @@ mod tests {
         // with a filesystem_pool dataset to remove.
         let mut durable_zone = None;
         let mut root_zone = None;
-        for (_, z) in &zones_config.zones {
+        for z in &zones_config.zones {
             if durable_zone.is_none() {
                 if z.zone_type.durable_zpool().is_some() {
                     durable_zone = Some(z.clone());
@@ -1519,7 +1519,7 @@ mod tests {
             .expect("got zones for sled with datasets");
         let mut durable_zone = None;
         let mut root_zone = None;
-        for (_, z) in &zones_config.zones {
+        for z in &zones_config.zones {
             if durable_zone.is_none() {
                 if z.zone_type.durable_zpool().is_some() {
                     durable_zone = Some(z.clone());

--- a/nexus/reconfigurator/blippy/src/checks.rs
+++ b/nexus/reconfigurator/blippy/src/checks.rs
@@ -611,6 +611,7 @@ mod tests {
     use nexus_types::deployment::blueprint_zone_type;
     use nexus_types::deployment::BlueprintZoneType;
     use omicron_test_utils::dev::test_setup_log;
+    use std::mem;
 
     // The tests below all take the example blueprint, mutate in some invalid
     // way, and confirm that blippy reports the invalidity. This test confirms
@@ -640,7 +641,7 @@ mod tests {
         // Copy the underlay IP from one Nexus to another.
         let mut nexus_iter = blueprint.blueprint_zones.iter_mut().flat_map(
             |(sled_id, zones_config)| {
-                zones_config.zones.values_mut().filter_map(move |zone| {
+                zones_config.zones.iter_mut().filter_map(move |zone| {
                     if zone.zone_type.is_nexus() {
                         Some((*sled_id, zone))
                     } else {
@@ -651,7 +652,7 @@ mod tests {
         );
         let (nexus0_sled_id, nexus0) =
             nexus_iter.next().expect("at least one Nexus zone");
-        let (nexus1_sled_id, nexus1) =
+        let (nexus1_sled_id, mut nexus1) =
             nexus_iter.next().expect("at least two Nexus zones");
         assert_ne!(nexus0_sled_id, nexus1_sled_id);
 
@@ -670,8 +671,8 @@ mod tests {
         // duplicate underlay IP, duplicate sled subnets, and sled1 having mixed
         // underlay subnets (the details of which depend on the ordering of
         // zones, so we'll sort that out here).
-        let nexus0 = nexus0.clone();
-        let nexus1 = nexus1.clone();
+        let nexus0 = nexus0.into_ref().clone();
+        let nexus1 = nexus1.into_ref().clone();
         let (mixed_underlay_zone1, mixed_underlay_zone2) = {
             let mut sled1_zones = blueprint
                 .blueprint_zones
@@ -745,7 +746,7 @@ mod tests {
             .blueprint_zones
             .iter_mut()
             .flat_map(|(sled_id, zones_config)| {
-                zones_config.zones.values_mut().filter_map(move |zone| {
+                zones_config.zones.iter_mut().filter_map(move |zone| {
                     if zone.zone_type.is_internal_dns() {
                         Some((*sled_id, zone))
                     } else {
@@ -755,7 +756,7 @@ mod tests {
             });
         let (dns0_sled_id, dns0) =
             internal_dns_iter.next().expect("at least one internal DNS zone");
-        let (dns1_sled_id, dns1) =
+        let (dns1_sled_id, mut dns1) =
             internal_dns_iter.next().expect("at least two internal DNS zones");
         assert_ne!(dns0_sled_id, dns1_sled_id);
 
@@ -806,6 +807,9 @@ mod tests {
             },
         };
 
+        mem::drop(dns0);
+        mem::drop(dns1);
+
         let report =
             Blippy::new(&blueprint).into_report(BlippyReportSortKey::Kind);
         eprintln!("{}", report.display());
@@ -826,7 +830,7 @@ mod tests {
         // Copy the external IP from one Nexus to another.
         let mut nexus_iter = blueprint.blueprint_zones.iter_mut().flat_map(
             |(sled_id, zones_config)| {
-                zones_config.zones.values_mut().filter_map(move |zone| {
+                zones_config.zones.iter_mut().filter_map(move |zone| {
                     if zone.zone_type.is_nexus() {
                         Some((*sled_id, zone))
                     } else {
@@ -837,7 +841,7 @@ mod tests {
         );
         let (nexus0_sled_id, nexus0) =
             nexus_iter.next().expect("at least one Nexus zone");
-        let (nexus1_sled_id, nexus1) =
+        let (nexus1_sled_id, mut nexus1) =
             nexus_iter.next().expect("at least two Nexus zones");
         assert_ne!(nexus0_sled_id, nexus1_sled_id);
 
@@ -874,6 +878,9 @@ mod tests {
             },
         }];
 
+        mem::drop(nexus0);
+        mem::drop(nexus1);
+
         let report =
             Blippy::new(&blueprint).into_report(BlippyReportSortKey::Kind);
         eprintln!("{}", report.display());
@@ -896,7 +903,7 @@ mod tests {
         // Copy the external IP from one Nexus to another.
         let mut nexus_iter = blueprint.blueprint_zones.iter_mut().flat_map(
             |(sled_id, zones_config)| {
-                zones_config.zones.values_mut().filter_map(move |zone| {
+                zones_config.zones.iter_mut().filter_map(move |zone| {
                     if zone.zone_type.is_nexus() {
                         Some((*sled_id, zone))
                     } else {
@@ -907,7 +914,7 @@ mod tests {
         );
         let (nexus0_sled_id, nexus0) =
             nexus_iter.next().expect("at least one Nexus zone");
-        let (nexus1_sled_id, nexus1) =
+        let (nexus1_sled_id, mut nexus1) =
             nexus_iter.next().expect("at least two Nexus zones");
         assert_ne!(nexus0_sled_id, nexus1_sled_id);
 
@@ -939,6 +946,9 @@ mod tests {
             },
         }];
 
+        mem::drop(nexus0);
+        mem::drop(nexus1);
+
         let report =
             Blippy::new(&blueprint).into_report(BlippyReportSortKey::Kind);
         eprintln!("{}", report.display());
@@ -961,7 +971,7 @@ mod tests {
         // Copy the external IP from one Nexus to another.
         let mut nexus_iter = blueprint.blueprint_zones.iter_mut().flat_map(
             |(sled_id, zones_config)| {
-                zones_config.zones.values_mut().filter_map(move |zone| {
+                zones_config.zones.iter_mut().filter_map(move |zone| {
                     if zone.zone_type.is_nexus() {
                         Some((*sled_id, zone))
                     } else {
@@ -972,7 +982,7 @@ mod tests {
         );
         let (nexus0_sled_id, nexus0) =
             nexus_iter.next().expect("at least one Nexus zone");
-        let (nexus1_sled_id, nexus1) =
+        let (nexus1_sled_id, mut nexus1) =
             nexus_iter.next().expect("at least two Nexus zones");
         assert_ne!(nexus0_sled_id, nexus1_sled_id);
 
@@ -1004,6 +1014,9 @@ mod tests {
             },
         }];
 
+        mem::drop(nexus0);
+        mem::drop(nexus1);
+
         let report =
             Blippy::new(&blueprint).into_report(BlippyReportSortKey::Kind);
         eprintln!("{}", report.display());
@@ -1030,7 +1043,7 @@ mod tests {
         // Copy the durable zpool from one external DNS to another.
         let mut dns_iter = blueprint.blueprint_zones.iter_mut().flat_map(
             |(sled_id, zones_config)| {
-                zones_config.zones.values_mut().filter_map(move |zone| {
+                zones_config.zones.iter_mut().filter_map(move |zone| {
                     if zone.zone_type.is_external_dns() {
                         Some((*sled_id, zone))
                     } else {
@@ -1041,7 +1054,7 @@ mod tests {
         );
         let (dns0_sled_id, dns0) =
             dns_iter.next().expect("at least one external DNS zone");
-        let (dns1_sled_id, dns1) =
+        let (dns1_sled_id, mut dns1) =
             dns_iter.next().expect("at least two external DNS zones");
         assert_ne!(dns0_sled_id, dns1_sled_id);
 
@@ -1058,6 +1071,9 @@ mod tests {
             }
             _ => unreachable!("this is an external DNS zone"),
         };
+
+        let dns0 = dns0.into_ref().clone();
+        let dns1 = dns1.into_ref().clone();
 
         let expected_notes = [
             Note {
@@ -1110,7 +1126,7 @@ mod tests {
         // Copy the filesystem zpool from one external DNS to another.
         let mut dns_iter = blueprint.blueprint_zones.iter_mut().flat_map(
             |(sled_id, zones_config)| {
-                zones_config.zones.values_mut().filter_map(move |zone| {
+                zones_config.zones.iter_mut().filter_map(move |zone| {
                     if zone.zone_type.is_external_dns() {
                         Some((*sled_id, zone))
                     } else {
@@ -1121,7 +1137,7 @@ mod tests {
         );
         let (dns0_sled_id, dns0) =
             dns_iter.next().expect("at least one external DNS zone");
-        let (dns1_sled_id, dns1) =
+        let (dns1_sled_id, mut dns1) =
             dns_iter.next().expect("at least two external DNS zones");
         assert_ne!(dns0_sled_id, dns1_sled_id);
 
@@ -1132,6 +1148,8 @@ mod tests {
             .clone();
         dns1.filesystem_pool = Some(dup_zpool.clone());
 
+        let dns0 = dns0.into_ref().clone();
+        let dns1 = dns1.into_ref().clone();
         let expected_notes = [
             Note {
                 severity: Severity::Fatal,

--- a/nexus/reconfigurator/blippy/src/checks.rs
+++ b/nexus/reconfigurator/blippy/src/checks.rs
@@ -1517,7 +1517,7 @@ mod tests {
             root_zone.expect("found zone with root dataset to prune");
         zones_config
             .zones
-            .retain(|_, z| z.id != durable_zone.id && z.id != root_zone.id);
+            .retain(|z| z.id != durable_zone.id && z.id != root_zone.id);
 
         let durable_dataset = durable_zone.zone_type.durable_dataset().unwrap();
         let root_dataset = root_zone.filesystem_dataset().unwrap();

--- a/nexus/reconfigurator/execution/src/clickhouse.rs
+++ b/nexus/reconfigurator/execution/src/clickhouse.rs
@@ -381,7 +381,6 @@ mod test {
                     ),
                 }]
                 .into_iter()
-                .map(|z| (z.id, z))
                 .collect(),
             };
             zones.insert(sled_id, zone_config);
@@ -423,7 +422,6 @@ mod test {
                     ),
                 }]
                 .into_iter()
-                .map(|z| (z.id, z))
                 .collect(),
             };
             zones.insert(sled_id, zone_config);

--- a/nexus/reconfigurator/execution/src/clickhouse.rs
+++ b/nexus/reconfigurator/execution/src/clickhouse.rs
@@ -209,7 +209,7 @@ fn server_configs(
         .flat_map(|zones_config| {
             zones_config
                 .zones
-                .values()
+                .iter()
                 .filter(|zone_config| {
                     clickhouse_cluster_config
                         .servers
@@ -267,7 +267,7 @@ fn keeper_configs(
         .flat_map(|zones_config| {
             zones_config
                 .zones
-                .values()
+                .iter()
                 .filter(|zone_config| {
                     clickhouse_cluster_config
                         .keepers

--- a/nexus/reconfigurator/execution/src/dns.rs
+++ b/nexus/reconfigurator/execution/src/dns.rs
@@ -370,6 +370,7 @@ mod test {
     use std::collections::BTreeMap;
     use std::collections::BTreeSet;
     use std::collections::HashMap;
+    use std::mem;
     use std::net::IpAddr;
     use std::net::Ipv4Addr;
     use std::net::Ipv6Addr;
@@ -1029,12 +1030,13 @@ mod test {
         // back for that sled.
         let (_, bp_zones_config) =
             blueprint.blueprint_zones.iter_mut().next().unwrap();
-        let nexus_zone = bp_zones_config
+        let mut nexus_zone = bp_zones_config
             .zones
-            .values_mut()
+            .iter_mut()
             .find(|z| z.zone_type.is_nexus())
             .unwrap();
         nexus_zone.disposition = BlueprintZoneDisposition::Quiesced;
+        mem::drop(nexus_zone);
 
         // Retrieve the DNS config based on the modified blueprint
         let external_dns_zone = blueprint_external_dns_config(

--- a/nexus/reconfigurator/execution/src/dns.rs
+++ b/nexus/reconfigurator/execution/src/dns.rs
@@ -637,8 +637,8 @@ mod test {
                     zones: sa.omicron_zones
                         .zones
                         .into_iter()
-                        .map(|config| -> (OmicronZoneUuid, BlueprintZoneConfig) {
-                           (config.id,  deprecated_omicron_zone_config_to_blueprint_zone_config(
+                        .map(|config| -> BlueprintZoneConfig {
+                           deprecated_omicron_zone_config_to_blueprint_zone_config(
                                 config,
                                 BlueprintZoneDisposition::InService,
                                 // We don't get external IP IDs in inventory
@@ -646,7 +646,7 @@ mod test {
                                 // zone that needs one here. This is gross.
                                 Some(ExternalIpUuid::new_v4()),
                             )
-                            .expect("failed to convert zone config"))
+                            .expect("failed to convert zone config")
                         })
                         .collect(),
                 },
@@ -679,7 +679,6 @@ mod test {
         let out_of_service_id = OmicronZoneUuid::new_v4();
         let out_of_service_addr = Ipv6Addr::LOCALHOST;
         blueprint.blueprint_zones.values_mut().next().unwrap().zones.insert(
-            out_of_service_id,
             BlueprintZoneConfig {
                 disposition: BlueprintZoneDisposition::Quiesced,
                 id: out_of_service_id,

--- a/nexus/reconfigurator/execution/src/omicron_zones.rs
+++ b/nexus/reconfigurator/execution/src/omicron_zones.rs
@@ -456,7 +456,6 @@ mod test {
                     ),
                 }]
                 .into_iter()
-                .map(|z| (z.id, z))
                 .collect(),
             }
         }
@@ -546,22 +545,18 @@ mod test {
             zones: &mut BlueprintZonesConfig,
             disposition: BlueprintZoneDisposition,
         ) {
-            let zone_id = OmicronZoneUuid::new_v4();
-            zones.zones.insert(
-                zone_id,
-                BlueprintZoneConfig {
-                    disposition,
-                    id: zone_id,
-                    filesystem_pool: Some(ZpoolName::new_external(
-                        ZpoolUuid::new_v4(),
-                    )),
-                    zone_type: BlueprintZoneType::InternalNtp(
-                        blueprint_zone_type::InternalNtp {
-                            address: "[::1]:0".parse().unwrap(),
-                        },
-                    ),
-                },
-            );
+            zones.zones.insert(BlueprintZoneConfig {
+                disposition,
+                id: OmicronZoneUuid::new_v4(),
+                filesystem_pool: Some(ZpoolName::new_external(
+                    ZpoolUuid::new_v4(),
+                )),
+                zone_type: BlueprintZoneType::InternalNtp(
+                    blueprint_zone_type::InternalNtp {
+                        address: "[::1]:0".parse().unwrap(),
+                    },
+                ),
+            });
         }
 
         // Both in-service and quiesced zones should be deployed.

--- a/nexus/reconfigurator/planning/src/blueprint_builder/builder.rs
+++ b/nexus/reconfigurator/planning/src/blueprint_builder/builder.rs
@@ -2329,7 +2329,7 @@ pub mod test {
         let (_, _, blueprint) = example(&logctx.log, TEST_NAME);
 
         for (_, zone_config) in &blueprint.blueprint_zones {
-            for (_, zone) in &zone_config.zones {
+            for zone in &zone_config.zones {
                 // The pool should only be optional for backwards compatibility.
                 let filesystem_pool = zone
                     .filesystem_pool

--- a/nexus/reconfigurator/planning/src/blueprint_builder/builder.rs
+++ b/nexus/reconfigurator/planning/src/blueprint_builder/builder.rs
@@ -2143,7 +2143,7 @@ pub mod test {
         // We're going under the hood of the blueprint here; a sled can only get
         // to the decommissioned state if all its disks/datasets/zones have been
         // expunged, so do that too.
-        for (_, zone) in &mut blueprint1
+        for mut zone in &mut blueprint1
             .blueprint_zones
             .get_mut(&decommision_sled_id)
             .expect("has zones")
@@ -2190,7 +2190,7 @@ pub mod test {
         builder.sleds_mut().get_mut(&decommision_sled_id).unwrap().state =
             SledState::Decommissioned;
         let input = builder.build();
-        for (_, z) in &mut blueprint2
+        for mut z in &mut blueprint2
             .blueprint_zones
             .get_mut(&decommision_sled_id)
             .unwrap()

--- a/nexus/reconfigurator/planning/src/blueprint_builder/builder.rs
+++ b/nexus/reconfigurator/planning/src/blueprint_builder/builder.rs
@@ -21,6 +21,7 @@ use nexus_inventory::now_db_precision;
 use nexus_sled_agent_shared::inventory::OmicronZoneDataset;
 use nexus_sled_agent_shared::inventory::ZoneKind;
 use nexus_types::deployment::blueprint_zone_type;
+use nexus_types::deployment::id_map::IdMap;
 use nexus_types::deployment::Blueprint;
 use nexus_types::deployment::BlueprintDatasetsConfig;
 use nexus_types::deployment::BlueprintPhysicalDiskConfig;
@@ -413,7 +414,7 @@ impl<'a> BlueprintBuilder<'a> {
             .map(|sled_id| {
                 let config = BlueprintZonesConfig {
                     generation: Generation::new(),
-                    zones: BTreeMap::new(),
+                    zones: IdMap::new(),
                 };
                 (sled_id, config)
             })
@@ -2553,7 +2554,7 @@ pub mod test {
                         .get_mut(sled_id)
                         .expect("missing sled")
                         .zones
-                        .retain(|_, z| match &z.zone_type {
+                        .retain(|z| match &z.zone_type {
                             BlueprintZoneType::Nexus(z) => {
                                 removed_nexus = Some(z.clone());
                                 false

--- a/nexus/reconfigurator/planning/src/blueprint_builder/internal_dns.rs
+++ b/nexus/reconfigurator/planning/src/blueprint_builder/internal_dns.rs
@@ -124,7 +124,7 @@ pub mod test {
         // `ExampleSystem` adds an internal DNS server to every sled. Manually
         // prune out all but the first of them to give us space to add more.
         for (_, zone_config) in blueprint1.blueprint_zones.iter_mut().skip(1) {
-            zone_config.zones.retain(|_, z| !z.zone_type.is_internal_dns());
+            zone_config.zones.retain(|z| !z.zone_type.is_internal_dns());
         }
         let npruned = blueprint1.blueprint_zones.len() - 1;
         assert!(npruned > 0);

--- a/nexus/reconfigurator/planning/src/blueprint_editor/sled_editor.rs
+++ b/nexus/reconfigurator/planning/src/blueprint_editor/sled_editor.rs
@@ -236,7 +236,7 @@ impl SledEditor {
                 edited
                     .zones
                     .zones
-                    .values()
+                    .iter()
                     .filter(move |zone| zone.disposition.matches(filter)),
             ),
         }

--- a/nexus/reconfigurator/planning/src/blueprint_editor/sled_editor/zones.rs
+++ b/nexus/reconfigurator/planning/src/blueprint_editor/sled_editor/zones.rs
@@ -124,7 +124,7 @@ impl ZonesEditor {
     }
 
     pub fn expunge_all_on_zpool(&mut self, zpool: &ZpoolUuid) {
-        for config in self.zones.values_mut() {
+        for mut config in self.zones.iter_mut() {
             // Expunge this zone if its filesystem or durable dataset are on
             // this zpool. (If it has both, they should be on the _same_ zpool,
             // but that's not strictly required by this method - we'll expunge a
@@ -138,7 +138,7 @@ impl ZonesEditor {
                 .durable_zpool()
                 .map_or(false, |pool| pool.id() == *zpool);
             if fs_is_on_zpool || dd_is_on_zpool {
-                Self::expunge_impl(config, &mut self.counts);
+                Self::expunge_impl(&mut config, &mut self.counts);
             }
         }
     }

--- a/nexus/reconfigurator/planning/src/blueprint_editor/sled_editor/zones.rs
+++ b/nexus/reconfigurator/planning/src/blueprint_editor/sled_editor/zones.rs
@@ -96,13 +96,13 @@ impl ZonesEditor {
         &mut self,
         zone_id: &OmicronZoneUuid,
     ) -> Result<(bool, &BlueprintZoneConfig), ZonesEditError> {
-        let config = self.zones.get_mut(zone_id).ok_or_else(|| {
+        let mut config = self.zones.get_mut(zone_id).ok_or_else(|| {
             ZonesEditError::ExpungeNonexistentZone { id: *zone_id }
         })?;
 
-        let did_expunge = Self::expunge_impl(config, &mut self.counts);
+        let did_expunge = Self::expunge_impl(&mut config, &mut self.counts);
 
-        Ok((did_expunge, &*config))
+        Ok((did_expunge, config.into_ref()))
     }
 
     fn expunge_impl(

--- a/nexus/reconfigurator/planning/src/blueprint_editor/sled_editor/zones.rs
+++ b/nexus/reconfigurator/planning/src/blueprint_editor/sled_editor/zones.rs
@@ -68,7 +68,7 @@ impl ZonesEditor {
         filter: BlueprintZoneFilter,
     ) -> impl Iterator<Item = &BlueprintZoneConfig> {
         self.zones
-            .values()
+            .iter()
             .filter(move |config| config.disposition.matches(filter))
     }
 

--- a/nexus/reconfigurator/planning/src/blueprint_editor/sled_editor/zones.rs
+++ b/nexus/reconfigurator/planning/src/blueprint_editor/sled_editor/zones.rs
@@ -4,6 +4,7 @@
 
 use crate::blueprint_builder::EditCounts;
 use nexus_sled_agent_shared::inventory::ZoneKind;
+use nexus_types::deployment::id_map::Entry;
 use nexus_types::deployment::id_map::IdMap;
 use nexus_types::deployment::BlueprintZoneConfig;
 use nexus_types::deployment::BlueprintZoneDisposition;
@@ -76,18 +77,22 @@ impl ZonesEditor {
         &mut self,
         zone: BlueprintZoneConfig,
     ) -> Result<(), ZonesEditError> {
-        if let Some(prev) = self.zones.get(&zone.id) {
-            // We shouldn't be trying to add zones that already exist --
-            // something went wrong in the planner logic.
-            return Err(ZonesEditError::AddDuplicateZoneId {
-                id: zone.id,
-                kind1: zone.zone_type.kind(),
-                kind2: prev.zone_type.kind(),
-            });
+        match self.zones.entry(zone.id) {
+            Entry::Vacant(slot) => {
+                slot.insert(zone);
+                self.counts.added += 1;
+                Ok(())
+            }
+            Entry::Occupied(prev) => {
+                // We shouldn't be trying to add zones that already exist --
+                // something went wrong in the planner logic.
+                Err(ZonesEditError::AddDuplicateZoneId {
+                    id: zone.id,
+                    kind1: zone.zone_type.kind(),
+                    kind2: prev.get().zone_type.kind(),
+                })
+            }
         }
-
-        self.zones.insert(zone);
-        Ok(())
     }
 
     /// Expunge a zone, returning `true` if the zone was expunged and `false` if

--- a/nexus/reconfigurator/planning/src/example.rs
+++ b/nexus/reconfigurator/planning/src/example.rs
@@ -461,7 +461,7 @@ impl ExampleSystemBuilder {
             let Some(zones) = blueprint.blueprint_zones.get(&sled_id) else {
                 continue;
             };
-            for (_, zone) in zones.zones.iter() {
+            for zone in zones.zones.iter() {
                 let service_id = zone.id;
                 if let Some((external_ip, nic)) =
                     zone.zone_type.external_networking()

--- a/nexus/reconfigurator/planning/src/planner.rs
+++ b/nexus/reconfigurator/planning/src/planner.rs
@@ -1252,7 +1252,7 @@ mod test {
         // Remove two of the internal DNS zones; the planner should put new
         // zones back in their places.
         for (_sled_id, zones) in blueprint1.blueprint_zones.iter_mut().take(2) {
-            zones.zones.retain(|_, z| !z.zone_type.is_internal_dns());
+            zones.zones.retain(|z| !z.zone_type.is_internal_dns());
         }
         for (_, dataset_config) in
             blueprint1.blueprint_datasets.iter_mut().take(2)
@@ -2223,7 +2223,7 @@ mod test {
             .unwrap()
             .zones;
 
-        zones.retain(|_, zone| {
+        zones.retain(|zone| {
             if let BlueprintZoneType::Nexus(blueprint_zone_type::Nexus {
                 internal_address,
                 ..

--- a/nexus/reconfigurator/planning/src/planner.rs
+++ b/nexus/reconfigurator/planning/src/planner.rs
@@ -1051,7 +1051,7 @@ mod test {
                 .get(&sled_id)
                 .expect("missing kept sled")
                 .zones
-                .values()
+                .iter()
                 .filter(|z| z.zone_type.is_nexus())
                 .count(),
             1
@@ -1134,7 +1134,7 @@ mod test {
             assert_eq!(
                 sled_config
                     .zones
-                    .values()
+                    .iter()
                     .filter(|z| z.zone_type.is_nexus())
                     .count(),
                 1
@@ -1217,7 +1217,7 @@ mod test {
             assert_eq!(
                 sled_config
                     .zones
-                    .values()
+                    .iter()
                     .filter(|z| z.zone_type.is_internal_dns())
                     .count(),
                 1
@@ -1366,7 +1366,7 @@ mod test {
         // The expunged sled should have an expunged Nexus zone.
         let zone = blueprint2.blueprint_zones[&sled_id]
             .zones
-            .values()
+            .iter()
             .find(|zone| matches!(zone.zone_type, BlueprintZoneType::Nexus(_)))
             .expect("no nexus zone found");
         assert_eq!(zone.disposition, BlueprintZoneDisposition::Expunged);
@@ -1402,7 +1402,7 @@ mod test {
         let new_zone = blueprint3
             .blueprint_zones
             .values()
-            .flat_map(|c| c.zones.values())
+            .flat_map(|c| c.zones.iter())
             .find(|zone| {
                 zone.disposition == BlueprintZoneDisposition::InService
                     && zone
@@ -1561,7 +1561,7 @@ mod test {
         assert_eq!(
             blueprint3.blueprint_zones[&sled_id]
                 .zones
-                .values()
+                .iter()
                 .filter(|zone| {
                     zone.disposition == BlueprintZoneDisposition::Expunged
                         && zone.zone_type.is_external_dns()
@@ -1798,7 +1798,7 @@ mod test {
         // multiple zones of distinct types.
         let mut zpool_by_zone_usage = HashMap::new();
         for zones in blueprint1.blueprint_zones.values() {
-            for (_, zone) in &zones.zones {
+            for zone in &zones.zones {
                 let pool = zone.filesystem_pool.as_ref().unwrap();
                 zpool_by_zone_usage
                     .entry(pool.id())
@@ -1931,7 +1931,7 @@ mod test {
             .blueprint_zones
             .iter()
             .find_map(|(_, zones_config)| {
-                for (_, zone_config) in &zones_config.zones {
+                for zone_config in &zones_config.zones {
                     if zone_config.zone_type.is_ntp() {
                         return zone_config.filesystem_pool.clone();
                     }
@@ -1946,7 +1946,7 @@ mod test {
             0,
             |acc, (_, zones_config)| {
                 let mut zones_using_zpool = 0;
-                for (_, zone_config) in &zones_config.zones {
+                for zone_config in &zones_config.zones {
                     if let Some(pool) = &zone_config.filesystem_pool {
                         if pool == &pool_to_expunge {
                             zones_using_zpool += 1;
@@ -2057,7 +2057,7 @@ mod test {
             assert_eq!(
                 sled_config
                     .zones
-                    .values()
+                    .iter()
                     .filter(|z| z.zone_type.is_nexus())
                     .count(),
                 1

--- a/nexus/reconfigurator/planning/src/planner.rs
+++ b/nexus/reconfigurator/planning/src/planner.rs
@@ -2091,7 +2091,7 @@ mod test {
             // expunged, so lie and pretend like that already happened
             // (otherwise the planner will rightfully fail to generate a new
             // blueprint, because we're feeding it invalid inputs).
-            for (_, zone) in
+            for mut zone in
                 &mut blueprint1.blueprint_zones.get_mut(sled_id).unwrap().zones
             {
                 zone.disposition = BlueprintZoneDisposition::Expunged;

--- a/nexus/src/app/background/tasks/blueprint_execution.rs
+++ b/nexus/src/app/background/tasks/blueprint_execution.rs
@@ -424,7 +424,6 @@ mod test {
                     ),
                 }]
                 .into_iter()
-                .map(|z| (z.id, z))
                 .collect(),
             }
         }

--- a/nexus/src/app/background/tasks/crdb_node_id_collector.rs
+++ b/nexus/src/app/background/tasks/crdb_node_id_collector.rs
@@ -293,48 +293,33 @@ mod tests {
         let crdb_addr1: SocketAddrV6 = "[2001:db8::1]:1111".parse().unwrap();
         let crdb_addr2: SocketAddrV6 = "[2001:db8::2]:1234".parse().unwrap();
         let crdb_addr3: SocketAddrV6 = "[2001:db8::3]:1234".parse().unwrap();
-        bp_zones.zones.insert(
+        bp_zones.zones.insert(make_crdb_zone_config(
+            BlueprintZoneDisposition::InService,
             crdb_id1,
-            make_crdb_zone_config(
-                BlueprintZoneDisposition::InService,
-                crdb_id1,
-                crdb_addr1,
-            ),
-        );
-        bp_zones.zones.insert(
+            crdb_addr1,
+        ));
+        bp_zones.zones.insert(make_crdb_zone_config(
+            BlueprintZoneDisposition::Expunged,
             crdb_id2,
-            make_crdb_zone_config(
-                BlueprintZoneDisposition::Expunged,
-                crdb_id2,
-                crdb_addr2,
-            ),
-        );
-        bp_zones.zones.insert(
+            crdb_addr2,
+        ));
+        bp_zones.zones.insert(make_crdb_zone_config(
+            BlueprintZoneDisposition::InService,
             crdb_id3,
-            make_crdb_zone_config(
-                BlueprintZoneDisposition::InService,
-                crdb_id3,
-                crdb_addr3,
-            ),
-        );
+            crdb_addr3,
+        ));
 
         // Also add a non-CRDB zone to ensure it's filtered out.
-        let zone_id = OmicronZoneUuid::new_v4();
-        bp_zones.zones.insert(
-            zone_id,
-            BlueprintZoneConfig {
-                disposition: BlueprintZoneDisposition::InService,
-                id: zone_id,
-                filesystem_pool: Some(ZpoolName::new_external(
-                    ZpoolUuid::new_v4(),
-                )),
-                zone_type: BlueprintZoneType::CruciblePantry(
-                    blueprint_zone_type::CruciblePantry {
-                        address: "[::1]:0".parse().unwrap(),
-                    },
-                ),
-            },
-        );
+        bp_zones.zones.insert(BlueprintZoneConfig {
+            disposition: BlueprintZoneDisposition::InService,
+            id: OmicronZoneUuid::new_v4(),
+            filesystem_pool: Some(ZpoolName::new_external(ZpoolUuid::new_v4())),
+            zone_type: BlueprintZoneType::CruciblePantry(
+                blueprint_zone_type::CruciblePantry {
+                    address: "[::1]:0".parse().unwrap(),
+                },
+            ),
+        });
 
         // We expect to see CRDB zones 1 and 3 with their IPs but the ports
         // changed to `COCKROACH_ADMIN_PORT`.

--- a/nexus/test-utils/src/lib.rs
+++ b/nexus/test-utils/src/lib.rs
@@ -824,11 +824,7 @@ impl<'a, N: NexusServer> ControlPlaneTestContextBuilder<'a, N> {
                         sled_id,
                         BlueprintZonesConfig {
                             generation: Generation::new().next(),
-                            zones: zones
-                                .iter()
-                                .cloned()
-                                .map(|z| (z.id, z))
-                                .collect(),
+                            zones: zones.iter().cloned().collect(),
                         },
                     );
                     sled_state.insert(sled_id, SledState::Active);

--- a/nexus/types/src/deployment.rs
+++ b/nexus/types/src/deployment.rs
@@ -55,12 +55,15 @@ mod blueprint_diff;
 mod blueprint_display;
 mod clickhouse;
 pub mod execution;
+mod id_map;
 mod network_resources;
 mod planning_input;
 mod tri_map;
 mod zone_type;
 
 pub use clickhouse::ClickhouseClusterConfig;
+pub use id_map::IdMap;
+pub use id_map::IdMappable;
 pub use network_resources::AddNetworkResourceError;
 pub use network_resources::OmicronZoneExternalFloatingAddr;
 pub use network_resources::OmicronZoneExternalFloatingIp;

--- a/nexus/types/src/deployment.rs
+++ b/nexus/types/src/deployment.rs
@@ -240,7 +240,7 @@ impl Blueprint {
     ) -> impl Iterator<Item = (SledUuid, &BlueprintZoneConfig)> {
         zones_by_sled_id.iter().flat_map(move |(sled_id, z)| {
             z.zones
-                .values()
+                .iter()
                 .filter(move |z| z.disposition.matches(filter))
                 .map(|z| (*sled_id, z))
         })
@@ -268,7 +268,7 @@ impl Blueprint {
     ) -> impl Iterator<Item = (SledUuid, &BlueprintZoneConfig)> {
         self.blueprint_zones.iter().flat_map(move |(sled_id, z)| {
             z.zones
-                .values()
+                .iter()
                 .filter(move |z| !z.disposition.matches(filter))
                 .map(|z| (*sled_id, z))
         })
@@ -336,7 +336,7 @@ impl BpTableData for BlueprintZonesConfig {
 
     fn rows(&self, state: BpDiffState) -> impl Iterator<Item = BpTableRow> {
         // We want to sort by (kind, id)
-        let mut zones: Vec<_> = self.zones.values().cloned().collect();
+        let mut zones: Vec<_> = self.zones.iter().cloned().collect();
         zones.sort_unstable_by_key(zone_sort_key);
         zones.into_iter().map(move |zone| {
             BpTableRow::from_strings(
@@ -565,7 +565,7 @@ impl From<BlueprintZonesConfig> for OmicronZonesConfig {
     fn from(config: BlueprintZonesConfig) -> Self {
         Self {
             generation: config.generation,
-            zones: config.zones.into_values().map(From::from).collect(),
+            zones: config.zones.into_iter().map(From::from).collect(),
         }
     }
 }
@@ -584,7 +584,7 @@ impl BlueprintZonesConfig {
             generation: self.generation,
             zones: self
                 .zones
-                .values()
+                .iter()
                 .filter(|z| z.disposition.matches(filter))
                 .cloned()
                 .map(OmicronZoneConfig::from)
@@ -596,7 +596,7 @@ impl BlueprintZonesConfig {
     /// `Expunged`, false otherwise.
     pub fn are_all_zones_expunged(&self) -> bool {
         self.zones
-            .values()
+            .iter()
             .all(|c| c.disposition == BlueprintZoneDisposition::Expunged)
     }
 }

--- a/nexus/types/src/deployment.rs
+++ b/nexus/types/src/deployment.rs
@@ -55,15 +55,13 @@ mod blueprint_diff;
 mod blueprint_display;
 mod clickhouse;
 pub mod execution;
-mod id_map;
+pub mod id_map;
 mod network_resources;
 mod planning_input;
 mod tri_map;
 mod zone_type;
 
 pub use clickhouse::ClickhouseClusterConfig;
-pub use id_map::IdMap;
-pub use id_map::IdMappable;
 pub use network_resources::AddNetworkResourceError;
 pub use network_resources::OmicronZoneExternalFloatingAddr;
 pub use network_resources::OmicronZoneExternalFloatingIp;
@@ -100,6 +98,7 @@ use blueprint_display::{
     BpPhysicalDisksTableSchema, BpTable, BpTableData, BpTableRow,
     KvListWithHeading,
 };
+use id_map::{IdMap, IdMappable};
 
 pub use blueprint_diff::BlueprintDiff;
 
@@ -344,7 +343,7 @@ impl BpTableData for BlueprintZonesConfig {
                 state,
                 vec![
                     zone.kind().report_str().to_string(),
-                    zone.id().to_string(),
+                    ZoneSortKey::id(&zone).to_string(),
                     zone.disposition.to_string(),
                     zone.underlay_ip().to_string(),
                 ],
@@ -559,7 +558,7 @@ pub struct BlueprintZonesConfig {
     pub generation: Generation,
 
     /// The set of running zones.
-    pub zones: BTreeMap<OmicronZoneUuid, BlueprintZoneConfig>,
+    pub zones: IdMap<BlueprintZoneConfig>,
 }
 
 impl From<BlueprintZonesConfig> for OmicronZonesConfig {
@@ -656,6 +655,14 @@ pub struct BlueprintZoneConfig {
     /// zpool used for the zone's (transient) root filesystem
     pub filesystem_pool: Option<ZpoolName>,
     pub zone_type: BlueprintZoneType,
+}
+
+impl IdMappable for BlueprintZoneConfig {
+    type Id = OmicronZoneUuid;
+
+    fn id(&self) -> Self::Id {
+        self.id
+    }
 }
 
 impl diffus::Same for BlueprintZoneConfig {

--- a/nexus/types/src/deployment/blueprint_diff.rs
+++ b/nexus/types/src/deployment/blueprint_diff.rs
@@ -211,13 +211,13 @@ impl BpDiffZones {
                 let before_by_id: BTreeMap<_, BlueprintZoneConfig> =
                     before_zones
                         .zones
-                        .into_values()
+                        .into_iter()
                         .map(|z| (z.id(), z))
                         .collect();
                 let mut after_by_id: BTreeMap<_, BlueprintZoneConfig> =
                     after_zones
                         .zones
-                        .into_values()
+                        .into_iter()
                         .map(|z| (z.id, z))
                         .collect();
 
@@ -306,7 +306,7 @@ impl BpDiffZones {
             } else {
                 // No `after_zones` for this `sled_id`, so `before_zones` are removed
                 assert!(removed.is_empty());
-                for (_, zone) in before_zones.zones {
+                for zone in before_zones.zones {
                     removed.push(zone);
                 }
 
@@ -333,7 +333,7 @@ impl BpDiffZones {
                     BpDiffZoneDetails {
                         generation_before: None,
                         generation_after: Some(after_zones.generation),
-                        zones: after_zones.zones.into_values().collect(),
+                        zones: after_zones.zones.into_iter().collect(),
                     },
                 );
             }

--- a/nexus/types/src/deployment/blueprint_diff.rs
+++ b/nexus/types/src/deployment/blueprint_diff.rs
@@ -215,11 +215,7 @@ impl BpDiffZones {
                         .map(|z| (z.id(), z))
                         .collect();
                 let mut after_by_id: BTreeMap<_, BlueprintZoneConfig> =
-                    after_zones
-                        .zones
-                        .into_iter()
-                        .map(|z| (z.id, z))
-                        .collect();
+                    after_zones.zones.into_iter().map(|z| (z.id, z)).collect();
 
                 for (zone_id, zone_before) in before_by_id {
                     if let Some(zone_after) = after_by_id.remove(&zone_id) {

--- a/nexus/types/src/deployment/id_map.rs
+++ b/nexus/types/src/deployment/id_map.rs
@@ -42,13 +42,23 @@ type Inner<T> = BTreeMap<<T as IdMappable>::Id, T>;
 /// the inner `BTreeMap` would, although deserialzation performs extra checks to
 /// guarantee the key-must-be-its-values-ID property.
 ///
-/// Similar to the constraint that a `BTreeMap`'s keys may not be modified in a
-/// way that affects their ordering, the _values_ of an `IdMap` must not be
-/// modified in a way that affects their `id()` (as returned by their
-/// [`IdMappable`] implementation. This is possible via methods like `get_mut()`
-/// but will induce a logic error that may produce panics, invalid
-/// serialization, etc. The type stored in `IdMap` is expected to have a stable,
-/// never-changing identity.
+/// `IdMap` has the same constraint as `BTreeMap` regarding mutating keys out
+/// from under it:
+///
+/// > It is a logic error for a key to be modified in such a way that the key’s
+/// > ordering relative to any other key, as determined by the Ord trait,
+/// > changes while it is in the map. This is normally only possible through
+/// > Cell, RefCell, global state, I/O, or unsafe code. The behavior resulting
+/// > from such a logic error is not specified, but will be encapsulated to the
+/// > BTreeMap that observed the logic error and not result in undefined
+/// > behavior. This could include panics, incorrect results, aborts, memory
+/// > leaks, and non-termination.
+///
+/// Additionally, `IdMap` has the requirement that when any _values_ are
+/// mutated, their ID must not change. This is enforced at runtime via the
+/// [`RefMut`] wrapper returned by `get_mut()` and `iter_mut()`. When the
+/// wrapper is dropped, it will induce a panic if the ID has changed from what
+/// the value had when it was retreived from the map.
 ///
 /// An entry-style API is _not_ provided, as it would be relatively unergonomic
 /// to provide while enforcing the key-must-be-ID invariant.

--- a/nexus/types/src/deployment/id_map.rs
+++ b/nexus/types/src/deployment/id_map.rs
@@ -83,11 +83,7 @@ impl<T: IdMappable> IdMap<T> {
         self.inner.get_mut(key).map(RefMut::new)
     }
 
-    pub fn iter(&self) -> btree_map::Iter<'_, T::Id, T> {
-        self.inner.iter()
-    }
-
-    pub fn values(&self) -> btree_map::Values<'_, T::Id, T> {
+    pub fn iter(&self) -> btree_map::Values<'_, T::Id, T> {
         self.inner.values()
     }
 
@@ -95,7 +91,7 @@ impl<T: IdMappable> IdMap<T> {
         IterMut { inner: self.inner.values_mut() }
     }
 
-    pub fn into_values(self) -> btree_map::IntoValues<T::Id, T> {
+    pub fn into_iter(self) -> btree_map::IntoValues<T::Id, T> {
         self.inner.into_values()
     }
 
@@ -116,20 +112,20 @@ impl<T: IdMappable> FromIterator<T> for IdMap<T> {
 }
 
 impl<T: IdMappable> IntoIterator for IdMap<T> {
-    type Item = (T::Id, T);
-    type IntoIter = btree_map::IntoIter<T::Id, T>;
+    type Item = T;
+    type IntoIter = btree_map::IntoValues<T::Id, T>;
 
     fn into_iter(self) -> Self::IntoIter {
-        self.inner.into_iter()
+        self.into_iter()
     }
 }
 
 impl<'a, T: IdMappable> IntoIterator for &'a IdMap<T> {
-    type Item = (&'a T::Id, &'a T);
-    type IntoIter = btree_map::Iter<'a, T::Id, T>;
+    type Item = &'a T;
+    type IntoIter = btree_map::Values<'a, T::Id, T>;
 
     fn into_iter(self) -> Self::IntoIter {
-        self.inner.iter()
+        self.iter()
     }
 }
 

--- a/nexus/types/src/deployment/id_map.rs
+++ b/nexus/types/src/deployment/id_map.rs
@@ -161,7 +161,7 @@ impl<'a, T: IdMappable> IntoIterator for &'a mut IdMap<T> {
 
 impl<T: IdMappable> JsonSchema for IdMap<T> {
     fn schema_name() -> String {
-        Inner::<T>::schema_name()
+        format!("IdMap{}", T::schema_name())
     }
 
     fn json_schema(

--- a/nexus/types/src/deployment/id_map.rs
+++ b/nexus/types/src/deployment/id_map.rs
@@ -1,0 +1,228 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at https://mozilla.org/MPL/2.0/.
+
+use derive_where::derive_where;
+use diffus::edit::Edit;
+use diffus::Diffable;
+use schemars::JsonSchema;
+use serde::de::Error as _;
+use serde::de::Visitor;
+use serde::Deserialize;
+use serde::Serialize;
+use std::collections::BTreeMap;
+use std::fmt;
+use std::marker::PhantomData;
+
+pub trait IdMappable:
+    JsonSchema + Serialize + for<'de> Deserialize<'de> + for<'a> Diffable<'a>
+{
+    type Id: Ord
+        + Copy
+        + fmt::Display
+        + fmt::Debug
+        + JsonSchema
+        + Serialize
+        + for<'de> Deserialize<'de>;
+
+    fn id(&self) -> Self::Id;
+}
+
+type Inner<T> = BTreeMap<<T as IdMappable>::Id, T>;
+
+/// A 1:1 map ordered by the entries' IDs.
+///
+/// `IdMap` is a newtype wrapper around `BTreeMap` that does not allow a
+/// mismatch between a key and its associated value (i.e., the keys are
+/// guaranteed to be the ID of their associated value). Its implementations of
+/// various serialization-related traits all erase the `IdMap` and behave like
+/// the inner `BTreeMap` would, although deserialzation performs extra checks to
+/// guarantee the key-must-be-its-values-ID property.
+#[derive(Clone, Debug, Eq, PartialEq)]
+#[derive_where(Default)]
+pub struct IdMap<T: IdMappable> {
+    inner: Inner<T>,
+}
+
+impl<T: IdMappable> IdMap<T> {
+    pub fn new() -> Self {
+        Self::default()
+    }
+
+    pub fn insert(&mut self, entry: T) -> Option<T> {
+        self.inner.insert(entry.id(), entry)
+    }
+}
+
+impl<T: IdMappable> FromIterator<T> for IdMap<T> {
+    fn from_iter<I: IntoIterator<Item = T>>(iter: I) -> Self {
+        let inner = iter.into_iter().map(|entry| (entry.id(), entry)).collect();
+        Self { inner }
+    }
+}
+
+impl<T: IdMappable> JsonSchema for IdMap<T> {
+    fn schema_name() -> String {
+        Inner::<T>::schema_name()
+    }
+
+    fn json_schema(
+        gen: &mut schemars::gen::SchemaGenerator,
+    ) -> schemars::schema::Schema {
+        Inner::<T>::json_schema(gen)
+    }
+}
+
+impl<T: IdMappable> Serialize for IdMap<T> {
+    fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
+    where
+        S: serde::Serializer,
+    {
+        self.inner.serialize(serializer)
+    }
+}
+
+impl<'de, T: IdMappable> Deserialize<'de> for IdMap<T> {
+    fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
+    where
+        D: serde::Deserializer<'de>,
+    {
+        struct IdCheckVisitor<T>(PhantomData<T>);
+
+        impl<'d, T: IdMappable> Visitor<'d> for IdCheckVisitor<T> {
+            type Value = IdMap<T>;
+
+            fn expecting(&self, f: &mut fmt::Formatter) -> fmt::Result {
+                f.write_str("a map keyed by ID")
+            }
+
+            fn visit_map<A>(self, mut map: A) -> Result<Self::Value, A::Error>
+            where
+                A: serde::de::MapAccess<'d>,
+            {
+                let mut inner = Inner::<T>::new();
+                while let Some((key, value)) = map.next_entry::<T::Id, T>()? {
+                    if key != value.id() {
+                        return Err(A::Error::custom(format!(
+                            "invalid map: key {} maps to value with ID {}",
+                            key,
+                            value.id()
+                        )));
+                    }
+                    if let Some(old) = inner.insert(key, value) {
+                        return Err(A::Error::custom(format!(
+                            "invalid map: duplicate key {}",
+                            old.id()
+                        )));
+                    }
+                }
+                Ok(IdMap { inner })
+            }
+        }
+
+        deserializer.deserialize_map(IdCheckVisitor(PhantomData))
+    }
+}
+
+impl<'a, T: IdMappable + 'a> Diffable<'a> for IdMap<T> {
+    type Diff = BTreeMap<&'a T::Id, diffus::edit::map::Edit<'a, T>>;
+
+    fn diff(&'a self, other: &'a Self) -> Edit<'a, Self> {
+        match self.inner.diff(&other.inner) {
+            Edit::Copy(_) => Edit::Copy(self),
+            Edit::Change(change) => Edit::Change(change),
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use diffus::Diffus;
+    use test_strategy::proptest;
+    use test_strategy::Arbitrary;
+
+    #[derive(
+        Debug,
+        Clone,
+        PartialEq,
+        Eq,
+        Arbitrary,
+        JsonSchema,
+        Serialize,
+        Deserialize,
+        Diffus,
+    )]
+    struct TestEntry {
+        id: u8,
+        val1: u32,
+        val2: u32,
+    }
+
+    impl IdMappable for TestEntry {
+        type Id = u8;
+
+        fn id(&self) -> Self::Id {
+            self.id
+        }
+    }
+
+    #[proptest]
+    fn serialization_roundtrip(values: Vec<TestEntry>) {
+        let map: IdMap<_> = values.into_iter().collect();
+
+        let serialized = serde_json::to_string(&map).unwrap();
+        let deserialized: IdMap<TestEntry> =
+            serde_json::from_str(&serialized).unwrap();
+
+        assert_eq!(map, deserialized);
+    }
+
+    #[proptest]
+    fn serialization_is_transparent(values: Vec<TestEntry>) {
+        let map: IdMap<_> = values.into_iter().collect();
+
+        let serialized = serde_json::to_string(&map).unwrap();
+        let serialized_inner = serde_json::to_string(&map.inner).unwrap();
+
+        assert_eq!(serialized, serialized_inner);
+    }
+
+    #[test]
+    fn deserialize_rejects_mismatched_keys() {
+        let mut map = IdMap::<TestEntry>::new();
+        map.insert(TestEntry { id: 1, val1: 2, val2: 3 });
+
+        let mut entries = map.inner;
+        entries.get_mut(&1).unwrap().id = 2;
+
+        let serialized = serde_json::to_string(&entries).unwrap();
+        let err =
+            serde_json::from_str::<IdMap<TestEntry>>(&serialized).unwrap_err();
+        let err = err.to_string();
+
+        assert!(
+            err.contains("key 1 maps to value with ID 2"),
+            "unexpected error message: {err:?}"
+        );
+    }
+
+    #[test]
+    fn deserialize_rejects_duplicates() {
+        let serialized = r#"
+        {
+            "1": {"id": 1, "val1": 2, "val2": 3},
+            "1": {"id": 1, "val1": 2, "val2": 3}
+        }
+        "#;
+
+        let err =
+            serde_json::from_str::<IdMap<TestEntry>>(&serialized).unwrap_err();
+        let err = err.to_string();
+
+        assert!(
+            err.contains("duplicate key 1"),
+            "unexpected error message: {err:?}"
+        );
+    }
+}

--- a/nexus/types/src/deployment/id_map.rs
+++ b/nexus/types/src/deployment/id_map.rs
@@ -71,7 +71,7 @@ impl<T: IdMappable> IdMap<T> {
         self.inner.insert(entry.id(), entry)
     }
 
-    pub fn first_value(&self) -> Option<&T> {
+    pub fn first(&self) -> Option<&T> {
         self.inner.first_key_value().map(|(_, val)| val)
     }
 

--- a/openapi/nexus-internal.json
+++ b/openapi/nexus-internal.json
@@ -2716,10 +2716,11 @@
           },
           "zones": {
             "description": "The set of running zones.",
-            "type": "object",
-            "additionalProperties": {
-              "$ref": "#/components/schemas/BlueprintZoneConfig"
-            }
+            "allOf": [
+              {
+                "$ref": "#/components/schemas/IdMapBlueprintZoneConfig"
+              }
+            ]
           }
         },
         "required": [
@@ -3740,6 +3741,12 @@
         "type": "integer",
         "format": "uint8",
         "minimum": 0
+      },
+      "IdMapBlueprintZoneConfig": {
+        "type": "object",
+        "additionalProperties": {
+          "$ref": "#/components/schemas/BlueprintZoneConfig"
+        }
       },
       "ImportExportPolicy": {
         "description": "Define policy relating to the import and export of prefixes from a BGP peer.",

--- a/sled-agent/src/rack_setup/service.rs
+++ b/sled-agent/src/rack_setup/service.rs
@@ -1604,12 +1604,7 @@ pub(crate) fn build_initial_blueprint_from_sled_configs(
             // value, we will need to revisit storing this in the serialized
             // RSS plan.
             generation: DeployStepVersion::V5_EVERYTHING,
-            zones: sled_config
-                .zones
-                .iter()
-                .cloned()
-                .map(|z| (z.id, z))
-                .collect(),
+            zones: sled_config.zones.iter().cloned().collect(),
         };
 
         blueprint_zones.insert(*sled_id, zones_config);


### PR DESCRIPTION
@andrewjstone mentioned being bothered by our `BTreeMap<Id, ValueWithAnId>` maps on #7315:

> The key to the map must always match the value in BlueprintZoneConfig. It's a shame a mismatch is now representable, and we can go about trying to change that if necessary. We can also just make it part of blippy for now. FWIW, this matches the pattern in BlueprintDatasetsConfig.

This has bugged me too, and adding a blippy check crossed my mind. But I think it would be better to make this just not possible, so this PR introduces a newtype wrapper around `BTreeMap<T::Id, T>` that enforces "key must be value's ID" via a mix of compile time API constraints (e.g., `insert` only takes the value and generates the key on its own) and runtime checks (e.g., when mutating a value stored in the map, it will panic if that mutation changes the ID of the value).

The new code is all in `id_map.rs`, and the rest of the changes are replacing the `BlueprintZonesConfig` map with it. If this looks reasonable to folks, followup PRs to change the other similar `BTreeMap`s to use `IdMap` should be straightforward.