### PR TITLE
[1/n] Add `id` column on tokens and sessions

### DIFF
--- a/nexus/auth/src/authn/external/session_cookie.rs
+++ b/nexus/auth/src/authn/external/session_cookie.rs
@@ -13,6 +13,7 @@ use chrono::{DateTime, Duration, Utc};
 use dropshot::HttpError;
 use http::HeaderValue;
 use nexus_types::authn::cookies::parse_cookies;
+use omicron_uuid_kinds::{ConsoleSessionKind, TypedUuid};
 use slog::debug;
 use uuid::Uuid;
 
@@ -20,6 +21,7 @@ use uuid::Uuid;
 // https://cheatsheetseries.owasp.org/cheatsheets/Session_Management_Cheat_Sheet.html
 
 pub trait Session {
+    fn id(&self) -> TypedUuid<ConsoleSessionKind>;
     fn silo_user_id(&self) -> Uuid;
     fn silo_id(&self) -> Uuid;
     fn time_last_used(&self) -> DateTime<Utc>;
@@ -39,11 +41,14 @@ pub trait SessionStore {
     /// Extend session by updating time_last_used to now
     async fn session_update_last_used(
         &self,
-        token: String,
+        id: TypedUuid<ConsoleSessionKind>,
     ) -> Option<Self::SessionModel>;
 
     /// Mark session expired
-    async fn session_expire(&self, token: String) -> Option<()>;
+    async fn session_expire(
+        &self,
+        id: TypedUuid<ConsoleSessionKind>,
+    ) -> Option<()>;
 
     /// Maximum time session can remain idle before expiring
     fn session_idle_timeout(&self) -> Duration;
@@ -131,7 +136,7 @@ where
         // expired
         let now = Utc::now();
         if session.time_last_used() + ctx.session_idle_timeout() < now {
-            let expired_session = ctx.session_expire(token.clone()).await;
+            let expired_session = ctx.session_expire(session.id()).await;
             if expired_session.is_none() {
                 debug!(log, "failed to expire session")
             }
@@ -151,7 +156,7 @@ where
         // existed longer than absolute_timeout, it is expired and we can no
         // longer extend the session
         if session.time_created() + ctx.session_absolute_timeout() < now {
-            let expired_session = ctx.session_expire(token.clone()).await;
+            let expired_session = ctx.session_expire(session.id()).await;
             if expired_session.is_none() {
                 debug!(log, "failed to expire session")
             }
@@ -172,7 +177,7 @@ where
         // authenticated for this request at this point. The next request might
         // be wrongly considered idle, but that's a problem for the next
         // request.
-        let updated_session = ctx.session_update_last_used(token).await;
+        let updated_session = ctx.session_update_last_used(session.id()).await;
         if updated_session.is_none() {
             debug!(log, "failed to extend session")
         }
@@ -199,19 +204,22 @@ mod test {
     use async_trait::async_trait;
     use chrono::{DateTime, Duration, Utc};
     use http;
+    use omicron_uuid_kinds::ConsoleSessionKind;
+    use omicron_uuid_kinds::TypedUuid;
     use slog;
-    use std::collections::HashMap;
     use std::sync::Mutex;
     use uuid::Uuid;
 
     // the mutex is annoying, but we need it in order to mutate the hashmap
     // without passing TestServerContext around as mutable
     struct TestServerContext {
-        sessions: Mutex<HashMap<String, FakeSession>>,
+        sessions: Mutex<Vec<FakeSession>>,
     }
 
-    #[derive(Clone, Copy)]
+    #[derive(Clone)]
     struct FakeSession {
+        id: TypedUuid<ConsoleSessionKind>,
+        token: String,
         silo_user_id: Uuid,
         silo_id: Uuid,
         time_created: DateTime<Utc>,
@@ -219,6 +227,9 @@ mod test {
     }
 
     impl Session for FakeSession {
+        fn id(&self) -> TypedUuid<ConsoleSessionKind> {
+            self.id
+        }
         fn silo_user_id(&self) -> Uuid {
             self.silo_user_id
         }
@@ -241,23 +252,37 @@ mod test {
             &self,
             token: String,
         ) -> Option<Self::SessionModel> {
-            self.sessions.lock().unwrap().get(&token).map(|s| *s)
+            self.sessions
+                .lock()
+                .unwrap()
+                .iter()
+                .find(|s| s.token == token)
+                .map(|s| s.clone())
         }
 
         async fn session_update_last_used(
             &self,
-            token: String,
+            id: TypedUuid<ConsoleSessionKind>,
         ) -> Option<Self::SessionModel> {
             let mut sessions = self.sessions.lock().unwrap();
-            let session = *sessions.get(&token).unwrap();
-            let new_session =
-                FakeSession { time_last_used: Utc::now(), ..session };
-            (*sessions).insert(token, new_session)
+            if let Some(pos) = sessions.iter().position(|s| s.id == id) {
+                let new_session = FakeSession {
+                    time_last_used: Utc::now(),
+                    ..sessions[pos].clone()
+                };
+                sessions[pos] = new_session.clone();
+                Some(new_session)
+            } else {
+                None
+            }
         }
 
-        async fn session_expire(&self, token: String) -> Option<()> {
+        async fn session_expire(
+            &self,
+            id: TypedUuid<ConsoleSessionKind>,
+        ) -> Option<()> {
             let mut sessions = self.sessions.lock().unwrap();
-            (*sessions).remove(&token);
+            sessions.retain(|s| s.id != id);
             Some(())
         }
 
@@ -295,16 +320,14 @@ mod test {
 
     #[tokio::test]
     async fn test_missing_cookie() {
-        let context =
-            TestServerContext { sessions: Mutex::new(HashMap::new()) };
+        let context = TestServerContext { sessions: Mutex::new(Vec::new()) };
         let result = authn_with_cookie(&context, None).await;
         assert!(matches!(result, SchemeResult::NotRequested));
     }
 
     #[tokio::test]
     async fn test_other_cookie() {
-        let context =
-            TestServerContext { sessions: Mutex::new(HashMap::new()) };
+        let context = TestServerContext { sessions: Mutex::new(Vec::new()) };
         let result = authn_with_cookie(&context, Some("other=def")).await;
         assert!(matches!(result, SchemeResult::NotRequested));
     }
@@ -312,41 +335,14 @@ mod test {
     #[tokio::test]
     async fn test_expired_cookie_idle() {
         let context = TestServerContext {
-            sessions: Mutex::new(HashMap::from([(
-                "abc".to_string(),
-                FakeSession {
-                    silo_user_id: Uuid::new_v4(),
-                    silo_id: Uuid::new_v4(),
-                    time_last_used: Utc::now() - Duration::hours(2),
-                    time_created: Utc::now() - Duration::hours(2),
-                },
-            )])),
-        };
-        let result = authn_with_cookie(&context, Some("session=abc")).await;
-        assert!(matches!(
-            result,
-            SchemeResult::Failed(Reason::BadCredentials {
-                actor: _,
-                source: _
-            })
-        ));
-
-        // key should be removed from sessions dict, i.e., session deleted
-        assert!(!context.sessions.lock().unwrap().contains_key("abc"))
-    }
-
-    #[tokio::test]
-    async fn test_expired_cookie_absolute() {
-        let context = TestServerContext {
-            sessions: Mutex::new(HashMap::from([(
-                "abc".to_string(),
-                FakeSession {
-                    silo_user_id: Uuid::new_v4(),
-                    silo_id: Uuid::new_v4(),
-                    time_last_used: Utc::now(),
-                    time_created: Utc::now() - Duration::hours(20),
-                },
-            )])),
+            sessions: Mutex::new(vec![FakeSession {
+                id: TypedUuid::new_v4(),
+                token: "abc".to_string(),
+                silo_user_id: Uuid::new_v4(),
+                silo_id: Uuid::new_v4(),
+                time_last_used: Utc::now() - Duration::hours(2),
+                time_created: Utc::now() - Duration::hours(2),
+            }]),
         };
         let result = authn_with_cookie(&context, Some("session=abc")).await;
         assert!(matches!(
@@ -359,22 +355,47 @@ mod test {
 
         // key should be removed from sessions dict, i.e., session deleted
         let sessions = context.sessions.lock().unwrap();
-        assert!(!sessions.contains_key("abc"))
+        assert!(!sessions.iter().any(|s| s.token == "abc"))
+    }
+
+    #[tokio::test]
+    async fn test_expired_cookie_absolute() {
+        let context = TestServerContext {
+            sessions: Mutex::new(vec![FakeSession {
+                id: TypedUuid::new_v4(),
+                token: "abc".to_string(),
+                silo_user_id: Uuid::new_v4(),
+                silo_id: Uuid::new_v4(),
+                time_last_used: Utc::now(),
+                time_created: Utc::now() - Duration::hours(20),
+            }]),
+        };
+        let result = authn_with_cookie(&context, Some("session=abc")).await;
+        assert!(matches!(
+            result,
+            SchemeResult::Failed(Reason::BadCredentials {
+                actor: _,
+                source: _
+            })
+        ));
+
+        // key should be removed from sessions dict, i.e., session deleted
+        let sessions = context.sessions.lock().unwrap();
+        assert!(!sessions.iter().any(|s| s.token == "abc"))
     }
 
     #[tokio::test]
     async fn test_valid_cookie() {
         let time_last_used = Utc::now() - Duration::seconds(5);
         let context = TestServerContext {
-            sessions: Mutex::new(HashMap::from([(
-                "abc".to_string(),
-                FakeSession {
-                    silo_user_id: Uuid::new_v4(),
-                    silo_id: Uuid::new_v4(),
-                    time_last_used,
-                    time_created: Utc::now(),
-                },
-            )])),
+            sessions: Mutex::new(vec![FakeSession {
+                id: TypedUuid::new_v4(),
+                token: "abc".to_string(),
+                silo_user_id: Uuid::new_v4(),
+                silo_id: Uuid::new_v4(),
+                time_last_used,
+                time_created: Utc::now(),
+            }]),
         };
         let result = authn_with_cookie(&context, Some("session=abc")).await;
         assert!(matches!(
@@ -384,13 +405,13 @@ mod test {
 
         // valid cookie should have updated time_last_used
         let sessions = context.sessions.lock().unwrap();
-        assert!(sessions.get("abc").unwrap().time_last_used > time_last_used)
+        let session = sessions.iter().find(|s| s.token == "abc").unwrap();
+        assert!(session.time_last_used > time_last_used)
     }
 
     #[tokio::test]
     async fn test_garbage_cookie() {
-        let context =
-            TestServerContext { sessions: Mutex::new(HashMap::new()) };
+        let context = TestServerContext { sessions: Mutex::new(Vec::new()) };
         let result =
             authn_with_cookie(&context, Some("unparsable garbage!!!!!1")).await;
         assert!(matches!(result, SchemeResult::NotRequested));

--- a/nexus/auth/src/authz/api_resources.rs
+++ b/nexus/auth/src/authz/api_resources.rs
@@ -939,7 +939,7 @@ authz_resource! {
 authz_resource! {
     name = "ConsoleSession",
     parent = "Fleet",
-    primary_key = String,
+    primary_key = { uuid_kind = ConsoleSessionKind },
     roles_allowed = false,
     polar_snippet = FleetChild,
 }

--- a/nexus/auth/src/authz/api_resources.rs
+++ b/nexus/auth/src/authz/api_resources.rs
@@ -955,7 +955,7 @@ authz_resource! {
 authz_resource! {
     name = "DeviceAccessToken",
     parent = "Fleet",
-    primary_key = String, // token
+    primary_key = { uuid_kind = AccessTokenKind },
     roles_allowed = false,
     polar_snippet = FleetChild,
 }

--- a/nexus/auth/src/context.rs
+++ b/nexus/auth/src/context.rs
@@ -11,6 +11,8 @@ use crate::authz::AuthorizedResource;
 use crate::storage::Storage;
 use chrono::{DateTime, Utc};
 use omicron_common::api::external::Error;
+use omicron_uuid_kinds::ConsoleSessionKind;
+use omicron_uuid_kinds::TypedUuid;
 use slog::debug;
 use slog::o;
 use slog::trace;
@@ -352,6 +354,10 @@ impl OpContext {
 }
 
 impl Session for ConsoleSessionWithSiloId {
+    fn id(&self) -> TypedUuid<ConsoleSessionKind> {
+        self.console_session.id()
+    }
+
     fn silo_user_id(&self) -> Uuid {
         self.console_session.silo_user_id
     }

--- a/nexus/auth/src/context.rs
+++ b/nexus/auth/src/context.rs
@@ -11,8 +11,7 @@ use crate::authz::AuthorizedResource;
 use crate::storage::Storage;
 use chrono::{DateTime, Utc};
 use omicron_common::api::external::Error;
-use omicron_uuid_kinds::ConsoleSessionKind;
-use omicron_uuid_kinds::TypedUuid;
+use omicron_uuid_kinds::ConsoleSessionUuid;
 use slog::debug;
 use slog::o;
 use slog::trace;
@@ -354,7 +353,7 @@ impl OpContext {
 }
 
 impl Session for ConsoleSessionWithSiloId {
-    fn id(&self) -> TypedUuid<ConsoleSessionKind> {
+    fn id(&self) -> ConsoleSessionUuid {
         self.console_session.id()
     }
 

--- a/nexus/db-lookup/src/lookup.rs
+++ b/nexus/db-lookup/src/lookup.rs
@@ -26,8 +26,10 @@ use nexus_types::identity::Resource;
 use omicron_common::api::external::Error;
 use omicron_common::api::external::InternalContext;
 use omicron_common::api::external::{LookupResult, LookupType, ResourceType};
+use omicron_uuid_kinds::AccessTokenKind;
 use omicron_uuid_kinds::AlertReceiverUuid;
 use omicron_uuid_kinds::AlertUuid;
+use omicron_uuid_kinds::ConsoleSessionKind;
 use omicron_uuid_kinds::PhysicalDiskUuid;
 use omicron_uuid_kinds::SupportBundleUuid;
 use omicron_uuid_kinds::TufArtifactKind;
@@ -200,7 +202,10 @@ impl<'a> LookupPath<'a> {
     // Fleet-level resources
 
     /// Select a resource of type ConsoleSession, identified by its `id`
-    pub fn console_session_id(self, id: Uuid) -> ConsoleSession<'a> {
+    pub fn console_session_id(
+        self,
+        id: TypedUuid<ConsoleSessionKind>,
+    ) -> ConsoleSession<'a> {
         ConsoleSession::PrimaryKey(Root { lookup_root: self }, id)
     }
 
@@ -220,7 +225,10 @@ impl<'a> LookupPath<'a> {
     }
 
     /// Select a resource of type DeviceAccessToken, identified by its `token`
-    pub fn device_access_token_id(self, id: Uuid) -> DeviceAccessToken<'a> {
+    pub fn device_access_token_id(
+        self,
+        id: TypedUuid<AccessTokenKind>,
+    ) -> DeviceAccessToken<'a> {
         DeviceAccessToken::PrimaryKey(Root { lookup_root: self }, id)
     }
 
@@ -742,7 +750,7 @@ lookup_resource! {
     lookup_by_name = false,
     soft_deletes = false,
     primary_key_columns = [
-        { column_name = "id", rust_type = Uuid },
+        { column_name = "id", uuid_kind = ConsoleSessionKind },
     ]
 }
 
@@ -761,9 +769,7 @@ lookup_resource! {
     ancestors = [],
     lookup_by_name = false,
     soft_deletes = false,
-    primary_key_columns = [
-        { column_name = "id", rust_type = Uuid },
-    ]
+    primary_key_columns = [ { column_name = "id", uuid_kind = AccessTokenKind } ]
 }
 
 lookup_resource! {

--- a/nexus/db-lookup/src/lookup.rs
+++ b/nexus/db-lookup/src/lookup.rs
@@ -199,19 +199,9 @@ impl<'a> LookupPath<'a> {
 
     // Fleet-level resources
 
-    /// Select a resource of type ConsoleSession, identified by its `token`
-    pub fn console_session_token<'b, 'c>(
-        self,
-        token: &'b str,
-    ) -> ConsoleSession<'c>
-    where
-        'a: 'c,
-        'b: 'c,
-    {
-        ConsoleSession::PrimaryKey(
-            Root { lookup_root: self },
-            token.to_string(),
-        )
+    /// Select a resource of type ConsoleSession, identified by its `id`
+    pub fn console_session_id(self, id: Uuid) -> ConsoleSession<'a> {
+        ConsoleSession::PrimaryKey(Root { lookup_root: self }, id)
     }
 
     /// Select a resource of type DeviceAuthRequest, identified by its `user_code`
@@ -762,7 +752,7 @@ lookup_resource! {
     lookup_by_name = false,
     soft_deletes = false,
     primary_key_columns = [
-        { column_name = "token", rust_type = String },
+        { column_name = "id", rust_type = Uuid },
     ]
 }
 

--- a/nexus/db-lookup/src/lookup.rs
+++ b/nexus/db-lookup/src/lookup.rs
@@ -749,9 +749,7 @@ lookup_resource! {
     ancestors = [],
     lookup_by_name = false,
     soft_deletes = false,
-    primary_key_columns = [
-        { column_name = "id", uuid_kind = ConsoleSessionKind },
-    ]
+    primary_key_columns = [ { column_name = "id", uuid_kind = ConsoleSessionKind } ]
 }
 
 lookup_resource! {

--- a/nexus/db-lookup/src/lookup.rs
+++ b/nexus/db-lookup/src/lookup.rs
@@ -224,7 +224,7 @@ impl<'a> LookupPath<'a> {
         )
     }
 
-    /// Select a resource of type DeviceAccessToken, identified by its `token`
+    /// Select a resource of type DeviceAccessToken, identified by its `id`
     pub fn device_access_token_id(
         self,
         id: TypedUuid<AccessTokenKind>,

--- a/nexus/db-lookup/src/lookup.rs
+++ b/nexus/db-lookup/src/lookup.rs
@@ -220,18 +220,8 @@ impl<'a> LookupPath<'a> {
     }
 
     /// Select a resource of type DeviceAccessToken, identified by its `token`
-    pub fn device_access_token<'b, 'c>(
-        self,
-        token: &'b str,
-    ) -> DeviceAccessToken<'c>
-    where
-        'a: 'c,
-        'b: 'c,
-    {
-        DeviceAccessToken::PrimaryKey(
-            Root { lookup_root: self },
-            token.to_string(),
-        )
+    pub fn device_access_token_id(self, id: Uuid) -> DeviceAccessToken<'a> {
+        DeviceAccessToken::PrimaryKey(Root { lookup_root: self }, id)
     }
 
     /// Select a resource of type RoleBuiltin, identified by its `name`
@@ -772,7 +762,7 @@ lookup_resource! {
     lookup_by_name = false,
     soft_deletes = false,
     primary_key_columns = [
-        { column_name = "token", rust_type = String },
+        { column_name = "id", rust_type = Uuid },
     ]
 }
 

--- a/nexus/db-lookup/src/lookup.rs
+++ b/nexus/db-lookup/src/lookup.rs
@@ -29,7 +29,7 @@ use omicron_common::api::external::{LookupResult, LookupType, ResourceType};
 use omicron_uuid_kinds::AccessTokenKind;
 use omicron_uuid_kinds::AlertReceiverUuid;
 use omicron_uuid_kinds::AlertUuid;
-use omicron_uuid_kinds::ConsoleSessionKind;
+use omicron_uuid_kinds::ConsoleSessionUuid;
 use omicron_uuid_kinds::PhysicalDiskUuid;
 use omicron_uuid_kinds::SupportBundleUuid;
 use omicron_uuid_kinds::TufArtifactKind;
@@ -204,7 +204,7 @@ impl<'a> LookupPath<'a> {
     /// Select a resource of type ConsoleSession, identified by its `id`
     pub fn console_session_id(
         self,
-        id: TypedUuid<ConsoleSessionKind>,
+        id: ConsoleSessionUuid,
     ) -> ConsoleSession<'a> {
         ConsoleSession::PrimaryKey(Root { lookup_root: self }, id)
     }

--- a/nexus/db-model/src/console_session.rs
+++ b/nexus/db-model/src/console_session.rs
@@ -5,7 +5,7 @@
 use chrono::{DateTime, Utc};
 use nexus_db_schema::schema::console_session;
 use omicron_uuid_kinds::ConsoleSessionKind;
-use omicron_uuid_kinds::TypedUuid;
+use omicron_uuid_kinds::ConsoleSessionUuid;
 use uuid::Uuid;
 
 use crate::typed_uuid::DbTypedUuid;
@@ -26,7 +26,7 @@ impl ConsoleSession {
     pub fn new(token: String, silo_user_id: Uuid) -> Self {
         let now = Utc::now();
         Self {
-            id: TypedUuid::new_v4().into(),
+            id: ConsoleSessionUuid::new_v4().into(),
             token,
             silo_user_id,
             time_last_used: now,
@@ -34,7 +34,7 @@ impl ConsoleSession {
         }
     }
 
-    pub fn id(&self) -> TypedUuid<ConsoleSessionKind> {
+    pub fn id(&self) -> ConsoleSessionUuid {
         self.id.0
     }
 }

--- a/nexus/db-model/src/console_session.rs
+++ b/nexus/db-model/src/console_session.rs
@@ -4,14 +4,18 @@
 
 use chrono::{DateTime, Utc};
 use nexus_db_schema::schema::console_session;
+use omicron_uuid_kinds::ConsoleSessionKind;
+use omicron_uuid_kinds::TypedUuid;
 use uuid::Uuid;
+
+use crate::typed_uuid::DbTypedUuid;
 
 // TODO: `struct SessionToken(String)` for session token
 
 #[derive(Queryable, Insertable, Clone, Debug, Selectable)]
 #[diesel(table_name = console_session)]
 pub struct ConsoleSession {
-    pub id: Uuid,
+    pub id: DbTypedUuid<ConsoleSessionKind>,
     pub token: String,
     pub time_created: DateTime<Utc>,
     pub time_last_used: DateTime<Utc>,
@@ -22,7 +26,7 @@ impl ConsoleSession {
     pub fn new(token: String, silo_user_id: Uuid) -> Self {
         let now = Utc::now();
         Self {
-            id: Uuid::new_v4(),
+            id: TypedUuid::new_v4().into(),
             token,
             silo_user_id,
             time_last_used: now,

--- a/nexus/db-model/src/console_session.rs
+++ b/nexus/db-model/src/console_session.rs
@@ -11,6 +11,7 @@ use uuid::Uuid;
 #[derive(Queryable, Insertable, Clone, Debug, Selectable)]
 #[diesel(table_name = console_session)]
 pub struct ConsoleSession {
+    pub id: Uuid,
     pub token: String,
     pub time_created: DateTime<Utc>,
     pub time_last_used: DateTime<Utc>,
@@ -20,7 +21,13 @@ pub struct ConsoleSession {
 impl ConsoleSession {
     pub fn new(token: String, silo_user_id: Uuid) -> Self {
         let now = Utc::now();
-        Self { token, silo_user_id, time_last_used: now, time_created: now }
+        Self {
+            id: Uuid::new_v4(),
+            token,
+            silo_user_id,
+            time_last_used: now,
+            time_created: now,
+        }
     }
 
     pub fn id(&self) -> String {

--- a/nexus/db-model/src/console_session.rs
+++ b/nexus/db-model/src/console_session.rs
@@ -34,7 +34,7 @@ impl ConsoleSession {
         }
     }
 
-    pub fn id(&self) -> String {
-        self.token.clone()
+    pub fn id(&self) -> TypedUuid<ConsoleSessionKind> {
+        self.id.0
     }
 }

--- a/nexus/db-model/src/device_auth.rs
+++ b/nexus/db-model/src/device_auth.rs
@@ -151,9 +151,8 @@ impl DeviceAccessToken {
         }
     }
 
-    // TODO: uhhhh
-    pub fn id(&self) -> String {
-        self.token.clone()
+    pub fn id(&self) -> TypedUuid<AccessTokenKind> {
+        self.id.0
     }
 
     pub fn expires(mut self, time: DateTime<Utc>) -> Self {

--- a/nexus/db-model/src/device_auth.rs
+++ b/nexus/db-model/src/device_auth.rs
@@ -11,8 +11,11 @@ use nexus_db_schema::schema::{device_access_token, device_auth_request};
 
 use chrono::{DateTime, Duration, Utc};
 use nexus_types::external_api::views;
+use omicron_uuid_kinds::{AccessTokenKind, TypedUuid};
 use rand::{Rng, RngCore, SeedableRng, distributions::Slice, rngs::StdRng};
 use uuid::Uuid;
+
+use crate::typed_uuid::DbTypedUuid;
 
 /// Default timeout in seconds for client to authenticate for a token request.
 const CLIENT_AUTHENTICATION_TIMEOUT: i64 = 300;
@@ -117,7 +120,7 @@ impl DeviceAuthRequest {
 #[derive(Clone, Debug, Insertable, Queryable, Selectable)]
 #[diesel(table_name = device_access_token)]
 pub struct DeviceAccessToken {
-    pub id: Uuid,
+    pub id: DbTypedUuid<AccessTokenKind>,
     pub token: String,
     pub client_id: Uuid,
     pub device_code: String,
@@ -137,7 +140,7 @@ impl DeviceAccessToken {
         let now = Utc::now();
         assert!(time_requested <= now);
         Self {
-            id: Uuid::new_v4(),
+            id: TypedUuid::new_v4().into(),
             token: generate_token(),
             client_id,
             device_code,

--- a/nexus/db-model/src/device_auth.rs
+++ b/nexus/db-model/src/device_auth.rs
@@ -117,6 +117,7 @@ impl DeviceAuthRequest {
 #[derive(Clone, Debug, Insertable, Queryable, Selectable)]
 #[diesel(table_name = device_access_token)]
 pub struct DeviceAccessToken {
+    pub id: Uuid,
     pub token: String,
     pub client_id: Uuid,
     pub device_code: String,
@@ -136,6 +137,7 @@ impl DeviceAccessToken {
         let now = Utc::now();
         assert!(time_requested <= now);
         Self {
+            id: Uuid::new_v4(),
             token: generate_token(),
             client_id,
             device_code,
@@ -146,6 +148,7 @@ impl DeviceAccessToken {
         }
     }
 
+    // TODO: uhhhh
     pub fn id(&self) -> String {
         self.token.clone()
     }

--- a/nexus/db-model/src/schema_versions.rs
+++ b/nexus/db-model/src/schema_versions.rs
@@ -16,7 +16,7 @@ use std::{collections::BTreeMap, sync::LazyLock};
 ///
 /// This must be updated when you change the database schema.  Refer to
 /// schema/crdb/README.adoc in the root of this repository for details.
-pub const SCHEMA_VERSION: Version = Version::new(144, 0, 0);
+pub const SCHEMA_VERSION: Version = Version::new(145, 0, 0);
 
 /// List of all past database schema versions, in *reverse* order
 ///
@@ -28,6 +28,7 @@ static KNOWN_VERSIONS: LazyLock<Vec<KnownVersion>> = LazyLock::new(|| {
         // |  leaving the first copy as an example for the next person.
         // v
         // KnownVersion::new(next_int, "unique-dirname-with-the-sql-files"),
+        KnownVersion::new(145, "token-and-session-ids"),
         KnownVersion::new(144, "inventory-omicron-sled-config"),
         KnownVersion::new(143, "alerts-renamening"),
         KnownVersion::new(142, "bp-add-remove-mupdate-override"),

--- a/nexus/db-queries/src/db/datastore/console_session.rs
+++ b/nexus/db-queries/src/db/datastore/console_session.rs
@@ -175,4 +175,25 @@ impl DataStore {
                 ))
             })
     }
+
+    pub async fn session_hard_delete_by_token(
+        &self,
+        opctx: &OpContext,
+        token: String,
+    ) -> DeleteResult {
+        // we don't do an authz check here because the possession of
+        // the token is the check
+        use nexus_db_schema::schema::console_session;
+        diesel::delete(console_session::table)
+            .filter(console_session::token.eq(token))
+            .execute_async(&*self.pool_connection_authorized(opctx).await?)
+            .await
+            .map(|_rows_deleted| ())
+            .map_err(|e| {
+                Error::internal_error(&format!(
+                    "error deleting session by token: {:?}",
+                    e
+                ))
+            })
+    }
 }

--- a/nexus/db-queries/src/db/datastore/console_session.rs
+++ b/nexus/db-queries/src/db/datastore/console_session.rs
@@ -25,6 +25,12 @@ use omicron_common::api::external::UpdateResult;
 use omicron_uuid_kinds::GenericUuid;
 
 impl DataStore {
+    /// Look up session by token. The token is a kind of password, so simply
+    /// having the token _is_ in a sense the primary authz check here.
+    ///
+    /// We need to define this lookup function manually because `token` is not
+    /// the primary key on the session (sessions have IDs), so we can't use the
+    /// automatically-generated lookup methods we use for IDs or names.
     pub async fn session_lookup_by_token(
         &self,
         opctx: &OpContext,

--- a/nexus/db-queries/src/db/datastore/console_session.rs
+++ b/nexus/db-queries/src/db/datastore/console_session.rs
@@ -22,6 +22,7 @@ use omicron_common::api::external::LookupResult;
 use omicron_common::api::external::LookupType;
 use omicron_common::api::external::ResourceType;
 use omicron_common::api::external::UpdateResult;
+use omicron_uuid_kinds::GenericUuid;
 
 impl DataStore {
     pub async fn session_lookup_by_token(
@@ -85,7 +86,7 @@ impl DataStore {
 
         use nexus_db_schema::schema::console_session::dsl;
         let console_session = diesel::update(dsl::console_session)
-            .filter(dsl::token.eq(authz_session.id()))
+            .filter(dsl::id.eq(authz_session.id().into_untyped_uuid()))
             .set((dsl::time_last_used.eq(Utc::now()),))
             .returning(ConsoleSession::as_returning())
             .get_result_async(&*self.pool_connection_authorized(opctx).await?)
@@ -149,7 +150,7 @@ impl DataStore {
         use nexus_db_schema::schema::console_session::dsl;
         diesel::delete(dsl::console_session)
             .filter(dsl::silo_user_id.eq(silo_user_id))
-            .filter(dsl::token.eq(authz_session.id()))
+            .filter(dsl::id.eq(authz_session.id().into_untyped_uuid()))
             .execute_async(&*self.pool_connection_authorized(opctx).await?)
             .await
             .map(|_rows_deleted| ())

--- a/nexus/db-queries/src/db/datastore/mod.rs
+++ b/nexus/db-queries/src/db/datastore/mod.rs
@@ -575,6 +575,7 @@ mod test {
         let silo_user_id = Uuid::new_v4();
 
         let session = ConsoleSession {
+            id: Uuid::new_v4(),
             token: token.clone(),
             time_created: Utc::now() - Duration::minutes(5),
             time_last_used: Utc::now() - Duration::minutes(5),

--- a/nexus/db-queries/src/db/datastore/mod.rs
+++ b/nexus/db-queries/src/db/datastore/mod.rs
@@ -618,6 +618,16 @@ mod test {
             .await
             .unwrap();
         assert_eq!(session.silo_user_id, fetched.silo_user_id);
+        assert_eq!(session.id, fetched.id);
+
+        // also try looking it up by ID
+        let (.., fetched) = LookupPath::new(&opctx, datastore)
+            .console_session_id(session.id.into())
+            .fetch()
+            .await
+            .unwrap();
+        assert_eq!(session.silo_user_id, fetched.silo_user_id);
+        assert_eq!(session.token, fetched.token);
 
         // trying to insert the same one again fails
         let duplicate =

--- a/nexus/db-queries/src/db/datastore/mod.rs
+++ b/nexus/db-queries/src/db/datastore/mod.rs
@@ -613,7 +613,7 @@ mod test {
         assert_eq!(DEFAULT_SILO_ID, db_silo_user.silo_id);
 
         // fetch the one we just created
-        let fetched = datastore
+        let (.., fetched) = datastore
             .session_lookup_by_token(&authn_opctx, token.clone())
             .await
             .unwrap();
@@ -655,7 +655,7 @@ mod test {
         // right thing between opctx or authn_opctx
 
         // time_last_used change persists in DB
-        let fetched = datastore
+        let (.., fetched) = datastore
             .session_lookup_by_token(&opctx, token.clone())
             .await
             .unwrap();

--- a/nexus/db-queries/src/db/datastore/mod.rs
+++ b/nexus/db-queries/src/db/datastore/mod.rs
@@ -482,12 +482,12 @@ mod test {
         ByteCount, Error, IdentityMetadataCreateParams, LookupType, Name,
     };
     use omicron_test_utils::dev;
-    use omicron_uuid_kinds::CollectionUuid;
     use omicron_uuid_kinds::DatasetUuid;
     use omicron_uuid_kinds::GenericUuid;
     use omicron_uuid_kinds::PhysicalDiskUuid;
     use omicron_uuid_kinds::SledUuid;
     use omicron_uuid_kinds::VolumeUuid;
+    use omicron_uuid_kinds::{CollectionUuid, TypedUuid};
     use std::collections::HashMap;
     use std::collections::HashSet;
     use std::net::{IpAddr, Ipv4Addr, Ipv6Addr, SocketAddrV6};
@@ -575,7 +575,7 @@ mod test {
         let silo_user_id = Uuid::new_v4();
 
         let session = ConsoleSession {
-            id: Uuid::new_v4(),
+            id: TypedUuid::new_v4().into(),
             token: token.clone(),
             time_created: Utc::now() - Duration::minutes(5),
             time_last_used: Utc::now() - Duration::minutes(5),

--- a/nexus/db-queries/src/db/datastore/mod.rs
+++ b/nexus/db-queries/src/db/datastore/mod.rs
@@ -700,6 +700,10 @@ mod test {
             datastore.session_hard_delete(&opctx, &authz_session).await;
         assert_eq!(delete_again, Ok(()));
 
+        let delete_again =
+            datastore.session_hard_delete_by_token(&opctx, token.clone()).await;
+        assert_eq!(delete_again, Ok(()));
+
         db.terminate().await;
         logctx.cleanup_successful();
     }

--- a/nexus/db-queries/src/db/datastore/mod.rs
+++ b/nexus/db-queries/src/db/datastore/mod.rs
@@ -651,9 +651,6 @@ mod test {
             renewed.console_session.time_last_used > session.time_last_used
         );
 
-        // TODO: check the opctx on these changes, make sure we're using the
-        // right thing between opctx or authn_opctx
-
         // time_last_used change persists in DB
         let (.., fetched) = datastore
             .session_lookup_by_token(&opctx, token.clone())

--- a/nexus/db-queries/src/db/datastore/mod.rs
+++ b/nexus/db-queries/src/db/datastore/mod.rs
@@ -640,8 +640,8 @@ mod test {
         // update last used (i.e., renew token)
         let authz_session = authz::ConsoleSession::new(
             authz::FLEET,
-            token.clone(),
-            LookupType::ByCompositeId(token.clone()),
+            session.id.into(),
+            LookupType::ById(session.id.into_untyped_uuid()),
         );
         let renewed = datastore
             .session_update_last_used(&opctx, &authz_session)
@@ -687,11 +687,9 @@ mod test {
             .session_hard_delete(&silo_user_opctx, &authz_session)
             .await;
         assert_eq!(delete, Ok(()));
-        let fetched = dbg!(
-            datastore
-                .session_lookup_by_token(&authn_opctx, token.clone())
-                .await
-        );
+        let fetched = datastore
+            .session_lookup_by_token(&authn_opctx, token.clone())
+            .await;
         assert!(matches!(
             fetched,
             Err(Error::ObjectNotFound { type_name: _, lookup_type: _ })

--- a/nexus/db-queries/src/policy_test/resources.rs
+++ b/nexus/db-queries/src/policy_test/resources.rs
@@ -8,9 +8,11 @@ use super::resource_builder::ResourceBuilder;
 use super::resource_builder::ResourceSet;
 use nexus_auth::authz;
 use omicron_common::api::external::LookupType;
+use omicron_uuid_kinds::AccessTokenKind;
 use omicron_uuid_kinds::GenericUuid;
 use omicron_uuid_kinds::PhysicalDiskUuid;
 use omicron_uuid_kinds::SupportBundleUuid;
+use omicron_uuid_kinds::TypedUuid;
 use oso::PolarClass;
 use std::collections::BTreeSet;
 use uuid::Uuid;
@@ -127,11 +129,12 @@ pub async fn make_resources(
         LookupType::ByName(device_user_code),
     ));
 
-    let device_access_token = String::from("a-device-access-token");
+    let device_access_token_id: TypedUuid<AccessTokenKind> =
+        "3b80c7f9-bee0-4b42-8550-6cdfc74dafdb".parse().unwrap();
     builder.new_resource(authz::DeviceAccessToken::new(
         authz::FLEET,
-        device_access_token.clone(),
-        LookupType::ByName(device_access_token),
+        device_access_token_id,
+        LookupType::ById(device_access_token_id.into_untyped_uuid()),
     ));
 
     let blueprint_id = "b9e923f6-caf3-4c83-96f9-8ffe8c627dd2".parse().unwrap();

--- a/nexus/db-queries/tests/output/authz-roles.out
+++ b/nexus/db-queries/tests/output/authz-roles.out
@@ -1174,7 +1174,7 @@ resource: DeviceAuthRequest "a-device-user-code"
   silo1-proj1-viewer               ✘  ✔  ✘  ✔  ✔  ✔  ✘  ✔
   unauthenticated                  !  !  !  !  !  !  !  !
 
-resource: DeviceAccessToken "a-device-access-token"
+resource: DeviceAccessToken id "3b80c7f9-bee0-4b42-8550-6cdfc74dafdb"
 
   USER                             Q  R LC RP  M MP CC  D
   fleet-admin                      ✘  ✔  ✔  ✔  ✔  ✔  ✔  ✔

--- a/nexus/db-schema/src/schema.rs
+++ b/nexus/db-schema/src/schema.rs
@@ -929,6 +929,7 @@ table! {
 
 table! {
     console_session (token) {
+        id -> Uuid,
         token -> Text,
         time_created -> Timestamptz,
         time_last_used -> Timestamptz,
@@ -1355,6 +1356,7 @@ table! {
 
 table! {
     device_access_token (token) {
+        id -> Uuid,
         token -> Text,
         client_id -> Uuid,
         device_code -> Text,

--- a/nexus/db-schema/src/schema.rs
+++ b/nexus/db-schema/src/schema.rs
@@ -928,7 +928,7 @@ table! {
 }
 
 table! {
-    console_session (token) {
+    console_session (id) {
         id -> Uuid,
         token -> Text,
         time_created -> Timestamptz,
@@ -1355,7 +1355,7 @@ table! {
 }
 
 table! {
-    device_access_token (token) {
+    device_access_token (id) {
         id -> Uuid,
         token -> Text,
         client_id -> Uuid,

--- a/nexus/src/app/device_auth.rs
+++ b/nexus/src/app/device_auth.rs
@@ -166,9 +166,9 @@ impl super::Nexus {
         opctx: &OpContext,
         token: String,
     ) -> Result<Actor, Reason> {
-        let (.., db_access_token) = LookupPath::new(opctx, &self.db_datastore)
-            .device_access_token(&token)
-            .fetch()
+        let db_access_token = self
+            .db_datastore
+            .device_token_lookup_by_token(opctx, token)
             .await
             .map_err(|e| match e {
                 Error::ObjectNotFound { .. } => Reason::UnknownActor {

--- a/nexus/src/app/device_auth.rs
+++ b/nexus/src/app/device_auth.rs
@@ -166,7 +166,7 @@ impl super::Nexus {
         opctx: &OpContext,
         token: String,
     ) -> Result<Actor, Reason> {
-        let db_access_token = self
+        let (.., db_access_token) = self
             .db_datastore
             .device_token_lookup_by_token(opctx, token)
             .await

--- a/nexus/src/app/session.rs
+++ b/nexus/src/app/session.rs
@@ -53,16 +53,16 @@ impl super::Nexus {
         opctx: &OpContext,
         token: String,
     ) -> LookupResult<authn::ConsoleSessionWithSiloId> {
-        let db_console_session =
+        let (.., db_session) =
             self.db_datastore.session_lookup_by_token(&opctx, token).await?;
 
         let (.., db_silo_user) = LookupPath::new(opctx, &self.db_datastore)
-            .silo_user_id(db_console_session.silo_user_id)
+            .silo_user_id(db_session.silo_user_id)
             .fetch()
             .await?;
 
         Ok(authn::ConsoleSessionWithSiloId {
-            console_session: db_console_session,
+            console_session: db_session,
             silo_id: db_silo_user.silo_id,
         })
     }

--- a/nexus/src/app/session.rs
+++ b/nexus/src/app/session.rs
@@ -18,9 +18,8 @@ use omicron_common::api::external::Error;
 use omicron_common::api::external::LookupResult;
 use omicron_common::api::external::LookupType;
 use omicron_common::api::external::UpdateResult;
-use omicron_uuid_kinds::ConsoleSessionKind;
+use omicron_uuid_kinds::ConsoleSessionUuid;
 use omicron_uuid_kinds::GenericUuid;
-use omicron_uuid_kinds::TypedUuid;
 use rand::{RngCore, SeedableRng, rngs::StdRng};
 use uuid::Uuid;
 
@@ -71,7 +70,7 @@ impl super::Nexus {
     pub(crate) async fn session_update_last_used(
         &self,
         opctx: &OpContext,
-        id: TypedUuid<ConsoleSessionKind>,
+        id: ConsoleSessionUuid,
     ) -> UpdateResult<authn::ConsoleSessionWithSiloId> {
         let authz_session = authz::ConsoleSession::new(
             authz::FLEET,
@@ -84,7 +83,7 @@ impl super::Nexus {
     pub(crate) async fn session_hard_delete(
         &self,
         opctx: &OpContext,
-        id: TypedUuid<ConsoleSessionKind>,
+        id: ConsoleSessionUuid,
     ) -> DeleteResult {
         let authz_session = authz::ConsoleSession::new(
             authz::FLEET,

--- a/nexus/src/app/session.rs
+++ b/nexus/src/app/session.rs
@@ -94,6 +94,14 @@ impl super::Nexus {
         self.db_datastore.session_hard_delete(opctx, &authz_session).await
     }
 
+    pub(crate) async fn session_hard_delete_by_token(
+        &self,
+        opctx: &OpContext,
+        token: String,
+    ) -> DeleteResult {
+        self.db_datastore.session_hard_delete_by_token(opctx, token).await
+    }
+
     pub(crate) async fn lookup_silo_for_authn(
         &self,
         opctx: &OpContext,

--- a/nexus/src/app/session.rs
+++ b/nexus/src/app/session.rs
@@ -50,11 +50,8 @@ impl super::Nexus {
         opctx: &OpContext,
         token: String,
     ) -> LookupResult<authn::ConsoleSessionWithSiloId> {
-        let (.., db_console_session) =
-            LookupPath::new(opctx, &self.db_datastore)
-                .console_session_token(&token)
-                .fetch()
-                .await?;
+        let db_console_session =
+            self.db_datastore.session_lookup_by_token(&opctx, token).await?;
 
         let (.., db_silo_user) = LookupPath::new(opctx, &self.db_datastore)
             .silo_user_id(db_console_session.silo_user_id)

--- a/nexus/src/app/session.rs
+++ b/nexus/src/app/session.rs
@@ -18,6 +18,9 @@ use omicron_common::api::external::Error;
 use omicron_common::api::external::LookupResult;
 use omicron_common::api::external::LookupType;
 use omicron_common::api::external::UpdateResult;
+use omicron_uuid_kinds::ConsoleSessionKind;
+use omicron_uuid_kinds::GenericUuid;
+use omicron_uuid_kinds::TypedUuid;
 use rand::{RngCore, SeedableRng, rngs::StdRng};
 use uuid::Uuid;
 
@@ -68,12 +71,12 @@ impl super::Nexus {
     pub(crate) async fn session_update_last_used(
         &self,
         opctx: &OpContext,
-        token: &str,
+        id: TypedUuid<ConsoleSessionKind>,
     ) -> UpdateResult<authn::ConsoleSessionWithSiloId> {
         let authz_session = authz::ConsoleSession::new(
             authz::FLEET,
-            token.to_string(),
-            LookupType::ByCompositeId(token.to_string()),
+            id,
+            LookupType::ById(id.into_untyped_uuid()),
         );
         self.db_datastore.session_update_last_used(opctx, &authz_session).await
     }
@@ -81,12 +84,12 @@ impl super::Nexus {
     pub(crate) async fn session_hard_delete(
         &self,
         opctx: &OpContext,
-        token: &str,
+        id: TypedUuid<ConsoleSessionKind>,
     ) -> DeleteResult {
         let authz_session = authz::ConsoleSession::new(
             authz::FLEET,
-            token.to_string(),
-            LookupType::ByCompositeId(token.to_string()),
+            id,
+            LookupType::ById(id.into_untyped_uuid()),
         );
         self.db_datastore.session_hard_delete(opctx, &authz_session).await
     }

--- a/nexus/src/context.rs
+++ b/nexus/src/context.rs
@@ -19,7 +19,9 @@ use nexus_db_queries::authn::external::session_cookie::SessionStore;
 use nexus_db_queries::context::{OpContext, OpKind};
 use nexus_db_queries::{authn, authz, db};
 use omicron_common::address::{AZ_PREFIX, Ipv6Subnet};
+use omicron_uuid_kinds::ConsoleSessionKind;
 use omicron_uuid_kinds::GenericUuid;
+use omicron_uuid_kinds::TypedUuid;
 use oximeter::types::ProducerRegistry;
 use oximeter_instruments::http::{HttpService, LatencyTracker};
 use slog::Logger;
@@ -470,15 +472,18 @@ impl SessionStore for ServerContext {
 
     async fn session_update_last_used(
         &self,
-        token: String,
+        id: TypedUuid<ConsoleSessionKind>,
     ) -> Option<Self::SessionModel> {
         let opctx = self.nexus.opctx_external_authn();
-        self.nexus.session_update_last_used(&opctx, &token).await.ok()
+        self.nexus.session_update_last_used(&opctx, id).await.ok()
     }
 
-    async fn session_expire(&self, token: String) -> Option<()> {
+    async fn session_expire(
+        &self,
+        id: TypedUuid<ConsoleSessionKind>,
+    ) -> Option<()> {
         let opctx = self.nexus.opctx_external_authn();
-        self.nexus.session_hard_delete(opctx, &token).await.ok()
+        self.nexus.session_hard_delete(opctx, id).await.ok()
     }
 
     fn session_idle_timeout(&self) -> Duration {

--- a/nexus/src/context.rs
+++ b/nexus/src/context.rs
@@ -19,9 +19,8 @@ use nexus_db_queries::authn::external::session_cookie::SessionStore;
 use nexus_db_queries::context::{OpContext, OpKind};
 use nexus_db_queries::{authn, authz, db};
 use omicron_common::address::{AZ_PREFIX, Ipv6Subnet};
-use omicron_uuid_kinds::ConsoleSessionKind;
+use omicron_uuid_kinds::ConsoleSessionUuid;
 use omicron_uuid_kinds::GenericUuid;
-use omicron_uuid_kinds::TypedUuid;
 use oximeter::types::ProducerRegistry;
 use oximeter_instruments::http::{HttpService, LatencyTracker};
 use slog::Logger;
@@ -472,16 +471,13 @@ impl SessionStore for ServerContext {
 
     async fn session_update_last_used(
         &self,
-        id: TypedUuid<ConsoleSessionKind>,
+        id: ConsoleSessionUuid,
     ) -> Option<Self::SessionModel> {
         let opctx = self.nexus.opctx_external_authn();
         self.nexus.session_update_last_used(&opctx, id).await.ok()
     }
 
-    async fn session_expire(
-        &self,
-        id: TypedUuid<ConsoleSessionKind>,
-    ) -> Option<()> {
+    async fn session_expire(&self, id: ConsoleSessionUuid) -> Option<()> {
         let opctx = self.nexus.opctx_external_authn();
         self.nexus.session_hard_delete(opctx, id).await.ok()
     }

--- a/nexus/src/external_api/http_entrypoints.rs
+++ b/nexus/src/external_api/http_entrypoints.rs
@@ -7587,7 +7587,20 @@ impl NexusExternalApi for NexusExternalApiImpl {
 
             if let Ok(opctx) = opctx {
                 if let Some(token) = token {
-                    nexus.session_hard_delete(&opctx, token.value()).await?;
+                    // TODO: This is the ONE spot where we do the hard delete
+                    // by token and we haven't already looked up the session
+                    // by token. Looking up the token first works but it would
+                    // be nice to avoid it
+
+                    // look up session and delete it if present. noop on any errors
+                    let session = nexus
+                        .session_fetch(&opctx, token.value().to_string())
+                        .await;
+                    if let Ok(session) = session {
+                        let session_id = session.console_session.id();
+                        let _ =
+                            nexus.session_hard_delete(&opctx, session_id).await;
+                    }
                 }
             }
 

--- a/nexus/tests/integration_tests/authn_http.rs
+++ b/nexus/tests/integration_tests/authn_http.rs
@@ -391,10 +391,16 @@ impl session_cookie::SessionStore for WhoamiServerState {
         id: TypedUuid<ConsoleSessionKind>,
     ) -> Option<Self::SessionModel> {
         let mut sessions = self.sessions.lock().unwrap();
-        let session = sessions.iter().find(|s| s.id == id).unwrap().clone();
-        let new_session = FakeSession { time_last_used: Utc::now(), ..session };
-        (*sessions).push(new_session.clone());
-        Some(new_session)
+        if let Some(pos) = sessions.iter().position(|s| s.id == id) {
+            let new_session = FakeSession {
+                time_last_used: Utc::now(),
+                ..sessions[pos].clone()
+            };
+            sessions[pos] = new_session.clone();
+            Some(new_session)
+        } else {
+            None
+        }
     }
 
     async fn session_expire(

--- a/nexus/tests/integration_tests/schema.rs
+++ b/nexus/tests/integration_tests/schema.rs
@@ -2198,6 +2198,16 @@ fn after_140_0_0<'a>(ctx: &'a MigrationContext<'a>) -> BoxFuture<'a, ()> {
     })
 }
 
+// TODO, obviously
+
+fn before_142_0_0<'a>(_ctx: &'a MigrationContext<'a>) -> BoxFuture<'a, ()> {
+    Box::pin(async {})
+}
+
+fn after_142_0_0<'a>(_ctx: &'a MigrationContext<'a>) -> BoxFuture<'a, ()> {
+    Box::pin(async {})
+}
+
 // Lazily initializes all migration checks. The combination of Rust function
 // pointers and async makes defining a static table fairly painful, so we're
 // using lazy initialization instead.
@@ -2261,6 +2271,10 @@ fn get_migration_checks() -> BTreeMap<Version, DataMigrationFns> {
     map.insert(
         Version::new(140, 0, 0),
         DataMigrationFns::new().before(before_140_0_0).after(after_140_0_0),
+    );
+    map.insert(
+        Version::new(145, 0, 0),
+        DataMigrationFns::new().before(before_145_0_0).after(after_145_0_0),
     );
 
     map

--- a/schema/crdb/dbinit.sql
+++ b/schema/crdb/dbinit.sql
@@ -2416,22 +2416,20 @@ CREATE TABLE IF NOT EXISTS omicron.public.console_session (
 -- to be used for cleaning up old tokens
 -- It's okay that this index is non-unique because we don't need to page through
 -- this list.  We'll just grab the next N, delete them, then repeat.
-CREATE INDEX IF NOT EXISTS lookup_console_by_creation ON omicron.public.console_session (
-    time_created
-);
+CREATE INDEX IF NOT EXISTS lookup_console_by_creation
+    ON omicron.public.console_session (time_created);
 
 -- This index is used to remove sessions for a user that's being deleted.
-CREATE INDEX IF NOT EXISTS lookup_console_by_silo_user ON omicron.public.console_session (
-    silo_user_id
-);
+CREATE INDEX IF NOT EXISTS lookup_console_by_silo_user
+    ON omicron.public.console_session (silo_user_id);
 
--- We added a UUID as the primary key, but we need the token to keep acting like it did before.
--- "When you change a primary key with ALTER PRIMARY KEY, the old primary key index becomes a secondary index."
--- We chose to use DROP CONSTRAINT and ADD CONSTRAINT instead and manually create the index.
+-- We added a UUID as the primary key, but we need the token to keep acting like
+-- it did before. "When you change a primary key with ALTER PRIMARY KEY, the old
+-- primary key index becomes a secondary index." We chose to use DROP CONSTRAINT
+-- and ADD CONSTRAINT instead and manually create the index.
 -- https://www.cockroachlabs.com/docs/v22.1/primary-key#changing-primary-key-columns
-CREATE UNIQUE INDEX IF NOT EXISTS console_session_token_unique ON omicron.public.console_session (
-    token
-);
+CREATE UNIQUE INDEX IF NOT EXISTS console_session_token_unique
+	ON omicron.public.console_session (token);
 
 /*******************************************************************/
 
@@ -2822,19 +2820,17 @@ CREATE TABLE IF NOT EXISTS omicron.public.device_access_token (
 
 -- This UNIQUE constraint is critical for ensuring that at most
 -- one token is ever created for a given device authorization flow.
-CREATE UNIQUE INDEX IF NOT EXISTS lookup_device_access_token_by_client ON omicron.public.device_access_token (
-    client_id, device_code
-);
+CREATE UNIQUE INDEX IF NOT EXISTS lookup_device_access_token_by_client
+    ON omicron.public.device_access_token (client_id, device_code);
 
--- We added a UUID as the primary key, but we need the token to keep acting like it did before
-CREATE UNIQUE INDEX IF NOT EXISTS device_access_token_unique ON omicron.public.device_access_token (
-    token
-);
+-- We added a UUID as the primary key, but we need the token to keep acting like
+-- it did before
+CREATE UNIQUE INDEX IF NOT EXISTS device_access_token_unique
+    ON omicron.public.device_access_token (token);
 
 -- This index is used to remove tokens for a user that's being deleted.
-CREATE INDEX IF NOT EXISTS lookup_device_access_token_by_silo_user ON omicron.public.device_access_token (
-    silo_user_id
-);
+CREATE INDEX IF NOT EXISTS lookup_device_access_token_by_silo_user
+    ON omicron.public.device_access_token (silo_user_id);
 
 /*
  * Roles built into the system

--- a/schema/crdb/dbinit.sql
+++ b/schema/crdb/dbinit.sql
@@ -2406,7 +2406,8 @@ CREATE TABLE IF NOT EXISTS omicron.public.saga_node_event (
  * Sessions for use by web console.
  */
 CREATE TABLE IF NOT EXISTS omicron.public.console_session (
-    token STRING(40) PRIMARY KEY,
+    id UUID PRIMARY KEY,
+    token STRING(40) NOT NULL,
     time_created TIMESTAMPTZ NOT NULL,
     time_last_used TIMESTAMPTZ NOT NULL,
     silo_user_id UUID NOT NULL
@@ -2422,6 +2423,14 @@ CREATE INDEX IF NOT EXISTS lookup_console_by_creation ON omicron.public.console_
 -- This index is used to remove sessions for a user that's being deleted.
 CREATE INDEX IF NOT EXISTS lookup_console_by_silo_user ON omicron.public.console_session (
     silo_user_id
+);
+
+-- We added a UUID as the primary key, but we need the token to keep acting like it did before.
+-- "When you change a primary key with ALTER PRIMARY KEY, the old primary key index becomes a secondary index."
+-- We chose to use DROP CONSTRAINT and ADD CONSTRAINT instead and manually create the index.
+-- https://www.cockroachlabs.com/docs/v22.1/primary-key#changing-primary-key-columns
+CREATE UNIQUE INDEX IF NOT EXISTS console_session_token_unique ON omicron.public.console_session (
+    token
 );
 
 /*******************************************************************/
@@ -2801,7 +2810,8 @@ CREATE TABLE IF NOT EXISTS omicron.public.device_auth_request (
 
 -- Access tokens granted in response to successful device authorization flows.
 CREATE TABLE IF NOT EXISTS omicron.public.device_access_token (
-    token STRING(40) PRIMARY KEY,
+    id UUID PRIMARY KEY,
+    token STRING(40) NOT NULL,
     client_id UUID NOT NULL,
     device_code STRING(40) NOT NULL,
     silo_user_id UUID NOT NULL,
@@ -2814,6 +2824,11 @@ CREATE TABLE IF NOT EXISTS omicron.public.device_access_token (
 -- one token is ever created for a given device authorization flow.
 CREATE UNIQUE INDEX IF NOT EXISTS lookup_device_access_token_by_client ON omicron.public.device_access_token (
     client_id, device_code
+);
+
+-- We added a UUID as the primary key, but we need the token to keep acting like it did before
+CREATE UNIQUE INDEX IF NOT EXISTS device_access_token_unique ON omicron.public.device_access_token (
+    token
 );
 
 -- This index is used to remove tokens for a user that's being deleted.
@@ -5671,7 +5686,7 @@ INSERT INTO omicron.public.db_metadata (
     version,
     target_version
 ) VALUES
-    (TRUE, NOW(), NOW(), '144.0.0', NULL)
+    (TRUE, NOW(), NOW(), '145.0.0', NULL)
 ON CONFLICT DO NOTHING;
 
 COMMIT;

--- a/schema/crdb/token-and-session-ids/README.md
+++ b/schema/crdb/token-and-session-ids/README.md
@@ -4,19 +4,17 @@ This migration adds UUID primary keys to the `console_session` and `device_acces
 
 ## `console_session`
 
-1. Add nullable `id` column (UUID)
-2. Populate existing rows with generated UUIDs
-3. Make `id` column non-nullable
-4. Change primary key from `token` to `id`
-5. Make `token` column non-nullable
-6. Add unique index on `token`
+1. Add non-nullable `id` column (UUID) with default
+2. Drop default from `id` column
+3. Change primary key from `token` to `id`
+4. Make `token` column non-nullable
+5. Add unique index on `token`
 
 ## `device_access_token`
 
-7. Add nullable `id` column (UUID)
-8. Populate existing rows with generated UUIDs
-9. Make `id` column non-nullable
-10. Change primary key from `token` to `id`
-11. Make `token` column non-nullable
-12. Add unique index on `token`
+6. Add non-nullable `id` column (UUID) with default
+7. Drop default from `id` column
+8. Change primary key from `token` to `id`
+9. Make `token` column non-nullable
+10. Add unique index on `token`
 

--- a/schema/crdb/token-and-session-ids/README.md
+++ b/schema/crdb/token-and-session-ids/README.md
@@ -1,0 +1,22 @@
+# Add `id` to token and session tables
+
+This migration adds UUID primary keys to the `console_session` and `device_access_token` tables, replacing the previous token-based primary keys.
+
+## `console_session`
+
+1. Add nullable `id` column (UUID)
+2. Populate existing rows with generated UUIDs
+3. Make `id` column non-nullable
+4. Change primary key from `token` to `id`
+5. Make `token` column non-nullable
+6. Add unique index on `token`
+
+## `device_access_token`
+
+7. Add nullable `id` column (UUID)
+8. Populate existing rows with generated UUIDs
+9. Make `id` column non-nullable
+10. Change primary key from `token` to `id`
+11. Make `token` column non-nullable
+12. Add unique index on `token`
+

--- a/schema/crdb/token-and-session-ids/up01.sql
+++ b/schema/crdb/token-and-session-ids/up01.sql
@@ -1,2 +1,2 @@
 ALTER TABLE omicron.public.console_session
-  ADD COLUMN IF NOT EXISTS id UUID;
+  ADD COLUMN IF NOT EXISTS id UUID NOT NULL DEFAULT gen_random_uuid();

--- a/schema/crdb/token-and-session-ids/up01.sql
+++ b/schema/crdb/token-and-session-ids/up01.sql
@@ -1,0 +1,2 @@
+ALTER TABLE omicron.public.console_session
+  ADD COLUMN IF NOT EXISTS id UUID;

--- a/schema/crdb/token-and-session-ids/up02.sql
+++ b/schema/crdb/token-and-session-ids/up02.sql
@@ -1,0 +1,5 @@
+set local disallow_full_table_scans = off;
+
+UPDATE omicron.public.console_session
+  SET id = gen_random_uuid()
+  WHERE id IS NULL;

--- a/schema/crdb/token-and-session-ids/up02.sql
+++ b/schema/crdb/token-and-session-ids/up02.sql
@@ -1,5 +1,2 @@
-set local disallow_full_table_scans = off;
-
-UPDATE omicron.public.console_session
-  SET id = gen_random_uuid()
-  WHERE id IS NULL;
+ALTER TABLE omicron.public.console_session
+  ALTER COLUMN id DROP DEFAULT;

--- a/schema/crdb/token-and-session-ids/up03.sql
+++ b/schema/crdb/token-and-session-ids/up03.sql
@@ -1,2 +1,14 @@
+-- the docs say to do both of these in the same transaction
+-- https://www.cockroachlabs.com/docs/v22.1/add-constraint#drop-and-add-a-primary-key-constraint
+
+-- docs use the constraint name "primary" in the example, but that doesn't work
+-- because it's actually called console_session_pkey, which I figured out with
+-- 
+--   show create table omicron.public.console_session
+
 ALTER TABLE omicron.public.console_session
-  ALTER COLUMN id SET NOT NULL;
+  DROP CONSTRAINT IF EXISTS "console_session_pkey";
+
+ALTER TABLE omicron.public.console_session
+  ADD CONSTRAINT "console_session_pkey" PRIMARY KEY (id);
+

--- a/schema/crdb/token-and-session-ids/up03.sql
+++ b/schema/crdb/token-and-session-ids/up03.sql
@@ -1,0 +1,2 @@
+ALTER TABLE omicron.public.console_session
+  ALTER COLUMN id SET NOT NULL;

--- a/schema/crdb/token-and-session-ids/up04.sql
+++ b/schema/crdb/token-and-session-ids/up04.sql
@@ -1,14 +1,2 @@
--- the docs say to do both of these in the same transaction
--- https://www.cockroachlabs.com/docs/v22.1/add-constraint#drop-and-add-a-primary-key-constraint
-
--- docs use the constraint name "primary" in the example, but that doesn't work
--- because it's actually called console_session_pkey, which I figured out with
--- 
---   show create table omicron.public.console_session
-
 ALTER TABLE omicron.public.console_session
-  DROP CONSTRAINT IF EXISTS "console_session_pkey";
-
-ALTER TABLE omicron.public.console_session
-  ADD CONSTRAINT "console_session_pkey" PRIMARY KEY (id);
-
+  ALTER COLUMN token SET NOT NULL;

--- a/schema/crdb/token-and-session-ids/up04.sql
+++ b/schema/crdb/token-and-session-ids/up04.sql
@@ -1,0 +1,14 @@
+-- the docs say to do both of these in the same transaction
+-- https://www.cockroachlabs.com/docs/v22.1/add-constraint#drop-and-add-a-primary-key-constraint
+
+-- docs use the constraint name "primary" in the example, but that doesn't work
+-- because it's actually called console_session_pkey, which I figured out with
+-- 
+--   show create table omicron.public.console_session
+
+ALTER TABLE omicron.public.console_session
+  DROP CONSTRAINT IF EXISTS "console_session_pkey";
+
+ALTER TABLE omicron.public.console_session
+  ADD CONSTRAINT "console_session_pkey" PRIMARY KEY (id);
+

--- a/schema/crdb/token-and-session-ids/up05.sql
+++ b/schema/crdb/token-and-session-ids/up05.sql
@@ -1,0 +1,2 @@
+ALTER TABLE omicron.public.console_session
+  ALTER COLUMN token SET NOT NULL;

--- a/schema/crdb/token-and-session-ids/up05.sql
+++ b/schema/crdb/token-and-session-ids/up05.sql
@@ -1,2 +1,2 @@
-ALTER TABLE omicron.public.console_session
-  ALTER COLUMN token SET NOT NULL;
+CREATE UNIQUE INDEX IF NOT EXISTS console_session_token_unique
+  ON omicron.public.console_session (token);

--- a/schema/crdb/token-and-session-ids/up06.sql
+++ b/schema/crdb/token-and-session-ids/up06.sql
@@ -1,0 +1,2 @@
+CREATE UNIQUE INDEX IF NOT EXISTS console_session_token_unique
+  ON omicron.public.console_session (token);

--- a/schema/crdb/token-and-session-ids/up06.sql
+++ b/schema/crdb/token-and-session-ids/up06.sql
@@ -1,2 +1,2 @@
-CREATE UNIQUE INDEX IF NOT EXISTS console_session_token_unique
-  ON omicron.public.console_session (token);
+ALTER TABLE omicron.public.device_access_token
+  ADD COLUMN IF NOT EXISTS id UUID NOT NULL DEFAULT gen_random_uuid();

--- a/schema/crdb/token-and-session-ids/up07.sql
+++ b/schema/crdb/token-and-session-ids/up07.sql
@@ -1,2 +1,2 @@
 ALTER TABLE omicron.public.device_access_token
-  ADD COLUMN IF NOT EXISTS id UUID;
+  ALTER COLUMN id DROP DEFAULT;

--- a/schema/crdb/token-and-session-ids/up07.sql
+++ b/schema/crdb/token-and-session-ids/up07.sql
@@ -1,0 +1,2 @@
+ALTER TABLE omicron.public.device_access_token
+  ADD COLUMN IF NOT EXISTS id UUID;

--- a/schema/crdb/token-and-session-ids/up08.sql
+++ b/schema/crdb/token-and-session-ids/up08.sql
@@ -1,0 +1,5 @@
+set local disallow_full_table_scans = off;
+
+UPDATE omicron.public.device_access_token
+  SET id = gen_random_uuid()
+  WHERE id IS NULL;

--- a/schema/crdb/token-and-session-ids/up08.sql
+++ b/schema/crdb/token-and-session-ids/up08.sql
@@ -1,5 +1,14 @@
-set local disallow_full_table_scans = off;
+-- the docs say to do both of these in the same transaction
+-- https://www.cockroachlabs.com/docs/v22.1/add-constraint#drop-and-add-a-primary-key-constraint
 
-UPDATE omicron.public.device_access_token
-  SET id = gen_random_uuid()
-  WHERE id IS NULL;
+-- docs use the constraint name "primary" in the example, but that doesn't work
+-- because it's actually called device_access_token_pkey, which I figured out with
+-- 
+--   show create table omicron.public.device_access_token
+
+ALTER TABLE omicron.public.device_access_token
+  DROP CONSTRAINT IF EXISTS "device_access_token_pkey";
+
+ALTER TABLE omicron.public.device_access_token
+  ADD CONSTRAINT "device_access_token_pkey" PRIMARY KEY (id);
+

--- a/schema/crdb/token-and-session-ids/up09.sql
+++ b/schema/crdb/token-and-session-ids/up09.sql
@@ -1,0 +1,2 @@
+ALTER TABLE omicron.public.device_access_token
+  ALTER COLUMN id SET NOT NULL;

--- a/schema/crdb/token-and-session-ids/up09.sql
+++ b/schema/crdb/token-and-session-ids/up09.sql
@@ -1,2 +1,2 @@
 ALTER TABLE omicron.public.device_access_token
-  ALTER COLUMN id SET NOT NULL;
+  ALTER COLUMN token SET NOT NULL;

--- a/schema/crdb/token-and-session-ids/up10.sql
+++ b/schema/crdb/token-and-session-ids/up10.sql
@@ -1,0 +1,14 @@
+-- the docs say to do both of these in the same transaction
+-- https://www.cockroachlabs.com/docs/v22.1/add-constraint#drop-and-add-a-primary-key-constraint
+
+-- docs use the constraint name "primary" in the example, but that doesn't work
+-- because it's actually called console_session_pkey, which I figured out with
+-- 
+--   show create table omicron.public.console_session
+
+ALTER TABLE omicron.public.device_access_token
+  DROP CONSTRAINT IF EXISTS "device_access_token_pkey";
+
+ALTER TABLE omicron.public.device_access_token
+  ADD CONSTRAINT "device_access_token_pkey" PRIMARY KEY (id);
+

--- a/schema/crdb/token-and-session-ids/up10.sql
+++ b/schema/crdb/token-and-session-ids/up10.sql
@@ -2,9 +2,9 @@
 -- https://www.cockroachlabs.com/docs/v22.1/add-constraint#drop-and-add-a-primary-key-constraint
 
 -- docs use the constraint name "primary" in the example, but that doesn't work
--- because it's actually called console_session_pkey, which I figured out with
+-- because it's actually called device_access_token_pkey, which I figured out with
 -- 
---   show create table omicron.public.console_session
+--   show create table omicron.public.device_access_token_pkey
 
 ALTER TABLE omicron.public.device_access_token
   DROP CONSTRAINT IF EXISTS "device_access_token_pkey";

--- a/schema/crdb/token-and-session-ids/up10.sql
+++ b/schema/crdb/token-and-session-ids/up10.sql
@@ -1,14 +1,2 @@
--- the docs say to do both of these in the same transaction
--- https://www.cockroachlabs.com/docs/v22.1/add-constraint#drop-and-add-a-primary-key-constraint
-
--- docs use the constraint name "primary" in the example, but that doesn't work
--- because it's actually called device_access_token_pkey, which I figured out with
--- 
---   show create table omicron.public.device_access_token_pkey
-
-ALTER TABLE omicron.public.device_access_token
-  DROP CONSTRAINT IF EXISTS "device_access_token_pkey";
-
-ALTER TABLE omicron.public.device_access_token
-  ADD CONSTRAINT "device_access_token_pkey" PRIMARY KEY (id);
-
+CREATE UNIQUE INDEX IF NOT EXISTS device_access_token_unique
+  ON omicron.public.device_access_token (token);

--- a/schema/crdb/token-and-session-ids/up11.sql
+++ b/schema/crdb/token-and-session-ids/up11.sql
@@ -1,2 +1,0 @@
-ALTER TABLE omicron.public.device_access_token
-  ALTER COLUMN token SET NOT NULL;

--- a/schema/crdb/token-and-session-ids/up11.sql
+++ b/schema/crdb/token-and-session-ids/up11.sql
@@ -1,0 +1,2 @@
+ALTER TABLE omicron.public.device_access_token
+  ALTER COLUMN token SET NOT NULL;

--- a/schema/crdb/token-and-session-ids/up12.sql
+++ b/schema/crdb/token-and-session-ids/up12.sql
@@ -1,2 +1,0 @@
-CREATE UNIQUE INDEX IF NOT EXISTS device_access_token_unique
-  ON omicron.public.device_access_token (token);

--- a/schema/crdb/token-and-session-ids/up12.sql
+++ b/schema/crdb/token-and-session-ids/up12.sql
@@ -1,0 +1,2 @@
+CREATE UNIQUE INDEX IF NOT EXISTS device_access_token_unique
+  ON omicron.public.device_access_token (token);

--- a/uuid-kinds/src/lib.rs
+++ b/uuid-kinds/src/lib.rs
@@ -51,12 +51,14 @@ macro_rules! impl_typed_uuid_kind {
 // Please keep this list in alphabetical order.
 
 impl_typed_uuid_kind! {
+    AccessToken => "access_token",
     AffinityGroup => "affinity_group",
     Alert => "alert",
     AlertReceiver => "alert_receiver",
     AntiAffinityGroup => "anti_affinity_group",
     Blueprint => "blueprint",
     Collection => "collection",
+    ConsoleSession => "console_session",
     Dataset => "dataset",
     DemoSaga => "demo_saga",
     Downstairs => "downstairs",


### PR DESCRIPTION
Closes #8139. Token IDs are used in #8227 and #8231 for token CRUD.

WIP. Everything compiles and existing tests work, but we are not yet testing retrieval by ID and we need to think about authz checks on the datastore functions for retrieving tokens and sessions by token string.

This PR would be a lot shorter if not for the fact that the `token` column was the primary key on both tables, so adding the `id` requires a bunch of migration steps to change the primary key. There were also a lot of changes to code and tests around making things ID-centric instead of token-centric.

* [x] SQL migrations for adding `id` col and changing primary key to that
* [x] Add `TypedUuid` to session and token DB models
* [x] Update `authz_resource!` and `lookup_resource!` calls for new primary key
* [x] Update `Session` trait methods to use `id` instead of `token`
* [x] Update app and datastore session and token methods to use ID instead of token
* [x] Update two distinct but nearly identical `FakeSession` implementations (one for unit tests, one for integration tests) to a) track sessions in a `Vec` instead of a `HashMap` with token keys
* [x] Figure out authz situation in new fetch session/token by token string methods