### PR TITLE
Trust quorum: reconfiguration and commit behavior

### DIFF
--- a/trust-quorum/src/errors.rs
+++ b/trust-quorum/src/errors.rs
@@ -1,0 +1,103 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at https://mozilla.org/MPL/2.0/.
+
+//! Various errors for the trust quorum APIs
+
+use crate::configuration::ConfigurationError;
+use crate::{Epoch, PlatformId, Threshold};
+use omicron_uuid_kinds::RackUuid;
+
+#[derive(Debug, Clone, thiserror::Error, PartialEq, Eq)]
+pub enum CommitError {
+    #[error("invalid rack id")]
+    InvalidRackId(
+        #[from]
+        #[source]
+        MismatchedRackIdError,
+    ),
+
+    #[error("missing prepare msg")]
+    MissingPrepare,
+
+    #[error("prepare for a later configuration exists")]
+    OutOfOrderCommit,
+}
+
+#[derive(Debug, Clone, thiserror::Error, PartialEq, Eq)]
+#[error(
+    "sled was decommissioned on msg from {from:?} at epoch {epoch:?}: last prepared epoch = {last_prepared_epoch:?}"
+)]
+pub struct SledDecommissionedError {
+    pub from: PlatformId,
+    pub epoch: Epoch,
+    pub last_prepared_epoch: Option<Epoch>,
+}
+
+#[derive(Debug, Clone, thiserror::Error, PartialEq, Eq)]
+#[error("mismatched rack id: expected {expected:?}, got {got:?}")]
+pub struct MismatchedRackIdError {
+    pub expected: RackUuid,
+    pub got: RackUuid,
+}
+
+#[derive(Debug, Clone, thiserror::Error, PartialEq, Eq)]
+pub enum ReconfigurationError {
+    #[error("reconfiguration coordinator must be a member of the new group")]
+    CoordinatorMustBeAMemberOfNewGroup,
+
+    #[error("upgrade from LRTQ required")]
+    UpgradeFromLrtqRequired,
+
+    #[error(
+        "number of members: {num_members:?} must be greater than threshold: {threshold:?}"
+    )]
+    ThresholdMismatch { num_members: usize, threshold: Threshold },
+
+    #[error(
+        "invalid membership size: {0:?}: must be between 3 and 32 inclusive"
+    )]
+    InvalidMembershipSize(usize),
+
+    #[error(
+        "invalid threshold: {0:?}: threshold must be between 2 and 31 inclusive"
+    )]
+    InvalidThreshold(Threshold),
+
+    #[error(
+        "Node has last committed epoch of {node_epoch:?}, message contains {msg_epoch:?}"
+    )]
+    LastCommittedEpochMismatch {
+        node_epoch: Option<Epoch>,
+        msg_epoch: Option<Epoch>,
+    },
+
+    #[error(
+        "sled has already prepared a request at epoch {existing:?}, and cannot prepare another at a smaller or equivalent epoch {new:?}"
+    )]
+    PreparedEpochMismatch { existing: Epoch, new: Epoch },
+
+    #[error("invalid rack id in reconfigure msg")]
+    InvalidRackId(
+        #[from]
+        #[source]
+        MismatchedRackIdError,
+    ),
+
+    #[error("cannot reconfigure a decommissioned sled")]
+    DecommissionedSled(
+        #[from]
+        #[source]
+        SledDecommissionedError,
+    ),
+    #[error(
+        "reconfiguration in progress at epoch {current_epoch:?}: cannot reconfigure for older epoch {msg_epoch:?}"
+    )]
+    ReconfigurationInProgress { current_epoch: Epoch, msg_epoch: Epoch },
+
+    #[error("mismatched reconfiguration requests for epoch {0:?}")]
+    MismatchedReconfigurationForSameEpoch(Epoch),
+
+    #[error(transparent)]
+    Configuration(#[from] ConfigurationError),
+}

--- a/trust-quorum/src/lib.rs
+++ b/trust-quorum/src/lib.rs
@@ -15,6 +15,7 @@ use serde::{Deserialize, Serialize};
 mod configuration;
 mod coordinator_state;
 pub(crate) mod crypto;
+pub(crate) mod errors;
 mod messages;
 mod node;
 mod persistent_state;
@@ -39,6 +40,13 @@ pub use persistent_state::{PersistentState, PersistentStateSummary};
     Display,
 )]
 pub struct Epoch(pub u64);
+
+impl Epoch {
+    // Increment the epoch and return the new value
+    pub fn inc(&self) -> Epoch {
+        Epoch(self.0 + 1)
+    }
+}
 
 /// The number of shares required to reconstruct the rack secret
 ///

--- a/trust-quorum/src/validators.rs
+++ b/trust-quorum/src/validators.rs
@@ -4,7 +4,9 @@
 
 //! Various validation functions to be used by a [`crate::Node`]
 
-use crate::configuration::ConfigurationError;
+use crate::errors::{
+    MismatchedRackIdError, ReconfigurationError, SledDecommissionedError,
+};
 use crate::messages::ReconfigureMsg;
 use crate::{Epoch, PersistentStateSummary, PlatformId, Threshold};
 use omicron_uuid_kinds::RackUuid;
@@ -42,84 +44,6 @@ fn check_in_service(
     }
 
     Ok(())
-}
-
-#[derive(Debug, Clone, thiserror::Error, PartialEq, Eq)]
-#[error(
-    "sled was decommissioned on msg from {from:?} at epoch {epoch:?}: last prepared epoch = {last_prepared_epoch:?}"
-)]
-pub struct SledDecommissionedError {
-    from: PlatformId,
-    epoch: Epoch,
-    last_prepared_epoch: Option<Epoch>,
-}
-
-#[derive(Debug, Clone, thiserror::Error, PartialEq, Eq)]
-#[error("mismatched rack id: expected {expected:?}, got {got:?}")]
-pub struct MismatchedRackIdError {
-    pub expected: RackUuid,
-    pub got: RackUuid,
-}
-
-#[derive(Debug, Clone, thiserror::Error, PartialEq, Eq)]
-pub enum ReconfigurationError {
-    #[error("reconfiguration coordinator must be a member of the new group")]
-    CoordinatorMustBeAMemberOfNewGroup,
-
-    #[error("upgrade from LRTQ required")]
-    UpgradeFromLrtqRequired,
-
-    #[error(
-        "number of members: {num_members:?} must be greater than threshold: {threshold:?}"
-    )]
-    ThresholdMismatch { num_members: usize, threshold: Threshold },
-
-    #[error(
-        "invalid membership size: {0:?}: must be between 3 and 32 inclusive"
-    )]
-    InvalidMembershipSize(usize),
-
-    #[error(
-        "invalid threshold: {0:?}: threshold must be between 2 and 31 inclusive"
-    )]
-    InvalidThreshold(Threshold),
-
-    #[error(
-        "Node has last committed epoch of {node_epoch:?}, message contains {msg_epoch:?}"
-    )]
-    LastCommittedEpochMismatch {
-        node_epoch: Option<Epoch>,
-        msg_epoch: Option<Epoch>,
-    },
-
-    #[error(
-        "sled has already prepared a request at epoch {existing:?}, and cannot prepare another at a smaller or equivalent epoch {new:?}"
-    )]
-    PreparedEpochMismatch { existing: Epoch, new: Epoch },
-
-    #[error("invalid rack id in reconfigure msg")]
-    InvalidRackId(
-        #[from]
-        #[source]
-        MismatchedRackIdError,
-    ),
-
-    #[error("cannot reconfigure a decommissioned sled")]
-    DecommissionedSled(
-        #[from]
-        #[source]
-        SledDecommissionedError,
-    ),
-    #[error(
-        "reconfiguration in progress at epoch {current_epoch:?}: cannot reconfigure for older epoch {msg_epoch:?}"
-    )]
-    ReconfigurationInProgress { current_epoch: Epoch, msg_epoch: Epoch },
-
-    #[error("mismatched reconfiguration requests for epoch {0:?}")]
-    MismatchedReconfigurationForSameEpoch(Epoch),
-
-    #[error(transparent)]
-    Configuration(#[from] ConfigurationError),
 }
 
 /// A `ReconfigureMsg` that has been determined to be valid for the remainder

--- a/trust-quorum/tests/coordinator.rs
+++ b/trust-quorum/tests/coordinator.rs
@@ -6,6 +6,7 @@
 
 use assert_matches::assert_matches;
 use bcs::Result;
+use gfss::shamir::Share;
 use omicron_test_utils::dev::test_setup_log;
 use omicron_uuid_kinds::RackUuid;
 use prop::sample::Index;
@@ -49,6 +50,9 @@ impl Sut {
 /// the SUT node itself to understand external events like messages that got
 /// sent in response to a tick.
 pub struct Model {
+    // A copy of our id
+    pub id: PlatformId,
+
     /// The current time
     pub now: Instant,
 
@@ -60,8 +64,9 @@ pub struct Model {
 }
 
 impl Model {
-    pub fn new() -> Model {
+    pub fn new(coordinator_id: PlatformId) -> Model {
         Model {
+            id: coordinator_id,
             now: Instant::now(),
             last_committed_config_msg: None,
             coordinator_state: None,
@@ -91,11 +96,9 @@ impl Model {
         // We don't currently collect LRTQ shares. This conditional
         // will have to be more specific when we do.
         let op = if self.last_committed_config_msg.is_some() {
-            ModelCoordinatorOp::CollectShares {
-                collected_from: BTreeSet::new(),
-            }
+            ModelCoordinatorOp::new_collect_shares(self.id.clone())
         } else {
-            ModelCoordinatorOp::Prepare { acked: BTreeSet::new() }
+            ModelCoordinatorOp::new_prepare(self.id.clone())
         };
 
         self.coordinator_state = Some(ModelCoordinatorState {
@@ -103,6 +106,11 @@ impl Model {
             retry_deadline: self.now + Duration::from_millis(RETRY_TIMEOUT_MS),
             op,
         });
+    }
+
+    pub fn commit(&mut self, msg: ReconfigureMsg) {
+        self.last_committed_config_msg = Some(msg);
+        self.coordinator_state = None;
     }
 
     // If we are currently preparing this epoch then record the ack
@@ -114,12 +122,112 @@ impl Model {
         }
     }
 
+    /// If we are currently waiting for shares in this epoch then record the
+    /// responder.
+    ///
+    /// If we've received enough shares to recompute the rack secret then
+    /// transition the model operation to `Prepare` and return `Ok(true)`.
+    pub fn handle_share(
+        &mut self,
+        from: PlatformId,
+        epoch: Epoch,
+    ) -> Result<bool, TestCaseError> {
+        let Some(last_committed_config_msg) = &self.last_committed_config_msg
+        else {
+            return Ok(false);
+        };
+        let Some(cs) = &mut self.coordinator_state else {
+            return Ok(false);
+        };
+
+        // Make sure our model state is consistent
+        prop_assert_eq!(
+            Some(last_committed_config_msg.epoch),
+            cs.msg.last_committed_epoch
+        );
+
+        // Record the share
+        if last_committed_config_msg.epoch == epoch {
+            cs.op.handle_share(from);
+        }
+
+        // Do we have a threshold of shares? If so, we should transition our
+        // operation to `Prepare`.
+        if cs.op.collected_shares().unwrap_or(&BTreeSet::new()).len()
+            == last_committed_config_msg.threshold.0 as usize
+        {
+            cs.op = ModelCoordinatorOp::new_prepare(self.id.clone());
+            return Ok(true);
+        }
+
+        Ok(false)
+    }
+
     /// Return nodes that have acked prepares for an ongoing coordination
     /// by the Model.
     ///
     /// Return `None` if the SUT is not currently coordinating or waiting on acks.
     pub fn acked_prepares(&self) -> Option<&BTreeSet<PlatformId>> {
         self.coordinator_state.as_ref().and_then(|cs| cs.op.acked_prepares())
+    }
+
+    /// Return the nodes that we are waiting for prepare acknowledgements from
+    pub fn waiting_for_prepare_acks_from(
+        &self,
+    ) -> Option<BTreeSet<PlatformId>> {
+        // We need to actually be coordinating to wait for shares
+        let Some(cs) = &self.coordinator_state else {
+            return None;
+        };
+        // We need to actually be waiting for acks
+        let Some(acked_prepares) = self
+            .coordinator_state
+            .as_ref()
+            .and_then(|cs| cs.op.acked_prepares())
+        else {
+            return None;
+        };
+
+        // Return all members of the current configuration that haven't acked a
+        // `PrepareMsg` yet. Exclude ourself.
+
+        let mut waiting_for: BTreeSet<_> =
+            cs.msg.members.difference(acked_prepares).cloned().collect();
+        waiting_for.remove(&self.id);
+        Some(waiting_for)
+    }
+
+    // Return the nodes that we are waiting for shares from
+    pub fn waiting_for_shares_from(&self) -> Option<BTreeSet<PlatformId>> {
+        // We only wait for shares if we have a prior committed config
+        let Some(last_committed_config_msg) = &self.last_committed_config_msg
+        else {
+            return None;
+        };
+        // We need to actually be coordinating to wait for shares
+        let Some(cs) = &self.coordinator_state else {
+            return None;
+        };
+        // We need to actually be collecting shares as a coordinator
+        let Some(collected_from) = cs.op.collected_shares() else {
+            return None;
+        };
+
+        // Return all members of the last committed configuration that we
+        // haven't received a share from yet. Exclude ourself.
+
+        let mut waiting_for: BTreeSet<_> = last_committed_config_msg
+            .members
+            .difference(collected_from)
+            .cloned()
+            .collect();
+        waiting_for.remove(&self.id);
+        Some(waiting_for)
+    }
+
+    // Return the current epoch being coordinated, if there is one
+    fn coordinating_epoch(&self) -> Option<Epoch> {
+        self.coordinator_state.as_ref().map(|cs| cs.msg.epoch)
     }
 
     /// Return the members of the current reconfiguration being coordinated.
@@ -149,6 +257,20 @@ pub enum ModelCoordinatorOp {
 }
 
 impl ModelCoordinatorOp {
+    pub fn new_collect_shares(ourself: PlatformId) -> Self {
+        ModelCoordinatorOp::CollectShares {
+            // Always include ourself
+            collected_from: BTreeSet::from([ourself]),
+        }
+    }
+
+    pub fn new_prepare(ourself: PlatformId) -> Self {
+        ModelCoordinatorOp::Prepare {
+            // Always include ourself
+            acked: BTreeSet::from([ourself]),
+        }
+    }
+
     pub fn ack_prepare(&mut self, from: PlatformId) {
         if let ModelCoordinatorOp::Prepare { acked } = self {
             acked.insert(from);
@@ -162,6 +284,32 @@ impl ModelCoordinatorOp {
             None
         }
     }
+
+    pub fn handle_share(&mut self, from: PlatformId) {
+        if let ModelCoordinatorOp::CollectShares { collected_from } = self {
+            collected_from.insert(from);
+        }
+    }
+
+    pub fn collected_shares(&self) -> Option<&BTreeSet<PlatformId>> {
+        if let ModelCoordinatorOp::CollectShares { collected_from } = self {
+            Some(collected_from)
+        } else {
+            None
+        }
+    }
+
+    pub fn is_collecting_shares(&self) -> bool {
+        matches!(self, ModelCoordinatorOp::CollectShares { .. })
+    }
+
+    pub fn is_collecting_lrtq_shares(&self) -> bool {
+        matches!(self, ModelCoordinatorOp::CollectLrtqShares { .. })
+    }
+
+    pub fn is_preparing(&self) -> bool {
+        matches!(self, ModelCoordinatorOp::Prepare { .. })
+    }
 }
 
 // The test itself maintains an internal state that includes not only the state
@@ -169,36 +317,68 @@ impl ModelCoordinatorOp {
 // tests via `Action`s.
 struct TestState {
     /// Our system under test
-    pub sut: Sut,
+    sut: Sut,
 
     /// The abstract model of our SUT
-    pub model: Model,
+    model: Model,
 
     // All in flight messages to nodes that are not the SUT
-    pub network_msgs: BTreeMap<PlatformId, Vec<PeerMsg>>,
+    network_msgs: BTreeMap<PlatformId, Vec<PeerMsg>>,
 
     // Messages delivered to each node that is not the SUT
-    pub delivered_msgs: BTreeMap<PlatformId, Vec<PeerMsg>>,
+    delivered_msgs: BTreeMap<PlatformId, Vec<PeerMsg>>,
+
+    // Shares delivered to nodes that are not the SUT.
+    //
+    // We track these so that we can implement replies for `GetShare` messages.
+    delivered_shares: BTreeMap<(Epoch, PlatformId), Share>,
+
+    // A cache of our member universe, so we only have to generate it once
+    member_universe: Vec<PlatformId>,
+
+    // The last epoch for a `PrepareMsg` sent by Nexus
+    // In production this is stored in CRDB, but it is simulated here
+    highest_prepared_epoch: Epoch,
+
+    // We reuse the same coordinator ID across all test runs
+    // There's no reason to randomize it.
+    coordinator_id: PlatformId,
+
+    // No reason to change the rack_id
+    rack_id: RackUuid,
 }
 
 impl TestState {
-    pub fn new(log: Logger, coordinator_id: PlatformId) -> TestState {
+    pub fn new(log: Logger) -> TestState {
+        let member_universe = member_universe();
+        let coordinator_id = member_universe[0].clone();
         TestState {
             sut: Sut {
-                node: Node::new(log, coordinator_id, PersistentState::empty()),
+                node: Node::new(
+                    log,
+                    coordinator_id.clone(),
+                    PersistentState::empty(),
+                ),
                 persistent_state: PersistentState::empty(),
             },
-            model: Model::new(),
+            model: Model::new(coordinator_id.clone()),
             network_msgs: BTreeMap::new(),
             delivered_msgs: BTreeMap::new(),
+            delivered_shares: BTreeMap::new(),
+            member_universe,
+            highest_prepared_epoch: Epoch(0),
+            coordinator_id,
+            rack_id: RackUuid::new_v4(),
         }
     }
 
     pub fn action_coordinate_reconfiguration(
         &mut self,
-        msg: ReconfigureMsg,
+        generated_config: GeneratedConfiguration,
     ) -> Result<(), TestCaseError> {
         let mut outbox = Vec::new();
+
+        let msg = self.generated_config_to_reconfigure_msg(generated_config);
 
         // Update the model state
         self.model.action_coordinate_reconfiguration(msg.clone());
@@ -233,9 +413,15 @@ impl TestState {
                 self.send(outbox.into_iter());
             }
             None => {
-                // The request is idempotent
-                // No action should have been taken
-                prop_assert!(outbox.is_empty());
+                // This is a reconfiguration, so before a `PersistentState`
+                // is returned we must collect share for the last committed
+                // configuration.
+                self.assert_envelopes_after_coordinate_reconfiguration(
+                    &outbox,
+                )?;
+
+                // We validated our messages. Let's put them into our test state as "in-flight".
+                self.send(outbox.into_iter());
             }
         }
 
@@ -252,11 +438,20 @@ impl TestState {
                 Action::DeliverMsgs(indices) => {
                     self.action_deliver_msgs(indices);
                 }
+                Action::DropMessages(indices) => {
+                    self.action_drop_msgs(indices);
+                }
                 Action::Reply(indices) => {
                     self.action_reply(indices)?;
                 }
                 Action::Tick(time_jump) => {
                     self.action_tick(time_jump)?;
+                }
+                Action::Commit(index) => {
+                    self.action_commit(index)?;
+                }
+                Action::CoordinateReconfiguration(generated_config) => {
+                    self.action_coordinate_reconfiguration(generated_config)?;
                 }
             }
         }
@@ -273,9 +468,33 @@ impl TestState {
         for index in indices {
             let id = index.get(&destinations);
             if let Some(msg) = self.network_msgs.get_mut(id).unwrap().pop() {
+                // If the message is a `Prepare`, also save its share so we can
+                // reply to `GetShare` messages.
+                if let PeerMsg::Prepare(prepare) = &msg {
+                    self.delivered_shares.insert(
+                        (prepare.config.epoch, id.clone()),
+                        prepare.share.clone(),
+                    );
+                }
                 let msgs = self.delivered_msgs.entry(id.clone()).or_default();
                 msgs.push(msg);
             }
+        }
+
+        // Remove any destinations with zero messages in-flight
+        self.network_msgs.retain(|_, msgs| !msgs.is_empty());
+    }
+
+    // Drop network messages destined for generated destinations
+    fn action_drop_msgs(&mut self, indices: Vec<Index>) {
+        let destinations: Vec<_> = self.network_msgs.keys().cloned().collect();
+        if destinations.is_empty() {
+            // nothing to do
+            return;
+        }
+        for index in indices {
+            let id = index.get(&destinations);
+            let _ = self.network_msgs.get_mut(id).unwrap().pop();
         }
 
         // Remove any destinations with zero messages in-flight
@@ -303,6 +522,9 @@ impl TestState {
                     PeerMsg::Prepare(prepare_msg) => {
                         self.reply_to_prepare_msg(from.clone(), prepare_msg)?;
                     }
+                    PeerMsg::GetShare(epoch) => {
+                        self.reply_to_get_share_msg(from.clone(), epoch)?;
+                    }
                     _ => todo!(),
                 }
             }
@@ -327,33 +549,140 @@ impl TestState {
         // If time has advanced past the coordinator's retry deadline
         // then we must see if we expected any retries to be sent.
         if timer_expired {
-            // Get the members of the current configuration being coordinated
-            let members = self.model.active_reconfiguration_members();
-
-            // We aren't coordinating
-            if members.is_empty() {
-                prop_assert!(outbox.is_empty());
-                return Ok(());
-            }
-
-            if let Some(acked_members) = self.model.acked_prepares() {
-                // We expect retries for all members that the coordinator
-                // has not received acks for.
-                let expected: BTreeSet<_> =
-                    members.difference(acked_members).collect();
-                for envelope in &outbox {
-                    prop_assert!(expected.contains(&envelope.to));
-                }
-            } else {
-                // We aren't waiting on acks, so won't retry sending prepares
-                prop_assert!(outbox.is_empty());
-            }
+            self.assert_expected_outgoing_envelopes(&outbox)?;
         }
 
         // Put any output messages onto the network
         self.send(outbox.into_iter());
 
         Ok(())
+    }
+
+    fn assert_expected_outgoing_envelopes(
+        &self,
+        outbox: &[Envelope],
+    ) -> Result<(), TestCaseError> {
+        if let Some(expected) = self.model.waiting_for_prepare_acks_from() {
+            for envelope in outbox {
+                assert_matches!(envelope.msg, PeerMsg::Prepare(_));
+                prop_assert!(expected.contains(&envelope.to));
+            }
+            // We are only sending either `Prepare` or `GetShare` variants, not both.
+            return Ok(());
+        }
+
+        if let Some(expected) = self.model.waiting_for_shares_from() {
+            for envelope in outbox {
+                assert_matches!(envelope.msg, PeerMsg::GetShare(_));
+                prop_assert!(expected.contains(&envelope.to));
+            }
+        }
+
+        Ok(())
+    }
+
+    // Precondition: Nexus will only actually commit if enough nodes
+    // have acked the `PrepareMsg` from the coordinator. Let's simulate
+    // that by checking our model state.
+    //
+    // Return `Some(reconfigure_msg)` if Nexus would decide to commit, `None` otherwise.
+    fn action_commit_precondition(
+        &mut self,
+        index: Index,
+    ) -> Option<ReconfigureMsg> {
+        // If we aren't currently coordinating, then just return as there's no
+        // configuration to commit.
+        let Some(cs) = &self.model.coordinator_state else {
+            return None;
+        };
+
+        // Compute the safety threshold used by nexus
+        // Nexus will choose a constant, but we vary it because we can.
+        let max_possible_z = cs.msg.members.len() - cs.msg.threshold.0 as usize;
+        let z =
+            if max_possible_z == 0 { 0 } else { index.index(max_possible_z) };
+
+        // We can only commit when the coordinator has seen a `PrepareAck` from
+        // K + Z nodes.
+        //
+        // Justification:  The coordinator does not know what `Z` is and cannot
+        // know if it has seen enough acks to know if it's safe to commit, so
+        // nexus must not try. Furthermore, Nexus informs non-coordinator nodes
+        // when to commit and they have no way to know if enough nodes have
+        // shares as a result of receiving `PrepareMsg`s. Because of this, we
+        // rely on Nexus to reliably uphold this correctness invariant, and
+        // simulate it in the test.
+        let acked = cs.op.acked_prepares().map(|s| s.len()).unwrap_or(0);
+        if acked >= cs.msg.threshold.0 as usize + z {
+            Some(cs.msg.clone())
+        } else {
+            None
+        }
+    }
+
+    fn action_commit(&mut self, index: Index) -> Result<(), TestCaseError> {
+        let Some(msg) = self.action_commit_precondition(index) else {
+            // We failed our precondition check. This isn't a test failure. It
+            // just means that the coordinator is not ready to commit.
+            return Ok(());
+        };
+
+        // Commit the configuration at our node
+        let persistent_state = self
+            .sut
+            .node
+            .commit_reconfiguration(msg.epoch, msg.rack_id)?
+            .expect("persistent state has been updated");
+
+        // Check the output of the persistent state
+        self.assert_persistent_state_after_commit_reconfiguration(
+            msg.epoch,
+            &persistent_state,
+        )?;
+
+        // Save the persistent state
+        self.sut.persistent_state = persistent_state;
+
+        // Update our model state
+        self.model.commit(msg);
+
+        Ok(())
+    }
+
+    fn generated_config_to_reconfigure_msg(
+        &mut self,
+        config: GeneratedConfiguration,
+    ) -> ReconfigureMsg {
+        let mut members: BTreeSet<PlatformId> = config
+            .members
+            .iter()
+            .map(|index| self.member_universe[*index].clone())
+            .collect();
+
+        // Ensure that the configuration always includes the coordinator
+        members.insert(self.coordinator_id.clone());
+
+        let threshold = Threshold(usize::max(
+            2,
+            config.threshold.index(members.len()),
+        ) as u8);
+
+        // Increment the epoch for this configuration. This simulates what Nexus
+        // would do.
+        self.highest_prepared_epoch = self.highest_prepared_epoch.inc();
+
+        ReconfigureMsg {
+            rack_id: self.rack_id,
+            epoch: self.highest_prepared_epoch,
+            last_committed_epoch: self
+                .model
+                .last_committed_config_msg
+                .as_ref()
+                .map(|msg| msg.epoch),
+            members,
+            threshold,
+            retry_timeout: Duration::from_millis(RETRY_TIMEOUT_MS),
+        }
     }
 
     fn reply_to_prepare_msg(
@@ -384,9 +713,86 @@ impl TestState {
 
         // Ensure that if the SUT is waiting for prepares, that the ack
         // is accounted for.
-        if let Some(acks) = self.model.acked_prepares() {
-            prop_assert!(acks.contains(&from));
+        //
+        // We only perform this check if this reply is for the current epoch
+        if self.model.coordinating_epoch() == Some(msg.config.epoch) {
+            if let Some(acks) = self.model.acked_prepares() {
+                prop_assert!(acks.contains(&from));
+            }
         }
+
+        Ok(())
+    }
+
+    fn reply_to_get_share_msg(
+        &mut self,
+        from: PlatformId,
+        epoch: Epoch,
+    ) -> Result<(), TestCaseError> {
+        // If we have a share, then return it. Otherwise return nothing.
+        // In the future we may implement other behaviors.
+        let Some(share) = self.delivered_shares.get(&(epoch, from.clone()))
+        else {
+            return Ok(());
+        };
+        let reply = PeerMsg::Share { epoch, share: share.clone() };
+        let mut outbox = Vec::new();
+        let output = self.sut.node.handle(
+            self.model.now,
+            &mut outbox,
+            from.clone(),
+            reply,
+        );
+
+        // If we just received a threshold number of shares, we expect
+        // reconstruction of the rack secret for the last committed
+        // configuration and the SUT to start sending prepare messages. As part
+        // of this transition the persistent state with the SUT's own latest
+        // `PrepareMsg` is also returned.
+        let start_preparing = self.model.handle_share(from.clone(), epoch)?;
+        if start_preparing {
+            // We just transitioned to preparing
+            let Some(persistent_state) = output else {
+                return Err(TestCaseError::fail(
+                    "Persistent state should exist",
+                ));
+            };
+
+            // The same checks should hold.
+            // TODO: Perhaps we should rename this method.
+            self.assert_persistent_state_after_coordinate_reconfiguration(
+                &persistent_state,
+            )?;
+
+            // We validated our persistent state is correct. Save it and move
+            // on.
+            self.sut.persistent_state = persistent_state;
+        }
+
+        self.assert_expected_outgoing_envelopes(&outbox)?;
+
+        self.send(outbox.into_iter());
+
+        Ok(())
+    }
+
+    /// Ensure that the output of `Node::commit_reconfiguration` is valid
+    /// given the test state.
+    fn assert_persistent_state_after_commit_reconfiguration(
+        &self,
+        epoch: Epoch,
+        persistent_state: &PersistentState,
+    ) -> Result<(), TestCaseError> {
+        // We should have one new commit for epoch: Epoch
+        prop_assert_eq!(
+            self.sut.persistent_state.commits.len() + 1,
+            persistent_state.commits.len()
+        );
+        assert!(!self.sut.persistent_state.commits.contains(&epoch));
+        assert!(persistent_state.commits.contains(&epoch));
+
+        // The SUT node should no longer be coordinating
+        assert!(self.sut.node.get_coordinator_state().is_none());
 
         Ok(())
     }
@@ -409,6 +815,7 @@ impl TestState {
             ))?
             .msg;
 
+        // TODO: This will have to change once we start supporting LRTQ
         prop_assert!(persistent_state.lrtq.is_none());
         prop_assert_eq!(
             &sut.persistent_state.commits,
@@ -447,37 +854,58 @@ impl TestState {
         outbox: &[Envelope],
     ) -> Result<(), TestCaseError> {
         let sut = &self.sut;
-        let msg = &self
-            .model
-            .coordinator_state
-            .as_ref()
-            .ok_or(TestCaseError::fail(
-                "Model should have a coordinator state",
-            ))?
-            .msg;
-
-        let config = sut.persistent_state.configuration(msg.epoch).unwrap();
-
-        // Ensure the members of the configuration match the model msg
-        prop_assert_eq!(
-            &msg.members,
-            &config.members.keys().cloned().collect()
-        );
+        let model_cs = &self.model.coordinator_state.as_ref().ok_or(
+            TestCaseError::fail("Model should have a coordinator state"),
+        )?;
 
         // The coordinator should send messages to every node but itself
-        assert_eq!(outbox.len(), config.members.len() - 1);
         for envelope in outbox {
-            assert_matches!(
-                &envelope.msg,
-                PeerMsg::Prepare(PrepareMsg { config: prepare_config, .. }) => {
-                    assert_eq!(*config, *prepare_config);
-                }
-            );
-            prop_assert_eq!(&envelope.from, &config.coordinator);
+            if model_cs.op.is_preparing() {
+                // We should be sending to every member of the current config
+                // except ourself.
+                assert_eq!(outbox.len(), model_cs.msg.members.len() - 1);
+
+                // Safety: We'll always have this configuration in the SUT persistent
+                // state if we are preparing.
+                let config = sut
+                    .persistent_state
+                    .configuration(model_cs.msg.epoch)
+                    .expect("config for this epoch: {epoch}");
+
+                assert_matches!(
+                    &envelope.msg,
+                    PeerMsg::Prepare(PrepareMsg { config: prepare_config, .. }) => {
+                        assert_eq!(*config, *prepare_config);
+                    }
+                );
+            } else {
+                // We should be sending to every member of the previous config
+                // except ourself.
+                //
+                // Safety: If we got here, then we have a prior committed
+                // configuration.
+                assert_eq!(
+                    outbox.len(),
+                    self.model
+                        .last_committed_config_msg
+                        .as_ref()
+                        .unwrap()
+                        .members
+                        .len()
+                        - 1
+                );
+                assert_matches!(
+                    &envelope.msg,
+                    PeerMsg::GetShare(epoch) => {
+                        assert_eq!(*epoch, model_cs.msg.last_committed_epoch.unwrap());
+                    }
+                );
+            }
+            prop_assert_eq!(&envelope.from, &self.coordinator_id);
 
             // We don't send a prepare to ourselves. We put it in our
             // `PersistentState` directly.
-            prop_assert_ne!(&envelope.to, &config.coordinator);
+            prop_assert_ne!(&envelope.to, &self.coordinator_id);
         }
 
         Ok(())
@@ -514,7 +942,7 @@ pub enum Action {
     /// use a Vec. We don't worry about shuffling messsages so they are out of
     /// order, because we use stream oriented transport.
     //#[weight(3)]
-    //DropMessages(Vec<Index>),
+    DropMessages(Vec<Index>),
 
     /// Fake a reply for a delivered message.
     ///
@@ -522,12 +950,13 @@ pub enum Action {
     /// `test_state.delivered_msgs`.
     #[weight(45)]
     Reply(Vec<Index>),
+
     // Start a reconfiguration that has a possibility of succeeding
     // given delivered messages.
     //
     // It will never fail a validation check.
     //#[weight(2)]
-    //StartReconfiguration(GeneratedConfiguration),
+    CoordinateReconfiguration(GeneratedConfiguration),
 
     // A tick duration in milliseconds
     #[weight(50)]
@@ -538,6 +967,17 @@ pub enum Action {
          )]
         Duration,
     ),
+
+    // Attempt to Commit a reconfiguration if possible
+    //
+    // We'll only attempt to commit a reconfiguration if K+Z nodes
+    // have acked prepares for that epoch.
+    //
+    // Z is randomly chosen between 0 and N-K, and is a "safety parameter"
+    // described in RFD 238.
+    //
+    // `Index` is used to compute Z here.
+    Commit(Index),
 }
 
 /// Informnation about configurations used at test generation time
@@ -552,7 +992,13 @@ pub struct GeneratedConfiguration {
     /// still be duplicated due to the shift implementation used. Therefore we
     /// instead just choose from a constrained set of usize values that we can
     /// use directly as indexes into our fixed size structure for all tests.
-    #[strategy(btree_set(0..=255usize, MIN_CLUSTER_SIZE..=MAX_CLUSTER_SIZE))]
+    ///
+    /// Note that we intentionally set the max set size to MAX_CLUSTER_SIZE-1.
+    /// This is because we always want to include the coordinator in the
+    /// configuration, but it's value may not be chosen randomly. In this case,
+    /// we have to add it to the actual membership set we generate from this
+    /// configuration with [`TestState::generated_config_to_reconfigure_msg`].
+    #[strategy(btree_set(0..=255usize, MIN_CLUSTER_SIZE..MAX_CLUSTER_SIZE))]
     pub members: BTreeSet<usize>,
 
     /// An index is roughly equivalent to a threshold, since a threshold cannot
@@ -584,60 +1030,13 @@ pub struct TestInput {
 fn test_coordinator_behavior_from_empty_state(input: TestInput) {
     let logctx = test_setup_log("coordinator_behavior_from_empty_state");
 
-    let universe = member_universe();
-    let rack_id = RackUuid::new_v4();
-
-    // We don't know the coordinator ID until we translate the indexes in the
-    // test input to `PlatformId`s.
-    let coordinator_id = None;
-    let initial_config_msg = generated_config_to_reconfigure_msg(
-        &universe,
-        coordinator_id,
-        Epoch(1),
-        rack_id,
-        input.initial_config,
-    );
-
-    let coordinator_id = initial_config_msg.members.first().unwrap().clone();
-    let mut state = TestState::new(logctx.log.clone(), coordinator_id);
+    let mut state = TestState::new(logctx.log.clone());
 
     // Start the initial configuration
-    state.action_coordinate_reconfiguration(initial_config_msg)?;
+    state.action_coordinate_reconfiguration(input.initial_config)?;
 
     // Start executing the actions
     state.run_actions(input.actions)?;
 
     logctx.cleanup_successful();
-}
-
-fn generated_config_to_reconfigure_msg(
-    member_universe: &[PlatformId],
-    coordinator_id: Option<&PlatformId>,
-    epoch: Epoch,
-    rack_id: RackUuid,
-    config: GeneratedConfiguration,
-) -> ReconfigureMsg {
-    let mut members: BTreeSet<PlatformId> = config
-        .members
-        .iter()
-        .map(|index| member_universe[*index].clone())
-        .collect();
-
-    if let Some(coordinator_id) = coordinator_id {
-        members.insert(coordinator_id.clone());
-    }
-
-    println!("members = {members:#?}");
-
-    let threshold =
-        Threshold(usize::max(2, config.threshold.index(members.len())) as u8);
-
-    ReconfigureMsg {
-        rack_id,
-        epoch,
-        last_committed_epoch: None,
-        members,
-        threshold,
-        retry_timeout: Duration::from_millis(RETRY_TIMEOUT_MS),
-    }
 }


### PR DESCRIPTION
This PR adds further functionality to the sans-io trust quorum protocol. Configurations can now be committed via `Node::commit_reconfiguration`. For each reconfiguration attempt made on top of a committed configuration, the rack secret for the last committed reconfiguration will be reconstructed after retreiving a threshold of shares from members of that configuration. At this point this "old" rack secret will be encrypted with a key derived from the rack secret for the current configuration being coordinated and included as necessary in prepare messages sent out during coordination.

The property based test for coordinator behavior has been expanded to include support for this functionality, as well as to allow dropping messages between nodes if such an action is generated. The bulk of this PR lies in the test code, and it has been restructured to handle multiple reconfigurations and commits. This has led to the tracking of shares across non-existent test nodes, and enhancements to the model.

Additionally, a small change was made to copy some of the errors out of `validators.rs` and into their own file.