### PR TITLE
The expected Content-Type should be configurable

### DIFF
--- a/nexus/test-utils/src/http_testing.rs
+++ b/nexus/test-utils/src/http_testing.rs
@@ -247,18 +247,19 @@ impl<'a> RequestBuilder<'a> {
     }
 
     /// Tells the requst to expect headers related to range requests
-    pub fn expect_range_requestable(mut self) -> Self {
+    pub fn expect_range_requestable<V, VE>(mut self, content_type: V) -> Self
+    where
+        V: TryInto<http::header::HeaderValue, Error = VE> + Debug,
+        VE: std::error::Error + Send + Sync + 'static,
+    {
         self.allowed_headers.as_mut().unwrap().extend([
             http::header::CONTENT_LENGTH,
             http::header::CONTENT_RANGE,
             http::header::CONTENT_TYPE,
             http::header::ACCEPT_RANGES,
         ]);
-        self.expect_response_header(
-            http::header::CONTENT_TYPE,
-            "application/zip",
-        )
-        .expect_response_header(http::header::ACCEPT_RANGES, "bytes")
+        self.expect_response_header(http::header::CONTENT_TYPE, content_type)
+            .expect_response_header(http::header::ACCEPT_RANGES, "bytes")
     }
 
     /// Tells the request to initiate and expect a WebSocket upgrade handshake.

--- a/nexus/tests/integration_tests/support_bundles.rs
+++ b/nexus/tests/integration_tests/support_bundles.rs
@@ -189,7 +189,7 @@ async fn bundle_download(
     let body = NexusRequest::new(
         RequestBuilder::new(client, Method::GET, &url)
             .expect_status(Some(StatusCode::OK))
-            .expect_range_requestable(),
+            .expect_range_requestable("application/zip"),
     )
     .authn_as(AuthnMode::PrivilegedUser)
     .execute()
@@ -208,7 +208,7 @@ async fn bundle_download_head(
     let len = NexusRequest::new(
         RequestBuilder::new(client, Method::HEAD, &url)
             .expect_status(Some(StatusCode::OK))
-            .expect_range_requestable(),
+            .expect_range_requestable("application/zip"),
     )
     .authn_as(AuthnMode::PrivilegedUser)
     .execute()
@@ -240,7 +240,7 @@ async fn bundle_download_range(
                 http::header::CONTENT_RANGE,
                 expected_content_range,
             )
-            .expect_range_requestable(),
+            .expect_range_requestable("application/zip"),
     )
     .authn_as(AuthnMode::PrivilegedUser)
     .execute()


### PR DESCRIPTION
When building a request for tests, the expected Content-Type should not be hard-coded to application/zip - this should be configurable so that other endpoints can also use this functionality.