### PR TITLE
omdb: add facility for abandoning a saga

### DIFF
--- a/dev-tools/omdb/tests/usage_errors.out
+++ b/dev-tools/omdb/tests/usage_errors.out
@@ -572,6 +572,7 @@ Usage: omdb db saga [OPTIONS] <COMMAND>
 Commands:
   running       List running sagas
   inject-error  Inject an error into a saga's currently running node(s)
+  abandon       Prevent new Nexus processes from resuming execution of a saga
   help          Print this message or the help of the given subcommand(s)
 
 Options:

--- a/nexus/db-model/src/saga_types.rs
+++ b/nexus/db-model/src/saga_types.rs
@@ -169,6 +169,16 @@ impl_enum_type!(
     Abandoned => b"abandoned"
 );
 
+impl SagaState {
+    /// A saga must be in this set of states to be a candidate for saga
+    /// recovery.
+    ///
+    /// Sagas that are Done don't need to be run anymore. Sagas that are
+    /// Abandoned have been explicitly opted out of being recovered.
+    pub const RECOVERY_CANDIDATE_STATES: &'static [Self] =
+        &[Self::Running, Self::Unwinding];
+}
+
 impl From<steno::SagaCachedState> for SagaState {
     fn from(value: steno::SagaCachedState) -> Self {
         match value {

--- a/nexus/db-model/src/schema_versions.rs
+++ b/nexus/db-model/src/schema_versions.rs
@@ -16,7 +16,7 @@ use std::{collections::BTreeMap, sync::LazyLock};
 ///
 /// This must be updated when you change the database schema.  Refer to
 /// schema/crdb/README.adoc in the root of this repository for details.
-pub const SCHEMA_VERSION: Version = Version::new(137, 0, 0);
+pub const SCHEMA_VERSION: Version = Version::new(138, 0, 0);
 
 /// List of all past database schema versions, in *reverse* order
 ///
@@ -28,6 +28,7 @@ static KNOWN_VERSIONS: LazyLock<Vec<KnownVersion>> = LazyLock::new(|| {
         // |  leaving the first copy as an example for the next person.
         // v
         // KnownVersion::new(next_int, "unique-dirname-with-the-sql-files"),
+        KnownVersion::new(138, "saga-abandoned-state"),
         KnownVersion::new(137, "oximeter-read-policy"),
         KnownVersion::new(136, "do-not-provision-flag-for-crucible-dataset"),
         KnownVersion::new(135, "blueprint-zone-image-source"),

--- a/nexus/db-queries/src/db/datastore/saga.rs
+++ b/nexus/db-queries/src/db/datastore/saga.rs
@@ -312,10 +312,9 @@ mod test {
 
         // The abandoned saga shouldn't show up in the output list.
         assert!(
-            observed_sagas
+            !observed_sagas
                 .iter()
-                .find(|s| s.saga_state == SagaState::Abandoned)
-                .is_none()
+                .any(|s| s.saga_state == SagaState::Abandoned)
         );
 
         // Remove the abandoned saga from the inserted set so that it can be

--- a/nexus/db-queries/src/db/sec_store.rs
+++ b/nexus/db-queries/src/db/sec_store.rs
@@ -102,7 +102,7 @@ impl steno::SecStore for CockroachDbSecStore {
             &log,
             || {
                 self.datastore
-                    .saga_update_state(id, update, self.sec_id)
+                    .saga_update_state(id, update.into(), self.sec_id)
                     .map_err(backoff::BackoffError::transient)
             },
             "updating saga state",

--- a/nexus/db-schema/src/enums.rs
+++ b/nexus/db-schema/src/enums.rs
@@ -61,7 +61,7 @@ define_enums! {
     RotImageErrorEnum => "rot_image_error",
     RotPageWhichEnum => "root_of_trust_page_which",
     RouterRouteKindEnum => "router_route_kind",
-    SagaCachedStateEnum => "saga_state",
+    SagaStateEnum => "saga_state",
     ServiceKindEnum => "service_kind",
     SledPolicyEnum => "sled_policy",
     SledRoleEnum => "sled_role",

--- a/nexus/db-schema/src/schema.rs
+++ b/nexus/db-schema/src/schema.rs
@@ -879,7 +879,7 @@ table! {
         time_created -> Timestamptz,
         name -> Text,
         saga_dag -> Jsonb,
-        saga_state -> crate::enums::SagaCachedStateEnum,
+        saga_state -> crate::enums::SagaStateEnum,
         current_sec -> Nullable<Uuid>,
         adopt_generation -> Int8,
         adopt_time -> Timestamptz,

--- a/schema/crdb/dbinit.sql
+++ b/schema/crdb/dbinit.sql
@@ -2295,7 +2295,8 @@ WHERE
 CREATE TYPE IF NOT EXISTS omicron.public.saga_state AS ENUM (
     'running',
     'unwinding',
-    'done'
+    'done',
+    'abandoned'
 );
 
 
@@ -5097,7 +5098,7 @@ INSERT INTO omicron.public.db_metadata (
     version,
     target_version
 ) VALUES
-    (TRUE, NOW(), NOW(), '137.0.0', NULL)
+    (TRUE, NOW(), NOW(), '138.0.0', NULL)
 ON CONFLICT DO NOTHING;
 
 COMMIT;

--- a/schema/crdb/saga-abandoned-state/up.sql
+++ b/schema/crdb/saga-abandoned-state/up.sql
@@ -1,0 +1,1 @@
+ALTER TYPE omicron.public.saga_state ADD VALUE IF NOT EXISTS 'abandoned' after 'done';


### PR DESCRIPTION
Add an `Abandoned` saga state. This state disqualifies a saga from being picked up by Nexus saga recovery. (A running saga will continue running if it is Abandoned, and continued saga execution may end up clobbering the Abandoned state entirely.) Add an `omdb` subcommand to move a saga to this state (and refactor a bit to avoid duplicating code with the `inject-error` subcommand).

Tested (so far) by:

- amending the datastore test that lists candidates for saga recovery
- starting a demo saga in a dev cluster and verifying (via Nexus logs) that the saga is normally recovered when its Nexus is restarted (via `svcadm restart`), but is no longer recovered once abandoned (and can't be completed anymore); if I manually move the saga back to Running and restart its SEC again, the saga is picked up normally.

Fixes #7730.