### PR TITLE
More omdb improvements

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -7203,6 +7203,7 @@ dependencies = [
  "omicron-workspace-hack",
  "oximeter-client",
  "oximeter-db",
+ "oxnet",
  "petgraph 0.7.1",
  "pq-sys",
  "ratatui",

--- a/dev-tools/omdb/Cargo.toml
+++ b/dev-tools/omdb/Cargo.toml
@@ -66,6 +66,7 @@ omicron-workspace-hack.workspace = true
 multimap.workspace = true
 indicatif.workspace = true
 petgraph.workspace = true
+oxnet.workspace = true
 
 [dev-dependencies]
 camino-tempfile.workspace = true

--- a/dev-tools/omdb/src/bin/omdb/db.rs
+++ b/dev-tools/omdb/src/bin/omdb/db.rs
@@ -886,9 +886,12 @@ struct VolumeReferenceArgs {
     #[clap(long, conflicts_with_all = ["ip", "net", "region_snapshot"])]
     read_only_region: Option<Uuid>,
 
-    /// Provide dataset, region, and snapshot ID in a string, delimited by
-    /// spaces.
-    #[clap(long, conflicts_with_all = ["ip", "net", "read_only_region"], value_delimiter = ' ')]
+    /// Provide dataset, region, and snapshot ID.
+    #[clap(
+        long,
+        conflicts_with_all = ["ip", "net", "read_only_region"],
+        num_args = 3,
+    )]
     region_snapshot: Option<Vec<Uuid>>,
 }
 
@@ -2876,7 +2879,10 @@ async fn cmd_db_volume_reference(
             .collect()
     } else if let Some(region_snapshot_ids) = &args.region_snapshot {
         if region_snapshot_ids.len() != 3 {
-            bail!("three IDs required: dataset, region, and snapshot");
+            bail!(
+                "three IDs required to uniquely identify a region snapshot: \
+                dataset, region, and snapshot"
+            );
         }
 
         datastore

--- a/dev-tools/omdb/src/bin/omdb/db.rs
+++ b/dev-tools/omdb/src/bin/omdb/db.rs
@@ -31,6 +31,7 @@ use chrono::DateTime;
 use chrono::SecondsFormat;
 use chrono::Utc;
 use clap::ArgAction;
+use clap::ArgGroup;
 use clap::Args;
 use clap::Subcommand;
 use clap::ValueEnum;
@@ -870,6 +871,11 @@ struct VolumeLockHolderArgs {
 }
 
 #[derive(Debug, Args, Clone)]
+#[clap(group(
+ArgGroup::new("volume-reference-group")
+    .required(true)
+    .args(&["ip", "net", "read_only_region", "region_snapshot"])
+))]
 struct VolumeReferenceArgs {
     #[clap(long, conflicts_with_all = ["net", "read_only_region", "region_snapshot"])]
     ip: Option<std::net::Ipv6Addr>,
@@ -880,7 +886,8 @@ struct VolumeReferenceArgs {
     #[clap(long, conflicts_with_all = ["ip", "net", "region_snapshot"])]
     read_only_region: Option<Uuid>,
 
-    /// Dataset, region, and snapshot ID.
+    /// Provide dataset, region, and snapshot ID in a string, delimited by
+    /// spaces.
     #[clap(long, conflicts_with_all = ["ip", "net", "read_only_region"], value_delimiter = ' ')]
     region_snapshot: Option<Vec<Uuid>>,
 }

--- a/dev-tools/omdb/src/bin/omdb/db.rs
+++ b/dev-tools/omdb/src/bin/omdb/db.rs
@@ -886,11 +886,11 @@ struct VolumeReferenceArgs {
     #[clap(long, conflicts_with_all = ["ip", "net", "region_snapshot"])]
     read_only_region: Option<Uuid>,
 
-    /// Provide dataset, region, and snapshot ID.
     #[clap(
         long,
         conflicts_with_all = ["ip", "net", "read_only_region"],
         num_args = 3,
+        value_names = ["DATASET ID", "REGION ID", "SNAPSHOT ID"],
     )]
     region_snapshot: Option<Vec<Uuid>>,
 }

--- a/dev-tools/omdb/src/bin/omdb/db.rs
+++ b/dev-tools/omdb/src/bin/omdb/db.rs
@@ -852,8 +852,8 @@ enum VolumeCommands {
     List,
     /// What is holding the lock?
     LockHolder(VolumeLockHolderArgs),
-    /// What volumes are cooked (read: cannot activate)?
-    Cooked,
+    /// What volumes cannot activate?
+    CannotActivate,
     /// What volumes reference a thing?
     Reference(VolumeReferenceArgs),
 }
@@ -1201,8 +1201,8 @@ impl DbArgs {
                         command: VolumeCommands::LockHolder(args),
                     }) => cmd_db_volume_lock_holder(&datastore, args).await,
                     DbCommands::Volumes(VolumeArgs {
-                        command: VolumeCommands::Cooked,
-                    }) => cmd_db_volume_cooked(&opctx, &datastore).await,
+                        command: VolumeCommands::CannotActivate,
+                    }) => cmd_db_volume_cannot_activate(&opctx, &datastore).await,
                     DbCommands::Volumes(VolumeArgs {
                         command: VolumeCommands::Reference(args),
                     }) => cmd_db_volume_reference(&opctx, &datastore, &fetch_opts, &args).await,
@@ -2789,8 +2789,7 @@ async fn cmd_db_volume_lock_holder(
     Ok(())
 }
 
-/// What volumes cannot activate?
-async fn cmd_db_volume_cooked(
+async fn cmd_db_volume_cannot_activate(
     opctx: &OpContext,
     datastore: &DataStore,
 ) -> Result<(), anyhow::Error> {

--- a/dev-tools/omdb/src/bin/omdb/db.rs
+++ b/dev-tools/omdb/src/bin/omdb/db.rs
@@ -2834,10 +2834,7 @@ async fn cmd_db_volume_cannot_activate(
                 }
 
                 VolumeCookedResult::TargetNotFound { target } => {
-                    println!(
-                        "target {target} not found (was probably \
-                        deleted concurrently when `volume_cooked` was called)"
-                    )
+                    println!("target {target} not found")
                 }
             }
         }


### PR DESCRIPTION
Three improvements to omdb:

- for the `replacements-to-do` command, show if there's an existing replacement request: display the id, request time, and state

- add a sub-command to show if any volumes are cooked, aka unable to activate due to a region set containing all expunged targets

- add a sub-command to show what volumes reference an ip, netmask, read-only region, or region snapshot