### PR TITLE
[reconfigurator] Add RPW to reconcile debug dataset rendezvous table

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -7049,6 +7049,7 @@ dependencies = [
  "nexus-reconfigurator-execution",
  "nexus-reconfigurator-planning",
  "nexus-reconfigurator-preparation",
+ "nexus-reconfigurator-rendezvous",
  "nexus-saga-recovery",
  "nexus-sled-agent-shared",
  "nexus-test-interface",

--- a/dev-tools/omdb/tests/env.out
+++ b/dev-tools/omdb/tests/env.out
@@ -43,6 +43,11 @@ task: "blueprint_loader"
     Loads the current target blueprint from the DB
 
 
+task: "blueprint_rendezvous"
+    reconciles blueprints and inventory collection, updating Reconfigurator-
+    owned rendezvous tables that other subsystems consume
+
+
 task: "crdb_node_id_collector"
     Collects node IDs of running CockroachDB zones
 
@@ -218,6 +223,11 @@ task: "blueprint_loader"
     Loads the current target blueprint from the DB
 
 
+task: "blueprint_rendezvous"
+    reconciles blueprints and inventory collection, updating Reconfigurator-
+    owned rendezvous tables that other subsystems consume
+
+
 task: "crdb_node_id_collector"
     Collects node IDs of running CockroachDB zones
 
@@ -378,6 +388,11 @@ task: "blueprint_executor"
 
 task: "blueprint_loader"
     Loads the current target blueprint from the DB
+
+
+task: "blueprint_rendezvous"
+    reconciles blueprints and inventory collection, updating Reconfigurator-
+    owned rendezvous tables that other subsystems consume
 
 
 task: "crdb_node_id_collector"

--- a/dev-tools/omdb/tests/successes.out
+++ b/dev-tools/omdb/tests/successes.out
@@ -261,6 +261,11 @@ task: "blueprint_loader"
     Loads the current target blueprint from the DB
 
 
+task: "blueprint_rendezvous"
+    reconciles blueprints and inventory collection, updating Reconfigurator-
+    owned rendezvous tables that other subsystems consume
+
+
 task: "crdb_node_id_collector"
     Collects node IDs of running CockroachDB zones
 
@@ -497,6 +502,13 @@ task: "bfd_manager"
   last completed activation: <REDACTED ITERATIONS>, triggered by a periodic timer firing
     started at <REDACTED_TIMESTAMP> (<REDACTED DURATION>s ago) and ran for <REDACTED DURATION>ms
     last completion reported error: failed to resolve addresses for Dendrite services: no record found for Query { name: Name("_dendrite._tcp.control-plane.oxide.internal."), query_type: SRV, query_class: IN }
+
+task: "blueprint_rendezvous"
+  configured period: every <REDACTED_DURATION>m
+  currently executing: no
+  last completed activation: <REDACTED ITERATIONS>, triggered by a dependent task completing
+    started at <REDACTED_TIMESTAMP> (<REDACTED DURATION>s ago) and ran for <REDACTED DURATION>ms
+    last completion reported error: no blueprint
 
 task: "crdb_node_id_collector"
   configured period: every <REDACTED_DURATION>m
@@ -949,6 +961,13 @@ task: "bfd_manager"
   last completed activation: <REDACTED ITERATIONS>, triggered by a periodic timer firing
     started at <REDACTED_TIMESTAMP> (<REDACTED DURATION>s ago) and ran for <REDACTED DURATION>ms
     last completion reported error: failed to resolve addresses for Dendrite services: no record found for Query { name: Name("_dendrite._tcp.control-plane.oxide.internal."), query_type: SRV, query_class: IN }
+
+task: "blueprint_rendezvous"
+  configured period: every <REDACTED_DURATION>m
+  currently executing: no
+  last completed activation: <REDACTED ITERATIONS>, triggered by a dependent task completing
+    started at <REDACTED_TIMESTAMP> (<REDACTED DURATION>s ago) and ran for <REDACTED DURATION>ms
+    last completion reported error: no blueprint
 
 task: "crdb_node_id_collector"
   configured period: every <REDACTED_DURATION>m

--- a/nexus-config/src/nexus_config.rs
+++ b/nexus-config/src/nexus_config.rs
@@ -581,6 +581,12 @@ pub struct BlueprintTasksConfig {
     pub period_secs_execute: Duration,
 
     /// period (in seconds) for periodic activations of the background task that
+    /// reconciles the latest blueprint and latest inventory collection into
+    /// Rencofigurator rendezvous tables
+    #[serde_as(as = "DurationSeconds<u64>")]
+    pub period_secs_rendezvous: Duration,
+
+    /// period (in seconds) for periodic activations of the background task that
     /// collects the node IDs of CockroachDB zones
     #[serde_as(as = "DurationSeconds<u64>")]
     pub period_secs_collect_crdb_node_ids: Duration,
@@ -953,6 +959,7 @@ mod test {
             phantom_disks.period_secs = 30
             blueprints.period_secs_load = 10
             blueprints.period_secs_execute = 60
+            blueprints.period_secs_rendezvous = 300
             blueprints.period_secs_collect_crdb_node_ids = 180
             sync_service_zone_nat.period_secs = 30
             switch_port_settings_manager.period_secs = 30
@@ -1108,6 +1115,7 @@ mod test {
                             period_secs_execute: Duration::from_secs(60),
                             period_secs_collect_crdb_node_ids:
                                 Duration::from_secs(180),
+                            period_secs_rendezvous: Duration::from_secs(300),
                         },
                         sync_service_zone_nat: SyncServiceZoneNatConfig {
                             period_secs: Duration::from_secs(30)
@@ -1231,6 +1239,7 @@ mod test {
             phantom_disks.period_secs = 30
             blueprints.period_secs_load = 10
             blueprints.period_secs_execute = 60
+            blueprints.period_secs_rendezvous = 300
             blueprints.period_secs_collect_crdb_node_ids = 180
             sync_service_zone_nat.period_secs = 30
             switch_port_settings_manager.period_secs = 30

--- a/nexus/Cargo.toml
+++ b/nexus/Cargo.toml
@@ -109,6 +109,7 @@ nexus-metrics-producer-gc.workspace = true
 nexus-reconfigurator-execution.workspace = true
 nexus-reconfigurator-planning.workspace = true
 nexus-reconfigurator-preparation.workspace = true
+nexus-reconfigurator-rendezvous.workspace = true
 nexus-sled-agent-shared.workspace = true
 nexus-types.workspace = true
 omicron-common.workspace = true

--- a/nexus/db-model/src/schema.rs
+++ b/nexus/db-model/src/schema.rs
@@ -2032,6 +2032,7 @@ allow_tables_to_appear_in_same_query!(hw_baseboard_id, inv_sled_agent,);
 allow_tables_to_appear_in_same_query!(
     bp_omicron_zone,
     bp_target,
+    rendezvous_debug_dataset,
     dataset,
     disk,
     image,

--- a/nexus/examples/config-second.toml
+++ b/nexus/examples/config-second.toml
@@ -126,6 +126,7 @@ support_bundle_collector.period_secs = 30
 decommissioned_disk_cleaner.period_secs = 60
 blueprints.period_secs_load = 10
 blueprints.period_secs_execute = 60
+blueprints.period_secs_rendezvous = 300
 blueprints.period_secs_collect_crdb_node_ids = 180
 sync_service_zone_nat.period_secs = 30
 switch_port_settings_manager.period_secs = 30

--- a/nexus/examples/config.toml
+++ b/nexus/examples/config.toml
@@ -112,6 +112,7 @@ support_bundle_collector.period_secs = 30
 decommissioned_disk_cleaner.period_secs = 60
 blueprints.period_secs_load = 10
 blueprints.period_secs_execute = 60
+blueprints.period_secs_rendezvous = 300
 blueprints.period_secs_collect_crdb_node_ids = 180
 sync_service_zone_nat.period_secs = 30
 switch_port_settings_manager.period_secs = 30

--- a/nexus/src/app/background/init.rs
+++ b/nexus/src/app/background/init.rs
@@ -92,6 +92,7 @@ use super::tasks::abandoned_vmm_reaper;
 use super::tasks::bfd;
 use super::tasks::blueprint_execution;
 use super::tasks::blueprint_load;
+use super::tasks::blueprint_rendezvous;
 use super::tasks::crdb_node_id_collector;
 use super::tasks::decommissioned_disk_cleaner;
 use super::tasks::dns_config;
@@ -156,6 +157,7 @@ pub struct BackgroundTasks {
     pub task_phantom_disks: Activator,
     pub task_blueprint_loader: Activator,
     pub task_blueprint_executor: Activator,
+    pub task_blueprint_rendezvous: Activator,
     pub task_crdb_node_id_collector: Activator,
     pub task_service_zone_nat_tracker: Activator,
     pub task_switch_port_settings_manager: Activator,
@@ -243,6 +245,7 @@ impl BackgroundTasksInitializer {
             task_phantom_disks: Activator::new(),
             task_blueprint_loader: Activator::new(),
             task_blueprint_executor: Activator::new(),
+            task_blueprint_rendezvous: Activator::new(),
             task_crdb_node_id_collector: Activator::new(),
             task_service_zone_nat_tracker: Activator::new(),
             task_switch_port_settings_manager: Activator::new(),
@@ -311,6 +314,7 @@ impl BackgroundTasksInitializer {
             task_phantom_disks,
             task_blueprint_loader,
             task_blueprint_executor,
+            task_blueprint_rendezvous,
             task_crdb_node_id_collector,
             task_service_zone_nat_tracker,
             task_switch_port_settings_manager,
@@ -491,19 +495,15 @@ impl BackgroundTasksInitializer {
             period: config.blueprints.period_secs_collect_crdb_node_ids,
             task_impl: Box::new(crdb_node_id_collector),
             opctx: opctx.child(BTreeMap::new()),
-            watchers: vec![Box::new(rx_blueprint)],
+            watchers: vec![Box::new(rx_blueprint.clone())],
             activator: task_crdb_node_id_collector,
         });
 
         // Background task: inventory collector
         //
-        // This currently depends on the "output" of the blueprint executor in
+        // This depends on the "output" of the blueprint executor in
         // order to automatically trigger inventory collection whenever the
-        // blueprint executor runs.  In the limit, this could become a problem
-        // because the blueprint executor might also depend indirectly on the
-        // inventory collector.  In that case, we could expose `Activator`s to
-        // one or both of these tasks to directly activate the other precisely
-        // when needed.  But for now, this works.
+        // blueprint executor runs.
         let inventory_watcher = {
             let collector = inventory_collection::InventoryCollector::new(
                 datastore.clone(),
@@ -563,8 +563,26 @@ impl BackgroundTasksInitializer {
                 ),
             ),
             opctx: opctx.child(BTreeMap::new()),
-            watchers: vec![Box::new(inventory_watcher)],
+            watchers: vec![Box::new(inventory_watcher.clone())],
             activator: task_physical_disk_adoption,
+        });
+
+        driver.register(TaskDefinition {
+            name: "blueprint_rendezvous",
+            description:
+                "reconciles blueprints and inventory collection, updating \
+                 Reconfigurator-owned rendezvous tables that other subsystems \
+                 consume",
+            period: config.blueprints.period_secs_rendezvous,
+            task_impl: Box::new(
+                blueprint_rendezvous::BlueprintRendezvous::new(
+                    datastore.clone(),
+                    rx_blueprint.clone(),
+                ),
+            ),
+            opctx: opctx.child(BTreeMap::new()),
+            watchers: vec![Box::new(inventory_watcher.clone())],
+            activator: task_blueprint_rendezvous,
         });
 
         driver.register(TaskDefinition {

--- a/nexus/src/app/background/tasks/blueprint_rendezvous.rs
+++ b/nexus/src/app/background/tasks/blueprint_rendezvous.rs
@@ -41,15 +41,14 @@ impl BlueprintRendezvous {
     /// The presence of `boxed()` in `BackgroundTask::activate` has caused some
     /// confusion with compilation errors in the past. So separate this method
     /// out.
-    async fn activate_impl<'a>(
+    async fn activate_impl(
         &mut self,
         opctx: &OpContext,
     ) -> serde_json::Value {
         // Get the latest blueprint, cloning to prevent holding a read lock
         // on the watch.
         let update = self.rx_blueprint.borrow_and_update().clone();
-
-        let Some(update) = update else {
+        let Some((_, blueprint)) = update.as_deref() else {
             warn!(
                 &opctx.log, "Blueprint rendezvous: skipped";
                 "reason" => "no blueprint",
@@ -86,7 +85,6 @@ impl BlueprintRendezvous {
         };
 
         // Actually perform rendezvous table reconciliation
-        let (_, blueprint) = &*update;
         let result = reconcile_blueprint_rendezvous_tables(
             opctx,
             &self.datastore,

--- a/nexus/src/app/background/tasks/blueprint_rendezvous.rs
+++ b/nexus/src/app/background/tasks/blueprint_rendezvous.rs
@@ -41,10 +41,7 @@ impl BlueprintRendezvous {
     /// The presence of `boxed()` in `BackgroundTask::activate` has caused some
     /// confusion with compilation errors in the past. So separate this method
     /// out.
-    async fn activate_impl(
-        &mut self,
-        opctx: &OpContext,
-    ) -> serde_json::Value {
+    async fn activate_impl(&mut self, opctx: &OpContext) -> serde_json::Value {
         // Get the latest blueprint, cloning to prevent holding a read lock
         // on the watch.
         let update = self.rx_blueprint.borrow_and_update().clone();

--- a/nexus/src/app/background/tasks/blueprint_rendezvous.rs
+++ b/nexus/src/app/background/tasks/blueprint_rendezvous.rs
@@ -1,0 +1,115 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at https://mozilla.org/MPL/2.0/.
+
+//! Background task for reconciling blueprints and inventory, updating
+//! Reconfigurator rendezvous tables
+
+use crate::app::background::BackgroundTask;
+use futures::future::BoxFuture;
+use futures::FutureExt;
+use nexus_db_queries::context::OpContext;
+use nexus_db_queries::db::DataStore;
+use nexus_reconfigurator_rendezvous::reconcile_blueprint_rendezvous_tables;
+use nexus_types::deployment::{Blueprint, BlueprintTarget};
+use serde_json::json;
+use slog_error_chain::InlineErrorChain;
+use std::sync::Arc;
+use tokio::sync::watch;
+
+/// Background task that takes a [`Blueprint`] and an inventory `Collection`
+/// and updates any rendezvous tables to track resources under Reconfigurator's
+/// control for other parts of Nexus to consume.
+pub struct BlueprintRendezvous {
+    datastore: Arc<DataStore>,
+    rx_blueprint: watch::Receiver<Option<Arc<(BlueprintTarget, Blueprint)>>>,
+}
+
+impl BlueprintRendezvous {
+    pub fn new(
+        datastore: Arc<DataStore>,
+        rx_blueprint: watch::Receiver<
+            Option<Arc<(BlueprintTarget, Blueprint)>>,
+        >,
+    ) -> Self {
+        Self { datastore, rx_blueprint }
+    }
+
+    /// Implementation for `BackgroundTask::activate` for `BlueprintRendezvous`,
+    /// added here to produce better compile errors.
+    ///
+    /// The presence of `boxed()` in `BackgroundTask::activate` has caused some
+    /// confusion with compilation errors in the past. So separate this method
+    /// out.
+    async fn activate_impl<'a>(
+        &mut self,
+        opctx: &OpContext,
+    ) -> serde_json::Value {
+        // Get the latest blueprint, cloning to prevent holding a read lock
+        // on the watch.
+        let update = self.rx_blueprint.borrow_and_update().clone();
+
+        let Some(update) = update else {
+            warn!(
+                &opctx.log, "Blueprint rendezvous: skipped";
+                "reason" => "no blueprint",
+            );
+            return json!({"error": "no blueprint" });
+        };
+
+        // Get the latest inventory collection
+        let maybe_collection = match self
+            .datastore
+            .inventory_get_latest_collection(opctx)
+            .await
+        {
+            Ok(maybe_collection) => maybe_collection,
+            Err(err) => {
+                let err = InlineErrorChain::new(&err);
+                warn!(
+                    &opctx.log, "Blueprint rendezvous: skipped";
+                    "reason" => "failed to read latest inventory collection",
+                    &err,
+                );
+                return json!({ "error":
+                    format!("failed reading inventory collection: {err}"),
+                });
+            }
+        };
+
+        let Some(collection) = maybe_collection else {
+            warn!(
+                &opctx.log, "Blueprint rendezvous: skipped";
+                "reason" => "no inventory collection",
+            );
+            return json!({"error": "no inventory collection" });
+        };
+
+        // Actually perform rendezvous table reconciliation
+        let (_, blueprint) = &*update;
+        let result = reconcile_blueprint_rendezvous_tables(
+            opctx,
+            &self.datastore,
+            blueprint,
+            &collection,
+        )
+        .await;
+
+        // Return the result as a `serde_json::Value`
+        match result {
+            Ok(()) => json!({}),
+            Err(err) => json!({ "error":
+                format!("rendezvous reconciliation failed: {err:#}"),
+            }),
+        }
+    }
+}
+
+impl BackgroundTask for BlueprintRendezvous {
+    fn activate<'a>(
+        &'a mut self,
+        opctx: &'a OpContext,
+    ) -> BoxFuture<'a, serde_json::Value> {
+        self.activate_impl(opctx).boxed()
+    }
+}

--- a/nexus/src/app/background/tasks/mod.rs
+++ b/nexus/src/app/background/tasks/mod.rs
@@ -8,6 +8,7 @@ pub mod abandoned_vmm_reaper;
 pub mod bfd;
 pub mod blueprint_execution;
 pub mod blueprint_load;
+pub mod blueprint_rendezvous;
 pub mod crdb_node_id_collector;
 pub mod decommissioned_disk_cleaner;
 pub mod dns_config;

--- a/nexus/src/lib.rs
+++ b/nexus/src/lib.rs
@@ -26,6 +26,7 @@ use dropshot::ConfigDropshot;
 use external_api::http_entrypoints::external_api;
 use internal_api::http_entrypoints::internal_api;
 use nexus_config::NexusConfig;
+use nexus_db_model::RendezvousDebugDataset;
 use nexus_types::deployment::blueprint_zone_type;
 use nexus_types::deployment::Blueprint;
 use nexus_types::deployment::BlueprintZoneFilter;
@@ -43,7 +44,10 @@ use omicron_common::api::internal::shared::{
 };
 use omicron_common::disk::DatasetKind;
 use omicron_common::FileKv;
+use omicron_uuid_kinds::BlueprintUuid;
 use omicron_uuid_kinds::DatasetUuid;
+use omicron_uuid_kinds::GenericUuid as _;
+use omicron_uuid_kinds::ZpoolUuid;
 use oximeter::types::ProducerRegistry;
 use oximeter_producer::Server as ProducerServer;
 use slog::Logger;
@@ -383,6 +387,7 @@ impl nexus_test_interface::NexusServer for Server {
             .unwrap();
 
         let zpool_id = zpool.id;
+        let is_debug_dataset = kind == DatasetKind::Debug;
 
         self.apictx.context.nexus.upsert_zpool(&opctx, zpool).await.unwrap();
 
@@ -392,6 +397,29 @@ impl nexus_test_interface::NexusServer for Server {
             .upsert_dataset(dataset_id, zpool_id, kind, address)
             .await
             .unwrap();
+
+        // If any tests want debug datasets, manually insert them into the
+        // blueprint rendezvous table with a fake blueprint ID.
+        //
+        // This is making the mess of test-utils / blueprint / dataset
+        // integration worse
+        // (https://github.com/oxidecomputer/omicron/issues/7081).
+        if is_debug_dataset {
+            self.apictx
+                .context
+                .nexus
+                .datastore()
+                .debug_dataset_insert_if_not_exists(
+                    &opctx,
+                    RendezvousDebugDataset::new(
+                        dataset_id,
+                        ZpoolUuid::from_untyped_uuid(zpool_id),
+                        BlueprintUuid::new_v4(),
+                    ),
+                )
+                .await
+                .unwrap();
+        }
     }
 
     async fn inventory_collect_and_get_latest_collection(

--- a/nexus/tests/config.test.toml
+++ b/nexus/tests/config.test.toml
@@ -112,6 +112,7 @@ decommissioned_disk_cleaner.period_secs = 60
 decommissioned_disk_cleaner.disable = true
 blueprints.period_secs_load = 100
 blueprints.period_secs_execute = 600
+blueprints.period_secs_rendezvous = 600
 blueprints.period_secs_collect_crdb_node_ids = 600
 sync_service_zone_nat.period_secs = 30
 switch_port_settings_manager.period_secs = 30

--- a/smf/nexus/multi-sled/config-partial.toml
+++ b/smf/nexus/multi-sled/config-partial.toml
@@ -54,6 +54,7 @@ support_bundle_collector.period_secs = 30
 decommissioned_disk_cleaner.period_secs = 60
 blueprints.period_secs_load = 10
 blueprints.period_secs_execute = 60
+blueprints.period_secs_rendezvous = 300
 blueprints.period_secs_collect_crdb_node_ids = 180
 sync_service_zone_nat.period_secs = 30
 switch_port_settings_manager.period_secs = 30

--- a/smf/nexus/single-sled/config-partial.toml
+++ b/smf/nexus/single-sled/config-partial.toml
@@ -54,6 +54,7 @@ support_bundle_collector.period_secs = 30
 decommissioned_disk_cleaner.period_secs = 60
 blueprints.period_secs_load = 10
 blueprints.period_secs_execute = 60
+blueprints.period_secs_rendezvous = 300
 blueprints.period_secs_collect_crdb_node_ids = 180
 sync_service_zone_nat.period_secs = 30
 switch_port_settings_manager.period_secs = 30


### PR DESCRIPTION
This is PR 2 of 2 and builds on #7341; it adds an RPW that calls the library added in that PR to actually reconcile blueprint+inventory and update the debug dataset rendezvous table, and changes the support bundle query that picks a debug dataset to use this new table.
