### PR TITLE
`Blueprint`: Merge the four maps keyed by sled ID into a single map

### DIFF
--- a/nexus/db-model/src/deployment.rs
+++ b/nexus/db-model/src/deployment.rs
@@ -138,7 +138,7 @@ impl From<BpTarget> for nexus_types::deployment::BlueprintTarget {
     }
 }
 
-/// See [`nexus_types::deployment::Blueprint::sled_state`].
+/// See [`nexus_types::deployment::BlueprintSledConfig::state`].
 #[derive(Queryable, Clone, Debug, Selectable, Insertable)]
 #[diesel(table_name = bp_sled_state)]
 pub struct BpSledState {

--- a/nexus/db-queries/src/db/datastore/rack.rs
+++ b/nexus/db-queries/src/db/datastore/rack.rs
@@ -1012,8 +1012,11 @@ mod test {
         SledBuilder, SystemDescription,
     };
     use nexus_sled_agent_shared::inventory::OmicronZoneDataset;
-    use nexus_types::deployment::BlueprintZonesConfig;
     use nexus_types::deployment::CockroachDbPreserveDowngrade;
+    use nexus_types::deployment::{
+        BlueprintDatasetsConfig, BlueprintPhysicalDisksConfig,
+        BlueprintSledConfig, BlueprintZonesConfig,
+    };
     use nexus_types::deployment::{
         BlueprintZoneConfig, OmicronZoneExternalFloatingAddr,
         OmicronZoneExternalFloatingIp,
@@ -1054,10 +1057,7 @@ mod test {
                 rack_subnet: nexus_test_utils::RACK_SUBNET.parse().unwrap(),
                 blueprint: Blueprint {
                     id: BlueprintUuid::new_v4(),
-                    blueprint_zones: BTreeMap::new(),
-                    blueprint_disks: BTreeMap::new(),
-                    blueprint_datasets: BTreeMap::new(),
-                    sled_state: BTreeMap::new(),
+                    sleds: BTreeMap::new(),
                     cockroachdb_setting_preserve_downgrade:
                         CockroachDbPreserveDowngrade::DoNotModify,
                     parent_blueprint_id: None,
@@ -1306,10 +1306,23 @@ mod test {
         }
     }
 
-    fn sled_states_active(
-        sled_ids: impl Iterator<Item = SledUuid>,
-    ) -> BTreeMap<SledUuid, SledState> {
-        sled_ids.map(|sled_id| (sled_id, SledState::Active)).collect()
+    fn make_sled_config_only_zones(
+        blueprint_zones: BTreeMap<SledUuid, BlueprintZonesConfig>,
+    ) -> BTreeMap<SledUuid, BlueprintSledConfig> {
+        blueprint_zones
+            .into_iter()
+            .map(|(sled_id, zones_config)| {
+                (
+                    sled_id,
+                    BlueprintSledConfig {
+                        state: SledState::Active,
+                        disks_config: BlueprintPhysicalDisksConfig::default(),
+                        datasets_config: BlueprintDatasetsConfig::default(),
+                        zones_config,
+                    },
+                )
+            })
+            .collect()
     }
 
     #[tokio::test]
@@ -1539,10 +1552,7 @@ mod test {
         );
         let blueprint = Blueprint {
             id: BlueprintUuid::new_v4(),
-            sled_state: sled_states_active(blueprint_zones.keys().copied()),
-            blueprint_zones,
-            blueprint_disks: BTreeMap::new(),
-            blueprint_datasets: BTreeMap::new(),
+            sleds: make_sled_config_only_zones(blueprint_zones),
             cockroachdb_setting_preserve_downgrade:
                 CockroachDbPreserveDowngrade::DoNotModify,
             parent_blueprint_id: None,
@@ -1799,10 +1809,7 @@ mod test {
 
         let blueprint = Blueprint {
             id: BlueprintUuid::new_v4(),
-            sled_state: sled_states_active(blueprint_zones.keys().copied()),
-            blueprint_zones,
-            blueprint_disks: BTreeMap::new(),
-            blueprint_datasets: BTreeMap::new(),
+            sleds: make_sled_config_only_zones(blueprint_zones),
             cockroachdb_setting_preserve_downgrade:
                 CockroachDbPreserveDowngrade::DoNotModify,
             parent_blueprint_id: None,
@@ -2010,10 +2017,7 @@ mod test {
         );
         let blueprint = Blueprint {
             id: BlueprintUuid::new_v4(),
-            sled_state: sled_states_active(blueprint_zones.keys().copied()),
-            blueprint_zones,
-            blueprint_disks: BTreeMap::new(),
-            blueprint_datasets: BTreeMap::new(),
+            sleds: make_sled_config_only_zones(blueprint_zones),
             cockroachdb_setting_preserve_downgrade:
                 CockroachDbPreserveDowngrade::DoNotModify,
             parent_blueprint_id: None,
@@ -2152,10 +2156,7 @@ mod test {
 
         let blueprint = Blueprint {
             id: BlueprintUuid::new_v4(),
-            sled_state: sled_states_active(blueprint_zones.keys().copied()),
-            blueprint_zones,
-            blueprint_disks: BTreeMap::new(),
-            blueprint_datasets: BTreeMap::new(),
+            sleds: make_sled_config_only_zones(blueprint_zones),
             cockroachdb_setting_preserve_downgrade:
                 CockroachDbPreserveDowngrade::DoNotModify,
             parent_blueprint_id: None,

--- a/nexus/db-queries/src/db/datastore/vpc.rs
+++ b/nexus/db-queries/src/db/datastore/vpc.rs
@@ -3260,7 +3260,7 @@ mod tests {
             .service_create_network_interface_raw(
                 &opctx,
                 db_nic_from_zone(
-                    bp1.blueprint_zones[&sled_ids[2]].zones.first().unwrap(),
+                    bp1.sleds[&sled_ids[2]].zones_config.zones.first().unwrap(),
                 ),
             )
             .await
@@ -3274,10 +3274,11 @@ mod tests {
             let mut bp2 = bp1.clone();
             bp2.id = BlueprintUuid::new_v4();
             bp2.parent_blueprint_id = Some(bp1.id);
-            let sled2_zones = bp2
-                .blueprint_zones
+            let sled2_zones = &mut bp2
+                .sleds
                 .get_mut(&sled_ids[2])
-                .expect("zones for third sled");
+                .expect("config for third sled")
+                .zones_config;
             sled2_zones.zones.clear();
             sled2_zones.generation = sled2_zones.generation.next();
             bp2
@@ -3292,7 +3293,8 @@ mod tests {
         datastore
             .service_delete_network_interface(
                 &opctx,
-                bp1.blueprint_zones[&sled_ids[2]]
+                bp1.sleds[&sled_ids[2]]
+                    .zones_config
                     .zones
                     .first()
                     .unwrap()
@@ -3327,7 +3329,7 @@ mod tests {
                 .service_create_network_interface_raw(
                     &opctx,
                     db_nic_from_zone(
-                        bp3.blueprint_zones[&sled_id].zones.first().unwrap(),
+                        bp3.sleds[&sled_id].zones_config.zones.first().unwrap(),
                     ),
                 )
                 .await
@@ -3377,10 +3379,11 @@ mod tests {
             bp4.parent_blueprint_id = Some(bp3.id);
 
             // Sled index 3's zone is expunged (should be excluded).
-            let sled3 = bp4
-                .blueprint_zones
+            let sled3 = &mut bp4
+                .sleds
                 .get_mut(&sled_ids[3])
-                .expect("zones for sled");
+                .expect("config for sled")
+                .zones_config;
             sled3.zones.iter_mut().next().unwrap().disposition =
                 BlueprintZoneDisposition::Expunged {
                     as_of_generation: Generation::new(),

--- a/nexus/reconfigurator/blippy/src/checks.rs
+++ b/nexus/reconfigurator/blippy/src/checks.rs
@@ -3,7 +3,6 @@
 // file, You can obtain one at https://mozilla.org/MPL/2.0/.
 
 use crate::blippy::Blippy;
-use crate::blippy::MultimapInconsistency;
 use crate::blippy::Severity;
 use crate::blippy::SledKind;
 use nexus_sled_agent_shared::inventory::ZoneKind;
@@ -11,6 +10,7 @@ use nexus_types::deployment::blueprint_zone_type;
 use nexus_types::deployment::BlueprintDatasetConfig;
 use nexus_types::deployment::BlueprintDatasetFilter;
 use nexus_types::deployment::BlueprintPhysicalDiskDisposition;
+use nexus_types::deployment::BlueprintSledConfig;
 use nexus_types::deployment::BlueprintZoneConfig;
 use nexus_types::deployment::BlueprintZoneDisposition;
 use nexus_types::deployment::BlueprintZoneType;
@@ -27,91 +27,10 @@ use std::collections::BTreeSet;
 use std::net::Ipv6Addr;
 
 pub(crate) fn perform_all_blueprint_only_checks(blippy: &mut Blippy<'_>) {
-    check_multiple_map_keys(blippy);
     check_underlay_ips(blippy);
     check_external_networking(blippy);
     check_dataset_zpool_uniqueness(blippy);
     check_datasets(blippy);
-}
-
-fn check_multiple_map_keys(blippy: &mut Blippy<'_>) {
-    // Until we merge the maps together
-    // (https://github.com/oxidecomputer/omicron/issues/7078), we'll treat
-    // `blueprint_zones` as the "primary" map. Any sled present in
-    // `blueprint_zones` should also have an entry in:
-    //
-    // * `sled_state`
-    // * `blueprint_disks`
-    // * `blueprint_datasets`
-    let blueprint = blippy.blueprint();
-
-    for &sled_id in blueprint.blueprint_zones.keys() {
-        if !blueprint.sled_state.contains_key(&sled_id) {
-            blippy.push_sled_note(
-                sled_id,
-                Severity::BackwardsCompatibility,
-                SledKind::MultimapInconsistency(
-                    MultimapInconsistency::PresentInZonesNotState,
-                ),
-            );
-        }
-
-        if !blueprint.blueprint_disks.contains_key(&sled_id) {
-            blippy.push_sled_note(
-                sled_id,
-                Severity::BackwardsCompatibility,
-                SledKind::MultimapInconsistency(
-                    MultimapInconsistency::PresentInZonesNotDisks,
-                ),
-            );
-        }
-
-        if !blueprint.blueprint_datasets.contains_key(&sled_id) {
-            blippy.push_sled_note(
-                sled_id,
-                Severity::BackwardsCompatibility,
-                SledKind::MultimapInconsistency(
-                    MultimapInconsistency::PresentInZonesNotDatasets,
-                ),
-            );
-        }
-    }
-
-    // Also check the other direction: do any of the "non-primary" maps have
-    // sleds that aren't in `blueprint_zones`?
-    for &sled_id in blueprint.sled_state.keys() {
-        if !blueprint.blueprint_zones.contains_key(&sled_id) {
-            blippy.push_sled_note(
-                sled_id,
-                Severity::BackwardsCompatibility,
-                SledKind::MultimapInconsistency(
-                    MultimapInconsistency::PresentInStateNotZones,
-                ),
-            );
-        }
-    }
-    for &sled_id in blueprint.blueprint_disks.keys() {
-        if !blueprint.blueprint_zones.contains_key(&sled_id) {
-            blippy.push_sled_note(
-                sled_id,
-                Severity::BackwardsCompatibility,
-                SledKind::MultimapInconsistency(
-                    MultimapInconsistency::PresentInDisksNotZones,
-                ),
-            );
-        }
-    }
-    for &sled_id in blueprint.blueprint_datasets.keys() {
-        if !blueprint.blueprint_zones.contains_key(&sled_id) {
-            blippy.push_sled_note(
-                sled_id,
-                Severity::BackwardsCompatibility,
-                SledKind::MultimapInconsistency(
-                    MultimapInconsistency::PresentInDatasetsNotZones,
-                ),
-            );
-        }
-    }
 }
 
 fn check_underlay_ips(blippy: &mut Blippy<'_>) {
@@ -374,181 +293,80 @@ fn check_dataset_zpool_uniqueness(blippy: &mut Blippy<'_>) {
 type DatasetByKind<'a> = BTreeMap<DatasetKind, &'a BlueprintDatasetConfig>;
 type DatasetsByZpool<'a> = BTreeMap<ZpoolUuid, DatasetByKind<'a>>;
 
-#[derive(Debug)]
-struct DatasetsBySled<'a> {
+#[derive(Debug, Default)]
+struct DatasetsBySledCache<'a> {
     by_sled: BTreeMap<SledUuid, DatasetsByZpool<'a>>,
-    noted_sleds_missing_datasets: BTreeSet<SledUuid>,
 }
 
-impl<'a> DatasetsBySled<'a> {
-    fn new(blippy: &mut Blippy<'a>) -> Self {
-        let mut by_sled = BTreeMap::new();
+impl<'a> DatasetsBySledCache<'a> {
+    fn get_cached(
+        &mut self,
+        blippy: &mut Blippy<'_>,
+        sled_id: SledUuid,
+        sled_config: &'a BlueprintSledConfig,
+    ) -> &DatasetsByZpool<'a> {
+        let vacant_entry = match self.by_sled.entry(sled_id) {
+            Entry::Vacant(vacant_entry) => vacant_entry,
+            Entry::Occupied(occupied_entry) => {
+                return occupied_entry.into_mut()
+            }
+        };
 
-        for (&sled_id, config) in &blippy.blueprint().blueprint_datasets {
-            let by_zpool: &mut BTreeMap<_, _> =
-                by_sled.entry(sled_id).or_default();
+        let config = &sled_config.datasets_config;
+        let mut by_zpool = BTreeMap::new();
 
-            for dataset in config.datasets.iter() {
-                let by_kind: &mut BTreeMap<_, _> =
-                    by_zpool.entry(dataset.pool.id()).or_default();
+        for dataset in config.datasets.iter() {
+            let by_kind: &mut BTreeMap<_, _> =
+                by_zpool.entry(dataset.pool.id()).or_default();
 
-                match by_kind.entry(dataset.kind.clone()) {
-                    Entry::Vacant(slot) => {
-                        slot.insert(dataset);
-                    }
-                    Entry::Occupied(prev) => {
-                        blippy.push_sled_note(
-                            sled_id,
-                            Severity::Fatal,
-                            SledKind::ZpoolWithDuplicateDatasetKinds {
-                                dataset1: (*prev.get()).clone(),
-                                dataset2: dataset.clone(),
-                                zpool: dataset.pool.id(),
-                            },
-                        );
-                    }
+            match by_kind.entry(dataset.kind.clone()) {
+                Entry::Vacant(slot) => {
+                    slot.insert(dataset);
+                }
+                Entry::Occupied(prev) => {
+                    blippy.push_sled_note(
+                        sled_id,
+                        Severity::Fatal,
+                        SledKind::ZpoolWithDuplicateDatasetKinds {
+                            dataset1: (*prev.get()).clone(),
+                            dataset2: dataset.clone(),
+                            zpool: dataset.pool.id(),
+                        },
+                    );
                 }
             }
         }
 
-        Self { by_sled, noted_sleds_missing_datasets: BTreeSet::new() }
-    }
-
-    // Get the datasets for each zpool on a given sled, or add a fatal note to
-    // `blippy` that the sled is missing an entry in `blueprint_datasets` for
-    // the specified reason `why`.
-    fn get_sled_or_note_missing(
-        &mut self,
-        blippy: &mut Blippy<'_>,
-        sled_id: SledUuid,
-        why: &'static str,
-    ) -> Option<&DatasetsByZpool<'a>> {
-        let maybe_datasets = self.by_sled.get(&sled_id);
-        if maybe_datasets.is_none()
-            && self.noted_sleds_missing_datasets.insert(sled_id)
-        {
-            blippy.push_sled_note(
-                sled_id,
-                Severity::Fatal,
-                SledKind::SledMissingDatasets { why },
-            );
-        }
-        maybe_datasets
+        vacant_entry.insert(by_zpool)
     }
 }
 
 fn check_datasets(blippy: &mut Blippy<'_>) {
-    let mut datasets = DatasetsBySled::new(blippy);
+    let mut datasets = DatasetsBySledCache::default();
 
     // As we loop through all the datasets we expect to see, mark them down.
     // Afterwards, we'll check for any datasets present that we _didn't_ expect
     // to see.
     let mut expected_datasets = BTreeSet::new();
 
-    // All disks should have debug and zone root datasets.
-    for (sled_id, disk) in blippy
-        .blueprint()
-        .all_omicron_disks(BlueprintPhysicalDiskDisposition::is_in_service)
-    {
-        // Note: This may be called multiple times per `sled_id`,
-        // which is somewhat inefficient. However it will still only report
-        // one error note per `sled_id`.
-        let Some(sled_datasets) = datasets.get_sled_or_note_missing(
-            blippy,
-            sled_id,
-            "sled has an entry in blueprint_disks",
-        ) else {
-            continue;
-        };
-
-        let sled_datasets = sled_datasets.get(&disk.pool_id);
-
-        match sled_datasets
-            .and_then(|by_zpool| by_zpool.get(&DatasetKind::Debug))
-        {
-            Some(dataset) => {
-                expected_datasets.insert(dataset.id);
-            }
-            None => {
-                blippy.push_sled_note(
-                    sled_id,
-                    Severity::Fatal,
-                    SledKind::ZpoolMissingDebugDataset { zpool: disk.pool_id },
-                );
-            }
-        }
-
-        match sled_datasets
-            .and_then(|by_zpool| by_zpool.get(&DatasetKind::TransientZoneRoot))
-        {
-            Some(dataset) => {
-                expected_datasets.insert(dataset.id);
-            }
-            None => {
-                blippy.push_sled_note(
-                    sled_id,
-                    Severity::Fatal,
-                    SledKind::ZpoolMissingZoneRootDataset {
-                        zpool: disk.pool_id,
-                    },
-                );
-            }
-        }
-    }
-
     // In a check below, we want to look up Crucible zones by zpool; build that
     // map as we perform the next set of checks.
     let mut crucible_zone_by_zpool = BTreeMap::new();
 
-    // There should be a dataset for every dataset referenced by a running zone
-    // (filesystem or durable).
-    for (sled_id, zone_config) in blippy
-        .blueprint()
-        .all_omicron_zones(BlueprintZoneDisposition::is_in_service)
-    {
-        let Some(sled_datasets) = datasets.get_sled_or_note_missing(
-            blippy,
-            sled_id,
-            "sled has running zones",
-        ) else {
-            continue;
-        };
+    // All disks should have debug and zone root datasets.
+    for (&sled_id, sled_config) in &blippy.blueprint().sleds {
+        let sled_datasets = datasets.get_cached(blippy, sled_id, sled_config);
 
-        match &zone_config.filesystem_dataset() {
-            Some(dataset) => {
-                match sled_datasets
-                    .get(&dataset.pool().id())
-                    .and_then(|by_zpool| by_zpool.get(dataset.kind()))
-                {
-                    Some(dataset) => {
-                        expected_datasets.insert(dataset.id);
-                    }
-                    None => {
-                        blippy.push_sled_note(
-                            sled_id,
-                            Severity::Fatal,
-                            SledKind::ZoneMissingFilesystemDataset {
-                                zone: zone_config.clone(),
-                            },
-                        );
-                    }
-                }
-            }
-            None => {
-                blippy.push_sled_note(
-                    sled_id,
-                    Severity::BackwardsCompatibility,
-                    SledKind::ZoneMissingFilesystemPool {
-                        zone: zone_config.clone(),
-                    },
-                );
-            }
-        }
+        for disk in sled_config
+            .disks_config
+            .disks
+            .iter()
+            .filter(|d| d.disposition.is_in_service())
+        {
+            let sled_datasets = sled_datasets.get(&disk.pool_id);
 
-        if let Some(dataset) = zone_config.zone_type.durable_dataset() {
             match sled_datasets
-                .get(&dataset.dataset.pool_name.id())
-                .and_then(|by_zpool| by_zpool.get(&dataset.kind))
+                .and_then(|by_zpool| by_zpool.get(&DatasetKind::Debug))
             {
                 Some(dataset) => {
                     expected_datasets.insert(dataset.id);
@@ -557,49 +375,117 @@ fn check_datasets(blippy: &mut Blippy<'_>) {
                     blippy.push_sled_note(
                         sled_id,
                         Severity::Fatal,
-                        SledKind::ZoneMissingDurableDataset {
+                        SledKind::ZpoolMissingDebugDataset {
+                            zpool: disk.pool_id,
+                        },
+                    );
+                }
+            }
+
+            match sled_datasets.and_then(|by_zpool| {
+                by_zpool.get(&DatasetKind::TransientZoneRoot)
+            }) {
+                Some(dataset) => {
+                    expected_datasets.insert(dataset.id);
+                }
+                None => {
+                    blippy.push_sled_note(
+                        sled_id,
+                        Severity::Fatal,
+                        SledKind::ZpoolMissingZoneRootDataset {
+                            zpool: disk.pool_id,
+                        },
+                    );
+                }
+            }
+        }
+
+        // There should be a dataset for every dataset referenced by a running
+        // zone (filesystem or durable).
+        for zone_config in sled_config
+            .zones_config
+            .zones
+            .iter()
+            .filter(|z| z.disposition.is_in_service())
+        {
+            match &zone_config.filesystem_dataset() {
+                Some(dataset) => {
+                    match sled_datasets
+                        .get(&dataset.pool().id())
+                        .and_then(|by_zpool| by_zpool.get(dataset.kind()))
+                    {
+                        Some(dataset) => {
+                            expected_datasets.insert(dataset.id);
+                        }
+                        None => {
+                            blippy.push_sled_note(
+                                sled_id,
+                                Severity::Fatal,
+                                SledKind::ZoneMissingFilesystemDataset {
+                                    zone: zone_config.clone(),
+                                },
+                            );
+                        }
+                    }
+                }
+                None => {
+                    blippy.push_sled_note(
+                        sled_id,
+                        Severity::BackwardsCompatibility,
+                        SledKind::ZoneMissingFilesystemPool {
                             zone: zone_config.clone(),
                         },
                     );
                 }
             }
 
-            if dataset.kind == DatasetKind::Crucible {
-                match &zone_config.zone_type {
-                    BlueprintZoneType::Crucible(crucible_zone_config) => {
-                        crucible_zone_by_zpool.insert(
-                            dataset.dataset.pool_name.id(),
-                            crucible_zone_config,
+            if let Some(dataset) = zone_config.zone_type.durable_dataset() {
+                match sled_datasets
+                    .get(&dataset.dataset.pool_name.id())
+                    .and_then(|by_zpool| by_zpool.get(&dataset.kind))
+                {
+                    Some(dataset) => {
+                        expected_datasets.insert(dataset.id);
+                    }
+                    None => {
+                        blippy.push_sled_note(
+                            sled_id,
+                            Severity::Fatal,
+                            SledKind::ZoneMissingDurableDataset {
+                                zone: zone_config.clone(),
+                            },
                         );
                     }
-                    _ => unreachable!(
-                        "zone_type.durable_dataset() returned Crucible for \
-                         non-Crucible zone type"
-                    ),
+                }
+
+                if dataset.kind == DatasetKind::Crucible {
+                    match &zone_config.zone_type {
+                        BlueprintZoneType::Crucible(crucible_zone_config) => {
+                            crucible_zone_by_zpool.insert(
+                                dataset.dataset.pool_name.id(),
+                                crucible_zone_config,
+                            );
+                        }
+                        _ => unreachable!(
+                            "zone_type.durable_dataset() returned Crucible for \
+                             non-Crucible zone type"
+                        ),
+                    }
                 }
             }
         }
     }
 
-    // TODO-correctness We currently only include in-service disks in the
-    // blueprint; once we include expunged or decommissioned disks too, we
-    // should filter here to only in-service.
-    let in_service_sled_zpools = blippy
+    let mut in_service_sled_zpools: BTreeMap<_, BTreeSet<_>> = BTreeMap::new();
+    for (sled_id, disk_config) in blippy
         .blueprint()
-        .blueprint_disks
-        .iter()
-        .map(|(sled_id, disk_config)| {
-            (
-                sled_id,
-                disk_config
-                    .disks
-                    .iter()
-                    .map(|disk| disk.pool_id)
-                    .collect::<BTreeSet<_>>(),
-            )
-        })
-        .collect::<BTreeMap<_, _>>();
-    let mut noted_sleds_without_disks = BTreeSet::new();
+        .all_omicron_disks(BlueprintPhysicalDiskDisposition::is_in_service)
+    {
+        in_service_sled_zpools
+            .entry(sled_id)
+            .or_default()
+            .insert(disk_config.pool_id);
+    }
 
     // All datasets should be on zpools that have disk records, and all datasets
     // should have been referenced by either a zone or a disk above.
@@ -616,19 +502,7 @@ fn check_datasets(blippy: &mut Blippy<'_>) {
             continue;
         }
 
-        let Some(sled_zpools) = in_service_sled_zpools.get(&sled_id) else {
-            if noted_sleds_without_disks.insert(sled_id) {
-                blippy.push_sled_note(
-                    sled_id,
-                    Severity::Fatal,
-                    SledKind::SledMissingDisks {
-                        why: "sled has in-service datasets",
-                    },
-                );
-            }
-            continue;
-        };
-
+        let sled_zpools = in_service_sled_zpools.entry(sled_id).or_default();
         if !sled_zpools.contains(&dataset.pool.id()) {
             blippy.push_sled_note(
                 sled_id,
@@ -725,17 +599,18 @@ mod tests {
         let (_, _, mut blueprint) = example(&logctx.log, TEST_NAME);
 
         // Copy the underlay IP from one Nexus to another.
-        let mut nexus_iter = blueprint.blueprint_zones.iter_mut().flat_map(
-            |(sled_id, zones_config)| {
-                zones_config.zones.iter_mut().filter_map(move |zone| {
-                    if zone.zone_type.is_nexus() {
-                        Some((*sled_id, zone))
-                    } else {
-                        None
-                    }
-                })
-            },
-        );
+        let mut nexus_iter =
+            blueprint.sleds.iter_mut().flat_map(|(sled_id, sled_config)| {
+                sled_config.zones_config.zones.iter_mut().filter_map(
+                    move |zone| {
+                        if zone.zone_type.is_nexus() {
+                            Some((*sled_id, zone))
+                        } else {
+                            None
+                        }
+                    },
+                )
+            });
         let (nexus0_sled_id, nexus0) =
             nexus_iter.next().expect("at least one Nexus zone");
         let (nexus1_sled_id, mut nexus1) =
@@ -761,9 +636,10 @@ mod tests {
         let nexus1 = nexus1.into_ref().clone();
         let (mixed_underlay_zone1, mixed_underlay_zone2) = {
             let mut sled1_zones = blueprint
-                .blueprint_zones
+                .sleds
                 .get(&nexus1_sled_id)
                 .unwrap()
+                .zones_config
                 .zones
                 .iter();
             let sled1_zone1 = sled1_zones.next().expect("at least one zone");
@@ -828,17 +704,17 @@ mod tests {
 
         // Change the second internal DNS zone to be from a different rack
         // subnet.
-        let mut internal_dns_iter = blueprint
-            .blueprint_zones
-            .iter_mut()
-            .flat_map(|(sled_id, zones_config)| {
-                zones_config.zones.iter_mut().filter_map(move |zone| {
-                    if zone.zone_type.is_internal_dns() {
-                        Some((*sled_id, zone))
-                    } else {
-                        None
-                    }
-                })
+        let mut internal_dns_iter =
+            blueprint.sleds.iter_mut().flat_map(|(sled_id, sled_config)| {
+                sled_config.zones_config.zones.iter_mut().filter_map(
+                    move |zone| {
+                        if zone.zone_type.is_internal_dns() {
+                            Some((*sled_id, zone))
+                        } else {
+                            None
+                        }
+                    },
+                )
             });
         let (dns0_sled_id, dns0) =
             internal_dns_iter.next().expect("at least one internal DNS zone");
@@ -914,17 +790,18 @@ mod tests {
         let (_, _, mut blueprint) = example(&logctx.log, TEST_NAME);
 
         // Copy the external IP from one Nexus to another.
-        let mut nexus_iter = blueprint.blueprint_zones.iter_mut().flat_map(
-            |(sled_id, zones_config)| {
-                zones_config.zones.iter_mut().filter_map(move |zone| {
-                    if zone.zone_type.is_nexus() {
-                        Some((*sled_id, zone))
-                    } else {
-                        None
-                    }
-                })
-            },
-        );
+        let mut nexus_iter =
+            blueprint.sleds.iter_mut().flat_map(|(sled_id, sled_config)| {
+                sled_config.zones_config.zones.iter_mut().filter_map(
+                    move |zone| {
+                        if zone.zone_type.is_nexus() {
+                            Some((*sled_id, zone))
+                        } else {
+                            None
+                        }
+                    },
+                )
+            });
         let (nexus0_sled_id, nexus0) =
             nexus_iter.next().expect("at least one Nexus zone");
         let (nexus1_sled_id, mut nexus1) =
@@ -987,17 +864,18 @@ mod tests {
         let (_, _, mut blueprint) = example(&logctx.log, TEST_NAME);
 
         // Copy the external IP from one Nexus to another.
-        let mut nexus_iter = blueprint.blueprint_zones.iter_mut().flat_map(
-            |(sled_id, zones_config)| {
-                zones_config.zones.iter_mut().filter_map(move |zone| {
-                    if zone.zone_type.is_nexus() {
-                        Some((*sled_id, zone))
-                    } else {
-                        None
-                    }
-                })
-            },
-        );
+        let mut nexus_iter =
+            blueprint.sleds.iter_mut().flat_map(|(sled_id, sled_config)| {
+                sled_config.zones_config.zones.iter_mut().filter_map(
+                    move |zone| {
+                        if zone.zone_type.is_nexus() {
+                            Some((*sled_id, zone))
+                        } else {
+                            None
+                        }
+                    },
+                )
+            });
         let (nexus0_sled_id, nexus0) =
             nexus_iter.next().expect("at least one Nexus zone");
         let (nexus1_sled_id, mut nexus1) =
@@ -1055,17 +933,18 @@ mod tests {
         let (_, _, mut blueprint) = example(&logctx.log, TEST_NAME);
 
         // Copy the external IP from one Nexus to another.
-        let mut nexus_iter = blueprint.blueprint_zones.iter_mut().flat_map(
-            |(sled_id, zones_config)| {
-                zones_config.zones.iter_mut().filter_map(move |zone| {
-                    if zone.zone_type.is_nexus() {
-                        Some((*sled_id, zone))
-                    } else {
-                        None
-                    }
-                })
-            },
-        );
+        let mut nexus_iter =
+            blueprint.sleds.iter_mut().flat_map(|(sled_id, sled_config)| {
+                sled_config.zones_config.zones.iter_mut().filter_map(
+                    move |zone| {
+                        if zone.zone_type.is_nexus() {
+                            Some((*sled_id, zone))
+                        } else {
+                            None
+                        }
+                    },
+                )
+            });
         let (nexus0_sled_id, nexus0) =
             nexus_iter.next().expect("at least one Nexus zone");
         let (nexus1_sled_id, mut nexus1) =
@@ -1127,17 +1006,18 @@ mod tests {
                 .build();
 
         // Copy the durable zpool from one external DNS to another.
-        let mut dns_iter = blueprint.blueprint_zones.iter_mut().flat_map(
-            |(sled_id, zones_config)| {
-                zones_config.zones.iter_mut().filter_map(move |zone| {
-                    if zone.zone_type.is_external_dns() {
-                        Some((*sled_id, zone))
-                    } else {
-                        None
-                    }
-                })
-            },
-        );
+        let mut dns_iter =
+            blueprint.sleds.iter_mut().flat_map(|(sled_id, sled_config)| {
+                sled_config.zones_config.zones.iter_mut().filter_map(
+                    move |zone| {
+                        if zone.zone_type.is_external_dns() {
+                            Some((*sled_id, zone))
+                        } else {
+                            None
+                        }
+                    },
+                )
+            });
         let (dns0_sled_id, dns0) =
             dns_iter.next().expect("at least one external DNS zone");
         let (dns1_sled_id, mut dns1) =
@@ -1210,17 +1090,18 @@ mod tests {
                 .build();
 
         // Copy the filesystem zpool from one external DNS to another.
-        let mut dns_iter = blueprint.blueprint_zones.iter_mut().flat_map(
-            |(sled_id, zones_config)| {
-                zones_config.zones.iter_mut().filter_map(move |zone| {
-                    if zone.zone_type.is_external_dns() {
-                        Some((*sled_id, zone))
-                    } else {
-                        None
-                    }
-                })
-            },
-        );
+        let mut dns_iter =
+            blueprint.sleds.iter_mut().flat_map(|(sled_id, sled_config)| {
+                sled_config.zones_config.zones.iter_mut().filter_map(
+                    move |zone| {
+                        if zone.zone_type.is_external_dns() {
+                            Some((*sled_id, zone))
+                        } else {
+                            None
+                        }
+                    },
+                )
+            });
         let (dns0_sled_id, dns0) =
             dns_iter.next().expect("at least one external DNS zone");
         let (dns1_sled_id, mut dns1) =
@@ -1292,8 +1173,10 @@ mod tests {
         let mut dataset1 = None;
         let mut dataset2 = None;
         let mut zpool = None;
-        'outer: for (sled_id, datasets_config) in
-            blueprint.blueprint_datasets.iter_mut()
+        'outer: for (sled_id, datasets_config) in blueprint
+            .sleds
+            .iter_mut()
+            .map(|(id, c)| (id, &mut c.datasets_config))
         {
             for mut dataset in datasets_config.datasets.iter_mut() {
                 if let Some(prev) =
@@ -1348,9 +1231,10 @@ mod tests {
         // Drop the Debug dataset from one zpool and the ZoneRoot dataset from
         // another; we should catch both errors.
         let (sled_id, datasets_config) = blueprint
-            .blueprint_datasets
+            .sleds
             .iter_mut()
             .next()
+            .map(|(id, c)| (id, &mut c.datasets_config))
             .expect("at least one sled");
 
         let mut debug_dataset = None;
@@ -1425,21 +1309,14 @@ mod tests {
         let logctx = test_setup_log(TEST_NAME);
         let (_, _, mut blueprint) = example(&logctx.log, TEST_NAME);
 
-        let (sled_id, datasets_config) = blueprint
-            .blueprint_datasets
-            .iter_mut()
-            .next()
-            .expect("at least one sled");
-        let zones_config = blueprint
-            .blueprint_zones
-            .get(sled_id)
-            .expect("got zones for sled with datasets");
+        let (sled_id, sled_config) =
+            blueprint.sleds.iter_mut().next().expect("at least one sled");
 
         // Pick a zone with a durable dataset to remove, and a different zone
         // with a filesystem_pool dataset to remove.
         let mut durable_zone = None;
         let mut root_zone = None;
-        for z in &zones_config.zones {
+        for z in &sled_config.zones_config.zones {
             if durable_zone.is_none() {
                 if z.zone_type.durable_zpool().is_some() {
                     durable_zone = Some(z.clone());
@@ -1456,7 +1333,7 @@ mod tests {
         assert_ne!(durable_zone.filesystem_pool, root_zone.filesystem_pool);
 
         // Actually strip these from the blueprint.
-        datasets_config.datasets.retain(|dataset| {
+        sled_config.datasets_config.datasets.retain(|dataset| {
             let matches_durable = (dataset.pool
                 == *durable_zone.zone_type.durable_zpool().unwrap())
                 && (dataset.kind
@@ -1502,90 +1379,6 @@ mod tests {
     }
 
     #[test]
-    fn test_sled_missing_datasets() {
-        static TEST_NAME: &str = "test_sled_missing_datasets";
-        let logctx = test_setup_log(TEST_NAME);
-        let (_, _, mut blueprint) = example(&logctx.log, TEST_NAME);
-
-        // Pick one sled and remove its blueprint_datasets entry entirely.
-        let removed_sled_id = *blueprint
-            .blueprint_datasets
-            .keys()
-            .next()
-            .expect("at least one sled");
-        blueprint
-            .blueprint_datasets
-            .retain(|&sled_id, _| sled_id != removed_sled_id);
-
-        let report =
-            Blippy::new(&blueprint).into_report(BlippyReportSortKey::Kind);
-        eprintln!("{}", report.display());
-        let mut found_sled_missing_note = false;
-        for note in report.notes() {
-            if note.severity == Severity::Fatal {
-                match &note.kind {
-                    Kind::Sled {
-                        sled_id,
-                        kind: SledKind::SledMissingDatasets { .. },
-                    } if *sled_id == removed_sled_id => {
-                        found_sled_missing_note = true;
-                    }
-                    _ => (),
-                }
-            }
-        }
-        assert!(
-            found_sled_missing_note,
-            "did not find expected note for missing datasets entry for \
-             sled {removed_sled_id}"
-        );
-
-        logctx.cleanup_successful();
-    }
-
-    #[test]
-    fn test_sled_missing_disks() {
-        static TEST_NAME: &str = "test_sled_missing_disks";
-        let logctx = test_setup_log(TEST_NAME);
-        let (_, _, mut blueprint) = example(&logctx.log, TEST_NAME);
-
-        // Pick one sled and remove its blueprint_disks entry entirely.
-        let removed_sled_id = *blueprint
-            .blueprint_disks
-            .keys()
-            .next()
-            .expect("at least one sled");
-        blueprint
-            .blueprint_disks
-            .retain(|&sled_id, _| sled_id != removed_sled_id);
-
-        let report =
-            Blippy::new(&blueprint).into_report(BlippyReportSortKey::Kind);
-        eprintln!("{}", report.display());
-        let mut found_sled_missing_note = false;
-        for note in report.notes() {
-            if note.severity == Severity::Fatal {
-                match &note.kind {
-                    Kind::Sled {
-                        sled_id,
-                        kind: SledKind::SledMissingDisks { .. },
-                    } if *sled_id == removed_sled_id => {
-                        found_sled_missing_note = true;
-                    }
-                    _ => (),
-                }
-            }
-        }
-        assert!(
-            found_sled_missing_note,
-            "did not find expected note for missing disks entry for \
-             sled {removed_sled_id}"
-        );
-
-        logctx.cleanup_successful();
-    }
-
-    #[test]
     fn test_orphaned_datasets() {
         static TEST_NAME: &str = "test_orphaned_datasets";
         let logctx = test_setup_log(TEST_NAME);
@@ -1594,18 +1387,11 @@ mod tests {
         // Pick two zones (one with a durable dataset and one with a filesystem
         // root dataset), and remove both those zones, which should orphan their
         // datasets.
-        let (sled_id, datasets_config) = blueprint
-            .blueprint_datasets
-            .iter_mut()
-            .next()
-            .expect("at least one sled");
-        let zones_config = blueprint
-            .blueprint_zones
-            .get_mut(sled_id)
-            .expect("got zones for sled with datasets");
+        let (sled_id, sled_config) =
+            blueprint.sleds.iter_mut().next().expect("at least one sled");
         let mut durable_zone = None;
         let mut root_zone = None;
-        for z in &zones_config.zones {
+        for z in &sled_config.zones_config.zones {
             if durable_zone.is_none() {
                 if z.zone_type.durable_zpool().is_some() {
                     durable_zone = Some(z.clone());
@@ -1619,7 +1405,8 @@ mod tests {
             durable_zone.expect("found zone with durable dataset to prune");
         let root_zone =
             root_zone.expect("found zone with root dataset to prune");
-        zones_config
+        sled_config
+            .zones_config
             .zones
             .retain(|z| z.id != durable_zone.id && z.id != root_zone.id);
 
@@ -1627,7 +1414,8 @@ mod tests {
         let root_dataset = root_zone.filesystem_dataset().unwrap();
 
         // Find the datasets we expect to have been orphaned.
-        let expected_notes = datasets_config
+        let expected_notes = sled_config
+            .datasets_config
             .datasets
             .iter()
             .filter_map(|dataset| {
@@ -1673,8 +1461,9 @@ mod tests {
         // Remove one zpool from one sled, then check that all datasets on that
         // zpool produce report notes.
         let (sled_id, disks_config) = blueprint
-            .blueprint_disks
+            .sleds
             .iter_mut()
+            .map(|(id, c)| (*id, &mut c.disks_config))
             .next()
             .expect("at least one sled");
         let first = disks_config.disks.first().unwrap().id;
@@ -1682,9 +1471,10 @@ mod tests {
         eprintln!("removed disk {removed_disk:?}");
 
         let expected_notes = blueprint
-            .blueprint_datasets
-            .get(sled_id)
+            .sleds
+            .get(&sled_id)
             .unwrap()
+            .datasets_config
             .datasets
             .iter()
             .filter_map(|dataset| {
@@ -1697,7 +1487,7 @@ mod tests {
                         Note {
                             severity: Severity::Fatal,
                             kind: Kind::Sled {
-                                sled_id: *sled_id,
+                                sled_id,
                                 kind: SledKind::OrphanedDataset {
                                     dataset: dataset.clone(),
                                 },
@@ -1707,7 +1497,7 @@ mod tests {
                     _ => Note {
                         severity: Severity::Fatal,
                         kind: Kind::Sled {
-                            sled_id: *sled_id,
+                            sled_id,
                             kind: SledKind::DatasetOnNonexistentZpool {
                                 dataset: dataset.clone(),
                             },
@@ -1768,8 +1558,10 @@ mod tests {
         let mut set_non_crucible_addr = false;
         let mut expected_notes = Vec::new();
 
-        for (sled_id, datasets_config) in
-            blueprint.blueprint_datasets.iter_mut()
+        for (sled_id, datasets_config) in blueprint
+            .sleds
+            .iter_mut()
+            .map(|(id, c)| (id, &mut c.datasets_config))
         {
             for mut dataset in datasets_config.datasets.iter_mut() {
                 match dataset.kind {
@@ -1826,129 +1618,6 @@ mod tests {
         let report =
             Blippy::new(&blueprint).into_report(BlippyReportSortKey::Kind);
         eprintln!("{}", report.display());
-        for note in expected_notes {
-            assert!(
-                report.notes().contains(&note),
-                "did not find expected note {note:?}"
-            );
-        }
-
-        logctx.cleanup_successful();
-    }
-
-    #[test]
-    fn test_sled_in_zones_map_but_not_others() {
-        static TEST_NAME: &str = "test_sled_in_zones_map_but_not_others";
-        let logctx = test_setup_log(TEST_NAME);
-        let (_, _, mut blueprint) = example(&logctx.log, TEST_NAME);
-
-        let mut sled_ids = blueprint.blueprint_zones.keys();
-        let some_sled = *sled_ids.next().expect("at least 1 sled");
-
-        // remove sled from each of the three non-`blueprint_zones` maps
-        blueprint
-            .sled_state
-            .remove(&some_sled)
-            .expect("removed sled 0 from sled_state");
-        blueprint
-            .blueprint_datasets
-            .remove(&some_sled)
-            .expect("removed sled 1 from blueprint_datasets");
-        blueprint
-            .blueprint_disks
-            .remove(&some_sled)
-            .expect("removed sled 1 from blueprint_disks");
-
-        let expected_notes = [
-            Note {
-                severity: Severity::BackwardsCompatibility,
-                kind: Kind::Sled {
-                    sled_id: some_sled,
-                    kind: SledKind::MultimapInconsistency(
-                        MultimapInconsistency::PresentInZonesNotState,
-                    ),
-                },
-            },
-            Note {
-                severity: Severity::BackwardsCompatibility,
-                kind: Kind::Sled {
-                    sled_id: some_sled,
-                    kind: SledKind::MultimapInconsistency(
-                        MultimapInconsistency::PresentInZonesNotDatasets,
-                    ),
-                },
-            },
-            Note {
-                severity: Severity::BackwardsCompatibility,
-                kind: Kind::Sled {
-                    sled_id: some_sled,
-                    kind: SledKind::MultimapInconsistency(
-                        MultimapInconsistency::PresentInZonesNotDisks,
-                    ),
-                },
-            },
-        ];
-        let report =
-            Blippy::new(&blueprint).into_report(BlippyReportSortKey::Kind);
-        eprintln!("{}", report.display());
-
-        for note in expected_notes {
-            assert!(
-                report.notes().contains(&note),
-                "did not find expected note {note:?}"
-            );
-        }
-
-        logctx.cleanup_successful();
-    }
-
-    #[test]
-    fn test_sled_not_in_zones_map() {
-        static TEST_NAME: &str = "test_sled_not_in_zones_map";
-        let logctx = test_setup_log(TEST_NAME);
-        let (_, _, mut blueprint) = example(&logctx.log, TEST_NAME);
-
-        let mut sled_ids = blueprint.blueprint_zones.keys();
-        let some_sled = *sled_ids.next().expect("at least 1 sled");
-
-        blueprint
-            .blueprint_zones
-            .remove(&some_sled)
-            .expect("removed sled from blueprint_zones");
-
-        let expected_notes = [
-            Note {
-                severity: Severity::BackwardsCompatibility,
-                kind: Kind::Sled {
-                    sled_id: some_sled,
-                    kind: SledKind::MultimapInconsistency(
-                        MultimapInconsistency::PresentInStateNotZones,
-                    ),
-                },
-            },
-            Note {
-                severity: Severity::BackwardsCompatibility,
-                kind: Kind::Sled {
-                    sled_id: some_sled,
-                    kind: SledKind::MultimapInconsistency(
-                        MultimapInconsistency::PresentInDisksNotZones,
-                    ),
-                },
-            },
-            Note {
-                severity: Severity::BackwardsCompatibility,
-                kind: Kind::Sled {
-                    sled_id: some_sled,
-                    kind: SledKind::MultimapInconsistency(
-                        MultimapInconsistency::PresentInDatasetsNotZones,
-                    ),
-                },
-            },
-        ];
-        let report =
-            Blippy::new(&blueprint).into_report(BlippyReportSortKey::Kind);
-        eprintln!("{}", report.display());
-
         for note in expected_notes {
             assert!(
                 report.notes().contains(&note),

--- a/nexus/reconfigurator/execution/src/clickhouse.rs
+++ b/nexus/reconfigurator/execution/src/clickhouse.rs
@@ -22,9 +22,7 @@ use futures::future::Either;
 use futures::stream::FuturesUnordered;
 use futures::stream::StreamExt;
 use nexus_db_queries::context::OpContext;
-use nexus_types::deployment::Blueprint;
-use nexus_types::deployment::BlueprintZoneDisposition;
-use nexus_types::deployment::BlueprintZonesConfig;
+use nexus_types::deployment::BlueprintZoneConfig;
 use nexus_types::deployment::ClickhouseClusterConfig;
 use omicron_common::address::CLICKHOUSE_ADMIN_PORT;
 use omicron_uuid_kinds::OmicronZoneUuid;
@@ -40,13 +38,20 @@ use std::str::FromStr;
 
 const CLICKHOUSE_DATA_DIR: &str = "/data";
 
-pub(crate) async fn deploy_nodes(
+pub(crate) async fn deploy_nodes<'a, I>(
     opctx: &OpContext,
-    zones: &BTreeMap<SledUuid, BlueprintZonesConfig>,
+    zones: I,
     clickhouse_cluster_config: &ClickhouseClusterConfig,
-) -> Result<(), Vec<anyhow::Error>> {
-    let keeper_configs = match keeper_configs(zones, clickhouse_cluster_config)
-    {
+) -> Result<(), Vec<anyhow::Error>>
+where
+    I: Iterator<Item = (SledUuid, &'a BlueprintZoneConfig)>,
+{
+    let zones: Vec<_> = zones.map(|(_, z)| z).collect();
+
+    let keeper_configs = match keeper_configs(
+        zones.iter().copied(),
+        clickhouse_cluster_config,
+    ) {
         Ok(keeper_configs) => keeper_configs,
         Err(e) => {
             // We can't proceed if we fail to generate configs.
@@ -64,19 +69,22 @@ pub(crate) async fn deploy_nodes(
         .map(|s| ClickhouseHost::Ipv6(s.settings.listen_addr))
         .collect();
 
-    let server_configs =
-        match server_configs(zones, clickhouse_cluster_config, keeper_hosts) {
-            Ok(server_configs) => server_configs,
-            Err(e) => {
-                // We can't proceed if we fail to generate configs.
-                // Let's be noisy about it.
-                error!(
-                    opctx.log,
-                    "Failed to generate clickhouse server configs: {e}"
-                );
-                return Err(vec![e]);
-            }
-        };
+    let server_configs = match server_configs(
+        zones.iter().copied(),
+        clickhouse_cluster_config,
+        keeper_hosts,
+    ) {
+        Ok(server_configs) => server_configs,
+        Err(e) => {
+            // We can't proceed if we fail to generate configs.
+            // Let's be noisy about it.
+            error!(
+                opctx.log,
+                "Failed to generate clickhouse server configs: {e}"
+            );
+            return Err(vec![e]);
+        }
+    };
 
     let mut errors = vec![];
     let log = opctx.log.clone();
@@ -178,16 +186,14 @@ pub(crate) async fn deploy_nodes(
     Ok(())
 }
 
-pub(crate) async fn deploy_single_node(
+pub(crate) async fn deploy_single_node<'a, I>(
     opctx: &OpContext,
-    zones: &BTreeMap<SledUuid, BlueprintZonesConfig>,
-) -> Result<(), anyhow::Error> {
-    if let Some((_, zone)) = Blueprint::filtered_zones(
-        zones,
-        BlueprintZoneDisposition::is_in_service,
-    )
-    .find(|(_, zone)| zone.zone_type.is_clickhouse())
-    {
+    mut zones: I,
+) -> Result<(), anyhow::Error>
+where
+    I: Iterator<Item = (SledUuid, &'a BlueprintZoneConfig)>,
+{
+    if let Some((_, zone)) = zones.next() {
         let admin_addr = SocketAddr::V6(SocketAddrV6::new(
             zone.underlay_ip(),
             CLICKHOUSE_ADMIN_PORT,
@@ -207,24 +213,19 @@ pub(crate) async fn deploy_single_node(
     }
 }
 
-fn server_configs(
-    zones: &BTreeMap<SledUuid, BlueprintZonesConfig>,
+fn server_configs<'a, I>(
+    zones: I,
     clickhouse_cluster_config: &ClickhouseClusterConfig,
     keepers: Vec<ClickhouseHost>,
-) -> anyhow::Result<Vec<ServerConfigurableSettings>> {
+) -> anyhow::Result<Vec<ServerConfigurableSettings>>
+where
+    I: Iterator<Item = &'a BlueprintZoneConfig>,
+{
     let server_ips: BTreeMap<OmicronZoneUuid, Ipv6Addr> = zones
-        .values()
-        .flat_map(|zones_config| {
-            zones_config
-                .zones
-                .iter()
-                .filter(|zone_config| {
-                    clickhouse_cluster_config
-                        .servers
-                        .contains_key(&zone_config.id)
-                })
-                .map(|zone_config| (zone_config.id, zone_config.underlay_ip()))
+        .filter(|zone_config| {
+            clickhouse_cluster_config.servers.contains_key(&zone_config.id)
         })
+        .map(|zone_config| (zone_config.id, zone_config.underlay_ip()))
         .collect();
 
     let mut remote_servers =
@@ -266,23 +267,18 @@ fn server_configs(
     Ok(server_configs)
 }
 
-fn keeper_configs(
-    zones: &BTreeMap<SledUuid, BlueprintZonesConfig>,
+fn keeper_configs<'a, I>(
+    zones: I,
     clickhouse_cluster_config: &ClickhouseClusterConfig,
-) -> Result<Vec<KeeperConfigurableSettings>, anyhow::Error> {
+) -> Result<Vec<KeeperConfigurableSettings>, anyhow::Error>
+where
+    I: Iterator<Item = &'a BlueprintZoneConfig>,
+{
     let keeper_ips: BTreeMap<OmicronZoneUuid, Ipv6Addr> = zones
-        .values()
-        .flat_map(|zones_config| {
-            zones_config
-                .zones
-                .iter()
-                .filter(|zone_config| {
-                    clickhouse_cluster_config
-                        .keepers
-                        .contains_key(&zone_config.id)
-                })
-                .map(|zone_config| (zone_config.id, zone_config.underlay_ip()))
+        .filter(|zone_config| {
+            clickhouse_cluster_config.keepers.contains_key(&zone_config.id)
         })
+        .map(|zone_config| (zone_config.id, zone_config.underlay_ip()))
         .collect();
 
     let mut raft_servers =
@@ -338,101 +334,86 @@ mod test {
     use nexus_types::deployment::BlueprintZoneDisposition;
     use nexus_types::deployment::BlueprintZoneType;
     use nexus_types::inventory::ZpoolName;
-    use omicron_common::api::external::Generation;
     use omicron_uuid_kinds::ZpoolUuid;
     use std::collections::BTreeSet;
 
-    fn test_data(
-    ) -> (BTreeMap<SledUuid, BlueprintZonesConfig>, ClickhouseClusterConfig)
-    {
+    fn test_data() -> (Vec<BlueprintZoneConfig>, ClickhouseClusterConfig) {
         let num_keepers = 3u64;
         let num_servers = 2u64;
 
-        let mut zones = BTreeMap::new();
+        let mut zones = Vec::new();
         let mut config = ClickhouseClusterConfig::new(
             "test".to_string(),
             "test".to_string(),
         );
 
         for keeper_id in 1..=num_keepers {
-            let sled_id = SledUuid::new_v4();
             let zone_id = OmicronZoneUuid::new_v4();
-            let zone_config = BlueprintZonesConfig {
-                generation: Generation::new(),
-                zones: [BlueprintZoneConfig {
-                    disposition: BlueprintZoneDisposition::InService,
-                    id: zone_id,
-                    filesystem_pool: None,
-                    zone_type: BlueprintZoneType::ClickhouseKeeper(
-                        blueprint_zone_type::ClickhouseKeeper {
-                            address: SocketAddrV6::new(
-                                Ipv6Addr::new(
-                                    0,
-                                    0,
-                                    0,
-                                    0,
-                                    0,
-                                    0,
-                                    0,
-                                    keeper_id as u16,
-                                ),
+            let zone_config = BlueprintZoneConfig {
+                disposition: BlueprintZoneDisposition::InService,
+                id: zone_id,
+                filesystem_pool: None,
+                zone_type: BlueprintZoneType::ClickhouseKeeper(
+                    blueprint_zone_type::ClickhouseKeeper {
+                        address: SocketAddrV6::new(
+                            Ipv6Addr::new(
                                 0,
                                 0,
                                 0,
+                                0,
+                                0,
+                                0,
+                                0,
+                                keeper_id as u16,
                             ),
-                            dataset: OmicronZoneDataset {
-                                pool_name: ZpoolName::new_external(
-                                    ZpoolUuid::new_v4(),
-                                ),
-                            },
+                            0,
+                            0,
+                            0,
+                        ),
+                        dataset: OmicronZoneDataset {
+                            pool_name: ZpoolName::new_external(
+                                ZpoolUuid::new_v4(),
+                            ),
                         },
-                    ),
-                }]
-                .into_iter()
-                .collect(),
+                    },
+                ),
             };
-            zones.insert(sled_id, zone_config);
+            zones.push(zone_config);
             config.keepers.insert(zone_id, keeper_id.into());
         }
 
         for server_id in 1..=num_servers {
-            let sled_id = SledUuid::new_v4();
             let zone_id = OmicronZoneUuid::new_v4();
-            let zone_config = BlueprintZonesConfig {
-                generation: Generation::new(),
-                zones: [BlueprintZoneConfig {
-                    disposition: BlueprintZoneDisposition::InService,
-                    id: zone_id,
-                    filesystem_pool: None,
-                    zone_type: BlueprintZoneType::ClickhouseServer(
-                        blueprint_zone_type::ClickhouseServer {
-                            address: SocketAddrV6::new(
-                                Ipv6Addr::new(
-                                    0,
-                                    0,
-                                    0,
-                                    0,
-                                    0,
-                                    0,
-                                    0,
-                                    server_id as u16 + 10,
-                                ),
+            let zone_config = BlueprintZoneConfig {
+                disposition: BlueprintZoneDisposition::InService,
+                id: zone_id,
+                filesystem_pool: None,
+                zone_type: BlueprintZoneType::ClickhouseServer(
+                    blueprint_zone_type::ClickhouseServer {
+                        address: SocketAddrV6::new(
+                            Ipv6Addr::new(
                                 0,
                                 0,
                                 0,
+                                0,
+                                0,
+                                0,
+                                0,
+                                server_id as u16 + 10,
                             ),
-                            dataset: OmicronZoneDataset {
-                                pool_name: ZpoolName::new_external(
-                                    ZpoolUuid::new_v4(),
-                                ),
-                            },
+                            0,
+                            0,
+                            0,
+                        ),
+                        dataset: OmicronZoneDataset {
+                            pool_name: ZpoolName::new_external(
+                                ZpoolUuid::new_v4(),
+                            ),
                         },
-                    ),
-                }]
-                .into_iter()
-                .collect(),
+                    },
+                ),
             };
-            zones.insert(sled_id, zone_config);
+            zones.push(zone_config);
             config.servers.insert(zone_id, server_id.into());
         }
 
@@ -445,7 +426,7 @@ mod test {
 
         // Generate our keeper settings to send to keepers
         let keeper_settings =
-            keeper_configs(&zones, &clickhouse_cluster_config)
+            keeper_configs(zones.iter(), &clickhouse_cluster_config)
                 .expect("generated keeper settings");
 
         // Are the keeper settings what we expect
@@ -474,9 +455,12 @@ mod test {
             .collect();
 
         // Generate our server settings to send to clickhouse servers
-        let server_settings =
-            server_configs(&zones, &clickhouse_cluster_config, keeper_hosts)
-                .expect("generated server settings");
+        let server_settings = server_configs(
+            zones.iter(),
+            &clickhouse_cluster_config,
+            keeper_hosts,
+        )
+        .expect("generated server settings");
 
         // Are our server settings what we expect
         assert_eq!(server_settings.len(), 2);

--- a/nexus/reconfigurator/execution/src/dns.rs
+++ b/nexus/reconfigurator/execution/src/dns.rs
@@ -326,6 +326,9 @@ mod test {
     use nexus_test_utils_macros::nexus_test;
     use nexus_types::deployment::blueprint_zone_type;
     use nexus_types::deployment::Blueprint;
+    use nexus_types::deployment::BlueprintDatasetsConfig;
+    use nexus_types::deployment::BlueprintPhysicalDisksConfig;
+    use nexus_types::deployment::BlueprintSledConfig;
     use nexus_types::deployment::BlueprintTarget;
     use nexus_types::deployment::BlueprintZoneConfig;
     use nexus_types::deployment::BlueprintZoneDisposition;
@@ -621,47 +624,47 @@ mod test {
             ipnet::Ipv6Net::new(rack_subnet_base, RACK_PREFIX).unwrap();
         let possible_sled_subnets = rack_subnet.subnets(SLED_PREFIX).unwrap();
 
-        // Convert the inventory `OmicronZonesConfig`s into
-        // `BlueprintZonesConfig`. This is going to get more painful over time
-        // as we add to blueprints, but for now we can make this work.
-        let mut blueprint_zones = BTreeMap::new();
-
-        // Also assume any sled in the collection is active.
-        let mut sled_state = BTreeMap::new();
+        let mut blueprint_sleds = BTreeMap::new();
 
         for (sled_id, sa) in collection.sled_agents {
-            blueprint_zones.insert(
+            // Convert the inventory `OmicronZonesConfig`s into
+            // `BlueprintZonesConfig`. This is going to get more painful over
+            // time as we add to blueprints, but for now we can make this work.
+            let zones_config = BlueprintZonesConfig {
+                generation: sa.omicron_zones.generation,
+                zones: sa
+                    .omicron_zones
+                    .zones
+                    .into_iter()
+                    .map(|config| -> BlueprintZoneConfig {
+                        deprecated_omicron_zone_config_to_blueprint_zone_config(
+                            config,
+                            BlueprintZoneDisposition::InService,
+                            // We don't get external IP IDs in inventory
+                            // collections. We'll just make one up for every
+                            // zone that needs one here. This is gross.
+                            Some(ExternalIpUuid::new_v4()),
+                        )
+                        .expect("failed to convert zone config")
+                    })
+                    .collect(),
+            };
+            blueprint_sleds.insert(
                 sled_id,
-                BlueprintZonesConfig {
-                    generation: sa.omicron_zones.generation,
-                    zones: sa.omicron_zones
-                        .zones
-                        .into_iter()
-                        .map(|config| -> BlueprintZoneConfig {
-                           deprecated_omicron_zone_config_to_blueprint_zone_config(
-                                config,
-                                BlueprintZoneDisposition::InService,
-                                // We don't get external IP IDs in inventory
-                                // collections. We'll just make one up for every
-                                // zone that needs one here. This is gross.
-                                Some(ExternalIpUuid::new_v4()),
-                            )
-                            .expect("failed to convert zone config")
-                        })
-                        .collect(),
+                BlueprintSledConfig {
+                    state: SledState::Active,
+                    disks_config: BlueprintPhysicalDisksConfig::default(),
+                    datasets_config: BlueprintDatasetsConfig::default(),
+                    zones_config,
                 },
             );
-            sled_state.insert(sled_id, SledState::Active);
         }
 
         let dns_empty = dns_config_empty();
         let initial_dns_generation = dns_empty.generation;
         let mut blueprint = Blueprint {
             id: BlueprintUuid::new_v4(),
-            blueprint_zones,
-            blueprint_disks: BTreeMap::new(),
-            blueprint_datasets: BTreeMap::new(),
-            sled_state,
+            sleds: blueprint_sleds,
             cockroachdb_setting_preserve_downgrade:
                 CockroachDbPreserveDowngrade::DoNotModify,
             parent_blueprint_id: None,
@@ -678,7 +681,7 @@ mod test {
         // not currently in service.
         let out_of_service_id = OmicronZoneUuid::new_v4();
         let out_of_service_addr = Ipv6Addr::LOCALHOST;
-        blueprint.blueprint_zones.values_mut().next().unwrap().zones.insert(
+        blueprint.sleds.values_mut().next().unwrap().zones_config.zones.insert(
             BlueprintZoneConfig {
                 disposition: BlueprintZoneDisposition::Expunged {
                     as_of_generation: Generation::new(),
@@ -704,7 +707,7 @@ mod test {
         // To generate the blueprint's DNS config, we need to make up a
         // different set of information about the Quiesced fake system.
         let sleds_by_id = blueprint
-            .blueprint_zones
+            .sleds
             .keys()
             .zip(possible_sled_subnets)
             .enumerate()
@@ -1030,8 +1033,8 @@ mod test {
         // Change the zone disposition to expunged for the nexus zone on the
         // first sled. This should ensure we don't get an external DNS record
         // back for that sled.
-        let (_, bp_zones_config) =
-            blueprint.blueprint_zones.iter_mut().next().unwrap();
+        let bp_zones_config =
+            &mut blueprint.sleds.values_mut().next().unwrap().zones_config;
         let mut nexus_zone = bp_zones_config
             .zones
             .iter_mut()

--- a/nexus/reconfigurator/execution/src/lib.rs
+++ b/nexus/reconfigurator/execution/src/lib.rs
@@ -336,7 +336,10 @@ fn register_deploy_disks_step<'a>(
                 let res = omicron_physical_disks::deploy_disks(
                     &opctx,
                     &sleds_by_id,
-                    &blueprint.blueprint_disks,
+                    blueprint
+                        .sleds
+                        .iter()
+                        .map(|(sled_id, sled)| (*sled_id, &sled.disks_config)),
                 )
                 .await
                 .map_err(merge_anyhow_list);
@@ -361,7 +364,9 @@ fn register_deploy_datasets_step<'a>(
                 let res = datasets::deploy_datasets(
                     &opctx,
                     &sleds_by_id,
-                    &blueprint.blueprint_datasets,
+                    blueprint.sleds.iter().map(|(sled_id, sled)| {
+                        (*sled_id, &sled.datasets_config)
+                    }),
                 )
                 .await
                 .map_err(merge_anyhow_list);
@@ -386,7 +391,10 @@ fn register_deploy_zones_step<'a>(
                 let done = omicron_zones::deploy_zones(
                     &opctx,
                     &sleds_by_id,
-                    &blueprint.blueprint_zones,
+                    blueprint
+                        .sleds
+                        .iter()
+                        .map(|(sled_id, sled)| (*sled_id, &sled.zones_config)),
                 )
                 .await
                 .map_err(merge_anyhow_list)?;
@@ -512,10 +520,10 @@ fn register_decommission_sleds_step<'a>(
                     &opctx,
                     datastore,
                     blueprint
-                        .sled_state
+                        .sleds
                         .iter()
-                        .filter(|&(_, &state)| {
-                            state == SledState::Decommissioned
+                        .filter(|(_, sled)| {
+                            sled.state == SledState::Decommissioned
                         })
                         .map(|(&sled_id, _)| sled_id),
                 )
@@ -568,7 +576,8 @@ fn register_deploy_clickhouse_cluster_nodes_step<'a>(
                 {
                     let res = clickhouse::deploy_nodes(
                         &opctx,
-                        &blueprint.blueprint_zones,
+                        blueprint
+                            .all_omicron_zones(BlueprintZoneDisposition::any),
                         &clickhouse_cluster_config,
                     )
                     .await
@@ -594,7 +603,11 @@ fn register_deploy_clickhouse_single_node_step<'a>(
             move |_cx| async move {
                 let res = clickhouse::deploy_single_node(
                     &opctx,
-                    &blueprint.blueprint_zones,
+                    blueprint
+                        .all_omicron_zones(
+                            BlueprintZoneDisposition::is_in_service,
+                        )
+                        .filter(|(_, z)| z.zone_type.is_clickhouse()),
                 )
                 .await;
                 result_to_step_result(res)

--- a/nexus/reconfigurator/execution/src/omicron_zones.rs
+++ b/nexus/reconfigurator/execution/src/omicron_zones.rs
@@ -40,14 +40,17 @@ pub(crate) struct DeployZonesDone(());
 
 /// Idempotently ensure that the specified Omicron zones are deployed to the
 /// corresponding sleds
-pub(crate) async fn deploy_zones(
+pub(crate) async fn deploy_zones<'a, I>(
     opctx: &OpContext,
     sleds_by_id: &BTreeMap<SledUuid, Sled>,
-    zones: &BTreeMap<SledUuid, BlueprintZonesConfig>,
-) -> Result<DeployZonesDone, Vec<anyhow::Error>> {
+    zones: I,
+) -> Result<DeployZonesDone, Vec<anyhow::Error>>
+where
+    I: Iterator<Item = (SledUuid, &'a BlueprintZonesConfig)>,
+{
     let errors: Vec<_> = stream::iter(zones)
         .filter_map(|(sled_id, config)| async move {
-            let db_sled = match sleds_by_id.get(sled_id) {
+            let db_sled = match sleds_by_id.get(&sled_id) {
                 Some(sled) => sled,
                 None => {
                     if config.are_all_zones_expunged() {
@@ -366,9 +369,11 @@ mod test {
     };
     use nexus_test_utils_macros::nexus_test;
     use nexus_types::deployment::{
-        blueprint_zone_type, Blueprint, BlueprintTarget,
+        blueprint_zone_type, Blueprint, BlueprintDatasetsConfig,
+        BlueprintPhysicalDisksConfig, BlueprintSledConfig, BlueprintTarget,
         CockroachDbPreserveDowngrade,
     };
+    use nexus_types::external_api::views::SledState;
     use omicron_common::api::external::Generation;
     use omicron_common::zpool_name::ZpoolName;
     use omicron_uuid_kinds::BlueprintUuid;
@@ -394,10 +399,22 @@ mod test {
             },
             Blueprint {
                 id,
-                blueprint_zones,
-                blueprint_disks: BTreeMap::new(),
-                blueprint_datasets: BTreeMap::new(),
-                sled_state: BTreeMap::new(),
+                sleds: blueprint_zones
+                    .into_iter()
+                    .map(|(sled_id, zones_config)| {
+                        (
+                            sled_id,
+                            BlueprintSledConfig {
+                                state: SledState::Active,
+                                zones_config,
+                                disks_config:
+                                    BlueprintPhysicalDisksConfig::default(),
+                                datasets_config:
+                                    BlueprintDatasetsConfig::default(),
+                            },
+                        )
+                    })
+                    .collect(),
                 cockroachdb_setting_preserve_downgrade:
                     CockroachDbPreserveDowngrade::DoNotModify,
                 parent_blueprint_id: None,
@@ -442,9 +459,16 @@ mod test {
         // Get a success result back when the blueprint has an empty set of
         // zones.
         let (_, blueprint) = create_blueprint(BTreeMap::new());
-        _ = deploy_zones(&opctx, &sleds_by_id, &blueprint.blueprint_zones)
-            .await
-            .expect("failed to deploy no zones");
+        _ = deploy_zones(
+            &opctx,
+            &sleds_by_id,
+            blueprint
+                .sleds
+                .iter()
+                .map(|(sled_id, config)| (*sled_id, &config.zones_config)),
+        )
+        .await
+        .expect("failed to deploy no zones");
 
         // Zones are updated in a particular order, but each request contains
         // the full set of zones that must be running.
@@ -500,9 +524,16 @@ mod test {
         }
 
         // Execute it.
-        _ = deploy_zones(&opctx, &sleds_by_id, &blueprint.blueprint_zones)
-            .await
-            .expect("failed to deploy initial zones");
+        _ = deploy_zones(
+            &opctx,
+            &sleds_by_id,
+            blueprint
+                .sleds
+                .iter()
+                .map(|(sled_id, config)| (*sled_id, &config.zones_config)),
+        )
+        .await
+        .expect("failed to deploy initial zones");
 
         s1.verify_and_clear();
         s2.verify_and_clear();
@@ -517,9 +548,16 @@ mod test {
                 .respond_with(status_code(204)),
             );
         }
-        _ = deploy_zones(&opctx, &sleds_by_id, &blueprint.blueprint_zones)
-            .await
-            .expect("failed to deploy same zones");
+        _ = deploy_zones(
+            &opctx,
+            &sleds_by_id,
+            blueprint
+                .sleds
+                .iter()
+                .map(|(sled_id, config)| (*sled_id, &config.zones_config)),
+        )
+        .await
+        .expect("failed to deploy same zones");
         s1.verify_and_clear();
         s2.verify_and_clear();
 
@@ -540,10 +578,16 @@ mod test {
             .respond_with(status_code(500)),
         );
 
-        let errors =
-            deploy_zones(&opctx, &sleds_by_id, &blueprint.blueprint_zones)
-                .await
-                .expect_err("unexpectedly succeeded in deploying zones");
+        let errors = deploy_zones(
+            &opctx,
+            &sleds_by_id,
+            blueprint
+                .sleds
+                .iter()
+                .map(|(sled_id, config)| (*sled_id, &config.zones_config)),
+        )
+        .await
+        .expect_err("unexpectedly succeeded in deploying zones");
 
         println!("{:?}", errors);
         assert_eq!(errors.len(), 1);
@@ -616,9 +660,16 @@ mod test {
         }
 
         // Activate the task
-        _ = deploy_zones(&opctx, &sleds_by_id, &blueprint.blueprint_zones)
-            .await
-            .expect("failed to deploy last round of zones");
+        _ = deploy_zones(
+            &opctx,
+            &sleds_by_id,
+            blueprint
+                .sleds
+                .iter()
+                .map(|(sled_id, config)| (*sled_id, &config.zones_config)),
+        )
+        .await
+        .expect("failed to deploy last round of zones");
         s1.verify_and_clear();
         s2.verify_and_clear();
     }

--- a/nexus/reconfigurator/planning/src/blueprint_builder/builder.rs
+++ b/nexus/reconfigurator/planning/src/blueprint_builder/builder.rs
@@ -2100,14 +2100,14 @@ pub mod test {
 
         let blueprint2 = builder.build();
         verify_blueprint(&blueprint2);
-        let diff = blueprint2.diff_since_blueprint(&blueprint1);
+        let summary = blueprint2.diff_since_blueprint(&blueprint1);
         println!(
             "initial blueprint -> next blueprint (expected no changes):\n{}",
-            diff.display()
+            summary.display()
         );
-        assert_eq!(diff.sleds_added.len(), 0);
-        assert_eq!(diff.sleds_removed.len(), 0);
-        assert_eq!(diff.sleds_modified.len(), 0);
+        assert_eq!(summary.sleds_added.len(), 0);
+        assert_eq!(summary.sleds_removed.len(), 0);
+        assert_eq!(summary.diff.sleds.modified().count(), 0);
 
         // The next step is adding these zones to a new sled.
         let mut sled_id_rng = rng.next_sled_id_rng();
@@ -2137,17 +2137,20 @@ pub mod test {
 
         let blueprint3 = builder.build();
         verify_blueprint(&blueprint3);
-        let diff = blueprint3.diff_since_blueprint(&blueprint2);
-        println!("expecting new NTP and Crucible zones:\n{}", diff.display());
+        let summary = blueprint3.diff_since_blueprint(&blueprint2);
+        println!(
+            "expecting new NTP and Crucible zones:\n{}",
+            summary.display()
+        );
 
         // No sleds were changed or removed.
-        assert_eq!(diff.sleds_modified.len(), 0);
-        assert_eq!(diff.sleds_removed.len(), 0);
+        assert_eq!(summary.diff.sleds.modified().count(), 0);
+        assert_eq!(summary.sleds_removed.len(), 0);
 
         // One sled was added.
-        assert_eq!(diff.sleds_added.len(), 1);
-        let sled_id = diff.sleds_added.first().unwrap();
-        let new_sled_zones = diff.added_zones(sled_id).unwrap();
+        assert_eq!(summary.sleds_added.len(), 1);
+        let sled_id = summary.sleds_added.first().unwrap();
+        let new_sled_zones = summary.added_zones(sled_id).unwrap();
         assert_eq!(*sled_id, new_sled_id);
         // The generation number should be newer than the initial default.
         assert!(new_sled_zones.generation_after > Some(Generation::new()));

--- a/nexus/reconfigurator/planning/src/blueprint_builder/builder.rs
+++ b/nexus/reconfigurator/planning/src/blueprint_builder/builder.rs
@@ -2105,7 +2105,7 @@ pub mod test {
             "initial blueprint -> next blueprint (expected no changes):\n{}",
             summary.display()
         );
-        assert_eq!(summary.sleds_added.len(), 0);
+        assert_eq!(summary.diff.sleds.added.len(), 0);
         assert_eq!(summary.diff.sleds.removed.len(), 0);
         assert_eq!(summary.diff.sleds.modified().count(), 0);
 
@@ -2148,12 +2148,13 @@ pub mod test {
         assert_eq!(summary.diff.sleds.removed.len(), 0);
 
         // One sled was added.
-        assert_eq!(summary.sleds_added.len(), 1);
-        let sled_id = summary.sleds_added.first().unwrap();
-        let new_sled_zones = summary.added_zones(sled_id).unwrap();
+        assert_eq!(summary.diff.sleds.added.len(), 1);
+        let (&sled_id, new_sled) =
+            summary.diff.sleds.added.first_key_value().unwrap();
+        let new_sled_zones = &new_sled.zones_config;
         assert_eq!(*sled_id, new_sled_id);
         // The generation number should be newer than the initial default.
-        assert!(new_sled_zones.generation_after > Some(Generation::new()));
+        assert!(new_sled_zones.generation > Generation::new());
 
         // All zones' underlay addresses ought to be on the sled's subnet.
         for z in &new_sled_zones.zones {

--- a/nexus/reconfigurator/planning/src/blueprint_builder/builder.rs
+++ b/nexus/reconfigurator/planning/src/blueprint_builder/builder.rs
@@ -2106,7 +2106,7 @@ pub mod test {
             summary.display()
         );
         assert_eq!(summary.sleds_added.len(), 0);
-        assert_eq!(summary.sleds_removed.len(), 0);
+        assert_eq!(summary.diff.sleds.removed.len(), 0);
         assert_eq!(summary.diff.sleds.modified().count(), 0);
 
         // The next step is adding these zones to a new sled.
@@ -2145,7 +2145,7 @@ pub mod test {
 
         // No sleds were changed or removed.
         assert_eq!(summary.diff.sleds.modified().count(), 0);
-        assert_eq!(summary.sleds_removed.len(), 0);
+        assert_eq!(summary.diff.sleds.removed.len(), 0);
 
         // One sled was added.
         assert_eq!(summary.sleds_added.len(), 1);

--- a/nexus/reconfigurator/planning/src/blueprint_builder/clickhouse.rs
+++ b/nexus/reconfigurator/planning/src/blueprint_builder/clickhouse.rs
@@ -12,7 +12,7 @@ use nexus_types::deployment::{
 };
 use omicron_uuid_kinds::{OmicronZoneUuid, SledUuid};
 use slog::{error, Logger};
-use std::collections::{BTreeMap, BTreeSet};
+use std::collections::BTreeSet;
 use thiserror::Error;
 
 // The set of clickhouse server and keeper zones that should be running as
@@ -26,12 +26,11 @@ pub struct ClickhouseZonesThatShouldBeRunning {
     pub servers: BTreeSet<OmicronZoneUuid>,
 }
 
-impl From<&BTreeMap<SledUuid, BlueprintZonesConfig>>
-    for ClickhouseZonesThatShouldBeRunning
-{
-    fn from(
-        zones_by_sled_id: &BTreeMap<SledUuid, BlueprintZonesConfig>,
-    ) -> Self {
+impl ClickhouseZonesThatShouldBeRunning {
+    pub fn new<'a, I>(zones_by_sled_id: I) -> Self
+    where
+        I: Iterator<Item = (SledUuid, &'a BlueprintZonesConfig)>,
+    {
         let mut keepers = BTreeSet::new();
         let mut servers = BTreeSet::new();
         for (_, bp_zone_config) in Blueprint::filtered_zones(

--- a/nexus/reconfigurator/planning/src/blueprint_builder/clickhouse.rs
+++ b/nexus/reconfigurator/planning/src/blueprint_builder/clickhouse.rs
@@ -293,6 +293,7 @@ pub mod test {
     use clickhouse_admin_types::ServerId;
     use omicron_common::api::external::Generation;
     use omicron_test_utils::dev::test_setup_log;
+    use std::collections::BTreeMap;
 
     fn initial_config(
         n_keeper_zones: u64,

--- a/nexus/reconfigurator/planning/src/blueprint_editor/allocators/internal_dns.rs
+++ b/nexus/reconfigurator/planning/src/blueprint_editor/allocators/internal_dns.rs
@@ -105,18 +105,19 @@ pub mod test {
 
         // `ExampleSystem` adds an internal DNS server to every sled. Manually
         // prune out all but the first of them to give us space to add more.
-        for (_, zone_config) in blueprint1.blueprint_zones.iter_mut().skip(1) {
-            zone_config.zones.retain(|z| !z.zone_type.is_internal_dns());
+        for (_, sled_config) in blueprint1.sleds.iter_mut().skip(1) {
+            sled_config
+                .zones_config
+                .zones
+                .retain(|z| !z.zone_type.is_internal_dns());
         }
-        let npruned = blueprint1.blueprint_zones.len() - 1;
+        let npruned = blueprint1.sleds.len() - 1;
         assert!(npruned > 0);
 
         // Also prune out the zones' datasets, or we're left with an invalid
         // blueprint.
-        for (_, dataset_config) in
-            blueprint1.blueprint_datasets.iter_mut().skip(1)
-        {
-            dataset_config.datasets.retain(|dataset| {
+        for (_, sled_config) in blueprint1.sleds.iter_mut().skip(1) {
+            sled_config.datasets_config.datasets.retain(|dataset| {
                 // This is gross; once zone configs know explicit dataset IDs,
                 // we should retain by ID instead.
                 match &dataset.kind {

--- a/nexus/reconfigurator/planning/src/example.rs
+++ b/nexus/reconfigurator/planning/src/example.rs
@@ -457,10 +457,8 @@ impl ExampleSystemBuilder {
         }
 
         let blueprint = builder.build();
-        for sled_id in blueprint.sleds() {
-            let Some(zones) = blueprint.blueprint_zones.get(&sled_id) else {
-                continue;
-            };
+        for sled_cfg in blueprint.sleds.values() {
+            let zones = &sled_cfg.zones_config;
             for zone in zones.zones.iter() {
                 let service_id = zone.id;
                 if let Some((external_ip, nic)) =
@@ -486,11 +484,14 @@ impl ExampleSystemBuilder {
             }
         }
 
-        for (sled_id, zones) in &blueprint.blueprint_zones {
+        for (sled_id, sled_cfg) in &blueprint.sleds {
             system
                 .sled_set_omicron_zones(
                     *sled_id,
-                    zones.clone().into_running_omicron_zones_config(),
+                    sled_cfg
+                        .zones_config
+                        .clone()
+                        .into_running_omicron_zones_config(),
                 )
                 .unwrap();
         }
@@ -500,10 +501,10 @@ impl ExampleSystemBuilder {
         //
         // Go back and add them so that the blueprint is consistent with
         // inventory.
-        for (sled_id, datasets) in &blueprint.blueprint_datasets {
+        for (sled_id, sled_cfg) in &blueprint.sleds {
             let sled = system.get_sled_mut(*sled_id).unwrap();
 
-            for dataset_config in datasets.datasets.iter() {
+            for dataset_config in sled_cfg.datasets_config.datasets.iter() {
                 let config = dataset_config.clone().try_into().unwrap();
                 sled.add_synthetic_dataset(config);
             }

--- a/nexus/reconfigurator/planning/src/planner.rs
+++ b/nexus/reconfigurator/planning/src/planner.rs
@@ -172,11 +172,12 @@ impl<'a> Planner<'a> {
                 (SledPolicy::Expunged, SledState::Active) => (),
             }
 
-            // Check that the sled isn't already decommissioned in the parent blueprint, if it exists.
-            if let Some(sled_state) =
-                self.blueprint.parent_blueprint().sled_state.get(&sled_id)
+            // Check that the sled isn't already decommissioned in the parent
+            // blueprint, if it exists.
+            if let Some(parent_sled_cfg) =
+                self.blueprint.parent_blueprint().sleds.get(&sled_id)
             {
-                if *sled_state == SledState::Decommissioned {
+                if parent_sled_cfg.state == SledState::Decommissioned {
                     continue;
                 }
             }

--- a/nexus/reconfigurator/planning/src/planner.rs
+++ b/nexus/reconfigurator/planning/src/planner.rs
@@ -1050,7 +1050,7 @@ pub(crate) mod test {
             "diff between blueprints (expected no changes):\n{}",
             summary.display()
         );
-        assert_eq!(summary.sleds_added.len(), 0);
+        assert_eq!(summary.diff.sleds.added.len(), 0);
         assert_eq!(summary.diff.sleds.removed.len(), 0);
         assert_eq!(summary.diff.sleds.modified().count(), 0);
     }
@@ -1089,7 +1089,7 @@ pub(crate) mod test {
 
         let summary = blueprint2.diff_since_blueprint(&blueprint1);
         println!("1 -> 2 (expected no changes):\n{}", summary.display());
-        assert_eq!(summary.sleds_added.len(), 0);
+        assert_eq!(summary.diff.sleds.added.len(), 0);
         assert_eq!(summary.diff.sleds.removed.len(), 0);
         assert_eq!(summary.diff.sleds.modified().count(), 0);
         assert_eq!(summary.diff.sleds.unchanged().count(), 3);
@@ -1134,16 +1134,16 @@ pub(crate) mod test {
             &summary.display().to_string(),
         );
 
-        assert_eq!(summary.sleds_added.len(), 1);
+        assert_eq!(summary.diff.sleds.added.len(), 1);
         assert_eq!(summary.total_disks_added(), 10);
         assert_eq!(summary.total_datasets_added(), 21);
-        let sled_id = *summary.sleds_added.first().unwrap();
-        let sled_added = summary.diff.sleds.added.get(&sled_id).unwrap();
+        let (&sled_id, sled_added) =
+            summary.diff.sleds.added.first_key_value().unwrap();
         // We have defined elsewhere that the first generation contains no
         // zones.  So the first one with zones must be newer.  See
         // OmicronZonesConfig::INITIAL_GENERATION.
         assert!(sled_added.zones_config.generation > Generation::new());
-        assert_eq!(sled_id, new_sled_id);
+        assert_eq!(*sled_id, new_sled_id);
         assert_eq!(sled_added.zones_config.zones.len(), 1);
         assert!(matches!(
             sled_added.zones_config.zones.first().unwrap().kind(),
@@ -1169,7 +1169,7 @@ pub(crate) mod test {
         .expect("failed to plan");
         let summary = blueprint4.diff_since_blueprint(&blueprint3);
         println!("3 -> 4 (expected no changes):\n{}", summary.display());
-        assert_eq!(summary.sleds_added.len(), 0);
+        assert_eq!(summary.diff.sleds.added.len(), 0);
         assert_eq!(summary.diff.sleds.removed.len(), 0);
         assert_eq!(summary.diff.sleds.modified().count(), 0);
         verify_blueprint(&blueprint4);
@@ -1213,7 +1213,7 @@ pub(crate) mod test {
             "tests/output/planner_basic_add_sled_3_5.txt",
             &summary.display().to_string(),
         );
-        assert_eq!(summary.sleds_added.len(), 0);
+        assert_eq!(summary.diff.sleds.added.len(), 0);
         assert_eq!(summary.diff.sleds.removed.len(), 0);
         assert_eq!(summary.diff.sleds.modified().count(), 1);
         let sled_id = summary.diff.sleds.modified_keys().next().unwrap();
@@ -1309,7 +1309,7 @@ pub(crate) mod test {
             "1 -> 2 (added additional Nexus zones):\n{}",
             summary.display()
         );
-        assert_eq!(summary.sleds_added.len(), 0);
+        assert_eq!(summary.diff.sleds.added.len(), 0);
         assert_eq!(summary.diff.sleds.removed.len(), 0);
         assert_eq!(summary.diff.sleds.modified().count(), 1);
         let (changed_sled_id, changed_sled) =
@@ -1388,7 +1388,7 @@ pub(crate) mod test {
             "1 -> 2 (added additional Nexus zones):\n{}",
             summary.display()
         );
-        assert_eq!(summary.sleds_added.len(), 0);
+        assert_eq!(summary.diff.sleds.added.len(), 0);
         assert_eq!(summary.diff.sleds.removed.len(), 0);
         assert_eq!(summary.diff.sleds.modified().count(), 3);
 
@@ -1517,7 +1517,7 @@ pub(crate) mod test {
             "1 -> 2 (added additional internal DNS zones):\n{}",
             summary.display()
         );
-        assert_eq!(summary.sleds_added.len(), 0);
+        assert_eq!(summary.diff.sleds.added.len(), 0);
         assert_eq!(summary.diff.sleds.removed.len(), 0);
         assert_eq!(summary.diff.sleds.modified().count(), 2);
 
@@ -2007,7 +2007,7 @@ pub(crate) mod test {
             &summary.display().to_string(),
         );
 
-        assert_eq!(summary.sleds_added.len(), 0);
+        assert_eq!(summary.diff.sleds.added.len(), 0);
         assert_eq!(summary.diff.sleds.removed.len(), 0);
         assert_eq!(summary.diff.sleds.modified().count(), 1);
 
@@ -2300,7 +2300,7 @@ pub(crate) mod test {
 
         let summary = blueprint2.diff_since_blueprint(&blueprint1);
         println!("1 -> 2 (expunge a disk):\n{}", summary.display());
-        assert_eq!(summary.sleds_added.len(), 0);
+        assert_eq!(summary.diff.sleds.added.len(), 0);
         assert_eq!(summary.diff.sleds.removed.len(), 0);
         assert_eq!(summary.diff.sleds.modified().count(), 1);
 
@@ -2480,7 +2480,7 @@ pub(crate) mod test {
 
         let summary = blueprint2.diff_since_blueprint(&blueprint1);
         println!("1 -> 2 (expunge a disk):\n{}", summary.display());
-        assert_eq!(summary.sleds_added.len(), 0);
+        assert_eq!(summary.diff.sleds.added.len(), 0);
         assert_eq!(summary.diff.sleds.removed.len(), 0);
         assert_eq!(summary.diff.sleds.modified().count(), 1);
 
@@ -2687,7 +2687,7 @@ pub(crate) mod test {
         // cleanup, and we aren't performing garbage collection on zones or
         // sleds at the moment.
 
-        assert_eq!(summary.sleds_added.len(), 0);
+        assert_eq!(summary.diff.sleds.added.len(), 0);
         assert_eq!(summary.diff.sleds.removed.len(), 0);
         assert_eq!(summary.diff.sleds.modified().count(), 3);
         assert_eq!(summary.diff.sleds.unchanged().count(), 2);
@@ -2962,7 +2962,7 @@ pub(crate) mod test {
             "2 -> 3 (decommissioned {expunged_sled_id}):\n{}",
             summary.display()
         );
-        assert_eq!(summary.sleds_added.len(), 0);
+        assert_eq!(summary.diff.sleds.added.len(), 0);
         assert_eq!(summary.diff.sleds.removed.len(), 0);
         assert_eq!(summary.diff.sleds.modified().count(), 0);
         assert_eq!(
@@ -3009,7 +3009,7 @@ pub(crate) mod test {
             "3 -> 4 (removed from input {expunged_sled_id}):\n{}",
             summary.display()
         );
-        assert_eq!(summary.sleds_added.len(), 0);
+        assert_eq!(summary.diff.sleds.added.len(), 0);
         assert_eq!(summary.diff.sleds.removed.len(), 0);
         assert_eq!(summary.diff.sleds.modified().count(), 0);
         assert_eq!(

--- a/nexus/reconfigurator/planning/src/planner.rs
+++ b/nexus/reconfigurator/planning/src/planner.rs
@@ -1051,7 +1051,7 @@ pub(crate) mod test {
             summary.display()
         );
         assert_eq!(summary.sleds_added.len(), 0);
-        assert_eq!(summary.sleds_removed.len(), 0);
+        assert_eq!(summary.diff.sleds.removed.len(), 0);
         assert_eq!(summary.diff.sleds.modified().count(), 0);
     }
 
@@ -1090,7 +1090,7 @@ pub(crate) mod test {
         let summary = blueprint2.diff_since_blueprint(&blueprint1);
         println!("1 -> 2 (expected no changes):\n{}", summary.display());
         assert_eq!(summary.sleds_added.len(), 0);
-        assert_eq!(summary.sleds_removed.len(), 0);
+        assert_eq!(summary.diff.sleds.removed.len(), 0);
         assert_eq!(summary.diff.sleds.modified().count(), 0);
         assert_eq!(summary.diff.sleds.unchanged().count(), 3);
         assert_eq!(summary.total_zones_added(), 0);
@@ -1149,7 +1149,7 @@ pub(crate) mod test {
             sled_added.zones_config.zones.first().unwrap().kind(),
             ZoneKind::InternalNtp
         ));
-        assert_eq!(summary.sleds_removed.len(), 0);
+        assert_eq!(summary.diff.sleds.removed.len(), 0);
         assert_eq!(summary.diff.sleds.modified().count(), 0);
         verify_blueprint(&blueprint3);
 
@@ -1170,7 +1170,7 @@ pub(crate) mod test {
         let summary = blueprint4.diff_since_blueprint(&blueprint3);
         println!("3 -> 4 (expected no changes):\n{}", summary.display());
         assert_eq!(summary.sleds_added.len(), 0);
-        assert_eq!(summary.sleds_removed.len(), 0);
+        assert_eq!(summary.diff.sleds.removed.len(), 0);
         assert_eq!(summary.diff.sleds.modified().count(), 0);
         verify_blueprint(&blueprint4);
 
@@ -1214,7 +1214,7 @@ pub(crate) mod test {
             &summary.display().to_string(),
         );
         assert_eq!(summary.sleds_added.len(), 0);
-        assert_eq!(summary.sleds_removed.len(), 0);
+        assert_eq!(summary.diff.sleds.removed.len(), 0);
         assert_eq!(summary.diff.sleds.modified().count(), 1);
         let sled_id = summary.diff.sleds.modified_keys().next().unwrap();
         assert_eq!(*sled_id, new_sled_id);
@@ -1310,7 +1310,7 @@ pub(crate) mod test {
             summary.display()
         );
         assert_eq!(summary.sleds_added.len(), 0);
-        assert_eq!(summary.sleds_removed.len(), 0);
+        assert_eq!(summary.diff.sleds.removed.len(), 0);
         assert_eq!(summary.diff.sleds.modified().count(), 1);
         let (changed_sled_id, changed_sled) =
             summary.diff.sleds.modified().next().unwrap();
@@ -1389,7 +1389,7 @@ pub(crate) mod test {
             summary.display()
         );
         assert_eq!(summary.sleds_added.len(), 0);
-        assert_eq!(summary.sleds_removed.len(), 0);
+        assert_eq!(summary.diff.sleds.removed.len(), 0);
         assert_eq!(summary.diff.sleds.modified().count(), 3);
 
         // All 3 sleds should get additional Nexus zones. We expect a total of
@@ -1518,7 +1518,7 @@ pub(crate) mod test {
             summary.display()
         );
         assert_eq!(summary.sleds_added.len(), 0);
-        assert_eq!(summary.sleds_removed.len(), 0);
+        assert_eq!(summary.diff.sleds.removed.len(), 0);
         assert_eq!(summary.diff.sleds.modified().count(), 2);
 
         // 2 sleds should each get 1 additional internal DNS zone.
@@ -2008,7 +2008,7 @@ pub(crate) mod test {
         );
 
         assert_eq!(summary.sleds_added.len(), 0);
-        assert_eq!(summary.sleds_removed.len(), 0);
+        assert_eq!(summary.diff.sleds.removed.len(), 0);
         assert_eq!(summary.diff.sleds.modified().count(), 1);
 
         assert_eq!(summary.total_zones_added(), 0);
@@ -2301,7 +2301,7 @@ pub(crate) mod test {
         let summary = blueprint2.diff_since_blueprint(&blueprint1);
         println!("1 -> 2 (expunge a disk):\n{}", summary.display());
         assert_eq!(summary.sleds_added.len(), 0);
-        assert_eq!(summary.sleds_removed.len(), 0);
+        assert_eq!(summary.diff.sleds.removed.len(), 0);
         assert_eq!(summary.diff.sleds.modified().count(), 1);
 
         // We should be removing a single zone, associated with the Crucible
@@ -2481,7 +2481,7 @@ pub(crate) mod test {
         let summary = blueprint2.diff_since_blueprint(&blueprint1);
         println!("1 -> 2 (expunge a disk):\n{}", summary.display());
         assert_eq!(summary.sleds_added.len(), 0);
-        assert_eq!(summary.sleds_removed.len(), 0);
+        assert_eq!(summary.diff.sleds.removed.len(), 0);
         assert_eq!(summary.diff.sleds.modified().count(), 1);
 
         // No zones should have been removed from the blueprint entirely.
@@ -2688,7 +2688,7 @@ pub(crate) mod test {
         // sleds at the moment.
 
         assert_eq!(summary.sleds_added.len(), 0);
-        assert_eq!(summary.sleds_removed.len(), 0);
+        assert_eq!(summary.diff.sleds.removed.len(), 0);
         assert_eq!(summary.diff.sleds.modified().count(), 3);
         assert_eq!(summary.diff.sleds.unchanged().count(), 2);
 
@@ -2963,7 +2963,7 @@ pub(crate) mod test {
             summary.display()
         );
         assert_eq!(summary.sleds_added.len(), 0);
-        assert_eq!(summary.sleds_removed.len(), 0);
+        assert_eq!(summary.diff.sleds.removed.len(), 0);
         assert_eq!(summary.diff.sleds.modified().count(), 0);
         assert_eq!(
             summary.diff.sleds.unchanged().count(),
@@ -2984,8 +2984,8 @@ pub(crate) mod test {
         // table are kept forever -- but we need to test it.)
         //
         // Eventually, once zone and sled garbage collection is implemented,
-        // we'll expect that the blueprint's sleds_removed will become
-        // non-zero. At some point we may also want to remove entries from the
+        // we'll expect that the diff's `sleds.removed` will become
+        // non-empty. At some point we may also want to remove entries from the
         // sled table, but that's a future concern that would come after
         // blueprint cleanup is implemented.
         let mut builder = input.into_builder();
@@ -3010,7 +3010,7 @@ pub(crate) mod test {
             summary.display()
         );
         assert_eq!(summary.sleds_added.len(), 0);
-        assert_eq!(summary.sleds_removed.len(), 0);
+        assert_eq!(summary.diff.sleds.removed.len(), 0);
         assert_eq!(summary.diff.sleds.modified().count(), 0);
         assert_eq!(
             summary.diff.sleds.unchanged().count(),

--- a/nexus/reconfigurator/planning/src/planner.rs
+++ b/nexus/reconfigurator/planning/src/planner.rs
@@ -1092,7 +1092,7 @@ pub(crate) mod test {
         assert_eq!(summary.sleds_added.len(), 0);
         assert_eq!(summary.sleds_removed.len(), 0);
         assert_eq!(summary.sleds_modified.len(), 0);
-        assert_eq!(summary.sleds_unchanged.len(), 3);
+        assert_eq!(summary.diff.sleds.unchanged().count(), 3);
         assert_eq!(summary.total_zones_added(), 0);
         assert_eq!(summary.total_zones_removed(), 0);
         assert_eq!(summary.total_zones_modified(), 0);
@@ -2696,7 +2696,7 @@ pub(crate) mod test {
         assert_eq!(summary.sleds_added.len(), 0);
         assert_eq!(summary.sleds_removed.len(), 0);
         assert_eq!(summary.sleds_modified.len(), 3);
-        assert_eq!(summary.sleds_unchanged.len(), 2);
+        assert_eq!(summary.diff.sleds.unchanged().count(), 2);
 
         assert_all_zones_expunged(&summary, expunged_sled_id, "expunged sled");
 
@@ -2966,7 +2966,7 @@ pub(crate) mod test {
         assert_eq!(summary.sleds_removed.len(), 0);
         assert_eq!(summary.sleds_modified.len(), 0);
         assert_eq!(
-            summary.sleds_unchanged.len(),
+            summary.diff.sleds.unchanged().count(),
             ExampleSystemBuilder::DEFAULT_N_SLEDS
         );
 
@@ -3013,7 +3013,7 @@ pub(crate) mod test {
         assert_eq!(summary.sleds_removed.len(), 0);
         assert_eq!(summary.sleds_modified.len(), 0);
         assert_eq!(
-            summary.sleds_unchanged.len(),
+            summary.diff.sleds.unchanged().count(),
             ExampleSystemBuilder::DEFAULT_N_SLEDS
         );
 

--- a/nexus/reconfigurator/planning/tests/output/planner_nonprovisionable_2_2a.txt
+++ b/nexus/reconfigurator/planning/tests/output/planner_nonprovisionable_2_2a.txt
@@ -183,6 +183,97 @@ to:   blueprint 9f71f5d3-a272-4382-9154-6ea2e171a6c6
     nexus          cab211e1-3ab1-475f-81fa-984748044d8c   in service    fd00:1122:3344:101::2d
 
 
+ REMOVED SLEDS:
+
+  sled 68d24ac5-f341-49ea-a92a-0381b52ab387 (was decommissioned):
+
+    physical disks from generation 2:
+    ------------------------------------------------------------------------------------
+    vendor        model        serial                                        disposition
+    ------------------------------------------------------------------------------------
+-   fake-vendor   fake-model   serial-09a5de95-c15f-486e-b776-fca62bf5e179   in service 
+-   fake-vendor   fake-model   serial-11b8eccf-7c78-4bde-8639-b35a83082a95   in service 
+-   fake-vendor   fake-model   serial-1931c422-4c6a-4597-8ae7-ecb44718462c   in service 
+-   fake-vendor   fake-model   serial-21a8a87e-73a4-42d4-a426-f6eec94004e3   in service 
+-   fake-vendor   fake-model   serial-222c0b55-2966-46b6-816c-9063a7587806   in service 
+-   fake-vendor   fake-model   serial-3676f688-f41c-4f89-936a-6b04c3011b2a   in service 
+-   fake-vendor   fake-model   serial-5e9e14c4-d60d-4b5c-a11c-bba54eb24c9f   in service 
+-   fake-vendor   fake-model   serial-74f7b89e-88f5-4336-ba8b-22283a6966c5   in service 
+-   fake-vendor   fake-model   serial-a787cac8-b5e3-49e3-aaab-20d8eadd8a63   in service 
+-   fake-vendor   fake-model   serial-d56b0c9f-0e57-43d8-a1ac-8b4d2c303c29   in service 
+
+
+    datasets from generation 2:
+    -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
+    dataset name                                                                                                   dataset id                             disposition   quota     reservation   compression
+    -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
+-   oxp_09a5de95-c15f-486e-b776-fca62bf5e179/crucible                                                              b77e647a-9173-499a-854a-6c0b4968b7e0   in service    none      none          off        
+-   oxp_11b8eccf-7c78-4bde-8639-b35a83082a95/crucible                                                              58fdafab-31e5-4fa2-89c6-322e3a2b482e   in service    none      none          off        
+-   oxp_1931c422-4c6a-4597-8ae7-ecb44718462c/crucible                                                              d0437bf1-8860-49d3-8fb3-da4c67a5a08b   in service    none      none          off        
+-   oxp_21a8a87e-73a4-42d4-a426-f6eec94004e3/crucible                                                              55406728-458a-4768-8c60-4bda237e5eee   in service    none      none          off        
+-   oxp_222c0b55-2966-46b6-816c-9063a7587806/crucible                                                              541775da-bd2a-47da-b3a7-0554f1b318d7   in service    none      none          off        
+-   oxp_3676f688-f41c-4f89-936a-6b04c3011b2a/crucible                                                              cf342d78-595a-4871-badc-4b4abf86df59   in service    none      none          off        
+-   oxp_5e9e14c4-d60d-4b5c-a11c-bba54eb24c9f/crucible                                                              f90acbe5-1565-4f3d-bab7-c82dbc5d88e0   in service    none      none          off        
+-   oxp_74f7b89e-88f5-4336-ba8b-22283a6966c5/crucible                                                              572b2277-6c1c-45b7-afaa-85c6838c4fb1   in service    none      none          off        
+-   oxp_a787cac8-b5e3-49e3-aaab-20d8eadd8a63/crucible                                                              46699296-d0e9-4fdd-bd1a-f6f7e23bf14e   in service    none      none          off        
+-   oxp_d56b0c9f-0e57-43d8-a1ac-8b4d2c303c29/crucible                                                              17e494d7-7797-4f2f-9f0e-f01340c5d20c   in service    none      none          off        
+-   oxp_09a5de95-c15f-486e-b776-fca62bf5e179/crypt/internal_dns                                                    6b3c8095-3f2e-4844-adad-58c2a9672b0f   in service    none      none          off        
+-   oxp_09a5de95-c15f-486e-b776-fca62bf5e179/crypt/zone                                                            0a15e4d5-df40-4084-b60d-cdf7ee46ab4e   in service    none      none          off        
+-   oxp_11b8eccf-7c78-4bde-8639-b35a83082a95/crypt/zone                                                            5d9f6772-bda9-4ad1-af28-06fe072d49ce   in service    none      none          off        
+-   oxp_1931c422-4c6a-4597-8ae7-ecb44718462c/crypt/zone                                                            22a21aab-ef00-4741-b1af-83628f9176ed   in service    none      none          off        
+-   oxp_21a8a87e-73a4-42d4-a426-f6eec94004e3/crypt/zone                                                            7d4d36bb-db99-44a8-9542-c18644925ecd   in service    none      none          off        
+-   oxp_222c0b55-2966-46b6-816c-9063a7587806/crypt/zone                                                            d9255b0c-5115-4b4c-9a15-20b7abc6a625   in service    none      none          off        
+-   oxp_3676f688-f41c-4f89-936a-6b04c3011b2a/crypt/zone                                                            5bd021b1-e4dd-4dfb-af5d-30a5d5fc6de6   in service    none      none          off        
+-   oxp_5e9e14c4-d60d-4b5c-a11c-bba54eb24c9f/crypt/zone                                                            1c0a27d1-5feb-4c88-8ef5-ad438e2e337b   in service    none      none          off        
+-   oxp_74f7b89e-88f5-4336-ba8b-22283a6966c5/crypt/zone                                                            378cde4a-b2e0-4c04-8a77-c8a333b21e79   in service    none      none          off        
+-   oxp_a787cac8-b5e3-49e3-aaab-20d8eadd8a63/crypt/zone                                                            6982b864-f299-4a0c-bc1c-b05cfd923ad4   in service    none      none          off        
+-   oxp_d56b0c9f-0e57-43d8-a1ac-8b4d2c303c29/crypt/zone                                                            21aba03d-0506-4ded-992c-2198a9df8db8   in service    none      none          off        
+-   oxp_11b8eccf-7c78-4bde-8639-b35a83082a95/crypt/zone/oxz_crucible_258c5106-ebcd-4651-96e4-d5b0895691f6          d3b4685c-6b3c-4547-8f31-914760b52b6f   in service    none      none          off        
+-   oxp_5e9e14c4-d60d-4b5c-a11c-bba54eb24c9f/crypt/zone/oxz_crucible_2b046f65-00f5-46da-988c-90c1de32a1dd          68670f81-967f-410a-89f5-5aeed7725f18   in service    none      none          off        
+-   oxp_d56b0c9f-0e57-43d8-a1ac-8b4d2c303c29/crypt/zone/oxz_crucible_30c770a8-625e-4864-8977-d83a11c1c596          bf61091c-be19-4e3c-9665-61fe5d3f984f   in service    none      none          off        
+-   oxp_21a8a87e-73a4-42d4-a426-f6eec94004e3/crypt/zone/oxz_crucible_35e3587d-25d3-4234-822f-2d68713b8cbf          ac9ca46f-4a0a-4cd0-ad58-e89609ebb241   in service    none      none          off        
+-   oxp_222c0b55-2966-46b6-816c-9063a7587806/crypt/zone/oxz_crucible_46293b15-fd26-48f9-9ccb-122fa0ef41b4          d406c3ce-a277-42c2-beac-9fe311e7a2f9   in service    none      none          off        
+-   oxp_09a5de95-c15f-486e-b776-fca62bf5e179/crypt/zone/oxz_crucible_462c6b8d-1872-4671-b84a-bdcbb69e3baf          83c9535d-cf93-440a-bfda-e7d17d5ad31e   in service    none      none          off        
+-   oxp_1931c422-4c6a-4597-8ae7-ecb44718462c/crypt/zone/oxz_crucible_a046c5f9-25e7-47c3-9c67-43d68fb39c5e          e485343e-cf15-4484-82eb-7913b388cdf0   in service    none      none          off        
+-   oxp_a787cac8-b5e3-49e3-aaab-20d8eadd8a63/crypt/zone/oxz_crucible_a49d4037-506e-4732-8e21-1f8c136a3c17          45e58d60-6bb9-4bc0-a925-a13952eef7bb   in service    none      none          off        
+-   oxp_74f7b89e-88f5-4336-ba8b-22283a6966c5/crypt/zone/oxz_crucible_df94dc9a-74d9-43a9-8879-199740665f29          1db67d8d-5443-4304-a4fc-22ee0ecf9a14   in service    none      none          off        
+-   oxp_3676f688-f41c-4f89-936a-6b04c3011b2a/crypt/zone/oxz_crucible_f1622981-7f0b-4a9f-9a70-6b46ab9d5e86          8d49a774-0f12-41ad-acd5-2853553044e4   in service    none      none          off        
+-   oxp_09a5de95-c15f-486e-b776-fca62bf5e179/crypt/zone/oxz_crucible_pantry_b217d3a5-4ebb-45e3-b5be-2ebb2c57d8fa   03429538-a04b-453e-85e0-4495f18d80c9   in service    none      none          off        
+-   oxp_09a5de95-c15f-486e-b776-fca62bf5e179/crypt/zone/oxz_internal_dns_0efed95e-f052-4535-b45a-fac1148c0e6a      0be7365d-2d85-4d99-a186-e404eb93ef59   in service    none      none          off        
+-   oxp_09a5de95-c15f-486e-b776-fca62bf5e179/crypt/zone/oxz_nexus_ee146b15-bc59-43a3-9567-bb8596e6188d             14cd103e-65f0-42f6-a03d-c03b1e865b4c   in service    none      none          off        
+-   oxp_09a5de95-c15f-486e-b776-fca62bf5e179/crypt/zone/oxz_ntp_61a79cb4-7fcb-432d-bbe9-3f9882452db2               0af1fd16-7dde-4bf5-8da6-dceb05bf4aef   in service    none      none          off        
+-   oxp_09a5de95-c15f-486e-b776-fca62bf5e179/crypt/debug                                                           455486dc-8ab4-4405-99fc-862d6dbfcda3   in service    100 GiB   none          gzip-9     
+-   oxp_11b8eccf-7c78-4bde-8639-b35a83082a95/crypt/debug                                                           de5f06bb-1d18-4dec-b8ca-e0947efd7605   in service    100 GiB   none          gzip-9     
+-   oxp_1931c422-4c6a-4597-8ae7-ecb44718462c/crypt/debug                                                           000775a7-f52a-4b4c-845e-f9ec8b27e32c   in service    100 GiB   none          gzip-9     
+-   oxp_21a8a87e-73a4-42d4-a426-f6eec94004e3/crypt/debug                                                           cd6d3991-5be5-49e3-8d2d-b0a29acc479c   in service    100 GiB   none          gzip-9     
+-   oxp_222c0b55-2966-46b6-816c-9063a7587806/crypt/debug                                                           5cfe962a-ff3d-4ab7-8c1b-8979dba15bb0   in service    100 GiB   none          gzip-9     
+-   oxp_3676f688-f41c-4f89-936a-6b04c3011b2a/crypt/debug                                                           0d918a12-c470-472e-9711-7e79ddd9b90b   in service    100 GiB   none          gzip-9     
+-   oxp_5e9e14c4-d60d-4b5c-a11c-bba54eb24c9f/crypt/debug                                                           56d77912-628f-4a06-8e60-ae83e0bd7292   in service    100 GiB   none          gzip-9     
+-   oxp_74f7b89e-88f5-4336-ba8b-22283a6966c5/crypt/debug                                                           54b2745f-9c22-4407-858e-31ea0c9db415   in service    100 GiB   none          gzip-9     
+-   oxp_a787cac8-b5e3-49e3-aaab-20d8eadd8a63/crypt/debug                                                           69c359cd-15e4-485f-8f32-e84c1a19eec8   in service    100 GiB   none          gzip-9     
+-   oxp_d56b0c9f-0e57-43d8-a1ac-8b4d2c303c29/crypt/debug                                                           34d0a7d0-56f8-4a8e-9e71-657c9ebc71f3   in service    100 GiB   none          gzip-9     
+
+
+    omicron zones from generation 2:
+    ----------------------------------------------------------------------------------------------
+    zone type         zone id                                disposition    underlay IP           
+    ----------------------------------------------------------------------------------------------
+-   crucible          258c5106-ebcd-4651-96e4-d5b0895691f6   expunged ⏳     fd00:1122:3344:102::25
+-   crucible          2b046f65-00f5-46da-988c-90c1de32a1dd   expunged ⏳     fd00:1122:3344:102::2a
+-   crucible          30c770a8-625e-4864-8977-d83a11c1c596   expunged ⏳     fd00:1122:3344:102::2d
+-   crucible          35e3587d-25d3-4234-822f-2d68713b8cbf   expunged ⏳     fd00:1122:3344:102::27
+-   crucible          46293b15-fd26-48f9-9ccb-122fa0ef41b4   expunged ⏳     fd00:1122:3344:102::28
+-   crucible          462c6b8d-1872-4671-b84a-bdcbb69e3baf   expunged ⏳     fd00:1122:3344:102::24
+-   crucible          a046c5f9-25e7-47c3-9c67-43d68fb39c5e   expunged ⏳     fd00:1122:3344:102::26
+-   crucible          a49d4037-506e-4732-8e21-1f8c136a3c17   expunged ⏳     fd00:1122:3344:102::2c
+-   crucible          df94dc9a-74d9-43a9-8879-199740665f29   expunged ⏳     fd00:1122:3344:102::2b
+-   crucible          f1622981-7f0b-4a9f-9a70-6b46ab9d5e86   expunged ⏳     fd00:1122:3344:102::29
+-   crucible_pantry   b217d3a5-4ebb-45e3-b5be-2ebb2c57d8fa   expunged ⏳     fd00:1122:3344:102::23
+-   internal_dns      0efed95e-f052-4535-b45a-fac1148c0e6a   expunged ⏳     fd00:1122:3344:3::1   
+-   internal_ntp      61a79cb4-7fcb-432d-bbe9-3f9882452db2   expunged ⏳     fd00:1122:3344:102::21
+-   nexus             ee146b15-bc59-43a3-9567-bb8596e6188d   expunged ⏳     fd00:1122:3344:102::22
+
+
  MODIFIED SLEDS:
 
   sled 2d1cb4f2-cf44-40fc-b118-85036eb732a9 (active):

--- a/nexus/src/app/background/tasks/blueprint_load.rs
+++ b/nexus/src/app/background/tasks/blueprint_load.rs
@@ -216,10 +216,7 @@ mod test {
             },
             Blueprint {
                 id,
-                blueprint_zones: BTreeMap::new(),
-                blueprint_disks: BTreeMap::new(),
-                blueprint_datasets: BTreeMap::new(),
-                sled_state: BTreeMap::new(),
+                sleds: BTreeMap::new(),
                 cockroachdb_setting_preserve_downgrade:
                     CockroachDbPreserveDowngrade::DoNotModify,
                 parent_blueprint_id: Some(parent_blueprint_id),

--- a/nexus/src/app/background/tasks/crdb_node_id_collector.rs
+++ b/nexus/src/app/background/tasks/crdb_node_id_collector.rs
@@ -262,10 +262,11 @@ mod tests {
             iter::once(sled_id),
             "test",
         );
-        let bp_zones = blueprint
-            .blueprint_zones
+        let bp_zones = &mut blueprint
+            .sleds
             .get_mut(&sled_id)
-            .expect("found entry for test sled");
+            .expect("found entry for test sled")
+            .zones_config;
 
         let zpool_id = ZpoolUuid::new_v4();
         let make_crdb_zone_config =

--- a/nexus/test-utils/src/lib.rs
+++ b/nexus/test-utils/src/lib.rs
@@ -45,6 +45,7 @@ use nexus_types::deployment::BlueprintDatasetsConfig;
 use nexus_types::deployment::BlueprintPhysicalDiskConfig;
 use nexus_types::deployment::BlueprintPhysicalDiskDisposition;
 use nexus_types::deployment::BlueprintPhysicalDisksConfig;
+use nexus_types::deployment::BlueprintSledConfig;
 use nexus_types::deployment::BlueprintZoneConfig;
 use nexus_types::deployment::BlueprintZoneDisposition;
 use nexus_types::deployment::BlueprintZoneType;
@@ -832,11 +833,8 @@ impl<'a, N: NexusServer> ControlPlaneTestContextBuilder<'a, N> {
         };
 
         let blueprint = {
-            let mut blueprint_zones = BTreeMap::new();
-            let mut blueprint_disks = BTreeMap::new();
+            let mut blueprint_sleds = BTreeMap::new();
             let mut disk_index = 0;
-            let mut blueprint_datasets = BTreeMap::new();
-            let mut sled_state = BTreeMap::new();
 
             // The first sled agent is the only one that'll have configured
             // blueprint zones, but the others all need to have disks.
@@ -849,20 +847,10 @@ impl<'a, N: NexusServer> ControlPlaneTestContextBuilder<'a, N> {
             {
                 let sled_id = sled_agent.sled_agent_id();
 
-                sled_state.insert(sled_id, SledState::Active);
-
                 let mut disks = IdMap::new();
                 let mut datasets = IdMap::new();
 
-                if let Some(zones) = maybe_zones {
-                    blueprint_zones.insert(
-                        sled_id,
-                        BlueprintZonesConfig {
-                            generation: Generation::new().next(),
-                            zones: zones.iter().cloned().collect(),
-                        },
-                    );
-
+                let zones_config = if let Some(zones) = maybe_zones {
                     for zone in zones {
                         if let Some(zpool) = &zone.filesystem_pool {
                             disks.insert(BlueprintPhysicalDiskConfig {
@@ -898,15 +886,16 @@ impl<'a, N: NexusServer> ControlPlaneTestContextBuilder<'a, N> {
                             });
                         }
                     }
+                    BlueprintZonesConfig {
+                        generation: Generation::new().next(),
+                        zones: zones.iter().cloned().collect(),
+                    }
                 } else {
-                    blueprint_zones.insert(
-                        sled_id,
-                        BlueprintZonesConfig {
-                            generation: Generation::new().next(),
-                            zones: IdMap::new(),
-                        },
-                    );
-                }
+                    BlueprintZonesConfig {
+                        generation: Generation::new().next(),
+                        zones: IdMap::new(),
+                    }
+                };
 
                 // Populate extra fake disks, giving each sled 10 total.
                 if disks.len() < 10 {
@@ -926,29 +915,26 @@ impl<'a, N: NexusServer> ControlPlaneTestContextBuilder<'a, N> {
                     }
                 }
 
-                blueprint_disks.insert(
+                blueprint_sleds.insert(
                     sled_id,
-                    BlueprintPhysicalDisksConfig {
-                        generation: Generation::new().next(),
-                        disks,
-                    },
-                );
-
-                blueprint_datasets.insert(
-                    sled_id,
-                    BlueprintDatasetsConfig {
-                        generation: Generation::new().next(),
-                        datasets,
+                    BlueprintSledConfig {
+                        state: SledState::Active,
+                        disks_config: BlueprintPhysicalDisksConfig {
+                            generation: Generation::new().next(),
+                            disks,
+                        },
+                        datasets_config: BlueprintDatasetsConfig {
+                            generation: Generation::new().next(),
+                            datasets,
+                        },
+                        zones_config,
                     },
                 );
             }
 
             Blueprint {
                 id: BlueprintUuid::new_v4(),
-                blueprint_zones,
-                blueprint_disks,
-                blueprint_datasets,
-                sled_state,
+                sleds: blueprint_sleds,
                 parent_blueprint_id: None,
                 internal_dns_version: dns_config.generation,
                 external_dns_version: Generation::new(),

--- a/nexus/test-utils/src/resource_helpers.rs
+++ b/nexus/test-utils/src/resource_helpers.rs
@@ -1232,8 +1232,8 @@ impl<'a, N: NexusServer> DiskTest<'a, N> {
     }
 
     pub async fn add_blueprint_disks(&mut self, blueprint: &Blueprint) {
-        for (sled_id, disks_config) in blueprint.blueprint_disks.iter() {
-            for disk in &disks_config.disks {
+        for (sled_id, sled_config) in blueprint.sleds.iter() {
+            for disk in &sled_config.disks_config.disks {
                 self.add_zpool_with_dataset_ext(
                     *sled_id,
                     disk.id,

--- a/nexus/types/src/deployment.rs
+++ b/nexus/types/src/deployment.rs
@@ -581,10 +581,7 @@ pub struct BlueprintZonesConfig {
 
 impl Default for BlueprintZonesConfig {
     fn default() -> Self {
-        Self {
-            generation: Generation::new(),
-            zones: IdMap::new(),
-        }
+        Self { generation: Generation::new(), zones: IdMap::new() }
     }
 }
 
@@ -1038,10 +1035,7 @@ pub struct BlueprintDatasetsConfig {
 
 impl Default for BlueprintDatasetsConfig {
     fn default() -> Self {
-        Self {
-            generation: Generation::new(),
-            datasets: IdMap::new(),
-        }
+        Self { generation: Generation::new(), datasets: IdMap::new() }
     }
 }
 

--- a/nexus/types/src/deployment.rs
+++ b/nexus/types/src/deployment.rs
@@ -147,26 +147,8 @@ pub struct Blueprint {
     /// unique identifier for this blueprint
     pub id: BlueprintUuid,
 
-    /// A map of sled id -> desired state of the sled.
-    ///
-    /// A sled is considered part of the control plane cluster iff it has an
-    /// entry in this map.
-    pub sled_state: BTreeMap<SledUuid, SledState>,
-
-    /// A map of sled id -> zones deployed on each sled, along with the
-    /// [`BlueprintZoneDisposition`] for each zone.
-    ///
-    /// Unlike `sled_state`, this map may contain entries for sleds that are no
-    /// longer a part of the control plane cluster (e.g., sleds that have been
-    /// decommissioned, but still have expunged zones where cleanup has not yet
-    /// completed).
-    pub blueprint_zones: BTreeMap<SledUuid, BlueprintZonesConfig>,
-
-    /// A map of sled id -> disks in use on each sled.
-    pub blueprint_disks: BTreeMap<SledUuid, BlueprintPhysicalDisksConfig>,
-
-    /// A map of sled id -> datasets in use on each sled
-    pub blueprint_datasets: BTreeMap<SledUuid, BlueprintDatasetsConfig>,
+    /// A map of sled id -> desired configuration of the sled.
+    pub sleds: BTreeMap<SledUuid, BlueprintSledConfig>,
 
     /// which blueprint this blueprint is based on
     pub parent_blueprint_id: Option<BlueprintUuid>,
@@ -233,7 +215,12 @@ impl Blueprint {
     where
         F: FnMut(BlueprintZoneDisposition) -> bool,
     {
-        Blueprint::filtered_zones(&self.blueprint_zones, filter)
+        Blueprint::filtered_zones(
+            self.sleds
+                .iter()
+                .map(|(sled_id, config)| (*sled_id, &config.zones_config)),
+            filter,
+        )
     }
 
     /// Iterate over the [`BlueprintZoneConfig`] instances that match the
@@ -241,17 +228,17 @@ impl Blueprint {
     //
     // This is a scoped function so that it can be used in the
     // `BlueprintBuilder` during planning as well as in the `Blueprint`.
-    pub fn filtered_zones<F>(
-        zones_by_sled_id: &BTreeMap<SledUuid, BlueprintZonesConfig>,
+    pub fn filtered_zones<'a, I, F>(
+        zones_by_sled_id: I,
         mut filter: F,
-    ) -> impl Iterator<Item = (SledUuid, &BlueprintZoneConfig)>
+    ) -> impl Iterator<Item = (SledUuid, &'a BlueprintZoneConfig)>
     where
+        I: Iterator<Item = (SledUuid, &'a BlueprintZonesConfig)>,
         F: FnMut(BlueprintZoneDisposition) -> bool,
     {
         zones_by_sled_id
-            .iter()
             .flat_map(move |(sled_id, z)| {
-                z.zones.iter().map(move |z| (*sled_id, z))
+                z.zones.iter().map(move |z| (sled_id, z))
             })
             .filter(move |(_, z)| filter(z.disposition))
     }
@@ -266,10 +253,10 @@ impl Blueprint {
     where
         F: FnMut(BlueprintPhysicalDiskDisposition) -> bool,
     {
-        self.blueprint_disks
+        self.sleds
             .iter()
-            .flat_map(move |(sled_id, disks)| {
-                disks.disks.iter().map(|disk| (*sled_id, disk))
+            .flat_map(move |(sled_id, config)| {
+                config.disks_config.disks.iter().map(|disk| (*sled_id, disk))
             })
             .filter(move |(_, d)| filter(d.disposition))
     }
@@ -279,17 +266,21 @@ impl Blueprint {
         &self,
         filter: BlueprintDatasetFilter,
     ) -> impl Iterator<Item = (SledUuid, &BlueprintDatasetConfig)> {
-        self.blueprint_datasets
+        self.sleds
             .iter()
-            .flat_map(move |(sled_id, datasets)| {
-                datasets.datasets.iter().map(|dataset| (*sled_id, dataset))
+            .flat_map(move |(sled_id, config)| {
+                config
+                    .datasets_config
+                    .datasets
+                    .iter()
+                    .map(|dataset| (*sled_id, dataset))
             })
             .filter(move |(_, d)| d.disposition.matches(filter))
     }
 
     /// Iterate over the ids of all sleds in the blueprint
     pub fn sleds(&self) -> impl Iterator<Item = SledUuid> + '_ {
-        self.blueprint_zones.keys().copied()
+        self.sleds.keys().copied()
     }
 
     /// Summarize the difference between two blueprints.
@@ -310,7 +301,7 @@ impl Blueprint {
     }
 }
 
-impl BpTableData for &BlueprintPhysicalDisksConfig {
+impl BpTableData for BlueprintPhysicalDisksConfig {
     fn bp_generation(&self) -> BpGeneration {
         BpGeneration::Value(self.generation)
     }
@@ -477,10 +468,7 @@ impl fmt::Display for BlueprintDisplay<'_> {
         // this method to update the display.
         let Blueprint {
             id,
-            sled_state,
-            blueprint_zones,
-            blueprint_disks,
-            blueprint_datasets,
+            sleds,
             parent_blueprint_id,
             // These two cockroachdb_* fields are handled by
             // `make_cockroachdb_table()`, called below.
@@ -510,101 +498,40 @@ impl fmt::Display for BlueprintDisplay<'_> {
         // Keep track of any sled_ids that have been seen in the first loop.
         let mut seen_sleds = BTreeSet::new();
 
-        // Loop through all sleds that have physical disks and print a table of
-        // those physical disks.
-        //
-        // If there are corresponding zones, print those as well.
-        for (sled_id, disks) in blueprint_disks {
+        // Loop through all sleds and print tables for their disks, datasets,
+        // and zones.
+        for (sled_id, config) in sleds {
             // Construct the disks subtable
             let disks_table = BpTable::new(
                 BpPhysicalDisksTableSchema {},
-                disks.bp_generation(),
-                disks.rows(BpDiffState::Unchanged).collect(),
+                config.disks_config.bp_generation(),
+                config.disks_config.rows(BpDiffState::Unchanged).collect(),
             );
 
             // Look up the sled state
-            let sled_state = sled_state
-                .get(sled_id)
-                .map(|state| state.to_string())
-                .unwrap_or_else(|| {
-                    "blueprint error: unknown sled state".to_string()
-                });
+            let sled_state = config.state;
             writeln!(
                 f,
                 "\n  sled: {sled_id} ({sled_state})\n\n{disks_table}\n",
             )?;
 
             // Construct the datasets subtable
-            if let Some(datasets) = blueprint_datasets.get(sled_id) {
-                let datasets_tab = BpTable::new(
-                    BpDatasetsTableSchema {},
-                    datasets.bp_generation(),
-                    datasets.rows(BpDiffState::Unchanged).collect(),
-                );
-                writeln!(f, "{datasets_tab}\n")?;
-            }
+            let datasets_tab = BpTable::new(
+                BpDatasetsTableSchema {},
+                config.datasets_config.bp_generation(),
+                config.datasets_config.rows(BpDiffState::Unchanged).collect(),
+            );
+            writeln!(f, "{datasets_tab}\n")?;
 
             // Construct the zones subtable
-            if let Some(zones) = blueprint_zones.get(sled_id) {
-                let zones_tab = BpTable::new(
-                    BpOmicronZonesTableSchema {},
-                    zones.bp_generation(),
-                    zones.rows(BpDiffState::Unchanged).collect(),
-                );
-                writeln!(f, "{zones_tab}\n")?;
-            }
+            let zones_tab = BpTable::new(
+                BpOmicronZonesTableSchema {},
+                config.zones_config.bp_generation(),
+                config.zones_config.rows(BpDiffState::Unchanged).collect(),
+            );
+            writeln!(f, "{zones_tab}\n")?;
+
             seen_sleds.insert(sled_id);
-        }
-
-        // Now create and display a table of zones/datasets on sleds that don't
-        // have physical disks.
-        //
-        // This should basically be impossible, so we warn if it occurs.
-        for (sled_id, zones) in blueprint_zones {
-            if !seen_sleds.contains(sled_id) && !zones.zones.is_empty() {
-                writeln!(
-                    f,
-                    "!{sled_id}\n{}\n{}\n\n",
-                    "WARNING: Zones exist without physical disks!",
-                    BpTable::new(
-                        BpOmicronZonesTableSchema {},
-                        zones.bp_generation(),
-                        zones.rows(BpDiffState::Unchanged).collect()
-                    )
-                )?;
-                if let Some(datasets) = blueprint_datasets.get(sled_id) {
-                    writeln!(
-                        f,
-                        "{}\n{}\n",
-                        "WARNING: Datasets also exist without physical disks!",
-                        BpTable::new(
-                            BpDatasetsTableSchema {},
-                            datasets.bp_generation(),
-                            datasets.rows(BpDiffState::Unchanged).collect(),
-                        )
-                    )?;
-                }
-                seen_sleds.insert(sled_id);
-            }
-        }
-
-        // Finally, create and display a table of datasets on sleds that don't
-        // have disks or zones.
-        //
-        // This should basically be impossible, so we warn if it occurs.
-        for (sled_id, datasets) in blueprint_datasets {
-            if !seen_sleds.contains(sled_id) && !datasets.datasets.is_empty() {
-                writeln!(
-                    f,
-                    "!{sled_id}\n{}\n{}\n\n",
-                    "WARNING: Datasets exist without physical disks or zones!",
-                    BpTable::new(
-                        BpDatasetsTableSchema {},
-                        datasets.bp_generation(),
-                        datasets.rows(BpDiffState::Unchanged).collect(),
-                    )
-                )?;
-            }
         }
 
         if let Some((t1, t2, t3)) = self.make_clickhouse_cluster_config_tables()
@@ -617,6 +544,19 @@ impl fmt::Display for BlueprintDisplay<'_> {
 
         Ok(())
     }
+}
+
+/// Information about the configuration of a sled as recorded in a blueprint.
+///
+/// Part of [`Blueprint`].
+#[derive(
+    Debug, Clone, Eq, PartialEq, JsonSchema, Deserialize, Serialize, Diffable,
+)]
+pub struct BlueprintSledConfig {
+    pub state: SledState,
+    pub disks_config: BlueprintPhysicalDisksConfig,
+    pub datasets_config: BlueprintDatasetsConfig,
+    pub zones_config: BlueprintZonesConfig,
 }
 
 /// Information about an Omicron zone as recorded in a blueprint.

--- a/nexus/types/src/deployment.rs
+++ b/nexus/types/src/deployment.rs
@@ -579,6 +579,15 @@ pub struct BlueprintZonesConfig {
     pub zones: IdMap<BlueprintZoneConfig>,
 }
 
+impl Default for BlueprintZonesConfig {
+    fn default() -> Self {
+        Self {
+            generation: Generation::new(),
+            zones: IdMap::new(),
+        }
+    }
+}
+
 impl BlueprintZonesConfig {
     /// Converts self into [`OmicronZonesConfig`].
     ///
@@ -1025,6 +1034,15 @@ impl From<BlueprintPhysicalDiskConfig> for OmicronPhysicalDiskConfig {
 pub struct BlueprintDatasetsConfig {
     pub generation: Generation,
     pub datasets: IdMap<BlueprintDatasetConfig>,
+}
+
+impl Default for BlueprintDatasetsConfig {
+    fn default() -> Self {
+        Self {
+            generation: Generation::new(),
+            datasets: IdMap::new(),
+        }
+    }
 }
 
 impl BlueprintDatasetsConfig {

--- a/nexus/types/src/deployment/blueprint_diff.rs
+++ b/nexus/types/src/deployment/blueprint_diff.rs
@@ -43,7 +43,6 @@ pub struct BlueprintDiffSummary<'a> {
     pub modified_sleds_diff: BTreeMap<SledUuid, BlueprintSledConfigDiff<'a>>,
     // TODO-john do we need these sets still?
     pub sleds_added: BTreeSet<SledUuid>,
-    pub sleds_removed: BTreeSet<SledUuid>,
 }
 
 impl<'a> BlueprintDiffSummary<'a> {
@@ -58,8 +57,6 @@ impl<'a> BlueprintDiffSummary<'a> {
         // TODO-john do we still need these or can we use `diff.sleds` directly?
         let sleds_added: BTreeSet<_> =
             diff.sleds.added.keys().map(|k| **k).collect();
-        let sleds_removed: BTreeSet<_> =
-            diff.sleds.removed.keys().map(|k| **k).collect();
 
         BlueprintDiffSummary {
             before,
@@ -67,7 +64,6 @@ impl<'a> BlueprintDiffSummary<'a> {
             diff,
             modified_sleds_diff,
             sleds_added,
-            sleds_removed,
         }
     }
 
@@ -1937,11 +1933,6 @@ impl<'diff> BlueprintDiffDisplay<'diff> {
         let after = self.summary.diff.sleds.added.get(sled_id).unwrap().state;
         format!("{after}")
     }
-    fn sled_state_removed(&self, sled_id: &SledUuid) -> String {
-        let before =
-            self.summary.diff.sleds.removed.get(sled_id).unwrap().state;
-        format!("was {before}")
-    }
 }
 
 impl fmt::Display for BlueprintDiffDisplay<'_> {
@@ -1984,14 +1975,10 @@ impl fmt::Display for BlueprintDiffDisplay<'_> {
         }
 
         // Write out tables for removed sleds
-        if !summary.sleds_removed.is_empty() {
+        if !summary.diff.sleds.removed.is_empty() {
             writeln!(f, " REMOVED SLEDS:\n")?;
-            for sled_id in &summary.sleds_removed {
-                writeln!(
-                    f,
-                    "  sled {sled_id} ({}):\n",
-                    self.sled_state_removed(sled_id)
-                )?;
+            for (sled_id, sled) in &summary.diff.sleds.removed {
+                writeln!(f, "  sled {sled_id} (was {}):\n", sled.state)?;
                 self.write_tables(f, sled_id)?;
             }
         }

--- a/openapi/nexus-internal.json
+++ b/openapi/nexus-internal.json
@@ -1855,27 +1855,6 @@
         "description": "Describes a complete set of software and configuration for the system",
         "type": "object",
         "properties": {
-          "blueprint_datasets": {
-            "description": "A map of sled id -> datasets in use on each sled",
-            "type": "object",
-            "additionalProperties": {
-              "$ref": "#/components/schemas/BlueprintDatasetsConfig"
-            }
-          },
-          "blueprint_disks": {
-            "description": "A map of sled id -> disks in use on each sled.",
-            "type": "object",
-            "additionalProperties": {
-              "$ref": "#/components/schemas/BlueprintPhysicalDisksConfig"
-            }
-          },
-          "blueprint_zones": {
-            "description": "A map of sled id -> zones deployed on each sled, along with the [`BlueprintZoneDisposition`] for each zone.\n\nUnlike `sled_state`, this map may contain entries for sleds that are no longer a part of the control plane cluster (e.g., sleds that have been decommissioned, but still have expunged zones where cleanup has not yet completed).",
-            "type": "object",
-            "additionalProperties": {
-              "$ref": "#/components/schemas/BlueprintZonesConfig"
-            }
-          },
           "clickhouse_cluster_config": {
             "nullable": true,
             "description": "Allocation of Clickhouse Servers and Keepers for replicated clickhouse setups. This is set to `None` if replicated clickhouse is not in use.",
@@ -1938,11 +1917,11 @@
               }
             ]
           },
-          "sled_state": {
-            "description": "A map of sled id -> desired state of the sled.\n\nA sled is considered part of the control plane cluster iff it has an entry in this map.",
+          "sleds": {
+            "description": "A map of sled id -> desired configuration of the sled.",
             "type": "object",
             "additionalProperties": {
-              "$ref": "#/components/schemas/SledState"
+              "$ref": "#/components/schemas/BlueprintSledConfig"
             }
           },
           "time_created": {
@@ -1952,9 +1931,6 @@
           }
         },
         "required": [
-          "blueprint_datasets",
-          "blueprint_disks",
-          "blueprint_zones",
           "cockroachdb_fingerprint",
           "cockroachdb_setting_preserve_downgrade",
           "comment",
@@ -1962,7 +1938,7 @@
           "external_dns_version",
           "id",
           "internal_dns_version",
-          "sled_state",
+          "sleds",
           "time_created"
         ]
       },
@@ -2231,6 +2207,30 @@
         "required": [
           "disks",
           "generation"
+        ]
+      },
+      "BlueprintSledConfig": {
+        "description": "Information about the configuration of a sled as recorded in a blueprint.\n\nPart of [`Blueprint`].",
+        "type": "object",
+        "properties": {
+          "datasets_config": {
+            "$ref": "#/components/schemas/BlueprintDatasetsConfig"
+          },
+          "disks_config": {
+            "$ref": "#/components/schemas/BlueprintPhysicalDisksConfig"
+          },
+          "state": {
+            "$ref": "#/components/schemas/SledState"
+          },
+          "zones_config": {
+            "$ref": "#/components/schemas/BlueprintZonesConfig"
+          }
+        },
+        "required": [
+          "datasets_config",
+          "disks_config",
+          "state",
+          "zones_config"
         ]
       },
       "BlueprintTarget": {

--- a/sled-agent/src/rack_setup/service.rs
+++ b/sled-agent/src/rack_setup/service.rs
@@ -90,6 +90,7 @@ use nexus_client::{
 use nexus_sled_agent_shared::inventory::{
     OmicronZoneConfig, OmicronZoneType, OmicronZonesConfig,
 };
+use nexus_types::deployment::BlueprintSledConfig;
 use nexus_types::deployment::{
     blueprint_zone_type, id_map::IdMap, Blueprint, BlueprintDatasetConfig,
     BlueprintDatasetDisposition, BlueprintDatasetsConfig, BlueprintZoneType,
@@ -833,9 +834,9 @@ impl ServiceInner {
         // field -- the coupling of datasets with addresses is linked
         // to usage by specific zones.
         for dataset in blueprint
-            .blueprint_datasets
+            .sleds
             .values()
-            .flat_map(|config| config.datasets.iter())
+            .flat_map(|config| config.datasets_config.datasets.iter())
             .filter(|dataset| dataset.kind == DatasetKind::Crucible)
         {
             let address = match dataset.address {
@@ -1517,12 +1518,7 @@ pub(crate) fn build_initial_blueprint_from_sled_configs(
     sled_configs_by_id: &BTreeMap<SledUuid, SledConfig>,
     internal_dns_version: Generation,
 ) -> anyhow::Result<Blueprint> {
-    let blueprint_disks: BTreeMap<_, _> = sled_configs_by_id
-        .iter()
-        .map(|(sled_id, sled_config)| (*sled_id, sled_config.disks.clone()))
-        .collect();
-
-    let mut blueprint_datasets = BTreeMap::new();
+    let mut blueprint_sleds = BTreeMap::new();
     for (sled_id, sled_config) in sled_configs_by_id {
         let mut datasets = IdMap::new();
         for d in sled_config.datasets.datasets.values() {
@@ -1563,43 +1559,36 @@ pub(crate) fn build_initial_blueprint_from_sled_configs(
             });
         }
 
-        blueprint_datasets.insert(
+        blueprint_sleds.insert(
             *sled_id,
-            BlueprintDatasetsConfig {
-                generation: sled_config.datasets.generation,
-                datasets,
+            BlueprintSledConfig {
+                state: SledState::Active,
+                disks_config: sled_config.disks.clone(),
+                datasets_config: BlueprintDatasetsConfig {
+                    generation: sled_config.datasets.generation,
+                    datasets,
+                },
+                // This is a bit of a hack. We only construct a blueprint after
+                // completing RSS, so we need to know the final generation value
+                // sent to all sleds. Arguably, we should record this in the
+                // serialized RSS plan; however, we have already deployed
+                // systems that did not. We know that every such system used
+                // `V5_EVERYTHING` as the final generation count, so we can just
+                // use that value here. If we ever change this, in particular in
+                // a way where newly-deployed systems will have a different
+                // value, we will need to revisit storing this in the serialized
+                // RSS plan.
+                zones_config: BlueprintZonesConfig {
+                    generation: DeployStepVersion::V5_EVERYTHING,
+                    zones: sled_config.zones.iter().cloned().collect(),
+                },
             },
         );
     }
 
-    let mut blueprint_zones = BTreeMap::new();
-    let mut sled_state = BTreeMap::new();
-    for (sled_id, sled_config) in sled_configs_by_id {
-        let zones_config = BlueprintZonesConfig {
-            // This is a bit of a hack. We only construct a blueprint after
-            // completing RSS, so we need to know the final generation value
-            // sent to all sleds. Arguably, we should record this in the
-            // serialized RSS plan; however, we have already deployed
-            // systems that did not. We know that every such system used
-            // `V5_EVERYTHING` as the final generation count, so we can just
-            // use that value here. If we ever change this, in particular in
-            // a way where newly-deployed systems will have a different
-            // value, we will need to revisit storing this in the serialized
-            // RSS plan.
-            generation: DeployStepVersion::V5_EVERYTHING,
-            zones: sled_config.zones.iter().cloned().collect(),
-        };
-
-        blueprint_zones.insert(*sled_id, zones_config);
-        sled_state.insert(*sled_id, SledState::Active);
-    }
-
     Ok(Blueprint {
         id: BlueprintUuid::new_v4(),
-        blueprint_zones,
-        blueprint_disks,
-        blueprint_datasets,
-        sled_state,
+        sleds: blueprint_sleds,
         parent_blueprint_id: None,
         internal_dns_version,
         // We don't configure external DNS during RSS, so set it to an initial


### PR DESCRIPTION
Sorry for the size of this PR. Most of the bulk of the diff is made up of mechanical changes to tests; I don't think there's a way to split this up any smaller. If you ignore whitespace that will trim a few hundred lines off the diff.

This PR should make zero behavioral changes. The main thrust of the PR is to replace the four maps in `Blueprint` (`sled_state`, `blueprint_zones`, `blueprint_disks`, `blueprint_datasets`) with a single map containing the config for each sled (`sleds: BTreeMap<SledUuid, BlueprintSledConfig>`). Only one expectorate file changed (and that's because I changed the test; it was previously doing a thing we can't do anymore with the combined maps).

Nontrivial fallout from this change:

* `BlueprintBuilder` no longer has to do work to ingest a parent blueprint where sleds present in `blueprint_zones` were missing in one or more of the other three maps.
* ... but `nexus-db-model` has to do that work now instead, to allow us to continue to load old blueprints from the db that didn't require all four maps to have consistent keys. We should be able to drop this and instead `bail!` after R14, since upgrading to that release will involve creating a blueprint that uses this combined map (and thus guarantees the blueprint in the db has entries for all its fields).
* `blippy` got to delete several checks that are now statically impossible.
* The blueprint diff implementation similarly got to delete a bunch of summary fields that were complicated to construct; the `daft` output from the `sleds` map is now directly usable in place of all those summary fields.

I think this is pretty clearly a win, but there are a couple places where users of blueprints or diffs are a little uglier IMO:

* Tests that were constructing a blueprint that only cared about one of the four maps now have to fill in the full `sleds` map. This is straightforward and mechanical, but is a little noisy.
* The executor library had substeps that took the individual maps as arguments. Those maps no longer exist, so I changed them to take iterators instead. This was also straightforward and mechanical, but even more noisy.
* Using the blueprint `summary.diff.sleds` directly in tests instead of the old summary sets is more verbose. (Personally I prefer this change, despite the verbosity, because I found it easier to look at `daft`'s docs then remember what all the helper methods in the diff summary did. But I could see others feeling differently.)

Fixes #7078. After this change, it'll be possible to start work on #7309 (merging the disks/datasets/zone sled-agent endpoints into one), since this restructuring will allow us to tag the combined config with a single generation.