### PR TITLE
sled-agent: revert Hyper-V enablement

### DIFF
--- a/sled-agent/src/instance.rs
+++ b/sled-agent/src/instance.rs
@@ -1031,7 +1031,6 @@ impl InstanceRunner {
             types::{
                 BlobStorageBackend, Board, BootOrderEntry, BootSettings,
                 Chipset, ComponentV0, CrucibleStorageBackend,
-                GuestHypervisorInterface, HyperVFeatureFlag,
                 InstanceInitializationMethod, NvmeDisk, QemuPvpanic,
                 ReplacementComponent, SerialPort, SerialPortNumber, VirtioDisk,
                 VirtioNetworkBackend, VirtioNic,
@@ -1238,11 +1237,7 @@ impl InstanceRunner {
                     cpus: self.vcpus,
                     memory_mb: self.memory_mib,
                     cpuid: None,
-                    guest_hv_interface: Some(
-                        GuestHypervisorInterface::HyperV {
-                            features: vec![HyperVFeatureFlag::ReferenceTsc],
-                        },
-                    ),
+                    guest_hv_interface: None,
                 },
                 components: Default::default(),
             };


### PR DESCRIPTION
Unconditionally masquerading as Hyper-V causes problems for some guest OSes (some FreeBSD versions, illumos distributions), so don't do that until users have a more robust way of opting in or out of this kind of feature.