### PR TITLE
[nexus] Allow null anti_affinity_groups during instance creation

### DIFF
--- a/end-to-end-tests/src/instance_launch.rs
+++ b/end-to-end-tests/src/instance_launch.rs
@@ -78,7 +78,7 @@ async fn instance_launch() -> Result<()> {
             )]),
             start: true,
             auto_restart_policy: Default::default(),
-            anti_affinity_groups: Vec::new(),
+            anti_affinity_groups: None,
         })
         .send()
         .await?;

--- a/nexus/db-queries/src/db/datastore/instance.rs
+++ b/nexus/db-queries/src/db/datastore/instance.rs
@@ -2187,7 +2187,7 @@ mod tests {
                         ssh_public_keys: None,
                         start: false,
                         auto_restart_policy: Default::default(),
-                        anti_affinity_groups: Vec::new(),
+                        anti_affinity_groups: None,
                     },
                 ),
             )

--- a/nexus/db-queries/src/db/datastore/migration.rs
+++ b/nexus/db-queries/src/db/datastore/migration.rs
@@ -238,7 +238,7 @@ mod tests {
                         ssh_public_keys: None,
                         start: false,
                         auto_restart_policy: Default::default(),
-                        anti_affinity_groups: Vec::new(),
+                        anti_affinity_groups: None,
                     },
                 ),
             )

--- a/nexus/db-queries/src/db/datastore/virtual_provisioning_collection.rs
+++ b/nexus/db-queries/src/db/datastore/virtual_provisioning_collection.rs
@@ -458,7 +458,7 @@ mod test {
                         ssh_public_keys: None,
                         start: false,
                         auto_restart_policy: Default::default(),
-                        anti_affinity_groups: Vec::new(),
+                        anti_affinity_groups: None,
                     },
                 ),
             )

--- a/nexus/db-queries/src/db/datastore/vpc.rs
+++ b/nexus/db-queries/src/db/datastore/vpc.rs
@@ -3877,7 +3877,7 @@ mod tests {
                         ssh_public_keys: None,
                         start: false,
                         auto_restart_policy: Default::default(),
-                        anti_affinity_groups: Vec::new(),
+                        anti_affinity_groups: None,
                     },
                 ),
             )

--- a/nexus/db-queries/src/db/pub_test_utils/helpers.rs
+++ b/nexus/db-queries/src/db/pub_test_utils/helpers.rs
@@ -222,7 +222,7 @@ pub async fn create_stopped_instance_record(
             ssh_public_keys: None,
             start: false,
             auto_restart_policy: Default::default(),
-            anti_affinity_groups: Vec::new(),
+            anti_affinity_groups: None,
         },
     );
 

--- a/nexus/db-queries/src/db/queries/external_ip.rs
+++ b/nexus/db-queries/src/db/queries/external_ip.rs
@@ -1004,7 +1004,7 @@ mod tests {
                 boot_disk: None,
                 start: false,
                 auto_restart_policy: Default::default(),
-                anti_affinity_groups: Vec::new(),
+                anti_affinity_groups: None,
             });
 
             let conn = self

--- a/nexus/db-queries/src/db/queries/network_interface.rs
+++ b/nexus/db-queries/src/db/queries/network_interface.rs
@@ -1888,7 +1888,7 @@ mod tests {
             boot_disk: None,
             start: true,
             auto_restart_policy: Default::default(),
-            anti_affinity_groups: Vec::new(),
+            anti_affinity_groups: None,
         };
 
         let instance = Instance::new(instance_id, project_id, &params);

--- a/nexus/src/app/background/tasks/instance_reincarnation.rs
+++ b/nexus/src/app/background/tasks/instance_reincarnation.rs
@@ -387,7 +387,7 @@ mod test {
                     ssh_public_keys: None,
                     start: state == InstanceState::Vmm,
                     auto_restart_policy,
-                    anti_affinity_groups: Vec::new(),
+                    anti_affinity_groups: None,
                 },
             )
             .await;

--- a/nexus/src/app/instance.rs
+++ b/nexus/src/app/instance.rs
@@ -478,11 +478,15 @@ impl super::Nexus {
         )
         .await?;
 
+        let groups = match params.anti_affinity_groups.as_ref() {
+            Some(groups) => groups,
+            None => &Vec::new(),
+        };
         let anti_affinity_groups = normalize_anti_affinity_groups(
             &self.db_datastore,
             opctx,
             &authz_project,
-            &params.anti_affinity_groups,
+            groups,
         )
         .await?;
 
@@ -499,7 +503,7 @@ impl super::Nexus {
             project_id: authz_project.id(),
             create_params: params::InstanceCreate {
                 ssh_public_keys: ssh_keys,
-                anti_affinity_groups,
+                anti_affinity_groups: Some(anti_affinity_groups),
                 ..params.clone()
             },
             boundary_switches: self
@@ -2490,7 +2494,7 @@ mod tests {
             ssh_public_keys: None,
             start: false,
             auto_restart_policy: Default::default(),
-            anti_affinity_groups: Vec::new(),
+            anti_affinity_groups: None,
         };
 
         let instance_id = InstanceUuid::from_untyped_uuid(Uuid::new_v4());

--- a/nexus/src/app/sagas/instance_create.rs
+++ b/nexus/src/app/sagas/instance_create.rs
@@ -187,9 +187,12 @@ impl NexusSaga for SagaInstanceCreate {
             Ok(())
         }
 
-        for (i, group) in
-            params.create_params.anti_affinity_groups.iter().enumerate()
+        let aa_groups = match params.create_params.anti_affinity_groups.as_ref()
         {
+            Some(groups) => groups,
+            None => &Vec::new(),
+        };
+        for (i, group) in aa_groups.iter().enumerate() {
             let group = match group {
                 NameOrId::Id(id) => {
                     AntiAffinityGroupUuid::from_untyped_uuid(*id)
@@ -1298,7 +1301,7 @@ pub mod test {
                 disks: Vec::new(),
                 start: false,
                 auto_restart_policy: Default::default(),
-                anti_affinity_groups: Vec::new(),
+                anti_affinity_groups: None,
             },
             boundary_switches: HashSet::from([SwitchLocation::Switch0]),
         }

--- a/nexus/src/app/sagas/instance_delete.rs
+++ b/nexus/src/app/sagas/instance_delete.rs
@@ -240,7 +240,7 @@ mod test {
             disks: Vec::new(),
             start: false,
             auto_restart_policy: Default::default(),
-            anti_affinity_groups: Vec::new(),
+            anti_affinity_groups: None,
         }
     }
 

--- a/nexus/src/app/sagas/instance_migrate.rs
+++ b/nexus/src/app/sagas/instance_migrate.rs
@@ -613,7 +613,7 @@ mod tests {
                 boot_disk: None,
                 start: true,
                 auto_restart_policy: Default::default(),
-                anti_affinity_groups: Vec::new(),
+                anti_affinity_groups: None,
             },
         )
         .await

--- a/nexus/src/app/sagas/instance_start.rs
+++ b/nexus/src/app/sagas/instance_start.rs
@@ -844,7 +844,7 @@ mod test {
                 boot_disk: None,
                 start: false,
                 auto_restart_policy: Default::default(),
-                anti_affinity_groups: Vec::new(),
+                anti_affinity_groups: None,
             },
         )
         .await

--- a/nexus/src/app/sagas/instance_update/mod.rs
+++ b/nexus/src/app/sagas/instance_update/mod.rs
@@ -1553,7 +1553,7 @@ mod test {
                 boot_disk: None,
                 start: true,
                 auto_restart_policy: Default::default(),
-                anti_affinity_groups: Vec::new(),
+                anti_affinity_groups: None,
             },
         )
         .await

--- a/nexus/src/app/sagas/snapshot_create.rs
+++ b/nexus/src/app/sagas/snapshot_create.rs
@@ -2174,7 +2174,7 @@ mod test {
                 external_ips: vec![],
                 start: true,
                 auto_restart_policy: Default::default(),
-                anti_affinity_groups: Vec::new(),
+                anti_affinity_groups: None,
             },
         )
         .await;

--- a/nexus/test-utils/src/resource_helpers.rs
+++ b/nexus/test-utils/src/resource_helpers.rs
@@ -563,7 +563,7 @@ pub async fn create_instance_with(
             boot_disk: None,
             start,
             auto_restart_policy,
-            anti_affinity_groups: Vec::new(),
+            anti_affinity_groups: None,
         },
     )
     .await

--- a/nexus/tests/integration_tests/endpoints.rs
+++ b/nexus/tests/integration_tests/endpoints.rs
@@ -655,7 +655,7 @@ pub static DEMO_INSTANCE_CREATE: LazyLock<params::InstanceCreate> =
         boot_disk: None,
         start: true,
         auto_restart_policy: Default::default(),
-        anti_affinity_groups: Vec::new(),
+        anti_affinity_groups: None,
     });
 pub static DEMO_STOPPED_INSTANCE_CREATE: LazyLock<params::InstanceCreate> =
     LazyLock::new(|| params::InstanceCreate {
@@ -676,7 +676,7 @@ pub static DEMO_STOPPED_INSTANCE_CREATE: LazyLock<params::InstanceCreate> =
         boot_disk: None,
         start: true,
         auto_restart_policy: Default::default(),
-        anti_affinity_groups: Vec::new(),
+        anti_affinity_groups: None,
     });
 pub static DEMO_INSTANCE_UPDATE: LazyLock<params::InstanceUpdate> =
     LazyLock::new(|| params::InstanceUpdate {

--- a/nexus/tests/integration_tests/external_ips.rs
+++ b/nexus/tests/integration_tests/external_ips.rs
@@ -1007,7 +1007,7 @@ async fn test_floating_ip_attach_fail_between_projects(
             boot_disk: None,
             start: true,
             auto_restart_policy: Default::default(),
-            anti_affinity_groups: Vec::new(),
+            anti_affinity_groups: None,
         },
         StatusCode::BAD_REQUEST,
     )

--- a/nexus/tests/integration_tests/instances.rs
+++ b/nexus/tests/integration_tests/instances.rs
@@ -235,7 +235,7 @@ async fn test_create_instance_with_bad_hostname_impl(
         start: false,
         ssh_public_keys: None,
         auto_restart_policy: Default::default(),
-        anti_affinity_groups: Vec::new(),
+        anti_affinity_groups: None,
     };
     let mut body: serde_json::Value =
         serde_json::from_str(&serde_json::to_string(&params).unwrap()).unwrap();
@@ -342,7 +342,7 @@ async fn test_instances_create_reboot_halt(
                 boot_disk: None,
                 start: true,
                 auto_restart_policy: Default::default(),
-                anti_affinity_groups: Vec::new(),
+                anti_affinity_groups: None,
             }))
             .expect_status(Some(StatusCode::BAD_REQUEST)),
     )
@@ -1896,7 +1896,7 @@ async fn test_instances_create_stopped_start(
             boot_disk: None,
             start: false,
             auto_restart_policy: Default::default(),
-            anti_affinity_groups: Vec::new(),
+            anti_affinity_groups: None,
         },
     )
     .await;
@@ -2080,7 +2080,7 @@ async fn test_instance_using_image_from_other_project_fails(
                 boot_disk: None,
                 start: true,
                 auto_restart_policy: Default::default(),
-                anti_affinity_groups: Vec::new(),
+                anti_affinity_groups: None,
             }))
             .expect_status(Some(StatusCode::BAD_REQUEST)),
     )
@@ -2146,7 +2146,7 @@ async fn test_instance_create_saga_removes_instance_database_record(
         boot_disk: None,
         start: true,
         auto_restart_policy: Default::default(),
-        anti_affinity_groups: Vec::new(),
+        anti_affinity_groups: None,
     };
     let response = NexusRequest::objects_post(
         client,
@@ -2177,7 +2177,7 @@ async fn test_instance_create_saga_removes_instance_database_record(
         boot_disk: None,
         start: true,
         auto_restart_policy: Default::default(),
-        anti_affinity_groups: Vec::new(),
+        anti_affinity_groups: None,
     };
     let _ = NexusRequest::objects_post(
         client,
@@ -2270,7 +2270,7 @@ async fn test_instance_with_single_explicit_ip_address(
         start: true,
 
         auto_restart_policy: Default::default(),
-        anti_affinity_groups: Vec::new(),
+        anti_affinity_groups: None,
     };
     let response = NexusRequest::objects_post(
         client,
@@ -2388,7 +2388,7 @@ async fn test_instance_with_new_custom_network_interfaces(
         boot_disk: None,
         start: true,
         auto_restart_policy: Default::default(),
-        anti_affinity_groups: Vec::new(),
+        anti_affinity_groups: None,
     };
     let response = NexusRequest::objects_post(
         client,
@@ -2506,7 +2506,7 @@ async fn test_instance_create_delete_network_interface(
         boot_disk: None,
         start: true,
         auto_restart_policy: Default::default(),
-        anti_affinity_groups: Vec::new(),
+        anti_affinity_groups: None,
     };
     let response = NexusRequest::objects_post(
         client,
@@ -2753,7 +2753,7 @@ async fn test_instance_update_network_interfaces(
         boot_disk: None,
         start: true,
         auto_restart_policy: Default::default(),
-        anti_affinity_groups: Vec::new(),
+        anti_affinity_groups: None,
     };
     let response = NexusRequest::objects_post(
         client,
@@ -3384,7 +3384,7 @@ async fn test_instance_with_multiple_nics_unwinds_completely(
         boot_disk: None,
         start: true,
         auto_restart_policy: Default::default(),
-        anti_affinity_groups: Vec::new(),
+        anti_affinity_groups: None,
     };
     let builder =
         RequestBuilder::new(client, http::Method::POST, &get_instances_url())
@@ -3457,7 +3457,7 @@ async fn test_attach_one_disk_to_instance(cptestctx: &ControlPlaneTestContext) {
         disks: Vec::new(),
         start: true,
         auto_restart_policy: Default::default(),
-        anti_affinity_groups: Vec::new(),
+        anti_affinity_groups: None,
     };
 
     let builder =
@@ -3548,7 +3548,7 @@ async fn test_instance_create_attach_disks(
         ],
         start: true,
         auto_restart_policy: Default::default(),
-        anti_affinity_groups: Vec::new(),
+        anti_affinity_groups: None,
     };
 
     let builder =
@@ -3646,7 +3646,7 @@ async fn test_instance_create_attach_disks_undo(
         boot_disk: None,
         start: true,
         auto_restart_policy: Default::default(),
-        anti_affinity_groups: Vec::new(),
+        anti_affinity_groups: None,
     };
 
     let builder =
@@ -3730,7 +3730,7 @@ async fn test_attach_eight_disks_to_instance(
             .collect(),
         start: true,
         auto_restart_policy: Default::default(),
-        anti_affinity_groups: Vec::new(),
+        anti_affinity_groups: None,
     };
 
     let builder =
@@ -3818,7 +3818,7 @@ async fn test_cannot_attach_nine_disks_to_instance(
             .collect(),
         start: true,
         auto_restart_policy: Default::default(),
-        anti_affinity_groups: Vec::new(),
+        anti_affinity_groups: None,
     };
 
     let url_instances = format!("/v1/instances?project={}", project_name);
@@ -3920,7 +3920,7 @@ async fn test_cannot_attach_faulted_disks(cptestctx: &ControlPlaneTestContext) {
             .collect(),
         start: true,
         auto_restart_policy: Default::default(),
-        anti_affinity_groups: Vec::new(),
+        anti_affinity_groups: None,
     };
 
     let builder =
@@ -4011,7 +4011,7 @@ async fn test_disks_detached_when_instance_destroyed(
             .collect(),
         start: true,
         auto_restart_policy: Default::default(),
-        anti_affinity_groups: Vec::new(),
+        anti_affinity_groups: None,
     };
 
     let builder =
@@ -4109,7 +4109,7 @@ async fn test_disks_detached_when_instance_destroyed(
             .collect(),
         start: true,
         auto_restart_policy: Default::default(),
-        anti_affinity_groups: Vec::new(),
+        anti_affinity_groups: None,
     };
 
     let builder =
@@ -4193,7 +4193,7 @@ async fn test_duplicate_disk_attach_requests_ok(
         boot_disk: None,
         start: true,
         auto_restart_policy: Default::default(),
-        anti_affinity_groups: Vec::new(),
+        anti_affinity_groups: None,
     };
 
     let builder =
@@ -4237,7 +4237,7 @@ async fn test_duplicate_disk_attach_requests_ok(
         )],
         start: true,
         auto_restart_policy: Default::default(),
-        anti_affinity_groups: Vec::new(),
+        anti_affinity_groups: None,
     };
 
     let builder =
@@ -4294,7 +4294,7 @@ async fn test_cannot_detach_boot_disk(cptestctx: &ControlPlaneTestContext) {
         disks: Vec::new(),
         start: false,
         auto_restart_policy: Default::default(),
-        anti_affinity_groups: Vec::new(),
+        anti_affinity_groups: None,
     };
 
     let builder =
@@ -4428,7 +4428,7 @@ async fn test_updating_running_instance_boot_disk_is_conflict(
         )),
         start: true,
         auto_restart_policy: Default::default(),
-        anti_affinity_groups: Vec::new(),
+        anti_affinity_groups: None,
     };
 
     let builder =
@@ -4590,7 +4590,7 @@ async fn test_size_can_be_changed(cptestctx: &ControlPlaneTestContext) {
         start: true,
         // Start out with None
         auto_restart_policy: None,
-        anti_affinity_groups: Vec::new(),
+        anti_affinity_groups: None,
     };
 
     let builder =
@@ -4797,7 +4797,7 @@ async fn test_auto_restart_policy_can_be_changed(
         start: true,
         // Start out with None
         auto_restart_policy: None,
-        anti_affinity_groups: Vec::new(),
+        anti_affinity_groups: None,
     };
 
     let builder =
@@ -4893,7 +4893,7 @@ async fn test_boot_disk_can_be_changed(cptestctx: &ControlPlaneTestContext) {
         )],
         start: false,
         auto_restart_policy: Default::default(),
-        anti_affinity_groups: Vec::new(),
+        anti_affinity_groups: None,
     };
 
     let builder =
@@ -4963,7 +4963,7 @@ async fn test_boot_disk_must_be_attached(cptestctx: &ControlPlaneTestContext) {
         boot_disk: None,
         start: false,
         auto_restart_policy: Default::default(),
-        anti_affinity_groups: Vec::new(),
+        anti_affinity_groups: None,
     };
 
     let builder =
@@ -5055,7 +5055,7 @@ async fn test_instances_memory_rejected_less_than_min_memory_size(
         boot_disk: None,
         start: true,
         auto_restart_policy: Default::default(),
-        anti_affinity_groups: Vec::new(),
+        anti_affinity_groups: None,
     };
 
     let error = NexusRequest::new(
@@ -5108,7 +5108,7 @@ async fn test_instances_memory_not_divisible_by_min_memory_size(
         boot_disk: None,
         start: true,
         auto_restart_policy: Default::default(),
-        anti_affinity_groups: Vec::new(),
+        anti_affinity_groups: None,
     };
 
     let error = NexusRequest::new(
@@ -5161,7 +5161,7 @@ async fn test_instances_memory_greater_than_max_size(
         boot_disk: None,
         start: true,
         auto_restart_policy: Default::default(),
-        anti_affinity_groups: Vec::new(),
+        anti_affinity_groups: None,
     };
 
     let error = NexusRequest::new(
@@ -5267,7 +5267,7 @@ async fn test_instance_create_with_anti_affinity_groups(
         disks: vec![],
         boot_disk: None,
         auto_restart_policy: Default::default(),
-        anti_affinity_groups: anti_affinity_groups_param,
+        anti_affinity_groups: Some(anti_affinity_groups_param),
     };
 
     let builder =
@@ -5336,7 +5336,7 @@ async fn test_instance_create_with_duplicate_anti_affinity_groups(
         disks: vec![],
         boot_disk: None,
         auto_restart_policy: Default::default(),
-        anti_affinity_groups: anti_affinity_groups_param,
+        anti_affinity_groups: Some(anti_affinity_groups_param),
     };
 
     let builder =
@@ -5406,7 +5406,7 @@ async fn test_instance_create_with_anti_affinity_groups_that_do_not_exist(
         disks: vec![],
         boot_disk: None,
         auto_restart_policy: Default::default(),
-        anti_affinity_groups: anti_affinity_groups_param,
+        anti_affinity_groups: Some(anti_affinity_groups_param),
     };
 
     let error = object_create_error(
@@ -5489,7 +5489,7 @@ async fn test_instance_create_with_ssh_keys(
         disks: vec![],
         boot_disk: None,
         auto_restart_policy: Default::default(),
-        anti_affinity_groups: Vec::new(),
+        anti_affinity_groups: None,
     };
 
     let builder =
@@ -5538,7 +5538,7 @@ async fn test_instance_create_with_ssh_keys(
         disks: vec![],
         boot_disk: None,
         auto_restart_policy: Default::default(),
-        anti_affinity_groups: Vec::new(),
+        anti_affinity_groups: None,
     };
 
     let builder =
@@ -5586,7 +5586,7 @@ async fn test_instance_create_with_ssh_keys(
         disks: vec![],
         boot_disk: None,
         auto_restart_policy: Default::default(),
-        anti_affinity_groups: Vec::new(),
+        anti_affinity_groups: None,
     };
 
     let builder =
@@ -5710,7 +5710,7 @@ async fn test_cannot_provision_instance_beyond_cpu_capacity(
             boot_disk: None,
             start: false,
             auto_restart_policy: Default::default(),
-            anti_affinity_groups: Vec::new(),
+            anti_affinity_groups: None,
         };
 
         let url_instances = get_instances_url();
@@ -5769,7 +5769,7 @@ async fn test_cannot_provision_instance_beyond_cpu_limit(
         boot_disk: None,
         start: false,
         auto_restart_policy: Default::default(),
-        anti_affinity_groups: Vec::new(),
+        anti_affinity_groups: None,
     };
     let url_instances = get_instances_url();
 
@@ -5825,7 +5825,7 @@ async fn test_cannot_provision_instance_beyond_ram_capacity(
             boot_disk: None,
             start: false,
             auto_restart_policy: Default::default(),
-            anti_affinity_groups: Vec::new(),
+            anti_affinity_groups: None,
         };
 
         let url_instances = get_instances_url();
@@ -6125,7 +6125,7 @@ async fn test_instance_ephemeral_ip_from_correct_pool(
         boot_disk: None,
         start: true,
         auto_restart_policy: Default::default(),
-        anti_affinity_groups: Vec::new(),
+        anti_affinity_groups: None,
     };
     let error = object_create_error(
         client,
@@ -6195,7 +6195,7 @@ async fn test_instance_ephemeral_ip_from_orphan_pool(
         boot_disk: None,
         start: true,
         auto_restart_policy: Default::default(),
-        anti_affinity_groups: Vec::new(),
+        anti_affinity_groups: None,
     };
 
     // instance create 404s
@@ -6259,7 +6259,7 @@ async fn test_instance_ephemeral_ip_no_default_pool_error(
         boot_disk: None,
         start: true,
         auto_restart_policy: Default::default(),
-        anti_affinity_groups: Vec::new(),
+        anti_affinity_groups: None,
     };
 
     let url = format!("/v1/instances?project={}", PROJECT_NAME);
@@ -6397,7 +6397,7 @@ async fn test_instance_allow_only_one_ephemeral_ip(
         boot_disk: None,
         start: true,
         auto_restart_policy: Default::default(),
-        anti_affinity_groups: Vec::new(),
+        anti_affinity_groups: None,
     };
     let error = object_create_error(
         client,
@@ -6531,7 +6531,7 @@ async fn test_instance_create_in_silo(cptestctx: &ControlPlaneTestContext) {
         boot_disk: None,
         start: true,
         auto_restart_policy: Default::default(),
-        anti_affinity_groups: Vec::new(),
+        anti_affinity_groups: None,
     };
     let url_instances = format!("/v1/instances?project={}", PROJECT_NAME);
     NexusRequest::objects_post(client, &url_instances, &instance_params)

--- a/nexus/tests/integration_tests/projects.rs
+++ b/nexus/tests/integration_tests/projects.rs
@@ -171,7 +171,7 @@ async fn test_project_deletion_with_instance(
             boot_disk: None,
             start: false,
             auto_restart_policy: Default::default(),
-            anti_affinity_groups: Vec::new(),
+            anti_affinity_groups: None,
         },
     )
     .await;

--- a/nexus/tests/integration_tests/quotas.rs
+++ b/nexus/tests/integration_tests/quotas.rs
@@ -89,7 +89,7 @@ impl ResourceAllocator {
                 boot_disk: None,
                 start: false,
                 auto_restart_policy: Default::default(),
-                anti_affinity_groups: Vec::new(),
+                anti_affinity_groups: None,
             },
         )
         .authn_as(self.auth.clone())

--- a/nexus/tests/integration_tests/schema.rs
+++ b/nexus/tests/integration_tests/schema.rs
@@ -1380,7 +1380,7 @@ fn at_current_101_0_0<'a>(ctx: &'a MigrationContext<'a>) -> BoxFuture<'a, ()> {
                         disks: Vec::new(),
                         start: false,
                         auto_restart_policy: Default::default(),
-                        anti_affinity_groups: Vec::new(),
+                        anti_affinity_groups: None,
                     },
                 ))
                 .execute_async(&*pool_and_conn.conn)

--- a/nexus/tests/integration_tests/snapshots.rs
+++ b/nexus/tests/integration_tests/snapshots.rs
@@ -149,7 +149,7 @@ async fn test_snapshot_basic(cptestctx: &ControlPlaneTestContext) {
             external_ips: vec![],
             start: true,
             auto_restart_policy: Default::default(),
-            anti_affinity_groups: Vec::new(),
+            anti_affinity_groups: None,
         },
     )
     .await;
@@ -355,7 +355,7 @@ async fn test_snapshot_stopped_instance(cptestctx: &ControlPlaneTestContext) {
             external_ips: vec![],
             start: false,
             auto_restart_policy: Default::default(),
-            anti_affinity_groups: Vec::new(),
+            anti_affinity_groups: None,
         },
     )
     .await;

--- a/nexus/tests/integration_tests/subnet_allocation.rs
+++ b/nexus/tests/integration_tests/subnet_allocation.rs
@@ -65,7 +65,7 @@ async fn create_instance_expect_failure(
         boot_disk: None,
         start: true,
         auto_restart_policy: Default::default(),
-        anti_affinity_groups: Vec::new(),
+        anti_affinity_groups: None,
     };
 
     NexusRequest::new(

--- a/nexus/types/src/external_api/params.rs
+++ b/nexus/types/src/external_api/params.rs
@@ -1230,8 +1230,10 @@ pub struct InstanceCreate {
     pub auto_restart_policy: Option<InstanceAutoRestartPolicy>,
 
     /// Anti-Affinity groups which this instance should be added.
+    ///
+    /// A "null" set of groups is equivalent to an empty set of groups.
     #[serde(default)]
-    pub anti_affinity_groups: Vec<NameOrId>,
+    pub anti_affinity_groups: Option<Vec<NameOrId>>,
 }
 
 /// Parameters of an `Instance` that can be reconfigured after creation.

--- a/openapi/nexus.json
+++ b/openapi/nexus.json
@@ -18052,8 +18052,9 @@
         "type": "object",
         "properties": {
           "anti_affinity_groups": {
-            "description": "Anti-Affinity groups which this instance should be added.",
-            "default": [],
+            "nullable": true,
+            "description": "Anti-Affinity groups which this instance should be added.\n\nA \"null\" set of groups is equivalent to an empty set of groups.",
+            "default": null,
             "type": "array",
             "items": {
               "$ref": "#/components/schemas/NameOrId"


### PR DESCRIPTION
Fixes https://github.com/oxidecomputer/omicron/issues/7986