### PR TITLE
[oximeter] Fix self_stat count test flakes

### DIFF
--- a/oximeter/collector/src/agent.rs
+++ b/oximeter/collector/src/agent.rs
@@ -747,10 +747,10 @@ mod tests {
         assert!(count != 0);
         let server_count = collection_count.load(Ordering::SeqCst);
         assert!(
-            count == server_count || count - 1 == server_count,
+            count == server_count || count + 1 == server_count,
             "number of collections reported by the collection \
-            task differs from the number reported by the empty \
-            producer server itself"
+            task ({count}) differs from the number reported by the empty \
+            producer server itself ({server_count})"
         );
         assert!(stats.failed_collections.is_empty());
         logctx.cleanup_successful();
@@ -901,10 +901,10 @@ mod tests {
         // server.
         let server_count = collection_count.load(Ordering::SeqCst);
         assert!(
-            count == server_count || count - 1 == server_count,
+            count == server_count || count + 1 == server_count,
             "number of collections reported by the collection \
-            task differs from the number reported by the always-ded \
-            producer server itself"
+            task ({count}) differs from the number reported by the always-ded \
+            producer server itself ({server_count})"
         );
         assert_eq!(stats.failed_collections.len(), 1);
         logctx.cleanup_successful();


### PR DESCRIPTION
#7262 tried to fix the off-by-one test flake #7255, but it's still around. I think based on discussion on that PR (https://github.com/oxidecomputer/omicron/pull/7262/files#r1890548730), the assertion in it was adding one to the wrong side: it's possible the fake server may have seen one more request than the agent has finished noting, which means `server_count` may be equal to either `count` or `count + 1`, not `count` or `count - 1`.

The change from `assert_eq` to `assert` also caused the new flakes to not log the actual values; this puts them back into the assertion message in case this fix is still not quite right.