### PR TITLE
[installinator] switch to async closures

### DIFF
--- a/installinator-common/src/block_size_writer.rs
+++ b/installinator-common/src/block_size_writer.rs
@@ -180,9 +180,8 @@ mod tests {
         }
     }
 
-    fn with_test_runtime<F, Fut, T>(f: F) -> T
+    fn with_test_runtime<Fut, T>(fut: Fut) -> T
     where
-        F: FnOnce() -> Fut,
         Fut: Future<Output = T>,
     {
         let runtime = tokio::runtime::Builder::new_current_thread()
@@ -190,7 +189,7 @@ mod tests {
             .start_paused(true)
             .build()
             .expect("tokio Runtime built successfully");
-        runtime.block_on(f())
+        runtime.block_on(fut)
     }
 
     #[proptest]
@@ -198,7 +197,7 @@ mod tests {
         chunks: Vec<Vec<u8>>,
         #[strategy(16_usize..4096)] block_size: usize,
     ) {
-        with_test_runtime(move || async move {
+        with_test_runtime(async move {
             proptest_block_writer_impl(chunks, block_size)
                 .await
                 .expect("test failed");

--- a/installinator/src/dispatch.rs
+++ b/installinator/src/dispatch.rs
@@ -211,7 +211,7 @@ impl InstallOpts {
                 InstallinatorComponent::HostPhase2,
                 InstallinatorStepId::Download,
                 "Downloading host phase 2 artifact",
-                |cx| async move {
+                async move |cx| {
                     let host_phase_2_artifact =
                         fetch_artifact(&cx, &host_phase_2_id, discovery, log)
                             .await?;
@@ -256,7 +256,7 @@ impl InstallOpts {
                 InstallinatorComponent::ControlPlane,
                 InstallinatorStepId::Download,
                 "Downloading control plane artifact",
-                |cx| async move {
+                async move |cx| {
                     let control_plane_artifact =
                         fetch_artifact(&cx, &control_plane_id, discovery, log)
                             .await?;
@@ -292,9 +292,7 @@ impl InstallOpts {
                     InstallinatorComponent::Both,
                     InstallinatorStepId::Scan,
                     "Scanning hardware to find M.2 disks",
-                    move |cx| async move {
-                        scan_hardware_with_retries(&cx, &log).await
-                    },
+                    async move |cx| scan_hardware_with_retries(&cx, &log).await,
                 )
                 .register()
         } else {
@@ -309,7 +307,7 @@ impl InstallOpts {
                 InstallinatorComponent::ControlPlane,
                 InstallinatorStepId::UnpackControlPlaneArtifact,
                 "Unpacking composite control plane artifact",
-                move |cx| async move {
+                async move |cx| {
                     let control_plane_artifact =
                         control_plane_artifact.into_value(cx.token()).await;
                     let zones = tokio::task::spawn_blocking(|| {
@@ -333,7 +331,7 @@ impl InstallOpts {
                 InstallinatorComponent::Both,
                 InstallinatorStepId::Write,
                 "Writing host and control plane artifacts",
-                |cx| async move {
+                async move |cx| {
                     let destination = destination.into_value(cx.token()).await;
                     let host_phase_2_artifact =
                         host_phase_2_artifact.into_value(cx.token()).await;

--- a/installinator/src/mock_peers.rs
+++ b/installinator/src/mock_peers.rs
@@ -575,7 +575,7 @@ mod tests {
         #[strategy(any::<[u8; 16]>().prop_map(Uuid::from_bytes))]
         update_id: Uuid,
     ) {
-        with_test_runtime(move || async move {
+        with_test_runtime(async move {
             let logctx = test_setup_log("proptest_fetch_artifact");
             let expected_result = universe.expected_result(timeout);
             let expected_artifact = universe.artifact.clone();
@@ -616,7 +616,7 @@ mod tests {
                     InstallinatorComponent::HostPhase2,
                     InstallinatorStepId::Download,
                     "Downloading artifact",
-                    |cx| async move {
+                    async move |cx| {
                         let artifact =
                             fetch_artifact(&cx, &log, attempts, timeout)
                                 .await?;

--- a/installinator/src/test_helpers.rs
+++ b/installinator/src/test_helpers.rs
@@ -17,9 +17,8 @@ pub(crate) fn dummy_artifact_hash_id(
     }
 }
 
-pub(crate) fn with_test_runtime<F, Fut, T>(f: F) -> T
+pub(crate) fn with_test_runtime<Fut, T>(fut: Fut) -> T
 where
-    F: FnOnce() -> Fut,
     Fut: Future<Output = T>,
 {
     let runtime = tokio::runtime::Builder::new_current_thread()
@@ -27,5 +26,5 @@ where
         .start_paused(true)
         .build()
         .expect("tokio Runtime built successfully");
-    runtime.block_on(f())
+    runtime.block_on(fut)
 }

--- a/installinator/src/write.rs
+++ b/installinator/src/write.rs
@@ -392,7 +392,7 @@ impl SlotWriteContext<'_> {
                 WriteComponent::HostPhase2,
                 WriteStepId::Writing { slot: self.slot },
                 format!("Writing host phase 2 to slot {}", self.slot),
-                move |ctx| async move {
+                async move |ctx| {
                     self.artifacts
                         .write_host_phase_2(
                             &self.log,
@@ -414,7 +414,7 @@ impl SlotWriteContext<'_> {
                     "Validating checksum of host phase 2 in slot {}",
                     self.slot
                 ),
-                move |ctx| async move {
+                async move |ctx| {
                     let block_size =
                         block_size_handle.into_value(&ctx.token()).await;
                     self.validate_written_host_phase_2_hash(block_size).await
@@ -494,7 +494,7 @@ impl SlotWriteContext<'_> {
                 WriteComponent::ControlPlane,
                 WriteStepId::Writing { slot: self.slot },
                 format!("Writing control plane to slot {}", self.slot),
-                move |cx2| async move {
+                async move |cx2| {
                     self.artifacts
                         .write_control_plane(
                             &self.log,
@@ -618,7 +618,7 @@ impl ControlPlaneZoneWriteContext<'_> {
                         path: output_directory.clone(),
                     },
                     format!("Removing files in {}", output_directory),
-                    move |_cx| async move {
+                    async move |_cx| {
                         let path = output_directory.clone();
                         tokio::task::spawn_blocking(move || {
                             remove_contents_of(&output_directory)
@@ -649,7 +649,7 @@ impl ControlPlaneZoneWriteContext<'_> {
                     WriteComponent::ControlPlane,
                     ControlPlaneZonesStepId::Zone { name: name.clone() },
                     format!("Writing zone {name}"),
-                    move |cx| async move {
+                    async move |cx| {
                         let transport = transport.into_value(cx.token()).await;
                         write_artifact_impl(
                             WriteComponent::ControlPlane,
@@ -675,7 +675,7 @@ impl ControlPlaneZoneWriteContext<'_> {
                 WriteComponent::ControlPlane,
                 ControlPlaneZonesStepId::Fsync,
                 "Syncing writes to disk",
-                move |_cx| async move {
+                async move |_cx| {
                     let output_directory =
                         File::open(&output_directory).await.map_err(
                             |error| WriteError::SyncOutputDirError { error },
@@ -948,7 +948,7 @@ mod tests {
         data2: Vec<Vec<u8>>,
         #[strategy(WriteOps::strategy())] write_ops: WriteOps,
     ) {
-        with_test_runtime(move || async move {
+        with_test_runtime(async move {
             proptest_write_artifact_impl(data1, data2, write_ops)
                 .await
                 .expect("test failed");
@@ -1123,7 +1123,7 @@ mod tests {
                 InstallinatorComponent::Both,
                 InstallinatorStepId::Write,
                 "Writing",
-                |cx| async move {
+                async move |cx| {
                     let write_output = writer
                         .write_with_transport(
                             &cx,


### PR DESCRIPTION
Similar to #7810.

Also drop the closure entirely from a spot where it's unnecessary (no context is passed in).
