### PR TITLE
nexus: clarify `InstanceCreate` disk attachment behavior

### DIFF
--- a/nexus/types/src/external_api/params.rs
+++ b/nexus/types/src/external_api/params.rs
@@ -1193,8 +1193,9 @@ pub struct InstanceCreate {
     /// Disk attachments of type "create" will be created, while those of type
     /// "attach" must already exist.
     ///
-    /// The order of this list does not guarantee a boot order for the
-    /// instance. Use the boot_disk attribute to specify a boot disk.
+    /// The order of this list does not guarantee a boot order for the instance.
+    /// Use the boot_disk attribute to specify a boot disk. When boot_disk is
+    /// specified it will count against the disk attachment limit.
     #[serde(default)]
     pub disks: Vec<InstanceDiskAttachment>,
 
@@ -1205,7 +1206,8 @@ pub struct InstanceCreate {
     ///
     /// Specifying a boot disk is optional but recommended to ensure predictable
     /// boot behavior. The boot disk can be set during instance creation or
-    /// later if the instance is stopped.
+    /// later if the instance is stopped. The boot disk counts against the disk
+    /// attachment limit.
     ///
     /// An instance that does not have a boot disk set will use the boot
     /// options specified in its UEFI settings, which are controlled by both the

--- a/openapi/nexus.json
+++ b/openapi/nexus.json
@@ -19383,7 +19383,7 @@
           },
           "boot_disk": {
             "nullable": true,
-            "description": "The disk the instance is configured to boot from.\n\nThis disk can either be attached if it already exists or created along with the instance.\n\nSpecifying a boot disk is optional but recommended to ensure predictable boot behavior. The boot disk can be set during instance creation or later if the instance is stopped.\n\nAn instance that does not have a boot disk set will use the boot options specified in its UEFI settings, which are controlled by both the instance's UEFI firmware and the guest operating system. Boot options can change as disks are attached and detached, which may result in an instance that only boots to the EFI shell until a boot disk is set.",
+            "description": "The disk the instance is configured to boot from.\n\nThis disk can either be attached if it already exists or created along with the instance.\n\nSpecifying a boot disk is optional but recommended to ensure predictable boot behavior. The boot disk can be set during instance creation or later if the instance is stopped. The boot disk counts against the disk attachment limit.\n\nAn instance that does not have a boot disk set will use the boot options specified in its UEFI settings, which are controlled by both the instance's UEFI firmware and the guest operating system. Boot options can change as disks are attached and detached, which may result in an instance that only boots to the EFI shell until a boot disk is set.",
             "default": null,
             "allOf": [
               {
@@ -19395,7 +19395,7 @@
             "type": "string"
           },
           "disks": {
-            "description": "A list of disks to be attached to the instance.\n\nDisk attachments of type \"create\" will be created, while those of type \"attach\" must already exist.\n\nThe order of this list does not guarantee a boot order for the instance. Use the boot_disk attribute to specify a boot disk.",
+            "description": "A list of disks to be attached to the instance.\n\nDisk attachments of type \"create\" will be created, while those of type \"attach\" must already exist.\n\nThe order of this list does not guarantee a boot order for the instance. Use the boot_disk attribute to specify a boot disk. When boot_disk is specified it will count against the disk attachment limit.",
             "default": [],
             "type": "array",
             "items": {


### PR DESCRIPTION
Update the documentation for the `boot_disk` and `disks` attributes to note that specifying a `boot_disk` counts against the disk attachment limit.

When attempting to create an instance with both a `boot_disk` specified and 8 `disks` specified, none of which are the boot disk, the API returns the following error.

```
{
  "request_id": "8f62e5f8-c5c4-4d30-9436-47d331a59b1c",
  "error_code": "InvalidRequest",
  "message": "cannot attach more than 8 disks to instance"
}
```

This is confusing to readers since it's not obviously that `boot_disk` counts against the disk attachment.