### PR TITLE
oxlog: Don't sort archived logs by full path

### DIFF
--- a/dev-tools/oxlog/src/bin/oxlog.rs
+++ b/dev-tools/oxlog/src/bin/oxlog.rs
@@ -96,13 +96,12 @@ fn main() -> Result<(), anyhow::Error> {
             };
 
             let logs = zones.zone_logs(&zone, filter);
-            for (svc_name, mut svc_logs) in logs {
+            for (svc_name, svc_logs) in logs {
                 if let Some(service) = &service {
                     if svc_name != service.as_str() {
                         continue;
                     }
                 }
-                svc_logs.archived.sort();
                 if filter.current {
                     if let Some(current) = &svc_logs.current {
                         if metadata {


### PR DESCRIPTION
With cf22afcc2 ([oxlog] sort log files before printing them out (#5356), 2024-04-02) OxLog will sort the logs found by file name, rather than full path. This ensures that that the records are sorted globally by timestamp. Sorting by full path will sort first by pool name, so each file in the pool will be sorted, but the ordering between pools may be incorrect.

However, in `main` we sort the already sorted archived logs again, but now by full path, which on dogfood is resulting in the inconsistent ordering mentioned above as we have enough archived nexus logs that they are split between multiple pools.

```
/pool/ext/cf940e15-.../oxide-nexus:default.log.1729518300
/pool/ext/cf940e15-.../oxide-nexus:default.log.1729520100
/pool/ext/e126ddcc-.../oxide-nexus:default.log.1693450770
/pool/ext/e126ddcc-.../oxide-nexus:default.log.1693465197
```

Remove the `sort()` as we have already sorted logs at this point.