### PR TITLE
[meta] update to rust 1.87

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -309,6 +309,9 @@ resolver = "3"
 [workspace.lints.clippy]
 # Clippy's style nits are useful, but not worth keeping in CI.
 style = { level = "allow", priority = -1 }
+# This lint would be useful to address over time, but has too many hits as of
+# 2025-05-15.
+result_large_err = "allow"
 # But continue to warn on anything in the "disallowed_" namespace.
 disallowed_macros = "warn"
 disallowed_methods = "warn"

--- a/nexus/db-macros/src/lookup.rs
+++ b/nexus/db-macros/src/lookup.rs
@@ -75,7 +75,7 @@ impl InputPrimaryKeyColumn {
                 ));
             }
             (Some(rust_type), None) => {
-                PrimaryKeyType::Standard(rust_type.into_inner())
+                PrimaryKeyType::Standard(Box::new(rust_type.into_inner()))
             }
             (None, Some(uuid_kind)) => {
                 PrimaryKeyType::new_typed_uuid(&uuid_kind)

--- a/nexus/db-model/src/device_auth.rs
+++ b/nexus/db-model/src/device_auth.rs
@@ -183,7 +183,7 @@ mod test {
                 user_code
                     .chars()
                     .filter(|x| *x != '-')
-                    .all(|x| { USER_CODE_ALPHABET.iter().any(|y| *y == x) })
+                    .all(|x| { USER_CODE_ALPHABET.contains(&x) })
             );
             assert!(!codes_seen.contains(&user_code));
             codes_seen.insert(user_code);

--- a/nexus/macros-common/src/lib.rs
+++ b/nexus/macros-common/src/lib.rs
@@ -12,15 +12,15 @@ use syn::parse_quote;
 #[derive(Debug)]
 pub enum PrimaryKeyType {
     /// A regular type.
-    Standard(syn::Type),
+    Standard(Box<syn::Type>),
 
     /// A typed UUID, which requires special handling.
     TypedUuid {
         /// The external type. This is used almost everywhere.
-        external: syn::Type,
+        external: Box<syn::Type>,
 
         /// The internal type used in nexus-db-model.
-        db: syn::Type,
+        db: Box<syn::Type>,
     },
 }
 
@@ -43,8 +43,8 @@ impl PrimaryKeyType {
     /// Converts self into the external type.
     pub fn into_external(self) -> syn::Type {
         match self {
-            PrimaryKeyType::Standard(path) => path,
-            PrimaryKeyType::TypedUuid { external, .. } => external,
+            PrimaryKeyType::Standard(path) => *path,
+            PrimaryKeyType::TypedUuid { external, .. } => *external,
         }
     }
 
@@ -62,8 +62,8 @@ impl PrimaryKeyType {
     /// Converts self into the database type.
     pub fn into_db(self) -> syn::Type {
         match self {
-            PrimaryKeyType::Standard(path) => path,
-            PrimaryKeyType::TypedUuid { db, .. } => db,
+            PrimaryKeyType::Standard(path) => *path,
+            PrimaryKeyType::TypedUuid { db, .. } => *db,
         }
     }
 

--- a/oximeter/db/src/client/mod.rs
+++ b/oximeter/db/src/client/mod.rs
@@ -1008,8 +1008,8 @@ impl Client {
                         "sample" => ?sample,
                     );
                     Err(Error::SchemaMismatch {
-                        expected: existing_schema.clone(),
-                        actual: sample_schema,
+                        expected: Box::new(existing_schema.clone()),
+                        actual: Box::new(sample_schema),
                     })
                 }
             }

--- a/oximeter/db/src/lib.rs
+++ b/oximeter/db/src/lib.rs
@@ -82,7 +82,10 @@ pub enum Error {
 
     /// A schema provided when collecting samples did not match the expected schema
     #[error("Schema mismatch for timeseries '{0}'", expected.timeseries_name)]
-    SchemaMismatch { expected: TimeseriesSchema, actual: TimeseriesSchema },
+    SchemaMismatch {
+        expected: Box<TimeseriesSchema>,
+        actual: Box<TimeseriesSchema>,
+    },
 
     #[error("Timeseries not found for: {0}")]
     TimeseriesNotFound(String),

--- a/oximeter/db/src/native/connection.rs
+++ b/oximeter/db/src/native/connection.rs
@@ -135,7 +135,9 @@ impl Connection {
         reader: &mut FramedRead<OwnedReadHalf, Decoder>,
         writer: &mut FramedWrite<OwnedWriteHalf, Encoder>,
     ) -> Result<ServerHello, Error> {
-        writer.send(ClientPacket::Hello(OXIMETER_HELLO.clone())).await?;
+        writer
+            .send(ClientPacket::Hello(Box::new(OXIMETER_HELLO.clone())))
+            .await?;
         let hello = match reader.next().await {
             Some(Ok(ServerPacket::Hello(hello))) => hello,
             Some(Ok(packet)) => {
@@ -245,7 +247,7 @@ impl Connection {
             profile_events: None,
         };
         let query = Query::new(query_result.id, self.address, query);
-        self.writer.send(ClientPacket::Query(query)).await?;
+        self.writer.send(ClientPacket::Query(Box::new(query))).await?;
         probes::packet__sent!(|| "Query");
         self.outstanding_query = true;
 

--- a/oximeter/db/src/native/io/packet/client.rs
+++ b/oximeter/db/src/native/io/packet/client.rs
@@ -26,15 +26,15 @@ pub struct Encoder;
 
 impl Encoder {
     /// Encode a client hello packet.
-    fn encode_hello(&self, hello: Hello, mut dst: &mut BytesMut) {
+    fn encode_hello(&self, hello: &Hello, mut dst: &mut BytesMut) {
         dst.put_u8(Packet::HELLO);
-        io::string::encode(hello.client_name, &mut dst);
+        io::string::encode(&hello.client_name, &mut dst);
         io::varuint::encode(hello.version_major, &mut dst);
         io::varuint::encode(hello.version_minor, &mut dst);
         io::varuint::encode(hello.protocol_version, &mut dst);
-        io::string::encode(hello.database, &mut dst);
-        io::string::encode(hello.username, &mut dst);
-        io::string::encode(hello.password, &mut dst);
+        io::string::encode(&hello.database, &mut dst);
+        io::string::encode(&hello.username, &mut dst);
+        io::string::encode(&hello.password, &mut dst);
 
         // NOTE: It's not described in the documentation for the protocol, but
         // recent client versions are required so send an "addendum" packet
@@ -48,7 +48,7 @@ impl Encoder {
     }
 
     /// Encode the client query packet.
-    fn encode_query(&self, query: Query, mut dst: &mut BytesMut) {
+    fn encode_query(&self, query: Box<Query>, mut dst: &mut BytesMut) {
         dst.put_u8(Packet::QUERY);
         io::string::encode(query.id, &mut dst);
         self.encode_client_info(query.client_info, &mut dst);
@@ -151,7 +151,7 @@ impl tokio_util::codec::Encoder<Packet> for Encoder {
     ) -> Result<(), Self::Error> {
         let kind = item.kind();
         match item {
-            Packet::Hello(hello) => self.encode_hello(hello, dst),
+            Packet::Hello(hello) => self.encode_hello(&hello, dst),
             Packet::Query(query) => self.encode_query(query, dst),
             Packet::Data(block) => self.encode_block(block, dst)?,
             Packet::Cancel => dst.put_u8(Packet::CANCEL),

--- a/oximeter/db/src/native/packets/client.rs
+++ b/oximeter/db/src/native/packets/client.rs
@@ -21,9 +21,9 @@ use uuid::Uuid;
 #[allow(dead_code)]
 pub enum Packet {
     /// The initial packet to the server, to say hello.
-    Hello(Hello),
+    Hello(Box<Hello>),
     /// Send a query to the server.
-    Query(Query),
+    Query(Box<Query>),
     /// Send a block of data to the server.
     Data(Block),
     /// Cancel the current query.

--- a/oximeter/producer/src/lib.rs
+++ b/oximeter/producer/src/lib.rs
@@ -264,7 +264,7 @@ impl Server {
                     our_addr,
                 )
                 .map_err(Error::Resolution)
-                .map(FindNexus::WithResolver)?
+                .map(|resolver| FindNexus::WithResolver(Box::new(resolver)))?
             }
         };
 
@@ -294,7 +294,7 @@ enum FindNexus {
     ByAddr(SocketAddr),
     /// An address was not provided, we'll resolve it on each attempt to renew
     /// the lease.
-    WithResolver(Resolver),
+    WithResolver(Box<Resolver>),
 }
 
 /// The rate at which we renew, as a fraction of the renewal interval.

--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -2,5 +2,5 @@
 # We choose a specific toolchain (rather than "stable") for repeatability.  The
 # intent is to keep this up-to-date with recently-released stable Rust.
 
-channel = "1.86.0"
+channel = "1.87.0"
 profile = "default"

--- a/sled-agent/src/services.rs
+++ b/sled-agent/src/services.rs
@@ -725,7 +725,7 @@ enum SwitchZoneState {
         // The original request for the zone
         request: SwitchZoneConfig,
         // The currently running zone
-        zone: RunningZone,
+        zone: Box<RunningZone>,
     },
 }
 
@@ -4938,8 +4938,10 @@ impl ServiceManager {
         let zone = self
             .initialize_zone(zone_args, zone_root_path, filesystems, data_links)
             .await?;
-        *sled_zone =
-            SwitchZoneState::Running { request: request.clone(), zone };
+        *sled_zone = SwitchZoneState::Running {
+            request: request.clone(),
+            zone: Box::new(zone),
+        };
         Ok(())
     }
 

--- a/test-utils/src/dev/clickhouse.rs
+++ b/test-utils/src/dev/clickhouse.rs
@@ -59,13 +59,13 @@ pub enum ClickHouseDeployment {
     ///
     /// This starts a single replica on one server. It is expected to work with
     /// the non-replicated version of the `oximeter` database.
-    SingleNode(ClickHouseReplica),
+    SingleNode(Box<ClickHouseReplica>),
     /// A replicated ClickHouse cluster.
     ///
     /// This starts several replica servers, and the required ClickHouse Keeper
     /// nodes that manage the cluster. It is expected to work with the
     /// replicated version of the `oximeter` database.
-    Cluster(ClickHouseCluster),
+    Cluster(Box<ClickHouseCluster>),
 }
 
 /// Port numbers that a ClickHouse replica listens on.
@@ -146,7 +146,7 @@ impl ClickHouseDeployment {
     ) -> Result<Self, anyhow::Error> {
         ClickHouseProcess::new_single_node(logctx, ports)
             .await
-            .map(Self::SingleNode)
+            .map(|replica| Self::SingleNode(Box::new(replica)))
     }
 
     /// Create a replicated cluster deployment.
@@ -157,7 +157,7 @@ impl ClickHouseDeployment {
     ) -> Result<Self, anyhow::Error> {
         ClickHouseCluster::new(logctx, replica_config, keeper_config)
             .await
-            .map(Self::Cluster)
+            .map(|cluster| Self::Cluster(Box::new(cluster)))
     }
 
     /// Return true if this is a cluster deployment.
@@ -296,7 +296,7 @@ impl ClickHouseDeployment {
     ) -> Box<dyn Iterator<Item = &ClickHouseReplica> + '_> {
         match self {
             ClickHouseDeployment::SingleNode(instance) => {
-                Box::new(std::iter::once(instance))
+                Box::new(std::iter::once(&**instance))
             }
             ClickHouseDeployment::Cluster(cluster) => {
                 Box::new(cluster.replicas())

--- a/wicket-dbg/src/lib.rs
+++ b/wicket-dbg/src/lib.rs
@@ -67,7 +67,7 @@ pub enum Cmd {
 pub enum Rpy {
     Ok,
     Err(String),
-    State(State),
+    State(Box<State>),
     Event(usize),
     Debug(DebugState),
 }

--- a/wicket-dbg/src/runner.rs
+++ b/wicket-dbg/src/runner.rs
@@ -106,7 +106,7 @@ impl Runner {
                         }
 
                         Cmd::Reset => self.restart(),
-                        Cmd::GetState => Rpy::State(self.core.state.clone()),
+                        Cmd::GetState => Rpy::State(Box::new(self.core.state.clone())),
                         Cmd::Break{event} => {
                             self.breakpoints.insert(event);
                             Rpy::Ok

--- a/wicket/src/ui/widgets/rack.rs
+++ b/wicket/src/ui/widgets/rack.rs
@@ -248,8 +248,10 @@ fn resize(rect: Rect) -> ComponentRects {
     let (rack_height, sled_height, other_height): (u16, u16, u16) =
         if max_height < 20 {
             // The window is too short.
-            let text = Paragraph::new(Text::raw("[window too short]"))
-                .alignment(Alignment::Center);
+            let text = Box::new(
+                Paragraph::new(Text::raw("[window too short]"))
+                    .alignment(Alignment::Center),
+            );
             // Center vertically.
             let text_rect =
                 Rect { y: rect.y + max_height / 2, height: 1, ..rect };
@@ -406,7 +408,7 @@ enum ComponentRects {
     },
 
     /// The window is too short and needs to be resized.
-    WindowTooShort { text: Paragraph<'static>, text_rect: Rect },
+    WindowTooShort { text: Box<Paragraph<'static>>, text_rect: Rect },
 }
 
 type ComponentRectsMap = BTreeMap<ComponentId, Rect>;


### PR DESCRIPTION
Rust 1.87 causes a bunch of existing lints (like large-enum-variants) to fire more often. Handle some instances, and silence others.
