### PR TITLE
Add timestamps to trace-db-queries.d

### DIFF
--- a/tools/dtrace/nexus/trace-db-queries.d
+++ b/tools/dtrace/nexus/trace-db-queries.d
@@ -26,7 +26,9 @@ diesel_db$target:::query-done
 {
     this->latency = (timestamp - ts[this->conn_id]) / 1000;
     printf(
-        "conn_id: %s, latency: %lu us, query: '%s'\n",
+        "%Y.%06d - conn_id: %s, latency: %lu us, query: '%s'\n",
+        walltimestamp,
+        (walltimestamp % 1000000000) / 1000,
         this->conn_id,
         this->latency,
         query[this->conn_id]


### PR DESCRIPTION
It can be difficult to correlate the raw queries captured by the `trace-db-queries.d` script with external events without knowing the time the query completed.

Add microsecond-precision timestamps at the start of each event. To keep the script simple, do this by appending fractional seconds with microsecond precision to standard `%Y` format.

```
2025 Jan 27 22:44:28.658927 - conn_id: a396755b-c6dc-4c76-82ed-50bd65c85fd4, latency: 1762 us, query: 'SELECT "role_assignment"."identity_type", "role_assignment"."identity_id", "role_assignment"."resource_type", "role_assignment"."resource_id", "role_assignment"."role_name" FROM "role_assignment" WHERE (((("role_assignment"."identity_type" = $1) AND ("role_assignment"."identity_id" = $2)) AND ("role_assignment"."resource_type" = $3)) AND ("role_assignment"."resource_id" = $4)) -- binds: [UserBuiltin, 001de000-05e4-4000-8000-000000000002, "fleet", 001de000-1334-4000-8000-000000000000]'
2025 Jan 27 22:44:28.661927 - conn_id: 9de93b53-dd62-4cfe-984f-eff4a0acb64e, latency: 551 us, query: 'set disallow_full_table_scans = on; set large_full_scan_rows = 0;'
```