### PR TITLE
[reconfigurator] rot-bootloader subcommand for reconfigurator-sp-updater

### DIFF
--- a/dev-tools/reconfigurator-sp-updater/src/main.rs
+++ b/dev-tools/reconfigurator-sp-updater/src/main.rs
@@ -422,10 +422,10 @@ enum Component {
         expected_transient_boot_preference: Option<RotSlot>,
     },
     RotBootloader {
-        /// expected version of the active slot
+        /// expected version of stage0 (active slot)
         #[arg(long, short = 'a')]
         expected_stage0_version: ArtifactVersion,
-        /// expected version of the inactive slot
+        /// expected version of stage0 next (inactive slot)
         #[arg(long, short = 'i')]
         expected_stage0_next_version: ExpectedVersion,
     },


### PR DESCRIPTION
This won't really do anything until https://github.com/oxidecomputer/omicron/pull/8325 is merged. But will be good having this around for performing manual tests,

```console
$ ./target/debug/reconfigurator-sp-updater --dns-server [::1]:47679 [::]:34643
Jun 13 01:13:02.664 INFO setting up resolver
Jun 13 01:13:02.664 INFO resolve MGS in DNS
Jun 13 01:13:02.720 INFO loaded inventory from MGS
Jun 13 01:13:02.720 INFO starting MgsUpdateDriver
〉help set
Configure an update

Usage: set <SERIAL> <ARTIFACT_HASH> <VERSION> <COMMAND>

Commands:
  sp              
  rot             
  rot-bootloader  
  help            Print this message or the help of the given subcommand(s)

Arguments:
  <SERIAL>         serial number to update
  <ARTIFACT_HASH>  artifact hash id
  <VERSION>        version

Options:
  -h, --help  Print help
〉help set rot-bootloader
Usage: set <SERIAL> <ARTIFACT_HASH> <VERSION> rot-bootloader --expected-stage0-version <EXPECTED_STAGE0_VERSION> --expected-stage0-next-version <EXPECTED_STAGE0_NEXT_VERSION>

Options:
  -a, --expected-stage0-version <EXPECTED_STAGE0_VERSION>            expected version of the active slot
  -i, --expected-stage0-next-version <EXPECTED_STAGE0_NEXT_VERSION>  expected version of the inactive slot
  -h, --help                                                         Print help
〉
```

Related: https://github.com/oxidecomputer/omicron/issues/7988