### PR TITLE
[reconfigurator] Test MGS driven RoT updates

### DIFF
--- a/nexus/mgs-updates/src/driver_update.rs
+++ b/nexus/mgs-updates/src/driver_update.rs
@@ -636,6 +636,8 @@ mod test {
     use gateway_client::types::SpType;
     use gateway_messages::SpPort;
     use gateway_test_utils::setup::GatewayTestContext;
+    use gateway_types::rot::RotSlot;
+    use nexus_types::deployment::ExpectedActiveRotSlot;
     use nexus_types::deployment::ExpectedVersion;
     use nexus_types::internal_api::views::UpdateAttemptStatus;
     use nexus_types::internal_api::views::UpdateCompletedHow;
@@ -701,7 +703,6 @@ mod test {
         gwtestctx.teardown().await;
     }
 
-    // TODO-K: test same but for rot
     async fn run_one_successful_sp_update(
         gwtestctx: &GatewayTestContext,
         artifacts: &TestArtifacts,
@@ -717,7 +718,7 @@ mod test {
             slot_id,
             artifact_hash,
             override_baseboard_id: None,
-            expected_sp_component: ExpectedSpComponent::Sp {
+            override_expected_sp_component: ExpectedSpComponent::Sp {
                 override_expected_active: None,
                 override_expected_inactive: None,
             },
@@ -733,7 +734,7 @@ mod test {
     #[tokio::test]
     async fn test_rot_update_basic() {
         let gwtestctx = gateway_test_utils::setup::test_setup(
-            "test_sp_update_basic",
+            "test_rot_update_basic",
             SpPort::One,
         )
         .await;
@@ -751,42 +752,41 @@ mod test {
         )
         .await;
 
-        //           // Basic case: attempted update, found no changes needed
-        //           run_one_successful_sp_update(
-        //               &gwtestctx,
-        //               &artifacts,
-        //               SpType::Sled,
-        //               1,
-        //               &artifacts.sp_gimlet_artifact_hash,
-        //               UpdateCompletedHow::FoundNoChangesNeeded,
-        //           )
-        //           .await;
-        //
-        //           // Run the same two tests for a switch SP.
-        //           run_one_successful_sp_update(
-        //               &gwtestctx,
-        //               &artifacts,
-        //               SpType::Switch,
-        //               0,
-        //               &artifacts.sp_sidecar_artifact_hash,
-        //               UpdateCompletedHow::CompletedUpdate,
-        //           )
-        //           .await;
-        //           run_one_successful_sp_update(
-        //               &gwtestctx,
-        //               &artifacts,
-        //               SpType::Switch,
-        //               0,
-        //               &artifacts.sp_sidecar_artifact_hash,
-        //               UpdateCompletedHow::FoundNoChangesNeeded,
-        //           )
-        //           .await;
+        // Basic case: attempted update, found no changes needed
+        run_one_successful_rot_update(
+            &gwtestctx,
+            &artifacts,
+            SpType::Sled,
+            1,
+            &artifacts.rot_gimlet_artifact_hash,
+            UpdateCompletedHow::FoundNoChangesNeeded,
+        )
+        .await;
+
+        // Run the same two tests for a switch RoT.
+        run_one_successful_rot_update(
+            &gwtestctx,
+            &artifacts,
+            SpType::Switch,
+            0,
+            &artifacts.rot_sidecar_artifact_hash,
+            UpdateCompletedHow::CompletedUpdate,
+        )
+        .await;
+        run_one_successful_rot_update(
+            &gwtestctx,
+            &artifacts,
+            SpType::Switch,
+            0,
+            &artifacts.rot_sidecar_artifact_hash,
+            UpdateCompletedHow::FoundNoChangesNeeded,
+        )
+        .await;
 
         artifacts.teardown().await;
         gwtestctx.teardown().await;
     }
 
-    // TODO-K: test same but for rot
     async fn run_one_successful_rot_update(
         gwtestctx: &GatewayTestContext,
         artifacts: &TestArtifacts,
@@ -802,7 +802,7 @@ mod test {
             slot_id,
             artifact_hash,
             override_baseboard_id: None,
-            expected_sp_component: ExpectedSpComponent::Rot {
+            override_expected_sp_component: ExpectedSpComponent::Rot {
                 override_expected_active_slot: None,
                 override_expected_inactive_version: None,
                 override_expected_persistent_boot_preference: None,
@@ -848,7 +848,7 @@ mod test {
             slot_id: 1,
             artifact_hash: &artifacts.sp_gimlet_artifact_hash,
             override_baseboard_id: None,
-            expected_sp_component: ExpectedSpComponent::Sp {
+            override_expected_sp_component: ExpectedSpComponent::Sp {
                 override_expected_active: None,
                 override_expected_inactive: None,
             },
@@ -862,7 +862,7 @@ mod test {
             slot_id: 1,
             artifact_hash: &artifacts.sp_gimlet_artifact_hash,
             override_baseboard_id: None,
-            expected_sp_component: ExpectedSpComponent::Sp {
+            override_expected_sp_component: ExpectedSpComponent::Sp {
                 override_expected_active: None,
                 override_expected_inactive: Some(ExpectedVersion::Version(
                     std::str::from_utf8(
@@ -924,7 +924,7 @@ mod test {
             slot_id: 1,
             artifact_hash: &artifacts.sp_gimlet_artifact_hash,
             override_baseboard_id: None,
-            expected_sp_component: ExpectedSpComponent::Sp {
+            override_expected_sp_component: ExpectedSpComponent::Sp {
                 override_expected_active: None,
                 override_expected_inactive: None,
             },
@@ -938,7 +938,7 @@ mod test {
             slot_id: 1,
             artifact_hash: &artifacts.sp_gimlet_artifact_hash,
             override_baseboard_id: None,
-            expected_sp_component: ExpectedSpComponent::Sp {
+            override_expected_sp_component: ExpectedSpComponent::Sp {
                 override_expected_active: None,
                 override_expected_inactive: Some(ExpectedVersion::Version(
                     std::str::from_utf8(
@@ -1017,7 +1017,7 @@ mod test {
                 part_number: String::from("i86pc"),
                 serial_number: String::from("SimGimlet0"),
             }),
-            expected_sp_component: ExpectedSpComponent::Sp {
+            override_expected_sp_component: ExpectedSpComponent::Sp {
                 override_expected_active: None,
                 override_expected_inactive: None,
             },
@@ -1046,7 +1046,7 @@ mod test {
             slot_id: 1,
             artifact_hash: &artifacts.sp_gimlet_artifact_hash,
             override_baseboard_id: None,
-            expected_sp_component: ExpectedSpComponent::Sp {
+            override_expected_sp_component: ExpectedSpComponent::Sp {
                 override_expected_active: Some("not-right".parse().unwrap()),
                 override_expected_inactive: None,
             },
@@ -1075,7 +1075,7 @@ mod test {
             slot_id: 1,
             artifact_hash: &artifacts.sp_gimlet_artifact_hash,
             override_baseboard_id: None,
-            expected_sp_component: ExpectedSpComponent::Sp {
+            override_expected_sp_component: ExpectedSpComponent::Sp {
                 override_expected_active: None,
                 override_expected_inactive: Some(
                     ExpectedVersion::NoValidVersion,
@@ -1106,7 +1106,7 @@ mod test {
             slot_id: 1,
             artifact_hash: &artifacts.sp_gimlet_artifact_hash,
             override_baseboard_id: None,
-            expected_sp_component: ExpectedSpComponent::Sp {
+            override_expected_sp_component: ExpectedSpComponent::Sp {
                 override_expected_active: None,
                 override_expected_inactive: Some(ExpectedVersion::Version(
                     "something-else".parse().unwrap(),
@@ -1138,9 +1138,221 @@ mod test {
             slot_id: 1,
             artifact_hash: &artifacts.sp_gimlet_artifact_hash,
             override_baseboard_id: None,
-            expected_sp_component: ExpectedSpComponent::Sp {
+            override_expected_sp_component: ExpectedSpComponent::Sp {
                 override_expected_active: None,
                 override_expected_inactive: None,
+            },
+            override_progress_timeout: None,
+        };
+        let in_progress = desc.setup().await;
+        artifacts.teardown().await;
+        in_progress.finish().await.expect_failure(&|error, sp1, sp2| {
+            assert_matches!(error, ApplyUpdateError::FetchArtifact(..));
+            // No changes should have been made in this case.
+            assert_eq!(sp1, sp2);
+        });
+
+        gwtestctx.teardown().await;
+    }
+
+    /// Tests several RoT update easy fast-failure cases.
+    #[tokio::test]
+    async fn test_rot_basic_failures() {
+        let gwtestctx = gateway_test_utils::setup::test_setup(
+            "test_rot_basic_failures",
+            SpPort::One,
+        )
+        .await;
+        let log = &gwtestctx.logctx.log;
+        let artifacts = TestArtifacts::new(log).await.unwrap();
+
+        // Test a case of mistaken identity (reported baseboard does not match
+        // the one that we expect).
+        let desc = UpdateDescription {
+            gwtestctx: &gwtestctx,
+            artifacts: &artifacts,
+            sp_type: SpType::Sled,
+            slot_id: 1,
+            artifact_hash: &artifacts.sp_gimlet_artifact_hash,
+            override_baseboard_id: Some(BaseboardId {
+                part_number: String::from("i86pc"),
+                serial_number: String::from("SimGimlet0"),
+            }),
+            override_expected_sp_component: ExpectedSpComponent::Rot {
+                override_expected_active_slot: None,
+                override_expected_inactive_version: None,
+                override_expected_persistent_boot_preference: None,
+                override_expected_pending_persistent_boot_preference: None,
+                override_expected_transient_boot_preference: None,
+            },
+            override_progress_timeout: None,
+        };
+
+        desc.setup().await.finish().await.expect_failure(&|error, sp1, sp2| {
+            assert_matches!(error, ApplyUpdateError::PreconditionFailed(..));
+            let message = InlineErrorChain::new(error).to_string();
+            eprintln!("{}", message);
+            assert!(message.contains(
+                "in sled slot 1, expected to find part \"i86pc\" serial \
+                 \"SimGimlet0\", but found part \"i86pc\" serial \
+                 \"SimGimlet01\"",
+            ));
+
+            // No changes should have been made in this case.
+            assert_eq!(sp1, sp2);
+        });
+
+        // Test a case where the active version doesn't match what we expect.
+        let desc = UpdateDescription {
+            gwtestctx: &gwtestctx,
+            artifacts: &artifacts,
+            sp_type: SpType::Sled,
+            slot_id: 1,
+            artifact_hash: &artifacts.sp_gimlet_artifact_hash,
+            override_baseboard_id: None,
+            override_expected_sp_component: ExpectedSpComponent::Rot {
+                override_expected_active_slot: Some(ExpectedActiveRotSlot {
+                    slot: RotSlot::A,
+                    version: "not-right".parse().unwrap(),
+                }),
+                override_expected_inactive_version: None,
+                override_expected_persistent_boot_preference: None,
+                override_expected_pending_persistent_boot_preference: None,
+                override_expected_transient_boot_preference: None,
+            },
+            override_progress_timeout: None,
+        };
+
+        desc.setup().await.finish().await.expect_failure(&|error, sp1, sp2| {
+            assert_matches!(error, ApplyUpdateError::PreconditionFailed(..));
+            let message = InlineErrorChain::new(error).to_string();
+            eprintln!("{}", message);
+            assert!(message.contains(
+                "expected to find active version \"not-right\", but \
+                     found \"0.0.4\""
+            ));
+
+            // No changes should have been made in this case.
+            assert_eq!(sp1, sp2);
+        });
+
+        // Test a case where the active slot doesn't match what we expect.
+        let desc = UpdateDescription {
+            gwtestctx: &gwtestctx,
+            artifacts: &artifacts,
+            sp_type: SpType::Sled,
+            slot_id: 1,
+            artifact_hash: &artifacts.sp_gimlet_artifact_hash,
+            override_baseboard_id: None,
+            override_expected_sp_component: ExpectedSpComponent::Rot {
+                override_expected_active_slot: Some(ExpectedActiveRotSlot {
+                    slot: RotSlot::B,
+                    version: "0.0.4".parse().unwrap(),
+                }),
+                override_expected_inactive_version: None,
+                override_expected_persistent_boot_preference: None,
+                override_expected_pending_persistent_boot_preference: None,
+                override_expected_transient_boot_preference: None,
+            },
+            override_progress_timeout: None,
+        };
+
+        desc.setup().await.finish().await.expect_failure(&|error, sp1, sp2| {
+            assert_matches!(error, ApplyUpdateError::PreconditionFailed(..));
+            let message = InlineErrorChain::new(error).to_string();
+            eprintln!("{}", message);
+            assert!(
+                message.contains("expected to find active slot B, but found A")
+            );
+
+            // No changes should have been made in this case.
+            assert_eq!(sp1, sp2);
+        });
+
+        // Test a case where the inactive version doesn't match what it should
+        // (expected invalid, found something else).
+        let desc = UpdateDescription {
+            gwtestctx: &gwtestctx,
+            artifacts: &artifacts,
+            sp_type: SpType::Sled,
+            slot_id: 1,
+            artifact_hash: &artifacts.sp_gimlet_artifact_hash,
+            override_baseboard_id: None,
+            override_expected_sp_component: ExpectedSpComponent::Rot {
+                override_expected_active_slot: None,
+                override_expected_inactive_version: Some(
+                    ExpectedVersion::NoValidVersion,
+                ),
+                override_expected_persistent_boot_preference: None,
+                override_expected_pending_persistent_boot_preference: None,
+                override_expected_transient_boot_preference: None,
+            },
+            override_progress_timeout: None,
+        };
+
+        desc.setup().await.finish().await.expect_failure(&|error, sp1, sp2| {
+            assert_matches!(error, ApplyUpdateError::PreconditionFailed(..));
+            let message = InlineErrorChain::new(error).to_string();
+            eprintln!("{}", message);
+            assert!(message.contains(
+                "expected to find inactive version NoValidVersion, \
+                     but found Version(\"0.0.3\")"
+            ));
+
+            // No changes should have been made in this case.
+            assert_eq!(sp1, sp2);
+        });
+
+        // Now test a case where the inactive version doesn't match what it
+        // should (expected a different valid version).
+        let desc = UpdateDescription {
+            gwtestctx: &gwtestctx,
+            artifacts: &artifacts,
+            sp_type: SpType::Sled,
+            slot_id: 1,
+            artifact_hash: &artifacts.sp_gimlet_artifact_hash,
+            override_baseboard_id: None,
+            override_expected_sp_component: ExpectedSpComponent::Rot {
+                override_expected_active_slot: None,
+                override_expected_inactive_version: Some(
+                    ExpectedVersion::Version("something-else".parse().unwrap()),
+                ),
+                override_expected_persistent_boot_preference: None,
+                override_expected_pending_persistent_boot_preference: None,
+                override_expected_transient_boot_preference: None,
+            },
+            override_progress_timeout: None,
+        };
+
+        desc.setup().await.finish().await.expect_failure(&|error, sp1, sp2| {
+            assert_matches!(error, ApplyUpdateError::PreconditionFailed(..));
+            let message = InlineErrorChain::new(error).to_string();
+            eprintln!("{}", message);
+            assert!(message.contains(
+                "expected to find inactive version \
+                     Version(ArtifactVersion(\"something-else\")), but found \
+                     Version(\"0.0.3\")"
+            ));
+
+            // No changes should have been made in this case.
+            assert_eq!(sp1, sp2);
+        });
+
+        // Test a case where we fail to fetch the artifact.  We simulate this by
+        // tearing down our artifact server before the update starts.
+        let desc = UpdateDescription {
+            gwtestctx: &gwtestctx,
+            artifacts: &artifacts,
+            sp_type: SpType::Sled,
+            slot_id: 1,
+            artifact_hash: &artifacts.sp_gimlet_artifact_hash,
+            override_baseboard_id: None,
+            override_expected_sp_component: ExpectedSpComponent::Rot {
+                override_expected_active_slot: None,
+                override_expected_inactive_version: None,
+                override_expected_persistent_boot_preference: None,
+                override_expected_pending_persistent_boot_preference: None,
+                override_expected_transient_boot_preference: None,
             },
             override_progress_timeout: None,
         };

--- a/nexus/mgs-updates/src/driver_update.rs
+++ b/nexus/mgs-updates/src/driver_update.rs
@@ -630,6 +630,7 @@ async fn wait_for_update_done(
 mod test {
     use super::ApplyUpdateError;
     use crate::test_util::test_artifacts::TestArtifacts;
+    use crate::test_util::updates::ExpectedSpComponent;
     use crate::test_util::updates::UpdateDescription;
     use assert_matches::assert_matches;
     use gateway_client::types::SpType;
@@ -700,6 +701,7 @@ mod test {
         gwtestctx.teardown().await;
     }
 
+    // TODO-K: test same but for rot
     async fn run_one_successful_update(
         gwtestctx: &GatewayTestContext,
         artifacts: &TestArtifacts,
@@ -715,8 +717,10 @@ mod test {
             slot_id,
             artifact_hash,
             override_baseboard_id: None,
-            override_expected_active: None,
-            override_expected_inactive: None,
+            expected_sp_component: ExpectedSpComponent::Sp {
+                override_expected_active: None,
+                override_expected_inactive: None,
+            },
             override_progress_timeout: None,
         };
 
@@ -756,8 +760,10 @@ mod test {
             slot_id: 1,
             artifact_hash: &artifacts.sp_gimlet_artifact_hash,
             override_baseboard_id: None,
-            override_expected_active: None,
-            override_expected_inactive: None,
+            expected_sp_component: ExpectedSpComponent::Sp {
+                override_expected_active: None,
+                override_expected_inactive: None,
+            },
             override_progress_timeout: None,
         };
 
@@ -768,19 +774,23 @@ mod test {
             slot_id: 1,
             artifact_hash: &artifacts.sp_gimlet_artifact_hash,
             override_baseboard_id: None,
-            override_expected_active: None,
-            override_expected_inactive: Some(ExpectedVersion::Version(
-                std::str::from_utf8(
-                    artifacts
-                        .deployed_caboose(&artifacts.sp_gimlet_artifact_hash)
-                        .expect("deployed caboose for generated artifact")
-                        .version()
-                        .expect("valid version"),
-                )
-                .expect("version is UTF-8")
-                .parse()
-                .expect("version is valid"),
-            )),
+            expected_sp_component: ExpectedSpComponent::Sp {
+                override_expected_active: None,
+                override_expected_inactive: Some(ExpectedVersion::Version(
+                    std::str::from_utf8(
+                        artifacts
+                            .deployed_caboose(
+                                &artifacts.sp_gimlet_artifact_hash,
+                            )
+                            .expect("deployed caboose for generated artifact")
+                            .version()
+                            .expect("valid version"),
+                    )
+                    .expect("version is UTF-8")
+                    .parse()
+                    .expect("version is valid"),
+                )),
+            },
             override_progress_timeout: None,
         };
 
@@ -825,8 +835,10 @@ mod test {
             slot_id: 1,
             artifact_hash: &artifacts.sp_gimlet_artifact_hash,
             override_baseboard_id: None,
-            override_expected_active: None,
-            override_expected_inactive: None,
+            expected_sp_component: ExpectedSpComponent::Sp {
+                override_expected_active: None,
+                override_expected_inactive: None,
+            },
             override_progress_timeout: None,
         };
 
@@ -837,19 +849,23 @@ mod test {
             slot_id: 1,
             artifact_hash: &artifacts.sp_gimlet_artifact_hash,
             override_baseboard_id: None,
-            override_expected_active: None,
-            override_expected_inactive: Some(ExpectedVersion::Version(
-                std::str::from_utf8(
-                    artifacts
-                        .deployed_caboose(&artifacts.sp_gimlet_artifact_hash)
-                        .expect("deployed caboose for generated artifact")
-                        .version()
-                        .expect("valid version"),
-                )
-                .expect("version is UTF-8")
-                .parse()
-                .expect("version is valid"),
-            )),
+            expected_sp_component: ExpectedSpComponent::Sp {
+                override_expected_active: None,
+                override_expected_inactive: Some(ExpectedVersion::Version(
+                    std::str::from_utf8(
+                        artifacts
+                            .deployed_caboose(
+                                &artifacts.sp_gimlet_artifact_hash,
+                            )
+                            .expect("deployed caboose for generated artifact")
+                            .version()
+                            .expect("valid version"),
+                    )
+                    .expect("version is UTF-8")
+                    .parse()
+                    .expect("version is valid"),
+                )),
+            },
             // This timeout (10 seconds) seeks to balance being long enough to
             // be relevant without making the tests take too long.  (It's
             // assumed that 10 seconds here is not a huge deal because this is
@@ -911,8 +927,10 @@ mod test {
                 part_number: String::from("i86pc"),
                 serial_number: String::from("SimGimlet0"),
             }),
-            override_expected_active: None,
-            override_expected_inactive: None,
+            expected_sp_component: ExpectedSpComponent::Sp {
+                override_expected_active: None,
+                override_expected_inactive: None,
+            },
             override_progress_timeout: None,
         };
 
@@ -938,8 +956,10 @@ mod test {
             slot_id: 1,
             artifact_hash: &artifacts.sp_gimlet_artifact_hash,
             override_baseboard_id: None,
-            override_expected_active: Some("not-right".parse().unwrap()),
-            override_expected_inactive: None,
+            expected_sp_component: ExpectedSpComponent::Sp {
+                override_expected_active: Some("not-right".parse().unwrap()),
+                override_expected_inactive: None,
+            },
             override_progress_timeout: None,
         };
 
@@ -965,8 +985,12 @@ mod test {
             slot_id: 1,
             artifact_hash: &artifacts.sp_gimlet_artifact_hash,
             override_baseboard_id: None,
-            override_expected_active: None,
-            override_expected_inactive: Some(ExpectedVersion::NoValidVersion),
+            expected_sp_component: ExpectedSpComponent::Sp {
+                override_expected_active: None,
+                override_expected_inactive: Some(
+                    ExpectedVersion::NoValidVersion,
+                ),
+            },
             override_progress_timeout: None,
         };
 
@@ -992,10 +1016,12 @@ mod test {
             slot_id: 1,
             artifact_hash: &artifacts.sp_gimlet_artifact_hash,
             override_baseboard_id: None,
-            override_expected_active: None,
-            override_expected_inactive: Some(ExpectedVersion::Version(
-                "something-else".parse().unwrap(),
-            )),
+            expected_sp_component: ExpectedSpComponent::Sp {
+                override_expected_active: None,
+                override_expected_inactive: Some(ExpectedVersion::Version(
+                    "something-else".parse().unwrap(),
+                )),
+            },
             override_progress_timeout: None,
         };
 
@@ -1022,8 +1048,10 @@ mod test {
             slot_id: 1,
             artifact_hash: &artifacts.sp_gimlet_artifact_hash,
             override_baseboard_id: None,
-            override_expected_active: None,
-            override_expected_inactive: None,
+            expected_sp_component: ExpectedSpComponent::Sp {
+                override_expected_active: None,
+                override_expected_inactive: None,
+            },
             override_progress_timeout: None,
         };
         let in_progress = desc.setup().await;

--- a/nexus/mgs-updates/src/test_util/sp_test_state.rs
+++ b/nexus/mgs-updates/src/test_util/sp_test_state.rs
@@ -134,6 +134,21 @@ impl SpTestState {
         self.caboose_rot_b.as_ref().expect("ROT slot B caboose")
     }
 
+    pub fn expect_caboose_rot_active(&self) -> &SpComponentCaboose {
+        match self.expect_rot_active_slot() {
+            RotSlot::A => self.expect_caboose_rot_a(),
+            RotSlot::B => self.expect_caboose_rot_b(),
+        }
+    }
+
+    pub fn expect_caboose_rot_inactive(&self) -> &SpComponentCaboose {
+        let slot = self.expect_rot_active_slot().toggled();
+        match slot {
+            RotSlot::A => self.expect_caboose_rot_a(),
+            RotSlot::B => self.expect_caboose_rot_b(),
+        }
+    }
+
     pub fn baseboard_id(&self) -> BaseboardId {
         BaseboardId {
             part_number: self.sp_state.model.clone(),

--- a/nexus/mgs-updates/src/test_util/test_artifacts.rs
+++ b/nexus/mgs-updates/src/test_util/test_artifacts.rs
@@ -32,9 +32,10 @@ type InMemoryRepoDepotServerContext = Arc<ArtifactData>;
 /// Together, this makes it easy to write SP update tests that use these
 /// artifacts.
 pub struct TestArtifacts {
-    // TODO-K: Add rot artifacts
     pub sp_gimlet_artifact_hash: ArtifactHash,
     pub sp_sidecar_artifact_hash: ArtifactHash,
+    pub rot_gimlet_artifact_hash: ArtifactHash,
+    pub rot_sidecar_artifact_hash: ArtifactHash,
     pub artifact_cache: Arc<ArtifactCache>,
     deployed_cabooses: BTreeMap<ArtifactHash, hubtools::Caboose>,
     resolver: FixedResolver,
@@ -75,10 +76,44 @@ impl TestArtifacts {
             ArtifactHash(digest.finalize().into())
         };
 
+        // Make an RoT update artifact for SimGimlet.
+        let rot_gimlet_artifact_caboose = CabooseBuilder::default()
+            .git_commit("fake-git-commit")
+            .board(SIM_GIMLET_BOARD)
+            .version("0.0.0")
+            .name("fake-name")
+            .build();
+        let mut builder = HubrisArchiveBuilder::with_fake_image();
+        builder.write_caboose(rot_gimlet_artifact_caboose.as_slice()).unwrap();
+        let rot_gimlet_artifact = builder.build_to_vec().unwrap();
+        let rot_gimlet_artifact_hash = {
+            let mut digest = sha2::Sha256::default();
+            digest.update(&rot_gimlet_artifact);
+            ArtifactHash(digest.finalize().into())
+        };
+
+        // Make an RoT update artifact for SimSidecar
+        let rot_sidecar_artifact_caboose = CabooseBuilder::default()
+            .git_commit("fake-git-commit")
+            .board(SIM_SIDECAR_BOARD)
+            .version("0.0.0")
+            .name("fake-name")
+            .build();
+        let mut builder = HubrisArchiveBuilder::with_fake_image();
+        builder.write_caboose(rot_sidecar_artifact_caboose.as_slice()).unwrap();
+        let rot_sidecar_artifact = builder.build_to_vec().unwrap();
+        let rot_sidecar_artifact_hash = {
+            let mut digest = sha2::Sha256::default();
+            digest.update(&rot_sidecar_artifact);
+            ArtifactHash(digest.finalize().into())
+        };
+
         // Assemble a map of artifact hash to artifact contents.
         let artifact_data = [
             (sp_gimlet_artifact_hash, sp_gimlet_artifact),
             (sp_sidecar_artifact_hash, sp_sidecar_artifact),
+            (rot_gimlet_artifact_hash, rot_gimlet_artifact),
+            (rot_sidecar_artifact_hash, rot_sidecar_artifact),
         ]
         .into_iter()
         .collect();
@@ -87,6 +122,8 @@ impl TestArtifacts {
         let deployed_cabooses = [
             (sp_gimlet_artifact_hash, sp_gimlet_artifact_caboose),
             (sp_sidecar_artifact_hash, sp_sidecar_artifact_caboose),
+            (rot_gimlet_artifact_hash, rot_gimlet_artifact_caboose),
+            (rot_sidecar_artifact_hash, rot_sidecar_artifact_caboose),
         ]
         .into_iter()
         .collect();
@@ -116,6 +153,8 @@ impl TestArtifacts {
         Ok(TestArtifacts {
             sp_gimlet_artifact_hash,
             sp_sidecar_artifact_hash,
+            rot_gimlet_artifact_hash,
+            rot_sidecar_artifact_hash,
             deployed_cabooses,
             artifact_cache,
             resolver,

--- a/nexus/mgs-updates/src/test_util/test_artifacts.rs
+++ b/nexus/mgs-updates/src/test_util/test_artifacts.rs
@@ -32,6 +32,7 @@ type InMemoryRepoDepotServerContext = Arc<ArtifactData>;
 /// Together, this makes it easy to write SP update tests that use these
 /// artifacts.
 pub struct TestArtifacts {
+    // TODO-K: Add rot artifacts
     pub sp_gimlet_artifact_hash: ArtifactHash,
     pub sp_sidecar_artifact_hash: ArtifactHash,
     pub artifact_cache: Arc<ArtifactCache>,

--- a/nexus/mgs-updates/src/test_util/updates.rs
+++ b/nexus/mgs-updates/src/test_util/updates.rs
@@ -44,13 +44,17 @@ pub enum ExpectedSpComponent {
         override_expected_active: Option<ArtifactVersion>,
         override_expected_inactive: Option<ExpectedVersion>,
     },
+    // TODO-K: Remove once fully implemented
+    #[allow(dead_code)]
     Rot {
-        override_expected_active_slot: ExpectedActiveRotSlot,
-        override_expected_inactive_version: ExpectedVersion,
-        override_expected_persistent_boot_preference: RotSlot,
+        override_expected_active_slot: Option<ExpectedActiveRotSlot>,
+        override_expected_inactive_version: Option<ExpectedVersion>,
+        override_expected_persistent_boot_preference: Option<RotSlot>,
         override_expected_pending_persistent_boot_preference: Option<RotSlot>,
         override_expected_transient_boot_preference: Option<RotSlot>,
     },
+    // TODO-K: Remove once fully implemented
+    #[allow(dead_code)]
     RotBootloader {},
 }
 
@@ -112,8 +116,34 @@ impl UpdateDescription<'_> {
                     expected_inactive_version,
                 }
             }
-            // TODO-K: Do Rot
-            _ => unimplemented!(),
+            ExpectedSpComponent::Rot {
+                override_expected_active_slot,
+                override_expected_inactive_version,
+                override_expected_persistent_boot_preference,
+                override_expected_pending_persistent_boot_preference,
+                override_expected_transient_boot_preference,
+            } => {
+                let expected_active_slot = override_expected_active_slot
+                    .clone()
+                    .unwrap_or_else(|| sp1.expect_rot_active_slot());
+                // TODO-K: fill these out
+                let expected_inactive_version =
+                    override_expected_inactive_version.clone().unwrap();
+                let expected_persistent_boot_preference =
+                    override_expected_persistent_boot_preference.unwrap();
+                let expected_pending_persistent_boot_preference =
+                    *override_expected_pending_persistent_boot_preference;
+                let expected_transient_boot_preference =
+                    *override_expected_transient_boot_preference;
+                PendingMgsUpdateDetails::Rot {
+                    expected_active_slot,
+                    expected_inactive_version,
+                    expected_persistent_boot_preference,
+                    expected_pending_persistent_boot_preference,
+                    expected_transient_boot_preference,
+                }
+            }
+            ExpectedSpComponent::RotBootloader {} => unimplemented!(),
         };
 
         let deployed_caboose = self

--- a/nexus/mgs-updates/src/test_util/updates.rs
+++ b/nexus/mgs-updates/src/test_util/updates.rs
@@ -125,16 +125,25 @@ impl UpdateDescription<'_> {
             } => {
                 let expected_active_slot = override_expected_active_slot
                     .clone()
-                    .unwrap_or_else(|| sp1.expect_rot_active_slot());
-                // TODO-K: fill these out
+                    .unwrap_or_else(|| sp1.expected_active_rot_slot());
                 let expected_inactive_version =
-                    override_expected_inactive_version.clone().unwrap();
+                    override_expected_inactive_version
+                        .clone()
+                        .unwrap_or_else(|| sp1.expect_rot_inactive_version());
                 let expected_persistent_boot_preference =
-                    override_expected_persistent_boot_preference.unwrap();
+                    override_expected_persistent_boot_preference
+                        .unwrap_or_else(|| {
+                            sp1.expect_rot_persistent_boot_preference()
+                        });
                 let expected_pending_persistent_boot_preference =
-                    *override_expected_pending_persistent_boot_preference;
+                    override_expected_pending_persistent_boot_preference
+                        .or_else(|| {
+                            sp1.expect_rot_pending_persistent_boot_preference()
+                        });
                 let expected_transient_boot_preference =
-                    *override_expected_transient_boot_preference;
+                    override_expected_transient_boot_preference
+                        .or_else(|| sp1.expect_rot_transient_boot_preference());
+
                 PendingMgsUpdateDetails::Rot {
                     expected_active_slot,
                     expected_inactive_version,

--- a/nexus/mgs-updates/src/test_util/updates.rs
+++ b/nexus/mgs-updates/src/test_util/updates.rs
@@ -75,9 +75,8 @@ pub struct UpdateDescription<'a> {
     // If `None`, the correct value is determined automatically.  These are
     // overridable in order to induce specific kinds of failures.
     pub override_baseboard_id: Option<BaseboardId>,
-    // TODO-K: change description "Overrides" above
-    pub expected_sp_component: ExpectedSpComponent,
     pub override_progress_timeout: Option<Duration>,
+    pub override_expected_sp_component: ExpectedSpComponent,
 }
 
 impl UpdateDescription<'_> {
@@ -100,7 +99,7 @@ impl UpdateDescription<'_> {
                 .unwrap_or_else(|| sp1.baseboard_id()),
         );
 
-        let details = match &self.expected_sp_component {
+        let details = match &self.override_expected_sp_component {
             ExpectedSpComponent::Sp {
                 override_expected_active,
                 override_expected_inactive,


### PR DESCRIPTION
This commit adapts the current code to have the capability to test any component that is update-able by the MGS updater, not just SPs. Additionally, I have added tests for RoT updates