### PR TITLE
Insert project filters into OxQL query AST instead of raw string

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -8118,6 +8118,7 @@ name = "oximeter-db"
 version = "0.1.0"
 dependencies = [
  "anyhow",
+ "assert_matches",
  "async-recursion",
  "async-trait",
  "bcs",

--- a/nexus/src/app/metrics.rs
+++ b/nexus/src/app/metrics.rs
@@ -14,7 +14,9 @@ use nexus_db_queries::{
 use nexus_external_api::TimeseriesSchemaPaginationParams;
 use nexus_types::external_api::params::SystemMetricName;
 use omicron_common::api::external::{Error, InternalContext};
-use oximeter_db::{Measurement, QueryAuthzScope, TimeseriesSchema};
+use oximeter_db::{
+    Measurement, TimeseriesSchema, oxql::query::QueryAuthzScope,
+};
 use std::num::NonZeroU32;
 
 impl super::Nexus {

--- a/nexus/src/app/metrics.rs
+++ b/nexus/src/app/metrics.rs
@@ -161,17 +161,8 @@ impl super::Nexus {
         // Ensure the user has read access to the project
         let (authz_silo, authz_project) =
             project_lookup.lookup_for(authz::Action::Read).await?;
-
-        // Ensure the query only refers to the project
-        let filtered_query = format!(
-            "{} | filter silo_id == \"{}\" && project_id == \"{}\"",
-            query.as_ref(),
-            authz_silo.id(),
-            authz_project.id()
-        );
-
         self.timeseries_client
-            .oxql_query(filtered_query)
+            .oxql_query_project(query, authz_silo.id(), authz_project.id())
             .await
             .map(|result| result.tables)
             .map_err(map_timeseries_err)

--- a/nexus/tests/integration_tests/metrics.rs
+++ b/nexus/tests/integration_tests/metrics.rs
@@ -552,7 +552,7 @@ async fn test_project_timeseries_query(
     assert_eq!(result.len(), 1);
     assert_eq!(result[0].timeseries().len(), 2);
 
-    // TODO: test with a set of subqueries
+    // TODO: test with a gnarly nested query
 
     // expect error when querying a metric that has no project_id on it
     let q5 = "get integration_target:integration_metric";

--- a/nexus/tests/integration_tests/metrics.rs
+++ b/nexus/tests/integration_tests/metrics.rs
@@ -521,9 +521,9 @@ async fn test_project_timeseries_query(
     let q2 = &format!("{} | filter project_id == \"{}\"", q1, p1.identity.id);
 
     let result = metrics_querier.project_timeseries_query("project1", q2).await;
-    // assert_eq!(dbg!(result.clone()).len(), 1);
     assert_eq!(result.len(), 1);
-    assert!(result[0].timeseries().len() > 0);
+    // we get 2 timeseries because there are two instances
+    assert!(result[0].timeseries().len() == 2);
 
     let result = metrics_querier.project_timeseries_query("project2", q2).await;
     assert_eq!(result.len(), 1);
@@ -543,14 +543,14 @@ async fn test_project_timeseries_query(
     assert_eq!(result.len(), 1);
     assert_eq!(result[0].timeseries().len(), 0);
 
-    // now let's test it with group_by. TODO: shit, it's broken
+    // now let's test it with group_by
     let q4 = &format!(
         "{} | align mean_within(1m) | group_by [instance_id], sum",
         q2
     );
     let result = metrics_querier.project_timeseries_query("project1", q4).await;
     assert_eq!(result.len(), 1);
-    assert_eq!(result[0].timeseries().len(), 1);
+    assert_eq!(result[0].timeseries().len(), 2);
 
     // TODO: test with a set of subqueries
 
@@ -571,7 +571,7 @@ async fn test_project_timeseries_query(
         The filter expression refers to \
         identifiers that are not valid for its input \
         table \"integration_target:integration_metric\". \
-        Invalid identifiers: [\"silo_id\", \"project_id\"], \
+        Invalid identifiers: [\"silo_id\"], \
         valid identifiers: [\"datum\", \"metric_name\", \"target_name\", \"timestamp\"]";
     assert!(result.message.ends_with(EXPECTED_ERROR_MESSAGE));
 

--- a/oximeter/db/Cargo.toml
+++ b/oximeter/db/Cargo.toml
@@ -104,6 +104,7 @@ nom.workspace = true
 quote.workspace = true
 
 [dev-dependencies]
+assert_matches.workspace = true
 camino-tempfile.workspace = true
 criterion = { workspace = true, features = [ "async_tokio" ] }
 expectorate.workspace = true

--- a/oximeter/db/src/client/oxql.rs
+++ b/oximeter/db/src/client/oxql.rs
@@ -210,7 +210,7 @@ impl Client {
 
         let parsed_query = oxql::Query::new(query)?;
         // this has to be used for everything
-        let filtered_query = parsed_query.add_filters(vec![
+        let filtered_query = parsed_query.insert_filters(vec![
             uuid_eq_filter("silo_id".to_string(), silo_id),
             uuid_eq_filter("project_id".to_string(), project_id),
         ]);

--- a/oximeter/db/src/client/oxql.rs
+++ b/oximeter/db/src/client/oxql.rs
@@ -20,6 +20,7 @@ use crate::oxql::ast::table_ops::filter;
 use crate::oxql::ast::table_ops::filter::Filter;
 use crate::oxql::ast::table_ops::limit::Limit;
 use crate::oxql::ast::table_ops::limit::LimitKind;
+use crate::oxql::query::uuid_eq_filter;
 use crate::query::field_table_name;
 use oximeter::Measurement;
 use oximeter::TimeseriesSchema;
@@ -210,8 +211,8 @@ impl Client {
         let parsed_query = oxql::Query::new(query)?;
         // this has to be used for everything
         let filtered_query = parsed_query.add_filters(vec![
-            ("silo_id".to_string(), silo_id),
-            ("project_id".to_string(), project_id),
+            uuid_eq_filter("silo_id".to_string(), silo_id),
+            uuid_eq_filter("project_id".to_string(), project_id),
         ]);
 
         let plan = self.build_query_plan(&filtered_query).await?;

--- a/oximeter/db/src/client/oxql.rs
+++ b/oximeter/db/src/client/oxql.rs
@@ -211,8 +211,8 @@ impl Client {
         let parsed_query = oxql::Query::new(query)?;
         // this has to be used for everything
         let filtered_query = parsed_query.insert_filters(vec![
-            uuid_eq_filter("silo_id".to_string(), silo_id),
-            uuid_eq_filter("project_id".to_string(), project_id),
+            uuid_eq_filter("silo_id", silo_id),
+            uuid_eq_filter("project_id", project_id),
         ]);
 
         let plan = self.build_query_plan(&filtered_query).await?;

--- a/oximeter/db/src/lib.rs
+++ b/oximeter/db/src/lib.rs
@@ -54,7 +54,6 @@ pub use client::TestDbWrite;
 pub use client::oxql::OxqlResult;
 pub use client::query_summary::QuerySummary;
 pub use model::OXIMETER_VERSION;
-pub use oxql::query::QueryAuthzScope;
 
 #[derive(Debug, Error)]
 pub enum Error {

--- a/oximeter/db/src/lib.rs
+++ b/oximeter/db/src/lib.rs
@@ -54,6 +54,7 @@ pub use client::TestDbWrite;
 pub use client::oxql::OxqlResult;
 pub use client::query_summary::QuerySummary;
 pub use model::OXIMETER_VERSION;
+pub use oxql::query::QueryAuthzScope;
 
 #[derive(Debug, Error)]
 pub enum Error {

--- a/oximeter/db/src/oxql/ast/mod.rs
+++ b/oximeter/db/src/oxql/ast/mod.rs
@@ -196,7 +196,7 @@ impl Query {
 
     /// Insert filters after the `get`, or in the case of subqueries, recurse
     /// down the tree and insert them after each get.
-    pub(crate) fn add_filters(&self, filters: Vec<Filter>) -> Self {
+    pub(crate) fn insert_filters(&self, filters: Vec<Filter>) -> Self {
         let mut new_ops = self.ops.clone();
 
         match self.first_op() {
@@ -216,7 +216,7 @@ impl Query {
                     ops: op
                         .ops
                         .iter()
-                        .map(|query| query.add_filters(filters.clone()))
+                        .map(|query| query.insert_filters(filters.clone()))
                         .collect(),
                 });
             }

--- a/oximeter/db/src/oxql/ast/mod.rs
+++ b/oximeter/db/src/oxql/ast/mod.rs
@@ -43,6 +43,10 @@ impl fmt::Display for Query {
 }
 
 impl Query {
+    pub(crate) fn new(ops: Vec<TableOp>) -> Self {
+        Self { ops }
+    }
+
     // Return the first operation in the query, which is always a form of `get`.
     fn first_op(&self) -> &TableOp {
         self.ops.first().expect("Should have parsed at least 1 operation")

--- a/oximeter/db/src/oxql/ast/mod.rs
+++ b/oximeter/db/src/oxql/ast/mod.rs
@@ -44,10 +44,6 @@ impl fmt::Display for Query {
 }
 
 impl Query {
-    pub(crate) fn new(ops: Vec<TableOp>) -> Self {
-        Self { ops }
-    }
-
     // Return the first operation in the query, which is always a form of `get`.
     pub(crate) fn first_op(&self) -> &TableOp {
         self.ops.first().expect("Should have parsed at least 1 operation")
@@ -222,7 +218,7 @@ impl Query {
             }
         }
 
-        Self::new(new_ops)
+        Self { ops: new_ops }
     }
 }
 

--- a/oximeter/db/src/oxql/ast/mod.rs
+++ b/oximeter/db/src/oxql/ast/mod.rs
@@ -12,6 +12,7 @@ use std::fmt;
 use chrono::DateTime;
 use chrono::Utc;
 use oximeter::TimeseriesName;
+use table_ops::filter::Filter;
 
 use self::table_ops::BasicTableOp;
 use self::table_ops::GroupedTableOp;
@@ -48,7 +49,7 @@ impl Query {
     }
 
     // Return the first operation in the query, which is always a form of `get`.
-    fn first_op(&self) -> &TableOp {
+    pub(crate) fn first_op(&self) -> &TableOp {
         self.ops.first().expect("Should have parsed at least 1 operation")
     }
 
@@ -191,6 +192,37 @@ impl Query {
                 grouped_max.max(op_max)
             }
         }
+    }
+
+    /// Insert filters after the `get`, or in the case of subqueries, recurse
+    /// down the tree and insert them after each get.
+    pub(crate) fn add_filters(&self, filters: Vec<Filter>) -> Self {
+        let mut new_ops = self.ops.clone();
+
+        match self.first_op() {
+            // for a basic query, just insert the filters after the first entry (the get)
+            TableOp::Basic(_) => {
+                let filter_ops = filters
+                    .iter()
+                    .map(|filter| {
+                        TableOp::Basic(BasicTableOp::Filter(filter.clone()))
+                    })
+                    .collect::<Vec<_>>();
+                new_ops.splice(1..1, filter_ops);
+            }
+            // for a grouped query, recurse to insert the filters in all subqueries
+            TableOp::Grouped(op) => {
+                new_ops[0] = TableOp::Grouped(GroupedTableOp {
+                    ops: op
+                        .ops
+                        .iter()
+                        .map(|query| query.add_filters(filters.clone()))
+                        .collect(),
+                });
+            }
+        }
+
+        Self::new(new_ops)
     }
 }
 

--- a/oximeter/db/src/oxql/query/mod.rs
+++ b/oximeter/db/src/oxql/query/mod.rs
@@ -379,9 +379,9 @@ impl Query {
 
 // TODO: move this to a more appropriate spot
 /// Just a helper for creating a UUID filter node concisely
-pub fn uuid_eq_filter(key: String, id: Uuid) -> Filter {
+pub fn uuid_eq_filter(key: impl AsRef<str>, id: Uuid) -> Filter {
     let simple_filter = SimpleFilter {
-        ident: Ident(key),
+        ident: Ident(key.as_ref().to_string()),
         cmp: Comparison::Eq,
         value: Literal::Uuid(id),
     };
@@ -1042,8 +1042,8 @@ mod tests {
         let silo_id = Uuid::new_v4();
         let project_id = Uuid::new_v4();
         let new_query = query.insert_filters(vec![
-            uuid_eq_filter("silo_id".to_string(), silo_id),
-            uuid_eq_filter("project_id".to_string(), project_id),
+            uuid_eq_filter("silo_id", silo_id),
+            uuid_eq_filter("project_id", project_id),
         ]);
 
         assert_eq!(query.parsed.table_ops().len(), 2);
@@ -1071,9 +1071,8 @@ mod tests {
         let project_id = Uuid::new_v4();
 
         // Define expected filters as AST nodes
-        let silo_filter = uuid_eq_filter("silo_id".to_string(), silo_id);
-        let project_filter =
-            uuid_eq_filter("project_id".to_string(), project_id);
+        let silo_filter = uuid_eq_filter("silo_id", silo_id);
+        let project_filter = uuid_eq_filter("project_id", project_id);
 
         let expected_silo_op =
             TableOp::Basic(BasicTableOp::Filter(silo_filter.clone()));
@@ -1124,9 +1123,8 @@ mod tests {
         let project_id = Uuid::new_v4();
 
         // Define expected filters as AST nodes
-        let silo_filter = uuid_eq_filter("silo_id".to_string(), silo_id);
-        let project_filter =
-            uuid_eq_filter("project_id".to_string(), project_id);
+        let silo_filter = uuid_eq_filter("silo_id", silo_id);
+        let project_filter = uuid_eq_filter("project_id", project_id);
 
         let expected_silo_op =
             TableOp::Basic(BasicTableOp::Filter(silo_filter.clone()));

--- a/oximeter/db/src/oxql/query/mod.rs
+++ b/oximeter/db/src/oxql/query/mod.rs
@@ -446,7 +446,6 @@ mod tests {
     use super::Filter;
     use super::Ident;
     use super::Query;
-    use crate::QueryAuthzScope;
     use crate::oxql::ast::SplitQuery;
     use crate::oxql::ast::cmp::Comparison;
     use crate::oxql::ast::literal::Literal;
@@ -460,6 +459,7 @@ mod tests {
     use crate::oxql::ast::table_ops::join::Join;
     use crate::oxql::ast::table_ops::limit::Limit;
     use crate::oxql::ast::table_ops::limit::LimitKind;
+    use crate::oxql::query::QueryAuthzScope;
     use crate::oxql::query::restrict_filter_idents;
     use crate::oxql::query::uuid_eq_filter;
     use assert_matches::assert_matches;

--- a/oximeter/db/src/shells/oxql.rs
+++ b/oximeter/db/src/shells/oxql.rs
@@ -7,7 +7,7 @@
 // Copyright 2024 Oxide Computer
 
 use super::{list_timeseries, prepare_columns};
-use crate::{Client, OxqlResult, make_client};
+use crate::{Client, OxqlResult, make_client, oxql::query::QueryAuthzScope};
 use clap::Args;
 use crossterm::style::Stylize;
 use oxql_types::Table;
@@ -126,7 +126,10 @@ pub async fn shell(
                             }
                         } else {
                             match client
-                                .oxql_query(cmd.trim().trim_end_matches(';'))
+                                .oxql_query(
+                                    cmd.trim().trim_end_matches(';'),
+                                    QueryAuthzScope::Fleet,
+                                )
                                 .await
                             {
                                 Ok(result) => {

--- a/oximeter/db/tests/integration_test.rs
+++ b/oximeter/db/tests/integration_test.rs
@@ -7,6 +7,7 @@ use clickward::{BasePorts, Deployment, DeploymentConfig, KeeperId};
 use dropshot::test_util::log_prefix_for_test;
 use omicron_test_utils::dev::poll;
 use omicron_test_utils::dev::test_setup_log;
+use oximeter_db::QueryAuthzScope;
 use oximeter_db::{Client, DbWrite, OxqlResult, Sample, TestDbWrite};
 use oximeter_test_utils::wait_for_keepers;
 use slog::{Logger, info};
@@ -213,6 +214,7 @@ async fn test_cluster() -> anyhow::Result<()> {
     let oxql_res1 = client1
         .oxql_query(
             "get virtual_machine:cpu_busy | filter timestamp > @2000-01-01",
+            QueryAuthzScope::Fleet,
         )
         .await
         .expect("failed to get all samples");
@@ -427,7 +429,9 @@ async fn wait_for_num_points(
     poll::wait_for_condition(
         || async {
             let oxql_res = client
-                .oxql_query("get virtual_machine:cpu_busy | filter timestamp > @2000-01-01")
+                .oxql_query(
+                    "get virtual_machine:cpu_busy | filter timestamp > @2000-01-01",
+                    QueryAuthzScope::Fleet)
                 .await
                 .map_err(|_| {
                     poll::CondCheckError::<oximeter_db::Error>::NotYet

--- a/oximeter/db/tests/integration_test.rs
+++ b/oximeter/db/tests/integration_test.rs
@@ -7,7 +7,7 @@ use clickward::{BasePorts, Deployment, DeploymentConfig, KeeperId};
 use dropshot::test_util::log_prefix_for_test;
 use omicron_test_utils::dev::poll;
 use omicron_test_utils::dev::test_setup_log;
-use oximeter_db::QueryAuthzScope;
+use oximeter_db::oxql::query::QueryAuthzScope;
 use oximeter_db::{Client, DbWrite, OxqlResult, Sample, TestDbWrite};
 use oximeter_test_utils::wait_for_keepers;
 use slog::{Logger, info};


### PR DESCRIPTION
Closes #7532. Instead of manipulating the query as a string to add the filters at the end, pass the silo and project IDs to the oximeter client, which has the parsed query AST on hand, and let it do the manipulation.

In case of simple queries, we just insert the filters after the initial `get` operation. For "grouped" queries (like `{ get a:b; get c:d | filter timestamp > @now() } | filter x > y`), the query is a tree, so we recurse down it and insert the filters in every leaf node, which is a simple query.