### PR TITLE
Trust Quorum: Handle prepare messages + Alarms

### DIFF
--- a/trust-quorum/src/alarm.rs
+++ b/trust-quorum/src/alarm.rs
@@ -46,14 +46,26 @@ pub enum Alarm {
     MissingPrepare { epoch: Epoch, latest_seen_epoch: Option<Epoch> },
 
     #[error(
-        "TQ Alarm: prepare received with mismatched last_committed_epoch: \
-        prepare's last committed epoch = {prepare_last_committed_epoch:?}, \
+        "TQ Alarm: prepare received from {from} with mismatched \
+        last_committed_epoch: prepare's last committed epoch = \
+        {prepare_last_committed_epoch:?}, \
         persisted prepare's last_committed_epoch = \
         {persisted_prepare_last_committed_epoch:?}"
     )]
     PrepareLastCommittedEpochMismatch {
+        from: PlatformId,
         prepare_last_committed_epoch: Option<Epoch>,
         persisted_prepare_last_committed_epoch: Option<Epoch>,
+    },
+
+    #[error(
+        "TQ Alarm: prepare received with invalid rack_id from {from}. \
+        Expected {expected}, got {got}."
+    )]
+    PrepareWithInvalidRackId {
+        from: PlatformId,
+        expected: RackUuid,
+        got: RackUuid,
     },
 
     #[error(

--- a/trust-quorum/src/alarm.rs
+++ b/trust-quorum/src/alarm.rs
@@ -1,0 +1,60 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at https://mozilla.org/MPL/2.0/.
+
+//! A mechanism for reporting protocol invariant violations
+//!
+//! Invariant violations should _never_ occur. They represent a critical bug in
+//! the implementation of the system. In certain scenarios we can detect these
+//! invariant violations and record them. This allows reporting them to higher
+//! levels of control plane software so that we can debug them and fix them in
+//! future releases, as well as rectify outstanding issues on systems where such
+//! an alarm arose.
+
+use crate::{Epoch, PlatformId};
+use serde::{Deserialize, Serialize};
+
+/// A critical invariant violation that should never occur.
+///
+/// Many invariant violations are only possible on receipt of peer messages,
+/// and are _not_ a result of API calls. This means that there isn't a good
+/// way to directly inform the rest of the control plane. Instead we provide a
+/// queryable API for `crate::Node` status that includes alerts.
+///
+/// If an `Alarm` is ever seen by an operator then support should be contacted
+/// immediately.
+#[derive(
+    Debug, Clone, thiserror::Error, PartialEq, Eq, Serialize, Deserialize,
+)]
+pub enum Alarm {
+    #[error(
+        "prepare for a later configuration exists: \
+        last_prepared_epoch = {last_prepared_epoch:?}, \
+        commit_epoch = {commit_epoch}"
+    )]
+    OutOfOrderCommit { last_prepared_epoch: Option<Epoch>, commit_epoch: Epoch },
+
+    #[error("commit attempted, but missing prepare message: epoch = {epoch}")]
+    MissingPrepare { epoch: Epoch },
+
+    #[error(
+        "prepare received with mismatched last_committed_epoch: prepare's last \
+        committed epoch = {prepare_last_committed_epoch:?}, persisted \
+        prepare's last_committed_epoch = \
+        {persisted_prepare_last_committed_epoch:?}"
+    )]
+    PrepareLastCommittedEpochMismatch {
+        prepare_last_committed_epoch: Option<Epoch>,
+        persisted_prepare_last_committed_epoch: Option<Epoch>,
+    },
+
+    #[error(
+        "different nodes coordinating same epoch = {epoch}: \
+        them = {them}, us = {us}"
+    )]
+    DifferentNodesCoordinatingSameEpoch {
+        epoch: Epoch,
+        them: PlatformId,
+        us: PlatformId,
+    },
+}

--- a/trust-quorum/src/coordinator_state.rs
+++ b/trust-quorum/src/coordinator_state.rs
@@ -211,7 +211,7 @@ impl CoordinatorState {
 
     /// Record a `PrepareAck` from another node as part of tracking
     /// quorum for the prepare phase of the trust quorum protocol.
-    pub fn ack_prepare(&mut self, from: PlatformId) {
+    pub fn record_prepare_ack(&mut self, from: PlatformId) {
         match &mut self.op {
             CoordinatorOperation::Prepare {
                 prepares, prepare_acks, ..

--- a/trust-quorum/src/crypto.rs
+++ b/trust-quorum/src/crypto.rs
@@ -29,8 +29,8 @@ use zeroize::{Zeroize, ZeroizeOnDrop, Zeroizing};
 const LRTQ_SHARE_SIZE: usize = 33;
 
 /// We don't distinguish whether this is an Ed25519 Scalar or set of GF(256)
-/// polynomials points with an x-coordinate of 0. Both can be treated as 32 byte
-/// blobs when decrypted, as they are immediately fed into HKDF.
+/// polynomials' points with an x-coordinate of 0. Both can be treated as 32
+/// byte blobs when decrypted, as they are immediately fed into HKDF.
 #[derive(
     Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Serialize, Deserialize,
 )]

--- a/trust-quorum/src/errors.rs
+++ b/trust-quorum/src/errors.rs
@@ -9,22 +9,6 @@ use crate::{Epoch, PlatformId, Threshold};
 use omicron_uuid_kinds::RackUuid;
 
 #[derive(Debug, Clone, thiserror::Error, PartialEq, Eq)]
-pub enum CommitError {
-    #[error("invalid rack id")]
-    InvalidRackId(
-        #[from]
-        #[source]
-        MismatchedRackIdError,
-    ),
-
-    #[error("missing prepare msg")]
-    MissingPrepare,
-
-    #[error("prepare for a later configuration exists")]
-    OutOfOrderCommit,
-}
-
-#[derive(Debug, Clone, thiserror::Error, PartialEq, Eq)]
 #[error(
     "sled was decommissioned on msg from {from:?} at epoch {epoch:?}: last prepared epoch = {last_prepared_epoch:?}"
 )]

--- a/trust-quorum/src/lib.rs
+++ b/trust-quorum/src/lib.rs
@@ -12,6 +12,7 @@
 use derive_more::Display;
 use serde::{Deserialize, Serialize};
 
+mod alarm;
 mod configuration;
 mod coordinator_state;
 pub(crate) mod crypto;
@@ -20,9 +21,10 @@ mod messages;
 mod node;
 mod persistent_state;
 mod validators;
-pub use configuration::Configuration;
+pub use alarm::Alarm;
+pub use configuration::{Configuration, PreviousConfiguration};
 pub(crate) use coordinator_state::CoordinatorState;
-pub use crypto::RackSecret;
+pub use crypto::{EncryptedRackSecret, RackSecret, Salt, Sha3_256Digest};
 pub use messages::*;
 pub use node::Node;
 pub use persistent_state::{PersistentState, PersistentStateSummary};

--- a/trust-quorum/src/messages.rs
+++ b/trust-quorum/src/messages.rs
@@ -63,7 +63,3 @@ pub struct PrepareMsg {
 pub struct CommitMsg {
     epoch: Epoch,
 }
-
-pub enum Error {
-    StalePrepare { received: Epoch, last_prepared_epoch: Epoch },
-}

--- a/trust-quorum/src/messages.rs
+++ b/trust-quorum/src/messages.rs
@@ -63,3 +63,7 @@ pub struct PrepareMsg {
 pub struct CommitMsg {
     epoch: Epoch,
 }
+
+pub enum Error {
+    StalePrepare { received: Epoch, last_prepared_epoch: Epoch },
+}

--- a/trust-quorum/src/node.rs
+++ b/trust-quorum/src/node.rs
@@ -234,7 +234,6 @@ impl Node {
                     "msg_epoch" => %msg.config.epoch,
                     "last_prepared_epoch" => %last_prepared_epoch
                 );
-                // TODO: Respond to sender?
                 return Ok(None);
             }
 

--- a/trust-quorum/src/persistent_state.rs
+++ b/trust-quorum/src/persistent_state.rs
@@ -8,18 +8,12 @@
 
 use crate::crypto::LrtqShare;
 use crate::messages::PrepareMsg;
-use crate::{Alarm, Configuration, Epoch, PlatformId};
+use crate::{Configuration, Epoch, PlatformId};
 use bootstore::schemes::v0::SharePkgCommon as LrtqShareData;
 use gfss::shamir::Share;
 use omicron_uuid_kinds::{GenericUuid, RackUuid};
 use serde::{Deserialize, Serialize};
 use std::collections::{BTreeMap, BTreeSet};
-
-// We want to prevent the situation where invariant violations keep replaying
-// due to message receipt and we blow up memory / storage with them. In
-// practice, even one `Alarm` is a critical bug, but we leave room to track a
-// few more.
-const MAX_ALARMS: usize = 10;
 
 /// All the persistent state for this protocol
 #[derive(Debug, Clone, Serialize, Deserialize, Default)]
@@ -36,14 +30,6 @@ pub struct PersistentState {
     // node. The sled corresponding to the node must be factory reset by wiping
     // its storage.
     pub decommissioned: Option<DecommissionedMetadata>,
-
-    // We persist [`Alarm`]s so that they can't be lost
-    //
-    // During a support scenario, any existing alarms must be manually cleared
-    // as part of resolving the issue. In principal, there should be *no* alarms
-    // as they are only for protocol invariant violations, so this should never
-    // be necessary.
-    alarms: Vec<Alarm>,
 }
 
 impl PersistentState {
@@ -53,7 +39,6 @@ impl PersistentState {
             prepares: BTreeMap::new(),
             commits: BTreeSet::new(),
             decommissioned: None,
-            alarms: Vec::new(),
         }
     }
 
@@ -113,13 +98,6 @@ impl PersistentState {
             self.prepares.get(&epoch).expect("missing prepare").share.clone()
         })
     }
-
-    // Add an alarm, if we haven't already reached the max number of alarms.
-    pub fn add_alarm(&mut self, alarm: Alarm) {
-        if self.alarms.len() < MAX_ALARMS {
-            self.alarms.push(alarm)
-        }
-    }
 }
 
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
@@ -142,7 +120,6 @@ pub struct PersistentStateSummary {
     pub last_prepared_epoch: Option<Epoch>,
     pub last_committed_epoch: Option<Epoch>,
     pub decommissioned: Option<DecommissionedMetadata>,
-    pub alarms: Vec<Alarm>,
 }
 
 impl From<&PersistentState> for PersistentStateSummary {
@@ -154,7 +131,6 @@ impl From<&PersistentState> for PersistentStateSummary {
             last_prepared_epoch: value.last_prepared_epoch(),
             last_committed_epoch: value.last_committed_epoch(),
             decommissioned: value.decommissioned.clone(),
-            alarms: value.alarms.clone(),
         }
     }
 }

--- a/trust-quorum/src/persistent_state.rs
+++ b/trust-quorum/src/persistent_state.rs
@@ -80,6 +80,11 @@ impl PersistentState {
         self.prepares.keys().last().map(|epoch| *epoch)
     }
 
+    /// Return the prepare with the highest epoch
+    pub fn latest_prepare(&self) -> Option<&PrepareMsg> {
+        self.prepares.last_key_value().map(|(_, v)| v)
+    }
+
     pub fn last_committed_epoch(&self) -> Option<Epoch> {
         self.commits.last().map(|epoch| *epoch)
     }

--- a/trust-quorum/src/validators.rs
+++ b/trust-quorum/src/validators.rs
@@ -271,7 +271,8 @@ impl ValidatedReconfigureMsg {
                 error!(
                     log,
                     concat!(
-                        "Reconfiguration in progress for same epoch, ",
+                        "Protocol invariant violation: ",
+                        "reconfiguration in progress for same epoch, ",
                         "but messages differ");
                     "epoch" => new_msg.epoch.to_string(),
                 );
@@ -371,6 +372,7 @@ mod tests {
                 last_prepared_epoch: None,
                 last_committed_epoch: None,
                 decommissioned: None,
+                alarms: Vec::new(),
             };
             (persistent_state, None)
         } else {
@@ -381,6 +383,7 @@ mod tests {
                 last_prepared_epoch: msg.last_committed_epoch,
                 last_committed_epoch: msg.last_committed_epoch,
                 decommissioned: None,
+                alarms: Vec::new(),
             };
             let mut members = input.members.clone();
             members
@@ -441,6 +444,7 @@ mod tests {
                 last_prepared_epoch: None,
                 last_committed_epoch: None,
                 decommissioned: None,
+                alarms: Vec::new(),
             };
             (persistent_state, None)
         } else {
@@ -451,6 +455,7 @@ mod tests {
                 last_prepared_epoch: msg.last_committed_epoch,
                 last_committed_epoch: msg.last_committed_epoch,
                 decommissioned: None,
+                alarms: Vec::new(),
             };
             let mut members = input.members.clone();
             members

--- a/trust-quorum/src/validators.rs
+++ b/trust-quorum/src/validators.rs
@@ -268,6 +268,12 @@ impl ValidatedReconfigureMsg {
 
         if current_epoch == new_msg.epoch {
             if existing_msg != new_msg {
+                // TODO: This should be an `Alarm`, but I"m not sure how
+                // to handle that. We could include an `Alarm` variant inside
+                // `ReconfigurationError`, but that would require a match/method
+                // to check for an alarm and pull it out. We could also return either
+                // an `Alarm` or a `ReconfigurationError` inside `Result::Err`. This is
+                // probably the best approach, but I'm open to other structures.
                 error!(
                     log,
                     concat!(

--- a/trust-quorum/src/validators.rs
+++ b/trust-quorum/src/validators.rs
@@ -372,7 +372,6 @@ mod tests {
                 last_prepared_epoch: None,
                 last_committed_epoch: None,
                 decommissioned: None,
-                alarms: Vec::new(),
             };
             (persistent_state, None)
         } else {
@@ -383,7 +382,6 @@ mod tests {
                 last_prepared_epoch: msg.last_committed_epoch,
                 last_committed_epoch: msg.last_committed_epoch,
                 decommissioned: None,
-                alarms: Vec::new(),
             };
             let mut members = input.members.clone();
             members
@@ -444,7 +442,6 @@ mod tests {
                 last_prepared_epoch: None,
                 last_committed_epoch: None,
                 decommissioned: None,
-                alarms: Vec::new(),
             };
             (persistent_state, None)
         } else {
@@ -455,7 +452,6 @@ mod tests {
                 last_prepared_epoch: msg.last_committed_epoch,
                 last_committed_epoch: msg.last_committed_epoch,
                 decommissioned: None,
-                alarms: Vec::new(),
             };
             let mut members = input.members.clone();
             members

--- a/trust-quorum/tests/coordinator.rs
+++ b/trust-quorum/tests/coordinator.rs
@@ -601,6 +601,7 @@ impl TestState {
                 coordinator.clone(),
                 PeerMsg::Prepare(prepare_msg.clone()),
             )
+            .expect("no alarm")
             .expect("persistent state");
 
         // We should have gotten back a persistent state including the prepare
@@ -795,12 +796,12 @@ impl TestState {
         // to check this.
         let reply = PeerMsg::PrepareAck(msg.config.epoch);
         let mut outbox = Vec::new();
-        let output = self.sut.node.handle(
-            self.model.now,
-            &mut outbox,
-            from.clone(),
-            reply,
-        );
+        let output = self
+            .sut
+            .node
+            .handle(self.model.now, &mut outbox, from.clone(), reply)
+            .expect("no alarm");
+
         prop_assert!(output.is_none());
         prop_assert!(outbox.is_empty());
 
@@ -833,12 +834,11 @@ impl TestState {
         };
         let reply = PeerMsg::Share { epoch, share: share.clone() };
         let mut outbox = Vec::new();
-        let output = self.sut.node.handle(
-            self.model.now,
-            &mut outbox,
-            from.clone(),
-            reply,
-        );
+        let output = self
+            .sut
+            .node
+            .handle(self.model.now, &mut outbox, from.clone(), reply)
+            .expect("no alarm");
 
         // If we just received a threshold number of shares, we expect
         // reconstruction of the rack secret for the last committed

--- a/trust-quorum/tests/coordinator.rs
+++ b/trust-quorum/tests/coordinator.rs
@@ -554,7 +554,7 @@ impl TestState {
 
         // Choose a node to send to the SUT.
         // Skip over the SUT which sorts first.
-        let coordinator = msg.members.iter().skip(1).next().cloned().unwrap();
+        let coordinator = msg.members.iter().nth(1).cloned().unwrap();
 
         // Since the test is never going to commit this Prepare, we just use
         // dummy values where necessary (primarily when crypto is involved).
@@ -582,7 +582,7 @@ impl TestState {
         // Generate a nonsense share for the SUT
         let share = Share {
             x_coordinate: Gf256::new(1),
-            y_coordinates: (0..32 as u8).into_iter().map(Gf256::new).collect(),
+            y_coordinates: (0..32_u8).map(Gf256::new).collect(),
         };
 
         let prepare_msg = PrepareMsg { config, share };


### PR DESCRIPTION
This builds on #8052.

Nodes now handle `PrepareMsg`s from coordinators. The coordinator proptest was updated to generate prepares from non-existent test only nodes and send them to the coordinator.

Additionally, protocol invariant violations are now detected in a few cases and recorded to the `PersistentState`. This is for debugging and support purposes. The goal is to test the code well enough that we never actually see an alarm in production.