### PR TITLE
specify positional interface for progenitor clients

### DIFF
--- a/clients/bootstrap-agent-client/src/lib.rs
+++ b/clients/bootstrap-agent-client/src/lib.rs
@@ -6,6 +6,7 @@
 
 progenitor::generate_api!(
     spec = "../../openapi/bootstrap-agent.json",
+    interface = Positional,
     inner_type = slog::Logger,
     pre_hook = (|log: &slog::Logger, request: &reqwest::Request| {
         slog::debug!(log, "client request";

--- a/clients/clickhouse-admin-keeper-client/src/lib.rs
+++ b/clients/clickhouse-admin-keeper-client/src/lib.rs
@@ -7,6 +7,7 @@
 
 progenitor::generate_api!(
     spec = "../../openapi/clickhouse-admin-keeper.json",
+    interface = Positional,
     inner_type = slog::Logger,
     pre_hook = (|log: &slog::Logger, request: &reqwest::Request| {
         slog::debug!(log, "client request";

--- a/clients/clickhouse-admin-server-client/src/lib.rs
+++ b/clients/clickhouse-admin-server-client/src/lib.rs
@@ -4,10 +4,10 @@
 
 //! Interface for making API requests to a clickhouse-admin-server server
 //! running in an omicron zone.
-use std::clone::Clone;
 
 progenitor::generate_api!(
     spec = "../../openapi/clickhouse-admin-server.json",
+    interface = Positional,
     inner_type = slog::Logger,
     pre_hook = (|log: &slog::Logger, request: &reqwest::Request| {
         slog::debug!(log, "client request";

--- a/clients/clickhouse-admin-single-client/src/lib.rs
+++ b/clients/clickhouse-admin-single-client/src/lib.rs
@@ -7,6 +7,7 @@
 
 progenitor::generate_api!(
     spec = "../../openapi/clickhouse-admin-single.json",
+    interface = Positional,
     inner_type = slog::Logger,
     pre_hook = (|log: &slog::Logger, request: &reqwest::Request| {
         slog::debug!(log, "client request";

--- a/clients/cockroach-admin-client/src/lib.rs
+++ b/clients/cockroach-admin-client/src/lib.rs
@@ -6,6 +6,7 @@
 
 progenitor::generate_api!(
     spec = "../../openapi/cockroach-admin.json",
+    interface = Positional,
     inner_type = slog::Logger,
     pre_hook = (|log: &slog::Logger, request: &reqwest::Request| {
         slog::debug!(log, "client request";

--- a/clients/dns-service-client/src/lib.rs
+++ b/clients/dns-service-client/src/lib.rs
@@ -4,6 +4,7 @@
 
 progenitor::generate_api!(
     spec = "../../openapi/dns-server/dns-server-latest.json",
+    interface = Positional,
     inner_type = slog::Logger,
     derives = [schemars::JsonSchema, Clone, Eq, PartialEq],
     pre_hook = (|log: &slog::Logger, request: &reqwest::Request| {

--- a/clients/ereport-client/src/lib.rs
+++ b/clients/ereport-client/src/lib.rs
@@ -4,6 +4,7 @@
 
 progenitor::generate_api!(
     spec = "../../openapi/ereport/ereport-latest.json",
+    interface = Positional,
     inner_type = slog::Logger,
     derives = [schemars::JsonSchema, Clone, Eq, PartialEq],
     pre_hook = (|log: &slog::Logger, request: &reqwest::Request| {

--- a/clients/gateway-client/src/lib.rs
+++ b/clients/gateway-client/src/lib.rs
@@ -46,6 +46,7 @@ pub use gateway_messages::SpComponent;
 // calls into Nexus, the current scheme is okay.)
 progenitor::generate_api!(
     spec = "../../openapi/gateway.json",
+    interface = Positional,
     inner_type = slog::Logger,
     pre_hook = (|log: &slog::Logger, request: &reqwest::Request| {
         slog::debug!(log, "client request";

--- a/clients/installinator-client/src/lib.rs
+++ b/clients/installinator-client/src/lib.rs
@@ -6,6 +6,7 @@
 
 progenitor::generate_api!(
     spec = "../../openapi/installinator.json",
+    interface = Positional,
     inner_type = slog::Logger,
     pre_hook = (|log: &slog::Logger, request: &reqwest::Request| {
         slog::debug!(log, "client request";

--- a/clients/nexus-client/src/lib.rs
+++ b/clients/nexus-client/src/lib.rs
@@ -9,6 +9,7 @@ use std::collections::HashMap;
 
 progenitor::generate_api!(
     spec = "../../openapi/nexus-internal.json",
+    interface = Positional,
     derives = [schemars::JsonSchema, PartialEq],
     inner_type = slog::Logger,
     pre_hook = (|log: &slog::Logger, request: &reqwest::Request| {

--- a/clients/oximeter-client/src/lib.rs
+++ b/clients/oximeter-client/src/lib.rs
@@ -2,12 +2,13 @@
 // License, v. 2.0. If a copy of the MPL was not distributed with this
 // file, You can obtain one at https://mozilla.org/MPL/2.0/.
 
-// Copyright 2021 Oxide Computer Company
+// Copyright 2025 Oxide Computer Company
 
 //! Interface for API requests to an Oximeter metric collection server
 
 progenitor::generate_api!(
     spec = "../../openapi/oximeter.json",
+    interface = Positional,
     inner_type = slog::Logger,
     pre_hook = (|log: &slog::Logger, request: &reqwest::Request| {
         slog::debug!(log, "client request";

--- a/clients/repo-depot-client/src/lib.rs
+++ b/clients/repo-depot-client/src/lib.rs
@@ -6,6 +6,7 @@
 
 progenitor::generate_api!(
     spec = "../../openapi/repo-depot.json",
+    interface = Positional,
     inner_type = slog::Logger,
     pre_hook = (|log: &slog::Logger, request: &reqwest::Request| {
         slog::debug!(log, "client request";

--- a/clients/sled-agent-client/src/lib.rs
+++ b/clients/sled-agent-client/src/lib.rs
@@ -16,7 +16,7 @@ pub use propolis_client::{CrucibleOpts, VolumeConstructionRequest};
 
 progenitor::generate_api!(
     spec = "../../openapi/sled-agent.json",
-    derives = [schemars::JsonSchema, PartialEq],
+    interface = Positional,
     inner_type = slog::Logger,
     pre_hook = (|log: &slog::Logger, request: &reqwest::Request| {
         slog::debug!(log, "client request";
@@ -28,6 +28,7 @@ progenitor::generate_api!(
     post_hook = (|log: &slog::Logger, result: &Result<_, _>| {
         slog::debug!(log, "client response"; "result" => ?result);
     }),
+    derives = [schemars::JsonSchema, PartialEq],
     patch = {
         BfdPeerConfig = { derives = [Eq, Hash] },
         BgpConfig = { derives = [Eq, Hash] },

--- a/clients/wicketd-client/src/lib.rs
+++ b/clients/wicketd-client/src/lib.rs
@@ -6,6 +6,7 @@
 
 progenitor::generate_api!(
     spec = "../../openapi/wicketd.json",
+    interface = Positional,
     inner_type = slog::Logger,
     pre_hook = (|log: &slog::Logger, request: &reqwest::Request| {
         slog::debug!(log, "client request";

--- a/internal-dns/resolver/src/resolver.rs
+++ b/internal-dns/resolver/src/resolver.rs
@@ -786,6 +786,7 @@ mod test {
 
     progenitor::generate_api!(
         spec = "tests/output/test-server.json",
+        interface = Positional,
         inner_type = slog::Logger,
         pre_hook = (|log: &slog::Logger, request: &reqwest::Request| {
             slog::debug!(log, "client request";


### PR DESCRIPTION
The default may change at some point so I'd like to be ready for that.