### PR TITLE
[reconfigurator] Replace `todo!`s with error returns

### DIFF
--- a/nexus/reconfigurator/planning/src/blueprint_builder/builder.rs
+++ b/nexus/reconfigurator/planning/src/blueprint_builder/builder.rs
@@ -925,13 +925,23 @@ impl<'a> BlueprintBuilder<'a> {
             match zone.disposition {
                 BlueprintZoneDisposition::Expunged => (),
                 BlueprintZoneDisposition::InService
-                | BlueprintZoneDisposition::Quiesced => todo!("fixme-1"),
+                | BlueprintZoneDisposition::Quiesced => {
+                    return Err(Error::Planner(anyhow!(
+                        "expunged all disks but a zone \
+                         is still in service: {zone:?}"
+                    )));
+                }
             }
         }
         for dataset in editor.datasets(BlueprintDatasetFilter::All) {
             match dataset.disposition {
                 BlueprintDatasetDisposition::Expunged => (),
-                BlueprintDatasetDisposition::InService => todo!("fixme-2"),
+                BlueprintDatasetDisposition::InService => {
+                    return Err(Error::Planner(anyhow!(
+                        "expunged all disks but a dataset \
+                         is still in service: {dataset:?}"
+                    )));
+                }
             }
         }
 


### PR DESCRIPTION
These were supposed to be fixed before merging #7495, but were not.

Both of these are of the flavor "should never happen unless there's an internal bug" and could arguably be `debug_assert`s, but having the option for Nexus panics due to internal bugs here is not awesome.