### PR TITLE
[nexus-config] use `pretty_assertions` in tests

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5774,6 +5774,7 @@ dependencies = [
  "omicron-common",
  "omicron-uuid-kinds",
  "omicron-workspace-hack",
+ "pretty_assertions",
  "schemars",
  "serde",
  "serde_json",

--- a/nexus-config/Cargo.toml
+++ b/nexus-config/Cargo.toml
@@ -24,3 +24,4 @@ uuid.workspace = true
 expectorate.workspace = true
 libc.workspace = true
 serde_json.workspace = true
+pretty_assertions.workspace = true

--- a/nexus-config/src/nexus_config.rs
+++ b/nexus-config/src/nexus_config.rs
@@ -830,6 +830,7 @@ mod test {
     use dropshot::ConfigLogging;
     use dropshot::ConfigLoggingIfExists;
     use dropshot::ConfigLoggingLevel;
+    use pretty_assertions::assert_eq;
     use std::collections::HashMap;
     use std::fs;
     use std::net::{Ipv6Addr, SocketAddr, SocketAddrV6};


### PR DESCRIPTION
Currently, assertion failures from the `nexus-config` tests are pretty hard to interpret. When we assert a parsed config matches the expected config, we use `assert_eq!`, which uses the default `fmt::Debug` formatter. As the config types are quite complex, this spits out a huge amount of text, and it's all on one line. the differences between the actual and expected onfig are pretty hard to find. For example, see [this failure on Buildomat][1].

This commit changes these tests to use the `pretty_assertions` crate's `assert_eq!` macro, which formats the difference between the actual and expected values as a diff, highlighting what didn't match. I also considered using `daft` to diff these values, but `pretty_assertions` is already in our dep tree, and didn't require any additional code outside of the tests (where `daft` would require deriving stuff for the config types). For this use case, the simple textual diff seems sufficient.

<details>
<summary>Example failure *before* this change</summary>

```
thread 'nexus_config::test::test_valid' panicked at nexus-config/src/nexus_config.rs:1077:9:
assertion `left == right` failed
  left: NexusConfig { pkg: PackageConfig { console: ConsoleConfig { static_dir: "tests/static", session_idle_timeout_minutes: 60, session_absolute_timeout_minutes: 480 }, log: File { level: Debug, path: "/nonexistent/path", if_exists: Fail }, authn: AuthnConfig { schemes_external: [] }, timeseries_db: TimeseriesDbConfig { address: Some([::1]:9000) }, updates: Some(UpdatesConfig { trusted_root: "/path/to/root.json" }), schema: None, tunables: Tunables { max_vpc_ipv4_subnet_prefix: 27, load_timeout: None }, dendrite: {Switch0: DpdConfig { address: [::1]:12224 }}, mgd: {Switch0: MgdConfig { address: [::1]:4676 }}, background_tasks: BackgroundTaskConfig { dns_internal: DnsTasksConfig { period_secs_config: 1s, period_secs_servers: 2s, period_secs_propagation: 3s, max_concurrent_server_updates: 4 }, dns_external: DnsTasksConfig { period_secs_config: 5s, period_secs_servers: 6s, period_secs_propagation: 7s, max_concurrent_server_updates: 8 }, metrics_producer_gc: MetricsProducerGcConfig { period_secs: 60s }, external_endpoints: ExternalEndpointsConfig { period_secs: 9s }, nat_cleanup: NatCleanupConfig { period_secs: 30s }, inventory: InventoryConfig { period_secs: 10s, nkeep: 11, disable: false }, support_bundle_collector: SupportBundleCollectorConfig { period_secs: 30s, disable: false }, physical_disk_adoption: PhysicalDiskAdoptionConfig { period_secs: 30s, disable: false }, decommissioned_disk_cleaner: DecommissionedDiskCleanerConfig { period_secs: 30s, disable: false }, phantom_disks: PhantomDiskConfig { period_secs: 30s }, blueprints: BlueprintTasksConfig { period_secs_load: 10s, period_secs_execute: 60s, period_secs_rendezvous: 300s, period_secs_collect_crdb_node_ids: 180s }, sync_service_zone_nat: SyncServiceZoneNatConfig { period_secs: 30s }, bfd_manager: BfdManagerConfig { period_secs: 30s }, switch_port_settings_manager: SwitchPortSettingsManagerConfig { period_secs: 30s }, region_replacement: RegionReplacementConfig { period_secs: 30s }, region_replacement_driver: RegionReplacementDriverConfig { period_secs: 30s }, instance_watcher: InstanceWatcherConfig { period_secs: 30s }, instance_updater: InstanceUpdaterConfig { period_secs: 30s, disable: false }, instance_reincarnation: InstanceReincarnationConfig { period_secs: 67s, disable: false }, service_firewall_propagation: ServiceFirewallPropagationConfig { period_secs: 300s }, v2p_mapping_propagation: V2PMappingPropagationConfig { period_secs: 30s }, abandoned_vmm_reaper: AbandonedVmmReaperConfig { period_secs: 60s }, saga_recovery: SagaRecoveryConfig { period_secs: 60s }, lookup_region_port: LookupRegionPortConfig { period_secs: 60s }, region_snapshot_replacement_start: RegionSnapshotReplacementStartConfig { period_secs: 30s }, region_snapshot_replacement_garbage_collection: RegionSnapshotReplacementGarbageCollectionConfig { period_secs: 30s }, region_snapshot_replacement_step: RegionSnapshotReplacementStepConfig { period_secs: 30s }, region_snapshot_replacement_finish: RegionSnapshotReplacementFinishConfig { period_secs: 30s }, tuf_artifact_replication: TufArtifactReplicationConfig { period_secs: 300s, min_sled_replication: 3 }, read_only_region_replacement_start: ReadOnlyRegionReplacementStartConfig { period_secs: 30s }, webhook_dispatcher: WebhookDispatcherConfig { period_secs: 42s }, webhook_deliverator: WebhookDeliveratorConfig { period_secs: 43s, lease_timeout_secs: 44, first_retry_backoff_secs: 45, second_retry_backoff_secs: 45 } }, default_region_allocation_strategy: Random { seed: Some(0) } }, deployment: DeploymentConfig { id: 28b90dc4-c22a-65ba-f49a-f051fe01208f (service), rack_id: 38b90dc4-c22a-65ba-f49a-f051fe01208f, techport_external_server_port: 12228, dropshot_external: ConfigDropshotWithTls { dropshot: ConfigDropshot { bind_address: 10.1.2.3:4567, default_request_body_max_bytes: 1024, default_handler_task_mode: Detached, log_headers: [] }, tls: false }, dropshot_internal: ConfigDropshot { bind_address: 10.1.2.3:4568, default_request_body_max_bytes: 1024, default_handler_task_mode: Detached, log_headers: [] }, internal_dns: FromSubnet { subnet: Ipv6Subnet { net: Ipv6Net { addr: ::, width: 56 } } }, database: FromDns, external_dns_servers: [1.1.1.1, 9.9.9.9] } }
 right: NexusConfig { pkg: PackageConfig { console: ConsoleConfig { static_dir: "tests/static", session_idle_timeout_minutes: 60, session_absolute_timeout_minutes: 480 }, log: File { level: Debug, path: "/nonexistent/path", if_exists: Fail }, authn: AuthnConfig { schemes_external: [] }, timeseries_db: TimeseriesDbConfig { address: Some([::1]:9000) }, updates: Some(UpdatesConfig { trusted_root: "/path/to/root.json" }), schema: None, tunables: Tunables { max_vpc_ipv4_subnet_prefix: 27, load_timeout: None }, dendrite: {Switch0: DpdConfig { address: [::1]:12224 }}, mgd: {Switch0: MgdConfig { address: [::1]:4676 }}, background_tasks: BackgroundTaskConfig { dns_internal: DnsTasksConfig { period_secs_config: 1s, period_secs_servers: 2s, period_secs_propagation: 3s, max_concurrent_server_updates: 4 }, dns_external: DnsTasksConfig { period_secs_config: 5s, period_secs_servers: 6s, period_secs_propagation: 7s, max_concurrent_server_updates: 8 }, metrics_producer_gc: MetricsProducerGcConfig { period_secs: 60s }, external_endpoints: ExternalEndpointsConfig { period_secs: 9s }, nat_cleanup: NatCleanupConfig { period_secs: 30s }, inventory: InventoryConfig { period_secs: 10s, nkeep: 11, disable: false }, support_bundle_collector: SupportBundleCollectorConfig { period_secs: 30s, disable: false }, physical_disk_adoption: PhysicalDiskAdoptionConfig { period_secs: 30s, disable: false }, decommissioned_disk_cleaner: DecommissionedDiskCleanerConfig { period_secs: 30s, disable: false }, phantom_disks: PhantomDiskConfig { period_secs: 30s }, blueprints: BlueprintTasksConfig { period_secs_load: 10s, period_secs_execute: 60s, period_secs_rendezvous: 300s, period_secs_collect_crdb_node_ids: 180s }, sync_service_zone_nat: SyncServiceZoneNatConfig { period_secs: 30s }, bfd_manager: BfdManagerConfig { period_secs: 30s }, switch_port_settings_manager: SwitchPortSettingsManagerConfig { period_secs: 30s }, region_replacement: RegionReplacementConfig { period_secs: 30s }, region_replacement_driver: RegionReplacementDriverConfig { period_secs: 30s }, instance_watcher: InstanceWatcherConfig { period_secs: 30s }, instance_updater: InstanceUpdaterConfig { period_secs: 30s, disable: false }, instance_reincarnation: InstanceReincarnationConfig { period_secs: 67s, disable: false }, service_firewall_propagation: ServiceFirewallPropagationConfig { period_secs: 300s }, v2p_mapping_propagation: V2PMappingPropagationConfig { period_secs: 30s }, abandoned_vmm_reaper: AbandonedVmmReaperConfig { period_secs: 60s }, saga_recovery: SagaRecoveryConfig { period_secs: 60s }, lookup_region_port: LookupRegionPortConfig { period_secs: 60s }, region_snapshot_replacement_start: RegionSnapshotReplacementStartConfig { period_secs: 30s }, region_snapshot_replacement_garbage_collection: RegionSnapshotReplacementGarbageCollectionConfig { period_secs: 30s }, region_snapshot_replacement_step: RegionSnapshotReplacementStepConfig { period_secs: 30s }, region_snapshot_replacement_finish: RegionSnapshotReplacementFinishConfig { period_secs: 30s }, tuf_artifact_replication: TufArtifactReplicationConfig { period_secs: 300s, min_sled_replication: 3 }, read_only_region_replacement_start: ReadOnlyRegionReplacementStartConfig { period_secs: 30s }, webhook_dispatcher: WebhookDispatcherConfig { period_secs: 42s }, webhook_deliverator: WebhookDeliveratorConfig { period_secs: 43s, lease_timeout_secs: 44, first_retry_backoff_secs: 45, second_retry_backoff_secs: 46 } }, default_region_allocation_strategy: Random { seed: Some(0) } }, deployment: DeploymentConfig { id: 28b90dc4-c22a-65ba-f49a-f051fe01208f (service), rack_id: 38b90dc4-c22a-65ba-f49a-f051fe01208f, techport_external_server_port: 12228, dropshot_external: ConfigDropshotWithTls { dropshot: ConfigDropshot { bind_address: 10.1.2.3:4567, default_request_body_max_bytes: 1024, default_handler_task_mode: Detached, log_headers: [] }, tls: false }, dropshot_internal: ConfigDropshot { bind_address: 10.1.2.3:4568, default_request_body_max_bytes: 1024, default_handler_task_mode: Detached, log_headers: [] }, internal_dns: FromSubnet { subnet: Ipv6Subnet { net: Ipv6Net { addr: ::, width: 56 } } }, database: FromDns, external_dns_servers: [1.1.1.1, 9.9.9.9] } }
```

</details>

<details>
<summary>Example failure *after* this change</summary>

Although ANSI colors aren't visible here, note the `<` and `>` symbols to indicate the lines that differ.

```
thread 'nexus_config::test::test_valid' panicked at nexus-config/src/nexus_config.rs:1078:9:
assertion failed: `(left == right)`

Diff < left / right > :
 NexusConfig {
     pkg: PackageConfig {
         console: ConsoleConfig {
             static_dir: "tests/static",
             session_idle_timeout_minutes: 60,
             session_absolute_timeout_minutes: 480,
         },
         log: File {
             level: Debug,
             path: "/nonexistent/path",
             if_exists: Fail,
         },
         authn: AuthnConfig {
             schemes_external: [],
         },
         timeseries_db: TimeseriesDbConfig {
             address: Some(
                 [::1]:9000,
             ),
         },
         updates: Some(
             UpdatesConfig {
                 trusted_root: "/path/to/root.json",
             },
         ),
         schema: None,
         tunables: Tunables {
             max_vpc_ipv4_subnet_prefix: 27,
             load_timeout: None,
         },
         dendrite: {
             Switch0: DpdConfig {
                 address: [::1]:12224,
             },
         },
         mgd: {
             Switch0: MgdConfig {
                 address: [::1]:4676,
             },
         },
         background_tasks: BackgroundTaskConfig {
             dns_internal: DnsTasksConfig {
                 period_secs_config: 1s,
                 period_secs_servers: 2s,
                 period_secs_propagation: 3s,
                 max_concurrent_server_updates: 4,
             },
             dns_external: DnsTasksConfig {
                 period_secs_config: 5s,
                 period_secs_servers: 6s,
                 period_secs_propagation: 7s,
                 max_concurrent_server_updates: 8,
             },
             metrics_producer_gc: MetricsProducerGcConfig {
                 period_secs: 60s,
             },
             external_endpoints: ExternalEndpointsConfig {
                 period_secs: 9s,
             },
             nat_cleanup: NatCleanupConfig {
                 period_secs: 30s,
             },
             inventory: InventoryConfig {
                 period_secs: 10s,
                 nkeep: 11,
                 disable: false,
             },
             support_bundle_collector: SupportBundleCollectorConfig {
                 period_secs: 30s,
                 disable: false,
             },
             physical_disk_adoption: PhysicalDiskAdoptionConfig {
                 period_secs: 30s,
                 disable: false,
             },
             decommissioned_disk_cleaner: DecommissionedDiskCleanerConfig {
                 period_secs: 30s,
                 disable: false,
             },
             phantom_disks: PhantomDiskConfig {
                 period_secs: 30s,
             },
             blueprints: BlueprintTasksConfig {
                 period_secs_load: 10s,
                 period_secs_execute: 60s,
                 period_secs_rendezvous: 300s,
                 period_secs_collect_crdb_node_ids: 180s,
             },
             sync_service_zone_nat: SyncServiceZoneNatConfig {
                 period_secs: 30s,
             },
             bfd_manager: BfdManagerConfig {
                 period_secs: 30s,
             },
             switch_port_settings_manager: SwitchPortSettingsManagerConfig {
                 period_secs: 30s,
             },
             region_replacement: RegionReplacementConfig {
                 period_secs: 30s,
             },
             region_replacement_driver: RegionReplacementDriverConfig {
                 period_secs: 30s,
             },
             instance_watcher: InstanceWatcherConfig {
                 period_secs: 30s,
             },
             instance_updater: InstanceUpdaterConfig {
                 period_secs: 30s,
                 disable: false,
             },
             instance_reincarnation: InstanceReincarnationConfig {
                 period_secs: 67s,
                 disable: false,
             },
             service_firewall_propagation: ServiceFirewallPropagationConfig {
                 period_secs: 300s,
             },
             v2p_mapping_propagation: V2PMappingPropagationConfig {
                 period_secs: 30s,
             },
             abandoned_vmm_reaper: AbandonedVmmReaperConfig {
                 period_secs: 60s,
             },
             saga_recovery: SagaRecoveryConfig {
                 period_secs: 60s,
             },
             lookup_region_port: LookupRegionPortConfig {
                 period_secs: 60s,
             },
             region_snapshot_replacement_start: RegionSnapshotReplacementStartConfig {
                 period_secs: 30s,
             },
             region_snapshot_replacement_garbage_collection: RegionSnapshotReplacementGarbageCollectionConfig {
                 period_secs: 30s,
             },
             region_snapshot_replacement_step: RegionSnapshotReplacementStepConfig {
                 period_secs: 30s,
             },
             region_snapshot_replacement_finish: RegionSnapshotReplacementFinishConfig {
                 period_secs: 30s,
             },
             tuf_artifact_replication: TufArtifactReplicationConfig {
                 period_secs: 300s,
                 min_sled_replication: 3,
             },
             read_only_region_replacement_start: ReadOnlyRegionReplacementStartConfig {
                 period_secs: 30s,
             },
             webhook_dispatcher: WebhookDispatcherConfig {
                 period_secs: 42s,
             },
             webhook_deliverator: WebhookDeliveratorConfig {
                 period_secs: 43s,
                 lease_timeout_secs: 44,
                 first_retry_backoff_secs: 45,
<                second_retry_backoff_secs: 45,
>                second_retry_backoff_secs: 46,
             },
         },
         default_region_allocation_strategy: Random {
             seed: Some(
                 0,
             ),
         },
     },
     deployment: DeploymentConfig {
         id: 28b90dc4-c22a-65ba-f49a-f051fe01208f (service),
         rack_id: 38b90dc4-c22a-65ba-f49a-f051fe01208f,
         techport_external_server_port: 12228,
         dropshot_external: ConfigDropshotWithTls {
             dropshot: ConfigDropshot {
                 bind_address: 10.1.2.3:4567,
                 default_request_body_max_bytes: 1024,
                 default_handler_task_mode: Detached,
                 log_headers: [],
             },
             tls: false,
         },
         dropshot_internal: ConfigDropshot {
             bind_address: 10.1.2.3:4568,
             default_request_body_max_bytes: 1024,
             default_handler_task_mode: Detached,
             log_headers: [],
         },
         internal_dns: FromSubnet {
             subnet: Ipv6Subnet {
                 net: Ipv6Net {
                     addr: ::,
                     width: 56,
                 },
             },
         },
         database: FromDns,
         external_dns_servers: [
             1.1.1.1,
             9.9.9.9,
         ],
     },
 }
```

</details>

[1]: https://buildomat.eng.oxide.computer/wg/0/details/01JP8BHQ5Z41DPB6GEK4D2K3N9/PhIpT14ekjFiDaHBPM5hDzWVhYr53VTLUXpaAAs6veI1rUJh/01JP8BJ6EZH8RRE1V27DGK7DDG#S6106