### PR TITLE
Document why we use `BlueprintZoneDisposition::any` for clickhouse exec

### DIFF
--- a/nexus/reconfigurator/execution/src/clickhouse.rs
+++ b/nexus/reconfigurator/execution/src/clickhouse.rs
@@ -45,6 +45,33 @@ pub(crate) async fn deploy_nodes(
     blueprint: &Blueprint,
     clickhouse_cluster_config: &ClickhouseClusterConfig,
 ) -> Result<(), Vec<anyhow::Error>> {
+    // Important: We must continue to pass in `BlueprintZoneDisposition::any`
+    // here, instead of `BlueprintZoneDisposition::is_in_service`, as would
+    // be expected.
+    //
+    // We can only add or remove one clickhouse keeper node at a time,
+    // and the planner generates the `ClickhouseClusterConfig` under this
+    // assumption. Unfortunately the `ClickhouseClusterConfig` only tracks
+    // the zone id -> keeper id mapping, and the executor does the zone to
+    // IP lookup in the `keeper_configs` function below. If two zones were
+    // expunged simultaneously (in the same planner round) and they both
+    // contained clickhouse keepers, only one would be removed from the
+    // `ClickhouseClusterConfig`. If we then only tried to lookup zone IPs based
+    // on in-service zones in `keeper_configs` below, we'd fail to find an ip
+    // for a given keeper id and execution would fail.
+    //
+    // This code is correct right now because we never remove any expunged zones
+    // from a blueprint. As soon as we start garbage collecting these zones
+    // however, we'll run into same problem where there won't be a matching zone
+    // with an IP that we can use. We can fix that in one of two ways:
+    //
+    // 1. Change the planner to put the ip address inside the
+    //    `ClickhouseClusterConfig`.
+    // 2. Gate the removal of zones from blueprints on the zone id
+    //    not being used elsewhere in the blueprint, like, say, the
+    //    `ClickhouseClusterConfig`.
+    //
+    // This is tracked in https://github.com/oxidecomputer/omicron/issues/7724
     deploy_nodes_impl(
         opctx,
         blueprint.all_omicron_zones(BlueprintZoneDisposition::any),

--- a/nexus/reconfigurator/planning/src/blueprint_builder/clickhouse.rs
+++ b/nexus/reconfigurator/planning/src/blueprint_builder/clickhouse.rs
@@ -17,10 +17,6 @@ use thiserror::Error;
 
 // The set of clickhouse server and keeper zones that should be running as
 // constructed by the `BlueprintBuilder` in the current planning iteration.
-//
-// Will be removed once the planner starts using this code
-// See: https://github.com/oxidecomputer/omicron/issues/6577
-#[allow(unused)]
 pub struct ClickhouseZonesThatShouldBeRunning {
     pub keepers: BTreeSet<OmicronZoneUuid>,
     pub servers: BTreeSet<OmicronZoneUuid>,
@@ -56,10 +52,6 @@ impl ClickhouseZonesThatShouldBeRunning {
 ///
 /// This is to be used as part of the `BlueprintBuilder` after zones have been
 /// allocated.
-//
-// Will be removed once the planner starts using this code
-// See: https://github.com/oxidecomputer/omicron/issues/6577
-#[allow(unused)]
 pub struct ClickhouseAllocator {
     log: Logger,
     parent_config: ClickhouseClusterConfig,
@@ -68,19 +60,12 @@ pub struct ClickhouseAllocator {
 }
 
 /// Errors encountered when trying to plan keeper deployments
-//
-// Will be removed once the planner starts using this code
-// See: https://github.com/oxidecomputer/omicron/issues/6577
-#[allow(unused)]
 #[derive(Debug, Error)]
 pub enum KeeperAllocationError {
     #[error("cannot add more than one keeper at a time: {added_keepers:?}")]
     BadMembershipChange { added_keepers: BTreeSet<KeeperId> },
 }
 
-// Will be removed once the planner starts using this code
-// https://github.com/oxidecomputer/omicron/issues/6577
-#[allow(unused)]
 impl ClickhouseAllocator {
     pub fn new(
         log: Logger,


### PR DESCRIPTION
This documents why #7724 remains open. It still needs to be fixed one way or the other.

Also, remove some stale references to a closed issue.