### PR TITLE
Add --no-rebuild option to package subcommand

### DIFF
--- a/package/src/lib.rs
+++ b/package/src/lib.rs
@@ -117,6 +117,9 @@ pub enum BuildCommand {
         /// Limit to building only these packages
         #[clap(long)]
         only: Vec<PackageName>,
+        /// Do not rebuild, just repack
+        #[clap(long)]
+        no_rebuild: bool,
     },
     /// Stamps semver versions onto packages within a manifest
     Stamp {


### PR DESCRIPTION
For situations where you want to alter files and repack the packages but skip rebuilding the Rust source binaries.