### PR TITLE
switch from dendrite-os back to dendrite

### DIFF
--- a/.github/buildomat/jobs/build-and-test-helios.sh
+++ b/.github/buildomat/jobs/build-and-test-helios.sh
@@ -12,7 +12,7 @@
 #:	"!/var/tmp/omicron_tmp/rustc*",
 #: ]
 #: access_repos = [
-#:	"oxidecomputer/dendrite-os"
+#:	"oxidecomputer/dendrite"
 #: ]
 #:
 #: [[publish]]

--- a/.github/buildomat/jobs/build-and-test-linux.sh
+++ b/.github/buildomat/jobs/build-and-test-linux.sh
@@ -12,7 +12,7 @@
 #:	"!/var/tmp/omicron_tmp/rustc*",
 #: ]
 #: access_repos = [
-#:	"oxidecomputer/dendrite-os",
+#:	"oxidecomputer/dendrite",
 #: ]
 #:
 #: [[publish]]

--- a/.github/reflector/update-dendrite.toml
+++ b/.github/reflector/update-dendrite.toml
@@ -12,7 +12,7 @@ requires_token = true
 # Run in response to the image buildomat job in dendrite completing
 
 [[on]]
-repository = "oxidecomputer/dendrite-os"
+repository = "oxidecomputer/dendrite"
 event = "check_run"
 action = "completed"
 check = "image"

--- a/dev-tools/downloader/src/lib.rs
+++ b/dev-tools/downloader/src/lib.rs
@@ -664,7 +664,7 @@ impl Downloader<'_> {
             get_values_from_file(["COMMIT", "SHA2"], &checksums_path).await?;
 
         let url = format!(
-            "{BUILDOMAT_URL}/oxidecomputer/dendrite-os/openapi/{commit}/dpd.json"
+            "{BUILDOMAT_URL}/oxidecomputer/dendrite/openapi/{commit}/dpd.json"
         );
         let path = download_dir.join(format!("dpd-{commit}.json"));
 
@@ -708,7 +708,7 @@ impl Downloader<'_> {
 
         let tarball_file = "dendrite-stub.tar.gz";
         let tarball_path = download_dir.join(tarball_file);
-        let repo = "oxidecomputer/dendrite-os";
+        let repo = "oxidecomputer/dendrite";
         let url_base = format!("{BUILDOMAT_URL}/{repo}/image/{commit}");
 
         tokio::fs::create_dir_all(&download_dir).await?;

--- a/dev-tools/ls-apis/src/cargo.rs
+++ b/dev-tools/ls-apis/src/cargo.rs
@@ -420,11 +420,11 @@ fn dendrite_workaround(
     cmd.env("CARGO_NET_GIT_FETCH_WITH_CLI", "true");
     cmd.env(
         format!("GIT_CONFIG_KEY_{count}"),
-        "url.git@github.com:oxidecomputer/dendrite-os.insteadOf",
+        "url.git@github.com:oxidecomputer/dendrite.insteadOf",
     );
     cmd.env(
         format!("GIT_CONFIG_VALUE_{count}"),
-        "https://github.com/oxidecomputer/dendrite-os",
+        "https://github.com/oxidecomputer/dendrite",
     );
     cmd.env("GIT_CONFIG_COUNT", (count + 1).to_string());
     cmd.exec().map_err(|err| {

--- a/package-manifest.toml
+++ b/package-manifest.toml
@@ -719,7 +719,7 @@ only_for_targets.image = "standard"
 # 3. Change the below `source.type` key to `"manual"` and comment out or remove
 # the other `source.*` keys.
 source.type = "prebuilt"
-source.repo = "dendrite-os"
+source.repo = "dendrite"
 source.commit = "668f1a2e35e7c76b22ab83fe6c2242d3454e2803"
 source.sha256 = "b3372ddd22c54d70188e6a8526a65c5249000c21c64384c60914259cc4efd445"
 output.type = "zone"
@@ -746,7 +746,7 @@ only_for_targets.image = "standard"
 # 3. Change the below `source.type` key to `"manual"` and comment out or remove
 # the other `source.*` keys.
 source.type = "prebuilt"
-source.repo = "dendrite-os"
+source.repo = "dendrite"
 source.commit = "668f1a2e35e7c76b22ab83fe6c2242d3454e2803"
 source.sha256 = "da35769c141bbd45de20d4ab4716926eca9d18fa0877ebf509e53e1ed0e2e4ce"
 output.type = "zone"
@@ -766,7 +766,7 @@ only_for_targets.image = "standard"
 # 3. Change the below `source.type` key to `"manual"` and comment out or remove
 # the other `source.*` keys.
 source.type = "prebuilt"
-source.repo = "dendrite-os"
+source.repo = "dendrite"
 source.commit = "668f1a2e35e7c76b22ab83fe6c2242d3454e2803"
 source.sha256 = "14c18fde61837b161b48eae8a8af7bbd9e3c9758b723e8dff792466e7b0a30ea"
 output.type = "zone"

--- a/tools/update_dendrite.sh
+++ b/tools/update_dendrite.sh
@@ -21,7 +21,7 @@ PACKAGES=(
   "dendrite-stub"
 )
 
-REPO="oxidecomputer/dendrite-os"
+REPO="oxidecomputer/dendrite"
 
 . "$SOURCE_DIR/update_helpers.sh"
 


### PR DESCRIPTION
I've renamed the old dendrite repo to dendrite-archived, and the new repo from dendrite-os to dendrite.  This PR just replaces all the occurrences of dendrite-os in omicron to point at the new canonical name for the repo.  Note: the name has changed, but the commit IDs haven't - just in case you were expecting to see that delta in package-manifest.toml.