### PR TITLE
nexus: update documenation for `EphemeralIpCreate`

### DIFF
--- a/nexus/types/src/external_api/params.rs
+++ b/nexus/types/src/external_api/params.rs
@@ -1116,8 +1116,8 @@ pub struct InstanceDiskAttach {
 #[serde(tag = "type", rename_all = "snake_case")]
 pub enum ExternalIpCreate {
     /// An IP address providing both inbound and outbound access. The address is
-    /// automatically-assigned from the provided IP Pool, or the current silo's
-    /// default pool if not specified.
+    /// automatically assigned from the provided IP pool or the default IP pool
+    /// if not specified.
     Ephemeral { pool: Option<NameOrId> },
     /// An IP address providing both inbound and outbound access. The address is
     /// an existing floating IP object assigned to the current project.
@@ -1130,7 +1130,8 @@ pub enum ExternalIpCreate {
 #[derive(Clone, Debug, Deserialize, Serialize, JsonSchema)]
 #[serde(tag = "type", rename_all = "snake_case")]
 pub struct EphemeralIpCreate {
-    /// Name or ID of the IP pool used to allocate an address
+    /// Name or ID of the IP pool used to allocate an address. If unspecified,
+    /// the default IP pool will be used.
     pub pool: Option<NameOrId>,
 }
 

--- a/openapi/nexus.json
+++ b/openapi/nexus.json
@@ -15985,7 +15985,7 @@
         "properties": {
           "pool": {
             "nullable": true,
-            "description": "Name or ID of the IP pool used to allocate an address",
+            "description": "Name or ID of the IP pool used to allocate an address. If unspecified, the default IP pool will be used.",
             "allOf": [
               {
                 "$ref": "#/components/schemas/NameOrId"
@@ -16111,7 +16111,7 @@
         "description": "Parameters for creating an external IP address for instances.",
         "oneOf": [
           {
-            "description": "An IP address providing both inbound and outbound access. The address is automatically-assigned from the provided IP Pool, or the current silo's default pool if not specified.",
+            "description": "An IP address providing both inbound and outbound access. The address is automatically assigned from the provided IP pool or the default IP pool if not specified.",
             "type": "object",
             "properties": {
               "pool": {


### PR DESCRIPTION
Passing an empty request body (i.e., `{}`) to the [instance_ephemeral_ip_attach](https://docs.oxide.computer/api/instance_ephemeral_ip_attach) API results in the API allocating an ephemeral IP from the silo's default IP pool. However, the documentation did not describe that behavior and now it does.

Here's an example request showing the behavior.

```sh
> echo "{}" | oxide api /v1/instances/$INSTANCE_ID/external-ips/ephemeral --method POST --input -
{
  "ip": "192.168.0.99",
  "kind": "ephemeral"
}
```