### PR TITLE
use blueprint comments for update-related steps

### DIFF
--- a/nexus/reconfigurator/planning/src/planner.rs
+++ b/nexus/reconfigurator/planning/src/planner.rs
@@ -996,7 +996,7 @@ impl<'a> Planner<'a> {
                         "image_source" => %image_source,
                     );
                     self.blueprint.comment(format!(
-                        "upgrade {:?} zone {} in-place",
+                        "updating {:?} zone {} in-place",
                         zone.zone_type.kind(),
                         zone.id
                     ));
@@ -1020,7 +1020,7 @@ impl<'a> Planner<'a> {
                         "kind" => ?zone.zone_type.kind(),
                     );
                     self.blueprint.comment(format!(
-                        "expunge {:?} zone {} for upgrade",
+                        "expunge {:?} zone {} for update",
                         zone.zone_type.kind(),
                         zone.id
                     ));


### PR DESCRIPTION
I hope this will make the `omdb reconfigurator history` output for an upgrade a little more informative.

I haven't tested this much yet, but I do believe it's super low risk.