### PR TITLE
Flesh out status report from reconfigurator rendezvous RPW

### DIFF
--- a/dev-tools/omdb/src/bin/omdb/nexus.rs
+++ b/dev-tools/omdb/src/bin/omdb/nexus.rs
@@ -1128,6 +1128,27 @@ fn print_task_blueprint_rendezvous(details: &serde_json::Value) {
                 "    inventory collection: {}",
                 status.inventory_collection_id
             );
+            println!("    debug_dataset rendezvous counts:");
+            println!(
+                "        num_inserted:           {}",
+                status.stats.debug_dataset.num_inserted
+            );
+            println!(
+                "        num_already_exist:      {}",
+                status.stats.debug_dataset.num_already_exist
+            );
+            println!(
+                "        num_not_in_inventory:   {}",
+                status.stats.debug_dataset.num_not_in_inventory
+            );
+            println!(
+                "        num_tombstoned:         {}",
+                status.stats.debug_dataset.num_tombstoned
+            );
+            println!(
+                "        num_already_tombstoned: {}",
+                status.stats.debug_dataset.num_already_tombstoned
+            );
             println!("    crucible_dataset rendezvous counts:");
             println!(
                 "        num_inserted:         {}",

--- a/nexus/reconfigurator/rendezvous/src/lib.rs
+++ b/nexus/reconfigurator/rendezvous/src/lib.rs
@@ -30,7 +30,7 @@ pub async fn reconcile_blueprint_rendezvous_tables(
         .flat_map(|sled| sled.datasets.iter().flat_map(|d| d.id))
         .collect();
 
-    debug_dataset::reconcile_debug_datasets(
+    let debug_dataset = debug_dataset::reconcile_debug_datasets(
         opctx,
         datastore,
         blueprint.id,
@@ -51,7 +51,7 @@ pub async fn reconcile_blueprint_rendezvous_tables(
     )
     .await?;
 
-    Ok(BlueprintRendezvousStats { crucible_dataset })
+    Ok(BlueprintRendezvousStats { debug_dataset, crucible_dataset })
 }
 
 #[cfg(test)]

--- a/nexus/types/src/internal_api/background.rs
+++ b/nexus/types/src/internal_api/background.rs
@@ -247,6 +247,7 @@ pub struct BlueprintRendezvousStatus {
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
 pub struct BlueprintRendezvousStats {
+    pub debug_dataset: DebugDatasetsRendezvousStats,
     pub crucible_dataset: CrucibleDatasetsRendezvousStats,
 }
 
@@ -280,6 +281,56 @@ impl slog::KV for CrucibleDatasetsRendezvousStats {
         serializer.emit_usize("num_already_exist".into(), num_already_exist)?;
         serializer
             .emit_usize("num_not_in_inventory".into(), num_not_in_inventory)?;
+        Ok(())
+    }
+}
+
+#[derive(
+    Debug, Clone, Copy, Default, PartialEq, Eq, Serialize, Deserialize,
+)]
+pub struct DebugDatasetsRendezvousStats {
+    /// Number of new Debug datasets recorded.
+    ///
+    /// This is a count of in-service Debug datasets that were also present
+    /// in inventory and newly-inserted into `rendezvous_debug_dataset`.
+    pub num_inserted: usize,
+    /// Number of Debug datasets that would have been inserted, except
+    /// records for them already existed.
+    pub num_already_exist: usize,
+    /// Number of Debug datasets that the current blueprint says are
+    /// in-service, but we did not attempt to insert them because they're not
+    /// present in the latest inventory collection.
+    pub num_not_in_inventory: usize,
+    /// Number of Debug datasets that we tombstoned based on their disposition
+    /// in the current blueprint being expunged.
+    pub num_tombstoned: usize,
+    /// Number of Debug datasets that we would have tombstoned, except they were
+    /// already tombstoned or deleted.
+    pub num_already_tombstoned: usize,
+}
+
+impl slog::KV for DebugDatasetsRendezvousStats {
+    fn serialize(
+        &self,
+        _record: &slog::Record,
+        serializer: &mut dyn slog::Serializer,
+    ) -> slog::Result {
+        let Self {
+            num_inserted,
+            num_already_exist,
+            num_not_in_inventory,
+            num_tombstoned,
+            num_already_tombstoned,
+        } = *self;
+        serializer.emit_usize("num_inserted".into(), num_inserted)?;
+        serializer.emit_usize("num_already_exist".into(), num_already_exist)?;
+        serializer
+            .emit_usize("num_not_in_inventory".into(), num_not_in_inventory)?;
+        serializer.emit_usize("num_tombstoned".into(), num_tombstoned)?;
+        serializer.emit_usize(
+            "num_already_tombstoned".into(),
+            num_already_tombstoned,
+        )?;
         Ok(())
     }
 }


### PR DESCRIPTION
Example output from `omicron-dev run-all` (so no meaningful rows, but just checking the field formatting and omdb deserialization):

```
task: "blueprint_rendezvous"
  configured period: every 5m
  currently executing: no
  last completed activation: iter 5, triggered by a dependent task completing
    started at 2025-01-24T21:07:40.740Z (222s ago) and ran for 68ms
    target blueprint:     72d199ef-d6bd-4895-8858-006f3ed212ad
    inventory collection: 7dfbf99c-3613-498c-a871-cfb9b2945abe
    debug_dataset rendezvous counts:
        num_inserted:           0
        num_already_exist:      0
        num_not_in_inventory:   0
        num_tombstoned:         0
        num_already_tombstoned: 0
    crucible_dataset rendezvous counts:
        num_inserted:         0
        num_already_exist:    0
        num_not_in_inventory: 0
```

Closes #7392.

Builds on #7397.