### PR TITLE
[gateway] Update MGS git deps

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3516,16 +3516,15 @@ dependencies = [
 [[package]]
 name = "gateway-ereport-messages"
 version = "0.1.0"
-source = "git+https://github.com/oxidecomputer/management-gateway-service?rev=57536869418e08667824c9a1b2cf115ed91b713f#57536869418e08667824c9a1b2cf115ed91b713f"
+source = "git+https://github.com/oxidecomputer/management-gateway-service?rev=0e1e055b66ec007c537e5bd45e210c245f9c537d#0e1e055b66ec007c537e5bd45e210c245f9c537d"
 dependencies = [
- "bitflags 2.9.0",
  "zerocopy 0.8.25",
 ]
 
 [[package]]
 name = "gateway-messages"
 version = "0.1.0"
-source = "git+https://github.com/oxidecomputer/management-gateway-service?rev=57536869418e08667824c9a1b2cf115ed91b713f#57536869418e08667824c9a1b2cf115ed91b713f"
+source = "git+https://github.com/oxidecomputer/management-gateway-service?rev=0e1e055b66ec007c537e5bd45e210c245f9c537d#0e1e055b66ec007c537e5bd45e210c245f9c537d"
 dependencies = [
  "bitflags 2.9.0",
  "hubpack",
@@ -3542,7 +3541,7 @@ dependencies = [
 [[package]]
 name = "gateway-sp-comms"
 version = "0.1.1"
-source = "git+https://github.com/oxidecomputer/management-gateway-service?rev=57536869418e08667824c9a1b2cf115ed91b713f#57536869418e08667824c9a1b2cf115ed91b713f"
+source = "git+https://github.com/oxidecomputer/management-gateway-service?rev=0e1e055b66ec007c537e5bd45e210c245f9c537d#0e1e055b66ec007c537e5bd45e210c245f9c537d"
 dependencies = [
  "async-trait",
  "backoff",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -436,9 +436,9 @@ gateway-client = { path = "clients/gateway-client" }
 # compatibility, but will mean that faux-mgs might be missing new
 # functionality.)
 #
-gateway-ereport-messages = { git = "https://github.com/oxidecomputer/management-gateway-service", rev = "57536869418e08667824c9a1b2cf115ed91b713f", default-features = false, features = ["debug-impls"] }
-gateway-messages = { git = "https://github.com/oxidecomputer/management-gateway-service", rev = "57536869418e08667824c9a1b2cf115ed91b713f", default-features = false, features = ["std"] }
-gateway-sp-comms = { git = "https://github.com/oxidecomputer/management-gateway-service", rev = "57536869418e08667824c9a1b2cf115ed91b713f" }
+gateway-ereport-messages = { git = "https://github.com/oxidecomputer/management-gateway-service", rev = "0e1e055b66ec007c537e5bd45e210c245f9c537d", default-features = false, features = ["debug-impls"] }
+gateway-messages = { git = "https://github.com/oxidecomputer/management-gateway-service", rev = "0e1e055b66ec007c537e5bd45e210c245f9c537d", default-features = false, features = ["std"] }
+gateway-sp-comms = { git = "https://github.com/oxidecomputer/management-gateway-service", rev = "0e1e055b66ec007c537e5bd45e210c245f9c537d" }
 gateway-test-utils = { path = "gateway-test-utils" }
 gateway-types = { path = "gateway-types" }
 gethostname = "0.5.0"

--- a/package-manifest.toml
+++ b/package-manifest.toml
@@ -560,8 +560,8 @@ source.type = "prebuilt"
 source.repo = "management-gateway-service"
 # In general, this commit should match the pinned revision of `gateway-sp-comms`
 # in `Cargo.toml`.
-source.commit = "57536869418e08667824c9a1b2cf115ed91b713f"
-source.sha256 = "51076e51bc549dd463a87fb2df1207c0a3f1c7ed93fcafe1fd73a0880282437c"
+source.commit = "0e1e055b66ec007c537e5bd45e210c245f9c537d"
+source.sha256 = "7723adcc881af22ab6acd9f25886adb5c2a06470c36e9aca686a54a4ad8a3e64"
 output.type = "zone"
 output.intermediate_only = true
 

--- a/sp-sim/src/ereport.rs
+++ b/sp-sim/src/ereport.rs
@@ -155,7 +155,7 @@ impl EreportState {
                 "req_restart_id" => ?req.restart_id,
                 "current_restart_id" => ?self.restart_id,
             );
-            (Some(&self.meta), Ena::new(0))
+            (Some(&self.meta), Ena::NONE)
         } else {
             // If we didn't "restart", we should honor the committed ENA (if the
             // request includes one), and we should start at the requested ENA.
@@ -171,7 +171,7 @@ impl EreportState {
                 while self
                     .ereports
                     .front()
-                    .map(|ereport| ereport.ena <= committed_ena)
+                    .map(|ereport| &ereport.ena <= committed_ena)
                     .unwrap_or(false)
                 {
                     self.ereports.pop_front();
@@ -200,7 +200,7 @@ impl EreportState {
             .peek()
             .map(|ereport| ereport.ena)
             // If there are no ereports, send ENA zero (which means "no ereports").
-            .unwrap_or(Ena::ZERO);
+            .unwrap_or(Ena::NONE);
 
         // Serialize the header.
         ResponseHeader::V0(ResponseHeaderV0 {

--- a/sp-sim/src/gimlet.rs
+++ b/sp-sim/src/gimlet.rs
@@ -30,6 +30,7 @@ use gateway_messages::DumpTask;
 use gateway_messages::Header;
 use gateway_messages::MgsRequest;
 use gateway_messages::MgsResponse;
+use gateway_messages::PowerStateTransition;
 use gateway_messages::RotBootInfo;
 use gateway_messages::RotRequest;
 use gateway_messages::RotResponse;
@@ -1183,14 +1184,22 @@ impl SpHandler for Handler {
         &mut self,
         sender: Sender<Self::VLanId>,
         power_state: PowerState,
-    ) -> Result<(), SpError> {
+    ) -> Result<PowerStateTransition, SpError> {
+        let transition = if power_state != self.power_state {
+            PowerStateTransition::Changed
+        } else {
+            PowerStateTransition::Unchanged
+        };
+
         debug!(
             &self.log, "received set power state";
             "sender" => ?sender,
+            "prev_power_state" => ?self.power_state,
             "power_state" => ?power_state,
+            "transition" => ?transition,
         );
         self.power_state = power_state;
-        Ok(())
+        Ok(transition)
     }
 
     fn reset_component_prepare(

--- a/sp-sim/src/sidecar.rs
+++ b/sp-sim/src/sidecar.rs
@@ -870,14 +870,21 @@ impl SpHandler for Handler {
         &mut self,
         sender: Sender<Self::VLanId>,
         power_state: gateway_messages::PowerState,
-    ) -> Result<(), SpError> {
+    ) -> Result<gateway_messages::PowerStateTransition, SpError> {
+        // NOTE(eliza): This is *currently* accurate to real life sidecar
+        // behavior, as the sidecar sequencer does not treat `set_power_state`
+        // calls with the current power state idempotently, the way the compute
+        // sled sequencer does.
+        // See: https://github.com/oxidecomputer/hubris/blob/13808140c49fdf8f1ce462184395d3b28212c217/task/control-plane-agent/src/mgs_sidecar.rs#L838-L840
+        let transition = gateway_messages::PowerStateTransition::Changed;
         debug!(
             &self.log, "received set power state";
             "sender" => ?sender,
             "power_state" => ?power_state,
+            "transition" => ?transition,
         );
         self.power_state = power_state;
-        Ok(())
+        Ok(transition)
     }
 
     fn reset_component_prepare(

--- a/workspace-hack/Cargo.toml
+++ b/workspace-hack/Cargo.toml
@@ -57,7 +57,7 @@ futures-io = { version = "0.3.31" }
 futures-sink = { version = "0.3.31" }
 futures-task = { version = "0.3.31", default-features = false, features = ["std"] }
 futures-util = { version = "0.3.31", features = ["channel", "io", "sink"] }
-gateway-messages = { git = "https://github.com/oxidecomputer/management-gateway-service", rev = "57536869418e08667824c9a1b2cf115ed91b713f", features = ["std"] }
+gateway-messages = { git = "https://github.com/oxidecomputer/management-gateway-service", rev = "0e1e055b66ec007c537e5bd45e210c245f9c537d", features = ["std"] }
 generic-array = { version = "0.14.7", default-features = false, features = ["more_lengths", "zeroize"] }
 getrandom-6f8ce4dd05d13bba = { package = "getrandom", version = "0.2.15", default-features = false, features = ["js", "rdrand", "std"] }
 group = { version = "0.13.0", default-features = false, features = ["alloc"] }
@@ -180,7 +180,7 @@ futures-io = { version = "0.3.31" }
 futures-sink = { version = "0.3.31" }
 futures-task = { version = "0.3.31", default-features = false, features = ["std"] }
 futures-util = { version = "0.3.31", features = ["channel", "io", "sink"] }
-gateway-messages = { git = "https://github.com/oxidecomputer/management-gateway-service", rev = "57536869418e08667824c9a1b2cf115ed91b713f", features = ["std"] }
+gateway-messages = { git = "https://github.com/oxidecomputer/management-gateway-service", rev = "0e1e055b66ec007c537e5bd45e210c245f9c537d", features = ["std"] }
 generic-array = { version = "0.14.7", default-features = false, features = ["more_lengths", "zeroize"] }
 getrandom-6f8ce4dd05d13bba = { package = "getrandom", version = "0.2.15", default-features = false, features = ["js", "rdrand", "std"] }
 group = { version = "0.13.0", default-features = false, features = ["alloc"] }


### PR DESCRIPTION
This commit updates the MGS repo git dependencies to oxidecomputer/management-gateway-service@0e1e055b66ec007c537e5bd45e210c245f9c537d. This picks up the following commits:

- oxidecomputer/management-gateway-service#389: Clap bump
- oxidecomputer/management-gateway-service#390: Make no-op `SetPowerState` calls succeed; needed to unblock oxidecomputer/hubris#2065 merging for R16
- oxidecomputer/management-gateway-service#388: Remove an unused flag bit from the ereport protocol
- oxidecomputer/management-gateway-service#391: Adds debug impls for the new `PowerStateTransition` type added in oxidecomputer/management-gateway-service#390

Most of these commits are mine, and should be relatively low risk to merge --- trust me. 😇