### PR TITLE
[sled-agent] Remove `OmicronZonesConfigLocal`

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -11658,6 +11658,7 @@ dependencies = [
  "omicron-uuid-kinds",
  "omicron-workspace-hack",
  "proptest",
+ "schemars",
  "scopeguard",
  "serde",
  "serde_json",

--- a/dev-tools/omdb/src/bin/omdb/db.rs
+++ b/dev-tools/omdb/src/bin/omdb/db.rs
@@ -7350,30 +7350,28 @@ fn inv_collection_print_sleds(collection: &Collection) {
                     "LAST RECONCILED CONFIG",
                     &last_reconciliation.last_reconciled_config,
                 );
-                let disk_errs = collect_config_reconciler_errors(
-                    &last_reconciliation.external_disks,
-                );
-                let dataset_errs = collect_config_reconciler_errors(
-                    &last_reconciliation.datasets,
-                );
-                let zone_errs = collect_config_reconciler_errors(
-                    &last_reconciliation.zones,
-                );
-                for (label, errs) in [
-                    ("disk", disk_errs),
-                    ("dataset", dataset_errs),
-                    ("zone", zone_errs),
-                ] {
-                    if errs.is_empty() {
-                        println!("    all {label}s reconciled successfully");
-                    } else {
-                        println!(
-                            "    {} {label} reconciliation errors:",
-                            errs.len()
-                        );
-                        for err in errs {
-                            println!("      {err}");
-                        }
+            }
+            let disk_errs = collect_config_reconciler_errors(
+                &last_reconciliation.external_disks,
+            );
+            let dataset_errs =
+                collect_config_reconciler_errors(&last_reconciliation.datasets);
+            let zone_errs =
+                collect_config_reconciler_errors(&last_reconciliation.zones);
+            for (label, errs) in [
+                ("disk", disk_errs),
+                ("dataset", dataset_errs),
+                ("zone", zone_errs),
+            ] {
+                if errs.is_empty() {
+                    println!("        all {label}s reconciled successfully");
+                } else {
+                    println!(
+                        "        {} {label} reconciliation errors:",
+                        errs.len()
+                    );
+                    for err in errs {
+                        println!("          {err}");
                     }
                 }
             }

--- a/schema/all-zones-requests.json
+++ b/schema/all-zones-requests.json
@@ -1,7 +1,7 @@
 {
   "$schema": "http://json-schema.org/draft-07/schema#",
   "title": "OmicronZonesConfigLocal",
-  "description": "Combines the Nexus-provided `OmicronZonesConfig` (which describes what Nexus wants for all of its zones) with the locally-determined configuration for these zones.",
+  "description": "Legacy type of the ledgered zone config.",
   "type": "object",
   "required": [
     "ledger_generation",
@@ -10,20 +10,10 @@
   ],
   "properties": {
     "ledger_generation": {
-      "description": "ledger-managed generation number\n\nThis generation is managed by the ledger facility itself.  It's bumped whenever we write a new ledger.  In practice, we don't currently have any reason to bump this _for a given Omicron generation_ so it's somewhat redundant.  In principle, if we needed to modify the ledgered configuration due to some event that doesn't change the Omicron config (e.g., if we wanted to move the root filesystem to a different path), we could do that by bumping this generation.",
-      "allOf": [
-        {
-          "$ref": "#/definitions/Generation"
-        }
-      ]
+      "$ref": "#/definitions/Generation"
     },
     "omicron_generation": {
-      "description": "generation of the Omicron-provided part of the configuration\n\nThis generation number is outside of Sled Agent's control.  We store exactly what we were given and use this number to decide when to fail requests to establish an outdated configuration.\n\nYou can think of this as a major version number, with `ledger_generation` being a minor version number.  See `is_newer_than()`.",
-      "allOf": [
-        {
-          "$ref": "#/definitions/Generation"
-        }
-      ]
+      "$ref": "#/definitions/Generation"
     },
     "zones": {
       "type": "array",
@@ -269,7 +259,6 @@
       }
     },
     "OmicronZoneConfigLocal": {
-      "description": "Combines the Nexus-provided `OmicronZoneConfig` (which describes what Nexus wants for this zone) with any locally-determined configuration (like the path to the root filesystem)",
       "type": "object",
       "required": [
         "root",

--- a/sled-agent/config-reconciler/Cargo.toml
+++ b/sled-agent/config-reconciler/Cargo.toml
@@ -45,6 +45,7 @@ expectorate.workspace = true
 illumos-utils = { workspace = true, features = ["testing"] }
 omicron-test-utils.workspace = true
 proptest.workspace = true
+schemars.workspace = true
 scopeguard.workspace = true
 serde_json.workspace = true
 sled-storage = { workspace = true, features = ["testing"] }

--- a/sled-agent/config-reconciler/src/ledger/legacy_configs.rs
+++ b/sled-agent/config-reconciler/src/ledger/legacy_configs.rs
@@ -218,6 +218,7 @@ fn merge_old_configs(
 
 /// Legacy type of the ledgered zone config.
 #[derive(Debug, Clone, Deserialize, Serialize)]
+#[cfg_attr(test, derive(schemars::JsonSchema))]
 struct OmicronZonesConfigLocal {
     omicron_generation: Generation,
     ledger_generation: Generation,
@@ -237,9 +238,11 @@ impl Ledgerable for OmicronZonesConfigLocal {
 }
 
 #[derive(Debug, Clone, Deserialize, Serialize)]
+#[cfg_attr(test, derive(schemars::JsonSchema))]
 struct OmicronZoneConfigLocal {
     zone: OmicronZoneConfig,
     #[serde(rename = "root")]
+    #[cfg_attr(test, schemars(with = "String"))]
     _root: Utf8PathBuf,
 }
 
@@ -263,6 +266,15 @@ pub(super) mod tests {
     // test_merge_old_configs below.
     const MERGED_CONFIG_PATH: &str =
         "test-data/expectorate/merged-sled-config.json";
+
+    #[test]
+    fn test_old_config_schema() {
+        let schema = schemars::schema_for!(OmicronZonesConfigLocal);
+        expectorate::assert_contents(
+            "../../schema/all-zones-requests.json",
+            &serde_json::to_string_pretty(&schema).unwrap(),
+        );
+    }
 
     #[test]
     fn test_merge_old_configs() {

--- a/sled-agent/src/services.rs
+++ b/sled-agent/src/services.rs
@@ -3050,7 +3050,7 @@ impl ServiceManager {
         Ok(running_zone)
     }
 
-    // Attempt to start a single Omicron zone is running.
+    // Attempt to start a single Omicron zone.
     //
     // This method is NOT idempotent.
     //


### PR DESCRIPTION
With all the zone start and ledgering moved to `sled-agent-config-reconciler`, we can remove this type entirely from `sled-agent`. I kept the schema check but moved it to the `legacy_configs.rs` module in the config reconciler, where the same structs still exist to allow conversion of the old ledgers -> the new combined ledger.

Builds on top of #8219.