### PR TITLE
blueprint-builder: Don't drop decommissioned sleds out of `sled_state`

### DIFF
--- a/nexus/reconfigurator/blippy/src/checks.rs
+++ b/nexus/reconfigurator/blippy/src/checks.rs
@@ -1871,7 +1871,7 @@ mod tests {
 
         // remove sled 1 from blueprint_disks and blueprint_datasets; we
         // shouldn't need to use a second sled ID here, but for now we only
-        // expecte disks/datasets entries for active sleds, so blippy only
+        // expect disks/datasets entries for active sleds, so blippy only
         // checks disks/datasets if the sled is in `sled_state`
         blueprint
             .blueprint_disks

--- a/nexus/reconfigurator/planning/tests/output/planner_nonprovisionable_2_2a.txt
+++ b/nexus/reconfigurator/planning/tests/output/planner_nonprovisionable_2_2a.txt
@@ -185,7 +185,7 @@ to:   blueprint 9f71f5d3-a272-4382-9154-6ea2e171a6c6
 
  REMOVED SLEDS:
 
-  sled 68d24ac5-f341-49ea-a92a-0381b52ab387 (state was unknown):
+  sled 68d24ac5-f341-49ea-a92a-0381b52ab387 (was decommissioned):
 
     omicron zones from generation 2:
     ---------------------------------------------------------------------------------------------


### PR DESCRIPTION
This is one part working towards #7078 and #7309 (and a few related issues). We'd like to be able to send sled-agent a complete config containing its zones+datasets+disks, which means first we need to merge the separate maps in the blueprint together (and attach an overriding generation number on this combo sled config).

Before we can do _that_, we need to ensure that each of the four maps keyed by a sled ID in the blueprint (`sled_state`, `blueprint_zones`, `blueprint_disks`, `blueprint_datasets`) have matching sets of keys. Viewing `blueprint_zones` as the primary map, `BlueprintBuilder::build()` has three "let's match the existing behavior" spots that can _drop_ entries from the other three maps.

This PR removes one of those three, and ensures that any sled ID present in `blueprint_zones` is also present in `sled_state`. (Previously, we'd drop sleds from `sled_state` after decommissioning.)

Most of the PR bulk is adding new checks to blippy to look for inconsistencies between the four maps.