### PR TITLE
Blueprints: make `filesystem_pool` required

### DIFF
--- a/nexus/db-model/src/deployment.rs
+++ b/nexus/db-model/src/deployment.rs
@@ -454,7 +454,7 @@ pub struct BpOmicronZone {
     disposition_expunged_ready_for_cleanup: bool,
 
     pub external_ip_id: Option<DbTypedUuid<ExternalIpKind>>,
-    pub filesystem_pool: Option<DbTypedUuid<ZpoolKind>>,
+    pub filesystem_pool: DbTypedUuid<ZpoolKind>,
 }
 
 impl BpOmicronZone {
@@ -482,10 +482,7 @@ impl BpOmicronZone {
             sled_id: sled_id.into(),
             id: blueprint_zone.id.into(),
             external_ip_id,
-            filesystem_pool: blueprint_zone
-                .filesystem_pool
-                .as_ref()
-                .map(|pool| pool.id().into()),
+            filesystem_pool: blueprint_zone.filesystem_pool.id().into(),
             disposition,
             disposition_expunged_as_of_generation,
             disposition_expunged_ready_for_cleanup,
@@ -883,9 +880,9 @@ impl BpOmicronZone {
         Ok(BlueprintZoneConfig {
             disposition: disposition_cols.try_into()?,
             id: self.id.into(),
-            filesystem_pool: self
-                .filesystem_pool
-                .map(|id| ZpoolName::new_external(id.into())),
+            filesystem_pool: ZpoolName::new_external(
+                self.filesystem_pool.into(),
+            ),
             zone_type,
             image_source: BlueprintZoneImageSource::InstallDataset,
         })

--- a/nexus/db-model/src/schema.rs
+++ b/nexus/db-model/src/schema.rs
@@ -1791,7 +1791,7 @@ table! {
         disposition_expunged_as_of_generation -> Nullable<Int8>,
         disposition_expunged_ready_for_cleanup -> Bool,
         external_ip_id -> Nullable<Uuid>,
-        filesystem_pool -> Nullable<Uuid>,
+        filesystem_pool -> Uuid,
     }
 }
 

--- a/nexus/db-model/src/schema_versions.rs
+++ b/nexus/db-model/src/schema_versions.rs
@@ -16,7 +16,7 @@ use std::{collections::BTreeMap, sync::LazyLock};
 ///
 /// This must be updated when you change the database schema.  Refer to
 /// schema/crdb/README.adoc in the root of this repository for details.
-pub const SCHEMA_VERSION: Version = Version::new(131, 0, 0);
+pub const SCHEMA_VERSION: Version = Version::new(132, 0, 0);
 
 /// List of all past database schema versions, in *reverse* order
 ///
@@ -28,6 +28,7 @@ static KNOWN_VERSIONS: LazyLock<Vec<KnownVersion>> = LazyLock::new(|| {
         // |  leaving the first copy as an example for the next person.
         // v
         // KnownVersion::new(next_int, "unique-dirname-with-the-sql-files"),
+        KnownVersion::new(132, "bp-omicron-zone-filesystem-pool-not-null"),
         KnownVersion::new(131, "tuf-generation"),
         KnownVersion::new(130, "bp-sled-agent-generation"),
         KnownVersion::new(129, "create-target-release"),

--- a/nexus/db-queries/src/db/datastore/deployment.rs
+++ b/nexus/db-queries/src/db/datastore/deployment.rs
@@ -1812,6 +1812,7 @@ mod tests {
     use omicron_common::api::internal::shared::NetworkInterface;
     use omicron_common::api::internal::shared::NetworkInterfaceKind;
     use omicron_common::disk::DiskIdentity;
+    use omicron_common::zpool_name::ZpoolName;
     use omicron_test_utils::dev;
     use omicron_test_utils::dev::poll::CondCheckError;
     use omicron_test_utils::dev::poll::wait_for_condition;
@@ -2582,7 +2583,9 @@ mod tests {
             BlueprintZoneConfig {
                 disposition: BlueprintZoneDisposition::InService,
                 id: zone_id,
-                filesystem_pool: None,
+                filesystem_pool: ZpoolName::new_external(
+                    ZpoolUuid::new_v4(),
+                ),
                 zone_type: BlueprintZoneType::Nexus(
                     blueprint_zone_type::Nexus {
                         internal_address: SocketAddrV6::new(

--- a/nexus/db-queries/src/db/datastore/deployment.rs
+++ b/nexus/db-queries/src/db/datastore/deployment.rs
@@ -2583,9 +2583,7 @@ mod tests {
             BlueprintZoneConfig {
                 disposition: BlueprintZoneDisposition::InService,
                 id: zone_id,
-                filesystem_pool: ZpoolName::new_external(
-                    ZpoolUuid::new_v4(),
-                ),
+                filesystem_pool: ZpoolName::new_external(ZpoolUuid::new_v4()),
                 zone_type: BlueprintZoneType::Nexus(
                     blueprint_zone_type::Nexus {
                         internal_address: SocketAddrV6::new(

--- a/nexus/db-queries/src/db/datastore/deployment/external_networking.rs
+++ b/nexus/db-queries/src/db/datastore/deployment/external_networking.rs
@@ -607,9 +607,9 @@ mod tests {
                 BlueprintZoneConfig {
                     disposition: BlueprintZoneDisposition::InService,
                     id: self.nexus_id,
-                    filesystem_pool: Some(ZpoolName::new_external(
+                    filesystem_pool: ZpoolName::new_external(
                         ZpoolUuid::new_v4(),
-                    )),
+                    ),
                     zone_type: BlueprintZoneType::Nexus(
                         blueprint_zone_type::Nexus {
                             internal_address: "[::1]:0".parse().unwrap(),
@@ -624,9 +624,9 @@ mod tests {
                 BlueprintZoneConfig {
                     disposition: BlueprintZoneDisposition::InService,
                     id: self.dns_id,
-                    filesystem_pool: Some(ZpoolName::new_external(
+                    filesystem_pool: ZpoolName::new_external(
                         ZpoolUuid::new_v4(),
-                    )),
+                    ),
                     zone_type: BlueprintZoneType::ExternalDns(
                         blueprint_zone_type::ExternalDns {
                             dataset: OmicronZoneDataset {
@@ -644,9 +644,9 @@ mod tests {
                 BlueprintZoneConfig {
                     disposition: BlueprintZoneDisposition::InService,
                     id: self.ntp_id,
-                    filesystem_pool: Some(ZpoolName::new_external(
+                    filesystem_pool: ZpoolName::new_external(
                         ZpoolUuid::new_v4(),
-                    )),
+                    ),
                     zone_type: BlueprintZoneType::BoundaryNtp(
                         blueprint_zone_type::BoundaryNtp {
                             address: "[::1]:0".parse().unwrap(),

--- a/nexus/db-queries/src/db/datastore/rack.rs
+++ b/nexus/db-queries/src/db/datastore/rack.rs
@@ -1411,7 +1411,7 @@ mod test {
                 BlueprintZoneConfig {
                     disposition: BlueprintZoneDisposition::InService,
                     id: ntp1_id,
-                    filesystem_pool: Some(random_zpool()),
+                    filesystem_pool: random_zpool(),
                     zone_type: BlueprintZoneType::BoundaryNtp(
                         blueprint_zone_type::BoundaryNtp {
                             address: "[::1]:80".parse().unwrap(),
@@ -1484,7 +1484,7 @@ mod test {
                 BlueprintZoneConfig {
                     disposition: BlueprintZoneDisposition::InService,
                     id: ntp2_id,
-                    filesystem_pool: Some(random_zpool()),
+                    filesystem_pool: random_zpool(),
                     zone_type: BlueprintZoneType::BoundaryNtp(
                         blueprint_zone_type::BoundaryNtp {
                             address: "[::1]:80".parse().unwrap(),
@@ -1734,7 +1734,7 @@ mod test {
                 BlueprintZoneConfig {
                     disposition: BlueprintZoneDisposition::InService,
                     id: nexus_id2,
-                    filesystem_pool: Some(random_zpool()),
+                    filesystem_pool: random_zpool(),
                     zone_type: BlueprintZoneType::Nexus(
                         blueprint_zone_type::Nexus {
                             internal_address: "[::1]:80".parse().unwrap(),
@@ -2102,7 +2102,7 @@ mod test {
                 BlueprintZoneConfig {
                     disposition: BlueprintZoneDisposition::InService,
                     id: nexus_id,
-                    filesystem_pool: Some(random_zpool()),
+                    filesystem_pool: random_zpool(),
                     zone_type: BlueprintZoneType::Nexus(
                         blueprint_zone_type::Nexus {
                             internal_address: "[::1]:80".parse().unwrap(),

--- a/nexus/db-queries/src/db/datastore/rack.rs
+++ b/nexus/db-queries/src/db/datastore/rack.rs
@@ -1381,7 +1381,7 @@ mod test {
                 BlueprintZoneConfig {
                     disposition: BlueprintZoneDisposition::InService,
                     id: external_dns_id,
-                    filesystem_pool: Some(dataset.pool_name.clone()),
+                    filesystem_pool: dataset.pool_name.clone(),
                     zone_type: BlueprintZoneType::ExternalDns(
                         blueprint_zone_type::ExternalDns {
                             dataset,
@@ -1453,7 +1453,7 @@ mod test {
                 BlueprintZoneConfig {
                     disposition: BlueprintZoneDisposition::InService,
                     id: nexus_id,
-                    filesystem_pool: Some(random_zpool()),
+                    filesystem_pool: random_zpool(),
                     zone_type: BlueprintZoneType::Nexus(
                         blueprint_zone_type::Nexus {
                             internal_address: "[::1]:80".parse().unwrap(),
@@ -1525,7 +1525,7 @@ mod test {
             [BlueprintZoneConfig {
                 disposition: BlueprintZoneDisposition::InService,
                 id: ntp3_id,
-                filesystem_pool: Some(random_zpool()),
+                filesystem_pool: random_zpool(),
                 zone_type: BlueprintZoneType::InternalNtp(
                     blueprint_zone_type::InternalNtp {
                         address: "[::1]:80".parse().unwrap(),
@@ -1703,7 +1703,7 @@ mod test {
                 BlueprintZoneConfig {
                     disposition: BlueprintZoneDisposition::InService,
                     id: nexus_id1,
-                    filesystem_pool: Some(random_zpool()),
+                    filesystem_pool: random_zpool(),
                     zone_type: BlueprintZoneType::Nexus(
                         blueprint_zone_type::Nexus {
                             internal_address: "[::1]:80".parse().unwrap(),
@@ -1968,7 +1968,7 @@ mod test {
             [BlueprintZoneConfig {
                 disposition: BlueprintZoneDisposition::InService,
                 id: nexus_id,
-                filesystem_pool: Some(random_zpool()),
+                filesystem_pool: random_zpool(),
                 zone_type: BlueprintZoneType::Nexus(
                     blueprint_zone_type::Nexus {
                         internal_address: "[::1]:80".parse().unwrap(),
@@ -2072,7 +2072,7 @@ mod test {
                 BlueprintZoneConfig {
                     disposition: BlueprintZoneDisposition::InService,
                     id: external_dns_id,
-                    filesystem_pool: Some(dataset.pool_name.clone()),
+                    filesystem_pool: dataset.pool_name.clone(),
                     zone_type: BlueprintZoneType::ExternalDns(
                         blueprint_zone_type::ExternalDns {
                             dataset,

--- a/nexus/reconfigurator/blippy/src/blippy.rs
+++ b/nexus/reconfigurator/blippy/src/blippy.rs
@@ -153,8 +153,6 @@ pub enum SledKind {
     ZpoolMissingZoneRootDataset { zpool: ZpoolUuid },
     /// A zone's filesystem dataset is missing from `blueprint_datasets`.
     ZoneMissingFilesystemDataset { zone: BlueprintZoneConfig },
-    /// A zone's filesystem pool value is missing from `blueprint_datasets`.
-    ZoneMissingFilesystemPool { zone: BlueprintZoneConfig },
     /// A zone's durable dataset is missing from `blueprint_datasets`.
     ZoneMissingDurableDataset { zone: BlueprintZoneConfig },
     /// A zone's durable dataset and transient root dataset are on different
@@ -303,15 +301,6 @@ impl fmt::Display for SledKind {
                 write!(
                     f,
                     "in-service zone's filesytem dataset is missing: {:?} {}",
-                    zone.zone_type.kind(),
-                    zone.id,
-                )
-            }
-            SledKind::ZoneMissingFilesystemPool { zone } => {
-                write!(
-                    f,
-                    "in-service zone's filesytem pool property is missing: \
-                     {:?} {}",
                     zone.zone_type.kind(),
                     zone.id,
                 )

--- a/nexus/reconfigurator/execution/src/clickhouse.rs
+++ b/nexus/reconfigurator/execution/src/clickhouse.rs
@@ -408,6 +408,9 @@ mod test {
                 disposition: BlueprintZoneDisposition::InService,
                 id: zone_id,
                 filesystem_pool: None,
+                filesystem_pool: ZpoolName::new_external(
+                    ZpoolUuid::new_v4(),
+                ),
                 zone_type: BlueprintZoneType::ClickhouseKeeper(
                     blueprint_zone_type::ClickhouseKeeper {
                         address: SocketAddrV6::new(
@@ -443,7 +446,9 @@ mod test {
             let zone_config = BlueprintZoneConfig {
                 disposition: BlueprintZoneDisposition::InService,
                 id: zone_id,
-                filesystem_pool: None,
+                filesystem_pool: ZpoolName::new_external(
+                    ZpoolUuid::new_v4(),
+                ),
                 zone_type: BlueprintZoneType::ClickhouseServer(
                     blueprint_zone_type::ClickhouseServer {
                         address: SocketAddrV6::new(

--- a/nexus/reconfigurator/execution/src/clickhouse.rs
+++ b/nexus/reconfigurator/execution/src/clickhouse.rs
@@ -407,9 +407,7 @@ mod test {
             let zone_config = BlueprintZoneConfig {
                 disposition: BlueprintZoneDisposition::InService,
                 id: zone_id,
-                filesystem_pool: ZpoolName::new_external(
-                    ZpoolUuid::new_v4(),
-                ),
+                filesystem_pool: ZpoolName::new_external(ZpoolUuid::new_v4()),
                 zone_type: BlueprintZoneType::ClickhouseKeeper(
                     blueprint_zone_type::ClickhouseKeeper {
                         address: SocketAddrV6::new(
@@ -445,9 +443,7 @@ mod test {
             let zone_config = BlueprintZoneConfig {
                 disposition: BlueprintZoneDisposition::InService,
                 id: zone_id,
-                filesystem_pool: ZpoolName::new_external(
-                    ZpoolUuid::new_v4(),
-                ),
+                filesystem_pool: ZpoolName::new_external(ZpoolUuid::new_v4()),
                 zone_type: BlueprintZoneType::ClickhouseServer(
                     blueprint_zone_type::ClickhouseServer {
                         address: SocketAddrV6::new(

--- a/nexus/reconfigurator/execution/src/clickhouse.rs
+++ b/nexus/reconfigurator/execution/src/clickhouse.rs
@@ -407,7 +407,6 @@ mod test {
             let zone_config = BlueprintZoneConfig {
                 disposition: BlueprintZoneDisposition::InService,
                 id: zone_id,
-                filesystem_pool: None,
                 filesystem_pool: ZpoolName::new_external(
                     ZpoolUuid::new_v4(),
                 ),

--- a/nexus/reconfigurator/execution/src/dns.rs
+++ b/nexus/reconfigurator/execution/src/dns.rs
@@ -600,7 +600,14 @@ mod test {
         Ok(BlueprintZoneConfig {
             disposition,
             id: config.id,
-            filesystem_pool: config.filesystem_pool,
+            // This is *VERY* incorrect, in terms of a real system, but is not
+            // harmful to our DNS tests below. We should not introduce any new
+            // callers of
+            // `deprecated_omicron_zone_config_to_blueprint_zone_config`, so
+            // hopefully this doesn't cause us too much pain in the future.
+            filesystem_pool: config.filesystem_pool.unwrap_or_else(|| {
+                ZpoolName::new_external(ZpoolUuid::new_v4())
+            }),
             zone_type,
             image_source,
         })
@@ -701,9 +708,7 @@ mod test {
                     ready_for_cleanup: false,
                 },
                 id: out_of_service_id,
-                filesystem_pool: Some(ZpoolName::new_external(
-                    ZpoolUuid::new_v4(),
-                )),
+                filesystem_pool: ZpoolName::new_external(ZpoolUuid::new_v4()),
                 zone_type: BlueprintZoneType::Oximeter(
                     blueprint_zone_type::Oximeter {
                         address: SocketAddrV6::new(

--- a/nexus/reconfigurator/execution/src/omicron_sled_config.rs
+++ b/nexus/reconfigurator/execution/src/omicron_sled_config.rs
@@ -277,7 +277,7 @@ mod tests {
         zones.insert(BlueprintZoneConfig {
             disposition: BlueprintZoneDisposition::InService,
             id: zone_id,
-            filesystem_pool: Some(dataset_pool.clone()),
+            filesystem_pool: dataset_pool.clone(),
             zone_type: BlueprintZoneType::Oximeter(
                 blueprint_zone_type::Oximeter {
                     address: "[::1]:0".parse().unwrap(),
@@ -291,7 +291,7 @@ mod tests {
                 ready_for_cleanup: false,
             },
             id: OmicronZoneUuid::new_v4(),
-            filesystem_pool: Some(dataset_pool.clone()),
+            filesystem_pool: dataset_pool.clone(),
             zone_type: BlueprintZoneType::Oximeter(
                 blueprint_zone_type::Oximeter {
                     address: "[::1]:0".parse().unwrap(),

--- a/nexus/reconfigurator/execution/src/omicron_zones.rs
+++ b/nexus/reconfigurator/execution/src/omicron_zones.rs
@@ -319,7 +319,7 @@ mod test {
                 ready_for_cleanup: true,
             },
             id: OmicronZoneUuid::new_v4(),
-            filesystem_pool: Some(ZpoolName::new_external(ZpoolUuid::new_v4())),
+            filesystem_pool: ZpoolName::new_external(ZpoolUuid::new_v4()),
             zone_type: BlueprintZoneType::CockroachDb(
                 blueprint_zone_type::CockroachDb {
                     address: "[::1]:0".parse().unwrap(),

--- a/nexus/reconfigurator/planning/src/blueprint_builder/builder.rs
+++ b/nexus/reconfigurator/planning/src/blueprint_builder/builder.rs
@@ -486,7 +486,7 @@ impl<'a> BlueprintBuilder<'a> {
         for (sled_id, sled_cfg) in &parent_blueprint.sleds {
             let state = sled_cfg.state;
 
-            let mut editor = match state {
+            let editor = match state {
                 SledState::Active => {
                     let subnet = input
                         .sled_lookup(SledFilter::Commissioned, *sled_id)
@@ -507,28 +507,6 @@ impl<'a> BlueprintBuilder<'a> {
             .with_context(|| {
                 format!("failed to construct SledEditor for sled {sled_id}")
             })?;
-
-            // Apply fixes for #7229 to all active sleds: If any zones have a
-            // missing or incorrect `filesystem_pool` property, correct it based
-            // on the inventory pools and datasets.
-            match state {
-                SledState::Active => {
-                    let sled_inventory = inventory.sled_agents.get(sled_id);
-                    editor
-                        .backfill_zone_filesystem_pools(
-                            sled_inventory.map_or(&[], |inv| &inv.zpools),
-                            sled_inventory.map_or(&[], |inv| &inv.datasets),
-                            &log,
-                        )
-                        .with_context(|| {
-                            format!(
-                                "failed to backfill zone filesystem_pool \
-                                 values for sled {sled_id}"
-                            )
-                        })?;
-                }
-                SledState::Decommissioned => (),
-            }
 
             sled_editors.insert(*sled_id, editor);
         }
@@ -2058,8 +2036,6 @@ pub mod test {
     use nexus_types::deployment::OmicronZoneNetworkResources;
     use nexus_types::external_api::views::SledPolicy;
     use omicron_common::address::IpRange;
-    use omicron_common::disk::DatasetKind;
-    use omicron_common::disk::DatasetName;
     use omicron_common::update::ArtifactHash;
     use omicron_test_utils::dev::test_setup_log;
     use std::collections::BTreeSet;
@@ -2881,222 +2857,6 @@ pub mod test {
             }
             _ => panic!("unexpected error {err}"),
         }
-
-        logctx.cleanup_successful();
-    }
-
-    #[test]
-    fn test_backfill_filesystem_pool() {
-        static TEST_NAME: &str =
-            "blueprint_builder_test_backfill_filesystem_pool";
-        let logctx = test_setup_log(TEST_NAME);
-
-        // Start a system that has 3 Nexus instances, each on a different sled.
-        let (example, mut parent) =
-            ExampleSystemBuilder::new(&logctx.log, TEST_NAME)
-                .nsleds(3)
-                .nexus_count(3)
-                .build();
-        let mut collection = example.collection;
-        let input = example.input;
-
-        // For each of the 3 Nexus instances:
-        //
-        // 0 - remains unchanged
-        // 1,2 - set filesystem_pool to None (should get filled in correctly)
-        //
-        // The zone config generation on sleds 1 and 2 should get bumped. 0
-        // should remain unchanged.
-        let mut sled_ids = Vec::with_capacity(3);
-        let mut expected_filesystem_pools = Vec::with_capacity(3);
-        let mut expected_zones_config_gen = Vec::with_capacity(3);
-
-        for (sled_id, sled_config) in parent.sleds.iter_mut() {
-            let mut nexus = sled_config
-                .zones
-                .iter_mut()
-                .find(|z| z.zone_type.is_nexus())
-                .expect("should find a nexus on each sled");
-            let orig_nexus_filesystem_pool =
-                nexus.filesystem_pool.clone().expect(
-                    "nexus instances in new blueprints \
-                     should have a filesystem_pool",
-                );
-
-            match sled_ids.len() {
-                0 => {
-                    expected_zones_config_gen
-                        .push(sled_config.sled_agent_generation);
-                }
-                1 | 2 => {
-                    expected_zones_config_gen
-                        .push(sled_config.sled_agent_generation.next());
-                    nexus.filesystem_pool = None;
-                }
-                _ => unreachable!("unexpected number of sleds in test"),
-            }
-            sled_ids.push(*sled_id);
-            expected_filesystem_pools.push(orig_nexus_filesystem_pool.clone());
-        }
-
-        // Create a builder and produce a new blueprint.
-        let blueprint1 = {
-            let mut builder = BlueprintBuilder::new_based_on(
-                &logctx.log,
-                &parent,
-                &input,
-                &collection,
-                "test",
-            )
-            .expect("constructed builder");
-
-            for sled_id in input.all_sled_ids(SledFilter::InService) {
-                builder
-                    .sled_ensure_zone_datasets(sled_id)
-                    .expect("ensured zone datasets");
-            }
-
-            builder.build()
-        };
-
-        // Check that our backfilling was correct.
-        for (i, &sled_id) in sled_ids.iter().enumerate() {
-            let sled_config =
-                blueprint1.sleds.get(&sled_id).expect("found sled");
-            assert_eq!(
-                sled_config.sled_agent_generation, expected_zones_config_gen[i],
-                "unexpected generation on sled {i}"
-            );
-
-            let nexus = sled_config
-                .zones
-                .iter()
-                .find(|z| z.zone_type.is_nexus())
-                .expect("found nexus on sled");
-            assert_eq!(
-                nexus.filesystem_pool.as_ref(),
-                Some(&expected_filesystem_pools[i]),
-                "unexpected filesystem_pool on sled {i}"
-            );
-        }
-
-        // Check that the new blueprint is blippy-clean.
-        verify_blueprint(&blueprint1);
-
-        // It's possible a sled-agent could restart in between when the
-        // inventory collection we used for backfilling was created and when we
-        // try to send it the new zone configs, and in doing so it could have
-        // changed the zpool it chose for any zone type that doesn't have a
-        // durable dataset (e.g., Nexus). To emulate this, mutate our collection
-        // and change the zpool for sled 2's Nexus to a different zpool; our
-        // backfilling should correct this again, even though the parent
-        // blueprint has a non-`None` filesystem pool for this Nexus.
-        let sled_2_new_nexus_zpool = {
-            // Get sled 2 and its Nexus from the collection...
-            let entry = collection
-                .sled_agents
-                .get_mut(&sled_ids[2])
-                .expect("sled 2 exists");
-            let nexus = entry
-                .omicron_zones
-                .zones
-                .iter()
-                .find(|z| z.zone_type.is_nexus())
-                .expect("found Nexus");
-            let nexus_filesystem_pool = nexus
-                .filesystem_pool
-                .as_ref()
-                .expect("Nexus has a filesystem_pool");
-
-            // ... pick some other pool to use ...
-            let some_other_pool = entry
-                .zpools
-                .iter()
-                .find_map(|zpool| {
-                    if zpool.id != nexus_filesystem_pool.id() {
-                        Some(ZpoolName::new_external(zpool.id))
-                    } else {
-                        None
-                    }
-                })
-                .expect("found some other zpool");
-
-            // ... and then update the collection's Nexus dataset to report that
-            // new pool as part of its dataset name.
-            let mut found_nexus_dataset = false;
-            for dataset in entry.datasets.iter_mut() {
-                if dataset.name.contains("nexus") {
-                    assert!(
-                        !found_nexus_dataset,
-                        "sled should only have 1 Nexus dataset"
-                    );
-                    found_nexus_dataset = true;
-                    dataset.name = DatasetName::new(
-                        some_other_pool.clone(),
-                        DatasetKind::TransientZone {
-                            name: illumos_utils::zone::zone_name(
-                                nexus.zone_type.kind().zone_prefix(),
-                                Some(nexus.id),
-                            ),
-                        },
-                    )
-                    .full_name();
-                }
-            }
-            assert!(
-                found_nexus_dataset,
-                "did not find and update Nexus dataset"
-            );
-
-            some_other_pool
-        };
-
-        let blueprint2 = {
-            let mut builder = BlueprintBuilder::new_based_on(
-                &logctx.log,
-                &blueprint1,
-                &input,
-                &collection,
-                "test",
-            )
-            .expect("constructed builder");
-
-            for sled_id in input.all_sled_ids(SledFilter::InService) {
-                builder
-                    .sled_ensure_zone_datasets(sled_id)
-                    .expect("ensured zone datasets");
-            }
-
-            builder.build()
-        };
-
-        // Check that our backfilling was correct: sled 2's generation should
-        // have been bumped again, and should have the filesystem pool reported
-        // by our modified collection.
-        expected_zones_config_gen[2] = expected_zones_config_gen[2].next();
-        expected_filesystem_pools[2] = sled_2_new_nexus_zpool;
-        for (i, &sled_id) in sled_ids.iter().enumerate() {
-            let sled_config =
-                blueprint2.sleds.get(&sled_id).expect("found sled");
-            assert_eq!(
-                sled_config.sled_agent_generation, expected_zones_config_gen[i],
-                "unexpected generation on sled {i}"
-            );
-
-            let nexus = sled_config
-                .zones
-                .iter()
-                .find(|z| z.zone_type.is_nexus())
-                .expect("found nexus on sled");
-            assert_eq!(
-                nexus.filesystem_pool.as_ref(),
-                Some(&expected_filesystem_pools[i]),
-                "unexpected filesystem_pool on sled {i}"
-            );
-        }
-
-        // Check that the new blueprint is blippy-clean.
-        verify_blueprint(&blueprint2);
 
         logctx.cleanup_successful();
     }

--- a/nexus/reconfigurator/planning/src/blueprint_builder/builder.rs
+++ b/nexus/reconfigurator/planning/src/blueprint_builder/builder.rs
@@ -1145,7 +1145,7 @@ impl<'a> BlueprintBuilder<'a> {
         let zone = BlueprintZoneConfig {
             disposition: BlueprintZoneDisposition::InService,
             id: self.rng.sled_rng(sled_id).next_zone(),
-            filesystem_pool: Some(zpool),
+            filesystem_pool: zpool,
             zone_type,
             image_source: BlueprintZoneImageSource::InstallDataset,
         };
@@ -1197,7 +1197,7 @@ impl<'a> BlueprintBuilder<'a> {
         let zone = BlueprintZoneConfig {
             disposition: BlueprintZoneDisposition::InService,
             id,
-            filesystem_pool: Some(pool_name),
+            filesystem_pool: pool_name,
             zone_type,
             image_source: BlueprintZoneImageSource::InstallDataset,
         };
@@ -1236,7 +1236,7 @@ impl<'a> BlueprintBuilder<'a> {
         let zone = BlueprintZoneConfig {
             disposition: BlueprintZoneDisposition::InService,
             id: self.rng.sled_rng(sled_id).next_zone(),
-            filesystem_pool: Some(filesystem_pool),
+            filesystem_pool,
             zone_type,
             image_source: BlueprintZoneImageSource::InstallDataset,
         };
@@ -1297,7 +1297,7 @@ impl<'a> BlueprintBuilder<'a> {
         let zone = BlueprintZoneConfig {
             disposition: BlueprintZoneDisposition::InService,
             id: self.rng.sled_rng(sled_id).next_zone(),
-            filesystem_pool: Some(filesystem_pool),
+            filesystem_pool,
             zone_type,
             image_source: BlueprintZoneImageSource::InstallDataset,
         };
@@ -1388,7 +1388,7 @@ impl<'a> BlueprintBuilder<'a> {
         let zone = BlueprintZoneConfig {
             disposition: BlueprintZoneDisposition::InService,
             id: nexus_id,
-            filesystem_pool: Some(filesystem_pool),
+            filesystem_pool,
             zone_type,
             image_source: BlueprintZoneImageSource::InstallDataset,
         };
@@ -1413,7 +1413,7 @@ impl<'a> BlueprintBuilder<'a> {
         let zone = BlueprintZoneConfig {
             disposition: BlueprintZoneDisposition::InService,
             id: oximeter_id,
-            filesystem_pool: Some(filesystem_pool),
+            filesystem_pool,
             zone_type,
             image_source: BlueprintZoneImageSource::InstallDataset,
         };
@@ -1437,7 +1437,7 @@ impl<'a> BlueprintBuilder<'a> {
         let zone = BlueprintZoneConfig {
             disposition: BlueprintZoneDisposition::InService,
             id: pantry_id,
-            filesystem_pool: Some(filesystem_pool),
+            filesystem_pool,
             zone_type,
             image_source: BlueprintZoneImageSource::InstallDataset,
         };
@@ -1471,7 +1471,7 @@ impl<'a> BlueprintBuilder<'a> {
         let zone = BlueprintZoneConfig {
             disposition: BlueprintZoneDisposition::InService,
             id: zone_id,
-            filesystem_pool: Some(filesystem_pool),
+            filesystem_pool,
             zone_type,
             image_source: BlueprintZoneImageSource::InstallDataset,
         };
@@ -1497,7 +1497,7 @@ impl<'a> BlueprintBuilder<'a> {
         let zone = BlueprintZoneConfig {
             disposition: BlueprintZoneDisposition::InService,
             id,
-            filesystem_pool: Some(pool_name),
+            filesystem_pool: pool_name,
             zone_type,
             image_source: BlueprintZoneImageSource::InstallDataset,
         };
@@ -1525,7 +1525,7 @@ impl<'a> BlueprintBuilder<'a> {
         let zone = BlueprintZoneConfig {
             disposition: BlueprintZoneDisposition::InService,
             id: zone_id,
-            filesystem_pool: Some(filesystem_pool),
+            filesystem_pool,
             zone_type,
             image_source: BlueprintZoneImageSource::InstallDataset,
         };
@@ -1553,7 +1553,7 @@ impl<'a> BlueprintBuilder<'a> {
         let zone = BlueprintZoneConfig {
             disposition: BlueprintZoneDisposition::InService,
             id: zone_id,
-            filesystem_pool: Some(filesystem_pool),
+            filesystem_pool,
             zone_type,
             image_source: BlueprintZoneImageSource::InstallDataset,
         };
@@ -1681,7 +1681,7 @@ impl<'a> BlueprintBuilder<'a> {
             BlueprintZoneConfig {
                 disposition: BlueprintZoneDisposition::InService,
                 id: new_zone_id,
-                filesystem_pool: Some(filesystem_pool),
+                filesystem_pool,
                 zone_type,
                 image_source: BlueprintZoneImageSource::InstallDataset,
             },
@@ -1797,9 +1797,7 @@ impl<'a> BlueprintBuilder<'a> {
             if let Some(zpool) = zone_config.zone_type.durable_zpool() {
                 skip_zpools.insert(zpool);
             }
-            if let Some(zpool) = &zone_config.filesystem_pool {
-                skip_zpools.insert(zpool);
-            }
+            skip_zpools.insert(&zone_config.filesystem_pool);
         }
 
         for &zpool_id in all_in_service_zpools {
@@ -2417,14 +2415,8 @@ pub mod test {
 
         for (_, sled_config) in &blueprint.sleds {
             for zone in &sled_config.zones {
-                // The pool should only be optional for backwards compatibility.
-                let filesystem_pool = zone
-                    .filesystem_pool
-                    .as_ref()
-                    .expect("Should have filesystem pool");
-
                 if let Some(durable_pool) = zone.zone_type.durable_zpool() {
-                    assert_eq!(durable_pool, filesystem_pool);
+                    assert_eq!(*durable_pool, zone.filesystem_pool);
                 }
             }
         }

--- a/nexus/reconfigurator/planning/src/blueprint_editor/allocators/external_networking.rs
+++ b/nexus/reconfigurator/planning/src/blueprint_editor/allocators/external_networking.rs
@@ -886,7 +886,7 @@ pub mod test {
             BlueprintZoneConfig {
                 disposition,
                 id,
-                filesystem_pool: Some(pool_name.clone()),
+                filesystem_pool: pool_name.clone(),
                 zone_type: BlueprintZoneType::ExternalDns(
                     blueprint_zone_type::ExternalDns {
                         dataset: OmicronZoneDataset { pool_name },

--- a/nexus/reconfigurator/planning/src/blueprint_editor/sled_editor.rs
+++ b/nexus/reconfigurator/planning/src/blueprint_editor/sled_editor.rs
@@ -20,23 +20,14 @@ use nexus_types::deployment::BlueprintZoneImageSource;
 use nexus_types::deployment::BlueprintZoneType;
 use nexus_types::deployment::blueprint_zone_type;
 use nexus_types::external_api::views::SledState;
-use nexus_types::inventory::Dataset;
-use nexus_types::inventory::Zpool;
 use omicron_common::address::Ipv6Subnet;
 use omicron_common::address::SLED_PREFIX;
 use omicron_common::api::external::Generation;
 use omicron_common::disk::DatasetKind;
-use omicron_common::disk::DatasetName;
 use omicron_uuid_kinds::DatasetUuid;
 use omicron_uuid_kinds::OmicronZoneUuid;
 use omicron_uuid_kinds::PhysicalDiskUuid;
 use omicron_uuid_kinds::ZpoolUuid;
-use slog::Logger;
-use slog::info;
-use slog::warn;
-use slog_error_chain::InlineErrorChain;
-use std::borrow::Cow;
-use std::collections::BTreeMap;
 use std::iter;
 use std::mem;
 use std::net::Ipv6Addr;
@@ -368,23 +359,6 @@ impl SledEditor {
     ) -> Result<(), SledEditError> {
         self.as_active_mut()?.ensure_datasets_for_running_zones(rng)
     }
-
-    // Apply fixes for #7229: If any zones have a missing or incorrect
-    // `filesystem_pool` property, correct it based on the inventory pools and
-    // datasets.
-    pub fn backfill_zone_filesystem_pools(
-        &mut self,
-        inventory_zpools: &[Zpool],
-        inventory_datasets: &[Dataset],
-        log: &Logger,
-    ) -> Result<(), SledEditError> {
-        self.as_active_mut()?.backfill_zone_filesystem_pools(
-            inventory_zpools,
-            inventory_datasets,
-            log,
-        );
-        Ok(())
-    }
 }
 
 #[derive(Debug)]
@@ -669,135 +643,6 @@ impl ActiveSledEditor {
                 .ensure_in_service(&mut self.datasets, rng);
         }
         Ok(())
-    }
-
-    pub fn backfill_zone_filesystem_pools(
-        &mut self,
-        inventory_zpools: &[Zpool],
-        inventory_datasets: &[Dataset],
-        log: &Logger,
-    ) {
-        let mut zones_to_edit: BTreeMap<OmicronZoneUuid, ZpoolName> =
-            BTreeMap::new();
-
-        for zone in self.zones.zones(BlueprintZoneDisposition::is_in_service) {
-            let expected_filesystem_pool = if let Some(pool) =
-                zone.zone_type.durable_zpool()
-            {
-                // Easy case: if this zone type has a durable dataset, its
-                // filesystem_pool must be on the same zpool.
-                Cow::Borrowed(pool)
-            } else {
-                // Hard case: this zone type has no durable dataset, so if
-                // its `filesystem_pool` is `None` in sled-agent's ledger,
-                // sled-agent chooses a random zpool each time it launches
-                // the zone. Look at the provided inventory collection and
-                // attempt to find that zpool. This could be fail in two
-                // ways:
-                //
-                // 1. We might not have an inventory collection for this
-                //    sled (in which case, we just skip this zone; we'll
-                //    have to backfill it during some future planning run
-                //    where we do have one)
-                // 2. sled-agent might have restarted the zone since the
-                //    inventory collection was taken and chosen a
-                //    _different_ zpool. We have no way of detecting this
-                //    now, but must be willing to overwrite a non-`None`
-                //    `filesystem_pool` value to correct ourselves if we've
-                //    hit this case (without knowing it!) in a past planner
-                //    run.
-                //
-                // We have a list of dataset names from inventory; we could
-                // try to parse those back into `DatasetName`s, but it's
-                // more straightforward to construct what this zone's
-                // `DatasetName` _would_ be (for any given zpool on the
-                // sled) and see if it's present in the inventory list. This
-                // is certainly less efficient than parsing the dataset name
-                // string, but we only have 10 zpools per sled, so shouldn't
-                // be too bad in practice.
-                let mut found_zpool = None;
-                let kind = DatasetKind::TransientZone {
-                    name: illumos_utils::zone::zone_name(
-                        zone.zone_type.kind().zone_prefix(),
-                        Some(zone.id),
-                    ),
-                };
-
-                for inv_zpool in inventory_zpools {
-                    let zpool = ZpoolName::new_external(inv_zpool.id);
-                    let dataset_name = DatasetName::new(zpool, kind.clone());
-                    let dataset_name_string = dataset_name.full_name();
-                    if inventory_datasets
-                        .iter()
-                        .any(|d| d.name == dataset_name_string)
-                    {
-                        found_zpool = Some(dataset_name.pool().clone());
-                        break;
-                    }
-                }
-
-                match found_zpool {
-                    Some(zpool) => Cow::Owned(zpool),
-                    None => {
-                        warn!(
-                            log,
-                            "could not determine expected \
-                             `filesystem_pool` for zone";
-                            "zone_id" => %zone.id,
-                            "zone_kind" => ?zone.zone_type.kind(),
-                            "current_filesystem_pool" => ?zone.filesystem_pool,
-                        );
-                        continue;
-                    }
-                }
-            };
-
-            // If the pool is already correct, we have nothing to do.
-            if zone.filesystem_pool.as_ref() == Some(&*expected_filesystem_pool)
-            {
-                continue;
-            }
-
-            info!(
-                log,
-                "updating filesystem_pool for zone";
-                "zone_id" => %zone.id,
-                "zone_kind" => ?zone.zone_type.kind(),
-                "current_filesystem_pool" => ?zone.filesystem_pool,
-                "new_filesystem_zpool" => %expected_filesystem_pool,
-            );
-
-            // If we're _correcting_ a filesystem_pool rather than just
-            // filling it in, we also need to expunge the dataset from the
-            // incorrect value.
-            if let Some(old_filesystem) = zone.filesystem_dataset() {
-                let (pool, kind) = old_filesystem.into_parts();
-                match self.datasets.expunge(&pool.id(), &kind) {
-                    Ok(()) => (),
-                    // We're trying to get rid of a potentially-orphaned
-                    // dataset; it not existing is okay but unexpected! Log
-                    // a warning but don't fail.
-                    Err(
-                        err @ DatasetsEditError::ExpungeNonexistentDataset {
-                            ..
-                        },
-                    ) => {
-                        warn!(
-                            log,
-                            "unexpected failure trying to expunge dataset";
-                            InlineErrorChain::new(&err),
-                        );
-                    }
-                }
-            }
-
-            zones_to_edit
-                .insert(zone.id, expected_filesystem_pool.into_owned());
-        }
-
-        for (zone_id, new_filesystem_zpool) in zones_to_edit {
-            self.zones.backfill_filesystem_pool(zone_id, new_filesystem_zpool);
-        }
     }
 }
 

--- a/nexus/reconfigurator/planning/src/blueprint_editor/sled_editor/zones.rs
+++ b/nexus/reconfigurator/planning/src/blueprint_editor/sled_editor/zones.rs
@@ -5,7 +5,6 @@
 use crate::blueprint_builder::EditCounts;
 use id_map::Entry;
 use id_map::IdMap;
-use illumos_utils::zpool::ZpoolName;
 use nexus_sled_agent_shared::inventory::ZoneKind;
 use nexus_types::deployment::BlueprintZoneConfig;
 use nexus_types::deployment::BlueprintZoneDisposition;
@@ -99,32 +98,6 @@ impl ZonesEditor {
                     kind2: prev.get().zone_type.kind(),
                 })
             }
-        }
-    }
-
-    /// Temporary method to backfill `filesystem_pool` properties for existing
-    /// zones.
-    ///
-    /// # Panics
-    ///
-    /// Panics if called with a nonexistent zone_id. This is not meant to be a
-    /// general-purpose method and should be removed entirely once all deployed
-    /// systems have this property backfilled successfully.
-    pub(super) fn backfill_filesystem_pool(
-        &mut self,
-        zone_id: OmicronZoneUuid,
-        filesystem_pool: ZpoolName,
-    ) {
-        let Some(mut zone) = self.zones.get_mut(&zone_id) else {
-            panic!(
-                "backfill_filesystem_pool called with \
-                 nonexistent zone id {zone_id}"
-            );
-        };
-
-        if zone.filesystem_pool.as_ref() != Some(&filesystem_pool) {
-            zone.filesystem_pool = Some(filesystem_pool);
-            self.counts.updated += 1;
         }
     }
 

--- a/nexus/reconfigurator/planning/src/blueprint_editor/sled_editor/zones.rs
+++ b/nexus/reconfigurator/planning/src/blueprint_editor/sled_editor/zones.rs
@@ -205,10 +205,7 @@ impl ZonesEditor {
             // this zpool. (If it has both, they should be on the _same_ zpool,
             // but that's not strictly required by this method - we'll expunge a
             // zone that depends on this zpool in any way.)
-            let fs_is_on_zpool = config
-                .filesystem_pool
-                .as_ref()
-                .map_or(false, |pool| pool.id() == *zpool);
+            let fs_is_on_zpool = config.filesystem_pool.id() == *zpool;
             let dd_is_on_zpool = config
                 .zone_type
                 .durable_zpool()

--- a/nexus/reconfigurator/planning/src/planner.rs
+++ b/nexus/reconfigurator/planning/src/planner.rs
@@ -4014,10 +4014,7 @@ pub(crate) mod test {
 
         // Expunge the disk used by the Nexus zone.
         let input = {
-            let nexus_zpool = nexus_config
-                .filesystem_pool
-                .as_ref()
-                .expect("Nexus has a filesystem pool");
+            let nexus_zpool = &nexus_config.filesystem_pool;
             let mut builder = input.into_builder();
             builder
                 .sleds_mut()
@@ -4198,10 +4195,7 @@ pub(crate) mod test {
 
         // Expunge the disk used by the internal DNS zone.
         let input = {
-            let internal_dns_zpool = internal_dns_config
-                .filesystem_pool
-                .as_ref()
-                .expect("internal DNS zone has a filesystem pool");
+            let internal_dns_zpool = &internal_dns_config.filesystem_pool;
             let mut builder = input.into_builder();
             builder
                 .sleds_mut()

--- a/nexus/reconfigurator/planning/src/planner.rs
+++ b/nexus/reconfigurator/planning/src/planner.rs
@@ -2256,7 +2256,7 @@ pub(crate) mod test {
         let mut zpool_by_zone_usage = HashMap::new();
         for sled in blueprint1.sleds.values() {
             for zone in &sled.zones {
-                let pool = zone.filesystem_pool.as_ref().unwrap();
+                let pool = &zone.filesystem_pool;
                 zpool_by_zone_usage
                     .entry(pool.id())
                     .and_modify(|count| *count += 1)
@@ -2408,7 +2408,7 @@ pub(crate) mod test {
             .find_map(|(_, sled_config)| {
                 for zone_config in &sled_config.zones {
                     if zone_config.zone_type.is_ntp() {
-                        return zone_config.filesystem_pool.clone();
+                        return Some(zone_config.filesystem_pool.clone());
                     }
                 }
                 None
@@ -2422,18 +2422,7 @@ pub(crate) mod test {
         for (_, zone_config) in blueprint1
             .all_omicron_zones(BlueprintZoneDisposition::is_in_service)
         {
-            let mut on_pool = false;
-            if let Some(pool) = &zone_config.filesystem_pool {
-                if pool == &pool_to_expunge {
-                    on_pool = true;
-                }
-            } else if let Some(pool) = zone_config.zone_type.durable_zpool() {
-                if pool == &pool_to_expunge {
-                    on_pool = true;
-                }
-            }
-
-            if on_pool {
+            if pool_to_expunge == zone_config.filesystem_pool {
                 zones_on_pool.insert(zone_config.id);
                 *zone_kinds_on_pool
                     .entry(zone_config.zone_type.kind())

--- a/nexus/src/app/background/tasks/blueprint_execution.rs
+++ b/nexus/src/app/background/tasks/blueprint_execution.rs
@@ -408,7 +408,7 @@ mod test {
             [BlueprintZoneConfig {
                 disposition,
                 id: zone_id,
-                filesystem_pool: Some(ZpoolName::new_external(pool_id)),
+                filesystem_pool: ZpoolName::new_external(pool_id),
                 zone_type: BlueprintZoneType::InternalDns(
                     blueprint_zone_type::InternalDns {
                         dataset: OmicronZoneDataset {

--- a/nexus/src/app/background/tasks/crdb_node_id_collector.rs
+++ b/nexus/src/app/background/tasks/crdb_node_id_collector.rs
@@ -273,7 +273,7 @@ mod tests {
             |disposition, id, addr: SocketAddrV6| BlueprintZoneConfig {
                 disposition,
                 id,
-                filesystem_pool: Some(ZpoolName::new_external(zpool_id)),
+                filesystem_pool: ZpoolName::new_external(zpool_id),
                 zone_type: BlueprintZoneType::CockroachDb(
                     blueprint_zone_type::CockroachDb {
                         address: addr,
@@ -319,7 +319,7 @@ mod tests {
         bp_sled.zones.insert(BlueprintZoneConfig {
             disposition: BlueprintZoneDisposition::InService,
             id: OmicronZoneUuid::new_v4(),
-            filesystem_pool: Some(ZpoolName::new_external(ZpoolUuid::new_v4())),
+            filesystem_pool: ZpoolName::new_external(ZpoolUuid::new_v4()),
             zone_type: BlueprintZoneType::CruciblePantry(
                 blueprint_zone_type::CruciblePantry {
                     address: "[::1]:0".parse().unwrap(),

--- a/nexus/test-utils/src/lib.rs
+++ b/nexus/test-utils/src/lib.rs
@@ -494,7 +494,7 @@ impl<'a, N: NexusServer> ControlPlaneTestContextBuilder<'a, N> {
         self.blueprint_zones.push(BlueprintZoneConfig {
             disposition: BlueprintZoneDisposition::InService,
             id: zone_id,
-            filesystem_pool: Some(ZpoolName::new_external(zpool_id)),
+            filesystem_pool: ZpoolName::new_external(zpool_id),
             zone_type: BlueprintZoneType::CockroachDb(
                 blueprint_zone_type::CockroachDb {
                     address,
@@ -545,7 +545,7 @@ impl<'a, N: NexusServer> ControlPlaneTestContextBuilder<'a, N> {
         self.blueprint_zones.push(BlueprintZoneConfig {
             disposition: BlueprintZoneDisposition::InService,
             id: zone_id,
-            filesystem_pool: Some(ZpoolName::new_external(zpool_id)),
+            filesystem_pool: ZpoolName::new_external(zpool_id),
             zone_type: BlueprintZoneType::Clickhouse(
                 blueprint_zone_type::Clickhouse {
                     address: http_address,
@@ -737,7 +737,7 @@ impl<'a, N: NexusServer> ControlPlaneTestContextBuilder<'a, N> {
         self.blueprint_zones.push(BlueprintZoneConfig {
             disposition: BlueprintZoneDisposition::InService,
             id: nexus_id,
-            filesystem_pool: Some(ZpoolName::new_external(ZpoolUuid::new_v4())),
+            filesystem_pool: ZpoolName::new_external(ZpoolUuid::new_v4()),
             zone_type: BlueprintZoneType::Nexus(blueprint_zone_type::Nexus {
                 external_dns_servers: self
                     .config
@@ -857,39 +857,35 @@ impl<'a, N: NexusServer> ControlPlaneTestContextBuilder<'a, N> {
 
                 let zones = if let Some(zones) = maybe_zones {
                     for zone in zones {
-                        if let Some(zpool) = &zone.filesystem_pool {
-                            disks.insert(BlueprintPhysicalDiskConfig {
-                                disposition:
-                                    BlueprintPhysicalDiskDisposition::InService,
-                                identity: omicron_common::disk::DiskIdentity {
-                                    vendor: "nexus-tests".to_string(),
-                                    model: "nexus-test-model".to_string(),
-                                    serial: format!(
-                                        "nexus-test-disk-{disk_index}"
-                                    ),
-                                },
-                                id: PhysicalDiskUuid::new_v4(),
-                                pool_id: zpool.id(),
-                            });
-                            disk_index += 1;
-                            let id = DatasetUuid::new_v4();
-                            datasets.insert(BlueprintDatasetConfig {
-                                disposition:
-                                    BlueprintDatasetDisposition::InService,
-                                id,
-                                pool: zpool.clone(),
-                                kind: DatasetKind::TransientZone {
-                                    name: illumos_utils::zone::zone_name(
-                                        zone.zone_type.kind().zone_prefix(),
-                                        Some(zone.id),
-                                    ),
-                                },
-                                address: None,
-                                quota: None,
-                                reservation: None,
-                                compression: CompressionAlgorithm::Off,
-                            });
-                        }
+                        let zpool = &zone.filesystem_pool;
+                        disks.insert(BlueprintPhysicalDiskConfig {
+                            disposition:
+                                BlueprintPhysicalDiskDisposition::InService,
+                            identity: omicron_common::disk::DiskIdentity {
+                                vendor: "nexus-tests".to_string(),
+                                model: "nexus-test-model".to_string(),
+                                serial: format!("nexus-test-disk-{disk_index}"),
+                            },
+                            id: PhysicalDiskUuid::new_v4(),
+                            pool_id: zpool.id(),
+                        });
+                        disk_index += 1;
+                        let id = DatasetUuid::new_v4();
+                        datasets.insert(BlueprintDatasetConfig {
+                            disposition: BlueprintDatasetDisposition::InService,
+                            id,
+                            pool: zpool.clone(),
+                            kind: DatasetKind::TransientZone {
+                                name: illumos_utils::zone::zone_name(
+                                    zone.zone_type.kind().zone_prefix(),
+                                    Some(zone.id),
+                                ),
+                            },
+                            address: None,
+                            quota: None,
+                            reservation: None,
+                            compression: CompressionAlgorithm::Off,
+                        });
                     }
                     zones.iter().cloned().collect()
                 } else {
@@ -1175,7 +1171,7 @@ impl<'a, N: NexusServer> ControlPlaneTestContextBuilder<'a, N> {
         self.blueprint_zones.push(BlueprintZoneConfig {
             disposition: BlueprintZoneDisposition::InService,
             id: zone_id,
-            filesystem_pool: Some(ZpoolName::new_external(ZpoolUuid::new_v4())),
+            filesystem_pool: ZpoolName::new_external(ZpoolUuid::new_v4()),
             zone_type: BlueprintZoneType::CruciblePantry(
                 blueprint_zone_type::CruciblePantry { address },
             ),
@@ -1217,7 +1213,7 @@ impl<'a, N: NexusServer> ControlPlaneTestContextBuilder<'a, N> {
         self.blueprint_zones.push(BlueprintZoneConfig {
             disposition: BlueprintZoneDisposition::InService,
             id: zone_id,
-            filesystem_pool: Some(ZpoolName::new_external(zpool_id)),
+            filesystem_pool: ZpoolName::new_external(zpool_id),
             zone_type: BlueprintZoneType::ExternalDns(
                 blueprint_zone_type::ExternalDns {
                     dataset: OmicronZoneDataset { pool_name },
@@ -1280,7 +1276,7 @@ impl<'a, N: NexusServer> ControlPlaneTestContextBuilder<'a, N> {
         self.blueprint_zones.push(BlueprintZoneConfig {
             disposition: BlueprintZoneDisposition::InService,
             id: zone_id,
-            filesystem_pool: Some(ZpoolName::new_external(zpool_id)),
+            filesystem_pool: ZpoolName::new_external(zpool_id),
             zone_type: BlueprintZoneType::InternalDns(
                 blueprint_zone_type::InternalDns {
                     dataset: OmicronZoneDataset { pool_name },

--- a/nexus/tests/integration_tests/schema.rs
+++ b/nexus/tests/integration_tests/schema.rs
@@ -1596,6 +1596,15 @@ fn before_125_0_0<'a>(ctx: &'a MigrationContext<'a>) -> BoxFuture<'a, ()> {
         let expunged_zone_id: Uuid =
             "00000002-0000-0000-0000-000000000000".parse().unwrap();
 
+        // Fill in a filesystem pool for each zone. This column was NULLable
+        // prior to schema version 132.0.0, but became NOT NULL in that version,
+        // so it's simplest to go ahead and populate it here (otherwise our test
+        // migration to 132 will fail). Operationally, we confirmed via omdb
+        // that all deployed systems had non-NULL filesystem_pool values prior
+        // to upgrading to 132.
+        let filesystem_pool: Uuid =
+            "00000000-0000-0000-0000-0000706f6f6c".parse().unwrap();
+
         for bp_id in [bp1_id, bp2_id] {
             for (zone_id, disposition) in [
                 (in_service_zone_id, "in_service"),
@@ -1611,6 +1620,7 @@ fn before_125_0_0<'a>(ctx: &'a MigrationContext<'a>) -> BoxFuture<'a, ()> {
                             zone_type,
                             primary_service_ip,
                             primary_service_port,
+                            filesystem_pool,
                             disposition
                         ) VALUES (
                             '{bp_id}',
@@ -1619,6 +1629,7 @@ fn before_125_0_0<'a>(ctx: &'a MigrationContext<'a>) -> BoxFuture<'a, ()> {
                             'oximeter',
                             '::1',
                             0,
+                            '{filesystem_pool}',
                             '{disposition}'
                         );
                     "

--- a/nexus/types/src/deployment.rs
+++ b/nexus/types/src/deployment.rs
@@ -734,7 +734,7 @@ pub struct BlueprintZoneConfig {
 
     pub id: OmicronZoneUuid,
     /// zpool used for the zone's (transient) root filesystem
-    pub filesystem_pool: Option<ZpoolName>,
+    pub filesystem_pool: ZpoolName,
     pub zone_type: BlueprintZoneType,
     pub image_source: BlueprintZoneImageSource,
 }
@@ -757,14 +757,13 @@ impl BlueprintZoneConfig {
     }
 
     /// Returns the dataset used for the the zone's (transient) root filesystem.
-    pub fn filesystem_dataset(&self) -> Option<DatasetName> {
-        let pool_name = self.filesystem_pool.clone()?;
+    pub fn filesystem_dataset(&self) -> DatasetName {
         let name = illumos_utils::zone::zone_name(
             self.zone_type.kind().zone_prefix(),
             Some(self.id),
         );
         let kind = DatasetKind::TransientZone { name };
-        Some(DatasetName::new(pool_name, kind))
+        DatasetName::new(self.filesystem_pool.clone(), kind)
     }
 
     pub fn kind(&self) -> ZoneKind {
@@ -783,7 +782,7 @@ impl From<BlueprintZoneConfig> for OmicronZoneConfig {
         } = z;
         Self {
             id,
-            filesystem_pool,
+            filesystem_pool: Some(z.filesystem_pool),
             zone_type: zone_type.into(),
             image_source: image_source.into(),
         }

--- a/nexus/types/src/deployment.rs
+++ b/nexus/types/src/deployment.rs
@@ -782,7 +782,7 @@ impl From<BlueprintZoneConfig> for OmicronZoneConfig {
         } = z;
         Self {
             id,
-            filesystem_pool: Some(z.filesystem_pool),
+            filesystem_pool: Some(filesystem_pool),
             zone_type: zone_type.into(),
             image_source: image_source.into(),
         }

--- a/nexus/types/src/deployment/blueprint_diff.rs
+++ b/nexus/types/src/deployment/blueprint_diff.rs
@@ -533,7 +533,7 @@ impl ModifiedZone {
                 zone: BlueprintZoneConfig {
                     disposition: *diff.disposition.after,
                     id: *diff.id.after,
-                    filesystem_pool: diff.filesystem_pool.after.cloned(),
+                    filesystem_pool: diff.filesystem_pool.after.clone(),
                     zone_type: diff.zone_type.after.clone(),
                     image_source: diff.image_source.after.clone(),
                 },

--- a/openapi/nexus-internal.json
+++ b/openapi/nexus-internal.json
@@ -2272,7 +2272,6 @@
             ]
           },
           "filesystem_pool": {
-            "nullable": true,
             "description": "zpool used for the zone's (transient) root filesystem",
             "allOf": [
               {
@@ -2292,6 +2291,7 @@
         },
         "required": [
           "disposition",
+          "filesystem_pool",
           "id",
           "image_source",
           "zone_type"

--- a/schema/crdb/bp-omicron-zone-filesystem-pool-not-null/up.sql
+++ b/schema/crdb/bp-omicron-zone-filesystem-pool-not-null/up.sql
@@ -1,0 +1,7 @@
+-- This migration will fail if there are any remaining bp_omicron_zone entries
+-- with a NULL filesystem_pool. We've confirmed via the `omdb reconfigurator
+-- archive` outputs from R13 upgrades that all deployed systems have
+-- fully-populated `filesystem_pool` values.
+ALTER TABLE omicron.public.bp_omicron_zone
+    ALTER COLUMN filesystem_pool
+    SET NOT NULL;

--- a/schema/crdb/dbinit.sql
+++ b/schema/crdb/dbinit.sql
@@ -3996,9 +3996,7 @@ CREATE TABLE IF NOT EXISTS omicron.public.bp_omicron_zone (
     -- created yet.
     external_ip_id UUID,
 
-    -- TODO: This is nullable for backwards compatibility.
-    -- Eventually, that nullability should be removed.
-    filesystem_pool UUID,
+    filesystem_pool UUID NOT NULL,
 
     -- Zone disposition
     disposition omicron.public.bp_zone_disposition NOT NULL,
@@ -5003,7 +5001,7 @@ INSERT INTO omicron.public.db_metadata (
     version,
     target_version
 ) VALUES
-    (TRUE, NOW(), NOW(), '131.0.0', NULL)
+    (TRUE, NOW(), NOW(), '132.0.0', NULL)
 ON CONFLICT DO NOTHING;
 
 COMMIT;

--- a/sled-agent/src/rack_setup/plan/service.rs
+++ b/sled-agent/src/rack_setup/plan/service.rs
@@ -111,7 +111,7 @@ impl SledConfig {
     /// durable datasets.
     pub fn add_zone_and_datasets(&mut self, zone: BlueprintZoneConfig) {
         let fs_dataset_name = DatasetName::new(
-            zone.filesystem_pool.clone().expect("Missing pool"),
+            zone.filesystem_pool.clone(),
             DatasetKind::TransientZone {
                 name: illumos_utils::zone::zone_name(
                     zone.zone_type.kind().zone_prefix(),
@@ -409,7 +409,7 @@ impl Plan {
                 .unwrap();
             let dataset_name =
                 sled.alloc_dataset_from_u2s(DatasetKind::InternalDns)?;
-            let filesystem_pool = Some(dataset_name.pool().clone());
+            let filesystem_pool = dataset_name.pool().clone();
 
             sled.request.add_zone_and_datasets(BlueprintZoneConfig {
                 disposition: BlueprintZoneDisposition::InService,
@@ -446,7 +446,7 @@ impl Plan {
                 .unwrap();
             let dataset_name =
                 sled.alloc_dataset_from_u2s(DatasetKind::Cockroach)?;
-            let filesystem_pool = Some(dataset_name.pool().clone());
+            let filesystem_pool = dataset_name.pool().clone();
             sled.request.add_zone_and_datasets(BlueprintZoneConfig {
                 disposition: BlueprintZoneDisposition::InService,
                 id,
@@ -494,7 +494,7 @@ impl Plan {
             );
             let dataset_kind = DatasetKind::ExternalDns;
             let dataset_name = sled.alloc_dataset_from_u2s(dataset_kind)?;
-            let filesystem_pool = Some(dataset_name.pool().clone());
+            let filesystem_pool = dataset_name.pool().clone();
 
             sled.request.add_zone_and_datasets(BlueprintZoneConfig {
                 disposition: BlueprintZoneDisposition::InService,
@@ -533,7 +533,7 @@ impl Plan {
                 )
                 .unwrap();
             let (nic, external_ip) = svc_port_builder.next_nexus(id)?;
-            let filesystem_pool = Some(sled.alloc_zpool_from_u2s()?);
+            let filesystem_pool = sled.alloc_zpool_from_u2s()?;
             sled.request.add_zone_and_datasets(BlueprintZoneConfig {
                 disposition: BlueprintZoneDisposition::InService,
                 id,
@@ -578,7 +578,7 @@ impl Plan {
             dns_builder
                 .host_zone_with_one_backend(id, ServiceName::Oximeter, address)
                 .unwrap();
-            let filesystem_pool = Some(sled.alloc_zpool_from_u2s()?);
+            let filesystem_pool = sled.alloc_zpool_from_u2s()?;
             sled.request.add_zone_and_datasets(BlueprintZoneConfig {
                 disposition: BlueprintZoneDisposition::InService,
                 id,
@@ -611,7 +611,7 @@ impl Plan {
                 .unwrap();
             let dataset_name =
                 sled.alloc_dataset_from_u2s(DatasetKind::Clickhouse)?;
-            let filesystem_pool = Some(dataset_name.pool().clone());
+            let filesystem_pool = dataset_name.pool().clone();
             sled.request.add_zone_and_datasets(BlueprintZoneConfig {
                 disposition: BlueprintZoneDisposition::InService,
                 id,
@@ -640,7 +640,7 @@ impl Plan {
             let port = omicron_common::address::CRUCIBLE_PANTRY_PORT;
             let address = SocketAddrV6::new(ip, port, 0, 0);
             let id = OmicronZoneUuid::new_v4();
-            let filesystem_pool = Some(sled.alloc_zpool_from_u2s()?);
+            let filesystem_pool = sled.alloc_zpool_from_u2s()?;
             dns_builder
                 .host_zone_with_one_backend(
                     id,
@@ -686,7 +686,7 @@ impl Plan {
                             },
                         },
                     ),
-                    filesystem_pool: Some(pool.clone()),
+                    filesystem_pool: pool.clone(),
                     image_source: BlueprintZoneImageSource::InstallDataset,
                 });
             }
@@ -700,7 +700,7 @@ impl Plan {
             let id = OmicronZoneUuid::new_v4();
             let ip = sled.addr_alloc.next().expect("Not enough addrs");
             let ntp_address = SocketAddrV6::new(ip, NTP_PORT, 0, 0);
-            let filesystem_pool = Some(sled.alloc_zpool_from_u2s()?);
+            let filesystem_pool = sled.alloc_zpool_from_u2s()?;
 
             let (zone_type, svcname) = if idx < BOUNDARY_NTP_REDUNDANCY {
                 boundary_ntp_servers

--- a/sled-agent/src/sim/server.rs
+++ b/sled-agent/src/sim/server.rs
@@ -404,7 +404,7 @@ pub async fn run_standalone_server(
             },
         ),
         // Co-locate the filesystem pool with the dataset
-        filesystem_pool: Some(pool_name),
+        filesystem_pool: pool_name,
         image_source: BlueprintZoneImageSource::InstallDataset,
     });
 
@@ -443,7 +443,7 @@ pub async fn run_standalone_server(
                 external_tls: false,
                 external_dns_servers: vec![],
             }),
-            filesystem_pool: Some(get_random_zpool()),
+            filesystem_pool: get_random_zpool(),
             image_source: BlueprintZoneImageSource::InstallDataset,
         });
 
@@ -495,7 +495,7 @@ pub async fn run_standalone_server(
                 },
             ),
             // Co-locate the filesystem pool with the dataset
-            filesystem_pool: Some(pool_name),
+            filesystem_pool: pool_name,
             image_source: BlueprintZoneImageSource::InstallDataset,
         });
 


### PR DESCRIPTION
~~This cannot be merged until R13 has shipped, updates have been performed, and we've confirmed that all `filesystem_pool` properties have been properly backfilled. I'm opening this to (a) remind myself to check all of that and merge this in the future and (b) make sure it passes CI.~~ 

This PR:

* Removes the code paths in the planner that backfill optional `filesystem_pool` properties that are set to `None`
* Makes `filesystem_pool` non-optional in blueprints (it's still optional in `OmicronZoneConfig`; I _think_ fixing that is more trouble than it's worth at the moment)

~~If we did not fully backfill all `filesystem_pool` properties during R13 or if R13 failed to delete old blueprints where `filesystem_pool` was `None` during the blueprint archival process, merging this will cause schema migrations to fail, since it sets `NOT NULL` on the `filesystem_pool` column.~~

Edit: Most R13 upgrades are complete, and all systems that needed these fixups have received them.