### PR TITLE
[reconfigurator] Remove `BlueprintDatasetFilter`

### DIFF
--- a/nexus/reconfigurator/blippy/src/checks.rs
+++ b/nexus/reconfigurator/blippy/src/checks.rs
@@ -7,7 +7,7 @@ use crate::blippy::Severity;
 use crate::blippy::SledKind;
 use nexus_sled_agent_shared::inventory::ZoneKind;
 use nexus_types::deployment::BlueprintDatasetConfig;
-use nexus_types::deployment::BlueprintDatasetFilter;
+use nexus_types::deployment::BlueprintDatasetDisposition;
 use nexus_types::deployment::BlueprintPhysicalDiskDisposition;
 use nexus_types::deployment::BlueprintSledConfig;
 use nexus_types::deployment::BlueprintZoneConfig;
@@ -491,7 +491,7 @@ fn check_datasets(blippy: &mut Blippy<'_>) {
     // should have been referenced by either a zone or a disk above.
     for (sled_id, dataset) in blippy
         .blueprint()
-        .all_omicron_datasets(BlueprintDatasetFilter::InService)
+        .all_omicron_datasets(BlueprintDatasetDisposition::is_in_service)
     {
         if !expected_datasets.contains(&dataset.id) {
             blippy.push_sled_note(
@@ -520,7 +520,7 @@ fn check_datasets(blippy: &mut Blippy<'_>) {
     // not have addresses.
     for (sled_id, dataset) in blippy
         .blueprint()
-        .all_omicron_datasets(BlueprintDatasetFilter::InService)
+        .all_omicron_datasets(BlueprintDatasetDisposition::is_in_service)
     {
         match dataset.kind {
             DatasetKind::Crucible => {

--- a/nexus/reconfigurator/planning/src/blueprint_editor/sled_editor.rs
+++ b/nexus/reconfigurator/planning/src/blueprint_editor/sled_editor.rs
@@ -10,7 +10,7 @@ use illumos_utils::zpool::ZpoolName;
 use itertools::Either;
 use nexus_sled_agent_shared::inventory::ZoneKind;
 use nexus_types::deployment::BlueprintDatasetConfig;
-use nexus_types::deployment::BlueprintDatasetFilter;
+use nexus_types::deployment::BlueprintDatasetDisposition;
 use nexus_types::deployment::BlueprintDatasetsConfig;
 use nexus_types::deployment::BlueprintPhysicalDiskConfig;
 use nexus_types::deployment::BlueprintPhysicalDiskDisposition;
@@ -256,10 +256,13 @@ impl SledEditor {
         }
     }
 
-    pub fn datasets(
+    pub fn datasets<F>(
         &self,
-        filter: BlueprintDatasetFilter,
-    ) -> impl Iterator<Item = &BlueprintDatasetConfig> {
+        mut filter: F,
+    ) -> impl Iterator<Item = &BlueprintDatasetConfig>
+    where
+        F: FnMut(BlueprintDatasetDisposition) -> bool,
+    {
         match &self.0 {
             InnerSledEditor::Active(editor) => {
                 Either::Left(editor.datasets(filter))
@@ -269,7 +272,7 @@ impl SledEditor {
                     .datasets
                     .datasets
                     .iter()
-                    .filter(move |disk| disk.disposition.matches(filter)),
+                    .filter(move |disk| filter(disk.disposition)),
             ),
         }
     }
@@ -503,10 +506,13 @@ impl ActiveSledEditor {
         self.disks.disks(filter)
     }
 
-    pub fn datasets(
+    pub fn datasets<F>(
         &self,
-        filter: BlueprintDatasetFilter,
-    ) -> impl Iterator<Item = &BlueprintDatasetConfig> {
+        filter: F,
+    ) -> impl Iterator<Item = &BlueprintDatasetConfig>
+    where
+        F: FnMut(BlueprintDatasetDisposition) -> bool,
+    {
         self.datasets.datasets(filter)
     }
 

--- a/nexus/reconfigurator/rendezvous/src/lib.rs
+++ b/nexus/reconfigurator/rendezvous/src/lib.rs
@@ -11,7 +11,7 @@
 use nexus_db_queries::context::OpContext;
 use nexus_db_queries::db::DataStore;
 use nexus_types::deployment::Blueprint;
-use nexus_types::deployment::BlueprintDatasetFilter;
+use nexus_types::deployment::BlueprintDatasetDisposition;
 use nexus_types::internal_api::background::BlueprintRendezvousStats;
 use nexus_types::inventory::Collection;
 
@@ -35,7 +35,7 @@ pub async fn reconcile_blueprint_rendezvous_tables(
         datastore,
         blueprint.id,
         blueprint
-            .all_omicron_datasets(BlueprintDatasetFilter::All)
+            .all_omicron_datasets(BlueprintDatasetDisposition::any)
             .map(|(_sled_id, dataset)| dataset),
         &inventory_dataset_ids,
     )
@@ -45,7 +45,7 @@ pub async fn reconcile_blueprint_rendezvous_tables(
         opctx,
         datastore,
         blueprint
-            .all_omicron_datasets(BlueprintDatasetFilter::All)
+            .all_omicron_datasets(BlueprintDatasetDisposition::any)
             .map(|(_sled_id, dataset)| dataset),
         &inventory_dataset_ids,
     )

--- a/nexus/types/src/deployment.rs
+++ b/nexus/types/src/deployment.rs
@@ -264,10 +264,13 @@ impl Blueprint {
     }
 
     /// Iterate over the [`BlueprintDatasetsConfig`] instances in the blueprint.
-    pub fn all_omicron_datasets(
+    pub fn all_omicron_datasets<F>(
         &self,
-        filter: BlueprintDatasetFilter,
-    ) -> impl Iterator<Item = (SledUuid, &BlueprintDatasetConfig)> {
+        mut filter: F,
+    ) -> impl Iterator<Item = (SledUuid, &BlueprintDatasetConfig)>
+    where
+        F: FnMut(BlueprintDatasetDisposition) -> bool,
+    {
         self.sleds
             .iter()
             .flat_map(move |(sled_id, config)| {
@@ -277,7 +280,7 @@ impl Blueprint {
                     .iter()
                     .map(|dataset| (*sled_id, dataset))
             })
-            .filter(move |(_, d)| d.disposition.matches(filter))
+            .filter(move |(_, d)| filter(d.disposition))
     }
 
     /// Iterate over the ids of all sleds in the blueprint
@@ -902,22 +905,6 @@ impl fmt::Display for BlueprintZoneImageSource {
     }
 }
 
-/// Filters that apply to blueprint datasets.
-#[derive(Copy, Clone, Debug, PartialEq, Eq, Hash)]
-pub enum BlueprintDatasetFilter {
-    // ---
-    // Prefer to keep this list in alphabetical order.
-    // ---
-    /// All datasets
-    All,
-
-    /// Datasets that have been expunged.
-    Expunged,
-
-    /// Datasets that are in-service.
-    InService,
-}
-
 /// The desired state of an Omicron-managed physical disk in a blueprint.
 #[derive(
     Debug,
@@ -1135,8 +1122,7 @@ impl BlueprintDatasetsConfig {
                 .datasets
                 .into_iter()
                 .filter_map(|d| {
-                    if d.disposition.matches(BlueprintDatasetFilter::InService)
-                    {
+                    if d.disposition.is_in_service() {
                         Some((d.id, d.into()))
                     } else {
                         None
@@ -1189,19 +1175,23 @@ pub enum BlueprintDatasetDisposition {
 }
 
 impl BlueprintDatasetDisposition {
-    pub fn matches(self, filter: BlueprintDatasetFilter) -> bool {
-        match self {
-            Self::InService => match filter {
-                BlueprintDatasetFilter::All => true,
-                BlueprintDatasetFilter::Expunged => false,
-                BlueprintDatasetFilter::InService => true,
-            },
-            Self::Expunged => match filter {
-                BlueprintDatasetFilter::All => true,
-                BlueprintDatasetFilter::Expunged => true,
-                BlueprintDatasetFilter::InService => false,
-            },
-        }
+    /// Always returns true.
+    ///
+    /// This is intended for use with methods that take a filtering
+    /// closure operating on a `BlueprintDatasetDisposition` (e.g.,
+    /// `Blueprint::all_omicron_datasets()`), allowing callers to make it clear
+    /// they accept any disposition via
+    ///
+    /// ```rust,ignore
+    /// blueprint.all_omicron_datasets(BlueprintDatasetDisposition::any)
+    /// ```
+    pub fn any(self) -> bool {
+        true
+    }
+
+    /// Returns true if `self` is `BlueprintDatasetDisposition::InService`
+    pub fn is_in_service(self) -> bool {
+        matches!(self, Self::InService)
     }
 
     /// Returns true if `self` is `BlueprintDatasetDisposition::Expunged`,


### PR DESCRIPTION
Replace it with a filter closure that acts on
`BlueprintDatasetDisposition`; this brings it in line with recent changes made to zones and disks.