### PR TITLE
[reconfigurator] Executor internal cleanup around iterators

### DIFF
--- a/nexus/reconfigurator/execution/src/lib.rs
+++ b/nexus/reconfigurator/execution/src/lib.rs
@@ -526,12 +526,11 @@ fn register_decommission_disks_step<'a>(
             ExecutionStepId::Cleanup,
             "Decommission expunged disks",
             move |_cx| async move {
-                let res =
-                    omicron_physical_disks::decommission_expunged_disks(
-                        opctx, datastore, blueprint,
-                    )
-                    .await
-                    .map_err(merge_anyhow_list);
+                let res = omicron_physical_disks::decommission_expunged_disks(
+                    opctx, datastore, blueprint,
+                )
+                .await
+                .map_err(merge_anyhow_list);
                 Ok(map_err_to_step_warning(res))
             },
         )
@@ -553,8 +552,7 @@ fn register_deploy_clickhouse_cluster_nodes_step<'a>(
                 {
                     let res = clickhouse::deploy_nodes(
                         opctx,
-                        blueprint
-                            .all_omicron_zones(BlueprintZoneDisposition::any),
+                        blueprint,
                         &clickhouse_cluster_config,
                     )
                     .await
@@ -578,15 +576,8 @@ fn register_deploy_clickhouse_single_node_step<'a>(
             ExecutionStepId::Ensure,
             "Deploy single-node clickhouse cluster",
             move |_cx| async move {
-                let res = clickhouse::deploy_single_node(
-                    opctx,
-                    blueprint
-                        .all_omicron_zones(
-                            BlueprintZoneDisposition::is_in_service,
-                        )
-                        .filter(|(_, z)| z.zone_type.is_clickhouse()),
-                )
-                .await;
+                let res =
+                    clickhouse::deploy_single_node(opctx, blueprint).await;
                 Ok(map_err_to_step_warning(res))
             },
         )

--- a/nexus/reconfigurator/execution/src/lib.rs
+++ b/nexus/reconfigurator/execution/src/lib.rs
@@ -476,12 +476,7 @@ fn register_cleanup_expunged_zones_step<'a>(
             "Cleanup expunged zones",
             move |_cx| async move {
                 let res = omicron_zones::clean_up_expunged_zones(
-                    &opctx,
-                    datastore,
-                    resolver,
-                    blueprint.all_omicron_zones(
-                        BlueprintZoneDisposition::is_ready_for_cleanup,
-                    ),
+                    &opctx, datastore, resolver, blueprint,
                 )
                 .await
                 .map_err(merge_anyhow_list);

--- a/nexus/reconfigurator/execution/src/lib.rs
+++ b/nexus/reconfigurator/execution/src/lib.rs
@@ -353,15 +353,10 @@ fn register_deploy_datasets_step<'a>(
             "Deploy datasets",
             move |cx| async move {
                 let sleds_by_id = sleds.into_value(cx.token()).await;
-                let res = datasets::deploy_datasets(
-                    opctx,
-                    &sleds_by_id,
-                    blueprint.sleds.iter().map(|(sled_id, sled)| {
-                        (*sled_id, &sled.datasets_config)
-                    }),
-                )
-                .await
-                .map_err(merge_anyhow_list);
+                let res =
+                    datasets::deploy_datasets(opctx, &sleds_by_id, blueprint)
+                        .await
+                        .map_err(merge_anyhow_list);
                 Ok(map_err_to_step_warning(res))
             },
         )

--- a/nexus/reconfigurator/execution/src/lib.rs
+++ b/nexus/reconfigurator/execution/src/lib.rs
@@ -11,10 +11,8 @@ use internal_dns_resolver::Resolver;
 use nexus_db_queries::context::OpContext;
 use nexus_db_queries::db::DataStore;
 use nexus_types::deployment::Blueprint;
-use nexus_types::deployment::BlueprintZoneDisposition;
 use nexus_types::deployment::SledFilter;
 use nexus_types::deployment::execution::*;
-use nexus_types::external_api::views::SledState;
 use nexus_types::identity::Asset;
 use omicron_uuid_kinds::GenericUuid;
 use omicron_uuid_kinds::OmicronZoneUuid;
@@ -496,19 +494,10 @@ fn register_decommission_sleds_step<'a>(
             ExecutionStepId::Cleanup,
             "Decommission sleds",
             move |_cx| async move {
-                let res = sled_state::decommission_sleds(
-                    opctx,
-                    datastore,
-                    blueprint
-                        .sleds
-                        .iter()
-                        .filter(|(_, sled)| {
-                            sled.state == SledState::Decommissioned
-                        })
-                        .map(|(&sled_id, _)| sled_id),
-                )
-                .await
-                .map_err(merge_anyhow_list);
+                let res =
+                    sled_state::decommission_sleds(opctx, datastore, blueprint)
+                        .await
+                        .map_err(merge_anyhow_list);
                 Ok(map_err_to_step_warning(res))
             },
         )

--- a/nexus/reconfigurator/execution/src/sled_state.rs
+++ b/nexus/reconfigurator/execution/src/sled_state.rs
@@ -5,16 +5,35 @@
 //! Updates sled states required by a given blueprint
 
 use anyhow::Context;
-use nexus_db_model::SledState;
+use nexus_db_model::SledState as DbSledState;
 use nexus_db_queries::authz::Action;
 use nexus_db_queries::context::OpContext;
 use nexus_db_queries::db::DataStore;
 use nexus_db_queries::db::datastore::TransitionError;
 use nexus_db_queries::db::lookup::LookupPath;
+use nexus_types::deployment::Blueprint;
+use nexus_types::external_api::views::SledState;
 use omicron_uuid_kinds::GenericUuid;
 use omicron_uuid_kinds::SledUuid;
 
 pub(crate) async fn decommission_sleds(
+    opctx: &OpContext,
+    datastore: &DataStore,
+    blueprint: &Blueprint,
+) -> Result<(), Vec<anyhow::Error>> {
+    decommission_sleds_impl(
+        opctx,
+        datastore,
+        blueprint
+            .sleds
+            .iter()
+            .filter(|(_, sled)| sled.state == SledState::Decommissioned)
+            .map(|(&sled_id, _)| sled_id),
+    )
+    .await
+}
+
+pub(crate) async fn decommission_sleds_impl(
     opctx: &OpContext,
     datastore: &DataStore,
     sled_ids_to_decommission: impl Iterator<Item = SledUuid>,
@@ -50,7 +69,7 @@ async fn decommission_one_sled(
         // already realized), this sled may already be decommissioned; that's
         // fine.
         Err(TransitionError::InvalidTransition { current, .. })
-            if current.state() == SledState::Decommissioned =>
+            if current.state() == DbSledState::Decommissioned =>
         {
             Ok(())
         }
@@ -112,7 +131,7 @@ mod tests {
             .expect("expunged sled");
 
         // Decommission the sled.
-        decommission_sleds(
+        decommission_sleds_impl(
             &opctx,
             datastore,
             std::iter::once(decommissioned_sled_id),
@@ -127,7 +146,7 @@ mod tests {
         );
 
         // Try to decommission the sled again; this should be fine.
-        decommission_sleds(
+        decommission_sleds_impl(
             &opctx,
             datastore,
             std::iter::once(decommissioned_sled_id),


### PR DESCRIPTION
Builds on #7713, and is followup from https://github.com/oxidecomputer/omicron/pull/7713#discussion_r1978146721. In #7652 I changed all the executor substeps to take iterators instead of `&BTreeMap` references that no longer existed, but that introduced a weird split where the top-level caller had to filter the blueprint down to just the items that the inner functions expected. @smklein pointed out one place where the inner code was being extra defensive, which was just more confusing than anything.

This PR removes that split: the top-level executor now always passes a full `&Blueprint` down, and the inner modules are responsible for doing their own filtering as appropriate. To easy testing, I kept the versions that take an iterator of already-filtered items as private `*_impl` functions that the new functions-that-take-a-full-`Blueprint` themselves call too.