### PR TITLE
Update Propolis and Crucible

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -693,7 +693,7 @@ dependencies = [
 [[package]]
 name = "bhyve_api"
 version = "0.0.0"
-source = "git+https://github.com/oxidecomputer/propolis?rev=99251f841debbe9aaceb4a407a984190c63dead5#99251f841debbe9aaceb4a407a984190c63dead5"
+source = "git+https://github.com/oxidecomputer/propolis?rev=0c186579ba1fafc5a75d46d2ac8ab9ffa97fe309#0c186579ba1fafc5a75d46d2ac8ab9ffa97fe309"
 dependencies = [
  "bhyve_api_sys",
  "libc",
@@ -703,7 +703,7 @@ dependencies = [
 [[package]]
 name = "bhyve_api_sys"
 version = "0.0.0"
-source = "git+https://github.com/oxidecomputer/propolis?rev=99251f841debbe9aaceb4a407a984190c63dead5#99251f841debbe9aaceb4a407a984190c63dead5"
+source = "git+https://github.com/oxidecomputer/propolis?rev=0c186579ba1fafc5a75d46d2ac8ab9ffa97fe309#0c186579ba1fafc5a75d46d2ac8ab9ffa97fe309"
 dependencies = [
  "libc",
  "strum",
@@ -1880,7 +1880,7 @@ dependencies = [
 [[package]]
 name = "crucible-agent-client"
 version = "0.0.1"
-source = "git+https://github.com/oxidecomputer/crucible?rev=86a2ce1f9f13912a5fe652472de765ec5fc22e76#86a2ce1f9f13912a5fe652472de765ec5fc22e76"
+source = "git+https://github.com/oxidecomputer/crucible?rev=03f940b8387750d8955b37e3cc31cc91a2727262#03f940b8387750d8955b37e3cc31cc91a2727262"
 dependencies = [
  "anyhow",
  "chrono",
@@ -1896,7 +1896,7 @@ dependencies = [
 [[package]]
 name = "crucible-client-types"
 version = "0.1.0"
-source = "git+https://github.com/oxidecomputer/crucible?rev=86a2ce1f9f13912a5fe652472de765ec5fc22e76#86a2ce1f9f13912a5fe652472de765ec5fc22e76"
+source = "git+https://github.com/oxidecomputer/crucible?rev=03f940b8387750d8955b37e3cc31cc91a2727262#03f940b8387750d8955b37e3cc31cc91a2727262"
 dependencies = [
  "base64 0.22.1",
  "crucible-workspace-hack",
@@ -1909,7 +1909,7 @@ dependencies = [
 [[package]]
 name = "crucible-common"
 version = "0.0.1"
-source = "git+https://github.com/oxidecomputer/crucible?rev=86a2ce1f9f13912a5fe652472de765ec5fc22e76#86a2ce1f9f13912a5fe652472de765ec5fc22e76"
+source = "git+https://github.com/oxidecomputer/crucible?rev=03f940b8387750d8955b37e3cc31cc91a2727262#03f940b8387750d8955b37e3cc31cc91a2727262"
 dependencies = [
  "anyhow",
  "atty",
@@ -1939,7 +1939,7 @@ dependencies = [
 [[package]]
 name = "crucible-pantry-client"
 version = "0.0.1"
-source = "git+https://github.com/oxidecomputer/crucible?rev=86a2ce1f9f13912a5fe652472de765ec5fc22e76#86a2ce1f9f13912a5fe652472de765ec5fc22e76"
+source = "git+https://github.com/oxidecomputer/crucible?rev=03f940b8387750d8955b37e3cc31cc91a2727262#03f940b8387750d8955b37e3cc31cc91a2727262"
 dependencies = [
  "anyhow",
  "chrono",
@@ -1956,7 +1956,7 @@ dependencies = [
 [[package]]
 name = "crucible-smf"
 version = "0.0.0"
-source = "git+https://github.com/oxidecomputer/crucible?rev=86a2ce1f9f13912a5fe652472de765ec5fc22e76#86a2ce1f9f13912a5fe652472de765ec5fc22e76"
+source = "git+https://github.com/oxidecomputer/crucible?rev=03f940b8387750d8955b37e3cc31cc91a2727262#03f940b8387750d8955b37e3cc31cc91a2727262"
 dependencies = [
  "crucible-workspace-hack",
  "libc",
@@ -7105,7 +7105,7 @@ dependencies = [
  "pq-sys",
  "pretty_assertions",
  "progenitor-client 0.9.1",
- "propolis-client 0.1.0 (git+https://github.com/oxidecomputer/propolis?rev=99251f841debbe9aaceb4a407a984190c63dead5)",
+ "propolis-client 0.1.0 (git+https://github.com/oxidecomputer/propolis?rev=0c186579ba1fafc5a75d46d2ac8ab9ffa97fe309)",
  "qorb",
  "rand",
  "range-requests",
@@ -7392,7 +7392,7 @@ dependencies = [
  "oximeter-producer",
  "oxnet",
  "pretty_assertions",
- "propolis-client 0.1.0 (git+https://github.com/oxidecomputer/propolis?rev=99251f841debbe9aaceb4a407a984190c63dead5)",
+ "propolis-client 0.1.0 (git+https://github.com/oxidecomputer/propolis?rev=0c186579ba1fafc5a75d46d2ac8ab9ffa97fe309)",
  "propolis-mock-server",
  "propolis_api_types",
  "rand",
@@ -9177,7 +9177,7 @@ dependencies = [
 [[package]]
 name = "propolis-client"
 version = "0.1.0"
-source = "git+https://github.com/oxidecomputer/propolis?rev=99251f841debbe9aaceb4a407a984190c63dead5#99251f841debbe9aaceb4a407a984190c63dead5"
+source = "git+https://github.com/oxidecomputer/propolis?rev=0c186579ba1fafc5a75d46d2ac8ab9ffa97fe309#0c186579ba1fafc5a75d46d2ac8ab9ffa97fe309"
 dependencies = [
  "async-trait",
  "base64 0.21.7",
@@ -9222,7 +9222,7 @@ dependencies = [
 [[package]]
 name = "propolis-mock-server"
 version = "0.0.0"
-source = "git+https://github.com/oxidecomputer/propolis?rev=99251f841debbe9aaceb4a407a984190c63dead5#99251f841debbe9aaceb4a407a984190c63dead5"
+source = "git+https://github.com/oxidecomputer/propolis?rev=0c186579ba1fafc5a75d46d2ac8ab9ffa97fe309#0c186579ba1fafc5a75d46d2ac8ab9ffa97fe309"
 dependencies = [
  "anyhow",
  "atty",
@@ -9264,7 +9264,7 @@ dependencies = [
 [[package]]
 name = "propolis_api_types"
 version = "0.0.0"
-source = "git+https://github.com/oxidecomputer/propolis?rev=99251f841debbe9aaceb4a407a984190c63dead5#99251f841debbe9aaceb4a407a984190c63dead5"
+source = "git+https://github.com/oxidecomputer/propolis?rev=0c186579ba1fafc5a75d46d2ac8ab9ffa97fe309#0c186579ba1fafc5a75d46d2ac8ab9ffa97fe309"
 dependencies = [
  "crucible-client-types",
  "propolis_types",
@@ -9278,7 +9278,7 @@ dependencies = [
 [[package]]
 name = "propolis_types"
 version = "0.0.0"
-source = "git+https://github.com/oxidecomputer/propolis?rev=99251f841debbe9aaceb4a407a984190c63dead5#99251f841debbe9aaceb4a407a984190c63dead5"
+source = "git+https://github.com/oxidecomputer/propolis?rev=0c186579ba1fafc5a75d46d2ac8ab9ffa97fe309#0c186579ba1fafc5a75d46d2ac8ab9ffa97fe309"
 dependencies = [
  "schemars",
  "serde",
@@ -10905,7 +10905,7 @@ dependencies = [
  "omicron-workspace-hack",
  "oxnet",
  "progenitor 0.9.1",
- "propolis-client 0.1.0 (git+https://github.com/oxidecomputer/propolis?rev=99251f841debbe9aaceb4a407a984190c63dead5)",
+ "propolis-client 0.1.0 (git+https://github.com/oxidecomputer/propolis?rev=0c186579ba1fafc5a75d46d2ac8ab9ffa97fe309)",
  "regress 0.9.1",
  "reqwest",
  "schemars",
@@ -10931,7 +10931,7 @@ dependencies = [
  "omicron-uuid-kinds",
  "omicron-workspace-hack",
  "oxnet",
- "propolis-client 0.1.0 (git+https://github.com/oxidecomputer/propolis?rev=99251f841debbe9aaceb4a407a984190c63dead5)",
+ "propolis-client 0.1.0 (git+https://github.com/oxidecomputer/propolis?rev=0c186579ba1fafc5a75d46d2ac8ab9ffa97fe309)",
  "rcgen",
  "schemars",
  "serde",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -362,10 +362,10 @@ crossterm = { version = "0.28.1", features = ["event-stream"] }
 # NOTE: if you change the pinned revision of the `crucible` dependencies, you
 # must also update the references in package-manifest.toml to match the new
 # revision.
-crucible-agent-client = { git = "https://github.com/oxidecomputer/crucible", rev = "86a2ce1f9f13912a5fe652472de765ec5fc22e76" }
-crucible-pantry-client = { git = "https://github.com/oxidecomputer/crucible", rev = "86a2ce1f9f13912a5fe652472de765ec5fc22e76" }
-crucible-smf = { git = "https://github.com/oxidecomputer/crucible", rev = "86a2ce1f9f13912a5fe652472de765ec5fc22e76" }
-crucible-common = { git = "https://github.com/oxidecomputer/crucible", rev = "86a2ce1f9f13912a5fe652472de765ec5fc22e76" }
+crucible-agent-client = { git = "https://github.com/oxidecomputer/crucible", rev = "03f940b8387750d8955b37e3cc31cc91a2727262" }
+crucible-pantry-client = { git = "https://github.com/oxidecomputer/crucible", rev = "03f940b8387750d8955b37e3cc31cc91a2727262" }
+crucible-smf = { git = "https://github.com/oxidecomputer/crucible", rev = "03f940b8387750d8955b37e3cc31cc91a2727262" }
+crucible-common = { git = "https://github.com/oxidecomputer/crucible", rev = "03f940b8387750d8955b37e3cc31cc91a2727262" }
 # NOTE: See above!
 csv = "1.3.1"
 curve25519-dalek = "4"
@@ -565,10 +565,10 @@ progenitor-client = "0.9.1"
 # NOTE: if you change the pinned revision of the `bhyve_api` and propolis
 # dependencies, you must also update the references in package-manifest.toml to
 # match the new revision.
-bhyve_api = { git = "https://github.com/oxidecomputer/propolis", rev = "99251f841debbe9aaceb4a407a984190c63dead5" }
-propolis_api_types = { git = "https://github.com/oxidecomputer/propolis", rev = "99251f841debbe9aaceb4a407a984190c63dead5" }
-propolis-client = { git = "https://github.com/oxidecomputer/propolis", rev = "99251f841debbe9aaceb4a407a984190c63dead5" }
-propolis-mock-server = { git = "https://github.com/oxidecomputer/propolis", rev = "99251f841debbe9aaceb4a407a984190c63dead5" }
+bhyve_api = { git = "https://github.com/oxidecomputer/propolis", rev = "0c186579ba1fafc5a75d46d2ac8ab9ffa97fe309" }
+propolis_api_types = { git = "https://github.com/oxidecomputer/propolis", rev = "0c186579ba1fafc5a75d46d2ac8ab9ffa97fe309" }
+propolis-client = { git = "https://github.com/oxidecomputer/propolis", rev = "0c186579ba1fafc5a75d46d2ac8ab9ffa97fe309" }
+propolis-mock-server = { git = "https://github.com/oxidecomputer/propolis", rev = "0c186579ba1fafc5a75d46d2ac8ab9ffa97fe309" }
 # NOTE: see above!
 proptest = "1.5.0"
 qorb = "0.2.1"

--- a/package-manifest.toml
+++ b/package-manifest.toml
@@ -579,10 +579,10 @@ only_for_targets.image = "standard"
 # 3. Use source.type = "manual" instead of "prebuilt"
 source.type = "prebuilt"
 source.repo = "crucible"
-source.commit = "86a2ce1f9f13912a5fe652472de765ec5fc22e76"
+source.commit = "03f940b8387750d8955b37e3cc31cc91a2727262"
 # The SHA256 digest is automatically posted to:
 # https://buildomat.eng.oxide.computer/public/file/oxidecomputer/crucible/image/<commit>/crucible.sha256.txt
-source.sha256 = "ff41d5fb504982536445c34fb62ddccc78d40d5806326fe0d01094f4dc4ba58f"
+source.sha256 = "4dbffda837d6c759faa843f8853a6e9323f49c5820daa4ab563efea5ff9cf5ae"
 output.type = "zone"
 output.intermediate_only = true
 
@@ -591,10 +591,10 @@ service_name = "crucible_pantry_prebuilt"
 only_for_targets.image = "standard"
 source.type = "prebuilt"
 source.repo = "crucible"
-source.commit = "86a2ce1f9f13912a5fe652472de765ec5fc22e76"
+source.commit = "03f940b8387750d8955b37e3cc31cc91a2727262"
 # The SHA256 digest is automatically posted to:
 # https://buildomat.eng.oxide.computer/public/file/oxidecomputer/crucible/image/<commit>/crucible-pantry.sha256.txt
-source.sha256 = "70b9423e0851afe9411957cd5ac515add0cd52dbe98a50f31c8c85ac7a43299c"
+source.sha256 = "988b72e8808bdc7c204488b73e11104915640012fb7c9a75056ebc28f11e6d0d"
 output.type = "zone"
 output.intermediate_only = true
 
@@ -608,10 +608,10 @@ service_name = "crucible_dtrace"
 only_for_targets.image = "standard"
 source.type = "prebuilt"
 source.repo = "crucible"
-source.commit = "86a2ce1f9f13912a5fe652472de765ec5fc22e76"
+source.commit = "03f940b8387750d8955b37e3cc31cc91a2727262"
 # The SHA256 digest is automatically posted to:
 # https://buildomat.eng.oxide.computer/public/file/oxidecomputer/crucible/image/<commit>/crucible-dtrace.sha256.txt
-source.sha256 = "580e0ccb93c24835ada62b40a054042ab301fce3e1c26cd6b29611a60829f545"
+source.sha256 = "73ebcc7a3e031f90361a08a99f9c3fc0ef1713209d2ead6fc44d55b0f8b7d040"
 output.type = "tarball"
 
 # Refer to
@@ -622,10 +622,10 @@ service_name = "propolis-server"
 only_for_targets.image = "standard"
 source.type = "prebuilt"
 source.repo = "propolis"
-source.commit = "99251f841debbe9aaceb4a407a984190c63dead5"
+source.commit = "0c186579ba1fafc5a75d46d2ac8ab9ffa97fe309"
 # The SHA256 digest is automatically posted to:
 # https://buildomat.eng.oxide.computer/public/file/oxidecomputer/propolis/image/<commit>/propolis-server.sha256.txt
-source.sha256 = "53721913ee25b2c649cd845c542fb1ebf86d3e61c68af4002fcfad60050c9e54"
+source.sha256 = "369f67ad5f1c205a50228cd5e4a5fd41f3cbf76ff8f64ae8bca8ee38a2ba5b5a"
 output.type = "zone"
 
 [package.mg-ddm-gz]

--- a/sled-agent/src/instance.rs
+++ b/sled-agent/src/instance.rs
@@ -1115,6 +1115,7 @@ impl InstanceRunner {
                     cpus: self.vcpus,
                     memory_mb: self.memory_mib,
                     cpuid: None,
+                    guest_hv_interface: None,
                 },
                 components: Default::default(),
             };

--- a/sled-agent/src/sim/sled_agent.rs
+++ b/sled-agent/src/sim/sled_agent.rs
@@ -290,6 +290,7 @@ impl SledAgent {
                                     .memory
                                     .to_whole_mebibytes(),
                                 cpuid: None,
+                                guest_hv_interface: None,
                             },
                             components: [(
                                 "com1".to_string(),


### PR DESCRIPTION
Crucible changes are:
Nexus notifications have different importance (#1621)

Propolis changes are:
lib: don't send CPUID settings in vCPU device state payload (#848) server/lib: add generic hypervisor enlightenment interface (#846) server: read host CPUID values if the spec has none (#844)

Added a new field to the Board struct that propolis requires.