### PR TITLE
remove old, pre-reconfigurator upgrade APIs

### DIFF
--- a/clients/nexus-client/src/lib.rs
+++ b/clients/nexus-client/src/lib.rs
@@ -246,16 +246,6 @@ impl From<&omicron_common::api::internal::nexus::ProducerEndpoint>
     }
 }
 
-impl From<omicron_common::api::external::SemverVersion>
-    for types::SemverVersion
-{
-    fn from(s: omicron_common::api::external::SemverVersion) -> Self {
-        s.to_string().parse().expect(
-            "semver should generate output that matches validation regex",
-        )
-    }
-}
-
 impl From<std::time::Duration> for types::Duration {
     fn from(s: std::time::Duration) -> Self {
         Self { secs: s.as_secs(), nanos: s.subsec_nanos() }

--- a/clients/sled-agent-client/src/lib.rs
+++ b/clients/sled-agent-client/src/lib.rs
@@ -262,63 +262,6 @@ impl From<omicron_common::api::external::L4PortRange> for types::L4PortRange {
     }
 }
 
-impl From<omicron_common::api::internal::nexus::UpdateArtifactId>
-    for types::UpdateArtifactId
-{
-    fn from(s: omicron_common::api::internal::nexus::UpdateArtifactId) -> Self {
-        types::UpdateArtifactId {
-            name: s.name,
-            version: s.version.into(),
-            kind: s.kind.into(),
-        }
-    }
-}
-
-impl From<omicron_common::api::external::SemverVersion>
-    for types::SemverVersion
-{
-    fn from(s: omicron_common::api::external::SemverVersion) -> Self {
-        s.to_string().parse().expect(
-            "semver should generate output that matches validation regex",
-        )
-    }
-}
-
-impl From<omicron_common::api::internal::nexus::KnownArtifactKind>
-    for types::KnownArtifactKind
-{
-    fn from(
-        s: omicron_common::api::internal::nexus::KnownArtifactKind,
-    ) -> Self {
-        use omicron_common::api::internal::nexus::KnownArtifactKind;
-
-        match s {
-            KnownArtifactKind::GimletRotBootloader => {
-                types::KnownArtifactKind::GimletRotBootloader
-            }
-            KnownArtifactKind::PscRotBootloader => {
-                types::KnownArtifactKind::PscRotBootloader
-            }
-            KnownArtifactKind::SwitchRotBootloader => {
-                types::KnownArtifactKind::SwitchRotBootloader
-            }
-            KnownArtifactKind::GimletSp => types::KnownArtifactKind::GimletSp,
-            KnownArtifactKind::GimletRot => types::KnownArtifactKind::GimletRot,
-            KnownArtifactKind::Host => types::KnownArtifactKind::Host,
-            KnownArtifactKind::Trampoline => {
-                types::KnownArtifactKind::Trampoline
-            }
-            KnownArtifactKind::ControlPlane => {
-                types::KnownArtifactKind::ControlPlane
-            }
-            KnownArtifactKind::PscSp => types::KnownArtifactKind::PscSp,
-            KnownArtifactKind::PscRot => types::KnownArtifactKind::PscRot,
-            KnownArtifactKind::SwitchSp => types::KnownArtifactKind::SwitchSp,
-            KnownArtifactKind::SwitchRot => types::KnownArtifactKind::SwitchRot,
-        }
-    }
-}
-
 impl From<omicron_common::api::internal::nexus::HostIdentifier>
     for types::HostIdentifier
 {

--- a/nexus/internal-api/src/lib.rs
+++ b/nexus/internal-api/src/lib.rs
@@ -5,9 +5,9 @@
 use std::collections::{BTreeMap, BTreeSet};
 
 use dropshot::{
-    FreeformBody, HttpError, HttpResponseCreated, HttpResponseDeleted,
-    HttpResponseOk, HttpResponseUpdatedNoContent, Path, Query, RequestContext,
-    ResultsPage, TypedBody,
+    HttpError, HttpResponseCreated, HttpResponseDeleted, HttpResponseOk,
+    HttpResponseUpdatedNoContent, Path, Query, RequestContext, ResultsPage,
+    TypedBody,
 };
 use nexus_types::{
     deployment::{
@@ -27,17 +27,13 @@ use nexus_types::{
         views::{BackgroundTask, DemoSaga, Ipv4NatEntryView, Saga},
     },
 };
-use omicron_common::{
-    api::{
-        external::{http_pagination::PaginatedById, Instance},
-        internal::nexus::{
-            DiskRuntimeState, DownstairsClientStopRequest,
-            DownstairsClientStopped, ProducerEndpoint,
-            ProducerRegistrationResponse, RepairFinishInfo, RepairProgress,
-            RepairStartInfo, SledVmmState,
-        },
+use omicron_common::api::{
+    external::{http_pagination::PaginatedById, Instance},
+    internal::nexus::{
+        DiskRuntimeState, DownstairsClientStopRequest, DownstairsClientStopped,
+        ProducerEndpoint, ProducerRegistrationResponse, RepairFinishInfo,
+        RepairProgress, RepairStartInfo, SledVmmState,
     },
-    update::ArtifactId,
 };
 use omicron_uuid_kinds::{
     DemoSagaUuid, DownstairsKind, PropolisUuid, SledUuid, TypedUuid,
@@ -207,16 +203,6 @@ pub trait NexusInternalApi {
         request_context: RequestContext<Self::Context>,
         oximeter_info: TypedBody<OximeterInfo>,
     ) -> Result<HttpResponseUpdatedNoContent, HttpError>;
-
-    /// Endpoint used by Sled Agents to download cached artifacts.
-    #[endpoint {
-    method = GET,
-    path = "/artifacts/{kind}/{name}/{version}",
-    }]
-    async fn cpapi_artifact_download(
-        request_context: RequestContext<Self::Context>,
-        path_params: Path<ArtifactId>,
-    ) -> Result<HttpResponseOk<FreeformBody>, HttpError>;
 
     /// An Upstairs will notify this endpoint when a repair starts
     #[endpoint {

--- a/nexus/src/app/update/mod.rs
+++ b/nexus/src/app/update/mod.rs
@@ -13,7 +13,6 @@ use nexus_db_queries::context::OpContext;
 use omicron_common::api::external::{
     Error, SemverVersion, TufRepoInsertResponse, TufRepoInsertStatus,
 };
-use omicron_common::update::ArtifactId;
 use update_common::artifacts::ArtifactsWithPlan;
 
 mod common_sp_update;
@@ -112,18 +111,5 @@ impl super::Nexus {
             .map_err(HttpError::from)?;
 
         Ok(tuf_repo_description)
-    }
-
-    /// Downloads a file (currently not implemented).
-    pub(crate) async fn updates_download_artifact(
-        &self,
-        _opctx: &OpContext,
-        _artifact: ArtifactId,
-    ) -> Result<Vec<u8>, Error> {
-        // TODO: this is part of the TUF repo depot.
-        return Err(Error::internal_error(
-            "artifact download not implemented, \
-             will be part of TUF repo depot",
-        ));
     }
 }

--- a/nexus/src/internal_api/http_entrypoints.rs
+++ b/nexus/src/internal_api/http_entrypoints.rs
@@ -7,8 +7,6 @@
 use super::params::{OximeterInfo, RackInitializationRequest};
 use crate::context::ApiContext;
 use dropshot::ApiDescription;
-use dropshot::Body;
-use dropshot::FreeformBody;
 use dropshot::HttpError;
 use dropshot::HttpResponseCreated;
 use dropshot::HttpResponseDeleted;
@@ -54,7 +52,6 @@ use omicron_common::api::internal::nexus::RepairFinishInfo;
 use omicron_common::api::internal::nexus::RepairProgress;
 use omicron_common::api::internal::nexus::RepairStartInfo;
 use omicron_common::api::internal::nexus::SledVmmState;
-use omicron_common::update::ArtifactId;
 use omicron_uuid_kinds::GenericUuid;
 use omicron_uuid_kinds::InstanceUuid;
 use std::collections::BTreeMap;
@@ -364,22 +361,6 @@ impl NexusInternalApi for NexusInternalApiImpl {
             .internal_latencies
             .instrument_dropshot_handler(&request_context, handler)
             .await
-    }
-
-    async fn cpapi_artifact_download(
-        request_context: RequestContext<Self::Context>,
-        path_params: Path<ArtifactId>,
-    ) -> Result<HttpResponseOk<FreeformBody>, HttpError> {
-        let context = &request_context.context().context;
-        let nexus = &context.nexus;
-        let opctx =
-            crate::context::op_context_for_internal_api(&request_context).await;
-        // TODO: return 404 if the error we get here says that the record isn't found
-        let body = nexus
-            .updates_download_artifact(&opctx, path_params.into_inner())
-            .await?;
-
-        Ok(HttpResponseOk(Body::from(body).into()))
     }
 
     async fn cpapi_upstairs_repair_start(

--- a/openapi/nexus-internal.json
+++ b/openapi/nexus-internal.json
@@ -10,57 +10,6 @@
     "version": "0.0.1"
   },
   "paths": {
-    "/artifacts/{kind}/{name}/{version}": {
-      "get": {
-        "summary": "Endpoint used by Sled Agents to download cached artifacts.",
-        "operationId": "cpapi_artifact_download",
-        "parameters": [
-          {
-            "in": "path",
-            "name": "kind",
-            "description": "The kind of artifact this is.",
-            "required": true,
-            "schema": {
-              "type": "string"
-            }
-          },
-          {
-            "in": "path",
-            "name": "name",
-            "description": "The artifact's name.",
-            "required": true,
-            "schema": {
-              "type": "string"
-            }
-          },
-          {
-            "in": "path",
-            "name": "version",
-            "description": "The artifact's version.",
-            "required": true,
-            "schema": {
-              "$ref": "#/components/schemas/SemverVersion"
-            }
-          }
-        ],
-        "responses": {
-          "200": {
-            "description": "",
-            "content": {
-              "*/*": {
-                "schema": {}
-              }
-            }
-          },
-          "4XX": {
-            "$ref": "#/components/responses/Error"
-          },
-          "5XX": {
-            "$ref": "#/components/responses/Error"
-          }
-        }
-      }
-    },
     "/bgtasks": {
       "get": {
         "summary": "List background tasks",
@@ -6082,10 +6031,6 @@
           "physical_disk_id",
           "sled_id"
         ]
-      },
-      "SemverVersion": {
-        "type": "string",
-        "pattern": "^(0|[1-9]\\d*)\\.(0|[1-9]\\d*)\\.(0|[1-9]\\d*)(?:-((?:0|[1-9]\\d*|\\d*[a-zA-Z-][0-9a-zA-Z-]*)(?:\\.(?:0|[1-9]\\d*|\\d*[a-zA-Z-][0-9a-zA-Z-]*))*))?(?:\\+([0-9a-zA-Z-]+(?:\\.[0-9a-zA-Z-]+)*))?$"
       },
       "TypedUuidForDownstairsKind": {
         "type": "string",

--- a/openapi/sled-agent.json
+++ b/openapi/sled-agent.json
@@ -1327,32 +1327,6 @@
         }
       }
     },
-    "/update": {
-      "post": {
-        "operationId": "update_artifact",
-        "requestBody": {
-          "content": {
-            "application/json": {
-              "schema": {
-                "$ref": "#/components/schemas/UpdateArtifactId"
-              }
-            }
-          },
-          "required": true
-        },
-        "responses": {
-          "204": {
-            "description": "resource updated"
-          },
-          "4XX": {
-            "$ref": "#/components/responses/Error"
-          },
-          "5XX": {
-            "$ref": "#/components/responses/Error"
-          }
-        }
-      }
-    },
     "/v2p": {
       "get": {
         "summary": "List v2p mappings present on sled",
@@ -4388,24 +4362,6 @@
           "net"
         ]
       },
-      "KnownArtifactKind": {
-        "description": "Kinds of update artifacts, as used by Nexus to determine what updates are available and by sled-agent to determine how to apply an update when asked.",
-        "type": "string",
-        "enum": [
-          "gimlet_sp",
-          "gimlet_rot",
-          "gimlet_rot_bootloader",
-          "host",
-          "trampoline",
-          "control_plane",
-          "psc_sp",
-          "psc_rot",
-          "psc_rot_bootloader",
-          "switch_sp",
-          "switch_rot",
-          "switch_rot_bootloader"
-        ]
-      },
       "L4PortRange": {
         "example": "22",
         "title": "A range of IP ports",
@@ -5618,10 +5574,6 @@
           "version"
         ]
       },
-      "SemverVersion": {
-        "type": "string",
-        "pattern": "^(0|[1-9]\\d*)\\.(0|[1-9]\\d*)\\.(0|[1-9]\\d*)(?:-((?:0|[1-9]\\d*|\\d*[a-zA-Z-][0-9a-zA-Z-]*)(?:\\.(?:0|[1-9]\\d*|\\d*[a-zA-Z-][0-9a-zA-Z-]*))*))?(?:\\+([0-9a-zA-Z-]+(?:\\.[0-9a-zA-Z-]+)*))?$"
-      },
       "SledDiagnosticsQueryOutput": {
         "oneOf": [
           {
@@ -6040,37 +5992,6 @@
       "TypedUuidForZpoolKind": {
         "type": "string",
         "format": "uuid"
-      },
-      "UpdateArtifactId": {
-        "description": "An identifier for a single update artifact.",
-        "type": "object",
-        "properties": {
-          "kind": {
-            "description": "The kind of update artifact this is.",
-            "allOf": [
-              {
-                "$ref": "#/components/schemas/KnownArtifactKind"
-              }
-            ]
-          },
-          "name": {
-            "description": "The artifact's name.",
-            "type": "string"
-          },
-          "version": {
-            "description": "The artifact's version.",
-            "allOf": [
-              {
-                "$ref": "#/components/schemas/SemverVersion"
-              }
-            ]
-          }
-        },
-        "required": [
-          "kind",
-          "name",
-          "version"
-        ]
       },
       "UplinkAddressConfig": {
         "type": "object",

--- a/sled-agent/api/src/lib.rs
+++ b/sled-agent/api/src/lib.rs
@@ -17,7 +17,7 @@ use nexus_sled_agent_shared::inventory::{
 };
 use omicron_common::{
     api::internal::{
-        nexus::{DiskRuntimeState, SledVmmState, UpdateArtifactId},
+        nexus::{DiskRuntimeState, SledVmmState},
         shared::{
             ExternalIpGatewayMap, ResolvedVpcRouteSet, ResolvedVpcRouteState,
             SledIdentifiers, SwitchPorts, VirtualNetworkInterfaceHost,
@@ -401,15 +401,6 @@ pub trait SledAgentApi {
         path_params: Path<DiskPathParam>,
         body: TypedBody<DiskEnsureBody>,
     ) -> Result<HttpResponseOk<DiskRuntimeState>, HttpError>;
-
-    #[endpoint {
-        method = POST,
-        path = "/update"
-    }]
-    async fn update_artifact(
-        rqctx: RequestContext<Self::Context>,
-        artifact: TypedBody<UpdateArtifactId>,
-    ) -> Result<HttpResponseUpdatedNoContent, HttpError>;
 
     #[endpoint {
         method = GET,

--- a/sled-agent/src/http_entrypoints.rs
+++ b/sled-agent/src/http_entrypoints.rs
@@ -21,9 +21,7 @@ use nexus_sled_agent_shared::inventory::{
     Inventory, OmicronZonesConfig, SledRole,
 };
 use omicron_common::api::external::Error;
-use omicron_common::api::internal::nexus::{
-    DiskRuntimeState, SledVmmState, UpdateArtifactId,
-};
+use omicron_common::api::internal::nexus::{DiskRuntimeState, SledVmmState};
 use omicron_common::api::internal::shared::{
     ExternalIpGatewayMap, ResolvedVpcRouteSet, ResolvedVpcRouteState,
     SledIdentifiers, SwitchPorts, VirtualNetworkInterfaceHost,
@@ -584,15 +582,6 @@ impl SledAgentApi for SledAgentImpl {
             .await
             .map_err(|e| Error::from(e))?,
         ))
-    }
-
-    async fn update_artifact(
-        rqctx: RequestContext<Self::Context>,
-        artifact: TypedBody<UpdateArtifactId>,
-    ) -> Result<HttpResponseUpdatedNoContent, HttpError> {
-        let sa = rqctx.context();
-        sa.update_artifact(artifact.into_inner()).await.map_err(Error::from)?;
-        Ok(HttpResponseUpdatedNoContent())
     }
 
     async fn artifact_list(

--- a/sled-agent/src/sim/http_entrypoints.rs
+++ b/sled-agent/src/sim/http_entrypoints.rs
@@ -27,7 +27,6 @@ use nexus_sled_agent_shared::inventory::SledRole;
 use nexus_sled_agent_shared::inventory::{Inventory, OmicronZonesConfig};
 use omicron_common::api::internal::nexus::DiskRuntimeState;
 use omicron_common::api::internal::nexus::SledVmmState;
-use omicron_common::api::internal::nexus::UpdateArtifactId;
 use omicron_common::api::internal::shared::ExternalIpGatewayMap;
 use omicron_common::api::internal::shared::SledIdentifiers;
 use omicron_common::api::internal::shared::VirtualNetworkInterfaceHost;
@@ -170,21 +169,6 @@ impl SledAgentApi for SledAgentSimImpl {
             )
             .await?,
         ))
-    }
-
-    async fn update_artifact(
-        rqctx: RequestContext<Self::Context>,
-        artifact: TypedBody<UpdateArtifactId>,
-    ) -> Result<HttpResponseUpdatedNoContent, HttpError> {
-        let sa = rqctx.context();
-        sa.updates()
-            .download_artifact(
-                artifact.into_inner(),
-                rqctx.context().nexus_client.as_ref(),
-            )
-            .await
-            .map_err(|e| HttpError::for_internal_error(e.to_string()))?;
-        Ok(HttpResponseUpdatedNoContent())
     }
 
     async fn artifact_list(

--- a/sled-agent/src/sled_agent.rs
+++ b/sled-agent/src/sled_agent.rs
@@ -20,7 +20,6 @@ use crate::probe_manager::ProbeManager;
 use crate::services::{self, ServiceManager};
 use crate::storage_monitor::StorageMonitorHandle;
 use crate::support_bundle::storage::SupportBundleManager;
-use crate::updates::{ConfigUpdates, UpdateManager};
 use crate::vmm_reservoir::{ReservoirMode, VmmReservoirManager};
 use crate::zone_bundle;
 use crate::zone_bundle::BundleError;
@@ -41,14 +40,11 @@ use omicron_common::address::{
     get_sled_address, get_switch_zone_address, Ipv6Subnet, SLED_PREFIX,
 };
 use omicron_common::api::external::{ByteCount, ByteCountRangeError, Vni};
-use omicron_common::api::internal::nexus::SledVmmState;
+use omicron_common::api::internal::nexus::{DiskRuntimeState, SledVmmState};
 use omicron_common::api::internal::shared::{
     ExternalIpGatewayMap, HostPortConfig, RackNetworkConfig,
     ResolvedVpcFirewallRule, ResolvedVpcRouteSet, ResolvedVpcRouteState,
     SledIdentifiers, VirtualNetworkInterfaceHost,
-};
-use omicron_common::api::{
-    internal::nexus::DiskRuntimeState, internal::nexus::UpdateArtifactId,
 };
 use omicron_common::backoff::{
     retry_notify, retry_policy_internal_service_aggressive, BackoffError,
@@ -346,9 +342,6 @@ struct SledAgentInner {
     // Component of Sled Agent responsible for monitoring hardware.
     hardware: HardwareManager,
 
-    // Component of Sled Agent responsible for managing updates.
-    updates: UpdateManager,
-
     // Component of Sled Agent responsible for managing OPTE ports.
     port_manager: PortManager,
 
@@ -523,11 +516,6 @@ impl SledAgent {
             metrics_manager.request_queue(),
         )?;
 
-        let update_config = ConfigUpdates {
-            zone_artifact_path: Utf8PathBuf::from("/opt/oxide"),
-        };
-        let updates = UpdateManager::new(update_config);
-
         let svc_config =
             services::Config::new(identifiers, config.sidecar_revision.clone());
 
@@ -628,7 +616,6 @@ impl SledAgent {
                 instances,
                 probes,
                 hardware: long_running_task_handles.hardware_manager.clone(),
-                updates,
                 port_manager,
                 services,
                 nexus_client,
@@ -1125,20 +1112,6 @@ impl SledAgent {
         _target: DiskStateRequested,
     ) -> Result<DiskRuntimeState, Error> {
         todo!("Disk attachment not yet implemented");
-    }
-
-    /// Downloads and applies an artifact.
-    // TODO: This is being split into "download" (i.e. store an artifact in the
-    // artifact store) and "apply" (perform an update using an artifact).
-    pub async fn update_artifact(
-        &self,
-        artifact: UpdateArtifactId,
-    ) -> Result<(), Error> {
-        self.inner
-            .updates
-            .download_artifact(artifact, &self.inner.nexus_client)
-            .await?;
-        Ok(())
     }
 
     pub fn artifact_store(&self) -> &ArtifactStore<StorageHandle> {

--- a/sled-agent/src/updates.rs
+++ b/sled-agent/src/updates.rs
@@ -4,17 +4,11 @@
 
 //! Management of per-sled updates
 
-use crate::nexus::NexusClient;
 use bootstrap_agent_api::Component;
 use camino::{Utf8Path, Utf8PathBuf};
-use camino_tempfile::NamedUtf8TempFile;
-use futures::{TryFutureExt, TryStreamExt};
-use omicron_common::api::internal::nexus::{
-    KnownArtifactKind, UpdateArtifactId,
-};
+use omicron_common::api::internal::nexus::UpdateArtifactId;
 use serde::{Deserialize, Serialize};
 use std::io::Read;
-use tokio::io::AsyncWriteExt;
 
 #[derive(thiserror::Error, Debug)]
 pub enum Error {
@@ -86,80 +80,6 @@ pub struct UpdateManager {
 impl UpdateManager {
     pub fn new(config: ConfigUpdates) -> Self {
         Self { config }
-    }
-
-    pub async fn download_artifact(
-        &self,
-        artifact: UpdateArtifactId,
-        nexus: &NexusClient,
-    ) -> Result<(), Error> {
-        match artifact.kind {
-            // TODO This is a demo for tests, for now.
-            KnownArtifactKind::ControlPlane => {
-                let directory = &self.config.zone_artifact_path.as_path();
-                tokio::fs::create_dir_all(&directory).await.map_err(|err| {
-                    Error::Io {
-                        message: format!("creating directory {directory:?}"),
-                        err,
-                    }
-                })?;
-
-                // We download the file to a temporary file. We then rename it to
-                // "<artifact-name>" after it has successfully downloaded, to
-                // signify that it is ready for usage.
-                let (file, temp_path) = NamedUtf8TempFile::new_in(&directory)
-                    .map_err(|err| Error::Io {
-                        message: "create temp file".to_string(),
-                        err,
-                    })?
-                    .into_parts();
-                let mut file = tokio::fs::File::from_std(file);
-
-                // Fetch the artifact and write to the file in its entirety,
-                // replacing it if it exists.
-
-                let response = nexus
-                    .cpapi_artifact_download(
-                        &KnownArtifactKind::ControlPlane.to_string(),
-                        &artifact.name,
-                        &artifact.version.clone().into(),
-                    )
-                    .await
-                    .map_err(Error::Response)?;
-
-                let mut stream = response.into_inner_stream();
-                while let Some(chunk) = stream
-                    .try_next()
-                    .await
-                    .map_err(|e| Error::Response(e.into()))?
-                {
-                    file.write_all(&chunk)
-                        .map_err(|err| Error::Io {
-                            message: "write_all".to_string(),
-                            err,
-                        })
-                        .await?;
-                }
-                file.flush().await.map_err(|err| Error::Io {
-                    message: "flush temp file".to_string(),
-                    err,
-                })?;
-                drop(file);
-
-                // Move the file to its final path.
-                let destination = directory.join(artifact.name);
-                temp_path.persist(&destination).map_err(|err| Error::Io {
-                    message: format!(
-                        "renaming {:?} to {destination:?}",
-                        err.path
-                    ),
-                    err: err.error,
-                })?;
-
-                Ok(())
-            }
-            _ => Err(Error::UnsupportedKind(artifact)),
-        }
     }
 
     // Gets the component version information from a single zone artifact.
@@ -251,72 +171,11 @@ impl UpdateManager {
 #[cfg(test)]
 mod test {
     use super::*;
-    use crate::fakes::nexus::FakeNexusServer;
-    use crate::nexus::NexusClient;
+    use camino_tempfile::NamedUtf8TempFile;
     use flate2::write::GzEncoder;
-    use omicron_common::api::external::{Error, SemverVersion};
-    use omicron_common::api::internal::nexus::UpdateArtifactId;
-    use omicron_test_utils::dev::test_setup_log;
+    use omicron_common::api::external::SemverVersion;
     use std::io::Write;
     use tar::Builder;
-
-    #[tokio::test]
-    async fn test_write_artifact_to_filesystem() {
-        let logctx = test_setup_log("test_write_artifact_to_filesystem");
-        let log = &logctx.log;
-        // The (completely fabricated) artifact we'd like to download.
-        let expected_name = "test_artifact";
-        const EXPECTED_CONTENTS: &'static str = "test_artifact contents";
-        let artifact = UpdateArtifactId {
-            name: expected_name.to_string(),
-            version: "0.0.0".parse().unwrap(),
-            kind: KnownArtifactKind::ControlPlane,
-        };
-
-        let tempdir =
-            camino_tempfile::tempdir().expect("Failed to make tempdir");
-        let expected_path = tempdir.path().join(expected_name);
-
-        // Remove the file if it already exists.
-        let _ = tokio::fs::remove_file(&expected_path).await;
-
-        // Let's pretend this is an artifact Nexus can actually give us.
-        struct NexusServer {}
-        impl FakeNexusServer for NexusServer {
-            fn cpapi_artifact_download(
-                &self,
-                artifact_id: UpdateArtifactId,
-            ) -> Result<Vec<u8>, Error> {
-                assert_eq!(artifact_id.name, "test_artifact");
-                assert_eq!(artifact_id.version.to_string(), "0.0.0");
-                assert_eq!(artifact_id.kind.to_string(), "control_plane");
-
-                Ok(EXPECTED_CONTENTS.as_bytes().to_vec())
-            }
-        }
-
-        let nexus_server = crate::fakes::nexus::start_test_server(
-            log.clone(),
-            Box::new(NexusServer {}),
-        );
-        let nexus_client = NexusClient::new(
-            &format!("http://{}", nexus_server.local_addr()),
-            log.clone(),
-        );
-
-        let config =
-            ConfigUpdates { zone_artifact_path: tempdir.path().into() };
-        let updates = UpdateManager { config };
-        // This should download the file to our local filesystem.
-        updates.download_artifact(artifact, &nexus_client).await.unwrap();
-
-        // Confirm the download succeeded.
-        assert!(expected_path.exists());
-        let contents = tokio::fs::read(&expected_path).await.unwrap();
-        assert_eq!(std::str::from_utf8(&contents).unwrap(), EXPECTED_CONTENTS);
-
-        logctx.cleanup_successful();
-    }
 
     #[tokio::test]
     async fn test_query_no_components() {


### PR DESCRIPTION
This removes:

- the Sled Agent API `update_artifact`, which was intended for Nexus to command Sled Agent to apply an arbitrary update, immediately, whatever that meant for the individual artifact.
- the Nexus internal API `cpapi_artifact_download`, which was intended for Sled Agent to be able to download an artifact from a local cache managed by Nexus and expected to be long-lived.
- the test which tested `update_artifact`.

The replacements for this functionality will be:

- the TUF Repo Depot, in which Nexus immediately pushes artifacts onto sleds so that it doesn't have to maintain persistent storage.
- Reconfigurator, which will plan and execute updates in a coordinated fashion across the rack.
- New/existing endpoints specific to artifact kinds for applying updates; for example for zones, Nexus will put a new zone configuration to Sled Agent that tells it to use a specific zone image from the Repo Depot.

I spotted that this cleanup is needed while working on #4411.