### PR TITLE
[reconfigurator] in blueprint displays, make KvList headings optional

### DIFF
--- a/nexus/types/src/deployment.rs
+++ b/nexus/types/src/deployment.rs
@@ -104,7 +104,7 @@ pub use zone_type::blueprint_zone_type;
 
 use blueprint_display::{
     BpDiffState, BpOmicronZonesTableSchema, BpPhysicalDisksTableSchema,
-    BpTable, BpTableData, BpTableRow, KvListWithHeading, constants::*,
+    BpTable, BpTableData, BpTableRow, KvList, constants::*,
 };
 use id_map::{IdMap, IdMappable};
 use serde::de::SeqAccess;
@@ -430,15 +430,15 @@ pub struct BlueprintDisplay<'a> {
 }
 
 impl BlueprintDisplay<'_> {
-    fn make_cockroachdb_table(&self) -> KvListWithHeading {
+    fn make_cockroachdb_table(&self) -> KvList {
         let fingerprint = if self.blueprint.cockroachdb_fingerprint.is_empty() {
             NONE_PARENS.to_string()
         } else {
             self.blueprint.cockroachdb_fingerprint.clone()
         };
 
-        KvListWithHeading::new_unchanged(
-            COCKROACHDB_HEADING,
+        KvList::new_unchanged(
+            Some(COCKROACHDB_HEADING),
             vec![
                 (COCKROACHDB_FINGERPRINT, fingerprint),
                 (
@@ -451,9 +451,9 @@ impl BlueprintDisplay<'_> {
         )
     }
 
-    fn make_oximeter_table(&self) -> KvListWithHeading {
-        KvListWithHeading::new_unchanged(
-            OXIMETER_HEADING,
+    fn make_oximeter_table(&self) -> KvList {
+        KvList::new_unchanged(
+            Some(OXIMETER_HEADING),
             vec![
                 (GENERATION, self.blueprint.oximeter_read_version.to_string()),
                 (
@@ -464,15 +464,15 @@ impl BlueprintDisplay<'_> {
         )
     }
 
-    fn make_metadata_table(&self) -> KvListWithHeading {
+    fn make_metadata_table(&self) -> KvList {
         let comment = if self.blueprint.comment.is_empty() {
             NONE_PARENS.to_string()
         } else {
             self.blueprint.comment.clone()
         };
 
-        KvListWithHeading::new_unchanged(
-            METADATA_HEADING,
+        KvList::new_unchanged(
+            Some(METADATA_HEADING),
             vec![
                 (CREATED_BY, self.blueprint.creator.clone()),
                 (
@@ -498,7 +498,7 @@ impl BlueprintDisplay<'_> {
     // Return tables representing a [`ClickhouseClusterConfig`] in a given blueprint
     fn make_clickhouse_cluster_config_tables(
         &self,
-    ) -> Option<(KvListWithHeading, BpTable, BpTable)> {
+    ) -> Option<(KvList, BpTable, BpTable)> {
         let config = &self.blueprint.clickhouse_cluster_config.as_ref()?;
 
         let diff_table =

--- a/nexus/types/src/deployment/blueprint_diff.rs
+++ b/nexus/types/src/deployment/blueprint_diff.rs
@@ -8,7 +8,7 @@ use super::blueprint_display::{
     BpClickhouseServersTableSchema, BpDatasetsTableSchema, BpDiffState,
     BpGeneration, BpOmicronZonesTableSchema, BpPendingMgsUpdates,
     BpPhysicalDisksTableSchema, BpTable, BpTableColumn, BpTableData,
-    BpTableRow, KvListWithHeading, KvPair, constants::*, linear_table_modified,
+    BpTableRow, KvList, KvPair, constants::*, linear_table_modified,
     linear_table_unchanged,
 };
 use super::{
@@ -1186,7 +1186,7 @@ impl BpDiffDatasets {
 /// there is only a single known blueprint with no before or after collection or
 /// bluerpint to compare to.
 pub struct ClickhouseClusterConfigDiffTablesForSingleBlueprint {
-    pub metadata: KvListWithHeading,
+    pub metadata: KvList,
     pub keepers: BpTable,
     pub servers: BpTable,
 }
@@ -1220,7 +1220,7 @@ impl ClickhouseClusterConfigDiffTablesForSingleBlueprint {
         .collect();
 
         let metadata =
-            KvListWithHeading::new(CLICKHOUSE_CLUSTER_CONFIG_HEADING, rows);
+            KvList::new(Some(CLICKHOUSE_CLUSTER_CONFIG_HEADING), rows);
 
         let keepers = BpTable::new(
             BpClickhouseKeepersTableSchema {},
@@ -1259,7 +1259,7 @@ impl From<ClickhouseClusterConfigDiffTablesForSingleBlueprint>
 /// `ClickhouseClusterConfig` tables or a `ClickhouseClusterConfig` table and
 /// its inventory representation.
 pub struct ClickhouseClusterConfigDiffTables {
-    pub metadata: KvListWithHeading,
+    pub metadata: KvList,
     pub keepers: BpTable,
     pub servers: Option<BpTable>,
 }
@@ -1289,8 +1289,8 @@ impl ClickhouseClusterConfigDiffTables {
                 ),
             )
         };
-        let metadata = KvListWithHeading::new(
-            CLICKHOUSE_CLUSTER_CONFIG_HEADING,
+        let metadata = KvList::new(
+            Some(CLICKHOUSE_CLUSTER_CONFIG_HEADING),
             vec![
                 KvPair::new(
                     BpDiffState::Added,
@@ -1434,8 +1434,8 @@ impl ClickhouseClusterConfigDiffTables {
             };
         }
 
-        let metadata = KvListWithHeading::new(
-            CLICKHOUSE_CLUSTER_CONFIG_HEADING,
+        let metadata = KvList::new(
+            Some(CLICKHOUSE_CLUSTER_CONFIG_HEADING),
             vec![
                 diff_row!(generation, GENERATION),
                 diff_row!(max_used_server_id, CLICKHOUSE_MAX_USED_SERVER_ID),
@@ -1523,8 +1523,8 @@ impl ClickhouseClusterConfigDiffTables {
         before: &clickhouse_admin_types::ClickhouseKeeperClusterMembership,
     ) -> Self {
         // There's only so much information in a collection. Show what we can.
-        let metadata = KvListWithHeading::new(
-            CLICKHOUSE_CLUSTER_CONFIG_HEADING,
+        let metadata = KvList::new(
+            Some(CLICKHOUSE_CLUSTER_CONFIG_HEADING),
             vec![KvPair::new(
                 BpDiffState::Removed,
                 CLICKHOUSE_HIGHEST_SEEN_KEEPER_LEADER_COMMITTED_LOG_INDEX,
@@ -1713,7 +1713,7 @@ impl<'diff> BlueprintDiffDisplay<'diff> {
 
     pub fn make_metadata_diff_tables(
         &self,
-    ) -> impl IntoIterator<Item = KvListWithHeading> {
+    ) -> impl IntoIterator<Item = KvList> {
         macro_rules! diff_row {
             ($member:ident, $label:expr) => {
                 diff_row!($member, $label, std::convert::identity)
@@ -1742,8 +1742,8 @@ impl<'diff> BlueprintDiffDisplay<'diff> {
         }
 
         [
-            KvListWithHeading::new(
-                COCKROACHDB_HEADING,
+            KvList::new(
+                Some(COCKROACHDB_HEADING),
                 vec![
                     diff_row!(
                         cockroachdb_fingerprint,
@@ -1757,8 +1757,8 @@ impl<'diff> BlueprintDiffDisplay<'diff> {
                     ),
                 ],
             ),
-            KvListWithHeading::new(
-                METADATA_HEADING,
+            KvList::new(
+                Some(METADATA_HEADING),
                 vec![
                     diff_row!(internal_dns_version, INTERNAL_DNS_VERSION),
                     diff_row!(external_dns_version, EXTERNAL_DNS_VERSION),
@@ -1769,7 +1769,7 @@ impl<'diff> BlueprintDiffDisplay<'diff> {
 
     pub fn make_oximeter_read_diff_tables(
         &self,
-    ) -> impl IntoIterator<Item = KvListWithHeading> {
+    ) -> impl IntoIterator<Item = KvList> {
         macro_rules! diff_row {
             ($member:ident, $label:expr) => {
                 diff_row!($member, $label, std::convert::identity)
@@ -1799,8 +1799,8 @@ impl<'diff> BlueprintDiffDisplay<'diff> {
             };
         }
 
-        [KvListWithHeading::new(
-            OXIMETER_HEADING,
+        [KvList::new(
+            Some(OXIMETER_HEADING),
             vec![
                 diff_row!(oximeter_read_version, GENERATION),
                 diff_row!(oximeter_read_mode, OXIMETER_READ_FROM),

--- a/nexus/types/src/deployment/blueprint_display.rs
+++ b/nexus/types/src/deployment/blueprint_display.rs
@@ -455,25 +455,25 @@ impl KvPair {
     }
 }
 
-// A top-to-bottom list of KV pairs with a heading
+// A top-to-bottom list of KV pairs, with or without a heading
 #[derive(Debug)]
-pub struct KvListWithHeading {
-    heading: &'static str,
+pub struct KvList {
+    heading: Option<&'static str>,
     kv: Vec<KvPair>,
 }
 
-impl KvListWithHeading {
+impl KvList {
     pub fn new_unchanged<S1: Into<String>, S2: Into<String>>(
-        heading: &'static str,
+        heading: Option<&'static str>,
         kv: Vec<(S1, S2)>,
-    ) -> KvListWithHeading {
+    ) -> KvList {
         let kv =
             kv.into_iter().map(|(k, v)| KvPair::new_unchanged(k, v)).collect();
-        KvListWithHeading { heading, kv }
+        KvList { heading, kv }
     }
 
-    pub fn new(heading: &'static str, kv: Vec<KvPair>) -> KvListWithHeading {
-        KvListWithHeading { heading, kv }
+    pub fn new(heading: Option<&'static str>, kv: Vec<KvPair>) -> KvList {
+        KvList { heading, kv }
     }
 
     /// Compute the max width of the keys for alignment purposes
@@ -482,10 +482,12 @@ impl KvListWithHeading {
     }
 }
 
-impl fmt::Display for KvListWithHeading {
+impl fmt::Display for KvList {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         // Write the heading
-        writeln!(f, " {}:", self.heading)?;
+        if let Some(heading) = self.heading {
+            writeln!(f, " {}:", heading)?;
+        }
 
         // Write the rows
         let key_width = self.max_key_width() + 1;


### PR DESCRIPTION
I'd like to use `KvListWithHeading` in a place where there isn't a reasonable heading. Rename the struct to `KvList` and make the heading optional.
