### PR TITLE
remove extraneous parameter from DnsConfigBuilder service-specific helpers

### DIFF
--- a/internal-dns/types/src/config.rs
+++ b/internal-dns/types/src/config.rs
@@ -426,23 +426,20 @@ impl DnsConfigBuilder {
     ///
     /// # Errors
     ///
-    /// This fails if the provided `http_service` is not for a ClickHouse single
-    /// node server. It also fails if the given zone has already been added
-    /// to the configuration.
+    /// This function fails if the given zone has already been added to the
+    /// configuration.
     pub fn host_zone_clickhouse_single_node(
         &mut self,
         zone_id: OmicronZoneUuid,
-        http_service: ServiceName,
         http_address: SocketAddrV6,
         read_policy_enabled: bool,
     ) -> anyhow::Result<()> {
-        anyhow::ensure!(
-            http_service == ServiceName::Clickhouse,
-            "This method is only valid for the ClickHouse single node server, \
-            but we were provided the service '{http_service:?}'",
-        );
         let zone = self.host_zone(zone_id, *http_address.ip())?;
-        self.service_backend_zone(http_service, &zone, http_address.port())?;
+        self.service_backend_zone(
+            ServiceName::Clickhouse,
+            &zone,
+            http_address.port(),
+        )?;
         if read_policy_enabled {
             self.service_backend_zone(
                 ServiceName::OximeterReader,
@@ -480,23 +477,20 @@ impl DnsConfigBuilder {
     ///
     /// # Errors
     ///
-    /// This fails if the provided `http_service` is not for a ClickHouse cluster
-    /// replica server. It also fails if the given zone has already been added
-    /// to the configuration.
+    /// This function fails if the given zone has already been added to the
+    /// configuration.
     pub fn host_zone_clickhouse_cluster(
         &mut self,
         zone_id: OmicronZoneUuid,
-        http_service: ServiceName,
         http_address: SocketAddrV6,
         read_policy_enabled: bool,
     ) -> anyhow::Result<()> {
-        anyhow::ensure!(
-            http_service == ServiceName::ClickhouseServer,
-            "This method is only valid for ClickHouse cluster replica servers, \
-            but we were provided the service '{http_service:?}'",
-        );
         let zone = self.host_zone(zone_id, *http_address.ip())?;
-        self.service_backend_zone(http_service, &zone, http_address.port())?;
+        self.service_backend_zone(
+            ServiceName::ClickhouseServer,
+            &zone,
+            http_address.port(),
+        )?;
         if read_policy_enabled {
             self.service_backend_zone(
                 ServiceName::OximeterReader,
@@ -521,22 +515,19 @@ impl DnsConfigBuilder {
     ///
     /// # Errors
     ///
-    /// This fails if the provided `service` is not for a ClickhouseKeeper
-    /// replica server. It also fails if the given zone has already been added
-    /// to the configuration.
+    /// This function fails if the given zone has already been added to the
+    /// configuration.
     pub fn host_zone_clickhouse_keeper(
         &mut self,
         zone_id: OmicronZoneUuid,
-        service: ServiceName,
         address: SocketAddrV6,
     ) -> anyhow::Result<()> {
-        anyhow::ensure!(
-            service == ServiceName::ClickhouseKeeper,
-            "This method is only valid for ClickHouse keeper servers, \
-            but we were provided the service '{service:?}'",
-        );
         let zone = self.host_zone(zone_id, *address.ip())?;
-        self.service_backend_zone(service, &zone, address.port())?;
+        self.service_backend_zone(
+            ServiceName::ClickhouseKeeper,
+            &zone,
+            address.port(),
+        )?;
         self.service_backend_zone(
             ServiceName::ClickhouseAdminKeeper,
             &zone,
@@ -549,23 +540,20 @@ impl DnsConfigBuilder {
     ///
     /// # Errors
     ///
-    /// This fails if the provided `service` is not for an internal DNS zone. It
-    /// also fails if the given zone has already been added to the
+    /// This function fails if the given zone has already been added to the
     /// configuration.
     pub fn host_zone_internal_dns(
         &mut self,
         zone_id: OmicronZoneUuid,
-        service: ServiceName,
         http_address: SocketAddrV6,
         dns_address: SocketAddrV6,
     ) -> anyhow::Result<()> {
-        anyhow::ensure!(
-            service == ServiceName::InternalDns,
-            "This method is only valid for internal DNS servers, \
-            but we were provided the service '{service:?}'",
-        );
         let zone = self.host_zone(zone_id, *http_address.ip())?;
-        self.service_backend_zone(service, &zone, http_address.port())?;
+        self.service_backend_zone(
+            ServiceName::InternalDns,
+            &zone,
+            http_address.port(),
+        )?;
         let prior_address =
             self.internal_dns_addresses.insert(zone.clone(), *dns_address.ip());
         if let Some(addr) = prior_address {
@@ -868,14 +856,12 @@ mod test {
             // Add clickhouse and clickhouse server zones, which have serveral services each
             b.host_zone_clickhouse_single_node(
                 zone_clickhouse_uuid,
-                ServiceName::Clickhouse,
                 SocketAddrV6::new(ZONE_CLICKHOUSE_IP, 0, 0, 0),
                 true,
             )
             .unwrap();
             b.host_zone_clickhouse_cluster(
                 zone_clickhouse_server_uuid,
-                ServiceName::ClickhouseServer,
                 SocketAddrV6::new(ZONE_CLICKHOUSE_SERVER_IP, 0, 0, 0),
                 false,
             )

--- a/nexus/test-utils/src/lib.rs
+++ b/nexus/test-utils/src/lib.rs
@@ -330,12 +330,7 @@ impl RackInitRequestBuilder {
         address: SocketAddrV6,
     ) {
         self.internal_dns_config
-            .host_zone_clickhouse_single_node(
-                zone_id,
-                ServiceName::Clickhouse,
-                address,
-                true,
-            )
+            .host_zone_clickhouse_single_node(zone_id, address, true)
             .expect("Failed to setup ClickHouse DNS");
     }
 
@@ -348,12 +343,7 @@ impl RackInitRequestBuilder {
         dns_address: SocketAddrV6,
     ) {
         self.internal_dns_config
-            .host_zone_internal_dns(
-                zone_id,
-                ServiceName::InternalDns,
-                http_address,
-                dns_address,
-            )
+            .host_zone_internal_dns(zone_id, http_address, dns_address)
             .expect("Failed to setup internal DNS");
     }
 }

--- a/nexus/types/src/deployment/execution/dns.rs
+++ b/nexus/types/src/deployment/execution/dns.rs
@@ -61,7 +61,6 @@ pub fn blueprint_internal_dns_config(
                 // falling through to call `host_zone_with_one_backend()`.
                 dns_builder.host_zone_clickhouse_single_node(
                     zone.id,
-                    ServiceName::Clickhouse,
                     *address,
                     blueprint.oximeter_read_mode.single_node_enabled(),
                 )?;
@@ -76,7 +75,6 @@ pub fn blueprint_internal_dns_config(
                 // falling through to call `host_zone_with_one_backend()`.
                 dns_builder.host_zone_clickhouse_cluster(
                     zone.id,
-                    ServiceName::ClickhouseServer,
                     *address,
                     blueprint.oximeter_read_mode.cluster_enabled(),
                 )?;
@@ -88,11 +86,7 @@ pub fn blueprint_internal_dns_config(
                 // Add the Clickhouse keeper service and `clickhouse-admin`
                 // service used for managing the keeper. We continue below so we
                 // don't fall through and call `host_zone_with_one_backend`.
-                dns_builder.host_zone_clickhouse_keeper(
-                    zone.id,
-                    ServiceName::ClickhouseKeeper,
-                    *address,
-                )?;
+                dns_builder.host_zone_clickhouse_keeper(zone.id, *address)?;
                 continue 'all_zones;
             }
             BlueprintZoneType::CockroachDb(
@@ -124,7 +118,6 @@ pub fn blueprint_internal_dns_config(
             ) => {
                 dns_builder.host_zone_internal_dns(
                     zone.id,
-                    ServiceName::InternalDns,
                     *http_address,
                     dns_address.to_owned(),
                 )?;

--- a/sled-agent/src/rack_setup/plan/service.rs
+++ b/sled-agent/src/rack_setup/plan/service.rs
@@ -415,12 +415,7 @@ impl Plan {
 
             let id = OmicronZoneUuid::new_v4();
             dns_builder
-                .host_zone_internal_dns(
-                    id,
-                    ServiceName::InternalDns,
-                    http_address,
-                    dns_address,
-                )
+                .host_zone_internal_dns(id, http_address, dns_address)
                 .unwrap();
             let dataset_name =
                 sled.alloc_dataset_from_u2s(DatasetKind::InternalDns)?;
@@ -624,7 +619,6 @@ impl Plan {
             dns_builder
                 .host_zone_clickhouse_single_node(
                     id,
-                    ServiceName::Clickhouse,
                     http_address,
                     oximeter_read_mode_enabled,
                 )


### PR DESCRIPTION
for the service-specific builder methods, the service name was expected as an argument but its only value was to check it was the same name that builder expected. the Clickhouse-related methods then used other associated names when they would set up multiple records!

the only value of the `service_name` argument seems to be as defensive programming, but it seems to primarily be a kind of redundant toestubber - if there were a copypaste error this would have caught, we still would likely still catch it. without the service name checks in service-specific helpers, we'd see one service defined as multiple zones on the same sled. this would also error!

(one of the two followups i'd talked with @davepacheco about in #8047)