### PR TITLE
Add protections for password handling in Nexus

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -7516,6 +7516,7 @@ dependencies = [
  "rand 0.8.5",
  "rust-argon2",
  "schemars",
+ "secrecy 0.10.3",
  "serde",
  "serde_with",
  "thiserror 1.0.69",

--- a/nexus/tests/integration_tests/authz.rs
+++ b/nexus/tests/integration_tests/authz.rs
@@ -5,6 +5,7 @@
 //! Tests for authz policy not covered in the set of unauthorized tests
 
 use nexus_test_utils::http_testing::{AuthnMode, NexusRequest, RequestBuilder};
+use nexus_test_utils::resource_helpers::test_params;
 use nexus_test_utils_macros::nexus_test;
 
 use nexus_types::external_api::params;
@@ -38,7 +39,7 @@ async fn test_cannot_read_others_ssh_keys(cptestctx: &ControlPlaneTestContext) {
         client,
         &silo,
         &"user1".parse().unwrap(),
-        params::UserPassword::LoginDisallowed,
+        test_params::UserPassword::LoginDisallowed,
     )
     .await
     .id;
@@ -46,7 +47,7 @@ async fn test_cannot_read_others_ssh_keys(cptestctx: &ControlPlaneTestContext) {
         client,
         &silo,
         &"user2".parse().unwrap(),
-        params::UserPassword::LoginDisallowed,
+        test_params::UserPassword::LoginDisallowed,
     )
     .await
     .id;
@@ -144,7 +145,7 @@ async fn test_list_silo_users_for_unpriv(cptestctx: &ControlPlaneTestContext) {
         client,
         &silo,
         &"unpriv".parse().unwrap(),
-        params::UserPassword::LoginDisallowed,
+        test_params::UserPassword::LoginDisallowed,
     )
     .await
     .id;
@@ -162,7 +163,7 @@ async fn test_list_silo_users_for_unpriv(cptestctx: &ControlPlaneTestContext) {
         client,
         &silo,
         &"otheruser".parse().unwrap(),
-        params::UserPassword::LoginDisallowed,
+        test_params::UserPassword::LoginDisallowed,
     )
     .await;
 
@@ -200,7 +201,7 @@ async fn test_list_silo_idps_for_unpriv(cptestctx: &ControlPlaneTestContext) {
         client,
         &silo,
         &"unpriv".parse().unwrap(),
-        params::UserPassword::LoginDisallowed,
+        test_params::UserPassword::LoginDisallowed,
     )
     .await
     .id;
@@ -236,7 +237,7 @@ async fn test_session_me_for_unpriv(cptestctx: &ControlPlaneTestContext) {
         client,
         &silo,
         &"unpriv".parse().unwrap(),
-        params::UserPassword::LoginDisallowed,
+        test_params::UserPassword::LoginDisallowed,
     )
     .await
     .id;
@@ -266,7 +267,7 @@ async fn test_silo_read_for_unpriv(cptestctx: &ControlPlaneTestContext) {
         client,
         &silo,
         &"unpriv".parse().unwrap(),
-        params::UserPassword::LoginDisallowed,
+        test_params::UserPassword::LoginDisallowed,
     )
     .await
     .id;

--- a/nexus/tests/integration_tests/console_api.rs
+++ b/nexus/tests/integration_tests/console_api.rs
@@ -19,6 +19,7 @@ use nexus_db_queries::db::identity::{Asset, Resource};
 use nexus_test_utils::http_testing::{
     AuthnMode, NexusRequest, RequestBuilder, TestResponse,
 };
+use nexus_test_utils::resource_helpers::test_params;
 use nexus_test_utils::resource_helpers::{
     create_silo, grant_iam, object_create,
 };
@@ -26,9 +27,7 @@ use nexus_test_utils::{
     TEST_SUITE_PASSWORD, load_test_config, test_setup_with_config,
 };
 use nexus_test_utils_macros::nexus_test;
-use nexus_types::external_api::params::{
-    self, ProjectCreate, UsernamePasswordCredentials,
-};
+use nexus_types::external_api::params::{self, ProjectCreate};
 use nexus_types::external_api::shared::{SiloIdentityMode, SiloRole};
 use nexus_types::external_api::{shared, views};
 use omicron_common::api::external::IdentityMetadataCreateParams;
@@ -878,9 +877,9 @@ async fn log_in_and_extract_token(
 ) -> String {
     let testctx = &cptestctx.external_client;
     let url = format!("/v1/login/{}/local", cptestctx.silo_name);
-    let credentials = UsernamePasswordCredentials {
+    let credentials = test_params::UsernamePasswordCredentials {
         username: cptestctx.user_name.as_ref().parse().unwrap(),
-        password: TEST_SUITE_PASSWORD.parse().unwrap(),
+        password: TEST_SUITE_PASSWORD.to_string(),
     };
     let login = RequestBuilder::new(&testctx, Method::POST, &url)
         .body(Some(&credentials))

--- a/nexus/tests/integration_tests/endpoints.rs
+++ b/nexus/tests/integration_tests/endpoints.rs
@@ -18,6 +18,7 @@ use nexus_test_utils::PHYSICAL_DISK_UUID;
 use nexus_test_utils::RACK_UUID;
 use nexus_test_utils::SLED_AGENT_UUID;
 use nexus_test_utils::SWITCH_UUID;
+use nexus_test_utils::resource_helpers::test_params;
 use nexus_types::external_api::params;
 use nexus_types::external_api::shared;
 use nexus_types::external_api::shared::IpRange;
@@ -1140,10 +1141,10 @@ pub static DEMO_TIMESERIES_QUERY: LazyLock<params::TimeseriesQuery> =
     });
 
 // Users
-pub static DEMO_USER_CREATE: LazyLock<params::UserCreate> =
-    LazyLock::new(|| params::UserCreate {
+pub static DEMO_USER_CREATE: LazyLock<test_params::UserCreate> =
+    LazyLock::new(|| test_params::UserCreate {
         external_id: UserId::from_str("dummy-user").unwrap(),
-        password: params::UserPassword::LoginDisallowed,
+        password: test_params::UserPassword::LoginDisallowed,
     });
 
 // Allowlist for user-facing services.
@@ -1689,8 +1690,10 @@ pub static VERIFY_ENDPOINTS: LazyLock<Vec<VerifyEndpoint>> =
                 visibility: Visibility::Public,
                 unprivileged_access: UnprivilegedAccess::ReadOnly,
                 allowed_methods: vec![AllowedMethod::Post(
-                    serde_json::to_value(params::UserPassword::LoginDisallowed)
-                        .unwrap(),
+                    serde_json::to_value(
+                        test_params::UserPassword::LoginDisallowed,
+                    )
+                    .unwrap(),
                 )],
             },
             /* Projects */

--- a/nexus/tests/integration_tests/external_ips.rs
+++ b/nexus/tests/integration_tests/external_ips.rs
@@ -34,6 +34,7 @@ use nexus_test_utils::resource_helpers::object_delete;
 use nexus_test_utils::resource_helpers::object_delete_error;
 use nexus_test_utils::resource_helpers::object_get;
 use nexus_test_utils::resource_helpers::object_put;
+use nexus_test_utils::resource_helpers::test_params;
 use nexus_test_utils_macros::nexus_test;
 use nexus_types::external_api::params;
 use nexus_types::external_api::shared;
@@ -297,7 +298,7 @@ async fn test_floating_ip_create_non_admin(
         client,
         &silo,
         &"user".parse().unwrap(),
-        params::UserPassword::LoginDisallowed,
+        test_params::UserPassword::LoginDisallowed,
     )
     .await;
 

--- a/nexus/tests/integration_tests/instances.rs
+++ b/nexus/tests/integration_tests/instances.rs
@@ -37,6 +37,7 @@ use nexus_test_utils::resource_helpers::object_get;
 use nexus_test_utils::resource_helpers::object_put;
 use nexus_test_utils::resource_helpers::object_put_error;
 use nexus_test_utils::resource_helpers::objects_list_page_authz;
+use nexus_test_utils::resource_helpers::test_params;
 use nexus_test_utils::wait_for_producer;
 use nexus_types::external_api::params::SshKeyCreate;
 use nexus_types::external_api::shared::IpKind;
@@ -6473,7 +6474,7 @@ async fn test_instance_create_in_silo(cptestctx: &ControlPlaneTestContext) {
         client,
         &silo,
         &"unpriv".parse().unwrap(),
-        params::UserPassword::LoginDisallowed,
+        test_params::UserPassword::LoginDisallowed,
     )
     .await
     .id;

--- a/nexus/tests/integration_tests/internet_gateway.rs
+++ b/nexus/tests/integration_tests/internet_gateway.rs
@@ -13,6 +13,7 @@ use nexus_test_utils::{
         create_local_user, create_project, create_route, create_router,
         create_vpc, delete_internet_gateway, detach_ip_address_from_igw,
         detach_ip_pool_from_igw, link_ip_pool, objects_list_page_authz,
+        test_params,
     },
 };
 use nexus_test_utils_macros::nexus_test;
@@ -271,7 +272,7 @@ async fn test_igw_ip_pool_attach_silo_user(ctx: &ControlPlaneTestContext) {
         c,
         &silo,
         &"user".parse().unwrap(),
-        params::UserPassword::LoginDisallowed,
+        test_params::UserPassword::LoginDisallowed,
     )
     .await;
 

--- a/nexus/tests/integration_tests/ip_pools.rs
+++ b/nexus/tests/integration_tests/ip_pools.rs
@@ -36,6 +36,7 @@ use nexus_test_utils::resource_helpers::object_get_error;
 use nexus_test_utils::resource_helpers::object_put;
 use nexus_test_utils::resource_helpers::object_put_error;
 use nexus_test_utils::resource_helpers::objects_list_page_authz;
+use nexus_test_utils::resource_helpers::test_params;
 use nexus_test_utils_macros::nexus_test;
 use nexus_types::external_api::params;
 use nexus_types::external_api::params::IpPoolCreate;
@@ -1183,7 +1184,7 @@ async fn test_ip_pool_list_in_silo(cptestctx: &ControlPlaneTestContext) {
         client,
         &silo,
         &"user".parse().unwrap(),
-        params::UserPassword::LoginDisallowed,
+        test_params::UserPassword::LoginDisallowed,
     )
     .await;
 

--- a/nexus/tests/integration_tests/password_login.rs
+++ b/nexus/tests/integration_tests/password_login.rs
@@ -9,7 +9,6 @@ use nexus_test_utils::resource_helpers::grant_iam;
 use nexus_test_utils::resource_helpers::test_params;
 use nexus_test_utils::resource_helpers::{create_local_user, create_silo};
 use nexus_test_utils_macros::nexus_test;
-use nexus_types::external_api::params;
 use nexus_types::external_api::shared::{self, SiloRole};
 use nexus_types::external_api::views;
 use omicron_common::api::external::{Name, UserId};

--- a/nexus/tests/integration_tests/password_login.rs
+++ b/nexus/tests/integration_tests/password_login.rs
@@ -6,6 +6,7 @@ use dropshot::test_util::ClientTestContext;
 use http::{StatusCode, header, method::Method};
 use nexus_test_utils::http_testing::{AuthnMode, NexusRequest, RequestBuilder};
 use nexus_test_utils::resource_helpers::grant_iam;
+use nexus_test_utils::resource_helpers::test_params;
 use nexus_test_utils::resource_helpers::{create_local_user, create_silo};
 use nexus_test_utils_macros::nexus_test;
 use nexus_types::external_api::params;
@@ -62,20 +63,19 @@ async fn test_local_user_basic(client: &ClientTestContext, silo: &views::Silo) {
         client,
         &silo_name,
         UserId::from_str("bigfoot").unwrap(),
-        params::Password::from_str("ahh").unwrap(),
+        "ahh".to_string(),
     )
     .await;
 
     // Create a test user with a known password.
     let test_user = UserId::from_str("abe-simpson").unwrap();
-    let test_password =
-        params::Password::from_str("let me in you idiot!").unwrap();
+    let test_password = "let me in you idiot!";
 
     let created_user = create_local_user(
         client,
         silo,
         &test_user,
-        params::UserPassword::Password(test_password.clone()),
+        test_params::UserPassword::Password(test_password.to_string()),
     )
     .await;
 
@@ -84,7 +84,7 @@ async fn test_local_user_basic(client: &ClientTestContext, silo: &views::Silo) {
         client,
         &silo_name,
         test_user.clone(),
-        params::Password::from_str("something else").unwrap(),
+        "something else".to_string(),
     )
     .await;
 
@@ -94,15 +94,14 @@ async fn test_local_user_basic(client: &ClientTestContext, silo: &views::Silo) {
         client,
         &silo_name,
         test_user.clone(),
-        test_password.clone(),
+        test_password.to_string(),
     )
     .await;
     let found_user = expect_session_valid(client, &session_token).await;
     assert_eq!(created_user, found_user.user);
 
     // While we're still logged in, change the password.
-    let test_password2 =
-        params::Password::from_str("as was the style at the time").unwrap();
+    let test_password2 = "as was the style at the time";
     let user_password_url = format!(
         "/v1/system/identity-providers/local/users/{}/set-password?silo={}",
         created_user.id, silo_name
@@ -110,8 +109,8 @@ async fn test_local_user_basic(client: &ClientTestContext, silo: &views::Silo) {
     NexusRequest::new(
         RequestBuilder::new(client, Method::POST, &user_password_url)
             .expect_status(Some(StatusCode::NO_CONTENT))
-            .body(Some(&params::UserPassword::Password(
-                test_password2.clone(),
+            .body(Some(&test_params::UserPassword::Password(
+                test_password2.to_string(),
             ))),
     )
     .authn_as(AuthnMode::Session(session_token.to_string()))
@@ -124,7 +123,7 @@ async fn test_local_user_basic(client: &ClientTestContext, silo: &views::Silo) {
         client,
         &silo_name,
         test_user.clone(),
-        test_password.clone(),
+        test_password.to_string(),
     )
     .await;
 
@@ -133,7 +132,7 @@ async fn test_local_user_basic(client: &ClientTestContext, silo: &views::Silo) {
         client,
         &silo_name,
         test_user.clone(),
-        test_password2.clone(),
+        test_password2.to_string(),
     )
     .await;
 
@@ -160,12 +159,12 @@ async fn test_local_user_basic(client: &ClientTestContext, silo: &views::Silo) {
     // Now, let's create an admin user and verify that they can change this
     // user's password.
     let admin_user = UserId::from_str("comic-book-guy").unwrap();
-    let admin_password = params::Password::from_str("toodle-ooh").unwrap();
+    let admin_password = "toodle-ooh";
     let admin_user_obj = create_local_user(
         client,
         silo,
         &admin_user,
-        params::UserPassword::Password(admin_password.clone()),
+        test_params::UserPassword::Password(admin_password.to_string()),
     )
     .await;
     let admin_password_url = format!(
@@ -187,17 +186,16 @@ async fn test_local_user_basic(client: &ClientTestContext, silo: &views::Silo) {
         client,
         &silo_name,
         admin_user.clone(),
-        admin_password.clone(),
+        admin_password.to_string(),
     )
     .await;
 
-    let hijacked_password =
-        params::Password::from_str("sarcasm detector").unwrap();
+    let hijacked_password = "sarcasm detector";
     NexusRequest::new(
         RequestBuilder::new(client, Method::POST, &user_password_url)
             .expect_status(Some(StatusCode::NO_CONTENT))
-            .body(Some(&params::UserPassword::Password(
-                hijacked_password.clone(),
+            .body(Some(&test_params::UserPassword::Password(
+                hijacked_password.to_string(),
             ))),
     )
     .authn_as(AuthnMode::Session(admin_session.to_string()))
@@ -210,14 +208,14 @@ async fn test_local_user_basic(client: &ClientTestContext, silo: &views::Silo) {
         client,
         &silo_name,
         test_user.clone(),
-        hijacked_password.clone(),
+        hijacked_password.to_string(),
     )
     .await;
     expect_login_failure(
         client,
         &silo_name,
         test_user.clone(),
-        test_password2.clone(),
+        test_password2.to_string(),
     )
     .await;
 
@@ -226,14 +224,14 @@ async fn test_local_user_basic(client: &ClientTestContext, silo: &views::Silo) {
         client,
         &silo_name,
         admin_user.clone(),
-        admin_password.clone(),
+        admin_password.to_string(),
     )
     .await;
     expect_login_failure(
         client,
         &silo_name,
         admin_user.clone(),
-        hijacked_password.clone(),
+        hijacked_password.to_string(),
     )
     .await;
 
@@ -241,7 +239,7 @@ async fn test_local_user_basic(client: &ClientTestContext, silo: &views::Silo) {
     NexusRequest::new(
         RequestBuilder::new(client, Method::POST, &user_password_url)
             .expect_status(Some(StatusCode::NO_CONTENT))
-            .body(Some(&params::UserPassword::LoginDisallowed)),
+            .body(Some(&test_params::UserPassword::LoginDisallowed)),
     )
     .authn_as(AuthnMode::Session(admin_session.to_string()))
     .execute()
@@ -251,7 +249,7 @@ async fn test_local_user_basic(client: &ClientTestContext, silo: &views::Silo) {
         client,
         &silo_name,
         test_user.clone(),
-        hijacked_password.clone(),
+        hijacked_password.to_string(),
     )
     .await;
     // And we did not modify the admin user's password.
@@ -259,14 +257,14 @@ async fn test_local_user_basic(client: &ClientTestContext, silo: &views::Silo) {
         client,
         &silo_name,
         admin_user.clone(),
-        admin_password.clone(),
+        admin_password.to_string(),
     )
     .await;
     expect_login_failure(
         client,
         &silo_name,
         admin_user.clone(),
-        hijacked_password.clone(),
+        hijacked_password.to_string(),
     )
     .await;
 
@@ -279,7 +277,7 @@ async fn test_local_user_basic(client: &ClientTestContext, silo: &views::Silo) {
         StatusCode::FORBIDDEN,
         Method::POST,
         &admin_password_url,
-        &params::UserPassword::Password(test_password.clone()),
+        &test_params::UserPassword::Password(test_password.to_string()),
     )
     .authn_as(AuthnMode::Session(session_token2.clone()))
     .execute()
@@ -291,7 +289,7 @@ async fn test_local_user_basic(client: &ClientTestContext, silo: &views::Silo) {
         StatusCode::FORBIDDEN,
         Method::POST,
         &admin_password_url,
-        &params::UserPassword::LoginDisallowed,
+        &test_params::UserPassword::LoginDisallowed,
     )
     .authn_as(AuthnMode::Session(session_token2.clone()))
     .execute()
@@ -311,21 +309,16 @@ async fn test_local_user_with_no_initial_password(
         client,
         silo,
         &test_user,
-        params::UserPassword::LoginDisallowed,
+        test_params::UserPassword::LoginDisallowed,
     )
     .await;
 
     // Logging in should not work.  (What password would we use, anyway?)
-    expect_login_failure(
-        client,
-        &silo_name,
-        test_user.clone(),
-        params::Password::from_str("").unwrap(),
-    )
-    .await;
+    expect_login_failure(client, &silo_name, test_user.clone(), "".to_string())
+        .await;
 
     // Now, set a password.
-    let test_password2 = params::Password::from_str("joshua").unwrap();
+    let test_password2 = "joshua";
     let user_password_url = format!(
         "/v1/system/identity-providers/local/users/{}/set-password?silo={}",
         created_user.id, silo_name,
@@ -333,8 +326,8 @@ async fn test_local_user_with_no_initial_password(
     NexusRequest::new(
         RequestBuilder::new(client, Method::POST, &user_password_url)
             .expect_status(Some(StatusCode::NO_CONTENT))
-            .body(Some(&params::UserPassword::Password(
-                test_password2.clone(),
+            .body(Some(&test_params::UserPassword::Password(
+                test_password2.to_string(),
             ))),
     )
     .authn_as(AuthnMode::PrivilegedUser)
@@ -347,7 +340,7 @@ async fn test_local_user_with_no_initial_password(
         client,
         &silo_name,
         test_user.clone(),
-        test_password2.clone(),
+        test_password2.to_string(),
     )
     .await;
     let found_user = expect_session_valid(client, &session_token).await;
@@ -386,7 +379,7 @@ async fn expect_login_failure(
     client: &ClientTestContext,
     silo_name: &Name,
     username: UserId,
-    password: params::Password,
+    password: String,
 ) {
     let start = std::time::Instant::now();
     let login_url = format!("/v1/login/{}/local", silo_name);
@@ -396,7 +389,7 @@ async fn expect_login_failure(
             StatusCode::UNAUTHORIZED,
             Method::POST,
             &login_url,
-            &params::UsernamePasswordCredentials { username, password },
+            &test_params::UsernamePasswordCredentials { username, password },
         )
         .execute()
         .await
@@ -426,12 +419,15 @@ async fn expect_login_success(
     client: &ClientTestContext,
     silo_name: &Name,
     username: UserId,
-    password: params::Password,
+    password: String,
 ) -> String {
     let start = std::time::Instant::now();
     let login_url = format!("/v1/login/{}/local", silo_name);
     let response = RequestBuilder::new(client, Method::POST, &login_url)
-        .body(Some(&params::UsernamePasswordCredentials { username, password }))
+        .body(Some(&test_params::UsernamePasswordCredentials {
+            username,
+            password,
+        }))
         .expect_status(Some(StatusCode::NO_CONTENT))
         .execute()
         .await

--- a/nexus/tests/integration_tests/quotas.rs
+++ b/nexus/tests/integration_tests/quotas.rs
@@ -12,6 +12,7 @@ use nexus_test_utils::resource_helpers::create_local_user;
 use nexus_test_utils::resource_helpers::grant_iam;
 use nexus_test_utils::resource_helpers::link_ip_pool;
 use nexus_test_utils::resource_helpers::object_create;
+use nexus_test_utils::resource_helpers::test_params;
 use nexus_test_utils_macros::nexus_test;
 use nexus_types::external_api::params;
 use nexus_types::external_api::shared;
@@ -202,7 +203,7 @@ async fn setup_silo_with_quota(
         client,
         &silo,
         &"user".parse().unwrap(),
-        params::UserPassword::LoginDisallowed,
+        test_params::UserPassword::LoginDisallowed,
     )
     .await;
 

--- a/nexus/tests/integration_tests/rack.rs
+++ b/nexus/tests/integration_tests/rack.rs
@@ -14,6 +14,7 @@ use nexus_test_utils::TEST_SUITE_PASSWORD;
 use nexus_test_utils::http_testing::AuthnMode;
 use nexus_test_utils::http_testing::NexusRequest;
 use nexus_test_utils::http_testing::RequestBuilder;
+use nexus_test_utils::resource_helpers::test_params;
 use nexus_test_utils_macros::nexus_test;
 use nexus_types::external_api::params;
 use nexus_types::external_api::shared::UninitializedSled;
@@ -75,9 +76,12 @@ async fn test_rack_initialization(cptestctx: &ControlPlaneTestContext) {
     // login.
     let login_url = format!("/v1/login/{}/local", cptestctx.silo_name);
     let username = cptestctx.user_name.clone();
-    let password: params::Password = TEST_SUITE_PASSWORD.parse().unwrap();
+    let password = TEST_SUITE_PASSWORD.to_string();
     let _ = RequestBuilder::new(&client, Method::POST, &login_url)
-        .body(Some(&params::UsernamePasswordCredentials { username, password }))
+        .body(Some(&test_params::UsernamePasswordCredentials {
+            username,
+            password,
+        }))
         .expect_status(Some(StatusCode::NO_CONTENT))
         .execute()
         .await

--- a/nexus/tests/integration_tests/silos.rs
+++ b/nexus/tests/integration_tests/silos.rs
@@ -16,7 +16,7 @@ use nexus_test_utils::http_testing::{AuthnMode, NexusRequest, RequestBuilder};
 use nexus_test_utils::resource_helpers::{
     create_ip_pool, create_local_user, create_project, create_silo, grant_iam,
     link_ip_pool, object_create, object_delete, objects_list_page_authz,
-    projects_list,
+    projects_list, test_params,
 };
 use nexus_test_utils_macros::nexus_test;
 use nexus_types::external_api::views::Certificate;
@@ -145,7 +145,7 @@ async fn test_silos(cptestctx: &ControlPlaneTestContext) {
         client,
         &silos[0],
         &"some-silo-user".parse().unwrap(),
-        params::UserPassword::LoginDisallowed,
+        test_params::UserPassword::LoginDisallowed,
     )
     .await
     .id;
@@ -797,7 +797,7 @@ async fn test_silo_user_provision_types(cptestctx: &ControlPlaneTestContext) {
                         client,
                         &silo,
                         &"external-id-com".parse().unwrap(),
-                        params::UserPassword::LoginDisallowed,
+                        test_params::UserPassword::LoginDisallowed,
                     )
                     .await;
                 }
@@ -871,7 +871,7 @@ async fn test_silo_user_fetch_by_external_id(
         client,
         &silo,
         &"f5513e049dac9468de5bdff36ab17d04f".parse().unwrap(),
-        params::UserPassword::LoginDisallowed,
+        test_params::UserPassword::LoginDisallowed,
     )
     .await;
 
@@ -935,7 +935,7 @@ async fn test_silo_users_list(cptestctx: &ControlPlaneTestContext) {
         client,
         &views::Silo::try_from(DEFAULT_SILO.clone()).unwrap(),
         &new_silo_user_external_id.parse().unwrap(),
-        params::UserPassword::LoginDisallowed,
+        test_params::UserPassword::LoginDisallowed,
     )
     .await
     .id;
@@ -979,7 +979,7 @@ async fn test_silo_users_list(cptestctx: &ControlPlaneTestContext) {
         client,
         &silo,
         &new_silo_user_name.parse().unwrap(),
-        params::UserPassword::LoginDisallowed,
+        test_params::UserPassword::LoginDisallowed,
     )
     .await
     .id;
@@ -1109,7 +1109,7 @@ async fn test_silo_groups_fixed(cptestctx: &ControlPlaneTestContext) {
         client,
         &silo,
         &"external-id-com".parse().unwrap(),
-        params::UserPassword::LoginDisallowed,
+        test_params::UserPassword::LoginDisallowed,
     )
     .await;
 
@@ -1545,7 +1545,7 @@ async fn test_silo_user_views(cptestctx: &ControlPlaneTestContext) {
         client,
         &silo2,
         &"silo2-user1".parse().unwrap(),
-        params::UserPassword::LoginDisallowed,
+        test_params::UserPassword::LoginDisallowed,
     )
     .await;
     let silo2_user1_id = silo2_user1.id;
@@ -1553,7 +1553,7 @@ async fn test_silo_user_views(cptestctx: &ControlPlaneTestContext) {
         client,
         &silo2,
         &"silo2-user2".parse().unwrap(),
-        params::UserPassword::LoginDisallowed,
+        test_params::UserPassword::LoginDisallowed,
     )
     .await;
     let silo2_user2_id = silo2_user2.id;
@@ -1768,9 +1768,9 @@ async fn test_jit_silo_constraints(cptestctx: &ControlPlaneTestContext) {
                 StatusCode::NOT_FOUND,
                 Method::POST,
                 "/v1/system/identity-providers/local/users?silo=jit",
-                &params::UserCreate {
+                &test_params::UserCreate {
                     external_id: UserId::from_str("dummy").unwrap(),
-                    password: params::UserPassword::LoginDisallowed,
+                    password: test_params::UserPassword::LoginDisallowed,
                 },
             )
             .authn_as(caller),
@@ -1793,7 +1793,7 @@ async fn test_jit_silo_constraints(cptestctx: &ControlPlaneTestContext) {
     // Neither the "test-privileged" user nor the Silo Admin ought to be able to
     // remove this user via the local identity provider, nor set the user's
     // password.
-    let password = params::Password::from_str("dummy").unwrap();
+    let password = "dummy";
     for caller in
         [AuthnMode::PrivilegedUser, AuthnMode::SiloUser(admin_user.id)]
     {
@@ -1814,7 +1814,7 @@ async fn test_jit_silo_constraints(cptestctx: &ControlPlaneTestContext) {
                 StatusCode::NOT_FOUND,
                 Method::POST,
                 &user_url_set_password,
-                &params::UserPassword::Password(password.clone()),
+                &test_params::UserPassword::Password(password.to_string()),
             )
             .authn_as(caller.clone()),
         )
@@ -1828,9 +1828,9 @@ async fn test_jit_silo_constraints(cptestctx: &ControlPlaneTestContext) {
         StatusCode::NOT_FOUND,
         Method::POST,
         "/v1/login/jit/local",
-        &params::UsernamePasswordCredentials {
+        &test_params::UsernamePasswordCredentials {
             username: UserId::from_str(admin_username).unwrap(),
-            password: password.clone(),
+            password: password.to_string(),
         },
     ))
     .await;
@@ -1841,9 +1841,9 @@ async fn test_jit_silo_constraints(cptestctx: &ControlPlaneTestContext) {
         StatusCode::NOT_FOUND,
         Method::POST,
         "/v1/login/jit/local",
-        &params::UsernamePasswordCredentials {
+        &test_params::UsernamePasswordCredentials {
             username: UserId::from_str("bogus").unwrap(),
-            password: password.clone(),
+            password: password.to_string(),
         },
     ))
     .await;
@@ -1879,7 +1879,7 @@ async fn test_local_silo_constraints(cptestctx: &ControlPlaneTestContext) {
         client,
         &silo,
         &"admin-user".parse().unwrap(),
-        params::UserPassword::LoginDisallowed,
+        test_params::UserPassword::LoginDisallowed,
     )
     .await
     .id;
@@ -1988,7 +1988,7 @@ async fn test_local_silo_users(cptestctx: &ControlPlaneTestContext) {
         client,
         &silo1,
         &"admin-user".parse().unwrap(),
-        params::UserPassword::LoginDisallowed,
+        test_params::UserPassword::LoginDisallowed,
     )
     .await;
     grant_iam(
@@ -2039,9 +2039,9 @@ async fn run_user_tests(
     let user_created = NexusRequest::objects_post(
         client,
         &url_user_create,
-        &params::UserCreate {
+        &test_params::UserCreate {
             external_id: UserId::from_str("a-test-user").unwrap(),
-            password: params::UserPassword::LoginDisallowed,
+            password: test_params::UserPassword::LoginDisallowed,
         },
     )
     .authn_as(authn_mode.clone())
@@ -2274,7 +2274,7 @@ async fn test_silo_authn_policy(cptestctx: &ControlPlaneTestContext) {
             client,
             &silo,
             &(format!("{}-user", label).parse().unwrap()),
-            params::UserPassword::LoginDisallowed,
+            test_params::UserPassword::LoginDisallowed,
         )
         .await;
         grant_iam(
@@ -2469,7 +2469,7 @@ async fn test_silo_admin_can_create_certs(cptestctx: &ControlPlaneTestContext) {
         client,
         &silo,
         &"admin".parse().unwrap(),
-        params::UserPassword::LoginDisallowed,
+        test_params::UserPassword::LoginDisallowed,
     )
     .await
     .id;

--- a/nexus/types/src/external_api/params.rs
+++ b/nexus/types/src/external_api/params.rs
@@ -483,7 +483,7 @@ pub struct SiloQuotasUpdate {
 }
 
 /// Create-time parameters for a `User`
-#[derive(Clone, Deserialize, Serialize, JsonSchema)]
+#[derive(Clone, Deserialize, JsonSchema)]
 pub struct UserCreate {
     /// username used to log in
     pub external_id: UserId,
@@ -492,14 +492,13 @@ pub struct UserCreate {
 }
 
 /// A password used for authenticating a local-only user
-#[derive(Clone, Deserialize, Serialize)]
+#[derive(Clone, Deserialize)]
 #[serde(try_from = "String")]
-#[serde(into = "String")]
 // We store both the raw String and omicron_passwords::Password forms of the
 // password.  That's because `omicron_passwords::Password` does not support
 // getting the String back out (by design), but we may need to do that in order
 // to impl Serialize.  See the `From<Password> for String` impl below.
-pub struct Password(String, omicron_passwords::Password);
+pub struct Password(omicron_passwords::Password);
 
 impl FromStr for Password {
     type Err = String;
@@ -517,16 +516,7 @@ impl TryFrom<String> for Password {
         // TODO-security If we want to apply password policy rules, this seems
         // like the place.  We presumably want to also document them in the
         // OpenAPI schema below.  See omicron#2307.
-        Ok(Password(value, inner))
-    }
-}
-
-// This "From" impl only exists to make it easier to derive `Serialize`.  That
-// in turn is only to make this easier to use from the test suite.  (There's no
-// other reason structs in this file should need to impl Serialize at all.)
-impl From<Password> for String {
-    fn from(password: Password) -> Self {
-        password.0
+        Ok(Password(inner))
     }
 }
 
@@ -568,12 +558,12 @@ impl JsonSchema for Password {
 
 impl AsRef<omicron_passwords::Password> for Password {
     fn as_ref(&self) -> &omicron_passwords::Password {
-        &self.1
+        &self.0
     }
 }
 
 /// Parameters for setting a user's password
-#[derive(Clone, Deserialize, JsonSchema, Serialize)]
+#[derive(Clone, Deserialize, JsonSchema)]
 #[serde(rename_all = "snake_case")]
 #[serde(tag = "mode", content = "value")]
 pub enum UserPassword {
@@ -584,7 +574,7 @@ pub enum UserPassword {
 }
 
 /// Credentials for local user login
-#[derive(Clone, Deserialize, JsonSchema, Serialize)]
+#[derive(Clone, Deserialize, JsonSchema)]
 pub struct UsernamePasswordCredentials {
     pub username: UserId,
     pub password: Password,

--- a/passwords/Cargo.toml
+++ b/passwords/Cargo.toml
@@ -8,10 +8,16 @@ license = "MPL-2.0"
 workspace = true
 
 [dependencies]
-argon2 = { version = "0.5.3", features = ["alloc", "password-hash", "rand", "std"] }
+argon2 = { version = "0.5.3", features = [
+    "alloc",
+    "password-hash",
+    "rand",
+    "std",
+] }
 rand.workspace = true
 thiserror.workspace = true
 schemars.workspace = true
+secrecy.workspace = true
 serde.workspace = true
 serde_with.workspace = true
 omicron-workspace-hack.workspace = true


### PR DESCRIPTION
This wraps uses of user passwords in `secrecy` types that:

1. make an effort to not accidentally expose passwords (via Debug, serialization, etc.)
2. zeroize memory when a password is no longer used.

The Nexus external API parameter type for passwords kept a local String copy of user passwords in addition to the internal password type, the former of which was used only for testing purposes. This removes that, ensuring that passwords in Nexus are always wrapped in `secrecy`, but it has the unfortunate requirement now that test code needs to use slightly different parameter types than those exposed by the external Nexus API. I've tried to make it clear where that happens in code and why in the code comments, but happy to take suggestions on different approaches.