### PR TITLE
[sled-agent] Remove explicitly-requested zone bundles

### DIFF
--- a/openapi/sled-agent.json
+++ b/openapi/sled-agent.json
@@ -6501,13 +6501,6 @@
             "enum": [
               "terminated_instance"
             ]
-          },
-          {
-            "description": "Generated in response to an explicit request to the sled agent.",
-            "type": "string",
-            "enum": [
-              "explicit_request"
-            ]
           }
         ]
       },

--- a/openapi/sled-agent.json
+++ b/openapi/sled-agent.json
@@ -2024,39 +2024,6 @@
             "$ref": "#/components/responses/Error"
           }
         }
-      },
-      "post": {
-        "summary": "Ask the sled agent to create a zone bundle.",
-        "operationId": "zone_bundle_create",
-        "parameters": [
-          {
-            "in": "path",
-            "name": "zone_name",
-            "description": "The name of the zone.",
-            "required": true,
-            "schema": {
-              "type": "string"
-            }
-          }
-        ],
-        "responses": {
-          "201": {
-            "description": "successful creation",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/ZoneBundleMetadata"
-                }
-              }
-            }
-          },
-          "4XX": {
-            "$ref": "#/components/responses/Error"
-          },
-          "5XX": {
-            "$ref": "#/components/responses/Error"
-          }
-        }
       }
     },
     "/zones/bundles/{zone_name}/{bundle_id}": {

--- a/schema/zone-bundle-metadata.json
+++ b/schema/zone-bundle-metadata.json
@@ -62,13 +62,6 @@
           "enum": [
             "terminated_instance"
           ]
-        },
-        {
-          "description": "Generated in response to an explicit request to the sled agent.",
-          "type": "string",
-          "enum": [
-            "explicit_request"
-          ]
         }
       ]
     },

--- a/sled-agent/api/src/lib.rs
+++ b/sled-agent/api/src/lib.rs
@@ -91,16 +91,6 @@ pub trait SledAgentApi {
         params: Path<ZonePathParam>,
     ) -> Result<HttpResponseOk<Vec<ZoneBundleMetadata>>, HttpError>;
 
-    /// Ask the sled agent to create a zone bundle.
-    #[endpoint {
-        method = POST,
-        path = "/zones/bundles/{zone_name}",
-    }]
-    async fn zone_bundle_create(
-        rqctx: RequestContext<Self::Context>,
-        params: Path<ZonePathParam>,
-    ) -> Result<HttpResponseCreated<ZoneBundleMetadata>, HttpError>;
-
     /// Fetch the binary content of a single zone bundle.
     #[endpoint {
         method = GET,

--- a/sled-agent/src/http_entrypoints.rs
+++ b/sled-agent/src/http_entrypoints.rs
@@ -92,19 +92,6 @@ impl SledAgentApi for SledAgentImpl {
             .map_err(HttpError::from)
     }
 
-    async fn zone_bundle_create(
-        rqctx: RequestContext<Self::Context>,
-        params: Path<ZonePathParam>,
-    ) -> Result<HttpResponseCreated<ZoneBundleMetadata>, HttpError> {
-        let params = params.into_inner();
-        let zone_name = params.zone_name;
-        let sa = rqctx.context();
-        sa.create_zone_bundle(&zone_name)
-            .await
-            .map(HttpResponseCreated)
-            .map_err(HttpError::from)
-    }
-
     async fn zone_bundle_get(
         rqctx: RequestContext<Self::Context>,
         params: Path<ZoneBundleId>,

--- a/sled-agent/src/instance_manager.rs
+++ b/sled-agent/src/instance_manager.rs
@@ -11,20 +11,17 @@ use crate::nexus::NexusClient;
 use crate::vmm_reservoir::VmmReservoirManagerHandle;
 use crate::zone_bundle::BundleError;
 use crate::zone_bundle::ZoneBundler;
-use illumos_utils::zone::PROPOLIS_ZONE_PREFIX;
-use omicron_common::api::external::ByteCount;
 
-use anyhow::anyhow;
 use illumos_utils::dladm::Etherstub;
 use illumos_utils::link::VnicAllocator;
 use illumos_utils::opte::PortManager;
 use illumos_utils::running_zone::ZoneBuilderFactory;
+use omicron_common::api::external::ByteCount;
 use omicron_common::api::external::Generation;
 use omicron_common::api::internal::nexus::SledVmmState;
 use omicron_common::api::internal::shared::SledIdentifiers;
 use omicron_uuid_kinds::PropolisUuid;
 use sled_agent_types::instance::*;
-use sled_agent_types::zone_bundle::ZoneBundleMetadata;
 use sled_storage::manager::StorageHandle;
 use sled_storage::resources::AllDisks;
 use slog::Logger;
@@ -255,23 +252,6 @@ impl InstanceManager {
         rx.await?
     }
 
-    /// Create a zone bundle from a named instance zone, if it exists.
-    pub async fn create_zone_bundle(
-        &self,
-        name: &str,
-    ) -> Result<ZoneBundleMetadata, BundleError> {
-        let (tx, rx) = oneshot::channel();
-        self.inner
-            .tx
-            .send(InstanceManagerRequest::CreateZoneBundle {
-                name: name.to_string(),
-                tx,
-            })
-            .await
-            .map_err(|err| BundleError::FailedSend(anyhow!(err)))?;
-        rx.await.map_err(|err| BundleError::DroppedRequest(anyhow!(err)))?
-    }
-
     pub async fn add_external_ip(
         &self,
         propolis_id: PropolisUuid,
@@ -389,10 +369,6 @@ enum InstanceManagerRequest {
         snapshot_id: Uuid,
         tx: oneshot::Sender<Result<(), Error>>,
     },
-    CreateZoneBundle {
-        name: String,
-        tx: oneshot::Sender<Result<ZoneBundleMetadata, BundleError>>,
-    },
     AddExternalIp {
         propolis_id: PropolisUuid,
         ip: InstanceExternalIpBody,
@@ -501,9 +477,6 @@ impl InstanceManagerRunner {
                         },
                         Some(IssueDiskSnapshot { propolis_id, disk_id, snapshot_id, tx }) => {
                             self.issue_disk_snapshot_request(tx, propolis_id, disk_id, snapshot_id)
-                        },
-                        Some(CreateZoneBundle { name, tx }) => {
-                            self.create_zone_bundle(tx, &name).map_err(Error::from)
                         },
                         Some(AddExternalIp { propolis_id, ip, tx }) => {
                             self.add_external_ip(tx, propolis_id, &ip)
@@ -716,33 +689,6 @@ impl InstanceManagerRunner {
         instance
             .issue_snapshot_request(tx, disk_id, snapshot_id)
             .map_err(Error::from)
-    }
-
-    /// Create a zone bundle from a named instance zone, if it exists.
-    fn create_zone_bundle(
-        &self,
-        tx: oneshot::Sender<Result<ZoneBundleMetadata, BundleError>>,
-        name: &str,
-    ) -> Result<(), BundleError> {
-        // A well-formed Propolis zone name must consist of
-        // `PROPOLIS_ZONE_PREFIX` and the Propolis ID. If the prefix is not
-        // present or the Propolis ID portion of the supplied zone name isn't
-        // parseable as a UUID, there is no Propolis zone with the specified
-        // name to capture into a bundle, so return a `NoSuchZone` error.
-        let vmm_id: PropolisUuid = name
-            .strip_prefix(PROPOLIS_ZONE_PREFIX)
-            .and_then(|uuid_str| uuid_str.parse::<PropolisUuid>().ok())
-            .ok_or_else(|| BundleError::NoSuchZone {
-                name: name.to_string(),
-            })?;
-
-        let Some(instance) = self.jobs.get(&vmm_id) else {
-            return Err(BundleError::NoSuchZone { name: name.to_string() });
-        };
-        instance
-            .request_zone_bundle(tx)
-            .map_err(|e| BundleError::FailedSend(anyhow!(e)))?;
-        Ok(())
     }
 
     fn add_external_ip(

--- a/sled-agent/src/sim/http_entrypoints.rs
+++ b/sled-agent/src/sim/http_entrypoints.rs
@@ -583,13 +583,6 @@ impl SledAgentApi for SledAgentSimImpl {
         method_unimplemented()
     }
 
-    async fn zone_bundle_create(
-        _rqctx: RequestContext<Self::Context>,
-        _params: Path<ZonePathParam>,
-    ) -> Result<HttpResponseCreated<ZoneBundleMetadata>, HttpError> {
-        method_unimplemented()
-    }
-
     async fn zone_bundle_get(
         _rqctx: RequestContext<Self::Context>,
         _params: Path<ZoneBundleId>,

--- a/sled-agent/src/sled_agent.rs
+++ b/sled-agent/src/sled_agent.rs
@@ -30,8 +30,6 @@ use dropshot::HttpError;
 use futures::StreamExt;
 use futures::stream::FuturesUnordered;
 use illumos_utils::opte::PortManager;
-use illumos_utils::zone::PROPOLIS_ZONE_PREFIX;
-use illumos_utils::zone::ZONE_PREFIX;
 use nexus_sled_agent_shared::inventory::{
     Inventory, InventoryDataset, InventoryDisk, InventoryZpool,
     OmicronSledConfig, OmicronSledConfigResult, OmicronZonesConfig, SledRole,
@@ -778,28 +776,6 @@ impl SledAgent {
         name: &str,
     ) -> Result<Vec<ZoneBundleMetadata>, Error> {
         self.inner.zone_bundler.list_for_zone(name).await.map_err(Error::from)
-    }
-
-    /// Create a zone bundle for the provided zone.
-    pub async fn create_zone_bundle(
-        &self,
-        name: &str,
-    ) -> Result<ZoneBundleMetadata, Error> {
-        if name.starts_with(PROPOLIS_ZONE_PREFIX) {
-            self.inner
-                .instances
-                .create_zone_bundle(name)
-                .await
-                .map_err(Error::from)
-        } else if name.starts_with(ZONE_PREFIX) {
-            self.inner
-                .services
-                .create_zone_bundle(name)
-                .await
-                .map_err(Error::from)
-        } else {
-            Err(Error::from(BundleError::NoSuchZone { name: name.to_string() }))
-        }
     }
 
     /// Fetch the paths to all zone bundles with the provided name and ID.

--- a/sled-agent/src/zone_bundle.rs
+++ b/sled-agent/src/zone_bundle.rs
@@ -2026,7 +2026,7 @@ mod illumos_tests {
         let info = insert_fake_bundle(
             &paths[0],
             DaysOfOurBundles::new().next().unwrap(),
-            ZoneBundleCause::ExplicitRequest,
+            ZoneBundleCause::UnexpectedZone,
         )
         .await
         .context("Failed to insert_fake_bundle")?;
@@ -2121,7 +2121,7 @@ mod illumos_tests {
             let it = insert_fake_bundle(
                 bundle_dir,
                 days.next().unwrap(),
-                ZoneBundleCause::ExplicitRequest,
+                ZoneBundleCause::UnexpectedZone,
             )
             .await?;
             info.push(it);
@@ -2172,7 +2172,7 @@ mod illumos_tests {
             let it = insert_fake_bundle_with_zone_name(
                 &ctx.resource_wrapper.dirs[0],
                 days.next().unwrap(),
-                ZoneBundleCause::ExplicitRequest,
+                ZoneBundleCause::UnexpectedZone,
                 format!("oxz_whatever_{i}").as_str(),
             )
             .await?;

--- a/sled-agent/types/src/zone_bundle.rs
+++ b/sled-agent/types/src/zone_bundle.rs
@@ -66,8 +66,6 @@ pub enum ZoneBundleCause {
     UnexpectedZone,
     /// An instance zone was terminated.
     TerminatedInstance,
-    /// Generated in response to an explicit request to the sled agent.
-    ExplicitRequest,
 }
 
 /// Metadata about a zone bundle.
@@ -403,10 +401,8 @@ mod tests {
     #[test]
     fn test_sort_zone_bundle_cause() {
         use ZoneBundleCause::*;
-        let mut original =
-            [ExplicitRequest, Other, TerminatedInstance, UnexpectedZone];
-        let expected =
-            [Other, UnexpectedZone, TerminatedInstance, ExplicitRequest];
+        let mut original = [Other, TerminatedInstance, UnexpectedZone];
+        let expected = [Other, UnexpectedZone, TerminatedInstance];
         original.sort();
         assert_eq!(original, expected);
     }
@@ -496,16 +492,16 @@ mod tests {
         }
 
         let info = [
+            make_info(2020, 1, 2, ZoneBundleCause::UnexpectedZone),
             make_info(2020, 1, 2, ZoneBundleCause::TerminatedInstance),
-            make_info(2020, 1, 2, ZoneBundleCause::ExplicitRequest),
+            make_info(2020, 1, 1, ZoneBundleCause::UnexpectedZone),
             make_info(2020, 1, 1, ZoneBundleCause::TerminatedInstance),
-            make_info(2020, 1, 1, ZoneBundleCause::ExplicitRequest),
         ];
 
         let mut sorted = info.clone();
         sorted.sort_by(|lhs, rhs| time_first.compare_bundles(lhs, rhs));
         // Low -> high priority
-        // [old/terminated, old/explicit, new/terminated, new/explicit]
+        // [old/unexpected, old/terminated, new/unexpected, new/terminated]
         let expected = [
             info[2].clone(),
             info[3].clone(),
@@ -520,7 +516,7 @@ mod tests {
         let mut sorted = info.clone();
         sorted.sort_by(|lhs, rhs| cause_first.compare_bundles(lhs, rhs));
         // Low -> high priority
-        // [old/terminated, new/terminated, old/explicit, new/explicit]
+        // [old/unexpected, new/unexpected, old/terminated, new/terminated]
         let expected = [
             info[2].clone(),
             info[0].clone(),


### PR DESCRIPTION
Removes the sled-agent endpoint that explicitly creates a zone bundle, and removes the `ZoneBundleCause::ExplicitRequest` variant (since there's no longer a way to explicitly request them!), which required small tweaks to a few tests to use different causes.

Removes the only callers of this API:

* `zone-bundle create`
* `zone-bundle bundle-all`
* The `--create` flag of `zone-bundle get`