### PR TITLE
Trust Quorum: Better match protocol in TLA+ spec

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -13438,6 +13438,7 @@ dependencies = [
  "gfss",
  "hex",
  "hkdf",
+ "iddqd",
  "omicron-test-utils",
  "omicron-uuid-kinds",
  "omicron-workspace-hack",

--- a/trust-quorum/Cargo.toml
+++ b/trust-quorum/Cargo.toml
@@ -16,6 +16,7 @@ derive_more.workspace = true
 gfss.workspace = true
 hex.workspace = true
 hkdf.workspace = true
+iddqd.workspace = true
 rand = { workspace = true, features = ["getrandom"] }
 secrecy.workspace = true
 serde.workspace = true

--- a/trust-quorum/src/configuration.rs
+++ b/trust-quorum/src/configuration.rs
@@ -8,6 +8,7 @@ use crate::crypto::{EncryptedRackSecret, RackSecret, Salt, Sha3_256Digest};
 use crate::validators::ValidatedReconfigureMsg;
 use crate::{Epoch, PlatformId, Threshold};
 use gfss::shamir::{Share, SplitError};
+use iddqd::{IdOrdItem, id_upcast};
 use omicron_uuid_kinds::RackUuid;
 use secrecy::ExposeSecret;
 use serde::{Deserialize, Serialize};
@@ -48,6 +49,16 @@ pub struct Configuration {
 
     // There is no previous configuration for the initial configuration
     pub previous_configuration: Option<PreviousConfiguration>,
+}
+
+impl IdOrdItem for Configuration {
+    type Key<'a> = Epoch;
+
+    fn key(&self) -> Self::Key<'_> {
+        self.epoch
+    }
+
+    id_upcast!();
 }
 
 impl Configuration {

--- a/trust-quorum/src/coordinator_state.rs
+++ b/trust-quorum/src/coordinator_state.rs
@@ -61,16 +61,14 @@ impl CoordinatorState {
         let (config, shares) = Configuration::new(&msg)?;
 
         let mut prepares = BTreeMap::new();
-        // `my_config` and `my_share` are optional only so that we can fill them
-        // in via the loop. They will always become `Some`, as a `Configuration`
-        // always contains the coordinator as a member as validated by
-        // construction of `ValidatedReconfigureMsg`.
-        let mut my_config: Option<Configuration> = None;
+        // `my_share` is optional only so that we can fill it in via the
+        // loop. It will always become `Some`, as a `Configuration` always
+        // contains the coordinator as a member as validated by construction of
+        // `ValidatedReconfigureMsg`.
         let mut my_share: Option<Share> = None;
         for (platform_id, share) in shares.into_iter() {
             if platform_id == *msg.coordinator_id() {
                 // The data to add to our `PersistentState`
-                my_config = Some(config.clone());
                 my_share = Some(share);
             } else {
                 // Create a message that requires sending
@@ -82,12 +80,12 @@ impl CoordinatorState {
             prepare_acks: BTreeSet::new(),
         };
 
-        let state = CoordinatorState::new(log, now, msg, config, op);
+        let state = CoordinatorState::new(log, now, msg, config.clone(), op);
 
         // Safety: Construction of a `ValidatedReconfigureMsg` ensures that
         // `my_platform_id` is part of the new configuration and has a share.
         // We can therefore safely unwrap here.
-        Ok((state, my_config.unwrap(), my_share.unwrap()))
+        Ok((state, config, my_share.unwrap()))
     }
 
     /// A reconfiguration from one group to another

--- a/trust-quorum/src/persistent_state.rs
+++ b/trust-quorum/src/persistent_state.rs
@@ -7,13 +7,13 @@
 //! Note that this state is not necessarily directly serialized and saved.
 
 use crate::crypto::LrtqShare;
-use crate::messages::{CommitMsg, PrepareMsg};
 use crate::{Configuration, Epoch, PlatformId};
 use bootstore::schemes::v0::SharePkgCommon as LrtqShareData;
 use gfss::shamir::Share;
+use iddqd::IdOrdMap;
 use omicron_uuid_kinds::{GenericUuid, RackUuid};
 use serde::{Deserialize, Serialize};
-use std::collections::BTreeMap;
+use std::collections::{BTreeMap, BTreeSet};
 
 /// All the persistent state for this protocol
 #[derive(Debug, Clone, Serialize, Deserialize, Default)]
@@ -21,29 +21,31 @@ pub struct PersistentState {
     // If this node was an LRTQ node, sled-agent will start it with the ledger
     // data it read from disk. This allows us to upgrade from LRTQ.
     pub lrtq: Option<LrtqShareData>,
-    pub prepares: BTreeMap<Epoch, PrepareMsg>,
-    pub commits: BTreeMap<Epoch, CommitMsg>,
+    pub configs: IdOrdMap<Configuration>,
+    pub shares: BTreeMap<Epoch, Share>,
+    pub commits: BTreeSet<Epoch>,
 
-    // Has the node seen a commit for an epoch higher than it's current
-    // configuration for which it has not received a `PrepareMsg` for? If at
-    // any time this gets set, than the it remains true for the lifetime of the
-    // node. The sled corresponding to the node must be factory reset by wiping
-    // its storage.
-    pub decommissioned: Option<DecommissionedMetadata>,
+    // Has the node been informed that it is no longer part of the trust quorum?
+    //
+    // If at any time this gets set, than the it remains true for the lifetime
+    // of the node. The sled corresponding to the node must be factory reset by
+    // wiping its storage.
+    pub expunged: Option<ExpungedMetadata>,
 }
 
 impl PersistentState {
     pub fn empty() -> PersistentState {
         PersistentState {
             lrtq: None,
-            prepares: BTreeMap::new(),
-            commits: BTreeMap::new(),
-            decommissioned: None,
+            configs: IdOrdMap::new(),
+            shares: BTreeMap::new(),
+            commits: BTreeSet::new(),
+            expunged: None,
         }
     }
 
     pub fn rack_id(&self) -> Option<RackUuid> {
-        self.last_committed_configuration().map(|c| c.rack_id).or_else(|| {
+        self.latest_committed_configuration().map(|c| c.rack_id).or_else(|| {
             self.lrtq
                 .as_ref()
                 .map(|pkg| RackUuid::from_untyped_uuid(pkg.rack_uuid))
@@ -53,30 +55,30 @@ impl PersistentState {
     // There is no information other than lrtq so far. Reconfigurations must
     // upgrade.
     pub fn is_lrtq_only(&self) -> bool {
-        self.lrtq.is_some() && self.last_committed_epoch().is_none()
+        self.lrtq.is_some() && self.latest_committed_epoch().is_none()
     }
 
     // Are there any committed configurations or lrtq data?
     pub fn is_uninitialized(&self) -> bool {
-        self.lrtq.is_none() && self.last_committed_epoch().is_none()
+        self.lrtq.is_none() && self.latest_committed_epoch().is_none()
     }
 
-    pub fn last_prepared_epoch(&self) -> Option<Epoch> {
-        self.prepares.keys().last().map(|epoch| *epoch)
+    pub fn latest_config(&self) -> Option<&Configuration> {
+        self.configs.iter().last()
     }
 
-    pub fn last_committed_epoch(&self) -> Option<Epoch> {
-        self.commits.keys().last().map(|epoch| *epoch)
+    pub fn latest_committed_epoch(&self) -> Option<Epoch> {
+        self.commits.iter().last().map(|epoch| *epoch)
     }
 
     // Get the configuration for the current epoch from its prepare message
     pub fn configuration(&self, epoch: Epoch) -> Option<&Configuration> {
-        self.prepares.get(&epoch).map(|p| &p.config)
+        self.configs.get(&epoch)
     }
 
-    pub fn last_committed_configuration(&self) -> Option<&Configuration> {
-        self.last_committed_epoch().map(|epoch| {
-            // There *must* be a prepare if we have a commit
+    pub fn latest_committed_configuration(&self) -> Option<&Configuration> {
+        self.latest_committed_epoch().map(|epoch| {
+            // There *must* be a configuration if we have a commit
             self.configuration(epoch).expect("missing prepare")
         })
     }
@@ -85,20 +87,12 @@ impl PersistentState {
     pub fn lrtq_key_share(&self) -> Option<LrtqShare> {
         self.lrtq.as_ref().map(|p| p.share.clone().into())
     }
-
-    // Return the key share for the latest committed trust quorum configuration
-    // if one exists
-    pub fn key_share(&self) -> Option<Share> {
-        self.last_committed_epoch().map(|epoch| {
-            self.prepares.get(&epoch).expect("missing prepare").share.clone()
-        })
-    }
 }
 
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
-pub struct DecommissionedMetadata {
+pub struct ExpungedMetadata {
     /// The committed epoch, later than its current configuration at which the
-    /// node learned that it had been decommissioned.
+    /// node learned that it had been expunged.
     pub epoch: Epoch,
 
     /// Which node this commit information was learned from  
@@ -112,9 +106,10 @@ pub struct PersistentStateSummary {
     pub rack_id: Option<RackUuid>,
     pub is_lrtq_only: bool,
     pub is_uninitialized: bool,
-    pub last_prepared_epoch: Option<Epoch>,
-    pub last_committed_epoch: Option<Epoch>,
-    pub decommissioned: Option<DecommissionedMetadata>,
+    pub latest_config: Option<Epoch>,
+    pub latest_committed_config: Option<Epoch>,
+    pub latest_share: Option<Epoch>,
+    pub expunged: Option<ExpungedMetadata>,
 }
 
 impl From<&PersistentState> for PersistentStateSummary {
@@ -123,9 +118,10 @@ impl From<&PersistentState> for PersistentStateSummary {
             rack_id: value.rack_id(),
             is_lrtq_only: value.is_lrtq_only(),
             is_uninitialized: value.is_uninitialized(),
-            last_prepared_epoch: value.last_prepared_epoch(),
-            last_committed_epoch: value.last_committed_epoch(),
-            decommissioned: value.decommissioned.clone(),
+            latest_config: value.latest_config().map(|c| c.epoch),
+            latest_committed_config: value.latest_committed_epoch(),
+            latest_share: value.shares.keys().last().map(|e| *e),
+            expunged: value.expunged.clone(),
         }
     }
 }

--- a/trust-quorum/tla/trust_quorum.tla
+++ b/trust-quorum/tla/trust_quorum.tla
@@ -218,17 +218,14 @@ Msgs ==
      the given epoch *)
   [type: {"expunged"}, epoch: Epoch, to: NODES, from: NODES] \union
 
-  (* This is an "implicit commit" in a reply message that comes from another
-     node when that node has moved on to a later configuration and the
-     requesting node is still part of the new configuration, but unaware of it.
+  (* Inform a node that it is utilizing an old committed onfiguration and give
+     it the new configuration.
 
-    As a result, a requesting node may have to retrieve a configuration and key
-    shares to recompute its share if it never received a prepare message for
-    this epoch.
+    As a result, a requesting node may have to retrieve key shares to recompute
+    its share if it never received a prepare message for this epoch.
   *)
   [type: {"commit_advance"},
-   config:
-   Configuration,
+   config: Configuration,
    to: NODES,
    from: NODES]
 


### PR DESCRIPTION
This PR changes the message implementation a bit and the `PersistentState` structure. It adds messages that will be used in follow up PRs, and ensures that `rack_id` is always checked on each message. Furthemore it stores configurations and shares separately inside the persistent state. This allows retrieval of a configuration for stale sled and the recomputation of its own share for that configuration to occur in separate steps. This matches what is done in the TLA+ spec.

I also added a comment about the intention of future code coming for the `Node` type. This reflects the experience of implementing LRTQ, and is helpful to simplify testing. If we don't have to track timeouts for arbitrary API requests inside the sans-io code, it becomes much simpler.