### PR TITLE
Make generic versions of two functions

### DIFF
--- a/nexus/src/app/mod.rs
+++ b/nexus/src/app/mod.rs
@@ -1052,6 +1052,22 @@ impl Nexus {
             ))
         })
     }
+
+    /// A [`service`] with [`address`] is considered gone if it is not present
+    /// in a DNS lookup of all addresses for that service.
+    async fn is_internal_service_gone(
+        &self,
+        service: ServiceName,
+        address: SocketAddrV6,
+    ) -> Result<bool, Error> {
+        match self.resolver().lookup_all_socket_v6(service).await {
+            Ok(entries) => Ok(!entries.contains(&address)),
+
+            Err(err) => {
+                return Err(Error::internal_error(&format!("{err}")));
+            }
+        }
+    }
 }
 
 /// For unimplemented endpoints, indicates whether the resource identified

--- a/nexus/src/app/mod.rs
+++ b/nexus/src/app/mod.rs
@@ -1053,8 +1053,8 @@ impl Nexus {
         })
     }
 
-    /// A [`service`] with [`address`] is considered gone if it is not present
-    /// in a DNS lookup of all addresses for that service.
+    /// A `service` with `address` is considered gone if it is not present in a
+    /// DNS lookup of all addresses for that service.
     async fn is_internal_service_gone(
         &self,
         service: ServiceName,

--- a/nexus/src/app/sagas/common_storage.rs
+++ b/nexus/src/app/sagas/common_storage.rs
@@ -101,12 +101,6 @@ pub(crate) async fn call_pantry_attach_for_disk(
             )))
         })?;
 
-    info!(
-        log,
-        "sending attach for disk {disk_id} volume {} to {pantry_address}",
-        disk.volume_id(),
-    );
-
     call_pantry_attach_for_volume(
         log,
         nexus,
@@ -125,6 +119,8 @@ pub(crate) async fn call_pantry_attach_for_volume(
     pantry_address: SocketAddrV6,
 ) -> Result<(), ActionError> {
     let endpoint = format!("http://{}", pantry_address);
+
+    info!(log, "sending attach request for {attach_id} to {pantry_address}");
 
     let client = crucible_pantry_client::Client::new(&endpoint);
 

--- a/nexus/src/app/sagas/common_storage.rs
+++ b/nexus/src/app/sagas/common_storage.rs
@@ -50,17 +50,16 @@ pub(crate) async fn get_pantry_address(
 // DNS, we can't go back and choose another pantry anyway, so we'll just keep
 // retrying until DNS comes back. All that to say: a failure to resolve DNS is
 // treated as "the pantry is not gone".
-pub(super) async fn is_pantry_gone(
+pub(crate) async fn is_pantry_gone(
     nexus: &Nexus,
     pantry_address: SocketAddrV6,
     log: &Logger,
 ) -> bool {
-    let all_pantry_dns_entries = match nexus
-        .resolver()
-        .lookup_all_socket_v6(ServiceName::CruciblePantry)
+    match nexus
+        .is_internal_service_gone(ServiceName::CruciblePantry, pantry_address)
         .await
     {
-        Ok(entries) => entries,
+        Ok(answer) => answer,
         Err(err) => {
             warn!(
                 log, "Failed to query DNS for Crucible pantry";
@@ -68,8 +67,7 @@ pub(super) async fn is_pantry_gone(
             );
             return false;
         }
-    };
-    !all_pantry_dns_entries.contains(&pantry_address)
+    }
 }
 
 pub(crate) async fn call_pantry_attach_for_disk(
@@ -79,8 +77,6 @@ pub(crate) async fn call_pantry_attach_for_disk(
     disk_id: Uuid,
     pantry_address: SocketAddrV6,
 ) -> Result<(), ActionError> {
-    let endpoint = format!("http://{}", pantry_address);
-
     let (.., disk) = LookupPath::new(opctx, &nexus.datastore())
         .disk_id(disk_id)
         .fetch_for(authz::Action::Modify)
@@ -96,12 +92,6 @@ pub(crate) async fn call_pantry_attach_for_disk(
         .await
         .map_err(ActionError::action_failed)?;
 
-    info!(
-        log,
-        "sending attach for disk {disk_id} volume {} to endpoint {endpoint}",
-        disk.volume_id(),
-    );
-
     let volume_construction_request: VolumeConstructionRequest =
         serde_json::from_str(&disk_volume.data()).map_err(|e| {
             ActionError::action_failed(Error::internal_error(&format!(
@@ -111,14 +101,40 @@ pub(crate) async fn call_pantry_attach_for_disk(
             )))
         })?;
 
+    info!(
+        log,
+        "sending attach for disk {disk_id} volume {} to {pantry_address}",
+        disk.volume_id(),
+    );
+
+    call_pantry_attach_for_volume(
+        log,
+        nexus,
+        disk_id,
+        volume_construction_request,
+        pantry_address,
+    )
+    .await
+}
+
+pub(crate) async fn call_pantry_attach_for_volume(
+    log: &slog::Logger,
+    nexus: &Nexus,
+    attach_id: Uuid,
+    volume_construction_request: VolumeConstructionRequest,
+    pantry_address: SocketAddrV6,
+) -> Result<(), ActionError> {
+    let endpoint = format!("http://{}", pantry_address);
+
     let client = crucible_pantry_client::Client::new(&endpoint);
 
     let attach_request = crucible_pantry_client::types::AttachRequest {
         volume_construction_request,
     };
 
-    let attach_operation =
-        || async { client.attach(&disk_id.to_string(), &attach_request).await };
+    let attach_operation = || async {
+        client.attach(&attach_id.to_string(), &attach_request).await
+    };
     let gone_check =
         || async { Ok(is_pantry_gone(nexus, pantry_address, log).await) };
 
@@ -135,20 +151,20 @@ pub(crate) async fn call_pantry_attach_for_disk(
     Ok(())
 }
 
-pub(crate) async fn call_pantry_detach_for_disk(
+pub(crate) async fn call_pantry_detach(
     nexus: &Nexus,
     log: &slog::Logger,
-    disk_id: Uuid,
+    attach_id: Uuid,
     pantry_address: SocketAddrV6,
 ) -> Result<(), ProgenitorOperationRetryError<CruciblePantryClientError>> {
     let endpoint = format!("http://{}", pantry_address);
 
-    info!(log, "sending detach for disk {disk_id} to endpoint {endpoint}");
+    info!(log, "sending detach for {attach_id} to endpoint {endpoint}");
 
     let client = crucible_pantry_client::Client::new(&endpoint);
 
     let detach_operation =
-        || async { client.detach(&disk_id.to_string()).await };
+        || async { client.detach(&attach_id.to_string()).await };
     let gone_check =
         || async { Ok(is_pantry_gone(nexus, pantry_address, log).await) };
 

--- a/nexus/src/app/sagas/disk_create.rs
+++ b/nexus/src/app/sagas/disk_create.rs
@@ -6,8 +6,7 @@ use super::{
     ACTION_GENERATE_ID, ActionRegistry, NexusActionContext, NexusSaga,
     SagaInitError,
     common_storage::{
-        call_pantry_attach_for_disk, call_pantry_detach_for_disk,
-        get_pantry_address,
+        call_pantry_attach_for_disk, call_pantry_detach, get_pantry_address,
     },
 };
 use crate::app::sagas::declare_saga_actions;
@@ -762,7 +761,7 @@ async fn sdc_call_pantry_attach_for_disk_undo(
 
     let pantry_address = sagactx.lookup::<SocketAddrV6>("pantry_address")?;
 
-    call_pantry_detach_for_disk(
+    call_pantry_detach(
         sagactx.user_data().nexus(),
         &log,
         disk_id,

--- a/nexus/src/app/sagas/finalize_disk.rs
+++ b/nexus/src/app/sagas/finalize_disk.rs
@@ -10,7 +10,7 @@ use super::NexusActionContext;
 use super::NexusSaga;
 use super::SagaInitError;
 use super::declare_saga_actions;
-use crate::app::sagas::common_storage::call_pantry_detach_for_disk;
+use crate::app::sagas::common_storage::call_pantry_detach;
 use crate::app::sagas::snapshot_create;
 use crate::external_api::params;
 use nexus_db_model::Generation;
@@ -287,7 +287,7 @@ async fn sfd_call_pantry_detach_for_disk(
     let params = sagactx.saga_params::<Params>()?;
     let pantry_address = sagactx.lookup::<SocketAddrV6>("pantry_address")?;
 
-    call_pantry_detach_for_disk(
+    call_pantry_detach(
         sagactx.user_data().nexus(),
         &log,
         params.disk_id,

--- a/nexus/src/app/sagas/snapshot_create.rs
+++ b/nexus/src/app/sagas/snapshot_create.rs
@@ -92,8 +92,8 @@ use super::{
     ACTION_GENERATE_ID, ActionRegistry, NexusActionContext, NexusSaga,
     SagaInitError,
     common_storage::{
-        call_pantry_attach_for_disk, call_pantry_detach_for_disk,
-        get_pantry_address, is_pantry_gone,
+        call_pantry_attach_for_disk, call_pantry_detach, get_pantry_address,
+        is_pantry_gone,
     },
 };
 use crate::app::sagas::declare_saga_actions;
@@ -1152,7 +1152,7 @@ async fn ssc_call_pantry_attach_for_disk_undo(
             pantry_address
         );
 
-        match call_pantry_detach_for_disk(
+        match call_pantry_detach(
             sagactx.user_data().nexus(),
             &log,
             params.disk_id,
@@ -1278,7 +1278,7 @@ async fn ssc_call_pantry_detach_for_disk(
             params.disk_id,
             pantry_address
         );
-        call_pantry_detach_for_disk(
+        call_pantry_detach(
             sagactx.user_data().nexus(),
             &log,
             params.disk_id,


### PR DESCRIPTION
Pull the check to see if a service is gone into a generic Nexus function `is_internal_service_gone`, and use that to determine if a Pantry is gone.

Separate the idea of attaching a disk to the pantry from attaching a volume with a new `call_pantry_attach_for_volume` function. This was required for the snapshot export work and was pulled out of that branch.
