### PR TITLE
[blueprint-planner] Correct comment for added NTP zones

### DIFF
--- a/nexus/reconfigurator/planning/src/planner.rs
+++ b/nexus/reconfigurator/planning/src/planner.rs
@@ -518,7 +518,7 @@ impl<'a> Planner<'a> {
                 );
                 self.blueprint.record_operation(Operation::AddZone {
                     sled_id,
-                    kind: ZoneKind::BoundaryNtp,
+                    kind: ZoneKind::InternalNtp,
                 });
 
                 // If we're setting up a new sled (the typical reason to add a


### PR DESCRIPTION
This part of planning always adds internal NTP zones, not boundary NTP zones. (Noticed this thanks to the new `reconfigurator history` comments, which claimed we were adding a whole bunch of boundary NTP zones. It's just the comments that were wrong.)