### PR TITLE
add internal API and omdb command for printing status of MGS-related updates

### DIFF
--- a/clients/nexus-client/src/lib.rs
+++ b/clients/nexus-client/src/lib.rs
@@ -43,6 +43,7 @@ progenitor::generate_api!(
         Generation = omicron_common::api::external::Generation,
         ImportExportPolicy = omicron_common::api::external::ImportExportPolicy,
         MacAddr = omicron_common::api::external::MacAddr,
+        MgsUpdateDriverStatus = nexus_types::internal_api::views::MgsUpdateDriverStatus,
         Name = omicron_common::api::external::Name,
         NetworkInterface = omicron_common::api::internal::shared::NetworkInterface,
         NetworkInterfaceKind = omicron_common::api::internal::shared::NetworkInterfaceKind,

--- a/dev-tools/omdb/src/bin/omdb/nexus.rs
+++ b/dev-tools/omdb/src/bin/omdb/nexus.rs
@@ -116,9 +116,11 @@ enum NexusCommands {
     BackgroundTasks(BackgroundTasksArgs),
     /// interact with blueprints
     Blueprints(BlueprintsArgs),
-    /// Interact with clickhouse policy
+    /// interact with clickhouse policy
     ClickhousePolicy(ClickhousePolicyArgs),
-    /// Interact with oximeter read policy
+    /// print information about pending MGS updates
+    MgsUpdates,
+    /// interact with oximeter read policy
     OximeterReadPolicy(OximeterReadPolicyArgs),
     /// view sagas, create and complete demo sagas
     Sagas(SagasArgs),
@@ -599,6 +601,8 @@ impl NexusArgs {
                     cmd_nexus_clickhouse_policy_set(&client, args, token).await
                 }
             },
+
+            NexusCommands::MgsUpdates => cmd_nexus_mgs_updates(&client).await,
 
             NexusCommands::OximeterReadPolicy(OximeterReadPolicyArgs {
                 command,
@@ -2849,6 +2853,18 @@ async fn cmd_nexus_clickhouse_policy_get(
         }
     }
 
+    Ok(())
+}
+
+async fn cmd_nexus_mgs_updates(
+    client: &nexus_client::Client,
+) -> Result<(), anyhow::Error> {
+    let response = client
+        .mgs_updates()
+        .await
+        .context("fetching update status")?
+        .into_inner();
+    println!("{}", response.detailed_display());
     Ok(())
 }
 

--- a/dev-tools/omdb/tests/usage_errors.out
+++ b/dev-tools/omdb/tests/usage_errors.out
@@ -701,8 +701,9 @@ Usage: omdb nexus [OPTIONS] <COMMAND>
 Commands:
   background-tasks      print information about background tasks
   blueprints            interact with blueprints
-  clickhouse-policy     Interact with clickhouse policy
-  oximeter-read-policy  Interact with oximeter read policy
+  clickhouse-policy     interact with clickhouse policy
+  mgs-updates           print information about pending MGS updates
+  oximeter-read-policy  interact with oximeter read policy
   sagas                 view sagas, create and complete demo sagas
   sleds                 interact with sleds
   help                  Print this message or the help of the given subcommand(s)

--- a/dev-tools/reconfigurator-sp-updater/src/main.rs
+++ b/dev-tools/reconfigurator-sp-updater/src/main.rs
@@ -6,7 +6,6 @@
 
 use anyhow::Context;
 use anyhow::anyhow;
-use chrono::SecondsFormat;
 use clap::Args;
 use clap::ColorChoice;
 use clap::Parser;
@@ -16,12 +15,12 @@ use gateway_client::types::SpIgnition;
 use gateway_client::types::SpType;
 use internal_dns_types::names::ServiceName;
 use nexus_mgs_updates::ArtifactCache;
-use nexus_mgs_updates::DriverStatus;
 use nexus_mgs_updates::MgsUpdateDriver;
 use nexus_types::deployment::ExpectedVersion;
 use nexus_types::deployment::PendingMgsUpdate;
 use nexus_types::deployment::PendingMgsUpdateDetails;
 use nexus_types::deployment::PendingMgsUpdates;
+use nexus_types::internal_api::views::MgsUpdateDriverStatus;
 use nexus_types::inventory::BaseboardId;
 use omicron_repl_utils::run_repl_on_stdin;
 use qorb::resolver::Resolver;
@@ -168,7 +167,7 @@ impl ReconfiguratorSpUpdater {
 
 struct UpdaterState {
     requests_tx: watch::Sender<PendingMgsUpdates>,
-    status_rx: watch::Receiver<DriverStatus>,
+    status_rx: watch::Receiver<MgsUpdateDriverStatus>,
     inventory: Inventory,
 }
 
@@ -335,59 +334,7 @@ fn cmd_status(
     updater_state: &mut UpdaterState,
 ) -> anyhow::Result<Option<String>> {
     let status = updater_state.status_rx.borrow();
-
-    let mut s = String::new();
-    writeln!(&mut s, "recent completed attempts:")?;
-    for r in &status.recent {
-        // Ignore units smaller than a millisecond.
-        let elapsed = Duration::from_millis(
-            u64::try_from(r.elapsed.as_millis())
-                .context("elapsed time too large")?,
-        );
-        writeln!(
-            &mut s,
-            "    {} to {} (took {}): serial {}",
-            r.time_started.to_rfc3339_opts(SecondsFormat::Millis, true),
-            r.time_done.to_rfc3339_opts(SecondsFormat::Millis, true),
-            humantime::format_duration(elapsed),
-            r.request.baseboard_id.serial_number,
-        )?;
-        writeln!(&mut s, "        attempt#: {}", r.nattempts_done)?;
-        writeln!(&mut s, "        version:  {}", r.request.artifact_version)?;
-        writeln!(&mut s, "        hash:     {}", r.request.artifact_hash,)?;
-        writeln!(&mut s, "        result:   {:?}", r.result)?;
-    }
-
-    writeln!(&mut s, "\ncurrently in progress:")?;
-    for (baseboard_id, status) in &status.in_progress {
-        // Ignore units smaller than a millisecond.
-        let elapsed = Duration::from_millis(
-            u64::try_from(status.instant_started.elapsed().as_millis())
-                .context("total runtime was too large")?,
-        );
-        writeln!(
-            &mut s,
-            "    {}: serial {}: {:?} (attempt {}, running {})",
-            status.time_started.to_rfc3339_opts(SecondsFormat::Millis, true),
-            baseboard_id.serial_number,
-            status.status,
-            status.nattempts_done + 1,
-            humantime::format_duration(elapsed),
-        )?;
-    }
-
-    writeln!(&mut s, "\nwaiting for retry:")?;
-    for (baseboard_id, wait_info) in &status.waiting {
-        writeln!(
-            &mut s,
-            "    serial {}: will try again at {} (attempt {})",
-            baseboard_id.serial_number,
-            wait_info.next_attempt_time,
-            wait_info.nattempts_done + 1,
-        )?;
-    }
-
-    Ok(Some(s))
+    Ok(Some(status.detailed_display().to_string()))
 }
 
 #[derive(Debug, Args)]

--- a/nexus/internal-api/src/lib.rs
+++ b/nexus/internal-api/src/lib.rs
@@ -17,16 +17,17 @@ use nexus_types::{
     external_api::{
         params::{PhysicalDiskPath, SledSelector, UninitializedSledId},
         shared::{ProbeInfo, UninitializedSled},
-        views::Ping,
-        views::PingStatus,
-        views::SledPolicy,
+        views::{Ping, PingStatus, SledPolicy},
     },
     internal_api::{
         params::{
             InstanceMigrateRequest, OximeterInfo, RackInitializationRequest,
             SledAgentInfo, SwitchPutRequest, SwitchPutResponse,
         },
-        views::{BackgroundTask, DemoSaga, Ipv4NatEntryView, Saga},
+        views::{
+            BackgroundTask, DemoSaga, Ipv4NatEntryView, MgsUpdateDriverStatus,
+            Saga,
+        },
     },
 };
 use omicron_common::api::{
@@ -276,7 +277,7 @@ pub trait NexusInternalApi {
         downstairs_client_stopped: TypedBody<DownstairsClientStopped>,
     ) -> Result<HttpResponseUpdatedNoContent, HttpError>;
 
-    // Sagas
+    // Debug interfaces for sagas
 
     /// List sagas
     #[endpoint {
@@ -323,7 +324,7 @@ pub trait NexusInternalApi {
         path_params: Path<DemoSagaPathParam>,
     ) -> Result<HttpResponseUpdatedNoContent, HttpError>;
 
-    // Background Tasks
+    // Debug interfaces for background Tasks
 
     /// List background tasks
     ///
@@ -359,6 +360,17 @@ pub trait NexusInternalApi {
         rqctx: RequestContext<Self::Context>,
         body: TypedBody<BackgroundTasksActivateRequest>,
     ) -> Result<HttpResponseUpdatedNoContent, HttpError>;
+
+    // Debug interfaces for ongoing MGS updates
+
+    /// Fetch information about ongoing MGS updates
+    #[endpoint {
+        method = GET,
+        path = "/mgs-updates",
+    }]
+    async fn mgs_updates(
+        rqctx: RequestContext<Self::Context>,
+    ) -> Result<HttpResponseOk<MgsUpdateDriverStatus>, HttpError>;
 
     // NAT RPW internal APIs
 

--- a/nexus/mgs-updates/src/driver_update.rs
+++ b/nexus/mgs-updates/src/driver_update.rs
@@ -8,7 +8,6 @@ use crate::common_sp_update::PrecheckError;
 use crate::common_sp_update::PrecheckStatus;
 use crate::common_sp_update::STATUS_POLL_INTERVAL;
 use crate::common_sp_update::SpComponentUpdateHelper;
-use crate::driver::UpdateAttemptStatus;
 use crate::driver::UpdateAttemptStatusUpdater;
 use crate::mgs_clients::GatewayClientError;
 use crate::{ArtifactCache, ArtifactCacheError, MgsClients};
@@ -16,6 +15,8 @@ use gateway_client::SpComponent;
 use gateway_client::types::UpdateAbortBody;
 use gateway_client::types::{SpType, SpUpdateStatus};
 use nexus_types::deployment::PendingMgsUpdate;
+use nexus_types::internal_api::views::UpdateAttemptStatus;
+use nexus_types::internal_api::views::UpdateCompletedHow;
 use qorb::resolver::AllBackends;
 use slog::{debug, error, info, o, warn};
 use slog_error_chain::InlineErrorChain;
@@ -59,14 +60,6 @@ impl SpComponentUpdate {
     fn component(&self) -> &str {
         self.component.const_as_str()
     }
-}
-
-#[derive(Clone, Debug)]
-pub enum UpdateCompletedHow {
-    FoundNoChangesNeeded,
-    CompletedUpdate,
-    WaitedForConcurrentUpdate,
-    TookOverConcurrentUpdate,
 }
 
 #[derive(Debug, Error)]

--- a/nexus/mgs-updates/src/lib.rs
+++ b/nexus/mgs-updates/src/lib.rs
@@ -25,7 +25,6 @@ pub use artifacts::ArtifactCacheError;
 pub use common_sp_update::SpComponentUpdateError;
 pub use common_sp_update::SpComponentUpdateHelper;
 pub use common_sp_update::SpComponentUpdater;
-pub use driver::DriverStatus;
 pub use driver::MgsUpdateDriver;
 pub use driver_update::DEFAULT_RETRY_TIMEOUT;
 pub use host_phase1_updater::HostPhase1Updater;

--- a/nexus/src/internal_api/http_entrypoints.rs
+++ b/nexus/src/internal_api/http_entrypoints.rs
@@ -37,6 +37,7 @@ use nexus_types::internal_api::params::SwitchPutResponse;
 use nexus_types::internal_api::views::BackgroundTask;
 use nexus_types::internal_api::views::DemoSaga;
 use nexus_types::internal_api::views::Ipv4NatEntryView;
+use nexus_types::internal_api::views::MgsUpdateDriverStatus;
 use nexus_types::internal_api::views::Saga;
 use nexus_types::internal_api::views::to_list;
 use omicron_common::api::external::Instance;
@@ -502,7 +503,7 @@ impl NexusInternalApi for NexusInternalApiImpl {
             .await
     }
 
-    // Sagas
+    // Debug interfaces for Sagas
 
     async fn saga_list(
         rqctx: RequestContext<Self::Context>,
@@ -582,7 +583,7 @@ impl NexusInternalApi for NexusInternalApiImpl {
             .await
     }
 
-    // Background Tasks
+    // Debug interfaces for Background Tasks
 
     async fn bgtask_list(
         rqctx: RequestContext<Self::Context>,
@@ -633,6 +634,24 @@ impl NexusInternalApi for NexusInternalApiImpl {
             let body = body.into_inner();
             nexus.bgtask_activate(&opctx, body.bgtask_names).await?;
             Ok(HttpResponseUpdatedNoContent())
+        };
+        apictx
+            .internal_latencies
+            .instrument_dropshot_handler(&rqctx, handler)
+            .await
+    }
+
+    // Debug interfaces for MGS updates
+
+    async fn mgs_updates(
+        rqctx: RequestContext<Self::Context>,
+    ) -> Result<HttpResponseOk<MgsUpdateDriverStatus>, HttpError> {
+        let apictx = &rqctx.context().context;
+        let handler = async {
+            let opctx =
+                crate::context::op_context_for_internal_api(&rqctx).await;
+            let nexus = &apictx.nexus;
+            Ok(HttpResponseOk(nexus.mgs_updates(&opctx).await?))
         };
         apictx
             .internal_latencies

--- a/nexus/types/src/internal_api/views.rs
+++ b/nexus/types/src/internal_api/views.rs
@@ -14,6 +14,7 @@ use omicron_common::api::external::ObjectStream;
 use omicron_common::api::external::Vni;
 use omicron_uuid_kinds::DemoSagaUuid;
 use schemars::JsonSchema;
+use serde::Deserialize;
 use serde::Serialize;
 use std::collections::BTreeMap;
 use std::collections::VecDeque;
@@ -26,7 +27,6 @@ use std::time::Instant;
 use steno::SagaResultErr;
 use steno::UndoActionError;
 use uuid::Uuid;
-use serde::Deserialize;
 
 pub async fn to_list<T, U>(object_stream: ObjectStream<T>) -> Vec<U>
 where
@@ -351,7 +351,7 @@ pub struct MgsUpdateDriverStatusDisplay<'a> {
     status: &'a MgsUpdateDriverStatus,
 }
 
-impl<'a> Display for MgsUpdateDriverStatusDisplay<'a> {
+impl Display for MgsUpdateDriverStatusDisplay<'_> {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         let status = self.status;
         writeln!(f, "recent completed attempts:")?;

--- a/nexus/types/src/internal_api/views.rs
+++ b/nexus/types/src/internal_api/views.rs
@@ -2,7 +2,10 @@
 // License, v. 2.0. If a copy of the MPL was not distributed with this
 // file, You can obtain one at https://mozilla.org/MPL/2.0/.
 
+use crate::deployment::PendingMgsUpdate;
+use crate::inventory::BaseboardId;
 use chrono::DateTime;
+use chrono::SecondsFormat;
 use chrono::Utc;
 use futures::future::ready;
 use futures::stream::StreamExt;
@@ -12,13 +15,18 @@ use omicron_common::api::external::Vni;
 use omicron_uuid_kinds::DemoSagaUuid;
 use schemars::JsonSchema;
 use serde::Serialize;
+use std::collections::BTreeMap;
+use std::collections::VecDeque;
+use std::fmt::Display;
 use std::net::Ipv4Addr;
 use std::net::Ipv6Addr;
+use std::sync::Arc;
 use std::time::Duration;
 use std::time::Instant;
 use steno::SagaResultErr;
 use steno::UndoActionError;
 use uuid::Uuid;
+use serde::Deserialize;
 
 pub async fn to_list<T, U>(object_stream: ObjectStream<T>) -> Vec<U>
 where
@@ -320,4 +328,162 @@ pub struct Ipv4NatEntryView {
     pub mac: MacAddr,
     pub gen: i64,
     pub deleted: bool,
+}
+
+// Externally-visible status for MGS-managed updates
+
+/// Status of ongoing update attempts, recently completed attempts, and update
+/// requests that are waiting for retry.
+#[derive(Clone, Debug, Deserialize, Serialize, JsonSchema)]
+pub struct MgsUpdateDriverStatus {
+    pub recent: VecDeque<CompletedAttempt>,
+    pub in_progress: BTreeMap<Arc<BaseboardId>, InProgressUpdateStatus>,
+    pub waiting: BTreeMap<Arc<BaseboardId>, WaitingStatus>,
+}
+
+impl MgsUpdateDriverStatus {
+    pub fn detailed_display(&self) -> MgsUpdateDriverStatusDisplay<'_> {
+        MgsUpdateDriverStatusDisplay { status: self }
+    }
+}
+
+pub struct MgsUpdateDriverStatusDisplay<'a> {
+    status: &'a MgsUpdateDriverStatus,
+}
+
+impl<'a> Display for MgsUpdateDriverStatusDisplay<'a> {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        let status = self.status;
+        writeln!(f, "recent completed attempts:")?;
+        for r in &status.recent {
+            // Ignore units smaller than a millisecond.
+            let elapsed = Duration::from_millis(
+                u64::try_from(r.elapsed.as_millis()).unwrap_or(u64::MAX),
+            );
+            writeln!(
+                f,
+                "    {} to {} (took {}): serial {}",
+                r.time_started.to_rfc3339_opts(SecondsFormat::Millis, true),
+                r.time_done.to_rfc3339_opts(SecondsFormat::Millis, true),
+                humantime::format_duration(elapsed),
+                r.request.baseboard_id.serial_number,
+            )?;
+            writeln!(f, "        attempt#: {}", r.nattempts_done)?;
+            writeln!(f, "        version:  {}", r.request.artifact_version)?;
+            writeln!(f, "        hash:     {}", r.request.artifact_hash,)?;
+            writeln!(f, "        result:   {:?}", r.result)?;
+        }
+
+        writeln!(f, "\ncurrently in progress:")?;
+        for (baseboard_id, status) in &status.in_progress {
+            // Ignore units smaller than a millisecond.
+            let elapsed = Duration::from_millis(
+                u64::try_from(
+                    (status.time_started - Utc::now()).num_milliseconds(),
+                )
+                .unwrap_or(0),
+            );
+            writeln!(
+                f,
+                "    {}: serial {}: {:?} (attempt {}, running {})",
+                status
+                    .time_started
+                    .to_rfc3339_opts(SecondsFormat::Millis, true),
+                baseboard_id.serial_number,
+                status.status,
+                status.nattempts_done + 1,
+                humantime::format_duration(elapsed),
+            )?;
+        }
+
+        writeln!(f, "\nwaiting for retry:")?;
+        for (baseboard_id, wait_info) in &status.waiting {
+            writeln!(
+                f,
+                "    serial {}: will try again at {} (attempt {})",
+                baseboard_id.serial_number,
+                wait_info.next_attempt_time,
+                wait_info.nattempts_done + 1,
+            )?;
+        }
+
+        Ok(())
+    }
+}
+
+/// externally-exposed status for a completed attempt
+#[derive(Debug, Clone, Deserialize, Serialize, JsonSchema)]
+pub struct CompletedAttempt {
+    pub time_started: DateTime<Utc>,
+    pub time_done: DateTime<Utc>,
+    pub elapsed: Duration,
+    pub request: PendingMgsUpdate,
+    #[serde(serialize_with = "serialize_snake_case_result")]
+    #[schemars(
+        schema_with = "SnakeCaseResult::<UpdateCompletedHow, String>::json_schema"
+    )]
+    pub result: Result<UpdateCompletedHow, String>,
+    pub nattempts_done: u32,
+}
+
+#[derive(Clone, Copy, Debug, Deserialize, Serialize, JsonSchema)]
+#[serde(rename_all = "snake_case")]
+pub enum UpdateCompletedHow {
+    FoundNoChangesNeeded,
+    CompletedUpdate,
+    WaitedForConcurrentUpdate,
+    TookOverConcurrentUpdate,
+}
+
+/// externally-exposed status for each in-progress update
+#[derive(Clone, Debug, Deserialize, Serialize, JsonSchema)]
+pub struct InProgressUpdateStatus {
+    pub time_started: DateTime<Utc>,
+    pub status: UpdateAttemptStatus,
+    pub nattempts_done: u32,
+}
+
+/// status of a single update attempt
+#[derive(Clone, Copy, Debug, Deserialize, Serialize, JsonSchema)]
+#[serde(rename_all = "snake_case")]
+pub enum UpdateAttemptStatus {
+    NotStarted,
+    FetchingArtifact,
+    Precheck,
+    Updating,
+    UpdateWaiting,
+    PostUpdate,
+    PostUpdateWait,
+    Done,
+}
+
+/// externally-exposed status for waiting updates
+#[derive(Clone, Debug, Deserialize, Serialize, JsonSchema)]
+pub struct WaitingStatus {
+    pub next_attempt_time: DateTime<Utc>,
+    pub nattempts_done: u32,
+}
+
+#[derive(JsonSchema, Serialize)]
+#[serde(rename = "Result{T}Or{E}")]
+#[serde(rename_all = "snake_case")]
+enum SnakeCaseResult<T, E> {
+    Ok(T),
+    Err(E),
+}
+
+fn serialize_snake_case_result<S, T, E>(
+    value: &Result<T, E>,
+    serializer: S,
+) -> Result<S::Ok, S::Error>
+where
+    S: serde::Serializer,
+    T: Serialize,
+    E: Serialize,
+{
+    match value {
+        Ok(val) => SnakeCaseResult::Ok(val),
+        Err(err) => SnakeCaseResult::Err(err),
+    }
+    .serialize(serializer)
 }

--- a/openapi/nexus-internal.json
+++ b/openapi/nexus-internal.json
@@ -915,6 +915,30 @@
         }
       }
     },
+    "/mgs-updates": {
+      "get": {
+        "summary": "Fetch information about ongoing MGS updates",
+        "operationId": "mgs_updates",
+        "responses": {
+          "200": {
+            "description": "successful operation",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/MgsUpdateDriverStatus"
+                }
+              }
+            }
+          },
+          "4XX": {
+            "$ref": "#/components/responses/Error"
+          },
+          "5XX": {
+            "$ref": "#/components/responses/Error"
+          }
+        }
+      }
+    },
     "/nat/ipv4/changeset/{from_gen}": {
       "get": {
         "summary": "Fetch NAT ChangeSet",
@@ -3158,6 +3182,67 @@
           }
         ]
       },
+      "CompletedAttempt": {
+        "description": "externally-exposed status for a completed attempt",
+        "type": "object",
+        "properties": {
+          "elapsed": {
+            "$ref": "#/components/schemas/Duration"
+          },
+          "nattempts_done": {
+            "type": "integer",
+            "format": "uint32",
+            "minimum": 0
+          },
+          "request": {
+            "$ref": "#/components/schemas/PendingMgsUpdate"
+          },
+          "result": {
+            "oneOf": [
+              {
+                "type": "object",
+                "properties": {
+                  "ok": {
+                    "$ref": "#/components/schemas/UpdateCompletedHow"
+                  }
+                },
+                "required": [
+                  "ok"
+                ],
+                "additionalProperties": false
+              },
+              {
+                "type": "object",
+                "properties": {
+                  "err": {
+                    "type": "string"
+                  }
+                },
+                "required": [
+                  "err"
+                ],
+                "additionalProperties": false
+              }
+            ]
+          },
+          "time_done": {
+            "type": "string",
+            "format": "date-time"
+          },
+          "time_started": {
+            "type": "string",
+            "format": "date-time"
+          }
+        },
+        "required": [
+          "elapsed",
+          "nattempts_done",
+          "request",
+          "result",
+          "time_done",
+          "time_started"
+        ]
+      },
       "CompressionAlgorithm": {
         "oneOf": [
           {
@@ -3994,6 +4079,29 @@
           }
         ]
       },
+      "InProgressUpdateStatus": {
+        "description": "externally-exposed status for each in-progress update",
+        "type": "object",
+        "properties": {
+          "nattempts_done": {
+            "type": "integer",
+            "format": "uint32",
+            "minimum": 0
+          },
+          "status": {
+            "$ref": "#/components/schemas/UpdateAttemptStatus"
+          },
+          "time_started": {
+            "type": "string",
+            "format": "date-time"
+          }
+        },
+        "required": [
+          "nattempts_done",
+          "status",
+          "time_started"
+        ]
+      },
       "Instance": {
         "description": "View of an Instance",
         "type": "object",
@@ -4525,6 +4633,35 @@
         "pattern": "^([0-9a-fA-F]{0,2}:){5}[0-9a-fA-F]{0,2}$",
         "minLength": 5,
         "maxLength": 17
+      },
+      "MgsUpdateDriverStatus": {
+        "description": "Status of ongoing update attempts, recently completed attempts, and update requests that are waiting for retry.",
+        "type": "object",
+        "properties": {
+          "in_progress": {
+            "type": "object",
+            "additionalProperties": {
+              "$ref": "#/components/schemas/InProgressUpdateStatus"
+            }
+          },
+          "recent": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/CompletedAttempt"
+            }
+          },
+          "waiting": {
+            "type": "object",
+            "additionalProperties": {
+              "$ref": "#/components/schemas/WaitingStatus"
+            }
+          }
+        },
+        "required": [
+          "in_progress",
+          "recent",
+          "waiting"
+        ]
       },
       "MigrationRuntimeState": {
         "description": "An update from a sled regarding the state of a migration, indicating the role of the VMM whose migration state was updated.",
@@ -6317,6 +6454,29 @@
           "items"
         ]
       },
+      "UpdateAttemptStatus": {
+        "description": "status of a single update attempt",
+        "type": "string",
+        "enum": [
+          "not_started",
+          "fetching_artifact",
+          "precheck",
+          "updating",
+          "update_waiting",
+          "post_update",
+          "post_update_wait",
+          "done"
+        ]
+      },
+      "UpdateCompletedHow": {
+        "type": "string",
+        "enum": [
+          "found_no_changes_needed",
+          "completed_update",
+          "waited_for_concurrent_update",
+          "took_over_concurrent_update"
+        ]
+      },
       "UplinkAddressConfig": {
         "type": "object",
         "properties": {
@@ -6449,6 +6609,25 @@
         "type": "integer",
         "format": "uint32",
         "minimum": 0
+      },
+      "WaitingStatus": {
+        "description": "externally-exposed status for waiting updates",
+        "type": "object",
+        "properties": {
+          "nattempts_done": {
+            "type": "integer",
+            "format": "uint32",
+            "minimum": 0
+          },
+          "next_attempt_time": {
+            "type": "string",
+            "format": "date-time"
+          }
+        },
+        "required": [
+          "nattempts_done",
+          "next_attempt_time"
+        ]
       },
       "ZpoolName": {
         "title": "The name of a Zpool",


### PR DESCRIPTION
This adds a Nexus internal API that's called by omdb to print the status of the MgsUpdateDriver.  I moved the status types (and had to change them a bit) and moved the printing code from `reconfigurator-sp-updater` to a Display impl.