### PR TITLE
[nexus] Make `views::AlertReceiverKind` a tagged enum

### DIFF
--- a/nexus/types/src/external_api/views.rs
+++ b/nexus/types/src/external_api/views.rs
@@ -1090,7 +1090,7 @@ pub struct AlertSubscriptionCreated {
 
 /// The possible alert delivery mechanisms for an alert receiver.
 #[derive(Clone, Debug, Deserialize, Serialize, JsonSchema, PartialEq)]
-#[serde(rename_all = "snake_case")]
+#[serde(rename_all = "snake_case", tag = "kind")]
 pub enum AlertReceiverKind {
     Webhook(WebhookReceiverConfig),
 }

--- a/openapi/nexus.json
+++ b/openapi/nexus.json
@@ -13519,16 +13519,32 @@
         "description": "The possible alert delivery mechanisms for an alert receiver.",
         "oneOf": [
           {
+            "description": "Webhook-specific alert receiver configuration.",
             "type": "object",
             "properties": {
-              "webhook": {
-                "$ref": "#/components/schemas/WebhookReceiverConfig"
+              "endpoint": {
+                "description": "The URL that webhook notification requests are sent to.",
+                "type": "string",
+                "format": "uri"
+              },
+              "kind": {
+                "type": "string",
+                "enum": [
+                  "webhook"
+                ]
+              },
+              "secrets": {
+                "type": "array",
+                "items": {
+                  "$ref": "#/components/schemas/WebhookSecret"
+                }
               }
             },
             "required": [
-              "webhook"
-            ],
-            "additionalProperties": false
+              "endpoint",
+              "kind",
+              "secrets"
+            ]
           }
         ]
       },
@@ -26135,27 +26151,6 @@
           "subscriptions",
           "time_created",
           "time_modified"
-        ]
-      },
-      "WebhookReceiverConfig": {
-        "description": "Webhook-specific alert receiver configuration.",
-        "type": "object",
-        "properties": {
-          "endpoint": {
-            "description": "The URL that webhook notification requests are sent to.",
-            "type": "string",
-            "format": "uri"
-          },
-          "secrets": {
-            "type": "array",
-            "items": {
-              "$ref": "#/components/schemas/WebhookSecret"
-            }
-          }
-        },
-        "required": [
-          "endpoint",
-          "secrets"
         ]
       },
       "WebhookReceiverUpdate": {


### PR DESCRIPTION
Without this change, the OpenAPI schema resulted in this client code:

```ts
export type AlertReceiverKind = { webhook: WebhookReceiverConfig };
```

Now it produces this:

```ts
export type AlertReceiverKind = {
  /** The URL that webhook notification requests are sent to. */
  endpoint: string;
  kind: "webhook";
  secrets: WebhookSecret[];
};
```

When there are more kinds, it will be a discriminated union with `kind` as the discriminator. I didn't expect it to inline `WebhookReceiverConfig` but it makes sense.