### PR TITLE
[1/n] [installinator] add PeerAddress wrapper

### DIFF
--- a/installinator/src/mock_peers.rs
+++ b/installinator/src/mock_peers.rs
@@ -27,12 +27,12 @@ use uuid::Uuid;
 
 use crate::{
     errors::HttpError,
-    peers::{FetchReceiver, PeersImpl},
+    peers::{FetchReceiver, PeerAddress, PeersImpl},
 };
 
 struct MockPeersUniverse {
     artifact: Bytes,
-    peers: BTreeMap<SocketAddr, MockPeer>,
+    peers: BTreeMap<PeerAddress, MockPeer>,
     attempt_bitmaps: Vec<AttemptBitmap>,
 }
 
@@ -49,7 +49,7 @@ impl fmt::Debug for MockPeersUniverse {
 impl MockPeersUniverse {
     fn new(
         artifact: Bytes,
-        peers: BTreeMap<SocketAddr, MockPeer>,
+        peers: BTreeMap<PeerAddress, MockPeer>,
         attempt_bitmaps: Vec<AttemptBitmap>,
     ) -> Self {
         assert!(peers.len() <= 32, "this test only supports up to 32 peers");
@@ -70,7 +70,7 @@ impl MockPeersUniverse {
         // being unique identifiers. This means that this code can use a BTreeMap rather than a
         // fancier structure like an IndexMap.
         let peers_strategy = prop::collection::btree_map(
-            any::<SocketAddr>(),
+            any::<PeerAddress>(),
             any::<MockResponse_>(),
             0..max_peer_count,
         );
@@ -82,7 +82,7 @@ impl MockPeersUniverse {
         (artifact_strategy, peers_strategy, attempt_bitmaps_strategy).prop_map(
             |(artifact, peers, attempt_bitmaps): (
                 Vec<u8>,
-                BTreeMap<SocketAddr, MockResponse_>,
+                BTreeMap<PeerAddress, MockResponse_>,
                 Vec<AttemptBitmap>,
             )| {
                 let artifact = Bytes::from(artifact);
@@ -107,7 +107,7 @@ impl MockPeersUniverse {
     fn expected_result(
         &self,
         timeout: Duration,
-    ) -> Result<(usize, SocketAddr), usize> {
+    ) -> Result<(usize, PeerAddress), usize> {
         self.attempts()
             .enumerate()
             .filter_map(|(attempt, peers)| {
@@ -174,20 +174,20 @@ enum AttemptBitmap {
 struct MockPeers {
     artifact: Bytes,
     // Peers within the universe that have been selected
-    selected_peers: BTreeMap<SocketAddr, MockPeer>,
+    selected_peers: BTreeMap<PeerAddress, MockPeer>,
 }
 
 impl MockPeers {
-    fn get(&self, addr: SocketAddr) -> Option<&MockPeer> {
-        self.selected_peers.get(&addr)
+    fn get(&self, peer: PeerAddress) -> Option<&MockPeer> {
+        self.selected_peers.get(&peer)
     }
 
-    fn peers(&self) -> impl Iterator<Item = (&SocketAddr, &MockPeer)> + '_ {
+    fn peers(&self) -> impl Iterator<Item = (&PeerAddress, &MockPeer)> + '_ {
         self.selected_peers.iter()
     }
 
     /// Returns the peer that can return the entire dataset within the timeout.
-    fn successful_peer(&self, timeout: Duration) -> Option<SocketAddr> {
+    fn successful_peer(&self, timeout: Duration) -> Option<PeerAddress> {
         self.peers()
             .filter_map(|(addr, peer)| {
                 if peer.artifact != self.artifact {
@@ -233,7 +233,7 @@ impl MockPeers {
 
 #[async_trait]
 impl PeersImpl for MockPeers {
-    fn peers(&self) -> Box<dyn Iterator<Item = SocketAddr> + Send + '_> {
+    fn peers(&self) -> Box<dyn Iterator<Item = PeerAddress> + Send + '_> {
         Box::new(self.selected_peers.keys().copied())
     }
 
@@ -243,7 +243,7 @@ impl PeersImpl for MockPeers {
 
     async fn fetch_from_peer_impl(
         &self,
-        peer: SocketAddr,
+        peer: PeerAddress,
         // We don't (yet) use the artifact ID in MockPeers
         _artifact_hash_id: ArtifactHashId,
     ) -> Result<(u64, FetchReceiver), HttpError> {
@@ -261,7 +261,7 @@ impl PeersImpl for MockPeers {
 
     async fn report_progress_impl(
         &self,
-        _peer: SocketAddr,
+        _peer: PeerAddress,
         _update_id: Uuid,
         _report: EventReport,
     ) -> Result<(), ClientError> {
@@ -469,26 +469,31 @@ struct MockReportPeers {
 
 impl MockReportPeers {
     // SocketAddr::new is not a const fn in stable Rust as of this writing
-    fn valid_peer() -> SocketAddr {
-        SocketAddr::new(IpAddr::V6(Ipv6Addr::new(0, 0, 0, 0, 0, 0, 0, 1)), 2000)
+    fn valid_peer() -> PeerAddress {
+        PeerAddress::new(SocketAddr::new(
+            IpAddr::V6(Ipv6Addr::new(0, 0, 0, 0, 0, 0, 0, 1)),
+            2000,
+        ))
     }
 
-    fn invalid_peer() -> SocketAddr {
-        SocketAddr::new(IpAddr::V6(Ipv6Addr::new(0, 0, 0, 0, 0, 0, 0, 2)), 2000)
+    fn invalid_peer() -> PeerAddress {
+        PeerAddress::new(SocketAddr::new(
+            IpAddr::V6(Ipv6Addr::new(0, 0, 0, 0, 0, 0, 0, 2)),
+            2000,
+        ))
     }
 
-    fn unresponsive_peer() -> SocketAddr {
-        SocketAddr::new(IpAddr::V6(Ipv6Addr::new(0, 0, 0, 0, 0, 0, 0, 3)), 2000)
-    }
-
-    fn new(update_id: Uuid, report_sender: mpsc::Sender<EventReport>) -> Self {
-        Self { update_id, report_sender }
+    fn unresponsive_peer() -> PeerAddress {
+        PeerAddress::new(SocketAddr::new(
+            IpAddr::V6(Ipv6Addr::new(0, 0, 0, 0, 0, 0, 0, 3)),
+            2000,
+        ))
     }
 }
 
 #[async_trait]
 impl PeersImpl for MockReportPeers {
-    fn peers(&self) -> Box<dyn Iterator<Item = SocketAddr> + Send + '_> {
+    fn peers(&self) -> Box<dyn Iterator<Item = PeerAddress> + Send + '_> {
         Box::new(
             [
                 Self::valid_peer(),
@@ -505,7 +510,7 @@ impl PeersImpl for MockReportPeers {
 
     async fn fetch_from_peer_impl(
         &self,
-        _peer: SocketAddr,
+        _peer: PeerAddress,
         _artifact_hash_id: ArtifactHashId,
     ) -> Result<(u64, FetchReceiver), HttpError> {
         unimplemented!(
@@ -516,7 +521,7 @@ impl PeersImpl for MockReportPeers {
 
     async fn report_progress_impl(
         &self,
-        peer: SocketAddr,
+        peer: PeerAddress,
         update_id: Uuid,
         report: EventReport,
     ) -> Result<(), ClientError> {
@@ -598,10 +603,10 @@ mod tests {
                     async move {
                         Ok(Peers::new(
                             &reporter_log,
-                            Box::new(MockReportPeers::new(
+                            Box::new(MockReportPeers {
                                 update_id,
                                 report_sender,
-                            )),
+                            }),
                             // The timeout is currently unused by broadcast_report.
                             Duration::from_secs(10),
                         ))
@@ -620,7 +625,7 @@ mod tests {
                         let artifact =
                             fetch_artifact(&cx, &log, attempts, timeout)
                                 .await?;
-                        let address = artifact.addr;
+                        let address = artifact.peer.address();
                         StepSuccess::new(artifact)
                             .with_metadata(
                                 InstallinatorCompletionMetadata::Download {
@@ -652,21 +657,21 @@ mod tests {
             match (expected_result, fetched_artifact) {
                 (
                     Ok((expected_attempt, expected_addr)),
-                    Ok(FetchedArtifact { attempt, addr, mut artifact }),
+                    Ok(FetchedArtifact { attempt, peer, mut artifact }),
                 ) => {
                     assert_eq!(
                         expected_attempt, attempt,
                         "expected successful attempt is the same as actual attempt"
                     );
                     assert_eq!(
-                        expected_addr, addr,
+                        expected_addr, peer,
                         "expected successful peer is the same as actual peer"
                     );
                     let artifact = artifact.copy_to_bytes(artifact.num_bytes());
                     assert_eq!(
                         expected_artifact, artifact,
                         "correct artifact fetched from peer {}",
-                        addr,
+                        peer,
                     );
                 }
                 (Err(_), Err(_)) => {}
@@ -716,7 +721,7 @@ mod tests {
 
     fn assert_reports(
         reports: &[EventReport],
-        expected_result: Result<(usize, SocketAddr), usize>,
+        expected_result: Result<(usize, PeerAddress), usize>,
     ) {
         let all_step_events: Vec<_> =
             reports.iter().flat_map(|report| &report.step_events).collect();
@@ -740,7 +745,7 @@ mod tests {
     fn assert_success_events(
         all_step_events: Vec<&StepEvent>,
         expected_attempt: usize,
-        expected_addr: SocketAddr,
+        expected_peer: PeerAddress,
     ) {
         let mut saw_success = false;
 
@@ -753,7 +758,8 @@ mod tests {
                                 peer,
                             } => {
                                 assert_ne!(
-                                    *peer, expected_addr,
+                                    *peer,
+                                    expected_peer.address(),
                                     "peer cannot match since this is the last attempt"
                                 );
                             }
@@ -795,7 +801,8 @@ mod tests {
                             ..
                         } => {
                             assert_eq!(
-                                *address, expected_addr,
+                                *address,
+                                expected_peer.address(),
                                 "address matches expected"
                             );
                         }

--- a/installinator/src/peers.rs
+++ b/installinator/src/peers.rs
@@ -5,7 +5,7 @@
 use std::{
     fmt,
     future::Future,
-    net::{IpAddr, SocketAddr},
+    net::{AddrParseError, IpAddr, SocketAddr},
     str::FromStr,
     time::Duration,
 };
@@ -42,7 +42,7 @@ pub(crate) enum DiscoveryMechanism {
     Bootstrap,
 
     /// A list of peers is manually specified.
-    List(Vec<SocketAddr>),
+    List(Vec<PeerAddress>),
 }
 
 impl DiscoveryMechanism {
@@ -50,7 +50,7 @@ impl DiscoveryMechanism {
     pub(crate) async fn discover_peers(
         &self,
         log: &slog::Logger,
-    ) -> Result<Box<dyn PeersImpl>, DiscoverPeersError> {
+    ) -> Result<Vec<PeerAddress>, DiscoverPeersError> {
         let peers = match self {
             Self::Bootstrap => {
                 // XXX: consider adding aborts to this after a certain number of tries.
@@ -72,17 +72,17 @@ impl DiscoveryMechanism {
                     })?;
                 addrs
                     .map(|addr| {
-                        SocketAddr::new(
+                        PeerAddress::new(SocketAddr::new(
                             IpAddr::V6(addr),
                             BOOTSTRAP_ARTIFACT_PORT,
-                        )
+                        ))
                     })
                     .collect()
             }
             Self::List(peers) => peers.clone(),
         };
 
-        Ok(Box::new(HttpPeers::new(log, peers)))
+        Ok(peers)
     }
 }
 
@@ -121,7 +121,7 @@ impl FromStr for DiscoveryMechanism {
 /// A fetched artifact.
 pub(crate) struct FetchedArtifact {
     pub(crate) attempt: usize,
-    pub(crate) addr: SocketAddr,
+    pub(crate) peer: PeerAddress,
     pub(crate) artifact: BufList,
 }
 
@@ -176,8 +176,8 @@ impl FetchedArtifact {
                 peers.display(),
             );
             match peers.fetch_artifact(&cx, artifact_hash_id).await {
-                Some((addr, artifact)) => {
-                    return Ok(Self { attempt, addr, artifact });
+                Some((peer, artifact)) => {
+                    return Ok(Self { attempt, peer, artifact });
                 }
                 None => {
                     slog::warn!(
@@ -200,7 +200,7 @@ impl fmt::Debug for FetchedArtifact {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         f.debug_struct("FetchedArtifact")
             .field("attempt", &self.attempt)
-            .field("addr", &self.addr)
+            .field("peer", &self.peer)
             .field(
                 "artifact",
                 &format!(
@@ -234,7 +234,7 @@ impl Peers {
         &self,
         cx: &StepContext,
         artifact_hash_id: &ArtifactHashId,
-    ) -> Option<(SocketAddr, BufList)> {
+    ) -> Option<(PeerAddress, BufList)> {
         // TODO: do we want a check phase that happens before the download?
         let peers = self.peers();
         let mut remaining_peers = self.peer_count();
@@ -279,7 +279,7 @@ impl Peers {
         None
     }
 
-    pub(crate) fn peers(&self) -> impl Iterator<Item = SocketAddr> + '_ {
+    pub(crate) fn peers(&self) -> impl Iterator<Item = PeerAddress> + '_ {
         self.imp.peers()
     }
 
@@ -294,7 +294,7 @@ impl Peers {
     async fn fetch_from_peer(
         &self,
         cx: &StepContext,
-        peer: SocketAddr,
+        peer: PeerAddress,
         artifact_hash_id: &ArtifactHashId,
     ) -> Result<BufList, ArtifactFetchError> {
         let log = self.log.new(slog::o!("peer" => peer.to_string()));
@@ -307,17 +307,23 @@ impl Peers {
             Ok(x) => x,
             Err(error) => {
                 cx.send_progress(StepProgress::Reset {
-                    metadata: InstallinatorProgressMetadata::Download { peer },
+                    metadata: InstallinatorProgressMetadata::Download {
+                        peer: peer.address,
+                    },
                     message: error.to_string().into(),
                 })
                 .await;
-                return Err(ArtifactFetchError::HttpError { peer, error });
+                return Err(ArtifactFetchError::HttpError {
+                    peer: peer.address,
+                    error,
+                });
             }
         };
 
         let mut artifact_bytes = BufList::new();
         let mut downloaded_bytes = 0u64;
-        let metadata = InstallinatorProgressMetadata::Download { peer };
+        let metadata =
+            InstallinatorProgressMetadata::Download { peer: peer.address };
 
         loop {
             match tokio::time::timeout(self.timeout, receiver.recv()).await {
@@ -349,7 +355,7 @@ impl Peers {
                     })
                     .await;
                     return Err(ArtifactFetchError::HttpError {
-                        peer,
+                        peer: peer.address,
                         error: error.into(),
                     });
                 }
@@ -369,7 +375,7 @@ impl Peers {
                     })
                     .await;
                     return Err(ArtifactFetchError::Timeout {
-                        peer,
+                        peer: peer.address,
                         timeout: self.timeout,
                         bytes_fetched: artifact_bytes.num_bytes(),
                     });
@@ -406,7 +412,7 @@ impl Peers {
 
     async fn send_report_to_peer(
         &self,
-        peer: SocketAddr,
+        peer: PeerAddress,
         update_id: Uuid,
         report: EventReport,
     ) -> Result<(), ClientError> {
@@ -448,22 +454,53 @@ impl Peers {
 
 #[async_trait]
 pub(crate) trait PeersImpl: fmt::Debug + Send + Sync {
-    fn peers(&self) -> Box<dyn Iterator<Item = SocketAddr> + Send + '_>;
+    fn peers(&self) -> Box<dyn Iterator<Item = PeerAddress> + Send + '_>;
     fn peer_count(&self) -> usize;
 
     /// Returns (size, receiver) on success, and an error on failure.
     async fn fetch_from_peer_impl(
         &self,
-        peer: SocketAddr,
+        peer: PeerAddress,
         artifact_hash_id: ArtifactHashId,
     ) -> Result<(u64, FetchReceiver), HttpError>;
 
     async fn report_progress_impl(
         &self,
-        peer: SocketAddr,
+        peer: PeerAddress,
         update_id: Uuid,
         report: EventReport,
     ) -> Result<(), ClientError>;
+}
+
+#[derive(Clone, Copy, Debug, PartialEq, PartialOrd, Ord, Eq)]
+#[cfg_attr(test, derive(test_strategy::Arbitrary))]
+pub(crate) struct PeerAddress {
+    address: SocketAddr,
+}
+
+impl PeerAddress {
+    pub(crate) const fn new(address: SocketAddr) -> Self {
+        Self { address }
+    }
+
+    pub(crate) fn address(&self) -> SocketAddr {
+        self.address
+    }
+}
+
+impl fmt::Display for PeerAddress {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        self.address.fmt(f)
+    }
+}
+
+impl FromStr for PeerAddress {
+    type Err = AddrParseError;
+
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        let address = s.parse()?;
+        Ok(Self { address })
+    }
 }
 
 /// The send side of the channel over which data is sent.
@@ -473,11 +510,11 @@ pub(crate) type FetchReceiver = mpsc::Receiver<Result<Bytes, ClientError>>;
 #[derive(Clone, Debug)]
 pub(crate) struct HttpPeers {
     log: slog::Logger,
-    peers: Vec<SocketAddr>,
+    peers: Vec<PeerAddress>,
 }
 
 impl HttpPeers {
-    pub(crate) fn new(log: &slog::Logger, peers: Vec<SocketAddr>) -> Self {
+    pub(crate) fn new(log: &slog::Logger, peers: Vec<PeerAddress>) -> Self {
         let log = log.new(slog::o!("component" => "HttpPeers"));
         Self { log, peers }
     }
@@ -485,7 +522,7 @@ impl HttpPeers {
 
 #[async_trait]
 impl PeersImpl for HttpPeers {
-    fn peers(&self) -> Box<dyn Iterator<Item = SocketAddr> + Send + '_> {
+    fn peers(&self) -> Box<dyn Iterator<Item = PeerAddress> + Send + '_> {
         Box::new(self.peers.iter().copied())
     }
 
@@ -495,21 +532,21 @@ impl PeersImpl for HttpPeers {
 
     async fn fetch_from_peer_impl(
         &self,
-        peer: SocketAddr,
+        peer: PeerAddress,
         artifact_hash_id: ArtifactHashId,
     ) -> Result<(u64, FetchReceiver), HttpError> {
         // TODO: be able to fetch from sled-agent clients as well
-        let artifact_client = ArtifactClient::new(peer, &self.log);
+        let artifact_client = ArtifactClient::new(peer.address, &self.log);
         artifact_client.fetch(artifact_hash_id).await
     }
 
     async fn report_progress_impl(
         &self,
-        peer: SocketAddr,
+        peer: PeerAddress,
         update_id: Uuid,
         report: EventReport,
     ) -> Result<(), ClientError> {
-        let artifact_client = ArtifactClient::new(peer, &self.log);
+        let artifact_client = ArtifactClient::new(peer.address, &self.log);
         artifact_client.report_progress(update_id, report).await
     }
 }


### PR DESCRIPTION
Add a newtype wrapper to ensure that we aren't handling bare `SocketAddr`
instances.
