### PR TITLE
Update secrecy crate from 0.8 to 0.10.

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -920,7 +920,7 @@ dependencies = [
  "pq-sys",
  "proptest",
  "rand 0.8.5",
- "secrecy",
+ "secrecy 0.10.3",
  "serde",
  "serde_with",
  "sha3",
@@ -3689,7 +3689,7 @@ dependencies = [
  "omicron-workspace-hack",
  "proptest",
  "rand 0.8.5",
- "secrecy",
+ "secrecy 0.10.3",
  "serde",
  "subtle",
  "test-strategy",
@@ -5149,7 +5149,7 @@ dependencies = [
  "hkdf",
  "omicron-common",
  "omicron-workspace-hack",
- "secrecy",
+ "secrecy 0.10.3",
  "sha3",
  "slog",
  "thiserror 1.0.69",
@@ -10999,6 +10999,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "secrecy"
+version = "0.10.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e891af845473308773346dc847b2c23ee78fe442e0472ac50e22a18a93d3ae5a"
+dependencies = [
+ "zeroize",
+]
+
+[[package]]
 name = "security-framework"
 version = "2.11.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -11836,7 +11845,7 @@ dependencies = [
  "libipcc",
  "pem-rfc7468",
  "rustls 0.23.19",
- "secrecy",
+ "secrecy 0.8.0",
  "serde",
  "sha2",
  "sha3",
@@ -13024,7 +13033,7 @@ dependencies = [
  "omicron-workspace-hack",
  "proptest",
  "rand 0.8.5",
- "secrecy",
+ "secrecy 0.10.3",
  "serde",
  "serde_with",
  "sha3",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -634,7 +634,7 @@ rustyline = "14.0.0"
 samael = { version = "0.0.18", features = ["xmlsec"] }
 schemars = "0.8.22"
 scopeguard = "1.2.0"
-secrecy = "0.8.0"
+secrecy = "0.10.0"
 semver = { version = "1.0.25", features = ["std", "serde"] }
 serde = { version = "1.0", default-features = false, features = [ "derive", "rc" ] }
 serde_human_bytes = { git = "https://github.com/oxidecomputer/serde_human_bytes", branch = "main" }

--- a/bootstore/src/schemes/v0/share_pkg.rs
+++ b/bootstore/src/schemes/v0/share_pkg.rs
@@ -9,7 +9,7 @@ use crate::trust_quorum::{RackSecret, TrustQuorumError};
 use chacha20poly1305::{ChaCha20Poly1305, Key, KeyInit, aead::Aead};
 use hkdf::Hkdf;
 use rand::{RngCore, rngs::OsRng};
-use secrecy::{ExposeSecret, Secret};
+use secrecy::{ExposeSecret, SecretBox};
 use serde::{Deserialize, Serialize};
 use sha3::{Digest, Sha3_256};
 use sled_hardware_types::Baseboard;
@@ -94,7 +94,7 @@ impl SharePkg {
     pub fn decrypt_shares(
         &self,
         rack_secret: &RackSecret,
-    ) -> Result<Secret<Vec<Vec<u8>>>, TrustQuorumError> {
+    ) -> Result<SecretBox<Vec<Vec<u8>>>, TrustQuorumError> {
         let cipher = derive_encryption_key(
             &self.common.rack_uuid,
             &rack_secret,
@@ -117,7 +117,7 @@ pub struct LearnedSharePkg {
 pub fn create_pkgs(
     rack_uuid: Uuid,
     initial_membership: BTreeSet<Baseboard>,
-) -> Result<Secret<Vec<SharePkg>>, TrustQuorumError> {
+) -> Result<SecretBox<Vec<SharePkg>>, TrustQuorumError> {
     // There are only up to 32 sleds in a rack.
     let n = u8::try_from(initial_membership.len()).unwrap();
     let rack_secret = RackSecret::new();
@@ -141,8 +141,8 @@ pub fn create_pkgs(
             .take(shares_per_sled);
         let share = iter.next().unwrap();
         let plaintext_len = (shares_per_sled - 1) * SHARE_SIZE;
-        let plaintext: Secret<Vec<u8>> = Secret::new(iter.fold(
-            Vec::with_capacity(plaintext_len),
+        let plaintext: SecretBox<Vec<u8>> = SecretBox::new(iter.fold(
+            Box::new(Vec::with_capacity(plaintext_len)),
             |mut acc, x| {
                 acc.extend_from_slice(x);
                 acc
@@ -170,7 +170,7 @@ pub fn create_pkgs(
         };
         pkgs.push(pkg);
     }
-    Ok(Secret::new(pkgs))
+    Ok(SecretBox::new(Box::new(pkgs)))
 }
 
 // This is a fairly standard nonce construction consisting of a random part and
@@ -186,7 +186,7 @@ fn new_nonce(i: u8) -> [u8; 12] {
     nonce
 }
 
-fn share_digests(shares: &Secret<Vec<Vec<u8>>>) -> BTreeSet<Sha3_256Digest> {
+fn share_digests(shares: &SecretBox<Vec<Vec<u8>>>) -> BTreeSet<Sha3_256Digest> {
     shares
         .expose_secret()
         .iter()
@@ -223,15 +223,15 @@ fn decrypt_shares(
     nonce: [u8; 12],
     cipher: &ChaCha20Poly1305,
     ciphertext: &[u8],
-) -> Result<Secret<Vec<Vec<u8>>>, TrustQuorumError> {
+) -> Result<SecretBox<Vec<Vec<u8>>>, TrustQuorumError> {
     let plaintext = Zeroizing::new(
         cipher
             .decrypt((&nonce).into(), ciphertext)
             .map_err(|_| TrustQuorumError::FailedToDecrypt)?,
     );
-    Ok(Secret::new(
+    Ok(SecretBox::new(Box::new(
         plaintext.chunks(SHARE_SIZE).map(|share| share.into()).collect(),
-    ))
+    )))
 }
 
 // We don't want to risk debug-logging the actual share contents, so implement

--- a/bootstore/src/schemes/v0/share_pkg.rs
+++ b/bootstore/src/schemes/v0/share_pkg.rs
@@ -141,13 +141,13 @@ pub fn create_pkgs(
             .take(shares_per_sled);
         let share = iter.next().unwrap();
         let plaintext_len = (shares_per_sled - 1) * SHARE_SIZE;
-        let plaintext: SecretBox<Vec<u8>> = SecretBox::new(iter.fold(
-            Box::new(Vec::with_capacity(plaintext_len)),
-            |mut acc, x| {
+        let plaintext: SecretBox<[u8]> = SecretBox::new(
+            iter.fold(Vec::with_capacity(plaintext_len), |mut acc, x| {
                 acc.extend_from_slice(x);
                 acc
-            },
-        ));
+            })
+            .into_boxed_slice(),
+        );
         let nonce = new_nonce(i);
         let encrypted_shares = cipher
             .encrypt((&nonce).into(), plaintext.expose_secret().as_ref())


### PR DESCRIPTION
This updates the `secrecy` crate from 0.8 to 0.10, which is a breaking change causing some the shape of some of the code using it.

There is a Box<Vec<T>> in a spot or two now, which looked like it could maybe just be a boxed slice instead, but I'm not sure.