### PR TITLE
Update Propolis and Crucible

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -693,7 +693,7 @@ dependencies = [
 [[package]]
 name = "bhyve_api"
 version = "0.0.0"
-source = "git+https://github.com/oxidecomputer/propolis?rev=f30ff7a830da26874a00307a3c6d6e1035eec818#f30ff7a830da26874a00307a3c6d6e1035eec818"
+source = "git+https://github.com/oxidecomputer/propolis?rev=e9db2377f4300a7539ebb3e4237e06d46ec1e6cc#e9db2377f4300a7539ebb3e4237e06d46ec1e6cc"
 dependencies = [
  "bhyve_api_sys",
  "libc",
@@ -703,7 +703,7 @@ dependencies = [
 [[package]]
 name = "bhyve_api_sys"
 version = "0.0.0"
-source = "git+https://github.com/oxidecomputer/propolis?rev=f30ff7a830da26874a00307a3c6d6e1035eec818#f30ff7a830da26874a00307a3c6d6e1035eec818"
+source = "git+https://github.com/oxidecomputer/propolis?rev=e9db2377f4300a7539ebb3e4237e06d46ec1e6cc#e9db2377f4300a7539ebb3e4237e06d46ec1e6cc"
 dependencies = [
  "libc",
  "strum",
@@ -1866,7 +1866,7 @@ dependencies = [
 [[package]]
 name = "crucible-agent-client"
 version = "0.0.1"
-source = "git+https://github.com/oxidecomputer/crucible?rev=c9d31d2f84ff5b59dfb1cf5358d8af657ab9b5e9#c9d31d2f84ff5b59dfb1cf5358d8af657ab9b5e9"
+source = "git+https://github.com/oxidecomputer/crucible?rev=ace54d9cb5957fda79422e8237d7c54c33af928e#ace54d9cb5957fda79422e8237d7c54c33af928e"
 dependencies = [
  "anyhow",
  "chrono",
@@ -1882,7 +1882,7 @@ dependencies = [
 [[package]]
 name = "crucible-client-types"
 version = "0.1.0"
-source = "git+https://github.com/oxidecomputer/crucible?rev=c9d31d2f84ff5b59dfb1cf5358d8af657ab9b5e9#c9d31d2f84ff5b59dfb1cf5358d8af657ab9b5e9"
+source = "git+https://github.com/oxidecomputer/crucible?rev=ace54d9cb5957fda79422e8237d7c54c33af928e#ace54d9cb5957fda79422e8237d7c54c33af928e"
 dependencies = [
  "base64 0.22.1",
  "crucible-workspace-hack",
@@ -1895,7 +1895,7 @@ dependencies = [
 [[package]]
 name = "crucible-common"
 version = "0.0.1"
-source = "git+https://github.com/oxidecomputer/crucible?rev=c9d31d2f84ff5b59dfb1cf5358d8af657ab9b5e9#c9d31d2f84ff5b59dfb1cf5358d8af657ab9b5e9"
+source = "git+https://github.com/oxidecomputer/crucible?rev=ace54d9cb5957fda79422e8237d7c54c33af928e#ace54d9cb5957fda79422e8237d7c54c33af928e"
 dependencies = [
  "anyhow",
  "atty",
@@ -1925,7 +1925,7 @@ dependencies = [
 [[package]]
 name = "crucible-pantry-client"
 version = "0.0.1"
-source = "git+https://github.com/oxidecomputer/crucible?rev=c9d31d2f84ff5b59dfb1cf5358d8af657ab9b5e9#c9d31d2f84ff5b59dfb1cf5358d8af657ab9b5e9"
+source = "git+https://github.com/oxidecomputer/crucible?rev=ace54d9cb5957fda79422e8237d7c54c33af928e#ace54d9cb5957fda79422e8237d7c54c33af928e"
 dependencies = [
  "anyhow",
  "chrono",
@@ -1942,7 +1942,7 @@ dependencies = [
 [[package]]
 name = "crucible-smf"
 version = "0.0.0"
-source = "git+https://github.com/oxidecomputer/crucible?rev=c9d31d2f84ff5b59dfb1cf5358d8af657ab9b5e9#c9d31d2f84ff5b59dfb1cf5358d8af657ab9b5e9"
+source = "git+https://github.com/oxidecomputer/crucible?rev=ace54d9cb5957fda79422e8237d7c54c33af928e#ace54d9cb5957fda79422e8237d7c54c33af928e"
 dependencies = [
  "crucible-workspace-hack",
  "libc",
@@ -7076,7 +7076,7 @@ dependencies = [
  "pq-sys",
  "pretty_assertions",
  "progenitor-client 0.9.1",
- "propolis-client 0.1.0 (git+https://github.com/oxidecomputer/propolis?rev=f30ff7a830da26874a00307a3c6d6e1035eec818)",
+ "propolis-client 0.1.0 (git+https://github.com/oxidecomputer/propolis?rev=e9db2377f4300a7539ebb3e4237e06d46ec1e6cc)",
  "qorb",
  "rand",
  "range-requests",
@@ -7347,7 +7347,7 @@ dependencies = [
  "oximeter-producer",
  "oxnet",
  "pretty_assertions",
- "propolis-client 0.1.0 (git+https://github.com/oxidecomputer/propolis?rev=f30ff7a830da26874a00307a3c6d6e1035eec818)",
+ "propolis-client 0.1.0 (git+https://github.com/oxidecomputer/propolis?rev=e9db2377f4300a7539ebb3e4237e06d46ec1e6cc)",
  "propolis-mock-server",
  "propolis_api_types",
  "rand",
@@ -9131,7 +9131,7 @@ dependencies = [
 [[package]]
 name = "propolis-client"
 version = "0.1.0"
-source = "git+https://github.com/oxidecomputer/propolis?rev=f30ff7a830da26874a00307a3c6d6e1035eec818#f30ff7a830da26874a00307a3c6d6e1035eec818"
+source = "git+https://github.com/oxidecomputer/propolis?rev=e9db2377f4300a7539ebb3e4237e06d46ec1e6cc#e9db2377f4300a7539ebb3e4237e06d46ec1e6cc"
 dependencies = [
  "async-trait",
  "base64 0.21.7",
@@ -9176,7 +9176,7 @@ dependencies = [
 [[package]]
 name = "propolis-mock-server"
 version = "0.0.0"
-source = "git+https://github.com/oxidecomputer/propolis?rev=f30ff7a830da26874a00307a3c6d6e1035eec818#f30ff7a830da26874a00307a3c6d6e1035eec818"
+source = "git+https://github.com/oxidecomputer/propolis?rev=e9db2377f4300a7539ebb3e4237e06d46ec1e6cc#e9db2377f4300a7539ebb3e4237e06d46ec1e6cc"
 dependencies = [
  "anyhow",
  "atty",
@@ -9218,7 +9218,7 @@ dependencies = [
 [[package]]
 name = "propolis_api_types"
 version = "0.0.0"
-source = "git+https://github.com/oxidecomputer/propolis?rev=f30ff7a830da26874a00307a3c6d6e1035eec818#f30ff7a830da26874a00307a3c6d6e1035eec818"
+source = "git+https://github.com/oxidecomputer/propolis?rev=e9db2377f4300a7539ebb3e4237e06d46ec1e6cc#e9db2377f4300a7539ebb3e4237e06d46ec1e6cc"
 dependencies = [
  "crucible-client-types",
  "propolis_types",
@@ -9232,7 +9232,7 @@ dependencies = [
 [[package]]
 name = "propolis_types"
 version = "0.0.0"
-source = "git+https://github.com/oxidecomputer/propolis?rev=f30ff7a830da26874a00307a3c6d6e1035eec818#f30ff7a830da26874a00307a3c6d6e1035eec818"
+source = "git+https://github.com/oxidecomputer/propolis?rev=e9db2377f4300a7539ebb3e4237e06d46ec1e6cc#e9db2377f4300a7539ebb3e4237e06d46ec1e6cc"
 dependencies = [
  "schemars",
  "serde",
@@ -10859,7 +10859,7 @@ dependencies = [
  "omicron-workspace-hack",
  "oxnet",
  "progenitor 0.9.1",
- "propolis-client 0.1.0 (git+https://github.com/oxidecomputer/propolis?rev=f30ff7a830da26874a00307a3c6d6e1035eec818)",
+ "propolis-client 0.1.0 (git+https://github.com/oxidecomputer/propolis?rev=e9db2377f4300a7539ebb3e4237e06d46ec1e6cc)",
  "regress 0.9.1",
  "reqwest",
  "schemars",
@@ -10885,7 +10885,7 @@ dependencies = [
  "omicron-uuid-kinds",
  "omicron-workspace-hack",
  "oxnet",
- "propolis-client 0.1.0 (git+https://github.com/oxidecomputer/propolis?rev=f30ff7a830da26874a00307a3c6d6e1035eec818)",
+ "propolis-client 0.1.0 (git+https://github.com/oxidecomputer/propolis?rev=e9db2377f4300a7539ebb3e4237e06d46ec1e6cc)",
  "rcgen",
  "schemars",
  "serde",
@@ -12489,13 +12489,11 @@ dependencies = [
 
 [[package]]
 name = "twox-hash"
-version = "1.6.3"
+version = "2.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "97fee6b57c6a41524a810daee9286c02d7752c4253064d0b05472833a438f675"
+checksum = "e7b17f197b3050ba473acf9181f7b1d3b66d1cf7356c6cc57886662276e65908"
 dependencies = [
- "cfg-if",
  "rand",
- "static_assertions",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -358,10 +358,10 @@ crossterm = { version = "0.28.1", features = ["event-stream"] }
 # NOTE: if you change the pinned revision of the `crucible` dependencies, you
 # must also update the references in package-manifest.toml to match the new
 # revision.
-crucible-agent-client = { git = "https://github.com/oxidecomputer/crucible", rev = "c9d31d2f84ff5b59dfb1cf5358d8af657ab9b5e9" }
-crucible-pantry-client = { git = "https://github.com/oxidecomputer/crucible", rev = "c9d31d2f84ff5b59dfb1cf5358d8af657ab9b5e9" }
-crucible-smf = { git = "https://github.com/oxidecomputer/crucible", rev = "c9d31d2f84ff5b59dfb1cf5358d8af657ab9b5e9" }
-crucible-common = { git = "https://github.com/oxidecomputer/crucible", rev = "c9d31d2f84ff5b59dfb1cf5358d8af657ab9b5e9" }
+crucible-agent-client = { git = "https://github.com/oxidecomputer/crucible", rev = "ace54d9cb5957fda79422e8237d7c54c33af928e" }
+crucible-pantry-client = { git = "https://github.com/oxidecomputer/crucible", rev = "ace54d9cb5957fda79422e8237d7c54c33af928e" }
+crucible-smf = { git = "https://github.com/oxidecomputer/crucible", rev = "ace54d9cb5957fda79422e8237d7c54c33af928e" }
+crucible-common = { git = "https://github.com/oxidecomputer/crucible", rev = "ace54d9cb5957fda79422e8237d7c54c33af928e" }
 # NOTE: See above!
 csv = "1.3.0"
 curve25519-dalek = "4"
@@ -559,10 +559,10 @@ progenitor-client = "0.9.1"
 # NOTE: if you change the pinned revision of the `bhyve_api` and propolis
 # dependencies, you must also update the references in package-manifest.toml to
 # match the new revision.
-bhyve_api = { git = "https://github.com/oxidecomputer/propolis", rev = "f30ff7a830da26874a00307a3c6d6e1035eec818" }
-propolis_api_types = { git = "https://github.com/oxidecomputer/propolis", rev = "f30ff7a830da26874a00307a3c6d6e1035eec818" }
-propolis-client = { git = "https://github.com/oxidecomputer/propolis", rev = "f30ff7a830da26874a00307a3c6d6e1035eec818" }
-propolis-mock-server = { git = "https://github.com/oxidecomputer/propolis", rev = "f30ff7a830da26874a00307a3c6d6e1035eec818" }
+bhyve_api = { git = "https://github.com/oxidecomputer/propolis", rev = "e9db2377f4300a7539ebb3e4237e06d46ec1e6cc" }
+propolis_api_types = { git = "https://github.com/oxidecomputer/propolis", rev = "e9db2377f4300a7539ebb3e4237e06d46ec1e6cc" }
+propolis-client = { git = "https://github.com/oxidecomputer/propolis", rev = "e9db2377f4300a7539ebb3e4237e06d46ec1e6cc" }
+propolis-mock-server = { git = "https://github.com/oxidecomputer/propolis", rev = "e9db2377f4300a7539ebb3e4237e06d46ec1e6cc" }
 # NOTE: see above!
 proptest = "1.5.0"
 qorb = "0.2.1"

--- a/dev-tools/ls-apis/tests/api_dependencies.out
+++ b/dev-tools/ls-apis/tests/api_dependencies.out
@@ -59,6 +59,7 @@ Maghemite MG Admin (client: mg-admin-client)
     consumed by: omicron-sled-agent (omicron/sled-agent) via 1 path
 
 Nexus Internal API (client: nexus-client)
+    consumed by: crucible-pantry (crucible/pantry) via 1 path
     consumed by: dpd (dendrite/dpd) via 1 path
     consumed by: omicron-sled-agent (omicron/sled-agent) via 1 path
     consumed by: oximeter-collector (omicron/oximeter/collector) via 1 path

--- a/package-manifest.toml
+++ b/package-manifest.toml
@@ -581,10 +581,10 @@ only_for_targets.image = "standard"
 # 3. Use source.type = "manual" instead of "prebuilt"
 source.type = "prebuilt"
 source.repo = "crucible"
-source.commit = "c9d31d2f84ff5b59dfb1cf5358d8af657ab9b5e9"
+source.commit = "ace54d9cb5957fda79422e8237d7c54c33af928e"
 # The SHA256 digest is automatically posted to:
 # https://buildomat.eng.oxide.computer/public/file/oxidecomputer/crucible/image/<commit>/crucible.sha256.txt
-source.sha256 = "089e872f79839ada217891631ff9db64ad59547e5d189cc7903646b495a3076f"
+source.sha256 = "6f25aa712542b8ba13cca1b969eeb2935b37e3337f022396b344a6cc83ff0d39"
 output.type = "zone"
 output.intermediate_only = true
 
@@ -593,10 +593,10 @@ service_name = "crucible_pantry_prebuilt"
 only_for_targets.image = "standard"
 source.type = "prebuilt"
 source.repo = "crucible"
-source.commit = "c9d31d2f84ff5b59dfb1cf5358d8af657ab9b5e9"
+source.commit = "ace54d9cb5957fda79422e8237d7c54c33af928e"
 # The SHA256 digest is automatically posted to:
 # https://buildomat.eng.oxide.computer/public/file/oxidecomputer/crucible/image/<commit>/crucible-pantry.sha256.txt
-source.sha256 = "edbbe0b8543bbd10ece8551dc9246b21c954cf9cf059237994ec324d29665042"
+source.sha256 = "92a40c04247679a32858a07578669690ab961a1d7e7bda92de5571e576a230fe"
 output.type = "zone"
 output.intermediate_only = true
 
@@ -610,10 +610,10 @@ service_name = "crucible_dtrace"
 only_for_targets.image = "standard"
 source.type = "prebuilt"
 source.repo = "crucible"
-source.commit = "c9d31d2f84ff5b59dfb1cf5358d8af657ab9b5e9"
+source.commit = "ace54d9cb5957fda79422e8237d7c54c33af928e"
 # The SHA256 digest is automatically posted to:
 # https://buildomat.eng.oxide.computer/public/file/oxidecomputer/crucible/image/<commit>/crucible-dtrace.sha256.txt
-source.sha256 = "264208edfb1925503dd86a05c2dfdf4919939d922cf96945f8dcdc13236ba9de"
+source.sha256 = "895544df19ef1df7ef1750e978c20e70cdba1bc1dc93db392798284b4ce9b55a"
 output.type = "tarball"
 
 # Refer to
@@ -624,10 +624,10 @@ service_name = "propolis-server"
 only_for_targets.image = "standard"
 source.type = "prebuilt"
 source.repo = "propolis"
-source.commit = "f30ff7a830da26874a00307a3c6d6e1035eec818"
+source.commit = "e9db2377f4300a7539ebb3e4237e06d46ec1e6cc"
 # The SHA256 digest is automatically posted to:
 # https://buildomat.eng.oxide.computer/public/file/oxidecomputer/propolis/image/<commit>/propolis-server.sha256.txt
-source.sha256 = "9fe49a902d04158bc4f98954eae93d66624f228aa4d7457ab8fbbd4937141953"
+source.sha256 = "819d4ff2a165197be8384f693f5a09d7f12a0718647a0f3235910bb980ce0d52"
 output.type = "zone"
 
 [package.mg-ddm-gz]


### PR DESCRIPTION
Crucible changes are:
Allow read only activation with less than three downstairs (#1608) Tweaks to automatic flush (#1613)
Update Rust crate twox-hash to v2 (#1547)
Remove `LastFlushAck` (#1603)
Correctly print 'connecting' state (#1612)
Make live-repair part of invariants checks (#1610) Simplify mend region selection (#1606)
Generic read test for crutest (#1609)
Always remove skipped jobs from dependencies (#1604) Add libsqlite3-dev install step to Github Actions CI (#1607) Move Nexus notification to standalone task (#1584) DTrace cleanup. (#1602)
Reset completed work Downstairs on a `Barrier` operation (#1601) Upstairs state machine refactoring (3/3) (#1577)

Propolis changes are:
Wire up initial support for AMD perf counters
build: upgrade tokio to 1.40.0 (#836)
build: explicitly install libsqlite3-dev in CI (#834) add JSON output format to cpuid-gen (#832)