### PR TITLE
prioritize some slow tests to run first

### DIFF
--- a/.config/nextest.toml
+++ b/.config/nextest.toml
@@ -49,13 +49,17 @@ live-tests = { max-threads = 1 }
 default-filter = 'all() - package(omicron-live-tests) - package(end-to-end-tests)'
 
 [[profile.default.overrides]]
-filter = 'package(oximeter-db) and test(replicated) + package(omicron-clickhouse-admin)'
-test-group = 'clickhouse-cluster'
-
-[[profile.default.overrides]]
 # These tests are quite slow and can hold up the run, so run them first.
 filter = 'package(oximeter-db) and test(=client::tests::test_replicated) + test(test_action_failure_can_unwind)'
 priority = 20
+
+[[profile.default.overrides]]
+filter = 'package(oximeter-db) and test(replicated) + package(omicron-clickhouse-admin)'
+test-group = 'clickhouse-cluster'
+# client::tests::test_replicated is part of this filter, but it's matched with
+# the higher priority (20) first. The other tests in this group are run after
+# that.
+priority = 10
 
 [[profile.default.overrides]]
 # These tests can time out under heavy contention.

--- a/.config/nextest.toml
+++ b/.config/nextest.toml
@@ -3,7 +3,7 @@
 #
 # The required version should be bumped up if we need new features, performance
 # improvements or bugfixes that are present in newer versions of nextest.
-nextest-version = { required = "0.9.77", recommended = "0.9.86" }
+nextest-version = { required = "0.9.91", recommended = "0.9.91" }
 
 experimental = ["setup-scripts"]
 
@@ -51,6 +51,11 @@ default-filter = 'all() - package(omicron-live-tests) - package(end-to-end-tests
 [[profile.default.overrides]]
 filter = 'package(oximeter-db) and test(replicated) + package(omicron-clickhouse-admin)'
 test-group = 'clickhouse-cluster'
+
+[[profile.default.overrides]]
+# These tests are quite slow and can hold up the run, so run them first.
+filter = 'package(oximeter-db) and test(=client::tests::test_replicated) + test(test_action_failure_can_unwind)'
+priority = 20
 
 [[profile.default.overrides]]
 # These tests can time out under heavy contention.

--- a/.github/buildomat/build-and-test.sh
+++ b/.github/buildomat/build-and-test.sh
@@ -18,7 +18,7 @@ target_os=$1
 # NOTE: This version should be in sync with the recommended version in
 # .config/nextest.toml. (Maybe build an automated way to pull the recommended
 # version in the future.)
-NEXTEST_VERSION='0.9.86'
+NEXTEST_VERSION='0.9.91'
 
 cargo --version
 rustc --version


### PR DESCRIPTION
I've noticed some tests be really slow, and if we decide to run them at the end
can cause the entire suite to take longer. Use nextest's new prioritization
feature to run them first.

A CI test run:

[Before](https://buildomat.eng.oxide.computer/wg/0/details/01JM0MBHDGSK6XN3HBEHCKZGVD/jAmTO9CSgt66QfrBETI1Iu6LV1AmFAagcLSucIFVsgQnRmLG/01JM0MBWCAGBTDYV95YBBH6FHD#S7624):

>      Summary [2608.012s] 1802 tests run: 1802 passed (23 slow, 1 leaky), 4 skipped

[After](https://buildomat.eng.oxide.computer/wg/0/details/01JM1FZ1EJW8WC53MNAXSTQFG4/L4NZVElgTNha3FQe1HR2B9AKEdlEmOBNvbbuuu4BVxtHsTZz/01JM1FZFRZEZZ8PTN4HHYDJSKX#S7626):

>      Summary [2182.362s] 1802 tests run: 1802 passed (21 slow, 1 leaky), 4 skipped

That's an around 400 second speedup -- not bad! There's still some opportunity in parallelizing the ClickHouse cluster tests, but this is good for now.