### PR TITLE
fix misleading dbinit_equals_sum_of_all_up advice

### DIFF
--- a/nexus/tests/integration_tests/schema.rs
+++ b/nexus/tests/integration_tests/schema.rs
@@ -552,11 +552,8 @@ impl InformationSchema {
             other.statistics,
             "Statistics did not match. This often means that in dbinit.sql, a new \
             column was added into the middle of a table rather than to the end. \
-            If that is the case:\n\n \
-            \
-            * Change dbinit.sql to add the column to the end of the table.\n\
-            * Update nexus/db-model/src/schema.rs and the corresponding \
-            Queryable/Insertable struct with the new column ordering."
+            If that is the case, change dbinit.sql to add the column to the \
+            end of the table.\n"
         );
         similar_asserts::assert_eq!(self.sequences, other.sequences);
         similar_asserts::assert_eq!(self.pg_indexes, other.pg_indexes);


### PR DESCRIPTION
Currently, if the test `dbinit_equals_sum_of_all_up` detects that a new column has been added in a different order from what's in `dbinit`, it prints this message:

> Statistics did not match. This often means that in dbinit.sql, a new column
> was added into the middle of a table rather than to the end. If that is the
> case:
>
> * Change dbinit.sql to add the column to the end of the table.
> * Update nexus/db-model/src/schema.rs and the corresponding
>   Queryable/Insertable struct with the new column ordering.

I think the advice given here is not quite right. The ordering of columns in `schema.rs` and in the `Queryable`/`Insertable` struct(s) must be the same, but the ordering in `schema.rs` does NOT need to match that in the SQL schema. This is important because, in some cases, a `Queryable` or `Insertable` type consists of multiple nested structs using `#[diesel(embed)]`, and the ordering in `schema.rs` may depend on that --- fields grouped into the same embedded struct must appear in a particular order so that they are part of the correct struct. This does NOT need to be the same order in `dbinit.sql`, and following the advice this assertion failure currently gives will result in much weirder compilation errors if fields are reordered in `schema.rs` in a way that doesn't match the struct ordering required by use of `#[diesel(embed)]`.

Therefore, I've removed the second bullet point, and changed the assertion to just suggest changing the ordering in `dbinit.sql`.