### PR TITLE
Fix `test_sled_instance_list`

### DIFF
--- a/nexus/tests/integration_tests/sleds.rs
+++ b/nexus/tests/integration_tests/sleds.rs
@@ -193,11 +193,13 @@ async fn test_sled_instance_list(cptestctx: &ControlPlaneTestContext) {
                 for sled in &sleds {
                     let sled_id = sled.identity.id;
 
-                    let instances_url =
-                        format!("/v1/system/hardware/sleds/{sled_id}/instances");
+                    let instances_url = format!(
+                        "/v1/system/hardware/sleds/{sled_id}/instances"
+                    );
 
                     let mut sled_instances =
-                        sled_instance_list(&external_client, &instances_url).await;
+                        sled_instance_list(&external_client, &instances_url)
+                            .await;
 
                     total_instances.append(&mut sled_instances);
                 }


### PR DESCRIPTION
`test_sled_instance_list` was broken by the most recent change to the control plane test context: previously only one of the two sled agents (the first one) was provisionable for instances, and the test would check that one to test the sled instances list endpoint. The most recent change to the test context made all sled agents provisionable but didn't update the test to check all the sleds for the provisioned instance. This resulted in a test flake: if the instance was allocated to the first sled, it would pass. If it was allocated to the second sled, it would time out.

Fixes #7365