### PR TITLE
[tests] Disable synchronous writeback on test databases

### DIFF
--- a/test-utils/src/dev/db.rs
+++ b/test-utils/src/dev/db.rs
@@ -586,6 +586,21 @@ impl CockroachInstance {
         client.cleanup().await.context("cleaning up after wipe")
     }
 
+    /// Disables fsync synchronization for the underlying storage layer.
+    ///
+    /// This is not a recommended operation in production, but it can
+    /// drastically improve the performance of test databases.
+    pub async fn disable_synchronization(&self) -> Result<(), anyhow::Error> {
+        let client = self.connect().await.context("connect")?;
+        client.batch_execute(
+            "SET CLUSTER SETTING kv.raft_log.disable_synchronization_unsafe = true"
+        ).await.context("disabling database synchronization")?;
+        client
+            .cleanup()
+            .await
+            .context("cleaning up after changing cluster settings")
+    }
+
     /// Wrapper around [`populate()`] using a connection to this database.
     pub async fn populate(&self) -> Result<(), anyhow::Error> {
         let client = self.connect().await.context("connect")?;

--- a/test-utils/src/dev/mod.rs
+++ b/test-utils/src/dev/mod.rs
@@ -129,6 +129,8 @@ async fn setup_database(
     let db_url = database.pg_config();
     info!(&log, "cockroach listen URL: {}", db_url);
 
+    database.disable_synchronization().await.expect("Failed to disable fsync");
+
     // If we populate the storage directory by importing the '.sql'
     // file, we must do so after the DB has started.
     match &storage_source {


### PR DESCRIPTION
Avoids synchronously writing back data to the test database, as a performance optimization.

As mentioned in comments, this is not a safe operation for production databases, but seems like a reasonable choice for testing.

This matches the settings used by https://github.com/cockroachlabs-field/cockroachdb-single-node/

Comparison vs main:
- build-and-test (ubuntu-22.04): 59-61 minutes -> This PR: 51 minutes