### PR TITLE
update to Rust 1.85

### DIFF
--- a/nexus/db-model/src/ipv6net.rs
+++ b/nexus/db-model/src/ipv6net.rs
@@ -61,7 +61,7 @@ impl Ipv6Net {
             StdRng::from_entropy()
         };
         let random =
-            u128::from(rng.next_u64()) << 64 | u128::from(rng.next_u64());
+            (u128::from(rng.next_u64()) << 64) | u128::from(rng.next_u64());
 
         // Generate a mask for the new address.
         //

--- a/nexus/src/app/background/tasks/networking.rs
+++ b/nexus/src/app/background/tasks/networking.rs
@@ -65,11 +65,11 @@ pub(crate) fn api_to_dpd_port_settings(
     let link_id = LinkId(0);
     let tx_eq = if let Some(Some(t)) = settings.tx_eq.get(0) {
         Some(TxEq {
-            pre1: t.pre1.map(Into::into),
-            pre2: t.pre2.map(Into::into),
-            main: t.main.map(Into::into),
-            post2: t.post2.map(Into::into),
-            post1: t.post2.map(Into::into),
+            pre1: t.pre1,
+            pre2: t.pre2,
+            main: t.main,
+            post2: t.post2,
+            post1: t.post2,
         })
     } else {
         None

--- a/nexus/src/app/background/tasks/sync_switch_configuration.rs
+++ b/nexus/src/app/background/tasks/sync_switch_configuration.rs
@@ -938,11 +938,11 @@ impl BackgroundTask for SwitchPortSettingsManager {
 		    // TODO https://github.com/oxidecomputer/omicron/issues/3062
 		    let tx_eq = if let Some(Some(c)) = info.tx_eq.get(0) {
 			Some(TxEqConfig {
-			    pre1: c.pre1.map(Into::into),
-			    pre2: c.pre2.map(Into::into),
-			    main: c.main.map(Into::into),
-			    post2: c.post2.map(Into::into),
-			    post1: c.post1.map(Into::into),
+			    pre1: c.pre1,
+			    pre2: c.pre2,
+			    main: c.main,
+			    post2: c.post2,
+			    post1: c.post1,
 			})
 		    } else {
 			None

--- a/oximeter/instruments/src/kstat/link.rs
+++ b/oximeter/instruments/src/kstat/link.rs
@@ -231,7 +231,6 @@ mod tests {
                 rand::thread_rng()
                     .sample_iter(Uniform::new('a', 'z'))
                     .take(5)
-                    .map(char::from)
                     .collect::<String>(),
             );
             Self::create(&name);

--- a/oximeter/oxql-types/src/point.rs
+++ b/oximeter/oxql-types/src/point.rs
@@ -821,7 +821,7 @@ impl Points {
                     let mut new = Vec::with_capacity(doubles.len());
                     for maybe_double in doubles.iter().copied() {
                         match maybe_double {
-                            Some(d) if d == 0.0 => new.push(Some(false)),
+                            Some(0.0) => new.push(Some(false)),
                             Some(_) => new.push(Some(true)),
                             None => new.push(None),
                         }

--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -2,5 +2,5 @@
 # We choose a specific toolchain (rather than "stable") for repeatability.  The
 # intent is to keep this up-to-date with recently-released stable Rust.
 
-channel = "1.84.1"
+channel = "1.85.0"
 profile = "default"

--- a/sled-agent/src/rack_setup/service.rs
+++ b/sled-agent/src/rack_setup/service.rs
@@ -972,8 +972,7 @@ impl ServiceInner {
                     .iter()
                     .map(|config| NexusTypes::BgpConfig {
                         asn: config.asn,
-                        originate: config
-                            .originate.to_vec(),
+                        originate: config.originate.to_vec(),
                         shaper: config.shaper.clone(),
                         checker: config.checker.clone(),
                     })

--- a/sled-agent/src/rack_setup/service.rs
+++ b/sled-agent/src/rack_setup/service.rs
@@ -973,11 +973,7 @@ impl ServiceInner {
                     .map(|config| NexusTypes::BgpConfig {
                         asn: config.asn,
                         originate: config
-                            .originate
-                            .iter()
-                            .cloned()
-                            .map(Into::into)
-                            .collect(),
+                            .originate.to_vec(),
                         shaper: config.shaper.clone(),
                         checker: config.checker.clone(),
                     })

--- a/sled-hardware/types/src/underlay.rs
+++ b/sled-hardware/types/src/underlay.rs
@@ -48,9 +48,9 @@ fn mac_to_bootstrap_ip(mac: MacAddr, interface_id: u64) -> Ipv6Addr {
         (u16::from(mac_bytes[0]) << 8) | u16::from(mac_bytes[1]),
         (u16::from(mac_bytes[2]) << 8) | u16::from(mac_bytes[3]),
         (u16::from(mac_bytes[4]) << 8) | u16::from(mac_bytes[5]),
-        (interface_id >> 48 & 0xffff).try_into().unwrap(),
-        (interface_id >> 32 & 0xffff).try_into().unwrap(),
-        (interface_id >> 16 & 0xffff).try_into().unwrap(),
+        ((interface_id >> 48) & 0xffff).try_into().unwrap(),
+        ((interface_id >> 32) & 0xffff).try_into().unwrap(),
+        ((interface_id >> 16) & 0xffff).try_into().unwrap(),
         (interface_id & 0xfff).try_into().unwrap(),
     )
 }


### PR DESCRIPTION
This is a major update (Rust 2024, async closures!), so let's kick it off now
so that we can gradually migrate over.

I ran a quick `cargo check --all-targets` to time it:

```
before: 901.01s user 158.67s system 957% cpu 1:50.66 total
after:  903.61s user 153.73s system 950% cpu 1:51.24 total
```

-- basically even.