### PR TITLE
Add `token_id` and `time_expires` to access token grant response

### DIFF
--- a/nexus/db-model/src/device_auth.rs
+++ b/nexus/db-model/src/device_auth.rs
@@ -177,6 +177,7 @@ impl DeviceAccessToken {
 impl From<DeviceAccessToken> for views::DeviceAccessTokenGrant {
     fn from(access_token: DeviceAccessToken) -> Self {
         Self {
+            token_id: access_token.id.into_untyped_uuid(),
             access_token: format!("oxide-token-{}", access_token.token),
             token_type: views::DeviceAccessTokenType::Bearer,
         }

--- a/nexus/db-model/src/device_auth.rs
+++ b/nexus/db-model/src/device_auth.rs
@@ -177,9 +177,10 @@ impl DeviceAccessToken {
 impl From<DeviceAccessToken> for views::DeviceAccessTokenGrant {
     fn from(access_token: DeviceAccessToken) -> Self {
         Self {
-            token_id: access_token.id.into_untyped_uuid(),
             access_token: format!("oxide-token-{}", access_token.token),
             token_type: views::DeviceAccessTokenType::Bearer,
+            token_id: access_token.id.into_untyped_uuid(),
+            time_expires: access_token.time_expires,
         }
     }
 }

--- a/nexus/tests/integration_tests/device_auth.rs
+++ b/nexus/tests/integration_tests/device_auth.rs
@@ -179,6 +179,7 @@ async fn test_device_auth_flow(cptestctx: &ControlPlaneTestContext) {
     assert_eq!(get_tokens_priv(testctx).await.len(), 0);
     let tokens_unpriv_after = get_tokens_unpriv(testctx).await;
     assert_eq!(tokens_unpriv_after.len(), 1);
+    assert_eq!(tokens_unpriv_after[0].id, token.token_id);
     assert_eq!(tokens_unpriv_after[0].time_expires, None);
 
     // now make a request with the token. it 403s because unpriv user has no

--- a/nexus/types/src/external_api/views.rs
+++ b/nexus/types/src/external_api/views.rs
@@ -997,6 +997,8 @@ pub struct DeviceAccessToken {
     /// "oxide-token-"
     pub id: Uuid,
     pub time_created: DateTime<Utc>,
+
+    /// Expiration timestamp. A null value means the token does not automatically expire.
     pub time_expires: Option<DateTime<Utc>>,
 }
 
@@ -1038,6 +1040,9 @@ pub struct DeviceAccessTokenGrant {
 
     /// A unique, immutable, system-controlled identifier for the token
     pub token_id: Uuid,
+
+    /// Expiration timestamp. A null value means the token does not automatically expire.
+    pub time_expires: Option<DateTime<Utc>>,
 }
 
 /// The kind of token granted.

--- a/nexus/types/src/external_api/views.rs
+++ b/nexus/types/src/external_api/views.rs
@@ -1012,10 +1012,10 @@ impl SimpleIdentity for DeviceAccessToken {
 /// See RFC 8628 §3.2 (Device Authorization Response).
 #[derive(Clone, Debug, Deserialize, Serialize, JsonSchema)]
 pub struct DeviceAuthResponse {
-    /// The device verification code.
+    /// The device verification code
     pub device_code: String,
 
-    /// The end-user verification code.
+    /// The end-user verification code
     pub user_code: String,
 
     /// The end-user verification URI on the authorization server.
@@ -1023,18 +1023,21 @@ pub struct DeviceAuthResponse {
     /// may be asked to manually type it into their user agent.
     pub verification_uri: String,
 
-    /// The lifetime in seconds of the `device_code` and `user_code`.
+    /// The lifetime in seconds of the `device_code` and `user_code`
     pub expires_in: u16,
 }
 
 /// Successful access token grant. See RFC 6749 §5.1.
 #[derive(Clone, Debug, Deserialize, Serialize, JsonSchema)]
 pub struct DeviceAccessTokenGrant {
-    /// The access token issued to the client.
+    /// The access token issued to the client
     pub access_token: String,
 
     /// The type of the token issued, as described in RFC 6749 §7.1.
     pub token_type: DeviceAccessTokenType,
+
+    /// A unique, immutable, system-controlled identifier for the token
+    pub token_id: Uuid,
 }
 
 /// The kind of token granted.

--- a/openapi/nexus.json
+++ b/openapi/nexus.json
@@ -16620,6 +16620,7 @@
           },
           "time_expires": {
             "nullable": true,
+            "description": "Expiration timestamp. A null value means the token does not automatically expire.",
             "type": "string",
             "format": "date-time"
           }


### PR DESCRIPTION
Closes #8279. It seems the response schemas I changed are not in the OpenAPI output, so there are no changes there.