### PR TITLE
[nexus] Hide affinity groups from API

### DIFF
--- a/nexus/external-api/output/nexus_tags.txt
+++ b/nexus/external-api/output/nexus_tags.txt
@@ -1,14 +1,5 @@
 API operations found with tag "affinity"
 OPERATION ID                             METHOD   URL PATH
-affinity_group_create                    POST     /v1/affinity-groups
-affinity_group_delete                    DELETE   /v1/affinity-groups/{affinity_group}
-affinity_group_list                      GET      /v1/affinity-groups
-affinity_group_member_instance_add       POST     /v1/affinity-groups/{affinity_group}/members/instance/{instance}
-affinity_group_member_instance_delete    DELETE   /v1/affinity-groups/{affinity_group}/members/instance/{instance}
-affinity_group_member_instance_view      GET      /v1/affinity-groups/{affinity_group}/members/instance/{instance}
-affinity_group_member_list               GET      /v1/affinity-groups/{affinity_group}/members
-affinity_group_update                    PUT      /v1/affinity-groups/{affinity_group}
-affinity_group_view                      GET      /v1/affinity-groups/{affinity_group}
 anti_affinity_group_create               POST     /v1/anti-affinity-groups
 anti_affinity_group_delete               DELETE   /v1/anti-affinity-groups/{anti_affinity_group}
 anti_affinity_group_list                 GET      /v1/anti-affinity-groups
@@ -43,9 +34,19 @@ floating_ip_view                         GET      /v1/floating-ips/{floating_ip}
 
 API operations found with tag "hidden"
 OPERATION ID                             METHOD   URL PATH
+affinity_group_create                    POST     /v1/affinity-groups
+affinity_group_delete                    DELETE   /v1/affinity-groups/{affinity_group}
+affinity_group_list                      GET      /v1/affinity-groups
+affinity_group_member_instance_add       POST     /v1/affinity-groups/{affinity_group}/members/instance/{instance}
+affinity_group_member_instance_delete    DELETE   /v1/affinity-groups/{affinity_group}/members/instance/{instance}
+affinity_group_member_instance_view      GET      /v1/affinity-groups/{affinity_group}/members/instance/{instance}
+affinity_group_member_list               GET      /v1/affinity-groups/{affinity_group}/members
+affinity_group_update                    PUT      /v1/affinity-groups/{affinity_group}
+affinity_group_view                      GET      /v1/affinity-groups/{affinity_group}
 device_access_token                      POST     /device/token
 device_auth_confirm                      POST     /device/confirm
 device_auth_request                      POST     /device/auth
+instance_affinity_group_list             GET      /v1/instances/{instance}/affinity-groups
 logout                                   POST     /v1/logout
 probe_create                             POST     /experimental/v1/probes
 probe_delete                             DELETE   /experimental/v1/probes/{probe}
@@ -75,7 +76,6 @@ image_view                               GET      /v1/images/{image}
 
 API operations found with tag "instances"
 OPERATION ID                             METHOD   URL PATH
-instance_affinity_group_list             GET      /v1/instances/{instance}/affinity-groups
 instance_anti_affinity_group_list        GET      /v1/instances/{instance}/anti-affinity-groups
 instance_create                          POST     /v1/instances
 instance_delete                          DELETE   /v1/instances/{instance}

--- a/nexus/external-api/src/lib.rs
+++ b/nexus/external-api/src/lib.rs
@@ -75,7 +75,7 @@ const PUT_UPDATE_REPOSITORY_MAX_BYTES: usize = 4 * GIB;
         policy = EndpointTagPolicy::ExactlyOne,
         tags = {
             "affinity" = {
-                description = "Affinity and anti-affinity groups give control over instance placement.",
+                description = "Anti-affinity groups give control over instance placement.",
                 external_docs = {
                     url = "http://docs.oxide.computer/api/affinity"
                 }
@@ -1268,7 +1268,7 @@ pub trait NexusExternalApi {
     #[endpoint {
         method = GET,
         path = "/v1/instances/{instance}/affinity-groups",
-        tags = ["instances"],
+        tags = ["hidden"],
     }]
     async fn instance_affinity_group_list(
         rqctx: RequestContext<Self::Context>,
@@ -1298,7 +1298,7 @@ pub trait NexusExternalApi {
     #[endpoint {
         method = GET,
         path = "/v1/affinity-groups",
-        tags = ["affinity"],
+        tags = ["hidden"],
     }]
     async fn affinity_group_list(
         rqctx: RequestContext<Self::Context>,
@@ -1309,7 +1309,7 @@ pub trait NexusExternalApi {
     #[endpoint {
         method = GET,
         path = "/v1/affinity-groups/{affinity_group}",
-        tags = ["affinity"],
+        tags = ["hidden"],
     }]
     async fn affinity_group_view(
         rqctx: RequestContext<Self::Context>,
@@ -1321,7 +1321,7 @@ pub trait NexusExternalApi {
     #[endpoint {
         method = GET,
         path = "/v1/affinity-groups/{affinity_group}/members",
-        tags = ["affinity"],
+        tags = ["hidden"],
     }]
     async fn affinity_group_member_list(
         rqctx: RequestContext<Self::Context>,
@@ -1335,7 +1335,7 @@ pub trait NexusExternalApi {
     #[endpoint {
         method = GET,
         path = "/v1/affinity-groups/{affinity_group}/members/instance/{instance}",
-        tags = ["affinity"],
+        tags = ["hidden"],
     }]
     async fn affinity_group_member_instance_view(
         rqctx: RequestContext<Self::Context>,
@@ -1347,7 +1347,7 @@ pub trait NexusExternalApi {
     #[endpoint {
         method = POST,
         path = "/v1/affinity-groups/{affinity_group}/members/instance/{instance}",
-        tags = ["affinity"],
+        tags = ["hidden"],
     }]
     async fn affinity_group_member_instance_add(
         rqctx: RequestContext<Self::Context>,
@@ -1359,7 +1359,7 @@ pub trait NexusExternalApi {
     #[endpoint {
         method = DELETE,
         path = "/v1/affinity-groups/{affinity_group}/members/instance/{instance}",
-        tags = ["affinity"],
+        tags = ["hidden"],
     }]
     async fn affinity_group_member_instance_delete(
         rqctx: RequestContext<Self::Context>,
@@ -1371,7 +1371,7 @@ pub trait NexusExternalApi {
     #[endpoint {
         method = POST,
         path = "/v1/affinity-groups",
-        tags = ["affinity"],
+        tags = ["hidden"],
     }]
     async fn affinity_group_create(
         rqctx: RequestContext<Self::Context>,
@@ -1383,7 +1383,7 @@ pub trait NexusExternalApi {
     #[endpoint {
         method = PUT,
         path = "/v1/affinity-groups/{affinity_group}",
-        tags = ["affinity"],
+        tags = ["hidden"],
     }]
     async fn affinity_group_update(
         rqctx: RequestContext<Self::Context>,
@@ -1396,7 +1396,7 @@ pub trait NexusExternalApi {
     #[endpoint {
         method = DELETE,
         path = "/v1/affinity-groups/{affinity_group}",
-        tags = ["affinity"],
+        tags = ["hidden"],
     }]
     async fn affinity_group_delete(
         rqctx: RequestContext<Self::Context>,

--- a/openapi/nexus.json
+++ b/openapi/nexus.json
@@ -686,7 +686,7 @@
     "/v1/affinity-groups": {
       "get": {
         "tags": [
-          "affinity"
+          "hidden"
         ],
         "summary": "List affinity groups",
         "operationId": "affinity_group_list",
@@ -753,7 +753,7 @@
       },
       "post": {
         "tags": [
-          "affinity"
+          "hidden"
         ],
         "summary": "Create affinity group",
         "operationId": "affinity_group_create",
@@ -801,7 +801,7 @@
     "/v1/affinity-groups/{affinity_group}": {
       "get": {
         "tags": [
-          "affinity"
+          "hidden"
         ],
         "summary": "Fetch affinity group",
         "operationId": "affinity_group_view",
@@ -845,7 +845,7 @@
       },
       "put": {
         "tags": [
-          "affinity"
+          "hidden"
         ],
         "summary": "Update affinity group",
         "operationId": "affinity_group_update",
@@ -899,7 +899,7 @@
       },
       "delete": {
         "tags": [
-          "affinity"
+          "hidden"
         ],
         "summary": "Delete affinity group",
         "operationId": "affinity_group_delete",
@@ -938,7 +938,7 @@
     "/v1/affinity-groups/{affinity_group}/members": {
       "get": {
         "tags": [
-          "affinity"
+          "hidden"
         ],
         "summary": "List affinity group members",
         "operationId": "affinity_group_member_list",
@@ -1014,7 +1014,7 @@
     "/v1/affinity-groups/{affinity_group}/members/instance/{instance}": {
       "get": {
         "tags": [
-          "affinity"
+          "hidden"
         ],
         "summary": "Fetch affinity group member",
         "operationId": "affinity_group_member_instance_view",
@@ -1065,7 +1065,7 @@
       },
       "post": {
         "tags": [
-          "affinity"
+          "hidden"
         ],
         "summary": "Add member to affinity group",
         "operationId": "affinity_group_member_instance_add",
@@ -1116,7 +1116,7 @@
       },
       "delete": {
         "tags": [
-          "affinity"
+          "hidden"
         ],
         "summary": "Remove member from affinity group",
         "operationId": "affinity_group_member_instance_delete",
@@ -3283,7 +3283,7 @@
     "/v1/instances/{instance}/affinity-groups": {
       "get": {
         "tags": [
-          "instances"
+          "hidden"
         ],
         "summary": "List affinity groups containing instance",
         "operationId": "instance_affinity_group_list",
@@ -24891,7 +24891,7 @@
   "tags": [
     {
       "name": "affinity",
-      "description": "Affinity and anti-affinity groups give control over instance placement.",
+      "description": "Anti-affinity groups give control over instance placement.",
       "externalDocs": {
         "url": "http://docs.oxide.computer/api/affinity"
       }


### PR DESCRIPTION
This PR preserves the non-experimental routes for affinity groups, but uses the tag system to mark them
as "hidden".

Fixes https://github.com/oxidecomputer/omicron/issues/7872