### PR TITLE
[omdb] Add datasets to `blueprints show ...`

### DIFF
--- a/dev-tools/omdb/tests/successes.out
+++ b/dev-tools/omdb/tests/successes.out
@@ -1337,6 +1337,12 @@ parent:    <none>
     nexus-tests   nexus-test-model   nexus-test-disk-19
 
 
+    datasets at generation 2:
+    ---------------------------------------------------------------------------
+    dataset name   dataset id   disposition   quota   reservation   compression
+    ---------------------------------------------------------------------------
+
+
     omicron zones at generation 2:
     -----------------------------------------------
     zone type   zone id   disposition   underlay IP
@@ -1360,6 +1366,18 @@ parent:    <none>
     nexus-tests   nexus-test-model   nexus-test-disk-7
     nexus-tests   nexus-test-model   nexus-test-disk-8
     nexus-tests   nexus-test-model   nexus-test-disk-9
+
+
+    datasets at generation 2:
+    -----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
+    dataset name                                                                                                   dataset id                             disposition   quota   reservation   compression
+    -----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
+    oxp_..........<REDACTED_UUID>.........../crypt/zone/oxz_clickhouse_..........<REDACTED_UUID>...........        ..........<REDACTED_UUID>...........   in service    none    none          off        
+    oxp_..........<REDACTED_UUID>.........../crypt/zone/oxz_cockroachdb_..........<REDACTED_UUID>...........       ..........<REDACTED_UUID>...........   in service    none    none          off        
+    oxp_..........<REDACTED_UUID>.........../crypt/zone/oxz_crucible_pantry_..........<REDACTED_UUID>...........   ..........<REDACTED_UUID>...........   in service    none    none          off        
+    oxp_..........<REDACTED_UUID>.........../crypt/zone/oxz_external_dns_..........<REDACTED_UUID>...........      ..........<REDACTED_UUID>...........   in service    none    none          off        
+    oxp_..........<REDACTED_UUID>.........../crypt/zone/oxz_internal_dns_..........<REDACTED_UUID>...........      ..........<REDACTED_UUID>...........   in service    none    none          off        
+    oxp_..........<REDACTED_UUID>.........../crypt/zone/oxz_nexus_..........<REDACTED_UUID>...........             ..........<REDACTED_UUID>...........   in service    none    none          off        
 
 
     omicron zones at generation 2:
@@ -1415,6 +1433,12 @@ parent:    <none>
     nexus-tests   nexus-test-model   nexus-test-disk-19
 
 
+    datasets at generation 2:
+    ---------------------------------------------------------------------------
+    dataset name   dataset id   disposition   quota   reservation   compression
+    ---------------------------------------------------------------------------
+
+
     omicron zones at generation 2:
     -----------------------------------------------
     zone type   zone id   disposition   underlay IP
@@ -1438,6 +1462,18 @@ parent:    <none>
     nexus-tests   nexus-test-model   nexus-test-disk-7
     nexus-tests   nexus-test-model   nexus-test-disk-8
     nexus-tests   nexus-test-model   nexus-test-disk-9
+
+
+    datasets at generation 2:
+    -----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
+    dataset name                                                                                                   dataset id                             disposition   quota   reservation   compression
+    -----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
+    oxp_..........<REDACTED_UUID>.........../crypt/zone/oxz_clickhouse_..........<REDACTED_UUID>...........        ..........<REDACTED_UUID>...........   in service    none    none          off        
+    oxp_..........<REDACTED_UUID>.........../crypt/zone/oxz_cockroachdb_..........<REDACTED_UUID>...........       ..........<REDACTED_UUID>...........   in service    none    none          off        
+    oxp_..........<REDACTED_UUID>.........../crypt/zone/oxz_crucible_pantry_..........<REDACTED_UUID>...........   ..........<REDACTED_UUID>...........   in service    none    none          off        
+    oxp_..........<REDACTED_UUID>.........../crypt/zone/oxz_external_dns_..........<REDACTED_UUID>...........      ..........<REDACTED_UUID>...........   in service    none    none          off        
+    oxp_..........<REDACTED_UUID>.........../crypt/zone/oxz_internal_dns_..........<REDACTED_UUID>...........      ..........<REDACTED_UUID>...........   in service    none    none          off        
+    oxp_..........<REDACTED_UUID>.........../crypt/zone/oxz_nexus_..........<REDACTED_UUID>...........             ..........<REDACTED_UUID>...........   in service    none    none          off        
 
 
     omicron zones at generation 2:

--- a/dev-tools/reconfigurator-cli/tests/output/cmd-example-stdout
+++ b/dev-tools/reconfigurator-cli/tests/output/cmd-example-stdout
@@ -84,6 +84,61 @@ parent:    02697f74-b14a-4418-90f0-c28b2a3a6aa9
     fake-vendor   fake-model   serial-d792c8cb-7490-40cb-bb1c-d4917242edf4
 
 
+    datasets at generation 2:
+    -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
+    dataset name                                                                                                   dataset id                             disposition   quota     reservation   compression
+    -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
+    oxp_088ed702-551e-453b-80d7-57700372a844/crucible                                                              b95a9149-be08-4845-997a-1fde96cf0e85   in service    none      none          off        
+    oxp_09e51697-abad-47c0-a193-eaf74bc5d3cd/crucible                                                              1fdbd927-34b1-48b4-9394-4b580ef9f6a3   in service    none      none          off        
+    oxp_3a512d49-edbe-47f3-8d0b-6051bfdc4044/crucible                                                              1308f1bc-a249-4ba3-b65e-db6c979aa7da   in service    none      none          off        
+    oxp_40517680-aa77-413c-bcf4-b9041dcf6612/crucible                                                              0497b348-53f7-49c1-8bdf-b802261a571c   in service    none      none          off        
+    oxp_78d3cb96-9295-4644-bf78-2e32191c71f9/crucible                                                              eeef27be-7691-4621-8025-bc06507ce481   in service    none      none          off        
+    oxp_853595e7-77da-404e-bc35-aba77478d55c/crucible                                                              edb2138e-849d-425e-aec0-5a6bb6a90c86   in service    none      none          off        
+    oxp_8926e0e7-65d9-4e2e-ac6d-f1298af81ef1/crucible                                                              7e2a255b-1850-44bb-ad97-076ac75ff48d   in service    none      none          off        
+    oxp_9c0b9151-17f3-4857-94cc-b5bfcd402326/crucible                                                              1a98a7a8-3e4f-4011-b126-cba62033255e   in service    none      none          off        
+    oxp_d61354fa-48d2-47c6-90bf-546e3ed1708b/crucible                                                              321a27f9-669d-4c78-98d4-dd7201dc3fcb   in service    none      none          off        
+    oxp_d792c8cb-7490-40cb-bb1c-d4917242edf4/crucible                                                              27b0e4d4-8099-4916-9ab9-3ba5dcdda17a   in service    none      none          off        
+    oxp_088ed702-551e-453b-80d7-57700372a844/crypt/clickhouse                                                      f2721ca7-c3b5-4c98-a24c-6c61401774ce   in service    none      none          off        
+    oxp_088ed702-551e-453b-80d7-57700372a844/crypt/external_dns                                                    516d5161-ba8e-45a0-a570-c141c868903d   in service    none      none          off        
+    oxp_088ed702-551e-453b-80d7-57700372a844/crypt/internal_dns                                                    e1325cf0-47dc-4085-ac93-f6da943745e8   in service    none      none          off        
+    oxp_088ed702-551e-453b-80d7-57700372a844/crypt/zone                                                            638501ff-3ae1-4de7-92a6-aae643f0f302   in service    none      none          off        
+    oxp_09e51697-abad-47c0-a193-eaf74bc5d3cd/crypt/zone                                                            1a2a375a-1d9a-481f-93c9-4f89d01d7ed6   in service    none      none          off        
+    oxp_3a512d49-edbe-47f3-8d0b-6051bfdc4044/crypt/zone                                                            1b544723-d28e-44da-ab51-b5a38633a9eb   in service    none      none          off        
+    oxp_40517680-aa77-413c-bcf4-b9041dcf6612/crypt/zone                                                            5373fee5-d77e-4f00-b3b4-f40ff0565783   in service    none      none          off        
+    oxp_78d3cb96-9295-4644-bf78-2e32191c71f9/crypt/zone                                                            3c40fe80-ba7e-4444-95c1-2dac25b09ceb   in service    none      none          off        
+    oxp_853595e7-77da-404e-bc35-aba77478d55c/crypt/zone                                                            28889aed-e213-4f24-83ce-80c2bc979cb8   in service    none      none          off        
+    oxp_8926e0e7-65d9-4e2e-ac6d-f1298af81ef1/crypt/zone                                                            63b4985a-f05b-41d0-bb4b-b28fc6342dd7   in service    none      none          off        
+    oxp_9c0b9151-17f3-4857-94cc-b5bfcd402326/crypt/zone                                                            aad54803-50a6-4733-b0d0-2d502b150404   in service    none      none          off        
+    oxp_d61354fa-48d2-47c6-90bf-546e3ed1708b/crypt/zone                                                            1fde35b2-d4e0-4226-b83d-f9bdfac7cbe2   in service    none      none          off        
+    oxp_d792c8cb-7490-40cb-bb1c-d4917242edf4/crypt/zone                                                            a7337ad7-3321-4d49-a6ad-636b9f41a6a7   in service    none      none          off        
+    oxp_088ed702-551e-453b-80d7-57700372a844/crypt/zone/oxz_clickhouse_3a3f243b-7e9e-4818-bb7c-fe30966b2949        312df2ab-5582-4b0f-84a0-b9391c1adb57   in service    none      none          off        
+    oxp_78d3cb96-9295-4644-bf78-2e32191c71f9/crypt/zone/oxz_crucible_279b230f-5e77-4960-b08e-594c6f2f57c0          24b9d80d-2a88-4bef-acc3-db32075bdabe   in service    none      none          off        
+    oxp_9c0b9151-17f3-4857-94cc-b5bfcd402326/crypt/zone/oxz_crucible_4328425e-f5ba-436a-9e46-3f337f07671e          f5d6040a-d278-42d8-82ed-55114fe7a065   in service    none      none          off        
+    oxp_d792c8cb-7490-40cb-bb1c-d4917242edf4/crypt/zone/oxz_crucible_4e60ff64-155b-44e8-9d39-e6de8c5d5fd3          ee5156ad-6b94-40c5-819f-41019a40c8e2   in service    none      none          off        
+    oxp_853595e7-77da-404e-bc35-aba77478d55c/crypt/zone/oxz_crucible_61282e88-43b3-4011-9314-b0929880895a          7d53fd70-018c-4f1b-949b-206d4d36440e   in service    none      none          off        
+    oxp_d61354fa-48d2-47c6-90bf-546e3ed1708b/crypt/zone/oxz_crucible_7537db8e-11c9-4a84-9dc7-b3ae7b657cc4          8936bf9c-264f-4106-8719-dc4dbe690b83   in service    none      none          off        
+    oxp_09e51697-abad-47c0-a193-eaf74bc5d3cd/crypt/zone/oxz_crucible_b37ebcb3-533b-4fd7-9960-bb1ac511bea2          dccc4c7e-7be8-48b4-ada1-6aa41275a040   in service    none      none          off        
+    oxp_8926e0e7-65d9-4e2e-ac6d-f1298af81ef1/crypt/zone/oxz_crucible_b8aba012-d4b3-48e1-af2d-cf6265e02bd7          6bff9e1a-fba4-48da-b5fb-325565c65cbe   in service    none      none          off        
+    oxp_3a512d49-edbe-47f3-8d0b-6051bfdc4044/crypt/zone/oxz_crucible_e1b405aa-a32c-4410-8335-59237a7bc9ad          c9c6fc54-5ff5-4231-8abd-0c1bddb6de92   in service    none      none          off        
+    oxp_40517680-aa77-413c-bcf4-b9041dcf6612/crypt/zone/oxz_crucible_e696d6f8-c706-4ca7-8846-561f0323ccbf          4c0f3572-d324-4299-b7a3-e3b26b060445   in service    none      none          off        
+    oxp_088ed702-551e-453b-80d7-57700372a844/crypt/zone/oxz_crucible_f69e36ff-ea67-4d1f-bc73-3d2a0315c77f          1a39a88e-0350-4e86-a83f-822af222686f   in service    none      none          off        
+    oxp_088ed702-551e-453b-80d7-57700372a844/crypt/zone/oxz_crucible_pantry_b4c3734e-b6d8-47d8-a695-5dad2c21622e   b3b784b5-1b6f-40f6-a388-8f8f210ee677   in service    none      none          off        
+    oxp_088ed702-551e-453b-80d7-57700372a844/crypt/zone/oxz_external_dns_c5fefafb-d65c-44e0-b45e-d2097dca02d1      001933b7-faf6-42d7-9f3a-13198b32e622   in service    none      none          off        
+    oxp_088ed702-551e-453b-80d7-57700372a844/crypt/zone/oxz_internal_dns_426face8-6cc4-4ba0-b3a3-8492876ecd37      2752a19b-3e30-4e24-b4b7-f0abaed80550   in service    none      none          off        
+    oxp_088ed702-551e-453b-80d7-57700372a844/crypt/zone/oxz_nexus_db1aa26e-7608-4ce0-933e-9968489f8a46             c85990bc-8643-4dc7-bbc9-c50e0a38db11   in service    none      none          off        
+    oxp_088ed702-551e-453b-80d7-57700372a844/crypt/zone/oxz_ntp_eaa48c21-f17c-41f7-9e85-fc6a10913b31               3eeb6d48-dc4a-4e0b-b499-b4815630611a   in service    none      none          off        
+    oxp_088ed702-551e-453b-80d7-57700372a844/crypt/debug                                                           55093b80-6478-4a6a-aa3b-64c0bd7395dc   in service    100 GiB   none          gzip-9     
+    oxp_09e51697-abad-47c0-a193-eaf74bc5d3cd/crypt/debug                                                           b1d00974-356b-4188-80e5-2ad9dd1fbc96   in service    100 GiB   none          gzip-9     
+    oxp_3a512d49-edbe-47f3-8d0b-6051bfdc4044/crypt/debug                                                           a420bdde-b687-4b52-8029-5d8474ecd6a7   in service    100 GiB   none          gzip-9     
+    oxp_40517680-aa77-413c-bcf4-b9041dcf6612/crypt/debug                                                           93900f81-e442-4567-b8bb-48fe9528462c   in service    100 GiB   none          gzip-9     
+    oxp_78d3cb96-9295-4644-bf78-2e32191c71f9/crypt/debug                                                           4cf44aa3-b0d3-4488-9bb6-e9f74eaf1160   in service    100 GiB   none          gzip-9     
+    oxp_853595e7-77da-404e-bc35-aba77478d55c/crypt/debug                                                           0cb7d226-bfe4-4e0b-a355-ac483902f145   in service    100 GiB   none          gzip-9     
+    oxp_8926e0e7-65d9-4e2e-ac6d-f1298af81ef1/crypt/debug                                                           edf3043e-0cb3-4bce-b6ca-c1b531de8abb   in service    100 GiB   none          gzip-9     
+    oxp_9c0b9151-17f3-4857-94cc-b5bfcd402326/crypt/debug                                                           31a5bfe9-b4f4-4dc4-bd9b-0ec26a7c5662   in service    100 GiB   none          gzip-9     
+    oxp_d61354fa-48d2-47c6-90bf-546e3ed1708b/crypt/debug                                                           ce9d87eb-3e67-426d-be15-e5b056d7fbb4   in service    100 GiB   none          gzip-9     
+    oxp_d792c8cb-7490-40cb-bb1c-d4917242edf4/crypt/debug                                                           dad250d2-5a42-43a1-8272-dd7e29d31954   in service    100 GiB   none          gzip-9     
+
+
     omicron zones at generation 2:
     ---------------------------------------------------------------------------------------------
     zone type         zone id                                disposition   underlay IP           
@@ -125,6 +180,59 @@ parent:    02697f74-b14a-4418-90f0-c28b2a3a6aa9
     fake-vendor   fake-model   serial-d7410a1c-e01d-49a4-be9c-f861f086760a
 
 
+    datasets at generation 2:
+    -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
+    dataset name                                                                                                   dataset id                             disposition   quota     reservation   compression
+    -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
+    oxp_128b0f04-229b-48dc-9c5c-555cb5723ed8/crucible                                                              ae3ff0ec-7eaa-4aa2-88f8-385d50ab295c   in service    none      none          off        
+    oxp_43ae0f4e-b0cf-4d74-8636-df0567ba01e6/crucible                                                              3b8acee7-a8c1-4834-8af8-f42be32d576a   in service    none      none          off        
+    oxp_4e9806d0-41cd-48c2-86ef-7f815c3ce3b1/crucible                                                              d2f61e61-612e-4ff6-8ebb-29ffb89c7615   in service    none      none          off        
+    oxp_70bb6d98-111f-4015-9d97-9ef1b2d6dcac/crucible                                                              716bd089-ff3e-4aa9-a124-1c0f4a3e4987   in service    none      none          off        
+    oxp_7ce5029f-703c-4c08-8164-9af9cf1acf23/crucible                                                              46a2171c-02e0-4ed7-8ac5-970792084d0e   in service    none      none          off        
+    oxp_b113c11f-44e6-4fb4-a56e-1d91bd652faf/crucible                                                              f77a65b9-0698-405f-acd2-3fc493f141a2   in service    none      none          off        
+    oxp_bf149c80-2498-481c-9989-6344da914081/crucible                                                              9c667167-c040-4939-9f6a-35717022366c   in service    none      none          off        
+    oxp_c69b6237-09f9-45aa-962c-5dbdd1d894be/crucible                                                              5a418594-920b-4d11-a302-1f51263099ab   in service    none      none          off        
+    oxp_ccd5a87b-00ae-42ad-85da-b37d70436cb1/crucible                                                              929430d8-4d9e-4643-a924-d4886ea06cc1   in service    none      none          off        
+    oxp_d7410a1c-e01d-49a4-be9c-f861f086760a/crucible                                                              42cc77ea-602c-4ae7-9e0e-10a5b320c1aa   in service    none      none          off        
+    oxp_128b0f04-229b-48dc-9c5c-555cb5723ed8/crypt/external_dns                                                    8a3e2e54-c779-44fd-8e89-3ff3d9695e5a   in service    none      none          off        
+    oxp_128b0f04-229b-48dc-9c5c-555cb5723ed8/crypt/internal_dns                                                    d353634c-51e0-4b56-b2af-fa08416a4307   in service    none      none          off        
+    oxp_128b0f04-229b-48dc-9c5c-555cb5723ed8/crypt/zone                                                            0ab616d3-728d-4d5c-9657-6a7062ed33b4   in service    none      none          off        
+    oxp_43ae0f4e-b0cf-4d74-8636-df0567ba01e6/crypt/zone                                                            5afb2ed7-1e0d-46e2-8cb2-24921a887883   in service    none      none          off        
+    oxp_4e9806d0-41cd-48c2-86ef-7f815c3ce3b1/crypt/zone                                                            eb02d392-27fe-4e0f-9e85-68d6ac4426e8   in service    none      none          off        
+    oxp_70bb6d98-111f-4015-9d97-9ef1b2d6dcac/crypt/zone                                                            786fa5bd-b472-4e0e-9d20-1dc541bebd16   in service    none      none          off        
+    oxp_7ce5029f-703c-4c08-8164-9af9cf1acf23/crypt/zone                                                            41092962-f1bc-4734-89c4-7bdc89548fab   in service    none      none          off        
+    oxp_b113c11f-44e6-4fb4-a56e-1d91bd652faf/crypt/zone                                                            6c9d0188-4369-4aa8-b5bd-762ef078c72a   in service    none      none          off        
+    oxp_bf149c80-2498-481c-9989-6344da914081/crypt/zone                                                            a50c7543-96ae-45ad-ba66-9766b4a08ed2   in service    none      none          off        
+    oxp_c69b6237-09f9-45aa-962c-5dbdd1d894be/crypt/zone                                                            d1ddd3ad-ac27-4cd1-9943-1124dc31b762   in service    none      none          off        
+    oxp_ccd5a87b-00ae-42ad-85da-b37d70436cb1/crypt/zone                                                            8bf57d85-6e39-4dd7-beb7-3f0d1c3a8d23   in service    none      none          off        
+    oxp_d7410a1c-e01d-49a4-be9c-f861f086760a/crypt/zone                                                            5d2f99ec-1d49-4ddf-a83c-7178dc2d7f03   in service    none      none          off        
+    oxp_70bb6d98-111f-4015-9d97-9ef1b2d6dcac/crypt/zone/oxz_crucible_096964a1-a60b-4de9-b4b5-dada560870ca          562a77a8-a139-461d-8b5a-1b0a8ded4639   in service    none      none          off        
+    oxp_ccd5a87b-00ae-42ad-85da-b37d70436cb1/crypt/zone/oxz_crucible_1a07a7f2-76ae-4670-8491-3383bb3e2d19          22cf1a51-e484-4ea1-bdbd-6d4c59ef1ba5   in service    none      none          off        
+    oxp_43ae0f4e-b0cf-4d74-8636-df0567ba01e6/crypt/zone/oxz_crucible_1a7ddc8f-90c7-4842-81a9-2abfc76e3cb4          e9261b1f-6914-4764-ad1e-12b7e5a6473e   in service    none      none          off        
+    oxp_128b0f04-229b-48dc-9c5c-555cb5723ed8/crypt/zone/oxz_crucible_2f5dec78-6071-41c1-8f3f-2f4e98fdad0a          58919e5b-6479-4c8f-95b0-4bf5d5c948db   in service    none      none          off        
+    oxp_c69b6237-09f9-45aa-962c-5dbdd1d894be/crypt/zone/oxz_crucible_52960cc6-af73-4ae6-b776-b4bcc371fd68          bc2726a9-8447-42c8-877f-2e4c4b7b3bfe   in service    none      none          off        
+    oxp_4e9806d0-41cd-48c2-86ef-7f815c3ce3b1/crypt/zone/oxz_crucible_6914b9aa-5712-405c-817a-77b2e6c6a824          fb6d9561-67ff-4464-b96b-85302afd2e6b   in service    none      none          off        
+    oxp_bf149c80-2498-481c-9989-6344da914081/crypt/zone/oxz_crucible_8e92b0f0-77b7-4b95-905f-653ee962b932          dd7ec937-21f1-41d6-bfbd-15d8ceccede3   in service    none      none          off        
+    oxp_d7410a1c-e01d-49a4-be9c-f861f086760a/crypt/zone/oxz_crucible_a2a98ae0-ee42-4933-9c4b-660123bc693d          88e0dd87-292c-4284-9179-8cc538201b3f   in service    none      none          off        
+    oxp_b113c11f-44e6-4fb4-a56e-1d91bd652faf/crypt/zone/oxz_crucible_d9ea5125-d6f0-4bfd-9ebd-497569d91adf          0387b296-b617-40b5-964b-be8c793d2f9b   in service    none      none          off        
+    oxp_7ce5029f-703c-4c08-8164-9af9cf1acf23/crypt/zone/oxz_crucible_f7ced707-a517-4529-91fa-03dc7683f413          58b594a1-52d1-4e34-af4a-30ac392b2bfa   in service    none      none          off        
+    oxp_128b0f04-229b-48dc-9c5c-555cb5723ed8/crypt/zone/oxz_crucible_pantry_41f7b32f-d85f-4cce-853c-144342cc8361   265a4c79-a14b-41dc-bcb7-2e437c97b043   in service    none      none          off        
+    oxp_128b0f04-229b-48dc-9c5c-555cb5723ed8/crypt/zone/oxz_external_dns_25087c5b-58b9-46f2-9e4c-e9440c081111      22fb3cce-7c6f-43dd-abf6-bbd00738b490   in service    none      none          off        
+    oxp_128b0f04-229b-48dc-9c5c-555cb5723ed8/crypt/zone/oxz_internal_dns_5c1386b0-ed6b-4e09-8a65-7d9f47c41839      2daf1716-1f5f-4553-81fa-06862226a825   in service    none      none          off        
+    oxp_128b0f04-229b-48dc-9c5c-555cb5723ed8/crypt/zone/oxz_nexus_3bfd90d6-0640-4f63-a578-76277ce9c7c6             e5551cbe-4f05-4492-848b-d81cc4eb9e34   in service    none      none          off        
+    oxp_128b0f04-229b-48dc-9c5c-555cb5723ed8/crypt/zone/oxz_ntp_9ec70cc1-a22d-40df-9697-8a4db3c72d74               46517374-da65-4bea-b454-90b627390e1e   in service    none      none          off        
+    oxp_128b0f04-229b-48dc-9c5c-555cb5723ed8/crypt/debug                                                           0ae02446-22d0-408c-9586-4b334d3958fb   in service    100 GiB   none          gzip-9     
+    oxp_43ae0f4e-b0cf-4d74-8636-df0567ba01e6/crypt/debug                                                           a6aeb394-e1b2-42f0-9e2f-3859debcd829   in service    100 GiB   none          gzip-9     
+    oxp_4e9806d0-41cd-48c2-86ef-7f815c3ce3b1/crypt/debug                                                           e5e4be98-f1ec-46df-ae3f-6244e89ad97e   in service    100 GiB   none          gzip-9     
+    oxp_70bb6d98-111f-4015-9d97-9ef1b2d6dcac/crypt/debug                                                           bac32918-715d-4011-ac63-20febaf734d3   in service    100 GiB   none          gzip-9     
+    oxp_7ce5029f-703c-4c08-8164-9af9cf1acf23/crypt/debug                                                           904efd19-34cf-47ff-9e8b-637b344d869a   in service    100 GiB   none          gzip-9     
+    oxp_b113c11f-44e6-4fb4-a56e-1d91bd652faf/crypt/debug                                                           891b924c-668d-4e09-a237-fbf3d1baae8a   in service    100 GiB   none          gzip-9     
+    oxp_bf149c80-2498-481c-9989-6344da914081/crypt/debug                                                           1ba3e5a1-9023-490a-9620-e909ca13276a   in service    100 GiB   none          gzip-9     
+    oxp_c69b6237-09f9-45aa-962c-5dbdd1d894be/crypt/debug                                                           8394620a-43ed-4455-bf61-861a465abf0e   in service    100 GiB   none          gzip-9     
+    oxp_ccd5a87b-00ae-42ad-85da-b37d70436cb1/crypt/debug                                                           79527a9d-5967-4e8d-81c1-1d7abbd4e226   in service    100 GiB   none          gzip-9     
+    oxp_d7410a1c-e01d-49a4-be9c-f861f086760a/crypt/debug                                                           a2fe585f-e674-475d-94d6-f22c72d6d454   in service    100 GiB   none          gzip-9     
+
+
     omicron zones at generation 2:
     ---------------------------------------------------------------------------------------------
     zone type         zone id                                disposition   underlay IP           
@@ -163,6 +271,59 @@ parent:    02697f74-b14a-4418-90f0-c28b2a3a6aa9
     fake-vendor   fake-model   serial-ce1c13f3-bef2-4306-b0f2-4e39bd4a18b6
     fake-vendor   fake-model   serial-f931ec80-a3e3-4adb-a8ba-fa5adbd2294c
     fake-vendor   fake-model   serial-fe1d5b9f-8db7-4e2d-bf17-c4b80e1f897c
+
+
+    datasets at generation 2:
+    -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
+    dataset name                                                                                                   dataset id                             disposition   quota     reservation   compression
+    -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
+    oxp_44fa7024-c2bc-4d2c-b478-c4997e4aece8/crucible                                                              46e16066-441b-40b5-90da-858ea4d74d2d   in service    none      none          off        
+    oxp_5265edc6-debf-4687-a758-a9746893ebd3/crucible                                                              498e4d41-f8a8-4c14-a4e2-71d2b1decfcd   in service    none      none          off        
+    oxp_532fbd69-b472-4445-86af-4c4c85afb313/crucible                                                              c8ef5f1a-4178-43ad-b0e1-79221e44987d   in service    none      none          off        
+    oxp_54fd6fa6-ce3c-4abe-8c9d-7e107e159e84/crucible                                                              a427d44c-c036-417c-9254-d6c992b8b2f6   in service    none      none          off        
+    oxp_8562317c-4736-4cfc-9292-7dcab96a6fee/crucible                                                              2ea203f3-c563-4a5c-a63c-3973513784de   in service    none      none          off        
+    oxp_9a1327e4-d11b-4d98-8454-8c41862e9832/crucible                                                              cc5f848d-6fde-42b2-af38-07049da3a88f   in service    none      none          off        
+    oxp_bf9d6692-64bc-459a-87dd-e7a83080a210/crucible                                                              d5619829-6b1e-48fa-8d2f-07ebbac995db   in service    none      none          off        
+    oxp_ce1c13f3-bef2-4306-b0f2-4e39bd4a18b6/crucible                                                              b45102ca-a709-4e86-b41d-ab41b1eeec46   in service    none      none          off        
+    oxp_f931ec80-a3e3-4adb-a8ba-fa5adbd2294c/crucible                                                              c24ade2e-c994-4d09-ad18-0d7f12e23bab   in service    none      none          off        
+    oxp_fe1d5b9f-8db7-4e2d-bf17-c4b80e1f897c/crucible                                                              23b89730-f252-48fd-a813-33798c05b641   in service    none      none          off        
+    oxp_44fa7024-c2bc-4d2c-b478-c4997e4aece8/crypt/external_dns                                                    7aa8f7da-fb93-4a57-8a90-2294429a6338   in service    none      none          off        
+    oxp_44fa7024-c2bc-4d2c-b478-c4997e4aece8/crypt/internal_dns                                                    ca1f5e8a-125a-4062-8eac-5f027dd5fd42   in service    none      none          off        
+    oxp_44fa7024-c2bc-4d2c-b478-c4997e4aece8/crypt/zone                                                            7dbc438c-4e61-4c9c-8b40-970f61e6d2cb   in service    none      none          off        
+    oxp_5265edc6-debf-4687-a758-a9746893ebd3/crypt/zone                                                            b5cf56eb-f9f7-4ad2-9eef-105485397e01   in service    none      none          off        
+    oxp_532fbd69-b472-4445-86af-4c4c85afb313/crypt/zone                                                            b6cf562b-50c1-4533-930d-fc882f22df60   in service    none      none          off        
+    oxp_54fd6fa6-ce3c-4abe-8c9d-7e107e159e84/crypt/zone                                                            757a9351-2213-4005-9693-5efa04e62078   in service    none      none          off        
+    oxp_8562317c-4736-4cfc-9292-7dcab96a6fee/crypt/zone                                                            9645f4e7-4381-4273-9e05-f076909f0624   in service    none      none          off        
+    oxp_9a1327e4-d11b-4d98-8454-8c41862e9832/crypt/zone                                                            30f3927c-6236-4309-823b-17434e789769   in service    none      none          off        
+    oxp_bf9d6692-64bc-459a-87dd-e7a83080a210/crypt/zone                                                            3f75edf4-fc61-49a9-ad48-f5d862acf1d9   in service    none      none          off        
+    oxp_ce1c13f3-bef2-4306-b0f2-4e39bd4a18b6/crypt/zone                                                            b48862cf-a4e1-4d82-8972-e6b8f81935df   in service    none      none          off        
+    oxp_f931ec80-a3e3-4adb-a8ba-fa5adbd2294c/crypt/zone                                                            46ced90c-8271-425f-bd29-818df820ceed   in service    none      none          off        
+    oxp_fe1d5b9f-8db7-4e2d-bf17-c4b80e1f897c/crypt/zone                                                            ed9705a1-0faa-43c5-a119-33bf687420db   in service    none      none          off        
+    oxp_54fd6fa6-ce3c-4abe-8c9d-7e107e159e84/crypt/zone/oxz_crucible_157d5b03-6897-4e80-9357-3cf733efe4b5          9f018b3f-8d6a-4c70-a0af-71d4ec3291ef   in service    none      none          off        
+    oxp_9a1327e4-d11b-4d98-8454-8c41862e9832/crypt/zone/oxz_crucible_7341456c-4c6c-4bb7-8be4-2acac834886f          bbe5126e-153a-4dfb-877e-99bb5e06c38b   in service    none      none          off        
+    oxp_532fbd69-b472-4445-86af-4c4c85afb313/crypt/zone/oxz_crucible_793a6315-a07b-4fcf-a0b4-633d5c53b8cf          4dd3109a-0075-4e0a-a7fb-60e17e81b14c   in service    none      none          off        
+    oxp_fe1d5b9f-8db7-4e2d-bf17-c4b80e1f897c/crypt/zone/oxz_crucible_7ce8eb07-58a7-4f1d-ba61-16db33b6fedd          2e392293-b820-4ca8-92d6-00b0ceb590ff   in service    none      none          off        
+    oxp_8562317c-4736-4cfc-9292-7dcab96a6fee/crypt/zone/oxz_crucible_9915de3b-8104-40ca-a6b5-46132d26bb15          fcf438a5-0536-4552-a497-65f2690f8716   in service    none      none          off        
+    oxp_ce1c13f3-bef2-4306-b0f2-4e39bd4a18b6/crypt/zone/oxz_crucible_a975d276-7434-4def-8f5b-f250657d1040          0c27cdbb-2a36-4dda-a33f-92b2d8f2490c   in service    none      none          off        
+    oxp_5265edc6-debf-4687-a758-a9746893ebd3/crypt/zone/oxz_crucible_b41461de-6b60-4d35-ad90-336eb1fa9874          a6939bff-0598-4307-ab4e-974c93e6d9d1   in service    none      none          off        
+    oxp_bf9d6692-64bc-459a-87dd-e7a83080a210/crypt/zone/oxz_crucible_d1374f2f-e9ba-4046-ba0b-83da927ba0d3          262de58b-a9af-4e84-9959-74f976b1ae84   in service    none      none          off        
+    oxp_44fa7024-c2bc-4d2c-b478-c4997e4aece8/crypt/zone/oxz_crucible_dc3c9584-44d8-4be6-b215-2df289f5763d          45dc1ef8-71be-48c7-b0a6-4aff2fdb278d   in service    none      none          off        
+    oxp_f931ec80-a3e3-4adb-a8ba-fa5adbd2294c/crypt/zone/oxz_crucible_e70d6f37-d0a6-4309-93b5-4f2f72b779a7          8c2c7164-32bd-464c-9cfb-ce67fb629a17   in service    none      none          off        
+    oxp_44fa7024-c2bc-4d2c-b478-c4997e4aece8/crypt/zone/oxz_crucible_pantry_efa9fb1c-9431-4072-877d-ff33d9d926ba   b774320b-b074-4087-8f1a-96bb8af4e6d8   in service    none      none          off        
+    oxp_44fa7024-c2bc-4d2c-b478-c4997e4aece8/crypt/zone/oxz_external_dns_761999e7-cf90-412c-91d8-f3247507edbc      2a869c5d-96f4-447b-aeeb-894a8a25ba57   in service    none      none          off        
+    oxp_44fa7024-c2bc-4d2c-b478-c4997e4aece8/crypt/zone/oxz_internal_dns_a2708dbc-a751-4c26-a1ed-6eaadf3402cf      79f79ab3-455d-4a63-ac40-994c3a87949c   in service    none      none          off        
+    oxp_44fa7024-c2bc-4d2c-b478-c4997e4aece8/crypt/zone/oxz_nexus_ba910747-f596-4088-a2d4-4372ee883dfd             a5e11e7e-f4ad-4267-9d25-faa178d4e71a   in service    none      none          off        
+    oxp_44fa7024-c2bc-4d2c-b478-c4997e4aece8/crypt/zone/oxz_ntp_4bb07cd6-dc94-4601-ac22-c7ad972735b3               b0fd5aa5-cc94-4657-baf4-72dc2923b8c7   in service    none      none          off        
+    oxp_44fa7024-c2bc-4d2c-b478-c4997e4aece8/crypt/debug                                                           a9c81633-6193-4901-8a82-5a4ba5ffe21a   in service    100 GiB   none          gzip-9     
+    oxp_5265edc6-debf-4687-a758-a9746893ebd3/crypt/debug                                                           b00b2487-9ef0-4f62-b0fe-c9e9e59829d0   in service    100 GiB   none          gzip-9     
+    oxp_532fbd69-b472-4445-86af-4c4c85afb313/crypt/debug                                                           c752d2d9-533e-4f8f-b3de-c710e6f3403e   in service    100 GiB   none          gzip-9     
+    oxp_54fd6fa6-ce3c-4abe-8c9d-7e107e159e84/crypt/debug                                                           5f955569-de9f-4fdd-be72-450b945cf182   in service    100 GiB   none          gzip-9     
+    oxp_8562317c-4736-4cfc-9292-7dcab96a6fee/crypt/debug                                                           dccfc806-60fd-4b77-b99f-caad7e75d412   in service    100 GiB   none          gzip-9     
+    oxp_9a1327e4-d11b-4d98-8454-8c41862e9832/crypt/debug                                                           6d20dd39-78b9-46fc-a337-f97030c1eeae   in service    100 GiB   none          gzip-9     
+    oxp_bf9d6692-64bc-459a-87dd-e7a83080a210/crypt/debug                                                           527d52ad-cafa-4b62-bebc-f2d75b708573   in service    100 GiB   none          gzip-9     
+    oxp_ce1c13f3-bef2-4306-b0f2-4e39bd4a18b6/crypt/debug                                                           50a3e065-a98d-431d-8147-818e50c03445   in service    100 GiB   none          gzip-9     
+    oxp_f931ec80-a3e3-4adb-a8ba-fa5adbd2294c/crypt/debug                                                           826b0fa6-4f9a-4efe-843a-009b239c102a   in service    100 GiB   none          gzip-9     
+    oxp_fe1d5b9f-8db7-4e2d-bf17-c4b80e1f897c/crypt/debug                                                           0510a6c1-558b-4038-96e4-7cd9209e5da4   in service    100 GiB   none          gzip-9     
 
 
     omicron zones at generation 2:
@@ -259,6 +420,20 @@ parent:    02697f74-b14a-4418-90f0-c28b2a3a6aa9
     fake-vendor   fake-model   serial-8562317c-4736-4cfc-9292-7dcab96a6fee
     fake-vendor   fake-model   serial-ce1c13f3-bef2-4306-b0f2-4e39bd4a18b6
     fake-vendor   fake-model   serial-f931ec80-a3e3-4adb-a8ba-fa5adbd2294c
+
+
+    datasets at generation 2:
+    -----------------------------------------------------------------------------------------------------------------------------------------------
+    dataset name                                           dataset id                             disposition   quota     reservation   compression
+    -----------------------------------------------------------------------------------------------------------------------------------------------
+    oxp_44fa7024-c2bc-4d2c-b478-c4997e4aece8/crypt/zone    819bb07a-b7be-4741-899a-62a2d7899032   in service    none      none          off        
+    oxp_8562317c-4736-4cfc-9292-7dcab96a6fee/crypt/zone    a63be222-b12b-40ec-9dd4-3a0068c6a578   in service    none      none          off        
+    oxp_ce1c13f3-bef2-4306-b0f2-4e39bd4a18b6/crypt/zone    750d6910-096b-4f39-a8b5-d8f09c80d3db   in service    none      none          off        
+    oxp_f931ec80-a3e3-4adb-a8ba-fa5adbd2294c/crypt/zone    a16b5eaa-346d-4516-8af2-5154697c5d72   in service    none      none          off        
+    oxp_44fa7024-c2bc-4d2c-b478-c4997e4aece8/crypt/debug   137ee88a-d89a-41a7-95d0-53e59f03a8e6   in service    100 GiB   none          gzip-9     
+    oxp_8562317c-4736-4cfc-9292-7dcab96a6fee/crypt/debug   67ebc7eb-f34d-4c8c-bd5c-6c69caf142af   in service    100 GiB   none          gzip-9     
+    oxp_ce1c13f3-bef2-4306-b0f2-4e39bd4a18b6/crypt/debug   673a9c1d-d762-4328-adbe-1fe1a158cc32   in service    100 GiB   none          gzip-9     
+    oxp_f931ec80-a3e3-4adb-a8ba-fa5adbd2294c/crypt/debug   d2c79018-e2df-4258-893b-fb7b6cacce44   in service    100 GiB   none          gzip-9     
 
 
     omicron zones at generation 1:

--- a/dev-tools/reconfigurator-cli/tests/output/cmd-expunge-newly-added-stdout
+++ b/dev-tools/reconfigurator-cli/tests/output/cmd-expunge-newly-added-stdout
@@ -28,6 +28,61 @@ parent:    06c88262-f435-410e-ba98-101bed41ec27
     fake-vendor   fake-model   serial-fb29d469-7d3f-47b9-944c-ce817fc70370
 
 
+    datasets at generation 2:
+    -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
+    dataset name                                                                                                   dataset id                             disposition   quota     reservation   compression
+    -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
+    oxp_3b46c403-ad14-435c-a1a8-e8f940bf814f/crucible                                                              7426782a-b56d-4bcd-a061-ef999680a483   in service    none      none          off        
+    oxp_3f8c9484-06e8-4662-9a90-aa7e92c43405/crucible                                                              ca4f4d56-e1be-4535-abc7-fa5e131f5be4   in service    none      none          off        
+    oxp_4a62a827-4bf3-45d5-a7f5-d080f25c61ef/crucible                                                              60b31115-e269-4cc6-967a-1bd86632ce6e   in service    none      none          off        
+    oxp_5f774f00-52b7-41b5-a57f-6f38037196f5/crucible                                                              6081371a-e229-4168-9706-99ed750d0beb   in service    none      none          off        
+    oxp_68ae41d4-99ed-4612-99e1-fecf795ca694/crucible                                                              3304ddb3-a458-4852-9955-2fae08196d35   in service    none      none          off        
+    oxp_6a66241b-b595-423d-84ef-a81b5d8430e8/crucible                                                              ba9a2005-5bc2-414d-ae3a-fffd398d4b78   in service    none      none          off        
+    oxp_7c45c3f6-6369-40d9-a73f-2f7ed0afe96b/crucible                                                              7fd796bb-369b-4f22-b552-f45ce12836b4   in service    none      none          off        
+    oxp_a216d334-4a9a-49dd-8b13-20548839306c/crucible                                                              a8d0b8ae-fec4-4c7e-b286-869d6f888616   in service    none      none          off        
+    oxp_c9ff8eb0-807c-40ad-a5c4-0d534947c9ad/crucible                                                              c0071842-4e56-40e9-a53a-0ea8242a66f4   in service    none      none          off        
+    oxp_fb29d469-7d3f-47b9-944c-ce817fc70370/crucible                                                              1463807d-6615-4643-95e2-8cfcfdffc5a2   in service    none      none          off        
+    oxp_3b46c403-ad14-435c-a1a8-e8f940bf814f/crypt/clickhouse                                                      b5197e35-15e8-423e-931f-ba32b3842eef   in service    none      none          off        
+    oxp_3b46c403-ad14-435c-a1a8-e8f940bf814f/crypt/external_dns                                                    65abb419-b456-4cac-9ca5-bcd823457692   in service    none      none          off        
+    oxp_3b46c403-ad14-435c-a1a8-e8f940bf814f/crypt/internal_dns                                                    d17fa7c3-e285-4725-9f69-185708d1d55c   in service    none      none          off        
+    oxp_3b46c403-ad14-435c-a1a8-e8f940bf814f/crypt/zone                                                            f68397e5-da5d-4d93-94a4-b68951f30522   in service    none      none          off        
+    oxp_3f8c9484-06e8-4662-9a90-aa7e92c43405/crypt/zone                                                            6d833180-97ee-461b-8cbd-62007f3172e3   in service    none      none          off        
+    oxp_4a62a827-4bf3-45d5-a7f5-d080f25c61ef/crypt/zone                                                            085f6578-6bb9-4cd6-9274-aa50a274fddb   in service    none      none          off        
+    oxp_5f774f00-52b7-41b5-a57f-6f38037196f5/crypt/zone                                                            0de067e1-b626-494a-9d41-03de4036c922   in service    none      none          off        
+    oxp_68ae41d4-99ed-4612-99e1-fecf795ca694/crypt/zone                                                            0b76c44a-1d99-460d-87fd-3ae5c8b241b9   in service    none      none          off        
+    oxp_6a66241b-b595-423d-84ef-a81b5d8430e8/crypt/zone                                                            cb33c02a-6db4-402b-adcf-919957342c84   in service    none      none          off        
+    oxp_7c45c3f6-6369-40d9-a73f-2f7ed0afe96b/crypt/zone                                                            9ea4aca6-ac88-4550-a4fd-10ddfd94e01e   in service    none      none          off        
+    oxp_a216d334-4a9a-49dd-8b13-20548839306c/crypt/zone                                                            b5e5d272-964b-40b7-9d03-fb92c4b491c0   in service    none      none          off        
+    oxp_c9ff8eb0-807c-40ad-a5c4-0d534947c9ad/crypt/zone                                                            219249df-e43f-4ee3-a4e2-eaa09b085d9a   in service    none      none          off        
+    oxp_fb29d469-7d3f-47b9-944c-ce817fc70370/crypt/zone                                                            e49ad6e5-2d96-4a2a-8e50-202d97d7f424   in service    none      none          off        
+    oxp_3b46c403-ad14-435c-a1a8-e8f940bf814f/crypt/zone/oxz_clickhouse_e9d3a6d6-6e95-4ec8-a857-a3ab1ce6e62d        6ee081c5-9830-4d6b-83a1-56f307b893fd   in service    none      none          off        
+    oxp_6a66241b-b595-423d-84ef-a81b5d8430e8/crypt/zone/oxz_crucible_53491964-307a-45f6-b277-79a5e90f20b7          80cb8976-735e-488d-8ff1-c49ec2bf4d4d   in service    none      none          off        
+    oxp_fb29d469-7d3f-47b9-944c-ce817fc70370/crypt/zone/oxz_crucible_777087c0-4fb9-43ed-846b-16aa6431a272          a03c380c-735d-434a-8e5c-6a39dfd1d54e   in service    none      none          off        
+    oxp_68ae41d4-99ed-4612-99e1-fecf795ca694/crypt/zone/oxz_crucible_78a45052-138b-47ee-877d-e73143467c8a          6f8bfed8-9387-4ef9-b307-873f072d349e   in service    none      none          off        
+    oxp_4a62a827-4bf3-45d5-a7f5-d080f25c61ef/crypt/zone/oxz_crucible_8ec567c1-6776-4573-bfe5-f3041165fdca          8886085a-1920-479b-ad17-7858a690aab1   in service    none      none          off        
+    oxp_c9ff8eb0-807c-40ad-a5c4-0d534947c9ad/crypt/zone/oxz_crucible_8ef7ff46-81f7-4f16-aa8f-0c1957589a5f          5579e9a2-eda0-4343-bb3a-7cf6d6910c3e   in service    none      none          off        
+    oxp_3f8c9484-06e8-4662-9a90-aa7e92c43405/crypt/zone/oxz_crucible_af3e8274-151f-4cb1-990c-b0a7680ff210          d773abef-bfdb-4c60-ba3d-8a980c9c50ed   in service    none      none          off        
+    oxp_5f774f00-52b7-41b5-a57f-6f38037196f5/crypt/zone/oxz_crucible_c3114d7e-07cd-4d80-b82b-49ccbe856af2          80da4d1c-b800-4f92-95ff-0e3f6e6b6eec   in service    none      none          off        
+    oxp_a216d334-4a9a-49dd-8b13-20548839306c/crypt/zone/oxz_crucible_d23b5191-04de-4b48-8599-cf866ffc06e8          8a7040dd-acf5-406f-9794-bb9844716585   in service    none      none          off        
+    oxp_3b46c403-ad14-435c-a1a8-e8f940bf814f/crypt/zone/oxz_crucible_efdbf061-321c-47d6-bf0f-4530ec4c287e          2b5f60f5-7830-4cf4-9051-a6a6dc470b66   in service    none      none          off        
+    oxp_7c45c3f6-6369-40d9-a73f-2f7ed0afe96b/crypt/zone/oxz_crucible_f31ab1c5-0f23-44dc-8504-c67c65afc11e          344481c4-02ad-4759-82c3-4986566f76bf   in service    none      none          off        
+    oxp_3b46c403-ad14-435c-a1a8-e8f940bf814f/crypt/zone/oxz_crucible_pantry_07738018-1b2a-4efc-8c5c-bd6b7a5d7b40   a4ca94e6-55de-405c-8a33-422ed5938bd3   in service    none      none          off        
+    oxp_3b46c403-ad14-435c-a1a8-e8f940bf814f/crypt/zone/oxz_external_dns_1b37911d-c427-4bf1-90d3-b2d0c2e98825      06af733b-6f79-4d4d-aef5-e18068a795df   in service    none      none          off        
+    oxp_3b46c403-ad14-435c-a1a8-e8f940bf814f/crypt/zone/oxz_internal_dns_7a1bd482-74f8-4562-b1db-c8bad16afb44      d648ac4b-0c2d-407b-84a5-05c25b24c463   in service    none      none          off        
+    oxp_3b46c403-ad14-435c-a1a8-e8f940bf814f/crypt/zone/oxz_nexus_ed2d3be3-fcee-4f6b-bb99-a1a9130c4eeb             a16bbe93-af8c-45bc-86ee-caff9ae76d17   in service    none      none          off        
+    oxp_3b46c403-ad14-435c-a1a8-e8f940bf814f/crypt/zone/oxz_ntp_8c368ed6-6c91-4437-b8ff-0d789193db38               dac5975a-67f3-44d7-9b0c-46a9f616ef4e   in service    none      none          off        
+    oxp_3b46c403-ad14-435c-a1a8-e8f940bf814f/crypt/debug                                                           86c4d965-971c-48fb-891d-9f63232d1577   in service    100 GiB   none          gzip-9     
+    oxp_3f8c9484-06e8-4662-9a90-aa7e92c43405/crypt/debug                                                           b3d9c2e2-c06d-4a99-bf4a-c8613691615a   in service    100 GiB   none          gzip-9     
+    oxp_4a62a827-4bf3-45d5-a7f5-d080f25c61ef/crypt/debug                                                           5c8561d4-afac-436b-b32c-e8dc44daa98a   in service    100 GiB   none          gzip-9     
+    oxp_5f774f00-52b7-41b5-a57f-6f38037196f5/crypt/debug                                                           c518735e-1306-4fbf-9ba4-010196249ee3   in service    100 GiB   none          gzip-9     
+    oxp_68ae41d4-99ed-4612-99e1-fecf795ca694/crypt/debug                                                           8b416b54-73b0-4fda-8d10-6823b67aa044   in service    100 GiB   none          gzip-9     
+    oxp_6a66241b-b595-423d-84ef-a81b5d8430e8/crypt/debug                                                           8194dbad-3f65-43d1-a7e0-50b23a81b674   in service    100 GiB   none          gzip-9     
+    oxp_7c45c3f6-6369-40d9-a73f-2f7ed0afe96b/crypt/debug                                                           ad878e0e-831b-4f0b-9417-1b17c5f5f744   in service    100 GiB   none          gzip-9     
+    oxp_a216d334-4a9a-49dd-8b13-20548839306c/crypt/debug                                                           5d15a682-d4ca-40be-8cf9-3cdc934c3787   in service    100 GiB   none          gzip-9     
+    oxp_c9ff8eb0-807c-40ad-a5c4-0d534947c9ad/crypt/debug                                                           5735d96e-efef-448d-8e40-cf0dc73a2c04   in service    100 GiB   none          gzip-9     
+    oxp_fb29d469-7d3f-47b9-944c-ce817fc70370/crypt/debug                                                           19c25551-a54c-47b6-8495-dbd51ed8e384   in service    100 GiB   none          gzip-9     
+
+
     omicron zones at generation 2:
     ---------------------------------------------------------------------------------------------
     zone type         zone id                                disposition   underlay IP           
@@ -69,6 +124,59 @@ parent:    06c88262-f435-410e-ba98-101bed41ec27
     fake-vendor   fake-model   serial-f1a041cc-85c7-4d14-8fc0-8d0e417f7e24
 
 
+    datasets at generation 2:
+    -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
+    dataset name                                                                                                   dataset id                             disposition   quota     reservation   compression
+    -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
+    oxp_1f9589d8-0a68-47e8-b977-d0fb17bd3fdb/crucible                                                              086f43f3-c939-4b81-8b42-a5cf1495e21a   in service    none      none          off        
+    oxp_44882b6c-5e19-418b-b6c3-065f2af5a557/crucible                                                              924b3557-8ab5-4edf-9c27-6617b89c7cdb   in service    none      none          off        
+    oxp_6de47efc-8a6d-4108-bf82-0146eab3be06/crucible                                                              ce82dc53-7e11-4403-be4b-2e9079126609   in service    none      none          off        
+    oxp_80e2c62f-052c-4580-8252-7af238fbbe9c/crucible                                                              39b7090c-574e-4fbc-8d06-c0b04e989e22   in service    none      none          off        
+    oxp_81d326ae-5f8a-4ffd-9d5e-a9e8246ac014/crucible                                                              867c9991-9dd1-46b5-989a-dfa280ccd135   in service    none      none          off        
+    oxp_878af5a0-7810-43e5-bdd5-a3215242459a/crucible                                                              4eae99b0-4319-4dcf-b2b4-22dab063b7fa   in service    none      none          off        
+    oxp_af59fef5-8258-4852-be1d-ce55ae7dc822/crucible                                                              0284b755-6ab8-427c-9e8c-e078c7369f04   in service    none      none          off        
+    oxp_b16aa11f-6e49-44c1-abcb-2e7584bffa12/crucible                                                              99a6bc05-1c43-455d-8b50-7e9e08a12602   in service    none      none          off        
+    oxp_f173c79b-a3b4-4f4a-a983-bc94b6b1a616/crucible                                                              4f8aafc8-21a7-4c64-9613-21b8d5162ed2   in service    none      none          off        
+    oxp_f1a041cc-85c7-4d14-8fc0-8d0e417f7e24/crucible                                                              004d26f7-f145-41c7-b708-1bffbaa31250   in service    none      none          off        
+    oxp_1f9589d8-0a68-47e8-b977-d0fb17bd3fdb/crypt/external_dns                                                    2ab4f9d3-6497-4d4b-bc61-daab02e40086   in service    none      none          off        
+    oxp_1f9589d8-0a68-47e8-b977-d0fb17bd3fdb/crypt/internal_dns                                                    fe27f0e0-acf4-4868-858e-b7c33bf904f3   in service    none      none          off        
+    oxp_1f9589d8-0a68-47e8-b977-d0fb17bd3fdb/crypt/zone                                                            c06bd208-d236-48d1-a8c0-b6d523b3fc3e   in service    none      none          off        
+    oxp_44882b6c-5e19-418b-b6c3-065f2af5a557/crypt/zone                                                            4ffdc4b3-694c-4c99-8e76-80df0ca3b2a4   in service    none      none          off        
+    oxp_6de47efc-8a6d-4108-bf82-0146eab3be06/crypt/zone                                                            5759f27e-3767-42df-9a76-4665267435c4   in service    none      none          off        
+    oxp_80e2c62f-052c-4580-8252-7af238fbbe9c/crypt/zone                                                            ea67cf51-95cf-40a1-af30-5d01b4e3537d   in service    none      none          off        
+    oxp_81d326ae-5f8a-4ffd-9d5e-a9e8246ac014/crypt/zone                                                            fa8d69c3-525e-4b9c-882d-1f31221e13b9   in service    none      none          off        
+    oxp_878af5a0-7810-43e5-bdd5-a3215242459a/crypt/zone                                                            f36eed10-3342-40db-a91a-724995c775f4   in service    none      none          off        
+    oxp_af59fef5-8258-4852-be1d-ce55ae7dc822/crypt/zone                                                            dec78c6b-0b4d-48a0-b471-8c0b357d2d5c   in service    none      none          off        
+    oxp_b16aa11f-6e49-44c1-abcb-2e7584bffa12/crypt/zone                                                            1b14f925-2368-4251-b303-07b193e88d0d   in service    none      none          off        
+    oxp_f173c79b-a3b4-4f4a-a983-bc94b6b1a616/crypt/zone                                                            511e9dc3-19d9-4e65-b670-a7123f086197   in service    none      none          off        
+    oxp_f1a041cc-85c7-4d14-8fc0-8d0e417f7e24/crypt/zone                                                            70b97568-5812-4246-8bd7-eae3be369fb9   in service    none      none          off        
+    oxp_6de47efc-8a6d-4108-bf82-0146eab3be06/crypt/zone/oxz_crucible_426cd521-e6ad-4a67-ad8d-a1acef5eab5e          381cb9c8-ee74-4b4d-adfb-f659933bdfec   in service    none      none          off        
+    oxp_f173c79b-a3b4-4f4a-a983-bc94b6b1a616/crypt/zone/oxz_crucible_4a392139-7423-459b-b1c9-5903421be40c          e57920ec-4bbc-4e93-906c-53e04bca6dc6   in service    none      none          off        
+    oxp_44882b6c-5e19-418b-b6c3-065f2af5a557/crypt/zone/oxz_crucible_51e403e5-a703-4cfb-b044-c72c52885e82          e7656c10-357a-427a-9e31-9b0462f0126d   in service    none      none          off        
+    oxp_1f9589d8-0a68-47e8-b977-d0fb17bd3fdb/crypt/zone/oxz_crucible_55a2094a-9590-442f-8203-dffe5a76ae66          f3d6bda9-83c1-40c5-bbd0-4d6ef040c6f8   in service    none      none          off        
+    oxp_81d326ae-5f8a-4ffd-9d5e-a9e8246ac014/crypt/zone/oxz_crucible_758d9a91-7070-43e3-8c60-ea1d0f818a12          0821ec11-cd56-4215-9199-6f3ea4fc92d5   in service    none      none          off        
+    oxp_878af5a0-7810-43e5-bdd5-a3215242459a/crypt/zone/oxz_crucible_8e4d80f8-80ea-48ac-ad47-95501c0c3fbe          9617a578-3d42-4e91-b4aa-48c0e718a9ae   in service    none      none          off        
+    oxp_f1a041cc-85c7-4d14-8fc0-8d0e417f7e24/crypt/zone/oxz_crucible_cbf109e0-cdd5-48f9-8998-e9f55c9be980          a2a01591-b10e-46a0-b91f-633c433c269b   in service    none      none          off        
+    oxp_b16aa11f-6e49-44c1-abcb-2e7584bffa12/crypt/zone/oxz_crucible_d60cc034-46c4-4233-8066-4008e947d904          0960a21d-c165-47ca-bd48-287e01168038   in service    none      none          off        
+    oxp_af59fef5-8258-4852-be1d-ce55ae7dc822/crypt/zone/oxz_crucible_f24b63e6-2382-4862-90bf-c39e42aad988          31f2b888-9f13-4584-878f-431c3d65c3b5   in service    none      none          off        
+    oxp_80e2c62f-052c-4580-8252-7af238fbbe9c/crypt/zone/oxz_crucible_fddd2bd6-a535-4e2c-9a36-cb90d048c0b7          69c63a34-be5f-4e62-bf44-e0902b1996dd   in service    none      none          off        
+    oxp_1f9589d8-0a68-47e8-b977-d0fb17bd3fdb/crypt/zone/oxz_crucible_pantry_eb4f0a57-7386-4216-bcb2-874d39aae836   636c3b45-4c7b-46a1-9852-ccbf5380ca23   in service    none      none          off        
+    oxp_1f9589d8-0a68-47e8-b977-d0fb17bd3fdb/crypt/zone/oxz_external_dns_47387358-e16d-4c34-b8f7-1f3f12c662eb      2cb6c311-5478-497c-afb0-672998b013b8   in service    none      none          off        
+    oxp_1f9589d8-0a68-47e8-b977-d0fb17bd3fdb/crypt/zone/oxz_internal_dns_edb6573c-3621-4d95-ad3b-93a088caeea5      f93c3b9e-88e2-4e2d-8df1-3e3fe9e1705f   in service    none      none          off        
+    oxp_1f9589d8-0a68-47e8-b977-d0fb17bd3fdb/crypt/zone/oxz_nexus_2cea0275-1fbc-410c-819e-2ec54ffeeffe             94b7f78b-bb21-493d-85de-6ae9bfd9a2f2   in service    none      none          off        
+    oxp_1f9589d8-0a68-47e8-b977-d0fb17bd3fdb/crypt/zone/oxz_ntp_6e1cdf48-6846-4bb3-8a72-8bc1e8d5b21d               e292f06d-aed2-4363-926c-1ca27866fb83   in service    none      none          off        
+    oxp_1f9589d8-0a68-47e8-b977-d0fb17bd3fdb/crypt/debug                                                           ae33e813-ae6f-4744-a335-9eb96d66c717   in service    100 GiB   none          gzip-9     
+    oxp_44882b6c-5e19-418b-b6c3-065f2af5a557/crypt/debug                                                           1b4b24fb-db9e-4edc-a934-8d4ef8527879   in service    100 GiB   none          gzip-9     
+    oxp_6de47efc-8a6d-4108-bf82-0146eab3be06/crypt/debug                                                           690c814f-6000-444b-b488-a90937eb07ca   in service    100 GiB   none          gzip-9     
+    oxp_80e2c62f-052c-4580-8252-7af238fbbe9c/crypt/debug                                                           c31e1ff2-6d54-4c3d-96bd-9bf697e37757   in service    100 GiB   none          gzip-9     
+    oxp_81d326ae-5f8a-4ffd-9d5e-a9e8246ac014/crypt/debug                                                           7cc4ea30-7f2f-48fe-a58b-30e62f52e27f   in service    100 GiB   none          gzip-9     
+    oxp_878af5a0-7810-43e5-bdd5-a3215242459a/crypt/debug                                                           4e14806d-82e2-44b9-aff1-cf558c1910fb   in service    100 GiB   none          gzip-9     
+    oxp_af59fef5-8258-4852-be1d-ce55ae7dc822/crypt/debug                                                           597c0560-2cb6-486a-9e87-a0ad425c36da   in service    100 GiB   none          gzip-9     
+    oxp_b16aa11f-6e49-44c1-abcb-2e7584bffa12/crypt/debug                                                           23fbb19c-a9e9-4631-ab2b-d0b97de444c1   in service    100 GiB   none          gzip-9     
+    oxp_f173c79b-a3b4-4f4a-a983-bc94b6b1a616/crypt/debug                                                           e75ed71c-f3a3-429e-9bb4-22a24572a9d2   in service    100 GiB   none          gzip-9     
+    oxp_f1a041cc-85c7-4d14-8fc0-8d0e417f7e24/crypt/debug                                                           83b408b5-02b6-4f06-bd08-f6a807d3c5e8   in service    100 GiB   none          gzip-9     
+
+
     omicron zones at generation 2:
     ---------------------------------------------------------------------------------------------
     zone type         zone id                                disposition   underlay IP           
@@ -107,6 +215,59 @@ parent:    06c88262-f435-410e-ba98-101bed41ec27
     fake-vendor   fake-model   serial-d4ad3cc1-956a-4444-81a6-da6a025f6df2
     fake-vendor   fake-model   serial-e1298a43-fa1a-4e6f-bcfa-b26996f69c50
     fake-vendor   fake-model   serial-fa9ce87c-fa7c-4854-95bd-69b8f01c46f9
+
+
+    datasets at generation 2:
+    -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
+    dataset name                                                                                                   dataset id                             disposition   quota     reservation   compression
+    -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
+    oxp_2f26e76b-6c91-4ee9-87b3-f424b942091b/crucible                                                              dd2ac836-55e7-4f13-a39f-24fbf9122dee   in service    none      none          off        
+    oxp_6f8fa855-4f34-42db-a6e4-9d0090d6c828/crucible                                                              b1d078dc-62ee-433a-b8cf-854fefb22039   in service    none      none          off        
+    oxp_71450d62-791e-4068-9882-8a206a465fd9/crucible                                                              91ea5860-a12b-458a-9b47-a3960e2d78b8   in service    none      none          off        
+    oxp_7b4ad242-8330-4c08-9588-c66782742678/crucible                                                              9316a944-5d51-475a-ad89-8df8b4dd0863   in service    none      none          off        
+    oxp_9bf23b52-565e-4439-9728-edb603fa6c4e/crucible                                                              8dabf037-8d33-47e3-95fc-ada8d20f1d44   in service    none      none          off        
+    oxp_c9476e3d-7745-4fa9-b336-b54ac5b08f56/crucible                                                              1e28e523-e77a-4270-99d1-fd3810e1aad9   in service    none      none          off        
+    oxp_d2cd1e65-b63d-4748-895f-aafecc81e440/crucible                                                              28ba9385-4ebf-49ce-9fa2-5c549ad1fded   in service    none      none          off        
+    oxp_d4ad3cc1-956a-4444-81a6-da6a025f6df2/crucible                                                              fdc03ce9-b4f2-47aa-bff8-b0b2a05fe3b0   in service    none      none          off        
+    oxp_e1298a43-fa1a-4e6f-bcfa-b26996f69c50/crucible                                                              7d9f72bd-23bc-40e6-97c5-a53ca255588d   in service    none      none          off        
+    oxp_fa9ce87c-fa7c-4854-95bd-69b8f01c46f9/crucible                                                              bf673cd5-b04e-4088-b017-c7a714ce2b63   in service    none      none          off        
+    oxp_2f26e76b-6c91-4ee9-87b3-f424b942091b/crypt/external_dns                                                    195da8dd-34fd-4e96-a949-b7329710133e   in service    none      none          off        
+    oxp_2f26e76b-6c91-4ee9-87b3-f424b942091b/crypt/internal_dns                                                    92ff6262-7b3c-4300-bb53-936bd3edce26   in service    none      none          off        
+    oxp_2f26e76b-6c91-4ee9-87b3-f424b942091b/crypt/zone                                                            9d6ab53a-6474-4ed6-8beb-9be1758229f5   in service    none      none          off        
+    oxp_6f8fa855-4f34-42db-a6e4-9d0090d6c828/crypt/zone                                                            df385279-2886-4422-957f-88f1f382a90b   in service    none      none          off        
+    oxp_71450d62-791e-4068-9882-8a206a465fd9/crypt/zone                                                            97a12796-0555-47c5-a0d3-c136e0e919f6   in service    none      none          off        
+    oxp_7b4ad242-8330-4c08-9588-c66782742678/crypt/zone                                                            39343108-efec-4643-80c8-1c741d045dad   in service    none      none          off        
+    oxp_9bf23b52-565e-4439-9728-edb603fa6c4e/crypt/zone                                                            b58b762a-7124-4441-a334-16d552f576f3   in service    none      none          off        
+    oxp_c9476e3d-7745-4fa9-b336-b54ac5b08f56/crypt/zone                                                            92c63f1f-4ba8-4a41-93c0-e227b3320eaa   in service    none      none          off        
+    oxp_d2cd1e65-b63d-4748-895f-aafecc81e440/crypt/zone                                                            434bf6e8-b885-441d-b944-9508b0c64311   in service    none      none          off        
+    oxp_d4ad3cc1-956a-4444-81a6-da6a025f6df2/crypt/zone                                                            58e91146-8da0-449a-adab-6e93504c9bf0   in service    none      none          off        
+    oxp_e1298a43-fa1a-4e6f-bcfa-b26996f69c50/crypt/zone                                                            e56258ab-55c4-42ca-95e5-ea8bbeff84e1   in service    none      none          off        
+    oxp_fa9ce87c-fa7c-4854-95bd-69b8f01c46f9/crypt/zone                                                            e070deb1-5298-46fb-983f-b6e153e98cd7   in service    none      none          off        
+    oxp_2f26e76b-6c91-4ee9-87b3-f424b942091b/crypt/zone/oxz_crucible_0903299a-6296-44f0-8ab9-7c70b5766a05          277b0d6a-bb61-4eb2-bd11-d750586b5fbc   in service    none      none          off        
+    oxp_71450d62-791e-4068-9882-8a206a465fd9/crypt/zone/oxz_crucible_2b6b3cfd-4524-465b-ac6e-10be9ab6d4d4          5073cf86-7d36-4c98-9e34-559172a0bc84   in service    none      none          off        
+    oxp_e1298a43-fa1a-4e6f-bcfa-b26996f69c50/crypt/zone/oxz_crucible_3e0ff677-2ca8-4124-9fef-7c23ac2da6fa          028fc58f-16ea-4536-9f50-b4eeb1aa57c9   in service    none      none          off        
+    oxp_c9476e3d-7745-4fa9-b336-b54ac5b08f56/crypt/zone/oxz_crucible_512758d0-335f-4c94-9afe-c82f6f127421          f20e7661-c0c7-47cd-b08a-e7f5b76026d6   in service    none      none          off        
+    oxp_6f8fa855-4f34-42db-a6e4-9d0090d6c828/crypt/zone/oxz_crucible_8ae67b12-ca74-40d3-a55e-90456cd623ea          3f7802ee-87bb-48d6-a42d-657bd0f85c74   in service    none      none          off        
+    oxp_fa9ce87c-fa7c-4854-95bd-69b8f01c46f9/crypt/zone/oxz_crucible_918c8cbc-1c62-4de5-9cf2-c4153a3d1a7e          41d832ad-7b85-4214-b485-9ca2ed4f85d0   in service    none      none          off        
+    oxp_7b4ad242-8330-4c08-9588-c66782742678/crypt/zone/oxz_crucible_be422e7a-16d0-426e-8567-da0aed7200d4          e0fb453d-b22c-4d87-be9b-94f6113cb25a   in service    none      none          off        
+    oxp_d2cd1e65-b63d-4748-895f-aafecc81e440/crypt/zone/oxz_crucible_ea50f438-1b5e-4d61-bd65-46d360f590ee          26a25185-a37f-4ead-8c81-77be56a21b0a   in service    none      none          off        
+    oxp_9bf23b52-565e-4439-9728-edb603fa6c4e/crypt/zone/oxz_crucible_f055a042-9d1b-4931-8268-d94cac801d7e          998b0fb1-b562-4858-a9ae-c02296c7c6ed   in service    none      none          off        
+    oxp_d4ad3cc1-956a-4444-81a6-da6a025f6df2/crypt/zone/oxz_crucible_f33e09d1-e3d7-4341-baf2-5f079f3679e5          aa4f1267-a83a-4081-b572-28e1860ff2f2   in service    none      none          off        
+    oxp_2f26e76b-6c91-4ee9-87b3-f424b942091b/crypt/zone/oxz_crucible_pantry_100e20aa-1816-4195-8d76-08beace10332   032bf309-8046-4c96-9453-29b9346b19fc   in service    none      none          off        
+    oxp_2f26e76b-6c91-4ee9-87b3-f424b942091b/crypt/zone/oxz_external_dns_9995de32-dd52-4eb1-b0eb-141eb84bc739      f258d941-f8b3-4d0e-bbe6-773996a002d5   in service    none      none          off        
+    oxp_2f26e76b-6c91-4ee9-87b3-f424b942091b/crypt/zone/oxz_internal_dns_171cabf0-8635-42e7-8ea1-2a1d2a2daf55      3531c6de-8d31-4917-bb72-884b6e168eca   in service    none      none          off        
+    oxp_2f26e76b-6c91-4ee9-87b3-f424b942091b/crypt/zone/oxz_nexus_5b01b0e0-5cdf-4b34-b0a6-c947cbbdb8be             5e3a1b9d-9475-4bd9-8112-5595a7c0da7d   in service    none      none          off        
+    oxp_2f26e76b-6c91-4ee9-87b3-f424b942091b/crypt/zone/oxz_ntp_7b4bccad-9869-48da-8320-2dc82752deea               45771e96-054c-4b05-8021-c32b23fcad8d   in service    none      none          off        
+    oxp_2f26e76b-6c91-4ee9-87b3-f424b942091b/crypt/debug                                                           29be83b4-4d0b-4787-819d-96e8e69301da   in service    100 GiB   none          gzip-9     
+    oxp_6f8fa855-4f34-42db-a6e4-9d0090d6c828/crypt/debug                                                           ce433c69-7540-4a7a-9e11-dd30b0d2dc19   in service    100 GiB   none          gzip-9     
+    oxp_71450d62-791e-4068-9882-8a206a465fd9/crypt/debug                                                           48cc9313-13c2-4ebe-8120-5b648ec26a28   in service    100 GiB   none          gzip-9     
+    oxp_7b4ad242-8330-4c08-9588-c66782742678/crypt/debug                                                           cdcfe435-881a-44dc-9dba-2a0fafdbf66d   in service    100 GiB   none          gzip-9     
+    oxp_9bf23b52-565e-4439-9728-edb603fa6c4e/crypt/debug                                                           835edc8b-9d33-45db-9bdc-ea8a956f3217   in service    100 GiB   none          gzip-9     
+    oxp_c9476e3d-7745-4fa9-b336-b54ac5b08f56/crypt/debug                                                           1754b8f0-07b8-4305-8bb2-b347ba3e0b68   in service    100 GiB   none          gzip-9     
+    oxp_d2cd1e65-b63d-4748-895f-aafecc81e440/crypt/debug                                                           7028b888-b4c0-43e5-a9d4-2e29d24f34a7   in service    100 GiB   none          gzip-9     
+    oxp_d4ad3cc1-956a-4444-81a6-da6a025f6df2/crypt/debug                                                           36ad4fe9-3897-4777-bc0e-88f142594d07   in service    100 GiB   none          gzip-9     
+    oxp_e1298a43-fa1a-4e6f-bcfa-b26996f69c50/crypt/debug                                                           d37e0b8c-6c43-4e83-b3ec-238429d1cbfb   in service    100 GiB   none          gzip-9     
+    oxp_fa9ce87c-fa7c-4854-95bd-69b8f01c46f9/crypt/debug                                                           b7569aa4-f0d6-4de0-9b9a-cd8d0a6cc01d   in service    100 GiB   none          gzip-9     
 
 
     omicron zones at generation 2:
@@ -170,6 +331,61 @@ parent:    3f00b694-1b16-4aaa-8f78-e6b3a527b434
     fake-vendor   fake-model   serial-fb29d469-7d3f-47b9-944c-ce817fc70370
 
 
+    datasets at generation 2:
+    -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
+    dataset name                                                                                                   dataset id                             disposition   quota     reservation   compression
+    -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
+    oxp_3b46c403-ad14-435c-a1a8-e8f940bf814f/crucible                                                              7426782a-b56d-4bcd-a061-ef999680a483   in service    none      none          off        
+    oxp_3f8c9484-06e8-4662-9a90-aa7e92c43405/crucible                                                              ca4f4d56-e1be-4535-abc7-fa5e131f5be4   in service    none      none          off        
+    oxp_4a62a827-4bf3-45d5-a7f5-d080f25c61ef/crucible                                                              60b31115-e269-4cc6-967a-1bd86632ce6e   in service    none      none          off        
+    oxp_5f774f00-52b7-41b5-a57f-6f38037196f5/crucible                                                              6081371a-e229-4168-9706-99ed750d0beb   in service    none      none          off        
+    oxp_68ae41d4-99ed-4612-99e1-fecf795ca694/crucible                                                              3304ddb3-a458-4852-9955-2fae08196d35   in service    none      none          off        
+    oxp_6a66241b-b595-423d-84ef-a81b5d8430e8/crucible                                                              ba9a2005-5bc2-414d-ae3a-fffd398d4b78   in service    none      none          off        
+    oxp_7c45c3f6-6369-40d9-a73f-2f7ed0afe96b/crucible                                                              7fd796bb-369b-4f22-b552-f45ce12836b4   in service    none      none          off        
+    oxp_a216d334-4a9a-49dd-8b13-20548839306c/crucible                                                              a8d0b8ae-fec4-4c7e-b286-869d6f888616   in service    none      none          off        
+    oxp_c9ff8eb0-807c-40ad-a5c4-0d534947c9ad/crucible                                                              c0071842-4e56-40e9-a53a-0ea8242a66f4   in service    none      none          off        
+    oxp_fb29d469-7d3f-47b9-944c-ce817fc70370/crucible                                                              1463807d-6615-4643-95e2-8cfcfdffc5a2   in service    none      none          off        
+    oxp_3b46c403-ad14-435c-a1a8-e8f940bf814f/crypt/clickhouse                                                      b5197e35-15e8-423e-931f-ba32b3842eef   in service    none      none          off        
+    oxp_3b46c403-ad14-435c-a1a8-e8f940bf814f/crypt/external_dns                                                    65abb419-b456-4cac-9ca5-bcd823457692   in service    none      none          off        
+    oxp_3b46c403-ad14-435c-a1a8-e8f940bf814f/crypt/internal_dns                                                    d17fa7c3-e285-4725-9f69-185708d1d55c   in service    none      none          off        
+    oxp_3b46c403-ad14-435c-a1a8-e8f940bf814f/crypt/zone                                                            f68397e5-da5d-4d93-94a4-b68951f30522   in service    none      none          off        
+    oxp_3f8c9484-06e8-4662-9a90-aa7e92c43405/crypt/zone                                                            6d833180-97ee-461b-8cbd-62007f3172e3   in service    none      none          off        
+    oxp_4a62a827-4bf3-45d5-a7f5-d080f25c61ef/crypt/zone                                                            085f6578-6bb9-4cd6-9274-aa50a274fddb   in service    none      none          off        
+    oxp_5f774f00-52b7-41b5-a57f-6f38037196f5/crypt/zone                                                            0de067e1-b626-494a-9d41-03de4036c922   in service    none      none          off        
+    oxp_68ae41d4-99ed-4612-99e1-fecf795ca694/crypt/zone                                                            0b76c44a-1d99-460d-87fd-3ae5c8b241b9   in service    none      none          off        
+    oxp_6a66241b-b595-423d-84ef-a81b5d8430e8/crypt/zone                                                            cb33c02a-6db4-402b-adcf-919957342c84   in service    none      none          off        
+    oxp_7c45c3f6-6369-40d9-a73f-2f7ed0afe96b/crypt/zone                                                            9ea4aca6-ac88-4550-a4fd-10ddfd94e01e   in service    none      none          off        
+    oxp_a216d334-4a9a-49dd-8b13-20548839306c/crypt/zone                                                            b5e5d272-964b-40b7-9d03-fb92c4b491c0   in service    none      none          off        
+    oxp_c9ff8eb0-807c-40ad-a5c4-0d534947c9ad/crypt/zone                                                            219249df-e43f-4ee3-a4e2-eaa09b085d9a   in service    none      none          off        
+    oxp_fb29d469-7d3f-47b9-944c-ce817fc70370/crypt/zone                                                            e49ad6e5-2d96-4a2a-8e50-202d97d7f424   in service    none      none          off        
+    oxp_3b46c403-ad14-435c-a1a8-e8f940bf814f/crypt/zone/oxz_clickhouse_e9d3a6d6-6e95-4ec8-a857-a3ab1ce6e62d        6ee081c5-9830-4d6b-83a1-56f307b893fd   in service    none      none          off        
+    oxp_6a66241b-b595-423d-84ef-a81b5d8430e8/crypt/zone/oxz_crucible_53491964-307a-45f6-b277-79a5e90f20b7          80cb8976-735e-488d-8ff1-c49ec2bf4d4d   in service    none      none          off        
+    oxp_fb29d469-7d3f-47b9-944c-ce817fc70370/crypt/zone/oxz_crucible_777087c0-4fb9-43ed-846b-16aa6431a272          a03c380c-735d-434a-8e5c-6a39dfd1d54e   in service    none      none          off        
+    oxp_68ae41d4-99ed-4612-99e1-fecf795ca694/crypt/zone/oxz_crucible_78a45052-138b-47ee-877d-e73143467c8a          6f8bfed8-9387-4ef9-b307-873f072d349e   in service    none      none          off        
+    oxp_4a62a827-4bf3-45d5-a7f5-d080f25c61ef/crypt/zone/oxz_crucible_8ec567c1-6776-4573-bfe5-f3041165fdca          8886085a-1920-479b-ad17-7858a690aab1   in service    none      none          off        
+    oxp_c9ff8eb0-807c-40ad-a5c4-0d534947c9ad/crypt/zone/oxz_crucible_8ef7ff46-81f7-4f16-aa8f-0c1957589a5f          5579e9a2-eda0-4343-bb3a-7cf6d6910c3e   in service    none      none          off        
+    oxp_3f8c9484-06e8-4662-9a90-aa7e92c43405/crypt/zone/oxz_crucible_af3e8274-151f-4cb1-990c-b0a7680ff210          d773abef-bfdb-4c60-ba3d-8a980c9c50ed   in service    none      none          off        
+    oxp_5f774f00-52b7-41b5-a57f-6f38037196f5/crypt/zone/oxz_crucible_c3114d7e-07cd-4d80-b82b-49ccbe856af2          80da4d1c-b800-4f92-95ff-0e3f6e6b6eec   in service    none      none          off        
+    oxp_a216d334-4a9a-49dd-8b13-20548839306c/crypt/zone/oxz_crucible_d23b5191-04de-4b48-8599-cf866ffc06e8          8a7040dd-acf5-406f-9794-bb9844716585   in service    none      none          off        
+    oxp_3b46c403-ad14-435c-a1a8-e8f940bf814f/crypt/zone/oxz_crucible_efdbf061-321c-47d6-bf0f-4530ec4c287e          2b5f60f5-7830-4cf4-9051-a6a6dc470b66   in service    none      none          off        
+    oxp_7c45c3f6-6369-40d9-a73f-2f7ed0afe96b/crypt/zone/oxz_crucible_f31ab1c5-0f23-44dc-8504-c67c65afc11e          344481c4-02ad-4759-82c3-4986566f76bf   in service    none      none          off        
+    oxp_3b46c403-ad14-435c-a1a8-e8f940bf814f/crypt/zone/oxz_crucible_pantry_07738018-1b2a-4efc-8c5c-bd6b7a5d7b40   a4ca94e6-55de-405c-8a33-422ed5938bd3   in service    none      none          off        
+    oxp_3b46c403-ad14-435c-a1a8-e8f940bf814f/crypt/zone/oxz_external_dns_1b37911d-c427-4bf1-90d3-b2d0c2e98825      06af733b-6f79-4d4d-aef5-e18068a795df   in service    none      none          off        
+    oxp_3b46c403-ad14-435c-a1a8-e8f940bf814f/crypt/zone/oxz_internal_dns_7a1bd482-74f8-4562-b1db-c8bad16afb44      d648ac4b-0c2d-407b-84a5-05c25b24c463   in service    none      none          off        
+    oxp_3b46c403-ad14-435c-a1a8-e8f940bf814f/crypt/zone/oxz_nexus_ed2d3be3-fcee-4f6b-bb99-a1a9130c4eeb             a16bbe93-af8c-45bc-86ee-caff9ae76d17   in service    none      none          off        
+    oxp_3b46c403-ad14-435c-a1a8-e8f940bf814f/crypt/zone/oxz_ntp_8c368ed6-6c91-4437-b8ff-0d789193db38               dac5975a-67f3-44d7-9b0c-46a9f616ef4e   in service    none      none          off        
+    oxp_3b46c403-ad14-435c-a1a8-e8f940bf814f/crypt/debug                                                           86c4d965-971c-48fb-891d-9f63232d1577   in service    100 GiB   none          gzip-9     
+    oxp_3f8c9484-06e8-4662-9a90-aa7e92c43405/crypt/debug                                                           b3d9c2e2-c06d-4a99-bf4a-c8613691615a   in service    100 GiB   none          gzip-9     
+    oxp_4a62a827-4bf3-45d5-a7f5-d080f25c61ef/crypt/debug                                                           5c8561d4-afac-436b-b32c-e8dc44daa98a   in service    100 GiB   none          gzip-9     
+    oxp_5f774f00-52b7-41b5-a57f-6f38037196f5/crypt/debug                                                           c518735e-1306-4fbf-9ba4-010196249ee3   in service    100 GiB   none          gzip-9     
+    oxp_68ae41d4-99ed-4612-99e1-fecf795ca694/crypt/debug                                                           8b416b54-73b0-4fda-8d10-6823b67aa044   in service    100 GiB   none          gzip-9     
+    oxp_6a66241b-b595-423d-84ef-a81b5d8430e8/crypt/debug                                                           8194dbad-3f65-43d1-a7e0-50b23a81b674   in service    100 GiB   none          gzip-9     
+    oxp_7c45c3f6-6369-40d9-a73f-2f7ed0afe96b/crypt/debug                                                           ad878e0e-831b-4f0b-9417-1b17c5f5f744   in service    100 GiB   none          gzip-9     
+    oxp_a216d334-4a9a-49dd-8b13-20548839306c/crypt/debug                                                           5d15a682-d4ca-40be-8cf9-3cdc934c3787   in service    100 GiB   none          gzip-9     
+    oxp_c9ff8eb0-807c-40ad-a5c4-0d534947c9ad/crypt/debug                                                           5735d96e-efef-448d-8e40-cf0dc73a2c04   in service    100 GiB   none          gzip-9     
+    oxp_fb29d469-7d3f-47b9-944c-ce817fc70370/crypt/debug                                                           19c25551-a54c-47b6-8495-dbd51ed8e384   in service    100 GiB   none          gzip-9     
+
+
     omicron zones at generation 2:
     ---------------------------------------------------------------------------------------------
     zone type         zone id                                disposition   underlay IP           
@@ -211,6 +427,59 @@ parent:    3f00b694-1b16-4aaa-8f78-e6b3a527b434
     fake-vendor   fake-model   serial-f1a041cc-85c7-4d14-8fc0-8d0e417f7e24
 
 
+    datasets at generation 2:
+    -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
+    dataset name                                                                                                   dataset id                             disposition   quota     reservation   compression
+    -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
+    oxp_1f9589d8-0a68-47e8-b977-d0fb17bd3fdb/crucible                                                              086f43f3-c939-4b81-8b42-a5cf1495e21a   in service    none      none          off        
+    oxp_44882b6c-5e19-418b-b6c3-065f2af5a557/crucible                                                              924b3557-8ab5-4edf-9c27-6617b89c7cdb   in service    none      none          off        
+    oxp_6de47efc-8a6d-4108-bf82-0146eab3be06/crucible                                                              ce82dc53-7e11-4403-be4b-2e9079126609   in service    none      none          off        
+    oxp_80e2c62f-052c-4580-8252-7af238fbbe9c/crucible                                                              39b7090c-574e-4fbc-8d06-c0b04e989e22   in service    none      none          off        
+    oxp_81d326ae-5f8a-4ffd-9d5e-a9e8246ac014/crucible                                                              867c9991-9dd1-46b5-989a-dfa280ccd135   in service    none      none          off        
+    oxp_878af5a0-7810-43e5-bdd5-a3215242459a/crucible                                                              4eae99b0-4319-4dcf-b2b4-22dab063b7fa   in service    none      none          off        
+    oxp_af59fef5-8258-4852-be1d-ce55ae7dc822/crucible                                                              0284b755-6ab8-427c-9e8c-e078c7369f04   in service    none      none          off        
+    oxp_b16aa11f-6e49-44c1-abcb-2e7584bffa12/crucible                                                              99a6bc05-1c43-455d-8b50-7e9e08a12602   in service    none      none          off        
+    oxp_f173c79b-a3b4-4f4a-a983-bc94b6b1a616/crucible                                                              4f8aafc8-21a7-4c64-9613-21b8d5162ed2   in service    none      none          off        
+    oxp_f1a041cc-85c7-4d14-8fc0-8d0e417f7e24/crucible                                                              004d26f7-f145-41c7-b708-1bffbaa31250   in service    none      none          off        
+    oxp_1f9589d8-0a68-47e8-b977-d0fb17bd3fdb/crypt/external_dns                                                    2ab4f9d3-6497-4d4b-bc61-daab02e40086   in service    none      none          off        
+    oxp_1f9589d8-0a68-47e8-b977-d0fb17bd3fdb/crypt/internal_dns                                                    fe27f0e0-acf4-4868-858e-b7c33bf904f3   in service    none      none          off        
+    oxp_1f9589d8-0a68-47e8-b977-d0fb17bd3fdb/crypt/zone                                                            c06bd208-d236-48d1-a8c0-b6d523b3fc3e   in service    none      none          off        
+    oxp_44882b6c-5e19-418b-b6c3-065f2af5a557/crypt/zone                                                            4ffdc4b3-694c-4c99-8e76-80df0ca3b2a4   in service    none      none          off        
+    oxp_6de47efc-8a6d-4108-bf82-0146eab3be06/crypt/zone                                                            5759f27e-3767-42df-9a76-4665267435c4   in service    none      none          off        
+    oxp_80e2c62f-052c-4580-8252-7af238fbbe9c/crypt/zone                                                            ea67cf51-95cf-40a1-af30-5d01b4e3537d   in service    none      none          off        
+    oxp_81d326ae-5f8a-4ffd-9d5e-a9e8246ac014/crypt/zone                                                            fa8d69c3-525e-4b9c-882d-1f31221e13b9   in service    none      none          off        
+    oxp_878af5a0-7810-43e5-bdd5-a3215242459a/crypt/zone                                                            f36eed10-3342-40db-a91a-724995c775f4   in service    none      none          off        
+    oxp_af59fef5-8258-4852-be1d-ce55ae7dc822/crypt/zone                                                            dec78c6b-0b4d-48a0-b471-8c0b357d2d5c   in service    none      none          off        
+    oxp_b16aa11f-6e49-44c1-abcb-2e7584bffa12/crypt/zone                                                            1b14f925-2368-4251-b303-07b193e88d0d   in service    none      none          off        
+    oxp_f173c79b-a3b4-4f4a-a983-bc94b6b1a616/crypt/zone                                                            511e9dc3-19d9-4e65-b670-a7123f086197   in service    none      none          off        
+    oxp_f1a041cc-85c7-4d14-8fc0-8d0e417f7e24/crypt/zone                                                            70b97568-5812-4246-8bd7-eae3be369fb9   in service    none      none          off        
+    oxp_6de47efc-8a6d-4108-bf82-0146eab3be06/crypt/zone/oxz_crucible_426cd521-e6ad-4a67-ad8d-a1acef5eab5e          381cb9c8-ee74-4b4d-adfb-f659933bdfec   in service    none      none          off        
+    oxp_f173c79b-a3b4-4f4a-a983-bc94b6b1a616/crypt/zone/oxz_crucible_4a392139-7423-459b-b1c9-5903421be40c          e57920ec-4bbc-4e93-906c-53e04bca6dc6   in service    none      none          off        
+    oxp_44882b6c-5e19-418b-b6c3-065f2af5a557/crypt/zone/oxz_crucible_51e403e5-a703-4cfb-b044-c72c52885e82          e7656c10-357a-427a-9e31-9b0462f0126d   in service    none      none          off        
+    oxp_1f9589d8-0a68-47e8-b977-d0fb17bd3fdb/crypt/zone/oxz_crucible_55a2094a-9590-442f-8203-dffe5a76ae66          f3d6bda9-83c1-40c5-bbd0-4d6ef040c6f8   in service    none      none          off        
+    oxp_81d326ae-5f8a-4ffd-9d5e-a9e8246ac014/crypt/zone/oxz_crucible_758d9a91-7070-43e3-8c60-ea1d0f818a12          0821ec11-cd56-4215-9199-6f3ea4fc92d5   in service    none      none          off        
+    oxp_878af5a0-7810-43e5-bdd5-a3215242459a/crypt/zone/oxz_crucible_8e4d80f8-80ea-48ac-ad47-95501c0c3fbe          9617a578-3d42-4e91-b4aa-48c0e718a9ae   in service    none      none          off        
+    oxp_f1a041cc-85c7-4d14-8fc0-8d0e417f7e24/crypt/zone/oxz_crucible_cbf109e0-cdd5-48f9-8998-e9f55c9be980          a2a01591-b10e-46a0-b91f-633c433c269b   in service    none      none          off        
+    oxp_b16aa11f-6e49-44c1-abcb-2e7584bffa12/crypt/zone/oxz_crucible_d60cc034-46c4-4233-8066-4008e947d904          0960a21d-c165-47ca-bd48-287e01168038   in service    none      none          off        
+    oxp_af59fef5-8258-4852-be1d-ce55ae7dc822/crypt/zone/oxz_crucible_f24b63e6-2382-4862-90bf-c39e42aad988          31f2b888-9f13-4584-878f-431c3d65c3b5   in service    none      none          off        
+    oxp_80e2c62f-052c-4580-8252-7af238fbbe9c/crypt/zone/oxz_crucible_fddd2bd6-a535-4e2c-9a36-cb90d048c0b7          69c63a34-be5f-4e62-bf44-e0902b1996dd   in service    none      none          off        
+    oxp_1f9589d8-0a68-47e8-b977-d0fb17bd3fdb/crypt/zone/oxz_crucible_pantry_eb4f0a57-7386-4216-bcb2-874d39aae836   636c3b45-4c7b-46a1-9852-ccbf5380ca23   in service    none      none          off        
+    oxp_1f9589d8-0a68-47e8-b977-d0fb17bd3fdb/crypt/zone/oxz_external_dns_47387358-e16d-4c34-b8f7-1f3f12c662eb      2cb6c311-5478-497c-afb0-672998b013b8   in service    none      none          off        
+    oxp_1f9589d8-0a68-47e8-b977-d0fb17bd3fdb/crypt/zone/oxz_internal_dns_edb6573c-3621-4d95-ad3b-93a088caeea5      f93c3b9e-88e2-4e2d-8df1-3e3fe9e1705f   in service    none      none          off        
+    oxp_1f9589d8-0a68-47e8-b977-d0fb17bd3fdb/crypt/zone/oxz_nexus_2cea0275-1fbc-410c-819e-2ec54ffeeffe             94b7f78b-bb21-493d-85de-6ae9bfd9a2f2   in service    none      none          off        
+    oxp_1f9589d8-0a68-47e8-b977-d0fb17bd3fdb/crypt/zone/oxz_ntp_6e1cdf48-6846-4bb3-8a72-8bc1e8d5b21d               e292f06d-aed2-4363-926c-1ca27866fb83   in service    none      none          off        
+    oxp_1f9589d8-0a68-47e8-b977-d0fb17bd3fdb/crypt/debug                                                           ae33e813-ae6f-4744-a335-9eb96d66c717   in service    100 GiB   none          gzip-9     
+    oxp_44882b6c-5e19-418b-b6c3-065f2af5a557/crypt/debug                                                           1b4b24fb-db9e-4edc-a934-8d4ef8527879   in service    100 GiB   none          gzip-9     
+    oxp_6de47efc-8a6d-4108-bf82-0146eab3be06/crypt/debug                                                           690c814f-6000-444b-b488-a90937eb07ca   in service    100 GiB   none          gzip-9     
+    oxp_80e2c62f-052c-4580-8252-7af238fbbe9c/crypt/debug                                                           c31e1ff2-6d54-4c3d-96bd-9bf697e37757   in service    100 GiB   none          gzip-9     
+    oxp_81d326ae-5f8a-4ffd-9d5e-a9e8246ac014/crypt/debug                                                           7cc4ea30-7f2f-48fe-a58b-30e62f52e27f   in service    100 GiB   none          gzip-9     
+    oxp_878af5a0-7810-43e5-bdd5-a3215242459a/crypt/debug                                                           4e14806d-82e2-44b9-aff1-cf558c1910fb   in service    100 GiB   none          gzip-9     
+    oxp_af59fef5-8258-4852-be1d-ce55ae7dc822/crypt/debug                                                           597c0560-2cb6-486a-9e87-a0ad425c36da   in service    100 GiB   none          gzip-9     
+    oxp_b16aa11f-6e49-44c1-abcb-2e7584bffa12/crypt/debug                                                           23fbb19c-a9e9-4631-ab2b-d0b97de444c1   in service    100 GiB   none          gzip-9     
+    oxp_f173c79b-a3b4-4f4a-a983-bc94b6b1a616/crypt/debug                                                           e75ed71c-f3a3-429e-9bb4-22a24572a9d2   in service    100 GiB   none          gzip-9     
+    oxp_f1a041cc-85c7-4d14-8fc0-8d0e417f7e24/crypt/debug                                                           83b408b5-02b6-4f06-bd08-f6a807d3c5e8   in service    100 GiB   none          gzip-9     
+
+
     omicron zones at generation 2:
     ---------------------------------------------------------------------------------------------
     zone type         zone id                                disposition   underlay IP           
@@ -249,6 +518,59 @@ parent:    3f00b694-1b16-4aaa-8f78-e6b3a527b434
     fake-vendor   fake-model   serial-d4ad3cc1-956a-4444-81a6-da6a025f6df2
     fake-vendor   fake-model   serial-e1298a43-fa1a-4e6f-bcfa-b26996f69c50
     fake-vendor   fake-model   serial-fa9ce87c-fa7c-4854-95bd-69b8f01c46f9
+
+
+    datasets at generation 3:
+    -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
+    dataset name                                                                                                   dataset id                             disposition   quota     reservation   compression
+    -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
+    oxp_2f26e76b-6c91-4ee9-87b3-f424b942091b/crucible                                                              dd2ac836-55e7-4f13-a39f-24fbf9122dee   in service    none      none          off        
+    oxp_6f8fa855-4f34-42db-a6e4-9d0090d6c828/crucible                                                              b1d078dc-62ee-433a-b8cf-854fefb22039   in service    none      none          off        
+    oxp_71450d62-791e-4068-9882-8a206a465fd9/crucible                                                              91ea5860-a12b-458a-9b47-a3960e2d78b8   in service    none      none          off        
+    oxp_7b4ad242-8330-4c08-9588-c66782742678/crucible                                                              9316a944-5d51-475a-ad89-8df8b4dd0863   in service    none      none          off        
+    oxp_9bf23b52-565e-4439-9728-edb603fa6c4e/crucible                                                              8dabf037-8d33-47e3-95fc-ada8d20f1d44   in service    none      none          off        
+    oxp_c9476e3d-7745-4fa9-b336-b54ac5b08f56/crucible                                                              1e28e523-e77a-4270-99d1-fd3810e1aad9   in service    none      none          off        
+    oxp_d2cd1e65-b63d-4748-895f-aafecc81e440/crucible                                                              28ba9385-4ebf-49ce-9fa2-5c549ad1fded   in service    none      none          off        
+    oxp_d4ad3cc1-956a-4444-81a6-da6a025f6df2/crucible                                                              fdc03ce9-b4f2-47aa-bff8-b0b2a05fe3b0   in service    none      none          off        
+    oxp_e1298a43-fa1a-4e6f-bcfa-b26996f69c50/crucible                                                              7d9f72bd-23bc-40e6-97c5-a53ca255588d   in service    none      none          off        
+    oxp_fa9ce87c-fa7c-4854-95bd-69b8f01c46f9/crucible                                                              bf673cd5-b04e-4088-b017-c7a714ce2b63   in service    none      none          off        
+    oxp_2f26e76b-6c91-4ee9-87b3-f424b942091b/crypt/external_dns                                                    195da8dd-34fd-4e96-a949-b7329710133e   expunged      none      none          off        
+    oxp_2f26e76b-6c91-4ee9-87b3-f424b942091b/crypt/internal_dns                                                    92ff6262-7b3c-4300-bb53-936bd3edce26   in service    none      none          off        
+    oxp_2f26e76b-6c91-4ee9-87b3-f424b942091b/crypt/zone                                                            9d6ab53a-6474-4ed6-8beb-9be1758229f5   in service    none      none          off        
+    oxp_6f8fa855-4f34-42db-a6e4-9d0090d6c828/crypt/zone                                                            df385279-2886-4422-957f-88f1f382a90b   in service    none      none          off        
+    oxp_71450d62-791e-4068-9882-8a206a465fd9/crypt/zone                                                            97a12796-0555-47c5-a0d3-c136e0e919f6   in service    none      none          off        
+    oxp_7b4ad242-8330-4c08-9588-c66782742678/crypt/zone                                                            39343108-efec-4643-80c8-1c741d045dad   in service    none      none          off        
+    oxp_9bf23b52-565e-4439-9728-edb603fa6c4e/crypt/zone                                                            b58b762a-7124-4441-a334-16d552f576f3   in service    none      none          off        
+    oxp_c9476e3d-7745-4fa9-b336-b54ac5b08f56/crypt/zone                                                            92c63f1f-4ba8-4a41-93c0-e227b3320eaa   in service    none      none          off        
+    oxp_d2cd1e65-b63d-4748-895f-aafecc81e440/crypt/zone                                                            434bf6e8-b885-441d-b944-9508b0c64311   in service    none      none          off        
+    oxp_d4ad3cc1-956a-4444-81a6-da6a025f6df2/crypt/zone                                                            58e91146-8da0-449a-adab-6e93504c9bf0   in service    none      none          off        
+    oxp_e1298a43-fa1a-4e6f-bcfa-b26996f69c50/crypt/zone                                                            e56258ab-55c4-42ca-95e5-ea8bbeff84e1   in service    none      none          off        
+    oxp_fa9ce87c-fa7c-4854-95bd-69b8f01c46f9/crypt/zone                                                            e070deb1-5298-46fb-983f-b6e153e98cd7   in service    none      none          off        
+    oxp_2f26e76b-6c91-4ee9-87b3-f424b942091b/crypt/zone/oxz_crucible_0903299a-6296-44f0-8ab9-7c70b5766a05          277b0d6a-bb61-4eb2-bd11-d750586b5fbc   in service    none      none          off        
+    oxp_71450d62-791e-4068-9882-8a206a465fd9/crypt/zone/oxz_crucible_2b6b3cfd-4524-465b-ac6e-10be9ab6d4d4          5073cf86-7d36-4c98-9e34-559172a0bc84   in service    none      none          off        
+    oxp_e1298a43-fa1a-4e6f-bcfa-b26996f69c50/crypt/zone/oxz_crucible_3e0ff677-2ca8-4124-9fef-7c23ac2da6fa          028fc58f-16ea-4536-9f50-b4eeb1aa57c9   in service    none      none          off        
+    oxp_c9476e3d-7745-4fa9-b336-b54ac5b08f56/crypt/zone/oxz_crucible_512758d0-335f-4c94-9afe-c82f6f127421          f20e7661-c0c7-47cd-b08a-e7f5b76026d6   in service    none      none          off        
+    oxp_6f8fa855-4f34-42db-a6e4-9d0090d6c828/crypt/zone/oxz_crucible_8ae67b12-ca74-40d3-a55e-90456cd623ea          3f7802ee-87bb-48d6-a42d-657bd0f85c74   in service    none      none          off        
+    oxp_fa9ce87c-fa7c-4854-95bd-69b8f01c46f9/crypt/zone/oxz_crucible_918c8cbc-1c62-4de5-9cf2-c4153a3d1a7e          41d832ad-7b85-4214-b485-9ca2ed4f85d0   in service    none      none          off        
+    oxp_7b4ad242-8330-4c08-9588-c66782742678/crypt/zone/oxz_crucible_be422e7a-16d0-426e-8567-da0aed7200d4          e0fb453d-b22c-4d87-be9b-94f6113cb25a   in service    none      none          off        
+    oxp_d2cd1e65-b63d-4748-895f-aafecc81e440/crypt/zone/oxz_crucible_ea50f438-1b5e-4d61-bd65-46d360f590ee          26a25185-a37f-4ead-8c81-77be56a21b0a   in service    none      none          off        
+    oxp_9bf23b52-565e-4439-9728-edb603fa6c4e/crypt/zone/oxz_crucible_f055a042-9d1b-4931-8268-d94cac801d7e          998b0fb1-b562-4858-a9ae-c02296c7c6ed   in service    none      none          off        
+    oxp_d4ad3cc1-956a-4444-81a6-da6a025f6df2/crypt/zone/oxz_crucible_f33e09d1-e3d7-4341-baf2-5f079f3679e5          aa4f1267-a83a-4081-b572-28e1860ff2f2   in service    none      none          off        
+    oxp_2f26e76b-6c91-4ee9-87b3-f424b942091b/crypt/zone/oxz_crucible_pantry_100e20aa-1816-4195-8d76-08beace10332   032bf309-8046-4c96-9453-29b9346b19fc   in service    none      none          off        
+    oxp_2f26e76b-6c91-4ee9-87b3-f424b942091b/crypt/zone/oxz_external_dns_9995de32-dd52-4eb1-b0eb-141eb84bc739      f258d941-f8b3-4d0e-bbe6-773996a002d5   expunged      none      none          off        
+    oxp_2f26e76b-6c91-4ee9-87b3-f424b942091b/crypt/zone/oxz_internal_dns_171cabf0-8635-42e7-8ea1-2a1d2a2daf55      3531c6de-8d31-4917-bb72-884b6e168eca   in service    none      none          off        
+    oxp_2f26e76b-6c91-4ee9-87b3-f424b942091b/crypt/zone/oxz_nexus_5b01b0e0-5cdf-4b34-b0a6-c947cbbdb8be             5e3a1b9d-9475-4bd9-8112-5595a7c0da7d   in service    none      none          off        
+    oxp_2f26e76b-6c91-4ee9-87b3-f424b942091b/crypt/zone/oxz_ntp_7b4bccad-9869-48da-8320-2dc82752deea               45771e96-054c-4b05-8021-c32b23fcad8d   in service    none      none          off        
+    oxp_2f26e76b-6c91-4ee9-87b3-f424b942091b/crypt/debug                                                           29be83b4-4d0b-4787-819d-96e8e69301da   in service    100 GiB   none          gzip-9     
+    oxp_6f8fa855-4f34-42db-a6e4-9d0090d6c828/crypt/debug                                                           ce433c69-7540-4a7a-9e11-dd30b0d2dc19   in service    100 GiB   none          gzip-9     
+    oxp_71450d62-791e-4068-9882-8a206a465fd9/crypt/debug                                                           48cc9313-13c2-4ebe-8120-5b648ec26a28   in service    100 GiB   none          gzip-9     
+    oxp_7b4ad242-8330-4c08-9588-c66782742678/crypt/debug                                                           cdcfe435-881a-44dc-9dba-2a0fafdbf66d   in service    100 GiB   none          gzip-9     
+    oxp_9bf23b52-565e-4439-9728-edb603fa6c4e/crypt/debug                                                           835edc8b-9d33-45db-9bdc-ea8a956f3217   in service    100 GiB   none          gzip-9     
+    oxp_c9476e3d-7745-4fa9-b336-b54ac5b08f56/crypt/debug                                                           1754b8f0-07b8-4305-8bb2-b347ba3e0b68   in service    100 GiB   none          gzip-9     
+    oxp_d2cd1e65-b63d-4748-895f-aafecc81e440/crypt/debug                                                           7028b888-b4c0-43e5-a9d4-2e29d24f34a7   in service    100 GiB   none          gzip-9     
+    oxp_d4ad3cc1-956a-4444-81a6-da6a025f6df2/crypt/debug                                                           36ad4fe9-3897-4777-bc0e-88f142594d07   in service    100 GiB   none          gzip-9     
+    oxp_e1298a43-fa1a-4e6f-bcfa-b26996f69c50/crypt/debug                                                           d37e0b8c-6c43-4e83-b3ec-238429d1cbfb   in service    100 GiB   none          gzip-9     
+    oxp_fa9ce87c-fa7c-4854-95bd-69b8f01c46f9/crypt/debug                                                           b7569aa4-f0d6-4de0-9b9a-cd8d0a6cc01d   in service    100 GiB   none          gzip-9     
 
 
     omicron zones at generation 3:
@@ -323,6 +645,61 @@ parent:    366b0b68-d80e-4bc1-abd3-dc69837847e0
     fake-vendor   fake-model   serial-fb29d469-7d3f-47b9-944c-ce817fc70370
 
 
+    datasets at generation 2:
+    -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
+    dataset name                                                                                                   dataset id                             disposition   quota     reservation   compression
+    -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
+    oxp_3b46c403-ad14-435c-a1a8-e8f940bf814f/crucible                                                              7426782a-b56d-4bcd-a061-ef999680a483   in service    none      none          off        
+    oxp_3f8c9484-06e8-4662-9a90-aa7e92c43405/crucible                                                              ca4f4d56-e1be-4535-abc7-fa5e131f5be4   in service    none      none          off        
+    oxp_4a62a827-4bf3-45d5-a7f5-d080f25c61ef/crucible                                                              60b31115-e269-4cc6-967a-1bd86632ce6e   in service    none      none          off        
+    oxp_5f774f00-52b7-41b5-a57f-6f38037196f5/crucible                                                              6081371a-e229-4168-9706-99ed750d0beb   in service    none      none          off        
+    oxp_68ae41d4-99ed-4612-99e1-fecf795ca694/crucible                                                              3304ddb3-a458-4852-9955-2fae08196d35   in service    none      none          off        
+    oxp_6a66241b-b595-423d-84ef-a81b5d8430e8/crucible                                                              ba9a2005-5bc2-414d-ae3a-fffd398d4b78   in service    none      none          off        
+    oxp_7c45c3f6-6369-40d9-a73f-2f7ed0afe96b/crucible                                                              7fd796bb-369b-4f22-b552-f45ce12836b4   in service    none      none          off        
+    oxp_a216d334-4a9a-49dd-8b13-20548839306c/crucible                                                              a8d0b8ae-fec4-4c7e-b286-869d6f888616   in service    none      none          off        
+    oxp_c9ff8eb0-807c-40ad-a5c4-0d534947c9ad/crucible                                                              c0071842-4e56-40e9-a53a-0ea8242a66f4   in service    none      none          off        
+    oxp_fb29d469-7d3f-47b9-944c-ce817fc70370/crucible                                                              1463807d-6615-4643-95e2-8cfcfdffc5a2   in service    none      none          off        
+    oxp_3b46c403-ad14-435c-a1a8-e8f940bf814f/crypt/clickhouse                                                      b5197e35-15e8-423e-931f-ba32b3842eef   in service    none      none          off        
+    oxp_3b46c403-ad14-435c-a1a8-e8f940bf814f/crypt/external_dns                                                    65abb419-b456-4cac-9ca5-bcd823457692   in service    none      none          off        
+    oxp_3b46c403-ad14-435c-a1a8-e8f940bf814f/crypt/internal_dns                                                    d17fa7c3-e285-4725-9f69-185708d1d55c   in service    none      none          off        
+    oxp_3b46c403-ad14-435c-a1a8-e8f940bf814f/crypt/zone                                                            f68397e5-da5d-4d93-94a4-b68951f30522   in service    none      none          off        
+    oxp_3f8c9484-06e8-4662-9a90-aa7e92c43405/crypt/zone                                                            6d833180-97ee-461b-8cbd-62007f3172e3   in service    none      none          off        
+    oxp_4a62a827-4bf3-45d5-a7f5-d080f25c61ef/crypt/zone                                                            085f6578-6bb9-4cd6-9274-aa50a274fddb   in service    none      none          off        
+    oxp_5f774f00-52b7-41b5-a57f-6f38037196f5/crypt/zone                                                            0de067e1-b626-494a-9d41-03de4036c922   in service    none      none          off        
+    oxp_68ae41d4-99ed-4612-99e1-fecf795ca694/crypt/zone                                                            0b76c44a-1d99-460d-87fd-3ae5c8b241b9   in service    none      none          off        
+    oxp_6a66241b-b595-423d-84ef-a81b5d8430e8/crypt/zone                                                            cb33c02a-6db4-402b-adcf-919957342c84   in service    none      none          off        
+    oxp_7c45c3f6-6369-40d9-a73f-2f7ed0afe96b/crypt/zone                                                            9ea4aca6-ac88-4550-a4fd-10ddfd94e01e   in service    none      none          off        
+    oxp_a216d334-4a9a-49dd-8b13-20548839306c/crypt/zone                                                            b5e5d272-964b-40b7-9d03-fb92c4b491c0   in service    none      none          off        
+    oxp_c9ff8eb0-807c-40ad-a5c4-0d534947c9ad/crypt/zone                                                            219249df-e43f-4ee3-a4e2-eaa09b085d9a   in service    none      none          off        
+    oxp_fb29d469-7d3f-47b9-944c-ce817fc70370/crypt/zone                                                            e49ad6e5-2d96-4a2a-8e50-202d97d7f424   in service    none      none          off        
+    oxp_3b46c403-ad14-435c-a1a8-e8f940bf814f/crypt/zone/oxz_clickhouse_e9d3a6d6-6e95-4ec8-a857-a3ab1ce6e62d        6ee081c5-9830-4d6b-83a1-56f307b893fd   in service    none      none          off        
+    oxp_6a66241b-b595-423d-84ef-a81b5d8430e8/crypt/zone/oxz_crucible_53491964-307a-45f6-b277-79a5e90f20b7          80cb8976-735e-488d-8ff1-c49ec2bf4d4d   in service    none      none          off        
+    oxp_fb29d469-7d3f-47b9-944c-ce817fc70370/crypt/zone/oxz_crucible_777087c0-4fb9-43ed-846b-16aa6431a272          a03c380c-735d-434a-8e5c-6a39dfd1d54e   in service    none      none          off        
+    oxp_68ae41d4-99ed-4612-99e1-fecf795ca694/crypt/zone/oxz_crucible_78a45052-138b-47ee-877d-e73143467c8a          6f8bfed8-9387-4ef9-b307-873f072d349e   in service    none      none          off        
+    oxp_4a62a827-4bf3-45d5-a7f5-d080f25c61ef/crypt/zone/oxz_crucible_8ec567c1-6776-4573-bfe5-f3041165fdca          8886085a-1920-479b-ad17-7858a690aab1   in service    none      none          off        
+    oxp_c9ff8eb0-807c-40ad-a5c4-0d534947c9ad/crypt/zone/oxz_crucible_8ef7ff46-81f7-4f16-aa8f-0c1957589a5f          5579e9a2-eda0-4343-bb3a-7cf6d6910c3e   in service    none      none          off        
+    oxp_3f8c9484-06e8-4662-9a90-aa7e92c43405/crypt/zone/oxz_crucible_af3e8274-151f-4cb1-990c-b0a7680ff210          d773abef-bfdb-4c60-ba3d-8a980c9c50ed   in service    none      none          off        
+    oxp_5f774f00-52b7-41b5-a57f-6f38037196f5/crypt/zone/oxz_crucible_c3114d7e-07cd-4d80-b82b-49ccbe856af2          80da4d1c-b800-4f92-95ff-0e3f6e6b6eec   in service    none      none          off        
+    oxp_a216d334-4a9a-49dd-8b13-20548839306c/crypt/zone/oxz_crucible_d23b5191-04de-4b48-8599-cf866ffc06e8          8a7040dd-acf5-406f-9794-bb9844716585   in service    none      none          off        
+    oxp_3b46c403-ad14-435c-a1a8-e8f940bf814f/crypt/zone/oxz_crucible_efdbf061-321c-47d6-bf0f-4530ec4c287e          2b5f60f5-7830-4cf4-9051-a6a6dc470b66   in service    none      none          off        
+    oxp_7c45c3f6-6369-40d9-a73f-2f7ed0afe96b/crypt/zone/oxz_crucible_f31ab1c5-0f23-44dc-8504-c67c65afc11e          344481c4-02ad-4759-82c3-4986566f76bf   in service    none      none          off        
+    oxp_3b46c403-ad14-435c-a1a8-e8f940bf814f/crypt/zone/oxz_crucible_pantry_07738018-1b2a-4efc-8c5c-bd6b7a5d7b40   a4ca94e6-55de-405c-8a33-422ed5938bd3   in service    none      none          off        
+    oxp_3b46c403-ad14-435c-a1a8-e8f940bf814f/crypt/zone/oxz_external_dns_1b37911d-c427-4bf1-90d3-b2d0c2e98825      06af733b-6f79-4d4d-aef5-e18068a795df   in service    none      none          off        
+    oxp_3b46c403-ad14-435c-a1a8-e8f940bf814f/crypt/zone/oxz_internal_dns_7a1bd482-74f8-4562-b1db-c8bad16afb44      d648ac4b-0c2d-407b-84a5-05c25b24c463   in service    none      none          off        
+    oxp_3b46c403-ad14-435c-a1a8-e8f940bf814f/crypt/zone/oxz_nexus_ed2d3be3-fcee-4f6b-bb99-a1a9130c4eeb             a16bbe93-af8c-45bc-86ee-caff9ae76d17   in service    none      none          off        
+    oxp_3b46c403-ad14-435c-a1a8-e8f940bf814f/crypt/zone/oxz_ntp_8c368ed6-6c91-4437-b8ff-0d789193db38               dac5975a-67f3-44d7-9b0c-46a9f616ef4e   in service    none      none          off        
+    oxp_3b46c403-ad14-435c-a1a8-e8f940bf814f/crypt/debug                                                           86c4d965-971c-48fb-891d-9f63232d1577   in service    100 GiB   none          gzip-9     
+    oxp_3f8c9484-06e8-4662-9a90-aa7e92c43405/crypt/debug                                                           b3d9c2e2-c06d-4a99-bf4a-c8613691615a   in service    100 GiB   none          gzip-9     
+    oxp_4a62a827-4bf3-45d5-a7f5-d080f25c61ef/crypt/debug                                                           5c8561d4-afac-436b-b32c-e8dc44daa98a   in service    100 GiB   none          gzip-9     
+    oxp_5f774f00-52b7-41b5-a57f-6f38037196f5/crypt/debug                                                           c518735e-1306-4fbf-9ba4-010196249ee3   in service    100 GiB   none          gzip-9     
+    oxp_68ae41d4-99ed-4612-99e1-fecf795ca694/crypt/debug                                                           8b416b54-73b0-4fda-8d10-6823b67aa044   in service    100 GiB   none          gzip-9     
+    oxp_6a66241b-b595-423d-84ef-a81b5d8430e8/crypt/debug                                                           8194dbad-3f65-43d1-a7e0-50b23a81b674   in service    100 GiB   none          gzip-9     
+    oxp_7c45c3f6-6369-40d9-a73f-2f7ed0afe96b/crypt/debug                                                           ad878e0e-831b-4f0b-9417-1b17c5f5f744   in service    100 GiB   none          gzip-9     
+    oxp_a216d334-4a9a-49dd-8b13-20548839306c/crypt/debug                                                           5d15a682-d4ca-40be-8cf9-3cdc934c3787   in service    100 GiB   none          gzip-9     
+    oxp_c9ff8eb0-807c-40ad-a5c4-0d534947c9ad/crypt/debug                                                           5735d96e-efef-448d-8e40-cf0dc73a2c04   in service    100 GiB   none          gzip-9     
+    oxp_fb29d469-7d3f-47b9-944c-ce817fc70370/crypt/debug                                                           19c25551-a54c-47b6-8495-dbd51ed8e384   in service    100 GiB   none          gzip-9     
+
+
     omicron zones at generation 2:
     ---------------------------------------------------------------------------------------------
     zone type         zone id                                disposition   underlay IP           
@@ -364,6 +741,59 @@ parent:    366b0b68-d80e-4bc1-abd3-dc69837847e0
     fake-vendor   fake-model   serial-f1a041cc-85c7-4d14-8fc0-8d0e417f7e24
 
 
+    datasets at generation 2:
+    -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
+    dataset name                                                                                                   dataset id                             disposition   quota     reservation   compression
+    -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
+    oxp_1f9589d8-0a68-47e8-b977-d0fb17bd3fdb/crucible                                                              086f43f3-c939-4b81-8b42-a5cf1495e21a   in service    none      none          off        
+    oxp_44882b6c-5e19-418b-b6c3-065f2af5a557/crucible                                                              924b3557-8ab5-4edf-9c27-6617b89c7cdb   in service    none      none          off        
+    oxp_6de47efc-8a6d-4108-bf82-0146eab3be06/crucible                                                              ce82dc53-7e11-4403-be4b-2e9079126609   in service    none      none          off        
+    oxp_80e2c62f-052c-4580-8252-7af238fbbe9c/crucible                                                              39b7090c-574e-4fbc-8d06-c0b04e989e22   in service    none      none          off        
+    oxp_81d326ae-5f8a-4ffd-9d5e-a9e8246ac014/crucible                                                              867c9991-9dd1-46b5-989a-dfa280ccd135   in service    none      none          off        
+    oxp_878af5a0-7810-43e5-bdd5-a3215242459a/crucible                                                              4eae99b0-4319-4dcf-b2b4-22dab063b7fa   in service    none      none          off        
+    oxp_af59fef5-8258-4852-be1d-ce55ae7dc822/crucible                                                              0284b755-6ab8-427c-9e8c-e078c7369f04   in service    none      none          off        
+    oxp_b16aa11f-6e49-44c1-abcb-2e7584bffa12/crucible                                                              99a6bc05-1c43-455d-8b50-7e9e08a12602   in service    none      none          off        
+    oxp_f173c79b-a3b4-4f4a-a983-bc94b6b1a616/crucible                                                              4f8aafc8-21a7-4c64-9613-21b8d5162ed2   in service    none      none          off        
+    oxp_f1a041cc-85c7-4d14-8fc0-8d0e417f7e24/crucible                                                              004d26f7-f145-41c7-b708-1bffbaa31250   in service    none      none          off        
+    oxp_1f9589d8-0a68-47e8-b977-d0fb17bd3fdb/crypt/external_dns                                                    2ab4f9d3-6497-4d4b-bc61-daab02e40086   in service    none      none          off        
+    oxp_1f9589d8-0a68-47e8-b977-d0fb17bd3fdb/crypt/internal_dns                                                    fe27f0e0-acf4-4868-858e-b7c33bf904f3   in service    none      none          off        
+    oxp_1f9589d8-0a68-47e8-b977-d0fb17bd3fdb/crypt/zone                                                            c06bd208-d236-48d1-a8c0-b6d523b3fc3e   in service    none      none          off        
+    oxp_44882b6c-5e19-418b-b6c3-065f2af5a557/crypt/zone                                                            4ffdc4b3-694c-4c99-8e76-80df0ca3b2a4   in service    none      none          off        
+    oxp_6de47efc-8a6d-4108-bf82-0146eab3be06/crypt/zone                                                            5759f27e-3767-42df-9a76-4665267435c4   in service    none      none          off        
+    oxp_80e2c62f-052c-4580-8252-7af238fbbe9c/crypt/zone                                                            ea67cf51-95cf-40a1-af30-5d01b4e3537d   in service    none      none          off        
+    oxp_81d326ae-5f8a-4ffd-9d5e-a9e8246ac014/crypt/zone                                                            fa8d69c3-525e-4b9c-882d-1f31221e13b9   in service    none      none          off        
+    oxp_878af5a0-7810-43e5-bdd5-a3215242459a/crypt/zone                                                            f36eed10-3342-40db-a91a-724995c775f4   in service    none      none          off        
+    oxp_af59fef5-8258-4852-be1d-ce55ae7dc822/crypt/zone                                                            dec78c6b-0b4d-48a0-b471-8c0b357d2d5c   in service    none      none          off        
+    oxp_b16aa11f-6e49-44c1-abcb-2e7584bffa12/crypt/zone                                                            1b14f925-2368-4251-b303-07b193e88d0d   in service    none      none          off        
+    oxp_f173c79b-a3b4-4f4a-a983-bc94b6b1a616/crypt/zone                                                            511e9dc3-19d9-4e65-b670-a7123f086197   in service    none      none          off        
+    oxp_f1a041cc-85c7-4d14-8fc0-8d0e417f7e24/crypt/zone                                                            70b97568-5812-4246-8bd7-eae3be369fb9   in service    none      none          off        
+    oxp_6de47efc-8a6d-4108-bf82-0146eab3be06/crypt/zone/oxz_crucible_426cd521-e6ad-4a67-ad8d-a1acef5eab5e          381cb9c8-ee74-4b4d-adfb-f659933bdfec   in service    none      none          off        
+    oxp_f173c79b-a3b4-4f4a-a983-bc94b6b1a616/crypt/zone/oxz_crucible_4a392139-7423-459b-b1c9-5903421be40c          e57920ec-4bbc-4e93-906c-53e04bca6dc6   in service    none      none          off        
+    oxp_44882b6c-5e19-418b-b6c3-065f2af5a557/crypt/zone/oxz_crucible_51e403e5-a703-4cfb-b044-c72c52885e82          e7656c10-357a-427a-9e31-9b0462f0126d   in service    none      none          off        
+    oxp_1f9589d8-0a68-47e8-b977-d0fb17bd3fdb/crypt/zone/oxz_crucible_55a2094a-9590-442f-8203-dffe5a76ae66          f3d6bda9-83c1-40c5-bbd0-4d6ef040c6f8   in service    none      none          off        
+    oxp_81d326ae-5f8a-4ffd-9d5e-a9e8246ac014/crypt/zone/oxz_crucible_758d9a91-7070-43e3-8c60-ea1d0f818a12          0821ec11-cd56-4215-9199-6f3ea4fc92d5   in service    none      none          off        
+    oxp_878af5a0-7810-43e5-bdd5-a3215242459a/crypt/zone/oxz_crucible_8e4d80f8-80ea-48ac-ad47-95501c0c3fbe          9617a578-3d42-4e91-b4aa-48c0e718a9ae   in service    none      none          off        
+    oxp_f1a041cc-85c7-4d14-8fc0-8d0e417f7e24/crypt/zone/oxz_crucible_cbf109e0-cdd5-48f9-8998-e9f55c9be980          a2a01591-b10e-46a0-b91f-633c433c269b   in service    none      none          off        
+    oxp_b16aa11f-6e49-44c1-abcb-2e7584bffa12/crypt/zone/oxz_crucible_d60cc034-46c4-4233-8066-4008e947d904          0960a21d-c165-47ca-bd48-287e01168038   in service    none      none          off        
+    oxp_af59fef5-8258-4852-be1d-ce55ae7dc822/crypt/zone/oxz_crucible_f24b63e6-2382-4862-90bf-c39e42aad988          31f2b888-9f13-4584-878f-431c3d65c3b5   in service    none      none          off        
+    oxp_80e2c62f-052c-4580-8252-7af238fbbe9c/crypt/zone/oxz_crucible_fddd2bd6-a535-4e2c-9a36-cb90d048c0b7          69c63a34-be5f-4e62-bf44-e0902b1996dd   in service    none      none          off        
+    oxp_1f9589d8-0a68-47e8-b977-d0fb17bd3fdb/crypt/zone/oxz_crucible_pantry_eb4f0a57-7386-4216-bcb2-874d39aae836   636c3b45-4c7b-46a1-9852-ccbf5380ca23   in service    none      none          off        
+    oxp_1f9589d8-0a68-47e8-b977-d0fb17bd3fdb/crypt/zone/oxz_external_dns_47387358-e16d-4c34-b8f7-1f3f12c662eb      2cb6c311-5478-497c-afb0-672998b013b8   in service    none      none          off        
+    oxp_1f9589d8-0a68-47e8-b977-d0fb17bd3fdb/crypt/zone/oxz_internal_dns_edb6573c-3621-4d95-ad3b-93a088caeea5      f93c3b9e-88e2-4e2d-8df1-3e3fe9e1705f   in service    none      none          off        
+    oxp_1f9589d8-0a68-47e8-b977-d0fb17bd3fdb/crypt/zone/oxz_nexus_2cea0275-1fbc-410c-819e-2ec54ffeeffe             94b7f78b-bb21-493d-85de-6ae9bfd9a2f2   in service    none      none          off        
+    oxp_1f9589d8-0a68-47e8-b977-d0fb17bd3fdb/crypt/zone/oxz_ntp_6e1cdf48-6846-4bb3-8a72-8bc1e8d5b21d               e292f06d-aed2-4363-926c-1ca27866fb83   in service    none      none          off        
+    oxp_1f9589d8-0a68-47e8-b977-d0fb17bd3fdb/crypt/debug                                                           ae33e813-ae6f-4744-a335-9eb96d66c717   in service    100 GiB   none          gzip-9     
+    oxp_44882b6c-5e19-418b-b6c3-065f2af5a557/crypt/debug                                                           1b4b24fb-db9e-4edc-a934-8d4ef8527879   in service    100 GiB   none          gzip-9     
+    oxp_6de47efc-8a6d-4108-bf82-0146eab3be06/crypt/debug                                                           690c814f-6000-444b-b488-a90937eb07ca   in service    100 GiB   none          gzip-9     
+    oxp_80e2c62f-052c-4580-8252-7af238fbbe9c/crypt/debug                                                           c31e1ff2-6d54-4c3d-96bd-9bf697e37757   in service    100 GiB   none          gzip-9     
+    oxp_81d326ae-5f8a-4ffd-9d5e-a9e8246ac014/crypt/debug                                                           7cc4ea30-7f2f-48fe-a58b-30e62f52e27f   in service    100 GiB   none          gzip-9     
+    oxp_878af5a0-7810-43e5-bdd5-a3215242459a/crypt/debug                                                           4e14806d-82e2-44b9-aff1-cf558c1910fb   in service    100 GiB   none          gzip-9     
+    oxp_af59fef5-8258-4852-be1d-ce55ae7dc822/crypt/debug                                                           597c0560-2cb6-486a-9e87-a0ad425c36da   in service    100 GiB   none          gzip-9     
+    oxp_b16aa11f-6e49-44c1-abcb-2e7584bffa12/crypt/debug                                                           23fbb19c-a9e9-4631-ab2b-d0b97de444c1   in service    100 GiB   none          gzip-9     
+    oxp_f173c79b-a3b4-4f4a-a983-bc94b6b1a616/crypt/debug                                                           e75ed71c-f3a3-429e-9bb4-22a24572a9d2   in service    100 GiB   none          gzip-9     
+    oxp_f1a041cc-85c7-4d14-8fc0-8d0e417f7e24/crypt/debug                                                           83b408b5-02b6-4f06-bd08-f6a807d3c5e8   in service    100 GiB   none          gzip-9     
+
+
     omicron zones at generation 2:
     ---------------------------------------------------------------------------------------------
     zone type         zone id                                disposition   underlay IP           
@@ -402,6 +832,61 @@ parent:    366b0b68-d80e-4bc1-abd3-dc69837847e0
     fake-vendor   fake-model   serial-d4ad3cc1-956a-4444-81a6-da6a025f6df2
     fake-vendor   fake-model   serial-e1298a43-fa1a-4e6f-bcfa-b26996f69c50
     fake-vendor   fake-model   serial-fa9ce87c-fa7c-4854-95bd-69b8f01c46f9
+
+
+    datasets at generation 4:
+    -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
+    dataset name                                                                                                   dataset id                             disposition   quota     reservation   compression
+    -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
+    oxp_2f26e76b-6c91-4ee9-87b3-f424b942091b/crucible                                                              dd2ac836-55e7-4f13-a39f-24fbf9122dee   in service    none      none          off        
+    oxp_6f8fa855-4f34-42db-a6e4-9d0090d6c828/crucible                                                              b1d078dc-62ee-433a-b8cf-854fefb22039   in service    none      none          off        
+    oxp_71450d62-791e-4068-9882-8a206a465fd9/crucible                                                              91ea5860-a12b-458a-9b47-a3960e2d78b8   in service    none      none          off        
+    oxp_7b4ad242-8330-4c08-9588-c66782742678/crucible                                                              9316a944-5d51-475a-ad89-8df8b4dd0863   in service    none      none          off        
+    oxp_9bf23b52-565e-4439-9728-edb603fa6c4e/crucible                                                              8dabf037-8d33-47e3-95fc-ada8d20f1d44   in service    none      none          off        
+    oxp_c9476e3d-7745-4fa9-b336-b54ac5b08f56/crucible                                                              1e28e523-e77a-4270-99d1-fd3810e1aad9   in service    none      none          off        
+    oxp_d2cd1e65-b63d-4748-895f-aafecc81e440/crucible                                                              28ba9385-4ebf-49ce-9fa2-5c549ad1fded   in service    none      none          off        
+    oxp_d4ad3cc1-956a-4444-81a6-da6a025f6df2/crucible                                                              fdc03ce9-b4f2-47aa-bff8-b0b2a05fe3b0   in service    none      none          off        
+    oxp_e1298a43-fa1a-4e6f-bcfa-b26996f69c50/crucible                                                              7d9f72bd-23bc-40e6-97c5-a53ca255588d   in service    none      none          off        
+    oxp_fa9ce87c-fa7c-4854-95bd-69b8f01c46f9/crucible                                                              bf673cd5-b04e-4088-b017-c7a714ce2b63   in service    none      none          off        
+    oxp_2f26e76b-6c91-4ee9-87b3-f424b942091b/crypt/external_dns                                                    07153a04-4e4a-485a-8399-15bc9063cb5d   in service    none      none          off        
+    oxp_2f26e76b-6c91-4ee9-87b3-f424b942091b/crypt/external_dns                                                    195da8dd-34fd-4e96-a949-b7329710133e   expunged      none      none          off        
+    oxp_2f26e76b-6c91-4ee9-87b3-f424b942091b/crypt/internal_dns                                                    92ff6262-7b3c-4300-bb53-936bd3edce26   in service    none      none          off        
+    oxp_2f26e76b-6c91-4ee9-87b3-f424b942091b/crypt/zone                                                            9d6ab53a-6474-4ed6-8beb-9be1758229f5   in service    none      none          off        
+    oxp_6f8fa855-4f34-42db-a6e4-9d0090d6c828/crypt/zone                                                            df385279-2886-4422-957f-88f1f382a90b   in service    none      none          off        
+    oxp_71450d62-791e-4068-9882-8a206a465fd9/crypt/zone                                                            97a12796-0555-47c5-a0d3-c136e0e919f6   in service    none      none          off        
+    oxp_7b4ad242-8330-4c08-9588-c66782742678/crypt/zone                                                            39343108-efec-4643-80c8-1c741d045dad   in service    none      none          off        
+    oxp_9bf23b52-565e-4439-9728-edb603fa6c4e/crypt/zone                                                            b58b762a-7124-4441-a334-16d552f576f3   in service    none      none          off        
+    oxp_c9476e3d-7745-4fa9-b336-b54ac5b08f56/crypt/zone                                                            92c63f1f-4ba8-4a41-93c0-e227b3320eaa   in service    none      none          off        
+    oxp_d2cd1e65-b63d-4748-895f-aafecc81e440/crypt/zone                                                            434bf6e8-b885-441d-b944-9508b0c64311   in service    none      none          off        
+    oxp_d4ad3cc1-956a-4444-81a6-da6a025f6df2/crypt/zone                                                            58e91146-8da0-449a-adab-6e93504c9bf0   in service    none      none          off        
+    oxp_e1298a43-fa1a-4e6f-bcfa-b26996f69c50/crypt/zone                                                            e56258ab-55c4-42ca-95e5-ea8bbeff84e1   in service    none      none          off        
+    oxp_fa9ce87c-fa7c-4854-95bd-69b8f01c46f9/crypt/zone                                                            e070deb1-5298-46fb-983f-b6e153e98cd7   in service    none      none          off        
+    oxp_2f26e76b-6c91-4ee9-87b3-f424b942091b/crypt/zone/oxz_crucible_0903299a-6296-44f0-8ab9-7c70b5766a05          277b0d6a-bb61-4eb2-bd11-d750586b5fbc   in service    none      none          off        
+    oxp_71450d62-791e-4068-9882-8a206a465fd9/crypt/zone/oxz_crucible_2b6b3cfd-4524-465b-ac6e-10be9ab6d4d4          5073cf86-7d36-4c98-9e34-559172a0bc84   in service    none      none          off        
+    oxp_e1298a43-fa1a-4e6f-bcfa-b26996f69c50/crypt/zone/oxz_crucible_3e0ff677-2ca8-4124-9fef-7c23ac2da6fa          028fc58f-16ea-4536-9f50-b4eeb1aa57c9   in service    none      none          off        
+    oxp_c9476e3d-7745-4fa9-b336-b54ac5b08f56/crypt/zone/oxz_crucible_512758d0-335f-4c94-9afe-c82f6f127421          f20e7661-c0c7-47cd-b08a-e7f5b76026d6   in service    none      none          off        
+    oxp_6f8fa855-4f34-42db-a6e4-9d0090d6c828/crypt/zone/oxz_crucible_8ae67b12-ca74-40d3-a55e-90456cd623ea          3f7802ee-87bb-48d6-a42d-657bd0f85c74   in service    none      none          off        
+    oxp_fa9ce87c-fa7c-4854-95bd-69b8f01c46f9/crypt/zone/oxz_crucible_918c8cbc-1c62-4de5-9cf2-c4153a3d1a7e          41d832ad-7b85-4214-b485-9ca2ed4f85d0   in service    none      none          off        
+    oxp_7b4ad242-8330-4c08-9588-c66782742678/crypt/zone/oxz_crucible_be422e7a-16d0-426e-8567-da0aed7200d4          e0fb453d-b22c-4d87-be9b-94f6113cb25a   in service    none      none          off        
+    oxp_d2cd1e65-b63d-4748-895f-aafecc81e440/crypt/zone/oxz_crucible_ea50f438-1b5e-4d61-bd65-46d360f590ee          26a25185-a37f-4ead-8c81-77be56a21b0a   in service    none      none          off        
+    oxp_9bf23b52-565e-4439-9728-edb603fa6c4e/crypt/zone/oxz_crucible_f055a042-9d1b-4931-8268-d94cac801d7e          998b0fb1-b562-4858-a9ae-c02296c7c6ed   in service    none      none          off        
+    oxp_d4ad3cc1-956a-4444-81a6-da6a025f6df2/crypt/zone/oxz_crucible_f33e09d1-e3d7-4341-baf2-5f079f3679e5          aa4f1267-a83a-4081-b572-28e1860ff2f2   in service    none      none          off        
+    oxp_2f26e76b-6c91-4ee9-87b3-f424b942091b/crypt/zone/oxz_crucible_pantry_100e20aa-1816-4195-8d76-08beace10332   032bf309-8046-4c96-9453-29b9346b19fc   in service    none      none          off        
+    oxp_2f26e76b-6c91-4ee9-87b3-f424b942091b/crypt/zone/oxz_external_dns_9995de32-dd52-4eb1-b0eb-141eb84bc739      f258d941-f8b3-4d0e-bbe6-773996a002d5   expunged      none      none          off        
+    oxp_2f26e76b-6c91-4ee9-87b3-f424b942091b/crypt/zone/oxz_external_dns_d786ef4a-5acb-4f5d-a732-a00addf986b5      39f57b97-0501-4902-8f3a-902ed4d7c869   in service    none      none          off        
+    oxp_2f26e76b-6c91-4ee9-87b3-f424b942091b/crypt/zone/oxz_internal_dns_171cabf0-8635-42e7-8ea1-2a1d2a2daf55      3531c6de-8d31-4917-bb72-884b6e168eca   in service    none      none          off        
+    oxp_2f26e76b-6c91-4ee9-87b3-f424b942091b/crypt/zone/oxz_nexus_5b01b0e0-5cdf-4b34-b0a6-c947cbbdb8be             5e3a1b9d-9475-4bd9-8112-5595a7c0da7d   in service    none      none          off        
+    oxp_2f26e76b-6c91-4ee9-87b3-f424b942091b/crypt/zone/oxz_ntp_7b4bccad-9869-48da-8320-2dc82752deea               45771e96-054c-4b05-8021-c32b23fcad8d   in service    none      none          off        
+    oxp_2f26e76b-6c91-4ee9-87b3-f424b942091b/crypt/debug                                                           29be83b4-4d0b-4787-819d-96e8e69301da   in service    100 GiB   none          gzip-9     
+    oxp_6f8fa855-4f34-42db-a6e4-9d0090d6c828/crypt/debug                                                           ce433c69-7540-4a7a-9e11-dd30b0d2dc19   in service    100 GiB   none          gzip-9     
+    oxp_71450d62-791e-4068-9882-8a206a465fd9/crypt/debug                                                           48cc9313-13c2-4ebe-8120-5b648ec26a28   in service    100 GiB   none          gzip-9     
+    oxp_7b4ad242-8330-4c08-9588-c66782742678/crypt/debug                                                           cdcfe435-881a-44dc-9dba-2a0fafdbf66d   in service    100 GiB   none          gzip-9     
+    oxp_9bf23b52-565e-4439-9728-edb603fa6c4e/crypt/debug                                                           835edc8b-9d33-45db-9bdc-ea8a956f3217   in service    100 GiB   none          gzip-9     
+    oxp_c9476e3d-7745-4fa9-b336-b54ac5b08f56/crypt/debug                                                           1754b8f0-07b8-4305-8bb2-b347ba3e0b68   in service    100 GiB   none          gzip-9     
+    oxp_d2cd1e65-b63d-4748-895f-aafecc81e440/crypt/debug                                                           7028b888-b4c0-43e5-a9d4-2e29d24f34a7   in service    100 GiB   none          gzip-9     
+    oxp_d4ad3cc1-956a-4444-81a6-da6a025f6df2/crypt/debug                                                           36ad4fe9-3897-4777-bc0e-88f142594d07   in service    100 GiB   none          gzip-9     
+    oxp_e1298a43-fa1a-4e6f-bcfa-b26996f69c50/crypt/debug                                                           d37e0b8c-6c43-4e83-b3ec-238429d1cbfb   in service    100 GiB   none          gzip-9     
+    oxp_fa9ce87c-fa7c-4854-95bd-69b8f01c46f9/crypt/debug                                                           b7569aa4-f0d6-4de0-9b9a-cd8d0a6cc01d   in service    100 GiB   none          gzip-9     
 
 
     omicron zones at generation 4:

--- a/nexus/reconfigurator/planning/tests/output/example_builder_zone_counts_blueprint.txt
+++ b/nexus/reconfigurator/planning/tests/output/example_builder_zone_counts_blueprint.txt
@@ -19,6 +19,64 @@ parent:    e35b2fdd-354d-48d9-acb5-703b2c269a54
     fake-vendor   fake-model   serial-cd783b74-e400-41e0-9bb7-1d1d2f8958ce
 
 
+    datasets at generation 2:
+    -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
+    dataset name                                                                                                   dataset id                             disposition   quota     reservation   compression
+    -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
+    oxp_2b9c7004-fa39-4cf0-ae41-c299d3191f26/crucible                                                              e3189dd4-ed84-4ba4-b59b-cd848c56c573   in service    none      none          off        
+    oxp_3ad934d9-90ee-4805-881c-20108827773f/crucible                                                              8cce58e1-6ae8-462a-a065-bb8da5328001   in service    none      none          off        
+    oxp_69db5dd6-795e-4e04-bfb3-f51962c49853/crucible                                                              1ad70dd8-73ac-4379-99f6-8557f0e27bb7   in service    none      none          off        
+    oxp_8557a3fb-cc12-497f-86d2-9f1a463b3685/crucible                                                              1b3fe177-9999-440a-9952-79db99dcc3ef   in service    none      none          off        
+    oxp_9bd3cc34-4891-4c28-a4de-c4fcf01b6215/crucible                                                              dcec5ce0-9ff1-4791-b5d9-0897660fe355   in service    none      none          off        
+    oxp_9dafffa2-31b7-43c0-b673-0c946be799f0/crucible                                                              be4a7122-b0ca-4a92-822e-6fc09814bea6   in service    none      none          off        
+    oxp_9e626a52-b5f1-4776-9cb8-271848b9c651/crucible                                                              88c76874-e55c-4dd1-b3ba-aac2430864f7   in service    none      none          off        
+    oxp_a645a1ac-4c49-4c7e-ba53-3dc60b737f06/crucible                                                              84f3e490-5c74-4da3-8cbf-21c1cc053e32   in service    none      none          off        
+    oxp_b5ae209c-9226-44a0-8a6b-03b44f93d456/crucible                                                              56952241-5d68-4f4c-929f-8d3c44f9aece   in service    none      none          off        
+    oxp_cd783b74-e400-41e0-9bb7-1d1d2f8958ce/crucible                                                              cb9f558a-9b61-43d7-9a99-94003f9fd1fc   in service    none      none          off        
+    oxp_2b9c7004-fa39-4cf0-ae41-c299d3191f26/crypt/clickhouse                                                      8f91d515-269a-4fda-8ee6-f1fd3d55e327   in service    none      none          off        
+    oxp_2b9c7004-fa39-4cf0-ae41-c299d3191f26/crypt/external_dns                                                    39c33925-dc15-4729-9e5f-4cab234fb339   in service    none      none          off        
+    oxp_3ad934d9-90ee-4805-881c-20108827773f/crypt/external_dns                                                    4ef5e0c8-76d6-475e-bae4-b52bb90ac70e   in service    none      none          off        
+    oxp_2b9c7004-fa39-4cf0-ae41-c299d3191f26/crypt/internal_dns                                                    167df3a6-2fff-4a0a-aca9-6688431c5d5a   in service    none      none          off        
+    oxp_2b9c7004-fa39-4cf0-ae41-c299d3191f26/crypt/zone                                                            43fb3066-5620-451f-a5c5-4d3b95b05950   in service    none      none          off        
+    oxp_3ad934d9-90ee-4805-881c-20108827773f/crypt/zone                                                            e78639f6-9a2e-49fb-9f6f-a043eaacc047   in service    none      none          off        
+    oxp_69db5dd6-795e-4e04-bfb3-f51962c49853/crypt/zone                                                            c2f103af-da69-44c9-bce6-84db33c8effb   in service    none      none          off        
+    oxp_8557a3fb-cc12-497f-86d2-9f1a463b3685/crypt/zone                                                            650100ce-5cc5-41ec-8809-84f6ab5cb77a   in service    none      none          off        
+    oxp_9bd3cc34-4891-4c28-a4de-c4fcf01b6215/crypt/zone                                                            493feef8-2121-4b8b-a97d-57697731e2ab   in service    none      none          off        
+    oxp_9dafffa2-31b7-43c0-b673-0c946be799f0/crypt/zone                                                            7b762302-7f5a-4f73-baca-37e6d678a9ce   in service    none      none          off        
+    oxp_9e626a52-b5f1-4776-9cb8-271848b9c651/crypt/zone                                                            cc1f3412-2695-4027-ae73-a1f80d404b97   in service    none      none          off        
+    oxp_a645a1ac-4c49-4c7e-ba53-3dc60b737f06/crypt/zone                                                            6d0c9b97-e7fd-4f99-9073-5f7fec416282   in service    none      none          off        
+    oxp_b5ae209c-9226-44a0-8a6b-03b44f93d456/crypt/zone                                                            1a710e19-7464-4fc0-9aba-ce95b7db9a2e   in service    none      none          off        
+    oxp_cd783b74-e400-41e0-9bb7-1d1d2f8958ce/crypt/zone                                                            4d2d4195-227d-415a-b4e3-8073d8ac53ae   in service    none      none          off        
+    oxp_2b9c7004-fa39-4cf0-ae41-c299d3191f26/crypt/zone/oxz_clickhouse_4365e906-7a33-4c8c-bf17-3b44445e333e        ed927d22-febb-47b8-96ac-fa2c41c37f34   in service    none      none          off        
+    oxp_b5ae209c-9226-44a0-8a6b-03b44f93d456/crypt/zone/oxz_crucible_1d8bbe29-01b8-4bc0-bcd0-ca9864d881df          16714ba4-4e78-4835-9e67-ad21a003c5a5   in service    none      none          off        
+    oxp_9bd3cc34-4891-4c28-a4de-c4fcf01b6215/crypt/zone/oxz_crucible_1f679ae9-d2c2-4d18-9258-a4ca59f34c2f          e1b540b8-1764-4618-a106-e5b52a0702ab   in service    none      none          off        
+    oxp_a645a1ac-4c49-4c7e-ba53-3dc60b737f06/crypt/zone/oxz_crucible_2098c2d8-fb3b-4514-a856-a89aca1d2086          e10c7762-e431-441d-8099-dbb300b74d86   in service    none      none          off        
+    oxp_69db5dd6-795e-4e04-bfb3-f51962c49853/crypt/zone/oxz_crucible_5aff48ae-3661-473b-9098-e2d185871289          6b75916e-fcda-4f7d-842a-990424593db9   in service    none      none          off        
+    oxp_2b9c7004-fa39-4cf0-ae41-c299d3191f26/crypt/zone/oxz_crucible_7ef24e88-d759-4d4d-b854-4a72e2e64999          02f6f537-8bba-438c-a0c0-94b10a9c9463   in service    none      none          off        
+    oxp_8557a3fb-cc12-497f-86d2-9f1a463b3685/crypt/zone/oxz_crucible_8f5f749a-12a0-4f65-a73f-7c05007ef8da          7dac2273-e9d4-464e-9771-9c9f61e9c012   in service    none      none          off        
+    oxp_cd783b74-e400-41e0-9bb7-1d1d2f8958ce/crypt/zone/oxz_crucible_a8fdd554-28cd-44e5-93c3-5f07bb3e0cbc          127a73f2-bd32-44a2-90bc-d2266815f3b6   in service    none      none          off        
+    oxp_9e626a52-b5f1-4776-9cb8-271848b9c651/crypt/zone/oxz_crucible_af336d4e-844d-44a9-87c2-295a51d4f26b          d331e0ae-30bd-4c1e-9a8a-d277b8ec96bc   in service    none      none          off        
+    oxp_9dafffa2-31b7-43c0-b673-0c946be799f0/crypt/zone/oxz_crucible_d10c1ac8-a352-4f02-a2f9-a9294ba358dd          3f71bfc8-003a-4ef2-90df-3d06f96712bf   in service    none      none          off        
+    oxp_3ad934d9-90ee-4805-881c-20108827773f/crypt/zone/oxz_crucible_ec1cac47-a611-4614-8615-9541d3f71709          3f2c7732-b50b-4c7d-a6df-f1c9cf3e7339   in service    none      none          off        
+    oxp_2b9c7004-fa39-4cf0-ae41-c299d3191f26/crypt/zone/oxz_crucible_pantry_07b0ef64-1d33-496f-a964-57e6d786f8ce   ef3826e8-95a3-4441-ab5b-78ffc1546a4a   in service    none      none          off        
+    oxp_3ad934d9-90ee-4805-881c-20108827773f/crypt/zone/oxz_external_dns_5c7f05d1-e37f-4756-b678-643783385603      7f736d5d-d9fe-4dc8-8af3-c3f9e0e9f709   in service    none      none          off        
+    oxp_2b9c7004-fa39-4cf0-ae41-c299d3191f26/crypt/zone/oxz_external_dns_ab072f6a-5cd8-4ade-99a7-b3f24c2b40d5      1cb6747e-2156-42b2-abe3-1a19e7ee274e   in service    none      none          off        
+    oxp_2b9c7004-fa39-4cf0-ae41-c299d3191f26/crypt/zone/oxz_internal_dns_246fa3f9-f3bc-4fb8-bc58-8a3d3c483ecb      9b0dcb87-cf3e-43e2-9535-bee1ec371401   in service    none      none          off        
+    oxp_2b9c7004-fa39-4cf0-ae41-c299d3191f26/crypt/zone/oxz_nexus_0bbeda6e-de94-41db-ba09-8b55c541d53b             92ad3b29-68de-492a-ae3c-c46df8736c7c   in service    none      none          off        
+    oxp_3ad934d9-90ee-4805-881c-20108827773f/crypt/zone/oxz_nexus_23d4c822-51bd-4966-8dc2-0be4b9e760c1             4af3831d-2095-4b44-8bbb-5f5c9207618d   in service    none      none          off        
+    oxp_2b9c7004-fa39-4cf0-ae41-c299d3191f26/crypt/zone/oxz_ntp_37a536a6-9043-4f44-bbc1-187b3b7859b1               da0468b1-a89b-4016-af05-b35867e3750c   in service    none      none          off        
+    oxp_2b9c7004-fa39-4cf0-ae41-c299d3191f26/crypt/debug                                                           e3ba833b-4c29-461e-a3d4-9466999f0dae   in service    100 GiB   none          gzip-9     
+    oxp_3ad934d9-90ee-4805-881c-20108827773f/crypt/debug                                                           774e2f52-6a61-47e1-8ded-1dcc42d49b9d   in service    100 GiB   none          gzip-9     
+    oxp_69db5dd6-795e-4e04-bfb3-f51962c49853/crypt/debug                                                           e862d2d3-c3f1-4e9b-9af7-d344b98e7db4   in service    100 GiB   none          gzip-9     
+    oxp_8557a3fb-cc12-497f-86d2-9f1a463b3685/crypt/debug                                                           7f828f9c-240d-4179-811f-47b8e0510783   in service    100 GiB   none          gzip-9     
+    oxp_9bd3cc34-4891-4c28-a4de-c4fcf01b6215/crypt/debug                                                           5332a2cf-909d-466a-952e-db872cb702e1   in service    100 GiB   none          gzip-9     
+    oxp_9dafffa2-31b7-43c0-b673-0c946be799f0/crypt/debug                                                           7f09d660-d1a7-40af-b3ea-06acfc9af7f1   in service    100 GiB   none          gzip-9     
+    oxp_9e626a52-b5f1-4776-9cb8-271848b9c651/crypt/debug                                                           4472ec31-9863-4fac-9944-97b0bc306b00   in service    100 GiB   none          gzip-9     
+    oxp_a645a1ac-4c49-4c7e-ba53-3dc60b737f06/crypt/debug                                                           1b77fcc9-f324-4927-8796-aa7d44fd98d4   in service    100 GiB   none          gzip-9     
+    oxp_b5ae209c-9226-44a0-8a6b-03b44f93d456/crypt/debug                                                           c0d15d22-3152-42a3-b71f-ae6d7c28ef27   in service    100 GiB   none          gzip-9     
+    oxp_cd783b74-e400-41e0-9bb7-1d1d2f8958ce/crypt/debug                                                           741acc7c-702f-4553-8117-0608b547029b   in service    100 GiB   none          gzip-9     
+
+
     omicron zones at generation 2:
     ---------------------------------------------------------------------------------------------
     zone type         zone id                                disposition   underlay IP           
@@ -62,6 +120,61 @@ parent:    e35b2fdd-354d-48d9-acb5-703b2c269a54
     fake-vendor   fake-model   serial-dfaae221-11a9-4db0-b861-41fe5648f185
 
 
+    datasets at generation 2:
+    -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
+    dataset name                                                                                                   dataset id                             disposition   quota     reservation   compression
+    -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
+    oxp_3cba16f1-1a3d-44e5-ba1d-e68cd2188615/crucible                                                              3f125cef-09e8-4172-8b1c-9e8627be2dec   in service    none      none          off        
+    oxp_3fc3ec87-1c39-4df8-99bf-30ca97ec5fac/crucible                                                              1e93c1bb-cfa3-4ffb-a539-4720efb57025   in service    none      none          off        
+    oxp_4c18c1af-dc1c-4de5-92a1-1b2923ea6a87/crucible                                                              3e4a4576-f5e6-4c52-aa33-e75d442de2b2   in service    none      none          off        
+    oxp_6f3a85db-de97-40d9-bf66-e6643ac1c114/crucible                                                              b2f683ff-aa52-43f2-a02e-9113bbc6355b   in service    none      none          off        
+    oxp_96f39cf4-b2ac-413d-8f94-ba66b127cddd/crucible                                                              0cd84eab-500d-4baf-85ad-27c06c289052   in service    none      none          off        
+    oxp_99c392f3-77b8-4f60-9efa-4efae0c92721/crucible                                                              f50c15fc-b7f1-4253-aff4-e2639786e4f5   in service    none      none          off        
+    oxp_bc3195df-61ca-4111-863b-08b5cc243eab/crucible                                                              c5522b33-7f8b-4205-9373-7d98e3a893e8   in service    none      none          off        
+    oxp_c787b52c-2cb8-4da2-a17a-128feb5eea0c/crucible                                                              00b23214-ac68-4249-a98a-22b78306d074   in service    none      none          off        
+    oxp_d59d419e-c4d3-41ef-ab6d-0df3620dc84b/crucible                                                              106f511d-a9a2-4f0e-97c3-1e0b4fdd42ab   in service    none      none          off        
+    oxp_dfaae221-11a9-4db0-b861-41fe5648f185/crucible                                                              72230b77-1c10-4af9-a015-3ff7e1c537c3   in service    none      none          off        
+    oxp_3cba16f1-1a3d-44e5-ba1d-e68cd2188615/crypt/external_dns                                                    00be99af-046d-4b20-829f-32f90194faf1   in service    none      none          off        
+    oxp_3fc3ec87-1c39-4df8-99bf-30ca97ec5fac/crypt/external_dns                                                    2aafcde6-94c9-4a50-9e7a-573311dbe574   in service    none      none          off        
+    oxp_3cba16f1-1a3d-44e5-ba1d-e68cd2188615/crypt/internal_dns                                                    b338b2b1-5a5c-42ff-84b9-07e5133358e4   in service    none      none          off        
+    oxp_3cba16f1-1a3d-44e5-ba1d-e68cd2188615/crypt/zone                                                            0adf2ec0-a465-412c-bdd2-dc832976bcd0   in service    none      none          off        
+    oxp_3fc3ec87-1c39-4df8-99bf-30ca97ec5fac/crypt/zone                                                            0627eda0-3a78-410e-a88f-66b641b00e3d   in service    none      none          off        
+    oxp_4c18c1af-dc1c-4de5-92a1-1b2923ea6a87/crypt/zone                                                            f63f0450-6dc3-499c-8784-11851c37fa66   in service    none      none          off        
+    oxp_6f3a85db-de97-40d9-bf66-e6643ac1c114/crypt/zone                                                            71551555-2f1c-4b7f-a5e4-42356a7c8b9e   in service    none      none          off        
+    oxp_96f39cf4-b2ac-413d-8f94-ba66b127cddd/crypt/zone                                                            3cebbd19-92b7-43c6-83f8-05aa64fbd337   in service    none      none          off        
+    oxp_99c392f3-77b8-4f60-9efa-4efae0c92721/crypt/zone                                                            a198988e-d77b-4d43-a49f-a5e52f0a50db   in service    none      none          off        
+    oxp_bc3195df-61ca-4111-863b-08b5cc243eab/crypt/zone                                                            1f2b9290-1904-47fe-959a-29af345badc7   in service    none      none          off        
+    oxp_c787b52c-2cb8-4da2-a17a-128feb5eea0c/crypt/zone                                                            b520b2c1-485a-448d-9392-e7682578d5fa   in service    none      none          off        
+    oxp_d59d419e-c4d3-41ef-ab6d-0df3620dc84b/crypt/zone                                                            3714a256-8c9b-4256-af26-ed86cbfec2d1   in service    none      none          off        
+    oxp_dfaae221-11a9-4db0-b861-41fe5648f185/crypt/zone                                                            02e31df7-2b6a-4f20-9376-9c3422b6bd45   in service    none      none          off        
+    oxp_bc3195df-61ca-4111-863b-08b5cc243eab/crypt/zone/oxz_crucible_06f09ec9-17bf-412c-a39f-9d7dfaf357a4          dbcf0e7e-ead8-4679-8c85-905acd83d76b   in service    none      none          off        
+    oxp_96f39cf4-b2ac-413d-8f94-ba66b127cddd/crypt/zone/oxz_crucible_0d903191-f7d9-4e03-9e8e-8c16a913279a          79504c59-5b62-4f58-87c1-edc82802ad2b   in service    none      none          off        
+    oxp_dfaae221-11a9-4db0-b861-41fe5648f185/crypt/zone/oxz_crucible_1d88c19b-5f8e-44dd-a9bd-c7d54710daba          9852f9d6-f546-42ef-bc23-5ad332285849   in service    none      none          off        
+    oxp_99c392f3-77b8-4f60-9efa-4efae0c92721/crypt/zone/oxz_crucible_2874301d-348d-4ec8-a907-3e9522e523f1          9eac2719-9b47-4719-94ab-89a45aa45536   in service    none      none          off        
+    oxp_3fc3ec87-1c39-4df8-99bf-30ca97ec5fac/crypt/zone/oxz_crucible_682a3145-d95b-4543-8683-25edea05cbc9          2f14c18a-d2d4-4140-b214-dbf9af07f308   in service    none      none          off        
+    oxp_3cba16f1-1a3d-44e5-ba1d-e68cd2188615/crypt/zone/oxz_crucible_73da1029-abcc-465a-b65d-8b15a43ef4f0          6e66fa48-8214-4232-bc73-8eebe46ffeb6   in service    none      none          off        
+    oxp_4c18c1af-dc1c-4de5-92a1-1b2923ea6a87/crypt/zone/oxz_crucible_d7886bb9-cf2f-46af-a9a7-3eda2a548c98          cd304504-b140-46bd-a0ec-24cc6e395f63   in service    none      none          off        
+    oxp_c787b52c-2cb8-4da2-a17a-128feb5eea0c/crypt/zone/oxz_crucible_d893603e-bbe6-4006-aebd-0cd96a160203          def74314-d972-4a72-bc19-43c4e3919009   in service    none      none          off        
+    oxp_d59d419e-c4d3-41ef-ab6d-0df3620dc84b/crypt/zone/oxz_crucible_f4945957-e5ea-4b38-8344-e7bd610aa442          a1454933-424d-4a66-946d-3cf4f1cb1605   in service    none      none          off        
+    oxp_6f3a85db-de97-40d9-bf66-e6643ac1c114/crypt/zone/oxz_crucible_f7540a15-7960-4681-a202-443d5ccd80b0          0bdd8497-22ed-470c-bb51-41d9769f5901   in service    none      none          off        
+    oxp_3cba16f1-1a3d-44e5-ba1d-e68cd2188615/crypt/zone/oxz_crucible_pantry_2d53e5bb-4265-4fe0-8ea4-f1a0a3bb9189   d0ab3f9d-3650-4f40-981a-85d3489ef115   in service    none      none          off        
+    oxp_3cba16f1-1a3d-44e5-ba1d-e68cd2188615/crypt/zone/oxz_external_dns_0eeabc44-5fc4-44e9-8884-68151571b217      bcdc6d49-e99a-46d0-ba0d-18c289139dbd   in service    none      none          off        
+    oxp_3fc3ec87-1c39-4df8-99bf-30ca97ec5fac/crypt/zone/oxz_external_dns_aad293d7-74dc-48dc-bb50-1e1f972fda23      df5f1e27-3308-47c9-bd6d-7a0dff28cf89   in service    none      none          off        
+    oxp_3cba16f1-1a3d-44e5-ba1d-e68cd2188615/crypt/zone/oxz_internal_dns_a399df19-8b57-4727-ac5d-94fdf76d0888      5919b87e-1e64-435a-8269-e47652fb4f20   in service    none      none          off        
+    oxp_3cba16f1-1a3d-44e5-ba1d-e68cd2188615/crypt/zone/oxz_nexus_0a3ccdda-78e3-4a90-b79e-dd1c8954098f             45f0eec3-6396-4e97-b72a-dbf0fe7f8802   in service    none      none          off        
+    oxp_3cba16f1-1a3d-44e5-ba1d-e68cd2188615/crypt/zone/oxz_ntp_3e305e50-9192-4c0d-8fb6-bc539a37fc3e               85629a7e-f129-4b45-b40e-d483d05cb29b   in service    none      none          off        
+    oxp_3cba16f1-1a3d-44e5-ba1d-e68cd2188615/crypt/debug                                                           bb19fb0d-b848-414e-a435-818eb17aca23   in service    100 GiB   none          gzip-9     
+    oxp_3fc3ec87-1c39-4df8-99bf-30ca97ec5fac/crypt/debug                                                           8fc63ec0-f51f-4d64-a329-9d9bf56023d5   in service    100 GiB   none          gzip-9     
+    oxp_4c18c1af-dc1c-4de5-92a1-1b2923ea6a87/crypt/debug                                                           1539143f-f25e-4b7e-af10-481ed9139082   in service    100 GiB   none          gzip-9     
+    oxp_6f3a85db-de97-40d9-bf66-e6643ac1c114/crypt/debug                                                           36d4d3e7-b866-42da-8569-e5442f0ae498   in service    100 GiB   none          gzip-9     
+    oxp_96f39cf4-b2ac-413d-8f94-ba66b127cddd/crypt/debug                                                           d967a933-cb35-4183-8a67-b6db665f227d   in service    100 GiB   none          gzip-9     
+    oxp_99c392f3-77b8-4f60-9efa-4efae0c92721/crypt/debug                                                           cd5c00e1-30e4-4523-8182-9f71e326f547   in service    100 GiB   none          gzip-9     
+    oxp_bc3195df-61ca-4111-863b-08b5cc243eab/crypt/debug                                                           3d95ebd4-eca8-4f56-9fc3-10c6de54204b   in service    100 GiB   none          gzip-9     
+    oxp_c787b52c-2cb8-4da2-a17a-128feb5eea0c/crypt/debug                                                           0bd5f018-b363-4e83-8e4d-6eb1155aac14   in service    100 GiB   none          gzip-9     
+    oxp_d59d419e-c4d3-41ef-ab6d-0df3620dc84b/crypt/debug                                                           7aa19675-8e61-4667-86ce-6ac3c668fc2a   in service    100 GiB   none          gzip-9     
+    oxp_dfaae221-11a9-4db0-b861-41fe5648f185/crypt/debug                                                           65550301-5f29-4d98-9797-96895547765d   in service    100 GiB   none          gzip-9     
+
+
     omicron zones at generation 2:
     ---------------------------------------------------------------------------------------------
     zone type         zone id                                disposition   underlay IP           
@@ -101,6 +214,59 @@ parent:    e35b2fdd-354d-48d9-acb5-703b2c269a54
     fake-vendor   fake-model   serial-a0bd8e79-1113-4c40-8705-ed00e66f0c35
     fake-vendor   fake-model   serial-b30e150e-c83e-4c1e-b3bf-91a330d42135
     fake-vendor   fake-model   serial-ff911b9b-57a8-4318-a253-e2363b70083d
+
+
+    datasets at generation 2:
+    -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
+    dataset name                                                                                                   dataset id                             disposition   quota     reservation   compression
+    -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
+    oxp_00fb9aa9-0bbf-49ab-a712-6e8feaf719e2/crucible                                                              c84905fc-abc9-490c-8d3c-e76e4e496fec   in service    none      none          off        
+    oxp_37f466d7-510b-40e4-b9a4-c5c092a6a5f6/crucible                                                              38118342-7d06-42e8-9da7-a0e1a6dd533f   in service    none      none          off        
+    oxp_734b7b3a-86af-48a7-bd00-8d79fa2690c3/crucible                                                              4bb5f832-371a-4f2f-9700-9f3b6fe25f86   in service    none      none          off        
+    oxp_747d2504-36a4-4acc-ad73-22291b5bbedb/crucible                                                              91ef7225-1257-4437-b609-6ef94edc1df1   in service    none      none          off        
+    oxp_7dd422ab-4839-4a7a-8109-ba1941357c70/crucible                                                              576f2ef5-4380-4110-8057-ff6c774aa284   in service    none      none          off        
+    oxp_8b020037-bc77-48b2-9280-a622f571908b/crucible                                                              26a21bf2-4fa4-425c-8cce-15ecc92a470f   in service    none      none          off        
+    oxp_96753d7f-de6b-4ce6-a9dc-004f6a0ba0cf/crucible                                                              ee9bf400-b26c-4588-9407-b679a4b78246   in service    none      none          off        
+    oxp_a0bd8e79-1113-4c40-8705-ed00e66f0c35/crucible                                                              f9dc0f24-7d91-4af6-826c-a07801087940   in service    none      none          off        
+    oxp_b30e150e-c83e-4c1e-b3bf-91a330d42135/crucible                                                              f73d3730-9b09-47e4-b8c7-4b538fa43885   in service    none      none          off        
+    oxp_ff911b9b-57a8-4318-a253-e2363b70083d/crucible                                                              d4c1bdd4-ca24-49fd-88aa-b68b70658d12   in service    none      none          off        
+    oxp_00fb9aa9-0bbf-49ab-a712-6e8feaf719e2/crypt/external_dns                                                    8b821069-94a5-4c09-b38f-8a491ba768a8   in service    none      none          off        
+    oxp_37f466d7-510b-40e4-b9a4-c5c092a6a5f6/crypt/external_dns                                                    c986afce-be1c-4f5e-a1df-2db34d9ef658   in service    none      none          off        
+    oxp_00fb9aa9-0bbf-49ab-a712-6e8feaf719e2/crypt/zone                                                            e8e6163a-8d37-4e56-8eff-4a9d6070a42a   in service    none      none          off        
+    oxp_37f466d7-510b-40e4-b9a4-c5c092a6a5f6/crypt/zone                                                            d4101deb-9d70-4ce8-b83c-af64d88e71ec   in service    none      none          off        
+    oxp_734b7b3a-86af-48a7-bd00-8d79fa2690c3/crypt/zone                                                            9aa253cc-560c-4786-b248-40de807174ee   in service    none      none          off        
+    oxp_747d2504-36a4-4acc-ad73-22291b5bbedb/crypt/zone                                                            679370c4-5719-4bde-b82c-0d49999d93ed   in service    none      none          off        
+    oxp_7dd422ab-4839-4a7a-8109-ba1941357c70/crypt/zone                                                            7fc3a86a-0e83-4fbc-a290-c322a1770608   in service    none      none          off        
+    oxp_8b020037-bc77-48b2-9280-a622f571908b/crypt/zone                                                            229fdf2f-d2cb-43f1-9d71-c4fbc92aa74d   in service    none      none          off        
+    oxp_96753d7f-de6b-4ce6-a9dc-004f6a0ba0cf/crypt/zone                                                            c0463104-1e65-45f2-8e80-53bd4cf695f6   in service    none      none          off        
+    oxp_a0bd8e79-1113-4c40-8705-ed00e66f0c35/crypt/zone                                                            c8ed6a97-eee1-4361-9314-70ec31d7a62e   in service    none      none          off        
+    oxp_b30e150e-c83e-4c1e-b3bf-91a330d42135/crypt/zone                                                            61b80718-24ee-4fb0-bc29-e8d11b2bcc64   in service    none      none          off        
+    oxp_ff911b9b-57a8-4318-a253-e2363b70083d/crypt/zone                                                            d4e92f89-4086-4423-9b66-40011280daf9   in service    none      none          off        
+    oxp_747d2504-36a4-4acc-ad73-22291b5bbedb/crypt/zone/oxz_crucible_0b5c74ed-0681-4112-ab22-e6aa282999ea          a5341b04-1d80-48c7-8d4b-7efa249a8327   in service    none      none          off        
+    oxp_37f466d7-510b-40e4-b9a4-c5c092a6a5f6/crypt/zone/oxz_crucible_2a71a664-3afc-4c9b-844a-838423a7ce6d          0eac6995-f863-47d5-9515-8b8580788810   in service    none      none          off        
+    oxp_7dd422ab-4839-4a7a-8109-ba1941357c70/crypt/zone/oxz_crucible_377b5e5a-d8e5-407e-ad33-d11592a234ca          01aa77a9-57d5-4004-a0c0-192e9a1ff683   in service    none      none          off        
+    oxp_8b020037-bc77-48b2-9280-a622f571908b/crypt/zone/oxz_crucible_470086b8-d5d5-4349-a63c-8c70021c89ad          cff76512-ed43-448f-98d4-e7792695b2ac   in service    none      none          off        
+    oxp_734b7b3a-86af-48a7-bd00-8d79fa2690c3/crypt/zone/oxz_crucible_4f559858-1c4f-4014-86f1-c497936510bf          5dd413ea-e392-493b-92e9-5878c16988d4   in service    none      none          off        
+    oxp_96753d7f-de6b-4ce6-a9dc-004f6a0ba0cf/crypt/zone/oxz_crucible_7f73bce2-c685-4501-a4fe-34327f6a30a5          70307373-e121-4fc8-b2ba-b09e25eb95d0   in service    none      none          off        
+    oxp_b30e150e-c83e-4c1e-b3bf-91a330d42135/crypt/zone/oxz_crucible_8971a3f0-32ed-4444-8b7c-c492f55f6464          12011fb6-a863-42a8-a358-6f48f1c64d4b   in service    none      none          off        
+    oxp_a0bd8e79-1113-4c40-8705-ed00e66f0c35/crypt/zone/oxz_crucible_95c4aca6-aab6-4bde-ab8c-94bbe3beef3f          b190b376-c483-4ae7-b5d4-2ce5ee6045c0   in service    none      none          off        
+    oxp_ff911b9b-57a8-4318-a253-e2363b70083d/crypt/zone/oxz_crucible_d2b2710c-99a0-4d76-8c45-918fe7745d6a          800c16c1-8394-4a4b-af48-c2f2fb7763f5   in service    none      none          off        
+    oxp_00fb9aa9-0bbf-49ab-a712-6e8feaf719e2/crypt/zone/oxz_crucible_dcdb2cf0-b347-49f4-a38d-0a2ce82d53ce          7e240cd3-fc74-407c-9a1a-073a68c5462c   in service    none      none          off        
+    oxp_00fb9aa9-0bbf-49ab-a712-6e8feaf719e2/crypt/zone/oxz_crucible_pantry_6c856814-7dda-466a-8c40-18dc59f23167   3c1ce61d-4c37-4466-8fb7-c235b710e259   in service    none      none          off        
+    oxp_00fb9aa9-0bbf-49ab-a712-6e8feaf719e2/crypt/zone/oxz_external_dns_a39f897f-d9a0-4193-aee4-f879d1cb8e2c      902c4b96-2da4-4182-953b-76b7a04da4ab   in service    none      none          off        
+    oxp_37f466d7-510b-40e4-b9a4-c5c092a6a5f6/crypt/zone/oxz_external_dns_bff5eb61-89b4-49f1-8dd7-3bbf9f3ff4c1      4de554ac-cd93-4f2c-8013-a52933a6a0f3   in service    none      none          off        
+    oxp_00fb9aa9-0bbf-49ab-a712-6e8feaf719e2/crypt/zone/oxz_nexus_eb1c79f7-1d99-42f6-b2cf-7d64419b2fed             96508cdf-0bde-4012-9d79-dafc34abc11c   in service    none      none          off        
+    oxp_00fb9aa9-0bbf-49ab-a712-6e8feaf719e2/crypt/zone/oxz_ntp_ab44f8b2-4346-4cb2-bd4a-44063fa5df56               f4eb2e00-7357-4dab-9889-d9480d7d3821   in service    none      none          off        
+    oxp_00fb9aa9-0bbf-49ab-a712-6e8feaf719e2/crypt/debug                                                           5d069a3f-6ef4-4391-8d76-47756dcea0c6   in service    100 GiB   none          gzip-9     
+    oxp_37f466d7-510b-40e4-b9a4-c5c092a6a5f6/crypt/debug                                                           e1a9202a-dd0a-4a36-ba85-918c95cdf638   in service    100 GiB   none          gzip-9     
+    oxp_734b7b3a-86af-48a7-bd00-8d79fa2690c3/crypt/debug                                                           cfb734e6-3df0-43a5-a571-de0aa44e04a3   in service    100 GiB   none          gzip-9     
+    oxp_747d2504-36a4-4acc-ad73-22291b5bbedb/crypt/debug                                                           94e90cc8-1d42-4ce1-88a8-0a221a0042bd   in service    100 GiB   none          gzip-9     
+    oxp_7dd422ab-4839-4a7a-8109-ba1941357c70/crypt/debug                                                           5dd5a82b-5265-45c8-9ae7-586adfcc24a3   in service    100 GiB   none          gzip-9     
+    oxp_8b020037-bc77-48b2-9280-a622f571908b/crypt/debug                                                           d926e7f5-5b5d-48e3-9d09-850ef0091de2   in service    100 GiB   none          gzip-9     
+    oxp_96753d7f-de6b-4ce6-a9dc-004f6a0ba0cf/crypt/debug                                                           f02ce72a-d518-4209-98dd-691fddb64d47   in service    100 GiB   none          gzip-9     
+    oxp_a0bd8e79-1113-4c40-8705-ed00e66f0c35/crypt/debug                                                           e635bfe0-b566-4d28-a76a-ed2852be4452   in service    100 GiB   none          gzip-9     
+    oxp_b30e150e-c83e-4c1e-b3bf-91a330d42135/crypt/debug                                                           8d322ef4-1d46-4042-a67e-f343be6547c4   in service    100 GiB   none          gzip-9     
+    oxp_ff911b9b-57a8-4318-a253-e2363b70083d/crypt/debug                                                           aaf36a06-b6fa-408a-99eb-18e9008beb6f   in service    100 GiB   none          gzip-9     
 
 
     omicron zones at generation 2:
@@ -143,6 +309,59 @@ parent:    e35b2fdd-354d-48d9-acb5-703b2c269a54
     fake-vendor   fake-model   serial-f9415bcf-5757-442a-a400-5a9ccfb5d80a
 
 
+    datasets at generation 2:
+    -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
+    dataset name                                                                                                   dataset id                             disposition   quota     reservation   compression
+    -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
+    oxp_07444848-952b-4333-aa72-401c7bf5d724/crucible                                                              0f4f1bed-c9b0-42fc-a4e4-32d45cc20cb3   in service    none      none          off        
+    oxp_242f8f98-fdc2-4ea9-ab69-e57b993df0df/crucible                                                              ba1e1c4a-ef12-493e-ad89-0178d03d8092   in service    none      none          off        
+    oxp_26cc7ce1-dc59-4398-8083-a4e1db957a46/crucible                                                              5f65675a-3d62-4e7b-9842-f7665142a9b5   in service    none      none          off        
+    oxp_3b757772-8c62-4543-a276-7c0051280687/crucible                                                              6b8a3459-a813-4f51-a849-2813d8294271   in service    none      none          off        
+    oxp_981430ec-a43e-4418-bd2c-28db344c8b06/crucible                                                              4c960b21-5b5b-46f8-9e3d-13a87a536ce9   in service    none      none          off        
+    oxp_9dbfe441-887c-45d0-a3ed-7d8e1a63327f/crucible                                                              9806783f-7ed5-40a1-98fb-0cf40451fef9   in service    none      none          off        
+    oxp_b37f5663-bedb-42a3-9b1a-5e417ee6c3d2/crucible                                                              1058a48d-f511-4a0b-aac1-0a812e5605dd   in service    none      none          off        
+    oxp_b48a178d-f7fd-4b50-811d-f7d195752710/crucible                                                              2622f9af-68d7-4cb4-b90a-72ec573b5cb3   in service    none      none          off        
+    oxp_be1784b0-017a-436f-8a6a-1884cddc5fa1/crucible                                                              7b6f5f64-27a6-402c-bade-9097b92678ac   in service    none      none          off        
+    oxp_f9415bcf-5757-442a-a400-5a9ccfb5d80a/crucible                                                              da310575-e60a-4c5c-8f64-ca7323f0f9a1   in service    none      none          off        
+    oxp_07444848-952b-4333-aa72-401c7bf5d724/crypt/external_dns                                                    b5cce810-822c-4d4b-a7f1-1fdf4cfbc355   in service    none      none          off        
+    oxp_242f8f98-fdc2-4ea9-ab69-e57b993df0df/crypt/external_dns                                                    a50c5b3f-671d-4eac-b926-31e2bded72a5   in service    none      none          off        
+    oxp_07444848-952b-4333-aa72-401c7bf5d724/crypt/zone                                                            a79bdbea-3beb-4ae3-8c1f-52b352dcef81   in service    none      none          off        
+    oxp_242f8f98-fdc2-4ea9-ab69-e57b993df0df/crypt/zone                                                            2f3a9ee6-2f6e-4c0b-b531-cb687bc402eb   in service    none      none          off        
+    oxp_26cc7ce1-dc59-4398-8083-a4e1db957a46/crypt/zone                                                            570087d6-eb92-423d-abd9-b5bdeea1756c   in service    none      none          off        
+    oxp_3b757772-8c62-4543-a276-7c0051280687/crypt/zone                                                            b8551aed-f4e4-4e78-a965-fcd1ed870915   in service    none      none          off        
+    oxp_981430ec-a43e-4418-bd2c-28db344c8b06/crypt/zone                                                            6b8a7654-aa52-478d-8f53-54e53c09d94f   in service    none      none          off        
+    oxp_9dbfe441-887c-45d0-a3ed-7d8e1a63327f/crypt/zone                                                            e53998fc-98fa-4fed-8651-e5db00061dbc   in service    none      none          off        
+    oxp_b37f5663-bedb-42a3-9b1a-5e417ee6c3d2/crypt/zone                                                            12a34b7d-186c-4c88-8a71-35dea613d3fc   in service    none      none          off        
+    oxp_b48a178d-f7fd-4b50-811d-f7d195752710/crypt/zone                                                            ed695361-9352-4ca6-bdd9-04225f77a043   in service    none      none          off        
+    oxp_be1784b0-017a-436f-8a6a-1884cddc5fa1/crypt/zone                                                            1b091f0a-4da2-4c29-b71b-2d128bb1a266   in service    none      none          off        
+    oxp_f9415bcf-5757-442a-a400-5a9ccfb5d80a/crypt/zone                                                            46180231-795e-4b62-b04a-45ae14b92f34   in service    none      none          off        
+    oxp_b48a178d-f7fd-4b50-811d-f7d195752710/crypt/zone/oxz_crucible_154d09df-6ba2-4b2d-9593-aed966fa8edd          97b34be3-c644-46fd-9ee2-bcd6d8a68969   in service    none      none          off        
+    oxp_f9415bcf-5757-442a-a400-5a9ccfb5d80a/crypt/zone/oxz_crucible_3c0d398b-e239-417e-94af-c0113f3b3df0          efc62657-7c5a-45fe-ad7b-bfcb38560bb1   in service    none      none          off        
+    oxp_3b757772-8c62-4543-a276-7c0051280687/crypt/zone/oxz_crucible_490b85bd-cb2a-4730-9586-7340c2b33290          fa8b2c77-75d2-4d61-96c4-84d00269666c   in service    none      none          off        
+    oxp_07444848-952b-4333-aa72-401c7bf5d724/crypt/zone/oxz_crucible_6dd7f36b-eb4c-4666-a5b3-8e4f7765f284          ea2cb3d2-8867-4856-a435-10147ba62391   in service    none      none          off        
+    oxp_981430ec-a43e-4418-bd2c-28db344c8b06/crypt/zone/oxz_crucible_72307d66-7b37-4bb5-a45b-1424bbd2db89          2189e57d-5aef-47d8-9ad1-e252df78eb5c   in service    none      none          off        
+    oxp_b37f5663-bedb-42a3-9b1a-5e417ee6c3d2/crypt/zone/oxz_crucible_80df9448-d723-450b-a5a9-55f67279e45c          74de6050-df66-494e-a39d-634486a42ba1   in service    none      none          off        
+    oxp_26cc7ce1-dc59-4398-8083-a4e1db957a46/crypt/zone/oxz_crucible_85078136-3cbf-4884-a44e-340c40cbd180          9e0b82f0-a54d-4fdf-94b2-c541122b9cc3   in service    none      none          off        
+    oxp_242f8f98-fdc2-4ea9-ab69-e57b993df0df/crypt/zone/oxz_crucible_dc841af2-b873-4a4b-a158-09a68db6445e          33a3b14e-9909-4479-97bd-0be277900b09   in service    none      none          off        
+    oxp_9dbfe441-887c-45d0-a3ed-7d8e1a63327f/crypt/zone/oxz_crucible_e1f8a0ca-4bce-4925-abe7-bdc508fff8e3          89217507-01e9-4dd8-996a-9e817ad0beb2   in service    none      none          off        
+    oxp_be1784b0-017a-436f-8a6a-1884cddc5fa1/crypt/zone/oxz_crucible_f3ac0681-8f1e-4e57-a81c-a958f79fe9db          7470d5e5-7364-46a2-b300-f2718152595e   in service    none      none          off        
+    oxp_07444848-952b-4333-aa72-401c7bf5d724/crypt/zone/oxz_crucible_pantry_60d6c6b4-0754-413e-8a59-bcc3509d411a   8be3f090-9117-48e6-a70c-d69316a6717b   in service    none      none          off        
+    oxp_07444848-952b-4333-aa72-401c7bf5d724/crypt/zone/oxz_external_dns_70bb46c9-820a-4e5b-b1fc-392aea9057e8      8c5070f6-e944-4145-8228-ab9113af93c5   in service    none      none          off        
+    oxp_242f8f98-fdc2-4ea9-ab69-e57b993df0df/crypt/zone/oxz_external_dns_e9aefa25-1524-4514-9a8d-075dc084c0a0      4021b946-52e8-4912-a593-ba7ceed36fea   in service    none      none          off        
+    oxp_07444848-952b-4333-aa72-401c7bf5d724/crypt/zone/oxz_nexus_0b93b21c-9914-4802-bb58-225c314bea37             8408dce0-29f8-4a60-8fad-2e03f021d644   in service    none      none          off        
+    oxp_07444848-952b-4333-aa72-401c7bf5d724/crypt/zone/oxz_ntp_705fe10e-b41f-4de1-b712-3b9cd2a6cd3b               86bfdc91-a081-4b03-a5bc-dd18d599d4d6   in service    none      none          off        
+    oxp_07444848-952b-4333-aa72-401c7bf5d724/crypt/debug                                                           d7dec1d7-5224-44ea-9204-010ee599c30b   in service    100 GiB   none          gzip-9     
+    oxp_242f8f98-fdc2-4ea9-ab69-e57b993df0df/crypt/debug                                                           f3018a49-906d-4d9d-86a3-8fabf977a065   in service    100 GiB   none          gzip-9     
+    oxp_26cc7ce1-dc59-4398-8083-a4e1db957a46/crypt/debug                                                           d60fb606-39d3-4009-9171-891e46162db3   in service    100 GiB   none          gzip-9     
+    oxp_3b757772-8c62-4543-a276-7c0051280687/crypt/debug                                                           ce7606db-0252-4e79-8206-67be3920832c   in service    100 GiB   none          gzip-9     
+    oxp_981430ec-a43e-4418-bd2c-28db344c8b06/crypt/debug                                                           dab6f0cc-f6ec-4db1-b7d6-2f5c70ae9707   in service    100 GiB   none          gzip-9     
+    oxp_9dbfe441-887c-45d0-a3ed-7d8e1a63327f/crypt/debug                                                           f0a4cd88-9dd6-4a91-82cf-4d2b38a880fa   in service    100 GiB   none          gzip-9     
+    oxp_b37f5663-bedb-42a3-9b1a-5e417ee6c3d2/crypt/debug                                                           4b9dafab-3e0e-45c3-9c5d-457b8f132848   in service    100 GiB   none          gzip-9     
+    oxp_b48a178d-f7fd-4b50-811d-f7d195752710/crypt/debug                                                           2df14d1f-6f07-4b68-936d-cb90250de553   in service    100 GiB   none          gzip-9     
+    oxp_be1784b0-017a-436f-8a6a-1884cddc5fa1/crypt/debug                                                           ff031e0e-da55-403e-89ff-80dd7f198d62   in service    100 GiB   none          gzip-9     
+    oxp_f9415bcf-5757-442a-a400-5a9ccfb5d80a/crypt/debug                                                           31ffef1c-9028-41d9-8f9c-0778af15ed80   in service    100 GiB   none          gzip-9     
+
+
     omicron zones at generation 2:
     ---------------------------------------------------------------------------------------------
     zone type         zone id                                disposition   underlay IP           
@@ -181,6 +400,59 @@ parent:    e35b2fdd-354d-48d9-acb5-703b2c269a54
     fake-vendor   fake-model   serial-c45c08e4-aade-4333-9dad-935ccf4e8352
     fake-vendor   fake-model   serial-df62d5da-7da0-468b-b328-0fefbf57568b
     fake-vendor   fake-model   serial-e6433ded-7c90-46a9-8bda-648bcc9fbf07
+
+
+    datasets at generation 2:
+    -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
+    dataset name                                                                                                   dataset id                             disposition   quota     reservation   compression
+    -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
+    oxp_148436fe-d3e9-4371-8d2e-ec950cc8a84c/crucible                                                              dee54247-21f2-4c28-bebb-f2fbb7c83bfe   in service    none      none          off        
+    oxp_7dd076f1-9d62-49a8-bc0c-5ff5d045c917/crucible                                                              529a930a-6320-411f-ae61-3f59e07c47f4   in service    none      none          off        
+    oxp_a50f4bb9-d19a-4be8-ad49-b9a552a21062/crucible                                                              fbdd0ac2-9f01-4b9a-ad23-8a4ec7cabde9   in service    none      none          off        
+    oxp_b4ee33bb-03f1-4085-9830-9da92002a969/crucible                                                              0c62551c-a3fb-413f-8ae3-e3b0ada9b450   in service    none      none          off        
+    oxp_b50bec8b-a8d3-4ba6-ba3d-12c2a0da911c/crucible                                                              2718de94-7ae1-4fef-9d41-310d00541642   in service    none      none          off        
+    oxp_b64f79f6-188f-4e98-9eac-d8111673a130/crucible                                                              2cb15ec7-4779-49eb-8d47-9a061f7eaff3   in service    none      none          off        
+    oxp_c144a26e-f859-42a0-adca-00d9091d98e4/crucible                                                              8a89a8f2-b50d-40b2-bacc-832199f82f87   in service    none      none          off        
+    oxp_c45c08e4-aade-4333-9dad-935ccf4e8352/crucible                                                              b3123cea-aecb-4e3e-8465-a78c7d1195c4   in service    none      none          off        
+    oxp_df62d5da-7da0-468b-b328-0fefbf57568b/crucible                                                              079b2268-a93c-4f39-acba-8c1d4439d136   in service    none      none          off        
+    oxp_e6433ded-7c90-46a9-8bda-648bcc9fbf07/crucible                                                              1b10d660-1940-46eb-b141-0cf26208b0a9   in service    none      none          off        
+    oxp_148436fe-d3e9-4371-8d2e-ec950cc8a84c/crypt/external_dns                                                    4622b344-5a96-4cc3-aad8-4507068f5017   in service    none      none          off        
+    oxp_7dd076f1-9d62-49a8-bc0c-5ff5d045c917/crypt/external_dns                                                    f667b2d7-74ab-43bf-a64c-57a878ee3034   in service    none      none          off        
+    oxp_148436fe-d3e9-4371-8d2e-ec950cc8a84c/crypt/zone                                                            85e98d0b-f6f0-4afe-ac4d-14d0f6669b2a   in service    none      none          off        
+    oxp_7dd076f1-9d62-49a8-bc0c-5ff5d045c917/crypt/zone                                                            d60ec30b-942e-44e5-882b-c8b8f888460e   in service    none      none          off        
+    oxp_a50f4bb9-d19a-4be8-ad49-b9a552a21062/crypt/zone                                                            3f7d18e0-9ec6-4a87-911d-0183739c2ffd   in service    none      none          off        
+    oxp_b4ee33bb-03f1-4085-9830-9da92002a969/crypt/zone                                                            08b6a055-98db-4376-b396-1e3dcd6fbecf   in service    none      none          off        
+    oxp_b50bec8b-a8d3-4ba6-ba3d-12c2a0da911c/crypt/zone                                                            a298c038-70ac-4116-895a-6fc4d1c51dec   in service    none      none          off        
+    oxp_b64f79f6-188f-4e98-9eac-d8111673a130/crypt/zone                                                            df6e91a0-82d7-405d-b481-6aae75c15047   in service    none      none          off        
+    oxp_c144a26e-f859-42a0-adca-00d9091d98e4/crypt/zone                                                            8b43e963-8588-43c8-96d2-7e6e7ef2e4e2   in service    none      none          off        
+    oxp_c45c08e4-aade-4333-9dad-935ccf4e8352/crypt/zone                                                            4a93eff0-1bfb-4320-af7a-1790a97799f3   in service    none      none          off        
+    oxp_df62d5da-7da0-468b-b328-0fefbf57568b/crypt/zone                                                            805cbc7f-343c-48d0-82d1-c37bd0d66791   in service    none      none          off        
+    oxp_e6433ded-7c90-46a9-8bda-648bcc9fbf07/crypt/zone                                                            3ec713f1-9d3f-4eec-8eaf-9fbd3463ab01   in service    none      none          off        
+    oxp_e6433ded-7c90-46a9-8bda-648bcc9fbf07/crypt/zone/oxz_crucible_39360f6b-69bc-4c7b-b24f-0a9d640e8e56          fbeef67c-87f4-4f72-8f37-26e91ac2b201   in service    none      none          off        
+    oxp_7dd076f1-9d62-49a8-bc0c-5ff5d045c917/crypt/zone/oxz_crucible_52074602-a8a5-47f0-90b6-5932b06034a2          eda95d99-943d-47f9-95c1-ed76644730a7   in service    none      none          off        
+    oxp_df62d5da-7da0-468b-b328-0fefbf57568b/crypt/zone/oxz_crucible_59da8225-2f80-41ae-afef-dce85dcb526d          a61a76cc-a67c-4058-9a86-331e7bd515e5   in service    none      none          off        
+    oxp_a50f4bb9-d19a-4be8-ad49-b9a552a21062/crypt/zone/oxz_crucible_5d3ec58b-746e-4f10-9998-5fd81dc34ef1          199b9d29-bd4c-49aa-9f01-ade8b3b8a675   in service    none      none          off        
+    oxp_c45c08e4-aade-4333-9dad-935ccf4e8352/crypt/zone/oxz_crucible_65fc4eb5-51c3-4361-81a4-a216b4ed67a0          94591489-a008-4a3a-a267-74eb92cbc1be   in service    none      none          off        
+    oxp_b64f79f6-188f-4e98-9eac-d8111673a130/crypt/zone/oxz_crucible_765252ef-de7d-4023-b271-7acd6299ba5f          b3e9840a-544d-42d5-8515-2ad770db981f   in service    none      none          off        
+    oxp_b4ee33bb-03f1-4085-9830-9da92002a969/crypt/zone/oxz_crucible_7bc16ca6-36d7-4a7c-93e7-6d1f0aad41bb          7955c220-1c2c-4e32-9b62-cabafb94b71b   in service    none      none          off        
+    oxp_b50bec8b-a8d3-4ba6-ba3d-12c2a0da911c/crypt/zone/oxz_crucible_a6a695dc-0d62-4d4e-936a-8e7ee1e527e8          6bcdc042-f427-45a7-8f80-7a104101a9a1   in service    none      none          off        
+    oxp_148436fe-d3e9-4371-8d2e-ec950cc8a84c/crypt/zone/oxz_crucible_abf18c62-0342-450c-b646-7df9f2951b76          8aa4766c-040a-4839-9d9b-9972db5f80ee   in service    none      none          off        
+    oxp_c144a26e-f859-42a0-adca-00d9091d98e4/crypt/zone/oxz_crucible_c0f1485b-d707-4aec-8c87-3c5057018ef2          28119b20-9f55-4f2e-9585-5e9cafbfb8e9   in service    none      none          off        
+    oxp_148436fe-d3e9-4371-8d2e-ec950cc8a84c/crypt/zone/oxz_crucible_pantry_038ba0cf-de93-45b1-a0ae-b894b36bf92d   71778fe9-8f9d-4909-a13e-32ab8d3e527f   in service    none      none          off        
+    oxp_7dd076f1-9d62-49a8-bc0c-5ff5d045c917/crypt/zone/oxz_external_dns_402719bf-c387-4979-8ae4-3a6f8eada5ab      abb0d1c2-72c3-4edf-85f0-0a6c58ae8b82   in service    none      none          off        
+    oxp_148436fe-d3e9-4371-8d2e-ec950cc8a84c/crypt/zone/oxz_external_dns_9ee48a0d-66ac-4fc9-aaa8-8f939ebef705      6cc1b1bf-4012-409d-ad57-110a5431ee86   in service    none      none          off        
+    oxp_148436fe-d3e9-4371-8d2e-ec950cc8a84c/crypt/zone/oxz_nexus_ec10317f-5c36-4092-827c-f2826c5572d5             c4714f55-8e4d-4a24-88c1-e3c16551ff26   in service    none      none          off        
+    oxp_148436fe-d3e9-4371-8d2e-ec950cc8a84c/crypt/zone/oxz_ntp_4420e03b-4086-48c6-b27d-824bb5bb4758               ea186f3b-214f-43b3-8b3e-1d3cb81f3ee9   in service    none      none          off        
+    oxp_148436fe-d3e9-4371-8d2e-ec950cc8a84c/crypt/debug                                                           dcb06a9e-a678-4e7f-9fc4-4907939152cb   in service    100 GiB   none          gzip-9     
+    oxp_7dd076f1-9d62-49a8-bc0c-5ff5d045c917/crypt/debug                                                           92678623-059c-486a-b250-4570f46b7110   in service    100 GiB   none          gzip-9     
+    oxp_a50f4bb9-d19a-4be8-ad49-b9a552a21062/crypt/debug                                                           c88f9b12-cb36-4d2a-a2e4-f31171fa43fb   in service    100 GiB   none          gzip-9     
+    oxp_b4ee33bb-03f1-4085-9830-9da92002a969/crypt/debug                                                           5eec2c42-41a5-47c1-854c-51c3fa647b29   in service    100 GiB   none          gzip-9     
+    oxp_b50bec8b-a8d3-4ba6-ba3d-12c2a0da911c/crypt/debug                                                           8b59e6bf-82bd-484d-91e8-4f0b1e268d4b   in service    100 GiB   none          gzip-9     
+    oxp_b64f79f6-188f-4e98-9eac-d8111673a130/crypt/debug                                                           a8488ccc-abf9-4037-a931-96d51e02949a   in service    100 GiB   none          gzip-9     
+    oxp_c144a26e-f859-42a0-adca-00d9091d98e4/crypt/debug                                                           ab25a292-63d1-4100-9aeb-d9a605e0f481   in service    100 GiB   none          gzip-9     
+    oxp_c45c08e4-aade-4333-9dad-935ccf4e8352/crypt/debug                                                           b2b9d826-085b-4ddc-94dd-2f0ef17502cf   in service    100 GiB   none          gzip-9     
+    oxp_df62d5da-7da0-468b-b328-0fefbf57568b/crypt/debug                                                           436054c4-b4ed-457a-b986-ae644b579e64   in service    100 GiB   none          gzip-9     
+    oxp_e6433ded-7c90-46a9-8bda-648bcc9fbf07/crypt/debug                                                           2d4fe11c-a87b-4e3a-a66a-9b5258986a50   in service    100 GiB   none          gzip-9     
 
 
     omicron zones at generation 2:

--- a/nexus/reconfigurator/planning/tests/output/planner_decommissions_sleds_bp2.txt
+++ b/nexus/reconfigurator/planning/tests/output/planner_decommissions_sleds_bp2.txt
@@ -19,6 +19,59 @@ parent:    516e80a3-b362-4fac-bd3c-4559717120dd
     fake-vendor   fake-model   serial-ff7e002b-3ad8-4d45-b03a-c46ef0ac8e59
 
 
+    datasets at generation 3:
+    -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
+    dataset name                                                                                                   dataset id                             disposition   quota     reservation   compression
+    -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
+    oxp_1e2ec79e-9c11-4133-ac77-e0b994a507d5/crucible                                                              6faaf132-5e10-43a9-926c-abc32ad8b2fe   in service    none      none          off        
+    oxp_440ae69d-5e2e-4539-91d0-e2930bdd7203/crucible                                                              cbb904a8-0871-4038-933c-7393bbc0738c   in service    none      none          off        
+    oxp_4e91d4a3-bb6c-44bb-bd4e-bf8913c1ba2b/crucible                                                              75b0260f-d857-434f-b0a6-d1b0b23702e2   in service    none      none          off        
+    oxp_67de3a80-29cb-4066-b743-e285a2ca1f4e/crucible                                                              80f92c60-b0f3-4841-ae1d-350f9263c51f   in service    none      none          off        
+    oxp_9139b70f-c1d3-475d-8f02-7c9acba52b2b/crucible                                                              ec3fcfea-8287-4e80-8f53-7967a939db01   in service    none      none          off        
+    oxp_95fbb110-5272-4646-ab50-21b31b7cde23/crucible                                                              9cc9e83b-d758-4be4-b9c5-5ab4e0d0c201   in service    none      none          off        
+    oxp_9bf35cd7-4938-4c34-8189-288b3195cb64/crucible                                                              4e7dac6e-b754-4911-89c1-1c9cd6a68ace   in service    none      none          off        
+    oxp_9d833141-18a1-4f24-8a34-6076c026aa87/crucible                                                              4f33ef0a-829e-48c1-b5b9-a4e11f0f38c3   in service    none      none          off        
+    oxp_a279461f-a7b9-413f-a79f-cb4dab4c3fce/crucible                                                              259a9726-27bc-495e-b7d2-29c884561005   in service    none      none          off        
+    oxp_ff7e002b-3ad8-4d45-b03a-c46ef0ac8e59/crucible                                                              df77d6ef-0910-433c-a7a5-baef6c34fc86   in service    none      none          off        
+    oxp_1e2ec79e-9c11-4133-ac77-e0b994a507d5/crypt/internal_dns                                                    e43ceee2-3657-4145-8e8f-fac08f34573b   in service    none      none          off        
+    oxp_1e2ec79e-9c11-4133-ac77-e0b994a507d5/crypt/zone                                                            dc72e5ba-059c-4075-9d2c-7c69116e17ec   in service    none      none          off        
+    oxp_440ae69d-5e2e-4539-91d0-e2930bdd7203/crypt/zone                                                            64a09f6f-3aa2-416d-a133-bfa44af9e83c   in service    none      none          off        
+    oxp_4e91d4a3-bb6c-44bb-bd4e-bf8913c1ba2b/crypt/zone                                                            48679db3-ca47-4bde-8ee7-6a6b2ab2afdb   in service    none      none          off        
+    oxp_67de3a80-29cb-4066-b743-e285a2ca1f4e/crypt/zone                                                            4177690d-bf09-45a1-add0-6c25f4d4806e   in service    none      none          off        
+    oxp_9139b70f-c1d3-475d-8f02-7c9acba52b2b/crypt/zone                                                            94e76685-337a-45ba-946f-e3ec5408c58a   in service    none      none          off        
+    oxp_95fbb110-5272-4646-ab50-21b31b7cde23/crypt/zone                                                            bc07535b-996c-402d-b488-d6b959c7c267   in service    none      none          off        
+    oxp_9bf35cd7-4938-4c34-8189-288b3195cb64/crypt/zone                                                            5e6eb3f4-a68a-418a-917b-3beafd068acd   in service    none      none          off        
+    oxp_9d833141-18a1-4f24-8a34-6076c026aa87/crypt/zone                                                            34f23c48-7d0a-4d83-98f8-4746e14a3315   in service    none      none          off        
+    oxp_a279461f-a7b9-413f-a79f-cb4dab4c3fce/crypt/zone                                                            70723c5d-41ba-47db-bb36-47ccc07325de   in service    none      none          off        
+    oxp_ff7e002b-3ad8-4d45-b03a-c46ef0ac8e59/crypt/zone                                                            f33074db-c35d-4cd8-a701-c28334be71d8   in service    none      none          off        
+    oxp_ff7e002b-3ad8-4d45-b03a-c46ef0ac8e59/crypt/zone/oxz_crucible_052553cb-8a1a-42a4-a6cb-97a913e78877          7f96c7eb-3117-4d62-92ff-04ca0b4d4a93   in service    none      none          off        
+    oxp_67de3a80-29cb-4066-b743-e285a2ca1f4e/crypt/zone/oxz_crucible_1bd2301a-acd3-4a9c-82d7-b0c19a3c5597          973ab9e7-2437-4d00-b6d4-61f19e352a2e   in service    none      none          off        
+    oxp_9d833141-18a1-4f24-8a34-6076c026aa87/crypt/zone/oxz_crucible_7975aa01-6fa9-4622-a8ba-8bfcf000f8eb          3c378515-facd-4c9f-b2b3-0920fe04456d   in service    none      none          off        
+    oxp_9139b70f-c1d3-475d-8f02-7c9acba52b2b/crypt/zone/oxz_crucible_85286e23-2498-4034-9999-c5263fc0295f          5eaa35c8-c0b4-40ad-ba1d-2ba9286b1acd   in service    none      none          off        
+    oxp_a279461f-a7b9-413f-a79f-cb4dab4c3fce/crypt/zone/oxz_crucible_a320b746-b5f6-4027-9c3c-d41e099f2def          0e65e617-9258-4b02-a0a5-76ce1b5c65d9   in service    none      none          off        
+    oxp_440ae69d-5e2e-4539-91d0-e2930bdd7203/crypt/zone/oxz_crucible_dcd393d4-d16c-41a8-8c16-48e0ab80d2e2          c2de0977-abf7-4c6c-b8ce-425c10d8da09   in service    none      none          off        
+    oxp_4e91d4a3-bb6c-44bb-bd4e-bf8913c1ba2b/crypt/zone/oxz_crucible_de34e868-675e-4291-a2f7-c0b24e2e18a1          6afaa452-d2ff-4ea9-ad6e-b0b59183ef2b   in service    none      none          off        
+    oxp_1e2ec79e-9c11-4133-ac77-e0b994a507d5/crypt/zone/oxz_crucible_e11dd8a6-951a-4019-8775-bed3a2092aaa          b3cd735d-4d94-412a-9a25-06b9fab912e0   in service    none      none          off        
+    oxp_9bf35cd7-4938-4c34-8189-288b3195cb64/crypt/zone/oxz_crucible_f8cdd98e-4ab4-46bb-b621-7590808582cc          4befe2e1-3d46-4b61-a92a-66f27db0df0e   in service    none      none          off        
+    oxp_95fbb110-5272-4646-ab50-21b31b7cde23/crypt/zone/oxz_crucible_fcccf363-d190-441c-ba40-58e24f8a9cb3          82c66769-fc0d-49df-bb32-bc7f61892134   in service    none      none          off        
+    oxp_440ae69d-5e2e-4539-91d0-e2930bdd7203/crypt/zone/oxz_crucible_pantry_6b6843d6-062c-4400-8fd9-d11b5d138fe6   204afeeb-fde3-400f-b809-e1acfc11bf7e   in service    none      none          off        
+    oxp_1e2ec79e-9c11-4133-ac77-e0b994a507d5/crypt/zone/oxz_crucible_pantry_a22472df-5df2-4c1f-ad1f-439a4164984f   2b22a609-539c-478a-939e-ba25068d31ee   in service    none      none          off        
+    oxp_1e2ec79e-9c11-4133-ac77-e0b994a507d5/crypt/zone/oxz_internal_dns_936b1cbb-84e5-48ab-bc59-3bbd7830a421      1f4d6d18-0bdf-4e39-b838-b82fb1eac0e0   in service    none      none          off        
+    oxp_1e2ec79e-9c11-4133-ac77-e0b994a507d5/crypt/zone/oxz_nexus_33ef9872-ee9a-4478-89b9-b22b78e00d3a             7924cb4a-4be3-4346-820a-04bfdb3c03a8   in service    none      none          off        
+    oxp_440ae69d-5e2e-4539-91d0-e2930bdd7203/crypt/zone/oxz_nexus_75fb916b-4793-4cd0-873b-573768b1efe5             9a3ecdfc-970b-4376-8f89-7fe8751ae9f5   in service    none      none          off        
+    oxp_1e2ec79e-9c11-4133-ac77-e0b994a507d5/crypt/zone/oxz_ntp_52031fcc-eb18-45f5-ae6c-65c7858b5e93               44dce497-2648-40ab-9a0f-d896c9b61db1   in service    none      none          off        
+    oxp_1e2ec79e-9c11-4133-ac77-e0b994a507d5/crypt/debug                                                           a5a387a4-2e8d-4038-b386-bf1dffc96d41   in service    100 GiB   none          gzip-9     
+    oxp_440ae69d-5e2e-4539-91d0-e2930bdd7203/crypt/debug                                                           c61256ce-c152-4658-8e49-b31f65b615e8   in service    100 GiB   none          gzip-9     
+    oxp_4e91d4a3-bb6c-44bb-bd4e-bf8913c1ba2b/crypt/debug                                                           52828e06-cdaf-4291-9d1c-b5b1f42515af   in service    100 GiB   none          gzip-9     
+    oxp_67de3a80-29cb-4066-b743-e285a2ca1f4e/crypt/debug                                                           4173e69d-fb09-4068-a3f9-23638e968082   in service    100 GiB   none          gzip-9     
+    oxp_9139b70f-c1d3-475d-8f02-7c9acba52b2b/crypt/debug                                                           bf42b426-4b74-433b-bc3e-7d4e7f1afba4   in service    100 GiB   none          gzip-9     
+    oxp_95fbb110-5272-4646-ab50-21b31b7cde23/crypt/debug                                                           250aa09f-3953-4ce6-8160-67ecabc98add   in service    100 GiB   none          gzip-9     
+    oxp_9bf35cd7-4938-4c34-8189-288b3195cb64/crypt/debug                                                           34a79944-be59-4246-afda-b676e91afddb   in service    100 GiB   none          gzip-9     
+    oxp_9d833141-18a1-4f24-8a34-6076c026aa87/crypt/debug                                                           9d168de0-6b87-405d-b4fc-926b381b0c45   in service    100 GiB   none          gzip-9     
+    oxp_a279461f-a7b9-413f-a79f-cb4dab4c3fce/crypt/debug                                                           9ace6e03-ed94-4444-b524-c3978461964c   in service    100 GiB   none          gzip-9     
+    oxp_ff7e002b-3ad8-4d45-b03a-c46ef0ac8e59/crypt/debug                                                           f43393b3-98ce-48b7-9c97-cb25b5a93130   in service    100 GiB   none          gzip-9     
+
+
     omicron zones at generation 3:
     ---------------------------------------------------------------------------------------------
     zone type         zone id                                disposition   underlay IP           
@@ -60,6 +113,61 @@ parent:    516e80a3-b362-4fac-bd3c-4559717120dd
     fake-vendor   fake-model   serial-99e926d6-bd42-4cde-9f63-5ecc7ea14322
 
 
+    datasets at generation 3:
+    -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
+    dataset name                                                                                                   dataset id                             disposition   quota     reservation   compression
+    -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
+    oxp_07068f19-1ff2-48da-8e72-874780df2339/crucible                                                              43cd1a3a-7dcf-47a2-bf7f-1042c9ed4461   in service    none      none          off        
+    oxp_0f12e6ee-41d2-4eb0-813f-ba5240900ded/crucible                                                              b934756b-aff6-4435-bf59-42fcdb5433ef   in service    none      none          off        
+    oxp_0fdb4a39-3cd5-47a0-9064-e7f3c285af61/crucible                                                              476e6363-ef7a-4538-9906-61380605378a   in service    none      none          off        
+    oxp_13572832-83ad-40d6-896a-751f7e53f4f6/crucible                                                              3b15616c-0339-4816-a057-1c9ca76bc5d9   in service    none      none          off        
+    oxp_3602bdd9-f7bb-4490-87a6-8f061f7712f5/crucible                                                              3fa34ab2-ae9e-4633-bf8f-e0b985591f55   in service    none      none          off        
+    oxp_65707837-95a4-45d7-84e6-8b9a4da215f1/crucible                                                              86cbb449-770b-4ef0-bbdd-e66c96abecb9   in service    none      none          off        
+    oxp_7a43b2b0-3846-401c-8317-d555715a00f7/crucible                                                              912ebbe4-bef6-4cf7-92a5-e21eb72fbf87   in service    none      none          off        
+    oxp_855e3ef1-6929-4e21-8451-0e62bd93c7c9/crucible                                                              4ff0cc73-4531-4717-a130-cb28345ddea2   in service    none      none          off        
+    oxp_8adcf329-4cee-4075-b798-28b5add1edf5/crucible                                                              3d95ffb6-833e-4e1a-a660-6f1544221ed5   in service    none      none          off        
+    oxp_99e926d6-bd42-4cde-9f63-5ecc7ea14322/crucible                                                              bc0f19c5-73af-4c32-97e4-51bee5a874de   in service    none      none          off        
+    oxp_07068f19-1ff2-48da-8e72-874780df2339/crypt/clickhouse                                                      dd8bc8e6-1103-4425-82da-0f7df6951581   in service    none      none          off        
+    oxp_07068f19-1ff2-48da-8e72-874780df2339/crypt/internal_dns                                                    5fe43d44-e28d-4343-b09b-06115e410cfc   in service    none      none          off        
+    oxp_0f12e6ee-41d2-4eb0-813f-ba5240900ded/crypt/internal_dns                                                    a1b355d4-5b1d-406d-960f-e61e30c2aa2a   in service    none      none          off        
+    oxp_07068f19-1ff2-48da-8e72-874780df2339/crypt/zone                                                            19c47885-6b4a-45c6-8dd6-8f3530737df1   in service    none      none          off        
+    oxp_0f12e6ee-41d2-4eb0-813f-ba5240900ded/crypt/zone                                                            1ffa3016-9c49-47f1-a443-429cc5ee72ff   in service    none      none          off        
+    oxp_0fdb4a39-3cd5-47a0-9064-e7f3c285af61/crypt/zone                                                            f21e6928-e9c2-4eff-a710-1e6034948aad   in service    none      none          off        
+    oxp_13572832-83ad-40d6-896a-751f7e53f4f6/crypt/zone                                                            ec753ba9-fa33-4e83-9cd2-7a0eb75f3825   in service    none      none          off        
+    oxp_3602bdd9-f7bb-4490-87a6-8f061f7712f5/crypt/zone                                                            08a7b1b4-2fe9-4412-b847-de67413835d8   in service    none      none          off        
+    oxp_65707837-95a4-45d7-84e6-8b9a4da215f1/crypt/zone                                                            d1404c52-a67c-4d5a-82ee-381fc43e7906   in service    none      none          off        
+    oxp_7a43b2b0-3846-401c-8317-d555715a00f7/crypt/zone                                                            ddef09d3-762e-40b1-b484-03bfa2da3bd9   in service    none      none          off        
+    oxp_855e3ef1-6929-4e21-8451-0e62bd93c7c9/crypt/zone                                                            51d6f7a3-386d-4d17-9898-ccc9e8da2b2b   in service    none      none          off        
+    oxp_8adcf329-4cee-4075-b798-28b5add1edf5/crypt/zone                                                            21095495-e67e-4f2f-ad5a-3382350b51b9   in service    none      none          off        
+    oxp_99e926d6-bd42-4cde-9f63-5ecc7ea14322/crypt/zone                                                            36b5605c-d6c0-4963-a4eb-5090988da393   in service    none      none          off        
+    oxp_07068f19-1ff2-48da-8e72-874780df2339/crypt/zone/oxz_clickhouse_a5813480-2b89-4e18-a09b-c9e5b6b317cc        c113e4ea-c33e-4df0-957b-5f7a856d5214   in service    none      none          off        
+    oxp_07068f19-1ff2-48da-8e72-874780df2339/crypt/zone/oxz_crucible_40f9f06b-eed5-47b9-9925-8afd5540d9f5          73f22559-8377-43cf-b028-4164d68826c9   in service    none      none          off        
+    oxp_13572832-83ad-40d6-896a-751f7e53f4f6/crypt/zone/oxz_crucible_4561a213-e297-41d2-b40d-995b35715ede          c49aa53a-775f-4d2f-bb60-931e82c9d837   in service    none      none          off        
+    oxp_99e926d6-bd42-4cde-9f63-5ecc7ea14322/crypt/zone/oxz_crucible_5e41815b-3aa2-4507-b3ea-3694c0e05b34          da3da14c-05b9-4922-b7a4-be05f23d1da8   in service    none      none          off        
+    oxp_7a43b2b0-3846-401c-8317-d555715a00f7/crypt/zone/oxz_crucible_619451af-30b4-4252-9688-379be6555534          da3ab91c-ffa8-46e4-8a4a-de8a56e02315   in service    none      none          off        
+    oxp_0fdb4a39-3cd5-47a0-9064-e7f3c285af61/crypt/zone/oxz_crucible_64f9bfcb-c1d5-4f15-a877-778ba83c4ada          07c46767-93f4-43df-8dcd-25abf3aaf296   in service    none      none          off        
+    oxp_8adcf329-4cee-4075-b798-28b5add1edf5/crypt/zone/oxz_crucible_a6ac7172-669b-4ac1-9532-2848bcb80545          dc27c769-7880-439e-84c7-29c92880a219   in service    none      none          off        
+    oxp_65707837-95a4-45d7-84e6-8b9a4da215f1/crypt/zone/oxz_crucible_e65276c2-baeb-4ab1-9a37-e48786f14dad          dceafe94-f4df-4556-9a46-560c59069e46   in service    none      none          off        
+    oxp_3602bdd9-f7bb-4490-87a6-8f061f7712f5/crypt/zone/oxz_crucible_e6788bd0-ac6e-4125-93d0-aacbc6380f04          d730d05e-7a17-442e-9959-2e0ea58860c5   in service    none      none          off        
+    oxp_0f12e6ee-41d2-4eb0-813f-ba5240900ded/crypt/zone/oxz_crucible_ea37e4ab-65c6-463a-a2d4-9cf8f0ccbd00          4035218d-b1ed-422a-a202-4f4fd19767b6   in service    none      none          off        
+    oxp_855e3ef1-6929-4e21-8451-0e62bd93c7c9/crypt/zone/oxz_crucible_f52b4e76-5989-42cf-9208-60548c34b487          a8d1ad8b-946f-46e9-8bc3-4aaae1ca31f6   in service    none      none          off        
+    oxp_07068f19-1ff2-48da-8e72-874780df2339/crypt/zone/oxz_crucible_pantry_4c1e95a8-7fae-4a3a-8651-9272ef7c9a88   53123c3d-64d2-432d-b72c-9e0c41ffa805   in service    none      none          off        
+    oxp_07068f19-1ff2-48da-8e72-874780df2339/crypt/zone/oxz_internal_dns_7b2bb1aa-639b-4aaa-bd80-9c680e4be5fc      f24ddc4e-2569-4447-ad1a-e1e0da2e7b41   in service    none      none          off        
+    oxp_0f12e6ee-41d2-4eb0-813f-ba5240900ded/crypt/zone/oxz_internal_dns_d74f14f1-0a19-4d92-b76f-1b3a6e630b2c      672e989c-aec3-4fd9-b7f9-f2af75b3bc01   in service    none      none          off        
+    oxp_07068f19-1ff2-48da-8e72-874780df2339/crypt/zone/oxz_nexus_294379f6-502c-465b-b32d-771c415a38af             61bd7f63-49c5-481e-8f1e-075642b59fa9   in service    none      none          off        
+    oxp_07068f19-1ff2-48da-8e72-874780df2339/crypt/zone/oxz_ntp_064ec0c2-a320-4efb-b006-9e0e1d942d8e               701a8f75-31f5-404f-ad44-1659106f80dd   in service    none      none          off        
+    oxp_07068f19-1ff2-48da-8e72-874780df2339/crypt/debug                                                           ba8224f4-9d26-4fa8-89ac-830e5734c58e   in service    100 GiB   none          gzip-9     
+    oxp_0f12e6ee-41d2-4eb0-813f-ba5240900ded/crypt/debug                                                           73d82f70-9ae4-4212-bc41-42aa7cd6d5c2   in service    100 GiB   none          gzip-9     
+    oxp_0fdb4a39-3cd5-47a0-9064-e7f3c285af61/crypt/debug                                                           71bbed5f-6b13-41f8-87e1-1dff19e2680f   in service    100 GiB   none          gzip-9     
+    oxp_13572832-83ad-40d6-896a-751f7e53f4f6/crypt/debug                                                           bd2e7c19-590f-476e-9eb1-b1cabe99600a   in service    100 GiB   none          gzip-9     
+    oxp_3602bdd9-f7bb-4490-87a6-8f061f7712f5/crypt/debug                                                           12b10546-bc67-43c4-993b-adcc04aa2b3f   in service    100 GiB   none          gzip-9     
+    oxp_65707837-95a4-45d7-84e6-8b9a4da215f1/crypt/debug                                                           08d9c58d-fe91-4b9c-9db8-0b32e3b7f4e0   in service    100 GiB   none          gzip-9     
+    oxp_7a43b2b0-3846-401c-8317-d555715a00f7/crypt/debug                                                           e7e5170c-5547-4733-885b-3fc385e97941   in service    100 GiB   none          gzip-9     
+    oxp_855e3ef1-6929-4e21-8451-0e62bd93c7c9/crypt/debug                                                           1097db6f-ea2d-46cb-9a1f-be933677f4ea   in service    100 GiB   none          gzip-9     
+    oxp_8adcf329-4cee-4075-b798-28b5add1edf5/crypt/debug                                                           10e453e2-115f-42dd-a575-10a593b56762   in service    100 GiB   none          gzip-9     
+    oxp_99e926d6-bd42-4cde-9f63-5ecc7ea14322/crypt/debug                                                           a5162371-5108-497f-a3de-2b95a0dfafbe   in service    100 GiB   none          gzip-9     
+
+
     omicron zones at generation 3:
     ---------------------------------------------------------------------------------------------
     zone type         zone id                                disposition   underlay IP           
@@ -80,7 +188,6 @@ parent:    516e80a3-b362-4fac-bd3c-4559717120dd
     internal_dns      d74f14f1-0a19-4d92-b76f-1b3a6e630b2c   in service    fd00:1122:3344:1::1   
     internal_ntp      064ec0c2-a320-4efb-b006-9e0e1d942d8e   in service    fd00:1122:3344:102::21
     nexus             294379f6-502c-465b-b32d-771c415a38af   in service    fd00:1122:3344:102::22
-
 
 
 !a1b477db-b629-48eb-911d-1ccdafca75b9

--- a/nexus/reconfigurator/planning/tests/output/planner_nonprovisionable_bp2.txt
+++ b/nexus/reconfigurator/planning/tests/output/planner_nonprovisionable_bp2.txt
@@ -19,6 +19,59 @@ parent:    4d4e6c38-cd95-4c4e-8f45-6af4d686964b
     fake-vendor   fake-model   serial-d1ebfd7b-3842-4ad7-be31-2b9c031209a9
 
 
+    datasets at generation 2:
+    -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
+    dataset name                                                                                                   dataset id                             disposition   quota     reservation   compression
+    -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
+    oxp_13e6503b-5300-4ccd-abc4-c1512b435929/crucible                                                              01b78855-bc58-45bd-937e-49221a71b875   in service    none      none          off        
+    oxp_44cdb6f2-fa6c-4b69-bab2-3ae4e1ec4b34/crucible                                                              99ddb9cf-a52c-4b59-884e-dea52e6b4f5d   in service    none      none          off        
+    oxp_4de5fc8e-0e41-4ab9-ba12-2dc63882c96a/crucible                                                              354e3bc2-e6c8-49c0-bf1d-c136e499037c   in service    none      none          off        
+    oxp_51564e7a-d69f-4942-bcfe-330224633ca6/crucible                                                              7f36c891-2cf8-4e94-b12a-24199b83462b   in service    none      none          off        
+    oxp_5ca23cb3-cc90-41c5-a474-01898cdd0796/crucible                                                              8dd12603-6cfc-42dd-8912-2a16cb7a748d   in service    none      none          off        
+    oxp_6a23a532-0712-4a8d-be9b-e8c17e97aa4b/crucible                                                              8ff2aecd-a1e8-47bd-8001-97c3e5efb99b   in service    none      none          off        
+    oxp_6f1a330e-e8d4-4c09-97fc-8918b69b2a3c/crucible                                                              dab52576-17e4-4bf8-b87e-c49983a388c2   in service    none      none          off        
+    oxp_7113d104-fb55-4299-bf53-b3c59d258e44/crucible                                                              d2c5b427-f956-4cd1-b174-6caca3685e6f   in service    none      none          off        
+    oxp_8c10be49-3a66-40d4-a082-64d09d916f14/crucible                                                              e2e73bed-32f9-4111-803b-561cbd7faa1a   in service    none      none          off        
+    oxp_d1ebfd7b-3842-4ad7-be31-2b9c031209a9/crucible                                                              5ba5e79d-0a13-41e5-b4d2-6c7cb468cb26   in service    none      none          off        
+    oxp_13e6503b-5300-4ccd-abc4-c1512b435929/crypt/clickhouse                                                      37aac368-1b57-4934-b771-5802ae6d6606   in service    none      none          off        
+    oxp_13e6503b-5300-4ccd-abc4-c1512b435929/crypt/internal_dns                                                    2f276f3f-ad8c-458e-bb62-03f5ec7643f3   in service    none      none          off        
+    oxp_13e6503b-5300-4ccd-abc4-c1512b435929/crypt/zone                                                            a8381430-0bf6-49fd-8e5a-4e7c7eb4edf4   in service    none      none          off        
+    oxp_44cdb6f2-fa6c-4b69-bab2-3ae4e1ec4b34/crypt/zone                                                            34fb7c7c-17c2-4cbb-af27-12b693965a4b   in service    none      none          off        
+    oxp_4de5fc8e-0e41-4ab9-ba12-2dc63882c96a/crypt/zone                                                            a6f2fa57-1161-4b49-b591-2a9cd5a992f3   in service    none      none          off        
+    oxp_51564e7a-d69f-4942-bcfe-330224633ca6/crypt/zone                                                            df22d065-beb6-45e4-984e-874dfdd3b285   in service    none      none          off        
+    oxp_5ca23cb3-cc90-41c5-a474-01898cdd0796/crypt/zone                                                            59656ee4-d86f-49ff-b4b8-39e1021642f4   in service    none      none          off        
+    oxp_6a23a532-0712-4a8d-be9b-e8c17e97aa4b/crypt/zone                                                            ea5ee557-cc4e-4a9b-87a7-7bb9b30589da   in service    none      none          off        
+    oxp_6f1a330e-e8d4-4c09-97fc-8918b69b2a3c/crypt/zone                                                            5b0f2d79-6120-4b28-8fd6-919a121f5875   in service    none      none          off        
+    oxp_7113d104-fb55-4299-bf53-b3c59d258e44/crypt/zone                                                            dd56b58b-871e-4f55-bcf5-0bd4e8184761   in service    none      none          off        
+    oxp_8c10be49-3a66-40d4-a082-64d09d916f14/crypt/zone                                                            bafeb8db-cb8e-45fc-8030-3a85a26e2feb   in service    none      none          off        
+    oxp_d1ebfd7b-3842-4ad7-be31-2b9c031209a9/crypt/zone                                                            b567319c-bb7a-4ac0-a95b-20bd88c26579   in service    none      none          off        
+    oxp_13e6503b-5300-4ccd-abc4-c1512b435929/crypt/zone/oxz_clickhouse_5fbb489a-141d-4de2-86c4-4fd7b9d9f315        648fecf4-8ce6-4bce-9020-789057c92f95   in service    none      none          off        
+    oxp_13e6503b-5300-4ccd-abc4-c1512b435929/crypt/zone/oxz_crucible_0ce2b998-f5ad-4dc5-b2ec-5250a308506d          4fe9bcd8-399f-444e-aa01-f8cb285de102   in service    none      none          off        
+    oxp_7113d104-fb55-4299-bf53-b3c59d258e44/crypt/zone/oxz_crucible_0e8e9f2d-291d-47fc-ba0f-84cb50e713fd          ff5a6a51-2797-4016-903f-69ec69e59ef9   in service    none      none          off        
+    oxp_51564e7a-d69f-4942-bcfe-330224633ca6/crypt/zone/oxz_crucible_11fc3b08-2470-4f1b-9187-acff1fc4c5ea          32b45c55-cc53-4635-ae2b-559821b409fe   in service    none      none          off        
+    oxp_6f1a330e-e8d4-4c09-97fc-8918b69b2a3c/crypt/zone/oxz_crucible_673ecd68-d12a-46d9-9126-0a6be6245f84          0377cfc0-2bf6-4906-87f7-031121797594   in service    none      none          off        
+    oxp_6a23a532-0712-4a8d-be9b-e8c17e97aa4b/crypt/zone/oxz_crucible_966c4f15-0aa8-4bef-95e4-49d686cffdfc          9ef1c45c-753a-4ecf-9145-72889ece2ad2   in service    none      none          off        
+    oxp_8c10be49-3a66-40d4-a082-64d09d916f14/crypt/zone/oxz_crucible_979a7b5b-81a5-49bc-82e5-d88b6eaf7d96          b075b63e-f072-4f35-86d1-a81e50065994   in service    none      none          off        
+    oxp_5ca23cb3-cc90-41c5-a474-01898cdd0796/crypt/zone/oxz_crucible_b6beadb1-351b-461d-a887-e7641d976a9e          9d2477db-7dea-4e19-b563-60a18a659cca   in service    none      none          off        
+    oxp_4de5fc8e-0e41-4ab9-ba12-2dc63882c96a/crypt/zone/oxz_crucible_cf7add30-1c49-4d49-a2d2-1c46a60cd884          3b71883e-8704-468e-96fa-7b4fd85d37e8   in service    none      none          off        
+    oxp_d1ebfd7b-3842-4ad7-be31-2b9c031209a9/crypt/zone/oxz_crucible_d0d4a23e-45fa-4f80-9bdf-a348de3f7b8f          5888130a-54bf-4358-bb1b-099347648757   in service    none      none          off        
+    oxp_44cdb6f2-fa6c-4b69-bab2-3ae4e1ec4b34/crypt/zone/oxz_crucible_e46d1442-2a63-44e3-a6aa-e88150b85d92          c4739101-dd65-4649-8e99-e221dc9ce93e   in service    none      none          off        
+    oxp_13e6503b-5300-4ccd-abc4-c1512b435929/crypt/zone/oxz_crucible_pantry_45b6f382-3590-4281-b65d-083ba7aff2d3   f07a8f89-a4e1-4c71-b223-a4c09af0e443   in service    none      none          off        
+    oxp_13e6503b-5300-4ccd-abc4-c1512b435929/crypt/zone/oxz_internal_dns_4fd906d8-94cd-44b3-ad5e-34b4d193bd3c      3681f68d-2840-47be-8bb7-8c7354daf8a7   in service    none      none          off        
+    oxp_13e6503b-5300-4ccd-abc4-c1512b435929/crypt/zone/oxz_nexus_88602518-f176-49a1-af12-02fac36214c3             99c53b55-b716-414d-b8ff-a9d56bd9cd6c   in service    none      none          off        
+    oxp_13e6503b-5300-4ccd-abc4-c1512b435929/crypt/zone/oxz_ntp_b0a48e5a-e2bd-46b2-9bc6-8babbbdc0adc               ed9b8ac9-88f4-46fa-8ecf-5a7534d4f020   in service    none      none          off        
+    oxp_13e6503b-5300-4ccd-abc4-c1512b435929/crypt/debug                                                           97bc5b54-dd6a-4b98-b9e0-081657a3db89   in service    100 GiB   none          gzip-9     
+    oxp_44cdb6f2-fa6c-4b69-bab2-3ae4e1ec4b34/crypt/debug                                                           8d054703-b940-4395-8c46-2ff519f5133a   in service    100 GiB   none          gzip-9     
+    oxp_4de5fc8e-0e41-4ab9-ba12-2dc63882c96a/crypt/debug                                                           bb388082-2d09-4a4b-bb22-ee3f4b7b5025   in service    100 GiB   none          gzip-9     
+    oxp_51564e7a-d69f-4942-bcfe-330224633ca6/crypt/debug                                                           fe2005ba-7f3d-4fc3-b324-09a258fc4a4b   in service    100 GiB   none          gzip-9     
+    oxp_5ca23cb3-cc90-41c5-a474-01898cdd0796/crypt/debug                                                           e20df72b-3d75-48ad-8349-3e39cc886886   in service    100 GiB   none          gzip-9     
+    oxp_6a23a532-0712-4a8d-be9b-e8c17e97aa4b/crypt/debug                                                           cf2b245f-c667-49a9-bbc2-ada9a51e63f0   in service    100 GiB   none          gzip-9     
+    oxp_6f1a330e-e8d4-4c09-97fc-8918b69b2a3c/crypt/debug                                                           1c606d5c-ce8c-42e8-9359-d2e0fe31d525   in service    100 GiB   none          gzip-9     
+    oxp_7113d104-fb55-4299-bf53-b3c59d258e44/crypt/debug                                                           1f3f9209-c380-40ab-a2f0-16ecddb6d4a8   in service    100 GiB   none          gzip-9     
+    oxp_8c10be49-3a66-40d4-a082-64d09d916f14/crypt/debug                                                           89b81a7c-3bc3-455d-97e3-75067de991d5   in service    100 GiB   none          gzip-9     
+    oxp_d1ebfd7b-3842-4ad7-be31-2b9c031209a9/crypt/debug                                                           1e581e94-bb9d-4514-8dbb-3a882e342d1b   in service    100 GiB   none          gzip-9     
+
+
     omicron zones at generation 2:
     ---------------------------------------------------------------------------------------------
     zone type         zone id                                disposition   underlay IP           
@@ -57,6 +110,57 @@ parent:    4d4e6c38-cd95-4c4e-8f45-6af4d686964b
     fake-vendor   fake-model   serial-cf32a1ce-2c9e-49f5-b1cf-4af7f2a28901
     fake-vendor   fake-model   serial-e405da11-cb6b-4ebc-bac1-9bc997352e10
     fake-vendor   fake-model   serial-f4d7f914-ec73-4b65-8696-5068591d9065
+
+
+    datasets at generation 3:
+    ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
+    dataset name                                                                                            dataset id                             disposition   quota     reservation   compression
+    ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
+    oxp_4069c804-c51a-4adc-8822-3cbbab56ed3f/crucible                                                       081aff15-bc64-4b57-bbcc-287d7267caa4   in service    none      none          off        
+    oxp_5248a306-4a03-449e-a8a3-6f86d26da755/crucible                                                       0beeebcf-b558-47e9-9274-bc3dd4a475b8   in service    none      none          off        
+    oxp_55196665-ed61-4b23-9a74-0711bf2eaf90/crucible                                                       757dd9e5-74db-4860-a87e-0aafd6795b91   in service    none      none          off        
+    oxp_6b2a719a-35eb-469f-aa54-114a1f21f37d/crucible                                                       bd64099e-57f0-447f-9c21-e493e2809372   in service    none      none          off        
+    oxp_7ed4296a-66d1-4fb2-bc56-9b23b8f27d7e/crucible                                                       3bd0565c-1170-4727-824b-f180454e4ff1   in service    none      none          off        
+    oxp_984e2389-e7fd-4af9-ab02-e3caf77f95b5/crucible                                                       010c6c12-6ea3-4bbd-9a69-90209dab73ab   in service    none      none          off        
+    oxp_a5f75431-3795-426c-8f80-176f658281a5/crucible                                                       2dbc8272-64ae-4d2d-ac1f-92f120204ddd   in service    none      none          off        
+    oxp_cf32a1ce-2c9e-49f5-b1cf-4af7f2a28901/crucible                                                       b4e4e724-ddfb-4d0a-bf6b-edd6dd91172d   in service    none      none          off        
+    oxp_e405da11-cb6b-4ebc-bac1-9bc997352e10/crucible                                                       8fdfaea0-1da2-429f-b64e-ef0107f2884d   in service    none      none          off        
+    oxp_f4d7f914-ec73-4b65-8696-5068591d9065/crucible                                                       74dc30b1-2c84-4e9d-910c-938d33f9a537   in service    none      none          off        
+    oxp_4069c804-c51a-4adc-8822-3cbbab56ed3f/crypt/zone                                                     f282431f-2ed2-4386-bc0f-0f3130b175bf   in service    none      none          off        
+    oxp_5248a306-4a03-449e-a8a3-6f86d26da755/crypt/zone                                                     ee3f0e38-23ac-45c6-8157-e611887572a6   in service    none      none          off        
+    oxp_55196665-ed61-4b23-9a74-0711bf2eaf90/crypt/zone                                                     acf672d0-effd-491a-bde8-a4253e078f14   in service    none      none          off        
+    oxp_6b2a719a-35eb-469f-aa54-114a1f21f37d/crypt/zone                                                     d5be658f-367a-4703-a377-7d8067aade3a   in service    none      none          off        
+    oxp_7ed4296a-66d1-4fb2-bc56-9b23b8f27d7e/crypt/zone                                                     adbebdd0-4d0d-4794-9bb5-6681b5119624   in service    none      none          off        
+    oxp_984e2389-e7fd-4af9-ab02-e3caf77f95b5/crypt/zone                                                     1e063fbb-083c-4e2e-a4f5-c40ce854f1d0   in service    none      none          off        
+    oxp_a5f75431-3795-426c-8f80-176f658281a5/crypt/zone                                                     6b476700-d002-4173-8a83-fb24d49be32f   in service    none      none          off        
+    oxp_cf32a1ce-2c9e-49f5-b1cf-4af7f2a28901/crypt/zone                                                     abaa13f5-c3ec-45b2-86da-2be74a259878   in service    none      none          off        
+    oxp_e405da11-cb6b-4ebc-bac1-9bc997352e10/crypt/zone                                                     d8c2da98-ef6d-4746-ae4b-ed537c78fc89   in service    none      none          off        
+    oxp_f4d7f914-ec73-4b65-8696-5068591d9065/crypt/zone                                                     b1c8156e-7490-46d2-a4af-7fc5dd39991d   in service    none      none          off        
+    oxp_6b2a719a-35eb-469f-aa54-114a1f21f37d/crypt/zone/oxz_crucible_05ba6d6e-90a7-402a-aaba-fd92190a9f48   6a6e744c-c4a9-4e58-b0ed-ef44eef0c6e0   in service    none      none          off        
+    oxp_f4d7f914-ec73-4b65-8696-5068591d9065/crypt/zone/oxz_crucible_2097bad3-ee65-4a1c-8fe2-75ed52e69ac8   54941545-0cee-4c36-8516-c63b3cbd02fb   in service    none      none          off        
+    oxp_4069c804-c51a-4adc-8822-3cbbab56ed3f/crypt/zone/oxz_crucible_430c8fe1-7296-4a73-b260-fc185260ec5e   d0ee4ede-c9a6-4d6a-9dbe-63b4c07a9cdd   in service    none      none          off        
+    oxp_cf32a1ce-2c9e-49f5-b1cf-4af7f2a28901/crypt/zone/oxz_crucible_a720288d-3e5b-44b7-9dab-a69a10768e0b   3fa16efe-c488-4d45-92ee-18eeb8b9453f   in service    none      none          off        
+    oxp_a5f75431-3795-426c-8f80-176f658281a5/crypt/zone/oxz_crucible_b2170eef-aa6f-4ec5-aaa9-2b4289eae65c   e20a6e28-7a52-480a-9d36-33f8d4474bf5   in service    none      none          off        
+    oxp_984e2389-e7fd-4af9-ab02-e3caf77f95b5/crypt/zone/oxz_crucible_b505d6e1-07b9-48bf-bc8a-d4081c25b12a   6b965329-4398-4738-84e6-b893f21a724c   in service    none      none          off        
+    oxp_5248a306-4a03-449e-a8a3-6f86d26da755/crypt/zone/oxz_crucible_cbe34d65-017e-4c26-966d-b1ce27bc1d94   8ad4a9ed-7be5-4f49-8a38-1686144ceaf6   in service    none      none          off        
+    oxp_e405da11-cb6b-4ebc-bac1-9bc997352e10/crypt/zone/oxz_crucible_e01462d1-5173-4d95-8477-78ca2157efbb   03fbd010-e16e-48a9-a9a9-5be665c0bdff   in service    none      none          off        
+    oxp_55196665-ed61-4b23-9a74-0711bf2eaf90/crypt/zone/oxz_crucible_e49b0403-3d7c-480f-9113-4bc0fca74a8a   62053fe9-281c-4949-9357-bf818004aef2   in service    none      none          off        
+    oxp_7ed4296a-66d1-4fb2-bc56-9b23b8f27d7e/crypt/zone/oxz_crucible_e6ec9399-b81b-4bdd-8e6e-b0f043aad942   f761d5be-fef1-47d7-850c-1f28a1f8a8b3   in service    none      none          off        
+    oxp_6b2a719a-35eb-469f-aa54-114a1f21f37d/crypt/zone/oxz_nexus_2ed23118-6137-45ca-824c-04df3bc3d085      047b92e1-2286-44bb-988e-403f20973ee4   in service    none      none          off        
+    oxp_5248a306-4a03-449e-a8a3-6f86d26da755/crypt/zone/oxz_nexus_33365de5-8a83-46c0-9d34-eddd68e54c6f      4f6d72db-de32-4a55-ae9d-30d776580c33   in service    none      none          off        
+    oxp_55196665-ed61-4b23-9a74-0711bf2eaf90/crypt/zone/oxz_nexus_80e4964b-a8c8-41ef-ae23-f86cfe5f3a7b      6944260c-23fd-47db-8a2c-02196b399f57   in service    none      none          off        
+    oxp_4069c804-c51a-4adc-8822-3cbbab56ed3f/crypt/zone/oxz_nexus_81f79040-bcf7-4eff-9a87-8e7bcb5a6db9      2694f256-cd46-4841-a009-6460f4ca0616   in service    none      none          off        
+    oxp_4069c804-c51a-4adc-8822-3cbbab56ed3f/crypt/zone/oxz_ntp_8f94a160-67ab-4ed5-bc3f-01e19fdd7e9b        225c385b-de3e-4262-a5c4-0250abc910f9   in service    none      none          off        
+    oxp_4069c804-c51a-4adc-8822-3cbbab56ed3f/crypt/debug                                                    041c4e17-e958-41aa-b621-03dd3b3e7da8   in service    100 GiB   none          gzip-9     
+    oxp_5248a306-4a03-449e-a8a3-6f86d26da755/crypt/debug                                                    7e551f2b-ac22-4637-bd2a-188f106b57c0   in service    100 GiB   none          gzip-9     
+    oxp_55196665-ed61-4b23-9a74-0711bf2eaf90/crypt/debug                                                    1e4208d8-041e-49eb-ab6d-dcedceee170c   in service    100 GiB   none          gzip-9     
+    oxp_6b2a719a-35eb-469f-aa54-114a1f21f37d/crypt/debug                                                    0872720b-c454-45f6-8816-2835d595894e   in service    100 GiB   none          gzip-9     
+    oxp_7ed4296a-66d1-4fb2-bc56-9b23b8f27d7e/crypt/debug                                                    fc7195f4-4472-4283-9094-2f6f7db01e71   in service    100 GiB   none          gzip-9     
+    oxp_984e2389-e7fd-4af9-ab02-e3caf77f95b5/crypt/debug                                                    baa19cce-f379-427c-9b5e-c413b050c2d5   in service    100 GiB   none          gzip-9     
+    oxp_a5f75431-3795-426c-8f80-176f658281a5/crypt/debug                                                    5828eb26-b03b-4481-b88d-027a90a24c50   in service    100 GiB   none          gzip-9     
+    oxp_cf32a1ce-2c9e-49f5-b1cf-4af7f2a28901/crypt/debug                                                    5e7deb25-14c2-4633-8728-6eff7833e14f   in service    100 GiB   none          gzip-9     
+    oxp_e405da11-cb6b-4ebc-bac1-9bc997352e10/crypt/debug                                                    e02c1929-a38a-49c2-8909-555c3e046d18   in service    100 GiB   none          gzip-9     
+    oxp_f4d7f914-ec73-4b65-8696-5068591d9065/crypt/debug                                                    0aeb1237-4ad7-41ae-abd2-45789a3ab2f2   in service    100 GiB   none          gzip-9     
 
 
     omicron zones at generation 3:
@@ -99,6 +203,57 @@ parent:    4d4e6c38-cd95-4c4e-8f45-6af4d686964b
     fake-vendor   fake-model   serial-fe4fdfba-3b6d-47d3-8612-1fb2390b650a
 
 
+    datasets at generation 3:
+    ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
+    dataset name                                                                                            dataset id                             disposition   quota     reservation   compression
+    ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
+    oxp_33d48d85-751e-4982-b738-eae4d9a05f01/crucible                                                       e7187a07-3759-4185-8893-36b01e1a7295   in service    none      none          off        
+    oxp_39ca2e23-4c38-4743-afe0-26b0380b27db/crucible                                                       f9901e16-a9e4-4c49-a3b9-464405830043   in service    none      none          off        
+    oxp_4fbd2fe0-2eac-41b8-8e8d-4fa46c3e8b6c/crucible                                                       024a9e5e-f8a8-4b8f-b75e-5b05509fa69a   in service    none      none          off        
+    oxp_60131a33-1f12-4dbb-9435-bdd368db1f51/crucible                                                       22547c0a-a710-4d4c-8984-32445fbf993b   in service    none      none          off        
+    oxp_77e45b5b-869f-4e78-8ce3-28bbe8cf37e9/crucible                                                       dec5883c-1abd-4425-8cc4-b2f57c85cdd4   in service    none      none          off        
+    oxp_789d607d-d196-428e-a988-f7886a327859/crucible                                                       fda176fb-2cea-4646-8601-8d719bcdbda0   in service    none      none          off        
+    oxp_b104b94c-2197-4e76-bfbd-6f966bd5af66/crucible                                                       4ded36d4-7e98-47fe-a0f4-c580e7d1eb21   in service    none      none          off        
+    oxp_cd62306a-aedf-47e8-93d5-92a358d64c7b/crucible                                                       623c87b5-8848-4e42-aa5e-6e706e11cf63   in service    none      none          off        
+    oxp_f1693454-aac1-4265-b8a0-4e9f3f41c7b3/crucible                                                       e98d07df-27a8-4868-a3f9-066ac235516c   in service    none      none          off        
+    oxp_fe4fdfba-3b6d-47d3-8612-1fb2390b650a/crucible                                                       639c96d6-265a-45dc-b03f-c145d2ea8c43   in service    none      none          off        
+    oxp_33d48d85-751e-4982-b738-eae4d9a05f01/crypt/zone                                                     64c4eb2e-82bf-450c-9379-594af3a4794b   in service    none      none          off        
+    oxp_39ca2e23-4c38-4743-afe0-26b0380b27db/crypt/zone                                                     f6c13b9c-4e22-448d-b7b8-04652f06423c   in service    none      none          off        
+    oxp_4fbd2fe0-2eac-41b8-8e8d-4fa46c3e8b6c/crypt/zone                                                     a15671b5-d3f3-43d9-b143-81bcd5170edf   in service    none      none          off        
+    oxp_60131a33-1f12-4dbb-9435-bdd368db1f51/crypt/zone                                                     dd78cd99-4aa3-4946-b4c3-b9fad49c6da6   in service    none      none          off        
+    oxp_77e45b5b-869f-4e78-8ce3-28bbe8cf37e9/crypt/zone                                                     1c30ecb3-32ba-49e7-a3dd-771a75d38c3a   in service    none      none          off        
+    oxp_789d607d-d196-428e-a988-f7886a327859/crypt/zone                                                     7ac707a2-5bcf-49d1-88eb-1c09841082cf   in service    none      none          off        
+    oxp_b104b94c-2197-4e76-bfbd-6f966bd5af66/crypt/zone                                                     b0d96454-0a1d-47ac-9a13-5c4866131c37   in service    none      none          off        
+    oxp_cd62306a-aedf-47e8-93d5-92a358d64c7b/crypt/zone                                                     082509f2-115a-4a71-b8f8-86be21efc081   in service    none      none          off        
+    oxp_f1693454-aac1-4265-b8a0-4e9f3f41c7b3/crypt/zone                                                     01b79cba-881c-4bda-a48d-baaef2fcb122   in service    none      none          off        
+    oxp_fe4fdfba-3b6d-47d3-8612-1fb2390b650a/crypt/zone                                                     32d3d763-0665-4945-a3d0-e3d862f7a718   in service    none      none          off        
+    oxp_b104b94c-2197-4e76-bfbd-6f966bd5af66/crypt/zone/oxz_crucible_1b38728b-8552-435b-b621-359ba20d465b   c02c8635-e2f5-4974-a8b9-f4fdfe231365   in service    none      none          off        
+    oxp_39ca2e23-4c38-4743-afe0-26b0380b27db/crypt/zone/oxz_crucible_31c42e26-3cdf-41a8-8826-ce71a513ed04   4876b95c-457b-4e81-9a04-ca1319429627   in service    none      none          off        
+    oxp_f1693454-aac1-4265-b8a0-4e9f3f41c7b3/crypt/zone/oxz_crucible_4f38e475-396a-4650-a49c-c3cc4acc3ab9   2aff7d20-2a2b-4ded-9e03-eb0d72d29e35   in service    none      none          off        
+    oxp_cd62306a-aedf-47e8-93d5-92a358d64c7b/crypt/zone/oxz_crucible_5cd47e9f-1faf-4afd-970a-18b9076b3407   686fcd72-5da5-4f8c-a740-88866e30b8da   in service    none      none          off        
+    oxp_fe4fdfba-3b6d-47d3-8612-1fb2390b650a/crypt/zone/oxz_crucible_768ab86c-d5d2-4734-a381-02df1032d5e9   d1bbe8aa-aeda-496b-93cd-f330f85da352   in service    none      none          off        
+    oxp_4fbd2fe0-2eac-41b8-8e8d-4fa46c3e8b6c/crypt/zone/oxz_crucible_abbf71e1-6568-42cf-9526-7e31549ba934   782adc3d-3a2f-400d-a6ce-531edc8cf546   in service    none      none          off        
+    oxp_789d607d-d196-428e-a988-f7886a327859/crypt/zone/oxz_crucible_e37d04f9-ed3f-4665-800e-b51ba7d5d306   6c55265b-7515-4259-adf1-ac07f847c2fb   in service    none      none          off        
+    oxp_33d48d85-751e-4982-b738-eae4d9a05f01/crypt/zone/oxz_crucible_e6c28c27-39d2-4aec-bf34-5d9f6b3cbd7f   803ed7a0-bb24-489f-8737-b01ff28e3278   in service    none      none          off        
+    oxp_77e45b5b-869f-4e78-8ce3-28bbe8cf37e9/crypt/zone/oxz_crucible_f19f884a-3e97-458d-b8fb-533882750cd6   b1044d62-0afd-473e-8719-ca3ecb57d801   in service    none      none          off        
+    oxp_60131a33-1f12-4dbb-9435-bdd368db1f51/crypt/zone/oxz_crucible_f54c359e-a980-4996-9462-25a548d96265   518e80f5-3074-44ec-8da3-ea64f3c0ad3e   in service    none      none          off        
+    oxp_4fbd2fe0-2eac-41b8-8e8d-4fa46c3e8b6c/crypt/zone/oxz_nexus_b539cea9-c37c-49ef-874f-170d898187b2      113c40a7-e9fd-492f-814e-528db4fd0e83   in service    none      none          off        
+    oxp_33d48d85-751e-4982-b738-eae4d9a05f01/crypt/zone/oxz_nexus_b854f752-383d-4e0b-8557-8c62d22ba994      537edbee-609e-40df-9a10-4c6f57c5f15f   in service    none      none          off        
+    oxp_60131a33-1f12-4dbb-9435-bdd368db1f51/crypt/zone/oxz_nexus_c5a0c592-319e-44df-9d00-1ddb1d5ad6aa      61e536fd-043c-4741-aed7-640d18d32b26   in service    none      none          off        
+    oxp_39ca2e23-4c38-4743-afe0-26b0380b27db/crypt/zone/oxz_nexus_cab211e1-3ab1-475f-81fa-984748044d8c      92f259d0-cda4-44e4-bb22-8b82d025d502   in service    none      none          off        
+    oxp_33d48d85-751e-4982-b738-eae4d9a05f01/crypt/zone/oxz_ntp_706286e2-8b09-42ff-9841-eaef65635eee        617a44e3-250b-4db1-a8e7-e42da46a0a0f   in service    none      none          off        
+    oxp_33d48d85-751e-4982-b738-eae4d9a05f01/crypt/debug                                                    856e98db-f5c6-4cbd-a8ad-c02f59f207d7   in service    100 GiB   none          gzip-9     
+    oxp_39ca2e23-4c38-4743-afe0-26b0380b27db/crypt/debug                                                    f14ef549-31db-4fae-a540-3a50f0fba233   in service    100 GiB   none          gzip-9     
+    oxp_4fbd2fe0-2eac-41b8-8e8d-4fa46c3e8b6c/crypt/debug                                                    e44949f2-403b-4944-b966-de77d4b9365c   in service    100 GiB   none          gzip-9     
+    oxp_60131a33-1f12-4dbb-9435-bdd368db1f51/crypt/debug                                                    425255d5-c1e8-44eb-855f-fe1770e83362   in service    100 GiB   none          gzip-9     
+    oxp_77e45b5b-869f-4e78-8ce3-28bbe8cf37e9/crypt/debug                                                    dc613555-a790-45af-9af4-0127d376f3c6   in service    100 GiB   none          gzip-9     
+    oxp_789d607d-d196-428e-a988-f7886a327859/crypt/debug                                                    4f359243-9639-431f-a0d1-5b2f2d6b5b0d   in service    100 GiB   none          gzip-9     
+    oxp_b104b94c-2197-4e76-bfbd-6f966bd5af66/crypt/debug                                                    1315d3d7-e347-4e68-8381-8c010be44ef0   in service    100 GiB   none          gzip-9     
+    oxp_cd62306a-aedf-47e8-93d5-92a358d64c7b/crypt/debug                                                    0e8321af-4634-4d31-aa79-145f8e171674   in service    100 GiB   none          gzip-9     
+    oxp_f1693454-aac1-4265-b8a0-4e9f3f41c7b3/crypt/debug                                                    5a0f4402-7d87-4b6b-b4d2-72f48000627c   in service    100 GiB   none          gzip-9     
+    oxp_fe4fdfba-3b6d-47d3-8612-1fb2390b650a/crypt/debug                                                    a2120fee-01bd-4f49-8c58-720384b1cbde   in service    100 GiB   none          gzip-9     
+
+
     omicron zones at generation 3:
     ------------------------------------------------------------------------------------------
     zone type      zone id                                disposition   underlay IP           
@@ -118,7 +273,6 @@ parent:    4d4e6c38-cd95-4c4e-8f45-6af4d686964b
     nexus          b854f752-383d-4e0b-8557-8c62d22ba994   in service    fd00:1122:3344:101::22
     nexus          c5a0c592-319e-44df-9d00-1ddb1d5ad6aa   in service    fd00:1122:3344:101::2f
     nexus          cab211e1-3ab1-475f-81fa-984748044d8c   in service    fd00:1122:3344:101::2d
-
 
 
 !48d95fef-bc9f-4f50-9a53-1e075836291d
@@ -141,7 +295,6 @@ WARNING: Zones exist without physical disks!
     internal_dns      c428175e-6a1c-40bf-aa36-f608a57431f5   expunged      fd00:1122:3344:2::1   
     internal_ntp      a8f1b53a-4231-4f04-9939-29e50a0f0e2c   expunged      fd00:1122:3344:103::21
     nexus             533416e6-d0bd-482d-b592-29346c8a3471   expunged      fd00:1122:3344:103::22
-
 
 
 

--- a/nexus/types/src/deployment.rs
+++ b/nexus/types/src/deployment.rs
@@ -18,6 +18,7 @@ use crate::inventory::Collection;
 pub use crate::inventory::SourceNatConfig;
 pub use crate::inventory::ZpoolName;
 use blueprint_diff::ClickhouseClusterConfigDiffTablesForSingleBlueprint;
+use blueprint_display::BpDatasetsTableSchema;
 use daft::Diffable;
 use nexus_sled_agent_shared::inventory::OmicronZoneConfig;
 use nexus_sled_agent_shared::inventory::OmicronZonesConfig;
@@ -315,6 +316,21 @@ impl BpTableData for &BlueprintPhysicalDisksConfig {
     }
 }
 
+impl BpTableData for BlueprintDatasetsConfig {
+    fn bp_generation(&self) -> BpGeneration {
+        BpGeneration::Value(self.generation)
+    }
+
+    fn rows(&self, state: BpDiffState) -> impl Iterator<Item = BpTableRow> {
+        // We want to sort by (kind, pool)
+        let mut datasets: Vec<_> = self.datasets.iter().collect();
+        datasets.sort_unstable_by_key(|d| (&d.kind, &d.pool));
+        datasets.into_iter().map(move |dataset| {
+            BpTableRow::from_strings(state, dataset.as_strings())
+        })
+    }
+}
+
 impl BpTableData for BlueprintZonesConfig {
     fn bp_generation(&self) -> BpGeneration {
         BpGeneration::Value(self.generation)
@@ -440,12 +456,36 @@ impl BlueprintDisplay<'_> {
 
 impl fmt::Display for BlueprintDisplay<'_> {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        let b = self.blueprint;
-        writeln!(f, "blueprint  {}", b.id)?;
+        // Unpack the blueprint so any future field changes require updating
+        // this method to update the display.
+        let Blueprint {
+            id,
+            sled_state,
+            blueprint_zones,
+            blueprint_disks,
+            blueprint_datasets,
+            parent_blueprint_id,
+            // These two cockroachdb_* fields are handled by
+            // `make_cockroachdb_table()`, called below.
+            cockroachdb_fingerprint: _,
+            cockroachdb_setting_preserve_downgrade: _,
+            // Handled by `make_clickhouse_cluster_config_tables()`, called
+            // below.
+            clickhouse_cluster_config: _,
+            // These five fields are handled by `make_metadata_table()`, called
+            // below.
+            internal_dns_version: _,
+            external_dns_version: _,
+            time_created: _,
+            creator: _,
+            comment: _,
+        } = self.blueprint;
+
+        writeln!(f, "blueprint  {}", id)?;
         writeln!(
             f,
             "parent:    {}",
-            b.parent_blueprint_id
+            parent_blueprint_id
                 .map(|u| u.to_string())
                 .unwrap_or_else(|| String::from("<none>"))
         )?;
@@ -457,7 +497,7 @@ impl fmt::Display for BlueprintDisplay<'_> {
         // those physical disks.
         //
         // If there are corresponding zones, print those as well.
-        for (sled_id, disks) in &self.blueprint.blueprint_disks {
+        for (sled_id, disks) in blueprint_disks {
             // Construct the disks subtable
             let disks_table = BpTable::new(
                 BpPhysicalDisksTableSchema {},
@@ -466,50 +506,85 @@ impl fmt::Display for BlueprintDisplay<'_> {
             );
 
             // Look up the sled state
-            let sled_state = self
-                .blueprint
-                .sled_state
+            let sled_state = sled_state
                 .get(sled_id)
                 .map(|state| state.to_string())
                 .unwrap_or_else(|| {
                     "blueprint error: unknown sled state".to_string()
                 });
+            writeln!(
+                f,
+                "\n  sled: {sled_id} ({sled_state})\n\n{disks_table}\n",
+            )?;
+
+            // Construct the datasets subtable
+            if let Some(datasets) = blueprint_datasets.get(sled_id) {
+                let datasets_tab = BpTable::new(
+                    BpDatasetsTableSchema {},
+                    datasets.bp_generation(),
+                    datasets.rows(BpDiffState::Unchanged).collect(),
+                );
+                writeln!(f, "{datasets_tab}\n")?;
+            }
 
             // Construct the zones subtable
-            match self.blueprint.blueprint_zones.get(sled_id) {
-                Some(zones) => {
-                    let zones_tab = BpTable::new(
-                        BpOmicronZonesTableSchema {},
-                        zones.bp_generation(),
-                        zones.rows(BpDiffState::Unchanged).collect(),
-                    );
-                    writeln!(
-                        f,
-                        "\n  sled: {sled_id} ({sled_state})\n\n{disks_table}\n\n{zones_tab}\n"
-                    )?;
-                }
-                None => writeln!(
-                    f,
-                    "\n  sled: {sled_id} ({sled_state})\n\n{disks_table}\n"
-                )?,
+            if let Some(zones) = blueprint_zones.get(sled_id) {
+                let zones_tab = BpTable::new(
+                    BpOmicronZonesTableSchema {},
+                    zones.bp_generation(),
+                    zones.rows(BpDiffState::Unchanged).collect(),
+                );
+                writeln!(f, "{zones_tab}\n")?;
             }
             seen_sleds.insert(sled_id);
         }
 
-        // Now create and display a table of zones on sleds that don't
-        // yet have physical disks.
+        // Now create and display a table of zones/datasets on sleds that don't
+        // have physical disks.
         //
         // This should basically be impossible, so we warn if it occurs.
-        for (sled_id, zones) in &self.blueprint.blueprint_zones {
+        for (sled_id, zones) in blueprint_zones {
             if !seen_sleds.contains(sled_id) && !zones.zones.is_empty() {
                 writeln!(
                     f,
-                    "\n!{sled_id}\n{}\n{}\n\n",
+                    "!{sled_id}\n{}\n{}\n\n",
                     "WARNING: Zones exist without physical disks!",
                     BpTable::new(
                         BpOmicronZonesTableSchema {},
                         zones.bp_generation(),
                         zones.rows(BpDiffState::Unchanged).collect()
+                    )
+                )?;
+                if let Some(datasets) = blueprint_datasets.get(sled_id) {
+                    writeln!(
+                        f,
+                        "{}\n{}\n",
+                        "WARNING: Datasets also exist without physical disks!",
+                        BpTable::new(
+                            BpDatasetsTableSchema {},
+                            datasets.bp_generation(),
+                            datasets.rows(BpDiffState::Unchanged).collect(),
+                        )
+                    )?;
+                }
+                seen_sleds.insert(sled_id);
+            }
+        }
+
+        // Finally, create and display a table of datasets on sleds that don't
+        // have disks or zones.
+        //
+        // This should basically be impossible, so we warn if it occurs.
+        for (sled_id, datasets) in blueprint_datasets {
+            if !seen_sleds.contains(sled_id) && !datasets.datasets.is_empty() {
+                writeln!(
+                    f,
+                    "!{sled_id}\n{}\n{}\n\n",
+                    "WARNING: Datasets exist without physical disks or zones!",
+                    BpTable::new(
+                        BpDatasetsTableSchema {},
+                        datasets.bp_generation(),
+                        datasets.rows(BpDiffState::Unchanged).collect(),
                     )
                 )?;
             }


### PR DESCRIPTION
A couple times debugging this week I tried to `omdb nexus blueprints show ...` to look at datasets, and had to resort to looking at diffs or raw JSON, so I figured it was time to flesh this out. The diff is almost all expectorate output; code changes are pretty small. I tried to make it slightly less likely we forget to update the blueprint display when fields are changed in the future.

Fixes #7303.