### PR TITLE
update zip to 4.2.0

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -717,7 +717,7 @@ dependencies = [
  "bitflags 2.9.0",
  "cexpr",
  "clang-sys",
- "itertools 0.12.1",
+ "itertools 0.10.5",
  "lazy_static",
  "lazycell",
  "log",
@@ -740,7 +740,7 @@ dependencies = [
  "bitflags 2.9.0",
  "cexpr",
  "clang-sys",
- "itertools 0.13.0",
+ "itertools 0.10.5",
  "log",
  "prettyplease",
  "proc-macro2",
@@ -1659,7 +1659,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "117725a109d387c937a1533ce01b450cbde6b88abceea8473c4d7a85853cda3c"
 dependencies = [
  "lazy_static",
- "windows-sys 0.59.0",
+ "windows-sys 0.48.0",
 ]
 
 [[package]]
@@ -3250,6 +3250,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4a3d7db9596fecd151c5f638c0ee5d5bd487b6e0ea232e5dc96d5250f6f94b1d"
 dependencies = [
  "crc32fast",
+ "libz-rs-sys",
  "miniz_oxide",
 ]
 
@@ -5398,7 +5399,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4979f22fdb869068da03c9f7528f8297c6fd2606bc3a4affe42e6a823fdb8da4"
 dependencies = [
  "cfg-if",
- "windows-targets 0.52.6",
+ "windows-targets 0.48.5",
 ]
 
 [[package]]
@@ -5509,6 +5510,15 @@ dependencies = [
  "libc",
  "pkg-config",
  "vcpkg",
+]
+
+[[package]]
+name = "libz-rs-sys"
+version = "0.5.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "172a788537a2221661b480fee8dc5f96c580eb34fa88764d3205dc356c7e4221"
+dependencies = [
+ "zlib-rs",
 ]
 
 [[package]]
@@ -7335,7 +7345,7 @@ dependencies = [
  "toml 0.8.23",
  "tufaceous-artifact",
  "uuid",
- "zip 2.6.1",
+ "zip 4.2.0",
 ]
 
 [[package]]
@@ -7547,7 +7557,7 @@ dependencies = [
  "update-common",
  "update-engine",
  "uuid",
- "zip 2.6.1",
+ "zip 4.2.0",
 ]
 
 [[package]]
@@ -7919,7 +7929,7 @@ dependencies = [
  "uuid",
  "walkdir",
  "zeroize",
- "zip 2.6.1",
+ "zip 4.2.0",
  "zone 0.3.1",
 ]
 
@@ -8029,6 +8039,7 @@ dependencies = [
  "getrandom 0.3.1",
  "group",
  "hashbrown 0.15.4",
+ "heck 0.4.1",
  "hickory-proto",
  "hmac",
  "hyper",
@@ -8040,7 +8051,6 @@ dependencies = [
  "inout",
  "ipnetwork",
  "itertools 0.10.5",
- "itertools 0.12.1",
  "lalrpop-util",
  "lazy_static",
  "libc",
@@ -8120,7 +8130,7 @@ dependencies = [
  "zerocopy 0.8.26",
  "zeroize",
  "zip 0.6.6",
- "zip 2.6.1",
+ "zip 4.2.0",
 ]
 
 [[package]]
@@ -11888,7 +11898,7 @@ dependencies = [
  "slog",
  "thiserror 2.0.12",
  "tokio",
- "zip 2.6.1",
+ "zip 4.2.0",
 ]
 
 [[package]]
@@ -12178,7 +12188,7 @@ version = "0.8.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "03c3c6b7927ffe7ecaa769ee0e3994da3b8cafc8f444578982c83ecb161af917"
 dependencies = [
- "heck 0.5.0",
+ "heck 0.4.1",
  "proc-macro2",
  "quote",
  "syn 2.0.104",
@@ -12522,9 +12532,9 @@ checksum = "13c2bddecc57b384dee18652358fb23172facb8a2c51ccc10d74c157bdea3292"
 
 [[package]]
 name = "support-bundle-viewer"
-version = "0.1.0"
+version = "0.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "960873bebab69a59f0f8506f78319b924a251bd8fbb24eeca162059cfc3a1fd6"
+checksum = "666cc8963ecbd9989684b9cfce6420e73b268c91a48faf332822c8315426da60"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -12533,7 +12543,7 @@ dependencies = [
  "crossterm",
  "ratatui",
  "tokio",
- "zip 2.6.1",
+ "zip 4.2.0",
 ]
 
 [[package]]
@@ -13508,7 +13518,7 @@ dependencies = [
 [[package]]
 name = "tufaceous"
 version = "0.1.0"
-source = "git+https://github.com/oxidecomputer/tufaceous?branch=main#04681f26ba09e144e5467dd6bd22c4887692a670"
+source = "git+https://github.com/oxidecomputer/tufaceous?branch=main#681cb87d43712ce0f00d469d538080e8368bf991"
 dependencies = [
  "anyhow",
  "camino",
@@ -13529,7 +13539,7 @@ dependencies = [
 [[package]]
 name = "tufaceous-artifact"
 version = "0.1.0"
-source = "git+https://github.com/oxidecomputer/tufaceous?branch=main#04681f26ba09e144e5467dd6bd22c4887692a670"
+source = "git+https://github.com/oxidecomputer/tufaceous?branch=main#681cb87d43712ce0f00d469d538080e8368bf991"
 dependencies = [
  "daft",
  "hex",
@@ -13546,7 +13556,7 @@ dependencies = [
 [[package]]
 name = "tufaceous-brand-metadata"
 version = "0.1.0"
-source = "git+https://github.com/oxidecomputer/tufaceous?branch=main#04681f26ba09e144e5467dd6bd22c4887692a670"
+source = "git+https://github.com/oxidecomputer/tufaceous?branch=main#681cb87d43712ce0f00d469d538080e8368bf991"
 dependencies = [
  "semver 1.0.26",
  "serde",
@@ -13558,7 +13568,7 @@ dependencies = [
 [[package]]
 name = "tufaceous-lib"
 version = "0.1.0"
-source = "git+https://github.com/oxidecomputer/tufaceous?branch=main#04681f26ba09e144e5467dd6bd22c4887692a670"
+source = "git+https://github.com/oxidecomputer/tufaceous?branch=main#681cb87d43712ce0f00d469d538080e8368bf991"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -13594,7 +13604,7 @@ dependencies = [
  "tufaceous-artifact",
  "tufaceous-brand-metadata",
  "url",
- "zip 2.6.1",
+ "zip 4.2.0",
 ]
 
 [[package]]
@@ -14676,7 +14686,7 @@ version = "0.1.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cf221c93e13a30d793f7645a0e7762c55d169dbb0a49671918a2319d289b10bb"
 dependencies = [
- "windows-sys 0.59.0",
+ "windows-sys 0.48.0",
 ]
 
 [[package]]
@@ -15256,20 +15266,25 @@ dependencies = [
 
 [[package]]
 name = "zip"
-version = "2.6.1"
+version = "4.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1dcb24d0152526ae49b9b96c1dcf71850ca1e0b882e4e28ed898a93c41334744"
+checksum = "95ab361742de920c5535880f89bbd611ee62002bf11341d16a5f057bb8ba6899"
 dependencies = [
  "arbitrary",
  "bzip2 0.5.2",
  "crc32fast",
- "crossbeam-utils",
  "flate2",
  "indexmap 2.9.0",
  "memchr",
  "zopfli",
  "zstd",
 ]
+
+[[package]]
+name = "zlib-rs"
+version = "0.5.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "626bd9fa9734751fc50d6060752170984d7053f5a39061f524cda68023d4db8a"
 
 [[package]]
 name = "zone"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -754,7 +754,7 @@ wicketd-client = { path = "clients/wicketd-client" }
 xshell = "0.2.7"
 zerocopy = "0.8.26"
 zeroize = { version = "1.8.1", features = ["zeroize_derive", "std"] }
-zip = { version = "2.6.1", default-features = false, features = ["deflate","bzip2"] }
+zip = { version = "4.2.0", default-features = false, features = ["deflate","bzip2"] }
 zone = { version = "0.3.1", default-features = false, features = ["async"] }
 
 # newtype-uuid is set to default-features = false because we don't want to

--- a/workspace-hack/Cargo.toml
+++ b/workspace-hack/Cargo.toml
@@ -48,7 +48,7 @@ ed25519-dalek = { version = "2.1.1", features = ["digest", "pkcs8", "rand_core"]
 either = { version = "1.15.0", features = ["use_std"] }
 elliptic-curve = { version = "0.13.8", features = ["ecdh", "hazmat", "pem", "std"] }
 ff = { version = "0.13.0", default-features = false, features = ["alloc"] }
-flate2 = { version = "1.1.2" }
+flate2 = { version = "1.1.2", features = ["zlib-rs"] }
 foldhash = { version = "0.1.5" }
 form_urlencoded = { version = "1.2.1" }
 fs-err = { version = "3.1.1", default-features = false, features = ["tokio"] }
@@ -63,6 +63,7 @@ generic-array = { version = "0.14.7", default-features = false, features = ["mor
 getrandom-6f8ce4dd05d13bba = { package = "getrandom", version = "0.2.15", default-features = false, features = ["js", "rdrand", "std"] }
 group = { version = "0.13.0", default-features = false, features = ["alloc"] }
 hashbrown = { version = "0.15.4" }
+heck = { version = "0.4.1" }
 hickory-proto = { version = "0.24.4", features = ["text-parsing"] }
 hmac = { version = "0.12.1", default-features = false, features = ["reset"] }
 hyper = { version = "1.6.0", features = ["full"] }
@@ -70,7 +71,7 @@ idna = { version = "1.0.3" }
 indexmap = { version = "2.9.0", features = ["serde"] }
 inout = { version = "0.1.3", default-features = false, features = ["std"] }
 ipnetwork = { version = "0.21.1", features = ["schemars", "serde"] }
-itertools-93f6ce9d446188ac = { package = "itertools", version = "0.10.5" }
+itertools = { version = "0.10.5" }
 lalrpop-util = { version = "0.19.12" }
 lazy_static = { version = "1.5.0", default-features = false, features = ["spin_no_std"] }
 libc = { version = "0.2.174", features = ["extra_traits"] }
@@ -142,8 +143,8 @@ x509-cert = { version = "0.2.5" }
 zerocopy-c38e5c1d305a1b54 = { package = "zerocopy", version = "0.8.26", default-features = false, features = ["derive"] }
 zerocopy-ca01ad9e24f5d932 = { package = "zerocopy", version = "0.7.35", features = ["derive", "simd"] }
 zeroize = { version = "1.8.1", features = ["std", "zeroize_derive"] }
+zip-164d15cefe24d7eb = { package = "zip", version = "4.2.0", default-features = false, features = ["bzip2", "deflate", "zstd"] }
 zip-3b31131e45eafb45 = { package = "zip", version = "0.6.6", default-features = false, features = ["bzip2", "deflate"] }
-zip-f595c2ba2a3f28df = { package = "zip", version = "2.6.1", default-features = false, features = ["bzip2", "deflate", "zstd"] }
 
 [build-dependencies]
 ahash = { version = "0.8.11" }
@@ -177,7 +178,7 @@ ed25519-dalek = { version = "2.1.1", features = ["digest", "pkcs8", "rand_core"]
 either = { version = "1.15.0", features = ["use_std"] }
 elliptic-curve = { version = "0.13.8", features = ["ecdh", "hazmat", "pem", "std"] }
 ff = { version = "0.13.0", default-features = false, features = ["alloc"] }
-flate2 = { version = "1.1.2" }
+flate2 = { version = "1.1.2", features = ["zlib-rs"] }
 foldhash = { version = "0.1.5" }
 form_urlencoded = { version = "1.2.1" }
 fs-err = { version = "3.1.1", default-features = false, features = ["tokio"] }
@@ -192,6 +193,7 @@ generic-array = { version = "0.14.7", default-features = false, features = ["mor
 getrandom-6f8ce4dd05d13bba = { package = "getrandom", version = "0.2.15", default-features = false, features = ["js", "rdrand", "std"] }
 group = { version = "0.13.0", default-features = false, features = ["alloc"] }
 hashbrown = { version = "0.15.4" }
+heck = { version = "0.4.1" }
 hickory-proto = { version = "0.24.4", features = ["text-parsing"] }
 hmac = { version = "0.12.1", default-features = false, features = ["reset"] }
 hyper = { version = "1.6.0", features = ["full"] }
@@ -199,7 +201,7 @@ idna = { version = "1.0.3" }
 indexmap = { version = "2.9.0", features = ["serde"] }
 inout = { version = "0.1.3", default-features = false, features = ["std"] }
 ipnetwork = { version = "0.21.1", features = ["schemars", "serde"] }
-itertools-93f6ce9d446188ac = { package = "itertools", version = "0.10.5" }
+itertools = { version = "0.10.5" }
 lalrpop-util = { version = "0.19.12" }
 lazy_static = { version = "1.5.0", default-features = false, features = ["spin_no_std"] }
 libc = { version = "0.2.174", features = ["extra_traits"] }
@@ -273,8 +275,8 @@ x509-cert = { version = "0.2.5" }
 zerocopy-c38e5c1d305a1b54 = { package = "zerocopy", version = "0.8.26", default-features = false, features = ["derive"] }
 zerocopy-ca01ad9e24f5d932 = { package = "zerocopy", version = "0.7.35", features = ["derive", "simd"] }
 zeroize = { version = "1.8.1", features = ["std", "zeroize_derive"] }
+zip-164d15cefe24d7eb = { package = "zip", version = "4.2.0", default-features = false, features = ["bzip2", "deflate", "zstd"] }
 zip-3b31131e45eafb45 = { package = "zip", version = "0.6.6", default-features = false, features = ["bzip2", "deflate"] }
-zip-f595c2ba2a3f28df = { package = "zip", version = "2.6.1", default-features = false, features = ["bzip2", "deflate", "zstd"] }
 
 [target.x86_64-unknown-linux-gnu.dependencies]
 bitflags-f595c2ba2a3f28df = { package = "bitflags", version = "2.9.0", default-features = false, features = ["std"] }
@@ -342,7 +344,6 @@ getrandom-468e82937335b1c9 = { package = "getrandom", version = "0.3.1", default
 hyper-rustls = { version = "0.27.7", features = ["http2", "ring", "webpki-tokio"] }
 hyper-util = { version = "0.1.14", features = ["client-proxy", "client-proxy-system", "full"] }
 indicatif = { version = "0.17.11", features = ["rayon"] }
-itertools-5ef9efb8ec2df382 = { package = "itertools", version = "0.12.1" }
 mio = { version = "1.0.2", features = ["net", "os-ext"] }
 rustix = { version = "0.38.37", features = ["event", "fs", "net", "pipe", "process", "stdio", "system", "termios", "time"] }
 toml_edit-cdcf2f9584511fe6 = { package = "toml_edit", version = "0.19.15", features = ["serde"] }
@@ -357,7 +358,6 @@ getrandom-468e82937335b1c9 = { package = "getrandom", version = "0.3.1", default
 hyper-rustls = { version = "0.27.7", features = ["http2", "ring", "webpki-tokio"] }
 hyper-util = { version = "0.1.14", features = ["client-proxy", "client-proxy-system", "full"] }
 indicatif = { version = "0.17.11", features = ["rayon"] }
-itertools-5ef9efb8ec2df382 = { package = "itertools", version = "0.12.1" }
 mio = { version = "1.0.2", features = ["net", "os-ext"] }
 rustix = { version = "0.38.37", features = ["event", "fs", "net", "pipe", "process", "stdio", "system", "termios", "time"] }
 toml_edit-cdcf2f9584511fe6 = { package = "toml_edit", version = "0.19.15", features = ["serde"] }


### PR DESCRIPTION
zip 2.6.x was yanked, which causes r-a in Omicron to be somewhat sad (see https://github.com/oxidecomputer/tufaceous/pull/31 for example output).

The versions were yanked due to breaking semver (and republished as zip version 3 and 4), but we already made our code compatible with zip 2.6 (https://github.com/oxidecomputer/tufaceous/pull/25) so this upgrade involves no code changes.
