### PR TITLE
[omdb] Add `omdb reconfigurator archive` to prune old blueprints

### DIFF
--- a/dev-tools/omdb/src/bin/omdb/db.rs
+++ b/dev-tools/omdb/src/bin/omdb/db.rs
@@ -901,11 +901,10 @@ impl DbArgs {
         omdb: &Omdb,
         log: &slog::Logger,
     ) -> Result<(), anyhow::Error> {
-        let command = self.command.clone();
-        let fetch_opts = self.fetch_opts.clone();
+        let fetch_opts = &self.fetch_opts;
         self.db_url_opts.with_datastore(omdb, log, |opctx, datastore| {
             async move {
-                match &command {
+                match &self.command {
                     DbCommands::Rack(RackArgs { command: RackCommands::List }) => {
                         cmd_db_rack_list(&opctx, &datastore, &fetch_opts).await
                     }

--- a/dev-tools/omdb/tests/test_all_output.rs
+++ b/dev-tools/omdb/tests/test_all_output.rs
@@ -105,6 +105,9 @@ async fn test_omdb_usage_errors() {
         &["oxql", "--help"],
         // Mispelled argument
         &["oxql", "--summarizes"],
+        &["reconfigurator"],
+        &["reconfigurator", "export"],
+        &["reconfigurator", "archive"],
     ];
 
     for args in invocations {

--- a/dev-tools/omdb/tests/usage_errors.out
+++ b/dev-tools/omdb/tests/usage_errors.out
@@ -822,3 +822,57 @@ Usage: omdb oxql <--clickhouse-url <CLICKHOUSE_URL>|--summaries|--elapsed>
 
 For more information, try '--help'.
 =============================================
+EXECUTING COMMAND: omdb ["reconfigurator"]
+termination: Exited(2)
+---------------------------------------------
+stdout:
+---------------------------------------------
+stderr:
+Interact with the Reconfigurator system
+
+Usage: omdb reconfigurator [OPTIONS] <COMMAND>
+
+Commands:
+  export   Save the current Reconfigurator state to a file
+  archive  Save the current Reconfigurator state to a file and remove historical artifacts from the
+           live system (e.g., non-target blueprints)
+  help     Print this message or the help of the given subcommand(s)
+
+Options:
+      --log-level <LOG_LEVEL>  log level filter [env: LOG_LEVEL=] [default: warn]
+      --color <COLOR>          Color output [default: auto] [possible values: auto, always, never]
+  -h, --help                   Print help
+
+Connection Options:
+      --db-url <DB_URL>          URL of the database SQL interface [env: OMDB_DB_URL=]
+      --dns-server <DNS_SERVER>  [env: OMDB_DNS_SERVER=]
+
+Safety Options:
+  -w, --destructive  Allow potentially-destructive subcommands
+=============================================
+EXECUTING COMMAND: omdb ["reconfigurator", "export"]
+termination: Exited(2)
+---------------------------------------------
+stdout:
+---------------------------------------------
+stderr:
+error: the following required arguments were not provided:
+  <OUTPUT_FILE>
+
+Usage: omdb reconfigurator export <OUTPUT_FILE>
+
+For more information, try '--help'.
+=============================================
+EXECUTING COMMAND: omdb ["reconfigurator", "archive"]
+termination: Exited(2)
+---------------------------------------------
+stdout:
+---------------------------------------------
+stderr:
+error: the following required arguments were not provided:
+  <OUTPUT_FILE>
+
+Usage: omdb reconfigurator archive <OUTPUT_FILE>
+
+For more information, try '--help'.
+=============================================


### PR DESCRIPTION
This gives us the tools to address #7278 (once our update runbooks are changed to use this command).

Builds on #7485. This is PR 3 of 3 to add this new subcommand).