### PR TITLE
Clean up volume usage records created by sagas

### DIFF
--- a/nexus/src/app/sagas/region_snapshot_replacement_start.rs
+++ b/nexus/src/app/sagas/region_snapshot_replacement_start.rs
@@ -911,6 +911,15 @@ async fn rsrss_new_region_volume_create_undo(
 
     let new_region_volume_id =
         sagactx.lookup::<VolumeUuid>("new_region_volume_id")?;
+
+    if osagactx.datastore().volume_get(new_region_volume_id).await?.is_some() {
+        // All the knowledge to unwind the resources created by this saga is in
+        // this saga, but use soft delete in order to keep volume resource usage
+        // records consistent (they would have been added in the volume create).
+        // Make sure to only call this if the volume still exists.
+        osagactx.datastore().soft_delete_volume(new_region_volume_id).await?;
+    }
+
     osagactx.datastore().volume_hard_delete(new_region_volume_id).await?;
 
     Ok(())
@@ -1008,6 +1017,15 @@ async fn rsrss_create_fake_volume_undo(
     // Delete the fake volume.
 
     let new_volume_id = sagactx.lookup::<VolumeUuid>("new_volume_id")?;
+
+    if osagactx.datastore().volume_get(new_volume_id).await?.is_some() {
+        // All the knowledge to unwind the resources created by this saga is in
+        // this saga, but use soft delete in order to keep volume resource usage
+        // records consistent (they would have been added in the volume create).
+        // Make sure to only call this if the volume still exists.
+        osagactx.datastore().soft_delete_volume(new_volume_id).await?;
+    }
+
     osagactx.datastore().volume_hard_delete(new_volume_id).await?;
 
     Ok(())

--- a/nexus/src/app/sagas/snapshot_create.rs
+++ b/nexus/src/app/sagas/snapshot_create.rs
@@ -629,7 +629,9 @@ async fn ssc_create_destination_volume_record_undo(
     // resources. It's safe here to perform a volume hard delete without
     // decreasing the crucible resource count because the destination volume is
     // guaranteed to never have read only resources that require that
-    // accounting.
+    // accounting. This is the same reason that volume resource usage records
+    // are not created for the destination volume (they're only created for
+    // read-only resources!)
 
     info!(log, "hard deleting volume {}", destination_volume_id);
 


### PR DESCRIPTION
Adding a check that the volume Nexus is about to hard delete does not have associated volume resource usage revealed areas where volumes that had read-only resources were not being correctly cleaned up. Fix that here!

Note that leaking these usage records does not cause a functional problem, but it's not good to leak them. I'll have to write a background task that cleans these up.