### PR TITLE
Change names of target_release API methods

### DIFF
--- a/nexus/external-api/output/nexus_tags.txt
+++ b/nexus/external-api/output/nexus_tags.txt
@@ -60,8 +60,8 @@ support_bundle_head_file                 HEAD     /experimental/v1/system/suppor
 support_bundle_index                     GET      /experimental/v1/system/support-bundles/{support_bundle}/index
 support_bundle_list                      GET      /experimental/v1/system/support-bundles
 support_bundle_view                      GET      /experimental/v1/system/support-bundles/{support_bundle}
-target_release_get                       GET      /v1/system/update/target-release
-target_release_set                       PUT      /v1/system/update/target-release
+target_release_update                    PUT      /v1/system/update/target-release
+target_release_view                      GET      /v1/system/update/target-release
 timeseries_query                         POST     /v1/timeseries/query
 
 API operations found with tag "images"

--- a/nexus/external-api/src/lib.rs
+++ b/nexus/external-api/src/lib.rs
@@ -2899,7 +2899,7 @@ pub trait NexusExternalApi {
         path = "/v1/system/update/target-release",
         tags = ["hidden"], // "system/update"
     }]
-    async fn target_release_get(
+    async fn target_release_view(
         rqctx: RequestContext<Self::Context>,
     ) -> Result<HttpResponseOk<views::TargetRelease>, HttpError>;
 
@@ -2913,7 +2913,7 @@ pub trait NexusExternalApi {
         path = "/v1/system/update/target-release",
         tags = ["hidden"], // "system/update"
     }]
-    async fn target_release_set(
+    async fn target_release_update(
         rqctx: RequestContext<Self::Context>,
         params: TypedBody<params::SetTargetReleaseParams>,
     ) -> Result<HttpResponseCreated<views::TargetRelease>, HttpError>;

--- a/nexus/src/external_api/http_entrypoints.rs
+++ b/nexus/src/external_api/http_entrypoints.rs
@@ -6407,7 +6407,7 @@ impl NexusExternalApi for NexusExternalApiImpl {
             .await
     }
 
-    async fn target_release_get(
+    async fn target_release_view(
         rqctx: RequestContext<ApiContext>,
     ) -> Result<HttpResponseOk<views::TargetRelease>, HttpError> {
         let apictx = rqctx.context();
@@ -6431,7 +6431,7 @@ impl NexusExternalApi for NexusExternalApiImpl {
             .await
     }
 
-    async fn target_release_set(
+    async fn target_release_update(
         rqctx: RequestContext<Self::Context>,
         body: TypedBody<params::SetTargetReleaseParams>,
     ) -> Result<HttpResponseCreated<views::TargetRelease>, HttpError> {

--- a/openapi/nexus.json
+++ b/openapi/nexus.json
@@ -10064,7 +10064,7 @@
         ],
         "summary": "Get the current target release of the rack's system software",
         "description": "This may not correspond to the actual software running on the rack at the time of request; it is instead the release that the rack reconfigurator should be moving towards as a goal state. After some number of planning and execution phases, the software running on the rack should eventually correspond to the release described here.",
-        "operationId": "target_release_get",
+        "operationId": "target_release_view",
         "responses": {
           "200": {
             "description": "successful operation",
@@ -10090,7 +10090,7 @@
         ],
         "summary": "Set the current target release of the rack's system software",
         "description": "The rack reconfigurator will treat the software specified here as a goal state for the rack's software, and attempt to asynchronously update to that release.",
-        "operationId": "target_release_set",
+        "operationId": "target_release_update",
         "requestBody": {
           "content": {
             "application/json": {


### PR DESCRIPTION
Use more conventional verbs: "view" & "update" rather than "get" & "set".

Thanks to @ahl for [pointing this out](https://github.com/oxidecomputer/omicron/pull/7518#discussion_r1985392215).