### PR TITLE
[xtask] fix recompilations with `cargo xtask clippy`

### DIFF
--- a/dev-tools/xtask/src/clippy.rs
+++ b/dev-tools/xtask/src/clippy.rs
@@ -4,10 +4,9 @@
 
 //! Subcommand: cargo xtask clippy
 
-use crate::common::run_subcmd;
+use crate::common::{cargo_command, run_subcmd};
 use anyhow::Result;
 use clap::Parser;
-use std::process::Command;
 
 #[derive(Parser)]
 pub struct ClippyArgs {
@@ -20,9 +19,7 @@ pub struct ClippyArgs {
 }
 
 pub fn run_cmd(args: ClippyArgs) -> Result<()> {
-    let cargo =
-        std::env::var("CARGO").unwrap_or_else(|_| String::from("cargo"));
-    let mut command = Command::new(&cargo);
+    let mut command = cargo_command();
     command.arg("clippy");
 
     if args.fix {

--- a/dev-tools/xtask/src/common.rs
+++ b/dev-tools/xtask/src/common.rs
@@ -5,7 +5,7 @@
 //! Common xtask command helpers
 
 use anyhow::{Context, Result, bail};
-use std::{process::Command, sync::LazyLock};
+use std::process::Command;
 
 /// Runs the given command, printing some basic debug information around it, and
 /// failing with an error message if the command does not exit successfully
@@ -53,21 +53,21 @@ pub(crate) fn cargo_command() -> Command {
 struct SanitizedEnvVars {
     // At the moment we only ban some prefixes, but we may also want to ban env
     // vars by exact name in the future.
-    prefixes: Vec<&'static str>,
+    prefixes: &'static [&'static str],
 }
 
 impl SanitizedEnvVars {
-    fn new() -> Self {
+    const fn new() -> Self {
         // Remove many of the environment variables set in
         // https://doc.rust-lang.org/cargo/reference/environment-variables.html#environment-variables-cargo-sets-for-build-scripts.
         // This is done to avoid recompilation with crates like ring between
         // `cargo clippy` and `cargo xtask clippy`. (This is really a bug in
-        // Cargo, link to the bug pending it being filed upstream.)
+        // both ring's build script and in Cargo.)
         //
         // The current list is informed by looking at ring's build script, so
         // it's not guaranteed to be exhaustive and it may need to grow over
         // time.
-        let prefixes = vec!["CARGO_PKG_", "CARGO_MANIFEST_", "CARGO_CFG_"];
+        let prefixes = &["CARGO_PKG_", "CARGO_MANIFEST_", "CARGO_CFG_"];
         Self { prefixes }
     }
 
@@ -76,5 +76,4 @@ impl SanitizedEnvVars {
     }
 }
 
-static SANITIZED_ENV_VARS: LazyLock<SanitizedEnvVars> =
-    LazyLock::new(SanitizedEnvVars::new);
+static SANITIZED_ENV_VARS: SanitizedEnvVars = SanitizedEnvVars::new();

--- a/dev-tools/xtask/src/external.rs
+++ b/dev-tools/xtask/src/external.rs
@@ -11,6 +11,8 @@ use std::process::Command;
 use anyhow::{Context, Result};
 use clap::Parser;
 
+use crate::common::cargo_command;
+
 /// Argument parser for external xtasks.
 ///
 /// In general we want all developer tasks to be discoverable simply by running
@@ -72,8 +74,7 @@ impl External {
 }
 
 fn new_command() -> Command {
-    let cargo = std::env::var_os("CARGO").unwrap_or_else(|| "cargo".into());
-    let mut command = Command::new(cargo);
+    let mut command = cargo_command();
     command.arg("run");
     command
 }

--- a/dev-tools/xtask/src/live_tests.rs
+++ b/dev-tools/xtask/src/live_tests.rs
@@ -4,7 +4,7 @@
 
 //! Subcommand: cargo xtask live-tests
 
-use crate::common::run_subcmd;
+use crate::common::{cargo_command, run_subcmd};
 use anyhow::{Context, Result, bail};
 use clap::Parser;
 use std::process::Command;
@@ -45,9 +45,7 @@ pub fn run_cmd(_args: Args) -> Result<()> {
     std::fs::create_dir(&proto_root)
         .with_context(|| format!("mkdir {:?}", &proto_root))?;
 
-    let cargo =
-        std::env::var("CARGO").unwrap_or_else(|_| String::from("cargo"));
-    let mut command = Command::new(&cargo);
+    let mut command = cargo_command();
 
     command.arg("nextest");
     command.arg("archive");

--- a/dev-tools/xtask/src/verify_libraries.rs
+++ b/dev-tools/xtask/src/verify_libraries.rs
@@ -15,6 +15,7 @@ use std::{
 };
 use swrite::{SWrite, swriteln};
 
+use crate::common::cargo_command;
 use crate::load_workspace;
 
 #[derive(Parser)]
@@ -98,8 +99,7 @@ pub fn run_cmd(args: Args) -> Result<()> {
     config_path.push(".cargo/xtask.toml");
     let config = read_xtask_toml(&config_path)?;
 
-    let cargo = std::env::var("CARGO").unwrap_or_else(|_| "cargo".to_string());
-    let mut command = Command::new(cargo);
+    let mut command = cargo_command();
     command.args([
         "build",
         "--bins",

--- a/workspace-hack/build.rs
+++ b/workspace-hack/build.rs
@@ -1,2 +1,4 @@
 // A build script is required for cargo to consider build dependencies.
-fn main() {}
+fn main() {
+    println!("cargo::rerun-if-changed=build.rs");
+}


### PR DESCRIPTION
@davepacheco reported an issue where `cargo check --all-targets && cargo xtask clippy` would cause many recompilations, starting from `ring`. This turned out to be because:

* `cargo xtask`, when run, has `CARGO_MANIFEST_DIR` and other related environment variables set in its environment, but a regular `cargo check` does not
* these variables were being inherited by child Cargo processes
* ring's build script emits a bunch of `cargo:rerun-if-env-changed` instructions for `CARGO_MANIFEST_DIR` etc
* when Cargo determines whether the env has actually changed, it only looks at what it *sees*, not what it *sets* for scripts

To address this, remove a few environment variables from child Cargo processes' environments. I've tested this and it solves this issue, but it isn't a full fix. It's quite possible that we'll have to add the list if we see more recompilations in the future, but at least we know what's going on now.

This is probably a bug in Cargo -- in this determination it should look at what it sets, since that's what build scripts care about.

This is also a bug in ring's build script, I think. Cargo's documentation says in [this section](https://doc.rust-lang.org/cargo/reference/build-scripts.html#rerun-if-env-changed):

> Note that the environment variables here are intended for global environment variables like CC and such, it is not possible to use this for environment variables like TARGET that [Cargo sets for build scripts](https://doc.rust-lang.org/cargo/reference/environment-variables.html#environment-variables-cargo-sets-for-build-scripts). The environment variables in use are those received by cargo invocations, not those received by the executable of the build script.

I've filed https://github.com/ctz/ring/issues/10 for that.

I determined this via logging both of these commands into files and comparing them. Thanks to @mkeeter for the suggestion to use this `CARGO_LOG` variable!

```console
$ CARGO_LOG=cargo::core::compiler::fingerprint=trace cargo clippy --all-targets --workspace
$ CARGO_LOG=cargo::core::compiler::fingerprint=trace cargo xtask clippy
```

---

I also included a `rerun-if-changed` instruction in the workspace-hack's `build.rs` to ensure that that doesn't cause any rebuilds either. (I should probably fix hakari's initialization template to produce this line.)