### PR TITLE
id-map: downgrade to 2021 edition

### DIFF
--- a/id-map/Cargo.toml
+++ b/id-map/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "id-map"
 version = "0.1.0"
-edition = "2024"
+edition = "2021"
 license = "MPL-2.0"
 
 [dependencies]


### PR DESCRIPTION
As discussed in chat -- this seems accidental. Thanks `cargo new`!