### PR TITLE
[internal-dns] fix for clickhouse zone services

### DIFF
--- a/internal-dns/types/src/names.rs
+++ b/internal-dns/types/src/names.rs
@@ -29,6 +29,8 @@ pub enum ServiceName {
     ClickhouseAdminKeeper,
     /// The HTTP interface for managing replicated clickhouse servers
     ClickhouseAdminServer,
+    /// The HTTP interface for managing a single node clickhouse server
+    ClickhouseAdminSingleServer,
     /// The native TCP interface to a ClickHouse server.
     ///
     /// NOTE: This is used for either single-node or a replicated cluster.
@@ -61,6 +63,9 @@ impl ServiceName {
             ServiceName::Clickhouse => "clickhouse",
             ServiceName::ClickhouseAdminKeeper => "clickhouse-admin-keeper",
             ServiceName::ClickhouseAdminServer => "clickhouse-admin-server",
+            ServiceName::ClickhouseAdminSingleServer => {
+                "clickhouse-admin-single-server"
+            }
             ServiceName::ClickhouseNative => "clickhouse-native",
             ServiceName::ClickhouseKeeper => "clickhouse-keeper",
             ServiceName::ClickhouseServer => "clickhouse-server",
@@ -90,6 +95,7 @@ impl ServiceName {
             ServiceName::Clickhouse
             | ServiceName::ClickhouseAdminKeeper
             | ServiceName::ClickhouseAdminServer
+            | ServiceName::ClickhouseAdminSingleServer
             | ServiceName::ClickhouseNative
             | ServiceName::ClickhouseKeeper
             | ServiceName::ClickhouseServer

--- a/internal-dns/types/tests/output/internal-dns-zone.txt
+++ b/internal-dns/types/tests/output/internal-dns-zone.txt
@@ -68,6 +68,18 @@ builder: "non_trivial"
       "data": "::1:4"
     }
   ],
+  "001de000-c04e-4000-8000-000000000005.host": [
+    {
+      "type": "AAAA",
+      "data": "::1:5"
+    }
+  ],
+  "001de000-c04e-4000-8000-000000000006.host": [
+    {
+      "type": "AAAA",
+      "data": "::1:6"
+    }
+  ],
   "_boundary-ntp._tcp": [
     {
       "type": "SRV",
@@ -76,6 +88,61 @@ builder: "non_trivial"
         "weight": 0,
         "port": 127,
         "target": "001de000-c04e-4000-8000-000000000002.host.control-plane.oxide.internal"
+      }
+    }
+  ],
+  "_clickhouse-admin-server._tcp": [
+    {
+      "type": "SRV",
+      "data": {
+        "prio": 0,
+        "weight": 0,
+        "port": 8888,
+        "target": "001de000-c04e-4000-8000-000000000006.host.control-plane.oxide.internal"
+      }
+    }
+  ],
+  "_clickhouse-admin-single-server._tcp": [
+    {
+      "type": "SRV",
+      "data": {
+        "prio": 0,
+        "weight": 0,
+        "port": 8888,
+        "target": "001de000-c04e-4000-8000-000000000005.host.control-plane.oxide.internal"
+      }
+    }
+  ],
+  "_clickhouse-native._tcp": [
+    {
+      "type": "SRV",
+      "data": {
+        "prio": 0,
+        "weight": 0,
+        "port": 9000,
+        "target": "001de000-c04e-4000-8000-000000000005.host.control-plane.oxide.internal"
+      }
+    }
+  ],
+  "_clickhouse-server._tcp": [
+    {
+      "type": "SRV",
+      "data": {
+        "prio": 0,
+        "weight": 0,
+        "port": 0,
+        "target": "001de000-c04e-4000-8000-000000000006.host.control-plane.oxide.internal"
+      }
+    }
+  ],
+  "_clickhouse._tcp": [
+    {
+      "type": "SRV",
+      "data": {
+        "prio": 0,
+        "weight": 0,
+        "port": 0,
+        "target": "001de000-c04e-4000-8000-000000000005.host.control-plane.oxide.internal"
       }
     }
   ],


### PR DESCRIPTION
This commit fixes an issue where the `ClickhouseNative` SRV record was pointing to both `clickhouse` and `clickhouse_cluster` IPs. This was causing Oximeter to indiscriminately write to either single node or cluster when both where running side by side. Additionally, we add a record for `ClickhouseSingleServerAdmin`.

## Manual testing on a local omicron deployment

### With only single node enabled

```console
coatlicue@centzon:~/src/omicron$ pfexec zlogin oxz_clickhouse_ae7bf43d-8234-4b6f-ab3a-540685f5ba41
[Connected to zone 'oxz_clickhouse_ae7bf43d-8234-4b6f-ab3a-540685f5ba41' pts/3]
The illumos Project     helios-2.0.23078        December 2024
root@oxz_clickhouse_ae7bf43d:~# nslookup -type=SRV _clickhouse-native._tcp.control-plane.oxide.internal
;; Got recursion not available from fd00:1122:3344:1::1, trying next server
;; Got recursion not available from fd00:1122:3344:2::1, trying next server
Server:         fd00:1122:3344:3::1
Address:        fd00:1122:3344:3::1#53

Non-authoritative answer:
_clickhouse-native._tcp.control-plane.oxide.internal    service = 0 0 9000 ae7bf43d-8234-4b6f-ab3a-540685f5ba41.host.control-plane.oxide.internal.

Authoritative answers can be found from:
ae7bf43d-8234-4b6f-ab3a-540685f5ba41.host.control-plane.oxide.internal  has AAAA address fd00:1122:3344:101::e

root@oxz_clickhouse_ae7bf43d:~# nslookup -type=SRV _clickhouse-admin-single-server._tcp.control-plane.oxide.internal
;; Got recursion not available from fd00:1122:3344:1::1, trying next server
;; Got recursion not available from fd00:1122:3344:2::1, trying next server
Server:         fd00:1122:3344:3::1
Address:        fd00:1122:3344:3::1#53

Non-authoritative answer:
_clickhouse-admin-single-server._tcp.control-plane.oxide.internal       service = 0 0 8888 ae7bf43d-8234-4b6f-ab3a-540685f5ba41.host.control-plane.oxide.internal.

Authoritative answers can be found from:
ae7bf43d-8234-4b6f-ab3a-540685f5ba41.host.control-plane.oxide.internal  has AAAA address fd00:1122:3344:101::e
```

### With both single node and cluster enabled

```console
root@oxz_clickhouse_ae7bf43d:~# nslookup -type=SRV _clickhouse-admin-single-server._tcp.control-plane.oxide.internal
;; Got recursion not available from fd00:1122:3344:1::1, trying next server
;; Got recursion not available from fd00:1122:3344:2::1, trying next server
Server:         fd00:1122:3344:3::1
Address:        fd00:1122:3344:3::1#53

Non-authoritative answer:
_clickhouse-admin-single-server._tcp.control-plane.oxide.internal       service = 0 0 8888 ae7bf43d-8234-4b6f-ab3a-540685f5ba41.host.control-plane.oxide.internal.

Authoritative answers can be found from:
ae7bf43d-8234-4b6f-ab3a-540685f5ba41.host.control-plane.oxide.internal  has AAAA address fd00:1122:3344:101::e

root@oxz_clickhouse_ae7bf43d:~# nslookup -type=SRV _clickhouse-native._tcp.control-plane.oxide.internal
;; Got recursion not available from fd00:1122:3344:1::1, trying next server
;; Got recursion not available from fd00:1122:3344:2::1, trying next server
Server:         fd00:1122:3344:3::1
Address:        fd00:1122:3344:3::1#53

Non-authoritative answer:
_clickhouse-native._tcp.control-plane.oxide.internal    service = 0 0 9000 ae7bf43d-8234-4b6f-ab3a-540685f5ba41.host.control-plane.oxide.internal.

Authoritative answers can be found from:
ae7bf43d-8234-4b6f-ab3a-540685f5ba41.host.control-plane.oxide.internal  has AAAA address fd00:1122:3344:101::e

root@oxz_clickhouse_ae7bf43d:~# nslookup -type=SRV _clickhouse-admin-server._tcp.control-plane.oxide.internal
;; Got recursion not available from fd00:1122:3344:1::1, trying next server
;; Got recursion not available from fd00:1122:3344:2::1, trying next server
Server:         fd00:1122:3344:3::1
Address:        fd00:1122:3344:3::1#53

Non-authoritative answer:
_clickhouse-admin-server._tcp.control-plane.oxide.internal      service = 0 0 8888 1ebb94b9-9cc4-4c4a-8402-f758cc3b1173.host.control-plane.oxide.internal.
_clickhouse-admin-server._tcp.control-plane.oxide.internal      service = 0 0 8888 b817f829-383f-402a-be4a-b393c1afdff0.host.control-plane.oxide.internal.
_clickhouse-admin-server._tcp.control-plane.oxide.internal      service = 0 0 8888 bdc23f73-83f9-4029-a749-2375d8cb4033.host.control-plane.oxide.internal.

Authoritative answers can be found from:
1ebb94b9-9cc4-4c4a-8402-f758cc3b1173.host.control-plane.oxide.internal  has AAAA address fd00:1122:3344:101::26
b817f829-383f-402a-be4a-b393c1afdff0.host.control-plane.oxide.internal  has AAAA address fd00:1122:3344:101::27
bdc23f73-83f9-4029-a749-2375d8cb4033.host.control-plane.oxide.internal  has AAAA address fd00:1122:3344:101::28
```

#### single-node

```console
root@oxz_clickhouse_ae7bf43d:~# /opt/oxide/clickhouse/clickhouse client --host fd00:1122:3344:101::e -q "select * from oximeter.fields_string limit 5"
ddm_router:originated_tunnel_endpoints  1927403117836933753     hostname        centzon
ddm_router:originated_tunnel_endpoints  13387177631086028603    hostname        oxz_switch
ddm_router:originated_underlay_prefixes 12164380667314673492    hostname        centzon
ddm_router:originated_underlay_prefixes 9657734132044246100     hostname        oxz_switch
ddm_session:advertisements_received     5533636839163709296     hostname        centzon
```

#### cluster

```console
oximeter_cluster_1 :) select * from oximeter.fields_string limit 5

SELECT *
FROM oximeter.fields_string
LIMIT 5

Query id: c4771ce0-1b36-4f48-aca9-068ec826a67b

Ok.

0 rows in set. Elapsed: 0.002 sec. 

Closes: https://github.com/oxidecomputer/omicron/issues/7577
```