### PR TITLE
RSS: Don't proceed on partial failure setting up disks

### DIFF
--- a/common/src/disk.rs
+++ b/common/src/disk.rs
@@ -512,7 +512,7 @@ pub enum DiskManagementError {
 }
 
 impl DiskManagementError {
-    fn retryable(&self) -> bool {
+    pub fn retryable(&self) -> bool {
         match self {
             DiskManagementError::KeyManager(_) => true,
             _ => false,


### PR DESCRIPTION
Fixes #7708.

I don't know how to intentionally reproduce this, but running this branch a4x2 I did hit it again; I saw these warnings in the RSS log:

```
18:55:26.442Z WARN SledAgent (RSS): failed to initialize Omicron storage
    error = Transient errors initializing disks: Retryable error initializing disk synthetic-vendor / synthetic-model-U2 / synthetic-serial-g1_3: Failed to access keys necessary to unlock storage. This error may be transient.
    file = sled-agent/src/rack_setup/service.rs:502
    retry_after = 79.359726ms
    sled_address = [fd00:1122:3344:102::1]:12345
18:55:27.047Z WARN SledAgent (RSS): failed to initialize Omicron storage
    error = Transient errors initializing disks: Retryable error initializing disk synthetic-vendor / synthetic-model-U2 / synthetic-serial-g3_2: Failed to access keys necessary to unlock storage. This error may be transient.
    file = sled-agent/src/rack_setup/service.rs:502
    retry_after = 114.775643ms
    sled_address = [fd00:1122:3344:103::1]:12345
18:55:27.076Z WARN SledAgent (RSS): failed to initialize Omicron storage
    error = Transient errors initializing disks: Retryable error initializing disk synthetic-vendor / synthetic-model-U2 / synthetic-serial-g0_2: Failed to access keys necessary to unlock storage. This error may be transient.
    file = sled-agent/src/rack_setup/service.rs:502
    retry_after = 104.205445ms
    sled_address = [fd00:1122:3344:101::1]:12345
```

but then RSS proceeded (presumably due to eventual success) and encountered no further errors.