### PR TITLE
[reconfigurator] Remove `BlueprintZoneFilter`

### DIFF
--- a/dev-tools/omdb/src/bin/omdb/db.rs
+++ b/dev-tools/omdb/src/bin/omdb/db.rs
@@ -111,7 +111,6 @@ use nexus_db_queries::db::queries::ALLOW_FULL_TABLE_SCAN_SQL;
 use nexus_db_queries::db::DataStore;
 use nexus_types::deployment::Blueprint;
 use nexus_types::deployment::BlueprintZoneDisposition;
-use nexus_types::deployment::BlueprintZoneFilter;
 use nexus_types::deployment::BlueprintZoneType;
 use nexus_types::deployment::DiskFilter;
 use nexus_types::deployment::SledFilter;
@@ -1283,7 +1282,7 @@ async fn lookup_service_info(
     blueprint: &Blueprint,
 ) -> anyhow::Result<Option<ServiceInfo>> {
     let Some(zone_config) = blueprint
-        .all_omicron_zones(BlueprintZoneFilter::All)
+        .all_omicron_zones(|_disposition| true)
         .find_map(|(_sled_id, zone_config)| {
             if zone_config.id.into_untyped_uuid() == service_id {
                 Some(zone_config)

--- a/dev-tools/reconfigurator-cli/src/main.rs
+++ b/dev-tools/reconfigurator-cli/src/main.rs
@@ -27,7 +27,7 @@ use nexus_reconfigurator_simulation::Simulator;
 use nexus_types::deployment::execution;
 use nexus_types::deployment::execution::blueprint_external_dns_config;
 use nexus_types::deployment::execution::blueprint_internal_dns_config;
-use nexus_types::deployment::BlueprintZoneFilter;
+use nexus_types::deployment::BlueprintZoneDisposition;
 use nexus_types::deployment::OmicronZoneNic;
 use nexus_types::deployment::PlanningInput;
 use nexus_types::deployment::SledFilter;
@@ -124,7 +124,7 @@ impl ReconfiguratorSim {
         builder.set_external_dns_version(parent_blueprint.external_dns_version);
 
         for (_, zone) in parent_blueprint
-            .all_omicron_zones(BlueprintZoneFilter::ShouldBeRunning)
+            .all_omicron_zones(BlueprintZoneDisposition::is_in_service)
         {
             if let Some((external_ip, nic)) =
                 zone.zone_type.external_networking()
@@ -890,7 +890,7 @@ fn cmd_blueprint_edit(
             let mut parent_sled_id = None;
             for sled_id in builder.sled_ids_with_zones() {
                 if builder
-                    .current_sled_zones(sled_id, BlueprintZoneFilter::All)
+                    .current_sled_zones(sled_id, |_disposition| true)
                     .any(|z| z.id == zone_id)
                 {
                     parent_sled_id = Some(sled_id);

--- a/nexus/db-queries/src/db/datastore/deployment.rs
+++ b/nexus/db-queries/src/db/datastore/deployment.rs
@@ -58,7 +58,6 @@ use nexus_types::deployment::BlueprintDatasetsConfig;
 use nexus_types::deployment::BlueprintMetadata;
 use nexus_types::deployment::BlueprintPhysicalDisksConfig;
 use nexus_types::deployment::BlueprintTarget;
-use nexus_types::deployment::BlueprintZoneFilter;
 use nexus_types::deployment::BlueprintZonesConfig;
 use nexus_types::deployment::ClickhouseClusterConfig;
 use nexus_types::deployment::CockroachDbPreserveDowngrade;
@@ -1390,9 +1389,9 @@ impl DataStore {
                     &conn,
                     &opctx.log,
                     blueprint
-                        .all_omicron_zones_not_in(
-                            BlueprintZoneFilter::ShouldBeExternallyReachable,
-                        )
+                        .all_omicron_zones(|disposition| {
+                            !disposition.is_in_service()
+                        })
                         .map(|(_sled_id, zone)| zone),
                 )
                 .await
@@ -1401,9 +1400,9 @@ impl DataStore {
                     &conn,
                     opctx,
                     blueprint
-                        .all_omicron_zones(
-                            BlueprintZoneFilter::ShouldBeExternallyReachable,
-                        )
+                        .all_omicron_zones(|disposition| {
+                            disposition.is_in_service()
+                        })
                         .map(|(_sled_id, zone)| zone),
                 )
                 .await
@@ -2011,7 +2010,6 @@ mod tests {
     use nexus_types::deployment::blueprint_zone_type;
     use nexus_types::deployment::BlueprintZoneConfig;
     use nexus_types::deployment::BlueprintZoneDisposition;
-    use nexus_types::deployment::BlueprintZoneFilter;
     use nexus_types::deployment::BlueprintZoneType;
     use nexus_types::deployment::BlueprintZonesConfig;
     use nexus_types::deployment::OmicronZoneExternalFloatingIp;
@@ -2276,7 +2274,7 @@ mod tests {
             collection.sled_agents.len()
         );
         assert_eq!(
-            blueprint1.all_omicron_zones(BlueprintZoneFilter::All).count(),
+            blueprint1.all_omicron_zones(|_disposition| true).count(),
             collection.all_omicron_zones().count()
         );
         // All zones should be in service.
@@ -2408,9 +2406,9 @@ mod tests {
             blueprint2.blueprint_zones.len()
         );
         assert_eq!(
-            blueprint1.all_omicron_zones(BlueprintZoneFilter::All).count()
+            blueprint1.all_omicron_zones(|_disposition| true).count()
                 + num_new_sled_zones,
-            blueprint2.all_omicron_zones(BlueprintZoneFilter::All).count()
+            blueprint2.all_omicron_zones(|_disposition| true).count()
         );
 
         // All zones should be in service.
@@ -2931,7 +2929,7 @@ mod tests {
 
         // Insert an IP pool range covering the one Nexus IP.
         let nexus_ip = blueprint1
-            .all_omicron_zones(BlueprintZoneFilter::ShouldBeRunning)
+            .all_omicron_zones(BlueprintZoneDisposition::is_in_service)
             .find_map(|(_, zone_config)| {
                 zone_config
                     .zone_type
@@ -3149,10 +3147,7 @@ mod tests {
 
     fn assert_all_zones_in_service(blueprint: &Blueprint) {
         let not_in_service = blueprint
-            .all_omicron_zones(BlueprintZoneFilter::All)
-            .filter(|(_, z)| {
-                z.disposition != BlueprintZoneDisposition::InService
-            })
+            .all_omicron_zones(|disposition| !disposition.is_in_service())
             .collect::<Vec<_>>();
         assert!(
             not_in_service.is_empty(),

--- a/nexus/db-queries/src/db/datastore/rack.rs
+++ b/nexus/db-queries/src/db/datastore/rack.rs
@@ -46,7 +46,7 @@ use nexus_types::deployment::blueprint_zone_type;
 use nexus_types::deployment::Blueprint;
 use nexus_types::deployment::BlueprintTarget;
 use nexus_types::deployment::BlueprintZoneConfig;
-use nexus_types::deployment::BlueprintZoneFilter;
+use nexus_types::deployment::BlueprintZoneDisposition;
 use nexus_types::deployment::BlueprintZoneType;
 use nexus_types::deployment::OmicronZoneExternalIp;
 use nexus_types::external_api::params as external_params;
@@ -789,7 +789,7 @@ impl DataStore {
                     })?;
 
                     // Allocate networking records for all services.
-                    for (_, zone_config) in blueprint.all_omicron_zones(BlueprintZoneFilter::ShouldBeRunning) {
+                    for (_, zone_config) in blueprint.all_omicron_zones(BlueprintZoneDisposition::is_in_service) {
                         self.rack_populate_service_networking_records(
                             &conn,
                             &log,
@@ -1842,7 +1842,7 @@ mod test {
 
         // We should see both of the Nexus services we provisioned.
         let mut observed_zones: Vec<_> = observed_blueprint
-            .all_omicron_zones(BlueprintZoneFilter::All)
+            .all_omicron_zones(|_disposition| true)
             .map(|(_, z)| z)
             .collect();
         observed_zones.sort_by_key(|z| z.id);
@@ -1870,7 +1870,7 @@ mod test {
                 external_ip,
                 ..
             }) = &blueprint
-                .all_omicron_zones(BlueprintZoneFilter::All)
+                .all_omicron_zones(|_disposition| true)
                 .next()
                 .unwrap()
                 .1
@@ -1889,7 +1889,7 @@ mod test {
                 external_ip,
                 ..
             }) = &blueprint
-                .all_omicron_zones(BlueprintZoneFilter::All)
+                .all_omicron_zones(|_disposition| true)
                 .nth(1)
                 .unwrap()
                 .1

--- a/nexus/db-queries/src/db/datastore/support_bundle.rs
+++ b/nexus/db-queries/src/db/datastore/support_bundle.rs
@@ -219,7 +219,7 @@ impl DataStore {
         // For this blueprint: The set of all expunged Nexus zones
         let invalid_nexus_zones = blueprint
             .all_omicron_zones(
-                nexus_types::deployment::BlueprintZoneFilter::Expunged,
+                nexus_types::deployment::BlueprintZoneDisposition::is_expunged,
             )
             .filter_map(|(_sled, zone)| {
                 if matches!(
@@ -486,7 +486,6 @@ mod test {
     use nexus_types::deployment::BlueprintDatasetDisposition;
     use nexus_types::deployment::BlueprintDatasetFilter;
     use nexus_types::deployment::BlueprintZoneDisposition;
-    use nexus_types::deployment::BlueprintZoneFilter;
     use nexus_types::deployment::BlueprintZoneType;
     use omicron_common::api::external::LookupType;
     use omicron_common::api::internal::shared::DatasetKind::Debug as DebugDatasetKind;
@@ -929,9 +928,8 @@ mod test {
         logctx.cleanup_successful();
     }
 
-    fn get_nexuses_from_blueprint(
+    fn get_in_service_nexuses_from_blueprint(
         bp: &Blueprint,
-        filter: BlueprintZoneFilter,
     ) -> Vec<OmicronZoneUuid> {
         bp.blueprint_zones
             .values()
@@ -939,7 +937,7 @@ mod test {
                 let mut nexus_zones = vec![];
                 for zone in &zones_config.zones {
                     if matches!(zone.zone_type, BlueprintZoneType::Nexus(_))
-                        && zone.disposition.matches(filter)
+                        && zone.disposition.is_in_service()
                     {
                         nexus_zones.push(zone.id);
                     }
@@ -1026,13 +1024,10 @@ mod test {
         }
 
         // Extract Nexus and Dataset information from the generated blueprint.
-        let this_nexus_id = get_nexuses_from_blueprint(
-            &bp1,
-            BlueprintZoneFilter::ShouldBeRunning,
-        )
-        .get(0)
-        .map(|id| *id)
-        .expect("There should be a Nexus in the example blueprint");
+        let this_nexus_id = get_in_service_nexuses_from_blueprint(&bp1)
+            .get(0)
+            .map(|id| *id)
+            .expect("There should be a Nexus in the example blueprint");
         let debug_datasets = get_debug_datasets_from_blueprint(
             &bp1,
             BlueprintDatasetFilter::InService,
@@ -1135,13 +1130,10 @@ mod test {
         }
 
         // Extract Nexus and Dataset information from the generated blueprint.
-        let this_nexus_id = get_nexuses_from_blueprint(
-            &bp1,
-            BlueprintZoneFilter::ShouldBeRunning,
-        )
-        .get(0)
-        .map(|id| *id)
-        .expect("There should be a Nexus in the example blueprint");
+        let this_nexus_id = get_in_service_nexuses_from_blueprint(&bp1)
+            .get(0)
+            .map(|id| *id)
+            .expect("There should be a Nexus in the example blueprint");
         let debug_datasets = get_debug_datasets_from_blueprint(
             &bp1,
             BlueprintDatasetFilter::InService,
@@ -1245,10 +1237,7 @@ mod test {
         }
 
         // Extract Nexus and Dataset information from the generated blueprint.
-        let nexus_ids = get_nexuses_from_blueprint(
-            &bp1,
-            BlueprintZoneFilter::ShouldBeRunning,
-        );
+        let nexus_ids = get_in_service_nexuses_from_blueprint(&bp1);
         let debug_datasets = get_debug_datasets_from_blueprint(
             &bp1,
             BlueprintDatasetFilter::InService,
@@ -1368,10 +1357,7 @@ mod test {
         }
 
         // Extract Nexus and Dataset information from the generated blueprint.
-        let nexus_ids = get_nexuses_from_blueprint(
-            &bp1,
-            BlueprintZoneFilter::ShouldBeRunning,
-        );
+        let nexus_ids = get_in_service_nexuses_from_blueprint(&bp1);
         let debug_datasets = get_debug_datasets_from_blueprint(
             &bp1,
             BlueprintDatasetFilter::InService,

--- a/nexus/reconfigurator/blippy/src/checks.rs
+++ b/nexus/reconfigurator/blippy/src/checks.rs
@@ -11,7 +11,7 @@ use nexus_types::deployment::blueprint_zone_type;
 use nexus_types::deployment::BlueprintDatasetConfig;
 use nexus_types::deployment::BlueprintDatasetFilter;
 use nexus_types::deployment::BlueprintZoneConfig;
-use nexus_types::deployment::BlueprintZoneFilter;
+use nexus_types::deployment::BlueprintZoneDisposition;
 use nexus_types::deployment::BlueprintZoneType;
 use nexus_types::deployment::OmicronZoneExternalIp;
 use nexus_types::external_api::views::SledState;
@@ -144,7 +144,7 @@ fn check_underlay_ips(blippy: &mut Blippy<'_>) {
 
     for (sled_id, zone) in blippy
         .blueprint()
-        .all_omicron_zones(BlueprintZoneFilter::ShouldBeRunning)
+        .all_omicron_zones(BlueprintZoneDisposition::is_in_service)
     {
         let ip = zone.underlay_ip();
 
@@ -237,7 +237,7 @@ fn check_external_networking(blippy: &mut Blippy<'_>) {
 
     for (sled_id, zone, external_ip, nic) in blippy
         .blueprint()
-        .all_omicron_zones(BlueprintZoneFilter::ShouldBeRunning)
+        .all_omicron_zones(BlueprintZoneDisposition::is_in_service)
         .filter_map(|(sled_id, zone)| {
             zone.zone_type
                 .external_networking()
@@ -325,7 +325,7 @@ fn check_dataset_zpool_uniqueness(blippy: &mut Blippy<'_>) {
     // kind.
     for (sled_id, zone) in blippy
         .blueprint()
-        .all_omicron_zones(BlueprintZoneFilter::ShouldBeRunning)
+        .all_omicron_zones(BlueprintZoneDisposition::is_in_service)
     {
         // Check "one kind per zpool" for durable datasets...
         if let Some(dataset) = zone.zone_type.durable_dataset() {
@@ -521,7 +521,7 @@ fn check_datasets(blippy: &mut Blippy<'_>) {
     // (filesystem or durable).
     for (sled_id, zone_config) in blippy
         .blueprint()
-        .all_omicron_zones(BlueprintZoneFilter::ShouldBeRunning)
+        .all_omicron_zones(BlueprintZoneDisposition::is_in_service)
     {
         let Some(sled_datasets) = datasets.get_sled_or_note_missing(
             blippy,
@@ -1756,7 +1756,7 @@ mod tests {
         let (_, _, mut blueprint) = example(&logctx.log, TEST_NAME);
 
         let crucible_addr_by_zpool = blueprint
-            .all_omicron_zones(BlueprintZoneFilter::ShouldBeRunning)
+            .all_omicron_zones(BlueprintZoneDisposition::is_in_service)
             .filter_map(|(_, z)| match z.zone_type {
                 BlueprintZoneType::Crucible(
                     blueprint_zone_type::Crucible { address, .. },

--- a/nexus/reconfigurator/execution/src/clickhouse.rs
+++ b/nexus/reconfigurator/execution/src/clickhouse.rs
@@ -23,7 +23,7 @@ use futures::stream::FuturesUnordered;
 use futures::stream::StreamExt;
 use nexus_db_queries::context::OpContext;
 use nexus_types::deployment::Blueprint;
-use nexus_types::deployment::BlueprintZoneFilter;
+use nexus_types::deployment::BlueprintZoneDisposition;
 use nexus_types::deployment::BlueprintZonesConfig;
 use nexus_types::deployment::ClickhouseClusterConfig;
 use omicron_common::address::CLICKHOUSE_ADMIN_PORT;
@@ -182,9 +182,11 @@ pub(crate) async fn deploy_single_node(
     opctx: &OpContext,
     zones: &BTreeMap<SledUuid, BlueprintZonesConfig>,
 ) -> Result<(), anyhow::Error> {
-    if let Some((_, zone)) =
-        Blueprint::filtered_zones(zones, BlueprintZoneFilter::ShouldBeRunning)
-            .find(|(_, zone)| zone.zone_type.is_clickhouse())
+    if let Some((_, zone)) = Blueprint::filtered_zones(
+        zones,
+        BlueprintZoneDisposition::is_in_service,
+    )
+    .find(|(_, zone)| zone.zone_type.is_clickhouse())
     {
         let admin_addr = SocketAddr::V6(SocketAddrV6::new(
             zone.underlay_ip(),

--- a/nexus/reconfigurator/execution/src/dns.rs
+++ b/nexus/reconfigurator/execution/src/dns.rs
@@ -329,7 +329,6 @@ mod test {
     use nexus_types::deployment::BlueprintTarget;
     use nexus_types::deployment::BlueprintZoneConfig;
     use nexus_types::deployment::BlueprintZoneDisposition;
-    use nexus_types::deployment::BlueprintZoneFilter;
     use nexus_types::deployment::BlueprintZoneType;
     use nexus_types::deployment::BlueprintZonesConfig;
     use nexus_types::deployment::CockroachDbClusterVersion;
@@ -758,7 +757,7 @@ mod test {
         // To start, we need a mapping from underlay IP to the corresponding
         // Omicron zone.
         let mut omicron_zones_by_ip: BTreeMap<_, _> = blueprint
-            .all_omicron_zones(BlueprintZoneFilter::ShouldBeInInternalDns)
+            .all_omicron_zones(BlueprintZoneDisposition::is_in_service)
             .map(|(_, zone)| (zone.underlay_ip(), zone.id))
             .collect();
         println!("omicron zones by IP: {:#?}", omicron_zones_by_ip);
@@ -1393,11 +1392,11 @@ mod test {
         eprintln!("blueprint2: {}", blueprint2.display());
         // Figure out the id of the new zone.
         let zones_before = blueprint
-            .all_omicron_zones(BlueprintZoneFilter::All)
+            .all_omicron_zones(|_disposition| true)
             .filter_map(|(_, z)| z.zone_type.is_nexus().then_some(z.id))
             .collect::<BTreeSet<_>>();
         let zones_after = blueprint2
-            .all_omicron_zones(BlueprintZoneFilter::All)
+            .all_omicron_zones(|_disposition| true)
             .filter_map(|(_, z)| z.zone_type.is_nexus().then_some(z.id))
             .collect::<BTreeSet<_>>();
         let new_zones: Vec<_> = zones_after.difference(&zones_before).collect();

--- a/nexus/reconfigurator/execution/src/lib.rs
+++ b/nexus/reconfigurator/execution/src/lib.rs
@@ -12,7 +12,7 @@ use nexus_db_queries::context::OpContext;
 use nexus_db_queries::db::DataStore;
 use nexus_types::deployment::execution::*;
 use nexus_types::deployment::Blueprint;
-use nexus_types::deployment::BlueprintZoneFilter;
+use nexus_types::deployment::BlueprintZoneDisposition;
 use nexus_types::deployment::SledFilter;
 use nexus_types::external_api::views::SledState;
 use nexus_types::identity::Asset;
@@ -465,7 +465,13 @@ fn register_cleanup_expunged_zones_step<'a>(
                     &opctx,
                     datastore,
                     resolver,
-                    blueprint.all_omicron_zones(BlueprintZoneFilter::Expunged),
+                    // TODO-correctness Once the planner fills in
+                    // `ready_for_cleanup`, we should filter on that here and
+                    // stop requiring `deploy_zones_done`. This is necessary to
+                    // fix omicron#6999.
+                    blueprint.all_omicron_zones(
+                        BlueprintZoneDisposition::is_expunged,
+                    ),
                     &done,
                 )
                 .await

--- a/nexus/reconfigurator/planning/src/blueprint_builder/clickhouse.rs
+++ b/nexus/reconfigurator/planning/src/blueprint_builder/clickhouse.rs
@@ -7,8 +7,8 @@
 
 use clickhouse_admin_types::{ClickhouseKeeperClusterMembership, KeeperId};
 use nexus_types::deployment::{
-    Blueprint, BlueprintZoneFilter, BlueprintZoneType, BlueprintZonesConfig,
-    ClickhouseClusterConfig,
+    Blueprint, BlueprintZoneDisposition, BlueprintZoneType,
+    BlueprintZonesConfig, ClickhouseClusterConfig,
 };
 use omicron_uuid_kinds::{OmicronZoneUuid, SledUuid};
 use slog::{error, Logger};
@@ -36,7 +36,7 @@ impl From<&BTreeMap<SledUuid, BlueprintZonesConfig>>
         let mut servers = BTreeSet::new();
         for (_, bp_zone_config) in Blueprint::filtered_zones(
             zones_by_sled_id,
-            BlueprintZoneFilter::ShouldBeRunning,
+            BlueprintZoneDisposition::is_in_service,
         ) {
             match bp_zone_config.zone_type {
                 BlueprintZoneType::ClickhouseKeeper(_) => {

--- a/nexus/reconfigurator/planning/src/blueprint_editor/allocators.rs
+++ b/nexus/reconfigurator/planning/src/blueprint_editor/allocators.rs
@@ -7,7 +7,7 @@
 use std::net::IpAddr;
 
 use super::SledEditor;
-use nexus_types::deployment::BlueprintZoneFilter;
+use nexus_types::deployment::BlueprintZoneDisposition;
 use omicron_common::address::DnsSubnet;
 use omicron_common::address::IpRange;
 use omicron_common::address::ReservedRackSubnet;
@@ -51,17 +51,17 @@ impl BlueprintResourceAllocator {
     {
         let internal_dns = InternalDnsSubnetAllocator::new(
             all_sleds.clone().flat_map(|(_, editor)| {
-                editor.zones(BlueprintZoneFilter::ShouldBeRunning)
+                editor.zones(BlueprintZoneDisposition::is_in_service)
             }),
             target_internal_dns_redundancy,
         )?;
 
         let external_networking = ExternalNetworkingAllocator::new(
             all_sleds.clone().flat_map(|(_, editor)| {
-                editor.zones(BlueprintZoneFilter::ShouldBeRunning)
+                editor.zones(BlueprintZoneDisposition::is_in_service)
             }),
             all_sleds.flat_map(|(_, editor)| {
-                editor.zones(BlueprintZoneFilter::Expunged)
+                editor.zones(BlueprintZoneDisposition::is_expunged)
             }),
             service_ip_pool_ranges,
         )

--- a/nexus/reconfigurator/planning/src/blueprint_editor/allocators/internal_dns.rs
+++ b/nexus/reconfigurator/planning/src/blueprint_editor/allocators/internal_dns.rs
@@ -113,7 +113,7 @@ pub mod test {
     use super::*;
     use crate::blueprint_builder::test::verify_blueprint;
     use crate::example::ExampleSystemBuilder;
-    use nexus_types::deployment::BlueprintZoneFilter;
+    use nexus_types::deployment::BlueprintZoneDisposition;
     use omicron_common::disk::DatasetKind;
     use omicron_common::policy::INTERNAL_DNS_REDUNDANCY;
     use omicron_test_utils::dev::test_setup_log;
@@ -164,7 +164,7 @@ pub mod test {
         // Create an allocator.
         let mut allocator = InternalDnsSubnetAllocator::new(
             blueprint1
-                .all_omicron_zones(BlueprintZoneFilter::ShouldBeRunning)
+                .all_omicron_zones(BlueprintZoneDisposition::is_in_service)
                 .map(|(_sled_id, zone_config)| zone_config),
             example.input.target_internal_dns_zone_count(),
         )

--- a/nexus/reconfigurator/planning/src/blueprint_editor/sled_editor.rs
+++ b/nexus/reconfigurator/planning/src/blueprint_editor/sled_editor.rs
@@ -17,7 +17,6 @@ use nexus_types::deployment::BlueprintPhysicalDiskConfig;
 use nexus_types::deployment::BlueprintPhysicalDisksConfig;
 use nexus_types::deployment::BlueprintZoneConfig;
 use nexus_types::deployment::BlueprintZoneDisposition;
-use nexus_types::deployment::BlueprintZoneFilter;
 use nexus_types::deployment::BlueprintZoneType;
 use nexus_types::deployment::BlueprintZonesConfig;
 use nexus_types::deployment::DiskFilter;
@@ -264,10 +263,13 @@ impl SledEditor {
         }
     }
 
-    pub fn zones(
+    pub fn zones<F>(
         &self,
-        filter: BlueprintZoneFilter,
-    ) -> impl Iterator<Item = &BlueprintZoneConfig> {
+        mut filter: F,
+    ) -> impl Iterator<Item = &BlueprintZoneConfig>
+    where
+        F: FnMut(BlueprintZoneDisposition) -> bool,
+    {
         match &self.0 {
             InnerSledEditor::Active(editor) => {
                 Either::Left(editor.zones(filter))
@@ -277,7 +279,7 @@ impl SledEditor {
                     .zones
                     .zones
                     .iter()
-                    .filter(move |zone| zone.disposition.matches(filter)),
+                    .filter(move |zone| filter(zone.disposition)),
             ),
         }
     }
@@ -383,7 +385,7 @@ impl ActiveSledEditor {
         // some time after expungement, we may reuse its IP; reconfigurator must
         // know that's safe prior to pruning the expunged zone.
         let zone_ips =
-            zones.zones(BlueprintZoneFilter::All).map(|z| z.underlay_ip());
+            zones.zones(|_disposition| true).map(|z| z.underlay_ip());
 
         Ok(Self {
             underlay_ip_allocator: SledUnderlayIpAllocator::new(
@@ -429,13 +431,11 @@ impl ActiveSledEditor {
     }
 
     fn validate_decommisionable(&self) -> Result<(), SledEditError> {
-        // ... and all zones are expunged.
-        if let Some(zone) = self.zones(BlueprintZoneFilter::All).find(|zone| {
-            match zone.disposition {
-                BlueprintZoneDisposition::InService => true,
-                BlueprintZoneDisposition::Expunged { .. } => false,
-            }
-        }) {
+        // A sled is only decommissionable if all its zones have been expunged
+        // (i.e., there are no zones left with an in-service disposition).
+        if let Some(zone) =
+            self.zones(BlueprintZoneDisposition::is_in_service).next()
+        {
             return Err(SledEditError::NonDecommissionableZoneNotExpunged {
                 zone_id: zone.id,
                 kind: zone.zone_type.kind(),
@@ -471,10 +471,13 @@ impl ActiveSledEditor {
         self.datasets.datasets(filter)
     }
 
-    pub fn zones(
+    pub fn zones<F>(
         &self,
-        filter: BlueprintZoneFilter,
-    ) -> impl Iterator<Item = &BlueprintZoneConfig> {
+        filter: F,
+    ) -> impl Iterator<Item = &BlueprintZoneConfig>
+    where
+        F: FnMut(BlueprintZoneDisposition) -> bool,
+    {
         self.zones.zones(filter)
     }
 
@@ -581,7 +584,7 @@ impl ActiveSledEditor {
         &mut self,
         rng: &mut SledPlannerRng,
     ) -> Result<(), SledEditError> {
-        for zone in self.zones.zones(BlueprintZoneFilter::ShouldBeRunning) {
+        for zone in self.zones.zones(BlueprintZoneDisposition::is_in_service) {
             ZoneDatasetConfigs::new(&self.disks, zone)?
                 .ensure_in_service(&mut self.datasets, rng);
         }
@@ -597,7 +600,7 @@ impl ActiveSledEditor {
         let mut zones_to_edit: BTreeMap<OmicronZoneUuid, ZpoolName> =
             BTreeMap::new();
 
-        for zone in self.zones.zones(BlueprintZoneFilter::ShouldBeRunning) {
+        for zone in self.zones.zones(BlueprintZoneDisposition::is_in_service) {
             let expected_filesystem_pool = if let Some(pool) =
                 zone.zone_type.durable_zpool()
             {

--- a/nexus/reconfigurator/planning/src/blueprint_editor/sled_editor/zones.rs
+++ b/nexus/reconfigurator/planning/src/blueprint_editor/sled_editor/zones.rs
@@ -9,7 +9,6 @@ use nexus_types::deployment::id_map::Entry;
 use nexus_types::deployment::id_map::IdMap;
 use nexus_types::deployment::BlueprintZoneConfig;
 use nexus_types::deployment::BlueprintZoneDisposition;
-use nexus_types::deployment::BlueprintZoneFilter;
 use nexus_types::deployment::BlueprintZonesConfig;
 use omicron_common::api::external::Generation;
 use omicron_uuid_kinds::OmicronZoneUuid;
@@ -65,13 +64,14 @@ impl ZonesEditor {
         self.counts
     }
 
-    pub fn zones(
+    pub fn zones<F>(
         &self,
-        filter: BlueprintZoneFilter,
-    ) -> impl Iterator<Item = &BlueprintZoneConfig> {
-        self.zones
-            .iter()
-            .filter(move |config| config.disposition.matches(filter))
+        mut filter: F,
+    ) -> impl Iterator<Item = &BlueprintZoneConfig>
+    where
+        F: FnMut(BlueprintZoneDisposition) -> bool,
+    {
+        self.zones.iter().filter(move |config| filter(config.disposition))
     }
 
     pub fn add_zone(

--- a/nexus/reconfigurator/planning/src/example.rs
+++ b/nexus/reconfigurator/planning/src/example.rs
@@ -543,7 +543,7 @@ impl ZoneCount {
 mod tests {
     use chrono::{NaiveDateTime, TimeZone, Utc};
     use nexus_sled_agent_shared::inventory::{OmicronZoneConfig, ZoneKind};
-    use nexus_types::deployment::{BlueprintZoneConfig, BlueprintZoneFilter};
+    use nexus_types::deployment::BlueprintZoneConfig;
     use omicron_test_utils::dev::test_setup_log;
 
     use super::*;
@@ -690,7 +690,7 @@ mod tests {
         kind: ZoneKind,
     ) -> Vec<&BlueprintZoneConfig> {
         blueprint
-            .all_omicron_zones(BlueprintZoneFilter::All)
+            .all_omicron_zones(|_disposition| true)
             .filter_map(|(_, zone)| {
                 (zone.zone_type.kind() == kind).then_some(zone)
             })

--- a/nexus/reconfigurator/planning/src/planner.rs
+++ b/nexus/reconfigurator/planning/src/planner.rs
@@ -18,7 +18,6 @@ use nexus_sled_agent_shared::inventory::OmicronZoneType;
 use nexus_sled_agent_shared::inventory::ZoneKind;
 use nexus_types::deployment::Blueprint;
 use nexus_types::deployment::BlueprintZoneDisposition;
-use nexus_types::deployment::BlueprintZoneFilter;
 use nexus_types::deployment::CockroachDbClusterVersion;
 use nexus_types::deployment::CockroachDbPreserveDowngrade;
 use nexus_types::deployment::CockroachDbSettings;
@@ -153,7 +152,7 @@ impl<'a> Planner<'a> {
             // we ourselves have made this change, which is fine.
             let all_zones_expunged = self
                 .blueprint
-                .current_sled_zones(sled_id, BlueprintZoneFilter::All)
+                .current_sled_zones(sled_id, |_disposition| true)
                 .all(|zone| {
                     matches!(
                         zone.disposition,
@@ -196,7 +195,7 @@ impl<'a> Planner<'a> {
             if !commissioned_sled_ids.contains(&sled_id) {
                 let num_zones = self
                     .blueprint
-                    .current_sled_zones(sled_id, BlueprintZoneFilter::All)
+                    .current_sled_zones(sled_id, |_disposition| true)
                     .filter(|zone| {
                         !matches!(
                             zone.disposition,
@@ -377,7 +376,7 @@ impl<'a> Planner<'a> {
                     .blueprint
                     .current_sled_zones(
                         sled_id,
-                        BlueprintZoneFilter::ShouldBeRunning,
+                        BlueprintZoneDisposition::is_in_service,
                     )
                     .any(|z| {
                         OmicronZoneType::from(z.zone_type.clone())
@@ -557,7 +556,7 @@ impl<'a> Planner<'a> {
                                 .blueprint
                                 .current_sled_zones(
                                     sled_id,
-                                    BlueprintZoneFilter::ShouldBeRunning,
+                                    BlueprintZoneDisposition::is_in_service,
                                 )
                                 .filter_map(|zone| {
                                     DiscretionaryOmicronZone::from_zone_type(
@@ -1586,7 +1585,7 @@ pub(crate) mod test {
         let blueprint1a = blueprint_builder.build();
         assert_eq!(
             blueprint1a
-                .all_omicron_zones(BlueprintZoneFilter::ShouldBeRunning)
+                .all_omicron_zones(BlueprintZoneDisposition::is_in_service)
                 .filter(|(_, zone)| zone.zone_type.is_external_dns())
                 .count(),
             3,
@@ -1614,7 +1613,7 @@ pub(crate) mod test {
         // The first sled should have three external DNS zones.
         assert_eq!(
             blueprint2
-                .all_omicron_zones(BlueprintZoneFilter::ShouldBeRunning)
+                .all_omicron_zones(BlueprintZoneDisposition::is_in_service)
                 .filter(|(_, zone)| zone.zone_type.is_external_dns())
                 .count(),
             3,
@@ -1666,7 +1665,7 @@ pub(crate) mod test {
         // The IP addresses of the new external DNS zones should be the
         // same as the original set that we "found".
         let mut ips = blueprint3
-            .all_omicron_zones(BlueprintZoneFilter::ShouldBeRunning)
+            .all_omicron_zones(BlueprintZoneDisposition::is_in_service)
             .filter_map(|(_id, zone)| {
                 zone.zone_type.is_external_dns().then(|| {
                     zone.zone_type.external_networking().unwrap().0.ip()
@@ -2057,8 +2056,8 @@ pub(crate) mod test {
         // Find all the zones using this same zpool.
         let mut zones_on_pool = BTreeSet::new();
         let mut zone_kinds_on_pool = BTreeMap::<_, usize>::new();
-        for (_, zone_config) in
-            blueprint1.all_omicron_zones(BlueprintZoneFilter::ShouldBeRunning)
+        for (_, zone_config) in blueprint1
+            .all_omicron_zones(BlueprintZoneDisposition::is_in_service)
         {
             let mut on_pool = false;
             if let Some(pool) = &zone_config.filesystem_pool {
@@ -2775,7 +2774,7 @@ pub(crate) mod test {
         // We should start with CRUCIBLE_PANTRY_REDUNDANCY pantries spread out
         // to at most 1 per sled. Find one of the sleds running one.
         let pantry_sleds = blueprint1
-            .all_omicron_zones(BlueprintZoneFilter::ShouldBeRunning)
+            .all_omicron_zones(BlueprintZoneDisposition::is_in_service)
             .filter_map(|(sled_id, zone)| {
                 zone.zone_type.is_crucible_pantry().then_some(sled_id)
             })
@@ -2815,7 +2814,7 @@ pub(crate) mod test {
         println!("1 -> 2 (expunged sled):\n{}", diff.display());
         assert_eq!(
             blueprint2
-                .all_omicron_zones(BlueprintZoneFilter::ShouldBeRunning)
+                .all_omicron_zones(BlueprintZoneDisposition::is_in_service)
                 .filter(|(sled_id, zone)| *sled_id != expunged_sled_id
                     && zone.zone_type.is_crucible_pantry())
                 .count(),
@@ -2848,7 +2847,7 @@ pub(crate) mod test {
 
         // We should start with one ClickHouse zone. Find out which sled it's on.
         let clickhouse_sleds = blueprint1
-            .all_omicron_zones(BlueprintZoneFilter::All)
+            .all_omicron_zones(|_disposition| true)
             .filter_map(|(sled, zone)| {
                 zone.zone_type.is_clickhouse().then(|| Some(sled))
             })
@@ -2885,7 +2884,7 @@ pub(crate) mod test {
         println!("1 -> 2 (expunged sled):\n{}", diff.display());
         assert_eq!(
             blueprint2
-                .all_omicron_zones(BlueprintZoneFilter::ShouldBeRunning)
+                .all_omicron_zones(BlueprintZoneDisposition::is_in_service)
                 .filter(|(sled, zone)| *sled != clickhouse_sled
                     && zone.zone_type.is_clickhouse())
                 .count(),
@@ -2953,7 +2952,7 @@ pub(crate) mod test {
 
         // We should see zones for 3 clickhouse keepers, and 2 servers created
         let active_zones: Vec<_> = blueprint2
-            .all_omicron_zones(BlueprintZoneFilter::ShouldBeRunning)
+            .all_omicron_zones(BlueprintZoneDisposition::is_in_service)
             .map(|(_, z)| z.clone())
             .collect();
 
@@ -3115,7 +3114,7 @@ pub(crate) mod test {
         );
 
         let active_zones: Vec<_> = blueprint5
-            .all_omicron_zones(BlueprintZoneFilter::ShouldBeRunning)
+            .all_omicron_zones(BlueprintZoneDisposition::is_in_service)
             .map(|(_, z)| z.clone())
             .collect();
 
@@ -3290,7 +3289,7 @@ pub(crate) mod test {
 
         // We should see zones for 3 clickhouse keepers, and 2 servers created
         let active_zones: Vec<_> = blueprint2
-            .all_omicron_zones(BlueprintZoneFilter::ShouldBeRunning)
+            .all_omicron_zones(BlueprintZoneDisposition::is_in_service)
             .map(|(_, z)| z.clone())
             .collect();
 
@@ -3353,7 +3352,7 @@ pub(crate) mod test {
 
         // Find the sled containing one of the keeper zones and expunge it
         let (sled_id, bp_zone_config) = blueprint3
-            .all_omicron_zones(BlueprintZoneFilter::ShouldBeRunning)
+            .all_omicron_zones(BlueprintZoneDisposition::is_in_service)
             .find(|(_, z)| z.zone_type.is_clickhouse_keeper())
             .unwrap();
 
@@ -3510,7 +3509,7 @@ pub(crate) mod test {
 
         // We should see zones for 3 clickhouse keepers, and 2 servers created
         let active_zones: Vec<_> = blueprint2
-            .all_omicron_zones(BlueprintZoneFilter::ShouldBeRunning)
+            .all_omicron_zones(BlueprintZoneDisposition::is_in_service)
             .map(|(_, z)| z.clone())
             .collect();
 
@@ -3557,7 +3556,7 @@ pub(crate) mod test {
 
         // We should have expunged our single-node clickhouse zone
         let expunged_zones: Vec<_> = blueprint3
-            .all_omicron_zones(BlueprintZoneFilter::Expunged)
+            .all_omicron_zones(BlueprintZoneDisposition::is_expunged)
             .map(|(_, z)| z.clone())
             .collect();
 
@@ -3592,7 +3591,7 @@ pub(crate) mod test {
         // All our clickhouse keeper and server zones that we created when we
         // enabled our clickhouse policy should be expunged when we disable it.
         let expunged_zones: Vec<_> = blueprint4
-            .all_omicron_zones(BlueprintZoneFilter::Expunged)
+            .all_omicron_zones(BlueprintZoneDisposition::is_expunged)
             .map(|(_, z)| z.clone())
             .collect();
 
@@ -3614,7 +3613,7 @@ pub(crate) mod test {
         assert_eq!(
             1,
             blueprint4
-                .all_omicron_zones(BlueprintZoneFilter::ShouldBeRunning)
+                .all_omicron_zones(BlueprintZoneDisposition::is_in_service)
                 .filter(|(_, z)| z.zone_type.is_clickhouse())
                 .count()
         );

--- a/nexus/src/app/background/tasks/blueprint_execution.rs
+++ b/nexus/src/app/background/tasks/blueprint_execution.rs
@@ -180,7 +180,6 @@ mod test {
         EventBuffer, EventReport, ExecutionComponent, ExecutionStepId,
         ReconfiguratorExecutionSpec, StepInfo,
     };
-    use nexus_types::deployment::BlueprintZoneFilter;
     use nexus_types::deployment::{
         blueprint_zone_type, Blueprint, BlueprintDatasetsConfig,
         BlueprintPhysicalDisksConfig, BlueprintTarget, BlueprintZoneConfig,
@@ -448,7 +447,7 @@ mod test {
 
         // Insert records for the zpools backing the datasets in these zones.
         for (sled_id, config) in
-            blueprint.1.all_omicron_zones(BlueprintZoneFilter::All)
+            blueprint.1.all_omicron_zones(|_disposition| true)
         {
             let Some(dataset) = config.zone_type.durable_dataset() else {
                 continue;

--- a/nexus/src/app/background/tasks/crdb_node_id_collector.rs
+++ b/nexus/src/app/background/tasks/crdb_node_id_collector.rs
@@ -35,7 +35,7 @@ use nexus_db_queries::db::DataStore;
 use nexus_types::deployment::blueprint_zone_type;
 use nexus_types::deployment::Blueprint;
 use nexus_types::deployment::BlueprintTarget;
-use nexus_types::deployment::BlueprintZoneFilter;
+use nexus_types::deployment::BlueprintZoneDisposition;
 use nexus_types::deployment::BlueprintZoneType;
 use omicron_common::address::COCKROACH_ADMIN_PORT;
 use omicron_uuid_kinds::OmicronZoneUuid;
@@ -145,7 +145,7 @@ impl CockroachAdminFromBlueprint for CockroachAdminFromBlueprintViaFixedPort {
         // We can only actively collect from zones that should be running; if
         // there are CRDB zones in other states that still need their node ID
         // collected, we have to wait until they're running.
-        let zone_filter = BlueprintZoneFilter::ShouldBeRunning;
+        let zone_filter = BlueprintZoneDisposition::is_in_service;
 
         blueprint.all_omicron_zones(zone_filter).filter_map(
             |(_sled_id, zone)| match &zone.zone_type {

--- a/nexus/src/app/rack.rs
+++ b/nexus/src/app/rack.rs
@@ -22,7 +22,7 @@ use nexus_db_queries::db::datastore::RackInit;
 use nexus_db_queries::db::datastore::SledUnderlayAllocationResult;
 use nexus_db_queries::db::lookup::LookupPath;
 use nexus_types::deployment::blueprint_zone_type;
-use nexus_types::deployment::BlueprintZoneFilter;
+use nexus_types::deployment::BlueprintZoneDisposition;
 use nexus_types::deployment::BlueprintZoneType;
 use nexus_types::deployment::CockroachDbClusterVersion;
 use nexus_types::deployment::SledFilter;
@@ -204,7 +204,7 @@ impl super::Nexus {
         let silo_name = &request.recovery_silo.silo_name;
         let dns_records = request
             .blueprint
-            .all_omicron_zones(BlueprintZoneFilter::ShouldBeExternallyReachable)
+            .all_omicron_zones(BlueprintZoneDisposition::is_in_service)
             .filter_map(|(_, zc)| match zc.zone_type {
                 BlueprintZoneType::Nexus(blueprint_zone_type::Nexus {
                     external_ip,

--- a/nexus/src/lib.rs
+++ b/nexus/src/lib.rs
@@ -29,7 +29,7 @@ use nexus_config::NexusConfig;
 use nexus_db_model::RendezvousDebugDataset;
 use nexus_types::deployment::blueprint_zone_type;
 use nexus_types::deployment::Blueprint;
-use nexus_types::deployment::BlueprintZoneFilter;
+use nexus_types::deployment::BlueprintZoneDisposition;
 use nexus_types::deployment::BlueprintZoneType;
 use nexus_types::internal_api::params::{
     PhysicalDiskPutRequest, ZpoolPutRequest,
@@ -283,7 +283,7 @@ impl nexus_test_interface::NexusServer for Server {
         // file.  Whatever it is, we fake up an IP pool range for use by system
         // services that includes solely this IP.
         let internal_services_ip_pool_ranges = blueprint
-            .all_omicron_zones(BlueprintZoneFilter::ShouldBeExternallyReachable)
+            .all_omicron_zones(BlueprintZoneDisposition::is_in_service)
             .filter_map(|(_, zc)| match &zc.zone_type {
                 BlueprintZoneType::ExternalDns(
                     blueprint_zone_type::ExternalDns { dns_address, .. },

--- a/nexus/types/src/deployment.rs
+++ b/nexus/types/src/deployment.rs
@@ -225,10 +225,13 @@ impl Blueprint {
 
     /// Iterate over the [`BlueprintZoneConfig`] instances in the blueprint
     /// that match the provided filter, along with the associated sled id.
-    pub fn all_omicron_zones(
+    pub fn all_omicron_zones<F>(
         &self,
-        filter: BlueprintZoneFilter,
-    ) -> impl Iterator<Item = (SledUuid, &BlueprintZoneConfig)> {
+        filter: F,
+    ) -> impl Iterator<Item = (SledUuid, &BlueprintZoneConfig)>
+    where
+        F: FnMut(BlueprintZoneDisposition) -> bool,
+    {
         Blueprint::filtered_zones(&self.blueprint_zones, filter)
     }
 
@@ -237,16 +240,19 @@ impl Blueprint {
     //
     // This is a scoped function so that it can be used in the
     // `BlueprintBuilder` during planning as well as in the `Blueprint`.
-    pub fn filtered_zones(
+    pub fn filtered_zones<F>(
         zones_by_sled_id: &BTreeMap<SledUuid, BlueprintZonesConfig>,
-        filter: BlueprintZoneFilter,
-    ) -> impl Iterator<Item = (SledUuid, &BlueprintZoneConfig)> {
-        zones_by_sled_id.iter().flat_map(move |(sled_id, z)| {
-            z.zones
-                .iter()
-                .filter(move |z| z.disposition.matches(filter))
-                .map(|z| (*sled_id, z))
-        })
+        mut filter: F,
+    ) -> impl Iterator<Item = (SledUuid, &BlueprintZoneConfig)>
+    where
+        F: FnMut(BlueprintZoneDisposition) -> bool,
+    {
+        zones_by_sled_id
+            .iter()
+            .flat_map(move |(sled_id, z)| {
+                z.zones.iter().map(move |z| (*sled_id, z))
+            })
+            .filter(move |(_, z)| filter(z.disposition))
     }
 
     /// Iterate over the [`BlueprintDatasetsConfig`] instances in the blueprint.
@@ -260,21 +266,6 @@ impl Blueprint {
                 datasets.datasets.iter().map(|dataset| (*sled_id, dataset))
             })
             .filter(move |(_, d)| d.disposition.matches(filter))
-    }
-
-    /// Iterate over the [`BlueprintZoneConfig`] instances in the blueprint
-    /// that do not match the provided filter, along with the associated sled
-    /// id.
-    pub fn all_omicron_zones_not_in(
-        &self,
-        filter: BlueprintZoneFilter,
-    ) -> impl Iterator<Item = (SledUuid, &BlueprintZoneConfig)> {
-        self.blueprint_zones.iter().flat_map(move |(sled_id, z)| {
-            z.zones
-                .iter()
-                .filter(move |z| !z.disposition.matches(filter))
-                .map(|z| (*sled_id, z))
-        })
     }
 
     /// Iterate over the ids of all sleds in the blueprint
@@ -637,9 +628,7 @@ impl BlueprintZonesConfig {
                 .zones
                 .into_iter()
                 .filter_map(|z| {
-                    if z.disposition
-                        .matches(BlueprintZoneFilter::ShouldBeRunning)
-                    {
+                    if z.disposition.is_in_service() {
                         Some(z.into())
                     } else {
                         None
@@ -798,34 +787,12 @@ pub enum BlueprintZoneDisposition {
 }
 
 impl BlueprintZoneDisposition {
-    /// Returns true if the zone disposition matches this filter.
-    pub fn matches(self, filter: BlueprintZoneFilter) -> bool {
-        // This code could be written in three ways:
-        //
-        // 1. match self { match filter { ... } }
-        // 2. match filter { match self { ... } }
-        // 3. match (self, filter) { ... }
-        //
-        // We choose 1 here because we expect many filters and just a few
-        // dispositions, and 1 is the easiest form to represent that.
-        match self {
-            Self::InService => match filter {
-                BlueprintZoneFilter::All => true,
-                BlueprintZoneFilter::Expunged => false,
-                BlueprintZoneFilter::ShouldBeRunning => true,
-                BlueprintZoneFilter::ShouldBeExternallyReachable => true,
-                BlueprintZoneFilter::ShouldBeInInternalDns => true,
-                BlueprintZoneFilter::ShouldDeployVpcFirewallRules => true,
-            },
-            Self::Expunged { .. } => match filter {
-                BlueprintZoneFilter::All => true,
-                BlueprintZoneFilter::Expunged => true,
-                BlueprintZoneFilter::ShouldBeRunning => false,
-                BlueprintZoneFilter::ShouldBeExternallyReachable => false,
-                BlueprintZoneFilter::ShouldBeInInternalDns => false,
-                BlueprintZoneFilter::ShouldDeployVpcFirewallRules => false,
-            },
-        }
+    pub fn is_in_service(self) -> bool {
+        matches!(self, Self::InService)
+    }
+
+    pub fn is_expunged(self) -> bool {
+        matches!(self, Self::Expunged { .. })
     }
 }
 
@@ -838,38 +805,6 @@ impl fmt::Display for BlueprintZoneDisposition {
             BlueprintZoneDisposition::Expunged { .. } => "expunged".fmt(f),
         }
     }
-}
-
-/// Filters that apply to blueprint zones.
-///
-/// This logic lives here rather than within the individual components making
-/// decisions, so that this is easier to read.
-///
-/// The meaning of a particular filter should not be overloaded -- each time a
-/// new use case wants to make a decision based on the zone disposition, a new
-/// variant should be added to this enum.
-#[derive(Copy, Clone, Debug, PartialEq, Eq, Hash)]
-pub enum BlueprintZoneFilter {
-    // ---
-    // Prefer to keep this list in alphabetical order.
-    // ---
-    /// All zones.
-    All,
-
-    /// Zones that have been expunged.
-    Expunged,
-
-    /// Zones that are desired to be in the RUNNING state
-    ShouldBeRunning,
-
-    /// Filter by zones that should have external IP and DNS resources.
-    ShouldBeExternallyReachable,
-
-    /// Filter by zones that should be in internal DNS.
-    ShouldBeInInternalDns,
-
-    /// Filter by zones that should be sent VPC firewall rules.
-    ShouldDeployVpcFirewallRules,
 }
 
 /// Filters that apply to blueprint datasets.

--- a/nexus/types/src/deployment/execution/dns.rs
+++ b/nexus/types/src/deployment/execution/dns.rs
@@ -13,7 +13,8 @@ use omicron_uuid_kinds::SledUuid;
 
 use crate::{
     deployment::{
-        blueprint_zone_type, Blueprint, BlueprintZoneFilter, BlueprintZoneType,
+        blueprint_zone_type, Blueprint, BlueprintZoneDisposition,
+        BlueprintZoneType,
     },
     internal_api::params::{DnsConfigZone, DnsRecord},
     silo::{default_silo_name, silo_dns_name},
@@ -36,7 +37,7 @@ pub fn blueprint_internal_dns_config(
     let mut dns_builder = DnsConfigBuilder::new();
 
     'all_zones: for (_, zone) in
-        blueprint.all_omicron_zones(BlueprintZoneFilter::ShouldBeInInternalDns)
+        blueprint.all_omicron_zones(BlueprintZoneDisposition::is_in_service)
     {
         let (service_name, &address) = match &zone.zone_type {
             BlueprintZoneType::BoundaryNtp(

--- a/nexus/types/src/deployment/execution/utils.rs
+++ b/nexus/types/src/deployment/execution/utils.rs
@@ -9,7 +9,7 @@ use omicron_common::address::{Ipv6Subnet, SLED_PREFIX};
 use omicron_uuid_kinds::SledUuid;
 
 use crate::deployment::{
-    blueprint_zone_type, Blueprint, BlueprintZoneFilter, BlueprintZoneType,
+    blueprint_zone_type, Blueprint, BlueprintZoneDisposition, BlueprintZoneType,
 };
 
 /// The minimal information needed to represent a sled in the context of
@@ -54,7 +54,7 @@ impl Sled {
 /// Return the Nexus external addresses according to the given blueprint
 pub fn blueprint_nexus_external_ips(blueprint: &Blueprint) -> Vec<IpAddr> {
     blueprint
-        .all_omicron_zones(BlueprintZoneFilter::ShouldBeExternallyReachable)
+        .all_omicron_zones(BlueprintZoneDisposition::is_in_service)
         .filter_map(|(_, z)| match z.zone_type {
             BlueprintZoneType::Nexus(blueprint_zone_type::Nexus {
                 external_ip,


### PR DESCRIPTION
This fell out of discussion around and is staged on top of #7558. Since that PR removes the diesel `blueprint_zones_filter()` extension (now that `BlueprintZoneDisposition::Expunged` carries extra data with it that has to be spread across multiple columns), the biggest motivator for `BlueprintZoneFilter` is gone.

We still want to force ourselves to consider zone dispositions, so this PR keeps the `filter` argument to `Blueprint::all_omicron_zones()` and related functions, but that filter is now a closure instead of a `BlueprintZoneFilter`. All the call sites boiled down to one of:

* `all_omicron_zones(BlueprintZoneDisposision::is_in_service)` (helper method that wraps `matches!(self, BlueprintZoneDisposition::InService)`)
* `all_omicron_zones(BlueprintZoneDisposision::is_expunged)` (helper method that wraps `matches!(self, BlueprintZoneDisposition::Expunged { .. })`)
* `all_omicron_zones(|_disposition| true)`

With followup work to have the planner fill in `BlueprintZoneDisposition::Expunged { ready_for_cleanup: true }`, some of the `is_expunged` callers will change to something like `is_ready_for_cleanup()`. But for now, this PR should introduce no behavioral changes at all.