### PR TITLE
sled-agent: clean up and reorder VMM termination logic

### DIFF
--- a/sled-agent/src/common/instance.rs
+++ b/sled-agent/src/common/instance.rs
@@ -188,7 +188,7 @@ impl InstanceStates {
         &self.vmm
     }
 
-    pub fn vmm_halted(&self) -> bool {
+    pub fn vmm_is_halted(&self) -> bool {
         matches!(self.vmm.state, VmmState::Destroyed | VmmState::Failed)
     }
 
@@ -276,7 +276,7 @@ impl InstanceStates {
             transition_migration(&mut self.migration_out, m, observed.time);
         }
 
-        if self.vmm_halted() {
+        if self.vmm_is_halted() {
             // If there's an active migration and the VMM is suddenly gone,
             // that should constitute a migration failure!
             if let Some(ref mut m) = self.migration_in {
@@ -412,7 +412,7 @@ mod test {
             let mut instance_state = make_instance();
             instance_state
                 .apply_propolis_observation(&make_observed_state(state.into()));
-            assert!(instance_state.vmm_halted())
+            assert!(instance_state.vmm_is_halted())
         }
     }
 
@@ -472,7 +472,7 @@ mod test {
         // instance's state generation.
         let prev = state.clone();
         state.apply_propolis_observation(&observed);
-        assert!(!state.vmm_halted());
+        assert!(!state.vmm_is_halted());
         assert_state_change_has_gen_change(&prev, &state);
 
         // The migration state should transition to "completed"
@@ -492,7 +492,7 @@ mod test {
         let prev = state.clone();
         observed.vmm_state = PropolisInstanceState(Observed::Stopped);
         state.apply_propolis_observation(&observed);
-        assert!(!state.vmm_halted());
+        assert!(!state.vmm_is_halted());
         assert_state_change_has_gen_change(&prev, &state);
 
         // The Stopped state is translated internally to Stopping to prevent
@@ -513,7 +513,7 @@ mod test {
         let prev = state.clone();
         observed.vmm_state = PropolisInstanceState(Observed::Destroyed);
         state.apply_propolis_observation(&observed);
-        assert!(state.vmm_halted());
+        assert!(state.vmm_is_halted());
         assert_state_change_has_gen_change(&prev, &state);
         assert_eq!(state.vmm.state, VmmState::Destroyed);
         assert!(state.vmm.gen > prev.vmm.gen);
@@ -553,7 +553,7 @@ mod test {
 
         let prev = state.clone();
         state.apply_propolis_observation(&observed);
-        assert!(state.vmm_halted());
+        assert!(state.vmm_is_halted());
         assert_state_change_has_gen_change(&prev, &state);
         assert_eq!(state.vmm.state, VmmState::Failed);
         assert!(state.vmm.gen > prev.vmm.gen);

--- a/sled-agent/src/instance.rs
+++ b/sled-agent/src/instance.rs
@@ -2033,8 +2033,7 @@ impl InstanceRunner {
                     &running_state.running_zone,
                     migration_params,
                 )
-                .await
-                .map_err(Into::into);
+                .await;
         }
 
         // Otherwise, set up the zone first, then ask Propolis to create the VM.
@@ -2042,7 +2041,7 @@ impl InstanceRunner {
             Ok(setup) => setup,
             Err(e) => {
                 error!(&self.log, "failed to set up Propolis zone"; "error" => ?e);
-                return Err(e.into());
+                return Err(e);
             }
         };
 
@@ -2055,7 +2054,7 @@ impl InstanceRunner {
             .await
         {
             error!(&self.log, "failed to create Propolis VM"; "error" => ?e);
-            return Err(e.into());
+            return Err(e);
         }
 
         // Move ownership of the zone into the instance and set up state

--- a/sled-agent/src/instance_manager.rs
+++ b/sled-agent/src/instance_manager.rs
@@ -418,7 +418,7 @@ enum InstanceManagerRequest {
 
 // Requests that the instance manager stop processing information about a
 // particular instance.
-struct InstanceDeregisterRequest {
+pub(crate) struct InstanceDeregisterRequest {
     id: PropolisUuid,
 }
 
@@ -874,7 +874,7 @@ pub struct InstanceTicket {
 impl InstanceTicket {
     // Creates a new instance ticket for the Propolis job with the supplied `id`
     // to be removed from the manager on destruction.
-    fn new(
+    pub(crate) fn new(
         id: PropolisUuid,
         terminate_tx: mpsc::UnboundedSender<InstanceDeregisterRequest>,
     ) -> Self {

--- a/sled-agent/src/instance_manager.rs
+++ b/sled-agent/src/instance_manager.rs
@@ -885,13 +885,19 @@ impl InstanceTicket {
     pub(crate) fn new_without_manager_for_test(id: PropolisUuid) -> Self {
         Self { id, terminate_tx: None }
     }
-}
 
-impl Drop for InstanceTicket {
-    fn drop(&mut self) {
+    /// Informs this instance's manager that it should release the instance.
+    /// Does nothing if the ticket has already been deregistered.
+    pub(crate) fn deregister(&mut self) {
         if let Some(terminate_tx) = self.terminate_tx.take() {
             let _ =
                 terminate_tx.send(InstanceDeregisterRequest { id: self.id });
         }
+    }
+}
+
+impl Drop for InstanceTicket {
+    fn drop(&mut self) {
+        self.deregister();
     }
 }

--- a/sled-agent/src/sim/instance.rs
+++ b/sled-agent/src/sim/instance.rs
@@ -308,7 +308,7 @@ impl SimInstanceInner {
                 &self.last_response,
             ));
 
-            self.state.vmm_halted().then_some(InstanceAction::Destroy)
+            self.state.vmm_is_halted().then_some(InstanceAction::Destroy)
         } else {
             None
         }


### PR DESCRIPTION
Try to clean up sled-agent's logic for terminating Propolis zones. Specifically, change `InstanceRunner::terminate` and its callees so that they no longer call `InstanceTicket::deregister` before the runner gets a chance to publish a terminal VMM state to Nexus. This fixes a race in which Nexus could call sled-agent, get a "VMM gone" response, and move the relevant VMM to Failed when sled-agent actually intended to move it to Destroyed. 

Do some housekeeping to (try to) make this code easier to reason about:

- Rename various types and routines to make their purposes and semantics a little clearer. (In particular, try not to have so many routines named "terminate" or variations thereon.)
- Clean up some code and comments that are obsolete now that the instance monitor and instance runner tasks pass messages instead of sharing state.
- Make explicit termination requests specify who is responsible for updating the terminated VMM's state: sometimes it's sled-agent (e.g. when terminating a Propolis because its U.2 is gone), but sometimes it's Nexus (e.g. when unwinding an instance start saga). This allows the instance runner to avoid updating a VMM that Nexus expects to be able to control.
- Remove `InstanceTicket::deregister` and move its implementation into `InstanceTicket::drop`. This prevents the runner from sending a "deregister me" message "too early"; it can still forget to send a VMM's terminal state to Nexus, but the structure of the main runner loop should help ensure that this last update always gets sent.

Fixes #7927.