### PR TITLE
Represent resolved firewall `filter_hosts` as a `HashSet`

### DIFF
--- a/clients/sled-agent-client/src/lib.rs
+++ b/clients/sled-agent-client/src/lib.rs
@@ -75,6 +75,7 @@ progenitor::generate_api!(
         PortFec = omicron_common::api::internal::shared::PortFec,
         PortSpeed = omicron_common::api::internal::shared::PortSpeed,
         RouterId = omicron_common::api::internal::shared::RouterId,
+        ResolvedVpcFirewallRule = omicron_common::api::internal::shared::ResolvedVpcFirewallRule,
         ResolvedVpcRoute = omicron_common::api::internal::shared::ResolvedVpcRoute,
         ResolvedVpcRouteSet = omicron_common::api::internal::shared::ResolvedVpcRouteSet,
         RouterTarget = omicron_common::api::internal::shared::RouterTarget,

--- a/common/src/api/internal/nexus.rs
+++ b/common/src/api/internal/nexus.rs
@@ -241,7 +241,9 @@ pub struct ProducerRegistrationResponse {
 /// A `HostIdentifier` represents either an IP host or network (v4 or v6),
 /// or an entire VPC (identified by its VNI). It is used in firewall rule
 /// host filters.
-#[derive(Clone, Debug, Deserialize, Serialize, PartialEq, JsonSchema)]
+#[derive(
+    Clone, Debug, Deserialize, Serialize, Eq, PartialEq, Hash, JsonSchema,
+)]
 #[serde(tag = "type", content = "value", rename_all = "snake_case")]
 pub enum HostIdentifier {
     Ip(oxnet::IpNet),

--- a/common/src/api/internal/shared.rs
+++ b/common/src/api/internal/shared.rs
@@ -784,12 +784,12 @@ pub struct ResolvedVpcRoute {
 }
 
 /// VPC firewall rule after object name resolution has been performed by Nexus
-#[derive(Clone, Debug, Serialize, Deserialize, JsonSchema)]
+#[derive(Clone, Debug, Serialize, Deserialize, PartialEq, JsonSchema)]
 pub struct ResolvedVpcFirewallRule {
     pub status: external::VpcFirewallRuleStatus,
     pub direction: external::VpcFirewallRuleDirection,
     pub targets: Vec<NetworkInterface>,
-    pub filter_hosts: Option<Vec<HostIdentifier>>,
+    pub filter_hosts: Option<HashSet<HostIdentifier>>,
     pub filter_ports: Option<Vec<external::L4PortRange>>,
     pub filter_protocols: Option<Vec<external::VpcFirewallRuleProtocol>>,
     pub action: external::VpcFirewallRuleAction,

--- a/nexus/src/app/vpc.rs
+++ b/nexus/src/app/vpc.rs
@@ -26,6 +26,7 @@ use omicron_common::api::external::NameOrId;
 use omicron_common::api::external::UpdateResult;
 use omicron_common::api::external::VpcFirewallRuleUpdateParams;
 use omicron_common::api::external::http_pagination::PaginatedBy;
+use omicron_common::api::internal::shared::ResolvedVpcFirewallRule;
 use std::sync::Arc;
 use uuid::Uuid;
 
@@ -261,8 +262,7 @@ impl super::Nexus {
         opctx: &OpContext,
         vpc: &db::model::Vpc,
         rules: &[db::model::VpcFirewallRule],
-    ) -> Result<Vec<sled_agent_client::types::ResolvedVpcFirewallRule>, Error>
-    {
+    ) -> Result<Vec<ResolvedVpcFirewallRule>, Error> {
         nexus_networking::resolve_firewall_rules_for_sled_agent(
             &self.db_datastore,
             opctx,

--- a/openapi/sled-agent.json
+++ b/openapi/sled-agent.json
@@ -6198,7 +6198,8 @@
             "type": "array",
             "items": {
               "$ref": "#/components/schemas/HostIdentifier"
-            }
+            },
+            "uniqueItems": true
           },
           "filter_ports": {
             "nullable": true,


### PR DESCRIPTION
Previously, we have been adding one `filter_host` entry for *every NIC* in the VPC when using a `VpcFirewallRuleHostFilter::Vpc(...)`. This PR fixes this in two ways:

* We no longer linear-scan the NIC list to attempt to resolve `vpc_name`->`Vni` mappings per rule. We build a `HashMap` of these early on.
* `filter_hosts` is now encoded as a `HashSet` in nexus and sled-agent, which ensures this property holds even under users' attempts to introduce duplicate host specifiers.

Closes #8305.