### PR TITLE
[sled-agent] Ensure Support Bundles are mounted

### DIFF
--- a/sled-agent/src/backing_fs.rs
+++ b/sled-agent/src/backing_fs.rs
@@ -134,7 +134,7 @@ pub(crate) fn ensure_backing_fs(
             sled_storage::dataset::M2_BACKING_DATASET,
             bfs.name
         );
-        let mountpoint = Mountpoint::Path(Utf8PathBuf::from(bfs.mountpoint));
+        let mountpoint = Mountpoint(Utf8PathBuf::from(bfs.mountpoint));
 
         info!(log, "Ensuring dataset {}", dataset);
 

--- a/sled-agent/src/bootstrap/pre_server.rs
+++ b/sled-agent/src/bootstrap/pre_server.rs
@@ -275,7 +275,7 @@ fn ensure_zfs_key_directory_exists(log: &Logger) -> Result<(), StartError> {
 fn ensure_zfs_ramdisk_dataset() -> Result<(), StartError> {
     Zfs::ensure_dataset(zfs::DatasetEnsureArgs {
         name: zfs::ZONE_ZFS_RAMDISK_DATASET,
-        mountpoint: zfs::Mountpoint::Path(Utf8PathBuf::from(
+        mountpoint: zfs::Mountpoint(Utf8PathBuf::from(
             zfs::ZONE_ZFS_RAMDISK_DATASET_MOUNTPOINT,
         )),
         can_mount: zfs::CanMount::On,

--- a/sled-storage/src/dataset.rs
+++ b/sled-storage/src/dataset.rs
@@ -266,7 +266,7 @@ pub(crate) async fn ensure_zpool_has_datasets(
         let name = format!("{}/{}", zpool_name, dataset);
         let result = Zfs::ensure_dataset(zfs::DatasetEnsureArgs {
             name: &name,
-            mountpoint: Mountpoint::Path(mountpoint),
+            mountpoint: Mountpoint(mountpoint),
             can_mount: zfs::CanMount::On,
             zoned,
             encryption_details: Some(encryption_details),
@@ -337,7 +337,7 @@ pub(crate) async fn ensure_zpool_has_datasets(
         });
         Zfs::ensure_dataset(zfs::DatasetEnsureArgs {
             name,
-            mountpoint: Mountpoint::Path(mountpoint),
+            mountpoint: Mountpoint(mountpoint),
             can_mount: zfs::CanMount::On,
             zoned,
             encryption_details,

--- a/sled-storage/src/manager.rs
+++ b/sled-storage/src/manager.rs
@@ -169,12 +169,9 @@ impl NestedDatasetLocation {
         mount_root: &Utf8Path,
     ) -> Result<Utf8PathBuf, Error> {
         let mountpoint = self.mountpoint(mount_root);
-        let zoned = false;
         Zfs::ensure_dataset_mounted_if_exists(
             &self.full_name(),
-            &Mountpoint::Path(mountpoint.clone()),
-            CanMount::On,
-            zoned,
+            &Mountpoint(mountpoint.clone()),
         )?;
 
         return Ok(mountpoint);
@@ -1106,7 +1103,7 @@ impl StorageManager {
         let mountpoint_path = config.name.mountpoint(mountpoint_root);
         let details = DatasetCreationDetails {
             zoned: config.name.kind().zoned(),
-            mountpoint: Mountpoint::Path(mountpoint_path),
+            mountpoint: Mountpoint(mountpoint_path),
             full_name: config.name.full_name(),
         };
 
@@ -1195,7 +1192,7 @@ impl StorageManager {
 
         let details = DatasetCreationDetails {
             zoned: false,
-            mountpoint: Mountpoint::Path(mountpoint_path),
+            mountpoint: Mountpoint(mountpoint_path),
             full_name: config.name.full_name(),
         };
 
@@ -1554,7 +1551,7 @@ impl StorageManager {
         let size_details = None;
         Zfs::ensure_dataset(DatasetEnsureArgs {
             name: fs_name,
-            mountpoint: Mountpoint::Path(Utf8PathBuf::from("/data")),
+            mountpoint: Mountpoint(Utf8PathBuf::from("/data")),
             can_mount: CanMount::On,
             zoned,
             encryption_details,


### PR DESCRIPTION
Related to https://github.com/oxidecomputer/omicron/pull/7887 - we have seen that datasets nested within
encrypted datasets are not automatically mounted on reboot.

To mitigate this issue: whenever we perform an operation which attempts to read the dataset, ensure
that it is mounted. To do this operation, some minor refactors were made to mounting-related code.

Fixes https://github.com/oxidecomputer/omicron/issues/7884