### PR TITLE
releng: allow pinning Helios

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -7245,6 +7245,19 @@ dependencies = [
 ]
 
 [[package]]
+name = "omicron-pins"
+version = "0.1.0"
+dependencies = [
+ "anyhow",
+ "camino",
+ "cargo_metadata",
+ "fs-err",
+ "omicron-workspace-hack",
+ "serde",
+ "toml_edit 0.22.22",
+]
+
+[[package]]
 name = "omicron-releng"
 version = "0.1.0"
 dependencies = [
@@ -7258,6 +7271,7 @@ dependencies = [
  "futures",
  "hex",
  "omicron-common",
+ "omicron-pins",
  "omicron-workspace-hack",
  "omicron-zone-package",
  "once_cell",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -41,6 +41,7 @@ members = [
     "dev-tools/openapi-manager",
     "dev-tools/openapi-manager/types",
     "dev-tools/oxlog",
+    "dev-tools/pins",
     "dev-tools/reconfigurator-cli",
     "dev-tools/releng",
     "dev-tools/xtask",
@@ -175,6 +176,7 @@ default-members = [
     "dev-tools/openapi-manager",
     "dev-tools/openapi-manager/types",
     "dev-tools/oxlog",
+    "dev-tools/pins",
     "dev-tools/reconfigurator-cli",
     "dev-tools/releng",
     # Do not include xtask in the list of default members, because this causes
@@ -503,6 +505,7 @@ omicron-nexus = { path = "nexus" }
 omicron-omdb = { path = "dev-tools/omdb" }
 omicron-package = { path = "package" }
 omicron-passwords = { path = "passwords" }
+omicron-pins = { path = "dev-tools/pins" }
 omicron-rpaths = { path = "rpaths" }
 omicron-sled-agent = { path = "sled-agent" }
 omicron-test-utils = { path = "test-utils" }

--- a/dev-tools/pins/Cargo.toml
+++ b/dev-tools/pins/Cargo.toml
@@ -1,0 +1,17 @@
+[package]
+name = "omicron-pins"
+version = "0.1.0"
+edition = "2021"
+license = "MPL-2.0"
+
+[dependencies]
+anyhow.workspace = true
+camino.workspace = true
+cargo_metadata.workspace = true
+fs-err.workspace = true
+omicron-workspace-hack.workspace = true
+serde.workspace = true
+toml_edit.workspace = true
+
+[lints]
+workspace = true

--- a/dev-tools/pins/src/lib.rs
+++ b/dev-tools/pins/src/lib.rs
@@ -7,11 +7,13 @@ use camino::Utf8Path;
 use serde::Deserialize;
 
 #[derive(Debug, Clone, Deserialize)]
+#[serde(deny_unknown_fields)]
 pub struct Pins {
     pub helios: Option<Helios>,
 }
 
 #[derive(Debug, Clone, Deserialize)]
+#[serde(deny_unknown_fields)]
 pub struct Helios {
     pub commit: String,
     pub incorporation: String,

--- a/dev-tools/pins/src/lib.rs
+++ b/dev-tools/pins/src/lib.rs
@@ -1,0 +1,36 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at https://mozilla.org/MPL/2.0/.
+
+use anyhow::{Context, Result};
+use camino::Utf8Path;
+use serde::Deserialize;
+
+#[derive(Debug, Clone, Deserialize)]
+pub struct Pins {
+    pub helios: Option<Helios>,
+}
+
+#[derive(Debug, Clone, Deserialize)]
+pub struct Helios {
+    pub commit: String,
+    pub incorporation: String,
+}
+
+impl Pins {
+    pub fn read() -> Result<Pins> {
+        let workspace_root = cargo_metadata::MetadataCommand::new()
+            .no_deps()
+            .exec()?
+            .workspace_root;
+        Pins::read_from_dir(&workspace_root)
+    }
+
+    pub fn read_from_dir(workspace_dir: &Utf8Path) -> Result<Pins> {
+        let pins_path = workspace_dir.join("tools").join("pins.toml");
+        let pins_text = fs_err::read(&pins_path)?;
+        let pins: Pins = toml_edit::de::from_slice(&pins_text)
+            .with_context(|| format!("while reading {pins_path}"))?;
+        Ok(pins)
+    }
+}

--- a/dev-tools/releng/Cargo.toml
+++ b/dev-tools/releng/Cargo.toml
@@ -15,6 +15,7 @@ fs-err = { workspace = true, features = ["tokio"] }
 futures.workspace = true
 hex.workspace = true
 omicron-common.workspace = true
+omicron-pins.workspace = true
 omicron-workspace-hack.workspace = true
 omicron-zone-package.workspace = true
 once_cell.workspace = true

--- a/dev-tools/releng/src/main.rs
+++ b/dev-tools/releng/src/main.rs
@@ -189,11 +189,11 @@ async fn main() -> Result<()> {
         .context("failed to change working directory to workspace root")?;
 
     // Determine the target directory.
-    let target_dir = cargo_metadata::MetadataCommand::new()
+    let metadata = cargo_metadata::MetadataCommand::new()
         .no_deps()
         .exec()
-        .context("failed to get cargo metadata")?
-        .target_directory;
+        .context("failed to get cargo metadata")?;
+    let target_dir = metadata.target_directory;
 
     // We build everything in Omicron with $CARGO, but we need to use the rustup
     // proxy for Cargo when outside Omicron.
@@ -208,6 +208,9 @@ async fn main() -> Result<()> {
             .context("$CARGO is not valid UTF-8")?,
         None => rustup_cargo.clone(),
     };
+
+    // Read pins.toml.
+    let pins = omicron_pins::Pins::read_from_dir(&metadata.workspace_root)?;
 
     let permits = Arc::new(Semaphore::new(
         std::thread::available_parallelism()
@@ -270,34 +273,66 @@ async fn main() -> Result<()> {
         }
     }
 
-    // Ensure the Helios checkout exists
-    if args.helios_dir.exists() {
+    // Ensure the Helios checkout exists. If the directory exists and is
+    // non-empty, check that the commit is correct.
+    if args.helios_dir.exists()
+        && fs::read_dir(&args.helios_dir).await?.next_entry().await?.is_some()
+    {
         if !args.ignore_helios_origin {
-            // check that our helios clone is up to date
-            Command::new(&args.git_bin)
-                .arg("-C")
-                .arg(&args.helios_dir)
-                .args(["fetch", "--no-write-fetch-head", "origin", "master"])
-                .ensure_success(&logger)
-                .await?;
-            let stdout = Command::new(&args.git_bin)
-                .arg("-C")
-                .arg(&args.helios_dir)
-                .args(["rev-parse", "HEAD", "origin/master"])
-                .ensure_stdout(&logger)
-                .await?;
-            let mut lines = stdout.lines();
-            let first =
-                lines.next().context("git-rev-parse output was empty")?;
-            if !lines.all(|line| line == first) {
-                error!(
-                    logger,
-                    "helios checkout at {0} is out-of-date; run \
-                    `git pull -C {0}`, or run omicron-releng with \
-                    --ignore-helios-origin or --helios-dir",
-                    shell_words::quote(args.helios_dir.as_str())
-                );
-                preflight_ok = false;
+            if let Some(helios) = &pins.helios {
+                let stdout = Command::new(&args.git_bin)
+                    .arg("-C")
+                    .arg(&args.helios_dir)
+                    .args(["rev-parse", "HEAD"])
+                    .ensure_stdout(&logger)
+                    .await?;
+                let line = stdout
+                    .lines()
+                    .next()
+                    .context("git-rev-parse output was empty")?;
+                if line != helios.commit {
+                    error!(
+                        logger,
+                        "helios checkout at {0} is not at pinned commit {1}; \
+                        checkout the correct commit, or run omicron-releng \
+                        with --ignore-helios-origin or --helios-dir",
+                        shell_words::quote(args.helios_dir.as_str()),
+                        shell_words::quote(&helios.commit),
+                    );
+                    preflight_ok = false;
+                }
+            } else {
+                // check that our helios clone is up to date
+                Command::new(&args.git_bin)
+                    .arg("-C")
+                    .arg(&args.helios_dir)
+                    .args([
+                        "fetch",
+                        "--no-write-fetch-head",
+                        "origin",
+                        "master",
+                    ])
+                    .ensure_success(&logger)
+                    .await?;
+                let stdout = Command::new(&args.git_bin)
+                    .arg("-C")
+                    .arg(&args.helios_dir)
+                    .args(["rev-parse", "HEAD", "origin/master"])
+                    .ensure_stdout(&logger)
+                    .await?;
+                let mut lines = stdout.lines();
+                let first =
+                    lines.next().context("git-rev-parse output was empty")?;
+                if !lines.all(|line| line == first) {
+                    error!(
+                        logger,
+                        "helios checkout at {0} is out-of-date; run \
+                        `git pull -C {0}`, or run omicron-releng with \
+                        --ignore-helios-origin or --helios-dir",
+                        shell_words::quote(args.helios_dir.as_str())
+                    );
+                    preflight_ok = false;
+                }
             }
         }
     } else {
@@ -307,14 +342,19 @@ async fn main() -> Result<()> {
             .arg(&args.helios_dir)
             .ensure_success(&logger)
             .await?;
+        if let Some(helios) = &pins.helios {
+            info!(
+                logger,
+                "checking out {} to {}", args.helios_dir, helios.commit,
+            );
+            Command::new(&args.git_bin)
+                .arg("-C")
+                .arg(&args.helios_dir)
+                .args(["checkout", &helios.commit])
+                .ensure_success(&logger)
+                .await?;
+        }
     }
-    // Record the branch and commit in the output
-    Command::new(&args.git_bin)
-        .arg("-C")
-        .arg(&args.helios_dir)
-        .args(["status", "--branch", "--porcelain=2"])
-        .ensure_success(&logger)
-        .await?;
 
     // Check that the omicron1 brand is installed
     if !Command::new("pkg")
@@ -362,6 +402,14 @@ async fn main() -> Result<()> {
     let tempdir = camino_tempfile::tempdir()
         .context("failed to create temporary directory")?;
     let mut jobs = Jobs::new(&logger, permits.clone(), &args.output_dir);
+
+    // Record the branch and commit of helios.git in the output
+    Command::new(&args.git_bin)
+        .arg("-C")
+        .arg(&args.helios_dir)
+        .args(["status", "--branch", "--porcelain=2"])
+        .ensure_success(&logger)
+        .await?;
 
     jobs.push_command(
         "helios-setup",
@@ -534,6 +582,14 @@ async fn main() -> Result<()> {
             )
             .env_remove("CARGO")
             .env_remove("RUSTUP_TOOLCHAIN");
+
+        if let Some(helios) = &pins.helios {
+            image_cmd = image_cmd.arg("-F").arg(format!(
+                "extra_packages+=\
+                /consolidation/oxide/omicron-release-incorporation@{}",
+                helios.incorporation
+            ));
+        }
 
         if !args.helios_local {
             image_cmd = image_cmd

--- a/tools/pins.toml
+++ b/tools/pins.toml
@@ -1,0 +1,4 @@
+# Helios should *not* be pinned except on release branches.
+#[helios]
+#commit = ""
+#incorporation = ""


### PR DESCRIPTION
Closes #7332.

This defines a new file, **tools/pins.toml**, and an associated dev-tools crate, **omicron-pins**, which is intended to eventually replace the various commit/checksum entries scattered across the tools directory. TOML is selected for its trivial Serde deserializability, Rust support for automatic editing of the file without destroying comments, and its built-in support in the Nix language, so we can easily continue supporting our download tools and the Nix development environment flake as we transition those pins over to pins.toml.

I expect `Pins::read_from_dir` will grow functionality for reading some commit refs from Cargo.toml or package-manifest.toml to avoid needing to update commits in several places where applicable. That is not relevant for Helios but will help for other tools we pin.