### PR TITLE
Add cmake as SunOS builder dependency

### DIFF
--- a/tools/install_builder_prerequisites.sh
+++ b/tools/install_builder_prerequisites.sh
@@ -142,6 +142,7 @@ function install_packages {
     packages=(
       "pkg:/package/pkg"
       "build-essential"
+      "cmake"
       "library/postgresql-$PGVER"
       "pkg-config"
       "library/libxmlsec1"


### PR DESCRIPTION
After running `pfexec ./tools/install_builder_prerequisites.sh -y`, `cargo build -p end-to-end-tests --bin dhcp-server --release` fails during compilation if cmake is not installed by other means:
```
error: failed to run custom build command for `aws-lc-sys v0.26.0`

Caused by:
  process didn't exit successfully:
`/home/trey/git/omicron2/target/debug/build/aws-lc-sys-fc21ff594f15ae53/build-script-main`
(exit status: 101)
  --- stdout
  cargo:rerun-if-env-changed=AWS_LC_SYS_NO_PREFIX
  cargo:rerun-if-env-changed=AWS_LC_SYS_PREGENERATING_BINDINGS
  cargo:rerun-if-env-changed=AWS_LC_SYS_EXTERNAL_BINDGEN
  cargo:rerun-if-env-changed=AWS_LC_SYS_NO_ASM
  cargo:rerun-if-env-changed=AWS_LC_SYS_CFLAGS
  cargo:rerun-if-env-changed=AWS_LC_SYS_PREBUILT_NASM
  cargo:rerun-if-env-changed=AWS_LC_SYS_C_STD
  cargo:rerun-if-env-changed=AWS_LC_SYS_CMAKE_BUILDER
  cargo:rerun-if-env-changed=AWS_LC_SYS_STATIC
  cargo:rerun-if-env-changed=CMAKE

  --- stderr
  Missing dependency: cmake

  thread 'main' panicked at
/home/trey/.cargo/registry/src/index.crates.io-1949cf8c6b5b557f/aws-lc-sys-0.26.0/builder/main.rs:382:40:
  called `Result::unwrap()` on an `Err` value: "Required build
dependency is missing. Halting build."
  note: run with `RUST_BACKTRACE=1` environment variable to display a
backtrace
Failed to run command -- will try 2 more times
    Finished `dev` profile [unoptimized + debuginfo] target(s) in 0.40s
     Running `target/debug/xtask download cockroach clickhouse console
dendrite-stub maghemite-mgd transceiver-control`
   Compiling aws-lc-sys v0.26.0
error: failed to run custom build command for `aws-lc-sys v0.26.0`

Caused by:
  process didn't exit successfully:
`/home/trey/git/omicron2/target/debug/build/aws-lc-sys-fc21ff594f15ae53/build-script-main`
(exit status: 101)
  --- stdout
  cargo:rerun-if-env-changed=AWS_LC_SYS_NO_PREFIX
  cargo:rerun-if-env-changed=AWS_LC_SYS_PREGENERATING_BINDINGS
  cargo:rerun-if-env-changed=AWS_LC_SYS_EXTERNAL_BINDGEN
  cargo:rerun-if-env-changed=AWS_LC_SYS_NO_ASM
  cargo:rerun-if-env-changed=AWS_LC_SYS_CFLAGS
  cargo:rerun-if-env-changed=AWS_LC_SYS_PREBUILT_NASM
  cargo:rerun-if-env-changed=AWS_LC_SYS_C_STD
  cargo:rerun-if-env-changed=AWS_LC_SYS_CMAKE_BUILDER
  cargo:rerun-if-env-changed=AWS_LC_SYS_STATIC
  cargo:rerun-if-env-changed=CMAKE

  --- stderr
  Missing dependency: cmake

  thread 'main' panicked at
/home/trey/.cargo/registry/src/index.crates.io-1949cf8c6b5b557f/aws-lc-sys-0.26.0/builder/main.rs:382:40:
  called `Result::unwrap()` on an `Err` value: "Required build
dependency is missing. Halting build."
  note: run with `RUST_BACKTRACE=1` environment variable to display a
backtrace
```

Manually installing cmake with `pfexec pkg install cmake` resolves the issue. This commit adds `cmake` as a dependency for SunOS systems.