### PR TITLE
update workspace to resolver = 3

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -265,7 +265,7 @@ default-members = [
     "workspace-hack",
     "zone-setup",
 ]
-resolver = "2"
+resolver = "3"
 
 #
 # Tree-wide lint configuration.


### PR DESCRIPTION
Cargo resolver [version 3](https://doc.rust-lang.org/edition-guide/rust-2024/cargo-resolver.html) introduces an MSRV-aware resolver. Unlike the change from resolver v1 to v2, there are no changes to packages or feature sets that get built.