### PR TITLE
add standalone tool for serving repo depot API from an unpacked TUF repo

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -7436,6 +7436,8 @@ dependencies = [
  "slog",
  "slog-error-chain",
  "tokio",
+ "tough",
+ "tufaceous-artifact",
  "tufaceous-lib",
 ]
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -7420,6 +7420,26 @@ dependencies = [
 ]
 
 [[package]]
+name = "omicron-repo-depot-standalone"
+version = "0.1.0"
+dependencies = [
+ "anyhow",
+ "buf-list",
+ "bytes",
+ "camino",
+ "clap",
+ "dropshot 0.16.0",
+ "futures",
+ "omicron-workspace-hack",
+ "repo-depot-api",
+ "serde_json",
+ "slog",
+ "slog-error-chain",
+ "tokio",
+ "tufaceous-lib",
+]
+
+[[package]]
 name = "omicron-rpaths"
 version = "0.1.0"
 dependencies = [

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -46,6 +46,7 @@ members = [
     "dev-tools/reconfigurator-cli",
     "dev-tools/reconfigurator-exec-unsafe",
     "dev-tools/releng",
+    "dev-tools/repo-depot-standalone",
     "dev-tools/xtask",
     "dns-server",
     "dns-server-api",
@@ -186,6 +187,7 @@ default-members = [
     "dev-tools/reconfigurator-cli",
     "dev-tools/reconfigurator-exec-unsafe",
     "dev-tools/releng",
+    "dev-tools/repo-depot-standalone",
     # Do not include xtask in the list of default members, because this causes
     # hakari to not work as well and build times to be longer.
     # See omicron#4392.

--- a/dev-tools/repo-depot-standalone/Cargo.toml
+++ b/dev-tools/repo-depot-standalone/Cargo.toml
@@ -20,6 +20,8 @@ serde_json.workspace = true
 slog.workspace = true
 slog-error-chain.workspace = true
 tokio = { workspace = true, features = [ "full" ] }
+tough.workspace = true
+tufaceous-artifact.workspace = true
 tufaceous-lib.workspace = true
 omicron-workspace-hack.workspace = true
 

--- a/dev-tools/repo-depot-standalone/Cargo.toml
+++ b/dev-tools/repo-depot-standalone/Cargo.toml
@@ -1,0 +1,28 @@
+[package]
+name = "omicron-repo-depot-standalone"
+version = "0.1.0"
+edition = "2021"
+license = "MPL-2.0"
+
+[lints]
+workspace = true
+
+[dependencies]
+anyhow.workspace = true
+buf-list.workspace = true
+bytes.workspace = true
+camino.workspace = true
+clap.workspace = true
+dropshot.workspace = true
+futures.workspace = true
+repo-depot-api.workspace = true
+serde_json.workspace = true
+slog.workspace = true
+slog-error-chain.workspace = true
+tokio = { workspace = true, features = [ "full" ] }
+tufaceous-lib.workspace = true
+omicron-workspace-hack.workspace = true
+
+[[bin]]
+name = "repo-depot-standalone"
+path = "src/main.rs"

--- a/dev-tools/repo-depot-standalone/src/main.rs
+++ b/dev-tools/repo-depot-standalone/src/main.rs
@@ -1,0 +1,157 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at https://mozilla.org/MPL/2.0/.
+
+//! Serve the Repo Depot API from an extracted TUF repo
+
+use anyhow::Context;
+use anyhow::anyhow;
+use buf_list::BufList;
+use bytes::Buf;
+use camino::Utf8PathBuf;
+use clap::Parser;
+use dropshot::FreeformBody;
+use dropshot::HttpError;
+use dropshot::HttpResponseOk;
+use dropshot::Path;
+use dropshot::RequestContext;
+use dropshot::ServerBuilder;
+use futures::stream::TryStreamExt;
+use repo_depot_api::ArtifactPathParams;
+use repo_depot_api::RepoDepotApi;
+use slog::info;
+use slog_error_chain::InlineErrorChain;
+use std::net::SocketAddr;
+use std::sync::Arc;
+use tufaceous_lib::OmicronRepo;
+
+#[tokio::main]
+async fn main() -> Result<(), anyhow::Error> {
+    let args = RepoDepotStandalone::parse();
+
+    if let Err(error) = args.exec().await {
+        eprintln!("error: {:#}", error);
+        std::process::exit(1);
+    }
+
+    Ok(())
+}
+
+/// Serve the Repo Depot API from an extracted TUF repo
+#[derive(Debug, Parser)]
+struct RepoDepotStandalone {
+    /// log level filter
+    #[arg(
+        env,
+        long,
+        value_parser = parse_dropshot_log_level,
+        default_value = "info",
+    )]
+    log_level: dropshot::ConfigLoggingLevel,
+
+    /// address on which to serve the API
+    #[arg(long, default_value = "[::]:0")]
+    listen_addr: SocketAddr,
+
+    /// path to local extracted Omicron TUF repository
+    repo_path: Utf8PathBuf,
+}
+
+fn parse_dropshot_log_level(
+    s: &str,
+) -> Result<dropshot::ConfigLoggingLevel, anyhow::Error> {
+    serde_json::from_str(&format!("{:?}", s)).context("parsing log level")
+}
+
+impl RepoDepotStandalone {
+    async fn exec(self) -> Result<(), anyhow::Error> {
+        let log = dropshot::ConfigLogging::StderrTerminal {
+            level: self.log_level.clone(),
+        }
+        .to_logger("repo-depot-standalone")
+        .context("failed to create logger")?;
+
+        let repo_path = &self.repo_path;
+        let repo =
+            OmicronRepo::load_untrusted_ignore_expiration(&log, repo_path)
+                .await
+                .with_context(|| {
+                    format!("loading repository at {repo_path}")
+                })?;
+        info!(&log, "loaded Omicron TUF repository"; "path" => %repo_path);
+
+        let my_api = repo_depot_api::repo_depot_api_mod::api_description::<
+            StandaloneApiImpl,
+        >()
+        .unwrap();
+
+        let server = ServerBuilder::new(my_api, Arc::new(repo), log)
+            .config(dropshot::ConfigDropshot {
+                bind_address: self.listen_addr,
+                ..Default::default()
+            })
+            .start()
+            .context("failed to create server")?;
+
+        server.await.map_err(|error| anyhow!("server shut down: {error}"))
+    }
+}
+
+struct StandaloneApiImpl;
+
+impl RepoDepotApi for StandaloneApiImpl {
+    type Context = Arc<OmicronRepo>;
+
+    async fn artifact_get_by_sha256(
+        rqctx: RequestContext<Self::Context>,
+        path_params: Path<ArtifactPathParams>,
+    ) -> Result<HttpResponseOk<FreeformBody>, HttpError> {
+        let omicron_repo = rqctx.context();
+        let tuf_repo = omicron_repo.repo();
+        let fetch_sha = path_params.into_inner().sha256;
+        let target_name = tuf_repo
+            .targets()
+            .signed
+            .targets
+            .iter()
+            .find(|(_, target)| {
+                let fetch_array: &[u8] = fetch_sha.as_ref();
+                let target_array: &[u8] = &target.hashes.sha256;
+                fetch_array == target_array
+            })
+            .ok_or_else(|| {
+                HttpError::for_not_found(
+                    None,
+                    String::from("found no target with this hash"),
+                )
+            })?
+            .0;
+        let reader = tuf_repo
+            .read_target(&target_name)
+            .await
+            .map_err(|error| {
+                HttpError::for_internal_error(format!(
+                    "failed to read target from TUF repo: {}",
+                    InlineErrorChain::new(&error),
+                ))
+            })?
+            .ok_or_else(|| {
+                // We already checked above that the hash is present in the TUF
+                // repo so this should not be a 404.
+                HttpError::for_internal_error(String::from(
+                    "missing target from TUF repo",
+                ))
+            })?;
+        let mut buf_list =
+            reader.try_collect::<BufList>().await.map_err(|error| {
+                HttpError::for_internal_error(format!(
+                    "reading target from TUF repo: {}",
+                    InlineErrorChain::new(&error),
+                ))
+            })?;
+        let body = dropshot::Body::with_content(
+            buf_list.copy_to_bytes(buf_list.num_bytes()),
+        );
+        Ok(HttpResponseOk(FreeformBody::from(body)))
+    }
+}


### PR DESCRIPTION
While working on SP/RoT upgrade I found it would be useful to have a tool that will serve the TUF repo depot API backed by a local, extracted TUF repo.

Here's an example.  I've unpacked the R12 TUF repo into `$HOME/tuf-repos/R12/repo`:

```
$ cargo run --bin=repo-depot-standalone ~/tuf-repos/R12/repo
    Finished `dev` profile [unoptimized + debuginfo] target(s) in 0.93s
     Running `target/debug/repo-depot-standalone /home/dap/tuf-repos/R12/repo`
Apr 04 22:16:57.304 INFO loaded Omicron TUF repository, path: /home/dap/tuf-repos/R12/repo
Apr 04 22:16:57.305 INFO listening, local_addr: [::]:41593
...
```

Here's grabbing an artifact from it by SHA sum and verifying the sum:

```
$ curl http://[::]:41593/artifact/sha256/f2fcb24dbb85a8be78235226fc95dd183250f75819bc813befdf5a166a72acd0 | shasum -a 256
  % Total    % Received % Xferd  Average Speed   Time    Time     Time  Current
                                 Dload  Upload   Total   Spent    Left  Speed
100 4755k  100 4755k    0     0  85.3M      0 --:--:-- --:--:-- --:--:-- 85.9M
f2fcb24dbb85a8be78235226fc95dd183250f75819bc813befdf5a166a72acd0  -
```

Here's giving a made up hash:

```
$ curl -i http://[::]:41593/artifact/sha256/f2fcb24dbb85a8be78235226fc95dd183250f75819bc813befdf5a166a72acd1 
HTTP/1.1 404 Not Found
content-type: application/json
x-request-id: 2204169b-e61d-43c8-8d4d-03033cca6e46
content-length: 84
date: Fri, 04 Apr 2025 22:18:15 GMT

{
  "request_id": "2204169b-e61d-43c8-8d4d-03033cca6e46",
  "message": "Not Found"
}
```