### PR TITLE
[sled-agent-config-reconciler] Inventory types for reconciler status

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -6570,6 +6570,7 @@ dependencies = [
 name = "nexus-sled-agent-shared"
 version = "0.1.0"
 dependencies = [
+ "chrono",
  "daft",
  "id-map",
  "illumos-utils",

--- a/nexus-sled-agent-shared/Cargo.toml
+++ b/nexus-sled-agent-shared/Cargo.toml
@@ -7,6 +7,7 @@ edition = "2021"
 workspace = true
 
 [dependencies]
+chrono.workspace = true
 daft.workspace = true
 id-map.workspace = true
 illumos-utils.workspace = true

--- a/nexus-sled-agent-shared/src/inventory.rs
+++ b/nexus-sled-agent-shared/src/inventory.rs
@@ -4,8 +4,11 @@
 
 //! Inventory types shared between Nexus and sled-agent.
 
+use std::collections::BTreeMap;
 use std::net::{IpAddr, Ipv6Addr, SocketAddr, SocketAddrV6};
+use std::time::Duration;
 
+use chrono::{DateTime, Utc};
 use daft::Diffable;
 use id_map::IdMap;
 use id_map::IdMappable;
@@ -21,8 +24,8 @@ use omicron_common::{
     },
     zpool_name::ZpoolName,
 };
-use omicron_uuid_kinds::MupdateOverrideUuid;
 use omicron_uuid_kinds::{DatasetUuid, OmicronZoneUuid};
+use omicron_uuid_kinds::{MupdateOverrideUuid, PhysicalDiskUuid};
 use omicron_uuid_kinds::{SledUuid, ZpoolUuid};
 use schemars::JsonSchema;
 use serde::{Deserialize, Serialize};
@@ -113,6 +116,59 @@ pub struct Inventory {
     pub zpools: Vec<InventoryZpool>,
     pub datasets: Vec<InventoryDataset>,
     pub omicron_physical_disks_generation: Generation,
+}
+
+/// Describes the last attempt made by the sled-agent-config-reconciler to
+/// reconcile the current sled config against the actual state of the sled.
+#[derive(Clone, Debug, PartialEq, Eq, Deserialize, JsonSchema, Serialize)]
+#[serde(rename_all = "snake_case")]
+pub struct ConfigReconcilerInventory {
+    pub last_reconciled_config: OmicronSledConfig,
+    pub external_disks:
+        BTreeMap<PhysicalDiskUuid, ConfigReconcilerInventoryResult>,
+    pub datasets: BTreeMap<DatasetUuid, ConfigReconcilerInventoryResult>,
+    pub zones: BTreeMap<OmicronZoneUuid, ConfigReconcilerInventoryResult>,
+}
+
+#[derive(Clone, Debug, PartialEq, Eq, Deserialize, JsonSchema, Serialize)]
+#[serde(tag = "result", rename_all = "snake_case")]
+pub enum ConfigReconcilerInventoryResult {
+    Ok,
+    Err { message: String },
+}
+
+impl From<Result<(), String>> for ConfigReconcilerInventoryResult {
+    fn from(result: Result<(), String>) -> Self {
+        match result {
+            Ok(()) => Self::Ok,
+            Err(message) => Self::Err { message },
+        }
+    }
+}
+
+/// Status of the sled-agent-config-reconciler task.
+#[derive(Clone, Debug, PartialEq, Eq, Deserialize, JsonSchema, Serialize)]
+#[serde(tag = "status", rename_all = "snake_case")]
+pub enum ConfigReconcilerInventoryStatus {
+    /// The reconciler task has not yet run for the first time since sled-agent
+    /// started.
+    NotYetRun,
+    /// The reconciler task is actively running.
+    Running {
+        config: OmicronSledConfig,
+        started_at: DateTime<Utc>,
+        running_for: Duration,
+    },
+    /// The reconciler task is currently idle, but previously did complete a
+    /// reconciliation attempt.
+    ///
+    /// This variant does not include the `OmicronSledConfig` used in the last
+    /// attempt, because that's always available via
+    /// [`ConfigReconcilerInventory::last_reconciled_config`].
+    Idle {
+        completed_at: DateTime<Utc>,
+        ran_for: Duration,
+    },
 }
 
 /// Describes the role of the sled within the rack.

--- a/nexus-sled-agent-shared/src/inventory.rs
+++ b/nexus-sled-agent-shared/src/inventory.rs
@@ -165,10 +165,7 @@ pub enum ConfigReconcilerInventoryStatus {
     /// This variant does not include the `OmicronSledConfig` used in the last
     /// attempt, because that's always available via
     /// [`ConfigReconcilerInventory::last_reconciled_config`].
-    Idle {
-        completed_at: DateTime<Utc>,
-        ran_for: Duration,
-    },
+    Idle { completed_at: DateTime<Utc>, ran_for: Duration },
 }
 
 /// Describes the role of the sled within the rack.

--- a/sled-agent/config-reconciler/src/handle.rs
+++ b/sled-agent/config-reconciler/src/handle.rs
@@ -340,7 +340,10 @@ impl ConfigReconcilerHandle {
     }
 
     /// Collect inventory fields relevant to config reconciliation.
-    pub fn inventory(&self) -> Result<ReconcilerInventory, InventoryError> {
+    pub async fn inventory(
+        &self,
+        log: &Logger,
+    ) -> Result<ReconcilerInventory, InventoryError> {
         let ledgered_sled_config = match self
             .ledger_task
             .get()
@@ -365,9 +368,11 @@ impl ConfigReconcilerHandle {
         let (reconciler_status, last_reconciliation) =
             self.reconciler_result_rx.borrow().to_inventory();
 
+        let zpools = self.currently_managed_zpools_rx.to_inventory(log).await;
+
         Ok(ReconcilerInventory {
             disks: self.raw_disks_tx.to_inventory(),
-            zpools: Vec::new(),
+            zpools,
             datasets: Vec::new(),
             ledgered_sled_config,
             reconciler_status,

--- a/sled-agent/config-reconciler/src/handle.rs
+++ b/sled-agent/config-reconciler/src/handle.rs
@@ -366,7 +366,7 @@ impl ConfigReconcilerHandle {
             self.reconciler_result_rx.borrow().to_inventory();
 
         Ok(ReconcilerInventory {
-            disks: Vec::new(),
+            disks: self.raw_disks_tx.to_inventory(),
             zpools: Vec::new(),
             datasets: Vec::new(),
             ledgered_sled_config,

--- a/sled-agent/config-reconciler/src/handle.rs
+++ b/sled-agent/config-reconciler/src/handle.rs
@@ -66,6 +66,8 @@ pub enum InventoryError {
     LedgerContentsNotAvailable,
     #[error("could not contact dataset task")]
     DatasetTaskError(#[from] DatasetTaskError),
+    #[error("could not list dataset properties")]
+    ListDatasetProperties(#[source] anyhow::Error),
 }
 
 #[derive(Debug, Clone, Copy)]
@@ -372,7 +374,7 @@ impl ConfigReconcilerHandle {
         let datasets = self
             .dataset_task
             .inventory(zpools.iter().map(|&(name, _)| name).collect())
-            .await?;
+            .await??;
 
         let (reconciler_status, last_reconciliation) =
             self.reconciler_result_rx.borrow().to_inventory();

--- a/sled-agent/config-reconciler/src/ledger.rs
+++ b/sled-agent/config-reconciler/src/ledger.rs
@@ -117,6 +117,7 @@ pub(crate) enum CurrentSledConfig {
 #[derive(Debug)]
 pub(crate) struct LedgerTaskHandle {
     request_tx: mpsc::Sender<LedgerTaskRequest>,
+    current_config_rx: watch::Receiver<CurrentSledConfig>,
 }
 
 impl LedgerTaskHandle {
@@ -160,7 +161,14 @@ impl LedgerTaskHandle {
             .run(),
         );
 
-        (Self { request_tx }, current_config_rx)
+        (
+            Self { request_tx, current_config_rx: current_config_rx.clone() },
+            current_config_rx,
+        )
+    }
+
+    pub(crate) fn current_config(&self) -> CurrentSledConfig {
+        self.current_config_rx.borrow().clone()
     }
 
     pub async fn set_new_config(

--- a/sled-agent/config-reconciler/src/lib.rs
+++ b/sled-agent/config-reconciler/src/lib.rs
@@ -71,6 +71,7 @@ pub use dataset_serialization_task::NestedDatasetMountError;
 pub use handle::AvailableDatasetsReceiver;
 pub use handle::ConfigReconcilerHandle;
 pub use handle::ConfigReconcilerSpawnToken;
+pub use handle::InventoryError;
 pub use handle::ReconcilerInventory;
 pub use handle::TimeSyncConfig;
 pub use internal_disks::InternalDisks;

--- a/sled-agent/config-reconciler/src/raw_disks.rs
+++ b/sled-agent/config-reconciler/src/raw_disks.rs
@@ -7,6 +7,7 @@
 
 use id_map::IdMap;
 use id_map::IdMappable;
+use nexus_sled_agent_shared::inventory::InventoryDisk;
 use omicron_common::disk::DiskIdentity;
 use sled_storage::disk::RawDisk;
 use slog::Logger;
@@ -123,6 +124,26 @@ impl RawDisksSender {
             Arc::make_mut(disks).remove(identity);
             true
         })
+    }
+
+    pub(crate) fn to_inventory(&self) -> Vec<InventoryDisk> {
+        self.0
+            .borrow()
+            .iter()
+            .map(|disk| {
+                let firmware = disk.firmware();
+                InventoryDisk {
+                    identity: disk.identity().clone(),
+                    variant: disk.variant(),
+                    slot: disk.slot(),
+                    active_firmware_slot: firmware.active_slot(),
+                    next_active_firmware_slot: firmware.next_active_slot(),
+                    number_of_firmware_slots: firmware.number_of_slots(),
+                    slot1_is_read_only: firmware.slot1_read_only(),
+                    slot_firmware_versions: firmware.slots().to_vec(),
+                }
+            })
+            .collect()
     }
 }
 

--- a/sled-agent/config-reconciler/src/reconciler_task.rs
+++ b/sled-agent/config-reconciler/src/reconciler_task.rs
@@ -84,11 +84,11 @@ pub(crate) fn spawn<T: SledAgentFacilities>(
     );
 }
 
-#[derive(Debug, Clone)]
+#[derive(Debug)]
 pub(crate) struct ReconcilerResult {
     mount_config: Arc<MountConfig>,
     status: ReconcilerTaskStatus,
-    latest_result: Option<Arc<LatestReconciliationResult>>,
+    latest_result: Option<LatestReconciliationResult>,
 }
 
 impl ReconcilerResult {
@@ -102,7 +102,7 @@ impl ReconcilerResult {
 
     pub(crate) fn timesync_status(&self) -> TimeSyncStatus {
         self.latest_result
-            .as_deref()
+            .as_ref()
             .map(|inner| inner.timesync_status.clone())
             .unwrap_or(TimeSyncStatus::NotYetChecked)
     }
@@ -484,7 +484,7 @@ impl ReconcilerTask {
                 completed_at_time: Utc::now(),
                 ran_for: started_at_instant.elapsed(),
             };
-            r.latest_result = Some(Arc::new(inner));
+            r.latest_result = Some(inner);
         });
 
         result

--- a/sled-agent/config-reconciler/src/reconciler_task.rs
+++ b/sled-agent/config-reconciler/src/reconciler_task.rs
@@ -10,13 +10,19 @@ use either::Either;
 use futures::future;
 use illumos_utils::zpool::PathInPool;
 use key_manager::StorageKeyRequester;
+use nexus_sled_agent_shared::inventory::ConfigReconcilerInventory;
+use nexus_sled_agent_shared::inventory::ConfigReconcilerInventoryResult;
+use nexus_sled_agent_shared::inventory::ConfigReconcilerInventoryStatus;
 use nexus_sled_agent_shared::inventory::OmicronSledConfig;
+use omicron_uuid_kinds::OmicronZoneUuid;
+use omicron_uuid_kinds::PhysicalDiskUuid;
 use sled_storage::config::MountConfig;
 use sled_storage::disk::Disk;
 use slog::Logger;
 use slog::info;
 use slog::warn;
 use slog_error_chain::InlineErrorChain;
+use std::collections::BTreeMap;
 use std::collections::HashSet;
 use std::sync::Arc;
 use std::time::Duration;
@@ -94,14 +100,14 @@ impl ReconcilerResult {
         }
     }
 
-    pub fn timesync_status(&self) -> TimeSyncStatus {
+    pub(crate) fn timesync_status(&self) -> TimeSyncStatus {
         self.latest_result
             .as_deref()
             .map(|inner| inner.timesync_status.clone())
             .unwrap_or(TimeSyncStatus::NotYetChecked)
     }
 
-    pub fn all_mounted_debug_datasets(
+    pub(crate) fn all_mounted_debug_datasets(
         &self,
     ) -> impl Iterator<Item = PathInPool> + '_ {
         let Some(latest_result) = &self.latest_result else {
@@ -114,7 +120,7 @@ impl ReconcilerResult {
         )
     }
 
-    pub fn all_mounted_zone_root_datasets(
+    pub(crate) fn all_mounted_zone_root_datasets(
         &self,
     ) -> impl Iterator<Item = PathInPool> + '_ {
         let Some(latest_result) = &self.latest_result else {
@@ -125,6 +131,16 @@ impl ReconcilerResult {
                 .datasets
                 .all_mounted_zone_root_datasets(&self.mount_config),
         )
+    }
+
+    pub(crate) fn to_inventory(
+        &self,
+    ) -> (ConfigReconcilerInventoryStatus, Option<ConfigReconcilerInventory>)
+    {
+        let status = self.status.to_inventory();
+        let latest_result =
+            self.latest_result.as_ref().map(|r| r.to_inventory());
+        (status, latest_result)
     }
 }
 
@@ -144,11 +160,52 @@ pub enum ReconcilerTaskStatus {
     },
 }
 
+impl ReconcilerTaskStatus {
+    fn to_inventory(&self) -> ConfigReconcilerInventoryStatus {
+        match self {
+            Self::NotYetRunning
+            | Self::WaitingForInternalDisks
+            | Self::WaitingForInitialConfig => {
+                ConfigReconcilerInventoryStatus::NotYetRun
+            }
+            Self::PerformingReconciliation {
+                config,
+                started_at_time,
+                started_at_instant,
+            } => ConfigReconcilerInventoryStatus::Running {
+                config: config.clone(),
+                started_at: *started_at_time,
+                running_for: started_at_instant.elapsed(),
+            },
+            Self::Idle { completed_at_time, ran_for } => {
+                ConfigReconcilerInventoryStatus::Idle {
+                    completed_at: *completed_at_time,
+                    ran_for: *ran_for,
+                }
+            }
+        }
+    }
+}
+
 #[derive(Debug)]
 struct LatestReconciliationResult {
     sled_config: OmicronSledConfig,
+    external_disks_inventory:
+        BTreeMap<PhysicalDiskUuid, ConfigReconcilerInventoryResult>,
     datasets: DatasetEnsureResult,
+    zones_inventory: BTreeMap<OmicronZoneUuid, ConfigReconcilerInventoryResult>,
     timesync_status: TimeSyncStatus,
+}
+
+impl LatestReconciliationResult {
+    fn to_inventory(&self) -> ConfigReconcilerInventory {
+        ConfigReconcilerInventory {
+            last_reconciled_config: self.sled_config.clone(),
+            external_disks: self.external_disks_inventory.clone(),
+            datasets: self.datasets.to_inventory(),
+            zones: self.zones_inventory.clone(),
+        }
+    }
 }
 
 struct ReconcilerTask {
@@ -417,7 +474,9 @@ impl ReconcilerTask {
 
         let inner = LatestReconciliationResult {
             sled_config,
+            external_disks_inventory: self.external_disks.to_inventory(),
             datasets,
+            zones_inventory: self.zones.to_inventory(),
             timesync_status,
         };
         self.reconciler_result_tx.send_modify(|r| {

--- a/sled-agent/config-reconciler/src/reconciler_task.rs
+++ b/sled-agent/config-reconciler/src/reconciler_task.rs
@@ -82,7 +82,7 @@ pub(crate) fn spawn<T: SledAgentFacilities>(
 pub(crate) struct ReconcilerResult {
     mount_config: Arc<MountConfig>,
     status: ReconcilerTaskStatus,
-    latest_result: Option<Arc<LatestReconcilerTaskResultInner>>,
+    latest_result: Option<Arc<LatestReconciliationResult>>,
 }
 
 impl ReconcilerResult {
@@ -145,7 +145,7 @@ pub enum ReconcilerTaskStatus {
 }
 
 #[derive(Debug)]
-struct LatestReconcilerTaskResultInner {
+struct LatestReconciliationResult {
     sled_config: OmicronSledConfig,
     datasets: DatasetEnsureResult,
     timesync_status: TimeSyncStatus,
@@ -415,7 +415,7 @@ impl ReconcilerTask {
             ReconciliationResult::NoRetryNeeded
         };
 
-        let inner = LatestReconcilerTaskResultInner {
+        let inner = LatestReconciliationResult {
             sled_config,
             datasets,
             timesync_status,

--- a/sled-agent/config-reconciler/src/reconciler_task/external_disks.rs
+++ b/sled-agent/config-reconciler/src/reconciler_task/external_disks.rs
@@ -175,11 +175,8 @@ impl CurrentlyManagedZpoolsReceiver {
 
         let zpool_futs =
             current_zpools.0.iter().map(|&zpool_name| async move {
-                let info_result = tokio::task::spawn_blocking(move || {
-                    Zpool::get_info(&zpool_name.to_string())
-                })
-                .await
-                .expect("task did not panic");
+                let info_result =
+                    Zpool::get_info(&zpool_name.to_string()).await;
 
                 (zpool_name, info_result)
             });


### PR DESCRIPTION
Adds a handful of types to `nexus-sled-agent-shared` that will be added to sled-agent's inventory report in a future PR, and fleshes out the `to_inventory()` functions in `sled-agent-config-reconciler` to return these types.