### PR TITLE
[nix flake] don't download mgd OpenAPI docs

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -2,11 +2,11 @@
   "nodes": {
     "nixpkgs": {
       "locked": {
-        "lastModified": 1738546358,
-        "narHash": "sha256-nLivjIygCiqLp5QcL7l56Tca/elVqM9FG1hGd9ZSsrg=",
+        "lastModified": 1739866667,
+        "narHash": "sha256-EO1ygNKZlsAC9avfcwHkKGMsmipUk1Uc0TbrEZpkn64=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "c6e957d81b96751a3d5967a0fd73694f303cc914",
+        "rev": "73cf49b8ad837ade2de76f87eb53fc85ed5d4680",
         "type": "github"
       },
       "original": {
@@ -29,11 +29,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1738635966,
-        "narHash": "sha256-5MbJhh6nz7tx8FYVOJ0+ixMaEn0ibGzV/hScPMmqVTE=",
+        "lastModified": 1739932111,
+        "narHash": "sha256-WkayjH0vuGw0hx2gmjTUGFRvMKpM17gKcpL/U8EUUw0=",
         "owner": "oxalica",
         "repo": "rust-overlay",
-        "rev": "1ff8663cd75a11e61f8046c62f4dbb05d1907b44",
+        "rev": "75b2271c5c087d830684cd5462d4410219acc367",
         "type": "github"
       },
       "original": {

--- a/flake.nix
+++ b/flake.nix
@@ -80,7 +80,6 @@
       mgVersion = openAPIVersion
         ./tools/maghemite_mg_openapi_version;
 
-
       dendriteOpenAPI = downloadOpenAPI
         {
           repo = "dendrite";
@@ -88,19 +87,6 @@
           version = dendriteVersion;
         };
 
-      ddmOpenAPI = downloadOpenAPI
-        {
-          repo = "maghemite";
-          file = "ddm-admin.json";
-          version = openAPIVersion ./tools/maghemite_ddm_openapi_version;
-        };
-
-      mgOpenAPI = downloadOpenAPI
-        {
-          repo = "maghemite";
-          file = "mg-admin.json";
-          version = mgVersion;
-        };
 
       # given a list of strings of the form `PREFIX="SHA256"`, finds the string
       # starting with the provided `name` and returns the hash for that prefix.
@@ -409,9 +395,6 @@
             LIBCLANG_PATH = "${libclang.lib}/lib";
             OPENSSL_DIR = "${openssl.dev}";
             OPENSSL_LIB_DIR = "${openssl.out}/lib";
-
-            MG_OPENAPI_PATH = mgOpenAPI;
-            DDM_OPENAPI_PATH = ddmOpenAPI;
             DPD_OPENAPI_PATH = dendriteOpenAPI;
 
             # Needed by rustfmt-wrapper, see:


### PR DESCRIPTION
It appears that downloading the `ddm-admin.json` and `mg-admin.json`
OpenAPI documents from the Maghemite repo is no longer part of the
normal dev environment setup, as Omicron now depends on the Progenitor
clients for Maghemite's HTTP APIs via a [Cargo git dep][1]. The `cargo
xtask download` command does not have commands to download the Maghemite
OpenAPI spec, just the actual `mgd` binary. Therefore, I've removed them
from the Nix flake, as well, since they're not necessary to build
Omicron.

This is particularly important as the
`tools/maghemite_mg_openapi_version` and
`tools/maghemite_ddm_openapi_version` no longer contain the SHA of the
file downloaded from Buildomat as of commit
31da03c1534bce0611a5c305bc6b5640be257341, so Nix no longer likes them.
Since they're not actually required, I've fixed the problem by just
removing them from the dev flake.

[1]: https://github.com/oxidecomputer/omicron/blob/18e317b1eb5bfbbbe9c11b86b4f7b7c76fd70528/Cargo.toml#L469-L470