### PR TITLE
New `BlueprintDiff` implementation

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -6934,6 +6934,7 @@ version = "0.1.0"
 dependencies = [
  "anyhow",
  "assert_matches",
+ "diffus",
  "dropshot 0.15.1",
  "futures",
  "internal-dns-resolver",

--- a/live-tests/Cargo.toml
+++ b/live-tests/Cargo.toml
@@ -15,6 +15,7 @@ omicron-workspace-hack.workspace = true
 [dev-dependencies]
 anyhow.workspace = true
 assert_matches.workspace = true
+diffus.workspace = true
 dropshot.workspace = true
 futures.workspace = true
 internal-dns-resolver.workspace = true

--- a/nexus/reconfigurator/planning/src/blueprint_builder/builder.rs
+++ b/nexus/reconfigurator/planning/src/blueprint_builder/builder.rs
@@ -2010,11 +2010,12 @@ pub mod test {
 
         // One sled was added.
         assert_eq!(diff.sleds_added.len(), 1);
-        let sled_id = diff.sleds_added.first().unwrap();
-        let new_sled_zones = diff.zones.added.get(sled_id).unwrap();
+        let (sled_id, sled_insert) =
+            diff.sleds_added.first_key_value().unwrap();
+        let new_sled_zones = sled_insert.zones.unwrap();
         assert_eq!(*sled_id, new_sled_id);
         // The generation number should be newer than the initial default.
-        assert!(new_sled_zones.generation_after.unwrap() > Generation::new());
+        assert!(new_sled_zones.generation > Generation::new());
 
         // All zones' underlay addresses ought to be on the sled's subnet.
         for z in &new_sled_zones.zones {

--- a/nexus/reconfigurator/planning/tests/output/planner_nonprovisionable_2_2a.txt
+++ b/nexus/reconfigurator/planning/tests/output/planner_nonprovisionable_2_2a.txt
@@ -187,7 +187,7 @@ to:   blueprint 9f71f5d3-a272-4382-9154-6ea2e171a6c6
 
   sled 68d24ac5-f341-49ea-a92a-0381b52ab387 (was active):
 
-    omicron zones from generation 2:
+    omicron zones at generation 2:
     ---------------------------------------------------------------------------------------------
     zone type         zone id                                disposition   underlay IP           
     ---------------------------------------------------------------------------------------------
@@ -298,6 +298,8 @@ to:   blueprint 9f71f5d3-a272-4382-9154-6ea2e171a6c6
 -   crucible          0e8e9f2d-291d-47fc-ba0f-84cb50e713fd   in service     fd00:1122:3344:105::2c
 *   crucible          0ce2b998-f5ad-4dc5-b2ec-5250a308506d   - in service   fd00:1122:3344:105::25
      └─                                                      + quiesced                           
+*   internal_ntp      b0a48e5a-e2bd-46b2-9bc6-8babbbdc0adc   in service     fd00:1122:3344:105::21
+*   nexus             88602518-f176-49a1-af12-02fac36214c3   in service     fd00:1122:3344:105::22
 
 
   sled 48d95fef-bc9f-4f50-9a53-1e075836291d (decommissioned):
@@ -323,14 +325,51 @@ to:   blueprint 9f71f5d3-a272-4382-9154-6ea2e171a6c6
 
 
 ERRORS:
-
-  sled 2d1cb4f2-cf44-40fc-b118-85036eb732a9
-
-    zone diff errors: before gen 2, after gen 2
-
-      zone id: 88602518-f176-49a1-af12-02fac36214c3
-      reason: mismatched underlay IP: before: fd00:1122:3344:105::22, after: fd01:1122:3344:105::22
-mismatched zone type: after: Nexus(
+Zone type not allowed to change. before: Nexus(
+    Nexus {
+        internal_address: [fd00:1122:3344:105::22]:12221,
+        external_ip: OmicronZoneExternalFloatingIp {
+            id: cc0d03f3-64b0-45c2-8fff-08f77c993590 (external_ip),
+            ip: 192.0.2.2,
+        },
+        nic: NetworkInterface {
+            id: 3eadc40f-d6ec-4bd0-8824-9dc47ca61302,
+            kind: Service {
+                id: 88602518-f176-49a1-af12-02fac36214c3,
+            },
+            name: Name(
+                "nexus-88602518-f176-49a1-af12-02fac36214c3",
+            ),
+            ip: 172.30.2.5,
+            mac: MacAddr(
+                MacAddr6(
+                    [
+                        168,
+                        64,
+                        37,
+                        255,
+                        128,
+                        0,
+                    ],
+                ),
+            ),
+            subnet: V4(
+                Ipv4Net {
+                    addr: 172.30.2.0,
+                    width: 24,
+                },
+            ),
+            vni: Vni(
+                100,
+            ),
+            primary: true,
+            slot: 0,
+            transit_ips: [],
+        },
+        external_tls: false,
+        external_dns_servers: [],
+    },
+), after: Nexus(
     Nexus {
         internal_address: [fd01:1122:3344:105::22]:12221,
         external_ip: OmicronZoneExternalFloatingIp {
@@ -375,10 +414,11 @@ mismatched zone type: after: Nexus(
         external_dns_servers: [],
     },
 )
-
-      zone id: b0a48e5a-e2bd-46b2-9bc6-8babbbdc0adc
-      reason: mismatched underlay IP: before: fd00:1122:3344:105::21, after: fd01:1122:3344:105::21
-mismatched zone type: after: InternalNtp(
+Zone type not allowed to change. before: InternalNtp(
+    InternalNtp {
+        address: [fd00:1122:3344:105::21]:123,
+    },
+), after: InternalNtp(
     InternalNtp {
         address: [fd01:1122:3344:105::21]:123,
     },

--- a/nexus/types/src/deployment/blueprint_diff.rs
+++ b/nexus/types/src/deployment/blueprint_diff.rs
@@ -10,938 +10,77 @@ use super::blueprint_display::{
     BpGeneration, BpOmicronZonesTableSchema, BpPhysicalDisksTableSchema,
     BpTable, BpTableColumn, BpTableData, BpTableRow, KvListWithHeading, KvPair,
 };
+use super::diff_visitors::visit_blueprint::{SledInsert, SledRemove};
+use super::diff_visitors::Change;
+use super::id_map::IdMap;
 use super::{
-    zone_sort_key, Blueprint, ClickhouseClusterConfig,
-    CockroachDbPreserveDowngrade, DiffBeforeClickhouseClusterConfig,
+    zone_sort_key, Blueprint, BlueprintDatasetDisposition,
+    BlueprintPhysicalDiskDisposition, ClickhouseClusterConfig,
+    CockroachDbPreserveDowngrade,
 };
-use diffus::Diffable;
-use nexus_sled_agent_shared::inventory::ZoneKind;
-use omicron_common::api::external::Generation;
-use omicron_common::disk::DiskIdentity;
-use omicron_uuid_kinds::OmicronZoneUuid;
-use omicron_uuid_kinds::SledUuid;
+use crate::deployment::blueprint_display::BpClickhouseKeepersTableSchema;
+use crate::deployment::{
+    unwrap_or_none, BlueprintDatasetConfig, BlueprintDatasetsConfig,
+    BlueprintPhysicalDiskConfig, BlueprintPhysicalDisksConfig,
+    BlueprintZoneConfig, BlueprintZoneDisposition, BlueprintZoneType,
+    BlueprintZonesConfig, ZoneSortKey, ZpoolName,
+};
+use crate::external_api::views::SledState;
+use omicron_common::api::external::{ByteCount, Generation};
+use omicron_common::api::internal::shared::DatasetKind;
+use omicron_common::disk::{CompressionAlgorithm, DatasetName};
+use omicron_uuid_kinds::{BlueprintUuid, DatasetUuid, SledUuid};
+use omicron_uuid_kinds::{OmicronZoneUuid, PhysicalDiskUuid};
 use std::collections::{BTreeMap, BTreeSet};
 use std::fmt;
 
-use crate::deployment::blueprint_display::BpClickhouseKeepersTableSchema;
-use crate::deployment::{
-    BlueprintDatasetConfig, BlueprintDatasetsConfig, BlueprintMetadata,
-    BlueprintPhysicalDisksConfig, BlueprintZoneConfig,
-    BlueprintZoneDisposition, BlueprintZonesConfig,
-    CollectionDatasetIdentifier, DiffBeforeMetadata, ZoneSortKey,
-};
-use crate::external_api::views::SledState;
-
-/// Diffs for omicron zones on a given sled with a given `BpDiffState`
-#[derive(Debug)]
-pub struct BpDiffZoneDetails {
-    pub generation_before: Option<Generation>,
-    pub generation_after: Option<Generation>,
-    pub zones: Vec<BlueprintZoneConfig>,
-}
-
-impl BpTableData for BpDiffZoneDetails {
-    fn bp_generation(&self) -> BpGeneration {
-        BpGeneration::Diff {
-            before: self.generation_before,
-            after: self.generation_after,
-        }
-    }
-
-    fn rows(&self, state: BpDiffState) -> impl Iterator<Item = BpTableRow> {
-        self.zones.iter().map(move |zone| {
-            BpTableRow::from_strings(
-                state,
-                vec![
-                    zone.kind().report_str().to_string(),
-                    zone.id().to_string(),
-                    zone.disposition.to_string(),
-                    zone.underlay_ip().to_string(),
-                ],
-            )
-        })
-    }
-}
-
-/// A modified omicron zone
+/// Accumulated state about diffs inside a `BlueprintDiffer`.
 ///
-/// A zone is considered modified if its `disposition` changes. All
-/// modifications to other fields are considered errors, and will be recorded
-/// as such.
+/// Tied to the lifetime of a diffus diff.
 #[derive(Debug)]
-pub struct ModifiedZone {
-    pub prior_disposition: BlueprintZoneDisposition,
-    pub zone: BlueprintZoneConfig,
-}
-
-impl ZoneSortKey for ModifiedZone {
-    fn kind(&self) -> ZoneKind {
-        self.zone.kind()
-    }
-
-    fn id(&self) -> OmicronZoneUuid {
-        self.zone.id()
-    }
-}
-
-impl ModifiedZone {
-    #[allow(clippy::result_large_err)]
-    pub fn new(
-        before: BlueprintZoneConfig,
-        after: BlueprintZoneConfig,
-    ) -> Result<ModifiedZone, BpDiffZoneError> {
-        // Do we have any errors? If so, create a "reason" string.
-        let mut reason = String::new();
-        if before.kind() != after.kind() {
-            let msg = format!(
-                "mismatched zone kind: before: {}, after: {}\n",
-                before.kind().report_str(),
-                after.kind().report_str(),
-            );
-            reason.push_str(&msg);
-        }
-        if before.underlay_ip() != after.underlay_ip() {
-            let msg = format!(
-                "mismatched underlay IP: before: {}, after: {}\n",
-                before.underlay_ip(),
-                after.underlay_ip()
-            );
-            reason.push_str(&msg);
-        }
-        if before.zone_type != after.zone_type {
-            let msg = format!(
-                "mismatched zone type: after: {:#?}\n",
-                after.zone_type
-            );
-            reason.push_str(&msg);
-        }
-        if reason.is_empty() {
-            Ok(ModifiedZone {
-                prior_disposition: before.disposition,
-                zone: after,
-            })
-        } else {
-            Err(BpDiffZoneError {
-                zone_before: before,
-                zone_after: after,
-                reason,
-            })
-        }
-    }
-}
-
-/// Details of modified zones on a given sled
-#[derive(Debug)]
-pub struct BpDiffZonesModified {
-    pub generation_before: Generation,
-    pub generation_after: Generation,
-    pub zones: Vec<ModifiedZone>,
-}
-
-impl BpTableData for BpDiffZonesModified {
-    fn bp_generation(&self) -> BpGeneration {
-        BpGeneration::Diff {
-            before: Some(self.generation_before),
-            after: Some(self.generation_after),
-        }
-    }
-
-    fn rows(&self, state: BpDiffState) -> impl Iterator<Item = BpTableRow> {
-        self.zones.iter().map(move |zone| {
-            BpTableRow::new(
-                state,
-                vec![
-                    BpTableColumn::value(
-                        zone.zone.kind().report_str().to_string(),
-                    ),
-                    BpTableColumn::value(zone.zone.id().to_string()),
-                    BpTableColumn::diff(
-                        zone.prior_disposition.to_string(),
-                        zone.zone.disposition.to_string(),
-                    ),
-                    BpTableColumn::value(zone.zone.underlay_ip().to_string()),
-                ],
-            )
-        })
-    }
-}
-
-#[derive(Debug)]
-/// Errors arising from illegally modified zone fields
-pub struct BpDiffZoneErrors {
-    pub generation_before: Generation,
-    pub generation_after: Generation,
-    pub errors: Vec<BpDiffZoneError>,
-}
-
-#[derive(Debug)]
-pub struct BpDiffZoneError {
-    pub zone_before: BlueprintZoneConfig,
-    pub zone_after: BlueprintZoneConfig,
-    pub reason: String,
-}
-
-/// All known zones across all known sleds, their various states, and errors
-#[derive(Debug, Default)]
-pub struct BpDiffZones {
-    pub added: BTreeMap<SledUuid, BpDiffZoneDetails>,
-    pub removed: BTreeMap<SledUuid, BpDiffZoneDetails>,
-    pub unchanged: BTreeMap<SledUuid, BpDiffZoneDetails>,
-    pub modified: BTreeMap<SledUuid, BpDiffZonesModified>,
-    pub errors: BTreeMap<SledUuid, BpDiffZoneErrors>,
-}
-
-impl BpDiffZones {
-    pub fn new(
-        before: BTreeMap<SledUuid, BlueprintZonesConfig>,
-        mut after: BTreeMap<SledUuid, BlueprintZonesConfig>,
-    ) -> Self {
-        let mut diffs = BpDiffZones::default();
-        for (sled_id, before_zones) in before {
-            let before_generation = before_zones.generation;
-            let mut removed = vec![];
-            if let Some(after_zones) = after.remove(&sled_id) {
-                let after_generation = after_zones.generation;
-                let mut unchanged = vec![];
-                let mut modified = vec![];
-                let mut errors = vec![];
-                let mut added = vec![];
-
-                // Compare `before_zones` and `after_zones` to look
-                // for additions, deletions, modifications, and errors.
-                let before_by_id: BTreeMap<_, BlueprintZoneConfig> =
-                    before_zones
-                        .zones
-                        .into_iter()
-                        .map(|z| (z.id(), z))
-                        .collect();
-                let mut after_by_id: BTreeMap<_, BlueprintZoneConfig> =
-                    after_zones.zones.into_iter().map(|z| (z.id, z)).collect();
-
-                for (zone_id, zone_before) in before_by_id {
-                    if let Some(zone_after) = after_by_id.remove(&zone_id) {
-                        // Are the zones equal?
-                        if zone_before == zone_after {
-                            unchanged.push(zone_after);
-                        } else {
-                            // The zones are different. They are only allowed to differ in terms
-                            // of `disposition`, otherwise we have an error.
-                            match ModifiedZone::new(zone_before, zone_after) {
-                                Ok(modified_zone) => {
-                                    modified.push(modified_zone)
-                                }
-                                Err(error) => errors.push(error),
-                            }
-                        }
-                    } else {
-                        // This zone doesn't exist in `zone_after` so it must have
-                        // been removed.
-                        removed.push(zone_before);
-                    }
-                }
-                // Any remaining zones in `after_by_id` are newly added
-                for (_, zone_after) in after_by_id {
-                    added.push(zone_after);
-                }
-
-                // Add all records to `diffs` that come from either `before` or `after`
-                // for this `sled_id`.
-                if !unchanged.is_empty() {
-                    unchanged.sort_unstable_by_key(zone_sort_key);
-                    diffs.unchanged.insert(
-                        sled_id,
-                        BpDiffZoneDetails {
-                            generation_before: Some(before_generation),
-                            generation_after: Some(after_generation),
-                            zones: unchanged,
-                        },
-                    );
-                }
-                if !removed.is_empty() {
-                    removed.sort_unstable_by_key(zone_sort_key);
-                    diffs.removed.insert(
-                        sled_id,
-                        BpDiffZoneDetails {
-                            generation_before: Some(before_generation),
-                            generation_after: Some(after_generation),
-                            zones: removed,
-                        },
-                    );
-                }
-                if !added.is_empty() {
-                    added.sort_unstable_by_key(zone_sort_key);
-                    diffs.added.insert(
-                        sled_id,
-                        BpDiffZoneDetails {
-                            generation_before: Some(before_generation),
-                            generation_after: Some(after_generation),
-                            zones: added,
-                        },
-                    );
-                }
-                if !modified.is_empty() {
-                    modified.sort_unstable_by_key(zone_sort_key);
-                    diffs.modified.insert(
-                        sled_id,
-                        BpDiffZonesModified {
-                            generation_before: before_generation,
-                            generation_after: after_generation,
-                            zones: modified,
-                        },
-                    );
-                }
-                if !errors.is_empty() {
-                    diffs.errors.insert(
-                        sled_id,
-                        BpDiffZoneErrors {
-                            generation_before: before_generation,
-                            generation_after: after_generation,
-                            errors,
-                        },
-                    );
-                }
-            } else {
-                // No `after_zones` for this `sled_id`, so `before_zones` are removed
-                assert!(removed.is_empty());
-                for zone in before_zones.zones {
-                    removed.push(zone);
-                }
-
-                if !removed.is_empty() {
-                    removed.sort_unstable_by_key(zone_sort_key);
-                    diffs.removed.insert(
-                        sled_id,
-                        BpDiffZoneDetails {
-                            generation_before: Some(before_generation),
-                            generation_after: None,
-                            zones: removed,
-                        },
-                    );
-                }
-            }
-        }
-
-        // Any sleds remaining in `after` have just been added, since we remove
-        // sleds from `after`, that were also in `before`, in the above loop.
-        for (sled_id, after_zones) in after {
-            if !after_zones.zones.is_empty() {
-                diffs.added.insert(
-                    sled_id,
-                    BpDiffZoneDetails {
-                        generation_before: None,
-                        generation_after: Some(after_zones.generation),
-                        zones: after_zones.zones.into_iter().collect(),
-                    },
-                );
-            }
-        }
-
-        diffs
-    }
-
-    /// Return a [`BpTable`] for the given `sled_id`
-    ///
-    /// We collate all the data from each category to produce a single table.
-    /// The order is:
-    ///
-    /// 1. Unchanged
-    /// 2. Removed
-    /// 3. Modified
-    /// 4. Added
-    ///
-    /// The idea behind the order is to (a) group all changes together
-    /// and (b) put changes towards the bottom, so people have to scroll
-    /// back less.
-    ///
-    /// Errors are printed in a more freeform manner after the table is
-    /// displayed.
-    pub fn to_bp_sled_subtable(&self, sled_id: &SledUuid) -> Option<BpTable> {
-        let mut generation = BpGeneration::Diff { before: None, after: None };
-        let mut rows = vec![];
-        if let Some(diff) = self.unchanged.get(sled_id) {
-            generation = diff.bp_generation();
-            rows.extend(diff.rows(BpDiffState::Unchanged));
-        }
-        if let Some(diff) = self.removed.get(sled_id) {
-            // Generations never vary for the same sled, so this is harmless
-            generation = diff.bp_generation();
-            rows.extend(diff.rows(BpDiffState::Removed));
-        }
-
-        if let Some(diff) = self.modified.get(sled_id) {
-            // Generations never vary for the same sled, so this is harmless
-            generation = diff.bp_generation();
-            rows.extend(diff.rows(BpDiffState::Modified));
-        }
-
-        if let Some(diff) = self.added.get(sled_id) {
-            // Generations never vary for the same sled, so this is harmless
-            generation = diff.bp_generation();
-            rows.extend(diff.rows(BpDiffState::Added));
-        }
-
-        if rows.is_empty() {
-            None
-        } else {
-            Some(BpTable::new(BpOmicronZonesTableSchema {}, generation, rows))
-        }
-    }
-}
-
-#[derive(Debug)]
-pub struct DiffPhysicalDisksDetails {
-    // Newly added sleds don't have "before" disks
-    pub before_generation: Option<Generation>,
-
-    // Disks that are removed don't have "after" generation numbers
-    pub after_generation: Option<Generation>,
-
-    // Disks added, removed, or unmodified
-    pub disks: BTreeSet<DiskIdentity>,
-}
-
-impl BpTableData for DiffPhysicalDisksDetails {
-    fn bp_generation(&self) -> BpGeneration {
-        BpGeneration::Diff {
-            before: self.before_generation,
-            after: self.after_generation,
-        }
-    }
-
-    fn rows(&self, state: BpDiffState) -> impl Iterator<Item = BpTableRow> {
-        self.disks.iter().map(move |d| {
-            BpTableRow::from_strings(
-                state,
-                vec![d.vendor.clone(), d.model.clone(), d.serial.clone()],
-            )
-        })
-    }
-}
-
-#[derive(Debug, Default)]
-pub struct BpDiffPhysicalDisks {
-    pub added: BTreeMap<SledUuid, DiffPhysicalDisksDetails>,
-    pub removed: BTreeMap<SledUuid, DiffPhysicalDisksDetails>,
-    pub unchanged: BTreeMap<SledUuid, DiffPhysicalDisksDetails>,
-}
-
-impl BpDiffPhysicalDisks {
-    pub fn new(
-        before: BTreeMap<SledUuid, BlueprintPhysicalDisksConfig>,
-        mut after: BTreeMap<SledUuid, BlueprintPhysicalDisksConfig>,
-    ) -> Self {
-        let mut diffs = BpDiffPhysicalDisks::default();
-        for (sled_id, before_disks) in before {
-            let before_generation = Some(before_disks.generation);
-            if let Some(after_disks) = after.remove(&sled_id) {
-                let after_generation = Some(after_disks.generation);
-                let a: BTreeSet<DiskIdentity> =
-                    after_disks.disks.into_iter().map(|d| d.identity).collect();
-                let b = before_disks
-                    .disks
-                    .iter()
-                    .map(|d| d.identity.clone())
-                    .collect();
-                let added: BTreeSet<_> = a.difference(&b).cloned().collect();
-                let removed: BTreeSet<_> = b.difference(&a).cloned().collect();
-                let unchanged: BTreeSet<_> =
-                    a.intersection(&b).cloned().collect();
-                if !added.is_empty() {
-                    diffs.added.insert(
-                        sled_id,
-                        DiffPhysicalDisksDetails {
-                            before_generation,
-                            after_generation,
-                            disks: added,
-                        },
-                    );
-                }
-                if !removed.is_empty() {
-                    diffs.removed.insert(
-                        sled_id,
-                        DiffPhysicalDisksDetails {
-                            before_generation,
-                            after_generation,
-                            disks: removed,
-                        },
-                    );
-                }
-                if !unchanged.is_empty() {
-                    diffs.unchanged.insert(
-                        sled_id,
-                        DiffPhysicalDisksDetails {
-                            before_generation,
-                            after_generation,
-                            disks: unchanged,
-                        },
-                    );
-                }
-            } else {
-                diffs.removed.insert(
-                    sled_id,
-                    DiffPhysicalDisksDetails {
-                        before_generation,
-                        after_generation: None,
-                        disks: before_disks
-                            .disks
-                            .into_iter()
-                            .map(|d| d.identity)
-                            .collect(),
-                    },
-                );
-            }
-        }
-
-        // Any sleds remaining in `after` have just been added, since we remove
-        // sleds from `after`, that were also in `before`, in the above loop.
-        for (sled_id, after_disks) in after {
-            let added: BTreeSet<DiskIdentity> =
-                after_disks.disks.into_iter().map(|d| d.identity).collect();
-            if !added.is_empty() {
-                diffs.added.insert(
-                    sled_id,
-                    DiffPhysicalDisksDetails {
-                        before_generation: None,
-                        after_generation: Some(after_disks.generation),
-                        disks: added,
-                    },
-                );
-            }
-        }
-
-        diffs
-    }
-
-    /// Return a [`BpTable`] for the given `sled_id`
-    pub fn to_bp_sled_subtable(&self, sled_id: &SledUuid) -> Option<BpTable> {
-        let mut generation = BpGeneration::Diff { before: None, after: None };
-        let mut rows = vec![];
-        if let Some(diff) = self.unchanged.get(sled_id) {
-            generation = diff.bp_generation();
-            rows.extend(diff.rows(BpDiffState::Unchanged));
-        }
-        if let Some(diff) = self.removed.get(sled_id) {
-            // Generations never vary for the same sled, so this is harmless
-            generation = diff.bp_generation();
-            rows.extend(diff.rows(BpDiffState::Removed));
-        }
-
-        if let Some(diff) = self.added.get(sled_id) {
-            // Generations never vary for the same sled, so this is harmless
-            generation = diff.bp_generation();
-            rows.extend(diff.rows(BpDiffState::Added));
-        }
-
-        if rows.is_empty() {
-            None
-        } else {
-            Some(BpTable::new(BpPhysicalDisksTableSchema {}, generation, rows))
-        }
-    }
-}
-
-#[derive(Debug)]
-pub struct DiffDatasetsDetails {
-    // Datasets that come from disks on newly added sleds don't have "before"
-    // generation numbers
-    pub before_generation: Option<Generation>,
-
-    // Datasets that are removed don't have "after" generation numbers
-    pub after_generation: Option<Generation>,
-
-    // Datasets added, removed, modified, or unmodified
-    pub datasets: BTreeMap<CollectionDatasetIdentifier, BlueprintDatasetConfig>,
-}
-
-impl BpTableData for DiffDatasetsDetails {
-    fn bp_generation(&self) -> BpGeneration {
-        BpGeneration::Diff {
-            before: self.before_generation,
-            after: self.after_generation,
-        }
-    }
-
-    fn rows(&self, state: BpDiffState) -> impl Iterator<Item = BpTableRow> {
-        // `self.datasets` is naturally ordered by ID, but that doesn't play
-        // well with expectorate-based tests: We end up sorted by (random)
-        // UUIDs. We redact the UUIDs, but that still results in test-to-test
-        // variance in the _order_ of the rows. We can work around this for now
-        // by sorting by dataset kind: after UUID redaction, that produces
-        // a stable table ordering for datasets.
-        let mut rows = self.datasets.values().collect::<Vec<_>>();
-        rows.sort_unstable_by_key(|d| (&d.kind, &d.pool));
-        rows.into_iter().map(move |dataset| {
-            BpTableRow::from_strings(state, dataset.as_strings())
-        })
-    }
-}
-
-#[derive(Debug)]
-pub struct ModifiedDataset {
-    pub before: BlueprintDatasetConfig,
-    pub after: BlueprintDatasetConfig,
-}
-
-#[derive(Debug)]
-pub struct BpDiffDatasetsModified {
-    pub generation_before: Option<Generation>,
-    pub generation_after: Option<Generation>,
-    pub datasets: Vec<ModifiedDataset>,
-}
-
-impl BpTableData for BpDiffDatasetsModified {
-    fn bp_generation(&self) -> BpGeneration {
-        BpGeneration::Diff {
-            before: self.generation_before,
-            after: self.generation_after,
-        }
-    }
-
-    fn rows(&self, state: BpDiffState) -> impl Iterator<Item = BpTableRow> {
-        self.datasets.iter().map(move |dataset| {
-            let before_strings = dataset.before.as_strings();
-            let after_strings = dataset.after.as_strings();
-
-            let mut columns = vec![];
-            for (before, after) in std::iter::zip(before_strings, after_strings)
-            {
-                let column = if before != after {
-                    BpTableColumn::diff(before, after)
-                } else {
-                    BpTableColumn::value(before)
-                };
-                columns.push(column);
-            }
-
-            BpTableRow::new(state, columns)
-        })
-    }
-}
-
-#[derive(Debug, Default)]
-pub struct BpDiffDatasets {
-    pub added: BTreeMap<SledUuid, DiffDatasetsDetails>,
-    pub removed: BTreeMap<SledUuid, DiffDatasetsDetails>,
-    pub modified: BTreeMap<SledUuid, BpDiffDatasetsModified>,
-    pub unchanged: BTreeMap<SledUuid, DiffDatasetsDetails>,
-}
-
-impl BpDiffDatasets {
-    pub fn new(
-        before: BTreeMap<SledUuid, BlueprintDatasetsConfig>,
-        mut after: BTreeMap<SledUuid, BlueprintDatasetsConfig>,
-    ) -> Self {
-        let mut diffs = BpDiffDatasets::default();
-
-        // Observe the set of old sleds first
-        for (sled_id, before_datasets) in before {
-            let before_generation = before_datasets.generation;
-
-            // If the sled exists in both the old and new set, compare
-            // the set of datasets to identify which "grouping" they should
-            // land in.
-            if let Some(after_datasets) = after.remove(&sled_id) {
-                let after_generation = Some(after_datasets.generation);
-
-                let mut unchanged = BTreeMap::new();
-                let mut modified = BTreeMap::new();
-                let mut removed = BTreeMap::new();
-
-                // Normalize the "before" and "after" data to compare individual
-                // datasets.
-
-                let b = before_datasets
-                    .datasets
-                    .iter()
-                    .map(|d| (CollectionDatasetIdentifier::from(d), d.clone()));
-                let mut added: BTreeMap<
-                    CollectionDatasetIdentifier,
-                    BlueprintDatasetConfig,
-                > = after_datasets
-                    .datasets
-                    .iter()
-                    .map(|d| (d.into(), d.clone()))
-                    .collect();
-
-                for (id, dataset_before) in b {
-                    if let Some(dataset_after) = added.remove(&id) {
-                        if dataset_before == dataset_after {
-                            unchanged.insert(id, dataset_after);
-                        } else {
-                            modified
-                                .insert(id, (dataset_before, dataset_after));
-                        }
-                    } else {
-                        removed.insert(id, dataset_before);
-                    }
-                }
-
-                if !added.is_empty() {
-                    diffs.added.insert(
-                        sled_id,
-                        DiffDatasetsDetails {
-                            before_generation: Some(before_generation),
-                            after_generation,
-                            datasets: added,
-                        },
-                    );
-                }
-                if !removed.is_empty() {
-                    diffs.removed.insert(
-                        sled_id,
-                        DiffDatasetsDetails {
-                            before_generation: Some(before_generation),
-                            after_generation,
-                            datasets: removed,
-                        },
-                    );
-                }
-                if !modified.is_empty() {
-                    diffs.modified.insert(
-                        sled_id,
-                        BpDiffDatasetsModified {
-                            generation_before: Some(before_generation),
-                            generation_after: after_generation,
-                            datasets: modified
-                                .into_values()
-                                .map(|(before, after)| ModifiedDataset {
-                                    before,
-                                    after,
-                                })
-                                .collect(),
-                        },
-                    );
-                }
-                if !unchanged.is_empty() {
-                    diffs.unchanged.insert(
-                        sled_id,
-                        DiffDatasetsDetails {
-                            before_generation: Some(before_generation),
-                            after_generation,
-                            datasets: unchanged,
-                        },
-                    );
-                }
-            } else {
-                diffs.removed.insert(
-                    sled_id,
-                    DiffDatasetsDetails {
-                        before_generation: Some(before_generation),
-                        after_generation: None,
-                        datasets: before_datasets
-                            .datasets
-                            .into_iter()
-                            .map(|d| (CollectionDatasetIdentifier::from(&d), d))
-                            .collect(),
-                    },
-                );
-            }
-        }
-
-        // Any sleds remaining in `after` have just been added, since we remove
-        // sleds from `after`, that were also in `before`, in the above loop.
-        for (sled_id, after_datasets) in after {
-            let added: BTreeMap<CollectionDatasetIdentifier, _> =
-                after_datasets
-                    .datasets
-                    .into_iter()
-                    .map(|d| (CollectionDatasetIdentifier::from(&d), d))
-                    .collect();
-            if !added.is_empty() {
-                diffs.added.insert(
-                    sled_id,
-                    DiffDatasetsDetails {
-                        before_generation: None,
-                        after_generation: Some(after_datasets.generation),
-                        datasets: added,
-                    },
-                );
-            }
-        }
-
-        diffs
-    }
-
-    /// Return a [`BpTable`] for the given `sled_id`
-    pub fn to_bp_sled_subtable(&self, sled_id: &SledUuid) -> Option<BpTable> {
-        let mut generation = BpGeneration::Diff { before: None, after: None };
-        let mut rows = vec![];
-        if let Some(diff) = self.unchanged.get(sled_id) {
-            generation = diff.bp_generation();
-            rows.extend(diff.rows(BpDiffState::Unchanged));
-        }
-        if let Some(diff) = self.removed.get(sled_id) {
-            // Generations never vary for the same sled, so this is harmless
-            //
-            // (Same below, where we overwrite the "generation")
-            generation = diff.bp_generation();
-            rows.extend(diff.rows(BpDiffState::Removed));
-        }
-        if let Some(diff) = self.modified.get(sled_id) {
-            generation = diff.bp_generation();
-            rows.extend(diff.rows(BpDiffState::Modified));
-        }
-        if let Some(diff) = self.added.get(sled_id) {
-            generation = diff.bp_generation();
-            rows.extend(diff.rows(BpDiffState::Added));
-        }
-
-        if rows.is_empty() {
-            None
-        } else {
-            Some(BpTable::new(BpDatasetsTableSchema {}, generation, rows))
-        }
-    }
-}
-
-/// Summarizes the differences between two blueprints
-#[derive(Debug)]
-pub struct BlueprintDiff {
-    pub before_meta: DiffBeforeMetadata,
-    pub after_meta: BlueprintMetadata,
-    pub before_state: BTreeMap<SledUuid, SledState>,
-    pub after_state: BTreeMap<SledUuid, SledState>,
-    pub zones: BpDiffZones,
-    pub physical_disks: BpDiffPhysicalDisks,
-    pub datasets: BpDiffDatasets,
-    pub sleds_added: BTreeSet<SledUuid>,
-    pub sleds_removed: BTreeSet<SledUuid>,
+pub struct BlueprintDiff<'e> {
+    pub before: &'e Blueprint,
+    pub after: &'e Blueprint,
+    pub errors: Vec<String>,
+    pub warnings: Vec<String>,
+    pub sleds_added: BTreeMap<SledUuid, SledInsert<'e>>,
+    pub sleds_removed: BTreeMap<SledUuid, SledRemove<'e>>,
     pub sleds_unchanged: BTreeSet<SledUuid>,
-    pub sleds_modified: BTreeSet<SledUuid>,
-    pub before_clickhouse_cluster_config: DiffBeforeClickhouseClusterConfig,
-    pub after_clickhouse_cluster_config: Option<ClickhouseClusterConfig>,
+    pub sleds_modified: BTreeMap<SledUuid, ModifiedSled<'e>>,
+    pub metadata: MetadataDiff<'e>,
+
+    // TODO: Change once we have a visitor for `ClickhouseClusterConfig`
+    pub clickhouse_cluster_config:
+        DiffValue<'e, Option<ClickhouseClusterConfig>>,
 }
 
-impl BlueprintDiff {
-    /// Build a diff with the provided contents, verifying that the provided
-    /// data is valid.
+impl<'e> BlueprintDiff<'e> {
     pub fn new(
-        before_meta: DiffBeforeMetadata,
-        before_clickhouse_cluster_config: DiffBeforeClickhouseClusterConfig,
-        before_state: BTreeMap<SledUuid, SledState>,
-        before_zones: BTreeMap<SledUuid, BlueprintZonesConfig>,
-        before_disks: BTreeMap<SledUuid, BlueprintPhysicalDisksConfig>,
-        before_datasets: BTreeMap<SledUuid, BlueprintDatasetsConfig>,
-        after_blueprint: &Blueprint,
-    ) -> Self {
-        let mut after_state = after_blueprint.sled_state.clone();
-        let after_zones = after_blueprint.blueprint_zones.clone();
-        let after_disks = after_blueprint.blueprint_disks.clone();
-        let after_datasets = after_blueprint.blueprint_datasets.clone();
-
-        // Work around a quirk of sled decommissioning. If a sled has a before
-        // state of `decommissioned`, it may or may not be present in
-        // `after_state` (presence will depend on whether or not the sled was
-        // present in the `PlanningInput`). However, we may still have entries
-        // in `after_zones` or `after_disks` due to expunged zones/disks that
-        // haven't been fully cleaned up yet. Without this workaround, this may
-        // produce confusing results: the sled might appear to be modified only
-        // because the state went from `decommissioned` to "missing entirely".
-        // We'll patch this up here: if we have a decommissioned sled that has
-        // no `after_state` entry but _does_ still have a corresponding zones or
-        // disks entry, we'll artificially insert `decommissioned` to avoid
-        // misleading output.
-        for (sled_id, _) in before_state
-            .iter()
-            .filter(|&(_, &state)| state == SledState::Decommissioned)
-        {
-            if !after_state.contains_key(sled_id)
-                && (after_zones.contains_key(sled_id)
-                    || after_disks.contains_key(sled_id))
-            {
-                after_state.insert(*sled_id, SledState::Decommissioned);
-            }
-        }
-
-        let before_sleds: BTreeSet<_> = before_state
-            .keys()
-            .chain(before_zones.keys())
-            .chain(before_disks.keys())
-            .chain(before_datasets.keys())
-            .collect();
-        let after_sleds: BTreeSet<_> = after_state
-            .keys()
-            .chain(after_zones.keys())
-            .chain(after_disks.keys())
-            .chain(after_datasets.keys())
-            .collect();
-        let all_sleds: BTreeSet<_> =
-            before_sleds.union(&after_sleds).map(|&sled_id| *sled_id).collect();
-
-        // All sleds that have state, zones, disks or datasets in `after_*`, but not
-        // `before_*` have been added.
-        let sleds_added: BTreeSet<_> = after_sleds
-            .difference(&before_sleds)
-            .map(|&sled_id| *sled_id)
-            .collect();
-
-        // All sleds that have state, zones, disks or datasets in `before_*`, but not
-        // `after_*` have been removed.
-        let sleds_removed: BTreeSet<_> = before_sleds
-            .difference(&after_sleds)
-            .map(|&sled_id| *sled_id)
-            .collect();
-
-        let zones = BpDiffZones::new(before_zones, after_zones);
-        let physical_disks =
-            BpDiffPhysicalDisks::new(before_disks, after_disks);
-        let datasets = BpDiffDatasets::new(before_datasets, after_datasets);
-
-        // Sleds that haven't been added or removed are either unchanged or
-        // modified.
-        let sleds_unchanged_or_modified: BTreeSet<_> = all_sleds
-            .iter()
-            .filter(|&sled_id| {
-                !sleds_added.contains(sled_id)
-                    && !sleds_removed.contains(sled_id)
-            })
-            .map(|s| *s)
-            .collect();
-
-        // Sleds are modified if their state changed or any zones or disks on
-        // those sleds are anything other than unchanged.
-        let mut sleds_modified = sleds_unchanged_or_modified.clone();
-        sleds_modified.retain(|sled_id| {
-            before_state.get(sled_id) != after_state.get(sled_id)
-                || physical_disks.added.contains_key(sled_id)
-                || physical_disks.removed.contains_key(sled_id)
-                || datasets.added.contains_key(sled_id)
-                || datasets.modified.contains_key(sled_id)
-                || datasets.removed.contains_key(sled_id)
-                || zones.added.contains_key(sled_id)
-                || zones.removed.contains_key(sled_id)
-                || zones.modified.contains_key(sled_id)
-                || zones.errors.contains_key(sled_id)
-        });
-
-        // The rest of the sleds must be unchanged.
-        let unchanged_sleds: BTreeSet<_> = sleds_unchanged_or_modified
-            .difference(&sleds_modified)
-            .map(|sled_id| *sled_id)
-            .collect();
-
+        before: &'e Blueprint,
+        after: &'e Blueprint,
+    ) -> BlueprintDiff<'e> {
         BlueprintDiff {
-            before_meta,
-            after_meta: after_blueprint.metadata(),
-            before_state,
-            after_state,
-            zones,
-            physical_disks,
-            datasets,
-            sleds_added,
-            sleds_removed,
-            sleds_unchanged: unchanged_sleds,
-            sleds_modified,
-            before_clickhouse_cluster_config,
-            after_clickhouse_cluster_config: after_blueprint
-                .clickhouse_cluster_config
-                .clone(),
+            before,
+            after,
+            errors: vec![],
+            warnings: vec![],
+            sleds_added: BTreeMap::new(),
+            sleds_removed: BTreeMap::new(),
+            sleds_unchanged: BTreeSet::new(),
+            sleds_modified: BTreeMap::new(),
+            metadata: MetadataDiff::new(before, after),
+            clickhouse_cluster_config: DiffValue::Unchanged(
+                &before.clickhouse_cluster_config,
+            ),
         }
     }
 
+    /// Build a diff with the provided contents, verifying that the provided
     /// Return a struct that can be used to display the diff.
     pub fn display(&self) -> BlueprintDiffDisplay<'_> {
-        BlueprintDiffDisplay::new(self)
+        // backwards compat
+        let show_unchanged = true;
+        BlueprintDiffDisplay::new(self, show_unchanged)
     }
 
     /// Returns whether the diff reflects any changes or if the blueprints are
@@ -957,26 +96,662 @@ impl BlueprintDiff {
             return true;
         }
 
-        // The clickhouse cluster config has changed if:
-        // - there was one before and now there isn't
-        // - there wasn't one before and now there is
-        // - there's one both before and after and their generation has changed
-        match (
-            &self.before_clickhouse_cluster_config,
-            &self.after_clickhouse_cluster_config,
-        ) {
-            (DiffBeforeClickhouseClusterConfig::Blueprint(None), None) => false,
-            (DiffBeforeClickhouseClusterConfig::Blueprint(None), Some(_)) => {
-                true
-            }
-            (DiffBeforeClickhouseClusterConfig::Blueprint(Some(_)), None) => {
-                true
-            }
-            (
-                DiffBeforeClickhouseClusterConfig::Blueprint(Some(before)),
-                Some(after),
-            ) => before.diff(&after).is_change(),
+        self.metadata.has_semantic_changes()
+            || self.clickhouse_cluster_config.is_changed()
+    }
+}
+
+/// A single value in a diff.
+#[derive(Debug, Clone)]
+pub enum DiffValue<'e, T> {
+    Unchanged(&'e T),
+    Changed(Change<'e, T>),
+}
+
+impl<'e, T> DiffValue<'e, T> {
+    fn is_unchanged(&self) -> bool {
+        if let DiffValue::Unchanged(_) = self {
+            true
+        } else {
+            false
         }
+    }
+
+    fn is_changed(&self) -> bool {
+        !self.is_unchanged()
+    }
+}
+
+#[derive(Debug, Clone)]
+pub struct ModifiedZone<'e> {
+    pub disposition: DiffValue<'e, BlueprintZoneDisposition>,
+    pub filesystem_pool: DiffValue<'e, Option<ZpoolName>>,
+    // zone_type is not allowed to change
+    pub zone_type: &'e BlueprintZoneType,
+}
+
+impl<'e> ModifiedZone<'e> {
+    /// Initialize a `ModifiedZone`.
+    ///
+    /// We always initialize to the `before` state as if this value is
+    /// unchanged. If a change callback fires for a given field, then we'll
+    /// update the value.
+    pub fn new(before: &'e BlueprintZoneConfig) -> ModifiedZone<'e> {
+        ModifiedZone {
+            disposition: DiffValue::Unchanged(&before.disposition),
+            filesystem_pool: DiffValue::Unchanged(&before.filesystem_pool),
+            zone_type: &before.zone_type,
+        }
+    }
+}
+
+#[derive(Debug, Clone)]
+pub struct ModifiedDisk<'e> {
+    pub disposition: DiffValue<'e, BlueprintPhysicalDiskDisposition>,
+}
+
+impl<'e> ModifiedDisk<'e> {
+    /// Initialize a `ModifiedDisk`.
+    ///
+    /// We always initialize to the `before` state as if this value is
+    /// unchanged. If a change callback fires for a given field, then we'll
+    /// update the value.
+    pub fn new(before: &'e BlueprintPhysicalDiskConfig) -> ModifiedDisk<'e> {
+        ModifiedDisk { disposition: DiffValue::Unchanged(&before.disposition) }
+    }
+}
+
+#[derive(Debug, Clone)]
+pub struct ModifiedDataset<'e> {
+    // The pool is not allowed to change
+    pub pool: &'e ZpoolName,
+    // The kind is not allowed to change
+    pub kind: &'e DatasetKind,
+    pub disposition: DiffValue<'e, BlueprintDatasetDisposition>,
+    pub quota: DiffValue<'e, Option<ByteCount>>,
+    pub reservation: DiffValue<'e, Option<ByteCount>>,
+    pub compression: DiffValue<'e, CompressionAlgorithm>,
+}
+
+impl<'e> ModifiedDataset<'e> {
+    /// Initialize a `ModifiedDataset`.
+    ///
+    /// We always initialize to the `before` state as if this value is
+    /// unchanged. If a change callback fires for a given field, then we'll
+    /// update the value.
+    pub fn new(before: &'e BlueprintDatasetConfig) -> ModifiedDataset<'e> {
+        ModifiedDataset {
+            pool: &before.pool,
+            kind: &before.kind,
+            disposition: DiffValue::Unchanged(&before.disposition),
+            quota: DiffValue::Unchanged(&before.quota),
+            reservation: DiffValue::Unchanged(&before.reservation),
+            compression: DiffValue::Unchanged(&before.compression),
+        }
+    }
+}
+
+/// All modifications of a sled that we track for purposes of diff display output
+#[derive(Debug, Clone)]
+pub struct ModifiedSled<'e> {
+    pub sled_state: DiffValue<'e, SledState>,
+    pub zones_generation: DiffValue<'e, Generation>,
+    pub zones_added: IdMap<BlueprintZoneConfig>,
+    pub zones_removed: IdMap<BlueprintZoneConfig>,
+    pub zones_unchanged: IdMap<BlueprintZoneConfig>,
+    pub zones_modified: BTreeMap<OmicronZoneUuid, ModifiedZone<'e>>,
+
+    // Backwards Compatibility: Disks can be removed from a decommissioned
+    // sled and then the planner may remove or modify a zone. We should prune
+    // `blueprint_disks`, blueprint_datasets`, and `blueprint_zones` together.
+    pub disks_generation: Option<DiffValue<'e, Generation>>,
+    pub disks_added: IdMap<BlueprintPhysicalDiskConfig>,
+    pub disks_removed: IdMap<BlueprintPhysicalDiskConfig>,
+    pub disks_unchanged: IdMap<BlueprintPhysicalDiskConfig>,
+    pub disks_modified: BTreeMap<PhysicalDiskUuid, ModifiedDisk<'e>>,
+
+    // Backwards Compatibility: Datasets can be removed from a decommissioned
+    // sled and then the planner may remove or modify a zone. We should prune
+    // `blueprint_disks`, blueprint_datasets`, and `blueprint_zones` together.
+    pub datasets_generation: Option<DiffValue<'e, Generation>>,
+    pub datasets_added: IdMap<BlueprintDatasetConfig>,
+    pub datasets_removed: IdMap<BlueprintDatasetConfig>,
+    pub datasets_unchanged: IdMap<BlueprintDatasetConfig>,
+    pub datasets_modified: BTreeMap<DatasetUuid, ModifiedDataset<'e>>,
+}
+
+impl<'e> ModifiedSled<'e> {
+    pub fn tables(&self, show_unchanged: bool) -> SledTables {
+        SledTables {
+            disks: self.disks_table(show_unchanged),
+            datasets: self.datasets_table(show_unchanged),
+            zones: self.zones_table(show_unchanged),
+        }
+    }
+
+    /// Collate all data from each category to produce a single table.
+    ///
+    /// The order is:
+    ///
+    /// 1. Unchanged (if `show_unchanged` flag is set)
+    /// 2. Removed
+    /// 3. Added
+    ///
+    /// The idea behind the order is to (a) group all changes together
+    /// and (b) put changes towards the bottom, so people have to scroll
+    /// back less.
+    ///
+    /// Note that we don't currently show modified disks for backwards
+    /// compatibility, but that is easily added.
+    fn disks_table(&self, show_unchanged: bool) -> Option<BpTable> {
+        let Some(diff) = &self.disks_generation else {
+            return None;
+        };
+        let generation = match *diff {
+            DiffValue::Unchanged(generation) => {
+                // Backwards compatibility:. If the generation doesn't change, we shouldn't
+                // have any modifications. However, we currently delete disks when a sled is
+                // expunged, rather than marking them expunged and bumping their generation.
+                //
+                // We indicate this deletion by having `after` set to None.
+                if self.disks_removed.is_empty() {
+                    BpGeneration::Diff {
+                        before: Some(*generation),
+                        after: Some(*generation),
+                    }
+                } else {
+                    BpGeneration::Diff {
+                        before: Some(*generation),
+                        after: None,
+                    }
+                }
+            }
+            DiffValue::Changed(generation) => BpGeneration::Diff {
+                before: Some(*generation.before),
+                after: Some(*generation.after),
+            },
+        };
+
+        let mut rows = vec![];
+
+        // Unchanged
+        let mut disks: Vec<_> = self.disks_unchanged.iter().cloned().collect();
+        disks.sort_unstable_by(|a, b| a.identity.cmp(&b.identity));
+        if show_unchanged {
+            rows.extend(
+                disks
+                    .iter()
+                    .map(|disk| disks_row(BpDiffState::Unchanged, disk)),
+            );
+        }
+
+        // Removed
+        let mut disks: Vec<_> = self.disks_removed.iter().cloned().collect();
+        disks.sort_unstable_by(|a, b| a.identity.cmp(&b.identity));
+        rows.extend(
+            disks.iter().map(|disk| disks_row(BpDiffState::Removed, disk)),
+        );
+
+        // Added
+        let mut disks: Vec<_> = self.disks_added.iter().cloned().collect();
+        disks.sort_unstable_by(|a, b| a.identity.cmp(&b.identity));
+        rows.extend(
+            disks.iter().map(|disk| disks_row(BpDiffState::Added, disk)),
+        );
+
+        if rows.is_empty() {
+            return None;
+        }
+
+        Some(BpTable::new(BpPhysicalDisksTableSchema {}, generation, rows))
+    }
+
+    /// Collate all data from each category to produce a single table.
+    ///
+    /// The order is:
+    ///
+    /// 1. Unchanged (if `show_unchanged` flag is set)
+    /// 2. Removed
+    /// 3. Modified
+    /// 4. Added
+    ///
+    /// The idea behind the order is to (a) group all changes together
+    /// and (b) put changes towards the bottom, so people have to scroll
+    /// back less.
+    fn datasets_table(&self, show_unchanged: bool) -> Option<BpTable> {
+        let Some(diff) = &self.datasets_generation else {
+            return None;
+        };
+        let generation = match *diff {
+            DiffValue::Unchanged(generation) => {
+                // Backwards compatibility:. If the generation doesn't change, we shouldn't
+                // have any modifications. However, we currently delete datasets when a sled is
+                // expunged, rather than marking them expunged and bumping their generation.
+                //
+                // We indicate this deletion by having `after` set to None.
+                if self.datasets_removed.is_empty() {
+                    BpGeneration::Diff {
+                        before: Some(*generation),
+                        after: Some(*generation),
+                    }
+                } else {
+                    BpGeneration::Diff {
+                        before: Some(*generation),
+                        after: None,
+                    }
+                }
+            }
+            DiffValue::Changed(generation) => BpGeneration::Diff {
+                before: Some(*generation.before),
+                after: Some(*generation.after),
+            },
+        };
+
+        let mut rows = vec![];
+
+        // Unchanged
+        let mut datasets: Vec<_> =
+            self.datasets_unchanged.iter().cloned().collect();
+        datasets.sort_unstable_by(|d1, d2| {
+            (&d1.kind, &d1.pool).cmp(&(&d2.kind, &d2.pool))
+        });
+        if show_unchanged {
+            rows.extend(datasets.into_iter().map(|dataset| {
+                BpTableRow::from_strings(
+                    BpDiffState::Unchanged,
+                    dataset.as_strings(),
+                )
+            }));
+        }
+
+        // Modified
+        let mut datasets: Vec<(_, _)> = self.datasets_modified.iter().collect();
+        datasets.sort_unstable_by(|d1, d2| {
+            (&d1.1.kind, &d1.1.pool).cmp(&(&d2.1.kind, &d2.1.pool))
+        });
+        rows.extend(datasets.into_iter().map(
+            |(dataset_id, modified_dataset)| {
+                let mut columns = vec![];
+
+                columns.push(BpTableColumn::Value(
+                    DatasetName::new(
+                        modified_dataset.pool.clone(),
+                        modified_dataset.kind.clone(),
+                    )
+                    .full_name(),
+                ));
+
+                columns.push(BpTableColumn::Value(dataset_id.to_string()));
+
+                match &modified_dataset.quota {
+                    DiffValue::Unchanged(quota) => columns
+                        .push(BpTableColumn::Value(unwrap_or_none(quota))),
+                    DiffValue::Changed(change) => {
+                        columns.push(BpTableColumn::Diff {
+                            before: unwrap_or_none(change.before),
+                            after: unwrap_or_none(change.after),
+                        })
+                    }
+                }
+
+                match &modified_dataset.reservation {
+                    DiffValue::Unchanged(reservation) => columns.push(
+                        BpTableColumn::Value(unwrap_or_none(reservation)),
+                    ),
+                    DiffValue::Changed(change) => {
+                        columns.push(BpTableColumn::Diff {
+                            before: unwrap_or_none(change.before),
+                            after: unwrap_or_none(change.after),
+                        })
+                    }
+                }
+
+                match &modified_dataset.compression {
+                    DiffValue::Unchanged(compression) => columns
+                        .push(BpTableColumn::Value(compression.to_string())),
+                    DiffValue::Changed(change) => {
+                        columns.push(BpTableColumn::Diff {
+                            before: change.before.to_string(),
+                            after: change.after.to_string(),
+                        })
+                    }
+                }
+
+                BpTableRow::new(BpDiffState::Modified, columns)
+            },
+        ));
+
+        // Removed
+        let mut datasets: Vec<_> =
+            self.datasets_removed.iter().cloned().collect();
+        datasets.sort_unstable_by(|d1, d2| {
+            (&d1.kind, &d1.pool).cmp(&(&d2.kind, &d2.pool))
+        });
+        rows.extend(datasets.iter().map(|dataset| {
+            BpTableRow::from_strings(BpDiffState::Removed, dataset.as_strings())
+        }));
+
+        // Added
+        let mut datasets: Vec<_> =
+            self.datasets_added.iter().cloned().collect();
+        datasets.sort_unstable_by(|d1, d2| {
+            (&d1.kind, &d1.pool).cmp(&(&d2.kind, &d2.pool))
+        });
+        rows.extend(datasets.iter().map(|dataset| {
+            BpTableRow::from_strings(BpDiffState::Added, dataset.as_strings())
+        }));
+
+        if rows.is_empty() {
+            return None;
+        }
+
+        Some(BpTable::new(BpDatasetsTableSchema {}, generation, rows))
+    }
+
+    /// Collate all data from each category to produce a single table.
+    ///
+    /// The order is:
+    ///
+    /// 1. Unchanged (if `show_unchanged` flag is set)
+    /// 2. Removed
+    /// 3. Modified
+    /// 4. Added
+    ///
+    /// The idea behind the order is to (a) group all changes together
+    /// and (b) put changes towards the bottom, so people have to scroll
+    /// back less.
+    fn zones_table(&self, show_unchanged: bool) -> Option<BpTable> {
+        let generation = match self.zones_generation {
+            DiffValue::Unchanged(generation) => {
+                BpGeneration::Value(*generation)
+            }
+            DiffValue::Changed(generation) => BpGeneration::Diff {
+                before: Some(*generation.before),
+                after: Some(*generation.after),
+            },
+        };
+
+        let mut rows = vec![];
+
+        // Unchanged
+        let mut zones_unchanged: Vec<_> =
+            self.zones_unchanged.iter().cloned().collect();
+        zones_unchanged.sort_unstable_by_key(zone_sort_key);
+        if show_unchanged {
+            rows.extend(
+                zones_unchanged
+                    .iter()
+                    .map(|zone| zones_row(BpDiffState::Unchanged, zone)),
+            );
+        }
+
+        // Removed
+        let mut zones_removed: Vec<_> =
+            self.zones_removed.iter().cloned().collect();
+        zones_removed.sort_unstable_by_key(zone_sort_key);
+        rows.extend(
+            zones_removed
+                .iter()
+                .map(|zone| zones_row(BpDiffState::Removed, zone)),
+        );
+
+        // Modified
+        let mut zones: Vec<(_, _)> = self.zones_modified.iter().collect();
+        zones.sort_unstable_by(|z1, z2| {
+            (&z1.1.zone_type.kind(), &z1.0)
+                .cmp(&(&z2.1.zone_type.kind(), &z2.0))
+        });
+        rows.extend(zones.iter().map(|(zone_id, fields)| {
+            let mut columns = vec![];
+
+            // kind
+            columns.push(BpTableColumn::Value(
+                fields.zone_type.kind().report_str().to_string(),
+            ));
+
+            // zone_id
+            columns.push(BpTableColumn::Value(zone_id.to_string()));
+
+            // disposition
+            match &fields.disposition {
+                DiffValue::Unchanged(val) => {
+                    columns.push(BpTableColumn::Value(val.to_string()));
+                }
+                DiffValue::Changed(change) => {
+                    columns.push(BpTableColumn::Diff {
+                        before: change.before.to_string(),
+                        after: change.after.to_string(),
+                    });
+                }
+            }
+
+            // underlay IP
+            columns.push(BpTableColumn::Value(
+                fields.zone_type.underlay_ip().to_string(),
+            ));
+
+            BpTableRow::new(BpDiffState::Modified, columns)
+        }));
+
+        // Added
+        let mut zones_added: Vec<_> =
+            self.zones_added.iter().cloned().collect();
+        zones_added.sort_unstable_by_key(zone_sort_key);
+        rows.extend(
+            zones_added.iter().map(|zone| zones_row(BpDiffState::Added, zone)),
+        );
+
+        if rows.is_empty() {
+            return None;
+        }
+
+        Some(BpTable::new(BpOmicronZonesTableSchema {}, generation, rows))
+    }
+}
+
+impl<'e> ModifiedSled<'e> {
+    /// Initialize a `ModifiedSled`.
+    ///
+    /// We always initialized `DiffValue`s to the `before` state as if they are
+    /// unchanged. If a change callback fires, then we'll update the state. We
+    /// do the same for unchanged zones, disks, and datasets.
+    pub fn new(before: &'e Blueprint, sled_id: SledUuid) -> ModifiedSled<'e> {
+        let zones_cfg = before.blueprint_zones.get(&sled_id).unwrap();
+        let disks_cfg = before.blueprint_disks.get(&sled_id);
+        let datasets_cfg = before.blueprint_datasets.get(&sled_id);
+        ModifiedSled {
+            sled_state: DiffValue::Unchanged(
+                before
+                    .sled_state
+                    .get(&sled_id)
+                    .unwrap_or(&SledState::Decommissioned),
+            ),
+            zones_generation: DiffValue::Unchanged(&zones_cfg.generation),
+            zones_added: IdMap::new(),
+            zones_removed: IdMap::new(),
+            zones_unchanged: zones_cfg.zones.clone(),
+            zones_modified: BTreeMap::new(),
+            // Backwards compat: See note in the field definition
+            disks_generation: disks_cfg
+                .map(|c| DiffValue::Unchanged(&c.generation)),
+            disks_added: IdMap::new(),
+            disks_removed: IdMap::new(),
+            // Backwards compat: See note in the field definition
+            disks_unchanged: disks_cfg
+                .map(|c| c.disks.clone())
+                .unwrap_or(IdMap::new()),
+            disks_modified: BTreeMap::new(),
+            // Backwards compat: See note in the field definition
+            datasets_generation: datasets_cfg
+                .map(|c| DiffValue::Unchanged(&c.generation)),
+            datasets_added: IdMap::new(),
+            datasets_removed: IdMap::new(),
+            datasets_unchanged: datasets_cfg
+                .map(|c| c.datasets.clone())
+                .unwrap_or(IdMap::new()),
+            datasets_modified: BTreeMap::new(),
+        }
+    }
+}
+
+/// All possible modifications to `BlueprintMetadata`
+#[derive(Debug)]
+pub struct MetadataDiff<'e> {
+    pub blueprint_id: DiffValue<'e, BlueprintUuid>,
+    pub parent_blueprint_id: DiffValue<'e, Option<BlueprintUuid>>,
+    pub internal_dns_version: DiffValue<'e, Generation>,
+    pub external_dns_version: DiffValue<'e, Generation>,
+    pub cockroachdb_fingerprint: DiffValue<'e, String>,
+    pub cockroachdb_setting_preserve_downgrade:
+        DiffValue<'e, CockroachDbPreserveDowngrade>,
+    pub creator: DiffValue<'e, String>,
+    pub comment: DiffValue<'e, String>,
+}
+
+impl<'e> MetadataDiff<'e> {
+    /// Initialize a `MetadataDiff`.
+    ///
+    /// We always initialize to the `before` state as if this value is
+    /// unchanged. If a change callback fires for a given field, then we'll
+    /// update the value.
+    pub fn new(
+        before: &'e Blueprint,
+        after: &'e Blueprint,
+    ) -> MetadataDiff<'e> {
+        // We don't get a callback for `id`, so just fill it in here.
+        let blueprint_id = if before.id == after.id {
+            DiffValue::Unchanged(&before.id)
+        } else {
+            DiffValue::Changed(Change { before: &before.id, after: &after.id })
+        };
+        MetadataDiff {
+            blueprint_id,
+            parent_blueprint_id: DiffValue::Unchanged(
+                &before.parent_blueprint_id,
+            ),
+            internal_dns_version: DiffValue::Unchanged(
+                &before.internal_dns_version,
+            ),
+            external_dns_version: DiffValue::Unchanged(
+                &before.external_dns_version,
+            ),
+            cockroachdb_fingerprint: DiffValue::Unchanged(
+                &before.cockroachdb_fingerprint,
+            ),
+            cockroachdb_setting_preserve_downgrade: DiffValue::Unchanged(
+                &before.cockroachdb_setting_preserve_downgrade,
+            ),
+            creator: DiffValue::Unchanged(&before.creator),
+            comment: DiffValue::Unchanged(&before.comment),
+        }
+    }
+
+    /// Does this diff have changes that are not superficial or likely to be
+    /// present in all diffs between two blueprints?
+    pub fn has_semantic_changes(&self) -> bool {
+        self.internal_dns_version.is_changed()
+            || self.external_dns_version.is_changed()
+            || self.cockroachdb_fingerprint.is_changed()
+            || self.cockroachdb_setting_preserve_downgrade.is_changed()
+    }
+
+    /// Return displayable tables
+    //
+    // The current format is backwards compatible for now
+    pub fn tables(&self, show_unchanged: bool) -> Vec<KvListWithHeading> {
+        let mut tables = vec![];
+
+        // Cockroach related data
+        let mut crdb_rows = vec![];
+        match &self.cockroachdb_fingerprint {
+            DiffValue::Unchanged(val) => {
+                if show_unchanged {
+                    crdb_rows.push(KvPair::new(
+                        BpDiffState::Unchanged,
+                        COCKROACHDB_FINGERPRINT,
+                        linear_table_unchanged(&display_none_if_empty(val)),
+                    ))
+                }
+            }
+            DiffValue::Changed(change) => crdb_rows.push(KvPair::new(
+                BpDiffState::Modified,
+                COCKROACHDB_FINGERPRINT,
+                linear_table_modified(
+                    &display_none_if_empty(change.before),
+                    &display_none_if_empty(change.after),
+                ),
+            )),
+        }
+
+        match &self.cockroachdb_setting_preserve_downgrade {
+            DiffValue::Unchanged(val) => {
+                if show_unchanged {
+                    crdb_rows.push(KvPair::new(
+                        BpDiffState::Unchanged,
+                        COCKROACHDB_PRESERVE_DOWNGRADE,
+                        linear_table_unchanged(
+                            &display_optional_preserve_downgrade(&Some(**val)),
+                        ),
+                    ))
+                }
+            }
+            DiffValue::Changed(change) => crdb_rows.push(KvPair::new(
+                BpDiffState::Modified,
+                COCKROACHDB_PRESERVE_DOWNGRADE,
+                linear_table_modified(
+                    &display_optional_preserve_downgrade(&Some(*change.before)),
+                    &display_optional_preserve_downgrade(&Some(*change.after)),
+                ),
+            )),
+        }
+
+        if !crdb_rows.is_empty() {
+            tables.push(KvListWithHeading::new(COCKROACHDB_HEADING, crdb_rows));
+        }
+
+        // Rest of metadata (Just DNS for backwards compatibility for now)
+        let mut metadata_rows = vec![];
+
+        match &self.internal_dns_version {
+            DiffValue::Unchanged(val) => {
+                if show_unchanged {
+                    metadata_rows.push(KvPair::new(
+                        BpDiffState::Unchanged,
+                        INTERNAL_DNS_VERSION,
+                        linear_table_unchanged(val),
+                    ))
+                }
+            }
+            DiffValue::Changed(change) => metadata_rows.push(KvPair::new(
+                BpDiffState::Modified,
+                INTERNAL_DNS_VERSION,
+                linear_table_modified(change.before, change.after),
+            )),
+        }
+
+        match &self.external_dns_version {
+            DiffValue::Unchanged(val) => {
+                if show_unchanged {
+                    metadata_rows.push(KvPair::new(
+                        BpDiffState::Unchanged,
+                        EXTERNAL_DNS_VERSION,
+                        linear_table_unchanged(val),
+                    ))
+                }
+            }
+            DiffValue::Changed(change) => metadata_rows.push(KvPair::new(
+                BpDiffState::Modified,
+                EXTERNAL_DNS_VERSION,
+                linear_table_modified(change.before, change.after),
+            )),
+        }
+
+        if !metadata_rows.is_empty() {
+            tables
+                .push(KvListWithHeading::new(METADATA_HEADING, metadata_rows));
+        }
+
+        tables
     }
 }
 
@@ -1056,6 +831,7 @@ impl From<ClickhouseClusterConfigDiffTablesForSingleBlueprint>
 /// A printable representation of the difference between two
 /// `ClickhouseClusterConfig` tables or a `ClickhouseClusterConfig` table and
 /// its inventory representation.
+#[derive(Debug)]
 pub struct ClickhouseClusterConfigDiffTables {
     pub metadata: KvListWithHeading,
     pub keepers: BpTable,
@@ -1063,151 +839,6 @@ pub struct ClickhouseClusterConfigDiffTables {
 }
 
 impl ClickhouseClusterConfigDiffTables {
-    pub fn diff_collection_and_blueprint(
-        before: &clickhouse_admin_types::ClickhouseKeeperClusterMembership,
-        after: &ClickhouseClusterConfig,
-    ) -> Self {
-        let leader_committed_log_index = if before.leader_committed_log_index
-            == after.highest_seen_keeper_leader_committed_log_index
-        {
-            KvPair::new(
-                BpDiffState::Unchanged,
-                CLICKHOUSE_HIGHEST_SEEN_KEEPER_LEADER_COMMITTED_LOG_INDEX,
-                linear_table_unchanged(
-                    &after.highest_seen_keeper_leader_committed_log_index,
-                ),
-            )
-        } else {
-            KvPair::new(
-                BpDiffState::Modified,
-                CLICKHOUSE_HIGHEST_SEEN_KEEPER_LEADER_COMMITTED_LOG_INDEX,
-                linear_table_modified(
-                    &before.leader_committed_log_index,
-                    &after.highest_seen_keeper_leader_committed_log_index,
-                ),
-            )
-        };
-        let metadata = KvListWithHeading::new(
-            CLICKHOUSE_CLUSTER_CONFIG_HEADING,
-            vec![
-                KvPair::new(
-                    BpDiffState::Added,
-                    GENERATION,
-                    linear_table_modified(
-                        &NOT_PRESENT_IN_COLLECTION_PARENS,
-                        &after.generation,
-                    ),
-                ),
-                KvPair::new(
-                    BpDiffState::Added,
-                    CLICKHOUSE_MAX_USED_SERVER_ID,
-                    linear_table_modified(
-                        &NOT_PRESENT_IN_COLLECTION_PARENS,
-                        &after.max_used_server_id,
-                    ),
-                ),
-                KvPair::new(
-                    BpDiffState::Added,
-                    CLICKHOUSE_MAX_USED_KEEPER_ID,
-                    linear_table_modified(
-                        &NOT_PRESENT_IN_COLLECTION_PARENS,
-                        &after.max_used_keeper_id,
-                    ),
-                ),
-                KvPair::new(
-                    BpDiffState::Added,
-                    CLICKHOUSE_CLUSTER_NAME,
-                    linear_table_modified(
-                        &NOT_PRESENT_IN_COLLECTION_PARENS,
-                        &after.cluster_name,
-                    ),
-                ),
-                KvPair::new(
-                    BpDiffState::Added,
-                    CLICKHOUSE_CLUSTER_SECRET,
-                    linear_table_modified(
-                        &NOT_PRESENT_IN_COLLECTION_PARENS,
-                        &after.cluster_secret,
-                    ),
-                ),
-                leader_committed_log_index,
-            ],
-        );
-
-        // Build up our keeper table
-        let mut keeper_rows = vec![];
-        for (zone_id, keeper_id) in &after.keepers {
-            if before.raft_config.contains(keeper_id) {
-                // Unchanged keepers
-                keeper_rows.push(BpTableRow::new(
-                    BpDiffState::Unchanged,
-                    vec![
-                        BpTableColumn::Value(zone_id.to_string()),
-                        BpTableColumn::Value(keeper_id.to_string()),
-                    ],
-                ));
-            } else {
-                // Added keepers
-                keeper_rows.push(BpTableRow::new(
-                    BpDiffState::Added,
-                    vec![
-                        BpTableColumn::Value(zone_id.to_string()),
-                        BpTableColumn::Value(keeper_id.to_string()),
-                    ],
-                ));
-            }
-        }
-
-        let after_ids: BTreeSet<_> = after.keepers.values().clone().collect();
-        for keeper_id in &before.raft_config {
-            if !after_ids.contains(keeper_id) {
-                // Removed keepers
-                keeper_rows.push(BpTableRow::new(
-                    BpDiffState::Removed,
-                    vec![
-                        BpTableColumn::Value(
-                            NOT_PRESENT_IN_COLLECTION_PARENS.to_string(),
-                        ),
-                        BpTableColumn::Value(keeper_id.to_string()),
-                    ],
-                ));
-            }
-        }
-
-        let keepers = BpTable::new(
-            BpClickhouseKeepersTableSchema {},
-            BpGeneration::Diff { before: None, after: Some(after.generation) },
-            keeper_rows,
-        );
-
-        // Build up our server table
-        let server_rows: Vec<BpTableRow> = after
-            .servers
-            .iter()
-            .map(|(zone_id, server_id)| {
-                BpTableRow::new(
-                    BpDiffState::Added,
-                    vec![
-                        BpTableColumn::CollectionNotPresentDiff {
-                            after: zone_id.to_string(),
-                        },
-                        BpTableColumn::CollectionNotPresentDiff {
-                            after: server_id.to_string(),
-                        },
-                    ],
-                )
-            })
-            .collect();
-
-        let servers = Some(BpTable::new(
-            BpClickhouseServersTableSchema {},
-            BpGeneration::Diff { before: None, after: Some(after.generation) },
-            server_rows,
-        ));
-
-        ClickhouseClusterConfigDiffTables { metadata, keepers, servers }
-    }
-
     pub fn diff_blueprints(
         before: &ClickhouseClusterConfig,
         after: &ClickhouseClusterConfig,
@@ -1313,46 +944,6 @@ impl ClickhouseClusterConfigDiffTables {
         ClickhouseClusterConfigDiffTables { metadata, keepers, servers }
     }
 
-    /// We are diffing a `Collection` and `Blueprint` but  the latest blueprint
-    /// does not have a ClickhouseClusterConfig.
-    pub fn removed_from_collection(
-        before: &clickhouse_admin_types::ClickhouseKeeperClusterMembership,
-    ) -> Self {
-        // There's only so much information in a collection. Show what we can.
-        let metadata = KvListWithHeading::new(
-            CLICKHOUSE_CLUSTER_CONFIG_HEADING,
-            vec![KvPair::new(
-                BpDiffState::Removed,
-                CLICKHOUSE_HIGHEST_SEEN_KEEPER_LEADER_COMMITTED_LOG_INDEX,
-                before.leader_committed_log_index.to_string(),
-            )],
-        );
-
-        let keeper_rows: Vec<BpTableRow> = before
-            .raft_config
-            .iter()
-            .map(|keeper_id| {
-                BpTableRow::new(
-                    BpDiffState::Removed,
-                    vec![
-                        BpTableColumn::Value(
-                            NOT_PRESENT_IN_COLLECTION_PARENS.to_string(),
-                        ),
-                        BpTableColumn::Value(keeper_id.to_string()),
-                    ],
-                )
-            })
-            .collect();
-
-        let keepers = BpTable::new(
-            BpClickhouseKeepersTableSchema {},
-            BpGeneration::unknown(),
-            keeper_rows,
-        );
-
-        ClickhouseClusterConfigDiffTables { metadata, keepers, servers: None }
-    }
-
     /// The "before" inventory collection or blueprint does not have a relevant
     /// keeper configuration.
     pub fn added_to_blueprint(after: &ClickhouseClusterConfig) -> Self {
@@ -1373,156 +964,286 @@ impl ClickhouseClusterConfigDiffTables {
         .into()
     }
 }
+/// Tables for added sleds in a blueprint diff
+#[derive(Debug)]
+pub struct SledTables {
+    pub disks: Option<BpTable>,
+    pub datasets: Option<BpTable>,
+    pub zones: Option<BpTable>,
+}
+
+impl std::fmt::Display for SledTables {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        // Write the physical disks table if it exists
+        if let Some(table) = &self.disks {
+            writeln!(f, "{table}\n")?;
+        }
+
+        // Write the datasets table if it exists
+        if let Some(table) = &self.datasets {
+            writeln!(f, "{table}\n")?;
+        }
+
+        // Write the zones table if it exists
+        if let Some(table) = &self.zones {
+            writeln!(f, "{table}\n")?;
+        }
+
+        Ok(())
+    }
+}
+
+/// Printable output derived from a `BlueprintDiff`
+#[derive(Debug, Default)]
+pub struct BpDiffPrintable {
+    pub errors: Vec<String>,
+    pub warnings: Vec<String>,
+    pub sleds_added: BTreeMap<SledUuid, SledTables>,
+    pub sleds_removed: BTreeMap<SledUuid, SledTables>,
+    pub sleds_unchanged: BTreeMap<SledUuid, SledTables>,
+    pub sleds_modified: BTreeMap<SledUuid, SledTables>,
+    pub metadata: Vec<KvListWithHeading>,
+    pub clickhouse_cluster_config: Option<ClickhouseClusterConfigDiffTables>,
+}
+
+impl BpDiffPrintable {
+    pub fn new(acc: &BlueprintDiff, show_unchanged: bool) -> BpDiffPrintable {
+        BpDiffPrintable {
+            errors: acc.errors.clone(),
+            warnings: acc.warnings.clone(),
+            sleds_added: acc
+                .sleds_added
+                .iter()
+                .map(|(sled_id, insert)| {
+                    (
+                        *sled_id,
+                        SledTables {
+                            disks: disks_table(
+                                BpDiffState::Added,
+                                insert.disks,
+                            ),
+                            datasets: datasets_table(
+                                BpDiffState::Added,
+                                insert.datasets,
+                            ),
+                            zones: zones_table(
+                                BpDiffState::Added,
+                                insert.zones,
+                            ),
+                        },
+                    )
+                })
+                .collect(),
+            sleds_removed: acc
+                .sleds_removed
+                .iter()
+                .map(|(sled_id, remove)| {
+                    (
+                        *sled_id,
+                        SledTables {
+                            disks: disks_table(
+                                BpDiffState::Removed,
+                                remove.disks,
+                            ),
+                            datasets: datasets_table(
+                                BpDiffState::Removed,
+                                remove.datasets,
+                            ),
+                            zones: zones_table(
+                                BpDiffState::Removed,
+                                remove.zones,
+                            ),
+                        },
+                    )
+                })
+                .collect(),
+            sleds_unchanged: {
+                if show_unchanged {
+                    acc.sleds_unchanged
+                        .iter()
+                        .map(|sled_id| {
+                            (
+                                *sled_id,
+                                SledTables {
+                                    disks: disks_table(
+                                        BpDiffState::Unchanged,
+                                        acc.before.blueprint_disks.get(sled_id),
+                                    ),
+                                    datasets: datasets_table(
+                                        BpDiffState::Unchanged,
+                                        acc.before
+                                            .blueprint_datasets
+                                            .get(sled_id),
+                                    ),
+                                    zones: zones_table(
+                                        BpDiffState::Unchanged,
+                                        acc.before.blueprint_zones.get(sled_id),
+                                    ),
+                                },
+                            )
+                        })
+                        .collect()
+                } else {
+                    BTreeMap::new()
+                }
+            },
+            sleds_modified: acc
+                .sleds_modified
+                .iter()
+                .map(|(sled_id, modified)| {
+                    (*sled_id, modified.tables(show_unchanged))
+                })
+                .collect(),
+
+            metadata: acc.metadata.tables(show_unchanged),
+            clickhouse_cluster_config: {
+                match &acc.clickhouse_cluster_config {
+                    DiffValue::Unchanged(val) => {
+                        make_clickhouse_cluster_config_diff_tables(*val, *val)
+                    }
+                    DiffValue::Changed(Change { before, after }) => {
+                        make_clickhouse_cluster_config_diff_tables(
+                            *before, *after,
+                        )
+                    }
+                }
+            },
+        }
+    }
+}
+
+// Diff's are still done manually for `ClickhouseClusterConfig`. It's relatively
+// simple compared to other diffs, but we could and probably should change to a
+// visitor/accumulator model for consistency with the rest of the code.
+pub fn make_clickhouse_cluster_config_diff_tables(
+    before: &Option<ClickhouseClusterConfig>,
+    after: &Option<ClickhouseClusterConfig>,
+) -> Option<ClickhouseClusterConfigDiffTables> {
+    match (before, after) {
+        // Before blueprint + after blueprint
+        (Some(before), Some(after)) => Some(
+            ClickhouseClusterConfigDiffTables::diff_blueprints(before, after),
+        ),
+
+        // Before blueprint only
+        (Some(before), None) => Some(
+            ClickhouseClusterConfigDiffTables::removed_from_blueprint(before),
+        ),
+
+        // After blueprint only
+        (None, Some(after)) => {
+            Some(ClickhouseClusterConfigDiffTables::added_to_blueprint(after))
+        }
+
+        // No before or after
+        (None, None) => None,
+    }
+}
+
+/// Create a `BpTable` from a `BlueprintPhysicalDisksConfig`.
+fn disks_table(
+    state: BpDiffState,
+    disks: Option<&BlueprintPhysicalDisksConfig>,
+) -> Option<BpTable> {
+    disks.map(|disks_config| {
+        let mut disks: Vec<_> = disks_config.disks.iter().cloned().collect();
+        disks.sort_unstable_by(|a, b| a.identity.cmp(&b.identity));
+        let rows = disks.iter().map(|disk| disks_row(state, disk)).collect();
+        BpTable::new(
+            BpPhysicalDisksTableSchema {},
+            disks_config.generation.into(),
+            rows,
+        )
+    })
+}
+
+fn disks_row(
+    state: BpDiffState,
+    disk: &BlueprintPhysicalDiskConfig,
+) -> BpTableRow {
+    BpTableRow::from_strings(
+        state,
+        vec![
+            disk.identity.vendor.clone(),
+            disk.identity.model.clone(),
+            disk.identity.serial.clone(),
+        ],
+    )
+}
+
+/// Create a `BpTable` from a `BlueprintDatasetsConfig`
+fn datasets_table(
+    state: BpDiffState,
+    datasets: Option<&BlueprintDatasetsConfig>,
+) -> Option<BpTable> {
+    datasets.map(|datasets_config| {
+        // `self.datasets` is naturally ordered by ID, but that doesn't play
+        // well with expectorate-based tests: We end up sorted by (random)
+        // UUIDs. We redact the UUIDs, but that still results in test-to-test
+        // variance in the _order_ of the rows. We can work around this for now
+        // by sorting by dataset kind: after UUID redaction, that produces
+        // a stable table ordering for datasets.
+        let mut rows = datasets_config.datasets.iter().collect::<Vec<_>>();
+        rows.sort_unstable_by_key(|d| (&d.kind, &d.pool));
+        let rows = rows
+            .into_iter()
+            .map(move |dataset| {
+                BpTableRow::from_strings(state, dataset.as_strings())
+            })
+            .collect();
+        BpTable::new(
+            BpDatasetsTableSchema {},
+            datasets_config.generation.into(),
+            rows,
+        )
+    })
+}
+
+/// Create a `BpTable` from a `BlueprintZonesConfig`
+fn zones_table(
+    state: BpDiffState,
+    zones: Option<&BlueprintZonesConfig>,
+) -> Option<BpTable> {
+    zones.map(|zones_config| {
+        let mut zones: Vec<_> = zones_config.zones.iter().cloned().collect();
+        zones.sort_unstable_by_key(zone_sort_key);
+        let rows = zones.iter().map(|zone| zones_row(state, zone)).collect();
+        BpTable::new(
+            BpOmicronZonesTableSchema {},
+            zones_config.generation.into(),
+            rows,
+        )
+    })
+}
+
+fn zones_row(state: BpDiffState, zone: &BlueprintZoneConfig) -> BpTableRow {
+    BpTableRow::from_strings(
+        state,
+        vec![
+            zone.kind().report_str().to_string(),
+            zone.id().to_string(),
+            zone.disposition.to_string(),
+            zone.underlay_ip().to_string(),
+        ],
+    )
+}
 
 /// Wrapper to allow a [`BlueprintDiff`] to be displayed.
 ///
 /// Returned by [`BlueprintDiff::display()`].
-#[derive(Clone, Debug)]
+#[derive(Debug)]
 #[must_use = "this struct does nothing unless displayed"]
 pub struct BlueprintDiffDisplay<'diff> {
-    pub diff: &'diff BlueprintDiff,
+    pub diff: &'diff BlueprintDiff<'diff>,
+    pub printable: BpDiffPrintable,
     // TODO: add colorization with a stylesheet
 }
 
 impl<'diff> BlueprintDiffDisplay<'diff> {
     #[inline]
-    fn new(diff: &'diff BlueprintDiff) -> Self {
-        Self { diff }
-    }
-
-    pub fn make_metadata_diff_tables(
-        &self,
-    ) -> impl IntoIterator<Item = KvListWithHeading> {
-        macro_rules! diff_row {
-            ($member:ident, $label:expr) => {
-                diff_row!($member, $label, std::convert::identity)
-            };
-
-            ($member:ident, $label:expr, $display:expr) => {
-                match &self.diff.before_meta {
-                    DiffBeforeMetadata::Collection { .. } => {
-                        // Collections have no metadata, so this is new
-                        KvPair::new(
-                            BpDiffState::Added,
-                            $label,
-                            linear_table_modified(
-                                &NOT_PRESENT_IN_COLLECTION_PARENS,
-                                &$display(&self.diff.after_meta.$member),
-                            ),
-                        )
-                    }
-                    DiffBeforeMetadata::Blueprint(before) => {
-                        if before.$member == self.diff.after_meta.$member {
-                            KvPair::new(
-                                BpDiffState::Unchanged,
-                                $label,
-                                linear_table_unchanged(&$display(
-                                    &self.diff.after_meta.$member,
-                                )),
-                            )
-                        } else {
-                            KvPair::new(
-                                BpDiffState::Modified,
-                                $label,
-                                linear_table_modified(
-                                    &$display(&before.$member),
-                                    &$display(&self.diff.after_meta.$member),
-                                ),
-                            )
-                        }
-                    }
-                }
-            };
-        }
-
-        [
-            KvListWithHeading::new(
-                COCKROACHDB_HEADING,
-                vec![
-                    diff_row!(
-                        cockroachdb_fingerprint,
-                        COCKROACHDB_FINGERPRINT,
-                        display_none_if_empty
-                    ),
-                    diff_row!(
-                        cockroachdb_setting_preserve_downgrade,
-                        COCKROACHDB_PRESERVE_DOWNGRADE,
-                        display_optional_preserve_downgrade
-                    ),
-                ],
-            ),
-            KvListWithHeading::new(
-                METADATA_HEADING,
-                vec![
-                    diff_row!(internal_dns_version, INTERNAL_DNS_VERSION),
-                    diff_row!(external_dns_version, EXTERNAL_DNS_VERSION),
-                ],
-            ),
-        ]
-    }
-
-    pub fn make_clickhouse_cluster_config_diff_tables(
-        &self,
-    ) -> Option<ClickhouseClusterConfigDiffTables> {
-        match (
-            &self.diff.before_clickhouse_cluster_config,
-            &self.diff.after_clickhouse_cluster_config,
-        ) {
-            // Before blueprint + after blueprint
-            (
-                DiffBeforeClickhouseClusterConfig::Blueprint(Some(before)),
-                Some(after),
-            ) => Some(ClickhouseClusterConfigDiffTables::diff_blueprints(
-                before, after,
-            )),
-
-            // Before blueprint only
-            (
-                DiffBeforeClickhouseClusterConfig::Blueprint(Some(before)),
-                None,
-            ) => {
-                Some(ClickhouseClusterConfigDiffTables::removed_from_blueprint(
-                    before,
-                ))
-            }
-
-            // After blueprint only
-            (
-                DiffBeforeClickhouseClusterConfig::Blueprint(None),
-                Some(after),
-            ) => Some(ClickhouseClusterConfigDiffTables::added_to_blueprint(
-                after,
-            )),
-
-            // No before or after
-            (DiffBeforeClickhouseClusterConfig::Blueprint(None), None) => None,
-        }
-    }
-
-    /// Write out physical disk and zone tables for a given `sled_id`
-    fn write_tables(
-        &self,
-        f: &mut fmt::Formatter<'_>,
-        sled_id: &SledUuid,
-    ) -> fmt::Result {
-        // Write the physical disks table if it exists
-        if let Some(table) =
-            self.diff.physical_disks.to_bp_sled_subtable(sled_id)
-        {
-            writeln!(f, "{table}\n")?;
-        }
-
-        // Write the datasets table if it exists
-        if let Some(table) = self.diff.datasets.to_bp_sled_subtable(sled_id) {
-            writeln!(f, "{table}\n")?;
-        }
-
-        // Write the zones table if it exists
-        if let Some(table) = self.diff.zones.to_bp_sled_subtable(sled_id) {
-            writeln!(f, "{table}\n")?;
-        }
-
-        Ok(())
+    fn new(diff: &'diff BlueprintDiff, show_unchanged: bool) -> Self {
+        let printable = BpDiffPrintable::new(diff, show_unchanged);
+        Self { diff, printable }
     }
 
     /// Helper methods to stringify sled states. These are separated by
@@ -1530,8 +1251,8 @@ impl<'diff> BlueprintDiffDisplay<'diff> {
     /// before and after should be that can only be wrong if we have a bug
     /// constructing the diff.
     fn sled_state_unchanged(&self, sled_id: &SledUuid) -> String {
-        let before = self.diff.before_state.get(sled_id);
-        let after = self.diff.after_state.get(sled_id);
+        let before = self.diff.before.sled_state.get(sled_id);
+        let after = self.diff.after.sled_state.get(sled_id);
         if before == after {
             after
                 .map(|s| s.to_string())
@@ -1544,8 +1265,8 @@ impl<'diff> BlueprintDiffDisplay<'diff> {
         }
     }
     fn sled_state_added(&self, sled_id: &SledUuid) -> String {
-        let before = self.diff.before_state.get(sled_id);
-        let after = self.diff.after_state.get(sled_id);
+        let before = self.diff.before.sled_state.get(sled_id);
+        let after = self.diff.after.sled_state.get(sled_id);
         if before.is_none() {
             after
                 .map(|s| format!("{s}"))
@@ -1558,8 +1279,8 @@ impl<'diff> BlueprintDiffDisplay<'diff> {
         }
     }
     fn sled_state_removed(&self, sled_id: &SledUuid) -> String {
-        let before = self.diff.before_state.get(sled_id);
-        let after = self.diff.after_state.get(sled_id);
+        let before = self.diff.before.sled_state.get(sled_id);
+        let after = self.diff.after.sled_state.get(sled_id);
         if after.is_none() {
             before
                 .map(|s| format!("was {s}"))
@@ -1572,8 +1293,8 @@ impl<'diff> BlueprintDiffDisplay<'diff> {
         }
     }
     fn sled_state_modified(&self, sled_id: &SledUuid) -> String {
-        let before = self.diff.before_state.get(sled_id);
-        let after = self.diff.after_state.get(sled_id);
+        let before = self.diff.before.sled_state.get(sled_id);
+        let after = self.diff.after.sled_state.get(sled_id);
         match (before, after) {
             (Some(before), Some(after)) if before != after => {
                 format!("{before} -> {after}")
@@ -1592,28 +1313,12 @@ impl<'diff> BlueprintDiffDisplay<'diff> {
 
 impl fmt::Display for BlueprintDiffDisplay<'_> {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        let diff = self.diff;
-
-        // Print things differently based on whether the diff is between a
-        // collection and a blueprint, or a blueprint and a blueprint.
-        match &diff.before_meta {
-            DiffBeforeMetadata::Collection { id } => {
-                writeln!(
-                    f,
-                    "from: collection {}\n\
-                     to:   blueprint  {}",
-                    id, diff.after_meta.id,
-                )?;
-            }
-            DiffBeforeMetadata::Blueprint(before) => {
-                writeln!(
-                    f,
-                    "from: blueprint {}\n\
-                     to:   blueprint {}\n",
-                    before.id, diff.after_meta.id
-                )?;
-            }
-        }
+        writeln!(
+            f,
+            "from: blueprint {}\n\
+             to:   blueprint {}\n",
+            self.diff.before.id, self.diff.after.id
+        )?;
 
         // Write out sled information
         //
@@ -1632,83 +1337,85 @@ impl fmt::Display for BlueprintDiffDisplay<'_> {
         // We put errors at the bottom to ensure they are seen immediately.
 
         // Write out tables for unchanged sleds
-        if !diff.sleds_unchanged.is_empty() {
+        if !self.printable.sleds_unchanged.is_empty() {
             writeln!(f, " UNCHANGED SLEDS:\n")?;
-            for sled_id in &diff.sleds_unchanged {
+            for (sled_id, tables) in &self.printable.sleds_unchanged {
                 writeln!(
                     f,
                     "  sled {sled_id} ({}):\n",
                     self.sled_state_unchanged(sled_id)
                 )?;
-                self.write_tables(f, sled_id)?;
+                write!(f, "{tables}")?;
             }
         }
 
         // Write out tables for removed sleds
-        if !diff.sleds_removed.is_empty() {
+        if !self.printable.sleds_removed.is_empty() {
             writeln!(f, " REMOVED SLEDS:\n")?;
-            for sled_id in &diff.sleds_removed {
+            for (sled_id, tables) in &self.printable.sleds_removed {
                 writeln!(
                     f,
                     "  sled {sled_id} ({}):\n",
                     self.sled_state_removed(sled_id)
                 )?;
-                self.write_tables(f, sled_id)?;
+                write!(f, "{tables}")?;
             }
         }
 
         // Write out tables for modified sleds
-        if !diff.sleds_modified.is_empty() {
+        if !self.printable.sleds_modified.is_empty() {
             writeln!(f, " MODIFIED SLEDS:\n")?;
-            for sled_id in &diff.sleds_modified {
+            for (sled_id, tables) in &self.printable.sleds_modified {
                 writeln!(
                     f,
                     "  sled {sled_id} ({}):\n",
                     self.sled_state_modified(sled_id)
                 )?;
-                self.write_tables(f, sled_id)?;
+                write!(f, "{tables}")?;
             }
         }
 
         // Write out tables for added sleds
-        if !diff.sleds_added.is_empty() {
+        if !self.printable.sleds_added.is_empty() {
             writeln!(f, " ADDED SLEDS:\n")?;
-            for sled_id in &diff.sleds_added {
+            for (sled_id, tables) in &self.printable.sleds_added {
                 writeln!(
                     f,
                     "  sled {sled_id} ({}):\n",
                     self.sled_state_added(sled_id)
                 )?;
-                self.write_tables(f, sled_id)?;
+                write!(f, "{tables}")?;
             }
         }
 
-        // Write out zone errors.
-        if !diff.zones.errors.is_empty() {
-            writeln!(f, "ERRORS:")?;
-            for (sled_id, errors) in &diff.zones.errors {
-                writeln!(f, "\n  sled {sled_id}\n")?;
-                writeln!(
-                    f,
-                    "    zone diff errors: before gen {}, after gen {}\n",
-                    errors.generation_before, errors.generation_after
-                )?;
-
-                for err in &errors.errors {
-                    writeln!(f, "      zone id: {}", err.zone_before.id())?;
-                    writeln!(f, "      reason: {}", err.reason)?;
-                }
+        // Write out warnings
+        if !self.printable.warnings.is_empty() {
+            writeln!(f, "WARNINGS:")?;
+            for err in &self.printable.errors {
+                writeln!(f, "{err}")?;
             }
+            writeln!(f, "")?;
+        }
+
+        // Write out errors.
+        // This is the only thing that isn't backwards compatible. The old
+        // mechanism for zone errors doesn't really fit with the new automated
+        // diff/visitor accumulator model.
+        if !self.printable.errors.is_empty() {
+            writeln!(f, "ERRORS:")?;
+            for err in &self.printable.errors {
+                writeln!(f, "{err}")?;
+            }
+            writeln!(f, "")?;
         }
 
         // Write out metadata diff table
-        for table in self.make_metadata_diff_tables() {
+        for table in &self.printable.metadata {
             writeln!(f, "{}", table)?;
         }
 
         // Write out clickhouse cluster diff tables
-        if let Some(tables) = self.make_clickhouse_cluster_config_diff_tables()
-        {
+        if let Some(tables) = &self.printable.clickhouse_cluster_config {
             writeln!(f, "{}", tables.metadata)?;
             writeln!(f, "{}", tables.keepers)?;
             if let Some(servers) = &tables.servers {

--- a/nexus/types/src/deployment/blueprint_differ.rs
+++ b/nexus/types/src/deployment/blueprint_differ.rs
@@ -1,0 +1,709 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at https://mozilla.org/MPL/2.0/.
+
+//! An implementation of a `VisitBlueprint` visitor that is used to construct
+//! a `BlueprintDiff`.
+
+use super::blueprint_diff::{
+    BlueprintDiff, DiffValue, ModifiedDataset, ModifiedDisk, ModifiedSled,
+    ModifiedZone,
+};
+use super::diff_visitors::visit_blueprint::{
+    SledInsert, SledRemove, VisitBlueprint,
+};
+use super::diff_visitors::visit_blueprint_datasets_config::VisitBlueprintDatasetsConfig;
+use super::diff_visitors::visit_blueprint_physical_disks_config::VisitBlueprintPhysicalDisksConfig;
+use super::diff_visitors::visit_blueprint_zones_config::VisitBlueprintZonesConfig;
+use super::diff_visitors::{BpVisitorContext, Change};
+use super::{
+    Blueprint, BlueprintDatasetDisposition, BlueprintPhysicalDiskDisposition,
+    ClickhouseClusterConfig, CockroachDbPreserveDowngrade,
+};
+
+use diffus::Diffable;
+use omicron_common::api::external::{ByteCount, Generation};
+use omicron_common::disk::CompressionAlgorithm;
+use omicron_uuid_kinds::BlueprintUuid;
+use std::collections::BTreeSet;
+
+use crate::deployment::{
+    BlueprintDatasetConfig, BlueprintPhysicalDiskConfig, BlueprintZoneConfig,
+    BlueprintZoneDisposition, BlueprintZoneType, ZpoolName,
+};
+use crate::external_api::views::SledState;
+
+/// A mechanism for creating a `BlueprintDiff` via a `VisitBlueprint`
+/// implementation.
+pub struct BlueprintDiffer<'e> {
+    before: &'e Blueprint,
+    after: &'e Blueprint,
+    /// An accumulator for diff state while traversing a visitor
+    diff: BlueprintDiff<'e>,
+}
+
+impl<'e> BlueprintDiffer<'e> {
+    pub fn new(
+        before: &'e Blueprint,
+        after: &'e Blueprint,
+    ) -> BlueprintDiffer<'e> {
+        BlueprintDiffer {
+            before,
+            after,
+            diff: BlueprintDiff::new(before, after),
+        }
+    }
+
+    pub fn diff(mut self) -> BlueprintDiff<'e> {
+        let mut ctx = BpVisitorContext::default();
+        let diff = self.before.diff(&self.after);
+        self.visit_blueprint(&mut ctx, diff);
+
+        // Unchanged sleds are those that do not exist in added, removed, or
+        // modified.
+        let changed_sleds: BTreeSet<_> = self
+            .diff
+            .sleds_added
+            .keys()
+            .cloned()
+            .chain(self.diff.sleds_removed.keys().cloned())
+            .chain(self.diff.sleds_modified.keys().cloned())
+            .collect();
+
+        let before_sleds: BTreeSet<_> = self.before.sleds().collect();
+        self.diff.sleds_unchanged =
+            before_sleds.difference(&changed_sleds).cloned().collect();
+
+        self.diff
+    }
+}
+
+impl<'e> VisitBlueprint<'e> for BlueprintDiffer<'e> {
+    fn zones_visitor(
+        &mut self,
+    ) -> Option<&mut impl VisitBlueprintZonesConfig<'e>> {
+        Some(&mut *self)
+    }
+
+    fn disks_visitor(
+        &mut self,
+    ) -> Option<&mut impl VisitBlueprintPhysicalDisksConfig<'e>> {
+        Some(&mut *self)
+    }
+
+    fn datasets_visitor(
+        &mut self,
+    ) -> Option<&mut impl VisitBlueprintDatasetsConfig<'e>> {
+        Some(&mut *self)
+    }
+
+    fn visit_sled_insert(
+        &mut self,
+        ctx: &mut BpVisitorContext,
+        node: SledInsert<'e>,
+    ) {
+        let Some(sled_id) = ctx.sled_id else {
+            let err =
+                "Missing sled id in ctx for visit_sled_insert".to_string();
+            self.diff.errors.push(err);
+            return;
+        };
+
+        self.diff.sleds_added.insert(sled_id, node);
+    }
+
+    fn visit_sled_remove(
+        &mut self,
+        ctx: &mut BpVisitorContext,
+        node: SledRemove<'e>,
+    ) {
+        let Some(sled_id) = ctx.sled_id else {
+            let err =
+                "Missing sled id in ctx for visit_sled_remove".to_string();
+            self.diff.errors.push(err);
+            return;
+        };
+
+        self.diff.sleds_removed.insert(sled_id, node);
+    }
+
+    fn visit_sled_state_change(
+        &mut self,
+        ctx: &mut BpVisitorContext,
+        change: Change<'e, SledState>,
+    ) {
+        let Some(sled_id) = ctx.sled_id else {
+            let err = "Missing sled id in ctx for visit_sled_state_change"
+                .to_string();
+            self.diff.errors.push(err);
+            return;
+        };
+        let s = self
+            .diff
+            .sleds_modified
+            .entry(sled_id)
+            .or_insert(ModifiedSled::new(&self.before, sled_id));
+        s.sled_state = DiffValue::Changed(change);
+    }
+
+    fn visit_parent_blueprint_id_change(
+        &mut self,
+        _ctx: &mut BpVisitorContext,
+        change: Change<'e, Option<BlueprintUuid>>,
+    ) {
+        self.diff.metadata.parent_blueprint_id = DiffValue::Changed(change);
+    }
+
+    fn visit_internal_dns_version_change(
+        &mut self,
+        _ctx: &mut BpVisitorContext,
+        change: Change<'e, Generation>,
+    ) {
+        self.diff.metadata.internal_dns_version = DiffValue::Changed(change);
+    }
+
+    fn visit_external_dns_version_change(
+        &mut self,
+        _ctx: &mut BpVisitorContext,
+        change: Change<'e, Generation>,
+    ) {
+        self.diff.metadata.external_dns_version = DiffValue::Changed(change);
+    }
+
+    fn visit_cockroachdb_fingerprint_change(
+        &mut self,
+        _ctx: &mut BpVisitorContext,
+        change: Change<'e, String>,
+    ) {
+        self.diff.metadata.cockroachdb_fingerprint = DiffValue::Changed(change);
+    }
+
+    fn visit_cockroachdb_setting_preserve_downgrade_change(
+        &mut self,
+        _ctx: &mut BpVisitorContext,
+        change: Change<'e, CockroachDbPreserveDowngrade>,
+    ) {
+        self.diff.metadata.cockroachdb_setting_preserve_downgrade =
+            DiffValue::Changed(change);
+    }
+
+    fn visit_creator_change(
+        &mut self,
+        _ctx: &mut BpVisitorContext,
+        change: Change<'e, String>,
+    ) {
+        self.diff.metadata.creator = DiffValue::Changed(change);
+    }
+
+    fn visit_comment_change(
+        &mut self,
+        _ctx: &mut BpVisitorContext,
+        change: Change<'e, String>,
+    ) {
+        self.diff.metadata.comment = DiffValue::Changed(change);
+    }
+
+    fn visit_clickhouse_cluster_config_change(
+        &mut self,
+        _ctx: &mut BpVisitorContext,
+        change: Change<'e, Option<ClickhouseClusterConfig>>,
+    ) {
+        // TODO: Change this once we have a visitor for `ClickhouseClusterconfig`
+        self.diff.clickhouse_cluster_config = DiffValue::Changed(change);
+    }
+}
+
+impl<'e> VisitBlueprintZonesConfig<'e> for BlueprintDiffer<'e> {
+    fn visit_generation_change(
+        &mut self,
+        ctx: &mut BpVisitorContext,
+        change: Change<'e, Generation>,
+    ) {
+        let Some(sled_id) = ctx.sled_id else {
+            let err =
+                "Missing sled id in ctx for zones visit_generation_change"
+                    .to_string();
+            self.diff.errors.push(err);
+            return;
+        };
+        let s = self
+            .diff
+            .sleds_modified
+            .entry(sled_id)
+            .or_insert(ModifiedSled::new(&self.before, sled_id));
+        s.zones_generation = DiffValue::Changed(change);
+    }
+
+    fn visit_zones_insert(
+        &mut self,
+        ctx: &mut BpVisitorContext,
+        node: &BlueprintZoneConfig,
+    ) {
+        let Some(sled_id) = ctx.sled_id else {
+            let err =
+                "Missing sled id in ctx for visit_zones_insert".to_string();
+            self.diff.errors.push(err);
+            return;
+        };
+        let s = self
+            .diff
+            .sleds_modified
+            .entry(sled_id)
+            .or_insert(ModifiedSled::new(&self.before, sled_id));
+        s.zones_added.insert(node.clone());
+    }
+
+    fn visit_zones_remove(
+        &mut self,
+        ctx: &mut BpVisitorContext,
+        node: &BlueprintZoneConfig,
+    ) {
+        let Some(sled_id) = ctx.sled_id else {
+            let err =
+                "Missing sled id in ctx for visit_zones_remove".to_string();
+            self.diff.errors.push(err);
+            return;
+        };
+        let s = self
+            .diff
+            .sleds_modified
+            .entry(sled_id)
+            .or_insert(ModifiedSled::new(&self.before, sled_id));
+        s.zones_removed.insert(node.clone());
+
+        // Remove this zone from the unchanged zones to compensate
+        // for constructor initialization.
+        s.zones_unchanged.remove(&node.id);
+    }
+
+    fn visit_zone_change(
+        &mut self,
+        ctx: &mut BpVisitorContext,
+        change: Change<'e, BlueprintZoneConfig>,
+    ) {
+        let Some(sled_id) = ctx.sled_id else {
+            let err =
+                "Missing sled id in ctx for visit_zone_change".to_string();
+            self.diff.errors.push(err);
+            return;
+        };
+
+        let s = self
+            .diff
+            .sleds_modified
+            .entry(sled_id)
+            .or_insert(ModifiedSled::new(&self.before, sled_id));
+        s.zones_modified
+            .insert(change.before.id, ModifiedZone::new(&change.before));
+
+        // At least one of the fields for this zone is going to change in a
+        // follow up callback, so we want to remove it from the unchanged zones
+        // to compensate for constructor initialization.
+        s.zones_unchanged.remove(&change.before.id);
+    }
+
+    fn visit_zone_disposition_change(
+        &mut self,
+        ctx: &mut BpVisitorContext,
+        change: Change<'e, BlueprintZoneDisposition>,
+    ) {
+        let Some(sled_id) = ctx.sled_id else {
+            let err =
+                "Missing sled id in ctx for visit_zone_disposition_change"
+                    .to_string();
+            self.diff.errors.push(err);
+            return;
+        };
+
+        let Some(zone_id) = ctx.zone_id else {
+            let err =
+                "Missing zone id in ctx for visit_zone_disposition_change"
+                    .to_string();
+            self.diff.errors.push(err);
+            return;
+        };
+
+        // Safety: We guarantee a `visit_zone_change` callback fired and
+        // created the `ModifiedSled` entry if it didn't exist.
+        let s = self.diff.sleds_modified.get_mut(&sled_id).unwrap();
+
+        // Safety: We guarantee a `visit_zone_change` callback fired and
+        // created the `ModifiedZone` entry.
+        s.zones_modified.get_mut(&zone_id).unwrap().disposition =
+            DiffValue::Changed(change);
+    }
+
+    fn visit_zone_filesystem_pool_change(
+        &mut self,
+        ctx: &mut BpVisitorContext,
+        change: Change<'e, Option<ZpoolName>>,
+    ) {
+        let Some(sled_id) = ctx.sled_id else {
+            let err =
+                "Missing sled id in ctx for visit_zone_filesystem_pool_change"
+                    .to_string();
+            self.diff.errors.push(err);
+            return;
+        };
+
+        let Some(zone_id) = ctx.zone_id else {
+            let err =
+                "Missing zone id in ctx for visit_zone_filesystem_pool_change"
+                    .to_string();
+            self.diff.errors.push(err);
+            return;
+        };
+
+        // Safety: We guarantee a `visit_zone_change` callback fired and
+        // created the `ModifiedSled` entry if it didn't exist.
+        let s = self.diff.sleds_modified.get_mut(&sled_id).unwrap();
+
+        // Safety: We guarantee a `visit_zone_change` callback fired and
+        // created the `ModifiedZone` entry.
+        s.zones_modified.get_mut(&zone_id).unwrap().filesystem_pool =
+            DiffValue::Changed(change);
+    }
+
+    fn visit_zone_zone_type_change(
+        &mut self,
+        _: &mut BpVisitorContext,
+        change: Change<'e, BlueprintZoneType>,
+    ) {
+        self.diff.errors.push(format!(
+            "Zone type not allowed to change. before: {:#?}, after: {:#?}",
+            change.before, change.after
+        ));
+    }
+}
+impl<'e> VisitBlueprintPhysicalDisksConfig<'e> for BlueprintDiffer<'e> {
+    fn visit_generation_change(
+        &mut self,
+        ctx: &mut BpVisitorContext,
+        change: Change<'e, Generation>,
+    ) {
+        let Some(sled_id) = ctx.sled_id else {
+            let err =
+                "Missing sled id in ctx for disks visit_generation_change"
+                    .to_string();
+            self.diff.errors.push(err);
+            return;
+        };
+        let s = self
+            .diff
+            .sleds_modified
+            .entry(sled_id)
+            .or_insert(ModifiedSled::new(&self.before, sled_id));
+        s.disks_generation = Some(DiffValue::Changed(change));
+    }
+
+    fn visit_disks_insert(
+        &mut self,
+        ctx: &mut BpVisitorContext,
+        node: &BlueprintPhysicalDiskConfig,
+    ) {
+        let Some(sled_id) = ctx.sled_id else {
+            let err =
+                "Missing sled id in ctx for visit_disks_insert".to_string();
+            self.diff.errors.push(err);
+            return;
+        };
+        let s = self
+            .diff
+            .sleds_modified
+            .entry(sled_id)
+            .or_insert(ModifiedSled::new(&self.before, sled_id));
+        s.disks_added.insert(node.clone());
+    }
+
+    fn visit_disks_remove(
+        &mut self,
+        ctx: &mut BpVisitorContext,
+        node: &BlueprintPhysicalDiskConfig,
+    ) {
+        let Some(sled_id) = ctx.sled_id else {
+            let err =
+                "Missing sled id in ctx for visit_disks_remove".to_string();
+            self.diff.errors.push(err);
+            return;
+        };
+        let s = self
+            .diff
+            .sleds_modified
+            .entry(sled_id)
+            .or_insert(ModifiedSled::new(&self.before, sled_id));
+        s.disks_removed.insert(node.clone());
+
+        // Remove this disk from the unchanged disks to compensate for
+        // constructor initialization.
+        s.disks_unchanged.remove(&node.id);
+    }
+
+    fn visit_disk_change(
+        &mut self,
+        ctx: &mut BpVisitorContext,
+        change: Change<'e, BlueprintPhysicalDiskConfig>,
+    ) {
+        let Some(sled_id) = ctx.sled_id else {
+            let err =
+                "Missing sled id in ctx for visit_disk_change".to_string();
+            self.diff.errors.push(err);
+            return;
+        };
+
+        let s = self
+            .diff
+            .sleds_modified
+            .entry(sled_id)
+            .or_insert(ModifiedSled::new(&self.before, sled_id));
+        s.disks_modified
+            .insert(change.before.id, ModifiedDisk::new(&change.before));
+
+        // At least one of the fields for this disk is going to change in a
+        // follow up callback, so we want to remove it from the unchanged disks
+        // to compensate for constructor initialization.
+        s.disks_unchanged.remove(&change.before.id);
+    }
+
+    fn visit_disk_disposition_change(
+        &mut self,
+        ctx: &mut BpVisitorContext,
+        change: Change<'e, BlueprintPhysicalDiskDisposition>,
+    ) {
+        let Some(sled_id) = ctx.sled_id else {
+            let err =
+                "Missing sled id in ctx for visit_disk_disposition_change"
+                    .to_string();
+            self.diff.errors.push(err);
+            return;
+        };
+
+        let Some(disk_id) = ctx.disk_id else {
+            let err =
+                "Missing disk id in ctx for visit_disk_disposition_change"
+                    .to_string();
+            self.diff.errors.push(err);
+            return;
+        };
+
+        // Safety: We guarantee a `visit_disk_change` callback fired and
+        // created the `ModifiedSled` entry if it didn't exist.
+        let s = self.diff.sleds_modified.get_mut(&sled_id).unwrap();
+
+        // Safety: We guarantee a `visit_disk_change` callback fired and
+        // created the `ModifiedZone` entry.
+        s.disks_modified.get_mut(&disk_id).unwrap().disposition =
+            DiffValue::Changed(change);
+    }
+}
+impl<'e> VisitBlueprintDatasetsConfig<'e> for BlueprintDiffer<'e> {
+    fn visit_generation_change(
+        &mut self,
+        ctx: &mut BpVisitorContext,
+        change: Change<'e, Generation>,
+    ) {
+        let Some(sled_id) = ctx.sled_id else {
+            let err =
+                "Missing sled id in ctx for datasets visit_generation_change"
+                    .to_string();
+            self.diff.errors.push(err);
+            return;
+        };
+        let s = self
+            .diff
+            .sleds_modified
+            .entry(sled_id)
+            .or_insert(ModifiedSled::new(&self.before, sled_id));
+        s.datasets_generation = Some(DiffValue::Changed(change));
+    }
+
+    fn visit_datasets_insert(
+        &mut self,
+        ctx: &mut BpVisitorContext,
+        node: &BlueprintDatasetConfig,
+    ) {
+        let Some(sled_id) = ctx.sled_id else {
+            let err =
+                "Missing sled id in ctx for visit_datasets_insert".to_string();
+            self.diff.errors.push(err);
+            return;
+        };
+        let s = self
+            .diff
+            .sleds_modified
+            .entry(sled_id)
+            .or_insert(ModifiedSled::new(&self.before, sled_id));
+        s.datasets_added.insert(node.clone());
+    }
+
+    fn visit_datasets_remove(
+        &mut self,
+        ctx: &mut BpVisitorContext,
+        node: &BlueprintDatasetConfig,
+    ) {
+        let Some(sled_id) = ctx.sled_id else {
+            let err =
+                "Missing sled id in ctx for visit_datasets_remove".to_string();
+            self.diff.errors.push(err);
+            return;
+        };
+        let s = self
+            .diff
+            .sleds_modified
+            .entry(sled_id)
+            .or_insert(ModifiedSled::new(&self.before, sled_id));
+        s.datasets_removed.insert(node.clone());
+
+        // Remove this dataset from the unchanged datasets to compensate
+        // for constructor initialization.
+        s.datasets_unchanged.remove(&node.id);
+    }
+
+    fn visit_dataset_change(
+        &mut self,
+        ctx: &mut BpVisitorContext,
+        change: Change<'e, BlueprintDatasetConfig>,
+    ) {
+        let Some(sled_id) = ctx.sled_id else {
+            let err =
+                "Missing sled id in ctx for visit_dataset_change".to_string();
+            self.diff.errors.push(err);
+            return;
+        };
+
+        let s = self
+            .diff
+            .sleds_modified
+            .entry(sled_id)
+            .or_insert(ModifiedSled::new(&self.before, sled_id));
+        s.datasets_modified
+            .insert(change.before.id, ModifiedDataset::new(&change.before));
+
+        // At least one of the fields for this dataset is going to change in a
+        // follow up callback, so we want to remove it from the unchanged datasets
+        // to compensate for constructor initialization.
+        s.datasets_unchanged.remove(&change.before.id);
+    }
+
+    fn visit_dataset_disposition_change(
+        &mut self,
+        ctx: &mut BpVisitorContext,
+        change: Change<'e, BlueprintDatasetDisposition>,
+    ) {
+        let Some(sled_id) = ctx.sled_id else {
+            let err =
+                "Missing sled id in ctx for visit_dataset_disposition_change"
+                    .to_string();
+            self.diff.errors.push(err);
+            return;
+        };
+
+        let Some(dataset_id) = ctx.dataset_id else {
+            let err =
+                "Missing dataset id in ctx for visit_dataset_disposition_change"
+                    .to_string();
+            self.diff.errors.push(err);
+            return;
+        };
+
+        // Safety: We guarantee a `visit_dataset_change` callback fired and
+        // created the `ModifiedSled` entry if it didn't exist.
+        let s = self.diff.sleds_modified.get_mut(&sled_id).unwrap();
+
+        // Safety: We guarantee a `visit_dataset_change` callback fired and
+        // created the `ModifiedDataset` entry.
+        s.datasets_modified.get_mut(&dataset_id).unwrap().disposition =
+            DiffValue::Changed(change);
+    }
+
+    fn visit_dataset_quota_change(
+        &mut self,
+        ctx: &mut BpVisitorContext,
+        change: Change<'e, Option<ByteCount>>,
+    ) {
+        let Some(sled_id) = ctx.sled_id else {
+            let err = "Missing sled id in ctx for visit_dataset_quota_change"
+                .to_string();
+            self.diff.errors.push(err);
+            return;
+        };
+
+        let Some(dataset_id) = ctx.dataset_id else {
+            let err =
+                "Missing dataset id in ctx for visit_dataset_quota_change"
+                    .to_string();
+            self.diff.errors.push(err);
+            return;
+        };
+
+        // Safety: We guarantee a `visit_dataset_change` callback fired and
+        // created the `ModifiedSled` entry if it didn't exist.
+        let s = self.diff.sleds_modified.get_mut(&sled_id).unwrap();
+
+        // Safety: We guarantee a `visit_dataset_change` callback fired and
+        // created the `ModifiedDataset` entry.
+        s.datasets_modified.get_mut(&dataset_id).unwrap().quota =
+            DiffValue::Changed(change);
+    }
+
+    fn visit_dataset_reservation_change(
+        &mut self,
+        ctx: &mut BpVisitorContext,
+        change: Change<'e, Option<ByteCount>>,
+    ) {
+        let Some(sled_id) = ctx.sled_id else {
+            let err =
+                "Missing sled id in ctx for visit_dataset_reservation_change"
+                    .to_string();
+            self.diff.errors.push(err);
+            return;
+        };
+
+        let Some(dataset_id) = ctx.dataset_id else {
+            let err =
+                "Missing dataset id in ctx for visit_dataset_reservation_change"
+                    .to_string();
+            self.diff.errors.push(err);
+            return;
+        };
+
+        // Safety: We guarantee a `visit_dataset_change` callback fired and
+        // created the `ModifiedSled` entry if it didn't exist.
+        let s = self.diff.sleds_modified.get_mut(&sled_id).unwrap();
+
+        // Safety: We guarantee a `visit_dataset_change` callback fired and
+        // created the `ModifiedDataset` entry.
+        s.datasets_modified.get_mut(&dataset_id).unwrap().reservation =
+            DiffValue::Changed(change);
+    }
+
+    fn visit_dataset_compression_change(
+        &mut self,
+        ctx: &mut BpVisitorContext,
+        change: Change<'e, CompressionAlgorithm>,
+    ) {
+        let Some(sled_id) = ctx.sled_id else {
+            let err =
+                "Missing sled id in ctx for visit_dataset_compression_change"
+                    .to_string();
+            self.diff.errors.push(err);
+            return;
+        };
+
+        let Some(dataset_id) = ctx.dataset_id else {
+            let err =
+                "Missing dataset id in ctx for visit_dataset_compression_change"
+                    .to_string();
+            self.diff.errors.push(err);
+            return;
+        };
+
+        // Safety: We guarantee a `visit_dataset_change` callback fired and
+        // created the `ModifiedSled` entry if it didn't exist.
+        let s = self.diff.sleds_modified.get_mut(&sled_id).unwrap();
+
+        // Safety: We guarantee a `visit_dataset_change` callback fired and
+        // created the `ModifiedDataset` entry.
+        s.datasets_modified.get_mut(&dataset_id).unwrap().compression =
+            DiffValue::Changed(change);
+    }
+}

--- a/nexus/types/src/deployment/blueprint_display.rs
+++ b/nexus/types/src/deployment/blueprint_display.rs
@@ -89,6 +89,12 @@ pub enum BpGeneration {
     Diff { before: Option<Generation>, after: Option<Generation> },
 }
 
+impl From<Generation> for BpGeneration {
+    fn from(value: Generation) -> Self {
+        BpGeneration::Value(value)
+    }
+}
+
 impl BpGeneration {
     // Used when there isn't a corresponding generation
     pub fn unknown() -> Self {
@@ -122,6 +128,7 @@ impl fmt::Display for BpGeneration {
     }
 }
 
+#[derive(Debug)]
 pub enum BpTableColumn {
     Value(String),
     Diff { before: String, after: String },
@@ -162,6 +169,7 @@ impl BpTableColumn {
 }
 
 /// A row in a [`BpTable`]
+#[derive(Debug)]
 pub struct BpTableRow {
     state: BpDiffState,
     columns: Vec<BpTableColumn>,
@@ -194,6 +202,7 @@ pub trait BpTableData {
 }
 
 /// A table specific to a sled resource, such as a zone or disk.
+#[derive(Debug)]
 pub struct BpTable {
     table_name: &'static str,
     column_names: &'static [&'static str],

--- a/nexus/types/src/deployment/diff_visitors/visit_blueprint.rs
+++ b/nexus/types/src/deployment/diff_visitors/visit_blueprint.rs
@@ -1,0 +1,506 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at https://mozilla.org/MPL/2.0/.
+
+//! A visitor for a `Blueprint`
+
+use super::{
+    visit_blueprint_datasets_config::VisitBlueprintDatasetsConfig,
+    visit_blueprint_physical_disks_config::VisitBlueprintPhysicalDisksConfig,
+    visit_blueprint_zones_config::VisitBlueprintZonesConfig, BpVisitorContext,
+    BpVisitorError, Change,
+};
+use crate::{
+    deployment::{
+        Blueprint, BlueprintDatasetsConfig, BlueprintPhysicalDisksConfig,
+        BlueprintZonesConfig, ClickhouseClusterConfig,
+        CockroachDbPreserveDowngrade, SledUuid,
+    },
+    external_api::views::SledState,
+};
+use diffus::edit::{map, Edit};
+use omicron_common::api::external::Generation;
+use omicron_uuid_kinds::BlueprintUuid;
+use std::collections::{BTreeMap, BTreeSet};
+
+/// State and Resources for an inserted sled
+#[derive(Debug, Clone, Copy)]
+pub struct SledInsert<'e> {
+    pub sled_state: SledState,
+    pub zones: Option<&'e BlueprintZonesConfig>,
+    pub disks: Option<&'e BlueprintPhysicalDisksConfig>,
+    pub datasets: Option<&'e BlueprintDatasetsConfig>,
+}
+
+impl<'e> SledInsert<'e> {
+    pub fn new(sled_state: SledState) -> SledInsert<'e> {
+        SledInsert { sled_state, zones: None, disks: None, datasets: None }
+    }
+}
+
+/// State and Resources for a removed sled
+#[derive(Debug, Clone, Copy)]
+pub struct SledRemove<'e> {
+    pub sled_state: SledState,
+    pub zones: Option<&'e BlueprintZonesConfig>,
+    pub disks: Option<&'e BlueprintPhysicalDisksConfig>,
+    pub datasets: Option<&'e BlueprintDatasetsConfig>,
+}
+
+impl<'e> SledRemove<'e> {
+    pub fn new(sled_state: SledState) -> SledRemove<'e> {
+        SledRemove { sled_state, zones: None, disks: None, datasets: None }
+    }
+}
+
+/// Allow default implementations for types.
+impl<'e> VisitBlueprintDatasetsConfig<'e> for () {}
+impl<'e> VisitBlueprintPhysicalDisksConfig<'e> for () {}
+impl<'e> VisitBlueprintZonesConfig<'e> for () {}
+
+/// A trait to visit a [`Blueprint`]
+pub trait VisitBlueprint<'e> {
+    fn zones_visitor(
+        &mut self,
+    ) -> Option<&mut impl VisitBlueprintZonesConfig<'e>> {
+        Option::<&mut ()>::None
+    }
+    fn disks_visitor(
+        &mut self,
+    ) -> Option<&mut impl VisitBlueprintPhysicalDisksConfig<'e>> {
+        Option::<&mut ()>::None
+    }
+    fn datasets_visitor(
+        &mut self,
+    ) -> Option<&mut impl VisitBlueprintDatasetsConfig<'e>> {
+        Option::<&mut ()>::None
+    }
+
+    fn visit_blueprint(
+        &mut self,
+        ctx: &mut BpVisitorContext,
+        node: Edit<'e, Blueprint>,
+    ) {
+        visit_blueprint(self, ctx, node);
+    }
+
+    fn visit_sled_inserts(
+        &mut self,
+        ctx: &mut BpVisitorContext,
+        node: BTreeMap<SledUuid, SledInsert<'e>>,
+    ) {
+        visit_sled_inserts(self, ctx, node);
+    }
+
+    fn visit_sled_removes(
+        &mut self,
+        ctx: &mut BpVisitorContext,
+        node: BTreeMap<SledUuid, SledRemove<'e>>,
+    ) {
+        visit_sled_removes(self, ctx, node);
+    }
+
+    /// A sled has been inserted
+    fn visit_sled_insert(
+        &mut self,
+        _ctx: &mut BpVisitorContext,
+        _val: SledInsert<'e>,
+    ) {
+        // Leaf node
+    }
+
+    /// A sled has been removed
+    fn visit_sled_remove(
+        &mut self,
+        _ctx: &mut BpVisitorContext,
+        _val: SledRemove<'e>,
+    ) {
+        // Leaf node
+    }
+
+    // A sled's state has been changed
+    fn visit_sled_state_change(
+        &mut self,
+        _ctx: &mut BpVisitorContext,
+        _change: Change<'e, SledState>,
+    ) {
+        // Leaf node
+    }
+
+    fn visit_parent_blueprint_id_change(
+        &mut self,
+        _ctx: &mut BpVisitorContext,
+        _change: Change<'e, Option<BlueprintUuid>>,
+    ) {
+        // Leaf node
+    }
+
+    fn visit_internal_dns_version_change(
+        &mut self,
+        _ctx: &mut BpVisitorContext,
+        _change: Change<'e, Generation>,
+    ) {
+        // Leaf node
+    }
+
+    fn visit_external_dns_version_change(
+        &mut self,
+        _ctx: &mut BpVisitorContext,
+        _change: Change<'e, Generation>,
+    ) {
+        // Leaf node
+    }
+
+    fn visit_cockroachdb_fingerprint_change(
+        &mut self,
+        _ctx: &mut BpVisitorContext,
+        _change: Change<'e, String>,
+    ) {
+        // Leaf node
+    }
+
+    fn visit_cockroachdb_setting_preserve_downgrade_change(
+        &mut self,
+        _ctx: &mut BpVisitorContext,
+        _change: Change<'e, CockroachDbPreserveDowngrade>,
+    ) {
+        // Leaf node
+    }
+
+    fn visit_clickhouse_cluster_config_change(
+        &mut self,
+        _ctx: &mut BpVisitorContext,
+        _change: Change<'e, Option<ClickhouseClusterConfig>>,
+    ) {
+        // Leaf node (for now)
+        //
+        // TODO: This should call a free function that uses a visitor for
+        // `ClickhouseClusterConfig`. First we need to implmement that visitor
+        // though.
+    }
+
+    fn visit_creator_change(
+        &mut self,
+        _ctx: &mut BpVisitorContext,
+        _change: Change<'e, String>,
+    ) {
+        // Leaf node
+    }
+
+    fn visit_comment_change(
+        &mut self,
+        _ctx: &mut BpVisitorContext,
+        _change: Change<'e, String>,
+    ) {
+        // Leaf node
+    }
+}
+
+pub fn visit_blueprint<'e, V>(
+    v: &mut V,
+    ctx: &mut BpVisitorContext,
+    node: Edit<'e, Blueprint>,
+) where
+    V: VisitBlueprint<'e> + ?Sized,
+{
+    let Edit::Change { before, after, diff } = node else {
+        return;
+    };
+
+    // Due to the fact that we have 4 different maps keyed by sled_id, we can
+    // only determine additions and removals easily by using the `before` and
+    // `after` blueprints explicitly. This will be unnecessary once these maps
+    // are collapsed.
+    //
+    // See https://github.com/oxidecomputer/omicron/issues/7078
+    let before_sleds: BTreeSet<_> = before
+        .sled_state
+        .keys()
+        .chain(before.blueprint_zones.keys())
+        .chain(before.blueprint_disks.keys())
+        .chain(before.blueprint_datasets.keys())
+        .collect();
+    let after_sleds: BTreeSet<_> = after
+        .sled_state
+        .keys()
+        .chain(after.blueprint_zones.keys())
+        .chain(after.blueprint_disks.keys())
+        .chain(after.blueprint_datasets.keys())
+        .collect();
+
+    // All sleds that have state, zones, disks or datasets in `before_*`, but not
+    // `after_*` have been removed.
+    let sled_ids_removed: BTreeSet<_> = before_sleds
+        .difference(&after_sleds)
+        .map(|&sled_id| *sled_id)
+        .collect();
+
+    let mut sled_inserts = BTreeMap::new();
+    let mut sled_removes = BTreeMap::new();
+
+    // Build up the set of all edits for a given sled
+    // This is going to be much easier once maps are collapsed!!!
+    if let Edit::Change { diff, .. } = &diff.sled_state {
+        for (&sled_id, edit) in diff {
+            ctx.sled_id = Some(*sled_id);
+            match edit {
+                map::Edit::Insert(&sled_state) => {
+                    sled_inserts.insert(*sled_id, SledInsert::new(sled_state));
+                }
+                map::Edit::Remove(&sled_state) => {
+                    // Work around a quirk of sled decommissioning. If a sled
+                    // has a before state of `decommissioned`, it may or may not
+                    // be present in `after` (presence will depend on whether
+                    // or not the sled was present in the `PlanningInput`).
+                    // However, we may still have entries in `zones`, `disks`,
+                    // or `datasets`  that haven't been fully cleaned up yet.
+                    if sled_ids_removed.contains(sled_id) {
+                        sled_removes
+                            .insert(*sled_id, SledRemove::new(sled_state));
+                    }
+                }
+                map::Edit::Change { before, after, .. } => {
+                    v.visit_sled_state_change(ctx, Change::new(before, after));
+                }
+                map::Edit::Copy(_) => {}
+            }
+        }
+        ctx.sled_id = None;
+    }
+    if let Edit::Change { diff, .. } = &diff.blueprint_zones {
+        for (&sled_id, edit) in diff {
+            ctx.sled_id = Some(*sled_id);
+            match edit {
+                map::Edit::Insert(zones) => {
+                    sled_inserts
+                        .entry(*sled_id)
+                        .and_modify(|e| e.zones = Some(zones))
+                        .or_insert_with(|| {
+                            // This is a *bug*. We don't have a valid `sled_state`
+                            // insert. Once we collapse the maps this will no longer
+                            // be an issue, but for now we insert what the sled state
+                            // should be for a newly inserted sled.
+                            ctx.errors.push(
+                                BpVisitorError::MissingSledStateOnZonesInsert {
+                                    sled_id: *sled_id,
+                                },
+                            );
+                            let mut insert = SledInsert::new(SledState::Active);
+                            insert.zones = Some(zones);
+                            insert
+                        });
+                }
+                map::Edit::Remove(zones) => {
+                    if sled_ids_removed.contains(sled_id) {
+                        sled_removes
+                            .entry(*sled_id)
+                            .and_modify(|e| e.zones = Some(*zones))
+                            .or_insert_with(|| {
+                                // This is a a workaround, where in some cases we have removed
+                                // the sled-state from the blueprint before any other sled resources.
+                                //
+                                // We backfill the sled state so we can create a proper
+                                // `SledRemove` entry.
+                                let mut remove =
+                                    SledRemove::new(SledState::Decommissioned);
+                                remove.zones = Some(zones);
+                                remove
+                            });
+                    }
+                }
+                map::Edit::Change { diff, .. } => {
+                    if let Some(v) = v.zones_visitor() {
+                        v.visit_zones_edit(ctx, diff);
+                    }
+                }
+                map::Edit::Copy(_) => {}
+            }
+        }
+        ctx.sled_id = None;
+    }
+    if let Edit::Change { diff, .. } = &diff.blueprint_disks {
+        for (&sled_id, edit) in diff {
+            ctx.sled_id = Some(*sled_id);
+            match edit {
+                map::Edit::Insert(disks) => {
+                    sled_inserts
+                        .entry(*sled_id)
+                        .and_modify(|e| e.disks = Some(disks))
+                        .or_insert_with(|| {
+                            // This is a *bug*. We don't have a valid `sled_state`
+                            // insert. Once we collapse the maps this will no longer
+                            // be an issue, but for now we insert what the sled state
+                            // should be for a newly inserted sled.
+                            ctx.errors.push(
+                                BpVisitorError::MissingSledStateOnDisksInsert {
+                                    sled_id: *sled_id,
+                                },
+                            );
+                            let mut insert = SledInsert::new(SledState::Active);
+                            insert.disks = Some(disks);
+                            insert
+                        });
+                }
+                map::Edit::Remove(disks) => {
+                    if !sled_ids_removed.contains(sled_id) {
+                        // Backwards compatibility. We shouldn't be removing
+                        // datasets until we remove the sled. They should just be
+                        // marked expunged.
+                        if let Some(v) = v.disks_visitor() {
+                            for disk in &disks.disks {
+                                v.visit_disks_remove(ctx, disk);
+                            }
+                        }
+                    } else {
+                        sled_removes
+                            .entry(*sled_id)
+                            .and_modify(|e| e.disks = Some(*disks))
+                            .or_insert_with(|| {
+                                // This is a a workaround, where in some cases we have removed
+                                // the sled-state from the blueprint before any other sled resources.
+                                //
+                                // We backfill the sled state so we can create a proper
+                                // `SledRemove` entry.
+                                let mut remove =
+                                    SledRemove::new(SledState::Decommissioned);
+                                remove.disks = Some(disks);
+                                remove
+                            });
+                    }
+                }
+                map::Edit::Change { diff, .. } => {
+                    if let Some(v) = v.disks_visitor() {
+                        v.visit_disks_edit(ctx, diff);
+                    }
+                }
+                map::Edit::Copy(_) => {}
+            }
+        }
+        ctx.sled_id = None;
+    }
+    if let Edit::Change { diff, .. } = &diff.blueprint_datasets {
+        for (&sled_id, edit) in diff {
+            ctx.sled_id = Some(*sled_id);
+            match edit {
+                map::Edit::Insert(datasets) => {
+                    sled_inserts
+                        .entry(*sled_id)
+                        .and_modify(|e| e.datasets = Some(datasets))
+                        .or_insert_with(|| {
+                            // This is a *bug*. We don't have a valid `sled_state`
+                            // insert. Once we collapse the maps this will no longer
+                            // be an issue, but for now we insert what the sled state
+                            // should be for a newly inserted sled.
+                            ctx.errors.push(
+                                BpVisitorError::MissingSledStateOnDatasetsInsert {
+                                    sled_id: *sled_id,
+                                },
+                            );
+                            let mut insert = SledInsert::new(SledState::Active);
+                            insert.datasets = Some(datasets);
+                            insert
+                        });
+                }
+                map::Edit::Remove(datasets) => {
+                    // Backwards compatibility: We shouldn't be removing
+                    // datasets until we remove the sled. They should just be
+                    // marked expunged.
+                    if !sled_ids_removed.contains(sled_id) {
+                        if let Some(v) = v.datasets_visitor() {
+                            for dataset in &datasets.datasets {
+                                v.visit_datasets_remove(ctx, dataset);
+                            }
+                        }
+                    } else {
+                        sled_removes
+                            .entry(*sled_id)
+                            .and_modify(|e| e.datasets = Some(*datasets))
+                            .or_insert_with(|| {
+                                // This is a a workaround, where in some cases we have removed
+                                // the sled-state from the blueprint before any other sled resources.
+                                //
+                                // We backfill the sled state so we can create a proper
+                                // `SledRemove` entry.
+                                let mut remove =
+                                    SledRemove::new(SledState::Decommissioned);
+                                remove.datasets = Some(datasets);
+                                remove
+                            });
+                    }
+                }
+                map::Edit::Change { diff, .. } => {
+                    if let Some(v) = v.datasets_visitor() {
+                        v.visit_datasets_edit(ctx, diff);
+                    }
+                }
+                map::Edit::Copy(_) => {}
+            }
+        }
+        ctx.sled_id = None;
+    }
+
+    v.visit_sled_inserts(ctx, sled_inserts);
+    v.visit_sled_removes(ctx, sled_removes);
+
+    if let Edit::Change { before, after, .. } = diff.parent_blueprint_id {
+        v.visit_parent_blueprint_id_change(ctx, Change::new(before, after));
+    }
+    if let Edit::Change { before, after, .. } = diff.internal_dns_version {
+        v.visit_internal_dns_version_change(ctx, Change::new(before, after));
+    }
+    if let Edit::Change { before, after, .. } = diff.external_dns_version {
+        v.visit_external_dns_version_change(ctx, Change::new(before, after));
+    }
+    if let Edit::Change { before, after, .. } = diff.cockroachdb_fingerprint {
+        v.visit_cockroachdb_fingerprint_change(ctx, Change::new(before, after));
+    }
+    if let Edit::Change { before, after, .. } =
+        diff.cockroachdb_setting_preserve_downgrade
+    {
+        v.visit_cockroachdb_setting_preserve_downgrade_change(
+            ctx,
+            Change::new(before, after),
+        );
+    }
+    if let Edit::Change { before, after, .. } = diff.clickhouse_cluster_config {
+        // TODO: We need a separate visitor for this config
+        v.visit_clickhouse_cluster_config_change(
+            ctx,
+            Change::new(before, after),
+        );
+    }
+    if let Edit::Change { before, after, .. } = diff.creator {
+        v.visit_creator_change(ctx, Change::new(before, after));
+    }
+    if let Edit::Change { before, after, .. } = diff.comment {
+        v.visit_comment_change(ctx, Change::new(before, after));
+    }
+}
+
+pub fn visit_sled_inserts<'e, V>(
+    v: &mut V,
+    ctx: &mut BpVisitorContext,
+    node: BTreeMap<SledUuid, SledInsert<'e>>,
+) where
+    V: VisitBlueprint<'e> + ?Sized,
+{
+    for (sled_id, insert) in &node {
+        ctx.sled_id = Some(*sled_id);
+        v.visit_sled_insert(ctx, *insert);
+    }
+    ctx.sled_id = None;
+}
+
+pub fn visit_sled_removes<'e, V>(
+    v: &mut V,
+    ctx: &mut BpVisitorContext,
+    node: BTreeMap<SledUuid, SledRemove<'e>>,
+) where
+    V: VisitBlueprint<'e> + ?Sized,
+{
+    for (sled_id, remove) in &node {
+        ctx.sled_id = Some(*sled_id);
+        v.visit_sled_remove(ctx, *remove);
+    }
+    ctx.sled_id = None;
+}


### PR DESCRIPTION
This commit introduces an automated blueprint diff mechanism based on [diffus](https://github.com/oxidecomputer/diffus) along with the visitor pattern for traversing heterogeneous diff trees. It builds on several prior commits that introduced diffus support and added visitors for types:

https://github.com/oxidecomputer/omicron/pull/7261 https://github.com/oxidecomputer/omicron/pull/7336 https://github.com/oxidecomputer/omicron/pull/7362 https://github.com/oxidecomputer/omicron/pull/7366

The new `BlueprintDiffer` implements the relevant visitors and accumulates change state from visitor method callbacks. The accumulated state  is the `BlueprintDiff` which replaces the old `BlueprintDiff`. The new structure intentionally groups resources by sleds, as the 4 primary maps in a `Blueprint` (`sled_state`, `blueprint_zones`, `blueprint_disks`, `blueprint_datasets`) are going to be collapsed into a single map. This allows us to modify the visitors to traverse the new blueprint diffs in one place and not have to worry about modifying the `BlueprintDiff` itself or any consumers. More details about why we are collapsing these maps can be found in #7078.

We primarily use `BlueprintDiff`s for testing and omdb output, and therefore the printed representation is absolutely critical for us. This commit reuses the types and formatting contained in `nexus/ types/src/deployment/ blueprint_display.rs` and provides a new type, `BpDiffPrintable` that can be created from a `BlueprintDiff`. `BpDiffPrintable` contains our formatted tables ready to be used by `BlueprintDiffDisplay` along with the orignal blueprints to render the diff. It's possible that we can collapse `BlueprintDiffDisplay` and `BpDiffPrintable` into one type and simplify a bit. I just haven't done that yet.

The printable output of the diffs has maintained backwards compatibility in all cases except for errors and warnings. Those have been specifically adapted to work with our visitors and be accumulated while walking the diffus diffs. This only resulted in the change to one test output file, which should leave us confident in the correctness of this new implementation. An optional `show_unchanged` flag was added at key points in the code and in the future we plan to change the default to only show actual changes. We didn't do that here so that we could ensure the output of the new implementation matches the existing code. We also plan to add more columns, such as `disposition` for datasets.

Usage going forward
--------------------

This is a significant change to our blueprint diff code, and in some cases it may take slightly more boilerplate in order to diff newly added fields or structs, than in the older code. However, there are a few things this new style has going for it. Figuring out the differences between blueprints is now done automatically and completely. There is no need to compute these differences, which is both error prone, and complicated. See the old [BpDiffZones](https://github.com/oxidecomputer/omicron/blob/888f90db8b36ccdf667d96423ae7805824c48aa9/nexus/types/src/deployment/blueprint_diff.rs#L195-L340) code for what finding the differences for just zones in a blueprint looked like.

With automated diffs output from diffus, we now need to write code to expose the necessary change information to consumers. We want to do this in a unified and rigorous manner, and one that composes nicely. We chose a `visitor` pattern for this. For each somewhat complex type (use your judgement), we provide a visitor trait that walks the heterogeneous diff tree and calls trait methods when a change is found. User code implements only the visitor methods that it cares about and then can accumulate its own internal state based on which callbacks fire. We provide a top-level `VisitBlueprint` trait to detect all changes in a blueprint and implement it in `BlueprintDiffer` to construct a `BlueprintDiff` in a format we can use.

There are a few important things to note about our visitors. While diffus provides a complete tree of all changes as well as fields and variants that have not changed, the visitors as currently implemented only expose changes. These changes are unified for simplicity into a `Change` type. We also don't currently expose all changes. For most fields that we don't expect to ever change, there is not a change callback. Mostly this is because the visitors were written before I had to use them :). It turns out it may actually be useful to expose these fields so that we can report errors or warnings in our diffs if they do change unexpectedly. You can see an example of error tracking in the `BlueprintDiffer::visit_zone_type_change` method and its test output in `nexus/reconfigurator/planning/tests/output/planner_nonprovisionable_2_2a.txt`.

It is tedious to write visitor traits to walk a diffus diff and then implement these traits to accumulate the state we want. It can reasonably be asked why we wouldn't just walk the tree and generate the state we want directly without the visitors. Indeed, this is quite reasonable for small one off tasks. But we are building a foundation that will grow over time in terms of type structure and number of developers working on the system. For such a long term project, it's usefulf to decouple the tree walking from the state accumulation. For one thing, it makes each bit easier to read and write on its own. For another, it allows us to build different implementations of the visitors for different use cases, such as testing. Remember, users only have to implement the methods they care about. Therefore if they only want to see if a zone changed, they  don't have to worry about parsing diffus types, but can just implement a callback. An example of this is the `TestVisitor` in `live-tests/tests/test_nexus_add_remove.rs`.

I anticipate we will find ways to make implementing and using diff visitors more ergonomic over time while maintaining the compositional rigor that the separation of concerns provides in this model.

Testing
--------

I mainly have run planning tests locally to ensure diffs work as expected. I still need to run the live tests and play with omdb.