### PR TITLE
use named, customizable arguments for `realize_blueprint()`

### DIFF
--- a/nexus/reconfigurator/execution/src/lib.rs
+++ b/nexus/reconfigurator/execution/src/lib.rs
@@ -37,7 +37,10 @@ mod sled_state;
 #[cfg(test)]
 mod test_utils;
 
-/// Encapsulates arguments used for [`realize_blueprint`].
+/// Encapsulates arguments used for [`realize_blueprint`]
+///
+/// You probably want to start with `RequiredRealizeArgs` and use the
+/// builder-like methods to tweak it as required.
 pub struct RealizeArgs<'a> {
     pub opctx: &'a OpContext,
     pub datastore: &'a DataStore,
@@ -58,6 +61,11 @@ impl<'a> RealizeArgs<'a> {
     }
 }
 
+/// Encapsulates all of the required arguments for [`realize_blueprint`]
+///
+/// You'll need to convert this to a [`RealizeArgs`] to use it with
+/// `realize_blueprint()`.  You can also use the builder-like `with_*` methods
+/// to tweak this as you do so.
 pub struct RequiredRealizeArgs<'a> {
     pub opctx: &'a OpContext,
     pub datastore: &'a DataStore,
@@ -78,6 +86,15 @@ impl<'a> From<RequiredRealizeArgs<'a>> for RealizeArgs<'a> {
             sender: value.sender,
             overrides: None,
         }
+    }
+}
+
+impl<'a> RequiredRealizeArgs<'a> {
+    pub fn with_overrides(
+        self,
+        overrides: &'a Overridables,
+    ) -> RealizeArgs<'a> {
+        RealizeArgs::from(self).with_overrides(overrides)
     }
 }
 

--- a/nexus/reconfigurator/execution/src/test_utils.rs
+++ b/nexus/reconfigurator/execution/src/test_utils.rs
@@ -15,7 +15,7 @@ use nexus_types::deployment::{
 use omicron_uuid_kinds::OmicronZoneUuid;
 use update_engine::TerminalKind;
 
-use crate::RealizeBlueprintOutput;
+use crate::{RealizeArgs, RealizeBlueprintOutput, RequiredRealizeArgs};
 
 pub(crate) async fn realize_blueprint_and_expect(
     opctx: &OpContext,
@@ -34,14 +34,16 @@ pub(crate) async fn realize_blueprint_and_expect(
         buffer
     });
 
-    let output = crate::realize_blueprint_with_overrides(
-        opctx,
-        datastore,
-        resolver,
-        blueprint,
-        OmicronZoneUuid::new_v4(),
-        overrides,
-        sender,
+    let output = crate::realize_blueprint(
+        RealizeArgs::from(RequiredRealizeArgs {
+            opctx,
+            datastore,
+            resolver,
+            blueprint,
+            nexus_id: OmicronZoneUuid::new_v4(),
+            sender,
+        })
+        .with_overrides(overrides),
     )
     .await
     // We expect here rather than in the caller because we want to assert that

--- a/nexus/reconfigurator/execution/src/test_utils.rs
+++ b/nexus/reconfigurator/execution/src/test_utils.rs
@@ -15,7 +15,7 @@ use nexus_types::deployment::{
 use omicron_uuid_kinds::OmicronZoneUuid;
 use update_engine::TerminalKind;
 
-use crate::{RealizeArgs, RealizeBlueprintOutput, RequiredRealizeArgs};
+use crate::{RealizeBlueprintOutput, RequiredRealizeArgs};
 
 pub(crate) async fn realize_blueprint_and_expect(
     opctx: &OpContext,
@@ -35,14 +35,14 @@ pub(crate) async fn realize_blueprint_and_expect(
     });
 
     let output = crate::realize_blueprint(
-        RealizeArgs::from(RequiredRealizeArgs {
+        RequiredRealizeArgs {
             opctx,
             datastore,
             resolver,
             blueprint,
             nexus_id: OmicronZoneUuid::new_v4(),
             sender,
-        })
+        }
         .with_overrides(overrides),
     )
     .await

--- a/nexus/src/app/background/tasks/blueprint_execution.rs
+++ b/nexus/src/app/background/tasks/blueprint_execution.rs
@@ -106,7 +106,7 @@ impl BlueprintExecutor {
                 opctx,
                 datastore: &self.datastore,
                 resolver: &self.resolver,
-                blueprint: blueprint,
+                blueprint,
                 nexus_id: self.nexus_id,
                 sender,
             }

--- a/nexus/src/app/background/tasks/blueprint_execution.rs
+++ b/nexus/src/app/background/tasks/blueprint_execution.rs
@@ -10,7 +10,9 @@ use futures::future::BoxFuture;
 use internal_dns_resolver::Resolver;
 use nexus_db_queries::context::OpContext;
 use nexus_db_queries::db::DataStore;
-use nexus_reconfigurator_execution::RealizeBlueprintOutput;
+use nexus_reconfigurator_execution::{
+    RealizeBlueprintOutput, RequiredRealizeArgs,
+};
 use nexus_types::deployment::{
     Blueprint, BlueprintTarget, execution::EventBuffer,
 };
@@ -100,12 +102,15 @@ impl BlueprintExecutor {
         });
 
         let result = nexus_reconfigurator_execution::realize_blueprint(
-            opctx,
-            &self.datastore,
-            &self.resolver,
-            blueprint,
-            self.nexus_id,
-            sender,
+            RequiredRealizeArgs {
+                opctx,
+                datastore: &self.datastore,
+                resolver: &self.resolver,
+                blueprint: blueprint,
+                nexus_id: self.nexus_id,
+                sender,
+            }
+            .into(),
         )
         .await;
 

--- a/nexus/types/src/deployment/execution/mod.rs
+++ b/nexus/types/src/deployment/execution/mod.rs
@@ -8,6 +8,6 @@ mod spec;
 mod utils;
 
 pub use dns::*;
-pub use overridables::*;
+pub use overridables::Overridables;
 pub use spec::*;
 pub use utils::*;

--- a/nexus/types/src/deployment/execution/mod.rs
+++ b/nexus/types/src/deployment/execution/mod.rs
@@ -3,7 +3,7 @@
 // file, You can obtain one at https://mozilla.org/MPL/2.0/.
 
 mod dns;
-mod overridables;
+pub mod overridables;
 mod spec;
 mod utils;
 

--- a/nexus/types/src/deployment/execution/overridables.rs
+++ b/nexus/types/src/deployment/execution/overridables.rs
@@ -11,6 +11,7 @@ use omicron_common::address::get_switch_zone_address;
 use omicron_uuid_kinds::SledUuid;
 use std::collections::BTreeMap;
 use std::net::Ipv6Addr;
+use std::sync::LazyLock;
 
 /// Override values used during blueprint execution
 ///
@@ -31,6 +32,9 @@ pub struct Overridables {
     /// map: sled id -> IP address of the sled's switch zone
     pub switch_zone_ips: BTreeMap<SledUuid, Ipv6Addr>,
 }
+
+pub static DEFAULT: LazyLock<Overridables> =
+    LazyLock::new(|| Overridables::default());
 
 impl Overridables {
     /// Specify the TCP port on which this sled's Dendrite is listening


### PR DESCRIPTION
I'm trying to solve a few different things here:

- Use named arguments for `realize_blueprint()`.  Right now, the function is close to the too-many-args clippy lint.  We'll be adding some stuff for MGS-driven updates that will push us over the limit.
- Make it possible to make optional customizations for blueprint execution without having to update every caller.  Examples:
    - We already have `Overridables` and a separate `realize_blueprint_with_overrides` for this.
    - For #7801, I want to be able to disable saga re-assignment, at least for now, for the reasons mentioned in https://github.com/oxidecomputer/omicron/pull/7801/files#r1996286864.

I'm open to better ways to do this.  The way I settled on is:

- There's just one function now, `realize_blueprint`, which takes a `RealizeArgs` with _all_ of the arguments, required and otherwise.  I got rid of `realize_blueprint_with_overrides`.
- For consumers that don't need to customize anything (i.e., the main consumer, the Nexus blueprint execution task): they can use `RequiredRealizeArgs { ... }.into()` so they only have to specify the required stuff.  This is infallible.
- For consumers that want to tweak things, they can start with `RequiredRealizeArgs`, then use a builder-like interface to tweak individual things.  This is also infallible.

I considered using a more typical builder but I really don't want `build()` to be fallible, especially for the main consumer (Nexus).  It's not an operational error that we can reasonably handle.  We could panic, but if we ever got it wrong, we'd create a Nexus panic loop.  It's worth some awkwardness to verify this call is correct at compile time.  I know there exist builders that enforce at compile time that you have specified all the fields, but this seemed excessive for this, especially given that there are 6 required arguments and a few more optional ones in the foreseeable future.