### PR TITLE
drop "qtop" feature from qorb

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -7591,7 +7591,6 @@ dependencies = [
  "postgres-types",
  "predicates",
  "proc-macro2",
- "qorb",
  "quote",
  "rand 0.8.5",
  "regex",
@@ -9396,17 +9395,13 @@ dependencies = [
  "async-trait",
  "debug-ignore",
  "derive-where",
- "dropshot 0.12.0",
  "futures",
  "hickory-resolver",
  "rand 0.8.5",
- "schemars",
  "serde",
- "serde_json",
  "thiserror 1.0.69",
  "tokio",
  "tokio-stream",
- "tokio-tungstenite 0.24.0",
  "tracing",
  "usdt",
 ]
@@ -12299,18 +12294,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "tokio-tungstenite"
-version = "0.24.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "edc5f74e248dc973e0dbb7b74c7e0d6fcc301c694ff50049504004ef4d0cdcd9"
-dependencies = [
- "futures-util",
- "log",
- "tokio",
- "tungstenite 0.24.0",
-]
-
-[[package]]
 name = "tokio-util"
 version = "0.7.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -12685,24 +12668,6 @@ name = "tungstenite"
 version = "0.23.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6e2e2ce1e47ed2994fd43b04c8f618008d4cabdd5ee34027cf14f9d918edd9c8"
-dependencies = [
- "byteorder",
- "bytes",
- "data-encoding",
- "http",
- "httparse",
- "log",
- "rand 0.8.5",
- "sha1",
- "thiserror 1.0.69",
- "utf-8",
-]
-
-[[package]]
-name = "tungstenite"
-version = "0.24.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "18e5b8366ee7a95b16d32197d0b2604b43a0be89dc5fac9f8e96ccafbaedda8a"
 dependencies = [
  "byteorder",
  "bytes",

--- a/nexus/db-queries/Cargo.toml
+++ b/nexus/db-queries/Cargo.toml
@@ -32,7 +32,7 @@ oxnet.workspace = true
 paste.workspace = true
 # See omicron-rpaths for more about the "pq-sys" dependency.
 pq-sys = "*"
-qorb = { workspace = true, features = [ "qtop" ] }
+qorb.workspace = true
 rand.workspace = true
 ref-cast.workspace = true
 schemars.workspace = true

--- a/workspace-hack/Cargo.toml
+++ b/workspace-hack/Cargo.toml
@@ -96,7 +96,6 @@ pkcs8 = { version = "0.10.2", default-features = false, features = ["encryption"
 postgres-types = { version = "0.2.9", default-features = false, features = ["with-chrono-0_4", "with-serde_json-1", "with-uuid-1"] }
 predicates = { version = "3.1.3" }
 proc-macro2 = { version = "1.0.94" }
-qorb = { version = "0.2.1", features = ["qtop"] }
 quote = { version = "1.0.39" }
 rand = { version = "0.8.5", features = ["small_rng"] }
 regex = { version = "1.11.1" }
@@ -219,7 +218,6 @@ pkcs8 = { version = "0.10.2", default-features = false, features = ["encryption"
 postgres-types = { version = "0.2.9", default-features = false, features = ["with-chrono-0_4", "with-serde_json-1", "with-uuid-1"] }
 predicates = { version = "3.1.3" }
 proc-macro2 = { version = "1.0.94" }
-qorb = { version = "0.2.1", features = ["qtop"] }
 quote = { version = "1.0.39" }
 rand = { version = "0.8.5", features = ["small_rng"] }
 regex = { version = "1.11.1" }


### PR DESCRIPTION
We don't seem to be using these functions in nexus-db-queries.

This removes one of the dropshot 0.12.0 dependency paths in Omicron.