### PR TITLE
[common] make ZpoolName Copy, constructors const fns

### DIFF
--- a/common/src/zpool_name.rs
+++ b/common/src/zpool_name.rs
@@ -39,7 +39,9 @@ pub enum ZpoolKind {
 ///
 /// This expects that the format will be: `ox{i,p}_<UUID>` - we parse the prefix
 /// when reading the structure, and validate that the UUID can be utilized.
-#[derive(Clone, Debug, Hash, PartialEq, Eq, PartialOrd, Ord, Diffable)]
+#[derive(
+    Clone, Copy, Debug, Hash, PartialEq, Eq, PartialOrd, Ord, Diffable,
+)]
 #[daft(leaf)]
 pub struct ZpoolName {
     id: ZpoolUuid,
@@ -80,19 +82,19 @@ impl JsonSchema for ZpoolName {
 }
 
 impl ZpoolName {
-    pub fn new_internal(id: ZpoolUuid) -> Self {
+    pub const fn new_internal(id: ZpoolUuid) -> Self {
         Self { id, kind: ZpoolKind::Internal }
     }
 
-    pub fn new_external(id: ZpoolUuid) -> Self {
+    pub const fn new_external(id: ZpoolUuid) -> Self {
         Self { id, kind: ZpoolKind::External }
     }
 
-    pub fn id(&self) -> ZpoolUuid {
+    pub const fn id(&self) -> ZpoolUuid {
         self.id
     }
 
-    pub fn kind(&self) -> ZpoolKind {
+    pub const fn kind(&self) -> ZpoolKind {
         self.kind
     }
 

--- a/installinator/src/write.rs
+++ b/installinator/src/write.rs
@@ -115,7 +115,7 @@ impl WriteDestination {
                         "zpool" => %disk.zpool_name(),
                     );
 
-                    let zpool_name = disk.zpool_name().clone();
+                    let zpool_name = *disk.zpool_name();
                     let control_plane_dir = zpool_name.dataset_mountpoint(
                         illumos_utils::zpool::ZPOOL_MOUNTPOINT_ROOT.into(),
                         sled_storage::dataset::INSTALL_DATASET,

--- a/nexus/db-queries/src/db/datastore/rack.rs
+++ b/nexus/db-queries/src/db/datastore/rack.rs
@@ -1385,7 +1385,7 @@ mod test {
                 BlueprintZoneConfig {
                     disposition: BlueprintZoneDisposition::InService,
                     id: external_dns_id,
-                    filesystem_pool: dataset.pool_name.clone(),
+                    filesystem_pool: dataset.pool_name,
                     zone_type: BlueprintZoneType::ExternalDns(
                         blueprint_zone_type::ExternalDns {
                             dataset,
@@ -2085,7 +2085,7 @@ mod test {
                 BlueprintZoneConfig {
                     disposition: BlueprintZoneDisposition::InService,
                     id: external_dns_id,
-                    filesystem_pool: dataset.pool_name.clone(),
+                    filesystem_pool: dataset.pool_name,
                     zone_type: BlueprintZoneType::ExternalDns(
                         blueprint_zone_type::ExternalDns {
                             dataset,

--- a/nexus/reconfigurator/execution/src/omicron_sled_config.rs
+++ b/nexus/reconfigurator/execution/src/omicron_sled_config.rs
@@ -258,7 +258,7 @@ mod tests {
         datasets.insert(BlueprintDatasetConfig {
             disposition: BlueprintDatasetDisposition::InService,
             id: dataset_id,
-            pool: dataset_pool.clone(),
+            pool: dataset_pool,
             kind: DatasetKind::Crucible,
             address: None,
             quota: None,
@@ -286,7 +286,7 @@ mod tests {
         zones.insert(BlueprintZoneConfig {
             disposition: BlueprintZoneDisposition::InService,
             id: zone_id,
-            filesystem_pool: dataset_pool.clone(),
+            filesystem_pool: dataset_pool,
             zone_type: BlueprintZoneType::Oximeter(
                 blueprint_zone_type::Oximeter {
                     address: "[::1]:0".parse().unwrap(),
@@ -300,7 +300,7 @@ mod tests {
                 ready_for_cleanup: false,
             },
             id: OmicronZoneUuid::new_v4(),
-            filesystem_pool: dataset_pool.clone(),
+            filesystem_pool: dataset_pool,
             zone_type: BlueprintZoneType::Oximeter(
                 blueprint_zone_type::Oximeter {
                     address: "[::1]:0".parse().unwrap(),

--- a/nexus/reconfigurator/planning/src/blueprint_builder/builder.rs
+++ b/nexus/reconfigurator/planning/src/blueprint_builder/builder.rs
@@ -1153,7 +1153,7 @@ impl<'a> BlueprintBuilder<'a> {
         let zpool = self.sled_select_zpool(sled_id, ZoneKind::InternalDns)?;
         let zone_type =
             BlueprintZoneType::InternalDns(blueprint_zone_type::InternalDns {
-                dataset: OmicronZoneDataset { pool_name: zpool.clone() },
+                dataset: OmicronZoneDataset { pool_name: zpool },
                 dns_address: SocketAddrV6::new(address, DNS_PORT, 0, 0),
                 http_address: SocketAddrV6::new(address, DNS_HTTP_PORT, 0, 0),
                 gz_address: dns_subnet.gz_address(),
@@ -1206,7 +1206,7 @@ impl<'a> BlueprintBuilder<'a> {
             self.sled_select_zpool(sled_id, ZoneKind::ExternalDns)?;
         let zone_type =
             BlueprintZoneType::ExternalDns(blueprint_zone_type::ExternalDns {
-                dataset: OmicronZoneDataset { pool_name: pool_name.clone() },
+                dataset: OmicronZoneDataset { pool_name },
                 http_address,
                 dns_address,
                 nic,
@@ -1308,7 +1308,7 @@ impl<'a> BlueprintBuilder<'a> {
         let zone_type =
             BlueprintZoneType::Crucible(blueprint_zone_type::Crucible {
                 address,
-                dataset: OmicronZoneDataset { pool_name: pool_name.clone() },
+                dataset: OmicronZoneDataset { pool_name },
             });
         let filesystem_pool = pool_name;
 
@@ -1482,7 +1482,7 @@ impl<'a> BlueprintBuilder<'a> {
         let zone_type =
             BlueprintZoneType::CockroachDb(blueprint_zone_type::CockroachDb {
                 address,
-                dataset: OmicronZoneDataset { pool_name: pool_name.clone() },
+                dataset: OmicronZoneDataset { pool_name },
             });
         let filesystem_pool = pool_name;
 
@@ -1509,7 +1509,7 @@ impl<'a> BlueprintBuilder<'a> {
         let zone_type =
             BlueprintZoneType::Clickhouse(blueprint_zone_type::Clickhouse {
                 address,
-                dataset: OmicronZoneDataset { pool_name: pool_name.clone() },
+                dataset: OmicronZoneDataset { pool_name },
             });
 
         let zone = BlueprintZoneConfig {
@@ -1535,7 +1535,7 @@ impl<'a> BlueprintBuilder<'a> {
         let zone_type = BlueprintZoneType::ClickhouseServer(
             blueprint_zone_type::ClickhouseServer {
                 address,
-                dataset: OmicronZoneDataset { pool_name: pool_name.clone() },
+                dataset: OmicronZoneDataset { pool_name },
             },
         );
         let filesystem_pool = pool_name;
@@ -1563,7 +1563,7 @@ impl<'a> BlueprintBuilder<'a> {
         let zone_type = BlueprintZoneType::ClickhouseKeeper(
             blueprint_zone_type::ClickhouseKeeper {
                 address,
-                dataset: OmicronZoneDataset { pool_name: pool_name.clone() },
+                dataset: OmicronZoneDataset { pool_name },
             },
         );
         let filesystem_pool = pool_name;
@@ -2222,7 +2222,7 @@ pub mod test {
                     {
                         let ip = address.ip();
                         assert!(new_sled_resources.subnet.net().contains(*ip));
-                        Some(dataset.pool_name.clone())
+                        Some(dataset.pool_name)
                     } else {
                         None
                     }

--- a/nexus/reconfigurator/planning/src/blueprint_editor/allocators/external_networking.rs
+++ b/nexus/reconfigurator/planning/src/blueprint_editor/allocators/external_networking.rs
@@ -886,7 +886,7 @@ pub mod test {
             BlueprintZoneConfig {
                 disposition,
                 id,
-                filesystem_pool: pool_name.clone(),
+                filesystem_pool: pool_name,
                 zone_type: BlueprintZoneType::ExternalDns(
                     blueprint_zone_type::ExternalDns {
                         dataset: OmicronZoneDataset { pool_name },

--- a/nexus/reconfigurator/planning/src/blueprint_editor/sled_editor.rs
+++ b/nexus/reconfigurator/planning/src/blueprint_editor/sled_editor.rs
@@ -517,7 +517,7 @@ impl ActiveSledEditor {
 
         // Every disk also gets a Debug and Transient Zone Root dataset; ensure
         // both of those exist as well.
-        let debug = PartialDatasetConfig::for_debug(zpool.clone());
+        let debug = PartialDatasetConfig::for_debug(zpool);
         let zone_root = PartialDatasetConfig::for_transient_zone_root(zpool);
 
         self.datasets.ensure_in_service(debug, rng);
@@ -672,7 +672,7 @@ impl ZoneDatasetConfigs {
                 _ => None,
             };
             PartialDatasetConfig::for_durable_zone(
-                dataset.dataset.pool_name.clone(),
+                dataset.dataset.pool_name,
                 dataset.kind,
                 address,
             )
@@ -684,8 +684,8 @@ impl ZoneDatasetConfigs {
             if filesystem_dataset.zpool() != dur.zpool() {
                 return Err(SledEditError::ZoneInvalidZpoolCombination {
                     zone_id: zone.id,
-                    fs_zpool: filesystem_dataset.zpool().clone(),
-                    dur_zpool: dur.zpool().clone(),
+                    fs_zpool: *filesystem_dataset.zpool(),
+                    dur_zpool: *dur.zpool(),
                 });
             }
         }
@@ -695,7 +695,7 @@ impl ZoneDatasetConfigs {
         if !disks.contains_zpool(&filesystem_dataset.zpool().id()) {
             return Err(SledEditError::ZoneOnNonexistentZpool {
                 zone_id: zone.id,
-                zpool: filesystem_dataset.zpool().clone(),
+                zpool: *filesystem_dataset.zpool(),
             });
         }
 

--- a/nexus/reconfigurator/planning/src/blueprint_editor/sled_editor/datasets.rs
+++ b/nexus/reconfigurator/planning/src/blueprint_editor/sled_editor/datasets.rs
@@ -502,10 +502,7 @@ mod tests {
                 .expect("expunged dataset");
 
             let new_dataset = PartialDatasetConfig {
-                name: DatasetName::new(
-                    dataset.pool.clone(),
-                    dataset.kind.clone(),
-                ),
+                name: DatasetName::new(dataset.pool, dataset.kind.clone()),
                 address: dataset.address,
                 quota: dataset.quota,
                 reservation: dataset.reservation,
@@ -563,10 +560,7 @@ mod tests {
             .filter(|dataset| dataset.disposition.is_in_service())
         {
             let new_dataset = PartialDatasetConfig {
-                name: DatasetName::new(
-                    dataset.pool.clone(),
-                    dataset.kind.clone(),
-                ),
+                name: DatasetName::new(dataset.pool, dataset.kind.clone()),
                 address: dataset.address,
                 quota: dataset.quota,
                 reservation: dataset.reservation,

--- a/nexus/reconfigurator/planning/src/planner.rs
+++ b/nexus/reconfigurator/planning/src/planner.rs
@@ -2411,7 +2411,7 @@ pub(crate) mod test {
             .find_map(|(_, sled_config)| {
                 for zone_config in &sled_config.zones {
                     if zone_config.zone_type.is_ntp() {
-                        return Some(zone_config.filesystem_pool.clone());
+                        return Some(zone_config.filesystem_pool);
                     }
                 }
                 None

--- a/nexus/test-utils/src/lib.rs
+++ b/nexus/test-utils/src/lib.rs
@@ -889,7 +889,7 @@ impl<'a, N: NexusServer> ControlPlaneTestContextBuilder<'a, N> {
                         datasets.insert(BlueprintDatasetConfig {
                             disposition: BlueprintDatasetDisposition::InService,
                             id,
-                            pool: zpool.clone(),
+                            pool: *zpool,
                             kind: DatasetKind::TransientZone {
                                 name: illumos_utils::zone::zone_name(
                                     zone.zone_type.kind().zone_prefix(),

--- a/nexus/types/src/deployment.rs
+++ b/nexus/types/src/deployment.rs
@@ -811,7 +811,7 @@ impl BlueprintZoneConfig {
             Some(self.id),
         );
         let kind = DatasetKind::TransientZone { name };
-        DatasetName::new(self.filesystem_pool.clone(), kind)
+        DatasetName::new(self.filesystem_pool, kind)
     }
 
     pub fn kind(&self) -> ZoneKind {
@@ -1546,7 +1546,7 @@ fn unwrap_or_none<T: ToString>(opt: &Option<T>) -> String {
 impl BlueprintDatasetConfig {
     fn as_strings(&self) -> Vec<String> {
         vec![
-            DatasetName::new(self.pool.clone(), self.kind.clone()).full_name(),
+            DatasetName::new(self.pool, self.kind.clone()).full_name(),
             self.id.to_string(),
             self.disposition.to_string(),
             unwrap_or_none(&self.quota),
@@ -1623,7 +1623,7 @@ impl From<&BlueprintDatasetConfig> for CollectionDatasetIdentifier {
     fn from(d: &BlueprintDatasetConfig) -> Self {
         Self {
             id: Some(d.id),
-            name: DatasetName::new(d.pool.clone(), d.kind.clone()).full_name(),
+            name: DatasetName::new(d.pool, d.kind.clone()).full_name(),
         }
     }
 }

--- a/nexus/types/src/deployment/blueprint_diff.rs
+++ b/nexus/types/src/deployment/blueprint_diff.rs
@@ -551,7 +551,7 @@ impl ModifiedZone {
                 zone: BlueprintZoneConfig {
                     disposition: *diff.disposition.after,
                     id: *diff.id.after,
-                    filesystem_pool: diff.filesystem_pool.after.clone(),
+                    filesystem_pool: *diff.filesystem_pool.after,
                     zone_type: diff.zone_type.after.clone(),
                     image_source: diff.image_source.after.clone(),
                 },
@@ -1043,7 +1043,7 @@ impl ModifiedDataset {
                 dataset: BlueprintDatasetConfig {
                     disposition: *disposition.after,
                     id: *id.after,
-                    pool: pool.after.clone(),
+                    pool: *pool.after,
                     kind: kind.after.clone(),
                     address: address.after.copied(),
                     quota: quota.after.copied(),
@@ -1074,9 +1074,8 @@ impl BpDiffDatasetsModified {
                 Err(error) => errors.push(error),
             }
         }
-        datasets.sort_unstable_by_key(|d| {
-            (d.dataset.kind.clone(), d.dataset.pool.clone())
-        });
+        datasets
+            .sort_unstable_by_key(|d| (d.dataset.kind.clone(), d.dataset.pool));
         (BpDiffDatasetsModified { datasets }, BpDiffDatasetErrors { errors })
     }
 }
@@ -1096,7 +1095,7 @@ impl BpTableData for BpDiffDatasetsModified {
                 vec![
                     BpTableColumn::value(
                         DatasetName::new(
-                            dataset.dataset.pool.clone(),
+                            dataset.dataset.pool,
                             dataset.dataset.kind.clone(),
                         )
                         .full_name(),

--- a/nexus/types/src/deployment/zone_type.rs
+++ b/nexus/types/src/deployment/zone_type.rs
@@ -241,7 +241,7 @@ pub struct DurableDataset<'a> {
 
 impl<'a> From<DurableDataset<'a>> for DatasetName {
     fn from(d: DurableDataset<'a>) -> Self {
-        DatasetName::new(d.dataset.pool_name.clone(), d.kind)
+        DatasetName::new(d.dataset.pool_name, d.kind)
     }
 }
 

--- a/sled-agent/config-reconciler/src/dump_setup.rs
+++ b/sled-agent/config-reconciler/src/dump_setup.rs
@@ -276,7 +276,7 @@ impl DumpSetup {
                         if info.health() == ZpoolHealth::Online {
                             m2_core_datasets.push(CoreZpool {
                                 mount_config: mount_config.clone(),
-                                name: name.clone(),
+                                name: *name,
                             });
                         } else {
                             warn!(
@@ -294,7 +294,7 @@ impl DumpSetup {
                         if info.health() == ZpoolHealth::Online {
                             u2_debug_datasets.push(DebugZpool {
                                 mount_config: mount_config.clone(),
-                                name: name.clone(),
+                                name: *name,
                             });
                         } else {
                             warn!(

--- a/sled-agent/config-reconciler/src/internal_disks.rs
+++ b/sled-agent/config-reconciler/src/internal_disks.rs
@@ -333,7 +333,7 @@ impl From<&'_ Disk> for InternalDiskDetails {
 
         Self {
             identity: Arc::new(disk.identity().clone()),
-            zpool_name: disk.zpool_name().clone(),
+            zpool_name: *disk.zpool_name(),
             is_boot_disk: disk.is_boot_disk(),
             slot,
             raw_devfs_path,

--- a/sled-agent/src/instance.rs
+++ b/sled-agent/src/instance.rs
@@ -1783,7 +1783,7 @@ impl InstanceRunner {
             return None;
         };
         match run_state.running_zone.root_zpool() {
-            ZpoolOrRamdisk::Zpool(zpool_name) => Some(zpool_name.clone()),
+            ZpoolOrRamdisk::Zpool(zpool_name) => Some(*zpool_name),
             ZpoolOrRamdisk::Ramdisk => None,
         }
     }

--- a/sled-agent/src/params.rs
+++ b/sled-agent/src/params.rs
@@ -70,10 +70,7 @@ pub(crate) trait OmicronZoneTypeExt {
             }
         }?;
 
-        Some((
-            DatasetName::new(dataset.pool_name.clone(), dataset_kind),
-            *address,
-        ))
+        Some((DatasetName::new(dataset.pool_name, dataset_kind), *address))
     }
 }
 

--- a/sled-agent/src/rack_setup/service.rs
+++ b/sled-agent/src/rack_setup/service.rs
@@ -1498,7 +1498,7 @@ pub(crate) fn build_initial_blueprint_from_sled_configs(
             datasets.insert(BlueprintDatasetConfig {
                 disposition: BlueprintDatasetDisposition::InService,
                 id: d.id,
-                pool: d.name.pool().clone(),
+                pool: *d.name.pool(),
                 kind: d.name.kind().clone(),
                 address,
                 compression: d.inner.compression,

--- a/sled-agent/src/sim/server.rs
+++ b/sled-agent/src/sim/server.rs
@@ -397,7 +397,7 @@ pub async fn run_standalone_server(
         id: OmicronZoneUuid::new_v4(),
         zone_type: BlueprintZoneType::InternalDns(
             blueprint_zone_type::InternalDns {
-                dataset: OmicronZoneDataset { pool_name: pool_name.clone() },
+                dataset: OmicronZoneDataset { pool_name },
                 http_address: http_bound,
                 dns_address: match dns.dns_server.local_address() {
                     SocketAddr::V4(_) => panic!("did not expect v4 address"),
@@ -472,9 +472,7 @@ pub async fn run_standalone_server(
             id,
             zone_type: BlueprintZoneType::ExternalDns(
                 blueprint_zone_type::ExternalDns {
-                    dataset: OmicronZoneDataset {
-                        pool_name: pool_name.clone(),
-                    },
+                    dataset: OmicronZoneDataset { pool_name },
                     http_address: external_dns_internal_addr,
                     dns_address: from_sockaddr_to_external_floating_addr(
                         SocketAddr::V6(external_dns_internal_addr),

--- a/sled-agent/src/sled_agent.rs
+++ b/sled-agent/src/sled_agent.rs
@@ -1387,21 +1387,20 @@ impl SledAgent {
                 total_size: ByteCount::try_from(info.size())?,
             });
 
-            let inv_props =
-                match self.storage().datasets_list(zpool.clone()).await {
-                    Ok(props) => props
-                        .into_iter()
-                        .map(|prop| InventoryDataset::from(prop)),
-                    Err(err) => {
-                        warn!(
-                            self.log,
-                            "Failed to access dataset info within zpool";
-                            "zpool" => %zpool,
-                            "err" => %err
-                        );
-                        continue;
-                    }
-                };
+            let inv_props = match self.storage().datasets_list(zpool).await {
+                Ok(props) => {
+                    props.into_iter().map(|prop| InventoryDataset::from(prop))
+                }
+                Err(err) => {
+                    warn!(
+                        self.log,
+                        "Failed to access dataset info within zpool";
+                        "zpool" => %zpool,
+                        "err" => %err
+                    );
+                    continue;
+                }
+            };
             datasets.extend(inv_props);
         }
 

--- a/sled-diagnostics/src/logs.rs
+++ b/sled-diagnostics/src/logs.rs
@@ -842,7 +842,7 @@ mod illumos_tests {
         async fn configure_dataset(&self, kind: DatasetKind) -> Utf8PathBuf {
             let zpool_name = ZpoolName::new_external(self.zpool_id);
             let dataset_id = DatasetUuid::new_v4();
-            let name = DatasetName::new(zpool_name.clone(), kind);
+            let name = DatasetName::new(zpool_name, kind);
             let mountpoint = name.mountpoint(
                 &self.storage_test_harness.handle().mount_config().root,
             );

--- a/sled-storage/src/dataset.rs
+++ b/sled-storage/src/dataset.rs
@@ -502,7 +502,7 @@ async fn ensure_zpool_dataset_is_encrypted(
     }
     info!(log, "Dataset should be encrypted");
 
-    let encrypted_dataset = DatasetName::new(zpool_name.clone(), kind);
+    let encrypted_dataset = DatasetName::new(*zpool_name, kind);
     let encrypted_dataset = encrypted_dataset.full_name();
 
     let (unencrypted_dataset_exists, encrypted_dataset_exists) = (

--- a/sled-storage/src/manager.rs
+++ b/sled-storage/src/manager.rs
@@ -2046,8 +2046,7 @@ mod tests {
         // We can call "upsert_filesystem" both with and without a UUID.
         let dataset_id = DatasetUuid::new_v4();
         let zpool_name = ZpoolName::new_external(config.disks[0].pool_id);
-        let dataset_name =
-            DatasetName::new(zpool_name.clone(), DatasetKind::Crucible);
+        let dataset_name = DatasetName::new(zpool_name, DatasetKind::Crucible);
         harness
             .handle()
             .upsert_filesystem(Some(dataset_id), dataset_name.clone())
@@ -2099,8 +2098,7 @@ mod tests {
 
         // Create a filesystem on the newly formatted U.2, without a UUID
         let zpool_name = ZpoolName::new_external(config.disks[0].pool_id);
-        let dataset_name =
-            DatasetName::new(zpool_name.clone(), DatasetKind::Crucible);
+        let dataset_name = DatasetName::new(zpool_name, DatasetKind::Crucible);
         harness
             .handle()
             .upsert_filesystem(None, dataset_name.clone())
@@ -2152,7 +2150,7 @@ mod tests {
         // Create a dataset on the newly formatted U.2
         let id = DatasetUuid::new_v4();
         let zpool_name = ZpoolName::new_external(config.disks[0].pool_id);
-        let name = DatasetName::new(zpool_name.clone(), DatasetKind::Crucible);
+        let name = DatasetName::new(zpool_name, DatasetKind::Crucible);
         let datasets = BTreeMap::from([(
             id,
             DatasetConfig { id, name, inner: SharedDatasetConfig::default() },
@@ -2250,7 +2248,7 @@ mod tests {
         // Create a dataset on the newly formatted U.2
         let id = DatasetUuid::new_v4();
         let zpool_name = ZpoolName::new_external(config.disks[0].pool_id);
-        let name = DatasetName::new(zpool_name.clone(), DatasetKind::Debug);
+        let name = DatasetName::new(zpool_name, DatasetKind::Debug);
         let datasets = BTreeMap::from([(
             id,
             DatasetConfig {
@@ -2317,7 +2315,7 @@ mod tests {
             !kind.zoned(),
             "We need to use a non-zoned dataset for this test"
         );
-        let name = DatasetName::new(zpool_name.clone(), kind);
+        let name = DatasetName::new(zpool_name, kind);
         let datasets = BTreeMap::from([(
             id,
             DatasetConfig {
@@ -2425,33 +2423,30 @@ mod tests {
             let zpool_name = ZpoolName::new_external(config.disks[i].pool_id);
 
             let id = DatasetUuid::new_v4();
+            let name = DatasetName::new(zpool_name, DatasetKind::Crucible);
+            datasets.insert(
+                id,
+                DatasetConfig {
+                    id,
+                    name,
+                    inner: SharedDatasetConfig::default(),
+                },
+            );
+
+            let id = DatasetUuid::new_v4();
+            let name = DatasetName::new(zpool_name, DatasetKind::Debug);
+            datasets.insert(
+                id,
+                DatasetConfig {
+                    id,
+                    name,
+                    inner: SharedDatasetConfig::default(),
+                },
+            );
+
+            let id = DatasetUuid::new_v4();
             let name =
-                DatasetName::new(zpool_name.clone(), DatasetKind::Crucible);
-            datasets.insert(
-                id,
-                DatasetConfig {
-                    id,
-                    name,
-                    inner: SharedDatasetConfig::default(),
-                },
-            );
-
-            let id = DatasetUuid::new_v4();
-            let name = DatasetName::new(zpool_name.clone(), DatasetKind::Debug);
-            datasets.insert(
-                id,
-                DatasetConfig {
-                    id,
-                    name,
-                    inner: SharedDatasetConfig::default(),
-                },
-            );
-
-            let id = DatasetUuid::new_v4();
-            let name = DatasetName::new(
-                zpool_name.clone(),
-                DatasetKind::TransientZoneRoot,
-            );
+                DatasetName::new(zpool_name, DatasetKind::TransientZoneRoot);
             datasets.insert(
                 id,
                 DatasetConfig {
@@ -2504,7 +2499,7 @@ mod tests {
 
         // Use the dataset on the newly formatted U.2
         let all_disks = harness.handle().get_latest_disks().await;
-        let zpool = all_disks.all_u2_zpools()[0].clone();
+        let zpool = all_disks.all_u2_zpools()[0];
         let datasets = harness.handle().datasets_list(zpool).await.unwrap();
 
         let dataset = datasets

--- a/sled-storage/src/resources.rs
+++ b/sled-storage/src/resources.rs
@@ -100,7 +100,7 @@ impl AllDisks {
         for (id, disk) in self.inner.values.iter() {
             if let ManagedDisk::ImplicitlyManaged(disk) = disk {
                 if disk.is_boot_disk() {
-                    return Some((id.clone(), disk.zpool_name().clone()));
+                    return Some((id.clone(), *disk.zpool_name()));
                 }
             }
         }
@@ -147,7 +147,7 @@ impl AllDisks {
             .filter_map(|disk| match disk {
                 ManagedDisk::ExplicitlyManaged(disk)
                 | ManagedDisk::ImplicitlyManaged(disk) => {
-                    Some((disk.zpool_name().clone(), disk.variant()))
+                    Some((*disk.zpool_name(), disk.variant()))
                 }
                 ManagedDisk::Unmanaged(_) => None,
             })
@@ -165,7 +165,7 @@ impl AllDisks {
                 ManagedDisk::ExplicitlyManaged(disk)
                 | ManagedDisk::ImplicitlyManaged(disk) => {
                     if disk.variant() == variant {
-                        return Some(disk.zpool_name().clone());
+                        return Some(*disk.zpool_name());
                     }
                     None
                 }


### PR DESCRIPTION
`ZpoolName` is pretty small, just a UUID (16 bytes) plus an internal/external enum (8 bytes) = 24 bytes, so it makes sense to have it be `Copy`.

Make the constructors `const` as well, I'm going to need this in upcoming work.
