### PR TITLE
sled-agent: Better handling of internal DNS gz address and DDM advertisements

### DIFF
--- a/illumos-utils/src/zone.rs
+++ b/illumos-utils/src/zone.rs
@@ -688,6 +688,10 @@ impl Zones {
         Ok(())
     }
 
+    /// Delete an address object.
+    ///
+    /// This method attempts to be idempotent: deleting a nonexistent address
+    /// object returns `Ok(())`.
     #[allow(clippy::needless_lifetimes)]
     pub fn delete_address<'a>(
         zone: Option<&'a str>,

--- a/sled-agent/src/ddm_reconciler.rs
+++ b/sled-agent/src/ddm_reconciler.rs
@@ -86,14 +86,27 @@ impl DdmReconciler {
         });
     }
 
-    pub fn set_internal_dns_subnets(
+    /// Add an internal DNS subset to the set we should be advertising.
+    ///
+    /// This method is idempotent.
+    pub fn add_internal_dns_subnet(
         &self,
-        internal_dns_subnets: BTreeSet<Ipv6Subnet<SLED_PREFIX>>,
+        internal_dns_subnet: Ipv6Subnet<SLED_PREFIX>,
     ) {
         self.prefixes.send_if_modified(|prefixes| {
-            let modified = prefixes.internal_dns != internal_dns_subnets;
-            prefixes.internal_dns = internal_dns_subnets;
-            modified
+            prefixes.internal_dns.insert(internal_dns_subnet)
+        });
+    }
+
+    /// Remove an internal DNS subnet from the set we should be advertising.
+    ///
+    /// This method is idempotent.
+    pub fn remove_internal_dns_subnet(
+        &self,
+        internal_dns_subnet: Ipv6Subnet<SLED_PREFIX>,
+    ) {
+        self.prefixes.send_if_modified(|prefixes| {
+            prefixes.internal_dns.remove(&internal_dns_subnet)
         });
     }
 }

--- a/sled-agent/src/services.rs
+++ b/sled-agent/src/services.rs
@@ -200,7 +200,7 @@ pub enum Error {
     ZoneCleanup {
         zone_name: String,
         #[source]
-        err: illumos_utils::zone::DeleteAddressError,
+        err: Box<illumos_utils::zone::DeleteAddressError>,
     },
 
     #[error("Failed to boot zone: {0}")]
@@ -3754,7 +3754,10 @@ impl ServiceManager {
             )
             .expect("internal DNS address object name is well-formed");
             Zones::delete_address(None, &addrobj).map_err(|err| {
-                Error::ZoneCleanup { zone_name: zone.zone_name(), err }
+                Error::ZoneCleanup {
+                    zone_name: zone.zone_name(),
+                    err: Box::new(err),
+                }
             })?;
 
             self.ddm_reconciler()


### PR DESCRIPTION
Two changes in this PR to fix two closely-related bugs:

* Instead of waiting until after ensuring all zones have been destroyed/started to update the set of internal DNS prefixes we tell DDM to advertise, we now start advertising immediately after creating or deleting the gz address. Fixes #7782.
* When shutting down an internal DNS zone, delete the gz address we created when we started it. Fixes #7785.

I'm spinning this up on a4x2 and will do some testing around internal DNS expungement and addition before merging.