### PR TITLE
Reduce regions_hard_delete contention

### DIFF
--- a/nexus/db-queries/src/db/queries/mod.rs
+++ b/nexus/db-queries/src/db/queries/mod.rs
@@ -13,6 +13,7 @@ mod next_item;
 pub mod network_interface;
 pub mod oximeter;
 pub mod region_allocation;
+pub mod regions_hard_delete;
 pub mod sled_reservation;
 pub mod virtual_provisioning_collection_update;
 pub mod vpc;

--- a/nexus/db-queries/src/db/queries/regions_hard_delete.rs
+++ b/nexus/db-queries/src/db/queries/regions_hard_delete.rs
@@ -1,0 +1,60 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at https://mozilla.org/MPL/2.0/.
+
+//! Implementation of query to update crucible_dataset size_used after
+//! hard-deleting regions
+
+use crate::db::datastore::RunnableQueryNoReturn;
+use crate::db::raw_query_builder::QueryBuilder;
+use diesel::sql_types;
+use uuid::Uuid;
+
+/// Update the affected Crucible dataset rows after hard-deleting regions
+pub fn dataset_update_query(
+    dataset_ids: Vec<Uuid>,
+) -> impl RunnableQueryNoReturn {
+    let mut builder = QueryBuilder::new();
+
+    builder.sql(
+        "WITH
+  size_used_with_reservation AS (
+    SELECT
+      crucible_dataset.id AS crucible_dataset_id,
+      SUM(
+        CASE
+          WHEN block_size IS NULL THEN 0
+          ELSE
+            CASE
+              WHEN reservation_percent = '25' THEN
+                (block_size * blocks_per_extent * extent_count) / 4 +
+                (block_size * blocks_per_extent * extent_count)
+            END
+        END
+      ) AS reserved_size
+    FROM crucible_dataset
+    LEFT JOIN region ON crucible_dataset.id = region.dataset_id
+    WHERE
+      crucible_dataset.time_deleted IS NULL AND
+      crucible_dataset.id IN (",
+    );
+
+    for (idx, dataset_id) in dataset_ids.into_iter().enumerate() {
+        if idx != 0 {
+            builder.sql(",");
+        }
+        builder.param().bind::<sql_types::Uuid, _>(dataset_id);
+    }
+
+    builder.sql(
+        ")
+    GROUP BY crucible_dataset.id
+  )
+  UPDATE crucible_dataset
+  SET size_used = size_used_with_reservation.reserved_size
+  FROM size_used_with_reservation
+  WHERE crucible_dataset.id = size_used_with_reservation.crucible_dataset_id",
+    );
+
+    builder.query::<()>()
+}

--- a/nexus/db-queries/src/db/queries/regions_hard_delete.rs
+++ b/nexus/db-queries/src/db/queries/regions_hard_delete.rs
@@ -36,15 +36,10 @@ pub fn dataset_update_query(
     LEFT JOIN region ON crucible_dataset.id = region.dataset_id
     WHERE
       crucible_dataset.time_deleted IS NULL AND
-      crucible_dataset.id IN (",
+      crucible_dataset.id = ANY (",
     );
 
-    for (idx, dataset_id) in dataset_ids.into_iter().enumerate() {
-        if idx != 0 {
-            builder.sql(",");
-        }
-        builder.param().bind::<sql_types::Uuid, _>(dataset_id);
-    }
+    builder.param().bind::<sql_types::Array<sql_types::Uuid>, _>(dataset_ids);
 
     builder.sql(
         ")

--- a/nexus/db-queries/tests/output/dataset_update_query.sql
+++ b/nexus/db-queries/tests/output/dataset_update_query.sql
@@ -17,7 +17,7 @@ WITH
       FROM
         crucible_dataset LEFT JOIN region ON crucible_dataset.id = region.dataset_id
       WHERE
-        crucible_dataset.time_deleted IS NULL AND crucible_dataset.id IN ($1, $2, $3)
+        crucible_dataset.time_deleted IS NULL AND crucible_dataset.id = ANY ($1)
       GROUP BY
         crucible_dataset.id
     )

--- a/nexus/db-queries/tests/output/dataset_update_query.sql
+++ b/nexus/db-queries/tests/output/dataset_update_query.sql
@@ -1,0 +1,31 @@
+WITH
+  size_used_with_reservation
+    AS (
+      SELECT
+        crucible_dataset.id AS crucible_dataset_id,
+        sum(
+          CASE
+          WHEN block_size IS NULL THEN 0
+          ELSE CASE
+          WHEN reservation_percent = '25'
+          THEN block_size * blocks_per_extent * extent_count / 4
+          + block_size * blocks_per_extent * extent_count
+          END
+          END
+        )
+          AS reserved_size
+      FROM
+        crucible_dataset LEFT JOIN region ON crucible_dataset.id = region.dataset_id
+      WHERE
+        crucible_dataset.time_deleted IS NULL AND crucible_dataset.id IN ($1, $2, $3)
+      GROUP BY
+        crucible_dataset.id
+    )
+UPDATE
+  crucible_dataset
+SET
+  size_used = size_used_with_reservation.reserved_size
+FROM
+  size_used_with_reservation
+WHERE
+  crucible_dataset.id = size_used_with_reservation.crucible_dataset_id


### PR DESCRIPTION
Recently, regions_hard_delete changed to use a CTE to update the size_used column of the crucible_dataset table. Unfortunately this had the side effect of causing a massive amount of contention: the CTE would

1) delete rows from the regions table
2) read from the regions table during the CTE
3) update the size_used column for _all_ crucible_dataset rows

This would almost certainly cause each invocation of the CTE to contend with each other, as seen when doing disk deletes in parallel.

This commit changes the CTE to:

1) delete rows from the regions table, returning the affected datasets
2) read from the regions table during the CTE
3) update the size_used column for affected crucible_dataset rows only.

This was tested by using terraform to create and tear down 90 disks, with a parallelism setting of 10, 20, and 30. Before this change, this would not work as Nexus would inevitably return 500s.

Fixes #7952