### PR TITLE
Blueprint executor: Don't warn about skipping steps on expunged sleds

### DIFF
--- a/nexus/reconfigurator/execution/src/datasets.rs
+++ b/nexus/reconfigurator/execution/src/datasets.rs
@@ -40,6 +40,14 @@ where
             let db_sled = match sleds_by_id.get(&sled_id) {
                 Some(sled) => sled,
                 None => {
+                    if config.are_all_datasets_expunged() {
+                        info!(
+                            log,
+                            "Skipping dataset deployment to expunged sled";
+                            "sled_id" => %sled_id
+                        );
+                        return None;
+                    }
                     let err = anyhow!("sled not found in db list: {}", sled_id);
                     warn!(log, "{err:#}");
                     return Some(err);

--- a/nexus/reconfigurator/execution/src/omicron_physical_disks.rs
+++ b/nexus/reconfigurator/execution/src/omicron_physical_disks.rs
@@ -40,6 +40,14 @@ where
             let db_sled = match sleds_by_id.get(&sled_id) {
                 Some(sled) => sled,
                 None => {
+                    if config.are_all_disks_expunged() {
+                        info!(
+                            log,
+                            "Skipping disk deployment to expunged sled";
+                            "sled_id" => %sled_id
+                        );
+                        return None;
+                    }
                     let err = anyhow!("sled not found in db list: {}", sled_id);
                     warn!(log, "{err:#}");
                     return Some(err);

--- a/nexus/types/src/deployment.rs
+++ b/nexus/types/src/deployment.rs
@@ -617,9 +617,7 @@ impl BlueprintZonesConfig {
     /// Returns true if all zones in the blueprint have a disposition of
     /// `Expunged`, false otherwise.
     pub fn are_all_zones_expunged(&self) -> bool {
-        self.zones.iter().all(|c| {
-            matches!(c.disposition, BlueprintZoneDisposition::Expunged { .. })
-        })
+        self.zones.iter().all(|c| c.disposition.is_expunged())
     }
 }
 
@@ -1070,6 +1068,12 @@ impl BlueprintPhysicalDisksConfig {
                 .collect(),
         }
     }
+
+    /// Returns true if all disks in the blueprint have a disposition of
+    /// `Expunged`, false otherwise.
+    pub fn are_all_disks_expunged(&self) -> bool {
+        self.disks.iter().all(|c| c.disposition.is_expunged())
+    }
 }
 
 impl IdMappable for BlueprintPhysicalDiskConfig {
@@ -1141,6 +1145,12 @@ impl BlueprintDatasetsConfig {
                 .collect(),
         }
     }
+
+    /// Returns true if all datasets in the blueprint have a disposition of
+    /// `Expunged`, false otherwise.
+    pub fn are_all_datasets_expunged(&self) -> bool {
+        self.datasets.iter().all(|c| c.disposition.is_expunged())
+    }
 }
 
 impl IdMappable for BlueprintDatasetConfig {
@@ -1192,6 +1202,12 @@ impl BlueprintDatasetDisposition {
                 BlueprintDatasetFilter::InService => false,
             },
         }
+    }
+
+    /// Returns true if `self` is `BlueprintDatasetDisposition::Expunged`,
+    /// regardless of any details contained within that variant.
+    pub fn is_expunged(self) -> bool {
+        matches!(self, Self::Expunged)
     }
 }
 


### PR DESCRIPTION
We already did this for zones, so this is just copy/paste to do the same thing for disks and datasets.

Fixes #7671.