### PR TITLE
[ls-apis] support APIs exposed by multiple servers

### DIFF
--- a/dev-tools/ls-apis/src/bin/ls-apis.rs
+++ b/dev-tools/ls-apis/src/bin/ls-apis.rs
@@ -8,8 +8,8 @@ use anyhow::{Context, Result, bail};
 use camino::Utf8PathBuf;
 use clap::{Args, Parser, Subcommand};
 use omicron_ls_apis::{
-    AllApiMetadata, ApiDependencyFilter, LoadArgs, ServerComponentName,
-    SystemApis, VersionedHow,
+    AllApiMetadata, ApiDependencyFilter, ApiMetadata, LoadArgs,
+    ServerComponentName, SystemApis, VersionedHow,
 };
 use parse_display::{Display, FromStr};
 
@@ -108,34 +108,33 @@ fn run_adoc(apis: &SystemApis) -> Result<()> {
 
     let metadata = apis.api_metadata();
     for api in metadata.apis() {
-        let Some(server_component) =
-            apis.api_producer(&api.client_package_name)
-        else {
-            continue;
-        };
-        println!("// DO NOT EDIT.  This table is auto-generated. See above.");
-        println!("|{}", api.label);
-        println!("|{}", apis.adoc_label(server_component)?);
-        println!("|{}", apis.adoc_label(&api.client_package_name)?);
-        println!("|");
+        for server_component in apis.api_producers(&api.client_package_name) {
+            println!(
+                "// DO NOT EDIT.  This table is auto-generated. See above."
+            );
+            println!("|{}", api.label);
+            println!("|{}", apis.adoc_label(server_component)?);
+            println!("|{}", apis.adoc_label(&api.client_package_name)?);
+            println!("|");
 
-        for (c, _) in apis.api_consumers(
-            &api.client_package_name,
-            ApiDependencyFilter::default(),
-        )? {
-            println!("* {}", apis.adoc_label(c)?);
-        }
-
-        match &api.versioned_how {
-            VersionedHow::Unknown => println!("|TBD"),
-            VersionedHow::Server => println!("|Server-side only"),
-            VersionedHow::Client(reason) => {
-                println!("|Client-side ({})", reason);
+            for (c, _) in apis.api_consumers(
+                &api.client_package_name,
+                ApiDependencyFilter::default(),
+            )? {
+                println!("* {}", apis.adoc_label(c)?);
             }
-        };
 
-        print!("|{}", api.notes.as_deref().unwrap_or("-\n"));
-        println!("");
+            match &api.versioned_how {
+                VersionedHow::Unknown => println!("|TBD"),
+                VersionedHow::Server => println!("|Server-side only"),
+                VersionedHow::Client(reason) => {
+                    println!("|Client-side ({})", reason);
+                }
+            };
+
+            print!("|{}", api.notes.as_deref().unwrap_or("-\n"));
+            println!("");
+        }
     }
 
     println!("|===\n");
@@ -214,12 +213,10 @@ fn print_server_components<'a>(
     for s in server_components.into_iter() {
         let (repo_name, pkg_path) = apis.package_label(s)?;
         println!("{}{} ({}/{})", prefix, s, repo_name, pkg_path);
-        for api in metadata.apis().filter(|a| {
-            matches!(
-                apis.api_producer(&a.client_package_name),
-                Some (name) if name == s
-            )
-        }) {
+        for api in metadata
+            .apis()
+            .filter(|a| apis.is_producer_of(s, &a.client_package_name))
+        {
             println!(
                 "{}    exposes: {} (client = {})",
                 prefix, api.label, api.client_package_name
@@ -301,6 +298,18 @@ fn run_check(apis: &SystemApis) -> Result<()> {
         );
     }
 
+    fn print_api_and_producers(api: &ApiMetadata, apis: &SystemApis) {
+        print!("    {} ({}", api.label, api.client_package_name,);
+        let mut producers = apis.api_producers(&api.client_package_name);
+        if let Some(producer) = producers.next() {
+            print!(", exposed by {producer}");
+            for producer in producers {
+                print!(", {producer}")
+            }
+        }
+        println!(")");
+    }
+
     println!("\n");
     println!("Server-managed APIs:\n");
     for api in apis
@@ -308,24 +317,14 @@ fn run_check(apis: &SystemApis) -> Result<()> {
         .apis()
         .filter(|f| f.deployed() && f.versioned_how == VersionedHow::Server)
     {
-        println!(
-            "    {} ({}, exposed by {})",
-            api.label,
-            api.client_package_name,
-            apis.api_producer(&api.client_package_name).unwrap()
-        );
+        print_api_and_producers(api, apis);
     }
 
     println!("\n");
     println!("Client-managed API:\n");
     for api in apis.api_metadata().apis().filter(|f| f.deployed()) {
         if let VersionedHow::Client(reason) = &api.versioned_how {
-            println!(
-                "    {} ({}, exposed by {})",
-                api.label,
-                api.client_package_name,
-                apis.api_producer(&api.client_package_name).unwrap()
-            );
+            print_api_and_producers(api, apis);
             println!("        reason: {}", reason);
         }
     }
@@ -342,12 +341,7 @@ fn run_check(apis: &SystemApis) -> Result<()> {
     } else {
         println!("\n");
         for api in unknown {
-            println!(
-                "    {} ({}, exposed by {})",
-                api.label,
-                api.client_package_name,
-                apis.api_producer(&api.client_package_name).unwrap()
-            );
+            print_api_and_producers(api, apis);
         }
         bail!("at least one API has unknown version strategy (see above)");
     }

--- a/dev-tools/ls-apis/src/lib.rs
+++ b/dev-tools/ls-apis/src/lib.rs
@@ -10,6 +10,7 @@ mod system_apis;
 mod workspaces;
 
 pub use api_metadata::AllApiMetadata;
+pub use api_metadata::ApiMetadata;
 pub use api_metadata::VersionedHow;
 pub use system_apis::ApiDependencyFilter;
 pub use system_apis::SystemApis;

--- a/dev-tools/ls-apis/src/system_apis.rs
+++ b/dev-tools/ls-apis/src/system_apis.rs
@@ -51,14 +51,16 @@ pub struct SystemApis {
         BTreeMap<ServerComponentName, Vec<DepPath>>,
     >,
 
-    /// maps an API name to the server component that exposes that API
-    api_producers: BTreeMap<ClientPackageName, (ServerComponentName, DepPath)>,
+    /// maps an API name to the server component(s) that expose that API
+    api_producers: BTreeMap<ClientPackageName, ApiProducerMap>,
 
     /// source of developer-maintained API metadata
     api_metadata: AllApiMetadata,
     /// source of Cargo package metadata
     workspaces: Workspaces,
 }
+
+type ApiProducerMap = BTreeMap<ServerComponentName, DepPath>;
 
 impl SystemApis {
     /// Load information about APIs in the system based on both developer-
@@ -259,12 +261,15 @@ impl SystemApis {
     }
 
     /// Given the client package name for an API, return the name of the server
-    /// component that provides it
-    pub fn api_producer(
-        &self,
+    /// component(s) that provide it
+    pub fn api_producers<'apis>(
+        &'apis self,
         client: &ClientPackageName,
-    ) -> Option<&ServerComponentName> {
-        self.api_producers.get(client).map(|s| &s.0)
+    ) -> impl Iterator<Item = &'apis ServerComponentName> + 'apis {
+        self.api_producers
+            .get(client)
+            .into_iter()
+            .flat_map(|producers| producers.keys())
     }
 
     /// Given the client package name for an API, return the list of server
@@ -301,6 +306,20 @@ impl SystemApis {
         }
 
         Ok(rv.into_iter())
+    }
+
+    /// Given the client package name for an API and the name of a server
+    /// component, returns `true` if the server is a producer of that API, or
+    /// `false` if it is not.
+    pub fn is_producer_of(
+        &self,
+        server: &ServerComponentName,
+        client: &ClientPackageName,
+    ) -> bool {
+        self.api_producers
+            .get(client)
+            .map(|producers| producers.contains_key(server))
+            .unwrap_or(false)
     }
 
     /// Given the name of any package defined in one of our workspaces, return
@@ -351,14 +370,27 @@ impl SystemApis {
                 for (client_pkg, _) in
                     self.component_apis_consumed(server_pkg, filter)?
                 {
-                    let other_component =
-                        self.api_producer(client_pkg).unwrap();
-                    let other_unit = self
-                        .server_component_units
-                        .get(other_component)
-                        .unwrap();
-                    let other_node = nodes.get(other_unit).unwrap();
-                    graph.add_edge(*my_node, *other_node, client_pkg.clone());
+                    // Multiple server components may produce an API. However,
+                    // if an API is produced by multiple server components
+                    // within the same deployment unit, we would like to only
+                    // create one edge per unit.  Thus, use a BTreeSet here to
+                    // de-duplicate the producing units.
+                    let other_units: BTreeSet<_> = self
+                        .api_producers(client_pkg)
+                        .map(|other_component| {
+                            self.server_component_units
+                                .get(other_component)
+                                .unwrap()
+                        })
+                        .collect();
+                    for other_unit in other_units {
+                        let other_node = nodes.get(other_unit).unwrap();
+                        graph.update_edge(
+                            *my_node,
+                            *other_node,
+                            client_pkg.clone(),
+                        );
+                    }
                 }
             }
         }
@@ -414,9 +446,10 @@ impl SystemApis {
                     }
                 }
 
-                let other_component = self.api_producer(client_pkg).unwrap();
-                let other_node = nodes.get(other_component).unwrap();
-                graph.add_edge(*my_node, *other_node, client_pkg);
+                for other_component in self.api_producers(client_pkg) {
+                    let other_node = nodes.get(other_component).unwrap();
+                    graph.add_edge(*my_node, *other_node, client_pkg);
+                }
             }
         }
 
@@ -526,105 +559,106 @@ impl SystemApis {
                 }
                 continue;
             }
-            let producer = self.api_producer(&api.client_package_name).unwrap();
-            let apis_consumed: BTreeSet<_> = self
-                .component_apis_consumed(producer, filter)?
-                .map(|(client_pkgname, _dep_path)| client_pkgname)
-                .collect();
-            let dependents: BTreeSet<_> = self
-                .api_consumers(&api.client_package_name, filter)
-                .unwrap()
-                .map(|(dependent, _dep_path)| dependent)
-                .collect();
+            for producer in self.api_producers(&api.client_package_name) {
+                let apis_consumed: BTreeSet<_> = self
+                    .component_apis_consumed(producer, filter)?
+                    .map(|(client_pkgname, _dep_path)| client_pkgname)
+                    .collect();
+                let dependents: BTreeSet<_> = self
+                    .api_consumers(&api.client_package_name, filter)
+                    .unwrap()
+                    .map(|(dependent, _dep_path)| dependent)
+                    .collect();
 
-            if api.versioned_how == VersionedHow::Unknown {
-                // If we haven't determined how to manage versioning on this
-                // API, and it has no dependencies on "unknown" or
-                // client-managed APIs, then it can be made server-managed.
-                if !apis_consumed.iter().any(|client_pkgname| {
-                    let api = self
-                        .api_metadata
-                        .client_pkgname_lookup(*client_pkgname)
-                        .unwrap();
-                    api.versioned_how != VersionedHow::Server
-                }) {
-                    dag_check.propose_server(
-                        &api.client_package_name,
-                        String::from(
-                            "has no unknown or client-managed dependencies",
-                        ),
-                    );
-                } else if apis_consumed.contains(&api.client_package_name) {
-                    // If this thing depends on itself, it must be
-                    // client-managed.
-                    dag_check.propose_client(
-                        &api.client_package_name,
-                        String::from("depends on itself"),
-                    );
-                } else if dependents.is_empty() {
-                    // If something has no consumers in deployed components, it
-                    // can be server-managed.  (These are generally debug APIs.)
-                    dag_check.propose_server(
-                        &api.client_package_name,
-                        String::from(
-                            "has no consumers among deployed components",
-                        ),
-                    );
-                }
-
-                continue;
-            }
-
-            let dependencies: BTreeMap<_, _> = apis_consumed
-                .iter()
-                .map(|dependency_clientpkg| {
-                    (
-                        self.api_producer(dependency_clientpkg).unwrap(),
-                        *dependency_clientpkg,
-                    )
-                })
-                .collect();
-
-            // Look for one-step circular dependencies (i.e., API API A1 is
-            // produced by component C1, which uses API A2 produced by C2, which
-            // also uses A1).  In such cases, either A1 or A2 must be
-            // client-managed (or both).
-            for other_pkgname in dependents {
-                if let Some(dependency_clientpkg) =
-                    dependencies.get(other_pkgname)
-                {
-                    let dependency_api = self
-                        .api_metadata
-                        .client_pkgname_lookup(*dependency_clientpkg)
-                        .unwrap();
-
-                    // If we're looking at a server-managed dependency and the
-                    // other is unknown, then that one should be client-managed.
-                    //
-                    // Without loss of generality, we can ignore the reverse
-                    // case (because we will catch that case when we're
-                    // iterating over the dependency API).
-                    if api.versioned_how == VersionedHow::Server
-                        && dependency_api.versioned_how == VersionedHow::Unknown
-                    {
-                        dag_check.propose_client(
-                            dependency_clientpkg,
-                            format!(
-                                "has cyclic dependency on {:?}, which is \
-                                 server-managed",
-                                api.client_package_name,
+                if api.versioned_how == VersionedHow::Unknown {
+                    // If we haven't determined how to manage versioning on this
+                    // API, and it has no dependencies on "unknown" or
+                    // client-managed APIs, then it can be made server-managed.
+                    if !apis_consumed.iter().any(|client_pkgname| {
+                        let api = self
+                            .api_metadata
+                            .client_pkgname_lookup(*client_pkgname)
+                            .unwrap();
+                        api.versioned_how != VersionedHow::Server
+                    }) {
+                        dag_check.propose_server(
+                            &api.client_package_name,
+                            String::from(
+                                "has no unknown or client-managed dependencies",
                             ),
-                        )
+                        );
+                    } else if apis_consumed.contains(&api.client_package_name) {
+                        // If this thing depends on itself, it must be
+                        // client-managed.
+                        dag_check.propose_client(
+                            &api.client_package_name,
+                            String::from("depends on itself"),
+                        );
+                    } else if dependents.is_empty() {
+                        // If something has no consumers in deployed components, it
+                        // can be server-managed.  (These are generally debug APIs.)
+                        dag_check.propose_server(
+                            &api.client_package_name,
+                            String::from(
+                                "has no consumers among deployed components",
+                            ),
+                        );
                     }
 
-                    // If both are Unknown, tell the user to pick one.
-                    if api.versioned_how == VersionedHow::Unknown
-                        && dependency_api.versioned_how == VersionedHow::Unknown
+                    continue;
+                }
+
+                let dependencies: BTreeMap<_, _> = apis_consumed
+                    .iter()
+                    .flat_map(|dependency_clientpkg| {
+                        self.api_producers(dependency_clientpkg)
+                            .map(|p| (p, *dependency_clientpkg))
+                    })
+                    .collect();
+
+                // Look for one-step circular dependencies (i.e., API API A1 is
+                // produced by component C1, which uses API A2 produced by C2, which
+                // also uses A1).  In such cases, either A1 or A2 must be
+                // client-managed (or both).
+                for other_pkgname in dependents {
+                    if let Some(dependency_clientpkg) =
+                        dependencies.get(other_pkgname)
                     {
-                        dag_check.propose_upick(
-                            &api.client_package_name,
-                            dependency_clientpkg,
-                        );
+                        let dependency_api = self
+                            .api_metadata
+                            .client_pkgname_lookup(*dependency_clientpkg)
+                            .unwrap();
+
+                        // If we're looking at a server-managed dependency and the
+                        // other is unknown, then that one should be client-managed.
+                        //
+                        // Without loss of generality, we can ignore the reverse
+                        // case (because we will catch that case when we're
+                        // iterating over the dependency API).
+                        if api.versioned_how == VersionedHow::Server
+                            && dependency_api.versioned_how
+                                == VersionedHow::Unknown
+                        {
+                            dag_check.propose_client(
+                                dependency_clientpkg,
+                                format!(
+                                    "has cyclic dependency on {:?}, which is \
+                                 server-managed",
+                                    api.client_package_name,
+                                ),
+                            )
+                        }
+
+                        // If both are Unknown, tell the user to pick one.
+                        if api.versioned_how == VersionedHow::Unknown
+                            && dependency_api.versioned_how
+                                == VersionedHow::Unknown
+                        {
+                            dag_check.propose_upick(
+                                &api.client_package_name,
+                                dependency_clientpkg,
+                            );
+                        }
                     }
                 }
             }
@@ -762,7 +796,7 @@ struct ServerComponentsTracker<'a> {
     server_component_units: BTreeMap<ServerComponentName, DeploymentUnitName>,
     unit_server_components:
         BTreeMap<DeploymentUnitName, BTreeSet<ServerComponentName>>,
-    api_producers: BTreeMap<ClientPackageName, (ServerComponentName, DepPath)>,
+    api_producers: BTreeMap<ClientPackageName, ApiProducerMap>,
 }
 
 impl<'a> ServerComponentsTracker<'a> {
@@ -826,17 +860,17 @@ impl<'a> ServerComponentsTracker<'a> {
             return;
         }
 
-        if let Some((previous, _)) = self.api_producers.insert(
-            api.client_package_name.clone(),
-            (server_pkgname.clone(), dep_path.clone()),
-        ) {
+        if let Some(prev_dep_path) = self
+            .api_producers
+            .entry(api.client_package_name.clone())
+            .or_default()
+            .insert(server_pkgname.clone(), dep_path.clone())
+        {
             self.errors.push(anyhow!(
-                "API for client {} appears to be exported by multiple \
-                 components: at least {} and {} ({:?})",
+                "API for client {} appears to be exported by {server_pkgname} \
+                 via multiple dependency paths: at least {prev_dep_path:?} and \
+                 {dep_path:?}",
                 api.client_package_name,
-                previous,
-                server_pkgname,
-                dep_path
             ));
         }
     }


### PR DESCRIPTION
Currently, `cargo xtask ls-apis` will fail when it encounters an API that is served by multiple entities.

For example, when adding the `ereporter-api` in #7833, which is served by both MGS and sled-agent, `ls-apis` currently fails with an error like this one:

```console
eliza@theseus ~/Code/oxide/omicron $ cargo xtask ls-apis apis
    Finished `dev` profile [unoptimized + debuginfo] target(s) in 0.45s
     Running `target/debug/xtask ls-apis apis`
    Finished `dev` profile [unoptimized + debuginfo] target(s) in 1.01s
     Running `target/debug/ls-apis apis`
loading metadata for workspace omicron from current workspace
loading metadata for workspace lldp from /home/eliza/.cargo/git/checkouts/lldp-d47de417041f191b/ce952e6/Cargo.toml
loading metadata for workspace propolis from /home/eliza/.cargo/git/checkouts/propolis-d68c8bd1bc59c9bd/6b5f2af/Cargo.toml
loading metadata for workspace crucible from /home/eliza/.cargo/git/checkouts/crucible-0a48bd218bc2bbbc/81a3528/Cargo.toml
loading metadata for workspace maghemite from /home/eliza/.cargo/git/checkouts/maghemite-c0236f0fd3d582b6/caafd88/Cargo.toml

loading metadata for workspace dendrite from /home/eliza/.cargo/git/checkouts/dendrite-ae9f1715c17fc765/a66561e/Cargo.toml
note: ignoring Cargo dependency from crucible-pantry -> ... -> crucible-control-client
note: ignoring Cargo dependency from omicron-sled-agent -> dns-server
error: API for client ereporter-client appears to be exported by multiple components: at least omicron-sled-agent and omicron-gateway (DepPath([PackageId { repr: "path+file:///home/eliza/Code/oxide/omicron/gateway#omicron-gateway@0.1.0" }]))
Error: found at least one API exported by multiple servers

# ... backtrace snipped for brevity ...

```

This is unfortunate, as it would be nice to be able to have such APIs without breaking `ls-apis`. Therefore, this commit adds support for APIs with multiple server components. This change ends up being pretty straightforward; it's mainly just changing the `api_producers` map from a map of client package names to server components to a map of client package names to *a map of* server components, and updating the code that consumes this information to loop over those server components as appropriate.

Now, the various `ls-apis` commands can handle the new `ereproter-api`. For example:

```console
eliza@theseus ~/Code/oxide/omicron $ cargo xtask ls-apis apis
    Finished `dev` profile [unoptimized + debuginfo] target(s) in 0.37s
     Running `target/debug/xtask ls-apis apis`
   Compiling omicron-ls-apis v0.1.0 (/home/eliza/Code/oxide/omicron/dev-tools/ls-apis)
    Finished `dev` profile [unoptimized + debuginfo] target(s) in 1.69s
     Running `target/debug/ls-apis apis`
loading metadata for workspace omicron from current workspace
loading metadata for workspace lldp from /home/eliza/.cargo/git/checkouts/lldp-d47de417041f191b/ce952e6/Cargo.toml
loading metadata for workspace maghemite from /home/eliza/.cargo/git/checkouts/maghemite-c0236f0fd3d582b6/caafd88/Cargo.toml
loading metadata for workspace propolis from /home/eliza/.cargo/git/checkouts/propolis-d68c8bd1bc59c9bd/6b5f2af/Cargo.toml
loading metadata for workspace crucible from /home/eliza/.cargo/git/checkouts/crucible-0a48bd218bc2bbbc/81a3528/Cargo.toml
loading metadata for workspace dendrite from /home/eliza/.cargo/git/checkouts/dendrite-ae9f1715c17fc765/a66561e/Cargo.toml
note: ignoring Cargo dependency from crucible-pantry -> ... -> crucible-control-client
note: ignoring Cargo dependency from omicron-sled-agent -> dns-server
Bootstrap Agent (client: bootstrap-agent-client)
    consumed by: omicron-sled-agent (omicron/sled-agent) via 1 path
    consumed by: wicketd (omicron/wicketd) via 2 paths

# ... snipped irrelevant APIs for brevity ...

Ereporter (client: ereporter-client)
    consumed by: omicron-nexus (omicron/nexus) via 1 path

# ... snipped irrelevant APIs for brevity ...

eliza@theseus ~/Code/oxide/omicron $ cargo xtask ls-apis check
    Finished `dev` profile [unoptimized + debuginfo] target(s) in 0.32s
     Running `target/debug/xtask ls-apis check`
    Finished `dev` profile [unoptimized + debuginfo] target(s) in 0.52s
     Running `target/debug/ls-apis check`
loading metadata for workspace omicron from current workspace
loading metadata for workspace lldp from /home/eliza/.cargo/git/checkouts/lldp-d47de417041f191b/ce952e6/Cargo.toml
loading metadata for workspace maghemite from /home/eliza/.cargo/git/checkouts/maghemite-c0236f0fd3d582b6/caafd88/Cargo.toml
loading metadata for workspace propolis from /home/eliza/.cargo/git/checkouts/propolis-d68c8bd1bc59c9bd/6b5f2af/Cargo.toml
loading metadata for workspace crucible from /home/eliza/.cargo/git/checkouts/crucible-0a48bd218bc2bbbc/81a3528/Cargo.toml
loading metadata for workspace dendrite from /home/eliza/.cargo/git/checkouts/dendrite-ae9f1715c17fc765/a66561e/Cargo.toml
note: ignoring Cargo dependency from crucible-pantry -> ... -> crucible-control-client
note: ignoring Cargo dependency from omicron-sled-agent -> dns-server

Server-managed APIs:

    Clickhouse Cluster Admin for Keepers (clickhouse-admin-keeper-client, exposed by omicron-clickhouse-admin)
    Clickhouse Cluster Admin for Servers (clickhouse-admin-server-client, exposed by omicron-clickhouse-admin)
    Clickhouse Single-Node Cluster Admin (clickhouse-admin-single-client, exposed by omicron-clickhouse-admin)
    CockroachDB Cluster Admin (cockroach-admin-client, exposed by omicron-cockroach-admin)
    Crucible Agent (crucible-agent-client, exposed by crucible-agent)
    Crucible Control (for testing only) (crucible-control-client, exposed by propolis-server)
    Crucible Pantry (crucible-pantry-client, exposed by crucible-pantry)
    Maghemite DDM Admin (ddm-admin-client, exposed by ddmd)
    DNS Server (dns-service-client, exposed by dns-server)
    Ereporter (ereporter-client, exposed by omicron-gateway, omicron-sled-agent)
    Management Gateway Service (gateway-client, exposed by omicron-gateway)
    LLDP daemon (lldpd-client, exposed by lldpd)
    Maghemite MG Admin (mg-admin-client, exposed by mgd)
    External API (oxide-client, exposed by omicron-nexus)
    Oximeter (oximeter-client, exposed by oximeter-collector)
    Propolis (propolis-client, exposed by propolis-server)
    Sled Agent (sled-agent-client, exposed by omicron-sled-agent)
    Wicketd (wicketd-client, exposed by wicketd)

Client-managed API:

    Bootstrap Agent (bootstrap-agent-client, exposed by omicron-sled-agent)
        reason: depends on itself (i.e., instances call each other)
    Dendrite DPD (dpd-client, exposed by dpd)
        reason: Sled Agent calling DPD creates a circular dependency
    Wicketd Installinator (installinator-client, exposed by wicketd)
        reason: client is provided implicitly by the operator
    Nexus Internal API (nexus-client, exposed by omicron-nexus)
        reason: Circular dependencies between Nexus and other services
    Crucible Repair (repair-client, exposed by crucible-downstairs)
        reason: depends on itself (i.e., instances call each other)
    Repo Depot API (repo-depot-client, exposed by omicron-sled-agent)
        reason: depends on itself (i.e., instances call each other)

APIs with unknown version management: none

````