### PR TITLE
update `reconfigurator-cli`, blueprint show, blueprint diff for SP updates

### DIFF
--- a/dev-tools/reconfigurator-cli/src/lib.rs
+++ b/dev-tools/reconfigurator-cli/src/lib.rs
@@ -378,7 +378,7 @@ enum BlueprintEditCommands {
     /// expunge a zone
     ExpungeZone { zone_id: OmicronZoneUuid },
     /// configure an SP update
-    SpUpdateSet {
+    SetSpUpdate {
         /// serial number to update
         serial: String,
         /// artifact hash id
@@ -390,7 +390,7 @@ enum BlueprintEditCommands {
         component: SpUpdateComponent,
     },
     /// delete a configured SP update
-    SpUpdateDelete {
+    DeleteSpUpdate {
         /// baseboard serial number whose update to delete
         serial: String,
     },
@@ -398,6 +398,7 @@ enum BlueprintEditCommands {
 
 #[derive(Clone, Debug, Subcommand)]
 enum SpUpdateComponent {
+    /// update the SP itself
     Sp {
         expected_active_version: ArtifactVersion,
         expected_inactive_version: ExpectedVersion,
@@ -904,7 +905,7 @@ fn cmd_blueprint_edit(
                 .context("failed to expunge zone")?;
             format!("expunged zone {zone_id} from sled {sled_id}")
         }
-        BlueprintEditCommands::SpUpdateSet {
+        BlueprintEditCommands::SetSpUpdate {
             serial,
             artifact_hash,
             version,
@@ -958,7 +959,7 @@ fn cmd_blueprint_edit(
                  hash or version"
             )
         }
-        BlueprintEditCommands::SpUpdateDelete { serial } => {
+        BlueprintEditCommands::DeleteSpUpdate { serial } => {
             let baseboard_id = latest_collection
                 .baseboards
                 .iter()

--- a/dev-tools/reconfigurator-cli/tests/input/cmds-set-mgs-updates.txt
+++ b/dev-tools/reconfigurator-cli/tests/input/cmds-set-mgs-updates.txt
@@ -1,0 +1,36 @@
+# Load example system
+load-example --nsleds 3 --ndisks-per-sled 3
+blueprint-show ad97e762-7bf1-45a6-a98f-60afb7e491c0
+
+# Configure an MGS-managed update to one of the SPs.
+blueprint-edit ad97e762-7bf1-45a6-a98f-60afb7e491c0 sp-update-set serial2 e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855 1.1.0 sp 1.0.0 1.0.1
+blueprint-show cca24b71-09b5-4042-9185-b33e9f2ebba0
+blueprint-diff ad97e762-7bf1-45a6-a98f-60afb7e491c0 cca24b71-09b5-4042-9185-b33e9f2ebba0
+
+# Change that configuration.  It should replace the previous one.
+# This also exercises versions that are not semver.
+blueprint-edit cca24b71-09b5-4042-9185-b33e9f2ebba0 sp-update-set serial2 e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855 newest sp newer older
+blueprint-show 5bf974f3-81f9-455b-b24e-3099f765664c
+blueprint-diff ad97e762-7bf1-45a6-a98f-60afb7e491c0 5bf974f3-81f9-455b-b24e-3099f765664c
+
+# Configure an MGS-managed update to a different SP.
+# This should *not* replace the existing one.
+# This also exercises the special "invalid" string for a version number.
+blueprint-edit 5bf974f3-81f9-455b-b24e-3099f765664c sp-update-set serial0 e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855 three sp two invalid
+blueprint-show 1b837a27-3be1-4fcb-8499-a921c839e1d0
+blueprint-diff 5bf974f3-81f9-455b-b24e-3099f765664c 1b837a27-3be1-4fcb-8499-a921c839e1d0
+
+# Delete one of these updates.
+blueprint-edit 1b837a27-3be1-4fcb-8499-a921c839e1d0 sp-update-delete serial2
+blueprint-show 3682a71b-c6ca-4b7e-8f84-16df80c85960
+blueprint-diff 1b837a27-3be1-4fcb-8499-a921c839e1d0 3682a71b-c6ca-4b7e-8f84-16df80c85960
+
+# test help output
+blueprint-edit ad97e762-7bf1-45a6-a98f-60afb7e491c0 help
+blueprint-edit ad97e762-7bf1-45a6-a98f-60afb7e491c0 sp-update-set help
+blueprint-edit ad97e762-7bf1-45a6-a98f-60afb7e491c0 sp-update-delete help
+
+# test error case: no such serial
+blueprint-edit ad97e762-7bf1-45a6-a98f-60afb7e491c0 sp-update-set not-a-serial e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855 1.1.0 sp 1.0.0 1.0.1
+# test error case: bad hash
+blueprint-edit ad97e762-7bf1-45a6-a98f-60afb7e491c0 sp-update-set serial0 bogus-hash 1.1.0 sp 1.0.0 1.0.1

--- a/dev-tools/reconfigurator-cli/tests/input/cmds-set-mgs-updates.txt
+++ b/dev-tools/reconfigurator-cli/tests/input/cmds-set-mgs-updates.txt
@@ -6,12 +6,16 @@ blueprint-show ad97e762-7bf1-45a6-a98f-60afb7e491c0
 blueprint-edit ad97e762-7bf1-45a6-a98f-60afb7e491c0 sp-update-set serial2 e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855 1.1.0 sp 1.0.0 1.0.1
 blueprint-show cca24b71-09b5-4042-9185-b33e9f2ebba0
 blueprint-diff ad97e762-7bf1-45a6-a98f-60afb7e491c0 cca24b71-09b5-4042-9185-b33e9f2ebba0
+# diff in the reverse direction.  Should show one removal.
+blueprint-diff cca24b71-09b5-4042-9185-b33e9f2ebba0 ad97e762-7bf1-45a6-a98f-60afb7e491c0
 
 # Change that configuration.  It should replace the previous one.
 # This also exercises versions that are not semver.
 blueprint-edit cca24b71-09b5-4042-9185-b33e9f2ebba0 sp-update-set serial2 e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855 newest sp newer older
 blueprint-show 5bf974f3-81f9-455b-b24e-3099f765664c
-blueprint-diff ad97e762-7bf1-45a6-a98f-60afb7e491c0 5bf974f3-81f9-455b-b24e-3099f765664c
+blueprint-diff cca24b71-09b5-4042-9185-b33e9f2ebba0 5bf974f3-81f9-455b-b24e-3099f765664c
+# diff in the reverse direction.  Should still show one modification.
+blueprint-diff 5bf974f3-81f9-455b-b24e-3099f765664c cca24b71-09b5-4042-9185-b33e9f2ebba0
 
 # Configure an MGS-managed update to a different SP.
 # This should *not* replace the existing one.
@@ -28,6 +32,8 @@ blueprint-diff 1b837a27-3be1-4fcb-8499-a921c839e1d0 3682a71b-c6ca-4b7e-8f84-16df
 # test help output
 blueprint-edit ad97e762-7bf1-45a6-a98f-60afb7e491c0 help
 blueprint-edit ad97e762-7bf1-45a6-a98f-60afb7e491c0 sp-update-set help
+blueprint-edit ad97e762-7bf1-45a6-a98f-60afb7e491c0 sp-update-set serial0 e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855 three --help
+blueprint-edit ad97e762-7bf1-45a6-a98f-60afb7e491c0 sp-update-set serial0 e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855 three sp --help
 blueprint-edit ad97e762-7bf1-45a6-a98f-60afb7e491c0 sp-update-delete help
 
 # test error case: no such serial

--- a/dev-tools/reconfigurator-cli/tests/input/cmds-set-mgs-updates.txt
+++ b/dev-tools/reconfigurator-cli/tests/input/cmds-set-mgs-updates.txt
@@ -3,7 +3,7 @@ load-example --nsleds 3 --ndisks-per-sled 3
 blueprint-show ad97e762-7bf1-45a6-a98f-60afb7e491c0
 
 # Configure an MGS-managed update to one of the SPs.
-blueprint-edit ad97e762-7bf1-45a6-a98f-60afb7e491c0 sp-update-set serial2 e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855 1.1.0 sp 1.0.0 1.0.1
+blueprint-edit ad97e762-7bf1-45a6-a98f-60afb7e491c0 set-sp-update serial2 e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855 1.1.0 sp 1.0.0 1.0.1
 blueprint-show cca24b71-09b5-4042-9185-b33e9f2ebba0
 blueprint-diff ad97e762-7bf1-45a6-a98f-60afb7e491c0 cca24b71-09b5-4042-9185-b33e9f2ebba0
 # diff in the reverse direction.  Should show one removal.
@@ -11,7 +11,7 @@ blueprint-diff cca24b71-09b5-4042-9185-b33e9f2ebba0 ad97e762-7bf1-45a6-a98f-60af
 
 # Change that configuration.  It should replace the previous one.
 # This also exercises versions that are not semver.
-blueprint-edit cca24b71-09b5-4042-9185-b33e9f2ebba0 sp-update-set serial2 e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855 newest sp newer older
+blueprint-edit cca24b71-09b5-4042-9185-b33e9f2ebba0 set-sp-update serial2 e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855 newest sp newer older
 blueprint-show 5bf974f3-81f9-455b-b24e-3099f765664c
 blueprint-diff cca24b71-09b5-4042-9185-b33e9f2ebba0 5bf974f3-81f9-455b-b24e-3099f765664c
 # diff in the reverse direction.  Should still show one modification.
@@ -20,23 +20,23 @@ blueprint-diff 5bf974f3-81f9-455b-b24e-3099f765664c cca24b71-09b5-4042-9185-b33e
 # Configure an MGS-managed update to a different SP.
 # This should *not* replace the existing one.
 # This also exercises the special "invalid" string for a version number.
-blueprint-edit 5bf974f3-81f9-455b-b24e-3099f765664c sp-update-set serial0 e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855 three sp two invalid
+blueprint-edit 5bf974f3-81f9-455b-b24e-3099f765664c set-sp-update serial0 e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855 three sp two invalid
 blueprint-show 1b837a27-3be1-4fcb-8499-a921c839e1d0
 blueprint-diff 5bf974f3-81f9-455b-b24e-3099f765664c 1b837a27-3be1-4fcb-8499-a921c839e1d0
 
 # Delete one of these updates.
-blueprint-edit 1b837a27-3be1-4fcb-8499-a921c839e1d0 sp-update-delete serial2
+blueprint-edit 1b837a27-3be1-4fcb-8499-a921c839e1d0 delete-sp-update serial2
 blueprint-show 3682a71b-c6ca-4b7e-8f84-16df80c85960
 blueprint-diff 1b837a27-3be1-4fcb-8499-a921c839e1d0 3682a71b-c6ca-4b7e-8f84-16df80c85960
 
 # test help output
 blueprint-edit ad97e762-7bf1-45a6-a98f-60afb7e491c0 help
-blueprint-edit ad97e762-7bf1-45a6-a98f-60afb7e491c0 sp-update-set help
-blueprint-edit ad97e762-7bf1-45a6-a98f-60afb7e491c0 sp-update-set serial0 e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855 three --help
-blueprint-edit ad97e762-7bf1-45a6-a98f-60afb7e491c0 sp-update-set serial0 e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855 three sp --help
-blueprint-edit ad97e762-7bf1-45a6-a98f-60afb7e491c0 sp-update-delete help
+blueprint-edit ad97e762-7bf1-45a6-a98f-60afb7e491c0 set-sp-update help
+blueprint-edit ad97e762-7bf1-45a6-a98f-60afb7e491c0 set-sp-update serial0 e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855 three --help
+blueprint-edit ad97e762-7bf1-45a6-a98f-60afb7e491c0 set-sp-update serial0 e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855 three sp --help
+blueprint-edit ad97e762-7bf1-45a6-a98f-60afb7e491c0 delete-sp-update help
 
 # test error case: no such serial
-blueprint-edit ad97e762-7bf1-45a6-a98f-60afb7e491c0 sp-update-set not-a-serial e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855 1.1.0 sp 1.0.0 1.0.1
+blueprint-edit ad97e762-7bf1-45a6-a98f-60afb7e491c0 set-sp-update not-a-serial e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855 1.1.0 sp 1.0.0 1.0.1
 # test error case: bad hash
-blueprint-edit ad97e762-7bf1-45a6-a98f-60afb7e491c0 sp-update-set serial0 bogus-hash 1.1.0 sp 1.0.0 1.0.1
+blueprint-edit ad97e762-7bf1-45a6-a98f-60afb7e491c0 set-sp-update serial0 bogus-hash 1.1.0 sp 1.0.0 1.0.1

--- a/dev-tools/reconfigurator-cli/tests/output/cmd-set-mgs-updates-stderr
+++ b/dev-tools/reconfigurator-cli/tests/output/cmd-set-mgs-updates-stderr
@@ -1,0 +1,3 @@
+error: invalid value 'bogus-hash' for '<ARTIFACT_HASH>': Invalid string length
+
+For more information, try '--help'.

--- a/dev-tools/reconfigurator-cli/tests/output/cmd-set-mgs-updates-stdout
+++ b/dev-tools/reconfigurator-cli/tests/output/cmd-set-mgs-updates-stdout
@@ -1339,11 +1339,11 @@ to:   blueprint 5bf974f3-81f9-455b-b24e-3099f765664c
  PENDING MGS UPDATES:
 
     Pending MGS-managed updates (all baseboards):
-    ---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
-    sp_type   slot   part_number   serial_number   artifact_kind   artifact_hash                                                      artifact_version   details                                                                                                               
-    ---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
--   sled      2      model2        serial2         gimlet_sp       e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855   1.1.0              Sp { expected_active_version: ArtifactVersion("1.0.0"), expected_inactive_version: Version(ArtifactVersion("1.0.1")) }
-+   sled      2      model2        serial2         gimlet_sp       e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855   newest             Sp { expected_active_version: ArtifactVersion("newer"), expected_inactive_version: Version(ArtifactVersion("older")) }
+    -----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
+    sp_type   slot   part_number   serial_number   artifact_kind   artifact_hash                                                      artifact_version   details                                                                                                                 
+    -----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
+*   sled      2      model2        serial2         gimlet_sp       e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855   - 1.1.0            - Sp { expected_active_version: ArtifactVersion("1.0.0"), expected_inactive_version: Version(ArtifactVersion("1.0.1")) }
+     └─                                                                                                                               + newest           + Sp { expected_active_version: ArtifactVersion("newer"), expected_inactive_version: Version(ArtifactVersion("older")) }
 
 
 internal DNS:
@@ -1640,11 +1640,11 @@ to:   blueprint cca24b71-09b5-4042-9185-b33e9f2ebba0
  PENDING MGS UPDATES:
 
     Pending MGS-managed updates (all baseboards):
-    ---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
-    sp_type   slot   part_number   serial_number   artifact_kind   artifact_hash                                                      artifact_version   details                                                                                                               
-    ---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
--   sled      2      model2        serial2         gimlet_sp       e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855   newest             Sp { expected_active_version: ArtifactVersion("newer"), expected_inactive_version: Version(ArtifactVersion("older")) }
-+   sled      2      model2        serial2         gimlet_sp       e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855   1.1.0              Sp { expected_active_version: ArtifactVersion("1.0.0"), expected_inactive_version: Version(ArtifactVersion("1.0.1")) }
+    -----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
+    sp_type   slot   part_number   serial_number   artifact_kind   artifact_hash                                                      artifact_version   details                                                                                                                 
+    -----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
+*   sled      2      model2        serial2         gimlet_sp       e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855   - newest           - Sp { expected_active_version: ArtifactVersion("newer"), expected_inactive_version: Version(ArtifactVersion("older")) }
+     └─                                                                                                                               + 1.1.0            + Sp { expected_active_version: ArtifactVersion("1.0.0"), expected_inactive_version: Version(ArtifactVersion("1.0.1")) }
 
 
 internal DNS:

--- a/dev-tools/reconfigurator-cli/tests/output/cmd-set-mgs-updates-stdout
+++ b/dev-tools/reconfigurator-cli/tests/output/cmd-set-mgs-updates-stdout
@@ -187,7 +187,7 @@ parent:    6ccc786b-17f1-4562-958f-5a7d9a5a15fd
 
 > # Configure an MGS-managed update to one of the SPs.
 
-> blueprint-edit ad97e762-7bf1-45a6-a98f-60afb7e491c0 sp-update-set serial2 e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855 1.1.0 sp 1.0.0 1.0.1
+> blueprint-edit ad97e762-7bf1-45a6-a98f-60afb7e491c0 set-sp-update serial2 e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855 1.1.0 sp 1.0.0 1.0.1
 blueprint cca24b71-09b5-4042-9185-b33e9f2ebba0 created from blueprint ad97e762-7bf1-45a6-a98f-60afb7e491c0: configured update for serial serial2
 warn: no validation is done on the requested artifact hash or version
 
@@ -978,7 +978,7 @@ external DNS:
 
 > # This also exercises versions that are not semver.
 
-> blueprint-edit cca24b71-09b5-4042-9185-b33e9f2ebba0 sp-update-set serial2 e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855 newest sp newer older
+> blueprint-edit cca24b71-09b5-4042-9185-b33e9f2ebba0 set-sp-update serial2 e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855 newest sp newer older
 blueprint 5bf974f3-81f9-455b-b24e-3099f765664c created from blueprint cca24b71-09b5-4042-9185-b33e9f2ebba0: configured update for serial serial2
 warn: no validation is done on the requested artifact hash or version
 
@@ -1773,7 +1773,7 @@ external DNS:
 
 > # This also exercises the special "invalid" string for a version number.
 
-> blueprint-edit 5bf974f3-81f9-455b-b24e-3099f765664c sp-update-set serial0 e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855 three sp two invalid
+> blueprint-edit 5bf974f3-81f9-455b-b24e-3099f765664c set-sp-update serial0 e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855 three sp two invalid
 blueprint 1b837a27-3be1-4fcb-8499-a921c839e1d0 created from blueprint 5bf974f3-81f9-455b-b24e-3099f765664c: configured update for serial serial0
 warn: no validation is done on the requested artifact hash or version
 
@@ -2264,7 +2264,7 @@ external DNS:
 
 > # Delete one of these updates.
 
-> blueprint-edit 1b837a27-3be1-4fcb-8499-a921c839e1d0 sp-update-delete serial2
+> blueprint-edit 1b837a27-3be1-4fcb-8499-a921c839e1d0 delete-sp-update serial2
 blueprint 3682a71b-c6ca-4b7e-8f84-16df80c85960 created from blueprint 1b837a27-3be1-4fcb-8499-a921c839e1d0: deleted configured update for serial serial2
 
 > blueprint-show 3682a71b-c6ca-4b7e-8f84-16df80c85960
@@ -2763,8 +2763,8 @@ Commands:
   add-cockroach     add a CockroachDB instance to a particular sled
   set-zone-image    set the image source for a zone
   expunge-zone      expunge a zone
-  sp-update-set     configure an SP update
-  sp-update-delete  delete a configured SP update
+  set-sp-update     configure an SP update
+  delete-sp-update  delete a configured SP update
   help              Print this message or the help of the given subcommand(s)
 
 Arguments:
@@ -2775,13 +2775,13 @@ Options:
       --comment <COMMENT>  "comment" field for the new blueprint
   -h, --help               Print help
 
-> blueprint-edit ad97e762-7bf1-45a6-a98f-60afb7e491c0 sp-update-set help
+> blueprint-edit ad97e762-7bf1-45a6-a98f-60afb7e491c0 set-sp-update help
 configure an SP update
 
-Usage: blueprint-edit <BLUEPRINT_ID> sp-update-set <SERIAL> <ARTIFACT_HASH> <VERSION> <COMMAND>
+Usage: blueprint-edit <BLUEPRINT_ID> set-sp-update <SERIAL> <ARTIFACT_HASH> <VERSION> <COMMAND>
 
 Commands:
-  sp    
+  sp    update the SP itself
   help  Print this message or the help of the given subcommand(s)
 
 Arguments:
@@ -2792,13 +2792,13 @@ Arguments:
 Options:
   -h, --help  Print help
 
-> blueprint-edit ad97e762-7bf1-45a6-a98f-60afb7e491c0 sp-update-set serial0 e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855 three --help
+> blueprint-edit ad97e762-7bf1-45a6-a98f-60afb7e491c0 set-sp-update serial0 e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855 three --help
 configure an SP update
 
-Usage: blueprint-edit <BLUEPRINT_ID> sp-update-set <SERIAL> <ARTIFACT_HASH> <VERSION> <COMMAND>
+Usage: blueprint-edit <BLUEPRINT_ID> set-sp-update <SERIAL> <ARTIFACT_HASH> <VERSION> <COMMAND>
 
 Commands:
-  sp    
+  sp    update the SP itself
   help  Print this message or the help of the given subcommand(s)
 
 Arguments:
@@ -2809,8 +2809,10 @@ Arguments:
 Options:
   -h, --help  Print help
 
-> blueprint-edit ad97e762-7bf1-45a6-a98f-60afb7e491c0 sp-update-set serial0 e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855 three sp --help
-Usage: blueprint-edit sp-update-set <SERIAL> <ARTIFACT_HASH> <VERSION> sp <EXPECTED_ACTIVE_VERSION> <EXPECTED_INACTIVE_VERSION>
+> blueprint-edit ad97e762-7bf1-45a6-a98f-60afb7e491c0 set-sp-update serial0 e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855 three sp --help
+update the SP itself
+
+Usage: blueprint-edit set-sp-update <SERIAL> <ARTIFACT_HASH> <VERSION> sp <EXPECTED_ACTIVE_VERSION> <EXPECTED_INACTIVE_VERSION>
 
 Arguments:
   <EXPECTED_ACTIVE_VERSION>    
@@ -2819,17 +2821,17 @@ Arguments:
 Options:
   -h, --help  Print help
 
-> blueprint-edit ad97e762-7bf1-45a6-a98f-60afb7e491c0 sp-update-delete help
+> blueprint-edit ad97e762-7bf1-45a6-a98f-60afb7e491c0 delete-sp-update help
 error: unknown baseboard serial: "help"
 
 > 
 
 > # test error case: no such serial
 
-> blueprint-edit ad97e762-7bf1-45a6-a98f-60afb7e491c0 sp-update-set not-a-serial e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855 1.1.0 sp 1.0.0 1.0.1
+> blueprint-edit ad97e762-7bf1-45a6-a98f-60afb7e491c0 set-sp-update not-a-serial e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855 1.1.0 sp 1.0.0 1.0.1
 error: unknown baseboard serial: "not-a-serial"
 
 > # test error case: bad hash
 
-> blueprint-edit ad97e762-7bf1-45a6-a98f-60afb7e491c0 sp-update-set serial0 bogus-hash 1.1.0 sp 1.0.0 1.0.1
+> blueprint-edit ad97e762-7bf1-45a6-a98f-60afb7e491c0 set-sp-update serial0 bogus-hash 1.1.0 sp 1.0.0 1.0.1
 

--- a/dev-tools/reconfigurator-cli/tests/output/cmd-set-mgs-updates-stdout
+++ b/dev-tools/reconfigurator-cli/tests/output/cmd-set-mgs-updates-stdout
@@ -366,7 +366,7 @@ parent:    ad97e762-7bf1-45a6-a98f-60afb7e491c0
     external DNS version:   1
 
  PENDING MGS-MANAGED UPDATES: 1
-    Pending MGS-managed updates:
+    Pending MGS-managed updates (all baseboards):
     ---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
     sp_type   slot   part_number   serial_number   artifact_kind   artifact_hash                                                      artifact_version   details                                                                                                               
     ---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
@@ -544,6 +544,314 @@ to:   blueprint cca24b71-09b5-4042-9185-b33e9f2ebba0
  OXIMETER SETTINGS:
     generation:   1 (unchanged)
     read from::   SingleNode (unchanged)
+
+ PENDING MGS UPDATES:
+
+    Pending MGS-managed updates (all baseboards):
+    ---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
+    sp_type   slot   part_number   serial_number   artifact_kind   artifact_hash                                                      artifact_version   details                                                                                                               
+    ---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
++   sled      2      model2        serial2         gimlet_sp       e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855   1.1.0              Sp { expected_active_version: ArtifactVersion("1.0.0"), expected_inactive_version: Version(ArtifactVersion("1.0.1")) }
+
+
+internal DNS:
+  DNS zone: "control-plane.oxide.internal" (unchanged)
+    name: 159e1f8f-6f32-413d-a48b-e40fb2efaf15.host          (records: 1)
+        AAAA fd00:1122:3344:2::1
+    name: 1dee8f37-8286-48dc-b4b4-e59979c030ec.host          (records: 1)
+        AAAA fd00:1122:3344:103::22
+    name: 327db2a9-fc45-4c3f-a6db-4ee58459e5cf.host          (records: 1)
+        AAAA fd00:1122:3344:103::27
+    name: 345fbd68-cb55-4faa-b6ea-801789018bc6.host          (records: 1)
+        AAAA fd00:1122:3344:102::21
+    name: 4ad9c209-bd1b-44c9-863d-1a6b84b34d53.host          (records: 1)
+        AAAA fd00:1122:3344:101::21
+    name: 543b3bb6-358d-4876-9774-53a53187aaa8.host          (records: 1)
+        AAAA fd00:1122:3344:102::22
+    name: 575bd77e-6cd9-4bb6-9c1f-2ac6f149278a.host          (records: 1)
+        AAAA fd00:1122:3344:101::26
+    name: 5c67f8ed-9f38-4be1-b64c-a2d9898d3263.host          (records: 1)
+        AAAA fd00:1122:3344:102::24
+    name: 5ea7f627-d51e-4e2d-8648-112ddc635e53.host          (records: 1)
+        AAAA fd00:1122:3344:103::25
+    name: 6df9649e-48f8-4754-94f3-55e8f9b039be.host          (records: 1)
+        AAAA fd00:1122:3344:101::22
+    name: 70b7e8a1-cc3f-4cdd-a577-4c8be9885f8b.host          (records: 1)
+        AAAA fd00:1122:3344:102::27
+    name: 719199e7-eacf-4add-b532-ddfaf867b478.host          (records: 1)
+        AAAA fd00:1122:3344:101::28
+    name: 7bb9667d-da70-4592-a579-31295f919aed.host          (records: 1)
+        AAAA fd00:1122:3344:102::26
+    name: 86c0837a-73ca-4d08-971d-8491401c2fe2.host          (records: 1)
+        AAAA fd00:1122:3344:101::24
+    name: 8a651785-3936-4cf6-b301-4fa7fa003c9f.host          (records: 1)
+        AAAA fd00:1122:3344:103::23
+    name: 9b8c5aff-3892-4645-8c66-c540456f05af.host          (records: 1)
+        AAAA fd00:1122:3344:101::27
+    name: _clickhouse-admin-single-server._tcp               (records: 1)
+        SRV  port  8888 c138c88c-a83d-4e2d-a8f8-e8e715d8e5f7.host.control-plane.oxide.internal
+    name: _clickhouse-native._tcp                            (records: 1)
+        SRV  port  9000 c138c88c-a83d-4e2d-a8f8-e8e715d8e5f7.host.control-plane.oxide.internal
+    name: _clickhouse._tcp                                   (records: 1)
+        SRV  port  8123 c138c88c-a83d-4e2d-a8f8-e8e715d8e5f7.host.control-plane.oxide.internal
+    name: _crucible-pantry._tcp                              (records: 3)
+        SRV  port 17000 5c67f8ed-9f38-4be1-b64c-a2d9898d3263.host.control-plane.oxide.internal
+        SRV  port 17000 a76d9883-b4fe-464f-acbb-e75b2bbb508d.host.control-plane.oxide.internal
+        SRV  port 17000 c4c56b5a-8c18-4eac-964a-62f94cac07b1.host.control-plane.oxide.internal
+    name: _crucible._tcp.327db2a9-fc45-4c3f-a6db-4ee58459e5cf (records: 1)
+        SRV  port 32345 327db2a9-fc45-4c3f-a6db-4ee58459e5cf.host.control-plane.oxide.internal
+    name: _crucible._tcp.575bd77e-6cd9-4bb6-9c1f-2ac6f149278a (records: 1)
+        SRV  port 32345 575bd77e-6cd9-4bb6-9c1f-2ac6f149278a.host.control-plane.oxide.internal
+    name: _crucible._tcp.5ea7f627-d51e-4e2d-8648-112ddc635e53 (records: 1)
+        SRV  port 32345 5ea7f627-d51e-4e2d-8648-112ddc635e53.host.control-plane.oxide.internal
+    name: _crucible._tcp.70b7e8a1-cc3f-4cdd-a577-4c8be9885f8b (records: 1)
+        SRV  port 32345 70b7e8a1-cc3f-4cdd-a577-4c8be9885f8b.host.control-plane.oxide.internal
+    name: _crucible._tcp.719199e7-eacf-4add-b532-ddfaf867b478 (records: 1)
+        SRV  port 32345 719199e7-eacf-4add-b532-ddfaf867b478.host.control-plane.oxide.internal
+    name: _crucible._tcp.7bb9667d-da70-4592-a579-31295f919aed (records: 1)
+        SRV  port 32345 7bb9667d-da70-4592-a579-31295f919aed.host.control-plane.oxide.internal
+    name: _crucible._tcp.9b8c5aff-3892-4645-8c66-c540456f05af (records: 1)
+        SRV  port 32345 9b8c5aff-3892-4645-8c66-c540456f05af.host.control-plane.oxide.internal
+    name: _crucible._tcp.a5a25771-1025-4c08-9362-c5ee4cecafc9 (records: 1)
+        SRV  port 32345 a5a25771-1025-4c08-9362-c5ee4cecafc9.host.control-plane.oxide.internal
+    name: _crucible._tcp.ad81aafc-e74d-4b0a-b4e6-2e58ef52b7a2 (records: 1)
+        SRV  port 32345 ad81aafc-e74d-4b0a-b4e6-2e58ef52b7a2.host.control-plane.oxide.internal
+    name: _external-dns._tcp                                 (records: 3)
+        SRV  port  5353 86c0837a-73ca-4d08-971d-8491401c2fe2.host.control-plane.oxide.internal
+        SRV  port  5353 8a651785-3936-4cf6-b301-4fa7fa003c9f.host.control-plane.oxide.internal
+        SRV  port  5353 b067565e-df5a-441f-85b9-69acc38bbf35.host.control-plane.oxide.internal
+    name: _internal-ntp._tcp                                 (records: 3)
+        SRV  port   123 345fbd68-cb55-4faa-b6ea-801789018bc6.host.control-plane.oxide.internal
+        SRV  port   123 4ad9c209-bd1b-44c9-863d-1a6b84b34d53.host.control-plane.oxide.internal
+        SRV  port   123 f282c429-5f5e-4430-8f71-600cf61ded56.host.control-plane.oxide.internal
+    name: _nameservice._tcp                                  (records: 3)
+        SRV  port  5353 159e1f8f-6f32-413d-a48b-e40fb2efaf15.host.control-plane.oxide.internal
+        SRV  port  5353 ae5b529a-2ada-490c-bea9-04c71cf8e72c.host.control-plane.oxide.internal
+        SRV  port  5353 f14b0fff-c0f0-420f-ab51-df1a605f43c3.host.control-plane.oxide.internal
+    name: _nexus._tcp                                        (records: 3)
+        SRV  port 12221 1dee8f37-8286-48dc-b4b4-e59979c030ec.host.control-plane.oxide.internal
+        SRV  port 12221 543b3bb6-358d-4876-9774-53a53187aaa8.host.control-plane.oxide.internal
+        SRV  port 12221 6df9649e-48f8-4754-94f3-55e8f9b039be.host.control-plane.oxide.internal
+    name: _oximeter-reader._tcp                              (records: 1)
+        SRV  port  9000 c138c88c-a83d-4e2d-a8f8-e8e715d8e5f7.host.control-plane.oxide.internal
+    name: _repo-depot._tcp                                   (records: 3)
+        SRV  port 12348 bb0ec23a-f97c-4b6a-a5bc-864b1ebc9236.sled.control-plane.oxide.internal
+        SRV  port 12348 bba6ea73-6c9c-4ab5-8bb4-1dd145071407.sled.control-plane.oxide.internal
+        SRV  port 12348 cc00b21a-5685-480a-ab5e-d2e29cf369df.sled.control-plane.oxide.internal
+    name: a5a25771-1025-4c08-9362-c5ee4cecafc9.host          (records: 1)
+        AAAA fd00:1122:3344:102::25
+    name: a76d9883-b4fe-464f-acbb-e75b2bbb508d.host          (records: 1)
+        AAAA fd00:1122:3344:103::24
+    name: ad81aafc-e74d-4b0a-b4e6-2e58ef52b7a2.host          (records: 1)
+        AAAA fd00:1122:3344:103::26
+    name: ae5b529a-2ada-490c-bea9-04c71cf8e72c.host          (records: 1)
+        AAAA fd00:1122:3344:1::1
+    name: b067565e-df5a-441f-85b9-69acc38bbf35.host          (records: 1)
+        AAAA fd00:1122:3344:102::23
+    name: bb0ec23a-f97c-4b6a-a5bc-864b1ebc9236.sled          (records: 1)
+        AAAA fd00:1122:3344:101::1
+    name: bba6ea73-6c9c-4ab5-8bb4-1dd145071407.sled          (records: 1)
+        AAAA fd00:1122:3344:102::1
+    name: c138c88c-a83d-4e2d-a8f8-e8e715d8e5f7.host          (records: 1)
+        AAAA fd00:1122:3344:101::23
+    name: c4c56b5a-8c18-4eac-964a-62f94cac07b1.host          (records: 1)
+        AAAA fd00:1122:3344:101::25
+    name: cc00b21a-5685-480a-ab5e-d2e29cf369df.sled          (records: 1)
+        AAAA fd00:1122:3344:103::1
+    name: f14b0fff-c0f0-420f-ab51-df1a605f43c3.host          (records: 1)
+        AAAA fd00:1122:3344:3::1
+    name: f282c429-5f5e-4430-8f71-600cf61ded56.host          (records: 1)
+        AAAA fd00:1122:3344:103::21
+
+external DNS:
+  DNS zone: "oxide.example" (unchanged)
+    name: example-silo.sys                                   (records: 3)
+        A    192.0.2.2
+        A    192.0.2.3
+        A    192.0.2.4
+
+
+
+> # diff in the reverse direction.  Should show one removal.
+
+> blueprint-diff cca24b71-09b5-4042-9185-b33e9f2ebba0 ad97e762-7bf1-45a6-a98f-60afb7e491c0
+from: blueprint cca24b71-09b5-4042-9185-b33e9f2ebba0
+to:   blueprint ad97e762-7bf1-45a6-a98f-60afb7e491c0
+
+ UNCHANGED SLEDS:
+
+  sled bb0ec23a-f97c-4b6a-a5bc-864b1ebc9236 (active, config generation 2):
+
+    physical disks:
+    ------------------------------------------------------------------------------------
+    vendor        model        serial                                        disposition
+    ------------------------------------------------------------------------------------
+    fake-vendor   fake-model   serial-a156a6d9-e839-4cb2-9d09-faf012dae700   in service 
+    fake-vendor   fake-model   serial-b48b5b36-fbb1-4c71-8b08-34a58b3ed2bd   in service 
+    fake-vendor   fake-model   serial-b62945fd-6ac2-4ec2-9e13-0a9a10620924   in service 
+
+
+    datasets:
+    -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
+    dataset name                                                                                                   dataset id                             disposition   quota     reservation   compression
+    -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
+    oxp_a156a6d9-e839-4cb2-9d09-faf012dae700/crucible                                                              bbf79ca9-a619-4142-9802-d306a4b58acb   in service    none      none          off        
+    oxp_b48b5b36-fbb1-4c71-8b08-34a58b3ed2bd/crucible                                                              ff6da666-707c-4370-b0d9-0572d8851e9d   in service    none      none          off        
+    oxp_b62945fd-6ac2-4ec2-9e13-0a9a10620924/crucible                                                              1f46779a-37b2-48d7-8ea9-a4e988bb0045   in service    none      none          off        
+    oxp_a156a6d9-e839-4cb2-9d09-faf012dae700/crypt/clickhouse                                                      43b6b5c0-61d8-4b88-bbb8-abede5589619   in service    none      none          off        
+    oxp_a156a6d9-e839-4cb2-9d09-faf012dae700/crypt/external_dns                                                    f5fc02e2-46ff-4012-a5c0-c91ad7881642   in service    none      none          off        
+    oxp_a156a6d9-e839-4cb2-9d09-faf012dae700/crypt/internal_dns                                                    2c16250f-d4aa-4fb5-bf4b-a6b5d72ac441   in service    none      none          off        
+    oxp_a156a6d9-e839-4cb2-9d09-faf012dae700/crypt/zone                                                            9077f1bd-3864-43d5-9c02-9370cbb9156d   in service    none      none          off        
+    oxp_b48b5b36-fbb1-4c71-8b08-34a58b3ed2bd/crypt/zone                                                            f4febe2f-789b-4c28-8bb7-aa594e0e4a4f   in service    none      none          off        
+    oxp_b62945fd-6ac2-4ec2-9e13-0a9a10620924/crypt/zone                                                            de0fe910-037f-49da-b86b-5865818c568d   in service    none      none          off        
+    oxp_a156a6d9-e839-4cb2-9d09-faf012dae700/crypt/zone/oxz_clickhouse_c138c88c-a83d-4e2d-a8f8-e8e715d8e5f7        7de7e173-0287-4e01-ad60-73681156e0e4   in service    none      none          off        
+    oxp_a156a6d9-e839-4cb2-9d09-faf012dae700/crypt/zone/oxz_crucible_575bd77e-6cd9-4bb6-9c1f-2ac6f149278a          252039e9-e48e-4790-930d-a8fad52256d7   in service    none      none          off        
+    oxp_b62945fd-6ac2-4ec2-9e13-0a9a10620924/crypt/zone/oxz_crucible_719199e7-eacf-4add-b532-ddfaf867b478          7ca01115-8692-438a-aa91-84b7c11f5ef2   in service    none      none          off        
+    oxp_b48b5b36-fbb1-4c71-8b08-34a58b3ed2bd/crypt/zone/oxz_crucible_9b8c5aff-3892-4645-8c66-c540456f05af          61a88822-ec1a-4c94-8134-f5d33e342428   in service    none      none          off        
+    oxp_a156a6d9-e839-4cb2-9d09-faf012dae700/crypt/zone/oxz_crucible_pantry_c4c56b5a-8c18-4eac-964a-62f94cac07b1   45b1fd69-7ace-41f8-97bc-3f6e99314e8a   in service    none      none          off        
+    oxp_a156a6d9-e839-4cb2-9d09-faf012dae700/crypt/zone/oxz_external_dns_86c0837a-73ca-4d08-971d-8491401c2fe2      6159b0b8-1c4b-4dd4-a32e-5c5a93df859b   in service    none      none          off        
+    oxp_a156a6d9-e839-4cb2-9d09-faf012dae700/crypt/zone/oxz_internal_dns_ae5b529a-2ada-490c-bea9-04c71cf8e72c      9f74b627-d96c-4183-92f4-7cfaca681fb5   in service    none      none          off        
+    oxp_a156a6d9-e839-4cb2-9d09-faf012dae700/crypt/zone/oxz_nexus_6df9649e-48f8-4754-94f3-55e8f9b039be             6985e6b4-a53b-4a88-bda6-41d2da73af48   in service    none      none          off        
+    oxp_a156a6d9-e839-4cb2-9d09-faf012dae700/crypt/zone/oxz_ntp_4ad9c209-bd1b-44c9-863d-1a6b84b34d53               233b6c7d-284f-42e6-b9e5-607e9377387d   in service    none      none          off        
+    oxp_a156a6d9-e839-4cb2-9d09-faf012dae700/crypt/debug                                                           a510cf34-74db-44fc-903f-36704f21ae67   in service    100 GiB   none          gzip-9     
+    oxp_b48b5b36-fbb1-4c71-8b08-34a58b3ed2bd/crypt/debug                                                           b9f7efe9-5088-45a3-96d9-6cc69be0ec72   in service    100 GiB   none          gzip-9     
+    oxp_b62945fd-6ac2-4ec2-9e13-0a9a10620924/crypt/debug                                                           ae71243d-118a-4e43-b4e3-9e425c6b8395   in service    100 GiB   none          gzip-9     
+
+
+    omicron zones:
+    ---------------------------------------------------------------------------------------------------------------
+    zone type         zone id                                image source      disposition   underlay IP           
+    ---------------------------------------------------------------------------------------------------------------
+    clickhouse        c138c88c-a83d-4e2d-a8f8-e8e715d8e5f7   install dataset   in service    fd00:1122:3344:101::23
+    crucible          575bd77e-6cd9-4bb6-9c1f-2ac6f149278a   install dataset   in service    fd00:1122:3344:101::26
+    crucible          719199e7-eacf-4add-b532-ddfaf867b478   install dataset   in service    fd00:1122:3344:101::28
+    crucible          9b8c5aff-3892-4645-8c66-c540456f05af   install dataset   in service    fd00:1122:3344:101::27
+    crucible_pantry   c4c56b5a-8c18-4eac-964a-62f94cac07b1   install dataset   in service    fd00:1122:3344:101::25
+    external_dns      86c0837a-73ca-4d08-971d-8491401c2fe2   install dataset   in service    fd00:1122:3344:101::24
+    internal_dns      ae5b529a-2ada-490c-bea9-04c71cf8e72c   install dataset   in service    fd00:1122:3344:1::1   
+    internal_ntp      4ad9c209-bd1b-44c9-863d-1a6b84b34d53   install dataset   in service    fd00:1122:3344:101::21
+    nexus             6df9649e-48f8-4754-94f3-55e8f9b039be   install dataset   in service    fd00:1122:3344:101::22
+
+
+  sled bba6ea73-6c9c-4ab5-8bb4-1dd145071407 (active, config generation 2):
+
+    physical disks:
+    ------------------------------------------------------------------------------------
+    vendor        model        serial                                        disposition
+    ------------------------------------------------------------------------------------
+    fake-vendor   fake-model   serial-2201d82d-3a3c-4744-ac41-657536a90afe   in service 
+    fake-vendor   fake-model   serial-bdf3642c-a783-4689-a8a6-8cfa257089bd   in service 
+    fake-vendor   fake-model   serial-eeb9b9ce-ac1c-4a41-9a7a-814e26e2a9ee   in service 
+
+
+    datasets:
+    -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
+    dataset name                                                                                                   dataset id                             disposition   quota     reservation   compression
+    -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
+    oxp_2201d82d-3a3c-4744-ac41-657536a90afe/crucible                                                              66beebb3-2b7a-4334-9ea7-e7c714b6dacc   in service    none      none          off        
+    oxp_bdf3642c-a783-4689-a8a6-8cfa257089bd/crucible                                                              4611f0cd-1ef4-42f2-b1bd-8ce5c0ee1ba4   in service    none      none          off        
+    oxp_eeb9b9ce-ac1c-4a41-9a7a-814e26e2a9ee/crucible                                                              4420b086-b23f-4ba6-b504-459a38e3b367   in service    none      none          off        
+    oxp_2201d82d-3a3c-4744-ac41-657536a90afe/crypt/external_dns                                                    ffe1a3c8-7546-495f-b437-f2405be4e533   in service    none      none          off        
+    oxp_2201d82d-3a3c-4744-ac41-657536a90afe/crypt/internal_dns                                                    c5300adb-042e-41fd-9b1f-5c01d68e7eb4   in service    none      none          off        
+    oxp_2201d82d-3a3c-4744-ac41-657536a90afe/crypt/zone                                                            06dfa1c2-42c3-4626-8bf3-4460dfec3646   in service    none      none          off        
+    oxp_bdf3642c-a783-4689-a8a6-8cfa257089bd/crypt/zone                                                            89ae62b7-0cff-4e09-b4e9-4c43bf242e1d   in service    none      none          off        
+    oxp_eeb9b9ce-ac1c-4a41-9a7a-814e26e2a9ee/crypt/zone                                                            78269a0c-ce98-4834-ae9e-d25eee99a079   in service    none      none          off        
+    oxp_eeb9b9ce-ac1c-4a41-9a7a-814e26e2a9ee/crypt/zone/oxz_crucible_70b7e8a1-cc3f-4cdd-a577-4c8be9885f8b          1382d296-a276-40ca-85b3-9f2578cb95cf   in service    none      none          off        
+    oxp_bdf3642c-a783-4689-a8a6-8cfa257089bd/crypt/zone/oxz_crucible_7bb9667d-da70-4592-a579-31295f919aed          57d3c6cb-64ff-4485-87c0-3ff5fe9c45d8   in service    none      none          off        
+    oxp_2201d82d-3a3c-4744-ac41-657536a90afe/crypt/zone/oxz_crucible_a5a25771-1025-4c08-9362-c5ee4cecafc9          a0e1cc1c-d542-4a21-96bb-efdfe40af009   in service    none      none          off        
+    oxp_2201d82d-3a3c-4744-ac41-657536a90afe/crypt/zone/oxz_crucible_pantry_5c67f8ed-9f38-4be1-b64c-a2d9898d3263   4f3e7986-e836-4ecc-ac69-8c013905707c   in service    none      none          off        
+    oxp_2201d82d-3a3c-4744-ac41-657536a90afe/crypt/zone/oxz_external_dns_b067565e-df5a-441f-85b9-69acc38bbf35      bc7affdc-54b9-4172-8264-af82b92fdfe0   in service    none      none          off        
+    oxp_2201d82d-3a3c-4744-ac41-657536a90afe/crypt/zone/oxz_internal_dns_159e1f8f-6f32-413d-a48b-e40fb2efaf15      79d73706-f701-4857-a378-fcf026cd6756   in service    none      none          off        
+    oxp_2201d82d-3a3c-4744-ac41-657536a90afe/crypt/zone/oxz_nexus_543b3bb6-358d-4876-9774-53a53187aaa8             71b813ec-4a24-43d1-b0b8-5c3303a1d9b5   in service    none      none          off        
+    oxp_2201d82d-3a3c-4744-ac41-657536a90afe/crypt/zone/oxz_ntp_345fbd68-cb55-4faa-b6ea-801789018bc6               d4126675-e113-4a2d-826a-cf7b224b794b   in service    none      none          off        
+    oxp_2201d82d-3a3c-4744-ac41-657536a90afe/crypt/debug                                                           afe7ef8e-c974-403e-932e-eb3c8057b22d   in service    100 GiB   none          gzip-9     
+    oxp_bdf3642c-a783-4689-a8a6-8cfa257089bd/crypt/debug                                                           f5f65250-3145-41bf-b462-359728bda24a   in service    100 GiB   none          gzip-9     
+    oxp_eeb9b9ce-ac1c-4a41-9a7a-814e26e2a9ee/crypt/debug                                                           7328892a-0525-401f-9160-a8e4501049fd   in service    100 GiB   none          gzip-9     
+
+
+    omicron zones:
+    ---------------------------------------------------------------------------------------------------------------
+    zone type         zone id                                image source      disposition   underlay IP           
+    ---------------------------------------------------------------------------------------------------------------
+    crucible          70b7e8a1-cc3f-4cdd-a577-4c8be9885f8b   install dataset   in service    fd00:1122:3344:102::27
+    crucible          7bb9667d-da70-4592-a579-31295f919aed   install dataset   in service    fd00:1122:3344:102::26
+    crucible          a5a25771-1025-4c08-9362-c5ee4cecafc9   install dataset   in service    fd00:1122:3344:102::25
+    crucible_pantry   5c67f8ed-9f38-4be1-b64c-a2d9898d3263   install dataset   in service    fd00:1122:3344:102::24
+    external_dns      b067565e-df5a-441f-85b9-69acc38bbf35   install dataset   in service    fd00:1122:3344:102::23
+    internal_dns      159e1f8f-6f32-413d-a48b-e40fb2efaf15   install dataset   in service    fd00:1122:3344:2::1   
+    internal_ntp      345fbd68-cb55-4faa-b6ea-801789018bc6   install dataset   in service    fd00:1122:3344:102::21
+    nexus             543b3bb6-358d-4876-9774-53a53187aaa8   install dataset   in service    fd00:1122:3344:102::22
+
+
+  sled cc00b21a-5685-480a-ab5e-d2e29cf369df (active, config generation 2):
+
+    physical disks:
+    ------------------------------------------------------------------------------------
+    vendor        model        serial                                        disposition
+    ------------------------------------------------------------------------------------
+    fake-vendor   fake-model   serial-78b8bc9a-8f5b-4fc2-9d70-4470b2d05aae   in service 
+    fake-vendor   fake-model   serial-9e809fde-e684-4ee8-8d46-dade081c3c37   in service 
+    fake-vendor   fake-model   serial-f2b5fdba-606d-45a4-9a9b-35bf20892bd6   in service 
+
+
+    datasets:
+    -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
+    dataset name                                                                                                   dataset id                             disposition   quota     reservation   compression
+    -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
+    oxp_78b8bc9a-8f5b-4fc2-9d70-4470b2d05aae/crucible                                                              a84f76f4-1f8c-4772-a072-ffb0dc7c281c   in service    none      none          off        
+    oxp_9e809fde-e684-4ee8-8d46-dade081c3c37/crucible                                                              db8f2cdf-721f-4c56-880e-d9265ec404f5   in service    none      none          off        
+    oxp_f2b5fdba-606d-45a4-9a9b-35bf20892bd6/crucible                                                              faa61220-8f21-4231-b069-3fb417699363   in service    none      none          off        
+    oxp_78b8bc9a-8f5b-4fc2-9d70-4470b2d05aae/crypt/external_dns                                                    b47f981e-ac2d-4ec1-8e67-c15dcf13af86   in service    none      none          off        
+    oxp_78b8bc9a-8f5b-4fc2-9d70-4470b2d05aae/crypt/internal_dns                                                    037ef4f6-dae1-478e-8397-3b68bf8e47dc   in service    none      none          off        
+    oxp_78b8bc9a-8f5b-4fc2-9d70-4470b2d05aae/crypt/zone                                                            fa042a64-d60c-4aa6-bc1a-ae9d0347bde8   in service    none      none          off        
+    oxp_9e809fde-e684-4ee8-8d46-dade081c3c37/crypt/zone                                                            5366ad89-e6ec-47e5-8870-fafc8224f11f   in service    none      none          off        
+    oxp_f2b5fdba-606d-45a4-9a9b-35bf20892bd6/crypt/zone                                                            fb5e2978-9182-46bd-919d-653b86b1fed3   in service    none      none          off        
+    oxp_f2b5fdba-606d-45a4-9a9b-35bf20892bd6/crypt/zone/oxz_crucible_327db2a9-fc45-4c3f-a6db-4ee58459e5cf          ac6a48f2-c9e0-4bf2-9c93-c234efc48a59   in service    none      none          off        
+    oxp_78b8bc9a-8f5b-4fc2-9d70-4470b2d05aae/crypt/zone/oxz_crucible_5ea7f627-d51e-4e2d-8648-112ddc635e53          d449dcc4-1725-4de2-92c0-e1a37d12299a   in service    none      none          off        
+    oxp_9e809fde-e684-4ee8-8d46-dade081c3c37/crypt/zone/oxz_crucible_ad81aafc-e74d-4b0a-b4e6-2e58ef52b7a2          2c018c08-7cc7-45a9-be60-cd6b82874cfc   in service    none      none          off        
+    oxp_78b8bc9a-8f5b-4fc2-9d70-4470b2d05aae/crypt/zone/oxz_crucible_pantry_a76d9883-b4fe-464f-acbb-e75b2bbb508d   ad79a937-7410-4e92-89e1-0af1a0595cef   in service    none      none          off        
+    oxp_78b8bc9a-8f5b-4fc2-9d70-4470b2d05aae/crypt/zone/oxz_external_dns_8a651785-3936-4cf6-b301-4fa7fa003c9f      e80f5919-dd7c-4d6c-b0de-45d24c0fe421   in service    none      none          off        
+    oxp_78b8bc9a-8f5b-4fc2-9d70-4470b2d05aae/crypt/zone/oxz_internal_dns_f14b0fff-c0f0-420f-ab51-df1a605f43c3      fd542516-55e6-42c6-a8de-0128b3cce65e   in service    none      none          off        
+    oxp_78b8bc9a-8f5b-4fc2-9d70-4470b2d05aae/crypt/zone/oxz_nexus_1dee8f37-8286-48dc-b4b4-e59979c030ec             7c89c13d-8f41-4c69-96d2-6f9ffbc27cbb   in service    none      none          off        
+    oxp_78b8bc9a-8f5b-4fc2-9d70-4470b2d05aae/crypt/zone/oxz_ntp_f282c429-5f5e-4430-8f71-600cf61ded56               7ea314c5-c702-4f47-b70c-02e5131682be   in service    none      none          off        
+    oxp_78b8bc9a-8f5b-4fc2-9d70-4470b2d05aae/crypt/debug                                                           b43d1c1e-5482-40de-869e-8cd2741c6fc0   in service    100 GiB   none          gzip-9     
+    oxp_9e809fde-e684-4ee8-8d46-dade081c3c37/crypt/debug                                                           19e5fb1e-c1f8-4262-9232-0f31eb746cdb   in service    100 GiB   none          gzip-9     
+    oxp_f2b5fdba-606d-45a4-9a9b-35bf20892bd6/crypt/debug                                                           ef852bdc-50a0-458e-a3f4-fd77a633d3cb   in service    100 GiB   none          gzip-9     
+
+
+    omicron zones:
+    ---------------------------------------------------------------------------------------------------------------
+    zone type         zone id                                image source      disposition   underlay IP           
+    ---------------------------------------------------------------------------------------------------------------
+    crucible          327db2a9-fc45-4c3f-a6db-4ee58459e5cf   install dataset   in service    fd00:1122:3344:103::27
+    crucible          5ea7f627-d51e-4e2d-8648-112ddc635e53   install dataset   in service    fd00:1122:3344:103::25
+    crucible          ad81aafc-e74d-4b0a-b4e6-2e58ef52b7a2   install dataset   in service    fd00:1122:3344:103::26
+    crucible_pantry   a76d9883-b4fe-464f-acbb-e75b2bbb508d   install dataset   in service    fd00:1122:3344:103::24
+    external_dns      8a651785-3936-4cf6-b301-4fa7fa003c9f   install dataset   in service    fd00:1122:3344:103::23
+    internal_dns      f14b0fff-c0f0-420f-ab51-df1a605f43c3   install dataset   in service    fd00:1122:3344:3::1   
+    internal_ntp      f282c429-5f5e-4430-8f71-600cf61ded56   install dataset   in service    fd00:1122:3344:103::21
+    nexus             1dee8f37-8286-48dc-b4b4-e59979c030ec   install dataset   in service    fd00:1122:3344:103::22
+
+
+ COCKROACHDB SETTINGS:
+    state fingerprint:::::::::::::::::   (none) (unchanged)
+    cluster.preserve_downgrade_option:   (do not modify) (unchanged)
+
+ METADATA:
+    internal DNS version:   1 (unchanged)
+    external DNS version:   1 (unchanged)
+
+ OXIMETER SETTINGS:
+    generation:   1 (unchanged)
+    read from::   SingleNode (unchanged)
+
+ PENDING MGS UPDATES:
+
+    Pending MGS-managed updates (all baseboards):
+    ---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
+    sp_type   slot   part_number   serial_number   artifact_kind   artifact_hash                                                      artifact_version   details                                                                                                               
+    ---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
+-   sled      2      model2        serial2         gimlet_sp       e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855   1.1.0              Sp { expected_active_version: ArtifactVersion("1.0.0"), expected_inactive_version: Version(ArtifactVersion("1.0.1")) }
 
 
 internal DNS:
@@ -849,7 +1157,7 @@ parent:    cca24b71-09b5-4042-9185-b33e9f2ebba0
     external DNS version:   1
 
  PENDING MGS-MANAGED UPDATES: 1
-    Pending MGS-managed updates:
+    Pending MGS-managed updates (all baseboards):
     ---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
     sp_type   slot   part_number   serial_number   artifact_kind   artifact_hash                                                      artifact_version   details                                                                                                               
     ---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
@@ -857,8 +1165,8 @@ parent:    cca24b71-09b5-4042-9185-b33e9f2ebba0
 
 
 
-> blueprint-diff ad97e762-7bf1-45a6-a98f-60afb7e491c0 5bf974f3-81f9-455b-b24e-3099f765664c
-from: blueprint ad97e762-7bf1-45a6-a98f-60afb7e491c0
+> blueprint-diff cca24b71-09b5-4042-9185-b33e9f2ebba0 5bf974f3-81f9-455b-b24e-3099f765664c
+from: blueprint cca24b71-09b5-4042-9185-b33e9f2ebba0
 to:   blueprint 5bf974f3-81f9-455b-b24e-3099f765664c
 
  UNCHANGED SLEDS:
@@ -1027,6 +1335,316 @@ to:   blueprint 5bf974f3-81f9-455b-b24e-3099f765664c
  OXIMETER SETTINGS:
     generation:   1 (unchanged)
     read from::   SingleNode (unchanged)
+
+ PENDING MGS UPDATES:
+
+    Pending MGS-managed updates (all baseboards):
+    ---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
+    sp_type   slot   part_number   serial_number   artifact_kind   artifact_hash                                                      artifact_version   details                                                                                                               
+    ---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
+-   sled      2      model2        serial2         gimlet_sp       e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855   1.1.0              Sp { expected_active_version: ArtifactVersion("1.0.0"), expected_inactive_version: Version(ArtifactVersion("1.0.1")) }
++   sled      2      model2        serial2         gimlet_sp       e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855   newest             Sp { expected_active_version: ArtifactVersion("newer"), expected_inactive_version: Version(ArtifactVersion("older")) }
+
+
+internal DNS:
+  DNS zone: "control-plane.oxide.internal" (unchanged)
+    name: 159e1f8f-6f32-413d-a48b-e40fb2efaf15.host          (records: 1)
+        AAAA fd00:1122:3344:2::1
+    name: 1dee8f37-8286-48dc-b4b4-e59979c030ec.host          (records: 1)
+        AAAA fd00:1122:3344:103::22
+    name: 327db2a9-fc45-4c3f-a6db-4ee58459e5cf.host          (records: 1)
+        AAAA fd00:1122:3344:103::27
+    name: 345fbd68-cb55-4faa-b6ea-801789018bc6.host          (records: 1)
+        AAAA fd00:1122:3344:102::21
+    name: 4ad9c209-bd1b-44c9-863d-1a6b84b34d53.host          (records: 1)
+        AAAA fd00:1122:3344:101::21
+    name: 543b3bb6-358d-4876-9774-53a53187aaa8.host          (records: 1)
+        AAAA fd00:1122:3344:102::22
+    name: 575bd77e-6cd9-4bb6-9c1f-2ac6f149278a.host          (records: 1)
+        AAAA fd00:1122:3344:101::26
+    name: 5c67f8ed-9f38-4be1-b64c-a2d9898d3263.host          (records: 1)
+        AAAA fd00:1122:3344:102::24
+    name: 5ea7f627-d51e-4e2d-8648-112ddc635e53.host          (records: 1)
+        AAAA fd00:1122:3344:103::25
+    name: 6df9649e-48f8-4754-94f3-55e8f9b039be.host          (records: 1)
+        AAAA fd00:1122:3344:101::22
+    name: 70b7e8a1-cc3f-4cdd-a577-4c8be9885f8b.host          (records: 1)
+        AAAA fd00:1122:3344:102::27
+    name: 719199e7-eacf-4add-b532-ddfaf867b478.host          (records: 1)
+        AAAA fd00:1122:3344:101::28
+    name: 7bb9667d-da70-4592-a579-31295f919aed.host          (records: 1)
+        AAAA fd00:1122:3344:102::26
+    name: 86c0837a-73ca-4d08-971d-8491401c2fe2.host          (records: 1)
+        AAAA fd00:1122:3344:101::24
+    name: 8a651785-3936-4cf6-b301-4fa7fa003c9f.host          (records: 1)
+        AAAA fd00:1122:3344:103::23
+    name: 9b8c5aff-3892-4645-8c66-c540456f05af.host          (records: 1)
+        AAAA fd00:1122:3344:101::27
+    name: _clickhouse-admin-single-server._tcp               (records: 1)
+        SRV  port  8888 c138c88c-a83d-4e2d-a8f8-e8e715d8e5f7.host.control-plane.oxide.internal
+    name: _clickhouse-native._tcp                            (records: 1)
+        SRV  port  9000 c138c88c-a83d-4e2d-a8f8-e8e715d8e5f7.host.control-plane.oxide.internal
+    name: _clickhouse._tcp                                   (records: 1)
+        SRV  port  8123 c138c88c-a83d-4e2d-a8f8-e8e715d8e5f7.host.control-plane.oxide.internal
+    name: _crucible-pantry._tcp                              (records: 3)
+        SRV  port 17000 5c67f8ed-9f38-4be1-b64c-a2d9898d3263.host.control-plane.oxide.internal
+        SRV  port 17000 a76d9883-b4fe-464f-acbb-e75b2bbb508d.host.control-plane.oxide.internal
+        SRV  port 17000 c4c56b5a-8c18-4eac-964a-62f94cac07b1.host.control-plane.oxide.internal
+    name: _crucible._tcp.327db2a9-fc45-4c3f-a6db-4ee58459e5cf (records: 1)
+        SRV  port 32345 327db2a9-fc45-4c3f-a6db-4ee58459e5cf.host.control-plane.oxide.internal
+    name: _crucible._tcp.575bd77e-6cd9-4bb6-9c1f-2ac6f149278a (records: 1)
+        SRV  port 32345 575bd77e-6cd9-4bb6-9c1f-2ac6f149278a.host.control-plane.oxide.internal
+    name: _crucible._tcp.5ea7f627-d51e-4e2d-8648-112ddc635e53 (records: 1)
+        SRV  port 32345 5ea7f627-d51e-4e2d-8648-112ddc635e53.host.control-plane.oxide.internal
+    name: _crucible._tcp.70b7e8a1-cc3f-4cdd-a577-4c8be9885f8b (records: 1)
+        SRV  port 32345 70b7e8a1-cc3f-4cdd-a577-4c8be9885f8b.host.control-plane.oxide.internal
+    name: _crucible._tcp.719199e7-eacf-4add-b532-ddfaf867b478 (records: 1)
+        SRV  port 32345 719199e7-eacf-4add-b532-ddfaf867b478.host.control-plane.oxide.internal
+    name: _crucible._tcp.7bb9667d-da70-4592-a579-31295f919aed (records: 1)
+        SRV  port 32345 7bb9667d-da70-4592-a579-31295f919aed.host.control-plane.oxide.internal
+    name: _crucible._tcp.9b8c5aff-3892-4645-8c66-c540456f05af (records: 1)
+        SRV  port 32345 9b8c5aff-3892-4645-8c66-c540456f05af.host.control-plane.oxide.internal
+    name: _crucible._tcp.a5a25771-1025-4c08-9362-c5ee4cecafc9 (records: 1)
+        SRV  port 32345 a5a25771-1025-4c08-9362-c5ee4cecafc9.host.control-plane.oxide.internal
+    name: _crucible._tcp.ad81aafc-e74d-4b0a-b4e6-2e58ef52b7a2 (records: 1)
+        SRV  port 32345 ad81aafc-e74d-4b0a-b4e6-2e58ef52b7a2.host.control-plane.oxide.internal
+    name: _external-dns._tcp                                 (records: 3)
+        SRV  port  5353 86c0837a-73ca-4d08-971d-8491401c2fe2.host.control-plane.oxide.internal
+        SRV  port  5353 8a651785-3936-4cf6-b301-4fa7fa003c9f.host.control-plane.oxide.internal
+        SRV  port  5353 b067565e-df5a-441f-85b9-69acc38bbf35.host.control-plane.oxide.internal
+    name: _internal-ntp._tcp                                 (records: 3)
+        SRV  port   123 345fbd68-cb55-4faa-b6ea-801789018bc6.host.control-plane.oxide.internal
+        SRV  port   123 4ad9c209-bd1b-44c9-863d-1a6b84b34d53.host.control-plane.oxide.internal
+        SRV  port   123 f282c429-5f5e-4430-8f71-600cf61ded56.host.control-plane.oxide.internal
+    name: _nameservice._tcp                                  (records: 3)
+        SRV  port  5353 159e1f8f-6f32-413d-a48b-e40fb2efaf15.host.control-plane.oxide.internal
+        SRV  port  5353 ae5b529a-2ada-490c-bea9-04c71cf8e72c.host.control-plane.oxide.internal
+        SRV  port  5353 f14b0fff-c0f0-420f-ab51-df1a605f43c3.host.control-plane.oxide.internal
+    name: _nexus._tcp                                        (records: 3)
+        SRV  port 12221 1dee8f37-8286-48dc-b4b4-e59979c030ec.host.control-plane.oxide.internal
+        SRV  port 12221 543b3bb6-358d-4876-9774-53a53187aaa8.host.control-plane.oxide.internal
+        SRV  port 12221 6df9649e-48f8-4754-94f3-55e8f9b039be.host.control-plane.oxide.internal
+    name: _oximeter-reader._tcp                              (records: 1)
+        SRV  port  9000 c138c88c-a83d-4e2d-a8f8-e8e715d8e5f7.host.control-plane.oxide.internal
+    name: _repo-depot._tcp                                   (records: 3)
+        SRV  port 12348 bb0ec23a-f97c-4b6a-a5bc-864b1ebc9236.sled.control-plane.oxide.internal
+        SRV  port 12348 bba6ea73-6c9c-4ab5-8bb4-1dd145071407.sled.control-plane.oxide.internal
+        SRV  port 12348 cc00b21a-5685-480a-ab5e-d2e29cf369df.sled.control-plane.oxide.internal
+    name: a5a25771-1025-4c08-9362-c5ee4cecafc9.host          (records: 1)
+        AAAA fd00:1122:3344:102::25
+    name: a76d9883-b4fe-464f-acbb-e75b2bbb508d.host          (records: 1)
+        AAAA fd00:1122:3344:103::24
+    name: ad81aafc-e74d-4b0a-b4e6-2e58ef52b7a2.host          (records: 1)
+        AAAA fd00:1122:3344:103::26
+    name: ae5b529a-2ada-490c-bea9-04c71cf8e72c.host          (records: 1)
+        AAAA fd00:1122:3344:1::1
+    name: b067565e-df5a-441f-85b9-69acc38bbf35.host          (records: 1)
+        AAAA fd00:1122:3344:102::23
+    name: bb0ec23a-f97c-4b6a-a5bc-864b1ebc9236.sled          (records: 1)
+        AAAA fd00:1122:3344:101::1
+    name: bba6ea73-6c9c-4ab5-8bb4-1dd145071407.sled          (records: 1)
+        AAAA fd00:1122:3344:102::1
+    name: c138c88c-a83d-4e2d-a8f8-e8e715d8e5f7.host          (records: 1)
+        AAAA fd00:1122:3344:101::23
+    name: c4c56b5a-8c18-4eac-964a-62f94cac07b1.host          (records: 1)
+        AAAA fd00:1122:3344:101::25
+    name: cc00b21a-5685-480a-ab5e-d2e29cf369df.sled          (records: 1)
+        AAAA fd00:1122:3344:103::1
+    name: f14b0fff-c0f0-420f-ab51-df1a605f43c3.host          (records: 1)
+        AAAA fd00:1122:3344:3::1
+    name: f282c429-5f5e-4430-8f71-600cf61ded56.host          (records: 1)
+        AAAA fd00:1122:3344:103::21
+
+external DNS:
+  DNS zone: "oxide.example" (unchanged)
+    name: example-silo.sys                                   (records: 3)
+        A    192.0.2.2
+        A    192.0.2.3
+        A    192.0.2.4
+
+
+
+> # diff in the reverse direction.  Should still show one modification.
+
+> blueprint-diff 5bf974f3-81f9-455b-b24e-3099f765664c cca24b71-09b5-4042-9185-b33e9f2ebba0
+from: blueprint 5bf974f3-81f9-455b-b24e-3099f765664c
+to:   blueprint cca24b71-09b5-4042-9185-b33e9f2ebba0
+
+ UNCHANGED SLEDS:
+
+  sled bb0ec23a-f97c-4b6a-a5bc-864b1ebc9236 (active, config generation 2):
+
+    physical disks:
+    ------------------------------------------------------------------------------------
+    vendor        model        serial                                        disposition
+    ------------------------------------------------------------------------------------
+    fake-vendor   fake-model   serial-a156a6d9-e839-4cb2-9d09-faf012dae700   in service 
+    fake-vendor   fake-model   serial-b48b5b36-fbb1-4c71-8b08-34a58b3ed2bd   in service 
+    fake-vendor   fake-model   serial-b62945fd-6ac2-4ec2-9e13-0a9a10620924   in service 
+
+
+    datasets:
+    -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
+    dataset name                                                                                                   dataset id                             disposition   quota     reservation   compression
+    -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
+    oxp_a156a6d9-e839-4cb2-9d09-faf012dae700/crucible                                                              bbf79ca9-a619-4142-9802-d306a4b58acb   in service    none      none          off        
+    oxp_b48b5b36-fbb1-4c71-8b08-34a58b3ed2bd/crucible                                                              ff6da666-707c-4370-b0d9-0572d8851e9d   in service    none      none          off        
+    oxp_b62945fd-6ac2-4ec2-9e13-0a9a10620924/crucible                                                              1f46779a-37b2-48d7-8ea9-a4e988bb0045   in service    none      none          off        
+    oxp_a156a6d9-e839-4cb2-9d09-faf012dae700/crypt/clickhouse                                                      43b6b5c0-61d8-4b88-bbb8-abede5589619   in service    none      none          off        
+    oxp_a156a6d9-e839-4cb2-9d09-faf012dae700/crypt/external_dns                                                    f5fc02e2-46ff-4012-a5c0-c91ad7881642   in service    none      none          off        
+    oxp_a156a6d9-e839-4cb2-9d09-faf012dae700/crypt/internal_dns                                                    2c16250f-d4aa-4fb5-bf4b-a6b5d72ac441   in service    none      none          off        
+    oxp_a156a6d9-e839-4cb2-9d09-faf012dae700/crypt/zone                                                            9077f1bd-3864-43d5-9c02-9370cbb9156d   in service    none      none          off        
+    oxp_b48b5b36-fbb1-4c71-8b08-34a58b3ed2bd/crypt/zone                                                            f4febe2f-789b-4c28-8bb7-aa594e0e4a4f   in service    none      none          off        
+    oxp_b62945fd-6ac2-4ec2-9e13-0a9a10620924/crypt/zone                                                            de0fe910-037f-49da-b86b-5865818c568d   in service    none      none          off        
+    oxp_a156a6d9-e839-4cb2-9d09-faf012dae700/crypt/zone/oxz_clickhouse_c138c88c-a83d-4e2d-a8f8-e8e715d8e5f7        7de7e173-0287-4e01-ad60-73681156e0e4   in service    none      none          off        
+    oxp_a156a6d9-e839-4cb2-9d09-faf012dae700/crypt/zone/oxz_crucible_575bd77e-6cd9-4bb6-9c1f-2ac6f149278a          252039e9-e48e-4790-930d-a8fad52256d7   in service    none      none          off        
+    oxp_b62945fd-6ac2-4ec2-9e13-0a9a10620924/crypt/zone/oxz_crucible_719199e7-eacf-4add-b532-ddfaf867b478          7ca01115-8692-438a-aa91-84b7c11f5ef2   in service    none      none          off        
+    oxp_b48b5b36-fbb1-4c71-8b08-34a58b3ed2bd/crypt/zone/oxz_crucible_9b8c5aff-3892-4645-8c66-c540456f05af          61a88822-ec1a-4c94-8134-f5d33e342428   in service    none      none          off        
+    oxp_a156a6d9-e839-4cb2-9d09-faf012dae700/crypt/zone/oxz_crucible_pantry_c4c56b5a-8c18-4eac-964a-62f94cac07b1   45b1fd69-7ace-41f8-97bc-3f6e99314e8a   in service    none      none          off        
+    oxp_a156a6d9-e839-4cb2-9d09-faf012dae700/crypt/zone/oxz_external_dns_86c0837a-73ca-4d08-971d-8491401c2fe2      6159b0b8-1c4b-4dd4-a32e-5c5a93df859b   in service    none      none          off        
+    oxp_a156a6d9-e839-4cb2-9d09-faf012dae700/crypt/zone/oxz_internal_dns_ae5b529a-2ada-490c-bea9-04c71cf8e72c      9f74b627-d96c-4183-92f4-7cfaca681fb5   in service    none      none          off        
+    oxp_a156a6d9-e839-4cb2-9d09-faf012dae700/crypt/zone/oxz_nexus_6df9649e-48f8-4754-94f3-55e8f9b039be             6985e6b4-a53b-4a88-bda6-41d2da73af48   in service    none      none          off        
+    oxp_a156a6d9-e839-4cb2-9d09-faf012dae700/crypt/zone/oxz_ntp_4ad9c209-bd1b-44c9-863d-1a6b84b34d53               233b6c7d-284f-42e6-b9e5-607e9377387d   in service    none      none          off        
+    oxp_a156a6d9-e839-4cb2-9d09-faf012dae700/crypt/debug                                                           a510cf34-74db-44fc-903f-36704f21ae67   in service    100 GiB   none          gzip-9     
+    oxp_b48b5b36-fbb1-4c71-8b08-34a58b3ed2bd/crypt/debug                                                           b9f7efe9-5088-45a3-96d9-6cc69be0ec72   in service    100 GiB   none          gzip-9     
+    oxp_b62945fd-6ac2-4ec2-9e13-0a9a10620924/crypt/debug                                                           ae71243d-118a-4e43-b4e3-9e425c6b8395   in service    100 GiB   none          gzip-9     
+
+
+    omicron zones:
+    ---------------------------------------------------------------------------------------------------------------
+    zone type         zone id                                image source      disposition   underlay IP           
+    ---------------------------------------------------------------------------------------------------------------
+    clickhouse        c138c88c-a83d-4e2d-a8f8-e8e715d8e5f7   install dataset   in service    fd00:1122:3344:101::23
+    crucible          575bd77e-6cd9-4bb6-9c1f-2ac6f149278a   install dataset   in service    fd00:1122:3344:101::26
+    crucible          719199e7-eacf-4add-b532-ddfaf867b478   install dataset   in service    fd00:1122:3344:101::28
+    crucible          9b8c5aff-3892-4645-8c66-c540456f05af   install dataset   in service    fd00:1122:3344:101::27
+    crucible_pantry   c4c56b5a-8c18-4eac-964a-62f94cac07b1   install dataset   in service    fd00:1122:3344:101::25
+    external_dns      86c0837a-73ca-4d08-971d-8491401c2fe2   install dataset   in service    fd00:1122:3344:101::24
+    internal_dns      ae5b529a-2ada-490c-bea9-04c71cf8e72c   install dataset   in service    fd00:1122:3344:1::1   
+    internal_ntp      4ad9c209-bd1b-44c9-863d-1a6b84b34d53   install dataset   in service    fd00:1122:3344:101::21
+    nexus             6df9649e-48f8-4754-94f3-55e8f9b039be   install dataset   in service    fd00:1122:3344:101::22
+
+
+  sled bba6ea73-6c9c-4ab5-8bb4-1dd145071407 (active, config generation 2):
+
+    physical disks:
+    ------------------------------------------------------------------------------------
+    vendor        model        serial                                        disposition
+    ------------------------------------------------------------------------------------
+    fake-vendor   fake-model   serial-2201d82d-3a3c-4744-ac41-657536a90afe   in service 
+    fake-vendor   fake-model   serial-bdf3642c-a783-4689-a8a6-8cfa257089bd   in service 
+    fake-vendor   fake-model   serial-eeb9b9ce-ac1c-4a41-9a7a-814e26e2a9ee   in service 
+
+
+    datasets:
+    -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
+    dataset name                                                                                                   dataset id                             disposition   quota     reservation   compression
+    -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
+    oxp_2201d82d-3a3c-4744-ac41-657536a90afe/crucible                                                              66beebb3-2b7a-4334-9ea7-e7c714b6dacc   in service    none      none          off        
+    oxp_bdf3642c-a783-4689-a8a6-8cfa257089bd/crucible                                                              4611f0cd-1ef4-42f2-b1bd-8ce5c0ee1ba4   in service    none      none          off        
+    oxp_eeb9b9ce-ac1c-4a41-9a7a-814e26e2a9ee/crucible                                                              4420b086-b23f-4ba6-b504-459a38e3b367   in service    none      none          off        
+    oxp_2201d82d-3a3c-4744-ac41-657536a90afe/crypt/external_dns                                                    ffe1a3c8-7546-495f-b437-f2405be4e533   in service    none      none          off        
+    oxp_2201d82d-3a3c-4744-ac41-657536a90afe/crypt/internal_dns                                                    c5300adb-042e-41fd-9b1f-5c01d68e7eb4   in service    none      none          off        
+    oxp_2201d82d-3a3c-4744-ac41-657536a90afe/crypt/zone                                                            06dfa1c2-42c3-4626-8bf3-4460dfec3646   in service    none      none          off        
+    oxp_bdf3642c-a783-4689-a8a6-8cfa257089bd/crypt/zone                                                            89ae62b7-0cff-4e09-b4e9-4c43bf242e1d   in service    none      none          off        
+    oxp_eeb9b9ce-ac1c-4a41-9a7a-814e26e2a9ee/crypt/zone                                                            78269a0c-ce98-4834-ae9e-d25eee99a079   in service    none      none          off        
+    oxp_eeb9b9ce-ac1c-4a41-9a7a-814e26e2a9ee/crypt/zone/oxz_crucible_70b7e8a1-cc3f-4cdd-a577-4c8be9885f8b          1382d296-a276-40ca-85b3-9f2578cb95cf   in service    none      none          off        
+    oxp_bdf3642c-a783-4689-a8a6-8cfa257089bd/crypt/zone/oxz_crucible_7bb9667d-da70-4592-a579-31295f919aed          57d3c6cb-64ff-4485-87c0-3ff5fe9c45d8   in service    none      none          off        
+    oxp_2201d82d-3a3c-4744-ac41-657536a90afe/crypt/zone/oxz_crucible_a5a25771-1025-4c08-9362-c5ee4cecafc9          a0e1cc1c-d542-4a21-96bb-efdfe40af009   in service    none      none          off        
+    oxp_2201d82d-3a3c-4744-ac41-657536a90afe/crypt/zone/oxz_crucible_pantry_5c67f8ed-9f38-4be1-b64c-a2d9898d3263   4f3e7986-e836-4ecc-ac69-8c013905707c   in service    none      none          off        
+    oxp_2201d82d-3a3c-4744-ac41-657536a90afe/crypt/zone/oxz_external_dns_b067565e-df5a-441f-85b9-69acc38bbf35      bc7affdc-54b9-4172-8264-af82b92fdfe0   in service    none      none          off        
+    oxp_2201d82d-3a3c-4744-ac41-657536a90afe/crypt/zone/oxz_internal_dns_159e1f8f-6f32-413d-a48b-e40fb2efaf15      79d73706-f701-4857-a378-fcf026cd6756   in service    none      none          off        
+    oxp_2201d82d-3a3c-4744-ac41-657536a90afe/crypt/zone/oxz_nexus_543b3bb6-358d-4876-9774-53a53187aaa8             71b813ec-4a24-43d1-b0b8-5c3303a1d9b5   in service    none      none          off        
+    oxp_2201d82d-3a3c-4744-ac41-657536a90afe/crypt/zone/oxz_ntp_345fbd68-cb55-4faa-b6ea-801789018bc6               d4126675-e113-4a2d-826a-cf7b224b794b   in service    none      none          off        
+    oxp_2201d82d-3a3c-4744-ac41-657536a90afe/crypt/debug                                                           afe7ef8e-c974-403e-932e-eb3c8057b22d   in service    100 GiB   none          gzip-9     
+    oxp_bdf3642c-a783-4689-a8a6-8cfa257089bd/crypt/debug                                                           f5f65250-3145-41bf-b462-359728bda24a   in service    100 GiB   none          gzip-9     
+    oxp_eeb9b9ce-ac1c-4a41-9a7a-814e26e2a9ee/crypt/debug                                                           7328892a-0525-401f-9160-a8e4501049fd   in service    100 GiB   none          gzip-9     
+
+
+    omicron zones:
+    ---------------------------------------------------------------------------------------------------------------
+    zone type         zone id                                image source      disposition   underlay IP           
+    ---------------------------------------------------------------------------------------------------------------
+    crucible          70b7e8a1-cc3f-4cdd-a577-4c8be9885f8b   install dataset   in service    fd00:1122:3344:102::27
+    crucible          7bb9667d-da70-4592-a579-31295f919aed   install dataset   in service    fd00:1122:3344:102::26
+    crucible          a5a25771-1025-4c08-9362-c5ee4cecafc9   install dataset   in service    fd00:1122:3344:102::25
+    crucible_pantry   5c67f8ed-9f38-4be1-b64c-a2d9898d3263   install dataset   in service    fd00:1122:3344:102::24
+    external_dns      b067565e-df5a-441f-85b9-69acc38bbf35   install dataset   in service    fd00:1122:3344:102::23
+    internal_dns      159e1f8f-6f32-413d-a48b-e40fb2efaf15   install dataset   in service    fd00:1122:3344:2::1   
+    internal_ntp      345fbd68-cb55-4faa-b6ea-801789018bc6   install dataset   in service    fd00:1122:3344:102::21
+    nexus             543b3bb6-358d-4876-9774-53a53187aaa8   install dataset   in service    fd00:1122:3344:102::22
+
+
+  sled cc00b21a-5685-480a-ab5e-d2e29cf369df (active, config generation 2):
+
+    physical disks:
+    ------------------------------------------------------------------------------------
+    vendor        model        serial                                        disposition
+    ------------------------------------------------------------------------------------
+    fake-vendor   fake-model   serial-78b8bc9a-8f5b-4fc2-9d70-4470b2d05aae   in service 
+    fake-vendor   fake-model   serial-9e809fde-e684-4ee8-8d46-dade081c3c37   in service 
+    fake-vendor   fake-model   serial-f2b5fdba-606d-45a4-9a9b-35bf20892bd6   in service 
+
+
+    datasets:
+    -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
+    dataset name                                                                                                   dataset id                             disposition   quota     reservation   compression
+    -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
+    oxp_78b8bc9a-8f5b-4fc2-9d70-4470b2d05aae/crucible                                                              a84f76f4-1f8c-4772-a072-ffb0dc7c281c   in service    none      none          off        
+    oxp_9e809fde-e684-4ee8-8d46-dade081c3c37/crucible                                                              db8f2cdf-721f-4c56-880e-d9265ec404f5   in service    none      none          off        
+    oxp_f2b5fdba-606d-45a4-9a9b-35bf20892bd6/crucible                                                              faa61220-8f21-4231-b069-3fb417699363   in service    none      none          off        
+    oxp_78b8bc9a-8f5b-4fc2-9d70-4470b2d05aae/crypt/external_dns                                                    b47f981e-ac2d-4ec1-8e67-c15dcf13af86   in service    none      none          off        
+    oxp_78b8bc9a-8f5b-4fc2-9d70-4470b2d05aae/crypt/internal_dns                                                    037ef4f6-dae1-478e-8397-3b68bf8e47dc   in service    none      none          off        
+    oxp_78b8bc9a-8f5b-4fc2-9d70-4470b2d05aae/crypt/zone                                                            fa042a64-d60c-4aa6-bc1a-ae9d0347bde8   in service    none      none          off        
+    oxp_9e809fde-e684-4ee8-8d46-dade081c3c37/crypt/zone                                                            5366ad89-e6ec-47e5-8870-fafc8224f11f   in service    none      none          off        
+    oxp_f2b5fdba-606d-45a4-9a9b-35bf20892bd6/crypt/zone                                                            fb5e2978-9182-46bd-919d-653b86b1fed3   in service    none      none          off        
+    oxp_f2b5fdba-606d-45a4-9a9b-35bf20892bd6/crypt/zone/oxz_crucible_327db2a9-fc45-4c3f-a6db-4ee58459e5cf          ac6a48f2-c9e0-4bf2-9c93-c234efc48a59   in service    none      none          off        
+    oxp_78b8bc9a-8f5b-4fc2-9d70-4470b2d05aae/crypt/zone/oxz_crucible_5ea7f627-d51e-4e2d-8648-112ddc635e53          d449dcc4-1725-4de2-92c0-e1a37d12299a   in service    none      none          off        
+    oxp_9e809fde-e684-4ee8-8d46-dade081c3c37/crypt/zone/oxz_crucible_ad81aafc-e74d-4b0a-b4e6-2e58ef52b7a2          2c018c08-7cc7-45a9-be60-cd6b82874cfc   in service    none      none          off        
+    oxp_78b8bc9a-8f5b-4fc2-9d70-4470b2d05aae/crypt/zone/oxz_crucible_pantry_a76d9883-b4fe-464f-acbb-e75b2bbb508d   ad79a937-7410-4e92-89e1-0af1a0595cef   in service    none      none          off        
+    oxp_78b8bc9a-8f5b-4fc2-9d70-4470b2d05aae/crypt/zone/oxz_external_dns_8a651785-3936-4cf6-b301-4fa7fa003c9f      e80f5919-dd7c-4d6c-b0de-45d24c0fe421   in service    none      none          off        
+    oxp_78b8bc9a-8f5b-4fc2-9d70-4470b2d05aae/crypt/zone/oxz_internal_dns_f14b0fff-c0f0-420f-ab51-df1a605f43c3      fd542516-55e6-42c6-a8de-0128b3cce65e   in service    none      none          off        
+    oxp_78b8bc9a-8f5b-4fc2-9d70-4470b2d05aae/crypt/zone/oxz_nexus_1dee8f37-8286-48dc-b4b4-e59979c030ec             7c89c13d-8f41-4c69-96d2-6f9ffbc27cbb   in service    none      none          off        
+    oxp_78b8bc9a-8f5b-4fc2-9d70-4470b2d05aae/crypt/zone/oxz_ntp_f282c429-5f5e-4430-8f71-600cf61ded56               7ea314c5-c702-4f47-b70c-02e5131682be   in service    none      none          off        
+    oxp_78b8bc9a-8f5b-4fc2-9d70-4470b2d05aae/crypt/debug                                                           b43d1c1e-5482-40de-869e-8cd2741c6fc0   in service    100 GiB   none          gzip-9     
+    oxp_9e809fde-e684-4ee8-8d46-dade081c3c37/crypt/debug                                                           19e5fb1e-c1f8-4262-9232-0f31eb746cdb   in service    100 GiB   none          gzip-9     
+    oxp_f2b5fdba-606d-45a4-9a9b-35bf20892bd6/crypt/debug                                                           ef852bdc-50a0-458e-a3f4-fd77a633d3cb   in service    100 GiB   none          gzip-9     
+
+
+    omicron zones:
+    ---------------------------------------------------------------------------------------------------------------
+    zone type         zone id                                image source      disposition   underlay IP           
+    ---------------------------------------------------------------------------------------------------------------
+    crucible          327db2a9-fc45-4c3f-a6db-4ee58459e5cf   install dataset   in service    fd00:1122:3344:103::27
+    crucible          5ea7f627-d51e-4e2d-8648-112ddc635e53   install dataset   in service    fd00:1122:3344:103::25
+    crucible          ad81aafc-e74d-4b0a-b4e6-2e58ef52b7a2   install dataset   in service    fd00:1122:3344:103::26
+    crucible_pantry   a76d9883-b4fe-464f-acbb-e75b2bbb508d   install dataset   in service    fd00:1122:3344:103::24
+    external_dns      8a651785-3936-4cf6-b301-4fa7fa003c9f   install dataset   in service    fd00:1122:3344:103::23
+    internal_dns      f14b0fff-c0f0-420f-ab51-df1a605f43c3   install dataset   in service    fd00:1122:3344:3::1   
+    internal_ntp      f282c429-5f5e-4430-8f71-600cf61ded56   install dataset   in service    fd00:1122:3344:103::21
+    nexus             1dee8f37-8286-48dc-b4b4-e59979c030ec   install dataset   in service    fd00:1122:3344:103::22
+
+
+ COCKROACHDB SETTINGS:
+    state fingerprint:::::::::::::::::   (none) (unchanged)
+    cluster.preserve_downgrade_option:   (do not modify) (unchanged)
+
+ METADATA:
+    internal DNS version:   1 (unchanged)
+    external DNS version:   1 (unchanged)
+
+ OXIMETER SETTINGS:
+    generation:   1 (unchanged)
+    read from::   SingleNode (unchanged)
+
+ PENDING MGS UPDATES:
+
+    Pending MGS-managed updates (all baseboards):
+    ---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
+    sp_type   slot   part_number   serial_number   artifact_kind   artifact_hash                                                      artifact_version   details                                                                                                               
+    ---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
+-   sled      2      model2        serial2         gimlet_sp       e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855   newest             Sp { expected_active_version: ArtifactVersion("newer"), expected_inactive_version: Version(ArtifactVersion("older")) }
++   sled      2      model2        serial2         gimlet_sp       e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855   1.1.0              Sp { expected_active_version: ArtifactVersion("1.0.0"), expected_inactive_version: Version(ArtifactVersion("1.0.1")) }
 
 
 internal DNS:
@@ -1334,7 +1952,7 @@ parent:    5bf974f3-81f9-455b-b24e-3099f765664c
     external DNS version:   1
 
  PENDING MGS-MANAGED UPDATES: 2
-    Pending MGS-managed updates:
+    Pending MGS-managed updates (all baseboards):
     ---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
     sp_type   slot   part_number   serial_number   artifact_kind   artifact_hash                                                      artifact_version   details                                                                                                               
     ---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
@@ -1513,6 +2131,15 @@ to:   blueprint 1b837a27-3be1-4fcb-8499-a921c839e1d0
  OXIMETER SETTINGS:
     generation:   1 (unchanged)
     read from::   SingleNode (unchanged)
+
+ PENDING MGS UPDATES:
+
+    Pending MGS-managed updates (all baseboards):
+    ---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
+    sp_type   slot   part_number   serial_number   artifact_kind   artifact_hash                                                      artifact_version   details                                                                                                               
+    ---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
+    sled      2      model2        serial2         gimlet_sp       e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855   newest             Sp { expected_active_version: ArtifactVersion("newer"), expected_inactive_version: Version(ArtifactVersion("older")) }
++   sled      0      model0        serial0         gimlet_sp       e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855   three              Sp { expected_active_version: ArtifactVersion("two"), expected_inactive_version: NoValidVersion }                     
 
 
 internal DNS:
@@ -1815,7 +2442,7 @@ parent:    1b837a27-3be1-4fcb-8499-a921c839e1d0
     external DNS version:   1
 
  PENDING MGS-MANAGED UPDATES: 1
-    Pending MGS-managed updates:
+    Pending MGS-managed updates (all baseboards):
     ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
     sp_type   slot   part_number   serial_number   artifact_kind   artifact_hash                                                      artifact_version   details                                                                                          
     ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
@@ -1994,6 +2621,15 @@ to:   blueprint 3682a71b-c6ca-4b7e-8f84-16df80c85960
     generation:   1 (unchanged)
     read from::   SingleNode (unchanged)
 
+ PENDING MGS UPDATES:
+
+    Pending MGS-managed updates (all baseboards):
+    ---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
+    sp_type   slot   part_number   serial_number   artifact_kind   artifact_hash                                                      artifact_version   details                                                                                                               
+    ---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
+    sled      0      model0        serial0         gimlet_sp       e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855   three              Sp { expected_active_version: ArtifactVersion("two"), expected_inactive_version: NoValidVersion }                     
+-   sled      2      model2        serial2         gimlet_sp       e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855   newest             Sp { expected_active_version: ArtifactVersion("newer"), expected_inactive_version: Version(ArtifactVersion("older")) }
+
 
 internal DNS:
   DNS zone: "control-plane.oxide.internal" (unchanged)
@@ -2152,6 +2788,33 @@ Arguments:
   <SERIAL>         serial number to update
   <ARTIFACT_HASH>  artifact hash id
   <VERSION>        version
+
+Options:
+  -h, --help  Print help
+
+> blueprint-edit ad97e762-7bf1-45a6-a98f-60afb7e491c0 sp-update-set serial0 e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855 three --help
+configure an SP update
+
+Usage: blueprint-edit <BLUEPRINT_ID> sp-update-set <SERIAL> <ARTIFACT_HASH> <VERSION> <COMMAND>
+
+Commands:
+  sp    
+  help  Print this message or the help of the given subcommand(s)
+
+Arguments:
+  <SERIAL>         serial number to update
+  <ARTIFACT_HASH>  artifact hash id
+  <VERSION>        version
+
+Options:
+  -h, --help  Print help
+
+> blueprint-edit ad97e762-7bf1-45a6-a98f-60afb7e491c0 sp-update-set serial0 e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855 three sp --help
+Usage: blueprint-edit sp-update-set <SERIAL> <ARTIFACT_HASH> <VERSION> sp <EXPECTED_ACTIVE_VERSION> <EXPECTED_INACTIVE_VERSION>
+
+Arguments:
+  <EXPECTED_ACTIVE_VERSION>    
+  <EXPECTED_INACTIVE_VERSION>  
 
 Options:
   -h, --help  Print help

--- a/dev-tools/reconfigurator-cli/tests/output/cmd-set-mgs-updates-stdout
+++ b/dev-tools/reconfigurator-cli/tests/output/cmd-set-mgs-updates-stdout
@@ -1,0 +1,2172 @@
+using provided RNG seed: test_set_mgs_updates
+> # Load example system
+
+> load-example --nsleds 3 --ndisks-per-sled 3
+loaded example system with:
+- collection: 365bdc65-0d27-4f02-aa72-09c39232ebfc
+- blueprint: ad97e762-7bf1-45a6-a98f-60afb7e491c0
+
+> blueprint-show ad97e762-7bf1-45a6-a98f-60afb7e491c0
+blueprint  ad97e762-7bf1-45a6-a98f-60afb7e491c0
+parent:    6ccc786b-17f1-4562-958f-5a7d9a5a15fd
+
+  sled: bb0ec23a-f97c-4b6a-a5bc-864b1ebc9236 (active, config generation 2)
+
+    physical disks:
+    ------------------------------------------------------------------------------------
+    vendor        model        serial                                        disposition
+    ------------------------------------------------------------------------------------
+    fake-vendor   fake-model   serial-a156a6d9-e839-4cb2-9d09-faf012dae700   in service 
+    fake-vendor   fake-model   serial-b48b5b36-fbb1-4c71-8b08-34a58b3ed2bd   in service 
+    fake-vendor   fake-model   serial-b62945fd-6ac2-4ec2-9e13-0a9a10620924   in service 
+
+
+    datasets:
+    -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
+    dataset name                                                                                                   dataset id                             disposition   quota     reservation   compression
+    -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
+    oxp_a156a6d9-e839-4cb2-9d09-faf012dae700/crucible                                                              bbf79ca9-a619-4142-9802-d306a4b58acb   in service    none      none          off        
+    oxp_b48b5b36-fbb1-4c71-8b08-34a58b3ed2bd/crucible                                                              ff6da666-707c-4370-b0d9-0572d8851e9d   in service    none      none          off        
+    oxp_b62945fd-6ac2-4ec2-9e13-0a9a10620924/crucible                                                              1f46779a-37b2-48d7-8ea9-a4e988bb0045   in service    none      none          off        
+    oxp_a156a6d9-e839-4cb2-9d09-faf012dae700/crypt/clickhouse                                                      43b6b5c0-61d8-4b88-bbb8-abede5589619   in service    none      none          off        
+    oxp_a156a6d9-e839-4cb2-9d09-faf012dae700/crypt/external_dns                                                    f5fc02e2-46ff-4012-a5c0-c91ad7881642   in service    none      none          off        
+    oxp_a156a6d9-e839-4cb2-9d09-faf012dae700/crypt/internal_dns                                                    2c16250f-d4aa-4fb5-bf4b-a6b5d72ac441   in service    none      none          off        
+    oxp_a156a6d9-e839-4cb2-9d09-faf012dae700/crypt/zone                                                            9077f1bd-3864-43d5-9c02-9370cbb9156d   in service    none      none          off        
+    oxp_b48b5b36-fbb1-4c71-8b08-34a58b3ed2bd/crypt/zone                                                            f4febe2f-789b-4c28-8bb7-aa594e0e4a4f   in service    none      none          off        
+    oxp_b62945fd-6ac2-4ec2-9e13-0a9a10620924/crypt/zone                                                            de0fe910-037f-49da-b86b-5865818c568d   in service    none      none          off        
+    oxp_a156a6d9-e839-4cb2-9d09-faf012dae700/crypt/zone/oxz_clickhouse_c138c88c-a83d-4e2d-a8f8-e8e715d8e5f7        7de7e173-0287-4e01-ad60-73681156e0e4   in service    none      none          off        
+    oxp_a156a6d9-e839-4cb2-9d09-faf012dae700/crypt/zone/oxz_crucible_575bd77e-6cd9-4bb6-9c1f-2ac6f149278a          252039e9-e48e-4790-930d-a8fad52256d7   in service    none      none          off        
+    oxp_b62945fd-6ac2-4ec2-9e13-0a9a10620924/crypt/zone/oxz_crucible_719199e7-eacf-4add-b532-ddfaf867b478          7ca01115-8692-438a-aa91-84b7c11f5ef2   in service    none      none          off        
+    oxp_b48b5b36-fbb1-4c71-8b08-34a58b3ed2bd/crypt/zone/oxz_crucible_9b8c5aff-3892-4645-8c66-c540456f05af          61a88822-ec1a-4c94-8134-f5d33e342428   in service    none      none          off        
+    oxp_a156a6d9-e839-4cb2-9d09-faf012dae700/crypt/zone/oxz_crucible_pantry_c4c56b5a-8c18-4eac-964a-62f94cac07b1   45b1fd69-7ace-41f8-97bc-3f6e99314e8a   in service    none      none          off        
+    oxp_a156a6d9-e839-4cb2-9d09-faf012dae700/crypt/zone/oxz_external_dns_86c0837a-73ca-4d08-971d-8491401c2fe2      6159b0b8-1c4b-4dd4-a32e-5c5a93df859b   in service    none      none          off        
+    oxp_a156a6d9-e839-4cb2-9d09-faf012dae700/crypt/zone/oxz_internal_dns_ae5b529a-2ada-490c-bea9-04c71cf8e72c      9f74b627-d96c-4183-92f4-7cfaca681fb5   in service    none      none          off        
+    oxp_a156a6d9-e839-4cb2-9d09-faf012dae700/crypt/zone/oxz_nexus_6df9649e-48f8-4754-94f3-55e8f9b039be             6985e6b4-a53b-4a88-bda6-41d2da73af48   in service    none      none          off        
+    oxp_a156a6d9-e839-4cb2-9d09-faf012dae700/crypt/zone/oxz_ntp_4ad9c209-bd1b-44c9-863d-1a6b84b34d53               233b6c7d-284f-42e6-b9e5-607e9377387d   in service    none      none          off        
+    oxp_a156a6d9-e839-4cb2-9d09-faf012dae700/crypt/debug                                                           a510cf34-74db-44fc-903f-36704f21ae67   in service    100 GiB   none          gzip-9     
+    oxp_b48b5b36-fbb1-4c71-8b08-34a58b3ed2bd/crypt/debug                                                           b9f7efe9-5088-45a3-96d9-6cc69be0ec72   in service    100 GiB   none          gzip-9     
+    oxp_b62945fd-6ac2-4ec2-9e13-0a9a10620924/crypt/debug                                                           ae71243d-118a-4e43-b4e3-9e425c6b8395   in service    100 GiB   none          gzip-9     
+
+
+    omicron zones:
+    ---------------------------------------------------------------------------------------------------------------
+    zone type         zone id                                image source      disposition   underlay IP           
+    ---------------------------------------------------------------------------------------------------------------
+    clickhouse        c138c88c-a83d-4e2d-a8f8-e8e715d8e5f7   install dataset   in service    fd00:1122:3344:101::23
+    crucible          575bd77e-6cd9-4bb6-9c1f-2ac6f149278a   install dataset   in service    fd00:1122:3344:101::26
+    crucible          719199e7-eacf-4add-b532-ddfaf867b478   install dataset   in service    fd00:1122:3344:101::28
+    crucible          9b8c5aff-3892-4645-8c66-c540456f05af   install dataset   in service    fd00:1122:3344:101::27
+    crucible_pantry   c4c56b5a-8c18-4eac-964a-62f94cac07b1   install dataset   in service    fd00:1122:3344:101::25
+    external_dns      86c0837a-73ca-4d08-971d-8491401c2fe2   install dataset   in service    fd00:1122:3344:101::24
+    internal_dns      ae5b529a-2ada-490c-bea9-04c71cf8e72c   install dataset   in service    fd00:1122:3344:1::1   
+    internal_ntp      4ad9c209-bd1b-44c9-863d-1a6b84b34d53   install dataset   in service    fd00:1122:3344:101::21
+    nexus             6df9649e-48f8-4754-94f3-55e8f9b039be   install dataset   in service    fd00:1122:3344:101::22
+
+
+
+  sled: bba6ea73-6c9c-4ab5-8bb4-1dd145071407 (active, config generation 2)
+
+    physical disks:
+    ------------------------------------------------------------------------------------
+    vendor        model        serial                                        disposition
+    ------------------------------------------------------------------------------------
+    fake-vendor   fake-model   serial-2201d82d-3a3c-4744-ac41-657536a90afe   in service 
+    fake-vendor   fake-model   serial-bdf3642c-a783-4689-a8a6-8cfa257089bd   in service 
+    fake-vendor   fake-model   serial-eeb9b9ce-ac1c-4a41-9a7a-814e26e2a9ee   in service 
+
+
+    datasets:
+    -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
+    dataset name                                                                                                   dataset id                             disposition   quota     reservation   compression
+    -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
+    oxp_2201d82d-3a3c-4744-ac41-657536a90afe/crucible                                                              66beebb3-2b7a-4334-9ea7-e7c714b6dacc   in service    none      none          off        
+    oxp_bdf3642c-a783-4689-a8a6-8cfa257089bd/crucible                                                              4611f0cd-1ef4-42f2-b1bd-8ce5c0ee1ba4   in service    none      none          off        
+    oxp_eeb9b9ce-ac1c-4a41-9a7a-814e26e2a9ee/crucible                                                              4420b086-b23f-4ba6-b504-459a38e3b367   in service    none      none          off        
+    oxp_2201d82d-3a3c-4744-ac41-657536a90afe/crypt/external_dns                                                    ffe1a3c8-7546-495f-b437-f2405be4e533   in service    none      none          off        
+    oxp_2201d82d-3a3c-4744-ac41-657536a90afe/crypt/internal_dns                                                    c5300adb-042e-41fd-9b1f-5c01d68e7eb4   in service    none      none          off        
+    oxp_2201d82d-3a3c-4744-ac41-657536a90afe/crypt/zone                                                            06dfa1c2-42c3-4626-8bf3-4460dfec3646   in service    none      none          off        
+    oxp_bdf3642c-a783-4689-a8a6-8cfa257089bd/crypt/zone                                                            89ae62b7-0cff-4e09-b4e9-4c43bf242e1d   in service    none      none          off        
+    oxp_eeb9b9ce-ac1c-4a41-9a7a-814e26e2a9ee/crypt/zone                                                            78269a0c-ce98-4834-ae9e-d25eee99a079   in service    none      none          off        
+    oxp_eeb9b9ce-ac1c-4a41-9a7a-814e26e2a9ee/crypt/zone/oxz_crucible_70b7e8a1-cc3f-4cdd-a577-4c8be9885f8b          1382d296-a276-40ca-85b3-9f2578cb95cf   in service    none      none          off        
+    oxp_bdf3642c-a783-4689-a8a6-8cfa257089bd/crypt/zone/oxz_crucible_7bb9667d-da70-4592-a579-31295f919aed          57d3c6cb-64ff-4485-87c0-3ff5fe9c45d8   in service    none      none          off        
+    oxp_2201d82d-3a3c-4744-ac41-657536a90afe/crypt/zone/oxz_crucible_a5a25771-1025-4c08-9362-c5ee4cecafc9          a0e1cc1c-d542-4a21-96bb-efdfe40af009   in service    none      none          off        
+    oxp_2201d82d-3a3c-4744-ac41-657536a90afe/crypt/zone/oxz_crucible_pantry_5c67f8ed-9f38-4be1-b64c-a2d9898d3263   4f3e7986-e836-4ecc-ac69-8c013905707c   in service    none      none          off        
+    oxp_2201d82d-3a3c-4744-ac41-657536a90afe/crypt/zone/oxz_external_dns_b067565e-df5a-441f-85b9-69acc38bbf35      bc7affdc-54b9-4172-8264-af82b92fdfe0   in service    none      none          off        
+    oxp_2201d82d-3a3c-4744-ac41-657536a90afe/crypt/zone/oxz_internal_dns_159e1f8f-6f32-413d-a48b-e40fb2efaf15      79d73706-f701-4857-a378-fcf026cd6756   in service    none      none          off        
+    oxp_2201d82d-3a3c-4744-ac41-657536a90afe/crypt/zone/oxz_nexus_543b3bb6-358d-4876-9774-53a53187aaa8             71b813ec-4a24-43d1-b0b8-5c3303a1d9b5   in service    none      none          off        
+    oxp_2201d82d-3a3c-4744-ac41-657536a90afe/crypt/zone/oxz_ntp_345fbd68-cb55-4faa-b6ea-801789018bc6               d4126675-e113-4a2d-826a-cf7b224b794b   in service    none      none          off        
+    oxp_2201d82d-3a3c-4744-ac41-657536a90afe/crypt/debug                                                           afe7ef8e-c974-403e-932e-eb3c8057b22d   in service    100 GiB   none          gzip-9     
+    oxp_bdf3642c-a783-4689-a8a6-8cfa257089bd/crypt/debug                                                           f5f65250-3145-41bf-b462-359728bda24a   in service    100 GiB   none          gzip-9     
+    oxp_eeb9b9ce-ac1c-4a41-9a7a-814e26e2a9ee/crypt/debug                                                           7328892a-0525-401f-9160-a8e4501049fd   in service    100 GiB   none          gzip-9     
+
+
+    omicron zones:
+    ---------------------------------------------------------------------------------------------------------------
+    zone type         zone id                                image source      disposition   underlay IP           
+    ---------------------------------------------------------------------------------------------------------------
+    crucible          70b7e8a1-cc3f-4cdd-a577-4c8be9885f8b   install dataset   in service    fd00:1122:3344:102::27
+    crucible          7bb9667d-da70-4592-a579-31295f919aed   install dataset   in service    fd00:1122:3344:102::26
+    crucible          a5a25771-1025-4c08-9362-c5ee4cecafc9   install dataset   in service    fd00:1122:3344:102::25
+    crucible_pantry   5c67f8ed-9f38-4be1-b64c-a2d9898d3263   install dataset   in service    fd00:1122:3344:102::24
+    external_dns      b067565e-df5a-441f-85b9-69acc38bbf35   install dataset   in service    fd00:1122:3344:102::23
+    internal_dns      159e1f8f-6f32-413d-a48b-e40fb2efaf15   install dataset   in service    fd00:1122:3344:2::1   
+    internal_ntp      345fbd68-cb55-4faa-b6ea-801789018bc6   install dataset   in service    fd00:1122:3344:102::21
+    nexus             543b3bb6-358d-4876-9774-53a53187aaa8   install dataset   in service    fd00:1122:3344:102::22
+
+
+
+  sled: cc00b21a-5685-480a-ab5e-d2e29cf369df (active, config generation 2)
+
+    physical disks:
+    ------------------------------------------------------------------------------------
+    vendor        model        serial                                        disposition
+    ------------------------------------------------------------------------------------
+    fake-vendor   fake-model   serial-78b8bc9a-8f5b-4fc2-9d70-4470b2d05aae   in service 
+    fake-vendor   fake-model   serial-9e809fde-e684-4ee8-8d46-dade081c3c37   in service 
+    fake-vendor   fake-model   serial-f2b5fdba-606d-45a4-9a9b-35bf20892bd6   in service 
+
+
+    datasets:
+    -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
+    dataset name                                                                                                   dataset id                             disposition   quota     reservation   compression
+    -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
+    oxp_78b8bc9a-8f5b-4fc2-9d70-4470b2d05aae/crucible                                                              a84f76f4-1f8c-4772-a072-ffb0dc7c281c   in service    none      none          off        
+    oxp_9e809fde-e684-4ee8-8d46-dade081c3c37/crucible                                                              db8f2cdf-721f-4c56-880e-d9265ec404f5   in service    none      none          off        
+    oxp_f2b5fdba-606d-45a4-9a9b-35bf20892bd6/crucible                                                              faa61220-8f21-4231-b069-3fb417699363   in service    none      none          off        
+    oxp_78b8bc9a-8f5b-4fc2-9d70-4470b2d05aae/crypt/external_dns                                                    b47f981e-ac2d-4ec1-8e67-c15dcf13af86   in service    none      none          off        
+    oxp_78b8bc9a-8f5b-4fc2-9d70-4470b2d05aae/crypt/internal_dns                                                    037ef4f6-dae1-478e-8397-3b68bf8e47dc   in service    none      none          off        
+    oxp_78b8bc9a-8f5b-4fc2-9d70-4470b2d05aae/crypt/zone                                                            fa042a64-d60c-4aa6-bc1a-ae9d0347bde8   in service    none      none          off        
+    oxp_9e809fde-e684-4ee8-8d46-dade081c3c37/crypt/zone                                                            5366ad89-e6ec-47e5-8870-fafc8224f11f   in service    none      none          off        
+    oxp_f2b5fdba-606d-45a4-9a9b-35bf20892bd6/crypt/zone                                                            fb5e2978-9182-46bd-919d-653b86b1fed3   in service    none      none          off        
+    oxp_f2b5fdba-606d-45a4-9a9b-35bf20892bd6/crypt/zone/oxz_crucible_327db2a9-fc45-4c3f-a6db-4ee58459e5cf          ac6a48f2-c9e0-4bf2-9c93-c234efc48a59   in service    none      none          off        
+    oxp_78b8bc9a-8f5b-4fc2-9d70-4470b2d05aae/crypt/zone/oxz_crucible_5ea7f627-d51e-4e2d-8648-112ddc635e53          d449dcc4-1725-4de2-92c0-e1a37d12299a   in service    none      none          off        
+    oxp_9e809fde-e684-4ee8-8d46-dade081c3c37/crypt/zone/oxz_crucible_ad81aafc-e74d-4b0a-b4e6-2e58ef52b7a2          2c018c08-7cc7-45a9-be60-cd6b82874cfc   in service    none      none          off        
+    oxp_78b8bc9a-8f5b-4fc2-9d70-4470b2d05aae/crypt/zone/oxz_crucible_pantry_a76d9883-b4fe-464f-acbb-e75b2bbb508d   ad79a937-7410-4e92-89e1-0af1a0595cef   in service    none      none          off        
+    oxp_78b8bc9a-8f5b-4fc2-9d70-4470b2d05aae/crypt/zone/oxz_external_dns_8a651785-3936-4cf6-b301-4fa7fa003c9f      e80f5919-dd7c-4d6c-b0de-45d24c0fe421   in service    none      none          off        
+    oxp_78b8bc9a-8f5b-4fc2-9d70-4470b2d05aae/crypt/zone/oxz_internal_dns_f14b0fff-c0f0-420f-ab51-df1a605f43c3      fd542516-55e6-42c6-a8de-0128b3cce65e   in service    none      none          off        
+    oxp_78b8bc9a-8f5b-4fc2-9d70-4470b2d05aae/crypt/zone/oxz_nexus_1dee8f37-8286-48dc-b4b4-e59979c030ec             7c89c13d-8f41-4c69-96d2-6f9ffbc27cbb   in service    none      none          off        
+    oxp_78b8bc9a-8f5b-4fc2-9d70-4470b2d05aae/crypt/zone/oxz_ntp_f282c429-5f5e-4430-8f71-600cf61ded56               7ea314c5-c702-4f47-b70c-02e5131682be   in service    none      none          off        
+    oxp_78b8bc9a-8f5b-4fc2-9d70-4470b2d05aae/crypt/debug                                                           b43d1c1e-5482-40de-869e-8cd2741c6fc0   in service    100 GiB   none          gzip-9     
+    oxp_9e809fde-e684-4ee8-8d46-dade081c3c37/crypt/debug                                                           19e5fb1e-c1f8-4262-9232-0f31eb746cdb   in service    100 GiB   none          gzip-9     
+    oxp_f2b5fdba-606d-45a4-9a9b-35bf20892bd6/crypt/debug                                                           ef852bdc-50a0-458e-a3f4-fd77a633d3cb   in service    100 GiB   none          gzip-9     
+
+
+    omicron zones:
+    ---------------------------------------------------------------------------------------------------------------
+    zone type         zone id                                image source      disposition   underlay IP           
+    ---------------------------------------------------------------------------------------------------------------
+    crucible          327db2a9-fc45-4c3f-a6db-4ee58459e5cf   install dataset   in service    fd00:1122:3344:103::27
+    crucible          5ea7f627-d51e-4e2d-8648-112ddc635e53   install dataset   in service    fd00:1122:3344:103::25
+    crucible          ad81aafc-e74d-4b0a-b4e6-2e58ef52b7a2   install dataset   in service    fd00:1122:3344:103::26
+    crucible_pantry   a76d9883-b4fe-464f-acbb-e75b2bbb508d   install dataset   in service    fd00:1122:3344:103::24
+    external_dns      8a651785-3936-4cf6-b301-4fa7fa003c9f   install dataset   in service    fd00:1122:3344:103::23
+    internal_dns      f14b0fff-c0f0-420f-ab51-df1a605f43c3   install dataset   in service    fd00:1122:3344:3::1   
+    internal_ntp      f282c429-5f5e-4430-8f71-600cf61ded56   install dataset   in service    fd00:1122:3344:103::21
+    nexus             1dee8f37-8286-48dc-b4b4-e59979c030ec   install dataset   in service    fd00:1122:3344:103::22
+
+
+ COCKROACHDB SETTINGS:
+    state fingerprint:::::::::::::::::   (none)
+    cluster.preserve_downgrade_option:   (do not modify)
+
+ OXIMETER SETTINGS:
+    generation:   1
+    read from::   SingleNode
+
+ METADATA:
+    created by:::::::::::   test suite
+    created at:::::::::::   <REDACTED_TIMESTAMP>
+    comment::::::::::::::   (none)
+    internal DNS version:   1
+    external DNS version:   1
+
+ PENDING MGS-MANAGED UPDATES: 0
+
+
+> 
+
+> # Configure an MGS-managed update to one of the SPs.
+
+> blueprint-edit ad97e762-7bf1-45a6-a98f-60afb7e491c0 sp-update-set serial2 e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855 1.1.0 sp 1.0.0 1.0.1
+blueprint cca24b71-09b5-4042-9185-b33e9f2ebba0 created from blueprint ad97e762-7bf1-45a6-a98f-60afb7e491c0: configured update for serial serial2
+warn: no validation is done on the requested artifact hash or version
+
+> blueprint-show cca24b71-09b5-4042-9185-b33e9f2ebba0
+blueprint  cca24b71-09b5-4042-9185-b33e9f2ebba0
+parent:    ad97e762-7bf1-45a6-a98f-60afb7e491c0
+
+  sled: bb0ec23a-f97c-4b6a-a5bc-864b1ebc9236 (active, config generation 2)
+
+    physical disks:
+    ------------------------------------------------------------------------------------
+    vendor        model        serial                                        disposition
+    ------------------------------------------------------------------------------------
+    fake-vendor   fake-model   serial-a156a6d9-e839-4cb2-9d09-faf012dae700   in service 
+    fake-vendor   fake-model   serial-b48b5b36-fbb1-4c71-8b08-34a58b3ed2bd   in service 
+    fake-vendor   fake-model   serial-b62945fd-6ac2-4ec2-9e13-0a9a10620924   in service 
+
+
+    datasets:
+    -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
+    dataset name                                                                                                   dataset id                             disposition   quota     reservation   compression
+    -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
+    oxp_a156a6d9-e839-4cb2-9d09-faf012dae700/crucible                                                              bbf79ca9-a619-4142-9802-d306a4b58acb   in service    none      none          off        
+    oxp_b48b5b36-fbb1-4c71-8b08-34a58b3ed2bd/crucible                                                              ff6da666-707c-4370-b0d9-0572d8851e9d   in service    none      none          off        
+    oxp_b62945fd-6ac2-4ec2-9e13-0a9a10620924/crucible                                                              1f46779a-37b2-48d7-8ea9-a4e988bb0045   in service    none      none          off        
+    oxp_a156a6d9-e839-4cb2-9d09-faf012dae700/crypt/clickhouse                                                      43b6b5c0-61d8-4b88-bbb8-abede5589619   in service    none      none          off        
+    oxp_a156a6d9-e839-4cb2-9d09-faf012dae700/crypt/external_dns                                                    f5fc02e2-46ff-4012-a5c0-c91ad7881642   in service    none      none          off        
+    oxp_a156a6d9-e839-4cb2-9d09-faf012dae700/crypt/internal_dns                                                    2c16250f-d4aa-4fb5-bf4b-a6b5d72ac441   in service    none      none          off        
+    oxp_a156a6d9-e839-4cb2-9d09-faf012dae700/crypt/zone                                                            9077f1bd-3864-43d5-9c02-9370cbb9156d   in service    none      none          off        
+    oxp_b48b5b36-fbb1-4c71-8b08-34a58b3ed2bd/crypt/zone                                                            f4febe2f-789b-4c28-8bb7-aa594e0e4a4f   in service    none      none          off        
+    oxp_b62945fd-6ac2-4ec2-9e13-0a9a10620924/crypt/zone                                                            de0fe910-037f-49da-b86b-5865818c568d   in service    none      none          off        
+    oxp_a156a6d9-e839-4cb2-9d09-faf012dae700/crypt/zone/oxz_clickhouse_c138c88c-a83d-4e2d-a8f8-e8e715d8e5f7        7de7e173-0287-4e01-ad60-73681156e0e4   in service    none      none          off        
+    oxp_a156a6d9-e839-4cb2-9d09-faf012dae700/crypt/zone/oxz_crucible_575bd77e-6cd9-4bb6-9c1f-2ac6f149278a          252039e9-e48e-4790-930d-a8fad52256d7   in service    none      none          off        
+    oxp_b62945fd-6ac2-4ec2-9e13-0a9a10620924/crypt/zone/oxz_crucible_719199e7-eacf-4add-b532-ddfaf867b478          7ca01115-8692-438a-aa91-84b7c11f5ef2   in service    none      none          off        
+    oxp_b48b5b36-fbb1-4c71-8b08-34a58b3ed2bd/crypt/zone/oxz_crucible_9b8c5aff-3892-4645-8c66-c540456f05af          61a88822-ec1a-4c94-8134-f5d33e342428   in service    none      none          off        
+    oxp_a156a6d9-e839-4cb2-9d09-faf012dae700/crypt/zone/oxz_crucible_pantry_c4c56b5a-8c18-4eac-964a-62f94cac07b1   45b1fd69-7ace-41f8-97bc-3f6e99314e8a   in service    none      none          off        
+    oxp_a156a6d9-e839-4cb2-9d09-faf012dae700/crypt/zone/oxz_external_dns_86c0837a-73ca-4d08-971d-8491401c2fe2      6159b0b8-1c4b-4dd4-a32e-5c5a93df859b   in service    none      none          off        
+    oxp_a156a6d9-e839-4cb2-9d09-faf012dae700/crypt/zone/oxz_internal_dns_ae5b529a-2ada-490c-bea9-04c71cf8e72c      9f74b627-d96c-4183-92f4-7cfaca681fb5   in service    none      none          off        
+    oxp_a156a6d9-e839-4cb2-9d09-faf012dae700/crypt/zone/oxz_nexus_6df9649e-48f8-4754-94f3-55e8f9b039be             6985e6b4-a53b-4a88-bda6-41d2da73af48   in service    none      none          off        
+    oxp_a156a6d9-e839-4cb2-9d09-faf012dae700/crypt/zone/oxz_ntp_4ad9c209-bd1b-44c9-863d-1a6b84b34d53               233b6c7d-284f-42e6-b9e5-607e9377387d   in service    none      none          off        
+    oxp_a156a6d9-e839-4cb2-9d09-faf012dae700/crypt/debug                                                           a510cf34-74db-44fc-903f-36704f21ae67   in service    100 GiB   none          gzip-9     
+    oxp_b48b5b36-fbb1-4c71-8b08-34a58b3ed2bd/crypt/debug                                                           b9f7efe9-5088-45a3-96d9-6cc69be0ec72   in service    100 GiB   none          gzip-9     
+    oxp_b62945fd-6ac2-4ec2-9e13-0a9a10620924/crypt/debug                                                           ae71243d-118a-4e43-b4e3-9e425c6b8395   in service    100 GiB   none          gzip-9     
+
+
+    omicron zones:
+    ---------------------------------------------------------------------------------------------------------------
+    zone type         zone id                                image source      disposition   underlay IP           
+    ---------------------------------------------------------------------------------------------------------------
+    clickhouse        c138c88c-a83d-4e2d-a8f8-e8e715d8e5f7   install dataset   in service    fd00:1122:3344:101::23
+    crucible          575bd77e-6cd9-4bb6-9c1f-2ac6f149278a   install dataset   in service    fd00:1122:3344:101::26
+    crucible          719199e7-eacf-4add-b532-ddfaf867b478   install dataset   in service    fd00:1122:3344:101::28
+    crucible          9b8c5aff-3892-4645-8c66-c540456f05af   install dataset   in service    fd00:1122:3344:101::27
+    crucible_pantry   c4c56b5a-8c18-4eac-964a-62f94cac07b1   install dataset   in service    fd00:1122:3344:101::25
+    external_dns      86c0837a-73ca-4d08-971d-8491401c2fe2   install dataset   in service    fd00:1122:3344:101::24
+    internal_dns      ae5b529a-2ada-490c-bea9-04c71cf8e72c   install dataset   in service    fd00:1122:3344:1::1   
+    internal_ntp      4ad9c209-bd1b-44c9-863d-1a6b84b34d53   install dataset   in service    fd00:1122:3344:101::21
+    nexus             6df9649e-48f8-4754-94f3-55e8f9b039be   install dataset   in service    fd00:1122:3344:101::22
+
+
+
+  sled: bba6ea73-6c9c-4ab5-8bb4-1dd145071407 (active, config generation 2)
+
+    physical disks:
+    ------------------------------------------------------------------------------------
+    vendor        model        serial                                        disposition
+    ------------------------------------------------------------------------------------
+    fake-vendor   fake-model   serial-2201d82d-3a3c-4744-ac41-657536a90afe   in service 
+    fake-vendor   fake-model   serial-bdf3642c-a783-4689-a8a6-8cfa257089bd   in service 
+    fake-vendor   fake-model   serial-eeb9b9ce-ac1c-4a41-9a7a-814e26e2a9ee   in service 
+
+
+    datasets:
+    -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
+    dataset name                                                                                                   dataset id                             disposition   quota     reservation   compression
+    -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
+    oxp_2201d82d-3a3c-4744-ac41-657536a90afe/crucible                                                              66beebb3-2b7a-4334-9ea7-e7c714b6dacc   in service    none      none          off        
+    oxp_bdf3642c-a783-4689-a8a6-8cfa257089bd/crucible                                                              4611f0cd-1ef4-42f2-b1bd-8ce5c0ee1ba4   in service    none      none          off        
+    oxp_eeb9b9ce-ac1c-4a41-9a7a-814e26e2a9ee/crucible                                                              4420b086-b23f-4ba6-b504-459a38e3b367   in service    none      none          off        
+    oxp_2201d82d-3a3c-4744-ac41-657536a90afe/crypt/external_dns                                                    ffe1a3c8-7546-495f-b437-f2405be4e533   in service    none      none          off        
+    oxp_2201d82d-3a3c-4744-ac41-657536a90afe/crypt/internal_dns                                                    c5300adb-042e-41fd-9b1f-5c01d68e7eb4   in service    none      none          off        
+    oxp_2201d82d-3a3c-4744-ac41-657536a90afe/crypt/zone                                                            06dfa1c2-42c3-4626-8bf3-4460dfec3646   in service    none      none          off        
+    oxp_bdf3642c-a783-4689-a8a6-8cfa257089bd/crypt/zone                                                            89ae62b7-0cff-4e09-b4e9-4c43bf242e1d   in service    none      none          off        
+    oxp_eeb9b9ce-ac1c-4a41-9a7a-814e26e2a9ee/crypt/zone                                                            78269a0c-ce98-4834-ae9e-d25eee99a079   in service    none      none          off        
+    oxp_eeb9b9ce-ac1c-4a41-9a7a-814e26e2a9ee/crypt/zone/oxz_crucible_70b7e8a1-cc3f-4cdd-a577-4c8be9885f8b          1382d296-a276-40ca-85b3-9f2578cb95cf   in service    none      none          off        
+    oxp_bdf3642c-a783-4689-a8a6-8cfa257089bd/crypt/zone/oxz_crucible_7bb9667d-da70-4592-a579-31295f919aed          57d3c6cb-64ff-4485-87c0-3ff5fe9c45d8   in service    none      none          off        
+    oxp_2201d82d-3a3c-4744-ac41-657536a90afe/crypt/zone/oxz_crucible_a5a25771-1025-4c08-9362-c5ee4cecafc9          a0e1cc1c-d542-4a21-96bb-efdfe40af009   in service    none      none          off        
+    oxp_2201d82d-3a3c-4744-ac41-657536a90afe/crypt/zone/oxz_crucible_pantry_5c67f8ed-9f38-4be1-b64c-a2d9898d3263   4f3e7986-e836-4ecc-ac69-8c013905707c   in service    none      none          off        
+    oxp_2201d82d-3a3c-4744-ac41-657536a90afe/crypt/zone/oxz_external_dns_b067565e-df5a-441f-85b9-69acc38bbf35      bc7affdc-54b9-4172-8264-af82b92fdfe0   in service    none      none          off        
+    oxp_2201d82d-3a3c-4744-ac41-657536a90afe/crypt/zone/oxz_internal_dns_159e1f8f-6f32-413d-a48b-e40fb2efaf15      79d73706-f701-4857-a378-fcf026cd6756   in service    none      none          off        
+    oxp_2201d82d-3a3c-4744-ac41-657536a90afe/crypt/zone/oxz_nexus_543b3bb6-358d-4876-9774-53a53187aaa8             71b813ec-4a24-43d1-b0b8-5c3303a1d9b5   in service    none      none          off        
+    oxp_2201d82d-3a3c-4744-ac41-657536a90afe/crypt/zone/oxz_ntp_345fbd68-cb55-4faa-b6ea-801789018bc6               d4126675-e113-4a2d-826a-cf7b224b794b   in service    none      none          off        
+    oxp_2201d82d-3a3c-4744-ac41-657536a90afe/crypt/debug                                                           afe7ef8e-c974-403e-932e-eb3c8057b22d   in service    100 GiB   none          gzip-9     
+    oxp_bdf3642c-a783-4689-a8a6-8cfa257089bd/crypt/debug                                                           f5f65250-3145-41bf-b462-359728bda24a   in service    100 GiB   none          gzip-9     
+    oxp_eeb9b9ce-ac1c-4a41-9a7a-814e26e2a9ee/crypt/debug                                                           7328892a-0525-401f-9160-a8e4501049fd   in service    100 GiB   none          gzip-9     
+
+
+    omicron zones:
+    ---------------------------------------------------------------------------------------------------------------
+    zone type         zone id                                image source      disposition   underlay IP           
+    ---------------------------------------------------------------------------------------------------------------
+    crucible          70b7e8a1-cc3f-4cdd-a577-4c8be9885f8b   install dataset   in service    fd00:1122:3344:102::27
+    crucible          7bb9667d-da70-4592-a579-31295f919aed   install dataset   in service    fd00:1122:3344:102::26
+    crucible          a5a25771-1025-4c08-9362-c5ee4cecafc9   install dataset   in service    fd00:1122:3344:102::25
+    crucible_pantry   5c67f8ed-9f38-4be1-b64c-a2d9898d3263   install dataset   in service    fd00:1122:3344:102::24
+    external_dns      b067565e-df5a-441f-85b9-69acc38bbf35   install dataset   in service    fd00:1122:3344:102::23
+    internal_dns      159e1f8f-6f32-413d-a48b-e40fb2efaf15   install dataset   in service    fd00:1122:3344:2::1   
+    internal_ntp      345fbd68-cb55-4faa-b6ea-801789018bc6   install dataset   in service    fd00:1122:3344:102::21
+    nexus             543b3bb6-358d-4876-9774-53a53187aaa8   install dataset   in service    fd00:1122:3344:102::22
+
+
+
+  sled: cc00b21a-5685-480a-ab5e-d2e29cf369df (active, config generation 2)
+
+    physical disks:
+    ------------------------------------------------------------------------------------
+    vendor        model        serial                                        disposition
+    ------------------------------------------------------------------------------------
+    fake-vendor   fake-model   serial-78b8bc9a-8f5b-4fc2-9d70-4470b2d05aae   in service 
+    fake-vendor   fake-model   serial-9e809fde-e684-4ee8-8d46-dade081c3c37   in service 
+    fake-vendor   fake-model   serial-f2b5fdba-606d-45a4-9a9b-35bf20892bd6   in service 
+
+
+    datasets:
+    -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
+    dataset name                                                                                                   dataset id                             disposition   quota     reservation   compression
+    -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
+    oxp_78b8bc9a-8f5b-4fc2-9d70-4470b2d05aae/crucible                                                              a84f76f4-1f8c-4772-a072-ffb0dc7c281c   in service    none      none          off        
+    oxp_9e809fde-e684-4ee8-8d46-dade081c3c37/crucible                                                              db8f2cdf-721f-4c56-880e-d9265ec404f5   in service    none      none          off        
+    oxp_f2b5fdba-606d-45a4-9a9b-35bf20892bd6/crucible                                                              faa61220-8f21-4231-b069-3fb417699363   in service    none      none          off        
+    oxp_78b8bc9a-8f5b-4fc2-9d70-4470b2d05aae/crypt/external_dns                                                    b47f981e-ac2d-4ec1-8e67-c15dcf13af86   in service    none      none          off        
+    oxp_78b8bc9a-8f5b-4fc2-9d70-4470b2d05aae/crypt/internal_dns                                                    037ef4f6-dae1-478e-8397-3b68bf8e47dc   in service    none      none          off        
+    oxp_78b8bc9a-8f5b-4fc2-9d70-4470b2d05aae/crypt/zone                                                            fa042a64-d60c-4aa6-bc1a-ae9d0347bde8   in service    none      none          off        
+    oxp_9e809fde-e684-4ee8-8d46-dade081c3c37/crypt/zone                                                            5366ad89-e6ec-47e5-8870-fafc8224f11f   in service    none      none          off        
+    oxp_f2b5fdba-606d-45a4-9a9b-35bf20892bd6/crypt/zone                                                            fb5e2978-9182-46bd-919d-653b86b1fed3   in service    none      none          off        
+    oxp_f2b5fdba-606d-45a4-9a9b-35bf20892bd6/crypt/zone/oxz_crucible_327db2a9-fc45-4c3f-a6db-4ee58459e5cf          ac6a48f2-c9e0-4bf2-9c93-c234efc48a59   in service    none      none          off        
+    oxp_78b8bc9a-8f5b-4fc2-9d70-4470b2d05aae/crypt/zone/oxz_crucible_5ea7f627-d51e-4e2d-8648-112ddc635e53          d449dcc4-1725-4de2-92c0-e1a37d12299a   in service    none      none          off        
+    oxp_9e809fde-e684-4ee8-8d46-dade081c3c37/crypt/zone/oxz_crucible_ad81aafc-e74d-4b0a-b4e6-2e58ef52b7a2          2c018c08-7cc7-45a9-be60-cd6b82874cfc   in service    none      none          off        
+    oxp_78b8bc9a-8f5b-4fc2-9d70-4470b2d05aae/crypt/zone/oxz_crucible_pantry_a76d9883-b4fe-464f-acbb-e75b2bbb508d   ad79a937-7410-4e92-89e1-0af1a0595cef   in service    none      none          off        
+    oxp_78b8bc9a-8f5b-4fc2-9d70-4470b2d05aae/crypt/zone/oxz_external_dns_8a651785-3936-4cf6-b301-4fa7fa003c9f      e80f5919-dd7c-4d6c-b0de-45d24c0fe421   in service    none      none          off        
+    oxp_78b8bc9a-8f5b-4fc2-9d70-4470b2d05aae/crypt/zone/oxz_internal_dns_f14b0fff-c0f0-420f-ab51-df1a605f43c3      fd542516-55e6-42c6-a8de-0128b3cce65e   in service    none      none          off        
+    oxp_78b8bc9a-8f5b-4fc2-9d70-4470b2d05aae/crypt/zone/oxz_nexus_1dee8f37-8286-48dc-b4b4-e59979c030ec             7c89c13d-8f41-4c69-96d2-6f9ffbc27cbb   in service    none      none          off        
+    oxp_78b8bc9a-8f5b-4fc2-9d70-4470b2d05aae/crypt/zone/oxz_ntp_f282c429-5f5e-4430-8f71-600cf61ded56               7ea314c5-c702-4f47-b70c-02e5131682be   in service    none      none          off        
+    oxp_78b8bc9a-8f5b-4fc2-9d70-4470b2d05aae/crypt/debug                                                           b43d1c1e-5482-40de-869e-8cd2741c6fc0   in service    100 GiB   none          gzip-9     
+    oxp_9e809fde-e684-4ee8-8d46-dade081c3c37/crypt/debug                                                           19e5fb1e-c1f8-4262-9232-0f31eb746cdb   in service    100 GiB   none          gzip-9     
+    oxp_f2b5fdba-606d-45a4-9a9b-35bf20892bd6/crypt/debug                                                           ef852bdc-50a0-458e-a3f4-fd77a633d3cb   in service    100 GiB   none          gzip-9     
+
+
+    omicron zones:
+    ---------------------------------------------------------------------------------------------------------------
+    zone type         zone id                                image source      disposition   underlay IP           
+    ---------------------------------------------------------------------------------------------------------------
+    crucible          327db2a9-fc45-4c3f-a6db-4ee58459e5cf   install dataset   in service    fd00:1122:3344:103::27
+    crucible          5ea7f627-d51e-4e2d-8648-112ddc635e53   install dataset   in service    fd00:1122:3344:103::25
+    crucible          ad81aafc-e74d-4b0a-b4e6-2e58ef52b7a2   install dataset   in service    fd00:1122:3344:103::26
+    crucible_pantry   a76d9883-b4fe-464f-acbb-e75b2bbb508d   install dataset   in service    fd00:1122:3344:103::24
+    external_dns      8a651785-3936-4cf6-b301-4fa7fa003c9f   install dataset   in service    fd00:1122:3344:103::23
+    internal_dns      f14b0fff-c0f0-420f-ab51-df1a605f43c3   install dataset   in service    fd00:1122:3344:3::1   
+    internal_ntp      f282c429-5f5e-4430-8f71-600cf61ded56   install dataset   in service    fd00:1122:3344:103::21
+    nexus             1dee8f37-8286-48dc-b4b4-e59979c030ec   install dataset   in service    fd00:1122:3344:103::22
+
+
+ COCKROACHDB SETTINGS:
+    state fingerprint:::::::::::::::::   (none)
+    cluster.preserve_downgrade_option:   (do not modify)
+
+ OXIMETER SETTINGS:
+    generation:   1
+    read from::   SingleNode
+
+ METADATA:
+    created by:::::::::::   reconfigurator-cli
+    created at:::::::::::   <REDACTED_TIMESTAMP>
+    comment::::::::::::::   (none)
+    internal DNS version:   1
+    external DNS version:   1
+
+ PENDING MGS-MANAGED UPDATES: 1
+    Pending MGS-managed updates:
+    ---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
+    sp_type   slot   part_number   serial_number   artifact_kind   artifact_hash                                                      artifact_version   details                                                                                                               
+    ---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
+    sled      2      model2        serial2         gimlet_sp       e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855   1.1.0              Sp { expected_active_version: ArtifactVersion("1.0.0"), expected_inactive_version: Version(ArtifactVersion("1.0.1")) }
+
+
+
+> blueprint-diff ad97e762-7bf1-45a6-a98f-60afb7e491c0 cca24b71-09b5-4042-9185-b33e9f2ebba0
+from: blueprint ad97e762-7bf1-45a6-a98f-60afb7e491c0
+to:   blueprint cca24b71-09b5-4042-9185-b33e9f2ebba0
+
+ UNCHANGED SLEDS:
+
+  sled bb0ec23a-f97c-4b6a-a5bc-864b1ebc9236 (active, config generation 2):
+
+    physical disks:
+    ------------------------------------------------------------------------------------
+    vendor        model        serial                                        disposition
+    ------------------------------------------------------------------------------------
+    fake-vendor   fake-model   serial-a156a6d9-e839-4cb2-9d09-faf012dae700   in service 
+    fake-vendor   fake-model   serial-b48b5b36-fbb1-4c71-8b08-34a58b3ed2bd   in service 
+    fake-vendor   fake-model   serial-b62945fd-6ac2-4ec2-9e13-0a9a10620924   in service 
+
+
+    datasets:
+    -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
+    dataset name                                                                                                   dataset id                             disposition   quota     reservation   compression
+    -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
+    oxp_a156a6d9-e839-4cb2-9d09-faf012dae700/crucible                                                              bbf79ca9-a619-4142-9802-d306a4b58acb   in service    none      none          off        
+    oxp_b48b5b36-fbb1-4c71-8b08-34a58b3ed2bd/crucible                                                              ff6da666-707c-4370-b0d9-0572d8851e9d   in service    none      none          off        
+    oxp_b62945fd-6ac2-4ec2-9e13-0a9a10620924/crucible                                                              1f46779a-37b2-48d7-8ea9-a4e988bb0045   in service    none      none          off        
+    oxp_a156a6d9-e839-4cb2-9d09-faf012dae700/crypt/clickhouse                                                      43b6b5c0-61d8-4b88-bbb8-abede5589619   in service    none      none          off        
+    oxp_a156a6d9-e839-4cb2-9d09-faf012dae700/crypt/external_dns                                                    f5fc02e2-46ff-4012-a5c0-c91ad7881642   in service    none      none          off        
+    oxp_a156a6d9-e839-4cb2-9d09-faf012dae700/crypt/internal_dns                                                    2c16250f-d4aa-4fb5-bf4b-a6b5d72ac441   in service    none      none          off        
+    oxp_a156a6d9-e839-4cb2-9d09-faf012dae700/crypt/zone                                                            9077f1bd-3864-43d5-9c02-9370cbb9156d   in service    none      none          off        
+    oxp_b48b5b36-fbb1-4c71-8b08-34a58b3ed2bd/crypt/zone                                                            f4febe2f-789b-4c28-8bb7-aa594e0e4a4f   in service    none      none          off        
+    oxp_b62945fd-6ac2-4ec2-9e13-0a9a10620924/crypt/zone                                                            de0fe910-037f-49da-b86b-5865818c568d   in service    none      none          off        
+    oxp_a156a6d9-e839-4cb2-9d09-faf012dae700/crypt/zone/oxz_clickhouse_c138c88c-a83d-4e2d-a8f8-e8e715d8e5f7        7de7e173-0287-4e01-ad60-73681156e0e4   in service    none      none          off        
+    oxp_a156a6d9-e839-4cb2-9d09-faf012dae700/crypt/zone/oxz_crucible_575bd77e-6cd9-4bb6-9c1f-2ac6f149278a          252039e9-e48e-4790-930d-a8fad52256d7   in service    none      none          off        
+    oxp_b62945fd-6ac2-4ec2-9e13-0a9a10620924/crypt/zone/oxz_crucible_719199e7-eacf-4add-b532-ddfaf867b478          7ca01115-8692-438a-aa91-84b7c11f5ef2   in service    none      none          off        
+    oxp_b48b5b36-fbb1-4c71-8b08-34a58b3ed2bd/crypt/zone/oxz_crucible_9b8c5aff-3892-4645-8c66-c540456f05af          61a88822-ec1a-4c94-8134-f5d33e342428   in service    none      none          off        
+    oxp_a156a6d9-e839-4cb2-9d09-faf012dae700/crypt/zone/oxz_crucible_pantry_c4c56b5a-8c18-4eac-964a-62f94cac07b1   45b1fd69-7ace-41f8-97bc-3f6e99314e8a   in service    none      none          off        
+    oxp_a156a6d9-e839-4cb2-9d09-faf012dae700/crypt/zone/oxz_external_dns_86c0837a-73ca-4d08-971d-8491401c2fe2      6159b0b8-1c4b-4dd4-a32e-5c5a93df859b   in service    none      none          off        
+    oxp_a156a6d9-e839-4cb2-9d09-faf012dae700/crypt/zone/oxz_internal_dns_ae5b529a-2ada-490c-bea9-04c71cf8e72c      9f74b627-d96c-4183-92f4-7cfaca681fb5   in service    none      none          off        
+    oxp_a156a6d9-e839-4cb2-9d09-faf012dae700/crypt/zone/oxz_nexus_6df9649e-48f8-4754-94f3-55e8f9b039be             6985e6b4-a53b-4a88-bda6-41d2da73af48   in service    none      none          off        
+    oxp_a156a6d9-e839-4cb2-9d09-faf012dae700/crypt/zone/oxz_ntp_4ad9c209-bd1b-44c9-863d-1a6b84b34d53               233b6c7d-284f-42e6-b9e5-607e9377387d   in service    none      none          off        
+    oxp_a156a6d9-e839-4cb2-9d09-faf012dae700/crypt/debug                                                           a510cf34-74db-44fc-903f-36704f21ae67   in service    100 GiB   none          gzip-9     
+    oxp_b48b5b36-fbb1-4c71-8b08-34a58b3ed2bd/crypt/debug                                                           b9f7efe9-5088-45a3-96d9-6cc69be0ec72   in service    100 GiB   none          gzip-9     
+    oxp_b62945fd-6ac2-4ec2-9e13-0a9a10620924/crypt/debug                                                           ae71243d-118a-4e43-b4e3-9e425c6b8395   in service    100 GiB   none          gzip-9     
+
+
+    omicron zones:
+    ---------------------------------------------------------------------------------------------------------------
+    zone type         zone id                                image source      disposition   underlay IP           
+    ---------------------------------------------------------------------------------------------------------------
+    clickhouse        c138c88c-a83d-4e2d-a8f8-e8e715d8e5f7   install dataset   in service    fd00:1122:3344:101::23
+    crucible          575bd77e-6cd9-4bb6-9c1f-2ac6f149278a   install dataset   in service    fd00:1122:3344:101::26
+    crucible          719199e7-eacf-4add-b532-ddfaf867b478   install dataset   in service    fd00:1122:3344:101::28
+    crucible          9b8c5aff-3892-4645-8c66-c540456f05af   install dataset   in service    fd00:1122:3344:101::27
+    crucible_pantry   c4c56b5a-8c18-4eac-964a-62f94cac07b1   install dataset   in service    fd00:1122:3344:101::25
+    external_dns      86c0837a-73ca-4d08-971d-8491401c2fe2   install dataset   in service    fd00:1122:3344:101::24
+    internal_dns      ae5b529a-2ada-490c-bea9-04c71cf8e72c   install dataset   in service    fd00:1122:3344:1::1   
+    internal_ntp      4ad9c209-bd1b-44c9-863d-1a6b84b34d53   install dataset   in service    fd00:1122:3344:101::21
+    nexus             6df9649e-48f8-4754-94f3-55e8f9b039be   install dataset   in service    fd00:1122:3344:101::22
+
+
+  sled bba6ea73-6c9c-4ab5-8bb4-1dd145071407 (active, config generation 2):
+
+    physical disks:
+    ------------------------------------------------------------------------------------
+    vendor        model        serial                                        disposition
+    ------------------------------------------------------------------------------------
+    fake-vendor   fake-model   serial-2201d82d-3a3c-4744-ac41-657536a90afe   in service 
+    fake-vendor   fake-model   serial-bdf3642c-a783-4689-a8a6-8cfa257089bd   in service 
+    fake-vendor   fake-model   serial-eeb9b9ce-ac1c-4a41-9a7a-814e26e2a9ee   in service 
+
+
+    datasets:
+    -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
+    dataset name                                                                                                   dataset id                             disposition   quota     reservation   compression
+    -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
+    oxp_2201d82d-3a3c-4744-ac41-657536a90afe/crucible                                                              66beebb3-2b7a-4334-9ea7-e7c714b6dacc   in service    none      none          off        
+    oxp_bdf3642c-a783-4689-a8a6-8cfa257089bd/crucible                                                              4611f0cd-1ef4-42f2-b1bd-8ce5c0ee1ba4   in service    none      none          off        
+    oxp_eeb9b9ce-ac1c-4a41-9a7a-814e26e2a9ee/crucible                                                              4420b086-b23f-4ba6-b504-459a38e3b367   in service    none      none          off        
+    oxp_2201d82d-3a3c-4744-ac41-657536a90afe/crypt/external_dns                                                    ffe1a3c8-7546-495f-b437-f2405be4e533   in service    none      none          off        
+    oxp_2201d82d-3a3c-4744-ac41-657536a90afe/crypt/internal_dns                                                    c5300adb-042e-41fd-9b1f-5c01d68e7eb4   in service    none      none          off        
+    oxp_2201d82d-3a3c-4744-ac41-657536a90afe/crypt/zone                                                            06dfa1c2-42c3-4626-8bf3-4460dfec3646   in service    none      none          off        
+    oxp_bdf3642c-a783-4689-a8a6-8cfa257089bd/crypt/zone                                                            89ae62b7-0cff-4e09-b4e9-4c43bf242e1d   in service    none      none          off        
+    oxp_eeb9b9ce-ac1c-4a41-9a7a-814e26e2a9ee/crypt/zone                                                            78269a0c-ce98-4834-ae9e-d25eee99a079   in service    none      none          off        
+    oxp_eeb9b9ce-ac1c-4a41-9a7a-814e26e2a9ee/crypt/zone/oxz_crucible_70b7e8a1-cc3f-4cdd-a577-4c8be9885f8b          1382d296-a276-40ca-85b3-9f2578cb95cf   in service    none      none          off        
+    oxp_bdf3642c-a783-4689-a8a6-8cfa257089bd/crypt/zone/oxz_crucible_7bb9667d-da70-4592-a579-31295f919aed          57d3c6cb-64ff-4485-87c0-3ff5fe9c45d8   in service    none      none          off        
+    oxp_2201d82d-3a3c-4744-ac41-657536a90afe/crypt/zone/oxz_crucible_a5a25771-1025-4c08-9362-c5ee4cecafc9          a0e1cc1c-d542-4a21-96bb-efdfe40af009   in service    none      none          off        
+    oxp_2201d82d-3a3c-4744-ac41-657536a90afe/crypt/zone/oxz_crucible_pantry_5c67f8ed-9f38-4be1-b64c-a2d9898d3263   4f3e7986-e836-4ecc-ac69-8c013905707c   in service    none      none          off        
+    oxp_2201d82d-3a3c-4744-ac41-657536a90afe/crypt/zone/oxz_external_dns_b067565e-df5a-441f-85b9-69acc38bbf35      bc7affdc-54b9-4172-8264-af82b92fdfe0   in service    none      none          off        
+    oxp_2201d82d-3a3c-4744-ac41-657536a90afe/crypt/zone/oxz_internal_dns_159e1f8f-6f32-413d-a48b-e40fb2efaf15      79d73706-f701-4857-a378-fcf026cd6756   in service    none      none          off        
+    oxp_2201d82d-3a3c-4744-ac41-657536a90afe/crypt/zone/oxz_nexus_543b3bb6-358d-4876-9774-53a53187aaa8             71b813ec-4a24-43d1-b0b8-5c3303a1d9b5   in service    none      none          off        
+    oxp_2201d82d-3a3c-4744-ac41-657536a90afe/crypt/zone/oxz_ntp_345fbd68-cb55-4faa-b6ea-801789018bc6               d4126675-e113-4a2d-826a-cf7b224b794b   in service    none      none          off        
+    oxp_2201d82d-3a3c-4744-ac41-657536a90afe/crypt/debug                                                           afe7ef8e-c974-403e-932e-eb3c8057b22d   in service    100 GiB   none          gzip-9     
+    oxp_bdf3642c-a783-4689-a8a6-8cfa257089bd/crypt/debug                                                           f5f65250-3145-41bf-b462-359728bda24a   in service    100 GiB   none          gzip-9     
+    oxp_eeb9b9ce-ac1c-4a41-9a7a-814e26e2a9ee/crypt/debug                                                           7328892a-0525-401f-9160-a8e4501049fd   in service    100 GiB   none          gzip-9     
+
+
+    omicron zones:
+    ---------------------------------------------------------------------------------------------------------------
+    zone type         zone id                                image source      disposition   underlay IP           
+    ---------------------------------------------------------------------------------------------------------------
+    crucible          70b7e8a1-cc3f-4cdd-a577-4c8be9885f8b   install dataset   in service    fd00:1122:3344:102::27
+    crucible          7bb9667d-da70-4592-a579-31295f919aed   install dataset   in service    fd00:1122:3344:102::26
+    crucible          a5a25771-1025-4c08-9362-c5ee4cecafc9   install dataset   in service    fd00:1122:3344:102::25
+    crucible_pantry   5c67f8ed-9f38-4be1-b64c-a2d9898d3263   install dataset   in service    fd00:1122:3344:102::24
+    external_dns      b067565e-df5a-441f-85b9-69acc38bbf35   install dataset   in service    fd00:1122:3344:102::23
+    internal_dns      159e1f8f-6f32-413d-a48b-e40fb2efaf15   install dataset   in service    fd00:1122:3344:2::1   
+    internal_ntp      345fbd68-cb55-4faa-b6ea-801789018bc6   install dataset   in service    fd00:1122:3344:102::21
+    nexus             543b3bb6-358d-4876-9774-53a53187aaa8   install dataset   in service    fd00:1122:3344:102::22
+
+
+  sled cc00b21a-5685-480a-ab5e-d2e29cf369df (active, config generation 2):
+
+    physical disks:
+    ------------------------------------------------------------------------------------
+    vendor        model        serial                                        disposition
+    ------------------------------------------------------------------------------------
+    fake-vendor   fake-model   serial-78b8bc9a-8f5b-4fc2-9d70-4470b2d05aae   in service 
+    fake-vendor   fake-model   serial-9e809fde-e684-4ee8-8d46-dade081c3c37   in service 
+    fake-vendor   fake-model   serial-f2b5fdba-606d-45a4-9a9b-35bf20892bd6   in service 
+
+
+    datasets:
+    -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
+    dataset name                                                                                                   dataset id                             disposition   quota     reservation   compression
+    -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
+    oxp_78b8bc9a-8f5b-4fc2-9d70-4470b2d05aae/crucible                                                              a84f76f4-1f8c-4772-a072-ffb0dc7c281c   in service    none      none          off        
+    oxp_9e809fde-e684-4ee8-8d46-dade081c3c37/crucible                                                              db8f2cdf-721f-4c56-880e-d9265ec404f5   in service    none      none          off        
+    oxp_f2b5fdba-606d-45a4-9a9b-35bf20892bd6/crucible                                                              faa61220-8f21-4231-b069-3fb417699363   in service    none      none          off        
+    oxp_78b8bc9a-8f5b-4fc2-9d70-4470b2d05aae/crypt/external_dns                                                    b47f981e-ac2d-4ec1-8e67-c15dcf13af86   in service    none      none          off        
+    oxp_78b8bc9a-8f5b-4fc2-9d70-4470b2d05aae/crypt/internal_dns                                                    037ef4f6-dae1-478e-8397-3b68bf8e47dc   in service    none      none          off        
+    oxp_78b8bc9a-8f5b-4fc2-9d70-4470b2d05aae/crypt/zone                                                            fa042a64-d60c-4aa6-bc1a-ae9d0347bde8   in service    none      none          off        
+    oxp_9e809fde-e684-4ee8-8d46-dade081c3c37/crypt/zone                                                            5366ad89-e6ec-47e5-8870-fafc8224f11f   in service    none      none          off        
+    oxp_f2b5fdba-606d-45a4-9a9b-35bf20892bd6/crypt/zone                                                            fb5e2978-9182-46bd-919d-653b86b1fed3   in service    none      none          off        
+    oxp_f2b5fdba-606d-45a4-9a9b-35bf20892bd6/crypt/zone/oxz_crucible_327db2a9-fc45-4c3f-a6db-4ee58459e5cf          ac6a48f2-c9e0-4bf2-9c93-c234efc48a59   in service    none      none          off        
+    oxp_78b8bc9a-8f5b-4fc2-9d70-4470b2d05aae/crypt/zone/oxz_crucible_5ea7f627-d51e-4e2d-8648-112ddc635e53          d449dcc4-1725-4de2-92c0-e1a37d12299a   in service    none      none          off        
+    oxp_9e809fde-e684-4ee8-8d46-dade081c3c37/crypt/zone/oxz_crucible_ad81aafc-e74d-4b0a-b4e6-2e58ef52b7a2          2c018c08-7cc7-45a9-be60-cd6b82874cfc   in service    none      none          off        
+    oxp_78b8bc9a-8f5b-4fc2-9d70-4470b2d05aae/crypt/zone/oxz_crucible_pantry_a76d9883-b4fe-464f-acbb-e75b2bbb508d   ad79a937-7410-4e92-89e1-0af1a0595cef   in service    none      none          off        
+    oxp_78b8bc9a-8f5b-4fc2-9d70-4470b2d05aae/crypt/zone/oxz_external_dns_8a651785-3936-4cf6-b301-4fa7fa003c9f      e80f5919-dd7c-4d6c-b0de-45d24c0fe421   in service    none      none          off        
+    oxp_78b8bc9a-8f5b-4fc2-9d70-4470b2d05aae/crypt/zone/oxz_internal_dns_f14b0fff-c0f0-420f-ab51-df1a605f43c3      fd542516-55e6-42c6-a8de-0128b3cce65e   in service    none      none          off        
+    oxp_78b8bc9a-8f5b-4fc2-9d70-4470b2d05aae/crypt/zone/oxz_nexus_1dee8f37-8286-48dc-b4b4-e59979c030ec             7c89c13d-8f41-4c69-96d2-6f9ffbc27cbb   in service    none      none          off        
+    oxp_78b8bc9a-8f5b-4fc2-9d70-4470b2d05aae/crypt/zone/oxz_ntp_f282c429-5f5e-4430-8f71-600cf61ded56               7ea314c5-c702-4f47-b70c-02e5131682be   in service    none      none          off        
+    oxp_78b8bc9a-8f5b-4fc2-9d70-4470b2d05aae/crypt/debug                                                           b43d1c1e-5482-40de-869e-8cd2741c6fc0   in service    100 GiB   none          gzip-9     
+    oxp_9e809fde-e684-4ee8-8d46-dade081c3c37/crypt/debug                                                           19e5fb1e-c1f8-4262-9232-0f31eb746cdb   in service    100 GiB   none          gzip-9     
+    oxp_f2b5fdba-606d-45a4-9a9b-35bf20892bd6/crypt/debug                                                           ef852bdc-50a0-458e-a3f4-fd77a633d3cb   in service    100 GiB   none          gzip-9     
+
+
+    omicron zones:
+    ---------------------------------------------------------------------------------------------------------------
+    zone type         zone id                                image source      disposition   underlay IP           
+    ---------------------------------------------------------------------------------------------------------------
+    crucible          327db2a9-fc45-4c3f-a6db-4ee58459e5cf   install dataset   in service    fd00:1122:3344:103::27
+    crucible          5ea7f627-d51e-4e2d-8648-112ddc635e53   install dataset   in service    fd00:1122:3344:103::25
+    crucible          ad81aafc-e74d-4b0a-b4e6-2e58ef52b7a2   install dataset   in service    fd00:1122:3344:103::26
+    crucible_pantry   a76d9883-b4fe-464f-acbb-e75b2bbb508d   install dataset   in service    fd00:1122:3344:103::24
+    external_dns      8a651785-3936-4cf6-b301-4fa7fa003c9f   install dataset   in service    fd00:1122:3344:103::23
+    internal_dns      f14b0fff-c0f0-420f-ab51-df1a605f43c3   install dataset   in service    fd00:1122:3344:3::1   
+    internal_ntp      f282c429-5f5e-4430-8f71-600cf61ded56   install dataset   in service    fd00:1122:3344:103::21
+    nexus             1dee8f37-8286-48dc-b4b4-e59979c030ec   install dataset   in service    fd00:1122:3344:103::22
+
+
+ COCKROACHDB SETTINGS:
+    state fingerprint:::::::::::::::::   (none) (unchanged)
+    cluster.preserve_downgrade_option:   (do not modify) (unchanged)
+
+ METADATA:
+    internal DNS version:   1 (unchanged)
+    external DNS version:   1 (unchanged)
+
+ OXIMETER SETTINGS:
+    generation:   1 (unchanged)
+    read from::   SingleNode (unchanged)
+
+
+internal DNS:
+  DNS zone: "control-plane.oxide.internal" (unchanged)
+    name: 159e1f8f-6f32-413d-a48b-e40fb2efaf15.host          (records: 1)
+        AAAA fd00:1122:3344:2::1
+    name: 1dee8f37-8286-48dc-b4b4-e59979c030ec.host          (records: 1)
+        AAAA fd00:1122:3344:103::22
+    name: 327db2a9-fc45-4c3f-a6db-4ee58459e5cf.host          (records: 1)
+        AAAA fd00:1122:3344:103::27
+    name: 345fbd68-cb55-4faa-b6ea-801789018bc6.host          (records: 1)
+        AAAA fd00:1122:3344:102::21
+    name: 4ad9c209-bd1b-44c9-863d-1a6b84b34d53.host          (records: 1)
+        AAAA fd00:1122:3344:101::21
+    name: 543b3bb6-358d-4876-9774-53a53187aaa8.host          (records: 1)
+        AAAA fd00:1122:3344:102::22
+    name: 575bd77e-6cd9-4bb6-9c1f-2ac6f149278a.host          (records: 1)
+        AAAA fd00:1122:3344:101::26
+    name: 5c67f8ed-9f38-4be1-b64c-a2d9898d3263.host          (records: 1)
+        AAAA fd00:1122:3344:102::24
+    name: 5ea7f627-d51e-4e2d-8648-112ddc635e53.host          (records: 1)
+        AAAA fd00:1122:3344:103::25
+    name: 6df9649e-48f8-4754-94f3-55e8f9b039be.host          (records: 1)
+        AAAA fd00:1122:3344:101::22
+    name: 70b7e8a1-cc3f-4cdd-a577-4c8be9885f8b.host          (records: 1)
+        AAAA fd00:1122:3344:102::27
+    name: 719199e7-eacf-4add-b532-ddfaf867b478.host          (records: 1)
+        AAAA fd00:1122:3344:101::28
+    name: 7bb9667d-da70-4592-a579-31295f919aed.host          (records: 1)
+        AAAA fd00:1122:3344:102::26
+    name: 86c0837a-73ca-4d08-971d-8491401c2fe2.host          (records: 1)
+        AAAA fd00:1122:3344:101::24
+    name: 8a651785-3936-4cf6-b301-4fa7fa003c9f.host          (records: 1)
+        AAAA fd00:1122:3344:103::23
+    name: 9b8c5aff-3892-4645-8c66-c540456f05af.host          (records: 1)
+        AAAA fd00:1122:3344:101::27
+    name: _clickhouse-admin-single-server._tcp               (records: 1)
+        SRV  port  8888 c138c88c-a83d-4e2d-a8f8-e8e715d8e5f7.host.control-plane.oxide.internal
+    name: _clickhouse-native._tcp                            (records: 1)
+        SRV  port  9000 c138c88c-a83d-4e2d-a8f8-e8e715d8e5f7.host.control-plane.oxide.internal
+    name: _clickhouse._tcp                                   (records: 1)
+        SRV  port  8123 c138c88c-a83d-4e2d-a8f8-e8e715d8e5f7.host.control-plane.oxide.internal
+    name: _crucible-pantry._tcp                              (records: 3)
+        SRV  port 17000 5c67f8ed-9f38-4be1-b64c-a2d9898d3263.host.control-plane.oxide.internal
+        SRV  port 17000 a76d9883-b4fe-464f-acbb-e75b2bbb508d.host.control-plane.oxide.internal
+        SRV  port 17000 c4c56b5a-8c18-4eac-964a-62f94cac07b1.host.control-plane.oxide.internal
+    name: _crucible._tcp.327db2a9-fc45-4c3f-a6db-4ee58459e5cf (records: 1)
+        SRV  port 32345 327db2a9-fc45-4c3f-a6db-4ee58459e5cf.host.control-plane.oxide.internal
+    name: _crucible._tcp.575bd77e-6cd9-4bb6-9c1f-2ac6f149278a (records: 1)
+        SRV  port 32345 575bd77e-6cd9-4bb6-9c1f-2ac6f149278a.host.control-plane.oxide.internal
+    name: _crucible._tcp.5ea7f627-d51e-4e2d-8648-112ddc635e53 (records: 1)
+        SRV  port 32345 5ea7f627-d51e-4e2d-8648-112ddc635e53.host.control-plane.oxide.internal
+    name: _crucible._tcp.70b7e8a1-cc3f-4cdd-a577-4c8be9885f8b (records: 1)
+        SRV  port 32345 70b7e8a1-cc3f-4cdd-a577-4c8be9885f8b.host.control-plane.oxide.internal
+    name: _crucible._tcp.719199e7-eacf-4add-b532-ddfaf867b478 (records: 1)
+        SRV  port 32345 719199e7-eacf-4add-b532-ddfaf867b478.host.control-plane.oxide.internal
+    name: _crucible._tcp.7bb9667d-da70-4592-a579-31295f919aed (records: 1)
+        SRV  port 32345 7bb9667d-da70-4592-a579-31295f919aed.host.control-plane.oxide.internal
+    name: _crucible._tcp.9b8c5aff-3892-4645-8c66-c540456f05af (records: 1)
+        SRV  port 32345 9b8c5aff-3892-4645-8c66-c540456f05af.host.control-plane.oxide.internal
+    name: _crucible._tcp.a5a25771-1025-4c08-9362-c5ee4cecafc9 (records: 1)
+        SRV  port 32345 a5a25771-1025-4c08-9362-c5ee4cecafc9.host.control-plane.oxide.internal
+    name: _crucible._tcp.ad81aafc-e74d-4b0a-b4e6-2e58ef52b7a2 (records: 1)
+        SRV  port 32345 ad81aafc-e74d-4b0a-b4e6-2e58ef52b7a2.host.control-plane.oxide.internal
+    name: _external-dns._tcp                                 (records: 3)
+        SRV  port  5353 86c0837a-73ca-4d08-971d-8491401c2fe2.host.control-plane.oxide.internal
+        SRV  port  5353 8a651785-3936-4cf6-b301-4fa7fa003c9f.host.control-plane.oxide.internal
+        SRV  port  5353 b067565e-df5a-441f-85b9-69acc38bbf35.host.control-plane.oxide.internal
+    name: _internal-ntp._tcp                                 (records: 3)
+        SRV  port   123 345fbd68-cb55-4faa-b6ea-801789018bc6.host.control-plane.oxide.internal
+        SRV  port   123 4ad9c209-bd1b-44c9-863d-1a6b84b34d53.host.control-plane.oxide.internal
+        SRV  port   123 f282c429-5f5e-4430-8f71-600cf61ded56.host.control-plane.oxide.internal
+    name: _nameservice._tcp                                  (records: 3)
+        SRV  port  5353 159e1f8f-6f32-413d-a48b-e40fb2efaf15.host.control-plane.oxide.internal
+        SRV  port  5353 ae5b529a-2ada-490c-bea9-04c71cf8e72c.host.control-plane.oxide.internal
+        SRV  port  5353 f14b0fff-c0f0-420f-ab51-df1a605f43c3.host.control-plane.oxide.internal
+    name: _nexus._tcp                                        (records: 3)
+        SRV  port 12221 1dee8f37-8286-48dc-b4b4-e59979c030ec.host.control-plane.oxide.internal
+        SRV  port 12221 543b3bb6-358d-4876-9774-53a53187aaa8.host.control-plane.oxide.internal
+        SRV  port 12221 6df9649e-48f8-4754-94f3-55e8f9b039be.host.control-plane.oxide.internal
+    name: _oximeter-reader._tcp                              (records: 1)
+        SRV  port  9000 c138c88c-a83d-4e2d-a8f8-e8e715d8e5f7.host.control-plane.oxide.internal
+    name: _repo-depot._tcp                                   (records: 3)
+        SRV  port 12348 bb0ec23a-f97c-4b6a-a5bc-864b1ebc9236.sled.control-plane.oxide.internal
+        SRV  port 12348 bba6ea73-6c9c-4ab5-8bb4-1dd145071407.sled.control-plane.oxide.internal
+        SRV  port 12348 cc00b21a-5685-480a-ab5e-d2e29cf369df.sled.control-plane.oxide.internal
+    name: a5a25771-1025-4c08-9362-c5ee4cecafc9.host          (records: 1)
+        AAAA fd00:1122:3344:102::25
+    name: a76d9883-b4fe-464f-acbb-e75b2bbb508d.host          (records: 1)
+        AAAA fd00:1122:3344:103::24
+    name: ad81aafc-e74d-4b0a-b4e6-2e58ef52b7a2.host          (records: 1)
+        AAAA fd00:1122:3344:103::26
+    name: ae5b529a-2ada-490c-bea9-04c71cf8e72c.host          (records: 1)
+        AAAA fd00:1122:3344:1::1
+    name: b067565e-df5a-441f-85b9-69acc38bbf35.host          (records: 1)
+        AAAA fd00:1122:3344:102::23
+    name: bb0ec23a-f97c-4b6a-a5bc-864b1ebc9236.sled          (records: 1)
+        AAAA fd00:1122:3344:101::1
+    name: bba6ea73-6c9c-4ab5-8bb4-1dd145071407.sled          (records: 1)
+        AAAA fd00:1122:3344:102::1
+    name: c138c88c-a83d-4e2d-a8f8-e8e715d8e5f7.host          (records: 1)
+        AAAA fd00:1122:3344:101::23
+    name: c4c56b5a-8c18-4eac-964a-62f94cac07b1.host          (records: 1)
+        AAAA fd00:1122:3344:101::25
+    name: cc00b21a-5685-480a-ab5e-d2e29cf369df.sled          (records: 1)
+        AAAA fd00:1122:3344:103::1
+    name: f14b0fff-c0f0-420f-ab51-df1a605f43c3.host          (records: 1)
+        AAAA fd00:1122:3344:3::1
+    name: f282c429-5f5e-4430-8f71-600cf61ded56.host          (records: 1)
+        AAAA fd00:1122:3344:103::21
+
+external DNS:
+  DNS zone: "oxide.example" (unchanged)
+    name: example-silo.sys                                   (records: 3)
+        A    192.0.2.2
+        A    192.0.2.3
+        A    192.0.2.4
+
+
+
+> 
+
+> # Change that configuration.  It should replace the previous one.
+
+> # This also exercises versions that are not semver.
+
+> blueprint-edit cca24b71-09b5-4042-9185-b33e9f2ebba0 sp-update-set serial2 e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855 newest sp newer older
+blueprint 5bf974f3-81f9-455b-b24e-3099f765664c created from blueprint cca24b71-09b5-4042-9185-b33e9f2ebba0: configured update for serial serial2
+warn: no validation is done on the requested artifact hash or version
+
+> blueprint-show 5bf974f3-81f9-455b-b24e-3099f765664c
+blueprint  5bf974f3-81f9-455b-b24e-3099f765664c
+parent:    cca24b71-09b5-4042-9185-b33e9f2ebba0
+
+  sled: bb0ec23a-f97c-4b6a-a5bc-864b1ebc9236 (active, config generation 2)
+
+    physical disks:
+    ------------------------------------------------------------------------------------
+    vendor        model        serial                                        disposition
+    ------------------------------------------------------------------------------------
+    fake-vendor   fake-model   serial-a156a6d9-e839-4cb2-9d09-faf012dae700   in service 
+    fake-vendor   fake-model   serial-b48b5b36-fbb1-4c71-8b08-34a58b3ed2bd   in service 
+    fake-vendor   fake-model   serial-b62945fd-6ac2-4ec2-9e13-0a9a10620924   in service 
+
+
+    datasets:
+    -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
+    dataset name                                                                                                   dataset id                             disposition   quota     reservation   compression
+    -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
+    oxp_a156a6d9-e839-4cb2-9d09-faf012dae700/crucible                                                              bbf79ca9-a619-4142-9802-d306a4b58acb   in service    none      none          off        
+    oxp_b48b5b36-fbb1-4c71-8b08-34a58b3ed2bd/crucible                                                              ff6da666-707c-4370-b0d9-0572d8851e9d   in service    none      none          off        
+    oxp_b62945fd-6ac2-4ec2-9e13-0a9a10620924/crucible                                                              1f46779a-37b2-48d7-8ea9-a4e988bb0045   in service    none      none          off        
+    oxp_a156a6d9-e839-4cb2-9d09-faf012dae700/crypt/clickhouse                                                      43b6b5c0-61d8-4b88-bbb8-abede5589619   in service    none      none          off        
+    oxp_a156a6d9-e839-4cb2-9d09-faf012dae700/crypt/external_dns                                                    f5fc02e2-46ff-4012-a5c0-c91ad7881642   in service    none      none          off        
+    oxp_a156a6d9-e839-4cb2-9d09-faf012dae700/crypt/internal_dns                                                    2c16250f-d4aa-4fb5-bf4b-a6b5d72ac441   in service    none      none          off        
+    oxp_a156a6d9-e839-4cb2-9d09-faf012dae700/crypt/zone                                                            9077f1bd-3864-43d5-9c02-9370cbb9156d   in service    none      none          off        
+    oxp_b48b5b36-fbb1-4c71-8b08-34a58b3ed2bd/crypt/zone                                                            f4febe2f-789b-4c28-8bb7-aa594e0e4a4f   in service    none      none          off        
+    oxp_b62945fd-6ac2-4ec2-9e13-0a9a10620924/crypt/zone                                                            de0fe910-037f-49da-b86b-5865818c568d   in service    none      none          off        
+    oxp_a156a6d9-e839-4cb2-9d09-faf012dae700/crypt/zone/oxz_clickhouse_c138c88c-a83d-4e2d-a8f8-e8e715d8e5f7        7de7e173-0287-4e01-ad60-73681156e0e4   in service    none      none          off        
+    oxp_a156a6d9-e839-4cb2-9d09-faf012dae700/crypt/zone/oxz_crucible_575bd77e-6cd9-4bb6-9c1f-2ac6f149278a          252039e9-e48e-4790-930d-a8fad52256d7   in service    none      none          off        
+    oxp_b62945fd-6ac2-4ec2-9e13-0a9a10620924/crypt/zone/oxz_crucible_719199e7-eacf-4add-b532-ddfaf867b478          7ca01115-8692-438a-aa91-84b7c11f5ef2   in service    none      none          off        
+    oxp_b48b5b36-fbb1-4c71-8b08-34a58b3ed2bd/crypt/zone/oxz_crucible_9b8c5aff-3892-4645-8c66-c540456f05af          61a88822-ec1a-4c94-8134-f5d33e342428   in service    none      none          off        
+    oxp_a156a6d9-e839-4cb2-9d09-faf012dae700/crypt/zone/oxz_crucible_pantry_c4c56b5a-8c18-4eac-964a-62f94cac07b1   45b1fd69-7ace-41f8-97bc-3f6e99314e8a   in service    none      none          off        
+    oxp_a156a6d9-e839-4cb2-9d09-faf012dae700/crypt/zone/oxz_external_dns_86c0837a-73ca-4d08-971d-8491401c2fe2      6159b0b8-1c4b-4dd4-a32e-5c5a93df859b   in service    none      none          off        
+    oxp_a156a6d9-e839-4cb2-9d09-faf012dae700/crypt/zone/oxz_internal_dns_ae5b529a-2ada-490c-bea9-04c71cf8e72c      9f74b627-d96c-4183-92f4-7cfaca681fb5   in service    none      none          off        
+    oxp_a156a6d9-e839-4cb2-9d09-faf012dae700/crypt/zone/oxz_nexus_6df9649e-48f8-4754-94f3-55e8f9b039be             6985e6b4-a53b-4a88-bda6-41d2da73af48   in service    none      none          off        
+    oxp_a156a6d9-e839-4cb2-9d09-faf012dae700/crypt/zone/oxz_ntp_4ad9c209-bd1b-44c9-863d-1a6b84b34d53               233b6c7d-284f-42e6-b9e5-607e9377387d   in service    none      none          off        
+    oxp_a156a6d9-e839-4cb2-9d09-faf012dae700/crypt/debug                                                           a510cf34-74db-44fc-903f-36704f21ae67   in service    100 GiB   none          gzip-9     
+    oxp_b48b5b36-fbb1-4c71-8b08-34a58b3ed2bd/crypt/debug                                                           b9f7efe9-5088-45a3-96d9-6cc69be0ec72   in service    100 GiB   none          gzip-9     
+    oxp_b62945fd-6ac2-4ec2-9e13-0a9a10620924/crypt/debug                                                           ae71243d-118a-4e43-b4e3-9e425c6b8395   in service    100 GiB   none          gzip-9     
+
+
+    omicron zones:
+    ---------------------------------------------------------------------------------------------------------------
+    zone type         zone id                                image source      disposition   underlay IP           
+    ---------------------------------------------------------------------------------------------------------------
+    clickhouse        c138c88c-a83d-4e2d-a8f8-e8e715d8e5f7   install dataset   in service    fd00:1122:3344:101::23
+    crucible          575bd77e-6cd9-4bb6-9c1f-2ac6f149278a   install dataset   in service    fd00:1122:3344:101::26
+    crucible          719199e7-eacf-4add-b532-ddfaf867b478   install dataset   in service    fd00:1122:3344:101::28
+    crucible          9b8c5aff-3892-4645-8c66-c540456f05af   install dataset   in service    fd00:1122:3344:101::27
+    crucible_pantry   c4c56b5a-8c18-4eac-964a-62f94cac07b1   install dataset   in service    fd00:1122:3344:101::25
+    external_dns      86c0837a-73ca-4d08-971d-8491401c2fe2   install dataset   in service    fd00:1122:3344:101::24
+    internal_dns      ae5b529a-2ada-490c-bea9-04c71cf8e72c   install dataset   in service    fd00:1122:3344:1::1   
+    internal_ntp      4ad9c209-bd1b-44c9-863d-1a6b84b34d53   install dataset   in service    fd00:1122:3344:101::21
+    nexus             6df9649e-48f8-4754-94f3-55e8f9b039be   install dataset   in service    fd00:1122:3344:101::22
+
+
+
+  sled: bba6ea73-6c9c-4ab5-8bb4-1dd145071407 (active, config generation 2)
+
+    physical disks:
+    ------------------------------------------------------------------------------------
+    vendor        model        serial                                        disposition
+    ------------------------------------------------------------------------------------
+    fake-vendor   fake-model   serial-2201d82d-3a3c-4744-ac41-657536a90afe   in service 
+    fake-vendor   fake-model   serial-bdf3642c-a783-4689-a8a6-8cfa257089bd   in service 
+    fake-vendor   fake-model   serial-eeb9b9ce-ac1c-4a41-9a7a-814e26e2a9ee   in service 
+
+
+    datasets:
+    -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
+    dataset name                                                                                                   dataset id                             disposition   quota     reservation   compression
+    -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
+    oxp_2201d82d-3a3c-4744-ac41-657536a90afe/crucible                                                              66beebb3-2b7a-4334-9ea7-e7c714b6dacc   in service    none      none          off        
+    oxp_bdf3642c-a783-4689-a8a6-8cfa257089bd/crucible                                                              4611f0cd-1ef4-42f2-b1bd-8ce5c0ee1ba4   in service    none      none          off        
+    oxp_eeb9b9ce-ac1c-4a41-9a7a-814e26e2a9ee/crucible                                                              4420b086-b23f-4ba6-b504-459a38e3b367   in service    none      none          off        
+    oxp_2201d82d-3a3c-4744-ac41-657536a90afe/crypt/external_dns                                                    ffe1a3c8-7546-495f-b437-f2405be4e533   in service    none      none          off        
+    oxp_2201d82d-3a3c-4744-ac41-657536a90afe/crypt/internal_dns                                                    c5300adb-042e-41fd-9b1f-5c01d68e7eb4   in service    none      none          off        
+    oxp_2201d82d-3a3c-4744-ac41-657536a90afe/crypt/zone                                                            06dfa1c2-42c3-4626-8bf3-4460dfec3646   in service    none      none          off        
+    oxp_bdf3642c-a783-4689-a8a6-8cfa257089bd/crypt/zone                                                            89ae62b7-0cff-4e09-b4e9-4c43bf242e1d   in service    none      none          off        
+    oxp_eeb9b9ce-ac1c-4a41-9a7a-814e26e2a9ee/crypt/zone                                                            78269a0c-ce98-4834-ae9e-d25eee99a079   in service    none      none          off        
+    oxp_eeb9b9ce-ac1c-4a41-9a7a-814e26e2a9ee/crypt/zone/oxz_crucible_70b7e8a1-cc3f-4cdd-a577-4c8be9885f8b          1382d296-a276-40ca-85b3-9f2578cb95cf   in service    none      none          off        
+    oxp_bdf3642c-a783-4689-a8a6-8cfa257089bd/crypt/zone/oxz_crucible_7bb9667d-da70-4592-a579-31295f919aed          57d3c6cb-64ff-4485-87c0-3ff5fe9c45d8   in service    none      none          off        
+    oxp_2201d82d-3a3c-4744-ac41-657536a90afe/crypt/zone/oxz_crucible_a5a25771-1025-4c08-9362-c5ee4cecafc9          a0e1cc1c-d542-4a21-96bb-efdfe40af009   in service    none      none          off        
+    oxp_2201d82d-3a3c-4744-ac41-657536a90afe/crypt/zone/oxz_crucible_pantry_5c67f8ed-9f38-4be1-b64c-a2d9898d3263   4f3e7986-e836-4ecc-ac69-8c013905707c   in service    none      none          off        
+    oxp_2201d82d-3a3c-4744-ac41-657536a90afe/crypt/zone/oxz_external_dns_b067565e-df5a-441f-85b9-69acc38bbf35      bc7affdc-54b9-4172-8264-af82b92fdfe0   in service    none      none          off        
+    oxp_2201d82d-3a3c-4744-ac41-657536a90afe/crypt/zone/oxz_internal_dns_159e1f8f-6f32-413d-a48b-e40fb2efaf15      79d73706-f701-4857-a378-fcf026cd6756   in service    none      none          off        
+    oxp_2201d82d-3a3c-4744-ac41-657536a90afe/crypt/zone/oxz_nexus_543b3bb6-358d-4876-9774-53a53187aaa8             71b813ec-4a24-43d1-b0b8-5c3303a1d9b5   in service    none      none          off        
+    oxp_2201d82d-3a3c-4744-ac41-657536a90afe/crypt/zone/oxz_ntp_345fbd68-cb55-4faa-b6ea-801789018bc6               d4126675-e113-4a2d-826a-cf7b224b794b   in service    none      none          off        
+    oxp_2201d82d-3a3c-4744-ac41-657536a90afe/crypt/debug                                                           afe7ef8e-c974-403e-932e-eb3c8057b22d   in service    100 GiB   none          gzip-9     
+    oxp_bdf3642c-a783-4689-a8a6-8cfa257089bd/crypt/debug                                                           f5f65250-3145-41bf-b462-359728bda24a   in service    100 GiB   none          gzip-9     
+    oxp_eeb9b9ce-ac1c-4a41-9a7a-814e26e2a9ee/crypt/debug                                                           7328892a-0525-401f-9160-a8e4501049fd   in service    100 GiB   none          gzip-9     
+
+
+    omicron zones:
+    ---------------------------------------------------------------------------------------------------------------
+    zone type         zone id                                image source      disposition   underlay IP           
+    ---------------------------------------------------------------------------------------------------------------
+    crucible          70b7e8a1-cc3f-4cdd-a577-4c8be9885f8b   install dataset   in service    fd00:1122:3344:102::27
+    crucible          7bb9667d-da70-4592-a579-31295f919aed   install dataset   in service    fd00:1122:3344:102::26
+    crucible          a5a25771-1025-4c08-9362-c5ee4cecafc9   install dataset   in service    fd00:1122:3344:102::25
+    crucible_pantry   5c67f8ed-9f38-4be1-b64c-a2d9898d3263   install dataset   in service    fd00:1122:3344:102::24
+    external_dns      b067565e-df5a-441f-85b9-69acc38bbf35   install dataset   in service    fd00:1122:3344:102::23
+    internal_dns      159e1f8f-6f32-413d-a48b-e40fb2efaf15   install dataset   in service    fd00:1122:3344:2::1   
+    internal_ntp      345fbd68-cb55-4faa-b6ea-801789018bc6   install dataset   in service    fd00:1122:3344:102::21
+    nexus             543b3bb6-358d-4876-9774-53a53187aaa8   install dataset   in service    fd00:1122:3344:102::22
+
+
+
+  sled: cc00b21a-5685-480a-ab5e-d2e29cf369df (active, config generation 2)
+
+    physical disks:
+    ------------------------------------------------------------------------------------
+    vendor        model        serial                                        disposition
+    ------------------------------------------------------------------------------------
+    fake-vendor   fake-model   serial-78b8bc9a-8f5b-4fc2-9d70-4470b2d05aae   in service 
+    fake-vendor   fake-model   serial-9e809fde-e684-4ee8-8d46-dade081c3c37   in service 
+    fake-vendor   fake-model   serial-f2b5fdba-606d-45a4-9a9b-35bf20892bd6   in service 
+
+
+    datasets:
+    -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
+    dataset name                                                                                                   dataset id                             disposition   quota     reservation   compression
+    -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
+    oxp_78b8bc9a-8f5b-4fc2-9d70-4470b2d05aae/crucible                                                              a84f76f4-1f8c-4772-a072-ffb0dc7c281c   in service    none      none          off        
+    oxp_9e809fde-e684-4ee8-8d46-dade081c3c37/crucible                                                              db8f2cdf-721f-4c56-880e-d9265ec404f5   in service    none      none          off        
+    oxp_f2b5fdba-606d-45a4-9a9b-35bf20892bd6/crucible                                                              faa61220-8f21-4231-b069-3fb417699363   in service    none      none          off        
+    oxp_78b8bc9a-8f5b-4fc2-9d70-4470b2d05aae/crypt/external_dns                                                    b47f981e-ac2d-4ec1-8e67-c15dcf13af86   in service    none      none          off        
+    oxp_78b8bc9a-8f5b-4fc2-9d70-4470b2d05aae/crypt/internal_dns                                                    037ef4f6-dae1-478e-8397-3b68bf8e47dc   in service    none      none          off        
+    oxp_78b8bc9a-8f5b-4fc2-9d70-4470b2d05aae/crypt/zone                                                            fa042a64-d60c-4aa6-bc1a-ae9d0347bde8   in service    none      none          off        
+    oxp_9e809fde-e684-4ee8-8d46-dade081c3c37/crypt/zone                                                            5366ad89-e6ec-47e5-8870-fafc8224f11f   in service    none      none          off        
+    oxp_f2b5fdba-606d-45a4-9a9b-35bf20892bd6/crypt/zone                                                            fb5e2978-9182-46bd-919d-653b86b1fed3   in service    none      none          off        
+    oxp_f2b5fdba-606d-45a4-9a9b-35bf20892bd6/crypt/zone/oxz_crucible_327db2a9-fc45-4c3f-a6db-4ee58459e5cf          ac6a48f2-c9e0-4bf2-9c93-c234efc48a59   in service    none      none          off        
+    oxp_78b8bc9a-8f5b-4fc2-9d70-4470b2d05aae/crypt/zone/oxz_crucible_5ea7f627-d51e-4e2d-8648-112ddc635e53          d449dcc4-1725-4de2-92c0-e1a37d12299a   in service    none      none          off        
+    oxp_9e809fde-e684-4ee8-8d46-dade081c3c37/crypt/zone/oxz_crucible_ad81aafc-e74d-4b0a-b4e6-2e58ef52b7a2          2c018c08-7cc7-45a9-be60-cd6b82874cfc   in service    none      none          off        
+    oxp_78b8bc9a-8f5b-4fc2-9d70-4470b2d05aae/crypt/zone/oxz_crucible_pantry_a76d9883-b4fe-464f-acbb-e75b2bbb508d   ad79a937-7410-4e92-89e1-0af1a0595cef   in service    none      none          off        
+    oxp_78b8bc9a-8f5b-4fc2-9d70-4470b2d05aae/crypt/zone/oxz_external_dns_8a651785-3936-4cf6-b301-4fa7fa003c9f      e80f5919-dd7c-4d6c-b0de-45d24c0fe421   in service    none      none          off        
+    oxp_78b8bc9a-8f5b-4fc2-9d70-4470b2d05aae/crypt/zone/oxz_internal_dns_f14b0fff-c0f0-420f-ab51-df1a605f43c3      fd542516-55e6-42c6-a8de-0128b3cce65e   in service    none      none          off        
+    oxp_78b8bc9a-8f5b-4fc2-9d70-4470b2d05aae/crypt/zone/oxz_nexus_1dee8f37-8286-48dc-b4b4-e59979c030ec             7c89c13d-8f41-4c69-96d2-6f9ffbc27cbb   in service    none      none          off        
+    oxp_78b8bc9a-8f5b-4fc2-9d70-4470b2d05aae/crypt/zone/oxz_ntp_f282c429-5f5e-4430-8f71-600cf61ded56               7ea314c5-c702-4f47-b70c-02e5131682be   in service    none      none          off        
+    oxp_78b8bc9a-8f5b-4fc2-9d70-4470b2d05aae/crypt/debug                                                           b43d1c1e-5482-40de-869e-8cd2741c6fc0   in service    100 GiB   none          gzip-9     
+    oxp_9e809fde-e684-4ee8-8d46-dade081c3c37/crypt/debug                                                           19e5fb1e-c1f8-4262-9232-0f31eb746cdb   in service    100 GiB   none          gzip-9     
+    oxp_f2b5fdba-606d-45a4-9a9b-35bf20892bd6/crypt/debug                                                           ef852bdc-50a0-458e-a3f4-fd77a633d3cb   in service    100 GiB   none          gzip-9     
+
+
+    omicron zones:
+    ---------------------------------------------------------------------------------------------------------------
+    zone type         zone id                                image source      disposition   underlay IP           
+    ---------------------------------------------------------------------------------------------------------------
+    crucible          327db2a9-fc45-4c3f-a6db-4ee58459e5cf   install dataset   in service    fd00:1122:3344:103::27
+    crucible          5ea7f627-d51e-4e2d-8648-112ddc635e53   install dataset   in service    fd00:1122:3344:103::25
+    crucible          ad81aafc-e74d-4b0a-b4e6-2e58ef52b7a2   install dataset   in service    fd00:1122:3344:103::26
+    crucible_pantry   a76d9883-b4fe-464f-acbb-e75b2bbb508d   install dataset   in service    fd00:1122:3344:103::24
+    external_dns      8a651785-3936-4cf6-b301-4fa7fa003c9f   install dataset   in service    fd00:1122:3344:103::23
+    internal_dns      f14b0fff-c0f0-420f-ab51-df1a605f43c3   install dataset   in service    fd00:1122:3344:3::1   
+    internal_ntp      f282c429-5f5e-4430-8f71-600cf61ded56   install dataset   in service    fd00:1122:3344:103::21
+    nexus             1dee8f37-8286-48dc-b4b4-e59979c030ec   install dataset   in service    fd00:1122:3344:103::22
+
+
+ COCKROACHDB SETTINGS:
+    state fingerprint:::::::::::::::::   (none)
+    cluster.preserve_downgrade_option:   (do not modify)
+
+ OXIMETER SETTINGS:
+    generation:   1
+    read from::   SingleNode
+
+ METADATA:
+    created by:::::::::::   reconfigurator-cli
+    created at:::::::::::   <REDACTED_TIMESTAMP>
+    comment::::::::::::::   (none)
+    internal DNS version:   1
+    external DNS version:   1
+
+ PENDING MGS-MANAGED UPDATES: 1
+    Pending MGS-managed updates:
+    ---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
+    sp_type   slot   part_number   serial_number   artifact_kind   artifact_hash                                                      artifact_version   details                                                                                                               
+    ---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
+    sled      2      model2        serial2         gimlet_sp       e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855   newest             Sp { expected_active_version: ArtifactVersion("newer"), expected_inactive_version: Version(ArtifactVersion("older")) }
+
+
+
+> blueprint-diff ad97e762-7bf1-45a6-a98f-60afb7e491c0 5bf974f3-81f9-455b-b24e-3099f765664c
+from: blueprint ad97e762-7bf1-45a6-a98f-60afb7e491c0
+to:   blueprint 5bf974f3-81f9-455b-b24e-3099f765664c
+
+ UNCHANGED SLEDS:
+
+  sled bb0ec23a-f97c-4b6a-a5bc-864b1ebc9236 (active, config generation 2):
+
+    physical disks:
+    ------------------------------------------------------------------------------------
+    vendor        model        serial                                        disposition
+    ------------------------------------------------------------------------------------
+    fake-vendor   fake-model   serial-a156a6d9-e839-4cb2-9d09-faf012dae700   in service 
+    fake-vendor   fake-model   serial-b48b5b36-fbb1-4c71-8b08-34a58b3ed2bd   in service 
+    fake-vendor   fake-model   serial-b62945fd-6ac2-4ec2-9e13-0a9a10620924   in service 
+
+
+    datasets:
+    -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
+    dataset name                                                                                                   dataset id                             disposition   quota     reservation   compression
+    -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
+    oxp_a156a6d9-e839-4cb2-9d09-faf012dae700/crucible                                                              bbf79ca9-a619-4142-9802-d306a4b58acb   in service    none      none          off        
+    oxp_b48b5b36-fbb1-4c71-8b08-34a58b3ed2bd/crucible                                                              ff6da666-707c-4370-b0d9-0572d8851e9d   in service    none      none          off        
+    oxp_b62945fd-6ac2-4ec2-9e13-0a9a10620924/crucible                                                              1f46779a-37b2-48d7-8ea9-a4e988bb0045   in service    none      none          off        
+    oxp_a156a6d9-e839-4cb2-9d09-faf012dae700/crypt/clickhouse                                                      43b6b5c0-61d8-4b88-bbb8-abede5589619   in service    none      none          off        
+    oxp_a156a6d9-e839-4cb2-9d09-faf012dae700/crypt/external_dns                                                    f5fc02e2-46ff-4012-a5c0-c91ad7881642   in service    none      none          off        
+    oxp_a156a6d9-e839-4cb2-9d09-faf012dae700/crypt/internal_dns                                                    2c16250f-d4aa-4fb5-bf4b-a6b5d72ac441   in service    none      none          off        
+    oxp_a156a6d9-e839-4cb2-9d09-faf012dae700/crypt/zone                                                            9077f1bd-3864-43d5-9c02-9370cbb9156d   in service    none      none          off        
+    oxp_b48b5b36-fbb1-4c71-8b08-34a58b3ed2bd/crypt/zone                                                            f4febe2f-789b-4c28-8bb7-aa594e0e4a4f   in service    none      none          off        
+    oxp_b62945fd-6ac2-4ec2-9e13-0a9a10620924/crypt/zone                                                            de0fe910-037f-49da-b86b-5865818c568d   in service    none      none          off        
+    oxp_a156a6d9-e839-4cb2-9d09-faf012dae700/crypt/zone/oxz_clickhouse_c138c88c-a83d-4e2d-a8f8-e8e715d8e5f7        7de7e173-0287-4e01-ad60-73681156e0e4   in service    none      none          off        
+    oxp_a156a6d9-e839-4cb2-9d09-faf012dae700/crypt/zone/oxz_crucible_575bd77e-6cd9-4bb6-9c1f-2ac6f149278a          252039e9-e48e-4790-930d-a8fad52256d7   in service    none      none          off        
+    oxp_b62945fd-6ac2-4ec2-9e13-0a9a10620924/crypt/zone/oxz_crucible_719199e7-eacf-4add-b532-ddfaf867b478          7ca01115-8692-438a-aa91-84b7c11f5ef2   in service    none      none          off        
+    oxp_b48b5b36-fbb1-4c71-8b08-34a58b3ed2bd/crypt/zone/oxz_crucible_9b8c5aff-3892-4645-8c66-c540456f05af          61a88822-ec1a-4c94-8134-f5d33e342428   in service    none      none          off        
+    oxp_a156a6d9-e839-4cb2-9d09-faf012dae700/crypt/zone/oxz_crucible_pantry_c4c56b5a-8c18-4eac-964a-62f94cac07b1   45b1fd69-7ace-41f8-97bc-3f6e99314e8a   in service    none      none          off        
+    oxp_a156a6d9-e839-4cb2-9d09-faf012dae700/crypt/zone/oxz_external_dns_86c0837a-73ca-4d08-971d-8491401c2fe2      6159b0b8-1c4b-4dd4-a32e-5c5a93df859b   in service    none      none          off        
+    oxp_a156a6d9-e839-4cb2-9d09-faf012dae700/crypt/zone/oxz_internal_dns_ae5b529a-2ada-490c-bea9-04c71cf8e72c      9f74b627-d96c-4183-92f4-7cfaca681fb5   in service    none      none          off        
+    oxp_a156a6d9-e839-4cb2-9d09-faf012dae700/crypt/zone/oxz_nexus_6df9649e-48f8-4754-94f3-55e8f9b039be             6985e6b4-a53b-4a88-bda6-41d2da73af48   in service    none      none          off        
+    oxp_a156a6d9-e839-4cb2-9d09-faf012dae700/crypt/zone/oxz_ntp_4ad9c209-bd1b-44c9-863d-1a6b84b34d53               233b6c7d-284f-42e6-b9e5-607e9377387d   in service    none      none          off        
+    oxp_a156a6d9-e839-4cb2-9d09-faf012dae700/crypt/debug                                                           a510cf34-74db-44fc-903f-36704f21ae67   in service    100 GiB   none          gzip-9     
+    oxp_b48b5b36-fbb1-4c71-8b08-34a58b3ed2bd/crypt/debug                                                           b9f7efe9-5088-45a3-96d9-6cc69be0ec72   in service    100 GiB   none          gzip-9     
+    oxp_b62945fd-6ac2-4ec2-9e13-0a9a10620924/crypt/debug                                                           ae71243d-118a-4e43-b4e3-9e425c6b8395   in service    100 GiB   none          gzip-9     
+
+
+    omicron zones:
+    ---------------------------------------------------------------------------------------------------------------
+    zone type         zone id                                image source      disposition   underlay IP           
+    ---------------------------------------------------------------------------------------------------------------
+    clickhouse        c138c88c-a83d-4e2d-a8f8-e8e715d8e5f7   install dataset   in service    fd00:1122:3344:101::23
+    crucible          575bd77e-6cd9-4bb6-9c1f-2ac6f149278a   install dataset   in service    fd00:1122:3344:101::26
+    crucible          719199e7-eacf-4add-b532-ddfaf867b478   install dataset   in service    fd00:1122:3344:101::28
+    crucible          9b8c5aff-3892-4645-8c66-c540456f05af   install dataset   in service    fd00:1122:3344:101::27
+    crucible_pantry   c4c56b5a-8c18-4eac-964a-62f94cac07b1   install dataset   in service    fd00:1122:3344:101::25
+    external_dns      86c0837a-73ca-4d08-971d-8491401c2fe2   install dataset   in service    fd00:1122:3344:101::24
+    internal_dns      ae5b529a-2ada-490c-bea9-04c71cf8e72c   install dataset   in service    fd00:1122:3344:1::1   
+    internal_ntp      4ad9c209-bd1b-44c9-863d-1a6b84b34d53   install dataset   in service    fd00:1122:3344:101::21
+    nexus             6df9649e-48f8-4754-94f3-55e8f9b039be   install dataset   in service    fd00:1122:3344:101::22
+
+
+  sled bba6ea73-6c9c-4ab5-8bb4-1dd145071407 (active, config generation 2):
+
+    physical disks:
+    ------------------------------------------------------------------------------------
+    vendor        model        serial                                        disposition
+    ------------------------------------------------------------------------------------
+    fake-vendor   fake-model   serial-2201d82d-3a3c-4744-ac41-657536a90afe   in service 
+    fake-vendor   fake-model   serial-bdf3642c-a783-4689-a8a6-8cfa257089bd   in service 
+    fake-vendor   fake-model   serial-eeb9b9ce-ac1c-4a41-9a7a-814e26e2a9ee   in service 
+
+
+    datasets:
+    -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
+    dataset name                                                                                                   dataset id                             disposition   quota     reservation   compression
+    -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
+    oxp_2201d82d-3a3c-4744-ac41-657536a90afe/crucible                                                              66beebb3-2b7a-4334-9ea7-e7c714b6dacc   in service    none      none          off        
+    oxp_bdf3642c-a783-4689-a8a6-8cfa257089bd/crucible                                                              4611f0cd-1ef4-42f2-b1bd-8ce5c0ee1ba4   in service    none      none          off        
+    oxp_eeb9b9ce-ac1c-4a41-9a7a-814e26e2a9ee/crucible                                                              4420b086-b23f-4ba6-b504-459a38e3b367   in service    none      none          off        
+    oxp_2201d82d-3a3c-4744-ac41-657536a90afe/crypt/external_dns                                                    ffe1a3c8-7546-495f-b437-f2405be4e533   in service    none      none          off        
+    oxp_2201d82d-3a3c-4744-ac41-657536a90afe/crypt/internal_dns                                                    c5300adb-042e-41fd-9b1f-5c01d68e7eb4   in service    none      none          off        
+    oxp_2201d82d-3a3c-4744-ac41-657536a90afe/crypt/zone                                                            06dfa1c2-42c3-4626-8bf3-4460dfec3646   in service    none      none          off        
+    oxp_bdf3642c-a783-4689-a8a6-8cfa257089bd/crypt/zone                                                            89ae62b7-0cff-4e09-b4e9-4c43bf242e1d   in service    none      none          off        
+    oxp_eeb9b9ce-ac1c-4a41-9a7a-814e26e2a9ee/crypt/zone                                                            78269a0c-ce98-4834-ae9e-d25eee99a079   in service    none      none          off        
+    oxp_eeb9b9ce-ac1c-4a41-9a7a-814e26e2a9ee/crypt/zone/oxz_crucible_70b7e8a1-cc3f-4cdd-a577-4c8be9885f8b          1382d296-a276-40ca-85b3-9f2578cb95cf   in service    none      none          off        
+    oxp_bdf3642c-a783-4689-a8a6-8cfa257089bd/crypt/zone/oxz_crucible_7bb9667d-da70-4592-a579-31295f919aed          57d3c6cb-64ff-4485-87c0-3ff5fe9c45d8   in service    none      none          off        
+    oxp_2201d82d-3a3c-4744-ac41-657536a90afe/crypt/zone/oxz_crucible_a5a25771-1025-4c08-9362-c5ee4cecafc9          a0e1cc1c-d542-4a21-96bb-efdfe40af009   in service    none      none          off        
+    oxp_2201d82d-3a3c-4744-ac41-657536a90afe/crypt/zone/oxz_crucible_pantry_5c67f8ed-9f38-4be1-b64c-a2d9898d3263   4f3e7986-e836-4ecc-ac69-8c013905707c   in service    none      none          off        
+    oxp_2201d82d-3a3c-4744-ac41-657536a90afe/crypt/zone/oxz_external_dns_b067565e-df5a-441f-85b9-69acc38bbf35      bc7affdc-54b9-4172-8264-af82b92fdfe0   in service    none      none          off        
+    oxp_2201d82d-3a3c-4744-ac41-657536a90afe/crypt/zone/oxz_internal_dns_159e1f8f-6f32-413d-a48b-e40fb2efaf15      79d73706-f701-4857-a378-fcf026cd6756   in service    none      none          off        
+    oxp_2201d82d-3a3c-4744-ac41-657536a90afe/crypt/zone/oxz_nexus_543b3bb6-358d-4876-9774-53a53187aaa8             71b813ec-4a24-43d1-b0b8-5c3303a1d9b5   in service    none      none          off        
+    oxp_2201d82d-3a3c-4744-ac41-657536a90afe/crypt/zone/oxz_ntp_345fbd68-cb55-4faa-b6ea-801789018bc6               d4126675-e113-4a2d-826a-cf7b224b794b   in service    none      none          off        
+    oxp_2201d82d-3a3c-4744-ac41-657536a90afe/crypt/debug                                                           afe7ef8e-c974-403e-932e-eb3c8057b22d   in service    100 GiB   none          gzip-9     
+    oxp_bdf3642c-a783-4689-a8a6-8cfa257089bd/crypt/debug                                                           f5f65250-3145-41bf-b462-359728bda24a   in service    100 GiB   none          gzip-9     
+    oxp_eeb9b9ce-ac1c-4a41-9a7a-814e26e2a9ee/crypt/debug                                                           7328892a-0525-401f-9160-a8e4501049fd   in service    100 GiB   none          gzip-9     
+
+
+    omicron zones:
+    ---------------------------------------------------------------------------------------------------------------
+    zone type         zone id                                image source      disposition   underlay IP           
+    ---------------------------------------------------------------------------------------------------------------
+    crucible          70b7e8a1-cc3f-4cdd-a577-4c8be9885f8b   install dataset   in service    fd00:1122:3344:102::27
+    crucible          7bb9667d-da70-4592-a579-31295f919aed   install dataset   in service    fd00:1122:3344:102::26
+    crucible          a5a25771-1025-4c08-9362-c5ee4cecafc9   install dataset   in service    fd00:1122:3344:102::25
+    crucible_pantry   5c67f8ed-9f38-4be1-b64c-a2d9898d3263   install dataset   in service    fd00:1122:3344:102::24
+    external_dns      b067565e-df5a-441f-85b9-69acc38bbf35   install dataset   in service    fd00:1122:3344:102::23
+    internal_dns      159e1f8f-6f32-413d-a48b-e40fb2efaf15   install dataset   in service    fd00:1122:3344:2::1   
+    internal_ntp      345fbd68-cb55-4faa-b6ea-801789018bc6   install dataset   in service    fd00:1122:3344:102::21
+    nexus             543b3bb6-358d-4876-9774-53a53187aaa8   install dataset   in service    fd00:1122:3344:102::22
+
+
+  sled cc00b21a-5685-480a-ab5e-d2e29cf369df (active, config generation 2):
+
+    physical disks:
+    ------------------------------------------------------------------------------------
+    vendor        model        serial                                        disposition
+    ------------------------------------------------------------------------------------
+    fake-vendor   fake-model   serial-78b8bc9a-8f5b-4fc2-9d70-4470b2d05aae   in service 
+    fake-vendor   fake-model   serial-9e809fde-e684-4ee8-8d46-dade081c3c37   in service 
+    fake-vendor   fake-model   serial-f2b5fdba-606d-45a4-9a9b-35bf20892bd6   in service 
+
+
+    datasets:
+    -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
+    dataset name                                                                                                   dataset id                             disposition   quota     reservation   compression
+    -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
+    oxp_78b8bc9a-8f5b-4fc2-9d70-4470b2d05aae/crucible                                                              a84f76f4-1f8c-4772-a072-ffb0dc7c281c   in service    none      none          off        
+    oxp_9e809fde-e684-4ee8-8d46-dade081c3c37/crucible                                                              db8f2cdf-721f-4c56-880e-d9265ec404f5   in service    none      none          off        
+    oxp_f2b5fdba-606d-45a4-9a9b-35bf20892bd6/crucible                                                              faa61220-8f21-4231-b069-3fb417699363   in service    none      none          off        
+    oxp_78b8bc9a-8f5b-4fc2-9d70-4470b2d05aae/crypt/external_dns                                                    b47f981e-ac2d-4ec1-8e67-c15dcf13af86   in service    none      none          off        
+    oxp_78b8bc9a-8f5b-4fc2-9d70-4470b2d05aae/crypt/internal_dns                                                    037ef4f6-dae1-478e-8397-3b68bf8e47dc   in service    none      none          off        
+    oxp_78b8bc9a-8f5b-4fc2-9d70-4470b2d05aae/crypt/zone                                                            fa042a64-d60c-4aa6-bc1a-ae9d0347bde8   in service    none      none          off        
+    oxp_9e809fde-e684-4ee8-8d46-dade081c3c37/crypt/zone                                                            5366ad89-e6ec-47e5-8870-fafc8224f11f   in service    none      none          off        
+    oxp_f2b5fdba-606d-45a4-9a9b-35bf20892bd6/crypt/zone                                                            fb5e2978-9182-46bd-919d-653b86b1fed3   in service    none      none          off        
+    oxp_f2b5fdba-606d-45a4-9a9b-35bf20892bd6/crypt/zone/oxz_crucible_327db2a9-fc45-4c3f-a6db-4ee58459e5cf          ac6a48f2-c9e0-4bf2-9c93-c234efc48a59   in service    none      none          off        
+    oxp_78b8bc9a-8f5b-4fc2-9d70-4470b2d05aae/crypt/zone/oxz_crucible_5ea7f627-d51e-4e2d-8648-112ddc635e53          d449dcc4-1725-4de2-92c0-e1a37d12299a   in service    none      none          off        
+    oxp_9e809fde-e684-4ee8-8d46-dade081c3c37/crypt/zone/oxz_crucible_ad81aafc-e74d-4b0a-b4e6-2e58ef52b7a2          2c018c08-7cc7-45a9-be60-cd6b82874cfc   in service    none      none          off        
+    oxp_78b8bc9a-8f5b-4fc2-9d70-4470b2d05aae/crypt/zone/oxz_crucible_pantry_a76d9883-b4fe-464f-acbb-e75b2bbb508d   ad79a937-7410-4e92-89e1-0af1a0595cef   in service    none      none          off        
+    oxp_78b8bc9a-8f5b-4fc2-9d70-4470b2d05aae/crypt/zone/oxz_external_dns_8a651785-3936-4cf6-b301-4fa7fa003c9f      e80f5919-dd7c-4d6c-b0de-45d24c0fe421   in service    none      none          off        
+    oxp_78b8bc9a-8f5b-4fc2-9d70-4470b2d05aae/crypt/zone/oxz_internal_dns_f14b0fff-c0f0-420f-ab51-df1a605f43c3      fd542516-55e6-42c6-a8de-0128b3cce65e   in service    none      none          off        
+    oxp_78b8bc9a-8f5b-4fc2-9d70-4470b2d05aae/crypt/zone/oxz_nexus_1dee8f37-8286-48dc-b4b4-e59979c030ec             7c89c13d-8f41-4c69-96d2-6f9ffbc27cbb   in service    none      none          off        
+    oxp_78b8bc9a-8f5b-4fc2-9d70-4470b2d05aae/crypt/zone/oxz_ntp_f282c429-5f5e-4430-8f71-600cf61ded56               7ea314c5-c702-4f47-b70c-02e5131682be   in service    none      none          off        
+    oxp_78b8bc9a-8f5b-4fc2-9d70-4470b2d05aae/crypt/debug                                                           b43d1c1e-5482-40de-869e-8cd2741c6fc0   in service    100 GiB   none          gzip-9     
+    oxp_9e809fde-e684-4ee8-8d46-dade081c3c37/crypt/debug                                                           19e5fb1e-c1f8-4262-9232-0f31eb746cdb   in service    100 GiB   none          gzip-9     
+    oxp_f2b5fdba-606d-45a4-9a9b-35bf20892bd6/crypt/debug                                                           ef852bdc-50a0-458e-a3f4-fd77a633d3cb   in service    100 GiB   none          gzip-9     
+
+
+    omicron zones:
+    ---------------------------------------------------------------------------------------------------------------
+    zone type         zone id                                image source      disposition   underlay IP           
+    ---------------------------------------------------------------------------------------------------------------
+    crucible          327db2a9-fc45-4c3f-a6db-4ee58459e5cf   install dataset   in service    fd00:1122:3344:103::27
+    crucible          5ea7f627-d51e-4e2d-8648-112ddc635e53   install dataset   in service    fd00:1122:3344:103::25
+    crucible          ad81aafc-e74d-4b0a-b4e6-2e58ef52b7a2   install dataset   in service    fd00:1122:3344:103::26
+    crucible_pantry   a76d9883-b4fe-464f-acbb-e75b2bbb508d   install dataset   in service    fd00:1122:3344:103::24
+    external_dns      8a651785-3936-4cf6-b301-4fa7fa003c9f   install dataset   in service    fd00:1122:3344:103::23
+    internal_dns      f14b0fff-c0f0-420f-ab51-df1a605f43c3   install dataset   in service    fd00:1122:3344:3::1   
+    internal_ntp      f282c429-5f5e-4430-8f71-600cf61ded56   install dataset   in service    fd00:1122:3344:103::21
+    nexus             1dee8f37-8286-48dc-b4b4-e59979c030ec   install dataset   in service    fd00:1122:3344:103::22
+
+
+ COCKROACHDB SETTINGS:
+    state fingerprint:::::::::::::::::   (none) (unchanged)
+    cluster.preserve_downgrade_option:   (do not modify) (unchanged)
+
+ METADATA:
+    internal DNS version:   1 (unchanged)
+    external DNS version:   1 (unchanged)
+
+ OXIMETER SETTINGS:
+    generation:   1 (unchanged)
+    read from::   SingleNode (unchanged)
+
+
+internal DNS:
+  DNS zone: "control-plane.oxide.internal" (unchanged)
+    name: 159e1f8f-6f32-413d-a48b-e40fb2efaf15.host          (records: 1)
+        AAAA fd00:1122:3344:2::1
+    name: 1dee8f37-8286-48dc-b4b4-e59979c030ec.host          (records: 1)
+        AAAA fd00:1122:3344:103::22
+    name: 327db2a9-fc45-4c3f-a6db-4ee58459e5cf.host          (records: 1)
+        AAAA fd00:1122:3344:103::27
+    name: 345fbd68-cb55-4faa-b6ea-801789018bc6.host          (records: 1)
+        AAAA fd00:1122:3344:102::21
+    name: 4ad9c209-bd1b-44c9-863d-1a6b84b34d53.host          (records: 1)
+        AAAA fd00:1122:3344:101::21
+    name: 543b3bb6-358d-4876-9774-53a53187aaa8.host          (records: 1)
+        AAAA fd00:1122:3344:102::22
+    name: 575bd77e-6cd9-4bb6-9c1f-2ac6f149278a.host          (records: 1)
+        AAAA fd00:1122:3344:101::26
+    name: 5c67f8ed-9f38-4be1-b64c-a2d9898d3263.host          (records: 1)
+        AAAA fd00:1122:3344:102::24
+    name: 5ea7f627-d51e-4e2d-8648-112ddc635e53.host          (records: 1)
+        AAAA fd00:1122:3344:103::25
+    name: 6df9649e-48f8-4754-94f3-55e8f9b039be.host          (records: 1)
+        AAAA fd00:1122:3344:101::22
+    name: 70b7e8a1-cc3f-4cdd-a577-4c8be9885f8b.host          (records: 1)
+        AAAA fd00:1122:3344:102::27
+    name: 719199e7-eacf-4add-b532-ddfaf867b478.host          (records: 1)
+        AAAA fd00:1122:3344:101::28
+    name: 7bb9667d-da70-4592-a579-31295f919aed.host          (records: 1)
+        AAAA fd00:1122:3344:102::26
+    name: 86c0837a-73ca-4d08-971d-8491401c2fe2.host          (records: 1)
+        AAAA fd00:1122:3344:101::24
+    name: 8a651785-3936-4cf6-b301-4fa7fa003c9f.host          (records: 1)
+        AAAA fd00:1122:3344:103::23
+    name: 9b8c5aff-3892-4645-8c66-c540456f05af.host          (records: 1)
+        AAAA fd00:1122:3344:101::27
+    name: _clickhouse-admin-single-server._tcp               (records: 1)
+        SRV  port  8888 c138c88c-a83d-4e2d-a8f8-e8e715d8e5f7.host.control-plane.oxide.internal
+    name: _clickhouse-native._tcp                            (records: 1)
+        SRV  port  9000 c138c88c-a83d-4e2d-a8f8-e8e715d8e5f7.host.control-plane.oxide.internal
+    name: _clickhouse._tcp                                   (records: 1)
+        SRV  port  8123 c138c88c-a83d-4e2d-a8f8-e8e715d8e5f7.host.control-plane.oxide.internal
+    name: _crucible-pantry._tcp                              (records: 3)
+        SRV  port 17000 5c67f8ed-9f38-4be1-b64c-a2d9898d3263.host.control-plane.oxide.internal
+        SRV  port 17000 a76d9883-b4fe-464f-acbb-e75b2bbb508d.host.control-plane.oxide.internal
+        SRV  port 17000 c4c56b5a-8c18-4eac-964a-62f94cac07b1.host.control-plane.oxide.internal
+    name: _crucible._tcp.327db2a9-fc45-4c3f-a6db-4ee58459e5cf (records: 1)
+        SRV  port 32345 327db2a9-fc45-4c3f-a6db-4ee58459e5cf.host.control-plane.oxide.internal
+    name: _crucible._tcp.575bd77e-6cd9-4bb6-9c1f-2ac6f149278a (records: 1)
+        SRV  port 32345 575bd77e-6cd9-4bb6-9c1f-2ac6f149278a.host.control-plane.oxide.internal
+    name: _crucible._tcp.5ea7f627-d51e-4e2d-8648-112ddc635e53 (records: 1)
+        SRV  port 32345 5ea7f627-d51e-4e2d-8648-112ddc635e53.host.control-plane.oxide.internal
+    name: _crucible._tcp.70b7e8a1-cc3f-4cdd-a577-4c8be9885f8b (records: 1)
+        SRV  port 32345 70b7e8a1-cc3f-4cdd-a577-4c8be9885f8b.host.control-plane.oxide.internal
+    name: _crucible._tcp.719199e7-eacf-4add-b532-ddfaf867b478 (records: 1)
+        SRV  port 32345 719199e7-eacf-4add-b532-ddfaf867b478.host.control-plane.oxide.internal
+    name: _crucible._tcp.7bb9667d-da70-4592-a579-31295f919aed (records: 1)
+        SRV  port 32345 7bb9667d-da70-4592-a579-31295f919aed.host.control-plane.oxide.internal
+    name: _crucible._tcp.9b8c5aff-3892-4645-8c66-c540456f05af (records: 1)
+        SRV  port 32345 9b8c5aff-3892-4645-8c66-c540456f05af.host.control-plane.oxide.internal
+    name: _crucible._tcp.a5a25771-1025-4c08-9362-c5ee4cecafc9 (records: 1)
+        SRV  port 32345 a5a25771-1025-4c08-9362-c5ee4cecafc9.host.control-plane.oxide.internal
+    name: _crucible._tcp.ad81aafc-e74d-4b0a-b4e6-2e58ef52b7a2 (records: 1)
+        SRV  port 32345 ad81aafc-e74d-4b0a-b4e6-2e58ef52b7a2.host.control-plane.oxide.internal
+    name: _external-dns._tcp                                 (records: 3)
+        SRV  port  5353 86c0837a-73ca-4d08-971d-8491401c2fe2.host.control-plane.oxide.internal
+        SRV  port  5353 8a651785-3936-4cf6-b301-4fa7fa003c9f.host.control-plane.oxide.internal
+        SRV  port  5353 b067565e-df5a-441f-85b9-69acc38bbf35.host.control-plane.oxide.internal
+    name: _internal-ntp._tcp                                 (records: 3)
+        SRV  port   123 345fbd68-cb55-4faa-b6ea-801789018bc6.host.control-plane.oxide.internal
+        SRV  port   123 4ad9c209-bd1b-44c9-863d-1a6b84b34d53.host.control-plane.oxide.internal
+        SRV  port   123 f282c429-5f5e-4430-8f71-600cf61ded56.host.control-plane.oxide.internal
+    name: _nameservice._tcp                                  (records: 3)
+        SRV  port  5353 159e1f8f-6f32-413d-a48b-e40fb2efaf15.host.control-plane.oxide.internal
+        SRV  port  5353 ae5b529a-2ada-490c-bea9-04c71cf8e72c.host.control-plane.oxide.internal
+        SRV  port  5353 f14b0fff-c0f0-420f-ab51-df1a605f43c3.host.control-plane.oxide.internal
+    name: _nexus._tcp                                        (records: 3)
+        SRV  port 12221 1dee8f37-8286-48dc-b4b4-e59979c030ec.host.control-plane.oxide.internal
+        SRV  port 12221 543b3bb6-358d-4876-9774-53a53187aaa8.host.control-plane.oxide.internal
+        SRV  port 12221 6df9649e-48f8-4754-94f3-55e8f9b039be.host.control-plane.oxide.internal
+    name: _oximeter-reader._tcp                              (records: 1)
+        SRV  port  9000 c138c88c-a83d-4e2d-a8f8-e8e715d8e5f7.host.control-plane.oxide.internal
+    name: _repo-depot._tcp                                   (records: 3)
+        SRV  port 12348 bb0ec23a-f97c-4b6a-a5bc-864b1ebc9236.sled.control-plane.oxide.internal
+        SRV  port 12348 bba6ea73-6c9c-4ab5-8bb4-1dd145071407.sled.control-plane.oxide.internal
+        SRV  port 12348 cc00b21a-5685-480a-ab5e-d2e29cf369df.sled.control-plane.oxide.internal
+    name: a5a25771-1025-4c08-9362-c5ee4cecafc9.host          (records: 1)
+        AAAA fd00:1122:3344:102::25
+    name: a76d9883-b4fe-464f-acbb-e75b2bbb508d.host          (records: 1)
+        AAAA fd00:1122:3344:103::24
+    name: ad81aafc-e74d-4b0a-b4e6-2e58ef52b7a2.host          (records: 1)
+        AAAA fd00:1122:3344:103::26
+    name: ae5b529a-2ada-490c-bea9-04c71cf8e72c.host          (records: 1)
+        AAAA fd00:1122:3344:1::1
+    name: b067565e-df5a-441f-85b9-69acc38bbf35.host          (records: 1)
+        AAAA fd00:1122:3344:102::23
+    name: bb0ec23a-f97c-4b6a-a5bc-864b1ebc9236.sled          (records: 1)
+        AAAA fd00:1122:3344:101::1
+    name: bba6ea73-6c9c-4ab5-8bb4-1dd145071407.sled          (records: 1)
+        AAAA fd00:1122:3344:102::1
+    name: c138c88c-a83d-4e2d-a8f8-e8e715d8e5f7.host          (records: 1)
+        AAAA fd00:1122:3344:101::23
+    name: c4c56b5a-8c18-4eac-964a-62f94cac07b1.host          (records: 1)
+        AAAA fd00:1122:3344:101::25
+    name: cc00b21a-5685-480a-ab5e-d2e29cf369df.sled          (records: 1)
+        AAAA fd00:1122:3344:103::1
+    name: f14b0fff-c0f0-420f-ab51-df1a605f43c3.host          (records: 1)
+        AAAA fd00:1122:3344:3::1
+    name: f282c429-5f5e-4430-8f71-600cf61ded56.host          (records: 1)
+        AAAA fd00:1122:3344:103::21
+
+external DNS:
+  DNS zone: "oxide.example" (unchanged)
+    name: example-silo.sys                                   (records: 3)
+        A    192.0.2.2
+        A    192.0.2.3
+        A    192.0.2.4
+
+
+
+> 
+
+> # Configure an MGS-managed update to a different SP.
+
+> # This should *not* replace the existing one.
+
+> # This also exercises the special "invalid" string for a version number.
+
+> blueprint-edit 5bf974f3-81f9-455b-b24e-3099f765664c sp-update-set serial0 e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855 three sp two invalid
+blueprint 1b837a27-3be1-4fcb-8499-a921c839e1d0 created from blueprint 5bf974f3-81f9-455b-b24e-3099f765664c: configured update for serial serial0
+warn: no validation is done on the requested artifact hash or version
+
+> blueprint-show 1b837a27-3be1-4fcb-8499-a921c839e1d0
+blueprint  1b837a27-3be1-4fcb-8499-a921c839e1d0
+parent:    5bf974f3-81f9-455b-b24e-3099f765664c
+
+  sled: bb0ec23a-f97c-4b6a-a5bc-864b1ebc9236 (active, config generation 2)
+
+    physical disks:
+    ------------------------------------------------------------------------------------
+    vendor        model        serial                                        disposition
+    ------------------------------------------------------------------------------------
+    fake-vendor   fake-model   serial-a156a6d9-e839-4cb2-9d09-faf012dae700   in service 
+    fake-vendor   fake-model   serial-b48b5b36-fbb1-4c71-8b08-34a58b3ed2bd   in service 
+    fake-vendor   fake-model   serial-b62945fd-6ac2-4ec2-9e13-0a9a10620924   in service 
+
+
+    datasets:
+    -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
+    dataset name                                                                                                   dataset id                             disposition   quota     reservation   compression
+    -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
+    oxp_a156a6d9-e839-4cb2-9d09-faf012dae700/crucible                                                              bbf79ca9-a619-4142-9802-d306a4b58acb   in service    none      none          off        
+    oxp_b48b5b36-fbb1-4c71-8b08-34a58b3ed2bd/crucible                                                              ff6da666-707c-4370-b0d9-0572d8851e9d   in service    none      none          off        
+    oxp_b62945fd-6ac2-4ec2-9e13-0a9a10620924/crucible                                                              1f46779a-37b2-48d7-8ea9-a4e988bb0045   in service    none      none          off        
+    oxp_a156a6d9-e839-4cb2-9d09-faf012dae700/crypt/clickhouse                                                      43b6b5c0-61d8-4b88-bbb8-abede5589619   in service    none      none          off        
+    oxp_a156a6d9-e839-4cb2-9d09-faf012dae700/crypt/external_dns                                                    f5fc02e2-46ff-4012-a5c0-c91ad7881642   in service    none      none          off        
+    oxp_a156a6d9-e839-4cb2-9d09-faf012dae700/crypt/internal_dns                                                    2c16250f-d4aa-4fb5-bf4b-a6b5d72ac441   in service    none      none          off        
+    oxp_a156a6d9-e839-4cb2-9d09-faf012dae700/crypt/zone                                                            9077f1bd-3864-43d5-9c02-9370cbb9156d   in service    none      none          off        
+    oxp_b48b5b36-fbb1-4c71-8b08-34a58b3ed2bd/crypt/zone                                                            f4febe2f-789b-4c28-8bb7-aa594e0e4a4f   in service    none      none          off        
+    oxp_b62945fd-6ac2-4ec2-9e13-0a9a10620924/crypt/zone                                                            de0fe910-037f-49da-b86b-5865818c568d   in service    none      none          off        
+    oxp_a156a6d9-e839-4cb2-9d09-faf012dae700/crypt/zone/oxz_clickhouse_c138c88c-a83d-4e2d-a8f8-e8e715d8e5f7        7de7e173-0287-4e01-ad60-73681156e0e4   in service    none      none          off        
+    oxp_a156a6d9-e839-4cb2-9d09-faf012dae700/crypt/zone/oxz_crucible_575bd77e-6cd9-4bb6-9c1f-2ac6f149278a          252039e9-e48e-4790-930d-a8fad52256d7   in service    none      none          off        
+    oxp_b62945fd-6ac2-4ec2-9e13-0a9a10620924/crypt/zone/oxz_crucible_719199e7-eacf-4add-b532-ddfaf867b478          7ca01115-8692-438a-aa91-84b7c11f5ef2   in service    none      none          off        
+    oxp_b48b5b36-fbb1-4c71-8b08-34a58b3ed2bd/crypt/zone/oxz_crucible_9b8c5aff-3892-4645-8c66-c540456f05af          61a88822-ec1a-4c94-8134-f5d33e342428   in service    none      none          off        
+    oxp_a156a6d9-e839-4cb2-9d09-faf012dae700/crypt/zone/oxz_crucible_pantry_c4c56b5a-8c18-4eac-964a-62f94cac07b1   45b1fd69-7ace-41f8-97bc-3f6e99314e8a   in service    none      none          off        
+    oxp_a156a6d9-e839-4cb2-9d09-faf012dae700/crypt/zone/oxz_external_dns_86c0837a-73ca-4d08-971d-8491401c2fe2      6159b0b8-1c4b-4dd4-a32e-5c5a93df859b   in service    none      none          off        
+    oxp_a156a6d9-e839-4cb2-9d09-faf012dae700/crypt/zone/oxz_internal_dns_ae5b529a-2ada-490c-bea9-04c71cf8e72c      9f74b627-d96c-4183-92f4-7cfaca681fb5   in service    none      none          off        
+    oxp_a156a6d9-e839-4cb2-9d09-faf012dae700/crypt/zone/oxz_nexus_6df9649e-48f8-4754-94f3-55e8f9b039be             6985e6b4-a53b-4a88-bda6-41d2da73af48   in service    none      none          off        
+    oxp_a156a6d9-e839-4cb2-9d09-faf012dae700/crypt/zone/oxz_ntp_4ad9c209-bd1b-44c9-863d-1a6b84b34d53               233b6c7d-284f-42e6-b9e5-607e9377387d   in service    none      none          off        
+    oxp_a156a6d9-e839-4cb2-9d09-faf012dae700/crypt/debug                                                           a510cf34-74db-44fc-903f-36704f21ae67   in service    100 GiB   none          gzip-9     
+    oxp_b48b5b36-fbb1-4c71-8b08-34a58b3ed2bd/crypt/debug                                                           b9f7efe9-5088-45a3-96d9-6cc69be0ec72   in service    100 GiB   none          gzip-9     
+    oxp_b62945fd-6ac2-4ec2-9e13-0a9a10620924/crypt/debug                                                           ae71243d-118a-4e43-b4e3-9e425c6b8395   in service    100 GiB   none          gzip-9     
+
+
+    omicron zones:
+    ---------------------------------------------------------------------------------------------------------------
+    zone type         zone id                                image source      disposition   underlay IP           
+    ---------------------------------------------------------------------------------------------------------------
+    clickhouse        c138c88c-a83d-4e2d-a8f8-e8e715d8e5f7   install dataset   in service    fd00:1122:3344:101::23
+    crucible          575bd77e-6cd9-4bb6-9c1f-2ac6f149278a   install dataset   in service    fd00:1122:3344:101::26
+    crucible          719199e7-eacf-4add-b532-ddfaf867b478   install dataset   in service    fd00:1122:3344:101::28
+    crucible          9b8c5aff-3892-4645-8c66-c540456f05af   install dataset   in service    fd00:1122:3344:101::27
+    crucible_pantry   c4c56b5a-8c18-4eac-964a-62f94cac07b1   install dataset   in service    fd00:1122:3344:101::25
+    external_dns      86c0837a-73ca-4d08-971d-8491401c2fe2   install dataset   in service    fd00:1122:3344:101::24
+    internal_dns      ae5b529a-2ada-490c-bea9-04c71cf8e72c   install dataset   in service    fd00:1122:3344:1::1   
+    internal_ntp      4ad9c209-bd1b-44c9-863d-1a6b84b34d53   install dataset   in service    fd00:1122:3344:101::21
+    nexus             6df9649e-48f8-4754-94f3-55e8f9b039be   install dataset   in service    fd00:1122:3344:101::22
+
+
+
+  sled: bba6ea73-6c9c-4ab5-8bb4-1dd145071407 (active, config generation 2)
+
+    physical disks:
+    ------------------------------------------------------------------------------------
+    vendor        model        serial                                        disposition
+    ------------------------------------------------------------------------------------
+    fake-vendor   fake-model   serial-2201d82d-3a3c-4744-ac41-657536a90afe   in service 
+    fake-vendor   fake-model   serial-bdf3642c-a783-4689-a8a6-8cfa257089bd   in service 
+    fake-vendor   fake-model   serial-eeb9b9ce-ac1c-4a41-9a7a-814e26e2a9ee   in service 
+
+
+    datasets:
+    -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
+    dataset name                                                                                                   dataset id                             disposition   quota     reservation   compression
+    -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
+    oxp_2201d82d-3a3c-4744-ac41-657536a90afe/crucible                                                              66beebb3-2b7a-4334-9ea7-e7c714b6dacc   in service    none      none          off        
+    oxp_bdf3642c-a783-4689-a8a6-8cfa257089bd/crucible                                                              4611f0cd-1ef4-42f2-b1bd-8ce5c0ee1ba4   in service    none      none          off        
+    oxp_eeb9b9ce-ac1c-4a41-9a7a-814e26e2a9ee/crucible                                                              4420b086-b23f-4ba6-b504-459a38e3b367   in service    none      none          off        
+    oxp_2201d82d-3a3c-4744-ac41-657536a90afe/crypt/external_dns                                                    ffe1a3c8-7546-495f-b437-f2405be4e533   in service    none      none          off        
+    oxp_2201d82d-3a3c-4744-ac41-657536a90afe/crypt/internal_dns                                                    c5300adb-042e-41fd-9b1f-5c01d68e7eb4   in service    none      none          off        
+    oxp_2201d82d-3a3c-4744-ac41-657536a90afe/crypt/zone                                                            06dfa1c2-42c3-4626-8bf3-4460dfec3646   in service    none      none          off        
+    oxp_bdf3642c-a783-4689-a8a6-8cfa257089bd/crypt/zone                                                            89ae62b7-0cff-4e09-b4e9-4c43bf242e1d   in service    none      none          off        
+    oxp_eeb9b9ce-ac1c-4a41-9a7a-814e26e2a9ee/crypt/zone                                                            78269a0c-ce98-4834-ae9e-d25eee99a079   in service    none      none          off        
+    oxp_eeb9b9ce-ac1c-4a41-9a7a-814e26e2a9ee/crypt/zone/oxz_crucible_70b7e8a1-cc3f-4cdd-a577-4c8be9885f8b          1382d296-a276-40ca-85b3-9f2578cb95cf   in service    none      none          off        
+    oxp_bdf3642c-a783-4689-a8a6-8cfa257089bd/crypt/zone/oxz_crucible_7bb9667d-da70-4592-a579-31295f919aed          57d3c6cb-64ff-4485-87c0-3ff5fe9c45d8   in service    none      none          off        
+    oxp_2201d82d-3a3c-4744-ac41-657536a90afe/crypt/zone/oxz_crucible_a5a25771-1025-4c08-9362-c5ee4cecafc9          a0e1cc1c-d542-4a21-96bb-efdfe40af009   in service    none      none          off        
+    oxp_2201d82d-3a3c-4744-ac41-657536a90afe/crypt/zone/oxz_crucible_pantry_5c67f8ed-9f38-4be1-b64c-a2d9898d3263   4f3e7986-e836-4ecc-ac69-8c013905707c   in service    none      none          off        
+    oxp_2201d82d-3a3c-4744-ac41-657536a90afe/crypt/zone/oxz_external_dns_b067565e-df5a-441f-85b9-69acc38bbf35      bc7affdc-54b9-4172-8264-af82b92fdfe0   in service    none      none          off        
+    oxp_2201d82d-3a3c-4744-ac41-657536a90afe/crypt/zone/oxz_internal_dns_159e1f8f-6f32-413d-a48b-e40fb2efaf15      79d73706-f701-4857-a378-fcf026cd6756   in service    none      none          off        
+    oxp_2201d82d-3a3c-4744-ac41-657536a90afe/crypt/zone/oxz_nexus_543b3bb6-358d-4876-9774-53a53187aaa8             71b813ec-4a24-43d1-b0b8-5c3303a1d9b5   in service    none      none          off        
+    oxp_2201d82d-3a3c-4744-ac41-657536a90afe/crypt/zone/oxz_ntp_345fbd68-cb55-4faa-b6ea-801789018bc6               d4126675-e113-4a2d-826a-cf7b224b794b   in service    none      none          off        
+    oxp_2201d82d-3a3c-4744-ac41-657536a90afe/crypt/debug                                                           afe7ef8e-c974-403e-932e-eb3c8057b22d   in service    100 GiB   none          gzip-9     
+    oxp_bdf3642c-a783-4689-a8a6-8cfa257089bd/crypt/debug                                                           f5f65250-3145-41bf-b462-359728bda24a   in service    100 GiB   none          gzip-9     
+    oxp_eeb9b9ce-ac1c-4a41-9a7a-814e26e2a9ee/crypt/debug                                                           7328892a-0525-401f-9160-a8e4501049fd   in service    100 GiB   none          gzip-9     
+
+
+    omicron zones:
+    ---------------------------------------------------------------------------------------------------------------
+    zone type         zone id                                image source      disposition   underlay IP           
+    ---------------------------------------------------------------------------------------------------------------
+    crucible          70b7e8a1-cc3f-4cdd-a577-4c8be9885f8b   install dataset   in service    fd00:1122:3344:102::27
+    crucible          7bb9667d-da70-4592-a579-31295f919aed   install dataset   in service    fd00:1122:3344:102::26
+    crucible          a5a25771-1025-4c08-9362-c5ee4cecafc9   install dataset   in service    fd00:1122:3344:102::25
+    crucible_pantry   5c67f8ed-9f38-4be1-b64c-a2d9898d3263   install dataset   in service    fd00:1122:3344:102::24
+    external_dns      b067565e-df5a-441f-85b9-69acc38bbf35   install dataset   in service    fd00:1122:3344:102::23
+    internal_dns      159e1f8f-6f32-413d-a48b-e40fb2efaf15   install dataset   in service    fd00:1122:3344:2::1   
+    internal_ntp      345fbd68-cb55-4faa-b6ea-801789018bc6   install dataset   in service    fd00:1122:3344:102::21
+    nexus             543b3bb6-358d-4876-9774-53a53187aaa8   install dataset   in service    fd00:1122:3344:102::22
+
+
+
+  sled: cc00b21a-5685-480a-ab5e-d2e29cf369df (active, config generation 2)
+
+    physical disks:
+    ------------------------------------------------------------------------------------
+    vendor        model        serial                                        disposition
+    ------------------------------------------------------------------------------------
+    fake-vendor   fake-model   serial-78b8bc9a-8f5b-4fc2-9d70-4470b2d05aae   in service 
+    fake-vendor   fake-model   serial-9e809fde-e684-4ee8-8d46-dade081c3c37   in service 
+    fake-vendor   fake-model   serial-f2b5fdba-606d-45a4-9a9b-35bf20892bd6   in service 
+
+
+    datasets:
+    -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
+    dataset name                                                                                                   dataset id                             disposition   quota     reservation   compression
+    -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
+    oxp_78b8bc9a-8f5b-4fc2-9d70-4470b2d05aae/crucible                                                              a84f76f4-1f8c-4772-a072-ffb0dc7c281c   in service    none      none          off        
+    oxp_9e809fde-e684-4ee8-8d46-dade081c3c37/crucible                                                              db8f2cdf-721f-4c56-880e-d9265ec404f5   in service    none      none          off        
+    oxp_f2b5fdba-606d-45a4-9a9b-35bf20892bd6/crucible                                                              faa61220-8f21-4231-b069-3fb417699363   in service    none      none          off        
+    oxp_78b8bc9a-8f5b-4fc2-9d70-4470b2d05aae/crypt/external_dns                                                    b47f981e-ac2d-4ec1-8e67-c15dcf13af86   in service    none      none          off        
+    oxp_78b8bc9a-8f5b-4fc2-9d70-4470b2d05aae/crypt/internal_dns                                                    037ef4f6-dae1-478e-8397-3b68bf8e47dc   in service    none      none          off        
+    oxp_78b8bc9a-8f5b-4fc2-9d70-4470b2d05aae/crypt/zone                                                            fa042a64-d60c-4aa6-bc1a-ae9d0347bde8   in service    none      none          off        
+    oxp_9e809fde-e684-4ee8-8d46-dade081c3c37/crypt/zone                                                            5366ad89-e6ec-47e5-8870-fafc8224f11f   in service    none      none          off        
+    oxp_f2b5fdba-606d-45a4-9a9b-35bf20892bd6/crypt/zone                                                            fb5e2978-9182-46bd-919d-653b86b1fed3   in service    none      none          off        
+    oxp_f2b5fdba-606d-45a4-9a9b-35bf20892bd6/crypt/zone/oxz_crucible_327db2a9-fc45-4c3f-a6db-4ee58459e5cf          ac6a48f2-c9e0-4bf2-9c93-c234efc48a59   in service    none      none          off        
+    oxp_78b8bc9a-8f5b-4fc2-9d70-4470b2d05aae/crypt/zone/oxz_crucible_5ea7f627-d51e-4e2d-8648-112ddc635e53          d449dcc4-1725-4de2-92c0-e1a37d12299a   in service    none      none          off        
+    oxp_9e809fde-e684-4ee8-8d46-dade081c3c37/crypt/zone/oxz_crucible_ad81aafc-e74d-4b0a-b4e6-2e58ef52b7a2          2c018c08-7cc7-45a9-be60-cd6b82874cfc   in service    none      none          off        
+    oxp_78b8bc9a-8f5b-4fc2-9d70-4470b2d05aae/crypt/zone/oxz_crucible_pantry_a76d9883-b4fe-464f-acbb-e75b2bbb508d   ad79a937-7410-4e92-89e1-0af1a0595cef   in service    none      none          off        
+    oxp_78b8bc9a-8f5b-4fc2-9d70-4470b2d05aae/crypt/zone/oxz_external_dns_8a651785-3936-4cf6-b301-4fa7fa003c9f      e80f5919-dd7c-4d6c-b0de-45d24c0fe421   in service    none      none          off        
+    oxp_78b8bc9a-8f5b-4fc2-9d70-4470b2d05aae/crypt/zone/oxz_internal_dns_f14b0fff-c0f0-420f-ab51-df1a605f43c3      fd542516-55e6-42c6-a8de-0128b3cce65e   in service    none      none          off        
+    oxp_78b8bc9a-8f5b-4fc2-9d70-4470b2d05aae/crypt/zone/oxz_nexus_1dee8f37-8286-48dc-b4b4-e59979c030ec             7c89c13d-8f41-4c69-96d2-6f9ffbc27cbb   in service    none      none          off        
+    oxp_78b8bc9a-8f5b-4fc2-9d70-4470b2d05aae/crypt/zone/oxz_ntp_f282c429-5f5e-4430-8f71-600cf61ded56               7ea314c5-c702-4f47-b70c-02e5131682be   in service    none      none          off        
+    oxp_78b8bc9a-8f5b-4fc2-9d70-4470b2d05aae/crypt/debug                                                           b43d1c1e-5482-40de-869e-8cd2741c6fc0   in service    100 GiB   none          gzip-9     
+    oxp_9e809fde-e684-4ee8-8d46-dade081c3c37/crypt/debug                                                           19e5fb1e-c1f8-4262-9232-0f31eb746cdb   in service    100 GiB   none          gzip-9     
+    oxp_f2b5fdba-606d-45a4-9a9b-35bf20892bd6/crypt/debug                                                           ef852bdc-50a0-458e-a3f4-fd77a633d3cb   in service    100 GiB   none          gzip-9     
+
+
+    omicron zones:
+    ---------------------------------------------------------------------------------------------------------------
+    zone type         zone id                                image source      disposition   underlay IP           
+    ---------------------------------------------------------------------------------------------------------------
+    crucible          327db2a9-fc45-4c3f-a6db-4ee58459e5cf   install dataset   in service    fd00:1122:3344:103::27
+    crucible          5ea7f627-d51e-4e2d-8648-112ddc635e53   install dataset   in service    fd00:1122:3344:103::25
+    crucible          ad81aafc-e74d-4b0a-b4e6-2e58ef52b7a2   install dataset   in service    fd00:1122:3344:103::26
+    crucible_pantry   a76d9883-b4fe-464f-acbb-e75b2bbb508d   install dataset   in service    fd00:1122:3344:103::24
+    external_dns      8a651785-3936-4cf6-b301-4fa7fa003c9f   install dataset   in service    fd00:1122:3344:103::23
+    internal_dns      f14b0fff-c0f0-420f-ab51-df1a605f43c3   install dataset   in service    fd00:1122:3344:3::1   
+    internal_ntp      f282c429-5f5e-4430-8f71-600cf61ded56   install dataset   in service    fd00:1122:3344:103::21
+    nexus             1dee8f37-8286-48dc-b4b4-e59979c030ec   install dataset   in service    fd00:1122:3344:103::22
+
+
+ COCKROACHDB SETTINGS:
+    state fingerprint:::::::::::::::::   (none)
+    cluster.preserve_downgrade_option:   (do not modify)
+
+ OXIMETER SETTINGS:
+    generation:   1
+    read from::   SingleNode
+
+ METADATA:
+    created by:::::::::::   reconfigurator-cli
+    created at:::::::::::   <REDACTED_TIMESTAMP>
+    comment::::::::::::::   (none)
+    internal DNS version:   1
+    external DNS version:   1
+
+ PENDING MGS-MANAGED UPDATES: 2
+    Pending MGS-managed updates:
+    ---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
+    sp_type   slot   part_number   serial_number   artifact_kind   artifact_hash                                                      artifact_version   details                                                                                                               
+    ---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
+    sled      0      model0        serial0         gimlet_sp       e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855   three              Sp { expected_active_version: ArtifactVersion("two"), expected_inactive_version: NoValidVersion }                     
+    sled      2      model2        serial2         gimlet_sp       e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855   newest             Sp { expected_active_version: ArtifactVersion("newer"), expected_inactive_version: Version(ArtifactVersion("older")) }
+
+
+
+> blueprint-diff 5bf974f3-81f9-455b-b24e-3099f765664c 1b837a27-3be1-4fcb-8499-a921c839e1d0
+from: blueprint 5bf974f3-81f9-455b-b24e-3099f765664c
+to:   blueprint 1b837a27-3be1-4fcb-8499-a921c839e1d0
+
+ UNCHANGED SLEDS:
+
+  sled bb0ec23a-f97c-4b6a-a5bc-864b1ebc9236 (active, config generation 2):
+
+    physical disks:
+    ------------------------------------------------------------------------------------
+    vendor        model        serial                                        disposition
+    ------------------------------------------------------------------------------------
+    fake-vendor   fake-model   serial-a156a6d9-e839-4cb2-9d09-faf012dae700   in service 
+    fake-vendor   fake-model   serial-b48b5b36-fbb1-4c71-8b08-34a58b3ed2bd   in service 
+    fake-vendor   fake-model   serial-b62945fd-6ac2-4ec2-9e13-0a9a10620924   in service 
+
+
+    datasets:
+    -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
+    dataset name                                                                                                   dataset id                             disposition   quota     reservation   compression
+    -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
+    oxp_a156a6d9-e839-4cb2-9d09-faf012dae700/crucible                                                              bbf79ca9-a619-4142-9802-d306a4b58acb   in service    none      none          off        
+    oxp_b48b5b36-fbb1-4c71-8b08-34a58b3ed2bd/crucible                                                              ff6da666-707c-4370-b0d9-0572d8851e9d   in service    none      none          off        
+    oxp_b62945fd-6ac2-4ec2-9e13-0a9a10620924/crucible                                                              1f46779a-37b2-48d7-8ea9-a4e988bb0045   in service    none      none          off        
+    oxp_a156a6d9-e839-4cb2-9d09-faf012dae700/crypt/clickhouse                                                      43b6b5c0-61d8-4b88-bbb8-abede5589619   in service    none      none          off        
+    oxp_a156a6d9-e839-4cb2-9d09-faf012dae700/crypt/external_dns                                                    f5fc02e2-46ff-4012-a5c0-c91ad7881642   in service    none      none          off        
+    oxp_a156a6d9-e839-4cb2-9d09-faf012dae700/crypt/internal_dns                                                    2c16250f-d4aa-4fb5-bf4b-a6b5d72ac441   in service    none      none          off        
+    oxp_a156a6d9-e839-4cb2-9d09-faf012dae700/crypt/zone                                                            9077f1bd-3864-43d5-9c02-9370cbb9156d   in service    none      none          off        
+    oxp_b48b5b36-fbb1-4c71-8b08-34a58b3ed2bd/crypt/zone                                                            f4febe2f-789b-4c28-8bb7-aa594e0e4a4f   in service    none      none          off        
+    oxp_b62945fd-6ac2-4ec2-9e13-0a9a10620924/crypt/zone                                                            de0fe910-037f-49da-b86b-5865818c568d   in service    none      none          off        
+    oxp_a156a6d9-e839-4cb2-9d09-faf012dae700/crypt/zone/oxz_clickhouse_c138c88c-a83d-4e2d-a8f8-e8e715d8e5f7        7de7e173-0287-4e01-ad60-73681156e0e4   in service    none      none          off        
+    oxp_a156a6d9-e839-4cb2-9d09-faf012dae700/crypt/zone/oxz_crucible_575bd77e-6cd9-4bb6-9c1f-2ac6f149278a          252039e9-e48e-4790-930d-a8fad52256d7   in service    none      none          off        
+    oxp_b62945fd-6ac2-4ec2-9e13-0a9a10620924/crypt/zone/oxz_crucible_719199e7-eacf-4add-b532-ddfaf867b478          7ca01115-8692-438a-aa91-84b7c11f5ef2   in service    none      none          off        
+    oxp_b48b5b36-fbb1-4c71-8b08-34a58b3ed2bd/crypt/zone/oxz_crucible_9b8c5aff-3892-4645-8c66-c540456f05af          61a88822-ec1a-4c94-8134-f5d33e342428   in service    none      none          off        
+    oxp_a156a6d9-e839-4cb2-9d09-faf012dae700/crypt/zone/oxz_crucible_pantry_c4c56b5a-8c18-4eac-964a-62f94cac07b1   45b1fd69-7ace-41f8-97bc-3f6e99314e8a   in service    none      none          off        
+    oxp_a156a6d9-e839-4cb2-9d09-faf012dae700/crypt/zone/oxz_external_dns_86c0837a-73ca-4d08-971d-8491401c2fe2      6159b0b8-1c4b-4dd4-a32e-5c5a93df859b   in service    none      none          off        
+    oxp_a156a6d9-e839-4cb2-9d09-faf012dae700/crypt/zone/oxz_internal_dns_ae5b529a-2ada-490c-bea9-04c71cf8e72c      9f74b627-d96c-4183-92f4-7cfaca681fb5   in service    none      none          off        
+    oxp_a156a6d9-e839-4cb2-9d09-faf012dae700/crypt/zone/oxz_nexus_6df9649e-48f8-4754-94f3-55e8f9b039be             6985e6b4-a53b-4a88-bda6-41d2da73af48   in service    none      none          off        
+    oxp_a156a6d9-e839-4cb2-9d09-faf012dae700/crypt/zone/oxz_ntp_4ad9c209-bd1b-44c9-863d-1a6b84b34d53               233b6c7d-284f-42e6-b9e5-607e9377387d   in service    none      none          off        
+    oxp_a156a6d9-e839-4cb2-9d09-faf012dae700/crypt/debug                                                           a510cf34-74db-44fc-903f-36704f21ae67   in service    100 GiB   none          gzip-9     
+    oxp_b48b5b36-fbb1-4c71-8b08-34a58b3ed2bd/crypt/debug                                                           b9f7efe9-5088-45a3-96d9-6cc69be0ec72   in service    100 GiB   none          gzip-9     
+    oxp_b62945fd-6ac2-4ec2-9e13-0a9a10620924/crypt/debug                                                           ae71243d-118a-4e43-b4e3-9e425c6b8395   in service    100 GiB   none          gzip-9     
+
+
+    omicron zones:
+    ---------------------------------------------------------------------------------------------------------------
+    zone type         zone id                                image source      disposition   underlay IP           
+    ---------------------------------------------------------------------------------------------------------------
+    clickhouse        c138c88c-a83d-4e2d-a8f8-e8e715d8e5f7   install dataset   in service    fd00:1122:3344:101::23
+    crucible          575bd77e-6cd9-4bb6-9c1f-2ac6f149278a   install dataset   in service    fd00:1122:3344:101::26
+    crucible          719199e7-eacf-4add-b532-ddfaf867b478   install dataset   in service    fd00:1122:3344:101::28
+    crucible          9b8c5aff-3892-4645-8c66-c540456f05af   install dataset   in service    fd00:1122:3344:101::27
+    crucible_pantry   c4c56b5a-8c18-4eac-964a-62f94cac07b1   install dataset   in service    fd00:1122:3344:101::25
+    external_dns      86c0837a-73ca-4d08-971d-8491401c2fe2   install dataset   in service    fd00:1122:3344:101::24
+    internal_dns      ae5b529a-2ada-490c-bea9-04c71cf8e72c   install dataset   in service    fd00:1122:3344:1::1   
+    internal_ntp      4ad9c209-bd1b-44c9-863d-1a6b84b34d53   install dataset   in service    fd00:1122:3344:101::21
+    nexus             6df9649e-48f8-4754-94f3-55e8f9b039be   install dataset   in service    fd00:1122:3344:101::22
+
+
+  sled bba6ea73-6c9c-4ab5-8bb4-1dd145071407 (active, config generation 2):
+
+    physical disks:
+    ------------------------------------------------------------------------------------
+    vendor        model        serial                                        disposition
+    ------------------------------------------------------------------------------------
+    fake-vendor   fake-model   serial-2201d82d-3a3c-4744-ac41-657536a90afe   in service 
+    fake-vendor   fake-model   serial-bdf3642c-a783-4689-a8a6-8cfa257089bd   in service 
+    fake-vendor   fake-model   serial-eeb9b9ce-ac1c-4a41-9a7a-814e26e2a9ee   in service 
+
+
+    datasets:
+    -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
+    dataset name                                                                                                   dataset id                             disposition   quota     reservation   compression
+    -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
+    oxp_2201d82d-3a3c-4744-ac41-657536a90afe/crucible                                                              66beebb3-2b7a-4334-9ea7-e7c714b6dacc   in service    none      none          off        
+    oxp_bdf3642c-a783-4689-a8a6-8cfa257089bd/crucible                                                              4611f0cd-1ef4-42f2-b1bd-8ce5c0ee1ba4   in service    none      none          off        
+    oxp_eeb9b9ce-ac1c-4a41-9a7a-814e26e2a9ee/crucible                                                              4420b086-b23f-4ba6-b504-459a38e3b367   in service    none      none          off        
+    oxp_2201d82d-3a3c-4744-ac41-657536a90afe/crypt/external_dns                                                    ffe1a3c8-7546-495f-b437-f2405be4e533   in service    none      none          off        
+    oxp_2201d82d-3a3c-4744-ac41-657536a90afe/crypt/internal_dns                                                    c5300adb-042e-41fd-9b1f-5c01d68e7eb4   in service    none      none          off        
+    oxp_2201d82d-3a3c-4744-ac41-657536a90afe/crypt/zone                                                            06dfa1c2-42c3-4626-8bf3-4460dfec3646   in service    none      none          off        
+    oxp_bdf3642c-a783-4689-a8a6-8cfa257089bd/crypt/zone                                                            89ae62b7-0cff-4e09-b4e9-4c43bf242e1d   in service    none      none          off        
+    oxp_eeb9b9ce-ac1c-4a41-9a7a-814e26e2a9ee/crypt/zone                                                            78269a0c-ce98-4834-ae9e-d25eee99a079   in service    none      none          off        
+    oxp_eeb9b9ce-ac1c-4a41-9a7a-814e26e2a9ee/crypt/zone/oxz_crucible_70b7e8a1-cc3f-4cdd-a577-4c8be9885f8b          1382d296-a276-40ca-85b3-9f2578cb95cf   in service    none      none          off        
+    oxp_bdf3642c-a783-4689-a8a6-8cfa257089bd/crypt/zone/oxz_crucible_7bb9667d-da70-4592-a579-31295f919aed          57d3c6cb-64ff-4485-87c0-3ff5fe9c45d8   in service    none      none          off        
+    oxp_2201d82d-3a3c-4744-ac41-657536a90afe/crypt/zone/oxz_crucible_a5a25771-1025-4c08-9362-c5ee4cecafc9          a0e1cc1c-d542-4a21-96bb-efdfe40af009   in service    none      none          off        
+    oxp_2201d82d-3a3c-4744-ac41-657536a90afe/crypt/zone/oxz_crucible_pantry_5c67f8ed-9f38-4be1-b64c-a2d9898d3263   4f3e7986-e836-4ecc-ac69-8c013905707c   in service    none      none          off        
+    oxp_2201d82d-3a3c-4744-ac41-657536a90afe/crypt/zone/oxz_external_dns_b067565e-df5a-441f-85b9-69acc38bbf35      bc7affdc-54b9-4172-8264-af82b92fdfe0   in service    none      none          off        
+    oxp_2201d82d-3a3c-4744-ac41-657536a90afe/crypt/zone/oxz_internal_dns_159e1f8f-6f32-413d-a48b-e40fb2efaf15      79d73706-f701-4857-a378-fcf026cd6756   in service    none      none          off        
+    oxp_2201d82d-3a3c-4744-ac41-657536a90afe/crypt/zone/oxz_nexus_543b3bb6-358d-4876-9774-53a53187aaa8             71b813ec-4a24-43d1-b0b8-5c3303a1d9b5   in service    none      none          off        
+    oxp_2201d82d-3a3c-4744-ac41-657536a90afe/crypt/zone/oxz_ntp_345fbd68-cb55-4faa-b6ea-801789018bc6               d4126675-e113-4a2d-826a-cf7b224b794b   in service    none      none          off        
+    oxp_2201d82d-3a3c-4744-ac41-657536a90afe/crypt/debug                                                           afe7ef8e-c974-403e-932e-eb3c8057b22d   in service    100 GiB   none          gzip-9     
+    oxp_bdf3642c-a783-4689-a8a6-8cfa257089bd/crypt/debug                                                           f5f65250-3145-41bf-b462-359728bda24a   in service    100 GiB   none          gzip-9     
+    oxp_eeb9b9ce-ac1c-4a41-9a7a-814e26e2a9ee/crypt/debug                                                           7328892a-0525-401f-9160-a8e4501049fd   in service    100 GiB   none          gzip-9     
+
+
+    omicron zones:
+    ---------------------------------------------------------------------------------------------------------------
+    zone type         zone id                                image source      disposition   underlay IP           
+    ---------------------------------------------------------------------------------------------------------------
+    crucible          70b7e8a1-cc3f-4cdd-a577-4c8be9885f8b   install dataset   in service    fd00:1122:3344:102::27
+    crucible          7bb9667d-da70-4592-a579-31295f919aed   install dataset   in service    fd00:1122:3344:102::26
+    crucible          a5a25771-1025-4c08-9362-c5ee4cecafc9   install dataset   in service    fd00:1122:3344:102::25
+    crucible_pantry   5c67f8ed-9f38-4be1-b64c-a2d9898d3263   install dataset   in service    fd00:1122:3344:102::24
+    external_dns      b067565e-df5a-441f-85b9-69acc38bbf35   install dataset   in service    fd00:1122:3344:102::23
+    internal_dns      159e1f8f-6f32-413d-a48b-e40fb2efaf15   install dataset   in service    fd00:1122:3344:2::1   
+    internal_ntp      345fbd68-cb55-4faa-b6ea-801789018bc6   install dataset   in service    fd00:1122:3344:102::21
+    nexus             543b3bb6-358d-4876-9774-53a53187aaa8   install dataset   in service    fd00:1122:3344:102::22
+
+
+  sled cc00b21a-5685-480a-ab5e-d2e29cf369df (active, config generation 2):
+
+    physical disks:
+    ------------------------------------------------------------------------------------
+    vendor        model        serial                                        disposition
+    ------------------------------------------------------------------------------------
+    fake-vendor   fake-model   serial-78b8bc9a-8f5b-4fc2-9d70-4470b2d05aae   in service 
+    fake-vendor   fake-model   serial-9e809fde-e684-4ee8-8d46-dade081c3c37   in service 
+    fake-vendor   fake-model   serial-f2b5fdba-606d-45a4-9a9b-35bf20892bd6   in service 
+
+
+    datasets:
+    -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
+    dataset name                                                                                                   dataset id                             disposition   quota     reservation   compression
+    -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
+    oxp_78b8bc9a-8f5b-4fc2-9d70-4470b2d05aae/crucible                                                              a84f76f4-1f8c-4772-a072-ffb0dc7c281c   in service    none      none          off        
+    oxp_9e809fde-e684-4ee8-8d46-dade081c3c37/crucible                                                              db8f2cdf-721f-4c56-880e-d9265ec404f5   in service    none      none          off        
+    oxp_f2b5fdba-606d-45a4-9a9b-35bf20892bd6/crucible                                                              faa61220-8f21-4231-b069-3fb417699363   in service    none      none          off        
+    oxp_78b8bc9a-8f5b-4fc2-9d70-4470b2d05aae/crypt/external_dns                                                    b47f981e-ac2d-4ec1-8e67-c15dcf13af86   in service    none      none          off        
+    oxp_78b8bc9a-8f5b-4fc2-9d70-4470b2d05aae/crypt/internal_dns                                                    037ef4f6-dae1-478e-8397-3b68bf8e47dc   in service    none      none          off        
+    oxp_78b8bc9a-8f5b-4fc2-9d70-4470b2d05aae/crypt/zone                                                            fa042a64-d60c-4aa6-bc1a-ae9d0347bde8   in service    none      none          off        
+    oxp_9e809fde-e684-4ee8-8d46-dade081c3c37/crypt/zone                                                            5366ad89-e6ec-47e5-8870-fafc8224f11f   in service    none      none          off        
+    oxp_f2b5fdba-606d-45a4-9a9b-35bf20892bd6/crypt/zone                                                            fb5e2978-9182-46bd-919d-653b86b1fed3   in service    none      none          off        
+    oxp_f2b5fdba-606d-45a4-9a9b-35bf20892bd6/crypt/zone/oxz_crucible_327db2a9-fc45-4c3f-a6db-4ee58459e5cf          ac6a48f2-c9e0-4bf2-9c93-c234efc48a59   in service    none      none          off        
+    oxp_78b8bc9a-8f5b-4fc2-9d70-4470b2d05aae/crypt/zone/oxz_crucible_5ea7f627-d51e-4e2d-8648-112ddc635e53          d449dcc4-1725-4de2-92c0-e1a37d12299a   in service    none      none          off        
+    oxp_9e809fde-e684-4ee8-8d46-dade081c3c37/crypt/zone/oxz_crucible_ad81aafc-e74d-4b0a-b4e6-2e58ef52b7a2          2c018c08-7cc7-45a9-be60-cd6b82874cfc   in service    none      none          off        
+    oxp_78b8bc9a-8f5b-4fc2-9d70-4470b2d05aae/crypt/zone/oxz_crucible_pantry_a76d9883-b4fe-464f-acbb-e75b2bbb508d   ad79a937-7410-4e92-89e1-0af1a0595cef   in service    none      none          off        
+    oxp_78b8bc9a-8f5b-4fc2-9d70-4470b2d05aae/crypt/zone/oxz_external_dns_8a651785-3936-4cf6-b301-4fa7fa003c9f      e80f5919-dd7c-4d6c-b0de-45d24c0fe421   in service    none      none          off        
+    oxp_78b8bc9a-8f5b-4fc2-9d70-4470b2d05aae/crypt/zone/oxz_internal_dns_f14b0fff-c0f0-420f-ab51-df1a605f43c3      fd542516-55e6-42c6-a8de-0128b3cce65e   in service    none      none          off        
+    oxp_78b8bc9a-8f5b-4fc2-9d70-4470b2d05aae/crypt/zone/oxz_nexus_1dee8f37-8286-48dc-b4b4-e59979c030ec             7c89c13d-8f41-4c69-96d2-6f9ffbc27cbb   in service    none      none          off        
+    oxp_78b8bc9a-8f5b-4fc2-9d70-4470b2d05aae/crypt/zone/oxz_ntp_f282c429-5f5e-4430-8f71-600cf61ded56               7ea314c5-c702-4f47-b70c-02e5131682be   in service    none      none          off        
+    oxp_78b8bc9a-8f5b-4fc2-9d70-4470b2d05aae/crypt/debug                                                           b43d1c1e-5482-40de-869e-8cd2741c6fc0   in service    100 GiB   none          gzip-9     
+    oxp_9e809fde-e684-4ee8-8d46-dade081c3c37/crypt/debug                                                           19e5fb1e-c1f8-4262-9232-0f31eb746cdb   in service    100 GiB   none          gzip-9     
+    oxp_f2b5fdba-606d-45a4-9a9b-35bf20892bd6/crypt/debug                                                           ef852bdc-50a0-458e-a3f4-fd77a633d3cb   in service    100 GiB   none          gzip-9     
+
+
+    omicron zones:
+    ---------------------------------------------------------------------------------------------------------------
+    zone type         zone id                                image source      disposition   underlay IP           
+    ---------------------------------------------------------------------------------------------------------------
+    crucible          327db2a9-fc45-4c3f-a6db-4ee58459e5cf   install dataset   in service    fd00:1122:3344:103::27
+    crucible          5ea7f627-d51e-4e2d-8648-112ddc635e53   install dataset   in service    fd00:1122:3344:103::25
+    crucible          ad81aafc-e74d-4b0a-b4e6-2e58ef52b7a2   install dataset   in service    fd00:1122:3344:103::26
+    crucible_pantry   a76d9883-b4fe-464f-acbb-e75b2bbb508d   install dataset   in service    fd00:1122:3344:103::24
+    external_dns      8a651785-3936-4cf6-b301-4fa7fa003c9f   install dataset   in service    fd00:1122:3344:103::23
+    internal_dns      f14b0fff-c0f0-420f-ab51-df1a605f43c3   install dataset   in service    fd00:1122:3344:3::1   
+    internal_ntp      f282c429-5f5e-4430-8f71-600cf61ded56   install dataset   in service    fd00:1122:3344:103::21
+    nexus             1dee8f37-8286-48dc-b4b4-e59979c030ec   install dataset   in service    fd00:1122:3344:103::22
+
+
+ COCKROACHDB SETTINGS:
+    state fingerprint:::::::::::::::::   (none) (unchanged)
+    cluster.preserve_downgrade_option:   (do not modify) (unchanged)
+
+ METADATA:
+    internal DNS version:   1 (unchanged)
+    external DNS version:   1 (unchanged)
+
+ OXIMETER SETTINGS:
+    generation:   1 (unchanged)
+    read from::   SingleNode (unchanged)
+
+
+internal DNS:
+  DNS zone: "control-plane.oxide.internal" (unchanged)
+    name: 159e1f8f-6f32-413d-a48b-e40fb2efaf15.host          (records: 1)
+        AAAA fd00:1122:3344:2::1
+    name: 1dee8f37-8286-48dc-b4b4-e59979c030ec.host          (records: 1)
+        AAAA fd00:1122:3344:103::22
+    name: 327db2a9-fc45-4c3f-a6db-4ee58459e5cf.host          (records: 1)
+        AAAA fd00:1122:3344:103::27
+    name: 345fbd68-cb55-4faa-b6ea-801789018bc6.host          (records: 1)
+        AAAA fd00:1122:3344:102::21
+    name: 4ad9c209-bd1b-44c9-863d-1a6b84b34d53.host          (records: 1)
+        AAAA fd00:1122:3344:101::21
+    name: 543b3bb6-358d-4876-9774-53a53187aaa8.host          (records: 1)
+        AAAA fd00:1122:3344:102::22
+    name: 575bd77e-6cd9-4bb6-9c1f-2ac6f149278a.host          (records: 1)
+        AAAA fd00:1122:3344:101::26
+    name: 5c67f8ed-9f38-4be1-b64c-a2d9898d3263.host          (records: 1)
+        AAAA fd00:1122:3344:102::24
+    name: 5ea7f627-d51e-4e2d-8648-112ddc635e53.host          (records: 1)
+        AAAA fd00:1122:3344:103::25
+    name: 6df9649e-48f8-4754-94f3-55e8f9b039be.host          (records: 1)
+        AAAA fd00:1122:3344:101::22
+    name: 70b7e8a1-cc3f-4cdd-a577-4c8be9885f8b.host          (records: 1)
+        AAAA fd00:1122:3344:102::27
+    name: 719199e7-eacf-4add-b532-ddfaf867b478.host          (records: 1)
+        AAAA fd00:1122:3344:101::28
+    name: 7bb9667d-da70-4592-a579-31295f919aed.host          (records: 1)
+        AAAA fd00:1122:3344:102::26
+    name: 86c0837a-73ca-4d08-971d-8491401c2fe2.host          (records: 1)
+        AAAA fd00:1122:3344:101::24
+    name: 8a651785-3936-4cf6-b301-4fa7fa003c9f.host          (records: 1)
+        AAAA fd00:1122:3344:103::23
+    name: 9b8c5aff-3892-4645-8c66-c540456f05af.host          (records: 1)
+        AAAA fd00:1122:3344:101::27
+    name: _clickhouse-admin-single-server._tcp               (records: 1)
+        SRV  port  8888 c138c88c-a83d-4e2d-a8f8-e8e715d8e5f7.host.control-plane.oxide.internal
+    name: _clickhouse-native._tcp                            (records: 1)
+        SRV  port  9000 c138c88c-a83d-4e2d-a8f8-e8e715d8e5f7.host.control-plane.oxide.internal
+    name: _clickhouse._tcp                                   (records: 1)
+        SRV  port  8123 c138c88c-a83d-4e2d-a8f8-e8e715d8e5f7.host.control-plane.oxide.internal
+    name: _crucible-pantry._tcp                              (records: 3)
+        SRV  port 17000 5c67f8ed-9f38-4be1-b64c-a2d9898d3263.host.control-plane.oxide.internal
+        SRV  port 17000 a76d9883-b4fe-464f-acbb-e75b2bbb508d.host.control-plane.oxide.internal
+        SRV  port 17000 c4c56b5a-8c18-4eac-964a-62f94cac07b1.host.control-plane.oxide.internal
+    name: _crucible._tcp.327db2a9-fc45-4c3f-a6db-4ee58459e5cf (records: 1)
+        SRV  port 32345 327db2a9-fc45-4c3f-a6db-4ee58459e5cf.host.control-plane.oxide.internal
+    name: _crucible._tcp.575bd77e-6cd9-4bb6-9c1f-2ac6f149278a (records: 1)
+        SRV  port 32345 575bd77e-6cd9-4bb6-9c1f-2ac6f149278a.host.control-plane.oxide.internal
+    name: _crucible._tcp.5ea7f627-d51e-4e2d-8648-112ddc635e53 (records: 1)
+        SRV  port 32345 5ea7f627-d51e-4e2d-8648-112ddc635e53.host.control-plane.oxide.internal
+    name: _crucible._tcp.70b7e8a1-cc3f-4cdd-a577-4c8be9885f8b (records: 1)
+        SRV  port 32345 70b7e8a1-cc3f-4cdd-a577-4c8be9885f8b.host.control-plane.oxide.internal
+    name: _crucible._tcp.719199e7-eacf-4add-b532-ddfaf867b478 (records: 1)
+        SRV  port 32345 719199e7-eacf-4add-b532-ddfaf867b478.host.control-plane.oxide.internal
+    name: _crucible._tcp.7bb9667d-da70-4592-a579-31295f919aed (records: 1)
+        SRV  port 32345 7bb9667d-da70-4592-a579-31295f919aed.host.control-plane.oxide.internal
+    name: _crucible._tcp.9b8c5aff-3892-4645-8c66-c540456f05af (records: 1)
+        SRV  port 32345 9b8c5aff-3892-4645-8c66-c540456f05af.host.control-plane.oxide.internal
+    name: _crucible._tcp.a5a25771-1025-4c08-9362-c5ee4cecafc9 (records: 1)
+        SRV  port 32345 a5a25771-1025-4c08-9362-c5ee4cecafc9.host.control-plane.oxide.internal
+    name: _crucible._tcp.ad81aafc-e74d-4b0a-b4e6-2e58ef52b7a2 (records: 1)
+        SRV  port 32345 ad81aafc-e74d-4b0a-b4e6-2e58ef52b7a2.host.control-plane.oxide.internal
+    name: _external-dns._tcp                                 (records: 3)
+        SRV  port  5353 86c0837a-73ca-4d08-971d-8491401c2fe2.host.control-plane.oxide.internal
+        SRV  port  5353 8a651785-3936-4cf6-b301-4fa7fa003c9f.host.control-plane.oxide.internal
+        SRV  port  5353 b067565e-df5a-441f-85b9-69acc38bbf35.host.control-plane.oxide.internal
+    name: _internal-ntp._tcp                                 (records: 3)
+        SRV  port   123 345fbd68-cb55-4faa-b6ea-801789018bc6.host.control-plane.oxide.internal
+        SRV  port   123 4ad9c209-bd1b-44c9-863d-1a6b84b34d53.host.control-plane.oxide.internal
+        SRV  port   123 f282c429-5f5e-4430-8f71-600cf61ded56.host.control-plane.oxide.internal
+    name: _nameservice._tcp                                  (records: 3)
+        SRV  port  5353 159e1f8f-6f32-413d-a48b-e40fb2efaf15.host.control-plane.oxide.internal
+        SRV  port  5353 ae5b529a-2ada-490c-bea9-04c71cf8e72c.host.control-plane.oxide.internal
+        SRV  port  5353 f14b0fff-c0f0-420f-ab51-df1a605f43c3.host.control-plane.oxide.internal
+    name: _nexus._tcp                                        (records: 3)
+        SRV  port 12221 1dee8f37-8286-48dc-b4b4-e59979c030ec.host.control-plane.oxide.internal
+        SRV  port 12221 543b3bb6-358d-4876-9774-53a53187aaa8.host.control-plane.oxide.internal
+        SRV  port 12221 6df9649e-48f8-4754-94f3-55e8f9b039be.host.control-plane.oxide.internal
+    name: _oximeter-reader._tcp                              (records: 1)
+        SRV  port  9000 c138c88c-a83d-4e2d-a8f8-e8e715d8e5f7.host.control-plane.oxide.internal
+    name: _repo-depot._tcp                                   (records: 3)
+        SRV  port 12348 bb0ec23a-f97c-4b6a-a5bc-864b1ebc9236.sled.control-plane.oxide.internal
+        SRV  port 12348 bba6ea73-6c9c-4ab5-8bb4-1dd145071407.sled.control-plane.oxide.internal
+        SRV  port 12348 cc00b21a-5685-480a-ab5e-d2e29cf369df.sled.control-plane.oxide.internal
+    name: a5a25771-1025-4c08-9362-c5ee4cecafc9.host          (records: 1)
+        AAAA fd00:1122:3344:102::25
+    name: a76d9883-b4fe-464f-acbb-e75b2bbb508d.host          (records: 1)
+        AAAA fd00:1122:3344:103::24
+    name: ad81aafc-e74d-4b0a-b4e6-2e58ef52b7a2.host          (records: 1)
+        AAAA fd00:1122:3344:103::26
+    name: ae5b529a-2ada-490c-bea9-04c71cf8e72c.host          (records: 1)
+        AAAA fd00:1122:3344:1::1
+    name: b067565e-df5a-441f-85b9-69acc38bbf35.host          (records: 1)
+        AAAA fd00:1122:3344:102::23
+    name: bb0ec23a-f97c-4b6a-a5bc-864b1ebc9236.sled          (records: 1)
+        AAAA fd00:1122:3344:101::1
+    name: bba6ea73-6c9c-4ab5-8bb4-1dd145071407.sled          (records: 1)
+        AAAA fd00:1122:3344:102::1
+    name: c138c88c-a83d-4e2d-a8f8-e8e715d8e5f7.host          (records: 1)
+        AAAA fd00:1122:3344:101::23
+    name: c4c56b5a-8c18-4eac-964a-62f94cac07b1.host          (records: 1)
+        AAAA fd00:1122:3344:101::25
+    name: cc00b21a-5685-480a-ab5e-d2e29cf369df.sled          (records: 1)
+        AAAA fd00:1122:3344:103::1
+    name: f14b0fff-c0f0-420f-ab51-df1a605f43c3.host          (records: 1)
+        AAAA fd00:1122:3344:3::1
+    name: f282c429-5f5e-4430-8f71-600cf61ded56.host          (records: 1)
+        AAAA fd00:1122:3344:103::21
+
+external DNS:
+  DNS zone: "oxide.example" (unchanged)
+    name: example-silo.sys                                   (records: 3)
+        A    192.0.2.2
+        A    192.0.2.3
+        A    192.0.2.4
+
+
+
+> 
+
+> # Delete one of these updates.
+
+> blueprint-edit 1b837a27-3be1-4fcb-8499-a921c839e1d0 sp-update-delete serial2
+blueprint 3682a71b-c6ca-4b7e-8f84-16df80c85960 created from blueprint 1b837a27-3be1-4fcb-8499-a921c839e1d0: deleted configured update for serial serial2
+
+> blueprint-show 3682a71b-c6ca-4b7e-8f84-16df80c85960
+blueprint  3682a71b-c6ca-4b7e-8f84-16df80c85960
+parent:    1b837a27-3be1-4fcb-8499-a921c839e1d0
+
+  sled: bb0ec23a-f97c-4b6a-a5bc-864b1ebc9236 (active, config generation 2)
+
+    physical disks:
+    ------------------------------------------------------------------------------------
+    vendor        model        serial                                        disposition
+    ------------------------------------------------------------------------------------
+    fake-vendor   fake-model   serial-a156a6d9-e839-4cb2-9d09-faf012dae700   in service 
+    fake-vendor   fake-model   serial-b48b5b36-fbb1-4c71-8b08-34a58b3ed2bd   in service 
+    fake-vendor   fake-model   serial-b62945fd-6ac2-4ec2-9e13-0a9a10620924   in service 
+
+
+    datasets:
+    -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
+    dataset name                                                                                                   dataset id                             disposition   quota     reservation   compression
+    -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
+    oxp_a156a6d9-e839-4cb2-9d09-faf012dae700/crucible                                                              bbf79ca9-a619-4142-9802-d306a4b58acb   in service    none      none          off        
+    oxp_b48b5b36-fbb1-4c71-8b08-34a58b3ed2bd/crucible                                                              ff6da666-707c-4370-b0d9-0572d8851e9d   in service    none      none          off        
+    oxp_b62945fd-6ac2-4ec2-9e13-0a9a10620924/crucible                                                              1f46779a-37b2-48d7-8ea9-a4e988bb0045   in service    none      none          off        
+    oxp_a156a6d9-e839-4cb2-9d09-faf012dae700/crypt/clickhouse                                                      43b6b5c0-61d8-4b88-bbb8-abede5589619   in service    none      none          off        
+    oxp_a156a6d9-e839-4cb2-9d09-faf012dae700/crypt/external_dns                                                    f5fc02e2-46ff-4012-a5c0-c91ad7881642   in service    none      none          off        
+    oxp_a156a6d9-e839-4cb2-9d09-faf012dae700/crypt/internal_dns                                                    2c16250f-d4aa-4fb5-bf4b-a6b5d72ac441   in service    none      none          off        
+    oxp_a156a6d9-e839-4cb2-9d09-faf012dae700/crypt/zone                                                            9077f1bd-3864-43d5-9c02-9370cbb9156d   in service    none      none          off        
+    oxp_b48b5b36-fbb1-4c71-8b08-34a58b3ed2bd/crypt/zone                                                            f4febe2f-789b-4c28-8bb7-aa594e0e4a4f   in service    none      none          off        
+    oxp_b62945fd-6ac2-4ec2-9e13-0a9a10620924/crypt/zone                                                            de0fe910-037f-49da-b86b-5865818c568d   in service    none      none          off        
+    oxp_a156a6d9-e839-4cb2-9d09-faf012dae700/crypt/zone/oxz_clickhouse_c138c88c-a83d-4e2d-a8f8-e8e715d8e5f7        7de7e173-0287-4e01-ad60-73681156e0e4   in service    none      none          off        
+    oxp_a156a6d9-e839-4cb2-9d09-faf012dae700/crypt/zone/oxz_crucible_575bd77e-6cd9-4bb6-9c1f-2ac6f149278a          252039e9-e48e-4790-930d-a8fad52256d7   in service    none      none          off        
+    oxp_b62945fd-6ac2-4ec2-9e13-0a9a10620924/crypt/zone/oxz_crucible_719199e7-eacf-4add-b532-ddfaf867b478          7ca01115-8692-438a-aa91-84b7c11f5ef2   in service    none      none          off        
+    oxp_b48b5b36-fbb1-4c71-8b08-34a58b3ed2bd/crypt/zone/oxz_crucible_9b8c5aff-3892-4645-8c66-c540456f05af          61a88822-ec1a-4c94-8134-f5d33e342428   in service    none      none          off        
+    oxp_a156a6d9-e839-4cb2-9d09-faf012dae700/crypt/zone/oxz_crucible_pantry_c4c56b5a-8c18-4eac-964a-62f94cac07b1   45b1fd69-7ace-41f8-97bc-3f6e99314e8a   in service    none      none          off        
+    oxp_a156a6d9-e839-4cb2-9d09-faf012dae700/crypt/zone/oxz_external_dns_86c0837a-73ca-4d08-971d-8491401c2fe2      6159b0b8-1c4b-4dd4-a32e-5c5a93df859b   in service    none      none          off        
+    oxp_a156a6d9-e839-4cb2-9d09-faf012dae700/crypt/zone/oxz_internal_dns_ae5b529a-2ada-490c-bea9-04c71cf8e72c      9f74b627-d96c-4183-92f4-7cfaca681fb5   in service    none      none          off        
+    oxp_a156a6d9-e839-4cb2-9d09-faf012dae700/crypt/zone/oxz_nexus_6df9649e-48f8-4754-94f3-55e8f9b039be             6985e6b4-a53b-4a88-bda6-41d2da73af48   in service    none      none          off        
+    oxp_a156a6d9-e839-4cb2-9d09-faf012dae700/crypt/zone/oxz_ntp_4ad9c209-bd1b-44c9-863d-1a6b84b34d53               233b6c7d-284f-42e6-b9e5-607e9377387d   in service    none      none          off        
+    oxp_a156a6d9-e839-4cb2-9d09-faf012dae700/crypt/debug                                                           a510cf34-74db-44fc-903f-36704f21ae67   in service    100 GiB   none          gzip-9     
+    oxp_b48b5b36-fbb1-4c71-8b08-34a58b3ed2bd/crypt/debug                                                           b9f7efe9-5088-45a3-96d9-6cc69be0ec72   in service    100 GiB   none          gzip-9     
+    oxp_b62945fd-6ac2-4ec2-9e13-0a9a10620924/crypt/debug                                                           ae71243d-118a-4e43-b4e3-9e425c6b8395   in service    100 GiB   none          gzip-9     
+
+
+    omicron zones:
+    ---------------------------------------------------------------------------------------------------------------
+    zone type         zone id                                image source      disposition   underlay IP           
+    ---------------------------------------------------------------------------------------------------------------
+    clickhouse        c138c88c-a83d-4e2d-a8f8-e8e715d8e5f7   install dataset   in service    fd00:1122:3344:101::23
+    crucible          575bd77e-6cd9-4bb6-9c1f-2ac6f149278a   install dataset   in service    fd00:1122:3344:101::26
+    crucible          719199e7-eacf-4add-b532-ddfaf867b478   install dataset   in service    fd00:1122:3344:101::28
+    crucible          9b8c5aff-3892-4645-8c66-c540456f05af   install dataset   in service    fd00:1122:3344:101::27
+    crucible_pantry   c4c56b5a-8c18-4eac-964a-62f94cac07b1   install dataset   in service    fd00:1122:3344:101::25
+    external_dns      86c0837a-73ca-4d08-971d-8491401c2fe2   install dataset   in service    fd00:1122:3344:101::24
+    internal_dns      ae5b529a-2ada-490c-bea9-04c71cf8e72c   install dataset   in service    fd00:1122:3344:1::1   
+    internal_ntp      4ad9c209-bd1b-44c9-863d-1a6b84b34d53   install dataset   in service    fd00:1122:3344:101::21
+    nexus             6df9649e-48f8-4754-94f3-55e8f9b039be   install dataset   in service    fd00:1122:3344:101::22
+
+
+
+  sled: bba6ea73-6c9c-4ab5-8bb4-1dd145071407 (active, config generation 2)
+
+    physical disks:
+    ------------------------------------------------------------------------------------
+    vendor        model        serial                                        disposition
+    ------------------------------------------------------------------------------------
+    fake-vendor   fake-model   serial-2201d82d-3a3c-4744-ac41-657536a90afe   in service 
+    fake-vendor   fake-model   serial-bdf3642c-a783-4689-a8a6-8cfa257089bd   in service 
+    fake-vendor   fake-model   serial-eeb9b9ce-ac1c-4a41-9a7a-814e26e2a9ee   in service 
+
+
+    datasets:
+    -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
+    dataset name                                                                                                   dataset id                             disposition   quota     reservation   compression
+    -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
+    oxp_2201d82d-3a3c-4744-ac41-657536a90afe/crucible                                                              66beebb3-2b7a-4334-9ea7-e7c714b6dacc   in service    none      none          off        
+    oxp_bdf3642c-a783-4689-a8a6-8cfa257089bd/crucible                                                              4611f0cd-1ef4-42f2-b1bd-8ce5c0ee1ba4   in service    none      none          off        
+    oxp_eeb9b9ce-ac1c-4a41-9a7a-814e26e2a9ee/crucible                                                              4420b086-b23f-4ba6-b504-459a38e3b367   in service    none      none          off        
+    oxp_2201d82d-3a3c-4744-ac41-657536a90afe/crypt/external_dns                                                    ffe1a3c8-7546-495f-b437-f2405be4e533   in service    none      none          off        
+    oxp_2201d82d-3a3c-4744-ac41-657536a90afe/crypt/internal_dns                                                    c5300adb-042e-41fd-9b1f-5c01d68e7eb4   in service    none      none          off        
+    oxp_2201d82d-3a3c-4744-ac41-657536a90afe/crypt/zone                                                            06dfa1c2-42c3-4626-8bf3-4460dfec3646   in service    none      none          off        
+    oxp_bdf3642c-a783-4689-a8a6-8cfa257089bd/crypt/zone                                                            89ae62b7-0cff-4e09-b4e9-4c43bf242e1d   in service    none      none          off        
+    oxp_eeb9b9ce-ac1c-4a41-9a7a-814e26e2a9ee/crypt/zone                                                            78269a0c-ce98-4834-ae9e-d25eee99a079   in service    none      none          off        
+    oxp_eeb9b9ce-ac1c-4a41-9a7a-814e26e2a9ee/crypt/zone/oxz_crucible_70b7e8a1-cc3f-4cdd-a577-4c8be9885f8b          1382d296-a276-40ca-85b3-9f2578cb95cf   in service    none      none          off        
+    oxp_bdf3642c-a783-4689-a8a6-8cfa257089bd/crypt/zone/oxz_crucible_7bb9667d-da70-4592-a579-31295f919aed          57d3c6cb-64ff-4485-87c0-3ff5fe9c45d8   in service    none      none          off        
+    oxp_2201d82d-3a3c-4744-ac41-657536a90afe/crypt/zone/oxz_crucible_a5a25771-1025-4c08-9362-c5ee4cecafc9          a0e1cc1c-d542-4a21-96bb-efdfe40af009   in service    none      none          off        
+    oxp_2201d82d-3a3c-4744-ac41-657536a90afe/crypt/zone/oxz_crucible_pantry_5c67f8ed-9f38-4be1-b64c-a2d9898d3263   4f3e7986-e836-4ecc-ac69-8c013905707c   in service    none      none          off        
+    oxp_2201d82d-3a3c-4744-ac41-657536a90afe/crypt/zone/oxz_external_dns_b067565e-df5a-441f-85b9-69acc38bbf35      bc7affdc-54b9-4172-8264-af82b92fdfe0   in service    none      none          off        
+    oxp_2201d82d-3a3c-4744-ac41-657536a90afe/crypt/zone/oxz_internal_dns_159e1f8f-6f32-413d-a48b-e40fb2efaf15      79d73706-f701-4857-a378-fcf026cd6756   in service    none      none          off        
+    oxp_2201d82d-3a3c-4744-ac41-657536a90afe/crypt/zone/oxz_nexus_543b3bb6-358d-4876-9774-53a53187aaa8             71b813ec-4a24-43d1-b0b8-5c3303a1d9b5   in service    none      none          off        
+    oxp_2201d82d-3a3c-4744-ac41-657536a90afe/crypt/zone/oxz_ntp_345fbd68-cb55-4faa-b6ea-801789018bc6               d4126675-e113-4a2d-826a-cf7b224b794b   in service    none      none          off        
+    oxp_2201d82d-3a3c-4744-ac41-657536a90afe/crypt/debug                                                           afe7ef8e-c974-403e-932e-eb3c8057b22d   in service    100 GiB   none          gzip-9     
+    oxp_bdf3642c-a783-4689-a8a6-8cfa257089bd/crypt/debug                                                           f5f65250-3145-41bf-b462-359728bda24a   in service    100 GiB   none          gzip-9     
+    oxp_eeb9b9ce-ac1c-4a41-9a7a-814e26e2a9ee/crypt/debug                                                           7328892a-0525-401f-9160-a8e4501049fd   in service    100 GiB   none          gzip-9     
+
+
+    omicron zones:
+    ---------------------------------------------------------------------------------------------------------------
+    zone type         zone id                                image source      disposition   underlay IP           
+    ---------------------------------------------------------------------------------------------------------------
+    crucible          70b7e8a1-cc3f-4cdd-a577-4c8be9885f8b   install dataset   in service    fd00:1122:3344:102::27
+    crucible          7bb9667d-da70-4592-a579-31295f919aed   install dataset   in service    fd00:1122:3344:102::26
+    crucible          a5a25771-1025-4c08-9362-c5ee4cecafc9   install dataset   in service    fd00:1122:3344:102::25
+    crucible_pantry   5c67f8ed-9f38-4be1-b64c-a2d9898d3263   install dataset   in service    fd00:1122:3344:102::24
+    external_dns      b067565e-df5a-441f-85b9-69acc38bbf35   install dataset   in service    fd00:1122:3344:102::23
+    internal_dns      159e1f8f-6f32-413d-a48b-e40fb2efaf15   install dataset   in service    fd00:1122:3344:2::1   
+    internal_ntp      345fbd68-cb55-4faa-b6ea-801789018bc6   install dataset   in service    fd00:1122:3344:102::21
+    nexus             543b3bb6-358d-4876-9774-53a53187aaa8   install dataset   in service    fd00:1122:3344:102::22
+
+
+
+  sled: cc00b21a-5685-480a-ab5e-d2e29cf369df (active, config generation 2)
+
+    physical disks:
+    ------------------------------------------------------------------------------------
+    vendor        model        serial                                        disposition
+    ------------------------------------------------------------------------------------
+    fake-vendor   fake-model   serial-78b8bc9a-8f5b-4fc2-9d70-4470b2d05aae   in service 
+    fake-vendor   fake-model   serial-9e809fde-e684-4ee8-8d46-dade081c3c37   in service 
+    fake-vendor   fake-model   serial-f2b5fdba-606d-45a4-9a9b-35bf20892bd6   in service 
+
+
+    datasets:
+    -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
+    dataset name                                                                                                   dataset id                             disposition   quota     reservation   compression
+    -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
+    oxp_78b8bc9a-8f5b-4fc2-9d70-4470b2d05aae/crucible                                                              a84f76f4-1f8c-4772-a072-ffb0dc7c281c   in service    none      none          off        
+    oxp_9e809fde-e684-4ee8-8d46-dade081c3c37/crucible                                                              db8f2cdf-721f-4c56-880e-d9265ec404f5   in service    none      none          off        
+    oxp_f2b5fdba-606d-45a4-9a9b-35bf20892bd6/crucible                                                              faa61220-8f21-4231-b069-3fb417699363   in service    none      none          off        
+    oxp_78b8bc9a-8f5b-4fc2-9d70-4470b2d05aae/crypt/external_dns                                                    b47f981e-ac2d-4ec1-8e67-c15dcf13af86   in service    none      none          off        
+    oxp_78b8bc9a-8f5b-4fc2-9d70-4470b2d05aae/crypt/internal_dns                                                    037ef4f6-dae1-478e-8397-3b68bf8e47dc   in service    none      none          off        
+    oxp_78b8bc9a-8f5b-4fc2-9d70-4470b2d05aae/crypt/zone                                                            fa042a64-d60c-4aa6-bc1a-ae9d0347bde8   in service    none      none          off        
+    oxp_9e809fde-e684-4ee8-8d46-dade081c3c37/crypt/zone                                                            5366ad89-e6ec-47e5-8870-fafc8224f11f   in service    none      none          off        
+    oxp_f2b5fdba-606d-45a4-9a9b-35bf20892bd6/crypt/zone                                                            fb5e2978-9182-46bd-919d-653b86b1fed3   in service    none      none          off        
+    oxp_f2b5fdba-606d-45a4-9a9b-35bf20892bd6/crypt/zone/oxz_crucible_327db2a9-fc45-4c3f-a6db-4ee58459e5cf          ac6a48f2-c9e0-4bf2-9c93-c234efc48a59   in service    none      none          off        
+    oxp_78b8bc9a-8f5b-4fc2-9d70-4470b2d05aae/crypt/zone/oxz_crucible_5ea7f627-d51e-4e2d-8648-112ddc635e53          d449dcc4-1725-4de2-92c0-e1a37d12299a   in service    none      none          off        
+    oxp_9e809fde-e684-4ee8-8d46-dade081c3c37/crypt/zone/oxz_crucible_ad81aafc-e74d-4b0a-b4e6-2e58ef52b7a2          2c018c08-7cc7-45a9-be60-cd6b82874cfc   in service    none      none          off        
+    oxp_78b8bc9a-8f5b-4fc2-9d70-4470b2d05aae/crypt/zone/oxz_crucible_pantry_a76d9883-b4fe-464f-acbb-e75b2bbb508d   ad79a937-7410-4e92-89e1-0af1a0595cef   in service    none      none          off        
+    oxp_78b8bc9a-8f5b-4fc2-9d70-4470b2d05aae/crypt/zone/oxz_external_dns_8a651785-3936-4cf6-b301-4fa7fa003c9f      e80f5919-dd7c-4d6c-b0de-45d24c0fe421   in service    none      none          off        
+    oxp_78b8bc9a-8f5b-4fc2-9d70-4470b2d05aae/crypt/zone/oxz_internal_dns_f14b0fff-c0f0-420f-ab51-df1a605f43c3      fd542516-55e6-42c6-a8de-0128b3cce65e   in service    none      none          off        
+    oxp_78b8bc9a-8f5b-4fc2-9d70-4470b2d05aae/crypt/zone/oxz_nexus_1dee8f37-8286-48dc-b4b4-e59979c030ec             7c89c13d-8f41-4c69-96d2-6f9ffbc27cbb   in service    none      none          off        
+    oxp_78b8bc9a-8f5b-4fc2-9d70-4470b2d05aae/crypt/zone/oxz_ntp_f282c429-5f5e-4430-8f71-600cf61ded56               7ea314c5-c702-4f47-b70c-02e5131682be   in service    none      none          off        
+    oxp_78b8bc9a-8f5b-4fc2-9d70-4470b2d05aae/crypt/debug                                                           b43d1c1e-5482-40de-869e-8cd2741c6fc0   in service    100 GiB   none          gzip-9     
+    oxp_9e809fde-e684-4ee8-8d46-dade081c3c37/crypt/debug                                                           19e5fb1e-c1f8-4262-9232-0f31eb746cdb   in service    100 GiB   none          gzip-9     
+    oxp_f2b5fdba-606d-45a4-9a9b-35bf20892bd6/crypt/debug                                                           ef852bdc-50a0-458e-a3f4-fd77a633d3cb   in service    100 GiB   none          gzip-9     
+
+
+    omicron zones:
+    ---------------------------------------------------------------------------------------------------------------
+    zone type         zone id                                image source      disposition   underlay IP           
+    ---------------------------------------------------------------------------------------------------------------
+    crucible          327db2a9-fc45-4c3f-a6db-4ee58459e5cf   install dataset   in service    fd00:1122:3344:103::27
+    crucible          5ea7f627-d51e-4e2d-8648-112ddc635e53   install dataset   in service    fd00:1122:3344:103::25
+    crucible          ad81aafc-e74d-4b0a-b4e6-2e58ef52b7a2   install dataset   in service    fd00:1122:3344:103::26
+    crucible_pantry   a76d9883-b4fe-464f-acbb-e75b2bbb508d   install dataset   in service    fd00:1122:3344:103::24
+    external_dns      8a651785-3936-4cf6-b301-4fa7fa003c9f   install dataset   in service    fd00:1122:3344:103::23
+    internal_dns      f14b0fff-c0f0-420f-ab51-df1a605f43c3   install dataset   in service    fd00:1122:3344:3::1   
+    internal_ntp      f282c429-5f5e-4430-8f71-600cf61ded56   install dataset   in service    fd00:1122:3344:103::21
+    nexus             1dee8f37-8286-48dc-b4b4-e59979c030ec   install dataset   in service    fd00:1122:3344:103::22
+
+
+ COCKROACHDB SETTINGS:
+    state fingerprint:::::::::::::::::   (none)
+    cluster.preserve_downgrade_option:   (do not modify)
+
+ OXIMETER SETTINGS:
+    generation:   1
+    read from::   SingleNode
+
+ METADATA:
+    created by:::::::::::   reconfigurator-cli
+    created at:::::::::::   <REDACTED_TIMESTAMP>
+    comment::::::::::::::   (none)
+    internal DNS version:   1
+    external DNS version:   1
+
+ PENDING MGS-MANAGED UPDATES: 1
+    Pending MGS-managed updates:
+    ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
+    sp_type   slot   part_number   serial_number   artifact_kind   artifact_hash                                                      artifact_version   details                                                                                          
+    ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
+    sled      0      model0        serial0         gimlet_sp       e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855   three              Sp { expected_active_version: ArtifactVersion("two"), expected_inactive_version: NoValidVersion }
+
+
+
+> blueprint-diff 1b837a27-3be1-4fcb-8499-a921c839e1d0 3682a71b-c6ca-4b7e-8f84-16df80c85960
+from: blueprint 1b837a27-3be1-4fcb-8499-a921c839e1d0
+to:   blueprint 3682a71b-c6ca-4b7e-8f84-16df80c85960
+
+ UNCHANGED SLEDS:
+
+  sled bb0ec23a-f97c-4b6a-a5bc-864b1ebc9236 (active, config generation 2):
+
+    physical disks:
+    ------------------------------------------------------------------------------------
+    vendor        model        serial                                        disposition
+    ------------------------------------------------------------------------------------
+    fake-vendor   fake-model   serial-a156a6d9-e839-4cb2-9d09-faf012dae700   in service 
+    fake-vendor   fake-model   serial-b48b5b36-fbb1-4c71-8b08-34a58b3ed2bd   in service 
+    fake-vendor   fake-model   serial-b62945fd-6ac2-4ec2-9e13-0a9a10620924   in service 
+
+
+    datasets:
+    -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
+    dataset name                                                                                                   dataset id                             disposition   quota     reservation   compression
+    -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
+    oxp_a156a6d9-e839-4cb2-9d09-faf012dae700/crucible                                                              bbf79ca9-a619-4142-9802-d306a4b58acb   in service    none      none          off        
+    oxp_b48b5b36-fbb1-4c71-8b08-34a58b3ed2bd/crucible                                                              ff6da666-707c-4370-b0d9-0572d8851e9d   in service    none      none          off        
+    oxp_b62945fd-6ac2-4ec2-9e13-0a9a10620924/crucible                                                              1f46779a-37b2-48d7-8ea9-a4e988bb0045   in service    none      none          off        
+    oxp_a156a6d9-e839-4cb2-9d09-faf012dae700/crypt/clickhouse                                                      43b6b5c0-61d8-4b88-bbb8-abede5589619   in service    none      none          off        
+    oxp_a156a6d9-e839-4cb2-9d09-faf012dae700/crypt/external_dns                                                    f5fc02e2-46ff-4012-a5c0-c91ad7881642   in service    none      none          off        
+    oxp_a156a6d9-e839-4cb2-9d09-faf012dae700/crypt/internal_dns                                                    2c16250f-d4aa-4fb5-bf4b-a6b5d72ac441   in service    none      none          off        
+    oxp_a156a6d9-e839-4cb2-9d09-faf012dae700/crypt/zone                                                            9077f1bd-3864-43d5-9c02-9370cbb9156d   in service    none      none          off        
+    oxp_b48b5b36-fbb1-4c71-8b08-34a58b3ed2bd/crypt/zone                                                            f4febe2f-789b-4c28-8bb7-aa594e0e4a4f   in service    none      none          off        
+    oxp_b62945fd-6ac2-4ec2-9e13-0a9a10620924/crypt/zone                                                            de0fe910-037f-49da-b86b-5865818c568d   in service    none      none          off        
+    oxp_a156a6d9-e839-4cb2-9d09-faf012dae700/crypt/zone/oxz_clickhouse_c138c88c-a83d-4e2d-a8f8-e8e715d8e5f7        7de7e173-0287-4e01-ad60-73681156e0e4   in service    none      none          off        
+    oxp_a156a6d9-e839-4cb2-9d09-faf012dae700/crypt/zone/oxz_crucible_575bd77e-6cd9-4bb6-9c1f-2ac6f149278a          252039e9-e48e-4790-930d-a8fad52256d7   in service    none      none          off        
+    oxp_b62945fd-6ac2-4ec2-9e13-0a9a10620924/crypt/zone/oxz_crucible_719199e7-eacf-4add-b532-ddfaf867b478          7ca01115-8692-438a-aa91-84b7c11f5ef2   in service    none      none          off        
+    oxp_b48b5b36-fbb1-4c71-8b08-34a58b3ed2bd/crypt/zone/oxz_crucible_9b8c5aff-3892-4645-8c66-c540456f05af          61a88822-ec1a-4c94-8134-f5d33e342428   in service    none      none          off        
+    oxp_a156a6d9-e839-4cb2-9d09-faf012dae700/crypt/zone/oxz_crucible_pantry_c4c56b5a-8c18-4eac-964a-62f94cac07b1   45b1fd69-7ace-41f8-97bc-3f6e99314e8a   in service    none      none          off        
+    oxp_a156a6d9-e839-4cb2-9d09-faf012dae700/crypt/zone/oxz_external_dns_86c0837a-73ca-4d08-971d-8491401c2fe2      6159b0b8-1c4b-4dd4-a32e-5c5a93df859b   in service    none      none          off        
+    oxp_a156a6d9-e839-4cb2-9d09-faf012dae700/crypt/zone/oxz_internal_dns_ae5b529a-2ada-490c-bea9-04c71cf8e72c      9f74b627-d96c-4183-92f4-7cfaca681fb5   in service    none      none          off        
+    oxp_a156a6d9-e839-4cb2-9d09-faf012dae700/crypt/zone/oxz_nexus_6df9649e-48f8-4754-94f3-55e8f9b039be             6985e6b4-a53b-4a88-bda6-41d2da73af48   in service    none      none          off        
+    oxp_a156a6d9-e839-4cb2-9d09-faf012dae700/crypt/zone/oxz_ntp_4ad9c209-bd1b-44c9-863d-1a6b84b34d53               233b6c7d-284f-42e6-b9e5-607e9377387d   in service    none      none          off        
+    oxp_a156a6d9-e839-4cb2-9d09-faf012dae700/crypt/debug                                                           a510cf34-74db-44fc-903f-36704f21ae67   in service    100 GiB   none          gzip-9     
+    oxp_b48b5b36-fbb1-4c71-8b08-34a58b3ed2bd/crypt/debug                                                           b9f7efe9-5088-45a3-96d9-6cc69be0ec72   in service    100 GiB   none          gzip-9     
+    oxp_b62945fd-6ac2-4ec2-9e13-0a9a10620924/crypt/debug                                                           ae71243d-118a-4e43-b4e3-9e425c6b8395   in service    100 GiB   none          gzip-9     
+
+
+    omicron zones:
+    ---------------------------------------------------------------------------------------------------------------
+    zone type         zone id                                image source      disposition   underlay IP           
+    ---------------------------------------------------------------------------------------------------------------
+    clickhouse        c138c88c-a83d-4e2d-a8f8-e8e715d8e5f7   install dataset   in service    fd00:1122:3344:101::23
+    crucible          575bd77e-6cd9-4bb6-9c1f-2ac6f149278a   install dataset   in service    fd00:1122:3344:101::26
+    crucible          719199e7-eacf-4add-b532-ddfaf867b478   install dataset   in service    fd00:1122:3344:101::28
+    crucible          9b8c5aff-3892-4645-8c66-c540456f05af   install dataset   in service    fd00:1122:3344:101::27
+    crucible_pantry   c4c56b5a-8c18-4eac-964a-62f94cac07b1   install dataset   in service    fd00:1122:3344:101::25
+    external_dns      86c0837a-73ca-4d08-971d-8491401c2fe2   install dataset   in service    fd00:1122:3344:101::24
+    internal_dns      ae5b529a-2ada-490c-bea9-04c71cf8e72c   install dataset   in service    fd00:1122:3344:1::1   
+    internal_ntp      4ad9c209-bd1b-44c9-863d-1a6b84b34d53   install dataset   in service    fd00:1122:3344:101::21
+    nexus             6df9649e-48f8-4754-94f3-55e8f9b039be   install dataset   in service    fd00:1122:3344:101::22
+
+
+  sled bba6ea73-6c9c-4ab5-8bb4-1dd145071407 (active, config generation 2):
+
+    physical disks:
+    ------------------------------------------------------------------------------------
+    vendor        model        serial                                        disposition
+    ------------------------------------------------------------------------------------
+    fake-vendor   fake-model   serial-2201d82d-3a3c-4744-ac41-657536a90afe   in service 
+    fake-vendor   fake-model   serial-bdf3642c-a783-4689-a8a6-8cfa257089bd   in service 
+    fake-vendor   fake-model   serial-eeb9b9ce-ac1c-4a41-9a7a-814e26e2a9ee   in service 
+
+
+    datasets:
+    -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
+    dataset name                                                                                                   dataset id                             disposition   quota     reservation   compression
+    -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
+    oxp_2201d82d-3a3c-4744-ac41-657536a90afe/crucible                                                              66beebb3-2b7a-4334-9ea7-e7c714b6dacc   in service    none      none          off        
+    oxp_bdf3642c-a783-4689-a8a6-8cfa257089bd/crucible                                                              4611f0cd-1ef4-42f2-b1bd-8ce5c0ee1ba4   in service    none      none          off        
+    oxp_eeb9b9ce-ac1c-4a41-9a7a-814e26e2a9ee/crucible                                                              4420b086-b23f-4ba6-b504-459a38e3b367   in service    none      none          off        
+    oxp_2201d82d-3a3c-4744-ac41-657536a90afe/crypt/external_dns                                                    ffe1a3c8-7546-495f-b437-f2405be4e533   in service    none      none          off        
+    oxp_2201d82d-3a3c-4744-ac41-657536a90afe/crypt/internal_dns                                                    c5300adb-042e-41fd-9b1f-5c01d68e7eb4   in service    none      none          off        
+    oxp_2201d82d-3a3c-4744-ac41-657536a90afe/crypt/zone                                                            06dfa1c2-42c3-4626-8bf3-4460dfec3646   in service    none      none          off        
+    oxp_bdf3642c-a783-4689-a8a6-8cfa257089bd/crypt/zone                                                            89ae62b7-0cff-4e09-b4e9-4c43bf242e1d   in service    none      none          off        
+    oxp_eeb9b9ce-ac1c-4a41-9a7a-814e26e2a9ee/crypt/zone                                                            78269a0c-ce98-4834-ae9e-d25eee99a079   in service    none      none          off        
+    oxp_eeb9b9ce-ac1c-4a41-9a7a-814e26e2a9ee/crypt/zone/oxz_crucible_70b7e8a1-cc3f-4cdd-a577-4c8be9885f8b          1382d296-a276-40ca-85b3-9f2578cb95cf   in service    none      none          off        
+    oxp_bdf3642c-a783-4689-a8a6-8cfa257089bd/crypt/zone/oxz_crucible_7bb9667d-da70-4592-a579-31295f919aed          57d3c6cb-64ff-4485-87c0-3ff5fe9c45d8   in service    none      none          off        
+    oxp_2201d82d-3a3c-4744-ac41-657536a90afe/crypt/zone/oxz_crucible_a5a25771-1025-4c08-9362-c5ee4cecafc9          a0e1cc1c-d542-4a21-96bb-efdfe40af009   in service    none      none          off        
+    oxp_2201d82d-3a3c-4744-ac41-657536a90afe/crypt/zone/oxz_crucible_pantry_5c67f8ed-9f38-4be1-b64c-a2d9898d3263   4f3e7986-e836-4ecc-ac69-8c013905707c   in service    none      none          off        
+    oxp_2201d82d-3a3c-4744-ac41-657536a90afe/crypt/zone/oxz_external_dns_b067565e-df5a-441f-85b9-69acc38bbf35      bc7affdc-54b9-4172-8264-af82b92fdfe0   in service    none      none          off        
+    oxp_2201d82d-3a3c-4744-ac41-657536a90afe/crypt/zone/oxz_internal_dns_159e1f8f-6f32-413d-a48b-e40fb2efaf15      79d73706-f701-4857-a378-fcf026cd6756   in service    none      none          off        
+    oxp_2201d82d-3a3c-4744-ac41-657536a90afe/crypt/zone/oxz_nexus_543b3bb6-358d-4876-9774-53a53187aaa8             71b813ec-4a24-43d1-b0b8-5c3303a1d9b5   in service    none      none          off        
+    oxp_2201d82d-3a3c-4744-ac41-657536a90afe/crypt/zone/oxz_ntp_345fbd68-cb55-4faa-b6ea-801789018bc6               d4126675-e113-4a2d-826a-cf7b224b794b   in service    none      none          off        
+    oxp_2201d82d-3a3c-4744-ac41-657536a90afe/crypt/debug                                                           afe7ef8e-c974-403e-932e-eb3c8057b22d   in service    100 GiB   none          gzip-9     
+    oxp_bdf3642c-a783-4689-a8a6-8cfa257089bd/crypt/debug                                                           f5f65250-3145-41bf-b462-359728bda24a   in service    100 GiB   none          gzip-9     
+    oxp_eeb9b9ce-ac1c-4a41-9a7a-814e26e2a9ee/crypt/debug                                                           7328892a-0525-401f-9160-a8e4501049fd   in service    100 GiB   none          gzip-9     
+
+
+    omicron zones:
+    ---------------------------------------------------------------------------------------------------------------
+    zone type         zone id                                image source      disposition   underlay IP           
+    ---------------------------------------------------------------------------------------------------------------
+    crucible          70b7e8a1-cc3f-4cdd-a577-4c8be9885f8b   install dataset   in service    fd00:1122:3344:102::27
+    crucible          7bb9667d-da70-4592-a579-31295f919aed   install dataset   in service    fd00:1122:3344:102::26
+    crucible          a5a25771-1025-4c08-9362-c5ee4cecafc9   install dataset   in service    fd00:1122:3344:102::25
+    crucible_pantry   5c67f8ed-9f38-4be1-b64c-a2d9898d3263   install dataset   in service    fd00:1122:3344:102::24
+    external_dns      b067565e-df5a-441f-85b9-69acc38bbf35   install dataset   in service    fd00:1122:3344:102::23
+    internal_dns      159e1f8f-6f32-413d-a48b-e40fb2efaf15   install dataset   in service    fd00:1122:3344:2::1   
+    internal_ntp      345fbd68-cb55-4faa-b6ea-801789018bc6   install dataset   in service    fd00:1122:3344:102::21
+    nexus             543b3bb6-358d-4876-9774-53a53187aaa8   install dataset   in service    fd00:1122:3344:102::22
+
+
+  sled cc00b21a-5685-480a-ab5e-d2e29cf369df (active, config generation 2):
+
+    physical disks:
+    ------------------------------------------------------------------------------------
+    vendor        model        serial                                        disposition
+    ------------------------------------------------------------------------------------
+    fake-vendor   fake-model   serial-78b8bc9a-8f5b-4fc2-9d70-4470b2d05aae   in service 
+    fake-vendor   fake-model   serial-9e809fde-e684-4ee8-8d46-dade081c3c37   in service 
+    fake-vendor   fake-model   serial-f2b5fdba-606d-45a4-9a9b-35bf20892bd6   in service 
+
+
+    datasets:
+    -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
+    dataset name                                                                                                   dataset id                             disposition   quota     reservation   compression
+    -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
+    oxp_78b8bc9a-8f5b-4fc2-9d70-4470b2d05aae/crucible                                                              a84f76f4-1f8c-4772-a072-ffb0dc7c281c   in service    none      none          off        
+    oxp_9e809fde-e684-4ee8-8d46-dade081c3c37/crucible                                                              db8f2cdf-721f-4c56-880e-d9265ec404f5   in service    none      none          off        
+    oxp_f2b5fdba-606d-45a4-9a9b-35bf20892bd6/crucible                                                              faa61220-8f21-4231-b069-3fb417699363   in service    none      none          off        
+    oxp_78b8bc9a-8f5b-4fc2-9d70-4470b2d05aae/crypt/external_dns                                                    b47f981e-ac2d-4ec1-8e67-c15dcf13af86   in service    none      none          off        
+    oxp_78b8bc9a-8f5b-4fc2-9d70-4470b2d05aae/crypt/internal_dns                                                    037ef4f6-dae1-478e-8397-3b68bf8e47dc   in service    none      none          off        
+    oxp_78b8bc9a-8f5b-4fc2-9d70-4470b2d05aae/crypt/zone                                                            fa042a64-d60c-4aa6-bc1a-ae9d0347bde8   in service    none      none          off        
+    oxp_9e809fde-e684-4ee8-8d46-dade081c3c37/crypt/zone                                                            5366ad89-e6ec-47e5-8870-fafc8224f11f   in service    none      none          off        
+    oxp_f2b5fdba-606d-45a4-9a9b-35bf20892bd6/crypt/zone                                                            fb5e2978-9182-46bd-919d-653b86b1fed3   in service    none      none          off        
+    oxp_f2b5fdba-606d-45a4-9a9b-35bf20892bd6/crypt/zone/oxz_crucible_327db2a9-fc45-4c3f-a6db-4ee58459e5cf          ac6a48f2-c9e0-4bf2-9c93-c234efc48a59   in service    none      none          off        
+    oxp_78b8bc9a-8f5b-4fc2-9d70-4470b2d05aae/crypt/zone/oxz_crucible_5ea7f627-d51e-4e2d-8648-112ddc635e53          d449dcc4-1725-4de2-92c0-e1a37d12299a   in service    none      none          off        
+    oxp_9e809fde-e684-4ee8-8d46-dade081c3c37/crypt/zone/oxz_crucible_ad81aafc-e74d-4b0a-b4e6-2e58ef52b7a2          2c018c08-7cc7-45a9-be60-cd6b82874cfc   in service    none      none          off        
+    oxp_78b8bc9a-8f5b-4fc2-9d70-4470b2d05aae/crypt/zone/oxz_crucible_pantry_a76d9883-b4fe-464f-acbb-e75b2bbb508d   ad79a937-7410-4e92-89e1-0af1a0595cef   in service    none      none          off        
+    oxp_78b8bc9a-8f5b-4fc2-9d70-4470b2d05aae/crypt/zone/oxz_external_dns_8a651785-3936-4cf6-b301-4fa7fa003c9f      e80f5919-dd7c-4d6c-b0de-45d24c0fe421   in service    none      none          off        
+    oxp_78b8bc9a-8f5b-4fc2-9d70-4470b2d05aae/crypt/zone/oxz_internal_dns_f14b0fff-c0f0-420f-ab51-df1a605f43c3      fd542516-55e6-42c6-a8de-0128b3cce65e   in service    none      none          off        
+    oxp_78b8bc9a-8f5b-4fc2-9d70-4470b2d05aae/crypt/zone/oxz_nexus_1dee8f37-8286-48dc-b4b4-e59979c030ec             7c89c13d-8f41-4c69-96d2-6f9ffbc27cbb   in service    none      none          off        
+    oxp_78b8bc9a-8f5b-4fc2-9d70-4470b2d05aae/crypt/zone/oxz_ntp_f282c429-5f5e-4430-8f71-600cf61ded56               7ea314c5-c702-4f47-b70c-02e5131682be   in service    none      none          off        
+    oxp_78b8bc9a-8f5b-4fc2-9d70-4470b2d05aae/crypt/debug                                                           b43d1c1e-5482-40de-869e-8cd2741c6fc0   in service    100 GiB   none          gzip-9     
+    oxp_9e809fde-e684-4ee8-8d46-dade081c3c37/crypt/debug                                                           19e5fb1e-c1f8-4262-9232-0f31eb746cdb   in service    100 GiB   none          gzip-9     
+    oxp_f2b5fdba-606d-45a4-9a9b-35bf20892bd6/crypt/debug                                                           ef852bdc-50a0-458e-a3f4-fd77a633d3cb   in service    100 GiB   none          gzip-9     
+
+
+    omicron zones:
+    ---------------------------------------------------------------------------------------------------------------
+    zone type         zone id                                image source      disposition   underlay IP           
+    ---------------------------------------------------------------------------------------------------------------
+    crucible          327db2a9-fc45-4c3f-a6db-4ee58459e5cf   install dataset   in service    fd00:1122:3344:103::27
+    crucible          5ea7f627-d51e-4e2d-8648-112ddc635e53   install dataset   in service    fd00:1122:3344:103::25
+    crucible          ad81aafc-e74d-4b0a-b4e6-2e58ef52b7a2   install dataset   in service    fd00:1122:3344:103::26
+    crucible_pantry   a76d9883-b4fe-464f-acbb-e75b2bbb508d   install dataset   in service    fd00:1122:3344:103::24
+    external_dns      8a651785-3936-4cf6-b301-4fa7fa003c9f   install dataset   in service    fd00:1122:3344:103::23
+    internal_dns      f14b0fff-c0f0-420f-ab51-df1a605f43c3   install dataset   in service    fd00:1122:3344:3::1   
+    internal_ntp      f282c429-5f5e-4430-8f71-600cf61ded56   install dataset   in service    fd00:1122:3344:103::21
+    nexus             1dee8f37-8286-48dc-b4b4-e59979c030ec   install dataset   in service    fd00:1122:3344:103::22
+
+
+ COCKROACHDB SETTINGS:
+    state fingerprint:::::::::::::::::   (none) (unchanged)
+    cluster.preserve_downgrade_option:   (do not modify) (unchanged)
+
+ METADATA:
+    internal DNS version:   1 (unchanged)
+    external DNS version:   1 (unchanged)
+
+ OXIMETER SETTINGS:
+    generation:   1 (unchanged)
+    read from::   SingleNode (unchanged)
+
+
+internal DNS:
+  DNS zone: "control-plane.oxide.internal" (unchanged)
+    name: 159e1f8f-6f32-413d-a48b-e40fb2efaf15.host          (records: 1)
+        AAAA fd00:1122:3344:2::1
+    name: 1dee8f37-8286-48dc-b4b4-e59979c030ec.host          (records: 1)
+        AAAA fd00:1122:3344:103::22
+    name: 327db2a9-fc45-4c3f-a6db-4ee58459e5cf.host          (records: 1)
+        AAAA fd00:1122:3344:103::27
+    name: 345fbd68-cb55-4faa-b6ea-801789018bc6.host          (records: 1)
+        AAAA fd00:1122:3344:102::21
+    name: 4ad9c209-bd1b-44c9-863d-1a6b84b34d53.host          (records: 1)
+        AAAA fd00:1122:3344:101::21
+    name: 543b3bb6-358d-4876-9774-53a53187aaa8.host          (records: 1)
+        AAAA fd00:1122:3344:102::22
+    name: 575bd77e-6cd9-4bb6-9c1f-2ac6f149278a.host          (records: 1)
+        AAAA fd00:1122:3344:101::26
+    name: 5c67f8ed-9f38-4be1-b64c-a2d9898d3263.host          (records: 1)
+        AAAA fd00:1122:3344:102::24
+    name: 5ea7f627-d51e-4e2d-8648-112ddc635e53.host          (records: 1)
+        AAAA fd00:1122:3344:103::25
+    name: 6df9649e-48f8-4754-94f3-55e8f9b039be.host          (records: 1)
+        AAAA fd00:1122:3344:101::22
+    name: 70b7e8a1-cc3f-4cdd-a577-4c8be9885f8b.host          (records: 1)
+        AAAA fd00:1122:3344:102::27
+    name: 719199e7-eacf-4add-b532-ddfaf867b478.host          (records: 1)
+        AAAA fd00:1122:3344:101::28
+    name: 7bb9667d-da70-4592-a579-31295f919aed.host          (records: 1)
+        AAAA fd00:1122:3344:102::26
+    name: 86c0837a-73ca-4d08-971d-8491401c2fe2.host          (records: 1)
+        AAAA fd00:1122:3344:101::24
+    name: 8a651785-3936-4cf6-b301-4fa7fa003c9f.host          (records: 1)
+        AAAA fd00:1122:3344:103::23
+    name: 9b8c5aff-3892-4645-8c66-c540456f05af.host          (records: 1)
+        AAAA fd00:1122:3344:101::27
+    name: _clickhouse-admin-single-server._tcp               (records: 1)
+        SRV  port  8888 c138c88c-a83d-4e2d-a8f8-e8e715d8e5f7.host.control-plane.oxide.internal
+    name: _clickhouse-native._tcp                            (records: 1)
+        SRV  port  9000 c138c88c-a83d-4e2d-a8f8-e8e715d8e5f7.host.control-plane.oxide.internal
+    name: _clickhouse._tcp                                   (records: 1)
+        SRV  port  8123 c138c88c-a83d-4e2d-a8f8-e8e715d8e5f7.host.control-plane.oxide.internal
+    name: _crucible-pantry._tcp                              (records: 3)
+        SRV  port 17000 5c67f8ed-9f38-4be1-b64c-a2d9898d3263.host.control-plane.oxide.internal
+        SRV  port 17000 a76d9883-b4fe-464f-acbb-e75b2bbb508d.host.control-plane.oxide.internal
+        SRV  port 17000 c4c56b5a-8c18-4eac-964a-62f94cac07b1.host.control-plane.oxide.internal
+    name: _crucible._tcp.327db2a9-fc45-4c3f-a6db-4ee58459e5cf (records: 1)
+        SRV  port 32345 327db2a9-fc45-4c3f-a6db-4ee58459e5cf.host.control-plane.oxide.internal
+    name: _crucible._tcp.575bd77e-6cd9-4bb6-9c1f-2ac6f149278a (records: 1)
+        SRV  port 32345 575bd77e-6cd9-4bb6-9c1f-2ac6f149278a.host.control-plane.oxide.internal
+    name: _crucible._tcp.5ea7f627-d51e-4e2d-8648-112ddc635e53 (records: 1)
+        SRV  port 32345 5ea7f627-d51e-4e2d-8648-112ddc635e53.host.control-plane.oxide.internal
+    name: _crucible._tcp.70b7e8a1-cc3f-4cdd-a577-4c8be9885f8b (records: 1)
+        SRV  port 32345 70b7e8a1-cc3f-4cdd-a577-4c8be9885f8b.host.control-plane.oxide.internal
+    name: _crucible._tcp.719199e7-eacf-4add-b532-ddfaf867b478 (records: 1)
+        SRV  port 32345 719199e7-eacf-4add-b532-ddfaf867b478.host.control-plane.oxide.internal
+    name: _crucible._tcp.7bb9667d-da70-4592-a579-31295f919aed (records: 1)
+        SRV  port 32345 7bb9667d-da70-4592-a579-31295f919aed.host.control-plane.oxide.internal
+    name: _crucible._tcp.9b8c5aff-3892-4645-8c66-c540456f05af (records: 1)
+        SRV  port 32345 9b8c5aff-3892-4645-8c66-c540456f05af.host.control-plane.oxide.internal
+    name: _crucible._tcp.a5a25771-1025-4c08-9362-c5ee4cecafc9 (records: 1)
+        SRV  port 32345 a5a25771-1025-4c08-9362-c5ee4cecafc9.host.control-plane.oxide.internal
+    name: _crucible._tcp.ad81aafc-e74d-4b0a-b4e6-2e58ef52b7a2 (records: 1)
+        SRV  port 32345 ad81aafc-e74d-4b0a-b4e6-2e58ef52b7a2.host.control-plane.oxide.internal
+    name: _external-dns._tcp                                 (records: 3)
+        SRV  port  5353 86c0837a-73ca-4d08-971d-8491401c2fe2.host.control-plane.oxide.internal
+        SRV  port  5353 8a651785-3936-4cf6-b301-4fa7fa003c9f.host.control-plane.oxide.internal
+        SRV  port  5353 b067565e-df5a-441f-85b9-69acc38bbf35.host.control-plane.oxide.internal
+    name: _internal-ntp._tcp                                 (records: 3)
+        SRV  port   123 345fbd68-cb55-4faa-b6ea-801789018bc6.host.control-plane.oxide.internal
+        SRV  port   123 4ad9c209-bd1b-44c9-863d-1a6b84b34d53.host.control-plane.oxide.internal
+        SRV  port   123 f282c429-5f5e-4430-8f71-600cf61ded56.host.control-plane.oxide.internal
+    name: _nameservice._tcp                                  (records: 3)
+        SRV  port  5353 159e1f8f-6f32-413d-a48b-e40fb2efaf15.host.control-plane.oxide.internal
+        SRV  port  5353 ae5b529a-2ada-490c-bea9-04c71cf8e72c.host.control-plane.oxide.internal
+        SRV  port  5353 f14b0fff-c0f0-420f-ab51-df1a605f43c3.host.control-plane.oxide.internal
+    name: _nexus._tcp                                        (records: 3)
+        SRV  port 12221 1dee8f37-8286-48dc-b4b4-e59979c030ec.host.control-plane.oxide.internal
+        SRV  port 12221 543b3bb6-358d-4876-9774-53a53187aaa8.host.control-plane.oxide.internal
+        SRV  port 12221 6df9649e-48f8-4754-94f3-55e8f9b039be.host.control-plane.oxide.internal
+    name: _oximeter-reader._tcp                              (records: 1)
+        SRV  port  9000 c138c88c-a83d-4e2d-a8f8-e8e715d8e5f7.host.control-plane.oxide.internal
+    name: _repo-depot._tcp                                   (records: 3)
+        SRV  port 12348 bb0ec23a-f97c-4b6a-a5bc-864b1ebc9236.sled.control-plane.oxide.internal
+        SRV  port 12348 bba6ea73-6c9c-4ab5-8bb4-1dd145071407.sled.control-plane.oxide.internal
+        SRV  port 12348 cc00b21a-5685-480a-ab5e-d2e29cf369df.sled.control-plane.oxide.internal
+    name: a5a25771-1025-4c08-9362-c5ee4cecafc9.host          (records: 1)
+        AAAA fd00:1122:3344:102::25
+    name: a76d9883-b4fe-464f-acbb-e75b2bbb508d.host          (records: 1)
+        AAAA fd00:1122:3344:103::24
+    name: ad81aafc-e74d-4b0a-b4e6-2e58ef52b7a2.host          (records: 1)
+        AAAA fd00:1122:3344:103::26
+    name: ae5b529a-2ada-490c-bea9-04c71cf8e72c.host          (records: 1)
+        AAAA fd00:1122:3344:1::1
+    name: b067565e-df5a-441f-85b9-69acc38bbf35.host          (records: 1)
+        AAAA fd00:1122:3344:102::23
+    name: bb0ec23a-f97c-4b6a-a5bc-864b1ebc9236.sled          (records: 1)
+        AAAA fd00:1122:3344:101::1
+    name: bba6ea73-6c9c-4ab5-8bb4-1dd145071407.sled          (records: 1)
+        AAAA fd00:1122:3344:102::1
+    name: c138c88c-a83d-4e2d-a8f8-e8e715d8e5f7.host          (records: 1)
+        AAAA fd00:1122:3344:101::23
+    name: c4c56b5a-8c18-4eac-964a-62f94cac07b1.host          (records: 1)
+        AAAA fd00:1122:3344:101::25
+    name: cc00b21a-5685-480a-ab5e-d2e29cf369df.sled          (records: 1)
+        AAAA fd00:1122:3344:103::1
+    name: f14b0fff-c0f0-420f-ab51-df1a605f43c3.host          (records: 1)
+        AAAA fd00:1122:3344:3::1
+    name: f282c429-5f5e-4430-8f71-600cf61ded56.host          (records: 1)
+        AAAA fd00:1122:3344:103::21
+
+external DNS:
+  DNS zone: "oxide.example" (unchanged)
+    name: example-silo.sys                                   (records: 3)
+        A    192.0.2.2
+        A    192.0.2.3
+        A    192.0.2.4
+
+
+
+> 
+
+> # test help output
+
+> blueprint-edit ad97e762-7bf1-45a6-a98f-60afb7e491c0 help
+edit contents of a blueprint directly
+
+Usage: blueprint-edit [OPTIONS] <BLUEPRINT_ID> <COMMAND>
+
+Commands:
+  add-nexus         add a Nexus instance to a particular sled
+  add-cockroach     add a CockroachDB instance to a particular sled
+  set-zone-image    set the image source for a zone
+  expunge-zone      expunge a zone
+  sp-update-set     configure an SP update
+  sp-update-delete  delete a configured SP update
+  help              Print this message or the help of the given subcommand(s)
+
+Arguments:
+  <BLUEPRINT_ID>  id of the blueprint to edit
+
+Options:
+      --creator <CREATOR>  "creator" field for the new blueprint
+      --comment <COMMENT>  "comment" field for the new blueprint
+  -h, --help               Print help
+
+> blueprint-edit ad97e762-7bf1-45a6-a98f-60afb7e491c0 sp-update-set help
+configure an SP update
+
+Usage: blueprint-edit <BLUEPRINT_ID> sp-update-set <SERIAL> <ARTIFACT_HASH> <VERSION> <COMMAND>
+
+Commands:
+  sp    
+  help  Print this message or the help of the given subcommand(s)
+
+Arguments:
+  <SERIAL>         serial number to update
+  <ARTIFACT_HASH>  artifact hash id
+  <VERSION>        version
+
+Options:
+  -h, --help  Print help
+
+> blueprint-edit ad97e762-7bf1-45a6-a98f-60afb7e491c0 sp-update-delete help
+error: unknown baseboard serial: "help"
+
+> 
+
+> # test error case: no such serial
+
+> blueprint-edit ad97e762-7bf1-45a6-a98f-60afb7e491c0 sp-update-set not-a-serial e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855 1.1.0 sp 1.0.0 1.0.1
+error: unknown baseboard serial: "not-a-serial"
+
+> # test error case: bad hash
+
+> blueprint-edit ad97e762-7bf1-45a6-a98f-60afb7e491c0 sp-update-set serial0 bogus-hash 1.1.0 sp 1.0.0 1.0.1
+

--- a/dev-tools/reconfigurator-cli/tests/output/cmd-set-zone-images-stdout
+++ b/dev-tools/reconfigurator-cli/tests/output/cmd-set-zone-images-stdout
@@ -679,11 +679,13 @@ edit contents of a blueprint directly
 Usage: blueprint-edit [OPTIONS] <BLUEPRINT_ID> <COMMAND>
 
 Commands:
-  add-nexus       add a Nexus instance to a particular sled
-  add-cockroach   add a CockroachDB instance to a particular sled
-  set-zone-image  set the image source for a zone
-  expunge-zone    expunge a zone
-  help            Print this message or the help of the given subcommand(s)
+  add-nexus         add a Nexus instance to a particular sled
+  add-cockroach     add a CockroachDB instance to a particular sled
+  set-zone-image    set the image source for a zone
+  expunge-zone      expunge a zone
+  sp-update-set     configure an SP update
+  sp-update-delete  delete a configured SP update
+  help              Print this message or the help of the given subcommand(s)
 
 Arguments:
   <BLUEPRINT_ID>  id of the blueprint to edit

--- a/dev-tools/reconfigurator-cli/tests/output/cmd-set-zone-images-stdout
+++ b/dev-tools/reconfigurator-cli/tests/output/cmd-set-zone-images-stdout
@@ -683,8 +683,8 @@ Commands:
   add-cockroach     add a CockroachDB instance to a particular sled
   set-zone-image    set the image source for a zone
   expunge-zone      expunge a zone
-  sp-update-set     configure an SP update
-  sp-update-delete  delete a configured SP update
+  set-sp-update     configure an SP update
+  delete-sp-update  delete a configured SP update
   help              Print this message or the help of the given subcommand(s)
 
 Arguments:

--- a/dev-tools/reconfigurator-cli/tests/test_basic.rs
+++ b/dev-tools/reconfigurator-cli/tests/test_basic.rs
@@ -103,3 +103,20 @@ fn test_set_zone_images() {
     assert_contents("tests/output/cmd-set-zone-images-stdout", &stdout_text);
     assert_contents("tests/output/cmd-set-zone-images-stderr", &stderr_text);
 }
+
+// Run tests that exercise the ability to configured MGS-managed updates.
+#[test]
+fn test_set_mgs_updates() {
+    let (exit_status, stdout_text, stderr_text) = run_cli(
+        "tests/input/cmds-set-mgs-updates.txt",
+        &["--seed", "test_set_mgs_updates"],
+    );
+    assert_exit_code(exit_status, EXIT_SUCCESS, &stderr_text);
+
+    // The example system uses a fixed seed, which means that UUIDs are
+    // deterministic. Some of the test commands also use those UUIDs, and it's
+    // convenient for everyone if they aren't redacted.
+    let stdout_text = Redactor::default().uuids(false).do_redact(&stdout_text);
+    assert_contents("tests/output/cmd-set-mgs-updates-stdout", &stdout_text);
+    assert_contents("tests/output/cmd-set-mgs-updates-stderr", &stderr_text);
+}

--- a/nexus/types/src/deployment.rs
+++ b/nexus/types/src/deployment.rs
@@ -632,6 +632,8 @@ impl fmt::Display for BlueprintDisplay<'_> {
                                     pu.baseboard_id.serial_number.clone(),
                                     pu.artifact_hash_id.kind.to_string(),
                                     pu.artifact_hash_id.hash.to_string(),
+                                    pu.artifact_version.to_string(),
+                                    format!("{:?}", pu.details),
                                 ],
                             )
                         })

--- a/nexus/types/src/deployment.rs
+++ b/nexus/types/src/deployment.rs
@@ -625,16 +625,7 @@ impl fmt::Display for BlueprintDisplay<'_> {
                         .map(|pu| {
                             BpTableRow::from_strings(
                                 BpDiffState::Unchanged,
-                                vec![
-                                    pu.sp_type.to_string(),
-                                    pu.slot_id.to_string(),
-                                    pu.baseboard_id.part_number.clone(),
-                                    pu.baseboard_id.serial_number.clone(),
-                                    pu.artifact_hash_id.kind.to_string(),
-                                    pu.artifact_hash_id.hash.to_string(),
-                                    pu.artifact_version.to_string(),
-                                    format!("{:?}", pu.details),
-                                ],
+                                pu.to_bp_table_values(),
                             )
                         })
                         .collect()
@@ -1232,6 +1223,21 @@ impl IdMappable for PendingMgsUpdate {
     type Id = Arc<BaseboardId>;
     fn id(&self) -> Self::Id {
         self.baseboard_id.clone()
+    }
+}
+
+impl PendingMgsUpdate {
+    fn to_bp_table_values(&self) -> Vec<String> {
+        vec![
+            self.sp_type.to_string(),
+            self.slot_id.to_string(),
+            self.baseboard_id.part_number.clone(),
+            self.baseboard_id.serial_number.clone(),
+            self.artifact_hash_id.kind.to_string(),
+            self.artifact_hash_id.hash.to_string(),
+            self.artifact_version.to_string(),
+            format!("{:?}", self.details),
+        ]
     }
 }
 

--- a/nexus/types/src/deployment/blueprint_diff.rs
+++ b/nexus/types/src/deployment/blueprint_diff.rs
@@ -1622,13 +1622,47 @@ impl<'a> BpDiffPendingMgsUpdates<'a> {
             has_changed = true;
             let u1 = &update.before;
             let u2 = &update.after;
-            rows.push(BpTableRow::from_strings(
-                BpDiffState::Removed,
-                u1.to_bp_table_values(),
-            ));
-            rows.push(BpTableRow::from_strings(
-                BpDiffState::Added,
-                u2.to_bp_table_values(),
+
+            let sp_type = BpTableColumn::new(&u1.sp_type, &u2.sp_type);
+            let slot_id = BpTableColumn::new(&u1.slot_id, &u2.slot_id);
+            let part_number = BpTableColumn::new(
+                &u1.baseboard_id.part_number,
+                &u2.baseboard_id.part_number,
+            );
+            let serial_number = BpTableColumn::new(
+                &u1.baseboard_id.serial_number,
+                &u2.baseboard_id.serial_number,
+            );
+            let artifact_kind = BpTableColumn::new(
+                &u1.artifact_hash_id.kind,
+                &u2.artifact_hash_id.kind,
+            );
+            let artifact_hash = BpTableColumn::new(
+                &u1.artifact_hash_id.hash,
+                &u2.artifact_hash_id.hash,
+            );
+            let artifact_version =
+                BpTableColumn::new(&u1.artifact_version, &u2.artifact_version);
+            let details = if u1.details != u2.details {
+                BpTableColumn::diff(
+                    format!("{:?}", &u1.details),
+                    format!("{:?}", &u2.details),
+                )
+            } else {
+                BpTableColumn::value(format!("{:?}", &u1.details))
+            };
+            rows.push(BpTableRow::new(
+                BpDiffState::Modified,
+                vec![
+                    sp_type,
+                    slot_id,
+                    part_number,
+                    serial_number,
+                    artifact_kind,
+                    artifact_hash,
+                    artifact_version,
+                    details,
+                ],
             ));
         }
         for (_, update) in &map.added {

--- a/nexus/types/src/deployment/blueprint_display.rs
+++ b/nexus/types/src/deployment/blueprint_display.rs
@@ -406,7 +406,7 @@ impl BpTableSchema for BpClickhouseServersTableSchema {
 pub struct BpPendingMgsUpdates {}
 impl BpTableSchema for BpPendingMgsUpdates {
     fn table_name(&self) -> &'static str {
-        "Pending MGS-managed updates"
+        "Pending MGS-managed updates (all baseboards)"
     }
 
     fn column_names(&self) -> &'static [&'static str] {

--- a/nexus/types/src/deployment/blueprint_display.rs
+++ b/nexus/types/src/deployment/blueprint_display.rs
@@ -417,6 +417,8 @@ impl BpTableSchema for BpPendingMgsUpdates {
             "serial_number",
             "artifact_kind",
             "artifact_hash",
+            "artifact_version",
+            "details",
         ]
     }
 }

--- a/nexus/types/src/deployment/blueprint_display.rs
+++ b/nexus/types/src/deployment/blueprint_display.rs
@@ -47,6 +47,7 @@ pub mod constants {
     pub const GENERATION: &str = "generation";
 }
 use constants::*;
+use std::fmt::Display;
 
 /// The state of a sled or resource (e.g. zone or physical disk) in this
 /// blueprint, with regards to the parent blueprint
@@ -131,11 +132,14 @@ pub enum BpTableColumn {
 }
 
 impl BpTableColumn {
-    pub fn new(before: String, after: String) -> BpTableColumn {
+    pub fn new<T: Display + Eq>(before: T, after: T) -> BpTableColumn {
         if before != after {
-            BpTableColumn::Diff { before, after }
+            BpTableColumn::Diff {
+                before: before.to_string(),
+                after: after.to_string(),
+            }
         } else {
-            BpTableColumn::Value(before)
+            BpTableColumn::Value(before.to_string())
         }
     }
 


### PR DESCRIPTION
This adds support to `reconfigurator-cli` for configuring SP updates in blueprints.  As part of this:

- the blueprint builder supports changes to `pending_mgs_updates`
- `blueprint diff` now shows changes to `pending_mgs_updates`
- we now have tests for basic manipulation of this structure (through the `reconfigurator-cli` tests)

(follows #7976)