### PR TITLE
[omdb] Move `omdb db reconfigurator-save` to `omdb reconfigurator export`

### DIFF
--- a/dev-tools/omdb/src/bin/omdb/main.rs
+++ b/dev-tools/omdb/src/bin/omdb/main.rs
@@ -54,6 +54,7 @@ mod mgs;
 mod nexus;
 mod oximeter;
 mod oxql;
+mod reconfigurator;
 mod sled_agent;
 
 #[tokio::main]
@@ -72,6 +73,9 @@ async fn main() -> Result<(), anyhow::Error> {
         OmdbCommands::Nexus(nexus) => nexus.run_cmd(&args, &log).await,
         OmdbCommands::Oximeter(oximeter) => oximeter.run_cmd(&args, &log).await,
         OmdbCommands::Oxql(oxql) => oxql.run_cmd(&args, &log).await,
+        OmdbCommands::Reconfigurator(reconfig) => {
+            reconfig.run_cmd(&args, &log).await
+        }
         OmdbCommands::SledAgent(sled) => sled.run_cmd(&args, &log).await,
         OmdbCommands::CrucibleAgent(crucible) => crucible.run_cmd(&args).await,
     }
@@ -286,6 +290,8 @@ enum OmdbCommands {
     Oximeter(oximeter::OximeterArgs),
     /// Enter the Oximeter Query Language shell for interactive querying.
     Oxql(oxql::OxqlArgs),
+    /// Interact with the Reconfigurator system
+    Reconfigurator(reconfigurator::ReconfiguratorArgs),
     /// Debug a specific Sled
     SledAgent(sled_agent::SledAgentArgs),
 }

--- a/dev-tools/omdb/src/bin/omdb/reconfigurator.rs
+++ b/dev-tools/omdb/src/bin/omdb/reconfigurator.rs
@@ -1,0 +1,92 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at https://mozilla.org/MPL/2.0/.
+
+//! omdb commands that interact with Reconfigurator
+
+use crate::db::DbUrlOptions;
+use crate::Omdb;
+use anyhow::Context as _;
+use camino::Utf8PathBuf;
+use clap::Args;
+use clap::Subcommand;
+use nexus_db_queries::context::OpContext;
+use nexus_db_queries::db::DataStore;
+use slog::Logger;
+
+/// Arguments to the "omdb reconfigurator" subcommand
+#[derive(Debug, Args)]
+pub struct ReconfiguratorArgs {
+    /// URL of the database SQL interface
+    #[clap(flatten)]
+    db_url_opts: DbUrlOptions,
+
+    #[command(subcommand)]
+    command: ReconfiguratorCommands,
+}
+
+/// Subcommands for the "omdb reconfigurator" subcommand
+#[allow(clippy::large_enum_variant)]
+#[derive(Debug, Subcommand)]
+enum ReconfiguratorCommands {
+    /// Save the current Reconfigurator state to a file
+    Export(ExportArgs),
+}
+
+#[derive(Debug, Args, Clone)]
+struct ExportArgs {
+    /// where to save the output
+    output_file: Utf8PathBuf,
+}
+
+impl ReconfiguratorArgs {
+    /// Run a `omdb reconfigurator` subcommand.
+    pub(crate) async fn run_cmd(
+        &self,
+        omdb: &Omdb,
+        log: &Logger,
+    ) -> anyhow::Result<()> {
+        match &self.command {
+            ReconfiguratorCommands::Export(export_args) => {
+                self.db_url_opts
+                    .with_datastore(omdb, log, |opctx, datastore| async move {
+                        cmd_reconfigurator_export(
+                            &opctx,
+                            &datastore,
+                            export_args,
+                        )
+                        .await
+                    })
+                    .await?;
+            }
+        }
+        Ok(())
+    }
+}
+
+/// Packages up database state that's used as input to the Reconfigurator
+/// planner into a file so that it can be loaded into `reconfigurator-cli`
+async fn cmd_reconfigurator_export(
+    opctx: &OpContext,
+    datastore: &DataStore,
+    export_args: &ExportArgs,
+) -> anyhow::Result<()> {
+    // See Nexus::blueprint_planning_context().
+    eprint!("assembling reconfigurator state ... ");
+    let state = nexus_reconfigurator_preparation::reconfigurator_state_load(
+        opctx, datastore,
+    )
+    .await?;
+    eprintln!("done");
+
+    let output_path = &export_args.output_file;
+    let file = std::fs::OpenOptions::new()
+        .create_new(true)
+        .write(true)
+        .open(&output_path)
+        .with_context(|| format!("open {:?}", output_path))?;
+    serde_json::to_writer_pretty(&file, &state)
+        .with_context(|| format!("write {:?}", output_path))?;
+    eprintln!("wrote {}", output_path);
+    Ok(())
+}

--- a/dev-tools/omdb/tests/successes.out
+++ b/dev-tools/omdb/tests/successes.out
@@ -58,17 +58,6 @@ stderr:
 note: using database URL postgresql://root@[::1]:REDACTED_PORT/omicron?sslmode=disable
 note: database schema version matches expected (<redacted database version>)
 =============================================
-EXECUTING COMMAND: omdb ["db", "reconfigurator-save", "<TMP_PATH_REDACTED>"]
-termination: Exited(0)
----------------------------------------------
-stdout:
----------------------------------------------
-stderr:
-note: using database URL postgresql://root@[::1]:REDACTED_PORT/omicron?sslmode=disable
-note: database schema version matches expected (<redacted database version>)
-assembling reconfigurator state ... done
-wrote <TMP_PATH_REDACTED>
-=============================================
 EXECUTING COMMAND: omdb ["db", "sleds"]
 termination: Exited(0)
 ---------------------------------------------
@@ -1560,4 +1549,15 @@ to:   blueprint ......<REDACTED_BLUEPRINT_ID>.......
 ---------------------------------------------
 stderr:
 note: using Nexus URL http://127.0.0.1:REDACTED_PORT/
+=============================================
+EXECUTING COMMAND: omdb ["reconfigurator", "export", "<TMP_PATH_REDACTED>"]
+termination: Exited(0)
+---------------------------------------------
+stdout:
+---------------------------------------------
+stderr:
+note: using database URL postgresql://root@[::1]:REDACTED_PORT/omicron?sslmode=disable
+note: database schema version matches expected (<redacted database version>)
+assembling reconfigurator state ... done
+wrote <TMP_PATH_REDACTED>
 =============================================

--- a/dev-tools/omdb/tests/test_all_output.rs
+++ b/dev-tools/omdb/tests/test_all_output.rs
@@ -135,7 +135,7 @@ async fn test_omdb_success_cases(cptestctx: &ControlPlaneTestContext) {
 
     let tmpdir = camino_tempfile::tempdir()
         .expect("failed to create temporary directory");
-    let tmppath = tmpdir.path().join("reconfigurator-save.out");
+    let tmppath = tmpdir.path().join("reconfigurator-export.out");
     let initial_blueprint_id = cptestctx.initial_blueprint_id.to_string();
 
     // Get the CockroachDB metadata from the blueprint so we can redact it
@@ -160,7 +160,6 @@ async fn test_omdb_success_cases(cptestctx: &ControlPlaneTestContext) {
         &["db", "dns", "diff", "external", "2"],
         &["db", "dns", "names", "external", "2"],
         &["db", "instances"],
-        &["db", "reconfigurator-save", tmppath.as_str()],
         &["db", "sleds"],
         &["db", "sleds", "-F", "discretionary"],
         &["mgs", "inventory"],
@@ -199,6 +198,7 @@ async fn test_omdb_success_cases(cptestctx: &ControlPlaneTestContext) {
             &initial_blueprint_id,
             "current-target",
         ],
+        &["reconfigurator", "export", tmppath.as_str()],
         // We can't easily test the sled agent output because that's only
         // provided by a real sled agent, which is not available in the
         // ControlPlaneTestContext.

--- a/dev-tools/omdb/tests/usage_errors.out
+++ b/dev-tools/omdb/tests/usage_errors.out
@@ -15,6 +15,7 @@ Commands:
   nexus           Debug a specific Nexus instance
   oximeter        Query oximeter collector state
   oxql            Enter the Oximeter Query Language shell for interactive querying
+  reconfigurator  Interact with the Reconfigurator system
   sled-agent      Debug a specific Sled
   help            Print this message or the help of the given subcommand(s)
 
@@ -47,6 +48,7 @@ Commands:
   nexus           Debug a specific Nexus instance
   oximeter        Query oximeter collector state
   oxql            Enter the Oximeter Query Language shell for interactive querying
+  reconfigurator  Interact with the Reconfigurator system
   sled-agent      Debug a specific Sled
   help            Print this message or the help of the given subcommand(s)
 
@@ -116,7 +118,6 @@ Commands:
   dns                          Print information about internal and external DNS
   inventory                    Print information about collected hardware/software inventory
   physical-disks               Print information about physical disks
-  reconfigurator-save          Save the current Reconfigurator inputs to a file
   region                       Print information about regions
   region-replacement           Query for information about region replacements, optionally manually
                                triggering one
@@ -167,7 +168,6 @@ Commands:
   dns                          Print information about internal and external DNS
   inventory                    Print information about collected hardware/software inventory
   physical-disks               Print information about physical disks
-  reconfigurator-save          Save the current Reconfigurator inputs to a file
   region                       Print information about regions
   region-replacement           Query for information about region replacements, optionally manually
                                triggering one


### PR DESCRIPTION
This is purely a rename, creating a new `omdb` subcommand for reconfigurator.

PR 1 of 3 moving toward adding `omdb db reconfigurator archive`.