### PR TITLE
sled-agent: Avoid `PUT /omicron-config` getting wedged by `StorageResources`

### DIFF
--- a/sled-storage/src/manager.rs
+++ b/sled-storage/src/manager.rs
@@ -1054,7 +1054,8 @@ impl StorageManager {
             }
         }
 
-        let mountpoint_root = &self.resources.disks().mount_config().root;
+        let disks = self.resources.disks();
+        let mountpoint_root = &disks.mount_config().root;
         let mountpoint_path = config.name.mountpoint(mountpoint_root);
         let details = DatasetCreationDetails {
             zoned: config.name.kind().zoned(),

--- a/sled-storage/src/resources.rs
+++ b/sled-storage/src/resources.rs
@@ -19,7 +19,7 @@ use omicron_common::disk::{
     OmicronPhysicalDisksConfig,
 };
 use sled_hardware::DiskFirmware;
-use slog::{error, info, o, warn, Logger};
+use slog::{Logger, error, info, o, warn};
 use std::collections::BTreeMap;
 use std::sync::Arc;
 use tokio::sync::watch;


### PR DESCRIPTION
This isn't a very big PR, but I'm not super familiar or comfortable with the pieces surrounding these changes, so please review carefully. Rationale for these changes follow.

---

In both #7622 and https://github.com/oxidecomputer/omicron/pull/7788#issuecomment-2721476490, we see `omicron_physical_disks_ensure` get stuck (apparently indefinitely) here: https://github.com/oxidecomputer/omicron/blob/3802ae4736a26b25b66be028c0a2217f6428a722/sled-agent/src/sled_agent.rs#L927-L930

I believe this can happen when there's a generation number change to the disks config but the corresponding execution of `StorageResources::synchronize_disk_management()` does not set `updated` to true, which means it [will not send the new disk config on the `disks_updated` channel](https://github.com/oxidecomputer/omicron/blob/3802ae4736a26b25b66be028c0a2217f6428a722/sled-storage/src/resources.rs#L403-L405). This leaves `StorageMonitor::await_generation()` stuck [waiting for an update that is never coming](https://github.com/oxidecomputer/omicron/blob/8222b27e850d2c3adc496222a317fe5ff96d1289/sled-agent/src/storage_monitor.rs#L59-L64).

Both of the above issues are examples of such paths:

1. In #7622, if the new config removes a disk that is physically not present, we [do not set `updated` to true](https://github.com/oxidecomputer/omicron/blob/3802ae4736a26b25b66be028c0a2217f6428a722/sled-storage/src/resources.rs#L331-L340).
2. In https://github.com/oxidecomputer/omicron/pull/7788#issuecomment-2721476490, if the generation is increased but there have been no changes to the disk config, we never set `updated` to true.

I think there are two design choices in `StorageResources` that make this difficult to reason about, and this PR attempts to address them both.

1. `StorageResources` holds both [`disks: AllDisks` and `disk_updates: watch::Sender<AllDisks>`](https://github.com/oxidecomputer/omicron/blob/3802ae4736a26b25b66be028c0a2217f6428a722/sled-storage/src/resources.rs#L221-L231), and allows them to diverge at times and has to choose when to sync them back up. This PR removes `disk_updates` and changes `disks` to be the `watch::Sender<AllDisks>`, removing the possibility of us having two different `AllDisks` that have diverged in contents. (We still have to make local clones of the `AllDisks` via `Arc::make_mut()`, so we temporarily have multiple copies that intentionally diverge, but they're local and dropped when the methods return.) I tried to make it so we didn't need to keep track of `updated` manually.
2. `StorageResources::set_config()` [updates the generation held inside `self.disks`](https://github.com/oxidecomputer/omicron/blob/3802ae4736a26b25b66be028c0a2217f6428a722/sled-storage/src/resources.rs#L274), but neither sends that information along the `disk_updates` channel nor informs `synchronize_disk_resources` that the generation has changed. This seems particularly dicey: after `set_config` returns, we've increased the generation inside `self.disks` but have not actually acted on the new config from that generation, so inspecting `self.disks` at that point would be very confusing. This PR changes `set_config` to record the generation "on the side" (i.e., not updating the generation inside `self.disks`), and defers updating the generation inside `self.disks` to `synchronize_disk_resources`.

I tested this on a4x2 by manually performing a "spurious disk config generation bump", and confirmed sled-agent did not get wedged as it does on `main`.

---

Fixes #7622.