### PR TITLE
[reconfigurator] Planner: mark zones `ready_for_cleanup` when appropriate

### DIFF
--- a/nexus/reconfigurator/planning/src/blueprint_builder/builder.rs
+++ b/nexus/reconfigurator/planning/src/blueprint_builder/builder.rs
@@ -980,6 +980,23 @@ impl<'a> BlueprintBuilder<'a> {
         Ok(())
     }
 
+    /// Mark expunged zones as ready for cleanup.
+    pub(crate) fn mark_expunged_zones_ready_for_cleanup(
+        &mut self,
+        sled_id: SledUuid,
+        zone_ids: &[OmicronZoneUuid],
+    ) -> Result<(), Error> {
+        let editor = self.sled_editors.get_mut(&sled_id).ok_or_else(|| {
+            Error::Planner(anyhow!("tried to expunge unknown sled {sled_id}"))
+        })?;
+        for zone_id in zone_ids {
+            editor
+                .mark_expunged_zone_ready_for_cleanup(zone_id)
+                .map_err(|err| Error::SledEditError { sled_id, err })?;
+        }
+        Ok(())
+    }
+
     pub(crate) fn expunge_all_multinode_clickhouse(
         &mut self,
         sled_id: SledUuid,

--- a/nexus/reconfigurator/planning/src/blueprint_editor/sled_editor.rs
+++ b/nexus/reconfigurator/planning/src/blueprint_editor/sled_editor.rs
@@ -180,6 +180,13 @@ impl SledEditor {
         }
     }
 
+    pub fn state(&self) -> SledState {
+        match &self.0 {
+            InnerSledEditor::Active(_) => SledState::Active,
+            InnerSledEditor::Decommissioned(edited_sled) => edited_sled.state,
+        }
+    }
+
     pub fn edit_counts(&self) -> SledEditCounts {
         match &self.0 {
             InnerSledEditor::Active(editor) => editor.edit_counts(),

--- a/nexus/reconfigurator/planning/src/blueprint_editor/sled_editor.rs
+++ b/nexus/reconfigurator/planning/src/blueprint_editor/sled_editor.rs
@@ -326,6 +326,13 @@ impl SledEditor {
         self.as_active_mut()?.expunge_zone(zone_id)
     }
 
+    pub fn mark_expunged_zone_ready_for_cleanup(
+        &mut self,
+        zone_id: &OmicronZoneUuid,
+    ) -> Result<bool, SledEditError> {
+        self.as_active_mut()?.mark_expunged_zone_ready_for_cleanup(zone_id)
+    }
+
     /// Backwards compatibility / test helper: If we're given a blueprint that
     /// has zones but wasn't created via `SledEditor`, it might not have
     /// datasets for all its zones. This method backfills them.
@@ -575,6 +582,15 @@ impl ActiveSledEditor {
         }
 
         Ok(did_expunge)
+    }
+
+    pub fn mark_expunged_zone_ready_for_cleanup(
+        &mut self,
+        zone_id: &OmicronZoneUuid,
+    ) -> Result<bool, SledEditError> {
+        let did_mark_ready =
+            self.zones.mark_expunged_zone_ready_for_cleanup(zone_id)?;
+        Ok(did_mark_ready)
     }
 
     /// Backwards compatibility / test helper: If we're given a blueprint that

--- a/nexus/reconfigurator/planning/src/blueprint_editor/sled_editor/zones.rs
+++ b/nexus/reconfigurator/planning/src/blueprint_editor/sled_editor/zones.rs
@@ -22,6 +22,10 @@ pub enum ZonesEditError {
     AddDuplicateZoneId { id: OmicronZoneUuid, kind1: ZoneKind, kind2: ZoneKind },
     #[error("tried to expunge nonexistent zone {id}")]
     ExpungeNonexistentZone { id: OmicronZoneUuid },
+    #[error("tried to mark a nonexistent zone as ready for cleanup: {id}")]
+    MarkNonexistentZoneReadyForCleanup { id: OmicronZoneUuid },
+    #[error("tried to mark a non-expunged zone as ready for cleanup: {id}")]
+    MarkNonExpungedZoneReadyForCleanup { id: OmicronZoneUuid },
 }
 
 #[derive(Debug, thiserror::Error)]
@@ -136,6 +140,41 @@ impl ZonesEditor {
             Self::expunge_impl(&mut config, &mut self.counts, self.generation);
 
         Ok((did_expunge, config.into_ref()))
+    }
+
+    /// Set an expunged zone's `ready_for_cleanup` flag to true.
+    ///
+    /// Unlike most edit operations, this (alone) will not result in an
+    /// increased generation when `finalize()` is called: this flag is produced
+    /// and consumed inside the Reconfigurator system, and is not included in
+    /// the generation-guarded config send to sled-agents.
+    ///
+    /// # Errors
+    ///
+    /// Fails if this zone ID does not exist or is not already in the expunged
+    /// disposition.
+    pub fn mark_expunged_zone_ready_for_cleanup(
+        &mut self,
+        zone_id: &OmicronZoneUuid,
+    ) -> Result<bool, ZonesEditError> {
+        let mut config = self.zones.get_mut(zone_id).ok_or_else(|| {
+            ZonesEditError::MarkNonexistentZoneReadyForCleanup { id: *zone_id }
+        })?;
+
+        match &mut config.disposition {
+            BlueprintZoneDisposition::InService => {
+                Err(ZonesEditError::MarkNonExpungedZoneReadyForCleanup {
+                    id: *zone_id,
+                })
+            }
+            BlueprintZoneDisposition::Expunged {
+                ready_for_cleanup, ..
+            } => {
+                let did_mark_ready = !*ready_for_cleanup;
+                *ready_for_cleanup = true;
+                Ok(did_mark_ready)
+            }
+        }
     }
 
     fn expunge_impl(

--- a/nexus/reconfigurator/planning/src/planner.rs
+++ b/nexus/reconfigurator/planning/src/planner.rs
@@ -1452,7 +1452,7 @@ pub(crate) mod test {
             BlueprintZoneDisposition::Expunged {
                 as_of_generation: blueprint2.blueprint_zones[&sled_id]
                     .generation,
-                ready_for_cleanup: false,
+                ready_for_cleanup: true,
             }
         );
 
@@ -1654,7 +1654,7 @@ pub(crate) mod test {
                             as_of_generation: blueprint3.blueprint_zones
                                 [&sled_id]
                                 .generation,
-                            ready_for_cleanup: false,
+                            ready_for_cleanup: true,
                         }
                         && zone.zone_type.is_external_dns()
                 })
@@ -2475,7 +2475,7 @@ pub(crate) mod test {
                 *modified_zone.disposition.after,
                 BlueprintZoneDisposition::Expunged {
                     as_of_generation: *modified_zones.generation.after,
-                    ready_for_cleanup: false,
+                    ready_for_cleanup: true,
                 },
                 "for {desc}, zone {} should have been marked expunged",
                 modified_zone.id.after

--- a/nexus/reconfigurator/planning/src/planner.rs
+++ b/nexus/reconfigurator/planning/src/planner.rs
@@ -301,7 +301,14 @@ impl<'a> Planner<'a> {
             // Has the sled been expunged? If so, expunge everything on this
             // sled from the blueprint.
             SledPolicy::Expunged => {
-                self.blueprint.expunge_sled(sled_id)?;
+                match self.blueprint.current_sled_state(sled_id)? {
+                    SledState::Active => {
+                        self.blueprint.expunge_sled(sled_id)?;
+                    }
+                    // If the sled is decommissioned, we've already expunged it
+                    // in a prior planning run.
+                    SledState::Decommissioned => (),
+                }
             }
         }
 

--- a/nexus/reconfigurator/planning/src/planner.rs
+++ b/nexus/reconfigurator/planning/src/planner.rs
@@ -287,12 +287,71 @@ impl<'a> Planner<'a> {
                         ZoneExpungeReason::ClickhouseSingleNodeDisabled,
                     )?;
                 }
+
+                // Are there any expunged zones that haven't yet been marked as
+                // ready for cleanup? If so, check whether we can mark them,
+                // which requires us to check the inventory collection for two
+                // properties:
+                //
+                // 1. The zone is not running
+                // 2. The zone config generation from the sled is at least as
+                //    high as the generation in which the zone was expunged
+                self.check_zones_eligible_for_cleanup(sled_id)?;
             }
             // Has the sled been expunged? If so, expunge everything on this
             // sled from the blueprint.
             SledPolicy::Expunged => {
                 self.blueprint.expunge_sled(sled_id)?;
             }
+        }
+
+        Ok(())
+    }
+
+    fn check_zones_eligible_for_cleanup(
+        &mut self,
+        sled_id: SledUuid,
+    ) -> Result<(), Error> {
+        let Some(sled_inv) = self.inventory.sled_agents.get(&sled_id) else {
+            warn!(
+                self.log,
+                "skipping zones eligible for cleanup check \
+                (sled not present in latest inventory collection)";
+                "sled_id" => %sled_id,
+            );
+            return Ok(());
+        };
+
+        let mut zones_ready_for_cleanup = Vec::new();
+        for zone in self
+            .blueprint
+            .current_sled_zones(sled_id, BlueprintZoneDisposition::is_expunged)
+        {
+            match zone.disposition {
+                BlueprintZoneDisposition::Expunged {
+                    as_of_generation,
+                    ready_for_cleanup,
+                } if !ready_for_cleanup => {
+                    if sled_inv.omicron_zones.generation >= as_of_generation
+                        && !sled_inv
+                            .omicron_zones
+                            .zones
+                            .iter()
+                            .any(|z| z.id == zone.id)
+                    {
+                        zones_ready_for_cleanup.push(zone.id);
+                    }
+                }
+                BlueprintZoneDisposition::InService
+                | BlueprintZoneDisposition::Expunged { .. } => continue,
+            }
+        }
+
+        if !zones_ready_for_cleanup.is_empty() {
+            self.blueprint.mark_expunged_zones_ready_for_cleanup(
+                sled_id,
+                &zones_ready_for_cleanup,
+            )?;
         }
 
         Ok(())
@@ -3616,6 +3675,191 @@ pub(crate) mod test {
                 .all_omicron_zones(BlueprintZoneDisposition::is_in_service)
                 .filter(|(_, z)| z.zone_type.is_clickhouse())
                 .count()
+        );
+
+        logctx.cleanup_successful();
+    }
+
+    #[test]
+    fn test_zones_marked_ready_for_cleanup_based_on_inventory() {
+        static TEST_NAME: &str =
+            "planner_zones_marked_ready_for_cleanup_based_on_inventory";
+        let logctx = test_setup_log(TEST_NAME);
+        let log = logctx.log.clone();
+
+        // Use our example system.
+        let (mut collection, input, blueprint1) = example(&log, TEST_NAME);
+
+        // Find a Nexus zone we'll use for our test.
+        let (sled_id, nexus_config) = blueprint1
+            .blueprint_zones
+            .iter()
+            .find_map(|(sled_id, zones_config)| {
+                let nexus = zones_config
+                    .zones
+                    .iter()
+                    .find(|z| z.zone_type.is_nexus())?;
+                Some((*sled_id, nexus.clone()))
+            })
+            .expect("found a Nexus zone");
+
+        // Expunge the disk used by the Nexus zone.
+        let input = {
+            let nexus_zpool = nexus_config
+                .filesystem_pool
+                .as_ref()
+                .expect("Nexus has a filesystem pool");
+            let mut builder = input.into_builder();
+            builder
+                .sleds_mut()
+                .get_mut(&sled_id)
+                .expect("input has all sleds")
+                .resources
+                .zpools
+                .get_mut(&nexus_zpool.id())
+                .expect("input has Nexus disk")
+                .policy = PhysicalDiskPolicy::Expunged;
+            builder.build()
+        };
+
+        // Run the planner. It should expunge all zones on the disk we just
+        // expunged, including our Nexus zone, but not mark them as ready for
+        // cleanup yet.
+        let blueprint2 = Planner::new_based_on(
+            logctx.log.clone(),
+            &blueprint1,
+            &input,
+            "expunge disk",
+            &collection,
+        )
+        .expect("created planner")
+        .with_rng(PlannerRng::from_seed((TEST_NAME, "bp2")))
+        .plan()
+        .expect("planned");
+
+        // Helper to extract the Nexus zone's disposition in a blueprint.
+        let get_nexus_disposition = |bp: &Blueprint| {
+            bp.blueprint_zones.get(&sled_id).unwrap().zones.iter().find_map(
+                |z| {
+                    if z.id == nexus_config.id {
+                        Some(z.disposition)
+                    } else {
+                        None
+                    }
+                },
+            )
+        };
+
+        // This sled's zone config generation should have been bumped...
+        let bp2_generation =
+            blueprint2.blueprint_zones.get(&sled_id).unwrap().generation;
+        assert_eq!(
+            blueprint1.blueprint_zones.get(&sled_id).unwrap().generation.next(),
+            bp2_generation
+        );
+        // ... and the Nexus should should have the disposition we expect.
+        assert_eq!(
+            get_nexus_disposition(&blueprint2),
+            Some(BlueprintZoneDisposition::Expunged {
+                as_of_generation: bp2_generation,
+                ready_for_cleanup: false,
+            })
+        );
+
+        // Running the planner again should make no changes until the inventory
+        // reports that the zone is not running and that the sled has seen a
+        // new-enough generation. Try three variants that should do nothing:
+        //
+        // * same inventory as above
+        // * inventory reports a new generation (but zone still running)
+        // * inventory reports zone not running (but still the old generation)
+        assert_planning_makes_no_changes(
+            &logctx.log,
+            &blueprint2,
+            &input,
+            &collection,
+            TEST_NAME,
+        );
+        assert_planning_makes_no_changes(
+            &logctx.log,
+            &blueprint2,
+            &input,
+            &{
+                let mut collection = collection.clone();
+                collection
+                    .sled_agents
+                    .get_mut(&sled_id)
+                    .unwrap()
+                    .omicron_zones
+                    .generation = bp2_generation;
+                collection
+            },
+            TEST_NAME,
+        );
+        assert_planning_makes_no_changes(
+            &logctx.log,
+            &blueprint2,
+            &input,
+            &{
+                let mut collection = collection.clone();
+                collection
+                    .sled_agents
+                    .get_mut(&sled_id)
+                    .unwrap()
+                    .omicron_zones
+                    .zones
+                    .retain(|z| z.id != nexus_config.id);
+                collection
+            },
+            TEST_NAME,
+        );
+
+        // Now make both changes to the inventory.
+        {
+            let zones = &mut collection
+                .sled_agents
+                .get_mut(&sled_id)
+                .unwrap()
+                .omicron_zones;
+            zones.generation = bp2_generation;
+            zones.zones.retain(|z| z.id != nexus_config.id);
+        }
+
+        // Run the planner. It mark our Nexus zone as ready for cleanup now that
+        // the inventory conditions are satisfied.
+        let blueprint3 = Planner::new_based_on(
+            logctx.log.clone(),
+            &blueprint2,
+            &input,
+            "removed Nexus zone from inventory",
+            &collection,
+        )
+        .expect("created planner")
+        .with_rng(PlannerRng::from_seed((TEST_NAME, "bp3")))
+        .plan()
+        .expect("planned");
+
+        assert_eq!(
+            get_nexus_disposition(&blueprint3),
+            Some(BlueprintZoneDisposition::Expunged {
+                as_of_generation: bp2_generation,
+                ready_for_cleanup: true,
+            })
+        );
+
+        // ready_for_cleanup changes should not bump the config generation,
+        // since it doesn't affect what's sent to sled-agent.
+        assert_eq!(
+            blueprint3.blueprint_zones.get(&sled_id).unwrap().generation,
+            bp2_generation
+        );
+
+        assert_planning_makes_no_changes(
+            &logctx.log,
+            &blueprint3,
+            &input,
+            &collection,
+            TEST_NAME,
         );
 
         logctx.cleanup_successful();

--- a/nexus/reconfigurator/planning/tests/output/planner_decommissions_sleds_1_2.txt
+++ b/nexus/reconfigurator/planning/tests/output/planner_decommissions_sleds_1_2.txt
@@ -79,35 +79,35 @@ to:   blueprint 1ac2d88f-27dd-4506-8585-6b2be832528e
     zone type         zone id                                disposition      underlay IP           
     ------------------------------------------------------------------------------------------------
 *   clickhouse        3fd081ea-93f1-417e-bcb1-405854435f28   - in service     fd00:1122:3344:103::23
-     └─                                                      + expunged ⏳                           
+     └─                                                      + expunged ✓                           
 *   crucible          290e7e97-c4b3-47da-9f40-8d909397fbae   - in service     fd00:1122:3344:103::2e
-     └─                                                      + expunged ⏳                           
+     └─                                                      + expunged ✓                           
 *   crucible          29bbe4ad-e6e8-4e05-b188-a811a793ccbb   - in service     fd00:1122:3344:103::2a
-     └─                                                      + expunged ⏳                           
+     └─                                                      + expunged ✓                           
 *   crucible          8500a060-a426-4324-ba40-a66dd4b89bc6   - in service     fd00:1122:3344:103::29
-     └─                                                      + expunged ⏳                           
+     └─                                                      + expunged ✓                           
 *   crucible          92b7abd8-3e34-49dd-9c56-19a314e97d49   - in service     fd00:1122:3344:103::25
-     └─                                                      + expunged ⏳                           
+     └─                                                      + expunged ✓                           
 *   crucible          b320954e-6c66-4540-9bf4-3d976f21ee1b   - in service     fd00:1122:3344:103::26
-     └─                                                      + expunged ⏳                           
+     └─                                                      + expunged ✓                           
 *   crucible          bc3e4495-7e51-46b6-9f55-026ea1da39dd   - in service     fd00:1122:3344:103::27
-     └─                                                      + expunged ⏳                           
+     └─                                                      + expunged ✓                           
 *   crucible          cfb7595b-280c-40f5-b1aa-6e154adf280b   - in service     fd00:1122:3344:103::28
-     └─                                                      + expunged ⏳                           
+     └─                                                      + expunged ✓                           
 *   crucible          d6b6ea5a-3f29-4815-aa42-b1afeb11dfc5   - in service     fd00:1122:3344:103::2c
-     └─                                                      + expunged ⏳                           
+     └─                                                      + expunged ✓                           
 *   crucible          d6b77c1f-8c9e-406d-944e-c97a57b3984d   - in service     fd00:1122:3344:103::2b
-     └─                                                      + expunged ⏳                           
+     └─                                                      + expunged ✓                           
 *   crucible          ecc03801-b315-4495-9b2c-49e0eead1283   - in service     fd00:1122:3344:103::2d
-     └─                                                      + expunged ⏳                           
+     └─                                                      + expunged ✓                           
 *   crucible_pantry   ecebab45-11e7-47ab-8bc2-ab9114c6e2bc   - in service     fd00:1122:3344:103::24
-     └─                                                      + expunged ⏳                           
+     └─                                                      + expunged ✓                           
 *   internal_dns      96b7a45b-be74-44e8-b68a-e530cfa81830   - in service     fd00:1122:3344:1::1   
-     └─                                                      + expunged ⏳                           
+     └─                                                      + expunged ✓                           
 *   internal_ntp      b3dbc671-0e4d-49ff-9f4f-71b249d21f57   - in service     fd00:1122:3344:103::21
-     └─                                                      + expunged ⏳                           
+     └─                                                      + expunged ✓                           
 *   nexus             bc0f4342-f88d-49cc-bb44-b555d9b8ca12   - in service     fd00:1122:3344:103::22
-     └─                                                      + expunged ⏳                           
+     └─                                                      + expunged ✓                           
 
 
   sled d67ce8f0-a691-4010-b414-420d82e80527 (active):

--- a/nexus/reconfigurator/planning/tests/output/planner_decommissions_sleds_bp2.txt
+++ b/nexus/reconfigurator/planning/tests/output/planner_decommissions_sleds_bp2.txt
@@ -196,21 +196,21 @@ WARNING: Zones exist without physical disks!
     ----------------------------------------------------------------------------------------------
     zone type         zone id                                disposition    underlay IP           
     ----------------------------------------------------------------------------------------------
-    clickhouse        3fd081ea-93f1-417e-bcb1-405854435f28   expunged ⏳     fd00:1122:3344:103::23
-    crucible          290e7e97-c4b3-47da-9f40-8d909397fbae   expunged ⏳     fd00:1122:3344:103::2e
-    crucible          29bbe4ad-e6e8-4e05-b188-a811a793ccbb   expunged ⏳     fd00:1122:3344:103::2a
-    crucible          8500a060-a426-4324-ba40-a66dd4b89bc6   expunged ⏳     fd00:1122:3344:103::29
-    crucible          92b7abd8-3e34-49dd-9c56-19a314e97d49   expunged ⏳     fd00:1122:3344:103::25
-    crucible          b320954e-6c66-4540-9bf4-3d976f21ee1b   expunged ⏳     fd00:1122:3344:103::26
-    crucible          bc3e4495-7e51-46b6-9f55-026ea1da39dd   expunged ⏳     fd00:1122:3344:103::27
-    crucible          cfb7595b-280c-40f5-b1aa-6e154adf280b   expunged ⏳     fd00:1122:3344:103::28
-    crucible          d6b6ea5a-3f29-4815-aa42-b1afeb11dfc5   expunged ⏳     fd00:1122:3344:103::2c
-    crucible          d6b77c1f-8c9e-406d-944e-c97a57b3984d   expunged ⏳     fd00:1122:3344:103::2b
-    crucible          ecc03801-b315-4495-9b2c-49e0eead1283   expunged ⏳     fd00:1122:3344:103::2d
-    crucible_pantry   ecebab45-11e7-47ab-8bc2-ab9114c6e2bc   expunged ⏳     fd00:1122:3344:103::24
-    internal_dns      96b7a45b-be74-44e8-b68a-e530cfa81830   expunged ⏳     fd00:1122:3344:1::1   
-    internal_ntp      b3dbc671-0e4d-49ff-9f4f-71b249d21f57   expunged ⏳     fd00:1122:3344:103::21
-    nexus             bc0f4342-f88d-49cc-bb44-b555d9b8ca12   expunged ⏳     fd00:1122:3344:103::22
+    clickhouse        3fd081ea-93f1-417e-bcb1-405854435f28   expunged ✓     fd00:1122:3344:103::23
+    crucible          290e7e97-c4b3-47da-9f40-8d909397fbae   expunged ✓     fd00:1122:3344:103::2e
+    crucible          29bbe4ad-e6e8-4e05-b188-a811a793ccbb   expunged ✓     fd00:1122:3344:103::2a
+    crucible          8500a060-a426-4324-ba40-a66dd4b89bc6   expunged ✓     fd00:1122:3344:103::29
+    crucible          92b7abd8-3e34-49dd-9c56-19a314e97d49   expunged ✓     fd00:1122:3344:103::25
+    crucible          b320954e-6c66-4540-9bf4-3d976f21ee1b   expunged ✓     fd00:1122:3344:103::26
+    crucible          bc3e4495-7e51-46b6-9f55-026ea1da39dd   expunged ✓     fd00:1122:3344:103::27
+    crucible          cfb7595b-280c-40f5-b1aa-6e154adf280b   expunged ✓     fd00:1122:3344:103::28
+    crucible          d6b6ea5a-3f29-4815-aa42-b1afeb11dfc5   expunged ✓     fd00:1122:3344:103::2c
+    crucible          d6b77c1f-8c9e-406d-944e-c97a57b3984d   expunged ✓     fd00:1122:3344:103::2b
+    crucible          ecc03801-b315-4495-9b2c-49e0eead1283   expunged ✓     fd00:1122:3344:103::2d
+    crucible_pantry   ecebab45-11e7-47ab-8bc2-ab9114c6e2bc   expunged ✓     fd00:1122:3344:103::24
+    internal_dns      96b7a45b-be74-44e8-b68a-e530cfa81830   expunged ✓     fd00:1122:3344:1::1   
+    internal_ntp      b3dbc671-0e4d-49ff-9f4f-71b249d21f57   expunged ✓     fd00:1122:3344:103::21
+    nexus             bc0f4342-f88d-49cc-bb44-b555d9b8ca12   expunged ✓     fd00:1122:3344:103::22
 
 
 

--- a/nexus/reconfigurator/planning/tests/output/planner_expunge_clickhouse_clusters_3_4.txt
+++ b/nexus/reconfigurator/planning/tests/output/planner_expunge_clickhouse_clusters_3_4.txt
@@ -81,37 +81,37 @@ to:   blueprint 74f2e7fd-687e-4c9e-b5d8-e474a5bb8e7c
     zone type           zone id                                disposition      underlay IP           
     --------------------------------------------------------------------------------------------------
 *   clickhouse          96dcbb7a-0140-4590-801c-406866500995   - in service     fd00:1122:3344:101::23
-     └─                                                        + expunged ⏳                           
+     └─                                                        + expunged ✓                           
 *   clickhouse_keeper   1998de68-a305-44f7-8ebc-cc5613c9e6fb   - in service     fd00:1122:3344:101::2f
-     └─                                                        + expunged ⏳                           
+     └─                                                        + expunged ✓                           
 *   crucible            5366862d-0c9e-4c21-bd16-5599298e75bc   - in service     fd00:1122:3344:101::2b
-     └─                                                        + expunged ⏳                           
+     └─                                                        + expunged ✓                           
 *   crucible            63dcf460-2794-434c-b0e7-4e09ba0f3a3c   - in service     fd00:1122:3344:101::28
-     └─                                                        + expunged ⏳                           
+     └─                                                        + expunged ✓                           
 *   crucible            71f24994-337b-4c5f-9826-75f885a669e7   - in service     fd00:1122:3344:101::2e
-     └─                                                        + expunged ⏳                           
+     └─                                                        + expunged ✓                           
 *   crucible            726f6522-a359-4e6e-abe9-0de41979de91   - in service     fd00:1122:3344:101::26
-     └─                                                        + expunged ⏳                           
+     └─                                                        + expunged ✓                           
 *   crucible            a794a5cd-ec63-4fe4-a813-720d79dcd2ca   - in service     fd00:1122:3344:101::2d
-     └─                                                        + expunged ⏳                           
+     └─                                                        + expunged ✓                           
 *   crucible            ab480489-af1c-4446-8e95-da4a7e58df59   - in service     fd00:1122:3344:101::25
-     └─                                                        + expunged ⏳                           
+     └─                                                        + expunged ✓                           
 *   crucible            cc6e2a17-ba9b-4332-b869-e0ce204915cf   - in service     fd00:1122:3344:101::2c
-     └─                                                        + expunged ⏳                           
+     └─                                                        + expunged ✓                           
 *   crucible            e5cd215f-19c6-43ca-b31a-039319dd5dcf   - in service     fd00:1122:3344:101::29
-     └─                                                        + expunged ⏳                           
+     └─                                                        + expunged ✓                           
 *   crucible            e7bc709c-4ef2-4f1f-be78-494f53169554   - in service     fd00:1122:3344:101::2a
-     └─                                                        + expunged ⏳                           
+     └─                                                        + expunged ✓                           
 *   crucible            fbaea242-74a6-490f-9bc0-0710a40768f4   - in service     fd00:1122:3344:101::27
-     └─                                                        + expunged ⏳                           
+     └─                                                        + expunged ✓                           
 *   crucible_pantry     ed79fef8-6124-4ecc-aaa4-51cf9fcf58db   - in service     fd00:1122:3344:101::24
-     └─                                                        + expunged ⏳                           
+     └─                                                        + expunged ✓                           
 *   internal_dns        4d152a2b-089e-4fe2-89fa-76b53fa58773   - in service     fd00:1122:3344:1::1   
-     └─                                                        + expunged ⏳                           
+     └─                                                        + expunged ✓                           
 *   internal_ntp        89d38277-9743-491b-af94-714776657ce2   - in service     fd00:1122:3344:101::21
-     └─                                                        + expunged ⏳                           
+     └─                                                        + expunged ✓                           
 *   nexus               4cb9b6d5-fd52-4cfb-b630-59f80bd26615   - in service     fd00:1122:3344:101::22
-     └─                                                        + expunged ⏳                           
+     └─                                                        + expunged ✓                           
 
 
   sled cdba3bea-3407-4b6e-a029-19bf4a02fca7 (active):

--- a/nexus/reconfigurator/planning/tests/output/planner_expunge_clickhouse_clusters_5_6.txt
+++ b/nexus/reconfigurator/planning/tests/output/planner_expunge_clickhouse_clusters_5_6.txt
@@ -9,22 +9,22 @@ to:   blueprint df68d4d4-5af4-4b56-95bb-1654a6957d4f
     ------------------------------------------------------------------------------------------------
     zone type           zone id                                disposition    underlay IP           
     ------------------------------------------------------------------------------------------------
-    clickhouse          96dcbb7a-0140-4590-801c-406866500995   expunged ⏳     fd00:1122:3344:101::23
-    clickhouse_keeper   1998de68-a305-44f7-8ebc-cc5613c9e6fb   expunged ⏳     fd00:1122:3344:101::2f
-    crucible            5366862d-0c9e-4c21-bd16-5599298e75bc   expunged ⏳     fd00:1122:3344:101::2b
-    crucible            63dcf460-2794-434c-b0e7-4e09ba0f3a3c   expunged ⏳     fd00:1122:3344:101::28
-    crucible            71f24994-337b-4c5f-9826-75f885a669e7   expunged ⏳     fd00:1122:3344:101::2e
-    crucible            726f6522-a359-4e6e-abe9-0de41979de91   expunged ⏳     fd00:1122:3344:101::26
-    crucible            a794a5cd-ec63-4fe4-a813-720d79dcd2ca   expunged ⏳     fd00:1122:3344:101::2d
-    crucible            ab480489-af1c-4446-8e95-da4a7e58df59   expunged ⏳     fd00:1122:3344:101::25
-    crucible            cc6e2a17-ba9b-4332-b869-e0ce204915cf   expunged ⏳     fd00:1122:3344:101::2c
-    crucible            e5cd215f-19c6-43ca-b31a-039319dd5dcf   expunged ⏳     fd00:1122:3344:101::29
-    crucible            e7bc709c-4ef2-4f1f-be78-494f53169554   expunged ⏳     fd00:1122:3344:101::2a
-    crucible            fbaea242-74a6-490f-9bc0-0710a40768f4   expunged ⏳     fd00:1122:3344:101::27
-    crucible_pantry     ed79fef8-6124-4ecc-aaa4-51cf9fcf58db   expunged ⏳     fd00:1122:3344:101::24
-    internal_dns        4d152a2b-089e-4fe2-89fa-76b53fa58773   expunged ⏳     fd00:1122:3344:1::1   
-    internal_ntp        89d38277-9743-491b-af94-714776657ce2   expunged ⏳     fd00:1122:3344:101::21
-    nexus               4cb9b6d5-fd52-4cfb-b630-59f80bd26615   expunged ⏳     fd00:1122:3344:101::22
+    clickhouse          96dcbb7a-0140-4590-801c-406866500995   expunged ✓     fd00:1122:3344:101::23
+    clickhouse_keeper   1998de68-a305-44f7-8ebc-cc5613c9e6fb   expunged ✓     fd00:1122:3344:101::2f
+    crucible            5366862d-0c9e-4c21-bd16-5599298e75bc   expunged ✓     fd00:1122:3344:101::2b
+    crucible            63dcf460-2794-434c-b0e7-4e09ba0f3a3c   expunged ✓     fd00:1122:3344:101::28
+    crucible            71f24994-337b-4c5f-9826-75f885a669e7   expunged ✓     fd00:1122:3344:101::2e
+    crucible            726f6522-a359-4e6e-abe9-0de41979de91   expunged ✓     fd00:1122:3344:101::26
+    crucible            a794a5cd-ec63-4fe4-a813-720d79dcd2ca   expunged ✓     fd00:1122:3344:101::2d
+    crucible            ab480489-af1c-4446-8e95-da4a7e58df59   expunged ✓     fd00:1122:3344:101::25
+    crucible            cc6e2a17-ba9b-4332-b869-e0ce204915cf   expunged ✓     fd00:1122:3344:101::2c
+    crucible            e5cd215f-19c6-43ca-b31a-039319dd5dcf   expunged ✓     fd00:1122:3344:101::29
+    crucible            e7bc709c-4ef2-4f1f-be78-494f53169554   expunged ✓     fd00:1122:3344:101::2a
+    crucible            fbaea242-74a6-490f-9bc0-0710a40768f4   expunged ✓     fd00:1122:3344:101::27
+    crucible_pantry     ed79fef8-6124-4ecc-aaa4-51cf9fcf58db   expunged ✓     fd00:1122:3344:101::24
+    internal_dns        4d152a2b-089e-4fe2-89fa-76b53fa58773   expunged ✓     fd00:1122:3344:1::1   
+    internal_ntp        89d38277-9743-491b-af94-714776657ce2   expunged ✓     fd00:1122:3344:101::21
+    nexus               4cb9b6d5-fd52-4cfb-b630-59f80bd26615   expunged ✓     fd00:1122:3344:101::22
 
 
   sled cdba3bea-3407-4b6e-a029-19bf4a02fca7 (active):

--- a/nexus/reconfigurator/planning/tests/output/planner_nonprovisionable_1_2.txt
+++ b/nexus/reconfigurator/planning/tests/output/planner_nonprovisionable_1_2.txt
@@ -171,33 +171,33 @@ to:   blueprint 9f71f5d3-a272-4382-9154-6ea2e171a6c6
     zone type         zone id                                disposition      underlay IP           
     ------------------------------------------------------------------------------------------------
 *   crucible          085d10cb-a6f0-46de-86bc-ad2f7f1defcf   - in service     fd00:1122:3344:103::2d
-     └─                                                      + expunged ⏳                           
+     └─                                                      + expunged ✓                           
 *   crucible          2bf62dfa-537a-4616-aad5-64447faaec53   - in service     fd00:1122:3344:103::2b
-     └─                                                      + expunged ⏳                           
+     └─                                                      + expunged ✓                           
 *   crucible          50d43a78-e9af-4051-9f5d-85410f44214b   - in service     fd00:1122:3344:103::27
-     └─                                                      + expunged ⏳                           
+     └─                                                      + expunged ✓                           
 *   crucible          6e7b5239-0d2e-42a5-80aa-51a3bc859318   - in service     fd00:1122:3344:103::2a
-     └─                                                      + expunged ⏳                           
+     └─                                                      + expunged ✓                           
 *   crucible          8d87b485-3fb4-480b-97ce-02d066b799d7   - in service     fd00:1122:3344:103::26
-     └─                                                      + expunged ⏳                           
+     └─                                                      + expunged ✓                           
 *   crucible          b3d757b8-033f-4a68-82db-6ff5331b9739   - in service     fd00:1122:3344:103::25
-     └─                                                      + expunged ⏳                           
+     └─                                                      + expunged ✓                           
 *   crucible          bcd98cf5-a798-4aa0-81cc-8972a376073c   - in service     fd00:1122:3344:103::28
-     └─                                                      + expunged ⏳                           
+     └─                                                      + expunged ✓                           
 *   crucible          bd12d9d5-bccf-433a-b078-794a69aeb89a   - in service     fd00:1122:3344:103::29
-     └─                                                      + expunged ⏳                           
+     └─                                                      + expunged ✓                           
 *   crucible          d283707c-1b8f-4cb9-946d-041b25a83967   - in service     fd00:1122:3344:103::2c
-     └─                                                      + expunged ⏳                           
+     └─                                                      + expunged ✓                           
 *   crucible          e362415d-2d54-4574-b823-3f01b9b751de   - in service     fd00:1122:3344:103::24
-     └─                                                      + expunged ⏳                           
+     └─                                                      + expunged ✓                           
 *   crucible_pantry   208c987a-ab33-47a3-a103-6108dd6dc4cb   - in service     fd00:1122:3344:103::23
-     └─                                                      + expunged ⏳                           
+     └─                                                      + expunged ✓                           
 *   internal_dns      c428175e-6a1c-40bf-aa36-f608a57431f5   - in service     fd00:1122:3344:2::1   
-     └─                                                      + expunged ⏳                           
+     └─                                                      + expunged ✓                           
 *   internal_ntp      a8f1b53a-4231-4f04-9939-29e50a0f0e2c   - in service     fd00:1122:3344:103::21
-     └─                                                      + expunged ⏳                           
+     └─                                                      + expunged ✓                           
 *   nexus             533416e6-d0bd-482d-b592-29346c8a3471   - in service     fd00:1122:3344:103::22
-     └─                                                      + expunged ⏳                           
+     └─                                                      + expunged ✓                           
 
 
   sled 68d24ac5-f341-49ea-a92a-0381b52ab387 (decommissioned):

--- a/nexus/reconfigurator/planning/tests/output/planner_nonprovisionable_2_2a.txt
+++ b/nexus/reconfigurator/planning/tests/output/planner_nonprovisionable_2_2a.txt
@@ -306,20 +306,20 @@ to:   blueprint 9f71f5d3-a272-4382-9154-6ea2e171a6c6
     ----------------------------------------------------------------------------------------------
     zone type         zone id                                disposition    underlay IP           
     ----------------------------------------------------------------------------------------------
--   crucible          085d10cb-a6f0-46de-86bc-ad2f7f1defcf   expunged ⏳     fd00:1122:3344:103::2d
--   crucible          2bf62dfa-537a-4616-aad5-64447faaec53   expunged ⏳     fd00:1122:3344:103::2b
--   crucible          50d43a78-e9af-4051-9f5d-85410f44214b   expunged ⏳     fd00:1122:3344:103::27
--   crucible          6e7b5239-0d2e-42a5-80aa-51a3bc859318   expunged ⏳     fd00:1122:3344:103::2a
--   crucible          8d87b485-3fb4-480b-97ce-02d066b799d7   expunged ⏳     fd00:1122:3344:103::26
--   crucible          b3d757b8-033f-4a68-82db-6ff5331b9739   expunged ⏳     fd00:1122:3344:103::25
--   crucible          bcd98cf5-a798-4aa0-81cc-8972a376073c   expunged ⏳     fd00:1122:3344:103::28
--   crucible          bd12d9d5-bccf-433a-b078-794a69aeb89a   expunged ⏳     fd00:1122:3344:103::29
--   crucible          d283707c-1b8f-4cb9-946d-041b25a83967   expunged ⏳     fd00:1122:3344:103::2c
--   crucible          e362415d-2d54-4574-b823-3f01b9b751de   expunged ⏳     fd00:1122:3344:103::24
--   crucible_pantry   208c987a-ab33-47a3-a103-6108dd6dc4cb   expunged ⏳     fd00:1122:3344:103::23
--   internal_dns      c428175e-6a1c-40bf-aa36-f608a57431f5   expunged ⏳     fd00:1122:3344:2::1   
--   internal_ntp      a8f1b53a-4231-4f04-9939-29e50a0f0e2c   expunged ⏳     fd00:1122:3344:103::21
--   nexus             533416e6-d0bd-482d-b592-29346c8a3471   expunged ⏳     fd00:1122:3344:103::22
+-   crucible          085d10cb-a6f0-46de-86bc-ad2f7f1defcf   expunged ✓     fd00:1122:3344:103::2d
+-   crucible          2bf62dfa-537a-4616-aad5-64447faaec53   expunged ✓     fd00:1122:3344:103::2b
+-   crucible          50d43a78-e9af-4051-9f5d-85410f44214b   expunged ✓     fd00:1122:3344:103::27
+-   crucible          6e7b5239-0d2e-42a5-80aa-51a3bc859318   expunged ✓     fd00:1122:3344:103::2a
+-   crucible          8d87b485-3fb4-480b-97ce-02d066b799d7   expunged ✓     fd00:1122:3344:103::26
+-   crucible          b3d757b8-033f-4a68-82db-6ff5331b9739   expunged ✓     fd00:1122:3344:103::25
+-   crucible          bcd98cf5-a798-4aa0-81cc-8972a376073c   expunged ✓     fd00:1122:3344:103::28
+-   crucible          bd12d9d5-bccf-433a-b078-794a69aeb89a   expunged ✓     fd00:1122:3344:103::29
+-   crucible          d283707c-1b8f-4cb9-946d-041b25a83967   expunged ✓     fd00:1122:3344:103::2c
+-   crucible          e362415d-2d54-4574-b823-3f01b9b751de   expunged ✓     fd00:1122:3344:103::24
+-   crucible_pantry   208c987a-ab33-47a3-a103-6108dd6dc4cb   expunged ✓     fd00:1122:3344:103::23
+-   internal_dns      c428175e-6a1c-40bf-aa36-f608a57431f5   expunged ✓     fd00:1122:3344:2::1   
+-   internal_ntp      a8f1b53a-4231-4f04-9939-29e50a0f0e2c   expunged ✓     fd00:1122:3344:103::21
+-   nexus             533416e6-d0bd-482d-b592-29346c8a3471   expunged ✓     fd00:1122:3344:103::22
 
 
 ZONE ERRORS:

--- a/nexus/reconfigurator/planning/tests/output/planner_nonprovisionable_bp2.txt
+++ b/nexus/reconfigurator/planning/tests/output/planner_nonprovisionable_bp2.txt
@@ -281,20 +281,20 @@ WARNING: Zones exist without physical disks!
     ----------------------------------------------------------------------------------------------
     zone type         zone id                                disposition    underlay IP           
     ----------------------------------------------------------------------------------------------
-    crucible          085d10cb-a6f0-46de-86bc-ad2f7f1defcf   expunged ⏳     fd00:1122:3344:103::2d
-    crucible          2bf62dfa-537a-4616-aad5-64447faaec53   expunged ⏳     fd00:1122:3344:103::2b
-    crucible          50d43a78-e9af-4051-9f5d-85410f44214b   expunged ⏳     fd00:1122:3344:103::27
-    crucible          6e7b5239-0d2e-42a5-80aa-51a3bc859318   expunged ⏳     fd00:1122:3344:103::2a
-    crucible          8d87b485-3fb4-480b-97ce-02d066b799d7   expunged ⏳     fd00:1122:3344:103::26
-    crucible          b3d757b8-033f-4a68-82db-6ff5331b9739   expunged ⏳     fd00:1122:3344:103::25
-    crucible          bcd98cf5-a798-4aa0-81cc-8972a376073c   expunged ⏳     fd00:1122:3344:103::28
-    crucible          bd12d9d5-bccf-433a-b078-794a69aeb89a   expunged ⏳     fd00:1122:3344:103::29
-    crucible          d283707c-1b8f-4cb9-946d-041b25a83967   expunged ⏳     fd00:1122:3344:103::2c
-    crucible          e362415d-2d54-4574-b823-3f01b9b751de   expunged ⏳     fd00:1122:3344:103::24
-    crucible_pantry   208c987a-ab33-47a3-a103-6108dd6dc4cb   expunged ⏳     fd00:1122:3344:103::23
-    internal_dns      c428175e-6a1c-40bf-aa36-f608a57431f5   expunged ⏳     fd00:1122:3344:2::1   
-    internal_ntp      a8f1b53a-4231-4f04-9939-29e50a0f0e2c   expunged ⏳     fd00:1122:3344:103::21
-    nexus             533416e6-d0bd-482d-b592-29346c8a3471   expunged ⏳     fd00:1122:3344:103::22
+    crucible          085d10cb-a6f0-46de-86bc-ad2f7f1defcf   expunged ✓     fd00:1122:3344:103::2d
+    crucible          2bf62dfa-537a-4616-aad5-64447faaec53   expunged ✓     fd00:1122:3344:103::2b
+    crucible          50d43a78-e9af-4051-9f5d-85410f44214b   expunged ✓     fd00:1122:3344:103::27
+    crucible          6e7b5239-0d2e-42a5-80aa-51a3bc859318   expunged ✓     fd00:1122:3344:103::2a
+    crucible          8d87b485-3fb4-480b-97ce-02d066b799d7   expunged ✓     fd00:1122:3344:103::26
+    crucible          b3d757b8-033f-4a68-82db-6ff5331b9739   expunged ✓     fd00:1122:3344:103::25
+    crucible          bcd98cf5-a798-4aa0-81cc-8972a376073c   expunged ✓     fd00:1122:3344:103::28
+    crucible          bd12d9d5-bccf-433a-b078-794a69aeb89a   expunged ✓     fd00:1122:3344:103::29
+    crucible          d283707c-1b8f-4cb9-946d-041b25a83967   expunged ✓     fd00:1122:3344:103::2c
+    crucible          e362415d-2d54-4574-b823-3f01b9b751de   expunged ✓     fd00:1122:3344:103::24
+    crucible_pantry   208c987a-ab33-47a3-a103-6108dd6dc4cb   expunged ✓     fd00:1122:3344:103::23
+    internal_dns      c428175e-6a1c-40bf-aa36-f608a57431f5   expunged ✓     fd00:1122:3344:2::1   
+    internal_ntp      a8f1b53a-4231-4f04-9939-29e50a0f0e2c   expunged ✓     fd00:1122:3344:103::21
+    nexus             533416e6-d0bd-482d-b592-29346c8a3471   expunged ✓     fd00:1122:3344:103::22
 
 
 


### PR DESCRIPTION
This PR implements two related planner changes:

* When expunging a sled, all the zones are immediately marked as `Expunged { ready_for_cleanup: true, .. }`.
* When there are expunged zones on an in-service sled, we'll consult the latest inventory collection and flip `ready_to_cleanup` to true if the zone is gone and the sled's zone config generation is >= the generation in which the zone was expunged.

No downstream users of `ready_for_cleanup` are included in this PR; those will come in followups.