### PR TITLE
add image source to `OmicronZoneConfig`

### DIFF
--- a/nexus-sled-agent-shared/src/inventory.rs
+++ b/nexus-sled-agent-shared/src/inventory.rs
@@ -161,6 +161,9 @@ pub struct OmicronZoneConfig {
     /// permitted to destroy this dataset each time the zone is initialized.
     pub filesystem_pool: Option<ZpoolName>,
     pub zone_type: OmicronZoneType,
+    // Use `InstallDataset` if this field is not present in a deserialized
+    // blueprint or ledger.
+    #[serde(default = "deserialize_image_source_default")]
     pub image_source: OmicronZoneImageSource,
 }
 
@@ -616,6 +619,12 @@ pub enum OmicronZoneImageSource {
     /// This originates from TUF repos uploaded to Nexus which are then
     /// replicated out to all sleds.
     Artifact { hash: ArtifactHash },
+}
+
+// See `OmicronZoneConfig`. This is a separate function instead of being `impl
+// Default` because we don't want to accidentally use this default in Rust code.
+fn deserialize_image_source_default() -> OmicronZoneImageSource {
+    OmicronZoneImageSource::InstallDataset
 }
 
 #[cfg(test)]

--- a/nexus-sled-agent-shared/src/inventory.rs
+++ b/nexus-sled-agent-shared/src/inventory.rs
@@ -13,6 +13,7 @@ use omicron_common::{
         internal::shared::{NetworkInterface, SourceNatConfig},
     },
     disk::DiskVariant,
+    update::ArtifactHash,
     zpool_name::ZpoolName,
 };
 use omicron_uuid_kinds::{DatasetUuid, OmicronZoneUuid};
@@ -160,6 +161,7 @@ pub struct OmicronZoneConfig {
     /// permitted to destroy this dataset each time the zone is initialized.
     pub filesystem_pool: Option<ZpoolName>,
     pub zone_type: OmicronZoneType,
+    pub image_source: OmicronZoneImageSource,
 }
 
 impl OmicronZoneConfig {
@@ -589,6 +591,15 @@ impl ZoneKind {
             ZoneKind::Oximeter => "oximeter",
         }
     }
+}
+
+#[derive(
+    Clone, Debug, Deserialize, Serialize, JsonSchema, PartialEq, Eq, Hash,
+)]
+#[serde(tag = "type", rename_all = "snake_case")]
+pub enum OmicronZoneImageSource {
+    InstallDataset,
+    Artifact { hash: ArtifactHash },
 }
 
 #[cfg(test)]

--- a/nexus-sled-agent-shared/src/inventory.rs
+++ b/nexus-sled-agent-shared/src/inventory.rs
@@ -593,12 +593,28 @@ impl ZoneKind {
     }
 }
 
+/// Where Sled Agent should get the image for a zone.
 #[derive(
     Clone, Debug, Deserialize, Serialize, JsonSchema, PartialEq, Eq, Hash,
 )]
 #[serde(tag = "type", rename_all = "snake_case")]
 pub enum OmicronZoneImageSource {
+    /// This zone's image source is whatever happens to be on the sled's
+    /// "install" dataset.
+    ///
+    /// This is whatever was put in place at the factory or by the latest
+    /// MUPdate. The image used here can vary by sled and even over time (if the
+    /// sled gets MUPdated again).
+    ///
+    /// Historically, this was the only source for zone images. In an system
+    /// with automated control-plane-driven update we expect to only use this
+    /// variant in emergencies where the system had to be recovered via MUPdate.
     InstallDataset,
+    /// This zone's image source is the artifact matching this hash from the TUF
+    /// artifact store (aka "TUF repo depot").
+    ///
+    /// This originates from TUF repos uploaded to Nexus which are then
+    /// replicated out to all sleds.
     Artifact { hash: ArtifactHash },
 }
 

--- a/nexus/db-model/src/inventory.rs
+++ b/nexus/db-model/src/inventory.rs
@@ -30,8 +30,10 @@ use diesel::pg::Pg;
 use diesel::serialize::ToSql;
 use diesel::{serialize, sql_types};
 use ipnetwork::IpNetwork;
-use nexus_sled_agent_shared::inventory::OmicronZoneDataset;
-use nexus_sled_agent_shared::inventory::{OmicronZoneConfig, OmicronZoneType};
+use nexus_sled_agent_shared::inventory::{
+    OmicronZoneConfig, OmicronZoneDataset, OmicronZoneImageSource,
+    OmicronZoneType,
+};
 use nexus_types::inventory::{
     BaseboardId, Caboose, Collection, NvmeFirmware, PowerState, RotPage,
     RotSlot,
@@ -1654,6 +1656,7 @@ impl InvOmicronZone {
                 .filesystem_pool
                 .map(|id| ZpoolName::new_external(id.into())),
             zone_type,
+            image_source: OmicronZoneImageSource::InstallDataset,
         })
     }
 }

--- a/nexus/inventory/src/collector.rs
+++ b/nexus/inventory/src/collector.rs
@@ -409,6 +409,7 @@ mod test {
     use crate::StaticSledAgentEnumerator;
     use gateway_messages::SpPort;
     use nexus_sled_agent_shared::inventory::OmicronZoneConfig;
+    use nexus_sled_agent_shared::inventory::OmicronZoneImageSource;
     use nexus_sled_agent_shared::inventory::OmicronZoneType;
     use nexus_sled_agent_shared::inventory::OmicronZonesConfig;
     use nexus_types::inventory::Collection;
@@ -598,6 +599,7 @@ mod test {
                         address: zone_address,
                     },
                     filesystem_pool: Some(filesystem_pool),
+                    image_source: OmicronZoneImageSource::InstallDataset,
                 }],
             })
             .await

--- a/nexus/types/src/deployment.rs
+++ b/nexus/types/src/deployment.rs
@@ -21,6 +21,7 @@ use blueprint_diff::ClickhouseClusterConfigDiffTablesForSingleBlueprint;
 use blueprint_display::BpDatasetsTableSchema;
 use daft::Diffable;
 use nexus_sled_agent_shared::inventory::OmicronZoneConfig;
+use nexus_sled_agent_shared::inventory::OmicronZoneImageSource;
 use nexus_sled_agent_shared::inventory::OmicronZonesConfig;
 use nexus_sled_agent_shared::inventory::ZoneKind;
 use omicron_common::api::external::ByteCount;
@@ -754,6 +755,7 @@ impl From<BlueprintZoneConfig> for OmicronZoneConfig {
             id: z.id,
             filesystem_pool: z.filesystem_pool,
             zone_type: z.zone_type.into(),
+            image_source: OmicronZoneImageSource::InstallDataset,
         }
     }
 }

--- a/nexus/types/src/deployment.rs
+++ b/nexus/types/src/deployment.rs
@@ -751,10 +751,16 @@ impl BlueprintZoneConfig {
 
 impl From<BlueprintZoneConfig> for OmicronZoneConfig {
     fn from(z: BlueprintZoneConfig) -> Self {
+        let BlueprintZoneConfig {
+            id,
+            filesystem_pool,
+            zone_type,
+            disposition: _disposition,
+        } = z;
         Self {
-            id: z.id,
-            filesystem_pool: z.filesystem_pool,
-            zone_type: z.zone_type.into(),
+            id,
+            filesystem_pool,
+            zone_type: zone_type.into(),
             image_source: OmicronZoneImageSource::InstallDataset,
         }
     }

--- a/openapi/sled-agent.json
+++ b/openapi/sled-agent.json
@@ -4688,7 +4688,14 @@
             "$ref": "#/components/schemas/TypedUuidForOmicronZoneKind"
           },
           "image_source": {
-            "$ref": "#/components/schemas/OmicronZoneImageSource"
+            "default": {
+              "type": "install_dataset"
+            },
+            "allOf": [
+              {
+                "$ref": "#/components/schemas/OmicronZoneImageSource"
+              }
+            ]
           },
           "zone_type": {
             "$ref": "#/components/schemas/OmicronZoneType"
@@ -4696,7 +4703,6 @@
         },
         "required": [
           "id",
-          "image_source",
           "zone_type"
         ]
       },
@@ -4713,8 +4719,10 @@
         ]
       },
       "OmicronZoneImageSource": {
+        "description": "Where Sled Agent should get the image for a zone.",
         "oneOf": [
           {
+            "description": "This zone's image source is whatever happens to be on the sled's \"install\" dataset.\n\nThis is whatever was put in place at the factory or by the latest MUPdate. The image used here can vary by sled and even over time (if the sled gets MUPdated again).\n\nHistorically, this was the only source for zone images. In an system with automated control-plane-driven update we expect to only use this variant in emergencies where the system had to be recovered via MUPdate.",
             "type": "object",
             "properties": {
               "type": {
@@ -4729,6 +4737,7 @@
             ]
           },
           {
+            "description": "This zone's image source is the artifact matching this hash from the TUF artifact store (aka \"TUF repo depot\").\n\nThis originates from TUF repos uploaded to Nexus which are then replicated out to all sleds.",
             "type": "object",
             "properties": {
               "hash": {

--- a/openapi/sled-agent.json
+++ b/openapi/sled-agent.json
@@ -4687,12 +4687,16 @@
           "id": {
             "$ref": "#/components/schemas/TypedUuidForOmicronZoneKind"
           },
+          "image_source": {
+            "$ref": "#/components/schemas/OmicronZoneImageSource"
+          },
           "zone_type": {
             "$ref": "#/components/schemas/OmicronZoneType"
           }
         },
         "required": [
           "id",
+          "image_source",
           "zone_type"
         ]
       },
@@ -4706,6 +4710,43 @@
         },
         "required": [
           "pool_name"
+        ]
+      },
+      "OmicronZoneImageSource": {
+        "oneOf": [
+          {
+            "type": "object",
+            "properties": {
+              "type": {
+                "type": "string",
+                "enum": [
+                  "install_dataset"
+                ]
+              }
+            },
+            "required": [
+              "type"
+            ]
+          },
+          {
+            "type": "object",
+            "properties": {
+              "hash": {
+                "type": "string",
+                "format": "hex string (32 bytes)"
+              },
+              "type": {
+                "type": "string",
+                "enum": [
+                  "artifact"
+                ]
+              }
+            },
+            "required": [
+              "hash",
+              "type"
+            ]
+          }
         ]
       },
       "OmicronZoneType": {

--- a/schema/all-zones-requests.json
+++ b/schema/all-zones-requests.json
@@ -253,6 +253,16 @@
         "id": {
           "$ref": "#/definitions/TypedUuidForOmicronZoneKind"
         },
+        "image_source": {
+          "default": {
+            "type": "install_dataset"
+          },
+          "allOf": [
+            {
+              "$ref": "#/definitions/OmicronZoneImageSource"
+            }
+          ]
+        },
         "zone_type": {
           "$ref": "#/definitions/OmicronZoneType"
         }
@@ -285,6 +295,46 @@
           "$ref": "#/definitions/ZpoolName"
         }
       }
+    },
+    "OmicronZoneImageSource": {
+      "description": "Where Sled Agent should get the image for a zone.",
+      "oneOf": [
+        {
+          "description": "This zone's image source is whatever happens to be on the sled's \"install\" dataset.\n\nThis is whatever was put in place at the factory or by the latest MUPdate. The image used here can vary by sled and even over time (if the sled gets MUPdated again).\n\nHistorically, this was the only source for zone images. In an system with automated control-plane-driven update we expect to only use this variant in emergencies where the system had to be recovered via MUPdate.",
+          "type": "object",
+          "required": [
+            "type"
+          ],
+          "properties": {
+            "type": {
+              "type": "string",
+              "enum": [
+                "install_dataset"
+              ]
+            }
+          }
+        },
+        {
+          "description": "This zone's image source is the artifact matching this hash from the TUF artifact store (aka \"TUF repo depot\").\n\nThis originates from TUF repos uploaded to Nexus which are then replicated out to all sleds.",
+          "type": "object",
+          "required": [
+            "hash",
+            "type"
+          ],
+          "properties": {
+            "hash": {
+              "type": "string",
+              "format": "hex string (32 bytes)"
+            },
+            "type": {
+              "type": "string",
+              "enum": [
+                "artifact"
+              ]
+            }
+          }
+        }
+      ]
     },
     "OmicronZoneType": {
       "description": "Describes what kind of zone this is (i.e., what component is running in it) as well as any type-specific configuration",

--- a/sled-agent/src/services.rs
+++ b/sled-agent/src/services.rs
@@ -4940,6 +4940,7 @@ mod illumos_tests {
         zone::MockZones,
     };
 
+    use nexus_sled_agent_shared::inventory::OmicronZoneImageSource;
     use omicron_uuid_kinds::OmicronZoneUuid;
     use sled_storage::manager_test_harness::StorageManagerTestHarness;
     use std::os::unix::process::ExitStatusExt;
@@ -5176,6 +5177,7 @@ mod illumos_tests {
                         id,
                         zone_type,
                         filesystem_pool: None,
+                        image_source: OmicronZoneImageSource::InstallDataset,
                     }],
                 },
                 Some(&tmp_dir),
@@ -5202,6 +5204,7 @@ mod illumos_tests {
                     id,
                     zone_type: OmicronZoneType::InternalNtp { address },
                     filesystem_pool: None,
+                    image_source: OmicronZoneImageSource::InstallDataset,
                 }],
             },
             Some(&tmp_dir),
@@ -5784,6 +5787,7 @@ mod illumos_tests {
             id: id1,
             zone_type: OmicronZoneType::InternalNtp { address },
             filesystem_pool: None,
+            image_source: OmicronZoneImageSource::InstallDataset,
         }];
 
         let tmp_dir = String::from(test_config.config_dir.path().as_str());
@@ -5806,6 +5810,7 @@ mod illumos_tests {
             id: id2,
             zone_type: OmicronZoneType::InternalNtp { address },
             filesystem_pool: None,
+            image_source: OmicronZoneImageSource::InstallDataset,
         });
 
         // Now try to apply that list with an older generation number.  This
@@ -5869,6 +5874,7 @@ mod illumos_tests {
 
 #[cfg(test)]
 mod test {
+    use nexus_sled_agent_shared::inventory::OmicronZoneImageSource;
     use omicron_uuid_kinds::ZpoolUuid;
 
     use super::*;
@@ -5915,6 +5921,7 @@ mod test {
                 zone_type: OmicronZoneType::Oximeter {
                     address: "[::1]:0".parse().unwrap(),
                 },
+                image_source: OmicronZoneImageSource::InstallDataset,
             }
         }
 


### PR DESCRIPTION
This adds the necessary bit of plumbing to be able to work on https://github.com/oxidecomputer/omicron/issues/7281 from both the Reconfigurator and Sled Agent sides simultaneously.