### PR TITLE
[nexus] add tokio-dtrace probes

### DIFF
--- a/.cargo/config.toml
+++ b/.cargo/config.toml
@@ -57,7 +57,9 @@ rustdocflags = "--document-private-items"
 # variety of things such as host OS.
 [target.x86_64-unknown-illumos]
 rustflags = [
-    "-C", "link-arg=-Wl,-znocompstrtab,-R/usr/platform/oxide/lib/amd64"
+    "-C", "link-arg=-Wl,-znocompstrtab,-R/usr/platform/oxide/lib/amd64",
+    # enable the `tokio-unstable` config for `tokio-dtrace` probes
+    "--cfg", "tokio_unstable"
 ]
 
 # Set up `cargo xtask`.

--- a/.github/buildomat/build-and-test.sh
+++ b/.github/buildomat/build-and-test.sh
@@ -92,14 +92,14 @@ banner ls-apis
 # from end-to-end-tests.
 #
 banner build
-export RUSTFLAGS="$RUSTFLAGS -D warnings"
+export RUSTFLAGS="--cfg tokio_unstable-D warnings"
 export RUSTDOCFLAGS="--document-private-items -D warnings"
 # When running on illumos we need to pass an additional runpath that is
 # usually configured via ".cargo/config" but the `RUSTFLAGS` env variable
 # takes precedence. This path contains oxide specific libraries such as
 # libipcc.
 if [[ $target_os == "illumos" ]]; then
-    export RUSTFLAGS="$RUSTFLAGS -C link-arg=-R/usr/platform/oxide/lib/amd64"
+    RUSTFLAGS="$RUSTFLAGS -C link-arg=-R/usr/platform/oxide/lib/amd64"
 fi
 export TMPDIR="$TEST_TMPDIR"
 export RUST_BACKTRACE=1

--- a/.github/buildomat/build-and-test.sh
+++ b/.github/buildomat/build-and-test.sh
@@ -92,7 +92,7 @@ banner ls-apis
 # from end-to-end-tests.
 #
 banner build
-export RUSTFLAGS="--cfg tokio_unstable-D warnings"
+export RUSTFLAGS="--cfg tokio_unstable -D warnings"
 export RUSTDOCFLAGS="--document-private-items -D warnings"
 # When running on illumos we need to pass an additional runpath that is
 # usually configured via ".cargo/config" but the `RUSTFLAGS` env variable

--- a/.github/buildomat/build-and-test.sh
+++ b/.github/buildomat/build-and-test.sh
@@ -92,18 +92,14 @@ banner ls-apis
 # from end-to-end-tests.
 #
 banner build
-export RUSTFLAGS="-D warnings"
+export RUSTFLAGS="$RUSTFLAGS -D warnings"
 export RUSTDOCFLAGS="--document-private-items -D warnings"
 # When running on illumos we need to pass an additional runpath that is
 # usually configured via ".cargo/config" but the `RUSTFLAGS` env variable
 # takes precedence. This path contains oxide specific libraries such as
 # libipcc.
-#
-# Additionally, we enable the "tokio_unstable" cfg in order to use
-# Tokio's unstable features for `tokio-dtrace`'s probes.
 if [[ $target_os == "illumos" ]]; then
-    RUSTFLAGS+=" -C link-arg=-R/usr/platform/oxide/lib/amd64"
-    RUSTFLAGS+=" --cfg tokio_unstable"
+    export RUSTFLAGS="$RUSTFLAGS -C link-arg=-R/usr/platform/oxide/lib/amd64"
 fi
 export TMPDIR="$TEST_TMPDIR"
 export RUST_BACKTRACE=1

--- a/.github/buildomat/build-and-test.sh
+++ b/.github/buildomat/build-and-test.sh
@@ -98,8 +98,12 @@ export RUSTDOCFLAGS="--document-private-items -D warnings"
 # usually configured via ".cargo/config" but the `RUSTFLAGS` env variable
 # takes precedence. This path contains oxide specific libraries such as
 # libipcc.
+#
+# Additionally, we enable the "tokio_unstable" cfg in order to use
+# Tokio's unstable features for `tokio-dtrace`'s probes.
 if [[ $target_os == "illumos" ]]; then
-    RUSTFLAGS="$RUSTFLAGS -C link-arg=-R/usr/platform/oxide/lib/amd64"
+    RUSTFLAGS+=" -C link-arg=-R/usr/platform/oxide/lib/amd64"
+    RUSTFLAGS+=" --cfg tokio_unstable"
 fi
 export TMPDIR="$TEST_TMPDIR"
 export RUST_BACKTRACE=1

--- a/.github/buildomat/ci-env.sh
+++ b/.github/buildomat/ci-env.sh
@@ -4,3 +4,6 @@
 
 # Color the output for easier readability.
 export CARGO_TERM_COLOR=always
+# Always enable the "tokio_unstable" cfg in order to use
+# Tokio's unstable features for `tokio-dtrace`'s probes.
+export RUSTFLAGS="--cfg tokio_unstable"

--- a/.github/buildomat/ci-env.sh
+++ b/.github/buildomat/ci-env.sh
@@ -4,6 +4,3 @@
 
 # Color the output for easier readability.
 export CARGO_TERM_COLOR=always
-# Always enable the "tokio_unstable" cfg in order to use
-# Tokio's unstable features for `tokio-dtrace`'s probes.
-export RUSTFLAGS="--cfg tokio_unstable"

--- a/.github/buildomat/jobs/clippy.sh
+++ b/.github/buildomat/jobs/clippy.sh
@@ -34,4 +34,4 @@ ptime -m bash ./tools/install_builder_prerequisites.sh -y
 banner clippy
 export CARGO_INCREMENTAL=0
 ptime -m cargo xtask clippy
-RUSTDOCFLAGS="--document-private-items -D warnings" ptime -m cargo doc --workspace --no-deps
+RUSTDOCFLAGS="--document-private-items -D warnings --cfg tokio" ptime -m cargo doc --workspace --no-deps

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -13036,7 +13036,7 @@ dependencies = [
 [[package]]
 name = "tokio-dtrace"
 version = "0.1.0"
-source = "git+https://github.com/oxidecomputer/tokio-dtrace?branch=main#45cb80e6e3e9484e686917023f6640c06e1fcef8"
+source = "git+https://github.com/oxidecomputer/tokio-dtrace?branch=main#55588b30dc424a87005deffdf4063679892b1c01"
 dependencies = [
  "thiserror 2.0.12",
  "tokio",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5420,7 +5420,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4979f22fdb869068da03c9f7528f8297c6fd2606bc3a4affe42e6a823fdb8da4"
 dependencies = [
  "cfg-if",
- "windows-targets 0.52.6",
+ "windows-targets 0.48.5",
 ]
 
 [[package]]
@@ -7553,6 +7553,7 @@ dependencies = [
  "term",
  "thiserror 1.0.69",
  "tokio",
+ "tokio-dtrace",
  "tokio-postgres",
  "tokio-util",
  "tough",
@@ -13016,9 +13017,9 @@ dependencies = [
 
 [[package]]
 name = "tokio"
-version = "1.45.0"
+version = "1.45.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2513ca694ef9ede0fb23fe71a4ee4107cb102b9dc1930f6d0fd77aae068ae165"
+checksum = "75ef51a33ef1da925cea3e4eb122833cb377c61439ca401b770f54902b806779"
 dependencies = [
  "backtrace",
  "bytes",
@@ -13030,6 +13031,16 @@ dependencies = [
  "socket2",
  "tokio-macros",
  "windows-sys 0.52.0",
+]
+
+[[package]]
+name = "tokio-dtrace"
+version = "0.1.0"
+source = "git+https://github.com/oxidecomputer/tokio-dtrace?branch=main#45cb80e6e3e9484e686917023f6640c06e1fcef8"
+dependencies = [
+ "thiserror 2.0.12",
+ "tokio",
+ "usdt",
 ]
 
 [[package]]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -7289,6 +7289,7 @@ dependencies = [
  "signal-hook-tokio",
  "subprocess",
  "tokio",
+ "tokio-dtrace",
  "tokio-postgres",
  "toml 0.8.22",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -717,6 +717,7 @@ test-strategy = "0.4.0"
 thiserror = "1.0"
 tofino = { git = "https://github.com/oxidecomputer/tofino", branch = "main" }
 tokio = "1.43.0"
+tokio-dtrace = { git = "https://github.com/oxidecomputer/tokio-dtrace", branch = "main" }
 tokio-postgres = { version = "0.7", features = [ "with-chrono-0_4", "with-uuid-1" ] }
 tokio-stream = "0.1.17"
 tokio-tungstenite = "0.23.1"

--- a/dev-tools/omicron-dev/Cargo.toml
+++ b/dev-tools/omicron-dev/Cargo.toml
@@ -27,6 +27,9 @@ signal-hook-tokio.workspace = true
 tokio.workspace = true
 toml.workspace = true
 
+[target.'cfg(target_os = "illumos")'.dependencies]
+tokio-dtrace.workspace = true
+
 [dev-dependencies]
 expectorate.workspace = true
 omicron-dev-lib.workspace = true

--- a/nexus/Cargo.toml
+++ b/nexus/Cargo.toml
@@ -136,6 +136,9 @@ omicron-workspace-hack.workspace = true
 omicron-uuid-kinds.workspace = true
 zip.workspace = true
 
+[target.'cfg(target_os = "illumos")'.dependencies]
+tokio-dtrace.workspace = true
+
 [dev-dependencies]
 async-bb8-diesel.workspace = true
 camino-tempfile.workspace = true

--- a/workspace-hack/Cargo.toml
+++ b/workspace-hack/Cargo.toml
@@ -121,7 +121,7 @@ strum = { version = "0.26.3", features = ["derive"] }
 subtle = { version = "2.6.1" }
 syn-f595c2ba2a3f28df = { package = "syn", version = "2.0.101", features = ["extra-traits", "fold", "full", "visit", "visit-mut"] }
 time = { version = "0.3.36", features = ["formatting", "local-offset", "macros", "parsing"] }
-tokio = { version = "1.45.0", features = ["full", "test-util"] }
+tokio = { version = "1.45.1", features = ["full", "test-util"] }
 tokio-postgres = { version = "0.7.13", features = ["with-chrono-0_4", "with-serde_json-1", "with-uuid-1"] }
 tokio-stream = { version = "0.1.17", features = ["net", "sync"] }
 tokio-util = { version = "0.7.13", features = ["codec", "io-util", "time"] }
@@ -248,7 +248,7 @@ syn-dff4ba8e3ae991db = { package = "syn", version = "1.0.109", features = ["extr
 syn-f595c2ba2a3f28df = { package = "syn", version = "2.0.101", features = ["extra-traits", "fold", "full", "visit", "visit-mut"] }
 time = { version = "0.3.36", features = ["formatting", "local-offset", "macros", "parsing"] }
 time-macros = { version = "0.2.18", default-features = false, features = ["formatting", "parsing"] }
-tokio = { version = "1.45.0", features = ["full", "test-util"] }
+tokio = { version = "1.45.1", features = ["full", "test-util"] }
 tokio-postgres = { version = "0.7.13", features = ["with-chrono-0_4", "with-serde_json-1", "with-uuid-1"] }
 tokio-stream = { version = "0.1.17", features = ["net", "sync"] }
 tokio-util = { version = "0.7.13", features = ["codec", "io-util", "time"] }


### PR DESCRIPTION
I've written [a crate][1] that adds USDT probes for Tokio runtime events, using the unstable callbacks provided by the Tokio runtime. This commit adds that crate to Nexus. Note that, because `tokio-dtrace` releis on Tokio's unstable features, it was necessary to add config to `.cargo/config.toml` to enable the `--cfg tokio_unstable` rustc config when compiling for illumos. In addition, adding the code necessary configure the Tokio runtime to record these probes required some changes to `bin/nexus.rs`, to change the use of the `#[tokio::main]` attribute to manual use of the runtime builder.

I'd like to add these DTrace
probes in other binaries in Omicron as well, but figured I'd start with Nexus as a proof of concept. It might be worth some general refactoring of our `main` functions in the process of doing so.

[1]: https://github.com/oxidecomputer/tokio-dtrace