### PR TITLE
[3/n] `/v1/me/access-tokens` list and delete 

### DIFF
--- a/nexus/db-model/src/device_auth.rs
+++ b/nexus/db-model/src/device_auth.rs
@@ -11,7 +11,7 @@ use nexus_db_schema::schema::{device_access_token, device_auth_request};
 
 use chrono::{DateTime, Duration, Utc};
 use nexus_types::external_api::views;
-use omicron_uuid_kinds::{AccessTokenKind, TypedUuid};
+use omicron_uuid_kinds::{AccessTokenKind, GenericUuid, TypedUuid};
 use rand::{Rng, RngCore, SeedableRng, distributions::Slice, rngs::StdRng};
 use uuid::Uuid;
 
@@ -169,6 +169,16 @@ impl From<DeviceAccessToken> for views::DeviceAccessTokenGrant {
         Self {
             access_token: format!("oxide-token-{}", access_token.token),
             token_type: views::DeviceAccessTokenType::Bearer,
+        }
+    }
+}
+
+impl From<DeviceAccessToken> for views::DeviceAccessToken {
+    fn from(access_token: DeviceAccessToken) -> Self {
+        Self {
+            id: access_token.id.into_untyped_uuid(),
+            time_created: access_token.time_created,
+            time_expires: access_token.time_expires,
         }
     }
 }

--- a/nexus/db-queries/src/db/datastore/device_auth.rs
+++ b/nexus/db-queries/src/db/datastore/device_auth.rs
@@ -201,9 +201,6 @@ impl DataStore {
                     .is_null()
                     .or(dsl::time_expires.gt(Utc::now())),
             )
-            // TODO: what if we used a different model struct here so we're not
-            // pulling less out of the DB and it's harder to accidentally return
-            // the token itself
             .select(DeviceAccessToken::as_select())
             .load_async(&*self.pool_connection_authorized(opctx).await?)
             .await

--- a/nexus/external-api/output/nexus_tags.txt
+++ b/nexus/external-api/output/nexus_tags.txt
@@ -289,8 +289,8 @@ ping                                     GET      /v1/ping
 
 API operations found with tag "tokens"
 OPERATION ID                             METHOD   URL PATH
-current_user_device_token_delete         DELETE   /v1/me/device-tokens/{token_id}
-current_user_device_token_list           GET      /v1/me/device-tokens
+current_user_access_token_delete         DELETE   /v1/me/access-tokens/{token_id}
+current_user_access_token_list           GET      /v1/me/access-tokens
 
 API operations found with tag "vpcs"
 OPERATION ID                             METHOD   URL PATH

--- a/nexus/external-api/output/nexus_tags.txt
+++ b/nexus/external-api/output/nexus_tags.txt
@@ -289,8 +289,8 @@ ping                                     GET      /v1/ping
 
 API operations found with tag "tokens"
 OPERATION ID                             METHOD   URL PATH
-current_user_token_delete                DELETE   /v1/me/tokens/{token_id}
-current_user_token_list                  GET      /v1/me/tokens
+current_user_device_token_delete         DELETE   /v1/me/device-tokens/{token_id}
+current_user_device_token_list           GET      /v1/me/device-tokens
 
 API operations found with tag "vpcs"
 OPERATION ID                             METHOD   URL PATH

--- a/nexus/external-api/output/nexus_tags.txt
+++ b/nexus/external-api/output/nexus_tags.txt
@@ -287,6 +287,10 @@ API operations found with tag "system/status"
 OPERATION ID                             METHOD   URL PATH
 ping                                     GET      /v1/ping
 
+API operations found with tag "tokens"
+OPERATION ID                             METHOD   URL PATH
+current_user_token_list                  GET      /v1/me/tokens
+
 API operations found with tag "vpcs"
 OPERATION ID                             METHOD   URL PATH
 internet_gateway_create                  POST     /v1/internet-gateways

--- a/nexus/external-api/output/nexus_tags.txt
+++ b/nexus/external-api/output/nexus_tags.txt
@@ -289,6 +289,7 @@ ping                                     GET      /v1/ping
 
 API operations found with tag "tokens"
 OPERATION ID                             METHOD   URL PATH
+current_user_token_delete                DELETE   /v1/me/tokens/{token_id}
 current_user_token_list                  GET      /v1/me/tokens
 
 API operations found with tag "vpcs"

--- a/nexus/external-api/src/lib.rs
+++ b/nexus/external-api/src/lib.rs
@@ -3155,28 +3155,28 @@ pub trait NexusExternalApi {
         path_params: Path<params::SshKeyPath>,
     ) -> Result<HttpResponseDeleted, HttpError>;
 
-    /// List device access tokens
+    /// List device tokens
     ///
     /// List device access tokens for the currently authenticated user.
     #[endpoint {
         method = GET,
-        path = "/v1/me/tokens",
+        path = "/v1/me/device-tokens",
         tags = ["tokens"],
     }]
-    async fn current_user_token_list(
+    async fn current_user_device_token_list(
         rqctx: RequestContext<Self::Context>,
         query_params: Query<PaginatedById>,
     ) -> Result<HttpResponseOk<ResultsPage<views::DeviceAccessToken>>, HttpError>;
 
-    /// Delete device access token
+    /// Delete device token
     ///
     /// Delete a device access token for the currently authenticated user.
     #[endpoint {
         method = DELETE,
-        path = "/v1/me/tokens/{token_id}",
+        path = "/v1/me/device-tokens/{token_id}",
         tags = ["tokens"],
     }]
-    async fn current_user_token_delete(
+    async fn current_user_device_token_delete(
         rqctx: RequestContext<Self::Context>,
         path_params: Path<params::TokenPath>,
     ) -> Result<HttpResponseDeleted, HttpError>;

--- a/nexus/external-api/src/lib.rs
+++ b/nexus/external-api/src/lib.rs
@@ -3155,28 +3155,28 @@ pub trait NexusExternalApi {
         path_params: Path<params::SshKeyPath>,
     ) -> Result<HttpResponseDeleted, HttpError>;
 
-    /// List device tokens
+    /// List access tokens
     ///
     /// List device access tokens for the currently authenticated user.
     #[endpoint {
         method = GET,
-        path = "/v1/me/device-tokens",
+        path = "/v1/me/access-tokens",
         tags = ["tokens"],
     }]
-    async fn current_user_device_token_list(
+    async fn current_user_access_token_list(
         rqctx: RequestContext<Self::Context>,
         query_params: Query<PaginatedById>,
     ) -> Result<HttpResponseOk<ResultsPage<views::DeviceAccessToken>>, HttpError>;
 
-    /// Delete device token
+    /// Delete access token
     ///
     /// Delete a device access token for the currently authenticated user.
     #[endpoint {
         method = DELETE,
-        path = "/v1/me/device-tokens/{token_id}",
+        path = "/v1/me/access-tokens/{token_id}",
         tags = ["tokens"],
     }]
-    async fn current_user_device_token_delete(
+    async fn current_user_access_token_delete(
         rqctx: RequestContext<Self::Context>,
         path_params: Path<params::TokenPath>,
     ) -> Result<HttpResponseDeleted, HttpError>;

--- a/nexus/external-api/src/lib.rs
+++ b/nexus/external-api/src/lib.rs
@@ -3168,6 +3168,19 @@ pub trait NexusExternalApi {
         query_params: Query<PaginatedById>,
     ) -> Result<HttpResponseOk<ResultsPage<views::DeviceAccessToken>>, HttpError>;
 
+    /// Delete device access token
+    ///
+    /// Delete a device access token for the currently authenticated user.
+    #[endpoint {
+        method = DELETE,
+        path = "/v1/me/tokens/{token_id}",
+        tags = ["tokens"],
+    }]
+    async fn current_user_token_delete(
+        rqctx: RequestContext<Self::Context>,
+        path_params: Path<params::TokenPath>,
+    ) -> Result<HttpResponseDeleted, HttpError>;
+
     // Support bundles (experimental)
 
     /// List all support bundles

--- a/nexus/external-api/src/lib.rs
+++ b/nexus/external-api/src/lib.rs
@@ -162,6 +162,12 @@ const PUT_UPDATE_REPOSITORY_MAX_BYTES: usize = 4 * GIB;
                     url = "http://docs.oxide.computer/api/snapshots"
                 }
             },
+            "tokens" = {
+                description = "API clients use device access tokens for authentication.",
+                external_docs = {
+                    url = "http://docs.oxide.computer/api/tokens"
+                }
+            },
             "vpcs" = {
                 description = "Virtual Private Clouds (VPCs) provide isolated network environments for managing and deploying services.",
                 external_docs = {
@@ -3148,6 +3154,19 @@ pub trait NexusExternalApi {
         rqctx: RequestContext<Self::Context>,
         path_params: Path<params::SshKeyPath>,
     ) -> Result<HttpResponseDeleted, HttpError>;
+
+    /// List device access tokens
+    ///
+    /// List device access tokens for the currently authenticated user.
+    #[endpoint {
+        method = GET,
+        path = "/v1/me/tokens",
+        tags = ["tokens"],
+    }]
+    async fn current_user_token_list(
+        rqctx: RequestContext<Self::Context>,
+        query_params: Query<PaginatedById>,
+    ) -> Result<HttpResponseOk<ResultsPage<views::DeviceAccessToken>>, HttpError>;
 
     // Support bundles (experimental)
 

--- a/nexus/src/app/device_auth.rs
+++ b/nexus/src/app/device_auth.rs
@@ -56,7 +56,7 @@ use anyhow::anyhow;
 use nexus_types::external_api::params::DeviceAccessTokenRequest;
 use nexus_types::external_api::views;
 use omicron_common::api::external::{
-    CreateResult, DataPageParams, Error, InternalContext, ListResultVec,
+    CreateResult, DataPageParams, Error, ListResultVec,
 };
 
 use chrono::{Duration, Utc};
@@ -299,17 +299,7 @@ impl super::Nexus {
         opctx: &OpContext,
         pagparams: &DataPageParams<'_, Uuid>,
     ) -> ListResultVec<DeviceAccessToken> {
-        let &actor = opctx
-            .authn
-            .actor_required()
-            .internal_context("loading current user to list tokens")?;
-        let (.., authz_user) = LookupPath::new(opctx, self.datastore())
-            .silo_user_id(actor.actor_id())
-            .lookup_for(authz::Action::ListChildren)
-            .await?;
-        self.db_datastore
-            .device_access_tokens_list(opctx, &authz_user, pagparams)
-            .await
+        self.db_datastore.current_user_token_list(opctx, pagparams).await
     }
 
     pub(crate) async fn current_user_token_delete(
@@ -317,16 +307,6 @@ impl super::Nexus {
         opctx: &OpContext,
         token_id: Uuid,
     ) -> Result<(), Error> {
-        let &actor = opctx
-            .authn
-            .actor_required()
-            .internal_context("loading current user to delete token")?;
-        let (.., authz_user) = LookupPath::new(opctx, self.datastore())
-            .silo_user_id(actor.actor_id())
-            .lookup_for(authz::Action::Modify)
-            .await?;
-        self.db_datastore
-            .device_access_token_delete(opctx, &authz_user, token_id)
-            .await
+        self.db_datastore.current_user_token_delete(opctx, token_id).await
     }
 }

--- a/nexus/src/app/device_auth.rs
+++ b/nexus/src/app/device_auth.rs
@@ -311,4 +311,22 @@ impl super::Nexus {
             .device_access_tokens_list(opctx, &authz_user, pagparams)
             .await
     }
+
+    pub(crate) async fn current_user_token_delete(
+        &self,
+        opctx: &OpContext,
+        token_id: Uuid,
+    ) -> Result<(), Error> {
+        let &actor = opctx
+            .authn
+            .actor_required()
+            .internal_context("loading current user to delete token")?;
+        let (.., authz_user) = LookupPath::new(opctx, self.datastore())
+            .silo_user_id(actor.actor_id())
+            .lookup_for(authz::Action::Modify)
+            .await?;
+        self.db_datastore
+            .device_access_token_delete(opctx, &authz_user, token_id)
+            .await
+    }
 }

--- a/nexus/src/external_api/http_entrypoints.rs
+++ b/nexus/src/external_api/http_entrypoints.rs
@@ -7099,6 +7099,26 @@ impl NexusExternalApi for NexusExternalApiImpl {
             .await
     }
 
+    async fn current_user_token_delete(
+        rqctx: RequestContext<Self::Context>,
+        path_params: Path<params::TokenPath>,
+    ) -> Result<HttpResponseDeleted, HttpError> {
+        let apictx = rqctx.context();
+        let handler = async {
+            let opctx =
+                crate::context::op_context_for_external_api(&rqctx).await?;
+            let nexus = &apictx.context.nexus;
+            let path = path_params.into_inner();
+            nexus.current_user_token_delete(&opctx, path.token_id).await?;
+            Ok(HttpResponseDeleted())
+        };
+        apictx
+            .context
+            .external_latencies
+            .instrument_dropshot_handler(&rqctx, handler)
+            .await
+    }
+
     async fn support_bundle_list(
         rqctx: RequestContext<ApiContext>,
         query_params: Query<PaginatedById>,

--- a/nexus/src/external_api/http_entrypoints.rs
+++ b/nexus/src/external_api/http_entrypoints.rs
@@ -7068,6 +7068,37 @@ impl NexusExternalApi for NexusExternalApiImpl {
             .await
     }
 
+    async fn current_user_token_list(
+        rqctx: RequestContext<Self::Context>,
+        query_params: Query<PaginatedById>,
+    ) -> Result<HttpResponseOk<ResultsPage<views::DeviceAccessToken>>, HttpError>
+    {
+        let apictx = rqctx.context();
+        let handler = async {
+            let opctx =
+                crate::context::op_context_for_external_api(&rqctx).await?;
+            let nexus = &apictx.context.nexus;
+            let query = query_params.into_inner();
+            let pag_params = data_page_params_for(&rqctx, &query)?;
+            let tokens = nexus
+                .current_user_token_list(&opctx, &pag_params)
+                .await?
+                .into_iter()
+                .map(views::DeviceAccessToken::from)
+                .collect();
+            Ok(HttpResponseOk(ScanById::results_page(
+                &query,
+                tokens,
+                &marker_for_id,
+            )?))
+        };
+        apictx
+            .context
+            .external_latencies
+            .instrument_dropshot_handler(&rqctx, handler)
+            .await
+    }
+
     async fn support_bundle_list(
         rqctx: RequestContext<ApiContext>,
         query_params: Query<PaginatedById>,

--- a/nexus/src/external_api/http_entrypoints.rs
+++ b/nexus/src/external_api/http_entrypoints.rs
@@ -7068,7 +7068,7 @@ impl NexusExternalApi for NexusExternalApiImpl {
             .await
     }
 
-    async fn current_user_device_token_list(
+    async fn current_user_access_token_list(
         rqctx: RequestContext<Self::Context>,
         query_params: Query<PaginatedById>,
     ) -> Result<HttpResponseOk<ResultsPage<views::DeviceAccessToken>>, HttpError>
@@ -7099,7 +7099,7 @@ impl NexusExternalApi for NexusExternalApiImpl {
             .await
     }
 
-    async fn current_user_device_token_delete(
+    async fn current_user_access_token_delete(
         rqctx: RequestContext<Self::Context>,
         path_params: Path<params::TokenPath>,
     ) -> Result<HttpResponseDeleted, HttpError> {

--- a/nexus/src/external_api/http_entrypoints.rs
+++ b/nexus/src/external_api/http_entrypoints.rs
@@ -7068,7 +7068,7 @@ impl NexusExternalApi for NexusExternalApiImpl {
             .await
     }
 
-    async fn current_user_token_list(
+    async fn current_user_device_token_list(
         rqctx: RequestContext<Self::Context>,
         query_params: Query<PaginatedById>,
     ) -> Result<HttpResponseOk<ResultsPage<views::DeviceAccessToken>>, HttpError>
@@ -7099,7 +7099,7 @@ impl NexusExternalApi for NexusExternalApiImpl {
             .await
     }
 
-    async fn current_user_token_delete(
+    async fn current_user_device_token_delete(
         rqctx: RequestContext<Self::Context>,
         path_params: Path<params::TokenPath>,
     ) -> Result<HttpResponseDeleted, HttpError> {

--- a/nexus/tests/integration_tests/device_auth.rs
+++ b/nexus/tests/integration_tests/device_auth.rs
@@ -209,7 +209,7 @@ async fn test_device_auth_flow(cptestctx: &ControlPlaneTestContext) {
 
     // Test that privileged user cannot delete unpriv's token through this
     // endpoint, though it will probably be able to do it via a different one
-    let token_url = format!("/v1/me/tokens/{}", token_id);
+    let token_url = format!("/v1/me/device-tokens/{}", token_id);
     NexusRequest::new(
         RequestBuilder::new(testctx, Method::DELETE, &token_url)
             .expect_status(Some(StatusCode::NOT_FOUND)),
@@ -442,7 +442,7 @@ async fn test_device_token_expiration(cptestctx: &ControlPlaneTestContext) {
 async fn get_tokens_priv(
     testctx: &ClientTestContext,
 ) -> Vec<views::DeviceAccessToken> {
-    NexusRequest::object_get(testctx, "/v1/me/tokens")
+    NexusRequest::object_get(testctx, "/v1/me/device-tokens")
         .authn_as(AuthnMode::PrivilegedUser)
         .execute_and_parse_unwrap::<ResultsPage<views::DeviceAccessToken>>()
         .await
@@ -452,7 +452,7 @@ async fn get_tokens_priv(
 async fn get_tokens_unpriv(
     testctx: &ClientTestContext,
 ) -> Vec<views::DeviceAccessToken> {
-    NexusRequest::object_get(testctx, "/v1/me/tokens")
+    NexusRequest::object_get(testctx, "/v1/me/device-tokens")
         .authn_as(AuthnMode::UnprivilegedUser)
         .execute_and_parse_unwrap::<ResultsPage<views::DeviceAccessToken>>()
         .await

--- a/nexus/tests/integration_tests/device_auth.rs
+++ b/nexus/tests/integration_tests/device_auth.rs
@@ -208,7 +208,7 @@ async fn test_device_auth_flow(cptestctx: &ControlPlaneTestContext) {
     let token_id = tokens_unpriv_after[0].id;
 
     // Priv user cannot delete unpriv's token through this endpoint by ID
-    let token_url = format!("/v1/me/device-tokens/{}", token_id);
+    let token_url = format!("/v1/me/access-tokens/{}", token_id);
     object_delete_error(testctx, &token_url, StatusCode::NOT_FOUND).await;
 
     // Test deleting the token as the owner
@@ -434,7 +434,7 @@ async fn test_device_token_expiration(cptestctx: &ControlPlaneTestContext) {
 async fn get_tokens_priv(
     testctx: &ClientTestContext,
 ) -> Vec<views::DeviceAccessToken> {
-    NexusRequest::object_get(testctx, "/v1/me/device-tokens")
+    NexusRequest::object_get(testctx, "/v1/me/access-tokens")
         .authn_as(AuthnMode::PrivilegedUser)
         .execute_and_parse_unwrap::<ResultsPage<views::DeviceAccessToken>>()
         .await
@@ -444,7 +444,7 @@ async fn get_tokens_priv(
 async fn get_tokens_unpriv(
     testctx: &ClientTestContext,
 ) -> Vec<views::DeviceAccessToken> {
-    NexusRequest::object_get(testctx, "/v1/me/device-tokens")
+    NexusRequest::object_get(testctx, "/v1/me/access-tokens")
         .authn_as(AuthnMode::UnprivilegedUser)
         .execute_and_parse_unwrap::<ResultsPage<views::DeviceAccessToken>>()
         .await

--- a/nexus/tests/integration_tests/device_auth.rs
+++ b/nexus/tests/integration_tests/device_auth.rs
@@ -4,6 +4,8 @@
 
 use std::num::NonZeroU32;
 
+use chrono::Utc;
+use dropshot::ResultsPage;
 use dropshot::test_util::ClientTestContext;
 use nexus_auth::authn::USER_TEST_UNPRIVILEGED;
 use nexus_db_queries::db::fixed_data::silo::DEFAULT_SILO;
@@ -138,6 +140,10 @@ async fn test_device_auth_flow(cptestctx: &ControlPlaneTestContext) {
             .expect("failed to deserialize OAuth error");
     assert_eq!(&error.error, "authorization_pending");
 
+    // Check tokens before creating the device token
+    assert_eq!(get_tokens_priv(testctx).await.len(), 0);
+    assert_eq!(get_tokens_unpriv(testctx).await.len(), 0);
+
     // Authenticated confirmation should succeed.
     NexusRequest::new(
         RequestBuilder::new(testctx, Method::POST, "/device/confirm")
@@ -162,9 +168,16 @@ async fn test_device_auth_flow(cptestctx: &ControlPlaneTestContext) {
     .expect("failed to get token")
     .parsed_body()
     .expect("failed to deserialize token response");
+
     assert_eq!(token.token_type, DeviceAccessTokenType::Bearer);
     assert_eq!(token.access_token.len(), 52);
     assert!(token.access_token.starts_with("oxide-token-"));
+
+    // Check token list endpoints after creating the device token
+    assert_eq!(get_tokens_priv(testctx).await.len(), 0);
+    let tokens_unpriv_after = get_tokens_unpriv(testctx).await;
+    assert_eq!(tokens_unpriv_after.len(), 1);
+    assert_eq!(tokens_unpriv_after[0].time_expires, None);
 
     // now make a request with the token. it 403s because unpriv user has no
     // roles
@@ -258,9 +271,17 @@ async fn test_device_token_expiration(cptestctx: &ControlPlaneTestContext) {
         object_get(testctx, "/v1/auth-settings").await;
     assert_eq!(settings.device_token_max_ttl_seconds, None);
 
+    // no tokens in the list
+    assert_eq!(get_tokens_priv(testctx).await.len(), 0);
+
     // get a token for the privileged user. default silo max token expiration
     // is null, so tokens don't expire
     let initial_token = get_device_token(testctx).await;
+
+    // now there is a token in the list
+    let tokens = get_tokens_priv(testctx).await;
+    assert_eq!(tokens.len(), 1);
+    assert_eq!(tokens[0].time_expires, None);
 
     // test token works on project list
     project_list(&testctx, &initial_token, StatusCode::OK)
@@ -325,6 +346,21 @@ async fn test_device_token_expiration(cptestctx: &ControlPlaneTestContext) {
     // create token again (this one will have the 3-second expiration)
     let expiring_token = get_device_token(testctx).await;
 
+    // use a block so we don't touch expiring_token
+    {
+        // now there are two tokens in the list
+        let tokens = get_tokens_priv(testctx).await;
+        assert_eq!(tokens.len(), 2);
+
+        let permanent_token =
+            tokens.iter().find(|t| t.time_expires.is_none()).unwrap();
+        let expiring_token =
+            tokens.iter().find(|t| t.time_expires.is_some()).unwrap();
+
+        assert_eq!(permanent_token.time_expires, None);
+        assert!(expiring_token.time_expires.unwrap() > Utc::now());
+    }
+
     // immediately use token, it should work
     project_list(&testctx, &expiring_token, StatusCode::OK)
         .await
@@ -343,6 +379,11 @@ async fn test_device_token_expiration(cptestctx: &ControlPlaneTestContext) {
         .await
         .expect("initial token should still work");
 
+    // back down to one non-expiring token
+    let tokens = get_tokens_priv(testctx).await;
+    assert_eq!(tokens.len(), 1);
+    assert_eq!(tokens[0].time_expires, None);
+
     // now test setting the silo max TTL back to null
     let settings: views::SiloAuthSettings = object_put(
         testctx,
@@ -357,6 +398,26 @@ async fn test_device_token_expiration(cptestctx: &ControlPlaneTestContext) {
     let settings: views::SiloAuthSettings =
         object_get(testctx, "/v1/auth-settings").await;
     assert_eq!(settings.device_token_max_ttl_seconds, None);
+}
+
+async fn get_tokens_priv(
+    testctx: &ClientTestContext,
+) -> Vec<views::DeviceAccessToken> {
+    NexusRequest::object_get(testctx, "/v1/me/tokens")
+        .authn_as(AuthnMode::PrivilegedUser)
+        .execute_and_parse_unwrap::<ResultsPage<views::DeviceAccessToken>>()
+        .await
+        .items
+}
+
+async fn get_tokens_unpriv(
+    testctx: &ClientTestContext,
+) -> Vec<views::DeviceAccessToken> {
+    NexusRequest::object_get(testctx, "/v1/me/tokens")
+        .authn_as(AuthnMode::UnprivilegedUser)
+        .execute_and_parse_unwrap::<ResultsPage<views::DeviceAccessToken>>()
+        .await
+        .items
 }
 
 async fn project_list(

--- a/nexus/tests/integration_tests/endpoints.rs
+++ b/nexus/tests/integration_tests/endpoints.rs
@@ -2599,7 +2599,7 @@ pub static VERIFY_ENDPOINTS: LazyLock<Vec<VerifyEndpoint>> =
             },
             /* Tokens */
             VerifyEndpoint {
-                url: "/v1/me/device-tokens",
+                url: "/v1/me/access-tokens",
                 visibility: Visibility::Public,
                 unprivileged_access: UnprivilegedAccess::ReadOnly,
                 allowed_methods: vec![AllowedMethod::Get],
@@ -2610,7 +2610,7 @@ pub static VERIFY_ENDPOINTS: LazyLock<Vec<VerifyEndpoint>> =
             // and opt out.
 
             // VerifyEndpoint {
-            //     url: "/v1/me/device-tokens/token-id",
+            //     url: "/v1/me/access-tokens/token-id",
             //     visibility: Visibility::Public,
             //     unprivileged_access: UnprivilegedAccess::None,
             //     allowed_methods: vec![AllowedMethod::Delete],

--- a/nexus/tests/integration_tests/endpoints.rs
+++ b/nexus/tests/integration_tests/endpoints.rs
@@ -2599,7 +2599,7 @@ pub static VERIFY_ENDPOINTS: LazyLock<Vec<VerifyEndpoint>> =
             },
             /* Tokens */
             VerifyEndpoint {
-                url: "/v1/me/tokens",
+                url: "/v1/me/device-tokens",
                 visibility: Visibility::Public,
                 unprivileged_access: UnprivilegedAccess::ReadOnly,
                 allowed_methods: vec![AllowedMethod::Get],
@@ -2610,7 +2610,7 @@ pub static VERIFY_ENDPOINTS: LazyLock<Vec<VerifyEndpoint>> =
             // and opt out.
 
             // VerifyEndpoint {
-            //     url: "/v1/me/tokens/token-id",
+            //     url: "/v1/me/device-tokens/token-id",
             //     visibility: Visibility::Public,
             //     unprivileged_access: UnprivilegedAccess::None,
             //     allowed_methods: vec![AllowedMethod::Delete],

--- a/nexus/tests/integration_tests/endpoints.rs
+++ b/nexus/tests/integration_tests/endpoints.rs
@@ -2597,6 +2597,25 @@ pub static VERIFY_ENDPOINTS: LazyLock<Vec<VerifyEndpoint>> =
                     AllowedMethod::Delete,
                 ],
             },
+            /* Tokens */
+            VerifyEndpoint {
+                url: "/v1/me/tokens",
+                visibility: Visibility::Public,
+                unprivileged_access: UnprivilegedAccess::ReadOnly,
+                allowed_methods: vec![AllowedMethod::Get],
+            },
+            // Creating the resource here with SetupReqs is more complicated
+            // than with other resources because it's a multi-step process where
+            // later steps depend on earlier ones, so for now we will be lazy
+            // and opt out.
+
+            // VerifyEndpoint {
+            //     url: "/v1/me/tokens/token-id",
+            //     visibility: Visibility::Public,
+            //     unprivileged_access: UnprivilegedAccess::None,
+            //     allowed_methods: vec![AllowedMethod::Delete],
+            // },
+
             /* Certificates */
             VerifyEndpoint {
                 url: &DEMO_CERTIFICATES_URL,

--- a/nexus/tests/output/uncovered-authz-endpoints.txt
+++ b/nexus/tests/output/uncovered-authz-endpoints.txt
@@ -1,6 +1,6 @@
 API endpoints with no coverage in authz tests:
 probe_delete                             (delete "/experimental/v1/probes/{probe}")
-current_user_device_token_delete         (delete "/v1/me/device-tokens/{token_id}")
+current_user_access_token_delete         (delete "/v1/me/access-tokens/{token_id}")
 probe_list                               (get    "/experimental/v1/probes")
 probe_view                               (get    "/experimental/v1/probes/{probe}")
 support_bundle_download                  (get    "/experimental/v1/system/support-bundles/{bundle_id}/download")

--- a/nexus/tests/output/uncovered-authz-endpoints.txt
+++ b/nexus/tests/output/uncovered-authz-endpoints.txt
@@ -1,5 +1,6 @@
 API endpoints with no coverage in authz tests:
 probe_delete                             (delete "/experimental/v1/probes/{probe}")
+current_user_token_delete                (delete "/v1/me/tokens/{token_id}")
 probe_list                               (get    "/experimental/v1/probes")
 probe_view                               (get    "/experimental/v1/probes/{probe}")
 support_bundle_download                  (get    "/experimental/v1/system/support-bundles/{bundle_id}/download")

--- a/nexus/tests/output/uncovered-authz-endpoints.txt
+++ b/nexus/tests/output/uncovered-authz-endpoints.txt
@@ -1,6 +1,6 @@
 API endpoints with no coverage in authz tests:
 probe_delete                             (delete "/experimental/v1/probes/{probe}")
-current_user_token_delete                (delete "/v1/me/device-tokens/{token_id}")
+current_user_device_token_delete         (delete "/v1/me/device-tokens/{token_id}")
 probe_list                               (get    "/experimental/v1/probes")
 probe_view                               (get    "/experimental/v1/probes/{probe}")
 support_bundle_download                  (get    "/experimental/v1/system/support-bundles/{bundle_id}/download")

--- a/nexus/tests/output/uncovered-authz-endpoints.txt
+++ b/nexus/tests/output/uncovered-authz-endpoints.txt
@@ -1,6 +1,6 @@
 API endpoints with no coverage in authz tests:
 probe_delete                             (delete "/experimental/v1/probes/{probe}")
-current_user_token_delete                (delete "/v1/me/tokens/{token_id}")
+current_user_token_delete                (delete "/v1/me/device-tokens/{token_id}")
 probe_list                               (get    "/experimental/v1/probes")
 probe_view                               (get    "/experimental/v1/probes/{probe}")
 support_bundle_download                  (get    "/experimental/v1/system/support-bundles/{bundle_id}/download")

--- a/nexus/types/src/external_api/params.rs
+++ b/nexus/types/src/external_api/params.rs
@@ -96,6 +96,7 @@ path_param!(CertificatePath, certificate, "certificate");
 
 id_path_param!(SupportBundlePath, bundle_id, "support bundle");
 id_path_param!(GroupPath, group_id, "group");
+id_path_param!(TokenPath, token_id, "token");
 
 // TODO: The hardware resources should be represented by its UUID or a hardware
 // ID that can be used to deterministically generate the UUID.

--- a/nexus/types/src/external_api/views.rs
+++ b/nexus/types/src/external_api/views.rs
@@ -15,7 +15,7 @@ use daft::Diffable;
 use omicron_common::api::external::{
     AffinityPolicy, AllowedSourceIps as ExternalAllowedSourceIps, ByteCount,
     Digest, Error, FailureDomain, IdentityMetadata, InstanceState, Name,
-    ObjectIdentity, RoleName, SimpleIdentityOrName,
+    ObjectIdentity, RoleName, SimpleIdentity, SimpleIdentityOrName,
 };
 use omicron_uuid_kinds::{AlertReceiverUuid, AlertUuid};
 use oxnet::{Ipv4Net, Ipv6Net};
@@ -987,6 +987,23 @@ pub struct SshKey {
 
     /// SSH public key, e.g., `"ssh-ed25519 AAAAC3NzaC..."`
     pub public_key: String,
+}
+
+/// View of a device access token
+#[derive(Clone, Debug, Deserialize, Serialize, JsonSchema, PartialEq)]
+pub struct DeviceAccessToken {
+    /// A unique, immutable, system-controlled identifier for the token.
+    /// Note that this ID is not the bearer token itself, which starts with
+    /// "oxide-token-"
+    pub id: Uuid,
+    pub time_created: DateTime<Utc>,
+    pub time_expires: Option<DateTime<Utc>>,
+}
+
+impl SimpleIdentity for DeviceAccessToken {
+    fn id(&self) -> Uuid {
+        self.id
+    }
 }
 
 // OAUTH 2.0 DEVICE AUTHORIZATION REQUESTS & TOKENS

--- a/openapi/nexus.json
+++ b/openapi/nexus.json
@@ -5512,6 +5512,99 @@
         }
       }
     },
+    "/v1/me/device-tokens": {
+      "get": {
+        "tags": [
+          "tokens"
+        ],
+        "summary": "List device tokens",
+        "description": "List device access tokens for the currently authenticated user.",
+        "operationId": "current_user_device_token_list",
+        "parameters": [
+          {
+            "in": "query",
+            "name": "limit",
+            "description": "Maximum number of items returned by a single call",
+            "schema": {
+              "nullable": true,
+              "type": "integer",
+              "format": "uint32",
+              "minimum": 1
+            }
+          },
+          {
+            "in": "query",
+            "name": "page_token",
+            "description": "Token returned by previous call to retrieve the subsequent page",
+            "schema": {
+              "nullable": true,
+              "type": "string"
+            }
+          },
+          {
+            "in": "query",
+            "name": "sort_by",
+            "schema": {
+              "$ref": "#/components/schemas/IdSortMode"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "successful operation",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/DeviceAccessTokenResultsPage"
+                }
+              }
+            }
+          },
+          "4XX": {
+            "$ref": "#/components/responses/Error"
+          },
+          "5XX": {
+            "$ref": "#/components/responses/Error"
+          }
+        },
+        "x-dropshot-pagination": {
+          "required": []
+        }
+      }
+    },
+    "/v1/me/device-tokens/{token_id}": {
+      "delete": {
+        "tags": [
+          "tokens"
+        ],
+        "summary": "Delete device token",
+        "description": "Delete a device access token for the currently authenticated user.",
+        "operationId": "current_user_device_token_delete",
+        "parameters": [
+          {
+            "in": "path",
+            "name": "token_id",
+            "description": "ID of the token",
+            "required": true,
+            "schema": {
+              "type": "string",
+              "format": "uuid"
+            }
+          }
+        ],
+        "responses": {
+          "204": {
+            "description": "successful deletion"
+          },
+          "4XX": {
+            "$ref": "#/components/responses/Error"
+          },
+          "5XX": {
+            "$ref": "#/components/responses/Error"
+          }
+        }
+      }
+    },
     "/v1/me/groups": {
       "get": {
         "tags": [
@@ -5720,99 +5813,6 @@
             "required": true,
             "schema": {
               "$ref": "#/components/schemas/NameOrId"
-            }
-          }
-        ],
-        "responses": {
-          "204": {
-            "description": "successful deletion"
-          },
-          "4XX": {
-            "$ref": "#/components/responses/Error"
-          },
-          "5XX": {
-            "$ref": "#/components/responses/Error"
-          }
-        }
-      }
-    },
-    "/v1/me/tokens": {
-      "get": {
-        "tags": [
-          "tokens"
-        ],
-        "summary": "List device access tokens",
-        "description": "List device access tokens for the currently authenticated user.",
-        "operationId": "current_user_token_list",
-        "parameters": [
-          {
-            "in": "query",
-            "name": "limit",
-            "description": "Maximum number of items returned by a single call",
-            "schema": {
-              "nullable": true,
-              "type": "integer",
-              "format": "uint32",
-              "minimum": 1
-            }
-          },
-          {
-            "in": "query",
-            "name": "page_token",
-            "description": "Token returned by previous call to retrieve the subsequent page",
-            "schema": {
-              "nullable": true,
-              "type": "string"
-            }
-          },
-          {
-            "in": "query",
-            "name": "sort_by",
-            "schema": {
-              "$ref": "#/components/schemas/IdSortMode"
-            }
-          }
-        ],
-        "responses": {
-          "200": {
-            "description": "successful operation",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/DeviceAccessTokenResultsPage"
-                }
-              }
-            }
-          },
-          "4XX": {
-            "$ref": "#/components/responses/Error"
-          },
-          "5XX": {
-            "$ref": "#/components/responses/Error"
-          }
-        },
-        "x-dropshot-pagination": {
-          "required": []
-        }
-      }
-    },
-    "/v1/me/tokens/{token_id}": {
-      "delete": {
-        "tags": [
-          "tokens"
-        ],
-        "summary": "Delete device access token",
-        "description": "Delete a device access token for the currently authenticated user.",
-        "operationId": "current_user_token_delete",
-        "parameters": [
-          {
-            "in": "path",
-            "name": "token_id",
-            "description": "ID of the token",
-            "required": true,
-            "schema": {
-              "type": "string",
-              "format": "uuid"
             }
           }
         ],

--- a/openapi/nexus.json
+++ b/openapi/nexus.json
@@ -5736,6 +5736,66 @@
         }
       }
     },
+    "/v1/me/tokens": {
+      "get": {
+        "tags": [
+          "tokens"
+        ],
+        "summary": "List device access tokens",
+        "description": "List device access tokens for the currently authenticated user.",
+        "operationId": "current_user_token_list",
+        "parameters": [
+          {
+            "in": "query",
+            "name": "limit",
+            "description": "Maximum number of items returned by a single call",
+            "schema": {
+              "nullable": true,
+              "type": "integer",
+              "format": "uint32",
+              "minimum": 1
+            }
+          },
+          {
+            "in": "query",
+            "name": "page_token",
+            "description": "Token returned by previous call to retrieve the subsequent page",
+            "schema": {
+              "nullable": true,
+              "type": "string"
+            }
+          },
+          {
+            "in": "query",
+            "name": "sort_by",
+            "schema": {
+              "$ref": "#/components/schemas/IdSortMode"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "successful operation",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/DeviceAccessTokenResultsPage"
+                }
+              }
+            }
+          },
+          "4XX": {
+            "$ref": "#/components/responses/Error"
+          },
+          "5XX": {
+            "$ref": "#/components/responses/Error"
+          }
+        },
+        "x-dropshot-pagination": {
+          "required": []
+        }
+      }
+    },
     "/v1/metrics/{metric_name}": {
       "get": {
         "tags": [
@@ -16512,6 +16572,30 @@
           "public_cert"
         ]
       },
+      "DeviceAccessToken": {
+        "description": "View of a device access token",
+        "type": "object",
+        "properties": {
+          "id": {
+            "description": "A unique, immutable, system-controlled identifier for the token. Note that this ID is not the bearer token itself, which starts with \"oxide-token-\"",
+            "type": "string",
+            "format": "uuid"
+          },
+          "time_created": {
+            "type": "string",
+            "format": "date-time"
+          },
+          "time_expires": {
+            "nullable": true,
+            "type": "string",
+            "format": "date-time"
+          }
+        },
+        "required": [
+          "id",
+          "time_created"
+        ]
+      },
       "DeviceAccessTokenRequest": {
         "type": "object",
         "properties": {
@@ -16530,6 +16614,27 @@
           "client_id",
           "device_code",
           "grant_type"
+        ]
+      },
+      "DeviceAccessTokenResultsPage": {
+        "description": "A single page of results",
+        "type": "object",
+        "properties": {
+          "items": {
+            "description": "list of items on this page of results",
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/DeviceAccessToken"
+            }
+          },
+          "next_page": {
+            "nullable": true,
+            "description": "token used to fetch the next page of results (if any)",
+            "type": "string"
+          }
+        },
+        "required": [
+          "items"
         ]
       },
       "DeviceAuthRequest": {
@@ -26727,6 +26832,13 @@
     },
     {
       "name": "system/update"
+    },
+    {
+      "name": "tokens",
+      "description": "API clients use device access tokens for authentication.",
+      "externalDocs": {
+        "url": "http://docs.oxide.computer/api/tokens"
+      }
     },
     {
       "name": "vpcs",

--- a/openapi/nexus.json
+++ b/openapi/nexus.json
@@ -5796,6 +5796,39 @@
         }
       }
     },
+    "/v1/me/tokens/{token_id}": {
+      "delete": {
+        "tags": [
+          "tokens"
+        ],
+        "summary": "Delete device access token",
+        "description": "Delete a device access token for the currently authenticated user.",
+        "operationId": "current_user_token_delete",
+        "parameters": [
+          {
+            "in": "path",
+            "name": "token_id",
+            "description": "ID of the token",
+            "required": true,
+            "schema": {
+              "type": "string",
+              "format": "uuid"
+            }
+          }
+        ],
+        "responses": {
+          "204": {
+            "description": "successful deletion"
+          },
+          "4XX": {
+            "$ref": "#/components/responses/Error"
+          },
+          "5XX": {
+            "$ref": "#/components/responses/Error"
+          }
+        }
+      }
+    },
     "/v1/metrics/{metric_name}": {
       "get": {
         "tags": [

--- a/openapi/nexus.json
+++ b/openapi/nexus.json
@@ -5512,14 +5512,14 @@
         }
       }
     },
-    "/v1/me/device-tokens": {
+    "/v1/me/access-tokens": {
       "get": {
         "tags": [
           "tokens"
         ],
-        "summary": "List device tokens",
+        "summary": "List access tokens",
         "description": "List device access tokens for the currently authenticated user.",
-        "operationId": "current_user_device_token_list",
+        "operationId": "current_user_access_token_list",
         "parameters": [
           {
             "in": "query",
@@ -5572,14 +5572,14 @@
         }
       }
     },
-    "/v1/me/device-tokens/{token_id}": {
+    "/v1/me/access-tokens/{token_id}": {
       "delete": {
         "tags": [
           "tokens"
         ],
-        "summary": "Delete device token",
+        "summary": "Delete access token",
         "description": "Delete a device access token for the currently authenticated user.",
-        "operationId": "current_user_device_token_delete",
+        "operationId": "current_user_access_token_delete",
         "parameters": [
           {
             "in": "path",


### PR DESCRIPTION
Built on top of #8137 and #8214.

This is only for a user to list and delete their own tokens. It doesn't quite match RFD 570, which says `/v1/device-tokens` instead of `/v1/me/access-tokens`, but it feels good under `/v1/me`, and after trying to make the UI too, I think "access tokens" is much more intuitive. If I stick with this, I will update RFD 570 to match.

~~I'm not sure about the path `/v1/device-tokens` — in the API we call them `Device Access Tokens`. I think `/v1/access-tokens` might be more intuitive because the `device` is sort of an implementation detail, it refers to the OAuth device auth flow, which we are using. In practice, the user just gets a token with the CLI and pastes a code into the web UI and they don't have to think too much about it, so exposing that detail in the name might not be worth it.~~ Went with `/v1/me/access-tokens`.

- [x] Basic token list and delete
- [x] Basic integration tests
- [x] Finalize endpoint paths
- [x] Figure out authz story
  - Went with restricting datastore functions to current actor for now
