### PR TITLE
[reconfigurator] Executor: only do cleanup for zones that are `ready_for_cleanup`

### DIFF
--- a/nexus/reconfigurator/execution/src/lib.rs
+++ b/nexus/reconfigurator/execution/src/lib.rs
@@ -216,7 +216,7 @@ pub async fn realize_blueprint_with_overrides(
 // Convert a `Result<(), anyhow::Error>` into a `StepResult` containing either a
 // `StepSuccess` or `StepWarning`.
 //
-// Most steps use this to avoid stoping execution at the errored step, which
+// Most steps use this to avoid stopping execution at the errored step, which
 // would prevent other independent steps after the errored step from executing.
 fn map_err_to_step_warning(
     res: Result<(), anyhow::Error>,

--- a/nexus/reconfigurator/execution/src/lib.rs
+++ b/nexus/reconfigurator/execution/src/lib.rs
@@ -602,12 +602,7 @@ fn register_deploy_clickhouse_single_node_step<'a>(
         .register();
 }
 
-#[derive(Debug)]
-struct ReassignSagaOutput {
-    needs_saga_recovery: bool,
-    error: Option<anyhow::Error>,
-}
-
+// Returns a boolean indicating whether saga recovery is needed.
 fn register_reassign_sagas_step<'a>(
     registrar: &ComponentRegistrar<'_, 'a>,
     opctx: &'a OpContext,

--- a/nexus/reconfigurator/execution/src/lib.rs
+++ b/nexus/reconfigurator/execution/src/lib.rs
@@ -266,7 +266,7 @@ fn register_support_bundle_failure_step<'a>(
 ) {
     registrar
         .new_step(
-            ExecutionStepId::Ensure,
+            ExecutionStepId::Cleanup,
             "Mark support bundles as failed if they rely on \
              an expunged disk or sled",
             move |_cx| async move {
@@ -472,7 +472,7 @@ fn register_cleanup_expunged_zones_step<'a>(
 ) {
     registrar
         .new_step(
-            ExecutionStepId::Remove,
+            ExecutionStepId::Cleanup,
             "Cleanup expunged zones",
             move |_cx| async move {
                 let res = omicron_zones::clean_up_expunged_zones(
@@ -499,7 +499,7 @@ fn register_decommission_sleds_step<'a>(
 ) {
     registrar
         .new_step(
-            ExecutionStepId::Remove,
+            ExecutionStepId::Cleanup,
             "Decommission sleds",
             move |_cx| async move {
                 let res = sled_state::decommission_sleds(
@@ -529,7 +529,7 @@ fn register_decommission_disks_step<'a>(
 ) {
     registrar
         .new_step(
-            ExecutionStepId::Remove,
+            ExecutionStepId::Cleanup,
             "Decommission expunged disks",
             move |_cx| async move {
                 let res = omicron_physical_disks::decommission_expunged_disks(
@@ -612,7 +612,7 @@ fn register_reassign_sagas_step<'a>(
 ) -> StepHandle<bool> {
     registrar
         .new_step(
-            ExecutionStepId::Ensure,
+            ExecutionStepId::Cleanup,
             "Reassign sagas",
             move |_cx| async move {
                 // For any expunged Nexus zones, re-assign in-progress sagas to

--- a/nexus/reconfigurator/execution/src/omicron_zones.rs
+++ b/nexus/reconfigurator/execution/src/omicron_zones.rs
@@ -32,18 +32,13 @@ use std::collections::BTreeMap;
 use std::net::SocketAddr;
 use std::net::SocketAddrV6;
 
-/// Typestate indicating that the deploy disks step was performed.
-#[derive(Debug)]
-#[must_use = "token indicating completion of deploy_zones"]
-pub(crate) struct DeployZonesDone(());
-
 /// Idempotently ensure that the specified Omicron zones are deployed to the
 /// corresponding sleds
 pub(crate) async fn deploy_zones<'a, I>(
     opctx: &OpContext,
     sleds_by_id: &BTreeMap<SledUuid, Sled>,
     zones: I,
-) -> Result<DeployZonesDone, Vec<anyhow::Error>>
+) -> Result<(), Vec<anyhow::Error>>
 where
     I: Iterator<Item = (SledUuid, &'a BlueprintZonesConfig)>,
 {
@@ -100,7 +95,11 @@ where
         .collect()
         .await;
 
-    if errors.is_empty() { Ok(DeployZonesDone(())) } else { Err(errors) }
+    if errors.is_empty() {
+        Ok(())
+    } else {
+        Err(errors)
+    }
 }
 
 /// Idempontently perform any cleanup actions necessary for expunged zones.

--- a/nexus/reconfigurator/execution/src/omicron_zones.rs
+++ b/nexus/reconfigurator/execution/src/omicron_zones.rs
@@ -95,11 +95,7 @@ where
         .collect()
         .await;
 
-    if errors.is_empty() {
-        Ok(())
-    } else {
-        Err(errors)
-    }
+    if errors.is_empty() { Ok(()) } else { Err(errors) }
 }
 
 /// Idempontently perform any cleanup actions necessary for expunged zones.

--- a/nexus/reconfigurator/execution/src/sagas.rs
+++ b/nexus/reconfigurator/execution/src/sagas.rs
@@ -4,7 +4,6 @@
 
 //! Re-assign sagas from expunged Nexus zones
 
-use crate::omicron_zones::DeployZonesDone;
 use nexus_db_model::SecId;
 use nexus_db_queries::context::OpContext;
 use nexus_db_queries::db::DataStore;
@@ -20,7 +19,6 @@ pub(crate) async fn reassign_sagas_from_expunged(
     datastore: &DataStore,
     blueprint: &Blueprint,
     nexus_id: SecId,
-    _deploy_zones_done: &DeployZonesDone,
 ) -> Result<bool, Error> {
     let log = &opctx.log;
 
@@ -36,12 +34,8 @@ pub(crate) async fn reassign_sagas_from_expunged(
     // instances running at the same time.  At that point, we will need to make
     // sure that we only ever try to assign ourselves sagas from other Nexus
     // instances that we know are running the same version as ourselves.
-    //
-    // TODO-correctness Once the planner fills in `ready_for_cleanup`, we should
-    // filter on that here and stop requiring `deploy_zones_done`. This is
-    // necessary to fix omicron#6999.
     let nexus_zone_ids: Vec<_> = blueprint
-        .all_omicron_zones(BlueprintZoneDisposition::is_expunged)
+        .all_omicron_zones(BlueprintZoneDisposition::is_ready_for_cleanup)
         .filter_map(|(_, z)| {
             z.zone_type
                 .is_nexus()

--- a/nexus/src/app/background/tasks/blueprint_execution.rs
+++ b/nexus/src/app/background/tasks/blueprint_execution.rs
@@ -168,6 +168,7 @@ mod test {
     use httptest::Expectation;
     use httptest::matchers::{not, request};
     use httptest::responders::status_code;
+    use itertools::Itertools as _;
     use nexus_db_model::{
         ByteCount, SledBaseboard, SledSystemHardware, SledUpdate, Zpool,
     };
@@ -178,7 +179,7 @@ mod test {
     use nexus_test_utils_macros::nexus_test;
     use nexus_types::deployment::execution::{
         EventBuffer, EventReport, ExecutionComponent, ExecutionStepId,
-        ReconfiguratorExecutionSpec, StepInfo,
+        StepOutcome, StepStatus,
     };
     use nexus_types::deployment::{
         Blueprint, BlueprintDatasetsConfig, BlueprintPhysicalDisksConfig,
@@ -196,13 +197,12 @@ mod test {
     use omicron_uuid_kinds::PhysicalDiskUuid;
     use omicron_uuid_kinds::SledUuid;
     use omicron_uuid_kinds::ZpoolUuid;
-    use serde::Deserialize;
     use serde_json::json;
     use std::collections::BTreeMap;
     use std::net::SocketAddr;
     use std::sync::Arc;
     use tokio::sync::watch;
-    use update_engine::{NestedError, TerminalKind};
+    use update_engine::{CompletionReason, NestedError, TerminalKind};
     use uuid::Uuid;
 
     type ControlPlaneTestContext =
@@ -538,26 +538,51 @@ mod test {
                 .respond_with(status_code(500)),
         );
 
-        #[derive(Deserialize)]
-        struct ErrorResult {
-            execution_error: NestedError,
-        }
-
         let mut value = task.activate(&opctx).await;
         let event_buffer = extract_event_buffer(&mut value);
 
-        println!("after failure: {:?}", value);
-        let result: ErrorResult = serde_json::from_value(value).unwrap();
-        assert_eq!(
-            result.execution_error.message(),
-            "step failed: Deploy Omicron zones"
-        );
+        let ensure_zones_outcome = {
+            let ensure_id =
+                serde_json::to_value(ExecutionStepId::Ensure).unwrap();
+            let zones_component =
+                serde_json::to_value(ExecutionComponent::OmicronZones).unwrap();
+            match event_buffer
+                .iter_steps_recursive()
+                .filter_map(|(_, step)| {
+                    let info = step.step_info();
+                    if info.id == ensure_id && info.component == zones_component
+                    {
+                        match step.step_status() {
+                            StepStatus::Completed {
+                                reason: CompletionReason::StepCompleted(info),
+                            } => Some(&info.outcome),
+                            status => {
+                                panic!("unexpected step status: {status:?}")
+                            }
+                        }
+                    } else {
+                        None
+                    }
+                })
+                .exactly_one()
+            {
+                Ok(outcome) => outcome,
+                Err(outcomes) => panic!(
+                    "expected exactly one step outcome, but found {}",
+                    outcomes.count()
+                ),
+            }
+        };
 
-        assert_event_buffer_failed_at(
-            &event_buffer,
-            ExecutionComponent::OmicronZones,
-            ExecutionStepId::Ensure,
-        );
+        match ensure_zones_outcome {
+            StepOutcome::Warning { message, .. } => {
+                assert!(
+                    message.contains("Failed to put OmicronZonesConfig"),
+                    "unexpected warning message: {message}"
+                );
+            }
+            other => panic!("unexpected zones outcome: {other:?}"),
+        }
 
         s1.verify_and_clear();
         s2.verify_and_clear();
@@ -595,40 +620,6 @@ mod test {
             terminal_info.kind,
             TerminalKind::Completed,
             "execution should have completed successfully"
-        );
-    }
-
-    fn assert_event_buffer_failed_at(
-        event_buffer: &EventBuffer,
-        component: ExecutionComponent,
-        step_id: ExecutionStepId,
-    ) {
-        let execution_status = event_buffer
-            .root_execution_summary()
-            .expect("event buffer has root execution summary")
-            .execution_status;
-        let terminal_info =
-            execution_status.terminal_info().unwrap_or_else(|| {
-                panic!(
-                    "execution status has terminal info: {:?}",
-                    execution_status
-                );
-            });
-        assert_eq!(
-            terminal_info.kind,
-            TerminalKind::Failed,
-            "execution should have failed"
-        );
-        let step =
-            event_buffer.get(&terminal_info.step_key).expect("step exists");
-        let step_info = StepInfo::<ReconfiguratorExecutionSpec>::from_generic(
-            step.step_info().clone(),
-        )
-        .expect("step info follows ReconfiguratorExecutionSpec");
-        assert_eq!(
-            (step_info.component, step_info.id),
-            (component, step_id),
-            "component and step id matches expected"
         );
     }
 }

--- a/nexus/types/src/deployment.rs
+++ b/nexus/types/src/deployment.rs
@@ -812,6 +812,12 @@ impl BlueprintZoneDisposition {
             } => !ready_for_cleanup,
         }
     }
+
+    /// Returns true if `self` indicates the zone is expunged and ready for
+    /// cleanup.
+    pub fn is_ready_for_cleanup(self) -> bool {
+        matches!(self, Self::Expunged { ready_for_cleanup: true, .. })
+    }
 }
 
 impl fmt::Display for BlueprintZoneDisposition {

--- a/nexus/types/src/deployment/execution/spec.rs
+++ b/nexus/types/src/deployment/execution/spec.rs
@@ -47,11 +47,9 @@ pub enum ExecutionComponent {
 pub enum ExecutionStepId {
     /// Fetch information that will be used in subsequent steps.
     Fetch,
-    Add,
-    Remove,
+    /// Perform cleanup actions on removed items.
+    Cleanup,
     /// Idempotent "ensure" or "deploy" step that delegates removes and adds to
     /// other parts of the system.
     Ensure,
-    /// Finalize the blueprint and check for errors at the end of execution.
-    Finalize,
 }


### PR DESCRIPTION
Changes the three steps that required the earlier `PUT /omicron-zones` execution step to succeed because they needed to clean up after zones that were definitely shut down to now ready the `ready_for_cleanup` blueprint disposition (which is set by the _planner_ after it confirms via inventory that the zones are dead).

While I was here, I removed both the special case error-to-warning implementation in a couple of steps and the `finalize` step that compiled those. I believe all of that predates the ability for `omdb` to interpret the update-engine event report. Now that it can, emitting step warnings directly is fine. I spun this branch up in a4x2 and then shut down one of the sled-agents; that results in this report the executor:

```
  last completed activation: iter 47, triggered by a periodic timer firing
    started at 2025-03-03T19:49:51.027Z (23s ago) and ran for 11711ms
    target blueprint: 3680509e-77c3-4d98-a8a4-276de89b2c53                                                                                                                                                                                                       
    execution:        enabled                                                                                                                                                                                                                                    
    status:           completed (15 steps)                                                                                                                                                                                                                       
    warning:          at: Plumb service firewall rules: failed to plumb service firewall rules to sleds: Internal Error: Communication Error: error sending request for url (http://[fd00:1122:3344:102::1]:12345/vpc/001de000-074c-4000-8000-000000000000/firewall/rules)
    warning:          at: Deploy Omicron zones: Failed to put OmicronZonesConfig {                                                                                                                                             

... snip the OmicronZonesConfig Debug output ...

} to sled e2389240-03a7-4a96-a04a-aa4ee3a38381: Communication Error: error sending request for url (http://[fd00:1122:3344:102::1]:12345/omicron-zones): error sending request for url (http://[fd00:1122:3344:102::1]:12345/omicron-zones): client error (Connect): tcp connect error: Connection refused (os error 146): Connection refused (os error 146)
    warning:          at: Deploy datasets: Failed to put DatasetsConfig {                                                                                                                                              

... snip the DatasetConfig Debug output ...

} to sled e2389240-03a7-4a96-a04a-aa4ee3a38381: Communication Error: error sending request for url (http://[fd00:1122:3344:102::1]:12345/datasets): error sending request for url (http://[fd00:1122:3344:102::1]:12345/datasets): client error (Connect): tcp connect error: Connection refused (os error 146): Connection refused (os error 146)
    warning:          at: Deploy physical disks: Failed to put BlueprintPhysicalDisksConfig {                                                                                                                                              

... snip the BlueprintPhysicalDisksConfig Debug output ...

} to sled e2389240-03a7-4a96-a04a-aa4ee3a38381: Communication Error: error sending request for url (http://[fd00:1122:3344:102::1]:12345/omicron-physical-disks): error sending request for url (http://[fd00:1122:3344:102::1]:12345/omicron-physical-disks): client error (Connect): tcp connect error: Connection refused (os error 146): Connection refused (os error 146)
    error:            (none)                                                                                                                                                                                                                                     
```

Closes #6999, under the assumption that as of this PR we've identified all the inter-step dependencies and broken them.

