### PR TITLE
[nexus] Experiment with using closer-to-raw-SQL pagination

### DIFF
--- a/nexus/db-queries/src/db/column_walker.rs
+++ b/nexus/db-queries/src/db/column_walker.rs
@@ -28,6 +28,7 @@ impl<T> ColumnWalker<T> {
 
 macro_rules! impl_column_walker {
     ( $len:literal $($column:ident)+ ) => (
+        /// Returns all columns with the "<prefix>." string prepended.
         #[allow(dead_code)]
         impl<$($column: Column),+> ColumnWalker<($($column,)+)> {
             pub fn with_prefix(prefix: &'static str) -> TrustedStr {
@@ -38,6 +39,44 @@ macro_rules! impl_column_walker {
                 // hopefully known at compile-time, and not leaked).
                 TrustedStr::i_take_responsibility_for_validating_this_string(
                     [$([prefix, $column::NAME].join("."),)+].join(", ")
+                )
+            }
+        }
+
+        /// Identical to [Self::with_prefix], but also aliases each column.
+        ///
+        /// The aliased name is "prefix_<column name>".
+        #[allow(dead_code)]
+        impl<$($column: Column),+> ColumnWalker<($($column,)+)> {
+            pub fn with_prefix_and_alias(prefix: &'static str) -> TrustedStr {
+                // This string is derived from:
+                // - The "table" type, with associated columns, which
+                // are not controlled by an arbitrary user, and
+                // - The "prefix" type, which is a "&'static str" (AKA,
+                // hopefully known at compile-time, and not leaked).
+                TrustedStr::i_take_responsibility_for_validating_this_string(
+                    [
+                        $(
+                            format!(
+                                "{prefix}.{column} as {prefix}_{column}",
+                                prefix = prefix, column = $column::NAME
+                            ),
+                        )+
+                    ].join(", ")
+                )
+            }
+        }
+
+
+        /// Returns all columns without any suffix.
+        #[allow(dead_code)]
+        impl<$($column: Column),+> ColumnWalker<($($column,)+)> {
+            pub fn as_str() -> TrustedStr {
+                // This string is derived from:
+                // - The "table" type, with associated columns, which
+                // are not controlled by an arbitrary user, and
+                TrustedStr::i_take_responsibility_for_validating_this_string(
+                    [$($column::NAME,)+].join(", ")
                 )
             }
         }

--- a/nexus/db-queries/src/db/datastore/cockroachdb_settings.rs
+++ b/nexus/db-queries/src/db/datastore/cockroachdb_settings.rs
@@ -66,18 +66,17 @@ impl DataStore {
         type QueryRow = (sql_types::Text, sql_types::Text, sql_types::Text);
 
         let conn = self.pool_connection_authorized(opctx).await?;
-        let output: QueryOutput = QueryBuilder::new()
+        let mut query = QueryBuilder::new();
+        query
             .sql("SELECT ")
             .sql(STATE_FINGERPRINT_SQL)
             .sql(", * FROM ")
             .sql("[SHOW CLUSTER SETTING version], ")
-            .sql("[SHOW CLUSTER SETTING cluster.preserve_downgrade_option]")
-            .query::<QueryRow>()
-            .get_result_async(&*conn)
-            .await
-            .map_err(|err| {
-                public_error_from_diesel(err, ErrorHandler::Server)
-            })?;
+            .sql("[SHOW CLUSTER SETTING cluster.preserve_downgrade_option]");
+        let output: QueryOutput =
+            query.query::<QueryRow>().get_result_async(&*conn).await.map_err(
+                |err| public_error_from_diesel(err, ErrorHandler::Server),
+            )?;
         Ok(CockroachDbSettings {
             state_fingerprint: output.state_fingerprint,
             version: output.version,
@@ -96,7 +95,8 @@ impl DataStore {
         value: String,
     ) -> Result<(), Error> {
         let conn = self.pool_connection_authorized(opctx).await?;
-        QueryBuilder::new()
+        let mut query = QueryBuilder::new();
+        query
             .sql("SET CLUSTER SETTING ")
             .sql(setting)
             // `CASE` is the one conditional statement we get out of the
@@ -114,13 +114,10 @@ impl DataStore {
             // below in `test_state_fingerprint`).
             .sql(" ELSE NULL END")
             .bind::<sql_types::Text, _>(state_fingerprint)
-            .bind::<sql_types::Text, _>(value.clone())
-            .query::<()>()
-            .execute_async(&*conn)
-            .await
-            .map_err(|err| {
-                public_error_from_diesel(err, ErrorHandler::Server)
-            })?;
+            .bind::<sql_types::Text, _>(value.clone());
+        query.query::<()>().execute_async(&*conn).await.map_err(|err| {
+            public_error_from_diesel(err, ErrorHandler::Server)
+        })?;
         info!(
             opctx.log,
             "set cockroachdb setting";

--- a/nexus/db-queries/src/db/datastore/deployment.rs
+++ b/nexus/db-queries/src/db/datastore/deployment.rs
@@ -3081,8 +3081,9 @@ mod tests {
         // target changes.
         //
         // More on this in the block comment below.
-        let _external_ips = QueryBuilder::new()
-            .sql("SELECT id FROM omicron.public.external_ip WHERE time_deleted IS NULL")
+        let mut query = QueryBuilder::new();
+        query.sql("SELECT id FROM omicron.public.external_ip WHERE time_deleted IS NULL");
+        let _external_ips = query
             .query::<diesel::sql_types::Uuid>()
             .load_async::<uuid::Uuid>(&*conn)
             .await

--- a/nexus/db-queries/src/db/datastore/inventory.rs
+++ b/nexus/db-queries/src/db/datastore/inventory.rs
@@ -3039,9 +3039,11 @@ mod test {
             .pool_connection_for_tests()
             .await
             .context("Failed to get datastore connection")?;
-        let tables: Vec<String> = QueryBuilder::new().sql(
+        let mut query = QueryBuilder::new();
+        query.sql(
             "SELECT table_name FROM information_schema.tables WHERE table_name LIKE 'inv\\_%'"
-            )
+        );
+        let tables: Vec<String> = query
             .query::<diesel::sql_types::Text>()
             .load_async(&*conn)
             .await
@@ -3063,14 +3065,16 @@ mod test {
                 .context("Failed to allow full table scans")?;
 
             for table in tables {
-                let count: i64 = QueryBuilder::new().sql(
-                        // We're scraping the table names dynamically here, so we
-                        // don't know them ahead of time. However, this is also a
-                        // test, so this usage is pretty benign.
-                        TrustedStr::i_take_responsibility_for_validating_this_string(
-                            format!("SELECT COUNT(*) FROM {table}")
-                        )
+                let mut query = QueryBuilder::new();
+                query.sql(
+                    // We're scraping the table names dynamically here, so we
+                    // don't know them ahead of time. However, this is also a
+                    // test, so this usage is pretty benign.
+                    TrustedStr::i_take_responsibility_for_validating_this_string(
+                        format!("SELECT COUNT(*) FROM {table}")
                     )
+                );
+                let count: i64 = query
                     .query::<diesel::sql_types::Int8>()
                     .get_result_async(&conn)
                     .await

--- a/nexus/db-queries/src/db/queries/sled_reservation.rs
+++ b/nexus/db-queries/src/db/queries/sled_reservation.rs
@@ -38,7 +38,8 @@ pub fn sled_find_targets_query(
     sql_types::Nullable<AffinityPolicyEnum>,
     sql_types::Nullable<AffinityPolicyEnum>,
 )> {
-    QueryBuilder::new().sql("
+    let mut query = QueryBuilder::new();
+    query.sql("
         WITH sled_targets AS (
             SELECT sled.id as sled_id
             FROM sled
@@ -183,8 +184,9 @@ pub fn sled_find_targets_query(
     .bind::<sql_types::Uuid, _>(instance_id.into_untyped_uuid())
     .bind::<sql_types::Uuid, _>(instance_id.into_untyped_uuid())
     .bind::<sql_types::Uuid, _>(instance_id.into_untyped_uuid())
-    .bind::<sql_types::Uuid, _>(instance_id.into_untyped_uuid())
-    .query()
+    .bind::<sql_types::Uuid, _>(instance_id.into_untyped_uuid());
+
+    query.query()
 }
 
 /// Inserts a sled_resource_vmm record into the database, if it is
@@ -192,7 +194,8 @@ pub fn sled_find_targets_query(
 pub fn sled_insert_resource_query(
     resource: &SledResourceVmm,
 ) -> TypedSqlQuery<(sql_types::Numeric,)> {
-    QueryBuilder::new().sql("
+    let mut query = QueryBuilder::new();
+    query.sql("
         WITH sled_has_space AS (
             SELECT 1
             FROM sled
@@ -345,8 +348,9 @@ pub fn sled_insert_resource_query(
     .bind::<sql_types::BigInt, _>(resource.resources.hardware_threads)
     .bind::<sql_types::BigInt, _>(resource.resources.rss_ram)
     .bind::<sql_types::BigInt, _>(resource.resources.reservoir_ram)
-    .bind::<sql_types::Uuid, _>(resource.instance_id.unwrap().into_untyped_uuid())
-    .query()
+    .bind::<sql_types::Uuid, _>(resource.instance_id.unwrap().into_untyped_uuid());
+
+    query.query()
 }
 
 #[cfg(test)]

--- a/nexus/db-queries/src/db/queries/virtual_provisioning_collection_update.rs
+++ b/nexus/db-queries/src/db/queries/virtual_provisioning_collection_update.rs
@@ -106,7 +106,9 @@ impl VirtualProvisioningCollectionUpdate {
         update_kind: UpdateKind,
         project_id: uuid::Uuid,
     ) -> TypedSqlQuery<SelectableSql<VirtualProvisioningCollection>> {
-        let query = QueryBuilder::new().sql("
+        let mut query = QueryBuilder::new();
+
+        query.sql("
 WITH
   parent_silo AS (SELECT project.silo_id AS id FROM project WHERE project.id = ").param().sql("),")
             .bind::<sql_types::Uuid, _>(project_id).sql("
@@ -140,7 +142,7 @@ WITH
         INNER JOIN parent_silo ON virtual_provisioning_collection.id = parent_silo.id
     ),");
 
-        let query = match update_kind.clone() {
+        match update_kind.clone() {
             UpdateKind::InsertInstance(resource) | UpdateKind::InsertStorage(resource) => {
                 query.sql("
   do_update
@@ -273,7 +275,7 @@ WITH
             },
         };
 
-        let query = match update_kind.clone() {
+        match update_kind.clone() {
             UpdateKind::InsertInstance(resource)
             | UpdateKind::InsertStorage(resource) => query
                 .sql(
@@ -345,7 +347,7 @@ WITH
                 .bind::<sql_types::Uuid, _>(id),
         };
 
-        let query = query.sql(
+        query.sql(
             "
   virtual_provisioning_collection
     AS (
@@ -353,7 +355,7 @@ WITH
         virtual_provisioning_collection
       SET",
         );
-        let query = match update_kind.clone() {
+        match update_kind.clone() {
             UpdateKind::InsertInstance(resource) => query
                 .sql(
                     "
@@ -415,7 +417,9 @@ SELECT "
     ).sql(AllColumnsOfVirtualCollection::with_prefix("virtual_provisioning_collection")).sql("
 FROM
   virtual_provisioning_collection
-").query()
+");
+
+        query.query()
     }
 
     pub fn new_insert_storage(

--- a/nexus/db-queries/src/db/raw_query_builder.rs
+++ b/nexus/db-queries/src/db/raw_query_builder.rs
@@ -88,14 +88,14 @@ type BoxedQuery = diesel::query_builder::BoxedSqlQuery<
 //
 // But this relies on nightly features.
 pub struct QueryBuilder {
-    query: BoxedQuery,
+    query: Option<BoxedQuery>,
     bind_counter: BindParamCounter,
 }
 
 impl QueryBuilder {
     pub fn new() -> Self {
         Self {
-            query: diesel::sql_query("").into_boxed(),
+            query: Some(diesel::sql_query("").into_boxed()),
             bind_counter: BindParamCounter::new(),
         }
     }
@@ -107,14 +107,12 @@ impl QueryBuilder {
     /// however, a distinct method, as "identifying bind params" should be
     /// decoupled from "using bind parameters" to have an efficient statement
     /// cache.
-    pub fn param(self) -> Self {
-        Self {
-            query: self
-                .query
-                .sql("$")
-                .sql(self.bind_counter.next().to_string()),
-            bind_counter: self.bind_counter,
-        }
+    pub fn param(&mut self) -> &mut Self {
+        self.query = self
+            .query
+            .take()
+            .map(|q| q.sql("$").sql(self.bind_counter.next().to_string()));
+        self
     }
 
     /// Slightly more strict than the "sql" method of Diesel's SqlQuery.
@@ -122,27 +120,28 @@ impl QueryBuilder {
     /// susceptibility to SQL injection.
     ///
     /// See the documentation of [TrustedStr] for more details.
-    pub fn sql<S: Into<TrustedStr>>(self, s: S) -> Self {
-        let query = match s.into().0 {
-            TrustedStrVariants::Static(s) => self.query.sql(s),
-            TrustedStrVariants::ValidatedExplicitly(s) => self.query.sql(s),
-        };
-        Self { query, bind_counter: self.bind_counter }
+    pub fn sql<S: Into<TrustedStr>>(&mut self, s: S) -> &mut Self {
+        self.query = self.query.take().map(|q| match s.into().0 {
+            TrustedStrVariants::Static(s) => q.sql(s),
+            TrustedStrVariants::ValidatedExplicitly(s) => q.sql(s),
+        });
+        self
     }
 
     /// A call-through function to [diesel::query_builder::BoxedSqlQuery].
-    pub fn bind<BindSt, Value>(self, b: Value) -> Self
+    pub fn bind<BindSt, Value>(&mut self, b: Value) -> &mut Self
     where
         Pg: sql_types::HasSqlType<BindSt>,
         Value: diesel::serialize::ToSql<BindSt, Pg> + Send + 'static,
         BindSt: Send + 'static,
     {
-        Self { query: self.query.bind(b), bind_counter: self.bind_counter }
+        self.query = self.query.take().map(|q| q.bind(b));
+        self
     }
 
     /// Takes the final boxed query
     pub fn query<T>(self) -> TypedSqlQuery<T> {
-        TypedSqlQuery { inner: self.query, _phantom: PhantomData }
+        TypedSqlQuery { inner: self.query.unwrap(), _phantom: PhantomData }
     }
 }
 


### PR DESCRIPTION
The `pagination` functions - in particular, the `paginated_multicolumn`  function - is notorious
for having incredibly complex generic parameters.

(See: https://github.com/oxidecomputer/omicron/blob/feae60c43f27712c7f076a4e9102c100514377ba/nexus/db-queries/src/db/pagination.rs#L82)

To reduce this pain, this PR provides pagination helpers which side-step Diesel's type-checking,
aiming to provide a more flexible option for pagination which can work across arbitrary JOINs,
UNIONs, etc, without relying on compile-time type-checking.