### PR TITLE
`&str`-based `FromSql` impls for firewall/route types

### DIFF
--- a/nexus/db-model/src/role_assignment.rs
+++ b/nexus/db-model/src/role_assignment.rs
@@ -118,6 +118,7 @@ where
 mod tests {
     use super::*;
     use omicron_common::api::external::ResourceType;
+    use std::borrow::Cow;
 
     #[derive(Clone, Copy, Debug, Deserialize, Eq, PartialEq)]
     #[serde(rename_all = "kebab-case")]
@@ -128,7 +129,7 @@ mod tests {
     impl crate::DatabaseString for DummyRoles {
         type Error = anyhow::Error;
 
-        fn to_database_string(&self) -> &str {
+        fn to_database_string(&self) -> Cow<str> {
             unimplemented!()
         }
 

--- a/nexus/db-model/src/vpc_firewall_rule.rs
+++ b/nexus/db-model/src/vpc_firewall_rule.rs
@@ -2,7 +2,9 @@
 // License, v. 2.0. If a copy of the MPL was not distributed with this
 // file, You can obtain one at https://mozilla.org/MPL/2.0/.
 
-use super::{L4PortRange, SqlU16, impl_enum_wrapper};
+use super::{
+    DatabaseString, L4PortRange, SqlU16, impl_enum_wrapper, impl_from_sql_text,
+};
 use db_macros::Resource;
 use diesel::backend::Backend;
 use diesel::deserialize::{self, FromSql};
@@ -14,8 +16,10 @@ use nexus_types::identity::Resource;
 use omicron_common::api::external;
 use serde::Deserialize;
 use serde::Serialize;
+use std::borrow::Cow;
 use std::collections::HashSet;
 use std::io::Write;
+use std::str::FromStr;
 use uuid::Uuid;
 
 impl_enum_wrapper!(
@@ -76,31 +80,19 @@ pub struct VpcFirewallRuleTarget(pub external::VpcFirewallRuleTarget);
 NewtypeFrom! { () pub struct VpcFirewallRuleTarget(external::VpcFirewallRuleTarget); }
 NewtypeDeref! { () pub struct VpcFirewallRuleTarget(external::VpcFirewallRuleTarget); }
 
-impl ToSql<sql_types::Text, Pg> for VpcFirewallRuleTarget {
-    fn to_sql<'a>(
-        &'a self,
-        out: &mut serialize::Output<'a, '_, Pg>,
-    ) -> serialize::Result {
-        <String as ToSql<sql_types::Text, Pg>>::to_sql(
-            &self.0.to_string(),
-            &mut out.reborrow(),
-        )
+impl DatabaseString for VpcFirewallRuleTarget {
+    type Error = <external::VpcFirewallRuleTarget as FromStr>::Err;
+
+    fn to_database_string(&self) -> Cow<str> {
+        self.0.to_string().into()
+    }
+
+    fn from_database_string(s: &str) -> Result<Self, Self::Error> {
+        s.parse::<external::VpcFirewallRuleTarget>().map(Self)
     }
 }
 
-// Deserialize the "VpcFirewallRuleTarget" object from SQL TEXT.
-impl<DB> FromSql<sql_types::Text, DB> for VpcFirewallRuleTarget
-where
-    DB: Backend,
-    String: FromSql<sql_types::Text, DB>,
-{
-    fn from_sql(bytes: DB::RawValue<'_>) -> deserialize::Result<Self> {
-        Ok(VpcFirewallRuleTarget(
-            String::from_sql(bytes)?
-                .parse::<external::VpcFirewallRuleTarget>()?,
-        ))
-    }
-}
+impl_from_sql_text!(VpcFirewallRuleTarget);
 
 /// Newtype wrapper around [`external::VpcFirewallRuleHostFilter`] so we can derive
 /// diesel traits for it
@@ -111,31 +103,19 @@ pub struct VpcFirewallRuleHostFilter(pub external::VpcFirewallRuleHostFilter);
 NewtypeFrom! { () pub struct VpcFirewallRuleHostFilter(external::VpcFirewallRuleHostFilter); }
 NewtypeDeref! { () pub struct VpcFirewallRuleHostFilter(external::VpcFirewallRuleHostFilter); }
 
-impl ToSql<sql_types::Text, Pg> for VpcFirewallRuleHostFilter {
-    fn to_sql<'a>(
-        &'a self,
-        out: &mut serialize::Output<'a, '_, Pg>,
-    ) -> serialize::Result {
-        <String as ToSql<sql_types::Text, Pg>>::to_sql(
-            &self.0.to_string(),
-            &mut out.reborrow(),
-        )
+impl DatabaseString for VpcFirewallRuleHostFilter {
+    type Error = <external::VpcFirewallRuleHostFilter as FromStr>::Err;
+
+    fn to_database_string(&self) -> Cow<str> {
+        self.0.to_string().into()
+    }
+
+    fn from_database_string(s: &str) -> Result<Self, Self::Error> {
+        s.parse::<external::VpcFirewallRuleHostFilter>().map(Self)
     }
 }
 
-// Deserialize the "VpcFirewallRuleHostFilter" object from SQL TEXT.
-impl<DB> FromSql<sql_types::Text, DB> for VpcFirewallRuleHostFilter
-where
-    DB: Backend,
-    String: FromSql<sql_types::Text, DB>,
-{
-    fn from_sql(bytes: DB::RawValue<'_>) -> deserialize::Result<Self> {
-        Ok(VpcFirewallRuleHostFilter(
-            String::from_sql(bytes)?
-                .parse::<external::VpcFirewallRuleHostFilter>()?,
-        ))
-    }
-}
+impl_from_sql_text!(VpcFirewallRuleHostFilter);
 
 /// Newtype wrapper around [`external::VpcFirewallRulePriority`] so we can derive
 /// diesel traits for it

--- a/nexus/tests/integration_tests/role_assignments.rs
+++ b/nexus/tests/integration_tests/role_assignments.rs
@@ -467,10 +467,10 @@ async fn run_test<T: RoleAssignmentTest>(
             .parsed_body()
             .unwrap();
     new_policy.role_assignments.sort_by_key(|r| {
-        (r.identity_id, r.role_name.to_database_string().to_owned())
+        (r.identity_id, r.role_name.to_database_string().into_owned())
     });
     updated_policy.role_assignments.sort_by_key(|r| {
-        (r.identity_id, r.role_name.to_database_string().to_owned())
+        (r.identity_id, r.role_name.to_database_string().into_owned())
     });
     assert_eq!(updated_policy, new_policy);
 


### PR DESCRIPTION
A few types (target & filter specifications, ranges) associated with firewall rules and routes rely on a custom string-based representation in CRDB. However, when deserializing them today we end up cycling through `PgValue`->`String`->`ParsedEnumType`, needlessly allocating and copying strings per element. This PR prevents us from doing so by generating these `impl`s for any type which implements the existing `DatabaseString` trait.

While there are more types in `nexus-db-model` using `FromSql<Text, _>`, most seem to make use of a `String` internally regardless, so there's no immediate benefit (other than consistency) in changing them up at this time.

Motivated by some of the discussion in #8194.