### PR TITLE
use tufaceous ArtifactVersion for artifact versions

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1105,7 +1105,7 @@ dependencies = [
  "semver 1.0.25",
  "serde",
  "serde_json",
- "thiserror 2.0.11",
+ "thiserror 2.0.12",
 ]
 
 [[package]]
@@ -2757,7 +2757,7 @@ dependencies = [
  "slog-bunyan",
  "slog-json",
  "slog-term",
- "thiserror 2.0.11",
+ "thiserror 2.0.12",
  "tokio",
  "tokio-rustls 0.25.0",
  "toml 0.8.20",
@@ -6184,7 +6184,6 @@ dependencies = [
  "oxnet",
  "proptest",
  "rand 0.8.5",
- "semver 1.0.25",
  "sled-agent-client",
  "slog",
  "slog-error-chain",
@@ -6192,6 +6191,7 @@ dependencies = [
  "strum",
  "test-strategy",
  "thiserror 1.0.69",
+ "tufaceous-artifact",
  "typed-rng",
  "uuid",
 ]
@@ -6428,6 +6428,7 @@ dependencies = [
  "strum",
  "test-strategy",
  "thiserror 1.0.69",
+ "tufaceous-artifact",
  "update-engine",
  "uuid",
 ]
@@ -7855,7 +7856,7 @@ dependencies = [
  "oxide-vpc",
  "postcard",
  "serde",
- "thiserror 2.0.11",
+ "thiserror 2.0.12",
 ]
 
 [[package]]
@@ -9199,7 +9200,7 @@ dependencies = [
  "serde",
  "serde_json",
  "syn 2.0.98",
- "thiserror 2.0.11",
+ "thiserror 2.0.12",
  "typify 0.3.0",
  "unicode-ident",
 ]
@@ -9717,6 +9718,7 @@ dependencies = [
  "swrite",
  "tabled 0.15.0",
  "tokio",
+ "tufaceous-artifact",
  "uuid",
 ]
 
@@ -10444,7 +10446,7 @@ dependencies = [
  "quick-xml",
  "rand 0.8.5",
  "serde",
- "thiserror 2.0.11",
+ "thiserror 2.0.12",
  "url",
  "uuid",
 ]
@@ -11957,11 +11959,11 @@ dependencies = [
 
 [[package]]
 name = "thiserror"
-version = "2.0.11"
+version = "2.0.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d452f284b73e6d76dd36758a0c8684b1d5be31f92b89d07fd5822175732206fc"
+checksum = "567b8a2dae586314f7be2a752ec7474332959c6460e02bde30d702a66d488708"
 dependencies = [
- "thiserror-impl 2.0.11",
+ "thiserror-impl 2.0.12",
 ]
 
 [[package]]
@@ -11977,9 +11979,9 @@ dependencies = [
 
 [[package]]
 name = "thiserror-impl"
-version = "2.0.11"
+version = "2.0.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "26afc1baea8a989337eeb52b6e72a039780ce45c3edfcc9c5b9d112feeb173c2"
+checksum = "7f7cf42b4507d8ea322120659672cf1b9dbb93f8f2d4ecfd6e51350ff5b17a1d"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -12511,7 +12513,7 @@ dependencies = [
  "slog-async",
  "slog-term",
  "tabled 0.18.0",
- "thiserror 2.0.11",
+ "thiserror 2.0.12",
  "tokio",
  "transceiver-decode",
  "transceiver-messages",
@@ -12527,7 +12529,7 @@ dependencies = [
  "schemars",
  "serde",
  "static_assertions",
- "thiserror 2.0.11",
+ "thiserror 2.0.12",
  "transceiver-messages",
 ]
 
@@ -12541,7 +12543,7 @@ dependencies = [
  "hubpack",
  "schemars",
  "serde",
- "thiserror 2.0.11",
+ "thiserror 2.0.12",
 ]
 
 [[package]]
@@ -12568,7 +12570,7 @@ dependencies = [
 [[package]]
 name = "tufaceous"
 version = "0.1.0"
-source = "git+https://github.com/oxidecomputer/tufaceous?branch=main#d2387032714f66e31b7e255d89f9bf6eb9b3a010"
+source = "git+https://github.com/oxidecomputer/tufaceous?branch=main#69e2896b5905aba61445e519aaa40f02d59638b2"
 dependencies = [
  "anyhow",
  "camino",
@@ -12589,8 +12591,9 @@ dependencies = [
 [[package]]
 name = "tufaceous-artifact"
 version = "0.1.0"
-source = "git+https://github.com/oxidecomputer/tufaceous?branch=main#d2387032714f66e31b7e255d89f9bf6eb9b3a010"
+source = "git+https://github.com/oxidecomputer/tufaceous?branch=main#69e2896b5905aba61445e519aaa40f02d59638b2"
 dependencies = [
+ "daft",
  "parse-display",
  "proptest",
  "schemars",
@@ -12599,12 +12602,13 @@ dependencies = [
  "serde_human_bytes",
  "strum",
  "test-strategy",
+ "thiserror 2.0.12",
 ]
 
 [[package]]
 name = "tufaceous-brand-metadata"
 version = "0.1.0"
-source = "git+https://github.com/oxidecomputer/tufaceous?branch=main#d2387032714f66e31b7e255d89f9bf6eb9b3a010"
+source = "git+https://github.com/oxidecomputer/tufaceous?branch=main#69e2896b5905aba61445e519aaa40f02d59638b2"
 dependencies = [
  "semver 1.0.25",
  "serde",
@@ -12615,7 +12619,7 @@ dependencies = [
 [[package]]
 name = "tufaceous-lib"
 version = "0.1.0"
-source = "git+https://github.com/oxidecomputer/tufaceous?branch=main#d2387032714f66e31b7e255d89f9bf6eb9b3a010"
+source = "git+https://github.com/oxidecomputer/tufaceous?branch=main#69e2896b5905aba61445e519aaa40f02d59638b2"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -12805,7 +12809,7 @@ dependencies = [
  "serde",
  "serde_json",
  "syn 2.0.98",
- "thiserror 2.0.11",
+ "thiserror 2.0.12",
  "unicode-ident",
 ]
 

--- a/clients/wicketd-client/src/lib.rs
+++ b/clients/wicketd-client/src/lib.rs
@@ -33,6 +33,7 @@ progenitor::generate_api!(
     replace = {
         AbortUpdateOptions = wicket_common::rack_update::AbortUpdateOptions,
         AllowedSourceIps = omicron_common::api::internal::shared::AllowedSourceIps,
+        ArtifactId = omicron_common::update::ArtifactId,
         Baseboard = sled_hardware_types::Baseboard,
         BgpAuthKey = wicket_common::rack_setup::BgpAuthKey,
         BgpAuthKeyId = wicket_common::rack_setup::BgpAuthKeyId,

--- a/common/src/update.rs
+++ b/common/src/update.rs
@@ -10,9 +10,8 @@ use schemars::{
     gen::SchemaGenerator,
     schema::{Schema, SchemaObject},
 };
-use semver::Version;
 use serde::{Deserialize, Serialize};
-use tufaceous_artifact::{Artifact, ArtifactKind};
+use tufaceous_artifact::{Artifact, ArtifactKind, ArtifactVersion};
 
 /// An identifier for an artifact.
 ///
@@ -35,7 +34,7 @@ pub struct ArtifactId {
     pub name: String,
 
     /// The artifact's version.
-    pub version: Version,
+    pub version: ArtifactVersion,
 
     /// The kind of artifact this is.
     pub kind: ArtifactKind,

--- a/dev-tools/reconfigurator-cli/Cargo.toml
+++ b/dev-tools/reconfigurator-cli/Cargo.toml
@@ -39,6 +39,7 @@ slog-term.workspace = true
 slog.workspace = true
 swrite.workspace = true
 tabled.workspace = true
+tufaceous-artifact.workspace = true
 uuid.workspace = true
 omicron-workspace-hack.workspace = true
 

--- a/dev-tools/reconfigurator-cli/src/main.rs
+++ b/dev-tools/reconfigurator-cli/src/main.rs
@@ -52,6 +52,7 @@ use std::io::BufRead;
 use std::io::IsTerminal;
 use swrite::{SWrite, swriteln};
 use tabled::Tabled;
+use tufaceous_artifact::ArtifactVersion;
 
 mod log_capture;
 
@@ -463,7 +464,7 @@ enum ImageSourceArgs {
     /// the zone image comes from the `install` dataset
     InstallDataset,
     /// the zone image comes from a specific TUF repo artifact
-    Artifact { version: semver::Version, hash: ArtifactHash },
+    Artifact { version: ArtifactVersion, hash: ArtifactHash },
 }
 
 impl From<ImageSourceArgs> for BlueprintZoneImageSource {

--- a/dev-tools/releng/src/hubris.rs
+++ b/dev-tools/releng/src/hubris.rs
@@ -14,6 +14,7 @@ use semver::Version;
 use serde::Deserialize;
 use slog::Logger;
 use slog::warn;
+use tufaceous_artifact::ArtifactVersion;
 use tufaceous_artifact::KnownArtifactKind;
 use tufaceous_lib::assemble::DeserializedArtifactData;
 use tufaceous_lib::assemble::DeserializedArtifactSource;
@@ -83,8 +84,17 @@ pub(crate) async fn fetch_hubris_artifacts(
                     };
                     manifest.artifacts.entry(kind).or_default().push(
                         DeserializedArtifactData {
-                            name: artifact.name,
-                            version: artifact.version,
+                            name: artifact.name.clone(),
+                            version: artifact
+                                .version
+                                .to_string()
+                                .parse::<ArtifactVersion>()
+                                .with_context(|| {
+                                    format!(
+                                        "artifact {} has invalid version: {}",
+                                        artifact.name, artifact.version
+                                    )
+                                })?,
                             source,
                         },
                     );

--- a/nexus/db-queries/src/db/datastore/target_release.rs
+++ b/nexus/db-queries/src/db/datastore/target_release.rs
@@ -119,7 +119,7 @@ mod test {
     use chrono::{TimeDelta, Utc};
     use omicron_common::update::ArtifactId;
     use omicron_test_utils::dev;
-    use tufaceous_artifact::ArtifactKind;
+    use tufaceous_artifact::{ArtifactKind, ArtifactVersion};
 
     #[tokio::test]
     async fn target_release_datastore() {
@@ -180,7 +180,9 @@ mod test {
         assert_eq!(target_release.generation, Generation(3.into()));
 
         // Now add a new TUF repo and use it as the source.
-        let version = SemverVersion::new(0, 0, 1);
+        let system_version = SemverVersion::new(0, 0, 1);
+        const ARTIFACT_VERSION: ArtifactVersion =
+            ArtifactVersion::new_const("0.0.1");
         let hash = ArtifactHash(
             "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855"
                 .parse()
@@ -194,13 +196,13 @@ mod test {
                         hash,
                         0,
                         Utc::now(),
-                        version.clone(),
+                        system_version.clone(),
                         String::from(""),
                     ),
                     artifacts: vec![TufArtifact::new(
                         ArtifactId {
                             name: String::from(""),
-                            version: version.clone().into(),
+                            version: ARTIFACT_VERSION.clone(),
                             kind: ArtifactKind::from_static("empty"),
                         },
                         hash,
@@ -212,7 +214,7 @@ mod test {
             .unwrap()
             .recorded
             .repo;
-        assert_eq!(repo.system_version, version);
+        assert_eq!(repo.system_version, system_version);
         let tuf_repo_id = repo.id;
 
         let before = Utc::now();

--- a/nexus/reconfigurator/planning/Cargo.toml
+++ b/nexus/reconfigurator/planning/Cargo.toml
@@ -29,13 +29,13 @@ omicron-uuid-kinds.workspace = true
 once_cell.workspace = true
 oxnet.workspace = true
 rand.workspace = true
-semver.workspace = true
 sled-agent-client.workspace = true
 slog.workspace = true
 slog-error-chain.workspace = true
 static_assertions.workspace = true
 strum.workspace = true
 thiserror.workspace = true
+tufaceous-artifact.workspace = true
 typed-rng.workspace = true
 uuid.workspace = true
 

--- a/nexus/reconfigurator/planning/src/blueprint_builder/builder.rs
+++ b/nexus/reconfigurator/planning/src/blueprint_builder/builder.rs
@@ -2062,9 +2062,9 @@ pub mod test {
     use omicron_common::disk::DatasetName;
     use omicron_common::update::ArtifactHash;
     use omicron_test_utils::dev::test_setup_log;
-    use semver::Version;
     use std::collections::BTreeSet;
     use std::mem;
+    use tufaceous_artifact::ArtifactVersion;
 
     pub const DEFAULT_N_SLEDS: usize = 3;
 
@@ -3141,11 +3141,13 @@ pub mod test {
                 .iter();
             let zone_id = zones.next().expect("zone exists").id;
             // Set the zone's image source to an artifact.
+            const ARTIFACT_VERSION: ArtifactVersion =
+                ArtifactVersion::new_const("1.2.3");
             editor
                 .set_zone_image_source(
                     &zone_id,
                     BlueprintZoneImageSource::Artifact {
-                        version: Version::new(1, 2, 3),
+                        version: ARTIFACT_VERSION,
                         // The hash is not displayed in the diff -- only the
                         // version is.
                         hash: ArtifactHash([0x12; 32]),

--- a/nexus/tests/integration_tests/target_release.rs
+++ b/nexus/tests/integration_tests/target_release.rs
@@ -4,10 +4,11 @@
 
 //! Get/set the target release via the external API.
 
+use camino::Utf8Path;
 use camino_tempfile::Utf8TempDir;
 use chrono::Utc;
 use clap::Parser as _;
-use dropshot::test_util::LogContext;
+use dropshot::test_util::{ClientTestContext, LogContext};
 use http::StatusCode;
 use http::method::Method;
 use nexus_config::UpdatesConfig;
@@ -38,6 +39,7 @@ async fn get_set_target_release() -> anyhow::Result<()> {
     )
     .await;
     let client = &ctx.external_client;
+    let logctx = LogContext::new("get_set_target_release", &config.pkg.log);
 
     // There should always be a target release.
     let target_release: TargetRelease =
@@ -64,55 +66,113 @@ async fn get_set_target_release() -> anyhow::Result<()> {
     .await
     .expect_err("invalid TUF repo");
 
+    let temp = Utf8TempDir::new().unwrap();
+
     // Adding a fake (tufaceous) repo and then setting it as the
     // target release should succeed.
-    let before = Utc::now();
-    let system_version = Version::new(1, 0, 0);
-    let logctx = LogContext::new("get_set_target_release", &config.pkg.log);
-    let temp = Utf8TempDir::new().unwrap();
-    let path = temp.path().join("repo.zip");
-    tufaceous::Args::try_parse_from([
-        "tufaceous",
-        "assemble",
-        "../update-common/manifests/fake.toml",
-        path.as_str(),
-    ])
-    .expect("can't parse tufaceous args")
-    .exec(&logctx.log)
-    .await
-    .expect("can't assemble TUF repo");
-
-    assert_eq!(
-        system_version,
-        NexusRequest::new(
-            RequestBuilder::new(
-                client,
-                http::Method::PUT,
-                "/v1/system/update/repository?file_name=/tmp/foo.zip",
-            )
-            .body_file(Some(&path))
-            .expect_status(Some(http::StatusCode::OK)),
-        )
-        .authn_as(AuthnMode::PrivilegedUser)
-        .execute()
+    {
+        let before = Utc::now();
+        let system_version = Version::new(1, 0, 0);
+        let path = temp.path().join("repo-1.0.0.zip");
+        tufaceous::Args::try_parse_from([
+            "tufaceous",
+            "assemble",
+            "../update-common/manifests/fake.toml",
+            path.as_str(),
+        ])
+        .expect("can't parse tufaceous args")
+        .exec(&logctx.log)
         .await
-        .unwrap()
-        .parsed_body::<TufRepoInsertResponse>()
-        .unwrap()
-        .recorded
-        .repo
-        .system_version
-    );
+        .expect("can't assemble TUF repo");
 
-    let target_release: TargetRelease = NexusRequest::new(
+        assert_eq!(
+            system_version,
+            upload_tuf_repo(client, &path).await.recorded.repo.system_version
+        );
+
+        let target_release =
+            set_target_release(client, system_version.clone()).await;
+        let after = Utc::now();
+        assert_eq!(target_release.generation, 2);
+        assert!(target_release.time_requested >= before);
+        assert!(target_release.time_requested <= after);
+        assert_eq!(
+            target_release.release_source,
+            TargetReleaseSource::SystemVersion { version: system_version },
+        );
+    }
+
+    // Add a repo with non-semver versions.
+    {
+        let before = Utc::now();
+        let system_version = Version::new(2, 0, 0);
+        let path = temp.path().join("repo-2.0.0.zip");
+        tufaceous::Args::try_parse_from([
+            "tufaceous",
+            "assemble",
+            "../update-common/manifests/fake-non-semver.toml",
+            "--allow-non-semver",
+            path.as_str(),
+        ])
+        .expect("can't parse tufaceous args")
+        .exec(&logctx.log)
+        .await
+        .expect("can't assemble TUF repo");
+
+        assert_eq!(
+            system_version,
+            upload_tuf_repo(client, &path).await.recorded.repo.system_version
+        );
+
+        let target_release =
+            set_target_release(client, system_version.clone()).await;
+        let after = Utc::now();
+        assert_eq!(target_release.generation, 3);
+        assert!(target_release.time_requested >= before);
+        assert!(target_release.time_requested <= after);
+        assert_eq!(
+            target_release.release_source,
+            TargetReleaseSource::SystemVersion { version: system_version },
+        );
+    }
+
+    ctx.teardown().await;
+    logctx.cleanup_successful();
+    Ok(())
+}
+
+async fn upload_tuf_repo(
+    client: &ClientTestContext,
+    path: &Utf8Path,
+) -> TufRepoInsertResponse {
+    NexusRequest::new(
+        RequestBuilder::new(
+            client,
+            http::Method::PUT,
+            "/v1/system/update/repository?file_name=/tmp/foo.zip",
+        )
+        .body_file(Some(path))
+        .expect_status(Some(StatusCode::OK)),
+    )
+    .authn_as(AuthnMode::PrivilegedUser)
+    .execute()
+    .await
+    .unwrap()
+    .parsed_body::<TufRepoInsertResponse>()
+    .unwrap()
+}
+
+async fn set_target_release(
+    client: &ClientTestContext,
+    system_version: Version,
+) -> TargetRelease {
+    NexusRequest::new(
         RequestBuilder::new(
             client,
             Method::PUT,
             "/v1/system/update/target-release",
         )
-        .body(Some(&SetTargetReleaseParams {
-            system_version: system_version.clone(),
-        }))
+        .body(Some(&SetTargetReleaseParams { system_version }))
         .expect_status(Some(StatusCode::CREATED)),
     )
     .authn_as(AuthnMode::PrivilegedUser)
@@ -120,17 +180,5 @@ async fn get_set_target_release() -> anyhow::Result<()> {
     .await
     .unwrap()
     .parsed_body()
-    .unwrap();
-    let after = Utc::now();
-    assert_eq!(target_release.generation, 2);
-    assert!(target_release.time_requested >= before);
-    assert!(target_release.time_requested <= after);
-    assert_eq!(
-        target_release.release_source,
-        TargetReleaseSource::SystemVersion { version: system_version },
-    );
-
-    ctx.teardown().await;
-    logctx.cleanup_successful();
-    Ok(())
+    .unwrap()
 }

--- a/nexus/types/Cargo.toml
+++ b/nexus/types/Cargo.toml
@@ -40,6 +40,7 @@ slog-error-chain.workspace = true
 steno.workspace = true
 strum.workspace = true
 thiserror.workspace = true
+tufaceous-artifact.workspace = true
 newtype-uuid.workspace = true
 update-engine.workspace = true
 uuid.workspace = true

--- a/nexus/types/src/deployment.rs
+++ b/nexus/types/src/deployment.rs
@@ -44,7 +44,6 @@ use omicron_uuid_kinds::PhysicalDiskUuid;
 use omicron_uuid_kinds::SledUuid;
 use omicron_uuid_kinds::ZpoolUuid;
 use schemars::JsonSchema;
-use semver::Version;
 use serde::Deserialize;
 use serde::Serialize;
 use std::collections::BTreeMap;
@@ -53,6 +52,7 @@ use std::fmt;
 use std::net::Ipv6Addr;
 use std::net::SocketAddrV6;
 use strum::EnumIter;
+use tufaceous_artifact::ArtifactVersion;
 
 mod blueprint_diff;
 mod blueprint_display;
@@ -934,7 +934,7 @@ pub enum BlueprintZoneImageSource {
     /// This originates from TUF repos uploaded to Nexus which are then
     /// replicated out to all sleds.
     #[serde(rename_all = "snake_case")]
-    Artifact { version: Version, hash: ArtifactHash },
+    Artifact { version: ArtifactVersion, hash: ArtifactHash },
 }
 
 impl From<BlueprintZoneImageSource> for OmicronZoneImageSource {

--- a/openapi/nexus-internal.json
+++ b/openapi/nexus-internal.json
@@ -1546,6 +1546,11 @@
           }
         ]
       },
+      "ArtifactVersion": {
+        "description": "An artifact version.\n\nThis is a freeform identifier with some basic validation. It may be the serialized form of a semver version, or a custom identifier that uses the same character set as a semver, plus `_`.\n\nThe exact pattern accepted is `^[a-zA-Z0-9._+-]{1,63}$`.\n\n# Ord implementation\n\n`ArtifactVersion`s are not intended to be sorted, just compared for equality. `ArtifactVersion` implements `Ord` only for storage within sorted collections.",
+        "type": "string",
+        "pattern": "^[a-zA-Z0-9._+-]{1,63}$"
+      },
       "BackgroundTask": {
         "description": "Background tasks\n\nThese are currently only intended for observability by developers.  We will eventually want to flesh this out into something more observable for end users.",
         "type": "object",
@@ -2374,8 +2379,7 @@
                 ]
               },
               "version": {
-                "type": "string",
-                "pattern": "^(0|[1-9]\\d*)\\.(0|[1-9]\\d*)\\.(0|[1-9]\\d*)(?:-((?:0|[1-9]\\d*|\\d*[a-zA-Z-][0-9a-zA-Z-]*)(?:\\.(?:0|[1-9]\\d*|\\d*[a-zA-Z-][0-9a-zA-Z-]*))*))?(?:\\+([0-9a-zA-Z-]+(?:\\.[0-9a-zA-Z-]+)*))?$"
+                "$ref": "#/components/schemas/ArtifactVersion"
               }
             },
             "required": [

--- a/openapi/wicketd.json
+++ b/openapi/wicketd.json
@@ -903,8 +903,11 @@
           },
           "version": {
             "description": "The artifact's version.",
-            "type": "string",
-            "pattern": "^(0|[1-9]\\d*)\\.(0|[1-9]\\d*)\\.(0|[1-9]\\d*)(?:-((?:0|[1-9]\\d*|\\d*[a-zA-Z-][0-9a-zA-Z-]*)(?:\\.(?:0|[1-9]\\d*|\\d*[a-zA-Z-][0-9a-zA-Z-]*))*))?(?:\\+([0-9a-zA-Z-]+(?:\\.[0-9a-zA-Z-]+)*))?$"
+            "allOf": [
+              {
+                "$ref": "#/components/schemas/ArtifactVersion"
+              }
+            ]
           }
         },
         "required": [
@@ -912,6 +915,11 @@
           "name",
           "version"
         ]
+      },
+      "ArtifactVersion": {
+        "description": "An artifact version.\n\nThis is a freeform identifier with some basic validation. It may be the serialized form of a semver version, or a custom identifier that uses the same character set as a semver, plus `_`.\n\nThe exact pattern accepted is `^[a-zA-Z0-9._+-]{1,63}$`.\n\n# Ord implementation\n\n`ArtifactVersion`s are not intended to be sorted, just compared for equality. `ArtifactVersion` implements `Ord` only for storage within sorted collections.",
+        "type": "string",
+        "pattern": "^[a-zA-Z0-9._+-]{1,63}$"
       },
       "Aux1Monitor": {
         "description": "The first auxlliary CMIS monitor.",

--- a/update-common/manifests/fake-non-semver.toml
+++ b/update-common/manifests/fake-non-semver.toml
@@ -1,0 +1,87 @@
+# This is an artifact manifest that generates fake entries for all components.
+# Some of the components have non-semver artifact versions.
+#
+# This is completely non-functional and is only useful for testing archive
+# extraction in other parts of the repository.
+
+system_version = "2.0.0"
+
+[[artifact.gimlet_sp]]
+name = "fake-gimlet-sp"
+version = "2.0.0"
+source = { kind = "fake", size = "1MiB" }
+
+[[artifact.gimlet_rot]]
+name = "fake-gimlet-rot"
+version = "2.0.0"
+[artifact.gimlet_rot.source]
+kind = "composite-rot"
+archive_a = { kind = "fake", size = "512KiB" }
+archive_b = { kind = "fake", size = "512KiB" }
+
+[[artifact.host]]
+name = "fake-host"
+version = "2.0.0"
+[artifact.host.source]
+kind = "composite-host"
+phase_1 = { kind = "fake", size = "512KiB" }
+phase_2 = { kind = "fake", size = "1MiB" }
+
+[[artifact.trampoline]]
+name = "fake-trampoline"
+version = "non-semver"
+[artifact.trampoline.source]
+kind = "composite-host"
+phase_1 = { kind = "fake", size = "512KiB" }
+phase_2 = { kind = "fake", size = "1MiB" }
+
+[[artifact.control_plane]]
+name = "fake-control-plane"
+version = "2.0.0"
+[artifact.control_plane.source]
+kind = "composite-control-plane"
+zones = [
+    { kind = "fake", name = "zone1", size = "1MiB" },
+    { kind = "fake", name = "zone2", size = "1MiB" },
+]
+
+[[artifact.psc_sp]]
+name = "fake-psc-sp"
+version = "2.0.0"
+source = { kind = "fake", size = "1MiB" }
+
+[[artifact.psc_rot]]
+name = "fake-psc-rot"
+version = "2.0.0"
+[artifact.psc_rot.source]
+kind = "composite-rot"
+archive_a = { kind = "fake", size = "512KiB" }
+archive_b = { kind = "fake", size = "512KiB" }
+
+[[artifact.switch_sp]]
+name = "fake-switch-sp"
+version = "2.0.0"
+source = { kind = "fake", size = "1MiB" }
+
+[[artifact.switch_rot]]
+name = "fake-switch-rot"
+version = "2.0.0"
+[artifact.switch_rot.source]
+kind = "composite-rot"
+archive_a = { kind = "fake", size = "512KiB" }
+archive_b = { kind = "fake", size = "512KiB" }
+
+[[artifact.gimlet_rot_bootloader]]
+name = "fake-gimlet-rot-bootloader"
+version = "2.0.0"
+source = { kind = "fake", size = "1MiB" }
+
+[[artifact.psc_rot_bootloader]]
+name = "fake-psc-rot-bootloader"
+version = "2.0.0"
+source = { kind = "fake", size = "1MiB" }
+
+[[artifact.switch_rot_bootloader]]
+name = "fake-switch-rot-bootloader"
+version = "non-semver-2"
+source = { kind = "fake", size = "1MiB" }

--- a/update-common/src/artifacts/update_plan.rs
+++ b/update-common/src/artifacts/update_plan.rs
@@ -36,6 +36,7 @@ use std::io;
 use tokio::io::AsyncReadExt;
 use tokio::runtime::Handle;
 use tufaceous_artifact::ArtifactKind;
+use tufaceous_artifact::ArtifactVersion;
 use tufaceous_artifact::KnownArtifactKind;
 use tufaceous_lib::ControlPlaneZoneImages;
 use tufaceous_lib::HostPhaseImages;
@@ -932,7 +933,7 @@ impl<'a> UpdatePlanBuilder<'a> {
 
             let artifact_id = ArtifactId {
                 name: info.pkg.clone(),
-                version: info.version.clone(),
+                version: ArtifactVersion::new(info.version.to_string())?,
                 kind: KnownArtifactKind::Zone.into(),
             };
             self.record_extracted_artifact(
@@ -1465,13 +1466,15 @@ mod tests {
 
     #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
     async fn test_bad_rot_versions() {
-        const VERSION_0: Version = Version::new(0, 0, 0);
-        const VERSION_1: Version = Version::new(0, 0, 1);
+        const ARTIFACT_VERSION_0: ArtifactVersion =
+            ArtifactVersion::new_const("0.0.0");
+        const ARTIFACT_VERSION_1: ArtifactVersion =
+            ArtifactVersion::new_const("0.0.1");
 
         let logctx = test_setup_log("test_bad_rot_version");
 
         let mut plan_builder = UpdatePlanBuilder::new(
-            VERSION_0,
+            "0.0.0".parse().unwrap(),
             ControlPlaneZonesMode::Composite,
             &logctx.log,
         )
@@ -1485,7 +1488,7 @@ mod tests {
             let hash = ArtifactHash(Sha256::digest(&data).into());
             let id = ArtifactId {
                 name: format!("{kind:?}"),
-                version: VERSION_0,
+                version: ARTIFACT_VERSION_0,
                 kind: kind.into(),
             };
             plan_builder
@@ -1512,7 +1515,7 @@ mod tests {
                 let hash = ArtifactHash(Sha256::digest(&data).into());
                 let id = ArtifactId {
                     name: board.to_string(),
-                    version: VERSION_0,
+                    version: ARTIFACT_VERSION_0,
                     kind: kind.into(),
                 };
                 plan_builder
@@ -1539,7 +1542,7 @@ mod tests {
             let hash = ArtifactHash(Sha256::digest(data).into());
             let id = ArtifactId {
                 name: format!("{kind:?}"),
-                version: VERSION_0,
+                version: ARTIFACT_VERSION_0,
                 kind: kind.into(),
             };
             plan_builder
@@ -1568,7 +1571,7 @@ mod tests {
             let hash = ArtifactHash(Sha256::digest(data).into());
             let id = ArtifactId {
                 name: format!("{kind:?}"),
-                version: VERSION_0,
+                version: ARTIFACT_VERSION_0,
                 kind: kind.into(),
             };
             plan_builder
@@ -1586,7 +1589,7 @@ mod tests {
         let hash = ArtifactHash(Sha256::digest(data).into());
         let id = ArtifactId {
             name: format!("{bad_kind:?}"),
-            version: VERSION_1,
+            version: ARTIFACT_VERSION_1,
             kind: bad_kind.into(),
         };
         plan_builder
@@ -1615,7 +1618,7 @@ mod tests {
             let hash = ArtifactHash(Sha256::digest(&artifact).into());
             let id = ArtifactId {
                 name: format!("{kind:?}"),
-                version: VERSION_0,
+                version: ARTIFACT_VERSION_0,
                 kind: kind.into(),
             };
             plan_builder
@@ -1637,8 +1640,10 @@ mod tests {
 
     #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
     async fn test_multi_rot_version() {
-        const VERSION_0: Version = Version::new(0, 0, 0);
-        const VERSION_1: Version = Version::new(0, 0, 1);
+        const ARTIFACT_VERSION_0: ArtifactVersion =
+            ArtifactVersion::new_const("0.0.0");
+        const ARTIFACT_VERSION_1: ArtifactVersion =
+            ArtifactVersion::new_const("0.0.1");
 
         let logctx = test_setup_log("test_multi_rot_version");
 
@@ -1657,7 +1662,7 @@ mod tests {
             let hash = ArtifactHash(Sha256::digest(&data).into());
             let id = ArtifactId {
                 name: format!("{kind:?}"),
-                version: VERSION_0,
+                version: ARTIFACT_VERSION_0,
                 kind: kind.into(),
             };
             plan_builder
@@ -1684,7 +1689,7 @@ mod tests {
                 let hash = ArtifactHash(Sha256::digest(&data).into());
                 let id = ArtifactId {
                     name: board.to_string(),
-                    version: VERSION_0,
+                    version: ARTIFACT_VERSION_0,
                     kind: kind.into(),
                 };
                 plan_builder
@@ -1711,7 +1716,7 @@ mod tests {
             let hash = ArtifactHash(Sha256::digest(data).into());
             let id = ArtifactId {
                 name: format!("{kind:?}"),
-                version: VERSION_0,
+                version: ARTIFACT_VERSION_0,
                 kind: kind.into(),
             };
             plan_builder
@@ -1742,7 +1747,7 @@ mod tests {
             let hash = ArtifactHash(Sha256::digest(data).into());
             let id = ArtifactId {
                 name: format!("{kind:?}"),
-                version: VERSION_0,
+                version: ARTIFACT_VERSION_0,
                 kind: kind.into(),
             };
             plan_builder
@@ -1764,7 +1769,7 @@ mod tests {
             let hash = ArtifactHash(Sha256::digest(data).into());
             let id = ArtifactId {
                 name: format!("{kind:?}"),
-                version: VERSION_1,
+                version: ARTIFACT_VERSION_1,
                 kind: kind.into(),
             };
             plan_builder
@@ -1798,7 +1803,7 @@ mod tests {
             let hash = ArtifactHash(Sha256::digest(&artifact).into());
             let id = ArtifactId {
                 name: format!("{kind:?}"),
-                version: VERSION_0,
+                version: ARTIFACT_VERSION_0,
                 kind: kind.into(),
             };
             plan_builder
@@ -1826,7 +1831,8 @@ mod tests {
     // is required.
     #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
     async fn test_update_plan_from_artifacts() {
-        const VERSION_0: Version = Version::new(0, 0, 0);
+        const ARTIFACT_VERSION_0: ArtifactVersion =
+            ArtifactVersion::new_const("0.0.0");
 
         let logctx = test_setup_log("test_update_plan_from_artifacts");
 
@@ -1846,7 +1852,7 @@ mod tests {
             let hash = ArtifactHash(Sha256::digest(&data).into());
             let id = ArtifactId {
                 name: kind.to_string(),
-                version: VERSION_0,
+                version: ARTIFACT_VERSION_0,
                 kind: kind.parse().unwrap(),
             };
             expected_unknown_artifacts.insert(id.clone());
@@ -1868,7 +1874,7 @@ mod tests {
             let hash = ArtifactHash(Sha256::digest(&data).into());
             let id = ArtifactId {
                 name: format!("{kind:?}"),
-                version: VERSION_0,
+                version: ARTIFACT_VERSION_0,
                 kind: kind.into(),
             };
             plan_builder
@@ -1895,7 +1901,7 @@ mod tests {
                 let hash = ArtifactHash(Sha256::digest(&data).into());
                 let id = ArtifactId {
                     name: board.to_string(),
-                    version: VERSION_0,
+                    version: ARTIFACT_VERSION_0,
                     kind: kind.into(),
                 };
                 plan_builder
@@ -1922,7 +1928,7 @@ mod tests {
             let hash = ArtifactHash(Sha256::digest(data).into());
             let id = ArtifactId {
                 name: format!("{kind:?}"),
-                version: VERSION_0,
+                version: ARTIFACT_VERSION_0,
                 kind: kind.into(),
             };
             plan_builder
@@ -1948,7 +1954,7 @@ mod tests {
             let hash = ArtifactHash(Sha256::digest(data).into());
             let id = ArtifactId {
                 name: format!("{kind:?}"),
-                version: VERSION_0,
+                version: ARTIFACT_VERSION_0,
                 kind: kind.into(),
             };
             plan_builder
@@ -1982,7 +1988,7 @@ mod tests {
             let hash = ArtifactHash(Sha256::digest(&artifact).into());
             let id = ArtifactId {
                 name: format!("{kind:?}"),
-                version: VERSION_0,
+                version: ARTIFACT_VERSION_0,
                 kind: kind.into(),
             };
             plan_builder
@@ -2131,7 +2137,8 @@ mod tests {
 
     #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
     async fn test_bad_hubris_cabooses() {
-        const VERSION_0: Version = Version::new(0, 0, 0);
+        const ARTIFACT_VERSION_0: ArtifactVersion =
+            ArtifactVersion::new_const("0.0.0");
 
         let logctx = test_setup_log("test_bad_hubris_cabooses");
 
@@ -2155,7 +2162,7 @@ mod tests {
             let hash = ArtifactHash(Sha256::digest(data).into());
             let id = ArtifactId {
                 name: format!("{kind:?}"),
-                version: VERSION_0,
+                version: ARTIFACT_VERSION_0,
                 kind: kind.into(),
             };
             match plan_builder
@@ -2188,7 +2195,7 @@ mod tests {
             let hash = ArtifactHash(Sha256::digest(&artifact).into());
             let id = ArtifactId {
                 name: format!("{kind:?}"),
-                version: VERSION_0,
+                version: ARTIFACT_VERSION_0,
                 kind: kind.into(),
             };
             match plan_builder
@@ -2209,8 +2216,10 @@ mod tests {
 
     #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
     async fn test_too_many_rot_bootloaders() {
-        const VERSION_0: Version = Version::new(0, 0, 0);
-        const VERSION_1: Version = Version::new(0, 0, 1);
+        const ARTIFACT_VERSION_0: ArtifactVersion =
+            ArtifactVersion::new_const("0.0.0");
+        const ARTIFACT_VERSION_1: ArtifactVersion =
+            ArtifactVersion::new_const("0.0.1");
 
         // The regular RoT can have multiple versions but _not_ the
         // bootloader
@@ -2233,7 +2242,7 @@ mod tests {
         let hash = ArtifactHash(Sha256::digest(&gimlet_rot_bootloader).into());
         let id = ArtifactId {
             name: format!("{kind:?}"),
-            version: VERSION_0,
+            version: ARTIFACT_VERSION_0,
             kind: kind.into(),
         };
         plan_builder
@@ -2248,7 +2257,7 @@ mod tests {
         let hash = ArtifactHash(Sha256::digest(&gimlet2_rot_bootloader).into());
         let id = ArtifactId {
             name: format!("{kind:?}"),
-            version: VERSION_1,
+            version: ARTIFACT_VERSION_1,
             kind: kind.into(),
         };
         match plan_builder
@@ -2278,7 +2287,8 @@ mod tests {
         // YYYY     BBBB     2.0.0
         // YYYY     CCCC     2.0.0
 
-        const VERSION_0: Version = Version::new(0, 0, 0);
+        const ARTIFACT_VERSION_0: ArtifactVersion =
+            ArtifactVersion::new_const("0.0.0");
 
         let logctx = test_setup_log("test_update_plan_from_artifacts");
 
@@ -2297,7 +2307,7 @@ mod tests {
             let hash = ArtifactHash(Sha256::digest(&data).into());
             let id = ArtifactId {
                 name: format!("{kind:?}"),
-                version: VERSION_0,
+                version: ARTIFACT_VERSION_0,
                 kind: kind.into(),
             };
             plan_builder
@@ -2324,7 +2334,7 @@ mod tests {
                 let hash = ArtifactHash(Sha256::digest(&data).into());
                 let id = ArtifactId {
                     name: board.to_string(),
-                    version: VERSION_0,
+                    version: ARTIFACT_VERSION_0,
                     kind: kind.into(),
                 };
                 plan_builder
@@ -2351,7 +2361,7 @@ mod tests {
             let hash = ArtifactHash(Sha256::digest(data).into());
             let id = ArtifactId {
                 name: format!("{kind:?}"),
-                version: VERSION_0,
+                version: ARTIFACT_VERSION_0,
                 kind: kind.into(),
             };
             plan_builder
@@ -2380,7 +2390,7 @@ mod tests {
             let hash = ArtifactHash(Sha256::digest(data).into());
             let id = ArtifactId {
                 name: format!("{kind:?}"),
-                version: VERSION_0,
+                version: ARTIFACT_VERSION_0,
                 kind: kind.into(),
             };
             plan_builder
@@ -2414,7 +2424,7 @@ mod tests {
             let hash = ArtifactHash(Sha256::digest(&artifact).into());
             let id = ArtifactId {
                 name: format!("{kind:?}"),
-                version: VERSION_0,
+                version: ARTIFACT_VERSION_0,
                 kind: kind.into(),
             };
             plan_builder
@@ -2442,7 +2452,8 @@ mod tests {
         // YYYY     BBBB
         // YYYY     CCCC
 
-        const VERSION_0: Version = Version::new(0, 0, 0);
+        const ARTIFACT_VERSION_0: ArtifactVersion =
+            ArtifactVersion::new_const("0.0.0");
 
         let logctx = test_setup_log("test_update_plan_from_artifacts");
 
@@ -2462,7 +2473,7 @@ mod tests {
         let hash = ArtifactHash(Sha256::digest(data).into());
         let id = ArtifactId {
             name: format!("{kind:?}"),
-            version: VERSION_0,
+            version: ARTIFACT_VERSION_0,
             kind: kind.into(),
         };
         plan_builder
@@ -2474,7 +2485,7 @@ mod tests {
         let hash = ArtifactHash(Sha256::digest(data).into());
         let id = ArtifactId {
             name: format!("{kind:?}"),
-            version: VERSION_0,
+            version: ARTIFACT_VERSION_0,
             kind: kind.into(),
         };
         match plan_builder
@@ -2491,6 +2502,8 @@ mod tests {
     #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
     async fn test_split_control_plane() {
         const VERSION_0: Version = Version::new(0, 0, 0);
+        const ARTIFACT_VERSION_0: ArtifactVersion =
+            ArtifactVersion::new_const("0.0.0");
 
         let logctx = test_setup_log("test_split_control_plane");
 
@@ -2533,7 +2546,7 @@ mod tests {
         let hash = ArtifactHash(Sha256::digest(&data).into());
         let id = ArtifactId {
             name: "control_plane".into(),
-            version: VERSION_0,
+            version: ARTIFACT_VERSION_0,
             kind: KnownArtifactKind::ControlPlane.into(),
         };
         plan_builder
@@ -2548,7 +2561,7 @@ mod tests {
             let content =
                 &zones.iter().find(|(name, _)| *name == id.name).unwrap().1;
             let expected_hash = ArtifactHash(Sha256::digest(content).into());
-            assert_eq!(id.version, VERSION_0);
+            assert_eq!(id.version, ARTIFACT_VERSION_0);
             assert_eq!(id.kind, KnownArtifactKind::Zone.into());
             assert_eq!(
                 vec,

--- a/update-common/src/errors.rs
+++ b/update-common/src/errors.rs
@@ -8,10 +8,9 @@ use camino::Utf8PathBuf;
 use display_error_chain::DisplayErrorChain;
 use dropshot::HttpError;
 use omicron_common::update::{ArtifactHashId, ArtifactId};
-use semver::Version;
 use slog::error;
 use thiserror::Error;
-use tufaceous_artifact::{ArtifactKind, KnownArtifactKind};
+use tufaceous_artifact::{ArtifactKind, ArtifactVersion, KnownArtifactKind};
 
 #[derive(Debug, Error)]
 pub enum RepositoryError {
@@ -144,8 +143,8 @@ pub enum RepositoryError {
     )]
     MultipleVersionsPresent {
         kind: KnownArtifactKind,
-        v1: Version,
-        v2: Version,
+        v1: ArtifactVersion,
+        v2: ArtifactVersion,
     },
     #[error("Caboose mismatch between A {a:?} and B {b:?}")]
     CabooseMismatch { a: String, b: String },

--- a/wicket/src/events.rs
+++ b/wicket/src/events.rs
@@ -4,6 +4,7 @@
 use crate::{State, keymap::Cmd, state::ComponentId};
 use camino::Utf8PathBuf;
 use humantime::format_rfc3339;
+use omicron_common::update::ArtifactId;
 use semver::Version;
 use serde::{Deserialize, Serialize};
 use std::collections::HashMap;
@@ -12,7 +13,7 @@ use std::time::SystemTime;
 use wicket_common::inventory::RackV1Inventory;
 use wicket_common::update_events::EventReport;
 use wicketd_client::types::{
-    ArtifactId, CurrentRssUserConfig, GetLocationResponse, IgnitionCommand,
+    CurrentRssUserConfig, GetLocationResponse, IgnitionCommand,
     RackOperationStatus,
 };
 

--- a/wicket/src/state/update.rs
+++ b/wicket/src/state/update.rs
@@ -22,7 +22,7 @@ use serde::{Deserialize, Serialize};
 use slog::Logger;
 use std::collections::BTreeMap;
 use std::fmt::Display;
-use tufaceous_artifact::KnownArtifactKind;
+use tufaceous_artifact::{ArtifactVersion, KnownArtifactKind};
 
 // Represents a version and the signature (optional) associated
 // with a particular artifact. This allows for multiple versions
@@ -30,7 +30,7 @@ use tufaceous_artifact::KnownArtifactKind;
 // sign is currently only used for RoT artifacts
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct ArtifactVersions {
-    pub version: Version,
+    pub version: ArtifactVersion,
     pub sign: Option<Vec<u8>>,
 }
 
@@ -122,7 +122,7 @@ impl RackUpdateState {
         self.artifacts = artifacts;
         self.artifact_versions.clear();
         for a in &mut self.artifacts {
-            if let Ok(known) = a.id.kind.parse() {
+            if let Some(known) = a.id.kind.to_known() {
                 self.artifact_versions.entry(known).or_default().push(
                     ArtifactVersions {
                         version: a.id.version.clone(),

--- a/wicketd/src/update_tracker.rs
+++ b/wicketd/src/update_tracker.rs
@@ -60,6 +60,7 @@ use tokio::sync::oneshot;
 use tokio::sync::watch;
 use tokio::task::JoinHandle;
 use tokio_util::io::StreamReader;
+use tufaceous_artifact::ArtifactVersion;
 use update_common::artifacts::ArtifactIdData;
 use update_common::artifacts::ArtifactsWithPlan;
 use update_common::artifacts::ControlPlaneZonesMode;
@@ -961,7 +962,7 @@ impl UpdateDriver {
                         "SP board {}, version {} (git commit {})",
                         caboose.board, caboose.version, caboose.git_commit
                     );
-                    match caboose.version.parse::<Version>() {
+                    match caboose.version.parse::<ArtifactVersion>() {
                         Ok(version) => {
                             StepSuccess::new((sp_artifact, Some(version)))
                                 .with_message(message)
@@ -1683,7 +1684,7 @@ struct RotInterrogation {
     sp: SpIdentifier,
     // Version reported by the target RoT.
     artifact_to_apply: ArtifactIdData,
-    active_version: Option<Version>,
+    active_version: Option<ArtifactVersion>,
 }
 
 impl RotInterrogation {
@@ -1918,7 +1919,7 @@ impl UpdateContext {
                     c.version, c.git_commit
                 );
 
-                match c.version.parse::<Version>() {
+                match c.version.parse::<ArtifactVersion>() {
                     Ok(version) => StepSuccess::new(make_result(Some(version)))
                         .with_message(message)
                         .into(),
@@ -2012,7 +2013,7 @@ impl UpdateContext {
             active_version,
         };
 
-        match caboose.version.parse::<Version>() {
+        match caboose.version.parse::<ArtifactVersion>() {
             Ok(version) => StepSuccess::new(make_result(Some(version)))
                 .with_message(message)
                 .into(),

--- a/wicketd/tests/integration_tests/updates.rs
+++ b/wicketd/tests/integration_tests/updates.rs
@@ -106,7 +106,7 @@ async fn test_updates() {
     let mut kinds = BTreeSet::new();
     let mut installable_kinds = BTreeSet::new();
     for artifact in response.artifacts {
-        kinds.insert(artifact.artifact_id.kind.parse().unwrap());
+        kinds.insert(artifact.artifact_id.kind);
         for installable in artifact.installable {
             installable_kinds.insert(installable.kind.parse().unwrap());
         }
@@ -278,10 +278,16 @@ async fn test_installinator_fetch() {
     let temp_dir = Utf8TempDir::new().expect("temp dir created");
     let archive_path = temp_dir.path().join("archive.zip");
 
+    // Test ingestion of an artifact with non-semver versions. This ensures that
+    // wicketd for v14 and above can handle non-semver versions.
+    //
+    // --allow-non-semver can be removed once customer systems are updated to
+    // v14 and above.
     let args = tufaceous::Args::try_parse_from([
         "tufaceous",
         "assemble",
-        "../update-common/manifests/fake.toml",
+        "../update-common/manifests/fake-non-semver.toml",
+        "--allow-non-semver",
         archive_path.as_str(),
     ])
     .expect("args parsed correctly");


### PR DESCRIPTION
Per [RFD 557], we're making artifact versions a freeform identifier (unlike system versions, which are still semver). Make this change.

New TUF repo creation via `tufaceous assemble` still requires semver for artifact versions, to ensure compatibility with wicketd in v13. But there's an override for that available in tufaceous.

[RFD 557]: https://rfd.shared.oxide.computer/rfd/0557
