### PR TITLE
[sled-agent-config-reconciler] Report orphaned datasets (PR 1/2)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -11754,6 +11754,7 @@ dependencies = [
  "futures",
  "glob",
  "id-map",
+ "iddqd",
  "illumos-utils",
  "key-manager",
  "nexus-sled-agent-shared",

--- a/common/Cargo.toml
+++ b/common/Cargo.toml
@@ -59,8 +59,10 @@ tufaceous-artifact.workspace = true
 camino-tempfile.workspace = true
 expectorate.workspace = true
 libc.workspace = true
+proptest.workspace = true
 regress.workspace = true
 serde_urlencoded.workspace = true
+test-strategy.workspace = true
 tokio = { workspace = true, features = ["test-util"] }
 toml.workspace = true
 

--- a/common/src/api/internal/shared.rs
+++ b/common/src/api/internal/shared.rs
@@ -942,8 +942,6 @@ pub enum DatasetKind {
 
     // Other datasets
     Debug,
-    // Stores update artifacts (the "TUF Repo Depot")
-    Update,
 }
 
 impl Serialize for DatasetKind {
@@ -1004,7 +1002,7 @@ impl DatasetKind {
         match self {
             Cockroach | Crucible | Clickhouse | ClickhouseKeeper
             | ClickhouseServer | ExternalDns | InternalDns => true,
-            TransientZoneRoot | TransientZone { .. } | Debug | Update => false,
+            TransientZoneRoot | TransientZone { .. } | Debug => false,
         }
     }
 
@@ -1042,7 +1040,6 @@ impl fmt::Display for DatasetKind {
                 return Ok(());
             }
             Debug => "debug",
-            Update => "update",
         };
         write!(f, "{}", s)
     }
@@ -1069,7 +1066,6 @@ impl FromStr for DatasetKind {
             "internal_dns" => InternalDns,
             "zone" => TransientZoneRoot,
             "debug" => Debug,
-            "update" => Update,
             other => {
                 if let Some(name) = other.strip_prefix("zone/") {
                     TransientZone { name: name.to_string() }
@@ -1165,7 +1161,6 @@ mod tests {
             DatasetKind::TransientZoneRoot,
             DatasetKind::TransientZone { name: String::from("myzone") },
             DatasetKind::Debug,
-            DatasetKind::Update,
         ];
 
         assert_eq!(kinds.len(), DatasetKind::COUNT);

--- a/common/src/api/internal/shared.rs
+++ b/common/src/api/internal/shared.rs
@@ -920,7 +920,7 @@ pub struct ExternalIpGatewayMap {
 #[derive(
     Debug, Clone, PartialEq, Eq, Ord, PartialOrd, Hash, EnumCount, Diffable,
 )]
-#[cfg_attr(feature = "testing", derive(test_strategy::Arbitrary))]
+#[cfg_attr(any(test, feature = "testing"), derive(test_strategy::Arbitrary))]
 pub enum DatasetKind {
     // Durable datasets for zones
     Cockroach,

--- a/common/src/disk.rs
+++ b/common/src/disk.rs
@@ -17,6 +17,7 @@ use std::collections::BTreeMap;
 use std::fmt;
 use std::str::FromStr;
 
+use crate::api::internal::shared::DatasetKindParseError;
 use crate::{
     api::external::{ByteCount, Generation},
     ledger::Ledgerable,
@@ -169,6 +170,69 @@ impl DatasetName {
 
     fn full_unencrypted_name(&self) -> String {
         format!("{}/{}", self.pool_name, self.kind)
+    }
+}
+
+#[derive(Debug, thiserror::Error)]
+pub enum DatasetNameParseError {
+    #[error("missing '/' separator in dataset name {0}")]
+    MissingSlash(String),
+    #[error("could not parse zpool name {zpool}: {err}")]
+    ParseZpoolName { zpool: String, err: String },
+    #[error("could not parse dataset kind {kind}")]
+    ParseDatasetKind {
+        kind: String,
+        #[source]
+        err: DatasetKindParseError,
+    },
+    #[error("expected `crypt/` for kind {kind:?} in dataset name {name}")]
+    MissingCryptInName { kind: DatasetKind, name: String },
+    #[error("unexpected `crypt/` for kind {kind:?} in dataset name {name}")]
+    UnexpectedCryptInName { kind: DatasetKind, name: String },
+}
+
+impl FromStr for DatasetName {
+    type Err = DatasetNameParseError;
+
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        let (pool_name, remainder) = s.split_once('/').ok_or_else(|| {
+            DatasetNameParseError::MissingSlash(s.to_string())
+        })?;
+
+        let pool_name = ZpoolName::from_str(pool_name).map_err(|err| {
+            DatasetNameParseError::ParseZpoolName {
+                zpool: pool_name.to_string(),
+                err,
+            }
+        })?;
+
+        let (kind_str, name_has_crypt) =
+            if let Some(remainder) = remainder.strip_prefix("crypt/") {
+                (remainder, true)
+            } else {
+                (remainder, false)
+            };
+
+        let kind = DatasetKind::from_str(kind_str).map_err(|err| {
+            DatasetNameParseError::ParseDatasetKind {
+                kind: kind_str.to_string(),
+                err,
+            }
+        })?;
+
+        match (kind.dataset_should_be_encrypted(), name_has_crypt) {
+            (true, true) | (false, false) => Ok(Self { pool_name, kind }),
+            (true, false) => Err(DatasetNameParseError::MissingCryptInName {
+                kind,
+                name: s.to_string(),
+            }),
+            (false, true) => {
+                Err(DatasetNameParseError::UnexpectedCryptInName {
+                    kind,
+                    name: s.to_string(),
+                })
+            }
+        }
     }
 }
 
@@ -580,6 +644,27 @@ impl TryFrom<i64> for M2Slot {
             17 => Ok(Self::A),
             18 => Ok(Self::B),
             _ => bail!("unexpected M.2 slot {value}"),
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use test_strategy::proptest;
+
+    #[proptest]
+    fn parse_dataset_name(pool_id: [u8; 16], kind: DatasetKind) {
+        let pool_id = ZpoolUuid::from_bytes(pool_id);
+        for pool in
+            [ZpoolName::new_internal(pool_id), ZpoolName::new_external(pool_id)]
+        {
+            let dataset_name = DatasetName::new(pool, kind.clone());
+            let s = dataset_name.full_name();
+            match DatasetName::from_str(&s) {
+                Ok(d) => assert_eq!(d, dataset_name),
+                Err(err) => panic!("failed to parse dataset name {s}: {err}"),
+            }
         }
     }
 }

--- a/illumos-utils/src/zfs.rs
+++ b/illumos-utils/src/zfs.rs
@@ -4,7 +4,6 @@
 
 //! Utilities for poking at ZFS.
 
-use crate::ExecutionError;
 use crate::{PFEXEC, execute_async};
 use anyhow::Context;
 use anyhow::anyhow;
@@ -18,7 +17,6 @@ use omicron_common::disk::DiskIdentity;
 use omicron_common::disk::SharedDatasetConfig;
 use omicron_uuid_kinds::DatasetUuid;
 use std::collections::BTreeMap;
-use std::ffi::OsStr;
 use std::fmt;
 
 use tokio::process::Command;
@@ -854,29 +852,6 @@ impl Zfs {
             })
             .collect();
         Ok(filesystems)
-    }
-
-    /// Lists all datasets within a set of parent filesystems.
-    ///
-    /// Unlike [`Zfs::list_datasets()`], this method does _not_ strip the input
-    /// names from the output names: assuming the input filesystems exist, the
-    /// output list will contain each requested filesystem itself, and will
-    /// include the full names of all direct children.
-    pub async fn list_datasets_full<I, S>(
-        names: I,
-    ) -> Result<Vec<String>, ExecutionError>
-    where
-        I: IntoIterator<Item = S>,
-        S: AsRef<OsStr>,
-    {
-        let output = execute_async(
-            Command::new(ZFS)
-                .args(&["list", "-d", "1", "-Hpo", "name"])
-                .args(names),
-        )
-        .await?;
-        let stdout = String::from_utf8_lossy(&output.stdout);
-        Ok(stdout.trim().split('\n').map(String::from).collect())
     }
 
     /// Get information about datasets within a list of zpools / datasets.

--- a/nexus/db-model/src/dataset_kind.rs
+++ b/nexus/db-model/src/dataset_kind.rs
@@ -46,12 +46,20 @@ impl DatasetKind {
                 ApiKind::TransientZone { name }
             }
             (Self::Debug, None) => ApiKind::Debug,
-            (Self::Update, None) => ApiKind::Update,
             (Self::TransientZone, None) => {
                 return Err(Error::internal_error("Zone kind needs name"));
             }
             (_, Some(_)) => {
                 return Err(Error::internal_error("Only zone kind needs name"));
+            }
+            // TODO-cleanup We should remove `Self::Update` entirely, but that's
+            // a lot of work for not a lot of gain, so we filed that away for
+            // our future selves as
+            // https://github.com/oxidecomputer/omicron/issues/8268.
+            (Self::Update, None) => {
+                return Err(Error::internal_error(
+                    "Unexpected `update` dataset kind",
+                ));
             }
         };
 
@@ -90,7 +98,6 @@ impl From<&internal::shared::DatasetKind> for DatasetKind {
                 DatasetKind::TransientZone
             }
             internal::shared::DatasetKind::Debug => DatasetKind::Debug,
-            internal::shared::DatasetKind::Update => DatasetKind::Update,
         }
     }
 }

--- a/nexus/reconfigurator/blippy/src/blippy.rs
+++ b/nexus/reconfigurator/blippy/src/blippy.rs
@@ -337,9 +337,9 @@ impl fmt::Display for SledKind {
                     | DatasetKind::ExternalDns
                     | DatasetKind::InternalDns
                     | DatasetKind::TransientZone { .. } => "zone",
-                    DatasetKind::TransientZoneRoot
-                    | DatasetKind::Debug
-                    | DatasetKind::Update => "disk",
+                    DatasetKind::TransientZoneRoot | DatasetKind::Debug => {
+                        "disk"
+                    }
                 };
                 write!(
                     f,

--- a/schema/crdb/dbinit.sql
+++ b/schema/crdb/dbinit.sql
@@ -604,6 +604,8 @@ CREATE INDEX IF NOT EXISTS lookup_zpool_by_disk on omicron.public.zpool (
     id
 ) WHERE physical_disk_id IS NOT NULL AND time_deleted IS NULL;
 
+-- TODO-cleanup If modifying this enum, please remove 'update'; see
+-- https://github.com/oxidecomputer/omicron/issues/8268.
 CREATE TYPE IF NOT EXISTS omicron.public.dataset_kind AS ENUM (
   'crucible',
   'cockroach',

--- a/sled-agent/config-reconciler/Cargo.toml
+++ b/sled-agent/config-reconciler/Cargo.toml
@@ -20,6 +20,7 @@ either.workspace = true
 futures.workspace = true
 glob.workspace = true
 id-map.workspace = true
+iddqd.workspace = true
 illumos-utils.workspace = true
 key-manager.workspace = true
 nexus-sled-agent-shared.workspace = true

--- a/sled-agent/config-reconciler/Cargo.toml
+++ b/sled-agent/config-reconciler/Cargo.toml
@@ -43,6 +43,7 @@ omicron-workspace-hack.workspace = true
 assert_matches.workspace = true
 expectorate.workspace = true
 illumos-utils = { workspace = true, features = ["testing"] }
+omicron-common = { workspace = true, features = ["testing"] }
 omicron-test-utils.workspace = true
 proptest.workspace = true
 schemars.workspace = true

--- a/sled-agent/config-reconciler/src/dataset_serialization_task.rs
+++ b/sled-agent/config-reconciler/src/dataset_serialization_task.rs
@@ -493,8 +493,7 @@ impl DatasetTask {
                 | DatasetKind::ClickhouseServer
                 | DatasetKind::ExternalDns
                 | DatasetKind::InternalDns
-                | DatasetKind::Debug
-                | DatasetKind::Update => {
+                | DatasetKind::Debug => {
                     non_transient_zone_configs.push(dataset);
                 }
             }

--- a/sled-agent/config-reconciler/src/dataset_serialization_task.rs
+++ b/sled-agent/config-reconciler/src/dataset_serialization_task.rs
@@ -30,6 +30,7 @@ use illumos_utils::zfs::Mountpoint;
 use illumos_utils::zfs::WhichDatasets;
 use illumos_utils::zfs::Zfs;
 use nexus_sled_agent_shared::inventory::InventoryDataset;
+use omicron_common::api::external::ByteCount;
 use omicron_common::disk::DatasetConfig;
 use omicron_common::disk::DatasetKind;
 use omicron_common::disk::DatasetName;
@@ -96,6 +97,10 @@ pub enum DatasetEnsureError {
 pub struct OrphanedDataset {
     pub name: DatasetName,
     pub reason: String,
+    pub id: Option<DatasetUuid>,
+    pub mounted: bool,
+    pub avail: ByteCount,
+    pub used: ByteCount,
 }
 
 impl IdOrdItem for OrphanedDataset {
@@ -570,8 +575,14 @@ impl DatasetTask {
                 }
             };
 
-            orphaned_datasets
-                .insert_overwrite(OrphanedDataset { name: dataset, reason });
+            orphaned_datasets.insert_overwrite(OrphanedDataset {
+                name: dataset,
+                reason,
+                id: properties.id,
+                mounted: properties.mounted,
+                avail: properties.avail,
+                used: properties.used,
+            });
         }
 
         Ok(orphaned_datasets)

--- a/sled-agent/config-reconciler/src/handle.rs
+++ b/sled-agent/config-reconciler/src/handle.rs
@@ -149,7 +149,6 @@ impl ConfigReconcilerHandle {
         // Spawn the task that serializes dataset operations.
         let dataset_task = DatasetTaskHandle::spawn_dataset_task(
             Arc::clone(&mount_config),
-            currently_managed_zpools_rx.clone(),
             base_log,
         );
 

--- a/sled-agent/config-reconciler/src/reconciler_task.rs
+++ b/sled-agent/config-reconciler/src/reconciler_task.rs
@@ -440,7 +440,11 @@ impl ReconcilerTask {
 
         // Ensure all the datasets we want exist.
         self.datasets
-            .ensure_datasets_if_needed(sled_config.datasets.clone(), &self.log)
+            .ensure_datasets_if_needed(
+                sled_config.datasets.clone(),
+                self.external_disks.currently_managed_zpools(),
+                &self.log,
+            )
             .await;
 
         // Collect the current timesync status (needed to start any new zones,

--- a/sled-agent/config-reconciler/src/reconciler_task.rs
+++ b/sled-agent/config-reconciler/src/reconciler_task.rs
@@ -34,9 +34,9 @@ use std::time::Duration;
 use std::time::Instant;
 use tokio::sync::watch;
 
-use crate::dataset_serialization_task::OrphanedDataset;
 use crate::TimeSyncConfig;
 use crate::dataset_serialization_task::DatasetTaskHandle;
+use crate::dataset_serialization_task::OrphanedDataset;
 use crate::ledger::CurrentSledConfig;
 use crate::raw_disks::RawDisksReceiver;
 use crate::sled_agent_facilities::SledAgentFacilities;

--- a/sled-agent/config-reconciler/src/reconciler_task.rs
+++ b/sled-agent/config-reconciler/src/reconciler_task.rs
@@ -8,6 +8,7 @@ use chrono::DateTime;
 use chrono::Utc;
 use either::Either;
 use futures::future;
+use iddqd::IdOrdMap;
 use illumos_utils::zpool::PathInPool;
 use illumos_utils::zpool::ZpoolOrRamdisk;
 use key_manager::StorageKeyRequester;
@@ -16,7 +17,6 @@ use nexus_sled_agent_shared::inventory::ConfigReconcilerInventoryResult;
 use nexus_sled_agent_shared::inventory::ConfigReconcilerInventoryStatus;
 use nexus_sled_agent_shared::inventory::OmicronSledConfig;
 use omicron_common::disk::DatasetKind;
-use omicron_common::disk::DatasetName;
 use omicron_uuid_kinds::DatasetUuid;
 use omicron_uuid_kinds::OmicronZoneUuid;
 use omicron_uuid_kinds::PhysicalDiskUuid;
@@ -28,13 +28,13 @@ use slog::Logger;
 use slog::info;
 use slog::warn;
 use std::collections::BTreeMap;
-use std::collections::BTreeSet;
 use std::collections::HashSet;
 use std::sync::Arc;
 use std::time::Duration;
 use std::time::Instant;
 use tokio::sync::watch;
 
+use crate::dataset_serialization_task::OrphanedDataset;
 use crate::TimeSyncConfig;
 use crate::dataset_serialization_task::DatasetTaskHandle;
 use crate::ledger::CurrentSledConfig;
@@ -199,7 +199,7 @@ struct LatestReconciliationResult {
     external_disks_inventory:
         BTreeMap<PhysicalDiskUuid, ConfigReconcilerInventoryResult>,
     datasets: BTreeMap<DatasetUuid, ConfigReconcilerInventoryResult>,
-    orphaned_datasets: BTreeSet<DatasetName>,
+    orphaned_datasets: IdOrdMap<OrphanedDataset>,
     zones_inventory: BTreeMap<OmicronZoneUuid, ConfigReconcilerInventoryResult>,
     timesync_status: TimeSyncStatus,
 }

--- a/sled-agent/config-reconciler/src/reconciler_task/datasets.rs
+++ b/sled-agent/config-reconciler/src/reconciler_task/datasets.rs
@@ -71,7 +71,7 @@ impl OmicronDatasets {
                 },
             })
             .collect();
-        Self { datasets, orphaned_datasets: BTreeSet::new(), dataset_task }
+        Self { datasets, orphaned_datasets: IdOrdMap::new(), dataset_task }
     }
 
     pub(super) fn new(dataset_task: DatasetTaskHandle) -> Self {
@@ -192,10 +192,7 @@ impl OmicronDatasets {
         // eventually _remove_ orphaned datasets instead of reporting them.
         match self
             .dataset_task
-            .datasets_report_orphans(
-                datasets.iter().map(|d| d.name.clone()).collect(),
-                currently_managed_zpools,
-            )
+            .datasets_report_orphans(datasets.clone(), currently_managed_zpools)
             .await
         {
             Ok(Ok(orphaned)) => {

--- a/sled-agent/config-reconciler/src/reconciler_task/datasets.rs
+++ b/sled-agent/config-reconciler/src/reconciler_task/datasets.rs
@@ -11,6 +11,7 @@
 //! operations" consumers (e.g., inventory requests perform operations to check
 //! the live state of datasets directly from ZFS).
 
+use super::CurrentlyManagedZpools;
 use crate::dataset_serialization_task::DatasetEnsureError;
 use crate::dataset_serialization_task::DatasetEnsureResult;
 use crate::dataset_serialization_task::DatasetTaskHandle;
@@ -171,9 +172,14 @@ impl OmicronDatasets {
     pub(super) async fn ensure_datasets_if_needed(
         &mut self,
         datasets: IdMap<DatasetConfig>,
+        currently_managed_zpools: Arc<CurrentlyManagedZpools>,
         log: &Logger,
     ) {
-        let results = match self.dataset_task.datasets_ensure(datasets).await {
+        let results = match self
+            .dataset_task
+            .datasets_ensure(datasets, currently_managed_zpools)
+            .await
+        {
             Ok(results) => results,
             Err(err) => {
                 // If we can't contact the dataset task, we leave

--- a/sled-agent/config-reconciler/src/reconciler_task/external_disks.rs
+++ b/sled-agent/config-reconciler/src/reconciler_task/external_disks.rs
@@ -63,10 +63,12 @@ impl CurrentlyManagedZpools {
 
     /// Within this crate, directly expose the set of zpools.
     ///
-    /// We should remove this once we clean up zone starting; starting a zone
-    /// should already know where to place datasets.
-    pub(crate) fn into_vec(self) -> Vec<ZpoolName> {
-        self.0.into_iter().collect()
+    /// We never use this to "pick a zpool to use" (any choosing should be
+    /// picking _datasets_, not zpools). We use it when we need to know all the
+    /// zpools we have to scan for something (e.g., orphaned datasets to
+    /// delete).
+    pub(crate) fn iter(&self) -> impl Iterator<Item = ZpoolName> + '_ {
+        self.0.iter().copied()
     }
 }
 


### PR DESCRIPTION
During a config reconciliation pass, when we ought to delete datasets (but don't yet - #6177), we now run a `zfs get ...` and attempt to scan for datasets we _ought_ to delete. These are accumulated into an in-memory set that will be reportable via inventory (coming in the subsequent PR).