### PR TITLE
Do not exhaustively maintain `VpcSubnet` routes using a transaction

### DIFF
--- a/nexus/db-model/src/schema.rs
+++ b/nexus/db-model/src/schema.rs
@@ -1178,6 +1178,7 @@ table! {
         vpc_router_id -> Uuid,
         target -> Text,
         destination -> Text,
+        vpc_subnet_id -> Nullable<Uuid>,
     }
 }
 

--- a/nexus/db-model/src/schema_versions.rs
+++ b/nexus/db-model/src/schema_versions.rs
@@ -17,7 +17,7 @@ use std::collections::BTreeMap;
 ///
 /// This must be updated when you change the database schema.  Refer to
 /// schema/crdb/README.adoc in the root of this repository for details.
-pub const SCHEMA_VERSION: SemverVersion = SemverVersion::new(122, 0, 0);
+pub const SCHEMA_VERSION: SemverVersion = SemverVersion::new(123, 0, 0);
 
 /// List of all past database schema versions, in *reverse* order
 ///
@@ -29,6 +29,7 @@ static KNOWN_VERSIONS: Lazy<Vec<KnownVersion>> = Lazy::new(|| {
         // |  leaving the first copy as an example for the next person.
         // v
         // KnownVersion::new(next_int, "unique-dirname-with-the-sql-files"),
+        KnownVersion::new(123, "vpc-subnet-contention"),
         KnownVersion::new(122, "tuf-artifact-replication"),
         KnownVersion::new(121, "dataset-to-crucible-dataset"),
         KnownVersion::new(120, "rendezvous-debug-dataset"),

--- a/nexus/db-model/src/vpc_route.rs
+++ b/nexus/db-model/src/vpc_route.rs
@@ -109,6 +109,7 @@ pub struct RouterRoute {
     pub vpc_router_id: Uuid,
     pub target: RouteTarget,
     pub destination: RouteDestination,
+    pub vpc_subnet_id: Option<Uuid>,
 }
 
 impl RouterRoute {
@@ -125,6 +126,7 @@ impl RouterRoute {
             kind: RouterRouteKind(kind),
             target: RouteTarget(params.target),
             destination: RouteDestination::new(params.destination),
+            vpc_subnet_id: None,
         }
     }
 
@@ -133,14 +135,50 @@ impl RouterRoute {
     /// This defaults to use the same name as the subnet. If this would conflict
     /// with the internet gateway rules, then the UUID is used instead (alongside
     /// notice that a name conflict has occurred).
-    pub fn for_subnet(
+    pub fn new_subnet(
         route_id: Uuid,
         system_router_id: Uuid,
-        subnet: Name,
+        subnet_name: Name,
+        subnet_id: Uuid,
     ) -> Self {
-        let forbidden_names = ["default-v4", "default-v6"];
+        let name = Self::deconflict_subnet_name(&subnet_name, route_id);
 
-        let name = if forbidden_names.contains(&subnet.as_str()) {
+        let identity = RouterRouteIdentity::new(
+            route_id,
+            external::IdentityMetadataCreateParams {
+                name,
+                description: "System-managed VPC Subnet route.".into(),
+            },
+        );
+
+        // The destination and target are technically presentation-only --
+        // these need to accurately track the state of subnet_id, which can
+        // cause messy reconciles.
+        // The route RPW will always rely on that linked subnet instead of
+        // these values (but should attempt a fixup if they fall out of sync).
+        Self {
+            identity,
+            vpc_router_id: system_router_id,
+            kind: RouterRouteKind(external::RouterRouteKind::VpcSubnet),
+            target: RouteTarget(external::RouteTarget::Subnet(
+                subnet_name.0.clone(),
+            )),
+            destination: RouteDestination(external::RouteDestination::Subnet(
+                subnet_name.0,
+            )),
+            vpc_subnet_id: Some(subnet_id),
+        }
+    }
+
+    /// Choose a new name (containing route_id) for a VPC subnet route when
+    /// it would conflict with prenamed IGW rules. These rules' names are
+    /// immutable.
+    pub fn deconflict_subnet_name(
+        name: &Name,
+        route_id: Uuid,
+    ) -> external::Name {
+        let forbidden_names = ["default-v4", "default-v6"];
+        if forbidden_names.contains(&name.as_str()) {
             // unwrap safety: a uuid is not by itself a valid name
             // so prepend it with another string.
             // - length constraint is <63 chars,
@@ -148,24 +186,10 @@ impl RouterRoute {
             // - "{subnet}-" is 11 chars
             // - "conflict-" is 9 chars
             //   = 56 chars
-            format!("conflict-{subnet}-{route_id}").parse().unwrap()
+            format!("conflict-{name}-{route_id}").parse().unwrap()
         } else {
-            subnet.0.clone()
-        };
-
-        Self::new(
-            route_id,
-            system_router_id,
-            external::RouterRouteKind::VpcSubnet,
-            params::RouterRouteCreate {
-                identity: external::IdentityMetadataCreateParams {
-                    name,
-                    description: format!("VPC Subnet route for '{subnet}'"),
-                },
-                target: external::RouteTarget::Subnet(subnet.0.clone()),
-                destination: external::RouteDestination::Subnet(subnet.0),
-            },
-        )
+            name.0.clone()
+        }
     }
 }
 
@@ -189,6 +213,30 @@ pub struct RouterRouteUpdate {
     pub time_modified: DateTime<Utc>,
     pub target: RouteTarget,
     pub destination: RouteDestination,
+}
+
+impl RouterRouteUpdate {
+    /// Generate an update for the presentation of an existing `VpcSubnet` route,
+    /// targeting a new name.
+    pub fn vpc_subnet_rename(
+        subnet_name: Name,
+        time_modified: DateTime<Utc>,
+    ) -> Self {
+        let name =
+            RouterRoute::deconflict_subnet_name(&subnet_name, Uuid::new_v4());
+
+        Self {
+            name: Some(Name(name)),
+            description: None,
+            time_modified,
+            target: RouteTarget(external::RouteTarget::Subnet(
+                subnet_name.0.clone(),
+            )),
+            destination: RouteDestination(external::RouteDestination::Subnet(
+                subnet_name.0,
+            )),
+        }
+    }
 }
 
 impl From<params::RouterRouteUpdate> for RouterRouteUpdate {

--- a/nexus/db-model/src/vpc_route.rs
+++ b/nexus/db-model/src/vpc_route.rs
@@ -153,9 +153,10 @@ impl RouterRoute {
 
         // The destination and target are technically presentation-only --
         // these need to accurately track the state of subnet_id, which can
-        // cause messy reconciles.
-        // The route RPW will always rely on that linked subnet instead of
-        // these values (but should attempt a fixup if they fall out of sync).
+        // cause messy reconciles. Otherwise in the app layer we make sure one
+        // exists for each subnet and keep the fields synced on a best-effort
+        // basis. The route RPW will always rely on that linked subnet instead
+        // of these values.
         Self {
             identity,
             vpc_router_id: system_router_id,

--- a/nexus/db-model/src/vpc_route.rs
+++ b/nexus/db-model/src/vpc_route.rs
@@ -183,7 +183,7 @@ impl RouterRoute {
             // so prepend it with another string.
             // - length constraint is <63 chars,
             // - a UUID is 36 chars including hyphens,
-            // - "{subnet}-" is 11 chars
+            // - "{name}-" is 11 chars
             // - "conflict-" is 9 chars
             //   = 56 chars
             format!("conflict-{name}-{route_id}").parse().unwrap()

--- a/nexus/db-model/src/vpc_route.rs
+++ b/nexus/db-model/src/vpc_route.rs
@@ -178,16 +178,18 @@ impl RouterRoute {
         name: &Name,
         route_id: Uuid,
     ) -> external::Name {
-        let forbidden_names = ["default-v4", "default-v6"];
-        if forbidden_names.contains(&name.as_str()) {
+        const FORBIDDEN_NAMES: [&str; 2] = ["default-v4", "default-v6"];
+        if FORBIDDEN_NAMES.contains(&name.as_str()) {
             // unwrap safety: a uuid is not by itself a valid name
             // so prepend it with another string.
-            // - length constraint is <63 chars,
+            // - length constraint is <= 63 chars,
             // - a UUID is 36 chars including hyphens,
-            // - "{name}-" is 11 chars
+            // - "{name}-" is max 11 chars
             // - "conflict-" is 9 chars
             //   = 56 chars
-            format!("conflict-{name}-{route_id}").parse().unwrap()
+            format!("conflict-{name}-{route_id}")
+                .parse()
+                .expect("all entries in 'FORBIDDEN_NAMES' are 10 chars long")
         } else {
             name.0.clone()
         }

--- a/nexus/db-model/src/vpc_subnet.rs
+++ b/nexus/db-model/src/vpc_subnet.rs
@@ -115,6 +115,7 @@ pub struct VpcSubnetUpdate {
     pub name: Option<Name>,
     pub description: Option<String>,
     pub time_modified: DateTime<Utc>,
+    pub custom_router_id: Option<Option<Uuid>>,
 }
 
 impl From<params::VpcSubnetUpdate> for VpcSubnetUpdate {
@@ -123,6 +124,7 @@ impl From<params::VpcSubnetUpdate> for VpcSubnetUpdate {
             name: params.identity.name.map(Name),
             description: params.identity.description,
             time_modified: Utc::now(),
+            custom_router_id: None,
         }
     }
 }

--- a/nexus/db-model/src/vpc_subnet.rs
+++ b/nexus/db-model/src/vpc_subnet.rs
@@ -109,7 +109,7 @@ impl From<VpcSubnet> for views::VpcSubnet {
     }
 }
 
-#[derive(AsChangeset)]
+#[derive(AsChangeset, Clone, Deserialize, Serialize, Debug)]
 #[diesel(table_name = vpc_subnet)]
 pub struct VpcSubnetUpdate {
     pub name: Option<Name>,

--- a/nexus/src/app/sagas/mod.rs
+++ b/nexus/src/app/sagas/mod.rs
@@ -50,6 +50,8 @@ pub mod test_saga;
 pub mod volume_delete;
 pub mod volume_remove_rop;
 pub mod vpc_create;
+pub mod vpc_subnet_create;
+pub mod vpc_subnet_delete;
 
 pub mod common_storage;
 
@@ -167,6 +169,8 @@ fn make_action_registry() -> ActionRegistry {
         volume_delete::SagaVolumeDelete,
         volume_remove_rop::SagaVolumeRemoveROP,
         vpc_create::SagaVpcCreate,
+        vpc_subnet_create::SagaVpcSubnetCreate,
+        vpc_subnet_delete::SagaVpcSubnetDelete,
         image_delete::SagaImageDelete,
         region_replacement_start::SagaRegionReplacementStart,
         region_replacement_drive::SagaRegionReplacementDrive,

--- a/nexus/src/app/sagas/mod.rs
+++ b/nexus/src/app/sagas/mod.rs
@@ -52,6 +52,7 @@ pub mod volume_remove_rop;
 pub mod vpc_create;
 pub mod vpc_subnet_create;
 pub mod vpc_subnet_delete;
+pub mod vpc_subnet_update;
 
 pub mod common_storage;
 
@@ -171,6 +172,7 @@ fn make_action_registry() -> ActionRegistry {
         vpc_create::SagaVpcCreate,
         vpc_subnet_create::SagaVpcSubnetCreate,
         vpc_subnet_delete::SagaVpcSubnetDelete,
+        vpc_subnet_update::SagaVpcSubnetUpdate,
         image_delete::SagaImageDelete,
         region_replacement_start::SagaRegionReplacementStart,
         region_replacement_drive::SagaRegionReplacementDrive,

--- a/nexus/src/app/sagas/vpc_create.rs
+++ b/nexus/src/app/sagas/vpc_create.rs
@@ -343,6 +343,7 @@ async fn svc_create_subnet(
     let (authz_vpc, db_vpc) =
         sagactx.lookup::<(authz::Vpc, db::model::Vpc)>("vpc")?;
     let default_subnet_id = sagactx.lookup::<Uuid>("default_subnet_id")?;
+    let authz_router = sagactx.lookup::<authz::VpcRouter>("router")?;
 
     // Allocate the first /64 sub-range from the requested or created
     // prefix.
@@ -375,7 +376,7 @@ async fn svc_create_subnet(
     // in our code.
     osagactx
         .datastore()
-        .vpc_create_subnet(&opctx, &authz_vpc, subnet)
+        .vpc_create_subnet(&opctx, &authz_vpc, &authz_router, subnet, None)
         .await
         .map_err(|err| match err {
             InsertVpcSubnetError::OverlappingIpRange(ip) => {

--- a/nexus/src/app/sagas/vpc_subnet_create.rs
+++ b/nexus/src/app/sagas/vpc_subnet_create.rs
@@ -204,7 +204,13 @@ async fn svsc_create_subnet_undo(
         .await;
 
     match res {
-        Ok(_) | Err(external::Error::ObjectNotFound { .. }) => Ok(()),
+        Ok(_) | Err(external::Error::ObjectNotFound { .. }) => {
+            let _ = osagactx
+                .datastore()
+                .vpc_increment_rpw_version(&opctx, params.authz_vpc.id())
+                .await;
+            Ok(())
+        }
         Err(e) => Err(e.into()),
     }
 }

--- a/nexus/src/app/sagas/vpc_subnet_delete.rs
+++ b/nexus/src/app/sagas/vpc_subnet_delete.rs
@@ -5,9 +5,9 @@
 use super::ActionRegistry;
 use super::NexusActionContext;
 use super::NexusSaga;
-use super::SagaInitError;
 use crate::app::sagas::declare_saga_actions;
 use nexus_db_queries::{authn, authz, db};
+use omicron_common::api::external;
 use serde::Deserialize;
 use serde::Serialize;
 use steno::ActionError;
@@ -39,18 +39,6 @@ declare_saga_actions! {
 
 // vpc subnet delete saga: definition
 
-/// Identical to [SagaVpcSubnetDelete::make_saga_dag], but using types
-/// to identify that parameters do not need to be supplied as input.
-pub fn create_dag(
-    mut builder: steno::DagBuilder,
-) -> Result<steno::Dag, SagaInitError> {
-    builder.append(vpc_subnet_delete_subnet_action());
-    builder.append(vpc_subnet_delete_sys_route_action());
-    builder.append(vpc_notify_rpw_action());
-
-    Ok(builder.build()?)
-}
-
 #[derive(Debug)]
 pub(crate) struct SagaVpcSubnetDelete;
 impl NexusSaga for SagaVpcSubnetDelete {
@@ -63,9 +51,13 @@ impl NexusSaga for SagaVpcSubnetDelete {
 
     fn make_saga_dag(
         _params: &Self::Params,
-        builder: steno::DagBuilder,
+        mut builder: steno::DagBuilder,
     ) -> Result<steno::Dag, super::SagaInitError> {
-        create_dag(builder)
+        builder.append(vpc_subnet_delete_subnet_action());
+        builder.append(vpc_subnet_delete_sys_route_action());
+        builder.append(vpc_notify_rpw_action());
+
+        Ok(builder.build()?)
     }
 }
 
@@ -81,11 +73,15 @@ async fn svsd_delete_subnet(
         &params.serialized_authn,
     );
 
-    osagactx
+    let res = osagactx
         .datastore()
-        .vpc_delete_subnet(&opctx, &params.db_subnet, &params.authz_subnet)
-        .await
-        .map_err(ActionError::action_failed)
+        .vpc_delete_subnet_raw(&opctx, &params.db_subnet, &params.authz_subnet)
+        .await;
+
+    match res {
+        Ok(_) | Err(external::Error::ObjectNotFound { .. }) => Ok(()),
+        Err(e) => Err(ActionError::action_failed(e)),
+    }
 }
 
 async fn svsd_delete_route(
@@ -124,26 +120,18 @@ async fn svsd_notify_rpw(
 
 #[cfg(test)]
 pub(crate) mod test {
+    use crate::app::saga::create_saga_dag;
+    use crate::app::sagas::test_helpers;
     use crate::{
-        app::sagas::vpc_create::Params, app::sagas::vpc_create::SagaVpcCreate,
+        app::sagas::vpc_subnet_delete::Params,
+        app::sagas::vpc_subnet_delete::SagaVpcSubnetDelete,
         external_api::params,
     };
-    use async_bb8_diesel::AsyncRunQueryDsl;
-    use diesel::{
-        ExpressionMethods, OptionalExtension, QueryDsl, SelectableHelper,
-    };
     use dropshot::test_util::ClientTestContext;
-    use nexus_db_queries::db::fixed_data::vpc::SERVICES_INTERNET_GATEWAY_ID;
-    use nexus_db_queries::{
-        authn::saga::Serialized, authz, context::OpContext,
-        db::datastore::DataStore, db::fixed_data::vpc::SERVICES_VPC_ID,
-        db::lookup::LookupPath,
-    };
+    use nexus_db_queries::{authn::saga::Serialized, context::OpContext};
     use nexus_test_utils::resource_helpers::create_default_ip_pool;
     use nexus_test_utils::resource_helpers::create_project;
     use nexus_test_utils_macros::nexus_test;
-    use omicron_common::api::external::IdentityMetadataCreateParams;
-    use omicron_common::api::external::Name;
     use omicron_common::api::external::NameOrId;
     use uuid::Uuid;
 
@@ -158,25 +146,6 @@ pub(crate) mod test {
         project.identity.id
     }
 
-    // Helper for creating VPC create parameters
-    fn new_test_params(
-        opctx: &OpContext,
-        authz_project: authz::Project,
-    ) -> Params {
-        Params {
-            serialized_authn: Serialized::for_opctx(opctx),
-            vpc_create: params::VpcCreate {
-                identity: IdentityMetadataCreateParams {
-                    name: "my-vpc".parse().unwrap(),
-                    description: "My VPC".to_string(),
-                },
-                ipv6_prefix: None,
-                dns_name: "abc".parse().unwrap(),
-            },
-            authz_project,
-        }
-    }
-
     fn test_opctx(cptestctx: &ControlPlaneTestContext) -> OpContext {
         OpContext::for_tests(
             cptestctx.logctx.log.new(o!()),
@@ -184,286 +153,32 @@ pub(crate) mod test {
         )
     }
 
-    async fn get_authz_project(
+    async fn new_test_params(
         cptestctx: &ControlPlaneTestContext,
         project_id: Uuid,
-        action: authz::Action,
-    ) -> authz::Project {
+    ) -> Params {
         let nexus = &cptestctx.server.server_context().nexus;
-        let project_selector =
-            params::ProjectSelector { project: NameOrId::Id(project_id) };
         let opctx = test_opctx(&cptestctx);
-        let (.., authz_project) = nexus
-            .project_lookup(&opctx, project_selector)
-            .expect("Invalid parameters constructing project lookup")
-            .lookup_for(action)
-            .await
-            .expect("Project does not exist");
-        authz_project
-    }
-
-    async fn delete_project_vpc_defaults(
-        cptestctx: &ControlPlaneTestContext,
-        project_id: Uuid,
-    ) {
-        let opctx = test_opctx(&cptestctx);
-        let datastore = cptestctx.server.server_context().nexus.datastore();
-        let default_name = Name::try_from("default".to_string()).unwrap();
-        let system_name = Name::try_from("system".to_string()).unwrap();
-
-        // Default Subnet
-        let (.., authz_subnet, subnet) = LookupPath::new(&opctx, &datastore)
-            .project_id(project_id)
-            .vpc_name(&default_name.clone().into())
-            .vpc_subnet_name(&default_name.clone().into())
-            .fetch()
-            .await
-            .expect("Failed to fetch default Subnet");
-        datastore
-            .vpc_delete_subnet(&opctx, &subnet, &authz_subnet)
-            .await
-            .expect("Failed to delete default Subnet");
-
-        // Default gateway routes
-        let (.., authz_route, _route) = LookupPath::new(&opctx, &datastore)
-            .project_id(project_id)
-            .vpc_name(&default_name.clone().into())
-            .vpc_router_name(&system_name.clone().into())
-            .router_route_name(&"default-v4".parse::<Name>().unwrap().into())
-            .fetch()
-            .await
-            .expect("Failed to fetch default route");
-        datastore
-            .router_delete_route(&opctx, &authz_route)
-            .await
-            .expect("Failed to delete default route");
-
-        let (.., authz_route, _route) = LookupPath::new(&opctx, &datastore)
-            .project_id(project_id)
-            .vpc_name(&default_name.clone().into())
-            .vpc_router_name(&system_name.clone().into())
-            .router_route_name(&"default-v6".parse::<Name>().unwrap().into())
-            .fetch()
-            .await
-            .expect("Failed to fetch default route");
-        datastore
-            .router_delete_route(&opctx, &authz_route)
-            .await
-            .expect("Failed to delete default route");
-
-        // System router
-        let (.., authz_router, _router) = LookupPath::new(&opctx, &datastore)
-            .project_id(project_id)
-            .vpc_name(&default_name.clone().into())
-            .vpc_router_name(&system_name.into())
-            .fetch()
-            .await
-            .expect("Failed to fetch system router");
-        datastore
-            .vpc_delete_router(&opctx, &authz_router)
-            .await
-            .expect("Failed to delete system router");
-
-        // Default gateway
-        let (.., authz_vpc, authz_igw, _igw) =
-            LookupPath::new(&opctx, &datastore)
-                .project_id(project_id)
-                .vpc_name(&default_name.clone().into())
-                .internet_gateway_name(&default_name.clone().into())
-                .fetch()
-                .await
-                .expect("Failed to fetch default gateway");
-        datastore
-            .vpc_delete_internet_gateway(
+        let (.., authz_vpc, authz_subnet, db_subnet) = nexus
+            .vpc_subnet_lookup(
                 &opctx,
-                &authz_igw,
-                authz_vpc.id(),
-                true,
+                params::SubnetSelector {
+                    project: Some(project_id.into()),
+                    vpc: Some(NameOrId::Name("default".parse().unwrap())),
+                    subnet: NameOrId::Name("default".parse().unwrap()),
+                },
             )
-            .await
-            .expect("Failed to delete default gateway");
-
-        // Default VPC & Firewall Rules
-        let (.., authz_vpc, vpc) = LookupPath::new(&opctx, &datastore)
-            .project_id(project_id)
-            .vpc_name(&default_name.into())
+            .unwrap()
             .fetch()
             .await
-            .expect("Failed to fetch default VPC");
-        datastore
-            .vpc_delete_all_firewall_rules(&opctx, &authz_vpc)
-            .await
-            .expect("Failed to delete all firewall rules for VPC");
-        datastore
-            .project_delete_vpc(&opctx, &vpc, &authz_vpc)
-            .await
-            .expect("Failed to delete VPC");
-    }
+            .unwrap();
 
-    pub(crate) async fn verify_clean_slate(datastore: &DataStore) {
-        assert!(no_vpcs_exist(datastore).await);
-        assert!(no_routers_exist(datastore).await);
-        assert!(no_routes_exist(datastore).await);
-        assert!(no_subnets_exist(datastore).await);
-        assert!(no_gateways_exist(datastore).await);
-        assert!(no_gateway_links_exist(datastore).await);
-        assert!(no_firewall_rules_exist(datastore).await);
-    }
-
-    async fn no_vpcs_exist(datastore: &DataStore) -> bool {
-        use nexus_db_queries::db::model::Vpc;
-        use nexus_db_queries::db::schema::vpc::dsl;
-
-        dsl::vpc
-            .filter(dsl::time_deleted.is_null())
-            // ignore built-in services VPC
-            .filter(dsl::id.ne(*SERVICES_VPC_ID))
-            .select(Vpc::as_select())
-            .first_async::<Vpc>(
-                &*datastore.pool_connection_for_tests().await.unwrap(),
-            )
-            .await
-            .optional()
-            .unwrap()
-            .map(|vpc| {
-                eprintln!("VPC exists: {vpc:?}");
-            })
-            .is_none()
-    }
-
-    async fn no_routers_exist(datastore: &DataStore) -> bool {
-        use nexus_db_queries::db::model::VpcRouter;
-        use nexus_db_queries::db::schema::vpc_router::dsl;
-
-        dsl::vpc_router
-            .filter(dsl::time_deleted.is_null())
-            // ignore built-in services VPC
-            .filter(dsl::vpc_id.ne(*SERVICES_VPC_ID))
-            .select(VpcRouter::as_select())
-            .first_async::<VpcRouter>(
-                &*datastore.pool_connection_for_tests().await.unwrap(),
-            )
-            .await
-            .optional()
-            .unwrap()
-            .map(|router| {
-                eprintln!("Router exists: {router:?}");
-            })
-            .is_none()
-    }
-
-    async fn no_gateways_exist(datastore: &DataStore) -> bool {
-        use nexus_db_queries::db::model::InternetGateway;
-        use nexus_db_queries::db::schema::internet_gateway::dsl;
-
-        dsl::internet_gateway
-            .filter(dsl::time_deleted.is_null())
-            // ignore built-in services VPC
-            .filter(dsl::vpc_id.ne(*SERVICES_VPC_ID))
-            .select(InternetGateway::as_select())
-            .first_async::<InternetGateway>(
-                &*datastore.pool_connection_for_tests().await.unwrap(),
-            )
-            .await
-            .optional()
-            .unwrap()
-            .map(|igw| {
-                eprintln!("Internet gateway exists: {igw:?}");
-            })
-            .is_none()
-    }
-
-    async fn no_gateway_links_exist(datastore: &DataStore) -> bool {
-        use nexus_db_queries::db::model::InternetGatewayIpPool;
-        use nexus_db_queries::db::schema::internet_gateway_ip_pool::dsl;
-
-        dsl::internet_gateway_ip_pool
-            .filter(dsl::time_deleted.is_null())
-            .filter(dsl::internet_gateway_id.ne(*SERVICES_INTERNET_GATEWAY_ID))
-            .select(InternetGatewayIpPool::as_select())
-            .first_async::<InternetGatewayIpPool>(
-                &*datastore.pool_connection_for_tests().await.unwrap(),
-            )
-            .await
-            .optional()
-            .unwrap()
-            .map(|igw_ip_pool| {
-                eprintln!(
-                    "Internet gateway ip pool links exists: {igw_ip_pool:?}"
-                );
-            })
-            .is_none()
-    }
-
-    async fn no_routes_exist(datastore: &DataStore) -> bool {
-        use nexus_db_queries::db::model::RouterRoute;
-        use nexus_db_queries::db::schema::router_route::dsl;
-        use nexus_db_queries::db::schema::vpc_router::dsl as vpc_router_dsl;
-
-        dsl::router_route
-            .filter(dsl::time_deleted.is_null())
-            // ignore built-in services VPC
-            .filter(
-                dsl::vpc_router_id.ne_all(
-                    vpc_router_dsl::vpc_router
-                        .select(vpc_router_dsl::id)
-                        .filter(vpc_router_dsl::vpc_id.eq(*SERVICES_VPC_ID))
-                        .filter(vpc_router_dsl::time_deleted.is_null()),
-                ),
-            )
-            .select(RouterRoute::as_select())
-            .first_async::<RouterRoute>(
-                &*datastore.pool_connection_for_tests().await.unwrap(),
-            )
-            .await
-            .optional()
-            .unwrap()
-            .map(|route| {
-                eprintln!("Route exists: {route:?}");
-            })
-            .is_none()
-    }
-
-    async fn no_subnets_exist(datastore: &DataStore) -> bool {
-        use nexus_db_queries::db::model::VpcSubnet;
-        use nexus_db_queries::db::schema::vpc_subnet::dsl;
-
-        dsl::vpc_subnet
-            .filter(dsl::time_deleted.is_null())
-            // ignore built-in services VPC
-            .filter(dsl::vpc_id.ne(*SERVICES_VPC_ID))
-            .select(VpcSubnet::as_select())
-            .first_async::<VpcSubnet>(
-                &*datastore.pool_connection_for_tests().await.unwrap(),
-            )
-            .await
-            .optional()
-            .unwrap()
-            .map(|subnet| {
-                eprintln!("Subnet exists: {subnet:?}");
-            })
-            .is_none()
-    }
-
-    async fn no_firewall_rules_exist(datastore: &DataStore) -> bool {
-        use nexus_db_queries::db::model::VpcFirewallRule;
-        use nexus_db_queries::db::schema::vpc_firewall_rule::dsl;
-
-        dsl::vpc_firewall_rule
-            .filter(dsl::time_deleted.is_null())
-            // ignore built-in services VPC
-            .filter(dsl::vpc_id.ne(*SERVICES_VPC_ID))
-            .select(VpcFirewallRule::as_select())
-            .first_async::<VpcFirewallRule>(
-                &*datastore.pool_connection_for_tests().await.unwrap(),
-            )
-            .await
-            .optional()
-            .unwrap()
-            .map(|rule| {
-                eprintln!("Firewall rule exists: {rule:?}");
-            })
-            .is_none()
+        Params {
+            serialized_authn: Serialized::for_opctx(&opctx),
+            authz_vpc,
+            authz_subnet,
+            db_subnet,
+        }
     }
 
     #[nexus_test(server = crate::Server)]
@@ -473,61 +188,21 @@ pub(crate) mod test {
         let client = &cptestctx.external_client;
         let nexus = &cptestctx.server.server_context().nexus;
         let project_id = create_org_and_project(&client).await;
-        delete_project_vpc_defaults(&cptestctx, project_id).await;
 
-        // Before running the test, confirm we have no records of any VPCs.
-        verify_clean_slate(nexus.datastore()).await;
-
-        // Build the saga DAG with the provided test parameters
-        let opctx = test_opctx(&cptestctx);
-        let authz_project = get_authz_project(
-            &cptestctx,
-            project_id,
-            authz::Action::CreateChild,
-        )
-        .await;
-        let params = new_test_params(&opctx, authz_project);
-        nexus.sagas.saga_execute::<SagaVpcCreate>(params).await.unwrap();
+        let params = new_test_params(cptestctx, project_id).await;
+        nexus.sagas.saga_execute::<SagaVpcSubnetDelete>(params).await.unwrap();
     }
 
     #[nexus_test(server = crate::Server)]
-    async fn test_action_failure_can_unwind(
+    async fn test_actions_succeed_idempotently(
         cptestctx: &ControlPlaneTestContext,
     ) {
-        let log = &cptestctx.logctx.log;
-
         let client = &cptestctx.external_client;
         let nexus = &cptestctx.server.server_context().nexus;
         let project_id = create_org_and_project(&client).await;
-        delete_project_vpc_defaults(&cptestctx, project_id).await;
 
-        let opctx = test_opctx(&cptestctx);
-        crate::app::sagas::test_helpers::action_failure_can_unwind::<
-            SagaVpcCreate,
-            _,
-            _,
-        >(
-            nexus,
-            || {
-                Box::pin(async {
-                    new_test_params(
-                        &opctx,
-                        get_authz_project(
-                            &cptestctx,
-                            project_id,
-                            authz::Action::CreateChild,
-                        )
-                        .await,
-                    )
-                })
-            },
-            || {
-                Box::pin(async {
-                    verify_clean_slate(nexus.datastore()).await;
-                })
-            },
-            log,
-        )
-        .await;
+        let params = new_test_params(cptestctx, project_id).await;
+        let dag = create_saga_dag::<SagaVpcSubnetDelete>(params).unwrap();
+        test_helpers::actions_succeed_idempotently(nexus, dag).await;
     }
 }

--- a/nexus/src/app/sagas/vpc_subnet_delete.rs
+++ b/nexus/src/app/sagas/vpc_subnet_delete.rs
@@ -1,0 +1,533 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at https://mozilla.org/MPL/2.0/.
+
+use super::ActionRegistry;
+use super::NexusActionContext;
+use super::NexusSaga;
+use super::SagaInitError;
+use crate::app::sagas::declare_saga_actions;
+use nexus_db_queries::{authn, authz, db};
+use serde::Deserialize;
+use serde::Serialize;
+use steno::ActionError;
+
+// vpc subnet delete saga: input parameters
+
+#[derive(Debug, Deserialize, Serialize)]
+pub(crate) struct Params {
+    pub serialized_authn: authn::saga::Serialized,
+    pub authz_vpc: authz::Vpc,
+    pub authz_subnet: authz::VpcSubnet,
+    pub db_subnet: db::model::VpcSubnet,
+}
+
+// vpc subnet delete saga: actions
+
+declare_saga_actions! {
+    vpc_subnet_delete;
+    VPC_SUBNET_DELETE_SUBNET -> "no_result_0" {
+        + svsd_delete_subnet
+    }
+    VPC_SUBNET_DELETE_SYS_ROUTE -> "no_result_1" {
+        + svsd_delete_route
+    }
+    VPC_NOTIFY_RPW -> "no_result_2" {
+        + svsd_notify_rpw
+    }
+}
+
+// vpc subnet delete saga: definition
+
+/// Identical to [SagaVpcSubnetDelete::make_saga_dag], but using types
+/// to identify that parameters do not need to be supplied as input.
+pub fn create_dag(
+    mut builder: steno::DagBuilder,
+) -> Result<steno::Dag, SagaInitError> {
+    builder.append(vpc_subnet_delete_subnet_action());
+    builder.append(vpc_subnet_delete_sys_route_action());
+    builder.append(vpc_notify_rpw_action());
+
+    Ok(builder.build()?)
+}
+
+#[derive(Debug)]
+pub(crate) struct SagaVpcSubnetDelete;
+impl NexusSaga for SagaVpcSubnetDelete {
+    const NAME: &'static str = "vpc-subnet-delete";
+    type Params = Params;
+
+    fn register_actions(registry: &mut ActionRegistry) {
+        vpc_subnet_delete_register_actions(registry);
+    }
+
+    fn make_saga_dag(
+        _params: &Self::Params,
+        builder: steno::DagBuilder,
+    ) -> Result<steno::Dag, super::SagaInitError> {
+        create_dag(builder)
+    }
+}
+
+// vpc subnet delete saga: action implementations
+
+async fn svsd_delete_subnet(
+    sagactx: NexusActionContext,
+) -> Result<(), ActionError> {
+    let osagactx = sagactx.user_data();
+    let params = sagactx.saga_params::<Params>()?;
+    let opctx = crate::context::op_context_for_saga_action(
+        &sagactx,
+        &params.serialized_authn,
+    );
+
+    osagactx
+        .datastore()
+        .vpc_delete_subnet(&opctx, &params.db_subnet, &params.authz_subnet)
+        .await
+        .map_err(ActionError::action_failed)
+}
+
+async fn svsd_delete_route(
+    sagactx: NexusActionContext,
+) -> Result<(), ActionError> {
+    let osagactx = sagactx.user_data();
+    let params = sagactx.saga_params::<Params>()?;
+    let opctx = crate::context::op_context_for_saga_action(
+        &sagactx,
+        &params.serialized_authn,
+    );
+
+    osagactx
+        .datastore()
+        .vpc_delete_subnet_route(&opctx, &params.authz_subnet)
+        .await
+        .map_err(ActionError::action_failed)
+}
+
+async fn svsd_notify_rpw(
+    sagactx: NexusActionContext,
+) -> Result<(), ActionError> {
+    let osagactx = sagactx.user_data();
+    let params = sagactx.saga_params::<Params>()?;
+    let opctx = crate::context::op_context_for_saga_action(
+        &sagactx,
+        &params.serialized_authn,
+    );
+
+    osagactx
+        .datastore()
+        .vpc_increment_rpw_version(&opctx, params.authz_vpc.id())
+        .await
+        .map_err(ActionError::action_failed)
+}
+
+#[cfg(test)]
+pub(crate) mod test {
+    use crate::{
+        app::sagas::vpc_create::Params, app::sagas::vpc_create::SagaVpcCreate,
+        external_api::params,
+    };
+    use async_bb8_diesel::AsyncRunQueryDsl;
+    use diesel::{
+        ExpressionMethods, OptionalExtension, QueryDsl, SelectableHelper,
+    };
+    use dropshot::test_util::ClientTestContext;
+    use nexus_db_queries::db::fixed_data::vpc::SERVICES_INTERNET_GATEWAY_ID;
+    use nexus_db_queries::{
+        authn::saga::Serialized, authz, context::OpContext,
+        db::datastore::DataStore, db::fixed_data::vpc::SERVICES_VPC_ID,
+        db::lookup::LookupPath,
+    };
+    use nexus_test_utils::resource_helpers::create_default_ip_pool;
+    use nexus_test_utils::resource_helpers::create_project;
+    use nexus_test_utils_macros::nexus_test;
+    use omicron_common::api::external::IdentityMetadataCreateParams;
+    use omicron_common::api::external::Name;
+    use omicron_common::api::external::NameOrId;
+    use uuid::Uuid;
+
+    type ControlPlaneTestContext =
+        nexus_test_utils::ControlPlaneTestContext<crate::Server>;
+
+    const PROJECT_NAME: &str = "springfield-squidport";
+
+    async fn create_org_and_project(client: &ClientTestContext) -> Uuid {
+        create_default_ip_pool(&client).await;
+        let project = create_project(client, PROJECT_NAME).await;
+        project.identity.id
+    }
+
+    // Helper for creating VPC create parameters
+    fn new_test_params(
+        opctx: &OpContext,
+        authz_project: authz::Project,
+    ) -> Params {
+        Params {
+            serialized_authn: Serialized::for_opctx(opctx),
+            vpc_create: params::VpcCreate {
+                identity: IdentityMetadataCreateParams {
+                    name: "my-vpc".parse().unwrap(),
+                    description: "My VPC".to_string(),
+                },
+                ipv6_prefix: None,
+                dns_name: "abc".parse().unwrap(),
+            },
+            authz_project,
+        }
+    }
+
+    fn test_opctx(cptestctx: &ControlPlaneTestContext) -> OpContext {
+        OpContext::for_tests(
+            cptestctx.logctx.log.new(o!()),
+            cptestctx.server.server_context().nexus.datastore().clone(),
+        )
+    }
+
+    async fn get_authz_project(
+        cptestctx: &ControlPlaneTestContext,
+        project_id: Uuid,
+        action: authz::Action,
+    ) -> authz::Project {
+        let nexus = &cptestctx.server.server_context().nexus;
+        let project_selector =
+            params::ProjectSelector { project: NameOrId::Id(project_id) };
+        let opctx = test_opctx(&cptestctx);
+        let (.., authz_project) = nexus
+            .project_lookup(&opctx, project_selector)
+            .expect("Invalid parameters constructing project lookup")
+            .lookup_for(action)
+            .await
+            .expect("Project does not exist");
+        authz_project
+    }
+
+    async fn delete_project_vpc_defaults(
+        cptestctx: &ControlPlaneTestContext,
+        project_id: Uuid,
+    ) {
+        let opctx = test_opctx(&cptestctx);
+        let datastore = cptestctx.server.server_context().nexus.datastore();
+        let default_name = Name::try_from("default".to_string()).unwrap();
+        let system_name = Name::try_from("system".to_string()).unwrap();
+
+        // Default Subnet
+        let (.., authz_subnet, subnet) = LookupPath::new(&opctx, &datastore)
+            .project_id(project_id)
+            .vpc_name(&default_name.clone().into())
+            .vpc_subnet_name(&default_name.clone().into())
+            .fetch()
+            .await
+            .expect("Failed to fetch default Subnet");
+        datastore
+            .vpc_delete_subnet(&opctx, &subnet, &authz_subnet)
+            .await
+            .expect("Failed to delete default Subnet");
+
+        // Default gateway routes
+        let (.., authz_route, _route) = LookupPath::new(&opctx, &datastore)
+            .project_id(project_id)
+            .vpc_name(&default_name.clone().into())
+            .vpc_router_name(&system_name.clone().into())
+            .router_route_name(&"default-v4".parse::<Name>().unwrap().into())
+            .fetch()
+            .await
+            .expect("Failed to fetch default route");
+        datastore
+            .router_delete_route(&opctx, &authz_route)
+            .await
+            .expect("Failed to delete default route");
+
+        let (.., authz_route, _route) = LookupPath::new(&opctx, &datastore)
+            .project_id(project_id)
+            .vpc_name(&default_name.clone().into())
+            .vpc_router_name(&system_name.clone().into())
+            .router_route_name(&"default-v6".parse::<Name>().unwrap().into())
+            .fetch()
+            .await
+            .expect("Failed to fetch default route");
+        datastore
+            .router_delete_route(&opctx, &authz_route)
+            .await
+            .expect("Failed to delete default route");
+
+        // System router
+        let (.., authz_router, _router) = LookupPath::new(&opctx, &datastore)
+            .project_id(project_id)
+            .vpc_name(&default_name.clone().into())
+            .vpc_router_name(&system_name.into())
+            .fetch()
+            .await
+            .expect("Failed to fetch system router");
+        datastore
+            .vpc_delete_router(&opctx, &authz_router)
+            .await
+            .expect("Failed to delete system router");
+
+        // Default gateway
+        let (.., authz_vpc, authz_igw, _igw) =
+            LookupPath::new(&opctx, &datastore)
+                .project_id(project_id)
+                .vpc_name(&default_name.clone().into())
+                .internet_gateway_name(&default_name.clone().into())
+                .fetch()
+                .await
+                .expect("Failed to fetch default gateway");
+        datastore
+            .vpc_delete_internet_gateway(
+                &opctx,
+                &authz_igw,
+                authz_vpc.id(),
+                true,
+            )
+            .await
+            .expect("Failed to delete default gateway");
+
+        // Default VPC & Firewall Rules
+        let (.., authz_vpc, vpc) = LookupPath::new(&opctx, &datastore)
+            .project_id(project_id)
+            .vpc_name(&default_name.into())
+            .fetch()
+            .await
+            .expect("Failed to fetch default VPC");
+        datastore
+            .vpc_delete_all_firewall_rules(&opctx, &authz_vpc)
+            .await
+            .expect("Failed to delete all firewall rules for VPC");
+        datastore
+            .project_delete_vpc(&opctx, &vpc, &authz_vpc)
+            .await
+            .expect("Failed to delete VPC");
+    }
+
+    pub(crate) async fn verify_clean_slate(datastore: &DataStore) {
+        assert!(no_vpcs_exist(datastore).await);
+        assert!(no_routers_exist(datastore).await);
+        assert!(no_routes_exist(datastore).await);
+        assert!(no_subnets_exist(datastore).await);
+        assert!(no_gateways_exist(datastore).await);
+        assert!(no_gateway_links_exist(datastore).await);
+        assert!(no_firewall_rules_exist(datastore).await);
+    }
+
+    async fn no_vpcs_exist(datastore: &DataStore) -> bool {
+        use nexus_db_queries::db::model::Vpc;
+        use nexus_db_queries::db::schema::vpc::dsl;
+
+        dsl::vpc
+            .filter(dsl::time_deleted.is_null())
+            // ignore built-in services VPC
+            .filter(dsl::id.ne(*SERVICES_VPC_ID))
+            .select(Vpc::as_select())
+            .first_async::<Vpc>(
+                &*datastore.pool_connection_for_tests().await.unwrap(),
+            )
+            .await
+            .optional()
+            .unwrap()
+            .map(|vpc| {
+                eprintln!("VPC exists: {vpc:?}");
+            })
+            .is_none()
+    }
+
+    async fn no_routers_exist(datastore: &DataStore) -> bool {
+        use nexus_db_queries::db::model::VpcRouter;
+        use nexus_db_queries::db::schema::vpc_router::dsl;
+
+        dsl::vpc_router
+            .filter(dsl::time_deleted.is_null())
+            // ignore built-in services VPC
+            .filter(dsl::vpc_id.ne(*SERVICES_VPC_ID))
+            .select(VpcRouter::as_select())
+            .first_async::<VpcRouter>(
+                &*datastore.pool_connection_for_tests().await.unwrap(),
+            )
+            .await
+            .optional()
+            .unwrap()
+            .map(|router| {
+                eprintln!("Router exists: {router:?}");
+            })
+            .is_none()
+    }
+
+    async fn no_gateways_exist(datastore: &DataStore) -> bool {
+        use nexus_db_queries::db::model::InternetGateway;
+        use nexus_db_queries::db::schema::internet_gateway::dsl;
+
+        dsl::internet_gateway
+            .filter(dsl::time_deleted.is_null())
+            // ignore built-in services VPC
+            .filter(dsl::vpc_id.ne(*SERVICES_VPC_ID))
+            .select(InternetGateway::as_select())
+            .first_async::<InternetGateway>(
+                &*datastore.pool_connection_for_tests().await.unwrap(),
+            )
+            .await
+            .optional()
+            .unwrap()
+            .map(|igw| {
+                eprintln!("Internet gateway exists: {igw:?}");
+            })
+            .is_none()
+    }
+
+    async fn no_gateway_links_exist(datastore: &DataStore) -> bool {
+        use nexus_db_queries::db::model::InternetGatewayIpPool;
+        use nexus_db_queries::db::schema::internet_gateway_ip_pool::dsl;
+
+        dsl::internet_gateway_ip_pool
+            .filter(dsl::time_deleted.is_null())
+            .filter(dsl::internet_gateway_id.ne(*SERVICES_INTERNET_GATEWAY_ID))
+            .select(InternetGatewayIpPool::as_select())
+            .first_async::<InternetGatewayIpPool>(
+                &*datastore.pool_connection_for_tests().await.unwrap(),
+            )
+            .await
+            .optional()
+            .unwrap()
+            .map(|igw_ip_pool| {
+                eprintln!(
+                    "Internet gateway ip pool links exists: {igw_ip_pool:?}"
+                );
+            })
+            .is_none()
+    }
+
+    async fn no_routes_exist(datastore: &DataStore) -> bool {
+        use nexus_db_queries::db::model::RouterRoute;
+        use nexus_db_queries::db::schema::router_route::dsl;
+        use nexus_db_queries::db::schema::vpc_router::dsl as vpc_router_dsl;
+
+        dsl::router_route
+            .filter(dsl::time_deleted.is_null())
+            // ignore built-in services VPC
+            .filter(
+                dsl::vpc_router_id.ne_all(
+                    vpc_router_dsl::vpc_router
+                        .select(vpc_router_dsl::id)
+                        .filter(vpc_router_dsl::vpc_id.eq(*SERVICES_VPC_ID))
+                        .filter(vpc_router_dsl::time_deleted.is_null()),
+                ),
+            )
+            .select(RouterRoute::as_select())
+            .first_async::<RouterRoute>(
+                &*datastore.pool_connection_for_tests().await.unwrap(),
+            )
+            .await
+            .optional()
+            .unwrap()
+            .map(|route| {
+                eprintln!("Route exists: {route:?}");
+            })
+            .is_none()
+    }
+
+    async fn no_subnets_exist(datastore: &DataStore) -> bool {
+        use nexus_db_queries::db::model::VpcSubnet;
+        use nexus_db_queries::db::schema::vpc_subnet::dsl;
+
+        dsl::vpc_subnet
+            .filter(dsl::time_deleted.is_null())
+            // ignore built-in services VPC
+            .filter(dsl::vpc_id.ne(*SERVICES_VPC_ID))
+            .select(VpcSubnet::as_select())
+            .first_async::<VpcSubnet>(
+                &*datastore.pool_connection_for_tests().await.unwrap(),
+            )
+            .await
+            .optional()
+            .unwrap()
+            .map(|subnet| {
+                eprintln!("Subnet exists: {subnet:?}");
+            })
+            .is_none()
+    }
+
+    async fn no_firewall_rules_exist(datastore: &DataStore) -> bool {
+        use nexus_db_queries::db::model::VpcFirewallRule;
+        use nexus_db_queries::db::schema::vpc_firewall_rule::dsl;
+
+        dsl::vpc_firewall_rule
+            .filter(dsl::time_deleted.is_null())
+            // ignore built-in services VPC
+            .filter(dsl::vpc_id.ne(*SERVICES_VPC_ID))
+            .select(VpcFirewallRule::as_select())
+            .first_async::<VpcFirewallRule>(
+                &*datastore.pool_connection_for_tests().await.unwrap(),
+            )
+            .await
+            .optional()
+            .unwrap()
+            .map(|rule| {
+                eprintln!("Firewall rule exists: {rule:?}");
+            })
+            .is_none()
+    }
+
+    #[nexus_test(server = crate::Server)]
+    async fn test_saga_basic_usage_succeeds(
+        cptestctx: &ControlPlaneTestContext,
+    ) {
+        let client = &cptestctx.external_client;
+        let nexus = &cptestctx.server.server_context().nexus;
+        let project_id = create_org_and_project(&client).await;
+        delete_project_vpc_defaults(&cptestctx, project_id).await;
+
+        // Before running the test, confirm we have no records of any VPCs.
+        verify_clean_slate(nexus.datastore()).await;
+
+        // Build the saga DAG with the provided test parameters
+        let opctx = test_opctx(&cptestctx);
+        let authz_project = get_authz_project(
+            &cptestctx,
+            project_id,
+            authz::Action::CreateChild,
+        )
+        .await;
+        let params = new_test_params(&opctx, authz_project);
+        nexus.sagas.saga_execute::<SagaVpcCreate>(params).await.unwrap();
+    }
+
+    #[nexus_test(server = crate::Server)]
+    async fn test_action_failure_can_unwind(
+        cptestctx: &ControlPlaneTestContext,
+    ) {
+        let log = &cptestctx.logctx.log;
+
+        let client = &cptestctx.external_client;
+        let nexus = &cptestctx.server.server_context().nexus;
+        let project_id = create_org_and_project(&client).await;
+        delete_project_vpc_defaults(&cptestctx, project_id).await;
+
+        let opctx = test_opctx(&cptestctx);
+        crate::app::sagas::test_helpers::action_failure_can_unwind::<
+            SagaVpcCreate,
+            _,
+            _,
+        >(
+            nexus,
+            || {
+                Box::pin(async {
+                    new_test_params(
+                        &opctx,
+                        get_authz_project(
+                            &cptestctx,
+                            project_id,
+                            authz::Action::CreateChild,
+                        )
+                        .await,
+                    )
+                })
+            },
+            || {
+                Box::pin(async {
+                    verify_clean_slate(nexus.datastore()).await;
+                })
+            },
+            log,
+        )
+        .await;
+    }
+}

--- a/nexus/src/app/sagas/vpc_subnet_update.rs
+++ b/nexus/src/app/sagas/vpc_subnet_update.rs
@@ -1,0 +1,217 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at https://mozilla.org/MPL/2.0/.
+
+use super::ActionRegistry;
+use super::NexusActionContext;
+use super::NexusSaga;
+use crate::app::sagas::declare_saga_actions;
+use nexus_db_model::VpcSubnet;
+use nexus_db_queries::{authn, authz, db};
+use serde::Deserialize;
+use serde::Serialize;
+use steno::ActionError;
+
+// vpc subnet update saga: input parameters
+
+#[derive(Debug, Deserialize, Serialize)]
+pub(crate) struct Params {
+    pub serialized_authn: authn::saga::Serialized,
+    pub authz_vpc: authz::Vpc,
+    pub authz_subnet: authz::VpcSubnet,
+    pub custom_router: Option<authz::VpcRouter>,
+    pub update: db::model::VpcSubnetUpdate,
+}
+
+// vpc subnet update saga: actions
+
+declare_saga_actions! {
+    vpc_subnet_update;
+    VPC_SUBNET_UPDATE -> "output" {
+        + svsu_do_update
+    }
+    VPC_NOTIFY_RPW -> "no_result" {
+        + svsu_notify_rpw
+    }
+}
+
+// vpc subnet update saga: definition
+
+#[derive(Debug)]
+pub(crate) struct SagaVpcSubnetUpdate;
+impl NexusSaga for SagaVpcSubnetUpdate {
+    const NAME: &'static str = "vpc-subnet-update";
+    type Params = Params;
+
+    fn register_actions(registry: &mut ActionRegistry) {
+        vpc_subnet_update_register_actions(registry);
+    }
+
+    fn make_saga_dag(
+        _params: &Self::Params,
+        mut builder: steno::DagBuilder,
+    ) -> Result<steno::Dag, super::SagaInitError> {
+        builder.append(vpc_subnet_update_action());
+        builder.append(vpc_notify_rpw_action());
+
+        Ok(builder.build()?)
+    }
+}
+
+// vpc subnet update saga: action implementations
+
+async fn svsu_do_update(
+    sagactx: NexusActionContext,
+) -> Result<VpcSubnet, ActionError> {
+    let osagactx = sagactx.user_data();
+    let Params {
+        serialized_authn, authz_subnet, custom_router, update, ..
+    } = sagactx.saga_params::<Params>()?;
+    let opctx =
+        crate::context::op_context_for_saga_action(&sagactx, &serialized_authn);
+
+    osagactx
+        .datastore()
+        .vpc_update_subnet(
+            &opctx,
+            &authz_subnet,
+            custom_router.as_ref(),
+            update,
+        )
+        .await
+        .map_err(ActionError::action_failed)
+}
+
+async fn svsu_notify_rpw(
+    sagactx: NexusActionContext,
+) -> Result<(), ActionError> {
+    let osagactx = sagactx.user_data();
+    let params = sagactx.saga_params::<Params>()?;
+    let opctx = crate::context::op_context_for_saga_action(
+        &sagactx,
+        &params.serialized_authn,
+    );
+
+    osagactx
+        .datastore()
+        .vpc_increment_rpw_version(&opctx, params.authz_vpc.id())
+        .await
+        .map_err(ActionError::action_failed)
+}
+
+#[cfg(test)]
+pub(crate) mod test {
+    use crate::app::saga::create_saga_dag;
+    use crate::app::sagas::test_helpers;
+    use crate::{
+        app::sagas::vpc_subnet_update::Params,
+        app::sagas::vpc_subnet_update::SagaVpcSubnetUpdate,
+        external_api::params,
+    };
+    use chrono::Utc;
+    use dropshot::test_util::ClientTestContext;
+    use nexus_db_queries::db;
+    use nexus_db_queries::{authn::saga::Serialized, context::OpContext};
+    use nexus_test_utils::resource_helpers::create_default_ip_pool;
+    use nexus_test_utils::resource_helpers::create_project;
+    use nexus_test_utils::resource_helpers::create_router;
+    use nexus_test_utils_macros::nexus_test;
+    use omicron_common::api::external::NameOrId;
+    use uuid::Uuid;
+
+    type ControlPlaneTestContext =
+        nexus_test_utils::ControlPlaneTestContext<crate::Server>;
+
+    const PROJECT_NAME: &str = "springfield-squidport";
+    const ROUTER_NAME: &str = "test-router";
+
+    async fn create_org_and_project(
+        client: &ClientTestContext,
+    ) -> (Uuid, Uuid) {
+        create_default_ip_pool(&client).await;
+        let project = create_project(client, PROJECT_NAME).await;
+        let router =
+            create_router(client, PROJECT_NAME, "default", ROUTER_NAME).await;
+        (project.identity.id, router.identity.id)
+    }
+
+    fn test_opctx(cptestctx: &ControlPlaneTestContext) -> OpContext {
+        OpContext::for_tests(
+            cptestctx.logctx.log.new(o!()),
+            cptestctx.server.server_context().nexus.datastore().clone(),
+        )
+    }
+
+    async fn new_test_params(
+        cptestctx: &ControlPlaneTestContext,
+        project_id: Uuid,
+        router_id: Uuid,
+    ) -> Params {
+        let nexus = &cptestctx.server.server_context().nexus;
+        let opctx = test_opctx(&cptestctx);
+        let (.., authz_vpc, authz_subnet, _) = nexus
+            .vpc_subnet_lookup(
+                &opctx,
+                params::SubnetSelector {
+                    project: Some(project_id.into()),
+                    vpc: Some(NameOrId::Name("default".parse().unwrap())),
+                    subnet: NameOrId::Name("default".parse().unwrap()),
+                },
+            )
+            .unwrap()
+            .fetch()
+            .await
+            .unwrap();
+
+        let (.., custom_router, _) = nexus
+            .vpc_router_lookup(
+                &opctx,
+                params::RouterSelector {
+                    project: None,
+                    vpc: None,
+                    router: NameOrId::Id(router_id),
+                },
+            )
+            .unwrap()
+            .fetch()
+            .await
+            .unwrap();
+
+        Params {
+            serialized_authn: Serialized::for_opctx(&opctx),
+            authz_vpc,
+            authz_subnet,
+            custom_router: Some(custom_router),
+            update: db::model::VpcSubnetUpdate {
+                name: Some(db::model::Name("defaulter".parse().unwrap())),
+                description: None,
+                time_modified: Utc::now(),
+            },
+        }
+    }
+
+    #[nexus_test(server = crate::Server)]
+    async fn test_saga_basic_usage_succeeds(
+        cptestctx: &ControlPlaneTestContext,
+    ) {
+        let client = &cptestctx.external_client;
+        let nexus = &cptestctx.server.server_context().nexus;
+        let (project_id, router_id) = create_org_and_project(&client).await;
+
+        let params = new_test_params(cptestctx, project_id, router_id).await;
+        nexus.sagas.saga_execute::<SagaVpcSubnetUpdate>(params).await.unwrap();
+    }
+
+    #[nexus_test(server = crate::Server)]
+    async fn test_actions_succeed_idempotently(
+        cptestctx: &ControlPlaneTestContext,
+    ) {
+        let client = &cptestctx.external_client;
+        let nexus = &cptestctx.server.server_context().nexus;
+        let (project_id, router_id) = create_org_and_project(&client).await;
+
+        let params = new_test_params(cptestctx, project_id, router_id).await;
+        let dag = create_saga_dag::<SagaVpcSubnetUpdate>(params).unwrap();
+        test_helpers::actions_succeed_idempotently(nexus, dag).await;
+    }
+}

--- a/nexus/src/app/sagas/vpc_subnet_update.rs
+++ b/nexus/src/app/sagas/vpc_subnet_update.rs
@@ -186,6 +186,7 @@ pub(crate) mod test {
                 name: Some(db::model::Name("defaulter".parse().unwrap())),
                 description: None,
                 time_modified: Utc::now(),
+                custom_router_id: None,
             },
         }
     }

--- a/nexus/src/app/vpc_router.rs
+++ b/nexus/src/app/vpc_router.rs
@@ -67,6 +67,8 @@ impl super::Nexus {
         }
     }
 
+    /// Lookup a (custom) router for attaching to a VPC subnet, when
+    /// we have already determined which VPC the subnet exists within.
     pub(crate) async fn vpc_router_lookup_for_attach(
         &self,
         opctx: &OpContext,
@@ -96,7 +98,8 @@ impl super::Nexus {
 
         if vpc.id() != authz_vpc.id() {
             return Err(Error::invalid_request(
-                "router and subnet must belong to the same VPC",
+                "a router can only be attached to a subnet when both \
+                belong to the same VPC",
             ));
         }
 

--- a/nexus/src/app/vpc_router.rs
+++ b/nexus/src/app/vpc_router.rs
@@ -67,6 +67,42 @@ impl super::Nexus {
         }
     }
 
+    pub(crate) async fn vpc_router_lookup_for_attach(
+        &self,
+        opctx: &OpContext,
+        router: &NameOrId,
+        authz_vpc: &authz::Vpc,
+    ) -> LookupResult<authz::VpcRouter> {
+        let (.., vpc, rtr) = (match router {
+            key @ NameOrId::Name(_) => self.vpc_router_lookup(
+                opctx,
+                params::RouterSelector {
+                    project: None,
+                    vpc: Some(NameOrId::Id(authz_vpc.id())),
+                    router: key.clone(),
+                },
+            )?,
+            key @ NameOrId::Id(_) => self.vpc_router_lookup(
+                opctx,
+                params::RouterSelector {
+                    project: None,
+                    vpc: None,
+                    router: key.clone(),
+                },
+            )?,
+        })
+        .lookup_for(authz::Action::Read)
+        .await?;
+
+        if vpc.id() != authz_vpc.id() {
+            return Err(Error::invalid_request(
+                "router and subnet must belong to the same VPC",
+            ));
+        }
+
+        Ok(rtr)
+    }
+
     pub(crate) async fn vpc_create_router(
         &self,
         opctx: &OpContext,

--- a/nexus/src/app/vpc_subnet.rs
+++ b/nexus/src/app/vpc_subnet.rs
@@ -114,7 +114,8 @@ impl super::Nexus {
         // TODO-robustness: We'd really prefer to allocate deterministically.
         // See <https://github.com/oxidecomputer/omicron/issues/685> for
         // details.
-        let ipv6_blocks = if let Some(ipv6_block) = params.ipv6_block {
+        let potential_ipv6_blocks = if let Some(ipv6_block) = params.ipv6_block
+        {
             if !ipv6_block.is_vpc_subnet(&db_vpc.ipv6_prefix) {
                 return Err(external::Error::invalid_request(&format!(
                     "VPC Subnet IPv6 address range '{}' is not valid for \
@@ -145,7 +146,7 @@ impl super::Nexus {
         let saga_params = sagas::vpc_subnet_create::Params {
             serialized_authn: authn::saga::Serialized::for_opctx(opctx),
             subnet_create: params.clone(),
-            ipv6_blocks,
+            potential_ipv6_blocks,
             custom_router,
             authz_vpc,
             authz_system_router,

--- a/nexus/src/app/vpc_subnet.rs
+++ b/nexus/src/app/vpc_subnet.rs
@@ -162,7 +162,7 @@ impl super::Nexus {
         let out = saga_outputs
             .lookup_node_output::<VpcSubnet>("output")
             .map_err(|e| Error::internal_error(&format!("{:#}", &e)))
-            .internal_context("looking up output from ip attach saga")?;
+            .internal_context("looking up output from vpc create saga")?;
 
         self.vpc_needed_notify_sleds();
 
@@ -214,7 +214,7 @@ impl super::Nexus {
         let out = saga_outputs
             .lookup_node_output::<VpcSubnet>("output")
             .map_err(|e| Error::internal_error(&format!("{:#}", &e)))
-            .internal_context("looking up output from ip attach saga")?;
+            .internal_context("looking up output from vpc update saga")?;
 
         self.vpc_needed_notify_sleds();
 

--- a/nexus/src/app/vpc_subnet.rs
+++ b/nexus/src/app/vpc_subnet.rs
@@ -4,6 +4,7 @@
 
 //! VPC Subnets and their network interfaces
 
+use super::sagas;
 use crate::external_api::params;
 use nexus_auth::authn;
 use nexus_config::MIN_VPC_IPV4_SUBNET_PREFIX;
@@ -24,8 +25,6 @@ use omicron_common::api::external::ListResultVec;
 use omicron_common::api::external::LookupResult;
 use omicron_common::api::external::NameOrId;
 use omicron_common::api::external::UpdateResult;
-
-use super::sagas;
 
 impl super::Nexus {
     pub fn vpc_subnet_lookup<'a>(

--- a/nexus/src/app/vpc_subnet.rs
+++ b/nexus/src/app/vpc_subnet.rs
@@ -121,10 +121,8 @@ impl super::Nexus {
                 > self.tunables.max_vpc_ipv4_subnet_prefix
         {
             return Err(external::Error::invalid_request(&format!(
-                concat!(
-                    "VPC Subnet IPv4 address ranges must have prefix ",
-                    "length between {} and {}, inclusive"
-                ),
+                "VPC Subnet IPv4 address ranges must have prefix \
+                length between {} and {}, inclusive",
                 MIN_VPC_IPV4_SUBNET_PREFIX,
                 self.tunables.max_vpc_ipv4_subnet_prefix,
             )));

--- a/nexus/tests/integration_tests/vpc_routers.rs
+++ b/nexus/tests/integration_tests/vpc_routers.rs
@@ -413,7 +413,10 @@ async fn test_vpc_routers_attach_to_subnet(
         StatusCode::BAD_REQUEST,
     )
     .await;
-    assert_eq!(err.message, "router and subnet must belong to the same VPC");
+    assert_eq!(
+        err.message,
+        "a router can only be attached to a subnet when both belong to the same VPC"
+    );
 
     // Detach (and double detach) should succeed without issue.
     let subnet3 = set_custom_router(client, subnet3_name, VPC_NAME, None).await;

--- a/schema/crdb/dbinit.sql
+++ b/schema/crdb/dbinit.sql
@@ -1849,8 +1849,7 @@ CREATE TABLE IF NOT EXISTS omicron.public.router_route (
      * linked item. Today, these are 'vpc_subnet' rules and their parent subnets.
      * 'vpc_peering' routes may also fall into this category in future.
      *
-     * User-created/modifiable routes must have this field as NULL -- none of their fields
-     * are a fiction maintained by Nexus.
+     * User-created/modifiable routes must have this field as NULL.
      */
     CONSTRAINT non_null_vpc_subnet CHECK (
         (kind = 'vpc_subnet' AND vpc_subnet_id IS NOT NULL) OR

--- a/schema/crdb/dbinit.sql
+++ b/schema/crdb/dbinit.sql
@@ -1839,7 +1839,23 @@ CREATE TABLE IF NOT EXISTS omicron.public.router_route (
     vpc_router_id UUID NOT NULL,
     kind omicron.public.router_route_kind NOT NULL,
     target STRING(128) NOT NULL,
-    destination STRING(128) NOT NULL
+    destination STRING(128) NOT NULL,
+
+    /* FK to the `vpc_subnet` table. See constraints below */
+    vpc_subnet_id UUID,
+
+    /*
+     * Only nullable if this is rule is not, in-fact, virtual and tightly coupled to a
+     * linked item. Today, these are 'vpc_subnet' rules and their parent subnets.
+     * 'vpc_peering' routes may also fall into this category in future.
+     *
+     * User-created/modifiable routes must have this field as NULL -- none of their fields
+     * are a fiction maintained by Nexus.
+     */
+    CONSTRAINT non_null_vpc_subnet CHECK (
+        (kind = 'vpc_subnet' AND vpc_subnet_id IS NOT NULL) OR
+        (kind != 'vpc_subnet' AND vpc_subnet_id IS NULL)
+    )
 );
 
 CREATE UNIQUE INDEX IF NOT EXISTS lookup_route_by_router ON omicron.public.router_route (
@@ -1847,6 +1863,12 @@ CREATE UNIQUE INDEX IF NOT EXISTS lookup_route_by_router ON omicron.public.route
     name
 ) WHERE
     time_deleted IS NULL;
+
+-- Enforce uniqueness of 'vpc_subnet' routes on parent (and help add/delete).
+CREATE UNIQUE INDEX IF NOT EXISTS lookup_subnet_route_by_id ON omicron.public.router_route (
+    vpc_subnet_id
+) WHERE
+    time_deleted IS NULL AND kind = 'vpc_subnet';
 
 CREATE TABLE IF NOT EXISTS omicron.public.internet_gateway (
     id UUID PRIMARY KEY,
@@ -4810,7 +4832,7 @@ INSERT INTO omicron.public.db_metadata (
     version,
     target_version
 ) VALUES
-    (TRUE, NOW(), NOW(), '122.0.0', NULL)
+    (TRUE, NOW(), NOW(), '123.0.0', NULL)
 ON CONFLICT DO NOTHING;
 
 COMMIT;

--- a/schema/crdb/vpc-subnet-contention/up01.sql
+++ b/schema/crdb/vpc-subnet-contention/up01.sql
@@ -1,0 +1,3 @@
+-- Add an FK to `vpc_subnet` for `vpc_subnet` routes.
+ALTER TABLE omicron.public.router_route
+ADD COLUMN IF NOT EXISTS vpc_subnet_id UUID;

--- a/schema/crdb/vpc-subnet-contention/up02.sql
+++ b/schema/crdb/vpc-subnet-contention/up02.sql
@@ -1,1 +1,80 @@
--- TODO: MIGRATION
+set local disallow_full_table_scans = off;
+
+-- Remove all exisiting VPC Subnet routes.
+-- These are fully managed by nexus, so no user state is at
+-- risk of being lost.
+DELETE FROM omicron.public.router_route
+WHERE router_route.kind = 'vpc_subnet';
+
+-- Insert subnet routes for every defined VPC subnet.
+-- Do this first for the majority of routes...
+INSERT INTO omicron.public.router_route
+    (
+        id, name,
+        description,
+        time_created, time_modified,
+        vpc_router_id, kind,
+        target, destination,
+        vpc_subnet_id
+    )
+SELECT
+    gen_random_uuid(), vpc_subnet.name,
+    'System-managed VPC Subnet route.',
+    now(), now(),
+    omicron.public.vpc_router.id, 'vpc_subnet',
+    'subnet:' || vpc_subnet.name, 'subnet:' || vpc_subnet.name,
+    vpc_subnet.id
+FROM
+    (omicron.public.vpc_subnet JOIN omicron.public.vpc
+        ON vpc_subnet.vpc_id = vpc.id) JOIN omicron.public.vpc_router
+            ON vpc_router.vpc_id = vpc.id
+WHERE
+    vpc_subnet.name != 'default-v4' AND vpc_subnet.name != 'default-v6'
+ON CONFLICT DO NOTHING;
+
+-- ...and then revisit any data which has unfortunately
+-- titled their subnets 'default-v4' or 'default-v6'.
+INSERT INTO omicron.public.router_route
+    (
+        id,
+        name,
+        description,
+        time_created, time_modified,
+        vpc_router_id, kind,
+        target, destination,
+        vpc_subnet_id
+    )
+SELECT
+    gen_random_uuid(),
+    'conflict-' || vpc_subnet.name || '-' || gen_random_uuid(),
+    'System-managed VPC Subnet route.',
+    now(), now(),
+    omicron.public.vpc_router.id, 'vpc_subnet',
+    'subnet:' || vpc_subnet.name, 'subnet:' || vpc_subnet.name,
+    vpc_subnet.id
+FROM
+    (omicron.public.vpc_subnet JOIN omicron.public.vpc
+        ON vpc_subnet.vpc_id = vpc.id) JOIN omicron.public.vpc_router
+            ON vpc_router.vpc_id = vpc.id
+WHERE
+    vpc_subnet.name = 'default-v4' OR vpc_subnet.name = 'default-v6'
+ON CONFLICT DO NOTHING;
+
+-- Replace IDs of fixed_data VPC Subnet routes for the services VPC.
+WITH known_ids (new_id, new_name) AS (
+    VALUES
+        (
+            '001de000-c470-4000-8000-000000000004', 'external-dns'
+        ),
+        (
+            '001de000-c470-4000-8000-000000000005', 'nexus'
+        ),
+        (
+            '001de000-c470-4000-8000-000000000006', 'boundary-ntp'
+        )
+)
+UPDATE omicron.public.router_route
+SET
+    id = CAST(new_id AS UUID)
+FROM known_ids
+WHERE vpc_router_id = '001de000-074c-4000-8000-000000000001' AND new_name = router_route.name;

--- a/schema/crdb/vpc-subnet-contention/up02.sql
+++ b/schema/crdb/vpc-subnet-contention/up02.sql
@@ -1,6 +1,6 @@
 set local disallow_full_table_scans = off;
 
--- Remove all exisiting VPC Subnet routes.
+-- Remove all existing VPC Subnet routes.
 -- These are fully managed by nexus, so no user state is at
 -- risk of being lost.
 DELETE FROM omicron.public.router_route
@@ -27,8 +27,9 @@ SELECT
 FROM
     (omicron.public.vpc_subnet JOIN omicron.public.vpc
         ON vpc_subnet.vpc_id = vpc.id) JOIN omicron.public.vpc_router
-            ON vpc_router.vpc_id = vpc.id
+            ON (vpc_router.vpc_id = vpc.id AND vpc_router.id = vpc.system_router_id)
 WHERE
+    vpc_router.kind = 'system' AND
     vpc_subnet.name != 'default-v4' AND vpc_subnet.name != 'default-v6'
 ON CONFLICT DO NOTHING;
 
@@ -55,9 +56,10 @@ SELECT
 FROM
     (omicron.public.vpc_subnet JOIN omicron.public.vpc
         ON vpc_subnet.vpc_id = vpc.id) JOIN omicron.public.vpc_router
-            ON vpc_router.vpc_id = vpc.id
+            ON (vpc_router.vpc_id = vpc.id AND vpc_router.id = vpc.system_router_id)
 WHERE
-    vpc_subnet.name = 'default-v4' OR vpc_subnet.name = 'default-v6'
+    vpc_router.kind = 'system' AND
+    (vpc_subnet.name = 'default-v4' OR vpc_subnet.name = 'default-v6')
 ON CONFLICT DO NOTHING;
 
 -- Replace IDs of fixed_data VPC Subnet routes for the services VPC.

--- a/schema/crdb/vpc-subnet-contention/up02.sql
+++ b/schema/crdb/vpc-subnet-contention/up02.sql
@@ -1,0 +1,1 @@
+-- TODO: MIGRATION

--- a/schema/crdb/vpc-subnet-contention/up03.sql
+++ b/schema/crdb/vpc-subnet-contention/up03.sql
@@ -1,0 +1,6 @@
+-- Ensure 'vpc_subnet's are the only rules with FKs for now.
+ALTER TABLE omicron.public.router_route
+ADD CONSTRAINT IF NOT EXISTS non_null_vpc_subnet CHECK (
+    (kind = 'vpc_subnet' AND vpc_subnet_id IS NOT NULL) OR
+    (kind != 'vpc_subnet' AND vpc_subnet_id IS NULL)
+);

--- a/schema/crdb/vpc-subnet-contention/up04.sql
+++ b/schema/crdb/vpc-subnet-contention/up04.sql
@@ -1,0 +1,5 @@
+-- Enforce uniqueness of 'vpc_subnet' routes on parent (and help add/delete).
+CREATE UNIQUE INDEX IF NOT EXISTS lookup_subnet_route_by_id ON omicron.public.router_route (
+    vpc_subnet_id
+) WHERE
+    time_deleted IS NULL AND kind = 'vpc_subnet';


### PR DESCRIPTION
This PR reworks VPC subnet create/delete/rename so that they do not require an exhaustive reconcile procedure of the VPC system router managed in concert with their existence. This is instead handled using an explicit foreign key relationship back to the Subnet for this class of rule.

- [x] Recast VPC Subnet Create/Delete as sagas.
  * We had a bit of leeway before, where most subnet operations could fill in missing routes after the fact if a nexus were to crash in an awkward spot. We need to be more stringent now.
  - [x] Create saga
  - [x] Delete saga
  - [x] Modify saga
- [x] Write migration query to regenerate `VpcSubnet` router rules with correct linkage.
- [ ] Optimisation: fetch all subnets (paginated) in RPW for system routers.
  * Punting on this for now. See #7490 .

Closes #7404.