### PR TITLE
[nexus] rename webhook alert headers

### DIFF
--- a/nexus/src/app/webhook.rs
+++ b/nexus/src/app/webhook.rs
@@ -381,11 +381,11 @@ impl<'a> ReceiverClient<'a> {
         const HDR_DELIVERY_ID: HeaderName =
             HeaderName::from_static("x-oxide-delivery-id");
         const HDR_RX_ID: HeaderName =
-            HeaderName::from_static("x-oxide-webhook-id");
-        const HDR_EVENT_ID: HeaderName =
-            HeaderName::from_static("x-oxide-event-id");
-        const HDR_EVENT_CLASS: HeaderName =
-            HeaderName::from_static("x-oxide-event-class");
+            HeaderName::from_static("x-oxide-receiver-id");
+        const HDR_ALERT_ID: HeaderName =
+            HeaderName::from_static("x-oxide-alert-id");
+        const HDR_ALERT_CLASS: HeaderName =
+            HeaderName::from_static("x-oxide-alert-class");
         const HDR_SIG: HeaderName =
             HeaderName::from_static("x-oxide-signature");
 
@@ -427,7 +427,7 @@ impl<'a> ReceiverClient<'a> {
             Ok(body) => body,
             Err(e) => {
                 const MSG: &'static str =
-                    "event payload could not be serialized";
+                    "alert payload could not be serialized";
                 slog::error!(
                     &opctx.log,
                     "webhook {MSG}";
@@ -438,10 +438,10 @@ impl<'a> ReceiverClient<'a> {
                     "error" => %e,
                 );
 
-                // This really shouldn't happen --- we expect the event
+                // This really shouldn't happen --- we expect the alert
                 // payload will always be valid JSON. We could *probably*
                 // just panic here unconditionally, but it seems nicer to
-                // try and do the other events. But, if there's ever a bug
+                // try and do the other alerts. But, if there's ever a bug
                 // that breaks serialization for *all* webhook payloads,
                 // I'd like the tests to fail in a more obvious way than
                 // eventually timing out waiting for the event to be
@@ -457,8 +457,8 @@ impl<'a> ReceiverClient<'a> {
             .post(&self.rx.endpoint)
             .header(HDR_RX_ID, self.hdr_rx_id.clone())
             .header(HDR_DELIVERY_ID, delivery.id.to_string())
-            .header(HDR_EVENT_ID, delivery.alert_id.to_string())
-            .header(HDR_EVENT_CLASS, alert_class.to_string())
+            .header(HDR_ALERT_ID, delivery.alert_id.to_string())
+            .header(HDR_ALERT_CLASS, alert_class.to_string())
             .header(http::header::CONTENT_TYPE, "application/json");
 
         // For each secret assigned to this webhook, calculate the HMAC and add a signature header.

--- a/nexus/src/app/webhook.rs
+++ b/nexus/src/app/webhook.rs
@@ -400,7 +400,7 @@ impl<'a> ReceiverClient<'a> {
         #[derive(serde::Serialize, Debug)]
         struct DeliveryMetadata<'a> {
             id: WebhookDeliveryUuid,
-            webhook_id: AlertReceiverUuid,
+            receiver_id: AlertReceiverUuid,
             sent_at: &'a str,
             trigger: views::AlertDeliveryTrigger,
         }
@@ -414,7 +414,7 @@ impl<'a> ReceiverClient<'a> {
             data,
             delivery: DeliveryMetadata {
                 id: delivery.id.into(),
-                webhook_id: self.rx.id(),
+                receiver_id: self.rx.id(),
                 sent_at: &sent_at,
                 trigger: delivery.triggered_by.into(),
             },

--- a/nexus/tests/integration_tests/webhooks.rs
+++ b/nexus/tests/integration_tests/webhooks.rs
@@ -264,7 +264,7 @@ fn is_valid_for_webhook(
     let id = webhook.identity.id.to_string();
     move |when| {
         when.path(path)
-            .header("x-oxide-webhook-id", id)
+            .header("x-oxide-receiver-id", id)
             .header_exists("x-oxide-delivery-id")
             .header_exists("x-oxide-signature")
             .header("content-type", "application/json")
@@ -514,8 +514,8 @@ async fn test_event_delivery(cptestctx: &ControlPlaneTestContext) {
                 })
                 .to_string();
                 when.method(POST)
-                    .header("x-oxide-event-class", "test.foo")
-                    .header("x-oxide-event-id", id.to_string())
+                    .header("x-oxide-alert-class", "test.foo")
+                    .header("x-oxide-alert-id", id.to_string())
                     .and(is_valid_for_webhook(&webhook))
                     .is_true(signature_verifies(
                         webhook.config.secrets[0].id,
@@ -627,8 +627,8 @@ async fn test_multiple_secrets(cptestctx: &ControlPlaneTestContext) {
     let mock = server
         .mock_async(|when, then| {
             when.method(POST)
-                .header("x-oxide-event-class", "test.foo")
-                .header("x-oxide-event-id", id.to_string())
+                .header("x-oxide-receiver-id", "test.foo")
+                .header("x-oxide-alert-id", id.to_string())
                 .and(is_valid_for_webhook(&webhook))
                 // There should be a signature header present for all three
                 // secrets, and they should all verify the contents of the
@@ -716,8 +716,8 @@ async fn test_multiple_receivers(cptestctx: &ControlPlaneTestContext) {
         srv_bar
             .mock_async(move |when, then| {
                 when.method(POST)
-                    .header("x-oxide-event-class", "test.foo.bar")
-                    .header("x-oxide-event-id", bar_alert_id.to_string())
+                    .header("x-oxide-alert-class", "test.foo.bar")
+                    .header("x-oxide-alert-id", bar_alert_id.to_string())
                     .and(is_valid_for_webhook(&webhook))
                     .is_true(signature_verifies(
                         webhook.config.secrets[0].id,
@@ -757,8 +757,8 @@ async fn test_multiple_receivers(cptestctx: &ControlPlaneTestContext) {
         srv_baz
             .mock_async(move |when, then| {
                 when.method(POST)
-                    .header("x-oxide-event-class", "test.foo.baz")
-                    .header("x-oxide-event-id", baz_alert_id.to_string())
+                    .header("x-oxide-alert-class", "test.foo.baz")
+                    .header("x-oxide-alert-id", baz_alert_id.to_string())
                     .and(is_valid_for_webhook(&webhook))
                     .is_true(signature_verifies(
                         webhook.config.secrets[0].id,
@@ -800,10 +800,10 @@ async fn test_multiple_receivers(cptestctx: &ControlPlaneTestContext) {
             .mock_async(move |when, then| {
                 when.method(POST)
                     .header_matches(
-                        "x-oxide-event-class",
+                        "x-oxide-alert-class",
                         "test\\.foo\\.ba[rz]",
                     )
-                    .header_exists("x-oxide-event-id")
+                    .header_exists("x-oxide-alert-id")
                     .and(is_valid_for_webhook(&webhook))
                     .is_true(signature_verifies(
                         webhook.config.secrets[0].id,
@@ -883,8 +883,8 @@ async fn test_retry_backoff(cptestctx: &ControlPlaneTestContext) {
                 })
                 .to_string();
                 when.method(POST)
-                    .header("x-oxide-event-class", "test.foo")
-                    .header("x-oxide-event-id", id.to_string())
+                    .header("x-oxide-alert-class", "test.foo")
+                    .header("x-oxide-alert-id", id.to_string())
                     .and(is_valid_for_webhook(&webhook))
                     .is_true(signature_verifies(
                         webhook.config.secrets[0].id,
@@ -962,8 +962,8 @@ async fn test_retry_backoff(cptestctx: &ControlPlaneTestContext) {
                 })
                 .to_string();
                 when.method(POST)
-                    .header("x-oxide-event-class", "test.foo")
-                    .header("x-oxide-event-id", id.to_string())
+                    .header("x-oxide-alert-class", "test.foo")
+                    .header("x-oxide-alert-id", id.to_string())
                     .and(is_valid_for_webhook(&webhook))
                     .is_true(signature_verifies(
                         webhook.config.secrets[0].id,
@@ -1032,8 +1032,8 @@ async fn test_retry_backoff(cptestctx: &ControlPlaneTestContext) {
                 })
                 .to_string();
                 when.method(POST)
-                    .header("x-oxide-event-class", "test.foo")
-                    .header("x-oxide-event-id", id.to_string())
+                    .header("x-oxide-alert-class", "test.foo")
+                    .header("x-oxide-alert-id", id.to_string())
                     .and(is_valid_for_webhook(&webhook))
                     .is_true(signature_verifies(
                         webhook.config.secrets[0].id,
@@ -1116,7 +1116,7 @@ async fn test_probe(cptestctx: &ControlPlaneTestContext) {
         server
             .mock_async(move |when, then| {
                 when.method(POST)
-                    .header("x-oxide-event-class", "probe")
+                    .header("x-oxide-alert-class", "probe")
                     .and(is_valid_for_webhook(&webhook))
                     .is_true(signature_verifies(
                         webhook.config.secrets[0].id,
@@ -1170,7 +1170,7 @@ async fn test_probe(cptestctx: &ControlPlaneTestContext) {
         server
             .mock_async(move |when, then| {
                 when.method(POST)
-                    .header("x-oxide-event-class", "probe")
+                    .header("x-oxide-alert-class", "probe")
                     .and(is_valid_for_webhook(&webhook))
                     .is_true(signature_verifies(
                         webhook.config.secrets[0].id,
@@ -1219,7 +1219,7 @@ async fn test_probe(cptestctx: &ControlPlaneTestContext) {
         server
             .mock_async(move |when, then| {
                 when.method(POST)
-                    .header("x-oxide-event-class", "probe")
+                    .header("x-oxide-alert-class", "probe")
                     .and(is_valid_for_webhook(&webhook))
                     .is_true(signature_verifies(
                         webhook.config.secrets[0].id,
@@ -1289,10 +1289,10 @@ async fn test_probe_resends_failed_deliveries(
         server
             .mock_async(move |when, then| {
                 when.method(POST)
-                    .header("x-oxide-event-class", "test.foo")
+                    .header("x-oxide-alert-class", "test.foo")
                     // either event
                     .header_matches(
-                        "x-oxide-event-id",
+                        "x-oxide-alert-id",
                         format!("({event1_id})|({event2_id})"),
                     )
                     .and(is_valid_for_webhook(&webhook))
@@ -1363,7 +1363,7 @@ async fn test_probe_resends_failed_deliveries(
                 })
                 .to_string();
                 when.method(POST)
-                    .header("x-oxide-event-class", "probe")
+                    .header("x-oxide-alert-class", "probe")
                     .and(is_valid_for_webhook(&webhook))
                     .is_true(signature_verifies(
                         webhook.config.secrets[0].id,
@@ -1381,10 +1381,10 @@ async fn test_probe_resends_failed_deliveries(
         server
             .mock_async(move |when, then| {
                 when.method(POST)
-                    .header("x-oxide-event-class", "test.foo")
+                    .header("x-oxide-alert-class", "test.foo")
                     // either event
                     .header_matches(
-                        "x-oxide-event-id",
+                        "x-oxide-alert-id",
                         format!("({event1_id})|({event2_id})"),
                     )
                     .and(is_valid_for_webhook(&webhook))
@@ -1453,8 +1453,8 @@ async fn test_api_resends_failed_deliveries(
         server
             .mock_async(move |when, then| {
                 when.method(POST)
-                    .header("x-oxide-event-class", "test.foo")
-                    .header("x-oxide-event-id", event1_id.to_string())
+                    .header("x-oxide-alert-class", "test.foo")
+                    .header("x-oxide-alert-id", event1_id.to_string())
                     .and(is_valid_for_webhook(&webhook))
                     .is_true(signature_verifies(
                         webhook.config.secrets[0].id,
@@ -1513,8 +1513,8 @@ async fn test_api_resends_failed_deliveries(
         server
             .mock_async(move |when, then| {
                 when.method(POST)
-                    .header("x-oxide-event-class", "test.foo")
-                    .header("x-oxide-event-id", event1_id.to_string())
+                    .header("x-oxide-alert-class", "test.foo")
+                    .header("x-oxide-alert-id", event1_id.to_string())
                     .and(is_valid_for_webhook(&webhook))
                     .is_true(signature_verifies(
                         webhook.config.secrets[0].id,
@@ -1592,8 +1592,8 @@ async fn subscription_add_test(
                 })
                 .to_string();
                 when.method(POST)
-                    .header("x-oxide-event-class", "test.foo.bar")
-                    .header("x-oxide-event-id", id2.to_string())
+                    .header("x-oxide-alert-class", "test.foo.bar")
+                    .header("x-oxide-alert-id", id2.to_string())
                     .and(is_valid_for_webhook(&webhook))
                     .is_true(signature_verifies(
                         webhook.config.secrets[0].id,
@@ -1724,8 +1724,8 @@ async fn subscription_remove_test(
                 })
                 .to_string();
                 when.method(POST)
-                    .header("x-oxide-event-class", "test.foo.bar")
-                    .header("x-oxide-event-id", id1.to_string())
+                    .header("x-oxide-alert-class", "test.foo.bar")
+                    .header("x-oxide-alert-id", id1.to_string())
                     .and(is_valid_for_webhook(&webhook))
                     .is_true(signature_verifies(
                         webhook.config.secrets[0].id,
@@ -1805,8 +1805,8 @@ async fn subscription_remove_test(
                 })
                 .to_string();
                 when.method(POST)
-                    .header("x-oxide-event-class", "test.foo")
-                    .header("x-oxide-event-id", id3.to_string())
+                    .header("x-oxide-alert-class", "test.foo")
+                    .header("x-oxide-alert-id", id3.to_string())
                     .and(is_valid_for_webhook(&webhook))
                     .is_true(signature_verifies(
                         webhook.config.secrets[0].id,

--- a/nexus/tests/integration_tests/webhooks.rs
+++ b/nexus/tests/integration_tests/webhooks.rs
@@ -627,7 +627,7 @@ async fn test_multiple_secrets(cptestctx: &ControlPlaneTestContext) {
     let mock = server
         .mock_async(|when, then| {
             when.method(POST)
-                .header("x-oxide-receiver-id", "test.foo")
+                .header("x-oxide-alert-class", "test.foo")
                 .header("x-oxide-alert-id", id.to_string())
                 .and(is_valid_for_webhook(&webhook))
                 // There should be a signature header present for all three


### PR DESCRIPTION
Somehow, while working on renaming "webhook events" to "alerts" in PR #8169, I managed to overlook the names of the headers `x-oxide-event-id` and `x-oxide-event-class` that we set on webhook delivery
requests. These should probably also be renamed to `alert`, so I did that. I also renamed `x-oxide-webhook-id` to `x-oxide-alert-id`, as that seemed clearer.