### PR TITLE
ci: use a tmpfs as TEST_TMPDIR on ubuntu

### DIFF
--- a/.github/buildomat/jobs/build-and-test-linux.sh
+++ b/.github/buildomat/jobs/build-and-test-linux.sh
@@ -26,5 +26,8 @@
 #: from_output = "/work/environment.json"
 #:
 
+# Mount tmpfs onto /var/tmp/omicron_tmp.
+sudo mount --mkdir -t tmpfs -o relatime,size=50%,mode=755 tmpfs /var/tmp/omicron_tmp
+
 sudo apt-get install -y jq
 exec .github/buildomat/build-and-test.sh linux


### PR DESCRIPTION
This appears to shave about 5-10 minutes off the test runtime for tests running in the **aws** factory (sample size 1).

The other working theory is that this will reduce disk contention on EBS volumes, particularly during database tests, possibly reducing flakes.