### PR TITLE
[nexus] increase timeout for test_driver_basic

### DIFF
--- a/nexus/src/app/background/driver.rs
+++ b/nexus/src/app/background/driver.rs
@@ -563,7 +563,7 @@ mod test {
 
         // Wait for four activations of our task.  (This is three periods.) That
         // should take between 300ms and 400ms.  Allow extra time for a busy
-        // system.
+        // system -- in practice, we've seen times up to 1.75 seconds.
         let start = Instant::now();
         let wall_start = Utc::now();
         wait_until_count(rx1.clone(), 4).await;
@@ -571,8 +571,8 @@ mod test {
         let duration = start.elapsed();
         println!("rx1 -> 3 took {:?}", duration);
         assert!(
-            duration.as_millis() < 1250,
-            "took longer than 1.25s to activate our \
+            duration < Duration::from_secs(3),
+            "took longer than 3s to activate our \
              every-100ms-task three times"
         );
         assert!(duration.as_millis() >= 300);


### PR DESCRIPTION
Fixes #6613.

I've seen this take up to 1.75 seconds locally, so bumping it up to 3s to give
it some margin.
