### PR TITLE
[dns-server] servers should be able to use older configs

### DIFF
--- a/dns-server/src/storage.rs
+++ b/dns-server/src/storage.rs
@@ -132,6 +132,34 @@ pub struct Store {
     poisoned: Arc<AtomicBool>,
 }
 
+/// A temporary schema for DNS configurations from before the presence of the
+/// `serial` field.
+///
+/// This form of `CurrentConfig` can be removed once we are certain all DNS
+/// configurations have been updated to include a `serial` field.
+///
+/// This is necessary for an unfortunate chicken-and-egg problem: each DNS zone
+/// (both internal and external) has a copy of its current configuration as a
+/// JSON file in its zone. When upgraded, Nexus will be able to provide a new
+/// configuration consistent with `CurrentConfig`. But to get Nexus running,
+/// internal DNS must be able to function sufficiently for internal services to
+/// start - Nexus, CockroachDB, etc. And herein lies the problem; immediately
+/// after upgrading, internal DNS will have a configuration without `serial` on
+/// disk, so it won't be able to load the configuration, won't serve any
+/// records, and sled-agent will get stuck very early on in bringing up the
+/// system post-upgrade.
+///
+/// So, we maintain support for reading the previous configuration schema which
+/// is trivially and (almost) infallibly convertable to the new schema with
+/// `serial`.
+#[derive(Debug, Deserialize, Eq, PartialEq, Serialize)]
+struct ConfigWithoutSerial {
+    generation: Generation,
+    zones: Vec<String>,
+    time_created: chrono::DateTime<chrono::Utc>,
+    time_applied: chrono::DateTime<chrono::Utc>,
+}
+
 #[derive(Debug, Deserialize, Eq, PartialEq, Serialize)]
 struct CurrentConfig {
     generation: Generation,
@@ -139,6 +167,38 @@ struct CurrentConfig {
     zones: Vec<String>,
     time_created: chrono::DateTime<chrono::Utc>,
     time_applied: chrono::DateTime<chrono::Utc>,
+}
+
+impl TryFrom<ConfigWithoutSerial> for CurrentConfig {
+    type Error = anyhow::Error;
+
+    fn try_from(value: ConfigWithoutSerial) -> Result<Self, Self::Error> {
+        let ConfigWithoutSerial {
+            generation,
+            zones,
+            time_created,
+            time_applied,
+        } = value;
+
+        // This is.. unlikely to say the least, but it would be impolite to
+        // panic here. To overflow a u32, the generation number would have had
+        // to be bumped on average 68 times a second, every second, for two
+        // years. If the generation number were this high, it would certainly
+        // imply other issues (and we would imminently have issues when Nexus
+        // tries this same conversion).
+        let serial = generation
+            .as_u64()
+            .try_into()
+            .context("generation overflows u32?")?;
+
+        Ok(CurrentConfig {
+            generation,
+            serial,
+            zones,
+            time_created,
+            time_applied,
+        })
+    }
 }
 
 #[derive(Debug, Error)]
@@ -235,8 +295,26 @@ impl Store {
             .get(KEY_CONFIG)
             .context("fetching current config")?
             .map(|config_bytes| {
-                serde_json::from_slice(&config_bytes)
-                    .context("parsing current config")
+                let current_result = serde_json::from_slice(&config_bytes)
+                    .context("parsing current config");
+
+                // If we can't parse the current on-disk configuration format,
+                // it may just be in the old format. Try parsing it that way
+                // instead; if we can read it as an old configuration, we can
+                // translate it forward and move on. If we still can't read it,
+                // the initial result is more representative of whatever went
+                // wrong, so if there's an error here we ignore it.
+                if current_result.is_err() {
+                    let without_serial = serde_json::from_slice::<
+                        ConfigWithoutSerial,
+                    >(&config_bytes);
+
+                    if let Ok(without_serial) = without_serial {
+                        return CurrentConfig::try_from(without_serial);
+                    }
+                }
+
+                current_result
             })
             .transpose()
     }


### PR DESCRIPTION
PR #8047 comes with an unfortunate upgrade-only bug: before an upgrade, a system's DNS servers would write out a configuration without the new `serial` field added in 8047. When upgraded, the DNS servers would then try to load that config, see it is missing a `serial` field, and error for every query.

We expect to replace the previous-format configuration immediately after upgrade by regenerating a blueprint for the current system and executing it. But we should be able to use the previous-format configuration anyway, so that DNS functions enough to get a control plane capable of planning and executing that blueprint.

I'm going to test out the upgrade flow imminently by hand somewhere, so we can be certain this will work on dogfood. Draft as I've not actually tried an upgrade with this change yet, but I'm very confident in it.

If we merge this, we should not merge https://github.com/oxidecomputer/omicron/pull/8272. If we merge #8272, then this will conflict with main, but would be a clean patch on top of a `revert #8272` commit where both can go in as a new squash commit. I'm fine either way, more focused on making sure upgrades still.. work.