### PR TITLE
[clickhouse] Fix DB initialisation on cluster nodes

### DIFF
--- a/oximeter/db/src/client/mod.rs
+++ b/oximeter/db/src/client/mod.rs
@@ -714,10 +714,8 @@ impl Client {
     /// Validates that the schema used by the DB matches the version used by
     /// the executable using it.
     ///
-    /// This function will **wipe** metrics data if the version stored within
-    /// the DB is less than the schema version of Oximeter.
-    /// If the version in the DB is newer than what is known to Oximeter, an
-    /// error is returned.
+    /// If the version in the DB is newer or older than what is known to Oximeter,
+    /// an error is returned.
     ///
     /// If you would like to non-destructively upgrade the database, then either
     /// the included binary `clickhouse-schema-updater` or the method

--- a/oximeter/db/src/client/mod.rs
+++ b/oximeter/db/src/client/mod.rs
@@ -3465,7 +3465,7 @@ mod tests {
             .expect("Failed to initialize timeseries database");
 
         // If we try to upgrade to a newer version, we expect a failure when
-        // re-initilaising the client.
+        // reinitialising the client.
         client
             .initialize_db_with_version(replicated, model::OXIMETER_VERSION + 1)
             .await


### PR DESCRIPTION
When running some manual tests with reconfigurator adding nodes to an existing cluster, I noticed that every time I added a new node, all of the other nodes would delete their existing `oximeter` database and create a new `oximeter` database with it's tables from scratch. This is not the behaviour we want. The other nodes should continue as they are and only the new node should have the database and schema initialised.

The unwanted behaviour when adding a new node can be seen in the following logs of a node that already existed and was part of the cluster.

- In the first line of the logs we can see initialisation is being skipped as the database already exists and is in the correct version.
- At some point before 23:11:44.738Z the new node is created, db-wipe.sql runs `DROP DATABASE IF EXISTS oximeter ON CLUSTER oximeter_cluster SYNC;` and deletes every `oximeter` database in the nodes.
- At 23:11:44.738Z clickhouse-admin sees the schema version is less that the current version (assumes "0" if the database doesn't exist) and wipes all of the databases again.
- At 23:11:51.510Z the all of the databases are wiped again presumably because some other node was also wiping everything, and entered some sort of DROP DATABASE loop.
- Finally, at 23:12:27.277Z clickhouse-admin skips initialization because the database is initialised and on the correct version.

```console
23:11:22.614Z INFO clickhouse-admin-server (ClickhouseCli): skipping initialization of replicated ClickHouse cluster at version 13
    file = clickhouse-admin/src/http_entrypoints.rs:117
23:11:22.614Z INFO clickhouse-admin-server (dropshot): request completed
    file = /home/coatlicue/.cargo/registry/src/index.crates.io-6f17d22bba15001f/dropshot-0.15.1/src/server.rs:867
    latency_us = 2412
    local_addr = [fd00:1122:3344:101::26]:8888
    method = PUT
    remote_addr = [fd00:1122:3344:101::c]:51733
    req_id = a770bb5b-31cb-4bae-9647-cead050daec9
    response_code = 204
    uri = /init
23:11:44.590Z INFO clickhouse-admin-server (dropshot): accepted connection
    file = /home/coatlicue/.cargo/registry/src/index.crates.io-6f17d22bba15001f/dropshot-0.15.1/src/server.rs:1025
    local_addr = [fd00:1122:3344:101::26]:8888
    remote_addr = [fd00:1122:3344:101::c]:59101
23:11:44.729Z INFO clickhouse-admin-server (dropshot): request completed
    file = /home/coatlicue/.cargo/registry/src/index.crates.io-6f17d22bba15001f/dropshot-0.15.1/src/server.rs:867
    latency_us = 35047
    local_addr = [fd00:1122:3344:101::26]:8888
    method = PUT
    remote_addr = [fd00:1122:3344:101::c]:59101
    req_id = 6319e2c0-3f86-4e50-8565-457aa1f93654
    response_code = 201
    uri = /config
23:11:44.735Z INFO clickhouse-admin-server (ClickhouseCli): initializing replicated ClickHouse cluster to version 13
    file = clickhouse-admin/src/http_entrypoints.rs:102
23:11:44.735Z INFO clickhouse-admin-server (ClickhouseCli): reading db version
    file = oximeter/db/src/client/mod.rs:732
    id = 53f2d94d-0be6-4cc8-bc41-c4653ecc87ee
23:11:44.738Z INFO clickhouse-admin-server (ClickhouseCli): read oximeter database version
    file = oximeter/db/src/client/mod.rs:736
    id = 53f2d94d-0be6-4cc8-bc41-c4653ecc87ee
    version = 0
23:11:44.738Z INFO clickhouse-admin-server (ClickhouseCli): wiping and re-initializing oximeter schema
    file = oximeter/db/src/client/mod.rs:741
    id = 53f2d94d-0be6-4cc8-bc41-c4653ecc87ee
23:11:46.630Z INFO clickhouse-admin-server (dropshot): accepted connection
    file = /home/coatlicue/.cargo/registry/src/index.crates.io-6f17d22bba15001f/dropshot-0.15.1/src/server.rs:1025
    local_addr = [fd00:1122:3344:101::26]:8888
    remote_addr = [fd00:1122:3344:101::b]:44556
23:11:46.763Z INFO clickhouse-admin-server (dropshot): request completed
    file = /home/coatlicue/.cargo/registry/src/index.crates.io-6f17d22bba15001f/dropshot-0.15.1/src/server.rs:867
    latency_us = 39948
    local_addr = [fd00:1122:3344:101::26]:8888
    method = PUT
    remote_addr = [fd00:1122:3344:101::b]:44556
    req_id = 025a88a4-7fc6-420f-8301-59c2354946b7
    response_code = 201
    uri = /config
23:11:46.919Z INFO clickhouse-admin-server (dropshot): accepted connection
    file = /home/coatlicue/.cargo/registry/src/index.crates.io-6f17d22bba15001f/dropshot-0.15.1/src/server.rs:1025
    local_addr = [fd00:1122:3344:101::26]:8888
    remote_addr = [fd00:1122:3344:101::a]:38254
23:11:47.049Z INFO clickhouse-admin-server (dropshot): request completed
    file = /home/coatlicue/.cargo/registry/src/index.crates.io-6f17d22bba15001f/dropshot-0.15.1/src/server.rs:867
    latency_us = 43307
    local_addr = [fd00:1122:3344:101::26]:8888
    method = PUT
    remote_addr = [fd00:1122:3344:101::a]:38254
    req_id = 7c651e0d-d685-48c1-bed7-ad47a3dec2d4
    response_code = 201
    uri = /config
23:11:51.504Z INFO clickhouse-admin-server (dropshot): request completed
    error_message_external = Internal Server Error
    error_message_internal = can't initialize replicated ClickHouse cluster to version 13: Native protocol error
    file = /home/coatlicue/.cargo/registry/src/index.crates.io-6f17d22bba15001f/dropshot-0.15.1/src/server.rs:855
    latency_us = 6774798
    local_addr = [fd00:1122:3344:101::26]:8888
    method = PUT
    remote_addr = [fd00:1122:3344:101::c]:59101
    req_id = a7af1143-2b0e-44a3-80f6-c64b2ef9f294
    response_code = 500
    uri = /init
23:11:51.509Z WARN clickhouse-admin-server (ClickhouseCli): oximeter database does not exist, or is out-of-date
    file = oximeter/db/src/client/mod.rs:823
    id = 53f2d94d-0be6-4cc8-bc41-c4653ecc87ee
23:11:51.509Z INFO clickhouse-admin-server (ClickhouseCli): initializing replicated ClickHouse cluster to version 13
    file = clickhouse-admin/src/http_entrypoints.rs:102
23:11:51.509Z INFO clickhouse-admin-server (ClickhouseCli): reading db version
    file = oximeter/db/src/client/mod.rs:732
    id = 53f2d94d-0be6-4cc8-bc41-c4653ecc87ee
23:11:51.510Z WARN clickhouse-admin-server (ClickhouseCli): oximeter database does not exist, or is out-of-date
    file = oximeter/db/src/client/mod.rs:823
    id = 53f2d94d-0be6-4cc8-bc41-c4653ecc87ee
23:11:51.510Z INFO clickhouse-admin-server (ClickhouseCli): read oximeter database version
    file = oximeter/db/src/client/mod.rs:736
    id = 53f2d94d-0be6-4cc8-bc41-c4653ecc87ee
    version = 0
23:11:51.510Z INFO clickhouse-admin-server (ClickhouseCli): wiping and re-initializing oximeter schema
    file = oximeter/db/src/client/mod.rs:741
    id = 53f2d94d-0be6-4cc8-bc41-c4653ecc87ee
23:12:01.769Z WARN clickhouse-admin-server (dropshot): request handling cancelled (client disconnected)
    file = /home/coatlicue/.cargo/registry/src/index.crates.io-6f17d22bba15001f/dropshot-0.15.1/src/server.rs:801
    latency_us = 15003374
    local_addr = [fd00:1122:3344:101::26]:8888
    method = PUT
    remote_addr = [fd00:1122:3344:101::b]:44556
    req_id = 90380119-9271-488c-b6a4-904f58b5b081
    uri = /init
23:12:02.053Z WARN clickhouse-admin-server (dropshot): request handling cancelled (client disconnected)
    file = /home/coatlicue/.cargo/registry/src/index.crates.io-6f17d22bba15001f/dropshot-0.15.1/src/server.rs:801
    latency_us = 15003025
    local_addr = [fd00:1122:3344:101::26]:8888
    method = PUT
    remote_addr = [fd00:1122:3344:101::a]:38254
    req_id = 41ba9f0b-50bd-4115-9dad-6f7c7b6d83d7
    uri = /init
23:12:27.262Z INFO clickhouse-admin-server (ClickhouseCli): inserting current version
    file = oximeter/db/src/client/mod.rs:764
    id = 53f2d94d-0be6-4cc8-bc41-c4653ecc87ee
    version = 13
23:12:27.275Z WARN clickhouse-admin-server (dropshot): request completed after handler was already cancelled
    file = /home/coatlicue/.cargo/registry/src/index.crates.io-6f17d22bba15001f/dropshot-0.15.1/src/server.rs:943
    local_addr = [fd00:1122:3344:101::26]:8888
    method = PUT
    remote_addr = [fd00:1122:3344:101::b]:44556
    req_id = 90380119-9271-488c-b6a4-904f58b5b081
    response_code = 204
    uri = /init
23:12:27.277Z INFO clickhouse-admin-server (ClickhouseCli): skipping initialization of replicated ClickHouse cluster at version 13
    file = clickhouse-admin/src/http_entrypoints.rs:117
```

To fix this issue, we are now only wiping the database associated with the node we're targeting. Here are the logs after applying the fix:

```console
23:47:52.506Z INFO clickhouse-admin-server (ClickhouseCli): skipping initialization of replicated ClickHouse cluster at version 13
    file = clickhouse-admin/src/http_entrypoints.rs:117
23:47:52.506Z INFO clickhouse-admin-server (dropshot): request completed
    file = /home/coatlicue/.cargo/registry/src/index.crates.io-6f17d22bba15001f/dropshot-0.15.1/src/server.rs:867
    latency_us = 2386
    local_addr = [fd00:1122:3344:101::28]:8888
    method = PUT
    remote_addr = [fd00:1122:3344:101::b]:64010
    req_id = 027b52d9-e5c8-4e35-998c-9e62529fb34c
    response_code = 204
    uri = /init
23:47:54.394Z INFO clickhouse-admin-server (dropshot): accepted connection
    file = /home/coatlicue/.cargo/registry/src/index.crates.io-6f17d22bba15001f/dropshot-0.15.1/src/server.rs:1025
    local_addr = [fd00:1122:3344:101::28]:8888
    remote_addr = [fd00:1122:3344:101::a]:50268
23:47:54.436Z INFO clickhouse-admin-server (dropshot): request completed
    file = /home/coatlicue/.cargo/registry/src/index.crates.io-6f17d22bba15001f/dropshot-0.15.1/src/server.rs:867
    latency_us = 41111
    local_addr = [fd00:1122:3344:101::28]:8888
    method = PUT
    remote_addr = [fd00:1122:3344:101::a]:50268
    req_id = 62e645c8-30bb-4508-b18d-7c70e378c8ee
    response_code = 201
    uri = /config
23:47:54.439Z INFO clickhouse-admin-server (ClickhouseCli): skipping initialization of replicated ClickHouse cluster at version 13
    file = clickhouse-admin/src/http_entrypoints.rs:117
23:47:54.439Z INFO clickhouse-admin-server (dropshot): request completed
    file = /home/coatlicue/.cargo/registry/src/index.crates.io-6f17d22bba15001f/dropshot-0.15.1/src/server.rs:867
    latency_us = 2249
    local_addr = [fd00:1122:3344:101::28]:8888
    method = PUT
    remote_addr = [fd00:1122:3344:101::a]:50268
    req_id = 64303d02-dd4f-45ac-8b2d-9e7f3f7b1e69
    response_code = 204
    uri = /init
23:48:52.437Z INFO clickhouse-admin-server (dropshot): accepted connection
    file = /home/coatlicue/.cargo/registry/src/index.crates.io-6f17d22bba15001f/dropshot-0.15.1/src/server.rs:1025
    local_addr = [fd00:1122:3344:101::28]:8888
    remote_addr = [fd00:1122:3344:101::b]:61722
23:48:52.477Z INFO clickhouse-admin-server (dropshot): request completed
    file = /home/coatlicue/.cargo/registry/src/index.crates.io-6f17d22bba15001f/dropshot-0.15.1/src/server.rs:867
    latency_us = 39209
    local_addr = [fd00:1122:3344:101::28]:8888
    method = PUT
    remote_addr = [fd00:1122:3344:101::b]:61722
    req_id = 837ef3af-af33-4599-9459-06f0569018ad
    response_code = 201
    uri = /config

root@oxz_clickhouse_server_f5abb38c:~# cat /var/svc/log/oxide-clickhouse-admin-server:default.log | grep wiping | looker
root@oxz_clickhouse_server_f5abb38c:~# 
```
