### PR TITLE
replace TUF artifact primary key with a UUID

### DIFF
--- a/nexus/auth/src/authz/api_resources.rs
+++ b/nexus/auth/src/authz/api_resources.rs
@@ -38,7 +38,6 @@ use authz_macros::authz_resource;
 use futures::future::BoxFuture;
 use futures::FutureExt;
 use nexus_db_fixed_data::FLEET_ID;
-use nexus_db_model::{ArtifactId, SemverVersion};
 use nexus_types::external_api::shared::{FleetRole, ProjectRole, SiloRole};
 use omicron_common::api::external::{Error, LookupType, ResourceType};
 use once_cell::sync::Lazy;
@@ -1014,8 +1013,7 @@ authz_resource! {
 authz_resource! {
     name = "TufArtifact",
     parent = "Fleet",
-    primary_key = (String, SemverVersion, String),
-    input_key = ArtifactId,
+    primary_key = { uuid_kind = TufArtifactKind },
     roles_allowed = false,
     polar_snippet = FleetChild,
 }

--- a/nexus/db-model/src/schema.rs
+++ b/nexus/db-model/src/schema.rs
@@ -1336,7 +1336,8 @@ table! {
 }
 
 table! {
-    tuf_artifact (name, version, kind) {
+    tuf_artifact (id) {
+        id -> Uuid,
         name -> Text,
         version -> Text,
         kind -> Text,
@@ -1347,11 +1348,9 @@ table! {
 }
 
 table! {
-    tuf_repo_artifact (tuf_repo_id, tuf_artifact_name, tuf_artifact_version, tuf_artifact_kind) {
+    tuf_repo_artifact (tuf_repo_id, tuf_artifact_id) {
         tuf_repo_id -> Uuid,
-        tuf_artifact_name -> Text,
-        tuf_artifact_version -> Text,
-        tuf_artifact_kind -> Text,
+        tuf_artifact_id -> Uuid,
     }
 }
 
@@ -1361,8 +1360,7 @@ allow_tables_to_appear_in_same_query!(
     tuf_artifact
 );
 joinable!(tuf_repo_artifact -> tuf_repo (tuf_repo_id));
-// Can't specify joinable for a composite primary key (tuf_repo_artifact ->
-// tuf_artifact).
+joinable!(tuf_repo_artifact -> tuf_artifact (tuf_artifact_id));
 
 table! {
     support_bundle {

--- a/nexus/db-model/src/schema_versions.rs
+++ b/nexus/db-model/src/schema_versions.rs
@@ -17,7 +17,7 @@ use std::collections::BTreeMap;
 ///
 /// This must be updated when you change the database schema.  Refer to
 /// schema/crdb/README.adoc in the root of this repository for details.
-pub const SCHEMA_VERSION: SemverVersion = SemverVersion::new(118, 0, 0);
+pub const SCHEMA_VERSION: SemverVersion = SemverVersion::new(119, 0, 0);
 
 /// List of all past database schema versions, in *reverse* order
 ///
@@ -29,6 +29,7 @@ static KNOWN_VERSIONS: Lazy<Vec<KnownVersion>> = Lazy::new(|| {
         // |  leaving the first copy as an example for the next person.
         // v
         // KnownVersion::new(next_int, "unique-dirname-with-the-sql-files"),
+        KnownVersion::new(119, "tuf-artifact-key-uuid"),
         KnownVersion::new(118, "support-bundles"),
         KnownVersion::new(117, "add-completing-and-new-region-volume"),
         KnownVersion::new(116, "bp-physical-disk-disposition"),

--- a/nexus/db-queries/src/db/lookup.rs
+++ b/nexus/db-queries/src/db/lookup.rs
@@ -22,6 +22,7 @@ use omicron_common::api::external::Error;
 use omicron_common::api::external::InternalContext;
 use omicron_common::api::external::{LookupResult, LookupType, ResourceType};
 use omicron_uuid_kinds::PhysicalDiskUuid;
+use omicron_uuid_kinds::TufArtifactKind;
 use omicron_uuid_kinds::TufRepoKind;
 use omicron_uuid_kinds::TypedUuid;
 use uuid::Uuid;
@@ -446,18 +447,11 @@ impl<'a> LookupPath<'a> {
 
     /// Select a resource of type UpdateArtifact, identified by its
     /// `(name, version, kind)` tuple
-    pub fn tuf_artifact_tuple(
+    pub fn tuf_artifact_id(
         self,
-        name: impl Into<String>,
-        version: db::model::SemverVersion,
-        kind: impl Into<String>,
+        id: TypedUuid<TufArtifactKind>,
     ) -> TufArtifact<'a> {
-        TufArtifact::PrimaryKey(
-            Root { lookup_root: self },
-            name.into(),
-            version,
-            kind.into(),
-        )
+        TufArtifact::PrimaryKey(Root { lookup_root: self }, id)
     }
 
     /// Select a resource of type UserBuiltin, identified by its `name`
@@ -895,11 +889,7 @@ lookup_resource! {
     children = [],
     lookup_by_name = false,
     soft_deletes = false,
-    primary_key_columns = [
-        { column_name = "name", rust_type = String },
-        { column_name = "version", rust_type = db::model::SemverVersion },
-        { column_name = "kind", rust_type = String },
-    ]
+    primary_key_columns = [ { column_name = "id", uuid_kind = TufArtifactKind } ]
 }
 
 lookup_resource! {

--- a/nexus/db-queries/src/policy_test/resources.rs
+++ b/nexus/db-queries/src/policy_test/resources.rs
@@ -6,9 +6,7 @@
 
 use super::resource_builder::ResourceBuilder;
 use super::resource_builder::ResourceSet;
-use crate::db::model::ArtifactId;
 use nexus_auth::authz;
-use nexus_db_model::SemverVersion;
 use omicron_common::api::external::LookupType;
 use omicron_uuid_kinds::GenericUuid;
 use omicron_uuid_kinds::PhysicalDiskUuid;
@@ -139,16 +137,12 @@ pub async fn make_resources(
         LookupType::ById(tuf_repo_id.into_untyped_uuid()),
     ));
 
-    let artifact_id = ArtifactId {
-        name: "a".to_owned(),
-        version: SemverVersion("1.0.0".parse().unwrap()),
-        kind: "b".to_owned(),
-    };
-    let artifact_id_desc = artifact_id.to_string();
+    let tuf_artifact_id =
+        "6827813e-bfaa-4205-9b9f-9f7901e4aab1".parse().unwrap();
     builder.new_resource(authz::TufArtifact::new(
         authz::FLEET,
-        artifact_id,
-        LookupType::ByCompositeId(artifact_id_desc),
+        tuf_artifact_id,
+        LookupType::ById(tuf_artifact_id.into_untyped_uuid()),
     ));
 
     let address_lot_id =

--- a/nexus/db-queries/tests/output/authz-roles.out
+++ b/nexus/db-queries/tests/output/authz-roles.out
@@ -1090,7 +1090,7 @@ resource: TufRepo id "3c52d72f-cbf7-4951-a62f-a4154e74da87"
   silo1-proj1-viewer               ✘  ✘  ✘  ✘  ✘  ✘  ✘  ✘
   unauthenticated                  !  !  !  !  !  !  !  !
 
-resource: TufArtifact id "a v1.0.0 (b)"
+resource: TufArtifact id "6827813e-bfaa-4205-9b9f-9f7901e4aab1"
 
   USER                             Q  R LC RP  M MP CC  D
   fleet-admin                      ✘  ✔  ✔  ✔  ✔  ✔  ✔  ✔

--- a/schema/crdb/dbinit.sql
+++ b/schema/crdb/dbinit.sql
@@ -2352,6 +2352,7 @@ CREATE TABLE IF NOT EXISTS omicron.public.tuf_repo (
 -- In the future, this may also be used to describe artifacts that are fetched
 -- from a remote TUF repo, but that requires some additional design work.
 CREATE TABLE IF NOT EXISTS omicron.public.tuf_artifact (
+    id UUID PRIMARY KEY,
     name STRING(63) NOT NULL,
     version STRING(63) NOT NULL,
     -- This used to be an enum but is now a string, because it can represent
@@ -2368,29 +2369,16 @@ CREATE TABLE IF NOT EXISTS omicron.public.tuf_artifact (
     -- The length of the artifact, in bytes.
     artifact_size INT8 NOT NULL,
 
-    PRIMARY KEY (name, version, kind)
+    CONSTRAINT unique_name_version_kind UNIQUE (name, version, kind)
 );
 
 -- Reflects that a particular artifact was provided by a particular TUF repo.
 -- This is a many-many mapping.
 CREATE TABLE IF NOT EXISTS omicron.public.tuf_repo_artifact (
     tuf_repo_id UUID NOT NULL,
-    tuf_artifact_name STRING(63) NOT NULL,
-    tuf_artifact_version STRING(63) NOT NULL,
-    tuf_artifact_kind STRING(63) NOT NULL,
+    tuf_artifact_id UUID NOT NULL,
 
-    /*
-    For the primary key, this definition uses the natural key rather than a
-    smaller surrogate key (UUID). That's because with CockroachDB the most
-    important factor in selecting a primary key is the ability to distribute
-    well. In this case, the first element of the primary key is the tuf_repo_id,
-    which is a random UUID.
-
-    For more, see https://www.cockroachlabs.com/blog/how-to-choose-a-primary-key/.
-    */
-    PRIMARY KEY (
-        tuf_repo_id, tuf_artifact_name, tuf_artifact_version, tuf_artifact_kind
-    )
+    PRIMARY KEY (tuf_repo_id, tuf_artifact_id)
 );
 
 /*******************************************************************/
@@ -4757,7 +4745,7 @@ INSERT INTO omicron.public.db_metadata (
     version,
     target_version
 ) VALUES
-    (TRUE, NOW(), NOW(), '118.0.0', NULL)
+    (TRUE, NOW(), NOW(), '119.0.0', NULL)
 ON CONFLICT DO NOTHING;
 
 COMMIT;

--- a/schema/crdb/tuf-artifact-key-uuid/up01.sql
+++ b/schema/crdb/tuf-artifact-key-uuid/up01.sql
@@ -1,0 +1,4 @@
+-- At the time of this migration, no racks are able to use the tuf_artifact
+-- and tuf_repo_artifact tables outside of testing; even if they were, those
+-- artifacts couldn't be durably stored. Drop these tables and recreate them.
+DROP TABLE IF EXISTS omicron.public.tuf_artifact

--- a/schema/crdb/tuf-artifact-key-uuid/up02.sql
+++ b/schema/crdb/tuf-artifact-key-uuid/up02.sql
@@ -1,0 +1,2 @@
+-- See up01.sql.
+DROP TABLE IF EXISTS omicron.public.tuf_repo_artifact

--- a/schema/crdb/tuf-artifact-key-uuid/up03.sql
+++ b/schema/crdb/tuf-artifact-key-uuid/up03.sql
@@ -1,0 +1,10 @@
+CREATE TABLE IF NOT EXISTS omicron.public.tuf_artifact (
+    id UUID PRIMARY KEY,
+    name STRING(63) NOT NULL,
+    version STRING(63) NOT NULL,
+    kind STRING(63) NOT NULL,
+    time_created TIMESTAMPTZ NOT NULL,
+    sha256 STRING(64) NOT NULL,
+    artifact_size INT8 NOT NULL,
+    CONSTRAINT unique_name_version_kind UNIQUE (name, version, kind)
+)

--- a/schema/crdb/tuf-artifact-key-uuid/up04.sql
+++ b/schema/crdb/tuf-artifact-key-uuid/up04.sql
@@ -1,0 +1,5 @@
+CREATE TABLE IF NOT EXISTS omicron.public.tuf_repo_artifact (
+    tuf_repo_id UUID NOT NULL,
+    tuf_artifact_id UUID NOT NULL,
+    PRIMARY KEY (tuf_repo_id, tuf_artifact_id)
+)

--- a/uuid-kinds/src/lib.rs
+++ b/uuid-kinds/src/lib.rs
@@ -69,6 +69,7 @@ impl_typed_uuid_kind! {
     Region => "region",
     Sled => "sled",
     SupportBundle => "support_bundle",
+    TufArtifact => "tuf_artifact",
     TufRepo => "tuf_repo",
     Upstairs => "upstairs",
     UpstairsRepair => "upstairs_repair",


### PR DESCRIPTION
`(name, version, kind)` is a natural key for the `tuf_artifact` table: given a kind and name for an artifact, we should only ever have one copy of any particular version.

However, this natural key does not distribute well, which [makes it a poor choice for a primary key in CockroachDB][1]. It also makes pagination more difficult.

Instead of altering the schema we drop the tables and recreate them, as any potential contents would be useless to us; until #7129 lands we have no means to store the artifacts from a repository.

[1]: https://www.cockroachlabs.com/blog/how-to-choose-a-primary-key/