### PR TITLE
[meta] warn on some style clippy lints

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -306,7 +306,10 @@ iter_nth = "warn"
 iter_nth_zero = "warn"
 iter_skip_next = "warn"
 len_zero = "warn"
+needless_borrow = "warn"
+println_empty_string = "warn"
 redundant_field_names = "warn"
+unwrap_or_default = "warn"
 # `declare_interior_mutable_const` is classified as a style lint, but it can
 # identify real bugs (e.g., declarying a `const Atomic` and using it like
 # a `static Atomic`). However, it is also subject to false positives (e.g.,

--- a/bootstore/src/schemes/v0/fsm.rs
+++ b/bootstore/src/schemes/v0/fsm.rs
@@ -706,14 +706,14 @@ fn decrypt_and_send_share_response(
     // If decryption fails, we log it locally. The peer will timeout and move to
     // the next one. This is really bad and should be impossible.
     let shares = pkg
-        .decrypt_shares(&rack_secret)
+        .decrypt_shares(rack_secret)
         .map_err(|_| ApiError::FailedToDecryptExtraShares)?;
 
     if let Some(idx) = distributed_shares.get(&from) {
         // The share was already handed out to this peer. Give back the same
         // one.
         let share = &shares.expose_secret()[idx.0];
-        queue_pkg_response(from, request_id, pkg, &share, envelopes);
+        queue_pkg_response(from, request_id, pkg, share, envelopes);
         // No state was updated, so no need to persist
         Ok(None)
     } else {

--- a/bootstore/src/schemes/v0/share_pkg.rs
+++ b/bootstore/src/schemes/v0/share_pkg.rs
@@ -97,7 +97,7 @@ impl SharePkg {
     ) -> Result<Secret<Vec<Vec<u8>>>, TrustQuorumError> {
         let cipher = derive_encryption_key(
             &self.common.rack_uuid,
-            &rack_secret,
+            rack_secret,
             &self.salt,
         );
         decrypt_shares(self.nonce, &cipher, &self.encrypted_shares)

--- a/bootstore/src/schemes/v0/storage.rs
+++ b/bootstore/src/schemes/v0/storage.rs
@@ -66,7 +66,7 @@ impl PersistentFsmState {
         config: FsmConfig,
     ) -> (Fsm, u64) {
         if let Some(ledger) =
-            Ledger::<PersistentFsmState>::new(&log, paths).await
+            Ledger::<PersistentFsmState>::new(log, paths).await
         {
             let persistent_state = ledger.into_inner();
             info!(
@@ -134,7 +134,7 @@ impl NetworkConfig {
         log: &Logger,
         paths: Vec<Utf8PathBuf>,
     ) -> Option<NetworkConfig> {
-        if let Some(ledger) = Ledger::<NetworkConfig>::new(&log, paths).await {
+        if let Some(ledger) = Ledger::<NetworkConfig>::new(log, paths).await {
             let config = ledger.into_inner();
             info!(
                 log,

--- a/bootstore/tests/v0-fsm-proptest-learner.rs
+++ b/bootstore/tests/v0-fsm-proptest-learner.rs
@@ -221,7 +221,7 @@ impl TestState {
     // outstanding request remains.
     fn disconnect_all_peers_and_clear_pending_learn_request(&mut self) {
         for peer in &self.common.connected_peers {
-            self.common.sut.on_disconnected(&peer);
+            self.common.sut.on_disconnected(peer);
         }
         self.common.connected_peers = BTreeSet::new();
         for _ in 0..self.ticks_until_learn_timeout() {

--- a/clickhouse-admin/types/src/lib.rs
+++ b/clickhouse-admin/types/src/lib.rs
@@ -548,7 +548,7 @@ impl RaftConfig {
             let Some(address) = split_info.next() else {
                 bail!("Returned None while attempting to retrieve address")
             };
-            let Some(port) = address.split(':').next_back() else {
+            let Some(port) = address.split(':').last() else {
                 bail!("A port could not be extracted from {address}")
             };
             let raft_port = match u16::from_str(port) {

--- a/common/src/zpool_name.rs
+++ b/common/src/zpool_name.rs
@@ -281,7 +281,7 @@ mod test {
 
         for bad_name in &bad_names {
             assert!(
-                parse_name(&bad_name).is_err(),
+                parse_name(bad_name).is_err(),
                 "Parsing {} should fail",
                 bad_name
             );

--- a/dev-tools/clickana/src/chart.rs
+++ b/dev-tools/clickana/src/chart.rs
@@ -225,7 +225,7 @@ struct YAxisValues {
 impl YAxisValues {
     fn new(unit: Unit, raw_data: &Vec<SystemTimeSeries>) -> Result<Self> {
         // Retrieve values only to create Y axis bounds and labels
-        let values = TimeSeriesValues::new(&raw_data);
+        let values = TimeSeriesValues::new(raw_data);
         let max_value = values.max()?;
         let min_value = values.min()?;
 
@@ -322,7 +322,7 @@ pub struct XAxisTimestamps {
 impl XAxisTimestamps {
     fn new(raw_data: &Vec<SystemTimeSeries>) -> Result<Self> {
         // Retrieve timestamps only to create chart bounds and labels
-        let timestamps = TimeSeriesTimestamps::new(&raw_data);
+        let timestamps = TimeSeriesTimestamps::new(raw_data);
         // These timestamps will be used to calculate start and end timestamps in order
         // to create labels and set bounds for the X axis. As above, some of these conversions
         // may lose precision, but it's OK as these values are only used to make sure the

--- a/dev-tools/downloader/src/lib.rs
+++ b/dev-tools/downloader/src/lib.rs
@@ -410,7 +410,7 @@ async fn download_file_and_verify(
 ) -> Result<()> {
     let do_download = if path.exists() {
         info!(log, "Already downloaded ({path})");
-        if algorithm.checksum(&path).await? == checksum {
+        if algorithm.checksum(path).await? == checksum {
             info!(
                 log,
                 "Checksum matches already downloaded file - skipping download"
@@ -430,7 +430,7 @@ async fn download_file_and_verify(
                 log,
                 "Downloading {path} (attempt {attempt}/{RETRY_ATTEMPTS})"
             );
-            match streaming_download(&url, &path).await {
+            match streaming_download(url, path).await {
                 Ok(()) => break,
                 Err(err) => {
                     if attempt == RETRY_ATTEMPTS {
@@ -443,7 +443,7 @@ async fn download_file_and_verify(
         }
     }
 
-    let observed_checksum = algorithm.checksum(&path).await?;
+    let observed_checksum = algorithm.checksum(path).await?;
     if observed_checksum != checksum {
         bail!(
             "Checksum mismatch (saw {observed_checksum}, expected {checksum})"

--- a/dev-tools/ls-apis/src/bin/ls-apis.rs
+++ b/dev-tools/ls-apis/src/bin/ls-apis.rs
@@ -104,7 +104,7 @@ fn run_adoc(apis: &SystemApis) -> Result<()> {
     println!("|Consumers (`repo:path`; excluding omdb and tests)");
     println!("|Versioning");
     println!("|Notes");
-    println!("");
+    println!();
 
     let metadata = apis.api_metadata();
     for api in metadata.apis() {
@@ -135,7 +135,7 @@ fn run_adoc(apis: &SystemApis) -> Result<()> {
         };
 
         print!("|{}", api.notes.as_deref().unwrap_or("-\n"));
-        println!("");
+        println!();
     }
 
     println!("|===\n");
@@ -174,7 +174,7 @@ fn run_apis(apis: &SystemApis, args: ShowDepsArgs) -> Result<()> {
                 }
             }
         }
-        println!("");
+        println!();
     }
     Ok(())
 }
@@ -195,7 +195,7 @@ fn run_deployment_units(apis: &SystemApis, args: DotArgs) -> Result<()> {
                     args.show_deps,
                     args.filter,
                 )?;
-                println!("");
+                println!();
             }
         }
     };
@@ -232,7 +232,7 @@ fn print_server_components<'a>(
             }
         }
 
-        println!("");
+        println!();
     }
     Ok(())
 }

--- a/dev-tools/ls-apis/src/cargo.rs
+++ b/dev-tools/ls-apis/src/cargo.rs
@@ -230,7 +230,7 @@ impl Workspace {
                     &self.workspace_root,
                 )
             })?;
-        let path = cargo_toml_parent(&relative_path, &manifest_path)?;
+        let path = cargo_toml_parent(relative_path, manifest_path)?;
         Ok(path)
     }
 

--- a/dev-tools/ls-apis/src/system_apis.rs
+++ b/dev-tools/ls-apis/src/system_apis.rs
@@ -285,7 +285,7 @@ impl SystemApis {
                 if filter.should_include(
                     &self.api_metadata,
                     &self.workspaces,
-                    &client,
+                    client,
                     p,
                 )? {
                     include.push(p);
@@ -696,7 +696,7 @@ impl<'a> DagCheck<'a> {
     ) {
         self.proposed_client_managed
             .entry(client_pkgname)
-            .or_insert_with(Vec::new)
+            .or_default()
             .push(reason);
     }
 
@@ -707,7 +707,7 @@ impl<'a> DagCheck<'a> {
     ) {
         self.proposed_server_managed
             .entry(client_pkgname)
-            .or_insert_with(Vec::new)
+            .or_default()
             .push(reason);
     }
 
@@ -739,7 +739,7 @@ impl<'a> DagCheck<'a> {
         // this order.
         self.proposed_upick
             .entry(client_pkgname1)
-            .or_insert_with(BTreeSet::new)
+            .or_default()
             .insert(client_pkgname2);
     }
 
@@ -955,15 +955,15 @@ impl<'a> ClientDependenciesTracker<'a> {
         let client_pkgname = ClientPackageName::from(pkgname.to_owned());
         self.api_consumers
             .entry(client_pkgname.clone())
-            .or_insert_with(BTreeMap::new)
+            .or_default()
             .entry(server_pkgname.clone())
-            .or_insert_with(Vec::new)
+            .or_default()
             .push(dep_path.clone());
         self.apis_consumed
             .entry(server_pkgname.clone())
-            .or_insert_with(BTreeMap::new)
+            .or_default()
             .entry(client_pkgname)
-            .or_insert_with(Vec::new)
+            .or_default()
             .push(dep_path.clone());
     }
 }

--- a/dev-tools/ls-apis/src/workspaces.rs
+++ b/dev-tools/ls-apis/src/workspaces.rs
@@ -120,7 +120,7 @@ impl Workspaces {
         workspaces.insert(
             String::from("dendrite"),
             load_dependent_repo(
-                &maghemite,
+                maghemite,
                 "dendrite",
                 "dpd-client",
                 None,
@@ -177,7 +177,7 @@ impl Workspaces {
             .workspaces
             .values()
             .filter_map(|w| {
-                w.find_workspace_package(&server_pkgname).map(|p| (w, p))
+                w.find_workspace_package(server_pkgname).map(|p| (w, p))
             })
             .collect();
 

--- a/dev-tools/omdb/src/bin/omdb/db.rs
+++ b/dev-tools/omdb/src/bin/omdb/db.rs
@@ -1158,36 +1158,36 @@ impl DbArgs {
                         replacements_to_do(&opctx, &datastore).await
                     }
                     DbCommands::Rack(RackArgs { command: RackCommands::List }) => {
-                        cmd_db_rack_list(&opctx, &datastore, &fetch_opts).await
+                        cmd_db_rack_list(&opctx, &datastore, fetch_opts).await
                     }
                     DbCommands::Disks(DiskArgs {
                         command: DiskCommands::Info(uuid),
                     }) => cmd_db_disk_info(&opctx, &datastore, uuid).await,
                     DbCommands::Disks(DiskArgs { command: DiskCommands::List }) => {
-                        cmd_db_disk_list(&datastore, &fetch_opts).await
+                        cmd_db_disk_list(&datastore, fetch_opts).await
                     }
                     DbCommands::Disks(DiskArgs {
                         command: DiskCommands::Physical(uuid),
                     }) => {
-                        cmd_db_disk_physical(&opctx, &datastore, &fetch_opts, uuid)
+                        cmd_db_disk_physical(&opctx, &datastore, fetch_opts, uuid)
                             .await
                     }
                     DbCommands::Dns(DnsArgs { command: DnsCommands::Show }) => {
-                        cmd_db_dns_show(&opctx, &datastore, &fetch_opts).await
+                        cmd_db_dns_show(&opctx, &datastore, fetch_opts).await
                     }
                     DbCommands::Dns(DnsArgs { command: DnsCommands::Diff(args) }) => {
-                        cmd_db_dns_diff(&opctx, &datastore, &fetch_opts, args)
+                        cmd_db_dns_diff(&opctx, &datastore, fetch_opts, args)
                             .await
                     }
                     DbCommands::Dns(DnsArgs { command: DnsCommands::Names(args) }) => {
-                        cmd_db_dns_names(&opctx, &datastore, &fetch_opts, args)
+                        cmd_db_dns_names(&opctx, &datastore, fetch_opts, args)
                             .await
                     }
                     DbCommands::Inventory(inventory_args) => {
                         cmd_db_inventory(
                             &opctx,
                             &datastore,
-                            &fetch_opts,
+                            fetch_opts,
                             inventory_args,
                         )
                         .await
@@ -1196,7 +1196,7 @@ impl DbArgs {
                         cmd_db_physical_disks(
                             &opctx,
                             &datastore,
-                            &fetch_opts,
+                            fetch_opts,
                             args,
                         )
                         .await
@@ -1209,7 +1209,7 @@ impl DbArgs {
                     }) => {
                         cmd_db_region_list(
                             &datastore,
-                            &fetch_opts,
+                            fetch_opts,
                             region_list_args,
                         )
                         .await
@@ -1219,7 +1219,7 @@ impl DbArgs {
                     }) => {
                         cmd_db_region_used_by(
                             &datastore,
-                            &fetch_opts,
+                            fetch_opts,
                             region_used_by_args,
                         )
                         .await
@@ -1232,7 +1232,7 @@ impl DbArgs {
                     }) => {
                         cmd_db_region_replacement_list(
                             &datastore,
-                            &fetch_opts,
+                            fetch_opts,
                             args,
                         )
                         .await
@@ -1243,7 +1243,7 @@ impl DbArgs {
                         cmd_db_region_replacement_status(
                             &opctx,
                             &datastore,
-                            &fetch_opts,
+                            fetch_opts,
                         )
                         .await
                     }
@@ -1262,28 +1262,28 @@ impl DbArgs {
                         .await
                     }
                     DbCommands::Saga(args) => {
-                        args.exec(&omdb, &opctx, &datastore).await
+                        args.exec(omdb, &opctx, &datastore).await
                     }
                     DbCommands::Sleds(args) => {
-                        cmd_db_sleds(&opctx, &datastore, &fetch_opts, args).await
+                        cmd_db_sleds(&opctx, &datastore, fetch_opts, args).await
                     }
                     DbCommands::Instance(InstanceArgs {
                         command: InstanceCommands::List(args),
                     }) => {
-                        cmd_db_instances(&opctx, &datastore, &fetch_opts, args)
+                        cmd_db_instances(&opctx, &datastore, fetch_opts, args)
                             .await
                     }
                     DbCommands::Instance(InstanceArgs {
                         command: InstanceCommands::Info(args),
                     }) => {
-                        cmd_db_instance_info(&opctx, &datastore, &fetch_opts, args)
+                        cmd_db_instance_info(&opctx, &datastore, fetch_opts, args)
                             .await
                     }
                     DbCommands::Instances(instances_options) => {
                         cmd_db_instances(
                             &opctx,
                             &datastore,
-                            &fetch_opts,
+                            fetch_opts,
                             instances_options,
                         )
                         .await
@@ -1292,7 +1292,7 @@ impl DbArgs {
                         command: NetworkCommands::ListEips,
                         verbose,
                     }) => {
-                        cmd_db_eips(&opctx, &datastore, &fetch_opts, *verbose)
+                        cmd_db_eips(&opctx, &datastore, fetch_opts, *verbose)
                             .await
                     }
                     DbCommands::Network(NetworkArgs {
@@ -1301,7 +1301,7 @@ impl DbArgs {
                     }) => {
                         cmd_db_network_list_vnics(
                             &datastore,
-                            &fetch_opts,
+                            fetch_opts,
                             *verbose,
                         )
                         .await
@@ -1309,14 +1309,14 @@ impl DbArgs {
                     DbCommands::Migrations(MigrationsArgs {
                         command: MigrationsCommands::List(args),
                     }) => {
-                        cmd_db_migrations_list(&datastore, &fetch_opts, args).await
+                        cmd_db_migrations_list(&datastore, fetch_opts, args).await
                     }
                     DbCommands::Snapshots(SnapshotArgs {
                         command: SnapshotCommands::Info(uuid),
                     }) => cmd_db_snapshot_info(&opctx, &datastore, uuid).await,
                     DbCommands::Snapshots(SnapshotArgs {
                         command: SnapshotCommands::List,
-                    }) => cmd_db_snapshot_list(&datastore, &fetch_opts).await,
+                    }) => cmd_db_snapshot_list(&datastore, fetch_opts).await,
                     DbCommands::RegionSnapshotReplacement(
                         RegionSnapshotReplacementArgs {
                             command: RegionSnapshotReplacementCommands::List(args),
@@ -1324,7 +1324,7 @@ impl DbArgs {
                     ) => {
                         cmd_db_region_snapshot_replacement_list(
                             &datastore,
-                            &fetch_opts,
+                            fetch_opts,
                             args,
                         )
                         .await
@@ -1337,7 +1337,7 @@ impl DbArgs {
                         cmd_db_region_snapshot_replacement_status(
                             &opctx,
                             &datastore,
-                            &fetch_opts,
+                            fetch_opts,
                         )
                         .await
                     }
@@ -1397,7 +1397,7 @@ impl DbArgs {
                     }) => cmd_db_volume_info(&datastore, args).await,
                     DbCommands::Volumes(VolumeArgs {
                         command: VolumeCommands::List,
-                    }) => cmd_db_volume_list(&datastore, &fetch_opts).await,
+                    }) => cmd_db_volume_list(&datastore, fetch_opts).await,
                     DbCommands::Volumes(VolumeArgs {
                         command: VolumeCommands::LockHolder(args),
                     }) => cmd_db_volume_lock_holder(&datastore, args).await,
@@ -1406,22 +1406,22 @@ impl DbArgs {
                     }) => cmd_db_volume_cannot_activate(&opctx, &datastore).await,
                     DbCommands::Volumes(VolumeArgs {
                         command: VolumeCommands::Reference(args),
-                    }) => cmd_db_volume_reference(&opctx, &datastore, &fetch_opts, &args).await,
+                    }) => cmd_db_volume_reference(&opctx, &datastore, fetch_opts, args).await,
 
                     DbCommands::Vmm(VmmArgs { command: VmmCommands::Info(args) }) => {
-                        cmd_db_vmm_info(&opctx, &datastore, &fetch_opts, &args)
+                        cmd_db_vmm_info(&opctx, &datastore, fetch_opts, args)
                             .await
                     }
                     DbCommands::Vmm(VmmArgs { command: VmmCommands::List(args) })
                     | DbCommands::Vmms(args) => {
-                        cmd_db_vmm_list(&datastore, &fetch_opts, args).await
+                        cmd_db_vmm_list(&datastore, fetch_opts, args).await
                     }
                     DbCommands::Oximeter(OximeterArgs {
                         command: OximeterCommands::ListProducers
                     }) => cmd_db_oximeter_list_producers(&datastore, fetch_opts).await,
                     DbCommands::Zpool(ZpoolArgs {
                         command: ZpoolCommands::List(args)
-                    }) => cmd_db_zpool_list(&opctx, &datastore, &args).await,
+                    }) => cmd_db_zpool_list(&opctx, &datastore, args).await,
                     DbCommands::Zpool(ZpoolArgs {
                         command: ZpoolCommands::SetStorageBuffer(args)
                     }) => {
@@ -1429,7 +1429,7 @@ impl DbArgs {
                         cmd_db_zpool_set_storage_buffer(
                             &opctx,
                             &datastore,
-                            &args,
+                            args,
                             token,
                         ).await
                     }
@@ -1932,7 +1932,7 @@ async fn replacements_to_do(
 
     println!("{}", table);
 
-    println!("");
+    println!();
 
     #[derive(Tabled)]
     #[tabled(rename_all = "SCREAMING_SNAKE_CASE")]
@@ -2214,7 +2214,7 @@ async fn get_and_display_vcr(
         .context("loading requested volume")?;
 
     for v in volumes {
-        match serde_json::from_str(&v.data()) {
+        match serde_json::from_str(v.data()) {
             Ok(vcr) => {
                 println!("VCR from volume ID {volume_id}");
                 print_vcr(vcr, 0);
@@ -2515,7 +2515,7 @@ async fn cmd_db_physical_disks(
     };
 
     let sleds = datastore
-        .physical_disk_list(&opctx, &first_page(limit), filter)
+        .physical_disk_list(opctx, &first_page(limit), filter)
         .await
         .context("listing physical disks")?;
     check_limit(&sleds, limit, || String::from("listing physical disks"));
@@ -2854,7 +2854,7 @@ async fn cmd_db_volume_info(
 
     let mut vcrs = Vec::new();
     let rows = volumes.into_iter().map(|volume| {
-        match serde_json::from_str(&volume.data()) {
+        match serde_json::from_str(volume.data()) {
             Ok(vcr) => {
                 vcrs.push(vcr);
             }
@@ -2942,7 +2942,7 @@ fn print_vcr(vcr: VolumeConstructionRequest, pad: usize) {
             for (index, sv) in sub_volumes.iter().enumerate() {
                 println!("{indent}SUB VOLUME {index}");
                 print_vcr(sv.clone(), pad + 4);
-                println!("");
+                println!();
             }
 
             if let Some(rop) = read_only_parent {
@@ -4027,7 +4027,7 @@ async fn cmd_db_sleds(
     };
 
     let sleds = datastore
-        .sled_list(&opctx, &first_page(limit), filter)
+        .sled_list(opctx, &first_page(limit), filter)
         .await
         .context("listing sleds")?;
     check_limit(&sleds, limit, || String::from("listing sleds"));
@@ -4793,7 +4793,7 @@ async fn cmd_db_dns_diff(
             added.len(),
             removed.len()
         );
-        println!("");
+        println!();
 
         for a in added {
             print_name("+", &a.name, a.records().context("parsing records"));
@@ -5597,7 +5597,7 @@ async fn cmd_db_region_snapshot_replacement_waiting(
         if let Some(lock_holder_id) = lock_holder.id() {
             node_indices.entry(lock_holder_id).or_insert_with(|| g.add_node(1));
 
-            let from_ix = node_indices[&replacement_id];
+            let from_ix = node_indices[replacement_id];
             let to_ix = node_indices[&lock_holder_id];
 
             g.add_edge(from_ix, to_ix, 1);
@@ -5714,7 +5714,7 @@ async fn cmd_db_validate_volume_references(
             .into_iter()
             .filter(|volume| {
                 let vcr: VolumeConstructionRequest =
-                    serde_json::from_str(&volume.data()).unwrap();
+                    serde_json::from_str(volume.data()).unwrap();
 
                 let mut targets = CrucibleTargets::default();
                 read_only_resources_associated_with_volume(&vcr, &mut targets);
@@ -6863,7 +6863,7 @@ async fn inv_collection_print_devices(
                     continue;
                 }
 
-                println!("");
+                println!();
                 println!(
                     "{:?} (serial number unknown -- this is a bug)",
                     sp.sp_type
@@ -6875,7 +6875,7 @@ async fn inv_collection_print_devices(
                     continue;
                 }
 
-                println!("");
+                println!();
                 println!("{:?} {}", sp.sp_type, baseboard.serial_number);
                 println!("    part number: {}", baseboard.part_number);
             }
@@ -6887,7 +6887,7 @@ async fn inv_collection_print_devices(
         if let SpType::Sled = sp.sp_type {
             print!(" (cubby {})", sp.sp_slot);
         }
-        println!("");
+        println!();
         println!("    found at: {} from {}", sp.time_collected, sp.source);
 
         #[derive(Tabled)]
@@ -6980,7 +6980,7 @@ async fn inv_collection_print_devices(
         }
     }
 
-    println!("");
+    println!();
     for sp_missing_rot in collection
         .sps
         .keys()
@@ -7125,7 +7125,7 @@ fn inv_collection_print_keeper_membership(collection: &Collection) {
     if collection.clickhouse_keeper_cluster_membership.is_empty() {
         println!("No membership retrieved.");
     }
-    println!("");
+    println!();
 }
 
 #[derive(Debug)]
@@ -7804,7 +7804,7 @@ async fn cmd_db_oximeter_list_producers(
 
 // Display an empty cell for an Option<T> if it's None.
 fn display_option_blank<T: Display>(opt: &Option<T>) -> String {
-    opt.as_ref().map(|x| x.to_string()).unwrap_or_else(|| "".to_string())
+    opt.as_ref().map(|x| x.to_string()).unwrap_or_default()
 }
 
 // Format a `chrono::DateTime` in RFC3339 with milliseconds precision and using

--- a/dev-tools/omdb/src/bin/omdb/db/saga.rs
+++ b/dev-tools/omdb/src/bin/omdb/db/saga.rs
@@ -209,7 +209,7 @@ You should only do this if:
                     bail!("dns lookup for {current_sec} found nothing");
                 };
 
-                let Some(addr) = resolver.ipv6_lookup(&target).await? else {
+                let Some(addr) = resolver.ipv6_lookup(target).await? else {
                     let text = format!(
                         "Cannot proceed: no AAAA record for Nexus with id \
                         {current_sec}, so cannot verify that it is not still \

--- a/dev-tools/omdb/src/bin/omdb/mgs.rs
+++ b/dev-tools/omdb/src/bin/omdb/mgs.rs
@@ -122,7 +122,7 @@ async fn cmd_mgs_inventory(
         .into_inner();
     sp_ids.sort();
     show_sp_ids(&sp_ids)?;
-    println!("");
+    println!();
 
     // Report which SPs are visible via Ignition.
     println!("SPs FOUND THROUGH IGNITION\n");
@@ -133,7 +133,7 @@ async fn cmd_mgs_inventory(
         .into_inner();
     sp_list_ignition.sort_by(|a, b| a.id.cmp(&b.id));
     show_sps_from_ignition(&sp_list_ignition)?;
-    println!("");
+    println!();
 
     // Print basic state about each SP that's visible to ignition.
     println!("SERVICE PROCESSOR STATES\n");
@@ -166,7 +166,7 @@ async fn cmd_mgs_inventory(
         .collect::<Vec<_>>();
     sp_infos.sort();
     show_sp_states(&sp_infos)?;
-    println!("");
+    println!();
 
     // Print detailed information about each SP that we've found so far.
     for (sp_id, sp_state) in &sp_infos {
@@ -394,7 +394,7 @@ async fn show_sp_details(
                 .with(tabled::settings::Padding::new(0, 1, 0, 0))
                 .to_string();
             println!("{}", textwrap::indent(&table.to_string(), "        "));
-            println!("");
+            println!();
         }
         RotState::V3 {
             active,
@@ -473,7 +473,7 @@ async fn show_sp_details(
                 .with(tabled::settings::Padding::new(0, 1, 0, 0))
                 .to_string();
             println!("{}", textwrap::indent(&table.to_string(), "        "));
-            println!("");
+            println!();
         }
     }
 
@@ -523,7 +523,7 @@ async fn show_sp_details(
         .to_string();
     println!("    COMPONENTS\n");
     println!("{}", textwrap::indent(&table.to_string(), "        "));
-    println!("");
+    println!();
 
     #[derive(Tabled)]
     #[tabled(rename_all = "SCREAMING_SNAKE_CASE")]
@@ -599,7 +599,7 @@ async fn show_sp_details(
         .to_string();
     println!("    COMPONENT CABOOSES\n");
     println!("{}", textwrap::indent(&table.to_string(), "        "));
-    println!("");
+    println!();
 
     Ok(())
 }

--- a/dev-tools/omdb/src/bin/omdb/mgs/sensors.rs
+++ b/dev-tools/omdb/src/bin/omdb/mgs/sensors.rs
@@ -782,7 +782,10 @@ fn sp_data_csv<R: std::io::Read + std::io::Seek>(
                 if let Some(ids) = metadata.sensors_by_sensor.get_vec(&sensor) {
                     for id in ids {
                         let (_, _, d) = metadata.sensors_by_id.get(id).unwrap();
-                        let value = record[d.field()].parse::<f32>().ok();
+                        let value = match record[d.field()].parse::<f32>() {
+                            Ok(value) => Some(value),
+                            _ => None,
+                        };
 
                         values.insert(*id, value);
                     }

--- a/dev-tools/omdb/src/bin/omdb/mgs/sensors.rs
+++ b/dev-tools/omdb/src/bin/omdb/mgs/sensors.rs
@@ -709,7 +709,7 @@ async fn sp_data_mgs(
     for sp_id in metadata.sensors_by_sp.keys() {
         let mgs_client = mgs_client.clone();
         let id = *sp_id;
-        let metadata = Arc::clone(&metadata);
+        let metadata = Arc::clone(metadata);
 
         let handle = tokio::spawn(async move {
             sp_read_sensors(&mgs_client, &id, &metadata).await
@@ -811,7 +811,7 @@ pub(crate) async fn sensor_data<R: std::io::Read + std::io::Seek>(
             sp_data_mgs(mgs_client, metadata).await
         }
         SensorInput::CsvReader(reader, position) => {
-            sp_data_csv(reader, position, &metadata)
+            sp_data_csv(reader, position, metadata)
         }
     }
 }

--- a/dev-tools/omdb/src/bin/omdb/nexus.rs
+++ b/dev-tools/omdb/src/bin/omdb/nexus.rs
@@ -860,7 +860,7 @@ fn print_task(bgtask: &BackgroundTask) {
     // unstable -- it gets exposed by background tasks as unstructured
     // (schemaless) data.  We make a best effort to interpret it.
     if let LastResult::Completed(completed) = &bgtask.last {
-        print_task_details(&bgtask, &completed.details);
+        print_task_details(bgtask, &completed.details);
     }
 }
 
@@ -887,7 +887,7 @@ fn print_task_details(bgtask: &BackgroundTask, details: &serde_json::Value) {
         serde_json::from_value::<TaskError>(details.clone())
     {
         println!("    last completion reported error: {}", found_error.error);
-        println!("");
+        println!();
         return;
     }
 
@@ -978,7 +978,7 @@ fn print_task_details(bgtask: &BackgroundTask, details: &serde_json::Value) {
         }
     }
 
-    println!("");
+    println!();
 }
 
 fn print_task_abandoned_vmm_reaper(details: &serde_json::Value) {
@@ -1289,7 +1289,7 @@ fn print_task_dns_propagation(details: &serde_json::Value) {
                 println!("{}", textwrap::indent(&table.to_string(), "      "));
             }
 
-            println!("");
+            println!();
             for (addr, error) in server_results.iter().filter_map(
                 |(addr, result)| match result {
                     Ok(_) => None,
@@ -1387,7 +1387,7 @@ fn print_task_external_endpoints(details: &serde_json::Value) {
                 println!("        warning: {}", w);
             }
 
-            println!("");
+            println!();
             println!("    TLS certificates: {}", tls_cert_rows.len());
             if !tls_cert_rows.is_empty() {
                 let table = tabled::Table::new(tls_cert_rows)
@@ -2443,7 +2443,7 @@ fn push_event_buffer_terminal_info(
 
             builder.push_record([
                 "  reason:".to_string(),
-                reason.message_display(&buffer).to_string(),
+                reason.message_display(buffer).to_string(),
             ]);
             // TODO: show last progress event
         }
@@ -3046,7 +3046,7 @@ async fn cmd_nexus_sled_expunge_with_datastore(
     let opctx = &opctx;
 
     // First, we need to look up the sled so we know its serial number.
-    let (_authz_sled, sled) = LookupPath::new(opctx, &datastore)
+    let (_authz_sled, sled) = LookupPath::new(opctx, datastore)
         .sled_id(args.sled_id.into_untyped_uuid())
         .fetch()
         .await
@@ -3150,7 +3150,7 @@ async fn cmd_nexus_sled_expunge_disk_with_datastore(
 
     // First, we need to look up the disk so we can lookup identity information.
     let (_authz_physical_disk, physical_disk) =
-        LookupPath::new(opctx, &datastore)
+        LookupPath::new(opctx, datastore)
             .physical_disk(args.physical_disk_id)
             .fetch()
             .await

--- a/dev-tools/omdb/src/bin/omdb/oxql.rs
+++ b/dev-tools/omdb/src/bin/omdb/oxql.rs
@@ -86,7 +86,7 @@ impl OxqlArgs {
         srv: ServiceName,
     ) -> anyhow::Result<SocketAddr> {
         match maybe_url {
-            Some(cli_or_env_url) => Url::parse(&cli_or_env_url)
+            Some(cli_or_env_url) => Url::parse(cli_or_env_url)
                 .context(
                     "failed parsing URL from command-line or environment variable",
                 )?

--- a/dev-tools/openapi-manager/src/environment.rs
+++ b/dev-tools/openapi-manager/src/environment.rs
@@ -51,7 +51,7 @@ impl Environment {
     /// Returns the path to the OpenAPI documents in this workspace
     pub(crate) fn openapi_dir(&self) -> &Utf8Path {
         match &self.local_source {
-            LocalSource::Directory { local_directory } => &local_directory,
+            LocalSource::Directory { local_directory } => local_directory,
         }
     }
 }
@@ -99,8 +99,8 @@ impl BlessedSource {
                 );
                 Ok((
                     BlessedFiles::load_from_git_parent_branch(
-                        &revision,
-                        &directory,
+                        revision,
+                        directory,
                         apis,
                         &mut errors,
                     )?,

--- a/dev-tools/openapi-manager/src/output.rs
+++ b/dev-tools/openapi-manager/src/output.rs
@@ -410,7 +410,7 @@ fn summarize_one(
         eprintln!(
             "{:>HEADER_WIDTH$} {}",
             FRESH.style(styles.success_header),
-            display_api_spec_version(api, version, &styles, resolution),
+            display_api_spec_version(api, version, styles, resolution),
         );
     } else {
         // There were one or more problems, some of which may be unfixable.
@@ -422,7 +422,7 @@ fn summarize_one(
                 assert!(resolution.has_problems());
                 STALE.style(styles.warning_header)
             },
-            display_api_spec_version(api, version, &styles, resolution),
+            display_api_spec_version(api, version, styles, resolution),
         );
 
         display_resolution_problems(env, problems, styles);
@@ -533,7 +533,7 @@ pub fn display_resolution_problems<'a, T>(
                     std::io::stderr(),
                 ),
             );
-            eprintln!("");
+            eprintln!();
         }
     }
 }

--- a/dev-tools/openapi-manager/src/resolved.rs
+++ b/dev-tools/openapi-manager/src/resolved.rs
@@ -427,7 +427,7 @@ impl Fix<'_> {
                 Ok(vec![format!(
                     "wrote {}: {:?}",
                     &path,
-                    overwrite_file(&path, expected_contents)?
+                    overwrite_file(path, expected_contents)?
                 )])
             }
             Fix::FixSymlink { api_ident, link } => {

--- a/dev-tools/openapi-manager/src/spec_files_blessed.rs
+++ b/dev-tools/openapi-manager/src/spec_files_blessed.rs
@@ -119,7 +119,7 @@ impl BlessedFiles {
     ) -> anyhow::Result<BlessedFiles> {
         let mut api_files: ApiSpecFilesBuilder<BlessedApiSpecFile> =
             ApiSpecFilesBuilder::new(apis, error_accumulator);
-        let files_found = git_ls_tree(&commit, directory)?;
+        let files_found = git_ls_tree(commit, directory)?;
         for f in files_found {
             // We should be looking at either a single-component path
             // ("api.json") or a file inside one level of directory hierarchy

--- a/dev-tools/openapi-manager/src/spec_files_generic.rs
+++ b/dev-tools/openapi-manager/src/spec_files_generic.rs
@@ -399,7 +399,7 @@ impl<'a, T: ApiLoad + AsRawFiles> ApiSpecFilesBuilder<'a, T> {
         &mut self,
         basename: &str,
     ) -> Option<ApiSpecFileName> {
-        match ApiSpecFileName::parse_lockstep(&self.apis, basename) {
+        match ApiSpecFileName::parse_lockstep(self.apis, basename) {
             Err(
                 warning @ (BadLockstepFileName::NoSuchApi
                 | BadLockstepFileName::NotLockstep),
@@ -483,7 +483,7 @@ impl<'a, T: ApiLoad + AsRawFiles> ApiSpecFilesBuilder<'a, T> {
         ident: &ApiIdent,
         basename: &str,
     ) -> Option<ApiSpecFileName> {
-        match ApiSpecFileName::parse_versioned(&self.apis, ident, basename) {
+        match ApiSpecFileName::parse_versioned(self.apis, ident, basename) {
             Ok(file_name) => Some(file_name),
             Err(
                 warning @ (BadVersionedFileName::NoSuchApi
@@ -521,7 +521,7 @@ impl<'a, T: ApiLoad + AsRawFiles> ApiSpecFilesBuilder<'a, T> {
         ident: &ApiIdent,
         basename: &str,
     ) -> Option<ApiSpecFileName> {
-        match ApiSpecFileName::parse_versioned(&self.apis, ident, basename) {
+        match ApiSpecFileName::parse_versioned(self.apis, ident, basename) {
             Ok(file_name) => Some(file_name),
             Err(
                 warning @ (BadVersionedFileName::NoSuchApi

--- a/dev-tools/openapi-manager/src/validation.rs
+++ b/dev-tools/openapi-manager/src/validation.rs
@@ -21,7 +21,7 @@ pub fn validate(
     generated: &GeneratedApiSpecFile,
 ) -> anyhow::Result<Vec<(Utf8PathBuf, CheckStatus)>> {
     let openapi = generated.openapi();
-    let validation_result = validate_generated_openapi_document(api, &openapi)?;
+    let validation_result = validate_generated_openapi_document(api, openapi)?;
     let extra_files = validation_result
         .extra_files
         .into_iter()
@@ -40,8 +40,8 @@ fn validate_generated_openapi_document(
 ) -> anyhow::Result<ValidationResult> {
     // Check for lint errors.
     let errors = match api.boundary() {
-        ApiBoundary::Internal => openapi_lint::validate(&openapi_doc),
-        ApiBoundary::External => openapi_lint::validate_external(&openapi_doc),
+        ApiBoundary::Internal => openapi_lint::validate(openapi_doc),
+        ApiBoundary::External => openapi_lint::validate_external(openapi_doc),
     };
     if !errors.is_empty() {
         return Err(anyhow::anyhow!("{}", errors.join("\n\n")));
@@ -51,7 +51,7 @@ fn validate_generated_openapi_document(
     let mut validation_context =
         ValidationContextImpl { errors: Vec::new(), files: Vec::new() };
     api.extra_validation(
-        &openapi_doc,
+        openapi_doc,
         ValidationContext::new(&mut validation_context),
     );
 

--- a/dev-tools/openapi-manager/types/src/versions.rs
+++ b/dev-tools/openapi-manager/types/src/versions.rs
@@ -26,7 +26,7 @@ impl SupportedVersion {
     }
 
     pub fn label(&self) -> &str {
-        &self.label
+        self.label
     }
 }
 

--- a/dev-tools/oxlog/src/lib.rs
+++ b/dev-tools/oxlog/src/lib.rs
@@ -25,7 +25,7 @@ fn get_uuid_dir(result: io::Result<Utf8DirEntry>) -> Option<Uuid> {
         return None;
     }
     let file_name = entry.file_name();
-    file_name.parse().ok()
+    if let Ok(uuid) = file_name.parse() { Some(uuid) } else { None }
 }
 
 #[derive(Debug)]

--- a/dev-tools/reconfigurator-cli/src/lib.rs
+++ b/dev-tools/reconfigurator-cli/src/lib.rs
@@ -193,7 +193,7 @@ impl CmdReconfiguratorSim {
                     LoopResult::Continue => (),
                     LoopResult::Bail(error) => return Err(error),
                 }
-                println!("");
+                println!();
             }
         } else {
             let mut ed = Reedline::create();
@@ -842,7 +842,7 @@ fn cmd_blueprint_blippy(
     let state = sim.current_state();
     let blueprint = state.system().get_blueprint(args.blueprint_id)?;
     let report =
-        Blippy::new(&blueprint).into_report(BlippyReportSortKey::Severity);
+        Blippy::new(blueprint).into_report(BlippyReportSortKey::Severity);
     Ok(Some(format!("{}", report.display())))
 }
 
@@ -1031,7 +1031,7 @@ fn cmd_blueprint_diff(
     let blueprint1 = state.system().get_blueprint(blueprint1_id)?;
     let blueprint2 = state.system().get_blueprint(blueprint2_id)?;
 
-    let sled_diff = blueprint2.diff_since_blueprint(&blueprint1);
+    let sled_diff = blueprint2.diff_since_blueprint(blueprint1);
     swriteln!(rv, "{}", sled_diff.display());
 
     // Diff'ing DNS is a little trickier.  First, compute what DNS should be for
@@ -1039,12 +1039,12 @@ fn cmd_blueprint_diff(
     // for the executor.
     let sleds_by_id = make_sleds_by_id(state.system().description())?;
     let internal_dns_config1 = blueprint_internal_dns_config(
-        &blueprint1,
+        blueprint1,
         &sleds_by_id,
         &Default::default(),
     )?;
     let internal_dns_config2 = blueprint_internal_dns_config(
-        &blueprint2,
+        blueprint2,
         &sleds_by_id,
         &Default::default(),
     )?;
@@ -1054,12 +1054,12 @@ fn cmd_blueprint_diff(
 
     let external_dns_zone_name = state.config().external_dns_zone_name();
     let external_dns_config1 = blueprint_external_dns_config(
-        &blueprint1,
+        blueprint1,
         state.config().silo_names(),
         external_dns_zone_name.to_owned(),
     );
     let external_dns_config2 = blueprint_external_dns_config(
-        &blueprint2,
+        blueprint2,
         state.config().silo_names(),
         external_dns_zone_name.to_owned(),
     );
@@ -1135,7 +1135,7 @@ fn cmd_blueprint_diff_dns(
     };
 
     let existing_dns_zone = existing_dns_config.sole_zone()?;
-    let dns_diff = DnsDiff::new(&existing_dns_zone, &blueprint_dns_zone)
+    let dns_diff = DnsDiff::new(existing_dns_zone, &blueprint_dns_zone)
         .context("failed to assemble DNS diff")?;
     Ok(Some(dns_diff.to_string()))
 }

--- a/dev-tools/reconfigurator-exec-unsafe/src/main.rs
+++ b/dev-tools/reconfigurator-exec-unsafe/src/main.rs
@@ -166,7 +166,7 @@ impl ReconfiguratorExec {
         let rv = realize_blueprint(
             RequiredRealizeArgs {
                 opctx: &opctx,
-                datastore: &datastore,
+                datastore,
                 resolver: &resolver,
                 blueprint: &blueprint,
                 creator: OmicronZoneUuid::from_untyped_uuid(creator),

--- a/dev-tools/repo-depot-standalone/src/main.rs
+++ b/dev-tools/repo-depot-standalone/src/main.rs
@@ -171,7 +171,7 @@ impl RepoDepotApi for StandaloneApiImpl {
             })?;
 
         let reader = tuf_repo
-            .read_target(&target_name)
+            .read_target(target_name)
             .await
             .map_err(|error| {
                 HttpError::for_internal_error(format!(

--- a/dev-tools/xtask/src/virtual_hardware.rs
+++ b/dev-tools/xtask/src/virtual_hardware.rs
@@ -554,7 +554,7 @@ fn destroy_vdevs(
                 .starts_with(Utf8PathBuf::from(ZVOL_ROOT).join(&zpool))
             {
                 println!("Removing {swap_device} from {zpool}");
-                swap_delete(&swap_device)?;
+                swap_delete(swap_device)?;
             }
         }
 

--- a/dns-server/src/dns_server.rs
+++ b/dns-server/src/dns_server.rs
@@ -155,7 +155,7 @@ async fn handle_dns_packet(request: Request) {
     trace!(&log, "buffer"; "buffer" => ?buf.hex_dump());
 
     // Decode the message.
-    let mut dec = BinDecoder::new(&buf);
+    let mut dec = BinDecoder::new(buf);
     let mr = match MessageRequest::read(&mut dec) {
         Ok(mr) => mr,
         Err(error) => {
@@ -366,7 +366,7 @@ async fn respond_records(
         additional_records,
     );
 
-    encode_and_send(&request, mresp, "records").await.map_err(|error| {
+    encode_and_send(request, mresp, "records").await.map_err(|error| {
         RequestError::ServFail(anyhow!("failed to emit response: {:#}", error))
     })
 }
@@ -382,7 +382,7 @@ async fn respond_nxdomain(
     header: &Header,
 ) {
     let log = &request.log;
-    let mresp = rb_nxdomain.error_msg(&header, ResponseCode::NXDomain);
+    let mresp = rb_nxdomain.error_msg(header, ResponseCode::NXDomain);
     if let Err(error) = encode_and_send(request, mresp, "NXDOMAIN").await {
         error!(
             log,

--- a/dns-server/src/lib.rs
+++ b/dns-server/src/lib.rs
@@ -156,7 +156,7 @@ impl TransientServer {
             log.clone(),
         );
         dns_config_client
-            .dns_config_put(&dns_config)
+            .dns_config_put(dns_config)
             .await
             .context("initializing DNS")?;
         Ok(())

--- a/dns-server/src/storage.rs
+++ b/dns-server/src/storage.rs
@@ -621,7 +621,7 @@ impl Store {
             .zones
             .iter()
             .find(|z| {
-                let zone_name = LowerName::from(Name::from_str(&z).unwrap());
+                let zone_name = LowerName::from(Name::from_str(z).unwrap());
                 zone_name.zone_of(name)
             })
             .ok_or_else(|| QueryError::NoZone(orig_name.to_string()))?;

--- a/dns-server/tests/basic_test.rs
+++ b/dns-server/tests/basic_test.rs
@@ -343,7 +343,7 @@ pub async fn empty_record() -> Result<(), anyhow::Error> {
     assert!(records.is_empty());
 
     // resolve the name
-    lookup_ip_expect_nxdomain(&resolver, &(name + "." + TEST_ZONE + ".")).await;
+    lookup_ip_expect_nxdomain(resolver, &(name + "." + TEST_ZONE + ".")).await;
 
     test_ctx.cleanup().await;
     Ok(())
@@ -372,7 +372,7 @@ pub async fn nxdomain() -> Result<(), anyhow::Error> {
 
     // asking for a nonexistent record within the domain of the internal DNS
     // server should result in an NXDOMAIN
-    lookup_ip_expect_nxdomain(&resolver, &format!("unicorn.{}.", TEST_ZONE))
+    lookup_ip_expect_nxdomain(resolver, &format!("unicorn.{}.", TEST_ZONE))
         .await;
 
     test_ctx.cleanup().await;

--- a/gateway/src/management_switch.rs
+++ b/gateway/src/management_switch.rs
@@ -202,7 +202,7 @@ impl ManagementSwitch {
                             shared_socket = Some(
                                 SharedSocket::bind(
                                     config.udp_listen_port,
-                                    Arc::clone(&host_phase2_provider),
+                                    Arc::clone(host_phase2_provider),
                                     log.clone(),
                                 )
                                 .await?,
@@ -215,7 +215,7 @@ impl ManagementSwitch {
                     };
 
                     SingleSp::new(
-                        &socket,
+                        socket,
                         gateway_sp_comms::SwitchPortConfig {
                             discovery_addr: default_discovery_addr(),
                             interface: interface.clone(),

--- a/id-map/src/lib.rs
+++ b/id-map/src/lib.rs
@@ -489,7 +489,7 @@ mod tests {
         "#;
 
         let err =
-            serde_json::from_str::<IdMap<TestEntry>>(&serialized).unwrap_err();
+            serde_json::from_str::<IdMap<TestEntry>>(serialized).unwrap_err();
         let err = err.to_string();
 
         assert!(

--- a/illumos-utils/src/running_zone.rs
+++ b/illumos-utils/src/running_zone.rs
@@ -720,7 +720,7 @@ impl RunningZone {
 
     /// Return a reference to the links for this zone.
     pub fn links(&self) -> &Vec<Link> {
-        &self.inner.links()
+        self.inner.links()
     }
 
     /// Return a mutable reference to the links for this zone.

--- a/illumos-utils/src/zfs.rs
+++ b/illumos-utils/src/zfs.rs
@@ -937,12 +937,12 @@ impl Zfs {
                 if let (CanMount::On, Mountpoint::Path(path)) =
                     (&can_mount, &mountpoint)
                 {
-                    ensure_empty_immutable_mountpoint(&path).map_err(
-                        |err| EnsureDatasetErrorRaw::MountpointCreation {
+                    ensure_empty_immutable_mountpoint(path).map_err(|err| {
+                        EnsureDatasetErrorRaw::MountpointCreation {
                             mountpoint: path.to_path_buf(),
                             err,
-                        },
-                    )?;
+                        }
+                    })?;
                     Self::mount_dataset(name)?;
                 }
             }
@@ -963,7 +963,7 @@ impl Zfs {
             if let (CanMount::On, Mountpoint::Path(path)) =
                 (&can_mount, &mountpoint)
             {
-                ensure_empty_immutable_mountpoint(&path).map_err(|err| {
+                ensure_empty_immutable_mountpoint(path).map_err(|err| {
                     EnsureDatasetErrorRaw::MountpointCreation {
                         mountpoint: path.to_path_buf(),
                         err,
@@ -1000,7 +1000,7 @@ impl Zfs {
 
         if let Some(opts) = additional_options {
             for o in &opts {
-                cmd.args(&["-o", &o]);
+                cmd.args(&["-o", o]);
             }
         }
 
@@ -1300,8 +1300,7 @@ pub fn get_all_omicron_datasets_for_delete() -> anyhow::Result<Vec<String>> {
     }
 
     // Collect all datasets for ramdisk-based Oxide zones, if any exist.
-    if let Ok(ramdisk_datasets) = Zfs::list_datasets(&ZONE_ZFS_RAMDISK_DATASET)
-    {
+    if let Ok(ramdisk_datasets) = Zfs::list_datasets(ZONE_ZFS_RAMDISK_DATASET) {
         for dataset in &ramdisk_datasets {
             datasets.push(format!("{}/{dataset}", ZONE_ZFS_RAMDISK_DATASET));
         }
@@ -1377,7 +1376,7 @@ mod test {
              dataset_name\tname\tI_AM_IGNORED\t-\n\
              dataset_name\tmounted\tyes\t-\n\
              dataset_name\tcompression\toff\tinherited from parent";
-        let props = DatasetProperties::parse_many(&input)
+        let props = DatasetProperties::parse_many(input)
             .expect("Should have parsed data");
         assert_eq!(props.len(), 1);
 
@@ -1398,7 +1397,7 @@ mod test {
              dataset_name\tname\tI_AM_IGNORED\t-\n\
              dataset_name\tmounted\tyes\t-\n\
              dataset_name\tcompression\toff\tinherited from parent";
-        let err = DatasetProperties::parse_many(&input)
+        let err = DatasetProperties::parse_many(input)
             .expect_err("Should have parsed data");
         assert!(
             err.to_string().contains("Unexpected column data: 'EXTRA'"),
@@ -1415,7 +1414,7 @@ mod test {
              dataset_name\tquota\t111\t-\n\
              dataset_name\treservation\t222\t-\n\
              dataset_name\tcompression\toff\tinherited from parent";
-        let props = DatasetProperties::parse_many(&input)
+        let props = DatasetProperties::parse_many(input)
             .expect("Should have parsed data");
         assert_eq!(props.len(), 1);
         assert_eq!(
@@ -1437,7 +1436,7 @@ mod test {
              dataset_name\tavailable\t1234\t-\n\
              dataset_name\tused\t5678\t-";
 
-        let err = DatasetProperties::parse_many(&input)
+        let err = DatasetProperties::parse_many(input)
             .expect_err("Should have failed to parse");
         assert!(
             format!("{err:#}").contains("error parsing UUID (dataset)"),
@@ -1450,7 +1449,7 @@ mod test {
         let input = "dataset_name\tavailable\tBADAVAIL\t-\n\
              dataset_name\tmounted\t-\t-\n\
              dataset_name\tused\t5678\t-";
-        let err = DatasetProperties::parse_many(&input)
+        let err = DatasetProperties::parse_many(input)
             .expect_err("Should have failed to parse");
         assert!(
             format!("{err:#}").contains("invalid digit found in string"),
@@ -1463,7 +1462,7 @@ mod test {
         let input = "dataset_name\tavailable\t1234\t-\n\
              dataset_name\tmounted\t-\t-\n\
              dataset_name\tused\tBADUSAGE\t-";
-        let err = DatasetProperties::parse_many(&input)
+        let err = DatasetProperties::parse_many(input)
             .expect_err("Should have failed to parse");
         assert!(
             format!("{err:#}").contains("invalid digit found in string"),
@@ -1477,7 +1476,7 @@ mod test {
              dataset_name\tused\t5678\t-\n\
              dataset_name\tmounted\t-\t-\n\
              dataset_name\tquota\tBADQUOTA\t-";
-        let err = DatasetProperties::parse_many(&input)
+        let err = DatasetProperties::parse_many(input)
             .expect_err("Should have failed to parse");
         assert!(
             format!("{err:#}").contains("invalid digit found in string"),
@@ -1492,7 +1491,7 @@ mod test {
              dataset_name\tquota\t111\t-\n\
              dataset_name\tmounted\t-\t-\n\
              dataset_name\treservation\tBADRES\t-";
-        let err = DatasetProperties::parse_many(&input)
+        let err = DatasetProperties::parse_many(input)
             .expect_err("Should have failed to parse");
         assert!(
             format!("{err:#}").contains("invalid digit found in string"),
@@ -1549,7 +1548,7 @@ mod test {
              dataset_name\tused\t5678\t-\n\
              dataset_name\tmounted\t-\t-\n\
              dataset_name\tcompression\toff\t-";
-        let props = DatasetProperties::parse_many(&input)
+        let props = DatasetProperties::parse_many(input)
             .expect("Should have parsed data");
         assert_eq!(props.len(), 1);
         assert_eq!(props[0].id, None);
@@ -1562,7 +1561,7 @@ mod test {
              dataset_name\tused\t5678\t-\n\
              dataset_name\tmounted\t-\t-\n\
              dataset_name\tcompression\toff\t-";
-        let props = DatasetProperties::parse_many(&input)
+        let props = DatasetProperties::parse_many(input)
             .expect("Should have parsed data");
         assert_eq!(props.len(), 1);
         assert_eq!(props[0].id, None);
@@ -1575,7 +1574,7 @@ mod test {
              dataset_name\tused\t5678\t-\n\
              dataset_name\tmounted\t-\t-\n\
              dataset_name\tcompression\toff\t-";
-        let props = DatasetProperties::parse_many(&input)
+        let props = DatasetProperties::parse_many(input)
             .expect("Should have parsed data");
         assert_eq!(props.len(), 1);
         assert_eq!(props[0].quota, None);
@@ -1588,7 +1587,7 @@ mod test {
              dataset_name\tused\t5678\t-\n\
              dataset_name\tmounted\t-\t-\n\
              dataset_name\tcompression\toff\t-";
-        let props = DatasetProperties::parse_many(&input)
+        let props = DatasetProperties::parse_many(input)
             .expect("Should have parsed data");
         assert_eq!(props.len(), 1);
         assert_eq!(props[0].reservation, None);
@@ -1609,7 +1608,7 @@ mod test {
              bar\tused\t222\t-\n\
              bar\tcompression\toff\t-";
 
-        let props = DatasetProperties::parse_many(&input)
+        let props = DatasetProperties::parse_many(input)
             .expect("Should have parsed data");
         assert_eq!(props.len(), 2);
         assert_eq!(props[0].name, "bar");

--- a/illumos-utils/src/zone.rs
+++ b/illumos-utils/src/zone.rs
@@ -791,7 +791,7 @@ impl Zones {
         zone: Option<&'a str>,
         addrobj: &AddrObject,
     ) -> Result<(), crate::ExecutionError> {
-        if let Ok(()) = Self::has_link_local_v6_address(zone, &addrobj) {
+        if let Ok(()) = Self::has_link_local_v6_address(zone, addrobj) {
             return Ok(());
         }
 

--- a/installinator/src/mock_peers.rs
+++ b/installinator/src/mock_peers.rs
@@ -700,7 +700,7 @@ mod tests {
             log,
             || match attempts.next() {
                 Some(Ok(peers)) => {
-                    future::ok(Peers::new(&log, Box::new(peers), timeout))
+                    future::ok(Peers::new(log, Box::new(peers), timeout))
                 }
                 Some(Err(error)) => {
                     future::err(DiscoverPeersError::Retry(error))

--- a/installinator/src/peers.rs
+++ b/installinator/src/peers.rs
@@ -175,7 +175,7 @@ impl FetchedArtifact {
                 peers.peer_count(),
                 peers.display(),
             );
-            match peers.fetch_artifact(&cx, artifact_hash_id).await {
+            match peers.fetch_artifact(cx, artifact_hash_id).await {
                 Some((addr, artifact)) => {
                     return Ok(Self { attempt, addr, artifact });
                 }

--- a/installinator/src/write.rs
+++ b/installinator/src/write.rs
@@ -414,7 +414,7 @@ impl SlotWriteContext<'_> {
                 ),
                 async move |ctx| {
                     let block_size =
-                        block_size_handle.into_value(&ctx.token()).await;
+                        block_size_handle.into_value(ctx.token()).await;
                     self.validate_written_host_phase_2_hash(block_size).await
                 },
             )
@@ -1293,8 +1293,7 @@ mod tests {
                 .make_writer(component, slot, destination, total_bytes)
                 .await?;
             // This is the next series of operations.
-            let these_ops =
-                self.partial_ops.pop_front().unwrap_or_else(Vec::new);
+            let these_ops = self.partial_ops.pop_front().unwrap_or_default();
             Ok(PartialAsyncWrite::new(f, these_ops))
         }
     }

--- a/internal-dns/resolver/src/resolver.rs
+++ b/internal-dns/resolver/src/resolver.rs
@@ -516,7 +516,7 @@ mod test {
             dns_config: &DnsConfigParams,
         ) -> anyhow::Result<()> {
             self.config_client
-                .dns_config_put(&dns_config)
+                .dns_config_put(dns_config)
                 .await
                 .context("updating DNS")
                 .map(|_| ())

--- a/internal-dns/types/src/config.rs
+++ b/internal-dns/types/src/config.rs
@@ -297,14 +297,11 @@ impl DnsConfigBuilder {
         // `DnsConfigBuilder`, it's possible that it was added to a different
         // DnsBuilder.
         ensure!(
-            self.zones.contains_key(&zone),
+            self.zones.contains_key(zone),
             "zone {zone} has not been defined",
         );
 
-        let set = self
-            .service_instances_zones
-            .entry(service)
-            .or_insert_with(BTreeMap::new);
+        let set = self.service_instances_zones.entry(service).or_default();
         match set.insert(zone.clone(), port) {
             None => Ok(()),
             Some(existing) => Err(anyhow!(
@@ -335,15 +332,12 @@ impl DnsConfigBuilder {
         // `DnsConfigBuilder`, it's possible that it was added to a different
         // DnsBuilder.
         ensure!(
-            self.sleds.contains_key(&sled),
+            self.sleds.contains_key(sled),
             "sled {} has not been defined",
             sled.0
         );
 
-        let set = self
-            .service_instances_sleds
-            .entry(service)
-            .or_insert_with(BTreeMap::new);
+        let set = self.service_instances_sleds.entry(service).or_default();
         let sled_id = sled.0;
         match set.insert(sled.clone(), port) {
             None => Ok(()),
@@ -539,7 +533,7 @@ impl DnsConfigBuilder {
                 let records = zone2port
                     .iter()
                     .map(|(zone, _port)| {
-                        let zone_ip = self.zones.get(&zone).expect(
+                        let zone_ip = self.zones.get(zone).expect(
                             "service_backend_zone() ensures zones are defined",
                         );
                         DnsRecord::Aaaa(*zone_ip)

--- a/live-tests/tests/common/mod.rs
+++ b/live-tests/tests/common/mod.rs
@@ -38,7 +38,7 @@ impl LiveTestContext {
         let log = &logctx.log;
         let resolver = create_resolver(log)?;
         check_execution_environment(&resolver).await?;
-        let datastore = create_datastore(&log, &resolver).await?;
+        let datastore = create_datastore(log, &resolver).await?;
         let opctx = OpContext::for_tests(log.clone(), datastore.clone());
         check_hardware_environment(&opctx, &datastore).await?;
         Ok(LiveTestContext { logctx, opctx, resolver, datastore })

--- a/live-tests/tests/common/reconfigurator.rs
+++ b/live-tests/tests/common/reconfigurator.rs
@@ -70,8 +70,8 @@ pub async fn blueprint_edit_current_target(
     let mut builder = BlueprintBuilder::new_based_on(
         log,
         &blueprint1,
-        &planning_input,
-        &collection,
+        planning_input,
+        collection,
         "test-suite",
     )
     .context("creating BlueprintBuilder")?;

--- a/live-tests/tests/test_nexus_add_remove.rs
+++ b/live-tests/tests/test_nexus_add_remove.rs
@@ -42,7 +42,7 @@ async fn test_nexus_add_remove(lc: &LiveTestContext) {
     let log = lc.log();
     let opctx = lc.opctx();
     let datastore = lc.datastore();
-    let planning_input = PlanningInputFromDb::assemble(&opctx, &datastore)
+    let planning_input = PlanningInputFromDb::assemble(opctx, datastore)
         .await
         .expect("planning input");
     let collection = datastore
@@ -62,7 +62,7 @@ async fn test_nexus_add_remove(lc: &LiveTestContext) {
         log,
         &planning_input,
         &collection,
-        &nexus,
+        nexus,
         &|builder: &mut BlueprintBuilder| {
             builder
                 .sled_add_zone_nexus(sled_id)
@@ -120,7 +120,7 @@ async fn test_nexus_add_remove(lc: &LiveTestContext) {
         log,
         &planning_input,
         &collection,
-        &nexus,
+        nexus,
         &|builder: &mut BlueprintBuilder| {
             builder
                 .sled_expunge_zone(sled_id, new_zone.id)
@@ -200,7 +200,7 @@ async fn test_nexus_add_remove(lc: &LiveTestContext) {
 
     // Now run through the planner.
     info!(log, "running through planner");
-    let planning_input = PlanningInputFromDb::assemble(&opctx, &datastore)
+    let planning_input = PlanningInputFromDb::assemble(opctx, datastore)
         .await
         .expect("planning input");
     let (_, parent_blueprint) = datastore
@@ -251,7 +251,7 @@ async fn test_nexus_add_remove(lc: &LiveTestContext) {
         || async {
             for nexus_client in &initial_nexus_clients {
                 assert!(nexus_client.baseurl() != new_zone_client.baseurl());
-                let Ok(sagas) = list_sagas(&nexus_client).await else {
+                let Ok(sagas) = list_sagas(nexus_client).await else {
                     continue;
                 };
 
@@ -284,7 +284,7 @@ async fn test_nexus_add_remove(lc: &LiveTestContext) {
         .expect("complete demo saga");
     let found = wait_for_condition(
         || async {
-            let sagas = list_sagas(&nexus_found).await.expect("listing sagas");
+            let sagas = list_sagas(nexus_found).await.expect("listing sagas");
             debug!(log, "found sagas (last): {:?}", sagas);
             let found = sagas.into_iter().find(|s| s.id == saga_id).unwrap();
             if matches!(found.state, SagaState::Succeeded) {

--- a/nexus/auth/src/authn/silos.rs
+++ b/nexus/auth/src/authn/silos.rs
@@ -144,7 +144,7 @@ impl SamlIdentityProvider {
         sp_builder.slo_url(self.slo_url.clone());
 
         if let Some(cert) = &self.public_cert_bytes()? {
-            if let Ok(parsed) = openssl::x509::X509::from_der(&cert) {
+            if let Ok(parsed) = openssl::x509::X509::from_der(cert) {
                 sp_builder.certificate(Some(parsed));
             }
         }

--- a/nexus/db-model/src/instance.rs
+++ b/nexus/db-model/src/instance.rs
@@ -335,7 +335,7 @@ impl InstanceAutoRestart {
                 );
                 true
             }
-            (InstanceState::Vmm, Some(ref vmm)) => {
+            (InstanceState::Vmm, Some(vmm)) => {
                 debug_assert_eq!(
                     state.propolis_id,
                     Some(vmm.id),
@@ -352,7 +352,7 @@ impl InstanceAutoRestart {
 
         InstanceKarmicStatus {
             needs_reincarnation,
-            can_reincarnate: self.can_reincarnate(&state),
+            can_reincarnate: self.can_reincarnate(state),
         }
     }
 

--- a/nexus/db-model/src/vpc_firewall_rule.rs
+++ b/nexus/db-model/src/vpc_firewall_rule.rs
@@ -238,13 +238,13 @@ impl VpcFirewallRule {
         ensure_max_len(&rule.targets, "targets", MAX_FW_RULE_PARTS)?;
 
         if let Some(hosts) = rule.filters.hosts.as_ref() {
-            ensure_max_len(&hosts, "filters.hosts", MAX_FW_RULE_PARTS)?;
+            ensure_max_len(hosts, "filters.hosts", MAX_FW_RULE_PARTS)?;
         }
         if let Some(ports) = rule.filters.ports.as_ref() {
-            ensure_max_len(&ports, "filters.ports", MAX_FW_RULE_PARTS)?;
+            ensure_max_len(ports, "filters.ports", MAX_FW_RULE_PARTS)?;
         }
         if let Some(protocols) = rule.filters.protocols.as_ref() {
-            ensure_max_len(&protocols, "filters.protocols", MAX_FW_RULE_PARTS)?;
+            ensure_max_len(protocols, "filters.protocols", MAX_FW_RULE_PARTS)?;
         }
 
         Ok(Self {

--- a/nexus/db-queries/benches/harness/db_utils.rs
+++ b/nexus/db-queries/benches/harness/db_utils.rs
@@ -71,7 +71,7 @@ pub async fn create_reservation(
     loop {
         match db
             .sled_reservation_create(
-                &opctx,
+                opctx,
                 instance_id,
                 vmm_id,
                 small_resource_request(),
@@ -101,7 +101,7 @@ pub async fn delete_reservation(
     db: &DataStore,
     vmm_id: PropolisUuid,
 ) -> Result<()> {
-    db.sled_reservation_delete(&opctx, vmm_id)
+    db.sled_reservation_delete(opctx, vmm_id)
         .await
         .context("Failed to delete reservation")?;
     Ok(())

--- a/nexus/db-queries/benches/harness/mod.rs
+++ b/nexus/db-queries/benches/harness/mod.rs
@@ -104,8 +104,8 @@ impl TestHarness {
         let db = TestDatabase::new_with_datastore(log).await;
         let (opctx, datastore) = (db.opctx(), db.datastore());
         let (authz_project, _project) =
-            create_project(&opctx, &datastore, "project").await;
-        create_sleds(&datastore, sled_count).await;
+            create_project(opctx, datastore, "project").await;
+        create_sleds(datastore, sled_count).await;
 
         Self { db, authz_project }
     }
@@ -160,7 +160,7 @@ impl TestHarness {
                         print!("|");
                         total_len += width + 3;
                     }
-                    println!("");
+                    println!();
                     println!("{:-<total_len$}", "");
                 }
                 header = false;
@@ -171,9 +171,9 @@ impl TestHarness {
                     print!(" {value:width$} ");
                     print!("|");
                 }
-                println!("");
+                println!();
             }
-            println!("");
+            println!();
         }
 
         client.cleanup().await.expect("Failed to clean up db connection");

--- a/nexus/db-queries/src/db/collection_attach.rs
+++ b/nexus/db-queries/src/db/collection_attach.rs
@@ -691,7 +691,7 @@ mod test {
             .await
             .unwrap();
 
-        get_collection(id, &conn).await
+        get_collection(id, conn).await
     }
 
     async fn get_collection(
@@ -895,7 +895,7 @@ mod test {
         let db = TestDatabase::new_with_pool(&logctx.log).await;
         let pool = db.pool();
 
-        let conn = setup_db(&pool).await;
+        let conn = setup_db(pool).await;
 
         let collection_id = uuid::Uuid::new_v4();
         let resource_id = uuid::Uuid::new_v4();
@@ -931,7 +931,7 @@ mod test {
         let db = TestDatabase::new_with_pool(&logctx.log).await;
         let pool = db.pool();
 
-        let conn = setup_db(&pool).await;
+        let conn = setup_db(pool).await;
 
         let collection_id = uuid::Uuid::new_v4();
         let resource_id = uuid::Uuid::new_v4();
@@ -978,7 +978,7 @@ mod test {
         let db = TestDatabase::new_with_pool(&logctx.log).await;
         let pool = db.pool();
 
-        let conn = setup_db(&pool).await;
+        let conn = setup_db(pool).await;
 
         let collection_id = uuid::Uuid::new_v4();
         let resource_id = uuid::Uuid::new_v4();

--- a/nexus/db-queries/src/db/datastore/address_lot.rs
+++ b/nexus/db-queries/src/db/datastore/address_lot.rs
@@ -229,7 +229,7 @@ impl DataStore {
 
         match pagparams {
             PaginatedBy::Id(pagparams) => {
-                paginated(dsl::address_lot, dsl::id, &pagparams)
+                paginated(dsl::address_lot, dsl::id, pagparams)
             }
             PaginatedBy::Name(pagparams) => paginated(
                 dsl::address_lot,
@@ -254,7 +254,7 @@ impl DataStore {
 
         let conn = self.pool_connection_authorized(opctx).await?;
 
-        paginated(dsl::address_lot_block, dsl::id, &pagparams)
+        paginated(dsl::address_lot_block, dsl::id, pagparams)
             .filter(dsl::address_lot_id.eq(authz_address_lot.id()))
             .select(AddressLotBlock::as_select())
             .load_async(&*conn)

--- a/nexus/db-queries/src/db/datastore/allow_list.rs
+++ b/nexus/db-queries/src/db/datastore/allow_list.rs
@@ -96,7 +96,7 @@ mod tests {
 
         // Should have the default to start with.
         let record = datastore
-            .allow_list_view(&opctx)
+            .allow_list_view(opctx)
             .await
             .expect("Expected default data populated in dbinit.sql");
         assert!(
@@ -110,7 +110,7 @@ mod tests {
         let allowed_ips =
             external::AllowedSourceIps::try_from(ips.as_slice()).unwrap();
         let record = datastore
-            .allow_list_upsert(&opctx, allowed_ips)
+            .allow_list_upsert(opctx, allowed_ips)
             .await
             .expect("Expected this insert to succeed");
         assert_eq!(
@@ -129,7 +129,7 @@ mod tests {
         let allowed_ips =
             external::AllowedSourceIps::try_from(new_ips.as_slice()).unwrap();
         let new_record = datastore
-            .allow_list_upsert(&opctx, allowed_ips)
+            .allow_list_upsert(opctx, allowed_ips)
             .await
             .expect("Expected this insert to succeed");
         assert_eq!(
@@ -154,7 +154,7 @@ mod tests {
         let record = new_record;
         let allowed_ips = external::AllowedSourceIps::Any;
         let new_record = datastore
-            .allow_list_upsert(&opctx, allowed_ips)
+            .allow_list_upsert(opctx, allowed_ips)
             .await
             .expect("Expected this insert to succeed");
         assert_eq!(
@@ -179,7 +179,7 @@ mod tests {
         let allowed_ips =
             external::AllowedSourceIps::try_from(new_ips.as_slice()).unwrap();
         let new_record = datastore
-            .allow_list_upsert(&opctx, allowed_ips)
+            .allow_list_upsert(opctx, allowed_ips)
             .await
             .expect("Expected this insert to succeed");
         assert_eq!(

--- a/nexus/db-queries/src/db/datastore/bgp.rs
+++ b/nexus/db-queries/src/db/datastore/bgp.rs
@@ -385,7 +385,7 @@ impl DataStore {
 
         match pagparams {
             PaginatedBy::Id(pagparams) => {
-                paginated(dsl::bgp_config, dsl::id, &pagparams)
+                paginated(dsl::bgp_config, dsl::id, pagparams)
             }
             PaginatedBy::Name(pagparams) => paginated(
                 dsl::bgp_config,
@@ -414,7 +414,7 @@ impl DataStore {
 
         match pagparams {
             PaginatedBy::Id(pagparams) => {
-                paginated(dsl::bgp_announce_set, dsl::id, &pagparams)
+                paginated(dsl::bgp_announce_set, dsl::id, pagparams)
             }
             PaginatedBy::Name(pagparams) => paginated(
                 dsl::bgp_announce_set,
@@ -1017,7 +1017,7 @@ mod tests {
 
         datastore
             .bgp_create_announce_set(
-                &opctx,
+                opctx,
                 &params::BgpAnnounceSetCreate {
                     identity: IdentityMetadataCreateParams {
                         name: announce_name.clone(),
@@ -1031,7 +1031,7 @@ mod tests {
 
         datastore
             .bgp_config_create(
-                &opctx,
+                opctx,
                 &params::BgpConfigCreate {
                     identity: IdentityMetadataCreateParams {
                         name: config_name.clone(),
@@ -1049,7 +1049,7 @@ mod tests {
 
         datastore
             .bgp_config_delete(
-                &opctx,
+                opctx,
                 &params::BgpConfigSelector {
                     name_or_id: NameOrId::Name(config_name),
                 },
@@ -1059,7 +1059,7 @@ mod tests {
 
         datastore
             .bgp_delete_announce_set(
-                &opctx,
+                opctx,
                 &params::BgpAnnounceSetSelector {
                     announce_set: NameOrId::Name(announce_name),
                 },

--- a/nexus/db-queries/src/db/datastore/certificate.rs
+++ b/nexus/db-queries/src/db/datastore/certificate.rs
@@ -89,7 +89,7 @@ impl DataStore {
         let query;
         match pagparams {
             PaginatedBy::Id(params) => {
-                query = paginated(dsl::certificate, dsl::id, &params)
+                query = paginated(dsl::certificate, dsl::id, params)
                     .filter(dsl::time_deleted.is_null());
             }
             PaginatedBy::Name(params) => {

--- a/nexus/db-queries/src/db/datastore/clickhouse_policy.rs
+++ b/nexus/db-queries/src/db/datastore/clickhouse_policy.rs
@@ -92,9 +92,9 @@ impl DataStore {
             .await?;
 
         let num_inserted = if policy.version == 1 {
-            self.clickhouse_policy_insert_first_policy(opctx, &policy).await?
+            self.clickhouse_policy_insert_first_policy(opctx, policy).await?
         } else {
-            self.clickhouse_policy_insert_next_policy(opctx, &policy).await?
+            self.clickhouse_policy_insert_next_policy(opctx, policy).await?
         };
 
         match num_inserted {

--- a/nexus/db-queries/src/db/datastore/cockroachdb_node_id.rs
+++ b/nexus/db-queries/src/db/datastore/cockroachdb_node_id.rs
@@ -96,7 +96,7 @@ mod tests {
 
         // We shouldn't have a mapping for it yet.
         let node_id = datastore
-            .cockroachdb_node_id(&opctx, crdb_zone_id)
+            .cockroachdb_node_id(opctx, crdb_zone_id)
             .await
             .expect("looked up node ID");
         assert_eq!(node_id, None);
@@ -105,7 +105,7 @@ mod tests {
         let fake_node_id = "test-node";
         datastore
             .set_cockroachdb_node_id(
-                &opctx,
+                opctx,
                 crdb_zone_id,
                 fake_node_id.to_string(),
             )
@@ -114,7 +114,7 @@ mod tests {
 
         // We can look up the mapping we created.
         let node_id = datastore
-            .cockroachdb_node_id(&opctx, crdb_zone_id)
+            .cockroachdb_node_id(opctx, crdb_zone_id)
             .await
             .expect("looked up node ID");
         assert_eq!(node_id.as_deref(), Some(fake_node_id));
@@ -123,7 +123,7 @@ mod tests {
         let different_node_id = "test-node-2";
         datastore
             .set_cockroachdb_node_id(
-                &opctx,
+                opctx,
                 crdb_zone_id,
                 different_node_id.to_string(),
             )
@@ -134,7 +134,7 @@ mod tests {
         let different_zone_id = OmicronZoneUuid::new_v4();
         datastore
             .set_cockroachdb_node_id(
-                &opctx,
+                opctx,
                 different_zone_id,
                 fake_node_id.to_string(),
             )
@@ -144,7 +144,7 @@ mod tests {
         // We can reassign the same node ID (i.e., setting is idempotent).
         datastore
             .set_cockroachdb_node_id(
-                &opctx,
+                opctx,
                 crdb_zone_id,
                 fake_node_id.to_string(),
             )
@@ -153,7 +153,7 @@ mod tests {
 
         // The mapping should not have changed.
         let node_id = datastore
-            .cockroachdb_node_id(&opctx, crdb_zone_id)
+            .cockroachdb_node_id(opctx, crdb_zone_id)
             .await
             .expect("looked up node ID");
         assert_eq!(node_id.as_deref(), Some(fake_node_id));

--- a/nexus/db-queries/src/db/datastore/cockroachdb_settings.rs
+++ b/nexus/db-queries/src/db/datastore/cockroachdb_settings.rs
@@ -142,7 +142,7 @@ mod test {
         let db = TestDatabase::new_with_datastore(&logctx.log).await;
         let (opctx, datastore) = (db.opctx(), db.datastore());
 
-        let settings = datastore.cockroachdb_settings(&opctx).await.unwrap();
+        let settings = datastore.cockroachdb_settings(opctx).await.unwrap();
         let version: CockroachDbClusterVersion =
             settings.version.parse().expect("unexpected cluster version");
         if settings.preserve_downgrade == "" {
@@ -164,7 +164,7 @@ mod test {
         // back.
         let Err(Error::InternalError { internal_message }) = datastore
             .cockroachdb_setting_set_string(
-                &opctx,
+                opctx,
                 String::new(),
                 "cluster.preserve_downgrade_option",
                 version.to_string(),
@@ -181,7 +181,7 @@ mod test {
         // And ensure that the state didn't change.
         assert_eq!(
             settings,
-            datastore.cockroachdb_settings(&opctx).await.unwrap()
+            datastore.cockroachdb_settings(opctx).await.unwrap()
         );
 
         // Test setting it (twice, to verify doing it again doesn't trigger
@@ -189,7 +189,7 @@ mod test {
         for _ in 0..2 {
             datastore
                 .cockroachdb_setting_set_string(
-                    &opctx,
+                    opctx,
                     settings.state_fingerprint.clone(),
                     "cluster.preserve_downgrade_option",
                     version.to_string(),
@@ -197,7 +197,7 @@ mod test {
                 .await
                 .unwrap();
             assert_eq!(
-                datastore.cockroachdb_settings(&opctx).await.unwrap(),
+                datastore.cockroachdb_settings(opctx).await.unwrap(),
                 CockroachDbSettings {
                     state_fingerprint: settings.state_fingerprint.clone(),
                     version: version.to_string(),
@@ -210,15 +210,14 @@ mod test {
         for _ in 0..2 {
             datastore
                 .cockroachdb_setting_set_string(
-                    &opctx,
+                    opctx,
                     settings.state_fingerprint.clone(),
                     "cluster.preserve_downgrade_option",
                     String::new(),
                 )
                 .await
                 .unwrap();
-            let settings =
-                datastore.cockroachdb_settings(&opctx).await.unwrap();
+            let settings = datastore.cockroachdb_settings(opctx).await.unwrap();
             if version == CockroachDbClusterVersion::NEWLY_INITIALIZED {
                 assert_eq!(
                     settings,

--- a/nexus/db-queries/src/db/datastore/console_session.rs
+++ b/nexus/db-queries/src/db/datastore/console_session.rs
@@ -76,7 +76,7 @@ impl DataStore {
                 ))
             })?;
 
-        let (.., db_silo_user) = LookupPath::new(opctx, &self)
+        let (.., db_silo_user) = LookupPath::new(opctx, self)
             .silo_user_id(console_session.silo_user_id)
             .fetch()
             .await

--- a/nexus/db-queries/src/db/datastore/crucible_dataset.rs
+++ b/nexus/db-queries/src/db/datastore/crucible_dataset.rs
@@ -61,7 +61,7 @@ impl DataStore {
         dataset: CrucibleDataset,
     ) -> CreateResult<CrucibleDataset> {
         let conn = &*self.pool_connection_unauthorized().await?;
-        Self::crucible_dataset_upsert_on_connection(&conn, dataset)
+        Self::crucible_dataset_upsert_on_connection(conn, dataset)
             .await
             .map_err(|e| match e {
                 TransactionError::CustomError(e) => e,
@@ -355,7 +355,7 @@ mod test {
         );
 
         let (_sled_id, zpool_id) =
-            create_sled_and_zpool(&datastore, opctx).await;
+            create_sled_and_zpool(datastore, opctx).await;
 
         // Inserting a new dataset should succeed.
         let dataset1 = datastore

--- a/nexus/db-queries/src/db/datastore/deployment/external_networking.rs
+++ b/nexus/db-queries/src/db/datastore/deployment/external_networking.rs
@@ -593,11 +593,11 @@ mod tests {
             datastore: &DataStore,
         ) {
             let (ip_pool, _) = datastore
-                .ip_pools_service_lookup(&opctx)
+                .ip_pools_service_lookup(opctx)
                 .await
                 .expect("failed to find service IP pool");
             datastore
-                .ip_pool_add_range(&opctx, &ip_pool, &self.external_ips_range)
+                .ip_pool_add_range(opctx, &ip_pool, &self.external_ips_range)
                 .await
                 .expect("failed to expand service IP pool");
         }
@@ -905,7 +905,7 @@ mod tests {
 
         // Generate the test values we care about.
         let mut harness = Harness::new();
-        harness.set_up_service_ip_pool(&opctx, &datastore).await;
+        harness.set_up_service_ip_pool(opctx, datastore).await;
 
         // Build the `zones` map needed by `ensure_zone_resources_allocated`,
         // with an arbitrary sled_id.
@@ -916,7 +916,7 @@ mod tests {
         datastore
             .ensure_zone_external_networking_allocated_on_connection(
                 &datastore.pool_connection_for_tests().await.unwrap(),
-                &opctx,
+                opctx,
                 zones.iter(),
             )
             .await
@@ -924,22 +924,22 @@ mod tests {
             .unwrap();
 
         // Check that the external IP and NIC records were created.
-        harness.assert_ips_exist_in_datastore(&datastore).await;
-        harness.assert_nics_exist_in_datastore(&datastore).await;
+        harness.assert_ips_exist_in_datastore(datastore).await;
+        harness.assert_nics_exist_in_datastore(datastore).await;
 
         // We should be able to run the function again with the same inputs, and
         // it should succeed without inserting any new records.
         datastore
             .ensure_zone_external_networking_allocated_on_connection(
                 &datastore.pool_connection_for_tests().await.unwrap(),
-                &opctx,
+                opctx,
                 zones.iter(),
             )
             .await
             .with_context(|| format!("{zones:#?}"))
             .unwrap();
-        harness.assert_ips_exist_in_datastore(&datastore).await;
-        harness.assert_nics_exist_in_datastore(&datastore).await;
+        harness.assert_ips_exist_in_datastore(datastore).await;
+        harness.assert_nics_exist_in_datastore(datastore).await;
 
         // Now that we've tested the happy path, try some requests that ought to
         // fail because the request includes an external IP that doesn't match
@@ -1025,7 +1025,7 @@ mod tests {
             let err = datastore
                 .ensure_zone_external_networking_allocated_on_connection(
                     &datastore.pool_connection_for_tests().await.unwrap(),
-                    &opctx,
+                    opctx,
                     mutated_zones.iter(),
                 )
                 .await
@@ -1083,7 +1083,7 @@ mod tests {
 
                     let err = datastore.ensure_zone_external_networking_allocated_on_connection(
                         &datastore.pool_connection_for_tests().await.unwrap(),
-                        &opctx,
+                        opctx,
                         mutated_zones.iter(),
                     )
                     .await
@@ -1109,7 +1109,7 @@ mod tests {
 
                     let err = datastore.ensure_zone_external_networking_allocated_on_connection(
                         &datastore.pool_connection_for_tests().await.unwrap(),
-                        &opctx,
+                        opctx,
                         mutated_zones.iter(),
                     )
                     .await
@@ -1135,7 +1135,7 @@ mod tests {
 
                     let err = datastore.ensure_zone_external_networking_allocated_on_connection(
                         &datastore.pool_connection_for_tests().await.unwrap(),
-                        &opctx,
+                        opctx,
                         mutated_zones.iter(),
                     )
                     .await
@@ -1165,7 +1165,7 @@ mod tests {
 
         // Generate the test values we care about.
         let harness = Harness::new();
-        harness.set_up_service_ip_pool(&opctx, &datastore).await;
+        harness.set_up_service_ip_pool(opctx, datastore).await;
 
         // Build the `zones` map needed by `ensure_zone_resources_allocated`,
         // with an arbitrary sled_id.
@@ -1176,7 +1176,7 @@ mod tests {
         datastore
             .ensure_zone_external_networking_allocated_on_connection(
                 &datastore.pool_connection_for_tests().await.unwrap(),
-                &opctx,
+                opctx,
                 zones.iter(),
             )
             .await
@@ -1184,8 +1184,8 @@ mod tests {
             .unwrap();
 
         // Check that the external IP and NIC records were created.
-        harness.assert_ips_exist_in_datastore(&datastore).await;
-        harness.assert_nics_exist_in_datastore(&datastore).await;
+        harness.assert_ips_exist_in_datastore(datastore).await;
+        harness.assert_nics_exist_in_datastore(datastore).await;
 
         // Deallocate resources: this should succeed and mark all relevant db
         // records deleted.
@@ -1199,8 +1199,8 @@ mod tests {
             .with_context(|| format!("{zones:#?}"))
             .unwrap();
 
-        harness.assert_ips_are_deleted_in_datastore(&datastore).await;
-        harness.assert_nics_are_deleted_in_datastore(&datastore).await;
+        harness.assert_ips_are_deleted_in_datastore(datastore).await;
+        harness.assert_nics_are_deleted_in_datastore(datastore).await;
 
         // This operation should be idempotent: we can run it again, and the
         // records remain deleted.
@@ -1214,8 +1214,8 @@ mod tests {
             .with_context(|| format!("{zones:#?}"))
             .unwrap();
 
-        harness.assert_ips_are_deleted_in_datastore(&datastore).await;
-        harness.assert_nics_are_deleted_in_datastore(&datastore).await;
+        harness.assert_ips_are_deleted_in_datastore(datastore).await;
+        harness.assert_nics_are_deleted_in_datastore(datastore).await;
 
         // Clean up.
         db.terminate().await;

--- a/nexus/db-queries/src/db/datastore/disk.rs
+++ b/nexus/db-queries/src/db/datastore/disk.rs
@@ -65,7 +65,7 @@ impl DataStore {
 
         match pagparams {
             PaginatedBy::Id(pagparams) => {
-                paginated(dsl::disk, dsl::id, &pagparams)
+                paginated(dsl::disk, dsl::id, pagparams)
             }
             PaginatedBy::Name(pagparams) => paginated(
                 dsl::disk,
@@ -140,7 +140,7 @@ impl DataStore {
         use nexus_db_schema::schema::disk::dsl;
         match pagparams {
             PaginatedBy::Id(pagparams) => {
-                paginated(dsl::disk, dsl::id, &pagparams)
+                paginated(dsl::disk, dsl::id, pagparams)
             }
             PaginatedBy::Name(pagparams) => paginated(
                 dsl::disk,
@@ -862,7 +862,7 @@ mod tests {
 
         let (authz_project, _db_project) = db_datastore
             .project_create(
-                &opctx,
+                opctx,
                 Project::new(
                     silo_id,
                     params::ProjectCreate {
@@ -878,7 +878,7 @@ mod tests {
 
         let disk = db_datastore
             .project_create_disk(
-                &opctx,
+                opctx,
                 &authz_project,
                 Disk::new(
                     Uuid::new_v4(),
@@ -903,7 +903,7 @@ mod tests {
             .await
             .unwrap();
 
-        let (.., authz_disk, db_disk) = LookupPath::new(&opctx, &db_datastore)
+        let (.., authz_disk, db_disk) = LookupPath::new(opctx, db_datastore)
             .disk_id(disk.id())
             .fetch()
             .await
@@ -911,7 +911,7 @@ mod tests {
 
         db_datastore
             .disk_update_runtime(
-                &opctx,
+                opctx,
                 &authz_disk,
                 &db_disk.runtime().detach(),
             )
@@ -929,7 +929,7 @@ mod tests {
         // Assert initial state - deleting the Disk will make LookupPath::fetch
         // not work.
         {
-            LookupPath::new(&opctx, &db_datastore)
+            LookupPath::new(opctx, db_datastore)
                 .disk_id(disk.id())
                 .fetch()
                 .await
@@ -946,7 +946,7 @@ mod tests {
         // Assert state change
 
         {
-            let (.., db_disk) = LookupPath::new(&opctx, &db_datastore)
+            let (.., db_disk) = LookupPath::new(opctx, db_datastore)
                 .disk_id(disk.id())
                 .fetch()
                 .await
@@ -967,7 +967,7 @@ mod tests {
         // Assert state is the same after the second call
 
         {
-            let (.., db_disk) = LookupPath::new(&opctx, &db_datastore)
+            let (.., db_disk) = LookupPath::new(opctx, db_datastore)
                 .disk_id(disk.id())
                 .fetch()
                 .await

--- a/nexus/db-queries/src/db/datastore/external_ip.rs
+++ b/nexus/db-queries/src/db/datastore/external_ip.rs
@@ -499,7 +499,7 @@ impl DataStore {
                 }
 
                 Err(match &collection.runtime_state.nexus_state {
-                    state if SAFE_TO_ATTACH_INSTANCE_STATES.contains(&state) => {
+                    state if SAFE_TO_ATTACH_INSTANCE_STATES.contains(state) => {
                         if attached_count >= i64::from(MAX_EXTERNAL_IPS_PLUS_SNAT) {
                             Error::invalid_request(&format!(
                                 "an instance may not have more than \
@@ -853,7 +853,7 @@ impl DataStore {
 
         match pagparams {
             PaginatedBy::Id(pagparams) => {
-                paginated(dsl::floating_ip, dsl::id, &pagparams)
+                paginated(dsl::floating_ip, dsl::id, pagparams)
             }
             PaginatedBy::Name(pagparams) => paginated(
                 dsl::floating_ip,
@@ -1171,7 +1171,7 @@ mod tests {
         let (opctx, datastore) = (db.opctx(), db.datastore());
 
         // No IPs, to start
-        let ips = read_all_service_ips(&datastore, opctx).await;
+        let ips = read_all_service_ips(datastore, opctx).await;
         assert_eq!(ips, vec![]);
 
         // Set up service IP pool range
@@ -1224,7 +1224,7 @@ mod tests {
         external_ips.sort_by_key(|ip| ip.id);
 
         // Ensure we see them all.
-        let ips = read_all_service_ips(&datastore, opctx).await;
+        let ips = read_all_service_ips(datastore, opctx).await;
         assert_eq!(ips, external_ips);
 
         // Deallocate a few, and ensure we don't see them anymore.
@@ -1246,7 +1246,7 @@ mod tests {
         external_ips.retain(|ip| !removed_ip_ids.contains(&ip.id));
 
         // Ensure we see them all remaining IPs.
-        let ips = read_all_service_ips(&datastore, opctx).await;
+        let ips = read_all_service_ips(datastore, opctx).await;
         assert_eq!(ips, external_ips);
 
         db.terminate().await;

--- a/nexus/db-queries/src/db/datastore/image.rs
+++ b/nexus/db-queries/src/db/datastore/image.rs
@@ -41,7 +41,7 @@ impl DataStore {
             PaginatedBy::Id(pagparams) => paginated(
                 project_dsl::project_image,
                 project_dsl::id,
-                &pagparams,
+                pagparams,
             ),
             PaginatedBy::Name(pagparams) => paginated(
                 project_dsl::project_image,
@@ -71,7 +71,7 @@ impl DataStore {
         use nexus_db_schema::schema::silo_image::dsl;
         match pagparams {
             PaginatedBy::Id(pagparams) => {
-                paginated(dsl::silo_image, dsl::id, &pagparams)
+                paginated(dsl::silo_image, dsl::id, pagparams)
             }
             PaginatedBy::Name(pagparams) => paginated(
                 dsl::silo_image,

--- a/nexus/db-queries/src/db/datastore/inventory.rs
+++ b/nexus/db-queries/src/db/datastore/inventory.rs
@@ -84,7 +84,7 @@ use uuid::Uuid;
 /// We use a [`Paginator`] to guard against single queries returning an
 /// unchecked number of rows.
 // unsafe: `new_unchecked` is only unsound if the argument is 0.
-const SQL_BATCH_SIZE: NonZeroU32 = NonZeroU32::new(1000).unwrap();
+const SQL_BATCH_SIZE: NonZeroU32 = unsafe { NonZeroU32::new_unchecked(1000) };
 
 impl DataStore {
     /// Store a complete inventory collection into the database

--- a/nexus/db-queries/src/db/datastore/inventory.rs
+++ b/nexus/db-queries/src/db/datastore/inventory.rs
@@ -2525,7 +2525,7 @@ mod test {
             part_number: "some-part".into(),
         };
         let err = datastore
-            .find_hw_baseboard_id(&opctx, &baseboard_id)
+            .find_hw_baseboard_id(opctx, &baseboard_id)
             .await
             .unwrap_err();
         assert!(matches!(err, Error::ObjectNotFound { .. }));
@@ -2546,14 +2546,14 @@ mod test {
         let builder = nexus_inventory::CollectionBuilder::new("test");
         let collection1 = builder.build();
         datastore
-            .inventory_insert_collection(&opctx, &collection1)
+            .inventory_insert_collection(opctx, &collection1)
             .await
             .expect("failed to insert collection");
 
         // Read it back.
         let conn = datastore.pool_connection_for_tests().await.unwrap();
         let collection_read = datastore
-            .inventory_collection_read(&opctx, collection1.id)
+            .inventory_collection_read(opctx, collection1.id)
             .await
             .expect("failed to read collection back");
         assert_eq!(collection1, collection_read);
@@ -2573,11 +2573,11 @@ mod test {
         let Representative { builder, .. } = representative();
         let collection2 = builder.build();
         datastore
-            .inventory_insert_collection(&opctx, &collection2)
+            .inventory_insert_collection(opctx, &collection2)
             .await
             .expect("failed to insert collection");
         let collection_read = datastore
-            .inventory_collection_read(&opctx, collection2.id)
+            .inventory_collection_read(opctx, collection2.id)
             .await
             .expect("failed to read collection back");
         assert_eq!(collection2, collection_read);
@@ -2598,7 +2598,7 @@ mod test {
         // having to actually read 1000s of records.
         let batched_read = datastore
             .inventory_collection_read_batched(
-                &opctx,
+                opctx,
                 collection2.id,
                 NonZeroU32::new(1).unwrap(),
             )
@@ -2617,11 +2617,11 @@ mod test {
         let Representative { builder, .. } = representative();
         let collection3 = builder.build();
         datastore
-            .inventory_insert_collection(&opctx, &collection3)
+            .inventory_insert_collection(opctx, &collection3)
             .await
             .expect("failed to insert collection");
         let collection_read = datastore
-            .inventory_collection_read(&opctx, collection3.id)
+            .inventory_collection_read(opctx, collection3.id)
             .await
             .expect("failed to read collection back");
         assert_eq!(collection3, collection_read);
@@ -2671,11 +2671,11 @@ mod test {
             .unwrap();
         let collection4 = builder.build();
         datastore
-            .inventory_insert_collection(&opctx, &collection4)
+            .inventory_insert_collection(opctx, &collection4)
             .await
             .expect("failed to insert collection");
         let collection_read = datastore
-            .inventory_collection_read(&opctx, collection4.id)
+            .inventory_collection_read(opctx, collection4.id)
             .await
             .expect("failed to read collection back");
         assert_eq!(collection4, collection_read);
@@ -2700,11 +2700,11 @@ mod test {
         let Representative { builder, .. } = representative();
         let collection5 = builder.build();
         datastore
-            .inventory_insert_collection(&opctx, &collection5)
+            .inventory_insert_collection(opctx, &collection5)
             .await
             .expect("failed to insert collection");
         let collection_read = datastore
-            .inventory_collection_read(&opctx, collection5.id)
+            .inventory_collection_read(opctx, collection5.id)
             .await
             .expect("failed to read collection back");
         assert_eq!(collection5, collection_read);
@@ -2721,7 +2721,7 @@ mod test {
 
         // Try to insert the same collection again and make sure it fails.
         let error = datastore
-            .inventory_insert_collection(&opctx, &collection5)
+            .inventory_insert_collection(opctx, &collection5)
             .await
             .expect_err("unexpectedly succeeded in inserting collection");
         assert!(
@@ -2762,7 +2762,7 @@ mod test {
             ]
         );
         datastore
-            .inventory_prune_collections(&opctx, 4)
+            .inventory_prune_collections(opctx, 4)
             .await
             .expect("failed to prune collections");
         assert_eq!(
@@ -2778,7 +2778,7 @@ mod test {
         // Again, we should skip over collection1 and delete the next oldest:
         // collection3.
         datastore
-            .inventory_prune_collections(&opctx, 3)
+            .inventory_prune_collections(opctx, 3)
             .await
             .expect("failed to prune collections");
         assert_eq!(
@@ -2793,7 +2793,7 @@ mod test {
         );
         // At this point, if we're keeping 3, we don't need to prune anything.
         datastore
-            .inventory_prune_collections(&opctx, 3)
+            .inventory_prune_collections(opctx, 3)
             .await
             .expect("failed to prune collections");
         assert_eq!(
@@ -2816,7 +2816,7 @@ mod test {
             collection6.id, collection6.time_started
         );
         datastore
-            .inventory_insert_collection(&opctx, &collection6)
+            .inventory_insert_collection(opctx, &collection6)
             .await
             .expect("failed to insert collection");
         assert_eq!(
@@ -2830,7 +2830,7 @@ mod test {
             &[collection1.id, collection4.id, collection5.id, collection6.id,]
         );
         datastore
-            .inventory_prune_collections(&opctx, 3)
+            .inventory_prune_collections(opctx, 3)
             .await
             .expect("failed to prune collections");
         assert_eq!(
@@ -2845,7 +2845,7 @@ mod test {
         );
         // Again, at this point, we should not prune anything.
         datastore
-            .inventory_prune_collections(&opctx, 3)
+            .inventory_prune_collections(opctx, 3)
             .await
             .expect("failed to prune collections");
         assert_eq!(
@@ -2868,11 +2868,11 @@ mod test {
             collection7.id, collection7.time_started
         );
         datastore
-            .inventory_insert_collection(&opctx, &collection7)
+            .inventory_insert_collection(opctx, &collection7)
             .await
             .expect("failed to insert collection");
         datastore
-            .inventory_prune_collections(&opctx, 3)
+            .inventory_prune_collections(opctx, 3)
             .await
             .expect("failed to prune collections");
         assert_eq!(
@@ -2888,23 +2888,23 @@ mod test {
 
         // If we try to fetch a pruned collection, we should get nothing.
         let _ = datastore
-            .inventory_collection_read(&opctx, collection4.id)
+            .inventory_collection_read(opctx, collection4.id)
             .await
             .expect_err("unexpectedly read pruned collection");
 
         // But we should still be able to fetch the collections that do exist.
         let collection_read = datastore
-            .inventory_collection_read(&opctx, collection5.id)
+            .inventory_collection_read(opctx, collection5.id)
             .await
             .unwrap();
         assert_eq!(collection5, collection_read);
         let collection_read = datastore
-            .inventory_collection_read(&opctx, collection6.id)
+            .inventory_collection_read(opctx, collection6.id)
             .await
             .unwrap();
         assert_eq!(collection6, collection_read);
         let collection_read = datastore
-            .inventory_collection_read(&opctx, collection7.id)
+            .inventory_collection_read(opctx, collection7.id)
             .await
             .unwrap();
         assert_eq!(collection7, collection_read);
@@ -2912,7 +2912,7 @@ mod test {
         // We should prune more than one collection, if needed.  We'll wind up
         // with just collection6 because that's the latest one with no errors.
         datastore
-            .inventory_prune_collections(&opctx, 1)
+            .inventory_prune_collections(opctx, 1)
             .await
             .expect("failed to prune collections");
         assert_eq!(
@@ -2929,7 +2929,7 @@ mod test {
         // Remove the remaining collection and make sure the inventory tables
         // are empty (i.e., we got everything).
         datastore
-            .inventory_delete_collection(&opctx, collection6.id)
+            .inventory_delete_collection(opctx, collection6.id)
             .await
             .expect("failed to delete collection");
         assert!(datastore.inventory_collections().await.unwrap().is_empty());
@@ -3122,18 +3122,18 @@ mod test {
         let Representative { builder, .. } = representative();
         let collection = builder.build();
         datastore
-            .inventory_insert_collection(&opctx, &collection)
+            .inventory_insert_collection(opctx, &collection)
             .await
             .expect("failed to insert collection");
 
         // Read all "inv_" tables and ensure that they are populated.
-        check_all_inv_tables(&datastore, AllInvTables::ArePopulated)
+        check_all_inv_tables(datastore, AllInvTables::ArePopulated)
             .await
             .expect("All inv_... tables should be populated by representative collection");
 
         // Delete that collection we just added
         datastore
-            .inventory_delete_collection(&opctx, collection.id)
+            .inventory_delete_collection(opctx, collection.id)
             .await
             .expect("failed to prune collections");
         assert_eq!(
@@ -3148,7 +3148,7 @@ mod test {
         );
 
         // Read all "inv_" tables and ensure that they're empty
-        check_all_inv_tables(&datastore, AllInvTables::AreEmpty).await.expect(
+        check_all_inv_tables(datastore, AllInvTables::AreEmpty).await.expect(
             "All inv_... tables should be deleted alongside collection",
         );
 
@@ -3168,12 +3168,12 @@ mod test {
         let Representative { builder, .. } = representative();
         let collection = builder.build();
         datastore
-            .inventory_insert_collection(&opctx, &collection)
+            .inventory_insert_collection(opctx, &collection)
             .await
             .expect("failed to insert collection");
 
         // Read all "inv_" tables and ensure that they are populated.
-        check_all_inv_tables(&datastore, AllInvTables::ArePopulated)
+        check_all_inv_tables(datastore, AllInvTables::ArePopulated)
             .await
             .expect("All inv_... tables should be populated by representative collection");
 

--- a/nexus/db-queries/src/db/datastore/migration.rs
+++ b/nexus/db-queries/src/db/datastore/migration.rs
@@ -200,7 +200,7 @@ mod tests {
 
         let (authz_project, _project) = datastore
             .project_create(
-                &opctx,
+                opctx,
                 Project::new_with_id(
                     project_id,
                     silo_id,
@@ -216,7 +216,7 @@ mod tests {
             .expect("project must be created successfully");
         let _ = datastore
             .project_create_instance(
-                &opctx,
+                opctx,
                 &authz_project,
                 Instance::new(
                     instance_id,
@@ -245,7 +245,7 @@ mod tests {
             .await
             .expect("instance must be created successfully");
 
-        let (.., authz_instance) = LookupPath::new(&opctx, &datastore)
+        let (.., authz_instance) = LookupPath::new(opctx, datastore)
             .instance_id(instance_id.into_untyped_uuid())
             .lookup_for(authz::Action::Modify)
             .await
@@ -266,7 +266,7 @@ mod tests {
         );
 
         datastore
-            .migration_insert(&opctx, migration.clone())
+            .migration_insert(opctx, migration.clone())
             .await
             .expect("must insert migration successfully");
 
@@ -279,17 +279,15 @@ mod tests {
         let logctx = dev::test_setup_log("test_migration_query_by_instance");
         let db = TestDatabase::new_with_datastore(&logctx.log).await;
         let (opctx, datastore) = (db.opctx(), db.datastore());
-        let authz_instance = create_test_instance(&datastore, &opctx).await;
+        let authz_instance = create_test_instance(datastore, opctx).await;
         let instance_id = InstanceUuid::from_untyped_uuid(authz_instance.id());
 
-        let migration1 =
-            insert_migration(&datastore, &opctx, instance_id).await;
-        let migration2 =
-            insert_migration(&datastore, &opctx, instance_id).await;
+        let migration1 = insert_migration(datastore, opctx, instance_id).await;
+        let migration2 = insert_migration(datastore, opctx, instance_id).await;
 
         let list = datastore
             .instance_list_migrations(
-                &opctx,
+                opctx,
                 instance_id,
                 &DataPageParams::max_page(),
             )
@@ -297,12 +295,11 @@ mod tests {
             .expect("must list migrations");
         assert_all_migrations_found(&[&migration1, &migration2], &list[..]);
 
-        let migration3 =
-            insert_migration(&datastore, &opctx, instance_id).await;
+        let migration3 = insert_migration(datastore, opctx, instance_id).await;
 
         let list = datastore
             .instance_list_migrations(
-                &opctx,
+                opctx,
                 instance_id,
                 &DataPageParams::max_page(),
             )
@@ -314,12 +311,12 @@ mod tests {
         );
 
         datastore
-            .migration_mark_deleted(&opctx, migration3.id)
+            .migration_mark_deleted(opctx, migration3.id)
             .await
             .expect("must delete migration");
         let list = datastore
             .instance_list_migrations(
-                &opctx,
+                opctx,
                 instance_id,
                 &DataPageParams::max_page(),
             )
@@ -328,7 +325,7 @@ mod tests {
         assert_all_migrations_found(&[&migration1, &migration2], &list[..]);
 
         let deleted = datastore
-            .instance_mark_migrations_deleted(&opctx, instance_id)
+            .instance_mark_migrations_deleted(opctx, instance_id)
             .await
             .expect("must delete remaining migrations");
         assert_eq!(
@@ -338,7 +335,7 @@ mod tests {
 
         let list = datastore
             .instance_list_migrations(
-                &opctx,
+                opctx,
                 instance_id,
                 &DataPageParams::max_page(),
             )
@@ -347,7 +344,7 @@ mod tests {
         assert!(list.is_empty(), "all migrations must be deleted");
 
         let deleted = datastore
-            .instance_mark_migrations_deleted(&opctx, instance_id)
+            .instance_mark_migrations_deleted(opctx, instance_id)
             .await
             .expect("must delete remaining migrations");
         assert_eq!(

--- a/nexus/db-queries/src/db/datastore/mod.rs
+++ b/nexus/db-queries/src/db/datastore/mod.rs
@@ -145,7 +145,8 @@ pub const SERVICE_IP_POOL_NAME: &str = "oxide-service-pool";
 /// This value is chosen to be small enough to avoid any queries being too
 /// expensive.
 // unsafe: `new_unchecked` is only unsound if the argument is 0.
-pub const SQL_BATCH_SIZE: NonZeroU32 = NonZeroU32::new(1000).unwrap();
+pub const SQL_BATCH_SIZE: NonZeroU32 =
+    unsafe { NonZeroU32::new_unchecked(1000) };
 
 // Represents a query that is ready to be executed.
 //

--- a/nexus/db-queries/src/db/datastore/probe.rs
+++ b/nexus/db-queries/src/db/datastore/probe.rs
@@ -66,7 +66,7 @@ impl super::DataStore {
 
         let probes = match pagparams {
             PaginatedBy::Id(pagparams) => {
-                paginated(dsl::probe, dsl::id, &pagparams)
+                paginated(dsl::probe, dsl::id, pagparams)
             }
             PaginatedBy::Name(pagparams) => paginated(
                 dsl::probe,

--- a/nexus/db-queries/src/db/datastore/project.rs
+++ b/nexus/db-queries/src/db/datastore/project.rs
@@ -102,7 +102,7 @@ impl DataStore {
 
         debug!(opctx.log, "attempting to create built-in projects");
 
-        let (authz_silo,) = db::lookup::LookupPath::new(&opctx, self)
+        let (authz_silo,) = db::lookup::LookupPath::new(opctx, self)
             .silo_id(INTERNAL_SILO_ID)
             .lookup_for(authz::Action::CreateChild)
             .await?;
@@ -314,7 +314,7 @@ impl DataStore {
         use nexus_db_schema::schema::project::dsl;
         match pagparams {
             PaginatedBy::Id(pagparams) => {
-                paginated(dsl::project, dsl::id, &pagparams)
+                paginated(dsl::project, dsl::id, pagparams)
             }
             PaginatedBy::Name(pagparams) => paginated(
                 dsl::project,

--- a/nexus/db-queries/src/db/datastore/region.rs
+++ b/nexus/db-queries/src/db/datastore/region.rs
@@ -134,7 +134,7 @@ impl DataStore {
                     .map_err(|e| Error::invalid_request(&e.to_string()))?)
             }
             params::DiskSource::Snapshot { snapshot_id } => {
-                let (.., db_snapshot) = LookupPath::new(opctx, &self)
+                let (.., db_snapshot) = LookupPath::new(opctx, self)
                     .snapshot_id(*snapshot_id)
                     .fetch()
                     .await?;
@@ -142,7 +142,7 @@ impl DataStore {
                 Ok(db_snapshot.block_size)
             }
             params::DiskSource::Image { image_id } => {
-                let (.., db_image) = LookupPath::new(opctx, &self)
+                let (.., db_image) = LookupPath::new(opctx, self)
                     .image_id(*image_id)
                     .fetch()
                     .await?;
@@ -238,7 +238,7 @@ impl DataStore {
                     size,
                 } => {
                     let block_size = self
-                        .get_block_size_from_disk_source(opctx, &disk_source)
+                        .get_block_size_from_disk_source(opctx, disk_source)
                         .await?;
 
                     let (blocks_per_extent, extent_count) =
@@ -271,7 +271,7 @@ impl DataStore {
             num_regions_required,
         )?;
 
-        let conn = self.pool_connection_authorized(&opctx).await?;
+        let conn = self.pool_connection_authorized(opctx).await?;
 
         let dataset_and_regions: Vec<(CrucibleDataset, Region)> =
             query.get_results_async(&*conn).await.map_err(|e| {

--- a/nexus/db-queries/src/db/datastore/region_replacement.rs
+++ b/nexus/db-queries/src/db/datastore/region_replacement.rs
@@ -959,11 +959,11 @@ mod test {
         let request_2 = RegionReplacement::new(region_2_id, volume_id);
 
         datastore
-            .insert_region_replacement_request(&opctx, request_1)
+            .insert_region_replacement_request(opctx, request_1)
             .await
             .unwrap();
         datastore
-            .insert_region_replacement_request(&opctx, request_2)
+            .insert_region_replacement_request(opctx, request_2)
             .await
             .unwrap_err();
 
@@ -1006,7 +1006,7 @@ mod test {
         };
 
         datastore
-            .insert_region_replacement_request(&opctx, request.clone())
+            .insert_region_replacement_request(opctx, request.clone())
             .await
             .unwrap();
 
@@ -1015,7 +1015,7 @@ mod test {
         let saga_id = Uuid::new_v4();
 
         datastore
-            .set_region_replacement_driving(&opctx, request.id, saga_id)
+            .set_region_replacement_driving(opctx, request.id, saga_id)
             .await
             .unwrap();
 
@@ -1024,7 +1024,7 @@ mod test {
         // should fail as the record was locked by the saga.
 
         datastore
-            .mark_region_replacement_as_done(&opctx, request.id)
+            .mark_region_replacement_as_done(opctx, request.id)
             .await
             .unwrap_err();
 
@@ -1032,7 +1032,7 @@ mod test {
         // set.
 
         let actual_request = datastore
-            .get_region_replacement_request_by_id(&opctx, request.id)
+            .get_region_replacement_request_by_id(opctx, request.id)
             .await
             .unwrap();
 
@@ -1047,7 +1047,7 @@ mod test {
         // finished ok.
 
         datastore
-            .undo_set_region_replacement_driving(&opctx, request.id, saga_id)
+            .undo_set_region_replacement_driving(opctx, request.id, saga_id)
             .await
             .unwrap();
 
@@ -1055,7 +1055,7 @@ mod test {
         // this time marks the record as replacement done successfully.
 
         datastore
-            .mark_region_replacement_as_done(&opctx, request.id)
+            .mark_region_replacement_as_done(opctx, request.id)
             .await
             .unwrap();
 
@@ -1063,7 +1063,7 @@ mod test {
         // is cleared.
 
         let actual_request = datastore
-            .get_region_replacement_request_by_id(&opctx, request.id)
+            .get_region_replacement_request_by_id(opctx, request.id)
             .await
             .unwrap();
 
@@ -1111,7 +1111,7 @@ mod test {
         };
 
         datastore
-            .insert_region_replacement_request(&opctx, request.clone())
+            .insert_region_replacement_request(opctx, request.clone())
             .await
             .unwrap();
 
@@ -1121,7 +1121,7 @@ mod test {
         let saga_id = Uuid::new_v4();
 
         datastore
-            .set_region_replacement_completing(&opctx, request.id, saga_id)
+            .set_region_replacement_completing(opctx, request.id, saga_id)
             .await
             .unwrap();
 
@@ -1130,7 +1130,7 @@ mod test {
 
         datastore
             .set_region_replacement_completing(
-                &opctx,
+                opctx,
                 request.id,
                 Uuid::new_v4(),
             )
@@ -1142,14 +1142,14 @@ mod test {
         // This should fail as the saga took the lock on this record.
 
         datastore
-            .mark_region_replacement_as_done(&opctx, request.id)
+            .mark_region_replacement_as_done(opctx, request.id)
             .await
             .unwrap_err();
 
         // The first saga has finished and sets the record to Complete.
 
         datastore
-            .set_region_replacement_complete(&opctx, request, saga_id)
+            .set_region_replacement_complete(opctx, request, saga_id)
             .await
             .unwrap();
 

--- a/nexus/db-queries/src/db/datastore/region_snapshot_replacement.rs
+++ b/nexus/db-queries/src/db/datastore/region_snapshot_replacement.rs
@@ -1501,7 +1501,7 @@ impl DataStore {
         }
 
         let maybe_snapshot = self
-            .find_snapshot_by_volume_id(&opctx, db_region.volume_id())
+            .find_snapshot_by_volume_id(opctx, db_region.volume_id())
             .await?;
 
         if maybe_snapshot.is_none() {
@@ -1595,14 +1595,14 @@ mod test {
 
         datastore
             .insert_region_snapshot_replacement_request_with_volume_id(
-                &opctx, request_1, volume_id,
+                opctx, request_1, volume_id,
             )
             .await
             .unwrap();
 
         datastore
             .insert_region_snapshot_replacement_request_with_volume_id(
-                &opctx, request_2, volume_id,
+                opctx, request_2, volume_id,
             )
             .await
             .unwrap_err();
@@ -1650,13 +1650,13 @@ mod test {
 
         datastore
             .insert_region_snapshot_replacement_request_with_volume_id(
-                &opctx, request_1, volume_id,
+                opctx, request_1, volume_id,
             )
             .await
             .unwrap();
 
         datastore
-            .insert_region_replacement_request(&opctx, request_2)
+            .insert_region_replacement_request(opctx, request_2)
             .await
             .unwrap_err();
 
@@ -1699,7 +1699,7 @@ mod test {
 
         datastore
             .insert_region_snapshot_replacement_request_with_volume_id(
-                &opctx, request, volume_id,
+                opctx, request, volume_id,
             )
             .await
             .unwrap();
@@ -1709,7 +1709,7 @@ mod test {
         assert_eq!(
             datastore
                 .in_progress_region_snapshot_replacement_steps(
-                    &opctx, request_id
+                    opctx, request_id
                 )
                 .await
                 .unwrap(),
@@ -1718,7 +1718,7 @@ mod test {
 
         assert!(
             datastore
-                .get_requested_region_snapshot_replacement_steps(&opctx)
+                .get_requested_region_snapshot_replacement_steps(opctx)
                 .await
                 .unwrap()
                 .is_empty()
@@ -1746,7 +1746,7 @@ mod test {
                 RegionSnapshotReplacementStep::new(request_id, step_volume_id);
 
             let result = datastore
-                .insert_region_snapshot_replacement_step(&opctx, step)
+                .insert_region_snapshot_replacement_step(opctx, step)
                 .await
                 .unwrap();
 
@@ -1756,7 +1756,7 @@ mod test {
         assert_eq!(
             datastore
                 .in_progress_region_snapshot_replacement_steps(
-                    &opctx, request_id
+                    opctx, request_id
                 )
                 .await
                 .unwrap(),
@@ -1765,7 +1765,7 @@ mod test {
 
         assert_eq!(
             datastore
-                .get_requested_region_snapshot_replacement_steps(&opctx)
+                .get_requested_region_snapshot_replacement_steps(opctx)
                 .await
                 .unwrap()
                 .len(),
@@ -1795,7 +1795,7 @@ mod test {
                 RegionSnapshotReplacementStepState::Running;
 
             let result = datastore
-                .insert_region_snapshot_replacement_step(&opctx, step)
+                .insert_region_snapshot_replacement_step(opctx, step)
                 .await
                 .unwrap();
 
@@ -1805,7 +1805,7 @@ mod test {
         assert_eq!(
             datastore
                 .in_progress_region_snapshot_replacement_steps(
-                    &opctx, request_id
+                    opctx, request_id
                 )
                 .await
                 .unwrap(),
@@ -1814,7 +1814,7 @@ mod test {
 
         assert_eq!(
             datastore
-                .get_requested_region_snapshot_replacement_steps(&opctx)
+                .get_requested_region_snapshot_replacement_steps(opctx)
                 .await
                 .unwrap()
                 .len(),
@@ -1845,7 +1845,7 @@ mod test {
                 RegionSnapshotReplacementStepState::VolumeDeleted;
 
             let result = datastore
-                .insert_region_snapshot_replacement_step(&opctx, step)
+                .insert_region_snapshot_replacement_step(opctx, step)
                 .await
                 .unwrap();
 
@@ -1855,7 +1855,7 @@ mod test {
         assert_eq!(
             datastore
                 .in_progress_region_snapshot_replacement_steps(
-                    &opctx, request_id
+                    opctx, request_id
                 )
                 .await
                 .unwrap(),
@@ -1864,7 +1864,7 @@ mod test {
 
         assert_eq!(
             datastore
-                .get_requested_region_snapshot_replacement_steps(&opctx)
+                .get_requested_region_snapshot_replacement_steps(opctx)
                 .await
                 .unwrap()
                 .len(),
@@ -1906,7 +1906,7 @@ mod test {
         let first_request_id = step.id;
 
         let result = datastore
-            .insert_region_snapshot_replacement_step(&opctx, step)
+            .insert_region_snapshot_replacement_step(opctx, step)
             .await
             .unwrap();
 
@@ -1916,7 +1916,7 @@ mod test {
             RegionSnapshotReplacementStep::new(Uuid::new_v4(), volume_id);
 
         let result = datastore
-            .insert_region_snapshot_replacement_step(&opctx, step.clone())
+            .insert_region_snapshot_replacement_step(opctx, step.clone())
             .await
             .unwrap();
 
@@ -1933,7 +1933,7 @@ mod test {
 
         datastore
             .set_region_snapshot_replacement_step_running(
-                &opctx,
+                opctx,
                 first_request_id,
                 saga_id,
             )
@@ -1941,7 +1941,7 @@ mod test {
             .unwrap();
 
         let result = datastore
-            .insert_region_snapshot_replacement_step(&opctx, step.clone())
+            .insert_region_snapshot_replacement_step(opctx, step.clone())
             .await
             .unwrap();
 
@@ -1956,7 +1956,7 @@ mod test {
 
         datastore
             .set_region_snapshot_replacement_step_complete(
-                &opctx,
+                opctx,
                 first_request_id,
                 saga_id,
                 VolumeUuid::new_v4(), // old_snapshot_volume_id
@@ -1965,7 +1965,7 @@ mod test {
             .unwrap();
 
         let result = datastore
-            .insert_region_snapshot_replacement_step(&opctx, step.clone())
+            .insert_region_snapshot_replacement_step(opctx, step.clone())
             .await
             .unwrap();
 
@@ -1979,7 +1979,7 @@ mod test {
 
         datastore
             .set_region_snapshot_replacement_step_volume_deleted(
-                &opctx,
+                opctx,
                 first_request_id,
             )
             .await
@@ -2021,7 +2021,7 @@ mod test {
 
         datastore
             .insert_region_snapshot_replacement_request_with_volume_id(
-                &opctx, request, volume_id,
+                opctx, request, volume_id,
             )
             .await
             .unwrap();
@@ -2029,7 +2029,7 @@ mod test {
         assert!(
             datastore
                 .region_snapshot_replacement_steps_requiring_garbage_collection(
-                    &opctx
+                    opctx
                 )
                 .await
                 .unwrap()
@@ -2056,7 +2056,7 @@ mod test {
         step.replacement_state = RegionSnapshotReplacementStepState::Complete;
 
         let result = datastore
-            .insert_region_snapshot_replacement_step(&opctx, step)
+            .insert_region_snapshot_replacement_step(opctx, step)
             .await
             .unwrap();
 
@@ -2082,7 +2082,7 @@ mod test {
         step.replacement_state = RegionSnapshotReplacementStepState::Complete;
 
         let result = datastore
-            .insert_region_snapshot_replacement_step(&opctx, step)
+            .insert_region_snapshot_replacement_step(opctx, step)
             .await
             .unwrap();
 
@@ -2092,7 +2092,7 @@ mod test {
             2,
             datastore
                 .region_snapshot_replacement_steps_requiring_garbage_collection(
-                    &opctx,
+                    opctx,
                 )
                 .await
                 .unwrap()
@@ -2152,7 +2152,7 @@ mod test {
         let first_step_id = step.id;
 
         let result = datastore
-            .insert_region_snapshot_replacement_step(&opctx, step)
+            .insert_region_snapshot_replacement_step(opctx, step)
             .await
             .unwrap();
 
@@ -2164,7 +2164,7 @@ mod test {
         );
 
         let result = datastore
-            .insert_region_snapshot_replacement_step(&opctx, step)
+            .insert_region_snapshot_replacement_step(opctx, step)
             .await
             .unwrap();
 
@@ -2209,7 +2209,7 @@ mod test {
         let request = RegionReplacement::new(Uuid::new_v4(), volume_id);
 
         datastore
-            .insert_region_replacement_request(&opctx, request)
+            .insert_region_replacement_request(opctx, request)
             .await
             .unwrap();
 
@@ -2217,7 +2217,7 @@ mod test {
             RegionSnapshotReplacementStep::new(Uuid::new_v4(), volume_id);
 
         datastore
-            .insert_region_snapshot_replacement_step(&opctx, request)
+            .insert_region_snapshot_replacement_step(opctx, request)
             .await
             .unwrap_err();
 

--- a/nexus/db-queries/src/db/datastore/role.rs
+++ b/nexus/db-queries/src/db/datastore/role.rs
@@ -66,8 +66,8 @@ impl DataStore {
             .map(|role_config| {
                 RoleBuiltin::new(
                     role_config.resource_type,
-                    &role_config.role_name,
-                    &role_config.description,
+                    role_config.role_name,
+                    role_config.description,
                 )
             })
             .collect::<Vec<RoleBuiltin>>();
@@ -262,7 +262,7 @@ impl DataStore {
                     r.identity_id,
                     resource_type,
                     resource_id,
-                    &r.role_name.to_database_string(),
+                    r.role_name.to_database_string(),
                 )
             })
             .collect::<Vec<_>>();

--- a/nexus/db-queries/src/db/datastore/saga.rs
+++ b/nexus/db-queries/src/db/datastore/saga.rs
@@ -300,7 +300,7 @@ mod test {
 
         // List them, expect to see them all in order by ID.
         let mut observed_sagas = datastore
-            .saga_list_recovery_candidates_batched(&opctx, sec_id)
+            .saga_list_recovery_candidates_batched(opctx, sec_id)
             .await
             .expect("Failed to list unfinished sagas");
         inserted_sagas.sort_by_key(|a| a.id);
@@ -372,7 +372,7 @@ mod test {
         // List them, expect to see them all in order by ID.
         let observed_nodes = datastore
             .saga_fetch_log_batched(
-                &opctx,
+                opctx,
                 nexus_db_model::saga_types::SagaId::from(node_cx.saga_id),
             )
             .await
@@ -417,7 +417,7 @@ mod test {
         // found" error.
         let observed_nodes = datastore
             .saga_fetch_log_batched(
-                &opctx,
+                opctx,
                 nexus_db_model::saga_types::SagaId::from(saga_id),
             )
             .await
@@ -651,7 +651,7 @@ mod test {
 
         // Reassign uncompleted sagas from SECs B and C to SEC A.
         let nreassigned = datastore
-            .sagas_reassign_sec(&opctx, &[sec_b, sec_c], sec_a)
+            .sagas_reassign_sec(opctx, &[sec_b, sec_c], sec_a)
             .await
             .expect("failed to re-assign sagas");
 
@@ -702,7 +702,7 @@ mod test {
 
         // If we do it again, we should make no changes.
         let nreassigned = datastore
-            .sagas_reassign_sec(&opctx, &[sec_b, sec_c], sec_a)
+            .sagas_reassign_sec(opctx, &[sec_b, sec_c], sec_a)
             .await
             .expect("failed to re-assign sagas");
         assert_eq!(nreassigned, 0);

--- a/nexus/db-queries/src/db/datastore/silo.rs
+++ b/nexus/db-queries/src/db/datastore/silo.rs
@@ -185,7 +185,7 @@ impl DataStore {
         {
             let silo_admin_group_ensure_query =
                 DataStore::silo_group_ensure_query(
-                    &nexus_opctx,
+                    nexus_opctx,
                     &authz_silo,
                     db::model::SiloGroup::new(
                         silo_group_id,
@@ -228,7 +228,7 @@ impl DataStore {
         // with retryable transactions.
         let silo = self
             .transaction_non_retry_wrapper("silo_create")
-            .transaction(&conn, |conn| async move {
+            .transaction(conn, |conn| async move {
                 let silo = silo_create_query
                     .get_result_async(&conn)
                     .await
@@ -334,7 +334,7 @@ impl DataStore {
 
         use nexus_db_schema::schema::silo::dsl;
         let mut query = match pagparams {
-            PaginatedBy::Id(params) => paginated(dsl::silo, dsl::id, &params),
+            PaginatedBy::Id(params) => paginated(dsl::silo, dsl::id, params),
             PaginatedBy::Name(params) => paginated(
                 dsl::silo,
                 dsl::name,
@@ -450,7 +450,7 @@ impl DataStore {
                     )));
                 }
 
-                self.silo_quotas_delete(opctx, &conn, &authz_silo).await?;
+                self.silo_quotas_delete(opctx, &conn, authz_silo).await?;
 
                 self.virtual_provisioning_collection_delete_on_connection(
                     &opctx.log, &conn, id,

--- a/nexus/db-queries/src/db/datastore/sled_instance.rs
+++ b/nexus/db-queries/src/db/datastore/sled_instance.rs
@@ -21,7 +21,7 @@ impl DataStore {
     ) -> ListResultVec<SledInstance> {
         opctx.authorize(authz::Action::ListChildren, &authz::FLEET).await?;
         use nexus_db_schema::schema::sled_instance::dsl;
-        paginated(dsl::sled_instance, dsl::id, &pagparams)
+        paginated(dsl::sled_instance, dsl::id, pagparams)
             .filter(dsl::active_sled_id.eq(authz_sled.id()))
             .select(SledInstance::as_select())
             .load_async::<SledInstance>(

--- a/nexus/db-queries/src/db/datastore/snapshot.rs
+++ b/nexus/db-queries/src/db/datastore/snapshot.rs
@@ -201,7 +201,7 @@ impl DataStore {
         use nexus_db_schema::schema::snapshot::dsl;
         match pagparams {
             PaginatedBy::Id(pagparams) => {
-                paginated(dsl::snapshot, dsl::id, &pagparams)
+                paginated(dsl::snapshot, dsl::id, pagparams)
             }
             PaginatedBy::Name(pagparams) => paginated(
                 dsl::snapshot,
@@ -250,7 +250,7 @@ impl DataStore {
                 dsl::state.eq(SnapshotState::Destroyed),
             ))
             .check_if_exists::<Snapshot>(snapshot_id)
-            .execute_and_check(&*self.pool_connection_authorized(&opctx).await?)
+            .execute_and_check(&*self.pool_connection_authorized(opctx).await?)
             .await
             .map_err(|e| {
                 public_error_from_diesel(

--- a/nexus/db-queries/src/db/datastore/ssh_key.rs
+++ b/nexus/db-queries/src/db/datastore/ssh_key.rs
@@ -182,7 +182,7 @@ impl DataStore {
         use nexus_db_schema::schema::ssh_key::dsl;
         match pagparams {
             PaginatedBy::Id(pagparams) => {
-                paginated(dsl::ssh_key, dsl::id, &pagparams)
+                paginated(dsl::ssh_key, dsl::id, pagparams)
             }
             PaginatedBy::Name(pagparams) => paginated(
                 dsl::ssh_key,
@@ -227,7 +227,7 @@ impl DataStore {
         use nexus_db_schema::schema::ssh_key::dsl;
         match pagparams {
             PaginatedBy::Id(pagparams) => {
-                paginated(dsl::ssh_key, dsl::id, &pagparams)
+                paginated(dsl::ssh_key, dsl::id, pagparams)
             }
             PaginatedBy::Name(pagparams) => paginated(
                 dsl::ssh_key,

--- a/nexus/db-queries/src/db/datastore/switch_interface.rs
+++ b/nexus/db-queries/src/db/datastore/switch_interface.rs
@@ -176,7 +176,7 @@ impl DataStore {
     ) -> ListResultVec<LoopbackAddress> {
         use nexus_db_schema::schema::loopback_address::dsl;
 
-        paginated(dsl::loopback_address, dsl::id, &pagparams)
+        paginated(dsl::loopback_address, dsl::id, pagparams)
             .select(LoopbackAddress::as_select())
             .load_async(&*self.pool_connection_authorized(opctx).await?)
             .await

--- a/nexus/db-queries/src/db/datastore/test_utils.rs
+++ b/nexus/db-queries/src/db/datastore/test_utils.rs
@@ -74,8 +74,8 @@ impl IneligibleSleds {
     ) -> Result<()> {
         let non_provisionable_fut = async {
             sled_set_policy(
-                &opctx,
-                &datastore,
+                opctx,
+                datastore,
                 self.non_provisionable,
                 SledPolicy::InService {
                     provision_policy: SledProvisionPolicy::NonProvisionable,
@@ -94,8 +94,8 @@ impl IneligibleSleds {
 
         let expunged_fut = async {
             sled_set_policy(
-                &opctx,
-                &datastore,
+                opctx,
+                datastore,
                 self.expunged,
                 SledPolicy::Expunged,
                 ValidateTransition::Yes,
@@ -115,8 +115,8 @@ impl IneligibleSleds {
         // removal as well.)
         let decommissioned_fut = async {
             sled_set_policy(
-                &opctx,
-                &datastore,
+                opctx,
+                datastore,
                 self.decommissioned,
                 SledPolicy::Expunged,
                 ValidateTransition::Yes,
@@ -132,8 +132,8 @@ impl IneligibleSleds {
             })?;
 
             sled_set_state(
-                &opctx,
-                &datastore,
+                opctx,
+                datastore,
                 self.decommissioned,
                 SledState::Decommissioned,
                 ValidateTransition::Yes,
@@ -153,8 +153,8 @@ impl IneligibleSleds {
         // provision resources on it.
         let illegal_decommissioned_fut = async {
             sled_set_state(
-                &opctx,
-                &datastore,
+                opctx,
+                datastore,
                 self.illegal_decommissioned,
                 SledState::Decommissioned,
                 ValidateTransition::No,
@@ -201,8 +201,8 @@ impl IneligibleSleds {
             kind: IneligibleSledKind,
         ) -> Result<()> {
             sled_set_policy(
-                &opctx,
-                &datastore,
+                opctx,
+                datastore,
                 sled_id,
                 SledPolicy::provisionable(),
                 ValidateTransition::No,
@@ -217,8 +217,8 @@ impl IneligibleSleds {
             })?;
 
             sled_set_state(
-                &opctx,
-                &datastore,
+                opctx,
+                datastore,
                 sled_id,
                 SledState::Active,
                 ValidateTransition::No,
@@ -252,7 +252,7 @@ pub(super) async fn sled_set_policy(
     check: ValidateTransition,
     expected_old_policy: Expected<SledPolicy>,
 ) -> Result<()> {
-    let (authz_sled, _) = LookupPath::new(&opctx, &datastore)
+    let (authz_sled, _) = LookupPath::new(opctx, datastore)
         .sled_id(sled_id.into_untyped_uuid())
         .fetch_for(authz::Action::Modify)
         .await
@@ -300,14 +300,14 @@ pub(super) async fn sled_set_state(
     check: ValidateTransition,
     expected_old_state: Expected<SledState>,
 ) -> Result<()> {
-    let (authz_sled, _) = LookupPath::new(&opctx, &datastore)
+    let (authz_sled, _) = LookupPath::new(opctx, datastore)
         .sled_id(sled_id.into_untyped_uuid())
         .fetch_for(authz::Action::Modify)
         .await
         .unwrap();
 
     let res = datastore
-        .sled_set_state_impl(&opctx, &authz_sled, new_state, check)
+        .sled_set_state_impl(opctx, &authz_sled, new_state, check)
         .await;
     match expected_old_state {
         Expected::Ok(expected) => {

--- a/nexus/db-queries/src/db/datastore/virtual_provisioning_collection.rs
+++ b/nexus/db-queries/src/db/datastore/virtual_provisioning_collection.rs
@@ -385,7 +385,7 @@ mod test {
 
         let (authz_project, _project) = datastore
             .project_create(
-                &opctx,
+                opctx,
                 Project::new_with_id(
                     project_id,
                     silo_id,
@@ -411,14 +411,14 @@ mod test {
             storage: Some(1 << 50),
             time_modified: chrono::Utc::now(),
         };
-        let authz_silo = LookupPath::new(&opctx, &datastore)
+        let authz_silo = LookupPath::new(opctx, datastore)
             .silo_id(silo_id)
             .lookup_for(crate::authz::Action::Modify)
             .await
             .unwrap()
             .0;
         datastore
-            .silo_update_quota(&opctx, &authz_silo, quotas_update)
+            .silo_update_quota(opctx, &authz_silo, quotas_update)
             .await
             .unwrap();
 
@@ -436,8 +436,8 @@ mod test {
     ) {
         datastore
             .project_create_instance(
-                &opctx,
-                &authz_project,
+                opctx,
+                authz_project,
                 Instance::new(
                     instance_id,
                     project_id,
@@ -472,7 +472,7 @@ mod test {
         let db = TestDatabase::new_with_datastore(&logctx.log).await;
         let (opctx, datastore) = (db.opctx(), db.datastore());
 
-        let test_data = setup_collections(&datastore, &opctx).await;
+        let test_data = setup_collections(datastore, opctx).await;
         let ids = test_data.ids();
         let project_id = test_data.project_id;
         let authz_project = test_data.authz_project;
@@ -484,12 +484,12 @@ mod test {
         let ram = ByteCount::try_from(1 << 30).unwrap();
 
         for id in ids {
-            verify_collection_usage(&datastore, &opctx, id, 0, 0, 0).await;
+            verify_collection_usage(datastore, opctx, id, 0, 0, 0).await;
         }
 
         create_instance_record(
-            &datastore,
-            &opctx,
+            datastore,
+            opctx,
             &authz_project,
             instance_id,
             project_id,
@@ -500,7 +500,7 @@ mod test {
 
         datastore
             .virtual_provisioning_collection_insert_instance(
-                &opctx,
+                opctx,
                 instance_id,
                 project_id,
                 cpus,
@@ -510,15 +510,14 @@ mod test {
             .unwrap();
 
         for id in ids {
-            verify_collection_usage(&datastore, &opctx, id, 12, 1 << 30, 0)
-                .await;
+            verify_collection_usage(datastore, opctx, id, 12, 1 << 30, 0).await;
         }
 
         // Delete the instance
 
         datastore
             .virtual_provisioning_collection_delete_instance(
-                &opctx,
+                opctx,
                 instance_id,
                 project_id,
                 cpus,
@@ -528,7 +527,7 @@ mod test {
             .unwrap();
 
         for id in ids {
-            verify_collection_usage(&datastore, &opctx, id, 0, 0, 0).await;
+            verify_collection_usage(datastore, opctx, id, 0, 0, 0).await;
         }
 
         db.terminate().await;
@@ -542,7 +541,7 @@ mod test {
         let db = TestDatabase::new_with_datastore(&logctx.log).await;
         let (opctx, datastore) = (db.opctx(), db.datastore());
 
-        let test_data = setup_collections(&datastore, &opctx).await;
+        let test_data = setup_collections(datastore, opctx).await;
         let ids = test_data.ids();
         let project_id = test_data.project_id;
         let authz_project = test_data.authz_project;
@@ -554,12 +553,12 @@ mod test {
         let ram = ByteCount::try_from(1 << 30).unwrap();
 
         for id in ids {
-            verify_collection_usage(&datastore, &opctx, id, 0, 0, 0).await;
+            verify_collection_usage(datastore, opctx, id, 0, 0, 0).await;
         }
 
         create_instance_record(
-            &datastore,
-            &opctx,
+            datastore,
+            opctx,
             &authz_project,
             instance_id,
             project_id,
@@ -570,7 +569,7 @@ mod test {
 
         datastore
             .virtual_provisioning_collection_insert_instance(
-                &opctx,
+                opctx,
                 instance_id,
                 project_id,
                 cpus,
@@ -580,8 +579,7 @@ mod test {
             .unwrap();
 
         for id in ids {
-            verify_collection_usage(&datastore, &opctx, id, 12, 1 << 30, 0)
-                .await;
+            verify_collection_usage(datastore, opctx, id, 12, 1 << 30, 0).await;
         }
 
         // Attempt to provision that same instance once more.
@@ -592,7 +590,7 @@ mod test {
 
         datastore
             .virtual_provisioning_collection_insert_instance(
-                &opctx,
+                opctx,
                 instance_id,
                 project_id,
                 cpus,
@@ -603,15 +601,14 @@ mod test {
 
         // Verify that the usage is the same as before the call
         for id in ids {
-            verify_collection_usage(&datastore, &opctx, id, 12, 1 << 30, 0)
-                .await;
+            verify_collection_usage(datastore, opctx, id, 12, 1 << 30, 0).await;
         }
 
         // Delete the instance
 
         datastore
             .virtual_provisioning_collection_delete_instance(
-                &opctx,
+                opctx,
                 instance_id,
                 project_id,
                 cpus,
@@ -621,7 +618,7 @@ mod test {
             .unwrap();
 
         for id in ids {
-            verify_collection_usage(&datastore, &opctx, id, 0, 0, 0).await;
+            verify_collection_usage(datastore, opctx, id, 0, 0, 0).await;
         }
 
         // Attempt to delete the same instance once more.
@@ -631,7 +628,7 @@ mod test {
 
         datastore
             .virtual_provisioning_collection_delete_instance(
-                &opctx,
+                opctx,
                 instance_id,
                 project_id,
                 cpus,
@@ -641,7 +638,7 @@ mod test {
             .unwrap();
 
         for id in ids {
-            verify_collection_usage(&datastore, &opctx, id, 0, 0, 0).await;
+            verify_collection_usage(datastore, opctx, id, 0, 0, 0).await;
         }
 
         db.terminate().await;
@@ -654,7 +651,7 @@ mod test {
         let db = TestDatabase::new_with_datastore(&logctx.log).await;
         let (opctx, datastore) = (db.opctx(), db.datastore());
 
-        let test_data = setup_collections(&datastore, &opctx).await;
+        let test_data = setup_collections(datastore, opctx).await;
         let ids = test_data.ids();
         let project_id = test_data.project_id;
 
@@ -664,12 +661,12 @@ mod test {
         let disk_byte_diff = ByteCount::try_from(1 << 30).unwrap();
 
         for id in ids {
-            verify_collection_usage(&datastore, &opctx, id, 0, 0, 0).await;
+            verify_collection_usage(datastore, opctx, id, 0, 0, 0).await;
         }
 
         datastore
             .virtual_provisioning_collection_insert_storage(
-                &opctx,
+                opctx,
                 disk_id,
                 project_id,
                 disk_byte_diff,
@@ -679,15 +676,14 @@ mod test {
             .unwrap();
 
         for id in ids {
-            verify_collection_usage(&datastore, &opctx, id, 0, 0, 1 << 30)
-                .await;
+            verify_collection_usage(datastore, opctx, id, 0, 0, 1 << 30).await;
         }
 
         // Delete the disk
 
         datastore
             .virtual_provisioning_collection_delete_storage(
-                &opctx,
+                opctx,
                 disk_id,
                 project_id,
                 disk_byte_diff,
@@ -696,7 +692,7 @@ mod test {
             .unwrap();
 
         for id in ids {
-            verify_collection_usage(&datastore, &opctx, id, 0, 0, 0).await;
+            verify_collection_usage(datastore, opctx, id, 0, 0, 0).await;
         }
 
         db.terminate().await;
@@ -710,7 +706,7 @@ mod test {
         let db = TestDatabase::new_with_datastore(&logctx.log).await;
         let (opctx, datastore) = (db.opctx(), db.datastore());
 
-        let test_data = setup_collections(&datastore, &opctx).await;
+        let test_data = setup_collections(datastore, opctx).await;
         let ids = test_data.ids();
         let project_id = test_data.project_id;
 
@@ -720,12 +716,12 @@ mod test {
         let disk_byte_diff = ByteCount::try_from(1 << 30).unwrap();
 
         for id in ids {
-            verify_collection_usage(&datastore, &opctx, id, 0, 0, 0).await;
+            verify_collection_usage(datastore, opctx, id, 0, 0, 0).await;
         }
 
         datastore
             .virtual_provisioning_collection_insert_storage(
-                &opctx,
+                opctx,
                 disk_id,
                 project_id,
                 disk_byte_diff,
@@ -735,8 +731,7 @@ mod test {
             .unwrap();
 
         for id in ids {
-            verify_collection_usage(&datastore, &opctx, id, 0, 0, 1 << 30)
-                .await;
+            verify_collection_usage(datastore, opctx, id, 0, 0, 1 << 30).await;
         }
 
         // Attempt to provision that same disk once more.
@@ -747,7 +742,7 @@ mod test {
 
         datastore
             .virtual_provisioning_collection_insert_storage(
-                &opctx,
+                opctx,
                 disk_id,
                 project_id,
                 disk_byte_diff,
@@ -758,15 +753,14 @@ mod test {
 
         // Verify that the usage is the same as before the call
         for id in ids {
-            verify_collection_usage(&datastore, &opctx, id, 0, 0, 1 << 30)
-                .await;
+            verify_collection_usage(datastore, opctx, id, 0, 0, 1 << 30).await;
         }
 
         // Delete the disk
 
         datastore
             .virtual_provisioning_collection_delete_storage(
-                &opctx,
+                opctx,
                 disk_id,
                 project_id,
                 disk_byte_diff,
@@ -775,7 +769,7 @@ mod test {
             .unwrap();
 
         for id in ids {
-            verify_collection_usage(&datastore, &opctx, id, 0, 0, 0).await;
+            verify_collection_usage(datastore, opctx, id, 0, 0, 0).await;
         }
 
         // Attempt to delete the same disk once more.
@@ -785,7 +779,7 @@ mod test {
 
         datastore
             .virtual_provisioning_collection_delete_storage(
-                &opctx,
+                opctx,
                 disk_id,
                 project_id,
                 disk_byte_diff,
@@ -794,7 +788,7 @@ mod test {
             .unwrap();
 
         for id in ids {
-            verify_collection_usage(&datastore, &opctx, id, 0, 0, 0).await;
+            verify_collection_usage(datastore, opctx, id, 0, 0, 0).await;
         }
 
         db.terminate().await;

--- a/nexus/db-queries/src/db/datastore/vmm.rs
+++ b/nexus/db-queries/src/db/datastore/vmm.rs
@@ -461,7 +461,7 @@ mod tests {
         let instance_id = InstanceUuid::from_untyped_uuid(Uuid::new_v4());
         let vmm1 = datastore
             .vmm_insert(
-                &opctx,
+                opctx,
                 Vmm {
                     id: Uuid::new_v4(),
                     time_created: Utc::now(),
@@ -482,7 +482,7 @@ mod tests {
 
         let vmm2 = datastore
             .vmm_insert(
-                &opctx,
+                opctx,
                 Vmm {
                     id: Uuid::new_v4(),
                     time_created: Utc::now(),
@@ -503,7 +503,7 @@ mod tests {
 
         let migration1 = datastore
             .migration_insert(
-                &opctx,
+                opctx,
                 Migration::new(Uuid::new_v4(), instance_id, vmm1.id, vmm2.id),
             )
             .await
@@ -525,7 +525,7 @@ mod tests {
         };
         datastore
             .vmm_and_migration_update_runtime(
-                &opctx,
+                opctx,
                 PropolisUuid::from_untyped_uuid(vmm1.id),
                 &VmmRuntimeState {
                     time_state_updated: Utc::now(),
@@ -547,7 +547,7 @@ mod tests {
         };
         datastore
             .vmm_and_migration_update_runtime(
-                &opctx,
+                opctx,
                 PropolisUuid::from_untyped_uuid(vmm2.id),
                 &VmmRuntimeState {
                     time_state_updated: Utc::now(),
@@ -564,7 +564,7 @@ mod tests {
 
         let all_migrations = datastore
             .instance_list_migrations(
-                &opctx,
+                opctx,
                 instance_id,
                 &DataPageParams::max_page(),
             )
@@ -592,7 +592,7 @@ mod tests {
         // now, let's simulate a second migration, out of vmm2.
         let vmm3 = datastore
             .vmm_insert(
-                &opctx,
+                opctx,
                 Vmm {
                     id: Uuid::new_v4(),
                     time_created: Utc::now(),
@@ -613,7 +613,7 @@ mod tests {
 
         let migration2 = datastore
             .migration_insert(
-                &opctx,
+                opctx,
                 Migration::new(Uuid::new_v4(), instance_id, vmm2.id, vmm3.id),
             )
             .await
@@ -634,7 +634,7 @@ mod tests {
         };
         datastore
             .vmm_and_migration_update_runtime(
-                &opctx,
+                opctx,
                 PropolisUuid::from_untyped_uuid(vmm2.id),
                 &VmmRuntimeState {
                     time_state_updated: Utc::now(),
@@ -658,7 +658,7 @@ mod tests {
         };
         datastore
             .vmm_and_migration_update_runtime(
-                &opctx,
+                opctx,
                 PropolisUuid::from_untyped_uuid(vmm3.id),
                 &VmmRuntimeState {
                     time_state_updated: Utc::now(),
@@ -675,7 +675,7 @@ mod tests {
 
         let all_migrations = datastore
             .instance_list_migrations(
-                &opctx,
+                opctx,
                 instance_id,
                 &DataPageParams::max_page(),
             )

--- a/nexus/db-queries/src/db/datastore/volume.rs
+++ b/nexus/db-queries/src/db/datastore/volume.rs
@@ -285,7 +285,7 @@ impl DataStore {
 
         // After volume creation, validate invariants for all volumes
         #[cfg(any(test, feature = "testing"))]
-        Self::validate_volume_invariants(&conn).await?;
+        Self::validate_volume_invariants(conn).await?;
 
         Ok(volume)
     }
@@ -598,7 +598,7 @@ impl DataStore {
                 // read-only, and will not take over from other read-only
                 // Upstairs.
 
-                match volume_is_read_only(&vcr) {
+                match volume_is_read_only(vcr) {
                     Ok(read_only) => {
                         if !read_only {
                             return Err(
@@ -1308,7 +1308,7 @@ impl DataStore {
         };
 
         let vcr: VolumeConstructionRequest =
-            serde_json::from_str(&volume.data())?;
+            serde_json::from_str(volume.data())?;
 
         let mut crucible_targets = CrucibleTargets::default();
 
@@ -1395,7 +1395,7 @@ impl DataStore {
         };
 
         let vcr: VolumeConstructionRequest =
-            serde_json::from_str(&volume.data())
+            serde_json::from_str(volume.data())
                 .map_err(|e| err.bail(e.into()))?;
 
         // Grab all the targets that the volume construction request references.
@@ -1716,7 +1716,7 @@ impl DataStore {
 
         // After volume deletion, validate invariants for all volumes
         #[cfg(any(test, feature = "testing"))]
-        Self::validate_volume_invariants(&conn).await?;
+        Self::validate_volume_invariants(conn).await?;
 
         Ok(resources_to_delete)
     }
@@ -2015,7 +2015,7 @@ impl DataStore {
         };
 
         let vcr: VolumeConstructionRequest =
-            serde_json::from_str(&volume.data())?;
+            serde_json::from_str(volume.data())?;
 
         let mut targets: Vec<SocketAddrV6> = vec![];
 
@@ -2629,7 +2629,7 @@ fn read_only_target_in_vcr(
     }
 
     let mut parts: VecDeque<Work> = VecDeque::new();
-    parts.push_back(Work { vcr_part: &vcr, under_read_only_parent: false });
+    parts.push_back(Work { vcr_part: vcr, under_read_only_parent: false });
 
     while let Some(work) = parts.pop_front() {
         match work.vcr_part {
@@ -2640,14 +2640,14 @@ fn read_only_target_in_vcr(
             } => {
                 for sub_volume in sub_volumes {
                     parts.push_back(Work {
-                        vcr_part: &sub_volume,
+                        vcr_part: sub_volume,
                         under_read_only_parent: work.under_read_only_parent,
                     });
                 }
 
                 if let Some(read_only_parent) = read_only_parent {
                     parts.push_back(Work {
-                        vcr_part: &read_only_parent,
+                        vcr_part: read_only_parent,
                         under_read_only_parent: true,
                     });
                 }
@@ -2861,7 +2861,7 @@ impl DataStore {
         }
 
         let old_vcr: VolumeConstructionRequest =
-            match serde_json::from_str(&old_volume.data()) {
+            match serde_json::from_str(old_volume.data()) {
                 Ok(vcr) => vcr,
                 Err(e) => {
                     return Err(err.bail(ReplaceRegionError::SerdeError(e)));
@@ -3118,7 +3118,7 @@ impl DataStore {
         }
 
         let old_vcr: VolumeConstructionRequest =
-            match serde_json::from_str(&old_volume.data()) {
+            match serde_json::from_str(old_volume.data()) {
                 Ok(vcr) => vcr,
                 Err(e) => {
                     return Err(err.bail(ReplaceSnapshotError::SerdeError(e)));
@@ -3449,7 +3449,7 @@ pub fn read_only_resources_associated_with_volume(
     crucible_targets: &mut CrucibleTargets,
 ) {
     let mut parts: VecDeque<&VolumeConstructionRequest> = VecDeque::new();
-    parts.push_back(&vcr);
+    parts.push_back(vcr);
 
     while let Some(vcr_part) = parts.pop_front() {
         match vcr_part {
@@ -3496,7 +3496,7 @@ pub fn read_write_resources_associated_with_volume(
     targets: &mut Vec<String>,
 ) {
     let mut parts: VecDeque<&VolumeConstructionRequest> = VecDeque::new();
-    parts.push_back(&vcr);
+    parts.push_back(vcr);
 
     while let Some(vcr_part) = parts.pop_front() {
         match vcr_part {
@@ -3796,11 +3796,11 @@ fn region_sets(
                 ..
             } => {
                 for sub_volume in sub_volumes {
-                    parts.push_back(&sub_volume);
+                    parts.push_back(sub_volume);
                 }
 
                 if let Some(read_only_parent) = read_only_parent {
-                    parts.push_back(&read_only_parent);
+                    parts.push_back(read_only_parent);
                 }
             }
 
@@ -3981,7 +3981,7 @@ impl DataStore {
 
             for volume in haystack {
                 let vcr: VolumeConstructionRequest =
-                    match serde_json::from_str(&volume.data()) {
+                    match serde_json::from_str(volume.data()) {
                         Ok(vcr) => vcr,
                         Err(e) => {
                             return Err(Error::internal_error(&format!(
@@ -4033,7 +4033,7 @@ impl DataStore {
 
             for volume in haystack {
                 let vcr: VolumeConstructionRequest =
-                    match serde_json::from_str(&volume.data()) {
+                    match serde_json::from_str(volume.data()) {
                         Ok(vcr) => vcr,
                         Err(e) => {
                             return Err(Error::internal_error(&format!(
@@ -4080,7 +4080,7 @@ impl DataStore {
 
             for volume in haystack {
                 let vcr: VolumeConstructionRequest =
-                    match serde_json::from_str(&volume.data()) {
+                    match serde_json::from_str(volume.data()) {
                         Ok(vcr) => vcr,
                         Err(e) => {
                             return Err(Error::internal_error(&format!(
@@ -4111,7 +4111,7 @@ impl DataStore {
         };
 
         let vcr: VolumeConstructionRequest =
-            match serde_json::from_str(&volume.data()) {
+            match serde_json::from_str(volume.data()) {
                 Ok(vcr) => vcr,
 
                 Err(e) => {
@@ -4143,7 +4143,7 @@ impl DataStore {
         };
 
         let vcr: VolumeConstructionRequest =
-            match serde_json::from_str(&volume.data()) {
+            match serde_json::from_str(volume.data()) {
                 Ok(vcr) => vcr,
 
                 Err(e) => {
@@ -4188,7 +4188,7 @@ impl DataStore {
             for target in &region_set {
                 let maybe_ro_usage =
                     Self::read_only_target_to_volume_resource_usage(
-                        &conn, &target,
+                        &conn, target,
                     )
                     .await
                     .map_err(|e| {
@@ -4197,7 +4197,7 @@ impl DataStore {
 
                 let maybe_region = Self::target_to_region(
                     &conn,
-                    &target,
+                    target,
                     RegionType::ReadWrite,
                 )
                 .await
@@ -4318,7 +4318,7 @@ impl DataStore {
                 p.found_batch(&haystack, &|v| *v.id().as_untyped_uuid());
 
             for volume in haystack {
-                Self::validate_volume_has_all_resources(&conn, &volume).await?;
+                Self::validate_volume_has_all_resources(conn, &volume).await?;
                 Self::validate_volume_region_sets_have_unique_targets(&volume)
                     .await?;
             }
@@ -4337,7 +4337,7 @@ impl DataStore {
             paginator = p.found_batch(&haystack, &|r| r.id());
 
             for region in haystack {
-                Self::validate_read_only_region_has_no_snapshots(&conn, region)
+                Self::validate_read_only_region_has_no_snapshots(conn, region)
                     .await?;
             }
         }
@@ -4357,7 +4357,7 @@ impl DataStore {
         }
 
         let vcr: VolumeConstructionRequest =
-            serde_json::from_str(&volume.data()).unwrap();
+            serde_json::from_str(volume.data()).unwrap();
 
         // validate all read/write resources still exist
 
@@ -4445,7 +4445,7 @@ impl DataStore {
         volume: &Volume,
     ) -> Result<(), diesel::result::Error> {
         let vcr: VolumeConstructionRequest =
-            serde_json::from_str(&volume.data()).unwrap();
+            serde_json::from_str(volume.data()).unwrap();
 
         let mut parts = VecDeque::new();
         parts.push_back(&vcr);
@@ -4662,7 +4662,7 @@ mod tests {
         let conn = datastore.pool_connection_for_tests().await.unwrap();
 
         let _test_datasets = TestDatasets::create(
-            &opctx,
+            opctx,
             datastore.clone(),
             REGION_REDUNDANCY_THRESHOLD,
         )
@@ -4673,11 +4673,11 @@ mod tests {
 
         let datasets_and_regions = datastore
             .disk_region_allocate(
-                &opctx,
+                opctx,
                 volume_id,
                 &DiskSource::Blank { block_size: 512.try_into().unwrap() },
                 ByteCount::from_gibibytes_u32(1),
-                &&RegionAllocationStrategy::RandomWithDistinctSleds {
+                &RegionAllocationStrategy::RandomWithDistinctSleds {
                     seed: None,
                 },
             )
@@ -4899,7 +4899,7 @@ mod tests {
         let conn = datastore.pool_connection_for_tests().await.unwrap();
 
         let _test_datasets = TestDatasets::create(
-            &opctx,
+            opctx,
             datastore.clone(),
             REGION_REDUNDANCY_THRESHOLD,
         )
@@ -4910,11 +4910,11 @@ mod tests {
 
         let datasets_and_regions = datastore
             .disk_region_allocate(
-                &opctx,
+                opctx,
                 volume_id,
                 &DiskSource::Blank { block_size: 512.try_into().unwrap() },
                 ByteCount::from_gibibytes_u32(1),
-                &&RegionAllocationStrategy::RandomWithDistinctSleds {
+                &RegionAllocationStrategy::RandomWithDistinctSleds {
                     seed: None,
                 },
             )
@@ -5514,7 +5514,7 @@ mod tests {
             .unwrap();
 
         let volumes = datastore
-            .find_volumes_referencing_socket_addr(&opctx, address_1.into())
+            .find_volumes_referencing_socket_addr(opctx, address_1.into())
             .await
             .unwrap();
 
@@ -5525,7 +5525,7 @@ mod tests {
 
         let volumes = datastore
             .find_volumes_referencing_socket_addr(
-                &opctx,
+                opctx,
                 "[fd55:1122:3344:104::1]:400".parse().unwrap(),
             )
             .await
@@ -6057,7 +6057,7 @@ mod tests {
         let (opctx, datastore) = (db.opctx(), db.datastore());
 
         let _test_datasets = TestDatasets::create(
-            &opctx,
+            opctx,
             datastore.clone(),
             REGION_REDUNDANCY_THRESHOLD,
         )
@@ -6072,11 +6072,11 @@ mod tests {
 
         let _datasets_and_regions = datastore
             .disk_region_allocate(
-                &opctx,
+                opctx,
                 volume_id,
                 &DiskSource::Blank { block_size: 512.try_into().unwrap() },
                 ByteCount::from_gibibytes_u32(1),
-                &&RegionAllocationStrategy::RandomWithDistinctSleds {
+                &RegionAllocationStrategy::RandomWithDistinctSleds {
                     seed: None,
                 },
             )

--- a/nexus/db-queries/src/db/datastore/volume_repair.rs
+++ b/nexus/db-queries/src/db/datastore/volume_repair.rs
@@ -197,10 +197,10 @@ mod test {
             .await
             .unwrap();
 
-        datastore.volume_repair_lock(&opctx, volume_id, lock_1).await.unwrap();
+        datastore.volume_repair_lock(opctx, volume_id, lock_1).await.unwrap();
 
         let err = datastore
-            .volume_repair_lock(&opctx, volume_id, lock_2)
+            .volume_repair_lock(opctx, volume_id, lock_2)
             .await
             .unwrap_err();
 
@@ -223,7 +223,7 @@ mod test {
         let volume_id = VolumeUuid::new_v4();
 
         datastore
-            .volume_repair_lock(&opctx, volume_id, lock_1)
+            .volume_repair_lock(opctx, volume_id, lock_1)
             .await
             .unwrap_err();
 
@@ -253,8 +253,8 @@ mod test {
             .await
             .unwrap();
 
-        datastore.volume_repair_lock(&opctx, volume_id, lock_id).await.unwrap();
-        datastore.volume_repair_lock(&opctx, volume_id, lock_id).await.unwrap();
+        datastore.volume_repair_lock(opctx, volume_id, lock_id).await.unwrap();
+        datastore.volume_repair_lock(opctx, volume_id, lock_id).await.unwrap();
 
         db.terminate().await;
         logctx.cleanup_successful();

--- a/nexus/db-queries/src/db/datastore/zpool.rs
+++ b/nexus/db-queries/src/db/datastore/zpool.rs
@@ -47,9 +47,9 @@ impl DataStore {
         opctx: &OpContext,
         zpool: Zpool,
     ) -> CreateResult<Zpool> {
-        let conn = &*self.pool_connection_authorized(&opctx).await?;
+        let conn = &*self.pool_connection_authorized(opctx).await?;
         let zpool =
-            Self::zpool_insert_on_connection(&conn, opctx, zpool).await?;
+            Self::zpool_insert_on_connection(conn, opctx, zpool).await?;
         Ok(zpool)
     }
 
@@ -196,9 +196,9 @@ impl DataStore {
         opctx: &OpContext,
         zpool_id: ZpoolUuid,
     ) -> DeleteResult {
-        let conn = &*self.pool_connection_authorized(&opctx).await?;
+        let conn = &*self.pool_connection_authorized(opctx).await?;
         Self::zpool_delete_self_and_all_datasets_on_connection(
-            &conn, opctx, zpool_id,
+            conn, opctx, zpool_id,
         )
         .await
     }

--- a/nexus/db-queries/src/db/explain.rs
+++ b/nexus/db-queries/src/db/explain.rs
@@ -146,7 +146,7 @@ mod test {
         let pool = db.pool();
         let conn = pool.claim().await.unwrap();
 
-        create_schema(&pool).await;
+        create_schema(pool).await;
 
         use schema::test_users::dsl;
         let explanation = dsl::test_users
@@ -170,7 +170,7 @@ mod test {
         let pool = db.pool();
         let conn = pool.claim().await.unwrap();
 
-        create_schema(&pool).await;
+        create_schema(pool).await;
 
         use schema::test_users::dsl;
         let explanation = dsl::test_users

--- a/nexus/db-queries/src/db/lookup.rs
+++ b/nexus/db-queries/src/db/lookup.rs
@@ -962,7 +962,7 @@ mod test {
         let project_name: Name = Name("my-project".parse().unwrap());
         let instance_name: Name = Name("my-instance".parse().unwrap());
 
-        let leaf = LookupPath::new(&opctx, &datastore)
+        let leaf = LookupPath::new(opctx, datastore)
             .project_name(&project_name)
             .instance_name(&instance_name);
         assert!(matches!(&leaf,
@@ -970,14 +970,14 @@ mod test {
             if **p == project_name && **i == instance_name));
 
         let leaf =
-            LookupPath::new(&opctx, &datastore).project_name(&project_name);
+            LookupPath::new(opctx, datastore).project_name(&project_name);
         assert!(matches!(&leaf,
             Project::Name(_, p)
             if **p == project_name));
 
         let project_id =
             "006f29d9-0ff0-e2d2-a022-87e152440122".parse().unwrap();
-        let leaf = LookupPath::new(&opctx, &datastore).project_id(project_id);
+        let leaf = LookupPath::new(opctx, datastore).project_id(project_id);
         assert!(matches!(&leaf,
             Project::PrimaryKey(_, p)
             if *p == project_id));

--- a/nexus/db-queries/src/db/pagination.rs
+++ b/nexus/db-queries/src/db/pagination.rs
@@ -666,7 +666,7 @@ mod test {
 
         use schema::test_users::dsl;
 
-        populate_users(&pool, &vec![(1, 1), (2, 2), (3, 3)]).await;
+        populate_users(pool, &vec![(1, 1), (2, 2), (3, 3)]).await;
 
         // Get the first paginated result.
         let mut pagparams = DataPageParams::<i64> {
@@ -675,7 +675,7 @@ mod test {
             limit: NonZeroU32::new(1).unwrap(),
         };
         let query = paginated(dsl::test_users, dsl::age, &pagparams);
-        let observed = execute_query(&pool, query).await;
+        let observed = execute_query(pool, query).await;
         assert_eq!(observed, vec![(1, 1)]);
 
         // Get the next paginated results, check that they arrived in the order
@@ -684,7 +684,7 @@ mod test {
         pagparams.marker = Some(&marker);
         pagparams.limit = NonZeroU32::new(2).unwrap();
         let query = paginated(dsl::test_users, dsl::age, &pagparams);
-        let observed = execute_query(&pool, query).await;
+        let observed = execute_query(pool, query).await;
         assert_eq!(observed, vec![(2, 2), (3, 3)]);
 
         db.terminate().await;
@@ -700,7 +700,7 @@ mod test {
 
         use schema::test_users::dsl;
 
-        populate_users(&pool, &vec![(1, 1), (2, 2), (3, 3)]).await;
+        populate_users(pool, &vec![(1, 1), (2, 2), (3, 3)]).await;
 
         // Get the first paginated result.
         let mut pagparams = DataPageParams::<i64> {
@@ -709,7 +709,7 @@ mod test {
             limit: NonZeroU32::new(1).unwrap(),
         };
         let query = paginated(dsl::test_users, dsl::age, &pagparams);
-        let observed = execute_query(&pool, query).await;
+        let observed = execute_query(pool, query).await;
         assert_eq!(observed, vec![(3, 3)]);
 
         // Get the next paginated results, check that they arrived in the order
@@ -718,7 +718,7 @@ mod test {
         pagparams.marker = Some(&marker);
         pagparams.limit = NonZeroU32::new(2).unwrap();
         let query = paginated(dsl::test_users, dsl::age, &pagparams);
-        let observed = execute_query(&pool, query).await;
+        let observed = execute_query(pool, query).await;
         assert_eq!(observed, vec![(2, 2), (1, 1)]);
 
         db.terminate().await;
@@ -734,7 +734,7 @@ mod test {
 
         use schema::test_users::dsl;
 
-        populate_users(&pool, &vec![(1, 1), (1, 2), (2, 1), (2, 3), (3, 1)])
+        populate_users(pool, &vec![(1, 1), (1, 2), (2, 1), (2, 3), (3, 1)])
             .await;
 
         // Get the first paginated result.
@@ -748,7 +748,7 @@ mod test {
             (dsl::age, dsl::height),
             &pagparams,
         );
-        let observed = execute_query(&pool, query).await;
+        let observed = execute_query(pool, query).await;
         assert_eq!(observed, vec![(1, 1)]);
 
         // Get the next paginated results, check that they arrived in the order
@@ -761,7 +761,7 @@ mod test {
             (dsl::age, dsl::height),
             &pagparams,
         );
-        let observed = execute_query(&pool, query).await;
+        let observed = execute_query(pool, query).await;
         assert_eq!(observed, vec![(1, 2), (2, 1), (2, 3), (3, 1)]);
 
         // Switch the order of columns to see height-first results.
@@ -771,7 +771,7 @@ mod test {
             (dsl::height, dsl::age),
             &pagparams,
         );
-        let observed = execute_query(&pool, query).await;
+        let observed = execute_query(pool, query).await;
         assert_eq!(observed, vec![(1, 1), (2, 1), (3, 1), (1, 2), (2, 3)]);
 
         db.terminate().await;
@@ -787,7 +787,7 @@ mod test {
 
         use schema::test_users::dsl;
 
-        populate_users(&pool, &vec![(1, 1), (1, 2), (2, 1), (2, 3), (3, 1)])
+        populate_users(pool, &vec![(1, 1), (1, 2), (2, 1), (2, 3), (3, 1)])
             .await;
 
         // Get the first paginated result.
@@ -801,7 +801,7 @@ mod test {
             (dsl::age, dsl::height),
             &pagparams,
         );
-        let observed = execute_query(&pool, query).await;
+        let observed = execute_query(pool, query).await;
         assert_eq!(observed, vec![(3, 1)]);
 
         // Get the next paginated results, check that they arrived in the order
@@ -814,7 +814,7 @@ mod test {
             (dsl::age, dsl::height),
             &pagparams,
         );
-        let observed = execute_query(&pool, query).await;
+        let observed = execute_query(pool, query).await;
         assert_eq!(observed, vec![(2, 3), (2, 1), (1, 2), (1, 1)]);
 
         // Switch the order of columns to see height-first results.
@@ -824,7 +824,7 @@ mod test {
             (dsl::height, dsl::age),
             &pagparams,
         );
-        let observed = execute_query(&pool, query).await;
+        let observed = execute_query(pool, query).await;
         assert_eq!(observed, vec![(2, 3), (1, 2), (3, 1), (2, 1), (1, 1)]);
 
         db.terminate().await;
@@ -843,7 +843,7 @@ mod test {
         use schema::test_phone_numbers::dsl as phone_numbers_dsl;
         use schema::test_users::dsl;
 
-        populate_users(&pool, &vec![(1, 1), (1, 2), (2, 1), (2, 3), (3, 1)])
+        populate_users(pool, &vec![(1, 1), (1, 2), (2, 1), (2, 3), (3, 1)])
             .await;
 
         async fn get_page(
@@ -868,7 +868,7 @@ mod test {
                             .on(phone_numbers_dsl::user_id.eq(dsl::id)),
                     ),
                     (dsl::age, phone_numbers_dsl::phone_number),
-                    &pagparams,
+                    pagparams,
                 )
                 .select((User::as_select(), PhoneNumber::as_select()))
                 .load_async(&conn)
@@ -890,7 +890,7 @@ mod test {
             direction: PaginationOrder::Ascending,
             limit: NonZeroU32::new(1).unwrap(),
         };
-        let observed = get_page(&pool, &pagparams).await;
+        let observed = get_page(pool, &pagparams).await;
         assert_eq!(dbg!(&observed), &[((1, 1), 10)]);
 
         // Get the next paginated results, check that they arrived in the order
@@ -899,7 +899,7 @@ mod test {
             (observed[0].user.age, observed[0].phone_number.phone_number);
         pagparams.marker = Some(&marker);
         pagparams.limit = NonZeroU32::new(10).unwrap();
-        let observed = get_page(&pool, &pagparams).await;
+        let observed = get_page(pool, &pagparams).await;
         assert_eq!(
             dbg!(&observed),
             &[
@@ -922,7 +922,7 @@ mod test {
             (observed[9].user.age, observed[9].phone_number.phone_number);
         pagparams.marker = Some(&marker);
         pagparams.limit = NonZeroU32::new(10).unwrap();
-        let observed = get_page(&pool, &pagparams).await;
+        let observed = get_page(pool, &pagparams).await;
         assert_eq!(
             dbg!(&observed),
             &[((2, 3), 42), ((3, 1), 50), ((3, 1), 51), ((3, 1), 52)]

--- a/nexus/db-queries/src/db/pool.rs
+++ b/nexus/db-queries/src/db/pool.rs
@@ -214,7 +214,7 @@ mod test {
         let mut db = crdb::test_setup_database(log).await;
         let cfg = crate::db::Config { url: db.pg_config().clone() };
         {
-            let pool = Pool::new_single_host(&log, &cfg);
+            let pool = Pool::new_single_host(log, &cfg);
             pool.terminate().await;
         }
         db.cleanup().await.unwrap();
@@ -231,7 +231,7 @@ mod test {
         let mut db = crdb::test_setup_database(log).await;
         let cfg = crate::db::Config { url: db.pg_config().clone() };
         {
-            let pool = Pool::new_single_host(&log, &cfg);
+            let pool = Pool::new_single_host(log, &cfg);
             drop(pool);
         }
         db.cleanup().await.unwrap();

--- a/nexus/db-queries/src/db/pub_test_utils/helpers.rs
+++ b/nexus/db-queries/src/db/pub_test_utils/helpers.rs
@@ -51,7 +51,7 @@ pub async fn create_project(
             },
         },
     );
-    datastore.project_create(&opctx, project).await.unwrap()
+    datastore.project_create(opctx, project).await.unwrap()
 }
 
 /// Creates a "fake" [`SledBaseboard`]
@@ -227,7 +227,7 @@ pub async fn create_stopped_instance_record(
     );
 
     let instance = datastore
-        .project_create_instance(&opctx, &authz_project, instance)
+        .project_create_instance(opctx, authz_project, instance)
         .await
         .unwrap();
 
@@ -261,7 +261,7 @@ pub async fn delete_instance_record(
         .lookup_for(authz::Action::Delete)
         .await
         .unwrap();
-    datastore.project_delete_instance(&opctx, &authz_instance).await.unwrap();
+    datastore.project_delete_instance(opctx, &authz_instance).await.unwrap();
 }
 
 pub async fn create_affinity_group(
@@ -272,8 +272,8 @@ pub async fn create_affinity_group(
     policy: external::AffinityPolicy,
 ) -> AffinityGroup {
     db.affinity_group_create(
-        &opctx,
-        &authz_project,
+        opctx,
+        authz_project,
         nexus_db_model::AffinityGroup::new(
             authz_project.id(),
             params::AffinityGroupCreate {
@@ -305,7 +305,7 @@ pub async fn delete_affinity_group(
         .await
         .unwrap();
 
-    db.affinity_group_delete(&opctx, &authz_group).await.unwrap();
+    db.affinity_group_delete(opctx, &authz_group).await.unwrap();
 }
 
 pub async fn create_anti_affinity_group(
@@ -316,8 +316,8 @@ pub async fn create_anti_affinity_group(
     policy: external::AffinityPolicy,
 ) -> AntiAffinityGroup {
     db.anti_affinity_group_create(
-        &opctx,
-        &authz_project,
+        opctx,
+        authz_project,
         nexus_db_model::AntiAffinityGroup::new(
             authz_project.id(),
             params::AntiAffinityGroupCreate {
@@ -349,7 +349,7 @@ pub async fn delete_anti_affinity_group(
         .await
         .unwrap();
 
-    db.anti_affinity_group_delete(&opctx, &authz_group).await.unwrap();
+    db.anti_affinity_group_delete(opctx, &authz_group).await.unwrap();
 }
 
 pub async fn create_affinity_group_member(

--- a/nexus/db-queries/src/db/pub_test_utils/mod.rs
+++ b/nexus/db-queries/src/db/pub_test_utils/mod.rs
@@ -114,7 +114,7 @@ impl TestDatabaseBuilder {
                     Interface::Datastore => {
                         let pool = new_pool(log, &db);
                         let datastore = Arc::new(
-                            DataStore::new(&log, pool, None).await.unwrap(),
+                            DataStore::new(log, pool, None).await.unwrap(),
                         );
                         TestDatabase {
                             db,
@@ -299,14 +299,14 @@ async fn datastore_test(
     use crate::authn;
 
     let cfg = db::Config { url: db.pg_config().clone() };
-    let pool = Arc::new(db::Pool::new_single_host(&log, &cfg));
-    let datastore = Arc::new(DataStore::new(&log, pool, None).await.unwrap());
+    let pool = Arc::new(db::Pool::new_single_host(log, &cfg));
+    let datastore = Arc::new(DataStore::new(log, pool, None).await.unwrap());
 
     // Create an OpContext with the credentials of "db-init" just for the
     // purpose of loading the built-in users, roles, and assignments.
     let opctx = OpContext::for_background(
         log.new(o!()),
-        Arc::new(authz::Authz::new(&log)),
+        Arc::new(authz::Authz::new(log)),
         authn::Context::internal_db_init(),
         Arc::clone(&datastore) as Arc<dyn nexus_auth::storage::Storage>,
     );

--- a/nexus/db-queries/src/db/queries/external_ip.rs
+++ b/nexus/db-queries/src/db/queries/external_ip.rs
@@ -945,7 +945,7 @@ mod tests {
 
             self.initialize_ip_pool(name, range).await;
 
-            LookupPath::new(self.db.opctx(), &self.db.datastore())
+            LookupPath::new(self.db.opctx(), self.db.datastore())
                 .ip_pool_id(pool.id())
                 .lookup_for(authz::Action::Read)
                 .await

--- a/nexus/db-queries/src/db/queries/network_interface.rs
+++ b/nexus/db-queries/src/db/queries/network_interface.rs
@@ -1893,14 +1893,14 @@ mod tests {
 
         let instance = Instance::new(instance_id, project_id, &params);
 
-        let (.., authz_project) = LookupPath::new(&opctx, &db_datastore)
+        let (.., authz_project) = LookupPath::new(opctx, db_datastore)
             .project_id(project_id)
             .lookup_for(authz::Action::CreateChild)
             .await
             .expect("Failed to lookup project for instance creation");
 
         db_datastore
-            .project_create_instance(&opctx, &authz_project, instance)
+            .project_create_instance(opctx, &authz_project, instance)
             .await
             .expect("Failed to create new instance record")
     }
@@ -2017,11 +2017,11 @@ mod tests {
                 },
             );
             let (.., project) =
-                datastore.project_create(&opctx, project).await.unwrap();
+                datastore.project_create(opctx, project).await.unwrap();
 
             use nexus_db_schema::schema::vpc_subnet::dsl::vpc_subnet;
             let conn =
-                datastore.pool_connection_authorized(&opctx).await.unwrap();
+                datastore.pool_connection_authorized(opctx).await.unwrap();
             let net1 = Network::new(n_subnets);
             let net2 = Network::new(n_subnets);
             for subnet in net1.subnets.iter().chain(net2.subnets.iter()) {

--- a/nexus/db-queries/src/db/queries/next_item.rs
+++ b/nexus/db-queries/src/db/queries/next_item.rs
@@ -1095,7 +1095,7 @@ mod tests {
         let conn = pool.claim().await.unwrap();
 
         // We're going to operate on a separate table, for simplicity.
-        setup_test_schema(&pool).await;
+        setup_test_schema(pool).await;
 
         // We'll first insert an item at 0.
         //
@@ -1155,7 +1155,7 @@ mod tests {
         let conn = pool.claim().await.unwrap();
 
         // We're going to operate on a separate table, for simplicity.
-        setup_test_schema(&pool).await;
+        setup_test_schema(pool).await;
 
         // To test ordering behavior, we'll generate a range where the natural
         // order of the _items_ differs from their indices. I.e., we have some
@@ -1242,7 +1242,7 @@ mod tests {
         let conn = pool.claim().await.unwrap();
 
         // We're going to operate on a separate table, for simplicity.
-        setup_test_schema(&pool).await;
+        setup_test_schema(pool).await;
 
         let query = NextItemSelfJoined::<
             item::dsl::item,
@@ -1266,7 +1266,7 @@ mod tests {
         let conn = pool.claim().await.unwrap();
 
         // We're going to operate on a separate table, for simplicity.
-        setup_test_schema(&pool).await;
+        setup_test_schema(pool).await;
 
         for i in 0..10 {
             let query = NextItemSelfJoinedQuery::new(0, 9);
@@ -1300,7 +1300,7 @@ mod tests {
         let conn = pool.claim().await.unwrap();
 
         // We're going to operate on a separate table, for simplicity.
-        setup_test_schema(&pool).await;
+        setup_test_schema(pool).await;
 
         // Insert mostly the same items, but leave some gaps.
         const TO_SKIP: [i32; 2] = [3, 7];
@@ -1351,7 +1351,7 @@ mod tests {
         let conn = pool.claim().await.unwrap();
 
         // We're going to operate on a separate table, for simplicity.
-        setup_test_schema(&pool).await;
+        setup_test_schema(pool).await;
 
         // Insert a bunch of items, not using the next item machinery.
         const N_ITEMS: usize = 10_000;

--- a/nexus/db-queries/src/policy_test/mod.rs
+++ b/nexus/db-queries/src/policy_test/mod.rs
@@ -75,7 +75,7 @@ async fn test_iam_roles_behavior() {
     );
     datastore
         .role_assignment_replace_visible(
-            &opctx,
+            opctx,
             &main_silo,
             &[shared::RoleAssignment {
                 identity_type: shared::IdentityType::SiloUser,
@@ -93,7 +93,7 @@ async fn test_iam_roles_behavior() {
     let exemptions = resources::exempted_authz_classes();
     let mut coverage = Coverage::new(&logctx.log, exemptions);
     let builder =
-        ResourceBuilder::new(&opctx, &datastore, &mut coverage, main_silo_id);
+        ResourceBuilder::new(opctx, datastore, &mut coverage, main_silo_id);
     let test_resources = resources::make_resources(builder, main_silo_id).await;
     coverage.verify();
 
@@ -116,7 +116,7 @@ async fn test_iam_roles_behavior() {
                     main_silo_id,
                     SiloAuthnPolicy::default(),
                 ),
-                Arc::clone(&datastore) as Arc<dyn nexus_auth::storage::Storage>,
+                Arc::clone(datastore) as Arc<dyn nexus_auth::storage::Storage>,
             );
 
             Arc::new((username.clone(), opctx))
@@ -139,7 +139,7 @@ async fn test_iam_roles_behavior() {
             user_log,
             Arc::clone(&authz),
             authn::Context::internal_unauthenticated(),
-            Arc::clone(&datastore) as Arc<dyn nexus_auth::storage::Storage>,
+            Arc::clone(datastore) as Arc<dyn nexus_auth::storage::Storage>,
         ),
     )));
 
@@ -168,7 +168,7 @@ async fn test_iam_roles_behavior() {
 
     expectorate::assert_contents(
         "tests/output/authz-roles.out",
-        &std::str::from_utf8(buffer.as_ref()).expect("non-UTF8 output"),
+        std::str::from_utf8(buffer.as_ref()).expect("non-UTF8 output"),
     );
 
     db.terminate().await;
@@ -341,7 +341,7 @@ async fn test_conferred_roles() {
     );
     datastore
         .role_assignment_replace_visible(
-            &opctx,
+            opctx,
             &main_silo,
             &[shared::RoleAssignment {
                 identity_type: shared::IdentityType::SiloUser,
@@ -360,7 +360,7 @@ async fn test_conferred_roles() {
     // behavior on the Fleet itself, as well as some top-level resources that
     // exist outside of a silo.
     let mut builder =
-        ResourceBuilder::new(&opctx, &datastore, &mut coverage, main_silo_id);
+        ResourceBuilder::new(opctx, datastore, &mut coverage, main_silo_id);
     builder.new_resource(authz::FLEET);
     builder.new_resource(authz::IP_POOL_LIST);
     let test_resources = builder.build();
@@ -368,7 +368,7 @@ async fn test_conferred_roles() {
     // We also create a Silo because the ResourceBuilder will create for us
     // users that we can use to test the behavior of each role.
     let mut silo_builder =
-        ResourceBuilder::new(&opctx, &datastore, &mut coverage, main_silo_id);
+        ResourceBuilder::new(opctx, datastore, &mut coverage, main_silo_id);
     silo_builder.new_resource(authz::FLEET);
     silo_builder.new_resource_with_users(main_silo).await;
     let silo_resources = silo_builder.build();
@@ -437,7 +437,7 @@ async fn test_conferred_roles() {
                             main_silo_id,
                             policy.clone(),
                         ),
-                        Arc::clone(&datastore)
+                        Arc::clone(datastore)
                             as Arc<dyn nexus_auth::storage::Storage>,
                     );
                     Arc::new((username.clone(), opctx))
@@ -458,7 +458,7 @@ async fn test_conferred_roles() {
 
     expectorate::assert_contents(
         "tests/output/authz-conferred-roles.out",
-        &std::str::from_utf8(buffer.as_ref()).expect("non-UTF8 output"),
+        std::str::from_utf8(buffer.as_ref()).expect("non-UTF8 output"),
     );
 
     db.terminate().await;

--- a/nexus/db-queries/src/provisioning.rs
+++ b/nexus/db-queries/src/provisioning.rs
@@ -34,8 +34,8 @@ impl Producer {
         &self,
         provisions: &Vec<VirtualProvisioningCollection>,
     ) -> Result<(), MetricsError> {
-        self.append_cpu_metrics(&provisions)?;
-        self.append_disk_metrics(&provisions)
+        self.append_cpu_metrics(provisions)?;
+        self.append_disk_metrics(provisions)
     }
 
     pub fn append_disk_metrics(

--- a/nexus/inventory/src/collector.rs
+++ b/nexus/inventory/src/collector.rs
@@ -353,7 +353,7 @@ impl<'a> Collector<'a> {
             }
         };
 
-        self.in_progress.found_sled_inventory(&sled_agent_url, inventory)
+        self.in_progress.found_sled_inventory(sled_agent_url, inventory)
     }
 
     /// Collect inventory from about keepers from all `ClickhouseAdminKeeper`
@@ -363,7 +363,7 @@ impl<'a> Collector<'a> {
             "nkeeper_admin_clients" => self.keeper_admin_clients.len());
 
         for client in &self.keeper_admin_clients {
-            Self::collect_one_keeper(&client, &self.log, &mut self.in_progress)
+            Self::collect_one_keeper(client, &self.log, &mut self.in_progress)
                 .await;
         }
 
@@ -548,7 +548,7 @@ mod test {
             // Some error strings have OS error numbers in them.  We want to
             // ignore those, particularly for CI, which runs these tests on
             // multiple OSes.
-            let message = os_error_re.replace_all(&e, "os error <<redacted>>");
+            let message = os_error_re.replace_all(e, "os error <<redacted>>");
             // Communication errors differ based on the configuration of the
             // machine running the test. For example whether or not the machine
             // has IPv6 configured will determine if an error is network
@@ -579,7 +579,7 @@ mod test {
         );
 
         let agent =
-            sim::Server::start(&config, &log, false, &simulated_upstairs, 0)
+            sim::Server::start(&config, &log, false, simulated_upstairs, 0)
                 .await
                 .unwrap();
 

--- a/nexus/metrics-producer-gc/src/lib.rs
+++ b/nexus/metrics-producer-gc/src/lib.rs
@@ -224,13 +224,13 @@ mod tests {
             address: "[::1]:0".parse().unwrap(),
         });
         datastore
-            .oximeter_create(&opctx, &collector_info)
+            .oximeter_create(opctx, &collector_info)
             .await
             .expect("failed to insert collector");
 
         // GC'ing expired producers should succeed if there are no producers at
         // all.
-        let pruned = prune_expired_producers(&opctx, &datastore, Utc::now())
+        let pruned = prune_expired_producers(opctx, datastore, Utc::now())
             .await
             .expect("failed to prune expired producers");
         assert!(pruned.successes.is_empty());
@@ -244,18 +244,18 @@ mod tests {
             interval: Duration::from_secs(0),    // unused
         };
         datastore
-            .producer_endpoint_upsert_and_assign(&opctx, &producer)
+            .producer_endpoint_upsert_and_assign(opctx, &producer)
             .await
             .expect("failed to insert producer");
 
         let producer_time_modified =
-            read_time_modified(&datastore, producer.id).await;
+            read_time_modified(datastore, producer.id).await;
 
         // GC'ing expired producers with an expiration time older than our
         // producer's `time_modified` should not prune anything.
         let pruned = prune_expired_producers(
-            &opctx,
-            &datastore,
+            opctx,
+            datastore,
             producer_time_modified - Duration::from_secs(1),
         )
         .await
@@ -266,8 +266,8 @@ mod tests {
         // GC'ing expired producers with an expiration time _newer_ than our
         // producer's `time_modified` should prune our one producer.
         let pruned = prune_expired_producers(
-            &opctx,
-            &datastore,
+            opctx,
+            datastore,
             producer_time_modified + Duration::from_secs(1),
         )
         .await
@@ -280,8 +280,8 @@ mod tests {
         // GC'ing again with the same expiration should do nothing, because we
         // already pruned the producer.
         let pruned = prune_expired_producers(
-            &opctx,
-            &datastore,
+            opctx,
+            datastore,
             producer_time_modified + Duration::from_secs(1),
         )
         .await
@@ -310,7 +310,7 @@ mod tests {
             address: collector.addr(),
         });
         datastore
-            .oximeter_create(&opctx, &collector_info)
+            .oximeter_create(opctx, &collector_info)
             .await
             .expect("failed to insert collector");
 
@@ -322,12 +322,12 @@ mod tests {
             interval: Duration::from_secs(0),    // unused
         };
         datastore
-            .producer_endpoint_upsert_and_assign(&opctx, &producer)
+            .producer_endpoint_upsert_and_assign(opctx, &producer)
             .await
             .expect("failed to insert producer");
 
         let producer_time_modified =
-            read_time_modified(&datastore, producer.id).await;
+            read_time_modified(datastore, producer.id).await;
 
         // GC'ing expired producers with an expiration time _newer_ than our
         // producer's `time_modified` should prune our one producer and notify
@@ -341,8 +341,8 @@ mod tests {
         );
 
         let pruned = prune_expired_producers(
-            &opctx,
-            &datastore,
+            opctx,
+            datastore,
             producer_time_modified + Duration::from_secs(1),
         )
         .await

--- a/nexus/reconfigurator/cli-integration-tests/tests/integration/blueprint_edit.rs
+++ b/nexus/reconfigurator/cli-integration-tests/tests/integration/blueprint_edit.rs
@@ -66,7 +66,7 @@ async fn test_blueprint_edit(cptestctx: &ControlPlaneTestContext) {
         .blueprint_target_get_current_full(&opctx)
         .await
         .expect("failed to read current target blueprint");
-    let mut disk_test = DiskTest::new(&cptestctx).await;
+    let mut disk_test = DiskTest::new(cptestctx).await;
     disk_test.add_blueprint_disks(&initial_blueprint).await;
 
     let tmpdir = camino_tempfile::tempdir().expect("failed to create tmpdir");

--- a/nexus/reconfigurator/execution/src/clickhouse.rs
+++ b/nexus/reconfigurator/execution/src/clickhouse.rs
@@ -175,7 +175,7 @@ where
         futs.push(Either::Right(async move {
             let client = ClickhouseServerClient::new(&admin_url, log.clone());
             if let Err(e) = client
-                .generate_config_and_enable_svc(&config)
+                .generate_config_and_enable_svc(config)
                 .await
                 .map(|_| ())
                 .map_err(|e| {

--- a/nexus/reconfigurator/execution/src/cockroachdb.rs
+++ b/nexus/reconfigurator/execution/src/cockroachdb.rs
@@ -94,7 +94,7 @@ mod test {
         );
         // Record the zpools so we don't fail to ensure datasets (unrelated to
         // crdb settings) during blueprint execution.
-        let mut disk_test = DiskTest::new(&cptestctx).await;
+        let mut disk_test = DiskTest::new(cptestctx).await;
         disk_test.add_blueprint_disks(&blueprint).await;
 
         // Execute the initial blueprint.

--- a/nexus/reconfigurator/execution/src/dns.rs
+++ b/nexus/reconfigurator/execution/src/dns.rs
@@ -246,7 +246,7 @@ fn dns_compute_update(
 ) -> Result<Option<DnsVersionUpdateBuilder>, Error> {
     let mut update = DnsVersionUpdateBuilder::new(dns_group, comment, creator);
 
-    let diff = DnsDiff::new(&current_zone, &new_zone)
+    let diff = DnsDiff::new(current_zone, new_zone)
         .map_err(|e| Error::internal_error(&format!("{:#}", e)))?;
     if diff.is_empty() {
         info!(log, "no changes");
@@ -1343,7 +1343,7 @@ mod test {
 
         // Record the zpools so we don't fail to ensure datasets (unrelated to
         // DNS) during blueprint execution.
-        let mut disk_test = DiskTest::new(&cptestctx).await;
+        let mut disk_test = DiskTest::new(cptestctx).await;
         disk_test.add_blueprint_disks(&blueprint).await;
 
         // Now, execute the initial blueprint.
@@ -1433,7 +1433,7 @@ mod test {
         };
         let collection = CollectionBuilder::new("test").build();
         let mut builder = BlueprintBuilder::new_based_on(
-            &log,
+            log,
             &blueprint,
             &planning_input,
             &collection,
@@ -1569,7 +1569,7 @@ mod test {
         // This ensures that the "create Silo" path picks up Nexus instances
         // that exist only in Reconfigurator, not the services table.
         let dns_latest_external = create_silo_and_verify_dns(
-            &cptestctx,
+            cptestctx,
             &opctx,
             datastore,
             resolver,
@@ -1650,12 +1650,12 @@ mod test {
         .await;
 
         let dns_latest_internal = datastore
-            .dns_config_read(&opctx, DnsGroup::Internal)
+            .dns_config_read(opctx, DnsGroup::Internal)
             .await
             .expect("fetching latest internal DNS");
         assert_eq!(old_internal.generation, dns_latest_internal.generation);
         let dns_latest_external = datastore
-            .dns_config_read(&opctx, DnsGroup::External)
+            .dns_config_read(opctx, DnsGroup::External)
             .await
             .expect("fetching latest external DNS");
         assert_eq!(
@@ -1664,7 +1664,7 @@ mod test {
         );
 
         // Specifically, there should be one new name (for the new Silo).
-        let diff = diff_sole_zones(&old_external, &dns_latest_external);
+        let diff = diff_sole_zones(old_external, &dns_latest_external);
         assert!(diff.names_removed().next().is_none());
         assert!(diff.names_changed().next().is_none());
         let added = diff.names_added().collect::<Vec<_>>();
@@ -1679,15 +1679,15 @@ mod test {
 
         // If we execute the blueprint, DNS should not be changed.
         _ = realize_blueprint_and_expect(
-            &opctx, datastore, resolver, &blueprint, &overrides,
+            opctx, datastore, resolver, blueprint, overrides,
         )
         .await;
         let dns_latest_internal = datastore
-            .dns_config_read(&opctx, DnsGroup::Internal)
+            .dns_config_read(opctx, DnsGroup::Internal)
             .await
             .expect("fetching latest internal DNS");
         let dns_latest_external = datastore
-            .dns_config_read(&opctx, DnsGroup::External)
+            .dns_config_read(opctx, DnsGroup::External)
             .await
             .expect("fetching latest external DNS");
         assert_eq!(old_internal.generation, dns_latest_internal.generation);
@@ -1706,11 +1706,11 @@ mod test {
         old_external: &DnsConfigParams,
     ) {
         let dns_latest_internal = datastore
-            .dns_config_read(&opctx, DnsGroup::Internal)
+            .dns_config_read(opctx, DnsGroup::Internal)
             .await
             .expect("fetching latest internal DNS");
         let dns_latest_external = datastore
-            .dns_config_read(&opctx, DnsGroup::External)
+            .dns_config_read(opctx, DnsGroup::External)
             .await
             .expect("fetching latest external DNS");
 

--- a/nexus/reconfigurator/execution/src/lib.rs
+++ b/nexus/reconfigurator/execution/src/lib.rs
@@ -542,7 +542,7 @@ fn register_deploy_clickhouse_cluster_nodes_step<'a>(
                     let res = clickhouse::deploy_nodes(
                         opctx,
                         blueprint,
-                        &clickhouse_cluster_config,
+                        clickhouse_cluster_config,
                     )
                     .await
                     .map_err(merge_anyhow_list);

--- a/nexus/reconfigurator/execution/src/omicron_physical_disks.rs
+++ b/nexus/reconfigurator/execution/src/omicron_physical_disks.rs
@@ -46,7 +46,7 @@ async fn decommission_expunged_disks_impl(
                 "disk_id" => disk_id.to_string(),
             ));
 
-            match datastore.physical_disk_decommission(&opctx, disk_id).await {
+            match datastore.physical_disk_decommission(opctx, disk_id).await {
                 Err(error) => {
                     warn!(
                         log,
@@ -118,7 +118,7 @@ mod test {
             sled_id.into_untyped_uuid(),
         );
         datastore
-            .physical_disk_insert(&opctx, physical_disk.clone())
+            .physical_disk_insert(opctx, physical_disk.clone())
             .await
             .unwrap();
         id
@@ -241,18 +241,18 @@ mod test {
         );
 
         let sled_id = SledUuid::from_untyped_uuid(
-            Uuid::from_str(&SLED_AGENT_UUID).unwrap(),
+            Uuid::from_str(SLED_AGENT_UUID).unwrap(),
         );
 
         // Create a couple disks in the database
         let disks = [
-            make_disk_in_db(&datastore, &opctx, 0, sled_id).await,
-            make_disk_in_db(&datastore, &opctx, 1, sled_id).await,
+            make_disk_in_db(datastore, &opctx, 0, sled_id).await,
+            make_disk_in_db(datastore, &opctx, 1, sled_id).await,
         ];
 
         // Add a zpool, dataset, and region to each disk.
         for disk_id in disks {
-            add_zpool_dataset_and_region(&datastore, &opctx, disk_id, sled_id)
+            add_zpool_dataset_and_region(datastore, &opctx, disk_id, sled_id)
                 .await;
         }
 
@@ -290,7 +290,7 @@ mod test {
 
         super::decommission_expunged_disks_impl(
             &opctx,
-            &datastore,
+            datastore,
             [(sled_id, disk_to_decommission)].into_iter(),
         )
         .await
@@ -319,19 +319,19 @@ mod test {
         // Even though we've decommissioned this disk, the pools, datasets, and
         // regions should remain. Refer to the "decommissioned_disk_cleaner"
         // for how these get eventually cleared up.
-        let pools = get_pools(&datastore, disk_to_decommission).await;
+        let pools = get_pools(datastore, disk_to_decommission).await;
         assert_eq!(pools.len(), 1);
-        let datasets = get_crucible_datasets(&datastore, pools[0]).await;
+        let datasets = get_crucible_datasets(datastore, pools[0]).await;
         assert_eq!(datasets.len(), 1);
-        let regions = get_regions(&datastore, datasets[0]).await;
+        let regions = get_regions(datastore, datasets[0]).await;
         assert_eq!(regions.len(), 1);
 
         // Similarly, the "other disk" should still exist.
-        let pools = get_pools(&datastore, other_disk).await;
+        let pools = get_pools(datastore, other_disk).await;
         assert_eq!(pools.len(), 1);
-        let datasets = get_crucible_datasets(&datastore, pools[0]).await;
+        let datasets = get_crucible_datasets(datastore, pools[0]).await;
         assert_eq!(datasets.len(), 1);
-        let regions = get_regions(&datastore, datasets[0]).await;
+        let regions = get_regions(datastore, datasets[0]).await;
         assert_eq!(regions.len(), 1);
     }
 }

--- a/nexus/reconfigurator/execution/src/omicron_sled_config.rs
+++ b/nexus/reconfigurator/execution/src/omicron_sled_config.rs
@@ -68,7 +68,10 @@ pub(crate) async fn deploy_sled_configs(
                     Some(error)
                 }
                 Ok(result) => {
-                    parse_config_result(result.into_inner(), &log).err()
+                    match parse_config_result(result.into_inner(), &log) {
+                        Ok(()) => None,
+                        Err(err) => Some(err),
+                    }
                 }
             }
         })

--- a/nexus/reconfigurator/execution/src/omicron_sled_config.rs
+++ b/nexus/reconfigurator/execution/src/omicron_sled_config.rs
@@ -34,7 +34,7 @@ pub(crate) async fn deploy_sled_configs(
                 "generation" => i64::from(&config.sled_agent_generation),
             ));
 
-            let db_sled = match sleds_by_id.get(&sled_id) {
+            let db_sled = match sleds_by_id.get(sled_id) {
                 Some(sled) => sled,
                 None => {
                     if config.are_all_items_expunged() {

--- a/nexus/reconfigurator/execution/src/sled_state.rs
+++ b/nexus/reconfigurator/execution/src/sled_state.rs
@@ -93,7 +93,7 @@ mod tests {
         datastore: &DataStore,
     ) -> Vec<SledUuid> {
         datastore
-            .sled_list_all_batched(&opctx, SledFilter::Commissioned)
+            .sled_list_all_batched(opctx, SledFilter::Commissioned)
             .await
             .expect("listing sleds")
             .into_iter()

--- a/nexus/reconfigurator/planning/src/blueprint_builder/builder.rs
+++ b/nexus/reconfigurator/planning/src/blueprint_builder/builder.rs
@@ -538,7 +538,7 @@ impl<'a> BlueprintBuilder<'a> {
     }
 
     pub fn parent_blueprint(&self) -> &Blueprint {
-        &self.parent_blueprint
+        self.parent_blueprint
     }
 
     fn resource_allocator(
@@ -2121,7 +2121,7 @@ pub mod test {
             .sled_lookup(SledFilter::Commissioned, new_sled_id)
             .unwrap()
             .resources;
-        builder.sled_add_disks(new_sled_id, &new_sled_resources).unwrap();
+        builder.sled_add_disks(new_sled_id, new_sled_resources).unwrap();
         builder.sled_ensure_zone_ntp(new_sled_id).unwrap();
         for pool_id in new_sled_resources.zpools.keys() {
             builder.sled_ensure_zone_crucible(new_sled_id, *pool_id).unwrap();
@@ -2365,7 +2365,7 @@ pub mod test {
                 input.all_sled_resources(SledFilter::InService)
             {
                 let edits =
-                    builder.sled_add_disks(sled_id, &sled_resources).unwrap();
+                    builder.sled_add_disks(sled_id, sled_resources).unwrap();
                 assert_eq!(
                     edits.disks,
                     EditCounts {

--- a/nexus/reconfigurator/planning/src/blueprint_builder/clickhouse.rs
+++ b/nexus/reconfigurator/planning/src/blueprint_builder/clickhouse.rs
@@ -243,7 +243,7 @@ impl ClickhouseAllocator {
         // We remove first, because the zones are already gone and therefore
         // don't help our quorum.
         for (zone_id, _) in &self.parent_config.keepers {
-            if !active_clickhouse_zones.keepers.contains(&zone_id) {
+            if !active_clickhouse_zones.keepers.contains(zone_id) {
                 // Remove the keeper for the first expunged zone we see.
                 // Remember, we only do one keeper membership change at time.
                 new_config.keepers.remove(zone_id);
@@ -588,7 +588,7 @@ pub mod test {
         // change, because the inventory doesn't reflect the removed keeper
         allocator.parent_config = new_config;
         allocator.inventory.as_mut().unwrap().leader_committed_log_index += 1;
-        let new_config = allocator.plan(&&active_clickhouse_zones).unwrap();
+        let new_config = allocator.plan(&active_clickhouse_zones).unwrap();
         assert!(!new_config.needs_generation_bump(&allocator.parent_config));
 
         // Reflecting the keeper removal in inventory should also result in no

--- a/nexus/reconfigurator/planning/src/planner.rs
+++ b/nexus/reconfigurator/planning/src/planner.rs
@@ -465,7 +465,7 @@ impl<'a> Planner<'a> {
             // First, we need to ensure that sleds are using their expected
             // disks. This is necessary before we can allocate any zones.
             let sled_edits =
-                self.blueprint.sled_add_disks(sled_id, &sled_resources)?;
+                self.blueprint.sled_add_disks(sled_id, sled_resources)?;
 
             if let EnsureMultiple::Changed {
                 added,
@@ -690,7 +690,7 @@ impl<'a> Planner<'a> {
                     .input
                     .all_sled_resources(SledFilter::Discretionary)
                     .filter(|(sled_id, _)| {
-                        !sleds_waiting_for_ntp_zone.contains(&sled_id)
+                        !sleds_waiting_for_ntp_zone.contains(sled_id)
                     })
                     .map(|(sled_id, sled_resources)| {
                         OmicronZonePlacementSledState {
@@ -1037,15 +1037,15 @@ pub(crate) mod test {
     ) {
         let planner = Planner::new_based_on(
             log.clone(),
-            &blueprint,
-            &input,
+            blueprint,
+            input,
             test_name,
-            &collection,
+            collection,
         )
         .expect("created planner");
         let child_blueprint = planner.plan().expect("planning succeeded");
         verify_blueprint(&child_blueprint);
-        let summary = child_blueprint.diff_since_blueprint(&blueprint);
+        let summary = child_blueprint.diff_since_blueprint(blueprint);
         eprintln!(
             "diff between blueprints (expected no changes):\n{}",
             summary.display()
@@ -2039,7 +2039,7 @@ pub(crate) mod test {
         assert_eq!(
             collection
                 .sled_agents
-                .get(&sled_id)
+                .get(sled_id)
                 .unwrap()
                 .omicron_physical_disks_generation,
             Generation::new()
@@ -2060,7 +2060,7 @@ pub(crate) mod test {
         let expunged_disk_id = {
             let expunged_disk = &mut builder
                 .sleds_mut()
-                .get_mut(&sled_id)
+                .get_mut(sled_id)
                 .unwrap()
                 .resources
                 .zpools
@@ -2126,7 +2126,7 @@ pub(crate) mod test {
         // has learned about the expungement.
         collection
             .sled_agents
-            .get_mut(&sled_id)
+            .get_mut(sled_id)
             .unwrap()
             .omicron_physical_disks_generation = Generation::from_u32(3);
 
@@ -2336,7 +2336,7 @@ pub(crate) mod test {
                     assert!(name.starts_with("oxz_crucible"));
                     assert!(expected_kinds.remove(&test_transient_zone_kind));
                 } else {
-                    assert!(expected_kinds.remove(&modified.kind.before));
+                    assert!(expected_kinds.remove(modified.kind.before));
                 }
             }
             modified_sled_configs.push(modified_sled);

--- a/nexus/reconfigurator/preparation/src/lib.rs
+++ b/nexus/reconfigurator/preparation/src/lib.rs
@@ -362,7 +362,7 @@ pub async fn reconfigurator_state_load(
     let blueprints_list = &blueprints;
     let fetch_dns_group = |dns_group: DnsGroup| async move {
         let latest_version = datastore
-            .dns_group_latest_version(&opctx, dns_group)
+            .dns_group_latest_version(opctx, dns_group)
             .await
             .with_context(|| {
                 format!("reading latest {:?} version", dns_group)
@@ -378,7 +378,7 @@ pub async fn reconfigurator_state_load(
         let mut rv = BTreeMap::new();
         for gen in dns_generations_needed {
             let config = datastore
-                .dns_config_read_version(&opctx, dns_group, gen)
+                .dns_config_read_version(opctx, dns_group, gen)
                 .await
                 .with_context(|| {
                     format!("reading {:?} DNS version {}", dns_group, gen)
@@ -392,14 +392,14 @@ pub async fn reconfigurator_state_load(
     let internal_dns = fetch_dns_group(DnsGroup::Internal).await?;
     let external_dns = fetch_dns_group(DnsGroup::External).await?;
     let silo_names = datastore
-        .silo_list_all_batched(&opctx, Discoverability::All)
+        .silo_list_all_batched(opctx, Discoverability::All)
         .await
         .context("listing all Silos")?
         .into_iter()
         .map(|s| s.name().clone())
         .collect();
     let external_dns_zone_names = datastore
-        .dns_zones_list_all(&opctx, DnsGroup::External)
+        .dns_zones_list_all(opctx, DnsGroup::External)
         .await
         .context("listing external DNS zone names")?
         .into_iter()

--- a/nexus/reconfigurator/simulation/src/sim.rs
+++ b/nexus/reconfigurator/simulation/src/sim.rs
@@ -90,7 +90,7 @@ impl Simulator {
     /// Versioned configurations start with this seed, though they may choose
     /// to change it as they go along.
     pub fn initial_seed(&self) -> &str {
-        &self.root_state.rng().seed()
+        self.root_state.rng().seed()
     }
 
     /// Get the current heads of the store.

--- a/nexus/reconfigurator/simulation/src/system.rs
+++ b/nexus/reconfigurator/simulation/src/system.rs
@@ -220,7 +220,7 @@ impl SimSystemBuilder {
 
     #[inline]
     pub fn description(&self) -> &SystemDescription {
-        &self.inner.system.description()
+        self.inner.system.description()
     }
 
     #[inline]
@@ -586,7 +586,7 @@ impl SimSystemBuilderInner {
                     let inv_rot = primary_collection.rots.get(baseboard_id);
                     if let (Some(inv_sp), Some(inv_rot)) = (inv_sp, inv_rot) {
                         Some(SledHwInventory {
-                            baseboard_id: &baseboard_id,
+                            baseboard_id,
                             sp: inv_sp,
                             rot: inv_rot,
                         })

--- a/nexus/src/app/background/tasks/abandoned_vmm_reaper.rs
+++ b/nexus/src/app/background/tasks/abandoned_vmm_reaper.rs
@@ -220,7 +220,7 @@ mod tests {
             datastore: &Arc<DataStore>,
             opctx: &OpContext,
         ) -> Self {
-            resource_helpers::create_default_ip_pool(&client).await;
+            resource_helpers::create_default_ip_pool(client).await;
 
             let _project =
                 resource_helpers::create_project(client, PROJECT_NAME).await;
@@ -234,7 +234,7 @@ mod tests {
             let destroyed_vmm_id = PropolisUuid::new_v4();
             datastore
                 .vmm_insert(
-                    &opctx,
+                    opctx,
                     dbg!(Vmm {
                         id: destroyed_vmm_id.into_untyped_uuid(),
                         time_created: Utc::now(),
@@ -263,7 +263,7 @@ mod tests {
             dbg!(
                 datastore
                     .sled_reservation_create(
-                        &opctx,
+                        opctx,
                         InstanceUuid::from_untyped_uuid(instance.identity.id),
                         destroyed_vmm_id,
                         resources.clone(),

--- a/nexus/src/app/background/tasks/bfd.rs
+++ b/nexus/src/app/background/tasks/bfd.rs
@@ -172,7 +172,7 @@ impl BackgroundTask for BfdManager {
             for x in &to_check {
                 let c = current.get(x).unwrap();
                 let t = target.get(x).unwrap();
-                if c.needs_update(&t) {
+                if c.needs_update(t) {
                     to_update.insert(t);
                 }
             }

--- a/nexus/src/app/background/tasks/blueprint_execution.rs
+++ b/nexus/src/app/background/tasks/blueprint_execution.rs
@@ -376,7 +376,7 @@ mod test {
         // complete and report a successful (empty) summary.
         let generation = Generation::new();
         let blueprint = Arc::new(
-            create_blueprint(&datastore, &opctx, BTreeMap::new(), generation)
+            create_blueprint(datastore, &opctx, BTreeMap::new(), generation)
                 .await,
         );
         let blueprint_id = blueprint.1.id;
@@ -435,7 +435,7 @@ mod test {
         //
         // TODO: add expunged zones to the test (should not be deployed).
         let mut blueprint = create_blueprint(
-            &datastore,
+            datastore,
             &opctx,
             BTreeMap::from([
                 (sled_id1, make_zones(BlueprintZoneDisposition::InService)),

--- a/nexus/src/app/background/tasks/crdb_node_id_collector.rs
+++ b/nexus/src/app/background/tasks/crdb_node_id_collector.rs
@@ -359,7 +359,7 @@ mod tests {
         let (_tx_blueprint, rx_blueprint) = watch::channel(None);
         let mut collector =
             CockroachNodeIdCollector::new(datastore.clone(), rx_blueprint);
-        let result = collector.activate(&opctx).await;
+        let result = collector.activate(opctx).await;
 
         assert_eq!(result, json!({"error": "no blueprint"}));
 
@@ -403,7 +403,7 @@ mod tests {
 
         // The blueprint is empty. This should be fine: we should get no
         // successes and no errors.
-        let result = collector.activate(&opctx).await;
+        let result = collector.activate(opctx).await;
         assert_eq!(result, json!({"nsuccess": 0}));
 
         // Create a few fake CRDB zones, and assign them node IDs in the
@@ -413,7 +413,7 @@ mod tests {
         for (i, zone_id) in crdb_zones.iter().copied().enumerate() {
             datastore
                 .set_cockroachdb_node_id(
-                    &opctx,
+                    opctx,
                     zone_id,
                     format!("test-node-{i}"),
                 )
@@ -427,7 +427,7 @@ mod tests {
         // should instead report that all nodes are recorded successfully.
         let result = collector
             .activate_impl(
-                &opctx,
+                opctx,
                 &FakeCockroachAdminAddrs(
                     crdb_zones
                         .iter()
@@ -525,7 +525,7 @@ mod tests {
             }),
         ));
 
-        let result = collector.activate_impl(&opctx, &crdb_admin_addrs).await;
+        let result = collector.activate_impl(opctx, &crdb_admin_addrs).await;
 
         admin1.verify_and_clear();
         admin2.verify_and_clear();

--- a/nexus/src/app/background/tasks/decommissioned_disk_cleaner.rs
+++ b/nexus/src/app/background/tasks/decommissioned_disk_cleaner.rs
@@ -38,7 +38,10 @@ struct ActivationResults {
     error_count: usize,
 }
 
-const MAX_BATCH: NonZeroU32 = NonZeroU32::new(100).unwrap();
+const MAX_BATCH: NonZeroU32 = unsafe {
+    // Safety: last time I checked, 100 was greater than zero.
+    NonZeroU32::new_unchecked(100)
+};
 
 impl DecommissionedDiskCleaner {
     pub fn new(datastore: Arc<DataStore>, disable: bool) -> Self {

--- a/nexus/src/app/background/tasks/decommissioned_disk_cleaner.rs
+++ b/nexus/src/app/background/tasks/decommissioned_disk_cleaner.rs
@@ -211,7 +211,7 @@ mod tests {
             sled_id.into_untyped_uuid(),
         );
         datastore
-            .physical_disk_insert(&opctx, physical_disk.clone())
+            .physical_disk_insert(opctx, physical_disk.clone())
             .await
             .unwrap();
         id
@@ -290,18 +290,18 @@ mod tests {
     impl TestFixture {
         async fn setup(datastore: &Arc<DataStore>, opctx: &OpContext) -> Self {
             let sled_id = SledUuid::from_untyped_uuid(
-                Uuid::from_str(&SLED_AGENT_UUID).unwrap(),
+                Uuid::from_str(SLED_AGENT_UUID).unwrap(),
             );
 
             let disk_id = make_disk_in_db(datastore, opctx, 0, sled_id).await;
             let (zpool_id, dataset_id, region_id) =
                 add_zpool_dataset_and_region(
-                    &datastore, &opctx, disk_id, sled_id,
+                    datastore, opctx, disk_id, sled_id,
                 )
                 .await;
             datastore
                 .physical_disk_update_policy(
-                    &opctx,
+                    opctx,
                     disk_id,
                     PhysicalDiskPolicy::Expunged,
                 )
@@ -388,7 +388,7 @@ mod tests {
         assert_eq!(results.deleted, 0);
         assert_eq!(results.error_count, 0);
 
-        assert!(!fixture.has_been_cleaned(&datastore).await);
+        assert!(!fixture.has_been_cleaned(datastore).await);
     }
 
     #[nexus_test(server = crate::Server)]
@@ -422,7 +422,7 @@ mod tests {
         assert_eq!(results.deleted, 0);
         assert_eq!(results.error_count, 0);
 
-        assert!(!fixture.has_been_cleaned(&datastore).await);
+        assert!(!fixture.has_been_cleaned(datastore).await);
     }
 
     #[nexus_test(server = crate::Server)]
@@ -444,7 +444,7 @@ mod tests {
             .await
             .unwrap();
 
-        fixture.delete_region(&datastore).await;
+        fixture.delete_region(datastore).await;
 
         // Setup: Disk is decommissioned and has no regions.
         // Expectation: We clean it.
@@ -458,6 +458,6 @@ mod tests {
         assert_eq!(results.deleted, 1);
         assert_eq!(results.error_count, 0);
 
-        assert!(fixture.has_been_cleaned(&datastore).await);
+        assert!(fixture.has_been_cleaned(datastore).await);
     }
 }

--- a/nexus/src/app/background/tasks/dns_config.rs
+++ b/nexus/src/app/background/tasks/dns_config.rs
@@ -200,7 +200,7 @@ mod test {
 
         // Now write generation 2, activate again, and verify that the update
         // was sent to the watcher.
-        write_test_dns_generation(&opctx, &datastore).await;
+        write_test_dns_generation(&opctx, datastore).await;
         assert_eq!(
             watcher.borrow().as_ref().unwrap().generation,
             Generation::from_u32(1)

--- a/nexus/src/app/background/tasks/instance_updater.rs
+++ b/nexus/src/app/background/tasks/instance_updater.rs
@@ -94,7 +94,7 @@ impl InstanceUpdater {
         )
         .await;
         status.destroyed_active_vmms = destroyed_active_vmms.len();
-        self.start_sagas(&opctx, status, &mut sagas, destroyed_active_vmms)
+        self.start_sagas(opctx, status, &mut sagas, destroyed_active_vmms)
             .await;
 
         let failed_active_vmms = find_instances(
@@ -106,7 +106,7 @@ impl InstanceUpdater {
         )
         .await;
         status.failed_active_vmms = failed_active_vmms.len();
-        self.start_sagas(&opctx, status, &mut sagas, failed_active_vmms).await;
+        self.start_sagas(opctx, status, &mut sagas, failed_active_vmms).await;
 
         let terminated_active_migrations = find_instances(
             "terminated active migrations",
@@ -119,7 +119,7 @@ impl InstanceUpdater {
         status.terminated_active_migrations =
             terminated_active_migrations.len();
         self.start_sagas(
-            &opctx,
+            opctx,
             status,
             &mut sagas,
             terminated_active_migrations,
@@ -169,7 +169,7 @@ impl InstanceUpdater {
             let instance_id = instance.id();
             let saga = async {
                 let (.., authz_instance) =
-                    LookupPath::new(&opctx, &self.datastore)
+                    LookupPath::new(opctx, &self.datastore)
                         .instance_id(instance_id)
                         .lookup_for(authz::Action::Modify)
                         .await?;

--- a/nexus/src/app/background/tasks/instance_watcher.rs
+++ b/nexus/src/app/background/tasks/instance_watcher.rs
@@ -64,7 +64,10 @@ pub(crate) struct InstanceWatcher {
 /// forgotten about the instances it was supposed to know about.  For now, we
 /// tune this pretty low, choosing safety over low recovery latency for these
 /// relatively rare events.
-const MAX_CONCURRENT_CHECKS: NonZeroU32 = NonZeroU32::new(16).unwrap();
+const MAX_CONCURRENT_CHECKS: NonZeroU32 = unsafe {
+    // Safety: last time I checked, 16 was greater than zero.
+    NonZeroU32::new_unchecked(16)
+};
 
 impl InstanceWatcher {
     pub(crate) fn new(

--- a/nexus/src/app/background/tasks/inventory_collection.rs
+++ b/nexus/src/app/background/tasks/inventory_collection.rs
@@ -223,7 +223,7 @@ impl nexus_inventory::SledAgentEnumerator for DbSledAgentEnumerator<'_> {
             Ok(self
                 .datastore
                 .sled_list_all_batched(
-                    &self.opctx,
+                    self.opctx,
                     SledFilter::QueryDuringInventory,
                 )
                 .await
@@ -386,8 +386,7 @@ mod test {
             cptestctx.logctx.log.clone(),
             datastore.clone(),
         );
-        let db_enum =
-            DbSledAgentEnumerator { opctx: &opctx, datastore: &datastore };
+        let db_enum = DbSledAgentEnumerator { opctx: &opctx, datastore };
 
         // There will be two sled agents set up as part of the test context.
         let initial_found_urls = db_enum.list_sled_agents().await.unwrap();

--- a/nexus/src/app/background/tasks/metrics_producer_gc.rs
+++ b/nexus/src/app/background/tasks/metrics_producer_gc.rs
@@ -227,7 +227,7 @@ mod tests {
         // Move our producer backwards in time: pretend it registered two hours
         // ago, which should result in it being pruned.
         set_time_modified(
-            &datastore,
+            datastore,
             producer.id,
             Utc::now() - chrono::TimeDelta::hours(2),
         )

--- a/nexus/src/app/background/tasks/read_only_region_replacement_start.rs
+++ b/nexus/src/app/background/tasks/read_only_region_replacement_start.rs
@@ -199,7 +199,7 @@ mod test {
         let disk_test = DiskTest::new(cptestctx).await;
 
         let client = &cptestctx.external_client;
-        let project = create_project(&client, "testing").await;
+        let project = create_project(client, "testing").await;
         let project_id = project.identity.id;
 
         let nexus = &cptestctx.server.server_context().nexus;
@@ -257,7 +257,7 @@ mod test {
 
         // Create the fake snapshot
 
-        let (.., authz_project) = LookupPath::new(&opctx, &datastore)
+        let (.., authz_project) = LookupPath::new(&opctx, datastore)
             .project_id(project_id)
             .lookup_for(authz::Action::CreateChild)
             .await

--- a/nexus/src/app/background/tasks/region_snapshot_replacement_start.rs
+++ b/nexus/src/app/background/tasks/region_snapshot_replacement_start.rs
@@ -218,7 +218,7 @@ impl RegionSnapshotReplacementDetector {
                 match self
                     .datastore
                     .set_region_snapshot_replacement_complete_from_requested(
-                        &opctx, request.id,
+                        opctx, request.id,
                     )
                     .await
                 {
@@ -434,7 +434,7 @@ mod test {
         let disk_test = DiskTest::new(cptestctx).await;
 
         let client = &cptestctx.external_client;
-        let project = create_project(&client, "testing").await;
+        let project = create_project(client, "testing").await;
         let project_id = project.identity.id;
 
         let nexus = &cptestctx.server.server_context().nexus;
@@ -482,7 +482,7 @@ mod test {
 
         // Create the fake snapshot
 
-        let (.., authz_project) = LookupPath::new(&opctx, &datastore)
+        let (.., authz_project) = LookupPath::new(&opctx, datastore)
             .project_id(project_id)
             .lookup_for(authz::Action::CreateChild)
             .await

--- a/nexus/src/app/background/tasks/region_snapshot_replacement_step.rs
+++ b/nexus/src/app/background/tasks/region_snapshot_replacement_step.rs
@@ -240,10 +240,7 @@ impl RegionSnapshotReplacementFindAffected {
 
             let volumes = match self
                 .datastore
-                .find_volumes_referencing_socket_addr(
-                    &opctx,
-                    target_addr.into(),
-                )
+                .find_volumes_referencing_socket_addr(opctx, target_addr.into())
                 .await
             {
                 Ok(volumes) => volumes,
@@ -850,20 +847,20 @@ mod test {
         // replaced
 
         let new_volume_1_id =
-            add_fake_volume_for_snapshot_addr(&datastore, snapshot_addr).await;
+            add_fake_volume_for_snapshot_addr(datastore, snapshot_addr).await;
         let new_volume_2_id =
-            add_fake_volume_for_snapshot_addr(&datastore, snapshot_addr).await;
+            add_fake_volume_for_snapshot_addr(datastore, snapshot_addr).await;
 
         // Add some fake volumes that do not
 
         let other_volume_1_id = add_fake_volume_for_snapshot_addr(
-            &datastore,
+            datastore,
             "[fd00:1122:3344::101]:1000".parse().unwrap(),
         )
         .await;
 
         let other_volume_2_id = add_fake_volume_for_snapshot_addr(
-            &datastore,
+            datastore,
             "[fd12:5544:3344::912]:3901".parse().unwrap(),
         )
         .await;

--- a/nexus/src/app/background/tasks/saga_recovery.rs
+++ b/nexus/src/app/background/tasks/saga_recovery.rs
@@ -425,7 +425,7 @@ async fn list_sagas_in_progress(
     let log = &opctx.log;
     debug!(log, "listing candidate sagas for recovery");
     let result = datastore
-        .saga_list_recovery_candidates_batched(&opctx, sec_id)
+        .saga_list_recovery_candidates_batched(opctx, sec_id)
         .await
         .internal_context("listing in-progress sagas for saga recovery")
         .map(|list| {
@@ -619,7 +619,7 @@ mod test {
         ));
         let sec_client =
             steno::sec(log.new(o!("component" => "SEC")), storage.clone());
-        let uctx = Arc::new(TestContext::new(&log, storage.clone()));
+        let uctx = Arc::new(TestContext::new(log, storage.clone()));
         (storage, sec_client, uctx)
     }
 
@@ -661,7 +661,7 @@ mod test {
         let sec_log = log.new(o!("component" => "SEC"));
         let opctx = OpContext::for_tests(
             log,
-            Arc::clone(&db_datastore) as Arc<dyn nexus_auth::storage::Storage>,
+            Arc::clone(db_datastore) as Arc<dyn nexus_auth::storage::Storage>,
         );
         let saga_recovery_opctx =
             opctx.child_with_authn(authn::Context::internal_saga_recovery());
@@ -748,7 +748,7 @@ mod test {
         let sec_log = log.new(o!("component" => "SEC"));
         let opctx = OpContext::for_tests(
             log,
-            Arc::clone(&db_datastore) as Arc<dyn nexus_auth::storage::Storage>,
+            Arc::clone(db_datastore) as Arc<dyn nexus_auth::storage::Storage>,
         );
         let saga_recovery_opctx =
             opctx.child_with_authn(authn::Context::internal_saga_recovery());

--- a/nexus/src/app/background/tasks/sync_switch_configuration.rs
+++ b/nexus/src/app/background/tasks/sync_switch_configuration.rs
@@ -1402,8 +1402,8 @@ async fn ensure_loopback_deleted(
     address: IpAddr,
 ) -> Result<(), serde_json::Value> {
     let result = match &address {
-        IpAddr::V4(a) => client.loopback_ipv4_delete(&a).await,
-        IpAddr::V6(a) => client.loopback_ipv6_delete(&a).await,
+        IpAddr::V4(a) => client.loopback_ipv4_delete(a).await,
+        IpAddr::V6(a) => client.loopback_ipv6_delete(a).await,
     };
 
     match result {
@@ -1687,7 +1687,7 @@ fn static_routes_to_add(
 
     // find routes to add
     for (switch_location, routes_wanted) in desired_static_routes {
-        let routes_on_switch = match current_static_routes.get(&switch_location)
+        let routes_on_switch = match current_static_routes.get(switch_location)
         {
             Some(routes) => routes,
             None => {
@@ -1787,7 +1787,7 @@ async fn apply_switch_port_changes(
     log: &slog::Logger,
 ) {
     for (location, switch_port, change) in changes {
-        let client = match dpd_clients.get(&location) {
+        let client = match dpd_clients.get(location) {
             Some(client) => client,
             None => {
                 error!(
@@ -1839,9 +1839,8 @@ async fn apply_switch_port_changes(
 
         match change {
             PortSettingsChange::Apply(settings) => {
-                let dpd_port_settings = match api_to_dpd_port_settings(
-                    &settings,
-                ) {
+                let dpd_port_settings = match api_to_dpd_port_settings(settings)
+                {
                     Ok(settings) => settings,
                     Err(e) => {
                         error!(

--- a/nexus/src/app/background/tasks/tuf_artifact_replication.rs
+++ b/nexus/src/app/background/tasks/tuf_artifact_replication.rs
@@ -568,7 +568,7 @@ impl ArtifactReplication {
     async fn list_sleds(&self, opctx: &OpContext) -> Result<Vec<Sled>> {
         Ok(self
             .datastore
-            .sled_list_all_batched(&opctx, SledFilter::TufArtifactReplication)
+            .sled_list_all_batched(opctx, SledFilter::TufArtifactReplication)
             .await?
             .into_iter()
             .map(|sled| Sled {

--- a/nexus/src/app/background/tasks/v2p_mappings.rs
+++ b/nexus/src/app/background/tasks/v2p_mappings.rs
@@ -113,7 +113,7 @@ impl BackgroundTask for V2PManager {
                 //
                 info!(&log, "v2p mappings to delete"; "sled" => sled.serial_number(), "mappings" => ?v2p_to_del);
                 for mapping in v2p_to_del {
-                    if let Err(e) = client.del_v2p(&mapping).await {
+                    if let Err(e) = client.del_v2p(mapping).await {
                         error!(
                             &log,
                             "failed to delete v2p mapping from sled";

--- a/nexus/src/app/background/tasks/vpc_routes.rs
+++ b/nexus/src/app/background/tasks/vpc_routes.rs
@@ -83,7 +83,7 @@ impl BackgroundTask for VpcRouteManager {
                     let client = sled_client_from_address(
                         sled.id(),
                         sled.address(),
-                        &log,
+                        log,
                     );
                     (sled, client)
                 })

--- a/nexus/src/app/crucible.rs
+++ b/nexus/src/app/crucible.rs
@@ -1248,7 +1248,7 @@ impl super::Nexus {
         futures::stream::iter(datasets_and_snapshots)
             .map(|(dataset, region_snapshot)| async move {
                 self.delete_crucible_running_snapshot_impl(
-                    &log,
+                    log,
                     &dataset,
                     region_snapshot.region_id,
                     region_snapshot.snapshot_id,
@@ -1286,7 +1286,7 @@ impl super::Nexus {
         futures::stream::iter(datasets_and_snapshots)
             .map(|(dataset, region_snapshot)| async move {
                 self.delete_crucible_snapshot_impl(
-                    &log,
+                    log,
                     &dataset,
                     region_snapshot.region_id,
                     region_snapshot.snapshot_id,
@@ -1342,7 +1342,7 @@ impl super::Nexus {
         futures::stream::iter(datasets_and_snapshots)
             .map(|(dataset, region_snapshot)| async move {
                 self.ensure_crucible_running_snapshot_impl(
-                    &log,
+                    log,
                     &dataset,
                     region_snapshot.region_id,
                     region_snapshot.snapshot_id,

--- a/nexus/src/app/deployment.rs
+++ b/nexus/src/app/deployment.rs
@@ -188,7 +188,7 @@ impl super::Nexus {
             ))
         })?;
 
-        self.blueprint_add(&opctx, &blueprint).await?;
+        self.blueprint_add(opctx, &blueprint).await?;
         Ok(blueprint)
     }
 
@@ -197,7 +197,7 @@ impl super::Nexus {
         opctx: &OpContext,
         blueprint: Blueprint,
     ) -> Result<(), Error> {
-        let _ = self.blueprint_add(&opctx, &blueprint).await?;
+        let _ = self.blueprint_add(opctx, &blueprint).await?;
         Ok(())
     }
 }

--- a/nexus/src/app/device_auth.rs
+++ b/nexus/src/app/device_auth.rs
@@ -212,7 +212,7 @@ impl super::Nexus {
         use DeviceAccessTokenResponse::*;
         match self
             .device_access_token_fetch(
-                &opctx,
+                opctx,
                 params.client_id,
                 params.device_code,
             )

--- a/nexus/src/app/disk.rs
+++ b/nexus/src/app/disk.rs
@@ -269,7 +269,7 @@ impl super::Nexus {
         new_state: &DiskRuntimeState,
     ) -> Result<(), Error> {
         let log = &self.log;
-        let (.., authz_disk) = LookupPath::new(&opctx, &self.db_datastore)
+        let (.., authz_disk) = LookupPath::new(opctx, &self.db_datastore)
             .disk_id(id)
             .lookup_for(authz::Action::Modify)
             .await?;
@@ -361,8 +361,7 @@ impl super::Nexus {
             .fetch()
             .await?;
 
-        self.volume_remove_read_only_parent(&opctx, db_disk.volume_id())
-            .await?;
+        self.volume_remove_read_only_parent(opctx, db_disk.volume_id()).await?;
 
         Ok(())
     }

--- a/nexus/src/app/external_endpoints.rs
+++ b/nexus/src/app/external_endpoints.rs
@@ -1245,17 +1245,17 @@ mod test {
 
         // Basic cases: look up a few Silos by name.
         let authority = Authority::from_static("silo1.sys.oxide1.test");
-        let ae1 = endpoint_for_authority(&log, &authority, &watch_rx).unwrap();
+        let ae1 = endpoint_for_authority(log, &authority, &watch_rx).unwrap();
         assert_eq!(ae1, *e1);
         let authority = Authority::from_static("silo1.sys.oxide2.test");
-        let ae1 = endpoint_for_authority(&log, &authority, &watch_rx).unwrap();
+        let ae1 = endpoint_for_authority(log, &authority, &watch_rx).unwrap();
         assert_eq!(ae1, *e1);
         let authority = Authority::from_static("silo2.sys.oxide1.test");
-        let ae2 = endpoint_for_authority(&log, &authority, &watch_rx).unwrap();
+        let ae2 = endpoint_for_authority(log, &authority, &watch_rx).unwrap();
         assert_eq!(ae2, *e2);
         // The port number in the authority should be ignored.
         let authority = Authority::from_static("silo3.sys.oxide1.test:456");
-        let ae3 = endpoint_for_authority(&log, &authority, &watch_rx).unwrap();
+        let ae3 = endpoint_for_authority(log, &authority, &watch_rx).unwrap();
         assert_eq!(ae3, *e3);
         // We should get back a default endpoint if we use a server name that's
         // not known.  That includes any IPv4 or IPv6 address, too.  The default
@@ -1269,7 +1269,7 @@ mod test {
         ] {
             let authority = Authority::from_static(name);
             let ae =
-                endpoint_for_authority(&log, &authority, &watch_rx).unwrap();
+                endpoint_for_authority(log, &authority, &watch_rx).unwrap();
             assert_eq!(ae, *e3);
         }
 
@@ -1523,7 +1523,7 @@ mod test {
             {
                 println!("config {:?} endpoint {:?}", rx_label, name);
                 let result =
-                    endpoint_for_authority(&log, &authority, rx_channel);
+                    endpoint_for_authority(log, &authority, rx_channel);
                 match result {
                     Err(Error::ServiceUnavailable { internal_message }) => {
                         assert_eq!(rx_label, "none");

--- a/nexus/src/app/instance_network.rs
+++ b/nexus/src/app/instance_network.rs
@@ -284,7 +284,7 @@ pub(crate) async fn instance_ensure_dpd_config(
     // traffic destined to those IPs, so there's nothing to configure and
     // it's safe to return early.
     let network_interface = match datastore
-        .derive_guest_network_interface_info(&opctx, &authz_instance)
+        .derive_guest_network_interface_info(opctx, &authz_instance)
         .await?
         .into_iter()
         .find(|interface| interface.primary)
@@ -309,7 +309,7 @@ pub(crate) async fn instance_ensure_dpd_config(
             "instance_id" => %instance_id);
 
     let ips =
-        datastore.instance_lookup_external_ips(&opctx, instance_id).await?;
+        datastore.instance_lookup_external_ips(opctx, instance_id).await?;
 
     let (ips_of_interest, must_all_be_attached) = if let Some(wanted_id) =
         ip_filter
@@ -442,7 +442,7 @@ pub(crate) async fn probe_ensure_dpd_config(
     // traffic destined to those IPs, so there's nothing to configure and
     // it's safe to return early.
     let network_interface = match datastore
-        .derive_probe_network_interface_info(&opctx, probe_id)
+        .derive_probe_network_interface_info(opctx, probe_id)
         .await?
         .into_iter()
         .find(|interface| interface.primary)
@@ -466,7 +466,7 @@ pub(crate) async fn probe_ensure_dpd_config(
     info!(log, "looking up probe's external IPs";
             "probe_id" => %probe_id);
 
-    let ips = datastore.probe_lookup_external_ips(&opctx, probe_id).await?;
+    let ips = datastore.probe_lookup_external_ips(opctx, probe_id).await?;
 
     if let Some(wanted_index) = ip_index_filter {
         if let None = ips.get(wanted_index) {
@@ -552,7 +552,7 @@ pub(crate) async fn instance_delete_dpd_config(
         datastore.instance_lookup_external_ips(opctx, instance_id).await?;
 
     for entry in external_ips {
-        external_ip_delete_dpd_config_inner(&datastore, &log, opctx, &entry)
+        external_ip_delete_dpd_config_inner(datastore, log, opctx, &entry)
             .await?;
     }
 
@@ -589,7 +589,7 @@ pub(crate) async fn probe_delete_dpd_config(
     let mut errors = vec![];
     for entry in external_ips {
         // Soft delete the NAT entry
-        match datastore.ipv4_nat_delete_by_external_ip(&opctx, &entry).await {
+        match datastore.ipv4_nat_delete_by_external_ip(opctx, &entry).await {
             Ok(_) => Ok(()),
             Err(err) => match err {
                 Error::ObjectNotFound { .. } => {
@@ -669,7 +669,7 @@ pub(crate) async fn delete_dpd_config_by_entry(
             "id" => ?nat_entry.id,
             "version_added" => %nat_entry.external_address.0);
 
-    match datastore.ipv4_nat_delete(&opctx, nat_entry).await {
+    match datastore.ipv4_nat_delete(opctx, nat_entry).await {
         Ok(_) => {}
         Err(err) => match err {
             Error::ObjectNotFound { .. } => {
@@ -704,7 +704,7 @@ async fn external_ip_delete_dpd_config_inner(
     external_ip: &ExternalIp,
 ) -> Result<(), Error> {
     // Soft delete the NAT entry
-    match datastore.ipv4_nat_delete_by_external_ip(&opctx, external_ip).await {
+    match datastore.ipv4_nat_delete_by_external_ip(opctx, external_ip).await {
         Ok(_) => Ok(()),
         Err(err) => match err {
             Error::ObjectNotFound { .. } => {

--- a/nexus/src/app/internet_gateway.rs
+++ b/nexus/src/app/internet_gateway.rs
@@ -75,7 +75,7 @@ impl super::Nexus {
             db::model::InternetGateway::new(id, authz_vpc.id(), params.clone());
         let (_, router) = self
             .db_datastore
-            .vpc_create_internet_gateway(&opctx, &authz_vpc, router)
+            .vpc_create_internet_gateway(opctx, &authz_vpc, router)
             .await?;
 
         self.vpc_needed_notify_sleds();
@@ -203,7 +203,7 @@ impl super::Nexus {
 
         // need to use this method so it works for non-fleet users
         let (authz_pool, ..) =
-            self.silo_ip_pool_fetch(&opctx, &params.ip_pool).await?;
+            self.silo_ip_pool_fetch(opctx, &params.ip_pool).await?;
 
         let id = Uuid::new_v4();
         let route = db::model::InternetGatewayIpPool::new(
@@ -214,7 +214,7 @@ impl super::Nexus {
         );
         let route = self
             .db_datastore
-            .internet_gateway_attach_ip_pool(&opctx, &authz_igw, route)
+            .internet_gateway_attach_ip_pool(opctx, &authz_igw, route)
             .await?;
 
         self.vpc_needed_notify_sleds();
@@ -339,7 +339,7 @@ impl super::Nexus {
         );
         let route = self
             .db_datastore
-            .internet_gateway_attach_ip_address(&opctx, &authz_igw, route)
+            .internet_gateway_attach_ip_address(opctx, &authz_igw, route)
             .await?;
 
         self.vpc_needed_notify_sleds();

--- a/nexus/src/app/ip_pool.rs
+++ b/nexus/src/app/ip_pool.rs
@@ -34,13 +34,13 @@ use uuid::Uuid;
 fn not_found_from_lookup(pool_lookup: &lookup::IpPool<'_>) -> Error {
     match pool_lookup {
         lookup::IpPool::Name(_, name) => {
-            Error::not_found_by_name(ResourceType::IpPool, &name)
+            Error::not_found_by_name(ResourceType::IpPool, name)
         }
         lookup::IpPool::OwnedName(_, name) => {
-            Error::not_found_by_name(ResourceType::IpPool, &name)
+            Error::not_found_by_name(ResourceType::IpPool, name)
         }
         lookup::IpPool::PrimaryKey(_, id) => {
-            Error::not_found_by_id(ResourceType::IpPool, &id)
+            Error::not_found_by_id(ResourceType::IpPool, id)
         }
         lookup::IpPool::Error(_, error) => error.to_owned(),
     }
@@ -173,7 +173,7 @@ impl super::Nexus {
         }
 
         let (authz_silo,) = self
-            .silo_lookup(&opctx, silo_link.silo.clone())?
+            .silo_lookup(opctx, silo_link.silo.clone())?
             .lookup_for(authz::Action::Modify)
             .await?;
         self.db_datastore

--- a/nexus/src/app/login.rs
+++ b/nexus/src/app/login.rs
@@ -18,7 +18,7 @@ impl super::Nexus {
     ) -> Result<HttpResponseFound, HttpError> {
         let (.., identity_provider) = self
             .datastore()
-            .identity_provider_lookup(&opctx, silo_name, provider_name)
+            .identity_provider_lookup(opctx, silo_name, provider_name)
             .await?;
 
         match identity_provider {
@@ -53,14 +53,14 @@ impl super::Nexus {
     ) -> Result<(ConsoleSession, String), HttpError> {
         let (authz_silo, db_silo, identity_provider) = self
             .datastore()
-            .identity_provider_lookup(&opctx, silo_name, provider_name)
+            .identity_provider_lookup(opctx, silo_name, provider_name)
             .await?;
         let (authenticated_subject, relay_state_string) =
             match identity_provider {
                 IdentityProviderType::Saml(saml_identity_provider) => {
                     let body_bytes = body_bytes.as_str()?;
                     saml_identity_provider.authenticated_subject(
-                        &body_bytes,
+                        body_bytes,
                         self.samael_max_issue_delay(),
                     )?
                 }
@@ -69,7 +69,7 @@ impl super::Nexus {
             relay_state_string.and_then(|v| RelayState::from_encoded(v).ok());
         let user = self
             .silo_user_from_authenticated_subject(
-                &opctx,
+                opctx,
                 &authz_silo,
                 &db_silo,
                 &authenticated_subject,

--- a/nexus/src/app/mod.rs
+++ b/nexus/src/app/mod.rs
@@ -1058,7 +1058,7 @@ async fn switch_zone_address_mappings(
                 return Err(e.to_string());
             }
         };
-        match map_switch_zone_addrs(&log, switch_zone_addresses).await {
+        match map_switch_zone_addrs(log, switch_zone_addresses).await {
             Ok(mappings) => {
                 return Ok(mappings);
             }

--- a/nexus/src/app/oximeter.rs
+++ b/nexus/src/app/oximeter.rs
@@ -36,7 +36,7 @@ impl super::Nexus {
         // Insert the Oximeter instance into the DB. Note that this _updates_ the record,
         // specifically, the time_modified, ip, and port columns, if the instance has already been
         // registered.
-        let db_info = db::model::OximeterInfo::new(&oximeter_info);
+        let db_info = db::model::OximeterInfo::new(oximeter_info);
         self.db_datastore.oximeter_create(opctx, &db_info).await?;
         info!(
             self.log,
@@ -205,8 +205,8 @@ pub(crate) async fn unassign_producer(
             datastore.oximeter_lookup(opctx, &collector_id).await?;
         let address =
             SocketAddr::new(oximeter_info.ip.ip(), *oximeter_info.port);
-        let client = build_oximeter_client(&log, &id, address);
-        if let Err(e) = client.producer_delete(&id).await {
+        let client = build_oximeter_client(log, id, address);
+        if let Err(e) = client.producer_delete(id).await {
             error!(
                 log,
                 "failed to delete producer from collector";

--- a/nexus/src/app/probe.rs
+++ b/nexus/src/app/probe.rs
@@ -45,7 +45,7 @@ impl super::Nexus {
     ) -> LookupResult<ProbeInfo> {
         let (.., authz_project) =
             project_lookup.lookup_for(authz::Action::CreateChild).await?;
-        self.db_datastore.probe_get(opctx, &authz_project, &name_or_id).await
+        self.db_datastore.probe_get(opctx, &authz_project, name_or_id).await
     }
 
     /// Create a probe. This adds the probe to the data store and sets up the
@@ -63,7 +63,7 @@ impl super::Nexus {
         // resolve NameOrId into authz::IpPool
         let pool = match &new_probe_params.ip_pool {
             Some(pool) => Some(
-                self.ip_pool_lookup(opctx, &pool)?
+                self.ip_pool_lookup(opctx, pool)?
                     .lookup_for(authz::Action::CreateChild)
                     .await?
                     .0,

--- a/nexus/src/app/rack.rs
+++ b/nexus/src/app/rack.rs
@@ -86,7 +86,7 @@ impl super::Nexus {
         opctx: &OpContext,
         pagparams: &DataPageParams<'_, Uuid>,
     ) -> ListResultVec<db::model::Rack> {
-        self.db_datastore.rack_list(&opctx, pagparams).await
+        self.db_datastore.rack_list(opctx, pagparams).await
     }
 
     pub(crate) async fn rack_lookup(
@@ -361,7 +361,7 @@ impl super::Nexus {
                     );
 
                     self.populate_switch_ports(
-                        &opctx,
+                        opctx,
                         &qsfp_ports,
                         switch.to_string().parse().unwrap(),
                     )
@@ -376,7 +376,7 @@ impl super::Nexus {
                 );
                 for (switch, ports) in port_mappings {
                     self.populate_switch_ports(
-                        &opctx,
+                        opctx,
                         &ports,
                         switch.to_string().parse().unwrap(),
                     )
@@ -442,7 +442,7 @@ impl super::Nexus {
             match self
                 .db_datastore
                 .address_lot_create(
-                    &opctx,
+                    opctx,
                     &AddressLotCreate {
                         identity: IdentityMetadataCreateParams {
                             name: address_lot_name,
@@ -477,7 +477,7 @@ impl super::Nexus {
             match self
                 .db_datastore
                 .bgp_create_announce_set(
-                    &opctx,
+                    opctx,
                     &BgpAnnounceSetCreate {
                         identity: IdentityMetadataCreateParams {
                             name: announce_set_name.clone(),
@@ -515,7 +515,7 @@ impl super::Nexus {
             match self
                 .db_datastore
                 .bgp_config_create(
-                    &opctx,
+                    opctx,
                     &BgpConfigCreate {
                         identity: IdentityMetadataCreateParams {
                             name: bgp_config_name,
@@ -762,7 +762,7 @@ impl super::Nexus {
     /// See RFD 278 for additional context.
     pub(crate) async fn await_rack_initialization(&self, opctx: &OpContext) {
         loop {
-            let result = self.rack_lookup(&opctx, &self.rack_id).await;
+            let result = self.rack_lookup(opctx, &self.rack_id).await;
             match result {
                 Ok(rack) => {
                     if rack.initialized {

--- a/nexus/src/app/sagas/common_storage.rs
+++ b/nexus/src/app/sagas/common_storage.rs
@@ -77,7 +77,7 @@ pub(crate) async fn call_pantry_attach_for_disk(
     disk_id: Uuid,
     pantry_address: SocketAddrV6,
 ) -> Result<(), ActionError> {
-    let (.., disk) = LookupPath::new(opctx, &nexus.datastore())
+    let (.., disk) = LookupPath::new(opctx, nexus.datastore())
         .disk_id(disk_id)
         .fetch_for(authz::Action::Modify)
         .await
@@ -93,7 +93,7 @@ pub(crate) async fn call_pantry_attach_for_disk(
         .map_err(ActionError::action_failed)?;
 
     let volume_construction_request: VolumeConstructionRequest =
-        serde_json::from_str(&disk_volume.data()).map_err(|e| {
+        serde_json::from_str(disk_volume.data()).map_err(|e| {
             ActionError::action_failed(Error::internal_error(&format!(
                 "failed to deserialize disk {} volume data: {}",
                 disk.id(),

--- a/nexus/src/app/sagas/disk_delete.rs
+++ b/nexus/src/app/sagas/disk_delete.rs
@@ -208,7 +208,7 @@ pub(crate) mod test {
 
     async fn create_disk(cptestctx: &ControlPlaneTestContext) -> Disk {
         let nexus = &cptestctx.server.server_context().nexus;
-        let opctx = test_opctx(&cptestctx);
+        let opctx = test_opctx(cptestctx);
 
         let project_selector = params::ProjectSelector {
             project: Name::try_from(PROJECT_NAME.to_string()).unwrap().into(),
@@ -235,10 +235,10 @@ pub(crate) mod test {
         let client = &cptestctx.external_client;
         let nexus = &cptestctx.server.server_context().nexus;
         let project_id = create_project(client, PROJECT_NAME).await.identity.id;
-        let disk = create_disk(&cptestctx).await;
+        let disk = create_disk(cptestctx).await;
 
         // Build the saga DAG with the provided test parameters and run it.
-        let opctx = test_opctx(&cptestctx);
+        let opctx = test_opctx(cptestctx);
         let params = Params {
             serialized_authn: Serialized::for_opctx(&opctx),
             project_id,
@@ -257,10 +257,10 @@ pub(crate) mod test {
         let client = &cptestctx.external_client;
         let nexus = &cptestctx.server.server_context().nexus;
         let project_id = create_project(client, PROJECT_NAME).await.identity.id;
-        let disk = create_disk(&cptestctx).await;
+        let disk = create_disk(cptestctx).await;
 
         // Build the saga DAG with the provided test parameters
-        let opctx = test_opctx(&cptestctx);
+        let opctx = test_opctx(cptestctx);
         let params = Params {
             serialized_authn: Serialized::for_opctx(&opctx),
             project_id,
@@ -274,7 +274,7 @@ pub(crate) mod test {
         .await;
 
         crate::app::sagas::disk_create::test::verify_clean_slate(
-            &cptestctx, &test,
+            cptestctx, &test,
         )
         .await;
     }

--- a/nexus/src/app/sagas/finalize_disk.rs
+++ b/nexus/src/app/sagas/finalize_disk.rs
@@ -144,7 +144,7 @@ async fn sfd_set_finalizing_state(
     );
 
     let (.., authz_disk, db_disk) =
-        LookupPath::new(&opctx, &osagactx.datastore())
+        LookupPath::new(&opctx, osagactx.datastore())
             .disk_id(params.disk_id)
             .fetch_for(authz::Action::Modify)
             .await
@@ -167,7 +167,7 @@ async fn sfd_set_finalizing_state(
             // Record the disk's new generation number as this saga node's output. It
             // will be important later to *only* transition this disk out of finalizing
             // if the generation number matches what *this* saga is doing.
-            let (.., db_disk) = LookupPath::new(&opctx, &osagactx.datastore())
+            let (.., db_disk) = LookupPath::new(&opctx, osagactx.datastore())
                 .disk_id(params.disk_id)
                 .fetch_for(authz::Action::Read)
                 .await
@@ -195,7 +195,7 @@ async fn sfd_set_finalizing_state_undo(
     );
 
     let (.., authz_disk, db_disk) =
-        LookupPath::new(&opctx, &osagactx.datastore())
+        LookupPath::new(&opctx, osagactx.datastore())
             .disk_id(params.disk_id)
             .fetch_for(authz::Action::Modify)
             .await
@@ -260,7 +260,7 @@ async fn sfd_get_pantry_address(
         &params.serialized_authn,
     );
 
-    let (.., db_disk) = LookupPath::new(&opctx, &osagactx.datastore())
+    let (.., db_disk) = LookupPath::new(&opctx, osagactx.datastore())
         .disk_id(params.disk_id)
         .fetch_for(authz::Action::Modify)
         .await
@@ -289,7 +289,7 @@ async fn sfd_call_pantry_detach_for_disk(
 
     call_pantry_detach(
         sagactx.user_data().nexus(),
-        &log,
+        log,
         params.disk_id,
         pantry_address,
     )
@@ -316,7 +316,7 @@ async fn sfd_clear_pantry_address(
 
     info!(log, "setting disk {} pantry to None", params.disk_id);
 
-    let (.., authz_disk) = LookupPath::new(&opctx, &datastore)
+    let (.., authz_disk) = LookupPath::new(&opctx, datastore)
         .disk_id(params.disk_id)
         .lookup_for(authz::Action::Modify)
         .await
@@ -342,7 +342,7 @@ async fn sfd_set_detached_state(
     );
 
     let (.., authz_disk, db_disk) =
-        LookupPath::new(&opctx, &osagactx.datastore())
+        LookupPath::new(&opctx, osagactx.datastore())
             .disk_id(params.disk_id)
             .fetch_for(authz::Action::Modify)
             .await

--- a/nexus/src/app/sagas/instance_common.rs
+++ b/nexus/src/app/sagas/instance_common.rs
@@ -104,7 +104,7 @@ pub async fn create_and_insert_vmm_record(
     );
 
     let vmm = datastore
-        .vmm_insert(&opctx, vmm)
+        .vmm_insert(opctx, vmm)
         .await
         .map_err(ActionError::action_failed)?;
 
@@ -153,7 +153,7 @@ pub async fn instance_ip_move_state(
     let osagactx = sagactx.user_data();
     let datastore = osagactx.datastore();
     let opctx =
-        crate::context::op_context_for_saga_action(&sagactx, serialized_authn);
+        crate::context::op_context_for_saga_action(sagactx, serialized_authn);
 
     if !new_ip.do_saga {
         return Ok(true);
@@ -199,7 +199,7 @@ pub(super) async fn instance_ip_get_instance_state(
     let osagactx = sagactx.user_data();
     let datastore = osagactx.datastore();
     let opctx =
-        crate::context::op_context_for_saga_action(&sagactx, serialized_authn);
+        crate::context::op_context_for_saga_action(sagactx, serialized_authn);
 
     let inst_and_vmm = datastore
         .instance_fetch_with_vmm(&opctx, authz_instance)
@@ -337,7 +337,7 @@ pub async fn instance_ip_add_nat(
     let osagactx = sagactx.user_data();
     let datastore = osagactx.datastore();
     let opctx =
-        crate::context::op_context_for_saga_action(&sagactx, serialized_authn);
+        crate::context::op_context_for_saga_action(sagactx, serialized_authn);
 
     // No physical sled? Don't push NAT.
     let Some(sled_uuid) = sled_uuid else {
@@ -355,7 +355,7 @@ pub async fn instance_ip_add_nat(
 
     // Querying sleds requires fleet access; use the instance allocator context
     // for this.
-    let (.., sled) = LookupPath::new(&osagactx.nexus().opctx_alloc, &datastore)
+    let (.., sled) = LookupPath::new(&osagactx.nexus().opctx_alloc, datastore)
         .sled_id(sled_uuid.into_untyped_uuid())
         .fetch()
         .await
@@ -392,7 +392,7 @@ pub async fn instance_ip_remove_nat(
 ) -> Result<(), ActionError> {
     let osagactx = sagactx.user_data();
     let opctx =
-        crate::context::op_context_for_saga_action(&sagactx, serialized_authn);
+        crate::context::op_context_for_saga_action(sagactx, serialized_authn);
 
     // No physical sled? Don't push NAT.
     if sled_uuid.is_none() {

--- a/nexus/src/app/sagas/instance_ip_attach.rs
+++ b/nexus/src/app/sagas/instance_ip_attach.rs
@@ -127,7 +127,7 @@ async fn siia_begin_attach_ip(
         }
         // Set the parent of an existing floating IP to the new instance's ID.
         ExternalIpAttach::Floating { floating_ip } => datastore
-            .floating_ip_begin_attach(&opctx, &floating_ip, instance_id, false)
+            .floating_ip_begin_attach(&opctx, floating_ip, instance_id, false)
             .await
             .map_err(ActionError::action_failed)
             .map(|(external_ip, do_saga)| ModifyStateForExternalIp {
@@ -349,7 +349,7 @@ pub(crate) mod test {
     const FIP_NAME: &str = "affogato";
 
     pub async fn ip_manip_test_setup(client: &ClientTestContext) -> Uuid {
-        create_default_ip_pool(&client).await;
+        create_default_ip_pool(client).await;
         let project = create_project(client, PROJECT_NAME).await;
         create_floating_ip(
             client,
@@ -408,7 +408,7 @@ pub(crate) mod test {
 
         let opctx = test_helpers::test_opctx(cptestctx);
         let datastore = &nexus.db_datastore;
-        let _project_id = ip_manip_test_setup(&client).await;
+        let _project_id = ip_manip_test_setup(client).await;
         let instance =
             create_instance(client, PROJECT_NAME, INSTANCE_NAME).await;
 
@@ -523,7 +523,7 @@ pub(crate) mod test {
 
         let opctx = test_helpers::test_opctx(cptestctx);
         let datastore = &nexus.db_datastore;
-        let _project_id = ip_manip_test_setup(&client).await;
+        let _project_id = ip_manip_test_setup(client).await;
         let instance =
             create_instance(client, PROJECT_NAME, INSTANCE_NAME).await;
 
@@ -538,7 +538,7 @@ pub(crate) mod test {
             test_helpers::action_failure_can_unwind::<SagaInstanceIpAttach, _, _>(
                 nexus,
                 || Box::pin(new_test_params(&opctx, datastore, use_float) ),
-                || Box::pin(verify_clean_slate(&cptestctx, instance_id)),
+                || Box::pin(verify_clean_slate(cptestctx, instance_id)),
                 log,
             )
             .await;
@@ -556,7 +556,7 @@ pub(crate) mod test {
 
         let opctx = test_helpers::test_opctx(cptestctx);
         let datastore = &nexus.db_datastore;
-        let _project_id = ip_manip_test_setup(&client).await;
+        let _project_id = ip_manip_test_setup(client).await;
         let instance =
             create_instance(client, PROJECT_NAME, INSTANCE_NAME).await;
 
@@ -575,7 +575,7 @@ pub(crate) mod test {
             >(
                 nexus,
                 || Box::pin(new_test_params(&opctx, datastore, use_float)),
-                || Box::pin(verify_clean_slate(&cptestctx, instance_id)),
+                || Box::pin(verify_clean_slate(cptestctx, instance_id)),
                 log,
             )
             .await;
@@ -592,7 +592,7 @@ pub(crate) mod test {
 
         let opctx = test_helpers::test_opctx(cptestctx);
         let datastore = &nexus.db_datastore;
-        let _project_id = ip_manip_test_setup(&client).await;
+        let _project_id = ip_manip_test_setup(client).await;
         let instance =
             create_instance(client, PROJECT_NAME, INSTANCE_NAME).await;
 

--- a/nexus/src/app/sagas/instance_ip_detach.rs
+++ b/nexus/src/app/sagas/instance_ip_detach.rs
@@ -376,7 +376,7 @@ pub(crate) mod test {
 
         let opctx = test_helpers::test_opctx(cptestctx);
         let datastore = &nexus.db_datastore;
-        let _ = ip_manip_test_setup(&client).await;
+        let _ = ip_manip_test_setup(client).await;
         let instance =
             create_instance(client, PROJECT_NAME, INSTANCE_NAME).await;
         let instance_id = InstanceUuid::from_untyped_uuid(instance.id());
@@ -490,7 +490,7 @@ pub(crate) mod test {
 
         let opctx = test_helpers::test_opctx(cptestctx);
         let datastore = &nexus.db_datastore;
-        let _project_id = ip_manip_test_setup(&client).await;
+        let _project_id = ip_manip_test_setup(client).await;
         let instance =
             create_instance(client, PROJECT_NAME, INSTANCE_NAME).await;
 
@@ -506,7 +506,7 @@ pub(crate) mod test {
             test_helpers::action_failure_can_unwind::<SagaInstanceIpDetach, _, _>(
                 nexus,
                 || Box::pin(new_test_params(&opctx, datastore, use_float) ),
-                || Box::pin(verify_clean_slate(&cptestctx, instance.id())),
+                || Box::pin(verify_clean_slate(cptestctx, instance.id())),
                 log,
             )
             .await;
@@ -524,7 +524,7 @@ pub(crate) mod test {
 
         let opctx = test_helpers::test_opctx(cptestctx);
         let datastore = &nexus.db_datastore;
-        let _project_id = ip_manip_test_setup(&client).await;
+        let _project_id = ip_manip_test_setup(client).await;
         let instance =
             create_instance(client, PROJECT_NAME, INSTANCE_NAME).await;
 
@@ -544,7 +544,7 @@ pub(crate) mod test {
             >(
                 nexus,
                 || Box::pin(new_test_params(&opctx, datastore, use_float)),
-                || Box::pin(verify_clean_slate(&cptestctx, instance.id())),
+                || Box::pin(verify_clean_slate(cptestctx, instance.id())),
                 log,
             )
             .await;
@@ -561,7 +561,7 @@ pub(crate) mod test {
 
         let opctx = test_helpers::test_opctx(cptestctx);
         let datastore = &nexus.db_datastore;
-        let _project_id = ip_manip_test_setup(&client).await;
+        let _project_id = ip_manip_test_setup(client).await;
         let instance =
             create_instance(client, PROJECT_NAME, INSTANCE_NAME).await;
 

--- a/nexus/src/app/sagas/instance_migrate.rs
+++ b/nexus/src/app/sagas/instance_migrate.rs
@@ -399,7 +399,7 @@ async fn sim_ensure_destination_propolis(
           "dst_vmm_state" => ?vmm);
 
     let (authz_silo, authz_project, authz_instance) =
-        LookupPath::new(&opctx, &osagactx.datastore())
+        LookupPath::new(&opctx, osagactx.datastore())
             .instance_id(db_instance.id())
             .lookup_for(authz::Action::Modify)
             .await
@@ -584,8 +584,8 @@ mod tests {
     const INSTANCE_NAME: &str = "test-instance";
 
     async fn setup_test_project(client: &ClientTestContext) -> Uuid {
-        create_default_ip_pool(&client).await;
-        let project = create_project(&client, PROJECT_NAME).await;
+        create_default_ip_pool(client).await;
+        let project = create_project(client, PROJECT_NAME).await;
         project.identity.id
     }
 
@@ -625,7 +625,7 @@ mod tests {
     ) {
         let client = &cptestctx.external_client;
         let nexus = &cptestctx.server.server_context().nexus;
-        let _project_id = setup_test_project(&client).await;
+        let _project_id = setup_test_project(client).await;
 
         let opctx = test_helpers::test_opctx(cptestctx);
         let instance = create_instance(client).await;
@@ -673,7 +673,7 @@ mod tests {
         let log = &cptestctx.logctx.log;
         let client = &cptestctx.external_client;
         let nexus = &cptestctx.server.server_context().nexus;
-        let _project_id = setup_test_project(&client).await;
+        let _project_id = setup_test_project(client).await;
 
         let opctx = test_helpers::test_opctx(cptestctx);
         let instance = create_instance(client).await;

--- a/nexus/src/app/sagas/instance_start.rs
+++ b/nexus/src/app/sagas/instance_start.rs
@@ -295,7 +295,7 @@ async fn sis_move_to_starting(
 
     // For idempotency, refetch the instance to see if this step already applied
     // its desired update.
-    let (_, _, authz_instance, ..) = LookupPath::new(&opctx, &datastore)
+    let (_, _, authz_instance, ..) = LookupPath::new(&opctx, datastore)
         .instance_id(instance_id.into_untyped_uuid())
         .fetch_for(authz::Action::Modify)
         .await
@@ -491,7 +491,7 @@ async fn sis_dpd_ensure(
     // Querying sleds requires fleet access; use the instance allocator context
     // for this.
     let sled_uuid = sagactx.lookup::<SledUuid>("sled_id")?;
-    let (.., sled) = LookupPath::new(&osagactx.nexus().opctx_alloc, &datastore)
+    let (.., sled) = LookupPath::new(&osagactx.nexus().opctx_alloc, datastore)
         .sled_id(sled_uuid.into_untyped_uuid())
         .fetch()
         .await
@@ -522,7 +522,7 @@ async fn sis_dpd_ensure_undo(
           "instance_id" => %instance_id,
           "start_reason" => ?params.reason);
 
-    let (.., authz_instance) = LookupPath::new(&opctx, &osagactx.datastore())
+    let (.., authz_instance) = LookupPath::new(&opctx, osagactx.datastore())
         .instance_id(instance_id)
         .lookup_for(authz::Action::Modify)
         .await
@@ -576,7 +576,7 @@ async fn sis_ensure_registered(
           "start_reason" => ?params.reason);
 
     let (authz_silo, authz_project, authz_instance) =
-        LookupPath::new(&opctx, &osagactx.datastore())
+        LookupPath::new(&opctx, osagactx.datastore())
             .instance_id(instance_id)
             .lookup_for(authz::Action::Modify)
             .await
@@ -646,7 +646,7 @@ async fn sis_ensure_registered_undo(
 
     // Fetch the latest record so that this callee can drive the instance into
     // a Failed state if the unregister call fails.
-    let (.., authz_instance, _) = LookupPath::new(&opctx, &datastore)
+    let (.., authz_instance, _) = LookupPath::new(&opctx, datastore)
         .instance_id(instance_id.into_untyped_uuid())
         .fetch()
         .await
@@ -815,8 +815,8 @@ mod test {
     const INSTANCE_NAME: &str = "test-instance";
 
     async fn setup_test_project(client: &ClientTestContext) -> Uuid {
-        create_default_ip_pool(&client).await;
-        let project = create_project(&client, PROJECT_NAME).await;
+        create_default_ip_pool(client).await;
+        let project = create_project(client, PROJECT_NAME).await;
         project.identity.id
     }
 
@@ -856,7 +856,7 @@ mod test {
     ) {
         let client = &cptestctx.external_client;
         let nexus = &cptestctx.server.server_context().nexus;
-        let _project_id = setup_test_project(&client).await;
+        let _project_id = setup_test_project(client).await;
         let opctx = test_helpers::test_opctx(cptestctx);
         let instance = create_instance(client).await;
         let instance_id = InstanceUuid::from_untyped_uuid(instance.identity.id);
@@ -896,7 +896,7 @@ mod test {
         let log = &cptestctx.logctx.log;
         let client = &cptestctx.external_client;
         let nexus = &cptestctx.server.server_context().nexus;
-        let _project_id = setup_test_project(&client).await;
+        let _project_id = setup_test_project(client).await;
         let opctx = test_helpers::test_opctx(cptestctx);
         let instance = create_instance(client).await;
         let instance_id = InstanceUuid::from_untyped_uuid(instance.identity.id);
@@ -955,7 +955,7 @@ mod test {
     ) {
         let client = &cptestctx.external_client;
         let nexus = &cptestctx.server.server_context().nexus;
-        let _project_id = setup_test_project(&client).await;
+        let _project_id = setup_test_project(client).await;
         let opctx = test_helpers::test_opctx(cptestctx);
         let instance = create_instance(client).await;
         let instance_id = InstanceUuid::from_untyped_uuid(instance.identity.id);
@@ -996,7 +996,7 @@ mod test {
     async fn test_ensure_running_unwind(cptestctx: &ControlPlaneTestContext) {
         let client = &cptestctx.external_client;
         let nexus = &cptestctx.server.server_context().nexus;
-        let _project_id = setup_test_project(&client).await;
+        let _project_id = setup_test_project(client).await;
         let opctx = test_helpers::test_opctx(cptestctx);
         let instance = create_instance(client).await;
         let instance_id = InstanceUuid::from_untyped_uuid(instance.identity.id);

--- a/nexus/src/app/sagas/mod.rs
+++ b/nexus/src/app/sagas/mod.rs
@@ -88,7 +88,7 @@ pub(crate) trait NexusSaga {
         params: &Self::Params,
     ) -> Result<SagaDag, omicron_common::api::external::Error> {
         let builder = DagBuilder::new(SagaName::new(Self::NAME));
-        let dag = Self::make_saga_dag(&params, builder)?;
+        let dag = Self::make_saga_dag(params, builder)?;
         let params = serde_json::to_value(&params).map_err(|e| {
             SagaInitError::SerializeError(format!("saga params: {params:?}"), e)
         })?;

--- a/nexus/src/app/sagas/project_create.rs
+++ b/nexus/src/app/sagas/project_create.rs
@@ -264,7 +264,7 @@ mod test {
         verify_clean_slate(nexus.datastore()).await;
 
         // Build the saga DAG with the provided test parameters and run it.
-        let opctx = test_opctx(&cptestctx);
+        let opctx = test_opctx(cptestctx);
         let authz_silo = opctx.authn.silo_required().unwrap();
         let params = new_test_params(&opctx, authz_silo);
         nexus.sagas.saga_execute::<SagaProjectCreate>(params).await.unwrap();
@@ -276,7 +276,7 @@ mod test {
     ) {
         let log = &cptestctx.logctx.log;
         let nexus = &cptestctx.server.server_context().nexus;
-        let opctx = test_opctx(&cptestctx);
+        let opctx = test_opctx(cptestctx);
         crate::app::sagas::test_helpers::action_failure_can_unwind::<
             SagaProjectCreate,
             _,

--- a/nexus/src/app/sagas/region_replacement_drive.rs
+++ b/nexus/src/app/sagas/region_replacement_drive.rs
@@ -375,7 +375,7 @@ async fn srrd_drive_region_replacement_check(
             };
 
             let (.., authz_instance) =
-                LookupPath::new(&opctx, &osagactx.datastore())
+                LookupPath::new(&opctx, osagactx.datastore())
                     .instance_id(step_instance_id)
                     .lookup_for(authz::Action::Read)
                     .await
@@ -742,7 +742,7 @@ async fn check_from_previous_pantry_step(
                     // the volume is no longer attached because a Propolis
                     // activation took over from the Pantry.
 
-                    match client.volume_status(&volume_id).await {
+                    match client.volume_status(volume_id).await {
                         Ok(_) => {
                             // The volume is still there as an entry, but the
                             // job isn't? Action is required: this saga should
@@ -874,7 +874,7 @@ async fn srrd_drive_region_replacement_prepare(
             Some(instance_id) => {
                 // The region's volume is attached to an instance
                 let (.., authz_instance) =
-                    LookupPath::new(&opctx, &osagactx.datastore())
+                    LookupPath::new(&opctx, osagactx.datastore())
                         .instance_id(*instance_id)
                         .lookup_for(authz::Action::Read)
                         .await
@@ -1187,7 +1187,7 @@ async fn srrd_drive_region_replacement_execute(
             };
 
             let (.., authz_instance) =
-                LookupPath::new(&opctx, &osagactx.datastore())
+                LookupPath::new(&opctx, osagactx.datastore())
                     .instance_id(instance_id)
                     .lookup_for(authz::Action::Read)
                     .await
@@ -1245,9 +1245,8 @@ async fn srrd_drive_region_replacement_execute(
                 }
             };
 
-            let instance_lookup =
-                LookupPath::new(&opctx, &osagactx.datastore())
-                    .instance_id(instance_id);
+            let instance_lookup = LookupPath::new(&opctx, osagactx.datastore())
+                .instance_id(instance_id);
 
             let (vmm, client) = osagactx
                 .nexus()
@@ -1449,7 +1448,7 @@ async fn execute_pantry_drive_action(
 
     let volume_construction_request:
         crucible_pantry_client::types::VolumeConstructionRequest =
-        serde_json::from_str(&disk_volume.data()).map_err(|e| {
+        serde_json::from_str(disk_volume.data()).map_err(|e| {
             ActionError::action_failed(Error::internal_error(&format!(
                 "failed to deserialize volume {volume_id} data: {e}",
             )))

--- a/nexus/src/app/sagas/region_replacement_start.rs
+++ b/nexus/src/app/sagas/region_replacement_start.rs
@@ -372,7 +372,7 @@ async fn srrs_new_region_ensure(
 
     let mut ensured_dataset_and_region = osagactx
         .nexus()
-        .ensure_all_datasets_and_regions(&log, vec![new_dataset_and_region])
+        .ensure_all_datasets_and_regions(log, vec![new_dataset_and_region])
         .await
         .map_err(ActionError::action_failed)?;
 
@@ -808,15 +808,15 @@ pub(crate) mod test {
         let opctx = test_opctx(cptestctx);
 
         let _project_id =
-            create_project(&client, PROJECT_NAME).await.identity.id;
+            create_project(client, PROJECT_NAME).await.identity.id;
 
         // Create a disk
         let client = &cptestctx.external_client;
-        let disk = create_disk(&client, PROJECT_NAME, DISK_NAME).await;
+        let disk = create_disk(client, PROJECT_NAME, DISK_NAME).await;
 
         // Assert disk has three allocated regions
         let disk_id = disk.identity.id;
-        let (.., db_disk) = LookupPath::new(&opctx, &datastore)
+        let (.., db_disk) = LookupPath::new(&opctx, datastore)
             .disk_id(disk_id)
             .fetch()
             .await
@@ -970,7 +970,7 @@ pub(crate) mod test {
         ];
 
         let only_new_region = find_only_new_region(
-            &log,
+            log,
             existing_datasets_and_regions,
             new_datasets_and_regions,
         );
@@ -1009,13 +1009,13 @@ pub(crate) mod test {
         )
         .await;
 
-        assert!(three_region_allocations_exist(&datastore, &test).await);
+        assert!(three_region_allocations_exist(datastore, test).await);
         assert_region_replacement_request_untouched(
-            cptestctx, &datastore, &request,
+            cptestctx, datastore, request,
         )
         .await;
-        assert_volume_untouched(&datastore, &affected_volume_original).await;
-        assert_region_untouched(&datastore, &affected_region_original).await;
+        assert_volume_untouched(datastore, affected_volume_original).await;
+        assert_region_untouched(datastore, affected_region_original).await;
     }
 
     async fn three_region_allocations_exist(
@@ -1094,10 +1094,10 @@ pub(crate) mod test {
             .unwrap();
 
         let mut actual: VolumeConstructionRequest =
-            serde_json::from_str(&affected_volume.data()).unwrap();
+            serde_json::from_str(affected_volume.data()).unwrap();
 
         let mut expected: VolumeConstructionRequest =
-            serde_json::from_str(&affected_volume_original.data()).unwrap();
+            serde_json::from_str(affected_volume_original.data()).unwrap();
 
         zero_out_gen_number(&mut actual);
         zero_out_gen_number(&mut expected);
@@ -1127,17 +1127,17 @@ pub(crate) mod test {
         let nexus = &cptestctx.server.server_context().nexus;
         let datastore = nexus.datastore();
 
-        let _ = create_project(&client, PROJECT_NAME).await.identity.id;
-        let opctx = test_opctx(&cptestctx);
+        let _ = create_project(client, PROJECT_NAME).await.identity.id;
+        let opctx = test_opctx(cptestctx);
 
         // Create a disk, and use the first region as input to the replacement
         // start saga
 
         let client = &cptestctx.external_client;
-        let disk = create_disk(&client, PROJECT_NAME, DISK_NAME).await;
+        let disk = create_disk(client, PROJECT_NAME, DISK_NAME).await;
 
         let disk_id = disk.identity.id;
-        let (.., db_disk) = LookupPath::new(&opctx, &datastore)
+        let (.., db_disk) = LookupPath::new(&opctx, datastore)
             .disk_id(disk_id)
             .fetch()
             .await
@@ -1180,11 +1180,11 @@ pub(crate) mod test {
             || Box::pin(async { new_test_params(&opctx, &request) }),
             || Box::pin(async {
                 verify_clean_slate(
-                    &cptestctx,
+                    cptestctx,
                     &disk_test,
                     &request,
                     &affected_volume_original,
-                    &region_to_replace,
+                    region_to_replace,
                 ).await;
             }),
             log
@@ -1202,17 +1202,17 @@ pub(crate) mod test {
         let nexus = &cptestctx.server.server_context().nexus;
         let datastore = nexus.datastore();
 
-        let _ = create_project(&client, PROJECT_NAME).await.identity.id;
-        let opctx = test_opctx(&cptestctx);
+        let _ = create_project(client, PROJECT_NAME).await.identity.id;
+        let opctx = test_opctx(cptestctx);
 
         // Create a disk, and use the first region as input to the replacement
         // start saga
 
         let client = &cptestctx.external_client;
-        let disk = create_disk(&client, PROJECT_NAME, DISK_NAME).await;
+        let disk = create_disk(client, PROJECT_NAME, DISK_NAME).await;
 
         let disk_id = disk.identity.id;
-        let (.., db_disk) = LookupPath::new(&opctx, &datastore)
+        let (.., db_disk) = LookupPath::new(&opctx, datastore)
             .disk_id(disk_id)
             .fetch()
             .await

--- a/nexus/src/app/sagas/region_snapshot_replacement_step.rs
+++ b/nexus/src/app/sagas/region_snapshot_replacement_step.rs
@@ -251,7 +251,7 @@ async fn rsrss_create_replace_params(
 
     let new_region_address = osagactx
         .nexus()
-        .region_addr(&log, new_region_id)
+        .region_addr(log, new_region_id)
         .await
         .map_err(ActionError::action_failed)?;
 
@@ -443,7 +443,7 @@ async fn rsrss_notify_upstairs(
         &params.serialized_authn,
     );
 
-    let (.., authz_instance) = LookupPath::new(&opctx, &osagactx.datastore())
+    let (.., authz_instance) = LookupPath::new(&opctx, osagactx.datastore())
         .instance_id(instance_id)
         .lookup_for(authz::Action::Read)
         .await
@@ -510,7 +510,7 @@ async fn rsrss_notify_upstairs(
     };
 
     let instance_lookup =
-        LookupPath::new(&opctx, &osagactx.datastore()).instance_id(instance_id);
+        LookupPath::new(&opctx, osagactx.datastore()).instance_id(instance_id);
 
     let (vmm, client) = osagactx
         .nexus()

--- a/nexus/src/app/sagas/test_helpers.rs
+++ b/nexus/src/app/sagas/test_helpers.rs
@@ -47,7 +47,7 @@ pub(crate) async fn instance_start(
     id: &InstanceUuid,
 ) {
     let nexus = &cptestctx.server.server_context().nexus;
-    let opctx = test_opctx(&cptestctx);
+    let opctx = test_opctx(cptestctx);
     let instance_selector =
         nexus_types::external_api::params::InstanceSelector {
             project: None,
@@ -67,7 +67,7 @@ pub(crate) async fn instance_stop(
     id: &InstanceUuid,
 ) {
     let nexus = &cptestctx.server.server_context().nexus;
-    let opctx = test_opctx(&cptestctx);
+    let opctx = test_opctx(cptestctx);
     let instance_selector =
         nexus_types::external_api::params::InstanceSelector {
             project: None,
@@ -88,7 +88,7 @@ pub(crate) async fn instance_stop_by_name(
     project_name: &str,
 ) {
     let nexus = &cptestctx.server.server_context().nexus;
-    let opctx = test_opctx(&cptestctx);
+    let opctx = test_opctx(cptestctx);
     let instance_selector =
         nexus_types::external_api::params::InstanceSelector {
             project: Some(project_name.to_string().try_into().unwrap()),
@@ -109,7 +109,7 @@ pub(crate) async fn instance_delete_by_name(
     project_name: &str,
 ) {
     let nexus = &cptestctx.server.server_context().nexus;
-    let opctx = test_opctx(&cptestctx);
+    let opctx = test_opctx(cptestctx);
     let instance_selector =
         nexus_types::external_api::params::InstanceSelector {
             project: Some(project_name.to_string().try_into().unwrap()),
@@ -173,7 +173,7 @@ pub(crate) async fn instance_simulate_by_name(
           "project_name" => %project_name);
 
     let nexus = &cptestctx.server.server_context().nexus;
-    let opctx = test_opctx(&cptestctx);
+    let opctx = test_opctx(cptestctx);
     let instance_selector =
         nexus_types::external_api::params::InstanceSelector {
             project: Some(project_name.to_string().try_into().unwrap()),
@@ -198,7 +198,7 @@ pub async fn instance_fetch(
     instance_id: InstanceUuid,
 ) -> InstanceAndActiveVmm {
     let datastore = cptestctx.server.server_context().nexus.datastore().clone();
-    let opctx = test_opctx(&cptestctx);
+    let opctx = test_opctx(cptestctx);
     let (.., authz_instance) = LookupPath::new(&opctx, &datastore)
         .instance_id(instance_id.into_untyped_uuid())
         .lookup_for(authz::Action::Read)
@@ -237,7 +237,7 @@ pub async fn instance_fetch_all(
     instance_id: InstanceUuid,
 ) -> InstanceGestalt {
     let datastore = cptestctx.server.server_context().nexus.datastore().clone();
-    let opctx = test_opctx(&cptestctx);
+    let opctx = test_opctx(cptestctx);
     let (.., authz_instance) = LookupPath::new(&opctx, &datastore)
         .instance_id(instance_id.into_untyped_uuid())
         .lookup_for(authz::Action::Read)
@@ -266,7 +266,7 @@ pub async fn instance_fetch_by_name(
 ) -> InstanceAndActiveVmm {
     let nexus = &cptestctx.server.server_context().nexus;
     let datastore = nexus.datastore();
-    let opctx = test_opctx(&cptestctx);
+    let opctx = test_opctx(cptestctx);
     let instance_selector =
         nexus_types::external_api::params::InstanceSelector {
             project: Some(project_name.to_string().try_into().unwrap()),
@@ -297,9 +297,9 @@ pub(crate) async fn instance_wait_for_state(
     instance_id: InstanceUuid,
     desired_state: InstanceState,
 ) -> InstanceAndActiveVmm {
-    let opctx = test_opctx(&cptestctx);
+    let opctx = test_opctx(cptestctx);
     let datastore = cptestctx.server.server_context().nexus.datastore();
-    let (.., authz_instance) = LookupPath::new(&opctx, &datastore)
+    let (.., authz_instance) = LookupPath::new(&opctx, datastore)
         .instance_id(instance_id.into_untyped_uuid())
         .lookup_for(authz::Action::Read)
         .await
@@ -314,7 +314,7 @@ pub async fn instance_wait_for_state_by_name(
     desired_state: InstanceState,
 ) -> InstanceAndActiveVmm {
     let nexus = &cptestctx.server.server_context().nexus;
-    let opctx = test_opctx(&cptestctx);
+    let opctx = test_opctx(cptestctx);
     let instance_selector =
         nexus_types::external_api::params::InstanceSelector {
             project: Some(project_name.to_string().try_into().unwrap()),
@@ -348,7 +348,7 @@ async fn instance_poll_state(
     let result = poll::wait_for_condition(
         || async {
             let db_state = datastore
-                .instance_fetch_with_vmm(&opctx, &authz_instance)
+                .instance_fetch_with_vmm(opctx, &authz_instance)
                 .await
                 .map_err(poll::CondCheckError::<Error>::Failed)?;
 

--- a/nexus/src/app/sagas/vpc_create.rs
+++ b/nexus/src/app/sagas/vpc_create.rs
@@ -676,7 +676,7 @@ pub(crate) mod test {
     const PROJECT_NAME: &str = "springfield-squidport";
 
     async fn create_org_and_project(client: &ClientTestContext) -> Uuid {
-        create_default_ip_pool(&client).await;
+        create_default_ip_pool(client).await;
         let project = create_project(client, PROJECT_NAME).await;
         project.identity.id
     }
@@ -715,7 +715,7 @@ pub(crate) mod test {
         let nexus = &cptestctx.server.server_context().nexus;
         let project_selector =
             params::ProjectSelector { project: NameOrId::Id(project_id) };
-        let opctx = test_opctx(&cptestctx);
+        let opctx = test_opctx(cptestctx);
         let (.., authz_project) = nexus
             .project_lookup(&opctx, project_selector)
             .expect("Invalid parameters constructing project lookup")
@@ -729,13 +729,13 @@ pub(crate) mod test {
         cptestctx: &ControlPlaneTestContext,
         project_id: Uuid,
     ) {
-        let opctx = test_opctx(&cptestctx);
+        let opctx = test_opctx(cptestctx);
         let datastore = cptestctx.server.server_context().nexus.datastore();
         let default_name = Name::try_from("default".to_string()).unwrap();
         let system_name = Name::try_from("system".to_string()).unwrap();
 
         // Default Subnet
-        let (.., authz_subnet, subnet) = LookupPath::new(&opctx, &datastore)
+        let (.., authz_subnet, subnet) = LookupPath::new(&opctx, datastore)
             .project_id(project_id)
             .vpc_name(&default_name.clone().into())
             .vpc_subnet_name(&default_name.clone().into())
@@ -748,7 +748,7 @@ pub(crate) mod test {
             .expect("Failed to delete default Subnet");
 
         // Default gateway routes
-        let (.., authz_route, _route) = LookupPath::new(&opctx, &datastore)
+        let (.., authz_route, _route) = LookupPath::new(&opctx, datastore)
             .project_id(project_id)
             .vpc_name(&default_name.clone().into())
             .vpc_router_name(&system_name.clone().into())
@@ -761,7 +761,7 @@ pub(crate) mod test {
             .await
             .expect("Failed to delete default route");
 
-        let (.., authz_route, _route) = LookupPath::new(&opctx, &datastore)
+        let (.., authz_route, _route) = LookupPath::new(&opctx, datastore)
             .project_id(project_id)
             .vpc_name(&default_name.clone().into())
             .vpc_router_name(&system_name.clone().into())
@@ -775,7 +775,7 @@ pub(crate) mod test {
             .expect("Failed to delete default route");
 
         // System router
-        let (.., authz_router, _router) = LookupPath::new(&opctx, &datastore)
+        let (.., authz_router, _router) = LookupPath::new(&opctx, datastore)
             .project_id(project_id)
             .vpc_name(&default_name.clone().into())
             .vpc_router_name(&system_name.into())
@@ -789,7 +789,7 @@ pub(crate) mod test {
 
         // Default gateway
         let (.., authz_vpc, authz_igw, _igw) =
-            LookupPath::new(&opctx, &datastore)
+            LookupPath::new(&opctx, datastore)
                 .project_id(project_id)
                 .vpc_name(&default_name.clone().into())
                 .internet_gateway_name(&default_name.clone().into())
@@ -807,7 +807,7 @@ pub(crate) mod test {
             .expect("Failed to delete default gateway");
 
         // Default VPC & Firewall Rules
-        let (.., authz_vpc, vpc) = LookupPath::new(&opctx, &datastore)
+        let (.., authz_vpc, vpc) = LookupPath::new(&opctx, datastore)
             .project_id(project_id)
             .vpc_name(&default_name.into())
             .fetch()
@@ -995,16 +995,16 @@ pub(crate) mod test {
     ) {
         let client = &cptestctx.external_client;
         let nexus = &cptestctx.server.server_context().nexus;
-        let project_id = create_org_and_project(&client).await;
-        delete_project_vpc_defaults(&cptestctx, project_id).await;
+        let project_id = create_org_and_project(client).await;
+        delete_project_vpc_defaults(cptestctx, project_id).await;
 
         // Before running the test, confirm we have no records of any VPCs.
         verify_clean_slate(nexus.datastore()).await;
 
         // Build the saga DAG with the provided test parameters
-        let opctx = test_opctx(&cptestctx);
+        let opctx = test_opctx(cptestctx);
         let authz_project = get_authz_project(
-            &cptestctx,
+            cptestctx,
             project_id,
             authz::Action::CreateChild,
         )
@@ -1021,10 +1021,10 @@ pub(crate) mod test {
 
         let client = &cptestctx.external_client;
         let nexus = &cptestctx.server.server_context().nexus;
-        let project_id = create_org_and_project(&client).await;
-        delete_project_vpc_defaults(&cptestctx, project_id).await;
+        let project_id = create_org_and_project(client).await;
+        delete_project_vpc_defaults(cptestctx, project_id).await;
 
-        let opctx = test_opctx(&cptestctx);
+        let opctx = test_opctx(cptestctx);
         crate::app::sagas::test_helpers::action_failure_can_unwind::<
             SagaVpcCreate,
             _,
@@ -1036,7 +1036,7 @@ pub(crate) mod test {
                     new_test_params(
                         &opctx,
                         get_authz_project(
-                            &cptestctx,
+                            cptestctx,
                             project_id,
                             authz::Action::CreateChild,
                         )

--- a/nexus/src/app/sagas/vpc_subnet_create.rs
+++ b/nexus/src/app/sagas/vpc_subnet_create.rs
@@ -373,7 +373,7 @@ pub(crate) mod test {
     const PROJECT_NAME: &str = "springfield-squidport";
 
     async fn create_org_and_project(client: &ClientTestContext) -> Uuid {
-        create_default_ip_pool(&client).await;
+        create_default_ip_pool(client).await;
         let project = create_project(client, PROJECT_NAME).await;
         project.identity.id
     }
@@ -421,7 +421,7 @@ pub(crate) mod test {
         project_id: Uuid,
     ) -> (authz::Vpc, db::model::Vpc, authz::VpcRouter) {
         let nexus = &cptestctx.server.server_context().nexus;
-        let opctx = test_opctx(&cptestctx);
+        let opctx = test_opctx(cptestctx);
         let datastore = nexus.datastore();
         let (.., authz_vpc, db_vpc) = nexus
             .vpc_lookup(
@@ -501,11 +501,11 @@ pub(crate) mod test {
     ) {
         let client = &cptestctx.external_client;
         let nexus = &cptestctx.server.server_context().nexus;
-        let project_id = create_org_and_project(&client).await;
-        let opctx = test_opctx(&cptestctx);
+        let project_id = create_org_and_project(client).await;
+        let opctx = test_opctx(cptestctx);
 
         let (authz_vpc, db_vpc, authz_system_router) =
-            get_vpc_state(&cptestctx, project_id).await;
+            get_vpc_state(cptestctx, project_id).await;
         verify_clean_slate(nexus.datastore(), authz_vpc.id()).await;
         let params =
             new_test_params(&opctx, authz_vpc, db_vpc, authz_system_router);
@@ -520,17 +520,17 @@ pub(crate) mod test {
 
         let client = &cptestctx.external_client;
         let nexus = &cptestctx.server.server_context().nexus;
-        let project_id = create_org_and_project(&client).await;
-        let (authz_vpc, ..) = get_vpc_state(&cptestctx, project_id).await;
+        let project_id = create_org_and_project(client).await;
+        let (authz_vpc, ..) = get_vpc_state(cptestctx, project_id).await;
         let vpc_id = authz_vpc.id();
 
-        let opctx = test_opctx(&cptestctx);
+        let opctx = test_opctx(cptestctx);
         test_helpers::action_failure_can_unwind::<SagaVpcSubnetCreate, _, _>(
             nexus,
             || {
                 Box::pin(async {
                     let (authz_vpc, db_vpc, authz_system_router) =
-                        get_vpc_state(&cptestctx, project_id).await;
+                        get_vpc_state(cptestctx, project_id).await;
                     new_test_params(
                         &opctx,
                         authz_vpc,
@@ -557,11 +557,11 @@ pub(crate) mod test {
 
         let client = &cptestctx.external_client;
         let nexus = &cptestctx.server.server_context().nexus;
-        let project_id = create_org_and_project(&client).await;
-        let (authz_vpc, ..) = get_vpc_state(&cptestctx, project_id).await;
+        let project_id = create_org_and_project(client).await;
+        let (authz_vpc, ..) = get_vpc_state(cptestctx, project_id).await;
         let vpc_id = authz_vpc.id();
 
-        let opctx = test_opctx(&cptestctx);
+        let opctx = test_opctx(cptestctx);
         test_helpers::action_failure_can_unwind_idempotently::<
             SagaVpcSubnetCreate,
             _,
@@ -571,7 +571,7 @@ pub(crate) mod test {
             || {
                 Box::pin(async {
                     let (authz_vpc, db_vpc, authz_system_router) =
-                        get_vpc_state(&cptestctx, project_id).await;
+                        get_vpc_state(cptestctx, project_id).await;
                     new_test_params(
                         &opctx,
                         authz_vpc,
@@ -596,11 +596,11 @@ pub(crate) mod test {
     ) {
         let client = &cptestctx.external_client;
         let nexus = &cptestctx.server.server_context().nexus;
-        let project_id = create_org_and_project(&client).await;
-        let opctx = test_opctx(&cptestctx);
+        let project_id = create_org_and_project(client).await;
+        let opctx = test_opctx(cptestctx);
 
         let (authz_vpc, db_vpc, authz_system_router) =
-            get_vpc_state(&cptestctx, project_id).await;
+            get_vpc_state(cptestctx, project_id).await;
         verify_clean_slate(nexus.datastore(), authz_vpc.id()).await;
         let params =
             new_test_params(&opctx, authz_vpc, db_vpc, authz_system_router);

--- a/nexus/src/app/sagas/vpc_subnet_delete.rs
+++ b/nexus/src/app/sagas/vpc_subnet_delete.rs
@@ -141,7 +141,7 @@ pub(crate) mod test {
     const PROJECT_NAME: &str = "springfield-squidport";
 
     async fn create_org_and_project(client: &ClientTestContext) -> Uuid {
-        create_default_ip_pool(&client).await;
+        create_default_ip_pool(client).await;
         let project = create_project(client, PROJECT_NAME).await;
         project.identity.id
     }
@@ -158,7 +158,7 @@ pub(crate) mod test {
         project_id: Uuid,
     ) -> Params {
         let nexus = &cptestctx.server.server_context().nexus;
-        let opctx = test_opctx(&cptestctx);
+        let opctx = test_opctx(cptestctx);
         let (.., authz_vpc, authz_subnet, db_subnet) = nexus
             .vpc_subnet_lookup(
                 &opctx,
@@ -187,7 +187,7 @@ pub(crate) mod test {
     ) {
         let client = &cptestctx.external_client;
         let nexus = &cptestctx.server.server_context().nexus;
-        let project_id = create_org_and_project(&client).await;
+        let project_id = create_org_and_project(client).await;
 
         let params = new_test_params(cptestctx, project_id).await;
         nexus.sagas.saga_execute::<SagaVpcSubnetDelete>(params).await.unwrap();
@@ -199,7 +199,7 @@ pub(crate) mod test {
     ) {
         let client = &cptestctx.external_client;
         let nexus = &cptestctx.server.server_context().nexus;
-        let project_id = create_org_and_project(&client).await;
+        let project_id = create_org_and_project(client).await;
 
         let params = new_test_params(cptestctx, project_id).await;
         let dag = create_saga_dag::<SagaVpcSubnetDelete>(params).unwrap();

--- a/nexus/src/app/sagas/vpc_subnet_update.rs
+++ b/nexus/src/app/sagas/vpc_subnet_update.rs
@@ -128,7 +128,7 @@ pub(crate) mod test {
     async fn create_org_and_project(
         client: &ClientTestContext,
     ) -> (Uuid, Uuid) {
-        create_default_ip_pool(&client).await;
+        create_default_ip_pool(client).await;
         let project = create_project(client, PROJECT_NAME).await;
         let router =
             create_router(client, PROJECT_NAME, "default", ROUTER_NAME).await;
@@ -148,7 +148,7 @@ pub(crate) mod test {
         router_id: Uuid,
     ) -> Params {
         let nexus = &cptestctx.server.server_context().nexus;
-        let opctx = test_opctx(&cptestctx);
+        let opctx = test_opctx(cptestctx);
         let (.., authz_vpc, authz_subnet, _) = nexus
             .vpc_subnet_lookup(
                 &opctx,
@@ -197,7 +197,7 @@ pub(crate) mod test {
     ) {
         let client = &cptestctx.external_client;
         let nexus = &cptestctx.server.server_context().nexus;
-        let (project_id, router_id) = create_org_and_project(&client).await;
+        let (project_id, router_id) = create_org_and_project(client).await;
 
         let params = new_test_params(cptestctx, project_id, router_id).await;
         nexus.sagas.saga_execute::<SagaVpcSubnetUpdate>(params).await.unwrap();
@@ -209,7 +209,7 @@ pub(crate) mod test {
     ) {
         let client = &cptestctx.external_client;
         let nexus = &cptestctx.server.server_context().nexus;
-        let (project_id, router_id) = create_org_and_project(&client).await;
+        let (project_id, router_id) = create_org_and_project(client).await;
 
         let params = new_test_params(cptestctx, project_id, router_id).await;
         let dag = create_saga_dag::<SagaVpcSubnetUpdate>(params).unwrap();

--- a/nexus/src/app/silo.rs
+++ b/nexus/src/app/silo.rs
@@ -71,7 +71,7 @@ impl super::Nexus {
     ) -> ListResultVec<String> {
         let (_, silo) =
             self.silo_lookup(opctx, silo_id.into())?.fetch().await?;
-        let silo_dns_name = silo_dns_name(&silo.name());
+        let silo_dns_name = silo_dns_name(silo.name());
         let external_dns_zones = self
             .db_datastore
             .dns_zones_list_all(opctx, nexus_db_model::DnsGroup::External)
@@ -131,8 +131,8 @@ impl super::Nexus {
 
         let silo = datastore
             .silo_create(
-                &opctx,
-                &nexus_opctx,
+                opctx,
+                nexus_opctx,
                 new_silo_params,
                 &new_silo_dns_names,
                 dns_update,
@@ -169,7 +169,7 @@ impl super::Nexus {
             format!("delete silo: {:?}", db_silo.name()),
             self.id.to_string(),
         );
-        dns_update.remove_name(silo_dns_name(&db_silo.name()))?;
+        dns_update.remove_name(silo_dns_name(db_silo.name()))?;
         datastore
             .silo_delete(opctx, &authz_silo, &db_silo, dns_opctx, dns_update)
             .await?;
@@ -378,7 +378,7 @@ impl super::Nexus {
             .datastore()
             .silo_user_fetch_by_external_id(
                 opctx,
-                &authz_silo,
+                authz_silo,
                 &authenticated_subject.external_id,
             )
             .await?;
@@ -410,7 +410,7 @@ impl super::Nexus {
                     );
 
                     self.db_datastore
-                        .silo_user_create(&authz_silo, silo_user)
+                        .silo_user_create(authz_silo, silo_user)
                         .await?
                 }
             }
@@ -429,7 +429,7 @@ impl super::Nexus {
                     self.db_datastore
                         .silo_group_optional_lookup(
                             opctx,
-                            &authz_silo,
+                            authz_silo,
                             group.clone(),
                         )
                         .await?
@@ -438,9 +438,7 @@ impl super::Nexus {
                 db::model::UserProvisionType::Jit => {
                     let silo_group = self
                         .silo_group_lookup_or_create_by_name(
-                            opctx,
-                            &authz_silo,
-                            &group,
+                            opctx, authz_silo, group,
                         )
                         .await?;
 

--- a/nexus/src/app/sled.rs
+++ b/nexus/src/app/sled.rs
@@ -140,7 +140,7 @@ impl super::Nexus {
         pagparams: &DataPageParams<'_, Uuid>,
     ) -> ListResultVec<db::model::Sled> {
         self.db_datastore
-            .sled_list(&opctx, pagparams, SledFilter::InService)
+            .sled_list(opctx, pagparams, SledFilter::InService)
             .await
     }
 
@@ -214,7 +214,7 @@ impl super::Nexus {
         disk_selector: &params::PhysicalDiskPath,
     ) -> Result<lookup::PhysicalDisk<'a>, Error> {
         // XXX how to do typed UUID as part of dropshot path?
-        Ok(lookup::LookupPath::new(&opctx, &self.db_datastore).physical_disk(
+        Ok(lookup::LookupPath::new(opctx, &self.db_datastore).physical_disk(
             PhysicalDiskUuid::from_untyped_uuid(disk_selector.disk_id),
         ))
     }
@@ -226,7 +226,7 @@ impl super::Nexus {
         pagparams: &DataPageParams<'_, Uuid>,
     ) -> ListResultVec<db::model::PhysicalDisk> {
         self.db_datastore
-            .sled_list_physical_disks(&opctx, sled_id, pagparams)
+            .sled_list_physical_disks(opctx, sled_id, pagparams)
             .await
     }
 
@@ -236,7 +236,7 @@ impl super::Nexus {
         pagparams: &DataPageParams<'_, Uuid>,
     ) -> ListResultVec<db::model::PhysicalDisk> {
         self.db_datastore
-            .physical_disk_list(&opctx, pagparams, DiskFilter::InService)
+            .physical_disk_list(opctx, pagparams, DiskFilter::InService)
             .await
     }
 
@@ -259,7 +259,7 @@ impl super::Nexus {
             "model" => %request.model,
         );
 
-        match LookupPath::new(&opctx, &self.db_datastore)
+        match LookupPath::new(opctx, &self.db_datastore)
             .physical_disk(request.id)
             .fetch()
             .await
@@ -287,7 +287,7 @@ impl super::Nexus {
             request.variant.into(),
             request.sled_id,
         );
-        self.db_datastore.physical_disk_insert(&opctx, disk).await?;
+        self.db_datastore.physical_disk_insert(opctx, disk).await?;
         Ok(())
     }
 
@@ -335,7 +335,7 @@ impl super::Nexus {
             // real value here.
             ByteCount::from_gibibytes_u32(0).into(),
         );
-        self.db_datastore.zpool_insert(&opctx, zpool).await?;
+        self.db_datastore.zpool_insert(opctx, zpool).await?;
         Ok(())
     }
 

--- a/nexus/src/app/snapshot.rs
+++ b/nexus/src/app/snapshot.rs
@@ -103,7 +103,7 @@ impl super::Nexus {
 
             let instance_state = self
                 .datastore()
-                .instance_fetch_with_vmm(&opctx, &authz_instance)
+                .instance_fetch_with_vmm(opctx, &authz_instance)
                 .await?;
 
             // If a Propolis _may_ exist, send the snapshot request there,

--- a/nexus/src/app/ssh_key.rs
+++ b/nexus/src/app/ssh_key.rs
@@ -49,7 +49,7 @@ impl super::Nexus {
         params: params::SshKeyCreate,
     ) -> CreateResult<db::model::SshKey> {
         let ssh_key = db::model::SshKey::new(silo_user_id, params);
-        let (.., authz_user) = LookupPath::new(opctx, &self.datastore())
+        let (.., authz_user) = LookupPath::new(opctx, self.datastore())
             .silo_user_id(silo_user_id)
             .lookup_for(authz::Action::CreateChild)
             .await?;
@@ -63,7 +63,7 @@ impl super::Nexus {
         silo_user_id: Uuid,
         page_params: &PaginatedBy<'_>,
     ) -> ListResultVec<SshKey> {
-        let (.., authz_user) = LookupPath::new(opctx, &self.datastore())
+        let (.., authz_user) = LookupPath::new(opctx, self.datastore())
             .silo_user_id(silo_user_id)
             .lookup_for(authz::Action::ListChildren)
             .await?;

--- a/nexus/src/app/support_bundles.rs
+++ b/nexus/src/app/support_bundles.rs
@@ -41,7 +41,7 @@ impl super::Nexus {
         opctx: &OpContext,
         pagparams: &DataPageParams<'_, Uuid>,
     ) -> ListResultVec<SupportBundle> {
-        self.db_datastore.support_bundle_list(&opctx, pagparams).await
+        self.db_datastore.support_bundle_list(opctx, pagparams).await
     }
 
     pub async fn support_bundle_view(
@@ -62,7 +62,7 @@ impl super::Nexus {
         opctx: &OpContext,
         reason: &'static str,
     ) -> CreateResult<SupportBundle> {
-        self.db_datastore.support_bundle_create(&opctx, reason, self.id).await
+        self.db_datastore.support_bundle_create(opctx, reason, self.id).await
     }
 
     pub async fn support_bundle_download(
@@ -88,7 +88,7 @@ impl super::Nexus {
         // Lookup the sled holding the bundle, forward the request there
         let sled_id = self
             .db_datastore
-            .zpool_get_sled_if_in_service(&opctx, bundle.zpool_id.into())
+            .zpool_get_sled_if_in_service(opctx, bundle.zpool_id.into())
             .await?;
         let client = self.sled_client(&sled_id).await?;
 
@@ -189,7 +189,7 @@ impl super::Nexus {
         // This is a terminal state
         self.db_datastore
             .support_bundle_update(
-                &opctx,
+                opctx,
                 &authz_bundle,
                 SupportBundleState::Destroying,
             )

--- a/nexus/src/app/switch.rs
+++ b/nexus/src/app/switch.rs
@@ -46,6 +46,6 @@ impl super::Nexus {
         pagparams: &DataPageParams<'_, Uuid>,
     ) -> ListResultVec<db::model::Switch> {
         opctx.authorize(authz::Action::ListChildren, &authz::FLEET).await?;
-        self.db_datastore.switch_list(&opctx, pagparams).await
+        self.db_datastore.switch_list(opctx, pagparams).await
     }
 }

--- a/nexus/src/app/switch_interface.rs
+++ b/nexus/src/app/switch_interface.rs
@@ -42,17 +42,17 @@ impl super::Nexus {
         validate_switch_location(params.switch_location.as_str())?;
 
         // Just a check to make sure a valid rack id was passed in.
-        self.rack_lookup(&opctx, &params.rack_id).await?;
+        self.rack_lookup(opctx, &params.rack_id).await?;
 
         let address_lot_lookup =
-            self.address_lot_lookup(&opctx, params.address_lot.clone())?;
+            self.address_lot_lookup(opctx, params.address_lot.clone())?;
 
         let (.., authz_address_lot) =
             address_lot_lookup.lookup_for(authz::Action::CreateChild).await?;
 
         let value = self
             .db_datastore
-            .loopback_address_create(&opctx, &params, None, &authz_address_lot)
+            .loopback_address_create(opctx, &params, None, &authz_address_lot)
             .await?;
 
         // eagerly propagate changes via rpw
@@ -70,7 +70,7 @@ impl super::Nexus {
         address: IpNet,
     ) -> DeleteResult {
         let loopback_address_lookup = self.loopback_address_lookup(
-            &opctx,
+            opctx,
             rack_id,
             switch_location,
             address,
@@ -80,7 +80,7 @@ impl super::Nexus {
             loopback_address_lookup.lookup_for(authz::Action::Delete).await?;
 
         self.db_datastore
-            .loopback_address_delete(&opctx, &authz_loopback_address)
+            .loopback_address_delete(opctx, &authz_loopback_address)
             .await?;
 
         // eagerly propagate changes via rpw

--- a/nexus/src/app/switch_port.rs
+++ b/nexus/src/app/switch_port.rs
@@ -119,7 +119,7 @@ impl super::Nexus {
 
         for (switch_port_id, _switch_port_name) in ports.into_iter() {
             self.set_switch_port_settings_id(
-                &opctx,
+                opctx,
                 switch_port_id,
                 Some(switch_port_settings_id),
                 UpdatePrecondition::DontCare,
@@ -233,7 +233,7 @@ impl super::Nexus {
         };
 
         self.set_switch_port_settings_id(
-            &opctx,
+            opctx,
             switch_port_id,
             Some(switch_port_settings_id),
             UpdatePrecondition::DontCare,
@@ -266,7 +266,7 @@ impl super::Nexus {
 
         // update the switch port settings association
         self.set_switch_port_settings_id(
-            &opctx,
+            opctx,
             switch_port_id,
             None,
             UpdatePrecondition::DontCare,

--- a/nexus/src/app/test_interfaces.rs
+++ b/nexus/src/app/test_interfaces.rs
@@ -89,7 +89,7 @@ impl TestInterfaces for super::Nexus {
             }
         };
 
-        let (.., authz_instance) = LookupPath::new(&opctx, &self.db_datastore)
+        let (.., authz_instance) = LookupPath::new(opctx, &self.db_datastore)
             .instance_id(id.into_untyped_uuid())
             .lookup_for(nexus_db_queries::authz::Action::Read)
             .await?;

--- a/nexus/src/app/vpc.rs
+++ b/nexus/src/app/vpc.rs
@@ -100,7 +100,7 @@ impl super::Nexus {
     ) -> ListResultVec<db::model::Vpc> {
         let (.., authz_project) =
             project_lookup.lookup_for(authz::Action::ListChildren).await?;
-        self.db_datastore.vpc_list(&opctx, &authz_project, pagparams).await
+        self.db_datastore.vpc_list(opctx, &authz_project, pagparams).await
     }
 
     pub(crate) async fn project_update_vpc(
@@ -144,13 +144,11 @@ impl super::Nexus {
         self.db_datastore
             .project_delete_vpc(opctx, &db_vpc, &authz_vpc)
             .await?;
-        self.db_datastore.vpc_delete_router(&opctx, &authz_vpc_router).await?;
+        self.db_datastore.vpc_delete_router(opctx, &authz_vpc_router).await?;
 
         // Delete all firewall rules after deleting the VPC, to ensure no
         // firewall rules get added between rules deletion and VPC deletion.
-        self.db_datastore
-            .vpc_delete_all_firewall_rules(&opctx, &authz_vpc)
-            .await
+        self.db_datastore.vpc_delete_all_firewall_rules(opctx, &authz_vpc).await
     }
 
     // Firewall rules

--- a/nexus/src/app/vpc_router.rs
+++ b/nexus/src/app/vpc_router.rs
@@ -123,7 +123,7 @@ impl super::Nexus {
         );
         let (_, router) = self
             .db_datastore
-            .vpc_create_router(&opctx, &authz_vpc, router)
+            .vpc_create_router(opctx, &authz_vpc, router)
             .await?;
 
         // Note: we don't trigger the route RPW here as it's impossible
@@ -256,7 +256,7 @@ impl super::Nexus {
         );
         let route = self
             .db_datastore
-            .router_create_route(&opctx, &authz_router, route)
+            .router_create_route(opctx, &authz_router, route)
             .await?;
 
         self.vpc_router_increment_rpw_version(opctx, &authz_router).await?;
@@ -318,7 +318,7 @@ impl super::Nexus {
 
         let out = self
             .db_datastore
-            .router_update_route(&opctx, &authz_route, params.clone().into())
+            .router_update_route(opctx, &authz_route, params.clone().into())
             .await?;
 
         self.vpc_router_increment_rpw_version(opctx, &authz_router).await?;

--- a/nexus/src/context.rs
+++ b/nexus/src/context.rs
@@ -399,7 +399,7 @@ where
             let authn = Arc::new(serialized_authn.to_authn());
             let authz = authz::Context::new(
                 Arc::clone(&authn),
-                Arc::clone(&osagactx.authz()),
+                Arc::clone(osagactx.authz()),
                 datastore,
             );
             Ok::<_, std::convert::Infallible>((authn, authz))
@@ -473,7 +473,7 @@ impl SessionStore for ServerContext {
         token: String,
     ) -> Option<Self::SessionModel> {
         let opctx = self.nexus.opctx_external_authn();
-        self.nexus.session_update_last_used(&opctx, &token).await.ok()
+        self.nexus.session_update_last_used(opctx, &token).await.ok()
     }
 
     async fn session_expire(&self, token: String) -> Option<()> {

--- a/nexus/src/external_api/console_api.rs
+++ b/nexus/src/external_api/console_api.rs
@@ -370,14 +370,14 @@ async fn serve_static(
         .and_then(|v| v.to_str().ok())
         .unwrap_or_default();
     let path_to_read = match accept_gz(accept_encoding)
-        .then(|| find_file(&with_gz_ext(&path), static_dir))
+        .then(|| find_file(&with_gz_ext(path), static_dir))
     {
         Some(Ok(gzipped_path)) => {
             resp = resp
                 .header(http::header::CONTENT_ENCODING, CONTENT_ENCODING_GZIP);
             gzipped_path
         }
-        _ => find_file(&path, static_dir)?,
+        _ => find_file(path, static_dir)?,
     };
 
     let file = File::open(&path_to_read).await.map_err(|e| {

--- a/nexus/src/external_api/http_entrypoints.rs
+++ b/nexus/src/external_api/http_entrypoints.rs
@@ -2082,7 +2082,7 @@ impl NexusExternalApi for NexusExternalApiImpl {
                 .project_create_instance(
                     &opctx,
                     &project_lookup,
-                    &new_instance_params,
+                    new_instance_params,
                 )
                 .await?;
             Ok(HttpResponseCreated(instance.into()))
@@ -4316,7 +4316,7 @@ impl NexusExternalApi for NexusExternalApiImpl {
                 }
             };
             let image =
-                nexus.image_create(&opctx, &parent_lookup, &params).await?;
+                nexus.image_create(&opctx, &parent_lookup, params).await?;
             Ok(HttpResponseCreated(image.into()))
         };
         apictx
@@ -4783,7 +4783,7 @@ impl NexusExternalApi for NexusExternalApiImpl {
             let new_snapshot_params = &new_snapshot.into_inner();
             let project_lookup = nexus.project_lookup(&opctx, query)?;
             let snapshot = nexus
-                .snapshot_create(&opctx, project_lookup, &new_snapshot_params)
+                .snapshot_create(&opctx, project_lookup, new_snapshot_params)
                 .await?;
             Ok(HttpResponseCreated(snapshot.into()))
         };
@@ -4956,7 +4956,7 @@ impl NexusExternalApi for NexusExternalApiImpl {
                 params::VpcSelector { project: query.project, vpc: path.vpc };
             let vpc_lookup = nexus.vpc_lookup(&opctx, vpc_selector)?;
             let vpc = nexus
-                .project_update_vpc(&opctx, &vpc_lookup, &updated_vpc_params)
+                .project_update_vpc(&opctx, &vpc_lookup, updated_vpc_params)
                 .await?;
             Ok(HttpResponseOk(vpc.into()))
         };
@@ -6815,7 +6815,7 @@ impl NexusExternalApi for NexusExternalApiImpl {
         let handler = async {
             let opctx =
                 crate::context::op_context_for_external_api(&rqctx).await?;
-            let role = nexus.role_builtin_fetch(&opctx, &role_name).await?;
+            let role = nexus.role_builtin_fetch(&opctx, role_name).await?;
             Ok(HttpResponseOk(role.into()))
         };
         apictx
@@ -7364,7 +7364,7 @@ impl NexusExternalApi for NexusExternalApiImpl {
             let project_lookup =
                 nexus.project_lookup(&opctx, project_selector)?;
             let probe = nexus
-                .probe_create(&opctx, &project_lookup, &new_probe_params)
+                .probe_create(&opctx, &project_lookup, new_probe_params)
                 .await?;
             Ok(HttpResponseCreated(probe.into()))
         };
@@ -7432,7 +7432,7 @@ impl NexusExternalApi for NexusExternalApiImpl {
 
             nexus
                 .login_saml_redirect(
-                    &opctx,
+                    opctx,
                     &path_params.silo_name.into(),
                     &path_params.provider_name.into(),
                     query_params.redirect_uri,
@@ -7523,9 +7523,9 @@ impl NexusExternalApi for NexusExternalApiImpl {
             // happen using the Nexus "external authentication" context, which we
             // keep specifically for this purpose.
             let opctx = nexus.opctx_external_authn();
-            let silo_lookup = nexus.silo_lookup(&opctx, silo)?;
+            let silo_lookup = nexus.silo_lookup(opctx, silo)?;
             let user =
-                nexus.login_local(&opctx, &silo_lookup, credentials).await?;
+                nexus.login_local(opctx, &silo_lookup, credentials).await?;
 
             let session = nexus.session_create(opctx, &user).await?;
             let mut response = HttpResponseHeaders::new_unnamed(
@@ -7723,7 +7723,7 @@ impl NexusExternalApi for NexusExternalApiImpl {
             };
 
             let model = nexus
-                .device_auth_request_create(&opctx, params.client_id)
+                .device_auth_request_create(opctx, params.client_id)
                 .await?;
             nexus.build_oauth_response(
                 StatusCode::OK,
@@ -7787,7 +7787,7 @@ impl NexusExternalApi for NexusExternalApiImpl {
             let nexus = &apictx.context.nexus;
             let opctx = nexus.opctx_external_authn();
             let params = params.into_inner();
-            nexus.device_access_token(&opctx, params).await
+            nexus.device_access_token(opctx, params).await
         };
         apictx
             .context

--- a/nexus/src/lib.rs
+++ b/nexus/src/lib.rs
@@ -79,12 +79,9 @@ impl InternalServer {
 
         let ctxlog = log.new(o!("component" => "ServerContext"));
 
-        let context = ApiContext::for_internal(
-            config.deployment.rack_id,
-            ctxlog,
-            &config,
-        )
-        .await?;
+        let context =
+            ApiContext::for_internal(config.deployment.rack_id, ctxlog, config)
+                .await?;
 
         // Launch the internal server.
         let http_server_internal = match dropshot::ServerBuilder::new(
@@ -231,7 +228,7 @@ impl nexus_test_interface::NexusServer for Server {
         config: &NexusConfig,
         log: &Logger,
     ) -> Result<(InternalServer, SocketAddr), String> {
-        let internal_server = InternalServer::start(config, &log).await?;
+        let internal_server = InternalServer::start(config, log).await?;
         internal_server.apictx.context.nexus.wait_for_populate().await.unwrap();
         let addr = internal_server.http_server_internal.local_addr();
         Ok((internal_server, addr))

--- a/nexus/src/saga_interface.rs
+++ b/nexus/src/saga_interface.rs
@@ -34,7 +34,7 @@ impl SagaContext {
     }
 
     pub(crate) fn authz(&self) -> &Arc<authz::Authz> {
-        &self.nexus.authz()
+        self.nexus.authz()
     }
 
     pub(crate) fn nexus(&self) -> &Arc<Nexus> {

--- a/nexus/test-utils/src/background.rs
+++ b/nexus/test-utils/src/background.rs
@@ -177,7 +177,7 @@ pub async fn run_region_replacement(
     internal_client: &ClientTestContext,
 ) -> usize {
     let last_background_task =
-        activate_background_task(&internal_client, "region_replacement").await;
+        activate_background_task(internal_client, "region_replacement").await;
 
     let LastResult::Completed(last_result_completed) =
         last_background_task.last
@@ -206,7 +206,7 @@ pub async fn run_region_replacement_driver(
     internal_client: &ClientTestContext,
 ) -> usize {
     let last_background_task =
-        activate_background_task(&internal_client, "region_replacement_driver")
+        activate_background_task(internal_client, "region_replacement_driver")
             .await;
 
     let LastResult::Completed(last_result_completed) =
@@ -234,7 +234,7 @@ pub async fn run_region_snapshot_replacement_start(
     internal_client: &ClientTestContext,
 ) -> usize {
     let last_background_task = activate_background_task(
-        &internal_client,
+        internal_client,
         "region_snapshot_replacement_start",
     )
     .await;
@@ -266,7 +266,7 @@ pub async fn run_region_snapshot_replacement_garbage_collection(
     internal_client: &ClientTestContext,
 ) -> usize {
     let last_background_task = activate_background_task(
-        &internal_client,
+        internal_client,
         "region_snapshot_replacement_garbage_collection",
     )
     .await;
@@ -297,7 +297,7 @@ pub async fn run_region_snapshot_replacement_step(
     internal_client: &ClientTestContext,
 ) -> usize {
     let last_background_task = activate_background_task(
-        &internal_client,
+        internal_client,
         "region_snapshot_replacement_step",
     )
     .await;
@@ -330,7 +330,7 @@ pub async fn run_region_snapshot_replacement_finish(
     internal_client: &ClientTestContext,
 ) -> usize {
     let last_background_task = activate_background_task(
-        &internal_client,
+        internal_client,
         "region_snapshot_replacement_finish",
     )
     .await;
@@ -362,7 +362,7 @@ pub async fn run_read_only_region_replacement_start(
     internal_client: &ClientTestContext,
 ) -> usize {
     let last_background_task = activate_background_task(
-        &internal_client,
+        internal_client,
         "read_only_region_replacement_start",
     )
     .await;
@@ -408,8 +408,7 @@ pub async fn wait_tuf_artifact_replication_step(
     internal_client: &ClientTestContext,
 ) -> TufArtifactReplicationStatus {
     let last_background_task =
-        wait_background_task(&internal_client, "tuf_artifact_replication")
-            .await;
+        wait_background_task(internal_client, "tuf_artifact_replication").await;
 
     let LastResult::Completed(last_result_completed) =
         last_background_task.last
@@ -432,7 +431,7 @@ pub async fn run_tuf_artifact_replication_step(
     internal_client: &ClientTestContext,
 ) -> TufArtifactReplicationStatus {
     let last_background_task =
-        activate_background_task(&internal_client, "tuf_artifact_replication")
+        activate_background_task(internal_client, "tuf_artifact_replication")
             .await;
 
     let LastResult::Completed(last_result_completed) =

--- a/nexus/test-utils/src/lib.rs
+++ b/nexus/test-utils/src/lib.rs
@@ -723,7 +723,7 @@ impl<'a, N: NexusServer> ControlPlaneTestContextBuilder<'a, N> {
         };
 
         let (nexus_internal, nexus_internal_addr) =
-            N::start_internal(&self.config, &log).await?;
+            N::start_internal(self.config, log).await?;
 
         let address = SocketAddrV6::new(
             match nexus_internal_addr.ip() {

--- a/nexus/test-utils/src/resource_helpers.rs
+++ b/nexus/test-utils/src/resource_helpers.rs
@@ -292,8 +292,8 @@ pub async fn link_ip_pool(
 pub async fn create_default_ip_pool(
     client: &ClientTestContext,
 ) -> views::IpPool {
-    let (pool, ..) = create_ip_pool(&client, "default", None).await;
-    link_ip_pool(&client, "default", &DEFAULT_SILO.id(), true).await;
+    let (pool, ..) = create_ip_pool(client, "default", None).await;
+    link_ip_pool(client, "default", &DEFAULT_SILO.id(), true).await;
     pool
 }
 
@@ -592,7 +592,7 @@ pub async fn create_affinity_group(
     group_name: &str,
 ) -> AffinityGroup {
     object_create(
-        &client,
+        client,
         format!("/v1/affinity-groups?project={}", &project_name).as_str(),
         &params::AffinityGroupCreate {
             identity: IdentityMetadataCreateParams {
@@ -612,7 +612,7 @@ pub async fn create_anti_affinity_group(
     group_name: &str,
 ) -> AntiAffinityGroup {
     object_create(
-        &client,
+        client,
         format!("/v1/anti-affinity-groups?project={}", &project_name).as_str(),
         &params::AntiAffinityGroupCreate {
             identity: IdentityMetadataCreateParams {
@@ -632,7 +632,7 @@ pub async fn create_vpc(
     vpc_name: &str,
 ) -> Vpc {
     object_create(
-        &client,
+        client,
         format!("/v1/vpcs?project={}", &project_name).as_str(),
         &params::VpcCreate {
             identity: IdentityMetadataCreateParams {
@@ -688,7 +688,7 @@ pub async fn create_vpc_subnet(
     custom_router: Option<&str>,
 ) -> VpcSubnet {
     object_create(
-        &client,
+        client,
         &format!("/v1/vpc-subnets?project={project_name}&vpc={vpc_name}"),
         &params::VpcSubnetCreate {
             identity: IdentityMetadataCreateParams {
@@ -711,7 +711,7 @@ pub async fn create_router(
     router_name: &str,
 ) -> VpcRouter {
     NexusRequest::objects_post(
-        &client,
+        client,
         format!("/v1/vpc-routers?project={}&vpc={}", &project_name, &vpc_name)
             .as_str(),
         &params::VpcRouterCreate {
@@ -739,7 +739,7 @@ pub async fn create_route(
     target: RouteTarget,
 ) -> RouterRoute {
     NexusRequest::objects_post(
-        &client,
+        client,
         format!(
             "/v1/vpc-router-routes?project={}&vpc={}&router={}",
             &project_name, &vpc_name, &router_name
@@ -808,7 +808,7 @@ pub async fn create_internet_gateway(
     internet_gateway_name: &str,
 ) -> InternetGateway {
     NexusRequest::objects_post(
-        &client,
+        client,
         format!(
             "/v1/internet-gateways?project={}&vpc={}",
             &project_name, &vpc_name
@@ -837,7 +837,7 @@ pub async fn delete_internet_gateway(
     cascade: bool,
 ) {
     NexusRequest::object_delete(
-        &client,
+        client,
         format!(
             "/v1/internet-gateways/{}?project={}&vpc={}&cascade={}",
             &internet_gateway_name, &project_name, &vpc_name, cascade
@@ -865,7 +865,7 @@ pub async fn attach_ip_pool_to_igw(
 
     let ip_pool: Name = ip_pool_name.parse().unwrap();
     NexusRequest::objects_post(
-        &client,
+        client,
         url.as_str(),
         &params::InternetGatewayIpPoolCreate {
             identity: IdentityMetadataCreateParams {
@@ -896,7 +896,7 @@ pub async fn detach_ip_pool_from_igw(
         ip_pool_name, project_name, vpc_name, igw_name, cascade,
     );
 
-    NexusRequest::object_delete(&client, url.as_str())
+    NexusRequest::object_delete(client, url.as_str())
         .authn_as(AuthnMode::PrivilegedUser)
         .execute()
         .await
@@ -917,7 +917,7 @@ pub async fn attach_ip_address_to_igw(
     );
 
     NexusRequest::objects_post(
-        &client,
+        client,
         url.as_str(),
         &params::InternetGatewayIpAddressCreate {
             identity: IdentityMetadataCreateParams {
@@ -948,7 +948,7 @@ pub async fn detach_ip_address_from_igw(
         attachment_name, project_name, vpc_name, igw_name, cascade
     );
 
-    NexusRequest::object_delete(&client, url.as_str())
+    NexusRequest::object_delete(client, url.as_str())
         .authn_as(AuthnMode::PrivilegedUser)
         .execute()
         .await

--- a/nexus/tests/integration_tests/affinity.rs
+++ b/nexus/tests/integration_tests/affinity.rs
@@ -59,8 +59,8 @@ impl<T: AffinityGroupish> ProjectScopedApiHelper<'_, T> {
         instance_name: &str,
     ) -> external::Instance {
         create_instance_with(
-            &self.client,
-            &self.project.as_ref().expect("Need to specify project name"),
+            self.client,
+            self.project.as_ref().expect("Need to specify project name"),
             instance_name,
             &params::InstanceNetworkInterfaceAttachment::None,
             // Disks=
@@ -77,12 +77,12 @@ impl<T: AffinityGroupish> ProjectScopedApiHelper<'_, T> {
 
     async fn instance_groups_list(&self, instance: &str) -> Vec<T::Group> {
         let url = instance_groups_url(T::URL_COMPONENT, instance, self.project);
-        objects_list_page_authz(&self.client, &url).await.items
+        objects_list_page_authz(self.client, &url).await.items
     }
 
     async fn groups_list(&self) -> Vec<T::Group> {
         let url = groups_url(T::URL_COMPONENT, self.project);
-        objects_list_page_authz(&self.client, &url).await.items
+        objects_list_page_authz(self.client, &url).await.items
     }
 
     async fn groups_list_expect_error(
@@ -90,13 +90,13 @@ impl<T: AffinityGroupish> ProjectScopedApiHelper<'_, T> {
         status: StatusCode,
     ) -> HttpErrorResponseBody {
         let url = groups_url(T::URL_COMPONENT, self.project);
-        object_get_error(&self.client, &url, status).await
+        object_get_error(self.client, &url, status).await
     }
 
     async fn group_create(&self, group: &str) -> T::Group {
         let url = groups_url(T::URL_COMPONENT, self.project);
         let params = T::make_create_params(group);
-        object_create(&self.client, &url, &params).await
+        object_create(self.client, &url, &params).await
     }
 
     async fn group_create_expect_error(
@@ -106,12 +106,12 @@ impl<T: AffinityGroupish> ProjectScopedApiHelper<'_, T> {
     ) -> HttpErrorResponseBody {
         let url = groups_url(T::URL_COMPONENT, self.project);
         let params = T::make_create_params(group);
-        object_create_error(&self.client, &url, &params, status).await
+        object_create_error(self.client, &url, &params, status).await
     }
 
     async fn group_get(&self, group: &str) -> T::Group {
         let url = group_url(T::URL_COMPONENT, self.project, group);
-        object_get(&self.client, &url).await
+        object_get(self.client, &url).await
     }
 
     async fn group_get_expect_error(
@@ -120,13 +120,13 @@ impl<T: AffinityGroupish> ProjectScopedApiHelper<'_, T> {
         status: StatusCode,
     ) -> HttpErrorResponseBody {
         let url = group_url(T::URL_COMPONENT, self.project, group);
-        object_get_error(&self.client, &url, status).await
+        object_get_error(self.client, &url, status).await
     }
 
     async fn group_update(&self, group: &str) -> T::Group {
         let url = group_url(T::URL_COMPONENT, self.project, group);
         let params = T::make_update_params();
-        object_put(&self.client, &url, &params).await
+        object_put(self.client, &url, &params).await
     }
 
     async fn group_update_expect_error(
@@ -136,12 +136,12 @@ impl<T: AffinityGroupish> ProjectScopedApiHelper<'_, T> {
     ) -> HttpErrorResponseBody {
         let url = group_url(T::URL_COMPONENT, self.project, group);
         let params = T::make_update_params();
-        object_put_error(&self.client, &url, &params, status).await
+        object_put_error(self.client, &url, &params, status).await
     }
 
     async fn group_delete(&self, group: &str) {
         let url = group_url(T::URL_COMPONENT, self.project, group);
-        object_delete(&self.client, &url).await
+        object_delete(self.client, &url).await
     }
 
     async fn group_delete_expect_error(
@@ -150,12 +150,12 @@ impl<T: AffinityGroupish> ProjectScopedApiHelper<'_, T> {
         status: StatusCode,
     ) -> HttpErrorResponseBody {
         let url = group_url(T::URL_COMPONENT, self.project, group);
-        object_delete_error(&self.client, &url, status).await
+        object_delete_error(self.client, &url, status).await
     }
 
     async fn group_members_list(&self, group: &str) -> Vec<T::Member> {
         let url = group_members_url(T::URL_COMPONENT, self.project, group);
-        objects_list_page_authz(&self.client, &url).await.items
+        objects_list_page_authz(self.client, &url).await.items
     }
 
     async fn group_members_list_expect_error(
@@ -164,7 +164,7 @@ impl<T: AffinityGroupish> ProjectScopedApiHelper<'_, T> {
         status: StatusCode,
     ) -> HttpErrorResponseBody {
         let url = group_members_url(T::URL_COMPONENT, self.project, group);
-        object_get_error(&self.client, &url, status).await
+        object_get_error(self.client, &url, status).await
     }
 
     async fn group_member_add(&self, group: &str, instance: &str) -> T::Member {
@@ -174,7 +174,7 @@ impl<T: AffinityGroupish> ProjectScopedApiHelper<'_, T> {
             group,
             instance,
         );
-        object_create(&self.client, &url, &()).await
+        object_create(self.client, &url, &()).await
     }
 
     async fn group_member_add_expect_error(
@@ -189,7 +189,7 @@ impl<T: AffinityGroupish> ProjectScopedApiHelper<'_, T> {
             group,
             instance,
         );
-        object_create_error(&self.client, &url, &(), status).await
+        object_create_error(self.client, &url, &(), status).await
     }
 
     async fn group_member_get(&self, group: &str, instance: &str) -> T::Member {
@@ -199,7 +199,7 @@ impl<T: AffinityGroupish> ProjectScopedApiHelper<'_, T> {
             group,
             instance,
         );
-        object_get(&self.client, &url).await
+        object_get(self.client, &url).await
     }
 
     async fn group_member_get_expect_error(
@@ -214,7 +214,7 @@ impl<T: AffinityGroupish> ProjectScopedApiHelper<'_, T> {
             group,
             instance,
         );
-        object_get_error(&self.client, &url, status).await
+        object_get_error(self.client, &url, status).await
     }
 
     async fn group_member_delete(&self, group: &str, instance: &str) {
@@ -224,7 +224,7 @@ impl<T: AffinityGroupish> ProjectScopedApiHelper<'_, T> {
             group,
             instance,
         );
-        object_delete(&self.client, &url).await
+        object_delete(self.client, &url).await
     }
 
     async fn group_member_delete_expect_error(
@@ -239,7 +239,7 @@ impl<T: AffinityGroupish> ProjectScopedApiHelper<'_, T> {
             group,
             instance,
         );
-        object_delete_error(&self.client, &url, status).await
+        object_delete_error(self.client, &url, status).await
     }
 }
 
@@ -268,17 +268,17 @@ impl<'a> ApiHelper<'a> {
     }
 
     async fn create_project(&self, name: &str) {
-        create_project(&self.client, name).await;
+        create_project(self.client, name).await;
     }
 
     async fn sleds_list(&self) -> Vec<Sled> {
         let url = "/v1/system/hardware/sleds";
-        objects_list_page_authz(&self.client, url).await.items
+        objects_list_page_authz(self.client, url).await.items
     }
 
     async fn sled_instance_list(&self, sled: &str) -> Vec<SledInstance> {
         let url = format!("/v1/system/hardware/sleds/{sled}/instances");
-        objects_list_page_authz(&self.client, &url).await.items
+        objects_list_page_authz(self.client, &url).await.items
     }
 
     async fn start_instance(
@@ -288,7 +288,7 @@ impl<'a> ApiHelper<'a> {
         let uri = format!("/v1/instances/{}/start", instance.identity.id);
 
         NexusRequest::new(
-            RequestBuilder::new(&self.client, http::Method::POST, &uri)
+            RequestBuilder::new(self.client, http::Method::POST, &uri)
                 .expect_status(Some(http::StatusCode::ACCEPTED)),
         )
         .authn_as(AuthnMode::PrivilegedUser)
@@ -462,7 +462,7 @@ async fn test_affinity_group_usage(cptestctx: &ControlPlaneTestContext) {
     }
 
     // Create an IP pool and project that we'll use for testing.
-    create_default_ip_pool(&external_client).await;
+    create_default_ip_pool(external_client).await;
     api.create_project(PROJECT_NAME).await;
 
     let project_api = api.use_project::<AffinityType>(PROJECT_NAME);
@@ -518,7 +518,7 @@ async fn test_affinity_group_usage(cptestctx: &ControlPlaneTestContext) {
     // We don't actually care that they're "running" from the perspective of the
     // simulated sled agent, we just want placement to be triggered from Nexus.
     for instance in &instances {
-        api.start_instance(&instance).await;
+        api.start_instance(instance).await;
     }
 
     // Use a BTreeSet so we can ignore ordering when comparing instance
@@ -573,7 +573,7 @@ async fn test_anti_affinity_group_usage(cptestctx: &ControlPlaneTestContext) {
     }
 
     // Create an IP pool and project that we'll use for testing.
-    create_default_ip_pool(&external_client).await;
+    create_default_ip_pool(external_client).await;
     api.create_project(PROJECT_NAME).await;
 
     let project_api = api.use_project::<AntiAffinityType>(PROJECT_NAME);
@@ -629,7 +629,7 @@ async fn test_anti_affinity_group_usage(cptestctx: &ControlPlaneTestContext) {
     // We don't actually care that they're "running" from the perspective of the
     // simulated sled agent, we just want placement to be triggered from Nexus.
     for instance in &instances {
-        api.start_instance(&instance).await;
+        api.start_instance(instance).await;
     }
 
     let mut expected_instances = instances
@@ -685,7 +685,7 @@ async fn test_group_crud<T: AffinityGroupish>(client: &ClientTestContext) {
     let api = ApiHelper::new(client);
 
     // Create an IP pool and project that we'll use for testing.
-    create_default_ip_pool(&client).await;
+    create_default_ip_pool(client).await;
     api.create_project(PROJECT_NAME).await;
 
     let project_api = api.use_project::<T>(PROJECT_NAME);
@@ -716,11 +716,11 @@ async fn test_group_crud<T: AffinityGroupish>(client: &ClientTestContext) {
 
     // Add the instance to the affinity group
     let instance_name = &instance.identity.name.to_string();
-    project_api.group_member_add(GROUP_NAME, &instance_name).await;
+    project_api.group_member_add(GROUP_NAME, instance_name).await;
     let response = project_api
         .group_member_add_expect_error(
             GROUP_NAME,
-            &instance_name,
+            instance_name,
             StatusCode::BAD_REQUEST,
         )
         .await;
@@ -741,11 +741,11 @@ async fn test_group_crud<T: AffinityGroupish>(client: &ClientTestContext) {
         .await;
 
     // Delete the member, observe that it is gone
-    project_api.group_member_delete(GROUP_NAME, &instance_name).await;
+    project_api.group_member_delete(GROUP_NAME, instance_name).await;
     project_api
         .group_member_delete_expect_error(
             GROUP_NAME,
-            &instance_name,
+            instance_name,
             StatusCode::NOT_FOUND,
         )
         .await;
@@ -754,7 +754,7 @@ async fn test_group_crud<T: AffinityGroupish>(client: &ClientTestContext) {
     project_api
         .group_member_get_expect_error(
             GROUP_NAME,
-            &instance_name,
+            instance_name,
             StatusCode::NOT_FOUND,
         )
         .await;
@@ -793,7 +793,7 @@ async fn test_instance_group_list<T: AffinityGroupish>(
     let api = ApiHelper::new(client);
 
     // Create an IP pool and project that we'll use for testing.
-    create_default_ip_pool(&client).await;
+    create_default_ip_pool(client).await;
     api.create_project(PROJECT_NAME).await;
 
     let project_api = api.use_project::<T>(PROJECT_NAME);
@@ -837,7 +837,7 @@ async fn test_group_project_selector<T: AffinityGroupish>(
     let api = ApiHelper::new(client);
 
     // Create an IP pool and project that we'll use for testing.
-    create_default_ip_pool(&client).await;
+    create_default_ip_pool(client).await;
     api.create_project(PROJECT_NAME).await;
 
     // All requests use the "?project={PROJECT_NAME}" query parameter

--- a/nexus/tests/integration_tests/authz.rs
+++ b/nexus/tests/integration_tests/authz.rs
@@ -26,13 +26,9 @@ async fn test_cannot_read_others_ssh_keys(cptestctx: &ControlPlaneTestContext) {
     let client = &cptestctx.external_client;
 
     // Create a silo with a two unprivileged users
-    let silo = create_silo(
-        &client,
-        "authz",
-        true,
-        shared::SiloIdentityMode::LocalOnly,
-    )
-    .await;
+    let silo =
+        create_silo(client, "authz", true, shared::SiloIdentityMode::LocalOnly)
+            .await;
 
     let user1 = create_local_user(
         client,
@@ -115,7 +111,7 @@ async fn test_cannot_read_others_ssh_keys(cptestctx: &ControlPlaneTestContext) {
 
     // it also shouldn't show up in their list
     let user2_keys: ResultsPage<views::SshKey> =
-        NexusRequest::object_get(client, &"/v1/me/ssh-keys")
+        NexusRequest::object_get(client, "/v1/me/ssh-keys")
             .authn_as(AuthnMode::SiloUser(user2))
             .execute()
             .await
@@ -132,13 +128,9 @@ async fn test_list_silo_users_for_unpriv(cptestctx: &ControlPlaneTestContext) {
     let client = &cptestctx.external_client;
 
     // Create a silo with an unprivileged user
-    let silo = create_silo(
-        &client,
-        "authz",
-        true,
-        shared::SiloIdentityMode::LocalOnly,
-    )
-    .await;
+    let silo =
+        create_silo(client, "authz", true, shared::SiloIdentityMode::LocalOnly)
+            .await;
 
     let new_silo_user_id = create_local_user(
         client,
@@ -150,13 +142,9 @@ async fn test_list_silo_users_for_unpriv(cptestctx: &ControlPlaneTestContext) {
     .id;
 
     // Create another silo with another unprivileged user
-    let silo = create_silo(
-        &client,
-        "other",
-        true,
-        shared::SiloIdentityMode::LocalOnly,
-    )
-    .await;
+    let silo =
+        create_silo(client, "other", true, shared::SiloIdentityMode::LocalOnly)
+            .await;
 
     create_local_user(
         client,
@@ -168,7 +156,7 @@ async fn test_list_silo_users_for_unpriv(cptestctx: &ControlPlaneTestContext) {
 
     // Listing users should work
     let users: ResultsPage<views::User> =
-        NexusRequest::object_get(client, &"/v1/users")
+        NexusRequest::object_get(client, "/v1/users")
             .authn_as(AuthnMode::SiloUser(new_silo_user_id))
             .execute()
             .await
@@ -188,13 +176,9 @@ async fn test_list_silo_idps_for_unpriv(cptestctx: &ControlPlaneTestContext) {
     let client = &cptestctx.external_client;
 
     // Create a silo with an unprivileged user
-    let silo = create_silo(
-        &client,
-        "authz",
-        true,
-        shared::SiloIdentityMode::LocalOnly,
-    )
-    .await;
+    let silo =
+        create_silo(client, "authz", true, shared::SiloIdentityMode::LocalOnly)
+            .await;
 
     let new_silo_user_id = create_local_user(
         client,
@@ -208,7 +192,7 @@ async fn test_list_silo_idps_for_unpriv(cptestctx: &ControlPlaneTestContext) {
     let _users: ResultsPage<views::IdentityProvider> =
         NexusRequest::object_get(
             client,
-            &"/v1/system/identity-providers?silo=authz",
+            "/v1/system/identity-providers?silo=authz",
         )
         .authn_as(AuthnMode::SiloUser(new_silo_user_id))
         .execute()
@@ -224,13 +208,9 @@ async fn test_session_me_for_unpriv(cptestctx: &ControlPlaneTestContext) {
     let client = &cptestctx.external_client;
 
     // Create a silo with an unprivileged user
-    let silo = create_silo(
-        &client,
-        "authz",
-        true,
-        shared::SiloIdentityMode::LocalOnly,
-    )
-    .await;
+    let silo =
+        create_silo(client, "authz", true, shared::SiloIdentityMode::LocalOnly)
+            .await;
 
     let new_silo_user_id = create_local_user(
         client,
@@ -241,7 +221,7 @@ async fn test_session_me_for_unpriv(cptestctx: &ControlPlaneTestContext) {
     .await
     .id;
 
-    let _session_user = NexusRequest::object_get(client, &"/v1/me")
+    let _session_user = NexusRequest::object_get(client, "/v1/me")
         .authn_as(AuthnMode::SiloUser(new_silo_user_id))
         .execute()
         .await
@@ -254,13 +234,9 @@ async fn test_silo_read_for_unpriv(cptestctx: &ControlPlaneTestContext) {
     let client = &cptestctx.external_client;
 
     // Create a silo with an unprivileged user
-    let silo = create_silo(
-        &client,
-        "authz",
-        true,
-        shared::SiloIdentityMode::LocalOnly,
-    )
-    .await;
+    let silo =
+        create_silo(client, "authz", true, shared::SiloIdentityMode::LocalOnly)
+            .await;
 
     let new_silo_user_id = create_local_user(
         client,
@@ -272,17 +248,13 @@ async fn test_silo_read_for_unpriv(cptestctx: &ControlPlaneTestContext) {
     .id;
 
     // Create another silo
-    let _silo = create_silo(
-        &client,
-        "other",
-        true,
-        shared::SiloIdentityMode::LocalOnly,
-    )
-    .await;
+    let _silo =
+        create_silo(client, "other", true, shared::SiloIdentityMode::LocalOnly)
+            .await;
 
     // That user can access their own silo
     let _silo: views::Silo =
-        NexusRequest::object_get(client, &"/v1/system/silos/authz")
+        NexusRequest::object_get(client, "/v1/system/silos/authz")
             .authn_as(AuthnMode::SiloUser(new_silo_user_id))
             .execute()
             .await
@@ -295,7 +267,7 @@ async fn test_silo_read_for_unpriv(cptestctx: &ControlPlaneTestContext) {
         RequestBuilder::new(
             client,
             http::Method::GET,
-            &"/v1/system/silos/other",
+            "/v1/system/silos/other",
         )
         .expect_status(Some(http::StatusCode::NOT_FOUND)),
     )

--- a/nexus/tests/integration_tests/basic.rs
+++ b/nexus/tests/integration_tests/basic.rs
@@ -148,7 +148,7 @@ async fn test_projects_basic(cptestctx: &ControlPlaneTestContext) {
     let projects_url = "/v1/projects";
 
     // Verify that there are no projects to begin with.
-    let projects = projects_list(&client, &projects_url, "", None).await;
+    let projects = projects_list(client, projects_url, "", None).await;
     assert_eq!(0, projects.len());
 
     // Create three projects used by the rest of this test.
@@ -199,8 +199,7 @@ async fn test_projects_basic(cptestctx: &ControlPlaneTestContext) {
     // Basic GET projects list now that we've created a few.
     // TODO-coverage: pagination
     // TODO-coverage: marker even without pagination
-    let initial_projects =
-        projects_list(&client, &projects_url, "", None).await;
+    let initial_projects = projects_list(client, projects_url, "", None).await;
     assert_eq!(initial_projects.len(), 3);
     assert_eq!(initial_projects[0].identity.id, new_project_ids[0]);
     assert_eq!(initial_projects[0].identity.name, "simproject1");
@@ -213,7 +212,7 @@ async fn test_projects_basic(cptestctx: &ControlPlaneTestContext) {
     assert!(!initial_projects[2].identity.description.is_empty());
 
     // Basic test of out-of-the-box GET project
-    let project = project_get(&client, "/v1/projects/simproject2").await;
+    let project = project_get(client, "/v1/projects/simproject2").await;
     let expected = &initial_projects[1];
     assert_eq!(project.identity.id, expected.identity.id);
     assert_eq!(project.identity.name, expected.identity.name);
@@ -276,7 +275,7 @@ async fn test_projects_basic(cptestctx: &ControlPlaneTestContext) {
         .iter()
         .filter(|p| p.identity.name != "simproject2")
         .collect();
-    let new_projects = projects_list(&client, "/v1/projects", "", None).await;
+    let new_projects = projects_list(client, "/v1/projects", "", None).await;
     assert_eq!(new_projects.len(), expected_projects.len());
     assert_eq!(new_projects[0].identity.id, expected_projects[0].identity.id);
     assert_eq!(
@@ -321,7 +320,7 @@ async fn test_projects_basic(cptestctx: &ControlPlaneTestContext) {
     assert_eq!(project.identity.description, "Li'l lightnin'");
 
     let expected = project;
-    let project = project_get(&client, "/v1/projects/simproject3").await;
+    let project = project_get(client, "/v1/projects/simproject3").await;
     assert_eq!(project.identity.name, expected.identity.name);
     assert_eq!(project.identity.description, expected.identity.description);
     assert_eq!(project.identity.description, "Li'l lightnin'");
@@ -369,7 +368,7 @@ async fn test_projects_basic(cptestctx: &ControlPlaneTestContext) {
         },
     };
     let error = NexusRequest::new(
-        RequestBuilder::new(client, Method::POST, &projects_url)
+        RequestBuilder::new(client, Method::POST, projects_url)
             .body(Some(&project_create))
             .expect_status(Some(StatusCode::BAD_REQUEST)),
     )
@@ -391,7 +390,7 @@ async fn test_projects_basic(cptestctx: &ControlPlaneTestContext) {
         description: &'static str,
     }
     let error = NexusRequest::new(
-        RequestBuilder::new(client, Method::POST, &projects_url)
+        RequestBuilder::new(client, Method::POST, projects_url)
             .body(Some(&BadProject {
                 name: "sim_project",
                 description: "underscore",
@@ -432,7 +431,7 @@ async fn test_projects_basic(cptestctx: &ControlPlaneTestContext) {
     // - "honor-roller" with description "a soapbox racer"
     // - "lil-lightnin" with description "little lightning"
     // - "simproject1", same as when it was created.
-    let projects = projects_list(&client, &projects_url, "", None).await;
+    let projects = projects_list(client, projects_url, "", None).await;
     assert_eq!(projects.len(), 3);
     assert_eq!(projects[0].identity.name, "honor-roller");
     assert_eq!(projects[0].identity.description, "a soapbox racer");
@@ -448,7 +447,7 @@ async fn test_projects_list(cptestctx: &ControlPlaneTestContext) {
 
     // Verify that there are no projects to begin with.
     let projects_url = "/v1/projects";
-    assert_eq!(projects_list(&client, &projects_url, "", None).await.len(), 0);
+    assert_eq!(projects_list(client, projects_url, "", None).await.len(), 0);
 
     // Create a large number of projects that we can page through.
     let projects_total = 10;
@@ -461,7 +460,7 @@ async fn test_projects_list(cptestctx: &ControlPlaneTestContext) {
         // a uuid though, so we'll use a prefix.
         let mut name = Uuid::new_v4().to_string();
         name.insert_str(0, "project-");
-        let project = create_project(&client, &name).await;
+        let project = create_project(client, &name).await;
         projects_created.push(project.identity);
     }
 
@@ -482,7 +481,7 @@ async fn test_projects_list(cptestctx: &ControlPlaneTestContext) {
     // Page through all the projects in the default order, which should be in
     // increasing order of name.
     let found_projects_by_name =
-        projects_list(&client, projects_url, "", Some(projects_subset)).await;
+        projects_list(client, projects_url, "", Some(projects_subset)).await;
     assert_eq!(found_projects_by_name.len(), project_names_by_name.len());
     assert_eq!(
         project_names_by_name,
@@ -495,7 +494,7 @@ async fn test_projects_list(cptestctx: &ControlPlaneTestContext) {
     // Page through all the projects in ascending order by name, which should be
     // the same as above.
     let found_projects_by_name = projects_list(
-        &client,
+        client,
         projects_url,
         "sort_by=name_ascending",
         Some(projects_subset),
@@ -513,7 +512,7 @@ async fn test_projects_list(cptestctx: &ControlPlaneTestContext) {
     // Page through all the projects in descending order by name, which should be
     // the reverse of the above.
     let mut found_projects_by_name = projects_list(
-        &client,
+        client,
         projects_url,
         "sort_by=name_descending",
         Some(projects_subset),
@@ -531,7 +530,7 @@ async fn test_projects_list(cptestctx: &ControlPlaneTestContext) {
 
     // Page through the projects in ascending order by id.
     let found_projects_by_id = projects_list(
-        &client,
+        client,
         projects_url,
         "sort_by=id_ascending",
         Some(projects_subset),

--- a/nexus/tests/integration_tests/endpoints.rs
+++ b/nexus/tests/integration_tests/endpoints.rs
@@ -1298,8 +1298,8 @@ impl AllowedMethod {
             | AllowedMethod::GetUnimplemented
             | AllowedMethod::GetVolatile
             | AllowedMethod::GetWebsocket => None,
-            AllowedMethod::Post(body) => Some(&body),
-            AllowedMethod::Put(body) => Some(&body),
+            AllowedMethod::Post(body) => Some(body),
+            AllowedMethod::Put(body) => Some(body),
         }
     }
 }
@@ -1314,7 +1314,7 @@ pub static VERIFY_ENDPOINTS: LazyLock<Vec<VerifyEndpoint>> =
         vec![
             // Global IAM policy
             VerifyEndpoint {
-                url: &SYSTEM_POLICY_URL,
+                url: SYSTEM_POLICY_URL,
                 visibility: Visibility::Public,
                 unprivileged_access: UnprivilegedAccess::None,
                 allowed_methods: vec![
@@ -1331,7 +1331,7 @@ pub static VERIFY_ENDPOINTS: LazyLock<Vec<VerifyEndpoint>> =
             },
             // IP Pools top-level endpoint
             VerifyEndpoint {
-                url: &DEMO_IP_POOLS_URL,
+                url: DEMO_IP_POOLS_URL,
                 visibility: Visibility::Public,
                 unprivileged_access: UnprivilegedAccess::None,
                 allowed_methods: vec![
@@ -1425,7 +1425,7 @@ pub static VERIFY_ENDPOINTS: LazyLock<Vec<VerifyEndpoint>> =
             },
             // IP Pool endpoint (Oxide services)
             VerifyEndpoint {
-                url: &DEMO_IP_POOL_SERVICE_URL,
+                url: DEMO_IP_POOL_SERVICE_URL,
                 visibility: Visibility::Protected,
                 unprivileged_access: UnprivilegedAccess::None,
                 allowed_methods: vec![AllowedMethod::Get],
@@ -2280,7 +2280,7 @@ pub static VERIFY_ENDPOINTS: LazyLock<Vec<VerifyEndpoint>> =
                 allowed_methods: vec![AllowedMethod::Get],
             },
             VerifyEndpoint {
-                url: &HARDWARE_UNINITIALIZED_SLEDS,
+                url: HARDWARE_UNINITIALIZED_SLEDS,
                 visibility: Visibility::Public,
                 unprivileged_access: UnprivilegedAccess::None,
                 allowed_methods: vec![AllowedMethod::Get],
@@ -2331,7 +2331,7 @@ pub static VERIFY_ENDPOINTS: LazyLock<Vec<VerifyEndpoint>> =
                 allowed_methods: vec![AllowedMethod::GetNonexistent],
             },
             VerifyEndpoint {
-                url: &HARDWARE_DISKS_URL,
+                url: HARDWARE_DISKS_URL,
                 visibility: Visibility::Public,
                 unprivileged_access: UnprivilegedAccess::None,
                 allowed_methods: vec![AllowedMethod::Get],
@@ -2350,7 +2350,7 @@ pub static VERIFY_ENDPOINTS: LazyLock<Vec<VerifyEndpoint>> =
             },
             /* Support Bundles */
             VerifyEndpoint {
-                url: &SUPPORT_BUNDLES_URL,
+                url: SUPPORT_BUNDLES_URL,
                 visibility: Visibility::Public,
                 unprivileged_access: UnprivilegedAccess::None,
                 allowed_methods: vec![
@@ -2435,13 +2435,13 @@ pub static VERIFY_ENDPOINTS: LazyLock<Vec<VerifyEndpoint>> =
             },
             /* Silo identity providers */
             VerifyEndpoint {
-                url: &IDENTITY_PROVIDERS_URL,
+                url: IDENTITY_PROVIDERS_URL,
                 visibility: Visibility::Public,
                 unprivileged_access: UnprivilegedAccess::ReadOnly,
                 allowed_methods: vec![AllowedMethod::Get],
             },
             VerifyEndpoint {
-                url: &SAML_IDENTITY_PROVIDERS_URL,
+                url: SAML_IDENTITY_PROVIDERS_URL,
                 // The visibility here deserves some explanation.  In order to
                 // create a real SAML identity provider for doing tests, we have to
                 // do it in a non-default Silo (because the default one does not
@@ -2476,7 +2476,7 @@ pub static VERIFY_ENDPOINTS: LazyLock<Vec<VerifyEndpoint>> =
             },
             /* SSH keys */
             VerifyEndpoint {
-                url: &DEMO_SSHKEYS_URL,
+                url: DEMO_SSHKEYS_URL,
                 visibility: Visibility::Protected,
                 unprivileged_access: UnprivilegedAccess::Full,
                 allowed_methods: vec![
@@ -2497,7 +2497,7 @@ pub static VERIFY_ENDPOINTS: LazyLock<Vec<VerifyEndpoint>> =
             },
             /* Certificates */
             VerifyEndpoint {
-                url: &DEMO_CERTIFICATES_URL,
+                url: DEMO_CERTIFICATES_URL,
                 visibility: Visibility::Public,
                 unprivileged_access: UnprivilegedAccess::None,
                 allowed_methods: vec![
@@ -2509,7 +2509,7 @@ pub static VERIFY_ENDPOINTS: LazyLock<Vec<VerifyEndpoint>> =
                 ],
             },
             VerifyEndpoint {
-                url: &DEMO_CERTIFICATE_URL,
+                url: DEMO_CERTIFICATE_URL,
                 visibility: Visibility::Protected,
                 unprivileged_access: UnprivilegedAccess::None,
                 allowed_methods: vec![
@@ -2519,7 +2519,7 @@ pub static VERIFY_ENDPOINTS: LazyLock<Vec<VerifyEndpoint>> =
             },
             /* External Networking */
             VerifyEndpoint {
-                url: &DEMO_SWITCH_PORT_URL,
+                url: DEMO_SWITCH_PORT_URL,
                 visibility: Visibility::Public,
                 unprivileged_access: UnprivilegedAccess::None,
                 allowed_methods: vec![AllowedMethod::Get],
@@ -2547,7 +2547,7 @@ pub static VERIFY_ENDPOINTS: LazyLock<Vec<VerifyEndpoint>> =
                 ],
             },
             VerifyEndpoint {
-                url: &DEMO_ADDRESS_LOTS_URL,
+                url: DEMO_ADDRESS_LOTS_URL,
                 visibility: Visibility::Public,
                 unprivileged_access: UnprivilegedAccess::None,
                 allowed_methods: vec![
@@ -2559,13 +2559,13 @@ pub static VERIFY_ENDPOINTS: LazyLock<Vec<VerifyEndpoint>> =
                 ],
             },
             VerifyEndpoint {
-                url: &DEMO_ADDRESS_LOT_URL,
+                url: DEMO_ADDRESS_LOT_URL,
                 visibility: Visibility::Protected,
                 unprivileged_access: UnprivilegedAccess::None,
                 allowed_methods: vec![AllowedMethod::Delete],
             },
             VerifyEndpoint {
-                url: &DEMO_ADDRESS_LOT_BLOCKS_URL,
+                url: DEMO_ADDRESS_LOT_BLOCKS_URL,
                 visibility: Visibility::Protected,
                 unprivileged_access: UnprivilegedAccess::None,
                 allowed_methods: vec![AllowedMethod::GetNonexistent],
@@ -2588,7 +2588,7 @@ pub static VERIFY_ENDPOINTS: LazyLock<Vec<VerifyEndpoint>> =
                 allowed_methods: vec![AllowedMethod::Delete],
             },
             VerifyEndpoint {
-                url: &DEMO_SWITCH_PORT_SETTINGS_URL,
+                url: DEMO_SWITCH_PORT_SETTINGS_URL,
                 visibility: Visibility::Public,
                 unprivileged_access: UnprivilegedAccess::None,
                 allowed_methods: vec![
@@ -2603,13 +2603,13 @@ pub static VERIFY_ENDPOINTS: LazyLock<Vec<VerifyEndpoint>> =
                 ],
             },
             VerifyEndpoint {
-                url: &DEMO_SWITCH_PORT_SETTINGS_INFO_URL,
+                url: DEMO_SWITCH_PORT_SETTINGS_INFO_URL,
                 visibility: Visibility::Public,
                 unprivileged_access: UnprivilegedAccess::None,
                 allowed_methods: vec![AllowedMethod::GetNonexistent],
             },
             VerifyEndpoint {
-                url: &DEMO_BGP_CONFIG_CREATE_URL,
+                url: DEMO_BGP_CONFIG_CREATE_URL,
                 visibility: Visibility::Public,
                 unprivileged_access: UnprivilegedAccess::None,
                 allowed_methods: vec![
@@ -2621,7 +2621,7 @@ pub static VERIFY_ENDPOINTS: LazyLock<Vec<VerifyEndpoint>> =
                 ],
             },
             VerifyEndpoint {
-                url: &DEMO_BGP_ANNOUNCE_SET_URL,
+                url: DEMO_BGP_ANNOUNCE_SET_URL,
                 visibility: Visibility::Public,
                 unprivileged_access: UnprivilegedAccess::None,
                 allowed_methods: vec![
@@ -2632,49 +2632,49 @@ pub static VERIFY_ENDPOINTS: LazyLock<Vec<VerifyEndpoint>> =
                 ],
             },
             VerifyEndpoint {
-                url: &DEMO_BGP_ANNOUNCE_SET_DELETE_URL,
+                url: DEMO_BGP_ANNOUNCE_SET_DELETE_URL,
                 visibility: Visibility::Public,
                 unprivileged_access: UnprivilegedAccess::None,
                 allowed_methods: vec![AllowedMethod::Delete],
             },
             VerifyEndpoint {
-                url: &DEMO_BGP_ANNOUNCEMENT_URL,
+                url: DEMO_BGP_ANNOUNCEMENT_URL,
                 visibility: Visibility::Public,
                 unprivileged_access: UnprivilegedAccess::None,
                 allowed_methods: vec![AllowedMethod::GetNonexistent],
             },
             VerifyEndpoint {
-                url: &DEMO_BGP_STATUS_URL,
+                url: DEMO_BGP_STATUS_URL,
                 visibility: Visibility::Public,
                 unprivileged_access: UnprivilegedAccess::None,
                 allowed_methods: vec![AllowedMethod::GetNonexistent],
             },
             VerifyEndpoint {
-                url: &DEMO_BGP_EXPORTED_URL,
+                url: DEMO_BGP_EXPORTED_URL,
                 visibility: Visibility::Public,
                 unprivileged_access: UnprivilegedAccess::None,
                 allowed_methods: vec![AllowedMethod::GetNonexistent],
             },
             VerifyEndpoint {
-                url: &DEMO_BGP_ROUTES_IPV4_URL,
+                url: DEMO_BGP_ROUTES_IPV4_URL,
                 visibility: Visibility::Public,
                 unprivileged_access: UnprivilegedAccess::None,
                 allowed_methods: vec![AllowedMethod::GetNonexistent],
             },
             VerifyEndpoint {
-                url: &DEMO_BGP_MESSAGE_HISTORY_URL,
+                url: DEMO_BGP_MESSAGE_HISTORY_URL,
                 visibility: Visibility::Public,
                 unprivileged_access: UnprivilegedAccess::None,
                 allowed_methods: vec![AllowedMethod::GetNonexistent],
             },
             VerifyEndpoint {
-                url: &DEMO_BFD_STATUS_URL,
+                url: DEMO_BFD_STATUS_URL,
                 visibility: Visibility::Public,
                 unprivileged_access: UnprivilegedAccess::None,
                 allowed_methods: vec![AllowedMethod::GetNonexistent],
             },
             VerifyEndpoint {
-                url: &DEMO_BFD_ENABLE_URL,
+                url: DEMO_BFD_ENABLE_URL,
                 visibility: Visibility::Public,
                 unprivileged_access: UnprivilegedAccess::None,
                 allowed_methods: vec![AllowedMethod::Post(
@@ -2682,7 +2682,7 @@ pub static VERIFY_ENDPOINTS: LazyLock<Vec<VerifyEndpoint>> =
                 )],
             },
             VerifyEndpoint {
-                url: &DEMO_BFD_DISABLE_URL,
+                url: DEMO_BFD_DISABLE_URL,
                 visibility: Visibility::Public,
                 unprivileged_access: UnprivilegedAccess::None,
                 allowed_methods: vec![AllowedMethod::Post(

--- a/nexus/tests/integration_tests/images.rs
+++ b/nexus/tests/integration_tests/images.rs
@@ -50,7 +50,7 @@ fn get_image_create(source: params::ImageSource) -> params::ImageCreate {
 #[nexus_test]
 async fn test_image_create(cptestctx: &ControlPlaneTestContext) {
     let client = &cptestctx.external_client;
-    DiskTest::new(&cptestctx).await;
+    DiskTest::new(cptestctx).await;
 
     let images_url = get_project_images_url(PROJECT_NAME);
 
@@ -101,12 +101,12 @@ async fn test_image_create(cptestctx: &ControlPlaneTestContext) {
 #[nexus_test]
 async fn test_silo_image_create(cptestctx: &ControlPlaneTestContext) {
     let client = &cptestctx.external_client;
-    DiskTest::new(&cptestctx).await;
+    DiskTest::new(cptestctx).await;
 
     let silo_images_url = "/v1/images";
 
     // Expect no images in the silo
-    let images = NexusRequest::object_get(client, &silo_images_url)
+    let images = NexusRequest::object_get(client, silo_images_url)
         .authn_as(AuthnMode::PrivilegedUser)
         .execute_and_parse_unwrap::<ResultsPage<views::Image>>()
         .await
@@ -120,12 +120,12 @@ async fn test_silo_image_create(cptestctx: &ControlPlaneTestContext) {
     );
 
     // Create image
-    NexusRequest::objects_post(client, &silo_images_url, &image_create_params)
+    NexusRequest::objects_post(client, silo_images_url, &image_create_params)
         .authn_as(AuthnMode::PrivilegedUser)
         .execute_and_parse_unwrap::<views::Image>()
         .await;
 
-    let images = NexusRequest::object_get(client, &silo_images_url)
+    let images = NexusRequest::object_get(client, silo_images_url)
         .authn_as(AuthnMode::PrivilegedUser)
         .execute_and_parse_unwrap::<ResultsPage<views::Image>>()
         .await
@@ -138,7 +138,7 @@ async fn test_silo_image_create(cptestctx: &ControlPlaneTestContext) {
 #[nexus_test]
 async fn test_make_disk_from_image(cptestctx: &ControlPlaneTestContext) {
     let client = &cptestctx.external_client;
-    DiskTest::new(&cptestctx).await;
+    DiskTest::new(cptestctx).await;
 
     // need a project to post both disk and image to
     create_project(client, PROJECT_NAME).await;
@@ -180,7 +180,7 @@ async fn test_make_disk_from_other_project_image_fails(
     cptestctx: &ControlPlaneTestContext,
 ) {
     let client = &cptestctx.external_client;
-    DiskTest::new(&cptestctx).await;
+    DiskTest::new(cptestctx).await;
 
     create_project(client, PROJECT_NAME).await;
     let another_project = create_project(client, "another-proj").await;
@@ -226,7 +226,7 @@ async fn test_make_disk_from_image_too_small(
     cptestctx: &ControlPlaneTestContext,
 ) {
     let client = &cptestctx.external_client;
-    DiskTest::new(&cptestctx).await;
+    DiskTest::new(cptestctx).await;
 
     // need a project to post both disk and image to
     create_project(client, PROJECT_NAME).await;
@@ -281,7 +281,7 @@ async fn test_make_disk_from_image_too_small(
 #[nexus_test]
 async fn test_image_promotion(cptestctx: &ControlPlaneTestContext) {
     let client = &cptestctx.external_client;
-    DiskTest::new(&cptestctx).await;
+    DiskTest::new(cptestctx).await;
 
     let silo_images_url = "/v1/images";
     let images_url = get_project_images_url(PROJECT_NAME);
@@ -334,7 +334,7 @@ async fn test_image_promotion(cptestctx: &ControlPlaneTestContext) {
     .execute_and_parse_unwrap::<views::Image>()
     .await;
 
-    let silo_images = NexusRequest::object_get(client, &silo_images_url)
+    let silo_images = NexusRequest::object_get(client, silo_images_url)
         .authn_as(AuthnMode::PrivilegedUser)
         .execute_and_parse_unwrap::<ResultsPage<views::Image>>()
         .await
@@ -396,7 +396,7 @@ async fn test_image_from_other_project_snapshot_fails(
     cptestctx: &ControlPlaneTestContext,
 ) {
     let client = &cptestctx.external_client;
-    DiskTest::new(&cptestctx).await;
+    DiskTest::new(cptestctx).await;
 
     create_project(client, PROJECT_NAME).await;
     let images_url = get_project_images_url(PROJECT_NAME);
@@ -473,7 +473,7 @@ async fn test_image_from_other_project_snapshot_fails(
 #[nexus_test]
 async fn test_image_deletion_permissions(cptestctx: &ControlPlaneTestContext) {
     let client = &cptestctx.external_client;
-    DiskTest::new(&cptestctx).await;
+    DiskTest::new(cptestctx).await;
 
     // Create a project
 
@@ -529,7 +529,7 @@ async fn test_image_deletion_permissions(cptestctx: &ControlPlaneTestContext) {
     .execute_and_parse_unwrap::<views::Image>()
     .await;
 
-    let silo_images = NexusRequest::object_get(client, &silo_images_url)
+    let silo_images = NexusRequest::object_get(client, silo_images_url)
         .authn_as(AuthnMode::PrivilegedUser)
         .execute_and_parse_unwrap::<ResultsPage<views::Image>>()
         .await

--- a/nexus/tests/integration_tests/internet_gateway.rs
+++ b/nexus/tests/integration_tests/internet_gateway.rs
@@ -308,7 +308,7 @@ async fn test_igw_ip_pool_attach_silo_user(ctx: &ControlPlaneTestContext) {
     };
 
     let _result: InternetGatewayIpPool =
-        NexusRequest::objects_post(&c, &url, &params)
+        NexusRequest::objects_post(c, &url, &params)
             .authn_as(AuthnMode::SiloUser(user.id))
             .execute_and_parse_unwrap()
             .await;
@@ -328,7 +328,7 @@ async fn test_igw_ip_pool_attach_silo_user(ctx: &ControlPlaneTestContext) {
         "/v1/internet-gateway-ip-pools/{}?project={}&vpc={}&gateway={}&cascade=true",
         IP_POOL_ATTACHMENT_NAME, PROJECT_NAME, VPC_NAME, IGW_NAME,
     );
-    NexusRequest::object_delete(&c, &url)
+    NexusRequest::object_delete(c, &url)
         .authn_as(AuthnMode::SiloUser(user.id))
         .execute()
         .await
@@ -343,8 +343,8 @@ async fn test_igw_ip_pool_attach_silo_user(ctx: &ControlPlaneTestContext) {
 
 async fn test_setup(c: &ClientTestContext) {
     // create a project and vpc to test with
-    let _proj = create_project(&c, PROJECT_NAME).await;
-    let _vpc = create_vpc(&c, PROJECT_NAME, VPC_NAME).await;
+    let _proj = create_project(c, PROJECT_NAME).await;
+    let _vpc = create_vpc(c, PROJECT_NAME, VPC_NAME).await;
     let _pool = create_ip_pool(
         c,
         IP_POOL_NAME,
@@ -354,7 +354,7 @@ async fn test_setup(c: &ClientTestContext) {
         })),
     )
     .await;
-    link_ip_pool(&c, IP_POOL_NAME, &DEFAULT_SILO.id(), true).await;
+    link_ip_pool(c, IP_POOL_NAME, &DEFAULT_SILO.id(), true).await;
     let _floater = create_floating_ip(
         c,
         FLOATING_IP_NAME,

--- a/nexus/tests/integration_tests/pantry.rs
+++ b/nexus/tests/integration_tests/pantry.rs
@@ -150,16 +150,16 @@ async fn create_instance_and_attach_disk(
     expected_status: StatusCode,
 ) {
     // Create an instance to attach the disk.
-    let instance = create_instance(&client, PROJECT_NAME, INSTANCE_NAME).await;
+    let instance = create_instance(client, PROJECT_NAME, INSTANCE_NAME).await;
     let instance_id = InstanceUuid::from_untyped_uuid(instance.identity.id);
 
     // TODO(https://github.com/oxidecomputer/omicron/issues/811):
     //
     // Instances must be stopped before disks can be attached - this
     // is an artificial limitation without hotplug support.
-    set_instance_state(&client, INSTANCE_NAME, "stop").await;
+    set_instance_state(client, INSTANCE_NAME, "stop").await;
     instance_simulate(nexus, &instance_id).await;
-    instance_wait_for_state(&client, instance_id, InstanceState::Stopped).await;
+    instance_wait_for_state(client, instance_id, InstanceState::Stopped).await;
 
     let url_instance_attach_disk =
         get_disk_attach_url(instance.identity.name.as_str());
@@ -344,7 +344,7 @@ async fn finalize_import_take_snapshot(
 
 async fn validate_disk_state(client: &ClientTestContext, state: DiskState) {
     let disk_url = get_disk_url(DISK_NAME);
-    let disk = disk_get(&client, &disk_url).await;
+    let disk = disk_get(client, &disk_url).await;
     assert_eq!(disk.state, state);
 }
 
@@ -353,7 +353,7 @@ async fn validate_disk_state(client: &ClientTestContext, state: DiskState) {
 #[nexus_test]
 async fn test_disk_create_for_importing(cptestctx: &ControlPlaneTestContext) {
     let client = &cptestctx.external_client;
-    DiskTest::new(&cptestctx).await;
+    DiskTest::new(cptestctx).await;
     create_project_and_pool(client).await;
     let disks_url = get_disks_url();
 
@@ -381,12 +381,12 @@ async fn test_disk_create_for_importing(cptestctx: &ControlPlaneTestContext) {
     .unwrap();
 
     let disk_url = get_disk_url(DISK_NAME);
-    let disk = disk_get(&client, &disk_url).await;
+    let disk = disk_get(client, &disk_url).await;
 
     assert_eq!(disk.state, DiskState::ImportReady);
 
     // List disks again and expect to find the one we just created.
-    let disks = disks_list(&client, &disks_url).await;
+    let disks = disks_list(client, &disks_url).await;
     assert_eq!(disks.len(), 1);
     disks_eq(&disks[0], &disk);
 }
@@ -399,7 +399,7 @@ async fn test_cannot_mount_import_ready_disk(
     let client = &cptestctx.external_client;
     let nexus = &cptestctx.server.server_context().nexus;
 
-    DiskTest::new(&cptestctx).await;
+    DiskTest::new(cptestctx).await;
     create_project_and_pool(client).await;
 
     create_disk_with_state_importing_blocks(client).await;
@@ -430,7 +430,7 @@ async fn test_cannot_mount_import_from_bulk_writes_disk(
     let client = &cptestctx.external_client;
     let nexus = &cptestctx.server.server_context().nexus;
 
-    DiskTest::new(&cptestctx).await;
+    DiskTest::new(cptestctx).await;
     create_project_and_pool(client).await;
 
     create_disk_with_state_importing_blocks(client).await;
@@ -454,7 +454,7 @@ async fn test_import_blocks_with_bulk_write(
     let client = &cptestctx.external_client;
     let nexus = &cptestctx.server.server_context().nexus;
 
-    DiskTest::new(&cptestctx).await;
+    DiskTest::new(cptestctx).await;
     create_project_and_pool(client).await;
 
     create_disk_with_state_importing_blocks(client).await;
@@ -495,7 +495,7 @@ async fn test_import_blocks_with_bulk_write_with_snapshot(
     let client = &cptestctx.external_client;
     let nexus = &cptestctx.server.server_context().nexus;
 
-    DiskTest::new(&cptestctx).await;
+    DiskTest::new(cptestctx).await;
     create_project_and_pool(client).await;
 
     create_disk_with_state_importing_blocks(client).await;
@@ -546,7 +546,7 @@ async fn test_cannot_finalize_without_stopping_bulk_writes(
 ) {
     let client = &cptestctx.external_client;
 
-    DiskTest::new(&cptestctx).await;
+    DiskTest::new(cptestctx).await;
     create_project_and_pool(client).await;
 
     create_disk_with_state_importing_blocks(client).await;
@@ -575,7 +575,7 @@ async fn test_cannot_bulk_write_to_unaligned_offset(
 ) {
     let client = &cptestctx.external_client;
 
-    DiskTest::new(&cptestctx).await;
+    DiskTest::new(cptestctx).await;
     create_project_and_pool(client).await;
 
     create_disk_with_state_importing_blocks(client).await;
@@ -608,7 +608,7 @@ async fn test_cannot_bulk_write_data_not_block_size_multiple(
 ) {
     let client = &cptestctx.external_client;
 
-    DiskTest::new(&cptestctx).await;
+    DiskTest::new(cptestctx).await;
     create_project_and_pool(client).await;
 
     create_disk_with_state_importing_blocks(client).await;
@@ -640,7 +640,7 @@ async fn test_cannot_bulk_write_data_past_end_of_disk(
 ) {
     let client = &cptestctx.external_client;
 
-    DiskTest::new(&cptestctx).await;
+    DiskTest::new(cptestctx).await;
     create_project_and_pool(client).await;
 
     create_disk_with_state_importing_blocks(client).await;
@@ -672,7 +672,7 @@ async fn test_cannot_bulk_write_data_non_base64(
 ) {
     let client = &cptestctx.external_client;
 
-    DiskTest::new(&cptestctx).await;
+    DiskTest::new(cptestctx).await;
     create_project_and_pool(client).await;
 
     create_disk_with_state_importing_blocks(client).await;
@@ -710,7 +710,7 @@ async fn test_can_stop_start_import_from_bulk_write(
 ) {
     let client = &cptestctx.external_client;
 
-    DiskTest::new(&cptestctx).await;
+    DiskTest::new(cptestctx).await;
     create_project_and_pool(client).await;
 
     create_disk_with_state_importing_blocks(client).await;
@@ -738,7 +738,7 @@ async fn test_cannot_bulk_write_start_attached_disk(
     let client = &cptestctx.external_client;
     let nexus = &cptestctx.server.server_context().nexus;
 
-    DiskTest::new(&cptestctx).await;
+    DiskTest::new(cptestctx).await;
     create_project_and_pool(client).await;
 
     create_disk_with_state_importing_blocks(client).await;
@@ -768,7 +768,7 @@ async fn test_cannot_bulk_write_attached_disk(
     let client = &cptestctx.external_client;
     let nexus = &cptestctx.server.server_context().nexus;
 
-    DiskTest::new(&cptestctx).await;
+    DiskTest::new(cptestctx).await;
     create_project_and_pool(client).await;
 
     create_disk_with_state_importing_blocks(client).await;
@@ -798,7 +798,7 @@ async fn test_cannot_bulk_write_stop_attached_disk(
     let client = &cptestctx.external_client;
     let nexus = &cptestctx.server.server_context().nexus;
 
-    DiskTest::new(&cptestctx).await;
+    DiskTest::new(cptestctx).await;
     create_project_and_pool(client).await;
 
     create_disk_with_state_importing_blocks(client).await;
@@ -827,7 +827,7 @@ async fn test_cannot_finalize_attached_disk(
     let client = &cptestctx.external_client;
     let nexus = &cptestctx.server.server_context().nexus;
 
-    DiskTest::new(&cptestctx).await;
+    DiskTest::new(cptestctx).await;
     create_project_and_pool(client).await;
 
     create_disk_with_state_importing_blocks(client).await;

--- a/nexus/tests/integration_tests/password_login.rs
+++ b/nexus/tests/integration_tests/password_login.rs
@@ -60,7 +60,7 @@ async fn test_local_user_basic(client: &ClientTestContext, silo: &views::Silo) {
     // The timing is verified in expect_login_failure().
     expect_login_failure(
         client,
-        &silo_name,
+        silo_name,
         UserId::from_str("bigfoot").unwrap(),
         params::Password::from_str("ahh").unwrap(),
     )
@@ -82,7 +82,7 @@ async fn test_local_user_basic(client: &ClientTestContext, silo: &views::Silo) {
     // Try to log in with a bogus password.
     expect_login_failure(
         client,
-        &silo_name,
+        silo_name,
         test_user.clone(),
         params::Password::from_str("something else").unwrap(),
     )
@@ -92,7 +92,7 @@ async fn test_local_user_basic(client: &ClientTestContext, silo: &views::Silo) {
     // something.
     let session_token = expect_login_success(
         client,
-        &silo_name,
+        silo_name,
         test_user.clone(),
         test_password.clone(),
     )
@@ -122,7 +122,7 @@ async fn test_local_user_basic(client: &ClientTestContext, silo: &views::Silo) {
     // The old password should no longer work.
     expect_login_failure(
         client,
-        &silo_name,
+        silo_name,
         test_user.clone(),
         test_password.clone(),
     )
@@ -131,7 +131,7 @@ async fn test_local_user_basic(client: &ClientTestContext, silo: &views::Silo) {
     // We should be able to login separately with the new password.
     let session_token2 = expect_login_success(
         client,
-        &silo_name,
+        silo_name,
         test_user.clone(),
         test_password2.clone(),
     )
@@ -185,7 +185,7 @@ async fn test_local_user_basic(client: &ClientTestContext, silo: &views::Silo) {
 
     let admin_session = expect_login_success(
         client,
-        &silo_name,
+        silo_name,
         admin_user.clone(),
         admin_password.clone(),
     )
@@ -208,14 +208,14 @@ async fn test_local_user_basic(client: &ClientTestContext, silo: &views::Silo) {
     // Just to be clear, we modified the test user's password.
     let _ = expect_login_success(
         client,
-        &silo_name,
+        silo_name,
         test_user.clone(),
         hijacked_password.clone(),
     )
     .await;
     expect_login_failure(
         client,
-        &silo_name,
+        silo_name,
         test_user.clone(),
         test_password2.clone(),
     )
@@ -224,14 +224,14 @@ async fn test_local_user_basic(client: &ClientTestContext, silo: &views::Silo) {
     // And we did not modify the admin user's password.
     let _ = expect_login_success(
         client,
-        &silo_name,
+        silo_name,
         admin_user.clone(),
         admin_password.clone(),
     )
     .await;
     expect_login_failure(
         client,
-        &silo_name,
+        silo_name,
         admin_user.clone(),
         hijacked_password.clone(),
     )
@@ -249,7 +249,7 @@ async fn test_local_user_basic(client: &ClientTestContext, silo: &views::Silo) {
     .unwrap();
     expect_login_failure(
         client,
-        &silo_name,
+        silo_name,
         test_user.clone(),
         hijacked_password.clone(),
     )
@@ -257,14 +257,14 @@ async fn test_local_user_basic(client: &ClientTestContext, silo: &views::Silo) {
     // And we did not modify the admin user's password.
     let _ = expect_login_success(
         client,
-        &silo_name,
+        silo_name,
         admin_user.clone(),
         admin_password.clone(),
     )
     .await;
     expect_login_failure(
         client,
-        &silo_name,
+        silo_name,
         admin_user.clone(),
         hijacked_password.clone(),
     )
@@ -318,7 +318,7 @@ async fn test_local_user_with_no_initial_password(
     // Logging in should not work.  (What password would we use, anyway?)
     expect_login_failure(
         client,
-        &silo_name,
+        silo_name,
         test_user.clone(),
         params::Password::from_str("").unwrap(),
     )
@@ -345,7 +345,7 @@ async fn test_local_user_with_no_initial_password(
     // Now, we should be able to log in and do things.
     let session_token = expect_login_success(
         client,
-        &silo_name,
+        silo_name,
         test_user.clone(),
         test_password2.clone(),
     )

--- a/nexus/tests/integration_tests/probe.rs
+++ b/nexus/tests/integration_tests/probe.rs
@@ -16,8 +16,8 @@ type ControlPlaneTestContext =
 async fn test_probe_basic_crud(ctx: &ControlPlaneTestContext) {
     let client = &ctx.external_client;
 
-    create_default_ip_pool(&client).await;
-    create_project(&client, "nebula").await;
+    create_default_ip_pool(client).await;
+    create_project(client, "nebula").await;
 
     let probes = NexusRequest::iter_collection_authn::<ProbeInfo>(
         client,

--- a/nexus/tests/integration_tests/quotas.rs
+++ b/nexus/tests/integration_tests/quotas.rs
@@ -194,8 +194,8 @@ async fn setup_silo_with_quota(
 
     // create default pool and link to this silo. can't use
     // create_default_ip_pool because that links to the default silo
-    create_ip_pool(&client, "default", None).await;
-    link_ip_pool(&client, "default", &silo.identity.id, true).await;
+    create_ip_pool(client, "default", None).await;
+    link_ip_pool(client, "default", &silo.identity.id, true).await;
 
     // Create a silo user
     let user = create_local_user(
@@ -241,10 +241,10 @@ async fn test_quotas(cptestctx: &ControlPlaneTestContext) {
     let client = &cptestctx.external_client;
 
     // Simulate space for disks
-    DiskTest::new(&cptestctx).await;
+    DiskTest::new(cptestctx).await;
 
     let system = setup_silo_with_quota(
-        &client,
+        client,
         "quota-test-silo",
         params::SiloQuotasCreate::empty(),
     )
@@ -325,7 +325,7 @@ async fn test_quota_limits(cptestctx: &ControlPlaneTestContext) {
     let client = &cptestctx.external_client;
 
     let system = setup_silo_with_quota(
-        &client,
+        client,
         "quota-test-silo",
         params::SiloQuotasCreate::empty(),
     )

--- a/nexus/tests/integration_tests/rack.rs
+++ b/nexus/tests/integration_tests/rack.rs
@@ -76,7 +76,7 @@ async fn test_rack_initialization(cptestctx: &ControlPlaneTestContext) {
     let login_url = format!("/v1/login/{}/local", cptestctx.silo_name);
     let username = cptestctx.user_name.clone();
     let password: params::Password = TEST_SUITE_PASSWORD.parse().unwrap();
-    let _ = RequestBuilder::new(&client, Method::POST, &login_url)
+    let _ = RequestBuilder::new(client, Method::POST, &login_url)
         .body(Some(&params::UsernamePasswordCredentials { username, password }))
         .expect_status(Some(StatusCode::NO_CONTENT))
         .execute()
@@ -98,7 +98,7 @@ async fn test_sled_list_uninitialized(cptestctx: &ControlPlaneTestContext) {
     let external_client = &cptestctx.external_client;
     let list_url = "/v1/system/hardware/sleds-uninitialized";
     let mut uninitialized_sleds =
-        NexusRequest::object_get(external_client, &list_url)
+        NexusRequest::object_get(external_client, list_url)
             .authn_as(AuthnMode::PrivilegedUser)
             .execute()
             .await
@@ -140,7 +140,7 @@ async fn test_sled_list_uninitialized(cptestctx: &ControlPlaneTestContext) {
     // Ensure there's only one unintialized sled remaining, and it's not
     // the one that was just added into the `sled` table
     let uninitialized_sleds_2 =
-        NexusRequest::object_get(external_client, &list_url)
+        NexusRequest::object_get(external_client, list_url)
             .authn_as(AuthnMode::PrivilegedUser)
             .execute()
             .await

--- a/nexus/tests/integration_tests/roles_builtin.rs
+++ b/nexus/tests/integration_tests/roles_builtin.rs
@@ -20,7 +20,7 @@ async fn test_roles_builtin(cptestctx: &ControlPlaneTestContext) {
     let testctx = &cptestctx.external_client;
 
     // Success cases
-    let roles = NexusRequest::object_get(&testctx, "/v1/system/roles")
+    let roles = NexusRequest::object_get(testctx, "/v1/system/roles")
         .authn_as(AuthnMode::PrivilegedUser)
         .execute()
         .await
@@ -51,7 +51,7 @@ async fn test_roles_builtin(cptestctx: &ControlPlaneTestContext) {
     // This endpoint uses a custom pagination scheme that is easy to get wrong.
     // Let's test that all markers do work.
     let roles_paginated = NexusRequest::iter_collection_authn(
-        &testctx,
+        testctx,
         "/v1/system/roles",
         "",
         Some(1),
@@ -67,7 +67,7 @@ async fn test_roles_builtin(cptestctx: &ControlPlaneTestContext) {
     // Success cases
     for r in &roles {
         let one_role = NexusRequest::object_get(
-            &testctx,
+            testctx,
             &format!("/v1/system/roles/{}", r.name),
         )
         .authn_as(AuthnMode::PrivilegedUser)

--- a/nexus/tests/integration_tests/router_routes.rs
+++ b/nexus/tests/integration_tests/router_routes.rs
@@ -126,10 +126,10 @@ async fn test_router_routes_crud_operations(
     let vpc_name = "vpc1";
     let router_name = "router1";
 
-    let _ = create_project(&client, PROJECT_NAME).await;
+    let _ = create_project(client, PROJECT_NAME).await;
 
     // Create a vpc
-    create_vpc(&client, PROJECT_NAME, vpc_name).await;
+    create_vpc(client, PROJECT_NAME, vpc_name).await;
 
     // Get the system router's routes
     let [v4_route, v6_route, subnet_route] =
@@ -155,7 +155,7 @@ async fn test_router_routes_crud_operations(
     }
 
     // Create a custom router
-    create_router(&client, PROJECT_NAME, vpc_name, router_name).await;
+    create_router(client, PROJECT_NAME, vpc_name, router_name).await;
 
     // Get routes list for custom router
     let routes = objects_list_page_authz::<RouterRoute>(
@@ -268,12 +268,12 @@ async fn test_router_routes_disallow_mixed_v4_v6(
     cptestctx: &ControlPlaneTestContext,
 ) {
     let client = &cptestctx.external_client;
-    let _ = create_project(&client, PROJECT_NAME).await;
-    let _ = create_vpc(&client, PROJECT_NAME, VPC_NAME).await;
+    let _ = create_project(client, PROJECT_NAME).await;
+    let _ = create_vpc(client, PROJECT_NAME, VPC_NAME).await;
 
     let router_name = ROUTER_NAMES[0];
     let _router =
-        create_router(&client, PROJECT_NAME, VPC_NAME, router_name).await;
+        create_router(client, PROJECT_NAME, VPC_NAME, router_name).await;
 
     // Some targets/strings refer to a mixed v4/v6 entity, e.g.,
     // subnet or instance. Others refer to one kind only (ipnet, ip).
@@ -350,8 +350,8 @@ async fn test_router_routes_modify_system_routes(
     cptestctx: &ControlPlaneTestContext,
 ) {
     let client = &cptestctx.external_client;
-    let _ = create_project(&client, PROJECT_NAME).await;
-    let _ = create_vpc(&client, PROJECT_NAME, VPC_NAME).await;
+    let _ = create_project(client, PROJECT_NAME).await;
+    let _ = create_vpc(client, PROJECT_NAME, VPC_NAME).await;
 
     // Attempting to add a new route to a system router should fail.
     let err = create_route_with_error(
@@ -378,7 +378,7 @@ async fn test_router_routes_modify_system_routes(
     // Deletes are tested above.
     let err = object_put_error(
         client,
-        &get_route_url(VPC_NAME, "system", subnet_route.name().as_str())
+        get_route_url(VPC_NAME, "system", subnet_route.name().as_str())
             .as_str(),
         &RouterRouteUpdate {
             identity: IdentityMetadataUpdateParams {
@@ -399,7 +399,7 @@ async fn test_router_routes_modify_system_routes(
     // Modifying the target of a Default (gateway) route should succeed.
     let v4_route: RouterRoute = object_put(
         client,
-        &get_route_url(VPC_NAME, "system", v4_route.name().as_str()).as_str(),
+        get_route_url(VPC_NAME, "system", v4_route.name().as_str()).as_str(),
         &RouterRouteUpdate {
             identity: IdentityMetadataUpdateParams {
                 name: None,
@@ -414,7 +414,7 @@ async fn test_router_routes_modify_system_routes(
 
     let v6_route: RouterRoute = object_put(
         client,
-        &get_route_url(VPC_NAME, "system", v6_route.name().as_str()).as_str(),
+        get_route_url(VPC_NAME, "system", v6_route.name().as_str()).as_str(),
         &RouterRouteUpdate {
             identity: IdentityMetadataUpdateParams {
                 name: None,
@@ -430,7 +430,7 @@ async fn test_router_routes_modify_system_routes(
     // Modifying the *destination* should not.
     let err = object_put_error(
         client,
-        &get_route_url(VPC_NAME, "system", v4_route.name().as_str()).as_str(),
+        get_route_url(VPC_NAME, "system", v4_route.name().as_str()).as_str(),
         &RouterRouteUpdate {
             identity: IdentityMetadataUpdateParams {
                 name: None,
@@ -453,11 +453,11 @@ async fn test_router_routes_internet_gateway_target(
     cptestctx: &ControlPlaneTestContext,
 ) {
     let client = &cptestctx.external_client;
-    let _ = create_project(&client, PROJECT_NAME).await;
-    let _ = create_vpc(&client, PROJECT_NAME, VPC_NAME).await;
+    let _ = create_project(client, PROJECT_NAME).await;
+    let _ = create_vpc(client, PROJECT_NAME, VPC_NAME).await;
     let router_name = ROUTER_NAMES[0];
     let _router =
-        create_router(&client, PROJECT_NAME, VPC_NAME, router_name).await;
+        create_router(client, PROJECT_NAME, VPC_NAME, router_name).await;
 
     let dest: RouteDestination = "ipnet:240.0.0.0/8".parse().unwrap();
 
@@ -483,11 +483,11 @@ async fn test_router_routes_disallow_custom_targets(
     cptestctx: &ControlPlaneTestContext,
 ) {
     let client = &cptestctx.external_client;
-    let _ = create_project(&client, PROJECT_NAME).await;
-    let _ = create_vpc(&client, PROJECT_NAME, VPC_NAME).await;
+    let _ = create_project(client, PROJECT_NAME).await;
+    let _ = create_vpc(client, PROJECT_NAME, VPC_NAME).await;
     let router_name = ROUTER_NAMES[0];
     let _router =
-        create_router(&client, PROJECT_NAME, VPC_NAME, router_name).await;
+        create_router(client, PROJECT_NAME, VPC_NAME, router_name).await;
 
     let valid_dest: RouteDestination = "ipnet:240.0.0.0/8".parse().unwrap();
     let pairs: &[(RouteDestination, RouteTarget, &str)] = &[
@@ -528,7 +528,7 @@ async fn test_router_routes_disallow_custom_targets(
                 client,
                 PROJECT_NAME,
                 VPC_NAME,
-                &router_name,
+                router_name,
                 "bad-route",
                 dest.clone(),
                 target.clone(),
@@ -540,7 +540,7 @@ async fn test_router_routes_disallow_custom_targets(
                 client,
                 PROJECT_NAME,
                 VPC_NAME,
-                &router_name,
+                router_name,
                 "good-route",
                 dest.clone(),
                 target.clone(),

--- a/nexus/tests/integration_tests/saml.rs
+++ b/nexus/tests/integration_tests/saml.rs
@@ -40,10 +40,10 @@ async fn test_create_a_saml_idp(cptestctx: &ControlPlaneTestContext) {
     let client = &cptestctx.external_client;
 
     const SILO_NAME: &str = "saml-silo";
-    create_silo(&client, SILO_NAME, true, shared::SiloIdentityMode::SamlJit)
+    create_silo(client, SILO_NAME, true, shared::SiloIdentityMode::SamlJit)
         .await;
     let silo: Silo = NexusRequest::object_get(
-        &client,
+        client,
         &format!("/v1/system/silos/{}", SILO_NAME,),
     )
     .authn_as(AuthnMode::PrivilegedUser)
@@ -94,7 +94,7 @@ async fn test_create_a_saml_idp(cptestctx: &ControlPlaneTestContext) {
     let nexus = &cptestctx.server.server_context().nexus;
     let (.., _retrieved_silo_nexus) = nexus
         .silo_lookup(
-            &nexus.opctx_external_authn(),
+            nexus.opctx_external_authn(),
             omicron_common::api::external::Name::try_from(
                 SILO_NAME.to_string(),
             )
@@ -109,7 +109,7 @@ async fn test_create_a_saml_idp(cptestctx: &ControlPlaneTestContext) {
     let (.., retrieved_silo_idp_from_nexus) = nexus
         .datastore()
         .identity_provider_lookup(
-            &nexus.opctx_external_authn(),
+            nexus.opctx_external_authn(),
             &omicron_common::api::external::Name::try_from(
                 SILO_NAME.to_string(),
             )
@@ -161,7 +161,7 @@ async fn test_create_a_saml_idp_invalid_descriptor_truncated(
     let client = &cptestctx.external_client;
 
     const SILO_NAME: &str = "saml-silo";
-    create_silo(&client, SILO_NAME, true, shared::SiloIdentityMode::SamlJit)
+    create_silo(client, SILO_NAME, true, shared::SiloIdentityMode::SamlJit)
         .await;
 
     let saml_idp_descriptor = {
@@ -221,7 +221,7 @@ async fn test_create_a_saml_idp_invalid_descriptor_no_redirect_binding(
     let client = &cptestctx.external_client;
 
     const SILO_NAME: &str = "saml-silo";
-    create_silo(&client, SILO_NAME, true, shared::SiloIdentityMode::SamlJit)
+    create_silo(client, SILO_NAME, true, shared::SiloIdentityMode::SamlJit)
         .await;
 
     let saml_idp_descriptor = {
@@ -295,7 +295,7 @@ async fn test_create_a_saml_idp_metadata_only_encryption_keys(
     let client = &cptestctx.external_client;
 
     const SILO_NAME: &str = "saml-silo";
-    create_silo(&client, SILO_NAME, true, shared::SiloIdentityMode::SamlJit)
+    create_silo(client, SILO_NAME, true, shared::SiloIdentityMode::SamlJit)
         .await;
 
     let saml_idp_descriptor =
@@ -352,7 +352,7 @@ async fn test_create_a_saml_idp_metadata_no_keys(
     let client = &cptestctx.external_client;
 
     const SILO_NAME: &str = "saml-silo";
-    create_silo(&client, SILO_NAME, true, shared::SiloIdentityMode::SamlJit)
+    create_silo(client, SILO_NAME, true, shared::SiloIdentityMode::SamlJit)
         .await;
 
     let saml_idp_descriptor = SAML_IDP_DESCRIPTOR_NO_KEYS.to_string();
@@ -407,7 +407,7 @@ async fn test_create_a_hidden_silo_saml_idp(
 ) {
     let client = &cptestctx.external_client;
 
-    create_silo(&client, "hidden", false, shared::SiloIdentityMode::SamlJit)
+    create_silo(client, "hidden", false, shared::SiloIdentityMode::SamlJit)
         .await;
 
     // Valid IdP descriptor
@@ -477,7 +477,7 @@ async fn test_saml_idp_metadata_url_404(cptestctx: &ControlPlaneTestContext) {
     let client = &cptestctx.external_client;
 
     const SILO_NAME: &str = "saml-silo";
-    create_silo(&client, SILO_NAME, true, shared::SiloIdentityMode::SamlJit)
+    create_silo(client, SILO_NAME, true, shared::SiloIdentityMode::SamlJit)
         .await;
 
     let server = Server::run();
@@ -531,7 +531,7 @@ async fn test_saml_idp_metadata_url_invalid(
     let client = &cptestctx.external_client;
 
     const SILO_NAME: &str = "saml-silo";
-    create_silo(&client, SILO_NAME, true, shared::SiloIdentityMode::SamlJit)
+    create_silo(client, SILO_NAME, true, shared::SiloIdentityMode::SamlJit)
         .await;
 
     NexusRequest::new(
@@ -592,7 +592,7 @@ async fn test_saml_idp_reject_keypair(cptestctx: &ControlPlaneTestContext) {
     );
 
     const SILO_NAME: &str = "saml-silo";
-    create_silo(&client, SILO_NAME, true, shared::SiloIdentityMode::SamlJit)
+    create_silo(client, SILO_NAME, true, shared::SiloIdentityMode::SamlJit)
         .await;
 
     let test_cases = vec![
@@ -692,7 +692,7 @@ async fn test_saml_idp_rsa_keypair_ok(cptestctx: &ControlPlaneTestContext) {
     );
 
     const SILO_NAME: &str = "saml-silo";
-    create_silo(&client, SILO_NAME, true, shared::SiloIdentityMode::SamlJit)
+    create_silo(client, SILO_NAME, true, shared::SiloIdentityMode::SamlJit)
         .await;
 
     NexusRequest::new(
@@ -1135,7 +1135,7 @@ async fn test_post_saml_response(cptestctx: &ControlPlaneTestContext) {
     let client = &cptestctx.external_client;
 
     const SILO_NAME: &str = "saml-silo";
-    create_silo(&client, SILO_NAME, true, shared::SiloIdentityMode::SamlJit)
+    create_silo(client, SILO_NAME, true, shared::SiloIdentityMode::SamlJit)
         .await;
 
     let _silo_saml_idp: views::SamlIdentityProvider = object_create(
@@ -1266,7 +1266,7 @@ async fn test_post_saml_response_with_relay_state(
     let client = &cptestctx.external_client;
 
     const SILO_NAME: &str = "saml-silo";
-    create_silo(&client, SILO_NAME, true, shared::SiloIdentityMode::SamlJit)
+    create_silo(client, SILO_NAME, true, shared::SiloIdentityMode::SamlJit)
         .await;
 
     let _silo_saml_idp: views::SamlIdentityProvider = object_create(

--- a/nexus/tests/integration_tests/silo_users.rs
+++ b/nexus/tests/integration_tests/silo_users.rs
@@ -34,14 +34,14 @@ async fn test_silo_group_users(cptestctx: &ControlPlaneTestContext) {
 
     // we start out with the two default users
     let users =
-        objects_list_page_authz::<views::User>(client, &"/v1/users").await;
+        objects_list_page_authz::<views::User>(client, "/v1/users").await;
     let user_names: Vec<&str> =
         users.items.iter().map(|u| u.display_name.as_str()).collect();
     assert_same_items(user_names, vec!["privileged", "unprivileged"]);
 
     // no groups to start with
     let groups =
-        objects_list_page_authz::<views::User>(client, &"/v1/groups").await;
+        objects_list_page_authz::<views::User>(client, "/v1/groups").await;
     assert_eq!(groups.items.len(), 0);
 
     let authz_silo = authz::Silo::new(
@@ -59,7 +59,7 @@ async fn test_silo_group_users(cptestctx: &ControlPlaneTestContext) {
 
     // now we have a group
     let groups =
-        objects_list_page_authz::<views::User>(client, &"/v1/groups").await;
+        objects_list_page_authz::<views::User>(client, "/v1/groups").await;
     assert_eq!(groups.items.len(), 1);
 
     let group = groups.items.get(0).unwrap();
@@ -67,7 +67,7 @@ async fn test_silo_group_users(cptestctx: &ControlPlaneTestContext) {
 
     // we can fetch that group by ID
     let group_url = format!("/v1/groups/{}", group.id);
-    let group = NexusRequest::object_get(&client, &group_url)
+    let group = NexusRequest::object_get(client, &group_url)
         .authn_as(AuthnMode::PrivilegedUser)
         .execute_and_parse_unwrap::<views::Group>()
         .await;
@@ -114,14 +114,14 @@ async fn test_silo_group_users_bad_group_id(
 
     // 404 on UUID that doesn't exist
     let nonexistent_group = format!("/v1/users?group={}", Uuid::new_v4());
-    expect_failure(&client, &nonexistent_group, StatusCode::NOT_FOUND).await;
+    expect_failure(client, &nonexistent_group, StatusCode::NOT_FOUND).await;
 
     // 400 on non-UUID identifier
-    expect_failure(&client, &"/v1/users?group=abc", StatusCode::BAD_REQUEST)
+    expect_failure(client, "/v1/users?group=abc", StatusCode::BAD_REQUEST)
         .await;
 
     // 400 on empty identifier
-    expect_failure(&client, &"/v1/users?group=", StatusCode::BAD_REQUEST).await;
+    expect_failure(client, "/v1/users?group=", StatusCode::BAD_REQUEST).await;
 }
 
 #[nexus_test]
@@ -132,10 +132,10 @@ async fn test_silo_group_detail_bad_group_id(
 
     // 404 on UUID that doesn't exist
     let nonexistent_group = format!("/v1/groups/{}", Uuid::new_v4());
-    expect_failure(&client, &nonexistent_group, StatusCode::NOT_FOUND).await;
+    expect_failure(client, &nonexistent_group, StatusCode::NOT_FOUND).await;
 
     // 400 on non-UUID identifier
-    expect_failure(&client, &"/v1/groups/abc", StatusCode::BAD_REQUEST).await;
+    expect_failure(client, "/v1/groups/abc", StatusCode::BAD_REQUEST).await;
 }
 
 async fn expect_failure(

--- a/nexus/tests/integration_tests/sleds.rs
+++ b/nexus/tests/integration_tests/sleds.rs
@@ -57,7 +57,7 @@ async fn test_sleds_list(cptestctx: &ControlPlaneTestContext) {
 
     // Verify that there are two sleds to begin with.
     let sleds_url = "/v1/system/hardware/sleds";
-    assert_eq!(sleds_list(&client, &sleds_url).await.len(), 2);
+    assert_eq!(sleds_list(client, sleds_url).await.len(), 2);
 
     // Now start a few more sled agents.
     let nsleds = 3;
@@ -76,7 +76,7 @@ async fn test_sleds_list(cptestctx: &ControlPlaneTestContext) {
                 // Index starts at 2: the `nexus_test` macro already created two
                 // sled agents as part of the ControlPlaneTestContext setup.
                 2 + i as u16,
-                &update_directory,
+                update_directory,
                 sim::SimMode::Explicit,
                 &cptestctx.first_sled_agent().simulated_upstairs,
             )
@@ -86,7 +86,7 @@ async fn test_sleds_list(cptestctx: &ControlPlaneTestContext) {
     }
 
     // List sleds again.
-    let sleds_found = sleds_list(&client, &sleds_url).await;
+    let sleds_found = sleds_list(client, sleds_url).await;
     assert_eq!(sleds_found.len(), nsleds + 2);
 
     let sledids_found =
@@ -109,17 +109,17 @@ async fn test_physical_disk_create_list_delete(
 
     // Verify that there are two sleds to begin with.
     let sleds_url = "/v1/system/hardware/sleds";
-    assert_eq!(sleds_list(&external_client, &sleds_url).await.len(), 2);
+    assert_eq!(sleds_list(external_client, sleds_url).await.len(), 2);
 
     // The test framework may set up some disks initially.
     let disks_url =
         format!("/v1/system/hardware/sleds/{SLED_AGENT_UUID}/disks");
-    let disks_initial = physical_disks_list(&external_client, &disks_url).await;
+    let disks_initial = physical_disks_list(external_client, &disks_url).await;
 
     // Inject a disk into the database, observe it in the external API
     let nexus = &cptestctx.server.server_context().nexus;
     let datastore = nexus.datastore();
-    let sled_id = Uuid::from_str(&SLED_AGENT_UUID).unwrap();
+    let sled_id = Uuid::from_str(SLED_AGENT_UUID).unwrap();
     let physical_disk = DbPhysicalDisk::new(
         PhysicalDiskUuid::new_v4(),
         "v".into(),
@@ -136,7 +136,7 @@ async fn test_physical_disk_create_list_delete(
         .await
         .expect("Failed to upsert physical disk");
 
-    let disks = physical_disks_list(&external_client, &disks_url).await;
+    let disks = physical_disks_list(external_client, &disks_url).await;
     assert_eq!(disks.len(), disks_initial.len() + 1);
     let new_disk = disks
         .iter()
@@ -156,7 +156,7 @@ async fn test_physical_disk_create_list_delete(
         .await
         .expect("Failed to upsert physical disk");
 
-    let list = physical_disks_list(&external_client, &disks_url).await;
+    let list = physical_disks_list(external_client, &disks_url).await;
     assert_eq!(list, disks_initial, "{:#?}", list,);
 }
 
@@ -166,7 +166,7 @@ async fn test_sled_instance_list(cptestctx: &ControlPlaneTestContext) {
 
     // Verify that there are two sleds to begin with.
     let sleds_url = "/v1/system/hardware/sleds";
-    let sleds = sleds_list(&external_client, &sleds_url).await;
+    let sleds = sleds_list(external_client, sleds_url).await;
     assert_eq!(sleds.len(), 2);
 
     // Verify that there are no instances on the sleds.
@@ -175,18 +175,17 @@ async fn test_sled_instance_list(cptestctx: &ControlPlaneTestContext) {
         let instances_url =
             format!("/v1/system/hardware/sleds/{sled_id}/instances");
         assert!(
-            sled_instance_list(&external_client, &instances_url)
+            sled_instance_list(external_client, &instances_url)
                 .await
                 .is_empty()
         );
     }
 
     // Create an IP pool and project that we'll use for testing.
-    create_default_ip_pool(&external_client).await;
-    let project = create_project(&external_client, "test-project").await;
+    create_default_ip_pool(external_client).await;
+    let project = create_project(external_client, "test-project").await;
     let instance =
-        create_instance(&external_client, "test-project", "test-instance")
-            .await;
+        create_instance(external_client, "test-project", "test-instance").await;
 
     // Ensure 1 instance was created on a sled
     let sled_instances = wait_for_condition(
@@ -204,7 +203,7 @@ async fn test_sled_instance_list(cptestctx: &ControlPlaneTestContext) {
                     );
 
                     let mut sled_instances =
-                        sled_instance_list(&external_client, &instances_url)
+                        sled_instance_list(external_client, &instances_url)
                             .await;
 
                     total_instances.append(&mut sled_instances);

--- a/nexus/tests/integration_tests/snapshots.rs
+++ b/nexus/tests/integration_tests/snapshots.rs
@@ -73,7 +73,7 @@ async fn create_project_and_pool(client: &ClientTestContext) -> Uuid {
 #[nexus_test]
 async fn test_snapshot_basic(cptestctx: &ControlPlaneTestContext) {
     let client = &cptestctx.external_client;
-    DiskTest::new(&cptestctx).await;
+    DiskTest::new(cptestctx).await;
     create_project_and_pool(client).await;
     let disks_url = get_disks_url();
 
@@ -182,7 +182,7 @@ async fn test_snapshot_basic(cptestctx: &ControlPlaneTestContext) {
 #[nexus_test]
 async fn test_snapshot_without_instance(cptestctx: &ControlPlaneTestContext) {
     let client = &cptestctx.external_client;
-    DiskTest::new(&cptestctx).await;
+    DiskTest::new(cptestctx).await;
     create_project_and_pool(client).await;
     let disks_url = get_disks_url();
 
@@ -279,7 +279,7 @@ async fn test_snapshot_without_instance(cptestctx: &ControlPlaneTestContext) {
 #[nexus_test]
 async fn test_snapshot_stopped_instance(cptestctx: &ControlPlaneTestContext) {
     let client = &cptestctx.external_client;
-    DiskTest::new(&cptestctx).await;
+    DiskTest::new(cptestctx).await;
     create_project_and_pool(client).await;
     let disks_url = get_disks_url();
 
@@ -387,7 +387,7 @@ async fn test_delete_snapshot(cptestctx: &ControlPlaneTestContext) {
     let client = &cptestctx.external_client;
     let nexus = &cptestctx.server.server_context().nexus;
     let datastore = nexus.datastore();
-    DiskTest::new(&cptestctx).await;
+    DiskTest::new(cptestctx).await;
     let project_id = create_project_and_pool(client).await;
     let disks_url = get_disks_url();
 
@@ -547,12 +547,12 @@ async fn test_reject_creating_disk_from_snapshot(
     let nexus = &cptestctx.server.server_context().nexus;
     let datastore = nexus.datastore();
 
-    let project_id = create_project_and_pool(&client).await;
+    let project_id = create_project_and_pool(client).await;
 
     let opctx =
         OpContext::for_tests(cptestctx.logctx.log.new(o!()), datastore.clone());
 
-    let (.., authz_project) = LookupPath::new(&opctx, &datastore)
+    let (.., authz_project) = LookupPath::new(&opctx, datastore)
         .project_id(project_id)
         .lookup_for(authz::Action::CreateChild)
         .await
@@ -700,12 +700,12 @@ async fn test_reject_creating_disk_from_illegal_snapshot(
     let nexus = &cptestctx.server.server_context().nexus;
     let datastore = nexus.datastore();
 
-    let project_id = create_project_and_pool(&client).await;
+    let project_id = create_project_and_pool(client).await;
 
     let opctx =
         OpContext::for_tests(cptestctx.logctx.log.new(o!()), datastore.clone());
 
-    let (.., authz_project) = LookupPath::new(&opctx, &datastore)
+    let (.., authz_project) = LookupPath::new(&opctx, datastore)
         .project_id(project_id)
         .lookup_for(authz::Action::CreateChild)
         .await
@@ -796,12 +796,12 @@ async fn test_reject_creating_disk_from_other_project_snapshot(
     let nexus = &cptestctx.server.server_context().nexus;
     let datastore = nexus.datastore();
 
-    let project_id = create_project_and_pool(&client).await;
+    let project_id = create_project_and_pool(client).await;
 
     let opctx =
         OpContext::for_tests(cptestctx.logctx.log.new(o!()), datastore.clone());
 
-    let (.., authz_project) = LookupPath::new(&opctx, &datastore)
+    let (.., authz_project) = LookupPath::new(&opctx, datastore)
         .project_id(project_id)
         .lookup_for(authz::Action::CreateChild)
         .await
@@ -875,7 +875,7 @@ async fn test_reject_creating_disk_from_other_project_snapshot(
 async fn test_cannot_snapshot_if_no_space(cptestctx: &ControlPlaneTestContext) {
     // Test that snapshots cannot be created if there is no space for the blocks
     let client = &cptestctx.external_client;
-    DiskTest::new(&cptestctx).await;
+    DiskTest::new(cptestctx).await;
     create_project_and_pool(client).await;
     let disks_url = get_disks_url();
 
@@ -928,7 +928,7 @@ async fn test_cannot_snapshot_if_no_space(cptestctx: &ControlPlaneTestContext) {
 #[nexus_test]
 async fn test_snapshot_unwind(cptestctx: &ControlPlaneTestContext) {
     let client = &cptestctx.external_client;
-    let disk_test = DiskTest::new(&cptestctx).await;
+    let disk_test = DiskTest::new(cptestctx).await;
     create_project_and_pool(client).await;
     let disks_url = get_disks_url();
 
@@ -1026,7 +1026,7 @@ async fn test_create_snapshot_record_idempotent(
     let nexus = &cptestctx.server.server_context().nexus;
     let datastore = nexus.datastore();
 
-    let project_id = create_project_and_pool(&client).await;
+    let project_id = create_project_and_pool(client).await;
     let disk_id = Uuid::new_v4();
     let snapshot_name =
         external::Name::try_from("snapshot".to_string()).unwrap();
@@ -1056,7 +1056,7 @@ async fn test_create_snapshot_record_idempotent(
     let opctx =
         OpContext::for_tests(cptestctx.logctx.log.new(o!()), datastore.clone());
 
-    let (.., authz_project) = LookupPath::new(&opctx, &datastore)
+    let (.., authz_project) = LookupPath::new(&opctx, datastore)
         .project_id(project_id)
         .lookup_for(authz::Action::CreateChild)
         .await
@@ -1115,7 +1115,7 @@ async fn test_create_snapshot_record_idempotent(
 
     // Move snapshot from Creating to Ready
 
-    let (.., authz_snapshot, db_snapshot) = LookupPath::new(&opctx, &datastore)
+    let (.., authz_snapshot, db_snapshot) = LookupPath::new(&opctx, datastore)
         .snapshot_id(snapshot_created_1.id())
         .fetch_for(authz::Action::Modify)
         .await
@@ -1133,7 +1133,7 @@ async fn test_create_snapshot_record_idempotent(
 
     // Grab the new snapshot (so generation number is updated)
 
-    let (.., authz_snapshot, db_snapshot) = LookupPath::new(&opctx, &datastore)
+    let (.., authz_snapshot, db_snapshot) = LookupPath::new(&opctx, datastore)
         .snapshot_id(snapshot_created_1.id())
         .fetch_for(authz::Action::Delete)
         .await
@@ -1158,7 +1158,7 @@ async fn test_create_snapshot_record_idempotent(
 
     {
         // Ensure the snapshot is gone
-        let r = LookupPath::new(&opctx, &datastore)
+        let r = LookupPath::new(&opctx, datastore)
             .snapshot_id(snapshot_created_1.id())
             .fetch_for(authz::Action::Read)
             .await;
@@ -1241,7 +1241,7 @@ async fn test_multiple_deletes_not_sent(cptestctx: &ControlPlaneTestContext) {
     let client = &cptestctx.external_client;
     let nexus = &cptestctx.server.server_context().nexus;
     let datastore = nexus.datastore();
-    DiskTest::new(&cptestctx).await;
+    DiskTest::new(cptestctx).await;
     let _project_id = create_project_and_pool(client).await;
     let disks_url = get_disks_url();
 
@@ -1324,7 +1324,7 @@ async fn test_multiple_deletes_not_sent(cptestctx: &ControlPlaneTestContext) {
         OpContext::for_tests(cptestctx.logctx.log.new(o!()), datastore.clone());
 
     let (.., authz_snapshot_1, db_snapshot_1) =
-        LookupPath::new(&opctx, &datastore)
+        LookupPath::new(&opctx, datastore)
             .snapshot_id(snapshot_1.identity.id)
             .fetch_for(authz::Action::Delete)
             .await
@@ -1346,7 +1346,7 @@ async fn test_multiple_deletes_not_sent(cptestctx: &ControlPlaneTestContext) {
         .unwrap();
 
     let (.., authz_snapshot_2, db_snapshot_2) =
-        LookupPath::new(&opctx, &datastore)
+        LookupPath::new(&opctx, datastore)
             .snapshot_id(snapshot_2.identity.id)
             .fetch_for(authz::Action::Delete)
             .await
@@ -1368,7 +1368,7 @@ async fn test_multiple_deletes_not_sent(cptestctx: &ControlPlaneTestContext) {
         .unwrap();
 
     let (.., authz_snapshot_3, db_snapshot_3) =
-        LookupPath::new(&opctx, &datastore)
+        LookupPath::new(&opctx, datastore)
             .snapshot_id(snapshot_3.identity.id)
             .fetch_for(authz::Action::Delete)
             .await
@@ -1466,7 +1466,7 @@ async fn test_region_allocation_for_snapshot(
     // We add one more than the "three" default to avoid failing
     // with "not enough storage".
     let sled_id = cptestctx.first_sled_id();
-    let mut disk_test = DiskTestBuilder::new(&cptestctx)
+    let mut disk_test = DiskTestBuilder::new(cptestctx)
         .on_specific_sled(sled_id)
         .with_zpool_count(4)
         .build()
@@ -1476,11 +1476,11 @@ async fn test_region_allocation_for_snapshot(
     let client = &cptestctx.external_client;
     let _project_id = create_project_and_pool(client).await;
 
-    let disk = create_disk(&client, PROJECT_NAME, "disk").await;
+    let disk = create_disk(client, PROJECT_NAME, "disk").await;
 
     // Assert disk has three allocated regions
     let disk_id = disk.identity.id;
-    let (.., db_disk) = LookupPath::new(&opctx, &datastore)
+    let (.., db_disk) = LookupPath::new(&opctx, datastore)
         .disk_id(disk_id)
         .fetch()
         .await
@@ -1513,7 +1513,7 @@ async fn test_region_allocation_for_snapshot(
     // There shouldn't be any regions for the snapshot volume
 
     let snapshot_id = snapshot.identity.id;
-    let (.., db_snapshot) = LookupPath::new(&opctx, &datastore)
+    let (.., db_snapshot) = LookupPath::new(&opctx, datastore)
         .snapshot_id(snapshot_id)
         .fetch()
         .await
@@ -1654,13 +1654,13 @@ async fn test_snapshot_expunge(cptestctx: &ControlPlaneTestContext) {
         OpContext::for_tests(cptestctx.logctx.log.new(o!()), datastore.clone());
 
     // Create three zpools, each with one dataset.
-    let _disk_test = DiskTest::new(&cptestctx).await;
+    let _disk_test = DiskTest::new(cptestctx).await;
 
     // Create a disk, then a snapshot of that disk
     let client = &cptestctx.external_client;
     let _project_id = create_project_and_pool(client).await;
 
-    let disk = create_disk(&client, PROJECT_NAME, "disk").await;
+    let disk = create_disk(client, PROJECT_NAME, "disk").await;
 
     let snapshots_url = format!("/v1/snapshots?project={}", PROJECT_NAME);
 

--- a/nexus/tests/integration_tests/subnet_allocation.rs
+++ b/nexus/tests/integration_tests/subnet_allocation.rs
@@ -69,7 +69,7 @@ async fn create_instance_expect_failure(
     };
 
     NexusRequest::new(
-        RequestBuilder::new(&client, Method::POST, &url_instances)
+        RequestBuilder::new(client, Method::POST, url_instances)
             .body(Some(&new_instance))
             .expect_status(Some(StatusCode::BAD_REQUEST)),
     )
@@ -88,8 +88,8 @@ async fn test_subnet_allocation(cptestctx: &ControlPlaneTestContext) {
     let project_name = "springfield-squidport";
 
     // Create a project that we'll use for testing.
-    create_default_ip_pool(&client).await;
-    create_project(&client, project_name).await;
+    create_default_ip_pool(client).await;
+    create_project(client, project_name).await;
     let url_instances = format!("/v1/instances?project={}", project_name);
 
     // Create a new, small VPC Subnet, so we don't need to issue many requests

--- a/nexus/tests/integration_tests/unauthorized.rs
+++ b/nexus/tests/integration_tests/unauthorized.rs
@@ -122,7 +122,7 @@ async fn test_unauthorized(cptestctx: &ControlPlaneTestContext) {
     print!("{}", VERIFY_HEADER);
     for endpoint in &*VERIFY_ENDPOINTS {
         let setup_response = setup_results.get(&endpoint.url);
-        verify_endpoint(&log, client, endpoint, setup_response).await;
+        verify_endpoint(log, client, endpoint, setup_response).await;
     }
 }
 
@@ -228,7 +228,7 @@ static SETUP_REQUESTS: LazyLock<Vec<SetupReq>> = LazyLock::new(|| {
         },
         // Create the default IP pool
         SetupReq::Post {
-            url: &DEMO_IP_POOLS_URL,
+            url: DEMO_IP_POOLS_URL,
             body: serde_json::to_value(&*DEMO_IP_POOL_CREATE).unwrap(),
             id_routes: vec!["/v1/ip-pools/{id}"],
         },
@@ -348,25 +348,25 @@ static SETUP_REQUESTS: LazyLock<Vec<SetupReq>> = LazyLock::new(|| {
         },
         // Create a SAML identity provider
         SetupReq::Post {
-            url: &SAML_IDENTITY_PROVIDERS_URL,
+            url: SAML_IDENTITY_PROVIDERS_URL,
             body: serde_json::to_value(&*SAML_IDENTITY_PROVIDER).unwrap(),
             id_routes: vec![],
         },
         // Create a SSH key
         SetupReq::Post {
-            url: &DEMO_SSHKEYS_URL,
+            url: DEMO_SSHKEYS_URL,
             body: serde_json::to_value(&*DEMO_SSHKEY_CREATE).unwrap(),
             id_routes: vec![],
         },
         // Create a Certificate
         SetupReq::Post {
-            url: &DEMO_CERTIFICATES_URL,
+            url: DEMO_CERTIFICATES_URL,
             body: serde_json::to_value(&*DEMO_CERTIFICATE_CREATE).unwrap(),
             id_routes: vec![],
         },
         // Create a Support Bundle
         SetupReq::Post {
-            url: &SUPPORT_BUNDLES_URL,
+            url: SUPPORT_BUNDLES_URL,
             body: serde_json::to_value(()).unwrap(),
             id_routes: vec!["/experimental/v1/system/support-bundles/{id}"],
         },

--- a/nexus/tests/integration_tests/utilization.rs
+++ b/nexus/tests/integration_tests/utilization.rs
@@ -27,7 +27,7 @@ type ControlPlaneTestContext =
 async fn test_utilization(cptestctx: &ControlPlaneTestContext) {
     let client = &cptestctx.external_client;
 
-    create_default_ip_pool(&client).await;
+    create_default_ip_pool(client).await;
 
     // set high quota for test silo
     let _ = NexusRequest::object_put(
@@ -90,8 +90,8 @@ async fn test_utilization(cptestctx: &ControlPlaneTestContext) {
         SiloQuotasCreate::arbitrarily_high_default().into()
     );
 
-    let _ = create_project(&client, &PROJECT_NAME).await;
-    let _ = create_instance(client, &PROJECT_NAME, &INSTANCE_NAME).await;
+    let _ = create_project(client, PROJECT_NAME).await;
+    let _ = create_instance(client, PROJECT_NAME, INSTANCE_NAME).await;
 
     // Start instance
     NexusRequest::new(
@@ -134,7 +134,7 @@ async fn test_utilization(cptestctx: &ControlPlaneTestContext) {
     );
 
     // Simulate space for disks
-    DiskTest::new(&cptestctx).await;
+    DiskTest::new(cptestctx).await;
 
     // provision disk
     NexusRequest::new(

--- a/nexus/tests/integration_tests/volume_management.rs
+++ b/nexus/tests/integration_tests/volume_management.rs
@@ -155,7 +155,7 @@ async fn create_base_disk(
     };
 
     NexusRequest::new(
-        RequestBuilder::new(client, Method::POST, &disks_url)
+        RequestBuilder::new(client, Method::POST, disks_url)
             .body(Some(&base_disk))
             .expect_status(Some(StatusCode::CREATED)),
     )
@@ -178,14 +178,14 @@ async fn test_snapshot_then_delete_disk(cptestctx: &ControlPlaneTestContext) {
     // 4. Delete the snapshot
 
     let client = &cptestctx.external_client;
-    let disk_test = DiskTest::new(&cptestctx).await;
+    let disk_test = DiskTest::new(cptestctx).await;
     let disks_url = get_disks_url();
     let base_disk_name: Name = "base-disk".parse().unwrap();
 
-    let image = create_image(&client).await;
+    let image = create_image(client).await;
     // Create a disk from this image
     let base_disk =
-        create_base_disk(&client, &image, &disks_url, &base_disk_name).await;
+        create_base_disk(client, &image, &disks_url, &base_disk_name).await;
 
     // Issue snapshot request
     let snapshot: views::Snapshot = object_create(
@@ -238,15 +238,15 @@ async fn test_delete_snapshot_then_disk(cptestctx: &ControlPlaneTestContext) {
     // 4. Delete the disk
 
     let client = &cptestctx.external_client;
-    let disk_test = DiskTest::new(&cptestctx).await;
+    let disk_test = DiskTest::new(cptestctx).await;
     let disks_url = get_disks_url();
     let base_disk_name: Name = "base-disk".parse().unwrap();
 
     // Define an image
-    let image = create_image(&client).await;
+    let image = create_image(client).await;
     // Create a disk from this image
     let base_disk =
-        create_base_disk(&client, &image, &disks_url, &base_disk_name).await;
+        create_base_disk(client, &image, &disks_url, &base_disk_name).await;
 
     // Issue snapshot request
     let snapshot: views::Snapshot = object_create(
@@ -299,14 +299,14 @@ async fn test_multiple_snapshots(cptestctx: &ControlPlaneTestContext) {
     // 4. Delete the snapshots
 
     let client = &cptestctx.external_client;
-    let disk_test = DiskTest::new(&cptestctx).await;
+    let disk_test = DiskTest::new(cptestctx).await;
     let disks_url = get_disks_url();
     let base_disk_name: Name = "base-disk".parse().unwrap();
 
-    let image = create_image(&client).await;
+    let image = create_image(client).await;
     // Create a disk from this image
     let base_disk =
-        create_base_disk(&client, &image, &disks_url, &base_disk_name).await;
+        create_base_disk(client, &image, &disks_url, &base_disk_name).await;
 
     // Issue snapshot requests
     for i in 0..4 {
@@ -362,14 +362,14 @@ async fn test_snapshot_prevents_other_disk(
     // allocation.
 
     let client = &cptestctx.external_client;
-    let disk_test = DiskTest::new(&cptestctx).await;
+    let disk_test = DiskTest::new(cptestctx).await;
     let disks_url = get_disks_url();
     let base_disk_name: Name = "base-disk".parse().unwrap();
 
-    let image = create_image(&client).await;
+    let image = create_image(client).await;
     // Create a disk from this image
     let base_disk =
-        create_base_disk(&client, &image, &disks_url, &base_disk_name).await;
+        create_base_disk(client, &image, &disks_url, &base_disk_name).await;
 
     // Issue snapshot request
     let snapshot: views::Snapshot = object_create(
@@ -464,7 +464,7 @@ async fn test_multiple_disks_multiple_snapshots_order_1(
 ) {
     // Test multiple disks with multiple snapshots
     let client = &cptestctx.external_client;
-    let disk_test = DiskTest::new(&cptestctx).await;
+    let disk_test = DiskTest::new(cptestctx).await;
     create_project_and_pool(client).await;
     let disks_url = get_disks_url();
 
@@ -599,7 +599,7 @@ async fn test_multiple_disks_multiple_snapshots_order_2(
 ) {
     // Test multiple disks with multiple snapshots, varying the delete order
     let client = &cptestctx.external_client;
-    let disk_test = DiskTest::new(&cptestctx).await;
+    let disk_test = DiskTest::new(cptestctx).await;
     create_project_and_pool(client).await;
     let disks_url = get_disks_url();
 
@@ -868,10 +868,10 @@ async fn test_multiple_layers_of_snapshots_delete_all_disks_first(
     // Test layering read-only snapshots through multiple disks:
     // delete all disks, then delete all snapshots
     let client = &cptestctx.external_client;
-    let disk_test = DiskTest::new(&cptestctx).await;
+    let disk_test = DiskTest::new(cptestctx).await;
     create_project_and_pool(client).await;
 
-    prepare_for_test_multiple_layers_of_snapshots(&client).await;
+    prepare_for_test_multiple_layers_of_snapshots(client).await;
 
     // Delete the disks
     for name in ["layer-1-disk", "layer-2-disk", "layer-3-disk"] {
@@ -906,10 +906,10 @@ async fn test_multiple_layers_of_snapshots_delete_all_snapshots_first(
     // Test layering read-only snapshots through multiple disks:
     // delete all snapshots, then delete all disks
     let client = &cptestctx.external_client;
-    let disk_test = DiskTest::new(&cptestctx).await;
+    let disk_test = DiskTest::new(cptestctx).await;
     create_project_and_pool(client).await;
 
-    prepare_for_test_multiple_layers_of_snapshots(&client).await;
+    prepare_for_test_multiple_layers_of_snapshots(client).await;
 
     // Delete the snapshots
     for name in ["layer-1-snapshot", "layer-2-snapshot", "layer-3-snapshot"] {
@@ -944,10 +944,10 @@ async fn test_multiple_layers_of_snapshots_random_delete_order(
     // Test layering read-only snapshots through multiple disks:
     // delete snapshots and disks in a random order
     let client = &cptestctx.external_client;
-    let disk_test = DiskTest::new(&cptestctx).await;
+    let disk_test = DiskTest::new(cptestctx).await;
     create_project_and_pool(client).await;
 
-    prepare_for_test_multiple_layers_of_snapshots(&client).await;
+    prepare_for_test_multiple_layers_of_snapshots(client).await;
 
     #[derive(Debug)]
     enum DeleteObject {
@@ -1008,15 +1008,15 @@ async fn test_create_image_from_snapshot(cptestctx: &ControlPlaneTestContext) {
     // 3. Create an image from that snapshot
 
     let client = &cptestctx.external_client;
-    let _disk_test = DiskTest::new(&cptestctx).await;
+    let _disk_test = DiskTest::new(cptestctx).await;
     let disks_url = get_disks_url();
     let base_disk_name: Name = "base-disk".parse().unwrap();
 
-    let image = create_image(&client).await;
+    let image = create_image(client).await;
 
     // Create a disk from this image
     let _base_disk =
-        create_base_disk(&client, &image, &disks_url, &base_disk_name).await;
+        create_base_disk(client, &image, &disks_url, &base_disk_name).await;
 
     // Issue snapshot request
     let snapshots_url = format!("/v1/snapshots?project={}", PROJECT_NAME);
@@ -1067,15 +1067,15 @@ async fn test_create_image_from_snapshot_delete(
     // 6. Delete the image.
 
     let client = &cptestctx.external_client;
-    let disk_test = DiskTest::new(&cptestctx).await;
+    let disk_test = DiskTest::new(cptestctx).await;
     let disks_url = get_disks_url();
     let base_disk_name: Name = "base-disk".parse().unwrap();
 
-    let image = create_image(&client).await;
+    let image = create_image(client).await;
 
     // Create a disk from this image
     let _base_disk =
-        create_base_disk(&client, &image, &disks_url, &base_disk_name).await;
+        create_base_disk(client, &image, &disks_url, &base_disk_name).await;
 
     // Issue snapshot request
     let snapshots_url = format!("/v1/snapshots?project={}", PROJECT_NAME);
@@ -1137,7 +1137,7 @@ async fn test_create_image_from_snapshot_delete(
 
     // Delete the image
     let image_url = "/v1/images/debian-11";
-    NexusRequest::object_delete(client, &image_url)
+    NexusRequest::object_delete(client, image_url)
         .authn_as(AuthnMode::PrivilegedUser)
         .execute()
         .await
@@ -1162,7 +1162,7 @@ async fn delete_image_test(
     // 3. Create an image from that snapshot
     // 4. Delete each of these items in some order
 
-    let disk_test = DiskTest::new(&cptestctx).await;
+    let disk_test = DiskTest::new(cptestctx).await;
 
     let client = &cptestctx.external_client;
     create_project_and_pool(client).await;
@@ -1242,7 +1242,7 @@ async fn delete_image_test(
         match item {
             DeleteImageTestParam::Image => {
                 let image_url = "/v1/images/debian-11";
-                NexusRequest::object_delete(client, &image_url)
+                NexusRequest::object_delete(client, image_url)
                     .authn_as(AuthnMode::PrivilegedUser)
                     .execute()
                     .await
@@ -1411,8 +1411,8 @@ async fn test_volume_remove_read_only_parent_base(
 
     // Create the Volume with a read_only_parent, and the temp volume that
     // the saga would create for us.
-    create_volume(&datastore, volume_id, Some(rop)).await;
-    create_volume(&datastore, t_vid, None).await;
+    create_volume(datastore, volume_id, Some(rop)).await;
+    create_volume(datastore, t_vid, None).await;
 
     // We should get Ok(true) back after removal of the ROP.
     let res = datastore.volume_remove_rop(volume_id, t_vid).await.unwrap();
@@ -1514,7 +1514,7 @@ async fn test_volume_remove_read_only_parent_no_parent(
 
     let volume_id = VolumeUuid::new_v4();
     let t_vid = VolumeUuid::new_v4();
-    create_volume(&datastore, volume_id, None).await;
+    create_volume(datastore, volume_id, None).await;
 
     // We will get Ok(false) back from this operation.
     let res = datastore.volume_remove_rop(volume_id, t_vid).await.unwrap();
@@ -1583,7 +1583,7 @@ async fn test_volume_remove_read_only_parent_volume_deleted(
         url: "http://oxide.computer/rop".to_string(),
     };
     // Make the volume
-    create_volume(&datastore, volume_id, Some(rop)).await;
+    create_volume(datastore, volume_id, Some(rop)).await;
 
     // Soft delete the volume
     let _cr = datastore.soft_delete_volume(volume_id).await.unwrap();
@@ -1611,7 +1611,7 @@ async fn test_volume_remove_rop_saga(cptestctx: &ControlPlaneTestContext) {
         url: "http://oxide.computer/rop".to_string(),
     };
 
-    create_volume(&datastore, volume_id, Some(rop)).await;
+    create_volume(datastore, volume_id, Some(rop)).await;
 
     println!("Created this volume: {:?}", volume_id);
     // disk to volume id, to then remove ROP?
@@ -1674,7 +1674,7 @@ async fn test_volume_remove_rop_saga_twice(
         url: "http://oxide.computer/rop".to_string(),
     };
 
-    create_volume(&datastore, volume_id, Some(rop)).await;
+    create_volume(datastore, volume_id, Some(rop)).await;
 
     println!("Created this volume: {:?}", volume_id);
     // disk to volume id, to then remove ROP?
@@ -1810,7 +1810,7 @@ async fn test_volume_remove_rop_saga_deleted_volume(
         url: "http://oxide.computer/rop".to_string(),
     };
     // Make the volume
-    create_volume(&datastore, volume_id, Some(rop)).await;
+    create_volume(datastore, volume_id, Some(rop)).await;
 
     // Soft delete the volume
     let _cr = datastore.soft_delete_volume(volume_id).await.unwrap();
@@ -2178,7 +2178,7 @@ async fn test_keep_your_targets_straight(cptestctx: &ControlPlaneTestContext) {
     let datastore = nexus.datastore();
 
     // Four zpools, one dataset each
-    let disk_test = DiskTestBuilder::new(&cptestctx)
+    let disk_test = DiskTestBuilder::new(cptestctx)
         .on_specific_sled(cptestctx.first_sled_id())
         .with_zpool_count(4)
         .build()
@@ -2503,7 +2503,7 @@ async fn test_disk_create_saga_unwinds_correctly(
     let client = &cptestctx.external_client;
     create_project_and_pool(client).await;
 
-    let disk_test = DiskTest::new(&cptestctx).await;
+    let disk_test = DiskTest::new(cptestctx).await;
     let disks_url = get_disks_url();
     let base_disk_name: Name = "base-disk".parse().unwrap();
 
@@ -2553,7 +2553,7 @@ async fn test_snapshot_create_saga_unwinds_correctly(
     let client = &cptestctx.external_client;
     create_project_and_pool(client).await;
 
-    let disk_test = DiskTest::new(&cptestctx).await;
+    let disk_test = DiskTest::new(cptestctx).await;
     let disks_url = get_disks_url();
     let base_disk_name: Name = "base-disk".parse().unwrap();
 
@@ -3475,7 +3475,7 @@ async fn test_upstairs_notify_downstairs_client_stops(
 #[nexus_test]
 async fn test_cte_returns_regions(cptestctx: &ControlPlaneTestContext) {
     let client = &cptestctx.external_client;
-    let _disk_test = DiskTest::new(&cptestctx).await;
+    let _disk_test = DiskTest::new(cptestctx).await;
     create_project_and_pool(client).await;
     let disks_url = get_disks_url();
 
@@ -3510,7 +3510,7 @@ async fn test_cte_returns_regions(cptestctx: &ControlPlaneTestContext) {
 
     let disk_id = disk.identity.id;
 
-    let (.., db_disk) = LookupPath::new(&opctx, &datastore)
+    let (.., db_disk) = LookupPath::new(&opctx, datastore)
         .disk_id(disk_id)
         .fetch()
         .await
@@ -3564,7 +3564,7 @@ impl TestReadOnlyRegionReferenceUsage {
             datastore.clone(),
         );
 
-        DiskTestBuilder::new(&cptestctx)
+        DiskTestBuilder::new(cptestctx)
             .on_specific_sled(cptestctx.first_sled_id())
             .with_zpool_count(4)
             .build()
@@ -3724,7 +3724,7 @@ impl TestReadOnlyRegionReferenceUsage {
         assert!(
             self.datastore
                 .regions_to_delete(
-                    &self.last_resources_to_delete.as_ref().unwrap()
+                    self.last_resources_to_delete.as_ref().unwrap()
                 )
                 .await
                 .unwrap()
@@ -3738,7 +3738,7 @@ impl TestReadOnlyRegionReferenceUsage {
             !self
                 .datastore
                 .regions_to_delete(
-                    &self.last_resources_to_delete.as_ref().unwrap()
+                    self.last_resources_to_delete.as_ref().unwrap()
                 )
                 .await
                 .unwrap()
@@ -4072,7 +4072,7 @@ async fn test_read_only_region_reference_counting(
 
     // Create one zpool on each of the 4 sleds. This is required for region
     // replacement or region snapshot replacement
-    let disk_test = DiskTestBuilder::new(&cptestctx)
+    let disk_test = DiskTestBuilder::new(cptestctx)
         .on_all_sleds()
         .with_zpool_count(1)
         .build()
@@ -4080,13 +4080,13 @@ async fn test_read_only_region_reference_counting(
 
     create_project_and_pool(client).await;
 
-    let disk = create_disk(&client, PROJECT_NAME, "disk").await;
+    let disk = create_disk(client, PROJECT_NAME, "disk").await;
 
     let snapshot =
-        create_snapshot(&client, PROJECT_NAME, "disk", "snapshot").await;
+        create_snapshot(client, PROJECT_NAME, "disk", "snapshot").await;
 
     let disk_from_snapshot = create_disk_from_snapshot(
-        &client,
+        client,
         PROJECT_NAME,
         "disk-from-snapshot",
         snapshot.identity.id,
@@ -4096,7 +4096,7 @@ async fn test_read_only_region_reference_counting(
     // Perform region snapshot replacement for one of the snapshot's regions,
     // causing a read-only region to be created.
 
-    let (.., db_disk) = LookupPath::new(&opctx, &datastore)
+    let (.., db_disk) = LookupPath::new(&opctx, datastore)
         .disk_id(disk.identity.id)
         .fetch()
         .await
@@ -4120,11 +4120,11 @@ async fn test_read_only_region_reference_counting(
         .await
         .unwrap();
 
-    wait_for_all_replacements(datastore, &internal_client).await;
+    wait_for_all_replacements(datastore, internal_client).await;
 
     // The snapshot's allocated regions should have the one read-only region
 
-    let (.., db_snapshot) = LookupPath::new(&opctx, &datastore)
+    let (.., db_snapshot) = LookupPath::new(&opctx, datastore)
         .snapshot_id(snapshot.identity.id)
         .fetch()
         .await
@@ -4146,7 +4146,7 @@ async fn test_read_only_region_reference_counting(
 
     // The disk-from-snap VCR should also reference that read-only region
 
-    let (.., db_disk_from_snapshot) = LookupPath::new(&opctx, &datastore)
+    let (.., db_disk_from_snapshot) = LookupPath::new(&opctx, datastore)
         .disk_id(disk_from_snapshot.identity.id)
         .fetch()
         .await
@@ -4342,7 +4342,7 @@ async fn test_read_only_region_reference_counting_layers(
 
     // Create one zpool on each of the 4 sleds. This is required for region
     // replacement or region snapshot replacement
-    let disk_test = DiskTestBuilder::new(&cptestctx)
+    let disk_test = DiskTestBuilder::new(cptestctx)
         .on_all_sleds()
         .with_zpool_count(1)
         .build()
@@ -4350,13 +4350,13 @@ async fn test_read_only_region_reference_counting_layers(
 
     create_project_and_pool(client).await;
 
-    let disk = create_disk(&client, PROJECT_NAME, "disk").await;
+    let disk = create_disk(client, PROJECT_NAME, "disk").await;
 
     let snapshot =
-        create_snapshot(&client, PROJECT_NAME, "disk", "snapshot").await;
+        create_snapshot(client, PROJECT_NAME, "disk", "snapshot").await;
 
     let disk_from_snapshot = create_disk_from_snapshot(
-        &client,
+        client,
         PROJECT_NAME,
         "disk-from-snapshot",
         snapshot.identity.id,
@@ -4366,7 +4366,7 @@ async fn test_read_only_region_reference_counting_layers(
     // Perform region snapshot replacement for one of the snapshot's regions,
     // causing a read-only region to be created.
 
-    let (.., db_disk) = LookupPath::new(&opctx, &datastore)
+    let (.., db_disk) = LookupPath::new(&opctx, datastore)
         .disk_id(disk.identity.id)
         .fetch()
         .await
@@ -4390,11 +4390,11 @@ async fn test_read_only_region_reference_counting_layers(
         .await
         .unwrap();
 
-    wait_for_all_replacements(datastore, &internal_client).await;
+    wait_for_all_replacements(datastore, internal_client).await;
 
     // Grab the read-only region in the snapshot volume
 
-    let (.., db_snapshot) = LookupPath::new(&opctx, &datastore)
+    let (.., db_snapshot) = LookupPath::new(&opctx, datastore)
         .snapshot_id(snapshot.identity.id)
         .fetch()
         .await
@@ -4411,7 +4411,7 @@ async fn test_read_only_region_reference_counting_layers(
 
     // The disk-from-snap VCR should also reference that read-only region
 
-    let (.., db_disk_from_snapshot) = LookupPath::new(&opctx, &datastore)
+    let (.., db_disk_from_snapshot) = LookupPath::new(&opctx, datastore)
         .disk_id(disk_from_snapshot.identity.id)
         .fetch()
         .await
@@ -4460,7 +4460,7 @@ async fn test_read_only_region_reference_counting_layers(
     // Take a snapshot of the disk-from-snapshot disk
 
     let double_snapshot = create_snapshot(
-        &client,
+        client,
         PROJECT_NAME,
         "disk-from-snapshot",
         "double-snapshot",
@@ -4469,7 +4469,7 @@ async fn test_read_only_region_reference_counting_layers(
 
     // Assert correct volume usage records
 
-    let (.., db_double_snapshot) = LookupPath::new(&opctx, &datastore)
+    let (.., db_double_snapshot) = LookupPath::new(&opctx, datastore)
         .snapshot_id(double_snapshot.identity.id)
         .fetch()
         .await
@@ -4587,7 +4587,7 @@ async fn test_volume_replace_snapshot_respects_accounting(
     let opctx =
         OpContext::for_tests(cptestctx.logctx.log.new(o!()), datastore.clone());
 
-    DiskTestBuilder::new(&cptestctx)
+    DiskTestBuilder::new(cptestctx)
         .on_specific_sled(cptestctx.first_sled_id())
         .with_zpool_count(4)
         .build()
@@ -4597,9 +4597,9 @@ async fn test_volume_replace_snapshot_respects_accounting(
 
     // Create a disk, then a snapshot of that disk
 
-    let disk = create_disk(&client, PROJECT_NAME, "disk").await;
+    let disk = create_disk(client, PROJECT_NAME, "disk").await;
 
-    let (.., db_disk) = LookupPath::new(&opctx, &datastore)
+    let (.., db_disk) = LookupPath::new(&opctx, datastore)
         .disk_id(disk.identity.id)
         .fetch()
         .await
@@ -4611,9 +4611,9 @@ async fn test_volume_replace_snapshot_respects_accounting(
     assert_eq!(disk_allocated_regions.len(), 3);
 
     let snapshot =
-        create_snapshot(&client, PROJECT_NAME, "disk", "snapshot").await;
+        create_snapshot(client, PROJECT_NAME, "disk", "snapshot").await;
 
-    let (.., db_snapshot) = LookupPath::new(&opctx, &datastore)
+    let (.., db_snapshot) = LookupPath::new(&opctx, datastore)
         .snapshot_id(snapshot.identity.id)
         .fetch()
         .await
@@ -4792,7 +4792,7 @@ async fn test_volume_remove_rop_respects_accounting(
     let opctx =
         OpContext::for_tests(cptestctx.logctx.log.new(o!()), datastore.clone());
 
-    DiskTestBuilder::new(&cptestctx)
+    DiskTestBuilder::new(cptestctx)
         .on_specific_sled(cptestctx.first_sled_id())
         .with_zpool_count(4)
         .build()
@@ -4803,9 +4803,9 @@ async fn test_volume_remove_rop_respects_accounting(
     // Create a disk, then a snapshot of that disk, then a disk from that
     // snapshot.
 
-    let disk = create_disk(&client, PROJECT_NAME, "disk").await;
+    let disk = create_disk(client, PROJECT_NAME, "disk").await;
 
-    let (.., db_disk) = LookupPath::new(&opctx, &datastore)
+    let (.., db_disk) = LookupPath::new(&opctx, datastore)
         .disk_id(disk.identity.id)
         .fetch()
         .await
@@ -4817,9 +4817,9 @@ async fn test_volume_remove_rop_respects_accounting(
     assert_eq!(disk_allocated_regions.len(), 3);
 
     let snapshot =
-        create_snapshot(&client, PROJECT_NAME, "disk", "snapshot").await;
+        create_snapshot(client, PROJECT_NAME, "disk", "snapshot").await;
 
-    let (.., db_snapshot) = LookupPath::new(&opctx, &datastore)
+    let (.., db_snapshot) = LookupPath::new(&opctx, datastore)
         .snapshot_id(snapshot.identity.id)
         .fetch()
         .await
@@ -4828,14 +4828,14 @@ async fn test_volume_remove_rop_respects_accounting(
         });
 
     let disk_from_snapshot = create_disk_from_snapshot(
-        &client,
+        client,
         PROJECT_NAME,
         "disk-from-snapshot",
         snapshot.identity.id,
     )
     .await;
 
-    let (.., db_disk_from_snapshot) = LookupPath::new(&opctx, &datastore)
+    let (.., db_disk_from_snapshot) = LookupPath::new(&opctx, datastore)
         .disk_id(disk_from_snapshot.identity.id)
         .fetch()
         .await
@@ -4955,7 +4955,7 @@ async fn test_volume_remove_rop_respects_accounting_no_modify_others(
     let opctx =
         OpContext::for_tests(cptestctx.logctx.log.new(o!()), datastore.clone());
 
-    DiskTestBuilder::new(&cptestctx)
+    DiskTestBuilder::new(cptestctx)
         .on_specific_sled(cptestctx.first_sled_id())
         .with_zpool_count(4)
         .build()
@@ -4966,9 +4966,9 @@ async fn test_volume_remove_rop_respects_accounting_no_modify_others(
     // Create a disk, then a snapshot of that disk, then a disk from that
     // snapshot.
 
-    let disk = create_disk(&client, PROJECT_NAME, "disk").await;
+    let disk = create_disk(client, PROJECT_NAME, "disk").await;
 
-    let (.., db_disk) = LookupPath::new(&opctx, &datastore)
+    let (.., db_disk) = LookupPath::new(&opctx, datastore)
         .disk_id(disk.identity.id)
         .fetch()
         .await
@@ -4980,9 +4980,9 @@ async fn test_volume_remove_rop_respects_accounting_no_modify_others(
     assert_eq!(disk_allocated_regions.len(), 3);
 
     let snapshot =
-        create_snapshot(&client, PROJECT_NAME, "disk", "snapshot").await;
+        create_snapshot(client, PROJECT_NAME, "disk", "snapshot").await;
 
-    let (.., db_snapshot) = LookupPath::new(&opctx, &datastore)
+    let (.., db_snapshot) = LookupPath::new(&opctx, datastore)
         .snapshot_id(snapshot.identity.id)
         .fetch()
         .await
@@ -4991,14 +4991,14 @@ async fn test_volume_remove_rop_respects_accounting_no_modify_others(
         });
 
     let disk_from_snapshot = create_disk_from_snapshot(
-        &client,
+        client,
         PROJECT_NAME,
         "disk-from-snapshot",
         snapshot.identity.id,
     )
     .await;
 
-    let (.., db_disk_from_snapshot) = LookupPath::new(&opctx, &datastore)
+    let (.., db_disk_from_snapshot) = LookupPath::new(&opctx, datastore)
         .disk_id(disk_from_snapshot.identity.id)
         .fetch()
         .await
@@ -5010,7 +5010,7 @@ async fn test_volume_remove_rop_respects_accounting_no_modify_others(
         });
 
     let another_disk_from_snapshot = create_disk_from_snapshot(
-        &client,
+        client,
         PROJECT_NAME,
         "another-disk-from-snapshot",
         snapshot.identity.id,
@@ -5018,7 +5018,7 @@ async fn test_volume_remove_rop_respects_accounting_no_modify_others(
     .await;
 
     let (.., db_another_disk_from_snapshot) =
-        LookupPath::new(&opctx, &datastore)
+        LookupPath::new(&opctx, datastore)
             .disk_id(another_disk_from_snapshot.identity.id)
             .fetch()
             .await
@@ -5214,7 +5214,7 @@ async fn test_migrate_to_ref_count_with_records(
     let nexus = &apictx.nexus;
     let datastore = nexus.datastore();
 
-    DiskTestBuilder::new(&cptestctx)
+    DiskTestBuilder::new(cptestctx)
         .on_specific_sled(cptestctx.first_sled_id())
         .with_zpool_count(4)
         .build()
@@ -5224,39 +5224,39 @@ async fn test_migrate_to_ref_count_with_records(
 
     // Create a disk
 
-    create_disk(&client, PROJECT_NAME, "disk").await;
+    create_disk(client, PROJECT_NAME, "disk").await;
 
     // Test migration
 
-    let records_before = get_volume_resource_usage_records(&datastore).await;
+    let records_before = get_volume_resource_usage_records(datastore).await;
 
-    delete_all_volume_resource_usage_records(&datastore).await;
-    perform_migration(&datastore).await;
+    delete_all_volume_resource_usage_records(datastore).await;
+    perform_migration(datastore).await;
 
-    let records_after = get_volume_resource_usage_records(&datastore).await;
+    let records_after = get_volume_resource_usage_records(datastore).await;
 
     assert_eq!(records_before, records_after);
 
     // Create a snapshot
 
     let snapshot =
-        create_snapshot(&client, PROJECT_NAME, "disk", "snapshot").await;
+        create_snapshot(client, PROJECT_NAME, "disk", "snapshot").await;
 
     // Test migration
 
-    let records_before = get_volume_resource_usage_records(&datastore).await;
+    let records_before = get_volume_resource_usage_records(datastore).await;
 
-    delete_all_volume_resource_usage_records(&datastore).await;
-    perform_migration(&datastore).await;
+    delete_all_volume_resource_usage_records(datastore).await;
+    perform_migration(datastore).await;
 
-    let records_after = get_volume_resource_usage_records(&datastore).await;
+    let records_after = get_volume_resource_usage_records(datastore).await;
 
     assert_eq!(records_before, records_after);
 
     // Create a disk from that snapshot
 
     create_disk_from_snapshot(
-        &client,
+        client,
         PROJECT_NAME,
         "disk-from-snapshot",
         snapshot.identity.id,
@@ -5265,12 +5265,12 @@ async fn test_migrate_to_ref_count_with_records(
 
     // Test migration
 
-    let records_before = get_volume_resource_usage_records(&datastore).await;
+    let records_before = get_volume_resource_usage_records(datastore).await;
 
-    delete_all_volume_resource_usage_records(&datastore).await;
-    perform_migration(&datastore).await;
+    delete_all_volume_resource_usage_records(datastore).await;
+    perform_migration(datastore).await;
 
-    let records_after = get_volume_resource_usage_records(&datastore).await;
+    let records_after = get_volume_resource_usage_records(datastore).await;
 
     assert_eq!(records_before, records_after);
 
@@ -5284,12 +5284,12 @@ async fn test_migrate_to_ref_count_with_records(
 
     // Test the migration
 
-    let records_before = get_volume_resource_usage_records(&datastore).await;
+    let records_before = get_volume_resource_usage_records(datastore).await;
 
-    delete_all_volume_resource_usage_records(&datastore).await;
-    perform_migration(&datastore).await;
+    delete_all_volume_resource_usage_records(datastore).await;
+    perform_migration(datastore).await;
 
-    let records_after = get_volume_resource_usage_records(&datastore).await;
+    let records_after = get_volume_resource_usage_records(datastore).await;
 
     assert_eq!(records_before, records_after);
 
@@ -5303,12 +5303,12 @@ async fn test_migrate_to_ref_count_with_records(
 
     // Test the migration
 
-    let records_before = get_volume_resource_usage_records(&datastore).await;
+    let records_before = get_volume_resource_usage_records(datastore).await;
 
-    delete_all_volume_resource_usage_records(&datastore).await;
-    perform_migration(&datastore).await;
+    delete_all_volume_resource_usage_records(datastore).await;
+    perform_migration(datastore).await;
 
-    let records_after = get_volume_resource_usage_records(&datastore).await;
+    let records_after = get_volume_resource_usage_records(datastore).await;
 
     assert_eq!(records_before, records_after);
 }
@@ -5324,7 +5324,7 @@ async fn test_migrate_to_ref_count_with_records_soft_delete_volume(
     let opctx =
         OpContext::for_tests(cptestctx.logctx.log.new(o!()), datastore.clone());
 
-    DiskTestBuilder::new(&cptestctx)
+    DiskTestBuilder::new(cptestctx)
         .on_specific_sled(cptestctx.first_sled_id())
         .with_zpool_count(4)
         .build()
@@ -5335,10 +5335,10 @@ async fn test_migrate_to_ref_count_with_records_soft_delete_volume(
     // Create a disk, then a snapshot from that disk, then an image based on
     // that snapshot
 
-    create_disk(&client, PROJECT_NAME, "disk").await;
+    create_disk(client, PROJECT_NAME, "disk").await;
 
     let snapshot =
-        create_snapshot(&client, PROJECT_NAME, "disk", "snapshot").await;
+        create_snapshot(client, PROJECT_NAME, "disk", "snapshot").await;
 
     let params = params::ImageCreate {
         identity: IdentityMetadataCreateParams {
@@ -5359,7 +5359,7 @@ async fn test_migrate_to_ref_count_with_records_soft_delete_volume(
 
     // Soft-delete the snapshot's volume
 
-    let (.., db_snapshot) = LookupPath::new(&opctx, &datastore)
+    let (.., db_snapshot) = LookupPath::new(&opctx, datastore)
         .snapshot_id(snapshot.identity.id)
         .fetch()
         .await
@@ -5379,12 +5379,12 @@ async fn test_migrate_to_ref_count_with_records_soft_delete_volume(
     // This means that the snapshot volume is soft-deleted, make sure the
     // migration does not make usage records for it!
 
-    let records_before = get_volume_resource_usage_records(&datastore).await;
+    let records_before = get_volume_resource_usage_records(datastore).await;
 
-    delete_all_volume_resource_usage_records(&datastore).await;
-    perform_migration(&datastore).await;
+    delete_all_volume_resource_usage_records(datastore).await;
+    perform_migration(datastore).await;
 
-    let records_after = get_volume_resource_usage_records(&datastore).await;
+    let records_after = get_volume_resource_usage_records(datastore).await;
 
     assert_eq!(records_before, records_after);
 }
@@ -5397,7 +5397,7 @@ async fn test_migrate_to_ref_count_with_records_region_snapshot_deleting(
     let nexus = &apictx.nexus;
     let datastore = nexus.datastore();
 
-    let disk_test = DiskTestBuilder::new(&cptestctx)
+    let disk_test = DiskTestBuilder::new(cptestctx)
         .on_specific_sled(cptestctx.first_sled_id())
         .with_zpool_count(4)
         .build()
@@ -5560,12 +5560,12 @@ async fn test_migrate_to_ref_count_with_records_region_snapshot_deleting(
     // Test the migration does not incorrectly think a region snapshot with
     // deleting = true is used by any volume
 
-    let records_before = get_volume_resource_usage_records(&datastore).await;
+    let records_before = get_volume_resource_usage_records(datastore).await;
 
-    delete_all_volume_resource_usage_records(&datastore).await;
-    perform_migration(&datastore).await;
+    delete_all_volume_resource_usage_records(datastore).await;
+    perform_migration(datastore).await;
 
-    let records_after = get_volume_resource_usage_records(&datastore).await;
+    let records_after = get_volume_resource_usage_records(datastore).await;
 
     assert_eq!(records_before, records_after);
 }
@@ -5592,7 +5592,7 @@ async fn test_double_layer_with_read_only_region_delete(
 
     // Create one zpool on each of the four sleds. This is required for region
     // replacement or region snapshot replacement
-    let disk_test = DiskTestBuilder::new(&cptestctx)
+    let disk_test = DiskTestBuilder::new(cptestctx)
         .on_all_sleds()
         .with_zpool_count(1)
         .build()
@@ -5600,13 +5600,13 @@ async fn test_double_layer_with_read_only_region_delete(
 
     create_project_and_pool(client).await;
 
-    let disk = create_disk(&client, PROJECT_NAME, "disk").await;
+    let disk = create_disk(client, PROJECT_NAME, "disk").await;
 
     let snapshot =
-        create_snapshot(&client, PROJECT_NAME, "disk", "snapshot").await;
+        create_snapshot(client, PROJECT_NAME, "disk", "snapshot").await;
 
     let _disk_from_snapshot = create_disk_from_snapshot(
-        &client,
+        client,
         PROJECT_NAME,
         "disk-from-snapshot",
         snapshot.identity.id,
@@ -5614,7 +5614,7 @@ async fn test_double_layer_with_read_only_region_delete(
     .await;
 
     let _another_disk_from_snapshot = create_disk_from_snapshot(
-        &client,
+        client,
         PROJECT_NAME,
         "another-disk-from-snapshot",
         snapshot.identity.id,
@@ -5624,7 +5624,7 @@ async fn test_double_layer_with_read_only_region_delete(
     // Perform region snapshot replacement for one of the snapshot's targets,
     // causing a read-only region to be created.
 
-    let (.., db_disk) = LookupPath::new(&opctx, &datastore)
+    let (.., db_disk) = LookupPath::new(&opctx, datastore)
         .disk_id(disk.identity.id)
         .fetch()
         .await
@@ -5648,7 +5648,7 @@ async fn test_double_layer_with_read_only_region_delete(
         .await
         .unwrap();
 
-    wait_for_all_replacements(datastore, &internal_client).await;
+    wait_for_all_replacements(datastore, internal_client).await;
 
     assert!(!disk_test.crucible_resources_deleted().await);
 
@@ -5717,7 +5717,7 @@ async fn test_double_layer_snapshot_with_read_only_region_delete_2(
 
     // Create one zpool on each of the four sleds. This is required for region
     // replacement or region snapshot replacement
-    let disk_test = DiskTestBuilder::new(&cptestctx)
+    let disk_test = DiskTestBuilder::new(cptestctx)
         .on_all_sleds()
         .with_zpool_count(1)
         .build()
@@ -5725,15 +5725,15 @@ async fn test_double_layer_snapshot_with_read_only_region_delete_2(
 
     create_project_and_pool(client).await;
 
-    let disk = create_disk(&client, PROJECT_NAME, "disk").await;
+    let disk = create_disk(client, PROJECT_NAME, "disk").await;
 
     let snapshot =
-        create_snapshot(&client, PROJECT_NAME, "disk", "snapshot").await;
+        create_snapshot(client, PROJECT_NAME, "disk", "snapshot").await;
 
     // Perform region snapshot replacement for two of the snapshot's targets,
     // causing two read-only regions to be created.
 
-    let (.., db_disk) = LookupPath::new(&opctx, &datastore)
+    let (.., db_disk) = LookupPath::new(&opctx, datastore)
         .disk_id(disk.identity.id)
         .fetch()
         .await
@@ -5759,7 +5759,7 @@ async fn test_double_layer_snapshot_with_read_only_region_delete_2(
         .await
         .unwrap();
 
-    wait_for_all_replacements(datastore, &internal_client).await;
+    wait_for_all_replacements(datastore, internal_client).await;
 
     wait_for_condition(
         || {
@@ -5805,14 +5805,14 @@ async fn test_double_layer_snapshot_with_read_only_region_delete_2(
         .await
         .unwrap();
 
-    wait_for_all_replacements(datastore, &internal_client).await;
+    wait_for_all_replacements(datastore, internal_client).await;
 
     assert!(!disk_test.crucible_resources_deleted().await);
 
     // Create a disk from the snapshot
 
     let _disk_from_snapshot = create_disk_from_snapshot(
-        &client,
+        client,
         PROJECT_NAME,
         "disk-from-snapshot",
         snapshot.identity.id,
@@ -5834,7 +5834,7 @@ async fn test_double_layer_snapshot_with_read_only_region_delete_2(
         .await
         .unwrap();
 
-    wait_for_all_replacements(datastore, &internal_client).await;
+    wait_for_all_replacements(datastore, internal_client).await;
 
     assert!(!disk_test.crucible_resources_deleted().await);
 
@@ -5892,7 +5892,7 @@ async fn test_no_zombie_region_snapshots(cptestctx: &ControlPlaneTestContext) {
 
     // Create one zpool on each of the 4 sleds. This is required for region
     // replacement or region snapshot replacement
-    DiskTestBuilder::new(&cptestctx)
+    DiskTestBuilder::new(cptestctx)
         .on_all_sleds()
         .with_zpool_count(1)
         .build()
@@ -5902,10 +5902,10 @@ async fn test_no_zombie_region_snapshots(cptestctx: &ControlPlaneTestContext) {
 
     // Create disk, then a snapshot
 
-    let _disk = create_disk(&client, PROJECT_NAME, "disk").await;
+    let _disk = create_disk(client, PROJECT_NAME, "disk").await;
 
     let snapshot =
-        create_snapshot(&client, PROJECT_NAME, "disk", "snapshot").await;
+        create_snapshot(client, PROJECT_NAME, "disk", "snapshot").await;
 
     // Delete the disk
 
@@ -5917,7 +5917,7 @@ async fn test_no_zombie_region_snapshots(cptestctx: &ControlPlaneTestContext) {
 
     // Create a volume that uses the snapshot volume as a read-only parent
 
-    let (.., db_snapshot) = LookupPath::new(&opctx, &datastore)
+    let (.., db_snapshot) = LookupPath::new(&opctx, datastore)
         .snapshot_id(snapshot.identity.id)
         .fetch()
         .await
@@ -6008,7 +6008,7 @@ async fn test_no_zombie_read_only_regions(cptestctx: &ControlPlaneTestContext) {
 
     // Create one zpool on each of the 4 sleds. This is required for region
     // replacement or region snapshot replacement
-    DiskTestBuilder::new(&cptestctx)
+    DiskTestBuilder::new(cptestctx)
         .on_all_sleds()
         .with_zpool_count(1)
         .build()
@@ -6193,7 +6193,7 @@ async fn test_no_zombie_read_write_regions(
 
     // Create one zpool on each of the 4 sleds. This is required for region
     // replacement or region snapshot replacement
-    DiskTestBuilder::new(&cptestctx)
+    DiskTestBuilder::new(cptestctx)
         .on_all_sleds()
         .with_zpool_count(1)
         .build()
@@ -6369,7 +6369,7 @@ async fn test_proper_region_sled_redundancy(
 
     let conn = datastore.pool_connection_for_tests().await.unwrap();
 
-    DiskTestBuilder::new(&cptestctx)
+    DiskTestBuilder::new(cptestctx)
         .on_all_sleds()
         .with_zpool_count(10)
         .build()
@@ -6380,7 +6380,7 @@ async fn test_proper_region_sled_redundancy(
 
     let client = &cptestctx.external_client;
     let sleds_url = "/v1/system/hardware/sleds";
-    let sleds_found = sleds_list(&client, &sleds_url).await;
+    let sleds_found = sleds_list(client, sleds_url).await;
     assert_eq!(sleds_found.len(), 4);
     for sled in sleds_found {
         assert_eq!(sled.state, views::SledState::Active);

--- a/nexus/tests/integration_tests/vpc_firewall.rs
+++ b/nexus/tests/integration_tests/vpc_firewall.rs
@@ -29,7 +29,7 @@ async fn test_vpc_firewall(cptestctx: &ControlPlaneTestContext) {
 
     // Create a project that we'll use for testing.
     let project_name = "springfield-squidport";
-    create_project(&client, &project_name).await;
+    create_project(client, project_name).await;
 
     let project_selector = format!("project={}", project_name);
     // Each project has a default VPC. Make sure it has the default rules.
@@ -55,7 +55,7 @@ async fn test_vpc_firewall(cptestctx: &ControlPlaneTestContext) {
     let other_vpc_selector = format!("{}&vpc={}", project_selector, other_vpc);
     let other_vpc_firewall =
         format!("/v1/vpc-firewall-rules?{}", other_vpc_selector);
-    let vpc2 = create_vpc(&client, &project_name, &other_vpc).await;
+    let vpc2 = create_vpc(client, project_name, other_vpc).await;
     let rules =
         object_get::<VpcFirewallRules>(client, &other_vpc_firewall).await.rules;
     assert!(rules.iter().all(|r| r.vpc_id == vpc2.identity.id));
@@ -292,7 +292,7 @@ async fn test_firewall_rules_same_name(cptestctx: &ControlPlaneTestContext) {
     let client = &cptestctx.external_client;
 
     let project_name = "my-project";
-    create_project(&client, &project_name).await;
+    create_project(client, project_name).await;
 
     let rule = VpcFirewallRuleUpdate {
         name: "dupe".parse().unwrap(),
@@ -330,7 +330,7 @@ async fn test_firewall_rules_max_lengths(cptestctx: &ControlPlaneTestContext) {
     let client = &cptestctx.external_client;
 
     let project_name = "my-project";
-    create_project(&client, &project_name).await;
+    create_project(client, project_name).await;
 
     let base_rule = VpcFirewallRuleUpdate {
         name: "my-rule".parse().unwrap(),

--- a/nexus/tests/integration_tests/vpcs.rs
+++ b/nexus/tests/integration_tests/vpcs.rs
@@ -42,11 +42,11 @@ async fn test_vpcs(cptestctx: &ControlPlaneTestContext) {
 
     // Create a project that we'll use for testing.
     let vpcs_url = format!("/v1/vpcs?project={}", PROJECT_NAME);
-    let _ = create_project(&client, &PROJECT_NAME).await;
-    let _ = create_project(&client, &PROJECT_NAME_2).await;
+    let _ = create_project(client, PROJECT_NAME).await;
+    let _ = create_project(client, PROJECT_NAME_2).await;
 
     // List vpcs.  We see the default VPC, and nothing else.
-    let mut vpcs = vpcs_list(&client, &vpcs_url).await;
+    let mut vpcs = vpcs_list(client, &vpcs_url).await;
     assert_eq!(vpcs.len(), 1);
     assert_eq!(vpcs[0].identity.name, "default");
     assert_eq!(vpcs[0].dns_name, "default");
@@ -95,7 +95,7 @@ async fn test_vpcs(cptestctx: &ControlPlaneTestContext) {
 
     // Create a VPC.
     let vpc_name = "just-rainsticks";
-    let vpc = create_vpc(&client, PROJECT_NAME, vpc_name).await;
+    let vpc = create_vpc(client, PROJECT_NAME, vpc_name).await;
     assert_eq!(vpc.identity.name, "just-rainsticks");
     assert_eq!(vpc.identity.description, "vpc description");
     assert_eq!(vpc.dns_name, "abc");
@@ -111,7 +111,7 @@ async fn test_vpcs(cptestctx: &ControlPlaneTestContext) {
 
     // Attempt to create a second VPC with a conflicting name.
     let error = create_vpc_with_error(
-        &client,
+        client,
         PROJECT_NAME,
         vpc_name,
         StatusCode::BAD_REQUEST,
@@ -120,17 +120,17 @@ async fn test_vpcs(cptestctx: &ControlPlaneTestContext) {
     assert_eq!(error.message, "already exists: vpc \"just-rainsticks\"");
 
     // creating a VPC with the same name in another project works, though
-    let vpc2: Vpc = create_vpc(&client, PROJECT_NAME_2, vpc_name).await;
+    let vpc2: Vpc = create_vpc(client, PROJECT_NAME_2, vpc_name).await;
     assert_eq!(vpc2.identity.name, "just-rainsticks");
 
     // List VPCs again and expect to find the one we just created.
-    let vpcs = vpcs_list(&client, &vpcs_url).await;
+    let vpcs = vpcs_list(client, &vpcs_url).await;
     assert_eq!(vpcs.len(), 2);
     vpcs_eq(&vpcs[0], &default_vpc);
     vpcs_eq(&vpcs[1], &vpc);
 
     // Fetch the VPC and expect it to match.
-    let vpc = vpc_get(&client, &vpc_url).await;
+    let vpc = vpc_get(client, &vpc_url).await;
     vpcs_eq(&vpcs[1], &vpc);
 
     // Update the VPC
@@ -141,7 +141,7 @@ async fn test_vpcs(cptestctx: &ControlPlaneTestContext) {
         },
         dns_name: Some("def".parse().unwrap()),
     };
-    let updated_vpc = vpc_put(&client, &vpc_url, update_params).await;
+    let updated_vpc = vpc_put(client, &vpc_url, update_params).await;
     assert_eq!(updated_vpc.identity.name, "new-name");
     assert_eq!(updated_vpc.identity.description, "another description");
     assert_eq!(updated_vpc.dns_name, "def");
@@ -165,7 +165,7 @@ async fn test_vpcs(cptestctx: &ControlPlaneTestContext) {
     let vpc_url = get_vpc_url("new-name");
 
     // Fetch the VPC again. It should have the updated properties.
-    let vpc = vpc_get(&client, &vpc_url).await;
+    let vpc = vpc_get(client, &vpc_url).await;
     assert_eq!(vpc.identity.name, "new-name");
     assert_eq!(vpc.identity.description, "another description");
     assert_eq!(vpc.dns_name, "def");
@@ -214,7 +214,7 @@ async fn test_vpcs(cptestctx: &ControlPlaneTestContext) {
     assert_eq!(error.message, "not found: vpc with name \"new-name\"");
 
     // And the list should be empty (aside from default VPC) again
-    let vpcs = vpcs_list(&client, &vpcs_url).await;
+    let vpcs = vpcs_list(client, &vpcs_url).await;
     assert_eq!(vpcs.len(), 1);
     vpcs_eq(&vpcs[0], &default_vpc);
 }

--- a/nexus/types/src/deployment/blueprint_diff.rs
+++ b/nexus/types/src/deployment/blueprint_diff.rs
@@ -1089,11 +1089,11 @@ impl BpTableData for BpDiffDatasetsModified {
                         dataset.dataset.disposition.to_string(),
                     ),
                     BpTableColumn::new(
-                        unwrap_or_none(&before_quota),
+                        unwrap_or_none(before_quota),
                         unwrap_or_none(&dataset.dataset.quota),
                     ),
                     BpTableColumn::new(
-                        unwrap_or_none(&before_reservation),
+                        unwrap_or_none(before_reservation),
                         unwrap_or_none(&dataset.dataset.reservation),
                     ),
                     BpTableColumn::new(

--- a/nexus/types/src/deployment/execution/dns.rs
+++ b/nexus/types/src/deployment/execution/dns.rs
@@ -183,7 +183,7 @@ pub fn blueprint_external_dns_config<'a>(
         // abstraction, such as it is, would be leakier).
         .filter_map(|silo_name| {
             (silo_name != default_silo_name())
-                .then(|| (silo_dns_name(&silo_name), dns_records.clone()))
+                .then(|| (silo_dns_name(silo_name), dns_records.clone()))
         })
         .collect::<HashMap<String, Vec<DnsRecord>>>();
 

--- a/nexus/types/src/deployment/planning_input.rs
+++ b/nexus/types/src/deployment/planning_input.rs
@@ -1065,7 +1065,7 @@ impl PlanningInputBuilder {
     ) -> Result<(), PlanningInputBuildError> {
         let sled_details = self
             .sleds_mut()
-            .get_mut(&sled_id)
+            .get_mut(sled_id)
             .ok_or(PlanningInputBuildError::SledNotFound(*sled_id))?;
         sled_details.policy = SledPolicy::Expunged;
         for (_, sled_disk) in sled_details.resources.zpools.iter_mut() {

--- a/nexus/types/src/external_api/params.rs
+++ b/nexus/types/src/external_api/params.rs
@@ -767,7 +767,7 @@ fn sign_junk_data(key_pair: &DerEncodedKeyPair) -> Result<(), anyhow::Error> {
 
     let mut signer = openssl::sign::Signer::new(
         openssl::hash::MessageDigest::sha256(),
-        &private_key.as_ref(),
+        private_key.as_ref(),
     )?;
 
     let some_junk_data = b"this is some junk data";
@@ -798,7 +798,7 @@ where
     let v = Option::<DerEncodedKeyPair>::deserialize(deserializer)?;
 
     if let Some(ref key_pair) = v {
-        if let Err(e) = sign_junk_data(&key_pair) {
+        if let Err(e) = sign_junk_data(key_pair) {
             return Err(de::Error::custom(format!(
                 "data signed with key not verified with certificate! {}",
                 e

--- a/oximeter/collector/src/agent.rs
+++ b/oximeter/collector/src/agent.rs
@@ -570,7 +570,7 @@ async fn refresh_producer_list_once(
     agent: &OximeterAgent,
     nexus_pool: &Pool<NexusClient>,
 ) {
-    let client = claim_nexus_with_backoff(&agent.log, &nexus_pool).await;
+    let client = claim_nexus_with_backoff(&agent.log, nexus_pool).await;
     let mut stream = client.cpapi_assigned_producers_list_stream(
         &agent.id,
         // This is a _total_ limit, not a page size, so `None` means "get

--- a/oximeter/collector/src/lib.rs
+++ b/oximeter/collector/src/lib.rs
@@ -407,7 +407,7 @@ impl Oximeter {
                 args.address,
                 crate::default_refresh_interval(),
                 db_config,
-                &log,
+                log,
             )
             .await?,
         );

--- a/oximeter/db/src/bin/oxdb/main.rs
+++ b/oximeter/db/src/bin/oxdb/main.rs
@@ -206,7 +206,7 @@ async fn insert_samples(
     );
     if !dry_run {
         client
-            .insert_samples(&samples)
+            .insert_samples(samples)
             .await
             .context("Failed to insert samples")?;
     }

--- a/oximeter/db/src/client/dbwrite.rs
+++ b/oximeter/db/src/client/dbwrite.rs
@@ -331,7 +331,7 @@ impl Client {
             // internal cache. Since we check the internal cache first for
             // schema, if we fail here but _don't_ remove the schema, we'll
             // never end up inserting the schema, but we will insert samples.
-            if let Err(e) = self.insert_native(handle, &body, block).await {
+            if let Err(e) = self.insert_native(handle, body, block).await {
                 debug!(
                     self.log,
                     "failed to insert new schema, removing from cache";

--- a/oximeter/db/src/client/mod.rs
+++ b/oximeter/db/src/client/mod.rs
@@ -578,7 +578,7 @@ impl Client {
     ) -> Result<(), Error> {
         let re = schema_validation_regex();
         for (path, sql) in files.values() {
-            if re.is_match(&sql) {
+            if re.is_match(sql) {
                 return Err(Error::SchemaUpdateModifiesData {
                     path: path.clone(),
                     statement: sql.clone(),
@@ -1811,7 +1811,7 @@ mod tests {
         let logctx = test_setup_log("cannot_ping_nonexistent_server");
         let log = &logctx.log;
         let bad_addr = "[::1]:80".parse().unwrap();
-        let client = Client::new(bad_addr, &log);
+        let client = Client::new(bad_addr, log);
         let e = client
             .ping()
             .await
@@ -3442,7 +3442,7 @@ mod tests {
             {}",
                     maybe_filter
                         .map(|f| format!("WHERE {f}"))
-                        .unwrap_or_else(String::new)
+                        .unwrap_or_default()
                 ),
             )
             .await
@@ -3733,7 +3733,7 @@ mod tests {
 
         // Next, we'll kill the database, and then try to insert the schema.
         // That will fail, since the DB is now inaccessible.
-        wipe_db(&db, &client).await;
+        wipe_db(db, &client).await;
         let res =
             client.save_new_schema_or_remove(&mut handle, new_schema).await;
         assert!(res.is_err(), "Should have failed since the DB is gone");
@@ -3928,7 +3928,7 @@ mod tests {
             "test_apply_one_schema_upgrade_{}",
             if replicated { "replicated" } else { "single_node" }
         );
-        let client = Client::new(address, &log);
+        let client = Client::new(address, log);
 
         // We'll test moving from version 1, which just creates a database and
         // table, to version 2, which adds two columns to that table in
@@ -4066,7 +4066,7 @@ mod tests {
         let mut db = ClickHouseDeployment::new_single_node(&logctx)
             .await
             .expect("Failed to start ClickHouse");
-        let client = Client::new(db.native_address().into(), &log);
+        let client = Client::new(db.native_address().into(), log);
         const REPLICATED: bool = false;
         client
             .initialize_db_with_version(
@@ -4108,7 +4108,7 @@ mod tests {
         let mut db = ClickHouseDeployment::new_single_node(&logctx)
             .await
             .expect("Failed to start ClickHouse");
-        let client = Client::new(db.native_address().into(), &log);
+        let client = Client::new(db.native_address().into(), log);
         const REPLICATED: bool = false;
         client
             .initialize_db_with_version(
@@ -4149,7 +4149,7 @@ mod tests {
             "test_ensure_schema_walks_through_multiple_steps_{}",
             if replicated { "replicated" } else { "single_node" }
         );
-        let client = Client::new(address, &log);
+        let client = Client::new(address, log);
 
         // We need to actually have the oximeter DB here, and the version table,
         // since `ensure_schema()` writes out versions to the DB as they're
@@ -4364,7 +4364,7 @@ mod tests {
         let mut db = ClickHouseDeployment::new_single_node(&logctx)
             .await
             .expect("Failed to start ClickHouse");
-        let client = Client::new(db.native_address().into(), &log);
+        let client = Client::new(db.native_address().into(), log);
         client
             .init_single_node_db()
             .await
@@ -4389,7 +4389,7 @@ mod tests {
         let mut db = ClickHouseDeployment::new_single_node(&logctx)
             .await
             .expect("Failed to start ClickHouse");
-        let client = Client::new(db.native_address().into(), &log);
+        let client = Client::new(db.native_address().into(), log);
         client
             .initialize_db_with_version(false, OXIMETER_VERSION)
             .await
@@ -4538,7 +4538,7 @@ mod tests {
                 .await
                 .expect("Failed to start ClickHouse")
         };
-        let client = Client::new(db.native_address().into(), &log);
+        let client = Client::new(db.native_address().into(), log);
 
         // Let's start with version 2, which is the first tracked and contains
         // the full SQL files we need to populate the DB.
@@ -4758,7 +4758,7 @@ mod tests {
         address: SocketAddr,
         replicated: bool,
     ) {
-        let client = Client::new(address, &log);
+        let client = Client::new(address, log);
 
         const STARTING_VERSION: u64 = 1;
         const NEXT_VERSION: u64 = 2;

--- a/oximeter/db/src/client/oxql.rs
+++ b/oximeter/db/src/client/oxql.rs
@@ -1371,7 +1371,7 @@ mod tests {
                 "failed to create expected points from inserted measurements",
             );
             let expected_timeseries =
-                find_timeseries_in_table(&table, target, foo)
+                find_timeseries_in_table(table, target, foo)
                     .expect("Table did not contain an expected timeseries");
             assert_eq!(
                 expected_timeseries.points, expected_points,
@@ -1418,7 +1418,7 @@ mod tests {
         );
 
         let expected_timeseries =
-            find_timeseries_in_table(&table, expected_target, expected_foo)
+            find_timeseries_in_table(table, expected_target, expected_foo)
                 .expect("Table did not contain expected timeseries");
         let measurements: Vec<_> =
             expected_samples.iter().map(|s| s.measurement.clone()).collect();
@@ -1706,7 +1706,7 @@ mod tests {
         );
 
         let expected_timeseries =
-            find_timeseries_in_table(&table, expected_target, expected_foo)
+            find_timeseries_in_table(table, expected_target, expected_foo)
                 .expect("Table did not contain expected timeseries");
         let measurements: Vec<_> = expected_samples
             .iter()

--- a/oximeter/db/src/lib.rs
+++ b/oximeter/db/src/lib.rs
@@ -236,7 +236,7 @@ pub async fn make_client(
     port: u16,
     log: &Logger,
 ) -> Result<Client, anyhow::Error> {
-    let client = Client::new(SocketAddr::new(address, port), &log);
+    let client = Client::new(SocketAddr::new(address, port), log);
     // TODO https://github.com/oxidecomputer/omicron/issues/7488: There is a db being initialised here as well.
     client
         .init_single_node_db()

--- a/oximeter/db/src/native/io/block.rs
+++ b/oximeter/db/src/native/io/block.rs
@@ -33,7 +33,7 @@ pub fn encode(block: Block, mut dst: &mut BytesMut) -> Result<(), Error> {
         &mut dst,
     );
     for (name, col) in block.columns {
-        io::column::encode(&name, col, &mut dst)?;
+        io::column::encode(&name, col, dst)?;
     }
     Ok(())
 }

--- a/oximeter/db/src/native/io/packet/client.rs
+++ b/oximeter/db/src/native/io/packet/client.rs
@@ -51,8 +51,8 @@ impl Encoder {
     fn encode_query(&self, query: Query, mut dst: &mut BytesMut) {
         dst.put_u8(Packet::QUERY);
         io::string::encode(query.id, &mut dst);
-        self.encode_client_info(query.client_info, &mut dst);
-        self.encode_settings(query.settings, &mut dst);
+        self.encode_client_info(query.client_info, dst);
+        self.encode_settings(query.settings, dst);
         io::string::encode(query.secret, &mut dst);
         let stage = match query.stage {
             Stage::FetchColumns => 0,
@@ -67,7 +67,7 @@ impl Encoder {
         io::string::encode("", &mut dst);
 
         // Send an empty block to signal the end of data transfer.
-        self.encode_block(Block::empty(), &mut dst).unwrap();
+        self.encode_block(Block::empty(), dst).unwrap();
     }
 
     /// Encode a ClientInfo into the buffer.

--- a/oximeter/db/src/native/io/table_columns.rs
+++ b/oximeter/db/src/native/io/table_columns.rs
@@ -203,7 +203,7 @@ mod tests {
 `timeseries_name` String
 `fields.name` Array(String)
 "#;
-        let columns = column_descriptions(&mut &*INPUT)
+        let columns = column_descriptions(INPUT)
             .expect("failed to decode column descriptions")
             .expect("expected Some(_) column description");
         assert_eq!(columns.len(), 2);
@@ -219,7 +219,7 @@ mod tests {
     #[test]
     fn test_column_description_with_default() {
         static INPUT: &str = "`timeseries_name` String\tDEFAULT \"foo\"";
-        let column = column_description(&mut &*INPUT)
+        let column = column_description(INPUT)
             .expect("failed to decode column description")
             .1;
         assert_eq!(column.name, "timeseries_name");

--- a/oximeter/db/src/oxql/ast/table_ops/align.rs
+++ b/oximeter/db/src/oxql/ast/table_ops/align.rs
@@ -160,7 +160,7 @@ fn align_mean_within(
             "Alignment by mean requires a gauge or delta metric, not {}",
             metric_type,
         );
-        verify_max_upsampling_ratio(points.timestamps(), &period)?;
+        verify_max_upsampling_ratio(points.timestamps(), period)?;
 
         // Always convert the output to doubles, when computing the mean. The
         // output is always a gauge, so we do not need the start times of the

--- a/oximeter/db/src/oxql/ast/table_ops/filter/mod.rs
+++ b/oximeter/db/src/oxql/ast/table_ops/filter/mod.rs
@@ -91,7 +91,7 @@ impl Filter {
     {
         match &self.expr {
             FilterExpr::Simple(simple) => {
-                visitor.visit_simple(self.negated, &simple)
+                visitor.visit_simple(self.negated, simple)
             }
             FilterExpr::Compound(compound) => {
                 let left = compound.left.visit_fields(visitor)?;

--- a/oximeter/db/src/oxql/plan/filter.rs
+++ b/oximeter/db/src/oxql/plan/filter.rs
@@ -140,12 +140,12 @@ impl Filter {
             filter::FilterExpr::Compound(compound) => {
                 Self::ensure_filter_expr_application_is_valid_impl(
                     &compound.left.expr,
-                    &schema,
+                    schema,
                     errors,
                 );
                 Self::ensure_filter_expr_application_is_valid_impl(
                     &compound.right.expr,
-                    &schema,
+                    schema,
                     errors,
                 );
             }

--- a/oximeter/db/src/oxql/plan/plan.rs
+++ b/oximeter/db/src/oxql/plan/plan.rs
@@ -218,7 +218,7 @@ impl Plan {
     ) -> anyhow::Result<Self> {
         let start = Instant::now();
         let mut nodes = Vec::with_capacity(query.table_ops().len());
-        Self::plan_query(&query, &schema, &mut nodes)?;
+        Self::plan_query(&query, schema, &mut nodes)?;
         let optimized = Self::optimize_plan(&nodes)?;
         let duration = start.elapsed();
         if let OptimizedPlan::Optimized(optimized_plan) = &optimized {
@@ -304,10 +304,10 @@ impl Plan {
         for table_op in query.table_ops() {
             match table_op {
                 TableOp::Basic(basic) => {
-                    Self::plan_basic_table_op(&schema, basic, nodes)?
+                    Self::plan_basic_table_op(schema, basic, nodes)?
                 }
                 TableOp::Grouped(grouped) => {
-                    Self::plan_subquery(&schema, grouped, nodes)?
+                    Self::plan_subquery(schema, grouped, nodes)?
                 }
             }
         }
@@ -921,7 +921,7 @@ pub(super) mod test_utils {
             .lines()
             .map(|line| {
                 let schema: DbTimeseriesSchema =
-                    serde_json::from_str(&line).unwrap();
+                    serde_json::from_str(line).unwrap();
                 (
                     TimeseriesName::try_from(schema.timeseries_name.as_str())
                         .unwrap(),
@@ -955,7 +955,7 @@ mod tests {
         let query =
             query_parser::query(&format!("get {TIMESERIES_NAME}")).unwrap();
         let all_schema = all_schema().await;
-        let plan = Plan::new(query, &all_schema).unwrap();
+        let plan = Plan::new(query, all_schema).unwrap();
 
         assert_eq!(
             plan.nodes.len(),
@@ -990,7 +990,7 @@ mod tests {
         let query =
             query_parser::query(&format!("get {TIMESERIES_NAME}")).unwrap();
         let all_schema = all_schema().await;
-        let plan = Plan::new(query, &all_schema).unwrap();
+        let plan = Plan::new(query, all_schema).unwrap();
 
         assert_eq!(
             plan.nodes.len(),

--- a/oximeter/db/src/oxql/plan/predicates.rs
+++ b/oximeter/db/src/oxql/plan/predicates.rs
@@ -468,7 +468,7 @@ mod tests {
         let filter = query_parser::filter("filter link_name == 'foo'").unwrap();
         let predicates = Predicates::Single(filter.clone());
         let SplitPredicates { pushed, not_pushed } =
-            predicates.split_around_align(&align).unwrap();
+            predicates.split_around_align(align).unwrap();
         let Predicates::Single(single) = pushed.as_ref().unwrap() else {
             panic!("Expected Predicates::Single, found {:?}", pushed);
         };
@@ -497,7 +497,7 @@ mod tests {
                 .unwrap();
         let predicates = Predicates::Single(filter.clone());
         let SplitPredicates { pushed, not_pushed } =
-            predicates.split_around_align(&align).unwrap();
+            predicates.split_around_align(align).unwrap();
         let Predicates::Single(single) = pushed.as_ref().unwrap() else {
             panic!("Expected Predicates::Single, found {:?}", pushed);
         };
@@ -533,7 +533,7 @@ mod tests {
         let filter = query_parser::filter("filter datum > 100.0").unwrap();
         let predicates = Predicates::Single(filter.clone());
         let SplitPredicates { pushed, not_pushed } =
-            predicates.split_around_align(&align).unwrap();
+            predicates.split_around_align(align).unwrap();
         assert!(
             pushed.is_none(),
             "Should have pushed nothing through alignment"
@@ -566,7 +566,7 @@ mod tests {
                 .unwrap();
         let predicates = Predicates::Single(filter.clone());
         let SplitPredicates { pushed, not_pushed } =
-            predicates.split_around_align(&align).unwrap();
+            predicates.split_around_align(align).unwrap();
         let Predicates::Disjunctions(list) = pushed.as_ref().unwrap() else {
             panic!("Expected Predicates::Disjunctions, found {:?}", pushed);
         };
@@ -614,7 +614,7 @@ mod tests {
                 .unwrap();
         let predicates = Predicates::Single(filter.clone());
         let SplitPredicates { pushed, not_pushed } =
-            predicates.split_around_align(&align).unwrap();
+            predicates.split_around_align(align).unwrap();
         let Predicates::Disjunctions(list) = pushed.as_ref().unwrap() else {
             panic!("Expected Predicates::Disjunctions, found {:?}", pushed);
         };

--- a/oximeter/db/src/oxql/query/mod.rs
+++ b/oximeter/db/src/oxql/query/mod.rs
@@ -274,7 +274,7 @@ impl Query {
                     BasicTableOp::Filter(filter) => {
                         // Merge with any existing filter.
                         if let Some(left) = maybe_filter {
-                            Some(left.merge(&filter, LogicalOp::And))
+                            Some(left.merge(filter, LogicalOp::And))
                         } else {
                             Some(filter.clone())
                         }

--- a/oximeter/db/src/query.rs
+++ b/oximeter/db/src/query.rs
@@ -165,48 +165,46 @@ impl SelectQueryBuilder {
         }
         let field_value = match field_type {
             FieldType::String => FieldValue::from(&selector.value),
-            FieldType::I8 => parse_selector_field_value::<i8>(
-                &field_schema,
-                &selector.value,
-            )?,
-            FieldType::U8 => parse_selector_field_value::<u8>(
-                &field_schema,
-                &selector.value,
-            )?,
+            FieldType::I8 => {
+                parse_selector_field_value::<i8>(field_schema, &selector.value)?
+            }
+            FieldType::U8 => {
+                parse_selector_field_value::<u8>(field_schema, &selector.value)?
+            }
             FieldType::I16 => parse_selector_field_value::<i16>(
-                &field_schema,
+                field_schema,
                 &selector.value,
             )?,
             FieldType::U16 => parse_selector_field_value::<u16>(
-                &field_schema,
+                field_schema,
                 &selector.value,
             )?,
             FieldType::I32 => parse_selector_field_value::<i32>(
-                &field_schema,
+                field_schema,
                 &selector.value,
             )?,
             FieldType::U32 => parse_selector_field_value::<u32>(
-                &field_schema,
+                field_schema,
                 &selector.value,
             )?,
             FieldType::I64 => parse_selector_field_value::<i64>(
-                &field_schema,
+                field_schema,
                 &selector.value,
             )?,
             FieldType::U64 => parse_selector_field_value::<u64>(
-                &field_schema,
+                field_schema,
                 &selector.value,
             )?,
             FieldType::IpAddr => parse_selector_field_value::<IpAddr>(
-                &field_schema,
+                field_schema,
                 &selector.value,
             )?,
             FieldType::Uuid => parse_selector_field_value::<Uuid>(
-                &field_schema,
+                field_schema,
                 &selector.value,
             )?,
             FieldType::Bool => parse_selector_field_value::<bool>(
-                &field_schema,
+                field_schema,
                 &selector.value,
             )?,
         };
@@ -657,7 +655,7 @@ impl SelectQuery {
                             &format!(
                                 "INNER JOIN ({subquery}) AS filter{i} ON ({join_on}) ",
                                 subquery = subquery,
-                                join_on = create_join_on_condition(&JOIN_COLUMNS, i),
+                                join_on = create_join_on_condition(JOIN_COLUMNS, i),
                                 i = i,
                         ));
                     }

--- a/oximeter/db/src/shells/sql.rs
+++ b/oximeter/db/src/shells/sql.rs
@@ -244,7 +244,7 @@ fn print_sql_query(query: &str) {
     println!(
         "{}",
         sqlformat::format(
-            &query,
+            query,
             &sqlformat::QueryParams::None,
             sqlformat::FormatOptions { uppercase: true, ..Default::default() }
         )

--- a/oximeter/db/src/sql/mod.rs
+++ b/oximeter/db/src/sql/mod.rs
@@ -226,7 +226,7 @@ impl RestrictedQuery {
     /// Construct a new restricted query.
     pub fn new(sql: impl AsRef<str>) -> Result<Self, OxdbError> {
         let safe_sql = SafeSql::new(sql);
-        let statements = Parser::parse_sql(&OxdbDialect, &safe_sql.safe_sql())
+        let statements = Parser::parse_sql(&OxdbDialect, safe_sql.safe_sql())
             .map_err(Error::from)?;
         if statements.len() != 1 {
             return unsupported!("Only a single SQL statement is supported");
@@ -267,7 +267,7 @@ impl RestrictedQuery {
         &self,
         timeseries_schema: &BTreeMap<TimeseriesName, TimeseriesSchema>,
     ) -> Result<String, OxdbError> {
-        self.generate_timeseries_ctes(&timeseries_schema).map(|cte_tables| {
+        self.generate_timeseries_ctes(timeseries_schema).map(|cte_tables| {
             if cte_tables.is_empty() {
                 // The query didn't reference any timeseries at all, let's just
                 // return it

--- a/oximeter/db/tests/integration_test.rs
+++ b/oximeter/db/tests/integration_test.rs
@@ -224,7 +224,7 @@ async fn test_cluster() -> anyhow::Result<()> {
     assert_input_and_output(&input, &samples, &oxql_res1);
 
     let start = tokio::time::Instant::now();
-    wait_for_num_points(&log, &client2, samples.len())
+    wait_for_num_points(log, &client2, samples.len())
         .await
         .expect("failed to get samples from client2");
     info!(log, "query samples from client2 time = {:?}", start.elapsed());
@@ -249,7 +249,7 @@ async fn test_cluster() -> anyhow::Result<()> {
 
     // Wait for all the data to be copied to node 3
     let start = tokio::time::Instant::now();
-    wait_for_num_points(&log, &client3, samples.len())
+    wait_for_num_points(log, &client3, samples.len())
         .await
         .expect("failed to get samples from client3");
     info!(log, "query samples from client3 time = {:?}", start.elapsed());
@@ -274,10 +274,10 @@ async fn test_cluster() -> anyhow::Result<()> {
         .expect("failed to insert samples at server3");
 
     // Ensure that both replica 3 and replica 2 have the samples
-    wait_for_num_points(&log, &client3, samples.len() * 2)
+    wait_for_num_points(log, &client3, samples.len() * 2)
         .await
         .expect("failed to get samples from client3");
-    wait_for_num_points(&log, &client2, samples.len() * 2)
+    wait_for_num_points(log, &client2, samples.len() * 2)
         .await
         .expect("failed to get samples from client2");
 
@@ -286,7 +286,7 @@ async fn test_cluster() -> anyhow::Result<()> {
         .start_server(1.into())
         .expect("failed to restart clickhouse server 1");
     wait_for_ping(log, &client1).await.expect("failed to ping server 1");
-    wait_for_num_points(&log, &client1, samples.len() * 2)
+    wait_for_num_points(log, &client1, samples.len() * 2)
         .await
         .expect("failed to get samples from client1");
 
@@ -294,7 +294,7 @@ async fn test_cluster() -> anyhow::Result<()> {
     deployment.remove_keeper(KeeperId(2)).expect("failed to remove keeper 2");
 
     // Querying from any node should still work after a keeper is removed
-    wait_for_num_points(&log, &client1, samples.len() * 2)
+    wait_for_num_points(log, &client1, samples.len() * 2)
         .await
         .expect("failed to get samples from client1");
 
@@ -310,7 +310,7 @@ async fn test_cluster() -> anyhow::Result<()> {
     wait_for_insert(log, &client3, &samples)
         .await
         .expect("failed to insert samples at server3");
-    wait_for_num_points(&log, &client2, samples.len() * 3)
+    wait_for_num_points(log, &client2, samples.len() * 3)
         .await
         .expect("failed to get samples from client2");
 
@@ -318,7 +318,7 @@ async fn test_cluster() -> anyhow::Result<()> {
     deployment.stop_keeper(1.into()).expect("failed to stop keeper 1");
 
     // We should still be able to query
-    wait_for_num_points(&log, &client3, samples.len() * 3)
+    wait_for_num_points(log, &client3, samples.len() * 3)
         .await
         .expect("failed to get samples from client1");
 
@@ -361,7 +361,7 @@ async fn test_cluster() -> anyhow::Result<()> {
     wait_for_insert(log, &client1, &samples)
         .await
         .expect("failed to insert samples at server1");
-    wait_for_num_points(&log, &client2, samples.len() * 4)
+    wait_for_num_points(log, &client2, samples.len() * 4)
         .await
         .expect("failed to get samples from client1");
 
@@ -383,7 +383,7 @@ async fn test_cluster() -> anyhow::Result<()> {
     wait_for_insert(log, &client1, &samples)
         .await
         .expect("failed to insert samples at server1");
-    wait_for_num_points(&log, &client2, samples.len() * 5)
+    wait_for_num_points(log, &client2, samples.len() * 5)
         .await
         .expect("failed to get samples from client1");
 
@@ -416,7 +416,7 @@ fn assert_input_and_output(
     assert_eq!(oxql_res.tables.len(), 1);
     let table = oxql_res.tables.first().unwrap();
     assert_eq!(table.n_timeseries(), input.n_timeseries());
-    assert_eq!(total_points(&oxql_res), samples.len());
+    assert_eq!(total_points(oxql_res), samples.len());
 }
 
 /// Wait for the number of `samples` inserted to equal the number of `points`
@@ -484,7 +484,7 @@ async fn wait_for_insert(
     poll::wait_for_condition(
         || async {
             client
-                .insert_samples(&samples)
+                .insert_samples(samples)
                 .await
                 .map_err(|_| poll::CondCheckError::<oximeter_db::Error>::NotYet)
         },

--- a/oximeter/oximeter-macro-impl/src/lib.rs
+++ b/oximeter/oximeter-macro-impl/src/lib.rs
@@ -50,7 +50,7 @@ fn target_impl(tokens: TokenStream) -> syn::Result<TokenStream> {
     if let Data::Struct(ref data) = item.data {
         let name = &item.ident;
         let fields = if let Fields::Named(ref data_fields) = data.fields {
-            extract_struct_fields(&data_fields, None)
+            extract_struct_fields(data_fields, None)
         } else if matches!(data.fields, Fields::Unit) {
             vec![]
         } else {
@@ -59,7 +59,7 @@ fn target_impl(tokens: TokenStream) -> syn::Result<TokenStream> {
                 "Can only be derived for structs with named fields or unit structs",
             ));
         };
-        return Ok(build_target_trait_impl(&name, &fields[..]));
+        return Ok(build_target_trait_impl(name, &fields[..]));
     }
     Err(Error::new(
         item.span(),
@@ -74,9 +74,9 @@ fn metric_impl(item: TokenStream) -> syn::Result<TokenStream> {
     let name = &item.ident;
     if let Fields::Named(ref data_fields) = item.fields {
         let ignore = datum_field.ident.as_ref().unwrap().to_string();
-        let fields = extract_struct_fields(&data_fields, Some(&ignore));
+        let fields = extract_struct_fields(data_fields, Some(&ignore));
         let metric_impl =
-            build_metric_trait_impl(name, &fields[..], &datum_field);
+            build_metric_trait_impl(name, &fields[..], datum_field);
         Ok(quote! {
             #metric_impl
         })

--- a/oximeter/oxql-types/src/point.rs
+++ b/oximeter/oxql-types/src/point.rs
@@ -1504,7 +1504,7 @@ impl ValueArray {
                     ) => {
                         let new = Distribution::from(new);
                         self.as_integer_distribution_mut()?
-                            .push(Some(new.checked_sub(&last)?));
+                            .push(Some(new.checked_sub(last)?));
                     }
                     (
                         CumulativeDatum::IntegerDistribution(last),
@@ -1512,7 +1512,7 @@ impl ValueArray {
                     ) => {
                         let new = Distribution::from(new);
                         self.as_integer_distribution_mut()?
-                            .push(Some(new.checked_sub(&last)?));
+                            .push(Some(new.checked_sub(last)?));
                     }
                     (
                         CumulativeDatum::IntegerDistribution(last),
@@ -1520,7 +1520,7 @@ impl ValueArray {
                     ) => {
                         let new = Distribution::from(new);
                         self.as_integer_distribution_mut()?
-                            .push(Some(new.checked_sub(&last)?));
+                            .push(Some(new.checked_sub(last)?));
                     }
                     (
                         CumulativeDatum::IntegerDistribution(last),
@@ -1528,7 +1528,7 @@ impl ValueArray {
                     ) => {
                         let new = Distribution::from(new);
                         self.as_integer_distribution_mut()?
-                            .push(Some(new.checked_sub(&last)?));
+                            .push(Some(new.checked_sub(last)?));
                     }
                     (
                         CumulativeDatum::IntegerDistribution(last),
@@ -1536,7 +1536,7 @@ impl ValueArray {
                     ) => {
                         let new = Distribution::from(new);
                         self.as_integer_distribution_mut()?
-                            .push(Some(new.checked_sub(&last)?));
+                            .push(Some(new.checked_sub(last)?));
                     }
                     (
                         CumulativeDatum::IntegerDistribution(last),
@@ -1544,7 +1544,7 @@ impl ValueArray {
                     ) => {
                         let new = Distribution::from(new);
                         self.as_integer_distribution_mut()?
-                            .push(Some(new.checked_sub(&last)?));
+                            .push(Some(new.checked_sub(last)?));
                     }
                     (
                         CumulativeDatum::IntegerDistribution(last),
@@ -1552,7 +1552,7 @@ impl ValueArray {
                     ) => {
                         let new = Distribution::from(new);
                         self.as_integer_distribution_mut()?
-                            .push(Some(new.checked_sub(&last)?));
+                            .push(Some(new.checked_sub(last)?));
                     }
                     (
                         CumulativeDatum::IntegerDistribution(last),
@@ -1560,7 +1560,7 @@ impl ValueArray {
                     ) => {
                         let new = Distribution::try_from(new)?;
                         self.as_integer_distribution_mut()?
-                            .push(Some(new.checked_sub(&last)?));
+                            .push(Some(new.checked_sub(last)?));
                     }
                     (
                         CumulativeDatum::DoubleDistribution(last),
@@ -1568,7 +1568,7 @@ impl ValueArray {
                     ) => {
                         let new = Distribution::<f64>::from(new);
                         self.as_double_distribution_mut()?
-                            .push(Some(new.checked_sub(&last)?));
+                            .push(Some(new.checked_sub(last)?));
                     }
                     (
                         CumulativeDatum::DoubleDistribution(last),
@@ -1576,7 +1576,7 @@ impl ValueArray {
                     ) => {
                         let new = Distribution::<f64>::from(new);
                         self.as_double_distribution_mut()?
-                            .push(Some(new.checked_sub(&last)?));
+                            .push(Some(new.checked_sub(last)?));
                     }
                     (_, _) => unreachable!(),
                 }

--- a/oximeter/producer/src/lib.rs
+++ b/oximeter/producer/src/lib.rs
@@ -116,7 +116,7 @@ impl Server {
     pub fn start(config: &Config) -> Result<Self, Error> {
         Self::with_registry(
             ProducerRegistry::with_id(config.server_info.id),
-            &config,
+            config,
         )
     }
 

--- a/oximeter/schema/src/ir.rs
+++ b/oximeter/schema/src/ir.rs
@@ -561,7 +561,7 @@ fn construct_field_schema(
     metric_name: &str,
     metric_field_names: &BTreeSet<String>,
 ) -> Result<BTreeSet<FieldSchema>, MetricsError> {
-    if let Some(dup) = target_fields.intersection(&metric_field_names).next() {
+    if let Some(dup) = target_fields.intersection(metric_field_names).next() {
         return Err(MetricsError::SchemaDefinition(format!(
             "Field '{}' is duplicated between target \
             '{}' and metric '{}'",

--- a/package/src/cargo_plan.rs
+++ b/package/src/cargo_plan.rs
@@ -243,14 +243,14 @@ impl fmt::Display for DisplayCargoPlan<'_> {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         write!(f, "release command: ")?;
         if let Some(command) = &self.plan.release.build_command(self.command) {
-            writeln!(f, "{}", command_to_string(&command))?;
+            writeln!(f, "{}", command_to_string(command))?;
         } else {
             writeln!(f, "(none)")?;
         }
 
         write!(f, "debug command: ")?;
         if let Some(command) = &self.plan.debug.build_command(self.command) {
-            writeln!(f, "{}", command_to_string(&command))?;
+            writeln!(f, "{}", command_to_string(command))?;
         } else {
             writeln!(f, "(none)")?;
         }

--- a/package/src/dot.rs
+++ b/package/src/dot.rs
@@ -202,8 +202,8 @@ pub fn do_dot(
                         .iter()
                         .map(|mapping| {
                             Ok((
-                                mapping.from.interpolate(&target)?,
-                                mapping.to.interpolate(&target)?,
+                                mapping.from.interpolate(target)?,
+                                mapping.to.interpolate(target)?,
                             ))
                         })
                         .collect::<anyhow::Result<_>>()?;

--- a/rpaths/src/lib.rs
+++ b/rpaths/src/lib.rs
@@ -259,7 +259,7 @@ mod internal {
 
             let error = configure_rpaths_from_path(
                 &mut v,
-                &OsStr::from_bytes(b"/foo/b\x80ar"),
+                OsStr::from_bytes(b"/foo/b\x80ar"),
             )
             .unwrap_err();
             assert_eq!(error, "contains non-UTF8 data");

--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -2,5 +2,5 @@
 # We choose a specific toolchain (rather than "stable") for repeatability.  The
 # intent is to keep this up-to-date with recently-released stable Rust.
 
-channel = "1.86.0"
+channel = "1.85.0"
 profile = "default"

--- a/sled-agent/src/backing_fs.rs
+++ b/sled-agent/src/backing_fs.rs
@@ -163,7 +163,7 @@ pub(crate) fn ensure_backing_fs(
         // can't retrieve the property at all, then there is definitely no ZFS
         // filesystem mounted there - most likely we are running with a non-ZFS
         // root, such as when net booted during CI.
-        if Zfs::get_value(&bfs.mountpoint, "mountpoint")
+        if Zfs::get_value(bfs.mountpoint, "mountpoint")
             .unwrap_or("not-zfs".to_string())
             == bfs.mountpoint
         {

--- a/sled-agent/src/bootstrap/bootstore_setup.rs
+++ b/sled-agent/src/bootstrap/bootstore_setup.rs
@@ -37,10 +37,8 @@ pub fn new_bootstore_config(
         learn_timeout: Duration::from_secs(5),
         rack_init_timeout: Duration::from_secs(300),
         rack_secret_request_timeout: Duration::from_secs(5),
-        fsm_state_ledger_paths: bootstore_fsm_state_paths(&all_disks)?,
-        network_config_ledger_paths: bootstore_network_config_paths(
-            &all_disks,
-        )?,
+        fsm_state_ledger_paths: bootstore_fsm_state_paths(all_disks)?,
+        network_config_ledger_paths: bootstore_network_config_paths(all_disks)?,
     })
 }
 

--- a/sled-agent/src/bootstrap/pre_server.rs
+++ b/sled-agent/src/bootstrap/pre_server.rs
@@ -228,7 +228,7 @@ async fn cleanup_all_old_global_state(log: &Logger) -> Result<(), StartError> {
     // Note that we don't currently delete the VNICs in any particular
     // order. That should be OK, since we're definitely deleting the guest
     // VNICs before the xde devices, which is the main constraint.
-    sled_hardware::cleanup::delete_omicron_vnics(&log)
+    sled_hardware::cleanup::delete_omicron_vnics(log)
         .await
         .map_err(StartError::DeleteOmicronVnics)?;
 
@@ -239,7 +239,7 @@ async fn cleanup_all_old_global_state(log: &Logger) -> Result<(), StartError> {
     //
     // This is also tracked by
     // https://github.com/oxidecomputer/omicron/issues/725.
-    illumos_utils::opte::delete_all_xde_devices(&log)
+    illumos_utils::opte::delete_all_xde_devices(log)
         .map_err(StartError::DeleteXdeDevices)?;
 
     Ok(())

--- a/sled-agent/src/bootstrap/server.rs
+++ b/sled-agent/src/bootstrap/server.rs
@@ -416,7 +416,7 @@ async fn start_sled_agent(
     let paths =
         sled_config_paths(&long_running_task_handles.storage_manager).await?;
 
-    let mut ledger = Ledger::new_with(&log, paths, request);
+    let mut ledger = Ledger::new_with(log, paths, request);
     ledger.commit().await?;
 
     Ok(server)
@@ -554,7 +554,7 @@ impl Inner {
                     self.long_running_task_handles.clone(),
                     self.service_manager.clone(),
                     &self.base_log,
-                    &log,
+                    log,
                 )
                 .await
                 {
@@ -672,12 +672,12 @@ impl Inner {
         // these addresses would delete "cxgbe0/ll", and could render
         // the sled inaccessible via a local interface.
 
-        sled_hardware::cleanup::delete_underlay_addresses(&log)
+        sled_hardware::cleanup::delete_underlay_addresses(log)
             .map_err(BootstrapError::Cleanup)?;
-        sled_hardware::cleanup::delete_omicron_vnics(&log)
+        sled_hardware::cleanup::delete_omicron_vnics(log)
             .await
             .map_err(BootstrapError::Cleanup)?;
-        illumos_utils::opte::delete_all_xde_devices(&log)?;
+        illumos_utils::opte::delete_all_xde_devices(log)?;
         Ok(())
     }
 

--- a/sled-agent/src/instance.rs
+++ b/sled-agent/src/instance.rs
@@ -1373,7 +1373,7 @@ impl InstanceRunner {
                         .order
                         .iter()
                         .map(|id| BootOrderEntry {
-                            id: SpecKey::Name(id_to_device_name(&id)),
+                            id: SpecKey::Name(id_to_device_name(id)),
                         })
                         .collect(),
                 });
@@ -2596,7 +2596,7 @@ mod tests {
             );
 
             let _dns_server =
-                crate::fakes::nexus::start_dns_server(&log, &_nexus_server)
+                crate::fakes::nexus::start_dns_server(log, &_nexus_server)
                     .await;
 
             let resolver = Arc::new(
@@ -2608,7 +2608,7 @@ mod tests {
             );
 
             let nexus_client = make_nexus_client_with_port(
-                &log,
+                log,
                 resolver,
                 _nexus_server.local_addr().port(),
             );
@@ -2823,7 +2823,7 @@ mod tests {
     impl InstanceTestObjects {
         async fn new(log: &slog::Logger) -> Self {
             let storage_harness = setup_storage_manager(log).await;
-            let nexus = FakeNexusParts::new(&log).await;
+            let nexus = FakeNexusParts::new(log).await;
             let temp_guard = Utf8TempDir::new().unwrap();
             let (services, metrics_rx) = fake_instance_manager_services(
                 log,
@@ -3378,17 +3378,17 @@ mod tests {
 
     impl TestInstanceRunner {
         async fn new(log: &slog::Logger) -> Self {
-            let storage_harness = setup_storage_manager(&log).await;
+            let storage_harness = setup_storage_manager(log).await;
             let FakeNexusParts {
                 nexus_client,
                 _nexus_server,
                 state_rx,
                 _dns_server,
-            } = FakeNexusParts::new(&log).await;
+            } = FakeNexusParts::new(log).await;
 
             let temp_guard = Utf8TempDir::new().unwrap();
             let (services, _metrics_rx) = fake_instance_manager_services(
-                &log,
+                log,
                 storage_harness.handle().clone(),
                 nexus_client,
                 &temp_guard.path().to_string(),

--- a/sled-agent/src/instance_manager.rs
+++ b/sled-agent/src/instance_manager.rs
@@ -657,7 +657,7 @@ impl InstanceManagerRunner {
                 )?;
                 let _old = self.jobs.insert(propolis_id, instance);
                 assert!(_old.is_none());
-                &self.jobs.get(&propolis_id).unwrap()
+                self.jobs.get(&propolis_id).unwrap()
             }
         };
         let (tx, rx) = oneshot::channel();

--- a/sled-agent/src/long_running_tasks.rs
+++ b/sled-agent/src/long_running_tasks.rs
@@ -80,7 +80,7 @@ pub async fn spawn_all_longrunning_tasks(
         spawn_storage_monitor(log, storage_manager.clone());
 
     let nongimlet_observed_disks =
-        config.nongimlet_observed_disks.clone().unwrap_or(vec![]);
+        config.nongimlet_observed_disks.clone().unwrap_or_default();
 
     let hardware_manager =
         spawn_hardware_manager(log, sled_mode, nongimlet_observed_disks).await;
@@ -90,7 +90,7 @@ pub async fn spawn_all_longrunning_tasks(
         spawn_hardware_monitor(log, &hardware_manager, &storage_manager);
 
     // Add some synthetic disks if necessary.
-    upsert_synthetic_disks_if_needed(&log, &storage_manager, &config).await;
+    upsert_synthetic_disks_if_needed(log, &storage_manager, config).await;
 
     // Wait for the boot disk so that we can work with any ledgers,
     // such as those needed by the bootstore and sled-agent

--- a/sled-agent/src/metrics.rs
+++ b/sled-agent/src/metrics.rs
@@ -358,7 +358,7 @@ impl MetricsManager {
         address: Ipv6Addr,
     ) -> Result<Self, Error> {
         let sampler = KstatSampler::new(log).map_err(Error::Kstat)?;
-        let server = start_producer_server(&log, identifiers.sled_id, address)?;
+        let server = start_producer_server(log, identifiers.sled_id, address)?;
         server
             .registry()
             .register_producer(sampler.clone())

--- a/sled-agent/src/profile.rs
+++ b/sled-agent/src/profile.rs
@@ -211,10 +211,7 @@ impl PropertyGroupBuilder {
             self.properties_seen.push(name.to_string());
         }
 
-        let values = self
-            .property_values
-            .entry(name.to_string())
-            .or_insert_with(Vec::new);
+        let values = self.property_values.entry(name.to_string()).or_default();
         values.push(value.into());
         self
     }

--- a/sled-agent/src/rack_setup/service.rs
+++ b/sled-agent/src/rack_setup/service.rs
@@ -1267,7 +1267,7 @@ impl ServiceInner {
         // Now that sled agents have been initialized, we can create
         // a service allocation plan.
         let service_plan =
-            ServicePlan::create(&self.log, &config, &sled_plan.sleds).await?;
+            ServicePlan::create(&self.log, config, &sled_plan.sleds).await?;
 
         // Set up internal DNS services first and write the initial
         // DNS configuration to the internal DNS servers.
@@ -1364,7 +1364,7 @@ impl ServiceInner {
         // At this point, even if we reboot, we must not try to manage sleds,
         // services, or DNS records.
         self.handoff_to_nexus(
-            &config,
+            config,
             &sled_plan,
             &service_plan,
             ExternalPortDiscovery::Auto(switch_mgmt_addrs),

--- a/sled-agent/src/server.rs
+++ b/sled-agent/src/server.rs
@@ -55,7 +55,7 @@ impl Server {
         let nexus_client = make_nexus_client(&log, resolver);
 
         let sled_agent = SledAgent::new(
-            &config,
+            config,
             log.clone(),
             nexus_client,
             request,

--- a/sled-agent/src/sim/instance.rs
+++ b/sled-agent/src/sim/instance.rs
@@ -162,7 +162,7 @@ impl SimInstanceInner {
                 MonitorChange::PropolisState(state) => Some(state),
                 _ => None,
             })
-            .next_back()
+            .last()
             .copied()
     }
 

--- a/sled-agent/src/sim/server.rs
+++ b/sled-agent/src/sim/server.rs
@@ -103,7 +103,7 @@ impl Server {
             "server" => config.id.clone().to_string()
         ));
         let sled_agent = SledAgent::new_simulated_with_id(
-            &config,
+            config,
             sa_log,
             config.nexus_address,
             Arc::clone(&nexus_client),
@@ -272,7 +272,7 @@ async fn handoff_to_nexus(
 
     let notify_nexus = || async {
         nexus_client
-            .rack_initialization_complete(&rack_id, &request)
+            .rack_initialization_complete(&rack_id, request)
             .await
             .map_err(BackoffError::transient)
     };
@@ -599,7 +599,7 @@ pub async fn run_standalone_server(
         allowed_source_ips: NexusTypes::AllowedSourceIps::Any,
     };
 
-    handoff_to_nexus(&log, &config, &rack_init_request).await?;
+    handoff_to_nexus(&log, config, &rack_init_request).await?;
     info!(log, "Handoff to Nexus is complete");
 
     server.wait_for_finish().await

--- a/sled-agent/src/sim/sled_agent.rs
+++ b/sled-agent/src/sim/sled_agent.rs
@@ -214,7 +214,7 @@ impl SledAgent {
         let ncpus: i64 = (&hardware.properties.ncpus).into();
         if ncpus > 16 {
             return Err(Error::internal_error(
-                &"could not allocate an instance: ran out of CPUs!",
+                "could not allocate an instance: ran out of CPUs!",
             ));
         };
 
@@ -684,7 +684,7 @@ impl SledAgent {
         let mut eips = self.external_ips.lock().unwrap();
         let my_eips = eips.entry(propolis_id).or_default();
 
-        my_eips.remove(&body_args);
+        my_eips.remove(body_args);
 
         Ok(())
     }

--- a/sled-agent/src/sim/storage.rs
+++ b/sled-agent/src/sim/storage.rs
@@ -171,7 +171,7 @@ impl CrucibleDataInner {
         }
 
         if let Some(region) = self.regions.get(&id) {
-            if let Some(mismatch) = mismatch(&params, &region) {
+            if let Some(mismatch) = mismatch(&params, region) {
                 let s = format!(
                     "region {region:?} already exists as {params:?}: {mismatch}"
                 );
@@ -1410,7 +1410,7 @@ impl StorageInner {
             });
         }
         self.nested_datasets
-            .retain(|dataset, _| dataset_names.contains(&dataset));
+            .retain(|dataset, _| dataset_names.contains(dataset));
 
         Ok(DatasetsManagementResult {
             status: config

--- a/sled-agent/src/sim/upstairs.rs
+++ b/sled-agent/src/sim/upstairs.rs
@@ -75,7 +75,7 @@ impl SimulatedUpstairs {
         let volume_construction_request = inner.id_to_vcr.get(&id).unwrap();
 
         let targets = extract_targets_from_volume_construction_request(
-            &volume_construction_request,
+            volume_construction_request,
         )
         .map_err(|e| {
             Error::invalid_request(&format!("bad socketaddr: {e:?}"))
@@ -137,7 +137,7 @@ fn extract_targets_from_volume_construction_request(
 
     let mut res = vec![];
     let mut parts: VecDeque<&VolumeConstructionRequest> = VecDeque::new();
-    parts.push_back(&vcr);
+    parts.push_back(vcr);
 
     while let Some(vcr_part) = parts.pop_front() {
         match vcr_part {

--- a/sled-agent/src/sled_agent.rs
+++ b/sled-agent/src/sled_agent.rs
@@ -1169,7 +1169,7 @@ impl SledAgent {
     }
 
     pub fn artifact_store(&self) -> &ArtifactStore<StorageHandle> {
-        &self.inner.repo_depot.app_private()
+        self.inner.repo_depot.app_private()
     }
 
     /// Issue a snapshot request for a Crucible disk attached to an instance

--- a/sled-agent/src/storage_monitor.rs
+++ b/sled-agent/src/storage_monitor.rs
@@ -74,7 +74,7 @@ impl StorageMonitor {
         mount_config: MountConfig,
         storage_manager: StorageHandle,
     ) -> (StorageMonitor, StorageMonitorHandle) {
-        let dump_setup = DumpSetup::new(&log, mount_config);
+        let dump_setup = DumpSetup::new(log, mount_config);
         let log = log.new(o!("component" => "StorageMonitor"));
         let (tx, rx) = watch::channel(StorageMonitorStatus::new());
         (

--- a/sled-agent/src/updates.rs
+++ b/sled-agent/src/updates.rs
@@ -96,7 +96,7 @@ impl UpdateManager {
                 //
                 // This logic may be tweaked in the future, depending on how we
                 // bundle together zones.
-                components.push(self.component_get_zone_version(&path).await?);
+                components.push(self.component_get_zone_version(path).await?);
             } else if file_type.is_dir() && entry.file_name() == "sled-agent" {
                 // Sled Agent is the only non-zone file recognized as a component.
                 let version_path = path.join("VERSION");
@@ -155,7 +155,7 @@ mod test {
 
         let mut json = NamedUtf8TempFile::new().unwrap();
         json.write_all(
-            &r#"{"v":"1","t":"layer","pkg":"test-pkg","version":"2.0.0"}"#
+            r#"{"v":"1","t":"layer","pkg":"test-pkg","version":"2.0.0"}"#
                 .as_bytes(),
         )
         .unwrap();

--- a/sled-agent/src/zone_bundle.rs
+++ b/sled-agent/src/zone_bundle.rs
@@ -399,7 +399,7 @@ impl ZoneBundler {
         let dirs = inner.bundle_directories().await;
         for dir in dirs.iter() {
             bundles.extend(
-                list_bundles_for_zone(&self.log, &dir, name)
+                list_bundles_for_zone(&self.log, dir, name)
                     .await?
                     .into_iter()
                     .map(|(_path, bdl)| bdl),
@@ -1106,7 +1106,7 @@ async fn create(
                     "zone" => zone.name(),
                     "error" => ?e,
                 );
-                cleanup_zfs_snapshots(&log, &snapshots);
+                cleanup_zfs_snapshots(log, &snapshots);
                 return Err(e);
             }
         };
@@ -1137,7 +1137,7 @@ async fn create(
 
     // Finish writing out the tarball itself.
     if let Err(e) = builder.into_inner().context("Failed to build bundle") {
-        cleanup_zfs_snapshots(&log, &snapshots);
+        cleanup_zfs_snapshots(log, &snapshots);
         return Err(BundleError::from(e));
     }
 
@@ -1160,7 +1160,7 @@ async fn create(
             break;
         }
     }
-    cleanup_zfs_snapshots(&log, &snapshots);
+    cleanup_zfs_snapshots(log, &snapshots);
     if let Some(err) = copy_err {
         return Err(err);
     }
@@ -1490,7 +1490,7 @@ async fn run_cleanup(
     }
 
     // There's some work to do, let's enumerate all the bundles.
-    let bundles = enumerate_zone_bundles(log, &storage_dirs).await?;
+    let bundles = enumerate_zone_bundles(log, storage_dirs).await?;
     debug!(
         log,
         "enumerated {} zone bundles across {} directories",
@@ -1847,7 +1847,7 @@ mod illumos_tests {
     }
 
     async fn setup_storage(log: &Logger) -> StorageManagerTestHarness {
-        let mut harness = StorageManagerTestHarness::new(&log).await;
+        let mut harness = StorageManagerTestHarness::new(log).await;
 
         harness.handle().key_manager_ready().await;
         let _raw_disks =

--- a/sled-agent/types/src/early_networking.rs
+++ b/sled-agent/types/src/early_networking.rs
@@ -44,7 +44,7 @@ impl FromStr for EarlyNetworkConfig {
             body: EarlyNetworkConfigBody,
         }
 
-        let v2_err = match serde_json::from_str::<ShadowConfig>(&value) {
+        let v2_err = match serde_json::from_str::<ShadowConfig>(value) {
             Ok(cfg) => {
                 return Ok(EarlyNetworkConfig {
                     generation: cfg.generation,
@@ -56,7 +56,7 @@ impl FromStr for EarlyNetworkConfig {
         };
         // If we fail to parse the config as any known version, we return the
         // error corresponding to the parse failure of the newest schema.
-        serde_json::from_str::<back_compat::EarlyNetworkConfigV1>(&value)
+        serde_json::from_str::<back_compat::EarlyNetworkConfigV1>(value)
             .map(|v1| EarlyNetworkConfig {
                 generation: v1.generation,
                 schema_version: Self::schema_version(),

--- a/sled-agent/types/src/rack_init.rs
+++ b/sled-agent/types/src/rack_init.rs
@@ -298,12 +298,12 @@ impl RackInitializeRequest {
     pub fn from_toml_with_fallback(
         data: &str,
     ) -> Result<RackInitializeRequest> {
-        let v2_err = match toml::from_str::<RackInitializeRequest>(&data) {
+        let v2_err = match toml::from_str::<RackInitializeRequest>(data) {
             Ok(req) => return Ok(req),
             Err(e) => e,
         };
         if let Ok(v1) =
-            toml::from_str::<back_compat::RackInitializeRequestV1>(&data)
+            toml::from_str::<back_compat::RackInitializeRequestV1>(data)
         {
             return Ok(v1.into());
         }

--- a/sled-hardware/src/disk.rs
+++ b/sled-hardware/src/disk.rs
@@ -292,7 +292,7 @@ impl PooledDisk {
         // Ensure the GPT has the right format. This does not necessarily
         // mean that the partitions are populated with the data we need.
         let partitions =
-            ensure_partition_layout(&log, &paths, variant, identity, zpool_id)?;
+            ensure_partition_layout(log, paths, variant, identity, zpool_id)?;
 
         // Find the path to the zpool which exists on this disk.
         //
@@ -327,7 +327,7 @@ impl PooledDisk {
 pub fn check_if_zpool_exists(
     zpool_path: &Utf8Path,
 ) -> Result<ZpoolName, PooledDiskError> {
-    let zpool_name = match Fstyp::get_zpool(&zpool_path) {
+    let zpool_name = match Fstyp::get_zpool(zpool_path) {
         Ok(zpool_name) => zpool_name,
         Err(_) => return Err(PooledDiskError::ZpoolDoesNotExist),
     };
@@ -340,7 +340,7 @@ pub fn ensure_zpool_exists(
     zpool_path: &Utf8Path,
     zpool_id: Option<ZpoolUuid>,
 ) -> Result<ZpoolName, PooledDiskError> {
-    let zpool_name = match Fstyp::get_zpool(&zpool_path) {
+    let zpool_name = match Fstyp::get_zpool(zpool_path) {
         Ok(zpool_name) => {
             if let Some(expected) = zpool_id {
                 info!(log, "Checking that UUID in storage matches request"; "expected" => ?expected);
@@ -388,7 +388,7 @@ pub fn ensure_zpool_exists(
                 DiskVariant::M2 => ZpoolName::new_internal(id),
                 DiskVariant::U2 => ZpoolName::new_external(id),
             };
-            Zpool::real_api().create(&zpool_name, &zpool_path)?;
+            Zpool::real_api().create(&zpool_name, zpool_path)?;
             zpool_name
         }
     };
@@ -404,7 +404,7 @@ pub fn ensure_zpool_imported(
     log: &Logger,
     zpool_name: &ZpoolName,
 ) -> Result<(), PooledDiskError> {
-    Zpool::import(&zpool_name).map_err(|e| {
+    Zpool::import(zpool_name).map_err(|e| {
         warn!(log, "Failed to import zpool {zpool_name}: {e}");
         PooledDiskError::ZpoolImport(e)
     })?;
@@ -422,7 +422,7 @@ pub fn ensure_zpool_failmode_is_continue(
     // actively harmful to try to wait for it to come back; we'll be waiting
     // forever and get stuck. We'd rather get the errors so we can deal with
     // them ourselves.
-    Zpool::set_failmode_continue(&zpool_name).map_err(|e| {
+    Zpool::set_failmode_continue(zpool_name).map_err(|e| {
         warn!(
             log,
             "Failed to set failmode=continue on zpool {zpool_name}: {e}"

--- a/sled-hardware/src/illumos/mod.rs
+++ b/sled-hardware/src/illumos/mod.rs
@@ -174,7 +174,7 @@ impl HardwareSnapshot {
         while let Some(node) =
             node_walker.next().transpose().map_err(Error::DevInfo)?
         {
-            poll_blkdev_node(&log, &mut disks, node, boot_storage_unit)?;
+            poll_blkdev_node(log, &mut disks, node, boot_storage_unit)?;
         }
 
         Ok(Self { tofino, disks, baseboard })
@@ -277,7 +277,7 @@ impl HardwareView {
 
         // Find new or updated disks.
         for (key, value) in &polled_hw.disks {
-            match self.disks.get(&key) {
+            match self.disks.get(key) {
                 Some(found) => {
                     if value != found {
                         updated.push(value.clone());

--- a/sled-hardware/src/illumos/partitions.rs
+++ b/sled-hardware/src/illumos/partitions.rs
@@ -395,7 +395,7 @@ mod test {
 
         let devfs_path = Utf8PathBuf::from("/devfs/path");
         let result = internal_ensure_partition_layout::<LabelNotFoundGPT>(
-            &log,
+            log,
             illumos_utils::fakes::zpool::Zpool::new().as_ref(),
             &DiskPaths { devfs_path, dev_path: None },
             DiskVariant::U2,
@@ -420,7 +420,7 @@ mod test {
         const DEV_PATH: &'static str = "/dev/path";
 
         let partitions = internal_ensure_partition_layout::<LabelNotFoundGPT>(
-            &log,
+            log,
             illumos_utils::fakes::zpool::Zpool::new().as_ref(),
             &DiskPaths {
                 devfs_path,
@@ -448,7 +448,7 @@ mod test {
 
         assert!(
             internal_ensure_partition_layout::<LabelNotFoundGPT>(
-                &log,
+                log,
                 illumos_utils::fakes::zpool::Zpool::new().as_ref(),
                 &DiskPaths {
                     devfs_path,
@@ -489,7 +489,7 @@ mod test {
         const DEV_PATH: &'static str = "/dev/path";
 
         let partitions = internal_ensure_partition_layout::<FakeU2GPT>(
-            &log,
+            log,
             illumos_utils::fakes::zpool::Zpool::new().as_ref(),
             &DiskPaths {
                 devfs_path,
@@ -534,7 +534,7 @@ mod test {
         const DEV_PATH: &'static str = "/dev/path";
 
         let partitions = internal_ensure_partition_layout::<FakeM2GPT>(
-            &log,
+            log,
             illumos_utils::fakes::zpool::Zpool::new().as_ref(),
             &DiskPaths {
                 devfs_path,
@@ -576,7 +576,7 @@ mod test {
 
         assert!(matches!(
             internal_ensure_partition_layout::<EmptyGPT>(
-                &log,
+                log,
                 illumos_utils::fakes::zpool::Zpool::new().as_ref(),
                 &DiskPaths {
                     devfs_path,
@@ -604,7 +604,7 @@ mod test {
 
         assert!(matches!(
             internal_ensure_partition_layout::<EmptyGPT>(
-                &log,
+                log,
                 illumos_utils::fakes::zpool::Zpool::new().as_ref(),
                 &DiskPaths {
                     devfs_path,

--- a/sled-hardware/types/src/lib.rs
+++ b/sled-hardware/types/src/lib.rs
@@ -59,16 +59,16 @@ impl Baseboard {
 
     pub fn identifier(&self) -> &str {
         match &self {
-            Self::Gimlet { identifier, .. } => &identifier,
-            Self::Pc { identifier, .. } => &identifier,
+            Self::Gimlet { identifier, .. } => identifier,
+            Self::Pc { identifier, .. } => identifier,
             Self::Unknown => "unknown",
         }
     }
 
     pub fn model(&self) -> &str {
         match self {
-            Self::Gimlet { model, .. } => &model,
-            Self::Pc { model, .. } => &model,
+            Self::Gimlet { model, .. } => model,
+            Self::Pc { model, .. } => model,
             Self::Unknown => "unknown",
         }
     }

--- a/sled-storage/src/disk.rs
+++ b/sled-storage/src/disk.rs
@@ -178,7 +178,7 @@ impl RawDisk {
 
     pub fn identity(&self) -> &DiskIdentity {
         match self {
-            Self::Real(disk) => &disk.identity(),
+            Self::Real(disk) => disk.identity(),
             Self::Synthetic(disk) => &disk.identity,
         }
     }

--- a/sled-storage/src/manager.rs
+++ b/sled-storage/src/manager.rs
@@ -833,7 +833,7 @@ impl StorageManager {
             // Identify which disks should be managed by the control
             // plane, and adopt all requested disks into the control plane
             // in a background task (see: [Self::manage_disks]).
-            self.resources.set_config(&ledger.data());
+            self.resources.set_config(ledger.data());
         } else {
             info!(self.log, "KeyManager ready, but no ledger detected");
         }
@@ -1369,7 +1369,7 @@ impl StorageManager {
 
         // Identify which disks should be managed by the control
         // plane, and adopt all requested disks into the control plane.
-        self.resources.set_config(&config);
+        self.resources.set_config(config);
 
         // Actually try to "manage" those disks, which may involve formatting
         // zpools and conforming partitions to those expected by the control
@@ -1487,7 +1487,7 @@ impl StorageManager {
             compression: config.compression,
         });
         Zfs::ensure_dataset(DatasetEnsureArgs {
-            name: &full_name,
+            name: full_name,
             mountpoint: mountpoint.clone(),
             can_mount: CanMount::On,
             zoned: *zoned,

--- a/sled-storage/src/manager_test_harness.rs
+++ b/sled-storage/src/manager_test_harness.rs
@@ -185,13 +185,13 @@ impl StorageManagerTestHarness {
 
         let key_manager_error_injector = Arc::new(AtomicBool::new(false));
         let (mut key_manager, key_requester) = key_manager::KeyManager::new(
-            &log,
+            log,
             HardcodedSecretRetriever {
                 inject_error: key_manager_error_injector.clone(),
             },
         );
         let (manager, handle) =
-            StorageManager::new(&log, mount_config, key_requester.clone());
+            StorageManager::new(log, mount_config, key_requester.clone());
 
         // Spawn the key_manager so that it will respond to requests for encryption keys
         let key_manager_task =
@@ -338,7 +338,7 @@ impl StorageManagerTestHarness {
     // Otherwise, removing the temporary directory containing that zpool
     // will likely fail with a "device busy" error.
     pub async fn remove_vdev(&mut self, raw: &RawDisk) {
-        assert!(self.vdevs.remove(&raw), "Vdev does not exist");
+        assert!(self.vdevs.remove(raw), "Vdev does not exist");
         self.handle
             .detected_raw_disk_removal(raw.clone())
             .await

--- a/sled-storage/src/resources.rs
+++ b/sled-storage/src/resources.rs
@@ -367,7 +367,7 @@ impl StorageResources {
                 // involve formatting it, and emplacing the zpool.
                 ManagedDisk::Unmanaged(raw_disk) => {
                     match Self::begin_disk_management(
-                        &log,
+                        log,
                         &all_disks.mount_config,
                         raw_disk,
                         config,
@@ -434,7 +434,7 @@ impl StorageResources {
     ) -> Result<ManagedDisk, DiskManagementError> {
         info!(log, "Invoking Disk::new on an unmanaged disk");
         let disk = Disk::new(
-            &log,
+            log,
             mount_config,
             raw_disk.clone(),
             Some(config.pool_id),
@@ -532,7 +532,7 @@ impl StorageResources {
             }
             DiskVariant::M2 => {
                 let managed_disk = Disk::new(
-                    &log,
+                    log,
                     &all_disks.mount_config,
                     disk,
                     None,

--- a/sp-sim/src/config.rs
+++ b/sp-sim/src/config.rs
@@ -61,7 +61,7 @@ impl slog::KV for NetworkConfig {
                 )?;
                 serializer.emit_str(
                     "multicast_interface".into(),
-                    &multicast_interface,
+                    multicast_interface,
                 )?;
             }
         }

--- a/sp-sim/src/gimlet.rs
+++ b/sp-sim/src/gimlet.rs
@@ -1356,7 +1356,7 @@ impl SpHandler for Handler {
             (SpComponent::ROT, b"VERS", 0, _) => ROT_VERS0,
             (SpComponent::ROT, b"VERS", 1, _) => ROT_VERS1,
             // gimlet staging/devel hash
-            (SpComponent::ROT, b"SIGN", _, _) => &"11594bb5548a757e918e6fe056e2ad9e084297c9555417a025d8788eacf55daf".as_bytes(),
+            (SpComponent::ROT, b"SIGN", _, _) => "11594bb5548a757e918e6fe056e2ad9e084297c9555417a025d8788eacf55daf".as_bytes(),
             (SpComponent::STAGE0, b"GITC", 0, false) => STAGE0_GITC0,
             (SpComponent::STAGE0, b"GITC", 1, false) => STAGE0_GITC1,
             (SpComponent::STAGE0, b"BORD", _, false) => STAGE0_BORD,
@@ -1364,7 +1364,7 @@ impl SpHandler for Handler {
             (SpComponent::STAGE0, b"VERS", 0, false) => STAGE0_VERS0,
             (SpComponent::STAGE0, b"VERS", 1, false) => STAGE0_VERS1,
             // gimlet staging/devel hash
-            (SpComponent::STAGE0, b"SIGN", _, false) => &"11594bb5548a757e918e6fe056e2ad9e084297c9555417a025d8788eacf55daf".as_bytes(),
+            (SpComponent::STAGE0, b"SIGN", _, false) => "11594bb5548a757e918e6fe056e2ad9e084297c9555417a025d8788eacf55daf".as_bytes(),
             _ => return Err(SpError::NoSuchCabooseKey(key)),
         };
 

--- a/sp-sim/src/server.rs
+++ b/sp-sim/src/server.rs
@@ -66,7 +66,7 @@ impl UdpServer {
                         format!("failed to bind to {}", bind_addr)
                     })?;
 
-                sock.join_multicast_v6(&multicast_addr, interface_index)
+                sock.join_multicast_v6(multicast_addr, interface_index)
                     .with_context(|| {
                         format!(
                             "failed to join multicast group {multicast_addr} \

--- a/sp-sim/src/sidecar.rs
+++ b/sp-sim/src/sidecar.rs
@@ -1056,7 +1056,7 @@ impl SpHandler for Handler {
             (SpComponent::ROT, b"VERS", 0, _) => ROT_VERS0,
             (SpComponent::ROT, b"VERS", 1, _) => ROT_VERS1,
             // sidecar staging/devel hash
-            (SpComponent::ROT, b"SIGN", _, _) => &"1432cc4cfe5688c51b55546fe37837c753cfbc89e8c3c6aabcf977fdf0c41e27".as_bytes(),
+            (SpComponent::ROT, b"SIGN", _, _) => "1432cc4cfe5688c51b55546fe37837c753cfbc89e8c3c6aabcf977fdf0c41e27".as_bytes(),
             (SpComponent::STAGE0, b"GITC", 0, false) => STAGE0_GITC0,
             (SpComponent::STAGE0, b"GITC", 1, false) => STAGE0_GITC1,
             (SpComponent::STAGE0, b"BORD", _, false) => STAGE0_BORD,
@@ -1064,7 +1064,7 @@ impl SpHandler for Handler {
             (SpComponent::STAGE0, b"VERS", 0, false) => STAGE0_VERS0,
             (SpComponent::STAGE0, b"VERS", 1, false) => STAGE0_VERS1,
             // sidecar staging/devel hash
-            (SpComponent::STAGE0, b"SIGN", _, false) => &"1432cc4cfe5688c51b55546fe37837c753cfbc89e8c3c6aabcf977fdf0c41e27".as_bytes(),
+            (SpComponent::STAGE0, b"SIGN", _, false) => "1432cc4cfe5688c51b55546fe37837c753cfbc89e8c3c6aabcf977fdf0c41e27".as_bytes(),
             _ => return Err(SpError::NoSuchCabooseKey(key)),
         };
 

--- a/test-utils/src/bin/falcon_runner.rs
+++ b/test-utils/src/bin/falcon_runner.rs
@@ -68,7 +68,7 @@ async fn main() -> Result<(), anyhow::Error> {
 
     // Ensure there is enough data left for an exit code
     let exit_code: u8 = if exit_code_index + 1 < out.len() {
-        (&out[exit_code_index + 1..]).parse().expect("Invalid exit code")
+        out[exit_code_index + 1..].parse().expect("Invalid exit code")
     } else {
         panic!("No exit code available");
     };

--- a/test-utils/src/dev/clickhouse.rs
+++ b/test-utils/src/dev/clickhouse.rs
@@ -918,10 +918,10 @@ impl Drop for ClickHouseProcess {
 }
 
 /// Number of data replicas in our test cluster.
-pub const N_REPLICAS: NonZeroU8 = NonZeroU8::new(2).unwrap();
+pub const N_REPLICAS: NonZeroU8 = unsafe { NonZeroU8::new_unchecked(2) };
 
 /// Number of ClickHouse Keepers in our test cluster.
-pub const N_KEEPERS: NonZeroU8 = NonZeroU8::new(3).unwrap();
+pub const N_KEEPERS: NonZeroU8 = unsafe { NonZeroU8::new_unchecked(3) };
 
 /// A `ClickHouseCluster` is used to start and manage a 2 replica 3 keeper ClickHouse cluster.
 #[derive(Debug)]
@@ -1230,7 +1230,7 @@ fn find_port_after_needle(
             return line[address_start..]
                 .trim()
                 .split(':')
-                .next_back()
+                .last()
                 .ok_or_else(|| ClickHouseError::InvalidAddress)?
                 .parse()
                 .map_err(|_| ClickHouseError::InvalidPort);

--- a/test-utils/src/dev/clickhouse.rs
+++ b/test-utils/src/dev/clickhouse.rs
@@ -894,12 +894,12 @@ impl Drop for ClickHouseProcess {
                 .as_ref()
                 .and_then(|child| child.id())
                 .map(|id| format!("(PID {})", id))
-                .unwrap_or_else(String::new);
+                .unwrap_or_default();
             let maybe_dir = self
                 .data_dir
                 .as_ref()
                 .map(|dir| format!(", {}", dir.root_path()))
-                .unwrap_or_else(String::new);
+                .unwrap_or_default();
             eprintln!(
                 "WARN: dropped ClickHouse process without cleaning it up first \
                 (there may still be a child process running {maybe_pid} and a \
@@ -1361,7 +1361,7 @@ mod tests {
             .unwrap();
         writeln!(file, "{}", CLICKHOUSE_READY).unwrap();
         file.flush().unwrap();
-        let ports = wait_for_ports(&file.path()).await.unwrap();
+        let ports = wait_for_ports(file.path()).await.unwrap();
         assert_eq!(ports.http, EXPECTED_HTTP_PORT);
         assert_eq!(ports.native, EXPECTED_TCP_PORT);
     }
@@ -1380,7 +1380,7 @@ mod tests {
         writeln!(file, "Another garbage line").unwrap();
         writeln!(file, "{}", CLICKHOUSE_READY).unwrap();
         file.flush().unwrap();
-        wait_for_ports(&file.path()).await.unwrap();
+        wait_for_ports(file.path()).await.unwrap();
     }
 
     #[tokio::test]

--- a/test-utils/src/dev/seed.rs
+++ b/test-utils/src/dev/seed.rs
@@ -19,8 +19,8 @@ pub fn digest_unique_to_schema() -> String {
     let schema = include_str!("../../../schema/crdb/dbinit.sql");
     let crdb_version = include_str!("../../../tools/cockroachdb_version");
     let mut ctx = ring::digest::Context::new(&ring::digest::SHA256);
-    ctx.update(&schema.as_bytes());
-    ctx.update(&crdb_version.as_bytes());
+    ctx.update(schema.as_bytes());
+    ctx.update(crdb_version.as_bytes());
     let digest = ctx.finish();
     hex::encode(digest.as_ref())
 }

--- a/test-utils/src/dev/test_cmds.rs
+++ b/test-utils/src/dev/test_cmds.rs
@@ -292,7 +292,7 @@ fn redact_basic(input: &str) -> String {
     // characters to avoid catching any random sequence of numbers.
     let s = regex::Regex::new(r"\[::1\]:\d{4,5}")
         .unwrap()
-        .replace_all(&input, "[::1]:REDACTED_PORT")
+        .replace_all(input, "[::1]:REDACTED_PORT")
         .to_string();
     let s = regex::Regex::new(r"\[::ffff:127.0.0.1\]:\d{4,5}")
         .unwrap()
@@ -380,7 +380,7 @@ fn redact_uuids(input: &str) -> String {
     const UUID_LEN: usize = 36;
     regex::Regex::new(r"[0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{12}")
         .unwrap()
-        .replace_all(&input, fill_redaction_text("uuid", UUID_LEN))
+        .replace_all(input, fill_redaction_text("uuid", UUID_LEN))
         .to_string()
 }
 

--- a/wicket/src/cli/rack_setup.rs
+++ b/wicket/src/cli/rack_setup.rs
@@ -365,7 +365,7 @@ impl SetBgpAuthKeyArgs {
             response.data.values().filter(|status| status.is_set()).count();
 
         for (i, key_id) in keys_to_set.iter().enumerate() {
-            let status = response.data.get(&key_id).with_context(|| {
+            let status = response.data.get(key_id).with_context(|| {
                 format!(
                     "info for key {} not returned \
                      (should have produced an HTTP error earlier!)",
@@ -395,7 +395,7 @@ impl SetBgpAuthKeyArgs {
                     let key = read_bgp_md5_key(&prompt)?;
                     let info = key.info().to_string_styled(styles.bold);
                     let response = client
-                        .put_bgp_auth_key(&key_id, &PutBgpAuthKeyBody { key })
+                        .put_bgp_auth_key(key_id, &PutBgpAuthKeyBody { key })
                         .await
                         .context("failed to set BGP auth key")?;
 

--- a/wicket/src/cli/rack_update.rs
+++ b/wicket/src/cli/rack_update.rs
@@ -246,7 +246,7 @@ async fn do_attach_to_updates(
                 for (id, event_report) in &*event_reports {
                     // If display.add_event_report errors out, it's for a report for a
                     // component we weren't interested in. Ignore it.
-                    _ = display.add_event_report(&id, event_report.clone());
+                    _ = display.add_event_report(id, event_report.clone());
                 }
 
                 // Print out status for each component ID at the end -- do it here so
@@ -531,7 +531,7 @@ impl ReplayStrategy {
 
                         // If display.add_event_report errors out, it's for a report for a
                         // component we weren't interested in. Ignore it.
-                        _ = display.add_event_report(&id, report);
+                        _ = display.add_event_report(id, report);
 
                         display.write_events()?;
                     }
@@ -546,7 +546,7 @@ impl ReplayStrategy {
 
                         // If display.add_event_report errors out, it's for a report for a
                         // component we weren't interested in. Ignore it.
-                        _ = display.add_event_report(&id, report);
+                        _ = display.add_event_report(id, report);
 
                         display.write_events()?;
                     }

--- a/wicket/src/ui/panes/update.rs
+++ b/wicket/src/ui/panes/update.rs
@@ -344,7 +344,7 @@ impl UpdatePane {
                     body.lines.push(Line::default());
                     let prefix =
                         vec![Span::styled("Message: ", style::selected())];
-                    push_text_lines(&message, prefix, &mut body.lines);
+                    push_text_lines(message, prefix, &mut body.lines);
                 }
             }
             StepStatus::Completed { reason: _ } => {
@@ -2632,7 +2632,7 @@ impl Control for UpdatePane {
                             scroll_offset,
                         } => Some(self.draw_start_update_failed_popup(
                             state,
-                            &message,
+                            message,
                             frame,
                             *scroll_offset,
                         )),
@@ -2655,7 +2655,7 @@ impl Control for UpdatePane {
                             scroll_offset,
                         } => Some(self.draw_abort_update_failed_popup(
                             state,
-                            &message,
+                            message,
                             frame,
                             *scroll_offset,
                         )),

--- a/wicket/src/ui/wrap.rs
+++ b/wicket/src/ui/wrap.rs
@@ -103,7 +103,7 @@ fn wrap_single_line_slow_path<'a>(
         options.width.saturating_sub(options.subsequent_indent.width());
     let line_widths = [initial_width, subsequent_width];
 
-    let split_words = find_words_in_line(&line);
+    let split_words = find_words_in_line(line);
 
     // We don't perform any word splitting.
     let broken_words = if options.break_words {

--- a/wicketd/src/artifacts/store.rs
+++ b/wicketd/src/artifacts/store.rs
@@ -51,7 +51,7 @@ impl WicketdArtifactStore {
             .map(|(k, v)| InstallableArtifacts {
                 artifact_id: k.clone(),
                 installable: v.clone(),
-                sign: artifacts.rot_by_sign().get(&k).cloned(),
+                sign: artifacts.rot_by_sign().get(k).cloned(),
             })
             .collect();
         Some((system_version, artifact_ids))

--- a/wicketd/src/update_tracker.rs
+++ b/wicketd/src/update_tracker.rs
@@ -470,13 +470,13 @@ impl SpawnUpdateDriver for RealSpawnUpdateDriver<'_> {
                     prev.task.abort();
                     *prev = self
                         .update_tracker
-                        .spawn_upload_trampoline_phase_2_to_mgs(&plan);
+                        .spawn_upload_trampoline_phase_2_to_mgs(plan);
                 }
             }
             None => {
                 *upload_trampoline_phase_2_to_mgs = Some(
                     self.update_tracker
-                        .spawn_upload_trampoline_phase_2_to_mgs(&plan),
+                        .spawn_upload_trampoline_phase_2_to_mgs(plan),
                 );
             }
         }

--- a/zone-setup/src/switch_zone_user.rs
+++ b/zone-setup/src/switch_zone_user.rs
@@ -51,16 +51,14 @@ impl SwitchZoneUser {
 
     fn add_new_group_for_user(&self) -> Result<(), ExecutionError> {
         if get_group_by_name(&self.group).is_none() {
-            execute(
-                &mut std::process::Command::new("groupadd").arg(&self.group),
-            )?;
+            execute(std::process::Command::new("groupadd").arg(&self.group))?;
         }
         Ok(())
     }
 
     fn add_new_user(&self) -> Result<(), ExecutionError> {
         if get_user_by_name(&self.user).is_none() {
-            execute(&mut std::process::Command::new("useradd").args([
+            execute(std::process::Command::new("useradd").args([
                 "-m",
                 "-s",
                 &self.shell,
@@ -75,16 +73,12 @@ impl SwitchZoneUser {
     }
 
     fn enable_passwordless_login(&self) -> Result<(), ExecutionError> {
-        execute(
-            &mut std::process::Command::new("passwd").args(["-d", &self.user]),
-        )?;
+        execute(std::process::Command::new("passwd").args(["-d", &self.user]))?;
         Ok(())
     }
 
     fn disable_password_based_login(&self) -> Result<(), ExecutionError> {
-        execute(
-            &mut std::process::Command::new("passwd").args(["-N", &self.user]),
-        )?;
+        execute(std::process::Command::new("passwd").args(["-N", &self.user]))?;
         Ok(())
     }
 
@@ -92,7 +86,7 @@ impl SwitchZoneUser {
         let profiles = self.profiles.join(",");
 
         execute(
-            &mut std::process::Command::new("usermod")
+            std::process::Command::new("usermod")
                 .args(["-P", &profiles, &self.user]),
         )?;
         Ok(())
@@ -121,7 +115,7 @@ impl SwitchZoneUser {
 
         // Not using std::os::unix::fs::chown here because it doesn't support
         // recursive option.
-        execute(&mut std::process::Command::new("chown").args([
+        execute(std::process::Command::new("chown").args([
             "-R",
             &self.user,
             homedir.as_str(),


### PR DESCRIPTION
The needless_borrow lint in particular seems to have many hits, and I think turning it on is an improvement.

I'd like to turn some more lints on in the future, but this is a big enough change that it should probably stand alone.

This PR is mostly automatically generated:

1. Enable the lints in `Cargo.toml`
2. Run `cargo clippy --fix --all-targets --workspace && cargo fmt` on illumos and linux
3. Manually fix up a few cases that `clippy --fix` left incomplete.

TODO:

- [ ] Add to `.git-blame-ignore-revs` once this PR lands.
