### PR TITLE
Move CRDB initialization from sled-agent to cockroach-admin

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -7673,6 +7673,7 @@ dependencies = [
  "chrono",
  "clap",
  "clickhouse-admin-types",
+ "cockroach-admin-client",
  "crucible-agent-client",
  "derive_more",
  "display-error-chain",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -7013,6 +7013,7 @@ version = "0.1.0"
 dependencies = [
  "anyhow",
  "camino",
+ "camino-tempfile",
  "chrono",
  "clap",
  "cockroach-admin-api",

--- a/cockroach-admin/Cargo.toml
+++ b/cockroach-admin/Cargo.toml
@@ -37,7 +37,6 @@ toml.workspace = true
 omicron-workspace-hack.workspace = true
 
 [dev-dependencies]
-anyhow.workspace = true
 expectorate.workspace = true
 nexus-test-utils.workspace = true
 omicron-test-utils.workspace = true

--- a/cockroach-admin/Cargo.toml
+++ b/cockroach-admin/Cargo.toml
@@ -10,6 +10,7 @@ omicron-rpaths.workspace = true
 [dependencies]
 anyhow.workspace = true
 camino.workspace = true
+camino-tempfile.workspace = true
 chrono.workspace = true
 clap.workspace = true
 cockroach-admin-api.workspace = true
@@ -36,6 +37,7 @@ toml.workspace = true
 omicron-workspace-hack.workspace = true
 
 [dev-dependencies]
+anyhow.workspace = true
 expectorate.workspace = true
 nexus-test-utils.workspace = true
 omicron-test-utils.workspace = true

--- a/cockroach-admin/api/src/lib.rs
+++ b/cockroach-admin/api/src/lib.rs
@@ -3,7 +3,10 @@
 // file, You can obtain one at https://mozilla.org/MPL/2.0/.
 
 use cockroach_admin_types::{NodeDecommission, NodeStatus};
-use dropshot::{HttpError, HttpResponseOk, RequestContext, TypedBody};
+use dropshot::{
+    HttpError, HttpResponseOk, HttpResponseUpdatedNoContent, RequestContext,
+    TypedBody,
+};
 use omicron_uuid_kinds::OmicronZoneUuid;
 use schemars::JsonSchema;
 use serde::{Deserialize, Serialize};
@@ -11,6 +14,19 @@ use serde::{Deserialize, Serialize};
 #[dropshot::api_description]
 pub trait CockroachAdminApi {
     type Context;
+
+    /// Initialize the CockroachDB cluster.
+    ///
+    /// This performs both the base-level `cockroach init` and installs the
+    /// Omicron schema. It should be idempotent, but we haven't heavily tested
+    /// that; in practice, only RSS calls this endpoint and does so serially.
+    #[endpoint {
+        method = POST,
+        path = "/cluster/init",
+    }]
+    async fn cluster_init(
+        rqctx: RequestContext<Self::Context>,
+    ) -> Result<HttpResponseUpdatedNoContent, HttpError>;
 
     /// Get the status of all nodes in the CRDB cluster.
     #[endpoint {

--- a/cockroach-admin/api/src/lib.rs
+++ b/cockroach-admin/api/src/lib.rs
@@ -19,7 +19,13 @@ pub trait CockroachAdminApi {
     ///
     /// This performs both the base-level `cockroach init` and installs the
     /// Omicron schema. It should be idempotent, but we haven't heavily tested
-    /// that; in practice, only RSS calls this endpoint and does so serially.
+    /// that. We test that this endpoint can safely be called multiple times,
+    /// but haven't tested calling it concurrently (either multiple simultaneous
+    /// requests to the same cockroach node, or sending simultaneous requests to
+    /// different cockroach nodes, both of which would rely on `cockroach init`
+    /// itself being safe to call concurrently). In practice, only RSS calls
+    /// this endpoint and it does so serially; as long as we don't change that,
+    /// the existing testing should be sufficient.
     #[endpoint {
         method = POST,
         path = "/cluster/init",

--- a/cockroach-admin/src/cockroach_cli.rs
+++ b/cockroach-admin/src/cockroach_cli.rs
@@ -418,6 +418,7 @@ mod tests {
     impl Drop for UninitializedCockroach {
         fn drop(&mut self) {
             self.child.kill().expect("killed cockroach child process");
+            self.child.wait().expect("waited for cockroach child process");
         }
     }
 
@@ -484,6 +485,7 @@ mod tests {
                 Ok(addr) => addr,
                 Err(err) => {
                     child.kill().expect("killed child cockroach");
+                    child.wait().expect("waited for child cockroach");
                     panic!(
                         "failed to wait for listen addr at \
                          {listen_addr_path}: {err:?}",

--- a/cockroach-admin/src/cockroach_cli.rs
+++ b/cockroach-admin/src/cockroach_cli.rs
@@ -427,6 +427,8 @@ mod tests {
         // However, this isn't true: we explicitly kill the child process in the
         // case where `wait_for_condition()` fails (and also when we're dropped,
         // in the success case!), so we shouldn't leave behind any zombies.
+        //
+        // Filed as https://github.com/rust-lang/rust-clippy/issues/14677
         #[allow(clippy::zombie_processes)]
         async fn start() -> Self {
             let tempdir = Utf8TempDir::new().expect("created temp dir");

--- a/cockroach-admin/src/context.rs
+++ b/cockroach-admin/src/context.rs
@@ -32,6 +32,10 @@ impl ServerContext {
         Self { zone_id, cockroach_cli, node_id: OnceCell::new(), log }
     }
 
+    pub fn log(&self) -> &Logger {
+        &self.log
+    }
+
     pub fn cockroach_cli(&self) -> &CockroachCli {
         &self.cockroach_cli
     }

--- a/cockroach-admin/src/http_entrypoints.rs
+++ b/cockroach-admin/src/http_entrypoints.rs
@@ -32,7 +32,7 @@ impl CockroachAdminApi for CockroachAdminImpl {
         let cli = ctx.cockroach_cli();
         let log = ctx.log();
 
-        info!(log, "Intializing CRDB cluster");
+        info!(log, "Initializing CRDB cluster");
         cli.cluster_init().await?;
         info!(log, "CRDB cluster initialized - initializing Omicron schema");
         cli.schema_init().await?;

--- a/cockroach-admin/src/http_entrypoints.rs
+++ b/cockroach-admin/src/http_entrypoints.rs
@@ -7,8 +7,10 @@ use cockroach_admin_api::*;
 use cockroach_admin_types::NodeDecommission;
 use dropshot::HttpError;
 use dropshot::HttpResponseOk;
+use dropshot::HttpResponseUpdatedNoContent;
 use dropshot::RequestContext;
 use dropshot::TypedBody;
+use slog::info;
 use std::sync::Arc;
 
 type CrdbApiDescription = dropshot::ApiDescription<Arc<ServerContext>>;
@@ -22,6 +24,22 @@ enum CockroachAdminImpl {}
 
 impl CockroachAdminApi for CockroachAdminImpl {
     type Context = Arc<ServerContext>;
+
+    async fn cluster_init(
+        rqctx: RequestContext<Self::Context>,
+    ) -> Result<HttpResponseUpdatedNoContent, HttpError> {
+        let ctx = rqctx.context();
+        let cli = ctx.cockroach_cli();
+        let log = ctx.log();
+
+        info!(log, "Intializing CRDB cluster");
+        cli.cluster_init().await?;
+        info!(log, "CRDB cluster initialized - initializing Omicron schema");
+        cli.schema_init().await?;
+        info!(log, "Omicron schema initialized");
+
+        Ok(HttpResponseUpdatedNoContent())
+    }
 
     async fn node_status(
         rqctx: RequestContext<Self::Context>,

--- a/dev-tools/ls-apis/tests/api_dependencies.out
+++ b/dev-tools/ls-apis/tests/api_dependencies.out
@@ -13,6 +13,7 @@ Clickhouse Single-Node Cluster Admin (client: clickhouse-admin-single-client)
 
 CockroachDB Cluster Admin (client: cockroach-admin-client)
     consumed by: omicron-nexus (omicron/nexus) via 2 paths
+    consumed by: omicron-sled-agent (omicron/sled-agent) via 1 path
 
 Crucible Agent (client: crucible-agent-client)
     consumed by: omicron-nexus (omicron/nexus) via 1 path

--- a/openapi/cockroach-admin.json
+++ b/openapi/cockroach-admin.json
@@ -13,7 +13,7 @@
     "/cluster/init": {
       "post": {
         "summary": "Initialize the CockroachDB cluster.",
-        "description": "This performs both the base-level `cockroach init` and installs the Omicron schema. It should be idempotent, but we haven't heavily tested that; in practice, only RSS calls this endpoint and does so serially.",
+        "description": "This performs both the base-level `cockroach init` and installs the Omicron schema. It should be idempotent, but we haven't heavily tested that. We test that this endpoint can safely be called multiple times, but haven't tested calling it concurrently (either multiple simultaneous requests to the same cockroach node, or sending simultaneous requests to different cockroach nodes, both of which would rely on `cockroach init` itself being safe to call concurrently). In practice, only RSS calls this endpoint and it does so serially; as long as we don't change that, the existing testing should be sufficient.",
         "operationId": "cluster_init",
         "responses": {
           "204": {

--- a/openapi/cockroach-admin.json
+++ b/openapi/cockroach-admin.json
@@ -10,6 +10,24 @@
     "version": "0.0.1"
   },
   "paths": {
+    "/cluster/init": {
+      "post": {
+        "summary": "Initialize the CockroachDB cluster.",
+        "description": "This performs both the base-level `cockroach init` and installs the Omicron schema. It should be idempotent, but we haven't heavily tested that; in practice, only RSS calls this endpoint and does so serially.",
+        "operationId": "cluster_init",
+        "responses": {
+          "204": {
+            "description": "resource updated"
+          },
+          "4XX": {
+            "$ref": "#/components/responses/Error"
+          },
+          "5XX": {
+            "$ref": "#/components/responses/Error"
+          }
+        }
+      }
+    },
     "/node/decommission": {
       "post": {
         "summary": "Decommission a node from the CRDB cluster.",

--- a/openapi/sled-agent.json
+++ b/openapi/sled-agent.json
@@ -334,23 +334,6 @@
         }
       }
     },
-    "/cockroachdb": {
-      "post": {
-        "summary": "Initializes a CockroachDB cluster",
-        "operationId": "cockroachdb_init",
-        "responses": {
-          "204": {
-            "description": "resource updated"
-          },
-          "4XX": {
-            "$ref": "#/components/responses/Error"
-          },
-          "5XX": {
-            "$ref": "#/components/responses/Error"
-          }
-        }
-      }
-    },
     "/datasets": {
       "get": {
         "summary": "Lists the datasets that this sled is configured to use",

--- a/sled-agent/Cargo.toml
+++ b/sled-agent/Cargo.toml
@@ -24,6 +24,7 @@ cfg-if.workspace = true
 chrono.workspace = true
 clap.workspace = true
 clickhouse-admin-types.workspace = true
+cockroach-admin-client.workspace = true
 # Only used by the simulated sled agent.
 crucible-agent-client.workspace = true
 derive_more.workspace = true

--- a/sled-agent/api/src/lib.rs
+++ b/sled-agent/api/src/lib.rs
@@ -305,15 +305,6 @@ pub trait SledAgentApi {
         rqctx: RequestContext<Self::Context>,
     ) -> Result<HttpResponseOk<SledRole>, HttpError>;
 
-    /// Initializes a CockroachDB cluster
-    #[endpoint {
-        method = POST,
-        path = "/cockroachdb",
-    }]
-    async fn cockroachdb_init(
-        rqctx: RequestContext<Self::Context>,
-    ) -> Result<HttpResponseUpdatedNoContent, HttpError>;
-
     #[endpoint {
         method = PUT,
         path = "/vmms/{propolis_id}",

--- a/sled-agent/src/http_entrypoints.rs
+++ b/sled-agent/src/http_entrypoints.rs
@@ -471,14 +471,6 @@ impl SledAgentApi for SledAgentImpl {
         Ok(HttpResponseOk(sa.get_role()))
     }
 
-    async fn cockroachdb_init(
-        rqctx: RequestContext<Self::Context>,
-    ) -> Result<HttpResponseUpdatedNoContent, HttpError> {
-        let sa = rqctx.context();
-        sa.cockroachdb_initialize().await?;
-        Ok(HttpResponseUpdatedNoContent())
-    }
-
     async fn vmm_register(
         rqctx: RequestContext<Self::Context>,
         path_params: Path<VmmPathParam>,

--- a/sled-agent/src/services.rs
+++ b/sled-agent/src/services.rs
@@ -71,7 +71,6 @@ use nexus_sled_agent_shared::inventory::{
     OmicronZoneConfig, OmicronZoneType, OmicronZonesConfig, ZoneKind,
 };
 use omicron_common::address::AZ_PREFIX;
-use omicron_common::address::COCKROACH_PORT;
 use omicron_common::address::DENDRITE_PORT;
 use omicron_common::address::LLDP_PORT;
 use omicron_common::address::MGS_PORT;
@@ -127,8 +126,6 @@ use uuid::Uuid;
 use illumos_utils::zone::Zones;
 
 const IPV6_UNSPECIFIED: IpAddr = IpAddr::V6(Ipv6Addr::UNSPECIFIED);
-
-const COCKROACH: &str = "/opt/oxide/cockroachdb/bin/cockroach";
 
 // These are all the same binary. They just reside at different paths.
 const CLICKHOUSE_SERVER_BINARY: &str =
@@ -4003,73 +4000,6 @@ impl ServiceManager {
             .dataset_mountpoint(&mount_config.root, ZONE_DATASET);
         let pool = ZpoolOrRamdisk::Zpool(filesystem_pool);
         Ok(PathInPool { pool, path })
-    }
-
-    pub async fn cockroachdb_initialize(&self) -> Result<(), Error> {
-        let log = &self.inner.log;
-        let dataset_zones = self.inner.zones.lock().await;
-        for zone in dataset_zones.values() {
-            // TODO: We could probably store the ZoneKind in the running zone to
-            // make this "comparison to existing zones by name" mechanism a bit
-            // safer.
-            if zone.name().contains(ZoneKind::CockroachDb.zone_prefix()) {
-                let address = Zones::get_address(
-                    Some(zone.name()),
-                    &zone.runtime.control_interface(),
-                )?
-                .ip();
-                let host = &format!("[{address}]:{COCKROACH_PORT}");
-                info!(
-                    log,
-                    "Initializing CRDB Cluster - sending request to {host}"
-                );
-                if let Err(err) = zone.runtime.run_cmd(&[
-                    COCKROACH,
-                    "init",
-                    "--insecure",
-                    "--host",
-                    host,
-                ]) {
-                    if !err
-                        .to_string()
-                        .contains("cluster has already been initialized")
-                    {
-                        return Err(Error::CockroachInit { err });
-                    }
-                };
-                info!(log, "Formatting CRDB");
-                zone.runtime
-                    .run_cmd(&[
-                        COCKROACH,
-                        "sql",
-                        "--insecure",
-                        "--host",
-                        host,
-                        "--file",
-                        "/opt/oxide/cockroachdb/sql/dbwipe.sql",
-                    ])
-                    .map_err(|err| Error::CockroachInit { err })?;
-                zone.runtime
-                    .run_cmd(&[
-                        COCKROACH,
-                        "sql",
-                        "--insecure",
-                        "--host",
-                        host,
-                        "--file",
-                        "/opt/oxide/cockroachdb/sql/dbinit.sql",
-                    ])
-                    .map_err(|err| Error::CockroachInit { err })?;
-                info!(log, "Formatting CRDB - Completed");
-
-                // In the single-sled case, if there are multiple CRDB nodes on
-                // a single device, we'd still only want to send the
-                // initialization requests to a single dataset.
-                return Ok(());
-            }
-        }
-
-        Ok(())
     }
 
     /// Adjust the system boot time to the latest boot time of all zones.

--- a/sled-agent/src/sim/http_entrypoints.rs
+++ b/sled-agent/src/sim/http_entrypoints.rs
@@ -652,12 +652,6 @@ impl SledAgentApi for SledAgentSimImpl {
         method_unimplemented()
     }
 
-    async fn cockroachdb_init(
-        _rqctx: RequestContext<Self::Context>,
-    ) -> Result<HttpResponseUpdatedNoContent, HttpError> {
-        method_unimplemented()
-    }
-
     async fn timesync_get(
         _rqctx: RequestContext<Self::Context>,
     ) -> Result<HttpResponseOk<TimeSync>, HttpError> {

--- a/sled-agent/src/sled_agent.rs
+++ b/sled-agent/src/sled_agent.rs
@@ -1038,11 +1038,6 @@ impl SledAgent {
         Ok(())
     }
 
-    pub async fn cockroachdb_initialize(&self) -> Result<(), Error> {
-        self.inner.services.cockroachdb_initialize().await?;
-        Ok(())
-    }
-
     /// Gets the sled's current list of all zpools.
     pub async fn zpools_get(&self) -> Vec<Zpool> {
         self.inner


### PR DESCRIPTION
The main change in this PR is removing the sled-agent `POST /cockroachdb` endpoint and adding the cockroach-admin `POST /cluster/init` endpoint. This endpoint is only used during rack setup, and is what runs both `cockroach init` and `dbinit.sql`.

There's one semantic change: the sled-agent handler also ran `dbwipe.sql`, and I dropped that from the cockroach-admin handler. I don't think there's any need to wipe: `dbinit.sql` runs inside a transaction, so there shouldn't be any case where it partially succeeds such that a retry would need to wipe before rerunning `dbinit.sql`. And it seems unreasonably dangerous to have an endpoint that can be `POST`'d to that wipes the entire db (which is currently the case in sled-agent!).

A couple other side benefits:

* sled-agent had to zlogin to the cockroach zone to do these operations; cockroach-admin doesn't since it's running in the zone already.
* This removes a thorny "where should this sled-agent code live" case on the upcoming reconciler branch.

I'll take this for a spin through a4x2, but I think if the helios/deploy CI job passes it's good; if anything is wrong here, I would expect RSS to fail.