### PR TITLE
Address `test_region_replacement_triple_sanity_2` flake

### DIFF
--- a/dev-tools/omdb/tests/usage_errors.out
+++ b/dev-tools/omdb/tests/usage_errors.out
@@ -113,6 +113,8 @@ Query the control plane database (CockroachDB)
 Usage: omdb db [OPTIONS] <COMMAND>
 
 Commands:
+  replacements-to-do           Print any Crucible resources that are located on expunged physical
+                               disks
   rack                         Print information about the rack
   disks                        Print information about virtual disks
   dns                          Print information about internal and external DNS
@@ -163,6 +165,8 @@ Query the control plane database (CockroachDB)
 Usage: omdb db [OPTIONS] <COMMAND>
 
 Commands:
+  replacements-to-do           Print any Crucible resources that are located on expunged physical
+                               disks
   rack                         Print information about the rack
   disks                        Print information about virtual disks
   dns                          Print information about internal and external DNS

--- a/nexus/test-utils/src/background.rs
+++ b/nexus/test-utils/src/background.rs
@@ -9,10 +9,28 @@ use dropshot::test_util::ClientTestContext;
 use nexus_client::types::BackgroundTask;
 use nexus_client::types::CurrentStatus;
 use nexus_client::types::LastResult;
+use nexus_client::types::LastResultCompleted;
 use nexus_types::internal_api::background::*;
 use omicron_test_utils::dev::poll::{wait_for_condition, CondCheckError};
-use slog::info;
 use std::time::Duration;
+
+/// Return the most recent activate time for a background task, returning None
+/// if it has never been started or is currently running.
+fn most_recent_activate_time(
+    task: &BackgroundTask,
+) -> Option<chrono::DateTime<chrono::Utc>> {
+    match task.current {
+        CurrentStatus::Idle => match task.last {
+            LastResult::Completed(LastResultCompleted {
+                start_time, ..
+            }) => Some(start_time),
+
+            LastResult::NeverCompleted => None,
+        },
+
+        CurrentStatus::Running(..) => None,
+    }
+}
 
 /// Given the name of a background task, wait for it to complete if it's
 /// running, then return the last polled `BackgroundTask` object. Panics if the
@@ -53,40 +71,19 @@ pub async fn wait_background_task(
 }
 
 /// Given the name of a background task, activate it, then wait for it to
-/// complete. Return the `BackgroundTask` object from this invocation.
+/// complete. Return the last polled `BackgroundTask` object.
 pub async fn activate_background_task(
     internal_client: &ClientTestContext,
     task_name: &str,
 ) -> BackgroundTask {
-    // If it is running, wait for an existing task to complete - this function
-    // has to wait for _this_ activation to finish.
-    //
-    // If it has never run, this function will return straight away.
-    let previous_task = wait_for_condition(
-        || async {
-            let task = NexusRequest::object_get(
-                internal_client,
-                &format!("/bgtasks/view/{task_name}"),
-            )
-            .execute_and_parse_unwrap::<BackgroundTask>()
-            .await;
-
-            if matches!(task.current, CurrentStatus::Idle) {
-                return Ok(task);
-            }
-
-            info!(
-                internal_client.client_log,
-                "waiting for {task_name} to go idle",
-            );
-
-            Err(CondCheckError::<()>::NotYet)
-        },
-        &Duration::from_millis(50),
-        &Duration::from_secs(10),
+    let task = NexusRequest::object_get(
+        internal_client,
+        &format!("/bgtasks/view/{task_name}"),
     )
-    .await
-    .expect("task went to idle");
+    .execute_and_parse_unwrap::<BackgroundTask>()
+    .await;
+
+    let last_activate = most_recent_activate_time(&task);
 
     internal_client
         .make_request(
@@ -101,12 +98,6 @@ pub async fn activate_background_task(
         .unwrap();
 
     // Wait for the task to finish
-    //
-    // Note: if another request to activate this background task occurred
-    // concurrently, this loop will wait for that to complete, not our
-    // activation (which would have been queued). This is ok: this function's
-    // intention is to have an activation of the background task occur _after_
-    // the call, and it doesn't matter which one lands first.
     let last_task_poll = wait_for_condition(
         || async {
             let task = NexusRequest::object_get(
@@ -118,40 +109,40 @@ pub async fn activate_background_task(
 
             // Wait until the task has actually run and then is idle
             if matches!(&task.current, CurrentStatus::Idle) {
-                match (&previous_task.last, &task.last) {
-                    (
-                        LastResult::NeverCompleted,
-                        LastResult::NeverCompleted,
-                    ) => {
-                        // task hasn't started yet
+                let current_activate = most_recent_activate_time(&task);
+                match (current_activate, last_activate) {
+                    (None, None) => {
+                        // task is idle but it hasn't started yet, and it was
+                        // never previously activated
                         Err(CondCheckError::<()>::NotYet)
                     }
 
-                    // task was activated for the first time by this function
-                    // call (or a concurrent one!), and it's done now (because
-                    // the task is idle)
-                    (LastResult::NeverCompleted, LastResult::Completed(_)) => {
+                    (Some(_), None) => {
+                        // task was activated for the first time by this
+                        // function call, and it's done now (because the task is
+                        // idle)
                         Ok(task)
                     }
 
-                    // the task first reported that it completed, but now
-                    // reports that it has never completed
-                    (LastResult::Completed(_), LastResult::NeverCompleted) => {
-                        panic!("completed, then never completed?!");
+                    (None, Some(_)) => {
+                        // the task is idle (due to the check above) but
+                        // `most_recent_activate_time` returned None, implying
+                        // that the LastResult is NeverCompleted? the Some in
+                        // the second part of the tuple means this ran before,
+                        // so panic here.
+                        panic!("task is idle, but there's no activate time?!");
                     }
 
-                    (LastResult::Completed(a), LastResult::Completed(b)) => {
-                        if a.iteration < b.iteration {
+                    (Some(current_activation), Some(last_activation)) => {
+                        // the task is idle, it started ok, and it was
+                        // previously activated: compare times to make sure we
+                        // didn't observe the same BackgroundTask object
+                        if current_activation > last_activation {
                             Ok(task)
-                        } else if a.iteration == b.iteration {
-                            // task hasn't started yet
-                            Err(CondCheckError::<()>::NotYet)
                         } else {
-                            // a.iteration > b.iteration
-                            panic!(
-                                "last iteration {}, current iteration {}",
-                                a.iteration, b.iteration,
-                            );
+                            // the task hasn't started yet, we observed the same
+                            // BackgroundTask object
+                            Err(CondCheckError::<()>::NotYet)
                         }
                     }
                 }

--- a/nexus/test-utils/src/background.rs
+++ b/nexus/test-utils/src/background.rs
@@ -9,28 +9,10 @@ use dropshot::test_util::ClientTestContext;
 use nexus_client::types::BackgroundTask;
 use nexus_client::types::CurrentStatus;
 use nexus_client::types::LastResult;
-use nexus_client::types::LastResultCompleted;
 use nexus_types::internal_api::background::*;
 use omicron_test_utils::dev::poll::{wait_for_condition, CondCheckError};
+use slog::info;
 use std::time::Duration;
-
-/// Return the most recent activate time for a background task, returning None
-/// if it has never been started or is currently running.
-fn most_recent_activate_time(
-    task: &BackgroundTask,
-) -> Option<chrono::DateTime<chrono::Utc>> {
-    match task.current {
-        CurrentStatus::Idle => match task.last {
-            LastResult::Completed(LastResultCompleted {
-                start_time, ..
-            }) => Some(start_time),
-
-            LastResult::NeverCompleted => None,
-        },
-
-        CurrentStatus::Running(..) => None,
-    }
-}
 
 /// Given the name of a background task, wait for it to complete if it's
 /// running, then return the last polled `BackgroundTask` object. Panics if the
@@ -71,19 +53,40 @@ pub async fn wait_background_task(
 }
 
 /// Given the name of a background task, activate it, then wait for it to
-/// complete. Return the last polled `BackgroundTask` object.
+/// complete. Return the `BackgroundTask` object from this invocation.
 pub async fn activate_background_task(
     internal_client: &ClientTestContext,
     task_name: &str,
 ) -> BackgroundTask {
-    let task = NexusRequest::object_get(
-        internal_client,
-        &format!("/bgtasks/view/{task_name}"),
-    )
-    .execute_and_parse_unwrap::<BackgroundTask>()
-    .await;
+    // If it is running, wait for an existing task to complete - this function
+    // has to wait for _this_ activation to finish.
+    //
+    // If it has never run, this function will return straight away.
+    let previous_task = wait_for_condition(
+        || async {
+            let task = NexusRequest::object_get(
+                internal_client,
+                &format!("/bgtasks/view/{task_name}"),
+            )
+            .execute_and_parse_unwrap::<BackgroundTask>()
+            .await;
 
-    let last_activate = most_recent_activate_time(&task);
+            if matches!(task.current, CurrentStatus::Idle) {
+                return Ok(task);
+            }
+
+            info!(
+                internal_client.client_log,
+                "waiting for {task_name} to go idle",
+            );
+
+            Err(CondCheckError::<()>::NotYet)
+        },
+        &Duration::from_millis(50),
+        &Duration::from_secs(10),
+    )
+    .await
+    .expect("task went to idle");
 
     internal_client
         .make_request(
@@ -98,6 +101,12 @@ pub async fn activate_background_task(
         .unwrap();
 
     // Wait for the task to finish
+    //
+    // Note: if another request to activate this background task occurred
+    // concurrently, this loop will wait for that to complete, not our
+    // activation (which would have been queued). This is ok: this function's
+    // intention is to have an activation of the background task occur _after_
+    // the call, and it doesn't matter which one lands first.
     let last_task_poll = wait_for_condition(
         || async {
             let task = NexusRequest::object_get(
@@ -109,40 +118,40 @@ pub async fn activate_background_task(
 
             // Wait until the task has actually run and then is idle
             if matches!(&task.current, CurrentStatus::Idle) {
-                let current_activate = most_recent_activate_time(&task);
-                match (current_activate, last_activate) {
-                    (None, None) => {
-                        // task is idle but it hasn't started yet, and it was
-                        // never previously activated
+                match (&previous_task.last, &task.last) {
+                    (
+                        LastResult::NeverCompleted,
+                        LastResult::NeverCompleted,
+                    ) => {
+                        // task hasn't started yet
                         Err(CondCheckError::<()>::NotYet)
                     }
 
-                    (Some(_), None) => {
-                        // task was activated for the first time by this
-                        // function call, and it's done now (because the task is
-                        // idle)
+                    // task was activated for the first time by this function
+                    // call (or a concurrent one!), and it's done now (because
+                    // the task is idle)
+                    (LastResult::NeverCompleted, LastResult::Completed(_)) => {
                         Ok(task)
                     }
 
-                    (None, Some(_)) => {
-                        // the task is idle (due to the check above) but
-                        // `most_recent_activate_time` returned None, implying
-                        // that the LastResult is NeverCompleted? the Some in
-                        // the second part of the tuple means this ran before,
-                        // so panic here.
-                        panic!("task is idle, but there's no activate time?!");
+                    // the task first reported that it completed, but now
+                    // reports that it has never completed
+                    (LastResult::Completed(_), LastResult::NeverCompleted) => {
+                        panic!("completed, then never completed?!");
                     }
 
-                    (Some(current_activation), Some(last_activation)) => {
-                        // the task is idle, it started ok, and it was
-                        // previously activated: compare times to make sure we
-                        // didn't observe the same BackgroundTask object
-                        if current_activation > last_activation {
+                    (LastResult::Completed(a), LastResult::Completed(b)) => {
+                        if a.iteration < b.iteration {
                             Ok(task)
-                        } else {
-                            // the task hasn't started yet, we observed the same
-                            // BackgroundTask object
+                        } else if a.iteration == b.iteration {
+                            // task hasn't started yet
                             Err(CondCheckError::<()>::NotYet)
+                        } else {
+                            // a.iteration > b.iteration
+                            panic!(
+                                "last iteration {}, current iteration {}",
+                                a.iteration, b.iteration,
+                            );
                         }
                     }
                 }
@@ -304,8 +313,6 @@ pub async fn run_region_snapshot_replacement_step(
         last_result_completed.details,
     )
     .unwrap();
-
-    eprintln!("{:?}", &status.errors);
 
     assert!(status.errors.is_empty());
 


### PR DESCRIPTION
`test_region_replacement_triple_sanity_2` performs two disk expungements before starting the Crucible replacement machinery to ensure that losing two out of three parts of a Volume's region set will not result in lost data. This test was occasionally failing with an assertion that indicated not all resources on expunged physical disks had been replaced in a volume.

`wait_for_all_replacements` is a routine that previously would:

1. run all background tasks related to region replacement and region snapshot replacement

2. bail out of the loop if there are no more non-completed replacements

This is incorrect! "no more non-completed replacements" is not an indicator that all necessary resource movement has completed, only that _current_ movement has completed. Rerunning the background tasks could request more work.

The real check that function should be performing is whether or not any resources used by Volumes are backed by physical disks that are expunged. This commit changes `wait_for_all_replacements` to:

1. run all background tasks related to region replacement and region snapshot replacement, but ignore the output

2. check how many resources are still backed by expunged physical disks, and loop if there still are some

3. check if work is in-progress, and loop if so

4. return to the caller

Also in this commit:

- an omdb command has been added that will print what resources need to be replaced (because they're on expunged physical disks)

- an errant eprintln has been removed (it was showing up in the `--nocapture` output)

Fixes #7535