### PR TITLE
Update Propolis and Crucible

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -693,7 +693,7 @@ dependencies = [
 [[package]]
 name = "bhyve_api"
 version = "0.0.0"
-source = "git+https://github.com/oxidecomputer/propolis?rev=e9db2377f4300a7539ebb3e4237e06d46ec1e6cc#e9db2377f4300a7539ebb3e4237e06d46ec1e6cc"
+source = "git+https://github.com/oxidecomputer/propolis?rev=99251f841debbe9aaceb4a407a984190c63dead5#99251f841debbe9aaceb4a407a984190c63dead5"
 dependencies = [
  "bhyve_api_sys",
  "libc",
@@ -703,7 +703,7 @@ dependencies = [
 [[package]]
 name = "bhyve_api_sys"
 version = "0.0.0"
-source = "git+https://github.com/oxidecomputer/propolis?rev=e9db2377f4300a7539ebb3e4237e06d46ec1e6cc#e9db2377f4300a7539ebb3e4237e06d46ec1e6cc"
+source = "git+https://github.com/oxidecomputer/propolis?rev=99251f841debbe9aaceb4a407a984190c63dead5#99251f841debbe9aaceb4a407a984190c63dead5"
 dependencies = [
  "libc",
  "strum",
@@ -1866,7 +1866,7 @@ dependencies = [
 [[package]]
 name = "crucible-agent-client"
 version = "0.0.1"
-source = "git+https://github.com/oxidecomputer/crucible?rev=ace54d9cb5957fda79422e8237d7c54c33af928e#ace54d9cb5957fda79422e8237d7c54c33af928e"
+source = "git+https://github.com/oxidecomputer/crucible?rev=86a2ce1f9f13912a5fe652472de765ec5fc22e76#86a2ce1f9f13912a5fe652472de765ec5fc22e76"
 dependencies = [
  "anyhow",
  "chrono",
@@ -1882,7 +1882,7 @@ dependencies = [
 [[package]]
 name = "crucible-client-types"
 version = "0.1.0"
-source = "git+https://github.com/oxidecomputer/crucible?rev=ace54d9cb5957fda79422e8237d7c54c33af928e#ace54d9cb5957fda79422e8237d7c54c33af928e"
+source = "git+https://github.com/oxidecomputer/crucible?rev=86a2ce1f9f13912a5fe652472de765ec5fc22e76#86a2ce1f9f13912a5fe652472de765ec5fc22e76"
 dependencies = [
  "base64 0.22.1",
  "crucible-workspace-hack",
@@ -1895,7 +1895,7 @@ dependencies = [
 [[package]]
 name = "crucible-common"
 version = "0.0.1"
-source = "git+https://github.com/oxidecomputer/crucible?rev=ace54d9cb5957fda79422e8237d7c54c33af928e#ace54d9cb5957fda79422e8237d7c54c33af928e"
+source = "git+https://github.com/oxidecomputer/crucible?rev=86a2ce1f9f13912a5fe652472de765ec5fc22e76#86a2ce1f9f13912a5fe652472de765ec5fc22e76"
 dependencies = [
  "anyhow",
  "atty",
@@ -1925,7 +1925,7 @@ dependencies = [
 [[package]]
 name = "crucible-pantry-client"
 version = "0.0.1"
-source = "git+https://github.com/oxidecomputer/crucible?rev=ace54d9cb5957fda79422e8237d7c54c33af928e#ace54d9cb5957fda79422e8237d7c54c33af928e"
+source = "git+https://github.com/oxidecomputer/crucible?rev=86a2ce1f9f13912a5fe652472de765ec5fc22e76#86a2ce1f9f13912a5fe652472de765ec5fc22e76"
 dependencies = [
  "anyhow",
  "chrono",
@@ -1942,7 +1942,7 @@ dependencies = [
 [[package]]
 name = "crucible-smf"
 version = "0.0.0"
-source = "git+https://github.com/oxidecomputer/crucible?rev=ace54d9cb5957fda79422e8237d7c54c33af928e#ace54d9cb5957fda79422e8237d7c54c33af928e"
+source = "git+https://github.com/oxidecomputer/crucible?rev=86a2ce1f9f13912a5fe652472de765ec5fc22e76#86a2ce1f9f13912a5fe652472de765ec5fc22e76"
 dependencies = [
  "crucible-workspace-hack",
  "libc",
@@ -7077,7 +7077,7 @@ dependencies = [
  "pq-sys",
  "pretty_assertions",
  "progenitor-client 0.9.1",
- "propolis-client 0.1.0 (git+https://github.com/oxidecomputer/propolis?rev=e9db2377f4300a7539ebb3e4237e06d46ec1e6cc)",
+ "propolis-client 0.1.0 (git+https://github.com/oxidecomputer/propolis?rev=99251f841debbe9aaceb4a407a984190c63dead5)",
  "qorb",
  "rand",
  "range-requests",
@@ -7348,7 +7348,7 @@ dependencies = [
  "oximeter-producer",
  "oxnet",
  "pretty_assertions",
- "propolis-client 0.1.0 (git+https://github.com/oxidecomputer/propolis?rev=e9db2377f4300a7539ebb3e4237e06d46ec1e6cc)",
+ "propolis-client 0.1.0 (git+https://github.com/oxidecomputer/propolis?rev=99251f841debbe9aaceb4a407a984190c63dead5)",
  "propolis-mock-server",
  "propolis_api_types",
  "rand",
@@ -9133,7 +9133,7 @@ dependencies = [
 [[package]]
 name = "propolis-client"
 version = "0.1.0"
-source = "git+https://github.com/oxidecomputer/propolis?rev=e9db2377f4300a7539ebb3e4237e06d46ec1e6cc#e9db2377f4300a7539ebb3e4237e06d46ec1e6cc"
+source = "git+https://github.com/oxidecomputer/propolis?rev=99251f841debbe9aaceb4a407a984190c63dead5#99251f841debbe9aaceb4a407a984190c63dead5"
 dependencies = [
  "async-trait",
  "base64 0.21.7",
@@ -9178,7 +9178,7 @@ dependencies = [
 [[package]]
 name = "propolis-mock-server"
 version = "0.0.0"
-source = "git+https://github.com/oxidecomputer/propolis?rev=e9db2377f4300a7539ebb3e4237e06d46ec1e6cc#e9db2377f4300a7539ebb3e4237e06d46ec1e6cc"
+source = "git+https://github.com/oxidecomputer/propolis?rev=99251f841debbe9aaceb4a407a984190c63dead5#99251f841debbe9aaceb4a407a984190c63dead5"
 dependencies = [
  "anyhow",
  "atty",
@@ -9220,7 +9220,7 @@ dependencies = [
 [[package]]
 name = "propolis_api_types"
 version = "0.0.0"
-source = "git+https://github.com/oxidecomputer/propolis?rev=e9db2377f4300a7539ebb3e4237e06d46ec1e6cc#e9db2377f4300a7539ebb3e4237e06d46ec1e6cc"
+source = "git+https://github.com/oxidecomputer/propolis?rev=99251f841debbe9aaceb4a407a984190c63dead5#99251f841debbe9aaceb4a407a984190c63dead5"
 dependencies = [
  "crucible-client-types",
  "propolis_types",
@@ -9234,7 +9234,7 @@ dependencies = [
 [[package]]
 name = "propolis_types"
 version = "0.0.0"
-source = "git+https://github.com/oxidecomputer/propolis?rev=e9db2377f4300a7539ebb3e4237e06d46ec1e6cc#e9db2377f4300a7539ebb3e4237e06d46ec1e6cc"
+source = "git+https://github.com/oxidecomputer/propolis?rev=99251f841debbe9aaceb4a407a984190c63dead5#99251f841debbe9aaceb4a407a984190c63dead5"
 dependencies = [
  "schemars",
  "serde",
@@ -10861,7 +10861,7 @@ dependencies = [
  "omicron-workspace-hack",
  "oxnet",
  "progenitor 0.9.1",
- "propolis-client 0.1.0 (git+https://github.com/oxidecomputer/propolis?rev=e9db2377f4300a7539ebb3e4237e06d46ec1e6cc)",
+ "propolis-client 0.1.0 (git+https://github.com/oxidecomputer/propolis?rev=99251f841debbe9aaceb4a407a984190c63dead5)",
  "regress 0.9.1",
  "reqwest",
  "schemars",
@@ -10887,7 +10887,7 @@ dependencies = [
  "omicron-uuid-kinds",
  "omicron-workspace-hack",
  "oxnet",
- "propolis-client 0.1.0 (git+https://github.com/oxidecomputer/propolis?rev=e9db2377f4300a7539ebb3e4237e06d46ec1e6cc)",
+ "propolis-client 0.1.0 (git+https://github.com/oxidecomputer/propolis?rev=99251f841debbe9aaceb4a407a984190c63dead5)",
  "rcgen",
  "schemars",
  "serde",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -358,10 +358,10 @@ crossterm = { version = "0.28.1", features = ["event-stream"] }
 # NOTE: if you change the pinned revision of the `crucible` dependencies, you
 # must also update the references in package-manifest.toml to match the new
 # revision.
-crucible-agent-client = { git = "https://github.com/oxidecomputer/crucible", rev = "ace54d9cb5957fda79422e8237d7c54c33af928e" }
-crucible-pantry-client = { git = "https://github.com/oxidecomputer/crucible", rev = "ace54d9cb5957fda79422e8237d7c54c33af928e" }
-crucible-smf = { git = "https://github.com/oxidecomputer/crucible", rev = "ace54d9cb5957fda79422e8237d7c54c33af928e" }
-crucible-common = { git = "https://github.com/oxidecomputer/crucible", rev = "ace54d9cb5957fda79422e8237d7c54c33af928e" }
+crucible-agent-client = { git = "https://github.com/oxidecomputer/crucible", rev = "86a2ce1f9f13912a5fe652472de765ec5fc22e76" }
+crucible-pantry-client = { git = "https://github.com/oxidecomputer/crucible", rev = "86a2ce1f9f13912a5fe652472de765ec5fc22e76" }
+crucible-smf = { git = "https://github.com/oxidecomputer/crucible", rev = "86a2ce1f9f13912a5fe652472de765ec5fc22e76" }
+crucible-common = { git = "https://github.com/oxidecomputer/crucible", rev = "86a2ce1f9f13912a5fe652472de765ec5fc22e76" }
 # NOTE: See above!
 csv = "1.3.1"
 curve25519-dalek = "4"
@@ -559,10 +559,10 @@ progenitor-client = "0.9.1"
 # NOTE: if you change the pinned revision of the `bhyve_api` and propolis
 # dependencies, you must also update the references in package-manifest.toml to
 # match the new revision.
-bhyve_api = { git = "https://github.com/oxidecomputer/propolis", rev = "e9db2377f4300a7539ebb3e4237e06d46ec1e6cc" }
-propolis_api_types = { git = "https://github.com/oxidecomputer/propolis", rev = "e9db2377f4300a7539ebb3e4237e06d46ec1e6cc" }
-propolis-client = { git = "https://github.com/oxidecomputer/propolis", rev = "e9db2377f4300a7539ebb3e4237e06d46ec1e6cc" }
-propolis-mock-server = { git = "https://github.com/oxidecomputer/propolis", rev = "e9db2377f4300a7539ebb3e4237e06d46ec1e6cc" }
+bhyve_api = { git = "https://github.com/oxidecomputer/propolis", rev = "99251f841debbe9aaceb4a407a984190c63dead5" }
+propolis_api_types = { git = "https://github.com/oxidecomputer/propolis", rev = "99251f841debbe9aaceb4a407a984190c63dead5" }
+propolis-client = { git = "https://github.com/oxidecomputer/propolis", rev = "99251f841debbe9aaceb4a407a984190c63dead5" }
+propolis-mock-server = { git = "https://github.com/oxidecomputer/propolis", rev = "99251f841debbe9aaceb4a407a984190c63dead5" }
 # NOTE: see above!
 proptest = "1.5.0"
 qorb = "0.2.1"

--- a/package-manifest.toml
+++ b/package-manifest.toml
@@ -627,7 +627,7 @@ source.repo = "propolis"
 source.commit = "99251f841debbe9aaceb4a407a984190c63dead5"
 # The SHA256 digest is automatically posted to:
 # https://buildomat.eng.oxide.computer/public/file/oxidecomputer/propolis/image/<commit>/propolis-server.sha256.txt
-source.sha256 = "819d4ff2a165197be8384f693f5a09d7f12a0718647a0f3235910bb980ce0d52"
+source.sha256 = "53721913ee25b2c649cd845c542fb1ebf86d3e61c68af4002fcfad60050c9e54"
 output.type = "zone"
 
 [package.mg-ddm-gz]

--- a/package-manifest.toml
+++ b/package-manifest.toml
@@ -581,10 +581,10 @@ only_for_targets.image = "standard"
 # 3. Use source.type = "manual" instead of "prebuilt"
 source.type = "prebuilt"
 source.repo = "crucible"
-source.commit = "ace54d9cb5957fda79422e8237d7c54c33af928e"
+source.commit = "86a2ce1f9f13912a5fe652472de765ec5fc22e76"
 # The SHA256 digest is automatically posted to:
 # https://buildomat.eng.oxide.computer/public/file/oxidecomputer/crucible/image/<commit>/crucible.sha256.txt
-source.sha256 = "6f25aa712542b8ba13cca1b969eeb2935b37e3337f022396b344a6cc83ff0d39"
+source.sha256 = "ff41d5fb504982536445c34fb62ddccc78d40d5806326fe0d01094f4dc4ba58f"
 output.type = "zone"
 output.intermediate_only = true
 
@@ -593,10 +593,10 @@ service_name = "crucible_pantry_prebuilt"
 only_for_targets.image = "standard"
 source.type = "prebuilt"
 source.repo = "crucible"
-source.commit = "ace54d9cb5957fda79422e8237d7c54c33af928e"
+source.commit = "86a2ce1f9f13912a5fe652472de765ec5fc22e76"
 # The SHA256 digest is automatically posted to:
 # https://buildomat.eng.oxide.computer/public/file/oxidecomputer/crucible/image/<commit>/crucible-pantry.sha256.txt
-source.sha256 = "92a40c04247679a32858a07578669690ab961a1d7e7bda92de5571e576a230fe"
+source.sha256 = "70b9423e0851afe9411957cd5ac515add0cd52dbe98a50f31c8c85ac7a43299c"
 output.type = "zone"
 output.intermediate_only = true
 
@@ -610,10 +610,10 @@ service_name = "crucible_dtrace"
 only_for_targets.image = "standard"
 source.type = "prebuilt"
 source.repo = "crucible"
-source.commit = "ace54d9cb5957fda79422e8237d7c54c33af928e"
+source.commit = "86a2ce1f9f13912a5fe652472de765ec5fc22e76"
 # The SHA256 digest is automatically posted to:
 # https://buildomat.eng.oxide.computer/public/file/oxidecomputer/crucible/image/<commit>/crucible-dtrace.sha256.txt
-source.sha256 = "895544df19ef1df7ef1750e978c20e70cdba1bc1dc93db392798284b4ce9b55a"
+source.sha256 = "580e0ccb93c24835ada62b40a054042ab301fce3e1c26cd6b29611a60829f545"
 output.type = "tarball"
 
 # Refer to
@@ -624,7 +624,7 @@ service_name = "propolis-server"
 only_for_targets.image = "standard"
 source.type = "prebuilt"
 source.repo = "propolis"
-source.commit = "e9db2377f4300a7539ebb3e4237e06d46ec1e6cc"
+source.commit = "99251f841debbe9aaceb4a407a984190c63dead5"
 # The SHA256 digest is automatically posted to:
 # https://buildomat.eng.oxide.computer/public/file/oxidecomputer/propolis/image/<commit>/propolis-server.sha256.txt
 source.sha256 = "819d4ff2a165197be8384f693f5a09d7f12a0718647a0f3235910bb980ce0d52"


### PR DESCRIPTION
Crucible changes are:
Add early rejection of IOs if too many Downstairs are inactive (#1565) 
Fix missing write stats in Oximeter. (#1617)
Shrink replay buffer (#1616)
Update tokio to 1.40 (#1611)

Propolis changes are:
crates: move host CPUID queries from cpuid-gen to cpuid-utils (#843)