### PR TITLE
[reconfigurator][support-bundles] Choose datasets for support bundles from current blueprint

### DIFF
--- a/nexus/db-model/src/schema.rs
+++ b/nexus/db-model/src/schema.rs
@@ -2021,6 +2021,7 @@ allow_tables_to_appear_in_same_query!(
 allow_tables_to_appear_in_same_query!(hw_baseboard_id, inv_sled_agent,);
 
 allow_tables_to_appear_in_same_query!(
+    bp_omicron_dataset,
     bp_omicron_zone,
     bp_target,
     dataset,

--- a/nexus/types/src/deployment.rs
+++ b/nexus/types/src/deployment.rs
@@ -1012,6 +1012,13 @@ impl BlueprintDatasetDisposition {
             },
         }
     }
+
+    /// Returns all dataset dispositions that match the given filter.
+    pub fn all_matching(
+        filter: BlueprintDatasetFilter,
+    ) -> impl Iterator<Item = Self> {
+        BlueprintDatasetDisposition::iter().filter(move |&d| d.matches(filter))
+    }
 }
 
 /// Information about a dataset as recorded in a blueprint


### PR DESCRIPTION
This is an incremental step towards #6998: we want to transition the `dataset` table to exclusively-for-crucible, so this removes one consumer of it.

The bulk of the diff is adding a couple of diesel extensions, _heavily_ derived from `ApplyBlueprintZoneFilterExt`. (One is a literal copy/paste then `s/zone/dataset/g`.) The other is a helper to filter a few of the blueprint tables down to just the current target blueprint, which both this query and the other query-the-blueprint consumer we have today wants (the VPC code, which changes here to use the new helper).