### PR TITLE
[reconfigurator] Remove spicy blueprint -> sled-agent From impls

### DIFF
--- a/nexus/reconfigurator/execution/src/omicron_physical_disks.rs
+++ b/nexus/reconfigurator/execution/src/omicron_physical_disks.rs
@@ -48,7 +48,9 @@ pub(crate) async fn deploy_disks(
                 &log,
             );
             let result = client
-                .omicron_physical_disks_put(&config.clone().into())
+                .omicron_physical_disks_put(
+                    &config.clone().into_in_service_disks(),
+                )
                 .await
                 .with_context(|| {
                     format!("Failed to put {config:#?} to sled {sled_id}")

--- a/nexus/reconfigurator/execution/src/omicron_zones.rs
+++ b/nexus/reconfigurator/execution/src/omicron_zones.rs
@@ -19,7 +19,6 @@ use nexus_db_queries::db::datastore::CollectorReassignment;
 use nexus_db_queries::db::DataStore;
 use nexus_types::deployment::BlueprintZoneConfig;
 use nexus_types::deployment::BlueprintZoneDisposition;
-use nexus_types::deployment::BlueprintZoneFilter;
 use nexus_types::deployment::BlueprintZoneType;
 use nexus_types::deployment::BlueprintZonesConfig;
 use omicron_common::address::COCKROACH_ADMIN_PORT;
@@ -65,8 +64,8 @@ pub(crate) async fn deploy_zones(
                 db_sled.sled_agent_address(),
                 &opctx.log,
             );
-            let omicron_zones = config
-                .to_omicron_zones_config(BlueprintZoneFilter::ShouldBeRunning);
+            let omicron_zones =
+                config.clone().into_running_omicron_zones_config();
             let result = client
                 .omicron_zones_put(&omicron_zones)
                 .await

--- a/nexus/reconfigurator/planning/src/example.rs
+++ b/nexus/reconfigurator/planning/src/example.rs
@@ -15,7 +15,6 @@ use crate::system::SledBuilder;
 use crate::system::SystemDescription;
 use nexus_inventory::CollectionBuilderRng;
 use nexus_types::deployment::Blueprint;
-use nexus_types::deployment::BlueprintZoneFilter;
 use nexus_types::deployment::OmicronZoneNic;
 use nexus_types::deployment::PlanningInput;
 use nexus_types::deployment::SledFilter;
@@ -490,9 +489,7 @@ impl ExampleSystemBuilder {
             system
                 .sled_set_omicron_zones(
                     *sled_id,
-                    zones.to_omicron_zones_config(
-                        BlueprintZoneFilter::ShouldBeRunning,
-                    ),
+                    zones.clone().into_running_omicron_zones_config(),
                 )
                 .unwrap();
         }
@@ -546,7 +543,7 @@ impl ZoneCount {
 mod tests {
     use chrono::{NaiveDateTime, TimeZone, Utc};
     use nexus_sled_agent_shared::inventory::{OmicronZoneConfig, ZoneKind};
-    use nexus_types::deployment::BlueprintZoneConfig;
+    use nexus_types::deployment::{BlueprintZoneConfig, BlueprintZoneFilter};
     use omicron_test_utils::dev::test_setup_log;
 
     use super::*;

--- a/nexus/reconfigurator/planning/src/planner.rs
+++ b/nexus/reconfigurator/planning/src/planner.rs
@@ -976,9 +976,8 @@ mod test {
                     .blueprint_zones
                     .get(&new_sled_id)
                     .expect("blueprint should contain zones for new sled")
-                    .to_omicron_zones_config(
-                        BlueprintZoneFilter::ShouldBeRunning,
-                    ),
+                    .clone()
+                    .into_running_omicron_zones_config(),
             )
             .unwrap();
         let collection =

--- a/sled-agent/src/rack_setup/service.rs
+++ b/sled-agent/src/rack_setup/service.rs
@@ -344,7 +344,7 @@ impl ServiceInner {
                 // Ensure all the physical disks are initialized
                 self.initialize_disks_on_sled(
                     *sled_address,
-                    config.disks.clone().into(),
+                    config.disks.clone().into_in_service_disks(),
                 )
                 .await?;
 


### PR DESCRIPTION
This is followup from #7308 and https://github.com/oxidecomputer/omicron/issues/7500#issuecomment-2641963974:

* Remove `From<BlueprintZonesConfig> for OmicronZonesConfig`. This included expunged zones, but thankfully had no callers.
* Change `BlueprintZonesConfig::to_omicron_zones_config(filter)` to `BlueprintZonesConfig::into_running_omicron_zones_config()` (no `filter` argument). All the callers of this method were passing `BlueprintZoneFilter::ShouldBeRunning`, and I don't think there's a reason to use any other filter?
* Remove `From<BlueprintPhysicalDisksConfig> for OmicronPhysicalDisksConfig` (which included expunged disks), and replace it with `BlueprintPhysicalDisksConfig::into_in_service_disks()`. This one _did_ have callers, including the blueprint executor, but I think we've avoided problems because the planner current [drops disks if the incoming planning input says they're not in service](https://github.com/oxidecomputer/omicron/blob/3ae42bf76cb9b55993705b817157e4f60935b6dd/nexus/reconfigurator/planning/src/blueprint_builder/builder.rs#L1090-L1097). I'm not sure that planner behavior is right, and might change with #7286, so it seemed safer to go ahead and fix this now.