### PR TITLE
Emit the expected operating saga id when a failure to update the operating saga id occurs

### DIFF
--- a/nexus/db-queries/src/db/datastore/region_replacement.rs
+++ b/nexus/db-queries/src/db/datastore/region_replacement.rs
@@ -220,10 +220,11 @@ impl DataStore {
                         Ok(())
                     } else {
                         Err(Error::conflict(format!(
-                            "region replacement {} set to {:?} (operating saga id {:?})",
+                            "region replacement {} set to {:?} (operating saga id {:?}) (expected operating saga id {:?})",
                             region_replacement_id,
                             record.replacement_state,
                             record.operating_saga_id,
+                            operating_saga_id,
                         )))
                     }
                 }
@@ -415,10 +416,11 @@ impl DataStore {
                         Ok(())
                     } else {
                         Err(Error::conflict(format!(
-                            "region replacement {} set to {:?} (operating saga id {:?})",
+                            "region replacement {} set to {:?} (operating saga id {:?}) (expected operating saga id {:?})",
                             region_replacement_id,
                             record.replacement_state,
                             record.operating_saga_id,
+                            operating_saga_id,
                         )))
                     }
                 }
@@ -618,10 +620,11 @@ impl DataStore {
                         Ok(())
                     } else {
                         Err(Error::conflict(format!(
-                            "region replacement {} set to {:?} (operating saga id {:?})",
+                            "region replacement {} set to {:?} (operating saga id {:?}) (expected operating saga id {:?})",
                             region_replacement_id,
                             record.replacement_state,
                             record.operating_saga_id,
+                            operating_saga_id,
                         )))
                     }
                 }


### PR DESCRIPTION
It would be helpful to verify what the saga was attempting to store as the operating saga id when reporting back the failure. This of course should always be the id stored in the saga context. Adding it to the error message here helps make that clear when looking at a saga's event history.