### PR TITLE
Show more information in omdb db snapshots

### DIFF
--- a/dev-tools/omdb/src/bin/omdb/db.rs
+++ b/dev-tools/omdb/src/bin/omdb/db.rs
@@ -1486,7 +1486,7 @@ async fn cmd_db_disk_info(
     struct DownstairsRow {
         host_serial: String,
         region: String,
-        zone: String,
+        dataset: String,
         physical_disk: String,
     }
 
@@ -1611,7 +1611,7 @@ async fn cmd_db_disk_info(
         rows.push(DownstairsRow {
             host_serial: my_sled.serial_number().to_string(),
             region: region.id().to_string(),
-            zone: format!("oxz_crucible_{}", dataset.id()),
+            dataset: dataset.id().to_string(),
             physical_disk: my_zpool.physical_disk_id.to_string(),
         });
     }
@@ -1647,7 +1647,7 @@ async fn get_and_display_vcr(
     for v in volumes {
         match serde_json::from_str(&v.data()) {
             Ok(vcr) => {
-                println!("\nVCR from volume ID {volume_id}");
+                println!("VCR from volume ID {volume_id}");
                 print_vcr(vcr, 0);
             }
             Err(e) => {
@@ -2048,12 +2048,12 @@ async fn cmd_db_snapshot_info(
     struct DownstairsRow {
         host_serial: String,
         region: String,
-        zone: String,
+        dataset: String,
         physical_disk: String,
     }
 
     use db::schema::snapshot::dsl as snapshot_dsl;
-    let snapshots = snapshot_dsl::snapshot
+    let mut snapshots = snapshot_dsl::snapshot
         .filter(snapshot_dsl::id.eq(args.uuid))
         .limit(1)
         .select(Snapshot::as_select())
@@ -2061,32 +2061,76 @@ async fn cmd_db_snapshot_info(
         .await
         .context("loading requested snapshot")?;
 
-    let mut dest_volume_ids = Vec::new();
-    let mut source_volume_ids = Vec::new();
-    let rows = snapshots.into_iter().map(|snapshot| {
-        dest_volume_ids.push(snapshot.destination_volume_id());
-        source_volume_ids.push(snapshot.volume_id());
-        SnapshotRow::from(snapshot)
-    });
-    if rows.len() == 0 {
-        bail!("No snapshout with UUID: {} found", args.uuid);
+    if snapshots.is_empty() {
+        bail!("No snapshot with UUID: {} found", args.uuid);
+    }
+    let snap = snapshots.pop().expect("Found more that one snapshot");
+
+    let dest_vol_id = snap.destination_volume_id;
+    let source_vol_id = snap.volume_id;
+    let snap = SnapshotRow::from(snap);
+
+    println!("                 Name: {}", snap.snap_name);
+    println!("                   id: {}", snap.id);
+    println!("                state: {}", snap.state);
+    println!("                 size: {}", snap.size);
+    println!("       source_disk_id: {}", snap.source_disk_id);
+    println!("     source_volume_id: {}", snap.source_volume_id);
+    println!("destination_volume_id: {}", snap.destination_volume_id);
+
+    use db::schema::region_snapshot::dsl as region_snapshot_dsl;
+    let region_snapshots = region_snapshot_dsl::region_snapshot
+        .filter(region_snapshot_dsl::snapshot_id.eq(args.uuid))
+        .limit(3)
+        .select(RegionSnapshot::as_select())
+        .load_async(&*datastore.pool_connection_for_tests().await?)
+        .await
+        .context("loading region snapshots")?;
+
+    println!();
+    if region_snapshots.is_empty() {
+        println!("No region snapshot info found");
+    } else {
+        // The row describing the region_snapshot.
+        #[derive(Tabled)]
+        #[tabled(rename_all = "SCREAMING_SNAKE_CASE")]
+        struct RegionSnapshotRow {
+            dataset_id: String,
+            region_id: String,
+            snapshot_id: String,
+            snapshot_addr: String,
+            volume_references: String,
+        }
+        let mut rsnap = Vec::new();
+
+        // From each region snapshot:
+        // Collect the snapshot IDs for later use.
+        // Display the region snapshot rows.
+        let mut snapshot_ids = HashSet::new();
+        for rs in region_snapshots {
+            snapshot_ids.insert(rs.snapshot_id);
+            let rs = RegionSnapshotRow {
+                dataset_id: rs.dataset_id.to_string(),
+                region_id: rs.region_id.to_string(),
+                snapshot_id: rs.snapshot_id.to_string(),
+                snapshot_addr: rs.snapshot_addr.to_string(),
+                volume_references: rs.volume_references.to_string(),
+            };
+            rsnap.push(rs);
+        }
+        let table = tabled::Table::new(rsnap)
+            .with(tabled::settings::Style::empty())
+            .with(tabled::settings::Padding::new(0, 1, 0, 0))
+            .to_string();
+
+        println!("REGION SNAPSHOT INFO:");
+        println!("{}", table);
     }
 
-    let table = tabled::Table::new(rows)
-        .with(tabled::settings::Style::empty())
-        .with(tabled::settings::Padding::new(0, 1, 0, 0))
-        .to_string();
-
-    println!("{}", table);
-
-    println!("SOURCE VOLUME VCR:");
-    for vol in source_volume_ids {
-        get_and_display_vcr(vol, datastore).await?;
-    }
-    for vol_id in dest_volume_ids {
-        // Get the dataset backing this volume.
-        let regions = datastore.get_allocated_regions(vol_id).await?;
-
+    let regions = datastore.get_allocated_regions(source_vol_id.into()).await?;
+    if regions.is_empty() {
+        println!("\nNo source region info found");
+    } else {
         let mut rows = Vec::with_capacity(3);
         for (dataset, region) in regions {
             let my_pool_id = dataset.pool_id;
@@ -2107,7 +2151,7 @@ async fn cmd_db_snapshot_info(
             rows.push(DownstairsRow {
                 host_serial: my_sled.serial_number().to_string(),
                 region: region.id().to_string(),
-                zone: format!("oxz_crucible_{}", dataset.id()),
+                dataset: dataset.id().to_string(),
                 physical_disk: my_zpool.physical_disk_id.to_string(),
             });
         }
@@ -2117,11 +2161,50 @@ async fn cmd_db_snapshot_info(
             .with(tabled::settings::Padding::new(0, 1, 0, 0))
             .to_string();
 
-        println!("DESTINATION REGION INFO:");
+        println!("\nSOURCE REGION INFO:");
         println!("{}", table);
-        println!("DESTINATION VOLUME VCR:");
-        get_and_display_vcr(vol_id, datastore).await?;
     }
+
+    println!("SOURCE VOLUME VCR:");
+    get_and_display_vcr(source_vol_id.into(), datastore).await?;
+
+    // Get the dataset backing this volume.
+    let regions = datastore.get_allocated_regions(dest_vol_id.into()).await?;
+
+    let mut rows = Vec::with_capacity(3);
+    for (dataset, region) in regions {
+        let my_pool_id = dataset.pool_id;
+        let (_, my_zpool) = LookupPath::new(opctx, datastore)
+            .zpool_id(my_pool_id)
+            .fetch()
+            .await
+            .context("failed to look up zpool")?;
+
+        let my_sled_id = my_zpool.sled_id;
+
+        let (_, my_sled) = LookupPath::new(opctx, datastore)
+            .sled_id(my_sled_id)
+            .fetch()
+            .await
+            .context("failed to look up sled")?;
+
+        rows.push(DownstairsRow {
+            host_serial: my_sled.serial_number().to_string(),
+            region: region.id().to_string(),
+            dataset: dataset.id().to_string(),
+            physical_disk: my_zpool.physical_disk_id.to_string(),
+        });
+    }
+
+    let table = tabled::Table::new(rows)
+        .with(tabled::settings::Style::empty())
+        .with(tabled::settings::Padding::new(0, 1, 0, 0))
+        .to_string();
+
+    println!("DESTINATION REGION INFO:");
+    println!("{}", table);
+    println!("DESTINATION VOLUME VCR:");
+    get_and_display_vcr(dest_vol_id.into(), datastore).await?;
 
     Ok(())
 }

--- a/dev-tools/omdb/src/bin/omdb/db.rs
+++ b/dev-tools/omdb/src/bin/omdb/db.rs
@@ -2081,7 +2081,6 @@ async fn cmd_db_snapshot_info(
     use db::schema::region_snapshot::dsl as region_snapshot_dsl;
     let region_snapshots = region_snapshot_dsl::region_snapshot
         .filter(region_snapshot_dsl::snapshot_id.eq(args.uuid))
-        .limit(3)
         .select(RegionSnapshot::as_select())
         .load_async(&*datastore.pool_connection_for_tests().await?)
         .await


### PR DESCRIPTION
Now we print, when available, the region snapshot info as well as the datasets that make up the source.
Changed the output a little, don't quite go so wide for the initial snapshot info.

The new output looks like this:
```
EVT22200005 # omdb-alan db snapshots info b965b4d3-ce1c-4a8c-9a98-768b57009cbc
                 Name: snap-s4
                   id: b965b4d3-ce1c-4a8c-9a98-768b57009cbc
                state: ready
                 size: 10 GiB
       source_disk_id: 034e3cdd-1a98-4fd3-a674-e4dfbd77b738
     source_volume_id: 4f938895-dc44-4fcf-b3b6-6027a261e075
destination_volume_id: 82f1b95d-eb5a-44b3-a8d3-028a49d988db

REGION SNAPSHOT INFO:
DATASET_ID                           REGION_ID                            SNAPSHOT_ID                          SNAPSHOT_ADDR                  VOLUME_REFERENCES 
892422ff-bb48-4fc4-9d8d-f479944f99f3 0a2b08ca-3cb9-463d-953c-20839b695446 b965b4d3-ce1c-4a8c-9a98-768b57009cbc [fd00:1122:3344:101::14]:19014 0                 
c288d7b5-de14-4b1f-8194-256a7162c637 1e4a3544-a2ba-45c2-b57b-d315ba3f99af b965b4d3-ce1c-4a8c-9a98-768b57009cbc [fd00:1122:3344:101::12]:19016 0                 

SOURCE REGION INFO:
HOST_SERIAL REGION                               DATASET                              PHYSICAL_DISK                        
unknown     279eb48d-5da8-4402-a88e-861e7d15d67b 07fc1def-bc81-4999-baa6-f9f7ab8013e7 3300a1fb-fc15-43f2-872b-a579aa3ea68c 
unknown     06da0949-c40a-4b35-9d91-55da4556e141 eb68993b-bd16-4b5d-bfc8-684948c027be d0e99907-56fe-4739-a937-0f346cfc4e1d 
SOURCE VOLUME VCR:
VCR from volume ID 4f938895-dc44-4fcf-b3b6-6027a261e075
ID                                   BS  SUB_VOLUMES READ_ONLY_PARENT 
35ef5440-3dbd-4234-ad79-840c9ea35320 512 1           true             

SUB VOLUME 0
    ID                                   BS  BPE    EC  GEN READ_ONLY 
    81cc751b-1a2f-446d-9f9d-a1a675c7f294 512 131072 160 68  true      
    [fd00:1122:3344:101::18]:19010
    [fd00:1122:3344:101::14]:19014
    [fd00:1122:3344:101::12]:19016

READ ONLY PARENT:
    ID                                   BS  SUB_VOLUMES READ_ONLY_PARENT 
    bef8ae26-0820-4274-9707-010ed0b7569b 512 1           true             

    SUB VOLUME 0
        ID                                   BS  BPE    EC  GEN READ_ONLY 
        c87d59a3-4dc8-4668-b913-b67aa9be4fe9 512 131072 160 2   true      
        [fd00:1122:3344:101::16]:19010
        [fd00:1122:3344:101::15]:19008
        [fd00:1122:3344:101::12]:19012

    READ ONLY PARENT:
        ID                                   BS  SUB_VOLUMES READ_ONLY_PARENT 
        bad1f680-7343-46d0-a0f4-d5cc3ba86dc6 512 1           true             

        SUB VOLUME 0
            ID                                   BS  BPE    EC  GEN READ_ONLY 
            4ed8855a-7251-4904-859f-70b8e056f18c 512 131072 160 2   true      
            [fd00:1122:3344:101::17]:19006
            [fd00:1122:3344:101::12]:19010
            [fd00:1122:3344:101::16]:19006

        READ ONLY PARENT:
            ID                                   BS  SUB_VOLUMES READ_ONLY_PARENT 
            2c465e96-9688-473b-9733-bd9a9f2c3a3e 512 1           false            

            SUB VOLUME 0
                ID                                   BS  BPE    EC  GEN READ_ONLY 
                fa1a7a62-810f-4ae4-8f50-af71f622a544 512 131072 160 9   true      
                [fd00:1122:3344:101::17]:19002
                [fd00:1122:3344:101::15]:19002
                [fd00:1122:3344:101::12]:19002

DESTINATION REGION INFO:
HOST_SERIAL REGION                               DATASET                              PHYSICAL_DISK                        
unknown     ba5439a7-740f-4505-bc31-dfc36ddf1b82 22715ad5-8085-4531-8c54-d3d73f6bbd39 bde68cf0-e824-465d-b0aa-183ab00604d8 
unknown     49e46f21-04c7-40db-9fd6-dd1c78fdebc2 892422ff-bb48-4fc4-9d8d-f479944f99f3 a8506389-4df6-44ac-bbd7-5fe8960757b6 
unknown     319d6d97-d233-4242-8d02-f49f4109009d c288d7b5-de14-4b1f-8194-256a7162c637 dbf54358-c777-4bc5-b0f4-da0dd1a79970 
DESTINATION VOLUME VCR:
VCR from volume ID 82f1b95d-eb5a-44b3-a8d3-028a49d988db
ID                                   BS  SUB_VOLUMES READ_ONLY_PARENT 
82f1b95d-eb5a-44b3-a8d3-028a49d988db 512 1           false            

SUB VOLUME 0
    ID                                   BS  BPE    EC  GEN READ_ONLY 
    82f1b95d-eb5a-44b3-a8d3-028a49d988db 512 131072 160 1   false     
    [fd00:1122:3344:101::12]:19015
    [fd00:1122:3344:101::14]:19011
    [fd00:1122:3344:101::15]:19012
```

The changes are, a new summary:
```
                 Name: snap-s4
                   id: b965b4d3-ce1c-4a8c-9a98-768b57009cbc
                state: ready
                 size: 10 GiB
       source_disk_id: 034e3cdd-1a98-4fd3-a674-e4dfbd77b738
     source_volume_id: 4f938895-dc44-4fcf-b3b6-6027a261e075
destination_volume_id: 82f1b95d-eb5a-44b3-a8d3-028a49d988db
```
Instead of all that on one row.

We also now print (if the snapshot contains it):
```
REGION SNAPSHOT INFO:
DATASET_ID                           REGION_ID                            SNAPSHOT_ID                          SNAPSHOT_ADDR                  VOLUME_REFERENCES 
892422ff-bb48-4fc4-9d8d-f479944f99f3 0a2b08ca-3cb9-463d-953c-20839b695446 b965b4d3-ce1c-4a8c-9a98-768b57009cbc [fd00:1122:3344:101::14]:19014 0                 
c288d7b5-de14-4b1f-8194-256a7162c637 1e4a3544-a2ba-45c2-b57b-d315ba3f99af b965b4d3-ce1c-4a8c-9a98-768b57009cbc [fd00:1122:3344:101::12]:19016 0                 

SOURCE REGION INFO:
HOST_SERIAL REGION                               DATASET                              PHYSICAL_DISK                        
unknown     279eb48d-5da8-4402-a88e-861e7d15d67b 07fc1def-bc81-4999-baa6-f9f7ab8013e7 3300a1fb-fc15-43f2-872b-a579aa3ea68c 
unknown     06da0949-c40a-4b35-9d91-55da4556e141 eb68993b-bd16-4b5d-bfc8-684948c027be d0e99907-56fe-4739-a937-0f346cfc4e1d 
```

In the above example we are in the middle of replacing the 2nd downstairs in this snapshot, so both the region snapshot info and source region info have two downstairs.

Having this info available in omdb allows us to write tests to find an replace a specific part of a downstairs in a snapshot.