### PR TITLE
PendingMgsUpdates does not impl Serialize/Deserialize correctly

### DIFF
--- a/dev-tools/reconfigurator-exec-unsafe/src/main.rs
+++ b/dev-tools/reconfigurator-exec-unsafe/src/main.rs
@@ -245,6 +245,9 @@ impl ReconfiguratorExec {
                 blueprint: &blueprint,
                 creator: OmicronZoneUuid::from_untyped_uuid(creator),
                 sender,
+                // The driver shuts down when the tx side of this channel gets
+                // closed.  Clone this sender so that it doesn't get shut down
+                // right away.
                 mgs_updates: mgs_updates.clone(),
             }
             .into(),
@@ -296,6 +299,7 @@ impl ReconfiguratorExec {
             info!(&log, "waiting for repo depot resolver to stop");
             repo_depot_resolver.terminate().await;
             info!(&log, "waiting for driver to stop");
+            // We're ready to drop this sender so that the driver shuts down.
             drop(mgs_updates);
             driver_task.await.context("waiting for driver to stop")?;
         }


### PR DESCRIPTION
This PR fixes a few problems that I ran into when I went to go test #7978 using `reconfigurator-exec-unsafe`.

My basic plan was:

1. grab a test racklette (dublin)
2. use `omdb reconfigurator export` to save the reconfigurator state to a file
3. use `reconfigurator-cli` to export the system's target blueprint from that file
4. hand-edit the blueprint to include a `PendingMgsUpdates` that contains an example update to one of the sled SPs
5. use `reconfigurator-exec-unsafe` to execute the blueprint

The main problem I ran into was constructing a serialized `PendingMgsUpdates` containing the update that I wanted to do. Since we don't have reconfigurator-cli support for this property yet, I wrote some code to do this.  (I'll put that into a comment below for posterity.)  But when I went to serialize it I got:

```
error: serializing blueprint: key must be a string
```

The problem is that `PendingMgsUpdates` didn't impl `Serialize` correctly.  The derived impl tries to serialize a map whose keys (`Arc<BaseboardId>`) are objects.  This is not allowed in JSON.

This PR impls `Serialize`/`Deserialize` by hand as a sequence of `PendingMgsUpdate` objects.  This is closer to the spirit of `IdMap` anyway.

This also fixes a few small things in `reconfigurator-exec-unsafe` that made it a little harder to test.

With this PR, I'm able to complete the above test and verify that using `reconfigurator-exec-unsafe`, we complete an SP update through blueprint execution 🎉 (This still won't work in Nexus until we do the database implementation of this field.)