### PR TITLE
trivial: Remove stray dbg added in #7374

### DIFF
--- a/nexus/src/app/login.rs
+++ b/nexus/src/app/login.rs
@@ -60,7 +60,7 @@ impl super::Nexus {
         let (authenticated_subject, relay_state_string) =
             match identity_provider {
                 IdentityProviderType::Saml(saml_identity_provider) => {
-                    let body_bytes = dbg!(body_bytes.as_str())?;
+                    let body_bytes = body_bytes.as_str()?;
                     saml_identity_provider.authenticated_subject(
                         &body_bytes,
                         self.samael_max_issue_delay(),


### PR DESCRIPTION
The method was copied more or less without modification, but I added a `dbg!` on this line and forgot to remove it.

https://github.com/oxidecomputer/omicron/pull/7374/files#diff-20ba9694e6963beb9b707281dc9837c9c41386316c82441ca72a6c0801dd9b8fR63