### PR TITLE
[sled-agent] wait_for_service should actually log the svc fmri

### DIFF
--- a/illumos-utils/src/svc.rs
+++ b/illumos-utils/src/svc.rs
@@ -41,7 +41,8 @@ mod inner {
         let log_notification_failure = |error, delay| {
             warn!(
                 log,
-                "wait for service {:?} failed: {}. retry in {:?}",
+                "wait for service {} in zone {:?} failed: {}. retry in {:?}",
+                fmri,
                 zone,
                 error,
                 delay


### PR DESCRIPTION
Currently sled-agents logs will show:
```
04:30:10.998Z WARN SledAgent (ServiceManager): wait for service Some("oxz_switch") failed: Property not found. retry in 961.878945ms
    file = illumos-utils/src/svc.rs:42
    zone = oxz_switch
 ```

We should actually log which fmri we are waiting for.