### PR TITLE
[reconfigurator] Rework planner/builder expungement logic

### DIFF
--- a/nexus/reconfigurator/planning/src/blueprint_editor.rs
+++ b/nexus/reconfigurator/planning/src/blueprint_editor.rs
@@ -27,3 +27,4 @@ pub(crate) use allocators::ExternalNetworkingChoice;
 pub(crate) use allocators::ExternalSnatNetworkingChoice;
 pub(crate) use sled_editor::EditedSled;
 pub(crate) use sled_editor::SledEditor;
+pub(crate) use sled_editor::DiskExpungeDetails;

--- a/nexus/reconfigurator/planning/src/blueprint_editor.rs
+++ b/nexus/reconfigurator/planning/src/blueprint_editor.rs
@@ -25,6 +25,6 @@ pub use sled_editor::ZonesEditError;
 pub(crate) use allocators::BlueprintResourceAllocator;
 pub(crate) use allocators::ExternalNetworkingChoice;
 pub(crate) use allocators::ExternalSnatNetworkingChoice;
+pub(crate) use sled_editor::DiskExpungeDetails;
 pub(crate) use sled_editor::EditedSled;
 pub(crate) use sled_editor::SledEditor;
-pub(crate) use sled_editor::DiskExpungeDetails;

--- a/nexus/reconfigurator/planning/src/blueprint_editor/sled_editor/disks.rs
+++ b/nexus/reconfigurator/planning/src/blueprint_editor/sled_editor/disks.rs
@@ -96,22 +96,25 @@ impl DisksEditor {
     pub fn expunge(
         &mut self,
         disk_id: &PhysicalDiskUuid,
-    ) -> Result<ZpoolUuid, DisksEditError> {
+    ) -> Result<(bool, ZpoolUuid), DisksEditError> {
         let config = self.disks.get_mut(disk_id).ok_or_else(|| {
             DisksEditError::ExpungeNonexistentDisk { id: *disk_id }
         })?;
 
+        let did_expunge: bool;
         match config.disposition {
             BlueprintPhysicalDiskDisposition::InService => {
                 config.disposition = BlueprintPhysicalDiskDisposition::Expunged;
                 self.counts.expunged += 1;
+                did_expunge = true;
             }
             BlueprintPhysicalDiskDisposition::Expunged => {
                 // expunge is idempotent; do nothing
+                did_expunge = false;
             }
         }
 
-        Ok(config.pool_id)
+        Ok((did_expunge, config.pool_id))
     }
 }
 

--- a/nexus/reconfigurator/planning/src/blueprint_editor/sled_editor/zones.rs
+++ b/nexus/reconfigurator/planning/src/blueprint_editor/sled_editor/zones.rs
@@ -155,7 +155,8 @@ impl ZonesEditor {
         }
     }
 
-    pub fn expunge_all_on_zpool(&mut self, zpool: &ZpoolUuid) {
+    pub fn expunge_all_on_zpool(&mut self, zpool: &ZpoolUuid) -> usize {
+        let mut nexpunged = 0;
         for mut config in self.zones.iter_mut() {
             // Expunge this zone if its filesystem or durable dataset are on
             // this zpool. (If it has both, they should be on the _same_ zpool,
@@ -170,9 +171,12 @@ impl ZonesEditor {
                 .durable_zpool()
                 .map_or(false, |pool| pool.id() == *zpool);
             if fs_is_on_zpool || dd_is_on_zpool {
-                Self::expunge_impl(&mut config, &mut self.counts);
+                if Self::expunge_impl(&mut config, &mut self.counts) {
+                    nexpunged += 1;
+                }
             }
         }
+        nexpunged
     }
 }
 

--- a/nexus/reconfigurator/planning/src/planner.rs
+++ b/nexus/reconfigurator/planning/src/planner.rs
@@ -11,19 +11,22 @@ use crate::blueprint_builder::Ensure;
 use crate::blueprint_builder::EnsureMultiple;
 use crate::blueprint_builder::Error;
 use crate::blueprint_builder::Operation;
+use crate::blueprint_editor::DisksEditError;
+use crate::blueprint_editor::SledEditError;
 use crate::planner::omicron_zone_placement::PlacementError;
 use nexus_sled_agent_shared::inventory::ZoneKind;
 use nexus_types::deployment::Blueprint;
-use nexus_types::deployment::BlueprintZoneConfig;
 use nexus_types::deployment::BlueprintZoneDisposition;
 use nexus_types::deployment::BlueprintZoneFilter;
 use nexus_types::deployment::CockroachDbClusterVersion;
 use nexus_types::deployment::CockroachDbPreserveDowngrade;
 use nexus_types::deployment::CockroachDbSettings;
+use nexus_types::deployment::DiskFilter;
 use nexus_types::deployment::PlanningInput;
 use nexus_types::deployment::SledDetails;
 use nexus_types::deployment::SledFilter;
 use nexus_types::deployment::ZpoolFilter;
+use nexus_types::external_api::views::PhysicalDiskPolicy;
 use nexus_types::external_api::views::SledPolicy;
 use nexus_types::external_api::views::SledState;
 use nexus_types::inventory::Collection;
@@ -177,9 +180,7 @@ impl<'a> Planner<'a> {
             self.input.all_sleds(SledFilter::Commissioned)
         {
             commissioned_sled_ids.insert(sled_id);
-
-            // Perform the expungement, for any zones that might need it.
-            self.blueprint.expunge_zones_for_sled(sled_id, sled_details)?;
+            self.do_plan_expunge_for_commissioned_sled(sled_id, sled_details)?;
         }
 
         // Check for any decommissioned sleds (i.e., sleds for which our
@@ -204,6 +205,87 @@ impl<'a> Planner<'a> {
                         },
                     );
                 }
+            }
+        }
+
+        Ok(())
+    }
+
+    fn do_plan_expunge_for_commissioned_sled(
+        &mut self,
+        sled_id: SledUuid,
+        sled_details: &SledDetails,
+    ) -> Result<(), Error> {
+        match sled_details.policy {
+            SledPolicy::InService { .. } => {
+                // Sled is still in service, but have any of its disks been
+                // expunged? If so, expunge them in the blueprint (which
+                // whill chain to expunging any datasets and zones that were
+                // using them).
+                //
+                // We don't use a more specific disk filter here because we
+                // want to look at _only_ the policy: if the operator has
+                // said a disk should be expunged, we'll expunge it from the
+                // blueprint regardless of its overall state.
+                for (_, disk) in sled_details
+                    .resources
+                    .all_disks(DiskFilter::All)
+                    .filter(|(_, disk)| match disk.policy {
+                        PhysicalDiskPolicy::InService => false,
+                        PhysicalDiskPolicy::Expunged => true,
+                    })
+                {
+                    match self.blueprint.expunge_disk(sled_id, disk.disk_id) {
+                        Ok(()) => (),
+                        Err(Error::SledEditError {
+                            err:
+                                SledEditError::EditDisks(
+                                    DisksEditError::ExpungeNonexistentDisk {
+                                        ..
+                                    },
+                                ),
+                            ..
+                        }) => {
+                            // While it should be rare, it's possible there's an
+                            // expunged disk present in the planning input that
+                            // isn't in the blueprint at all (e.g., a disk could
+                            // have been added and then expunged since our
+                            // parent blueprint was created). We don't want to
+                            // fail in this case, but will issue a warning.
+                            warn!(
+                                self.log,
+                                "planning input contained expunged disk not \
+                                 present in parent blueprint";
+                                "sled_id" => %sled_id,
+                                "disk" => ?disk,
+                            );
+                        }
+                        Err(err) => return Err(err),
+                    }
+                }
+
+                // Expunge any multinode clickhouse zones if the policy says
+                // they shouldn't exist.
+                if !self.input.clickhouse_cluster_enabled() {
+                    self.blueprint.expunge_all_multinode_clickhouse(
+                        sled_id,
+                        ZoneExpungeReason::ClickhouseClusterDisabled,
+                    )?;
+                }
+
+                // Similarly, expunge any singlenode clickhouse if the policy
+                // says they should exist.
+                if !self.input.clickhouse_single_node_enabled() {
+                    self.blueprint.expunge_all_singlenode_clickhouse(
+                        sled_id,
+                        ZoneExpungeReason::ClickhouseSingleNodeDisabled,
+                    )?;
+                }
+            }
+            // Has the sled been expunged? If so, expunge everything on this
+            // sled from the blueprint.
+            SledPolicy::Expunged => {
+                self.blueprint.expunge_sled(sled_id)?;
             }
         }
 
@@ -697,87 +779,12 @@ impl<'a> Planner<'a> {
     }
 }
 
-/// Returns `Some(reason)` if the sled needs its zones to be expunged,
-/// based on the policy and state.
-fn sled_needs_all_zones_expunged(
-    state: SledState,
-    policy: SledPolicy,
-) -> Option<ZoneExpungeReason> {
-    match state {
-        SledState::Active => {}
-        SledState::Decommissioned => {
-            // A decommissioned sled that still has resources attached to it is
-            // an illegal state, but representable. If we see a sled in this
-            // state, we should still expunge all zones in it, but parent code
-            // should warn on it.
-            return Some(ZoneExpungeReason::SledDecommissioned);
-        }
-    }
-
-    match policy {
-        SledPolicy::InService { .. } => None,
-        SledPolicy::Expunged => Some(ZoneExpungeReason::SledExpunged),
-    }
-}
-
-pub(crate) fn zone_needs_expungement(
-    sled_details: &SledDetails,
-    zone_config: &BlueprintZoneConfig,
-    input: &PlanningInput,
-) -> Option<ZoneExpungeReason> {
-    // Should we expunge the zone because the sled is gone?
-    if let Some(reason) =
-        sled_needs_all_zones_expunged(sled_details.state, sled_details.policy)
-    {
-        return Some(reason);
-    }
-
-    // Should we expunge the zone because durable storage is gone?
-    if let Some(durable_storage_zpool) = zone_config.zone_type.durable_zpool() {
-        let zpool_id = durable_storage_zpool.id();
-        if !sled_details.resources.zpool_is_provisionable(&zpool_id) {
-            return Some(ZoneExpungeReason::DiskExpunged);
-        }
-    };
-
-    // Should we expunge the zone because transient storage is gone?
-    if let Some(ref filesystem_zpool) = zone_config.filesystem_pool {
-        let zpool_id = filesystem_zpool.id();
-        if !sled_details.resources.zpool_is_provisionable(&zpool_id) {
-            return Some(ZoneExpungeReason::DiskExpunged);
-        }
-    };
-
-    // Should we expunge the zone because clickhouse clusters are no longer
-    // enabled via policy?
-    if !input.clickhouse_cluster_enabled() {
-        if zone_config.zone_type.is_clickhouse_keeper()
-            || zone_config.zone_type.is_clickhouse_server()
-        {
-            return Some(ZoneExpungeReason::ClickhouseClusterDisabled);
-        }
-    }
-
-    // Should we expunge the zone because single-node clickhouse is no longer
-    // enabled via policy?
-    if !input.clickhouse_single_node_enabled() {
-        if zone_config.zone_type.is_clickhouse() {
-            return Some(ZoneExpungeReason::ClickhouseSingleNodeDisabled);
-        }
-    }
-
-    None
-}
-
 /// The reason a sled's zones need to be expunged.
 ///
 /// This is used only for introspection and logging -- it's not part of the
 /// logical flow.
 #[derive(Copy, Clone, Debug, Eq, PartialEq, Ord, PartialOrd)]
 pub(crate) enum ZoneExpungeReason {
-    DiskExpunged,
-    SledDecommissioned,
-    SledExpunged,
     ClickhouseClusterDisabled,
     ClickhouseSingleNodeDisabled,
 }

--- a/nexus/reconfigurator/planning/tests/output/planner_decommissions_sleds_bp2.txt
+++ b/nexus/reconfigurator/planning/tests/output/planner_decommissions_sleds_bp2.txt
@@ -114,7 +114,7 @@ WARNING: Zones exist without physical disks!
  METADATA:
     created by:::::::::::   test_blueprint2
     created at:::::::::::   1970-01-01T00:00:00.000Z
-    comment::::::::::::::   sled a1b477db-b629-48eb-911d-1ccdafca75b9: expunged 15 zones because: sled policy is expunged
+    comment::::::::::::::   sled a1b477db-b629-48eb-911d-1ccdafca75b9 expunged (expunged 10 disks, 47 datasets, 15 zones)
     internal DNS version:   1
     external DNS version:   1
 

--- a/nexus/reconfigurator/planning/tests/output/planner_nonprovisionable_bp2.txt
+++ b/nexus/reconfigurator/planning/tests/output/planner_nonprovisionable_bp2.txt
@@ -175,7 +175,7 @@ WARNING: Zones exist without physical disks!
  METADATA:
     created by:::::::::::   test_blueprint2
     created at:::::::::::   1970-01-01T00:00:00.000Z
-    comment::::::::::::::   sled 48d95fef-bc9f-4f50-9a53-1e075836291d: expunged 14 zones because: sled policy is expunged
+    comment::::::::::::::   sled 48d95fef-bc9f-4f50-9a53-1e075836291d expunged (expunged 10 disks, 45 datasets, 14 zones)
     internal DNS version:   1
     external DNS version:   1
 


### PR DESCRIPTION
The high-level summary of this change is that it moves the logic for handling expunged sleds out of `BlueprintBuilder::expunge_zones_for_sled()` (which is now gone entirely) and into a new method on the planner (`do_plan_expunge_for_commissioned_sled()`, naming suggestions welcome).

This fixes two problems; one stylistic, and one semantic:

1. `BlueprintBuilder::expunge_zones_for_sled()` was maybe the worst offender for "is this a builder API or a planner API", because a big chunk of its logic was actually delegated back to `zone_needs_expungement()`, a helper function defined in the planner. The builder now has more explicit and direct methods to expunge specific things, and it's the planner that decides based on the planning input which things to expunge.
2. `BlueprintBuilder::expunge_zones_for_sled()` only handled expunging _zones_. When a sled was expunged, at no point did the planner expunge the disks or datasets on that sled. We haven't been bitten by this yet because the builder currently omits expunged sleds from `blueprint_disks` and `blueprint_datasets` entirely, but that's a major roadblock in the path to joining the maps together (which is a prereq for fixing #7309 by merging sled-agent endpoints together). `do_plan_expunge_for_commissioned_sled()` expunges disks, datasets, and zones. For now we still omit the expunged sleds from `blueprint_disks` and `blueprint_datasets`, but when we stop doing that we'll at least have set the dispositions correctly.