### PR TITLE
move support bundle bg tasks into internal_api crate

### DIFF
--- a/nexus/src/app/background/mod.rs
+++ b/nexus/src/app/background/mod.rs
@@ -140,13 +140,6 @@ pub use init::BackgroundTasksData;
 pub use init::BackgroundTasksInitializer;
 pub use tasks::saga_recovery::SagaRecoveryHelpers;
 
-// Expose background task outputs to they can be deserialized and
-// observed.
-pub mod task_output {
-    pub use super::tasks::support_bundle_collector::CleanupReport;
-    pub use super::tasks::support_bundle_collector::CollectionReport;
-}
-
 use futures::future::BoxFuture;
 use nexus_auth::context::OpContext;
 

--- a/nexus/src/app/background/tasks/support_bundle_collector.rs
+++ b/nexus/src/app/background/tasks/support_bundle_collector.rs
@@ -19,6 +19,8 @@ use nexus_db_queries::context::OpContext;
 use nexus_db_queries::db::DataStore;
 use nexus_types::deployment::SledFilter;
 use nexus_types::identity::Asset;
+use nexus_types::internal_api::background::SupportBundleCleanupReport;
+use nexus_types::internal_api::background::SupportBundleCollectionReport;
 use omicron_common::api::external::DataPageParams;
 use omicron_common::api::external::Error;
 use omicron_common::api::external::LookupType;
@@ -30,8 +32,6 @@ use omicron_uuid_kinds::OmicronZoneUuid;
 use omicron_uuid_kinds::SledUuid;
 use omicron_uuid_kinds::SupportBundleUuid;
 use omicron_uuid_kinds::ZpoolUuid;
-use serde::Deserialize;
-use serde::Serialize;
 use serde_json::json;
 use sha2::{Digest, Sha256};
 use std::io::Write;
@@ -59,19 +59,6 @@ fn authz_support_bundle_from_id(id: SupportBundleUuid) -> authz::SupportBundle {
 struct BundleRequest {
     // If "false": Skip collecting host-specific info from each sled.
     skip_sled_info: bool,
-}
-
-// Describes what happened while attempting to clean up Support Bundles.
-#[derive(Debug, Default, Deserialize, Serialize, Eq, PartialEq)]
-pub struct CleanupReport {
-    // Responses from Sled Agents
-    pub sled_bundles_deleted_ok: usize,
-    pub sled_bundles_deleted_not_found: usize,
-    pub sled_bundles_delete_failed: usize,
-
-    // Results from updating our database records
-    pub db_destroying_bundles_removed: usize,
-    pub db_failing_bundles_updated: usize,
 }
 
 // Result of asking a sled agent to clean up a bundle
@@ -244,7 +231,7 @@ impl SupportBundleCollector {
     async fn cleanup_destroyed_bundles(
         &self,
         opctx: &OpContext,
-    ) -> anyhow::Result<CleanupReport> {
+    ) -> anyhow::Result<SupportBundleCleanupReport> {
         let pagparams = DataPageParams::max_page();
         let result = self
             .datastore
@@ -271,7 +258,7 @@ impl SupportBundleCollector {
             }
         };
 
-        let mut report = CleanupReport::default();
+        let mut report = SupportBundleCleanupReport::default();
 
         // NOTE: This could be concurrent, but the priority for that also seems low
         for bundle in bundles_to_destroy {
@@ -344,7 +331,7 @@ impl SupportBundleCollector {
         &self,
         opctx: &OpContext,
         request: &BundleRequest,
-    ) -> anyhow::Result<Option<CollectionReport>> {
+    ) -> anyhow::Result<Option<SupportBundleCollectionReport>> {
         let pagparams = DataPageParams::max_page();
         let result = self
             .datastore
@@ -438,7 +425,7 @@ impl BundleCollection<'_> {
     // Collect the bundle within Nexus, and store it on a target sled.
     async fn collect_bundle_and_store_on_sled(
         &self,
-    ) -> anyhow::Result<CollectionReport> {
+    ) -> anyhow::Result<SupportBundleCollectionReport> {
         // Create a temporary directory where we'll store the support bundle
         // as it's being collected.
         let dir = tempdir_in(TEMPDIR)?;
@@ -543,8 +530,8 @@ impl BundleCollection<'_> {
     // - "bundle" is metadata about the bundle being collected.
     //
     // If a partial bundle can be collected, it should be returned as
-    // an Ok(CollectionReport). Any failures from this function will prevent
-    // the support bundle from being collected altogether.
+    // an Ok(SupportBundleCollectionReport). Any failures from this function
+    // will prevent the support bundle from being collected altogether.
     //
     // NOTE: The background task infrastructure will periodically check to see
     // if the bundle has been cancelled by a user while it is being collected.
@@ -555,11 +542,12 @@ impl BundleCollection<'_> {
     async fn collect_bundle_as_file(
         &self,
         dir: &Utf8TempDir,
-    ) -> anyhow::Result<CollectionReport> {
+    ) -> anyhow::Result<SupportBundleCollectionReport> {
         let log = &self.log;
 
         info!(&log, "Collecting bundle as local file");
-        let mut report = CollectionReport::new(self.bundle.id.into());
+        let mut report =
+            SupportBundleCollectionReport::new(self.bundle.id.into());
 
         tokio::fs::write(
             dir.path().join("bundle_id.txt"),
@@ -740,30 +728,6 @@ async fn sha2_hash(file: &mut tokio::fs::File) -> anyhow::Result<ArtifactHash> {
     Ok(ArtifactHash(digest.as_slice().try_into()?))
 }
 
-// Identifies what we could or could not store within this support bundle.
-//
-// This struct will get emitted as part of the background task infrastructure.
-#[derive(Debug, Deserialize, Serialize, PartialEq, Eq)]
-pub struct CollectionReport {
-    pub bundle: SupportBundleUuid,
-
-    // True iff we could list in-service sleds
-    pub listed_in_service_sleds: bool,
-
-    // True iff the bundle was successfully made 'active' in the database.
-    pub activated_in_db_ok: bool,
-}
-
-impl CollectionReport {
-    fn new(bundle: SupportBundleUuid) -> Self {
-        Self {
-            bundle,
-            listed_in_service_sleds: false,
-            activated_in_db_ok: false,
-        }
-    }
-}
-
 async fn write_command_result_or_error<D: std::fmt::Debug>(
     path: &Utf8Path,
     command: &str,
@@ -858,7 +822,7 @@ mod test {
             .await
             .expect("Cleanup should succeed with no work to do");
 
-        assert_eq!(report, CleanupReport::default());
+        assert_eq!(report, SupportBundleCleanupReport::default());
     }
 
     // If there are no bundles in need of collection, the collection task should
@@ -1176,7 +1140,7 @@ mod test {
             .expect("Cleanup should succeed with no work to do");
         assert_eq!(
             report,
-            CleanupReport {
+            SupportBundleCleanupReport {
                 // Nothing was provisioned on the sled, since we hadn't started
                 // collection yet.
                 sled_bundles_deleted_not_found: 1,
@@ -1241,7 +1205,7 @@ mod test {
             .expect("Cleanup should succeed with no work to do");
         assert_eq!(
             report,
-            CleanupReport {
+            SupportBundleCleanupReport {
                 // Nothing was provisioned on the sled, since we hadn't started
                 // collection yet.
                 sled_bundles_deleted_ok: 1,
@@ -1298,7 +1262,7 @@ mod test {
             .expect("Cleanup should delete failing bundle");
         assert_eq!(
             report,
-            CleanupReport {
+            SupportBundleCleanupReport {
                 // Nothing was provisioned on the sled, since we hadn't started
                 // collection yet.
                 sled_bundles_deleted_not_found: 1,
@@ -1366,7 +1330,7 @@ mod test {
             .expect("Cleanup should delete failing bundle");
         assert_eq!(
             report,
-            CleanupReport {
+            SupportBundleCleanupReport {
                 // The bundle was provisioned on the sled, so we should have
                 // successfully removed it when we later talk to the sled.
                 //
@@ -1448,7 +1412,7 @@ mod test {
             .expect("Cleanup should delete failing bundle");
         assert_eq!(
             report,
-            CleanupReport {
+            SupportBundleCleanupReport {
                 // The database state was "failing", and now it's updated.
                 //
                 // Note that it isn't immediately deleted, so the end-user

--- a/nexus/src/app/test_interfaces.rs
+++ b/nexus/src/app/test_interfaces.rs
@@ -18,8 +18,6 @@ pub use super::update::SpUpdater;
 pub use super::update::UpdateProgress;
 pub use gateway_client::types::SpType;
 
-pub use crate::app::background::task_output;
-
 /// The information needed to talk to a sled agent about an instance that is
 /// active on that sled.
 pub struct InstanceSledAgentInfo {

--- a/nexus/tests/integration_tests/support_bundles.rs
+++ b/nexus/tests/integration_tests/support_bundles.rs
@@ -18,8 +18,9 @@ use nexus_test_utils::resource_helpers::TestDataset;
 use nexus_test_utils_macros::nexus_test;
 use nexus_types::external_api::shared::SupportBundleInfo;
 use nexus_types::external_api::shared::SupportBundleState;
+use nexus_types::internal_api::background::SupportBundleCleanupReport;
+use nexus_types::internal_api::background::SupportBundleCollectionReport;
 use omicron_common::api::internal::shared::DatasetKind;
-use omicron_nexus::app::test_interfaces::task_output;
 use omicron_uuid_kinds::{DatasetUuid, SupportBundleUuid, ZpoolUuid};
 use serde::Deserialize;
 use std::io::Cursor;
@@ -236,8 +237,8 @@ async fn bundle_download_expect_fail(
 struct TaskOutput {
     cleanup_err: Option<String>,
     collection_err: Option<String>,
-    cleanup_report: Option<task_output::CleanupReport>,
-    collection_report: Option<task_output::CollectionReport>,
+    cleanup_report: Option<SupportBundleCleanupReport>,
+    collection_report: Option<SupportBundleCollectionReport>,
 }
 
 async fn activate_bundle_collection_background_task(
@@ -416,11 +417,11 @@ async fn test_support_bundle_lifecycle(cptestctx: &ControlPlaneTestContext) {
     assert_eq!(output.collection_err, None);
     assert_eq!(
         output.cleanup_report,
-        Some(task_output::CleanupReport { ..Default::default() })
+        Some(SupportBundleCleanupReport { ..Default::default() })
     );
     assert_eq!(
         output.collection_report,
-        Some(task_output::CollectionReport {
+        Some(SupportBundleCollectionReport {
             bundle: bundle.id,
             listed_in_service_sleds: true,
             activated_in_db_ok: true,
@@ -459,7 +460,7 @@ async fn test_support_bundle_lifecycle(cptestctx: &ControlPlaneTestContext) {
     assert_eq!(output.collection_err, None);
     assert_eq!(
         output.cleanup_report,
-        Some(task_output::CleanupReport {
+        Some(SupportBundleCleanupReport {
             sled_bundles_deleted_ok: 1,
             db_destroying_bundles_removed: 1,
             ..Default::default()


### PR DESCRIPTION
I didn't realize this is where other background task outputs were being stashed.

This is an intermediate PR to help omdb parse support bundle background task output