### PR TITLE
Do not pass arbitrary strings to volume_create!

### DIFF
--- a/nexus/db-queries/src/db/datastore/region_replacement.rs
+++ b/nexus/db-queries/src/db/datastore/region_replacement.rs
@@ -943,16 +943,15 @@ mod test {
         let volume_id = VolumeUuid::new_v4();
 
         datastore
-            .volume_create(nexus_db_model::Volume::new(
+            .volume_create(
                 volume_id,
-                serde_json::to_string(&VolumeConstructionRequest::Volume {
+                VolumeConstructionRequest::Volume {
                     id: Uuid::new_v4(),
                     block_size: 512,
                     sub_volumes: vec![],
                     read_only_parent: None,
-                })
-                .unwrap(),
-            ))
+                },
+            )
             .await
             .unwrap();
 
@@ -988,16 +987,15 @@ mod test {
         let volume_id = VolumeUuid::new_v4();
 
         datastore
-            .volume_create(nexus_db_model::Volume::new(
+            .volume_create(
                 volume_id,
-                serde_json::to_string(&VolumeConstructionRequest::Volume {
+                VolumeConstructionRequest::Volume {
                     id: Uuid::new_v4(),
                     block_size: 512,
                     sub_volumes: vec![],
                     read_only_parent: None,
-                })
-                .unwrap(),
-            ))
+                },
+            )
             .await
             .unwrap();
 
@@ -1094,16 +1092,15 @@ mod test {
         let volume_id = VolumeUuid::new_v4();
 
         datastore
-            .volume_create(nexus_db_model::Volume::new(
+            .volume_create(
                 volume_id,
-                serde_json::to_string(&VolumeConstructionRequest::Volume {
+                VolumeConstructionRequest::Volume {
                     id: Uuid::new_v4(),
                     block_size: 512,
                     sub_volumes: vec![],
                     read_only_parent: None,
-                })
-                .unwrap(),
-            ))
+                },
+            )
             .await
             .unwrap();
 

--- a/nexus/db-queries/src/db/datastore/region_snapshot_replacement.rs
+++ b/nexus/db-queries/src/db/datastore/region_snapshot_replacement.rs
@@ -1404,16 +1404,15 @@ mod test {
         let volume_id = VolumeUuid::new_v4();
 
         datastore
-            .volume_create(nexus_db_model::Volume::new(
+            .volume_create(
                 volume_id,
-                serde_json::to_string(&VolumeConstructionRequest::Volume {
+                VolumeConstructionRequest::Volume {
                     id: Uuid::new_v4(), // not required to match!
                     block_size: 512,
                     sub_volumes: vec![], // nothing needed here
                     read_only_parent: None,
-                })
-                .unwrap(),
-            ))
+                },
+            )
             .await
             .unwrap();
 
@@ -1464,16 +1463,15 @@ mod test {
         let volume_id = VolumeUuid::new_v4();
 
         datastore
-            .volume_create(nexus_db_model::Volume::new(
+            .volume_create(
                 volume_id,
-                serde_json::to_string(&VolumeConstructionRequest::Volume {
+                VolumeConstructionRequest::Volume {
                     id: Uuid::new_v4(), // not required to match!
                     block_size: 512,
                     sub_volumes: vec![], // nothing needed here
                     read_only_parent: None,
-                })
-                .unwrap(),
-            ))
+                },
+            )
             .await
             .unwrap();
 
@@ -1514,16 +1512,15 @@ mod test {
         let volume_id = VolumeUuid::new_v4();
 
         datastore
-            .volume_create(nexus_db_model::Volume::new(
+            .volume_create(
                 volume_id,
-                serde_json::to_string(&VolumeConstructionRequest::Volume {
+                VolumeConstructionRequest::Volume {
                     id: Uuid::new_v4(), // not required to match!
                     block_size: 512,
                     sub_volumes: vec![], // nothing needed here
                     read_only_parent: None,
-                })
-                .unwrap(),
-            ))
+                },
+            )
             .await
             .unwrap();
 
@@ -1562,16 +1559,15 @@ mod test {
         let step_volume_id = VolumeUuid::new_v4();
 
         datastore
-            .volume_create(nexus_db_model::Volume::new(
+            .volume_create(
                 step_volume_id,
-                serde_json::to_string(&VolumeConstructionRequest::Volume {
+                VolumeConstructionRequest::Volume {
                     id: Uuid::new_v4(), // not required to match!
                     block_size: 512,
                     sub_volumes: vec![], // nothing needed here
                     read_only_parent: None,
-                })
-                .unwrap(),
-            ))
+                },
+            )
             .await
             .unwrap();
 
@@ -1609,16 +1605,15 @@ mod test {
         let step_volume_id = VolumeUuid::new_v4();
 
         datastore
-            .volume_create(nexus_db_model::Volume::new(
+            .volume_create(
                 step_volume_id,
-                serde_json::to_string(&VolumeConstructionRequest::Volume {
+                VolumeConstructionRequest::Volume {
                     id: Uuid::new_v4(), // not required to match!
                     block_size: 512,
                     sub_volumes: vec![], // nothing needed here
                     read_only_parent: None,
-                })
-                .unwrap(),
-            ))
+                },
+            )
             .await
             .unwrap();
 
@@ -1659,16 +1654,15 @@ mod test {
         let step_volume_id = VolumeUuid::new_v4();
 
         datastore
-            .volume_create(nexus_db_model::Volume::new(
+            .volume_create(
                 step_volume_id,
-                serde_json::to_string(&VolumeConstructionRequest::Volume {
+                VolumeConstructionRequest::Volume {
                     id: Uuid::new_v4(), // not required to match!
                     block_size: 512,
                     sub_volumes: vec![], // nothing needed here
                     read_only_parent: None,
-                })
-                .unwrap(),
-            ))
+                },
+            )
             .await
             .unwrap();
 
@@ -1725,16 +1719,15 @@ mod test {
         let volume_id = VolumeUuid::new_v4();
 
         datastore
-            .volume_create(nexus_db_model::Volume::new(
+            .volume_create(
                 volume_id,
-                serde_json::to_string(&VolumeConstructionRequest::Volume {
+                VolumeConstructionRequest::Volume {
                     id: Uuid::new_v4(), // not required to match!
                     block_size: 512,
                     sub_volumes: vec![], // nothing needed here
                     read_only_parent: None,
-                })
-                .unwrap(),
-            ))
+                },
+            )
             .await
             .unwrap();
 
@@ -1835,16 +1828,15 @@ mod test {
         let volume_id = VolumeUuid::new_v4();
 
         datastore
-            .volume_create(nexus_db_model::Volume::new(
+            .volume_create(
                 volume_id,
-                serde_json::to_string(&VolumeConstructionRequest::Volume {
+                VolumeConstructionRequest::Volume {
                     id: Uuid::new_v4(), // not required to match!
                     block_size: 512,
                     sub_volumes: vec![], // nothing needed here
                     read_only_parent: None,
-                })
-                .unwrap(),
-            ))
+                },
+            )
             .await
             .unwrap();
 
@@ -1875,16 +1867,15 @@ mod test {
         let step_volume_id = VolumeUuid::new_v4();
 
         datastore
-            .volume_create(nexus_db_model::Volume::new(
+            .volume_create(
                 step_volume_id,
-                serde_json::to_string(&VolumeConstructionRequest::Volume {
+                VolumeConstructionRequest::Volume {
                     id: Uuid::new_v4(), // not required to match!
                     block_size: 512,
                     sub_volumes: vec![], // nothing needed here
                     read_only_parent: None,
-                })
-                .unwrap(),
-            ))
+                },
+            )
             .await
             .unwrap();
 
@@ -1902,16 +1893,15 @@ mod test {
         let step_volume_id = VolumeUuid::new_v4();
 
         datastore
-            .volume_create(nexus_db_model::Volume::new(
+            .volume_create(
                 step_volume_id,
-                serde_json::to_string(&VolumeConstructionRequest::Volume {
+                VolumeConstructionRequest::Volume {
                     id: Uuid::new_v4(), // not required to match!
                     block_size: 512,
                     sub_volumes: vec![], // nothing needed here
                     read_only_parent: None,
-                })
-                .unwrap(),
-            ))
+                },
+            )
             .await
             .unwrap();
 
@@ -1957,30 +1947,28 @@ mod test {
         let old_snapshot_volume_id = VolumeUuid::new_v4();
 
         datastore
-            .volume_create(nexus_db_model::Volume::new(
+            .volume_create(
                 volume_id,
-                serde_json::to_string(&VolumeConstructionRequest::Volume {
+                VolumeConstructionRequest::Volume {
                     id: Uuid::new_v4(), // not required to match!
                     block_size: 512,
                     sub_volumes: vec![], // nothing needed here
                     read_only_parent: None,
-                })
-                .unwrap(),
-            ))
+                },
+            )
             .await
             .unwrap();
 
         datastore
-            .volume_create(nexus_db_model::Volume::new(
+            .volume_create(
                 old_snapshot_volume_id,
-                serde_json::to_string(&VolumeConstructionRequest::Volume {
+                VolumeConstructionRequest::Volume {
                     id: Uuid::new_v4(), // not required to match!
                     block_size: 512,
                     sub_volumes: vec![], // nothing needed here
                     read_only_parent: None,
-                })
-                .unwrap(),
-            ))
+                },
+            )
             .await
             .unwrap();
 
@@ -2034,16 +2022,15 @@ mod test {
         let volume_id = VolumeUuid::new_v4();
 
         datastore
-            .volume_create(nexus_db_model::Volume::new(
+            .volume_create(
                 volume_id,
-                serde_json::to_string(&VolumeConstructionRequest::Volume {
+                VolumeConstructionRequest::Volume {
                     id: Uuid::new_v4(),
                     block_size: 512,
                     sub_volumes: vec![],
                     read_only_parent: None,
-                })
-                .unwrap(),
-            ))
+                },
+            )
             .await
             .unwrap();
 

--- a/nexus/db-queries/src/db/datastore/volume_repair.rs
+++ b/nexus/db-queries/src/db/datastore/volume_repair.rs
@@ -185,16 +185,15 @@ mod test {
         let volume_id = VolumeUuid::new_v4();
 
         datastore
-            .volume_create(nexus_db_model::Volume::new(
+            .volume_create(
                 volume_id,
-                serde_json::to_string(&VolumeConstructionRequest::Volume {
+                VolumeConstructionRequest::Volume {
                     id: Uuid::new_v4(),
                     block_size: 512,
                     sub_volumes: vec![],
                     read_only_parent: None,
-                })
-                .unwrap(),
-            ))
+                },
+            )
             .await
             .unwrap();
 
@@ -242,16 +241,15 @@ mod test {
         let volume_id = VolumeUuid::new_v4();
 
         datastore
-            .volume_create(nexus_db_model::Volume::new(
+            .volume_create(
                 volume_id,
-                serde_json::to_string(&VolumeConstructionRequest::Volume {
+                VolumeConstructionRequest::Volume {
                     id: Uuid::new_v4(),
                     block_size: 512,
                     sub_volumes: vec![],
                     read_only_parent: None,
-                })
-                .unwrap(),
-            ))
+                },
+            )
             .await
             .unwrap();
 

--- a/nexus/src/app/background/tasks/region_replacement.rs
+++ b/nexus/src/app/background/tasks/region_replacement.rs
@@ -304,7 +304,6 @@ mod test {
     use super::*;
     use crate::app::background::init::test::NoopStartSaga;
     use nexus_db_model::RegionReplacement;
-    use nexus_db_model::Volume;
     use nexus_test_utils_macros::nexus_test;
     use omicron_uuid_kinds::VolumeUuid;
     use sled_agent_client::CrucibleOpts;
@@ -337,16 +336,15 @@ mod test {
         let volume_id = VolumeUuid::new_v4();
 
         datastore
-            .volume_create(nexus_db_model::Volume::new(
+            .volume_create(
                 volume_id,
-                serde_json::to_string(&VolumeConstructionRequest::Volume {
+                VolumeConstructionRequest::Volume {
                     id: Uuid::new_v4(),
                     block_size: 512,
                     sub_volumes: vec![],
                     read_only_parent: None,
-                })
-                .unwrap(),
-            ))
+                },
+            )
             .await
             .unwrap();
 
@@ -385,12 +383,10 @@ mod test {
             read_only_parent: None,
         };
 
-        let volume_data =
-            serde_json::to_string(&volume_construction_request).unwrap();
-
-        let volume = Volume::new(volume_id, volume_data);
-
-        datastore.volume_create(volume).await.unwrap();
+        datastore
+            .volume_create(volume_id, volume_construction_request)
+            .await
+            .unwrap();
 
         // Activate the task - it should pick that up and try to run the region
         // replacement start saga

--- a/nexus/src/app/background/tasks/region_replacement_driver.rs
+++ b/nexus/src/app/background/tasks/region_replacement_driver.rs
@@ -290,16 +290,15 @@ mod test {
         let volume_id = VolumeUuid::new_v4();
 
         datastore
-            .volume_create(nexus_db_model::Volume::new(
+            .volume_create(
                 volume_id,
-                serde_json::to_string(&VolumeConstructionRequest::Volume {
+                VolumeConstructionRequest::Volume {
                     id: Uuid::new_v4(),
                     block_size: 512,
                     sub_volumes: vec![],
                     read_only_parent: None,
-                })
-                .unwrap(),
-            ))
+                },
+            )
             .await
             .unwrap();
 
@@ -398,16 +397,15 @@ mod test {
         }
 
         datastore
-            .volume_create(nexus_db_model::Volume::new(
+            .volume_create(
                 old_region.volume_id(),
-                serde_json::to_string(&VolumeConstructionRequest::Volume {
+                VolumeConstructionRequest::Volume {
                     id: Uuid::new_v4(),
                     block_size: 512,
                     sub_volumes: vec![],
                     read_only_parent: None,
-                })
-                .unwrap(),
-            ))
+                },
+            )
             .await
             .unwrap();
 
@@ -511,16 +509,15 @@ mod test {
         }
 
         datastore
-            .volume_create(nexus_db_model::Volume::new(
+            .volume_create(
                 old_region.volume_id(),
-                serde_json::to_string(&VolumeConstructionRequest::Volume {
+                VolumeConstructionRequest::Volume {
                     id: Uuid::new_v4(),
                     block_size: 512,
                     sub_volumes: vec![],
                     read_only_parent: None,
-                })
-                .unwrap(),
-            ))
+                },
+            )
             .await
             .unwrap();
 
@@ -668,16 +665,15 @@ mod test {
         }
 
         datastore
-            .volume_create(nexus_db_model::Volume::new(
+            .volume_create(
                 old_region.volume_id(),
-                serde_json::to_string(&VolumeConstructionRequest::Volume {
+                VolumeConstructionRequest::Volume {
                     id: Uuid::new_v4(),
                     block_size: 512,
                     sub_volumes: vec![],
                     read_only_parent: None,
-                })
-                .unwrap(),
-            ))
+                },
+            )
             .await
             .unwrap();
 

--- a/nexus/src/app/background/tasks/region_snapshot_replacement_finish.rs
+++ b/nexus/src/app/background/tasks/region_snapshot_replacement_finish.rs
@@ -245,16 +245,15 @@ mod test {
         let volume_id = VolumeUuid::new_v4();
 
         datastore
-            .volume_create(nexus_db_model::Volume::new(
+            .volume_create(
                 volume_id,
-                serde_json::to_string(&VolumeConstructionRequest::Volume {
+                VolumeConstructionRequest::Volume {
                     id: Uuid::new_v4(), // not required to match!
                     block_size: 512,
                     sub_volumes: vec![], // nothing needed here
                     read_only_parent: None,
-                })
-                .unwrap(),
-            ))
+                },
+            )
             .await
             .unwrap();
 
@@ -319,16 +318,15 @@ mod test {
 
         let step_volume_id = VolumeUuid::new_v4();
         datastore
-            .volume_create(nexus_db_model::Volume::new(
+            .volume_create(
                 step_volume_id,
-                serde_json::to_string(&VolumeConstructionRequest::Volume {
+                VolumeConstructionRequest::Volume {
                     id: Uuid::new_v4(), // not required to match!
                     block_size: 512,
                     sub_volumes: vec![], // nothing needed here
                     read_only_parent: None,
-                })
-                .unwrap(),
-            ))
+                },
+            )
             .await
             .unwrap();
 
@@ -340,16 +338,15 @@ mod test {
 
         let step_volume_id = VolumeUuid::new_v4();
         datastore
-            .volume_create(nexus_db_model::Volume::new(
+            .volume_create(
                 step_volume_id,
-                serde_json::to_string(&VolumeConstructionRequest::Volume {
+                VolumeConstructionRequest::Volume {
                     id: Uuid::new_v4(), // not required to match!
                     block_size: 512,
                     sub_volumes: vec![], // nothing needed here
                     read_only_parent: None,
-                })
-                .unwrap(),
-            ))
+                },
+            )
             .await
             .unwrap();
 

--- a/nexus/src/app/background/tasks/region_snapshot_replacement_garbage_collect.rs
+++ b/nexus/src/app/background/tasks/region_snapshot_replacement_garbage_collect.rs
@@ -204,16 +204,15 @@ mod test {
         let volume_id = VolumeUuid::new_v4();
 
         datastore
-            .volume_create(nexus_db_model::Volume::new(
+            .volume_create(
                 volume_id,
-                serde_json::to_string(&VolumeConstructionRequest::Volume {
+                VolumeConstructionRequest::Volume {
                     id: Uuid::new_v4(), // not required to match!
                     block_size: 512,
                     sub_volumes: vec![], // nothing needed here
                     read_only_parent: None,
-                })
-                .unwrap(),
-            ))
+                },
+            )
             .await
             .unwrap();
 
@@ -238,16 +237,15 @@ mod test {
         let volume_id = VolumeUuid::new_v4();
 
         datastore
-            .volume_create(nexus_db_model::Volume::new(
+            .volume_create(
                 volume_id,
-                serde_json::to_string(&VolumeConstructionRequest::Volume {
+                VolumeConstructionRequest::Volume {
                     id: Uuid::new_v4(), // not required to match!
                     block_size: 512,
                     sub_volumes: vec![], // nothing needed here
                     read_only_parent: None,
-                })
-                .unwrap(),
-            ))
+                },
+            )
             .await
             .unwrap();
 

--- a/nexus/src/app/background/tasks/region_snapshot_replacement_start.rs
+++ b/nexus/src/app/background/tasks/region_snapshot_replacement_start.rs
@@ -412,16 +412,15 @@ mod test {
         let volume_id = VolumeUuid::new_v4();
 
         datastore
-            .volume_create(nexus_db_model::Volume::new(
+            .volume_create(
                 volume_id,
-                serde_json::to_string(&VolumeConstructionRequest::Volume {
+                VolumeConstructionRequest::Volume {
                     id: Uuid::new_v4(), // not required to match!
                     block_size: 512,
                     sub_volumes: vec![], // nothing needed here
                     read_only_parent: None,
-                })
-                .unwrap(),
-            ))
+                },
+            )
             .await
             .unwrap();
 
@@ -517,16 +516,15 @@ mod test {
         let volume_id = VolumeUuid::new_v4();
 
         datastore
-            .volume_create(nexus_db_model::Volume::new(
+            .volume_create(
                 volume_id,
-                serde_json::to_string(&VolumeConstructionRequest::Volume {
+                VolumeConstructionRequest::Volume {
                     id: Uuid::new_v4(),
                     block_size: 512,
                     sub_volumes: vec![],
                     read_only_parent: None,
-                })
-                .unwrap(),
-            ))
+                },
+            )
             .await
             .unwrap();
 
@@ -689,9 +687,9 @@ mod test {
         let volume_id = VolumeUuid::new_v4();
 
         datastore
-            .volume_create(nexus_db_model::Volume::new(
+            .volume_create(
                 volume_id,
-                serde_json::to_string(&VolumeConstructionRequest::Volume {
+                VolumeConstructionRequest::Volume {
                     id: Uuid::new_v4(), // not required to match!
                     block_size: 512,
                     sub_volumes: vec![],
@@ -715,9 +713,8 @@ mod test {
                             },
                         },
                     )),
-                })
-                .unwrap(),
-            ))
+                },
+            )
             .await
             .unwrap();
 

--- a/nexus/src/app/background/tasks/region_snapshot_replacement_step.rs
+++ b/nexus/src/app/background/tasks/region_snapshot_replacement_step.rs
@@ -566,7 +566,6 @@ mod test {
     use nexus_db_model::RegionSnapshotReplacement;
     use nexus_db_model::RegionSnapshotReplacementStep;
     use nexus_db_model::RegionSnapshotReplacementStepState;
-    use nexus_db_model::Volume;
     use nexus_test_utils_macros::nexus_test;
     use omicron_uuid_kinds::DatasetUuid;
     use omicron_uuid_kinds::GenericUuid;
@@ -624,12 +623,10 @@ mod test {
             )),
         };
 
-        let volume_data =
-            serde_json::to_string(&volume_construction_request).unwrap();
-
-        let volume = Volume::new(new_volume_id, volume_data);
-
-        datastore.volume_create(volume).await.unwrap();
+        datastore
+            .volume_create(new_volume_id, volume_construction_request)
+            .await
+            .unwrap();
 
         new_volume_id
     }
@@ -682,16 +679,15 @@ mod test {
         let volume_id = VolumeUuid::new_v4();
 
         datastore
-            .volume_create(nexus_db_model::Volume::new(
+            .volume_create(
                 volume_id,
-                serde_json::to_string(&VolumeConstructionRequest::Volume {
+                VolumeConstructionRequest::Volume {
                     id: Uuid::new_v4(), // not required to match!
                     block_size: 512,
                     sub_volumes: vec![], // nothing needed here
                     read_only_parent: None,
-                })
-                .unwrap(),
-            ))
+                },
+            )
             .await
             .unwrap();
 
@@ -848,16 +844,15 @@ mod test {
         let volume_id = VolumeUuid::new_v4();
 
         datastore
-            .volume_create(nexus_db_model::Volume::new(
+            .volume_create(
                 volume_id,
-                serde_json::to_string(&VolumeConstructionRequest::Volume {
+                VolumeConstructionRequest::Volume {
                     id: Uuid::new_v4(),
                     block_size: 512,
                     sub_volumes: vec![], // nothing needed here
                     read_only_parent: None,
-                })
-                .unwrap(),
-            ))
+                },
+            )
             .await
             .unwrap();
 
@@ -883,16 +878,15 @@ mod test {
         let volume_id = VolumeUuid::new_v4();
 
         datastore
-            .volume_create(nexus_db_model::Volume::new(
+            .volume_create(
                 volume_id,
-                serde_json::to_string(&VolumeConstructionRequest::Volume {
+                VolumeConstructionRequest::Volume {
                     id: Uuid::new_v4(),
                     block_size: 512,
                     sub_volumes: vec![], // nothing needed here
                     read_only_parent: None,
-                })
-                .unwrap(),
-            ))
+                },
+            )
             .await
             .unwrap();
 

--- a/nexus/src/app/image.rs
+++ b/nexus/src/app/image.rs
@@ -163,9 +163,6 @@ impl super::Nexus {
                             .into(),
                     };
 
-                let volume_data =
-                    serde_json::to_string(&volume_construction_request)?;
-
                 // Nexus runs in its own zone so we can't ask the propolis zone
                 // image tar file for size of alpine.iso. Conservatively set the
                 // size to 100M (at the time of this comment, it's 41M). Any
@@ -179,10 +176,13 @@ impl super::Nexus {
                         )
                     })?;
 
-                let new_image_volume =
-                    db::model::Volume::new(VolumeUuid::new_v4(), volume_data);
-                let volume =
-                    self.db_datastore.volume_create(new_image_volume).await?;
+                let volume = self
+                    .db_datastore
+                    .volume_create(
+                        VolumeUuid::new_v4(),
+                        volume_construction_request,
+                    )
+                    .await?;
 
                 db::model::Image {
                     identity: db::model::ImageIdentity::new(

--- a/nexus/src/app/sagas/disk_create.rs
+++ b/nexus/src/app/sagas/disk_create.rs
@@ -345,7 +345,7 @@ async fn sdc_noop(_sagactx: NexusActionContext) -> Result<(), ActionError> {
 /// Call out to Crucible agent and perform region creation.
 async fn sdc_regions_ensure(
     sagactx: NexusActionContext,
-) -> Result<String, ActionError> {
+) -> Result<VolumeConstructionRequest, ActionError> {
     let osagactx = sagactx.user_data();
     let log = osagactx.log();
     let disk_id = sagactx.lookup::<Uuid>("disk_id")?;
@@ -541,12 +541,7 @@ async fn sdc_regions_ensure(
         read_only_parent,
     };
 
-    let volume_data = serde_json::to_string(&volume_construction_request)
-        .map_err(|e| {
-            ActionError::action_failed(Error::internal_error(&e.to_string()))
-        })?;
-
-    Ok(volume_data)
+    Ok(volume_construction_request)
 }
 
 async fn sdc_regions_ensure_undo(
@@ -614,13 +609,12 @@ async fn sdc_create_volume_record(
     let osagactx = sagactx.user_data();
 
     let volume_id = sagactx.lookup::<VolumeUuid>("volume_id")?;
-    let volume_data = sagactx.lookup::<String>("regions_ensure")?;
-
-    let volume = db::model::Volume::new(volume_id, volume_data);
+    let volume_data =
+        sagactx.lookup::<VolumeConstructionRequest>("regions_ensure")?;
 
     osagactx
         .datastore()
-        .volume_create(volume)
+        .volume_create(volume_id, volume_data)
         .await
         .map_err(ActionError::action_failed)?;
 

--- a/nexus/src/app/sagas/region_replacement_finish.rs
+++ b/nexus/src/app/sagas/region_replacement_finish.rs
@@ -215,7 +215,6 @@ pub(crate) mod test {
     use nexus_db_model::Region;
     use nexus_db_model::RegionReplacement;
     use nexus_db_model::RegionReplacementState;
-    use nexus_db_model::Volume;
     use nexus_db_queries::authn::saga::Serialized;
     use nexus_db_queries::context::OpContext;
     use nexus_test_utils_macros::nexus_test;
@@ -295,11 +294,8 @@ pub(crate) mod test {
             read_only_parent: None,
         };
 
-        let volume_data =
-            serde_json::to_string(&volume_construction_request).unwrap();
-
         datastore
-            .volume_create(Volume::new(old_region_volume_id, volume_data))
+            .volume_create(old_region_volume_id, volume_construction_request)
             .await
             .unwrap();
 
@@ -315,16 +311,15 @@ pub(crate) mod test {
         };
 
         datastore
-            .volume_create(nexus_db_model::Volume::new(
+            .volume_create(
                 new_volume_id,
-                serde_json::to_string(&VolumeConstructionRequest::Volume {
+                VolumeConstructionRequest::Volume {
                     id: Uuid::new_v4(),
                     block_size: 512,
                     sub_volumes: vec![], // nothing needed here
                     read_only_parent: None,
-                })
-                .unwrap(),
-            ))
+                },
+            )
             .await
             .unwrap();
 

--- a/nexus/src/app/sagas/region_replacement_start.rs
+++ b/nexus/src/app/sagas/region_replacement_start.rs
@@ -704,16 +704,9 @@ async fn srrs_create_fake_volume(
         read_only_parent: None,
     };
 
-    let volume_data = serde_json::to_string(&volume_construction_request)
-        .map_err(|e| {
-            ActionError::action_failed(Error::internal_error(&e.to_string()))
-        })?;
-
-    let volume = db::model::Volume::new(new_volume_id, volume_data);
-
     osagactx
         .datastore()
-        .volume_create(volume)
+        .volume_create(new_volume_id, volume_construction_request)
         .await
         .map_err(ActionError::action_failed)?;
 

--- a/nexus/src/app/sagas/region_snapshot_replacement_garbage_collect.rs
+++ b/nexus/src/app/sagas/region_snapshot_replacement_garbage_collect.rs
@@ -215,7 +215,6 @@ pub(crate) mod test {
     };
     use nexus_db_model::RegionSnapshotReplacement;
     use nexus_db_model::RegionSnapshotReplacementState;
-    use nexus_db_model::Volume;
     use nexus_db_queries::authn::saga::Serialized;
     use nexus_db_queries::context::OpContext;
     use nexus_test_utils_macros::nexus_test;
@@ -270,11 +269,8 @@ pub(crate) mod test {
             read_only_parent: None,
         };
 
-        let volume_data =
-            serde_json::to_string(&volume_construction_request).unwrap();
-
         datastore
-            .volume_create(Volume::new(old_snapshot_volume_id, volume_data))
+            .volume_create(old_snapshot_volume_id, volume_construction_request)
             .await
             .unwrap();
 
@@ -290,16 +286,15 @@ pub(crate) mod test {
         let volume_id = VolumeUuid::new_v4();
 
         datastore
-            .volume_create(nexus_db_model::Volume::new(
+            .volume_create(
                 volume_id,
-                serde_json::to_string(&VolumeConstructionRequest::Volume {
+                VolumeConstructionRequest::Volume {
                     id: Uuid::new_v4(),
                     block_size: 512,
                     sub_volumes: vec![], // nothing needed here
                     read_only_parent: None,
-                })
-                .unwrap(),
-            ))
+                },
+            )
             .await
             .unwrap();
 

--- a/nexus/src/app/sagas/region_snapshot_replacement_start.rs
+++ b/nexus/src/app/sagas/region_snapshot_replacement_start.rs
@@ -772,16 +772,9 @@ async fn rsrss_new_region_volume_create(
         read_only_parent: None,
     };
 
-    let volume_data = serde_json::to_string(&volume_construction_request)
-        .map_err(|e| {
-            ActionError::action_failed(Error::internal_error(&e.to_string()))
-        })?;
-
-    let volume = db::model::Volume::new(new_region_volume_id, volume_data);
-
     osagactx
         .datastore()
-        .volume_create(volume)
+        .volume_create(new_region_volume_id, volume_construction_request)
         .await
         .map_err(ActionError::action_failed)?;
 
@@ -877,16 +870,9 @@ async fn rsrss_create_fake_volume(
         read_only_parent: None,
     };
 
-    let volume_data = serde_json::to_string(&volume_construction_request)
-        .map_err(|e| {
-            ActionError::action_failed(Error::internal_error(&e.to_string()))
-        })?;
-
-    let volume = db::model::Volume::new(new_volume_id, volume_data);
-
     osagactx
         .datastore()
-        .volume_create(volume)
+        .volume_create(new_volume_id, volume_construction_request)
         .await
         .map_err(ActionError::action_failed)?;
 

--- a/nexus/src/app/sagas/region_snapshot_replacement_step.rs
+++ b/nexus/src/app/sagas/region_snapshot_replacement_step.rs
@@ -311,16 +311,9 @@ async fn rssrs_create_fake_volume(
         read_only_parent: None,
     };
 
-    let volume_data = serde_json::to_string(&volume_construction_request)
-        .map_err(|e| {
-            ActionError::action_failed(Error::internal_error(&e.to_string()))
-        })?;
-
-    let volume = db::model::Volume::new(new_volume_id, volume_data);
-
     osagactx
         .datastore()
-        .volume_create(volume)
+        .volume_create(new_volume_id, volume_construction_request)
         .await
         .map_err(ActionError::action_failed)?;
 

--- a/nexus/src/app/sagas/region_snapshot_replacement_step_garbage_collect.rs
+++ b/nexus/src/app/sagas/region_snapshot_replacement_step_garbage_collect.rs
@@ -126,7 +126,6 @@ pub(crate) mod test {
     use crate::app::sagas::region_snapshot_replacement_step_garbage_collect::*;
     use nexus_db_model::RegionSnapshotReplacementStep;
     use nexus_db_model::RegionSnapshotReplacementStepState;
-    use nexus_db_model::Volume;
     use nexus_db_queries::authn::saga::Serialized;
     use nexus_db_queries::context::OpContext;
     use nexus_db_queries::db::datastore::region_snapshot_replacement;
@@ -181,27 +180,23 @@ pub(crate) mod test {
             read_only_parent: None,
         };
 
-        let volume_data =
-            serde_json::to_string(&volume_construction_request).unwrap();
-
         datastore
-            .volume_create(Volume::new(old_snapshot_volume_id, volume_data))
+            .volume_create(old_snapshot_volume_id, volume_construction_request)
             .await
             .unwrap();
 
         let step_volume_id = VolumeUuid::new_v4();
 
         datastore
-            .volume_create(nexus_db_model::Volume::new(
+            .volume_create(
                 step_volume_id,
-                serde_json::to_string(&VolumeConstructionRequest::Volume {
+                VolumeConstructionRequest::Volume {
                     id: Uuid::new_v4(),
                     block_size: 512,
                     sub_volumes: vec![], // nothing needed here
                     read_only_parent: None,
-                })
-                .unwrap(),
-            ))
+                },
+            )
             .await
             .unwrap();
 

--- a/nexus/src/app/sagas/snapshot_create.rs
+++ b/nexus/src/app/sagas/snapshot_create.rs
@@ -496,7 +496,7 @@ async fn ssc_alloc_regions_undo(
 
 async fn ssc_regions_ensure(
     sagactx: NexusActionContext,
-) -> Result<String, ActionError> {
+) -> Result<VolumeConstructionRequest, ActionError> {
     let osagactx = sagactx.user_data();
     let log = osagactx.log();
     let destination_volume_id =
@@ -580,12 +580,7 @@ async fn ssc_regions_ensure(
         read_only_parent: None,
     };
 
-    let volume_data = serde_json::to_string(&volume_construction_request)
-        .map_err(|e| {
-            ActionError::action_failed(Error::internal_error(&e.to_string()))
-        })?;
-
-    Ok(volume_data)
+    Ok(volume_construction_request)
 }
 
 async fn ssc_regions_ensure_undo(
@@ -615,14 +610,12 @@ async fn ssc_create_destination_volume_record(
     let destination_volume_id =
         sagactx.lookup::<VolumeUuid>("destination_volume_id")?;
 
-    let destination_volume_data = sagactx.lookup::<String>("regions_ensure")?;
-
-    let volume =
-        db::model::Volume::new(destination_volume_id, destination_volume_data);
+    let destination_volume_data =
+        sagactx.lookup::<VolumeConstructionRequest>("regions_ensure")?;
 
     osagactx
         .datastore()
-        .volume_create(volume)
+        .volume_create(destination_volume_id, destination_volume_data)
         .await
         .map_err(ActionError::action_failed)?;
 
@@ -1577,20 +1570,17 @@ async fn ssc_create_volume_record(
             ActionError::action_failed(Error::internal_error(&e.to_string()))
         })?;
 
-    // Create the volume record for this snapshot
-    let volume_data: String = serde_json::to_string(
-        &snapshot_volume_construction_request,
-    )
-    .map_err(|e| {
-        ActionError::action_failed(Error::internal_error(&e.to_string()))
-    })?;
-    info!(log, "snapshot volume construction request {}", volume_data);
-    let volume = db::model::Volume::new(volume_id, volume_data);
-
     // Insert volume record into the DB
+
+    info!(
+        log,
+        "snapshot volume construction request {:?}",
+        snapshot_volume_construction_request
+    );
+
     osagactx
         .datastore()
-        .volume_create(volume)
+        .volume_create(volume_id, snapshot_volume_construction_request)
         .await
         .map_err(ActionError::action_failed)?;
 

--- a/nexus/src/app/sagas/volume_remove_rop.rs
+++ b/nexus/src/app/sagas/volume_remove_rop.rs
@@ -6,8 +6,6 @@ use super::{ActionRegistry, NexusActionContext, NexusSaga, SagaInitError};
 use crate::app::sagas;
 use crate::app::sagas::declare_saga_actions;
 use nexus_db_queries::authn;
-use nexus_db_queries::db;
-use omicron_common::api::external::Error;
 use omicron_uuid_kinds::GenericUuid;
 use omicron_uuid_kinds::VolumeUuid;
 use serde::Deserialize;
@@ -140,18 +138,10 @@ async fn svr_create_temp_volume(
         sub_volumes: vec![],
         read_only_parent: None,
     };
-    let temp_volume_data = serde_json::to_string(&volume_construction_request)
-        .map_err(|e| {
-            ActionError::action_failed(Error::internal_error(&format!(
-                "failed to deserialize volume data: {}",
-                e,
-            )))
-        })?;
 
-    let volume = db::model::Volume::new(temp_volume_id, temp_volume_data);
     osagactx
         .datastore()
-        .volume_create(volume)
+        .volume_create(temp_volume_id, volume_construction_request)
         .await
         .map_err(ActionError::action_failed)?;
 

--- a/nexus/tests/integration_tests/volume_management.rs
+++ b/nexus/tests/integration_tests/volume_management.rs
@@ -1370,16 +1370,15 @@ async fn create_volume(
 
     // Create the volume from the parts above and insert into the database.
     datastore
-        .volume_create(nexus_db_model::Volume::new(
+        .volume_create(
             volume_id,
-            serde_json::to_string(&VolumeConstructionRequest::Volume {
+            VolumeConstructionRequest::Volume {
                 id: *volume_id.as_untyped_uuid(),
                 block_size,
                 sub_volumes,
                 read_only_parent: rop,
-            })
-            .unwrap(),
-        ))
+            },
+        )
         .await
         .unwrap();
 }
@@ -1529,15 +1528,14 @@ async fn test_volume_remove_read_only_parent_volume_not_volume(
     let t_vid = VolumeUuid::new_v4();
 
     datastore
-        .volume_create(nexus_db_model::Volume::new(
+        .volume_create(
             volume_id,
-            serde_json::to_string(&VolumeConstructionRequest::File {
+            VolumeConstructionRequest::File {
                 id: *volume_id.as_untyped_uuid(),
                 block_size: 512,
                 path: "/lol".to_string(),
-            })
-            .unwrap(),
-        ))
+            },
+        )
         .await
         .unwrap();
 
@@ -1761,15 +1759,14 @@ async fn test_volume_remove_rop_saga_volume_not_volume(
     let datastore = nexus.datastore();
 
     datastore
-        .volume_create(nexus_db_model::Volume::new(
+        .volume_create(
             volume_id,
-            serde_json::to_string(&VolumeConstructionRequest::File {
+            VolumeConstructionRequest::File {
                 id: *volume_id.as_untyped_uuid(),
                 block_size: 512,
                 path: "/lol".to_string(),
-            })
-            .unwrap(),
-        ))
+            },
+        )
         .await
         .unwrap();
 
@@ -1872,10 +1869,7 @@ async fn test_volume_checkout(cptestctx: &ControlPlaneTestContext) {
 
     // Take our VCR from above and insert into the database.
     datastore
-        .volume_create(nexus_db_model::Volume::new(
-            volume_id,
-            serde_json::to_string(&volume_construction_request).unwrap(),
-        ))
+        .volume_create(volume_id, volume_construction_request)
         .await
         .unwrap();
 
@@ -1927,10 +1921,7 @@ async fn test_volume_checkout_updates_nothing(
 
     // Take our VCR from above and insert into the database.
     datastore
-        .volume_create(nexus_db_model::Volume::new(
-            volume_id,
-            serde_json::to_string(&volume_construction_request).unwrap(),
-        ))
+        .volume_create(volume_id, volume_construction_request)
         .await
         .unwrap();
 
@@ -1979,10 +1970,7 @@ async fn test_volume_checkout_updates_multiple_gen(
 
     // Insert the volume into the database.
     datastore
-        .volume_create(nexus_db_model::Volume::new(
-            volume_id,
-            serde_json::to_string(&volume_construction_request).unwrap(),
-        ))
+        .volume_create(volume_id, volume_construction_request)
         .await
         .unwrap();
 
@@ -2050,10 +2038,7 @@ async fn test_volume_checkout_updates_sparse_multiple_gen(
 
     // Insert the volume into the database.
     datastore
-        .volume_create(nexus_db_model::Volume::new(
-            volume_id,
-            serde_json::to_string(&volume_construction_request).unwrap(),
-        ))
+        .volume_create(volume_id, volume_construction_request)
         .await
         .unwrap();
 
@@ -2111,10 +2096,7 @@ async fn test_volume_checkout_updates_sparse_mid_multiple_gen(
 
     // Insert the volume into the database.
     datastore
-        .volume_create(nexus_db_model::Volume::new(
-            volume_id,
-            serde_json::to_string(&volume_construction_request).unwrap(),
-        ))
+        .volume_create(volume_id, volume_construction_request)
         .await
         .unwrap();
 
@@ -2166,10 +2148,7 @@ async fn test_volume_checkout_randomize_ids_only_read_only(
 
     // Insert the volume into the database.
     datastore
-        .volume_create(nexus_db_model::Volume::new(
-            volume_id,
-            serde_json::to_string(&volume_construction_request).unwrap(),
-        ))
+        .volume_create(volume_id, volume_construction_request)
         .await
         .unwrap();
 
@@ -2270,9 +2249,9 @@ async fn test_keep_your_targets_straight(cptestctx: &ControlPlaneTestContext) {
 
     let volume_id = VolumeUuid::new_v4();
     let volume = datastore
-        .volume_create(nexus_db_model::Volume::new(
+        .volume_create(
             volume_id,
-            serde_json::to_string(&VolumeConstructionRequest::Volume {
+            VolumeConstructionRequest::Volume {
                 id: *volume_id.as_untyped_uuid(),
                 block_size: 512,
                 sub_volumes: vec![],
@@ -2300,9 +2279,8 @@ async fn test_keep_your_targets_straight(cptestctx: &ControlPlaneTestContext) {
                         },
                     },
                 )),
-            })
-            .unwrap(),
-        ))
+            },
+        )
         .await
         .unwrap();
 
@@ -2391,9 +2369,9 @@ async fn test_keep_your_targets_straight(cptestctx: &ControlPlaneTestContext) {
 
     let volume_id = VolumeUuid::new_v4();
     let volume = datastore
-        .volume_create(nexus_db_model::Volume::new(
+        .volume_create(
             volume_id,
-            serde_json::to_string(&VolumeConstructionRequest::Volume {
+            VolumeConstructionRequest::Volume {
                 id: *volume_id.as_untyped_uuid(),
                 block_size: 512,
                 sub_volumes: vec![],
@@ -2421,9 +2399,8 @@ async fn test_keep_your_targets_straight(cptestctx: &ControlPlaneTestContext) {
                         },
                     },
                 )),
-            })
-            .unwrap(),
-        ))
+            },
+        )
         .await
         .unwrap();
 
@@ -2712,15 +2689,14 @@ async fn test_volume_hard_delete_idempotent(
 
     let volume_id = VolumeUuid::new_v4();
     datastore
-        .volume_create(nexus_db_model::Volume::new(
+        .volume_create(
             volume_id,
-            serde_json::to_string(&VolumeConstructionRequest::File {
+            VolumeConstructionRequest::File {
                 id: *volume_id.as_untyped_uuid(),
                 block_size: 512,
                 path: "/lol".to_string(),
-            })
-            .unwrap(),
-        ))
+            },
+        )
         .await
         .unwrap();
 
@@ -3643,9 +3619,9 @@ impl TestReadOnlyRegionReferenceUsage {
 
     pub async fn create_first_volume(&self) {
         self.datastore
-            .volume_create(nexus_db_model::Volume::new(
+            .volume_create(
                 self.first_volume_id,
-                serde_json::to_string(&VolumeConstructionRequest::Volume {
+                VolumeConstructionRequest::Volume {
                     id: *self.first_volume_id.as_untyped_uuid(),
                     block_size: 512,
                     sub_volumes: vec![VolumeConstructionRequest::Region {
@@ -3667,9 +3643,8 @@ impl TestReadOnlyRegionReferenceUsage {
                         },
                     }],
                     read_only_parent: None,
-                })
-                .unwrap(),
-            ))
+                },
+            )
             .await
             .unwrap();
     }
@@ -3771,9 +3746,9 @@ impl TestReadOnlyRegionReferenceUsage {
 
     pub async fn create_first_volume_region_in_rop(&self) {
         self.datastore
-            .volume_create(nexus_db_model::Volume::new(
+            .volume_create(
                 self.first_volume_id,
-                serde_json::to_string(&VolumeConstructionRequest::Volume {
+                VolumeConstructionRequest::Volume {
                     id: *self.first_volume_id.as_untyped_uuid(),
                     block_size: 512,
                     sub_volumes: vec![],
@@ -3797,18 +3772,17 @@ impl TestReadOnlyRegionReferenceUsage {
                             },
                         },
                     )),
-                })
-                .unwrap(),
-            ))
+                },
+            )
             .await
             .unwrap();
     }
 
     pub async fn create_second_volume(&self) {
         self.datastore
-            .volume_create(nexus_db_model::Volume::new(
+            .volume_create(
                 self.second_volume_id,
-                serde_json::to_string(&VolumeConstructionRequest::Volume {
+                VolumeConstructionRequest::Volume {
                     id: *self.second_volume_id.as_untyped_uuid(),
                     block_size: 512,
                     sub_volumes: vec![VolumeConstructionRequest::Region {
@@ -3830,18 +3804,17 @@ impl TestReadOnlyRegionReferenceUsage {
                         },
                     }],
                     read_only_parent: None,
-                })
-                .unwrap(),
-            ))
+                },
+            )
             .await
             .unwrap();
     }
 
     pub async fn create_second_volume_region_in_rop(&self) {
         self.datastore
-            .volume_create(nexus_db_model::Volume::new(
+            .volume_create(
                 self.second_volume_id,
-                serde_json::to_string(&VolumeConstructionRequest::Volume {
+                VolumeConstructionRequest::Volume {
                     id: *self.second_volume_id.as_untyped_uuid(),
                     block_size: 512,
                     sub_volumes: vec![],
@@ -3865,9 +3838,8 @@ impl TestReadOnlyRegionReferenceUsage {
                             },
                         },
                     )),
-                })
-                .unwrap(),
-            ))
+                },
+            )
             .await
             .unwrap();
     }
@@ -4638,16 +4610,15 @@ async fn test_volume_replace_snapshot_respects_accounting(
     let volume_to_delete_id = VolumeUuid::new_v4();
 
     datastore
-        .volume_create(nexus_db_model::Volume::new(
+        .volume_create(
             volume_to_delete_id,
-            serde_json::to_string(&VolumeConstructionRequest::Volume {
+            VolumeConstructionRequest::Volume {
                 id: *volume_to_delete_id.as_untyped_uuid(),
                 block_size: 512,
                 sub_volumes: vec![],
                 read_only_parent: None,
-            })
-            .unwrap(),
-        ))
+            },
+        )
         .await
         .unwrap();
 
@@ -4855,16 +4826,15 @@ async fn test_volume_remove_rop_respects_accounting(
     let volume_to_delete_id = VolumeUuid::new_v4();
 
     datastore
-        .volume_create(nexus_db_model::Volume::new(
+        .volume_create(
             volume_to_delete_id,
-            serde_json::to_string(&VolumeConstructionRequest::Volume {
+            VolumeConstructionRequest::Volume {
                 id: *volume_to_delete_id.as_untyped_uuid(),
                 block_size: 512,
                 sub_volumes: vec![],
                 read_only_parent: None,
-            })
-            .unwrap(),
-        ))
+            },
+        )
         .await
         .unwrap();
 
@@ -5041,16 +5011,15 @@ async fn test_volume_remove_rop_respects_accounting_no_modify_others(
     let volume_to_delete_id = VolumeUuid::new_v4();
 
     datastore
-        .volume_create(nexus_db_model::Volume::new(
+        .volume_create(
             volume_to_delete_id,
-            serde_json::to_string(&VolumeConstructionRequest::Volume {
+            VolumeConstructionRequest::Volume {
                 id: *volume_to_delete_id.as_untyped_uuid(),
                 block_size: 512,
                 sub_volumes: vec![],
                 read_only_parent: None,
-            })
-            .unwrap(),
-        ))
+            },
+        )
         .await
         .unwrap();
 
@@ -5428,9 +5397,9 @@ async fn test_migrate_to_ref_count_with_records_region_snapshot_deleting(
 
     let first_volume_id = VolumeUuid::new_v4();
     datastore
-        .volume_create(nexus_db_model::Volume::new(
+        .volume_create(
             first_volume_id,
-            serde_json::to_string(&VolumeConstructionRequest::Volume {
+            VolumeConstructionRequest::Volume {
                 id: *first_volume_id.as_untyped_uuid(),
                 block_size: 512,
                 sub_volumes: vec![],
@@ -5458,17 +5427,16 @@ async fn test_migrate_to_ref_count_with_records_region_snapshot_deleting(
                         },
                     },
                 )),
-            })
-            .unwrap(),
-        ))
+            },
+        )
         .await
         .unwrap();
 
     let second_volume_id = VolumeUuid::new_v4();
     datastore
-        .volume_create(nexus_db_model::Volume::new(
+        .volume_create(
             second_volume_id,
-            serde_json::to_string(&VolumeConstructionRequest::Volume {
+            VolumeConstructionRequest::Volume {
                 id: *second_volume_id.as_untyped_uuid(),
                 block_size: 512,
                 sub_volumes: vec![],
@@ -5496,9 +5464,8 @@ async fn test_migrate_to_ref_count_with_records_region_snapshot_deleting(
                         },
                     },
                 )),
-            })
-            .unwrap(),
-        ))
+            },
+        )
         .await
         .unwrap();
 
@@ -5907,16 +5874,15 @@ async fn test_no_zombie_region_snapshots(cptestctx: &ControlPlaneTestContext) {
 
     let step_3_volume_id = VolumeUuid::new_v4();
     datastore
-        .volume_create(nexus_db_model::Volume::new(
+        .volume_create(
             step_3_volume_id,
-            serde_json::to_string(&VolumeConstructionRequest::Volume {
+            VolumeConstructionRequest::Volume {
                 id: *step_3_volume_id.as_untyped_uuid(),
                 block_size: 512,
                 sub_volumes: vec![],
                 read_only_parent: Some(Box::new(snapshot_vcr.clone())),
-            })
-            .unwrap(),
-        ))
+            },
+        )
         .await
         .unwrap();
 
@@ -5945,16 +5911,15 @@ async fn test_no_zombie_region_snapshots(cptestctx: &ControlPlaneTestContext) {
 
     let racing_volume_id = VolumeUuid::new_v4();
     let result = datastore
-        .volume_create(nexus_db_model::Volume::new(
+        .volume_create(
             racing_volume_id,
-            serde_json::to_string(&VolumeConstructionRequest::Volume {
+            VolumeConstructionRequest::Volume {
                 id: *racing_volume_id.as_untyped_uuid(),
                 block_size: 512,
                 sub_volumes: vec![],
                 read_only_parent: Some(Box::new(snapshot_vcr.clone())),
-            })
-            .unwrap(),
-        ))
+            },
+        )
         .await;
 
     assert!(result.is_err());
@@ -6043,9 +6008,9 @@ async fn test_no_zombie_read_only_regions(cptestctx: &ControlPlaneTestContext) {
     // subvolume, not the read-only parent
 
     datastore
-        .volume_create(nexus_db_model::Volume::new(
+        .volume_create(
             step_1_volume_id,
-            serde_json::to_string(&VolumeConstructionRequest::Volume {
+            VolumeConstructionRequest::Volume {
                 id: *step_1_volume_id.as_untyped_uuid(),
                 block_size: 512,
                 sub_volumes: vec![VolumeConstructionRequest::Region {
@@ -6071,9 +6036,8 @@ async fn test_no_zombie_read_only_regions(cptestctx: &ControlPlaneTestContext) {
                     },
                 }],
                 read_only_parent: None,
-            })
-            .unwrap(),
-        ))
+            },
+        )
         .await
         .unwrap();
 
@@ -6092,16 +6056,15 @@ async fn test_no_zombie_read_only_regions(cptestctx: &ControlPlaneTestContext) {
     let step_2_volume_id = VolumeUuid::new_v4();
 
     datastore
-        .volume_create(nexus_db_model::Volume::new(
+        .volume_create(
             step_2_volume_id,
-            serde_json::to_string(&VolumeConstructionRequest::Volume {
+            VolumeConstructionRequest::Volume {
                 id: *step_2_volume_id.as_untyped_uuid(),
                 block_size: 512,
                 sub_volumes: vec![],
                 read_only_parent: Some(Box::new(step_1_vcr.clone())),
-            })
-            .unwrap(),
-        ))
+            },
+        )
         .await
         .unwrap();
 
@@ -6129,16 +6092,15 @@ async fn test_no_zombie_read_only_regions(cptestctx: &ControlPlaneTestContext) {
 
     let racing_volume_id = VolumeUuid::new_v4();
     let result = datastore
-        .volume_create(nexus_db_model::Volume::new(
+        .volume_create(
             racing_volume_id,
-            serde_json::to_string(&VolumeConstructionRequest::Volume {
+            VolumeConstructionRequest::Volume {
                 id: *racing_volume_id.as_untyped_uuid(),
                 block_size: 512,
                 sub_volumes: vec![],
                 read_only_parent: Some(Box::new(step_1_vcr)),
-            })
-            .unwrap(),
-        ))
+            },
+        )
         .await;
 
     assert!(result.is_err());
@@ -6229,9 +6191,9 @@ async fn test_no_zombie_read_write_regions(
     // subvolume, not the read-only parent
 
     datastore
-        .volume_create(nexus_db_model::Volume::new(
+        .volume_create(
             step_1_volume_id,
-            serde_json::to_string(&VolumeConstructionRequest::Volume {
+            VolumeConstructionRequest::Volume {
                 id: *step_1_volume_id.as_untyped_uuid(),
                 block_size: 512,
                 sub_volumes: vec![VolumeConstructionRequest::Region {
@@ -6257,9 +6219,8 @@ async fn test_no_zombie_read_write_regions(
                     },
                 }],
                 read_only_parent: None,
-            })
-            .unwrap(),
-        ))
+            },
+        )
         .await
         .unwrap();
 
@@ -6278,16 +6239,15 @@ async fn test_no_zombie_read_write_regions(
     let step_2_volume_id = VolumeUuid::new_v4();
 
     datastore
-        .volume_create(nexus_db_model::Volume::new(
+        .volume_create(
             step_2_volume_id,
-            serde_json::to_string(&VolumeConstructionRequest::Volume {
+            VolumeConstructionRequest::Volume {
                 id: *step_2_volume_id.as_untyped_uuid(),
                 block_size: 512,
                 sub_volumes: vec![],
                 read_only_parent: Some(Box::new(step_1_vcr.clone())),
-            })
-            .unwrap(),
-        ))
+            },
+        )
         .await
         .unwrap();
 
@@ -6315,16 +6275,15 @@ async fn test_no_zombie_read_write_regions(
 
     let racing_volume_id = VolumeUuid::new_v4();
     let result = datastore
-        .volume_create(nexus_db_model::Volume::new(
+        .volume_create(
             racing_volume_id,
-            serde_json::to_string(&VolumeConstructionRequest::Volume {
+            VolumeConstructionRequest::Volume {
                 id: *racing_volume_id.as_untyped_uuid(),
                 block_size: 512,
                 sub_volumes: vec![],
                 read_only_parent: Some(Box::new(step_1_vcr)),
-            })
-            .unwrap(),
-        ))
+            },
+        )
         .await;
 
     assert!(result.is_err());


### PR DESCRIPTION
Accepting arbitrary strings is a bad idea! Instead, change `volume_create` from accepting a `Volume` argument to accepting a `VolumeUuid` and a `VolumeConstructionRequest` directly.

This wasn't a large lift in terms of changes, as most call sites of `volume_create` pass in the result of `Volume::new`, which takes an id and a serialized `VolumeConstructionRequest` string. This commit changes that to skip performing the `serde_json::to_string` and pass the id and volume construction request directly, and instead lets the `volume_create` handle the serialization (this function already returns a `Err(SerdeError)` variant, so this commit is not introducing anything new).