### PR TITLE
Remove alpine disk source from OpenAPI schema

### DIFF
--- a/nexus/types/src/external_api/params.rs
+++ b/nexus/types/src/external_api/params.rs
@@ -2112,6 +2112,7 @@ pub enum ImageSource {
 
     /// Boot the Alpine ISO that ships with the Propolis zone. Intended for
     /// development purposes only.
+    #[schemars(skip)] // keep it out of the OpenAPI schema
     YouCanBootAnythingAsLongAsItsAlpine,
 }
 

--- a/openapi/nexus.json
+++ b/openapi/nexus.json
@@ -17666,21 +17666,6 @@
               "id",
               "type"
             ]
-          },
-          {
-            "description": "Boot the Alpine ISO that ships with the Propolis zone. Intended for development purposes only.",
-            "type": "object",
-            "properties": {
-              "type": {
-                "type": "string",
-                "enum": [
-                  "you_can_boot_anything_as_long_as_its_alpine"
-                ]
-              }
-            },
-            "required": [
-              "type"
-            ]
           }
         ]
       },


### PR DESCRIPTION
Removing `YouCanBootAnythingAsLongAsItsAlpine` fully (#4222) requires changing the tests that rely on it. There aren't that many ([repo search](https://github.com/search?q=repo%3Aoxidecomputer%2Fomicron%20YouCanBootAnythingAsLongAsItsAlpine&type=code)) but I'd have to puzzle it out. What I can do trivially, however, is get it out the OpenAPI schema so API and CLI users don't have to see it.