### PR TITLE
Convert the `KstatSampler` to a non-blocking self-stat queue

### DIFF
--- a/oximeter/instruments/src/kstat/sampler.rs
+++ b/oximeter/instruments/src/kstat/sampler.rs
@@ -1324,6 +1324,7 @@ impl oximeter::Producer for KstatSampler {
                         self.log,
                         "kstat stampler self-stat queue tx disconnected"
                     );
+                    break;
                 }
             }
         }

--- a/oximeter/instruments/src/kstat/sampler.rs
+++ b/oximeter/instruments/src/kstat/sampler.rs
@@ -1138,6 +1138,11 @@ pub struct KstatSampler {
     log: Logger,
     samples: Arc<Mutex<BTreeMap<TargetId, Vec<Sample>>>>,
     outbox: mpsc::Sender<Request>,
+    // NOTE: We're using a broadcast MPMC channel here intentionally, even
+    // though there is only one receiver. That's to make use of its ring-buffer
+    // properties, where old samples are evicted if `oximeter` can't collect
+    // from us quickly enough. See the discussion in
+    // https://github.com/oxidecomputer/omicron/issues/7983 for more.
     self_stat_rx: Arc<Mutex<broadcast::Receiver<Sample>>>,
     _worker_task: Arc<tokio::task::JoinHandle<()>>,
     #[cfg(all(test, target_os = "illumos"))]

--- a/oximeter/instruments/src/kstat/sampler.rs
+++ b/oximeter/instruments/src/kstat/sampler.rs
@@ -1318,6 +1318,7 @@ impl oximeter::Producer for KstatSampler {
                         being produced faster than `oximeter` is collecting";
                         "n_missed" => %n_missed,
                     );
+                    break;
                 }
                 Err(broadcast::error::TryRecvError::Closed) => {
                     debug!(

--- a/oximeter/instruments/src/kstat/sampler.rs
+++ b/oximeter/instruments/src/kstat/sampler.rs
@@ -1318,7 +1318,6 @@ impl oximeter::Producer for KstatSampler {
                         being produced faster than `oximeter` is collecting";
                         "n_missed" => %n_missed,
                     );
-                    break;
                 }
                 Err(broadcast::error::TryRecvError::Closed) => {
                     debug!(


### PR DESCRIPTION
- Switch the `KstatSampler`'s queue used to report self-statistics from a `tokio::sync::mpsc` channel to a `tokio::sync::broadcast`. This latter channel is a ring-buffer, where slow readers lose the earliest samples when they lag behind. The `mpsc` queue could block the worker entirely, if `oximeter` never actually reached the producer to drain that queue.
- Fixes #7983