### PR TITLE
[nexus] Don't squash rack init error codes down to 500s

### DIFF
--- a/nexus/db-queries/src/db/datastore/rack.rs
+++ b/nexus/db-queries/src/db/datastore/rack.rs
@@ -140,14 +140,18 @@ impl From<RackInitError> for Error {
                     public_error_from_diesel(e, ErrorHandler::Server)
                 }
             },
-            RackInitError::PhysicalDiskInsert(err) => err,
-            RackInitError::ZpoolInsert(err) => err,
-            RackInitError::BlueprintInsert(err) => Error::internal_error(
-                &format!("failed to insert Blueprint: {:#}", err),
-            ),
-            RackInitError::BlueprintTargetSet(err) => Error::internal_error(
-                &format!("failed to insert set target Blueprint: {:#}", err),
-            ),
+            RackInitError::PhysicalDiskInsert(err) => {
+                err.internal_context("failed to insert physical disk")
+            }
+            RackInitError::ZpoolInsert(err) => {
+                err.internal_context("failed to insert zpool")
+            }
+            RackInitError::BlueprintInsert(err) => {
+                err.internal_context("failed to insert Blueprint")
+            }
+            RackInitError::BlueprintTargetSet(err) => {
+                err.internal_context("failed to insert set target Blueprint")
+            }
             RackInitError::RackUpdate { err, rack_id } => {
                 public_error_from_diesel(
                     err,
@@ -157,17 +161,16 @@ impl From<RackInitError> for Error {
                     ),
                 )
             }
-            RackInitError::DnsSerialization(err) => Error::internal_error(
-                &format!("failed to serialize initial DNS records: {:#}", err),
-            ),
-            RackInitError::Silo(err) => Error::internal_error(&format!(
-                "failed to create recovery Silo: {:#}",
-                err
-            )),
-            RackInitError::RoleAssignment(err) => Error::internal_error(
-                &format!("failed to assign role to initial user: {:#}", err),
-            ),
-            RackInitError::Retryable(err) => Error::internal_error(&format!(
+            RackInitError::DnsSerialization(err) => {
+                err.internal_context("failed to serialize initial DNS records")
+            }
+            RackInitError::Silo(err) => {
+                err.internal_context("failed to create recovery Silo")
+            }
+            RackInitError::RoleAssignment(err) => {
+                err.internal_context("failed to assign role to initial user")
+            }
+            RackInitError::Retryable(err) => Error::unavail(&format!(
                 "failed operation due to database contention: {:#}",
                 err
             )),


### PR DESCRIPTION
On main, if we attempt RSS with an expired cert, Nexus will reject the rack handoff request, but Nexus sends back a generic `500 Internal Server Error`. This gets logged in the sled-agent / RSS logs, which is the first place we typically look for "why is RSS stuck not handing off". It's certainly possible to get from the 500 error in the sled-agent logs to the _real_ problem in the Nexus logs; e.g.,

```
15:05:37.096Z INFO 3da7004d-c7a9-4864-8a50-c5928796d3b7 (dropshot_internal): request completed
    error_message_external = Internal Server Error
    error_message_internal = failed to create recovery Silo: Invalid Value: certificate, Certificate exists, but is expired
    file = /home/build/.cargo/registry/src/index.crates.io-6f17d22bba15001f/dropshot-0.15.1/src/server.rs:855
    latency_us = 1586827
    local_addr = [fd00:1122:3344:103::4]:12221
    method = PUT
    remote_addr = [fd00:1122:3344:103::1]:43545
    req_id = d661f15a-f8c2-46c1-996d-454bb1311d6e
    response_code = 500
    uri = /racks/c3f565f0-7536-45fc-a77f-d3514ef5b9b2/initialization-complete
```

but this is annoying (you have to find the right Nexus, find the request, etc.). With this change, Nexus now honors the underlying error code (e.g., cert expired is a 400) when unpacking a `RackInitError`, so we get much more useful logs on the sled-agent / RSS side:

```
23:09:50.416Z INFO SledAgent (RSS): Failed to handoff to nexus: Error Response: status: 400 Bad Request; headers: {"content-type": "application/json", "x-request-id": "6b11b651-c9d3-4c24-baf8-612c4f535534", "content-length": "180", "date": "Wed, 26 Feb 2025 23:09:49 GMT"}; value: Error { error_code: Some("InvalidValue"), message: "unsupported value for \"certificate\": Certificate exists, but is expired", request_id: "6b11b651-c9d3-4c24-baf8-612c4f535534" }
    file = sled-agent/src/rack_setup/service.rs:1070
```

Fixes #7457, I think? It's not pretty but the info is there.