### PR TITLE
[VM metrics] add a metric for VMM VSZ

### DIFF
--- a/oximeter/oximeter/schema/virtual-machine.toml
+++ b/oximeter/oximeter/schema/virtual-machine.toml
@@ -18,6 +18,15 @@ versions = [
 ]
 
 [[metrics]]
+name = "vmm_vsz"
+description = "Total virtual memory reserved for reasons other than direct access by the virtual machine"
+units = "bytes"
+datum_type = "u64"
+versions = [
+    { added_in = 1, fields = [ ] }
+]
+
+[[metrics]]
 name = "reset"
 description = "Cumulative number of times the virtual machine has been reset"
 units = "count"


### PR DESCRIPTION
pairs with https://github.com/oxidecomputer/propolis/pull/889. this would land first, then i'll plumb the schema change through to Propolis and remove the gross Cargo.toml patching that's in Propolis#889.