### PR TITLE
Claim connections to ClickHouse less frequently

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -8037,6 +8037,7 @@ dependencies = [
  "slog",
  "slog-async",
  "slog-dtrace",
+ "slog-error-chain",
  "slog-term",
  "sqlformat",
  "sqlparser",

--- a/nexus/src/app/mod.rs
+++ b/nexus/src/app/mod.rs
@@ -430,7 +430,7 @@ impl Nexus {
             None => {
                 let native_resolver =
                     qorb_resolver.for_service(ServiceName::ClickhouseNative);
-                oximeter_db::Client::new_with_pool(native_resolver, &log)
+                oximeter_db::Client::new_with_resolver(native_resolver, &log)
             }
             Some(address) => oximeter_db::Client::new(*address, &log),
         };

--- a/oximeter/collector/src/agent.rs
+++ b/oximeter/collector/src/agent.rs
@@ -101,7 +101,7 @@ impl OximeterAgent {
         // - The DB doesn't exist at all. This reports a version number of 0. We
         // need to create the DB here, at the latest version. This is used in
         // fresh installations and tests.
-        let client = Client::new_with_pool(native_resolver, &log);
+        let client = Client::new_with_resolver(native_resolver, &log);
         match client.check_db_is_at_expected_version().await {
             Ok(_) => {}
             Err(oximeter_db::Error::DatabaseVersionMismatch {

--- a/oximeter/db/Cargo.toml
+++ b/oximeter/db/Cargo.toml
@@ -41,6 +41,7 @@ serde_json.workspace = true
 slog.workspace = true
 slog-async.workspace = true
 slog-dtrace.workspace = true
+slog-error-chain.workspace = true
 slog-term.workspace = true
 strum.workspace = true
 termtree.workspace = true

--- a/oximeter/db/src/client/dbwrite.rs
+++ b/oximeter/db/src/client/dbwrite.rs
@@ -4,7 +4,7 @@
 
 //! Implementation of client methods that write to the ClickHouse database.
 
-// Copyright 2024 Oxide Computer Company
+// Copyright 2025 Oxide Computer Company
 
 use crate::client::Client;
 use crate::model;
@@ -18,6 +18,8 @@ use slog::debug;
 use std::collections::btree_map::Entry;
 use std::collections::BTreeMap;
 use std::collections::BTreeSet;
+
+use super::Handle;
 
 #[derive(Debug)]
 pub(super) struct UnrolledSampleRows {
@@ -55,11 +57,12 @@ pub trait DbWrite {
 impl DbWrite for Client {
     /// Insert the given samples into the database.
     async fn insert_samples(&self, samples: &[Sample]) -> Result<(), Error> {
+        let mut handle = self.claim_connection().await?;
         debug!(self.log, "unrolling {} total samples", samples.len());
         let UnrolledSampleRows { new_schema, blocks } =
-            self.unroll_samples(samples).await;
-        self.save_new_schema_or_remove(new_schema).await?;
-        self.insert_unrolled_samples(blocks).await
+            self.unroll_samples(&mut handle, samples).await;
+        self.save_new_schema_or_remove(&mut handle, new_schema).await?;
+        self.insert_unrolled_samples(&mut handle, blocks).await
     }
 
     /// Initialize the replicated telemetry database, creating tables as needed.
@@ -68,46 +71,62 @@ impl DbWrite for Client {
     /// These files are intentionally disjoint so that we don't have to
     /// duplicate any setup.
     async fn init_replicated_db(&self) -> Result<(), Error> {
+        let mut handle = self.claim_connection().await?;
         debug!(self.log, "initializing ClickHouse database");
-        self.run_many_sql_statements(include_str!(concat!(
-            env!("CARGO_MANIFEST_DIR"),
-            "/schema/replicated/db-init-1.sql"
-        )))
+        self.run_many_sql_statements(
+            &mut handle,
+            include_str!(concat!(
+                env!("CARGO_MANIFEST_DIR"),
+                "/schema/replicated/db-init-1.sql"
+            )),
+        )
         .await?;
-        self.run_many_sql_statements(include_str!(concat!(
-            env!("CARGO_MANIFEST_DIR"),
-            "/schema/replicated/db-init-2.sql"
-        )))
+        self.run_many_sql_statements(
+            &mut handle,
+            include_str!(concat!(
+                env!("CARGO_MANIFEST_DIR"),
+                "/schema/replicated/db-init-2.sql"
+            )),
+        )
         .await
     }
 
     /// Wipe the ClickHouse database entirely from a replicated set up.
     async fn wipe_replicated_db(&self) -> Result<(), Error> {
         debug!(self.log, "wiping ClickHouse database");
-        self.run_many_sql_statements(include_str!(concat!(
-            env!("CARGO_MANIFEST_DIR"),
-            "/schema/replicated/db-wipe.sql"
-        )))
+        self.run_many_sql_statements(
+            &mut self.claim_connection().await?,
+            include_str!(concat!(
+                env!("CARGO_MANIFEST_DIR"),
+                "/schema/replicated/db-wipe.sql"
+            )),
+        )
         .await
     }
 
     /// Initialize a single node telemetry database, creating tables as needed.
     async fn init_single_node_db(&self) -> Result<(), Error> {
         debug!(self.log, "initializing ClickHouse database");
-        self.run_many_sql_statements(include_str!(concat!(
-            env!("CARGO_MANIFEST_DIR"),
-            "/schema/single-node/db-init.sql"
-        )))
+        self.run_many_sql_statements(
+            &mut self.claim_connection().await?,
+            include_str!(concat!(
+                env!("CARGO_MANIFEST_DIR"),
+                "/schema/single-node/db-init.sql"
+            )),
+        )
         .await
     }
 
     /// Wipe the ClickHouse database entirely from a single node set up.
     async fn wipe_single_node_db(&self) -> Result<(), Error> {
         debug!(self.log, "wiping ClickHouse database");
-        self.run_many_sql_statements(include_str!(concat!(
-            env!("CARGO_MANIFEST_DIR"),
-            "/schema/single-node/db-wipe.sql"
-        )))
+        self.run_many_sql_statements(
+            &mut self.claim_connection().await?,
+            include_str!(concat!(
+                env!("CARGO_MANIFEST_DIR"),
+                "/schema/single-node/db-wipe.sql"
+            )),
+        )
         .await
     }
 }
@@ -134,10 +153,13 @@ impl TestDbWrite for Client {
     /// of tables required for replication/cluster tests.
     async fn init_test_minimal_replicated_db(&self) -> Result<(), Error> {
         debug!(self.log, "initializing ClickHouse database");
-        self.run_many_sql_statements(include_str!(concat!(
-            env!("CARGO_MANIFEST_DIR"),
-            "/schema/replicated/db-init-1.sql"
-        )))
+        self.run_many_sql_statements(
+            &mut self.claim_connection().await?,
+            include_str!(concat!(
+                env!("CARGO_MANIFEST_DIR"),
+                "/schema/replicated/db-init-1.sql"
+            )),
+        )
         .await
     }
 
@@ -160,7 +182,8 @@ impl TestDbWrite for Client {
                 err,
             }
         })?;
-        self.run_many_sql_statements(sql).await
+        self.run_many_sql_statements(&mut self.claim_connection().await?, sql)
+            .await
     }
 }
 
@@ -171,6 +194,7 @@ impl Client {
     // does not already exist there.
     pub(super) async fn unroll_samples(
         &self,
+        handle: &mut Handle,
         samples: &[Sample],
     ) -> UnrolledSampleRows {
         let mut seen_timeseries = BTreeSet::new();
@@ -178,7 +202,7 @@ impl Client {
         let mut new_schema = BTreeMap::new();
 
         for sample in samples.iter() {
-            match self.verify_or_cache_sample_schema(sample).await {
+            match self.verify_or_cache_sample_schema(handle, sample).await {
                 Err(_) => {
                     // Skip the sample, but otherwise do nothing. The error is logged in the above
                     // call.
@@ -239,6 +263,7 @@ impl Client {
     // Insert unrolled sample rows into the corresponding tables.
     async fn insert_unrolled_samples(
         &self,
+        handle: &mut Handle,
         blocks: BTreeMap<String, Block>,
     ) -> Result<(), Error> {
         for (table_name, block) in blocks {
@@ -251,7 +276,7 @@ impl Client {
             // TODO-robustness We've verified the schema, so this is likely a transient failure.
             // But we may want to check the actual error condition, and, if possible, continue
             // inserting any remaining data.
-            self.insert_native(&query, block).await?;
+            self.insert_native(handle, &query, block).await?;
             debug!(
                 self.log,
                 "inserted rows into table";
@@ -285,6 +310,7 @@ impl Client {
     // receive a sample with a new schema, and both would then try to insert that schema.
     pub(super) async fn save_new_schema_or_remove(
         &self,
+        handle: &mut Handle,
         new_schema: Vec<TimeseriesSchema>,
     ) -> Result<(), Error> {
         if !new_schema.is_empty() {
@@ -305,7 +331,7 @@ impl Client {
             // internal cache. Since we check the internal cache first for
             // schema, if we fail here but _don't_ remove the schema, we'll
             // never end up inserting the schema, but we will insert samples.
-            if let Err(e) = self.insert_native(&body, block).await {
+            if let Err(e) = self.insert_native(handle, &body, block).await {
                 debug!(
                     self.log,
                     "failed to insert new schema, removing from cache";
@@ -332,10 +358,11 @@ impl Client {
     // statements.
     async fn run_many_sql_statements(
         &self,
+        handle: &mut Handle,
         sql: impl AsRef<str>,
     ) -> Result<(), Error> {
         for stmt in sql.as_ref().split(';').filter(|s| !s.trim().is_empty()) {
-            self.execute_native(stmt).await?;
+            self.execute_native(handle, stmt).await?;
         }
         Ok(())
     }

--- a/oximeter/db/src/client/mod.rs
+++ b/oximeter/db/src/client/mod.rs
@@ -25,6 +25,7 @@ use crate::native::block::ValueArray;
 use crate::native::QueryResult;
 use crate::query;
 use crate::Error;
+use crate::Handle;
 use crate::Metric;
 use crate::Target;
 use crate::Timeseries;
@@ -37,6 +38,7 @@ use dropshot::PaginationOrder;
 use dropshot::ResultsPage;
 use dropshot::WhichPage;
 use omicron_common::backoff;
+use omicron_common::backoff::Backoff as _;
 use oximeter::schema::TimeseriesKey;
 use oximeter::types::Sample;
 use oximeter::Measurement;
@@ -53,6 +55,7 @@ use slog::info;
 use slog::trace;
 use slog::warn;
 use slog::Logger;
+use slog_error_chain::InlineErrorChain;
 use std::collections::btree_map::Entry;
 use std::collections::BTreeMap;
 use std::collections::BTreeSet;
@@ -196,7 +199,7 @@ impl Client {
 
     /// Ping the ClickHouse server to verify connectivity.
     pub async fn ping(&self) -> Result<(), Error> {
-        let mut handle = self.pool.claim().await?;
+        let mut handle = self.claim_connection().await?;
         trace!(self.log, "acquired native pool claim");
         handle.ping().await.map_err(Error::Native)?;
         trace!(self.log, "successful ping of ClickHouse server");
@@ -248,11 +251,16 @@ impl Client {
         }
 
         let query = query_builder.build();
+        let mut handle = self.claim_connection().await?;
         let info = match query.field_query() {
             Some(field_query) => {
-                self.select_matching_timeseries_info(&field_query, &schema)
-                    .await?
-                    .1
+                self.select_matching_timeseries_info(
+                    &mut handle,
+                    &field_query,
+                    &schema,
+                )
+                .await?
+                .1
             }
             None => BTreeMap::new(),
         };
@@ -268,7 +276,13 @@ impl Client {
             // a way that is arbitrary with respect to the query.
             Err(Error::InvalidLimitQuery)
         } else {
-            self.select_timeseries_with_keys(&query, &info, &schema).await
+            self.select_timeseries_with_keys(
+                &mut handle,
+                &query,
+                &info,
+                &schema,
+            )
+            .await
         }
     }
 
@@ -303,18 +317,29 @@ impl Client {
         }
 
         let query = query_builder.build();
+        let mut handle = self.claim_connection().await?;
         let info = match query.field_query() {
             Some(field_query) => {
-                self.select_matching_timeseries_info(&field_query, &schema)
-                    .await?
-                    .1
+                self.select_matching_timeseries_info(
+                    &mut handle,
+                    &field_query,
+                    &schema,
+                )
+                .await?
+                .1
             }
             None => BTreeMap::new(),
         };
         let results = if info.is_empty() {
             vec![]
         } else {
-            self.select_timeseries_with_keys(&query, &info, &schema).await?
+            self.select_timeseries_with_keys(
+                &mut handle,
+                &query,
+                &info,
+                &schema,
+            )
+            .await?
         };
         Ok(ResultsPage::new(results, &params, |_, _| {
             NonZeroU32::try_from(limit.get() + offset).unwrap()
@@ -336,7 +361,8 @@ impl Client {
         if let Some(s) = schema.get(name) {
             return Ok(Some(s.clone()));
         }
-        self.get_schema_locked(&mut schema).await?;
+        let mut handle = self.claim_connection().await?;
+        self.get_schema_locked(&mut handle, &mut schema).await?;
         Ok(schema.get(name).map(Clone::clone))
     }
 
@@ -375,7 +401,9 @@ impl Client {
                 )
             }
         };
-        let result = self.execute_with_block(&sql).await?;
+        let result = self
+            .execute_with_block(&mut self.claim_connection().await?, &sql)
+            .await?;
         let Some(block) = result.data.as_ref() else {
             error!(
                 self.log,
@@ -436,7 +464,7 @@ impl Client {
             }
             match name.parse() {
                 Ok(ver) => {
-                    debug!(log, "valid version dir"; "ver" => ver);
+                    debug!(log, "valid version dir"; "ver" => %ver);
                     assert!(versions.insert(ver), "Versions should be unique");
                 }
                 Err(e) => warn!(
@@ -460,8 +488,25 @@ impl Client {
         desired_version: u64,
         schema_dir: impl AsRef<Path>,
     ) -> Result<(), Error> {
+        let mut handle = self.claim_connection().await?;
+        self.ensure_schema_with_handle(
+            &mut handle,
+            replicated,
+            desired_version,
+            schema_dir,
+        )
+        .await
+    }
+
+    async fn ensure_schema_with_handle(
+        &self,
+        handle: &mut Handle,
+        replicated: bool,
+        desired_version: u64,
+        schema_dir: impl AsRef<Path>,
+    ) -> Result<(), Error> {
         let schema_dir = schema_dir.as_ref();
-        let latest = self.read_latest_version().await?;
+        let latest = self.read_latest_version_with_handle(handle).await?;
         if latest == desired_version {
             debug!(
                 self.log,
@@ -506,7 +551,9 @@ impl Client {
         let mut current = latest;
         for version in versions_to_apply {
             if let Err(e) = self
-                .apply_one_schema_upgrade(replicated, *version, schema_dir)
+                .apply_one_schema_upgrade(
+                    handle, replicated, *version, schema_dir,
+                )
                 .await
             {
                 error!(
@@ -521,7 +568,7 @@ impl Client {
                 return Err(e);
             }
             current = *version;
-            self.insert_version(current).await?;
+            self.insert_version(handle, current).await?;
         }
         Ok(())
     }
@@ -548,6 +595,7 @@ impl Client {
 
     async fn apply_one_schema_upgrade(
         &self,
+        handle: &mut Handle,
         replicated: bool,
         next_version: u64,
         schema_dir: impl AsRef<Path>,
@@ -576,7 +624,7 @@ impl Client {
                 "path" => path.display(),
                 "filename" => &name,
             );
-            match self.execute_native(&sql).await {
+            match self.execute_native(handle, &sql).await {
                 Ok(_) => debug!(
                     self.log,
                     "successfully applied schema upgrade file";
@@ -610,7 +658,8 @@ impl Client {
                 "schema upgrade includes list of timeseries to be deleted";
                 "n_timeseries" => to_delete.len(),
             );
-            self.expunge_timeseries_by_name(replicated, &to_delete).await?;
+            self.expunge_timeseries_by_name(handle, replicated, &to_delete)
+                .await?;
         }
         Ok(())
     }
@@ -745,7 +794,8 @@ impl Client {
         info!(self.log, "reading db version");
 
         // Read the version from the DB
-        let version = self.read_latest_version().await?;
+        let mut handle = self.claim_connection().await?;
+        let version = self.read_latest_version_with_handle(&mut handle).await?;
         info!(self.log, "read oximeter database version"; "version" => version);
 
         // Decide how to conform the on-disk version with this version of
@@ -773,18 +823,28 @@ impl Client {
         }
 
         info!(self.log, "inserting current version"; "version" => expected_version);
-        self.insert_version(expected_version).await?;
+        self.insert_version(&mut handle, expected_version).await?;
         Ok(())
     }
 
     /// Read the latest version applied in the database.
     pub async fn read_latest_version(&self) -> Result<u64, Error> {
+        let mut handle = self.claim_connection().await?;
+        self.read_latest_version_with_handle(&mut handle).await
+    }
+
+    /// Read the latest version applied in the database, with an existing
+    /// connection.
+    async fn read_latest_version_with_handle(
+        &self,
+        handle: &mut Handle,
+    ) -> Result<u64, Error> {
         const ALIAS: &str = "max_version";
         const QUERY: &str = const_format::formatcp!(
             "SELECT MAX(value) AS {ALIAS} FROM {db_name}.version;",
             db_name = crate::DATABASE_NAME,
         );
-        match self.execute_with_block(QUERY).await {
+        match self.execute_with_block(handle, QUERY).await {
             Ok(result) => {
                 let Some(data) = &result.data else {
                     error!(
@@ -875,29 +935,35 @@ impl Client {
         }
     }
 
-    async fn insert_version(&self, version: u64) -> Result<(), Error> {
+    async fn insert_version(
+        &self,
+        handle: &mut Handle,
+        version: u64,
+    ) -> Result<(), Error> {
         let sql = format!(
             "INSERT INTO {db_name}.version (*) VALUES ({version}, now());",
             db_name = crate::DATABASE_NAME,
         );
-        self.execute_native(&sql).await
+        self.execute_native(handle, &sql).await
     }
 
     /// Verifies if instance is part of oximeter_cluster
     pub async fn is_oximeter_cluster(&self) -> Result<bool, Error> {
         const QUERY: &str =
             const_format::formatcp!("SHOW CLUSTER {}", crate::CLUSTER_NAME);
-        self.execute_with_block(QUERY).await.and_then(|result| {
-            result
-                .data
-                .ok_or_else(|| {
-                    Error::Database(String::from(
-                        "Query for `oximeter` cluster unexpectedly \
+        self.execute_with_block(&mut self.claim_connection().await?, QUERY)
+            .await
+            .and_then(|result| {
+                result
+                    .data
+                    .ok_or_else(|| {
+                        Error::Database(String::from(
+                            "Query for `oximeter` cluster unexpectedly \
                     returned an empty data block",
-                    ))
-                })
-                .map(|block| block.n_rows() > 0)
-        })
+                        ))
+                    })
+                    .map(|block| block.n_rows() > 0)
+            })
     }
 
     // Verifies that the schema for a sample matches the schema in the database,
@@ -912,6 +978,7 @@ impl Client {
     // time.
     async fn verify_or_cache_sample_schema(
         &self,
+        handle: &mut Handle,
         sample: &Sample,
     ) -> Result<Option<TimeseriesSchema>, Error> {
         let sample_schema = TimeseriesSchema::from(sample);
@@ -925,7 +992,7 @@ impl Client {
         // read of the DB), then we check that the derived schema matches. If
         // not, we can insert it in the cache and the DB.
         if !schema.contains_key(&name) {
-            self.get_schema_locked(&mut schema).await?;
+            self.get_schema_locked(handle, &mut schema).await?;
         }
         match schema.entry(name) {
             Entry::Occupied(entry) => {
@@ -957,11 +1024,12 @@ impl Client {
     // query.
     async fn select_matching_timeseries_info(
         &self,
+        handle: &mut Handle,
         field_query: &str,
         schema: &TimeseriesSchema,
     ) -> Result<(QuerySummary, BTreeMap<TimeseriesKey, (Target, Metric)>), Error>
     {
-        let result = self.execute_with_block(field_query).await?;
+        let result = self.execute_with_block(handle, field_query).await?;
         let summary = result.query_summary();
         let Some(block) = &result.data else {
             error!(
@@ -987,6 +1055,7 @@ impl Client {
     // measurements from timeseries with those keys.
     async fn select_timeseries_with_keys(
         &self,
+        handle: &mut Handle,
         query: &query::SelectQuery,
         info: &BTreeMap<TimeseriesKey, (Target, Metric)>,
         schema: &TimeseriesSchema,
@@ -995,7 +1064,7 @@ impl Client {
         let keys = info.keys().copied().collect::<Vec<_>>();
         let measurement_query = query.measurement_query(&keys);
         let Some(block) =
-            self.execute_with_block(&measurement_query).await?.data
+            self.execute_with_block(handle, &measurement_query).await?.data
         else {
             error!(
                 self.log,
@@ -1042,6 +1111,7 @@ impl Client {
     // Insert data using the native TCP interface.
     async fn insert_native(
         &self,
+        handle: &mut Handle,
         sql: &str,
         block: Block,
     ) -> Result<QueryResult, Error> {
@@ -1052,7 +1122,6 @@ impl Client {
             "n_rows" => block.n_rows(),
             "n_columns" => block.n_columns(),
         );
-        let mut handle = self.pool.claim().await?;
         let id = usdt::UniqueId::new();
         probes::sql__query__start!(|| (&id, sql));
         let now = tokio::time::Instant::now();
@@ -1072,8 +1141,12 @@ impl Client {
     }
 
     // Execute a generic SQL statement, using the native TCP interface.
-    async fn execute_native(&self, sql: &str) -> Result<(), Error> {
-        self.execute_with_block(sql).await.map(|_| ())
+    async fn execute_native(
+        &self,
+        handle: &mut Handle,
+        sql: &str,
+    ) -> Result<(), Error> {
+        self.execute_with_block(handle, sql).await.map(|_| ())
     }
 
     // Execute a generic SQL statement, returning the query result as a data
@@ -1082,6 +1155,7 @@ impl Client {
     // TODO-robustness This currently does no validation of the statement.
     async fn execute_with_block(
         &self,
+        handle: &mut Handle,
         sql: &str,
     ) -> Result<QueryResult, Error> {
         trace!(
@@ -1090,7 +1164,6 @@ impl Client {
             "sql" => sql,
         );
 
-        let mut handle = self.pool.claim().await?;
         let id = usdt::UniqueId::new();
         probes::sql__query__start!(|| (&id, sql));
         let now = tokio::time::Instant::now();
@@ -1111,6 +1184,7 @@ impl Client {
     // Can only be called after acquiring the lock around `self.schema`.
     async fn get_schema_locked(
         &self,
+        handle: &mut Handle,
         schema: &mut BTreeMap<TimeseriesName, TimeseriesSchema>,
     ) -> Result<(), Error> {
         debug!(self.log, "retrieving timeseries schema from database");
@@ -1139,7 +1213,7 @@ impl Client {
                 )
             }
         };
-        let body = self.execute_with_block(&sql).await?;
+        let body = self.execute_with_block(handle, &sql).await?;
         let Some(data) = body.data.as_ref() else {
             trace!(self.log, "no new timeseries schema in database");
             return Ok(());
@@ -1166,49 +1240,71 @@ impl Client {
     /// will continue to retry the operation until it succeeds.
     async fn expunge_timeseries_by_name(
         &self,
+        handle: &mut Handle,
         replicated: bool,
         to_delete: &[TimeseriesName],
     ) -> Result<(), Error> {
-        let op = || async {
-            self.expunge_timeseries_by_name_once(replicated, to_delete)
+        // NOTE: We're effectively inlining `backoff::retry_notify_ext()` here,
+        // which is intentional. We have a `&mut Handle`, that we want to pass
+        // to our operation. But that needs to be `impl FnMut` based on the type
+        // signature of `retry_notify_ext()`, which means the closure here can't
+        // capture that exclusive reference.
+        //
+        // That type signature is overly-constraining in this case.
+        let mut backoff = backoff::retry_policy_internal_service();
+        let mut call_count = 0;
+        loop {
+            let Err(e) = self
+                .expunge_timeseries_by_name_once(handle, replicated, to_delete)
                 .await
-                .map_err(|err| match err {
-                    Error::DatabaseUnavailable(_) | Error::Connection(_) => {
-                        backoff::BackoffError::transient(err)
-                    }
-                    _ => backoff::BackoffError::permanent(err),
-                })
-        };
-        let notify = |error, count, delay| {
-            warn!(
-                self.log,
-                "failed to delete some timeseries";
-                "error" => ?error,
-                "call_count" => count,
-                "retry_after" => ?delay,
+            else {
+                return Ok(());
+            };
+            call_count += 1;
+
+            // We always have a next-backoff, so let's just check if the error
+            // is permanent.
+            let delay = backoff.next_backoff().expect(
+                "internal service retry policy should have no max time",
             );
-        };
-        backoff::retry_notify_ext(
-            backoff::retry_policy_internal_service(),
-            op,
-            notify,
-        )
-        .await
+            match e {
+                Error::DatabaseUnavailable(_) | Error::Connection(_) => {
+                    warn!(
+                        self.log,
+                        "failed to delete some timeseries";
+                        "error" => InlineErrorChain::new(&e),
+                        "call_count" => call_count,
+                        "retry_after" => ?delay,
+                    );
+                    tokio::time::sleep(delay).await;
+                }
+                _ => {
+                    error!(
+                        self.log,
+                        "permanent error deleting some timeseries";
+                        "error" => InlineErrorChain::new(&e),
+                        "call_count" => %call_count,
+                    );
+                    return Err(e);
+                }
+            }
+        }
     }
 
     /// Attempt to delete the named timeseries once.
     async fn expunge_timeseries_by_name_once(
         &self,
+        handle: &mut Handle,
         replicated: bool,
         to_delete: &[TimeseriesName],
     ) -> Result<(), Error> {
         // The version table should not have any matching data, but let's avoid
         // it entirely anyway.
         let tables = self
-            .list_oximeter_database_tables(ListDetails {
-                include_version: false,
-                replicated,
-            })
+            .list_oximeter_database_tables(
+                handle,
+                ListDetails { include_version: false, replicated },
+            )
             .await?;
 
         // This size is arbitrary, and just something to avoid enormous requests
@@ -1248,7 +1344,7 @@ impl Client {
                     "table_name" => table,
                     "n_timeseries" => chunk.len(),
                 );
-                self.execute_native(&sql).await?;
+                self.execute_native(handle, &sql).await?;
             }
         }
         Ok(())
@@ -1275,16 +1371,17 @@ impl Client {
 
     /// Useful for testing and introspection
     pub async fn list_replicated_tables(&self) -> Result<Vec<String>, Error> {
-        self.list_oximeter_database_tables(ListDetails {
-            include_version: true,
-            replicated: true,
-        })
+        self.list_oximeter_database_tables(
+            &mut self.claim_connection().await?,
+            ListDetails { include_version: true, replicated: true },
+        )
         .await
     }
 
     /// List tables in the oximeter database.
     async fn list_oximeter_database_tables(
         &self,
+        handle: &mut Handle,
         ListDetails { include_version, replicated }: ListDetails,
     ) -> Result<Vec<String>, Error> {
         let mut sql = format!(
@@ -1301,7 +1398,7 @@ impl Client {
             sql.push_str(" AND engine = 'ReplicatedMergeTree'");
         }
         let col = self
-            .execute_with_block(&sql)
+            .execute_with_block(handle, &sql)
             .await
             .and_then(|result| {
                 result.data.ok_or_else(|| {
@@ -1328,6 +1425,11 @@ impl Client {
             )));
         };
         Ok(names)
+    }
+
+    /// Claim a connection to the database from the qorb connection pool.
+    async fn claim_connection(&self) -> Result<Handle, Error> {
+        self.pool.claim().await.map_err(Error::from)
     }
 }
 
@@ -1816,7 +1918,9 @@ mod tests {
             datum: 1,
         };
         let sample = Sample::new(&bad_name, &metric).unwrap();
-        let result = client.verify_or_cache_sample_schema(&sample).await;
+        let mut handle = client.claim_connection().await.unwrap();
+        let result =
+            client.verify_or_cache_sample_schema(&mut handle, &sample).await;
         assert!(matches!(result, Err(Error::SchemaMismatch { .. })));
     }
 
@@ -1840,8 +1944,11 @@ mod tests {
 
         // Verify that this sample is considered new, i.e., we return rows to update the timeseries
         // schema table.
-        let result =
-            client.verify_or_cache_sample_schema(&sample).await.unwrap();
+        let mut handle = client.claim_connection().await.unwrap();
+        let result = client
+            .verify_or_cache_sample_schema(&mut handle, &sample)
+            .await
+            .unwrap();
         assert!(
                 matches!(result, Some(_)),
                 "When verifying a new sample, the rows to be inserted should be returned"
@@ -1874,8 +1981,11 @@ mod tests {
 
         // This should no longer return a new row to be inserted for the schema of this sample, as
         // any schema have been included above.
-        let result =
-            client.verify_or_cache_sample_schema(&sample).await.unwrap();
+        let mut handle = client.claim_connection().await.unwrap();
+        let result = client
+            .verify_or_cache_sample_schema(&mut handle, &sample)
+            .await
+            .unwrap();
         assert!(
             matches!(result, None),
             "After inserting new schema, it should no longer be considered new"
@@ -1886,7 +1996,7 @@ mod tests {
             "SELECT * FROM oximeter.timeseries_schema FORMAT JSONEachRow;";
         let schema = TimeseriesSchema::from_block(
             client
-                .execute_with_block(sql)
+                .execute_with_block(&mut handle, sql)
                 .await
                 .expect("Failed to select schema")
                 .data
@@ -2016,10 +2126,10 @@ mod tests {
             expected_count: usize,
         ) {
             let ValueArray::UInt64(counts) = client
-                .execute_with_block(&format!(
-                    "SELECT COUNT() FROM oximeter.{};",
-                    table
-                ))
+                .execute_with_block(
+                    &mut client.claim_connection().await.unwrap(),
+                    &format!("SELECT COUNT() FROM oximeter.{};", table),
+                )
                 .await
                 .expect("Failed to select count of rows")
                 .data
@@ -2690,8 +2800,9 @@ mod tests {
 
         let original_schema = client.schema.lock().await.clone();
         let mut schema = client.schema.lock().await;
+        let mut handle = client.claim_connection().await.unwrap();
         client
-            .get_schema_locked(&mut schema)
+            .get_schema_locked(&mut handle, &mut schema)
             .await
             .expect("Failed to get timeseries schema");
         assert_eq!(&original_schema, &*schema, "Schema shouldn't change");
@@ -2925,8 +3036,9 @@ mod tests {
         let field_table = field_table_name(field_value.field_type());
         let insert_sql =
             format!("INSERT INTO oximeter.{field_table} FORMAT NATIVE");
+        let mut handle = client.claim_connection().await.unwrap();
         client
-            .insert_native(&insert_sql, inserted_block.clone())
+            .insert_native(&mut handle, &insert_sql, inserted_block.clone())
             .await
             .expect("Failed to insert field row");
 
@@ -2934,7 +3046,7 @@ mod tests {
         let select_sql =
             format!("SELECT * FROM oximeter.{field_table} LIMIT 1",);
         let block = client
-            .execute_with_block(&select_sql)
+            .execute_with_block(&mut handle, &select_sql)
             .await
             .expect("Failed to select field row")
             .data
@@ -3266,8 +3378,9 @@ mod tests {
         );
         println!("Expected measurement: {:#?}", measurement);
         println!("Inserted block: {:#?}", inserted_block);
+        let mut handle = client.claim_connection().await.unwrap();
         client
-            .insert_native(&insert_sql, inserted_block)
+            .insert_native(&mut handle, &insert_sql, inserted_block)
             .await
             .expect("Failed to insert measurement block");
 
@@ -3279,7 +3392,7 @@ mod tests {
             measurement.timestamp().format(crate::DATABASE_TIMESTAMP_FORMAT),
         );
         let selected_block = client
-            .execute_with_block(&select_sql)
+            .execute_with_block(&mut handle, &select_sql)
             .await
             .expect("Failed to select measurement row")
             .data
@@ -3303,14 +3416,17 @@ mod tests {
         maybe_filter: Option<&str>,
     ) -> usize {
         client
-            .execute_with_block(&format!(
-                "SELECT COUNT() AS count \
+            .execute_with_block(
+                &mut client.claim_connection().await.unwrap(),
+                &format!(
+                    "SELECT COUNT() AS count \
             FROM oximeter.timeseries_schema \
             {}",
-                maybe_filter
-                    .map(|f| format!("WHERE {f}"))
-                    .unwrap_or_else(String::new)
-            ))
+                    maybe_filter
+                        .map(|f| format!("WHERE {f}"))
+                        .unwrap_or_else(String::new)
+                ),
+            )
             .await
             .expect("Failed to SELECT from database")
             .data
@@ -3443,7 +3559,10 @@ mod tests {
 
         // Bump the version of the database to a "too new" version
         client
-            .insert_version(model::OXIMETER_VERSION + 1)
+            .insert_version(
+                &mut client.claim_connection().await.unwrap(),
+                model::OXIMETER_VERSION + 1,
+            )
             .await
             .expect("Failed to insert very new DB version");
 
@@ -3589,14 +3708,16 @@ mod tests {
         //
         // First, insert the sample into the local cache. This method also
         // checks the DB, since this schema doesn't exist in the cache.
+        let mut handle = client.claim_connection().await.unwrap();
         let UnrolledSampleRows { new_schema, .. } =
-            client.unroll_samples(&samples).await;
+            client.unroll_samples(&mut handle, &samples).await;
         assert_eq!(client.schema.lock().await.len(), 1);
 
         // Next, we'll kill the database, and then try to insert the schema.
         // That will fail, since the DB is now inaccessible.
         wipe_db(&db, &client).await;
-        let res = client.save_new_schema_or_remove(new_schema).await;
+        let res =
+            client.save_new_schema_or_remove(&mut handle, new_schema).await;
         assert!(res.is_err(), "Should have failed since the DB is gone");
         assert!(
             client.schema.lock().await.is_empty(),
@@ -3794,20 +3915,27 @@ mod tests {
         // We'll test moving from version 1, which just creates a database and
         // table, to version 2, which adds two columns to that table in
         // different SQL files.
+        let mut handle = client.claim_connection().await.unwrap();
         client
-            .execute_native(&format!("CREATE DATABASE {test_name};"))
+            .execute_native(
+                &mut handle,
+                &format!("CREATE DATABASE {test_name};"),
+            )
             .await
             .unwrap();
         client
-            .execute_native(&format!(
-                "\
+            .execute_native(
+                &mut handle,
+                &format!(
+                    "\
             CREATE TABLE {test_name}.tbl (\
                 `col0` UInt8 \
             )\
             ENGINE = MergeTree()
             ORDER BY `col0`;\
         "
-            ))
+                ),
+            )
             .await
             .unwrap();
 
@@ -3835,6 +3963,7 @@ mod tests {
         // Apply the upgrade itself.
         client
             .apply_one_schema_upgrade(
+                &mut handle,
                 replicated,
                 NEXT_VERSION,
                 schema_dir.path(),
@@ -3844,12 +3973,15 @@ mod tests {
 
         // Check that it actually worked!
         let block = client
-            .execute_with_block(&format!(
-                "\
+            .execute_with_block(
+                &mut handle,
+                &format!(
+                    "\
             SELECT name, type FROM system.columns \
             WHERE database = '{test_name}' AND table = 'tbl' \
             ORDER BY name"
-            ))
+                ),
+            )
             .await
             .expect("Failed to run query")
             .data
@@ -4011,20 +4143,27 @@ mod tests {
         // the `test_apply_one_schema_upgrade` test, but we split the two
         // modifications over two versions, rather than as multiple schema
         // upgrades in one version bump.
+        let mut handle = client.claim_connection().await.unwrap();
         client
-            .execute_native(&format!("CREATE DATABASE {test_name};"))
+            .execute_native(
+                &mut handle,
+                &format!("CREATE DATABASE {test_name};"),
+            )
             .await
             .unwrap();
         client
-            .execute_native(&format!(
-                "\
+            .execute_native(
+                &mut handle,
+                &format!(
+                    "\
             CREATE TABLE {test_name}.tbl (\
                 `col0` UInt8 \
             )\
             ENGINE = MergeTree()
             ORDER BY `col0`;\
         "
-            ))
+                ),
+            )
             .await
             .unwrap();
 
@@ -4059,12 +4198,15 @@ mod tests {
 
         // Check that it actually worked!
         let block = client
-            .execute_with_block(&format!(
-                "\
+            .execute_with_block(
+                &mut handle,
+                &format!(
+                    "\
             SELECT name, type FROM system.columns \
             WHERE database = '{test_name}' AND table = 'tbl' \
             ORDER BY name"
-            ))
+                ),
+            )
             .await
             .expect("Failed to run query")
             .data
@@ -4088,7 +4230,8 @@ mod tests {
             &["UInt8", "UInt16", "String"],
         );
 
-        let latest_version = client.read_latest_version().await.unwrap();
+        let latest_version =
+            client.read_latest_version_with_handle(&mut handle).await.unwrap();
         assert_eq!(
             latest_version,
             *VERSIONS.last().unwrap(),
@@ -4462,6 +4605,7 @@ mod tests {
     ) -> BTreeMap<String, serde_json::Map<String, serde_json::Value>> {
         let block = client
             .execute_with_block(
+                &mut client.claim_connection().await.unwrap(),
                 "SELECT \
                     name, \
                     engine_full, \
@@ -4626,19 +4770,20 @@ mod tests {
         assert_eq!(all_timeseries.len(), 2);
 
         // Count the number of records in all tables, by timeseries.
+        let mut handle = client.claim_connection().await.unwrap();
         let mut records_by_timeseries: BTreeMap<_, Vec<_>> = BTreeMap::new();
         let all_tables = client
-            .list_oximeter_database_tables(ListDetails {
-                include_version: false,
-                replicated,
-            })
+            .list_oximeter_database_tables(
+                &mut handle,
+                ListDetails { include_version: false, replicated },
+            )
             .await
             .unwrap();
         for table in all_tables.iter() {
             let sql =
                 format!("SELECT * FROM {}.{}", crate::DATABASE_NAME, table,);
             for row in client
-                .execute_with_block(&sql)
+                .execute_with_block(&mut handle, &sql)
                 .await
                 .expect("failed to execute query")
                 .data
@@ -4673,7 +4818,12 @@ mod tests {
         // Let's run the "schema upgrade", which should only delete these
         // particular timeseries.
         client
-            .ensure_schema(replicated, NEXT_VERSION, schema_dir.path())
+            .ensure_schema_with_handle(
+                &mut handle,
+                replicated,
+                NEXT_VERSION,
+                schema_dir.path(),
+            )
             .await
             .unwrap();
 
@@ -4690,7 +4840,7 @@ mod tests {
                 &to_delete[0].to_string(),
             );
             let count = client
-                .execute_with_block(&sql)
+                .execute_with_block(&mut handle, &sql)
                 .await
                 .expect("failed to get count of timeseries")
                 .data
@@ -4714,7 +4864,7 @@ mod tests {
             let sql =
                 format!("SELECT * FROM {}.{}", crate::DATABASE_NAME, table,);
             for row in client
-                .execute_with_block(&sql)
+                .execute_with_block(&mut handle, &sql)
                 .await
                 .expect("failed to execute query")
                 .data
@@ -4810,9 +4960,13 @@ mod tests {
             ClickHouseDeployment::new_single_node(&logctx).await.unwrap();
         let client = Client::new(db.native_address().into(), &logctx.log);
         init_db(&db, &client).await;
-        client.execute_native("DROP TABLE oximeter.version").await.unwrap();
+        let mut handle = client.claim_connection().await.unwrap();
+        client
+            .execute_native(&mut handle, "DROP TABLE oximeter.version")
+            .await
+            .unwrap();
         assert_eq!(
-            client.read_latest_version().await.unwrap(),
+            client.read_latest_version_with_handle(&mut handle).await.unwrap(),
             0,
             "Reading the database version when there is no \
             version table should return 0",
@@ -4846,11 +5000,12 @@ mod tests {
         let mut db =
             ClickHouseDeployment::new_single_node(&logctx).await.unwrap();
         let client = Client::new(db.native_address().into(), &logctx.log);
+        let mut handle = client.claim_connection().await.unwrap();
         init_db(&db, &client).await;
-        client.insert_version(1).await.unwrap();
-        client.insert_version(10).await.unwrap();
+        client.insert_version(&mut handle, 1).await.unwrap();
+        client.insert_version(&mut handle, 10).await.unwrap();
         assert_eq!(
-            client.read_latest_version().await.unwrap(),
+            client.read_latest_version_with_handle(&mut handle).await.unwrap(),
             10,
             "Read incorrect database version",
         );

--- a/oximeter/db/src/client/sql.rs
+++ b/oximeter/db/src/client/sql.rs
@@ -48,7 +48,9 @@ impl Client {
             "original_sql" => &original_query,
             "rewritten_sql" => &rewritten,
         );
-        let result = self.execute_with_block(&rewritten).await?;
+        let result = self
+            .execute_with_block(&mut self.claim_connection().await?, &rewritten)
+            .await?;
         let summary = result.query_summary();
         let Some(block) = result.data.as_ref() else {
             return Err(Error::Database(String::from(

--- a/oximeter/db/src/lib.rs
+++ b/oximeter/db/src/lib.rs
@@ -4,7 +4,7 @@
 
 //! Tools for interacting with the control plane telemetry database.
 
-// Copyright 2024 Oxide Computer Company
+// Copyright 2025 Oxide Computer Company
 
 use crate::query::StringFieldSelector;
 use anyhow::Context as _;
@@ -180,6 +180,9 @@ impl From<crate::oxql::Error> for Error {
         Error::Oxql(e)
     }
 }
+
+/// Alias for a connection to the database claimed from a `qorb` pool.
+pub(crate) type Handle = qorb::claim::Handle<crate::native::Connection>;
 
 /// The target identifies the resource or component about which metric data is produced.
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]


### PR DESCRIPTION
- Modify most methods in the `oximeter_db::Client` to require a connection to the database as an argument, rather than taking them deep inside complicated methods. This ensures that we claim a connection once when we expect to start a long sequence of operations, thus amortizing that connection cost over them all. This also lets us fail _much_ more gracefully when the database isn't available -- those complex methods fail at the start, rather than potentially at each and every step of the way.
- Fixes #7674