### PR TITLE
[reconfigurator] Add dataset disposition to blueprint diffs

### DIFF
--- a/dev-tools/omdb/tests/successes.out
+++ b/dev-tools/omdb/tests/successes.out
@@ -1514,15 +1514,15 @@ to:   blueprint ......<REDACTED_BLUEPRINT_ID>.......
 
 
     datasets at generation 2:
-    ---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
-    dataset name                                                                                                   dataset uuid                           quota   reservation   compression
-    ---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
-    oxp_..........<REDACTED_UUID>.........../crypt/zone/oxz_clickhouse_..........<REDACTED_UUID>...........        ..........<REDACTED_UUID>...........   none    none          off        
-    oxp_..........<REDACTED_UUID>.........../crypt/zone/oxz_cockroachdb_..........<REDACTED_UUID>...........       ..........<REDACTED_UUID>...........   none    none          off        
-    oxp_..........<REDACTED_UUID>.........../crypt/zone/oxz_crucible_pantry_..........<REDACTED_UUID>...........   ..........<REDACTED_UUID>...........   none    none          off        
-    oxp_..........<REDACTED_UUID>.........../crypt/zone/oxz_external_dns_..........<REDACTED_UUID>...........      ..........<REDACTED_UUID>...........   none    none          off        
-    oxp_..........<REDACTED_UUID>.........../crypt/zone/oxz_internal_dns_..........<REDACTED_UUID>...........      ..........<REDACTED_UUID>...........   none    none          off        
-    oxp_..........<REDACTED_UUID>.........../crypt/zone/oxz_nexus_..........<REDACTED_UUID>...........             ..........<REDACTED_UUID>...........   none    none          off        
+    -----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
+    dataset name                                                                                                   dataset id                             disposition   quota   reservation   compression
+    -----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
+    oxp_..........<REDACTED_UUID>.........../crypt/zone/oxz_clickhouse_..........<REDACTED_UUID>...........        ..........<REDACTED_UUID>...........   in service    none    none          off        
+    oxp_..........<REDACTED_UUID>.........../crypt/zone/oxz_cockroachdb_..........<REDACTED_UUID>...........       ..........<REDACTED_UUID>...........   in service    none    none          off        
+    oxp_..........<REDACTED_UUID>.........../crypt/zone/oxz_crucible_pantry_..........<REDACTED_UUID>...........   ..........<REDACTED_UUID>...........   in service    none    none          off        
+    oxp_..........<REDACTED_UUID>.........../crypt/zone/oxz_external_dns_..........<REDACTED_UUID>...........      ..........<REDACTED_UUID>...........   in service    none    none          off        
+    oxp_..........<REDACTED_UUID>.........../crypt/zone/oxz_internal_dns_..........<REDACTED_UUID>...........      ..........<REDACTED_UUID>...........   in service    none    none          off        
+    oxp_..........<REDACTED_UUID>.........../crypt/zone/oxz_nexus_..........<REDACTED_UUID>...........             ..........<REDACTED_UUID>...........   in service    none    none          off        
 
 
     omicron zones at generation 2:

--- a/nexus/reconfigurator/planning/tests/output/planner_basic_add_sled_2_3.txt
+++ b/nexus/reconfigurator/planning/tests/output/planner_basic_add_sled_2_3.txt
@@ -22,56 +22,56 @@ to:   blueprint 4171ad05-89dd-474b-846b-b007e4346366
 
 
     datasets at generation 2:
-    -----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
-    dataset name                                                                                                   dataset uuid                           quota     reservation   compression
-    -----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
-    oxp_014eb1e9-04fe-4f36-8339-0a090b053ada/crucible                                                              ea8bb9f4-ef14-4764-8713-299c94aee754   none      none          off        
-    oxp_31a3bc64-7a3b-496d-b644-785dc44b6e37/crucible                                                              7dcb9cca-dcac-4d95-92d1-f9ee376558ee   none      none          off        
-    oxp_7bb40bd6-9c43-4b63-8337-18313c72aea2/crucible                                                              87f012e5-1979-4d4f-abd7-5004e6a4de4a   none      none          off        
-    oxp_988aa8c2-cb5e-406b-9289-425dc2e5bc3a/crucible                                                              8a017cce-a6e3-4891-80d2-282134012f1f   none      none          off        
-    oxp_ad574c09-2ae0-4534-a2a4-f923ce20ae87/crucible                                                              51734f27-2839-481c-b11d-f59843297269   none      none          off        
-    oxp_ad91e238-4901-4ff4-a91b-75233c936426/crucible                                                              4ebb5c8c-77cc-4d9a-a66a-aab846d7f4d7   none      none          off        
-    oxp_ce58d463-d442-4c97-a6b4-f7d98c3fd902/crucible                                                              7e930ce3-f0e6-4188-940a-07dee8fc97cd   none      none          off        
-    oxp_f18f7689-0059-4b79-880e-34faf7a0fe0e/crucible                                                              e688234b-9854-4a4e-ae8e-5ec66a323784   none      none          off        
-    oxp_f1d6cea4-640f-415e-89fe-2b1784ce3db8/crucible                                                              48a12bd9-3d59-4151-adf1-ff703d71977c   none      none          off        
-    oxp_f4a96860-bdeb-4435-bdf5-2a10beb3d44a/crucible                                                              4a0ed488-8ab7-4a8b-90da-ab568081832b   none      none          off        
-    oxp_014eb1e9-04fe-4f36-8339-0a090b053ada/crypt/clickhouse                                                      87d67ac6-6079-4a4c-960e-44991410a64c   none      none          off        
-    oxp_014eb1e9-04fe-4f36-8339-0a090b053ada/crypt/internal_dns                                                    31caca18-3e69-4e95-a48e-1a3f9219a304   none      none          off        
-    oxp_014eb1e9-04fe-4f36-8339-0a090b053ada/crypt/zone                                                            8df851fd-0e0c-4069-ad4b-e8669051e42d   none      none          off        
-    oxp_31a3bc64-7a3b-496d-b644-785dc44b6e37/crypt/zone                                                            3c2b2846-d286-4ac7-9001-1dbc92d8ec52   none      none          off        
-    oxp_7bb40bd6-9c43-4b63-8337-18313c72aea2/crypt/zone                                                            d7519dd3-b371-4570-b474-e198d679bc47   none      none          off        
-    oxp_988aa8c2-cb5e-406b-9289-425dc2e5bc3a/crypt/zone                                                            da77f084-5fc9-477a-a5b1-e424f98aa53f   none      none          off        
-    oxp_ad574c09-2ae0-4534-a2a4-f923ce20ae87/crypt/zone                                                            8ffb3c67-d81d-4edc-b4fa-f829bc6d9fb5   none      none          off        
-    oxp_ad91e238-4901-4ff4-a91b-75233c936426/crypt/zone                                                            12c23a3b-389d-4f4f-950e-f7e36ae44262   none      none          off        
-    oxp_ce58d463-d442-4c97-a6b4-f7d98c3fd902/crypt/zone                                                            6614568a-a5a5-4db2-80f2-3e405fe35e17   none      none          off        
-    oxp_f18f7689-0059-4b79-880e-34faf7a0fe0e/crypt/zone                                                            a7d4d358-7935-4060-985f-280829de083c   none      none          off        
-    oxp_f1d6cea4-640f-415e-89fe-2b1784ce3db8/crypt/zone                                                            35decedb-c97e-4fde-9ee2-26680ccc7f7e   none      none          off        
-    oxp_f4a96860-bdeb-4435-bdf5-2a10beb3d44a/crypt/zone                                                            a0b8487f-b194-4583-ab31-3b02d85af60b   none      none          off        
-    oxp_014eb1e9-04fe-4f36-8339-0a090b053ada/crypt/zone/oxz_clickhouse_98229df2-6faf-45a4-8501-48e1ad25706e        0bda3f6e-6852-4476-8539-8d6315466ccb   none      none          off        
-    oxp_ad574c09-2ae0-4534-a2a4-f923ce20ae87/crypt/zone/oxz_crucible_3384bb31-72f2-46fc-9ada-b324580e2930          707c72de-e19c-4c7b-b2a1-4b028e1026c9   none      none          off        
-    oxp_f1d6cea4-640f-415e-89fe-2b1784ce3db8/crypt/zone/oxz_crucible_397f4188-68b0-4d82-aea4-5b950f6fc779          8cab65a0-26af-42e7-9f77-10a03096edf0   none      none          off        
-    oxp_988aa8c2-cb5e-406b-9289-425dc2e5bc3a/crypt/zone/oxz_crucible_4a35beea-a998-4ef1-845c-55d69d35108f          74aacf3e-7c5b-44d5-869c-ae04c9f70bf9   none      none          off        
-    oxp_ad91e238-4901-4ff4-a91b-75233c936426/crypt/zone/oxz_crucible_5710b56a-a07e-49e2-8dfb-34f1c87ca02e          1e1bfd91-4900-4869-9b17-d6ff94d95301   none      none          off        
-    oxp_f4a96860-bdeb-4435-bdf5-2a10beb3d44a/crypt/zone/oxz_crucible_62b70007-57c1-4086-8e35-e61443f0c259          b1217132-9894-472e-a763-626798f46cc2   none      none          off        
-    oxp_014eb1e9-04fe-4f36-8339-0a090b053ada/crypt/zone/oxz_crucible_8ca9bfdc-c3a6-4280-ad34-b5af8fd5187e          14b40d48-c5b1-4e8e-90ec-e374d824204d   none      none          off        
-    oxp_31a3bc64-7a3b-496d-b644-785dc44b6e37/crypt/zone/oxz_crucible_9c927800-ba15-4e84-b80e-781606bec308          eb2960e5-5b89-432f-a384-3009d3b3db5d   none      none          off        
-    oxp_ce58d463-d442-4c97-a6b4-f7d98c3fd902/crypt/zone/oxz_crucible_a7cab59f-59f2-4cb9-b559-551dc6c43aaf          8c16b33b-54f3-453d-a28a-baed87bd45da   none      none          off        
-    oxp_f18f7689-0059-4b79-880e-34faf7a0fe0e/crypt/zone/oxz_crucible_cb67f66d-37e3-40a6-adbd-69962fb6cf73          52036fa0-92ad-4444-8156-01d0b2e9b676   none      none          off        
-    oxp_7bb40bd6-9c43-4b63-8337-18313c72aea2/crypt/zone/oxz_crucible_da2fc172-8cb2-4d66-a92b-017a97842c27          3aa614f6-5a75-44a0-a950-6adb6c299299   none      none          off        
-    oxp_014eb1e9-04fe-4f36-8339-0a090b053ada/crypt/zone/oxz_crucible_pantry_be4a1d4a-093f-40e0-8e06-74cc1d786d1b   25438f31-b9e0-499f-a55f-9bfcb0a4194d   none      none          off        
-    oxp_014eb1e9-04fe-4f36-8339-0a090b053ada/crypt/zone/oxz_internal_dns_2a6f89a2-3476-4c3b-97b2-322f00f2fc9a      572f2970-46ed-46e1-b600-d021e080903e   none      none          off        
-    oxp_014eb1e9-04fe-4f36-8339-0a090b053ada/crypt/zone/oxz_nexus_fb07dee1-d608-451b-83eb-4ee913d6e1f8             0e2d27bc-01d7-4afd-82e2-973db6138e70   none      none          off        
-    oxp_014eb1e9-04fe-4f36-8339-0a090b053ada/crypt/zone/oxz_ntp_d7ffba91-8f9d-4168-89a4-26c6c4370cb0               63e6eeb0-e079-4165-9444-8aac3d50fef3   none      none          off        
-    oxp_014eb1e9-04fe-4f36-8339-0a090b053ada/crypt/debug                                                           9982db80-b762-4c5f-9916-35383d59b6df   100 GiB   none          gzip-9     
-    oxp_31a3bc64-7a3b-496d-b644-785dc44b6e37/crypt/debug                                                           fd25bb57-dc4b-42ea-a2ab-d6395b38334f   100 GiB   none          gzip-9     
-    oxp_7bb40bd6-9c43-4b63-8337-18313c72aea2/crypt/debug                                                           95f111d8-854f-4177-bcff-481e625dd73d   100 GiB   none          gzip-9     
-    oxp_988aa8c2-cb5e-406b-9289-425dc2e5bc3a/crypt/debug                                                           38903da8-c23d-4516-b0ca-6036e26c49e4   100 GiB   none          gzip-9     
-    oxp_ad574c09-2ae0-4534-a2a4-f923ce20ae87/crypt/debug                                                           216e74e6-691b-45f9-ad7f-037ae799a8c9   100 GiB   none          gzip-9     
-    oxp_ad91e238-4901-4ff4-a91b-75233c936426/crypt/debug                                                           e598cc97-90c4-403a-b7fc-741f8b93de87   100 GiB   none          gzip-9     
-    oxp_ce58d463-d442-4c97-a6b4-f7d98c3fd902/crypt/debug                                                           235746b2-5d3f-4608-9017-2bd8d1521d2b   100 GiB   none          gzip-9     
-    oxp_f18f7689-0059-4b79-880e-34faf7a0fe0e/crypt/debug                                                           08fdf2b1-430d-4a5c-adf3-b0a0f323ae9d   100 GiB   none          gzip-9     
-    oxp_f1d6cea4-640f-415e-89fe-2b1784ce3db8/crypt/debug                                                           ea7fa07f-f47b-4039-a0db-6ab9ca0f0e2c   100 GiB   none          gzip-9     
-    oxp_f4a96860-bdeb-4435-bdf5-2a10beb3d44a/crypt/debug                                                           547cb9ee-f196-4dfe-9f2c-aa4b2f114abe   100 GiB   none          gzip-9     
+    -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
+    dataset name                                                                                                   dataset id                             disposition   quota     reservation   compression
+    -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
+    oxp_014eb1e9-04fe-4f36-8339-0a090b053ada/crucible                                                              ea8bb9f4-ef14-4764-8713-299c94aee754   in service    none      none          off        
+    oxp_31a3bc64-7a3b-496d-b644-785dc44b6e37/crucible                                                              7dcb9cca-dcac-4d95-92d1-f9ee376558ee   in service    none      none          off        
+    oxp_7bb40bd6-9c43-4b63-8337-18313c72aea2/crucible                                                              87f012e5-1979-4d4f-abd7-5004e6a4de4a   in service    none      none          off        
+    oxp_988aa8c2-cb5e-406b-9289-425dc2e5bc3a/crucible                                                              8a017cce-a6e3-4891-80d2-282134012f1f   in service    none      none          off        
+    oxp_ad574c09-2ae0-4534-a2a4-f923ce20ae87/crucible                                                              51734f27-2839-481c-b11d-f59843297269   in service    none      none          off        
+    oxp_ad91e238-4901-4ff4-a91b-75233c936426/crucible                                                              4ebb5c8c-77cc-4d9a-a66a-aab846d7f4d7   in service    none      none          off        
+    oxp_ce58d463-d442-4c97-a6b4-f7d98c3fd902/crucible                                                              7e930ce3-f0e6-4188-940a-07dee8fc97cd   in service    none      none          off        
+    oxp_f18f7689-0059-4b79-880e-34faf7a0fe0e/crucible                                                              e688234b-9854-4a4e-ae8e-5ec66a323784   in service    none      none          off        
+    oxp_f1d6cea4-640f-415e-89fe-2b1784ce3db8/crucible                                                              48a12bd9-3d59-4151-adf1-ff703d71977c   in service    none      none          off        
+    oxp_f4a96860-bdeb-4435-bdf5-2a10beb3d44a/crucible                                                              4a0ed488-8ab7-4a8b-90da-ab568081832b   in service    none      none          off        
+    oxp_014eb1e9-04fe-4f36-8339-0a090b053ada/crypt/clickhouse                                                      87d67ac6-6079-4a4c-960e-44991410a64c   in service    none      none          off        
+    oxp_014eb1e9-04fe-4f36-8339-0a090b053ada/crypt/internal_dns                                                    31caca18-3e69-4e95-a48e-1a3f9219a304   in service    none      none          off        
+    oxp_014eb1e9-04fe-4f36-8339-0a090b053ada/crypt/zone                                                            8df851fd-0e0c-4069-ad4b-e8669051e42d   in service    none      none          off        
+    oxp_31a3bc64-7a3b-496d-b644-785dc44b6e37/crypt/zone                                                            3c2b2846-d286-4ac7-9001-1dbc92d8ec52   in service    none      none          off        
+    oxp_7bb40bd6-9c43-4b63-8337-18313c72aea2/crypt/zone                                                            d7519dd3-b371-4570-b474-e198d679bc47   in service    none      none          off        
+    oxp_988aa8c2-cb5e-406b-9289-425dc2e5bc3a/crypt/zone                                                            da77f084-5fc9-477a-a5b1-e424f98aa53f   in service    none      none          off        
+    oxp_ad574c09-2ae0-4534-a2a4-f923ce20ae87/crypt/zone                                                            8ffb3c67-d81d-4edc-b4fa-f829bc6d9fb5   in service    none      none          off        
+    oxp_ad91e238-4901-4ff4-a91b-75233c936426/crypt/zone                                                            12c23a3b-389d-4f4f-950e-f7e36ae44262   in service    none      none          off        
+    oxp_ce58d463-d442-4c97-a6b4-f7d98c3fd902/crypt/zone                                                            6614568a-a5a5-4db2-80f2-3e405fe35e17   in service    none      none          off        
+    oxp_f18f7689-0059-4b79-880e-34faf7a0fe0e/crypt/zone                                                            a7d4d358-7935-4060-985f-280829de083c   in service    none      none          off        
+    oxp_f1d6cea4-640f-415e-89fe-2b1784ce3db8/crypt/zone                                                            35decedb-c97e-4fde-9ee2-26680ccc7f7e   in service    none      none          off        
+    oxp_f4a96860-bdeb-4435-bdf5-2a10beb3d44a/crypt/zone                                                            a0b8487f-b194-4583-ab31-3b02d85af60b   in service    none      none          off        
+    oxp_014eb1e9-04fe-4f36-8339-0a090b053ada/crypt/zone/oxz_clickhouse_98229df2-6faf-45a4-8501-48e1ad25706e        0bda3f6e-6852-4476-8539-8d6315466ccb   in service    none      none          off        
+    oxp_ad574c09-2ae0-4534-a2a4-f923ce20ae87/crypt/zone/oxz_crucible_3384bb31-72f2-46fc-9ada-b324580e2930          707c72de-e19c-4c7b-b2a1-4b028e1026c9   in service    none      none          off        
+    oxp_f1d6cea4-640f-415e-89fe-2b1784ce3db8/crypt/zone/oxz_crucible_397f4188-68b0-4d82-aea4-5b950f6fc779          8cab65a0-26af-42e7-9f77-10a03096edf0   in service    none      none          off        
+    oxp_988aa8c2-cb5e-406b-9289-425dc2e5bc3a/crypt/zone/oxz_crucible_4a35beea-a998-4ef1-845c-55d69d35108f          74aacf3e-7c5b-44d5-869c-ae04c9f70bf9   in service    none      none          off        
+    oxp_ad91e238-4901-4ff4-a91b-75233c936426/crypt/zone/oxz_crucible_5710b56a-a07e-49e2-8dfb-34f1c87ca02e          1e1bfd91-4900-4869-9b17-d6ff94d95301   in service    none      none          off        
+    oxp_f4a96860-bdeb-4435-bdf5-2a10beb3d44a/crypt/zone/oxz_crucible_62b70007-57c1-4086-8e35-e61443f0c259          b1217132-9894-472e-a763-626798f46cc2   in service    none      none          off        
+    oxp_014eb1e9-04fe-4f36-8339-0a090b053ada/crypt/zone/oxz_crucible_8ca9bfdc-c3a6-4280-ad34-b5af8fd5187e          14b40d48-c5b1-4e8e-90ec-e374d824204d   in service    none      none          off        
+    oxp_31a3bc64-7a3b-496d-b644-785dc44b6e37/crypt/zone/oxz_crucible_9c927800-ba15-4e84-b80e-781606bec308          eb2960e5-5b89-432f-a384-3009d3b3db5d   in service    none      none          off        
+    oxp_ce58d463-d442-4c97-a6b4-f7d98c3fd902/crypt/zone/oxz_crucible_a7cab59f-59f2-4cb9-b559-551dc6c43aaf          8c16b33b-54f3-453d-a28a-baed87bd45da   in service    none      none          off        
+    oxp_f18f7689-0059-4b79-880e-34faf7a0fe0e/crypt/zone/oxz_crucible_cb67f66d-37e3-40a6-adbd-69962fb6cf73          52036fa0-92ad-4444-8156-01d0b2e9b676   in service    none      none          off        
+    oxp_7bb40bd6-9c43-4b63-8337-18313c72aea2/crypt/zone/oxz_crucible_da2fc172-8cb2-4d66-a92b-017a97842c27          3aa614f6-5a75-44a0-a950-6adb6c299299   in service    none      none          off        
+    oxp_014eb1e9-04fe-4f36-8339-0a090b053ada/crypt/zone/oxz_crucible_pantry_be4a1d4a-093f-40e0-8e06-74cc1d786d1b   25438f31-b9e0-499f-a55f-9bfcb0a4194d   in service    none      none          off        
+    oxp_014eb1e9-04fe-4f36-8339-0a090b053ada/crypt/zone/oxz_internal_dns_2a6f89a2-3476-4c3b-97b2-322f00f2fc9a      572f2970-46ed-46e1-b600-d021e080903e   in service    none      none          off        
+    oxp_014eb1e9-04fe-4f36-8339-0a090b053ada/crypt/zone/oxz_nexus_fb07dee1-d608-451b-83eb-4ee913d6e1f8             0e2d27bc-01d7-4afd-82e2-973db6138e70   in service    none      none          off        
+    oxp_014eb1e9-04fe-4f36-8339-0a090b053ada/crypt/zone/oxz_ntp_d7ffba91-8f9d-4168-89a4-26c6c4370cb0               63e6eeb0-e079-4165-9444-8aac3d50fef3   in service    none      none          off        
+    oxp_014eb1e9-04fe-4f36-8339-0a090b053ada/crypt/debug                                                           9982db80-b762-4c5f-9916-35383d59b6df   in service    100 GiB   none          gzip-9     
+    oxp_31a3bc64-7a3b-496d-b644-785dc44b6e37/crypt/debug                                                           fd25bb57-dc4b-42ea-a2ab-d6395b38334f   in service    100 GiB   none          gzip-9     
+    oxp_7bb40bd6-9c43-4b63-8337-18313c72aea2/crypt/debug                                                           95f111d8-854f-4177-bcff-481e625dd73d   in service    100 GiB   none          gzip-9     
+    oxp_988aa8c2-cb5e-406b-9289-425dc2e5bc3a/crypt/debug                                                           38903da8-c23d-4516-b0ca-6036e26c49e4   in service    100 GiB   none          gzip-9     
+    oxp_ad574c09-2ae0-4534-a2a4-f923ce20ae87/crypt/debug                                                           216e74e6-691b-45f9-ad7f-037ae799a8c9   in service    100 GiB   none          gzip-9     
+    oxp_ad91e238-4901-4ff4-a91b-75233c936426/crypt/debug                                                           e598cc97-90c4-403a-b7fc-741f8b93de87   in service    100 GiB   none          gzip-9     
+    oxp_ce58d463-d442-4c97-a6b4-f7d98c3fd902/crypt/debug                                                           235746b2-5d3f-4608-9017-2bd8d1521d2b   in service    100 GiB   none          gzip-9     
+    oxp_f18f7689-0059-4b79-880e-34faf7a0fe0e/crypt/debug                                                           08fdf2b1-430d-4a5c-adf3-b0a0f323ae9d   in service    100 GiB   none          gzip-9     
+    oxp_f1d6cea4-640f-415e-89fe-2b1784ce3db8/crypt/debug                                                           ea7fa07f-f47b-4039-a0db-6ab9ca0f0e2c   in service    100 GiB   none          gzip-9     
+    oxp_f4a96860-bdeb-4435-bdf5-2a10beb3d44a/crypt/debug                                                           547cb9ee-f196-4dfe-9f2c-aa4b2f114abe   in service    100 GiB   none          gzip-9     
 
 
     omicron zones at generation 2:
@@ -114,54 +114,54 @@ to:   blueprint 4171ad05-89dd-474b-846b-b007e4346366
 
 
     datasets at generation 2:
-    -----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
-    dataset name                                                                                                   dataset uuid                           quota     reservation   compression
-    -----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
-    oxp_12057b4a-0b06-4f70-ba22-336de2385bfe/crucible                                                              55136aae-73db-46b2-bd32-e26634f865ed   none      none          off        
-    oxp_29758363-6c77-40c3-8740-9c0c64f6e14a/crucible                                                              5c4eda29-ed3e-4dc6-b756-afafa1c216b8   none      none          off        
-    oxp_3f331c10-7882-48ab-85d9-05108490b55b/crucible                                                              9b5d5293-2546-43f0-b953-73a696cad4bf   none      none          off        
-    oxp_5152d1aa-9045-4e06-9ef6-6eadac3696e4/crucible                                                              74c65a92-1d4a-44cc-9a55-cd540e9fb57e   none      none          off        
-    oxp_5c0dd424-d905-4fc5-a73c-36254fdd470c/crucible                                                              cc25055b-483e-46ab-a5bf-1d8838b846fd   none      none          off        
-    oxp_794df76f-bca0-4635-9eb6-773ad0108f7e/crucible                                                              8270e505-beff-480a-955b-bf96c4b1a9a3   none      none          off        
-    oxp_9024d350-38a7-459b-8550-3b2c4a88b5c1/crucible                                                              ea234d9d-291b-4adf-9d96-48b7945c2892   none      none          off        
-    oxp_95e86080-e162-4980-a589-db6bb1a95ca7/crucible                                                              d8d9a6d4-f6be-4044-8eac-b994aa166053   none      none          off        
-    oxp_d55d36d7-df92-4615-944d-440a1f8b5001/crucible                                                              64955a3e-2059-4d16-aee4-f63f9362b554   none      none          off        
-    oxp_db6686c8-2dd9-4032-8444-2a06b43baa68/crucible                                                              863c76ac-732e-4d10-b7a3-1d6ba02dc1f5   none      none          off        
-    oxp_12057b4a-0b06-4f70-ba22-336de2385bfe/crypt/internal_dns                                                    b4df380c-6cca-41c1-b79c-45671067d459   none      none          off        
-    oxp_12057b4a-0b06-4f70-ba22-336de2385bfe/crypt/zone                                                            9bcac944-9866-4251-b333-1cbdc137a03e   none      none          off        
-    oxp_29758363-6c77-40c3-8740-9c0c64f6e14a/crypt/zone                                                            0557de8a-45cf-44a0-a39d-4a7095e9045b   none      none          off        
-    oxp_3f331c10-7882-48ab-85d9-05108490b55b/crypt/zone                                                            5f5e1e10-1561-4556-aac1-6b6285df5cb2   none      none          off        
-    oxp_5152d1aa-9045-4e06-9ef6-6eadac3696e4/crypt/zone                                                            52d9152d-e80a-455e-b24a-70b5d2ffc372   none      none          off        
-    oxp_5c0dd424-d905-4fc5-a73c-36254fdd470c/crypt/zone                                                            1b990bb0-ea73-430c-bafa-6eb5647af125   none      none          off        
-    oxp_794df76f-bca0-4635-9eb6-773ad0108f7e/crypt/zone                                                            4fc058ac-95d8-4ea4-808c-6b976e95449e   none      none          off        
-    oxp_9024d350-38a7-459b-8550-3b2c4a88b5c1/crypt/zone                                                            208cd4b7-be74-4187-a4e3-21e518bc92a6   none      none          off        
-    oxp_95e86080-e162-4980-a589-db6bb1a95ca7/crypt/zone                                                            bf66b843-7c47-4e46-b629-267111de97b5   none      none          off        
-    oxp_d55d36d7-df92-4615-944d-440a1f8b5001/crypt/zone                                                            5672e912-aa12-4614-b79b-5fcf548e9d96   none      none          off        
-    oxp_db6686c8-2dd9-4032-8444-2a06b43baa68/crypt/zone                                                            99d7b142-b462-4a67-b84e-f3fc79e761fd   none      none          off        
-    oxp_95e86080-e162-4980-a589-db6bb1a95ca7/crypt/zone/oxz_crucible_1437bb47-a2d3-48e9-8902-021ff5057d26          3dd86436-a934-44a8-97b2-1848ab6ebbc9   none      none          off        
-    oxp_5c0dd424-d905-4fc5-a73c-36254fdd470c/crypt/zone/oxz_crucible_31f49108-cdda-4659-bf24-319bf99a9c20          faa7fe52-a532-4784-84f3-376dc8334fdd   none      none          off        
-    oxp_29758363-6c77-40c3-8740-9c0c64f6e14a/crypt/zone/oxz_crucible_5152e5e7-8615-407d-beed-37fd03852ad6          5def9f9d-7e1f-4ef0-94cf-b26f21e6da07   none      none          off        
-    oxp_3f331c10-7882-48ab-85d9-05108490b55b/crypt/zone/oxz_crucible_6593648a-53f3-4a0f-b902-ef6cd7eab43b          9651f8ed-ae45-476c-bca4-42ebe6ee1618   none      none          off        
-    oxp_d55d36d7-df92-4615-944d-440a1f8b5001/crypt/zone/oxz_crucible_754bae61-cbff-402f-b250-91bec499b449          8e72b070-ef13-4082-bcf8-2c54488a4ae1   none      none          off        
-    oxp_12057b4a-0b06-4f70-ba22-336de2385bfe/crypt/zone/oxz_crucible_8f316745-d46d-47cb-8c7e-678fd9021c40          d508ecc2-baf5-4299-9799-e6d30f83663e   none      none          off        
-    oxp_9024d350-38a7-459b-8550-3b2c4a88b5c1/crypt/zone/oxz_crucible_9fdb739d-b149-4f8f-b488-b97d16ea284a          96dc8dcd-700b-4dd7-8970-568e91b93948   none      none          off        
-    oxp_db6686c8-2dd9-4032-8444-2a06b43baa68/crypt/zone/oxz_crucible_b23471ff-b35a-4919-aa3f-3c3683fa3210          646e79ac-9828-4a8d-8173-e385f5e65a15   none      none          off        
-    oxp_794df76f-bca0-4635-9eb6-773ad0108f7e/crypt/zone/oxz_crucible_fa8963b6-dad1-4cf8-9243-c77b3f86d654          2dd82bf7-cad0-4725-ba7d-0cf40b725b39   none      none          off        
-    oxp_5152d1aa-9045-4e06-9ef6-6eadac3696e4/crypt/zone/oxz_crucible_ff5bf6ea-ab3e-40c5-a9a5-cb2bc89de9c8          ead9603d-c1ea-4ea8-9ca7-f3bc31718458   none      none          off        
-    oxp_12057b4a-0b06-4f70-ba22-336de2385bfe/crypt/zone/oxz_crucible_pantry_634fc0b7-9f95-494d-939b-28819cbcaa2b   be2863b0-0d23-4fd4-92e8-ffc4184e5742   none      none          off        
-    oxp_12057b4a-0b06-4f70-ba22-336de2385bfe/crypt/zone/oxz_internal_dns_92628102-eef4-4000-a061-1df796db3806      998bf38c-b6ec-4ddd-80ac-59fc1ee30ca2   none      none          off        
-    oxp_12057b4a-0b06-4f70-ba22-336de2385bfe/crypt/zone/oxz_nexus_7a3ea24a-85f4-4aad-a935-4e7b22766985             73e12d19-7957-4c44-b3e0-fef8d2ad4826   none      none          off        
-    oxp_12057b4a-0b06-4f70-ba22-336de2385bfe/crypt/zone/oxz_ntp_edd3fb4a-6ea7-49a5-82fb-444dfcf6fcc5               305f5727-4d83-4282-9efe-f776ad63aef9   none      none          off        
-    oxp_12057b4a-0b06-4f70-ba22-336de2385bfe/crypt/debug                                                           b3261747-8c28-4c02-8ab7-be1b8cab03fe   100 GiB   none          gzip-9     
-    oxp_29758363-6c77-40c3-8740-9c0c64f6e14a/crypt/debug                                                           be79f715-8cc9-475c-81dd-f3a8141df986   100 GiB   none          gzip-9     
-    oxp_3f331c10-7882-48ab-85d9-05108490b55b/crypt/debug                                                           b0f40911-5074-4dad-bcf9-269e20793f6f   100 GiB   none          gzip-9     
-    oxp_5152d1aa-9045-4e06-9ef6-6eadac3696e4/crypt/debug                                                           1f81c8ba-d0b2-4c24-b8b8-90a5a3148b2a   100 GiB   none          gzip-9     
-    oxp_5c0dd424-d905-4fc5-a73c-36254fdd470c/crypt/debug                                                           b489b3a7-eb94-481f-805d-c93958f566dd   100 GiB   none          gzip-9     
-    oxp_794df76f-bca0-4635-9eb6-773ad0108f7e/crypt/debug                                                           903e2867-5fc0-487b-9d9c-9afe60731a6c   100 GiB   none          gzip-9     
-    oxp_9024d350-38a7-459b-8550-3b2c4a88b5c1/crypt/debug                                                           a02260de-3336-4cbf-ba45-ff79586b40fa   100 GiB   none          gzip-9     
-    oxp_95e86080-e162-4980-a589-db6bb1a95ca7/crypt/debug                                                           667d664c-c5a1-4b77-a54c-6bbb1bcc2096   100 GiB   none          gzip-9     
-    oxp_d55d36d7-df92-4615-944d-440a1f8b5001/crypt/debug                                                           4f4ad767-8887-4892-b6c7-5bc652f3d673   100 GiB   none          gzip-9     
-    oxp_db6686c8-2dd9-4032-8444-2a06b43baa68/crypt/debug                                                           f5b987f9-0a34-4394-8fc5-2ee12bf3e9bf   100 GiB   none          gzip-9     
+    -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
+    dataset name                                                                                                   dataset id                             disposition   quota     reservation   compression
+    -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
+    oxp_12057b4a-0b06-4f70-ba22-336de2385bfe/crucible                                                              55136aae-73db-46b2-bd32-e26634f865ed   in service    none      none          off        
+    oxp_29758363-6c77-40c3-8740-9c0c64f6e14a/crucible                                                              5c4eda29-ed3e-4dc6-b756-afafa1c216b8   in service    none      none          off        
+    oxp_3f331c10-7882-48ab-85d9-05108490b55b/crucible                                                              9b5d5293-2546-43f0-b953-73a696cad4bf   in service    none      none          off        
+    oxp_5152d1aa-9045-4e06-9ef6-6eadac3696e4/crucible                                                              74c65a92-1d4a-44cc-9a55-cd540e9fb57e   in service    none      none          off        
+    oxp_5c0dd424-d905-4fc5-a73c-36254fdd470c/crucible                                                              cc25055b-483e-46ab-a5bf-1d8838b846fd   in service    none      none          off        
+    oxp_794df76f-bca0-4635-9eb6-773ad0108f7e/crucible                                                              8270e505-beff-480a-955b-bf96c4b1a9a3   in service    none      none          off        
+    oxp_9024d350-38a7-459b-8550-3b2c4a88b5c1/crucible                                                              ea234d9d-291b-4adf-9d96-48b7945c2892   in service    none      none          off        
+    oxp_95e86080-e162-4980-a589-db6bb1a95ca7/crucible                                                              d8d9a6d4-f6be-4044-8eac-b994aa166053   in service    none      none          off        
+    oxp_d55d36d7-df92-4615-944d-440a1f8b5001/crucible                                                              64955a3e-2059-4d16-aee4-f63f9362b554   in service    none      none          off        
+    oxp_db6686c8-2dd9-4032-8444-2a06b43baa68/crucible                                                              863c76ac-732e-4d10-b7a3-1d6ba02dc1f5   in service    none      none          off        
+    oxp_12057b4a-0b06-4f70-ba22-336de2385bfe/crypt/internal_dns                                                    b4df380c-6cca-41c1-b79c-45671067d459   in service    none      none          off        
+    oxp_12057b4a-0b06-4f70-ba22-336de2385bfe/crypt/zone                                                            9bcac944-9866-4251-b333-1cbdc137a03e   in service    none      none          off        
+    oxp_29758363-6c77-40c3-8740-9c0c64f6e14a/crypt/zone                                                            0557de8a-45cf-44a0-a39d-4a7095e9045b   in service    none      none          off        
+    oxp_3f331c10-7882-48ab-85d9-05108490b55b/crypt/zone                                                            5f5e1e10-1561-4556-aac1-6b6285df5cb2   in service    none      none          off        
+    oxp_5152d1aa-9045-4e06-9ef6-6eadac3696e4/crypt/zone                                                            52d9152d-e80a-455e-b24a-70b5d2ffc372   in service    none      none          off        
+    oxp_5c0dd424-d905-4fc5-a73c-36254fdd470c/crypt/zone                                                            1b990bb0-ea73-430c-bafa-6eb5647af125   in service    none      none          off        
+    oxp_794df76f-bca0-4635-9eb6-773ad0108f7e/crypt/zone                                                            4fc058ac-95d8-4ea4-808c-6b976e95449e   in service    none      none          off        
+    oxp_9024d350-38a7-459b-8550-3b2c4a88b5c1/crypt/zone                                                            208cd4b7-be74-4187-a4e3-21e518bc92a6   in service    none      none          off        
+    oxp_95e86080-e162-4980-a589-db6bb1a95ca7/crypt/zone                                                            bf66b843-7c47-4e46-b629-267111de97b5   in service    none      none          off        
+    oxp_d55d36d7-df92-4615-944d-440a1f8b5001/crypt/zone                                                            5672e912-aa12-4614-b79b-5fcf548e9d96   in service    none      none          off        
+    oxp_db6686c8-2dd9-4032-8444-2a06b43baa68/crypt/zone                                                            99d7b142-b462-4a67-b84e-f3fc79e761fd   in service    none      none          off        
+    oxp_95e86080-e162-4980-a589-db6bb1a95ca7/crypt/zone/oxz_crucible_1437bb47-a2d3-48e9-8902-021ff5057d26          3dd86436-a934-44a8-97b2-1848ab6ebbc9   in service    none      none          off        
+    oxp_5c0dd424-d905-4fc5-a73c-36254fdd470c/crypt/zone/oxz_crucible_31f49108-cdda-4659-bf24-319bf99a9c20          faa7fe52-a532-4784-84f3-376dc8334fdd   in service    none      none          off        
+    oxp_29758363-6c77-40c3-8740-9c0c64f6e14a/crypt/zone/oxz_crucible_5152e5e7-8615-407d-beed-37fd03852ad6          5def9f9d-7e1f-4ef0-94cf-b26f21e6da07   in service    none      none          off        
+    oxp_3f331c10-7882-48ab-85d9-05108490b55b/crypt/zone/oxz_crucible_6593648a-53f3-4a0f-b902-ef6cd7eab43b          9651f8ed-ae45-476c-bca4-42ebe6ee1618   in service    none      none          off        
+    oxp_d55d36d7-df92-4615-944d-440a1f8b5001/crypt/zone/oxz_crucible_754bae61-cbff-402f-b250-91bec499b449          8e72b070-ef13-4082-bcf8-2c54488a4ae1   in service    none      none          off        
+    oxp_12057b4a-0b06-4f70-ba22-336de2385bfe/crypt/zone/oxz_crucible_8f316745-d46d-47cb-8c7e-678fd9021c40          d508ecc2-baf5-4299-9799-e6d30f83663e   in service    none      none          off        
+    oxp_9024d350-38a7-459b-8550-3b2c4a88b5c1/crypt/zone/oxz_crucible_9fdb739d-b149-4f8f-b488-b97d16ea284a          96dc8dcd-700b-4dd7-8970-568e91b93948   in service    none      none          off        
+    oxp_db6686c8-2dd9-4032-8444-2a06b43baa68/crypt/zone/oxz_crucible_b23471ff-b35a-4919-aa3f-3c3683fa3210          646e79ac-9828-4a8d-8173-e385f5e65a15   in service    none      none          off        
+    oxp_794df76f-bca0-4635-9eb6-773ad0108f7e/crypt/zone/oxz_crucible_fa8963b6-dad1-4cf8-9243-c77b3f86d654          2dd82bf7-cad0-4725-ba7d-0cf40b725b39   in service    none      none          off        
+    oxp_5152d1aa-9045-4e06-9ef6-6eadac3696e4/crypt/zone/oxz_crucible_ff5bf6ea-ab3e-40c5-a9a5-cb2bc89de9c8          ead9603d-c1ea-4ea8-9ca7-f3bc31718458   in service    none      none          off        
+    oxp_12057b4a-0b06-4f70-ba22-336de2385bfe/crypt/zone/oxz_crucible_pantry_634fc0b7-9f95-494d-939b-28819cbcaa2b   be2863b0-0d23-4fd4-92e8-ffc4184e5742   in service    none      none          off        
+    oxp_12057b4a-0b06-4f70-ba22-336de2385bfe/crypt/zone/oxz_internal_dns_92628102-eef4-4000-a061-1df796db3806      998bf38c-b6ec-4ddd-80ac-59fc1ee30ca2   in service    none      none          off        
+    oxp_12057b4a-0b06-4f70-ba22-336de2385bfe/crypt/zone/oxz_nexus_7a3ea24a-85f4-4aad-a935-4e7b22766985             73e12d19-7957-4c44-b3e0-fef8d2ad4826   in service    none      none          off        
+    oxp_12057b4a-0b06-4f70-ba22-336de2385bfe/crypt/zone/oxz_ntp_edd3fb4a-6ea7-49a5-82fb-444dfcf6fcc5               305f5727-4d83-4282-9efe-f776ad63aef9   in service    none      none          off        
+    oxp_12057b4a-0b06-4f70-ba22-336de2385bfe/crypt/debug                                                           b3261747-8c28-4c02-8ab7-be1b8cab03fe   in service    100 GiB   none          gzip-9     
+    oxp_29758363-6c77-40c3-8740-9c0c64f6e14a/crypt/debug                                                           be79f715-8cc9-475c-81dd-f3a8141df986   in service    100 GiB   none          gzip-9     
+    oxp_3f331c10-7882-48ab-85d9-05108490b55b/crypt/debug                                                           b0f40911-5074-4dad-bcf9-269e20793f6f   in service    100 GiB   none          gzip-9     
+    oxp_5152d1aa-9045-4e06-9ef6-6eadac3696e4/crypt/debug                                                           1f81c8ba-d0b2-4c24-b8b8-90a5a3148b2a   in service    100 GiB   none          gzip-9     
+    oxp_5c0dd424-d905-4fc5-a73c-36254fdd470c/crypt/debug                                                           b489b3a7-eb94-481f-805d-c93958f566dd   in service    100 GiB   none          gzip-9     
+    oxp_794df76f-bca0-4635-9eb6-773ad0108f7e/crypt/debug                                                           903e2867-5fc0-487b-9d9c-9afe60731a6c   in service    100 GiB   none          gzip-9     
+    oxp_9024d350-38a7-459b-8550-3b2c4a88b5c1/crypt/debug                                                           a02260de-3336-4cbf-ba45-ff79586b40fa   in service    100 GiB   none          gzip-9     
+    oxp_95e86080-e162-4980-a589-db6bb1a95ca7/crypt/debug                                                           667d664c-c5a1-4b77-a54c-6bbb1bcc2096   in service    100 GiB   none          gzip-9     
+    oxp_d55d36d7-df92-4615-944d-440a1f8b5001/crypt/debug                                                           4f4ad767-8887-4892-b6c7-5bc652f3d673   in service    100 GiB   none          gzip-9     
+    oxp_db6686c8-2dd9-4032-8444-2a06b43baa68/crypt/debug                                                           f5b987f9-0a34-4394-8fc5-2ee12bf3e9bf   in service    100 GiB   none          gzip-9     
 
 
     omicron zones at generation 2:
@@ -203,54 +203,54 @@ to:   blueprint 4171ad05-89dd-474b-846b-b007e4346366
 
 
     datasets at generation 2:
-    -----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
-    dataset name                                                                                                   dataset uuid                           quota     reservation   compression
-    -----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
-    oxp_2a94863d-16e2-4535-973b-e98dd47fd18d/crucible                                                              852963f5-4c4b-4bd9-a5b6-25ea416c25fe   none      none          off        
-    oxp_32456d15-f5b6-4efc-90c8-dbba979b69cb/crucible                                                              d37faff5-a0a8-4b60-bb33-508c478fe1c9   none      none          off        
-    oxp_416fe9f9-5161-4b0f-9e11-c9d81563ded5/crucible                                                              c096ba5f-adbf-498d-8ea5-ba736454d9fb   none      none          off        
-    oxp_4c68800e-23f8-485b-b251-628fd151e445/crucible                                                              56661c11-0041-4ffd-8a0c-72b5fc0486b9   none      none          off        
-    oxp_9dd87c4d-5fb4-475a-86fa-c0da81a3e00a/crucible                                                              b6a3f4cf-27f4-4ba8-b063-b4b3c7b03cc3   none      none          off        
-    oxp_be93a517-445e-46c2-aa21-3dc526d4a413/crucible                                                              f32a5631-dd04-4e2d-a9f9-b5974253601d   none      none          off        
-    oxp_d9344e2b-84d2-4392-84ab-41b86ed02237/crucible                                                              a15aacbb-53de-45e0-a646-a88817c929c6   none      none          off        
-    oxp_eab188d0-b34a-4673-b254-12e705597654/crucible                                                              932f321c-10ae-476a-9721-33b5e76fb989   none      none          off        
-    oxp_f1e0386f-11b6-4cdf-8250-826d256db6b5/crucible                                                              ad47c2f1-68ea-413f-ad9e-0975d02a0e11   none      none          off        
-    oxp_f8c9c9a9-d73e-4cdf-a9af-03cfbbbce12b/crucible                                                              9861aeea-9a0c-4fc7-b3d7-e80f3e5c88a5   none      none          off        
-    oxp_2a94863d-16e2-4535-973b-e98dd47fd18d/crypt/internal_dns                                                    a8eea986-61ba-4723-a97c-61f911210031   none      none          off        
-    oxp_2a94863d-16e2-4535-973b-e98dd47fd18d/crypt/zone                                                            3938e220-b204-4f50-bd73-9c835eb4dea7   none      none          off        
-    oxp_32456d15-f5b6-4efc-90c8-dbba979b69cb/crypt/zone                                                            ba8d7bd5-7282-468c-bba6-28462b5400ff   none      none          off        
-    oxp_416fe9f9-5161-4b0f-9e11-c9d81563ded5/crypt/zone                                                            57497a15-47dd-4eca-a52a-1ee1a3a005b4   none      none          off        
-    oxp_4c68800e-23f8-485b-b251-628fd151e445/crypt/zone                                                            44a73f30-9601-4fbd-9699-deb600252cb1   none      none          off        
-    oxp_9dd87c4d-5fb4-475a-86fa-c0da81a3e00a/crypt/zone                                                            6ce8fc11-2f6e-4c7a-b026-d2f05ee49c8f   none      none          off        
-    oxp_be93a517-445e-46c2-aa21-3dc526d4a413/crypt/zone                                                            babe6a59-94f6-4fbb-b49e-2fda486cc39e   none      none          off        
-    oxp_d9344e2b-84d2-4392-84ab-41b86ed02237/crypt/zone                                                            69686d88-8e89-4137-9377-3e1b61995d79   none      none          off        
-    oxp_eab188d0-b34a-4673-b254-12e705597654/crypt/zone                                                            f1a436b2-d773-4b72-ad3a-fc5d03ae9855   none      none          off        
-    oxp_f1e0386f-11b6-4cdf-8250-826d256db6b5/crypt/zone                                                            8196e6fd-4094-4bc9-ad43-1d774de79b25   none      none          off        
-    oxp_f8c9c9a9-d73e-4cdf-a9af-03cfbbbce12b/crypt/zone                                                            de91df2d-b85b-4300-82f4-70ee5d0c8f71   none      none          off        
-    oxp_32456d15-f5b6-4efc-90c8-dbba979b69cb/crypt/zone/oxz_crucible_3b49c2c6-0b0b-4a11-be95-bf94c1cb54a8          e033c975-ab2f-4d39-96e1-02fc6d95e58f   none      none          off        
-    oxp_d9344e2b-84d2-4392-84ab-41b86ed02237/crypt/zone/oxz_crucible_4c65501d-a08d-4fe5-9c78-2694ce6b3a43          28c2eb82-e779-4629-91af-633e4460cd21   none      none          off        
-    oxp_eab188d0-b34a-4673-b254-12e705597654/crypt/zone/oxz_crucible_60e74b27-a7d7-475e-b5ce-2a92eff4fa63          362a51ca-7116-4df3-96bd-5383c32b33f3   none      none          off        
-    oxp_f1e0386f-11b6-4cdf-8250-826d256db6b5/crypt/zone/oxz_crucible_68f44e7e-8231-40c0-861e-2f4d0c2eb392          1db171be-4a44-473a-bfa0-c9dda78fed77   none      none          off        
-    oxp_2a94863d-16e2-4535-973b-e98dd47fd18d/crypt/zone/oxz_crucible_74fc3000-c4b7-4687-88b5-a27584b45434          00218e6a-5e1b-450c-ad38-624ad37d2fc4   none      none          off        
-    oxp_f8c9c9a9-d73e-4cdf-a9af-03cfbbbce12b/crypt/zone/oxz_crucible_83ae0625-2e61-4637-a1f9-473b21b94f72          418a8d5c-fbe8-46c0-b260-e77eb2235105   none      none          off        
-    oxp_416fe9f9-5161-4b0f-9e11-c9d81563ded5/crypt/zone/oxz_crucible_9b462d74-c05a-4a7e-8d24-449c848a7b13          bea24fa2-353f-4c13-844d-3ce58d682eb7   none      none          off        
-    oxp_be93a517-445e-46c2-aa21-3dc526d4a413/crypt/zone/oxz_crucible_a9ed9f72-e57d-4092-ab0e-bb2000a5459e          dda0482e-cffe-4230-9370-9eebfb9c7121   none      none          off        
-    oxp_4c68800e-23f8-485b-b251-628fd151e445/crypt/zone/oxz_crucible_d84bc314-4895-4331-8afb-22bffdd56699          17f7d94a-7734-4b3b-a108-dc11b114610e   none      none          off        
-    oxp_9dd87c4d-5fb4-475a-86fa-c0da81a3e00a/crypt/zone/oxz_crucible_f1f03b7d-916e-4c5f-8906-1e18e498184d          3f1fb9c9-8a05-44fc-af26-eb71bec3b890   none      none          off        
-    oxp_2a94863d-16e2-4535-973b-e98dd47fd18d/crypt/zone/oxz_crucible_pantry_ecdc7438-a007-4558-96b3-65bdab21a8a9   f48c22cc-5ff7-4170-bdbd-bd082c882de3   none      none          off        
-    oxp_2a94863d-16e2-4535-973b-e98dd47fd18d/crypt/zone/oxz_internal_dns_c1049e2e-7269-4de0-b96e-2e9f8edc90ea      67f5eef3-2c29-4a5c-9664-81dbd5ed55a5   none      none          off        
-    oxp_2a94863d-16e2-4535-973b-e98dd47fd18d/crypt/zone/oxz_nexus_785868d0-a003-4860-acc1-9beee9f39816             2a2e9b25-83b8-4bc3-b934-723c947f56d7   none      none          off        
-    oxp_2a94863d-16e2-4535-973b-e98dd47fd18d/crypt/zone/oxz_ntp_d5b390d3-7280-4d2b-b670-340f91d7ebd7               7b3fae75-9421-4a8d-8524-b17a540f994e   none      none          off        
-    oxp_2a94863d-16e2-4535-973b-e98dd47fd18d/crypt/debug                                                           5eb19f06-e5e9-4b96-b1c3-84355460b2ea   100 GiB   none          gzip-9     
-    oxp_32456d15-f5b6-4efc-90c8-dbba979b69cb/crypt/debug                                                           89ab2d4a-101f-46c5-8bb8-2c93dbe2d020   100 GiB   none          gzip-9     
-    oxp_416fe9f9-5161-4b0f-9e11-c9d81563ded5/crypt/debug                                                           12f242f1-44e6-449d-9dfd-b4c5c1bb5ddf   100 GiB   none          gzip-9     
-    oxp_4c68800e-23f8-485b-b251-628fd151e445/crypt/debug                                                           45d68f02-6f5a-4c8b-9a59-e4554ebbeff7   100 GiB   none          gzip-9     
-    oxp_9dd87c4d-5fb4-475a-86fa-c0da81a3e00a/crypt/debug                                                           e0e621f0-62f6-4425-a4b0-ff659c63ea11   100 GiB   none          gzip-9     
-    oxp_be93a517-445e-46c2-aa21-3dc526d4a413/crypt/debug                                                           b90bbe6c-15d2-4313-9fce-c1b9ccdf38d3   100 GiB   none          gzip-9     
-    oxp_d9344e2b-84d2-4392-84ab-41b86ed02237/crypt/debug                                                           3bae870d-ae7b-4e95-b4ea-419ba251839b   100 GiB   none          gzip-9     
-    oxp_eab188d0-b34a-4673-b254-12e705597654/crypt/debug                                                           b7284180-362b-42ba-b970-90c27a8468c5   100 GiB   none          gzip-9     
-    oxp_f1e0386f-11b6-4cdf-8250-826d256db6b5/crypt/debug                                                           d814aea1-475f-44c2-8dcc-e2cd2d335bf9   100 GiB   none          gzip-9     
-    oxp_f8c9c9a9-d73e-4cdf-a9af-03cfbbbce12b/crypt/debug                                                           fdd77b3a-5ec9-4e1a-bc62-379baa7c5552   100 GiB   none          gzip-9     
+    -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
+    dataset name                                                                                                   dataset id                             disposition   quota     reservation   compression
+    -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
+    oxp_2a94863d-16e2-4535-973b-e98dd47fd18d/crucible                                                              852963f5-4c4b-4bd9-a5b6-25ea416c25fe   in service    none      none          off        
+    oxp_32456d15-f5b6-4efc-90c8-dbba979b69cb/crucible                                                              d37faff5-a0a8-4b60-bb33-508c478fe1c9   in service    none      none          off        
+    oxp_416fe9f9-5161-4b0f-9e11-c9d81563ded5/crucible                                                              c096ba5f-adbf-498d-8ea5-ba736454d9fb   in service    none      none          off        
+    oxp_4c68800e-23f8-485b-b251-628fd151e445/crucible                                                              56661c11-0041-4ffd-8a0c-72b5fc0486b9   in service    none      none          off        
+    oxp_9dd87c4d-5fb4-475a-86fa-c0da81a3e00a/crucible                                                              b6a3f4cf-27f4-4ba8-b063-b4b3c7b03cc3   in service    none      none          off        
+    oxp_be93a517-445e-46c2-aa21-3dc526d4a413/crucible                                                              f32a5631-dd04-4e2d-a9f9-b5974253601d   in service    none      none          off        
+    oxp_d9344e2b-84d2-4392-84ab-41b86ed02237/crucible                                                              a15aacbb-53de-45e0-a646-a88817c929c6   in service    none      none          off        
+    oxp_eab188d0-b34a-4673-b254-12e705597654/crucible                                                              932f321c-10ae-476a-9721-33b5e76fb989   in service    none      none          off        
+    oxp_f1e0386f-11b6-4cdf-8250-826d256db6b5/crucible                                                              ad47c2f1-68ea-413f-ad9e-0975d02a0e11   in service    none      none          off        
+    oxp_f8c9c9a9-d73e-4cdf-a9af-03cfbbbce12b/crucible                                                              9861aeea-9a0c-4fc7-b3d7-e80f3e5c88a5   in service    none      none          off        
+    oxp_2a94863d-16e2-4535-973b-e98dd47fd18d/crypt/internal_dns                                                    a8eea986-61ba-4723-a97c-61f911210031   in service    none      none          off        
+    oxp_2a94863d-16e2-4535-973b-e98dd47fd18d/crypt/zone                                                            3938e220-b204-4f50-bd73-9c835eb4dea7   in service    none      none          off        
+    oxp_32456d15-f5b6-4efc-90c8-dbba979b69cb/crypt/zone                                                            ba8d7bd5-7282-468c-bba6-28462b5400ff   in service    none      none          off        
+    oxp_416fe9f9-5161-4b0f-9e11-c9d81563ded5/crypt/zone                                                            57497a15-47dd-4eca-a52a-1ee1a3a005b4   in service    none      none          off        
+    oxp_4c68800e-23f8-485b-b251-628fd151e445/crypt/zone                                                            44a73f30-9601-4fbd-9699-deb600252cb1   in service    none      none          off        
+    oxp_9dd87c4d-5fb4-475a-86fa-c0da81a3e00a/crypt/zone                                                            6ce8fc11-2f6e-4c7a-b026-d2f05ee49c8f   in service    none      none          off        
+    oxp_be93a517-445e-46c2-aa21-3dc526d4a413/crypt/zone                                                            babe6a59-94f6-4fbb-b49e-2fda486cc39e   in service    none      none          off        
+    oxp_d9344e2b-84d2-4392-84ab-41b86ed02237/crypt/zone                                                            69686d88-8e89-4137-9377-3e1b61995d79   in service    none      none          off        
+    oxp_eab188d0-b34a-4673-b254-12e705597654/crypt/zone                                                            f1a436b2-d773-4b72-ad3a-fc5d03ae9855   in service    none      none          off        
+    oxp_f1e0386f-11b6-4cdf-8250-826d256db6b5/crypt/zone                                                            8196e6fd-4094-4bc9-ad43-1d774de79b25   in service    none      none          off        
+    oxp_f8c9c9a9-d73e-4cdf-a9af-03cfbbbce12b/crypt/zone                                                            de91df2d-b85b-4300-82f4-70ee5d0c8f71   in service    none      none          off        
+    oxp_32456d15-f5b6-4efc-90c8-dbba979b69cb/crypt/zone/oxz_crucible_3b49c2c6-0b0b-4a11-be95-bf94c1cb54a8          e033c975-ab2f-4d39-96e1-02fc6d95e58f   in service    none      none          off        
+    oxp_d9344e2b-84d2-4392-84ab-41b86ed02237/crypt/zone/oxz_crucible_4c65501d-a08d-4fe5-9c78-2694ce6b3a43          28c2eb82-e779-4629-91af-633e4460cd21   in service    none      none          off        
+    oxp_eab188d0-b34a-4673-b254-12e705597654/crypt/zone/oxz_crucible_60e74b27-a7d7-475e-b5ce-2a92eff4fa63          362a51ca-7116-4df3-96bd-5383c32b33f3   in service    none      none          off        
+    oxp_f1e0386f-11b6-4cdf-8250-826d256db6b5/crypt/zone/oxz_crucible_68f44e7e-8231-40c0-861e-2f4d0c2eb392          1db171be-4a44-473a-bfa0-c9dda78fed77   in service    none      none          off        
+    oxp_2a94863d-16e2-4535-973b-e98dd47fd18d/crypt/zone/oxz_crucible_74fc3000-c4b7-4687-88b5-a27584b45434          00218e6a-5e1b-450c-ad38-624ad37d2fc4   in service    none      none          off        
+    oxp_f8c9c9a9-d73e-4cdf-a9af-03cfbbbce12b/crypt/zone/oxz_crucible_83ae0625-2e61-4637-a1f9-473b21b94f72          418a8d5c-fbe8-46c0-b260-e77eb2235105   in service    none      none          off        
+    oxp_416fe9f9-5161-4b0f-9e11-c9d81563ded5/crypt/zone/oxz_crucible_9b462d74-c05a-4a7e-8d24-449c848a7b13          bea24fa2-353f-4c13-844d-3ce58d682eb7   in service    none      none          off        
+    oxp_be93a517-445e-46c2-aa21-3dc526d4a413/crypt/zone/oxz_crucible_a9ed9f72-e57d-4092-ab0e-bb2000a5459e          dda0482e-cffe-4230-9370-9eebfb9c7121   in service    none      none          off        
+    oxp_4c68800e-23f8-485b-b251-628fd151e445/crypt/zone/oxz_crucible_d84bc314-4895-4331-8afb-22bffdd56699          17f7d94a-7734-4b3b-a108-dc11b114610e   in service    none      none          off        
+    oxp_9dd87c4d-5fb4-475a-86fa-c0da81a3e00a/crypt/zone/oxz_crucible_f1f03b7d-916e-4c5f-8906-1e18e498184d          3f1fb9c9-8a05-44fc-af26-eb71bec3b890   in service    none      none          off        
+    oxp_2a94863d-16e2-4535-973b-e98dd47fd18d/crypt/zone/oxz_crucible_pantry_ecdc7438-a007-4558-96b3-65bdab21a8a9   f48c22cc-5ff7-4170-bdbd-bd082c882de3   in service    none      none          off        
+    oxp_2a94863d-16e2-4535-973b-e98dd47fd18d/crypt/zone/oxz_internal_dns_c1049e2e-7269-4de0-b96e-2e9f8edc90ea      67f5eef3-2c29-4a5c-9664-81dbd5ed55a5   in service    none      none          off        
+    oxp_2a94863d-16e2-4535-973b-e98dd47fd18d/crypt/zone/oxz_nexus_785868d0-a003-4860-acc1-9beee9f39816             2a2e9b25-83b8-4bc3-b934-723c947f56d7   in service    none      none          off        
+    oxp_2a94863d-16e2-4535-973b-e98dd47fd18d/crypt/zone/oxz_ntp_d5b390d3-7280-4d2b-b670-340f91d7ebd7               7b3fae75-9421-4a8d-8524-b17a540f994e   in service    none      none          off        
+    oxp_2a94863d-16e2-4535-973b-e98dd47fd18d/crypt/debug                                                           5eb19f06-e5e9-4b96-b1c3-84355460b2ea   in service    100 GiB   none          gzip-9     
+    oxp_32456d15-f5b6-4efc-90c8-dbba979b69cb/crypt/debug                                                           89ab2d4a-101f-46c5-8bb8-2c93dbe2d020   in service    100 GiB   none          gzip-9     
+    oxp_416fe9f9-5161-4b0f-9e11-c9d81563ded5/crypt/debug                                                           12f242f1-44e6-449d-9dfd-b4c5c1bb5ddf   in service    100 GiB   none          gzip-9     
+    oxp_4c68800e-23f8-485b-b251-628fd151e445/crypt/debug                                                           45d68f02-6f5a-4c8b-9a59-e4554ebbeff7   in service    100 GiB   none          gzip-9     
+    oxp_9dd87c4d-5fb4-475a-86fa-c0da81a3e00a/crypt/debug                                                           e0e621f0-62f6-4425-a4b0-ff659c63ea11   in service    100 GiB   none          gzip-9     
+    oxp_be93a517-445e-46c2-aa21-3dc526d4a413/crypt/debug                                                           b90bbe6c-15d2-4313-9fce-c1b9ccdf38d3   in service    100 GiB   none          gzip-9     
+    oxp_d9344e2b-84d2-4392-84ab-41b86ed02237/crypt/debug                                                           3bae870d-ae7b-4e95-b4ea-419ba251839b   in service    100 GiB   none          gzip-9     
+    oxp_eab188d0-b34a-4673-b254-12e705597654/crypt/debug                                                           b7284180-362b-42ba-b970-90c27a8468c5   in service    100 GiB   none          gzip-9     
+    oxp_f1e0386f-11b6-4cdf-8250-826d256db6b5/crypt/debug                                                           d814aea1-475f-44c2-8dcc-e2cd2d335bf9   in service    100 GiB   none          gzip-9     
+    oxp_f8c9c9a9-d73e-4cdf-a9af-03cfbbbce12b/crypt/debug                                                           fdd77b3a-5ec9-4e1a-bc62-379baa7c5552   in service    100 GiB   none          gzip-9     
 
 
     omicron zones at generation 2:
@@ -294,30 +294,30 @@ to:   blueprint 4171ad05-89dd-474b-846b-b007e4346366
 
 
     datasets at generation 2:
-    -----------------------------------------------------------------------------------------------------------------------------------------------------------------------------
-    dataset name                                                                                       dataset uuid                           quota     reservation   compression
-    -----------------------------------------------------------------------------------------------------------------------------------------------------------------------------
-+   oxp_28699448-c5d9-49ea-bf7e-627800efe783/crypt/zone                                                bd515f95-ef75-4243-b279-5448e8c56693   none      none          off        
-+   oxp_2c490e96-27f2-4a7f-b440-04d4bfd1e4f6/crypt/zone                                                a5ebe3b2-007d-4cb6-a01b-519eb696dd51   none      none          off        
-+   oxp_4c3bb1c7-55b6-49b8-b212-516b8f2c26c2/crypt/zone                                                292da7cf-54f6-4d8c-a941-eebe5d47fe50   none      none          off        
-+   oxp_5db07562-31a8-43e3-b99e-7c7cb89754b7/crypt/zone                                                58573ab1-3d00-4251-9e32-1c8c94d41689   none      none          off        
-+   oxp_9451a5d5-b358-4719-b6c1-a0d187da217c/crypt/zone                                                823a6464-7317-41c4-88d1-317e6156da3b   none      none          off        
-+   oxp_bb2e2869-9481-483a-bc49-2bdd62f515f5/crypt/zone                                                edf02038-6f07-4788-80f7-1c9ef4537956   none      none          off        
-+   oxp_d5a36c66-4b2f-46e6-96f4-b82debee1a4a/crypt/zone                                                77234c3d-1877-4d9b-9885-cd70b05f6d3d   none      none          off        
-+   oxp_f99ec996-ec08-4ccf-9a6e-6c5cab440fb4/crypt/zone                                                04ebd243-fe45-4222-a437-da51aa719c37   none      none          off        
-+   oxp_faccbb39-d686-42a1-a50a-0eb59ba74a87/crypt/zone                                                b6c84399-0029-4eaa-af95-328e62813332   none      none          off        
-+   oxp_fdfd067b-1d86-444d-a21f-ed33709f3e4d/crypt/zone                                                d1121115-497a-49a1-8908-2bc330bb5b98   none      none          off        
-+   oxp_28699448-c5d9-49ea-bf7e-627800efe783/crypt/zone/oxz_ntp_f4a71d99-95e2-484a-ae67-6f98aacee92b   2178dce4-6fba-4b15-b5ce-ece8c54083b5   none      none          off        
-+   oxp_28699448-c5d9-49ea-bf7e-627800efe783/crypt/debug                                               9c2fc653-d640-4d06-8fb0-a32ce35309b7   100 GiB   none          gzip-9     
-+   oxp_2c490e96-27f2-4a7f-b440-04d4bfd1e4f6/crypt/debug                                               3544ad60-7696-44a4-812d-1e830e2de897   100 GiB   none          gzip-9     
-+   oxp_4c3bb1c7-55b6-49b8-b212-516b8f2c26c2/crypt/debug                                               81d852cd-0bfd-4f3a-98b5-641657f2acda   100 GiB   none          gzip-9     
-+   oxp_5db07562-31a8-43e3-b99e-7c7cb89754b7/crypt/debug                                               fa35030d-d14d-4969-9dbf-38dfb7bd4a4d   100 GiB   none          gzip-9     
-+   oxp_9451a5d5-b358-4719-b6c1-a0d187da217c/crypt/debug                                               2110ad2b-9665-4427-b6fb-9059d3d65070   100 GiB   none          gzip-9     
-+   oxp_bb2e2869-9481-483a-bc49-2bdd62f515f5/crypt/debug                                               c4f6dae6-d357-4ad3-becd-5e49c4dcf171   100 GiB   none          gzip-9     
-+   oxp_d5a36c66-4b2f-46e6-96f4-b82debee1a4a/crypt/debug                                               25c84622-b39a-4c28-9dd5-1f9f33170150   100 GiB   none          gzip-9     
-+   oxp_f99ec996-ec08-4ccf-9a6e-6c5cab440fb4/crypt/debug                                               1a88aed3-4f65-479a-8677-af5771feade4   100 GiB   none          gzip-9     
-+   oxp_faccbb39-d686-42a1-a50a-0eb59ba74a87/crypt/debug                                               25eff656-ae3f-42bc-9bfb-8adbc9a1f146   100 GiB   none          gzip-9     
-+   oxp_fdfd067b-1d86-444d-a21f-ed33709f3e4d/crypt/debug                                               ecba8219-9446-4f43-a2fd-098f54ebdfd2   100 GiB   none          gzip-9     
+    -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
+    dataset name                                                                                       dataset id                             disposition   quota     reservation   compression
+    -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
++   oxp_28699448-c5d9-49ea-bf7e-627800efe783/crypt/zone                                                bd515f95-ef75-4243-b279-5448e8c56693   in service    none      none          off        
++   oxp_2c490e96-27f2-4a7f-b440-04d4bfd1e4f6/crypt/zone                                                a5ebe3b2-007d-4cb6-a01b-519eb696dd51   in service    none      none          off        
++   oxp_4c3bb1c7-55b6-49b8-b212-516b8f2c26c2/crypt/zone                                                292da7cf-54f6-4d8c-a941-eebe5d47fe50   in service    none      none          off        
++   oxp_5db07562-31a8-43e3-b99e-7c7cb89754b7/crypt/zone                                                58573ab1-3d00-4251-9e32-1c8c94d41689   in service    none      none          off        
++   oxp_9451a5d5-b358-4719-b6c1-a0d187da217c/crypt/zone                                                823a6464-7317-41c4-88d1-317e6156da3b   in service    none      none          off        
++   oxp_bb2e2869-9481-483a-bc49-2bdd62f515f5/crypt/zone                                                edf02038-6f07-4788-80f7-1c9ef4537956   in service    none      none          off        
++   oxp_d5a36c66-4b2f-46e6-96f4-b82debee1a4a/crypt/zone                                                77234c3d-1877-4d9b-9885-cd70b05f6d3d   in service    none      none          off        
++   oxp_f99ec996-ec08-4ccf-9a6e-6c5cab440fb4/crypt/zone                                                04ebd243-fe45-4222-a437-da51aa719c37   in service    none      none          off        
++   oxp_faccbb39-d686-42a1-a50a-0eb59ba74a87/crypt/zone                                                b6c84399-0029-4eaa-af95-328e62813332   in service    none      none          off        
++   oxp_fdfd067b-1d86-444d-a21f-ed33709f3e4d/crypt/zone                                                d1121115-497a-49a1-8908-2bc330bb5b98   in service    none      none          off        
++   oxp_28699448-c5d9-49ea-bf7e-627800efe783/crypt/zone/oxz_ntp_f4a71d99-95e2-484a-ae67-6f98aacee92b   2178dce4-6fba-4b15-b5ce-ece8c54083b5   in service    none      none          off        
++   oxp_28699448-c5d9-49ea-bf7e-627800efe783/crypt/debug                                               9c2fc653-d640-4d06-8fb0-a32ce35309b7   in service    100 GiB   none          gzip-9     
++   oxp_2c490e96-27f2-4a7f-b440-04d4bfd1e4f6/crypt/debug                                               3544ad60-7696-44a4-812d-1e830e2de897   in service    100 GiB   none          gzip-9     
++   oxp_4c3bb1c7-55b6-49b8-b212-516b8f2c26c2/crypt/debug                                               81d852cd-0bfd-4f3a-98b5-641657f2acda   in service    100 GiB   none          gzip-9     
++   oxp_5db07562-31a8-43e3-b99e-7c7cb89754b7/crypt/debug                                               fa35030d-d14d-4969-9dbf-38dfb7bd4a4d   in service    100 GiB   none          gzip-9     
++   oxp_9451a5d5-b358-4719-b6c1-a0d187da217c/crypt/debug                                               2110ad2b-9665-4427-b6fb-9059d3d65070   in service    100 GiB   none          gzip-9     
++   oxp_bb2e2869-9481-483a-bc49-2bdd62f515f5/crypt/debug                                               c4f6dae6-d357-4ad3-becd-5e49c4dcf171   in service    100 GiB   none          gzip-9     
++   oxp_d5a36c66-4b2f-46e6-96f4-b82debee1a4a/crypt/debug                                               25c84622-b39a-4c28-9dd5-1f9f33170150   in service    100 GiB   none          gzip-9     
++   oxp_f99ec996-ec08-4ccf-9a6e-6c5cab440fb4/crypt/debug                                               1a88aed3-4f65-479a-8677-af5771feade4   in service    100 GiB   none          gzip-9     
++   oxp_faccbb39-d686-42a1-a50a-0eb59ba74a87/crypt/debug                                               25eff656-ae3f-42bc-9bfb-8adbc9a1f146   in service    100 GiB   none          gzip-9     
++   oxp_fdfd067b-1d86-444d-a21f-ed33709f3e4d/crypt/debug                                               ecba8219-9446-4f43-a2fd-098f54ebdfd2   in service    100 GiB   none          gzip-9     
 
 
     omicron zones at generation 2:

--- a/nexus/reconfigurator/planning/tests/output/planner_basic_add_sled_3_5.txt
+++ b/nexus/reconfigurator/planning/tests/output/planner_basic_add_sled_3_5.txt
@@ -22,56 +22,56 @@ to:   blueprint f432fcd5-1284-4058-8b4a-9286a3de6163
 
 
     datasets at generation 2:
-    -----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
-    dataset name                                                                                                   dataset uuid                           quota     reservation   compression
-    -----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
-    oxp_014eb1e9-04fe-4f36-8339-0a090b053ada/crucible                                                              ea8bb9f4-ef14-4764-8713-299c94aee754   none      none          off        
-    oxp_31a3bc64-7a3b-496d-b644-785dc44b6e37/crucible                                                              7dcb9cca-dcac-4d95-92d1-f9ee376558ee   none      none          off        
-    oxp_7bb40bd6-9c43-4b63-8337-18313c72aea2/crucible                                                              87f012e5-1979-4d4f-abd7-5004e6a4de4a   none      none          off        
-    oxp_988aa8c2-cb5e-406b-9289-425dc2e5bc3a/crucible                                                              8a017cce-a6e3-4891-80d2-282134012f1f   none      none          off        
-    oxp_ad574c09-2ae0-4534-a2a4-f923ce20ae87/crucible                                                              51734f27-2839-481c-b11d-f59843297269   none      none          off        
-    oxp_ad91e238-4901-4ff4-a91b-75233c936426/crucible                                                              4ebb5c8c-77cc-4d9a-a66a-aab846d7f4d7   none      none          off        
-    oxp_ce58d463-d442-4c97-a6b4-f7d98c3fd902/crucible                                                              7e930ce3-f0e6-4188-940a-07dee8fc97cd   none      none          off        
-    oxp_f18f7689-0059-4b79-880e-34faf7a0fe0e/crucible                                                              e688234b-9854-4a4e-ae8e-5ec66a323784   none      none          off        
-    oxp_f1d6cea4-640f-415e-89fe-2b1784ce3db8/crucible                                                              48a12bd9-3d59-4151-adf1-ff703d71977c   none      none          off        
-    oxp_f4a96860-bdeb-4435-bdf5-2a10beb3d44a/crucible                                                              4a0ed488-8ab7-4a8b-90da-ab568081832b   none      none          off        
-    oxp_014eb1e9-04fe-4f36-8339-0a090b053ada/crypt/clickhouse                                                      87d67ac6-6079-4a4c-960e-44991410a64c   none      none          off        
-    oxp_014eb1e9-04fe-4f36-8339-0a090b053ada/crypt/internal_dns                                                    31caca18-3e69-4e95-a48e-1a3f9219a304   none      none          off        
-    oxp_014eb1e9-04fe-4f36-8339-0a090b053ada/crypt/zone                                                            8df851fd-0e0c-4069-ad4b-e8669051e42d   none      none          off        
-    oxp_31a3bc64-7a3b-496d-b644-785dc44b6e37/crypt/zone                                                            3c2b2846-d286-4ac7-9001-1dbc92d8ec52   none      none          off        
-    oxp_7bb40bd6-9c43-4b63-8337-18313c72aea2/crypt/zone                                                            d7519dd3-b371-4570-b474-e198d679bc47   none      none          off        
-    oxp_988aa8c2-cb5e-406b-9289-425dc2e5bc3a/crypt/zone                                                            da77f084-5fc9-477a-a5b1-e424f98aa53f   none      none          off        
-    oxp_ad574c09-2ae0-4534-a2a4-f923ce20ae87/crypt/zone                                                            8ffb3c67-d81d-4edc-b4fa-f829bc6d9fb5   none      none          off        
-    oxp_ad91e238-4901-4ff4-a91b-75233c936426/crypt/zone                                                            12c23a3b-389d-4f4f-950e-f7e36ae44262   none      none          off        
-    oxp_ce58d463-d442-4c97-a6b4-f7d98c3fd902/crypt/zone                                                            6614568a-a5a5-4db2-80f2-3e405fe35e17   none      none          off        
-    oxp_f18f7689-0059-4b79-880e-34faf7a0fe0e/crypt/zone                                                            a7d4d358-7935-4060-985f-280829de083c   none      none          off        
-    oxp_f1d6cea4-640f-415e-89fe-2b1784ce3db8/crypt/zone                                                            35decedb-c97e-4fde-9ee2-26680ccc7f7e   none      none          off        
-    oxp_f4a96860-bdeb-4435-bdf5-2a10beb3d44a/crypt/zone                                                            a0b8487f-b194-4583-ab31-3b02d85af60b   none      none          off        
-    oxp_014eb1e9-04fe-4f36-8339-0a090b053ada/crypt/zone/oxz_clickhouse_98229df2-6faf-45a4-8501-48e1ad25706e        0bda3f6e-6852-4476-8539-8d6315466ccb   none      none          off        
-    oxp_ad574c09-2ae0-4534-a2a4-f923ce20ae87/crypt/zone/oxz_crucible_3384bb31-72f2-46fc-9ada-b324580e2930          707c72de-e19c-4c7b-b2a1-4b028e1026c9   none      none          off        
-    oxp_f1d6cea4-640f-415e-89fe-2b1784ce3db8/crypt/zone/oxz_crucible_397f4188-68b0-4d82-aea4-5b950f6fc779          8cab65a0-26af-42e7-9f77-10a03096edf0   none      none          off        
-    oxp_988aa8c2-cb5e-406b-9289-425dc2e5bc3a/crypt/zone/oxz_crucible_4a35beea-a998-4ef1-845c-55d69d35108f          74aacf3e-7c5b-44d5-869c-ae04c9f70bf9   none      none          off        
-    oxp_ad91e238-4901-4ff4-a91b-75233c936426/crypt/zone/oxz_crucible_5710b56a-a07e-49e2-8dfb-34f1c87ca02e          1e1bfd91-4900-4869-9b17-d6ff94d95301   none      none          off        
-    oxp_f4a96860-bdeb-4435-bdf5-2a10beb3d44a/crypt/zone/oxz_crucible_62b70007-57c1-4086-8e35-e61443f0c259          b1217132-9894-472e-a763-626798f46cc2   none      none          off        
-    oxp_014eb1e9-04fe-4f36-8339-0a090b053ada/crypt/zone/oxz_crucible_8ca9bfdc-c3a6-4280-ad34-b5af8fd5187e          14b40d48-c5b1-4e8e-90ec-e374d824204d   none      none          off        
-    oxp_31a3bc64-7a3b-496d-b644-785dc44b6e37/crypt/zone/oxz_crucible_9c927800-ba15-4e84-b80e-781606bec308          eb2960e5-5b89-432f-a384-3009d3b3db5d   none      none          off        
-    oxp_ce58d463-d442-4c97-a6b4-f7d98c3fd902/crypt/zone/oxz_crucible_a7cab59f-59f2-4cb9-b559-551dc6c43aaf          8c16b33b-54f3-453d-a28a-baed87bd45da   none      none          off        
-    oxp_f18f7689-0059-4b79-880e-34faf7a0fe0e/crypt/zone/oxz_crucible_cb67f66d-37e3-40a6-adbd-69962fb6cf73          52036fa0-92ad-4444-8156-01d0b2e9b676   none      none          off        
-    oxp_7bb40bd6-9c43-4b63-8337-18313c72aea2/crypt/zone/oxz_crucible_da2fc172-8cb2-4d66-a92b-017a97842c27          3aa614f6-5a75-44a0-a950-6adb6c299299   none      none          off        
-    oxp_014eb1e9-04fe-4f36-8339-0a090b053ada/crypt/zone/oxz_crucible_pantry_be4a1d4a-093f-40e0-8e06-74cc1d786d1b   25438f31-b9e0-499f-a55f-9bfcb0a4194d   none      none          off        
-    oxp_014eb1e9-04fe-4f36-8339-0a090b053ada/crypt/zone/oxz_internal_dns_2a6f89a2-3476-4c3b-97b2-322f00f2fc9a      572f2970-46ed-46e1-b600-d021e080903e   none      none          off        
-    oxp_014eb1e9-04fe-4f36-8339-0a090b053ada/crypt/zone/oxz_nexus_fb07dee1-d608-451b-83eb-4ee913d6e1f8             0e2d27bc-01d7-4afd-82e2-973db6138e70   none      none          off        
-    oxp_014eb1e9-04fe-4f36-8339-0a090b053ada/crypt/zone/oxz_ntp_d7ffba91-8f9d-4168-89a4-26c6c4370cb0               63e6eeb0-e079-4165-9444-8aac3d50fef3   none      none          off        
-    oxp_014eb1e9-04fe-4f36-8339-0a090b053ada/crypt/debug                                                           9982db80-b762-4c5f-9916-35383d59b6df   100 GiB   none          gzip-9     
-    oxp_31a3bc64-7a3b-496d-b644-785dc44b6e37/crypt/debug                                                           fd25bb57-dc4b-42ea-a2ab-d6395b38334f   100 GiB   none          gzip-9     
-    oxp_7bb40bd6-9c43-4b63-8337-18313c72aea2/crypt/debug                                                           95f111d8-854f-4177-bcff-481e625dd73d   100 GiB   none          gzip-9     
-    oxp_988aa8c2-cb5e-406b-9289-425dc2e5bc3a/crypt/debug                                                           38903da8-c23d-4516-b0ca-6036e26c49e4   100 GiB   none          gzip-9     
-    oxp_ad574c09-2ae0-4534-a2a4-f923ce20ae87/crypt/debug                                                           216e74e6-691b-45f9-ad7f-037ae799a8c9   100 GiB   none          gzip-9     
-    oxp_ad91e238-4901-4ff4-a91b-75233c936426/crypt/debug                                                           e598cc97-90c4-403a-b7fc-741f8b93de87   100 GiB   none          gzip-9     
-    oxp_ce58d463-d442-4c97-a6b4-f7d98c3fd902/crypt/debug                                                           235746b2-5d3f-4608-9017-2bd8d1521d2b   100 GiB   none          gzip-9     
-    oxp_f18f7689-0059-4b79-880e-34faf7a0fe0e/crypt/debug                                                           08fdf2b1-430d-4a5c-adf3-b0a0f323ae9d   100 GiB   none          gzip-9     
-    oxp_f1d6cea4-640f-415e-89fe-2b1784ce3db8/crypt/debug                                                           ea7fa07f-f47b-4039-a0db-6ab9ca0f0e2c   100 GiB   none          gzip-9     
-    oxp_f4a96860-bdeb-4435-bdf5-2a10beb3d44a/crypt/debug                                                           547cb9ee-f196-4dfe-9f2c-aa4b2f114abe   100 GiB   none          gzip-9     
+    -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
+    dataset name                                                                                                   dataset id                             disposition   quota     reservation   compression
+    -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
+    oxp_014eb1e9-04fe-4f36-8339-0a090b053ada/crucible                                                              ea8bb9f4-ef14-4764-8713-299c94aee754   in service    none      none          off        
+    oxp_31a3bc64-7a3b-496d-b644-785dc44b6e37/crucible                                                              7dcb9cca-dcac-4d95-92d1-f9ee376558ee   in service    none      none          off        
+    oxp_7bb40bd6-9c43-4b63-8337-18313c72aea2/crucible                                                              87f012e5-1979-4d4f-abd7-5004e6a4de4a   in service    none      none          off        
+    oxp_988aa8c2-cb5e-406b-9289-425dc2e5bc3a/crucible                                                              8a017cce-a6e3-4891-80d2-282134012f1f   in service    none      none          off        
+    oxp_ad574c09-2ae0-4534-a2a4-f923ce20ae87/crucible                                                              51734f27-2839-481c-b11d-f59843297269   in service    none      none          off        
+    oxp_ad91e238-4901-4ff4-a91b-75233c936426/crucible                                                              4ebb5c8c-77cc-4d9a-a66a-aab846d7f4d7   in service    none      none          off        
+    oxp_ce58d463-d442-4c97-a6b4-f7d98c3fd902/crucible                                                              7e930ce3-f0e6-4188-940a-07dee8fc97cd   in service    none      none          off        
+    oxp_f18f7689-0059-4b79-880e-34faf7a0fe0e/crucible                                                              e688234b-9854-4a4e-ae8e-5ec66a323784   in service    none      none          off        
+    oxp_f1d6cea4-640f-415e-89fe-2b1784ce3db8/crucible                                                              48a12bd9-3d59-4151-adf1-ff703d71977c   in service    none      none          off        
+    oxp_f4a96860-bdeb-4435-bdf5-2a10beb3d44a/crucible                                                              4a0ed488-8ab7-4a8b-90da-ab568081832b   in service    none      none          off        
+    oxp_014eb1e9-04fe-4f36-8339-0a090b053ada/crypt/clickhouse                                                      87d67ac6-6079-4a4c-960e-44991410a64c   in service    none      none          off        
+    oxp_014eb1e9-04fe-4f36-8339-0a090b053ada/crypt/internal_dns                                                    31caca18-3e69-4e95-a48e-1a3f9219a304   in service    none      none          off        
+    oxp_014eb1e9-04fe-4f36-8339-0a090b053ada/crypt/zone                                                            8df851fd-0e0c-4069-ad4b-e8669051e42d   in service    none      none          off        
+    oxp_31a3bc64-7a3b-496d-b644-785dc44b6e37/crypt/zone                                                            3c2b2846-d286-4ac7-9001-1dbc92d8ec52   in service    none      none          off        
+    oxp_7bb40bd6-9c43-4b63-8337-18313c72aea2/crypt/zone                                                            d7519dd3-b371-4570-b474-e198d679bc47   in service    none      none          off        
+    oxp_988aa8c2-cb5e-406b-9289-425dc2e5bc3a/crypt/zone                                                            da77f084-5fc9-477a-a5b1-e424f98aa53f   in service    none      none          off        
+    oxp_ad574c09-2ae0-4534-a2a4-f923ce20ae87/crypt/zone                                                            8ffb3c67-d81d-4edc-b4fa-f829bc6d9fb5   in service    none      none          off        
+    oxp_ad91e238-4901-4ff4-a91b-75233c936426/crypt/zone                                                            12c23a3b-389d-4f4f-950e-f7e36ae44262   in service    none      none          off        
+    oxp_ce58d463-d442-4c97-a6b4-f7d98c3fd902/crypt/zone                                                            6614568a-a5a5-4db2-80f2-3e405fe35e17   in service    none      none          off        
+    oxp_f18f7689-0059-4b79-880e-34faf7a0fe0e/crypt/zone                                                            a7d4d358-7935-4060-985f-280829de083c   in service    none      none          off        
+    oxp_f1d6cea4-640f-415e-89fe-2b1784ce3db8/crypt/zone                                                            35decedb-c97e-4fde-9ee2-26680ccc7f7e   in service    none      none          off        
+    oxp_f4a96860-bdeb-4435-bdf5-2a10beb3d44a/crypt/zone                                                            a0b8487f-b194-4583-ab31-3b02d85af60b   in service    none      none          off        
+    oxp_014eb1e9-04fe-4f36-8339-0a090b053ada/crypt/zone/oxz_clickhouse_98229df2-6faf-45a4-8501-48e1ad25706e        0bda3f6e-6852-4476-8539-8d6315466ccb   in service    none      none          off        
+    oxp_ad574c09-2ae0-4534-a2a4-f923ce20ae87/crypt/zone/oxz_crucible_3384bb31-72f2-46fc-9ada-b324580e2930          707c72de-e19c-4c7b-b2a1-4b028e1026c9   in service    none      none          off        
+    oxp_f1d6cea4-640f-415e-89fe-2b1784ce3db8/crypt/zone/oxz_crucible_397f4188-68b0-4d82-aea4-5b950f6fc779          8cab65a0-26af-42e7-9f77-10a03096edf0   in service    none      none          off        
+    oxp_988aa8c2-cb5e-406b-9289-425dc2e5bc3a/crypt/zone/oxz_crucible_4a35beea-a998-4ef1-845c-55d69d35108f          74aacf3e-7c5b-44d5-869c-ae04c9f70bf9   in service    none      none          off        
+    oxp_ad91e238-4901-4ff4-a91b-75233c936426/crypt/zone/oxz_crucible_5710b56a-a07e-49e2-8dfb-34f1c87ca02e          1e1bfd91-4900-4869-9b17-d6ff94d95301   in service    none      none          off        
+    oxp_f4a96860-bdeb-4435-bdf5-2a10beb3d44a/crypt/zone/oxz_crucible_62b70007-57c1-4086-8e35-e61443f0c259          b1217132-9894-472e-a763-626798f46cc2   in service    none      none          off        
+    oxp_014eb1e9-04fe-4f36-8339-0a090b053ada/crypt/zone/oxz_crucible_8ca9bfdc-c3a6-4280-ad34-b5af8fd5187e          14b40d48-c5b1-4e8e-90ec-e374d824204d   in service    none      none          off        
+    oxp_31a3bc64-7a3b-496d-b644-785dc44b6e37/crypt/zone/oxz_crucible_9c927800-ba15-4e84-b80e-781606bec308          eb2960e5-5b89-432f-a384-3009d3b3db5d   in service    none      none          off        
+    oxp_ce58d463-d442-4c97-a6b4-f7d98c3fd902/crypt/zone/oxz_crucible_a7cab59f-59f2-4cb9-b559-551dc6c43aaf          8c16b33b-54f3-453d-a28a-baed87bd45da   in service    none      none          off        
+    oxp_f18f7689-0059-4b79-880e-34faf7a0fe0e/crypt/zone/oxz_crucible_cb67f66d-37e3-40a6-adbd-69962fb6cf73          52036fa0-92ad-4444-8156-01d0b2e9b676   in service    none      none          off        
+    oxp_7bb40bd6-9c43-4b63-8337-18313c72aea2/crypt/zone/oxz_crucible_da2fc172-8cb2-4d66-a92b-017a97842c27          3aa614f6-5a75-44a0-a950-6adb6c299299   in service    none      none          off        
+    oxp_014eb1e9-04fe-4f36-8339-0a090b053ada/crypt/zone/oxz_crucible_pantry_be4a1d4a-093f-40e0-8e06-74cc1d786d1b   25438f31-b9e0-499f-a55f-9bfcb0a4194d   in service    none      none          off        
+    oxp_014eb1e9-04fe-4f36-8339-0a090b053ada/crypt/zone/oxz_internal_dns_2a6f89a2-3476-4c3b-97b2-322f00f2fc9a      572f2970-46ed-46e1-b600-d021e080903e   in service    none      none          off        
+    oxp_014eb1e9-04fe-4f36-8339-0a090b053ada/crypt/zone/oxz_nexus_fb07dee1-d608-451b-83eb-4ee913d6e1f8             0e2d27bc-01d7-4afd-82e2-973db6138e70   in service    none      none          off        
+    oxp_014eb1e9-04fe-4f36-8339-0a090b053ada/crypt/zone/oxz_ntp_d7ffba91-8f9d-4168-89a4-26c6c4370cb0               63e6eeb0-e079-4165-9444-8aac3d50fef3   in service    none      none          off        
+    oxp_014eb1e9-04fe-4f36-8339-0a090b053ada/crypt/debug                                                           9982db80-b762-4c5f-9916-35383d59b6df   in service    100 GiB   none          gzip-9     
+    oxp_31a3bc64-7a3b-496d-b644-785dc44b6e37/crypt/debug                                                           fd25bb57-dc4b-42ea-a2ab-d6395b38334f   in service    100 GiB   none          gzip-9     
+    oxp_7bb40bd6-9c43-4b63-8337-18313c72aea2/crypt/debug                                                           95f111d8-854f-4177-bcff-481e625dd73d   in service    100 GiB   none          gzip-9     
+    oxp_988aa8c2-cb5e-406b-9289-425dc2e5bc3a/crypt/debug                                                           38903da8-c23d-4516-b0ca-6036e26c49e4   in service    100 GiB   none          gzip-9     
+    oxp_ad574c09-2ae0-4534-a2a4-f923ce20ae87/crypt/debug                                                           216e74e6-691b-45f9-ad7f-037ae799a8c9   in service    100 GiB   none          gzip-9     
+    oxp_ad91e238-4901-4ff4-a91b-75233c936426/crypt/debug                                                           e598cc97-90c4-403a-b7fc-741f8b93de87   in service    100 GiB   none          gzip-9     
+    oxp_ce58d463-d442-4c97-a6b4-f7d98c3fd902/crypt/debug                                                           235746b2-5d3f-4608-9017-2bd8d1521d2b   in service    100 GiB   none          gzip-9     
+    oxp_f18f7689-0059-4b79-880e-34faf7a0fe0e/crypt/debug                                                           08fdf2b1-430d-4a5c-adf3-b0a0f323ae9d   in service    100 GiB   none          gzip-9     
+    oxp_f1d6cea4-640f-415e-89fe-2b1784ce3db8/crypt/debug                                                           ea7fa07f-f47b-4039-a0db-6ab9ca0f0e2c   in service    100 GiB   none          gzip-9     
+    oxp_f4a96860-bdeb-4435-bdf5-2a10beb3d44a/crypt/debug                                                           547cb9ee-f196-4dfe-9f2c-aa4b2f114abe   in service    100 GiB   none          gzip-9     
 
 
     omicron zones at generation 2:
@@ -114,54 +114,54 @@ to:   blueprint f432fcd5-1284-4058-8b4a-9286a3de6163
 
 
     datasets at generation 2:
-    -----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
-    dataset name                                                                                                   dataset uuid                           quota     reservation   compression
-    -----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
-    oxp_12057b4a-0b06-4f70-ba22-336de2385bfe/crucible                                                              55136aae-73db-46b2-bd32-e26634f865ed   none      none          off        
-    oxp_29758363-6c77-40c3-8740-9c0c64f6e14a/crucible                                                              5c4eda29-ed3e-4dc6-b756-afafa1c216b8   none      none          off        
-    oxp_3f331c10-7882-48ab-85d9-05108490b55b/crucible                                                              9b5d5293-2546-43f0-b953-73a696cad4bf   none      none          off        
-    oxp_5152d1aa-9045-4e06-9ef6-6eadac3696e4/crucible                                                              74c65a92-1d4a-44cc-9a55-cd540e9fb57e   none      none          off        
-    oxp_5c0dd424-d905-4fc5-a73c-36254fdd470c/crucible                                                              cc25055b-483e-46ab-a5bf-1d8838b846fd   none      none          off        
-    oxp_794df76f-bca0-4635-9eb6-773ad0108f7e/crucible                                                              8270e505-beff-480a-955b-bf96c4b1a9a3   none      none          off        
-    oxp_9024d350-38a7-459b-8550-3b2c4a88b5c1/crucible                                                              ea234d9d-291b-4adf-9d96-48b7945c2892   none      none          off        
-    oxp_95e86080-e162-4980-a589-db6bb1a95ca7/crucible                                                              d8d9a6d4-f6be-4044-8eac-b994aa166053   none      none          off        
-    oxp_d55d36d7-df92-4615-944d-440a1f8b5001/crucible                                                              64955a3e-2059-4d16-aee4-f63f9362b554   none      none          off        
-    oxp_db6686c8-2dd9-4032-8444-2a06b43baa68/crucible                                                              863c76ac-732e-4d10-b7a3-1d6ba02dc1f5   none      none          off        
-    oxp_12057b4a-0b06-4f70-ba22-336de2385bfe/crypt/internal_dns                                                    b4df380c-6cca-41c1-b79c-45671067d459   none      none          off        
-    oxp_12057b4a-0b06-4f70-ba22-336de2385bfe/crypt/zone                                                            9bcac944-9866-4251-b333-1cbdc137a03e   none      none          off        
-    oxp_29758363-6c77-40c3-8740-9c0c64f6e14a/crypt/zone                                                            0557de8a-45cf-44a0-a39d-4a7095e9045b   none      none          off        
-    oxp_3f331c10-7882-48ab-85d9-05108490b55b/crypt/zone                                                            5f5e1e10-1561-4556-aac1-6b6285df5cb2   none      none          off        
-    oxp_5152d1aa-9045-4e06-9ef6-6eadac3696e4/crypt/zone                                                            52d9152d-e80a-455e-b24a-70b5d2ffc372   none      none          off        
-    oxp_5c0dd424-d905-4fc5-a73c-36254fdd470c/crypt/zone                                                            1b990bb0-ea73-430c-bafa-6eb5647af125   none      none          off        
-    oxp_794df76f-bca0-4635-9eb6-773ad0108f7e/crypt/zone                                                            4fc058ac-95d8-4ea4-808c-6b976e95449e   none      none          off        
-    oxp_9024d350-38a7-459b-8550-3b2c4a88b5c1/crypt/zone                                                            208cd4b7-be74-4187-a4e3-21e518bc92a6   none      none          off        
-    oxp_95e86080-e162-4980-a589-db6bb1a95ca7/crypt/zone                                                            bf66b843-7c47-4e46-b629-267111de97b5   none      none          off        
-    oxp_d55d36d7-df92-4615-944d-440a1f8b5001/crypt/zone                                                            5672e912-aa12-4614-b79b-5fcf548e9d96   none      none          off        
-    oxp_db6686c8-2dd9-4032-8444-2a06b43baa68/crypt/zone                                                            99d7b142-b462-4a67-b84e-f3fc79e761fd   none      none          off        
-    oxp_95e86080-e162-4980-a589-db6bb1a95ca7/crypt/zone/oxz_crucible_1437bb47-a2d3-48e9-8902-021ff5057d26          3dd86436-a934-44a8-97b2-1848ab6ebbc9   none      none          off        
-    oxp_5c0dd424-d905-4fc5-a73c-36254fdd470c/crypt/zone/oxz_crucible_31f49108-cdda-4659-bf24-319bf99a9c20          faa7fe52-a532-4784-84f3-376dc8334fdd   none      none          off        
-    oxp_29758363-6c77-40c3-8740-9c0c64f6e14a/crypt/zone/oxz_crucible_5152e5e7-8615-407d-beed-37fd03852ad6          5def9f9d-7e1f-4ef0-94cf-b26f21e6da07   none      none          off        
-    oxp_3f331c10-7882-48ab-85d9-05108490b55b/crypt/zone/oxz_crucible_6593648a-53f3-4a0f-b902-ef6cd7eab43b          9651f8ed-ae45-476c-bca4-42ebe6ee1618   none      none          off        
-    oxp_d55d36d7-df92-4615-944d-440a1f8b5001/crypt/zone/oxz_crucible_754bae61-cbff-402f-b250-91bec499b449          8e72b070-ef13-4082-bcf8-2c54488a4ae1   none      none          off        
-    oxp_12057b4a-0b06-4f70-ba22-336de2385bfe/crypt/zone/oxz_crucible_8f316745-d46d-47cb-8c7e-678fd9021c40          d508ecc2-baf5-4299-9799-e6d30f83663e   none      none          off        
-    oxp_9024d350-38a7-459b-8550-3b2c4a88b5c1/crypt/zone/oxz_crucible_9fdb739d-b149-4f8f-b488-b97d16ea284a          96dc8dcd-700b-4dd7-8970-568e91b93948   none      none          off        
-    oxp_db6686c8-2dd9-4032-8444-2a06b43baa68/crypt/zone/oxz_crucible_b23471ff-b35a-4919-aa3f-3c3683fa3210          646e79ac-9828-4a8d-8173-e385f5e65a15   none      none          off        
-    oxp_794df76f-bca0-4635-9eb6-773ad0108f7e/crypt/zone/oxz_crucible_fa8963b6-dad1-4cf8-9243-c77b3f86d654          2dd82bf7-cad0-4725-ba7d-0cf40b725b39   none      none          off        
-    oxp_5152d1aa-9045-4e06-9ef6-6eadac3696e4/crypt/zone/oxz_crucible_ff5bf6ea-ab3e-40c5-a9a5-cb2bc89de9c8          ead9603d-c1ea-4ea8-9ca7-f3bc31718458   none      none          off        
-    oxp_12057b4a-0b06-4f70-ba22-336de2385bfe/crypt/zone/oxz_crucible_pantry_634fc0b7-9f95-494d-939b-28819cbcaa2b   be2863b0-0d23-4fd4-92e8-ffc4184e5742   none      none          off        
-    oxp_12057b4a-0b06-4f70-ba22-336de2385bfe/crypt/zone/oxz_internal_dns_92628102-eef4-4000-a061-1df796db3806      998bf38c-b6ec-4ddd-80ac-59fc1ee30ca2   none      none          off        
-    oxp_12057b4a-0b06-4f70-ba22-336de2385bfe/crypt/zone/oxz_nexus_7a3ea24a-85f4-4aad-a935-4e7b22766985             73e12d19-7957-4c44-b3e0-fef8d2ad4826   none      none          off        
-    oxp_12057b4a-0b06-4f70-ba22-336de2385bfe/crypt/zone/oxz_ntp_edd3fb4a-6ea7-49a5-82fb-444dfcf6fcc5               305f5727-4d83-4282-9efe-f776ad63aef9   none      none          off        
-    oxp_12057b4a-0b06-4f70-ba22-336de2385bfe/crypt/debug                                                           b3261747-8c28-4c02-8ab7-be1b8cab03fe   100 GiB   none          gzip-9     
-    oxp_29758363-6c77-40c3-8740-9c0c64f6e14a/crypt/debug                                                           be79f715-8cc9-475c-81dd-f3a8141df986   100 GiB   none          gzip-9     
-    oxp_3f331c10-7882-48ab-85d9-05108490b55b/crypt/debug                                                           b0f40911-5074-4dad-bcf9-269e20793f6f   100 GiB   none          gzip-9     
-    oxp_5152d1aa-9045-4e06-9ef6-6eadac3696e4/crypt/debug                                                           1f81c8ba-d0b2-4c24-b8b8-90a5a3148b2a   100 GiB   none          gzip-9     
-    oxp_5c0dd424-d905-4fc5-a73c-36254fdd470c/crypt/debug                                                           b489b3a7-eb94-481f-805d-c93958f566dd   100 GiB   none          gzip-9     
-    oxp_794df76f-bca0-4635-9eb6-773ad0108f7e/crypt/debug                                                           903e2867-5fc0-487b-9d9c-9afe60731a6c   100 GiB   none          gzip-9     
-    oxp_9024d350-38a7-459b-8550-3b2c4a88b5c1/crypt/debug                                                           a02260de-3336-4cbf-ba45-ff79586b40fa   100 GiB   none          gzip-9     
-    oxp_95e86080-e162-4980-a589-db6bb1a95ca7/crypt/debug                                                           667d664c-c5a1-4b77-a54c-6bbb1bcc2096   100 GiB   none          gzip-9     
-    oxp_d55d36d7-df92-4615-944d-440a1f8b5001/crypt/debug                                                           4f4ad767-8887-4892-b6c7-5bc652f3d673   100 GiB   none          gzip-9     
-    oxp_db6686c8-2dd9-4032-8444-2a06b43baa68/crypt/debug                                                           f5b987f9-0a34-4394-8fc5-2ee12bf3e9bf   100 GiB   none          gzip-9     
+    -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
+    dataset name                                                                                                   dataset id                             disposition   quota     reservation   compression
+    -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
+    oxp_12057b4a-0b06-4f70-ba22-336de2385bfe/crucible                                                              55136aae-73db-46b2-bd32-e26634f865ed   in service    none      none          off        
+    oxp_29758363-6c77-40c3-8740-9c0c64f6e14a/crucible                                                              5c4eda29-ed3e-4dc6-b756-afafa1c216b8   in service    none      none          off        
+    oxp_3f331c10-7882-48ab-85d9-05108490b55b/crucible                                                              9b5d5293-2546-43f0-b953-73a696cad4bf   in service    none      none          off        
+    oxp_5152d1aa-9045-4e06-9ef6-6eadac3696e4/crucible                                                              74c65a92-1d4a-44cc-9a55-cd540e9fb57e   in service    none      none          off        
+    oxp_5c0dd424-d905-4fc5-a73c-36254fdd470c/crucible                                                              cc25055b-483e-46ab-a5bf-1d8838b846fd   in service    none      none          off        
+    oxp_794df76f-bca0-4635-9eb6-773ad0108f7e/crucible                                                              8270e505-beff-480a-955b-bf96c4b1a9a3   in service    none      none          off        
+    oxp_9024d350-38a7-459b-8550-3b2c4a88b5c1/crucible                                                              ea234d9d-291b-4adf-9d96-48b7945c2892   in service    none      none          off        
+    oxp_95e86080-e162-4980-a589-db6bb1a95ca7/crucible                                                              d8d9a6d4-f6be-4044-8eac-b994aa166053   in service    none      none          off        
+    oxp_d55d36d7-df92-4615-944d-440a1f8b5001/crucible                                                              64955a3e-2059-4d16-aee4-f63f9362b554   in service    none      none          off        
+    oxp_db6686c8-2dd9-4032-8444-2a06b43baa68/crucible                                                              863c76ac-732e-4d10-b7a3-1d6ba02dc1f5   in service    none      none          off        
+    oxp_12057b4a-0b06-4f70-ba22-336de2385bfe/crypt/internal_dns                                                    b4df380c-6cca-41c1-b79c-45671067d459   in service    none      none          off        
+    oxp_12057b4a-0b06-4f70-ba22-336de2385bfe/crypt/zone                                                            9bcac944-9866-4251-b333-1cbdc137a03e   in service    none      none          off        
+    oxp_29758363-6c77-40c3-8740-9c0c64f6e14a/crypt/zone                                                            0557de8a-45cf-44a0-a39d-4a7095e9045b   in service    none      none          off        
+    oxp_3f331c10-7882-48ab-85d9-05108490b55b/crypt/zone                                                            5f5e1e10-1561-4556-aac1-6b6285df5cb2   in service    none      none          off        
+    oxp_5152d1aa-9045-4e06-9ef6-6eadac3696e4/crypt/zone                                                            52d9152d-e80a-455e-b24a-70b5d2ffc372   in service    none      none          off        
+    oxp_5c0dd424-d905-4fc5-a73c-36254fdd470c/crypt/zone                                                            1b990bb0-ea73-430c-bafa-6eb5647af125   in service    none      none          off        
+    oxp_794df76f-bca0-4635-9eb6-773ad0108f7e/crypt/zone                                                            4fc058ac-95d8-4ea4-808c-6b976e95449e   in service    none      none          off        
+    oxp_9024d350-38a7-459b-8550-3b2c4a88b5c1/crypt/zone                                                            208cd4b7-be74-4187-a4e3-21e518bc92a6   in service    none      none          off        
+    oxp_95e86080-e162-4980-a589-db6bb1a95ca7/crypt/zone                                                            bf66b843-7c47-4e46-b629-267111de97b5   in service    none      none          off        
+    oxp_d55d36d7-df92-4615-944d-440a1f8b5001/crypt/zone                                                            5672e912-aa12-4614-b79b-5fcf548e9d96   in service    none      none          off        
+    oxp_db6686c8-2dd9-4032-8444-2a06b43baa68/crypt/zone                                                            99d7b142-b462-4a67-b84e-f3fc79e761fd   in service    none      none          off        
+    oxp_95e86080-e162-4980-a589-db6bb1a95ca7/crypt/zone/oxz_crucible_1437bb47-a2d3-48e9-8902-021ff5057d26          3dd86436-a934-44a8-97b2-1848ab6ebbc9   in service    none      none          off        
+    oxp_5c0dd424-d905-4fc5-a73c-36254fdd470c/crypt/zone/oxz_crucible_31f49108-cdda-4659-bf24-319bf99a9c20          faa7fe52-a532-4784-84f3-376dc8334fdd   in service    none      none          off        
+    oxp_29758363-6c77-40c3-8740-9c0c64f6e14a/crypt/zone/oxz_crucible_5152e5e7-8615-407d-beed-37fd03852ad6          5def9f9d-7e1f-4ef0-94cf-b26f21e6da07   in service    none      none          off        
+    oxp_3f331c10-7882-48ab-85d9-05108490b55b/crypt/zone/oxz_crucible_6593648a-53f3-4a0f-b902-ef6cd7eab43b          9651f8ed-ae45-476c-bca4-42ebe6ee1618   in service    none      none          off        
+    oxp_d55d36d7-df92-4615-944d-440a1f8b5001/crypt/zone/oxz_crucible_754bae61-cbff-402f-b250-91bec499b449          8e72b070-ef13-4082-bcf8-2c54488a4ae1   in service    none      none          off        
+    oxp_12057b4a-0b06-4f70-ba22-336de2385bfe/crypt/zone/oxz_crucible_8f316745-d46d-47cb-8c7e-678fd9021c40          d508ecc2-baf5-4299-9799-e6d30f83663e   in service    none      none          off        
+    oxp_9024d350-38a7-459b-8550-3b2c4a88b5c1/crypt/zone/oxz_crucible_9fdb739d-b149-4f8f-b488-b97d16ea284a          96dc8dcd-700b-4dd7-8970-568e91b93948   in service    none      none          off        
+    oxp_db6686c8-2dd9-4032-8444-2a06b43baa68/crypt/zone/oxz_crucible_b23471ff-b35a-4919-aa3f-3c3683fa3210          646e79ac-9828-4a8d-8173-e385f5e65a15   in service    none      none          off        
+    oxp_794df76f-bca0-4635-9eb6-773ad0108f7e/crypt/zone/oxz_crucible_fa8963b6-dad1-4cf8-9243-c77b3f86d654          2dd82bf7-cad0-4725-ba7d-0cf40b725b39   in service    none      none          off        
+    oxp_5152d1aa-9045-4e06-9ef6-6eadac3696e4/crypt/zone/oxz_crucible_ff5bf6ea-ab3e-40c5-a9a5-cb2bc89de9c8          ead9603d-c1ea-4ea8-9ca7-f3bc31718458   in service    none      none          off        
+    oxp_12057b4a-0b06-4f70-ba22-336de2385bfe/crypt/zone/oxz_crucible_pantry_634fc0b7-9f95-494d-939b-28819cbcaa2b   be2863b0-0d23-4fd4-92e8-ffc4184e5742   in service    none      none          off        
+    oxp_12057b4a-0b06-4f70-ba22-336de2385bfe/crypt/zone/oxz_internal_dns_92628102-eef4-4000-a061-1df796db3806      998bf38c-b6ec-4ddd-80ac-59fc1ee30ca2   in service    none      none          off        
+    oxp_12057b4a-0b06-4f70-ba22-336de2385bfe/crypt/zone/oxz_nexus_7a3ea24a-85f4-4aad-a935-4e7b22766985             73e12d19-7957-4c44-b3e0-fef8d2ad4826   in service    none      none          off        
+    oxp_12057b4a-0b06-4f70-ba22-336de2385bfe/crypt/zone/oxz_ntp_edd3fb4a-6ea7-49a5-82fb-444dfcf6fcc5               305f5727-4d83-4282-9efe-f776ad63aef9   in service    none      none          off        
+    oxp_12057b4a-0b06-4f70-ba22-336de2385bfe/crypt/debug                                                           b3261747-8c28-4c02-8ab7-be1b8cab03fe   in service    100 GiB   none          gzip-9     
+    oxp_29758363-6c77-40c3-8740-9c0c64f6e14a/crypt/debug                                                           be79f715-8cc9-475c-81dd-f3a8141df986   in service    100 GiB   none          gzip-9     
+    oxp_3f331c10-7882-48ab-85d9-05108490b55b/crypt/debug                                                           b0f40911-5074-4dad-bcf9-269e20793f6f   in service    100 GiB   none          gzip-9     
+    oxp_5152d1aa-9045-4e06-9ef6-6eadac3696e4/crypt/debug                                                           1f81c8ba-d0b2-4c24-b8b8-90a5a3148b2a   in service    100 GiB   none          gzip-9     
+    oxp_5c0dd424-d905-4fc5-a73c-36254fdd470c/crypt/debug                                                           b489b3a7-eb94-481f-805d-c93958f566dd   in service    100 GiB   none          gzip-9     
+    oxp_794df76f-bca0-4635-9eb6-773ad0108f7e/crypt/debug                                                           903e2867-5fc0-487b-9d9c-9afe60731a6c   in service    100 GiB   none          gzip-9     
+    oxp_9024d350-38a7-459b-8550-3b2c4a88b5c1/crypt/debug                                                           a02260de-3336-4cbf-ba45-ff79586b40fa   in service    100 GiB   none          gzip-9     
+    oxp_95e86080-e162-4980-a589-db6bb1a95ca7/crypt/debug                                                           667d664c-c5a1-4b77-a54c-6bbb1bcc2096   in service    100 GiB   none          gzip-9     
+    oxp_d55d36d7-df92-4615-944d-440a1f8b5001/crypt/debug                                                           4f4ad767-8887-4892-b6c7-5bc652f3d673   in service    100 GiB   none          gzip-9     
+    oxp_db6686c8-2dd9-4032-8444-2a06b43baa68/crypt/debug                                                           f5b987f9-0a34-4394-8fc5-2ee12bf3e9bf   in service    100 GiB   none          gzip-9     
 
 
     omicron zones at generation 2:
@@ -203,54 +203,54 @@ to:   blueprint f432fcd5-1284-4058-8b4a-9286a3de6163
 
 
     datasets at generation 2:
-    -----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
-    dataset name                                                                                                   dataset uuid                           quota     reservation   compression
-    -----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
-    oxp_2a94863d-16e2-4535-973b-e98dd47fd18d/crucible                                                              852963f5-4c4b-4bd9-a5b6-25ea416c25fe   none      none          off        
-    oxp_32456d15-f5b6-4efc-90c8-dbba979b69cb/crucible                                                              d37faff5-a0a8-4b60-bb33-508c478fe1c9   none      none          off        
-    oxp_416fe9f9-5161-4b0f-9e11-c9d81563ded5/crucible                                                              c096ba5f-adbf-498d-8ea5-ba736454d9fb   none      none          off        
-    oxp_4c68800e-23f8-485b-b251-628fd151e445/crucible                                                              56661c11-0041-4ffd-8a0c-72b5fc0486b9   none      none          off        
-    oxp_9dd87c4d-5fb4-475a-86fa-c0da81a3e00a/crucible                                                              b6a3f4cf-27f4-4ba8-b063-b4b3c7b03cc3   none      none          off        
-    oxp_be93a517-445e-46c2-aa21-3dc526d4a413/crucible                                                              f32a5631-dd04-4e2d-a9f9-b5974253601d   none      none          off        
-    oxp_d9344e2b-84d2-4392-84ab-41b86ed02237/crucible                                                              a15aacbb-53de-45e0-a646-a88817c929c6   none      none          off        
-    oxp_eab188d0-b34a-4673-b254-12e705597654/crucible                                                              932f321c-10ae-476a-9721-33b5e76fb989   none      none          off        
-    oxp_f1e0386f-11b6-4cdf-8250-826d256db6b5/crucible                                                              ad47c2f1-68ea-413f-ad9e-0975d02a0e11   none      none          off        
-    oxp_f8c9c9a9-d73e-4cdf-a9af-03cfbbbce12b/crucible                                                              9861aeea-9a0c-4fc7-b3d7-e80f3e5c88a5   none      none          off        
-    oxp_2a94863d-16e2-4535-973b-e98dd47fd18d/crypt/internal_dns                                                    a8eea986-61ba-4723-a97c-61f911210031   none      none          off        
-    oxp_2a94863d-16e2-4535-973b-e98dd47fd18d/crypt/zone                                                            3938e220-b204-4f50-bd73-9c835eb4dea7   none      none          off        
-    oxp_32456d15-f5b6-4efc-90c8-dbba979b69cb/crypt/zone                                                            ba8d7bd5-7282-468c-bba6-28462b5400ff   none      none          off        
-    oxp_416fe9f9-5161-4b0f-9e11-c9d81563ded5/crypt/zone                                                            57497a15-47dd-4eca-a52a-1ee1a3a005b4   none      none          off        
-    oxp_4c68800e-23f8-485b-b251-628fd151e445/crypt/zone                                                            44a73f30-9601-4fbd-9699-deb600252cb1   none      none          off        
-    oxp_9dd87c4d-5fb4-475a-86fa-c0da81a3e00a/crypt/zone                                                            6ce8fc11-2f6e-4c7a-b026-d2f05ee49c8f   none      none          off        
-    oxp_be93a517-445e-46c2-aa21-3dc526d4a413/crypt/zone                                                            babe6a59-94f6-4fbb-b49e-2fda486cc39e   none      none          off        
-    oxp_d9344e2b-84d2-4392-84ab-41b86ed02237/crypt/zone                                                            69686d88-8e89-4137-9377-3e1b61995d79   none      none          off        
-    oxp_eab188d0-b34a-4673-b254-12e705597654/crypt/zone                                                            f1a436b2-d773-4b72-ad3a-fc5d03ae9855   none      none          off        
-    oxp_f1e0386f-11b6-4cdf-8250-826d256db6b5/crypt/zone                                                            8196e6fd-4094-4bc9-ad43-1d774de79b25   none      none          off        
-    oxp_f8c9c9a9-d73e-4cdf-a9af-03cfbbbce12b/crypt/zone                                                            de91df2d-b85b-4300-82f4-70ee5d0c8f71   none      none          off        
-    oxp_32456d15-f5b6-4efc-90c8-dbba979b69cb/crypt/zone/oxz_crucible_3b49c2c6-0b0b-4a11-be95-bf94c1cb54a8          e033c975-ab2f-4d39-96e1-02fc6d95e58f   none      none          off        
-    oxp_d9344e2b-84d2-4392-84ab-41b86ed02237/crypt/zone/oxz_crucible_4c65501d-a08d-4fe5-9c78-2694ce6b3a43          28c2eb82-e779-4629-91af-633e4460cd21   none      none          off        
-    oxp_eab188d0-b34a-4673-b254-12e705597654/crypt/zone/oxz_crucible_60e74b27-a7d7-475e-b5ce-2a92eff4fa63          362a51ca-7116-4df3-96bd-5383c32b33f3   none      none          off        
-    oxp_f1e0386f-11b6-4cdf-8250-826d256db6b5/crypt/zone/oxz_crucible_68f44e7e-8231-40c0-861e-2f4d0c2eb392          1db171be-4a44-473a-bfa0-c9dda78fed77   none      none          off        
-    oxp_2a94863d-16e2-4535-973b-e98dd47fd18d/crypt/zone/oxz_crucible_74fc3000-c4b7-4687-88b5-a27584b45434          00218e6a-5e1b-450c-ad38-624ad37d2fc4   none      none          off        
-    oxp_f8c9c9a9-d73e-4cdf-a9af-03cfbbbce12b/crypt/zone/oxz_crucible_83ae0625-2e61-4637-a1f9-473b21b94f72          418a8d5c-fbe8-46c0-b260-e77eb2235105   none      none          off        
-    oxp_416fe9f9-5161-4b0f-9e11-c9d81563ded5/crypt/zone/oxz_crucible_9b462d74-c05a-4a7e-8d24-449c848a7b13          bea24fa2-353f-4c13-844d-3ce58d682eb7   none      none          off        
-    oxp_be93a517-445e-46c2-aa21-3dc526d4a413/crypt/zone/oxz_crucible_a9ed9f72-e57d-4092-ab0e-bb2000a5459e          dda0482e-cffe-4230-9370-9eebfb9c7121   none      none          off        
-    oxp_4c68800e-23f8-485b-b251-628fd151e445/crypt/zone/oxz_crucible_d84bc314-4895-4331-8afb-22bffdd56699          17f7d94a-7734-4b3b-a108-dc11b114610e   none      none          off        
-    oxp_9dd87c4d-5fb4-475a-86fa-c0da81a3e00a/crypt/zone/oxz_crucible_f1f03b7d-916e-4c5f-8906-1e18e498184d          3f1fb9c9-8a05-44fc-af26-eb71bec3b890   none      none          off        
-    oxp_2a94863d-16e2-4535-973b-e98dd47fd18d/crypt/zone/oxz_crucible_pantry_ecdc7438-a007-4558-96b3-65bdab21a8a9   f48c22cc-5ff7-4170-bdbd-bd082c882de3   none      none          off        
-    oxp_2a94863d-16e2-4535-973b-e98dd47fd18d/crypt/zone/oxz_internal_dns_c1049e2e-7269-4de0-b96e-2e9f8edc90ea      67f5eef3-2c29-4a5c-9664-81dbd5ed55a5   none      none          off        
-    oxp_2a94863d-16e2-4535-973b-e98dd47fd18d/crypt/zone/oxz_nexus_785868d0-a003-4860-acc1-9beee9f39816             2a2e9b25-83b8-4bc3-b934-723c947f56d7   none      none          off        
-    oxp_2a94863d-16e2-4535-973b-e98dd47fd18d/crypt/zone/oxz_ntp_d5b390d3-7280-4d2b-b670-340f91d7ebd7               7b3fae75-9421-4a8d-8524-b17a540f994e   none      none          off        
-    oxp_2a94863d-16e2-4535-973b-e98dd47fd18d/crypt/debug                                                           5eb19f06-e5e9-4b96-b1c3-84355460b2ea   100 GiB   none          gzip-9     
-    oxp_32456d15-f5b6-4efc-90c8-dbba979b69cb/crypt/debug                                                           89ab2d4a-101f-46c5-8bb8-2c93dbe2d020   100 GiB   none          gzip-9     
-    oxp_416fe9f9-5161-4b0f-9e11-c9d81563ded5/crypt/debug                                                           12f242f1-44e6-449d-9dfd-b4c5c1bb5ddf   100 GiB   none          gzip-9     
-    oxp_4c68800e-23f8-485b-b251-628fd151e445/crypt/debug                                                           45d68f02-6f5a-4c8b-9a59-e4554ebbeff7   100 GiB   none          gzip-9     
-    oxp_9dd87c4d-5fb4-475a-86fa-c0da81a3e00a/crypt/debug                                                           e0e621f0-62f6-4425-a4b0-ff659c63ea11   100 GiB   none          gzip-9     
-    oxp_be93a517-445e-46c2-aa21-3dc526d4a413/crypt/debug                                                           b90bbe6c-15d2-4313-9fce-c1b9ccdf38d3   100 GiB   none          gzip-9     
-    oxp_d9344e2b-84d2-4392-84ab-41b86ed02237/crypt/debug                                                           3bae870d-ae7b-4e95-b4ea-419ba251839b   100 GiB   none          gzip-9     
-    oxp_eab188d0-b34a-4673-b254-12e705597654/crypt/debug                                                           b7284180-362b-42ba-b970-90c27a8468c5   100 GiB   none          gzip-9     
-    oxp_f1e0386f-11b6-4cdf-8250-826d256db6b5/crypt/debug                                                           d814aea1-475f-44c2-8dcc-e2cd2d335bf9   100 GiB   none          gzip-9     
-    oxp_f8c9c9a9-d73e-4cdf-a9af-03cfbbbce12b/crypt/debug                                                           fdd77b3a-5ec9-4e1a-bc62-379baa7c5552   100 GiB   none          gzip-9     
+    -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
+    dataset name                                                                                                   dataset id                             disposition   quota     reservation   compression
+    -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
+    oxp_2a94863d-16e2-4535-973b-e98dd47fd18d/crucible                                                              852963f5-4c4b-4bd9-a5b6-25ea416c25fe   in service    none      none          off        
+    oxp_32456d15-f5b6-4efc-90c8-dbba979b69cb/crucible                                                              d37faff5-a0a8-4b60-bb33-508c478fe1c9   in service    none      none          off        
+    oxp_416fe9f9-5161-4b0f-9e11-c9d81563ded5/crucible                                                              c096ba5f-adbf-498d-8ea5-ba736454d9fb   in service    none      none          off        
+    oxp_4c68800e-23f8-485b-b251-628fd151e445/crucible                                                              56661c11-0041-4ffd-8a0c-72b5fc0486b9   in service    none      none          off        
+    oxp_9dd87c4d-5fb4-475a-86fa-c0da81a3e00a/crucible                                                              b6a3f4cf-27f4-4ba8-b063-b4b3c7b03cc3   in service    none      none          off        
+    oxp_be93a517-445e-46c2-aa21-3dc526d4a413/crucible                                                              f32a5631-dd04-4e2d-a9f9-b5974253601d   in service    none      none          off        
+    oxp_d9344e2b-84d2-4392-84ab-41b86ed02237/crucible                                                              a15aacbb-53de-45e0-a646-a88817c929c6   in service    none      none          off        
+    oxp_eab188d0-b34a-4673-b254-12e705597654/crucible                                                              932f321c-10ae-476a-9721-33b5e76fb989   in service    none      none          off        
+    oxp_f1e0386f-11b6-4cdf-8250-826d256db6b5/crucible                                                              ad47c2f1-68ea-413f-ad9e-0975d02a0e11   in service    none      none          off        
+    oxp_f8c9c9a9-d73e-4cdf-a9af-03cfbbbce12b/crucible                                                              9861aeea-9a0c-4fc7-b3d7-e80f3e5c88a5   in service    none      none          off        
+    oxp_2a94863d-16e2-4535-973b-e98dd47fd18d/crypt/internal_dns                                                    a8eea986-61ba-4723-a97c-61f911210031   in service    none      none          off        
+    oxp_2a94863d-16e2-4535-973b-e98dd47fd18d/crypt/zone                                                            3938e220-b204-4f50-bd73-9c835eb4dea7   in service    none      none          off        
+    oxp_32456d15-f5b6-4efc-90c8-dbba979b69cb/crypt/zone                                                            ba8d7bd5-7282-468c-bba6-28462b5400ff   in service    none      none          off        
+    oxp_416fe9f9-5161-4b0f-9e11-c9d81563ded5/crypt/zone                                                            57497a15-47dd-4eca-a52a-1ee1a3a005b4   in service    none      none          off        
+    oxp_4c68800e-23f8-485b-b251-628fd151e445/crypt/zone                                                            44a73f30-9601-4fbd-9699-deb600252cb1   in service    none      none          off        
+    oxp_9dd87c4d-5fb4-475a-86fa-c0da81a3e00a/crypt/zone                                                            6ce8fc11-2f6e-4c7a-b026-d2f05ee49c8f   in service    none      none          off        
+    oxp_be93a517-445e-46c2-aa21-3dc526d4a413/crypt/zone                                                            babe6a59-94f6-4fbb-b49e-2fda486cc39e   in service    none      none          off        
+    oxp_d9344e2b-84d2-4392-84ab-41b86ed02237/crypt/zone                                                            69686d88-8e89-4137-9377-3e1b61995d79   in service    none      none          off        
+    oxp_eab188d0-b34a-4673-b254-12e705597654/crypt/zone                                                            f1a436b2-d773-4b72-ad3a-fc5d03ae9855   in service    none      none          off        
+    oxp_f1e0386f-11b6-4cdf-8250-826d256db6b5/crypt/zone                                                            8196e6fd-4094-4bc9-ad43-1d774de79b25   in service    none      none          off        
+    oxp_f8c9c9a9-d73e-4cdf-a9af-03cfbbbce12b/crypt/zone                                                            de91df2d-b85b-4300-82f4-70ee5d0c8f71   in service    none      none          off        
+    oxp_32456d15-f5b6-4efc-90c8-dbba979b69cb/crypt/zone/oxz_crucible_3b49c2c6-0b0b-4a11-be95-bf94c1cb54a8          e033c975-ab2f-4d39-96e1-02fc6d95e58f   in service    none      none          off        
+    oxp_d9344e2b-84d2-4392-84ab-41b86ed02237/crypt/zone/oxz_crucible_4c65501d-a08d-4fe5-9c78-2694ce6b3a43          28c2eb82-e779-4629-91af-633e4460cd21   in service    none      none          off        
+    oxp_eab188d0-b34a-4673-b254-12e705597654/crypt/zone/oxz_crucible_60e74b27-a7d7-475e-b5ce-2a92eff4fa63          362a51ca-7116-4df3-96bd-5383c32b33f3   in service    none      none          off        
+    oxp_f1e0386f-11b6-4cdf-8250-826d256db6b5/crypt/zone/oxz_crucible_68f44e7e-8231-40c0-861e-2f4d0c2eb392          1db171be-4a44-473a-bfa0-c9dda78fed77   in service    none      none          off        
+    oxp_2a94863d-16e2-4535-973b-e98dd47fd18d/crypt/zone/oxz_crucible_74fc3000-c4b7-4687-88b5-a27584b45434          00218e6a-5e1b-450c-ad38-624ad37d2fc4   in service    none      none          off        
+    oxp_f8c9c9a9-d73e-4cdf-a9af-03cfbbbce12b/crypt/zone/oxz_crucible_83ae0625-2e61-4637-a1f9-473b21b94f72          418a8d5c-fbe8-46c0-b260-e77eb2235105   in service    none      none          off        
+    oxp_416fe9f9-5161-4b0f-9e11-c9d81563ded5/crypt/zone/oxz_crucible_9b462d74-c05a-4a7e-8d24-449c848a7b13          bea24fa2-353f-4c13-844d-3ce58d682eb7   in service    none      none          off        
+    oxp_be93a517-445e-46c2-aa21-3dc526d4a413/crypt/zone/oxz_crucible_a9ed9f72-e57d-4092-ab0e-bb2000a5459e          dda0482e-cffe-4230-9370-9eebfb9c7121   in service    none      none          off        
+    oxp_4c68800e-23f8-485b-b251-628fd151e445/crypt/zone/oxz_crucible_d84bc314-4895-4331-8afb-22bffdd56699          17f7d94a-7734-4b3b-a108-dc11b114610e   in service    none      none          off        
+    oxp_9dd87c4d-5fb4-475a-86fa-c0da81a3e00a/crypt/zone/oxz_crucible_f1f03b7d-916e-4c5f-8906-1e18e498184d          3f1fb9c9-8a05-44fc-af26-eb71bec3b890   in service    none      none          off        
+    oxp_2a94863d-16e2-4535-973b-e98dd47fd18d/crypt/zone/oxz_crucible_pantry_ecdc7438-a007-4558-96b3-65bdab21a8a9   f48c22cc-5ff7-4170-bdbd-bd082c882de3   in service    none      none          off        
+    oxp_2a94863d-16e2-4535-973b-e98dd47fd18d/crypt/zone/oxz_internal_dns_c1049e2e-7269-4de0-b96e-2e9f8edc90ea      67f5eef3-2c29-4a5c-9664-81dbd5ed55a5   in service    none      none          off        
+    oxp_2a94863d-16e2-4535-973b-e98dd47fd18d/crypt/zone/oxz_nexus_785868d0-a003-4860-acc1-9beee9f39816             2a2e9b25-83b8-4bc3-b934-723c947f56d7   in service    none      none          off        
+    oxp_2a94863d-16e2-4535-973b-e98dd47fd18d/crypt/zone/oxz_ntp_d5b390d3-7280-4d2b-b670-340f91d7ebd7               7b3fae75-9421-4a8d-8524-b17a540f994e   in service    none      none          off        
+    oxp_2a94863d-16e2-4535-973b-e98dd47fd18d/crypt/debug                                                           5eb19f06-e5e9-4b96-b1c3-84355460b2ea   in service    100 GiB   none          gzip-9     
+    oxp_32456d15-f5b6-4efc-90c8-dbba979b69cb/crypt/debug                                                           89ab2d4a-101f-46c5-8bb8-2c93dbe2d020   in service    100 GiB   none          gzip-9     
+    oxp_416fe9f9-5161-4b0f-9e11-c9d81563ded5/crypt/debug                                                           12f242f1-44e6-449d-9dfd-b4c5c1bb5ddf   in service    100 GiB   none          gzip-9     
+    oxp_4c68800e-23f8-485b-b251-628fd151e445/crypt/debug                                                           45d68f02-6f5a-4c8b-9a59-e4554ebbeff7   in service    100 GiB   none          gzip-9     
+    oxp_9dd87c4d-5fb4-475a-86fa-c0da81a3e00a/crypt/debug                                                           e0e621f0-62f6-4425-a4b0-ff659c63ea11   in service    100 GiB   none          gzip-9     
+    oxp_be93a517-445e-46c2-aa21-3dc526d4a413/crypt/debug                                                           b90bbe6c-15d2-4313-9fce-c1b9ccdf38d3   in service    100 GiB   none          gzip-9     
+    oxp_d9344e2b-84d2-4392-84ab-41b86ed02237/crypt/debug                                                           3bae870d-ae7b-4e95-b4ea-419ba251839b   in service    100 GiB   none          gzip-9     
+    oxp_eab188d0-b34a-4673-b254-12e705597654/crypt/debug                                                           b7284180-362b-42ba-b970-90c27a8468c5   in service    100 GiB   none          gzip-9     
+    oxp_f1e0386f-11b6-4cdf-8250-826d256db6b5/crypt/debug                                                           d814aea1-475f-44c2-8dcc-e2cd2d335bf9   in service    100 GiB   none          gzip-9     
+    oxp_f8c9c9a9-d73e-4cdf-a9af-03cfbbbce12b/crypt/debug                                                           fdd77b3a-5ec9-4e1a-bc62-379baa7c5552   in service    100 GiB   none          gzip-9     
 
 
     omicron zones at generation 2:
@@ -294,50 +294,50 @@ to:   blueprint f432fcd5-1284-4058-8b4a-9286a3de6163
 
 
     datasets generation 2 -> 3:
-    ----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
-    dataset name                                                                                            dataset uuid                           quota     reservation   compression
-    ----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
-    oxp_28699448-c5d9-49ea-bf7e-627800efe783/crypt/zone                                                     bd515f95-ef75-4243-b279-5448e8c56693   none      none          off        
-    oxp_2c490e96-27f2-4a7f-b440-04d4bfd1e4f6/crypt/zone                                                     a5ebe3b2-007d-4cb6-a01b-519eb696dd51   none      none          off        
-    oxp_4c3bb1c7-55b6-49b8-b212-516b8f2c26c2/crypt/zone                                                     292da7cf-54f6-4d8c-a941-eebe5d47fe50   none      none          off        
-    oxp_5db07562-31a8-43e3-b99e-7c7cb89754b7/crypt/zone                                                     58573ab1-3d00-4251-9e32-1c8c94d41689   none      none          off        
-    oxp_9451a5d5-b358-4719-b6c1-a0d187da217c/crypt/zone                                                     823a6464-7317-41c4-88d1-317e6156da3b   none      none          off        
-    oxp_bb2e2869-9481-483a-bc49-2bdd62f515f5/crypt/zone                                                     edf02038-6f07-4788-80f7-1c9ef4537956   none      none          off        
-    oxp_d5a36c66-4b2f-46e6-96f4-b82debee1a4a/crypt/zone                                                     77234c3d-1877-4d9b-9885-cd70b05f6d3d   none      none          off        
-    oxp_f99ec996-ec08-4ccf-9a6e-6c5cab440fb4/crypt/zone                                                     04ebd243-fe45-4222-a437-da51aa719c37   none      none          off        
-    oxp_faccbb39-d686-42a1-a50a-0eb59ba74a87/crypt/zone                                                     b6c84399-0029-4eaa-af95-328e62813332   none      none          off        
-    oxp_fdfd067b-1d86-444d-a21f-ed33709f3e4d/crypt/zone                                                     d1121115-497a-49a1-8908-2bc330bb5b98   none      none          off        
-    oxp_28699448-c5d9-49ea-bf7e-627800efe783/crypt/zone/oxz_ntp_f4a71d99-95e2-484a-ae67-6f98aacee92b        2178dce4-6fba-4b15-b5ce-ece8c54083b5   none      none          off        
-    oxp_28699448-c5d9-49ea-bf7e-627800efe783/crypt/debug                                                    9c2fc653-d640-4d06-8fb0-a32ce35309b7   100 GiB   none          gzip-9     
-    oxp_2c490e96-27f2-4a7f-b440-04d4bfd1e4f6/crypt/debug                                                    3544ad60-7696-44a4-812d-1e830e2de897   100 GiB   none          gzip-9     
-    oxp_4c3bb1c7-55b6-49b8-b212-516b8f2c26c2/crypt/debug                                                    81d852cd-0bfd-4f3a-98b5-641657f2acda   100 GiB   none          gzip-9     
-    oxp_5db07562-31a8-43e3-b99e-7c7cb89754b7/crypt/debug                                                    fa35030d-d14d-4969-9dbf-38dfb7bd4a4d   100 GiB   none          gzip-9     
-    oxp_9451a5d5-b358-4719-b6c1-a0d187da217c/crypt/debug                                                    2110ad2b-9665-4427-b6fb-9059d3d65070   100 GiB   none          gzip-9     
-    oxp_bb2e2869-9481-483a-bc49-2bdd62f515f5/crypt/debug                                                    c4f6dae6-d357-4ad3-becd-5e49c4dcf171   100 GiB   none          gzip-9     
-    oxp_d5a36c66-4b2f-46e6-96f4-b82debee1a4a/crypt/debug                                                    25c84622-b39a-4c28-9dd5-1f9f33170150   100 GiB   none          gzip-9     
-    oxp_f99ec996-ec08-4ccf-9a6e-6c5cab440fb4/crypt/debug                                                    1a88aed3-4f65-479a-8677-af5771feade4   100 GiB   none          gzip-9     
-    oxp_faccbb39-d686-42a1-a50a-0eb59ba74a87/crypt/debug                                                    25eff656-ae3f-42bc-9bfb-8adbc9a1f146   100 GiB   none          gzip-9     
-    oxp_fdfd067b-1d86-444d-a21f-ed33709f3e4d/crypt/debug                                                    ecba8219-9446-4f43-a2fd-098f54ebdfd2   100 GiB   none          gzip-9     
-+   oxp_28699448-c5d9-49ea-bf7e-627800efe783/crucible                                                       3b11b123-120d-49fd-a9fc-84527b75580d   none      none          off        
-+   oxp_2c490e96-27f2-4a7f-b440-04d4bfd1e4f6/crucible                                                       eaff368e-4ef0-4afd-aaec-1a3d4f296c10   none      none          off        
-+   oxp_4c3bb1c7-55b6-49b8-b212-516b8f2c26c2/crucible                                                       ff493493-2593-4864-9635-53d8bd7d1875   none      none          off        
-+   oxp_5db07562-31a8-43e3-b99e-7c7cb89754b7/crucible                                                       8295c04b-0fe1-456b-aa4f-41aed656e041   none      none          off        
-+   oxp_9451a5d5-b358-4719-b6c1-a0d187da217c/crucible                                                       50f55ff5-352e-44dd-9f6e-5294a49050af   none      none          off        
-+   oxp_bb2e2869-9481-483a-bc49-2bdd62f515f5/crucible                                                       9a497b55-c55d-4e8c-ac67-fc51dc626b2b   none      none          off        
-+   oxp_d5a36c66-4b2f-46e6-96f4-b82debee1a4a/crucible                                                       5fc3b305-20ca-4882-8222-00cb453e1370   none      none          off        
-+   oxp_f99ec996-ec08-4ccf-9a6e-6c5cab440fb4/crucible                                                       027b5ae4-442d-4e44-a3af-41f1a369d2fd   none      none          off        
-+   oxp_faccbb39-d686-42a1-a50a-0eb59ba74a87/crucible                                                       6e98176b-93c2-4e70-b982-715a4af7def3   none      none          off        
-+   oxp_fdfd067b-1d86-444d-a21f-ed33709f3e4d/crucible                                                       4a66c4d8-5448-4a01-8b3e-5aa96a383f5f   none      none          off        
-+   oxp_4c3bb1c7-55b6-49b8-b212-516b8f2c26c2/crypt/zone/oxz_crucible_199d6b91-4def-46d4-a629-6e462f149d2c   51acb6aa-a707-443d-a797-591efbaed739   none      none          off        
-+   oxp_fdfd067b-1d86-444d-a21f-ed33709f3e4d/crypt/zone/oxz_crucible_1a42f499-42eb-4bbe-8248-df1432c20a44   99cd74fc-d598-4237-afe2-6099dd3e7f27   none      none          off        
-+   oxp_bb2e2869-9481-483a-bc49-2bdd62f515f5/crypt/zone/oxz_crucible_2dac1d18-171c-4c27-b4f4-dd9a04b3cd4c   d3f32cce-77c1-45c9-b5fc-5946ce45d6ab   none      none          off        
-+   oxp_9451a5d5-b358-4719-b6c1-a0d187da217c/crypt/zone/oxz_crucible_5cfcfcf1-fc41-4056-b681-28b822fc9ba9   cf93aa67-8057-486b-8117-fcb210113d78   none      none          off        
-+   oxp_faccbb39-d686-42a1-a50a-0eb59ba74a87/crypt/zone/oxz_crucible_639c583f-fff1-488a-83ea-9f506de5eeff   f301a2d1-5a5c-4af5-92a2-eb4241b07e32   none      none          off        
-+   oxp_d5a36c66-4b2f-46e6-96f4-b82debee1a4a/crypt/zone/oxz_crucible_6a1eeaa3-4106-4765-9883-0b481d112f2f   c7bc6bbf-cd8e-4d46-870a-c51269d3f938   none      none          off        
-+   oxp_28699448-c5d9-49ea-bf7e-627800efe783/crypt/zone/oxz_crucible_7faa36f4-c38e-49d9-9e50-87a2c509d1c0   6de4f5f7-41aa-4ede-b742-b814306a33cb   none      none          off        
-+   oxp_5db07562-31a8-43e3-b99e-7c7cb89754b7/crypt/zone/oxz_crucible_89d9477c-0a66-4297-9333-78d421265495   9efc87a2-2990-4e9d-8636-0cc5003c78df   none      none          off        
-+   oxp_2c490e96-27f2-4a7f-b440-04d4bfd1e4f6/crypt/zone/oxz_crucible_b4ddca08-a1d7-4c1e-8c65-69376ff4dd6f   f9d13e2d-bcd0-416d-9a4a-fbee18fdd8d0   none      none          off        
-+   oxp_f99ec996-ec08-4ccf-9a6e-6c5cab440fb4/crypt/zone/oxz_crucible_d70466d6-ace2-4913-a62c-ad9f42a52369   dc55d9bf-2b5c-4fc4-b0b3-df4a87d32688   none      none          off        
+    ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
+    dataset name                                                                                            dataset id                             disposition   quota     reservation   compression
+    ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
+    oxp_28699448-c5d9-49ea-bf7e-627800efe783/crypt/zone                                                     bd515f95-ef75-4243-b279-5448e8c56693   in service    none      none          off        
+    oxp_2c490e96-27f2-4a7f-b440-04d4bfd1e4f6/crypt/zone                                                     a5ebe3b2-007d-4cb6-a01b-519eb696dd51   in service    none      none          off        
+    oxp_4c3bb1c7-55b6-49b8-b212-516b8f2c26c2/crypt/zone                                                     292da7cf-54f6-4d8c-a941-eebe5d47fe50   in service    none      none          off        
+    oxp_5db07562-31a8-43e3-b99e-7c7cb89754b7/crypt/zone                                                     58573ab1-3d00-4251-9e32-1c8c94d41689   in service    none      none          off        
+    oxp_9451a5d5-b358-4719-b6c1-a0d187da217c/crypt/zone                                                     823a6464-7317-41c4-88d1-317e6156da3b   in service    none      none          off        
+    oxp_bb2e2869-9481-483a-bc49-2bdd62f515f5/crypt/zone                                                     edf02038-6f07-4788-80f7-1c9ef4537956   in service    none      none          off        
+    oxp_d5a36c66-4b2f-46e6-96f4-b82debee1a4a/crypt/zone                                                     77234c3d-1877-4d9b-9885-cd70b05f6d3d   in service    none      none          off        
+    oxp_f99ec996-ec08-4ccf-9a6e-6c5cab440fb4/crypt/zone                                                     04ebd243-fe45-4222-a437-da51aa719c37   in service    none      none          off        
+    oxp_faccbb39-d686-42a1-a50a-0eb59ba74a87/crypt/zone                                                     b6c84399-0029-4eaa-af95-328e62813332   in service    none      none          off        
+    oxp_fdfd067b-1d86-444d-a21f-ed33709f3e4d/crypt/zone                                                     d1121115-497a-49a1-8908-2bc330bb5b98   in service    none      none          off        
+    oxp_28699448-c5d9-49ea-bf7e-627800efe783/crypt/zone/oxz_ntp_f4a71d99-95e2-484a-ae67-6f98aacee92b        2178dce4-6fba-4b15-b5ce-ece8c54083b5   in service    none      none          off        
+    oxp_28699448-c5d9-49ea-bf7e-627800efe783/crypt/debug                                                    9c2fc653-d640-4d06-8fb0-a32ce35309b7   in service    100 GiB   none          gzip-9     
+    oxp_2c490e96-27f2-4a7f-b440-04d4bfd1e4f6/crypt/debug                                                    3544ad60-7696-44a4-812d-1e830e2de897   in service    100 GiB   none          gzip-9     
+    oxp_4c3bb1c7-55b6-49b8-b212-516b8f2c26c2/crypt/debug                                                    81d852cd-0bfd-4f3a-98b5-641657f2acda   in service    100 GiB   none          gzip-9     
+    oxp_5db07562-31a8-43e3-b99e-7c7cb89754b7/crypt/debug                                                    fa35030d-d14d-4969-9dbf-38dfb7bd4a4d   in service    100 GiB   none          gzip-9     
+    oxp_9451a5d5-b358-4719-b6c1-a0d187da217c/crypt/debug                                                    2110ad2b-9665-4427-b6fb-9059d3d65070   in service    100 GiB   none          gzip-9     
+    oxp_bb2e2869-9481-483a-bc49-2bdd62f515f5/crypt/debug                                                    c4f6dae6-d357-4ad3-becd-5e49c4dcf171   in service    100 GiB   none          gzip-9     
+    oxp_d5a36c66-4b2f-46e6-96f4-b82debee1a4a/crypt/debug                                                    25c84622-b39a-4c28-9dd5-1f9f33170150   in service    100 GiB   none          gzip-9     
+    oxp_f99ec996-ec08-4ccf-9a6e-6c5cab440fb4/crypt/debug                                                    1a88aed3-4f65-479a-8677-af5771feade4   in service    100 GiB   none          gzip-9     
+    oxp_faccbb39-d686-42a1-a50a-0eb59ba74a87/crypt/debug                                                    25eff656-ae3f-42bc-9bfb-8adbc9a1f146   in service    100 GiB   none          gzip-9     
+    oxp_fdfd067b-1d86-444d-a21f-ed33709f3e4d/crypt/debug                                                    ecba8219-9446-4f43-a2fd-098f54ebdfd2   in service    100 GiB   none          gzip-9     
++   oxp_28699448-c5d9-49ea-bf7e-627800efe783/crucible                                                       3b11b123-120d-49fd-a9fc-84527b75580d   in service    none      none          off        
++   oxp_2c490e96-27f2-4a7f-b440-04d4bfd1e4f6/crucible                                                       eaff368e-4ef0-4afd-aaec-1a3d4f296c10   in service    none      none          off        
++   oxp_4c3bb1c7-55b6-49b8-b212-516b8f2c26c2/crucible                                                       ff493493-2593-4864-9635-53d8bd7d1875   in service    none      none          off        
++   oxp_5db07562-31a8-43e3-b99e-7c7cb89754b7/crucible                                                       8295c04b-0fe1-456b-aa4f-41aed656e041   in service    none      none          off        
++   oxp_9451a5d5-b358-4719-b6c1-a0d187da217c/crucible                                                       50f55ff5-352e-44dd-9f6e-5294a49050af   in service    none      none          off        
++   oxp_bb2e2869-9481-483a-bc49-2bdd62f515f5/crucible                                                       9a497b55-c55d-4e8c-ac67-fc51dc626b2b   in service    none      none          off        
++   oxp_d5a36c66-4b2f-46e6-96f4-b82debee1a4a/crucible                                                       5fc3b305-20ca-4882-8222-00cb453e1370   in service    none      none          off        
++   oxp_f99ec996-ec08-4ccf-9a6e-6c5cab440fb4/crucible                                                       027b5ae4-442d-4e44-a3af-41f1a369d2fd   in service    none      none          off        
++   oxp_faccbb39-d686-42a1-a50a-0eb59ba74a87/crucible                                                       6e98176b-93c2-4e70-b982-715a4af7def3   in service    none      none          off        
++   oxp_fdfd067b-1d86-444d-a21f-ed33709f3e4d/crucible                                                       4a66c4d8-5448-4a01-8b3e-5aa96a383f5f   in service    none      none          off        
++   oxp_4c3bb1c7-55b6-49b8-b212-516b8f2c26c2/crypt/zone/oxz_crucible_199d6b91-4def-46d4-a629-6e462f149d2c   51acb6aa-a707-443d-a797-591efbaed739   in service    none      none          off        
++   oxp_fdfd067b-1d86-444d-a21f-ed33709f3e4d/crypt/zone/oxz_crucible_1a42f499-42eb-4bbe-8248-df1432c20a44   99cd74fc-d598-4237-afe2-6099dd3e7f27   in service    none      none          off        
++   oxp_bb2e2869-9481-483a-bc49-2bdd62f515f5/crypt/zone/oxz_crucible_2dac1d18-171c-4c27-b4f4-dd9a04b3cd4c   d3f32cce-77c1-45c9-b5fc-5946ce45d6ab   in service    none      none          off        
++   oxp_9451a5d5-b358-4719-b6c1-a0d187da217c/crypt/zone/oxz_crucible_5cfcfcf1-fc41-4056-b681-28b822fc9ba9   cf93aa67-8057-486b-8117-fcb210113d78   in service    none      none          off        
++   oxp_faccbb39-d686-42a1-a50a-0eb59ba74a87/crypt/zone/oxz_crucible_639c583f-fff1-488a-83ea-9f506de5eeff   f301a2d1-5a5c-4af5-92a2-eb4241b07e32   in service    none      none          off        
++   oxp_d5a36c66-4b2f-46e6-96f4-b82debee1a4a/crypt/zone/oxz_crucible_6a1eeaa3-4106-4765-9883-0b481d112f2f   c7bc6bbf-cd8e-4d46-870a-c51269d3f938   in service    none      none          off        
++   oxp_28699448-c5d9-49ea-bf7e-627800efe783/crypt/zone/oxz_crucible_7faa36f4-c38e-49d9-9e50-87a2c509d1c0   6de4f5f7-41aa-4ede-b742-b814306a33cb   in service    none      none          off        
++   oxp_5db07562-31a8-43e3-b99e-7c7cb89754b7/crypt/zone/oxz_crucible_89d9477c-0a66-4297-9333-78d421265495   9efc87a2-2990-4e9d-8636-0cc5003c78df   in service    none      none          off        
++   oxp_2c490e96-27f2-4a7f-b440-04d4bfd1e4f6/crypt/zone/oxz_crucible_b4ddca08-a1d7-4c1e-8c65-69376ff4dd6f   f9d13e2d-bcd0-416d-9a4a-fbee18fdd8d0   in service    none      none          off        
++   oxp_f99ec996-ec08-4ccf-9a6e-6c5cab440fb4/crypt/zone/oxz_crucible_d70466d6-ace2-4913-a62c-ad9f42a52369   dc55d9bf-2b5c-4fc4-b0b3-df4a87d32688   in service    none      none          off        
 
 
     omicron zones generation 2 -> 3:

--- a/nexus/reconfigurator/planning/tests/output/planner_dataset_settings_modified_in_place_1_2.txt
+++ b/nexus/reconfigurator/planning/tests/output/planner_dataset_settings_modified_in_place_1_2.txt
@@ -22,63 +22,63 @@ to:   blueprint fe13be30-94c2-4fa6-aad5-ae3c5028f6bb
 
 
     datasets generation 2 -> 3:
-    -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
-    dataset name                                                                                                   dataset uuid                           quota       reservation   compression
-    -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
-    oxp_3b6e2ade-57fc-4f9d-85c3-38fca27f1df6/crucible                                                              c2b2149b-1ad7-479f-bc9f-2404cf3eec0d   none        none          off        
-    oxp_5192ef62-5a12-4a0c-829d-a409da87909c/crucible                                                              74601f4f-d373-438c-808a-b9e6e94c0a67   none        none          off        
-    oxp_8778bcc5-dddf-4345-9fdf-5c46a36497b0/crucible                                                              f8ffebff-ffd1-4005-9803-3bd79dd5b012   none        none          off        
-    oxp_9134de8d-9ba8-4ddc-9e84-eb00ec616b53/crucible                                                              02ab12e1-26f0-4151-b2f3-e675b8f5be44   none        none          off        
-    oxp_96569b61-9e0c-4ee7-bd11-a5e0c541ca99/crucible                                                              56e4a163-8f97-4122-a2a2-38546daffbfc   none        none          off        
-    oxp_ba90170e-7399-4260-910a-376254a8a9bf/crucible                                                              25c1c3c4-88b2-4c7f-8069-1b9412d045e6   none        none          off        
-    oxp_bc649720-926b-48f2-a62a-efdcff96b49e/crucible                                                              8c3ff417-0e78-4946-b48f-f83a1a65526b   none        none          off        
-    oxp_d55da288-4f35-4e92-97b0-29a5e6009109/crucible                                                              27251d6c-990a-4537-ad6d-a23eb40a61e2   none        none          off        
-    oxp_f83302fc-785c-4ab3-bcca-0d040b3c3062/crucible                                                              707bf418-524a-4a44-aaf1-fc0fe903226b   none        none          off        
-    oxp_f843fb62-0f04-4c7d-a56f-62531104dc77/crucible                                                              54e1705b-2579-4319-9f96-717a4d0508da   none        none          off        
-    oxp_3b6e2ade-57fc-4f9d-85c3-38fca27f1df6/crypt/clickhouse                                                      06c210fe-97c6-40a9-b7e2-3ae2b8304523   none        none          off        
-    oxp_3b6e2ade-57fc-4f9d-85c3-38fca27f1df6/crypt/internal_dns                                                    f2999945-8940-4eea-9423-80972552a6a1   none        none          off        
-    oxp_5192ef62-5a12-4a0c-829d-a409da87909c/crypt/internal_dns                                                    86643402-4dbc-4d33-ba3e-2e475c3a9f47   none        none          off        
-    oxp_8778bcc5-dddf-4345-9fdf-5c46a36497b0/crypt/internal_dns                                                    1ddb78c9-40dd-406a-bcd0-80271360a43e   none        none          off        
-    oxp_3b6e2ade-57fc-4f9d-85c3-38fca27f1df6/crypt/zone                                                            80d1989b-2118-4b8f-887a-693c26901a63   none        none          off        
-    oxp_5192ef62-5a12-4a0c-829d-a409da87909c/crypt/zone                                                            95358c68-0461-4236-ac9a-31889f14d704   none        none          off        
-    oxp_8778bcc5-dddf-4345-9fdf-5c46a36497b0/crypt/zone                                                            11a0e954-7001-4b97-b521-2eafd179058c   none        none          off        
-    oxp_9134de8d-9ba8-4ddc-9e84-eb00ec616b53/crypt/zone                                                            ec5d1490-2ab1-446a-931a-83acb726fce9   none        none          off        
-    oxp_96569b61-9e0c-4ee7-bd11-a5e0c541ca99/crypt/zone                                                            b7aaee47-6098-4004-8cc1-0f6ffd27b314   none        none          off        
-    oxp_ba90170e-7399-4260-910a-376254a8a9bf/crypt/zone                                                            2ad4c1d4-a8c8-4757-9c4d-b2a74aebceb0   none        none          off        
-    oxp_bc649720-926b-48f2-a62a-efdcff96b49e/crypt/zone                                                            8cfbfb7d-b024-4459-aa92-fad02c3479e5   none        none          off        
-    oxp_d55da288-4f35-4e92-97b0-29a5e6009109/crypt/zone                                                            6d88208a-9cd6-4b1c-9367-0d7a7237d2ba   none        none          off        
-    oxp_f83302fc-785c-4ab3-bcca-0d040b3c3062/crypt/zone                                                            627fcb15-3896-4517-9848-6e14398ca33f   none        none          off        
-    oxp_f843fb62-0f04-4c7d-a56f-62531104dc77/crypt/zone                                                            b2bfbf22-be11-44c4-86ce-f4c9d7c61bca   none        none          off        
-    oxp_3b6e2ade-57fc-4f9d-85c3-38fca27f1df6/crypt/zone/oxz_clickhouse_2e7dca68-90bc-42a5-b516-8872899cc38f        d93a80f1-5f19-42f9-a24e-5a3bed2ecdd6   none        none          off        
-    oxp_bc649720-926b-48f2-a62a-efdcff96b49e/crypt/zone/oxz_crucible_017681e7-e03e-4fc9-94b7-9963f37a5251          285b3278-0bac-48a8-b718-75ee4393f5d2   none        none          off        
-    oxp_8778bcc5-dddf-4345-9fdf-5c46a36497b0/crypt/zone/oxz_crucible_0465511c-088d-45d3-8f1f-a59d196aa6c0          d6f0bfb0-b67f-474c-a45a-44f7f25c079a   none        none          off        
-    oxp_d55da288-4f35-4e92-97b0-29a5e6009109/crypt/zone/oxz_crucible_222b4052-a14c-435d-9d05-bd2acfb360d1          478428de-7aaf-40d7-9a50-f7a5f29ba4d6   none        none          off        
-    oxp_5192ef62-5a12-4a0c-829d-a409da87909c/crypt/zone/oxz_crucible_48b34cc7-0ea1-4c7f-a44b-576c2c9aae8d          95962f35-1a28-472c-b060-04213df9648f   none        none          off        
-    oxp_96569b61-9e0c-4ee7-bd11-a5e0c541ca99/crypt/zone/oxz_crucible_5ca82295-48f7-4ace-805e-bcf8ff1169e6          2ec7fb3f-1c91-4633-ae2c-1538e4ead7ef   none        none          off        
-    oxp_f843fb62-0f04-4c7d-a56f-62531104dc77/crypt/zone/oxz_crucible_6d4baeff-b0b2-48d4-9d57-98300ca470b0          36600c7a-1488-4b99-b697-95e3e057f701   none        none          off        
-    oxp_9134de8d-9ba8-4ddc-9e84-eb00ec616b53/crypt/zone/oxz_crucible_a4ed47c6-afc1-406a-a722-9c2ca18d8f15          983da03f-f39a-4c86-be8f-cd42187a0efb   none        none          off        
-    oxp_3b6e2ade-57fc-4f9d-85c3-38fca27f1df6/crypt/zone/oxz_crucible_b2bd58dd-4056-4418-9adc-99133fb7340d          472883c8-a687-415a-9400-963dc4ebfb23   none        none          off        
-    oxp_ba90170e-7399-4260-910a-376254a8a9bf/crypt/zone/oxz_crucible_b9871e7b-e158-4541-b590-f2388518a629          a0584b79-723b-47fb-a375-6270893e4034   none        none          off        
-    oxp_f83302fc-785c-4ab3-bcca-0d040b3c3062/crypt/zone/oxz_crucible_d845b03f-a140-46fd-b81a-3d930f804db2          391a1adf-4b07-4838-bc63-3f2ca17d54c7   none        none          off        
-    oxp_5192ef62-5a12-4a0c-829d-a409da87909c/crypt/zone/oxz_crucible_pantry_4ce5fadc-ed9a-4fc0-adc2-816ba38ac0ff   6ac03c83-58f0-4472-9946-fa8284d6ce22   none        none          off        
-    oxp_3b6e2ade-57fc-4f9d-85c3-38fca27f1df6/crypt/zone/oxz_crucible_pantry_62817fb3-3432-4d29-a7f0-0c430d91e70b   4fd8f841-8ced-4c14-9a54-1651b8c827b1   none        none          off        
-    oxp_8778bcc5-dddf-4345-9fdf-5c46a36497b0/crypt/zone/oxz_crucible_pantry_f40b4b52-a596-4c8b-ac14-a1a4608e48ad   82674874-7065-4219-903c-f9215896fb38   none        none          off        
-    oxp_8778bcc5-dddf-4345-9fdf-5c46a36497b0/crypt/zone/oxz_internal_dns_0f5fa763-0f32-4b4d-9160-ed03d92ae886      167519d0-d053-455b-a545-ad6f9b51856d   none        none          off        
-    oxp_3b6e2ade-57fc-4f9d-85c3-38fca27f1df6/crypt/zone/oxz_internal_dns_a2b1dbad-c401-434a-b1a3-d390e3d582c7      e32a6b3b-2cec-4213-bb19-bdd05730959c   none        none          off        
-    oxp_5192ef62-5a12-4a0c-829d-a409da87909c/crypt/zone/oxz_internal_dns_ed5dafdf-9ff6-47ef-a90a-c4d44ac225df      dd90bad1-a07d-4d19-920f-7adfa7c7277c   none        none          off        
-    oxp_3b6e2ade-57fc-4f9d-85c3-38fca27f1df6/crypt/zone/oxz_nexus_244029bd-c704-4894-8667-0c7af6bd62c1             c94b54db-b218-4cc5-938e-a12688dc1811   none        none          off        
-    oxp_3b6e2ade-57fc-4f9d-85c3-38fca27f1df6/crypt/zone/oxz_ntp_1bcf8d76-a533-4f21-a4e1-4b8af4b3e80a               301aaff5-4531-42a7-abec-be6169ad1922   none        none          off        
-    oxp_3b6e2ade-57fc-4f9d-85c3-38fca27f1df6/crypt/debug                                                           8674ab89-23a1-46b5-bb40-bfd938d3c026   100 GiB     none          gzip-9     
-    oxp_5192ef62-5a12-4a0c-829d-a409da87909c/crypt/debug                                                           3463b0a5-8e0f-41b5-bac9-1be5186ffe13   100 GiB     none          gzip-9     
-    oxp_8778bcc5-dddf-4345-9fdf-5c46a36497b0/crypt/debug                                                           435c0ab4-c566-4f0f-a8e3-399465075174   100 GiB     none          gzip-9     
-    oxp_9134de8d-9ba8-4ddc-9e84-eb00ec616b53/crypt/debug                                                           b2ba48cd-52b7-489d-a877-88da2392067b   100 GiB     none          gzip-9     
-    oxp_96569b61-9e0c-4ee7-bd11-a5e0c541ca99/crypt/debug                                                           702cbaf8-3e09-45b7-ba07-b610a95b3546   100 GiB     none          gzip-9     
-    oxp_ba90170e-7399-4260-910a-376254a8a9bf/crypt/debug                                                           5b1b49c7-83c4-44e4-8d54-4d1336cd5b6a   100 GiB     none          gzip-9     
-    oxp_bc649720-926b-48f2-a62a-efdcff96b49e/crypt/debug                                                           e70e6fa1-185f-4932-959f-8ddc1d52d995   100 GiB     none          gzip-9     
-    oxp_f83302fc-785c-4ab3-bcca-0d040b3c3062/crypt/debug                                                           35748580-b8b2-4882-ab41-cdc16ec52d05   100 GiB     none          gzip-9     
-    oxp_f843fb62-0f04-4c7d-a56f-62531104dc77/crypt/debug                                                           97b89a78-8a3b-4026-b3a9-88434389a2d7   100 GiB     none          gzip-9     
-*   oxp_d55da288-4f35-4e92-97b0-29a5e6009109/crypt/debug                                                           029a51d9-e7e7-418c-a55e-3f6982f1fe14   - none      - 1 GiB       gzip-9     
-     └─                                                                                                                                                   + 100 GiB   + none                   
+    ---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
+    dataset name                                                                                                   dataset id                             disposition   quota       reservation   compression
+    ---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
+    oxp_3b6e2ade-57fc-4f9d-85c3-38fca27f1df6/crucible                                                              c2b2149b-1ad7-479f-bc9f-2404cf3eec0d   in service    none        none          off        
+    oxp_5192ef62-5a12-4a0c-829d-a409da87909c/crucible                                                              74601f4f-d373-438c-808a-b9e6e94c0a67   in service    none        none          off        
+    oxp_8778bcc5-dddf-4345-9fdf-5c46a36497b0/crucible                                                              f8ffebff-ffd1-4005-9803-3bd79dd5b012   in service    none        none          off        
+    oxp_9134de8d-9ba8-4ddc-9e84-eb00ec616b53/crucible                                                              02ab12e1-26f0-4151-b2f3-e675b8f5be44   in service    none        none          off        
+    oxp_96569b61-9e0c-4ee7-bd11-a5e0c541ca99/crucible                                                              56e4a163-8f97-4122-a2a2-38546daffbfc   in service    none        none          off        
+    oxp_ba90170e-7399-4260-910a-376254a8a9bf/crucible                                                              25c1c3c4-88b2-4c7f-8069-1b9412d045e6   in service    none        none          off        
+    oxp_bc649720-926b-48f2-a62a-efdcff96b49e/crucible                                                              8c3ff417-0e78-4946-b48f-f83a1a65526b   in service    none        none          off        
+    oxp_d55da288-4f35-4e92-97b0-29a5e6009109/crucible                                                              27251d6c-990a-4537-ad6d-a23eb40a61e2   in service    none        none          off        
+    oxp_f83302fc-785c-4ab3-bcca-0d040b3c3062/crucible                                                              707bf418-524a-4a44-aaf1-fc0fe903226b   in service    none        none          off        
+    oxp_f843fb62-0f04-4c7d-a56f-62531104dc77/crucible                                                              54e1705b-2579-4319-9f96-717a4d0508da   in service    none        none          off        
+    oxp_3b6e2ade-57fc-4f9d-85c3-38fca27f1df6/crypt/clickhouse                                                      06c210fe-97c6-40a9-b7e2-3ae2b8304523   in service    none        none          off        
+    oxp_3b6e2ade-57fc-4f9d-85c3-38fca27f1df6/crypt/internal_dns                                                    f2999945-8940-4eea-9423-80972552a6a1   in service    none        none          off        
+    oxp_5192ef62-5a12-4a0c-829d-a409da87909c/crypt/internal_dns                                                    86643402-4dbc-4d33-ba3e-2e475c3a9f47   in service    none        none          off        
+    oxp_8778bcc5-dddf-4345-9fdf-5c46a36497b0/crypt/internal_dns                                                    1ddb78c9-40dd-406a-bcd0-80271360a43e   in service    none        none          off        
+    oxp_3b6e2ade-57fc-4f9d-85c3-38fca27f1df6/crypt/zone                                                            80d1989b-2118-4b8f-887a-693c26901a63   in service    none        none          off        
+    oxp_5192ef62-5a12-4a0c-829d-a409da87909c/crypt/zone                                                            95358c68-0461-4236-ac9a-31889f14d704   in service    none        none          off        
+    oxp_8778bcc5-dddf-4345-9fdf-5c46a36497b0/crypt/zone                                                            11a0e954-7001-4b97-b521-2eafd179058c   in service    none        none          off        
+    oxp_9134de8d-9ba8-4ddc-9e84-eb00ec616b53/crypt/zone                                                            ec5d1490-2ab1-446a-931a-83acb726fce9   in service    none        none          off        
+    oxp_96569b61-9e0c-4ee7-bd11-a5e0c541ca99/crypt/zone                                                            b7aaee47-6098-4004-8cc1-0f6ffd27b314   in service    none        none          off        
+    oxp_ba90170e-7399-4260-910a-376254a8a9bf/crypt/zone                                                            2ad4c1d4-a8c8-4757-9c4d-b2a74aebceb0   in service    none        none          off        
+    oxp_bc649720-926b-48f2-a62a-efdcff96b49e/crypt/zone                                                            8cfbfb7d-b024-4459-aa92-fad02c3479e5   in service    none        none          off        
+    oxp_d55da288-4f35-4e92-97b0-29a5e6009109/crypt/zone                                                            6d88208a-9cd6-4b1c-9367-0d7a7237d2ba   in service    none        none          off        
+    oxp_f83302fc-785c-4ab3-bcca-0d040b3c3062/crypt/zone                                                            627fcb15-3896-4517-9848-6e14398ca33f   in service    none        none          off        
+    oxp_f843fb62-0f04-4c7d-a56f-62531104dc77/crypt/zone                                                            b2bfbf22-be11-44c4-86ce-f4c9d7c61bca   in service    none        none          off        
+    oxp_3b6e2ade-57fc-4f9d-85c3-38fca27f1df6/crypt/zone/oxz_clickhouse_2e7dca68-90bc-42a5-b516-8872899cc38f        d93a80f1-5f19-42f9-a24e-5a3bed2ecdd6   in service    none        none          off        
+    oxp_bc649720-926b-48f2-a62a-efdcff96b49e/crypt/zone/oxz_crucible_017681e7-e03e-4fc9-94b7-9963f37a5251          285b3278-0bac-48a8-b718-75ee4393f5d2   in service    none        none          off        
+    oxp_8778bcc5-dddf-4345-9fdf-5c46a36497b0/crypt/zone/oxz_crucible_0465511c-088d-45d3-8f1f-a59d196aa6c0          d6f0bfb0-b67f-474c-a45a-44f7f25c079a   in service    none        none          off        
+    oxp_d55da288-4f35-4e92-97b0-29a5e6009109/crypt/zone/oxz_crucible_222b4052-a14c-435d-9d05-bd2acfb360d1          478428de-7aaf-40d7-9a50-f7a5f29ba4d6   in service    none        none          off        
+    oxp_5192ef62-5a12-4a0c-829d-a409da87909c/crypt/zone/oxz_crucible_48b34cc7-0ea1-4c7f-a44b-576c2c9aae8d          95962f35-1a28-472c-b060-04213df9648f   in service    none        none          off        
+    oxp_96569b61-9e0c-4ee7-bd11-a5e0c541ca99/crypt/zone/oxz_crucible_5ca82295-48f7-4ace-805e-bcf8ff1169e6          2ec7fb3f-1c91-4633-ae2c-1538e4ead7ef   in service    none        none          off        
+    oxp_f843fb62-0f04-4c7d-a56f-62531104dc77/crypt/zone/oxz_crucible_6d4baeff-b0b2-48d4-9d57-98300ca470b0          36600c7a-1488-4b99-b697-95e3e057f701   in service    none        none          off        
+    oxp_9134de8d-9ba8-4ddc-9e84-eb00ec616b53/crypt/zone/oxz_crucible_a4ed47c6-afc1-406a-a722-9c2ca18d8f15          983da03f-f39a-4c86-be8f-cd42187a0efb   in service    none        none          off        
+    oxp_3b6e2ade-57fc-4f9d-85c3-38fca27f1df6/crypt/zone/oxz_crucible_b2bd58dd-4056-4418-9adc-99133fb7340d          472883c8-a687-415a-9400-963dc4ebfb23   in service    none        none          off        
+    oxp_ba90170e-7399-4260-910a-376254a8a9bf/crypt/zone/oxz_crucible_b9871e7b-e158-4541-b590-f2388518a629          a0584b79-723b-47fb-a375-6270893e4034   in service    none        none          off        
+    oxp_f83302fc-785c-4ab3-bcca-0d040b3c3062/crypt/zone/oxz_crucible_d845b03f-a140-46fd-b81a-3d930f804db2          391a1adf-4b07-4838-bc63-3f2ca17d54c7   in service    none        none          off        
+    oxp_5192ef62-5a12-4a0c-829d-a409da87909c/crypt/zone/oxz_crucible_pantry_4ce5fadc-ed9a-4fc0-adc2-816ba38ac0ff   6ac03c83-58f0-4472-9946-fa8284d6ce22   in service    none        none          off        
+    oxp_3b6e2ade-57fc-4f9d-85c3-38fca27f1df6/crypt/zone/oxz_crucible_pantry_62817fb3-3432-4d29-a7f0-0c430d91e70b   4fd8f841-8ced-4c14-9a54-1651b8c827b1   in service    none        none          off        
+    oxp_8778bcc5-dddf-4345-9fdf-5c46a36497b0/crypt/zone/oxz_crucible_pantry_f40b4b52-a596-4c8b-ac14-a1a4608e48ad   82674874-7065-4219-903c-f9215896fb38   in service    none        none          off        
+    oxp_8778bcc5-dddf-4345-9fdf-5c46a36497b0/crypt/zone/oxz_internal_dns_0f5fa763-0f32-4b4d-9160-ed03d92ae886      167519d0-d053-455b-a545-ad6f9b51856d   in service    none        none          off        
+    oxp_3b6e2ade-57fc-4f9d-85c3-38fca27f1df6/crypt/zone/oxz_internal_dns_a2b1dbad-c401-434a-b1a3-d390e3d582c7      e32a6b3b-2cec-4213-bb19-bdd05730959c   in service    none        none          off        
+    oxp_5192ef62-5a12-4a0c-829d-a409da87909c/crypt/zone/oxz_internal_dns_ed5dafdf-9ff6-47ef-a90a-c4d44ac225df      dd90bad1-a07d-4d19-920f-7adfa7c7277c   in service    none        none          off        
+    oxp_3b6e2ade-57fc-4f9d-85c3-38fca27f1df6/crypt/zone/oxz_nexus_244029bd-c704-4894-8667-0c7af6bd62c1             c94b54db-b218-4cc5-938e-a12688dc1811   in service    none        none          off        
+    oxp_3b6e2ade-57fc-4f9d-85c3-38fca27f1df6/crypt/zone/oxz_ntp_1bcf8d76-a533-4f21-a4e1-4b8af4b3e80a               301aaff5-4531-42a7-abec-be6169ad1922   in service    none        none          off        
+    oxp_3b6e2ade-57fc-4f9d-85c3-38fca27f1df6/crypt/debug                                                           8674ab89-23a1-46b5-bb40-bfd938d3c026   in service    100 GiB     none          gzip-9     
+    oxp_5192ef62-5a12-4a0c-829d-a409da87909c/crypt/debug                                                           3463b0a5-8e0f-41b5-bac9-1be5186ffe13   in service    100 GiB     none          gzip-9     
+    oxp_8778bcc5-dddf-4345-9fdf-5c46a36497b0/crypt/debug                                                           435c0ab4-c566-4f0f-a8e3-399465075174   in service    100 GiB     none          gzip-9     
+    oxp_9134de8d-9ba8-4ddc-9e84-eb00ec616b53/crypt/debug                                                           b2ba48cd-52b7-489d-a877-88da2392067b   in service    100 GiB     none          gzip-9     
+    oxp_96569b61-9e0c-4ee7-bd11-a5e0c541ca99/crypt/debug                                                           702cbaf8-3e09-45b7-ba07-b610a95b3546   in service    100 GiB     none          gzip-9     
+    oxp_ba90170e-7399-4260-910a-376254a8a9bf/crypt/debug                                                           5b1b49c7-83c4-44e4-8d54-4d1336cd5b6a   in service    100 GiB     none          gzip-9     
+    oxp_bc649720-926b-48f2-a62a-efdcff96b49e/crypt/debug                                                           e70e6fa1-185f-4932-959f-8ddc1d52d995   in service    100 GiB     none          gzip-9     
+    oxp_f83302fc-785c-4ab3-bcca-0d040b3c3062/crypt/debug                                                           35748580-b8b2-4882-ab41-cdc16ec52d05   in service    100 GiB     none          gzip-9     
+    oxp_f843fb62-0f04-4c7d-a56f-62531104dc77/crypt/debug                                                           97b89a78-8a3b-4026-b3a9-88434389a2d7   in service    100 GiB     none          gzip-9     
+*   oxp_d55da288-4f35-4e92-97b0-29a5e6009109/crypt/debug                                                           029a51d9-e7e7-418c-a55e-3f6982f1fe14   in service    - none      - 1 GiB       gzip-9     
+     └─                                                                                                                                                                 + 100 GiB   + none                   
 
 
     omicron zones at generation 2:

--- a/nexus/reconfigurator/planning/tests/output/planner_decommissions_sleds_1_2.txt
+++ b/nexus/reconfigurator/planning/tests/output/planner_decommissions_sleds_1_2.txt
@@ -22,56 +22,56 @@ to:   blueprint 1ac2d88f-27dd-4506-8585-6b2be832528e
 
 
     datasets from generation 2:
-    -----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
-    dataset name                                                                                                   dataset uuid                           quota     reservation   compression
-    -----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
--   oxp_069446b4-7881-49dc-838a-63a782d4896d/crucible                                                              6c3dbdf9-0871-48d5-b32d-f93dbc0adef9   none      none          off        
--   oxp_20eba316-dffe-4516-9703-af561da19b0b/crucible                                                              16cedd55-3841-489b-8268-b60d42f3aa26   none      none          off        
--   oxp_426f4b6d-4a82-4106-bf4b-64ee86a2a5a4/crucible                                                              64222170-0027-4f28-a934-387689d63ac8   none      none          off        
--   oxp_82daeef2-8641-4bf5-ac66-f7b5f62c48b6/crucible                                                              b6b8607b-1639-458d-9c27-6adb9d6eaebd   none      none          off        
--   oxp_8e5feeb2-14f1-440f-a909-3c34aa8e129b/crucible                                                              5191937e-a424-4b1b-aef9-2f8a1065b874   none      none          off        
--   oxp_942e2123-7c4e-4f6b-9317-1341fe212647/crucible                                                              c3bb341f-09c5-4f6d-b4ed-6689f46ebf86   none      none          off        
--   oxp_97a5ce17-df5b-47e7-baf8-80ae710ce18e/crucible                                                              5cee7433-4662-42a0-948c-26c96580bc27   none      none          off        
--   oxp_debc9fb6-bd58-4e4f-b8b8-6a9a07fcf25d/crucible                                                              b6d4ceab-9815-4672-9359-073b6c5e5678   none      none          off        
--   oxp_f63a32a9-0659-43cf-8efc-8f34e7af9d45/crucible                                                              7d3ce847-80bb-48cd-9e7a-588f67303326   none      none          off        
--   oxp_ffea118f-7715-4e21-8fc5-bb23cd0f59e8/crucible                                                              28439e9e-4972-4c63-83e9-a6b575275361   none      none          off        
--   oxp_069446b4-7881-49dc-838a-63a782d4896d/crypt/clickhouse                                                      dca7679a-b028-40fe-bf45-54f53d15850d   none      none          off        
--   oxp_069446b4-7881-49dc-838a-63a782d4896d/crypt/internal_dns                                                    aa1b3c0b-2cde-4ed2-8a36-679aacb3f6f8   none      none          off        
--   oxp_069446b4-7881-49dc-838a-63a782d4896d/crypt/zone                                                            dd41720e-4936-45d0-8fb2-926d8066ea02   none      none          off        
--   oxp_20eba316-dffe-4516-9703-af561da19b0b/crypt/zone                                                            704d24de-9d71-4834-8cd5-72cda2745c62   none      none          off        
--   oxp_426f4b6d-4a82-4106-bf4b-64ee86a2a5a4/crypt/zone                                                            bf13115d-7900-4f67-8071-ff7acc7fa30f   none      none          off        
--   oxp_82daeef2-8641-4bf5-ac66-f7b5f62c48b6/crypt/zone                                                            b1adb353-1eb1-4093-b5e3-dda3baf09a27   none      none          off        
--   oxp_8e5feeb2-14f1-440f-a909-3c34aa8e129b/crypt/zone                                                            214b02d1-d63e-49c4-acfb-3fff1254961e   none      none          off        
--   oxp_942e2123-7c4e-4f6b-9317-1341fe212647/crypt/zone                                                            24778f3d-473d-4c03-8e33-cfef2c11f783   none      none          off        
--   oxp_97a5ce17-df5b-47e7-baf8-80ae710ce18e/crypt/zone                                                            fe0dc780-8237-4eb5-b6ba-6e0dffdc90a8   none      none          off        
--   oxp_debc9fb6-bd58-4e4f-b8b8-6a9a07fcf25d/crypt/zone                                                            752c2113-c084-4297-be5a-900abc9d091b   none      none          off        
--   oxp_f63a32a9-0659-43cf-8efc-8f34e7af9d45/crypt/zone                                                            565a1a74-53a9-40b5-8de0-66c0b1cc5b24   none      none          off        
--   oxp_ffea118f-7715-4e21-8fc5-bb23cd0f59e8/crypt/zone                                                            16d104de-5149-4a2f-90c4-517252ffa112   none      none          off        
--   oxp_069446b4-7881-49dc-838a-63a782d4896d/crypt/zone/oxz_clickhouse_3fd081ea-93f1-417e-bcb1-405854435f28        426ee766-c13a-42cb-9a08-9c5af90cf559   none      none          off        
--   oxp_ffea118f-7715-4e21-8fc5-bb23cd0f59e8/crypt/zone/oxz_crucible_290e7e97-c4b3-47da-9f40-8d909397fbae          4fa44ded-a308-4f69-b0ba-ea60e2a2319a   none      none          off        
--   oxp_942e2123-7c4e-4f6b-9317-1341fe212647/crypt/zone/oxz_crucible_29bbe4ad-e6e8-4e05-b188-a811a793ccbb          c35c1a79-41a2-45dc-a0dd-a9bbabf34462   none      none          off        
--   oxp_8e5feeb2-14f1-440f-a909-3c34aa8e129b/crypt/zone/oxz_crucible_8500a060-a426-4324-ba40-a66dd4b89bc6          8ef95c11-2ec4-4764-ba85-d78f3c4cacf0   none      none          off        
--   oxp_069446b4-7881-49dc-838a-63a782d4896d/crypt/zone/oxz_crucible_92b7abd8-3e34-49dd-9c56-19a314e97d49          364f8c8d-4924-468e-851c-42b504ab87ae   none      none          off        
--   oxp_20eba316-dffe-4516-9703-af561da19b0b/crypt/zone/oxz_crucible_b320954e-6c66-4540-9bf4-3d976f21ee1b          0059c701-30b8-4f30-85b1-60ce6265978b   none      none          off        
--   oxp_426f4b6d-4a82-4106-bf4b-64ee86a2a5a4/crypt/zone/oxz_crucible_bc3e4495-7e51-46b6-9f55-026ea1da39dd          e46deb07-6509-4f5d-b0b7-fbeff03bdedf   none      none          off        
--   oxp_82daeef2-8641-4bf5-ac66-f7b5f62c48b6/crypt/zone/oxz_crucible_cfb7595b-280c-40f5-b1aa-6e154adf280b          dbfdcc07-9c21-4231-bcc7-bb5933412e46   none      none          off        
--   oxp_debc9fb6-bd58-4e4f-b8b8-6a9a07fcf25d/crypt/zone/oxz_crucible_d6b6ea5a-3f29-4815-aa42-b1afeb11dfc5          dd090f1e-bb4b-4f1b-a295-53e94fb880e7   none      none          off        
--   oxp_97a5ce17-df5b-47e7-baf8-80ae710ce18e/crypt/zone/oxz_crucible_d6b77c1f-8c9e-406d-944e-c97a57b3984d          4b5e0d5a-b6ff-4ca7-821f-bc96a2686df7   none      none          off        
--   oxp_f63a32a9-0659-43cf-8efc-8f34e7af9d45/crypt/zone/oxz_crucible_ecc03801-b315-4495-9b2c-49e0eead1283          56654da3-2657-4392-94f1-1d4f6853d178   none      none          off        
--   oxp_069446b4-7881-49dc-838a-63a782d4896d/crypt/zone/oxz_crucible_pantry_ecebab45-11e7-47ab-8bc2-ab9114c6e2bc   42d694ba-0a83-4a27-96a5-166dbf0b2440   none      none          off        
--   oxp_069446b4-7881-49dc-838a-63a782d4896d/crypt/zone/oxz_internal_dns_96b7a45b-be74-44e8-b68a-e530cfa81830      8a4183fd-c357-4857-9717-a577dbb8b5a4   none      none          off        
--   oxp_069446b4-7881-49dc-838a-63a782d4896d/crypt/zone/oxz_nexus_bc0f4342-f88d-49cc-bb44-b555d9b8ca12             238cbec5-a63d-41b6-93d0-1fdd2b789872   none      none          off        
--   oxp_069446b4-7881-49dc-838a-63a782d4896d/crypt/zone/oxz_ntp_b3dbc671-0e4d-49ff-9f4f-71b249d21f57               4ea6474a-6e19-487f-877a-8f18d085bfd3   none      none          off        
--   oxp_069446b4-7881-49dc-838a-63a782d4896d/crypt/debug                                                           47b590b2-dba4-4cd6-b0ec-91ef84697d9c   100 GiB   none          gzip-9     
--   oxp_20eba316-dffe-4516-9703-af561da19b0b/crypt/debug                                                           69c1e2e4-1038-4c8b-8c86-2b254e100915   100 GiB   none          gzip-9     
--   oxp_426f4b6d-4a82-4106-bf4b-64ee86a2a5a4/crypt/debug                                                           f6d25d99-0ee3-4f25-a94f-e2b1353abe3f   100 GiB   none          gzip-9     
--   oxp_82daeef2-8641-4bf5-ac66-f7b5f62c48b6/crypt/debug                                                           bdbefa26-d30a-480e-8a22-f7c93421d6e0   100 GiB   none          gzip-9     
--   oxp_8e5feeb2-14f1-440f-a909-3c34aa8e129b/crypt/debug                                                           b5a777ab-6722-4511-b35a-8dbd099968c6   100 GiB   none          gzip-9     
--   oxp_942e2123-7c4e-4f6b-9317-1341fe212647/crypt/debug                                                           48828e8f-eaf5-4ec4-a5ec-5cbf5d616cb3   100 GiB   none          gzip-9     
--   oxp_97a5ce17-df5b-47e7-baf8-80ae710ce18e/crypt/debug                                                           e02c001d-9270-4788-ad91-576470e751de   100 GiB   none          gzip-9     
--   oxp_debc9fb6-bd58-4e4f-b8b8-6a9a07fcf25d/crypt/debug                                                           7a39606c-fbed-4aec-ac06-6ad7d5a2c7d4   100 GiB   none          gzip-9     
--   oxp_f63a32a9-0659-43cf-8efc-8f34e7af9d45/crypt/debug                                                           31802082-7903-4270-983e-5681228436be   100 GiB   none          gzip-9     
--   oxp_ffea118f-7715-4e21-8fc5-bb23cd0f59e8/crypt/debug                                                           d7eaf6f8-440a-405e-9234-35ba00e09e85   100 GiB   none          gzip-9     
+    -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
+    dataset name                                                                                                   dataset id                             disposition   quota     reservation   compression
+    -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
+-   oxp_069446b4-7881-49dc-838a-63a782d4896d/crucible                                                              6c3dbdf9-0871-48d5-b32d-f93dbc0adef9   in service    none      none          off        
+-   oxp_20eba316-dffe-4516-9703-af561da19b0b/crucible                                                              16cedd55-3841-489b-8268-b60d42f3aa26   in service    none      none          off        
+-   oxp_426f4b6d-4a82-4106-bf4b-64ee86a2a5a4/crucible                                                              64222170-0027-4f28-a934-387689d63ac8   in service    none      none          off        
+-   oxp_82daeef2-8641-4bf5-ac66-f7b5f62c48b6/crucible                                                              b6b8607b-1639-458d-9c27-6adb9d6eaebd   in service    none      none          off        
+-   oxp_8e5feeb2-14f1-440f-a909-3c34aa8e129b/crucible                                                              5191937e-a424-4b1b-aef9-2f8a1065b874   in service    none      none          off        
+-   oxp_942e2123-7c4e-4f6b-9317-1341fe212647/crucible                                                              c3bb341f-09c5-4f6d-b4ed-6689f46ebf86   in service    none      none          off        
+-   oxp_97a5ce17-df5b-47e7-baf8-80ae710ce18e/crucible                                                              5cee7433-4662-42a0-948c-26c96580bc27   in service    none      none          off        
+-   oxp_debc9fb6-bd58-4e4f-b8b8-6a9a07fcf25d/crucible                                                              b6d4ceab-9815-4672-9359-073b6c5e5678   in service    none      none          off        
+-   oxp_f63a32a9-0659-43cf-8efc-8f34e7af9d45/crucible                                                              7d3ce847-80bb-48cd-9e7a-588f67303326   in service    none      none          off        
+-   oxp_ffea118f-7715-4e21-8fc5-bb23cd0f59e8/crucible                                                              28439e9e-4972-4c63-83e9-a6b575275361   in service    none      none          off        
+-   oxp_069446b4-7881-49dc-838a-63a782d4896d/crypt/clickhouse                                                      dca7679a-b028-40fe-bf45-54f53d15850d   in service    none      none          off        
+-   oxp_069446b4-7881-49dc-838a-63a782d4896d/crypt/internal_dns                                                    aa1b3c0b-2cde-4ed2-8a36-679aacb3f6f8   in service    none      none          off        
+-   oxp_069446b4-7881-49dc-838a-63a782d4896d/crypt/zone                                                            dd41720e-4936-45d0-8fb2-926d8066ea02   in service    none      none          off        
+-   oxp_20eba316-dffe-4516-9703-af561da19b0b/crypt/zone                                                            704d24de-9d71-4834-8cd5-72cda2745c62   in service    none      none          off        
+-   oxp_426f4b6d-4a82-4106-bf4b-64ee86a2a5a4/crypt/zone                                                            bf13115d-7900-4f67-8071-ff7acc7fa30f   in service    none      none          off        
+-   oxp_82daeef2-8641-4bf5-ac66-f7b5f62c48b6/crypt/zone                                                            b1adb353-1eb1-4093-b5e3-dda3baf09a27   in service    none      none          off        
+-   oxp_8e5feeb2-14f1-440f-a909-3c34aa8e129b/crypt/zone                                                            214b02d1-d63e-49c4-acfb-3fff1254961e   in service    none      none          off        
+-   oxp_942e2123-7c4e-4f6b-9317-1341fe212647/crypt/zone                                                            24778f3d-473d-4c03-8e33-cfef2c11f783   in service    none      none          off        
+-   oxp_97a5ce17-df5b-47e7-baf8-80ae710ce18e/crypt/zone                                                            fe0dc780-8237-4eb5-b6ba-6e0dffdc90a8   in service    none      none          off        
+-   oxp_debc9fb6-bd58-4e4f-b8b8-6a9a07fcf25d/crypt/zone                                                            752c2113-c084-4297-be5a-900abc9d091b   in service    none      none          off        
+-   oxp_f63a32a9-0659-43cf-8efc-8f34e7af9d45/crypt/zone                                                            565a1a74-53a9-40b5-8de0-66c0b1cc5b24   in service    none      none          off        
+-   oxp_ffea118f-7715-4e21-8fc5-bb23cd0f59e8/crypt/zone                                                            16d104de-5149-4a2f-90c4-517252ffa112   in service    none      none          off        
+-   oxp_069446b4-7881-49dc-838a-63a782d4896d/crypt/zone/oxz_clickhouse_3fd081ea-93f1-417e-bcb1-405854435f28        426ee766-c13a-42cb-9a08-9c5af90cf559   in service    none      none          off        
+-   oxp_ffea118f-7715-4e21-8fc5-bb23cd0f59e8/crypt/zone/oxz_crucible_290e7e97-c4b3-47da-9f40-8d909397fbae          4fa44ded-a308-4f69-b0ba-ea60e2a2319a   in service    none      none          off        
+-   oxp_942e2123-7c4e-4f6b-9317-1341fe212647/crypt/zone/oxz_crucible_29bbe4ad-e6e8-4e05-b188-a811a793ccbb          c35c1a79-41a2-45dc-a0dd-a9bbabf34462   in service    none      none          off        
+-   oxp_8e5feeb2-14f1-440f-a909-3c34aa8e129b/crypt/zone/oxz_crucible_8500a060-a426-4324-ba40-a66dd4b89bc6          8ef95c11-2ec4-4764-ba85-d78f3c4cacf0   in service    none      none          off        
+-   oxp_069446b4-7881-49dc-838a-63a782d4896d/crypt/zone/oxz_crucible_92b7abd8-3e34-49dd-9c56-19a314e97d49          364f8c8d-4924-468e-851c-42b504ab87ae   in service    none      none          off        
+-   oxp_20eba316-dffe-4516-9703-af561da19b0b/crypt/zone/oxz_crucible_b320954e-6c66-4540-9bf4-3d976f21ee1b          0059c701-30b8-4f30-85b1-60ce6265978b   in service    none      none          off        
+-   oxp_426f4b6d-4a82-4106-bf4b-64ee86a2a5a4/crypt/zone/oxz_crucible_bc3e4495-7e51-46b6-9f55-026ea1da39dd          e46deb07-6509-4f5d-b0b7-fbeff03bdedf   in service    none      none          off        
+-   oxp_82daeef2-8641-4bf5-ac66-f7b5f62c48b6/crypt/zone/oxz_crucible_cfb7595b-280c-40f5-b1aa-6e154adf280b          dbfdcc07-9c21-4231-bcc7-bb5933412e46   in service    none      none          off        
+-   oxp_debc9fb6-bd58-4e4f-b8b8-6a9a07fcf25d/crypt/zone/oxz_crucible_d6b6ea5a-3f29-4815-aa42-b1afeb11dfc5          dd090f1e-bb4b-4f1b-a295-53e94fb880e7   in service    none      none          off        
+-   oxp_97a5ce17-df5b-47e7-baf8-80ae710ce18e/crypt/zone/oxz_crucible_d6b77c1f-8c9e-406d-944e-c97a57b3984d          4b5e0d5a-b6ff-4ca7-821f-bc96a2686df7   in service    none      none          off        
+-   oxp_f63a32a9-0659-43cf-8efc-8f34e7af9d45/crypt/zone/oxz_crucible_ecc03801-b315-4495-9b2c-49e0eead1283          56654da3-2657-4392-94f1-1d4f6853d178   in service    none      none          off        
+-   oxp_069446b4-7881-49dc-838a-63a782d4896d/crypt/zone/oxz_crucible_pantry_ecebab45-11e7-47ab-8bc2-ab9114c6e2bc   42d694ba-0a83-4a27-96a5-166dbf0b2440   in service    none      none          off        
+-   oxp_069446b4-7881-49dc-838a-63a782d4896d/crypt/zone/oxz_internal_dns_96b7a45b-be74-44e8-b68a-e530cfa81830      8a4183fd-c357-4857-9717-a577dbb8b5a4   in service    none      none          off        
+-   oxp_069446b4-7881-49dc-838a-63a782d4896d/crypt/zone/oxz_nexus_bc0f4342-f88d-49cc-bb44-b555d9b8ca12             238cbec5-a63d-41b6-93d0-1fdd2b789872   in service    none      none          off        
+-   oxp_069446b4-7881-49dc-838a-63a782d4896d/crypt/zone/oxz_ntp_b3dbc671-0e4d-49ff-9f4f-71b249d21f57               4ea6474a-6e19-487f-877a-8f18d085bfd3   in service    none      none          off        
+-   oxp_069446b4-7881-49dc-838a-63a782d4896d/crypt/debug                                                           47b590b2-dba4-4cd6-b0ec-91ef84697d9c   in service    100 GiB   none          gzip-9     
+-   oxp_20eba316-dffe-4516-9703-af561da19b0b/crypt/debug                                                           69c1e2e4-1038-4c8b-8c86-2b254e100915   in service    100 GiB   none          gzip-9     
+-   oxp_426f4b6d-4a82-4106-bf4b-64ee86a2a5a4/crypt/debug                                                           f6d25d99-0ee3-4f25-a94f-e2b1353abe3f   in service    100 GiB   none          gzip-9     
+-   oxp_82daeef2-8641-4bf5-ac66-f7b5f62c48b6/crypt/debug                                                           bdbefa26-d30a-480e-8a22-f7c93421d6e0   in service    100 GiB   none          gzip-9     
+-   oxp_8e5feeb2-14f1-440f-a909-3c34aa8e129b/crypt/debug                                                           b5a777ab-6722-4511-b35a-8dbd099968c6   in service    100 GiB   none          gzip-9     
+-   oxp_942e2123-7c4e-4f6b-9317-1341fe212647/crypt/debug                                                           48828e8f-eaf5-4ec4-a5ec-5cbf5d616cb3   in service    100 GiB   none          gzip-9     
+-   oxp_97a5ce17-df5b-47e7-baf8-80ae710ce18e/crypt/debug                                                           e02c001d-9270-4788-ad91-576470e751de   in service    100 GiB   none          gzip-9     
+-   oxp_debc9fb6-bd58-4e4f-b8b8-6a9a07fcf25d/crypt/debug                                                           7a39606c-fbed-4aec-ac06-6ad7d5a2c7d4   in service    100 GiB   none          gzip-9     
+-   oxp_f63a32a9-0659-43cf-8efc-8f34e7af9d45/crypt/debug                                                           31802082-7903-4270-983e-5681228436be   in service    100 GiB   none          gzip-9     
+-   oxp_ffea118f-7715-4e21-8fc5-bb23cd0f59e8/crypt/debug                                                           d7eaf6f8-440a-405e-9234-35ba00e09e85   in service    100 GiB   none          gzip-9     
 
 
     omicron zones generation 2 -> 3:
@@ -129,56 +129,56 @@ to:   blueprint 1ac2d88f-27dd-4506-8585-6b2be832528e
 
 
     datasets generation 2 -> 3:
-    -----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
-    dataset name                                                                                                   dataset uuid                           quota     reservation   compression
-    -----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
-    oxp_1e2ec79e-9c11-4133-ac77-e0b994a507d5/crucible                                                              6faaf132-5e10-43a9-926c-abc32ad8b2fe   none      none          off        
-    oxp_440ae69d-5e2e-4539-91d0-e2930bdd7203/crucible                                                              cbb904a8-0871-4038-933c-7393bbc0738c   none      none          off        
-    oxp_4e91d4a3-bb6c-44bb-bd4e-bf8913c1ba2b/crucible                                                              75b0260f-d857-434f-b0a6-d1b0b23702e2   none      none          off        
-    oxp_67de3a80-29cb-4066-b743-e285a2ca1f4e/crucible                                                              80f92c60-b0f3-4841-ae1d-350f9263c51f   none      none          off        
-    oxp_9139b70f-c1d3-475d-8f02-7c9acba52b2b/crucible                                                              ec3fcfea-8287-4e80-8f53-7967a939db01   none      none          off        
-    oxp_95fbb110-5272-4646-ab50-21b31b7cde23/crucible                                                              9cc9e83b-d758-4be4-b9c5-5ab4e0d0c201   none      none          off        
-    oxp_9bf35cd7-4938-4c34-8189-288b3195cb64/crucible                                                              4e7dac6e-b754-4911-89c1-1c9cd6a68ace   none      none          off        
-    oxp_9d833141-18a1-4f24-8a34-6076c026aa87/crucible                                                              4f33ef0a-829e-48c1-b5b9-a4e11f0f38c3   none      none          off        
-    oxp_a279461f-a7b9-413f-a79f-cb4dab4c3fce/crucible                                                              259a9726-27bc-495e-b7d2-29c884561005   none      none          off        
-    oxp_ff7e002b-3ad8-4d45-b03a-c46ef0ac8e59/crucible                                                              df77d6ef-0910-433c-a7a5-baef6c34fc86   none      none          off        
-    oxp_1e2ec79e-9c11-4133-ac77-e0b994a507d5/crypt/internal_dns                                                    e43ceee2-3657-4145-8e8f-fac08f34573b   none      none          off        
-    oxp_1e2ec79e-9c11-4133-ac77-e0b994a507d5/crypt/zone                                                            dc72e5ba-059c-4075-9d2c-7c69116e17ec   none      none          off        
-    oxp_440ae69d-5e2e-4539-91d0-e2930bdd7203/crypt/zone                                                            64a09f6f-3aa2-416d-a133-bfa44af9e83c   none      none          off        
-    oxp_4e91d4a3-bb6c-44bb-bd4e-bf8913c1ba2b/crypt/zone                                                            48679db3-ca47-4bde-8ee7-6a6b2ab2afdb   none      none          off        
-    oxp_67de3a80-29cb-4066-b743-e285a2ca1f4e/crypt/zone                                                            4177690d-bf09-45a1-add0-6c25f4d4806e   none      none          off        
-    oxp_9139b70f-c1d3-475d-8f02-7c9acba52b2b/crypt/zone                                                            94e76685-337a-45ba-946f-e3ec5408c58a   none      none          off        
-    oxp_95fbb110-5272-4646-ab50-21b31b7cde23/crypt/zone                                                            bc07535b-996c-402d-b488-d6b959c7c267   none      none          off        
-    oxp_9bf35cd7-4938-4c34-8189-288b3195cb64/crypt/zone                                                            5e6eb3f4-a68a-418a-917b-3beafd068acd   none      none          off        
-    oxp_9d833141-18a1-4f24-8a34-6076c026aa87/crypt/zone                                                            34f23c48-7d0a-4d83-98f8-4746e14a3315   none      none          off        
-    oxp_a279461f-a7b9-413f-a79f-cb4dab4c3fce/crypt/zone                                                            70723c5d-41ba-47db-bb36-47ccc07325de   none      none          off        
-    oxp_ff7e002b-3ad8-4d45-b03a-c46ef0ac8e59/crypt/zone                                                            f33074db-c35d-4cd8-a701-c28334be71d8   none      none          off        
-    oxp_ff7e002b-3ad8-4d45-b03a-c46ef0ac8e59/crypt/zone/oxz_crucible_052553cb-8a1a-42a4-a6cb-97a913e78877          7f96c7eb-3117-4d62-92ff-04ca0b4d4a93   none      none          off        
-    oxp_67de3a80-29cb-4066-b743-e285a2ca1f4e/crypt/zone/oxz_crucible_1bd2301a-acd3-4a9c-82d7-b0c19a3c5597          973ab9e7-2437-4d00-b6d4-61f19e352a2e   none      none          off        
-    oxp_9d833141-18a1-4f24-8a34-6076c026aa87/crypt/zone/oxz_crucible_7975aa01-6fa9-4622-a8ba-8bfcf000f8eb          3c378515-facd-4c9f-b2b3-0920fe04456d   none      none          off        
-    oxp_9139b70f-c1d3-475d-8f02-7c9acba52b2b/crypt/zone/oxz_crucible_85286e23-2498-4034-9999-c5263fc0295f          5eaa35c8-c0b4-40ad-ba1d-2ba9286b1acd   none      none          off        
-    oxp_a279461f-a7b9-413f-a79f-cb4dab4c3fce/crypt/zone/oxz_crucible_a320b746-b5f6-4027-9c3c-d41e099f2def          0e65e617-9258-4b02-a0a5-76ce1b5c65d9   none      none          off        
-    oxp_440ae69d-5e2e-4539-91d0-e2930bdd7203/crypt/zone/oxz_crucible_dcd393d4-d16c-41a8-8c16-48e0ab80d2e2          c2de0977-abf7-4c6c-b8ce-425c10d8da09   none      none          off        
-    oxp_4e91d4a3-bb6c-44bb-bd4e-bf8913c1ba2b/crypt/zone/oxz_crucible_de34e868-675e-4291-a2f7-c0b24e2e18a1          6afaa452-d2ff-4ea9-ad6e-b0b59183ef2b   none      none          off        
-    oxp_1e2ec79e-9c11-4133-ac77-e0b994a507d5/crypt/zone/oxz_crucible_e11dd8a6-951a-4019-8775-bed3a2092aaa          b3cd735d-4d94-412a-9a25-06b9fab912e0   none      none          off        
-    oxp_9bf35cd7-4938-4c34-8189-288b3195cb64/crypt/zone/oxz_crucible_f8cdd98e-4ab4-46bb-b621-7590808582cc          4befe2e1-3d46-4b61-a92a-66f27db0df0e   none      none          off        
-    oxp_95fbb110-5272-4646-ab50-21b31b7cde23/crypt/zone/oxz_crucible_fcccf363-d190-441c-ba40-58e24f8a9cb3          82c66769-fc0d-49df-bb32-bc7f61892134   none      none          off        
-    oxp_1e2ec79e-9c11-4133-ac77-e0b994a507d5/crypt/zone/oxz_crucible_pantry_a22472df-5df2-4c1f-ad1f-439a4164984f   2b22a609-539c-478a-939e-ba25068d31ee   none      none          off        
-    oxp_1e2ec79e-9c11-4133-ac77-e0b994a507d5/crypt/zone/oxz_internal_dns_936b1cbb-84e5-48ab-bc59-3bbd7830a421      1f4d6d18-0bdf-4e39-b838-b82fb1eac0e0   none      none          off        
-    oxp_1e2ec79e-9c11-4133-ac77-e0b994a507d5/crypt/zone/oxz_nexus_33ef9872-ee9a-4478-89b9-b22b78e00d3a             7924cb4a-4be3-4346-820a-04bfdb3c03a8   none      none          off        
-    oxp_1e2ec79e-9c11-4133-ac77-e0b994a507d5/crypt/zone/oxz_ntp_52031fcc-eb18-45f5-ae6c-65c7858b5e93               44dce497-2648-40ab-9a0f-d896c9b61db1   none      none          off        
-    oxp_1e2ec79e-9c11-4133-ac77-e0b994a507d5/crypt/debug                                                           a5a387a4-2e8d-4038-b386-bf1dffc96d41   100 GiB   none          gzip-9     
-    oxp_440ae69d-5e2e-4539-91d0-e2930bdd7203/crypt/debug                                                           c61256ce-c152-4658-8e49-b31f65b615e8   100 GiB   none          gzip-9     
-    oxp_4e91d4a3-bb6c-44bb-bd4e-bf8913c1ba2b/crypt/debug                                                           52828e06-cdaf-4291-9d1c-b5b1f42515af   100 GiB   none          gzip-9     
-    oxp_67de3a80-29cb-4066-b743-e285a2ca1f4e/crypt/debug                                                           4173e69d-fb09-4068-a3f9-23638e968082   100 GiB   none          gzip-9     
-    oxp_9139b70f-c1d3-475d-8f02-7c9acba52b2b/crypt/debug                                                           bf42b426-4b74-433b-bc3e-7d4e7f1afba4   100 GiB   none          gzip-9     
-    oxp_95fbb110-5272-4646-ab50-21b31b7cde23/crypt/debug                                                           250aa09f-3953-4ce6-8160-67ecabc98add   100 GiB   none          gzip-9     
-    oxp_9bf35cd7-4938-4c34-8189-288b3195cb64/crypt/debug                                                           34a79944-be59-4246-afda-b676e91afddb   100 GiB   none          gzip-9     
-    oxp_9d833141-18a1-4f24-8a34-6076c026aa87/crypt/debug                                                           9d168de0-6b87-405d-b4fc-926b381b0c45   100 GiB   none          gzip-9     
-    oxp_a279461f-a7b9-413f-a79f-cb4dab4c3fce/crypt/debug                                                           9ace6e03-ed94-4444-b524-c3978461964c   100 GiB   none          gzip-9     
-    oxp_ff7e002b-3ad8-4d45-b03a-c46ef0ac8e59/crypt/debug                                                           f43393b3-98ce-48b7-9c97-cb25b5a93130   100 GiB   none          gzip-9     
-+   oxp_440ae69d-5e2e-4539-91d0-e2930bdd7203/crypt/zone/oxz_crucible_pantry_6b6843d6-062c-4400-8fd9-d11b5d138fe6   204afeeb-fde3-400f-b809-e1acfc11bf7e   none      none          off        
-+   oxp_440ae69d-5e2e-4539-91d0-e2930bdd7203/crypt/zone/oxz_nexus_75fb916b-4793-4cd0-873b-573768b1efe5             9a3ecdfc-970b-4376-8f89-7fe8751ae9f5   none      none          off        
+    -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
+    dataset name                                                                                                   dataset id                             disposition   quota     reservation   compression
+    -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
+    oxp_1e2ec79e-9c11-4133-ac77-e0b994a507d5/crucible                                                              6faaf132-5e10-43a9-926c-abc32ad8b2fe   in service    none      none          off        
+    oxp_440ae69d-5e2e-4539-91d0-e2930bdd7203/crucible                                                              cbb904a8-0871-4038-933c-7393bbc0738c   in service    none      none          off        
+    oxp_4e91d4a3-bb6c-44bb-bd4e-bf8913c1ba2b/crucible                                                              75b0260f-d857-434f-b0a6-d1b0b23702e2   in service    none      none          off        
+    oxp_67de3a80-29cb-4066-b743-e285a2ca1f4e/crucible                                                              80f92c60-b0f3-4841-ae1d-350f9263c51f   in service    none      none          off        
+    oxp_9139b70f-c1d3-475d-8f02-7c9acba52b2b/crucible                                                              ec3fcfea-8287-4e80-8f53-7967a939db01   in service    none      none          off        
+    oxp_95fbb110-5272-4646-ab50-21b31b7cde23/crucible                                                              9cc9e83b-d758-4be4-b9c5-5ab4e0d0c201   in service    none      none          off        
+    oxp_9bf35cd7-4938-4c34-8189-288b3195cb64/crucible                                                              4e7dac6e-b754-4911-89c1-1c9cd6a68ace   in service    none      none          off        
+    oxp_9d833141-18a1-4f24-8a34-6076c026aa87/crucible                                                              4f33ef0a-829e-48c1-b5b9-a4e11f0f38c3   in service    none      none          off        
+    oxp_a279461f-a7b9-413f-a79f-cb4dab4c3fce/crucible                                                              259a9726-27bc-495e-b7d2-29c884561005   in service    none      none          off        
+    oxp_ff7e002b-3ad8-4d45-b03a-c46ef0ac8e59/crucible                                                              df77d6ef-0910-433c-a7a5-baef6c34fc86   in service    none      none          off        
+    oxp_1e2ec79e-9c11-4133-ac77-e0b994a507d5/crypt/internal_dns                                                    e43ceee2-3657-4145-8e8f-fac08f34573b   in service    none      none          off        
+    oxp_1e2ec79e-9c11-4133-ac77-e0b994a507d5/crypt/zone                                                            dc72e5ba-059c-4075-9d2c-7c69116e17ec   in service    none      none          off        
+    oxp_440ae69d-5e2e-4539-91d0-e2930bdd7203/crypt/zone                                                            64a09f6f-3aa2-416d-a133-bfa44af9e83c   in service    none      none          off        
+    oxp_4e91d4a3-bb6c-44bb-bd4e-bf8913c1ba2b/crypt/zone                                                            48679db3-ca47-4bde-8ee7-6a6b2ab2afdb   in service    none      none          off        
+    oxp_67de3a80-29cb-4066-b743-e285a2ca1f4e/crypt/zone                                                            4177690d-bf09-45a1-add0-6c25f4d4806e   in service    none      none          off        
+    oxp_9139b70f-c1d3-475d-8f02-7c9acba52b2b/crypt/zone                                                            94e76685-337a-45ba-946f-e3ec5408c58a   in service    none      none          off        
+    oxp_95fbb110-5272-4646-ab50-21b31b7cde23/crypt/zone                                                            bc07535b-996c-402d-b488-d6b959c7c267   in service    none      none          off        
+    oxp_9bf35cd7-4938-4c34-8189-288b3195cb64/crypt/zone                                                            5e6eb3f4-a68a-418a-917b-3beafd068acd   in service    none      none          off        
+    oxp_9d833141-18a1-4f24-8a34-6076c026aa87/crypt/zone                                                            34f23c48-7d0a-4d83-98f8-4746e14a3315   in service    none      none          off        
+    oxp_a279461f-a7b9-413f-a79f-cb4dab4c3fce/crypt/zone                                                            70723c5d-41ba-47db-bb36-47ccc07325de   in service    none      none          off        
+    oxp_ff7e002b-3ad8-4d45-b03a-c46ef0ac8e59/crypt/zone                                                            f33074db-c35d-4cd8-a701-c28334be71d8   in service    none      none          off        
+    oxp_ff7e002b-3ad8-4d45-b03a-c46ef0ac8e59/crypt/zone/oxz_crucible_052553cb-8a1a-42a4-a6cb-97a913e78877          7f96c7eb-3117-4d62-92ff-04ca0b4d4a93   in service    none      none          off        
+    oxp_67de3a80-29cb-4066-b743-e285a2ca1f4e/crypt/zone/oxz_crucible_1bd2301a-acd3-4a9c-82d7-b0c19a3c5597          973ab9e7-2437-4d00-b6d4-61f19e352a2e   in service    none      none          off        
+    oxp_9d833141-18a1-4f24-8a34-6076c026aa87/crypt/zone/oxz_crucible_7975aa01-6fa9-4622-a8ba-8bfcf000f8eb          3c378515-facd-4c9f-b2b3-0920fe04456d   in service    none      none          off        
+    oxp_9139b70f-c1d3-475d-8f02-7c9acba52b2b/crypt/zone/oxz_crucible_85286e23-2498-4034-9999-c5263fc0295f          5eaa35c8-c0b4-40ad-ba1d-2ba9286b1acd   in service    none      none          off        
+    oxp_a279461f-a7b9-413f-a79f-cb4dab4c3fce/crypt/zone/oxz_crucible_a320b746-b5f6-4027-9c3c-d41e099f2def          0e65e617-9258-4b02-a0a5-76ce1b5c65d9   in service    none      none          off        
+    oxp_440ae69d-5e2e-4539-91d0-e2930bdd7203/crypt/zone/oxz_crucible_dcd393d4-d16c-41a8-8c16-48e0ab80d2e2          c2de0977-abf7-4c6c-b8ce-425c10d8da09   in service    none      none          off        
+    oxp_4e91d4a3-bb6c-44bb-bd4e-bf8913c1ba2b/crypt/zone/oxz_crucible_de34e868-675e-4291-a2f7-c0b24e2e18a1          6afaa452-d2ff-4ea9-ad6e-b0b59183ef2b   in service    none      none          off        
+    oxp_1e2ec79e-9c11-4133-ac77-e0b994a507d5/crypt/zone/oxz_crucible_e11dd8a6-951a-4019-8775-bed3a2092aaa          b3cd735d-4d94-412a-9a25-06b9fab912e0   in service    none      none          off        
+    oxp_9bf35cd7-4938-4c34-8189-288b3195cb64/crypt/zone/oxz_crucible_f8cdd98e-4ab4-46bb-b621-7590808582cc          4befe2e1-3d46-4b61-a92a-66f27db0df0e   in service    none      none          off        
+    oxp_95fbb110-5272-4646-ab50-21b31b7cde23/crypt/zone/oxz_crucible_fcccf363-d190-441c-ba40-58e24f8a9cb3          82c66769-fc0d-49df-bb32-bc7f61892134   in service    none      none          off        
+    oxp_1e2ec79e-9c11-4133-ac77-e0b994a507d5/crypt/zone/oxz_crucible_pantry_a22472df-5df2-4c1f-ad1f-439a4164984f   2b22a609-539c-478a-939e-ba25068d31ee   in service    none      none          off        
+    oxp_1e2ec79e-9c11-4133-ac77-e0b994a507d5/crypt/zone/oxz_internal_dns_936b1cbb-84e5-48ab-bc59-3bbd7830a421      1f4d6d18-0bdf-4e39-b838-b82fb1eac0e0   in service    none      none          off        
+    oxp_1e2ec79e-9c11-4133-ac77-e0b994a507d5/crypt/zone/oxz_nexus_33ef9872-ee9a-4478-89b9-b22b78e00d3a             7924cb4a-4be3-4346-820a-04bfdb3c03a8   in service    none      none          off        
+    oxp_1e2ec79e-9c11-4133-ac77-e0b994a507d5/crypt/zone/oxz_ntp_52031fcc-eb18-45f5-ae6c-65c7858b5e93               44dce497-2648-40ab-9a0f-d896c9b61db1   in service    none      none          off        
+    oxp_1e2ec79e-9c11-4133-ac77-e0b994a507d5/crypt/debug                                                           a5a387a4-2e8d-4038-b386-bf1dffc96d41   in service    100 GiB   none          gzip-9     
+    oxp_440ae69d-5e2e-4539-91d0-e2930bdd7203/crypt/debug                                                           c61256ce-c152-4658-8e49-b31f65b615e8   in service    100 GiB   none          gzip-9     
+    oxp_4e91d4a3-bb6c-44bb-bd4e-bf8913c1ba2b/crypt/debug                                                           52828e06-cdaf-4291-9d1c-b5b1f42515af   in service    100 GiB   none          gzip-9     
+    oxp_67de3a80-29cb-4066-b743-e285a2ca1f4e/crypt/debug                                                           4173e69d-fb09-4068-a3f9-23638e968082   in service    100 GiB   none          gzip-9     
+    oxp_9139b70f-c1d3-475d-8f02-7c9acba52b2b/crypt/debug                                                           bf42b426-4b74-433b-bc3e-7d4e7f1afba4   in service    100 GiB   none          gzip-9     
+    oxp_95fbb110-5272-4646-ab50-21b31b7cde23/crypt/debug                                                           250aa09f-3953-4ce6-8160-67ecabc98add   in service    100 GiB   none          gzip-9     
+    oxp_9bf35cd7-4938-4c34-8189-288b3195cb64/crypt/debug                                                           34a79944-be59-4246-afda-b676e91afddb   in service    100 GiB   none          gzip-9     
+    oxp_9d833141-18a1-4f24-8a34-6076c026aa87/crypt/debug                                                           9d168de0-6b87-405d-b4fc-926b381b0c45   in service    100 GiB   none          gzip-9     
+    oxp_a279461f-a7b9-413f-a79f-cb4dab4c3fce/crypt/debug                                                           9ace6e03-ed94-4444-b524-c3978461964c   in service    100 GiB   none          gzip-9     
+    oxp_ff7e002b-3ad8-4d45-b03a-c46ef0ac8e59/crypt/debug                                                           f43393b3-98ce-48b7-9c97-cb25b5a93130   in service    100 GiB   none          gzip-9     
++   oxp_440ae69d-5e2e-4539-91d0-e2930bdd7203/crypt/zone/oxz_crucible_pantry_6b6843d6-062c-4400-8fd9-d11b5d138fe6   204afeeb-fde3-400f-b809-e1acfc11bf7e   in service    none      none          off        
++   oxp_440ae69d-5e2e-4539-91d0-e2930bdd7203/crypt/zone/oxz_nexus_75fb916b-4793-4cd0-873b-573768b1efe5             9a3ecdfc-970b-4376-8f89-7fe8751ae9f5   in service    none      none          off        
 
 
     omicron zones generation 2 -> 3:
@@ -222,58 +222,58 @@ to:   blueprint 1ac2d88f-27dd-4506-8585-6b2be832528e
 
 
     datasets generation 2 -> 3:
-    -----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
-    dataset name                                                                                                   dataset uuid                           quota     reservation   compression
-    -----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
-    oxp_07068f19-1ff2-48da-8e72-874780df2339/crucible                                                              43cd1a3a-7dcf-47a2-bf7f-1042c9ed4461   none      none          off        
-    oxp_0f12e6ee-41d2-4eb0-813f-ba5240900ded/crucible                                                              b934756b-aff6-4435-bf59-42fcdb5433ef   none      none          off        
-    oxp_0fdb4a39-3cd5-47a0-9064-e7f3c285af61/crucible                                                              476e6363-ef7a-4538-9906-61380605378a   none      none          off        
-    oxp_13572832-83ad-40d6-896a-751f7e53f4f6/crucible                                                              3b15616c-0339-4816-a057-1c9ca76bc5d9   none      none          off        
-    oxp_3602bdd9-f7bb-4490-87a6-8f061f7712f5/crucible                                                              3fa34ab2-ae9e-4633-bf8f-e0b985591f55   none      none          off        
-    oxp_65707837-95a4-45d7-84e6-8b9a4da215f1/crucible                                                              86cbb449-770b-4ef0-bbdd-e66c96abecb9   none      none          off        
-    oxp_7a43b2b0-3846-401c-8317-d555715a00f7/crucible                                                              912ebbe4-bef6-4cf7-92a5-e21eb72fbf87   none      none          off        
-    oxp_855e3ef1-6929-4e21-8451-0e62bd93c7c9/crucible                                                              4ff0cc73-4531-4717-a130-cb28345ddea2   none      none          off        
-    oxp_8adcf329-4cee-4075-b798-28b5add1edf5/crucible                                                              3d95ffb6-833e-4e1a-a660-6f1544221ed5   none      none          off        
-    oxp_99e926d6-bd42-4cde-9f63-5ecc7ea14322/crucible                                                              bc0f19c5-73af-4c32-97e4-51bee5a874de   none      none          off        
-    oxp_07068f19-1ff2-48da-8e72-874780df2339/crypt/internal_dns                                                    5fe43d44-e28d-4343-b09b-06115e410cfc   none      none          off        
-    oxp_07068f19-1ff2-48da-8e72-874780df2339/crypt/zone                                                            19c47885-6b4a-45c6-8dd6-8f3530737df1   none      none          off        
-    oxp_0f12e6ee-41d2-4eb0-813f-ba5240900ded/crypt/zone                                                            1ffa3016-9c49-47f1-a443-429cc5ee72ff   none      none          off        
-    oxp_0fdb4a39-3cd5-47a0-9064-e7f3c285af61/crypt/zone                                                            f21e6928-e9c2-4eff-a710-1e6034948aad   none      none          off        
-    oxp_13572832-83ad-40d6-896a-751f7e53f4f6/crypt/zone                                                            ec753ba9-fa33-4e83-9cd2-7a0eb75f3825   none      none          off        
-    oxp_3602bdd9-f7bb-4490-87a6-8f061f7712f5/crypt/zone                                                            08a7b1b4-2fe9-4412-b847-de67413835d8   none      none          off        
-    oxp_65707837-95a4-45d7-84e6-8b9a4da215f1/crypt/zone                                                            d1404c52-a67c-4d5a-82ee-381fc43e7906   none      none          off        
-    oxp_7a43b2b0-3846-401c-8317-d555715a00f7/crypt/zone                                                            ddef09d3-762e-40b1-b484-03bfa2da3bd9   none      none          off        
-    oxp_855e3ef1-6929-4e21-8451-0e62bd93c7c9/crypt/zone                                                            51d6f7a3-386d-4d17-9898-ccc9e8da2b2b   none      none          off        
-    oxp_8adcf329-4cee-4075-b798-28b5add1edf5/crypt/zone                                                            21095495-e67e-4f2f-ad5a-3382350b51b9   none      none          off        
-    oxp_99e926d6-bd42-4cde-9f63-5ecc7ea14322/crypt/zone                                                            36b5605c-d6c0-4963-a4eb-5090988da393   none      none          off        
-    oxp_07068f19-1ff2-48da-8e72-874780df2339/crypt/zone/oxz_crucible_40f9f06b-eed5-47b9-9925-8afd5540d9f5          73f22559-8377-43cf-b028-4164d68826c9   none      none          off        
-    oxp_13572832-83ad-40d6-896a-751f7e53f4f6/crypt/zone/oxz_crucible_4561a213-e297-41d2-b40d-995b35715ede          c49aa53a-775f-4d2f-bb60-931e82c9d837   none      none          off        
-    oxp_99e926d6-bd42-4cde-9f63-5ecc7ea14322/crypt/zone/oxz_crucible_5e41815b-3aa2-4507-b3ea-3694c0e05b34          da3da14c-05b9-4922-b7a4-be05f23d1da8   none      none          off        
-    oxp_7a43b2b0-3846-401c-8317-d555715a00f7/crypt/zone/oxz_crucible_619451af-30b4-4252-9688-379be6555534          da3ab91c-ffa8-46e4-8a4a-de8a56e02315   none      none          off        
-    oxp_0fdb4a39-3cd5-47a0-9064-e7f3c285af61/crypt/zone/oxz_crucible_64f9bfcb-c1d5-4f15-a877-778ba83c4ada          07c46767-93f4-43df-8dcd-25abf3aaf296   none      none          off        
-    oxp_8adcf329-4cee-4075-b798-28b5add1edf5/crypt/zone/oxz_crucible_a6ac7172-669b-4ac1-9532-2848bcb80545          dc27c769-7880-439e-84c7-29c92880a219   none      none          off        
-    oxp_65707837-95a4-45d7-84e6-8b9a4da215f1/crypt/zone/oxz_crucible_e65276c2-baeb-4ab1-9a37-e48786f14dad          dceafe94-f4df-4556-9a46-560c59069e46   none      none          off        
-    oxp_3602bdd9-f7bb-4490-87a6-8f061f7712f5/crypt/zone/oxz_crucible_e6788bd0-ac6e-4125-93d0-aacbc6380f04          d730d05e-7a17-442e-9959-2e0ea58860c5   none      none          off        
-    oxp_0f12e6ee-41d2-4eb0-813f-ba5240900ded/crypt/zone/oxz_crucible_ea37e4ab-65c6-463a-a2d4-9cf8f0ccbd00          4035218d-b1ed-422a-a202-4f4fd19767b6   none      none          off        
-    oxp_855e3ef1-6929-4e21-8451-0e62bd93c7c9/crypt/zone/oxz_crucible_f52b4e76-5989-42cf-9208-60548c34b487          a8d1ad8b-946f-46e9-8bc3-4aaae1ca31f6   none      none          off        
-    oxp_07068f19-1ff2-48da-8e72-874780df2339/crypt/zone/oxz_crucible_pantry_4c1e95a8-7fae-4a3a-8651-9272ef7c9a88   53123c3d-64d2-432d-b72c-9e0c41ffa805   none      none          off        
-    oxp_07068f19-1ff2-48da-8e72-874780df2339/crypt/zone/oxz_internal_dns_7b2bb1aa-639b-4aaa-bd80-9c680e4be5fc      f24ddc4e-2569-4447-ad1a-e1e0da2e7b41   none      none          off        
-    oxp_07068f19-1ff2-48da-8e72-874780df2339/crypt/zone/oxz_nexus_294379f6-502c-465b-b32d-771c415a38af             61bd7f63-49c5-481e-8f1e-075642b59fa9   none      none          off        
-    oxp_07068f19-1ff2-48da-8e72-874780df2339/crypt/zone/oxz_ntp_064ec0c2-a320-4efb-b006-9e0e1d942d8e               701a8f75-31f5-404f-ad44-1659106f80dd   none      none          off        
-    oxp_07068f19-1ff2-48da-8e72-874780df2339/crypt/debug                                                           ba8224f4-9d26-4fa8-89ac-830e5734c58e   100 GiB   none          gzip-9     
-    oxp_0f12e6ee-41d2-4eb0-813f-ba5240900ded/crypt/debug                                                           73d82f70-9ae4-4212-bc41-42aa7cd6d5c2   100 GiB   none          gzip-9     
-    oxp_0fdb4a39-3cd5-47a0-9064-e7f3c285af61/crypt/debug                                                           71bbed5f-6b13-41f8-87e1-1dff19e2680f   100 GiB   none          gzip-9     
-    oxp_13572832-83ad-40d6-896a-751f7e53f4f6/crypt/debug                                                           bd2e7c19-590f-476e-9eb1-b1cabe99600a   100 GiB   none          gzip-9     
-    oxp_3602bdd9-f7bb-4490-87a6-8f061f7712f5/crypt/debug                                                           12b10546-bc67-43c4-993b-adcc04aa2b3f   100 GiB   none          gzip-9     
-    oxp_65707837-95a4-45d7-84e6-8b9a4da215f1/crypt/debug                                                           08d9c58d-fe91-4b9c-9db8-0b32e3b7f4e0   100 GiB   none          gzip-9     
-    oxp_7a43b2b0-3846-401c-8317-d555715a00f7/crypt/debug                                                           e7e5170c-5547-4733-885b-3fc385e97941   100 GiB   none          gzip-9     
-    oxp_855e3ef1-6929-4e21-8451-0e62bd93c7c9/crypt/debug                                                           1097db6f-ea2d-46cb-9a1f-be933677f4ea   100 GiB   none          gzip-9     
-    oxp_8adcf329-4cee-4075-b798-28b5add1edf5/crypt/debug                                                           10e453e2-115f-42dd-a575-10a593b56762   100 GiB   none          gzip-9     
-    oxp_99e926d6-bd42-4cde-9f63-5ecc7ea14322/crypt/debug                                                           a5162371-5108-497f-a3de-2b95a0dfafbe   100 GiB   none          gzip-9     
-+   oxp_07068f19-1ff2-48da-8e72-874780df2339/crypt/clickhouse                                                      dd8bc8e6-1103-4425-82da-0f7df6951581   none      none          off        
-+   oxp_0f12e6ee-41d2-4eb0-813f-ba5240900ded/crypt/internal_dns                                                    a1b355d4-5b1d-406d-960f-e61e30c2aa2a   none      none          off        
-+   oxp_07068f19-1ff2-48da-8e72-874780df2339/crypt/zone/oxz_clickhouse_a5813480-2b89-4e18-a09b-c9e5b6b317cc        c113e4ea-c33e-4df0-957b-5f7a856d5214   none      none          off        
-+   oxp_0f12e6ee-41d2-4eb0-813f-ba5240900ded/crypt/zone/oxz_internal_dns_d74f14f1-0a19-4d92-b76f-1b3a6e630b2c      672e989c-aec3-4fd9-b7f9-f2af75b3bc01   none      none          off        
+    -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
+    dataset name                                                                                                   dataset id                             disposition   quota     reservation   compression
+    -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
+    oxp_07068f19-1ff2-48da-8e72-874780df2339/crucible                                                              43cd1a3a-7dcf-47a2-bf7f-1042c9ed4461   in service    none      none          off        
+    oxp_0f12e6ee-41d2-4eb0-813f-ba5240900ded/crucible                                                              b934756b-aff6-4435-bf59-42fcdb5433ef   in service    none      none          off        
+    oxp_0fdb4a39-3cd5-47a0-9064-e7f3c285af61/crucible                                                              476e6363-ef7a-4538-9906-61380605378a   in service    none      none          off        
+    oxp_13572832-83ad-40d6-896a-751f7e53f4f6/crucible                                                              3b15616c-0339-4816-a057-1c9ca76bc5d9   in service    none      none          off        
+    oxp_3602bdd9-f7bb-4490-87a6-8f061f7712f5/crucible                                                              3fa34ab2-ae9e-4633-bf8f-e0b985591f55   in service    none      none          off        
+    oxp_65707837-95a4-45d7-84e6-8b9a4da215f1/crucible                                                              86cbb449-770b-4ef0-bbdd-e66c96abecb9   in service    none      none          off        
+    oxp_7a43b2b0-3846-401c-8317-d555715a00f7/crucible                                                              912ebbe4-bef6-4cf7-92a5-e21eb72fbf87   in service    none      none          off        
+    oxp_855e3ef1-6929-4e21-8451-0e62bd93c7c9/crucible                                                              4ff0cc73-4531-4717-a130-cb28345ddea2   in service    none      none          off        
+    oxp_8adcf329-4cee-4075-b798-28b5add1edf5/crucible                                                              3d95ffb6-833e-4e1a-a660-6f1544221ed5   in service    none      none          off        
+    oxp_99e926d6-bd42-4cde-9f63-5ecc7ea14322/crucible                                                              bc0f19c5-73af-4c32-97e4-51bee5a874de   in service    none      none          off        
+    oxp_07068f19-1ff2-48da-8e72-874780df2339/crypt/internal_dns                                                    5fe43d44-e28d-4343-b09b-06115e410cfc   in service    none      none          off        
+    oxp_07068f19-1ff2-48da-8e72-874780df2339/crypt/zone                                                            19c47885-6b4a-45c6-8dd6-8f3530737df1   in service    none      none          off        
+    oxp_0f12e6ee-41d2-4eb0-813f-ba5240900ded/crypt/zone                                                            1ffa3016-9c49-47f1-a443-429cc5ee72ff   in service    none      none          off        
+    oxp_0fdb4a39-3cd5-47a0-9064-e7f3c285af61/crypt/zone                                                            f21e6928-e9c2-4eff-a710-1e6034948aad   in service    none      none          off        
+    oxp_13572832-83ad-40d6-896a-751f7e53f4f6/crypt/zone                                                            ec753ba9-fa33-4e83-9cd2-7a0eb75f3825   in service    none      none          off        
+    oxp_3602bdd9-f7bb-4490-87a6-8f061f7712f5/crypt/zone                                                            08a7b1b4-2fe9-4412-b847-de67413835d8   in service    none      none          off        
+    oxp_65707837-95a4-45d7-84e6-8b9a4da215f1/crypt/zone                                                            d1404c52-a67c-4d5a-82ee-381fc43e7906   in service    none      none          off        
+    oxp_7a43b2b0-3846-401c-8317-d555715a00f7/crypt/zone                                                            ddef09d3-762e-40b1-b484-03bfa2da3bd9   in service    none      none          off        
+    oxp_855e3ef1-6929-4e21-8451-0e62bd93c7c9/crypt/zone                                                            51d6f7a3-386d-4d17-9898-ccc9e8da2b2b   in service    none      none          off        
+    oxp_8adcf329-4cee-4075-b798-28b5add1edf5/crypt/zone                                                            21095495-e67e-4f2f-ad5a-3382350b51b9   in service    none      none          off        
+    oxp_99e926d6-bd42-4cde-9f63-5ecc7ea14322/crypt/zone                                                            36b5605c-d6c0-4963-a4eb-5090988da393   in service    none      none          off        
+    oxp_07068f19-1ff2-48da-8e72-874780df2339/crypt/zone/oxz_crucible_40f9f06b-eed5-47b9-9925-8afd5540d9f5          73f22559-8377-43cf-b028-4164d68826c9   in service    none      none          off        
+    oxp_13572832-83ad-40d6-896a-751f7e53f4f6/crypt/zone/oxz_crucible_4561a213-e297-41d2-b40d-995b35715ede          c49aa53a-775f-4d2f-bb60-931e82c9d837   in service    none      none          off        
+    oxp_99e926d6-bd42-4cde-9f63-5ecc7ea14322/crypt/zone/oxz_crucible_5e41815b-3aa2-4507-b3ea-3694c0e05b34          da3da14c-05b9-4922-b7a4-be05f23d1da8   in service    none      none          off        
+    oxp_7a43b2b0-3846-401c-8317-d555715a00f7/crypt/zone/oxz_crucible_619451af-30b4-4252-9688-379be6555534          da3ab91c-ffa8-46e4-8a4a-de8a56e02315   in service    none      none          off        
+    oxp_0fdb4a39-3cd5-47a0-9064-e7f3c285af61/crypt/zone/oxz_crucible_64f9bfcb-c1d5-4f15-a877-778ba83c4ada          07c46767-93f4-43df-8dcd-25abf3aaf296   in service    none      none          off        
+    oxp_8adcf329-4cee-4075-b798-28b5add1edf5/crypt/zone/oxz_crucible_a6ac7172-669b-4ac1-9532-2848bcb80545          dc27c769-7880-439e-84c7-29c92880a219   in service    none      none          off        
+    oxp_65707837-95a4-45d7-84e6-8b9a4da215f1/crypt/zone/oxz_crucible_e65276c2-baeb-4ab1-9a37-e48786f14dad          dceafe94-f4df-4556-9a46-560c59069e46   in service    none      none          off        
+    oxp_3602bdd9-f7bb-4490-87a6-8f061f7712f5/crypt/zone/oxz_crucible_e6788bd0-ac6e-4125-93d0-aacbc6380f04          d730d05e-7a17-442e-9959-2e0ea58860c5   in service    none      none          off        
+    oxp_0f12e6ee-41d2-4eb0-813f-ba5240900ded/crypt/zone/oxz_crucible_ea37e4ab-65c6-463a-a2d4-9cf8f0ccbd00          4035218d-b1ed-422a-a202-4f4fd19767b6   in service    none      none          off        
+    oxp_855e3ef1-6929-4e21-8451-0e62bd93c7c9/crypt/zone/oxz_crucible_f52b4e76-5989-42cf-9208-60548c34b487          a8d1ad8b-946f-46e9-8bc3-4aaae1ca31f6   in service    none      none          off        
+    oxp_07068f19-1ff2-48da-8e72-874780df2339/crypt/zone/oxz_crucible_pantry_4c1e95a8-7fae-4a3a-8651-9272ef7c9a88   53123c3d-64d2-432d-b72c-9e0c41ffa805   in service    none      none          off        
+    oxp_07068f19-1ff2-48da-8e72-874780df2339/crypt/zone/oxz_internal_dns_7b2bb1aa-639b-4aaa-bd80-9c680e4be5fc      f24ddc4e-2569-4447-ad1a-e1e0da2e7b41   in service    none      none          off        
+    oxp_07068f19-1ff2-48da-8e72-874780df2339/crypt/zone/oxz_nexus_294379f6-502c-465b-b32d-771c415a38af             61bd7f63-49c5-481e-8f1e-075642b59fa9   in service    none      none          off        
+    oxp_07068f19-1ff2-48da-8e72-874780df2339/crypt/zone/oxz_ntp_064ec0c2-a320-4efb-b006-9e0e1d942d8e               701a8f75-31f5-404f-ad44-1659106f80dd   in service    none      none          off        
+    oxp_07068f19-1ff2-48da-8e72-874780df2339/crypt/debug                                                           ba8224f4-9d26-4fa8-89ac-830e5734c58e   in service    100 GiB   none          gzip-9     
+    oxp_0f12e6ee-41d2-4eb0-813f-ba5240900ded/crypt/debug                                                           73d82f70-9ae4-4212-bc41-42aa7cd6d5c2   in service    100 GiB   none          gzip-9     
+    oxp_0fdb4a39-3cd5-47a0-9064-e7f3c285af61/crypt/debug                                                           71bbed5f-6b13-41f8-87e1-1dff19e2680f   in service    100 GiB   none          gzip-9     
+    oxp_13572832-83ad-40d6-896a-751f7e53f4f6/crypt/debug                                                           bd2e7c19-590f-476e-9eb1-b1cabe99600a   in service    100 GiB   none          gzip-9     
+    oxp_3602bdd9-f7bb-4490-87a6-8f061f7712f5/crypt/debug                                                           12b10546-bc67-43c4-993b-adcc04aa2b3f   in service    100 GiB   none          gzip-9     
+    oxp_65707837-95a4-45d7-84e6-8b9a4da215f1/crypt/debug                                                           08d9c58d-fe91-4b9c-9db8-0b32e3b7f4e0   in service    100 GiB   none          gzip-9     
+    oxp_7a43b2b0-3846-401c-8317-d555715a00f7/crypt/debug                                                           e7e5170c-5547-4733-885b-3fc385e97941   in service    100 GiB   none          gzip-9     
+    oxp_855e3ef1-6929-4e21-8451-0e62bd93c7c9/crypt/debug                                                           1097db6f-ea2d-46cb-9a1f-be933677f4ea   in service    100 GiB   none          gzip-9     
+    oxp_8adcf329-4cee-4075-b798-28b5add1edf5/crypt/debug                                                           10e453e2-115f-42dd-a575-10a593b56762   in service    100 GiB   none          gzip-9     
+    oxp_99e926d6-bd42-4cde-9f63-5ecc7ea14322/crypt/debug                                                           a5162371-5108-497f-a3de-2b95a0dfafbe   in service    100 GiB   none          gzip-9     
++   oxp_07068f19-1ff2-48da-8e72-874780df2339/crypt/clickhouse                                                      dd8bc8e6-1103-4425-82da-0f7df6951581   in service    none      none          off        
++   oxp_0f12e6ee-41d2-4eb0-813f-ba5240900ded/crypt/internal_dns                                                    a1b355d4-5b1d-406d-960f-e61e30c2aa2a   in service    none      none          off        
++   oxp_07068f19-1ff2-48da-8e72-874780df2339/crypt/zone/oxz_clickhouse_a5813480-2b89-4e18-a09b-c9e5b6b317cc        c113e4ea-c33e-4df0-957b-5f7a856d5214   in service    none      none          off        
++   oxp_0f12e6ee-41d2-4eb0-813f-ba5240900ded/crypt/zone/oxz_internal_dns_d74f14f1-0a19-4d92-b76f-1b3a6e630b2c      672e989c-aec3-4fd9-b7f9-f2af75b3bc01   in service    none      none          off        
 
 
     omicron zones generation 2 -> 3:

--- a/nexus/reconfigurator/planning/tests/output/planner_deploy_all_keeper_nodes_1_2.txt
+++ b/nexus/reconfigurator/planning/tests/output/planner_deploy_all_keeper_nodes_1_2.txt
@@ -22,58 +22,58 @@ to:   blueprint 31ef2071-2ec9-49d9-8827-fd83b17a0e3d
 
 
     datasets generation 2 -> 3:
-    -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
-    dataset name                                                                                                     dataset uuid                           quota     reservation   compression
-    -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
-    oxp_60e6b021-79d6-4a6b-917c-6637e0769558/crucible                                                                723e4ec2-5f4a-48a9-a6a1-cb523dc47d3d   none      none          off        
-    oxp_71a07ac0-d24e-446c-a202-1998e7f6ac8c/crucible                                                                b2796e6b-ad7d-41a5-82a6-947b96e42d47   none      none          off        
-    oxp_736d4cab-c262-485e-89c2-07e6543f0855/crucible                                                                c993b4da-bea9-4010-a8d6-17d733698f07   none      none          off        
-    oxp_8ae56ca0-709d-4b8f-9869-51b62b542eef/crucible                                                                4f497ece-88c1-4557-a8b4-0e990f9941a9   none      none          off        
-    oxp_8e0bcc4f-0799-450c-a0ad-80c1637f59e3/crucible                                                                43a16c22-e79a-4bea-bcf6-682099a728dd   none      none          off        
-    oxp_8eeebb8e-6db6-43e8-a429-d26dde99882c/crucible                                                                b6bbb45b-68fc-4fa5-86cc-b59b0f797fb2   none      none          off        
-    oxp_a3e8de5b-c47a-49c0-b698-4d6955e1327f/crucible                                                                e4838ed0-304f-475e-a282-9f644f2ba3e5   none      none          off        
-    oxp_b32fa3da-4dec-4237-9776-e1a57ba15a21/crucible                                                                046f2730-768d-4bcc-8ebf-4b5f5597151c   none      none          off        
-    oxp_e9c238f6-87a3-4087-8ba4-aa594a82d012/crucible                                                                0830fc6d-ed82-41de-9389-0bd3fd4677ea   none      none          off        
-    oxp_fbf997ef-52d3-438a-b036-b9117322e569/crucible                                                                d9662141-585e-4e18-a461-9627097f02a2   none      none          off        
-    oxp_60e6b021-79d6-4a6b-917c-6637e0769558/crypt/clickhouse                                                        a4f84c49-4303-411f-bb1b-08877d828946   none      none          off        
-    oxp_60e6b021-79d6-4a6b-917c-6637e0769558/crypt/internal_dns                                                      2edca3dc-a0e5-4d34-b8a2-065be4cca767   none      none          off        
-    oxp_60e6b021-79d6-4a6b-917c-6637e0769558/crypt/zone                                                              87cd9f37-3de3-457c-9412-d0dc5678eda8   none      none          off        
-    oxp_71a07ac0-d24e-446c-a202-1998e7f6ac8c/crypt/zone                                                              3a164f36-1f53-45b3-b190-ad8a2817bc69   none      none          off        
-    oxp_736d4cab-c262-485e-89c2-07e6543f0855/crypt/zone                                                              407556ed-09ab-430e-bc8f-8291b8f8c8fe   none      none          off        
-    oxp_8ae56ca0-709d-4b8f-9869-51b62b542eef/crypt/zone                                                              99d57d61-f12a-4b56-8114-86ba92d07649   none      none          off        
-    oxp_8e0bcc4f-0799-450c-a0ad-80c1637f59e3/crypt/zone                                                              da1eb596-8764-4268-a60b-f4705b4f615b   none      none          off        
-    oxp_8eeebb8e-6db6-43e8-a429-d26dde99882c/crypt/zone                                                              d555bf19-887c-48d2-8144-47c2eac9a9e8   none      none          off        
-    oxp_a3e8de5b-c47a-49c0-b698-4d6955e1327f/crypt/zone                                                              9785e77a-9422-4b46-a4ae-8b9a155eb121   none      none          off        
-    oxp_b32fa3da-4dec-4237-9776-e1a57ba15a21/crypt/zone                                                              1192a37c-a871-4c48-905d-03c3d6035bdc   none      none          off        
-    oxp_e9c238f6-87a3-4087-8ba4-aa594a82d012/crypt/zone                                                              7bf1c7ec-5465-4bfd-b1d9-939f05336012   none      none          off        
-    oxp_fbf997ef-52d3-438a-b036-b9117322e569/crypt/zone                                                              be526b44-2c78-49ec-8ab4-73e161e27f22   none      none          off        
-    oxp_60e6b021-79d6-4a6b-917c-6637e0769558/crypt/zone/oxz_clickhouse_35e8d4b6-ea92-45cf-923c-3f566a0b1fe5          cd7e5c3a-2328-4568-b8f8-cf349f0cdd12   none      none          off        
-    oxp_e9c238f6-87a3-4087-8ba4-aa594a82d012/crypt/zone/oxz_crucible_044d074d-7905-4024-82ff-68d76221db68            98fd0f42-7337-4ce7-814e-f988304b8873   none      none          off        
-    oxp_71a07ac0-d24e-446c-a202-1998e7f6ac8c/crypt/zone/oxz_crucible_28826473-ac0b-41ea-8c54-72b782db1bcb            bbda84d8-c4ca-4f52-a766-681872fa06f0   none      none          off        
-    oxp_fbf997ef-52d3-438a-b036-b9117322e569/crypt/zone/oxz_crucible_2d3ff798-dda9-4ccf-8f91-070a20f06d55            e9c77dbd-c56a-404c-8ff9-6504b3f92556   none      none          off        
-    oxp_8eeebb8e-6db6-43e8-a429-d26dde99882c/crypt/zone/oxz_crucible_7538d29b-69f2-43e8-8509-505b25cb1c84            19110f8a-6267-41ed-ac7d-539cd0fe3511   none      none          off        
-    oxp_8ae56ca0-709d-4b8f-9869-51b62b542eef/crypt/zone/oxz_crucible_8234bbd2-4b31-4f6b-8dcc-4744b1d14e64            0fe4f647-ffd2-4845-805a-c069096560ee   none      none          off        
-    oxp_8e0bcc4f-0799-450c-a0ad-80c1637f59e3/crypt/zone/oxz_crucible_85358363-cee8-4bc3-af66-4d89e5cd714f            a1daa561-2448-4afb-8233-ec149d2bd7f4   none      none          off        
-    oxp_736d4cab-c262-485e-89c2-07e6543f0855/crypt/zone/oxz_crucible_9b58d04f-85bf-4f5e-8c6a-5d855062d5c4            69812f66-4b59-4590-9e1f-bce3e93b3b08   none      none          off        
-    oxp_60e6b021-79d6-4a6b-917c-6637e0769558/crypt/zone/oxz_crucible_e7da0aec-c6b6-4a56-9525-35385b9c62a2            36e58025-88e2-4eb9-8af0-ed9a98dda1b9   none      none          off        
-    oxp_a3e8de5b-c47a-49c0-b698-4d6955e1327f/crypt/zone/oxz_crucible_f3f977cc-7eca-4491-9b07-82b6284eb169            482fad9a-d83f-4025-8f0b-d3adea6ae2cf   none      none          off        
-    oxp_b32fa3da-4dec-4237-9776-e1a57ba15a21/crypt/zone/oxz_crucible_fef381d2-8368-4a2d-96a1-c956ed011f7b            b1937368-4019-40c4-af02-9811dc7eb143   none      none          off        
-    oxp_60e6b021-79d6-4a6b-917c-6637e0769558/crypt/zone/oxz_crucible_pantry_fe63bfd3-3128-4675-8118-cf6968293471     e3b31ef3-6b54-4901-aec4-0c672de62c7f   none      none          off        
-    oxp_60e6b021-79d6-4a6b-917c-6637e0769558/crypt/zone/oxz_internal_dns_b6b0689e-ef48-484d-b3c7-3c596edad20c        501e0672-2897-4992-8911-600e0283f04c   none      none          off        
-    oxp_60e6b021-79d6-4a6b-917c-6637e0769558/crypt/zone/oxz_nexus_46ecde76-fef7-4394-93dd-d22b003148e9               53655959-866b-4fee-bcf9-1e35504ad625   none      none          off        
-    oxp_60e6b021-79d6-4a6b-917c-6637e0769558/crypt/zone/oxz_ntp_4d009155-44fb-45b9-afed-f89cb57ce8da                 0590facf-202a-463b-81be-b6e88c47da76   none      none          off        
-    oxp_60e6b021-79d6-4a6b-917c-6637e0769558/crypt/debug                                                             8f7f16c1-d9fb-4405-9dcf-68bfbaa7bf8c   100 GiB   none          gzip-9     
-    oxp_71a07ac0-d24e-446c-a202-1998e7f6ac8c/crypt/debug                                                             6482f332-801a-473f-a77d-e07d30e2a5b7   100 GiB   none          gzip-9     
-    oxp_736d4cab-c262-485e-89c2-07e6543f0855/crypt/debug                                                             0bb0541f-2c64-487b-a8af-162454207504   100 GiB   none          gzip-9     
-    oxp_8ae56ca0-709d-4b8f-9869-51b62b542eef/crypt/debug                                                             902a6889-244f-4b67-baa4-b245f3d622c8   100 GiB   none          gzip-9     
-    oxp_8e0bcc4f-0799-450c-a0ad-80c1637f59e3/crypt/debug                                                             667ffd3c-6735-4b50-bc3b-cfa32fcc811e   100 GiB   none          gzip-9     
-    oxp_8eeebb8e-6db6-43e8-a429-d26dde99882c/crypt/debug                                                             cf48ba87-a4bb-435f-999b-bca46cfd6a89   100 GiB   none          gzip-9     
-    oxp_a3e8de5b-c47a-49c0-b698-4d6955e1327f/crypt/debug                                                             7d64cab3-7311-4519-ae4a-1af6b320fa9b   100 GiB   none          gzip-9     
-    oxp_b32fa3da-4dec-4237-9776-e1a57ba15a21/crypt/debug                                                             d3e957fd-5f26-498a-8fa3-deaea4dc5820   100 GiB   none          gzip-9     
-    oxp_e9c238f6-87a3-4087-8ba4-aa594a82d012/crypt/debug                                                             4da77f4a-5e41-4604-af30-8cf568c38428   100 GiB   none          gzip-9     
-    oxp_fbf997ef-52d3-438a-b036-b9117322e569/crypt/debug                                                             03935cb1-ce06-4594-b2fe-23e127d1cd9d   100 GiB   none          gzip-9     
-+   oxp_60e6b021-79d6-4a6b-917c-6637e0769558/crypt/clickhouse_keeper                                                 04ee4b4b-fcbe-4224-86fd-30144a4f2592   none      none          off        
-+   oxp_60e6b021-79d6-4a6b-917c-6637e0769558/crypt/zone/oxz_clickhouse_keeper_dd5ab8b1-e6e7-40e0-9ea6-b6a16f485b52   a51fb98f-3fff-4c0a-82f0-7a4aad82096b   none      none          off        
+    ---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
+    dataset name                                                                                                     dataset id                             disposition   quota     reservation   compression
+    ---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
+    oxp_60e6b021-79d6-4a6b-917c-6637e0769558/crucible                                                                723e4ec2-5f4a-48a9-a6a1-cb523dc47d3d   in service    none      none          off        
+    oxp_71a07ac0-d24e-446c-a202-1998e7f6ac8c/crucible                                                                b2796e6b-ad7d-41a5-82a6-947b96e42d47   in service    none      none          off        
+    oxp_736d4cab-c262-485e-89c2-07e6543f0855/crucible                                                                c993b4da-bea9-4010-a8d6-17d733698f07   in service    none      none          off        
+    oxp_8ae56ca0-709d-4b8f-9869-51b62b542eef/crucible                                                                4f497ece-88c1-4557-a8b4-0e990f9941a9   in service    none      none          off        
+    oxp_8e0bcc4f-0799-450c-a0ad-80c1637f59e3/crucible                                                                43a16c22-e79a-4bea-bcf6-682099a728dd   in service    none      none          off        
+    oxp_8eeebb8e-6db6-43e8-a429-d26dde99882c/crucible                                                                b6bbb45b-68fc-4fa5-86cc-b59b0f797fb2   in service    none      none          off        
+    oxp_a3e8de5b-c47a-49c0-b698-4d6955e1327f/crucible                                                                e4838ed0-304f-475e-a282-9f644f2ba3e5   in service    none      none          off        
+    oxp_b32fa3da-4dec-4237-9776-e1a57ba15a21/crucible                                                                046f2730-768d-4bcc-8ebf-4b5f5597151c   in service    none      none          off        
+    oxp_e9c238f6-87a3-4087-8ba4-aa594a82d012/crucible                                                                0830fc6d-ed82-41de-9389-0bd3fd4677ea   in service    none      none          off        
+    oxp_fbf997ef-52d3-438a-b036-b9117322e569/crucible                                                                d9662141-585e-4e18-a461-9627097f02a2   in service    none      none          off        
+    oxp_60e6b021-79d6-4a6b-917c-6637e0769558/crypt/clickhouse                                                        a4f84c49-4303-411f-bb1b-08877d828946   in service    none      none          off        
+    oxp_60e6b021-79d6-4a6b-917c-6637e0769558/crypt/internal_dns                                                      2edca3dc-a0e5-4d34-b8a2-065be4cca767   in service    none      none          off        
+    oxp_60e6b021-79d6-4a6b-917c-6637e0769558/crypt/zone                                                              87cd9f37-3de3-457c-9412-d0dc5678eda8   in service    none      none          off        
+    oxp_71a07ac0-d24e-446c-a202-1998e7f6ac8c/crypt/zone                                                              3a164f36-1f53-45b3-b190-ad8a2817bc69   in service    none      none          off        
+    oxp_736d4cab-c262-485e-89c2-07e6543f0855/crypt/zone                                                              407556ed-09ab-430e-bc8f-8291b8f8c8fe   in service    none      none          off        
+    oxp_8ae56ca0-709d-4b8f-9869-51b62b542eef/crypt/zone                                                              99d57d61-f12a-4b56-8114-86ba92d07649   in service    none      none          off        
+    oxp_8e0bcc4f-0799-450c-a0ad-80c1637f59e3/crypt/zone                                                              da1eb596-8764-4268-a60b-f4705b4f615b   in service    none      none          off        
+    oxp_8eeebb8e-6db6-43e8-a429-d26dde99882c/crypt/zone                                                              d555bf19-887c-48d2-8144-47c2eac9a9e8   in service    none      none          off        
+    oxp_a3e8de5b-c47a-49c0-b698-4d6955e1327f/crypt/zone                                                              9785e77a-9422-4b46-a4ae-8b9a155eb121   in service    none      none          off        
+    oxp_b32fa3da-4dec-4237-9776-e1a57ba15a21/crypt/zone                                                              1192a37c-a871-4c48-905d-03c3d6035bdc   in service    none      none          off        
+    oxp_e9c238f6-87a3-4087-8ba4-aa594a82d012/crypt/zone                                                              7bf1c7ec-5465-4bfd-b1d9-939f05336012   in service    none      none          off        
+    oxp_fbf997ef-52d3-438a-b036-b9117322e569/crypt/zone                                                              be526b44-2c78-49ec-8ab4-73e161e27f22   in service    none      none          off        
+    oxp_60e6b021-79d6-4a6b-917c-6637e0769558/crypt/zone/oxz_clickhouse_35e8d4b6-ea92-45cf-923c-3f566a0b1fe5          cd7e5c3a-2328-4568-b8f8-cf349f0cdd12   in service    none      none          off        
+    oxp_e9c238f6-87a3-4087-8ba4-aa594a82d012/crypt/zone/oxz_crucible_044d074d-7905-4024-82ff-68d76221db68            98fd0f42-7337-4ce7-814e-f988304b8873   in service    none      none          off        
+    oxp_71a07ac0-d24e-446c-a202-1998e7f6ac8c/crypt/zone/oxz_crucible_28826473-ac0b-41ea-8c54-72b782db1bcb            bbda84d8-c4ca-4f52-a766-681872fa06f0   in service    none      none          off        
+    oxp_fbf997ef-52d3-438a-b036-b9117322e569/crypt/zone/oxz_crucible_2d3ff798-dda9-4ccf-8f91-070a20f06d55            e9c77dbd-c56a-404c-8ff9-6504b3f92556   in service    none      none          off        
+    oxp_8eeebb8e-6db6-43e8-a429-d26dde99882c/crypt/zone/oxz_crucible_7538d29b-69f2-43e8-8509-505b25cb1c84            19110f8a-6267-41ed-ac7d-539cd0fe3511   in service    none      none          off        
+    oxp_8ae56ca0-709d-4b8f-9869-51b62b542eef/crypt/zone/oxz_crucible_8234bbd2-4b31-4f6b-8dcc-4744b1d14e64            0fe4f647-ffd2-4845-805a-c069096560ee   in service    none      none          off        
+    oxp_8e0bcc4f-0799-450c-a0ad-80c1637f59e3/crypt/zone/oxz_crucible_85358363-cee8-4bc3-af66-4d89e5cd714f            a1daa561-2448-4afb-8233-ec149d2bd7f4   in service    none      none          off        
+    oxp_736d4cab-c262-485e-89c2-07e6543f0855/crypt/zone/oxz_crucible_9b58d04f-85bf-4f5e-8c6a-5d855062d5c4            69812f66-4b59-4590-9e1f-bce3e93b3b08   in service    none      none          off        
+    oxp_60e6b021-79d6-4a6b-917c-6637e0769558/crypt/zone/oxz_crucible_e7da0aec-c6b6-4a56-9525-35385b9c62a2            36e58025-88e2-4eb9-8af0-ed9a98dda1b9   in service    none      none          off        
+    oxp_a3e8de5b-c47a-49c0-b698-4d6955e1327f/crypt/zone/oxz_crucible_f3f977cc-7eca-4491-9b07-82b6284eb169            482fad9a-d83f-4025-8f0b-d3adea6ae2cf   in service    none      none          off        
+    oxp_b32fa3da-4dec-4237-9776-e1a57ba15a21/crypt/zone/oxz_crucible_fef381d2-8368-4a2d-96a1-c956ed011f7b            b1937368-4019-40c4-af02-9811dc7eb143   in service    none      none          off        
+    oxp_60e6b021-79d6-4a6b-917c-6637e0769558/crypt/zone/oxz_crucible_pantry_fe63bfd3-3128-4675-8118-cf6968293471     e3b31ef3-6b54-4901-aec4-0c672de62c7f   in service    none      none          off        
+    oxp_60e6b021-79d6-4a6b-917c-6637e0769558/crypt/zone/oxz_internal_dns_b6b0689e-ef48-484d-b3c7-3c596edad20c        501e0672-2897-4992-8911-600e0283f04c   in service    none      none          off        
+    oxp_60e6b021-79d6-4a6b-917c-6637e0769558/crypt/zone/oxz_nexus_46ecde76-fef7-4394-93dd-d22b003148e9               53655959-866b-4fee-bcf9-1e35504ad625   in service    none      none          off        
+    oxp_60e6b021-79d6-4a6b-917c-6637e0769558/crypt/zone/oxz_ntp_4d009155-44fb-45b9-afed-f89cb57ce8da                 0590facf-202a-463b-81be-b6e88c47da76   in service    none      none          off        
+    oxp_60e6b021-79d6-4a6b-917c-6637e0769558/crypt/debug                                                             8f7f16c1-d9fb-4405-9dcf-68bfbaa7bf8c   in service    100 GiB   none          gzip-9     
+    oxp_71a07ac0-d24e-446c-a202-1998e7f6ac8c/crypt/debug                                                             6482f332-801a-473f-a77d-e07d30e2a5b7   in service    100 GiB   none          gzip-9     
+    oxp_736d4cab-c262-485e-89c2-07e6543f0855/crypt/debug                                                             0bb0541f-2c64-487b-a8af-162454207504   in service    100 GiB   none          gzip-9     
+    oxp_8ae56ca0-709d-4b8f-9869-51b62b542eef/crypt/debug                                                             902a6889-244f-4b67-baa4-b245f3d622c8   in service    100 GiB   none          gzip-9     
+    oxp_8e0bcc4f-0799-450c-a0ad-80c1637f59e3/crypt/debug                                                             667ffd3c-6735-4b50-bc3b-cfa32fcc811e   in service    100 GiB   none          gzip-9     
+    oxp_8eeebb8e-6db6-43e8-a429-d26dde99882c/crypt/debug                                                             cf48ba87-a4bb-435f-999b-bca46cfd6a89   in service    100 GiB   none          gzip-9     
+    oxp_a3e8de5b-c47a-49c0-b698-4d6955e1327f/crypt/debug                                                             7d64cab3-7311-4519-ae4a-1af6b320fa9b   in service    100 GiB   none          gzip-9     
+    oxp_b32fa3da-4dec-4237-9776-e1a57ba15a21/crypt/debug                                                             d3e957fd-5f26-498a-8fa3-deaea4dc5820   in service    100 GiB   none          gzip-9     
+    oxp_e9c238f6-87a3-4087-8ba4-aa594a82d012/crypt/debug                                                             4da77f4a-5e41-4604-af30-8cf568c38428   in service    100 GiB   none          gzip-9     
+    oxp_fbf997ef-52d3-438a-b036-b9117322e569/crypt/debug                                                             03935cb1-ce06-4594-b2fe-23e127d1cd9d   in service    100 GiB   none          gzip-9     
++   oxp_60e6b021-79d6-4a6b-917c-6637e0769558/crypt/clickhouse_keeper                                                 04ee4b4b-fcbe-4224-86fd-30144a4f2592   in service    none      none          off        
++   oxp_60e6b021-79d6-4a6b-917c-6637e0769558/crypt/zone/oxz_clickhouse_keeper_dd5ab8b1-e6e7-40e0-9ea6-b6a16f485b52   a51fb98f-3fff-4c0a-82f0-7a4aad82096b   in service    none      none          off        
 
 
     omicron zones generation 2 -> 3:
@@ -117,58 +117,58 @@ to:   blueprint 31ef2071-2ec9-49d9-8827-fd83b17a0e3d
 
 
     datasets generation 2 -> 3:
-    -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
-    dataset name                                                                                                     dataset uuid                           quota     reservation   compression
-    -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
-    oxp_0bf9d028-2b4a-4bff-82a1-6eb5fcefd985/crucible                                                                f18270c8-a39b-4579-be20-d2d1b80bba42   none      none          off        
-    oxp_19293a1d-fddc-40a7-88a4-ccafdb6f66d3/crucible                                                                06c2af14-055c-4041-aa26-9155f9f42661   none      none          off        
-    oxp_44484c44-477a-4676-8266-b98a00e80d79/crucible                                                                9deffea6-d340-4432-be3c-fad135dc29a5   none      none          off        
-    oxp_79787cd4-92da-4de5-bfd8-30a635521e10/crucible                                                                47ca08b9-b962-43e2-99d7-c2e0556c0f52   none      none          off        
-    oxp_9ae94c94-baae-477e-912a-60f0c4f3bd13/crucible                                                                b2e54e29-6915-4b6d-bc76-6f72e5c7c55a   none      none          off        
-    oxp_af85eec8-36b3-4b88-966d-a717b9b58fe5/crucible                                                                cb992d4e-7a69-4bcd-96c8-fe6e40989e24   none      none          off        
-    oxp_ddfaaba3-dafe-4103-b868-e9843d29d346/crucible                                                                68338fc3-2d8b-4419-b33d-4cce6fe9380d   none      none          off        
-    oxp_ec458c3e-91ca-40f1-a2a3-3f4292c1f279/crucible                                                                5294b99c-3eac-40e1-a35b-1f1cf2f0d6bf   none      none          off        
-    oxp_f2fc7c4c-7966-449d-8ec3-5a70f460501d/crucible                                                                31718dcf-ebd5-432c-a9e5-40abcb40931c   none      none          off        
-    oxp_f635c28a-e5ca-4d22-ac94-d8f278a6ea0e/crucible                                                                ff7ff4a9-21c4-499e-9ceb-8a00a4bb21bc   none      none          off        
-    oxp_0bf9d028-2b4a-4bff-82a1-6eb5fcefd985/crypt/internal_dns                                                      56a1af5d-de86-46c5-9504-2d1ee70587c5   none      none          off        
-    oxp_0bf9d028-2b4a-4bff-82a1-6eb5fcefd985/crypt/zone                                                              003c1d4e-15bb-4fca-aa71-a7dff507b124   none      none          off        
-    oxp_19293a1d-fddc-40a7-88a4-ccafdb6f66d3/crypt/zone                                                              bf35a148-62f0-4f88-8f60-0a13747daba2   none      none          off        
-    oxp_44484c44-477a-4676-8266-b98a00e80d79/crypt/zone                                                              9b1bf42e-6f06-44cc-af5b-bff65d929322   none      none          off        
-    oxp_79787cd4-92da-4de5-bfd8-30a635521e10/crypt/zone                                                              2c9d6bce-0293-4364-b8c9-4bdea345490e   none      none          off        
-    oxp_9ae94c94-baae-477e-912a-60f0c4f3bd13/crypt/zone                                                              11726c79-6590-4831-8480-cf50e6322c8a   none      none          off        
-    oxp_af85eec8-36b3-4b88-966d-a717b9b58fe5/crypt/zone                                                              b463f0c2-3ae4-45f7-a38c-110731fcc5cb   none      none          off        
-    oxp_ddfaaba3-dafe-4103-b868-e9843d29d346/crypt/zone                                                              626abe12-321d-439b-ad8f-f8dfb2022f25   none      none          off        
-    oxp_ec458c3e-91ca-40f1-a2a3-3f4292c1f279/crypt/zone                                                              4200e2a7-0fd6-4631-9d60-21fd821193fe   none      none          off        
-    oxp_f2fc7c4c-7966-449d-8ec3-5a70f460501d/crypt/zone                                                              85f34c02-a35d-404e-8cde-bedf3e193b1c   none      none          off        
-    oxp_f635c28a-e5ca-4d22-ac94-d8f278a6ea0e/crypt/zone                                                              dd19c2c5-0bc9-48de-a116-b92503569092   none      none          off        
-    oxp_f635c28a-e5ca-4d22-ac94-d8f278a6ea0e/crypt/zone/oxz_crucible_06b45c33-9a90-408b-8534-f94ab6df8a42            9e0a360d-c158-417f-a45f-9d29ee67cdce   none      none          off        
-    oxp_19293a1d-fddc-40a7-88a4-ccafdb6f66d3/crypt/zone/oxz_crucible_32999e20-ed5c-4c25-b4bd-41a3fbaf1445            dd7a45b8-3175-4744-8b99-ce19b22bb8ce   none      none          off        
-    oxp_9ae94c94-baae-477e-912a-60f0c4f3bd13/crypt/zone/oxz_crucible_4a037563-f969-4028-8384-164bdf308c3c            0d5b2580-7190-4bcc-9982-5012dac51f05   none      none          off        
-    oxp_44484c44-477a-4676-8266-b98a00e80d79/crypt/zone/oxz_crucible_6564394d-2c51-4252-b3b1-f5f88a72d7c3            26a1cc86-f717-4a12-b644-5acd168843aa   none      none          off        
-    oxp_0bf9d028-2b4a-4bff-82a1-6eb5fcefd985/crypt/zone/oxz_crucible_87427b40-5114-49cd-96bd-63edd61fce90            e7364079-58e3-4b36-81a7-b9e08f2a8fff   none      none          off        
-    oxp_ddfaaba3-dafe-4103-b868-e9843d29d346/crypt/zone/oxz_crucible_8acdc189-d4da-45a7-b306-23b43e86f695            6fa84a9c-0161-40c9-b596-f3b2c679ef99   none      none          off        
-    oxp_ec458c3e-91ca-40f1-a2a3-3f4292c1f279/crypt/zone/oxz_crucible_971ce633-cdc4-48cf-983e-dc272c1639eb            cb8ca8a6-6a00-4aae-8702-1493e1c3b166   none      none          off        
-    oxp_af85eec8-36b3-4b88-966d-a717b9b58fe5/crypt/zone/oxz_crucible_cfa6af7a-bf53-4fe6-bf1a-7ce3812d15c4            27323e49-f61e-4a73-bc87-f8d9f5082143   none      none          off        
-    oxp_f2fc7c4c-7966-449d-8ec3-5a70f460501d/crypt/zone/oxz_crucible_e145fb8e-df12-4df9-8049-b146ae0275be            35c46d33-4e08-4fad-90d2-3da719538ef2   none      none          off        
-    oxp_79787cd4-92da-4de5-bfd8-30a635521e10/crypt/zone/oxz_crucible_f1d08ae7-68fe-4799-8f31-f1100887c6f0            02863a62-7624-4017-9269-412910ab73f0   none      none          off        
-    oxp_0bf9d028-2b4a-4bff-82a1-6eb5fcefd985/crypt/zone/oxz_crucible_pantry_f9e18694-fdff-46a3-b40d-570d43206f48     3cb3f346-9879-4023-b919-55c4172bbf23   none      none          off        
-    oxp_0bf9d028-2b4a-4bff-82a1-6eb5fcefd985/crypt/zone/oxz_internal_dns_a00d8ae3-d1db-4aef-9174-3ff867af5e9e        c2d9b145-5e15-47be-a835-7e1f51f27679   none      none          off        
-    oxp_0bf9d028-2b4a-4bff-82a1-6eb5fcefd985/crypt/zone/oxz_nexus_8ccafc1f-97f9-4da7-bb04-d346213387ce               dcc3603b-b160-42d9-a743-11075c3b6941   none      none          off        
-    oxp_0bf9d028-2b4a-4bff-82a1-6eb5fcefd985/crypt/zone/oxz_ntp_a1797f1d-2d2a-4396-9ab5-044630b41c35                 5a70b3fe-9fad-4c17-982b-272b8595c2e8   none      none          off        
-    oxp_0bf9d028-2b4a-4bff-82a1-6eb5fcefd985/crypt/debug                                                             4e4b2f99-dc01-4793-a37a-072d942da264   100 GiB   none          gzip-9     
-    oxp_19293a1d-fddc-40a7-88a4-ccafdb6f66d3/crypt/debug                                                             8573903d-9610-4084-b0c6-ffcbb5d96c39   100 GiB   none          gzip-9     
-    oxp_44484c44-477a-4676-8266-b98a00e80d79/crypt/debug                                                             540272e1-99d2-4d2e-9d3d-032014b0e6d9   100 GiB   none          gzip-9     
-    oxp_79787cd4-92da-4de5-bfd8-30a635521e10/crypt/debug                                                             4adf2ef6-2694-4aac-aabe-688bca767092   100 GiB   none          gzip-9     
-    oxp_9ae94c94-baae-477e-912a-60f0c4f3bd13/crypt/debug                                                             7e9d012a-6d8e-475e-805e-65985a66ffcd   100 GiB   none          gzip-9     
-    oxp_af85eec8-36b3-4b88-966d-a717b9b58fe5/crypt/debug                                                             2189574d-9a73-4d25-858e-1084d57b59a8   100 GiB   none          gzip-9     
-    oxp_ddfaaba3-dafe-4103-b868-e9843d29d346/crypt/debug                                                             3cf0580b-4e1d-4ff9-bc22-4dc51ca9a53b   100 GiB   none          gzip-9     
-    oxp_ec458c3e-91ca-40f1-a2a3-3f4292c1f279/crypt/debug                                                             f499c5f8-b62f-493d-858a-8d33f7db81ff   100 GiB   none          gzip-9     
-    oxp_f2fc7c4c-7966-449d-8ec3-5a70f460501d/crypt/debug                                                             c16ff3c0-3282-46de-a620-49c6b1e3f882   100 GiB   none          gzip-9     
-    oxp_f635c28a-e5ca-4d22-ac94-d8f278a6ea0e/crypt/debug                                                             8dde6eee-f28e-4b55-8c11-525884ec81e5   100 GiB   none          gzip-9     
-+   oxp_0bf9d028-2b4a-4bff-82a1-6eb5fcefd985/crypt/clickhouse_keeper                                                 473adeb2-a57a-4240-82e9-88f2bebc1245   none      none          off        
-+   oxp_0bf9d028-2b4a-4bff-82a1-6eb5fcefd985/crypt/clickhouse_server                                                 4363b5f8-9a67-49af-b49d-585e532fa7bc   none      none          off        
-+   oxp_0bf9d028-2b4a-4bff-82a1-6eb5fcefd985/crypt/zone/oxz_clickhouse_keeper_31a66e47-6252-4f38-aa92-f48637da152c   49f52cc5-74df-4cfa-b7f0-07c7e810940d   none      none          off        
-+   oxp_0bf9d028-2b4a-4bff-82a1-6eb5fcefd985/crypt/zone/oxz_clickhouse_server_6fedfc94-2ae6-4cc7-a968-5185207284f4   f1143eb2-0685-4708-a471-968a58f93bad   none      none          off        
+    ---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
+    dataset name                                                                                                     dataset id                             disposition   quota     reservation   compression
+    ---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
+    oxp_0bf9d028-2b4a-4bff-82a1-6eb5fcefd985/crucible                                                                f18270c8-a39b-4579-be20-d2d1b80bba42   in service    none      none          off        
+    oxp_19293a1d-fddc-40a7-88a4-ccafdb6f66d3/crucible                                                                06c2af14-055c-4041-aa26-9155f9f42661   in service    none      none          off        
+    oxp_44484c44-477a-4676-8266-b98a00e80d79/crucible                                                                9deffea6-d340-4432-be3c-fad135dc29a5   in service    none      none          off        
+    oxp_79787cd4-92da-4de5-bfd8-30a635521e10/crucible                                                                47ca08b9-b962-43e2-99d7-c2e0556c0f52   in service    none      none          off        
+    oxp_9ae94c94-baae-477e-912a-60f0c4f3bd13/crucible                                                                b2e54e29-6915-4b6d-bc76-6f72e5c7c55a   in service    none      none          off        
+    oxp_af85eec8-36b3-4b88-966d-a717b9b58fe5/crucible                                                                cb992d4e-7a69-4bcd-96c8-fe6e40989e24   in service    none      none          off        
+    oxp_ddfaaba3-dafe-4103-b868-e9843d29d346/crucible                                                                68338fc3-2d8b-4419-b33d-4cce6fe9380d   in service    none      none          off        
+    oxp_ec458c3e-91ca-40f1-a2a3-3f4292c1f279/crucible                                                                5294b99c-3eac-40e1-a35b-1f1cf2f0d6bf   in service    none      none          off        
+    oxp_f2fc7c4c-7966-449d-8ec3-5a70f460501d/crucible                                                                31718dcf-ebd5-432c-a9e5-40abcb40931c   in service    none      none          off        
+    oxp_f635c28a-e5ca-4d22-ac94-d8f278a6ea0e/crucible                                                                ff7ff4a9-21c4-499e-9ceb-8a00a4bb21bc   in service    none      none          off        
+    oxp_0bf9d028-2b4a-4bff-82a1-6eb5fcefd985/crypt/internal_dns                                                      56a1af5d-de86-46c5-9504-2d1ee70587c5   in service    none      none          off        
+    oxp_0bf9d028-2b4a-4bff-82a1-6eb5fcefd985/crypt/zone                                                              003c1d4e-15bb-4fca-aa71-a7dff507b124   in service    none      none          off        
+    oxp_19293a1d-fddc-40a7-88a4-ccafdb6f66d3/crypt/zone                                                              bf35a148-62f0-4f88-8f60-0a13747daba2   in service    none      none          off        
+    oxp_44484c44-477a-4676-8266-b98a00e80d79/crypt/zone                                                              9b1bf42e-6f06-44cc-af5b-bff65d929322   in service    none      none          off        
+    oxp_79787cd4-92da-4de5-bfd8-30a635521e10/crypt/zone                                                              2c9d6bce-0293-4364-b8c9-4bdea345490e   in service    none      none          off        
+    oxp_9ae94c94-baae-477e-912a-60f0c4f3bd13/crypt/zone                                                              11726c79-6590-4831-8480-cf50e6322c8a   in service    none      none          off        
+    oxp_af85eec8-36b3-4b88-966d-a717b9b58fe5/crypt/zone                                                              b463f0c2-3ae4-45f7-a38c-110731fcc5cb   in service    none      none          off        
+    oxp_ddfaaba3-dafe-4103-b868-e9843d29d346/crypt/zone                                                              626abe12-321d-439b-ad8f-f8dfb2022f25   in service    none      none          off        
+    oxp_ec458c3e-91ca-40f1-a2a3-3f4292c1f279/crypt/zone                                                              4200e2a7-0fd6-4631-9d60-21fd821193fe   in service    none      none          off        
+    oxp_f2fc7c4c-7966-449d-8ec3-5a70f460501d/crypt/zone                                                              85f34c02-a35d-404e-8cde-bedf3e193b1c   in service    none      none          off        
+    oxp_f635c28a-e5ca-4d22-ac94-d8f278a6ea0e/crypt/zone                                                              dd19c2c5-0bc9-48de-a116-b92503569092   in service    none      none          off        
+    oxp_f635c28a-e5ca-4d22-ac94-d8f278a6ea0e/crypt/zone/oxz_crucible_06b45c33-9a90-408b-8534-f94ab6df8a42            9e0a360d-c158-417f-a45f-9d29ee67cdce   in service    none      none          off        
+    oxp_19293a1d-fddc-40a7-88a4-ccafdb6f66d3/crypt/zone/oxz_crucible_32999e20-ed5c-4c25-b4bd-41a3fbaf1445            dd7a45b8-3175-4744-8b99-ce19b22bb8ce   in service    none      none          off        
+    oxp_9ae94c94-baae-477e-912a-60f0c4f3bd13/crypt/zone/oxz_crucible_4a037563-f969-4028-8384-164bdf308c3c            0d5b2580-7190-4bcc-9982-5012dac51f05   in service    none      none          off        
+    oxp_44484c44-477a-4676-8266-b98a00e80d79/crypt/zone/oxz_crucible_6564394d-2c51-4252-b3b1-f5f88a72d7c3            26a1cc86-f717-4a12-b644-5acd168843aa   in service    none      none          off        
+    oxp_0bf9d028-2b4a-4bff-82a1-6eb5fcefd985/crypt/zone/oxz_crucible_87427b40-5114-49cd-96bd-63edd61fce90            e7364079-58e3-4b36-81a7-b9e08f2a8fff   in service    none      none          off        
+    oxp_ddfaaba3-dafe-4103-b868-e9843d29d346/crypt/zone/oxz_crucible_8acdc189-d4da-45a7-b306-23b43e86f695            6fa84a9c-0161-40c9-b596-f3b2c679ef99   in service    none      none          off        
+    oxp_ec458c3e-91ca-40f1-a2a3-3f4292c1f279/crypt/zone/oxz_crucible_971ce633-cdc4-48cf-983e-dc272c1639eb            cb8ca8a6-6a00-4aae-8702-1493e1c3b166   in service    none      none          off        
+    oxp_af85eec8-36b3-4b88-966d-a717b9b58fe5/crypt/zone/oxz_crucible_cfa6af7a-bf53-4fe6-bf1a-7ce3812d15c4            27323e49-f61e-4a73-bc87-f8d9f5082143   in service    none      none          off        
+    oxp_f2fc7c4c-7966-449d-8ec3-5a70f460501d/crypt/zone/oxz_crucible_e145fb8e-df12-4df9-8049-b146ae0275be            35c46d33-4e08-4fad-90d2-3da719538ef2   in service    none      none          off        
+    oxp_79787cd4-92da-4de5-bfd8-30a635521e10/crypt/zone/oxz_crucible_f1d08ae7-68fe-4799-8f31-f1100887c6f0            02863a62-7624-4017-9269-412910ab73f0   in service    none      none          off        
+    oxp_0bf9d028-2b4a-4bff-82a1-6eb5fcefd985/crypt/zone/oxz_crucible_pantry_f9e18694-fdff-46a3-b40d-570d43206f48     3cb3f346-9879-4023-b919-55c4172bbf23   in service    none      none          off        
+    oxp_0bf9d028-2b4a-4bff-82a1-6eb5fcefd985/crypt/zone/oxz_internal_dns_a00d8ae3-d1db-4aef-9174-3ff867af5e9e        c2d9b145-5e15-47be-a835-7e1f51f27679   in service    none      none          off        
+    oxp_0bf9d028-2b4a-4bff-82a1-6eb5fcefd985/crypt/zone/oxz_nexus_8ccafc1f-97f9-4da7-bb04-d346213387ce               dcc3603b-b160-42d9-a743-11075c3b6941   in service    none      none          off        
+    oxp_0bf9d028-2b4a-4bff-82a1-6eb5fcefd985/crypt/zone/oxz_ntp_a1797f1d-2d2a-4396-9ab5-044630b41c35                 5a70b3fe-9fad-4c17-982b-272b8595c2e8   in service    none      none          off        
+    oxp_0bf9d028-2b4a-4bff-82a1-6eb5fcefd985/crypt/debug                                                             4e4b2f99-dc01-4793-a37a-072d942da264   in service    100 GiB   none          gzip-9     
+    oxp_19293a1d-fddc-40a7-88a4-ccafdb6f66d3/crypt/debug                                                             8573903d-9610-4084-b0c6-ffcbb5d96c39   in service    100 GiB   none          gzip-9     
+    oxp_44484c44-477a-4676-8266-b98a00e80d79/crypt/debug                                                             540272e1-99d2-4d2e-9d3d-032014b0e6d9   in service    100 GiB   none          gzip-9     
+    oxp_79787cd4-92da-4de5-bfd8-30a635521e10/crypt/debug                                                             4adf2ef6-2694-4aac-aabe-688bca767092   in service    100 GiB   none          gzip-9     
+    oxp_9ae94c94-baae-477e-912a-60f0c4f3bd13/crypt/debug                                                             7e9d012a-6d8e-475e-805e-65985a66ffcd   in service    100 GiB   none          gzip-9     
+    oxp_af85eec8-36b3-4b88-966d-a717b9b58fe5/crypt/debug                                                             2189574d-9a73-4d25-858e-1084d57b59a8   in service    100 GiB   none          gzip-9     
+    oxp_ddfaaba3-dafe-4103-b868-e9843d29d346/crypt/debug                                                             3cf0580b-4e1d-4ff9-bc22-4dc51ca9a53b   in service    100 GiB   none          gzip-9     
+    oxp_ec458c3e-91ca-40f1-a2a3-3f4292c1f279/crypt/debug                                                             f499c5f8-b62f-493d-858a-8d33f7db81ff   in service    100 GiB   none          gzip-9     
+    oxp_f2fc7c4c-7966-449d-8ec3-5a70f460501d/crypt/debug                                                             c16ff3c0-3282-46de-a620-49c6b1e3f882   in service    100 GiB   none          gzip-9     
+    oxp_f635c28a-e5ca-4d22-ac94-d8f278a6ea0e/crypt/debug                                                             8dde6eee-f28e-4b55-8c11-525884ec81e5   in service    100 GiB   none          gzip-9     
++   oxp_0bf9d028-2b4a-4bff-82a1-6eb5fcefd985/crypt/clickhouse_keeper                                                 473adeb2-a57a-4240-82e9-88f2bebc1245   in service    none      none          off        
++   oxp_0bf9d028-2b4a-4bff-82a1-6eb5fcefd985/crypt/clickhouse_server                                                 4363b5f8-9a67-49af-b49d-585e532fa7bc   in service    none      none          off        
++   oxp_0bf9d028-2b4a-4bff-82a1-6eb5fcefd985/crypt/zone/oxz_clickhouse_keeper_31a66e47-6252-4f38-aa92-f48637da152c   49f52cc5-74df-4cfa-b7f0-07c7e810940d   in service    none      none          off        
++   oxp_0bf9d028-2b4a-4bff-82a1-6eb5fcefd985/crypt/zone/oxz_clickhouse_server_6fedfc94-2ae6-4cc7-a968-5185207284f4   f1143eb2-0685-4708-a471-968a58f93bad   in service    none      none          off        
 
 
     omicron zones generation 2 -> 3:
@@ -212,58 +212,58 @@ to:   blueprint 31ef2071-2ec9-49d9-8827-fd83b17a0e3d
 
 
     datasets generation 2 -> 3:
-    -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
-    dataset name                                                                                                     dataset uuid                           quota     reservation   compression
-    -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
-    oxp_2a76ab1a-fb16-412d-93f9-b8cd9aa94e85/crucible                                                                c73b47ac-ad1f-4cd1-b449-f220b5ad8104   none      none          off        
-    oxp_2de2bf7e-c679-4b2b-b373-908e9d3ffbfc/crucible                                                                813c7aac-695b-49ce-8bc5-f4cdbfc04b38   none      none          off        
-    oxp_2f02a5c6-fcf5-4b5a-bc7d-7f65369918ba/crucible                                                                e5da836d-fffb-4435-8500-889c05b04689   none      none          off        
-    oxp_32041dbf-e58d-4f32-840d-923d3d3b68af/crucible                                                                9f8d056c-3e84-4474-b9c7-5b7a890a8a7b   none      none          off        
-    oxp_5f88adff-bb50-4dc1-bbfb-5a410c753ed5/crucible                                                                e93cfc01-9581-4f6e-b77c-eb6300ca6ffb   none      none          off        
-    oxp_74d64eb9-bf69-4782-af16-2d3a761ca171/crucible                                                                f54d6e59-67a1-458b-8e66-6dc3b2adb755   none      none          off        
-    oxp_b3c231c9-b2a5-4267-b4bf-9651881b91a5/crucible                                                                6604dd1b-5f21-475d-952a-894717512d1b   none      none          off        
-    oxp_bca80b95-8dca-4a3b-b24d-d44b6a9ff71b/crucible                                                                05cb728f-f6b9-4132-922d-fe249b1ba736   none      none          off        
-    oxp_db16345e-427a-4c8e-9032-17270f729308/crucible                                                                500f8d46-a32d-4bd1-8f2c-cb9d36822660   none      none          off        
-    oxp_e3b45593-8f0c-47b2-a381-802a7dad1f54/crucible                                                                66c673a1-e8d8-4863-b368-a7ea292555fb   none      none          off        
-    oxp_2a76ab1a-fb16-412d-93f9-b8cd9aa94e85/crypt/internal_dns                                                      03de030d-d958-4ce5-86d2-368fa88e0bd8   none      none          off        
-    oxp_2a76ab1a-fb16-412d-93f9-b8cd9aa94e85/crypt/zone                                                              4c3c89bd-21cf-4986-b012-e89e4e1c1ac4   none      none          off        
-    oxp_2de2bf7e-c679-4b2b-b373-908e9d3ffbfc/crypt/zone                                                              ff4a77a2-528a-4c70-a5b9-f0093c95697b   none      none          off        
-    oxp_2f02a5c6-fcf5-4b5a-bc7d-7f65369918ba/crypt/zone                                                              676fc8c5-743b-48ca-99fd-2f2379c83890   none      none          off        
-    oxp_32041dbf-e58d-4f32-840d-923d3d3b68af/crypt/zone                                                              63362c89-4b42-4649-9ebe-43e19a5c0e51   none      none          off        
-    oxp_5f88adff-bb50-4dc1-bbfb-5a410c753ed5/crypt/zone                                                              6f83a31e-1181-418f-92b0-d0534e9ae6dd   none      none          off        
-    oxp_74d64eb9-bf69-4782-af16-2d3a761ca171/crypt/zone                                                              260ffd7d-4da5-4657-9158-ba7e1eae5971   none      none          off        
-    oxp_b3c231c9-b2a5-4267-b4bf-9651881b91a5/crypt/zone                                                              ed4c8570-3951-4f79-b27e-da73150609be   none      none          off        
-    oxp_bca80b95-8dca-4a3b-b24d-d44b6a9ff71b/crypt/zone                                                              e5dcf165-3ebb-40a2-b16f-a07b036a6533   none      none          off        
-    oxp_db16345e-427a-4c8e-9032-17270f729308/crypt/zone                                                              dd27be6b-214d-4022-a99d-2a7d12e7d8bb   none      none          off        
-    oxp_e3b45593-8f0c-47b2-a381-802a7dad1f54/crypt/zone                                                              b7500d95-2499-48fc-a7d6-2460d61e197a   none      none          off        
-    oxp_32041dbf-e58d-4f32-840d-923d3d3b68af/crypt/zone/oxz_crucible_0b0e12fd-2800-4203-acb6-24e6e976271c            cf46ee68-f945-4af6-a647-4d612c1f05be   none      none          off        
-    oxp_2de2bf7e-c679-4b2b-b373-908e9d3ffbfc/crypt/zone/oxz_crucible_1a02d419-10c4-4326-b34e-eb2b1bd90bd7            2a439799-3f16-46df-ba1b-7ea29edd392d   none      none          off        
-    oxp_2a76ab1a-fb16-412d-93f9-b8cd9aa94e85/crypt/zone/oxz_crucible_56e18c31-f630-4643-ad5c-1fede34f35de            c30be90e-20cf-46c6-bb4a-b65d2c407878   none      none          off        
-    oxp_b3c231c9-b2a5-4267-b4bf-9651881b91a5/crypt/zone/oxz_crucible_5ea86015-8f62-40aa-b3b2-c659f17ee510            6289ea03-b2c9-4470-b7ba-b935450aa764   none      none          off        
-    oxp_5f88adff-bb50-4dc1-bbfb-5a410c753ed5/crypt/zone/oxz_crucible_78965849-e6e3-4250-a66a-dc50512fad34            43b36ba3-e516-4732-be8b-8cd2ca9de93c   none      none          off        
-    oxp_74d64eb9-bf69-4782-af16-2d3a761ca171/crypt/zone/oxz_crucible_90c484e5-69d3-4636-9c64-6a878f593d33            7cc8018e-323f-4d35-bb33-fcf557b9dace   none      none          off        
-    oxp_db16345e-427a-4c8e-9032-17270f729308/crypt/zone/oxz_crucible_a3901043-fa2a-4ef7-a40e-6ef0e5fd189f            88fd4e5a-50fd-43c7-8a75-0ad4376bd564   none      none          off        
-    oxp_2f02a5c6-fcf5-4b5a-bc7d-7f65369918ba/crypt/zone/oxz_crucible_be9fd98a-6422-4890-a32b-42d42d1c8957            932cbb0d-b1d0-423d-87b6-9dce8ddb6338   none      none          off        
-    oxp_e3b45593-8f0c-47b2-a381-802a7dad1f54/crypt/zone/oxz_crucible_bf71d1a8-9e65-479d-8920-0be8e3422ac5            fd0ce816-4da0-4490-be32-4d38fb78c13c   none      none          off        
-    oxp_bca80b95-8dca-4a3b-b24d-d44b6a9ff71b/crypt/zone/oxz_crucible_eb4176ea-456b-48f6-b284-7b76da0bf4a1            704ea6b5-0ffc-443f-ae8a-482666f8277c   none      none          off        
-    oxp_2a76ab1a-fb16-412d-93f9-b8cd9aa94e85/crypt/zone/oxz_crucible_pantry_417c97a4-fe25-439d-8359-3f7062981923     8957a276-6d4e-4c58-a856-d7c5433806e1   none      none          off        
-    oxp_2a76ab1a-fb16-412d-93f9-b8cd9aa94e85/crypt/zone/oxz_internal_dns_f2bbaa79-0eab-4b91-a404-dad4c19b58c2        fe0f566f-3cff-43ef-960c-649c27746c56   none      none          off        
-    oxp_2a76ab1a-fb16-412d-93f9-b8cd9aa94e85/crypt/zone/oxz_nexus_33ba37c4-2535-4095-a7e9-c69937fc584d               77d0cd16-b6e3-484d-962f-0477cd242482   none      none          off        
-    oxp_2a76ab1a-fb16-412d-93f9-b8cd9aa94e85/crypt/zone/oxz_ntp_47eab17a-4dd4-4467-90b2-f643f465cf34                 4eaf1849-1fe4-415c-bdc7-4cc04cac20ce   none      none          off        
-    oxp_2a76ab1a-fb16-412d-93f9-b8cd9aa94e85/crypt/debug                                                             c5b8f4f9-bd10-45b8-a9f3-93adf1402ecc   100 GiB   none          gzip-9     
-    oxp_2de2bf7e-c679-4b2b-b373-908e9d3ffbfc/crypt/debug                                                             43abf982-d457-46d1-8566-8047d2a78a41   100 GiB   none          gzip-9     
-    oxp_2f02a5c6-fcf5-4b5a-bc7d-7f65369918ba/crypt/debug                                                             1b6a1722-d9f7-48ea-b351-5bc8bad4fd07   100 GiB   none          gzip-9     
-    oxp_32041dbf-e58d-4f32-840d-923d3d3b68af/crypt/debug                                                             8be43fb0-00e7-4748-9a1a-ace9772d8a83   100 GiB   none          gzip-9     
-    oxp_5f88adff-bb50-4dc1-bbfb-5a410c753ed5/crypt/debug                                                             2ccb3aa9-f0ef-4fd4-9fd7-43b4a88b8d6b   100 GiB   none          gzip-9     
-    oxp_74d64eb9-bf69-4782-af16-2d3a761ca171/crypt/debug                                                             56759eb6-69e9-46a3-b44c-fc748cd506aa   100 GiB   none          gzip-9     
-    oxp_b3c231c9-b2a5-4267-b4bf-9651881b91a5/crypt/debug                                                             76fffbd2-9c74-46b5-8033-f442be1256f5   100 GiB   none          gzip-9     
-    oxp_bca80b95-8dca-4a3b-b24d-d44b6a9ff71b/crypt/debug                                                             c13a3d71-1241-42d1-95a8-d720c20ee2c4   100 GiB   none          gzip-9     
-    oxp_db16345e-427a-4c8e-9032-17270f729308/crypt/debug                                                             f030ef33-cad2-4760-9431-1907b797161b   100 GiB   none          gzip-9     
-    oxp_e3b45593-8f0c-47b2-a381-802a7dad1f54/crypt/debug                                                             947b2823-3dca-4b56-9324-f476e2c1c6da   100 GiB   none          gzip-9     
-+   oxp_2a76ab1a-fb16-412d-93f9-b8cd9aa94e85/crypt/clickhouse_keeper                                                 6c5a6622-5f75-45a0-a9e8-4b513f5ac352   none      none          off        
-+   oxp_2a76ab1a-fb16-412d-93f9-b8cd9aa94e85/crypt/clickhouse_server                                                 f8706468-85ac-4f9f-b41d-ff7c3a17ee5f   none      none          off        
-+   oxp_2a76ab1a-fb16-412d-93f9-b8cd9aa94e85/crypt/zone/oxz_clickhouse_keeper_7aa82b80-0c37-4f20-9398-bfce4707f327   0bf9cddb-1911-495b-8aad-09b7eea5fff4   none      none          off        
-+   oxp_2a76ab1a-fb16-412d-93f9-b8cd9aa94e85/crypt/zone/oxz_clickhouse_server_812be70a-f237-47d5-ab49-f9450fe948db   292f53fc-27bb-4cc4-a61b-7d02c978149c   none      none          off        
+    ---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
+    dataset name                                                                                                     dataset id                             disposition   quota     reservation   compression
+    ---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
+    oxp_2a76ab1a-fb16-412d-93f9-b8cd9aa94e85/crucible                                                                c73b47ac-ad1f-4cd1-b449-f220b5ad8104   in service    none      none          off        
+    oxp_2de2bf7e-c679-4b2b-b373-908e9d3ffbfc/crucible                                                                813c7aac-695b-49ce-8bc5-f4cdbfc04b38   in service    none      none          off        
+    oxp_2f02a5c6-fcf5-4b5a-bc7d-7f65369918ba/crucible                                                                e5da836d-fffb-4435-8500-889c05b04689   in service    none      none          off        
+    oxp_32041dbf-e58d-4f32-840d-923d3d3b68af/crucible                                                                9f8d056c-3e84-4474-b9c7-5b7a890a8a7b   in service    none      none          off        
+    oxp_5f88adff-bb50-4dc1-bbfb-5a410c753ed5/crucible                                                                e93cfc01-9581-4f6e-b77c-eb6300ca6ffb   in service    none      none          off        
+    oxp_74d64eb9-bf69-4782-af16-2d3a761ca171/crucible                                                                f54d6e59-67a1-458b-8e66-6dc3b2adb755   in service    none      none          off        
+    oxp_b3c231c9-b2a5-4267-b4bf-9651881b91a5/crucible                                                                6604dd1b-5f21-475d-952a-894717512d1b   in service    none      none          off        
+    oxp_bca80b95-8dca-4a3b-b24d-d44b6a9ff71b/crucible                                                                05cb728f-f6b9-4132-922d-fe249b1ba736   in service    none      none          off        
+    oxp_db16345e-427a-4c8e-9032-17270f729308/crucible                                                                500f8d46-a32d-4bd1-8f2c-cb9d36822660   in service    none      none          off        
+    oxp_e3b45593-8f0c-47b2-a381-802a7dad1f54/crucible                                                                66c673a1-e8d8-4863-b368-a7ea292555fb   in service    none      none          off        
+    oxp_2a76ab1a-fb16-412d-93f9-b8cd9aa94e85/crypt/internal_dns                                                      03de030d-d958-4ce5-86d2-368fa88e0bd8   in service    none      none          off        
+    oxp_2a76ab1a-fb16-412d-93f9-b8cd9aa94e85/crypt/zone                                                              4c3c89bd-21cf-4986-b012-e89e4e1c1ac4   in service    none      none          off        
+    oxp_2de2bf7e-c679-4b2b-b373-908e9d3ffbfc/crypt/zone                                                              ff4a77a2-528a-4c70-a5b9-f0093c95697b   in service    none      none          off        
+    oxp_2f02a5c6-fcf5-4b5a-bc7d-7f65369918ba/crypt/zone                                                              676fc8c5-743b-48ca-99fd-2f2379c83890   in service    none      none          off        
+    oxp_32041dbf-e58d-4f32-840d-923d3d3b68af/crypt/zone                                                              63362c89-4b42-4649-9ebe-43e19a5c0e51   in service    none      none          off        
+    oxp_5f88adff-bb50-4dc1-bbfb-5a410c753ed5/crypt/zone                                                              6f83a31e-1181-418f-92b0-d0534e9ae6dd   in service    none      none          off        
+    oxp_74d64eb9-bf69-4782-af16-2d3a761ca171/crypt/zone                                                              260ffd7d-4da5-4657-9158-ba7e1eae5971   in service    none      none          off        
+    oxp_b3c231c9-b2a5-4267-b4bf-9651881b91a5/crypt/zone                                                              ed4c8570-3951-4f79-b27e-da73150609be   in service    none      none          off        
+    oxp_bca80b95-8dca-4a3b-b24d-d44b6a9ff71b/crypt/zone                                                              e5dcf165-3ebb-40a2-b16f-a07b036a6533   in service    none      none          off        
+    oxp_db16345e-427a-4c8e-9032-17270f729308/crypt/zone                                                              dd27be6b-214d-4022-a99d-2a7d12e7d8bb   in service    none      none          off        
+    oxp_e3b45593-8f0c-47b2-a381-802a7dad1f54/crypt/zone                                                              b7500d95-2499-48fc-a7d6-2460d61e197a   in service    none      none          off        
+    oxp_32041dbf-e58d-4f32-840d-923d3d3b68af/crypt/zone/oxz_crucible_0b0e12fd-2800-4203-acb6-24e6e976271c            cf46ee68-f945-4af6-a647-4d612c1f05be   in service    none      none          off        
+    oxp_2de2bf7e-c679-4b2b-b373-908e9d3ffbfc/crypt/zone/oxz_crucible_1a02d419-10c4-4326-b34e-eb2b1bd90bd7            2a439799-3f16-46df-ba1b-7ea29edd392d   in service    none      none          off        
+    oxp_2a76ab1a-fb16-412d-93f9-b8cd9aa94e85/crypt/zone/oxz_crucible_56e18c31-f630-4643-ad5c-1fede34f35de            c30be90e-20cf-46c6-bb4a-b65d2c407878   in service    none      none          off        
+    oxp_b3c231c9-b2a5-4267-b4bf-9651881b91a5/crypt/zone/oxz_crucible_5ea86015-8f62-40aa-b3b2-c659f17ee510            6289ea03-b2c9-4470-b7ba-b935450aa764   in service    none      none          off        
+    oxp_5f88adff-bb50-4dc1-bbfb-5a410c753ed5/crypt/zone/oxz_crucible_78965849-e6e3-4250-a66a-dc50512fad34            43b36ba3-e516-4732-be8b-8cd2ca9de93c   in service    none      none          off        
+    oxp_74d64eb9-bf69-4782-af16-2d3a761ca171/crypt/zone/oxz_crucible_90c484e5-69d3-4636-9c64-6a878f593d33            7cc8018e-323f-4d35-bb33-fcf557b9dace   in service    none      none          off        
+    oxp_db16345e-427a-4c8e-9032-17270f729308/crypt/zone/oxz_crucible_a3901043-fa2a-4ef7-a40e-6ef0e5fd189f            88fd4e5a-50fd-43c7-8a75-0ad4376bd564   in service    none      none          off        
+    oxp_2f02a5c6-fcf5-4b5a-bc7d-7f65369918ba/crypt/zone/oxz_crucible_be9fd98a-6422-4890-a32b-42d42d1c8957            932cbb0d-b1d0-423d-87b6-9dce8ddb6338   in service    none      none          off        
+    oxp_e3b45593-8f0c-47b2-a381-802a7dad1f54/crypt/zone/oxz_crucible_bf71d1a8-9e65-479d-8920-0be8e3422ac5            fd0ce816-4da0-4490-be32-4d38fb78c13c   in service    none      none          off        
+    oxp_bca80b95-8dca-4a3b-b24d-d44b6a9ff71b/crypt/zone/oxz_crucible_eb4176ea-456b-48f6-b284-7b76da0bf4a1            704ea6b5-0ffc-443f-ae8a-482666f8277c   in service    none      none          off        
+    oxp_2a76ab1a-fb16-412d-93f9-b8cd9aa94e85/crypt/zone/oxz_crucible_pantry_417c97a4-fe25-439d-8359-3f7062981923     8957a276-6d4e-4c58-a856-d7c5433806e1   in service    none      none          off        
+    oxp_2a76ab1a-fb16-412d-93f9-b8cd9aa94e85/crypt/zone/oxz_internal_dns_f2bbaa79-0eab-4b91-a404-dad4c19b58c2        fe0f566f-3cff-43ef-960c-649c27746c56   in service    none      none          off        
+    oxp_2a76ab1a-fb16-412d-93f9-b8cd9aa94e85/crypt/zone/oxz_nexus_33ba37c4-2535-4095-a7e9-c69937fc584d               77d0cd16-b6e3-484d-962f-0477cd242482   in service    none      none          off        
+    oxp_2a76ab1a-fb16-412d-93f9-b8cd9aa94e85/crypt/zone/oxz_ntp_47eab17a-4dd4-4467-90b2-f643f465cf34                 4eaf1849-1fe4-415c-bdc7-4cc04cac20ce   in service    none      none          off        
+    oxp_2a76ab1a-fb16-412d-93f9-b8cd9aa94e85/crypt/debug                                                             c5b8f4f9-bd10-45b8-a9f3-93adf1402ecc   in service    100 GiB   none          gzip-9     
+    oxp_2de2bf7e-c679-4b2b-b373-908e9d3ffbfc/crypt/debug                                                             43abf982-d457-46d1-8566-8047d2a78a41   in service    100 GiB   none          gzip-9     
+    oxp_2f02a5c6-fcf5-4b5a-bc7d-7f65369918ba/crypt/debug                                                             1b6a1722-d9f7-48ea-b351-5bc8bad4fd07   in service    100 GiB   none          gzip-9     
+    oxp_32041dbf-e58d-4f32-840d-923d3d3b68af/crypt/debug                                                             8be43fb0-00e7-4748-9a1a-ace9772d8a83   in service    100 GiB   none          gzip-9     
+    oxp_5f88adff-bb50-4dc1-bbfb-5a410c753ed5/crypt/debug                                                             2ccb3aa9-f0ef-4fd4-9fd7-43b4a88b8d6b   in service    100 GiB   none          gzip-9     
+    oxp_74d64eb9-bf69-4782-af16-2d3a761ca171/crypt/debug                                                             56759eb6-69e9-46a3-b44c-fc748cd506aa   in service    100 GiB   none          gzip-9     
+    oxp_b3c231c9-b2a5-4267-b4bf-9651881b91a5/crypt/debug                                                             76fffbd2-9c74-46b5-8033-f442be1256f5   in service    100 GiB   none          gzip-9     
+    oxp_bca80b95-8dca-4a3b-b24d-d44b6a9ff71b/crypt/debug                                                             c13a3d71-1241-42d1-95a8-d720c20ee2c4   in service    100 GiB   none          gzip-9     
+    oxp_db16345e-427a-4c8e-9032-17270f729308/crypt/debug                                                             f030ef33-cad2-4760-9431-1907b797161b   in service    100 GiB   none          gzip-9     
+    oxp_e3b45593-8f0c-47b2-a381-802a7dad1f54/crypt/debug                                                             947b2823-3dca-4b56-9324-f476e2c1c6da   in service    100 GiB   none          gzip-9     
++   oxp_2a76ab1a-fb16-412d-93f9-b8cd9aa94e85/crypt/clickhouse_keeper                                                 6c5a6622-5f75-45a0-a9e8-4b513f5ac352   in service    none      none          off        
++   oxp_2a76ab1a-fb16-412d-93f9-b8cd9aa94e85/crypt/clickhouse_server                                                 f8706468-85ac-4f9f-b41d-ff7c3a17ee5f   in service    none      none          off        
++   oxp_2a76ab1a-fb16-412d-93f9-b8cd9aa94e85/crypt/zone/oxz_clickhouse_keeper_7aa82b80-0c37-4f20-9398-bfce4707f327   0bf9cddb-1911-495b-8aad-09b7eea5fff4   in service    none      none          off        
++   oxp_2a76ab1a-fb16-412d-93f9-b8cd9aa94e85/crypt/zone/oxz_clickhouse_server_812be70a-f237-47d5-ab49-f9450fe948db   292f53fc-27bb-4cc4-a61b-7d02c978149c   in service    none      none          off        
 
 
     omicron zones generation 2 -> 3:

--- a/nexus/reconfigurator/planning/tests/output/planner_deploy_all_keeper_nodes_3_4.txt
+++ b/nexus/reconfigurator/planning/tests/output/planner_deploy_all_keeper_nodes_3_4.txt
@@ -22,58 +22,58 @@ to:   blueprint 92fa943c-7dd4-48c3-9447-c9d0665744b6
 
 
     datasets at generation 3:
-    -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
-    dataset name                                                                                                     dataset uuid                           quota     reservation   compression
-    -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
-    oxp_60e6b021-79d6-4a6b-917c-6637e0769558/crucible                                                                723e4ec2-5f4a-48a9-a6a1-cb523dc47d3d   none      none          off        
-    oxp_71a07ac0-d24e-446c-a202-1998e7f6ac8c/crucible                                                                b2796e6b-ad7d-41a5-82a6-947b96e42d47   none      none          off        
-    oxp_736d4cab-c262-485e-89c2-07e6543f0855/crucible                                                                c993b4da-bea9-4010-a8d6-17d733698f07   none      none          off        
-    oxp_8ae56ca0-709d-4b8f-9869-51b62b542eef/crucible                                                                4f497ece-88c1-4557-a8b4-0e990f9941a9   none      none          off        
-    oxp_8e0bcc4f-0799-450c-a0ad-80c1637f59e3/crucible                                                                43a16c22-e79a-4bea-bcf6-682099a728dd   none      none          off        
-    oxp_8eeebb8e-6db6-43e8-a429-d26dde99882c/crucible                                                                b6bbb45b-68fc-4fa5-86cc-b59b0f797fb2   none      none          off        
-    oxp_a3e8de5b-c47a-49c0-b698-4d6955e1327f/crucible                                                                e4838ed0-304f-475e-a282-9f644f2ba3e5   none      none          off        
-    oxp_b32fa3da-4dec-4237-9776-e1a57ba15a21/crucible                                                                046f2730-768d-4bcc-8ebf-4b5f5597151c   none      none          off        
-    oxp_e9c238f6-87a3-4087-8ba4-aa594a82d012/crucible                                                                0830fc6d-ed82-41de-9389-0bd3fd4677ea   none      none          off        
-    oxp_fbf997ef-52d3-438a-b036-b9117322e569/crucible                                                                d9662141-585e-4e18-a461-9627097f02a2   none      none          off        
-    oxp_60e6b021-79d6-4a6b-917c-6637e0769558/crypt/clickhouse                                                        a4f84c49-4303-411f-bb1b-08877d828946   none      none          off        
-    oxp_60e6b021-79d6-4a6b-917c-6637e0769558/crypt/clickhouse_keeper                                                 04ee4b4b-fcbe-4224-86fd-30144a4f2592   none      none          off        
-    oxp_60e6b021-79d6-4a6b-917c-6637e0769558/crypt/internal_dns                                                      2edca3dc-a0e5-4d34-b8a2-065be4cca767   none      none          off        
-    oxp_60e6b021-79d6-4a6b-917c-6637e0769558/crypt/zone                                                              87cd9f37-3de3-457c-9412-d0dc5678eda8   none      none          off        
-    oxp_71a07ac0-d24e-446c-a202-1998e7f6ac8c/crypt/zone                                                              3a164f36-1f53-45b3-b190-ad8a2817bc69   none      none          off        
-    oxp_736d4cab-c262-485e-89c2-07e6543f0855/crypt/zone                                                              407556ed-09ab-430e-bc8f-8291b8f8c8fe   none      none          off        
-    oxp_8ae56ca0-709d-4b8f-9869-51b62b542eef/crypt/zone                                                              99d57d61-f12a-4b56-8114-86ba92d07649   none      none          off        
-    oxp_8e0bcc4f-0799-450c-a0ad-80c1637f59e3/crypt/zone                                                              da1eb596-8764-4268-a60b-f4705b4f615b   none      none          off        
-    oxp_8eeebb8e-6db6-43e8-a429-d26dde99882c/crypt/zone                                                              d555bf19-887c-48d2-8144-47c2eac9a9e8   none      none          off        
-    oxp_a3e8de5b-c47a-49c0-b698-4d6955e1327f/crypt/zone                                                              9785e77a-9422-4b46-a4ae-8b9a155eb121   none      none          off        
-    oxp_b32fa3da-4dec-4237-9776-e1a57ba15a21/crypt/zone                                                              1192a37c-a871-4c48-905d-03c3d6035bdc   none      none          off        
-    oxp_e9c238f6-87a3-4087-8ba4-aa594a82d012/crypt/zone                                                              7bf1c7ec-5465-4bfd-b1d9-939f05336012   none      none          off        
-    oxp_fbf997ef-52d3-438a-b036-b9117322e569/crypt/zone                                                              be526b44-2c78-49ec-8ab4-73e161e27f22   none      none          off        
-    oxp_60e6b021-79d6-4a6b-917c-6637e0769558/crypt/zone/oxz_clickhouse_35e8d4b6-ea92-45cf-923c-3f566a0b1fe5          cd7e5c3a-2328-4568-b8f8-cf349f0cdd12   none      none          off        
-    oxp_60e6b021-79d6-4a6b-917c-6637e0769558/crypt/zone/oxz_clickhouse_keeper_dd5ab8b1-e6e7-40e0-9ea6-b6a16f485b52   a51fb98f-3fff-4c0a-82f0-7a4aad82096b   none      none          off        
-    oxp_e9c238f6-87a3-4087-8ba4-aa594a82d012/crypt/zone/oxz_crucible_044d074d-7905-4024-82ff-68d76221db68            98fd0f42-7337-4ce7-814e-f988304b8873   none      none          off        
-    oxp_71a07ac0-d24e-446c-a202-1998e7f6ac8c/crypt/zone/oxz_crucible_28826473-ac0b-41ea-8c54-72b782db1bcb            bbda84d8-c4ca-4f52-a766-681872fa06f0   none      none          off        
-    oxp_fbf997ef-52d3-438a-b036-b9117322e569/crypt/zone/oxz_crucible_2d3ff798-dda9-4ccf-8f91-070a20f06d55            e9c77dbd-c56a-404c-8ff9-6504b3f92556   none      none          off        
-    oxp_8eeebb8e-6db6-43e8-a429-d26dde99882c/crypt/zone/oxz_crucible_7538d29b-69f2-43e8-8509-505b25cb1c84            19110f8a-6267-41ed-ac7d-539cd0fe3511   none      none          off        
-    oxp_8ae56ca0-709d-4b8f-9869-51b62b542eef/crypt/zone/oxz_crucible_8234bbd2-4b31-4f6b-8dcc-4744b1d14e64            0fe4f647-ffd2-4845-805a-c069096560ee   none      none          off        
-    oxp_8e0bcc4f-0799-450c-a0ad-80c1637f59e3/crypt/zone/oxz_crucible_85358363-cee8-4bc3-af66-4d89e5cd714f            a1daa561-2448-4afb-8233-ec149d2bd7f4   none      none          off        
-    oxp_736d4cab-c262-485e-89c2-07e6543f0855/crypt/zone/oxz_crucible_9b58d04f-85bf-4f5e-8c6a-5d855062d5c4            69812f66-4b59-4590-9e1f-bce3e93b3b08   none      none          off        
-    oxp_60e6b021-79d6-4a6b-917c-6637e0769558/crypt/zone/oxz_crucible_e7da0aec-c6b6-4a56-9525-35385b9c62a2            36e58025-88e2-4eb9-8af0-ed9a98dda1b9   none      none          off        
-    oxp_a3e8de5b-c47a-49c0-b698-4d6955e1327f/crypt/zone/oxz_crucible_f3f977cc-7eca-4491-9b07-82b6284eb169            482fad9a-d83f-4025-8f0b-d3adea6ae2cf   none      none          off        
-    oxp_b32fa3da-4dec-4237-9776-e1a57ba15a21/crypt/zone/oxz_crucible_fef381d2-8368-4a2d-96a1-c956ed011f7b            b1937368-4019-40c4-af02-9811dc7eb143   none      none          off        
-    oxp_60e6b021-79d6-4a6b-917c-6637e0769558/crypt/zone/oxz_crucible_pantry_fe63bfd3-3128-4675-8118-cf6968293471     e3b31ef3-6b54-4901-aec4-0c672de62c7f   none      none          off        
-    oxp_60e6b021-79d6-4a6b-917c-6637e0769558/crypt/zone/oxz_internal_dns_b6b0689e-ef48-484d-b3c7-3c596edad20c        501e0672-2897-4992-8911-600e0283f04c   none      none          off        
-    oxp_60e6b021-79d6-4a6b-917c-6637e0769558/crypt/zone/oxz_nexus_46ecde76-fef7-4394-93dd-d22b003148e9               53655959-866b-4fee-bcf9-1e35504ad625   none      none          off        
-    oxp_60e6b021-79d6-4a6b-917c-6637e0769558/crypt/zone/oxz_ntp_4d009155-44fb-45b9-afed-f89cb57ce8da                 0590facf-202a-463b-81be-b6e88c47da76   none      none          off        
-    oxp_60e6b021-79d6-4a6b-917c-6637e0769558/crypt/debug                                                             8f7f16c1-d9fb-4405-9dcf-68bfbaa7bf8c   100 GiB   none          gzip-9     
-    oxp_71a07ac0-d24e-446c-a202-1998e7f6ac8c/crypt/debug                                                             6482f332-801a-473f-a77d-e07d30e2a5b7   100 GiB   none          gzip-9     
-    oxp_736d4cab-c262-485e-89c2-07e6543f0855/crypt/debug                                                             0bb0541f-2c64-487b-a8af-162454207504   100 GiB   none          gzip-9     
-    oxp_8ae56ca0-709d-4b8f-9869-51b62b542eef/crypt/debug                                                             902a6889-244f-4b67-baa4-b245f3d622c8   100 GiB   none          gzip-9     
-    oxp_8e0bcc4f-0799-450c-a0ad-80c1637f59e3/crypt/debug                                                             667ffd3c-6735-4b50-bc3b-cfa32fcc811e   100 GiB   none          gzip-9     
-    oxp_8eeebb8e-6db6-43e8-a429-d26dde99882c/crypt/debug                                                             cf48ba87-a4bb-435f-999b-bca46cfd6a89   100 GiB   none          gzip-9     
-    oxp_a3e8de5b-c47a-49c0-b698-4d6955e1327f/crypt/debug                                                             7d64cab3-7311-4519-ae4a-1af6b320fa9b   100 GiB   none          gzip-9     
-    oxp_b32fa3da-4dec-4237-9776-e1a57ba15a21/crypt/debug                                                             d3e957fd-5f26-498a-8fa3-deaea4dc5820   100 GiB   none          gzip-9     
-    oxp_e9c238f6-87a3-4087-8ba4-aa594a82d012/crypt/debug                                                             4da77f4a-5e41-4604-af30-8cf568c38428   100 GiB   none          gzip-9     
-    oxp_fbf997ef-52d3-438a-b036-b9117322e569/crypt/debug                                                             03935cb1-ce06-4594-b2fe-23e127d1cd9d   100 GiB   none          gzip-9     
+    ---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
+    dataset name                                                                                                     dataset id                             disposition   quota     reservation   compression
+    ---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
+    oxp_60e6b021-79d6-4a6b-917c-6637e0769558/crucible                                                                723e4ec2-5f4a-48a9-a6a1-cb523dc47d3d   in service    none      none          off        
+    oxp_71a07ac0-d24e-446c-a202-1998e7f6ac8c/crucible                                                                b2796e6b-ad7d-41a5-82a6-947b96e42d47   in service    none      none          off        
+    oxp_736d4cab-c262-485e-89c2-07e6543f0855/crucible                                                                c993b4da-bea9-4010-a8d6-17d733698f07   in service    none      none          off        
+    oxp_8ae56ca0-709d-4b8f-9869-51b62b542eef/crucible                                                                4f497ece-88c1-4557-a8b4-0e990f9941a9   in service    none      none          off        
+    oxp_8e0bcc4f-0799-450c-a0ad-80c1637f59e3/crucible                                                                43a16c22-e79a-4bea-bcf6-682099a728dd   in service    none      none          off        
+    oxp_8eeebb8e-6db6-43e8-a429-d26dde99882c/crucible                                                                b6bbb45b-68fc-4fa5-86cc-b59b0f797fb2   in service    none      none          off        
+    oxp_a3e8de5b-c47a-49c0-b698-4d6955e1327f/crucible                                                                e4838ed0-304f-475e-a282-9f644f2ba3e5   in service    none      none          off        
+    oxp_b32fa3da-4dec-4237-9776-e1a57ba15a21/crucible                                                                046f2730-768d-4bcc-8ebf-4b5f5597151c   in service    none      none          off        
+    oxp_e9c238f6-87a3-4087-8ba4-aa594a82d012/crucible                                                                0830fc6d-ed82-41de-9389-0bd3fd4677ea   in service    none      none          off        
+    oxp_fbf997ef-52d3-438a-b036-b9117322e569/crucible                                                                d9662141-585e-4e18-a461-9627097f02a2   in service    none      none          off        
+    oxp_60e6b021-79d6-4a6b-917c-6637e0769558/crypt/clickhouse                                                        a4f84c49-4303-411f-bb1b-08877d828946   in service    none      none          off        
+    oxp_60e6b021-79d6-4a6b-917c-6637e0769558/crypt/clickhouse_keeper                                                 04ee4b4b-fcbe-4224-86fd-30144a4f2592   in service    none      none          off        
+    oxp_60e6b021-79d6-4a6b-917c-6637e0769558/crypt/internal_dns                                                      2edca3dc-a0e5-4d34-b8a2-065be4cca767   in service    none      none          off        
+    oxp_60e6b021-79d6-4a6b-917c-6637e0769558/crypt/zone                                                              87cd9f37-3de3-457c-9412-d0dc5678eda8   in service    none      none          off        
+    oxp_71a07ac0-d24e-446c-a202-1998e7f6ac8c/crypt/zone                                                              3a164f36-1f53-45b3-b190-ad8a2817bc69   in service    none      none          off        
+    oxp_736d4cab-c262-485e-89c2-07e6543f0855/crypt/zone                                                              407556ed-09ab-430e-bc8f-8291b8f8c8fe   in service    none      none          off        
+    oxp_8ae56ca0-709d-4b8f-9869-51b62b542eef/crypt/zone                                                              99d57d61-f12a-4b56-8114-86ba92d07649   in service    none      none          off        
+    oxp_8e0bcc4f-0799-450c-a0ad-80c1637f59e3/crypt/zone                                                              da1eb596-8764-4268-a60b-f4705b4f615b   in service    none      none          off        
+    oxp_8eeebb8e-6db6-43e8-a429-d26dde99882c/crypt/zone                                                              d555bf19-887c-48d2-8144-47c2eac9a9e8   in service    none      none          off        
+    oxp_a3e8de5b-c47a-49c0-b698-4d6955e1327f/crypt/zone                                                              9785e77a-9422-4b46-a4ae-8b9a155eb121   in service    none      none          off        
+    oxp_b32fa3da-4dec-4237-9776-e1a57ba15a21/crypt/zone                                                              1192a37c-a871-4c48-905d-03c3d6035bdc   in service    none      none          off        
+    oxp_e9c238f6-87a3-4087-8ba4-aa594a82d012/crypt/zone                                                              7bf1c7ec-5465-4bfd-b1d9-939f05336012   in service    none      none          off        
+    oxp_fbf997ef-52d3-438a-b036-b9117322e569/crypt/zone                                                              be526b44-2c78-49ec-8ab4-73e161e27f22   in service    none      none          off        
+    oxp_60e6b021-79d6-4a6b-917c-6637e0769558/crypt/zone/oxz_clickhouse_35e8d4b6-ea92-45cf-923c-3f566a0b1fe5          cd7e5c3a-2328-4568-b8f8-cf349f0cdd12   in service    none      none          off        
+    oxp_60e6b021-79d6-4a6b-917c-6637e0769558/crypt/zone/oxz_clickhouse_keeper_dd5ab8b1-e6e7-40e0-9ea6-b6a16f485b52   a51fb98f-3fff-4c0a-82f0-7a4aad82096b   in service    none      none          off        
+    oxp_e9c238f6-87a3-4087-8ba4-aa594a82d012/crypt/zone/oxz_crucible_044d074d-7905-4024-82ff-68d76221db68            98fd0f42-7337-4ce7-814e-f988304b8873   in service    none      none          off        
+    oxp_71a07ac0-d24e-446c-a202-1998e7f6ac8c/crypt/zone/oxz_crucible_28826473-ac0b-41ea-8c54-72b782db1bcb            bbda84d8-c4ca-4f52-a766-681872fa06f0   in service    none      none          off        
+    oxp_fbf997ef-52d3-438a-b036-b9117322e569/crypt/zone/oxz_crucible_2d3ff798-dda9-4ccf-8f91-070a20f06d55            e9c77dbd-c56a-404c-8ff9-6504b3f92556   in service    none      none          off        
+    oxp_8eeebb8e-6db6-43e8-a429-d26dde99882c/crypt/zone/oxz_crucible_7538d29b-69f2-43e8-8509-505b25cb1c84            19110f8a-6267-41ed-ac7d-539cd0fe3511   in service    none      none          off        
+    oxp_8ae56ca0-709d-4b8f-9869-51b62b542eef/crypt/zone/oxz_crucible_8234bbd2-4b31-4f6b-8dcc-4744b1d14e64            0fe4f647-ffd2-4845-805a-c069096560ee   in service    none      none          off        
+    oxp_8e0bcc4f-0799-450c-a0ad-80c1637f59e3/crypt/zone/oxz_crucible_85358363-cee8-4bc3-af66-4d89e5cd714f            a1daa561-2448-4afb-8233-ec149d2bd7f4   in service    none      none          off        
+    oxp_736d4cab-c262-485e-89c2-07e6543f0855/crypt/zone/oxz_crucible_9b58d04f-85bf-4f5e-8c6a-5d855062d5c4            69812f66-4b59-4590-9e1f-bce3e93b3b08   in service    none      none          off        
+    oxp_60e6b021-79d6-4a6b-917c-6637e0769558/crypt/zone/oxz_crucible_e7da0aec-c6b6-4a56-9525-35385b9c62a2            36e58025-88e2-4eb9-8af0-ed9a98dda1b9   in service    none      none          off        
+    oxp_a3e8de5b-c47a-49c0-b698-4d6955e1327f/crypt/zone/oxz_crucible_f3f977cc-7eca-4491-9b07-82b6284eb169            482fad9a-d83f-4025-8f0b-d3adea6ae2cf   in service    none      none          off        
+    oxp_b32fa3da-4dec-4237-9776-e1a57ba15a21/crypt/zone/oxz_crucible_fef381d2-8368-4a2d-96a1-c956ed011f7b            b1937368-4019-40c4-af02-9811dc7eb143   in service    none      none          off        
+    oxp_60e6b021-79d6-4a6b-917c-6637e0769558/crypt/zone/oxz_crucible_pantry_fe63bfd3-3128-4675-8118-cf6968293471     e3b31ef3-6b54-4901-aec4-0c672de62c7f   in service    none      none          off        
+    oxp_60e6b021-79d6-4a6b-917c-6637e0769558/crypt/zone/oxz_internal_dns_b6b0689e-ef48-484d-b3c7-3c596edad20c        501e0672-2897-4992-8911-600e0283f04c   in service    none      none          off        
+    oxp_60e6b021-79d6-4a6b-917c-6637e0769558/crypt/zone/oxz_nexus_46ecde76-fef7-4394-93dd-d22b003148e9               53655959-866b-4fee-bcf9-1e35504ad625   in service    none      none          off        
+    oxp_60e6b021-79d6-4a6b-917c-6637e0769558/crypt/zone/oxz_ntp_4d009155-44fb-45b9-afed-f89cb57ce8da                 0590facf-202a-463b-81be-b6e88c47da76   in service    none      none          off        
+    oxp_60e6b021-79d6-4a6b-917c-6637e0769558/crypt/debug                                                             8f7f16c1-d9fb-4405-9dcf-68bfbaa7bf8c   in service    100 GiB   none          gzip-9     
+    oxp_71a07ac0-d24e-446c-a202-1998e7f6ac8c/crypt/debug                                                             6482f332-801a-473f-a77d-e07d30e2a5b7   in service    100 GiB   none          gzip-9     
+    oxp_736d4cab-c262-485e-89c2-07e6543f0855/crypt/debug                                                             0bb0541f-2c64-487b-a8af-162454207504   in service    100 GiB   none          gzip-9     
+    oxp_8ae56ca0-709d-4b8f-9869-51b62b542eef/crypt/debug                                                             902a6889-244f-4b67-baa4-b245f3d622c8   in service    100 GiB   none          gzip-9     
+    oxp_8e0bcc4f-0799-450c-a0ad-80c1637f59e3/crypt/debug                                                             667ffd3c-6735-4b50-bc3b-cfa32fcc811e   in service    100 GiB   none          gzip-9     
+    oxp_8eeebb8e-6db6-43e8-a429-d26dde99882c/crypt/debug                                                             cf48ba87-a4bb-435f-999b-bca46cfd6a89   in service    100 GiB   none          gzip-9     
+    oxp_a3e8de5b-c47a-49c0-b698-4d6955e1327f/crypt/debug                                                             7d64cab3-7311-4519-ae4a-1af6b320fa9b   in service    100 GiB   none          gzip-9     
+    oxp_b32fa3da-4dec-4237-9776-e1a57ba15a21/crypt/debug                                                             d3e957fd-5f26-498a-8fa3-deaea4dc5820   in service    100 GiB   none          gzip-9     
+    oxp_e9c238f6-87a3-4087-8ba4-aa594a82d012/crypt/debug                                                             4da77f4a-5e41-4604-af30-8cf568c38428   in service    100 GiB   none          gzip-9     
+    oxp_fbf997ef-52d3-438a-b036-b9117322e569/crypt/debug                                                             03935cb1-ce06-4594-b2fe-23e127d1cd9d   in service    100 GiB   none          gzip-9     
 
 
     omicron zones at generation 3:
@@ -117,58 +117,58 @@ to:   blueprint 92fa943c-7dd4-48c3-9447-c9d0665744b6
 
 
     datasets at generation 3:
-    -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
-    dataset name                                                                                                     dataset uuid                           quota     reservation   compression
-    -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
-    oxp_0bf9d028-2b4a-4bff-82a1-6eb5fcefd985/crucible                                                                f18270c8-a39b-4579-be20-d2d1b80bba42   none      none          off        
-    oxp_19293a1d-fddc-40a7-88a4-ccafdb6f66d3/crucible                                                                06c2af14-055c-4041-aa26-9155f9f42661   none      none          off        
-    oxp_44484c44-477a-4676-8266-b98a00e80d79/crucible                                                                9deffea6-d340-4432-be3c-fad135dc29a5   none      none          off        
-    oxp_79787cd4-92da-4de5-bfd8-30a635521e10/crucible                                                                47ca08b9-b962-43e2-99d7-c2e0556c0f52   none      none          off        
-    oxp_9ae94c94-baae-477e-912a-60f0c4f3bd13/crucible                                                                b2e54e29-6915-4b6d-bc76-6f72e5c7c55a   none      none          off        
-    oxp_af85eec8-36b3-4b88-966d-a717b9b58fe5/crucible                                                                cb992d4e-7a69-4bcd-96c8-fe6e40989e24   none      none          off        
-    oxp_ddfaaba3-dafe-4103-b868-e9843d29d346/crucible                                                                68338fc3-2d8b-4419-b33d-4cce6fe9380d   none      none          off        
-    oxp_ec458c3e-91ca-40f1-a2a3-3f4292c1f279/crucible                                                                5294b99c-3eac-40e1-a35b-1f1cf2f0d6bf   none      none          off        
-    oxp_f2fc7c4c-7966-449d-8ec3-5a70f460501d/crucible                                                                31718dcf-ebd5-432c-a9e5-40abcb40931c   none      none          off        
-    oxp_f635c28a-e5ca-4d22-ac94-d8f278a6ea0e/crucible                                                                ff7ff4a9-21c4-499e-9ceb-8a00a4bb21bc   none      none          off        
-    oxp_0bf9d028-2b4a-4bff-82a1-6eb5fcefd985/crypt/clickhouse_keeper                                                 473adeb2-a57a-4240-82e9-88f2bebc1245   none      none          off        
-    oxp_0bf9d028-2b4a-4bff-82a1-6eb5fcefd985/crypt/clickhouse_server                                                 4363b5f8-9a67-49af-b49d-585e532fa7bc   none      none          off        
-    oxp_0bf9d028-2b4a-4bff-82a1-6eb5fcefd985/crypt/internal_dns                                                      56a1af5d-de86-46c5-9504-2d1ee70587c5   none      none          off        
-    oxp_0bf9d028-2b4a-4bff-82a1-6eb5fcefd985/crypt/zone                                                              003c1d4e-15bb-4fca-aa71-a7dff507b124   none      none          off        
-    oxp_19293a1d-fddc-40a7-88a4-ccafdb6f66d3/crypt/zone                                                              bf35a148-62f0-4f88-8f60-0a13747daba2   none      none          off        
-    oxp_44484c44-477a-4676-8266-b98a00e80d79/crypt/zone                                                              9b1bf42e-6f06-44cc-af5b-bff65d929322   none      none          off        
-    oxp_79787cd4-92da-4de5-bfd8-30a635521e10/crypt/zone                                                              2c9d6bce-0293-4364-b8c9-4bdea345490e   none      none          off        
-    oxp_9ae94c94-baae-477e-912a-60f0c4f3bd13/crypt/zone                                                              11726c79-6590-4831-8480-cf50e6322c8a   none      none          off        
-    oxp_af85eec8-36b3-4b88-966d-a717b9b58fe5/crypt/zone                                                              b463f0c2-3ae4-45f7-a38c-110731fcc5cb   none      none          off        
-    oxp_ddfaaba3-dafe-4103-b868-e9843d29d346/crypt/zone                                                              626abe12-321d-439b-ad8f-f8dfb2022f25   none      none          off        
-    oxp_ec458c3e-91ca-40f1-a2a3-3f4292c1f279/crypt/zone                                                              4200e2a7-0fd6-4631-9d60-21fd821193fe   none      none          off        
-    oxp_f2fc7c4c-7966-449d-8ec3-5a70f460501d/crypt/zone                                                              85f34c02-a35d-404e-8cde-bedf3e193b1c   none      none          off        
-    oxp_f635c28a-e5ca-4d22-ac94-d8f278a6ea0e/crypt/zone                                                              dd19c2c5-0bc9-48de-a116-b92503569092   none      none          off        
-    oxp_0bf9d028-2b4a-4bff-82a1-6eb5fcefd985/crypt/zone/oxz_clickhouse_keeper_31a66e47-6252-4f38-aa92-f48637da152c   49f52cc5-74df-4cfa-b7f0-07c7e810940d   none      none          off        
-    oxp_0bf9d028-2b4a-4bff-82a1-6eb5fcefd985/crypt/zone/oxz_clickhouse_server_6fedfc94-2ae6-4cc7-a968-5185207284f4   f1143eb2-0685-4708-a471-968a58f93bad   none      none          off        
-    oxp_f635c28a-e5ca-4d22-ac94-d8f278a6ea0e/crypt/zone/oxz_crucible_06b45c33-9a90-408b-8534-f94ab6df8a42            9e0a360d-c158-417f-a45f-9d29ee67cdce   none      none          off        
-    oxp_19293a1d-fddc-40a7-88a4-ccafdb6f66d3/crypt/zone/oxz_crucible_32999e20-ed5c-4c25-b4bd-41a3fbaf1445            dd7a45b8-3175-4744-8b99-ce19b22bb8ce   none      none          off        
-    oxp_9ae94c94-baae-477e-912a-60f0c4f3bd13/crypt/zone/oxz_crucible_4a037563-f969-4028-8384-164bdf308c3c            0d5b2580-7190-4bcc-9982-5012dac51f05   none      none          off        
-    oxp_44484c44-477a-4676-8266-b98a00e80d79/crypt/zone/oxz_crucible_6564394d-2c51-4252-b3b1-f5f88a72d7c3            26a1cc86-f717-4a12-b644-5acd168843aa   none      none          off        
-    oxp_0bf9d028-2b4a-4bff-82a1-6eb5fcefd985/crypt/zone/oxz_crucible_87427b40-5114-49cd-96bd-63edd61fce90            e7364079-58e3-4b36-81a7-b9e08f2a8fff   none      none          off        
-    oxp_ddfaaba3-dafe-4103-b868-e9843d29d346/crypt/zone/oxz_crucible_8acdc189-d4da-45a7-b306-23b43e86f695            6fa84a9c-0161-40c9-b596-f3b2c679ef99   none      none          off        
-    oxp_ec458c3e-91ca-40f1-a2a3-3f4292c1f279/crypt/zone/oxz_crucible_971ce633-cdc4-48cf-983e-dc272c1639eb            cb8ca8a6-6a00-4aae-8702-1493e1c3b166   none      none          off        
-    oxp_af85eec8-36b3-4b88-966d-a717b9b58fe5/crypt/zone/oxz_crucible_cfa6af7a-bf53-4fe6-bf1a-7ce3812d15c4            27323e49-f61e-4a73-bc87-f8d9f5082143   none      none          off        
-    oxp_f2fc7c4c-7966-449d-8ec3-5a70f460501d/crypt/zone/oxz_crucible_e145fb8e-df12-4df9-8049-b146ae0275be            35c46d33-4e08-4fad-90d2-3da719538ef2   none      none          off        
-    oxp_79787cd4-92da-4de5-bfd8-30a635521e10/crypt/zone/oxz_crucible_f1d08ae7-68fe-4799-8f31-f1100887c6f0            02863a62-7624-4017-9269-412910ab73f0   none      none          off        
-    oxp_0bf9d028-2b4a-4bff-82a1-6eb5fcefd985/crypt/zone/oxz_crucible_pantry_f9e18694-fdff-46a3-b40d-570d43206f48     3cb3f346-9879-4023-b919-55c4172bbf23   none      none          off        
-    oxp_0bf9d028-2b4a-4bff-82a1-6eb5fcefd985/crypt/zone/oxz_internal_dns_a00d8ae3-d1db-4aef-9174-3ff867af5e9e        c2d9b145-5e15-47be-a835-7e1f51f27679   none      none          off        
-    oxp_0bf9d028-2b4a-4bff-82a1-6eb5fcefd985/crypt/zone/oxz_nexus_8ccafc1f-97f9-4da7-bb04-d346213387ce               dcc3603b-b160-42d9-a743-11075c3b6941   none      none          off        
-    oxp_0bf9d028-2b4a-4bff-82a1-6eb5fcefd985/crypt/zone/oxz_ntp_a1797f1d-2d2a-4396-9ab5-044630b41c35                 5a70b3fe-9fad-4c17-982b-272b8595c2e8   none      none          off        
-    oxp_0bf9d028-2b4a-4bff-82a1-6eb5fcefd985/crypt/debug                                                             4e4b2f99-dc01-4793-a37a-072d942da264   100 GiB   none          gzip-9     
-    oxp_19293a1d-fddc-40a7-88a4-ccafdb6f66d3/crypt/debug                                                             8573903d-9610-4084-b0c6-ffcbb5d96c39   100 GiB   none          gzip-9     
-    oxp_44484c44-477a-4676-8266-b98a00e80d79/crypt/debug                                                             540272e1-99d2-4d2e-9d3d-032014b0e6d9   100 GiB   none          gzip-9     
-    oxp_79787cd4-92da-4de5-bfd8-30a635521e10/crypt/debug                                                             4adf2ef6-2694-4aac-aabe-688bca767092   100 GiB   none          gzip-9     
-    oxp_9ae94c94-baae-477e-912a-60f0c4f3bd13/crypt/debug                                                             7e9d012a-6d8e-475e-805e-65985a66ffcd   100 GiB   none          gzip-9     
-    oxp_af85eec8-36b3-4b88-966d-a717b9b58fe5/crypt/debug                                                             2189574d-9a73-4d25-858e-1084d57b59a8   100 GiB   none          gzip-9     
-    oxp_ddfaaba3-dafe-4103-b868-e9843d29d346/crypt/debug                                                             3cf0580b-4e1d-4ff9-bc22-4dc51ca9a53b   100 GiB   none          gzip-9     
-    oxp_ec458c3e-91ca-40f1-a2a3-3f4292c1f279/crypt/debug                                                             f499c5f8-b62f-493d-858a-8d33f7db81ff   100 GiB   none          gzip-9     
-    oxp_f2fc7c4c-7966-449d-8ec3-5a70f460501d/crypt/debug                                                             c16ff3c0-3282-46de-a620-49c6b1e3f882   100 GiB   none          gzip-9     
-    oxp_f635c28a-e5ca-4d22-ac94-d8f278a6ea0e/crypt/debug                                                             8dde6eee-f28e-4b55-8c11-525884ec81e5   100 GiB   none          gzip-9     
+    ---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
+    dataset name                                                                                                     dataset id                             disposition   quota     reservation   compression
+    ---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
+    oxp_0bf9d028-2b4a-4bff-82a1-6eb5fcefd985/crucible                                                                f18270c8-a39b-4579-be20-d2d1b80bba42   in service    none      none          off        
+    oxp_19293a1d-fddc-40a7-88a4-ccafdb6f66d3/crucible                                                                06c2af14-055c-4041-aa26-9155f9f42661   in service    none      none          off        
+    oxp_44484c44-477a-4676-8266-b98a00e80d79/crucible                                                                9deffea6-d340-4432-be3c-fad135dc29a5   in service    none      none          off        
+    oxp_79787cd4-92da-4de5-bfd8-30a635521e10/crucible                                                                47ca08b9-b962-43e2-99d7-c2e0556c0f52   in service    none      none          off        
+    oxp_9ae94c94-baae-477e-912a-60f0c4f3bd13/crucible                                                                b2e54e29-6915-4b6d-bc76-6f72e5c7c55a   in service    none      none          off        
+    oxp_af85eec8-36b3-4b88-966d-a717b9b58fe5/crucible                                                                cb992d4e-7a69-4bcd-96c8-fe6e40989e24   in service    none      none          off        
+    oxp_ddfaaba3-dafe-4103-b868-e9843d29d346/crucible                                                                68338fc3-2d8b-4419-b33d-4cce6fe9380d   in service    none      none          off        
+    oxp_ec458c3e-91ca-40f1-a2a3-3f4292c1f279/crucible                                                                5294b99c-3eac-40e1-a35b-1f1cf2f0d6bf   in service    none      none          off        
+    oxp_f2fc7c4c-7966-449d-8ec3-5a70f460501d/crucible                                                                31718dcf-ebd5-432c-a9e5-40abcb40931c   in service    none      none          off        
+    oxp_f635c28a-e5ca-4d22-ac94-d8f278a6ea0e/crucible                                                                ff7ff4a9-21c4-499e-9ceb-8a00a4bb21bc   in service    none      none          off        
+    oxp_0bf9d028-2b4a-4bff-82a1-6eb5fcefd985/crypt/clickhouse_keeper                                                 473adeb2-a57a-4240-82e9-88f2bebc1245   in service    none      none          off        
+    oxp_0bf9d028-2b4a-4bff-82a1-6eb5fcefd985/crypt/clickhouse_server                                                 4363b5f8-9a67-49af-b49d-585e532fa7bc   in service    none      none          off        
+    oxp_0bf9d028-2b4a-4bff-82a1-6eb5fcefd985/crypt/internal_dns                                                      56a1af5d-de86-46c5-9504-2d1ee70587c5   in service    none      none          off        
+    oxp_0bf9d028-2b4a-4bff-82a1-6eb5fcefd985/crypt/zone                                                              003c1d4e-15bb-4fca-aa71-a7dff507b124   in service    none      none          off        
+    oxp_19293a1d-fddc-40a7-88a4-ccafdb6f66d3/crypt/zone                                                              bf35a148-62f0-4f88-8f60-0a13747daba2   in service    none      none          off        
+    oxp_44484c44-477a-4676-8266-b98a00e80d79/crypt/zone                                                              9b1bf42e-6f06-44cc-af5b-bff65d929322   in service    none      none          off        
+    oxp_79787cd4-92da-4de5-bfd8-30a635521e10/crypt/zone                                                              2c9d6bce-0293-4364-b8c9-4bdea345490e   in service    none      none          off        
+    oxp_9ae94c94-baae-477e-912a-60f0c4f3bd13/crypt/zone                                                              11726c79-6590-4831-8480-cf50e6322c8a   in service    none      none          off        
+    oxp_af85eec8-36b3-4b88-966d-a717b9b58fe5/crypt/zone                                                              b463f0c2-3ae4-45f7-a38c-110731fcc5cb   in service    none      none          off        
+    oxp_ddfaaba3-dafe-4103-b868-e9843d29d346/crypt/zone                                                              626abe12-321d-439b-ad8f-f8dfb2022f25   in service    none      none          off        
+    oxp_ec458c3e-91ca-40f1-a2a3-3f4292c1f279/crypt/zone                                                              4200e2a7-0fd6-4631-9d60-21fd821193fe   in service    none      none          off        
+    oxp_f2fc7c4c-7966-449d-8ec3-5a70f460501d/crypt/zone                                                              85f34c02-a35d-404e-8cde-bedf3e193b1c   in service    none      none          off        
+    oxp_f635c28a-e5ca-4d22-ac94-d8f278a6ea0e/crypt/zone                                                              dd19c2c5-0bc9-48de-a116-b92503569092   in service    none      none          off        
+    oxp_0bf9d028-2b4a-4bff-82a1-6eb5fcefd985/crypt/zone/oxz_clickhouse_keeper_31a66e47-6252-4f38-aa92-f48637da152c   49f52cc5-74df-4cfa-b7f0-07c7e810940d   in service    none      none          off        
+    oxp_0bf9d028-2b4a-4bff-82a1-6eb5fcefd985/crypt/zone/oxz_clickhouse_server_6fedfc94-2ae6-4cc7-a968-5185207284f4   f1143eb2-0685-4708-a471-968a58f93bad   in service    none      none          off        
+    oxp_f635c28a-e5ca-4d22-ac94-d8f278a6ea0e/crypt/zone/oxz_crucible_06b45c33-9a90-408b-8534-f94ab6df8a42            9e0a360d-c158-417f-a45f-9d29ee67cdce   in service    none      none          off        
+    oxp_19293a1d-fddc-40a7-88a4-ccafdb6f66d3/crypt/zone/oxz_crucible_32999e20-ed5c-4c25-b4bd-41a3fbaf1445            dd7a45b8-3175-4744-8b99-ce19b22bb8ce   in service    none      none          off        
+    oxp_9ae94c94-baae-477e-912a-60f0c4f3bd13/crypt/zone/oxz_crucible_4a037563-f969-4028-8384-164bdf308c3c            0d5b2580-7190-4bcc-9982-5012dac51f05   in service    none      none          off        
+    oxp_44484c44-477a-4676-8266-b98a00e80d79/crypt/zone/oxz_crucible_6564394d-2c51-4252-b3b1-f5f88a72d7c3            26a1cc86-f717-4a12-b644-5acd168843aa   in service    none      none          off        
+    oxp_0bf9d028-2b4a-4bff-82a1-6eb5fcefd985/crypt/zone/oxz_crucible_87427b40-5114-49cd-96bd-63edd61fce90            e7364079-58e3-4b36-81a7-b9e08f2a8fff   in service    none      none          off        
+    oxp_ddfaaba3-dafe-4103-b868-e9843d29d346/crypt/zone/oxz_crucible_8acdc189-d4da-45a7-b306-23b43e86f695            6fa84a9c-0161-40c9-b596-f3b2c679ef99   in service    none      none          off        
+    oxp_ec458c3e-91ca-40f1-a2a3-3f4292c1f279/crypt/zone/oxz_crucible_971ce633-cdc4-48cf-983e-dc272c1639eb            cb8ca8a6-6a00-4aae-8702-1493e1c3b166   in service    none      none          off        
+    oxp_af85eec8-36b3-4b88-966d-a717b9b58fe5/crypt/zone/oxz_crucible_cfa6af7a-bf53-4fe6-bf1a-7ce3812d15c4            27323e49-f61e-4a73-bc87-f8d9f5082143   in service    none      none          off        
+    oxp_f2fc7c4c-7966-449d-8ec3-5a70f460501d/crypt/zone/oxz_crucible_e145fb8e-df12-4df9-8049-b146ae0275be            35c46d33-4e08-4fad-90d2-3da719538ef2   in service    none      none          off        
+    oxp_79787cd4-92da-4de5-bfd8-30a635521e10/crypt/zone/oxz_crucible_f1d08ae7-68fe-4799-8f31-f1100887c6f0            02863a62-7624-4017-9269-412910ab73f0   in service    none      none          off        
+    oxp_0bf9d028-2b4a-4bff-82a1-6eb5fcefd985/crypt/zone/oxz_crucible_pantry_f9e18694-fdff-46a3-b40d-570d43206f48     3cb3f346-9879-4023-b919-55c4172bbf23   in service    none      none          off        
+    oxp_0bf9d028-2b4a-4bff-82a1-6eb5fcefd985/crypt/zone/oxz_internal_dns_a00d8ae3-d1db-4aef-9174-3ff867af5e9e        c2d9b145-5e15-47be-a835-7e1f51f27679   in service    none      none          off        
+    oxp_0bf9d028-2b4a-4bff-82a1-6eb5fcefd985/crypt/zone/oxz_nexus_8ccafc1f-97f9-4da7-bb04-d346213387ce               dcc3603b-b160-42d9-a743-11075c3b6941   in service    none      none          off        
+    oxp_0bf9d028-2b4a-4bff-82a1-6eb5fcefd985/crypt/zone/oxz_ntp_a1797f1d-2d2a-4396-9ab5-044630b41c35                 5a70b3fe-9fad-4c17-982b-272b8595c2e8   in service    none      none          off        
+    oxp_0bf9d028-2b4a-4bff-82a1-6eb5fcefd985/crypt/debug                                                             4e4b2f99-dc01-4793-a37a-072d942da264   in service    100 GiB   none          gzip-9     
+    oxp_19293a1d-fddc-40a7-88a4-ccafdb6f66d3/crypt/debug                                                             8573903d-9610-4084-b0c6-ffcbb5d96c39   in service    100 GiB   none          gzip-9     
+    oxp_44484c44-477a-4676-8266-b98a00e80d79/crypt/debug                                                             540272e1-99d2-4d2e-9d3d-032014b0e6d9   in service    100 GiB   none          gzip-9     
+    oxp_79787cd4-92da-4de5-bfd8-30a635521e10/crypt/debug                                                             4adf2ef6-2694-4aac-aabe-688bca767092   in service    100 GiB   none          gzip-9     
+    oxp_9ae94c94-baae-477e-912a-60f0c4f3bd13/crypt/debug                                                             7e9d012a-6d8e-475e-805e-65985a66ffcd   in service    100 GiB   none          gzip-9     
+    oxp_af85eec8-36b3-4b88-966d-a717b9b58fe5/crypt/debug                                                             2189574d-9a73-4d25-858e-1084d57b59a8   in service    100 GiB   none          gzip-9     
+    oxp_ddfaaba3-dafe-4103-b868-e9843d29d346/crypt/debug                                                             3cf0580b-4e1d-4ff9-bc22-4dc51ca9a53b   in service    100 GiB   none          gzip-9     
+    oxp_ec458c3e-91ca-40f1-a2a3-3f4292c1f279/crypt/debug                                                             f499c5f8-b62f-493d-858a-8d33f7db81ff   in service    100 GiB   none          gzip-9     
+    oxp_f2fc7c4c-7966-449d-8ec3-5a70f460501d/crypt/debug                                                             c16ff3c0-3282-46de-a620-49c6b1e3f882   in service    100 GiB   none          gzip-9     
+    oxp_f635c28a-e5ca-4d22-ac94-d8f278a6ea0e/crypt/debug                                                             8dde6eee-f28e-4b55-8c11-525884ec81e5   in service    100 GiB   none          gzip-9     
 
 
     omicron zones at generation 3:
@@ -212,58 +212,58 @@ to:   blueprint 92fa943c-7dd4-48c3-9447-c9d0665744b6
 
 
     datasets at generation 3:
-    -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
-    dataset name                                                                                                     dataset uuid                           quota     reservation   compression
-    -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
-    oxp_2a76ab1a-fb16-412d-93f9-b8cd9aa94e85/crucible                                                                c73b47ac-ad1f-4cd1-b449-f220b5ad8104   none      none          off        
-    oxp_2de2bf7e-c679-4b2b-b373-908e9d3ffbfc/crucible                                                                813c7aac-695b-49ce-8bc5-f4cdbfc04b38   none      none          off        
-    oxp_2f02a5c6-fcf5-4b5a-bc7d-7f65369918ba/crucible                                                                e5da836d-fffb-4435-8500-889c05b04689   none      none          off        
-    oxp_32041dbf-e58d-4f32-840d-923d3d3b68af/crucible                                                                9f8d056c-3e84-4474-b9c7-5b7a890a8a7b   none      none          off        
-    oxp_5f88adff-bb50-4dc1-bbfb-5a410c753ed5/crucible                                                                e93cfc01-9581-4f6e-b77c-eb6300ca6ffb   none      none          off        
-    oxp_74d64eb9-bf69-4782-af16-2d3a761ca171/crucible                                                                f54d6e59-67a1-458b-8e66-6dc3b2adb755   none      none          off        
-    oxp_b3c231c9-b2a5-4267-b4bf-9651881b91a5/crucible                                                                6604dd1b-5f21-475d-952a-894717512d1b   none      none          off        
-    oxp_bca80b95-8dca-4a3b-b24d-d44b6a9ff71b/crucible                                                                05cb728f-f6b9-4132-922d-fe249b1ba736   none      none          off        
-    oxp_db16345e-427a-4c8e-9032-17270f729308/crucible                                                                500f8d46-a32d-4bd1-8f2c-cb9d36822660   none      none          off        
-    oxp_e3b45593-8f0c-47b2-a381-802a7dad1f54/crucible                                                                66c673a1-e8d8-4863-b368-a7ea292555fb   none      none          off        
-    oxp_2a76ab1a-fb16-412d-93f9-b8cd9aa94e85/crypt/clickhouse_keeper                                                 6c5a6622-5f75-45a0-a9e8-4b513f5ac352   none      none          off        
-    oxp_2a76ab1a-fb16-412d-93f9-b8cd9aa94e85/crypt/clickhouse_server                                                 f8706468-85ac-4f9f-b41d-ff7c3a17ee5f   none      none          off        
-    oxp_2a76ab1a-fb16-412d-93f9-b8cd9aa94e85/crypt/internal_dns                                                      03de030d-d958-4ce5-86d2-368fa88e0bd8   none      none          off        
-    oxp_2a76ab1a-fb16-412d-93f9-b8cd9aa94e85/crypt/zone                                                              4c3c89bd-21cf-4986-b012-e89e4e1c1ac4   none      none          off        
-    oxp_2de2bf7e-c679-4b2b-b373-908e9d3ffbfc/crypt/zone                                                              ff4a77a2-528a-4c70-a5b9-f0093c95697b   none      none          off        
-    oxp_2f02a5c6-fcf5-4b5a-bc7d-7f65369918ba/crypt/zone                                                              676fc8c5-743b-48ca-99fd-2f2379c83890   none      none          off        
-    oxp_32041dbf-e58d-4f32-840d-923d3d3b68af/crypt/zone                                                              63362c89-4b42-4649-9ebe-43e19a5c0e51   none      none          off        
-    oxp_5f88adff-bb50-4dc1-bbfb-5a410c753ed5/crypt/zone                                                              6f83a31e-1181-418f-92b0-d0534e9ae6dd   none      none          off        
-    oxp_74d64eb9-bf69-4782-af16-2d3a761ca171/crypt/zone                                                              260ffd7d-4da5-4657-9158-ba7e1eae5971   none      none          off        
-    oxp_b3c231c9-b2a5-4267-b4bf-9651881b91a5/crypt/zone                                                              ed4c8570-3951-4f79-b27e-da73150609be   none      none          off        
-    oxp_bca80b95-8dca-4a3b-b24d-d44b6a9ff71b/crypt/zone                                                              e5dcf165-3ebb-40a2-b16f-a07b036a6533   none      none          off        
-    oxp_db16345e-427a-4c8e-9032-17270f729308/crypt/zone                                                              dd27be6b-214d-4022-a99d-2a7d12e7d8bb   none      none          off        
-    oxp_e3b45593-8f0c-47b2-a381-802a7dad1f54/crypt/zone                                                              b7500d95-2499-48fc-a7d6-2460d61e197a   none      none          off        
-    oxp_2a76ab1a-fb16-412d-93f9-b8cd9aa94e85/crypt/zone/oxz_clickhouse_keeper_7aa82b80-0c37-4f20-9398-bfce4707f327   0bf9cddb-1911-495b-8aad-09b7eea5fff4   none      none          off        
-    oxp_2a76ab1a-fb16-412d-93f9-b8cd9aa94e85/crypt/zone/oxz_clickhouse_server_812be70a-f237-47d5-ab49-f9450fe948db   292f53fc-27bb-4cc4-a61b-7d02c978149c   none      none          off        
-    oxp_32041dbf-e58d-4f32-840d-923d3d3b68af/crypt/zone/oxz_crucible_0b0e12fd-2800-4203-acb6-24e6e976271c            cf46ee68-f945-4af6-a647-4d612c1f05be   none      none          off        
-    oxp_2de2bf7e-c679-4b2b-b373-908e9d3ffbfc/crypt/zone/oxz_crucible_1a02d419-10c4-4326-b34e-eb2b1bd90bd7            2a439799-3f16-46df-ba1b-7ea29edd392d   none      none          off        
-    oxp_2a76ab1a-fb16-412d-93f9-b8cd9aa94e85/crypt/zone/oxz_crucible_56e18c31-f630-4643-ad5c-1fede34f35de            c30be90e-20cf-46c6-bb4a-b65d2c407878   none      none          off        
-    oxp_b3c231c9-b2a5-4267-b4bf-9651881b91a5/crypt/zone/oxz_crucible_5ea86015-8f62-40aa-b3b2-c659f17ee510            6289ea03-b2c9-4470-b7ba-b935450aa764   none      none          off        
-    oxp_5f88adff-bb50-4dc1-bbfb-5a410c753ed5/crypt/zone/oxz_crucible_78965849-e6e3-4250-a66a-dc50512fad34            43b36ba3-e516-4732-be8b-8cd2ca9de93c   none      none          off        
-    oxp_74d64eb9-bf69-4782-af16-2d3a761ca171/crypt/zone/oxz_crucible_90c484e5-69d3-4636-9c64-6a878f593d33            7cc8018e-323f-4d35-bb33-fcf557b9dace   none      none          off        
-    oxp_db16345e-427a-4c8e-9032-17270f729308/crypt/zone/oxz_crucible_a3901043-fa2a-4ef7-a40e-6ef0e5fd189f            88fd4e5a-50fd-43c7-8a75-0ad4376bd564   none      none          off        
-    oxp_2f02a5c6-fcf5-4b5a-bc7d-7f65369918ba/crypt/zone/oxz_crucible_be9fd98a-6422-4890-a32b-42d42d1c8957            932cbb0d-b1d0-423d-87b6-9dce8ddb6338   none      none          off        
-    oxp_e3b45593-8f0c-47b2-a381-802a7dad1f54/crypt/zone/oxz_crucible_bf71d1a8-9e65-479d-8920-0be8e3422ac5            fd0ce816-4da0-4490-be32-4d38fb78c13c   none      none          off        
-    oxp_bca80b95-8dca-4a3b-b24d-d44b6a9ff71b/crypt/zone/oxz_crucible_eb4176ea-456b-48f6-b284-7b76da0bf4a1            704ea6b5-0ffc-443f-ae8a-482666f8277c   none      none          off        
-    oxp_2a76ab1a-fb16-412d-93f9-b8cd9aa94e85/crypt/zone/oxz_crucible_pantry_417c97a4-fe25-439d-8359-3f7062981923     8957a276-6d4e-4c58-a856-d7c5433806e1   none      none          off        
-    oxp_2a76ab1a-fb16-412d-93f9-b8cd9aa94e85/crypt/zone/oxz_internal_dns_f2bbaa79-0eab-4b91-a404-dad4c19b58c2        fe0f566f-3cff-43ef-960c-649c27746c56   none      none          off        
-    oxp_2a76ab1a-fb16-412d-93f9-b8cd9aa94e85/crypt/zone/oxz_nexus_33ba37c4-2535-4095-a7e9-c69937fc584d               77d0cd16-b6e3-484d-962f-0477cd242482   none      none          off        
-    oxp_2a76ab1a-fb16-412d-93f9-b8cd9aa94e85/crypt/zone/oxz_ntp_47eab17a-4dd4-4467-90b2-f643f465cf34                 4eaf1849-1fe4-415c-bdc7-4cc04cac20ce   none      none          off        
-    oxp_2a76ab1a-fb16-412d-93f9-b8cd9aa94e85/crypt/debug                                                             c5b8f4f9-bd10-45b8-a9f3-93adf1402ecc   100 GiB   none          gzip-9     
-    oxp_2de2bf7e-c679-4b2b-b373-908e9d3ffbfc/crypt/debug                                                             43abf982-d457-46d1-8566-8047d2a78a41   100 GiB   none          gzip-9     
-    oxp_2f02a5c6-fcf5-4b5a-bc7d-7f65369918ba/crypt/debug                                                             1b6a1722-d9f7-48ea-b351-5bc8bad4fd07   100 GiB   none          gzip-9     
-    oxp_32041dbf-e58d-4f32-840d-923d3d3b68af/crypt/debug                                                             8be43fb0-00e7-4748-9a1a-ace9772d8a83   100 GiB   none          gzip-9     
-    oxp_5f88adff-bb50-4dc1-bbfb-5a410c753ed5/crypt/debug                                                             2ccb3aa9-f0ef-4fd4-9fd7-43b4a88b8d6b   100 GiB   none          gzip-9     
-    oxp_74d64eb9-bf69-4782-af16-2d3a761ca171/crypt/debug                                                             56759eb6-69e9-46a3-b44c-fc748cd506aa   100 GiB   none          gzip-9     
-    oxp_b3c231c9-b2a5-4267-b4bf-9651881b91a5/crypt/debug                                                             76fffbd2-9c74-46b5-8033-f442be1256f5   100 GiB   none          gzip-9     
-    oxp_bca80b95-8dca-4a3b-b24d-d44b6a9ff71b/crypt/debug                                                             c13a3d71-1241-42d1-95a8-d720c20ee2c4   100 GiB   none          gzip-9     
-    oxp_db16345e-427a-4c8e-9032-17270f729308/crypt/debug                                                             f030ef33-cad2-4760-9431-1907b797161b   100 GiB   none          gzip-9     
-    oxp_e3b45593-8f0c-47b2-a381-802a7dad1f54/crypt/debug                                                             947b2823-3dca-4b56-9324-f476e2c1c6da   100 GiB   none          gzip-9     
+    ---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
+    dataset name                                                                                                     dataset id                             disposition   quota     reservation   compression
+    ---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
+    oxp_2a76ab1a-fb16-412d-93f9-b8cd9aa94e85/crucible                                                                c73b47ac-ad1f-4cd1-b449-f220b5ad8104   in service    none      none          off        
+    oxp_2de2bf7e-c679-4b2b-b373-908e9d3ffbfc/crucible                                                                813c7aac-695b-49ce-8bc5-f4cdbfc04b38   in service    none      none          off        
+    oxp_2f02a5c6-fcf5-4b5a-bc7d-7f65369918ba/crucible                                                                e5da836d-fffb-4435-8500-889c05b04689   in service    none      none          off        
+    oxp_32041dbf-e58d-4f32-840d-923d3d3b68af/crucible                                                                9f8d056c-3e84-4474-b9c7-5b7a890a8a7b   in service    none      none          off        
+    oxp_5f88adff-bb50-4dc1-bbfb-5a410c753ed5/crucible                                                                e93cfc01-9581-4f6e-b77c-eb6300ca6ffb   in service    none      none          off        
+    oxp_74d64eb9-bf69-4782-af16-2d3a761ca171/crucible                                                                f54d6e59-67a1-458b-8e66-6dc3b2adb755   in service    none      none          off        
+    oxp_b3c231c9-b2a5-4267-b4bf-9651881b91a5/crucible                                                                6604dd1b-5f21-475d-952a-894717512d1b   in service    none      none          off        
+    oxp_bca80b95-8dca-4a3b-b24d-d44b6a9ff71b/crucible                                                                05cb728f-f6b9-4132-922d-fe249b1ba736   in service    none      none          off        
+    oxp_db16345e-427a-4c8e-9032-17270f729308/crucible                                                                500f8d46-a32d-4bd1-8f2c-cb9d36822660   in service    none      none          off        
+    oxp_e3b45593-8f0c-47b2-a381-802a7dad1f54/crucible                                                                66c673a1-e8d8-4863-b368-a7ea292555fb   in service    none      none          off        
+    oxp_2a76ab1a-fb16-412d-93f9-b8cd9aa94e85/crypt/clickhouse_keeper                                                 6c5a6622-5f75-45a0-a9e8-4b513f5ac352   in service    none      none          off        
+    oxp_2a76ab1a-fb16-412d-93f9-b8cd9aa94e85/crypt/clickhouse_server                                                 f8706468-85ac-4f9f-b41d-ff7c3a17ee5f   in service    none      none          off        
+    oxp_2a76ab1a-fb16-412d-93f9-b8cd9aa94e85/crypt/internal_dns                                                      03de030d-d958-4ce5-86d2-368fa88e0bd8   in service    none      none          off        
+    oxp_2a76ab1a-fb16-412d-93f9-b8cd9aa94e85/crypt/zone                                                              4c3c89bd-21cf-4986-b012-e89e4e1c1ac4   in service    none      none          off        
+    oxp_2de2bf7e-c679-4b2b-b373-908e9d3ffbfc/crypt/zone                                                              ff4a77a2-528a-4c70-a5b9-f0093c95697b   in service    none      none          off        
+    oxp_2f02a5c6-fcf5-4b5a-bc7d-7f65369918ba/crypt/zone                                                              676fc8c5-743b-48ca-99fd-2f2379c83890   in service    none      none          off        
+    oxp_32041dbf-e58d-4f32-840d-923d3d3b68af/crypt/zone                                                              63362c89-4b42-4649-9ebe-43e19a5c0e51   in service    none      none          off        
+    oxp_5f88adff-bb50-4dc1-bbfb-5a410c753ed5/crypt/zone                                                              6f83a31e-1181-418f-92b0-d0534e9ae6dd   in service    none      none          off        
+    oxp_74d64eb9-bf69-4782-af16-2d3a761ca171/crypt/zone                                                              260ffd7d-4da5-4657-9158-ba7e1eae5971   in service    none      none          off        
+    oxp_b3c231c9-b2a5-4267-b4bf-9651881b91a5/crypt/zone                                                              ed4c8570-3951-4f79-b27e-da73150609be   in service    none      none          off        
+    oxp_bca80b95-8dca-4a3b-b24d-d44b6a9ff71b/crypt/zone                                                              e5dcf165-3ebb-40a2-b16f-a07b036a6533   in service    none      none          off        
+    oxp_db16345e-427a-4c8e-9032-17270f729308/crypt/zone                                                              dd27be6b-214d-4022-a99d-2a7d12e7d8bb   in service    none      none          off        
+    oxp_e3b45593-8f0c-47b2-a381-802a7dad1f54/crypt/zone                                                              b7500d95-2499-48fc-a7d6-2460d61e197a   in service    none      none          off        
+    oxp_2a76ab1a-fb16-412d-93f9-b8cd9aa94e85/crypt/zone/oxz_clickhouse_keeper_7aa82b80-0c37-4f20-9398-bfce4707f327   0bf9cddb-1911-495b-8aad-09b7eea5fff4   in service    none      none          off        
+    oxp_2a76ab1a-fb16-412d-93f9-b8cd9aa94e85/crypt/zone/oxz_clickhouse_server_812be70a-f237-47d5-ab49-f9450fe948db   292f53fc-27bb-4cc4-a61b-7d02c978149c   in service    none      none          off        
+    oxp_32041dbf-e58d-4f32-840d-923d3d3b68af/crypt/zone/oxz_crucible_0b0e12fd-2800-4203-acb6-24e6e976271c            cf46ee68-f945-4af6-a647-4d612c1f05be   in service    none      none          off        
+    oxp_2de2bf7e-c679-4b2b-b373-908e9d3ffbfc/crypt/zone/oxz_crucible_1a02d419-10c4-4326-b34e-eb2b1bd90bd7            2a439799-3f16-46df-ba1b-7ea29edd392d   in service    none      none          off        
+    oxp_2a76ab1a-fb16-412d-93f9-b8cd9aa94e85/crypt/zone/oxz_crucible_56e18c31-f630-4643-ad5c-1fede34f35de            c30be90e-20cf-46c6-bb4a-b65d2c407878   in service    none      none          off        
+    oxp_b3c231c9-b2a5-4267-b4bf-9651881b91a5/crypt/zone/oxz_crucible_5ea86015-8f62-40aa-b3b2-c659f17ee510            6289ea03-b2c9-4470-b7ba-b935450aa764   in service    none      none          off        
+    oxp_5f88adff-bb50-4dc1-bbfb-5a410c753ed5/crypt/zone/oxz_crucible_78965849-e6e3-4250-a66a-dc50512fad34            43b36ba3-e516-4732-be8b-8cd2ca9de93c   in service    none      none          off        
+    oxp_74d64eb9-bf69-4782-af16-2d3a761ca171/crypt/zone/oxz_crucible_90c484e5-69d3-4636-9c64-6a878f593d33            7cc8018e-323f-4d35-bb33-fcf557b9dace   in service    none      none          off        
+    oxp_db16345e-427a-4c8e-9032-17270f729308/crypt/zone/oxz_crucible_a3901043-fa2a-4ef7-a40e-6ef0e5fd189f            88fd4e5a-50fd-43c7-8a75-0ad4376bd564   in service    none      none          off        
+    oxp_2f02a5c6-fcf5-4b5a-bc7d-7f65369918ba/crypt/zone/oxz_crucible_be9fd98a-6422-4890-a32b-42d42d1c8957            932cbb0d-b1d0-423d-87b6-9dce8ddb6338   in service    none      none          off        
+    oxp_e3b45593-8f0c-47b2-a381-802a7dad1f54/crypt/zone/oxz_crucible_bf71d1a8-9e65-479d-8920-0be8e3422ac5            fd0ce816-4da0-4490-be32-4d38fb78c13c   in service    none      none          off        
+    oxp_bca80b95-8dca-4a3b-b24d-d44b6a9ff71b/crypt/zone/oxz_crucible_eb4176ea-456b-48f6-b284-7b76da0bf4a1            704ea6b5-0ffc-443f-ae8a-482666f8277c   in service    none      none          off        
+    oxp_2a76ab1a-fb16-412d-93f9-b8cd9aa94e85/crypt/zone/oxz_crucible_pantry_417c97a4-fe25-439d-8359-3f7062981923     8957a276-6d4e-4c58-a856-d7c5433806e1   in service    none      none          off        
+    oxp_2a76ab1a-fb16-412d-93f9-b8cd9aa94e85/crypt/zone/oxz_internal_dns_f2bbaa79-0eab-4b91-a404-dad4c19b58c2        fe0f566f-3cff-43ef-960c-649c27746c56   in service    none      none          off        
+    oxp_2a76ab1a-fb16-412d-93f9-b8cd9aa94e85/crypt/zone/oxz_nexus_33ba37c4-2535-4095-a7e9-c69937fc584d               77d0cd16-b6e3-484d-962f-0477cd242482   in service    none      none          off        
+    oxp_2a76ab1a-fb16-412d-93f9-b8cd9aa94e85/crypt/zone/oxz_ntp_47eab17a-4dd4-4467-90b2-f643f465cf34                 4eaf1849-1fe4-415c-bdc7-4cc04cac20ce   in service    none      none          off        
+    oxp_2a76ab1a-fb16-412d-93f9-b8cd9aa94e85/crypt/debug                                                             c5b8f4f9-bd10-45b8-a9f3-93adf1402ecc   in service    100 GiB   none          gzip-9     
+    oxp_2de2bf7e-c679-4b2b-b373-908e9d3ffbfc/crypt/debug                                                             43abf982-d457-46d1-8566-8047d2a78a41   in service    100 GiB   none          gzip-9     
+    oxp_2f02a5c6-fcf5-4b5a-bc7d-7f65369918ba/crypt/debug                                                             1b6a1722-d9f7-48ea-b351-5bc8bad4fd07   in service    100 GiB   none          gzip-9     
+    oxp_32041dbf-e58d-4f32-840d-923d3d3b68af/crypt/debug                                                             8be43fb0-00e7-4748-9a1a-ace9772d8a83   in service    100 GiB   none          gzip-9     
+    oxp_5f88adff-bb50-4dc1-bbfb-5a410c753ed5/crypt/debug                                                             2ccb3aa9-f0ef-4fd4-9fd7-43b4a88b8d6b   in service    100 GiB   none          gzip-9     
+    oxp_74d64eb9-bf69-4782-af16-2d3a761ca171/crypt/debug                                                             56759eb6-69e9-46a3-b44c-fc748cd506aa   in service    100 GiB   none          gzip-9     
+    oxp_b3c231c9-b2a5-4267-b4bf-9651881b91a5/crypt/debug                                                             76fffbd2-9c74-46b5-8033-f442be1256f5   in service    100 GiB   none          gzip-9     
+    oxp_bca80b95-8dca-4a3b-b24d-d44b6a9ff71b/crypt/debug                                                             c13a3d71-1241-42d1-95a8-d720c20ee2c4   in service    100 GiB   none          gzip-9     
+    oxp_db16345e-427a-4c8e-9032-17270f729308/crypt/debug                                                             f030ef33-cad2-4760-9431-1907b797161b   in service    100 GiB   none          gzip-9     
+    oxp_e3b45593-8f0c-47b2-a381-802a7dad1f54/crypt/debug                                                             947b2823-3dca-4b56-9324-f476e2c1c6da   in service    100 GiB   none          gzip-9     
 
 
     omicron zones at generation 3:

--- a/nexus/reconfigurator/planning/tests/output/planner_deploy_all_keeper_nodes_4_5.txt
+++ b/nexus/reconfigurator/planning/tests/output/planner_deploy_all_keeper_nodes_4_5.txt
@@ -22,58 +22,58 @@ to:   blueprint 2886dab5-61a2-46b4-87af-bc7aeb44cccb
 
 
     datasets at generation 3:
-    -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
-    dataset name                                                                                                     dataset uuid                           quota     reservation   compression
-    -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
-    oxp_60e6b021-79d6-4a6b-917c-6637e0769558/crucible                                                                723e4ec2-5f4a-48a9-a6a1-cb523dc47d3d   none      none          off        
-    oxp_71a07ac0-d24e-446c-a202-1998e7f6ac8c/crucible                                                                b2796e6b-ad7d-41a5-82a6-947b96e42d47   none      none          off        
-    oxp_736d4cab-c262-485e-89c2-07e6543f0855/crucible                                                                c993b4da-bea9-4010-a8d6-17d733698f07   none      none          off        
-    oxp_8ae56ca0-709d-4b8f-9869-51b62b542eef/crucible                                                                4f497ece-88c1-4557-a8b4-0e990f9941a9   none      none          off        
-    oxp_8e0bcc4f-0799-450c-a0ad-80c1637f59e3/crucible                                                                43a16c22-e79a-4bea-bcf6-682099a728dd   none      none          off        
-    oxp_8eeebb8e-6db6-43e8-a429-d26dde99882c/crucible                                                                b6bbb45b-68fc-4fa5-86cc-b59b0f797fb2   none      none          off        
-    oxp_a3e8de5b-c47a-49c0-b698-4d6955e1327f/crucible                                                                e4838ed0-304f-475e-a282-9f644f2ba3e5   none      none          off        
-    oxp_b32fa3da-4dec-4237-9776-e1a57ba15a21/crucible                                                                046f2730-768d-4bcc-8ebf-4b5f5597151c   none      none          off        
-    oxp_e9c238f6-87a3-4087-8ba4-aa594a82d012/crucible                                                                0830fc6d-ed82-41de-9389-0bd3fd4677ea   none      none          off        
-    oxp_fbf997ef-52d3-438a-b036-b9117322e569/crucible                                                                d9662141-585e-4e18-a461-9627097f02a2   none      none          off        
-    oxp_60e6b021-79d6-4a6b-917c-6637e0769558/crypt/clickhouse                                                        a4f84c49-4303-411f-bb1b-08877d828946   none      none          off        
-    oxp_60e6b021-79d6-4a6b-917c-6637e0769558/crypt/clickhouse_keeper                                                 04ee4b4b-fcbe-4224-86fd-30144a4f2592   none      none          off        
-    oxp_60e6b021-79d6-4a6b-917c-6637e0769558/crypt/internal_dns                                                      2edca3dc-a0e5-4d34-b8a2-065be4cca767   none      none          off        
-    oxp_60e6b021-79d6-4a6b-917c-6637e0769558/crypt/zone                                                              87cd9f37-3de3-457c-9412-d0dc5678eda8   none      none          off        
-    oxp_71a07ac0-d24e-446c-a202-1998e7f6ac8c/crypt/zone                                                              3a164f36-1f53-45b3-b190-ad8a2817bc69   none      none          off        
-    oxp_736d4cab-c262-485e-89c2-07e6543f0855/crypt/zone                                                              407556ed-09ab-430e-bc8f-8291b8f8c8fe   none      none          off        
-    oxp_8ae56ca0-709d-4b8f-9869-51b62b542eef/crypt/zone                                                              99d57d61-f12a-4b56-8114-86ba92d07649   none      none          off        
-    oxp_8e0bcc4f-0799-450c-a0ad-80c1637f59e3/crypt/zone                                                              da1eb596-8764-4268-a60b-f4705b4f615b   none      none          off        
-    oxp_8eeebb8e-6db6-43e8-a429-d26dde99882c/crypt/zone                                                              d555bf19-887c-48d2-8144-47c2eac9a9e8   none      none          off        
-    oxp_a3e8de5b-c47a-49c0-b698-4d6955e1327f/crypt/zone                                                              9785e77a-9422-4b46-a4ae-8b9a155eb121   none      none          off        
-    oxp_b32fa3da-4dec-4237-9776-e1a57ba15a21/crypt/zone                                                              1192a37c-a871-4c48-905d-03c3d6035bdc   none      none          off        
-    oxp_e9c238f6-87a3-4087-8ba4-aa594a82d012/crypt/zone                                                              7bf1c7ec-5465-4bfd-b1d9-939f05336012   none      none          off        
-    oxp_fbf997ef-52d3-438a-b036-b9117322e569/crypt/zone                                                              be526b44-2c78-49ec-8ab4-73e161e27f22   none      none          off        
-    oxp_60e6b021-79d6-4a6b-917c-6637e0769558/crypt/zone/oxz_clickhouse_35e8d4b6-ea92-45cf-923c-3f566a0b1fe5          cd7e5c3a-2328-4568-b8f8-cf349f0cdd12   none      none          off        
-    oxp_60e6b021-79d6-4a6b-917c-6637e0769558/crypt/zone/oxz_clickhouse_keeper_dd5ab8b1-e6e7-40e0-9ea6-b6a16f485b52   a51fb98f-3fff-4c0a-82f0-7a4aad82096b   none      none          off        
-    oxp_e9c238f6-87a3-4087-8ba4-aa594a82d012/crypt/zone/oxz_crucible_044d074d-7905-4024-82ff-68d76221db68            98fd0f42-7337-4ce7-814e-f988304b8873   none      none          off        
-    oxp_71a07ac0-d24e-446c-a202-1998e7f6ac8c/crypt/zone/oxz_crucible_28826473-ac0b-41ea-8c54-72b782db1bcb            bbda84d8-c4ca-4f52-a766-681872fa06f0   none      none          off        
-    oxp_fbf997ef-52d3-438a-b036-b9117322e569/crypt/zone/oxz_crucible_2d3ff798-dda9-4ccf-8f91-070a20f06d55            e9c77dbd-c56a-404c-8ff9-6504b3f92556   none      none          off        
-    oxp_8eeebb8e-6db6-43e8-a429-d26dde99882c/crypt/zone/oxz_crucible_7538d29b-69f2-43e8-8509-505b25cb1c84            19110f8a-6267-41ed-ac7d-539cd0fe3511   none      none          off        
-    oxp_8ae56ca0-709d-4b8f-9869-51b62b542eef/crypt/zone/oxz_crucible_8234bbd2-4b31-4f6b-8dcc-4744b1d14e64            0fe4f647-ffd2-4845-805a-c069096560ee   none      none          off        
-    oxp_8e0bcc4f-0799-450c-a0ad-80c1637f59e3/crypt/zone/oxz_crucible_85358363-cee8-4bc3-af66-4d89e5cd714f            a1daa561-2448-4afb-8233-ec149d2bd7f4   none      none          off        
-    oxp_736d4cab-c262-485e-89c2-07e6543f0855/crypt/zone/oxz_crucible_9b58d04f-85bf-4f5e-8c6a-5d855062d5c4            69812f66-4b59-4590-9e1f-bce3e93b3b08   none      none          off        
-    oxp_60e6b021-79d6-4a6b-917c-6637e0769558/crypt/zone/oxz_crucible_e7da0aec-c6b6-4a56-9525-35385b9c62a2            36e58025-88e2-4eb9-8af0-ed9a98dda1b9   none      none          off        
-    oxp_a3e8de5b-c47a-49c0-b698-4d6955e1327f/crypt/zone/oxz_crucible_f3f977cc-7eca-4491-9b07-82b6284eb169            482fad9a-d83f-4025-8f0b-d3adea6ae2cf   none      none          off        
-    oxp_b32fa3da-4dec-4237-9776-e1a57ba15a21/crypt/zone/oxz_crucible_fef381d2-8368-4a2d-96a1-c956ed011f7b            b1937368-4019-40c4-af02-9811dc7eb143   none      none          off        
-    oxp_60e6b021-79d6-4a6b-917c-6637e0769558/crypt/zone/oxz_crucible_pantry_fe63bfd3-3128-4675-8118-cf6968293471     e3b31ef3-6b54-4901-aec4-0c672de62c7f   none      none          off        
-    oxp_60e6b021-79d6-4a6b-917c-6637e0769558/crypt/zone/oxz_internal_dns_b6b0689e-ef48-484d-b3c7-3c596edad20c        501e0672-2897-4992-8911-600e0283f04c   none      none          off        
-    oxp_60e6b021-79d6-4a6b-917c-6637e0769558/crypt/zone/oxz_nexus_46ecde76-fef7-4394-93dd-d22b003148e9               53655959-866b-4fee-bcf9-1e35504ad625   none      none          off        
-    oxp_60e6b021-79d6-4a6b-917c-6637e0769558/crypt/zone/oxz_ntp_4d009155-44fb-45b9-afed-f89cb57ce8da                 0590facf-202a-463b-81be-b6e88c47da76   none      none          off        
-    oxp_60e6b021-79d6-4a6b-917c-6637e0769558/crypt/debug                                                             8f7f16c1-d9fb-4405-9dcf-68bfbaa7bf8c   100 GiB   none          gzip-9     
-    oxp_71a07ac0-d24e-446c-a202-1998e7f6ac8c/crypt/debug                                                             6482f332-801a-473f-a77d-e07d30e2a5b7   100 GiB   none          gzip-9     
-    oxp_736d4cab-c262-485e-89c2-07e6543f0855/crypt/debug                                                             0bb0541f-2c64-487b-a8af-162454207504   100 GiB   none          gzip-9     
-    oxp_8ae56ca0-709d-4b8f-9869-51b62b542eef/crypt/debug                                                             902a6889-244f-4b67-baa4-b245f3d622c8   100 GiB   none          gzip-9     
-    oxp_8e0bcc4f-0799-450c-a0ad-80c1637f59e3/crypt/debug                                                             667ffd3c-6735-4b50-bc3b-cfa32fcc811e   100 GiB   none          gzip-9     
-    oxp_8eeebb8e-6db6-43e8-a429-d26dde99882c/crypt/debug                                                             cf48ba87-a4bb-435f-999b-bca46cfd6a89   100 GiB   none          gzip-9     
-    oxp_a3e8de5b-c47a-49c0-b698-4d6955e1327f/crypt/debug                                                             7d64cab3-7311-4519-ae4a-1af6b320fa9b   100 GiB   none          gzip-9     
-    oxp_b32fa3da-4dec-4237-9776-e1a57ba15a21/crypt/debug                                                             d3e957fd-5f26-498a-8fa3-deaea4dc5820   100 GiB   none          gzip-9     
-    oxp_e9c238f6-87a3-4087-8ba4-aa594a82d012/crypt/debug                                                             4da77f4a-5e41-4604-af30-8cf568c38428   100 GiB   none          gzip-9     
-    oxp_fbf997ef-52d3-438a-b036-b9117322e569/crypt/debug                                                             03935cb1-ce06-4594-b2fe-23e127d1cd9d   100 GiB   none          gzip-9     
+    ---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
+    dataset name                                                                                                     dataset id                             disposition   quota     reservation   compression
+    ---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
+    oxp_60e6b021-79d6-4a6b-917c-6637e0769558/crucible                                                                723e4ec2-5f4a-48a9-a6a1-cb523dc47d3d   in service    none      none          off        
+    oxp_71a07ac0-d24e-446c-a202-1998e7f6ac8c/crucible                                                                b2796e6b-ad7d-41a5-82a6-947b96e42d47   in service    none      none          off        
+    oxp_736d4cab-c262-485e-89c2-07e6543f0855/crucible                                                                c993b4da-bea9-4010-a8d6-17d733698f07   in service    none      none          off        
+    oxp_8ae56ca0-709d-4b8f-9869-51b62b542eef/crucible                                                                4f497ece-88c1-4557-a8b4-0e990f9941a9   in service    none      none          off        
+    oxp_8e0bcc4f-0799-450c-a0ad-80c1637f59e3/crucible                                                                43a16c22-e79a-4bea-bcf6-682099a728dd   in service    none      none          off        
+    oxp_8eeebb8e-6db6-43e8-a429-d26dde99882c/crucible                                                                b6bbb45b-68fc-4fa5-86cc-b59b0f797fb2   in service    none      none          off        
+    oxp_a3e8de5b-c47a-49c0-b698-4d6955e1327f/crucible                                                                e4838ed0-304f-475e-a282-9f644f2ba3e5   in service    none      none          off        
+    oxp_b32fa3da-4dec-4237-9776-e1a57ba15a21/crucible                                                                046f2730-768d-4bcc-8ebf-4b5f5597151c   in service    none      none          off        
+    oxp_e9c238f6-87a3-4087-8ba4-aa594a82d012/crucible                                                                0830fc6d-ed82-41de-9389-0bd3fd4677ea   in service    none      none          off        
+    oxp_fbf997ef-52d3-438a-b036-b9117322e569/crucible                                                                d9662141-585e-4e18-a461-9627097f02a2   in service    none      none          off        
+    oxp_60e6b021-79d6-4a6b-917c-6637e0769558/crypt/clickhouse                                                        a4f84c49-4303-411f-bb1b-08877d828946   in service    none      none          off        
+    oxp_60e6b021-79d6-4a6b-917c-6637e0769558/crypt/clickhouse_keeper                                                 04ee4b4b-fcbe-4224-86fd-30144a4f2592   in service    none      none          off        
+    oxp_60e6b021-79d6-4a6b-917c-6637e0769558/crypt/internal_dns                                                      2edca3dc-a0e5-4d34-b8a2-065be4cca767   in service    none      none          off        
+    oxp_60e6b021-79d6-4a6b-917c-6637e0769558/crypt/zone                                                              87cd9f37-3de3-457c-9412-d0dc5678eda8   in service    none      none          off        
+    oxp_71a07ac0-d24e-446c-a202-1998e7f6ac8c/crypt/zone                                                              3a164f36-1f53-45b3-b190-ad8a2817bc69   in service    none      none          off        
+    oxp_736d4cab-c262-485e-89c2-07e6543f0855/crypt/zone                                                              407556ed-09ab-430e-bc8f-8291b8f8c8fe   in service    none      none          off        
+    oxp_8ae56ca0-709d-4b8f-9869-51b62b542eef/crypt/zone                                                              99d57d61-f12a-4b56-8114-86ba92d07649   in service    none      none          off        
+    oxp_8e0bcc4f-0799-450c-a0ad-80c1637f59e3/crypt/zone                                                              da1eb596-8764-4268-a60b-f4705b4f615b   in service    none      none          off        
+    oxp_8eeebb8e-6db6-43e8-a429-d26dde99882c/crypt/zone                                                              d555bf19-887c-48d2-8144-47c2eac9a9e8   in service    none      none          off        
+    oxp_a3e8de5b-c47a-49c0-b698-4d6955e1327f/crypt/zone                                                              9785e77a-9422-4b46-a4ae-8b9a155eb121   in service    none      none          off        
+    oxp_b32fa3da-4dec-4237-9776-e1a57ba15a21/crypt/zone                                                              1192a37c-a871-4c48-905d-03c3d6035bdc   in service    none      none          off        
+    oxp_e9c238f6-87a3-4087-8ba4-aa594a82d012/crypt/zone                                                              7bf1c7ec-5465-4bfd-b1d9-939f05336012   in service    none      none          off        
+    oxp_fbf997ef-52d3-438a-b036-b9117322e569/crypt/zone                                                              be526b44-2c78-49ec-8ab4-73e161e27f22   in service    none      none          off        
+    oxp_60e6b021-79d6-4a6b-917c-6637e0769558/crypt/zone/oxz_clickhouse_35e8d4b6-ea92-45cf-923c-3f566a0b1fe5          cd7e5c3a-2328-4568-b8f8-cf349f0cdd12   in service    none      none          off        
+    oxp_60e6b021-79d6-4a6b-917c-6637e0769558/crypt/zone/oxz_clickhouse_keeper_dd5ab8b1-e6e7-40e0-9ea6-b6a16f485b52   a51fb98f-3fff-4c0a-82f0-7a4aad82096b   in service    none      none          off        
+    oxp_e9c238f6-87a3-4087-8ba4-aa594a82d012/crypt/zone/oxz_crucible_044d074d-7905-4024-82ff-68d76221db68            98fd0f42-7337-4ce7-814e-f988304b8873   in service    none      none          off        
+    oxp_71a07ac0-d24e-446c-a202-1998e7f6ac8c/crypt/zone/oxz_crucible_28826473-ac0b-41ea-8c54-72b782db1bcb            bbda84d8-c4ca-4f52-a766-681872fa06f0   in service    none      none          off        
+    oxp_fbf997ef-52d3-438a-b036-b9117322e569/crypt/zone/oxz_crucible_2d3ff798-dda9-4ccf-8f91-070a20f06d55            e9c77dbd-c56a-404c-8ff9-6504b3f92556   in service    none      none          off        
+    oxp_8eeebb8e-6db6-43e8-a429-d26dde99882c/crypt/zone/oxz_crucible_7538d29b-69f2-43e8-8509-505b25cb1c84            19110f8a-6267-41ed-ac7d-539cd0fe3511   in service    none      none          off        
+    oxp_8ae56ca0-709d-4b8f-9869-51b62b542eef/crypt/zone/oxz_crucible_8234bbd2-4b31-4f6b-8dcc-4744b1d14e64            0fe4f647-ffd2-4845-805a-c069096560ee   in service    none      none          off        
+    oxp_8e0bcc4f-0799-450c-a0ad-80c1637f59e3/crypt/zone/oxz_crucible_85358363-cee8-4bc3-af66-4d89e5cd714f            a1daa561-2448-4afb-8233-ec149d2bd7f4   in service    none      none          off        
+    oxp_736d4cab-c262-485e-89c2-07e6543f0855/crypt/zone/oxz_crucible_9b58d04f-85bf-4f5e-8c6a-5d855062d5c4            69812f66-4b59-4590-9e1f-bce3e93b3b08   in service    none      none          off        
+    oxp_60e6b021-79d6-4a6b-917c-6637e0769558/crypt/zone/oxz_crucible_e7da0aec-c6b6-4a56-9525-35385b9c62a2            36e58025-88e2-4eb9-8af0-ed9a98dda1b9   in service    none      none          off        
+    oxp_a3e8de5b-c47a-49c0-b698-4d6955e1327f/crypt/zone/oxz_crucible_f3f977cc-7eca-4491-9b07-82b6284eb169            482fad9a-d83f-4025-8f0b-d3adea6ae2cf   in service    none      none          off        
+    oxp_b32fa3da-4dec-4237-9776-e1a57ba15a21/crypt/zone/oxz_crucible_fef381d2-8368-4a2d-96a1-c956ed011f7b            b1937368-4019-40c4-af02-9811dc7eb143   in service    none      none          off        
+    oxp_60e6b021-79d6-4a6b-917c-6637e0769558/crypt/zone/oxz_crucible_pantry_fe63bfd3-3128-4675-8118-cf6968293471     e3b31ef3-6b54-4901-aec4-0c672de62c7f   in service    none      none          off        
+    oxp_60e6b021-79d6-4a6b-917c-6637e0769558/crypt/zone/oxz_internal_dns_b6b0689e-ef48-484d-b3c7-3c596edad20c        501e0672-2897-4992-8911-600e0283f04c   in service    none      none          off        
+    oxp_60e6b021-79d6-4a6b-917c-6637e0769558/crypt/zone/oxz_nexus_46ecde76-fef7-4394-93dd-d22b003148e9               53655959-866b-4fee-bcf9-1e35504ad625   in service    none      none          off        
+    oxp_60e6b021-79d6-4a6b-917c-6637e0769558/crypt/zone/oxz_ntp_4d009155-44fb-45b9-afed-f89cb57ce8da                 0590facf-202a-463b-81be-b6e88c47da76   in service    none      none          off        
+    oxp_60e6b021-79d6-4a6b-917c-6637e0769558/crypt/debug                                                             8f7f16c1-d9fb-4405-9dcf-68bfbaa7bf8c   in service    100 GiB   none          gzip-9     
+    oxp_71a07ac0-d24e-446c-a202-1998e7f6ac8c/crypt/debug                                                             6482f332-801a-473f-a77d-e07d30e2a5b7   in service    100 GiB   none          gzip-9     
+    oxp_736d4cab-c262-485e-89c2-07e6543f0855/crypt/debug                                                             0bb0541f-2c64-487b-a8af-162454207504   in service    100 GiB   none          gzip-9     
+    oxp_8ae56ca0-709d-4b8f-9869-51b62b542eef/crypt/debug                                                             902a6889-244f-4b67-baa4-b245f3d622c8   in service    100 GiB   none          gzip-9     
+    oxp_8e0bcc4f-0799-450c-a0ad-80c1637f59e3/crypt/debug                                                             667ffd3c-6735-4b50-bc3b-cfa32fcc811e   in service    100 GiB   none          gzip-9     
+    oxp_8eeebb8e-6db6-43e8-a429-d26dde99882c/crypt/debug                                                             cf48ba87-a4bb-435f-999b-bca46cfd6a89   in service    100 GiB   none          gzip-9     
+    oxp_a3e8de5b-c47a-49c0-b698-4d6955e1327f/crypt/debug                                                             7d64cab3-7311-4519-ae4a-1af6b320fa9b   in service    100 GiB   none          gzip-9     
+    oxp_b32fa3da-4dec-4237-9776-e1a57ba15a21/crypt/debug                                                             d3e957fd-5f26-498a-8fa3-deaea4dc5820   in service    100 GiB   none          gzip-9     
+    oxp_e9c238f6-87a3-4087-8ba4-aa594a82d012/crypt/debug                                                             4da77f4a-5e41-4604-af30-8cf568c38428   in service    100 GiB   none          gzip-9     
+    oxp_fbf997ef-52d3-438a-b036-b9117322e569/crypt/debug                                                             03935cb1-ce06-4594-b2fe-23e127d1cd9d   in service    100 GiB   none          gzip-9     
 
 
     omicron zones at generation 3:
@@ -119,60 +119,60 @@ to:   blueprint 2886dab5-61a2-46b4-87af-bc7aeb44cccb
 
 
     datasets generation 3 -> 4:
-    -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
-    dataset name                                                                                                     dataset uuid                           quota     reservation   compression
-    -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
-    oxp_0bf9d028-2b4a-4bff-82a1-6eb5fcefd985/crucible                                                                f18270c8-a39b-4579-be20-d2d1b80bba42   none      none          off        
-    oxp_19293a1d-fddc-40a7-88a4-ccafdb6f66d3/crucible                                                                06c2af14-055c-4041-aa26-9155f9f42661   none      none          off        
-    oxp_44484c44-477a-4676-8266-b98a00e80d79/crucible                                                                9deffea6-d340-4432-be3c-fad135dc29a5   none      none          off        
-    oxp_79787cd4-92da-4de5-bfd8-30a635521e10/crucible                                                                47ca08b9-b962-43e2-99d7-c2e0556c0f52   none      none          off        
-    oxp_9ae94c94-baae-477e-912a-60f0c4f3bd13/crucible                                                                b2e54e29-6915-4b6d-bc76-6f72e5c7c55a   none      none          off        
-    oxp_af85eec8-36b3-4b88-966d-a717b9b58fe5/crucible                                                                cb992d4e-7a69-4bcd-96c8-fe6e40989e24   none      none          off        
-    oxp_ddfaaba3-dafe-4103-b868-e9843d29d346/crucible                                                                68338fc3-2d8b-4419-b33d-4cce6fe9380d   none      none          off        
-    oxp_ec458c3e-91ca-40f1-a2a3-3f4292c1f279/crucible                                                                5294b99c-3eac-40e1-a35b-1f1cf2f0d6bf   none      none          off        
-    oxp_f2fc7c4c-7966-449d-8ec3-5a70f460501d/crucible                                                                31718dcf-ebd5-432c-a9e5-40abcb40931c   none      none          off        
-    oxp_f635c28a-e5ca-4d22-ac94-d8f278a6ea0e/crucible                                                                ff7ff4a9-21c4-499e-9ceb-8a00a4bb21bc   none      none          off        
-    oxp_0bf9d028-2b4a-4bff-82a1-6eb5fcefd985/crypt/clickhouse_keeper                                                 473adeb2-a57a-4240-82e9-88f2bebc1245   none      none          off        
-    oxp_0bf9d028-2b4a-4bff-82a1-6eb5fcefd985/crypt/clickhouse_server                                                 4363b5f8-9a67-49af-b49d-585e532fa7bc   none      none          off        
-    oxp_0bf9d028-2b4a-4bff-82a1-6eb5fcefd985/crypt/internal_dns                                                      56a1af5d-de86-46c5-9504-2d1ee70587c5   none      none          off        
-    oxp_0bf9d028-2b4a-4bff-82a1-6eb5fcefd985/crypt/zone                                                              003c1d4e-15bb-4fca-aa71-a7dff507b124   none      none          off        
-    oxp_19293a1d-fddc-40a7-88a4-ccafdb6f66d3/crypt/zone                                                              bf35a148-62f0-4f88-8f60-0a13747daba2   none      none          off        
-    oxp_44484c44-477a-4676-8266-b98a00e80d79/crypt/zone                                                              9b1bf42e-6f06-44cc-af5b-bff65d929322   none      none          off        
-    oxp_79787cd4-92da-4de5-bfd8-30a635521e10/crypt/zone                                                              2c9d6bce-0293-4364-b8c9-4bdea345490e   none      none          off        
-    oxp_9ae94c94-baae-477e-912a-60f0c4f3bd13/crypt/zone                                                              11726c79-6590-4831-8480-cf50e6322c8a   none      none          off        
-    oxp_af85eec8-36b3-4b88-966d-a717b9b58fe5/crypt/zone                                                              b463f0c2-3ae4-45f7-a38c-110731fcc5cb   none      none          off        
-    oxp_ddfaaba3-dafe-4103-b868-e9843d29d346/crypt/zone                                                              626abe12-321d-439b-ad8f-f8dfb2022f25   none      none          off        
-    oxp_ec458c3e-91ca-40f1-a2a3-3f4292c1f279/crypt/zone                                                              4200e2a7-0fd6-4631-9d60-21fd821193fe   none      none          off        
-    oxp_f2fc7c4c-7966-449d-8ec3-5a70f460501d/crypt/zone                                                              85f34c02-a35d-404e-8cde-bedf3e193b1c   none      none          off        
-    oxp_f635c28a-e5ca-4d22-ac94-d8f278a6ea0e/crypt/zone                                                              dd19c2c5-0bc9-48de-a116-b92503569092   none      none          off        
-    oxp_0bf9d028-2b4a-4bff-82a1-6eb5fcefd985/crypt/zone/oxz_clickhouse_keeper_31a66e47-6252-4f38-aa92-f48637da152c   49f52cc5-74df-4cfa-b7f0-07c7e810940d   none      none          off        
-    oxp_0bf9d028-2b4a-4bff-82a1-6eb5fcefd985/crypt/zone/oxz_clickhouse_server_6fedfc94-2ae6-4cc7-a968-5185207284f4   f1143eb2-0685-4708-a471-968a58f93bad   none      none          off        
-    oxp_f635c28a-e5ca-4d22-ac94-d8f278a6ea0e/crypt/zone/oxz_crucible_06b45c33-9a90-408b-8534-f94ab6df8a42            9e0a360d-c158-417f-a45f-9d29ee67cdce   none      none          off        
-    oxp_19293a1d-fddc-40a7-88a4-ccafdb6f66d3/crypt/zone/oxz_crucible_32999e20-ed5c-4c25-b4bd-41a3fbaf1445            dd7a45b8-3175-4744-8b99-ce19b22bb8ce   none      none          off        
-    oxp_9ae94c94-baae-477e-912a-60f0c4f3bd13/crypt/zone/oxz_crucible_4a037563-f969-4028-8384-164bdf308c3c            0d5b2580-7190-4bcc-9982-5012dac51f05   none      none          off        
-    oxp_44484c44-477a-4676-8266-b98a00e80d79/crypt/zone/oxz_crucible_6564394d-2c51-4252-b3b1-f5f88a72d7c3            26a1cc86-f717-4a12-b644-5acd168843aa   none      none          off        
-    oxp_0bf9d028-2b4a-4bff-82a1-6eb5fcefd985/crypt/zone/oxz_crucible_87427b40-5114-49cd-96bd-63edd61fce90            e7364079-58e3-4b36-81a7-b9e08f2a8fff   none      none          off        
-    oxp_ddfaaba3-dafe-4103-b868-e9843d29d346/crypt/zone/oxz_crucible_8acdc189-d4da-45a7-b306-23b43e86f695            6fa84a9c-0161-40c9-b596-f3b2c679ef99   none      none          off        
-    oxp_ec458c3e-91ca-40f1-a2a3-3f4292c1f279/crypt/zone/oxz_crucible_971ce633-cdc4-48cf-983e-dc272c1639eb            cb8ca8a6-6a00-4aae-8702-1493e1c3b166   none      none          off        
-    oxp_af85eec8-36b3-4b88-966d-a717b9b58fe5/crypt/zone/oxz_crucible_cfa6af7a-bf53-4fe6-bf1a-7ce3812d15c4            27323e49-f61e-4a73-bc87-f8d9f5082143   none      none          off        
-    oxp_f2fc7c4c-7966-449d-8ec3-5a70f460501d/crypt/zone/oxz_crucible_e145fb8e-df12-4df9-8049-b146ae0275be            35c46d33-4e08-4fad-90d2-3da719538ef2   none      none          off        
-    oxp_79787cd4-92da-4de5-bfd8-30a635521e10/crypt/zone/oxz_crucible_f1d08ae7-68fe-4799-8f31-f1100887c6f0            02863a62-7624-4017-9269-412910ab73f0   none      none          off        
-    oxp_0bf9d028-2b4a-4bff-82a1-6eb5fcefd985/crypt/zone/oxz_crucible_pantry_f9e18694-fdff-46a3-b40d-570d43206f48     3cb3f346-9879-4023-b919-55c4172bbf23   none      none          off        
-    oxp_0bf9d028-2b4a-4bff-82a1-6eb5fcefd985/crypt/zone/oxz_internal_dns_a00d8ae3-d1db-4aef-9174-3ff867af5e9e        c2d9b145-5e15-47be-a835-7e1f51f27679   none      none          off        
-    oxp_0bf9d028-2b4a-4bff-82a1-6eb5fcefd985/crypt/zone/oxz_nexus_8ccafc1f-97f9-4da7-bb04-d346213387ce               dcc3603b-b160-42d9-a743-11075c3b6941   none      none          off        
-    oxp_0bf9d028-2b4a-4bff-82a1-6eb5fcefd985/crypt/zone/oxz_ntp_a1797f1d-2d2a-4396-9ab5-044630b41c35                 5a70b3fe-9fad-4c17-982b-272b8595c2e8   none      none          off        
-    oxp_0bf9d028-2b4a-4bff-82a1-6eb5fcefd985/crypt/debug                                                             4e4b2f99-dc01-4793-a37a-072d942da264   100 GiB   none          gzip-9     
-    oxp_19293a1d-fddc-40a7-88a4-ccafdb6f66d3/crypt/debug                                                             8573903d-9610-4084-b0c6-ffcbb5d96c39   100 GiB   none          gzip-9     
-    oxp_44484c44-477a-4676-8266-b98a00e80d79/crypt/debug                                                             540272e1-99d2-4d2e-9d3d-032014b0e6d9   100 GiB   none          gzip-9     
-    oxp_79787cd4-92da-4de5-bfd8-30a635521e10/crypt/debug                                                             4adf2ef6-2694-4aac-aabe-688bca767092   100 GiB   none          gzip-9     
-    oxp_9ae94c94-baae-477e-912a-60f0c4f3bd13/crypt/debug                                                             7e9d012a-6d8e-475e-805e-65985a66ffcd   100 GiB   none          gzip-9     
-    oxp_af85eec8-36b3-4b88-966d-a717b9b58fe5/crypt/debug                                                             2189574d-9a73-4d25-858e-1084d57b59a8   100 GiB   none          gzip-9     
-    oxp_ddfaaba3-dafe-4103-b868-e9843d29d346/crypt/debug                                                             3cf0580b-4e1d-4ff9-bc22-4dc51ca9a53b   100 GiB   none          gzip-9     
-    oxp_ec458c3e-91ca-40f1-a2a3-3f4292c1f279/crypt/debug                                                             f499c5f8-b62f-493d-858a-8d33f7db81ff   100 GiB   none          gzip-9     
-    oxp_f2fc7c4c-7966-449d-8ec3-5a70f460501d/crypt/debug                                                             c16ff3c0-3282-46de-a620-49c6b1e3f882   100 GiB   none          gzip-9     
-    oxp_f635c28a-e5ca-4d22-ac94-d8f278a6ea0e/crypt/debug                                                             8dde6eee-f28e-4b55-8c11-525884ec81e5   100 GiB   none          gzip-9     
-+   oxp_19293a1d-fddc-40a7-88a4-ccafdb6f66d3/crypt/clickhouse_keeper                                                 882d4fee-d6d4-455f-9dc1-de3637cd29d0   none      none          off        
-+   oxp_19293a1d-fddc-40a7-88a4-ccafdb6f66d3/crypt/zone/oxz_clickhouse_keeper_e222f1c0-39ca-463a-88ad-ebfb6022fd1a   fbf9198e-996a-4194-af5b-c4e95ea4286d   none      none          off        
+    ---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
+    dataset name                                                                                                     dataset id                             disposition   quota     reservation   compression
+    ---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
+    oxp_0bf9d028-2b4a-4bff-82a1-6eb5fcefd985/crucible                                                                f18270c8-a39b-4579-be20-d2d1b80bba42   in service    none      none          off        
+    oxp_19293a1d-fddc-40a7-88a4-ccafdb6f66d3/crucible                                                                06c2af14-055c-4041-aa26-9155f9f42661   in service    none      none          off        
+    oxp_44484c44-477a-4676-8266-b98a00e80d79/crucible                                                                9deffea6-d340-4432-be3c-fad135dc29a5   in service    none      none          off        
+    oxp_79787cd4-92da-4de5-bfd8-30a635521e10/crucible                                                                47ca08b9-b962-43e2-99d7-c2e0556c0f52   in service    none      none          off        
+    oxp_9ae94c94-baae-477e-912a-60f0c4f3bd13/crucible                                                                b2e54e29-6915-4b6d-bc76-6f72e5c7c55a   in service    none      none          off        
+    oxp_af85eec8-36b3-4b88-966d-a717b9b58fe5/crucible                                                                cb992d4e-7a69-4bcd-96c8-fe6e40989e24   in service    none      none          off        
+    oxp_ddfaaba3-dafe-4103-b868-e9843d29d346/crucible                                                                68338fc3-2d8b-4419-b33d-4cce6fe9380d   in service    none      none          off        
+    oxp_ec458c3e-91ca-40f1-a2a3-3f4292c1f279/crucible                                                                5294b99c-3eac-40e1-a35b-1f1cf2f0d6bf   in service    none      none          off        
+    oxp_f2fc7c4c-7966-449d-8ec3-5a70f460501d/crucible                                                                31718dcf-ebd5-432c-a9e5-40abcb40931c   in service    none      none          off        
+    oxp_f635c28a-e5ca-4d22-ac94-d8f278a6ea0e/crucible                                                                ff7ff4a9-21c4-499e-9ceb-8a00a4bb21bc   in service    none      none          off        
+    oxp_0bf9d028-2b4a-4bff-82a1-6eb5fcefd985/crypt/clickhouse_keeper                                                 473adeb2-a57a-4240-82e9-88f2bebc1245   in service    none      none          off        
+    oxp_0bf9d028-2b4a-4bff-82a1-6eb5fcefd985/crypt/clickhouse_server                                                 4363b5f8-9a67-49af-b49d-585e532fa7bc   in service    none      none          off        
+    oxp_0bf9d028-2b4a-4bff-82a1-6eb5fcefd985/crypt/internal_dns                                                      56a1af5d-de86-46c5-9504-2d1ee70587c5   in service    none      none          off        
+    oxp_0bf9d028-2b4a-4bff-82a1-6eb5fcefd985/crypt/zone                                                              003c1d4e-15bb-4fca-aa71-a7dff507b124   in service    none      none          off        
+    oxp_19293a1d-fddc-40a7-88a4-ccafdb6f66d3/crypt/zone                                                              bf35a148-62f0-4f88-8f60-0a13747daba2   in service    none      none          off        
+    oxp_44484c44-477a-4676-8266-b98a00e80d79/crypt/zone                                                              9b1bf42e-6f06-44cc-af5b-bff65d929322   in service    none      none          off        
+    oxp_79787cd4-92da-4de5-bfd8-30a635521e10/crypt/zone                                                              2c9d6bce-0293-4364-b8c9-4bdea345490e   in service    none      none          off        
+    oxp_9ae94c94-baae-477e-912a-60f0c4f3bd13/crypt/zone                                                              11726c79-6590-4831-8480-cf50e6322c8a   in service    none      none          off        
+    oxp_af85eec8-36b3-4b88-966d-a717b9b58fe5/crypt/zone                                                              b463f0c2-3ae4-45f7-a38c-110731fcc5cb   in service    none      none          off        
+    oxp_ddfaaba3-dafe-4103-b868-e9843d29d346/crypt/zone                                                              626abe12-321d-439b-ad8f-f8dfb2022f25   in service    none      none          off        
+    oxp_ec458c3e-91ca-40f1-a2a3-3f4292c1f279/crypt/zone                                                              4200e2a7-0fd6-4631-9d60-21fd821193fe   in service    none      none          off        
+    oxp_f2fc7c4c-7966-449d-8ec3-5a70f460501d/crypt/zone                                                              85f34c02-a35d-404e-8cde-bedf3e193b1c   in service    none      none          off        
+    oxp_f635c28a-e5ca-4d22-ac94-d8f278a6ea0e/crypt/zone                                                              dd19c2c5-0bc9-48de-a116-b92503569092   in service    none      none          off        
+    oxp_0bf9d028-2b4a-4bff-82a1-6eb5fcefd985/crypt/zone/oxz_clickhouse_keeper_31a66e47-6252-4f38-aa92-f48637da152c   49f52cc5-74df-4cfa-b7f0-07c7e810940d   in service    none      none          off        
+    oxp_0bf9d028-2b4a-4bff-82a1-6eb5fcefd985/crypt/zone/oxz_clickhouse_server_6fedfc94-2ae6-4cc7-a968-5185207284f4   f1143eb2-0685-4708-a471-968a58f93bad   in service    none      none          off        
+    oxp_f635c28a-e5ca-4d22-ac94-d8f278a6ea0e/crypt/zone/oxz_crucible_06b45c33-9a90-408b-8534-f94ab6df8a42            9e0a360d-c158-417f-a45f-9d29ee67cdce   in service    none      none          off        
+    oxp_19293a1d-fddc-40a7-88a4-ccafdb6f66d3/crypt/zone/oxz_crucible_32999e20-ed5c-4c25-b4bd-41a3fbaf1445            dd7a45b8-3175-4744-8b99-ce19b22bb8ce   in service    none      none          off        
+    oxp_9ae94c94-baae-477e-912a-60f0c4f3bd13/crypt/zone/oxz_crucible_4a037563-f969-4028-8384-164bdf308c3c            0d5b2580-7190-4bcc-9982-5012dac51f05   in service    none      none          off        
+    oxp_44484c44-477a-4676-8266-b98a00e80d79/crypt/zone/oxz_crucible_6564394d-2c51-4252-b3b1-f5f88a72d7c3            26a1cc86-f717-4a12-b644-5acd168843aa   in service    none      none          off        
+    oxp_0bf9d028-2b4a-4bff-82a1-6eb5fcefd985/crypt/zone/oxz_crucible_87427b40-5114-49cd-96bd-63edd61fce90            e7364079-58e3-4b36-81a7-b9e08f2a8fff   in service    none      none          off        
+    oxp_ddfaaba3-dafe-4103-b868-e9843d29d346/crypt/zone/oxz_crucible_8acdc189-d4da-45a7-b306-23b43e86f695            6fa84a9c-0161-40c9-b596-f3b2c679ef99   in service    none      none          off        
+    oxp_ec458c3e-91ca-40f1-a2a3-3f4292c1f279/crypt/zone/oxz_crucible_971ce633-cdc4-48cf-983e-dc272c1639eb            cb8ca8a6-6a00-4aae-8702-1493e1c3b166   in service    none      none          off        
+    oxp_af85eec8-36b3-4b88-966d-a717b9b58fe5/crypt/zone/oxz_crucible_cfa6af7a-bf53-4fe6-bf1a-7ce3812d15c4            27323e49-f61e-4a73-bc87-f8d9f5082143   in service    none      none          off        
+    oxp_f2fc7c4c-7966-449d-8ec3-5a70f460501d/crypt/zone/oxz_crucible_e145fb8e-df12-4df9-8049-b146ae0275be            35c46d33-4e08-4fad-90d2-3da719538ef2   in service    none      none          off        
+    oxp_79787cd4-92da-4de5-bfd8-30a635521e10/crypt/zone/oxz_crucible_f1d08ae7-68fe-4799-8f31-f1100887c6f0            02863a62-7624-4017-9269-412910ab73f0   in service    none      none          off        
+    oxp_0bf9d028-2b4a-4bff-82a1-6eb5fcefd985/crypt/zone/oxz_crucible_pantry_f9e18694-fdff-46a3-b40d-570d43206f48     3cb3f346-9879-4023-b919-55c4172bbf23   in service    none      none          off        
+    oxp_0bf9d028-2b4a-4bff-82a1-6eb5fcefd985/crypt/zone/oxz_internal_dns_a00d8ae3-d1db-4aef-9174-3ff867af5e9e        c2d9b145-5e15-47be-a835-7e1f51f27679   in service    none      none          off        
+    oxp_0bf9d028-2b4a-4bff-82a1-6eb5fcefd985/crypt/zone/oxz_nexus_8ccafc1f-97f9-4da7-bb04-d346213387ce               dcc3603b-b160-42d9-a743-11075c3b6941   in service    none      none          off        
+    oxp_0bf9d028-2b4a-4bff-82a1-6eb5fcefd985/crypt/zone/oxz_ntp_a1797f1d-2d2a-4396-9ab5-044630b41c35                 5a70b3fe-9fad-4c17-982b-272b8595c2e8   in service    none      none          off        
+    oxp_0bf9d028-2b4a-4bff-82a1-6eb5fcefd985/crypt/debug                                                             4e4b2f99-dc01-4793-a37a-072d942da264   in service    100 GiB   none          gzip-9     
+    oxp_19293a1d-fddc-40a7-88a4-ccafdb6f66d3/crypt/debug                                                             8573903d-9610-4084-b0c6-ffcbb5d96c39   in service    100 GiB   none          gzip-9     
+    oxp_44484c44-477a-4676-8266-b98a00e80d79/crypt/debug                                                             540272e1-99d2-4d2e-9d3d-032014b0e6d9   in service    100 GiB   none          gzip-9     
+    oxp_79787cd4-92da-4de5-bfd8-30a635521e10/crypt/debug                                                             4adf2ef6-2694-4aac-aabe-688bca767092   in service    100 GiB   none          gzip-9     
+    oxp_9ae94c94-baae-477e-912a-60f0c4f3bd13/crypt/debug                                                             7e9d012a-6d8e-475e-805e-65985a66ffcd   in service    100 GiB   none          gzip-9     
+    oxp_af85eec8-36b3-4b88-966d-a717b9b58fe5/crypt/debug                                                             2189574d-9a73-4d25-858e-1084d57b59a8   in service    100 GiB   none          gzip-9     
+    oxp_ddfaaba3-dafe-4103-b868-e9843d29d346/crypt/debug                                                             3cf0580b-4e1d-4ff9-bc22-4dc51ca9a53b   in service    100 GiB   none          gzip-9     
+    oxp_ec458c3e-91ca-40f1-a2a3-3f4292c1f279/crypt/debug                                                             f499c5f8-b62f-493d-858a-8d33f7db81ff   in service    100 GiB   none          gzip-9     
+    oxp_f2fc7c4c-7966-449d-8ec3-5a70f460501d/crypt/debug                                                             c16ff3c0-3282-46de-a620-49c6b1e3f882   in service    100 GiB   none          gzip-9     
+    oxp_f635c28a-e5ca-4d22-ac94-d8f278a6ea0e/crypt/debug                                                             8dde6eee-f28e-4b55-8c11-525884ec81e5   in service    100 GiB   none          gzip-9     
++   oxp_19293a1d-fddc-40a7-88a4-ccafdb6f66d3/crypt/clickhouse_keeper                                                 882d4fee-d6d4-455f-9dc1-de3637cd29d0   in service    none      none          off        
++   oxp_19293a1d-fddc-40a7-88a4-ccafdb6f66d3/crypt/zone/oxz_clickhouse_keeper_e222f1c0-39ca-463a-88ad-ebfb6022fd1a   fbf9198e-996a-4194-af5b-c4e95ea4286d   in service    none      none          off        
 
 
     omicron zones generation 3 -> 4:
@@ -217,60 +217,60 @@ to:   blueprint 2886dab5-61a2-46b4-87af-bc7aeb44cccb
 
 
     datasets generation 3 -> 4:
-    -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
-    dataset name                                                                                                     dataset uuid                           quota     reservation   compression
-    -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
-    oxp_2a76ab1a-fb16-412d-93f9-b8cd9aa94e85/crucible                                                                c73b47ac-ad1f-4cd1-b449-f220b5ad8104   none      none          off        
-    oxp_2de2bf7e-c679-4b2b-b373-908e9d3ffbfc/crucible                                                                813c7aac-695b-49ce-8bc5-f4cdbfc04b38   none      none          off        
-    oxp_2f02a5c6-fcf5-4b5a-bc7d-7f65369918ba/crucible                                                                e5da836d-fffb-4435-8500-889c05b04689   none      none          off        
-    oxp_32041dbf-e58d-4f32-840d-923d3d3b68af/crucible                                                                9f8d056c-3e84-4474-b9c7-5b7a890a8a7b   none      none          off        
-    oxp_5f88adff-bb50-4dc1-bbfb-5a410c753ed5/crucible                                                                e93cfc01-9581-4f6e-b77c-eb6300ca6ffb   none      none          off        
-    oxp_74d64eb9-bf69-4782-af16-2d3a761ca171/crucible                                                                f54d6e59-67a1-458b-8e66-6dc3b2adb755   none      none          off        
-    oxp_b3c231c9-b2a5-4267-b4bf-9651881b91a5/crucible                                                                6604dd1b-5f21-475d-952a-894717512d1b   none      none          off        
-    oxp_bca80b95-8dca-4a3b-b24d-d44b6a9ff71b/crucible                                                                05cb728f-f6b9-4132-922d-fe249b1ba736   none      none          off        
-    oxp_db16345e-427a-4c8e-9032-17270f729308/crucible                                                                500f8d46-a32d-4bd1-8f2c-cb9d36822660   none      none          off        
-    oxp_e3b45593-8f0c-47b2-a381-802a7dad1f54/crucible                                                                66c673a1-e8d8-4863-b368-a7ea292555fb   none      none          off        
-    oxp_2a76ab1a-fb16-412d-93f9-b8cd9aa94e85/crypt/clickhouse_keeper                                                 6c5a6622-5f75-45a0-a9e8-4b513f5ac352   none      none          off        
-    oxp_2a76ab1a-fb16-412d-93f9-b8cd9aa94e85/crypt/clickhouse_server                                                 f8706468-85ac-4f9f-b41d-ff7c3a17ee5f   none      none          off        
-    oxp_2a76ab1a-fb16-412d-93f9-b8cd9aa94e85/crypt/internal_dns                                                      03de030d-d958-4ce5-86d2-368fa88e0bd8   none      none          off        
-    oxp_2a76ab1a-fb16-412d-93f9-b8cd9aa94e85/crypt/zone                                                              4c3c89bd-21cf-4986-b012-e89e4e1c1ac4   none      none          off        
-    oxp_2de2bf7e-c679-4b2b-b373-908e9d3ffbfc/crypt/zone                                                              ff4a77a2-528a-4c70-a5b9-f0093c95697b   none      none          off        
-    oxp_2f02a5c6-fcf5-4b5a-bc7d-7f65369918ba/crypt/zone                                                              676fc8c5-743b-48ca-99fd-2f2379c83890   none      none          off        
-    oxp_32041dbf-e58d-4f32-840d-923d3d3b68af/crypt/zone                                                              63362c89-4b42-4649-9ebe-43e19a5c0e51   none      none          off        
-    oxp_5f88adff-bb50-4dc1-bbfb-5a410c753ed5/crypt/zone                                                              6f83a31e-1181-418f-92b0-d0534e9ae6dd   none      none          off        
-    oxp_74d64eb9-bf69-4782-af16-2d3a761ca171/crypt/zone                                                              260ffd7d-4da5-4657-9158-ba7e1eae5971   none      none          off        
-    oxp_b3c231c9-b2a5-4267-b4bf-9651881b91a5/crypt/zone                                                              ed4c8570-3951-4f79-b27e-da73150609be   none      none          off        
-    oxp_bca80b95-8dca-4a3b-b24d-d44b6a9ff71b/crypt/zone                                                              e5dcf165-3ebb-40a2-b16f-a07b036a6533   none      none          off        
-    oxp_db16345e-427a-4c8e-9032-17270f729308/crypt/zone                                                              dd27be6b-214d-4022-a99d-2a7d12e7d8bb   none      none          off        
-    oxp_e3b45593-8f0c-47b2-a381-802a7dad1f54/crypt/zone                                                              b7500d95-2499-48fc-a7d6-2460d61e197a   none      none          off        
-    oxp_2a76ab1a-fb16-412d-93f9-b8cd9aa94e85/crypt/zone/oxz_clickhouse_keeper_7aa82b80-0c37-4f20-9398-bfce4707f327   0bf9cddb-1911-495b-8aad-09b7eea5fff4   none      none          off        
-    oxp_2a76ab1a-fb16-412d-93f9-b8cd9aa94e85/crypt/zone/oxz_clickhouse_server_812be70a-f237-47d5-ab49-f9450fe948db   292f53fc-27bb-4cc4-a61b-7d02c978149c   none      none          off        
-    oxp_32041dbf-e58d-4f32-840d-923d3d3b68af/crypt/zone/oxz_crucible_0b0e12fd-2800-4203-acb6-24e6e976271c            cf46ee68-f945-4af6-a647-4d612c1f05be   none      none          off        
-    oxp_2de2bf7e-c679-4b2b-b373-908e9d3ffbfc/crypt/zone/oxz_crucible_1a02d419-10c4-4326-b34e-eb2b1bd90bd7            2a439799-3f16-46df-ba1b-7ea29edd392d   none      none          off        
-    oxp_2a76ab1a-fb16-412d-93f9-b8cd9aa94e85/crypt/zone/oxz_crucible_56e18c31-f630-4643-ad5c-1fede34f35de            c30be90e-20cf-46c6-bb4a-b65d2c407878   none      none          off        
-    oxp_b3c231c9-b2a5-4267-b4bf-9651881b91a5/crypt/zone/oxz_crucible_5ea86015-8f62-40aa-b3b2-c659f17ee510            6289ea03-b2c9-4470-b7ba-b935450aa764   none      none          off        
-    oxp_5f88adff-bb50-4dc1-bbfb-5a410c753ed5/crypt/zone/oxz_crucible_78965849-e6e3-4250-a66a-dc50512fad34            43b36ba3-e516-4732-be8b-8cd2ca9de93c   none      none          off        
-    oxp_74d64eb9-bf69-4782-af16-2d3a761ca171/crypt/zone/oxz_crucible_90c484e5-69d3-4636-9c64-6a878f593d33            7cc8018e-323f-4d35-bb33-fcf557b9dace   none      none          off        
-    oxp_db16345e-427a-4c8e-9032-17270f729308/crypt/zone/oxz_crucible_a3901043-fa2a-4ef7-a40e-6ef0e5fd189f            88fd4e5a-50fd-43c7-8a75-0ad4376bd564   none      none          off        
-    oxp_2f02a5c6-fcf5-4b5a-bc7d-7f65369918ba/crypt/zone/oxz_crucible_be9fd98a-6422-4890-a32b-42d42d1c8957            932cbb0d-b1d0-423d-87b6-9dce8ddb6338   none      none          off        
-    oxp_e3b45593-8f0c-47b2-a381-802a7dad1f54/crypt/zone/oxz_crucible_bf71d1a8-9e65-479d-8920-0be8e3422ac5            fd0ce816-4da0-4490-be32-4d38fb78c13c   none      none          off        
-    oxp_bca80b95-8dca-4a3b-b24d-d44b6a9ff71b/crypt/zone/oxz_crucible_eb4176ea-456b-48f6-b284-7b76da0bf4a1            704ea6b5-0ffc-443f-ae8a-482666f8277c   none      none          off        
-    oxp_2a76ab1a-fb16-412d-93f9-b8cd9aa94e85/crypt/zone/oxz_crucible_pantry_417c97a4-fe25-439d-8359-3f7062981923     8957a276-6d4e-4c58-a856-d7c5433806e1   none      none          off        
-    oxp_2a76ab1a-fb16-412d-93f9-b8cd9aa94e85/crypt/zone/oxz_internal_dns_f2bbaa79-0eab-4b91-a404-dad4c19b58c2        fe0f566f-3cff-43ef-960c-649c27746c56   none      none          off        
-    oxp_2a76ab1a-fb16-412d-93f9-b8cd9aa94e85/crypt/zone/oxz_nexus_33ba37c4-2535-4095-a7e9-c69937fc584d               77d0cd16-b6e3-484d-962f-0477cd242482   none      none          off        
-    oxp_2a76ab1a-fb16-412d-93f9-b8cd9aa94e85/crypt/zone/oxz_ntp_47eab17a-4dd4-4467-90b2-f643f465cf34                 4eaf1849-1fe4-415c-bdc7-4cc04cac20ce   none      none          off        
-    oxp_2a76ab1a-fb16-412d-93f9-b8cd9aa94e85/crypt/debug                                                             c5b8f4f9-bd10-45b8-a9f3-93adf1402ecc   100 GiB   none          gzip-9     
-    oxp_2de2bf7e-c679-4b2b-b373-908e9d3ffbfc/crypt/debug                                                             43abf982-d457-46d1-8566-8047d2a78a41   100 GiB   none          gzip-9     
-    oxp_2f02a5c6-fcf5-4b5a-bc7d-7f65369918ba/crypt/debug                                                             1b6a1722-d9f7-48ea-b351-5bc8bad4fd07   100 GiB   none          gzip-9     
-    oxp_32041dbf-e58d-4f32-840d-923d3d3b68af/crypt/debug                                                             8be43fb0-00e7-4748-9a1a-ace9772d8a83   100 GiB   none          gzip-9     
-    oxp_5f88adff-bb50-4dc1-bbfb-5a410c753ed5/crypt/debug                                                             2ccb3aa9-f0ef-4fd4-9fd7-43b4a88b8d6b   100 GiB   none          gzip-9     
-    oxp_74d64eb9-bf69-4782-af16-2d3a761ca171/crypt/debug                                                             56759eb6-69e9-46a3-b44c-fc748cd506aa   100 GiB   none          gzip-9     
-    oxp_b3c231c9-b2a5-4267-b4bf-9651881b91a5/crypt/debug                                                             76fffbd2-9c74-46b5-8033-f442be1256f5   100 GiB   none          gzip-9     
-    oxp_bca80b95-8dca-4a3b-b24d-d44b6a9ff71b/crypt/debug                                                             c13a3d71-1241-42d1-95a8-d720c20ee2c4   100 GiB   none          gzip-9     
-    oxp_db16345e-427a-4c8e-9032-17270f729308/crypt/debug                                                             f030ef33-cad2-4760-9431-1907b797161b   100 GiB   none          gzip-9     
-    oxp_e3b45593-8f0c-47b2-a381-802a7dad1f54/crypt/debug                                                             947b2823-3dca-4b56-9324-f476e2c1c6da   100 GiB   none          gzip-9     
-+   oxp_2de2bf7e-c679-4b2b-b373-908e9d3ffbfc/crypt/clickhouse_keeper                                                 f6464cd8-84bc-4bae-8386-c0a5a82aab95   none      none          off        
-+   oxp_2de2bf7e-c679-4b2b-b373-908e9d3ffbfc/crypt/zone/oxz_clickhouse_keeper_60cf5091-670b-48c9-a729-b82c5e7683ca   8ee3f0bb-d102-4a00-af81-72e2f284878b   none      none          off        
+    ---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
+    dataset name                                                                                                     dataset id                             disposition   quota     reservation   compression
+    ---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
+    oxp_2a76ab1a-fb16-412d-93f9-b8cd9aa94e85/crucible                                                                c73b47ac-ad1f-4cd1-b449-f220b5ad8104   in service    none      none          off        
+    oxp_2de2bf7e-c679-4b2b-b373-908e9d3ffbfc/crucible                                                                813c7aac-695b-49ce-8bc5-f4cdbfc04b38   in service    none      none          off        
+    oxp_2f02a5c6-fcf5-4b5a-bc7d-7f65369918ba/crucible                                                                e5da836d-fffb-4435-8500-889c05b04689   in service    none      none          off        
+    oxp_32041dbf-e58d-4f32-840d-923d3d3b68af/crucible                                                                9f8d056c-3e84-4474-b9c7-5b7a890a8a7b   in service    none      none          off        
+    oxp_5f88adff-bb50-4dc1-bbfb-5a410c753ed5/crucible                                                                e93cfc01-9581-4f6e-b77c-eb6300ca6ffb   in service    none      none          off        
+    oxp_74d64eb9-bf69-4782-af16-2d3a761ca171/crucible                                                                f54d6e59-67a1-458b-8e66-6dc3b2adb755   in service    none      none          off        
+    oxp_b3c231c9-b2a5-4267-b4bf-9651881b91a5/crucible                                                                6604dd1b-5f21-475d-952a-894717512d1b   in service    none      none          off        
+    oxp_bca80b95-8dca-4a3b-b24d-d44b6a9ff71b/crucible                                                                05cb728f-f6b9-4132-922d-fe249b1ba736   in service    none      none          off        
+    oxp_db16345e-427a-4c8e-9032-17270f729308/crucible                                                                500f8d46-a32d-4bd1-8f2c-cb9d36822660   in service    none      none          off        
+    oxp_e3b45593-8f0c-47b2-a381-802a7dad1f54/crucible                                                                66c673a1-e8d8-4863-b368-a7ea292555fb   in service    none      none          off        
+    oxp_2a76ab1a-fb16-412d-93f9-b8cd9aa94e85/crypt/clickhouse_keeper                                                 6c5a6622-5f75-45a0-a9e8-4b513f5ac352   in service    none      none          off        
+    oxp_2a76ab1a-fb16-412d-93f9-b8cd9aa94e85/crypt/clickhouse_server                                                 f8706468-85ac-4f9f-b41d-ff7c3a17ee5f   in service    none      none          off        
+    oxp_2a76ab1a-fb16-412d-93f9-b8cd9aa94e85/crypt/internal_dns                                                      03de030d-d958-4ce5-86d2-368fa88e0bd8   in service    none      none          off        
+    oxp_2a76ab1a-fb16-412d-93f9-b8cd9aa94e85/crypt/zone                                                              4c3c89bd-21cf-4986-b012-e89e4e1c1ac4   in service    none      none          off        
+    oxp_2de2bf7e-c679-4b2b-b373-908e9d3ffbfc/crypt/zone                                                              ff4a77a2-528a-4c70-a5b9-f0093c95697b   in service    none      none          off        
+    oxp_2f02a5c6-fcf5-4b5a-bc7d-7f65369918ba/crypt/zone                                                              676fc8c5-743b-48ca-99fd-2f2379c83890   in service    none      none          off        
+    oxp_32041dbf-e58d-4f32-840d-923d3d3b68af/crypt/zone                                                              63362c89-4b42-4649-9ebe-43e19a5c0e51   in service    none      none          off        
+    oxp_5f88adff-bb50-4dc1-bbfb-5a410c753ed5/crypt/zone                                                              6f83a31e-1181-418f-92b0-d0534e9ae6dd   in service    none      none          off        
+    oxp_74d64eb9-bf69-4782-af16-2d3a761ca171/crypt/zone                                                              260ffd7d-4da5-4657-9158-ba7e1eae5971   in service    none      none          off        
+    oxp_b3c231c9-b2a5-4267-b4bf-9651881b91a5/crypt/zone                                                              ed4c8570-3951-4f79-b27e-da73150609be   in service    none      none          off        
+    oxp_bca80b95-8dca-4a3b-b24d-d44b6a9ff71b/crypt/zone                                                              e5dcf165-3ebb-40a2-b16f-a07b036a6533   in service    none      none          off        
+    oxp_db16345e-427a-4c8e-9032-17270f729308/crypt/zone                                                              dd27be6b-214d-4022-a99d-2a7d12e7d8bb   in service    none      none          off        
+    oxp_e3b45593-8f0c-47b2-a381-802a7dad1f54/crypt/zone                                                              b7500d95-2499-48fc-a7d6-2460d61e197a   in service    none      none          off        
+    oxp_2a76ab1a-fb16-412d-93f9-b8cd9aa94e85/crypt/zone/oxz_clickhouse_keeper_7aa82b80-0c37-4f20-9398-bfce4707f327   0bf9cddb-1911-495b-8aad-09b7eea5fff4   in service    none      none          off        
+    oxp_2a76ab1a-fb16-412d-93f9-b8cd9aa94e85/crypt/zone/oxz_clickhouse_server_812be70a-f237-47d5-ab49-f9450fe948db   292f53fc-27bb-4cc4-a61b-7d02c978149c   in service    none      none          off        
+    oxp_32041dbf-e58d-4f32-840d-923d3d3b68af/crypt/zone/oxz_crucible_0b0e12fd-2800-4203-acb6-24e6e976271c            cf46ee68-f945-4af6-a647-4d612c1f05be   in service    none      none          off        
+    oxp_2de2bf7e-c679-4b2b-b373-908e9d3ffbfc/crypt/zone/oxz_crucible_1a02d419-10c4-4326-b34e-eb2b1bd90bd7            2a439799-3f16-46df-ba1b-7ea29edd392d   in service    none      none          off        
+    oxp_2a76ab1a-fb16-412d-93f9-b8cd9aa94e85/crypt/zone/oxz_crucible_56e18c31-f630-4643-ad5c-1fede34f35de            c30be90e-20cf-46c6-bb4a-b65d2c407878   in service    none      none          off        
+    oxp_b3c231c9-b2a5-4267-b4bf-9651881b91a5/crypt/zone/oxz_crucible_5ea86015-8f62-40aa-b3b2-c659f17ee510            6289ea03-b2c9-4470-b7ba-b935450aa764   in service    none      none          off        
+    oxp_5f88adff-bb50-4dc1-bbfb-5a410c753ed5/crypt/zone/oxz_crucible_78965849-e6e3-4250-a66a-dc50512fad34            43b36ba3-e516-4732-be8b-8cd2ca9de93c   in service    none      none          off        
+    oxp_74d64eb9-bf69-4782-af16-2d3a761ca171/crypt/zone/oxz_crucible_90c484e5-69d3-4636-9c64-6a878f593d33            7cc8018e-323f-4d35-bb33-fcf557b9dace   in service    none      none          off        
+    oxp_db16345e-427a-4c8e-9032-17270f729308/crypt/zone/oxz_crucible_a3901043-fa2a-4ef7-a40e-6ef0e5fd189f            88fd4e5a-50fd-43c7-8a75-0ad4376bd564   in service    none      none          off        
+    oxp_2f02a5c6-fcf5-4b5a-bc7d-7f65369918ba/crypt/zone/oxz_crucible_be9fd98a-6422-4890-a32b-42d42d1c8957            932cbb0d-b1d0-423d-87b6-9dce8ddb6338   in service    none      none          off        
+    oxp_e3b45593-8f0c-47b2-a381-802a7dad1f54/crypt/zone/oxz_crucible_bf71d1a8-9e65-479d-8920-0be8e3422ac5            fd0ce816-4da0-4490-be32-4d38fb78c13c   in service    none      none          off        
+    oxp_bca80b95-8dca-4a3b-b24d-d44b6a9ff71b/crypt/zone/oxz_crucible_eb4176ea-456b-48f6-b284-7b76da0bf4a1            704ea6b5-0ffc-443f-ae8a-482666f8277c   in service    none      none          off        
+    oxp_2a76ab1a-fb16-412d-93f9-b8cd9aa94e85/crypt/zone/oxz_crucible_pantry_417c97a4-fe25-439d-8359-3f7062981923     8957a276-6d4e-4c58-a856-d7c5433806e1   in service    none      none          off        
+    oxp_2a76ab1a-fb16-412d-93f9-b8cd9aa94e85/crypt/zone/oxz_internal_dns_f2bbaa79-0eab-4b91-a404-dad4c19b58c2        fe0f566f-3cff-43ef-960c-649c27746c56   in service    none      none          off        
+    oxp_2a76ab1a-fb16-412d-93f9-b8cd9aa94e85/crypt/zone/oxz_nexus_33ba37c4-2535-4095-a7e9-c69937fc584d               77d0cd16-b6e3-484d-962f-0477cd242482   in service    none      none          off        
+    oxp_2a76ab1a-fb16-412d-93f9-b8cd9aa94e85/crypt/zone/oxz_ntp_47eab17a-4dd4-4467-90b2-f643f465cf34                 4eaf1849-1fe4-415c-bdc7-4cc04cac20ce   in service    none      none          off        
+    oxp_2a76ab1a-fb16-412d-93f9-b8cd9aa94e85/crypt/debug                                                             c5b8f4f9-bd10-45b8-a9f3-93adf1402ecc   in service    100 GiB   none          gzip-9     
+    oxp_2de2bf7e-c679-4b2b-b373-908e9d3ffbfc/crypt/debug                                                             43abf982-d457-46d1-8566-8047d2a78a41   in service    100 GiB   none          gzip-9     
+    oxp_2f02a5c6-fcf5-4b5a-bc7d-7f65369918ba/crypt/debug                                                             1b6a1722-d9f7-48ea-b351-5bc8bad4fd07   in service    100 GiB   none          gzip-9     
+    oxp_32041dbf-e58d-4f32-840d-923d3d3b68af/crypt/debug                                                             8be43fb0-00e7-4748-9a1a-ace9772d8a83   in service    100 GiB   none          gzip-9     
+    oxp_5f88adff-bb50-4dc1-bbfb-5a410c753ed5/crypt/debug                                                             2ccb3aa9-f0ef-4fd4-9fd7-43b4a88b8d6b   in service    100 GiB   none          gzip-9     
+    oxp_74d64eb9-bf69-4782-af16-2d3a761ca171/crypt/debug                                                             56759eb6-69e9-46a3-b44c-fc748cd506aa   in service    100 GiB   none          gzip-9     
+    oxp_b3c231c9-b2a5-4267-b4bf-9651881b91a5/crypt/debug                                                             76fffbd2-9c74-46b5-8033-f442be1256f5   in service    100 GiB   none          gzip-9     
+    oxp_bca80b95-8dca-4a3b-b24d-d44b6a9ff71b/crypt/debug                                                             c13a3d71-1241-42d1-95a8-d720c20ee2c4   in service    100 GiB   none          gzip-9     
+    oxp_db16345e-427a-4c8e-9032-17270f729308/crypt/debug                                                             f030ef33-cad2-4760-9431-1907b797161b   in service    100 GiB   none          gzip-9     
+    oxp_e3b45593-8f0c-47b2-a381-802a7dad1f54/crypt/debug                                                             947b2823-3dca-4b56-9324-f476e2c1c6da   in service    100 GiB   none          gzip-9     
++   oxp_2de2bf7e-c679-4b2b-b373-908e9d3ffbfc/crypt/clickhouse_keeper                                                 f6464cd8-84bc-4bae-8386-c0a5a82aab95   in service    none      none          off        
++   oxp_2de2bf7e-c679-4b2b-b373-908e9d3ffbfc/crypt/zone/oxz_clickhouse_keeper_60cf5091-670b-48c9-a729-b82c5e7683ca   8ee3f0bb-d102-4a00-af81-72e2f284878b   in service    none      none          off        
 
 
     omicron zones generation 3 -> 4:

--- a/nexus/reconfigurator/planning/tests/output/planner_deploy_all_keeper_nodes_5_6.txt
+++ b/nexus/reconfigurator/planning/tests/output/planner_deploy_all_keeper_nodes_5_6.txt
@@ -22,58 +22,58 @@ to:   blueprint cb39be9d-5476-44fa-9edf-9938376219ef
 
 
     datasets at generation 3:
-    -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
-    dataset name                                                                                                     dataset uuid                           quota     reservation   compression
-    -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
-    oxp_60e6b021-79d6-4a6b-917c-6637e0769558/crucible                                                                723e4ec2-5f4a-48a9-a6a1-cb523dc47d3d   none      none          off        
-    oxp_71a07ac0-d24e-446c-a202-1998e7f6ac8c/crucible                                                                b2796e6b-ad7d-41a5-82a6-947b96e42d47   none      none          off        
-    oxp_736d4cab-c262-485e-89c2-07e6543f0855/crucible                                                                c993b4da-bea9-4010-a8d6-17d733698f07   none      none          off        
-    oxp_8ae56ca0-709d-4b8f-9869-51b62b542eef/crucible                                                                4f497ece-88c1-4557-a8b4-0e990f9941a9   none      none          off        
-    oxp_8e0bcc4f-0799-450c-a0ad-80c1637f59e3/crucible                                                                43a16c22-e79a-4bea-bcf6-682099a728dd   none      none          off        
-    oxp_8eeebb8e-6db6-43e8-a429-d26dde99882c/crucible                                                                b6bbb45b-68fc-4fa5-86cc-b59b0f797fb2   none      none          off        
-    oxp_a3e8de5b-c47a-49c0-b698-4d6955e1327f/crucible                                                                e4838ed0-304f-475e-a282-9f644f2ba3e5   none      none          off        
-    oxp_b32fa3da-4dec-4237-9776-e1a57ba15a21/crucible                                                                046f2730-768d-4bcc-8ebf-4b5f5597151c   none      none          off        
-    oxp_e9c238f6-87a3-4087-8ba4-aa594a82d012/crucible                                                                0830fc6d-ed82-41de-9389-0bd3fd4677ea   none      none          off        
-    oxp_fbf997ef-52d3-438a-b036-b9117322e569/crucible                                                                d9662141-585e-4e18-a461-9627097f02a2   none      none          off        
-    oxp_60e6b021-79d6-4a6b-917c-6637e0769558/crypt/clickhouse                                                        a4f84c49-4303-411f-bb1b-08877d828946   none      none          off        
-    oxp_60e6b021-79d6-4a6b-917c-6637e0769558/crypt/clickhouse_keeper                                                 04ee4b4b-fcbe-4224-86fd-30144a4f2592   none      none          off        
-    oxp_60e6b021-79d6-4a6b-917c-6637e0769558/crypt/internal_dns                                                      2edca3dc-a0e5-4d34-b8a2-065be4cca767   none      none          off        
-    oxp_60e6b021-79d6-4a6b-917c-6637e0769558/crypt/zone                                                              87cd9f37-3de3-457c-9412-d0dc5678eda8   none      none          off        
-    oxp_71a07ac0-d24e-446c-a202-1998e7f6ac8c/crypt/zone                                                              3a164f36-1f53-45b3-b190-ad8a2817bc69   none      none          off        
-    oxp_736d4cab-c262-485e-89c2-07e6543f0855/crypt/zone                                                              407556ed-09ab-430e-bc8f-8291b8f8c8fe   none      none          off        
-    oxp_8ae56ca0-709d-4b8f-9869-51b62b542eef/crypt/zone                                                              99d57d61-f12a-4b56-8114-86ba92d07649   none      none          off        
-    oxp_8e0bcc4f-0799-450c-a0ad-80c1637f59e3/crypt/zone                                                              da1eb596-8764-4268-a60b-f4705b4f615b   none      none          off        
-    oxp_8eeebb8e-6db6-43e8-a429-d26dde99882c/crypt/zone                                                              d555bf19-887c-48d2-8144-47c2eac9a9e8   none      none          off        
-    oxp_a3e8de5b-c47a-49c0-b698-4d6955e1327f/crypt/zone                                                              9785e77a-9422-4b46-a4ae-8b9a155eb121   none      none          off        
-    oxp_b32fa3da-4dec-4237-9776-e1a57ba15a21/crypt/zone                                                              1192a37c-a871-4c48-905d-03c3d6035bdc   none      none          off        
-    oxp_e9c238f6-87a3-4087-8ba4-aa594a82d012/crypt/zone                                                              7bf1c7ec-5465-4bfd-b1d9-939f05336012   none      none          off        
-    oxp_fbf997ef-52d3-438a-b036-b9117322e569/crypt/zone                                                              be526b44-2c78-49ec-8ab4-73e161e27f22   none      none          off        
-    oxp_60e6b021-79d6-4a6b-917c-6637e0769558/crypt/zone/oxz_clickhouse_35e8d4b6-ea92-45cf-923c-3f566a0b1fe5          cd7e5c3a-2328-4568-b8f8-cf349f0cdd12   none      none          off        
-    oxp_60e6b021-79d6-4a6b-917c-6637e0769558/crypt/zone/oxz_clickhouse_keeper_dd5ab8b1-e6e7-40e0-9ea6-b6a16f485b52   a51fb98f-3fff-4c0a-82f0-7a4aad82096b   none      none          off        
-    oxp_e9c238f6-87a3-4087-8ba4-aa594a82d012/crypt/zone/oxz_crucible_044d074d-7905-4024-82ff-68d76221db68            98fd0f42-7337-4ce7-814e-f988304b8873   none      none          off        
-    oxp_71a07ac0-d24e-446c-a202-1998e7f6ac8c/crypt/zone/oxz_crucible_28826473-ac0b-41ea-8c54-72b782db1bcb            bbda84d8-c4ca-4f52-a766-681872fa06f0   none      none          off        
-    oxp_fbf997ef-52d3-438a-b036-b9117322e569/crypt/zone/oxz_crucible_2d3ff798-dda9-4ccf-8f91-070a20f06d55            e9c77dbd-c56a-404c-8ff9-6504b3f92556   none      none          off        
-    oxp_8eeebb8e-6db6-43e8-a429-d26dde99882c/crypt/zone/oxz_crucible_7538d29b-69f2-43e8-8509-505b25cb1c84            19110f8a-6267-41ed-ac7d-539cd0fe3511   none      none          off        
-    oxp_8ae56ca0-709d-4b8f-9869-51b62b542eef/crypt/zone/oxz_crucible_8234bbd2-4b31-4f6b-8dcc-4744b1d14e64            0fe4f647-ffd2-4845-805a-c069096560ee   none      none          off        
-    oxp_8e0bcc4f-0799-450c-a0ad-80c1637f59e3/crypt/zone/oxz_crucible_85358363-cee8-4bc3-af66-4d89e5cd714f            a1daa561-2448-4afb-8233-ec149d2bd7f4   none      none          off        
-    oxp_736d4cab-c262-485e-89c2-07e6543f0855/crypt/zone/oxz_crucible_9b58d04f-85bf-4f5e-8c6a-5d855062d5c4            69812f66-4b59-4590-9e1f-bce3e93b3b08   none      none          off        
-    oxp_60e6b021-79d6-4a6b-917c-6637e0769558/crypt/zone/oxz_crucible_e7da0aec-c6b6-4a56-9525-35385b9c62a2            36e58025-88e2-4eb9-8af0-ed9a98dda1b9   none      none          off        
-    oxp_a3e8de5b-c47a-49c0-b698-4d6955e1327f/crypt/zone/oxz_crucible_f3f977cc-7eca-4491-9b07-82b6284eb169            482fad9a-d83f-4025-8f0b-d3adea6ae2cf   none      none          off        
-    oxp_b32fa3da-4dec-4237-9776-e1a57ba15a21/crypt/zone/oxz_crucible_fef381d2-8368-4a2d-96a1-c956ed011f7b            b1937368-4019-40c4-af02-9811dc7eb143   none      none          off        
-    oxp_60e6b021-79d6-4a6b-917c-6637e0769558/crypt/zone/oxz_crucible_pantry_fe63bfd3-3128-4675-8118-cf6968293471     e3b31ef3-6b54-4901-aec4-0c672de62c7f   none      none          off        
-    oxp_60e6b021-79d6-4a6b-917c-6637e0769558/crypt/zone/oxz_internal_dns_b6b0689e-ef48-484d-b3c7-3c596edad20c        501e0672-2897-4992-8911-600e0283f04c   none      none          off        
-    oxp_60e6b021-79d6-4a6b-917c-6637e0769558/crypt/zone/oxz_nexus_46ecde76-fef7-4394-93dd-d22b003148e9               53655959-866b-4fee-bcf9-1e35504ad625   none      none          off        
-    oxp_60e6b021-79d6-4a6b-917c-6637e0769558/crypt/zone/oxz_ntp_4d009155-44fb-45b9-afed-f89cb57ce8da                 0590facf-202a-463b-81be-b6e88c47da76   none      none          off        
-    oxp_60e6b021-79d6-4a6b-917c-6637e0769558/crypt/debug                                                             8f7f16c1-d9fb-4405-9dcf-68bfbaa7bf8c   100 GiB   none          gzip-9     
-    oxp_71a07ac0-d24e-446c-a202-1998e7f6ac8c/crypt/debug                                                             6482f332-801a-473f-a77d-e07d30e2a5b7   100 GiB   none          gzip-9     
-    oxp_736d4cab-c262-485e-89c2-07e6543f0855/crypt/debug                                                             0bb0541f-2c64-487b-a8af-162454207504   100 GiB   none          gzip-9     
-    oxp_8ae56ca0-709d-4b8f-9869-51b62b542eef/crypt/debug                                                             902a6889-244f-4b67-baa4-b245f3d622c8   100 GiB   none          gzip-9     
-    oxp_8e0bcc4f-0799-450c-a0ad-80c1637f59e3/crypt/debug                                                             667ffd3c-6735-4b50-bc3b-cfa32fcc811e   100 GiB   none          gzip-9     
-    oxp_8eeebb8e-6db6-43e8-a429-d26dde99882c/crypt/debug                                                             cf48ba87-a4bb-435f-999b-bca46cfd6a89   100 GiB   none          gzip-9     
-    oxp_a3e8de5b-c47a-49c0-b698-4d6955e1327f/crypt/debug                                                             7d64cab3-7311-4519-ae4a-1af6b320fa9b   100 GiB   none          gzip-9     
-    oxp_b32fa3da-4dec-4237-9776-e1a57ba15a21/crypt/debug                                                             d3e957fd-5f26-498a-8fa3-deaea4dc5820   100 GiB   none          gzip-9     
-    oxp_e9c238f6-87a3-4087-8ba4-aa594a82d012/crypt/debug                                                             4da77f4a-5e41-4604-af30-8cf568c38428   100 GiB   none          gzip-9     
-    oxp_fbf997ef-52d3-438a-b036-b9117322e569/crypt/debug                                                             03935cb1-ce06-4594-b2fe-23e127d1cd9d   100 GiB   none          gzip-9     
+    ---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
+    dataset name                                                                                                     dataset id                             disposition   quota     reservation   compression
+    ---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
+    oxp_60e6b021-79d6-4a6b-917c-6637e0769558/crucible                                                                723e4ec2-5f4a-48a9-a6a1-cb523dc47d3d   in service    none      none          off        
+    oxp_71a07ac0-d24e-446c-a202-1998e7f6ac8c/crucible                                                                b2796e6b-ad7d-41a5-82a6-947b96e42d47   in service    none      none          off        
+    oxp_736d4cab-c262-485e-89c2-07e6543f0855/crucible                                                                c993b4da-bea9-4010-a8d6-17d733698f07   in service    none      none          off        
+    oxp_8ae56ca0-709d-4b8f-9869-51b62b542eef/crucible                                                                4f497ece-88c1-4557-a8b4-0e990f9941a9   in service    none      none          off        
+    oxp_8e0bcc4f-0799-450c-a0ad-80c1637f59e3/crucible                                                                43a16c22-e79a-4bea-bcf6-682099a728dd   in service    none      none          off        
+    oxp_8eeebb8e-6db6-43e8-a429-d26dde99882c/crucible                                                                b6bbb45b-68fc-4fa5-86cc-b59b0f797fb2   in service    none      none          off        
+    oxp_a3e8de5b-c47a-49c0-b698-4d6955e1327f/crucible                                                                e4838ed0-304f-475e-a282-9f644f2ba3e5   in service    none      none          off        
+    oxp_b32fa3da-4dec-4237-9776-e1a57ba15a21/crucible                                                                046f2730-768d-4bcc-8ebf-4b5f5597151c   in service    none      none          off        
+    oxp_e9c238f6-87a3-4087-8ba4-aa594a82d012/crucible                                                                0830fc6d-ed82-41de-9389-0bd3fd4677ea   in service    none      none          off        
+    oxp_fbf997ef-52d3-438a-b036-b9117322e569/crucible                                                                d9662141-585e-4e18-a461-9627097f02a2   in service    none      none          off        
+    oxp_60e6b021-79d6-4a6b-917c-6637e0769558/crypt/clickhouse                                                        a4f84c49-4303-411f-bb1b-08877d828946   in service    none      none          off        
+    oxp_60e6b021-79d6-4a6b-917c-6637e0769558/crypt/clickhouse_keeper                                                 04ee4b4b-fcbe-4224-86fd-30144a4f2592   in service    none      none          off        
+    oxp_60e6b021-79d6-4a6b-917c-6637e0769558/crypt/internal_dns                                                      2edca3dc-a0e5-4d34-b8a2-065be4cca767   in service    none      none          off        
+    oxp_60e6b021-79d6-4a6b-917c-6637e0769558/crypt/zone                                                              87cd9f37-3de3-457c-9412-d0dc5678eda8   in service    none      none          off        
+    oxp_71a07ac0-d24e-446c-a202-1998e7f6ac8c/crypt/zone                                                              3a164f36-1f53-45b3-b190-ad8a2817bc69   in service    none      none          off        
+    oxp_736d4cab-c262-485e-89c2-07e6543f0855/crypt/zone                                                              407556ed-09ab-430e-bc8f-8291b8f8c8fe   in service    none      none          off        
+    oxp_8ae56ca0-709d-4b8f-9869-51b62b542eef/crypt/zone                                                              99d57d61-f12a-4b56-8114-86ba92d07649   in service    none      none          off        
+    oxp_8e0bcc4f-0799-450c-a0ad-80c1637f59e3/crypt/zone                                                              da1eb596-8764-4268-a60b-f4705b4f615b   in service    none      none          off        
+    oxp_8eeebb8e-6db6-43e8-a429-d26dde99882c/crypt/zone                                                              d555bf19-887c-48d2-8144-47c2eac9a9e8   in service    none      none          off        
+    oxp_a3e8de5b-c47a-49c0-b698-4d6955e1327f/crypt/zone                                                              9785e77a-9422-4b46-a4ae-8b9a155eb121   in service    none      none          off        
+    oxp_b32fa3da-4dec-4237-9776-e1a57ba15a21/crypt/zone                                                              1192a37c-a871-4c48-905d-03c3d6035bdc   in service    none      none          off        
+    oxp_e9c238f6-87a3-4087-8ba4-aa594a82d012/crypt/zone                                                              7bf1c7ec-5465-4bfd-b1d9-939f05336012   in service    none      none          off        
+    oxp_fbf997ef-52d3-438a-b036-b9117322e569/crypt/zone                                                              be526b44-2c78-49ec-8ab4-73e161e27f22   in service    none      none          off        
+    oxp_60e6b021-79d6-4a6b-917c-6637e0769558/crypt/zone/oxz_clickhouse_35e8d4b6-ea92-45cf-923c-3f566a0b1fe5          cd7e5c3a-2328-4568-b8f8-cf349f0cdd12   in service    none      none          off        
+    oxp_60e6b021-79d6-4a6b-917c-6637e0769558/crypt/zone/oxz_clickhouse_keeper_dd5ab8b1-e6e7-40e0-9ea6-b6a16f485b52   a51fb98f-3fff-4c0a-82f0-7a4aad82096b   in service    none      none          off        
+    oxp_e9c238f6-87a3-4087-8ba4-aa594a82d012/crypt/zone/oxz_crucible_044d074d-7905-4024-82ff-68d76221db68            98fd0f42-7337-4ce7-814e-f988304b8873   in service    none      none          off        
+    oxp_71a07ac0-d24e-446c-a202-1998e7f6ac8c/crypt/zone/oxz_crucible_28826473-ac0b-41ea-8c54-72b782db1bcb            bbda84d8-c4ca-4f52-a766-681872fa06f0   in service    none      none          off        
+    oxp_fbf997ef-52d3-438a-b036-b9117322e569/crypt/zone/oxz_crucible_2d3ff798-dda9-4ccf-8f91-070a20f06d55            e9c77dbd-c56a-404c-8ff9-6504b3f92556   in service    none      none          off        
+    oxp_8eeebb8e-6db6-43e8-a429-d26dde99882c/crypt/zone/oxz_crucible_7538d29b-69f2-43e8-8509-505b25cb1c84            19110f8a-6267-41ed-ac7d-539cd0fe3511   in service    none      none          off        
+    oxp_8ae56ca0-709d-4b8f-9869-51b62b542eef/crypt/zone/oxz_crucible_8234bbd2-4b31-4f6b-8dcc-4744b1d14e64            0fe4f647-ffd2-4845-805a-c069096560ee   in service    none      none          off        
+    oxp_8e0bcc4f-0799-450c-a0ad-80c1637f59e3/crypt/zone/oxz_crucible_85358363-cee8-4bc3-af66-4d89e5cd714f            a1daa561-2448-4afb-8233-ec149d2bd7f4   in service    none      none          off        
+    oxp_736d4cab-c262-485e-89c2-07e6543f0855/crypt/zone/oxz_crucible_9b58d04f-85bf-4f5e-8c6a-5d855062d5c4            69812f66-4b59-4590-9e1f-bce3e93b3b08   in service    none      none          off        
+    oxp_60e6b021-79d6-4a6b-917c-6637e0769558/crypt/zone/oxz_crucible_e7da0aec-c6b6-4a56-9525-35385b9c62a2            36e58025-88e2-4eb9-8af0-ed9a98dda1b9   in service    none      none          off        
+    oxp_a3e8de5b-c47a-49c0-b698-4d6955e1327f/crypt/zone/oxz_crucible_f3f977cc-7eca-4491-9b07-82b6284eb169            482fad9a-d83f-4025-8f0b-d3adea6ae2cf   in service    none      none          off        
+    oxp_b32fa3da-4dec-4237-9776-e1a57ba15a21/crypt/zone/oxz_crucible_fef381d2-8368-4a2d-96a1-c956ed011f7b            b1937368-4019-40c4-af02-9811dc7eb143   in service    none      none          off        
+    oxp_60e6b021-79d6-4a6b-917c-6637e0769558/crypt/zone/oxz_crucible_pantry_fe63bfd3-3128-4675-8118-cf6968293471     e3b31ef3-6b54-4901-aec4-0c672de62c7f   in service    none      none          off        
+    oxp_60e6b021-79d6-4a6b-917c-6637e0769558/crypt/zone/oxz_internal_dns_b6b0689e-ef48-484d-b3c7-3c596edad20c        501e0672-2897-4992-8911-600e0283f04c   in service    none      none          off        
+    oxp_60e6b021-79d6-4a6b-917c-6637e0769558/crypt/zone/oxz_nexus_46ecde76-fef7-4394-93dd-d22b003148e9               53655959-866b-4fee-bcf9-1e35504ad625   in service    none      none          off        
+    oxp_60e6b021-79d6-4a6b-917c-6637e0769558/crypt/zone/oxz_ntp_4d009155-44fb-45b9-afed-f89cb57ce8da                 0590facf-202a-463b-81be-b6e88c47da76   in service    none      none          off        
+    oxp_60e6b021-79d6-4a6b-917c-6637e0769558/crypt/debug                                                             8f7f16c1-d9fb-4405-9dcf-68bfbaa7bf8c   in service    100 GiB   none          gzip-9     
+    oxp_71a07ac0-d24e-446c-a202-1998e7f6ac8c/crypt/debug                                                             6482f332-801a-473f-a77d-e07d30e2a5b7   in service    100 GiB   none          gzip-9     
+    oxp_736d4cab-c262-485e-89c2-07e6543f0855/crypt/debug                                                             0bb0541f-2c64-487b-a8af-162454207504   in service    100 GiB   none          gzip-9     
+    oxp_8ae56ca0-709d-4b8f-9869-51b62b542eef/crypt/debug                                                             902a6889-244f-4b67-baa4-b245f3d622c8   in service    100 GiB   none          gzip-9     
+    oxp_8e0bcc4f-0799-450c-a0ad-80c1637f59e3/crypt/debug                                                             667ffd3c-6735-4b50-bc3b-cfa32fcc811e   in service    100 GiB   none          gzip-9     
+    oxp_8eeebb8e-6db6-43e8-a429-d26dde99882c/crypt/debug                                                             cf48ba87-a4bb-435f-999b-bca46cfd6a89   in service    100 GiB   none          gzip-9     
+    oxp_a3e8de5b-c47a-49c0-b698-4d6955e1327f/crypt/debug                                                             7d64cab3-7311-4519-ae4a-1af6b320fa9b   in service    100 GiB   none          gzip-9     
+    oxp_b32fa3da-4dec-4237-9776-e1a57ba15a21/crypt/debug                                                             d3e957fd-5f26-498a-8fa3-deaea4dc5820   in service    100 GiB   none          gzip-9     
+    oxp_e9c238f6-87a3-4087-8ba4-aa594a82d012/crypt/debug                                                             4da77f4a-5e41-4604-af30-8cf568c38428   in service    100 GiB   none          gzip-9     
+    oxp_fbf997ef-52d3-438a-b036-b9117322e569/crypt/debug                                                             03935cb1-ce06-4594-b2fe-23e127d1cd9d   in service    100 GiB   none          gzip-9     
 
 
     omicron zones at generation 3:
@@ -117,60 +117,60 @@ to:   blueprint cb39be9d-5476-44fa-9edf-9938376219ef
 
 
     datasets at generation 4:
-    -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
-    dataset name                                                                                                     dataset uuid                           quota     reservation   compression
-    -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
-    oxp_0bf9d028-2b4a-4bff-82a1-6eb5fcefd985/crucible                                                                f18270c8-a39b-4579-be20-d2d1b80bba42   none      none          off        
-    oxp_19293a1d-fddc-40a7-88a4-ccafdb6f66d3/crucible                                                                06c2af14-055c-4041-aa26-9155f9f42661   none      none          off        
-    oxp_44484c44-477a-4676-8266-b98a00e80d79/crucible                                                                9deffea6-d340-4432-be3c-fad135dc29a5   none      none          off        
-    oxp_79787cd4-92da-4de5-bfd8-30a635521e10/crucible                                                                47ca08b9-b962-43e2-99d7-c2e0556c0f52   none      none          off        
-    oxp_9ae94c94-baae-477e-912a-60f0c4f3bd13/crucible                                                                b2e54e29-6915-4b6d-bc76-6f72e5c7c55a   none      none          off        
-    oxp_af85eec8-36b3-4b88-966d-a717b9b58fe5/crucible                                                                cb992d4e-7a69-4bcd-96c8-fe6e40989e24   none      none          off        
-    oxp_ddfaaba3-dafe-4103-b868-e9843d29d346/crucible                                                                68338fc3-2d8b-4419-b33d-4cce6fe9380d   none      none          off        
-    oxp_ec458c3e-91ca-40f1-a2a3-3f4292c1f279/crucible                                                                5294b99c-3eac-40e1-a35b-1f1cf2f0d6bf   none      none          off        
-    oxp_f2fc7c4c-7966-449d-8ec3-5a70f460501d/crucible                                                                31718dcf-ebd5-432c-a9e5-40abcb40931c   none      none          off        
-    oxp_f635c28a-e5ca-4d22-ac94-d8f278a6ea0e/crucible                                                                ff7ff4a9-21c4-499e-9ceb-8a00a4bb21bc   none      none          off        
-    oxp_0bf9d028-2b4a-4bff-82a1-6eb5fcefd985/crypt/clickhouse_keeper                                                 473adeb2-a57a-4240-82e9-88f2bebc1245   none      none          off        
-    oxp_19293a1d-fddc-40a7-88a4-ccafdb6f66d3/crypt/clickhouse_keeper                                                 882d4fee-d6d4-455f-9dc1-de3637cd29d0   none      none          off        
-    oxp_0bf9d028-2b4a-4bff-82a1-6eb5fcefd985/crypt/clickhouse_server                                                 4363b5f8-9a67-49af-b49d-585e532fa7bc   none      none          off        
-    oxp_0bf9d028-2b4a-4bff-82a1-6eb5fcefd985/crypt/internal_dns                                                      56a1af5d-de86-46c5-9504-2d1ee70587c5   none      none          off        
-    oxp_0bf9d028-2b4a-4bff-82a1-6eb5fcefd985/crypt/zone                                                              003c1d4e-15bb-4fca-aa71-a7dff507b124   none      none          off        
-    oxp_19293a1d-fddc-40a7-88a4-ccafdb6f66d3/crypt/zone                                                              bf35a148-62f0-4f88-8f60-0a13747daba2   none      none          off        
-    oxp_44484c44-477a-4676-8266-b98a00e80d79/crypt/zone                                                              9b1bf42e-6f06-44cc-af5b-bff65d929322   none      none          off        
-    oxp_79787cd4-92da-4de5-bfd8-30a635521e10/crypt/zone                                                              2c9d6bce-0293-4364-b8c9-4bdea345490e   none      none          off        
-    oxp_9ae94c94-baae-477e-912a-60f0c4f3bd13/crypt/zone                                                              11726c79-6590-4831-8480-cf50e6322c8a   none      none          off        
-    oxp_af85eec8-36b3-4b88-966d-a717b9b58fe5/crypt/zone                                                              b463f0c2-3ae4-45f7-a38c-110731fcc5cb   none      none          off        
-    oxp_ddfaaba3-dafe-4103-b868-e9843d29d346/crypt/zone                                                              626abe12-321d-439b-ad8f-f8dfb2022f25   none      none          off        
-    oxp_ec458c3e-91ca-40f1-a2a3-3f4292c1f279/crypt/zone                                                              4200e2a7-0fd6-4631-9d60-21fd821193fe   none      none          off        
-    oxp_f2fc7c4c-7966-449d-8ec3-5a70f460501d/crypt/zone                                                              85f34c02-a35d-404e-8cde-bedf3e193b1c   none      none          off        
-    oxp_f635c28a-e5ca-4d22-ac94-d8f278a6ea0e/crypt/zone                                                              dd19c2c5-0bc9-48de-a116-b92503569092   none      none          off        
-    oxp_0bf9d028-2b4a-4bff-82a1-6eb5fcefd985/crypt/zone/oxz_clickhouse_keeper_31a66e47-6252-4f38-aa92-f48637da152c   49f52cc5-74df-4cfa-b7f0-07c7e810940d   none      none          off        
-    oxp_19293a1d-fddc-40a7-88a4-ccafdb6f66d3/crypt/zone/oxz_clickhouse_keeper_e222f1c0-39ca-463a-88ad-ebfb6022fd1a   fbf9198e-996a-4194-af5b-c4e95ea4286d   none      none          off        
-    oxp_0bf9d028-2b4a-4bff-82a1-6eb5fcefd985/crypt/zone/oxz_clickhouse_server_6fedfc94-2ae6-4cc7-a968-5185207284f4   f1143eb2-0685-4708-a471-968a58f93bad   none      none          off        
-    oxp_f635c28a-e5ca-4d22-ac94-d8f278a6ea0e/crypt/zone/oxz_crucible_06b45c33-9a90-408b-8534-f94ab6df8a42            9e0a360d-c158-417f-a45f-9d29ee67cdce   none      none          off        
-    oxp_19293a1d-fddc-40a7-88a4-ccafdb6f66d3/crypt/zone/oxz_crucible_32999e20-ed5c-4c25-b4bd-41a3fbaf1445            dd7a45b8-3175-4744-8b99-ce19b22bb8ce   none      none          off        
-    oxp_9ae94c94-baae-477e-912a-60f0c4f3bd13/crypt/zone/oxz_crucible_4a037563-f969-4028-8384-164bdf308c3c            0d5b2580-7190-4bcc-9982-5012dac51f05   none      none          off        
-    oxp_44484c44-477a-4676-8266-b98a00e80d79/crypt/zone/oxz_crucible_6564394d-2c51-4252-b3b1-f5f88a72d7c3            26a1cc86-f717-4a12-b644-5acd168843aa   none      none          off        
-    oxp_0bf9d028-2b4a-4bff-82a1-6eb5fcefd985/crypt/zone/oxz_crucible_87427b40-5114-49cd-96bd-63edd61fce90            e7364079-58e3-4b36-81a7-b9e08f2a8fff   none      none          off        
-    oxp_ddfaaba3-dafe-4103-b868-e9843d29d346/crypt/zone/oxz_crucible_8acdc189-d4da-45a7-b306-23b43e86f695            6fa84a9c-0161-40c9-b596-f3b2c679ef99   none      none          off        
-    oxp_ec458c3e-91ca-40f1-a2a3-3f4292c1f279/crypt/zone/oxz_crucible_971ce633-cdc4-48cf-983e-dc272c1639eb            cb8ca8a6-6a00-4aae-8702-1493e1c3b166   none      none          off        
-    oxp_af85eec8-36b3-4b88-966d-a717b9b58fe5/crypt/zone/oxz_crucible_cfa6af7a-bf53-4fe6-bf1a-7ce3812d15c4            27323e49-f61e-4a73-bc87-f8d9f5082143   none      none          off        
-    oxp_f2fc7c4c-7966-449d-8ec3-5a70f460501d/crypt/zone/oxz_crucible_e145fb8e-df12-4df9-8049-b146ae0275be            35c46d33-4e08-4fad-90d2-3da719538ef2   none      none          off        
-    oxp_79787cd4-92da-4de5-bfd8-30a635521e10/crypt/zone/oxz_crucible_f1d08ae7-68fe-4799-8f31-f1100887c6f0            02863a62-7624-4017-9269-412910ab73f0   none      none          off        
-    oxp_0bf9d028-2b4a-4bff-82a1-6eb5fcefd985/crypt/zone/oxz_crucible_pantry_f9e18694-fdff-46a3-b40d-570d43206f48     3cb3f346-9879-4023-b919-55c4172bbf23   none      none          off        
-    oxp_0bf9d028-2b4a-4bff-82a1-6eb5fcefd985/crypt/zone/oxz_internal_dns_a00d8ae3-d1db-4aef-9174-3ff867af5e9e        c2d9b145-5e15-47be-a835-7e1f51f27679   none      none          off        
-    oxp_0bf9d028-2b4a-4bff-82a1-6eb5fcefd985/crypt/zone/oxz_nexus_8ccafc1f-97f9-4da7-bb04-d346213387ce               dcc3603b-b160-42d9-a743-11075c3b6941   none      none          off        
-    oxp_0bf9d028-2b4a-4bff-82a1-6eb5fcefd985/crypt/zone/oxz_ntp_a1797f1d-2d2a-4396-9ab5-044630b41c35                 5a70b3fe-9fad-4c17-982b-272b8595c2e8   none      none          off        
-    oxp_0bf9d028-2b4a-4bff-82a1-6eb5fcefd985/crypt/debug                                                             4e4b2f99-dc01-4793-a37a-072d942da264   100 GiB   none          gzip-9     
-    oxp_19293a1d-fddc-40a7-88a4-ccafdb6f66d3/crypt/debug                                                             8573903d-9610-4084-b0c6-ffcbb5d96c39   100 GiB   none          gzip-9     
-    oxp_44484c44-477a-4676-8266-b98a00e80d79/crypt/debug                                                             540272e1-99d2-4d2e-9d3d-032014b0e6d9   100 GiB   none          gzip-9     
-    oxp_79787cd4-92da-4de5-bfd8-30a635521e10/crypt/debug                                                             4adf2ef6-2694-4aac-aabe-688bca767092   100 GiB   none          gzip-9     
-    oxp_9ae94c94-baae-477e-912a-60f0c4f3bd13/crypt/debug                                                             7e9d012a-6d8e-475e-805e-65985a66ffcd   100 GiB   none          gzip-9     
-    oxp_af85eec8-36b3-4b88-966d-a717b9b58fe5/crypt/debug                                                             2189574d-9a73-4d25-858e-1084d57b59a8   100 GiB   none          gzip-9     
-    oxp_ddfaaba3-dafe-4103-b868-e9843d29d346/crypt/debug                                                             3cf0580b-4e1d-4ff9-bc22-4dc51ca9a53b   100 GiB   none          gzip-9     
-    oxp_ec458c3e-91ca-40f1-a2a3-3f4292c1f279/crypt/debug                                                             f499c5f8-b62f-493d-858a-8d33f7db81ff   100 GiB   none          gzip-9     
-    oxp_f2fc7c4c-7966-449d-8ec3-5a70f460501d/crypt/debug                                                             c16ff3c0-3282-46de-a620-49c6b1e3f882   100 GiB   none          gzip-9     
-    oxp_f635c28a-e5ca-4d22-ac94-d8f278a6ea0e/crypt/debug                                                             8dde6eee-f28e-4b55-8c11-525884ec81e5   100 GiB   none          gzip-9     
+    ---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
+    dataset name                                                                                                     dataset id                             disposition   quota     reservation   compression
+    ---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
+    oxp_0bf9d028-2b4a-4bff-82a1-6eb5fcefd985/crucible                                                                f18270c8-a39b-4579-be20-d2d1b80bba42   in service    none      none          off        
+    oxp_19293a1d-fddc-40a7-88a4-ccafdb6f66d3/crucible                                                                06c2af14-055c-4041-aa26-9155f9f42661   in service    none      none          off        
+    oxp_44484c44-477a-4676-8266-b98a00e80d79/crucible                                                                9deffea6-d340-4432-be3c-fad135dc29a5   in service    none      none          off        
+    oxp_79787cd4-92da-4de5-bfd8-30a635521e10/crucible                                                                47ca08b9-b962-43e2-99d7-c2e0556c0f52   in service    none      none          off        
+    oxp_9ae94c94-baae-477e-912a-60f0c4f3bd13/crucible                                                                b2e54e29-6915-4b6d-bc76-6f72e5c7c55a   in service    none      none          off        
+    oxp_af85eec8-36b3-4b88-966d-a717b9b58fe5/crucible                                                                cb992d4e-7a69-4bcd-96c8-fe6e40989e24   in service    none      none          off        
+    oxp_ddfaaba3-dafe-4103-b868-e9843d29d346/crucible                                                                68338fc3-2d8b-4419-b33d-4cce6fe9380d   in service    none      none          off        
+    oxp_ec458c3e-91ca-40f1-a2a3-3f4292c1f279/crucible                                                                5294b99c-3eac-40e1-a35b-1f1cf2f0d6bf   in service    none      none          off        
+    oxp_f2fc7c4c-7966-449d-8ec3-5a70f460501d/crucible                                                                31718dcf-ebd5-432c-a9e5-40abcb40931c   in service    none      none          off        
+    oxp_f635c28a-e5ca-4d22-ac94-d8f278a6ea0e/crucible                                                                ff7ff4a9-21c4-499e-9ceb-8a00a4bb21bc   in service    none      none          off        
+    oxp_0bf9d028-2b4a-4bff-82a1-6eb5fcefd985/crypt/clickhouse_keeper                                                 473adeb2-a57a-4240-82e9-88f2bebc1245   in service    none      none          off        
+    oxp_19293a1d-fddc-40a7-88a4-ccafdb6f66d3/crypt/clickhouse_keeper                                                 882d4fee-d6d4-455f-9dc1-de3637cd29d0   in service    none      none          off        
+    oxp_0bf9d028-2b4a-4bff-82a1-6eb5fcefd985/crypt/clickhouse_server                                                 4363b5f8-9a67-49af-b49d-585e532fa7bc   in service    none      none          off        
+    oxp_0bf9d028-2b4a-4bff-82a1-6eb5fcefd985/crypt/internal_dns                                                      56a1af5d-de86-46c5-9504-2d1ee70587c5   in service    none      none          off        
+    oxp_0bf9d028-2b4a-4bff-82a1-6eb5fcefd985/crypt/zone                                                              003c1d4e-15bb-4fca-aa71-a7dff507b124   in service    none      none          off        
+    oxp_19293a1d-fddc-40a7-88a4-ccafdb6f66d3/crypt/zone                                                              bf35a148-62f0-4f88-8f60-0a13747daba2   in service    none      none          off        
+    oxp_44484c44-477a-4676-8266-b98a00e80d79/crypt/zone                                                              9b1bf42e-6f06-44cc-af5b-bff65d929322   in service    none      none          off        
+    oxp_79787cd4-92da-4de5-bfd8-30a635521e10/crypt/zone                                                              2c9d6bce-0293-4364-b8c9-4bdea345490e   in service    none      none          off        
+    oxp_9ae94c94-baae-477e-912a-60f0c4f3bd13/crypt/zone                                                              11726c79-6590-4831-8480-cf50e6322c8a   in service    none      none          off        
+    oxp_af85eec8-36b3-4b88-966d-a717b9b58fe5/crypt/zone                                                              b463f0c2-3ae4-45f7-a38c-110731fcc5cb   in service    none      none          off        
+    oxp_ddfaaba3-dafe-4103-b868-e9843d29d346/crypt/zone                                                              626abe12-321d-439b-ad8f-f8dfb2022f25   in service    none      none          off        
+    oxp_ec458c3e-91ca-40f1-a2a3-3f4292c1f279/crypt/zone                                                              4200e2a7-0fd6-4631-9d60-21fd821193fe   in service    none      none          off        
+    oxp_f2fc7c4c-7966-449d-8ec3-5a70f460501d/crypt/zone                                                              85f34c02-a35d-404e-8cde-bedf3e193b1c   in service    none      none          off        
+    oxp_f635c28a-e5ca-4d22-ac94-d8f278a6ea0e/crypt/zone                                                              dd19c2c5-0bc9-48de-a116-b92503569092   in service    none      none          off        
+    oxp_0bf9d028-2b4a-4bff-82a1-6eb5fcefd985/crypt/zone/oxz_clickhouse_keeper_31a66e47-6252-4f38-aa92-f48637da152c   49f52cc5-74df-4cfa-b7f0-07c7e810940d   in service    none      none          off        
+    oxp_19293a1d-fddc-40a7-88a4-ccafdb6f66d3/crypt/zone/oxz_clickhouse_keeper_e222f1c0-39ca-463a-88ad-ebfb6022fd1a   fbf9198e-996a-4194-af5b-c4e95ea4286d   in service    none      none          off        
+    oxp_0bf9d028-2b4a-4bff-82a1-6eb5fcefd985/crypt/zone/oxz_clickhouse_server_6fedfc94-2ae6-4cc7-a968-5185207284f4   f1143eb2-0685-4708-a471-968a58f93bad   in service    none      none          off        
+    oxp_f635c28a-e5ca-4d22-ac94-d8f278a6ea0e/crypt/zone/oxz_crucible_06b45c33-9a90-408b-8534-f94ab6df8a42            9e0a360d-c158-417f-a45f-9d29ee67cdce   in service    none      none          off        
+    oxp_19293a1d-fddc-40a7-88a4-ccafdb6f66d3/crypt/zone/oxz_crucible_32999e20-ed5c-4c25-b4bd-41a3fbaf1445            dd7a45b8-3175-4744-8b99-ce19b22bb8ce   in service    none      none          off        
+    oxp_9ae94c94-baae-477e-912a-60f0c4f3bd13/crypt/zone/oxz_crucible_4a037563-f969-4028-8384-164bdf308c3c            0d5b2580-7190-4bcc-9982-5012dac51f05   in service    none      none          off        
+    oxp_44484c44-477a-4676-8266-b98a00e80d79/crypt/zone/oxz_crucible_6564394d-2c51-4252-b3b1-f5f88a72d7c3            26a1cc86-f717-4a12-b644-5acd168843aa   in service    none      none          off        
+    oxp_0bf9d028-2b4a-4bff-82a1-6eb5fcefd985/crypt/zone/oxz_crucible_87427b40-5114-49cd-96bd-63edd61fce90            e7364079-58e3-4b36-81a7-b9e08f2a8fff   in service    none      none          off        
+    oxp_ddfaaba3-dafe-4103-b868-e9843d29d346/crypt/zone/oxz_crucible_8acdc189-d4da-45a7-b306-23b43e86f695            6fa84a9c-0161-40c9-b596-f3b2c679ef99   in service    none      none          off        
+    oxp_ec458c3e-91ca-40f1-a2a3-3f4292c1f279/crypt/zone/oxz_crucible_971ce633-cdc4-48cf-983e-dc272c1639eb            cb8ca8a6-6a00-4aae-8702-1493e1c3b166   in service    none      none          off        
+    oxp_af85eec8-36b3-4b88-966d-a717b9b58fe5/crypt/zone/oxz_crucible_cfa6af7a-bf53-4fe6-bf1a-7ce3812d15c4            27323e49-f61e-4a73-bc87-f8d9f5082143   in service    none      none          off        
+    oxp_f2fc7c4c-7966-449d-8ec3-5a70f460501d/crypt/zone/oxz_crucible_e145fb8e-df12-4df9-8049-b146ae0275be            35c46d33-4e08-4fad-90d2-3da719538ef2   in service    none      none          off        
+    oxp_79787cd4-92da-4de5-bfd8-30a635521e10/crypt/zone/oxz_crucible_f1d08ae7-68fe-4799-8f31-f1100887c6f0            02863a62-7624-4017-9269-412910ab73f0   in service    none      none          off        
+    oxp_0bf9d028-2b4a-4bff-82a1-6eb5fcefd985/crypt/zone/oxz_crucible_pantry_f9e18694-fdff-46a3-b40d-570d43206f48     3cb3f346-9879-4023-b919-55c4172bbf23   in service    none      none          off        
+    oxp_0bf9d028-2b4a-4bff-82a1-6eb5fcefd985/crypt/zone/oxz_internal_dns_a00d8ae3-d1db-4aef-9174-3ff867af5e9e        c2d9b145-5e15-47be-a835-7e1f51f27679   in service    none      none          off        
+    oxp_0bf9d028-2b4a-4bff-82a1-6eb5fcefd985/crypt/zone/oxz_nexus_8ccafc1f-97f9-4da7-bb04-d346213387ce               dcc3603b-b160-42d9-a743-11075c3b6941   in service    none      none          off        
+    oxp_0bf9d028-2b4a-4bff-82a1-6eb5fcefd985/crypt/zone/oxz_ntp_a1797f1d-2d2a-4396-9ab5-044630b41c35                 5a70b3fe-9fad-4c17-982b-272b8595c2e8   in service    none      none          off        
+    oxp_0bf9d028-2b4a-4bff-82a1-6eb5fcefd985/crypt/debug                                                             4e4b2f99-dc01-4793-a37a-072d942da264   in service    100 GiB   none          gzip-9     
+    oxp_19293a1d-fddc-40a7-88a4-ccafdb6f66d3/crypt/debug                                                             8573903d-9610-4084-b0c6-ffcbb5d96c39   in service    100 GiB   none          gzip-9     
+    oxp_44484c44-477a-4676-8266-b98a00e80d79/crypt/debug                                                             540272e1-99d2-4d2e-9d3d-032014b0e6d9   in service    100 GiB   none          gzip-9     
+    oxp_79787cd4-92da-4de5-bfd8-30a635521e10/crypt/debug                                                             4adf2ef6-2694-4aac-aabe-688bca767092   in service    100 GiB   none          gzip-9     
+    oxp_9ae94c94-baae-477e-912a-60f0c4f3bd13/crypt/debug                                                             7e9d012a-6d8e-475e-805e-65985a66ffcd   in service    100 GiB   none          gzip-9     
+    oxp_af85eec8-36b3-4b88-966d-a717b9b58fe5/crypt/debug                                                             2189574d-9a73-4d25-858e-1084d57b59a8   in service    100 GiB   none          gzip-9     
+    oxp_ddfaaba3-dafe-4103-b868-e9843d29d346/crypt/debug                                                             3cf0580b-4e1d-4ff9-bc22-4dc51ca9a53b   in service    100 GiB   none          gzip-9     
+    oxp_ec458c3e-91ca-40f1-a2a3-3f4292c1f279/crypt/debug                                                             f499c5f8-b62f-493d-858a-8d33f7db81ff   in service    100 GiB   none          gzip-9     
+    oxp_f2fc7c4c-7966-449d-8ec3-5a70f460501d/crypt/debug                                                             c16ff3c0-3282-46de-a620-49c6b1e3f882   in service    100 GiB   none          gzip-9     
+    oxp_f635c28a-e5ca-4d22-ac94-d8f278a6ea0e/crypt/debug                                                             8dde6eee-f28e-4b55-8c11-525884ec81e5   in service    100 GiB   none          gzip-9     
 
 
     omicron zones at generation 4:
@@ -215,60 +215,60 @@ to:   blueprint cb39be9d-5476-44fa-9edf-9938376219ef
 
 
     datasets at generation 4:
-    -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
-    dataset name                                                                                                     dataset uuid                           quota     reservation   compression
-    -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
-    oxp_2a76ab1a-fb16-412d-93f9-b8cd9aa94e85/crucible                                                                c73b47ac-ad1f-4cd1-b449-f220b5ad8104   none      none          off        
-    oxp_2de2bf7e-c679-4b2b-b373-908e9d3ffbfc/crucible                                                                813c7aac-695b-49ce-8bc5-f4cdbfc04b38   none      none          off        
-    oxp_2f02a5c6-fcf5-4b5a-bc7d-7f65369918ba/crucible                                                                e5da836d-fffb-4435-8500-889c05b04689   none      none          off        
-    oxp_32041dbf-e58d-4f32-840d-923d3d3b68af/crucible                                                                9f8d056c-3e84-4474-b9c7-5b7a890a8a7b   none      none          off        
-    oxp_5f88adff-bb50-4dc1-bbfb-5a410c753ed5/crucible                                                                e93cfc01-9581-4f6e-b77c-eb6300ca6ffb   none      none          off        
-    oxp_74d64eb9-bf69-4782-af16-2d3a761ca171/crucible                                                                f54d6e59-67a1-458b-8e66-6dc3b2adb755   none      none          off        
-    oxp_b3c231c9-b2a5-4267-b4bf-9651881b91a5/crucible                                                                6604dd1b-5f21-475d-952a-894717512d1b   none      none          off        
-    oxp_bca80b95-8dca-4a3b-b24d-d44b6a9ff71b/crucible                                                                05cb728f-f6b9-4132-922d-fe249b1ba736   none      none          off        
-    oxp_db16345e-427a-4c8e-9032-17270f729308/crucible                                                                500f8d46-a32d-4bd1-8f2c-cb9d36822660   none      none          off        
-    oxp_e3b45593-8f0c-47b2-a381-802a7dad1f54/crucible                                                                66c673a1-e8d8-4863-b368-a7ea292555fb   none      none          off        
-    oxp_2a76ab1a-fb16-412d-93f9-b8cd9aa94e85/crypt/clickhouse_keeper                                                 6c5a6622-5f75-45a0-a9e8-4b513f5ac352   none      none          off        
-    oxp_2de2bf7e-c679-4b2b-b373-908e9d3ffbfc/crypt/clickhouse_keeper                                                 f6464cd8-84bc-4bae-8386-c0a5a82aab95   none      none          off        
-    oxp_2a76ab1a-fb16-412d-93f9-b8cd9aa94e85/crypt/clickhouse_server                                                 f8706468-85ac-4f9f-b41d-ff7c3a17ee5f   none      none          off        
-    oxp_2a76ab1a-fb16-412d-93f9-b8cd9aa94e85/crypt/internal_dns                                                      03de030d-d958-4ce5-86d2-368fa88e0bd8   none      none          off        
-    oxp_2a76ab1a-fb16-412d-93f9-b8cd9aa94e85/crypt/zone                                                              4c3c89bd-21cf-4986-b012-e89e4e1c1ac4   none      none          off        
-    oxp_2de2bf7e-c679-4b2b-b373-908e9d3ffbfc/crypt/zone                                                              ff4a77a2-528a-4c70-a5b9-f0093c95697b   none      none          off        
-    oxp_2f02a5c6-fcf5-4b5a-bc7d-7f65369918ba/crypt/zone                                                              676fc8c5-743b-48ca-99fd-2f2379c83890   none      none          off        
-    oxp_32041dbf-e58d-4f32-840d-923d3d3b68af/crypt/zone                                                              63362c89-4b42-4649-9ebe-43e19a5c0e51   none      none          off        
-    oxp_5f88adff-bb50-4dc1-bbfb-5a410c753ed5/crypt/zone                                                              6f83a31e-1181-418f-92b0-d0534e9ae6dd   none      none          off        
-    oxp_74d64eb9-bf69-4782-af16-2d3a761ca171/crypt/zone                                                              260ffd7d-4da5-4657-9158-ba7e1eae5971   none      none          off        
-    oxp_b3c231c9-b2a5-4267-b4bf-9651881b91a5/crypt/zone                                                              ed4c8570-3951-4f79-b27e-da73150609be   none      none          off        
-    oxp_bca80b95-8dca-4a3b-b24d-d44b6a9ff71b/crypt/zone                                                              e5dcf165-3ebb-40a2-b16f-a07b036a6533   none      none          off        
-    oxp_db16345e-427a-4c8e-9032-17270f729308/crypt/zone                                                              dd27be6b-214d-4022-a99d-2a7d12e7d8bb   none      none          off        
-    oxp_e3b45593-8f0c-47b2-a381-802a7dad1f54/crypt/zone                                                              b7500d95-2499-48fc-a7d6-2460d61e197a   none      none          off        
-    oxp_2de2bf7e-c679-4b2b-b373-908e9d3ffbfc/crypt/zone/oxz_clickhouse_keeper_60cf5091-670b-48c9-a729-b82c5e7683ca   8ee3f0bb-d102-4a00-af81-72e2f284878b   none      none          off        
-    oxp_2a76ab1a-fb16-412d-93f9-b8cd9aa94e85/crypt/zone/oxz_clickhouse_keeper_7aa82b80-0c37-4f20-9398-bfce4707f327   0bf9cddb-1911-495b-8aad-09b7eea5fff4   none      none          off        
-    oxp_2a76ab1a-fb16-412d-93f9-b8cd9aa94e85/crypt/zone/oxz_clickhouse_server_812be70a-f237-47d5-ab49-f9450fe948db   292f53fc-27bb-4cc4-a61b-7d02c978149c   none      none          off        
-    oxp_32041dbf-e58d-4f32-840d-923d3d3b68af/crypt/zone/oxz_crucible_0b0e12fd-2800-4203-acb6-24e6e976271c            cf46ee68-f945-4af6-a647-4d612c1f05be   none      none          off        
-    oxp_2de2bf7e-c679-4b2b-b373-908e9d3ffbfc/crypt/zone/oxz_crucible_1a02d419-10c4-4326-b34e-eb2b1bd90bd7            2a439799-3f16-46df-ba1b-7ea29edd392d   none      none          off        
-    oxp_2a76ab1a-fb16-412d-93f9-b8cd9aa94e85/crypt/zone/oxz_crucible_56e18c31-f630-4643-ad5c-1fede34f35de            c30be90e-20cf-46c6-bb4a-b65d2c407878   none      none          off        
-    oxp_b3c231c9-b2a5-4267-b4bf-9651881b91a5/crypt/zone/oxz_crucible_5ea86015-8f62-40aa-b3b2-c659f17ee510            6289ea03-b2c9-4470-b7ba-b935450aa764   none      none          off        
-    oxp_5f88adff-bb50-4dc1-bbfb-5a410c753ed5/crypt/zone/oxz_crucible_78965849-e6e3-4250-a66a-dc50512fad34            43b36ba3-e516-4732-be8b-8cd2ca9de93c   none      none          off        
-    oxp_74d64eb9-bf69-4782-af16-2d3a761ca171/crypt/zone/oxz_crucible_90c484e5-69d3-4636-9c64-6a878f593d33            7cc8018e-323f-4d35-bb33-fcf557b9dace   none      none          off        
-    oxp_db16345e-427a-4c8e-9032-17270f729308/crypt/zone/oxz_crucible_a3901043-fa2a-4ef7-a40e-6ef0e5fd189f            88fd4e5a-50fd-43c7-8a75-0ad4376bd564   none      none          off        
-    oxp_2f02a5c6-fcf5-4b5a-bc7d-7f65369918ba/crypt/zone/oxz_crucible_be9fd98a-6422-4890-a32b-42d42d1c8957            932cbb0d-b1d0-423d-87b6-9dce8ddb6338   none      none          off        
-    oxp_e3b45593-8f0c-47b2-a381-802a7dad1f54/crypt/zone/oxz_crucible_bf71d1a8-9e65-479d-8920-0be8e3422ac5            fd0ce816-4da0-4490-be32-4d38fb78c13c   none      none          off        
-    oxp_bca80b95-8dca-4a3b-b24d-d44b6a9ff71b/crypt/zone/oxz_crucible_eb4176ea-456b-48f6-b284-7b76da0bf4a1            704ea6b5-0ffc-443f-ae8a-482666f8277c   none      none          off        
-    oxp_2a76ab1a-fb16-412d-93f9-b8cd9aa94e85/crypt/zone/oxz_crucible_pantry_417c97a4-fe25-439d-8359-3f7062981923     8957a276-6d4e-4c58-a856-d7c5433806e1   none      none          off        
-    oxp_2a76ab1a-fb16-412d-93f9-b8cd9aa94e85/crypt/zone/oxz_internal_dns_f2bbaa79-0eab-4b91-a404-dad4c19b58c2        fe0f566f-3cff-43ef-960c-649c27746c56   none      none          off        
-    oxp_2a76ab1a-fb16-412d-93f9-b8cd9aa94e85/crypt/zone/oxz_nexus_33ba37c4-2535-4095-a7e9-c69937fc584d               77d0cd16-b6e3-484d-962f-0477cd242482   none      none          off        
-    oxp_2a76ab1a-fb16-412d-93f9-b8cd9aa94e85/crypt/zone/oxz_ntp_47eab17a-4dd4-4467-90b2-f643f465cf34                 4eaf1849-1fe4-415c-bdc7-4cc04cac20ce   none      none          off        
-    oxp_2a76ab1a-fb16-412d-93f9-b8cd9aa94e85/crypt/debug                                                             c5b8f4f9-bd10-45b8-a9f3-93adf1402ecc   100 GiB   none          gzip-9     
-    oxp_2de2bf7e-c679-4b2b-b373-908e9d3ffbfc/crypt/debug                                                             43abf982-d457-46d1-8566-8047d2a78a41   100 GiB   none          gzip-9     
-    oxp_2f02a5c6-fcf5-4b5a-bc7d-7f65369918ba/crypt/debug                                                             1b6a1722-d9f7-48ea-b351-5bc8bad4fd07   100 GiB   none          gzip-9     
-    oxp_32041dbf-e58d-4f32-840d-923d3d3b68af/crypt/debug                                                             8be43fb0-00e7-4748-9a1a-ace9772d8a83   100 GiB   none          gzip-9     
-    oxp_5f88adff-bb50-4dc1-bbfb-5a410c753ed5/crypt/debug                                                             2ccb3aa9-f0ef-4fd4-9fd7-43b4a88b8d6b   100 GiB   none          gzip-9     
-    oxp_74d64eb9-bf69-4782-af16-2d3a761ca171/crypt/debug                                                             56759eb6-69e9-46a3-b44c-fc748cd506aa   100 GiB   none          gzip-9     
-    oxp_b3c231c9-b2a5-4267-b4bf-9651881b91a5/crypt/debug                                                             76fffbd2-9c74-46b5-8033-f442be1256f5   100 GiB   none          gzip-9     
-    oxp_bca80b95-8dca-4a3b-b24d-d44b6a9ff71b/crypt/debug                                                             c13a3d71-1241-42d1-95a8-d720c20ee2c4   100 GiB   none          gzip-9     
-    oxp_db16345e-427a-4c8e-9032-17270f729308/crypt/debug                                                             f030ef33-cad2-4760-9431-1907b797161b   100 GiB   none          gzip-9     
-    oxp_e3b45593-8f0c-47b2-a381-802a7dad1f54/crypt/debug                                                             947b2823-3dca-4b56-9324-f476e2c1c6da   100 GiB   none          gzip-9     
+    ---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
+    dataset name                                                                                                     dataset id                             disposition   quota     reservation   compression
+    ---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
+    oxp_2a76ab1a-fb16-412d-93f9-b8cd9aa94e85/crucible                                                                c73b47ac-ad1f-4cd1-b449-f220b5ad8104   in service    none      none          off        
+    oxp_2de2bf7e-c679-4b2b-b373-908e9d3ffbfc/crucible                                                                813c7aac-695b-49ce-8bc5-f4cdbfc04b38   in service    none      none          off        
+    oxp_2f02a5c6-fcf5-4b5a-bc7d-7f65369918ba/crucible                                                                e5da836d-fffb-4435-8500-889c05b04689   in service    none      none          off        
+    oxp_32041dbf-e58d-4f32-840d-923d3d3b68af/crucible                                                                9f8d056c-3e84-4474-b9c7-5b7a890a8a7b   in service    none      none          off        
+    oxp_5f88adff-bb50-4dc1-bbfb-5a410c753ed5/crucible                                                                e93cfc01-9581-4f6e-b77c-eb6300ca6ffb   in service    none      none          off        
+    oxp_74d64eb9-bf69-4782-af16-2d3a761ca171/crucible                                                                f54d6e59-67a1-458b-8e66-6dc3b2adb755   in service    none      none          off        
+    oxp_b3c231c9-b2a5-4267-b4bf-9651881b91a5/crucible                                                                6604dd1b-5f21-475d-952a-894717512d1b   in service    none      none          off        
+    oxp_bca80b95-8dca-4a3b-b24d-d44b6a9ff71b/crucible                                                                05cb728f-f6b9-4132-922d-fe249b1ba736   in service    none      none          off        
+    oxp_db16345e-427a-4c8e-9032-17270f729308/crucible                                                                500f8d46-a32d-4bd1-8f2c-cb9d36822660   in service    none      none          off        
+    oxp_e3b45593-8f0c-47b2-a381-802a7dad1f54/crucible                                                                66c673a1-e8d8-4863-b368-a7ea292555fb   in service    none      none          off        
+    oxp_2a76ab1a-fb16-412d-93f9-b8cd9aa94e85/crypt/clickhouse_keeper                                                 6c5a6622-5f75-45a0-a9e8-4b513f5ac352   in service    none      none          off        
+    oxp_2de2bf7e-c679-4b2b-b373-908e9d3ffbfc/crypt/clickhouse_keeper                                                 f6464cd8-84bc-4bae-8386-c0a5a82aab95   in service    none      none          off        
+    oxp_2a76ab1a-fb16-412d-93f9-b8cd9aa94e85/crypt/clickhouse_server                                                 f8706468-85ac-4f9f-b41d-ff7c3a17ee5f   in service    none      none          off        
+    oxp_2a76ab1a-fb16-412d-93f9-b8cd9aa94e85/crypt/internal_dns                                                      03de030d-d958-4ce5-86d2-368fa88e0bd8   in service    none      none          off        
+    oxp_2a76ab1a-fb16-412d-93f9-b8cd9aa94e85/crypt/zone                                                              4c3c89bd-21cf-4986-b012-e89e4e1c1ac4   in service    none      none          off        
+    oxp_2de2bf7e-c679-4b2b-b373-908e9d3ffbfc/crypt/zone                                                              ff4a77a2-528a-4c70-a5b9-f0093c95697b   in service    none      none          off        
+    oxp_2f02a5c6-fcf5-4b5a-bc7d-7f65369918ba/crypt/zone                                                              676fc8c5-743b-48ca-99fd-2f2379c83890   in service    none      none          off        
+    oxp_32041dbf-e58d-4f32-840d-923d3d3b68af/crypt/zone                                                              63362c89-4b42-4649-9ebe-43e19a5c0e51   in service    none      none          off        
+    oxp_5f88adff-bb50-4dc1-bbfb-5a410c753ed5/crypt/zone                                                              6f83a31e-1181-418f-92b0-d0534e9ae6dd   in service    none      none          off        
+    oxp_74d64eb9-bf69-4782-af16-2d3a761ca171/crypt/zone                                                              260ffd7d-4da5-4657-9158-ba7e1eae5971   in service    none      none          off        
+    oxp_b3c231c9-b2a5-4267-b4bf-9651881b91a5/crypt/zone                                                              ed4c8570-3951-4f79-b27e-da73150609be   in service    none      none          off        
+    oxp_bca80b95-8dca-4a3b-b24d-d44b6a9ff71b/crypt/zone                                                              e5dcf165-3ebb-40a2-b16f-a07b036a6533   in service    none      none          off        
+    oxp_db16345e-427a-4c8e-9032-17270f729308/crypt/zone                                                              dd27be6b-214d-4022-a99d-2a7d12e7d8bb   in service    none      none          off        
+    oxp_e3b45593-8f0c-47b2-a381-802a7dad1f54/crypt/zone                                                              b7500d95-2499-48fc-a7d6-2460d61e197a   in service    none      none          off        
+    oxp_2de2bf7e-c679-4b2b-b373-908e9d3ffbfc/crypt/zone/oxz_clickhouse_keeper_60cf5091-670b-48c9-a729-b82c5e7683ca   8ee3f0bb-d102-4a00-af81-72e2f284878b   in service    none      none          off        
+    oxp_2a76ab1a-fb16-412d-93f9-b8cd9aa94e85/crypt/zone/oxz_clickhouse_keeper_7aa82b80-0c37-4f20-9398-bfce4707f327   0bf9cddb-1911-495b-8aad-09b7eea5fff4   in service    none      none          off        
+    oxp_2a76ab1a-fb16-412d-93f9-b8cd9aa94e85/crypt/zone/oxz_clickhouse_server_812be70a-f237-47d5-ab49-f9450fe948db   292f53fc-27bb-4cc4-a61b-7d02c978149c   in service    none      none          off        
+    oxp_32041dbf-e58d-4f32-840d-923d3d3b68af/crypt/zone/oxz_crucible_0b0e12fd-2800-4203-acb6-24e6e976271c            cf46ee68-f945-4af6-a647-4d612c1f05be   in service    none      none          off        
+    oxp_2de2bf7e-c679-4b2b-b373-908e9d3ffbfc/crypt/zone/oxz_crucible_1a02d419-10c4-4326-b34e-eb2b1bd90bd7            2a439799-3f16-46df-ba1b-7ea29edd392d   in service    none      none          off        
+    oxp_2a76ab1a-fb16-412d-93f9-b8cd9aa94e85/crypt/zone/oxz_crucible_56e18c31-f630-4643-ad5c-1fede34f35de            c30be90e-20cf-46c6-bb4a-b65d2c407878   in service    none      none          off        
+    oxp_b3c231c9-b2a5-4267-b4bf-9651881b91a5/crypt/zone/oxz_crucible_5ea86015-8f62-40aa-b3b2-c659f17ee510            6289ea03-b2c9-4470-b7ba-b935450aa764   in service    none      none          off        
+    oxp_5f88adff-bb50-4dc1-bbfb-5a410c753ed5/crypt/zone/oxz_crucible_78965849-e6e3-4250-a66a-dc50512fad34            43b36ba3-e516-4732-be8b-8cd2ca9de93c   in service    none      none          off        
+    oxp_74d64eb9-bf69-4782-af16-2d3a761ca171/crypt/zone/oxz_crucible_90c484e5-69d3-4636-9c64-6a878f593d33            7cc8018e-323f-4d35-bb33-fcf557b9dace   in service    none      none          off        
+    oxp_db16345e-427a-4c8e-9032-17270f729308/crypt/zone/oxz_crucible_a3901043-fa2a-4ef7-a40e-6ef0e5fd189f            88fd4e5a-50fd-43c7-8a75-0ad4376bd564   in service    none      none          off        
+    oxp_2f02a5c6-fcf5-4b5a-bc7d-7f65369918ba/crypt/zone/oxz_crucible_be9fd98a-6422-4890-a32b-42d42d1c8957            932cbb0d-b1d0-423d-87b6-9dce8ddb6338   in service    none      none          off        
+    oxp_e3b45593-8f0c-47b2-a381-802a7dad1f54/crypt/zone/oxz_crucible_bf71d1a8-9e65-479d-8920-0be8e3422ac5            fd0ce816-4da0-4490-be32-4d38fb78c13c   in service    none      none          off        
+    oxp_bca80b95-8dca-4a3b-b24d-d44b6a9ff71b/crypt/zone/oxz_crucible_eb4176ea-456b-48f6-b284-7b76da0bf4a1            704ea6b5-0ffc-443f-ae8a-482666f8277c   in service    none      none          off        
+    oxp_2a76ab1a-fb16-412d-93f9-b8cd9aa94e85/crypt/zone/oxz_crucible_pantry_417c97a4-fe25-439d-8359-3f7062981923     8957a276-6d4e-4c58-a856-d7c5433806e1   in service    none      none          off        
+    oxp_2a76ab1a-fb16-412d-93f9-b8cd9aa94e85/crypt/zone/oxz_internal_dns_f2bbaa79-0eab-4b91-a404-dad4c19b58c2        fe0f566f-3cff-43ef-960c-649c27746c56   in service    none      none          off        
+    oxp_2a76ab1a-fb16-412d-93f9-b8cd9aa94e85/crypt/zone/oxz_nexus_33ba37c4-2535-4095-a7e9-c69937fc584d               77d0cd16-b6e3-484d-962f-0477cd242482   in service    none      none          off        
+    oxp_2a76ab1a-fb16-412d-93f9-b8cd9aa94e85/crypt/zone/oxz_ntp_47eab17a-4dd4-4467-90b2-f643f465cf34                 4eaf1849-1fe4-415c-bdc7-4cc04cac20ce   in service    none      none          off        
+    oxp_2a76ab1a-fb16-412d-93f9-b8cd9aa94e85/crypt/debug                                                             c5b8f4f9-bd10-45b8-a9f3-93adf1402ecc   in service    100 GiB   none          gzip-9     
+    oxp_2de2bf7e-c679-4b2b-b373-908e9d3ffbfc/crypt/debug                                                             43abf982-d457-46d1-8566-8047d2a78a41   in service    100 GiB   none          gzip-9     
+    oxp_2f02a5c6-fcf5-4b5a-bc7d-7f65369918ba/crypt/debug                                                             1b6a1722-d9f7-48ea-b351-5bc8bad4fd07   in service    100 GiB   none          gzip-9     
+    oxp_32041dbf-e58d-4f32-840d-923d3d3b68af/crypt/debug                                                             8be43fb0-00e7-4748-9a1a-ace9772d8a83   in service    100 GiB   none          gzip-9     
+    oxp_5f88adff-bb50-4dc1-bbfb-5a410c753ed5/crypt/debug                                                             2ccb3aa9-f0ef-4fd4-9fd7-43b4a88b8d6b   in service    100 GiB   none          gzip-9     
+    oxp_74d64eb9-bf69-4782-af16-2d3a761ca171/crypt/debug                                                             56759eb6-69e9-46a3-b44c-fc748cd506aa   in service    100 GiB   none          gzip-9     
+    oxp_b3c231c9-b2a5-4267-b4bf-9651881b91a5/crypt/debug                                                             76fffbd2-9c74-46b5-8033-f442be1256f5   in service    100 GiB   none          gzip-9     
+    oxp_bca80b95-8dca-4a3b-b24d-d44b6a9ff71b/crypt/debug                                                             c13a3d71-1241-42d1-95a8-d720c20ee2c4   in service    100 GiB   none          gzip-9     
+    oxp_db16345e-427a-4c8e-9032-17270f729308/crypt/debug                                                             f030ef33-cad2-4760-9431-1907b797161b   in service    100 GiB   none          gzip-9     
+    oxp_e3b45593-8f0c-47b2-a381-802a7dad1f54/crypt/debug                                                             947b2823-3dca-4b56-9324-f476e2c1c6da   in service    100 GiB   none          gzip-9     
 
 
     omicron zones at generation 4:

--- a/nexus/reconfigurator/planning/tests/output/planner_expunge_clickhouse_clusters_3_4.txt
+++ b/nexus/reconfigurator/planning/tests/output/planner_expunge_clickhouse_clusters_3_4.txt
@@ -22,58 +22,58 @@ to:   blueprint 74f2e7fd-687e-4c9e-b5d8-e474a5bb8e7c
 
 
     datasets from generation 3:
-    -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
-    dataset name                                                                                                     dataset uuid                           quota     reservation   compression
-    -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
--   oxp_03a84dd2-e0a4-435d-96de-67bfe2674f4e/crucible                                                                d40442a5-6bc0-47e2-b856-eaf133d1e304   none      none          off        
--   oxp_188c3b95-16fa-45ea-b9f7-e987560b4d62/crucible                                                                3c535eee-1560-47b0-be54-ae5a72f81ed7   none      none          off        
--   oxp_1f3bbc7c-888f-40fa-b705-fab3f148b147/crucible                                                                1cc83d94-5150-4c1b-9e60-5520e5dedfbb   none      none          off        
--   oxp_45a81e70-03bb-4c53-bf49-d598c9fb8d34/crucible                                                                240113d4-845f-4183-b4a7-e8c994e062b7   none      none          off        
--   oxp_56c3f0ef-fac1-473d-9317-0e3668aa7e88/crucible                                                                01887c83-946b-463c-a58a-8398019e5a2c   none      none          off        
--   oxp_96f1615c-3dda-427f-8132-408b2fad24e0/crucible                                                                e9dc86e8-1628-4168-88fc-274b0698d692   none      none          off        
--   oxp_a9ef71b2-ec22-421c-adc9-bddc4c0641c4/crucible                                                                3891477e-b97e-4917-a8e0-558852169291   none      none          off        
--   oxp_b9f9c626-3293-48eb-a475-1debaaccdf6c/crucible                                                                3c1cb24a-963a-448e-a7a1-7c701e3c9b2a   none      none          off        
--   oxp_d563fd5f-9306-49b4-8511-78a2f64733ce/crucible                                                                bae3e304-87d5-49b5-aeac-8d6ad6849893   none      none          off        
--   oxp_fcca32b6-9629-468f-a282-63d7da992447/crucible                                                                61f460f4-0afe-4be7-8021-be98ebf8e6a7   none      none          off        
--   oxp_03a84dd2-e0a4-435d-96de-67bfe2674f4e/crypt/clickhouse                                                        dc455819-f15b-410e-bcf1-8c2f728d2c28   none      none          off        
--   oxp_03a84dd2-e0a4-435d-96de-67bfe2674f4e/crypt/clickhouse_keeper                                                 4b06dacf-0426-4474-8f23-d2cc89cebf79   none      none          off        
--   oxp_03a84dd2-e0a4-435d-96de-67bfe2674f4e/crypt/internal_dns                                                      4bb9b134-29cc-48f7-ab87-fe8d848d3bcb   none      none          off        
--   oxp_03a84dd2-e0a4-435d-96de-67bfe2674f4e/crypt/zone                                                              f60180c7-5adc-46cd-95bf-eada188126d5   none      none          off        
--   oxp_188c3b95-16fa-45ea-b9f7-e987560b4d62/crypt/zone                                                              7b71a19c-0787-4289-8758-62e730b8eea7   none      none          off        
--   oxp_1f3bbc7c-888f-40fa-b705-fab3f148b147/crypt/zone                                                              5d7b3a35-7748-4add-9c45-8c13fffa6242   none      none          off        
--   oxp_45a81e70-03bb-4c53-bf49-d598c9fb8d34/crypt/zone                                                              4468c7cd-c756-42c5-8974-5b2fd12fe7d8   none      none          off        
--   oxp_56c3f0ef-fac1-473d-9317-0e3668aa7e88/crypt/zone                                                              063e51c0-4b74-45f3-899e-4f47e405c885   none      none          off        
--   oxp_96f1615c-3dda-427f-8132-408b2fad24e0/crypt/zone                                                              1c629490-3edb-45ad-a45e-30a6fa049dc5   none      none          off        
--   oxp_a9ef71b2-ec22-421c-adc9-bddc4c0641c4/crypt/zone                                                              85569c4c-044f-4f6f-a25d-137a53ed52c1   none      none          off        
--   oxp_b9f9c626-3293-48eb-a475-1debaaccdf6c/crypt/zone                                                              40e94b66-4686-48f3-b606-6ba7d992c8f2   none      none          off        
--   oxp_d563fd5f-9306-49b4-8511-78a2f64733ce/crypt/zone                                                              626ecfdb-dfd7-4ff6-bec6-391c9c44b0e4   none      none          off        
--   oxp_fcca32b6-9629-468f-a282-63d7da992447/crypt/zone                                                              e61020a5-742a-4ee8-bda3-08e6f0a776be   none      none          off        
--   oxp_03a84dd2-e0a4-435d-96de-67bfe2674f4e/crypt/zone/oxz_clickhouse_96dcbb7a-0140-4590-801c-406866500995          87252c34-5d73-4d3a-bce6-6a27dad3fdf6   none      none          off        
--   oxp_03a84dd2-e0a4-435d-96de-67bfe2674f4e/crypt/zone/oxz_clickhouse_keeper_1998de68-a305-44f7-8ebc-cc5613c9e6fb   485f09fd-df18-4d81-a4e7-ba7109c56f86   none      none          off        
--   oxp_a9ef71b2-ec22-421c-adc9-bddc4c0641c4/crypt/zone/oxz_crucible_5366862d-0c9e-4c21-bd16-5599298e75bc            3aa44cc5-0d66-48c3-b4ca-2bf69f9b885e   none      none          off        
--   oxp_45a81e70-03bb-4c53-bf49-d598c9fb8d34/crypt/zone/oxz_crucible_63dcf460-2794-434c-b0e7-4e09ba0f3a3c            80773e28-95b8-4c87-8066-96217d4f91fc   none      none          off        
--   oxp_fcca32b6-9629-468f-a282-63d7da992447/crypt/zone/oxz_crucible_71f24994-337b-4c5f-9826-75f885a669e7            f41aa130-536c-419f-841b-6b70f5d7f04e   none      none          off        
--   oxp_188c3b95-16fa-45ea-b9f7-e987560b4d62/crypt/zone/oxz_crucible_726f6522-a359-4e6e-abe9-0de41979de91            e536abb6-5358-42a9-bda0-ccdd4040bc76   none      none          off        
--   oxp_d563fd5f-9306-49b4-8511-78a2f64733ce/crypt/zone/oxz_crucible_a794a5cd-ec63-4fe4-a813-720d79dcd2ca            46694e7d-bce7-4b0e-a900-a192b4091435   none      none          off        
--   oxp_03a84dd2-e0a4-435d-96de-67bfe2674f4e/crypt/zone/oxz_crucible_ab480489-af1c-4446-8e95-da4a7e58df59            90052aeb-7130-4ff2-aa27-5cf3b04fbb8c   none      none          off        
--   oxp_b9f9c626-3293-48eb-a475-1debaaccdf6c/crypt/zone/oxz_crucible_cc6e2a17-ba9b-4332-b869-e0ce204915cf            98b4a865-2894-4cd2-ac6b-e738281c58bb   none      none          off        
--   oxp_56c3f0ef-fac1-473d-9317-0e3668aa7e88/crypt/zone/oxz_crucible_e5cd215f-19c6-43ca-b31a-039319dd5dcf            36ff569c-9c13-49ea-9326-475045f720b0   none      none          off        
--   oxp_96f1615c-3dda-427f-8132-408b2fad24e0/crypt/zone/oxz_crucible_e7bc709c-4ef2-4f1f-be78-494f53169554            97bb7eaf-90b4-4a0b-802a-fa8505ec75bd   none      none          off        
--   oxp_1f3bbc7c-888f-40fa-b705-fab3f148b147/crypt/zone/oxz_crucible_fbaea242-74a6-490f-9bc0-0710a40768f4            c9cbc06f-28a0-4599-9871-34d1412af931   none      none          off        
--   oxp_03a84dd2-e0a4-435d-96de-67bfe2674f4e/crypt/zone/oxz_crucible_pantry_ed79fef8-6124-4ecc-aaa4-51cf9fcf58db     9dd5432c-c9fc-4d94-8536-f17d51179351   none      none          off        
--   oxp_03a84dd2-e0a4-435d-96de-67bfe2674f4e/crypt/zone/oxz_internal_dns_4d152a2b-089e-4fe2-89fa-76b53fa58773        c4e8da9a-abce-419c-ad1f-3e5ba3277bbd   none      none          off        
--   oxp_03a84dd2-e0a4-435d-96de-67bfe2674f4e/crypt/zone/oxz_nexus_4cb9b6d5-fd52-4cfb-b630-59f80bd26615               fcf013e5-369d-46a8-b613-827c09a19609   none      none          off        
--   oxp_03a84dd2-e0a4-435d-96de-67bfe2674f4e/crypt/zone/oxz_ntp_89d38277-9743-491b-af94-714776657ce2                 d7c7f6d8-8cbf-4e89-9910-beeddeced77d   none      none          off        
--   oxp_03a84dd2-e0a4-435d-96de-67bfe2674f4e/crypt/debug                                                             bc75e6c5-7133-4fcb-8331-e14094471da3   100 GiB   none          gzip-9     
--   oxp_188c3b95-16fa-45ea-b9f7-e987560b4d62/crypt/debug                                                             2682e3a1-a848-4e3c-93f0-3fd6f0d9bb42   100 GiB   none          gzip-9     
--   oxp_1f3bbc7c-888f-40fa-b705-fab3f148b147/crypt/debug                                                             3ce1e570-2d1f-4898-ab97-de7984c655ea   100 GiB   none          gzip-9     
--   oxp_45a81e70-03bb-4c53-bf49-d598c9fb8d34/crypt/debug                                                             c01b1d43-aa78-4faf-a8ca-dcc06af33a6c   100 GiB   none          gzip-9     
--   oxp_56c3f0ef-fac1-473d-9317-0e3668aa7e88/crypt/debug                                                             8246cb67-ed7a-4116-a3d7-565ac65f93b6   100 GiB   none          gzip-9     
--   oxp_96f1615c-3dda-427f-8132-408b2fad24e0/crypt/debug                                                             56460589-94e8-4f23-9a19-e33394556f15   100 GiB   none          gzip-9     
--   oxp_a9ef71b2-ec22-421c-adc9-bddc4c0641c4/crypt/debug                                                             3e4f8418-ecac-487d-8ee6-fda164388f77   100 GiB   none          gzip-9     
--   oxp_b9f9c626-3293-48eb-a475-1debaaccdf6c/crypt/debug                                                             f93f289f-6d12-477c-a2d3-28a8d6d71413   100 GiB   none          gzip-9     
--   oxp_d563fd5f-9306-49b4-8511-78a2f64733ce/crypt/debug                                                             71bee626-79e5-4bc7-98af-e0cf412bbcba   100 GiB   none          gzip-9     
--   oxp_fcca32b6-9629-468f-a282-63d7da992447/crypt/debug                                                             402246fc-dfe5-410c-92c0-d9d497c03188   100 GiB   none          gzip-9     
+    ---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
+    dataset name                                                                                                     dataset id                             disposition   quota     reservation   compression
+    ---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
+-   oxp_03a84dd2-e0a4-435d-96de-67bfe2674f4e/crucible                                                                d40442a5-6bc0-47e2-b856-eaf133d1e304   in service    none      none          off        
+-   oxp_188c3b95-16fa-45ea-b9f7-e987560b4d62/crucible                                                                3c535eee-1560-47b0-be54-ae5a72f81ed7   in service    none      none          off        
+-   oxp_1f3bbc7c-888f-40fa-b705-fab3f148b147/crucible                                                                1cc83d94-5150-4c1b-9e60-5520e5dedfbb   in service    none      none          off        
+-   oxp_45a81e70-03bb-4c53-bf49-d598c9fb8d34/crucible                                                                240113d4-845f-4183-b4a7-e8c994e062b7   in service    none      none          off        
+-   oxp_56c3f0ef-fac1-473d-9317-0e3668aa7e88/crucible                                                                01887c83-946b-463c-a58a-8398019e5a2c   in service    none      none          off        
+-   oxp_96f1615c-3dda-427f-8132-408b2fad24e0/crucible                                                                e9dc86e8-1628-4168-88fc-274b0698d692   in service    none      none          off        
+-   oxp_a9ef71b2-ec22-421c-adc9-bddc4c0641c4/crucible                                                                3891477e-b97e-4917-a8e0-558852169291   in service    none      none          off        
+-   oxp_b9f9c626-3293-48eb-a475-1debaaccdf6c/crucible                                                                3c1cb24a-963a-448e-a7a1-7c701e3c9b2a   in service    none      none          off        
+-   oxp_d563fd5f-9306-49b4-8511-78a2f64733ce/crucible                                                                bae3e304-87d5-49b5-aeac-8d6ad6849893   in service    none      none          off        
+-   oxp_fcca32b6-9629-468f-a282-63d7da992447/crucible                                                                61f460f4-0afe-4be7-8021-be98ebf8e6a7   in service    none      none          off        
+-   oxp_03a84dd2-e0a4-435d-96de-67bfe2674f4e/crypt/clickhouse                                                        dc455819-f15b-410e-bcf1-8c2f728d2c28   in service    none      none          off        
+-   oxp_03a84dd2-e0a4-435d-96de-67bfe2674f4e/crypt/clickhouse_keeper                                                 4b06dacf-0426-4474-8f23-d2cc89cebf79   in service    none      none          off        
+-   oxp_03a84dd2-e0a4-435d-96de-67bfe2674f4e/crypt/internal_dns                                                      4bb9b134-29cc-48f7-ab87-fe8d848d3bcb   in service    none      none          off        
+-   oxp_03a84dd2-e0a4-435d-96de-67bfe2674f4e/crypt/zone                                                              f60180c7-5adc-46cd-95bf-eada188126d5   in service    none      none          off        
+-   oxp_188c3b95-16fa-45ea-b9f7-e987560b4d62/crypt/zone                                                              7b71a19c-0787-4289-8758-62e730b8eea7   in service    none      none          off        
+-   oxp_1f3bbc7c-888f-40fa-b705-fab3f148b147/crypt/zone                                                              5d7b3a35-7748-4add-9c45-8c13fffa6242   in service    none      none          off        
+-   oxp_45a81e70-03bb-4c53-bf49-d598c9fb8d34/crypt/zone                                                              4468c7cd-c756-42c5-8974-5b2fd12fe7d8   in service    none      none          off        
+-   oxp_56c3f0ef-fac1-473d-9317-0e3668aa7e88/crypt/zone                                                              063e51c0-4b74-45f3-899e-4f47e405c885   in service    none      none          off        
+-   oxp_96f1615c-3dda-427f-8132-408b2fad24e0/crypt/zone                                                              1c629490-3edb-45ad-a45e-30a6fa049dc5   in service    none      none          off        
+-   oxp_a9ef71b2-ec22-421c-adc9-bddc4c0641c4/crypt/zone                                                              85569c4c-044f-4f6f-a25d-137a53ed52c1   in service    none      none          off        
+-   oxp_b9f9c626-3293-48eb-a475-1debaaccdf6c/crypt/zone                                                              40e94b66-4686-48f3-b606-6ba7d992c8f2   in service    none      none          off        
+-   oxp_d563fd5f-9306-49b4-8511-78a2f64733ce/crypt/zone                                                              626ecfdb-dfd7-4ff6-bec6-391c9c44b0e4   in service    none      none          off        
+-   oxp_fcca32b6-9629-468f-a282-63d7da992447/crypt/zone                                                              e61020a5-742a-4ee8-bda3-08e6f0a776be   in service    none      none          off        
+-   oxp_03a84dd2-e0a4-435d-96de-67bfe2674f4e/crypt/zone/oxz_clickhouse_96dcbb7a-0140-4590-801c-406866500995          87252c34-5d73-4d3a-bce6-6a27dad3fdf6   in service    none      none          off        
+-   oxp_03a84dd2-e0a4-435d-96de-67bfe2674f4e/crypt/zone/oxz_clickhouse_keeper_1998de68-a305-44f7-8ebc-cc5613c9e6fb   485f09fd-df18-4d81-a4e7-ba7109c56f86   in service    none      none          off        
+-   oxp_a9ef71b2-ec22-421c-adc9-bddc4c0641c4/crypt/zone/oxz_crucible_5366862d-0c9e-4c21-bd16-5599298e75bc            3aa44cc5-0d66-48c3-b4ca-2bf69f9b885e   in service    none      none          off        
+-   oxp_45a81e70-03bb-4c53-bf49-d598c9fb8d34/crypt/zone/oxz_crucible_63dcf460-2794-434c-b0e7-4e09ba0f3a3c            80773e28-95b8-4c87-8066-96217d4f91fc   in service    none      none          off        
+-   oxp_fcca32b6-9629-468f-a282-63d7da992447/crypt/zone/oxz_crucible_71f24994-337b-4c5f-9826-75f885a669e7            f41aa130-536c-419f-841b-6b70f5d7f04e   in service    none      none          off        
+-   oxp_188c3b95-16fa-45ea-b9f7-e987560b4d62/crypt/zone/oxz_crucible_726f6522-a359-4e6e-abe9-0de41979de91            e536abb6-5358-42a9-bda0-ccdd4040bc76   in service    none      none          off        
+-   oxp_d563fd5f-9306-49b4-8511-78a2f64733ce/crypt/zone/oxz_crucible_a794a5cd-ec63-4fe4-a813-720d79dcd2ca            46694e7d-bce7-4b0e-a900-a192b4091435   in service    none      none          off        
+-   oxp_03a84dd2-e0a4-435d-96de-67bfe2674f4e/crypt/zone/oxz_crucible_ab480489-af1c-4446-8e95-da4a7e58df59            90052aeb-7130-4ff2-aa27-5cf3b04fbb8c   in service    none      none          off        
+-   oxp_b9f9c626-3293-48eb-a475-1debaaccdf6c/crypt/zone/oxz_crucible_cc6e2a17-ba9b-4332-b869-e0ce204915cf            98b4a865-2894-4cd2-ac6b-e738281c58bb   in service    none      none          off        
+-   oxp_56c3f0ef-fac1-473d-9317-0e3668aa7e88/crypt/zone/oxz_crucible_e5cd215f-19c6-43ca-b31a-039319dd5dcf            36ff569c-9c13-49ea-9326-475045f720b0   in service    none      none          off        
+-   oxp_96f1615c-3dda-427f-8132-408b2fad24e0/crypt/zone/oxz_crucible_e7bc709c-4ef2-4f1f-be78-494f53169554            97bb7eaf-90b4-4a0b-802a-fa8505ec75bd   in service    none      none          off        
+-   oxp_1f3bbc7c-888f-40fa-b705-fab3f148b147/crypt/zone/oxz_crucible_fbaea242-74a6-490f-9bc0-0710a40768f4            c9cbc06f-28a0-4599-9871-34d1412af931   in service    none      none          off        
+-   oxp_03a84dd2-e0a4-435d-96de-67bfe2674f4e/crypt/zone/oxz_crucible_pantry_ed79fef8-6124-4ecc-aaa4-51cf9fcf58db     9dd5432c-c9fc-4d94-8536-f17d51179351   in service    none      none          off        
+-   oxp_03a84dd2-e0a4-435d-96de-67bfe2674f4e/crypt/zone/oxz_internal_dns_4d152a2b-089e-4fe2-89fa-76b53fa58773        c4e8da9a-abce-419c-ad1f-3e5ba3277bbd   in service    none      none          off        
+-   oxp_03a84dd2-e0a4-435d-96de-67bfe2674f4e/crypt/zone/oxz_nexus_4cb9b6d5-fd52-4cfb-b630-59f80bd26615               fcf013e5-369d-46a8-b613-827c09a19609   in service    none      none          off        
+-   oxp_03a84dd2-e0a4-435d-96de-67bfe2674f4e/crypt/zone/oxz_ntp_89d38277-9743-491b-af94-714776657ce2                 d7c7f6d8-8cbf-4e89-9910-beeddeced77d   in service    none      none          off        
+-   oxp_03a84dd2-e0a4-435d-96de-67bfe2674f4e/crypt/debug                                                             bc75e6c5-7133-4fcb-8331-e14094471da3   in service    100 GiB   none          gzip-9     
+-   oxp_188c3b95-16fa-45ea-b9f7-e987560b4d62/crypt/debug                                                             2682e3a1-a848-4e3c-93f0-3fd6f0d9bb42   in service    100 GiB   none          gzip-9     
+-   oxp_1f3bbc7c-888f-40fa-b705-fab3f148b147/crypt/debug                                                             3ce1e570-2d1f-4898-ab97-de7984c655ea   in service    100 GiB   none          gzip-9     
+-   oxp_45a81e70-03bb-4c53-bf49-d598c9fb8d34/crypt/debug                                                             c01b1d43-aa78-4faf-a8ca-dcc06af33a6c   in service    100 GiB   none          gzip-9     
+-   oxp_56c3f0ef-fac1-473d-9317-0e3668aa7e88/crypt/debug                                                             8246cb67-ed7a-4116-a3d7-565ac65f93b6   in service    100 GiB   none          gzip-9     
+-   oxp_96f1615c-3dda-427f-8132-408b2fad24e0/crypt/debug                                                             56460589-94e8-4f23-9a19-e33394556f15   in service    100 GiB   none          gzip-9     
+-   oxp_a9ef71b2-ec22-421c-adc9-bddc4c0641c4/crypt/debug                                                             3e4f8418-ecac-487d-8ee6-fda164388f77   in service    100 GiB   none          gzip-9     
+-   oxp_b9f9c626-3293-48eb-a475-1debaaccdf6c/crypt/debug                                                             f93f289f-6d12-477c-a2d3-28a8d6d71413   in service    100 GiB   none          gzip-9     
+-   oxp_d563fd5f-9306-49b4-8511-78a2f64733ce/crypt/debug                                                             71bee626-79e5-4bc7-98af-e0cf412bbcba   in service    100 GiB   none          gzip-9     
+-   oxp_fcca32b6-9629-468f-a282-63d7da992447/crypt/debug                                                             402246fc-dfe5-410c-92c0-d9d497c03188   in service    100 GiB   none          gzip-9     
 
 
     omicron zones generation 3 -> 4:
@@ -133,62 +133,62 @@ to:   blueprint 74f2e7fd-687e-4c9e-b5d8-e474a5bb8e7c
 
 
     datasets generation 3 -> 4:
-    -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
-    dataset name                                                                                                     dataset uuid                           quota     reservation   compression
-    -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
-    oxp_08616473-ded4-4785-9b53-b6ccc1efb67a/crucible                                                                7576ef1f-3e41-44cc-b750-9b397374e234   none      none          off        
-    oxp_2d44b756-94df-45ec-a644-50021248682d/crucible                                                                4c886e70-05ef-437c-a7ab-ba8a1b5cf9af   none      none          off        
-    oxp_2dce7cf0-3097-485d-aaf6-9fc51f99eae5/crucible                                                                ec7693f9-a469-48ad-8f8d-6d0bc0138be8   none      none          off        
-    oxp_3b9d69e5-aa80-4fc8-9d2e-a2a24bd0f1d7/crucible                                                                b3ad0776-d6f0-4cbd-a382-a1b78576753b   none      none          off        
-    oxp_44342c41-75a7-4708-8004-eb2ca5c5a3c2/crucible                                                                8d7eebdb-c82f-4a29-b3c3-290bd343814a   none      none          off        
-    oxp_650b4eff-80a2-430a-97c8-f837248480a1/crucible                                                                a30613bb-70dd-43dd-b23c-c8759df0acdd   none      none          off        
-    oxp_6e418b8c-cadd-4fb8-8370-f351a07e1eed/crucible                                                                251a271a-0469-4309-ba94-7ecd827e3425   none      none          off        
-    oxp_6e5772a5-8234-46d1-ba5a-503a83d9d2fb/crucible                                                                8a62b925-a1cf-493a-a05e-67fc73605d82   none      none          off        
-    oxp_c1da692e-7713-43a0-b6bb-5c182084c09d/crucible                                                                649edc79-adc6-4391-a105-a54be7143259   none      none          off        
-    oxp_e35766ef-789a-4b2f-9a6c-e6626d5ab195/crucible                                                                8f1039b4-fd76-4444-802c-96385e68abde   none      none          off        
-    oxp_08616473-ded4-4785-9b53-b6ccc1efb67a/crypt/clickhouse_keeper                                                 00f7bc76-5861-485e-a7a7-8bc475950804   none      none          off        
-    oxp_08616473-ded4-4785-9b53-b6ccc1efb67a/crypt/clickhouse_server                                                 12e71b76-b549-4357-8209-215144d61723   none      none          off        
-    oxp_08616473-ded4-4785-9b53-b6ccc1efb67a/crypt/internal_dns                                                      f2c56628-2b29-42da-9ce3-ca705a0e4a97   none      none          off        
-    oxp_08616473-ded4-4785-9b53-b6ccc1efb67a/crypt/zone                                                              6c76a56e-edc0-46e8-92b4-162920f7de33   none      none          off        
-    oxp_2d44b756-94df-45ec-a644-50021248682d/crypt/zone                                                              ce9648f6-3e8f-4c4f-a116-d57aff785b51   none      none          off        
-    oxp_2dce7cf0-3097-485d-aaf6-9fc51f99eae5/crypt/zone                                                              0c0b9b34-0f11-480b-bc42-83ab3cfb3667   none      none          off        
-    oxp_3b9d69e5-aa80-4fc8-9d2e-a2a24bd0f1d7/crypt/zone                                                              cb900fc0-fd1e-42fd-8e0b-491454d70d5e   none      none          off        
-    oxp_44342c41-75a7-4708-8004-eb2ca5c5a3c2/crypt/zone                                                              cae317ef-de63-4265-a0d7-777c5a70dd4e   none      none          off        
-    oxp_650b4eff-80a2-430a-97c8-f837248480a1/crypt/zone                                                              fec03736-ce6e-444e-b7dc-30ae3d00e502   none      none          off        
-    oxp_6e418b8c-cadd-4fb8-8370-f351a07e1eed/crypt/zone                                                              c22dfc9e-b068-4b85-ae0a-e81bc67f679a   none      none          off        
-    oxp_6e5772a5-8234-46d1-ba5a-503a83d9d2fb/crypt/zone                                                              8b954de0-88d8-4a00-902f-e612eed9da0c   none      none          off        
-    oxp_c1da692e-7713-43a0-b6bb-5c182084c09d/crypt/zone                                                              27d840dc-67e6-4795-8bb1-427213d0df3e   none      none          off        
-    oxp_e35766ef-789a-4b2f-9a6c-e6626d5ab195/crypt/zone                                                              b8e322e8-fe4f-43e8-b51a-d08b12f7e515   none      none          off        
-    oxp_08616473-ded4-4785-9b53-b6ccc1efb67a/crypt/zone/oxz_clickhouse_keeper_3f78fa04-0b7e-4959-9718-c232c76500e1   cbe9ab91-b85c-490d-8561-739c66bd2bee   none      none          off        
-    oxp_08616473-ded4-4785-9b53-b6ccc1efb67a/crypt/zone/oxz_clickhouse_server_f0341fc6-6a73-4318-8787-dd0c6b26c385   39e58c15-5cb4-4f89-9bb3-adef453e9e3d   none      none          off        
-    oxp_650b4eff-80a2-430a-97c8-f837248480a1/crypt/zone/oxz_crucible_49afbe38-6b68-4764-afae-a279a7b9b1ab            3d258387-fe93-49c1-8cad-135b3f3556bf   none      none          off        
-    oxp_6e418b8c-cadd-4fb8-8370-f351a07e1eed/crypt/zone/oxz_crucible_4a223081-0985-45c7-b60e-478c371fde4b            69e7fb35-ff48-4d47-986f-374ce7ebac71   none      none          off        
-    oxp_2d44b756-94df-45ec-a644-50021248682d/crypt/zone/oxz_crucible_4e11460c-cfd2-4fa3-a7a7-25c976accece            6b5f0710-4fab-4921-b1ba-05de5d9ff2c3   none      none          off        
-    oxp_c1da692e-7713-43a0-b6bb-5c182084c09d/crypt/zone/oxz_crucible_4f7d1ee4-bd7b-48a5-99e0-e61fc8e6e58e            45831cd5-d578-4473-a97a-f737aedd9903   none      none          off        
-    oxp_08616473-ded4-4785-9b53-b6ccc1efb67a/crypt/zone/oxz_crucible_7cc30ab4-c566-42d4-8fb0-31a8a27156ff            df1af4ad-ec0e-4094-b8f2-d7ce592f40c0   none      none          off        
-    oxp_6e5772a5-8234-46d1-ba5a-503a83d9d2fb/crypt/zone/oxz_crucible_a50a59b8-b59a-4f1d-b5d4-41f113802b5f            c2832f18-d620-49d0-9c8e-b2fc9871e06f   none      none          off        
-    oxp_44342c41-75a7-4708-8004-eb2ca5c5a3c2/crypt/zone/oxz_crucible_a8839f9e-93f8-42a2-ac3a-9b804a5316f9            fdbdb20f-3a77-4da9-afff-96e7ac54f297   none      none          off        
-    oxp_3b9d69e5-aa80-4fc8-9d2e-a2a24bd0f1d7/crypt/zone/oxz_crucible_da1d617e-6450-4bb8-8696-d1518b2f0731            458a4d6e-83ee-4e74-85e7-69b35dc8045c   none      none          off        
-    oxp_e35766ef-789a-4b2f-9a6c-e6626d5ab195/crypt/zone/oxz_crucible_e71169cf-ee83-47b2-85ec-3396a20b4e02            97f033d1-1878-4429-81cf-9da9dc36bd95   none      none          off        
-    oxp_2dce7cf0-3097-485d-aaf6-9fc51f99eae5/crypt/zone/oxz_crucible_eeab4659-62e8-467f-a6f7-690854db89b5            854c1daf-e3bf-4b0a-84ef-3a1b9912f3df   none      none          off        
-    oxp_08616473-ded4-4785-9b53-b6ccc1efb67a/crypt/zone/oxz_crucible_pantry_2a8f8547-7c9a-4e79-8608-3c925fa3e4b7     74856b03-a612-43b4-94e7-6250cf56fba0   none      none          off        
-    oxp_08616473-ded4-4785-9b53-b6ccc1efb67a/crypt/zone/oxz_internal_dns_e8014d8f-0620-4dde-9fab-435cf4c0c321        2d7179ba-92a0-4bd1-8d5c-eba85fe540d3   none      none          off        
-    oxp_08616473-ded4-4785-9b53-b6ccc1efb67a/crypt/zone/oxz_nexus_d52405a5-debc-4682-8f32-8a3faee16b69               3fab12f1-b0ca-47e2-8865-9710e7e37117   none      none          off        
-    oxp_08616473-ded4-4785-9b53-b6ccc1efb67a/crypt/zone/oxz_ntp_a3e9eacd-48af-4333-aeb8-e7528042e664                 e56af4f5-a7ba-4ff1-a44d-d955f21755b6   none      none          off        
-    oxp_08616473-ded4-4785-9b53-b6ccc1efb67a/crypt/debug                                                             fdd71393-adb7-45c9-8a88-f3ce8d2bb93e   100 GiB   none          gzip-9     
-    oxp_2d44b756-94df-45ec-a644-50021248682d/crypt/debug                                                             c9b2026d-e9fd-4076-9a8c-32b06e34f0a3   100 GiB   none          gzip-9     
-    oxp_2dce7cf0-3097-485d-aaf6-9fc51f99eae5/crypt/debug                                                             3325118f-1ebc-48cd-9ade-cf2d319211b3   100 GiB   none          gzip-9     
-    oxp_3b9d69e5-aa80-4fc8-9d2e-a2a24bd0f1d7/crypt/debug                                                             d0213d2b-116c-4329-a93d-02c69c44c598   100 GiB   none          gzip-9     
-    oxp_44342c41-75a7-4708-8004-eb2ca5c5a3c2/crypt/debug                                                             247e51dd-fe88-43f2-b2bc-366e1b85c12b   100 GiB   none          gzip-9     
-    oxp_650b4eff-80a2-430a-97c8-f837248480a1/crypt/debug                                                             9321a17c-709d-44df-a4e3-8ca09bb3665f   100 GiB   none          gzip-9     
-    oxp_6e418b8c-cadd-4fb8-8370-f351a07e1eed/crypt/debug                                                             ee28398d-301c-4661-85a5-ddf27cff28b4   100 GiB   none          gzip-9     
-    oxp_6e5772a5-8234-46d1-ba5a-503a83d9d2fb/crypt/debug                                                             e74f80f2-5369-4647-8bd0-35b7d8b2a0b0   100 GiB   none          gzip-9     
-    oxp_c1da692e-7713-43a0-b6bb-5c182084c09d/crypt/debug                                                             d0a324c8-9de3-414a-8c8c-3fe301549cdb   100 GiB   none          gzip-9     
-    oxp_e35766ef-789a-4b2f-9a6c-e6626d5ab195/crypt/debug                                                             820def87-14ab-43c9-8f7d-b2be75a2570a   100 GiB   none          gzip-9     
-+   oxp_2d44b756-94df-45ec-a644-50021248682d/crypt/clickhouse_keeper                                                 3b45a02a-3f37-4deb-93c6-0cba30538645   none      none          off        
-+   oxp_2d44b756-94df-45ec-a644-50021248682d/crypt/internal_dns                                                      2bd9382d-ab49-4570-8ec8-c4da8c822693   none      none          off        
-+   oxp_2d44b756-94df-45ec-a644-50021248682d/crypt/zone/oxz_clickhouse_keeper_bbba3c50-ff89-4a7f-96c1-d40ee996c417   ca2a30ab-baf8-4bb9-af14-3d41f6df6bf7   none      none          off        
-+   oxp_2d44b756-94df-45ec-a644-50021248682d/crypt/zone/oxz_internal_dns_7f707d70-deef-42dc-96cc-a76cf6366386        40610ea8-b288-408c-91fd-e40edbba09cf   none      none          off        
+    ---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
+    dataset name                                                                                                     dataset id                             disposition   quota     reservation   compression
+    ---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
+    oxp_08616473-ded4-4785-9b53-b6ccc1efb67a/crucible                                                                7576ef1f-3e41-44cc-b750-9b397374e234   in service    none      none          off        
+    oxp_2d44b756-94df-45ec-a644-50021248682d/crucible                                                                4c886e70-05ef-437c-a7ab-ba8a1b5cf9af   in service    none      none          off        
+    oxp_2dce7cf0-3097-485d-aaf6-9fc51f99eae5/crucible                                                                ec7693f9-a469-48ad-8f8d-6d0bc0138be8   in service    none      none          off        
+    oxp_3b9d69e5-aa80-4fc8-9d2e-a2a24bd0f1d7/crucible                                                                b3ad0776-d6f0-4cbd-a382-a1b78576753b   in service    none      none          off        
+    oxp_44342c41-75a7-4708-8004-eb2ca5c5a3c2/crucible                                                                8d7eebdb-c82f-4a29-b3c3-290bd343814a   in service    none      none          off        
+    oxp_650b4eff-80a2-430a-97c8-f837248480a1/crucible                                                                a30613bb-70dd-43dd-b23c-c8759df0acdd   in service    none      none          off        
+    oxp_6e418b8c-cadd-4fb8-8370-f351a07e1eed/crucible                                                                251a271a-0469-4309-ba94-7ecd827e3425   in service    none      none          off        
+    oxp_6e5772a5-8234-46d1-ba5a-503a83d9d2fb/crucible                                                                8a62b925-a1cf-493a-a05e-67fc73605d82   in service    none      none          off        
+    oxp_c1da692e-7713-43a0-b6bb-5c182084c09d/crucible                                                                649edc79-adc6-4391-a105-a54be7143259   in service    none      none          off        
+    oxp_e35766ef-789a-4b2f-9a6c-e6626d5ab195/crucible                                                                8f1039b4-fd76-4444-802c-96385e68abde   in service    none      none          off        
+    oxp_08616473-ded4-4785-9b53-b6ccc1efb67a/crypt/clickhouse_keeper                                                 00f7bc76-5861-485e-a7a7-8bc475950804   in service    none      none          off        
+    oxp_08616473-ded4-4785-9b53-b6ccc1efb67a/crypt/clickhouse_server                                                 12e71b76-b549-4357-8209-215144d61723   in service    none      none          off        
+    oxp_08616473-ded4-4785-9b53-b6ccc1efb67a/crypt/internal_dns                                                      f2c56628-2b29-42da-9ce3-ca705a0e4a97   in service    none      none          off        
+    oxp_08616473-ded4-4785-9b53-b6ccc1efb67a/crypt/zone                                                              6c76a56e-edc0-46e8-92b4-162920f7de33   in service    none      none          off        
+    oxp_2d44b756-94df-45ec-a644-50021248682d/crypt/zone                                                              ce9648f6-3e8f-4c4f-a116-d57aff785b51   in service    none      none          off        
+    oxp_2dce7cf0-3097-485d-aaf6-9fc51f99eae5/crypt/zone                                                              0c0b9b34-0f11-480b-bc42-83ab3cfb3667   in service    none      none          off        
+    oxp_3b9d69e5-aa80-4fc8-9d2e-a2a24bd0f1d7/crypt/zone                                                              cb900fc0-fd1e-42fd-8e0b-491454d70d5e   in service    none      none          off        
+    oxp_44342c41-75a7-4708-8004-eb2ca5c5a3c2/crypt/zone                                                              cae317ef-de63-4265-a0d7-777c5a70dd4e   in service    none      none          off        
+    oxp_650b4eff-80a2-430a-97c8-f837248480a1/crypt/zone                                                              fec03736-ce6e-444e-b7dc-30ae3d00e502   in service    none      none          off        
+    oxp_6e418b8c-cadd-4fb8-8370-f351a07e1eed/crypt/zone                                                              c22dfc9e-b068-4b85-ae0a-e81bc67f679a   in service    none      none          off        
+    oxp_6e5772a5-8234-46d1-ba5a-503a83d9d2fb/crypt/zone                                                              8b954de0-88d8-4a00-902f-e612eed9da0c   in service    none      none          off        
+    oxp_c1da692e-7713-43a0-b6bb-5c182084c09d/crypt/zone                                                              27d840dc-67e6-4795-8bb1-427213d0df3e   in service    none      none          off        
+    oxp_e35766ef-789a-4b2f-9a6c-e6626d5ab195/crypt/zone                                                              b8e322e8-fe4f-43e8-b51a-d08b12f7e515   in service    none      none          off        
+    oxp_08616473-ded4-4785-9b53-b6ccc1efb67a/crypt/zone/oxz_clickhouse_keeper_3f78fa04-0b7e-4959-9718-c232c76500e1   cbe9ab91-b85c-490d-8561-739c66bd2bee   in service    none      none          off        
+    oxp_08616473-ded4-4785-9b53-b6ccc1efb67a/crypt/zone/oxz_clickhouse_server_f0341fc6-6a73-4318-8787-dd0c6b26c385   39e58c15-5cb4-4f89-9bb3-adef453e9e3d   in service    none      none          off        
+    oxp_650b4eff-80a2-430a-97c8-f837248480a1/crypt/zone/oxz_crucible_49afbe38-6b68-4764-afae-a279a7b9b1ab            3d258387-fe93-49c1-8cad-135b3f3556bf   in service    none      none          off        
+    oxp_6e418b8c-cadd-4fb8-8370-f351a07e1eed/crypt/zone/oxz_crucible_4a223081-0985-45c7-b60e-478c371fde4b            69e7fb35-ff48-4d47-986f-374ce7ebac71   in service    none      none          off        
+    oxp_2d44b756-94df-45ec-a644-50021248682d/crypt/zone/oxz_crucible_4e11460c-cfd2-4fa3-a7a7-25c976accece            6b5f0710-4fab-4921-b1ba-05de5d9ff2c3   in service    none      none          off        
+    oxp_c1da692e-7713-43a0-b6bb-5c182084c09d/crypt/zone/oxz_crucible_4f7d1ee4-bd7b-48a5-99e0-e61fc8e6e58e            45831cd5-d578-4473-a97a-f737aedd9903   in service    none      none          off        
+    oxp_08616473-ded4-4785-9b53-b6ccc1efb67a/crypt/zone/oxz_crucible_7cc30ab4-c566-42d4-8fb0-31a8a27156ff            df1af4ad-ec0e-4094-b8f2-d7ce592f40c0   in service    none      none          off        
+    oxp_6e5772a5-8234-46d1-ba5a-503a83d9d2fb/crypt/zone/oxz_crucible_a50a59b8-b59a-4f1d-b5d4-41f113802b5f            c2832f18-d620-49d0-9c8e-b2fc9871e06f   in service    none      none          off        
+    oxp_44342c41-75a7-4708-8004-eb2ca5c5a3c2/crypt/zone/oxz_crucible_a8839f9e-93f8-42a2-ac3a-9b804a5316f9            fdbdb20f-3a77-4da9-afff-96e7ac54f297   in service    none      none          off        
+    oxp_3b9d69e5-aa80-4fc8-9d2e-a2a24bd0f1d7/crypt/zone/oxz_crucible_da1d617e-6450-4bb8-8696-d1518b2f0731            458a4d6e-83ee-4e74-85e7-69b35dc8045c   in service    none      none          off        
+    oxp_e35766ef-789a-4b2f-9a6c-e6626d5ab195/crypt/zone/oxz_crucible_e71169cf-ee83-47b2-85ec-3396a20b4e02            97f033d1-1878-4429-81cf-9da9dc36bd95   in service    none      none          off        
+    oxp_2dce7cf0-3097-485d-aaf6-9fc51f99eae5/crypt/zone/oxz_crucible_eeab4659-62e8-467f-a6f7-690854db89b5            854c1daf-e3bf-4b0a-84ef-3a1b9912f3df   in service    none      none          off        
+    oxp_08616473-ded4-4785-9b53-b6ccc1efb67a/crypt/zone/oxz_crucible_pantry_2a8f8547-7c9a-4e79-8608-3c925fa3e4b7     74856b03-a612-43b4-94e7-6250cf56fba0   in service    none      none          off        
+    oxp_08616473-ded4-4785-9b53-b6ccc1efb67a/crypt/zone/oxz_internal_dns_e8014d8f-0620-4dde-9fab-435cf4c0c321        2d7179ba-92a0-4bd1-8d5c-eba85fe540d3   in service    none      none          off        
+    oxp_08616473-ded4-4785-9b53-b6ccc1efb67a/crypt/zone/oxz_nexus_d52405a5-debc-4682-8f32-8a3faee16b69               3fab12f1-b0ca-47e2-8865-9710e7e37117   in service    none      none          off        
+    oxp_08616473-ded4-4785-9b53-b6ccc1efb67a/crypt/zone/oxz_ntp_a3e9eacd-48af-4333-aeb8-e7528042e664                 e56af4f5-a7ba-4ff1-a44d-d955f21755b6   in service    none      none          off        
+    oxp_08616473-ded4-4785-9b53-b6ccc1efb67a/crypt/debug                                                             fdd71393-adb7-45c9-8a88-f3ce8d2bb93e   in service    100 GiB   none          gzip-9     
+    oxp_2d44b756-94df-45ec-a644-50021248682d/crypt/debug                                                             c9b2026d-e9fd-4076-9a8c-32b06e34f0a3   in service    100 GiB   none          gzip-9     
+    oxp_2dce7cf0-3097-485d-aaf6-9fc51f99eae5/crypt/debug                                                             3325118f-1ebc-48cd-9ade-cf2d319211b3   in service    100 GiB   none          gzip-9     
+    oxp_3b9d69e5-aa80-4fc8-9d2e-a2a24bd0f1d7/crypt/debug                                                             d0213d2b-116c-4329-a93d-02c69c44c598   in service    100 GiB   none          gzip-9     
+    oxp_44342c41-75a7-4708-8004-eb2ca5c5a3c2/crypt/debug                                                             247e51dd-fe88-43f2-b2bc-366e1b85c12b   in service    100 GiB   none          gzip-9     
+    oxp_650b4eff-80a2-430a-97c8-f837248480a1/crypt/debug                                                             9321a17c-709d-44df-a4e3-8ca09bb3665f   in service    100 GiB   none          gzip-9     
+    oxp_6e418b8c-cadd-4fb8-8370-f351a07e1eed/crypt/debug                                                             ee28398d-301c-4661-85a5-ddf27cff28b4   in service    100 GiB   none          gzip-9     
+    oxp_6e5772a5-8234-46d1-ba5a-503a83d9d2fb/crypt/debug                                                             e74f80f2-5369-4647-8bd0-35b7d8b2a0b0   in service    100 GiB   none          gzip-9     
+    oxp_c1da692e-7713-43a0-b6bb-5c182084c09d/crypt/debug                                                             d0a324c8-9de3-414a-8c8c-3fe301549cdb   in service    100 GiB   none          gzip-9     
+    oxp_e35766ef-789a-4b2f-9a6c-e6626d5ab195/crypt/debug                                                             820def87-14ab-43c9-8f7d-b2be75a2570a   in service    100 GiB   none          gzip-9     
++   oxp_2d44b756-94df-45ec-a644-50021248682d/crypt/clickhouse_keeper                                                 3b45a02a-3f37-4deb-93c6-0cba30538645   in service    none      none          off        
++   oxp_2d44b756-94df-45ec-a644-50021248682d/crypt/internal_dns                                                      2bd9382d-ab49-4570-8ec8-c4da8c822693   in service    none      none          off        
++   oxp_2d44b756-94df-45ec-a644-50021248682d/crypt/zone/oxz_clickhouse_keeper_bbba3c50-ff89-4a7f-96c1-d40ee996c417   ca2a30ab-baf8-4bb9-af14-3d41f6df6bf7   in service    none      none          off        
++   oxp_2d44b756-94df-45ec-a644-50021248682d/crypt/zone/oxz_internal_dns_7f707d70-deef-42dc-96cc-a76cf6366386        40610ea8-b288-408c-91fd-e40edbba09cf   in service    none      none          off        
 
 
     omicron zones generation 3 -> 4:
@@ -234,62 +234,62 @@ to:   blueprint 74f2e7fd-687e-4c9e-b5d8-e474a5bb8e7c
 
 
     datasets generation 3 -> 4:
-    -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
-    dataset name                                                                                                     dataset uuid                           quota     reservation   compression
-    -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
-    oxp_21d60319-5fe1-4a3b-a4c0-6aa7465e7bde/crucible                                                                b97110cd-9c9d-47d8-ac3e-38b2a5fbf4bb   none      none          off        
-    oxp_2acfbb84-5ce0-424e-8d73-44c5071d4430/crucible                                                                b07b36ec-f27e-4bef-bd0e-adbab3dbded0   none      none          off        
-    oxp_2db7f3b4-ed19-4229-b42c-44f49eeb8a91/crucible                                                                50904cf3-e571-42ee-9be7-40e0d293be12   none      none          off        
-    oxp_2fa34d8e-13d9-42d3-b8ba-ca9d74ac496a/crucible                                                                e3ed0aa2-a4bf-4619-a276-ff287c23f260   none      none          off        
-    oxp_355e268c-c932-4f32-841c-f3ec88fe0495/crucible                                                                c5a79172-3a48-4ecc-a814-77f4a0ac87c3   none      none          off        
-    oxp_427b2ccd-998f-4085-af21-e600604cf21e/crucible                                                                0490a48d-59be-412f-8db8-8a8778f5bdce   none      none          off        
-    oxp_588058f2-f51b-4800-a211-1c5dbb32296b/crucible                                                                d148662e-1244-416e-9043-2c6e5bc3391c   none      none          off        
-    oxp_736f6f07-2aa2-4658-8b5c-3bf409ea747a/crucible                                                                55340375-5d36-475d-99d6-8c8dc38a8421   none      none          off        
-    oxp_bcfcdede-7084-4a31-97a8-ac4299c268f9/crucible                                                                cdf74236-d6b4-4872-ab29-3ef21b1f9e9e   none      none          off        
-    oxp_fe379ac6-1938-4cc2-93a9-43b1447229ae/crucible                                                                98085696-2290-4467-b2de-cecd1ab6255e   none      none          off        
-    oxp_21d60319-5fe1-4a3b-a4c0-6aa7465e7bde/crypt/clickhouse_keeper                                                 56624401-f56f-4fd2-88fb-cfd56df535aa   none      none          off        
-    oxp_21d60319-5fe1-4a3b-a4c0-6aa7465e7bde/crypt/clickhouse_server                                                 67e873d4-5ee2-4fcd-bd1f-9311ad2ed23c   none      none          off        
-    oxp_21d60319-5fe1-4a3b-a4c0-6aa7465e7bde/crypt/internal_dns                                                      eba7c3d8-af0f-4de7-9b07-8e63ff8c9a34   none      none          off        
-    oxp_21d60319-5fe1-4a3b-a4c0-6aa7465e7bde/crypt/zone                                                              a27fb298-e263-4560-965a-2c56292ea19a   none      none          off        
-    oxp_2acfbb84-5ce0-424e-8d73-44c5071d4430/crypt/zone                                                              03dfbeda-a138-45c2-975f-05a9af2ef2b9   none      none          off        
-    oxp_2db7f3b4-ed19-4229-b42c-44f49eeb8a91/crypt/zone                                                              40986d49-c197-462c-baac-ba937da44571   none      none          off        
-    oxp_2fa34d8e-13d9-42d3-b8ba-ca9d74ac496a/crypt/zone                                                              006eede7-d6b6-4af2-a2ff-37b94386b421   none      none          off        
-    oxp_355e268c-c932-4f32-841c-f3ec88fe0495/crypt/zone                                                              18279e0e-4f67-4e87-bc5a-2eb3927ec023   none      none          off        
-    oxp_427b2ccd-998f-4085-af21-e600604cf21e/crypt/zone                                                              491b337c-3c25-4284-ae13-443206ff696f   none      none          off        
-    oxp_588058f2-f51b-4800-a211-1c5dbb32296b/crypt/zone                                                              5aa2c795-468a-45df-8769-16f4d5d0e42a   none      none          off        
-    oxp_736f6f07-2aa2-4658-8b5c-3bf409ea747a/crypt/zone                                                              89c95288-774f-480c-ab14-a0327bec365b   none      none          off        
-    oxp_bcfcdede-7084-4a31-97a8-ac4299c268f9/crypt/zone                                                              e7569f72-580c-417b-b223-0e5f998dd9c1   none      none          off        
-    oxp_fe379ac6-1938-4cc2-93a9-43b1447229ae/crypt/zone                                                              2aae5bf8-7c17-43c4-9183-4c1956571243   none      none          off        
-    oxp_21d60319-5fe1-4a3b-a4c0-6aa7465e7bde/crypt/zone/oxz_clickhouse_keeper_2b368dcd-bb4b-4415-9daf-0d36fd769fed   c22caa52-6179-49a7-95dc-5cf0d9f3f827   none      none          off        
-    oxp_21d60319-5fe1-4a3b-a4c0-6aa7465e7bde/crypt/zone/oxz_clickhouse_server_097ab295-aec4-427f-9124-bb4e8aecfeca   e21880d2-f6f9-4e97-b7da-5a8a934845ab   none      none          off        
-    oxp_736f6f07-2aa2-4658-8b5c-3bf409ea747a/crypt/zone/oxz_crucible_308c592a-b022-4790-9824-7a5e10b83d1b            4e514d61-b9d3-4e8c-b528-4b9577d8ad84   none      none          off        
-    oxp_2fa34d8e-13d9-42d3-b8ba-ca9d74ac496a/crypt/zone/oxz_crucible_7233139a-ad5b-4c0e-be80-759fbd5cb262            2c3d31cf-9a06-4f47-8f30-97884d06de8f   none      none          off        
-    oxp_2acfbb84-5ce0-424e-8d73-44c5071d4430/crypt/zone/oxz_crucible_8c43faff-54c7-4b91-820c-ff130b7049e9            9155b21a-1803-44b3-b80e-6d22f7af2e07   none      none          off        
-    oxp_fe379ac6-1938-4cc2-93a9-43b1447229ae/crypt/zone/oxz_crucible_8ddbafde-d699-4e37-b70d-dcd803f0898e            a46724b6-7ca0-4d70-9dd2-6fd22d1e6150   none      none          off        
-    oxp_427b2ccd-998f-4085-af21-e600604cf21e/crypt/zone/oxz_crucible_955bd7eb-8cc2-4128-a636-19bde11ab251            44153191-15ac-4206-b153-167261b232fe   none      none          off        
-    oxp_21d60319-5fe1-4a3b-a4c0-6aa7465e7bde/crypt/zone/oxz_crucible_a6192358-d6e1-4483-a3c6-755a05911f22            5fd12d35-d258-42ca-8fe3-dc5788bdc66c   none      none          off        
-    oxp_bcfcdede-7084-4a31-97a8-ac4299c268f9/crypt/zone/oxz_crucible_a68bc085-0ad5-4c42-a9f7-0b540de24ced            1de186f8-a37f-42fa-9e70-05aa05641c7e   none      none          off        
-    oxp_355e268c-c932-4f32-841c-f3ec88fe0495/crypt/zone/oxz_crucible_cdc00fbb-5ac7-4667-9fc8-926ea73a002a            510ecf2a-6a98-40f2-b387-3bab22da2bf7   none      none          off        
-    oxp_2db7f3b4-ed19-4229-b42c-44f49eeb8a91/crypt/zone/oxz_crucible_d04ed118-4eb8-4ba4-8f05-7714060291e2            282ed619-0004-4647-9d60-85509d68170e   none      none          off        
-    oxp_588058f2-f51b-4800-a211-1c5dbb32296b/crypt/zone/oxz_crucible_e5347768-7d4d-4862-b78e-38291aca675a            ba5652ea-a567-4e7f-a62d-616fd9ab2aff   none      none          off        
-    oxp_21d60319-5fe1-4a3b-a4c0-6aa7465e7bde/crypt/zone/oxz_crucible_pantry_0af27834-4e26-4417-9cc3-9a04105b1cbc     8d62e551-9775-4ac8-a830-15e1f3aabb46   none      none          off        
-    oxp_21d60319-5fe1-4a3b-a4c0-6aa7465e7bde/crypt/zone/oxz_internal_dns_a6212313-b0c0-4a69-9ca6-5ea9c7e3e947        38daea72-c487-4f80-9e27-ef67e6b2d05d   none      none          off        
-    oxp_21d60319-5fe1-4a3b-a4c0-6aa7465e7bde/crypt/zone/oxz_nexus_e786e397-2ccc-4112-bf26-45ca1de89f3b               a26d8d3b-1483-4e98-bb4b-1680c75c2956   none      none          off        
-    oxp_21d60319-5fe1-4a3b-a4c0-6aa7465e7bde/crypt/zone/oxz_ntp_0991f26b-97a1-4033-af5d-df7e56c2189a                 a6f0a3f1-aff9-45d9-8e70-610780c75c73   none      none          off        
-    oxp_21d60319-5fe1-4a3b-a4c0-6aa7465e7bde/crypt/debug                                                             c2868186-4510-4c56-9374-13a4fda781be   100 GiB   none          gzip-9     
-    oxp_2acfbb84-5ce0-424e-8d73-44c5071d4430/crypt/debug                                                             80bb6683-3e89-4652-9b4d-a2adc6dc05c3   100 GiB   none          gzip-9     
-    oxp_2db7f3b4-ed19-4229-b42c-44f49eeb8a91/crypt/debug                                                             35abcc8e-8fae-4e0f-9db7-457c21c27244   100 GiB   none          gzip-9     
-    oxp_2fa34d8e-13d9-42d3-b8ba-ca9d74ac496a/crypt/debug                                                             ae45ae89-0fc5-4c82-8e38-bdc4efb2a4cd   100 GiB   none          gzip-9     
-    oxp_355e268c-c932-4f32-841c-f3ec88fe0495/crypt/debug                                                             f567b79a-c05c-4ba5-85a6-87f217687c9b   100 GiB   none          gzip-9     
-    oxp_427b2ccd-998f-4085-af21-e600604cf21e/crypt/debug                                                             da15e9ee-d60c-4b9d-a383-52c8c82f8bad   100 GiB   none          gzip-9     
-    oxp_588058f2-f51b-4800-a211-1c5dbb32296b/crypt/debug                                                             f8390042-25a5-43db-9d6c-336223c5210f   100 GiB   none          gzip-9     
-    oxp_736f6f07-2aa2-4658-8b5c-3bf409ea747a/crypt/debug                                                             68191fe0-2606-4d82-833e-e467ff129a19   100 GiB   none          gzip-9     
-    oxp_bcfcdede-7084-4a31-97a8-ac4299c268f9/crypt/debug                                                             2755f94e-a5e8-4bf8-8cdc-2645e5b21578   100 GiB   none          gzip-9     
-    oxp_fe379ac6-1938-4cc2-93a9-43b1447229ae/crypt/debug                                                             68b11f7e-4258-483b-a75a-4243ca7ede6f   100 GiB   none          gzip-9     
-+   oxp_21d60319-5fe1-4a3b-a4c0-6aa7465e7bde/crypt/clickhouse                                                        650004ee-2360-47a3-ba98-b07dd9873c06   none      none          off        
-+   oxp_21d60319-5fe1-4a3b-a4c0-6aa7465e7bde/crypt/zone/oxz_clickhouse_ca54c155-5e4c-42e6-96f2-b70448019418          b760c1d2-fa43-441d-8b79-d1fde01a8753   none      none          off        
-+   oxp_2acfbb84-5ce0-424e-8d73-44c5071d4430/crypt/zone/oxz_crucible_pantry_84fc3bdc-a8f6-4ceb-8fcf-59a003bc91c0     96d231ab-baee-465f-a584-6eedcc3e14cc   none      none          off        
-+   oxp_2acfbb84-5ce0-424e-8d73-44c5071d4430/crypt/zone/oxz_nexus_b2e9a34b-7b15-4f56-836d-b39e474afbc5               a89cea5b-db88-4f12-a2f4-700a04803af1   none      none          off        
+    ---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
+    dataset name                                                                                                     dataset id                             disposition   quota     reservation   compression
+    ---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
+    oxp_21d60319-5fe1-4a3b-a4c0-6aa7465e7bde/crucible                                                                b97110cd-9c9d-47d8-ac3e-38b2a5fbf4bb   in service    none      none          off        
+    oxp_2acfbb84-5ce0-424e-8d73-44c5071d4430/crucible                                                                b07b36ec-f27e-4bef-bd0e-adbab3dbded0   in service    none      none          off        
+    oxp_2db7f3b4-ed19-4229-b42c-44f49eeb8a91/crucible                                                                50904cf3-e571-42ee-9be7-40e0d293be12   in service    none      none          off        
+    oxp_2fa34d8e-13d9-42d3-b8ba-ca9d74ac496a/crucible                                                                e3ed0aa2-a4bf-4619-a276-ff287c23f260   in service    none      none          off        
+    oxp_355e268c-c932-4f32-841c-f3ec88fe0495/crucible                                                                c5a79172-3a48-4ecc-a814-77f4a0ac87c3   in service    none      none          off        
+    oxp_427b2ccd-998f-4085-af21-e600604cf21e/crucible                                                                0490a48d-59be-412f-8db8-8a8778f5bdce   in service    none      none          off        
+    oxp_588058f2-f51b-4800-a211-1c5dbb32296b/crucible                                                                d148662e-1244-416e-9043-2c6e5bc3391c   in service    none      none          off        
+    oxp_736f6f07-2aa2-4658-8b5c-3bf409ea747a/crucible                                                                55340375-5d36-475d-99d6-8c8dc38a8421   in service    none      none          off        
+    oxp_bcfcdede-7084-4a31-97a8-ac4299c268f9/crucible                                                                cdf74236-d6b4-4872-ab29-3ef21b1f9e9e   in service    none      none          off        
+    oxp_fe379ac6-1938-4cc2-93a9-43b1447229ae/crucible                                                                98085696-2290-4467-b2de-cecd1ab6255e   in service    none      none          off        
+    oxp_21d60319-5fe1-4a3b-a4c0-6aa7465e7bde/crypt/clickhouse_keeper                                                 56624401-f56f-4fd2-88fb-cfd56df535aa   in service    none      none          off        
+    oxp_21d60319-5fe1-4a3b-a4c0-6aa7465e7bde/crypt/clickhouse_server                                                 67e873d4-5ee2-4fcd-bd1f-9311ad2ed23c   in service    none      none          off        
+    oxp_21d60319-5fe1-4a3b-a4c0-6aa7465e7bde/crypt/internal_dns                                                      eba7c3d8-af0f-4de7-9b07-8e63ff8c9a34   in service    none      none          off        
+    oxp_21d60319-5fe1-4a3b-a4c0-6aa7465e7bde/crypt/zone                                                              a27fb298-e263-4560-965a-2c56292ea19a   in service    none      none          off        
+    oxp_2acfbb84-5ce0-424e-8d73-44c5071d4430/crypt/zone                                                              03dfbeda-a138-45c2-975f-05a9af2ef2b9   in service    none      none          off        
+    oxp_2db7f3b4-ed19-4229-b42c-44f49eeb8a91/crypt/zone                                                              40986d49-c197-462c-baac-ba937da44571   in service    none      none          off        
+    oxp_2fa34d8e-13d9-42d3-b8ba-ca9d74ac496a/crypt/zone                                                              006eede7-d6b6-4af2-a2ff-37b94386b421   in service    none      none          off        
+    oxp_355e268c-c932-4f32-841c-f3ec88fe0495/crypt/zone                                                              18279e0e-4f67-4e87-bc5a-2eb3927ec023   in service    none      none          off        
+    oxp_427b2ccd-998f-4085-af21-e600604cf21e/crypt/zone                                                              491b337c-3c25-4284-ae13-443206ff696f   in service    none      none          off        
+    oxp_588058f2-f51b-4800-a211-1c5dbb32296b/crypt/zone                                                              5aa2c795-468a-45df-8769-16f4d5d0e42a   in service    none      none          off        
+    oxp_736f6f07-2aa2-4658-8b5c-3bf409ea747a/crypt/zone                                                              89c95288-774f-480c-ab14-a0327bec365b   in service    none      none          off        
+    oxp_bcfcdede-7084-4a31-97a8-ac4299c268f9/crypt/zone                                                              e7569f72-580c-417b-b223-0e5f998dd9c1   in service    none      none          off        
+    oxp_fe379ac6-1938-4cc2-93a9-43b1447229ae/crypt/zone                                                              2aae5bf8-7c17-43c4-9183-4c1956571243   in service    none      none          off        
+    oxp_21d60319-5fe1-4a3b-a4c0-6aa7465e7bde/crypt/zone/oxz_clickhouse_keeper_2b368dcd-bb4b-4415-9daf-0d36fd769fed   c22caa52-6179-49a7-95dc-5cf0d9f3f827   in service    none      none          off        
+    oxp_21d60319-5fe1-4a3b-a4c0-6aa7465e7bde/crypt/zone/oxz_clickhouse_server_097ab295-aec4-427f-9124-bb4e8aecfeca   e21880d2-f6f9-4e97-b7da-5a8a934845ab   in service    none      none          off        
+    oxp_736f6f07-2aa2-4658-8b5c-3bf409ea747a/crypt/zone/oxz_crucible_308c592a-b022-4790-9824-7a5e10b83d1b            4e514d61-b9d3-4e8c-b528-4b9577d8ad84   in service    none      none          off        
+    oxp_2fa34d8e-13d9-42d3-b8ba-ca9d74ac496a/crypt/zone/oxz_crucible_7233139a-ad5b-4c0e-be80-759fbd5cb262            2c3d31cf-9a06-4f47-8f30-97884d06de8f   in service    none      none          off        
+    oxp_2acfbb84-5ce0-424e-8d73-44c5071d4430/crypt/zone/oxz_crucible_8c43faff-54c7-4b91-820c-ff130b7049e9            9155b21a-1803-44b3-b80e-6d22f7af2e07   in service    none      none          off        
+    oxp_fe379ac6-1938-4cc2-93a9-43b1447229ae/crypt/zone/oxz_crucible_8ddbafde-d699-4e37-b70d-dcd803f0898e            a46724b6-7ca0-4d70-9dd2-6fd22d1e6150   in service    none      none          off        
+    oxp_427b2ccd-998f-4085-af21-e600604cf21e/crypt/zone/oxz_crucible_955bd7eb-8cc2-4128-a636-19bde11ab251            44153191-15ac-4206-b153-167261b232fe   in service    none      none          off        
+    oxp_21d60319-5fe1-4a3b-a4c0-6aa7465e7bde/crypt/zone/oxz_crucible_a6192358-d6e1-4483-a3c6-755a05911f22            5fd12d35-d258-42ca-8fe3-dc5788bdc66c   in service    none      none          off        
+    oxp_bcfcdede-7084-4a31-97a8-ac4299c268f9/crypt/zone/oxz_crucible_a68bc085-0ad5-4c42-a9f7-0b540de24ced            1de186f8-a37f-42fa-9e70-05aa05641c7e   in service    none      none          off        
+    oxp_355e268c-c932-4f32-841c-f3ec88fe0495/crypt/zone/oxz_crucible_cdc00fbb-5ac7-4667-9fc8-926ea73a002a            510ecf2a-6a98-40f2-b387-3bab22da2bf7   in service    none      none          off        
+    oxp_2db7f3b4-ed19-4229-b42c-44f49eeb8a91/crypt/zone/oxz_crucible_d04ed118-4eb8-4ba4-8f05-7714060291e2            282ed619-0004-4647-9d60-85509d68170e   in service    none      none          off        
+    oxp_588058f2-f51b-4800-a211-1c5dbb32296b/crypt/zone/oxz_crucible_e5347768-7d4d-4862-b78e-38291aca675a            ba5652ea-a567-4e7f-a62d-616fd9ab2aff   in service    none      none          off        
+    oxp_21d60319-5fe1-4a3b-a4c0-6aa7465e7bde/crypt/zone/oxz_crucible_pantry_0af27834-4e26-4417-9cc3-9a04105b1cbc     8d62e551-9775-4ac8-a830-15e1f3aabb46   in service    none      none          off        
+    oxp_21d60319-5fe1-4a3b-a4c0-6aa7465e7bde/crypt/zone/oxz_internal_dns_a6212313-b0c0-4a69-9ca6-5ea9c7e3e947        38daea72-c487-4f80-9e27-ef67e6b2d05d   in service    none      none          off        
+    oxp_21d60319-5fe1-4a3b-a4c0-6aa7465e7bde/crypt/zone/oxz_nexus_e786e397-2ccc-4112-bf26-45ca1de89f3b               a26d8d3b-1483-4e98-bb4b-1680c75c2956   in service    none      none          off        
+    oxp_21d60319-5fe1-4a3b-a4c0-6aa7465e7bde/crypt/zone/oxz_ntp_0991f26b-97a1-4033-af5d-df7e56c2189a                 a6f0a3f1-aff9-45d9-8e70-610780c75c73   in service    none      none          off        
+    oxp_21d60319-5fe1-4a3b-a4c0-6aa7465e7bde/crypt/debug                                                             c2868186-4510-4c56-9374-13a4fda781be   in service    100 GiB   none          gzip-9     
+    oxp_2acfbb84-5ce0-424e-8d73-44c5071d4430/crypt/debug                                                             80bb6683-3e89-4652-9b4d-a2adc6dc05c3   in service    100 GiB   none          gzip-9     
+    oxp_2db7f3b4-ed19-4229-b42c-44f49eeb8a91/crypt/debug                                                             35abcc8e-8fae-4e0f-9db7-457c21c27244   in service    100 GiB   none          gzip-9     
+    oxp_2fa34d8e-13d9-42d3-b8ba-ca9d74ac496a/crypt/debug                                                             ae45ae89-0fc5-4c82-8e38-bdc4efb2a4cd   in service    100 GiB   none          gzip-9     
+    oxp_355e268c-c932-4f32-841c-f3ec88fe0495/crypt/debug                                                             f567b79a-c05c-4ba5-85a6-87f217687c9b   in service    100 GiB   none          gzip-9     
+    oxp_427b2ccd-998f-4085-af21-e600604cf21e/crypt/debug                                                             da15e9ee-d60c-4b9d-a383-52c8c82f8bad   in service    100 GiB   none          gzip-9     
+    oxp_588058f2-f51b-4800-a211-1c5dbb32296b/crypt/debug                                                             f8390042-25a5-43db-9d6c-336223c5210f   in service    100 GiB   none          gzip-9     
+    oxp_736f6f07-2aa2-4658-8b5c-3bf409ea747a/crypt/debug                                                             68191fe0-2606-4d82-833e-e467ff129a19   in service    100 GiB   none          gzip-9     
+    oxp_bcfcdede-7084-4a31-97a8-ac4299c268f9/crypt/debug                                                             2755f94e-a5e8-4bf8-8cdc-2645e5b21578   in service    100 GiB   none          gzip-9     
+    oxp_fe379ac6-1938-4cc2-93a9-43b1447229ae/crypt/debug                                                             68b11f7e-4258-483b-a75a-4243ca7ede6f   in service    100 GiB   none          gzip-9     
++   oxp_21d60319-5fe1-4a3b-a4c0-6aa7465e7bde/crypt/clickhouse                                                        650004ee-2360-47a3-ba98-b07dd9873c06   in service    none      none          off        
++   oxp_21d60319-5fe1-4a3b-a4c0-6aa7465e7bde/crypt/zone/oxz_clickhouse_ca54c155-5e4c-42e6-96f2-b70448019418          b760c1d2-fa43-441d-8b79-d1fde01a8753   in service    none      none          off        
++   oxp_2acfbb84-5ce0-424e-8d73-44c5071d4430/crypt/zone/oxz_crucible_pantry_84fc3bdc-a8f6-4ceb-8fcf-59a003bc91c0     96d231ab-baee-465f-a584-6eedcc3e14cc   in service    none      none          off        
++   oxp_2acfbb84-5ce0-424e-8d73-44c5071d4430/crypt/zone/oxz_nexus_b2e9a34b-7b15-4f56-836d-b39e474afbc5               a89cea5b-db88-4f12-a2f4-700a04803af1   in service    none      none          off        
 
 
     omicron zones generation 3 -> 4:

--- a/nexus/reconfigurator/planning/tests/output/planner_expunge_clickhouse_clusters_5_6.txt
+++ b/nexus/reconfigurator/planning/tests/output/planner_expunge_clickhouse_clusters_5_6.txt
@@ -46,62 +46,62 @@ to:   blueprint df68d4d4-5af4-4b56-95bb-1654a6957d4f
 
 
     datasets at generation 4:
-    -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
-    dataset name                                                                                                     dataset uuid                           quota     reservation   compression
-    -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
-    oxp_08616473-ded4-4785-9b53-b6ccc1efb67a/crucible                                                                7576ef1f-3e41-44cc-b750-9b397374e234   none      none          off        
-    oxp_2d44b756-94df-45ec-a644-50021248682d/crucible                                                                4c886e70-05ef-437c-a7ab-ba8a1b5cf9af   none      none          off        
-    oxp_2dce7cf0-3097-485d-aaf6-9fc51f99eae5/crucible                                                                ec7693f9-a469-48ad-8f8d-6d0bc0138be8   none      none          off        
-    oxp_3b9d69e5-aa80-4fc8-9d2e-a2a24bd0f1d7/crucible                                                                b3ad0776-d6f0-4cbd-a382-a1b78576753b   none      none          off        
-    oxp_44342c41-75a7-4708-8004-eb2ca5c5a3c2/crucible                                                                8d7eebdb-c82f-4a29-b3c3-290bd343814a   none      none          off        
-    oxp_650b4eff-80a2-430a-97c8-f837248480a1/crucible                                                                a30613bb-70dd-43dd-b23c-c8759df0acdd   none      none          off        
-    oxp_6e418b8c-cadd-4fb8-8370-f351a07e1eed/crucible                                                                251a271a-0469-4309-ba94-7ecd827e3425   none      none          off        
-    oxp_6e5772a5-8234-46d1-ba5a-503a83d9d2fb/crucible                                                                8a62b925-a1cf-493a-a05e-67fc73605d82   none      none          off        
-    oxp_c1da692e-7713-43a0-b6bb-5c182084c09d/crucible                                                                649edc79-adc6-4391-a105-a54be7143259   none      none          off        
-    oxp_e35766ef-789a-4b2f-9a6c-e6626d5ab195/crucible                                                                8f1039b4-fd76-4444-802c-96385e68abde   none      none          off        
-    oxp_08616473-ded4-4785-9b53-b6ccc1efb67a/crypt/clickhouse_keeper                                                 00f7bc76-5861-485e-a7a7-8bc475950804   none      none          off        
-    oxp_2d44b756-94df-45ec-a644-50021248682d/crypt/clickhouse_keeper                                                 3b45a02a-3f37-4deb-93c6-0cba30538645   none      none          off        
-    oxp_08616473-ded4-4785-9b53-b6ccc1efb67a/crypt/clickhouse_server                                                 12e71b76-b549-4357-8209-215144d61723   none      none          off        
-    oxp_08616473-ded4-4785-9b53-b6ccc1efb67a/crypt/internal_dns                                                      f2c56628-2b29-42da-9ce3-ca705a0e4a97   none      none          off        
-    oxp_2d44b756-94df-45ec-a644-50021248682d/crypt/internal_dns                                                      2bd9382d-ab49-4570-8ec8-c4da8c822693   none      none          off        
-    oxp_08616473-ded4-4785-9b53-b6ccc1efb67a/crypt/zone                                                              6c76a56e-edc0-46e8-92b4-162920f7de33   none      none          off        
-    oxp_2d44b756-94df-45ec-a644-50021248682d/crypt/zone                                                              ce9648f6-3e8f-4c4f-a116-d57aff785b51   none      none          off        
-    oxp_2dce7cf0-3097-485d-aaf6-9fc51f99eae5/crypt/zone                                                              0c0b9b34-0f11-480b-bc42-83ab3cfb3667   none      none          off        
-    oxp_3b9d69e5-aa80-4fc8-9d2e-a2a24bd0f1d7/crypt/zone                                                              cb900fc0-fd1e-42fd-8e0b-491454d70d5e   none      none          off        
-    oxp_44342c41-75a7-4708-8004-eb2ca5c5a3c2/crypt/zone                                                              cae317ef-de63-4265-a0d7-777c5a70dd4e   none      none          off        
-    oxp_650b4eff-80a2-430a-97c8-f837248480a1/crypt/zone                                                              fec03736-ce6e-444e-b7dc-30ae3d00e502   none      none          off        
-    oxp_6e418b8c-cadd-4fb8-8370-f351a07e1eed/crypt/zone                                                              c22dfc9e-b068-4b85-ae0a-e81bc67f679a   none      none          off        
-    oxp_6e5772a5-8234-46d1-ba5a-503a83d9d2fb/crypt/zone                                                              8b954de0-88d8-4a00-902f-e612eed9da0c   none      none          off        
-    oxp_c1da692e-7713-43a0-b6bb-5c182084c09d/crypt/zone                                                              27d840dc-67e6-4795-8bb1-427213d0df3e   none      none          off        
-    oxp_e35766ef-789a-4b2f-9a6c-e6626d5ab195/crypt/zone                                                              b8e322e8-fe4f-43e8-b51a-d08b12f7e515   none      none          off        
-    oxp_08616473-ded4-4785-9b53-b6ccc1efb67a/crypt/zone/oxz_clickhouse_keeper_3f78fa04-0b7e-4959-9718-c232c76500e1   cbe9ab91-b85c-490d-8561-739c66bd2bee   none      none          off        
-    oxp_2d44b756-94df-45ec-a644-50021248682d/crypt/zone/oxz_clickhouse_keeper_bbba3c50-ff89-4a7f-96c1-d40ee996c417   ca2a30ab-baf8-4bb9-af14-3d41f6df6bf7   none      none          off        
-    oxp_08616473-ded4-4785-9b53-b6ccc1efb67a/crypt/zone/oxz_clickhouse_server_f0341fc6-6a73-4318-8787-dd0c6b26c385   39e58c15-5cb4-4f89-9bb3-adef453e9e3d   none      none          off        
-    oxp_650b4eff-80a2-430a-97c8-f837248480a1/crypt/zone/oxz_crucible_49afbe38-6b68-4764-afae-a279a7b9b1ab            3d258387-fe93-49c1-8cad-135b3f3556bf   none      none          off        
-    oxp_6e418b8c-cadd-4fb8-8370-f351a07e1eed/crypt/zone/oxz_crucible_4a223081-0985-45c7-b60e-478c371fde4b            69e7fb35-ff48-4d47-986f-374ce7ebac71   none      none          off        
-    oxp_2d44b756-94df-45ec-a644-50021248682d/crypt/zone/oxz_crucible_4e11460c-cfd2-4fa3-a7a7-25c976accece            6b5f0710-4fab-4921-b1ba-05de5d9ff2c3   none      none          off        
-    oxp_c1da692e-7713-43a0-b6bb-5c182084c09d/crypt/zone/oxz_crucible_4f7d1ee4-bd7b-48a5-99e0-e61fc8e6e58e            45831cd5-d578-4473-a97a-f737aedd9903   none      none          off        
-    oxp_08616473-ded4-4785-9b53-b6ccc1efb67a/crypt/zone/oxz_crucible_7cc30ab4-c566-42d4-8fb0-31a8a27156ff            df1af4ad-ec0e-4094-b8f2-d7ce592f40c0   none      none          off        
-    oxp_6e5772a5-8234-46d1-ba5a-503a83d9d2fb/crypt/zone/oxz_crucible_a50a59b8-b59a-4f1d-b5d4-41f113802b5f            c2832f18-d620-49d0-9c8e-b2fc9871e06f   none      none          off        
-    oxp_44342c41-75a7-4708-8004-eb2ca5c5a3c2/crypt/zone/oxz_crucible_a8839f9e-93f8-42a2-ac3a-9b804a5316f9            fdbdb20f-3a77-4da9-afff-96e7ac54f297   none      none          off        
-    oxp_3b9d69e5-aa80-4fc8-9d2e-a2a24bd0f1d7/crypt/zone/oxz_crucible_da1d617e-6450-4bb8-8696-d1518b2f0731            458a4d6e-83ee-4e74-85e7-69b35dc8045c   none      none          off        
-    oxp_e35766ef-789a-4b2f-9a6c-e6626d5ab195/crypt/zone/oxz_crucible_e71169cf-ee83-47b2-85ec-3396a20b4e02            97f033d1-1878-4429-81cf-9da9dc36bd95   none      none          off        
-    oxp_2dce7cf0-3097-485d-aaf6-9fc51f99eae5/crypt/zone/oxz_crucible_eeab4659-62e8-467f-a6f7-690854db89b5            854c1daf-e3bf-4b0a-84ef-3a1b9912f3df   none      none          off        
-    oxp_08616473-ded4-4785-9b53-b6ccc1efb67a/crypt/zone/oxz_crucible_pantry_2a8f8547-7c9a-4e79-8608-3c925fa3e4b7     74856b03-a612-43b4-94e7-6250cf56fba0   none      none          off        
-    oxp_2d44b756-94df-45ec-a644-50021248682d/crypt/zone/oxz_internal_dns_7f707d70-deef-42dc-96cc-a76cf6366386        40610ea8-b288-408c-91fd-e40edbba09cf   none      none          off        
-    oxp_08616473-ded4-4785-9b53-b6ccc1efb67a/crypt/zone/oxz_internal_dns_e8014d8f-0620-4dde-9fab-435cf4c0c321        2d7179ba-92a0-4bd1-8d5c-eba85fe540d3   none      none          off        
-    oxp_08616473-ded4-4785-9b53-b6ccc1efb67a/crypt/zone/oxz_nexus_d52405a5-debc-4682-8f32-8a3faee16b69               3fab12f1-b0ca-47e2-8865-9710e7e37117   none      none          off        
-    oxp_08616473-ded4-4785-9b53-b6ccc1efb67a/crypt/zone/oxz_ntp_a3e9eacd-48af-4333-aeb8-e7528042e664                 e56af4f5-a7ba-4ff1-a44d-d955f21755b6   none      none          off        
-    oxp_08616473-ded4-4785-9b53-b6ccc1efb67a/crypt/debug                                                             fdd71393-adb7-45c9-8a88-f3ce8d2bb93e   100 GiB   none          gzip-9     
-    oxp_2d44b756-94df-45ec-a644-50021248682d/crypt/debug                                                             c9b2026d-e9fd-4076-9a8c-32b06e34f0a3   100 GiB   none          gzip-9     
-    oxp_2dce7cf0-3097-485d-aaf6-9fc51f99eae5/crypt/debug                                                             3325118f-1ebc-48cd-9ade-cf2d319211b3   100 GiB   none          gzip-9     
-    oxp_3b9d69e5-aa80-4fc8-9d2e-a2a24bd0f1d7/crypt/debug                                                             d0213d2b-116c-4329-a93d-02c69c44c598   100 GiB   none          gzip-9     
-    oxp_44342c41-75a7-4708-8004-eb2ca5c5a3c2/crypt/debug                                                             247e51dd-fe88-43f2-b2bc-366e1b85c12b   100 GiB   none          gzip-9     
-    oxp_650b4eff-80a2-430a-97c8-f837248480a1/crypt/debug                                                             9321a17c-709d-44df-a4e3-8ca09bb3665f   100 GiB   none          gzip-9     
-    oxp_6e418b8c-cadd-4fb8-8370-f351a07e1eed/crypt/debug                                                             ee28398d-301c-4661-85a5-ddf27cff28b4   100 GiB   none          gzip-9     
-    oxp_6e5772a5-8234-46d1-ba5a-503a83d9d2fb/crypt/debug                                                             e74f80f2-5369-4647-8bd0-35b7d8b2a0b0   100 GiB   none          gzip-9     
-    oxp_c1da692e-7713-43a0-b6bb-5c182084c09d/crypt/debug                                                             d0a324c8-9de3-414a-8c8c-3fe301549cdb   100 GiB   none          gzip-9     
-    oxp_e35766ef-789a-4b2f-9a6c-e6626d5ab195/crypt/debug                                                             820def87-14ab-43c9-8f7d-b2be75a2570a   100 GiB   none          gzip-9     
+    ---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
+    dataset name                                                                                                     dataset id                             disposition   quota     reservation   compression
+    ---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
+    oxp_08616473-ded4-4785-9b53-b6ccc1efb67a/crucible                                                                7576ef1f-3e41-44cc-b750-9b397374e234   in service    none      none          off        
+    oxp_2d44b756-94df-45ec-a644-50021248682d/crucible                                                                4c886e70-05ef-437c-a7ab-ba8a1b5cf9af   in service    none      none          off        
+    oxp_2dce7cf0-3097-485d-aaf6-9fc51f99eae5/crucible                                                                ec7693f9-a469-48ad-8f8d-6d0bc0138be8   in service    none      none          off        
+    oxp_3b9d69e5-aa80-4fc8-9d2e-a2a24bd0f1d7/crucible                                                                b3ad0776-d6f0-4cbd-a382-a1b78576753b   in service    none      none          off        
+    oxp_44342c41-75a7-4708-8004-eb2ca5c5a3c2/crucible                                                                8d7eebdb-c82f-4a29-b3c3-290bd343814a   in service    none      none          off        
+    oxp_650b4eff-80a2-430a-97c8-f837248480a1/crucible                                                                a30613bb-70dd-43dd-b23c-c8759df0acdd   in service    none      none          off        
+    oxp_6e418b8c-cadd-4fb8-8370-f351a07e1eed/crucible                                                                251a271a-0469-4309-ba94-7ecd827e3425   in service    none      none          off        
+    oxp_6e5772a5-8234-46d1-ba5a-503a83d9d2fb/crucible                                                                8a62b925-a1cf-493a-a05e-67fc73605d82   in service    none      none          off        
+    oxp_c1da692e-7713-43a0-b6bb-5c182084c09d/crucible                                                                649edc79-adc6-4391-a105-a54be7143259   in service    none      none          off        
+    oxp_e35766ef-789a-4b2f-9a6c-e6626d5ab195/crucible                                                                8f1039b4-fd76-4444-802c-96385e68abde   in service    none      none          off        
+    oxp_08616473-ded4-4785-9b53-b6ccc1efb67a/crypt/clickhouse_keeper                                                 00f7bc76-5861-485e-a7a7-8bc475950804   in service    none      none          off        
+    oxp_2d44b756-94df-45ec-a644-50021248682d/crypt/clickhouse_keeper                                                 3b45a02a-3f37-4deb-93c6-0cba30538645   in service    none      none          off        
+    oxp_08616473-ded4-4785-9b53-b6ccc1efb67a/crypt/clickhouse_server                                                 12e71b76-b549-4357-8209-215144d61723   in service    none      none          off        
+    oxp_08616473-ded4-4785-9b53-b6ccc1efb67a/crypt/internal_dns                                                      f2c56628-2b29-42da-9ce3-ca705a0e4a97   in service    none      none          off        
+    oxp_2d44b756-94df-45ec-a644-50021248682d/crypt/internal_dns                                                      2bd9382d-ab49-4570-8ec8-c4da8c822693   in service    none      none          off        
+    oxp_08616473-ded4-4785-9b53-b6ccc1efb67a/crypt/zone                                                              6c76a56e-edc0-46e8-92b4-162920f7de33   in service    none      none          off        
+    oxp_2d44b756-94df-45ec-a644-50021248682d/crypt/zone                                                              ce9648f6-3e8f-4c4f-a116-d57aff785b51   in service    none      none          off        
+    oxp_2dce7cf0-3097-485d-aaf6-9fc51f99eae5/crypt/zone                                                              0c0b9b34-0f11-480b-bc42-83ab3cfb3667   in service    none      none          off        
+    oxp_3b9d69e5-aa80-4fc8-9d2e-a2a24bd0f1d7/crypt/zone                                                              cb900fc0-fd1e-42fd-8e0b-491454d70d5e   in service    none      none          off        
+    oxp_44342c41-75a7-4708-8004-eb2ca5c5a3c2/crypt/zone                                                              cae317ef-de63-4265-a0d7-777c5a70dd4e   in service    none      none          off        
+    oxp_650b4eff-80a2-430a-97c8-f837248480a1/crypt/zone                                                              fec03736-ce6e-444e-b7dc-30ae3d00e502   in service    none      none          off        
+    oxp_6e418b8c-cadd-4fb8-8370-f351a07e1eed/crypt/zone                                                              c22dfc9e-b068-4b85-ae0a-e81bc67f679a   in service    none      none          off        
+    oxp_6e5772a5-8234-46d1-ba5a-503a83d9d2fb/crypt/zone                                                              8b954de0-88d8-4a00-902f-e612eed9da0c   in service    none      none          off        
+    oxp_c1da692e-7713-43a0-b6bb-5c182084c09d/crypt/zone                                                              27d840dc-67e6-4795-8bb1-427213d0df3e   in service    none      none          off        
+    oxp_e35766ef-789a-4b2f-9a6c-e6626d5ab195/crypt/zone                                                              b8e322e8-fe4f-43e8-b51a-d08b12f7e515   in service    none      none          off        
+    oxp_08616473-ded4-4785-9b53-b6ccc1efb67a/crypt/zone/oxz_clickhouse_keeper_3f78fa04-0b7e-4959-9718-c232c76500e1   cbe9ab91-b85c-490d-8561-739c66bd2bee   in service    none      none          off        
+    oxp_2d44b756-94df-45ec-a644-50021248682d/crypt/zone/oxz_clickhouse_keeper_bbba3c50-ff89-4a7f-96c1-d40ee996c417   ca2a30ab-baf8-4bb9-af14-3d41f6df6bf7   in service    none      none          off        
+    oxp_08616473-ded4-4785-9b53-b6ccc1efb67a/crypt/zone/oxz_clickhouse_server_f0341fc6-6a73-4318-8787-dd0c6b26c385   39e58c15-5cb4-4f89-9bb3-adef453e9e3d   in service    none      none          off        
+    oxp_650b4eff-80a2-430a-97c8-f837248480a1/crypt/zone/oxz_crucible_49afbe38-6b68-4764-afae-a279a7b9b1ab            3d258387-fe93-49c1-8cad-135b3f3556bf   in service    none      none          off        
+    oxp_6e418b8c-cadd-4fb8-8370-f351a07e1eed/crypt/zone/oxz_crucible_4a223081-0985-45c7-b60e-478c371fde4b            69e7fb35-ff48-4d47-986f-374ce7ebac71   in service    none      none          off        
+    oxp_2d44b756-94df-45ec-a644-50021248682d/crypt/zone/oxz_crucible_4e11460c-cfd2-4fa3-a7a7-25c976accece            6b5f0710-4fab-4921-b1ba-05de5d9ff2c3   in service    none      none          off        
+    oxp_c1da692e-7713-43a0-b6bb-5c182084c09d/crypt/zone/oxz_crucible_4f7d1ee4-bd7b-48a5-99e0-e61fc8e6e58e            45831cd5-d578-4473-a97a-f737aedd9903   in service    none      none          off        
+    oxp_08616473-ded4-4785-9b53-b6ccc1efb67a/crypt/zone/oxz_crucible_7cc30ab4-c566-42d4-8fb0-31a8a27156ff            df1af4ad-ec0e-4094-b8f2-d7ce592f40c0   in service    none      none          off        
+    oxp_6e5772a5-8234-46d1-ba5a-503a83d9d2fb/crypt/zone/oxz_crucible_a50a59b8-b59a-4f1d-b5d4-41f113802b5f            c2832f18-d620-49d0-9c8e-b2fc9871e06f   in service    none      none          off        
+    oxp_44342c41-75a7-4708-8004-eb2ca5c5a3c2/crypt/zone/oxz_crucible_a8839f9e-93f8-42a2-ac3a-9b804a5316f9            fdbdb20f-3a77-4da9-afff-96e7ac54f297   in service    none      none          off        
+    oxp_3b9d69e5-aa80-4fc8-9d2e-a2a24bd0f1d7/crypt/zone/oxz_crucible_da1d617e-6450-4bb8-8696-d1518b2f0731            458a4d6e-83ee-4e74-85e7-69b35dc8045c   in service    none      none          off        
+    oxp_e35766ef-789a-4b2f-9a6c-e6626d5ab195/crypt/zone/oxz_crucible_e71169cf-ee83-47b2-85ec-3396a20b4e02            97f033d1-1878-4429-81cf-9da9dc36bd95   in service    none      none          off        
+    oxp_2dce7cf0-3097-485d-aaf6-9fc51f99eae5/crypt/zone/oxz_crucible_eeab4659-62e8-467f-a6f7-690854db89b5            854c1daf-e3bf-4b0a-84ef-3a1b9912f3df   in service    none      none          off        
+    oxp_08616473-ded4-4785-9b53-b6ccc1efb67a/crypt/zone/oxz_crucible_pantry_2a8f8547-7c9a-4e79-8608-3c925fa3e4b7     74856b03-a612-43b4-94e7-6250cf56fba0   in service    none      none          off        
+    oxp_2d44b756-94df-45ec-a644-50021248682d/crypt/zone/oxz_internal_dns_7f707d70-deef-42dc-96cc-a76cf6366386        40610ea8-b288-408c-91fd-e40edbba09cf   in service    none      none          off        
+    oxp_08616473-ded4-4785-9b53-b6ccc1efb67a/crypt/zone/oxz_internal_dns_e8014d8f-0620-4dde-9fab-435cf4c0c321        2d7179ba-92a0-4bd1-8d5c-eba85fe540d3   in service    none      none          off        
+    oxp_08616473-ded4-4785-9b53-b6ccc1efb67a/crypt/zone/oxz_nexus_d52405a5-debc-4682-8f32-8a3faee16b69               3fab12f1-b0ca-47e2-8865-9710e7e37117   in service    none      none          off        
+    oxp_08616473-ded4-4785-9b53-b6ccc1efb67a/crypt/zone/oxz_ntp_a3e9eacd-48af-4333-aeb8-e7528042e664                 e56af4f5-a7ba-4ff1-a44d-d955f21755b6   in service    none      none          off        
+    oxp_08616473-ded4-4785-9b53-b6ccc1efb67a/crypt/debug                                                             fdd71393-adb7-45c9-8a88-f3ce8d2bb93e   in service    100 GiB   none          gzip-9     
+    oxp_2d44b756-94df-45ec-a644-50021248682d/crypt/debug                                                             c9b2026d-e9fd-4076-9a8c-32b06e34f0a3   in service    100 GiB   none          gzip-9     
+    oxp_2dce7cf0-3097-485d-aaf6-9fc51f99eae5/crypt/debug                                                             3325118f-1ebc-48cd-9ade-cf2d319211b3   in service    100 GiB   none          gzip-9     
+    oxp_3b9d69e5-aa80-4fc8-9d2e-a2a24bd0f1d7/crypt/debug                                                             d0213d2b-116c-4329-a93d-02c69c44c598   in service    100 GiB   none          gzip-9     
+    oxp_44342c41-75a7-4708-8004-eb2ca5c5a3c2/crypt/debug                                                             247e51dd-fe88-43f2-b2bc-366e1b85c12b   in service    100 GiB   none          gzip-9     
+    oxp_650b4eff-80a2-430a-97c8-f837248480a1/crypt/debug                                                             9321a17c-709d-44df-a4e3-8ca09bb3665f   in service    100 GiB   none          gzip-9     
+    oxp_6e418b8c-cadd-4fb8-8370-f351a07e1eed/crypt/debug                                                             ee28398d-301c-4661-85a5-ddf27cff28b4   in service    100 GiB   none          gzip-9     
+    oxp_6e5772a5-8234-46d1-ba5a-503a83d9d2fb/crypt/debug                                                             e74f80f2-5369-4647-8bd0-35b7d8b2a0b0   in service    100 GiB   none          gzip-9     
+    oxp_c1da692e-7713-43a0-b6bb-5c182084c09d/crypt/debug                                                             d0a324c8-9de3-414a-8c8c-3fe301549cdb   in service    100 GiB   none          gzip-9     
+    oxp_e35766ef-789a-4b2f-9a6c-e6626d5ab195/crypt/debug                                                             820def87-14ab-43c9-8f7d-b2be75a2570a   in service    100 GiB   none          gzip-9     
 
 
     omicron zones at generation 4:
@@ -147,62 +147,62 @@ to:   blueprint df68d4d4-5af4-4b56-95bb-1654a6957d4f
 
 
     datasets at generation 4:
-    -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
-    dataset name                                                                                                     dataset uuid                           quota     reservation   compression
-    -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
-    oxp_21d60319-5fe1-4a3b-a4c0-6aa7465e7bde/crucible                                                                b97110cd-9c9d-47d8-ac3e-38b2a5fbf4bb   none      none          off        
-    oxp_2acfbb84-5ce0-424e-8d73-44c5071d4430/crucible                                                                b07b36ec-f27e-4bef-bd0e-adbab3dbded0   none      none          off        
-    oxp_2db7f3b4-ed19-4229-b42c-44f49eeb8a91/crucible                                                                50904cf3-e571-42ee-9be7-40e0d293be12   none      none          off        
-    oxp_2fa34d8e-13d9-42d3-b8ba-ca9d74ac496a/crucible                                                                e3ed0aa2-a4bf-4619-a276-ff287c23f260   none      none          off        
-    oxp_355e268c-c932-4f32-841c-f3ec88fe0495/crucible                                                                c5a79172-3a48-4ecc-a814-77f4a0ac87c3   none      none          off        
-    oxp_427b2ccd-998f-4085-af21-e600604cf21e/crucible                                                                0490a48d-59be-412f-8db8-8a8778f5bdce   none      none          off        
-    oxp_588058f2-f51b-4800-a211-1c5dbb32296b/crucible                                                                d148662e-1244-416e-9043-2c6e5bc3391c   none      none          off        
-    oxp_736f6f07-2aa2-4658-8b5c-3bf409ea747a/crucible                                                                55340375-5d36-475d-99d6-8c8dc38a8421   none      none          off        
-    oxp_bcfcdede-7084-4a31-97a8-ac4299c268f9/crucible                                                                cdf74236-d6b4-4872-ab29-3ef21b1f9e9e   none      none          off        
-    oxp_fe379ac6-1938-4cc2-93a9-43b1447229ae/crucible                                                                98085696-2290-4467-b2de-cecd1ab6255e   none      none          off        
-    oxp_21d60319-5fe1-4a3b-a4c0-6aa7465e7bde/crypt/clickhouse                                                        650004ee-2360-47a3-ba98-b07dd9873c06   none      none          off        
-    oxp_21d60319-5fe1-4a3b-a4c0-6aa7465e7bde/crypt/clickhouse_keeper                                                 56624401-f56f-4fd2-88fb-cfd56df535aa   none      none          off        
-    oxp_21d60319-5fe1-4a3b-a4c0-6aa7465e7bde/crypt/clickhouse_server                                                 67e873d4-5ee2-4fcd-bd1f-9311ad2ed23c   none      none          off        
-    oxp_21d60319-5fe1-4a3b-a4c0-6aa7465e7bde/crypt/internal_dns                                                      eba7c3d8-af0f-4de7-9b07-8e63ff8c9a34   none      none          off        
-    oxp_21d60319-5fe1-4a3b-a4c0-6aa7465e7bde/crypt/zone                                                              a27fb298-e263-4560-965a-2c56292ea19a   none      none          off        
-    oxp_2acfbb84-5ce0-424e-8d73-44c5071d4430/crypt/zone                                                              03dfbeda-a138-45c2-975f-05a9af2ef2b9   none      none          off        
-    oxp_2db7f3b4-ed19-4229-b42c-44f49eeb8a91/crypt/zone                                                              40986d49-c197-462c-baac-ba937da44571   none      none          off        
-    oxp_2fa34d8e-13d9-42d3-b8ba-ca9d74ac496a/crypt/zone                                                              006eede7-d6b6-4af2-a2ff-37b94386b421   none      none          off        
-    oxp_355e268c-c932-4f32-841c-f3ec88fe0495/crypt/zone                                                              18279e0e-4f67-4e87-bc5a-2eb3927ec023   none      none          off        
-    oxp_427b2ccd-998f-4085-af21-e600604cf21e/crypt/zone                                                              491b337c-3c25-4284-ae13-443206ff696f   none      none          off        
-    oxp_588058f2-f51b-4800-a211-1c5dbb32296b/crypt/zone                                                              5aa2c795-468a-45df-8769-16f4d5d0e42a   none      none          off        
-    oxp_736f6f07-2aa2-4658-8b5c-3bf409ea747a/crypt/zone                                                              89c95288-774f-480c-ab14-a0327bec365b   none      none          off        
-    oxp_bcfcdede-7084-4a31-97a8-ac4299c268f9/crypt/zone                                                              e7569f72-580c-417b-b223-0e5f998dd9c1   none      none          off        
-    oxp_fe379ac6-1938-4cc2-93a9-43b1447229ae/crypt/zone                                                              2aae5bf8-7c17-43c4-9183-4c1956571243   none      none          off        
-    oxp_21d60319-5fe1-4a3b-a4c0-6aa7465e7bde/crypt/zone/oxz_clickhouse_ca54c155-5e4c-42e6-96f2-b70448019418          b760c1d2-fa43-441d-8b79-d1fde01a8753   none      none          off        
-    oxp_21d60319-5fe1-4a3b-a4c0-6aa7465e7bde/crypt/zone/oxz_clickhouse_keeper_2b368dcd-bb4b-4415-9daf-0d36fd769fed   c22caa52-6179-49a7-95dc-5cf0d9f3f827   none      none          off        
-    oxp_21d60319-5fe1-4a3b-a4c0-6aa7465e7bde/crypt/zone/oxz_clickhouse_server_097ab295-aec4-427f-9124-bb4e8aecfeca   e21880d2-f6f9-4e97-b7da-5a8a934845ab   none      none          off        
-    oxp_736f6f07-2aa2-4658-8b5c-3bf409ea747a/crypt/zone/oxz_crucible_308c592a-b022-4790-9824-7a5e10b83d1b            4e514d61-b9d3-4e8c-b528-4b9577d8ad84   none      none          off        
-    oxp_2fa34d8e-13d9-42d3-b8ba-ca9d74ac496a/crypt/zone/oxz_crucible_7233139a-ad5b-4c0e-be80-759fbd5cb262            2c3d31cf-9a06-4f47-8f30-97884d06de8f   none      none          off        
-    oxp_2acfbb84-5ce0-424e-8d73-44c5071d4430/crypt/zone/oxz_crucible_8c43faff-54c7-4b91-820c-ff130b7049e9            9155b21a-1803-44b3-b80e-6d22f7af2e07   none      none          off        
-    oxp_fe379ac6-1938-4cc2-93a9-43b1447229ae/crypt/zone/oxz_crucible_8ddbafde-d699-4e37-b70d-dcd803f0898e            a46724b6-7ca0-4d70-9dd2-6fd22d1e6150   none      none          off        
-    oxp_427b2ccd-998f-4085-af21-e600604cf21e/crypt/zone/oxz_crucible_955bd7eb-8cc2-4128-a636-19bde11ab251            44153191-15ac-4206-b153-167261b232fe   none      none          off        
-    oxp_21d60319-5fe1-4a3b-a4c0-6aa7465e7bde/crypt/zone/oxz_crucible_a6192358-d6e1-4483-a3c6-755a05911f22            5fd12d35-d258-42ca-8fe3-dc5788bdc66c   none      none          off        
-    oxp_bcfcdede-7084-4a31-97a8-ac4299c268f9/crypt/zone/oxz_crucible_a68bc085-0ad5-4c42-a9f7-0b540de24ced            1de186f8-a37f-42fa-9e70-05aa05641c7e   none      none          off        
-    oxp_355e268c-c932-4f32-841c-f3ec88fe0495/crypt/zone/oxz_crucible_cdc00fbb-5ac7-4667-9fc8-926ea73a002a            510ecf2a-6a98-40f2-b387-3bab22da2bf7   none      none          off        
-    oxp_2db7f3b4-ed19-4229-b42c-44f49eeb8a91/crypt/zone/oxz_crucible_d04ed118-4eb8-4ba4-8f05-7714060291e2            282ed619-0004-4647-9d60-85509d68170e   none      none          off        
-    oxp_588058f2-f51b-4800-a211-1c5dbb32296b/crypt/zone/oxz_crucible_e5347768-7d4d-4862-b78e-38291aca675a            ba5652ea-a567-4e7f-a62d-616fd9ab2aff   none      none          off        
-    oxp_21d60319-5fe1-4a3b-a4c0-6aa7465e7bde/crypt/zone/oxz_crucible_pantry_0af27834-4e26-4417-9cc3-9a04105b1cbc     8d62e551-9775-4ac8-a830-15e1f3aabb46   none      none          off        
-    oxp_2acfbb84-5ce0-424e-8d73-44c5071d4430/crypt/zone/oxz_crucible_pantry_84fc3bdc-a8f6-4ceb-8fcf-59a003bc91c0     96d231ab-baee-465f-a584-6eedcc3e14cc   none      none          off        
-    oxp_21d60319-5fe1-4a3b-a4c0-6aa7465e7bde/crypt/zone/oxz_internal_dns_a6212313-b0c0-4a69-9ca6-5ea9c7e3e947        38daea72-c487-4f80-9e27-ef67e6b2d05d   none      none          off        
-    oxp_2acfbb84-5ce0-424e-8d73-44c5071d4430/crypt/zone/oxz_nexus_b2e9a34b-7b15-4f56-836d-b39e474afbc5               a89cea5b-db88-4f12-a2f4-700a04803af1   none      none          off        
-    oxp_21d60319-5fe1-4a3b-a4c0-6aa7465e7bde/crypt/zone/oxz_nexus_e786e397-2ccc-4112-bf26-45ca1de89f3b               a26d8d3b-1483-4e98-bb4b-1680c75c2956   none      none          off        
-    oxp_21d60319-5fe1-4a3b-a4c0-6aa7465e7bde/crypt/zone/oxz_ntp_0991f26b-97a1-4033-af5d-df7e56c2189a                 a6f0a3f1-aff9-45d9-8e70-610780c75c73   none      none          off        
-    oxp_21d60319-5fe1-4a3b-a4c0-6aa7465e7bde/crypt/debug                                                             c2868186-4510-4c56-9374-13a4fda781be   100 GiB   none          gzip-9     
-    oxp_2acfbb84-5ce0-424e-8d73-44c5071d4430/crypt/debug                                                             80bb6683-3e89-4652-9b4d-a2adc6dc05c3   100 GiB   none          gzip-9     
-    oxp_2db7f3b4-ed19-4229-b42c-44f49eeb8a91/crypt/debug                                                             35abcc8e-8fae-4e0f-9db7-457c21c27244   100 GiB   none          gzip-9     
-    oxp_2fa34d8e-13d9-42d3-b8ba-ca9d74ac496a/crypt/debug                                                             ae45ae89-0fc5-4c82-8e38-bdc4efb2a4cd   100 GiB   none          gzip-9     
-    oxp_355e268c-c932-4f32-841c-f3ec88fe0495/crypt/debug                                                             f567b79a-c05c-4ba5-85a6-87f217687c9b   100 GiB   none          gzip-9     
-    oxp_427b2ccd-998f-4085-af21-e600604cf21e/crypt/debug                                                             da15e9ee-d60c-4b9d-a383-52c8c82f8bad   100 GiB   none          gzip-9     
-    oxp_588058f2-f51b-4800-a211-1c5dbb32296b/crypt/debug                                                             f8390042-25a5-43db-9d6c-336223c5210f   100 GiB   none          gzip-9     
-    oxp_736f6f07-2aa2-4658-8b5c-3bf409ea747a/crypt/debug                                                             68191fe0-2606-4d82-833e-e467ff129a19   100 GiB   none          gzip-9     
-    oxp_bcfcdede-7084-4a31-97a8-ac4299c268f9/crypt/debug                                                             2755f94e-a5e8-4bf8-8cdc-2645e5b21578   100 GiB   none          gzip-9     
-    oxp_fe379ac6-1938-4cc2-93a9-43b1447229ae/crypt/debug                                                             68b11f7e-4258-483b-a75a-4243ca7ede6f   100 GiB   none          gzip-9     
+    ---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
+    dataset name                                                                                                     dataset id                             disposition   quota     reservation   compression
+    ---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
+    oxp_21d60319-5fe1-4a3b-a4c0-6aa7465e7bde/crucible                                                                b97110cd-9c9d-47d8-ac3e-38b2a5fbf4bb   in service    none      none          off        
+    oxp_2acfbb84-5ce0-424e-8d73-44c5071d4430/crucible                                                                b07b36ec-f27e-4bef-bd0e-adbab3dbded0   in service    none      none          off        
+    oxp_2db7f3b4-ed19-4229-b42c-44f49eeb8a91/crucible                                                                50904cf3-e571-42ee-9be7-40e0d293be12   in service    none      none          off        
+    oxp_2fa34d8e-13d9-42d3-b8ba-ca9d74ac496a/crucible                                                                e3ed0aa2-a4bf-4619-a276-ff287c23f260   in service    none      none          off        
+    oxp_355e268c-c932-4f32-841c-f3ec88fe0495/crucible                                                                c5a79172-3a48-4ecc-a814-77f4a0ac87c3   in service    none      none          off        
+    oxp_427b2ccd-998f-4085-af21-e600604cf21e/crucible                                                                0490a48d-59be-412f-8db8-8a8778f5bdce   in service    none      none          off        
+    oxp_588058f2-f51b-4800-a211-1c5dbb32296b/crucible                                                                d148662e-1244-416e-9043-2c6e5bc3391c   in service    none      none          off        
+    oxp_736f6f07-2aa2-4658-8b5c-3bf409ea747a/crucible                                                                55340375-5d36-475d-99d6-8c8dc38a8421   in service    none      none          off        
+    oxp_bcfcdede-7084-4a31-97a8-ac4299c268f9/crucible                                                                cdf74236-d6b4-4872-ab29-3ef21b1f9e9e   in service    none      none          off        
+    oxp_fe379ac6-1938-4cc2-93a9-43b1447229ae/crucible                                                                98085696-2290-4467-b2de-cecd1ab6255e   in service    none      none          off        
+    oxp_21d60319-5fe1-4a3b-a4c0-6aa7465e7bde/crypt/clickhouse                                                        650004ee-2360-47a3-ba98-b07dd9873c06   in service    none      none          off        
+    oxp_21d60319-5fe1-4a3b-a4c0-6aa7465e7bde/crypt/clickhouse_keeper                                                 56624401-f56f-4fd2-88fb-cfd56df535aa   in service    none      none          off        
+    oxp_21d60319-5fe1-4a3b-a4c0-6aa7465e7bde/crypt/clickhouse_server                                                 67e873d4-5ee2-4fcd-bd1f-9311ad2ed23c   in service    none      none          off        
+    oxp_21d60319-5fe1-4a3b-a4c0-6aa7465e7bde/crypt/internal_dns                                                      eba7c3d8-af0f-4de7-9b07-8e63ff8c9a34   in service    none      none          off        
+    oxp_21d60319-5fe1-4a3b-a4c0-6aa7465e7bde/crypt/zone                                                              a27fb298-e263-4560-965a-2c56292ea19a   in service    none      none          off        
+    oxp_2acfbb84-5ce0-424e-8d73-44c5071d4430/crypt/zone                                                              03dfbeda-a138-45c2-975f-05a9af2ef2b9   in service    none      none          off        
+    oxp_2db7f3b4-ed19-4229-b42c-44f49eeb8a91/crypt/zone                                                              40986d49-c197-462c-baac-ba937da44571   in service    none      none          off        
+    oxp_2fa34d8e-13d9-42d3-b8ba-ca9d74ac496a/crypt/zone                                                              006eede7-d6b6-4af2-a2ff-37b94386b421   in service    none      none          off        
+    oxp_355e268c-c932-4f32-841c-f3ec88fe0495/crypt/zone                                                              18279e0e-4f67-4e87-bc5a-2eb3927ec023   in service    none      none          off        
+    oxp_427b2ccd-998f-4085-af21-e600604cf21e/crypt/zone                                                              491b337c-3c25-4284-ae13-443206ff696f   in service    none      none          off        
+    oxp_588058f2-f51b-4800-a211-1c5dbb32296b/crypt/zone                                                              5aa2c795-468a-45df-8769-16f4d5d0e42a   in service    none      none          off        
+    oxp_736f6f07-2aa2-4658-8b5c-3bf409ea747a/crypt/zone                                                              89c95288-774f-480c-ab14-a0327bec365b   in service    none      none          off        
+    oxp_bcfcdede-7084-4a31-97a8-ac4299c268f9/crypt/zone                                                              e7569f72-580c-417b-b223-0e5f998dd9c1   in service    none      none          off        
+    oxp_fe379ac6-1938-4cc2-93a9-43b1447229ae/crypt/zone                                                              2aae5bf8-7c17-43c4-9183-4c1956571243   in service    none      none          off        
+    oxp_21d60319-5fe1-4a3b-a4c0-6aa7465e7bde/crypt/zone/oxz_clickhouse_ca54c155-5e4c-42e6-96f2-b70448019418          b760c1d2-fa43-441d-8b79-d1fde01a8753   in service    none      none          off        
+    oxp_21d60319-5fe1-4a3b-a4c0-6aa7465e7bde/crypt/zone/oxz_clickhouse_keeper_2b368dcd-bb4b-4415-9daf-0d36fd769fed   c22caa52-6179-49a7-95dc-5cf0d9f3f827   in service    none      none          off        
+    oxp_21d60319-5fe1-4a3b-a4c0-6aa7465e7bde/crypt/zone/oxz_clickhouse_server_097ab295-aec4-427f-9124-bb4e8aecfeca   e21880d2-f6f9-4e97-b7da-5a8a934845ab   in service    none      none          off        
+    oxp_736f6f07-2aa2-4658-8b5c-3bf409ea747a/crypt/zone/oxz_crucible_308c592a-b022-4790-9824-7a5e10b83d1b            4e514d61-b9d3-4e8c-b528-4b9577d8ad84   in service    none      none          off        
+    oxp_2fa34d8e-13d9-42d3-b8ba-ca9d74ac496a/crypt/zone/oxz_crucible_7233139a-ad5b-4c0e-be80-759fbd5cb262            2c3d31cf-9a06-4f47-8f30-97884d06de8f   in service    none      none          off        
+    oxp_2acfbb84-5ce0-424e-8d73-44c5071d4430/crypt/zone/oxz_crucible_8c43faff-54c7-4b91-820c-ff130b7049e9            9155b21a-1803-44b3-b80e-6d22f7af2e07   in service    none      none          off        
+    oxp_fe379ac6-1938-4cc2-93a9-43b1447229ae/crypt/zone/oxz_crucible_8ddbafde-d699-4e37-b70d-dcd803f0898e            a46724b6-7ca0-4d70-9dd2-6fd22d1e6150   in service    none      none          off        
+    oxp_427b2ccd-998f-4085-af21-e600604cf21e/crypt/zone/oxz_crucible_955bd7eb-8cc2-4128-a636-19bde11ab251            44153191-15ac-4206-b153-167261b232fe   in service    none      none          off        
+    oxp_21d60319-5fe1-4a3b-a4c0-6aa7465e7bde/crypt/zone/oxz_crucible_a6192358-d6e1-4483-a3c6-755a05911f22            5fd12d35-d258-42ca-8fe3-dc5788bdc66c   in service    none      none          off        
+    oxp_bcfcdede-7084-4a31-97a8-ac4299c268f9/crypt/zone/oxz_crucible_a68bc085-0ad5-4c42-a9f7-0b540de24ced            1de186f8-a37f-42fa-9e70-05aa05641c7e   in service    none      none          off        
+    oxp_355e268c-c932-4f32-841c-f3ec88fe0495/crypt/zone/oxz_crucible_cdc00fbb-5ac7-4667-9fc8-926ea73a002a            510ecf2a-6a98-40f2-b387-3bab22da2bf7   in service    none      none          off        
+    oxp_2db7f3b4-ed19-4229-b42c-44f49eeb8a91/crypt/zone/oxz_crucible_d04ed118-4eb8-4ba4-8f05-7714060291e2            282ed619-0004-4647-9d60-85509d68170e   in service    none      none          off        
+    oxp_588058f2-f51b-4800-a211-1c5dbb32296b/crypt/zone/oxz_crucible_e5347768-7d4d-4862-b78e-38291aca675a            ba5652ea-a567-4e7f-a62d-616fd9ab2aff   in service    none      none          off        
+    oxp_21d60319-5fe1-4a3b-a4c0-6aa7465e7bde/crypt/zone/oxz_crucible_pantry_0af27834-4e26-4417-9cc3-9a04105b1cbc     8d62e551-9775-4ac8-a830-15e1f3aabb46   in service    none      none          off        
+    oxp_2acfbb84-5ce0-424e-8d73-44c5071d4430/crypt/zone/oxz_crucible_pantry_84fc3bdc-a8f6-4ceb-8fcf-59a003bc91c0     96d231ab-baee-465f-a584-6eedcc3e14cc   in service    none      none          off        
+    oxp_21d60319-5fe1-4a3b-a4c0-6aa7465e7bde/crypt/zone/oxz_internal_dns_a6212313-b0c0-4a69-9ca6-5ea9c7e3e947        38daea72-c487-4f80-9e27-ef67e6b2d05d   in service    none      none          off        
+    oxp_2acfbb84-5ce0-424e-8d73-44c5071d4430/crypt/zone/oxz_nexus_b2e9a34b-7b15-4f56-836d-b39e474afbc5               a89cea5b-db88-4f12-a2f4-700a04803af1   in service    none      none          off        
+    oxp_21d60319-5fe1-4a3b-a4c0-6aa7465e7bde/crypt/zone/oxz_nexus_e786e397-2ccc-4112-bf26-45ca1de89f3b               a26d8d3b-1483-4e98-bb4b-1680c75c2956   in service    none      none          off        
+    oxp_21d60319-5fe1-4a3b-a4c0-6aa7465e7bde/crypt/zone/oxz_ntp_0991f26b-97a1-4033-af5d-df7e56c2189a                 a6f0a3f1-aff9-45d9-8e70-610780c75c73   in service    none      none          off        
+    oxp_21d60319-5fe1-4a3b-a4c0-6aa7465e7bde/crypt/debug                                                             c2868186-4510-4c56-9374-13a4fda781be   in service    100 GiB   none          gzip-9     
+    oxp_2acfbb84-5ce0-424e-8d73-44c5071d4430/crypt/debug                                                             80bb6683-3e89-4652-9b4d-a2adc6dc05c3   in service    100 GiB   none          gzip-9     
+    oxp_2db7f3b4-ed19-4229-b42c-44f49eeb8a91/crypt/debug                                                             35abcc8e-8fae-4e0f-9db7-457c21c27244   in service    100 GiB   none          gzip-9     
+    oxp_2fa34d8e-13d9-42d3-b8ba-ca9d74ac496a/crypt/debug                                                             ae45ae89-0fc5-4c82-8e38-bdc4efb2a4cd   in service    100 GiB   none          gzip-9     
+    oxp_355e268c-c932-4f32-841c-f3ec88fe0495/crypt/debug                                                             f567b79a-c05c-4ba5-85a6-87f217687c9b   in service    100 GiB   none          gzip-9     
+    oxp_427b2ccd-998f-4085-af21-e600604cf21e/crypt/debug                                                             da15e9ee-d60c-4b9d-a383-52c8c82f8bad   in service    100 GiB   none          gzip-9     
+    oxp_588058f2-f51b-4800-a211-1c5dbb32296b/crypt/debug                                                             f8390042-25a5-43db-9d6c-336223c5210f   in service    100 GiB   none          gzip-9     
+    oxp_736f6f07-2aa2-4658-8b5c-3bf409ea747a/crypt/debug                                                             68191fe0-2606-4d82-833e-e467ff129a19   in service    100 GiB   none          gzip-9     
+    oxp_bcfcdede-7084-4a31-97a8-ac4299c268f9/crypt/debug                                                             2755f94e-a5e8-4bf8-8cdc-2645e5b21578   in service    100 GiB   none          gzip-9     
+    oxp_fe379ac6-1938-4cc2-93a9-43b1447229ae/crypt/debug                                                             68b11f7e-4258-483b-a75a-4243ca7ede6f   in service    100 GiB   none          gzip-9     
 
 
     omicron zones at generation 4:

--- a/nexus/reconfigurator/planning/tests/output/planner_expunge_clickhouse_zones_after_policy_is_changed_3_4.txt
+++ b/nexus/reconfigurator/planning/tests/output/planner_expunge_clickhouse_zones_after_policy_is_changed_3_4.txt
@@ -22,58 +22,60 @@ to:   blueprint d895ef50-9978-454c-bdfb-b8dbe2c9a918
 
 
     datasets generation 4 -> 5:
-    -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
-    dataset name                                                                                                     dataset uuid                           quota     reservation   compression
-    -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
-    oxp_41eaf63b-4fa9-443e-8da1-78d1e79aac7d/crucible                                                                2995233a-0449-4072-b509-76033ef98ba6   none      none          off        
-    oxp_5b04e3d3-7a8b-466e-ab63-6ca89a93e100/crucible                                                                af187db0-8de0-4d0f-93f6-df8aecedac9b   none      none          off        
-    oxp_6e8fdb9f-c47a-47b0-b7ee-9a2adc7e4af5/crucible                                                                cbdac478-a890-4b3f-9201-48a4ab393e1b   none      none          off        
-    oxp_8e2c9e92-e35e-494c-8e14-dcf5f5009656/crucible                                                                32d14ae0-68ee-4bcc-bfa1-135cc3221765   none      none          off        
-    oxp_a4c575b4-934b-49b9-9c47-9c1241a33607/crucible                                                                f998be6f-0965-4e91-8bca-19924f5d4fdd   none      none          off        
-    oxp_a9a8a692-d2d7-4b3e-a297-d648faf8c7cf/crucible                                                                31ef6da6-6d72-4b16-b66e-de5919248fa1   none      none          off        
-    oxp_b65c8376-0084-4d6f-9891-9d6a413d4e56/crucible                                                                e47bdf6e-29d5-4a43-8909-a4b60aea8c88   none      none          off        
-    oxp_bc61cdae-c96f-4886-b8bd-f9fd69d51e3a/crucible                                                                e8025577-6780-42cb-a6a4-c0d462e7e726   none      none          off        
-    oxp_e9f68306-460a-4b11-b904-f752633bf1fc/crucible                                                                e636f409-22a1-4e85-a180-275d1c586350   none      none          off        
-    oxp_fbc5bdf2-9644-4d0a-b349-f490486da25d/crucible                                                                5b79a673-5132-4781-a33f-732e564ac40c   none      none          off        
-    oxp_41eaf63b-4fa9-443e-8da1-78d1e79aac7d/crypt/clickhouse                                                        ed9a1f42-6aec-4bf8-ae48-0bc25d8a2be2   none      none          off        
-    oxp_41eaf63b-4fa9-443e-8da1-78d1e79aac7d/crypt/internal_dns                                                      fe4d67a2-5fb8-4096-97b2-12cf077ae41e   none      none          off        
-    oxp_41eaf63b-4fa9-443e-8da1-78d1e79aac7d/crypt/zone                                                              567b450c-835e-4622-8fd9-3e41bff04b99   none      none          off        
-    oxp_5b04e3d3-7a8b-466e-ab63-6ca89a93e100/crypt/zone                                                              7771428a-e7a9-40fe-89f2-deb92f8b77eb   none      none          off        
-    oxp_6e8fdb9f-c47a-47b0-b7ee-9a2adc7e4af5/crypt/zone                                                              88131d15-f49e-467c-9241-7236f5b14e0b   none      none          off        
-    oxp_8e2c9e92-e35e-494c-8e14-dcf5f5009656/crypt/zone                                                              033c5679-6241-4502-99f1-50f685f57403   none      none          off        
-    oxp_a4c575b4-934b-49b9-9c47-9c1241a33607/crypt/zone                                                              39c3d488-3bd7-48c0-a965-d8e0b77a3dea   none      none          off        
-    oxp_a9a8a692-d2d7-4b3e-a297-d648faf8c7cf/crypt/zone                                                              9e18151a-63b1-4715-bb5c-e2088b1fcd57   none      none          off        
-    oxp_b65c8376-0084-4d6f-9891-9d6a413d4e56/crypt/zone                                                              5ea593b7-5882-47db-986a-570362ea7180   none      none          off        
-    oxp_bc61cdae-c96f-4886-b8bd-f9fd69d51e3a/crypt/zone                                                              01e0e8fc-a101-4e55-ab67-6a2d6472f5c2   none      none          off        
-    oxp_e9f68306-460a-4b11-b904-f752633bf1fc/crypt/zone                                                              4b14443d-d9bf-4c9b-9c74-1f434c467b8a   none      none          off        
-    oxp_fbc5bdf2-9644-4d0a-b349-f490486da25d/crypt/zone                                                              49b5c150-d615-487b-bda2-00d8d5fa85fc   none      none          off        
-    oxp_41eaf63b-4fa9-443e-8da1-78d1e79aac7d/crypt/zone/oxz_clickhouse_c3d4b77c-2e77-45ef-9764-5f45723f1e6e          5782d4d4-614c-4521-ba76-64d146ff4086   none      none          off        
-    oxp_8e2c9e92-e35e-494c-8e14-dcf5f5009656/crypt/zone/oxz_crucible_060bee8a-a830-4db9-b43f-d2d4d651460f            1b994560-5065-495b-8f52-089a66023db9   none      none          off        
-    oxp_bc61cdae-c96f-4886-b8bd-f9fd69d51e3a/crypt/zone/oxz_crucible_14b40b41-0679-4a97-abb9-670d4a014168            4e7d5a46-7ae5-4065-86b6-d6e549a86381   none      none          off        
-    oxp_fbc5bdf2-9644-4d0a-b349-f490486da25d/crypt/zone/oxz_crucible_2d00b429-277a-4670-9841-59dfe36418f5            ba483769-2ff7-469a-8bd5-9d0069c98f3a   none      none          off        
-    oxp_41eaf63b-4fa9-443e-8da1-78d1e79aac7d/crypt/zone/oxz_crucible_6667f342-3f4d-498f-852b-af58fe6cfe4d            12468ab7-b48d-401c-9ef9-26b2d50cd9aa   none      none          off        
-    oxp_e9f68306-460a-4b11-b904-f752633bf1fc/crypt/zone/oxz_crucible_6acddc3a-7c18-4bed-9bee-06179a16b511            636854c7-673f-4a5c-8841-a4ea7d669856   none      none          off        
-    oxp_6e8fdb9f-c47a-47b0-b7ee-9a2adc7e4af5/crypt/zone/oxz_crucible_6d91fce2-b64b-4778-bc7d-3a3ee4fc050f            e8d9ad3c-b77a-4ae9-bd7a-8717663d4732   none      none          off        
-    oxp_a9a8a692-d2d7-4b3e-a297-d648faf8c7cf/crypt/zone/oxz_crucible_743f2573-1cd6-418b-a0e0-7fb6d5dc65c9            0a19c469-38a3-4ad1-acff-a2eec66d039b   none      none          off        
-    oxp_5b04e3d3-7a8b-466e-ab63-6ca89a93e100/crypt/zone/oxz_crucible_9bb3f4a7-3699-481f-928a-f57cbe505f12            7fec29ed-8f6f-4f72-af7a-1603f74ae3e6   none      none          off        
-    oxp_b65c8376-0084-4d6f-9891-9d6a413d4e56/crypt/zone/oxz_crucible_9bcc969f-8a33-4c30-8608-ad9e0048035a            4c0d8c8a-ddb6-4a88-be7f-1bf5685adafa   none      none          off        
-    oxp_a4c575b4-934b-49b9-9c47-9c1241a33607/crypt/zone/oxz_crucible_f50159f9-2c73-4ea6-9e03-296e158a3af4            8f7c7096-7cd3-4a79-b24b-dc0e7fa3e3ec   none      none          off        
-    oxp_41eaf63b-4fa9-443e-8da1-78d1e79aac7d/crypt/zone/oxz_crucible_pantry_c9e73f39-4dd7-4a87-828b-58c4fcf60d4a     786f9c46-8818-4811-a816-65be22187e13   none      none          off        
-    oxp_41eaf63b-4fa9-443e-8da1-78d1e79aac7d/crypt/zone/oxz_internal_dns_42bf3233-3a94-4f47-8c51-7ac3524ea1f5        923f9064-ee22-42f2-a75f-c7da7dde3acc   none      none          off        
-    oxp_41eaf63b-4fa9-443e-8da1-78d1e79aac7d/crypt/zone/oxz_nexus_254bd45b-ef24-4ce2-812b-9e825d11da65               5b7c73f6-8e61-4160-b747-d69aad5af1ac   none      none          off        
-    oxp_41eaf63b-4fa9-443e-8da1-78d1e79aac7d/crypt/zone/oxz_ntp_ac14e7ae-b9d4-455b-9400-89931771987c                 49673924-48da-4afb-85f8-8c92c32c06f0   none      none          off        
-    oxp_41eaf63b-4fa9-443e-8da1-78d1e79aac7d/crypt/debug                                                             e271927c-4565-48f7-b983-721b5e46a1e6   100 GiB   none          gzip-9     
-    oxp_5b04e3d3-7a8b-466e-ab63-6ca89a93e100/crypt/debug                                                             901ce577-ae12-461a-99a9-f8e972f7cc5d   100 GiB   none          gzip-9     
-    oxp_6e8fdb9f-c47a-47b0-b7ee-9a2adc7e4af5/crypt/debug                                                             c2b2e20a-b273-4b7c-b2d9-142447e5fc69   100 GiB   none          gzip-9     
-    oxp_8e2c9e92-e35e-494c-8e14-dcf5f5009656/crypt/debug                                                             2891a537-17ea-4d83-b2ea-af36a6d22d2d   100 GiB   none          gzip-9     
-    oxp_a4c575b4-934b-49b9-9c47-9c1241a33607/crypt/debug                                                             dc614216-2b34-4659-bfbe-55462fe203f0   100 GiB   none          gzip-9     
-    oxp_a9a8a692-d2d7-4b3e-a297-d648faf8c7cf/crypt/debug                                                             872f53ed-6dc6-43e1-8a52-9c87938e2330   100 GiB   none          gzip-9     
-    oxp_b65c8376-0084-4d6f-9891-9d6a413d4e56/crypt/debug                                                             2f0c179c-d7dd-4450-9163-e799de0aef90   100 GiB   none          gzip-9     
-    oxp_bc61cdae-c96f-4886-b8bd-f9fd69d51e3a/crypt/debug                                                             8b49dee0-2726-4261-aabd-331752764e91   100 GiB   none          gzip-9     
-    oxp_e9f68306-460a-4b11-b904-f752633bf1fc/crypt/debug                                                             f6dae5d2-fff9-4562-9fd4-be99ff888afc   100 GiB   none          gzip-9     
-    oxp_fbc5bdf2-9644-4d0a-b349-f490486da25d/crypt/debug                                                             e0a59564-f99b-47a6-b1ca-b83001fe6908   100 GiB   none          gzip-9     
-*   oxp_41eaf63b-4fa9-443e-8da1-78d1e79aac7d/crypt/clickhouse_keeper                                                 04cdeda2-c4f7-4f76-bfbf-f946dcdefda3   none      none          off        
-*   oxp_41eaf63b-4fa9-443e-8da1-78d1e79aac7d/crypt/zone/oxz_clickhouse_keeper_14b84b08-598b-4756-99ec-eea98f8fa46e   1b4c5dcd-24e9-4076-9219-e9559ae49857   none      none          off        
+    ----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
+    dataset name                                                                                                     dataset id                             disposition    quota     reservation   compression
+    ----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
+    oxp_41eaf63b-4fa9-443e-8da1-78d1e79aac7d/crucible                                                                2995233a-0449-4072-b509-76033ef98ba6   in service     none      none          off        
+    oxp_5b04e3d3-7a8b-466e-ab63-6ca89a93e100/crucible                                                                af187db0-8de0-4d0f-93f6-df8aecedac9b   in service     none      none          off        
+    oxp_6e8fdb9f-c47a-47b0-b7ee-9a2adc7e4af5/crucible                                                                cbdac478-a890-4b3f-9201-48a4ab393e1b   in service     none      none          off        
+    oxp_8e2c9e92-e35e-494c-8e14-dcf5f5009656/crucible                                                                32d14ae0-68ee-4bcc-bfa1-135cc3221765   in service     none      none          off        
+    oxp_a4c575b4-934b-49b9-9c47-9c1241a33607/crucible                                                                f998be6f-0965-4e91-8bca-19924f5d4fdd   in service     none      none          off        
+    oxp_a9a8a692-d2d7-4b3e-a297-d648faf8c7cf/crucible                                                                31ef6da6-6d72-4b16-b66e-de5919248fa1   in service     none      none          off        
+    oxp_b65c8376-0084-4d6f-9891-9d6a413d4e56/crucible                                                                e47bdf6e-29d5-4a43-8909-a4b60aea8c88   in service     none      none          off        
+    oxp_bc61cdae-c96f-4886-b8bd-f9fd69d51e3a/crucible                                                                e8025577-6780-42cb-a6a4-c0d462e7e726   in service     none      none          off        
+    oxp_e9f68306-460a-4b11-b904-f752633bf1fc/crucible                                                                e636f409-22a1-4e85-a180-275d1c586350   in service     none      none          off        
+    oxp_fbc5bdf2-9644-4d0a-b349-f490486da25d/crucible                                                                5b79a673-5132-4781-a33f-732e564ac40c   in service     none      none          off        
+    oxp_41eaf63b-4fa9-443e-8da1-78d1e79aac7d/crypt/clickhouse                                                        ed9a1f42-6aec-4bf8-ae48-0bc25d8a2be2   expunged       none      none          off        
+    oxp_41eaf63b-4fa9-443e-8da1-78d1e79aac7d/crypt/internal_dns                                                      fe4d67a2-5fb8-4096-97b2-12cf077ae41e   in service     none      none          off        
+    oxp_41eaf63b-4fa9-443e-8da1-78d1e79aac7d/crypt/zone                                                              567b450c-835e-4622-8fd9-3e41bff04b99   in service     none      none          off        
+    oxp_5b04e3d3-7a8b-466e-ab63-6ca89a93e100/crypt/zone                                                              7771428a-e7a9-40fe-89f2-deb92f8b77eb   in service     none      none          off        
+    oxp_6e8fdb9f-c47a-47b0-b7ee-9a2adc7e4af5/crypt/zone                                                              88131d15-f49e-467c-9241-7236f5b14e0b   in service     none      none          off        
+    oxp_8e2c9e92-e35e-494c-8e14-dcf5f5009656/crypt/zone                                                              033c5679-6241-4502-99f1-50f685f57403   in service     none      none          off        
+    oxp_a4c575b4-934b-49b9-9c47-9c1241a33607/crypt/zone                                                              39c3d488-3bd7-48c0-a965-d8e0b77a3dea   in service     none      none          off        
+    oxp_a9a8a692-d2d7-4b3e-a297-d648faf8c7cf/crypt/zone                                                              9e18151a-63b1-4715-bb5c-e2088b1fcd57   in service     none      none          off        
+    oxp_b65c8376-0084-4d6f-9891-9d6a413d4e56/crypt/zone                                                              5ea593b7-5882-47db-986a-570362ea7180   in service     none      none          off        
+    oxp_bc61cdae-c96f-4886-b8bd-f9fd69d51e3a/crypt/zone                                                              01e0e8fc-a101-4e55-ab67-6a2d6472f5c2   in service     none      none          off        
+    oxp_e9f68306-460a-4b11-b904-f752633bf1fc/crypt/zone                                                              4b14443d-d9bf-4c9b-9c74-1f434c467b8a   in service     none      none          off        
+    oxp_fbc5bdf2-9644-4d0a-b349-f490486da25d/crypt/zone                                                              49b5c150-d615-487b-bda2-00d8d5fa85fc   in service     none      none          off        
+    oxp_41eaf63b-4fa9-443e-8da1-78d1e79aac7d/crypt/zone/oxz_clickhouse_c3d4b77c-2e77-45ef-9764-5f45723f1e6e          5782d4d4-614c-4521-ba76-64d146ff4086   expunged       none      none          off        
+    oxp_8e2c9e92-e35e-494c-8e14-dcf5f5009656/crypt/zone/oxz_crucible_060bee8a-a830-4db9-b43f-d2d4d651460f            1b994560-5065-495b-8f52-089a66023db9   in service     none      none          off        
+    oxp_bc61cdae-c96f-4886-b8bd-f9fd69d51e3a/crypt/zone/oxz_crucible_14b40b41-0679-4a97-abb9-670d4a014168            4e7d5a46-7ae5-4065-86b6-d6e549a86381   in service     none      none          off        
+    oxp_fbc5bdf2-9644-4d0a-b349-f490486da25d/crypt/zone/oxz_crucible_2d00b429-277a-4670-9841-59dfe36418f5            ba483769-2ff7-469a-8bd5-9d0069c98f3a   in service     none      none          off        
+    oxp_41eaf63b-4fa9-443e-8da1-78d1e79aac7d/crypt/zone/oxz_crucible_6667f342-3f4d-498f-852b-af58fe6cfe4d            12468ab7-b48d-401c-9ef9-26b2d50cd9aa   in service     none      none          off        
+    oxp_e9f68306-460a-4b11-b904-f752633bf1fc/crypt/zone/oxz_crucible_6acddc3a-7c18-4bed-9bee-06179a16b511            636854c7-673f-4a5c-8841-a4ea7d669856   in service     none      none          off        
+    oxp_6e8fdb9f-c47a-47b0-b7ee-9a2adc7e4af5/crypt/zone/oxz_crucible_6d91fce2-b64b-4778-bc7d-3a3ee4fc050f            e8d9ad3c-b77a-4ae9-bd7a-8717663d4732   in service     none      none          off        
+    oxp_a9a8a692-d2d7-4b3e-a297-d648faf8c7cf/crypt/zone/oxz_crucible_743f2573-1cd6-418b-a0e0-7fb6d5dc65c9            0a19c469-38a3-4ad1-acff-a2eec66d039b   in service     none      none          off        
+    oxp_5b04e3d3-7a8b-466e-ab63-6ca89a93e100/crypt/zone/oxz_crucible_9bb3f4a7-3699-481f-928a-f57cbe505f12            7fec29ed-8f6f-4f72-af7a-1603f74ae3e6   in service     none      none          off        
+    oxp_b65c8376-0084-4d6f-9891-9d6a413d4e56/crypt/zone/oxz_crucible_9bcc969f-8a33-4c30-8608-ad9e0048035a            4c0d8c8a-ddb6-4a88-be7f-1bf5685adafa   in service     none      none          off        
+    oxp_a4c575b4-934b-49b9-9c47-9c1241a33607/crypt/zone/oxz_crucible_f50159f9-2c73-4ea6-9e03-296e158a3af4            8f7c7096-7cd3-4a79-b24b-dc0e7fa3e3ec   in service     none      none          off        
+    oxp_41eaf63b-4fa9-443e-8da1-78d1e79aac7d/crypt/zone/oxz_crucible_pantry_c9e73f39-4dd7-4a87-828b-58c4fcf60d4a     786f9c46-8818-4811-a816-65be22187e13   in service     none      none          off        
+    oxp_41eaf63b-4fa9-443e-8da1-78d1e79aac7d/crypt/zone/oxz_internal_dns_42bf3233-3a94-4f47-8c51-7ac3524ea1f5        923f9064-ee22-42f2-a75f-c7da7dde3acc   in service     none      none          off        
+    oxp_41eaf63b-4fa9-443e-8da1-78d1e79aac7d/crypt/zone/oxz_nexus_254bd45b-ef24-4ce2-812b-9e825d11da65               5b7c73f6-8e61-4160-b747-d69aad5af1ac   in service     none      none          off        
+    oxp_41eaf63b-4fa9-443e-8da1-78d1e79aac7d/crypt/zone/oxz_ntp_ac14e7ae-b9d4-455b-9400-89931771987c                 49673924-48da-4afb-85f8-8c92c32c06f0   in service     none      none          off        
+    oxp_41eaf63b-4fa9-443e-8da1-78d1e79aac7d/crypt/debug                                                             e271927c-4565-48f7-b983-721b5e46a1e6   in service     100 GiB   none          gzip-9     
+    oxp_5b04e3d3-7a8b-466e-ab63-6ca89a93e100/crypt/debug                                                             901ce577-ae12-461a-99a9-f8e972f7cc5d   in service     100 GiB   none          gzip-9     
+    oxp_6e8fdb9f-c47a-47b0-b7ee-9a2adc7e4af5/crypt/debug                                                             c2b2e20a-b273-4b7c-b2d9-142447e5fc69   in service     100 GiB   none          gzip-9     
+    oxp_8e2c9e92-e35e-494c-8e14-dcf5f5009656/crypt/debug                                                             2891a537-17ea-4d83-b2ea-af36a6d22d2d   in service     100 GiB   none          gzip-9     
+    oxp_a4c575b4-934b-49b9-9c47-9c1241a33607/crypt/debug                                                             dc614216-2b34-4659-bfbe-55462fe203f0   in service     100 GiB   none          gzip-9     
+    oxp_a9a8a692-d2d7-4b3e-a297-d648faf8c7cf/crypt/debug                                                             872f53ed-6dc6-43e1-8a52-9c87938e2330   in service     100 GiB   none          gzip-9     
+    oxp_b65c8376-0084-4d6f-9891-9d6a413d4e56/crypt/debug                                                             2f0c179c-d7dd-4450-9163-e799de0aef90   in service     100 GiB   none          gzip-9     
+    oxp_bc61cdae-c96f-4886-b8bd-f9fd69d51e3a/crypt/debug                                                             8b49dee0-2726-4261-aabd-331752764e91   in service     100 GiB   none          gzip-9     
+    oxp_e9f68306-460a-4b11-b904-f752633bf1fc/crypt/debug                                                             f6dae5d2-fff9-4562-9fd4-be99ff888afc   in service     100 GiB   none          gzip-9     
+    oxp_fbc5bdf2-9644-4d0a-b349-f490486da25d/crypt/debug                                                             e0a59564-f99b-47a6-b1ca-b83001fe6908   in service     100 GiB   none          gzip-9     
+*   oxp_41eaf63b-4fa9-443e-8da1-78d1e79aac7d/crypt/clickhouse_keeper                                                 04cdeda2-c4f7-4f76-bfbf-f946dcdefda3   - in service   none      none          off        
+     └─                                                                                                                                                     + expunged                                        
+*   oxp_41eaf63b-4fa9-443e-8da1-78d1e79aac7d/crypt/zone/oxz_clickhouse_keeper_14b84b08-598b-4756-99ec-eea98f8fa46e   1b4c5dcd-24e9-4076-9219-e9559ae49857   - in service   none      none          off        
+     └─                                                                                                                                                     + expunged                                        
 
 
     omicron zones generation 4 -> 5:
@@ -118,58 +120,62 @@ to:   blueprint d895ef50-9978-454c-bdfb-b8dbe2c9a918
 
 
     datasets generation 3 -> 4:
-    -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
-    dataset name                                                                                                     dataset uuid                           quota     reservation   compression
-    -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
-    oxp_21b01477-48d0-4b65-9089-4a48277af033/crucible                                                                84bb55f1-1bb2-43e8-876e-6ea25177c441   none      none          off        
-    oxp_2704e66b-3d5c-4b64-951c-a051fa15e4a8/crucible                                                                458ad495-6e68-4c37-92f1-fe95b4793d34   none      none          off        
-    oxp_27a22f7e-754a-43ea-8ec4-e9cbd9b62e08/crucible                                                                a76905d1-b8fa-4fe4-9d92-a6cb6dfb2a52   none      none          off        
-    oxp_51c788ff-de33-43f7-b9c5-f5f56bf80736/crucible                                                                560e9d58-5ec1-48ee-bb54-de7195c87105   none      none          off        
-    oxp_5fe54077-c016-49a9-becb-14993f133d43/crucible                                                                1e4af81b-d9fd-4098-8407-7a02ded667a6   none      none          off        
-    oxp_7e2644a1-bec7-433c-8168-8898d7140aab/crucible                                                                4a10912d-26ef-40be-b53d-ebd1be2511d8   none      none          off        
-    oxp_9825ff38-f07d-44a1-9efc-55a25e72015b/crucible                                                                170c77e2-33d8-420e-95d9-f844cf92b669   none      none          off        
-    oxp_cc585a73-ec86-4f8e-a327-901b947a4c69/crucible                                                                e41db0f3-9cf0-40d7-974e-2bc52e2cb423   none      none          off        
-    oxp_d2801671-bb69-408e-93f7-ac2b05d992f8/crucible                                                                443efd4a-56e8-4cf6-a937-fd9b88c6726f   none      none          off        
-    oxp_f52832ea-60d7-443b-9847-df5384bfc8e2/crucible                                                                b5e0fa95-c29f-4a40-9aed-a6ba784011db   none      none          off        
-    oxp_21b01477-48d0-4b65-9089-4a48277af033/crypt/internal_dns                                                      2b28cc6f-9331-4ebc-ae96-722dbbe50787   none      none          off        
-    oxp_21b01477-48d0-4b65-9089-4a48277af033/crypt/zone                                                              8ed08c10-262a-431d-899a-fd1cd9ef7b7a   none      none          off        
-    oxp_2704e66b-3d5c-4b64-951c-a051fa15e4a8/crypt/zone                                                              513e31d7-ad8e-4d14-ac09-22ccda3e09a0   none      none          off        
-    oxp_27a22f7e-754a-43ea-8ec4-e9cbd9b62e08/crypt/zone                                                              24f9f357-065a-4d0e-8d26-3bc8bf6b7e4d   none      none          off        
-    oxp_51c788ff-de33-43f7-b9c5-f5f56bf80736/crypt/zone                                                              d64352bf-f0cc-4045-9ed2-b28f7ba60b30   none      none          off        
-    oxp_5fe54077-c016-49a9-becb-14993f133d43/crypt/zone                                                              70cb8400-e02f-4c3f-8c50-ed9dc631b144   none      none          off        
-    oxp_7e2644a1-bec7-433c-8168-8898d7140aab/crypt/zone                                                              e8163cfc-097a-486a-ae53-a5704c02b71f   none      none          off        
-    oxp_9825ff38-f07d-44a1-9efc-55a25e72015b/crypt/zone                                                              0f6ed045-ff2e-4bec-91aa-298c11427ad1   none      none          off        
-    oxp_cc585a73-ec86-4f8e-a327-901b947a4c69/crypt/zone                                                              e9a8bebe-0d55-438b-83c5-8177c6ff5338   none      none          off        
-    oxp_d2801671-bb69-408e-93f7-ac2b05d992f8/crypt/zone                                                              f6c82983-cefd-4ce2-aa70-a31e8ce01fb9   none      none          off        
-    oxp_f52832ea-60d7-443b-9847-df5384bfc8e2/crypt/zone                                                              de7c7a98-40a6-427b-ad10-ba86092d0063   none      none          off        
-    oxp_7e2644a1-bec7-433c-8168-8898d7140aab/crypt/zone/oxz_crucible_219b9a45-ed13-4b8c-8c11-4dc050e20622            9b67b652-271f-4f3b-aec8-da672954c7d0   none      none          off        
-    oxp_9825ff38-f07d-44a1-9efc-55a25e72015b/crypt/zone/oxz_crucible_27ccb886-b2d4-417e-80d5-48aca47b1af4            ee782292-53a4-4e79-a0de-2dc161b86c9d   none      none          off        
-    oxp_51c788ff-de33-43f7-b9c5-f5f56bf80736/crypt/zone/oxz_crucible_289b3a22-d704-4463-9ffb-0f6d28f3375c            0fff2deb-36aa-4cc1-b137-8c8e257b6bde   none      none          off        
-    oxp_21b01477-48d0-4b65-9089-4a48277af033/crypt/zone/oxz_crucible_426ca71b-a99b-438d-ab68-aadc572e091d            2569e010-759a-404e-bf2c-5d078b236a98   none      none          off        
-    oxp_f52832ea-60d7-443b-9847-df5384bfc8e2/crypt/zone/oxz_crucible_49ac37b2-44ab-4dc0-95e2-94aeb02feac1            adf11973-c20d-4716-8b43-85362547abb4   none      none          off        
-    oxp_5fe54077-c016-49a9-becb-14993f133d43/crypt/zone/oxz_crucible_4aec3ce0-42c3-4517-9824-d586b0573995            94b5c89a-4cd4-42e3-b58f-46b9ac5144cb   none      none          off        
-    oxp_cc585a73-ec86-4f8e-a327-901b947a4c69/crypt/zone/oxz_crucible_524ac4e1-4450-42c8-b3c2-be1543719114            0af0283c-ff72-4653-9081-2e9736b77b42   none      none          off        
-    oxp_d2801671-bb69-408e-93f7-ac2b05d992f8/crypt/zone/oxz_crucible_74efcbfe-af9b-4725-afe0-cd7be749259c            7fb4dbdd-06fa-41ae-b3f3-8bb1beec4d6a   none      none          off        
-    oxp_27a22f7e-754a-43ea-8ec4-e9cbd9b62e08/crypt/zone/oxz_crucible_b9de2375-60b4-493a-afc3-b39037e39e61            99a7b0dc-e71d-4972-b02b-9cd52504d37d   none      none          off        
-    oxp_2704e66b-3d5c-4b64-951c-a051fa15e4a8/crypt/zone/oxz_crucible_fb520cbc-e538-4e68-99e5-d3815dfa8eda            18a1222c-c627-4cc4-bed2-a7ad09f67401   none      none          off        
-    oxp_21b01477-48d0-4b65-9089-4a48277af033/crypt/zone/oxz_crucible_pantry_7ad82737-6993-41c9-a756-1115d84a9a4c     ddb61eb2-a252-40cb-ba2f-d89819e50b2a   none      none          off        
-    oxp_21b01477-48d0-4b65-9089-4a48277af033/crypt/zone/oxz_internal_dns_edceecb5-d6a2-4da3-abed-51d36c44588b        1174e0b7-3343-43ce-9357-6fd52b5847ca   none      none          off        
-    oxp_21b01477-48d0-4b65-9089-4a48277af033/crypt/zone/oxz_nexus_5e3bbe2e-34ed-4461-bb25-d0e9773a6b17               d6952149-15d8-440f-a7d0-16a842e3cda8   none      none          off        
-    oxp_21b01477-48d0-4b65-9089-4a48277af033/crypt/zone/oxz_ntp_b03bea01-5e98-4aaf-a886-c7498ff42012                 d247b879-8e1f-4ade-a71a-55a715b0f750   none      none          off        
-    oxp_21b01477-48d0-4b65-9089-4a48277af033/crypt/debug                                                             b8b68350-ab5b-497f-896a-1e40f8b1110c   100 GiB   none          gzip-9     
-    oxp_2704e66b-3d5c-4b64-951c-a051fa15e4a8/crypt/debug                                                             2e5f5bf1-224c-48f1-a388-85f0ccdc26b3   100 GiB   none          gzip-9     
-    oxp_27a22f7e-754a-43ea-8ec4-e9cbd9b62e08/crypt/debug                                                             928de1b9-33d6-4529-9c28-baaabde0158b   100 GiB   none          gzip-9     
-    oxp_51c788ff-de33-43f7-b9c5-f5f56bf80736/crypt/debug                                                             e9c16c98-cce5-4171-8605-b9453de85cd3   100 GiB   none          gzip-9     
-    oxp_5fe54077-c016-49a9-becb-14993f133d43/crypt/debug                                                             2313cf25-da1e-4ddb-b1ca-3c37f76b5579   100 GiB   none          gzip-9     
-    oxp_7e2644a1-bec7-433c-8168-8898d7140aab/crypt/debug                                                             883d3371-ed4f-4c13-8162-5d555b322cd4   100 GiB   none          gzip-9     
-    oxp_9825ff38-f07d-44a1-9efc-55a25e72015b/crypt/debug                                                             0239ed9a-4439-40d4-a6d7-4e9bbbcbb8c3   100 GiB   none          gzip-9     
-    oxp_cc585a73-ec86-4f8e-a327-901b947a4c69/crypt/debug                                                             1bac8756-a4cb-42a6-a2a6-2bb4aec66f1c   100 GiB   none          gzip-9     
-    oxp_d2801671-bb69-408e-93f7-ac2b05d992f8/crypt/debug                                                             96bd6ec7-2830-4715-8416-5628d10f726c   100 GiB   none          gzip-9     
-    oxp_f52832ea-60d7-443b-9847-df5384bfc8e2/crypt/debug                                                             99fd5841-618c-45a0-88e0-048839bf19c8   100 GiB   none          gzip-9     
-*   oxp_21b01477-48d0-4b65-9089-4a48277af033/crypt/clickhouse_keeper                                                 89c1fd47-d4b7-4948-b2f8-2b2621fdb892   none      none          off        
-*   oxp_21b01477-48d0-4b65-9089-4a48277af033/crypt/clickhouse_server                                                 231c7aa0-8206-47a7-8b3e-e88548565081   none      none          off        
-*   oxp_21b01477-48d0-4b65-9089-4a48277af033/crypt/zone/oxz_clickhouse_keeper_10db7ee4-04bb-430a-836d-c4308716e995   716b7f3a-718e-41e4-86e2-f55c3bf288d7   none      none          off        
-*   oxp_21b01477-48d0-4b65-9089-4a48277af033/crypt/zone/oxz_clickhouse_server_fe8b84ef-ee63-4dd9-9110-4a8dd696b5c4   273770ea-58d1-4dfe-af91-2bb1e7bfc5b3   none      none          off        
+    ----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
+    dataset name                                                                                                     dataset id                             disposition    quota     reservation   compression
+    ----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
+    oxp_21b01477-48d0-4b65-9089-4a48277af033/crucible                                                                84bb55f1-1bb2-43e8-876e-6ea25177c441   in service     none      none          off        
+    oxp_2704e66b-3d5c-4b64-951c-a051fa15e4a8/crucible                                                                458ad495-6e68-4c37-92f1-fe95b4793d34   in service     none      none          off        
+    oxp_27a22f7e-754a-43ea-8ec4-e9cbd9b62e08/crucible                                                                a76905d1-b8fa-4fe4-9d92-a6cb6dfb2a52   in service     none      none          off        
+    oxp_51c788ff-de33-43f7-b9c5-f5f56bf80736/crucible                                                                560e9d58-5ec1-48ee-bb54-de7195c87105   in service     none      none          off        
+    oxp_5fe54077-c016-49a9-becb-14993f133d43/crucible                                                                1e4af81b-d9fd-4098-8407-7a02ded667a6   in service     none      none          off        
+    oxp_7e2644a1-bec7-433c-8168-8898d7140aab/crucible                                                                4a10912d-26ef-40be-b53d-ebd1be2511d8   in service     none      none          off        
+    oxp_9825ff38-f07d-44a1-9efc-55a25e72015b/crucible                                                                170c77e2-33d8-420e-95d9-f844cf92b669   in service     none      none          off        
+    oxp_cc585a73-ec86-4f8e-a327-901b947a4c69/crucible                                                                e41db0f3-9cf0-40d7-974e-2bc52e2cb423   in service     none      none          off        
+    oxp_d2801671-bb69-408e-93f7-ac2b05d992f8/crucible                                                                443efd4a-56e8-4cf6-a937-fd9b88c6726f   in service     none      none          off        
+    oxp_f52832ea-60d7-443b-9847-df5384bfc8e2/crucible                                                                b5e0fa95-c29f-4a40-9aed-a6ba784011db   in service     none      none          off        
+    oxp_21b01477-48d0-4b65-9089-4a48277af033/crypt/internal_dns                                                      2b28cc6f-9331-4ebc-ae96-722dbbe50787   in service     none      none          off        
+    oxp_21b01477-48d0-4b65-9089-4a48277af033/crypt/zone                                                              8ed08c10-262a-431d-899a-fd1cd9ef7b7a   in service     none      none          off        
+    oxp_2704e66b-3d5c-4b64-951c-a051fa15e4a8/crypt/zone                                                              513e31d7-ad8e-4d14-ac09-22ccda3e09a0   in service     none      none          off        
+    oxp_27a22f7e-754a-43ea-8ec4-e9cbd9b62e08/crypt/zone                                                              24f9f357-065a-4d0e-8d26-3bc8bf6b7e4d   in service     none      none          off        
+    oxp_51c788ff-de33-43f7-b9c5-f5f56bf80736/crypt/zone                                                              d64352bf-f0cc-4045-9ed2-b28f7ba60b30   in service     none      none          off        
+    oxp_5fe54077-c016-49a9-becb-14993f133d43/crypt/zone                                                              70cb8400-e02f-4c3f-8c50-ed9dc631b144   in service     none      none          off        
+    oxp_7e2644a1-bec7-433c-8168-8898d7140aab/crypt/zone                                                              e8163cfc-097a-486a-ae53-a5704c02b71f   in service     none      none          off        
+    oxp_9825ff38-f07d-44a1-9efc-55a25e72015b/crypt/zone                                                              0f6ed045-ff2e-4bec-91aa-298c11427ad1   in service     none      none          off        
+    oxp_cc585a73-ec86-4f8e-a327-901b947a4c69/crypt/zone                                                              e9a8bebe-0d55-438b-83c5-8177c6ff5338   in service     none      none          off        
+    oxp_d2801671-bb69-408e-93f7-ac2b05d992f8/crypt/zone                                                              f6c82983-cefd-4ce2-aa70-a31e8ce01fb9   in service     none      none          off        
+    oxp_f52832ea-60d7-443b-9847-df5384bfc8e2/crypt/zone                                                              de7c7a98-40a6-427b-ad10-ba86092d0063   in service     none      none          off        
+    oxp_7e2644a1-bec7-433c-8168-8898d7140aab/crypt/zone/oxz_crucible_219b9a45-ed13-4b8c-8c11-4dc050e20622            9b67b652-271f-4f3b-aec8-da672954c7d0   in service     none      none          off        
+    oxp_9825ff38-f07d-44a1-9efc-55a25e72015b/crypt/zone/oxz_crucible_27ccb886-b2d4-417e-80d5-48aca47b1af4            ee782292-53a4-4e79-a0de-2dc161b86c9d   in service     none      none          off        
+    oxp_51c788ff-de33-43f7-b9c5-f5f56bf80736/crypt/zone/oxz_crucible_289b3a22-d704-4463-9ffb-0f6d28f3375c            0fff2deb-36aa-4cc1-b137-8c8e257b6bde   in service     none      none          off        
+    oxp_21b01477-48d0-4b65-9089-4a48277af033/crypt/zone/oxz_crucible_426ca71b-a99b-438d-ab68-aadc572e091d            2569e010-759a-404e-bf2c-5d078b236a98   in service     none      none          off        
+    oxp_f52832ea-60d7-443b-9847-df5384bfc8e2/crypt/zone/oxz_crucible_49ac37b2-44ab-4dc0-95e2-94aeb02feac1            adf11973-c20d-4716-8b43-85362547abb4   in service     none      none          off        
+    oxp_5fe54077-c016-49a9-becb-14993f133d43/crypt/zone/oxz_crucible_4aec3ce0-42c3-4517-9824-d586b0573995            94b5c89a-4cd4-42e3-b58f-46b9ac5144cb   in service     none      none          off        
+    oxp_cc585a73-ec86-4f8e-a327-901b947a4c69/crypt/zone/oxz_crucible_524ac4e1-4450-42c8-b3c2-be1543719114            0af0283c-ff72-4653-9081-2e9736b77b42   in service     none      none          off        
+    oxp_d2801671-bb69-408e-93f7-ac2b05d992f8/crypt/zone/oxz_crucible_74efcbfe-af9b-4725-afe0-cd7be749259c            7fb4dbdd-06fa-41ae-b3f3-8bb1beec4d6a   in service     none      none          off        
+    oxp_27a22f7e-754a-43ea-8ec4-e9cbd9b62e08/crypt/zone/oxz_crucible_b9de2375-60b4-493a-afc3-b39037e39e61            99a7b0dc-e71d-4972-b02b-9cd52504d37d   in service     none      none          off        
+    oxp_2704e66b-3d5c-4b64-951c-a051fa15e4a8/crypt/zone/oxz_crucible_fb520cbc-e538-4e68-99e5-d3815dfa8eda            18a1222c-c627-4cc4-bed2-a7ad09f67401   in service     none      none          off        
+    oxp_21b01477-48d0-4b65-9089-4a48277af033/crypt/zone/oxz_crucible_pantry_7ad82737-6993-41c9-a756-1115d84a9a4c     ddb61eb2-a252-40cb-ba2f-d89819e50b2a   in service     none      none          off        
+    oxp_21b01477-48d0-4b65-9089-4a48277af033/crypt/zone/oxz_internal_dns_edceecb5-d6a2-4da3-abed-51d36c44588b        1174e0b7-3343-43ce-9357-6fd52b5847ca   in service     none      none          off        
+    oxp_21b01477-48d0-4b65-9089-4a48277af033/crypt/zone/oxz_nexus_5e3bbe2e-34ed-4461-bb25-d0e9773a6b17               d6952149-15d8-440f-a7d0-16a842e3cda8   in service     none      none          off        
+    oxp_21b01477-48d0-4b65-9089-4a48277af033/crypt/zone/oxz_ntp_b03bea01-5e98-4aaf-a886-c7498ff42012                 d247b879-8e1f-4ade-a71a-55a715b0f750   in service     none      none          off        
+    oxp_21b01477-48d0-4b65-9089-4a48277af033/crypt/debug                                                             b8b68350-ab5b-497f-896a-1e40f8b1110c   in service     100 GiB   none          gzip-9     
+    oxp_2704e66b-3d5c-4b64-951c-a051fa15e4a8/crypt/debug                                                             2e5f5bf1-224c-48f1-a388-85f0ccdc26b3   in service     100 GiB   none          gzip-9     
+    oxp_27a22f7e-754a-43ea-8ec4-e9cbd9b62e08/crypt/debug                                                             928de1b9-33d6-4529-9c28-baaabde0158b   in service     100 GiB   none          gzip-9     
+    oxp_51c788ff-de33-43f7-b9c5-f5f56bf80736/crypt/debug                                                             e9c16c98-cce5-4171-8605-b9453de85cd3   in service     100 GiB   none          gzip-9     
+    oxp_5fe54077-c016-49a9-becb-14993f133d43/crypt/debug                                                             2313cf25-da1e-4ddb-b1ca-3c37f76b5579   in service     100 GiB   none          gzip-9     
+    oxp_7e2644a1-bec7-433c-8168-8898d7140aab/crypt/debug                                                             883d3371-ed4f-4c13-8162-5d555b322cd4   in service     100 GiB   none          gzip-9     
+    oxp_9825ff38-f07d-44a1-9efc-55a25e72015b/crypt/debug                                                             0239ed9a-4439-40d4-a6d7-4e9bbbcbb8c3   in service     100 GiB   none          gzip-9     
+    oxp_cc585a73-ec86-4f8e-a327-901b947a4c69/crypt/debug                                                             1bac8756-a4cb-42a6-a2a6-2bb4aec66f1c   in service     100 GiB   none          gzip-9     
+    oxp_d2801671-bb69-408e-93f7-ac2b05d992f8/crypt/debug                                                             96bd6ec7-2830-4715-8416-5628d10f726c   in service     100 GiB   none          gzip-9     
+    oxp_f52832ea-60d7-443b-9847-df5384bfc8e2/crypt/debug                                                             99fd5841-618c-45a0-88e0-048839bf19c8   in service     100 GiB   none          gzip-9     
+*   oxp_21b01477-48d0-4b65-9089-4a48277af033/crypt/clickhouse_keeper                                                 89c1fd47-d4b7-4948-b2f8-2b2621fdb892   - in service   none      none          off        
+     └─                                                                                                                                                     + expunged                                        
+*   oxp_21b01477-48d0-4b65-9089-4a48277af033/crypt/clickhouse_server                                                 231c7aa0-8206-47a7-8b3e-e88548565081   - in service   none      none          off        
+     └─                                                                                                                                                     + expunged                                        
+*   oxp_21b01477-48d0-4b65-9089-4a48277af033/crypt/zone/oxz_clickhouse_keeper_10db7ee4-04bb-430a-836d-c4308716e995   716b7f3a-718e-41e4-86e2-f55c3bf288d7   - in service   none      none          off        
+     └─                                                                                                                                                     + expunged                                        
+*   oxp_21b01477-48d0-4b65-9089-4a48277af033/crypt/zone/oxz_clickhouse_server_fe8b84ef-ee63-4dd9-9110-4a8dd696b5c4   273770ea-58d1-4dfe-af91-2bb1e7bfc5b3   - in service   none      none          off        
+     └─                                                                                                                                                     + expunged                                        
 
 
     omicron zones generation 3 -> 4:
@@ -215,60 +221,64 @@ to:   blueprint d895ef50-9978-454c-bdfb-b8dbe2c9a918
 
 
     datasets generation 3 -> 4:
-    -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
-    dataset name                                                                                                     dataset uuid                           quota     reservation   compression
-    -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
-    oxp_288d864c-3a9e-4f21-8c6e-720702c82a29/crucible                                                                7a03c6b4-1ad5-4345-a698-e8ec846570b8   none      none          off        
-    oxp_5f877424-eca4-4c5d-af7f-41627382cfd8/crucible                                                                69633ed3-7ae3-44c8-b18f-9185be5e8b16   none      none          off        
-    oxp_65ebc532-cbb7-43e1-923b-37c5cb7236d7/crucible                                                                25eab6da-bb9d-4d85-9416-5d9ecb15fcb0   none      none          off        
-    oxp_8277a18f-3187-4893-8ef1-5cbfe2284616/crucible                                                                ecec4ffc-28d5-467c-bfef-40b78ef90578   none      none          off        
-    oxp_83592889-d746-4c5d-98e8-582d9c34a15f/crucible                                                                f7bb8bb0-af54-470c-a43a-15368a7ee3ea   none      none          off        
-    oxp_88e423b5-98c9-4e78-992a-5d01e1c33272/crucible                                                                2d7b9c72-0af0-4a4a-8aa9-0d9af1ceb031   none      none          off        
-    oxp_a5553017-9991-4ffb-ae37-f9c0e3428562/crucible                                                                ed2876ea-e461-4ad9-a18f-b96898761a74   none      none          off        
-    oxp_b2c5a75b-9f72-405a-8134-691c0f45a1fd/crucible                                                                d649a820-d5bc-47c8-8f09-a153fea0cae6   none      none          off        
-    oxp_d4d665fc-df4d-4a13-b9c2-ad13549c0845/crucible                                                                23bc903a-73d5-401d-9701-ccb4b5620f6d   none      none          off        
-    oxp_facb28ca-94fd-47a0-bf63-ee394d32c43b/crucible                                                                fa87edd8-3150-49e3-a3c1-ad11b82a428e   none      none          off        
-    oxp_288d864c-3a9e-4f21-8c6e-720702c82a29/crypt/internal_dns                                                      b5e9c350-d032-4854-9445-38af42b6da6c   none      none          off        
-    oxp_288d864c-3a9e-4f21-8c6e-720702c82a29/crypt/zone                                                              523f0aaa-c792-417b-88fa-eddfad1c96e1   none      none          off        
-    oxp_5f877424-eca4-4c5d-af7f-41627382cfd8/crypt/zone                                                              fd0ad3de-0bc6-4524-8132-856dea1574a5   none      none          off        
-    oxp_65ebc532-cbb7-43e1-923b-37c5cb7236d7/crypt/zone                                                              767a46bc-9cb2-4ff6-9969-9798bff46115   none      none          off        
-    oxp_8277a18f-3187-4893-8ef1-5cbfe2284616/crypt/zone                                                              2f047175-93b1-4827-890b-ad4df41dc908   none      none          off        
-    oxp_83592889-d746-4c5d-98e8-582d9c34a15f/crypt/zone                                                              5edb9668-3ca5-4416-8e0d-b07e374fc510   none      none          off        
-    oxp_88e423b5-98c9-4e78-992a-5d01e1c33272/crypt/zone                                                              c0a7a1cf-a47d-45ab-8249-bd147f9e78fa   none      none          off        
-    oxp_a5553017-9991-4ffb-ae37-f9c0e3428562/crypt/zone                                                              924d9c1f-021d-494d-acf7-31afcdc6dfd6   none      none          off        
-    oxp_b2c5a75b-9f72-405a-8134-691c0f45a1fd/crypt/zone                                                              923fd3c8-9e2d-46a8-9d64-040adb4f97aa   none      none          off        
-    oxp_d4d665fc-df4d-4a13-b9c2-ad13549c0845/crypt/zone                                                              e0469419-68c7-4f33-ba83-5dd63ad35e82   none      none          off        
-    oxp_facb28ca-94fd-47a0-bf63-ee394d32c43b/crypt/zone                                                              b0e61094-c730-4f49-a2a9-fc257eab77d7   none      none          off        
-    oxp_facb28ca-94fd-47a0-bf63-ee394d32c43b/crypt/zone/oxz_crucible_0b3c14a3-2ebc-465f-bea0-36dafe72b645            536689a3-5791-4c4b-bc59-f20c52653647   none      none          off        
-    oxp_a5553017-9991-4ffb-ae37-f9c0e3428562/crypt/zone/oxz_crucible_196e0925-a8bd-4b24-a8d1-8786dceaed24            52857ff2-3f93-4023-a1d9-bab881b273fb   none      none          off        
-    oxp_8277a18f-3187-4893-8ef1-5cbfe2284616/crypt/zone/oxz_crucible_2fde7a41-f139-4bd8-9617-328de00b69b6            f399a80d-d344-47c2-90e3-79516ad322c8   none      none          off        
-    oxp_65ebc532-cbb7-43e1-923b-37c5cb7236d7/crypt/zone/oxz_crucible_37f4b29c-1a9a-4747-8baf-ee9ac8cba5f4            aa74afec-728d-4d14-ae52-731cb0c437dc   none      none          off        
-    oxp_5f877424-eca4-4c5d-af7f-41627382cfd8/crypt/zone/oxz_crucible_4dc70ea3-fc77-43d4-8b23-b3e22b777292            f2174337-2580-4b41-9c14-7e0efcee0e2d   none      none          off        
-    oxp_88e423b5-98c9-4e78-992a-5d01e1c33272/crypt/zone/oxz_crucible_671d516f-43f5-4b17-856e-65c08bdc7821            3785f450-eab8-485c-bae6-970a722d045c   none      none          off        
-    oxp_83592889-d746-4c5d-98e8-582d9c34a15f/crypt/zone/oxz_crucible_8048791b-05f9-447f-aa0c-1a25cec2a012            6d4d1083-ff28-4fca-8593-6884dc5c86bd   none      none          off        
-    oxp_288d864c-3a9e-4f21-8c6e-720702c82a29/crypt/zone/oxz_crucible_837842a8-ad59-4654-a83d-b13a68a30a92            7fc41833-5f1b-4565-999d-dfe3faaba5ec   none      none          off        
-    oxp_b2c5a75b-9f72-405a-8134-691c0f45a1fd/crypt/zone/oxz_crucible_a6cebeb0-12cf-433d-adaf-7e5e635054bc            7dfa1f54-6587-4d09-8f8f-7eb0402ec1d7   none      none          off        
-    oxp_d4d665fc-df4d-4a13-b9c2-ad13549c0845/crypt/zone/oxz_crucible_b51501a5-50be-439c-bbcd-47e85ac03f68            706dbdb1-086b-4db5-a8e1-5270e65848ac   none      none          off        
-    oxp_288d864c-3a9e-4f21-8c6e-720702c82a29/crypt/zone/oxz_crucible_pantry_511cbb04-ff55-48d3-a1fd-5c2bbbd10ba7     92d0dbde-6a18-48d8-9c70-6bc5d73425d6   none      none          off        
-    oxp_288d864c-3a9e-4f21-8c6e-720702c82a29/crypt/zone/oxz_internal_dns_aae73b3c-14cf-485b-ab97-ebeffcf3fbdc        cb5d97eb-c0d6-4006-a747-7971634a58cf   none      none          off        
-    oxp_288d864c-3a9e-4f21-8c6e-720702c82a29/crypt/zone/oxz_nexus_5424157d-fb7c-4816-9fd1-fedea5eaa4d8               e4504980-52c5-4345-b2d6-3c40d95ec378   none      none          off        
-    oxp_288d864c-3a9e-4f21-8c6e-720702c82a29/crypt/zone/oxz_ntp_db6ac8f4-eeba-4dad-81b5-dbac0dbf3529                 522e92c9-748e-4e46-9e22-5f85e70bf039   none      none          off        
-    oxp_288d864c-3a9e-4f21-8c6e-720702c82a29/crypt/debug                                                             472c10e2-8919-4b4a-a17b-27d886ef8b28   100 GiB   none          gzip-9     
-    oxp_5f877424-eca4-4c5d-af7f-41627382cfd8/crypt/debug                                                             8c119af1-d840-4b9d-827e-8064501f0c7a   100 GiB   none          gzip-9     
-    oxp_65ebc532-cbb7-43e1-923b-37c5cb7236d7/crypt/debug                                                             c227c948-b83f-44c0-9e2d-2b65237b0e8d   100 GiB   none          gzip-9     
-    oxp_8277a18f-3187-4893-8ef1-5cbfe2284616/crypt/debug                                                             8ef34a90-1e48-4d2e-b49e-e84200a5143b   100 GiB   none          gzip-9     
-    oxp_83592889-d746-4c5d-98e8-582d9c34a15f/crypt/debug                                                             ed1845c2-e1a4-481d-b569-de693c8cf267   100 GiB   none          gzip-9     
-    oxp_88e423b5-98c9-4e78-992a-5d01e1c33272/crypt/debug                                                             e3566f33-41c7-4aff-a790-adc53e2a94cc   100 GiB   none          gzip-9     
-    oxp_a5553017-9991-4ffb-ae37-f9c0e3428562/crypt/debug                                                             decc30a9-2c66-4bbd-9388-c711f7233f0e   100 GiB   none          gzip-9     
-    oxp_b2c5a75b-9f72-405a-8134-691c0f45a1fd/crypt/debug                                                             38bc5f30-17f4-4610-b87d-918f04c859ed   100 GiB   none          gzip-9     
-    oxp_d4d665fc-df4d-4a13-b9c2-ad13549c0845/crypt/debug                                                             a84a2e72-8032-451a-862d-06f4eb18db24   100 GiB   none          gzip-9     
-    oxp_facb28ca-94fd-47a0-bf63-ee394d32c43b/crypt/debug                                                             dd44015d-6b42-4970-9080-49267bf44c48   100 GiB   none          gzip-9     
-*   oxp_288d864c-3a9e-4f21-8c6e-720702c82a29/crypt/clickhouse_keeper                                                 1589e72c-6719-46bf-bd6b-496eb5bdded5   none      none          off        
-*   oxp_288d864c-3a9e-4f21-8c6e-720702c82a29/crypt/clickhouse_server                                                 bd823ad1-bcd2-4bfb-9f98-4080f8c5a6d0   none      none          off        
-*   oxp_288d864c-3a9e-4f21-8c6e-720702c82a29/crypt/zone/oxz_clickhouse_keeper_0326e8e8-1d52-495e-9773-cd3fa559edbe   579beffb-3093-445a-823c-3dbd96e882ff   none      none          off        
-*   oxp_288d864c-3a9e-4f21-8c6e-720702c82a29/crypt/zone/oxz_clickhouse_server_1b6b784b-d157-4544-b7ff-6c71f3622a0f   af0cfce5-065b-4444-a1aa-fe6f82ab3f3f   none      none          off        
-+   oxp_288d864c-3a9e-4f21-8c6e-720702c82a29/crypt/clickhouse                                                        3514fa60-ee1a-4917-9893-def35dd0043d   none      none          off        
-+   oxp_288d864c-3a9e-4f21-8c6e-720702c82a29/crypt/zone/oxz_clickhouse_bf9a0f08-fd0d-480c-ae73-3d7507a52b1d          9ef55ba9-8462-424e-a0ff-d4ba686a0bca   none      none          off        
+    ----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
+    dataset name                                                                                                     dataset id                             disposition    quota     reservation   compression
+    ----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
+    oxp_288d864c-3a9e-4f21-8c6e-720702c82a29/crucible                                                                7a03c6b4-1ad5-4345-a698-e8ec846570b8   in service     none      none          off        
+    oxp_5f877424-eca4-4c5d-af7f-41627382cfd8/crucible                                                                69633ed3-7ae3-44c8-b18f-9185be5e8b16   in service     none      none          off        
+    oxp_65ebc532-cbb7-43e1-923b-37c5cb7236d7/crucible                                                                25eab6da-bb9d-4d85-9416-5d9ecb15fcb0   in service     none      none          off        
+    oxp_8277a18f-3187-4893-8ef1-5cbfe2284616/crucible                                                                ecec4ffc-28d5-467c-bfef-40b78ef90578   in service     none      none          off        
+    oxp_83592889-d746-4c5d-98e8-582d9c34a15f/crucible                                                                f7bb8bb0-af54-470c-a43a-15368a7ee3ea   in service     none      none          off        
+    oxp_88e423b5-98c9-4e78-992a-5d01e1c33272/crucible                                                                2d7b9c72-0af0-4a4a-8aa9-0d9af1ceb031   in service     none      none          off        
+    oxp_a5553017-9991-4ffb-ae37-f9c0e3428562/crucible                                                                ed2876ea-e461-4ad9-a18f-b96898761a74   in service     none      none          off        
+    oxp_b2c5a75b-9f72-405a-8134-691c0f45a1fd/crucible                                                                d649a820-d5bc-47c8-8f09-a153fea0cae6   in service     none      none          off        
+    oxp_d4d665fc-df4d-4a13-b9c2-ad13549c0845/crucible                                                                23bc903a-73d5-401d-9701-ccb4b5620f6d   in service     none      none          off        
+    oxp_facb28ca-94fd-47a0-bf63-ee394d32c43b/crucible                                                                fa87edd8-3150-49e3-a3c1-ad11b82a428e   in service     none      none          off        
+    oxp_288d864c-3a9e-4f21-8c6e-720702c82a29/crypt/internal_dns                                                      b5e9c350-d032-4854-9445-38af42b6da6c   in service     none      none          off        
+    oxp_288d864c-3a9e-4f21-8c6e-720702c82a29/crypt/zone                                                              523f0aaa-c792-417b-88fa-eddfad1c96e1   in service     none      none          off        
+    oxp_5f877424-eca4-4c5d-af7f-41627382cfd8/crypt/zone                                                              fd0ad3de-0bc6-4524-8132-856dea1574a5   in service     none      none          off        
+    oxp_65ebc532-cbb7-43e1-923b-37c5cb7236d7/crypt/zone                                                              767a46bc-9cb2-4ff6-9969-9798bff46115   in service     none      none          off        
+    oxp_8277a18f-3187-4893-8ef1-5cbfe2284616/crypt/zone                                                              2f047175-93b1-4827-890b-ad4df41dc908   in service     none      none          off        
+    oxp_83592889-d746-4c5d-98e8-582d9c34a15f/crypt/zone                                                              5edb9668-3ca5-4416-8e0d-b07e374fc510   in service     none      none          off        
+    oxp_88e423b5-98c9-4e78-992a-5d01e1c33272/crypt/zone                                                              c0a7a1cf-a47d-45ab-8249-bd147f9e78fa   in service     none      none          off        
+    oxp_a5553017-9991-4ffb-ae37-f9c0e3428562/crypt/zone                                                              924d9c1f-021d-494d-acf7-31afcdc6dfd6   in service     none      none          off        
+    oxp_b2c5a75b-9f72-405a-8134-691c0f45a1fd/crypt/zone                                                              923fd3c8-9e2d-46a8-9d64-040adb4f97aa   in service     none      none          off        
+    oxp_d4d665fc-df4d-4a13-b9c2-ad13549c0845/crypt/zone                                                              e0469419-68c7-4f33-ba83-5dd63ad35e82   in service     none      none          off        
+    oxp_facb28ca-94fd-47a0-bf63-ee394d32c43b/crypt/zone                                                              b0e61094-c730-4f49-a2a9-fc257eab77d7   in service     none      none          off        
+    oxp_facb28ca-94fd-47a0-bf63-ee394d32c43b/crypt/zone/oxz_crucible_0b3c14a3-2ebc-465f-bea0-36dafe72b645            536689a3-5791-4c4b-bc59-f20c52653647   in service     none      none          off        
+    oxp_a5553017-9991-4ffb-ae37-f9c0e3428562/crypt/zone/oxz_crucible_196e0925-a8bd-4b24-a8d1-8786dceaed24            52857ff2-3f93-4023-a1d9-bab881b273fb   in service     none      none          off        
+    oxp_8277a18f-3187-4893-8ef1-5cbfe2284616/crypt/zone/oxz_crucible_2fde7a41-f139-4bd8-9617-328de00b69b6            f399a80d-d344-47c2-90e3-79516ad322c8   in service     none      none          off        
+    oxp_65ebc532-cbb7-43e1-923b-37c5cb7236d7/crypt/zone/oxz_crucible_37f4b29c-1a9a-4747-8baf-ee9ac8cba5f4            aa74afec-728d-4d14-ae52-731cb0c437dc   in service     none      none          off        
+    oxp_5f877424-eca4-4c5d-af7f-41627382cfd8/crypt/zone/oxz_crucible_4dc70ea3-fc77-43d4-8b23-b3e22b777292            f2174337-2580-4b41-9c14-7e0efcee0e2d   in service     none      none          off        
+    oxp_88e423b5-98c9-4e78-992a-5d01e1c33272/crypt/zone/oxz_crucible_671d516f-43f5-4b17-856e-65c08bdc7821            3785f450-eab8-485c-bae6-970a722d045c   in service     none      none          off        
+    oxp_83592889-d746-4c5d-98e8-582d9c34a15f/crypt/zone/oxz_crucible_8048791b-05f9-447f-aa0c-1a25cec2a012            6d4d1083-ff28-4fca-8593-6884dc5c86bd   in service     none      none          off        
+    oxp_288d864c-3a9e-4f21-8c6e-720702c82a29/crypt/zone/oxz_crucible_837842a8-ad59-4654-a83d-b13a68a30a92            7fc41833-5f1b-4565-999d-dfe3faaba5ec   in service     none      none          off        
+    oxp_b2c5a75b-9f72-405a-8134-691c0f45a1fd/crypt/zone/oxz_crucible_a6cebeb0-12cf-433d-adaf-7e5e635054bc            7dfa1f54-6587-4d09-8f8f-7eb0402ec1d7   in service     none      none          off        
+    oxp_d4d665fc-df4d-4a13-b9c2-ad13549c0845/crypt/zone/oxz_crucible_b51501a5-50be-439c-bbcd-47e85ac03f68            706dbdb1-086b-4db5-a8e1-5270e65848ac   in service     none      none          off        
+    oxp_288d864c-3a9e-4f21-8c6e-720702c82a29/crypt/zone/oxz_crucible_pantry_511cbb04-ff55-48d3-a1fd-5c2bbbd10ba7     92d0dbde-6a18-48d8-9c70-6bc5d73425d6   in service     none      none          off        
+    oxp_288d864c-3a9e-4f21-8c6e-720702c82a29/crypt/zone/oxz_internal_dns_aae73b3c-14cf-485b-ab97-ebeffcf3fbdc        cb5d97eb-c0d6-4006-a747-7971634a58cf   in service     none      none          off        
+    oxp_288d864c-3a9e-4f21-8c6e-720702c82a29/crypt/zone/oxz_nexus_5424157d-fb7c-4816-9fd1-fedea5eaa4d8               e4504980-52c5-4345-b2d6-3c40d95ec378   in service     none      none          off        
+    oxp_288d864c-3a9e-4f21-8c6e-720702c82a29/crypt/zone/oxz_ntp_db6ac8f4-eeba-4dad-81b5-dbac0dbf3529                 522e92c9-748e-4e46-9e22-5f85e70bf039   in service     none      none          off        
+    oxp_288d864c-3a9e-4f21-8c6e-720702c82a29/crypt/debug                                                             472c10e2-8919-4b4a-a17b-27d886ef8b28   in service     100 GiB   none          gzip-9     
+    oxp_5f877424-eca4-4c5d-af7f-41627382cfd8/crypt/debug                                                             8c119af1-d840-4b9d-827e-8064501f0c7a   in service     100 GiB   none          gzip-9     
+    oxp_65ebc532-cbb7-43e1-923b-37c5cb7236d7/crypt/debug                                                             c227c948-b83f-44c0-9e2d-2b65237b0e8d   in service     100 GiB   none          gzip-9     
+    oxp_8277a18f-3187-4893-8ef1-5cbfe2284616/crypt/debug                                                             8ef34a90-1e48-4d2e-b49e-e84200a5143b   in service     100 GiB   none          gzip-9     
+    oxp_83592889-d746-4c5d-98e8-582d9c34a15f/crypt/debug                                                             ed1845c2-e1a4-481d-b569-de693c8cf267   in service     100 GiB   none          gzip-9     
+    oxp_88e423b5-98c9-4e78-992a-5d01e1c33272/crypt/debug                                                             e3566f33-41c7-4aff-a790-adc53e2a94cc   in service     100 GiB   none          gzip-9     
+    oxp_a5553017-9991-4ffb-ae37-f9c0e3428562/crypt/debug                                                             decc30a9-2c66-4bbd-9388-c711f7233f0e   in service     100 GiB   none          gzip-9     
+    oxp_b2c5a75b-9f72-405a-8134-691c0f45a1fd/crypt/debug                                                             38bc5f30-17f4-4610-b87d-918f04c859ed   in service     100 GiB   none          gzip-9     
+    oxp_d4d665fc-df4d-4a13-b9c2-ad13549c0845/crypt/debug                                                             a84a2e72-8032-451a-862d-06f4eb18db24   in service     100 GiB   none          gzip-9     
+    oxp_facb28ca-94fd-47a0-bf63-ee394d32c43b/crypt/debug                                                             dd44015d-6b42-4970-9080-49267bf44c48   in service     100 GiB   none          gzip-9     
+*   oxp_288d864c-3a9e-4f21-8c6e-720702c82a29/crypt/clickhouse_keeper                                                 1589e72c-6719-46bf-bd6b-496eb5bdded5   - in service   none      none          off        
+     └─                                                                                                                                                     + expunged                                        
+*   oxp_288d864c-3a9e-4f21-8c6e-720702c82a29/crypt/clickhouse_server                                                 bd823ad1-bcd2-4bfb-9f98-4080f8c5a6d0   - in service   none      none          off        
+     └─                                                                                                                                                     + expunged                                        
+*   oxp_288d864c-3a9e-4f21-8c6e-720702c82a29/crypt/zone/oxz_clickhouse_keeper_0326e8e8-1d52-495e-9773-cd3fa559edbe   579beffb-3093-445a-823c-3dbd96e882ff   - in service   none      none          off        
+     └─                                                                                                                                                     + expunged                                        
+*   oxp_288d864c-3a9e-4f21-8c6e-720702c82a29/crypt/zone/oxz_clickhouse_server_1b6b784b-d157-4544-b7ff-6c71f3622a0f   af0cfce5-065b-4444-a1aa-fe6f82ab3f3f   - in service   none      none          off        
+     └─                                                                                                                                                     + expunged                                        
++   oxp_288d864c-3a9e-4f21-8c6e-720702c82a29/crypt/clickhouse                                                        3514fa60-ee1a-4917-9893-def35dd0043d   in service     none      none          off        
++   oxp_288d864c-3a9e-4f21-8c6e-720702c82a29/crypt/zone/oxz_clickhouse_bf9a0f08-fd0d-480c-ae73-3d7507a52b1d          9ef55ba9-8462-424e-a0ff-d4ba686a0bca   in service     none      none          off        
 
 
     omicron zones generation 3 -> 4:

--- a/nexus/reconfigurator/planning/tests/output/planner_nonprovisionable_1_2.txt
+++ b/nexus/reconfigurator/planning/tests/output/planner_nonprovisionable_1_2.txt
@@ -22,56 +22,56 @@ to:   blueprint 9f71f5d3-a272-4382-9154-6ea2e171a6c6
 
 
     datasets at generation 2:
-    -----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
-    dataset name                                                                                                   dataset uuid                           quota     reservation   compression
-    -----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
-    oxp_13e6503b-5300-4ccd-abc4-c1512b435929/crucible                                                              01b78855-bc58-45bd-937e-49221a71b875   none      none          off        
-    oxp_44cdb6f2-fa6c-4b69-bab2-3ae4e1ec4b34/crucible                                                              99ddb9cf-a52c-4b59-884e-dea52e6b4f5d   none      none          off        
-    oxp_4de5fc8e-0e41-4ab9-ba12-2dc63882c96a/crucible                                                              354e3bc2-e6c8-49c0-bf1d-c136e499037c   none      none          off        
-    oxp_51564e7a-d69f-4942-bcfe-330224633ca6/crucible                                                              7f36c891-2cf8-4e94-b12a-24199b83462b   none      none          off        
-    oxp_5ca23cb3-cc90-41c5-a474-01898cdd0796/crucible                                                              8dd12603-6cfc-42dd-8912-2a16cb7a748d   none      none          off        
-    oxp_6a23a532-0712-4a8d-be9b-e8c17e97aa4b/crucible                                                              8ff2aecd-a1e8-47bd-8001-97c3e5efb99b   none      none          off        
-    oxp_6f1a330e-e8d4-4c09-97fc-8918b69b2a3c/crucible                                                              dab52576-17e4-4bf8-b87e-c49983a388c2   none      none          off        
-    oxp_7113d104-fb55-4299-bf53-b3c59d258e44/crucible                                                              d2c5b427-f956-4cd1-b174-6caca3685e6f   none      none          off        
-    oxp_8c10be49-3a66-40d4-a082-64d09d916f14/crucible                                                              e2e73bed-32f9-4111-803b-561cbd7faa1a   none      none          off        
-    oxp_d1ebfd7b-3842-4ad7-be31-2b9c031209a9/crucible                                                              5ba5e79d-0a13-41e5-b4d2-6c7cb468cb26   none      none          off        
-    oxp_13e6503b-5300-4ccd-abc4-c1512b435929/crypt/clickhouse                                                      37aac368-1b57-4934-b771-5802ae6d6606   none      none          off        
-    oxp_13e6503b-5300-4ccd-abc4-c1512b435929/crypt/internal_dns                                                    2f276f3f-ad8c-458e-bb62-03f5ec7643f3   none      none          off        
-    oxp_13e6503b-5300-4ccd-abc4-c1512b435929/crypt/zone                                                            a8381430-0bf6-49fd-8e5a-4e7c7eb4edf4   none      none          off        
-    oxp_44cdb6f2-fa6c-4b69-bab2-3ae4e1ec4b34/crypt/zone                                                            34fb7c7c-17c2-4cbb-af27-12b693965a4b   none      none          off        
-    oxp_4de5fc8e-0e41-4ab9-ba12-2dc63882c96a/crypt/zone                                                            a6f2fa57-1161-4b49-b591-2a9cd5a992f3   none      none          off        
-    oxp_51564e7a-d69f-4942-bcfe-330224633ca6/crypt/zone                                                            df22d065-beb6-45e4-984e-874dfdd3b285   none      none          off        
-    oxp_5ca23cb3-cc90-41c5-a474-01898cdd0796/crypt/zone                                                            59656ee4-d86f-49ff-b4b8-39e1021642f4   none      none          off        
-    oxp_6a23a532-0712-4a8d-be9b-e8c17e97aa4b/crypt/zone                                                            ea5ee557-cc4e-4a9b-87a7-7bb9b30589da   none      none          off        
-    oxp_6f1a330e-e8d4-4c09-97fc-8918b69b2a3c/crypt/zone                                                            5b0f2d79-6120-4b28-8fd6-919a121f5875   none      none          off        
-    oxp_7113d104-fb55-4299-bf53-b3c59d258e44/crypt/zone                                                            dd56b58b-871e-4f55-bcf5-0bd4e8184761   none      none          off        
-    oxp_8c10be49-3a66-40d4-a082-64d09d916f14/crypt/zone                                                            bafeb8db-cb8e-45fc-8030-3a85a26e2feb   none      none          off        
-    oxp_d1ebfd7b-3842-4ad7-be31-2b9c031209a9/crypt/zone                                                            b567319c-bb7a-4ac0-a95b-20bd88c26579   none      none          off        
-    oxp_13e6503b-5300-4ccd-abc4-c1512b435929/crypt/zone/oxz_clickhouse_5fbb489a-141d-4de2-86c4-4fd7b9d9f315        648fecf4-8ce6-4bce-9020-789057c92f95   none      none          off        
-    oxp_13e6503b-5300-4ccd-abc4-c1512b435929/crypt/zone/oxz_crucible_0ce2b998-f5ad-4dc5-b2ec-5250a308506d          4fe9bcd8-399f-444e-aa01-f8cb285de102   none      none          off        
-    oxp_7113d104-fb55-4299-bf53-b3c59d258e44/crypt/zone/oxz_crucible_0e8e9f2d-291d-47fc-ba0f-84cb50e713fd          ff5a6a51-2797-4016-903f-69ec69e59ef9   none      none          off        
-    oxp_51564e7a-d69f-4942-bcfe-330224633ca6/crypt/zone/oxz_crucible_11fc3b08-2470-4f1b-9187-acff1fc4c5ea          32b45c55-cc53-4635-ae2b-559821b409fe   none      none          off        
-    oxp_6f1a330e-e8d4-4c09-97fc-8918b69b2a3c/crypt/zone/oxz_crucible_673ecd68-d12a-46d9-9126-0a6be6245f84          0377cfc0-2bf6-4906-87f7-031121797594   none      none          off        
-    oxp_6a23a532-0712-4a8d-be9b-e8c17e97aa4b/crypt/zone/oxz_crucible_966c4f15-0aa8-4bef-95e4-49d686cffdfc          9ef1c45c-753a-4ecf-9145-72889ece2ad2   none      none          off        
-    oxp_8c10be49-3a66-40d4-a082-64d09d916f14/crypt/zone/oxz_crucible_979a7b5b-81a5-49bc-82e5-d88b6eaf7d96          b075b63e-f072-4f35-86d1-a81e50065994   none      none          off        
-    oxp_5ca23cb3-cc90-41c5-a474-01898cdd0796/crypt/zone/oxz_crucible_b6beadb1-351b-461d-a887-e7641d976a9e          9d2477db-7dea-4e19-b563-60a18a659cca   none      none          off        
-    oxp_4de5fc8e-0e41-4ab9-ba12-2dc63882c96a/crypt/zone/oxz_crucible_cf7add30-1c49-4d49-a2d2-1c46a60cd884          3b71883e-8704-468e-96fa-7b4fd85d37e8   none      none          off        
-    oxp_d1ebfd7b-3842-4ad7-be31-2b9c031209a9/crypt/zone/oxz_crucible_d0d4a23e-45fa-4f80-9bdf-a348de3f7b8f          5888130a-54bf-4358-bb1b-099347648757   none      none          off        
-    oxp_44cdb6f2-fa6c-4b69-bab2-3ae4e1ec4b34/crypt/zone/oxz_crucible_e46d1442-2a63-44e3-a6aa-e88150b85d92          c4739101-dd65-4649-8e99-e221dc9ce93e   none      none          off        
-    oxp_13e6503b-5300-4ccd-abc4-c1512b435929/crypt/zone/oxz_crucible_pantry_45b6f382-3590-4281-b65d-083ba7aff2d3   f07a8f89-a4e1-4c71-b223-a4c09af0e443   none      none          off        
-    oxp_13e6503b-5300-4ccd-abc4-c1512b435929/crypt/zone/oxz_internal_dns_4fd906d8-94cd-44b3-ad5e-34b4d193bd3c      3681f68d-2840-47be-8bb7-8c7354daf8a7   none      none          off        
-    oxp_13e6503b-5300-4ccd-abc4-c1512b435929/crypt/zone/oxz_nexus_88602518-f176-49a1-af12-02fac36214c3             99c53b55-b716-414d-b8ff-a9d56bd9cd6c   none      none          off        
-    oxp_13e6503b-5300-4ccd-abc4-c1512b435929/crypt/zone/oxz_ntp_b0a48e5a-e2bd-46b2-9bc6-8babbbdc0adc               ed9b8ac9-88f4-46fa-8ecf-5a7534d4f020   none      none          off        
-    oxp_13e6503b-5300-4ccd-abc4-c1512b435929/crypt/debug                                                           97bc5b54-dd6a-4b98-b9e0-081657a3db89   100 GiB   none          gzip-9     
-    oxp_44cdb6f2-fa6c-4b69-bab2-3ae4e1ec4b34/crypt/debug                                                           8d054703-b940-4395-8c46-2ff519f5133a   100 GiB   none          gzip-9     
-    oxp_4de5fc8e-0e41-4ab9-ba12-2dc63882c96a/crypt/debug                                                           bb388082-2d09-4a4b-bb22-ee3f4b7b5025   100 GiB   none          gzip-9     
-    oxp_51564e7a-d69f-4942-bcfe-330224633ca6/crypt/debug                                                           fe2005ba-7f3d-4fc3-b324-09a258fc4a4b   100 GiB   none          gzip-9     
-    oxp_5ca23cb3-cc90-41c5-a474-01898cdd0796/crypt/debug                                                           e20df72b-3d75-48ad-8349-3e39cc886886   100 GiB   none          gzip-9     
-    oxp_6a23a532-0712-4a8d-be9b-e8c17e97aa4b/crypt/debug                                                           cf2b245f-c667-49a9-bbc2-ada9a51e63f0   100 GiB   none          gzip-9     
-    oxp_6f1a330e-e8d4-4c09-97fc-8918b69b2a3c/crypt/debug                                                           1c606d5c-ce8c-42e8-9359-d2e0fe31d525   100 GiB   none          gzip-9     
-    oxp_7113d104-fb55-4299-bf53-b3c59d258e44/crypt/debug                                                           1f3f9209-c380-40ab-a2f0-16ecddb6d4a8   100 GiB   none          gzip-9     
-    oxp_8c10be49-3a66-40d4-a082-64d09d916f14/crypt/debug                                                           89b81a7c-3bc3-455d-97e3-75067de991d5   100 GiB   none          gzip-9     
-    oxp_d1ebfd7b-3842-4ad7-be31-2b9c031209a9/crypt/debug                                                           1e581e94-bb9d-4514-8dbb-3a882e342d1b   100 GiB   none          gzip-9     
+    -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
+    dataset name                                                                                                   dataset id                             disposition   quota     reservation   compression
+    -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
+    oxp_13e6503b-5300-4ccd-abc4-c1512b435929/crucible                                                              01b78855-bc58-45bd-937e-49221a71b875   in service    none      none          off        
+    oxp_44cdb6f2-fa6c-4b69-bab2-3ae4e1ec4b34/crucible                                                              99ddb9cf-a52c-4b59-884e-dea52e6b4f5d   in service    none      none          off        
+    oxp_4de5fc8e-0e41-4ab9-ba12-2dc63882c96a/crucible                                                              354e3bc2-e6c8-49c0-bf1d-c136e499037c   in service    none      none          off        
+    oxp_51564e7a-d69f-4942-bcfe-330224633ca6/crucible                                                              7f36c891-2cf8-4e94-b12a-24199b83462b   in service    none      none          off        
+    oxp_5ca23cb3-cc90-41c5-a474-01898cdd0796/crucible                                                              8dd12603-6cfc-42dd-8912-2a16cb7a748d   in service    none      none          off        
+    oxp_6a23a532-0712-4a8d-be9b-e8c17e97aa4b/crucible                                                              8ff2aecd-a1e8-47bd-8001-97c3e5efb99b   in service    none      none          off        
+    oxp_6f1a330e-e8d4-4c09-97fc-8918b69b2a3c/crucible                                                              dab52576-17e4-4bf8-b87e-c49983a388c2   in service    none      none          off        
+    oxp_7113d104-fb55-4299-bf53-b3c59d258e44/crucible                                                              d2c5b427-f956-4cd1-b174-6caca3685e6f   in service    none      none          off        
+    oxp_8c10be49-3a66-40d4-a082-64d09d916f14/crucible                                                              e2e73bed-32f9-4111-803b-561cbd7faa1a   in service    none      none          off        
+    oxp_d1ebfd7b-3842-4ad7-be31-2b9c031209a9/crucible                                                              5ba5e79d-0a13-41e5-b4d2-6c7cb468cb26   in service    none      none          off        
+    oxp_13e6503b-5300-4ccd-abc4-c1512b435929/crypt/clickhouse                                                      37aac368-1b57-4934-b771-5802ae6d6606   in service    none      none          off        
+    oxp_13e6503b-5300-4ccd-abc4-c1512b435929/crypt/internal_dns                                                    2f276f3f-ad8c-458e-bb62-03f5ec7643f3   in service    none      none          off        
+    oxp_13e6503b-5300-4ccd-abc4-c1512b435929/crypt/zone                                                            a8381430-0bf6-49fd-8e5a-4e7c7eb4edf4   in service    none      none          off        
+    oxp_44cdb6f2-fa6c-4b69-bab2-3ae4e1ec4b34/crypt/zone                                                            34fb7c7c-17c2-4cbb-af27-12b693965a4b   in service    none      none          off        
+    oxp_4de5fc8e-0e41-4ab9-ba12-2dc63882c96a/crypt/zone                                                            a6f2fa57-1161-4b49-b591-2a9cd5a992f3   in service    none      none          off        
+    oxp_51564e7a-d69f-4942-bcfe-330224633ca6/crypt/zone                                                            df22d065-beb6-45e4-984e-874dfdd3b285   in service    none      none          off        
+    oxp_5ca23cb3-cc90-41c5-a474-01898cdd0796/crypt/zone                                                            59656ee4-d86f-49ff-b4b8-39e1021642f4   in service    none      none          off        
+    oxp_6a23a532-0712-4a8d-be9b-e8c17e97aa4b/crypt/zone                                                            ea5ee557-cc4e-4a9b-87a7-7bb9b30589da   in service    none      none          off        
+    oxp_6f1a330e-e8d4-4c09-97fc-8918b69b2a3c/crypt/zone                                                            5b0f2d79-6120-4b28-8fd6-919a121f5875   in service    none      none          off        
+    oxp_7113d104-fb55-4299-bf53-b3c59d258e44/crypt/zone                                                            dd56b58b-871e-4f55-bcf5-0bd4e8184761   in service    none      none          off        
+    oxp_8c10be49-3a66-40d4-a082-64d09d916f14/crypt/zone                                                            bafeb8db-cb8e-45fc-8030-3a85a26e2feb   in service    none      none          off        
+    oxp_d1ebfd7b-3842-4ad7-be31-2b9c031209a9/crypt/zone                                                            b567319c-bb7a-4ac0-a95b-20bd88c26579   in service    none      none          off        
+    oxp_13e6503b-5300-4ccd-abc4-c1512b435929/crypt/zone/oxz_clickhouse_5fbb489a-141d-4de2-86c4-4fd7b9d9f315        648fecf4-8ce6-4bce-9020-789057c92f95   in service    none      none          off        
+    oxp_13e6503b-5300-4ccd-abc4-c1512b435929/crypt/zone/oxz_crucible_0ce2b998-f5ad-4dc5-b2ec-5250a308506d          4fe9bcd8-399f-444e-aa01-f8cb285de102   in service    none      none          off        
+    oxp_7113d104-fb55-4299-bf53-b3c59d258e44/crypt/zone/oxz_crucible_0e8e9f2d-291d-47fc-ba0f-84cb50e713fd          ff5a6a51-2797-4016-903f-69ec69e59ef9   in service    none      none          off        
+    oxp_51564e7a-d69f-4942-bcfe-330224633ca6/crypt/zone/oxz_crucible_11fc3b08-2470-4f1b-9187-acff1fc4c5ea          32b45c55-cc53-4635-ae2b-559821b409fe   in service    none      none          off        
+    oxp_6f1a330e-e8d4-4c09-97fc-8918b69b2a3c/crypt/zone/oxz_crucible_673ecd68-d12a-46d9-9126-0a6be6245f84          0377cfc0-2bf6-4906-87f7-031121797594   in service    none      none          off        
+    oxp_6a23a532-0712-4a8d-be9b-e8c17e97aa4b/crypt/zone/oxz_crucible_966c4f15-0aa8-4bef-95e4-49d686cffdfc          9ef1c45c-753a-4ecf-9145-72889ece2ad2   in service    none      none          off        
+    oxp_8c10be49-3a66-40d4-a082-64d09d916f14/crypt/zone/oxz_crucible_979a7b5b-81a5-49bc-82e5-d88b6eaf7d96          b075b63e-f072-4f35-86d1-a81e50065994   in service    none      none          off        
+    oxp_5ca23cb3-cc90-41c5-a474-01898cdd0796/crypt/zone/oxz_crucible_b6beadb1-351b-461d-a887-e7641d976a9e          9d2477db-7dea-4e19-b563-60a18a659cca   in service    none      none          off        
+    oxp_4de5fc8e-0e41-4ab9-ba12-2dc63882c96a/crypt/zone/oxz_crucible_cf7add30-1c49-4d49-a2d2-1c46a60cd884          3b71883e-8704-468e-96fa-7b4fd85d37e8   in service    none      none          off        
+    oxp_d1ebfd7b-3842-4ad7-be31-2b9c031209a9/crypt/zone/oxz_crucible_d0d4a23e-45fa-4f80-9bdf-a348de3f7b8f          5888130a-54bf-4358-bb1b-099347648757   in service    none      none          off        
+    oxp_44cdb6f2-fa6c-4b69-bab2-3ae4e1ec4b34/crypt/zone/oxz_crucible_e46d1442-2a63-44e3-a6aa-e88150b85d92          c4739101-dd65-4649-8e99-e221dc9ce93e   in service    none      none          off        
+    oxp_13e6503b-5300-4ccd-abc4-c1512b435929/crypt/zone/oxz_crucible_pantry_45b6f382-3590-4281-b65d-083ba7aff2d3   f07a8f89-a4e1-4c71-b223-a4c09af0e443   in service    none      none          off        
+    oxp_13e6503b-5300-4ccd-abc4-c1512b435929/crypt/zone/oxz_internal_dns_4fd906d8-94cd-44b3-ad5e-34b4d193bd3c      3681f68d-2840-47be-8bb7-8c7354daf8a7   in service    none      none          off        
+    oxp_13e6503b-5300-4ccd-abc4-c1512b435929/crypt/zone/oxz_nexus_88602518-f176-49a1-af12-02fac36214c3             99c53b55-b716-414d-b8ff-a9d56bd9cd6c   in service    none      none          off        
+    oxp_13e6503b-5300-4ccd-abc4-c1512b435929/crypt/zone/oxz_ntp_b0a48e5a-e2bd-46b2-9bc6-8babbbdc0adc               ed9b8ac9-88f4-46fa-8ecf-5a7534d4f020   in service    none      none          off        
+    oxp_13e6503b-5300-4ccd-abc4-c1512b435929/crypt/debug                                                           97bc5b54-dd6a-4b98-b9e0-081657a3db89   in service    100 GiB   none          gzip-9     
+    oxp_44cdb6f2-fa6c-4b69-bab2-3ae4e1ec4b34/crypt/debug                                                           8d054703-b940-4395-8c46-2ff519f5133a   in service    100 GiB   none          gzip-9     
+    oxp_4de5fc8e-0e41-4ab9-ba12-2dc63882c96a/crypt/debug                                                           bb388082-2d09-4a4b-bb22-ee3f4b7b5025   in service    100 GiB   none          gzip-9     
+    oxp_51564e7a-d69f-4942-bcfe-330224633ca6/crypt/debug                                                           fe2005ba-7f3d-4fc3-b324-09a258fc4a4b   in service    100 GiB   none          gzip-9     
+    oxp_5ca23cb3-cc90-41c5-a474-01898cdd0796/crypt/debug                                                           e20df72b-3d75-48ad-8349-3e39cc886886   in service    100 GiB   none          gzip-9     
+    oxp_6a23a532-0712-4a8d-be9b-e8c17e97aa4b/crypt/debug                                                           cf2b245f-c667-49a9-bbc2-ada9a51e63f0   in service    100 GiB   none          gzip-9     
+    oxp_6f1a330e-e8d4-4c09-97fc-8918b69b2a3c/crypt/debug                                                           1c606d5c-ce8c-42e8-9359-d2e0fe31d525   in service    100 GiB   none          gzip-9     
+    oxp_7113d104-fb55-4299-bf53-b3c59d258e44/crypt/debug                                                           1f3f9209-c380-40ab-a2f0-16ecddb6d4a8   in service    100 GiB   none          gzip-9     
+    oxp_8c10be49-3a66-40d4-a082-64d09d916f14/crypt/debug                                                           89b81a7c-3bc3-455d-97e3-75067de991d5   in service    100 GiB   none          gzip-9     
+    oxp_d1ebfd7b-3842-4ad7-be31-2b9c031209a9/crypt/debug                                                           1e581e94-bb9d-4514-8dbb-3a882e342d1b   in service    100 GiB   none          gzip-9     
 
 
     omicron zones at generation 2:
@@ -116,54 +116,54 @@ to:   blueprint 9f71f5d3-a272-4382-9154-6ea2e171a6c6
 
 
     datasets from generation 2:
-    -----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
-    dataset name                                                                                                   dataset uuid                           quota     reservation   compression
-    -----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
--   oxp_22930645-144a-415c-bceb-2dbfafb9c29e/crucible                                                              4393326c-f79e-497e-8539-e8268de235ae   none      none          off        
--   oxp_24155070-8a43-4244-a3ba-853d8c71972d/crucible                                                              6bcb7a19-f5e8-49a2-b2ff-35a97be53a4e   none      none          off        
--   oxp_494782c7-3821-4f49-918b-ce42cc4d18ad/crucible                                                              ee61b0d0-a302-41c0-aba7-1fc4bc9c1f29   none      none          off        
--   oxp_6ea8a67f-d27d-472b-844c-6c8245b00e2b/crucible                                                              6d5d6e6a-d1cd-4ca2-aaf9-1db561847e58   none      none          off        
--   oxp_77565d57-c235-4905-b3c7-32d1c2ca2c44/crucible                                                              0ae3e100-879c-4aed-9671-51405148857c   none      none          off        
--   oxp_8746874c-dc3b-4454-93cd-2a8fc13720fe/crucible                                                              0e520292-0605-4508-8b87-bc9f4bdb2d17   none      none          off        
--   oxp_a42c5a67-6e10-4586-a56e-48bb8260e75f/crucible                                                              baf9409f-9730-4c3b-9969-6d0af7abfa96   none      none          off        
--   oxp_ca89b120-7bcd-4eeb-baa7-71031fbd103b/crucible                                                              87efc84a-b983-4c40-8dcf-711348dfab9a   none      none          off        
--   oxp_ef61aa97-c862-428c-82f3-0a69a50d6155/crucible                                                              4a0fdd0e-ae77-45d3-b3b9-889898179f86   none      none          off        
--   oxp_ef64ff6d-250d-47ac-8686-e696cfb46966/crucible                                                              84296646-39b7-4329-8c7b-83651c0501f9   none      none          off        
--   oxp_22930645-144a-415c-bceb-2dbfafb9c29e/crypt/internal_dns                                                    50eb638f-21eb-41f1-bb0b-fc8e3adbf516   none      none          off        
--   oxp_22930645-144a-415c-bceb-2dbfafb9c29e/crypt/zone                                                            6348353d-db1d-4016-9686-ea46eb9ffafe   none      none          off        
--   oxp_24155070-8a43-4244-a3ba-853d8c71972d/crypt/zone                                                            6760b9f3-b130-4604-8212-964507005533   none      none          off        
--   oxp_494782c7-3821-4f49-918b-ce42cc4d18ad/crypt/zone                                                            81a147f6-4f29-490d-862f-09333e6c0331   none      none          off        
--   oxp_6ea8a67f-d27d-472b-844c-6c8245b00e2b/crypt/zone                                                            7ba4cc5a-05d5-48f8-bf1f-c19431c02e21   none      none          off        
--   oxp_77565d57-c235-4905-b3c7-32d1c2ca2c44/crypt/zone                                                            d2b96129-68b8-428c-9041-f92a28b231d2   none      none          off        
--   oxp_8746874c-dc3b-4454-93cd-2a8fc13720fe/crypt/zone                                                            edce7c97-7d0e-4da9-9d34-86b577bb5477   none      none          off        
--   oxp_a42c5a67-6e10-4586-a56e-48bb8260e75f/crypt/zone                                                            02c0a9a5-0b9b-4421-9643-4e8b9c5ff39e   none      none          off        
--   oxp_ca89b120-7bcd-4eeb-baa7-71031fbd103b/crypt/zone                                                            ddb27eda-8f02-438d-8956-87aa3d11ae9a   none      none          off        
--   oxp_ef61aa97-c862-428c-82f3-0a69a50d6155/crypt/zone                                                            54f218fb-6023-4693-ad38-8e8fb2056a36   none      none          off        
--   oxp_ef64ff6d-250d-47ac-8686-e696cfb46966/crypt/zone                                                            c1b62139-e0fe-4458-a7fd-593d6fc0b7a0   none      none          off        
--   oxp_ef64ff6d-250d-47ac-8686-e696cfb46966/crypt/zone/oxz_crucible_085d10cb-a6f0-46de-86bc-ad2f7f1defcf          e365431d-2c6b-4ab8-ac38-66bda9a09c58   none      none          off        
--   oxp_ca89b120-7bcd-4eeb-baa7-71031fbd103b/crypt/zone/oxz_crucible_2bf62dfa-537a-4616-aad5-64447faaec53          30584efb-cb2a-4446-8e92-979e1e3ad21c   none      none          off        
--   oxp_6ea8a67f-d27d-472b-844c-6c8245b00e2b/crypt/zone/oxz_crucible_50d43a78-e9af-4051-9f5d-85410f44214b          f165f189-8f8d-4e75-b947-8cde0b3b9d1a   none      none          off        
--   oxp_a42c5a67-6e10-4586-a56e-48bb8260e75f/crypt/zone/oxz_crucible_6e7b5239-0d2e-42a5-80aa-51a3bc859318          9d9170ef-3f05-4893-a322-31d80038fcbc   none      none          off        
--   oxp_494782c7-3821-4f49-918b-ce42cc4d18ad/crypt/zone/oxz_crucible_8d87b485-3fb4-480b-97ce-02d066b799d7          51767a5b-953f-4333-b123-630d38803e98   none      none          off        
--   oxp_24155070-8a43-4244-a3ba-853d8c71972d/crypt/zone/oxz_crucible_b3d757b8-033f-4a68-82db-6ff5331b9739          ac210527-730a-41a7-bb39-b5ab118b0176   none      none          off        
--   oxp_77565d57-c235-4905-b3c7-32d1c2ca2c44/crypt/zone/oxz_crucible_bcd98cf5-a798-4aa0-81cc-8972a376073c          36312983-f969-4f3e-9008-23439cfdf85b   none      none          off        
--   oxp_8746874c-dc3b-4454-93cd-2a8fc13720fe/crypt/zone/oxz_crucible_bd12d9d5-bccf-433a-b078-794a69aeb89a          112c4751-37b3-4dd1-9669-9d78eb778221   none      none          off        
--   oxp_ef61aa97-c862-428c-82f3-0a69a50d6155/crypt/zone/oxz_crucible_d283707c-1b8f-4cb9-946d-041b25a83967          4a35ecb6-9930-499b-a784-7f423a7d1975   none      none          off        
--   oxp_22930645-144a-415c-bceb-2dbfafb9c29e/crypt/zone/oxz_crucible_e362415d-2d54-4574-b823-3f01b9b751de          7991a9e3-04df-42f3-9ce5-ad6d9f54a308   none      none          off        
--   oxp_22930645-144a-415c-bceb-2dbfafb9c29e/crypt/zone/oxz_crucible_pantry_208c987a-ab33-47a3-a103-6108dd6dc4cb   d8a25751-04a7-4f92-920d-e4294cd0d9f5   none      none          off        
--   oxp_22930645-144a-415c-bceb-2dbfafb9c29e/crypt/zone/oxz_internal_dns_c428175e-6a1c-40bf-aa36-f608a57431f5      c9e9ec7e-68d6-4d78-88ae-144336a5f68d   none      none          off        
--   oxp_22930645-144a-415c-bceb-2dbfafb9c29e/crypt/zone/oxz_nexus_533416e6-d0bd-482d-b592-29346c8a3471             e3638c01-8669-41a4-a4a6-9b981bf478ed   none      none          off        
--   oxp_22930645-144a-415c-bceb-2dbfafb9c29e/crypt/zone/oxz_ntp_a8f1b53a-4231-4f04-9939-29e50a0f0e2c               a943567c-1e12-48b9-80f3-a1c48242191c   none      none          off        
--   oxp_22930645-144a-415c-bceb-2dbfafb9c29e/crypt/debug                                                           3dfdb70d-6884-4143-939b-3a973ae7314e   100 GiB   none          gzip-9     
--   oxp_24155070-8a43-4244-a3ba-853d8c71972d/crypt/debug                                                           e6fe9880-110a-4e55-8390-5a7d9205aea0   100 GiB   none          gzip-9     
--   oxp_494782c7-3821-4f49-918b-ce42cc4d18ad/crypt/debug                                                           730e9778-32bb-4eb9-9488-5412e8c00e9a   100 GiB   none          gzip-9     
--   oxp_6ea8a67f-d27d-472b-844c-6c8245b00e2b/crypt/debug                                                           38509c13-7948-4bf3-b34b-8f51862b135a   100 GiB   none          gzip-9     
--   oxp_77565d57-c235-4905-b3c7-32d1c2ca2c44/crypt/debug                                                           aff03579-cf55-4e57-b22c-84e54788bcfe   100 GiB   none          gzip-9     
--   oxp_8746874c-dc3b-4454-93cd-2a8fc13720fe/crypt/debug                                                           f8b506cf-c947-4579-a852-dc017f59e092   100 GiB   none          gzip-9     
--   oxp_a42c5a67-6e10-4586-a56e-48bb8260e75f/crypt/debug                                                           06ee31c6-5e75-444b-af7d-49695a1fbff4   100 GiB   none          gzip-9     
--   oxp_ca89b120-7bcd-4eeb-baa7-71031fbd103b/crypt/debug                                                           20745882-62c8-48db-a8fd-c0b0dc967897   100 GiB   none          gzip-9     
--   oxp_ef61aa97-c862-428c-82f3-0a69a50d6155/crypt/debug                                                           a6ca9c24-86cc-4e94-b921-38c0f1c922d4   100 GiB   none          gzip-9     
--   oxp_ef64ff6d-250d-47ac-8686-e696cfb46966/crypt/debug                                                           5d4ce100-3838-401c-8f2e-46b5b5374115   100 GiB   none          gzip-9     
+    -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
+    dataset name                                                                                                   dataset id                             disposition   quota     reservation   compression
+    -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
+-   oxp_22930645-144a-415c-bceb-2dbfafb9c29e/crucible                                                              4393326c-f79e-497e-8539-e8268de235ae   in service    none      none          off        
+-   oxp_24155070-8a43-4244-a3ba-853d8c71972d/crucible                                                              6bcb7a19-f5e8-49a2-b2ff-35a97be53a4e   in service    none      none          off        
+-   oxp_494782c7-3821-4f49-918b-ce42cc4d18ad/crucible                                                              ee61b0d0-a302-41c0-aba7-1fc4bc9c1f29   in service    none      none          off        
+-   oxp_6ea8a67f-d27d-472b-844c-6c8245b00e2b/crucible                                                              6d5d6e6a-d1cd-4ca2-aaf9-1db561847e58   in service    none      none          off        
+-   oxp_77565d57-c235-4905-b3c7-32d1c2ca2c44/crucible                                                              0ae3e100-879c-4aed-9671-51405148857c   in service    none      none          off        
+-   oxp_8746874c-dc3b-4454-93cd-2a8fc13720fe/crucible                                                              0e520292-0605-4508-8b87-bc9f4bdb2d17   in service    none      none          off        
+-   oxp_a42c5a67-6e10-4586-a56e-48bb8260e75f/crucible                                                              baf9409f-9730-4c3b-9969-6d0af7abfa96   in service    none      none          off        
+-   oxp_ca89b120-7bcd-4eeb-baa7-71031fbd103b/crucible                                                              87efc84a-b983-4c40-8dcf-711348dfab9a   in service    none      none          off        
+-   oxp_ef61aa97-c862-428c-82f3-0a69a50d6155/crucible                                                              4a0fdd0e-ae77-45d3-b3b9-889898179f86   in service    none      none          off        
+-   oxp_ef64ff6d-250d-47ac-8686-e696cfb46966/crucible                                                              84296646-39b7-4329-8c7b-83651c0501f9   in service    none      none          off        
+-   oxp_22930645-144a-415c-bceb-2dbfafb9c29e/crypt/internal_dns                                                    50eb638f-21eb-41f1-bb0b-fc8e3adbf516   in service    none      none          off        
+-   oxp_22930645-144a-415c-bceb-2dbfafb9c29e/crypt/zone                                                            6348353d-db1d-4016-9686-ea46eb9ffafe   in service    none      none          off        
+-   oxp_24155070-8a43-4244-a3ba-853d8c71972d/crypt/zone                                                            6760b9f3-b130-4604-8212-964507005533   in service    none      none          off        
+-   oxp_494782c7-3821-4f49-918b-ce42cc4d18ad/crypt/zone                                                            81a147f6-4f29-490d-862f-09333e6c0331   in service    none      none          off        
+-   oxp_6ea8a67f-d27d-472b-844c-6c8245b00e2b/crypt/zone                                                            7ba4cc5a-05d5-48f8-bf1f-c19431c02e21   in service    none      none          off        
+-   oxp_77565d57-c235-4905-b3c7-32d1c2ca2c44/crypt/zone                                                            d2b96129-68b8-428c-9041-f92a28b231d2   in service    none      none          off        
+-   oxp_8746874c-dc3b-4454-93cd-2a8fc13720fe/crypt/zone                                                            edce7c97-7d0e-4da9-9d34-86b577bb5477   in service    none      none          off        
+-   oxp_a42c5a67-6e10-4586-a56e-48bb8260e75f/crypt/zone                                                            02c0a9a5-0b9b-4421-9643-4e8b9c5ff39e   in service    none      none          off        
+-   oxp_ca89b120-7bcd-4eeb-baa7-71031fbd103b/crypt/zone                                                            ddb27eda-8f02-438d-8956-87aa3d11ae9a   in service    none      none          off        
+-   oxp_ef61aa97-c862-428c-82f3-0a69a50d6155/crypt/zone                                                            54f218fb-6023-4693-ad38-8e8fb2056a36   in service    none      none          off        
+-   oxp_ef64ff6d-250d-47ac-8686-e696cfb46966/crypt/zone                                                            c1b62139-e0fe-4458-a7fd-593d6fc0b7a0   in service    none      none          off        
+-   oxp_ef64ff6d-250d-47ac-8686-e696cfb46966/crypt/zone/oxz_crucible_085d10cb-a6f0-46de-86bc-ad2f7f1defcf          e365431d-2c6b-4ab8-ac38-66bda9a09c58   in service    none      none          off        
+-   oxp_ca89b120-7bcd-4eeb-baa7-71031fbd103b/crypt/zone/oxz_crucible_2bf62dfa-537a-4616-aad5-64447faaec53          30584efb-cb2a-4446-8e92-979e1e3ad21c   in service    none      none          off        
+-   oxp_6ea8a67f-d27d-472b-844c-6c8245b00e2b/crypt/zone/oxz_crucible_50d43a78-e9af-4051-9f5d-85410f44214b          f165f189-8f8d-4e75-b947-8cde0b3b9d1a   in service    none      none          off        
+-   oxp_a42c5a67-6e10-4586-a56e-48bb8260e75f/crypt/zone/oxz_crucible_6e7b5239-0d2e-42a5-80aa-51a3bc859318          9d9170ef-3f05-4893-a322-31d80038fcbc   in service    none      none          off        
+-   oxp_494782c7-3821-4f49-918b-ce42cc4d18ad/crypt/zone/oxz_crucible_8d87b485-3fb4-480b-97ce-02d066b799d7          51767a5b-953f-4333-b123-630d38803e98   in service    none      none          off        
+-   oxp_24155070-8a43-4244-a3ba-853d8c71972d/crypt/zone/oxz_crucible_b3d757b8-033f-4a68-82db-6ff5331b9739          ac210527-730a-41a7-bb39-b5ab118b0176   in service    none      none          off        
+-   oxp_77565d57-c235-4905-b3c7-32d1c2ca2c44/crypt/zone/oxz_crucible_bcd98cf5-a798-4aa0-81cc-8972a376073c          36312983-f969-4f3e-9008-23439cfdf85b   in service    none      none          off        
+-   oxp_8746874c-dc3b-4454-93cd-2a8fc13720fe/crypt/zone/oxz_crucible_bd12d9d5-bccf-433a-b078-794a69aeb89a          112c4751-37b3-4dd1-9669-9d78eb778221   in service    none      none          off        
+-   oxp_ef61aa97-c862-428c-82f3-0a69a50d6155/crypt/zone/oxz_crucible_d283707c-1b8f-4cb9-946d-041b25a83967          4a35ecb6-9930-499b-a784-7f423a7d1975   in service    none      none          off        
+-   oxp_22930645-144a-415c-bceb-2dbfafb9c29e/crypt/zone/oxz_crucible_e362415d-2d54-4574-b823-3f01b9b751de          7991a9e3-04df-42f3-9ce5-ad6d9f54a308   in service    none      none          off        
+-   oxp_22930645-144a-415c-bceb-2dbfafb9c29e/crypt/zone/oxz_crucible_pantry_208c987a-ab33-47a3-a103-6108dd6dc4cb   d8a25751-04a7-4f92-920d-e4294cd0d9f5   in service    none      none          off        
+-   oxp_22930645-144a-415c-bceb-2dbfafb9c29e/crypt/zone/oxz_internal_dns_c428175e-6a1c-40bf-aa36-f608a57431f5      c9e9ec7e-68d6-4d78-88ae-144336a5f68d   in service    none      none          off        
+-   oxp_22930645-144a-415c-bceb-2dbfafb9c29e/crypt/zone/oxz_nexus_533416e6-d0bd-482d-b592-29346c8a3471             e3638c01-8669-41a4-a4a6-9b981bf478ed   in service    none      none          off        
+-   oxp_22930645-144a-415c-bceb-2dbfafb9c29e/crypt/zone/oxz_ntp_a8f1b53a-4231-4f04-9939-29e50a0f0e2c               a943567c-1e12-48b9-80f3-a1c48242191c   in service    none      none          off        
+-   oxp_22930645-144a-415c-bceb-2dbfafb9c29e/crypt/debug                                                           3dfdb70d-6884-4143-939b-3a973ae7314e   in service    100 GiB   none          gzip-9     
+-   oxp_24155070-8a43-4244-a3ba-853d8c71972d/crypt/debug                                                           e6fe9880-110a-4e55-8390-5a7d9205aea0   in service    100 GiB   none          gzip-9     
+-   oxp_494782c7-3821-4f49-918b-ce42cc4d18ad/crypt/debug                                                           730e9778-32bb-4eb9-9488-5412e8c00e9a   in service    100 GiB   none          gzip-9     
+-   oxp_6ea8a67f-d27d-472b-844c-6c8245b00e2b/crypt/debug                                                           38509c13-7948-4bf3-b34b-8f51862b135a   in service    100 GiB   none          gzip-9     
+-   oxp_77565d57-c235-4905-b3c7-32d1c2ca2c44/crypt/debug                                                           aff03579-cf55-4e57-b22c-84e54788bcfe   in service    100 GiB   none          gzip-9     
+-   oxp_8746874c-dc3b-4454-93cd-2a8fc13720fe/crypt/debug                                                           f8b506cf-c947-4579-a852-dc017f59e092   in service    100 GiB   none          gzip-9     
+-   oxp_a42c5a67-6e10-4586-a56e-48bb8260e75f/crypt/debug                                                           06ee31c6-5e75-444b-af7d-49695a1fbff4   in service    100 GiB   none          gzip-9     
+-   oxp_ca89b120-7bcd-4eeb-baa7-71031fbd103b/crypt/debug                                                           20745882-62c8-48db-a8fd-c0b0dc967897   in service    100 GiB   none          gzip-9     
+-   oxp_ef61aa97-c862-428c-82f3-0a69a50d6155/crypt/debug                                                           a6ca9c24-86cc-4e94-b921-38c0f1c922d4   in service    100 GiB   none          gzip-9     
+-   oxp_ef64ff6d-250d-47ac-8686-e696cfb46966/crypt/debug                                                           5d4ce100-3838-401c-8f2e-46b5b5374115   in service    100 GiB   none          gzip-9     
 
 
     omicron zones generation 2 -> 3:
@@ -219,54 +219,54 @@ to:   blueprint 9f71f5d3-a272-4382-9154-6ea2e171a6c6
 
 
     datasets from generation 2:
-    -----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
-    dataset name                                                                                                   dataset uuid                           quota     reservation   compression
-    -----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
--   oxp_09a5de95-c15f-486e-b776-fca62bf5e179/crucible                                                              b77e647a-9173-499a-854a-6c0b4968b7e0   none      none          off        
--   oxp_11b8eccf-7c78-4bde-8639-b35a83082a95/crucible                                                              58fdafab-31e5-4fa2-89c6-322e3a2b482e   none      none          off        
--   oxp_1931c422-4c6a-4597-8ae7-ecb44718462c/crucible                                                              d0437bf1-8860-49d3-8fb3-da4c67a5a08b   none      none          off        
--   oxp_21a8a87e-73a4-42d4-a426-f6eec94004e3/crucible                                                              55406728-458a-4768-8c60-4bda237e5eee   none      none          off        
--   oxp_222c0b55-2966-46b6-816c-9063a7587806/crucible                                                              541775da-bd2a-47da-b3a7-0554f1b318d7   none      none          off        
--   oxp_3676f688-f41c-4f89-936a-6b04c3011b2a/crucible                                                              cf342d78-595a-4871-badc-4b4abf86df59   none      none          off        
--   oxp_5e9e14c4-d60d-4b5c-a11c-bba54eb24c9f/crucible                                                              f90acbe5-1565-4f3d-bab7-c82dbc5d88e0   none      none          off        
--   oxp_74f7b89e-88f5-4336-ba8b-22283a6966c5/crucible                                                              572b2277-6c1c-45b7-afaa-85c6838c4fb1   none      none          off        
--   oxp_a787cac8-b5e3-49e3-aaab-20d8eadd8a63/crucible                                                              46699296-d0e9-4fdd-bd1a-f6f7e23bf14e   none      none          off        
--   oxp_d56b0c9f-0e57-43d8-a1ac-8b4d2c303c29/crucible                                                              17e494d7-7797-4f2f-9f0e-f01340c5d20c   none      none          off        
--   oxp_09a5de95-c15f-486e-b776-fca62bf5e179/crypt/internal_dns                                                    6b3c8095-3f2e-4844-adad-58c2a9672b0f   none      none          off        
--   oxp_09a5de95-c15f-486e-b776-fca62bf5e179/crypt/zone                                                            0a15e4d5-df40-4084-b60d-cdf7ee46ab4e   none      none          off        
--   oxp_11b8eccf-7c78-4bde-8639-b35a83082a95/crypt/zone                                                            5d9f6772-bda9-4ad1-af28-06fe072d49ce   none      none          off        
--   oxp_1931c422-4c6a-4597-8ae7-ecb44718462c/crypt/zone                                                            22a21aab-ef00-4741-b1af-83628f9176ed   none      none          off        
--   oxp_21a8a87e-73a4-42d4-a426-f6eec94004e3/crypt/zone                                                            7d4d36bb-db99-44a8-9542-c18644925ecd   none      none          off        
--   oxp_222c0b55-2966-46b6-816c-9063a7587806/crypt/zone                                                            d9255b0c-5115-4b4c-9a15-20b7abc6a625   none      none          off        
--   oxp_3676f688-f41c-4f89-936a-6b04c3011b2a/crypt/zone                                                            5bd021b1-e4dd-4dfb-af5d-30a5d5fc6de6   none      none          off        
--   oxp_5e9e14c4-d60d-4b5c-a11c-bba54eb24c9f/crypt/zone                                                            1c0a27d1-5feb-4c88-8ef5-ad438e2e337b   none      none          off        
--   oxp_74f7b89e-88f5-4336-ba8b-22283a6966c5/crypt/zone                                                            378cde4a-b2e0-4c04-8a77-c8a333b21e79   none      none          off        
--   oxp_a787cac8-b5e3-49e3-aaab-20d8eadd8a63/crypt/zone                                                            6982b864-f299-4a0c-bc1c-b05cfd923ad4   none      none          off        
--   oxp_d56b0c9f-0e57-43d8-a1ac-8b4d2c303c29/crypt/zone                                                            21aba03d-0506-4ded-992c-2198a9df8db8   none      none          off        
--   oxp_11b8eccf-7c78-4bde-8639-b35a83082a95/crypt/zone/oxz_crucible_258c5106-ebcd-4651-96e4-d5b0895691f6          d3b4685c-6b3c-4547-8f31-914760b52b6f   none      none          off        
--   oxp_5e9e14c4-d60d-4b5c-a11c-bba54eb24c9f/crypt/zone/oxz_crucible_2b046f65-00f5-46da-988c-90c1de32a1dd          68670f81-967f-410a-89f5-5aeed7725f18   none      none          off        
--   oxp_d56b0c9f-0e57-43d8-a1ac-8b4d2c303c29/crypt/zone/oxz_crucible_30c770a8-625e-4864-8977-d83a11c1c596          bf61091c-be19-4e3c-9665-61fe5d3f984f   none      none          off        
--   oxp_21a8a87e-73a4-42d4-a426-f6eec94004e3/crypt/zone/oxz_crucible_35e3587d-25d3-4234-822f-2d68713b8cbf          ac9ca46f-4a0a-4cd0-ad58-e89609ebb241   none      none          off        
--   oxp_222c0b55-2966-46b6-816c-9063a7587806/crypt/zone/oxz_crucible_46293b15-fd26-48f9-9ccb-122fa0ef41b4          d406c3ce-a277-42c2-beac-9fe311e7a2f9   none      none          off        
--   oxp_09a5de95-c15f-486e-b776-fca62bf5e179/crypt/zone/oxz_crucible_462c6b8d-1872-4671-b84a-bdcbb69e3baf          83c9535d-cf93-440a-bfda-e7d17d5ad31e   none      none          off        
--   oxp_1931c422-4c6a-4597-8ae7-ecb44718462c/crypt/zone/oxz_crucible_a046c5f9-25e7-47c3-9c67-43d68fb39c5e          e485343e-cf15-4484-82eb-7913b388cdf0   none      none          off        
--   oxp_a787cac8-b5e3-49e3-aaab-20d8eadd8a63/crypt/zone/oxz_crucible_a49d4037-506e-4732-8e21-1f8c136a3c17          45e58d60-6bb9-4bc0-a925-a13952eef7bb   none      none          off        
--   oxp_74f7b89e-88f5-4336-ba8b-22283a6966c5/crypt/zone/oxz_crucible_df94dc9a-74d9-43a9-8879-199740665f29          1db67d8d-5443-4304-a4fc-22ee0ecf9a14   none      none          off        
--   oxp_3676f688-f41c-4f89-936a-6b04c3011b2a/crypt/zone/oxz_crucible_f1622981-7f0b-4a9f-9a70-6b46ab9d5e86          8d49a774-0f12-41ad-acd5-2853553044e4   none      none          off        
--   oxp_09a5de95-c15f-486e-b776-fca62bf5e179/crypt/zone/oxz_crucible_pantry_b217d3a5-4ebb-45e3-b5be-2ebb2c57d8fa   03429538-a04b-453e-85e0-4495f18d80c9   none      none          off        
--   oxp_09a5de95-c15f-486e-b776-fca62bf5e179/crypt/zone/oxz_internal_dns_0efed95e-f052-4535-b45a-fac1148c0e6a      0be7365d-2d85-4d99-a186-e404eb93ef59   none      none          off        
--   oxp_09a5de95-c15f-486e-b776-fca62bf5e179/crypt/zone/oxz_nexus_ee146b15-bc59-43a3-9567-bb8596e6188d             14cd103e-65f0-42f6-a03d-c03b1e865b4c   none      none          off        
--   oxp_09a5de95-c15f-486e-b776-fca62bf5e179/crypt/zone/oxz_ntp_61a79cb4-7fcb-432d-bbe9-3f9882452db2               0af1fd16-7dde-4bf5-8da6-dceb05bf4aef   none      none          off        
--   oxp_09a5de95-c15f-486e-b776-fca62bf5e179/crypt/debug                                                           455486dc-8ab4-4405-99fc-862d6dbfcda3   100 GiB   none          gzip-9     
--   oxp_11b8eccf-7c78-4bde-8639-b35a83082a95/crypt/debug                                                           de5f06bb-1d18-4dec-b8ca-e0947efd7605   100 GiB   none          gzip-9     
--   oxp_1931c422-4c6a-4597-8ae7-ecb44718462c/crypt/debug                                                           000775a7-f52a-4b4c-845e-f9ec8b27e32c   100 GiB   none          gzip-9     
--   oxp_21a8a87e-73a4-42d4-a426-f6eec94004e3/crypt/debug                                                           cd6d3991-5be5-49e3-8d2d-b0a29acc479c   100 GiB   none          gzip-9     
--   oxp_222c0b55-2966-46b6-816c-9063a7587806/crypt/debug                                                           5cfe962a-ff3d-4ab7-8c1b-8979dba15bb0   100 GiB   none          gzip-9     
--   oxp_3676f688-f41c-4f89-936a-6b04c3011b2a/crypt/debug                                                           0d918a12-c470-472e-9711-7e79ddd9b90b   100 GiB   none          gzip-9     
--   oxp_5e9e14c4-d60d-4b5c-a11c-bba54eb24c9f/crypt/debug                                                           56d77912-628f-4a06-8e60-ae83e0bd7292   100 GiB   none          gzip-9     
--   oxp_74f7b89e-88f5-4336-ba8b-22283a6966c5/crypt/debug                                                           54b2745f-9c22-4407-858e-31ea0c9db415   100 GiB   none          gzip-9     
--   oxp_a787cac8-b5e3-49e3-aaab-20d8eadd8a63/crypt/debug                                                           69c359cd-15e4-485f-8f32-e84c1a19eec8   100 GiB   none          gzip-9     
--   oxp_d56b0c9f-0e57-43d8-a1ac-8b4d2c303c29/crypt/debug                                                           34d0a7d0-56f8-4a8e-9e71-657c9ebc71f3   100 GiB   none          gzip-9     
+    -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
+    dataset name                                                                                                   dataset id                             disposition   quota     reservation   compression
+    -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
+-   oxp_09a5de95-c15f-486e-b776-fca62bf5e179/crucible                                                              b77e647a-9173-499a-854a-6c0b4968b7e0   in service    none      none          off        
+-   oxp_11b8eccf-7c78-4bde-8639-b35a83082a95/crucible                                                              58fdafab-31e5-4fa2-89c6-322e3a2b482e   in service    none      none          off        
+-   oxp_1931c422-4c6a-4597-8ae7-ecb44718462c/crucible                                                              d0437bf1-8860-49d3-8fb3-da4c67a5a08b   in service    none      none          off        
+-   oxp_21a8a87e-73a4-42d4-a426-f6eec94004e3/crucible                                                              55406728-458a-4768-8c60-4bda237e5eee   in service    none      none          off        
+-   oxp_222c0b55-2966-46b6-816c-9063a7587806/crucible                                                              541775da-bd2a-47da-b3a7-0554f1b318d7   in service    none      none          off        
+-   oxp_3676f688-f41c-4f89-936a-6b04c3011b2a/crucible                                                              cf342d78-595a-4871-badc-4b4abf86df59   in service    none      none          off        
+-   oxp_5e9e14c4-d60d-4b5c-a11c-bba54eb24c9f/crucible                                                              f90acbe5-1565-4f3d-bab7-c82dbc5d88e0   in service    none      none          off        
+-   oxp_74f7b89e-88f5-4336-ba8b-22283a6966c5/crucible                                                              572b2277-6c1c-45b7-afaa-85c6838c4fb1   in service    none      none          off        
+-   oxp_a787cac8-b5e3-49e3-aaab-20d8eadd8a63/crucible                                                              46699296-d0e9-4fdd-bd1a-f6f7e23bf14e   in service    none      none          off        
+-   oxp_d56b0c9f-0e57-43d8-a1ac-8b4d2c303c29/crucible                                                              17e494d7-7797-4f2f-9f0e-f01340c5d20c   in service    none      none          off        
+-   oxp_09a5de95-c15f-486e-b776-fca62bf5e179/crypt/internal_dns                                                    6b3c8095-3f2e-4844-adad-58c2a9672b0f   in service    none      none          off        
+-   oxp_09a5de95-c15f-486e-b776-fca62bf5e179/crypt/zone                                                            0a15e4d5-df40-4084-b60d-cdf7ee46ab4e   in service    none      none          off        
+-   oxp_11b8eccf-7c78-4bde-8639-b35a83082a95/crypt/zone                                                            5d9f6772-bda9-4ad1-af28-06fe072d49ce   in service    none      none          off        
+-   oxp_1931c422-4c6a-4597-8ae7-ecb44718462c/crypt/zone                                                            22a21aab-ef00-4741-b1af-83628f9176ed   in service    none      none          off        
+-   oxp_21a8a87e-73a4-42d4-a426-f6eec94004e3/crypt/zone                                                            7d4d36bb-db99-44a8-9542-c18644925ecd   in service    none      none          off        
+-   oxp_222c0b55-2966-46b6-816c-9063a7587806/crypt/zone                                                            d9255b0c-5115-4b4c-9a15-20b7abc6a625   in service    none      none          off        
+-   oxp_3676f688-f41c-4f89-936a-6b04c3011b2a/crypt/zone                                                            5bd021b1-e4dd-4dfb-af5d-30a5d5fc6de6   in service    none      none          off        
+-   oxp_5e9e14c4-d60d-4b5c-a11c-bba54eb24c9f/crypt/zone                                                            1c0a27d1-5feb-4c88-8ef5-ad438e2e337b   in service    none      none          off        
+-   oxp_74f7b89e-88f5-4336-ba8b-22283a6966c5/crypt/zone                                                            378cde4a-b2e0-4c04-8a77-c8a333b21e79   in service    none      none          off        
+-   oxp_a787cac8-b5e3-49e3-aaab-20d8eadd8a63/crypt/zone                                                            6982b864-f299-4a0c-bc1c-b05cfd923ad4   in service    none      none          off        
+-   oxp_d56b0c9f-0e57-43d8-a1ac-8b4d2c303c29/crypt/zone                                                            21aba03d-0506-4ded-992c-2198a9df8db8   in service    none      none          off        
+-   oxp_11b8eccf-7c78-4bde-8639-b35a83082a95/crypt/zone/oxz_crucible_258c5106-ebcd-4651-96e4-d5b0895691f6          d3b4685c-6b3c-4547-8f31-914760b52b6f   in service    none      none          off        
+-   oxp_5e9e14c4-d60d-4b5c-a11c-bba54eb24c9f/crypt/zone/oxz_crucible_2b046f65-00f5-46da-988c-90c1de32a1dd          68670f81-967f-410a-89f5-5aeed7725f18   in service    none      none          off        
+-   oxp_d56b0c9f-0e57-43d8-a1ac-8b4d2c303c29/crypt/zone/oxz_crucible_30c770a8-625e-4864-8977-d83a11c1c596          bf61091c-be19-4e3c-9665-61fe5d3f984f   in service    none      none          off        
+-   oxp_21a8a87e-73a4-42d4-a426-f6eec94004e3/crypt/zone/oxz_crucible_35e3587d-25d3-4234-822f-2d68713b8cbf          ac9ca46f-4a0a-4cd0-ad58-e89609ebb241   in service    none      none          off        
+-   oxp_222c0b55-2966-46b6-816c-9063a7587806/crypt/zone/oxz_crucible_46293b15-fd26-48f9-9ccb-122fa0ef41b4          d406c3ce-a277-42c2-beac-9fe311e7a2f9   in service    none      none          off        
+-   oxp_09a5de95-c15f-486e-b776-fca62bf5e179/crypt/zone/oxz_crucible_462c6b8d-1872-4671-b84a-bdcbb69e3baf          83c9535d-cf93-440a-bfda-e7d17d5ad31e   in service    none      none          off        
+-   oxp_1931c422-4c6a-4597-8ae7-ecb44718462c/crypt/zone/oxz_crucible_a046c5f9-25e7-47c3-9c67-43d68fb39c5e          e485343e-cf15-4484-82eb-7913b388cdf0   in service    none      none          off        
+-   oxp_a787cac8-b5e3-49e3-aaab-20d8eadd8a63/crypt/zone/oxz_crucible_a49d4037-506e-4732-8e21-1f8c136a3c17          45e58d60-6bb9-4bc0-a925-a13952eef7bb   in service    none      none          off        
+-   oxp_74f7b89e-88f5-4336-ba8b-22283a6966c5/crypt/zone/oxz_crucible_df94dc9a-74d9-43a9-8879-199740665f29          1db67d8d-5443-4304-a4fc-22ee0ecf9a14   in service    none      none          off        
+-   oxp_3676f688-f41c-4f89-936a-6b04c3011b2a/crypt/zone/oxz_crucible_f1622981-7f0b-4a9f-9a70-6b46ab9d5e86          8d49a774-0f12-41ad-acd5-2853553044e4   in service    none      none          off        
+-   oxp_09a5de95-c15f-486e-b776-fca62bf5e179/crypt/zone/oxz_crucible_pantry_b217d3a5-4ebb-45e3-b5be-2ebb2c57d8fa   03429538-a04b-453e-85e0-4495f18d80c9   in service    none      none          off        
+-   oxp_09a5de95-c15f-486e-b776-fca62bf5e179/crypt/zone/oxz_internal_dns_0efed95e-f052-4535-b45a-fac1148c0e6a      0be7365d-2d85-4d99-a186-e404eb93ef59   in service    none      none          off        
+-   oxp_09a5de95-c15f-486e-b776-fca62bf5e179/crypt/zone/oxz_nexus_ee146b15-bc59-43a3-9567-bb8596e6188d             14cd103e-65f0-42f6-a03d-c03b1e865b4c   in service    none      none          off        
+-   oxp_09a5de95-c15f-486e-b776-fca62bf5e179/crypt/zone/oxz_ntp_61a79cb4-7fcb-432d-bbe9-3f9882452db2               0af1fd16-7dde-4bf5-8da6-dceb05bf4aef   in service    none      none          off        
+-   oxp_09a5de95-c15f-486e-b776-fca62bf5e179/crypt/debug                                                           455486dc-8ab4-4405-99fc-862d6dbfcda3   in service    100 GiB   none          gzip-9     
+-   oxp_11b8eccf-7c78-4bde-8639-b35a83082a95/crypt/debug                                                           de5f06bb-1d18-4dec-b8ca-e0947efd7605   in service    100 GiB   none          gzip-9     
+-   oxp_1931c422-4c6a-4597-8ae7-ecb44718462c/crypt/debug                                                           000775a7-f52a-4b4c-845e-f9ec8b27e32c   in service    100 GiB   none          gzip-9     
+-   oxp_21a8a87e-73a4-42d4-a426-f6eec94004e3/crypt/debug                                                           cd6d3991-5be5-49e3-8d2d-b0a29acc479c   in service    100 GiB   none          gzip-9     
+-   oxp_222c0b55-2966-46b6-816c-9063a7587806/crypt/debug                                                           5cfe962a-ff3d-4ab7-8c1b-8979dba15bb0   in service    100 GiB   none          gzip-9     
+-   oxp_3676f688-f41c-4f89-936a-6b04c3011b2a/crypt/debug                                                           0d918a12-c470-472e-9711-7e79ddd9b90b   in service    100 GiB   none          gzip-9     
+-   oxp_5e9e14c4-d60d-4b5c-a11c-bba54eb24c9f/crypt/debug                                                           56d77912-628f-4a06-8e60-ae83e0bd7292   in service    100 GiB   none          gzip-9     
+-   oxp_74f7b89e-88f5-4336-ba8b-22283a6966c5/crypt/debug                                                           54b2745f-9c22-4407-858e-31ea0c9db415   in service    100 GiB   none          gzip-9     
+-   oxp_a787cac8-b5e3-49e3-aaab-20d8eadd8a63/crypt/debug                                                           69c359cd-15e4-485f-8f32-e84c1a19eec8   in service    100 GiB   none          gzip-9     
+-   oxp_d56b0c9f-0e57-43d8-a1ac-8b4d2c303c29/crypt/debug                                                           34d0a7d0-56f8-4a8e-9e71-657c9ebc71f3   in service    100 GiB   none          gzip-9     
 
 
     omicron zones at generation 2:
@@ -308,54 +308,54 @@ to:   blueprint 9f71f5d3-a272-4382-9154-6ea2e171a6c6
 
 
     datasets generation 2 -> 3:
-    ----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
-    dataset name                                                                                            dataset uuid                           quota     reservation   compression
-    ----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
-    oxp_4069c804-c51a-4adc-8822-3cbbab56ed3f/crucible                                                       081aff15-bc64-4b57-bbcc-287d7267caa4   none      none          off        
-    oxp_5248a306-4a03-449e-a8a3-6f86d26da755/crucible                                                       0beeebcf-b558-47e9-9274-bc3dd4a475b8   none      none          off        
-    oxp_55196665-ed61-4b23-9a74-0711bf2eaf90/crucible                                                       757dd9e5-74db-4860-a87e-0aafd6795b91   none      none          off        
-    oxp_6b2a719a-35eb-469f-aa54-114a1f21f37d/crucible                                                       bd64099e-57f0-447f-9c21-e493e2809372   none      none          off        
-    oxp_7ed4296a-66d1-4fb2-bc56-9b23b8f27d7e/crucible                                                       3bd0565c-1170-4727-824b-f180454e4ff1   none      none          off        
-    oxp_984e2389-e7fd-4af9-ab02-e3caf77f95b5/crucible                                                       010c6c12-6ea3-4bbd-9a69-90209dab73ab   none      none          off        
-    oxp_a5f75431-3795-426c-8f80-176f658281a5/crucible                                                       2dbc8272-64ae-4d2d-ac1f-92f120204ddd   none      none          off        
-    oxp_cf32a1ce-2c9e-49f5-b1cf-4af7f2a28901/crucible                                                       b4e4e724-ddfb-4d0a-bf6b-edd6dd91172d   none      none          off        
-    oxp_e405da11-cb6b-4ebc-bac1-9bc997352e10/crucible                                                       8fdfaea0-1da2-429f-b64e-ef0107f2884d   none      none          off        
-    oxp_f4d7f914-ec73-4b65-8696-5068591d9065/crucible                                                       74dc30b1-2c84-4e9d-910c-938d33f9a537   none      none          off        
-    oxp_4069c804-c51a-4adc-8822-3cbbab56ed3f/crypt/zone                                                     f282431f-2ed2-4386-bc0f-0f3130b175bf   none      none          off        
-    oxp_5248a306-4a03-449e-a8a3-6f86d26da755/crypt/zone                                                     ee3f0e38-23ac-45c6-8157-e611887572a6   none      none          off        
-    oxp_55196665-ed61-4b23-9a74-0711bf2eaf90/crypt/zone                                                     acf672d0-effd-491a-bde8-a4253e078f14   none      none          off        
-    oxp_6b2a719a-35eb-469f-aa54-114a1f21f37d/crypt/zone                                                     d5be658f-367a-4703-a377-7d8067aade3a   none      none          off        
-    oxp_7ed4296a-66d1-4fb2-bc56-9b23b8f27d7e/crypt/zone                                                     adbebdd0-4d0d-4794-9bb5-6681b5119624   none      none          off        
-    oxp_984e2389-e7fd-4af9-ab02-e3caf77f95b5/crypt/zone                                                     1e063fbb-083c-4e2e-a4f5-c40ce854f1d0   none      none          off        
-    oxp_a5f75431-3795-426c-8f80-176f658281a5/crypt/zone                                                     6b476700-d002-4173-8a83-fb24d49be32f   none      none          off        
-    oxp_cf32a1ce-2c9e-49f5-b1cf-4af7f2a28901/crypt/zone                                                     abaa13f5-c3ec-45b2-86da-2be74a259878   none      none          off        
-    oxp_e405da11-cb6b-4ebc-bac1-9bc997352e10/crypt/zone                                                     d8c2da98-ef6d-4746-ae4b-ed537c78fc89   none      none          off        
-    oxp_f4d7f914-ec73-4b65-8696-5068591d9065/crypt/zone                                                     b1c8156e-7490-46d2-a4af-7fc5dd39991d   none      none          off        
-    oxp_6b2a719a-35eb-469f-aa54-114a1f21f37d/crypt/zone/oxz_crucible_05ba6d6e-90a7-402a-aaba-fd92190a9f48   6a6e744c-c4a9-4e58-b0ed-ef44eef0c6e0   none      none          off        
-    oxp_f4d7f914-ec73-4b65-8696-5068591d9065/crypt/zone/oxz_crucible_2097bad3-ee65-4a1c-8fe2-75ed52e69ac8   54941545-0cee-4c36-8516-c63b3cbd02fb   none      none          off        
-    oxp_4069c804-c51a-4adc-8822-3cbbab56ed3f/crypt/zone/oxz_crucible_430c8fe1-7296-4a73-b260-fc185260ec5e   d0ee4ede-c9a6-4d6a-9dbe-63b4c07a9cdd   none      none          off        
-    oxp_cf32a1ce-2c9e-49f5-b1cf-4af7f2a28901/crypt/zone/oxz_crucible_a720288d-3e5b-44b7-9dab-a69a10768e0b   3fa16efe-c488-4d45-92ee-18eeb8b9453f   none      none          off        
-    oxp_a5f75431-3795-426c-8f80-176f658281a5/crypt/zone/oxz_crucible_b2170eef-aa6f-4ec5-aaa9-2b4289eae65c   e20a6e28-7a52-480a-9d36-33f8d4474bf5   none      none          off        
-    oxp_984e2389-e7fd-4af9-ab02-e3caf77f95b5/crypt/zone/oxz_crucible_b505d6e1-07b9-48bf-bc8a-d4081c25b12a   6b965329-4398-4738-84e6-b893f21a724c   none      none          off        
-    oxp_5248a306-4a03-449e-a8a3-6f86d26da755/crypt/zone/oxz_crucible_cbe34d65-017e-4c26-966d-b1ce27bc1d94   8ad4a9ed-7be5-4f49-8a38-1686144ceaf6   none      none          off        
-    oxp_e405da11-cb6b-4ebc-bac1-9bc997352e10/crypt/zone/oxz_crucible_e01462d1-5173-4d95-8477-78ca2157efbb   03fbd010-e16e-48a9-a9a9-5be665c0bdff   none      none          off        
-    oxp_55196665-ed61-4b23-9a74-0711bf2eaf90/crypt/zone/oxz_crucible_e49b0403-3d7c-480f-9113-4bc0fca74a8a   62053fe9-281c-4949-9357-bf818004aef2   none      none          off        
-    oxp_7ed4296a-66d1-4fb2-bc56-9b23b8f27d7e/crypt/zone/oxz_crucible_e6ec9399-b81b-4bdd-8e6e-b0f043aad942   f761d5be-fef1-47d7-850c-1f28a1f8a8b3   none      none          off        
-    oxp_4069c804-c51a-4adc-8822-3cbbab56ed3f/crypt/zone/oxz_nexus_81f79040-bcf7-4eff-9a87-8e7bcb5a6db9      2694f256-cd46-4841-a009-6460f4ca0616   none      none          off        
-    oxp_4069c804-c51a-4adc-8822-3cbbab56ed3f/crypt/zone/oxz_ntp_8f94a160-67ab-4ed5-bc3f-01e19fdd7e9b        225c385b-de3e-4262-a5c4-0250abc910f9   none      none          off        
-    oxp_4069c804-c51a-4adc-8822-3cbbab56ed3f/crypt/debug                                                    041c4e17-e958-41aa-b621-03dd3b3e7da8   100 GiB   none          gzip-9     
-    oxp_5248a306-4a03-449e-a8a3-6f86d26da755/crypt/debug                                                    7e551f2b-ac22-4637-bd2a-188f106b57c0   100 GiB   none          gzip-9     
-    oxp_55196665-ed61-4b23-9a74-0711bf2eaf90/crypt/debug                                                    1e4208d8-041e-49eb-ab6d-dcedceee170c   100 GiB   none          gzip-9     
-    oxp_6b2a719a-35eb-469f-aa54-114a1f21f37d/crypt/debug                                                    0872720b-c454-45f6-8816-2835d595894e   100 GiB   none          gzip-9     
-    oxp_7ed4296a-66d1-4fb2-bc56-9b23b8f27d7e/crypt/debug                                                    fc7195f4-4472-4283-9094-2f6f7db01e71   100 GiB   none          gzip-9     
-    oxp_984e2389-e7fd-4af9-ab02-e3caf77f95b5/crypt/debug                                                    baa19cce-f379-427c-9b5e-c413b050c2d5   100 GiB   none          gzip-9     
-    oxp_a5f75431-3795-426c-8f80-176f658281a5/crypt/debug                                                    5828eb26-b03b-4481-b88d-027a90a24c50   100 GiB   none          gzip-9     
-    oxp_cf32a1ce-2c9e-49f5-b1cf-4af7f2a28901/crypt/debug                                                    5e7deb25-14c2-4633-8728-6eff7833e14f   100 GiB   none          gzip-9     
-    oxp_e405da11-cb6b-4ebc-bac1-9bc997352e10/crypt/debug                                                    e02c1929-a38a-49c2-8909-555c3e046d18   100 GiB   none          gzip-9     
-    oxp_f4d7f914-ec73-4b65-8696-5068591d9065/crypt/debug                                                    0aeb1237-4ad7-41ae-abd2-45789a3ab2f2   100 GiB   none          gzip-9     
-+   oxp_6b2a719a-35eb-469f-aa54-114a1f21f37d/crypt/zone/oxz_nexus_2ed23118-6137-45ca-824c-04df3bc3d085      047b92e1-2286-44bb-988e-403f20973ee4   none      none          off        
-+   oxp_5248a306-4a03-449e-a8a3-6f86d26da755/crypt/zone/oxz_nexus_33365de5-8a83-46c0-9d34-eddd68e54c6f      4f6d72db-de32-4a55-ae9d-30d776580c33   none      none          off        
-+   oxp_55196665-ed61-4b23-9a74-0711bf2eaf90/crypt/zone/oxz_nexus_80e4964b-a8c8-41ef-ae23-f86cfe5f3a7b      6944260c-23fd-47db-8a2c-02196b399f57   none      none          off        
+    ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
+    dataset name                                                                                            dataset id                             disposition   quota     reservation   compression
+    ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
+    oxp_4069c804-c51a-4adc-8822-3cbbab56ed3f/crucible                                                       081aff15-bc64-4b57-bbcc-287d7267caa4   in service    none      none          off        
+    oxp_5248a306-4a03-449e-a8a3-6f86d26da755/crucible                                                       0beeebcf-b558-47e9-9274-bc3dd4a475b8   in service    none      none          off        
+    oxp_55196665-ed61-4b23-9a74-0711bf2eaf90/crucible                                                       757dd9e5-74db-4860-a87e-0aafd6795b91   in service    none      none          off        
+    oxp_6b2a719a-35eb-469f-aa54-114a1f21f37d/crucible                                                       bd64099e-57f0-447f-9c21-e493e2809372   in service    none      none          off        
+    oxp_7ed4296a-66d1-4fb2-bc56-9b23b8f27d7e/crucible                                                       3bd0565c-1170-4727-824b-f180454e4ff1   in service    none      none          off        
+    oxp_984e2389-e7fd-4af9-ab02-e3caf77f95b5/crucible                                                       010c6c12-6ea3-4bbd-9a69-90209dab73ab   in service    none      none          off        
+    oxp_a5f75431-3795-426c-8f80-176f658281a5/crucible                                                       2dbc8272-64ae-4d2d-ac1f-92f120204ddd   in service    none      none          off        
+    oxp_cf32a1ce-2c9e-49f5-b1cf-4af7f2a28901/crucible                                                       b4e4e724-ddfb-4d0a-bf6b-edd6dd91172d   in service    none      none          off        
+    oxp_e405da11-cb6b-4ebc-bac1-9bc997352e10/crucible                                                       8fdfaea0-1da2-429f-b64e-ef0107f2884d   in service    none      none          off        
+    oxp_f4d7f914-ec73-4b65-8696-5068591d9065/crucible                                                       74dc30b1-2c84-4e9d-910c-938d33f9a537   in service    none      none          off        
+    oxp_4069c804-c51a-4adc-8822-3cbbab56ed3f/crypt/zone                                                     f282431f-2ed2-4386-bc0f-0f3130b175bf   in service    none      none          off        
+    oxp_5248a306-4a03-449e-a8a3-6f86d26da755/crypt/zone                                                     ee3f0e38-23ac-45c6-8157-e611887572a6   in service    none      none          off        
+    oxp_55196665-ed61-4b23-9a74-0711bf2eaf90/crypt/zone                                                     acf672d0-effd-491a-bde8-a4253e078f14   in service    none      none          off        
+    oxp_6b2a719a-35eb-469f-aa54-114a1f21f37d/crypt/zone                                                     d5be658f-367a-4703-a377-7d8067aade3a   in service    none      none          off        
+    oxp_7ed4296a-66d1-4fb2-bc56-9b23b8f27d7e/crypt/zone                                                     adbebdd0-4d0d-4794-9bb5-6681b5119624   in service    none      none          off        
+    oxp_984e2389-e7fd-4af9-ab02-e3caf77f95b5/crypt/zone                                                     1e063fbb-083c-4e2e-a4f5-c40ce854f1d0   in service    none      none          off        
+    oxp_a5f75431-3795-426c-8f80-176f658281a5/crypt/zone                                                     6b476700-d002-4173-8a83-fb24d49be32f   in service    none      none          off        
+    oxp_cf32a1ce-2c9e-49f5-b1cf-4af7f2a28901/crypt/zone                                                     abaa13f5-c3ec-45b2-86da-2be74a259878   in service    none      none          off        
+    oxp_e405da11-cb6b-4ebc-bac1-9bc997352e10/crypt/zone                                                     d8c2da98-ef6d-4746-ae4b-ed537c78fc89   in service    none      none          off        
+    oxp_f4d7f914-ec73-4b65-8696-5068591d9065/crypt/zone                                                     b1c8156e-7490-46d2-a4af-7fc5dd39991d   in service    none      none          off        
+    oxp_6b2a719a-35eb-469f-aa54-114a1f21f37d/crypt/zone/oxz_crucible_05ba6d6e-90a7-402a-aaba-fd92190a9f48   6a6e744c-c4a9-4e58-b0ed-ef44eef0c6e0   in service    none      none          off        
+    oxp_f4d7f914-ec73-4b65-8696-5068591d9065/crypt/zone/oxz_crucible_2097bad3-ee65-4a1c-8fe2-75ed52e69ac8   54941545-0cee-4c36-8516-c63b3cbd02fb   in service    none      none          off        
+    oxp_4069c804-c51a-4adc-8822-3cbbab56ed3f/crypt/zone/oxz_crucible_430c8fe1-7296-4a73-b260-fc185260ec5e   d0ee4ede-c9a6-4d6a-9dbe-63b4c07a9cdd   in service    none      none          off        
+    oxp_cf32a1ce-2c9e-49f5-b1cf-4af7f2a28901/crypt/zone/oxz_crucible_a720288d-3e5b-44b7-9dab-a69a10768e0b   3fa16efe-c488-4d45-92ee-18eeb8b9453f   in service    none      none          off        
+    oxp_a5f75431-3795-426c-8f80-176f658281a5/crypt/zone/oxz_crucible_b2170eef-aa6f-4ec5-aaa9-2b4289eae65c   e20a6e28-7a52-480a-9d36-33f8d4474bf5   in service    none      none          off        
+    oxp_984e2389-e7fd-4af9-ab02-e3caf77f95b5/crypt/zone/oxz_crucible_b505d6e1-07b9-48bf-bc8a-d4081c25b12a   6b965329-4398-4738-84e6-b893f21a724c   in service    none      none          off        
+    oxp_5248a306-4a03-449e-a8a3-6f86d26da755/crypt/zone/oxz_crucible_cbe34d65-017e-4c26-966d-b1ce27bc1d94   8ad4a9ed-7be5-4f49-8a38-1686144ceaf6   in service    none      none          off        
+    oxp_e405da11-cb6b-4ebc-bac1-9bc997352e10/crypt/zone/oxz_crucible_e01462d1-5173-4d95-8477-78ca2157efbb   03fbd010-e16e-48a9-a9a9-5be665c0bdff   in service    none      none          off        
+    oxp_55196665-ed61-4b23-9a74-0711bf2eaf90/crypt/zone/oxz_crucible_e49b0403-3d7c-480f-9113-4bc0fca74a8a   62053fe9-281c-4949-9357-bf818004aef2   in service    none      none          off        
+    oxp_7ed4296a-66d1-4fb2-bc56-9b23b8f27d7e/crypt/zone/oxz_crucible_e6ec9399-b81b-4bdd-8e6e-b0f043aad942   f761d5be-fef1-47d7-850c-1f28a1f8a8b3   in service    none      none          off        
+    oxp_4069c804-c51a-4adc-8822-3cbbab56ed3f/crypt/zone/oxz_nexus_81f79040-bcf7-4eff-9a87-8e7bcb5a6db9      2694f256-cd46-4841-a009-6460f4ca0616   in service    none      none          off        
+    oxp_4069c804-c51a-4adc-8822-3cbbab56ed3f/crypt/zone/oxz_ntp_8f94a160-67ab-4ed5-bc3f-01e19fdd7e9b        225c385b-de3e-4262-a5c4-0250abc910f9   in service    none      none          off        
+    oxp_4069c804-c51a-4adc-8822-3cbbab56ed3f/crypt/debug                                                    041c4e17-e958-41aa-b621-03dd3b3e7da8   in service    100 GiB   none          gzip-9     
+    oxp_5248a306-4a03-449e-a8a3-6f86d26da755/crypt/debug                                                    7e551f2b-ac22-4637-bd2a-188f106b57c0   in service    100 GiB   none          gzip-9     
+    oxp_55196665-ed61-4b23-9a74-0711bf2eaf90/crypt/debug                                                    1e4208d8-041e-49eb-ab6d-dcedceee170c   in service    100 GiB   none          gzip-9     
+    oxp_6b2a719a-35eb-469f-aa54-114a1f21f37d/crypt/debug                                                    0872720b-c454-45f6-8816-2835d595894e   in service    100 GiB   none          gzip-9     
+    oxp_7ed4296a-66d1-4fb2-bc56-9b23b8f27d7e/crypt/debug                                                    fc7195f4-4472-4283-9094-2f6f7db01e71   in service    100 GiB   none          gzip-9     
+    oxp_984e2389-e7fd-4af9-ab02-e3caf77f95b5/crypt/debug                                                    baa19cce-f379-427c-9b5e-c413b050c2d5   in service    100 GiB   none          gzip-9     
+    oxp_a5f75431-3795-426c-8f80-176f658281a5/crypt/debug                                                    5828eb26-b03b-4481-b88d-027a90a24c50   in service    100 GiB   none          gzip-9     
+    oxp_cf32a1ce-2c9e-49f5-b1cf-4af7f2a28901/crypt/debug                                                    5e7deb25-14c2-4633-8728-6eff7833e14f   in service    100 GiB   none          gzip-9     
+    oxp_e405da11-cb6b-4ebc-bac1-9bc997352e10/crypt/debug                                                    e02c1929-a38a-49c2-8909-555c3e046d18   in service    100 GiB   none          gzip-9     
+    oxp_f4d7f914-ec73-4b65-8696-5068591d9065/crypt/debug                                                    0aeb1237-4ad7-41ae-abd2-45789a3ab2f2   in service    100 GiB   none          gzip-9     
++   oxp_6b2a719a-35eb-469f-aa54-114a1f21f37d/crypt/zone/oxz_nexus_2ed23118-6137-45ca-824c-04df3bc3d085      047b92e1-2286-44bb-988e-403f20973ee4   in service    none      none          off        
++   oxp_5248a306-4a03-449e-a8a3-6f86d26da755/crypt/zone/oxz_nexus_33365de5-8a83-46c0-9d34-eddd68e54c6f      4f6d72db-de32-4a55-ae9d-30d776580c33   in service    none      none          off        
++   oxp_55196665-ed61-4b23-9a74-0711bf2eaf90/crypt/zone/oxz_nexus_80e4964b-a8c8-41ef-ae23-f86cfe5f3a7b      6944260c-23fd-47db-8a2c-02196b399f57   in service    none      none          off        
 
 
     omicron zones generation 2 -> 3:
@@ -398,54 +398,54 @@ to:   blueprint 9f71f5d3-a272-4382-9154-6ea2e171a6c6
 
 
     datasets generation 2 -> 3:
-    ----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
-    dataset name                                                                                            dataset uuid                           quota     reservation   compression
-    ----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
-    oxp_33d48d85-751e-4982-b738-eae4d9a05f01/crucible                                                       e7187a07-3759-4185-8893-36b01e1a7295   none      none          off        
-    oxp_39ca2e23-4c38-4743-afe0-26b0380b27db/crucible                                                       f9901e16-a9e4-4c49-a3b9-464405830043   none      none          off        
-    oxp_4fbd2fe0-2eac-41b8-8e8d-4fa46c3e8b6c/crucible                                                       024a9e5e-f8a8-4b8f-b75e-5b05509fa69a   none      none          off        
-    oxp_60131a33-1f12-4dbb-9435-bdd368db1f51/crucible                                                       22547c0a-a710-4d4c-8984-32445fbf993b   none      none          off        
-    oxp_77e45b5b-869f-4e78-8ce3-28bbe8cf37e9/crucible                                                       dec5883c-1abd-4425-8cc4-b2f57c85cdd4   none      none          off        
-    oxp_789d607d-d196-428e-a988-f7886a327859/crucible                                                       fda176fb-2cea-4646-8601-8d719bcdbda0   none      none          off        
-    oxp_b104b94c-2197-4e76-bfbd-6f966bd5af66/crucible                                                       4ded36d4-7e98-47fe-a0f4-c580e7d1eb21   none      none          off        
-    oxp_cd62306a-aedf-47e8-93d5-92a358d64c7b/crucible                                                       623c87b5-8848-4e42-aa5e-6e706e11cf63   none      none          off        
-    oxp_f1693454-aac1-4265-b8a0-4e9f3f41c7b3/crucible                                                       e98d07df-27a8-4868-a3f9-066ac235516c   none      none          off        
-    oxp_fe4fdfba-3b6d-47d3-8612-1fb2390b650a/crucible                                                       639c96d6-265a-45dc-b03f-c145d2ea8c43   none      none          off        
-    oxp_33d48d85-751e-4982-b738-eae4d9a05f01/crypt/zone                                                     64c4eb2e-82bf-450c-9379-594af3a4794b   none      none          off        
-    oxp_39ca2e23-4c38-4743-afe0-26b0380b27db/crypt/zone                                                     f6c13b9c-4e22-448d-b7b8-04652f06423c   none      none          off        
-    oxp_4fbd2fe0-2eac-41b8-8e8d-4fa46c3e8b6c/crypt/zone                                                     a15671b5-d3f3-43d9-b143-81bcd5170edf   none      none          off        
-    oxp_60131a33-1f12-4dbb-9435-bdd368db1f51/crypt/zone                                                     dd78cd99-4aa3-4946-b4c3-b9fad49c6da6   none      none          off        
-    oxp_77e45b5b-869f-4e78-8ce3-28bbe8cf37e9/crypt/zone                                                     1c30ecb3-32ba-49e7-a3dd-771a75d38c3a   none      none          off        
-    oxp_789d607d-d196-428e-a988-f7886a327859/crypt/zone                                                     7ac707a2-5bcf-49d1-88eb-1c09841082cf   none      none          off        
-    oxp_b104b94c-2197-4e76-bfbd-6f966bd5af66/crypt/zone                                                     b0d96454-0a1d-47ac-9a13-5c4866131c37   none      none          off        
-    oxp_cd62306a-aedf-47e8-93d5-92a358d64c7b/crypt/zone                                                     082509f2-115a-4a71-b8f8-86be21efc081   none      none          off        
-    oxp_f1693454-aac1-4265-b8a0-4e9f3f41c7b3/crypt/zone                                                     01b79cba-881c-4bda-a48d-baaef2fcb122   none      none          off        
-    oxp_fe4fdfba-3b6d-47d3-8612-1fb2390b650a/crypt/zone                                                     32d3d763-0665-4945-a3d0-e3d862f7a718   none      none          off        
-    oxp_b104b94c-2197-4e76-bfbd-6f966bd5af66/crypt/zone/oxz_crucible_1b38728b-8552-435b-b621-359ba20d465b   c02c8635-e2f5-4974-a8b9-f4fdfe231365   none      none          off        
-    oxp_39ca2e23-4c38-4743-afe0-26b0380b27db/crypt/zone/oxz_crucible_31c42e26-3cdf-41a8-8826-ce71a513ed04   4876b95c-457b-4e81-9a04-ca1319429627   none      none          off        
-    oxp_f1693454-aac1-4265-b8a0-4e9f3f41c7b3/crypt/zone/oxz_crucible_4f38e475-396a-4650-a49c-c3cc4acc3ab9   2aff7d20-2a2b-4ded-9e03-eb0d72d29e35   none      none          off        
-    oxp_cd62306a-aedf-47e8-93d5-92a358d64c7b/crypt/zone/oxz_crucible_5cd47e9f-1faf-4afd-970a-18b9076b3407   686fcd72-5da5-4f8c-a740-88866e30b8da   none      none          off        
-    oxp_fe4fdfba-3b6d-47d3-8612-1fb2390b650a/crypt/zone/oxz_crucible_768ab86c-d5d2-4734-a381-02df1032d5e9   d1bbe8aa-aeda-496b-93cd-f330f85da352   none      none          off        
-    oxp_4fbd2fe0-2eac-41b8-8e8d-4fa46c3e8b6c/crypt/zone/oxz_crucible_abbf71e1-6568-42cf-9526-7e31549ba934   782adc3d-3a2f-400d-a6ce-531edc8cf546   none      none          off        
-    oxp_789d607d-d196-428e-a988-f7886a327859/crypt/zone/oxz_crucible_e37d04f9-ed3f-4665-800e-b51ba7d5d306   6c55265b-7515-4259-adf1-ac07f847c2fb   none      none          off        
-    oxp_33d48d85-751e-4982-b738-eae4d9a05f01/crypt/zone/oxz_crucible_e6c28c27-39d2-4aec-bf34-5d9f6b3cbd7f   803ed7a0-bb24-489f-8737-b01ff28e3278   none      none          off        
-    oxp_77e45b5b-869f-4e78-8ce3-28bbe8cf37e9/crypt/zone/oxz_crucible_f19f884a-3e97-458d-b8fb-533882750cd6   b1044d62-0afd-473e-8719-ca3ecb57d801   none      none          off        
-    oxp_60131a33-1f12-4dbb-9435-bdd368db1f51/crypt/zone/oxz_crucible_f54c359e-a980-4996-9462-25a548d96265   518e80f5-3074-44ec-8da3-ea64f3c0ad3e   none      none          off        
-    oxp_33d48d85-751e-4982-b738-eae4d9a05f01/crypt/zone/oxz_nexus_b854f752-383d-4e0b-8557-8c62d22ba994      537edbee-609e-40df-9a10-4c6f57c5f15f   none      none          off        
-    oxp_33d48d85-751e-4982-b738-eae4d9a05f01/crypt/zone/oxz_ntp_706286e2-8b09-42ff-9841-eaef65635eee        617a44e3-250b-4db1-a8e7-e42da46a0a0f   none      none          off        
-    oxp_33d48d85-751e-4982-b738-eae4d9a05f01/crypt/debug                                                    856e98db-f5c6-4cbd-a8ad-c02f59f207d7   100 GiB   none          gzip-9     
-    oxp_39ca2e23-4c38-4743-afe0-26b0380b27db/crypt/debug                                                    f14ef549-31db-4fae-a540-3a50f0fba233   100 GiB   none          gzip-9     
-    oxp_4fbd2fe0-2eac-41b8-8e8d-4fa46c3e8b6c/crypt/debug                                                    e44949f2-403b-4944-b966-de77d4b9365c   100 GiB   none          gzip-9     
-    oxp_60131a33-1f12-4dbb-9435-bdd368db1f51/crypt/debug                                                    425255d5-c1e8-44eb-855f-fe1770e83362   100 GiB   none          gzip-9     
-    oxp_77e45b5b-869f-4e78-8ce3-28bbe8cf37e9/crypt/debug                                                    dc613555-a790-45af-9af4-0127d376f3c6   100 GiB   none          gzip-9     
-    oxp_789d607d-d196-428e-a988-f7886a327859/crypt/debug                                                    4f359243-9639-431f-a0d1-5b2f2d6b5b0d   100 GiB   none          gzip-9     
-    oxp_b104b94c-2197-4e76-bfbd-6f966bd5af66/crypt/debug                                                    1315d3d7-e347-4e68-8381-8c010be44ef0   100 GiB   none          gzip-9     
-    oxp_cd62306a-aedf-47e8-93d5-92a358d64c7b/crypt/debug                                                    0e8321af-4634-4d31-aa79-145f8e171674   100 GiB   none          gzip-9     
-    oxp_f1693454-aac1-4265-b8a0-4e9f3f41c7b3/crypt/debug                                                    5a0f4402-7d87-4b6b-b4d2-72f48000627c   100 GiB   none          gzip-9     
-    oxp_fe4fdfba-3b6d-47d3-8612-1fb2390b650a/crypt/debug                                                    a2120fee-01bd-4f49-8c58-720384b1cbde   100 GiB   none          gzip-9     
-+   oxp_4fbd2fe0-2eac-41b8-8e8d-4fa46c3e8b6c/crypt/zone/oxz_nexus_b539cea9-c37c-49ef-874f-170d898187b2      113c40a7-e9fd-492f-814e-528db4fd0e83   none      none          off        
-+   oxp_60131a33-1f12-4dbb-9435-bdd368db1f51/crypt/zone/oxz_nexus_c5a0c592-319e-44df-9d00-1ddb1d5ad6aa      61e536fd-043c-4741-aed7-640d18d32b26   none      none          off        
-+   oxp_39ca2e23-4c38-4743-afe0-26b0380b27db/crypt/zone/oxz_nexus_cab211e1-3ab1-475f-81fa-984748044d8c      92f259d0-cda4-44e4-bb22-8b82d025d502   none      none          off        
+    ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
+    dataset name                                                                                            dataset id                             disposition   quota     reservation   compression
+    ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
+    oxp_33d48d85-751e-4982-b738-eae4d9a05f01/crucible                                                       e7187a07-3759-4185-8893-36b01e1a7295   in service    none      none          off        
+    oxp_39ca2e23-4c38-4743-afe0-26b0380b27db/crucible                                                       f9901e16-a9e4-4c49-a3b9-464405830043   in service    none      none          off        
+    oxp_4fbd2fe0-2eac-41b8-8e8d-4fa46c3e8b6c/crucible                                                       024a9e5e-f8a8-4b8f-b75e-5b05509fa69a   in service    none      none          off        
+    oxp_60131a33-1f12-4dbb-9435-bdd368db1f51/crucible                                                       22547c0a-a710-4d4c-8984-32445fbf993b   in service    none      none          off        
+    oxp_77e45b5b-869f-4e78-8ce3-28bbe8cf37e9/crucible                                                       dec5883c-1abd-4425-8cc4-b2f57c85cdd4   in service    none      none          off        
+    oxp_789d607d-d196-428e-a988-f7886a327859/crucible                                                       fda176fb-2cea-4646-8601-8d719bcdbda0   in service    none      none          off        
+    oxp_b104b94c-2197-4e76-bfbd-6f966bd5af66/crucible                                                       4ded36d4-7e98-47fe-a0f4-c580e7d1eb21   in service    none      none          off        
+    oxp_cd62306a-aedf-47e8-93d5-92a358d64c7b/crucible                                                       623c87b5-8848-4e42-aa5e-6e706e11cf63   in service    none      none          off        
+    oxp_f1693454-aac1-4265-b8a0-4e9f3f41c7b3/crucible                                                       e98d07df-27a8-4868-a3f9-066ac235516c   in service    none      none          off        
+    oxp_fe4fdfba-3b6d-47d3-8612-1fb2390b650a/crucible                                                       639c96d6-265a-45dc-b03f-c145d2ea8c43   in service    none      none          off        
+    oxp_33d48d85-751e-4982-b738-eae4d9a05f01/crypt/zone                                                     64c4eb2e-82bf-450c-9379-594af3a4794b   in service    none      none          off        
+    oxp_39ca2e23-4c38-4743-afe0-26b0380b27db/crypt/zone                                                     f6c13b9c-4e22-448d-b7b8-04652f06423c   in service    none      none          off        
+    oxp_4fbd2fe0-2eac-41b8-8e8d-4fa46c3e8b6c/crypt/zone                                                     a15671b5-d3f3-43d9-b143-81bcd5170edf   in service    none      none          off        
+    oxp_60131a33-1f12-4dbb-9435-bdd368db1f51/crypt/zone                                                     dd78cd99-4aa3-4946-b4c3-b9fad49c6da6   in service    none      none          off        
+    oxp_77e45b5b-869f-4e78-8ce3-28bbe8cf37e9/crypt/zone                                                     1c30ecb3-32ba-49e7-a3dd-771a75d38c3a   in service    none      none          off        
+    oxp_789d607d-d196-428e-a988-f7886a327859/crypt/zone                                                     7ac707a2-5bcf-49d1-88eb-1c09841082cf   in service    none      none          off        
+    oxp_b104b94c-2197-4e76-bfbd-6f966bd5af66/crypt/zone                                                     b0d96454-0a1d-47ac-9a13-5c4866131c37   in service    none      none          off        
+    oxp_cd62306a-aedf-47e8-93d5-92a358d64c7b/crypt/zone                                                     082509f2-115a-4a71-b8f8-86be21efc081   in service    none      none          off        
+    oxp_f1693454-aac1-4265-b8a0-4e9f3f41c7b3/crypt/zone                                                     01b79cba-881c-4bda-a48d-baaef2fcb122   in service    none      none          off        
+    oxp_fe4fdfba-3b6d-47d3-8612-1fb2390b650a/crypt/zone                                                     32d3d763-0665-4945-a3d0-e3d862f7a718   in service    none      none          off        
+    oxp_b104b94c-2197-4e76-bfbd-6f966bd5af66/crypt/zone/oxz_crucible_1b38728b-8552-435b-b621-359ba20d465b   c02c8635-e2f5-4974-a8b9-f4fdfe231365   in service    none      none          off        
+    oxp_39ca2e23-4c38-4743-afe0-26b0380b27db/crypt/zone/oxz_crucible_31c42e26-3cdf-41a8-8826-ce71a513ed04   4876b95c-457b-4e81-9a04-ca1319429627   in service    none      none          off        
+    oxp_f1693454-aac1-4265-b8a0-4e9f3f41c7b3/crypt/zone/oxz_crucible_4f38e475-396a-4650-a49c-c3cc4acc3ab9   2aff7d20-2a2b-4ded-9e03-eb0d72d29e35   in service    none      none          off        
+    oxp_cd62306a-aedf-47e8-93d5-92a358d64c7b/crypt/zone/oxz_crucible_5cd47e9f-1faf-4afd-970a-18b9076b3407   686fcd72-5da5-4f8c-a740-88866e30b8da   in service    none      none          off        
+    oxp_fe4fdfba-3b6d-47d3-8612-1fb2390b650a/crypt/zone/oxz_crucible_768ab86c-d5d2-4734-a381-02df1032d5e9   d1bbe8aa-aeda-496b-93cd-f330f85da352   in service    none      none          off        
+    oxp_4fbd2fe0-2eac-41b8-8e8d-4fa46c3e8b6c/crypt/zone/oxz_crucible_abbf71e1-6568-42cf-9526-7e31549ba934   782adc3d-3a2f-400d-a6ce-531edc8cf546   in service    none      none          off        
+    oxp_789d607d-d196-428e-a988-f7886a327859/crypt/zone/oxz_crucible_e37d04f9-ed3f-4665-800e-b51ba7d5d306   6c55265b-7515-4259-adf1-ac07f847c2fb   in service    none      none          off        
+    oxp_33d48d85-751e-4982-b738-eae4d9a05f01/crypt/zone/oxz_crucible_e6c28c27-39d2-4aec-bf34-5d9f6b3cbd7f   803ed7a0-bb24-489f-8737-b01ff28e3278   in service    none      none          off        
+    oxp_77e45b5b-869f-4e78-8ce3-28bbe8cf37e9/crypt/zone/oxz_crucible_f19f884a-3e97-458d-b8fb-533882750cd6   b1044d62-0afd-473e-8719-ca3ecb57d801   in service    none      none          off        
+    oxp_60131a33-1f12-4dbb-9435-bdd368db1f51/crypt/zone/oxz_crucible_f54c359e-a980-4996-9462-25a548d96265   518e80f5-3074-44ec-8da3-ea64f3c0ad3e   in service    none      none          off        
+    oxp_33d48d85-751e-4982-b738-eae4d9a05f01/crypt/zone/oxz_nexus_b854f752-383d-4e0b-8557-8c62d22ba994      537edbee-609e-40df-9a10-4c6f57c5f15f   in service    none      none          off        
+    oxp_33d48d85-751e-4982-b738-eae4d9a05f01/crypt/zone/oxz_ntp_706286e2-8b09-42ff-9841-eaef65635eee        617a44e3-250b-4db1-a8e7-e42da46a0a0f   in service    none      none          off        
+    oxp_33d48d85-751e-4982-b738-eae4d9a05f01/crypt/debug                                                    856e98db-f5c6-4cbd-a8ad-c02f59f207d7   in service    100 GiB   none          gzip-9     
+    oxp_39ca2e23-4c38-4743-afe0-26b0380b27db/crypt/debug                                                    f14ef549-31db-4fae-a540-3a50f0fba233   in service    100 GiB   none          gzip-9     
+    oxp_4fbd2fe0-2eac-41b8-8e8d-4fa46c3e8b6c/crypt/debug                                                    e44949f2-403b-4944-b966-de77d4b9365c   in service    100 GiB   none          gzip-9     
+    oxp_60131a33-1f12-4dbb-9435-bdd368db1f51/crypt/debug                                                    425255d5-c1e8-44eb-855f-fe1770e83362   in service    100 GiB   none          gzip-9     
+    oxp_77e45b5b-869f-4e78-8ce3-28bbe8cf37e9/crypt/debug                                                    dc613555-a790-45af-9af4-0127d376f3c6   in service    100 GiB   none          gzip-9     
+    oxp_789d607d-d196-428e-a988-f7886a327859/crypt/debug                                                    4f359243-9639-431f-a0d1-5b2f2d6b5b0d   in service    100 GiB   none          gzip-9     
+    oxp_b104b94c-2197-4e76-bfbd-6f966bd5af66/crypt/debug                                                    1315d3d7-e347-4e68-8381-8c010be44ef0   in service    100 GiB   none          gzip-9     
+    oxp_cd62306a-aedf-47e8-93d5-92a358d64c7b/crypt/debug                                                    0e8321af-4634-4d31-aa79-145f8e171674   in service    100 GiB   none          gzip-9     
+    oxp_f1693454-aac1-4265-b8a0-4e9f3f41c7b3/crypt/debug                                                    5a0f4402-7d87-4b6b-b4d2-72f48000627c   in service    100 GiB   none          gzip-9     
+    oxp_fe4fdfba-3b6d-47d3-8612-1fb2390b650a/crypt/debug                                                    a2120fee-01bd-4f49-8c58-720384b1cbde   in service    100 GiB   none          gzip-9     
++   oxp_4fbd2fe0-2eac-41b8-8e8d-4fa46c3e8b6c/crypt/zone/oxz_nexus_b539cea9-c37c-49ef-874f-170d898187b2      113c40a7-e9fd-492f-814e-528db4fd0e83   in service    none      none          off        
++   oxp_60131a33-1f12-4dbb-9435-bdd368db1f51/crypt/zone/oxz_nexus_c5a0c592-319e-44df-9d00-1ddb1d5ad6aa      61e536fd-043c-4741-aed7-640d18d32b26   in service    none      none          off        
++   oxp_39ca2e23-4c38-4743-afe0-26b0380b27db/crypt/zone/oxz_nexus_cab211e1-3ab1-475f-81fa-984748044d8c      92f259d0-cda4-44e4-bb22-8b82d025d502   in service    none      none          off        
 
 
     omicron zones generation 2 -> 3:

--- a/nexus/reconfigurator/planning/tests/output/planner_nonprovisionable_2_2a.txt
+++ b/nexus/reconfigurator/planning/tests/output/planner_nonprovisionable_2_2a.txt
@@ -22,54 +22,54 @@ to:   blueprint 9f71f5d3-a272-4382-9154-6ea2e171a6c6
 
 
     datasets at generation 3:
-    ----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
-    dataset name                                                                                            dataset uuid                           quota     reservation   compression
-    ----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
-    oxp_4069c804-c51a-4adc-8822-3cbbab56ed3f/crucible                                                       081aff15-bc64-4b57-bbcc-287d7267caa4   none      none          off        
-    oxp_5248a306-4a03-449e-a8a3-6f86d26da755/crucible                                                       0beeebcf-b558-47e9-9274-bc3dd4a475b8   none      none          off        
-    oxp_55196665-ed61-4b23-9a74-0711bf2eaf90/crucible                                                       757dd9e5-74db-4860-a87e-0aafd6795b91   none      none          off        
-    oxp_6b2a719a-35eb-469f-aa54-114a1f21f37d/crucible                                                       bd64099e-57f0-447f-9c21-e493e2809372   none      none          off        
-    oxp_7ed4296a-66d1-4fb2-bc56-9b23b8f27d7e/crucible                                                       3bd0565c-1170-4727-824b-f180454e4ff1   none      none          off        
-    oxp_984e2389-e7fd-4af9-ab02-e3caf77f95b5/crucible                                                       010c6c12-6ea3-4bbd-9a69-90209dab73ab   none      none          off        
-    oxp_a5f75431-3795-426c-8f80-176f658281a5/crucible                                                       2dbc8272-64ae-4d2d-ac1f-92f120204ddd   none      none          off        
-    oxp_cf32a1ce-2c9e-49f5-b1cf-4af7f2a28901/crucible                                                       b4e4e724-ddfb-4d0a-bf6b-edd6dd91172d   none      none          off        
-    oxp_e405da11-cb6b-4ebc-bac1-9bc997352e10/crucible                                                       8fdfaea0-1da2-429f-b64e-ef0107f2884d   none      none          off        
-    oxp_f4d7f914-ec73-4b65-8696-5068591d9065/crucible                                                       74dc30b1-2c84-4e9d-910c-938d33f9a537   none      none          off        
-    oxp_4069c804-c51a-4adc-8822-3cbbab56ed3f/crypt/zone                                                     f282431f-2ed2-4386-bc0f-0f3130b175bf   none      none          off        
-    oxp_5248a306-4a03-449e-a8a3-6f86d26da755/crypt/zone                                                     ee3f0e38-23ac-45c6-8157-e611887572a6   none      none          off        
-    oxp_55196665-ed61-4b23-9a74-0711bf2eaf90/crypt/zone                                                     acf672d0-effd-491a-bde8-a4253e078f14   none      none          off        
-    oxp_6b2a719a-35eb-469f-aa54-114a1f21f37d/crypt/zone                                                     d5be658f-367a-4703-a377-7d8067aade3a   none      none          off        
-    oxp_7ed4296a-66d1-4fb2-bc56-9b23b8f27d7e/crypt/zone                                                     adbebdd0-4d0d-4794-9bb5-6681b5119624   none      none          off        
-    oxp_984e2389-e7fd-4af9-ab02-e3caf77f95b5/crypt/zone                                                     1e063fbb-083c-4e2e-a4f5-c40ce854f1d0   none      none          off        
-    oxp_a5f75431-3795-426c-8f80-176f658281a5/crypt/zone                                                     6b476700-d002-4173-8a83-fb24d49be32f   none      none          off        
-    oxp_cf32a1ce-2c9e-49f5-b1cf-4af7f2a28901/crypt/zone                                                     abaa13f5-c3ec-45b2-86da-2be74a259878   none      none          off        
-    oxp_e405da11-cb6b-4ebc-bac1-9bc997352e10/crypt/zone                                                     d8c2da98-ef6d-4746-ae4b-ed537c78fc89   none      none          off        
-    oxp_f4d7f914-ec73-4b65-8696-5068591d9065/crypt/zone                                                     b1c8156e-7490-46d2-a4af-7fc5dd39991d   none      none          off        
-    oxp_6b2a719a-35eb-469f-aa54-114a1f21f37d/crypt/zone/oxz_crucible_05ba6d6e-90a7-402a-aaba-fd92190a9f48   6a6e744c-c4a9-4e58-b0ed-ef44eef0c6e0   none      none          off        
-    oxp_f4d7f914-ec73-4b65-8696-5068591d9065/crypt/zone/oxz_crucible_2097bad3-ee65-4a1c-8fe2-75ed52e69ac8   54941545-0cee-4c36-8516-c63b3cbd02fb   none      none          off        
-    oxp_4069c804-c51a-4adc-8822-3cbbab56ed3f/crypt/zone/oxz_crucible_430c8fe1-7296-4a73-b260-fc185260ec5e   d0ee4ede-c9a6-4d6a-9dbe-63b4c07a9cdd   none      none          off        
-    oxp_cf32a1ce-2c9e-49f5-b1cf-4af7f2a28901/crypt/zone/oxz_crucible_a720288d-3e5b-44b7-9dab-a69a10768e0b   3fa16efe-c488-4d45-92ee-18eeb8b9453f   none      none          off        
-    oxp_a5f75431-3795-426c-8f80-176f658281a5/crypt/zone/oxz_crucible_b2170eef-aa6f-4ec5-aaa9-2b4289eae65c   e20a6e28-7a52-480a-9d36-33f8d4474bf5   none      none          off        
-    oxp_984e2389-e7fd-4af9-ab02-e3caf77f95b5/crypt/zone/oxz_crucible_b505d6e1-07b9-48bf-bc8a-d4081c25b12a   6b965329-4398-4738-84e6-b893f21a724c   none      none          off        
-    oxp_5248a306-4a03-449e-a8a3-6f86d26da755/crypt/zone/oxz_crucible_cbe34d65-017e-4c26-966d-b1ce27bc1d94   8ad4a9ed-7be5-4f49-8a38-1686144ceaf6   none      none          off        
-    oxp_e405da11-cb6b-4ebc-bac1-9bc997352e10/crypt/zone/oxz_crucible_e01462d1-5173-4d95-8477-78ca2157efbb   03fbd010-e16e-48a9-a9a9-5be665c0bdff   none      none          off        
-    oxp_55196665-ed61-4b23-9a74-0711bf2eaf90/crypt/zone/oxz_crucible_e49b0403-3d7c-480f-9113-4bc0fca74a8a   62053fe9-281c-4949-9357-bf818004aef2   none      none          off        
-    oxp_7ed4296a-66d1-4fb2-bc56-9b23b8f27d7e/crypt/zone/oxz_crucible_e6ec9399-b81b-4bdd-8e6e-b0f043aad942   f761d5be-fef1-47d7-850c-1f28a1f8a8b3   none      none          off        
-    oxp_6b2a719a-35eb-469f-aa54-114a1f21f37d/crypt/zone/oxz_nexus_2ed23118-6137-45ca-824c-04df3bc3d085      047b92e1-2286-44bb-988e-403f20973ee4   none      none          off        
-    oxp_5248a306-4a03-449e-a8a3-6f86d26da755/crypt/zone/oxz_nexus_33365de5-8a83-46c0-9d34-eddd68e54c6f      4f6d72db-de32-4a55-ae9d-30d776580c33   none      none          off        
-    oxp_55196665-ed61-4b23-9a74-0711bf2eaf90/crypt/zone/oxz_nexus_80e4964b-a8c8-41ef-ae23-f86cfe5f3a7b      6944260c-23fd-47db-8a2c-02196b399f57   none      none          off        
-    oxp_4069c804-c51a-4adc-8822-3cbbab56ed3f/crypt/zone/oxz_nexus_81f79040-bcf7-4eff-9a87-8e7bcb5a6db9      2694f256-cd46-4841-a009-6460f4ca0616   none      none          off        
-    oxp_4069c804-c51a-4adc-8822-3cbbab56ed3f/crypt/zone/oxz_ntp_8f94a160-67ab-4ed5-bc3f-01e19fdd7e9b        225c385b-de3e-4262-a5c4-0250abc910f9   none      none          off        
-    oxp_4069c804-c51a-4adc-8822-3cbbab56ed3f/crypt/debug                                                    041c4e17-e958-41aa-b621-03dd3b3e7da8   100 GiB   none          gzip-9     
-    oxp_5248a306-4a03-449e-a8a3-6f86d26da755/crypt/debug                                                    7e551f2b-ac22-4637-bd2a-188f106b57c0   100 GiB   none          gzip-9     
-    oxp_55196665-ed61-4b23-9a74-0711bf2eaf90/crypt/debug                                                    1e4208d8-041e-49eb-ab6d-dcedceee170c   100 GiB   none          gzip-9     
-    oxp_6b2a719a-35eb-469f-aa54-114a1f21f37d/crypt/debug                                                    0872720b-c454-45f6-8816-2835d595894e   100 GiB   none          gzip-9     
-    oxp_7ed4296a-66d1-4fb2-bc56-9b23b8f27d7e/crypt/debug                                                    fc7195f4-4472-4283-9094-2f6f7db01e71   100 GiB   none          gzip-9     
-    oxp_984e2389-e7fd-4af9-ab02-e3caf77f95b5/crypt/debug                                                    baa19cce-f379-427c-9b5e-c413b050c2d5   100 GiB   none          gzip-9     
-    oxp_a5f75431-3795-426c-8f80-176f658281a5/crypt/debug                                                    5828eb26-b03b-4481-b88d-027a90a24c50   100 GiB   none          gzip-9     
-    oxp_cf32a1ce-2c9e-49f5-b1cf-4af7f2a28901/crypt/debug                                                    5e7deb25-14c2-4633-8728-6eff7833e14f   100 GiB   none          gzip-9     
-    oxp_e405da11-cb6b-4ebc-bac1-9bc997352e10/crypt/debug                                                    e02c1929-a38a-49c2-8909-555c3e046d18   100 GiB   none          gzip-9     
-    oxp_f4d7f914-ec73-4b65-8696-5068591d9065/crypt/debug                                                    0aeb1237-4ad7-41ae-abd2-45789a3ab2f2   100 GiB   none          gzip-9     
+    ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
+    dataset name                                                                                            dataset id                             disposition   quota     reservation   compression
+    ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
+    oxp_4069c804-c51a-4adc-8822-3cbbab56ed3f/crucible                                                       081aff15-bc64-4b57-bbcc-287d7267caa4   in service    none      none          off        
+    oxp_5248a306-4a03-449e-a8a3-6f86d26da755/crucible                                                       0beeebcf-b558-47e9-9274-bc3dd4a475b8   in service    none      none          off        
+    oxp_55196665-ed61-4b23-9a74-0711bf2eaf90/crucible                                                       757dd9e5-74db-4860-a87e-0aafd6795b91   in service    none      none          off        
+    oxp_6b2a719a-35eb-469f-aa54-114a1f21f37d/crucible                                                       bd64099e-57f0-447f-9c21-e493e2809372   in service    none      none          off        
+    oxp_7ed4296a-66d1-4fb2-bc56-9b23b8f27d7e/crucible                                                       3bd0565c-1170-4727-824b-f180454e4ff1   in service    none      none          off        
+    oxp_984e2389-e7fd-4af9-ab02-e3caf77f95b5/crucible                                                       010c6c12-6ea3-4bbd-9a69-90209dab73ab   in service    none      none          off        
+    oxp_a5f75431-3795-426c-8f80-176f658281a5/crucible                                                       2dbc8272-64ae-4d2d-ac1f-92f120204ddd   in service    none      none          off        
+    oxp_cf32a1ce-2c9e-49f5-b1cf-4af7f2a28901/crucible                                                       b4e4e724-ddfb-4d0a-bf6b-edd6dd91172d   in service    none      none          off        
+    oxp_e405da11-cb6b-4ebc-bac1-9bc997352e10/crucible                                                       8fdfaea0-1da2-429f-b64e-ef0107f2884d   in service    none      none          off        
+    oxp_f4d7f914-ec73-4b65-8696-5068591d9065/crucible                                                       74dc30b1-2c84-4e9d-910c-938d33f9a537   in service    none      none          off        
+    oxp_4069c804-c51a-4adc-8822-3cbbab56ed3f/crypt/zone                                                     f282431f-2ed2-4386-bc0f-0f3130b175bf   in service    none      none          off        
+    oxp_5248a306-4a03-449e-a8a3-6f86d26da755/crypt/zone                                                     ee3f0e38-23ac-45c6-8157-e611887572a6   in service    none      none          off        
+    oxp_55196665-ed61-4b23-9a74-0711bf2eaf90/crypt/zone                                                     acf672d0-effd-491a-bde8-a4253e078f14   in service    none      none          off        
+    oxp_6b2a719a-35eb-469f-aa54-114a1f21f37d/crypt/zone                                                     d5be658f-367a-4703-a377-7d8067aade3a   in service    none      none          off        
+    oxp_7ed4296a-66d1-4fb2-bc56-9b23b8f27d7e/crypt/zone                                                     adbebdd0-4d0d-4794-9bb5-6681b5119624   in service    none      none          off        
+    oxp_984e2389-e7fd-4af9-ab02-e3caf77f95b5/crypt/zone                                                     1e063fbb-083c-4e2e-a4f5-c40ce854f1d0   in service    none      none          off        
+    oxp_a5f75431-3795-426c-8f80-176f658281a5/crypt/zone                                                     6b476700-d002-4173-8a83-fb24d49be32f   in service    none      none          off        
+    oxp_cf32a1ce-2c9e-49f5-b1cf-4af7f2a28901/crypt/zone                                                     abaa13f5-c3ec-45b2-86da-2be74a259878   in service    none      none          off        
+    oxp_e405da11-cb6b-4ebc-bac1-9bc997352e10/crypt/zone                                                     d8c2da98-ef6d-4746-ae4b-ed537c78fc89   in service    none      none          off        
+    oxp_f4d7f914-ec73-4b65-8696-5068591d9065/crypt/zone                                                     b1c8156e-7490-46d2-a4af-7fc5dd39991d   in service    none      none          off        
+    oxp_6b2a719a-35eb-469f-aa54-114a1f21f37d/crypt/zone/oxz_crucible_05ba6d6e-90a7-402a-aaba-fd92190a9f48   6a6e744c-c4a9-4e58-b0ed-ef44eef0c6e0   in service    none      none          off        
+    oxp_f4d7f914-ec73-4b65-8696-5068591d9065/crypt/zone/oxz_crucible_2097bad3-ee65-4a1c-8fe2-75ed52e69ac8   54941545-0cee-4c36-8516-c63b3cbd02fb   in service    none      none          off        
+    oxp_4069c804-c51a-4adc-8822-3cbbab56ed3f/crypt/zone/oxz_crucible_430c8fe1-7296-4a73-b260-fc185260ec5e   d0ee4ede-c9a6-4d6a-9dbe-63b4c07a9cdd   in service    none      none          off        
+    oxp_cf32a1ce-2c9e-49f5-b1cf-4af7f2a28901/crypt/zone/oxz_crucible_a720288d-3e5b-44b7-9dab-a69a10768e0b   3fa16efe-c488-4d45-92ee-18eeb8b9453f   in service    none      none          off        
+    oxp_a5f75431-3795-426c-8f80-176f658281a5/crypt/zone/oxz_crucible_b2170eef-aa6f-4ec5-aaa9-2b4289eae65c   e20a6e28-7a52-480a-9d36-33f8d4474bf5   in service    none      none          off        
+    oxp_984e2389-e7fd-4af9-ab02-e3caf77f95b5/crypt/zone/oxz_crucible_b505d6e1-07b9-48bf-bc8a-d4081c25b12a   6b965329-4398-4738-84e6-b893f21a724c   in service    none      none          off        
+    oxp_5248a306-4a03-449e-a8a3-6f86d26da755/crypt/zone/oxz_crucible_cbe34d65-017e-4c26-966d-b1ce27bc1d94   8ad4a9ed-7be5-4f49-8a38-1686144ceaf6   in service    none      none          off        
+    oxp_e405da11-cb6b-4ebc-bac1-9bc997352e10/crypt/zone/oxz_crucible_e01462d1-5173-4d95-8477-78ca2157efbb   03fbd010-e16e-48a9-a9a9-5be665c0bdff   in service    none      none          off        
+    oxp_55196665-ed61-4b23-9a74-0711bf2eaf90/crypt/zone/oxz_crucible_e49b0403-3d7c-480f-9113-4bc0fca74a8a   62053fe9-281c-4949-9357-bf818004aef2   in service    none      none          off        
+    oxp_7ed4296a-66d1-4fb2-bc56-9b23b8f27d7e/crypt/zone/oxz_crucible_e6ec9399-b81b-4bdd-8e6e-b0f043aad942   f761d5be-fef1-47d7-850c-1f28a1f8a8b3   in service    none      none          off        
+    oxp_6b2a719a-35eb-469f-aa54-114a1f21f37d/crypt/zone/oxz_nexus_2ed23118-6137-45ca-824c-04df3bc3d085      047b92e1-2286-44bb-988e-403f20973ee4   in service    none      none          off        
+    oxp_5248a306-4a03-449e-a8a3-6f86d26da755/crypt/zone/oxz_nexus_33365de5-8a83-46c0-9d34-eddd68e54c6f      4f6d72db-de32-4a55-ae9d-30d776580c33   in service    none      none          off        
+    oxp_55196665-ed61-4b23-9a74-0711bf2eaf90/crypt/zone/oxz_nexus_80e4964b-a8c8-41ef-ae23-f86cfe5f3a7b      6944260c-23fd-47db-8a2c-02196b399f57   in service    none      none          off        
+    oxp_4069c804-c51a-4adc-8822-3cbbab56ed3f/crypt/zone/oxz_nexus_81f79040-bcf7-4eff-9a87-8e7bcb5a6db9      2694f256-cd46-4841-a009-6460f4ca0616   in service    none      none          off        
+    oxp_4069c804-c51a-4adc-8822-3cbbab56ed3f/crypt/zone/oxz_ntp_8f94a160-67ab-4ed5-bc3f-01e19fdd7e9b        225c385b-de3e-4262-a5c4-0250abc910f9   in service    none      none          off        
+    oxp_4069c804-c51a-4adc-8822-3cbbab56ed3f/crypt/debug                                                    041c4e17-e958-41aa-b621-03dd3b3e7da8   in service    100 GiB   none          gzip-9     
+    oxp_5248a306-4a03-449e-a8a3-6f86d26da755/crypt/debug                                                    7e551f2b-ac22-4637-bd2a-188f106b57c0   in service    100 GiB   none          gzip-9     
+    oxp_55196665-ed61-4b23-9a74-0711bf2eaf90/crypt/debug                                                    1e4208d8-041e-49eb-ab6d-dcedceee170c   in service    100 GiB   none          gzip-9     
+    oxp_6b2a719a-35eb-469f-aa54-114a1f21f37d/crypt/debug                                                    0872720b-c454-45f6-8816-2835d595894e   in service    100 GiB   none          gzip-9     
+    oxp_7ed4296a-66d1-4fb2-bc56-9b23b8f27d7e/crypt/debug                                                    fc7195f4-4472-4283-9094-2f6f7db01e71   in service    100 GiB   none          gzip-9     
+    oxp_984e2389-e7fd-4af9-ab02-e3caf77f95b5/crypt/debug                                                    baa19cce-f379-427c-9b5e-c413b050c2d5   in service    100 GiB   none          gzip-9     
+    oxp_a5f75431-3795-426c-8f80-176f658281a5/crypt/debug                                                    5828eb26-b03b-4481-b88d-027a90a24c50   in service    100 GiB   none          gzip-9     
+    oxp_cf32a1ce-2c9e-49f5-b1cf-4af7f2a28901/crypt/debug                                                    5e7deb25-14c2-4633-8728-6eff7833e14f   in service    100 GiB   none          gzip-9     
+    oxp_e405da11-cb6b-4ebc-bac1-9bc997352e10/crypt/debug                                                    e02c1929-a38a-49c2-8909-555c3e046d18   in service    100 GiB   none          gzip-9     
+    oxp_f4d7f914-ec73-4b65-8696-5068591d9065/crypt/debug                                                    0aeb1237-4ad7-41ae-abd2-45789a3ab2f2   in service    100 GiB   none          gzip-9     
 
 
     omicron zones at generation 3:
@@ -112,54 +112,54 @@ to:   blueprint 9f71f5d3-a272-4382-9154-6ea2e171a6c6
 
 
     datasets at generation 3:
-    ----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
-    dataset name                                                                                            dataset uuid                           quota     reservation   compression
-    ----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
-    oxp_33d48d85-751e-4982-b738-eae4d9a05f01/crucible                                                       e7187a07-3759-4185-8893-36b01e1a7295   none      none          off        
-    oxp_39ca2e23-4c38-4743-afe0-26b0380b27db/crucible                                                       f9901e16-a9e4-4c49-a3b9-464405830043   none      none          off        
-    oxp_4fbd2fe0-2eac-41b8-8e8d-4fa46c3e8b6c/crucible                                                       024a9e5e-f8a8-4b8f-b75e-5b05509fa69a   none      none          off        
-    oxp_60131a33-1f12-4dbb-9435-bdd368db1f51/crucible                                                       22547c0a-a710-4d4c-8984-32445fbf993b   none      none          off        
-    oxp_77e45b5b-869f-4e78-8ce3-28bbe8cf37e9/crucible                                                       dec5883c-1abd-4425-8cc4-b2f57c85cdd4   none      none          off        
-    oxp_789d607d-d196-428e-a988-f7886a327859/crucible                                                       fda176fb-2cea-4646-8601-8d719bcdbda0   none      none          off        
-    oxp_b104b94c-2197-4e76-bfbd-6f966bd5af66/crucible                                                       4ded36d4-7e98-47fe-a0f4-c580e7d1eb21   none      none          off        
-    oxp_cd62306a-aedf-47e8-93d5-92a358d64c7b/crucible                                                       623c87b5-8848-4e42-aa5e-6e706e11cf63   none      none          off        
-    oxp_f1693454-aac1-4265-b8a0-4e9f3f41c7b3/crucible                                                       e98d07df-27a8-4868-a3f9-066ac235516c   none      none          off        
-    oxp_fe4fdfba-3b6d-47d3-8612-1fb2390b650a/crucible                                                       639c96d6-265a-45dc-b03f-c145d2ea8c43   none      none          off        
-    oxp_33d48d85-751e-4982-b738-eae4d9a05f01/crypt/zone                                                     64c4eb2e-82bf-450c-9379-594af3a4794b   none      none          off        
-    oxp_39ca2e23-4c38-4743-afe0-26b0380b27db/crypt/zone                                                     f6c13b9c-4e22-448d-b7b8-04652f06423c   none      none          off        
-    oxp_4fbd2fe0-2eac-41b8-8e8d-4fa46c3e8b6c/crypt/zone                                                     a15671b5-d3f3-43d9-b143-81bcd5170edf   none      none          off        
-    oxp_60131a33-1f12-4dbb-9435-bdd368db1f51/crypt/zone                                                     dd78cd99-4aa3-4946-b4c3-b9fad49c6da6   none      none          off        
-    oxp_77e45b5b-869f-4e78-8ce3-28bbe8cf37e9/crypt/zone                                                     1c30ecb3-32ba-49e7-a3dd-771a75d38c3a   none      none          off        
-    oxp_789d607d-d196-428e-a988-f7886a327859/crypt/zone                                                     7ac707a2-5bcf-49d1-88eb-1c09841082cf   none      none          off        
-    oxp_b104b94c-2197-4e76-bfbd-6f966bd5af66/crypt/zone                                                     b0d96454-0a1d-47ac-9a13-5c4866131c37   none      none          off        
-    oxp_cd62306a-aedf-47e8-93d5-92a358d64c7b/crypt/zone                                                     082509f2-115a-4a71-b8f8-86be21efc081   none      none          off        
-    oxp_f1693454-aac1-4265-b8a0-4e9f3f41c7b3/crypt/zone                                                     01b79cba-881c-4bda-a48d-baaef2fcb122   none      none          off        
-    oxp_fe4fdfba-3b6d-47d3-8612-1fb2390b650a/crypt/zone                                                     32d3d763-0665-4945-a3d0-e3d862f7a718   none      none          off        
-    oxp_b104b94c-2197-4e76-bfbd-6f966bd5af66/crypt/zone/oxz_crucible_1b38728b-8552-435b-b621-359ba20d465b   c02c8635-e2f5-4974-a8b9-f4fdfe231365   none      none          off        
-    oxp_39ca2e23-4c38-4743-afe0-26b0380b27db/crypt/zone/oxz_crucible_31c42e26-3cdf-41a8-8826-ce71a513ed04   4876b95c-457b-4e81-9a04-ca1319429627   none      none          off        
-    oxp_f1693454-aac1-4265-b8a0-4e9f3f41c7b3/crypt/zone/oxz_crucible_4f38e475-396a-4650-a49c-c3cc4acc3ab9   2aff7d20-2a2b-4ded-9e03-eb0d72d29e35   none      none          off        
-    oxp_cd62306a-aedf-47e8-93d5-92a358d64c7b/crypt/zone/oxz_crucible_5cd47e9f-1faf-4afd-970a-18b9076b3407   686fcd72-5da5-4f8c-a740-88866e30b8da   none      none          off        
-    oxp_fe4fdfba-3b6d-47d3-8612-1fb2390b650a/crypt/zone/oxz_crucible_768ab86c-d5d2-4734-a381-02df1032d5e9   d1bbe8aa-aeda-496b-93cd-f330f85da352   none      none          off        
-    oxp_4fbd2fe0-2eac-41b8-8e8d-4fa46c3e8b6c/crypt/zone/oxz_crucible_abbf71e1-6568-42cf-9526-7e31549ba934   782adc3d-3a2f-400d-a6ce-531edc8cf546   none      none          off        
-    oxp_789d607d-d196-428e-a988-f7886a327859/crypt/zone/oxz_crucible_e37d04f9-ed3f-4665-800e-b51ba7d5d306   6c55265b-7515-4259-adf1-ac07f847c2fb   none      none          off        
-    oxp_33d48d85-751e-4982-b738-eae4d9a05f01/crypt/zone/oxz_crucible_e6c28c27-39d2-4aec-bf34-5d9f6b3cbd7f   803ed7a0-bb24-489f-8737-b01ff28e3278   none      none          off        
-    oxp_77e45b5b-869f-4e78-8ce3-28bbe8cf37e9/crypt/zone/oxz_crucible_f19f884a-3e97-458d-b8fb-533882750cd6   b1044d62-0afd-473e-8719-ca3ecb57d801   none      none          off        
-    oxp_60131a33-1f12-4dbb-9435-bdd368db1f51/crypt/zone/oxz_crucible_f54c359e-a980-4996-9462-25a548d96265   518e80f5-3074-44ec-8da3-ea64f3c0ad3e   none      none          off        
-    oxp_4fbd2fe0-2eac-41b8-8e8d-4fa46c3e8b6c/crypt/zone/oxz_nexus_b539cea9-c37c-49ef-874f-170d898187b2      113c40a7-e9fd-492f-814e-528db4fd0e83   none      none          off        
-    oxp_33d48d85-751e-4982-b738-eae4d9a05f01/crypt/zone/oxz_nexus_b854f752-383d-4e0b-8557-8c62d22ba994      537edbee-609e-40df-9a10-4c6f57c5f15f   none      none          off        
-    oxp_60131a33-1f12-4dbb-9435-bdd368db1f51/crypt/zone/oxz_nexus_c5a0c592-319e-44df-9d00-1ddb1d5ad6aa      61e536fd-043c-4741-aed7-640d18d32b26   none      none          off        
-    oxp_39ca2e23-4c38-4743-afe0-26b0380b27db/crypt/zone/oxz_nexus_cab211e1-3ab1-475f-81fa-984748044d8c      92f259d0-cda4-44e4-bb22-8b82d025d502   none      none          off        
-    oxp_33d48d85-751e-4982-b738-eae4d9a05f01/crypt/zone/oxz_ntp_706286e2-8b09-42ff-9841-eaef65635eee        617a44e3-250b-4db1-a8e7-e42da46a0a0f   none      none          off        
-    oxp_33d48d85-751e-4982-b738-eae4d9a05f01/crypt/debug                                                    856e98db-f5c6-4cbd-a8ad-c02f59f207d7   100 GiB   none          gzip-9     
-    oxp_39ca2e23-4c38-4743-afe0-26b0380b27db/crypt/debug                                                    f14ef549-31db-4fae-a540-3a50f0fba233   100 GiB   none          gzip-9     
-    oxp_4fbd2fe0-2eac-41b8-8e8d-4fa46c3e8b6c/crypt/debug                                                    e44949f2-403b-4944-b966-de77d4b9365c   100 GiB   none          gzip-9     
-    oxp_60131a33-1f12-4dbb-9435-bdd368db1f51/crypt/debug                                                    425255d5-c1e8-44eb-855f-fe1770e83362   100 GiB   none          gzip-9     
-    oxp_77e45b5b-869f-4e78-8ce3-28bbe8cf37e9/crypt/debug                                                    dc613555-a790-45af-9af4-0127d376f3c6   100 GiB   none          gzip-9     
-    oxp_789d607d-d196-428e-a988-f7886a327859/crypt/debug                                                    4f359243-9639-431f-a0d1-5b2f2d6b5b0d   100 GiB   none          gzip-9     
-    oxp_b104b94c-2197-4e76-bfbd-6f966bd5af66/crypt/debug                                                    1315d3d7-e347-4e68-8381-8c010be44ef0   100 GiB   none          gzip-9     
-    oxp_cd62306a-aedf-47e8-93d5-92a358d64c7b/crypt/debug                                                    0e8321af-4634-4d31-aa79-145f8e171674   100 GiB   none          gzip-9     
-    oxp_f1693454-aac1-4265-b8a0-4e9f3f41c7b3/crypt/debug                                                    5a0f4402-7d87-4b6b-b4d2-72f48000627c   100 GiB   none          gzip-9     
-    oxp_fe4fdfba-3b6d-47d3-8612-1fb2390b650a/crypt/debug                                                    a2120fee-01bd-4f49-8c58-720384b1cbde   100 GiB   none          gzip-9     
+    ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
+    dataset name                                                                                            dataset id                             disposition   quota     reservation   compression
+    ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
+    oxp_33d48d85-751e-4982-b738-eae4d9a05f01/crucible                                                       e7187a07-3759-4185-8893-36b01e1a7295   in service    none      none          off        
+    oxp_39ca2e23-4c38-4743-afe0-26b0380b27db/crucible                                                       f9901e16-a9e4-4c49-a3b9-464405830043   in service    none      none          off        
+    oxp_4fbd2fe0-2eac-41b8-8e8d-4fa46c3e8b6c/crucible                                                       024a9e5e-f8a8-4b8f-b75e-5b05509fa69a   in service    none      none          off        
+    oxp_60131a33-1f12-4dbb-9435-bdd368db1f51/crucible                                                       22547c0a-a710-4d4c-8984-32445fbf993b   in service    none      none          off        
+    oxp_77e45b5b-869f-4e78-8ce3-28bbe8cf37e9/crucible                                                       dec5883c-1abd-4425-8cc4-b2f57c85cdd4   in service    none      none          off        
+    oxp_789d607d-d196-428e-a988-f7886a327859/crucible                                                       fda176fb-2cea-4646-8601-8d719bcdbda0   in service    none      none          off        
+    oxp_b104b94c-2197-4e76-bfbd-6f966bd5af66/crucible                                                       4ded36d4-7e98-47fe-a0f4-c580e7d1eb21   in service    none      none          off        
+    oxp_cd62306a-aedf-47e8-93d5-92a358d64c7b/crucible                                                       623c87b5-8848-4e42-aa5e-6e706e11cf63   in service    none      none          off        
+    oxp_f1693454-aac1-4265-b8a0-4e9f3f41c7b3/crucible                                                       e98d07df-27a8-4868-a3f9-066ac235516c   in service    none      none          off        
+    oxp_fe4fdfba-3b6d-47d3-8612-1fb2390b650a/crucible                                                       639c96d6-265a-45dc-b03f-c145d2ea8c43   in service    none      none          off        
+    oxp_33d48d85-751e-4982-b738-eae4d9a05f01/crypt/zone                                                     64c4eb2e-82bf-450c-9379-594af3a4794b   in service    none      none          off        
+    oxp_39ca2e23-4c38-4743-afe0-26b0380b27db/crypt/zone                                                     f6c13b9c-4e22-448d-b7b8-04652f06423c   in service    none      none          off        
+    oxp_4fbd2fe0-2eac-41b8-8e8d-4fa46c3e8b6c/crypt/zone                                                     a15671b5-d3f3-43d9-b143-81bcd5170edf   in service    none      none          off        
+    oxp_60131a33-1f12-4dbb-9435-bdd368db1f51/crypt/zone                                                     dd78cd99-4aa3-4946-b4c3-b9fad49c6da6   in service    none      none          off        
+    oxp_77e45b5b-869f-4e78-8ce3-28bbe8cf37e9/crypt/zone                                                     1c30ecb3-32ba-49e7-a3dd-771a75d38c3a   in service    none      none          off        
+    oxp_789d607d-d196-428e-a988-f7886a327859/crypt/zone                                                     7ac707a2-5bcf-49d1-88eb-1c09841082cf   in service    none      none          off        
+    oxp_b104b94c-2197-4e76-bfbd-6f966bd5af66/crypt/zone                                                     b0d96454-0a1d-47ac-9a13-5c4866131c37   in service    none      none          off        
+    oxp_cd62306a-aedf-47e8-93d5-92a358d64c7b/crypt/zone                                                     082509f2-115a-4a71-b8f8-86be21efc081   in service    none      none          off        
+    oxp_f1693454-aac1-4265-b8a0-4e9f3f41c7b3/crypt/zone                                                     01b79cba-881c-4bda-a48d-baaef2fcb122   in service    none      none          off        
+    oxp_fe4fdfba-3b6d-47d3-8612-1fb2390b650a/crypt/zone                                                     32d3d763-0665-4945-a3d0-e3d862f7a718   in service    none      none          off        
+    oxp_b104b94c-2197-4e76-bfbd-6f966bd5af66/crypt/zone/oxz_crucible_1b38728b-8552-435b-b621-359ba20d465b   c02c8635-e2f5-4974-a8b9-f4fdfe231365   in service    none      none          off        
+    oxp_39ca2e23-4c38-4743-afe0-26b0380b27db/crypt/zone/oxz_crucible_31c42e26-3cdf-41a8-8826-ce71a513ed04   4876b95c-457b-4e81-9a04-ca1319429627   in service    none      none          off        
+    oxp_f1693454-aac1-4265-b8a0-4e9f3f41c7b3/crypt/zone/oxz_crucible_4f38e475-396a-4650-a49c-c3cc4acc3ab9   2aff7d20-2a2b-4ded-9e03-eb0d72d29e35   in service    none      none          off        
+    oxp_cd62306a-aedf-47e8-93d5-92a358d64c7b/crypt/zone/oxz_crucible_5cd47e9f-1faf-4afd-970a-18b9076b3407   686fcd72-5da5-4f8c-a740-88866e30b8da   in service    none      none          off        
+    oxp_fe4fdfba-3b6d-47d3-8612-1fb2390b650a/crypt/zone/oxz_crucible_768ab86c-d5d2-4734-a381-02df1032d5e9   d1bbe8aa-aeda-496b-93cd-f330f85da352   in service    none      none          off        
+    oxp_4fbd2fe0-2eac-41b8-8e8d-4fa46c3e8b6c/crypt/zone/oxz_crucible_abbf71e1-6568-42cf-9526-7e31549ba934   782adc3d-3a2f-400d-a6ce-531edc8cf546   in service    none      none          off        
+    oxp_789d607d-d196-428e-a988-f7886a327859/crypt/zone/oxz_crucible_e37d04f9-ed3f-4665-800e-b51ba7d5d306   6c55265b-7515-4259-adf1-ac07f847c2fb   in service    none      none          off        
+    oxp_33d48d85-751e-4982-b738-eae4d9a05f01/crypt/zone/oxz_crucible_e6c28c27-39d2-4aec-bf34-5d9f6b3cbd7f   803ed7a0-bb24-489f-8737-b01ff28e3278   in service    none      none          off        
+    oxp_77e45b5b-869f-4e78-8ce3-28bbe8cf37e9/crypt/zone/oxz_crucible_f19f884a-3e97-458d-b8fb-533882750cd6   b1044d62-0afd-473e-8719-ca3ecb57d801   in service    none      none          off        
+    oxp_60131a33-1f12-4dbb-9435-bdd368db1f51/crypt/zone/oxz_crucible_f54c359e-a980-4996-9462-25a548d96265   518e80f5-3074-44ec-8da3-ea64f3c0ad3e   in service    none      none          off        
+    oxp_4fbd2fe0-2eac-41b8-8e8d-4fa46c3e8b6c/crypt/zone/oxz_nexus_b539cea9-c37c-49ef-874f-170d898187b2      113c40a7-e9fd-492f-814e-528db4fd0e83   in service    none      none          off        
+    oxp_33d48d85-751e-4982-b738-eae4d9a05f01/crypt/zone/oxz_nexus_b854f752-383d-4e0b-8557-8c62d22ba994      537edbee-609e-40df-9a10-4c6f57c5f15f   in service    none      none          off        
+    oxp_60131a33-1f12-4dbb-9435-bdd368db1f51/crypt/zone/oxz_nexus_c5a0c592-319e-44df-9d00-1ddb1d5ad6aa      61e536fd-043c-4741-aed7-640d18d32b26   in service    none      none          off        
+    oxp_39ca2e23-4c38-4743-afe0-26b0380b27db/crypt/zone/oxz_nexus_cab211e1-3ab1-475f-81fa-984748044d8c      92f259d0-cda4-44e4-bb22-8b82d025d502   in service    none      none          off        
+    oxp_33d48d85-751e-4982-b738-eae4d9a05f01/crypt/zone/oxz_ntp_706286e2-8b09-42ff-9841-eaef65635eee        617a44e3-250b-4db1-a8e7-e42da46a0a0f   in service    none      none          off        
+    oxp_33d48d85-751e-4982-b738-eae4d9a05f01/crypt/debug                                                    856e98db-f5c6-4cbd-a8ad-c02f59f207d7   in service    100 GiB   none          gzip-9     
+    oxp_39ca2e23-4c38-4743-afe0-26b0380b27db/crypt/debug                                                    f14ef549-31db-4fae-a540-3a50f0fba233   in service    100 GiB   none          gzip-9     
+    oxp_4fbd2fe0-2eac-41b8-8e8d-4fa46c3e8b6c/crypt/debug                                                    e44949f2-403b-4944-b966-de77d4b9365c   in service    100 GiB   none          gzip-9     
+    oxp_60131a33-1f12-4dbb-9435-bdd368db1f51/crypt/debug                                                    425255d5-c1e8-44eb-855f-fe1770e83362   in service    100 GiB   none          gzip-9     
+    oxp_77e45b5b-869f-4e78-8ce3-28bbe8cf37e9/crypt/debug                                                    dc613555-a790-45af-9af4-0127d376f3c6   in service    100 GiB   none          gzip-9     
+    oxp_789d607d-d196-428e-a988-f7886a327859/crypt/debug                                                    4f359243-9639-431f-a0d1-5b2f2d6b5b0d   in service    100 GiB   none          gzip-9     
+    oxp_b104b94c-2197-4e76-bfbd-6f966bd5af66/crypt/debug                                                    1315d3d7-e347-4e68-8381-8c010be44ef0   in service    100 GiB   none          gzip-9     
+    oxp_cd62306a-aedf-47e8-93d5-92a358d64c7b/crypt/debug                                                    0e8321af-4634-4d31-aa79-145f8e171674   in service    100 GiB   none          gzip-9     
+    oxp_f1693454-aac1-4265-b8a0-4e9f3f41c7b3/crypt/debug                                                    5a0f4402-7d87-4b6b-b4d2-72f48000627c   in service    100 GiB   none          gzip-9     
+    oxp_fe4fdfba-3b6d-47d3-8612-1fb2390b650a/crypt/debug                                                    a2120fee-01bd-4f49-8c58-720384b1cbde   in service    100 GiB   none          gzip-9     
 
 
     omicron zones at generation 3:
@@ -228,56 +228,56 @@ to:   blueprint 9f71f5d3-a272-4382-9154-6ea2e171a6c6
 
 
     datasets at generation 2:
-    -----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
-    dataset name                                                                                                   dataset uuid                           quota     reservation   compression
-    -----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
-    oxp_13e6503b-5300-4ccd-abc4-c1512b435929/crucible                                                              01b78855-bc58-45bd-937e-49221a71b875   none      none          off        
-    oxp_44cdb6f2-fa6c-4b69-bab2-3ae4e1ec4b34/crucible                                                              99ddb9cf-a52c-4b59-884e-dea52e6b4f5d   none      none          off        
-    oxp_4de5fc8e-0e41-4ab9-ba12-2dc63882c96a/crucible                                                              354e3bc2-e6c8-49c0-bf1d-c136e499037c   none      none          off        
-    oxp_51564e7a-d69f-4942-bcfe-330224633ca6/crucible                                                              7f36c891-2cf8-4e94-b12a-24199b83462b   none      none          off        
-    oxp_5ca23cb3-cc90-41c5-a474-01898cdd0796/crucible                                                              8dd12603-6cfc-42dd-8912-2a16cb7a748d   none      none          off        
-    oxp_6a23a532-0712-4a8d-be9b-e8c17e97aa4b/crucible                                                              8ff2aecd-a1e8-47bd-8001-97c3e5efb99b   none      none          off        
-    oxp_6f1a330e-e8d4-4c09-97fc-8918b69b2a3c/crucible                                                              dab52576-17e4-4bf8-b87e-c49983a388c2   none      none          off        
-    oxp_7113d104-fb55-4299-bf53-b3c59d258e44/crucible                                                              d2c5b427-f956-4cd1-b174-6caca3685e6f   none      none          off        
-    oxp_8c10be49-3a66-40d4-a082-64d09d916f14/crucible                                                              e2e73bed-32f9-4111-803b-561cbd7faa1a   none      none          off        
-    oxp_d1ebfd7b-3842-4ad7-be31-2b9c031209a9/crucible                                                              5ba5e79d-0a13-41e5-b4d2-6c7cb468cb26   none      none          off        
-    oxp_13e6503b-5300-4ccd-abc4-c1512b435929/crypt/clickhouse                                                      37aac368-1b57-4934-b771-5802ae6d6606   none      none          off        
-    oxp_13e6503b-5300-4ccd-abc4-c1512b435929/crypt/internal_dns                                                    2f276f3f-ad8c-458e-bb62-03f5ec7643f3   none      none          off        
-    oxp_13e6503b-5300-4ccd-abc4-c1512b435929/crypt/zone                                                            a8381430-0bf6-49fd-8e5a-4e7c7eb4edf4   none      none          off        
-    oxp_44cdb6f2-fa6c-4b69-bab2-3ae4e1ec4b34/crypt/zone                                                            34fb7c7c-17c2-4cbb-af27-12b693965a4b   none      none          off        
-    oxp_4de5fc8e-0e41-4ab9-ba12-2dc63882c96a/crypt/zone                                                            a6f2fa57-1161-4b49-b591-2a9cd5a992f3   none      none          off        
-    oxp_51564e7a-d69f-4942-bcfe-330224633ca6/crypt/zone                                                            df22d065-beb6-45e4-984e-874dfdd3b285   none      none          off        
-    oxp_5ca23cb3-cc90-41c5-a474-01898cdd0796/crypt/zone                                                            59656ee4-d86f-49ff-b4b8-39e1021642f4   none      none          off        
-    oxp_6a23a532-0712-4a8d-be9b-e8c17e97aa4b/crypt/zone                                                            ea5ee557-cc4e-4a9b-87a7-7bb9b30589da   none      none          off        
-    oxp_6f1a330e-e8d4-4c09-97fc-8918b69b2a3c/crypt/zone                                                            5b0f2d79-6120-4b28-8fd6-919a121f5875   none      none          off        
-    oxp_7113d104-fb55-4299-bf53-b3c59d258e44/crypt/zone                                                            dd56b58b-871e-4f55-bcf5-0bd4e8184761   none      none          off        
-    oxp_8c10be49-3a66-40d4-a082-64d09d916f14/crypt/zone                                                            bafeb8db-cb8e-45fc-8030-3a85a26e2feb   none      none          off        
-    oxp_d1ebfd7b-3842-4ad7-be31-2b9c031209a9/crypt/zone                                                            b567319c-bb7a-4ac0-a95b-20bd88c26579   none      none          off        
-    oxp_13e6503b-5300-4ccd-abc4-c1512b435929/crypt/zone/oxz_clickhouse_5fbb489a-141d-4de2-86c4-4fd7b9d9f315        648fecf4-8ce6-4bce-9020-789057c92f95   none      none          off        
-    oxp_13e6503b-5300-4ccd-abc4-c1512b435929/crypt/zone/oxz_crucible_0ce2b998-f5ad-4dc5-b2ec-5250a308506d          4fe9bcd8-399f-444e-aa01-f8cb285de102   none      none          off        
-    oxp_7113d104-fb55-4299-bf53-b3c59d258e44/crypt/zone/oxz_crucible_0e8e9f2d-291d-47fc-ba0f-84cb50e713fd          ff5a6a51-2797-4016-903f-69ec69e59ef9   none      none          off        
-    oxp_51564e7a-d69f-4942-bcfe-330224633ca6/crypt/zone/oxz_crucible_11fc3b08-2470-4f1b-9187-acff1fc4c5ea          32b45c55-cc53-4635-ae2b-559821b409fe   none      none          off        
-    oxp_6f1a330e-e8d4-4c09-97fc-8918b69b2a3c/crypt/zone/oxz_crucible_673ecd68-d12a-46d9-9126-0a6be6245f84          0377cfc0-2bf6-4906-87f7-031121797594   none      none          off        
-    oxp_6a23a532-0712-4a8d-be9b-e8c17e97aa4b/crypt/zone/oxz_crucible_966c4f15-0aa8-4bef-95e4-49d686cffdfc          9ef1c45c-753a-4ecf-9145-72889ece2ad2   none      none          off        
-    oxp_8c10be49-3a66-40d4-a082-64d09d916f14/crypt/zone/oxz_crucible_979a7b5b-81a5-49bc-82e5-d88b6eaf7d96          b075b63e-f072-4f35-86d1-a81e50065994   none      none          off        
-    oxp_5ca23cb3-cc90-41c5-a474-01898cdd0796/crypt/zone/oxz_crucible_b6beadb1-351b-461d-a887-e7641d976a9e          9d2477db-7dea-4e19-b563-60a18a659cca   none      none          off        
-    oxp_4de5fc8e-0e41-4ab9-ba12-2dc63882c96a/crypt/zone/oxz_crucible_cf7add30-1c49-4d49-a2d2-1c46a60cd884          3b71883e-8704-468e-96fa-7b4fd85d37e8   none      none          off        
-    oxp_d1ebfd7b-3842-4ad7-be31-2b9c031209a9/crypt/zone/oxz_crucible_d0d4a23e-45fa-4f80-9bdf-a348de3f7b8f          5888130a-54bf-4358-bb1b-099347648757   none      none          off        
-    oxp_44cdb6f2-fa6c-4b69-bab2-3ae4e1ec4b34/crypt/zone/oxz_crucible_e46d1442-2a63-44e3-a6aa-e88150b85d92          c4739101-dd65-4649-8e99-e221dc9ce93e   none      none          off        
-    oxp_13e6503b-5300-4ccd-abc4-c1512b435929/crypt/zone/oxz_crucible_pantry_45b6f382-3590-4281-b65d-083ba7aff2d3   f07a8f89-a4e1-4c71-b223-a4c09af0e443   none      none          off        
-    oxp_13e6503b-5300-4ccd-abc4-c1512b435929/crypt/zone/oxz_internal_dns_4fd906d8-94cd-44b3-ad5e-34b4d193bd3c      3681f68d-2840-47be-8bb7-8c7354daf8a7   none      none          off        
-    oxp_13e6503b-5300-4ccd-abc4-c1512b435929/crypt/zone/oxz_nexus_88602518-f176-49a1-af12-02fac36214c3             99c53b55-b716-414d-b8ff-a9d56bd9cd6c   none      none          off        
-    oxp_13e6503b-5300-4ccd-abc4-c1512b435929/crypt/zone/oxz_ntp_b0a48e5a-e2bd-46b2-9bc6-8babbbdc0adc               ed9b8ac9-88f4-46fa-8ecf-5a7534d4f020   none      none          off        
-    oxp_13e6503b-5300-4ccd-abc4-c1512b435929/crypt/debug                                                           97bc5b54-dd6a-4b98-b9e0-081657a3db89   100 GiB   none          gzip-9     
-    oxp_44cdb6f2-fa6c-4b69-bab2-3ae4e1ec4b34/crypt/debug                                                           8d054703-b940-4395-8c46-2ff519f5133a   100 GiB   none          gzip-9     
-    oxp_4de5fc8e-0e41-4ab9-ba12-2dc63882c96a/crypt/debug                                                           bb388082-2d09-4a4b-bb22-ee3f4b7b5025   100 GiB   none          gzip-9     
-    oxp_51564e7a-d69f-4942-bcfe-330224633ca6/crypt/debug                                                           fe2005ba-7f3d-4fc3-b324-09a258fc4a4b   100 GiB   none          gzip-9     
-    oxp_5ca23cb3-cc90-41c5-a474-01898cdd0796/crypt/debug                                                           e20df72b-3d75-48ad-8349-3e39cc886886   100 GiB   none          gzip-9     
-    oxp_6a23a532-0712-4a8d-be9b-e8c17e97aa4b/crypt/debug                                                           cf2b245f-c667-49a9-bbc2-ada9a51e63f0   100 GiB   none          gzip-9     
-    oxp_6f1a330e-e8d4-4c09-97fc-8918b69b2a3c/crypt/debug                                                           1c606d5c-ce8c-42e8-9359-d2e0fe31d525   100 GiB   none          gzip-9     
-    oxp_7113d104-fb55-4299-bf53-b3c59d258e44/crypt/debug                                                           1f3f9209-c380-40ab-a2f0-16ecddb6d4a8   100 GiB   none          gzip-9     
-    oxp_8c10be49-3a66-40d4-a082-64d09d916f14/crypt/debug                                                           89b81a7c-3bc3-455d-97e3-75067de991d5   100 GiB   none          gzip-9     
-    oxp_d1ebfd7b-3842-4ad7-be31-2b9c031209a9/crypt/debug                                                           1e581e94-bb9d-4514-8dbb-3a882e342d1b   100 GiB   none          gzip-9     
+    -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
+    dataset name                                                                                                   dataset id                             disposition   quota     reservation   compression
+    -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
+    oxp_13e6503b-5300-4ccd-abc4-c1512b435929/crucible                                                              01b78855-bc58-45bd-937e-49221a71b875   in service    none      none          off        
+    oxp_44cdb6f2-fa6c-4b69-bab2-3ae4e1ec4b34/crucible                                                              99ddb9cf-a52c-4b59-884e-dea52e6b4f5d   in service    none      none          off        
+    oxp_4de5fc8e-0e41-4ab9-ba12-2dc63882c96a/crucible                                                              354e3bc2-e6c8-49c0-bf1d-c136e499037c   in service    none      none          off        
+    oxp_51564e7a-d69f-4942-bcfe-330224633ca6/crucible                                                              7f36c891-2cf8-4e94-b12a-24199b83462b   in service    none      none          off        
+    oxp_5ca23cb3-cc90-41c5-a474-01898cdd0796/crucible                                                              8dd12603-6cfc-42dd-8912-2a16cb7a748d   in service    none      none          off        
+    oxp_6a23a532-0712-4a8d-be9b-e8c17e97aa4b/crucible                                                              8ff2aecd-a1e8-47bd-8001-97c3e5efb99b   in service    none      none          off        
+    oxp_6f1a330e-e8d4-4c09-97fc-8918b69b2a3c/crucible                                                              dab52576-17e4-4bf8-b87e-c49983a388c2   in service    none      none          off        
+    oxp_7113d104-fb55-4299-bf53-b3c59d258e44/crucible                                                              d2c5b427-f956-4cd1-b174-6caca3685e6f   in service    none      none          off        
+    oxp_8c10be49-3a66-40d4-a082-64d09d916f14/crucible                                                              e2e73bed-32f9-4111-803b-561cbd7faa1a   in service    none      none          off        
+    oxp_d1ebfd7b-3842-4ad7-be31-2b9c031209a9/crucible                                                              5ba5e79d-0a13-41e5-b4d2-6c7cb468cb26   in service    none      none          off        
+    oxp_13e6503b-5300-4ccd-abc4-c1512b435929/crypt/clickhouse                                                      37aac368-1b57-4934-b771-5802ae6d6606   in service    none      none          off        
+    oxp_13e6503b-5300-4ccd-abc4-c1512b435929/crypt/internal_dns                                                    2f276f3f-ad8c-458e-bb62-03f5ec7643f3   in service    none      none          off        
+    oxp_13e6503b-5300-4ccd-abc4-c1512b435929/crypt/zone                                                            a8381430-0bf6-49fd-8e5a-4e7c7eb4edf4   in service    none      none          off        
+    oxp_44cdb6f2-fa6c-4b69-bab2-3ae4e1ec4b34/crypt/zone                                                            34fb7c7c-17c2-4cbb-af27-12b693965a4b   in service    none      none          off        
+    oxp_4de5fc8e-0e41-4ab9-ba12-2dc63882c96a/crypt/zone                                                            a6f2fa57-1161-4b49-b591-2a9cd5a992f3   in service    none      none          off        
+    oxp_51564e7a-d69f-4942-bcfe-330224633ca6/crypt/zone                                                            df22d065-beb6-45e4-984e-874dfdd3b285   in service    none      none          off        
+    oxp_5ca23cb3-cc90-41c5-a474-01898cdd0796/crypt/zone                                                            59656ee4-d86f-49ff-b4b8-39e1021642f4   in service    none      none          off        
+    oxp_6a23a532-0712-4a8d-be9b-e8c17e97aa4b/crypt/zone                                                            ea5ee557-cc4e-4a9b-87a7-7bb9b30589da   in service    none      none          off        
+    oxp_6f1a330e-e8d4-4c09-97fc-8918b69b2a3c/crypt/zone                                                            5b0f2d79-6120-4b28-8fd6-919a121f5875   in service    none      none          off        
+    oxp_7113d104-fb55-4299-bf53-b3c59d258e44/crypt/zone                                                            dd56b58b-871e-4f55-bcf5-0bd4e8184761   in service    none      none          off        
+    oxp_8c10be49-3a66-40d4-a082-64d09d916f14/crypt/zone                                                            bafeb8db-cb8e-45fc-8030-3a85a26e2feb   in service    none      none          off        
+    oxp_d1ebfd7b-3842-4ad7-be31-2b9c031209a9/crypt/zone                                                            b567319c-bb7a-4ac0-a95b-20bd88c26579   in service    none      none          off        
+    oxp_13e6503b-5300-4ccd-abc4-c1512b435929/crypt/zone/oxz_clickhouse_5fbb489a-141d-4de2-86c4-4fd7b9d9f315        648fecf4-8ce6-4bce-9020-789057c92f95   in service    none      none          off        
+    oxp_13e6503b-5300-4ccd-abc4-c1512b435929/crypt/zone/oxz_crucible_0ce2b998-f5ad-4dc5-b2ec-5250a308506d          4fe9bcd8-399f-444e-aa01-f8cb285de102   in service    none      none          off        
+    oxp_7113d104-fb55-4299-bf53-b3c59d258e44/crypt/zone/oxz_crucible_0e8e9f2d-291d-47fc-ba0f-84cb50e713fd          ff5a6a51-2797-4016-903f-69ec69e59ef9   in service    none      none          off        
+    oxp_51564e7a-d69f-4942-bcfe-330224633ca6/crypt/zone/oxz_crucible_11fc3b08-2470-4f1b-9187-acff1fc4c5ea          32b45c55-cc53-4635-ae2b-559821b409fe   in service    none      none          off        
+    oxp_6f1a330e-e8d4-4c09-97fc-8918b69b2a3c/crypt/zone/oxz_crucible_673ecd68-d12a-46d9-9126-0a6be6245f84          0377cfc0-2bf6-4906-87f7-031121797594   in service    none      none          off        
+    oxp_6a23a532-0712-4a8d-be9b-e8c17e97aa4b/crypt/zone/oxz_crucible_966c4f15-0aa8-4bef-95e4-49d686cffdfc          9ef1c45c-753a-4ecf-9145-72889ece2ad2   in service    none      none          off        
+    oxp_8c10be49-3a66-40d4-a082-64d09d916f14/crypt/zone/oxz_crucible_979a7b5b-81a5-49bc-82e5-d88b6eaf7d96          b075b63e-f072-4f35-86d1-a81e50065994   in service    none      none          off        
+    oxp_5ca23cb3-cc90-41c5-a474-01898cdd0796/crypt/zone/oxz_crucible_b6beadb1-351b-461d-a887-e7641d976a9e          9d2477db-7dea-4e19-b563-60a18a659cca   in service    none      none          off        
+    oxp_4de5fc8e-0e41-4ab9-ba12-2dc63882c96a/crypt/zone/oxz_crucible_cf7add30-1c49-4d49-a2d2-1c46a60cd884          3b71883e-8704-468e-96fa-7b4fd85d37e8   in service    none      none          off        
+    oxp_d1ebfd7b-3842-4ad7-be31-2b9c031209a9/crypt/zone/oxz_crucible_d0d4a23e-45fa-4f80-9bdf-a348de3f7b8f          5888130a-54bf-4358-bb1b-099347648757   in service    none      none          off        
+    oxp_44cdb6f2-fa6c-4b69-bab2-3ae4e1ec4b34/crypt/zone/oxz_crucible_e46d1442-2a63-44e3-a6aa-e88150b85d92          c4739101-dd65-4649-8e99-e221dc9ce93e   in service    none      none          off        
+    oxp_13e6503b-5300-4ccd-abc4-c1512b435929/crypt/zone/oxz_crucible_pantry_45b6f382-3590-4281-b65d-083ba7aff2d3   f07a8f89-a4e1-4c71-b223-a4c09af0e443   in service    none      none          off        
+    oxp_13e6503b-5300-4ccd-abc4-c1512b435929/crypt/zone/oxz_internal_dns_4fd906d8-94cd-44b3-ad5e-34b4d193bd3c      3681f68d-2840-47be-8bb7-8c7354daf8a7   in service    none      none          off        
+    oxp_13e6503b-5300-4ccd-abc4-c1512b435929/crypt/zone/oxz_nexus_88602518-f176-49a1-af12-02fac36214c3             99c53b55-b716-414d-b8ff-a9d56bd9cd6c   in service    none      none          off        
+    oxp_13e6503b-5300-4ccd-abc4-c1512b435929/crypt/zone/oxz_ntp_b0a48e5a-e2bd-46b2-9bc6-8babbbdc0adc               ed9b8ac9-88f4-46fa-8ecf-5a7534d4f020   in service    none      none          off        
+    oxp_13e6503b-5300-4ccd-abc4-c1512b435929/crypt/debug                                                           97bc5b54-dd6a-4b98-b9e0-081657a3db89   in service    100 GiB   none          gzip-9     
+    oxp_44cdb6f2-fa6c-4b69-bab2-3ae4e1ec4b34/crypt/debug                                                           8d054703-b940-4395-8c46-2ff519f5133a   in service    100 GiB   none          gzip-9     
+    oxp_4de5fc8e-0e41-4ab9-ba12-2dc63882c96a/crypt/debug                                                           bb388082-2d09-4a4b-bb22-ee3f4b7b5025   in service    100 GiB   none          gzip-9     
+    oxp_51564e7a-d69f-4942-bcfe-330224633ca6/crypt/debug                                                           fe2005ba-7f3d-4fc3-b324-09a258fc4a4b   in service    100 GiB   none          gzip-9     
+    oxp_5ca23cb3-cc90-41c5-a474-01898cdd0796/crypt/debug                                                           e20df72b-3d75-48ad-8349-3e39cc886886   in service    100 GiB   none          gzip-9     
+    oxp_6a23a532-0712-4a8d-be9b-e8c17e97aa4b/crypt/debug                                                           cf2b245f-c667-49a9-bbc2-ada9a51e63f0   in service    100 GiB   none          gzip-9     
+    oxp_6f1a330e-e8d4-4c09-97fc-8918b69b2a3c/crypt/debug                                                           1c606d5c-ce8c-42e8-9359-d2e0fe31d525   in service    100 GiB   none          gzip-9     
+    oxp_7113d104-fb55-4299-bf53-b3c59d258e44/crypt/debug                                                           1f3f9209-c380-40ab-a2f0-16ecddb6d4a8   in service    100 GiB   none          gzip-9     
+    oxp_8c10be49-3a66-40d4-a082-64d09d916f14/crypt/debug                                                           89b81a7c-3bc3-455d-97e3-75067de991d5   in service    100 GiB   none          gzip-9     
+    oxp_d1ebfd7b-3842-4ad7-be31-2b9c031209a9/crypt/debug                                                           1e581e94-bb9d-4514-8dbb-3a882e342d1b   in service    100 GiB   none          gzip-9     
 
 
     omicron zones at generation 2:
@@ -322,7 +322,7 @@ to:   blueprint 9f71f5d3-a272-4382-9154-6ea2e171a6c6
 -   nexus             533416e6-d0bd-482d-b592-29346c8a3471   expunged      fd00:1122:3344:103::22
 
 
-ERRORS:
+ZONE ERRORS:
 
   sled 2d1cb4f2-cf44-40fc-b118-85036eb732a9
 

--- a/nexus/types/src/deployment.rs
+++ b/nexus/types/src/deployment.rs
@@ -1014,6 +1014,17 @@ impl BlueprintDatasetDisposition {
     }
 }
 
+impl fmt::Display for BlueprintDatasetDisposition {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self {
+            // Neither `write!(f, "...")` nor `f.write_str("...")` obey fill
+            // and alignment (used above), but this does.
+            BlueprintDatasetDisposition::InService => "in service".fmt(f),
+            BlueprintDatasetDisposition::Expunged => "expunged".fmt(f),
+        }
+    }
+}
+
 /// Information about a dataset as recorded in a blueprint
 #[derive(
     Debug,
@@ -1028,9 +1039,7 @@ impl BlueprintDatasetDisposition {
     Diffable,
 )]
 pub struct BlueprintDatasetConfig {
-    // TODO: Display this in diffs - leave for now, for backwards compat
     pub disposition: BlueprintDatasetDisposition,
-
     pub id: DatasetUuid,
     pub pool: ZpoolName,
     pub kind: DatasetKind,
@@ -1063,6 +1072,7 @@ impl BlueprintDatasetConfig {
         vec![
             DatasetName::new(self.pool.clone(), self.kind.clone()).full_name(),
             self.id.to_string(),
+            self.disposition.to_string(),
             unwrap_or_none(&self.quota),
             unwrap_or_none(&self.reservation),
             self.compression.to_string(),

--- a/nexus/types/src/deployment/blueprint_diff.rs
+++ b/nexus/types/src/deployment/blueprint_diff.rs
@@ -12,19 +12,20 @@ use super::blueprint_display::{
 };
 use super::{
     unwrap_or_none, zone_sort_key, BlueprintDatasetConfigDiff,
-    BlueprintDatasetsConfigDiff, BlueprintDiff, BlueprintMetadata,
-    BlueprintPhysicalDiskConfig, BlueprintPhysicalDisksConfigDiff,
-    BlueprintZoneConfigDiff, BlueprintZonesConfigDiff, ClickhouseClusterConfig,
+    BlueprintDatasetDisposition, BlueprintDatasetsConfigDiff, BlueprintDiff,
+    BlueprintMetadata, BlueprintPhysicalDiskConfig,
+    BlueprintPhysicalDisksConfigDiff, BlueprintZoneConfigDiff,
+    BlueprintZonesConfigDiff, ClickhouseClusterConfig,
     CockroachDbPreserveDowngrade,
 };
 use daft::Diffable;
 use nexus_sled_agent_shared::inventory::ZoneKind;
-use omicron_common::api::external::Generation;
-use omicron_common::disk::{DatasetName, DiskIdentity};
-use omicron_uuid_kinds::OmicronZoneUuid;
+use omicron_common::api::external::{ByteCount, Generation};
+use omicron_common::disk::{CompressionAlgorithm, DatasetName, DiskIdentity};
 use omicron_uuid_kinds::SledUuid;
+use omicron_uuid_kinds::{DatasetUuid, OmicronZoneUuid};
 use std::collections::{BTreeMap, BTreeSet};
-use std::fmt;
+use std::fmt::{self, Write as _};
 
 use crate::deployment::blueprint_display::BpClickhouseKeepersTableSchema;
 use crate::deployment::{
@@ -603,21 +604,18 @@ impl<'a> BlueprintDiffSummary<'a> {
     pub fn modified_datasets(
         &'a self,
         sled_id: &SledUuid,
-    ) -> Option<BpDiffDatasetsModified<'a>> {
+    ) -> Option<(BpDiffDatasetsModified, BpDiffDatasetErrors)> {
         // Check if the sled is modified and there are any modified datasets
         let datasets_cfg_diff =
             self.diff.blueprint_datasets.modified.get(sled_id)?;
         if datasets_cfg_diff.datasets.modified.is_empty() {
             return None;
         }
-        let mut datasets: Vec<_> =
-            datasets_cfg_diff.datasets.modified.values().collect();
-        datasets.sort_unstable_by_key(|d| (d.kind.before, d.pool.before));
-        Some(BpDiffDatasetsModified {
-            generation_before: *datasets_cfg_diff.generation.before,
-            generation_after: *datasets_cfg_diff.generation.after,
-            datasets,
-        })
+        Some(BpDiffDatasetsModified::new(
+            *datasets_cfg_diff.generation.before,
+            *datasets_cfg_diff.generation.after,
+            datasets_cfg_diff.datasets.modified.values(),
+        ))
     }
 }
 
@@ -796,8 +794,8 @@ impl BpTableData for BpDiffZonesModified {
     }
 }
 
-#[derive(Debug)]
 /// Errors arising from illegally modified zone fields
+#[derive(Debug)]
 pub struct BpDiffZoneErrors {
     pub generation_before: Generation,
     pub generation_after: Generation,
@@ -1048,14 +1046,147 @@ impl BpTableData for DiffDatasetsDetails {
     }
 }
 
+/// Properties of a dataset that may change from one blueprint to another.
+///
+/// Other properties of a dataset (e.g., its `pool`, `kind`, and `address`) are
+/// not expected to change, and we'll record an error if they do.
 #[derive(Debug)]
-pub struct BpDiffDatasetsModified<'a> {
-    pub generation_before: Generation,
-    pub generation_after: Generation,
-    pub datasets: Vec<&'a BlueprintDatasetConfigDiff<'a>>,
+pub struct ModifiableDatasetProperties {
+    pub disposition: BlueprintDatasetDisposition,
+    pub quota: Option<ByteCount>,
+    pub reservation: Option<ByteCount>,
+    pub compression: CompressionAlgorithm,
 }
 
-impl BpTableData for BpDiffDatasetsModified<'_> {
+/// Errors arising from illegally modified dataset fields
+#[derive(Debug)]
+pub struct BpDiffDatasetErrors {
+    pub generation_before: Generation,
+    pub generation_after: Generation,
+    pub errors: Vec<BpDiffDatasetError>,
+}
+
+#[derive(Debug)]
+pub struct BpDiffDatasetError {
+    pub dataset_id: DatasetUuid,
+    pub reason: String,
+}
+
+#[derive(Debug)]
+pub struct ModifiedDataset {
+    pub prior_properties: ModifiableDatasetProperties,
+    pub dataset: BlueprintDatasetConfig,
+}
+
+impl ModifiedDataset {
+    pub fn from_diff(
+        diff: &BlueprintDatasetConfigDiff,
+    ) -> Result<Self, BpDiffDatasetError> {
+        // Do we have any errors? If so, create a "reason" string.
+        let mut reason = String::new();
+        let BlueprintDatasetConfigDiff {
+            disposition,
+            id,
+            pool,
+            kind,
+            address,
+            quota,
+            reservation,
+            compression,
+        } = diff;
+
+        // If we're a "modified" dataset, we must have the same ID before and
+        // after. (Otherwise our "before" or "after" should've been recorded as
+        // removed/added.)
+        debug_assert_eq!(id.before, id.after);
+
+        let prior_properties = ModifiableDatasetProperties {
+            disposition: *disposition.before,
+            quota: *quota.before,
+            reservation: *reservation.before,
+            compression: *compression.before,
+        };
+        if pool.before != pool.after {
+            writeln!(
+                &mut reason,
+                "mismatched zpool: before: {}, after: {}",
+                pool.before, pool.after
+            )
+            .expect("write to String is infallible");
+        }
+        if kind.before != kind.after {
+            writeln!(
+                &mut reason,
+                "mismatched kind: before: {}, after: {}",
+                kind.before, kind.after
+            )
+            .expect("write to String is infallible");
+        }
+        if address.before != address.after {
+            writeln!(
+                &mut reason,
+                "mismatched address: before: {:?}, after: {:?}",
+                address.before, address.after
+            )
+            .expect("write to String is infallible");
+        }
+
+        if reason.is_empty() {
+            Ok(Self {
+                prior_properties,
+                dataset: BlueprintDatasetConfig {
+                    disposition: *disposition.after,
+                    id: *id.after,
+                    pool: pool.after.clone(),
+                    kind: kind.after.clone(),
+                    address: *address.after,
+                    quota: *quota.after,
+                    reservation: *reservation.after,
+                    compression: *compression.after,
+                },
+            })
+        } else {
+            Err(BpDiffDatasetError { dataset_id: *id.after, reason })
+        }
+    }
+}
+
+#[derive(Debug)]
+pub struct BpDiffDatasetsModified {
+    pub generation_before: Generation,
+    pub generation_after: Generation,
+    pub datasets: Vec<ModifiedDataset>,
+}
+
+impl BpDiffDatasetsModified {
+    pub fn new<'a>(
+        generation_before: Generation,
+        generation_after: Generation,
+        dataset_diffs: impl Iterator<Item = &'a BlueprintDatasetConfigDiff<'a>>,
+    ) -> (BpDiffDatasetsModified, BpDiffDatasetErrors) {
+        let mut datasets = vec![];
+        let mut errors = vec![];
+        for diff in dataset_diffs {
+            match ModifiedDataset::from_diff(diff) {
+                Ok(modified_zone) => datasets.push(modified_zone),
+                Err(error) => errors.push(error),
+            }
+        }
+        datasets.sort_unstable_by_key(|d| {
+            (d.dataset.kind.clone(), d.dataset.pool.clone())
+        });
+        (
+            BpDiffDatasetsModified {
+                generation_before,
+                generation_after,
+                datasets,
+            },
+            BpDiffDatasetErrors { generation_before, generation_after, errors },
+        )
+    }
+}
+
+impl BpTableData for BpDiffDatasetsModified {
     fn bp_generation(&self) -> BpGeneration {
         BpGeneration::Diff {
             before: Some(self.generation_before),
@@ -1064,55 +1195,60 @@ impl BpTableData for BpDiffDatasetsModified<'_> {
     }
 
     fn rows(&self, state: BpDiffState) -> impl Iterator<Item = BpTableRow> {
-        self.datasets.iter().map(move |&dataset| {
-            let mut columns = vec![];
+        self.datasets.iter().map(move |dataset| {
+            let ModifiableDatasetProperties {
+                disposition: before_disposition,
+                quota: before_quota,
+                reservation: before_reservation,
+                compression: before_compression,
+            } = &dataset.prior_properties;
 
-            // Dataset Name
-            let before = DatasetName::new(
-                dataset.pool.before.clone(),
-                dataset.kind.before.clone(),
+            BpTableRow::new(
+                state,
+                vec![
+                    BpTableColumn::value(
+                        DatasetName::new(
+                            dataset.dataset.pool.clone(),
+                            dataset.dataset.kind.clone(),
+                        )
+                        .full_name(),
+                    ),
+                    BpTableColumn::value(dataset.dataset.id.to_string()),
+                    BpTableColumn::new(
+                        before_disposition.to_string(),
+                        dataset.dataset.disposition.to_string(),
+                    ),
+                    BpTableColumn::new(
+                        unwrap_or_none(&before_quota),
+                        unwrap_or_none(&dataset.dataset.quota),
+                    ),
+                    BpTableColumn::new(
+                        unwrap_or_none(&before_reservation),
+                        unwrap_or_none(&dataset.dataset.reservation),
+                    ),
+                    BpTableColumn::new(
+                        before_compression.to_string(),
+                        dataset.dataset.compression.to_string(),
+                    ),
+                ],
             )
-            .full_name();
-            let after = DatasetName::new(
-                dataset.pool.after.clone(),
-                dataset.kind.after.clone(),
-            )
-            .full_name();
-            columns.push(BpTableColumn::new(before, after));
-
-            // IDs don't change
-            columns.push(BpTableColumn::Value(dataset.id.before.to_string()));
-
-            // Quota
-            let before = unwrap_or_none(dataset.quota.before);
-            let after = unwrap_or_none(dataset.quota.after);
-            columns.push(BpTableColumn::new(before, after));
-
-            // Reservation
-            let before = unwrap_or_none(dataset.reservation.before);
-            let after = unwrap_or_none(dataset.reservation.after);
-            columns.push(BpTableColumn::new(before, after));
-
-            // Compression
-            let before = dataset.compression.before.to_string();
-            let after = dataset.compression.after.to_string();
-            columns.push(BpTableColumn::new(before, after));
-
-            BpTableRow::new(state, columns)
         })
     }
 }
 
 #[derive(Debug, Default)]
-pub struct BpDiffDatasets<'a> {
+pub struct BpDiffDatasets {
     pub added: BTreeMap<SledUuid, DiffDatasetsDetails>,
     pub removed: BTreeMap<SledUuid, DiffDatasetsDetails>,
-    pub modified: BTreeMap<SledUuid, BpDiffDatasetsModified<'a>>,
+    pub modified: BTreeMap<SledUuid, BpDiffDatasetsModified>,
     pub unchanged: BTreeMap<SledUuid, DiffDatasetsDetails>,
+    pub errors: BTreeMap<SledUuid, BpDiffDatasetErrors>,
 }
 
-impl<'a> BpDiffDatasets<'a> {
-    pub fn from_diff_summary(summary: &'a BlueprintDiffSummary<'a>) -> Self {
+impl BpDiffDatasets {
+    pub fn from_diff_summary<'a>(
+        summary: &'a BlueprintDiffSummary<'a>,
+    ) -> Self {
         let mut diffs = BpDiffDatasets::default();
         for sled_id in &summary.all_sleds {
             if let Some(added) = summary.added_datasets(sled_id) {
@@ -1124,8 +1260,12 @@ impl<'a> BpDiffDatasets<'a> {
             if let Some(unchanged) = summary.unchanged_datasets(sled_id) {
                 diffs.unchanged.insert(*sled_id, unchanged);
             }
-            if let Some(modified) = summary.modified_datasets(sled_id) {
+            if let Some((modified, errors)) = summary.modified_datasets(sled_id)
+            {
                 diffs.modified.insert(*sled_id, modified);
+                if !errors.errors.is_empty() {
+                    diffs.errors.insert(*sled_id, errors);
+                }
             }
         }
         diffs
@@ -1565,7 +1705,7 @@ pub struct BlueprintDiffDisplay<'diff> {
     after_meta: BlueprintMetadata,
     zones: BpDiffZones,
     disks: BpDiffPhysicalDisks,
-    datasets: BpDiffDatasets<'diff>,
+    datasets: BpDiffDatasets,
 }
 
 impl<'diff> BlueprintDiffDisplay<'diff> {
@@ -1820,7 +1960,7 @@ impl fmt::Display for BlueprintDiffDisplay<'_> {
 
         // Write out zone errors.
         if !self.zones.errors.is_empty() {
-            writeln!(f, "ERRORS:")?;
+            writeln!(f, "ZONE ERRORS:")?;
             for (sled_id, errors) in &self.zones.errors {
                 writeln!(f, "\n  sled {sled_id}\n")?;
                 writeln!(
@@ -1831,6 +1971,24 @@ impl fmt::Display for BlueprintDiffDisplay<'_> {
 
                 for err in &errors.errors {
                     writeln!(f, "      zone id: {}", err.zone_before_id)?;
+                    writeln!(f, "      reason: {}", err.reason)?;
+                }
+            }
+        }
+
+        // Write out dataset errors.
+        if !self.datasets.errors.is_empty() {
+            writeln!(f, "DATASET ERRORS:")?;
+            for (sled_id, errors) in &self.datasets.errors {
+                writeln!(f, "\n  sled {sled_id}\n")?;
+                writeln!(
+                    f,
+                    "    dataset diff errors: before gen {}, after gen {}\n",
+                    errors.generation_before, errors.generation_after
+                )?;
+
+                for err in &errors.errors {
+                    writeln!(f, "      dataset id: {}", err.dataset_id)?;
                     writeln!(f, "      reason: {}", err.reason)?;
                 }
             }

--- a/nexus/types/src/deployment/blueprint_display.rs
+++ b/nexus/types/src/deployment/blueprint_display.rs
@@ -122,6 +122,7 @@ impl fmt::Display for BpGeneration {
     }
 }
 
+#[derive(Debug)]
 pub enum BpTableColumn {
     Value(String),
     Diff { before: String, after: String },
@@ -343,7 +344,14 @@ impl BpTableSchema for BpDatasetsTableSchema {
     }
 
     fn column_names(&self) -> &'static [&'static str] {
-        &["dataset name", "dataset uuid", "quota", "reservation", "compression"]
+        &[
+            "dataset name",
+            "dataset id",
+            "disposition",
+            "quota",
+            "reservation",
+            "compression",
+        ]
     }
 }
 


### PR DESCRIPTION
Fixes #7302, I think! (The issue is titled generically, but the specifics are about dataset diffs, which are fixed by this PR.)

The diff is large because of expectorate. The code changes are _heavily_ modified after our existing `ModifiedZone` / zone error stuff (largely "copy, paste, s/zone/dataset/").