### PR TITLE
Better error handling when tracking zone datalinks

### DIFF
--- a/sled-agent/src/probe_manager.rs
+++ b/sled-agent/src/probe_manager.rs
@@ -421,7 +421,7 @@ impl ProbeManagerInner {
                     Err(errors) => error!(
                         self.log,
                         "Failed to stop tracking one or more datalinks in the \
-                        zone, some metrics will not be produced";
+                        zone, some metrics may still be produced";
                         "zone_name" => running_zone.name(),
                         "errors" => ?errors,
                     ),

--- a/sled-agent/src/services.rs
+++ b/sled-agent/src/services.rs
@@ -4224,6 +4224,9 @@ impl ServiceManager {
             // We expect to have a metrics queue by this point, so
             // we can safely send a message on it to say the sled has
             // been synchronized.
+            //
+            // We may want to retry or ensure this notification happens. See
+            // https://github.com/oxidecomputer/omicron/issues/8022.
             let queue = self.metrics_queue();
             match queue.notify_time_synced_sled(self.sled_id()) {
                 Ok(_) => debug!(

--- a/sled-agent/src/services.rs
+++ b/sled-agent/src/services.rs
@@ -1164,13 +1164,19 @@ impl ServiceManager {
         if let SwitchZoneState::Running { zone, .. } =
             &*self.inner.switch_zone.lock().await
         {
-            if !metrics_queue.track_zone_links(zone).await {
-                error!(
-                    self.inner.log,
-                    "Failed to track one or more data links in \
-                    the switch zone, some metrics will not \
-                    be produced."
-                );
+            match metrics_queue.track_zone_links(zone) {
+                Ok(_) => {
+                    debug!(self.inner.log, "Stopped tracking zone datalinks")
+                }
+                Err(errors) => {
+                    error!(
+                        self.inner.log,
+                        "Failed to track one or more data links in \
+                        the switch zone, some metrics will not \
+                        be produced.";
+                        "errors" => ?errors,
+                    );
+                }
             }
         }
 
@@ -3420,13 +3426,17 @@ impl ServiceManager {
         // but before we've either run RSS or unlocked the rack. In both those
         // cases, we have a `StartSledAgentRequest`, and so a metrics queue.
         if let Some(queue) = self.maybe_metrics_queue() {
-            if !queue.track_zone_links(&running_zone).await {
-                error!(
-                    self.inner.log,
-                    "Failed to track one or more links in the zone, \
-                    some metrics will not be produced";
-                    "zone_name" => running_zone.name(),
-                );
+            match queue.track_zone_links(&running_zone) {
+                Ok(_) => debug!(self.inner.log, "Tracking zone datalinks"),
+                Err(errors) => {
+                    error!(
+                        self.inner.log,
+                        "Failed to track one or more links in the zone, \
+                        some metrics will not be produced";
+                        "zone_name" => running_zone.name(),
+                        "errors" => ?errors,
+                    );
+                }
             }
         }
         Ok(running_zone)
@@ -3789,7 +3799,19 @@ impl ServiceManager {
         // Ensure that the sled agent's metrics task is not tracking the zone's
         // VNICs or OPTE ports.
         if let Some(queue) = self.maybe_metrics_queue() {
-            queue.untrack_zone_links(&zone.runtime).await;
+            match queue.untrack_zone_links(&zone.runtime) {
+                Ok(_) => debug!(
+                    log,
+                    "stopped tracking zone datalinks";
+                    "zone_name" => &expected_zone_name,
+                ),
+                Err(errors) => error!(
+                    log,
+                    "failed to stop tracking zone datalinks";
+                    "errors" => ?errors,
+                    "zone_name" => &expected_zone_name
+                ),
+            }
         }
         debug!(
             log,
@@ -4203,12 +4225,17 @@ impl ServiceManager {
             // we can safely send a message on it to say the sled has
             // been synchronized.
             let queue = self.metrics_queue();
-            if !queue.notify_time_synced_sled(self.sled_id()).await {
-                error!(
+            match queue.notify_time_synced_sled(self.sled_id()) {
+                Ok(_) => debug!(
                     self.inner.log,
-                    "Failed to notify metrics queue of sled \
-                     time synchronization, metrics may not be produced."
-                );
+                    "Notified metrics task that time is now synced",
+                ),
+                Err(e) => error!(
+                    self.inner.log,
+                    "Failed to notify metrics task that \
+                     time is now synced, metrics may not be produced.";
+                     "error" => InlineErrorChain::new(&e),
+                ),
             }
         } else {
             debug!(self.inner.log, "Time was already synchronized");
@@ -4907,7 +4934,17 @@ impl ServiceManager {
                 if let Some(queue) =
                     self.inner.sled_info.get().map(|sa| &sa.metrics_queue)
                 {
-                    queue.untrack_zone_links(zone).await;
+                    match queue.untrack_zone_links(zone) {
+                        Ok(_) => debug!(
+                            log,
+                            "stopped tracking switch zone datalinks"
+                        ),
+                        Err(errors) => error!(
+                            log,
+                            "failed to stop tracking switch zone datalinks";
+                            "errors" => ?errors,
+                        ),
+                    }
                 }
 
                 let _ = zone.stop().await;
@@ -5288,7 +5325,13 @@ mod illumos_tests {
         // deleted.
         let queue = mgr.metrics_queue();
         for zone in mgr.inner.zones.lock().await.values() {
-            queue.untrack_zone_links(&zone.runtime).await;
+            if let Err(e) = queue.untrack_zone_links(&zone.runtime) {
+                error!(
+                    mgr.inner.log,
+                    "failed to stop tracking zone datalinks";
+                    "errors" => ?e,
+                );
+            }
         }
 
         // Explicitly drop the service manager

--- a/sled-agent/src/sled_agent.rs
+++ b/sled-agent/src/sled_agent.rs
@@ -481,10 +481,19 @@ impl SledAgent {
 
         // Start tracking the underlay physical links.
         for link in underlay::find_chelsio_links(&config.data_links)? {
-            metrics_manager
+            match metrics_manager
                 .request_queue()
                 .track_physical("global", &link.0)
-                .await;
+            {
+                Ok(_) => {
+                    debug!(log, "started tracking global zone underlay links")
+                }
+                Err(e) => error!(
+                    log,
+                    "failed to track global zone underlay link";
+                    "error" => slog_error_chain::InlineErrorChain::new(&e),
+                ),
+            }
         }
 
         // Create the PortManager to manage all the OPTE ports on the sled.


### PR DESCRIPTION
- Make operations for tracking / untracking datalinks in zones return actual error information, rather than a boolean.
- Use `try_send()` internally when sending messages to the actual metrics task, to avoid blocking indefinitely if that task is corked. This helps ensure we don't block things like the instance lifecycle simply because we couldn't track the Propolis zone's datalinks -- we'd rather the instance boot without those in that case.
- Fixes #7869