### PR TITLE
use daft and more in more update-related types

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3540,6 +3540,7 @@ version = "0.1.0"
 dependencies = [
  "base64 0.22.1",
  "chrono",
+ "daft",
  "gateway-messages",
  "omicron-workspace-hack",
  "progenitor 0.9.1",

--- a/clients/gateway-client/Cargo.toml
+++ b/clients/gateway-client/Cargo.toml
@@ -10,6 +10,7 @@ workspace = true
 [dependencies]
 base64.workspace = true
 chrono.workspace = true
+daft.workspace = true
 gateway-messages.workspace = true
 progenitor.workspace = true
 rand.workspace = true

--- a/clients/gateway-client/src/lib.rs
+++ b/clients/gateway-client/src/lib.rs
@@ -69,6 +69,9 @@ progenitor::generate_api!(
         SpIgnition = { derives = [PartialEq, Eq, PartialOrd, Ord] },
         SpIgnitionSystemType = { derives = [Copy, PartialEq, Eq, PartialOrd, Ord] },
         SpState = { derives = [PartialEq, Eq, PartialOrd, Ord] },
+        SpType = { derives = [daft::Diffable] },
+        SpUpdateStatus = { derives = [PartialEq, Hash, Eq] },
+        UpdatePreparationProgress = { derives = [PartialEq, Hash, Eq] },
     },
 );
 

--- a/common/src/update.rs
+++ b/common/src/update.rs
@@ -4,6 +4,7 @@
 
 use std::fmt;
 
+use daft::Diffable;
 use schemars::JsonSchema;
 use serde::{Deserialize, Serialize};
 use tufaceous_artifact::{Artifact, ArtifactKind, ArtifactVersion};
@@ -15,6 +16,7 @@ use tufaceous_artifact::{Artifact, ArtifactKind, ArtifactVersion};
 // TODO: move this to tufaceous-artifact in the future
 #[derive(
     Debug,
+    Diffable,
     Clone,
     PartialEq,
     Eq,


### PR DESCRIPTION
Adding daft and some other common derives on a few update-related types.  This is a prerequisite for putting SP/RoT-update-related types into the blueprint (which will be coming in a follow-on PR).