### PR TITLE
[oxlog] skip unnecessary lstat

### DIFF
--- a/dev-tools/oxlog/src/lib.rs
+++ b/dev-tools/oxlog/src/lib.rs
@@ -383,10 +383,12 @@ fn load_svc_logs(
                 continue;
             };
 
-            logfile.read_metadata(&entry);
-            if logfile.size == Some(0) && !show_empty {
-                // skip 0 size files
-                continue;
+            if !show_empty {
+                logfile.read_metadata(&entry);
+                if logfile.size == Some(0) {
+                    // skip 0 size files
+                    continue;
+                }
             }
 
             let is_current = filename.ends_with(".log");

--- a/dev-tools/oxlog/src/lib.rs
+++ b/dev-tools/oxlog/src/lib.rs
@@ -426,10 +426,12 @@ fn load_extra_logs(
         let mut path = dir.clone();
         path.push(filename);
         let mut logfile = LogFile::new(path);
-        logfile.read_metadata(&entry);
-        if logfile.size == Some(0) && !show_empty {
-            // skip 0 size files
-            continue;
+        if !show_empty {
+            logfile.read_metadata(&entry);
+            if logfile.size == Some(0) {
+                // skip 0 size files
+                continue;
+            }
         }
         svc_logs.extra.push(logfile);
     }


### PR DESCRIPTION
We should not incur the cost of calling `lstat` on every log file oxlog walks over when we are returning all log files regardless of size. If someone requests that we don't show 0 length files through oxlog the binary or the library then we will do the `lstat` in order to check the file length.

I originally found this edge case when operating on a sled with 600k plus log files that were being walked. Figuring out what we want to do about aging out old debug logs is out of the scope of this PR.