### PR TITLE
move guts of reconfigurator-cli into separate package

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -7520,6 +7520,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "omicron-repl-utils"
+version = "0.1.0"
+dependencies = [
+ "anyhow",
+ "camino",
+ "clap",
+ "omicron-workspace-hack",
+ "reedline",
+]
+
+[[package]]
 name = "omicron-repo-depot-standalone"
 version = "0.1.0"
 dependencies = [
@@ -9996,12 +10007,12 @@ dependencies = [
  "nexus-sled-agent-shared",
  "nexus-types",
  "omicron-common",
+ "omicron-repl-utils",
  "omicron-rpaths",
  "omicron-test-utils",
  "omicron-uuid-kinds",
  "omicron-workspace-hack",
  "pq-sys",
- "reedline",
  "semver 1.0.25",
  "serde",
  "serde_json",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -7843,6 +7843,7 @@ dependencies = [
  "smallvec 1.14.0",
  "spin",
  "string_cache",
+ "strum",
  "subtle",
  "syn 1.0.109",
  "syn 2.0.98",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -45,6 +45,7 @@ members = [
     "dev-tools/reconfigurator-cli",
     "dev-tools/reconfigurator-exec-unsafe",
     "dev-tools/releng",
+    "dev-tools/repl-utils",
     "dev-tools/repo-depot-standalone",
     "dev-tools/xtask",
     "dns-server",
@@ -186,6 +187,7 @@ default-members = [
     "dev-tools/reconfigurator-cli",
     "dev-tools/reconfigurator-exec-unsafe",
     "dev-tools/releng",
+    "dev-tools/repl-utils",
     "dev-tools/repo-depot-standalone",
     # Do not include xtask in the list of default members, because this causes
     # hakari to not work as well and build times to be longer.
@@ -523,6 +525,7 @@ omicron-omdb = { path = "dev-tools/omdb" }
 omicron-package = { path = "package" }
 omicron-passwords = { path = "passwords" }
 omicron-pins = { path = "dev-tools/pins" }
+omicron-repl-utils = { path = "dev-tools/repl-utils" }
 omicron-rpaths = { path = "rpaths" }
 omicron-sled-agent = { path = "sled-agent" }
 omicron-test-utils = { path = "test-utils" }

--- a/dev-tools/reconfigurator-cli/Cargo.toml
+++ b/dev-tools/reconfigurator-cli/Cargo.toml
@@ -28,10 +28,10 @@ nexus-reconfigurator-simulation.workspace = true
 nexus-sled-agent-shared.workspace = true
 nexus-types.workspace = true
 omicron-common.workspace = true
+omicron-repl-utils.workspace = true
 omicron-uuid-kinds.workspace = true
 # See omicron-rpaths for more about the "pq-sys" dependency.
 pq-sys = "*"
-reedline.workspace = true
 semver.workspace = true
 serde_json.workspace = true
 slog-error-chain.workspace = true

--- a/dev-tools/repl-utils/Cargo.toml
+++ b/dev-tools/repl-utils/Cargo.toml
@@ -1,0 +1,15 @@
+[package]
+name = "omicron-repl-utils"
+version = "0.1.0"
+edition = "2021"
+license = "MPL-2.0"
+
+[lints]
+workspace = true
+
+[dependencies]
+anyhow.workspace = true
+camino.workspace = true
+clap.workspace = true
+reedline.workspace = true
+omicron-workspace-hack.workspace = true

--- a/dev-tools/repl-utils/src/lib.rs
+++ b/dev-tools/repl-utils/src/lib.rs
@@ -38,7 +38,7 @@ pub fn run_repl_from_file<C: Parser>(
             LoopResult::Continue => (),
             LoopResult::Bail(error) => return Err(error),
         }
-        println!("");
+        println!();
     }
     Ok(())
 }

--- a/dev-tools/repl-utils/src/lib.rs
+++ b/dev-tools/repl-utils/src/lib.rs
@@ -1,0 +1,157 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at https://mozilla.org/MPL/2.0/.
+
+//! helpers for running a REPL with reedline
+
+use anyhow::Context;
+use anyhow::anyhow;
+use anyhow::bail;
+use camino::Utf8Path;
+use clap::Parser;
+use reedline::Reedline;
+use reedline::Signal;
+use std::fs::File;
+use std::io::BufRead;
+use std::io::BufReader;
+
+/// Runs the same kind of REPL as `run_repl_on_stdin()`, but reads commands from
+/// a file
+///
+/// Commands are printed to stdout before being executed.
+///
+/// This is useful for expectorate tests.  You can define a file of input
+/// commands and check it against known output.  The output has the commands in
+/// it so that it's easier to verify.
+pub fn run_repl_from_file<C: Parser>(
+    input_file: &Utf8Path,
+    run_one: &mut dyn FnMut(C) -> anyhow::Result<Option<String>>,
+) -> anyhow::Result<()> {
+    let file = File::open(&input_file)
+        .with_context(|| format!("open {:?}", &input_file))?;
+    let bufread = BufReader::new(file);
+    for maybe_buffer in bufread.lines() {
+        let buffer =
+            maybe_buffer.with_context(|| format!("read {:?}", &input_file))?;
+        println!("> {}", buffer);
+        match process_entry(buffer, run_one) {
+            LoopResult::Continue => (),
+            LoopResult::Bail(error) => return Err(error),
+        }
+        println!("");
+    }
+    Ok(())
+}
+
+/// Runs a REPL using stdin/stdout
+///
+/// Behavior:
+///
+/// - Each line is treated as a command.  It's parsed as a `C`, which is of type
+///   `clap::Parser`.  In other words: you use `clap` to define the commands
+///   supported in your REPL.
+/// - On failure to parse each line as a `C` command, a usage message is
+///   printed.
+/// - '#' is a comment character.  In each line, the first '#' and any
+///   subsequent characters are ignored.
+/// - `run_one` is invoked for each successfully parsed command.
+///   - On success with `Some(string)`, the string is printed, followed by a
+///     newline.
+///   - On success with `None`, nothing is printed.
+///   - On failure, the error and its cause chain are printed.
+///
+/// Limitations:
+///
+/// - Arguments are currently split on whitespace, so commands, options, and
+///   arguments cannot have whitespace in them.
+pub fn run_repl_on_stdin<C: Parser>(
+    run_one: &mut dyn FnMut(C) -> anyhow::Result<Option<String>>,
+) -> anyhow::Result<()> {
+    let mut ed = Reedline::create();
+    let prompt = reedline::DefaultPrompt::new(
+        reedline::DefaultPromptSegment::Empty,
+        reedline::DefaultPromptSegment::Empty,
+    );
+    loop {
+        match ed.read_line(&prompt) {
+            Ok(Signal::Success(buffer)) => match process_entry(buffer, run_one)
+            {
+                LoopResult::Continue => (),
+                LoopResult::Bail(error) => return Err(error),
+            },
+            Ok(Signal::CtrlD) | Ok(Signal::CtrlC) => break,
+            Err(error) => {
+                bail!("unexpected error: {:#}", error);
+            }
+        }
+    }
+
+    Ok(())
+}
+
+fn process_entry<C: Parser>(
+    entry: String,
+    run_one: &mut dyn FnMut(C) -> anyhow::Result<Option<String>>,
+) -> LoopResult {
+    // Strip everything after '#' as a comment.
+    let entry = match entry.split_once('#') {
+        Some((real, _comment)) => real,
+        None => &entry,
+    };
+
+    // If no input was provided, take another lap (print the prompt and accept
+    // another line).  This gets handled specially because otherwise clap would
+    // treat this as a usage error and print a help message, which isn't what we
+    // want here.
+    if entry.trim().is_empty() {
+        return LoopResult::Continue;
+    }
+
+    // Parse the line of input as a REPL command.
+    //
+    // Using `split_whitespace()` like this is going to be a problem if we ever
+    // want to support arguments with whitespace in them (using quotes).  But
+    // it's good enough for now.
+    let parts = entry.split_whitespace();
+    let parsed_command = C::command()
+        .multicall(true)
+        .try_get_matches_from(parts)
+        .and_then(|matches| C::from_arg_matches(&matches));
+    let command = match parsed_command {
+        Err(error) => {
+            // We failed to parse the command.  Print the error.
+            return match error.print() {
+                // Assuming that worked, just take another lap.
+                Ok(_) => LoopResult::Continue,
+                // If we failed to even print the error, that itself is a fatal
+                // error.
+                Err(error) => LoopResult::Bail(
+                    anyhow!(error).context("printing previous error"),
+                ),
+            };
+        }
+        Ok(cmd) => cmd,
+    };
+
+    match run_one(command) {
+        Err(error) => println!("error: {:#}", error),
+        Ok(Some(s)) => println!("{}", s),
+        Ok(None) => (),
+    }
+
+    LoopResult::Continue
+}
+
+/// Describes next steps after evaluating one "line" of user input
+///
+/// This could just be `Result`, but it's easy to misuse that here because
+/// _commands_ might fail all the time without needing to bail out of the REPL.
+/// We use a separate type for clarity about what success/failure actually
+/// means.
+enum LoopResult {
+    /// Show the prompt and accept another command
+    Continue,
+
+    /// Exit the REPL with a fatal error
+    Bail(anyhow::Error),
+}

--- a/workspace-hack/Cargo.toml
+++ b/workspace-hack/Cargo.toml
@@ -116,6 +116,7 @@ slog = { version = "2.7.0", features = ["dynamic-keys", "max_level_trace", "rele
 smallvec = { version = "1.14.0", default-features = false, features = ["const_new"] }
 spin = { version = "0.9.8" }
 string_cache = { version = "0.8.9" }
+strum = { version = "0.26.3", features = ["derive"] }
 subtle = { version = "2.6.1" }
 syn-f595c2ba2a3f28df = { package = "syn", version = "2.0.98", features = ["extra-traits", "fold", "full", "visit", "visit-mut"] }
 time = { version = "0.3.36", features = ["formatting", "local-offset", "macros", "parsing"] }
@@ -237,6 +238,7 @@ slog = { version = "2.7.0", features = ["dynamic-keys", "max_level_trace", "rele
 smallvec = { version = "1.14.0", default-features = false, features = ["const_new"] }
 spin = { version = "0.9.8" }
 string_cache = { version = "0.8.9" }
+strum = { version = "0.26.3", features = ["derive"] }
 subtle = { version = "2.6.1" }
 syn-dff4ba8e3ae991db = { package = "syn", version = "1.0.109", features = ["extra-traits", "fold", "full", "visit"] }
 syn-f595c2ba2a3f28df = { package = "syn", version = "2.0.98", features = ["extra-traits", "fold", "full", "visit", "visit-mut"] }


### PR DESCRIPTION
I want to re-use this code in a new dev tool that also has a REPL.

I went for minimal changes to the existing structure here.