### PR TITLE
Simplify system internet gateway targets

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4516,6 +4516,7 @@ dependencies = [
  "macaddr",
  "mockall",
  "omicron-common",
+ "omicron-test-utils",
  "omicron-uuid-kinds",
  "omicron-workspace-hack",
  "opte-ioctl",

--- a/common/src/api/internal/shared.rs
+++ b/common/src/api/internal/shared.rs
@@ -822,14 +822,26 @@ pub struct DhcpConfig {
 
 /// The target for a given router entry.
 #[derive(
-    Clone, Debug, Deserialize, Serialize, JsonSchema, PartialEq, Eq, Hash,
+    Copy, Clone, Debug, Deserialize, Serialize, JsonSchema, PartialEq, Eq, Hash,
 )]
 #[serde(tag = "type", rename_all = "snake_case", content = "value")]
 pub enum RouterTarget {
     Drop,
-    InternetGateway(Option<Uuid>),
+    InternetGateway(InternetGatewayRouterTarget),
     Ip(IpAddr),
     VpcSubnet(IpNet),
+}
+
+/// An Internet Gateway router target.
+#[derive(
+    Copy, Clone, Debug, Deserialize, Eq, Hash, JsonSchema, PartialEq, Serialize,
+)]
+#[serde(tag = "type", content = "value", rename_all = "snake_case")]
+pub enum InternetGatewayRouterTarget {
+    /// Targets the gateway for the system-internal services VPC.
+    System,
+    /// Targets a gateway for an instance's VPC.
+    Instance(Uuid),
 }
 
 /// Information on the current parent router (and version) of a route set

--- a/illumos-utils/Cargo.toml
+++ b/illumos-utils/Cargo.toml
@@ -48,6 +48,7 @@ omicron-workspace-hack.workspace = true
 opte-ioctl.workspace = true
 
 [dev-dependencies]
+omicron-test-utils.workspace = true
 mockall.workspace = true
 regress.workspace = true
 serde_json.workspace = true

--- a/illumos-utils/Cargo.toml
+++ b/illumos-utils/Cargo.toml
@@ -48,8 +48,8 @@ omicron-workspace-hack.workspace = true
 opte-ioctl.workspace = true
 
 [dev-dependencies]
-omicron-test-utils.workspace = true
 mockall.workspace = true
+omicron-test-utils.workspace = true
 regress.workspace = true
 serde_json.workspace = true
 toml.workspace = true

--- a/illumos-utils/src/opte/illumos.rs
+++ b/illumos-utils/src/opte/illumos.rs
@@ -8,6 +8,7 @@ use crate::addrobj::AddrObject;
 use crate::dladm;
 use camino::Utf8Path;
 use omicron_common::api::internal::shared::NetworkInterfaceKind;
+use opte_ioctl::Error as OpteError;
 use opte_ioctl::OpteHdl;
 use slog::info;
 use slog::Logger;
@@ -63,7 +64,7 @@ pub enum Error {
 
 /// Delete all xde devices on the system.
 pub fn delete_all_xde_devices(log: &Logger) -> Result<(), Error> {
-    let hdl = OpteHdl::open(OpteHdl::XDE_CTL)?;
+    let hdl = Handle::new()?;
     for port_info in hdl.list_ports()?.ports.into_iter() {
         let name = &port_info.name;
         info!(
@@ -103,7 +104,7 @@ pub fn initialize_xde_driver(
             String::from(MESSAGE),
         )));
     }
-    match OpteHdl::open(OpteHdl::XDE_CTL)?.set_xde_underlay(
+    match Handle::new()?.set_xde_underlay(
         underlay_nics[0].interface(),
         underlay_nics[1].interface(),
     ) {
@@ -129,5 +130,26 @@ pub fn initialize_xde_driver(
             opte_ioctl::OpteError::System { errno: libc::EEXIST, .. },
         )) => Ok(()),
         Err(e) => Err(e.into()),
+    }
+}
+
+/// Handle to the OPTE kernel driver.
+pub struct Handle {
+    inner: OpteHdl,
+}
+
+impl Handle {
+    /// Construct a new handle to the OPTE kernel driver.
+    pub fn new() -> Result<Self, OpteError> {
+        OpteHdl::open(OpteHdl::XDE_CTL).map(|inner| Self { inner })
+    }
+}
+
+// This deref impl lets us use the actual API of `OpteHdl`.
+impl std::ops::Deref for Handle {
+    type Target = OpteHdl;
+
+    fn deref(&self) -> &Self::Target {
+        &self.inner
     }
 }

--- a/illumos-utils/src/opte/mod.rs
+++ b/illumos-utils/src/opte/mod.rs
@@ -87,22 +87,21 @@ fn net_to_cidr(net: IpNet) -> IpCidr {
 
 /// Convert a nexus `RouterTarget` to an OPTE `RouterTarget`.
 ///
-/// Currently, we strip InternetGateway IDs from any routes targeting
-/// non-instance NICs, because we need to actively store the full set
-/// (and division of) SNAT/ephemeral/floating IPs.
-/// Sled-agent only holds this today for instances, because these are
-/// reconfigurable at run-time (whereas services and probes are fixed).
-fn router_target_opte(
-    target: &shared::RouterTarget,
-    is_instance: bool,
-) -> RouterTarget {
+/// This is effectively a `From` impl, but defined for two out-of-crate types.
+/// We map internet gateways that target the (single) "system" VPC IG to
+/// `InternetGateway(None)`. Everything else is mapped directly, translating IP
+/// address types as needed.
+fn router_target_opte(target: &shared::RouterTarget) -> RouterTarget {
+    use shared::InternetGatewayRouterTarget;
     use shared::RouterTarget::*;
     match target {
         Drop => RouterTarget::Drop,
-        InternetGateway(id) if is_instance => {
-            RouterTarget::InternetGateway(*id)
+        InternetGateway(InternetGatewayRouterTarget::System) => {
+            RouterTarget::InternetGateway(None)
         }
-        InternetGateway(_) => RouterTarget::InternetGateway(None),
+        InternetGateway(InternetGatewayRouterTarget::Instance(id)) => {
+            RouterTarget::InternetGateway(Some(*id))
+        }
         Ip(ip) => RouterTarget::Ip((*ip).into()),
         VpcSubnet(net) => RouterTarget::VpcSubnet(net_to_cidr(*net)),
     }

--- a/illumos-utils/src/opte/mod.rs
+++ b/illumos-utils/src/opte/mod.rs
@@ -3,7 +3,7 @@
 // file, You can obtain one at https://mozilla.org/MPL/2.0/.
 
 cfg_if::cfg_if! {
-    if #[cfg(target_os = "illumos")] {
+    if #[cfg(all(target_os = "illumos", not(test)))] {
         mod illumos;
         pub use illumos::*;
     } else {

--- a/illumos-utils/src/opte/non_illumos.rs
+++ b/illumos-utils/src/opte/non_illumos.rs
@@ -4,14 +4,41 @@
 
 //! Mock / dummy versions of the OPTE module, for non-illumos platforms
 
-use slog::Logger;
-
 use crate::addrobj::AddrObject;
 use omicron_common::api::internal::shared::NetworkInterfaceKind;
+use oxide_vpc::api::AddRouterEntryReq;
+use oxide_vpc::api::ClearVirt2PhysReq;
+use oxide_vpc::api::DelRouterEntryReq;
+use oxide_vpc::api::DhcpCfg;
+use oxide_vpc::api::Direction;
+use oxide_vpc::api::DumpVirt2PhysReq;
+use oxide_vpc::api::DumpVirt2PhysResp;
+use oxide_vpc::api::IpCfg;
+use oxide_vpc::api::IpCidr;
+use oxide_vpc::api::Ipv4Addr;
+use oxide_vpc::api::Ipv4Cidr;
+use oxide_vpc::api::ListPortsResp;
+use oxide_vpc::api::NoResp;
+use oxide_vpc::api::PortInfo;
+use oxide_vpc::api::RouterClass;
+use oxide_vpc::api::RouterTarget;
+use oxide_vpc::api::SetExternalIpsReq;
+use oxide_vpc::api::SetFwRulesReq;
+use oxide_vpc::api::SetVirt2PhysReq;
+use oxide_vpc::api::VpcCfg;
+use slog::Logger;
+use std::collections::HashMap;
 use std::net::IpAddr;
+use std::sync::Mutex;
+use std::sync::OnceLock;
+
+type OpteError = anyhow::Error;
 
 #[derive(thiserror::Error, Debug)]
 pub enum Error {
+    #[error("Failure interacting with the dummy OPTE implementation")]
+    Opte(#[from] OpteError),
+
     #[error("Invalid IP configuration for port")]
     InvalidPortIpConfig,
 
@@ -42,4 +69,269 @@ pub fn initialize_xde_driver(
 pub fn delete_all_xde_devices(log: &Logger) -> Result<(), Error> {
     slog::warn!(log, "`xde` driver is a fiction on non-illumos systems");
     Ok(())
+}
+
+#[derive(Debug)]
+pub(crate) struct RouteInfo {
+    pub dest: IpCidr,
+    pub target: RouterTarget,
+    pub class: RouterClass,
+}
+
+impl PartialEq for RouteInfo {
+    fn eq(&self, other: &Self) -> bool {
+        if self.dest != other.dest {
+            return false;
+        }
+        match (self.class, other.class) {
+            (RouterClass::System, RouterClass::Custom) => return false,
+            (RouterClass::Custom, RouterClass::System) => return false,
+            (_, _) => {}
+        }
+        match (self.target, other.target) {
+            (RouterTarget::Drop, RouterTarget::Drop) => true,
+            (
+                RouterTarget::InternetGateway(id0),
+                RouterTarget::InternetGateway(id1),
+            ) => id0 == id1,
+            (RouterTarget::Ip(ip0), RouterTarget::Ip(ip1)) => ip0 == ip1,
+            (
+                RouterTarget::VpcSubnet(cidr0),
+                RouterTarget::VpcSubnet(cidr1),
+            ) => cidr0 == cidr1,
+            (_, _) => false,
+        }
+    }
+}
+
+impl RouteInfo {
+    #[allow(dead_code)]
+    pub fn is_system_default_ipv4_route(&self) -> bool {
+        if self.dest
+            != IpCidr::Ip4(Ipv4Cidr::new(
+                Ipv4Addr::ANY_ADDR,
+                0.try_into().unwrap(),
+            ))
+        {
+            return false;
+        }
+        if !matches!(self.target, RouterTarget::InternetGateway(None)) {
+            return false;
+        }
+        matches!(self.class, RouterClass::System)
+    }
+}
+
+impl From<&AddRouterEntryReq> for RouteInfo {
+    fn from(value: &AddRouterEntryReq) -> Self {
+        Self { dest: value.dest, target: value.target, class: value.class }
+    }
+}
+impl From<&DelRouterEntryReq> for RouteInfo {
+    fn from(value: &DelRouterEntryReq) -> Self {
+        Self { dest: value.dest, target: value.target, class: value.class }
+    }
+}
+
+/// Data for one OPTE port
+#[derive(Debug)]
+pub(crate) struct PortData {
+    /// The OPTE-layer information
+    #[cfg_attr(test, allow(dead_code))]
+    pub port: PortInfo,
+    /// The routes for this port. This simulates the router layer.
+    pub routes: Vec<RouteInfo>,
+}
+
+#[derive(Debug)]
+pub(crate) struct State {
+    pub ports: HashMap<String, PortData>,
+    pub underlay_initialized: bool,
+}
+
+const NO_RESPONSE: NoResp = NoResp { unused: 99 };
+static OPTE_STATE: OnceLock<Mutex<State>> = OnceLock::new();
+
+fn opte_state() -> &'static Mutex<State> {
+    OPTE_STATE.get_or_init(|| {
+        Mutex::new(State { ports: HashMap::new(), underlay_initialized: true })
+    })
+}
+
+/// Simulated handle to OPTE
+pub struct Handle;
+
+impl Handle {
+    /// Create a new handle to the test OPTE kernel module.
+    pub fn new() -> Result<Self, OpteError> {
+        Ok(Self)
+    }
+
+    /// Helper to get the OPTE state.
+    #[cfg(test)]
+    pub(crate) fn state(&self) -> &'static Mutex<State> {
+        opte_state()
+    }
+
+    /// Add a new port.
+    pub fn create_xde(
+        &self,
+        name: &str,
+        cfg: VpcCfg,
+        _: DhcpCfg,
+        _: bool,
+    ) -> Result<NoResp, OpteError> {
+        let name = name.to_string();
+        let IpCfg::Ipv4(ip_cfg) = cfg.ip_cfg else {
+            unimplemented!("IPv6 support");
+        };
+        let ephemeral_ip4_addr =
+            ip_cfg.external_ips.snat.as_ref().map(|snat| snat.external_ip);
+        let port = PortInfo {
+            name: name.clone(),
+            mac_addr: cfg.guest_mac,
+            ip4_addr: Some(ip_cfg.private_ip),
+            ephemeral_ip4_addr,
+            floating_ip4_addrs: None,
+            ip6_addr: None,
+            ephemeral_ip6_addr: None,
+            floating_ip6_addrs: None,
+            state: "created".to_string(),
+        };
+        let mut state = opte_state().lock().unwrap();
+        anyhow::ensure!(
+            state.underlay_initialized,
+            "Underlay is not initialized"
+        );
+        assert!(
+            state
+                .ports
+                .insert(name, PortData { port, routes: Vec::new() })
+                .is_none(),
+            "duplicate OPTE ports"
+        );
+        Ok(NO_RESPONSE)
+    }
+
+    pub fn delete_xde(&self, name: &str) -> Result<NoResp, OpteError> {
+        let _ = opte_state().lock().unwrap().ports.remove(name);
+        Ok(NO_RESPONSE)
+    }
+
+    /// Set new firewall rules.
+    pub fn set_fw_rules(&self, _: &SetFwRulesReq) -> Result<NoResp, OpteError> {
+        Ok(NO_RESPONSE)
+    }
+
+    /// Add a new router entry to OPTE.
+    pub fn add_router_entry(
+        &self,
+        req: &AddRouterEntryReq,
+    ) -> Result<NoResp, OpteError> {
+        let mut inner = opte_state().lock().unwrap();
+        let Some(PortData { routes, .. }) = inner.ports.get_mut(&req.port_name)
+        else {
+            anyhow::bail!("No such port '{}'", req.port_name);
+        };
+        routes.push(req.into());
+        Ok(NO_RESPONSE)
+    }
+
+    /// Allow traffic to / from a CIDR block on a port.
+    pub fn allow_cidr(
+        &self,
+        _: &str,
+        _: IpCidr,
+        _: Direction,
+    ) -> Result<NoResp, OpteError> {
+        todo!()
+    }
+
+    /// Delete a router entry from a port.
+    pub fn del_router_entry(
+        &self,
+        req: &DelRouterEntryReq,
+    ) -> Result<NoResp, OpteError> {
+        let mut inner = opte_state().lock().unwrap();
+        let Some(PortData { routes, .. }) = inner.ports.get_mut(&req.port_name)
+        else {
+            anyhow::bail!("No such port '{}'", req.port_name);
+        };
+        let req = RouteInfo::from(req);
+        if let Some(index) = routes.iter().position(|rt| rt == &req) {
+            routes.remove(index);
+        }
+        Ok(NO_RESPONSE)
+    }
+
+    /// Set the external IPs in use by a port.
+    pub fn set_external_ips(
+        &self,
+        _: &SetExternalIpsReq,
+    ) -> Result<NoResp, OpteError> {
+        unimplemented!("Not yet used in tests")
+    }
+
+    /// Set a mapping from a virtual NIC to a physical host.
+    pub fn set_v2p(&self, _: &SetVirt2PhysReq) -> Result<NoResp, OpteError> {
+        unimplemented!("Not yet used in tests")
+    }
+
+    /// Dump a mapping from a virtual NIC to a physical host.
+    pub fn dump_v2p(
+        &self,
+        _: &DumpVirt2PhysReq,
+    ) -> Result<DumpVirt2PhysResp, OpteError> {
+        unimplemented!("Not yet used in tests")
+    }
+
+    /// Clear a mapping from a virtual NIC to a physical host.
+    pub fn clear_v2p(
+        &self,
+        _: &ClearVirt2PhysReq,
+    ) -> Result<NoResp, OpteError> {
+        unimplemented!("Not yet used in tests")
+    }
+
+    /// List ports on the current system.
+    #[allow(dead_code)]
+    pub(crate) fn list_ports(&self) -> Result<ListPortsResp, OpteError> {
+        let ports = opte_state()
+            .lock()
+            .unwrap()
+            .ports
+            .values()
+            .map(|data| {
+                let info = &data.port;
+                PortInfo {
+                    name: info.name.clone(),
+                    mac_addr: info.mac_addr,
+                    ip4_addr: info.ip4_addr,
+                    ephemeral_ip4_addr: info.ephemeral_ip4_addr,
+                    floating_ip4_addrs: info.floating_ip4_addrs.clone(),
+                    ip6_addr: info.ip6_addr,
+                    ephemeral_ip6_addr: info.ephemeral_ip6_addr,
+                    floating_ip6_addrs: info.floating_ip6_addrs.clone(),
+                    state: info.state.clone(),
+                }
+            })
+            .collect();
+        Ok(ListPortsResp { ports })
+    }
+
+    /// Set the underlay devices on the system.
+    #[allow(dead_code)]
+    pub(crate) fn set_xde_underlay(
+        &self,
+        _: &str,
+        _: &str,
+    ) -> Result<NoResp, OpteError> {
+        let mut state = opte_state().lock().unwrap();
+        anyhow::ensure!(
+            !state.underlay_initialized,
+            "Underlay is already initialized"
+        );
+        state.underlay_initialized = true;
+        Ok(NO_RESPONSE)
+    }
 }

--- a/illumos-utils/src/opte/non_illumos.rs
+++ b/illumos-utils/src/opte/non_illumos.rs
@@ -15,8 +15,6 @@ use oxide_vpc::api::DumpVirt2PhysReq;
 use oxide_vpc::api::DumpVirt2PhysResp;
 use oxide_vpc::api::IpCfg;
 use oxide_vpc::api::IpCidr;
-use oxide_vpc::api::Ipv4Addr;
-use oxide_vpc::api::Ipv4Cidr;
 use oxide_vpc::api::ListPortsResp;
 use oxide_vpc::api::NoResp;
 use oxide_vpc::api::PortInfo;
@@ -123,8 +121,8 @@ impl RouteInfo {
     #[cfg(test)]
     pub fn is_system_default_ipv4_route(&self) -> bool {
         let system_default_route = RouteInfo {
-            dest: IpCidr::Ip4(Ipv4Cidr::new(
-                Ipv4Addr::ANY_ADDR,
+            dest: IpCidr::Ip4(oxide_vpc::api::Ipv4Cidr::new(
+                oxide_vpc::api::Ipv4Addr::ANY_ADDR,
                 0.try_into().unwrap(),
             )),
             target: RouterTarget::InternetGateway(None),

--- a/illumos-utils/src/opte/port.rs
+++ b/illumos-utils/src/opte/port.rs
@@ -5,6 +5,7 @@
 //! A single port on the OPTE virtual switch.
 
 use crate::opte::Gateway;
+use crate::opte::Handle;
 use crate::opte::Vni;
 use macaddr::MacAddr6;
 use omicron_common::api::external;
@@ -43,11 +44,9 @@ impl core::ops::Deref for PortInner {
     }
 }
 
-#[cfg(target_os = "illumos")]
 impl Drop for PortInner {
     fn drop(&mut self) {
-        let err = match opte_ioctl::OpteHdl::open(opte_ioctl::OpteHdl::XDE_CTL)
-        {
+        let err = match Handle::new() {
             Ok(hdl) => {
                 if let Err(e) = hdl.delete_xde(&self.name) {
                     e

--- a/openapi/sled-agent.json
+++ b/openapi/sled-agent.json
@@ -4104,6 +4104,46 @@
           "ncpus"
         ]
       },
+      "InternetGatewayRouterTarget": {
+        "description": "An Internet Gateway router target.",
+        "oneOf": [
+          {
+            "description": "Targets the gateway for the system-internal services VPC.",
+            "type": "object",
+            "properties": {
+              "type": {
+                "type": "string",
+                "enum": [
+                  "system"
+                ]
+              }
+            },
+            "required": [
+              "type"
+            ]
+          },
+          {
+            "description": "Targets a gateway for an instance's VPC.",
+            "type": "object",
+            "properties": {
+              "type": {
+                "type": "string",
+                "enum": [
+                  "instance"
+                ]
+              },
+              "value": {
+                "type": "string",
+                "format": "uuid"
+              }
+            },
+            "required": [
+              "type",
+              "value"
+            ]
+          }
+        ]
+      },
       "Inventory": {
         "description": "Identity and basic status information about this sled agent",
         "type": "object",
@@ -5506,9 +5546,7 @@
                 ]
               },
               "value": {
-                "nullable": true,
-                "type": "string",
-                "format": "uuid"
+                "$ref": "#/components/schemas/InternetGatewayRouterTarget"
               }
             },
             "required": [


### PR DESCRIPTION
This PR is best viewed as two commits. The first does a bit of cleanup around platform-specific code to make it easier to test our OPTE `PortManager`, and then introduces a regression test for #7541. That test sets up the specific sequence of events we believe triggers the issue, which is due to incoherent state between the routes the `PortManager` believes it has and those it's actually applied in OPTE. This commit also includes commented-out code that _passes_ -- that's useful for showing the current (incorrect) behavior, and for writing the test itself.

The second commit fixes #7541, by simplifying how we refer to routes that target an Internet Gateway. Rather than allow an optional ID of the gateway, we make explicit that we're targeting either the builtin services VPC's internet gateway or a customer / instance VPC's gateway. In the latter, we always include the ID of the gateway, which is how it's currently used on `main` anyway.

In the former, we _never_ include the ID. During bootstrapping of the system (e.g., NTP sync), we don't know the gateway's ID yet, because it's part of the "fixed database data" that we only learn after starting up Nexus. And even when we do learn the ID, it's a static, fixed ID and there's only one of them, so it's not particularly useful. But by removing the ID, we ensure that our logic in the `PortManager` for deciding what new routes to apply or remove on a notification from Nexus, we don't confuse ourselves by making the (useless) distinction between a route targeting the services VPC Internet Gateway just because one request has an ID and the other does not.