### PR TITLE
sled-agent: enable Hyper-V TSC enlightenment for new VMs

### DIFF
--- a/sled-agent/src/instance.rs
+++ b/sled-agent/src/instance.rs
@@ -969,6 +969,7 @@ impl InstanceRunner {
             types::{
                 BlobStorageBackend, Board, BootOrderEntry, BootSettings,
                 Chipset, ComponentV0, CrucibleStorageBackend,
+                GuestHypervisorInterface, HyperVFeatureFlag,
                 InstanceInitializationMethod, NvmeDisk, QemuPvpanic,
                 ReplacementComponent, SerialPort, SerialPortNumber, VirtioDisk,
                 VirtioNetworkBackend, VirtioNic,
@@ -1175,7 +1176,11 @@ impl InstanceRunner {
                     cpus: self.vcpus,
                     memory_mb: self.memory_mib,
                     cpuid: None,
-                    guest_hv_interface: None,
+                    guest_hv_interface: Some(
+                        GuestHypervisorInterface::HyperV {
+                            features: vec![HyperVFeatureFlag::ReferenceTsc],
+                        },
+                    ),
                 },
                 components: Default::default(),
             };


### PR DESCRIPTION
Modify sled-agent's instance creation logic to enable the Hyper-V enlightenment stack and the reference TSC enlightenment for all newly-started VMs. Enabling this setting globally carries a little bit of risk, in that a badly-behaved guest OS may decide to do something illegal (like write to a read-only Hyper-V MSR) that it would not have done had the enlightenment not been exposed. In practice, however, I don't know of any guest OSes that do this; the feature itself was tested on several Linux and Windows guest OSes while it was in development in the Propolis repo.

Tested by launching a Debian 11 instance in a dev cluster and checking the clocksource reported in sysfs.