### PR TITLE
[wicketd] switch to async closures

### DIFF
--- a/wicketd/src/preflight_check/uplink.rs
+++ b/wicketd/src/preflight_check/uplink.rs
@@ -230,7 +230,7 @@ fn add_steps_for_single_local_uplink_preflight_check<'a>(
         .new_step(
             UplinkPreflightStepId::WaitForL1Link,
             "Waiting for L1 link up",
-            move |cx| async move {
+            async move |cx| {
                 let (port_id, link_id) = prev_step.into_value(cx.token()).await;
 
                 // Wait for link up.
@@ -289,7 +289,7 @@ fn add_steps_for_single_local_uplink_preflight_check<'a>(
         .new_step(
             UplinkPreflightStepId::ConfigureAddress,
             "Configuring IP address in host OS",
-            move |cx| async move {
+            async move |cx| {
                 let level1 = match prev_step.into_value(cx.token()).await {
                     Ok(level1) => level1,
                     Err(failure) => {
@@ -413,7 +413,7 @@ fn add_steps_for_single_local_uplink_preflight_check<'a>(
         .new_step(
             UplinkPreflightStepId::ConfigureRouting,
             "Configuring routing in host OS",
-            move |cx| async move {
+            async move |cx| {
                 let level2 = match prev_step.into_value(cx.token()).await {
                     Ok(level2) => level2,
                     Err(failure) => {
@@ -464,7 +464,7 @@ fn add_steps_for_single_local_uplink_preflight_check<'a>(
         .new_step(
             UplinkPreflightStepId::CheckExternalDnsConnectivity,
             "Checking for external DNS connectivity",
-            move |cx| async move {
+            async move |cx| {
                 let level2 = match prev_step.into_value(cx.token()).await {
                     Ok(level2) => level2,
                     Err(err) => {
@@ -489,7 +489,7 @@ fn add_steps_for_single_local_uplink_preflight_check<'a>(
         .new_step(
             UplinkPreflightStepId::CheckExternalNtpConnectivity,
             "Checking for external NTP connectivity",
-            move |cx| async move {
+            async move |cx| {
                 let (level2, ntp_ips) =
                     match prev_step.into_value(cx.token()).await {
                         Ok((level2, ntp_ips)) => (level2, ntp_ips),
@@ -590,7 +590,7 @@ fn add_steps_for_single_local_uplink_preflight_check<'a>(
         .new_step(
             UplinkPreflightStepId::CleanupRouting,
             "Cleaning up host OS routing configuration",
-            move |cx| async move {
+            async move |cx| {
                 let remove_host_route: bool;
                 let level2 = match prev_step.into_value(cx.token()).await {
                     Ok(RoutingSuccess { level2 }) => {
@@ -642,7 +642,7 @@ fn add_steps_for_single_local_uplink_preflight_check<'a>(
             .new_step(
                 UplinkPreflightStepId::CleanupAddress,
                 "Cleaning up host OS IP address configuration",
-                move |cx| async move {
+                async move |cx| {
                     let mut uplink_property_to_remove = None;
                     let level1 = match prev_step.into_value(cx.token()).await {
                         Ok(L2Success { level1, uplink_property }) => {
@@ -716,7 +716,7 @@ fn add_steps_for_single_local_uplink_preflight_check<'a>(
         .new_step(
             UplinkPreflightStepId::CleanupL1,
             "Cleaning up switch configuration",
-            move |cx| async move {
+            async move |cx| {
                 let (port_id, _link_id) =
                     match prev_step.into_value(cx.token()).await {
                         Ok(L1Success { port_id, link_id })

--- a/wicketd/src/update_tracker.rs
+++ b/wicketd/src/update_tracker.rs
@@ -586,7 +586,7 @@ impl SpawnUpdateDriver for FakeUpdateDriver {
                     UpdateComponent::Host,
                     UpdateStepId::RunningInstallinator,
                     "Fake step that waits for receiver to resolve",
-                    move |_cx| async move {
+                    async |_cx| {
                         // This will resolve as soon as the sender (typically a
                         // test) sends a value over the channel.
                         let ret = fake_step_receiver.await;
@@ -1226,7 +1226,7 @@ impl UpdateDriver {
             .new_step(
                 UpdateStepId::DownloadingInstallinator,
                 "Downloading installinator, waiting for it to start",
-                async move |cx| {
+                async |cx| {
                     let image_id = image_id_handle.into_value(cx.token()).await;
                     // The previous step should send this value in.
                     let report_receiver = update_cx
@@ -1249,7 +1249,7 @@ impl UpdateDriver {
             .new_step(
                 UpdateStepId::RunningInstallinator,
                 "Running installinator",
-                move |cx| async move {
+                async |cx| {
                     let report_receiver =
                         start_handle.into_value(cx.token()).await;
                     let write_output = update_cx
@@ -2820,7 +2820,7 @@ impl<'a> SpComponentUpdateContext<'a> {
                     .new_step(
                         SpComponentUpdateStepId::Resetting,
                         "Resetting the RoT to check the bootloader signature",
-                        move |_cx| async move {
+                        async |_cx| {
                             update_cx
                                 .reset_sp_component(SpComponent::ROT.const_as_str())
                                 .await


### PR DESCRIPTION
Rust 1.85 stabilizes async closures via `async ||` or `async move ||`. Start converting over some wicketd closures.

We cannot switch update-engine to `AsyncFnOnce` yet, because there's currently no way to add a bound that the future returns `Send`. Hopefully that comes soon. For now, anything that implements `AsyncFnOnce` also implements `FnOnce` so this works out.
