### PR TITLE
Compare request against existing region

### DIFF
--- a/sled-agent/src/sim/http_entrypoints_storage.rs
+++ b/sled-agent/src/sim/http_entrypoints_storage.rs
@@ -77,11 +77,7 @@ async fn region_create(
     let params = body.into_inner();
     let crucible = rc.context();
 
-    let region = crucible.create(params).map_err(|e| {
-        HttpError::for_internal_error(
-            format!("region create failure: {:?}", e,),
-        )
-    })?;
+    let region = crucible.create(params)?;
 
     Ok(HttpResponseOk(region))
 }


### PR DESCRIPTION
If the IDs match, the simulated Crucible agent should compare the CreateRegion request against the existing Region, and return a conflict error if the request differs.

Also, correctly use the fields from the CreateRegion request when creating the region: encrypted, cert_pem, key_pem, and root_pem were not being set properly!