### PR TITLE
ls-apis: mention related RFDs and sections

### DIFF
--- a/dev-tools/ls-apis/README.adoc
+++ b/dev-tools/ls-apis/README.adoc
@@ -95,7 +95,7 @@ Crucible Pantry
 The `servers` and `deployment-units` commands accept a `--dot` argument to print output in a format that `dot(1)` can process:
 
 ```
-$ cargo xtask ls-apis deployment-units --dot > deployment-units.dot
+$ cargo xtask ls-apis deployment-units --output-format dot > deployment-units.dot
 ```
 
 You can generate a PNG image of the graph like this:

--- a/dev-tools/ls-apis/api-manifest.toml
+++ b/dev-tools/ls-apis/api-manifest.toml
@@ -149,6 +149,13 @@ packages = [ "oximeter-collector" ]
 #              tooling supports this value so that during development you can
 #              relax these constraints.
 #
+# "server" and "client" versioning is elaborated on more in RFD 532.  Note that
+# "lockstep" collapses into "server" here, as it's trivially the case that if
+# the server and client(s) are updated atomically the server does not have to
+# support older clients.  Additionally, the "updated before" relationship is
+# discussed some in RFD 565, [Update
+# sequence](https://rfd.shared.oxide.computer/rfd/0565#_update_sequence).
+#
 # [`versioned_how_reason`]: free text string explaining why `versioned_how` must
 # be "client" for this API.  This is printed in documentation and command output
 # and serves as documentation for developers to understand why we made this


### PR DESCRIPTION
i think my confusion about "is `dns-server-api` client-versioned or server-versioned" in [this rev](https://github.com/oxidecomputer/omicron/commit/b5f2efb3329adf43d46588ea46741f84f5135b4d) of #8322 came from both not quite understanding the relationship between `versioned_how` in `api-manifest.toml`, versions as described in `openapi-manager`, and RFD 532. i think this helps clarify the relationship, and mentioning 565 _might_ have helped clarify the "updated before" relationship.

i'm actually still not very sure i know how to determine if the DNS API is or is not server-managed. abstractly, it makes sense, but what i think i was hoping to find is a source of truth for what service must be updated before others as reconfigurator executes a blueprint. 565 talks about each component a bit more which helped me conceptualize "tiers" better (plenty familiar with DAGs, but the `dot` output was still hard to parse and i couldn't reason through "why"s)

really, the confusion i had was that i wasn't sure if `api-manifest.toml` incorrectly modeled service update dependencies, or if i'd misunderstood the model. so i'd tried reasoning through "can there be an old DNS client with a new DNS server" and got that wrong. maybe what i'd have needed was more like the source of truth about the order services are updated? i'm not sure if my confusion makes sense, even.

maybe the question i'm trying to ask is: "is `versioned_how` prescriptive or descriptive?" i think it is descriptive, and i was trying to find a prescriptive answer to check it against.