### PR TITLE
Improvements to time synchronisation in the face of connectivity problems.

### DIFF
--- a/sled-agent/src/services.rs
+++ b/sled-agent/src/services.rs
@@ -1556,12 +1556,12 @@ impl ServiceManager {
         // not creating a new property group, nor are we configuring a property
         // group on the instance.
         //
-        // Callers may decide to provide specific addresses to set as
+        // Callers may decide to provide specific addresses to set as additional
         // nameservers; e.g., boundary NTP zones need to specify upstream DNS
         // servers to resolve customer-provided NTP server names.
-        let nameservers = ip_addrs.unwrap_or_else(|| {
-            get_internal_dns_server_addresses(info.underlay_address)
-        });
+        let mut nameservers =
+            get_internal_dns_server_addresses(info.underlay_address);
+        nameservers.extend(ip_addrs.into_iter().flatten());
 
         let mut dns_config_builder = PropertyGroupBuilder::new("install_props");
         for ns_addr in &nameservers {


### PR DESCRIPTION
For consistency of time within the rack we must guard against there ever
being two authoritative sources of time. We currently have two (admittedly
edge) cases where this can occur.

1) When, some time after everything is synchronised, one or both of the
   boundary NTP servers loses upstream connectivity, but continues to
   advertise at the same stratum as its clock begins to drift.
2) If both boundary NTP servers lose connectivity and fall back to their
   local clocks, advertising them with stratum 10, they will both be
   authoritative but with potentially different times.

This change addresses both of these by updating the NTP server configuration
in a number of ways.

1) Adding each boundary server as a source to the other;
2) Configuring the boundary "local" sources with the "orphan" flag that
   causes selection of just one as authoritative if both are in that mode;
3) Configuring RSS sources with a new "failfast" flag that causes them to
   be discounted quickly (marked as "unselectable") once they are considered
   unreachable, instead of waiting for their "distance" to degrade over time;
4) Adjusting the root dispersion decay rate from chrony's default of 1µs/s
   (versus RFC recommended default of 15µs/s) up to 60µs/s to achieve faster
   source reselection.

This is partially in response to the problems encountered in https://github.com/oxidecomputer/omicron/issues/7534