### PR TITLE
[reconfigurator] blueprint builder: backfill filesystem_pool

### DIFF
--- a/nexus/reconfigurator/planning/src/blueprint_builder/builder.rs
+++ b/nexus/reconfigurator/planning/src/blueprint_builder/builder.rs
@@ -545,7 +545,9 @@ impl<'a> BlueprintBuilder<'a> {
                 format!("failed to construct SledEditor for sled {sled_id}")
             })?;
 
-            // TODO-john explain this and when it goes away
+            // Apply fixes for omicron-7229 to all active sleds: If any zones
+            // have a missing or incorrect `filesystem_pool` property, correct
+            // it based on the inventory pools and datasets.
             match state {
                 SledState::Active => {
                     let sled_inventory = inventory.sled_agents.get(sled_id);

--- a/nexus/reconfigurator/planning/src/blueprint_builder/builder.rs
+++ b/nexus/reconfigurator/planning/src/blueprint_builder/builder.rs
@@ -545,9 +545,9 @@ impl<'a> BlueprintBuilder<'a> {
                 format!("failed to construct SledEditor for sled {sled_id}")
             })?;
 
-            // Apply fixes for omicron-7229 to all active sleds: If any zones
-            // have a missing or incorrect `filesystem_pool` property, correct
-            // it based on the inventory pools and datasets.
+            // Apply fixes for #7229 to all active sleds: If any zones have a
+            // missing or incorrect `filesystem_pool` property, correct it based
+            // on the inventory pools and datasets.
             match state {
                 SledState::Active => {
                     let sled_inventory = inventory.sled_agents.get(sled_id);

--- a/nexus/reconfigurator/planning/src/blueprint_editor/sled_editor.rs
+++ b/nexus/reconfigurator/planning/src/blueprint_editor/sled_editor.rs
@@ -306,6 +306,9 @@ impl SledEditor {
         self.as_active_mut()?.ensure_datasets_for_running_zones(rng)
     }
 
+    // Apply fixes for omicron-7229: If any zones have a missing or incorrect
+    // `filesystem_pool` property, correct it based on the inventory pools and
+    // datasets.
     pub fn backfill_zone_filesystem_pools(
         &mut self,
         inventory_zpools: &[Zpool],

--- a/nexus/reconfigurator/planning/src/blueprint_editor/sled_editor.rs
+++ b/nexus/reconfigurator/planning/src/blueprint_editor/sled_editor.rs
@@ -306,7 +306,7 @@ impl SledEditor {
         self.as_active_mut()?.ensure_datasets_for_running_zones(rng)
     }
 
-    // Apply fixes for omicron-7229: If any zones have a missing or incorrect
+    // Apply fixes for #7229: If any zones have a missing or incorrect
     // `filesystem_pool` property, correct it based on the inventory pools and
     // datasets.
     pub fn backfill_zone_filesystem_pools(


### PR DESCRIPTION
This builds on #7449 and, in combination with it, fixes #7229.

When planning a new blueprint, one of the first things we now do is loop over all in-service zones on all active sleds and check that their `filesystem_pool` is consistent with the latest inventory collection from that sled. The expectation here is that we'll be filling in `filesystem_pool: None` values from older systems (i.e., #7229). There's also an edge case where we might need to correct our own incorrect backfills, if a sled-agent has restarted since the inventory collection was taken and has chosen a different zpool for some zone.

If we can't find what the correct filesystem pool should be (e.g., if the sled isn't present in inventory at all, or none of its zpool/dataset combinations match the zone), we leave the `filesystem_pool` value untouched.

I'll put testing notes from a4x2 in a comment below.