### PR TITLE
[external api] Set a default empty array for VpcFirewallRuleUpdate

### DIFF
--- a/common/src/api/external/mod.rs
+++ b/common/src/api/external/mod.rs
@@ -1789,6 +1789,7 @@ pub struct VpcFirewallRuleUpdate {
 #[derive(Clone, Debug, Deserialize, Serialize, JsonSchema)]
 pub struct VpcFirewallRuleUpdateParams {
     #[schemars(length(max = 1024))]
+    #[serde(default)]
     pub rules: Vec<VpcFirewallRuleUpdate>,
 }
 

--- a/openapi/nexus.json
+++ b/openapi/nexus.json
@@ -25265,16 +25265,14 @@
         "type": "object",
         "properties": {
           "rules": {
+            "default": [],
             "type": "array",
             "items": {
               "$ref": "#/components/schemas/VpcFirewallRuleUpdate"
             },
             "maxItems": 1024
           }
-        },
-        "required": [
-          "rules"
-        ]
+        }
       },
       "VpcFirewallRules": {
         "description": "Collection of a Vpc's firewall rules",


### PR DESCRIPTION
In our attempt to make the Go SDK generator less hacky https://github.com/oxidecomputer/oxide.go/pull/283, we had the unexpected side effect of breaking our `VpcFirewallRuleUpdateParams` struct https://github.com/oxidecomputer/oxide.go/pull/283/files#diff-841a2b1b5f072b633551cac9c34c9732a722b415e297a1530b92d5988962062eR6810-R6811 due to Go's fun way of handling empty values. Using this API no longer allows us to delete the entirety of the firewall rules.

This commit sets an empty array as the default for `rules` following the pattern that other APIs use.
https://github.com/oxidecomputer/omicron/blob/main/nexus/types/src/external_api/params.rs#L1163-L1177

cc @sudomateo 