### PR TITLE
[sled-agent] Report boot partition contents of M.2 drives in inventory (PR 2/2)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -7803,6 +7803,7 @@ dependencies = [
  "tabled 0.15.0",
  "textwrap",
  "tokio",
+ "tufaceous-artifact",
  "unicode-width 0.1.14",
  "update-engine",
  "url",

--- a/dev-tools/omdb/Cargo.toml
+++ b/dev-tools/omdb/Cargo.toml
@@ -71,6 +71,7 @@ supports-color.workspace = true
 tabled.workspace = true
 textwrap.workspace = true
 tokio = { workspace = true, features = [ "full" ] }
+tufaceous-artifact.workspace = true
 unicode-width.workspace = true
 update-engine.workspace = true
 url.workspace = true

--- a/dev-tools/omdb/src/bin/omdb/db.rs
+++ b/dev-tools/omdb/src/bin/omdb/db.rs
@@ -7493,9 +7493,11 @@ fn inv_print_boot_partition_details(
         image_size: _,
         target_size: _,
         sha256,
+        image_name,
     } = header;
 
     println!("{indent}artifact: {artifact_hash} ({artifact_size} bytes)");
+    println!("{indent}image name: {image_name}");
     println!("{indent}phase 2 hash: {}", ArtifactHash(*sha256));
 }
 

--- a/nexus-sled-agent-shared/src/inventory.rs
+++ b/nexus-sled-agent-shared/src/inventory.rs
@@ -27,7 +27,6 @@ use omicron_common::{
         internal::shared::{NetworkInterface, SourceNatConfig},
     },
     disk::{DatasetConfig, DiskVariant, OmicronPhysicalDiskConfig},
-    snake_case_result::{self, SnakeCaseResult},
     update::ArtifactId,
     zpool_name::ZpoolName,
 };

--- a/nexus-sled-agent-shared/src/inventory.rs
+++ b/nexus-sled-agent-shared/src/inventory.rs
@@ -141,6 +141,7 @@ pub struct ConfigReconcilerInventory {
     pub datasets: BTreeMap<DatasetUuid, ConfigReconcilerInventoryResult>,
     pub orphaned_datasets: IdOrdMap<OrphanedDataset>,
     pub zones: BTreeMap<OmicronZoneUuid, ConfigReconcilerInventoryResult>,
+    pub boot_partitions: BootPartitionContents,
 }
 
 impl ConfigReconcilerInventory {
@@ -204,11 +205,21 @@ impl ConfigReconcilerInventory {
             datasets,
             orphaned_datasets: IdOrdMap::new(),
             zones,
+            boot_partitions: {
+                // None of our callers care about this; if that changes, we
+                // could pass in boot partition contents.
+                let err = "constructed via debug_assume_success()".to_string();
+                BootPartitionContents {
+                    boot_disk: Err(err.clone()),
+                    slot_a: Err(err.clone()),
+                    slot_b: Err(err),
+                }
+            },
         }
     }
 }
 
-#[derive(Clone, Debug, Deserialize, JsonSchema, Serialize)]
+#[derive(Clone, Debug, PartialEq, Eq, Deserialize, JsonSchema, Serialize)]
 pub struct BootPartitionContents {
     #[serde(with = "snake_case_result")]
     #[schemars(schema_with = "SnakeCaseResult::<M2Slot, String>::json_schema")]
@@ -225,7 +236,7 @@ pub struct BootPartitionContents {
     pub slot_b: Result<BootPartitionDetails, String>,
 }
 
-#[derive(Clone, Debug, Deserialize, JsonSchema, Serialize)]
+#[derive(Clone, Debug, PartialEq, Eq, Deserialize, JsonSchema, Serialize)]
 pub struct BootPartitionDetails {
     pub header: BootImageHeader,
     pub artifact_hash: ArtifactHash,
@@ -235,7 +246,7 @@ pub struct BootPartitionDetails {
 // There are several other fields in the header that we either parse and discard
 // or ignore completely; see https://github.com/oxidecomputer/boot-image-tools
 // for more thorough support.
-#[derive(Clone, Debug, Deserialize, JsonSchema, Serialize)]
+#[derive(Clone, Debug, PartialEq, Eq, Deserialize, JsonSchema, Serialize)]
 pub struct BootImageHeader {
     pub flags: u64,
     pub data_size: u64,

--- a/nexus-sled-agent-shared/src/inventory.rs
+++ b/nexus-sled-agent-shared/src/inventory.rs
@@ -252,6 +252,7 @@ pub struct BootImageHeader {
     pub image_size: u64,
     pub target_size: u64,
     pub sha256: [u8; 32],
+    pub image_name: String,
 }
 
 #[derive(Clone, Debug, PartialEq, Eq, Deserialize, JsonSchema, Serialize)]

--- a/nexus/db-model/src/inventory.rs
+++ b/nexus/db-model/src/inventory.rs
@@ -1034,6 +1034,7 @@ pub struct InvSledBootPartition {
     header_image_size: i64,
     header_target_size: i64,
     header_sha256: ArtifactHash,
+    header_image_name: String,
 }
 
 impl InvSledBootPartition {
@@ -1066,6 +1067,7 @@ impl InvSledBootPartition {
             header_sha256: ArtifactHash(ExternalArtifactHash(
                 details.header.sha256,
             )),
+            header_image_name: details.header.image_name,
         }
     }
 
@@ -1095,6 +1097,7 @@ impl From<InvSledBootPartition> for BootPartitionDetails {
                 image_size: value.header_image_size as u64,
                 target_size: value.header_target_size as u64,
                 sha256: value.header_sha256.0.0,
+                image_name: value.header_image_name,
             },
         }
     }

--- a/nexus/db-model/src/inventory.rs
+++ b/nexus/db-model/src/inventory.rs
@@ -38,9 +38,11 @@ use nexus_db_schema::schema::{
     inv_omicron_sled_config_dataset, inv_omicron_sled_config_disk,
     inv_omicron_sled_config_zone, inv_omicron_sled_config_zone_nic,
     inv_physical_disk, inv_root_of_trust, inv_root_of_trust_page,
-    inv_service_processor, inv_sled_agent, inv_zpool, sw_caboose,
-    sw_root_of_trust_page,
+    inv_service_processor, inv_sled_agent, inv_sled_boot_partition,
+    inv_sled_config_reconciler, inv_zpool, sw_caboose, sw_root_of_trust_page,
 };
+use nexus_sled_agent_shared::inventory::BootImageHeader;
+use nexus_sled_agent_shared::inventory::BootPartitionDetails;
 use nexus_sled_agent_shared::inventory::ConfigReconcilerInventoryStatus;
 use nexus_sled_agent_shared::inventory::MupdateOverrideBootInventory;
 use nexus_sled_agent_shared::inventory::MupdateOverrideInventory;
@@ -64,6 +66,7 @@ use omicron_common::api::internal::shared::NetworkInterface;
 use omicron_common::disk::DatasetConfig;
 use omicron_common::disk::DatasetName;
 use omicron_common::disk::DiskIdentity;
+use omicron_common::disk::M2Slot;
 use omicron_common::disk::OmicronPhysicalDiskConfig;
 use omicron_common::update::OmicronZoneManifestSource;
 use omicron_common::zpool_name::ZpoolName;
@@ -87,6 +90,7 @@ use std::collections::BTreeSet;
 use std::net::{IpAddr, SocketAddrV6};
 use std::time::Duration;
 use thiserror::Error;
+use tufaceous_artifact::ArtifactHash as ExternalArtifactHash;
 use uuid::Uuid;
 
 // See [`nexus_types::inventory::PowerState`].
@@ -838,11 +842,6 @@ pub struct InvSledAgent {
     // Soft foreign key to an `InvOmicronSledConfig`
     pub ledgered_sled_config: Option<DbTypedUuid<OmicronSledConfigKind>>,
 
-    // Soft foreign key to an `InvOmicronSledConfig`. May or may not be the same
-    // as `ledgered_sled_config`.
-    pub last_reconciliation_sled_config:
-        Option<DbTypedUuid<OmicronSledConfigKind>>,
-
     #[diesel(embed)]
     pub reconciler_status: InvConfigReconcilerStatus,
 
@@ -943,13 +942,170 @@ impl_enum_type!(
     Idle => b"idle"
 );
 
+/// See [`nexus_sled_agent_shared::inventory::ConfigReconcilerInventory`].
+#[derive(Queryable, Clone, Debug, Selectable, Insertable)]
+#[diesel(table_name = inv_sled_config_reconciler)]
+pub struct InvSledConfigReconciler {
+    pub inv_collection_id: DbTypedUuid<CollectionKind>,
+    pub sled_id: DbTypedUuid<SledKind>,
+    pub last_reconciled_config: DbTypedUuid<OmicronSledConfigKind>,
+    boot_disk_slot: Option<SqlU8>,
+    boot_disk_error: Option<String>,
+    pub boot_partition_a_error: Option<String>,
+    pub boot_partition_b_error: Option<String>,
+}
+
+impl InvSledConfigReconciler {
+    pub fn new(
+        inv_collection_id: CollectionUuid,
+        sled_id: SledUuid,
+        last_reconciled_config: OmicronSledConfigUuid,
+        boot_disk: Result<M2Slot, String>,
+        boot_partition_a_error: Option<String>,
+        boot_partition_b_error: Option<String>,
+    ) -> Self {
+        let (boot_disk_slot, boot_disk_error) = match boot_disk {
+            Ok(M2Slot::A) => (Some(SqlU8(0)), None),
+            Ok(M2Slot::B) => (Some(SqlU8(1)), None),
+            Err(err) => (None, Some(err)),
+        };
+
+        Self {
+            inv_collection_id: inv_collection_id.into(),
+            sled_id: sled_id.into(),
+            last_reconciled_config: last_reconciled_config.into(),
+            boot_disk_slot,
+            boot_disk_error,
+            boot_partition_a_error,
+            boot_partition_b_error,
+        }
+    }
+
+    pub fn boot_disk(&self) -> anyhow::Result<Result<M2Slot, String>> {
+        match (self.boot_disk_slot.as_deref(), self.boot_disk_error.as_ref()) {
+            (Some(0), None) => Ok(Ok(M2Slot::A)),
+            (Some(1), None) => Ok(Ok(M2Slot::B)),
+            (Some(n), None) => {
+                bail!(
+                    "inv_sled_config_reconciler CHECK constraint violated \
+                     (collection {}, sled {}): \
+                     boot_disk_slot other than 0 or 1: {n}",
+                    self.inv_collection_id,
+                    self.sled_id,
+                );
+            }
+            (None, Some(err)) => Ok(Err(err.clone())),
+            (None, None) => {
+                bail!(
+                    "inv_sled_config_reconciler CHECK constraint violated \
+                     (collection {}, sled {}): \
+                     neither boot_disk_slot nor boot_disk_error set",
+                    self.inv_collection_id,
+                    self.sled_id,
+                );
+            }
+            (Some(_), Some(_)) => {
+                bail!(
+                    "inv_sled_config_reconciler CHECK constraint violated \
+                     (collection {}, sled {}): \
+                     both boot_disk_slot and boot_disk_error set",
+                    self.inv_collection_id,
+                    self.sled_id,
+                );
+            }
+        }
+    }
+}
+
+/// See [`nexus_sled_agent_shared::inventory::BootPartitionDetails`].
+#[derive(Queryable, Clone, Debug, Selectable, Insertable)]
+#[diesel(table_name = inv_sled_boot_partition)]
+pub struct InvSledBootPartition {
+    pub inv_collection_id: DbTypedUuid<CollectionKind>,
+    pub sled_id: DbTypedUuid<SledKind>,
+    /// This field is `pub` so `nexus-db-queries` can use it during pagination;
+    /// consumes of this type probably want the `slot()` method instead, to
+    /// convert this value to an [`M2Slot`].
+    pub boot_disk_slot: SqlU8,
+    artifact_hash: ArtifactHash,
+    artifact_size: i64,
+    header_flags: i64,
+    header_data_size: i64,
+    header_image_size: i64,
+    header_target_size: i64,
+    header_sha256: ArtifactHash,
+}
+
+impl InvSledBootPartition {
+    pub fn new(
+        inv_collection_id: CollectionUuid,
+        sled_id: SledUuid,
+        boot_disk_slot: M2Slot,
+        details: BootPartitionDetails,
+    ) -> Self {
+        let boot_disk_slot = match boot_disk_slot {
+            M2Slot::A => 0,
+            M2Slot::B => 1,
+        };
+        Self {
+            inv_collection_id: inv_collection_id.into(),
+            sled_id: sled_id.into(),
+            boot_disk_slot: SqlU8(boot_disk_slot),
+            artifact_hash: ArtifactHash(details.artifact_hash),
+            // We use `as i64` because we don't want to throw errors if any of
+            // these fields happen to have their high bit set, and we don't care
+            // that that might produce negative numbers in the DB. E.g., we
+            // never need to order columns based on any of these values; we only
+            // want to faithfully store and load them. My kingdom for unsigned
+            // integers in SQL.
+            artifact_size: details.artifact_size as i64,
+            header_flags: details.header.flags as i64,
+            header_data_size: details.header.data_size as i64,
+            header_image_size: details.header.image_size as i64,
+            header_target_size: details.header.target_size as i64,
+            header_sha256: ArtifactHash(ExternalArtifactHash(
+                details.header.sha256,
+            )),
+        }
+    }
+
+    pub fn slot(&self) -> anyhow::Result<M2Slot> {
+        match *self.boot_disk_slot {
+            0 => Ok(M2Slot::A),
+            1 => Ok(M2Slot::B),
+            n => bail!(
+                "inv_sled_boot_partition CHECK constraint violated \
+                 (collection {}, sled {}): \
+                 boot_disk_slot other than 0 or 1: {n}",
+                self.inv_collection_id,
+                self.sled_id,
+            ),
+        }
+    }
+}
+
+impl From<InvSledBootPartition> for BootPartitionDetails {
+    fn from(value: InvSledBootPartition) -> Self {
+        Self {
+            artifact_hash: *value.artifact_hash,
+            artifact_size: value.artifact_size as usize,
+            header: BootImageHeader {
+                flags: value.header_flags as u64,
+                data_size: value.header_data_size as u64,
+                image_size: value.header_image_size as u64,
+                target_size: value.header_target_size as u64,
+                sha256: value.header_sha256.0.0,
+            },
+        }
+    }
+}
+
 impl InvSledAgent {
     /// Construct a new `InvSledAgent`.
     pub fn new_without_baseboard(
         collection_id: CollectionUuid,
         sled_agent: &nexus_types::inventory::SledAgent,
         ledgered_sled_config: Option<OmicronSledConfigUuid>,
-        last_reconciliation_sled_config: Option<OmicronSledConfigUuid>,
         reconciler_status: InvConfigReconcilerStatus,
         zone_image_resolver: InvZoneImageResolver,
     ) -> Result<InvSledAgent, anyhow::Error> {
@@ -990,8 +1146,6 @@ impl InvSledAgent {
                 ),
                 reservoir_size: ByteCount::from(sled_agent.reservoir_size),
                 ledgered_sled_config: ledgered_sled_config.map(From::from),
-                last_reconciliation_sled_config:
-                    last_reconciliation_sled_config.map(From::from),
                 reconciler_status,
                 zone_image_resolver,
             })

--- a/nexus/db-model/src/inventory.rs
+++ b/nexus/db-model/src/inventory.rs
@@ -1024,7 +1024,7 @@ pub struct InvSledBootPartition {
     pub inv_collection_id: DbTypedUuid<CollectionKind>,
     pub sled_id: DbTypedUuid<SledKind>,
     /// This field is `pub` so `nexus-db-queries` can use it during pagination;
-    /// consumes of this type probably want the `slot()` method instead, to
+    /// consumers of this type probably want the `slot()` method instead to
     /// convert this value to an [`M2Slot`].
     pub boot_disk_slot: SqlU8,
     artifact_hash: ArtifactHash,

--- a/nexus/db-model/src/schema_versions.rs
+++ b/nexus/db-model/src/schema_versions.rs
@@ -16,7 +16,7 @@ use std::{collections::BTreeMap, sync::LazyLock};
 ///
 /// This must be updated when you change the database schema.  Refer to
 /// schema/crdb/README.adoc in the root of this repository for details.
-pub const SCHEMA_VERSION: Version = Version::new(155, 0, 0);
+pub const SCHEMA_VERSION: Version = Version::new(156, 0, 0);
 
 /// List of all past database schema versions, in *reverse* order
 ///
@@ -28,6 +28,7 @@ static KNOWN_VERSIONS: LazyLock<Vec<KnownVersion>> = LazyLock::new(|| {
         // |  leaving the first copy as an example for the next person.
         // v
         // KnownVersion::new(next_int, "unique-dirname-with-the-sql-files"),
+        KnownVersion::new(156, "boot-partitions-inventory"),
         KnownVersion::new(155, "vpc-firewall-icmp"),
         KnownVersion::new(154, "add-pending-mgs-updates"),
         KnownVersion::new(153, "chicken-switches"),

--- a/nexus/db-queries/src/db/datastore/inventory.rs
+++ b/nexus/db-queries/src/db/datastore/inventory.rs
@@ -52,6 +52,8 @@ use nexus_db_model::InvRootOfTrust;
 use nexus_db_model::InvRotPage;
 use nexus_db_model::InvServiceProcessor;
 use nexus_db_model::InvSledAgent;
+use nexus_db_model::InvSledBootPartition;
+use nexus_db_model::InvSledConfigReconciler;
 use nexus_db_model::InvZpool;
 use nexus_db_model::RotImageError;
 use nexus_db_model::SledRole;
@@ -76,6 +78,7 @@ use nexus_db_schema::enums::{
 };
 use nexus_db_schema::enums::{HwPowerStateEnum, InvZoneManifestSourceEnum};
 use nexus_sled_agent_shared::inventory::BootPartitionContents;
+use nexus_sled_agent_shared::inventory::BootPartitionDetails;
 use nexus_sled_agent_shared::inventory::ConfigReconcilerInventory;
 use nexus_sled_agent_shared::inventory::ConfigReconcilerInventoryResult;
 use nexus_sled_agent_shared::inventory::ConfigReconcilerInventoryStatus;
@@ -93,6 +96,7 @@ use omicron_common::api::external::InternalContext;
 use omicron_common::api::external::LookupType;
 use omicron_common::api::external::ResourceType;
 use omicron_common::bail_unless;
+use omicron_common::disk::M2Slot;
 use omicron_uuid_kinds::CollectionUuid;
 use omicron_uuid_kinds::DatasetUuid;
 use omicron_uuid_kinds::GenericUuid;
@@ -311,6 +315,7 @@ impl DataStore {
         // reconciler properties for each sled. We need all of this to construct
         // `InvSledAgent` instances below.
         let ConfigReconcilerRows {
+            config_reconcilers,
             sled_configs: omicron_sled_configs,
             disks: omicron_sled_config_disks,
             datasets: omicron_sled_config_datasets,
@@ -320,6 +325,7 @@ impl DataStore {
             dataset_results: reconciler_dataset_results,
             orphaned_datasets: reconciler_orphaned_datasets,
             zone_results: reconciler_zone_results,
+            boot_partitions: reconciler_boot_partitions,
             mut config_reconciler_fields_by_sled,
         } = ConfigReconcilerRows::new(collection_id, collection)
             .map_err(|e| Error::internal_error(&format!("{e:#}")))?;
@@ -339,7 +345,6 @@ impl DataStore {
                 assert!(sled_agent.baseboard_id.is_none());
                 let ConfigReconcilerFields {
                     ledgered_sled_config,
-                    last_reconciliation_sled_config,
                     reconciler_status,
                 } = config_reconciler_fields_by_sled
                     .remove(&sled_agent.sled_id)
@@ -350,7 +355,6 @@ impl DataStore {
                     collection_id,
                     sled_agent,
                     ledgered_sled_config,
-                    last_reconciliation_sled_config,
                     reconciler_status,
                     zone_image_resolver,
                 )
@@ -956,6 +960,49 @@ impl DataStore {
                 }
             }
 
+            // Insert rows for all the config reconcilers we found.
+            {
+                use nexus_db_schema::schema::inv_sled_config_reconciler::dsl;
+
+                let batch_size = SQL_BATCH_SIZE.get().try_into().unwrap();
+                let mut reconcilers = config_reconcilers.into_iter();
+                loop {
+                    let some_reconcilers = reconcilers
+                        .by_ref()
+                        .take(batch_size)
+                        .collect::<Vec<_>>();
+                    if some_reconcilers.is_empty() {
+                        break;
+                    }
+                    let _ = diesel::insert_into(dsl::inv_sled_config_reconciler)
+                        .values(some_reconcilers)
+                        .execute_async(&conn)
+                        .await?;
+                }
+            }
+
+            // Insert rows for all the boot partition details we found.
+            {
+                use nexus_db_schema::schema::inv_sled_boot_partition::dsl;
+
+                let batch_size = SQL_BATCH_SIZE.get().try_into().unwrap();
+                let mut boot_partitions = reconciler_boot_partitions
+                    .into_iter();
+                loop {
+                    let some_boot_partitions = boot_partitions
+                        .by_ref()
+                        .take(batch_size)
+                        .collect::<Vec<_>>();
+                    if some_boot_partitions.is_empty() {
+                        break;
+                    }
+                    let _ = diesel::insert_into(dsl::inv_sled_boot_partition)
+                        .values(some_boot_partitions)
+                        .execute_async(&conn)
+                        .await?;
+                }
+            }
+
             // Insert rows for the all the sled configs we found.
             {
                 use nexus_db_schema::schema::inv_omicron_sled_config::dsl;
@@ -1201,7 +1248,6 @@ impl DataStore {
                     );
                     let ConfigReconcilerFields {
                         ledgered_sled_config,
-                        last_reconciliation_sled_config,
                         reconciler_status,
                     } = config_reconciler_fields_by_sled
                         .remove(&sled_agent.sled_id)
@@ -1240,9 +1286,6 @@ impl DataStore {
                             )
                             .into_sql::<diesel::sql_types::Int8>(),
                             ledgered_sled_config
-                                .map(|id| id.into_untyped_uuid())
-                                .into_sql::<Nullable<diesel::sql_types::Uuid>>(),
-                            last_reconciliation_sled_config
                                 .map(|id| id.into_untyped_uuid())
                                 .into_sql::<Nullable<diesel::sql_types::Uuid>>(),
                             reconciler_status.reconciler_status_kind
@@ -1294,7 +1337,6 @@ impl DataStore {
                                 sa_dsl::usable_physical_ram,
                                 sa_dsl::reservoir_size,
                                 sa_dsl::ledgered_sled_config,
-                                sa_dsl::last_reconciliation_sled_config,
                                 sa_dsl::reconciler_status_kind,
                                 sa_dsl::reconciler_status_sled_config,
                                 sa_dsl::reconciler_status_timestamp,
@@ -1326,7 +1368,6 @@ impl DataStore {
                         _usable_physical_ram,
                         _reservoir_size,
                         _ledgered_sled_config,
-                        _last_reconciliation_sled_config,
                         _reconciler_status_kind,
                         _reconciler_status_sled_config,
                         _reconciler_status_timestamp,
@@ -1640,6 +1681,8 @@ impl DataStore {
             nzone_manifest_zones: usize,
             nzone_manifest_non_boot: usize,
             nmupdate_override_non_boot: usize,
+            nconfig_reconcilers: usize,
+            nboot_partitions: usize,
             nomicron_sled_configs: usize,
             nomicron_sled_config_disks: usize,
             nomicron_sled_config_datasets: usize,
@@ -1667,6 +1710,8 @@ impl DataStore {
             nzone_manifest_zones,
             nzone_manifest_non_boot,
             nmupdate_override_non_boot,
+            nconfig_reconcilers,
+            nboot_partitions,
             nomicron_sled_configs,
             nomicron_sled_config_disks,
             nomicron_sled_config_datasets,
@@ -1830,6 +1875,24 @@ impl DataStore {
                         .await?
                     };
 
+                    // Remove rows associated with sled-agent config reconcilers
+                    let nconfig_reconcilers = {
+                        use nexus_db_schema::schema::inv_sled_config_reconciler::dsl;
+                        diesel::delete(dsl::inv_sled_config_reconciler.filter(
+                            dsl::inv_collection_id.eq(db_collection_id),
+                        ))
+                        .execute_async(&conn)
+                        .await?
+                    };
+                    let nboot_partitions = {
+                        use nexus_db_schema::schema::inv_sled_boot_partition::dsl;
+                        diesel::delete(dsl::inv_sled_boot_partition.filter(
+                            dsl::inv_collection_id.eq(db_collection_id),
+                        ))
+                        .execute_async(&conn)
+                        .await?
+                    };
+
                     // Remove rows associated with `OmicronSledConfig`s.
                     let nomicron_sled_configs = {
                         use nexus_db_schema::schema::inv_omicron_sled_config::dsl;
@@ -1920,6 +1983,8 @@ impl DataStore {
                         nzone_manifest_zones,
                         nzone_manifest_non_boot,
                         nmupdate_override_non_boot,
+                        nconfig_reconcilers,
+                        nboot_partitions,
                         nomicron_sled_configs,
                         nomicron_sled_config_disks,
                         nomicron_sled_config_datasets,
@@ -1957,6 +2022,8 @@ impl DataStore {
             "nzone_manifest_zones" => nzone_manifest_zones,
             "nzone_manifest_non_boot" => nzone_manifest_non_boot,
             "nmupdate_override_non_boot" => nmupdate_override_non_boot,
+            "nconfig_reconcilers" => nconfig_reconcilers,
+            "nboot_partitions" => nboot_partitions,
             "nomicron_sled_configs" => nomicron_sled_configs,
             "nomicron_sled_config_disks" => nomicron_sled_config_disks,
             "nomicron_sled_config_datasets" => nomicron_sled_config_datasets,
@@ -2908,6 +2975,76 @@ impl DataStore {
             }
         }
 
+        // Load all the config reconciler top-level rows; build a map keyed by
+        // sled ID.
+        let mut sled_config_reconcilers = {
+            use nexus_db_schema::schema::inv_sled_config_reconciler::dsl;
+
+            let mut results: BTreeMap<SledUuid, _> = BTreeMap::new();
+
+            let mut paginator = Paginator::new(batch_size);
+            while let Some(p) = paginator.next() {
+                let batch = paginated(
+                    dsl::inv_sled_config_reconciler,
+                    dsl::sled_id,
+                    &p.current_pagparams(),
+                )
+                .filter(dsl::inv_collection_id.eq(db_id))
+                .select(InvSledConfigReconciler::as_select())
+                .load_async(&*conn)
+                .await
+                .map_err(|e| {
+                    public_error_from_diesel(e, ErrorHandler::Server)
+                })?;
+                paginator = p.found_batch(&batch, &|row| row.sled_id);
+
+                for row in batch {
+                    results.insert(row.sled_id.into(), row);
+                }
+            }
+
+            results
+        };
+
+        // Load all the sled boot partition details; build a map of maps keyed
+        // by sled ID -> M2Slot.
+        let mut sled_boot_partition_details = {
+            use nexus_db_schema::schema::inv_sled_boot_partition::dsl;
+
+            let mut results: BTreeMap<SledUuid, BTreeMap<M2Slot, _>> =
+                BTreeMap::new();
+
+            let mut paginator = Paginator::new(batch_size);
+            while let Some(p) = paginator.next() {
+                let batch = paginated_multicolumn(
+                    dsl::inv_sled_boot_partition,
+                    (dsl::sled_id, dsl::boot_disk_slot),
+                    &p.current_pagparams(),
+                )
+                .filter(dsl::inv_collection_id.eq(db_id))
+                .select(InvSledBootPartition::as_select())
+                .load_async(&*conn)
+                .await
+                .map_err(|e| {
+                    public_error_from_diesel(e, ErrorHandler::Server)
+                })?;
+                paginator = p.found_batch(&batch, &|row| {
+                    (row.sled_id, row.boot_disk_slot)
+                });
+
+                for row in batch {
+                    let sled_map =
+                        results.entry(row.sled_id.into()).or_default();
+                    let slot = row.slot().map_err(|err| {
+                        Error::internal_error(&format!("{err:#}"))
+                    })?;
+                    sled_map.insert(slot, row);
+                }
+            }
+
+            results
+        };
+
         // Load all the config reconciler disk results; build a map of maps
         // keyed by sled ID.
         let mut last_reconciliation_disk_results = {
@@ -3269,11 +3406,11 @@ impl DataStore {
                         .map(|c| c.config.clone())
                 })
                 .map_err(|e| Error::internal_error(&format!("{e:#}")))?;
-            let last_reconciliation = s
-                .last_reconciliation_sled_config
-                .map(|id| {
+            let last_reconciliation = sled_config_reconcilers
+                .remove(&sled_id)
+                .map(|reconciler| {
                     let last_reconciled_config = omicron_sled_configs
-                        .get(&id.into())
+                        .get(&reconciler.last_reconciled_config.into())
                         .as_ref()
                         .ok_or_else(|| {
                             Error::internal_error(
@@ -3283,6 +3420,46 @@ impl DataStore {
                         })?
                         .config
                         .clone();
+
+                    let boot_partitions = {
+                        let boot_disk =
+                            reconciler.boot_disk().map_err(|err| {
+                                Error::internal_error(&format!("{err:#}"))
+                            })?;
+
+                        // Helper to convert our nullable error column into
+                        // either the error message (if present) or, if NULL,
+                        // looking up the `BootPartitionDetails` from the rows
+                        // we loaded above. We have to do this for both slots.
+                        let mut slot_details = |maybe_err, slot| match maybe_err
+                        {
+                            Some(err) => Ok(Err(err)),
+                            None => sled_boot_partition_details
+                                .get_mut(&sled_id)
+                                .and_then(|by_slot| by_slot.remove(&slot))
+                                .map(|details| {
+                                    Ok(BootPartitionDetails::from(details))
+                                })
+                                .ok_or_else(|| {
+                                    Error::internal_error(
+                                        "missing boot partition details that \
+                                         we should have fetched",
+                                    )
+                                }),
+                        };
+
+                        let slot_a = slot_details(
+                            reconciler.boot_partition_a_error,
+                            M2Slot::A,
+                        )?;
+                        let slot_b = slot_details(
+                            reconciler.boot_partition_b_error,
+                            M2Slot::B,
+                        )?;
+
+                        BootPartitionContents { boot_disk, slot_a, slot_b }
+                    };
+
                     Ok::<_, Error>(ConfigReconcilerInventory {
                         last_reconciled_config,
                         external_disks: last_reconciliation_disk_results
@@ -3298,12 +3475,7 @@ impl DataStore {
                         zones: last_reconciliation_zone_results
                             .remove(&sled_id)
                             .unwrap_or_default(),
-                        // TODO-john
-                        boot_partitions: BootPartitionContents {
-                            boot_disk: Err("xxx".to_string()),
-                            slot_a: Err("xxx".to_string()),
-                            slot_b: Err("xxx".to_string()),
-                        },
+                        boot_partitions,
                     })
                 })
                 .transpose()?;
@@ -3366,6 +3538,31 @@ impl DataStore {
 
         // Check that we consumed all the reconciliation results we found in
         // this collection.
+        bail_unless!(
+            sled_config_reconcilers.is_empty(),
+            "found extra sled config reconcilers: {:?}",
+            sled_config_reconcilers.keys(),
+        );
+        {
+            // `sled_boot_partition_details` is a map of maps; we don't prune
+            // the outermost map, but they should all be empty.
+            let sleds_with_leftover_boot_partitions =
+                sled_boot_partition_details
+                    .iter()
+                    .filter_map(|(sled_id, boot_partitions)| {
+                        if boot_partitions.is_empty() {
+                            None
+                        } else {
+                            Some(sled_id)
+                        }
+                    })
+                    .collect::<Vec<_>>();
+            bail_unless!(
+                sleds_with_leftover_boot_partitions.is_empty(),
+                "found extra sled boot partition details: {:?}",
+                sleds_with_leftover_boot_partitions,
+            );
+        }
         bail_unless!(
             last_reconciliation_disk_results.is_empty(),
             "found extra config reconciliation disk results: {:?}",
@@ -3433,7 +3630,6 @@ impl IdMappable for OmicronSledConfigWithId {
 #[derive(Debug)]
 struct ConfigReconcilerFields {
     ledgered_sled_config: Option<OmicronSledConfigUuid>,
-    last_reconciliation_sled_config: Option<OmicronSledConfigUuid>,
     reconciler_status: InvConfigReconcilerStatus,
 }
 
@@ -3441,6 +3637,7 @@ struct ConfigReconcilerFields {
 // per-sled config reconciler status rows for an inventory collection.
 #[derive(Debug, Default)]
 struct ConfigReconcilerRows {
+    config_reconcilers: Vec<InvSledConfigReconciler>,
     sled_configs: Vec<InvOmicronSledConfig>,
     disks: Vec<InvOmicronSledConfigDisk>,
     datasets: Vec<InvOmicronSledConfigDataset>,
@@ -3450,6 +3647,7 @@ struct ConfigReconcilerRows {
     dataset_results: Vec<InvLastReconciliationDatasetResult>,
     orphaned_datasets: Vec<InvLastReconciliationOrphanedDataset>,
     zone_results: Vec<InvLastReconciliationZoneResult>,
+    boot_partitions: Vec<InvSledBootPartition>,
     config_reconciler_fields_by_sled:
         BTreeMap<SledUuid, ConfigReconcilerFields>,
 }
@@ -3478,20 +3676,73 @@ impl ConfigReconcilerRows {
                 Some(self.accumulate_config(collection_id, config)?);
         }
 
-        let mut last_reconciliation_sled_config = None;
+        let mut last_reconciliation_config_id = None;
         if let Some(last_reconciliation) = &sled_agent.last_reconciliation {
             // If this config exactly matches the ledgered sled config, we can
             // reuse the foreign key; otherwise, accumulate the new one.
-            if Some(&last_reconciliation.last_reconciled_config)
-                == sled_agent.ledgered_sled_config.as_ref()
-            {
-                last_reconciliation_sled_config = ledgered_sled_config;
-            } else {
-                last_reconciliation_sled_config =
-                    Some(self.accumulate_config(
+            let last_reconciled_config =
+                if Some(&last_reconciliation.last_reconciled_config)
+                    == sled_agent.ledgered_sled_config.as_ref()
+                {
+                    // We always set this to `Some(_)` above if we have a
+                    // ledgered sled config, which we must to pass this check.
+                    ledgered_sled_config
+                        .expect("always Some(_) if we have a ledgered config")
+                } else {
+                    self.accumulate_config(
                         collection_id,
                         &last_reconciliation.last_reconciled_config,
-                    )?);
+                    )?
+                };
+            last_reconciliation_config_id = Some(last_reconciled_config);
+
+            self.config_reconcilers.push(InvSledConfigReconciler::new(
+                collection_id,
+                sled_id,
+                last_reconciled_config,
+                last_reconciliation.boot_partitions.boot_disk.clone(),
+                last_reconciliation
+                    .boot_partitions
+                    .slot_a
+                    .as_ref()
+                    .err()
+                    .cloned(),
+                last_reconciliation
+                    .boot_partitions
+                    .slot_b
+                    .as_ref()
+                    .err()
+                    .cloned(),
+            ));
+
+            // Boot partition _errors_ are kept in `InvSledConfigReconciler`
+            // above, but non-errors get their own rows; handle those here.
+            //
+            // `.into_iter().flatten()` strips out `None`s (i.e., slots that had
+            // an error, after the conversions we do here).
+            for (slot, details) in [
+                last_reconciliation
+                    .boot_partitions
+                    .slot_a
+                    .as_ref()
+                    .ok()
+                    .map(|details| (M2Slot::A, details.clone())),
+                last_reconciliation
+                    .boot_partitions
+                    .slot_b
+                    .as_ref()
+                    .ok()
+                    .map(|details| (M2Slot::B, details.clone())),
+            ]
+            .into_iter()
+            .flatten()
+            {
+                self.boot_partitions.push(InvSledBootPartition::new(
+                    collection_id,
+                    sled_id,
+                    slot,
+                    details,
+                ));
             }
 
             self.disk_results.extend(
@@ -3567,7 +3818,7 @@ impl ConfigReconcilerRows {
                         .as_ref()
                         .map(|lr| &lr.last_reconciled_config)
                 {
-                    last_reconciliation_sled_config
+                    last_reconciliation_config_id
                 } else {
                     Some(self.accumulate_config(collection_id, config)?)
                 };
@@ -3596,11 +3847,7 @@ impl ConfigReconcilerRows {
 
         self.config_reconciler_fields_by_sled.insert(
             sled_id,
-            ConfigReconcilerFields {
-                ledgered_sled_config,
-                last_reconciliation_sled_config,
-                reconciler_status,
-            },
+            ConfigReconcilerFields { ledgered_sled_config, reconciler_status },
         );
 
         Ok(())

--- a/nexus/db-queries/src/db/datastore/inventory.rs
+++ b/nexus/db-queries/src/db/datastore/inventory.rs
@@ -2982,7 +2982,10 @@ impl DataStore {
 
             let mut results: BTreeMap<SledUuid, _> = BTreeMap::new();
 
-            let mut paginator = Paginator::new(batch_size);
+            let mut paginator = Paginator::new(
+                batch_size,
+                dropshot::PaginationOrder::Ascending,
+            );
             while let Some(p) = paginator.next() {
                 let batch = paginated(
                     dsl::inv_sled_config_reconciler,
@@ -3014,7 +3017,10 @@ impl DataStore {
             let mut results: BTreeMap<SledUuid, BTreeMap<M2Slot, _>> =
                 BTreeMap::new();
 
-            let mut paginator = Paginator::new(batch_size);
+            let mut paginator = Paginator::new(
+                batch_size,
+                dropshot::PaginationOrder::Ascending,
+            );
             while let Some(p) = paginator.next() {
                 let batch = paginated_multicolumn(
                     dsl::inv_sled_boot_partition,

--- a/nexus/db-queries/src/db/datastore/inventory.rs
+++ b/nexus/db-queries/src/db/datastore/inventory.rs
@@ -4819,6 +4819,7 @@ mod test {
                                 image_size: 234567,
                                 target_size: 345678,
                                 sha256: [1; 32],
+                                image_name: "test image".to_string(),
                             },
                             artifact_hash: ArtifactHash([2; 32]),
                             artifact_size: 456789,

--- a/nexus/db-queries/src/db/datastore/inventory.rs
+++ b/nexus/db-queries/src/db/datastore/inventory.rs
@@ -75,6 +75,7 @@ use nexus_db_schema::enums::{
     CabooseWhichEnum, InvConfigReconcilerStatusKindEnum,
 };
 use nexus_db_schema::enums::{HwPowerStateEnum, InvZoneManifestSourceEnum};
+use nexus_sled_agent_shared::inventory::BootPartitionContents;
 use nexus_sled_agent_shared::inventory::ConfigReconcilerInventory;
 use nexus_sled_agent_shared::inventory::ConfigReconcilerInventoryResult;
 use nexus_sled_agent_shared::inventory::ConfigReconcilerInventoryStatus;
@@ -3297,6 +3298,12 @@ impl DataStore {
                         zones: last_reconciliation_zone_results
                             .remove(&sled_id)
                             .unwrap_or_default(),
+                        // TODO-john
+                        boot_partitions: BootPartitionContents {
+                            boot_disk: Err("xxx".to_string()),
+                            slot_a: Err("xxx".to_string()),
+                            slot_b: Err("xxx".to_string()),
+                        },
                     })
                 })
                 .transpose()?;
@@ -3706,6 +3713,9 @@ mod test {
     use nexus_inventory::examples::Representative;
     use nexus_inventory::examples::representative;
     use nexus_inventory::now_db_precision;
+    use nexus_sled_agent_shared::inventory::BootImageHeader;
+    use nexus_sled_agent_shared::inventory::BootPartitionContents;
+    use nexus_sled_agent_shared::inventory::BootPartitionDetails;
     use nexus_sled_agent_shared::inventory::OrphanedDataset;
     use nexus_sled_agent_shared::inventory::{
         ConfigReconcilerInventory, ConfigReconcilerInventoryResult,
@@ -3718,6 +3728,7 @@ mod test {
     use omicron_common::api::external::Error;
     use omicron_common::disk::DatasetKind;
     use omicron_common::disk::DatasetName;
+    use omicron_common::disk::M2Slot;
     use omicron_common::zpool_name::ZpoolName;
     use omicron_test_utils::dev;
     use omicron_uuid_kinds::{
@@ -4551,6 +4562,21 @@ mod test {
                             (OmicronZoneUuid::new_v4(), make_result("zone", i))
                         })
                         .collect(),
+                    boot_partitions: BootPartitionContents {
+                        boot_disk: Ok(M2Slot::B),
+                        slot_a: Err("some error".to_string()),
+                        slot_b: Ok(BootPartitionDetails {
+                            header: BootImageHeader {
+                                flags: u64::MAX,
+                                data_size: 123456,
+                                image_size: 234567,
+                                target_size: 345678,
+                                sha256: [1; 32],
+                            },
+                            artifact_hash: ArtifactHash([2; 32]),
+                            artifact_size: 456789,
+                        }),
+                    },
                 }
             });
 

--- a/nexus/db-schema/src/schema.rs
+++ b/nexus/db-schema/src/schema.rs
@@ -1641,6 +1641,7 @@ table! {
         header_image_size -> Int8,
         header_target_size -> Int8,
         header_sha256 -> Text,
+        header_image_name -> Text,
     }
 }
 

--- a/nexus/db-schema/src/schema.rs
+++ b/nexus/db-schema/src/schema.rs
@@ -1596,7 +1596,6 @@ table! {
         reservoir_size -> Int8,
 
         ledgered_sled_config -> Nullable<Uuid>,
-        last_reconciliation_sled_config -> Nullable<Uuid>,
         reconciler_status_kind -> crate::enums::InvConfigReconcilerStatusKindEnum,
         reconciler_status_sled_config -> Nullable<Uuid>,
         reconciler_status_timestamp -> Nullable<Timestamptz>,
@@ -1610,6 +1609,38 @@ table! {
         mupdate_override_boot_disk_path -> Text,
         mupdate_override_id -> Nullable<Uuid>,
         mupdate_override_boot_disk_error -> Nullable<Text>,
+    }
+}
+
+table! {
+    inv_sled_config_reconciler (inv_collection_id, sled_id) {
+        inv_collection_id -> Uuid,
+        sled_id -> Uuid,
+
+        last_reconciled_config -> Uuid,
+
+        boot_disk_slot -> Nullable<Int2>,
+        boot_disk_error -> Nullable<Text>,
+
+        boot_partition_a_error -> Nullable<Text>,
+        boot_partition_b_error -> Nullable<Text>,
+    }
+}
+
+table! {
+    inv_sled_boot_partition (inv_collection_id, sled_id, boot_disk_slot) {
+        inv_collection_id -> Uuid,
+        sled_id -> Uuid,
+        boot_disk_slot -> Int2,
+
+        artifact_hash -> Text,
+        artifact_size -> Int8,
+
+        header_flags -> Int8,
+        header_data_size -> Int8,
+        header_image_size -> Int8,
+        header_target_size -> Int8,
+        header_sha256 -> Text,
     }
 }
 

--- a/nexus/inventory/src/examples.rs
+++ b/nexus/inventory/src/examples.rs
@@ -17,6 +17,8 @@ use gateway_client::types::SpType;
 use gateway_types::rot::RotSlot;
 use iddqd::id_ord_map;
 use nexus_sled_agent_shared::inventory::Baseboard;
+use nexus_sled_agent_shared::inventory::BootImageHeader;
+use nexus_sled_agent_shared::inventory::BootPartitionDetails;
 use nexus_sled_agent_shared::inventory::ConfigReconcilerInventory;
 use nexus_sled_agent_shared::inventory::ConfigReconcilerInventoryStatus;
 use nexus_sled_agent_shared::inventory::Inventory;
@@ -38,6 +40,7 @@ use omicron_common::disk::DatasetConfig;
 use omicron_common::disk::DatasetKind;
 use omicron_common::disk::DatasetName;
 use omicron_common::disk::DiskVariant;
+use omicron_common::disk::M2Slot;
 use omicron_common::disk::OmicronPhysicalDiskConfig;
 use omicron_common::disk::SharedDatasetConfig;
 use omicron_uuid_kinds::DatasetUuid;
@@ -67,6 +70,7 @@ use sled_agent_zone_images_examples::dataset_missing_error;
 use std::sync::Arc;
 use std::time::Duration;
 use strum::IntoEnumIterator;
+use tufaceous_artifact::ArtifactHash;
 use uuid::Uuid;
 
 /// Returns an example Collection used for testing
@@ -843,6 +847,7 @@ pub fn sled_agent(
     // Assume the `ledgered_sled_config` was reconciled successfully.
     let last_reconciliation = ledgered_sled_config.clone().map(|config| {
         let mut inv = ConfigReconcilerInventory::debug_assume_success(config);
+
         // Add an orphaned dataset with no tie to other pools/datasets.
         inv.orphaned_datasets.insert_overwrite(OrphanedDataset {
             name: DatasetName::new(
@@ -855,6 +860,21 @@ pub fn sled_agent(
             available: 0.into(),
             used: 0.into(),
         });
+
+        // Fill in some fake boot partition details.
+        inv.boot_partitions.boot_disk = Ok(M2Slot::A);
+        inv.boot_partitions.slot_a = Ok(BootPartitionDetails {
+            header: BootImageHeader {
+                flags: 0,
+                data_size: 10_000,
+                image_size: 10_000,
+                target_size: 10_000,
+                sha256: [0; 32],
+            },
+            artifact_hash: ArtifactHash([1; 32]),
+            artifact_size: 10_000 + 4096,
+        });
+
         inv
     });
 

--- a/nexus/inventory/src/examples.rs
+++ b/nexus/inventory/src/examples.rs
@@ -870,6 +870,7 @@ pub fn sled_agent(
                 image_size: 10_000,
                 target_size: 10_000,
                 sha256: [0; 32],
+                image_name: "fake image for tests".to_string(),
             },
             artifact_hash: ArtifactHash([1; 32]),
             artifact_size: 10_000 + 4096,

--- a/nexus/tests/integration_tests/schema.rs
+++ b/nexus/tests/integration_tests/schema.rs
@@ -2367,7 +2367,7 @@ fn after_151_0_0<'a>(ctx: &'a MigrationContext<'a>) -> BoxFuture<'a, ()> {
                 &[],
             )
             .await
-            .expect("inserted post-migration inv_sled_agent data");
+            .expect("queried post-migration inv_sled_agent data");
 
         assert_eq!(rows.len(), 1);
         let row = &rows[0];
@@ -2505,6 +2505,152 @@ fn after_155_0_0<'a>(ctx: &'a MigrationContext<'a>) -> BoxFuture<'a, ()> {
     })
 }
 
+mod migration_156 {
+    use super::*;
+    use pretty_assertions::assert_eq;
+    use std::collections::BTreeSet;
+
+    const INV_COLLECTION_ID_1: &str = "5cb42909-d94a-4903-be72-330eea0325d9";
+    const INV_COLLECTION_ID_2: &str = "142b62c2-9348-4530-9eed-7077351fb94b";
+    const SLED_ID_1: &str = "3b5b7861-03aa-420a-a057-0a14347dc4c0";
+    const SLED_ID_2: &str = "de7ab4c0-30d4-4e9e-b620-3a959a9d59dd";
+    const SLED_CONFIG_ID_1: &str = "a1637607-c49e-4658-b637-96473a72bb32";
+    const SLED_CONFIG_ID_2: &str = "695de2f0-9c09-42b0-a22a-1e5b783a38c0";
+    const SLED_CONFIG_ID_3: &str = "50a8d074-879b-4c59-a2ef-700156e49a97";
+
+    pub(super) fn before<'a>(
+        ctx: &'a MigrationContext<'a>,
+    ) -> BoxFuture<'a, ()> {
+        Box::pin(async move {
+            // Insert these tuples:
+            //
+            // (collection 1, sled 1, sled config ID 1)
+            // (collection 1, sled 2, NULL)
+            // (collection 2, sled 1, sled config ID 2)
+            // (collection 2, sled 2, sled config ID 3)
+            ctx.client
+                .batch_execute(&format!(
+                    "
+                    INSERT INTO omicron.public.inv_sled_agent (
+                        inv_collection_id, time_collected, source, sled_id,
+                        sled_agent_ip, sled_agent_port, sled_role,
+                        usable_hardware_threads, usable_physical_ram,
+                        reservoir_size, last_reconciliation_sled_config,
+                        reconciler_status_kind, zone_manifest_boot_disk_path,
+                        zone_manifest_source, mupdate_override_boot_disk_path
+                    )
+                    VALUES (
+                        '{INV_COLLECTION_ID_1}', now(), 'test-source',
+                        '{SLED_ID_1}', '192.168.1.1', 0, 'gimlet',
+                        32, 68719476736, 1073741824, '{SLED_CONFIG_ID_1}',
+                        'not-yet-run', '/tmp', 'sled-agent', '/tmp'
+                    ), (
+                        '{INV_COLLECTION_ID_1}', now(), 'test-source',
+                        '{SLED_ID_2}', '192.168.1.1', 0, 'gimlet',
+                        32, 68719476736, 1073741824, NULL,
+                        'not-yet-run', '/tmp', 'sled-agent', '/tmp'
+                    ), (
+                        '{INV_COLLECTION_ID_2}', now(), 'test-source',
+                        '{SLED_ID_1}', '192.168.1.1', 0, 'gimlet',
+                        32, 68719476736, 1073741824, '{SLED_CONFIG_ID_2}',
+                        'not-yet-run', '/tmp', 'sled-agent', '/tmp'
+                    ), (
+                        '{INV_COLLECTION_ID_2}', now(), 'test-source',
+                        '{SLED_ID_2}', '192.168.1.1', 0, 'gimlet',
+                        32, 68719476736, 1073741824, '{SLED_CONFIG_ID_3}',
+                        'not-yet-run', '/tmp', 'sled-agent', '/tmp'
+                    );
+                    "
+                ))
+                .await
+                .expect("inserted pre-migration data");
+        })
+    }
+
+    pub(super) fn after<'a>(
+        ctx: &'a MigrationContext<'a>,
+    ) -> BoxFuture<'a, ()> {
+        Box::pin(async move {
+            // Verify that the new inv_sled_config_reconciler table has 3 rows
+            // corresponding to the three inv_sled_agent rows that had a
+            // non-NULL last_reconciliation_sled_config inserted in `before()`.
+            let expected = {
+                let mut expected = BTreeSet::<(Uuid, Uuid, Uuid)>::new();
+                expected.insert((
+                    INV_COLLECTION_ID_1.parse().unwrap(),
+                    SLED_ID_1.parse().unwrap(),
+                    SLED_CONFIG_ID_1.parse().unwrap(),
+                ));
+                expected.insert((
+                    INV_COLLECTION_ID_2.parse().unwrap(),
+                    SLED_ID_1.parse().unwrap(),
+                    SLED_CONFIG_ID_2.parse().unwrap(),
+                ));
+                expected.insert((
+                    INV_COLLECTION_ID_2.parse().unwrap(),
+                    SLED_ID_2.parse().unwrap(),
+                    SLED_CONFIG_ID_3.parse().unwrap(),
+                ));
+                expected
+            };
+
+            let rows = ctx
+                .client
+                .query(
+                    "
+                    SELECT
+                    inv_collection_id, sled_id, last_reconciled_config,
+                    boot_disk_slot, boot_disk_error, boot_partition_a_error,
+                    boot_partition_b_error
+                    FROM omicron.public.inv_sled_config_reconciler
+                    ",
+                    &[],
+                )
+                .await
+                .expect("queried post-migration data");
+
+            let mut seen = BTreeSet::new();
+            for row in rows {
+                let inv_collection_id: Uuid = row.get("inv_collection_id");
+                let sled_id: Uuid = row.get("sled_id");
+                let last_reconciled_config: Uuid =
+                    row.get("last_reconciled_config");
+                let boot_disk_slot: Option<i16> = row.get("boot_disk_slot");
+                let boot_disk_error: Option<String> =
+                    row.get("boot_disk_error");
+                let boot_partition_a_error: Option<String> =
+                    row.get("boot_partition_a_error");
+                let boot_partition_b_error: Option<String> =
+                    row.get("boot_partition_b_error");
+
+                seen.insert((
+                    inv_collection_id,
+                    sled_id,
+                    last_reconciled_config,
+                ));
+
+                // Migration should have populated all the error fields.
+                assert_eq!(boot_disk_slot, None);
+                assert_eq!(
+                    boot_disk_error.as_deref(),
+                    Some("old collection, data missing")
+                );
+                assert_eq!(
+                    boot_partition_a_error.as_deref(),
+                    Some("old collection, data missing")
+                );
+                assert_eq!(
+                    boot_partition_b_error.as_deref(),
+                    Some("old collection, data missing")
+                );
+            }
+
+            assert_eq!(seen, expected);
+        })
+    }
+>>>>>>> 857fc1a24 (add schema migrations)
+}
+
 // Lazily initializes all migration checks. The combination of Rust function
 // pointers and async makes defining a static table fairly painful, so we're
 // using lazy initialization instead.
@@ -2584,6 +2730,12 @@ fn get_migration_checks() -> BTreeMap<Version, DataMigrationFns> {
     map.insert(
         Version::new(155, 0, 0),
         DataMigrationFns::new().before(before_155_0_0).after(after_155_0_0),
+    );
+    map.insert(
+        Version::new(156, 0, 0),
+        DataMigrationFns::new()
+            .before(migration_156::before)
+            .after(migration_156::after),
     );
 
     map

--- a/nexus/tests/integration_tests/schema.rs
+++ b/nexus/tests/integration_tests/schema.rs
@@ -2648,7 +2648,6 @@ mod migration_156 {
             assert_eq!(seen, expected);
         })
     }
->>>>>>> 857fc1a24 (add schema migrations)
 }
 
 // Lazily initializes all migration checks. The combination of Rust function

--- a/openapi/sled-agent.json
+++ b/openapi/sled-agent.json
@@ -2854,6 +2854,52 @@
           }
         ]
       },
+      "BootImageHeader": {
+        "type": "object",
+        "properties": {
+          "data_size": {
+            "type": "integer",
+            "format": "uint64",
+            "minimum": 0
+          },
+          "flags": {
+            "type": "integer",
+            "format": "uint64",
+            "minimum": 0
+          },
+          "image_name": {
+            "type": "string"
+          },
+          "image_size": {
+            "type": "integer",
+            "format": "uint64",
+            "minimum": 0
+          },
+          "sha256": {
+            "type": "array",
+            "items": {
+              "type": "integer",
+              "format": "uint8",
+              "minimum": 0
+            },
+            "minItems": 32,
+            "maxItems": 32
+          },
+          "target_size": {
+            "type": "integer",
+            "format": "uint64",
+            "minimum": 0
+          }
+        },
+        "required": [
+          "data_size",
+          "flags",
+          "image_name",
+          "image_size",
+          "sha256",
+          "target_size"
+        ]
+      },
       "BootOrderEntry": {
         "description": "An entry in the boot order stored in a [`BootSettings`] component.",
         "type": "object",
@@ -2869,6 +2915,155 @@
         },
         "required": [
           "id"
+        ]
+      },
+      "BootPartitionContents": {
+        "type": "object",
+        "properties": {
+          "boot_disk": {
+            "x-rust-type": {
+              "crate": "std",
+              "parameters": [
+                {
+                  "$ref": "#/components/schemas/M2Slot"
+                },
+                {
+                  "type": "string"
+                }
+              ],
+              "path": "::std::result::Result",
+              "version": "*"
+            },
+            "oneOf": [
+              {
+                "type": "object",
+                "properties": {
+                  "ok": {
+                    "$ref": "#/components/schemas/M2Slot"
+                  }
+                },
+                "required": [
+                  "ok"
+                ]
+              },
+              {
+                "type": "object",
+                "properties": {
+                  "err": {
+                    "type": "string"
+                  }
+                },
+                "required": [
+                  "err"
+                ]
+              }
+            ]
+          },
+          "slot_a": {
+            "x-rust-type": {
+              "crate": "std",
+              "parameters": [
+                {
+                  "$ref": "#/components/schemas/BootPartitionDetails"
+                },
+                {
+                  "type": "string"
+                }
+              ],
+              "path": "::std::result::Result",
+              "version": "*"
+            },
+            "oneOf": [
+              {
+                "type": "object",
+                "properties": {
+                  "ok": {
+                    "$ref": "#/components/schemas/BootPartitionDetails"
+                  }
+                },
+                "required": [
+                  "ok"
+                ]
+              },
+              {
+                "type": "object",
+                "properties": {
+                  "err": {
+                    "type": "string"
+                  }
+                },
+                "required": [
+                  "err"
+                ]
+              }
+            ]
+          },
+          "slot_b": {
+            "x-rust-type": {
+              "crate": "std",
+              "parameters": [
+                {
+                  "$ref": "#/components/schemas/BootPartitionDetails"
+                },
+                {
+                  "type": "string"
+                }
+              ],
+              "path": "::std::result::Result",
+              "version": "*"
+            },
+            "oneOf": [
+              {
+                "type": "object",
+                "properties": {
+                  "ok": {
+                    "$ref": "#/components/schemas/BootPartitionDetails"
+                  }
+                },
+                "required": [
+                  "ok"
+                ]
+              },
+              {
+                "type": "object",
+                "properties": {
+                  "err": {
+                    "type": "string"
+                  }
+                },
+                "required": [
+                  "err"
+                ]
+              }
+            ]
+          }
+        },
+        "required": [
+          "boot_disk",
+          "slot_a",
+          "slot_b"
+        ]
+      },
+      "BootPartitionDetails": {
+        "type": "object",
+        "properties": {
+          "artifact_hash": {
+            "type": "string",
+            "format": "hex string (32 bytes)"
+          },
+          "artifact_size": {
+            "type": "integer",
+            "format": "uint",
+            "minimum": 0
+          },
+          "header": {
+            "$ref": "#/components/schemas/BootImageHeader"
+          }
+        },
+        "required": [
+          "artifact_hash",
+          "artifact_size",
+          "header"
         ]
       },
       "BootSettings": {
@@ -3547,6 +3742,9 @@
         "description": "Describes the last attempt made by the sled-agent-config-reconciler to reconcile the current sled config against the actual state of the sled.",
         "type": "object",
         "properties": {
+          "boot_partitions": {
+            "$ref": "#/components/schemas/BootPartitionContents"
+          },
           "datasets": {
             "type": "object",
             "additionalProperties": {
@@ -3588,6 +3786,7 @@
           }
         },
         "required": [
+          "boot_partitions",
           "datasets",
           "external_disks",
           "last_reconciled_config",
@@ -5243,6 +5442,14 @@
         },
         "required": [
           "status"
+        ]
+      },
+      "M2Slot": {
+        "description": "Describes an M.2 slot, often in the context of writing a system image to it.",
+        "type": "string",
+        "enum": [
+          "A",
+          "B"
         ]
       },
       "MacAddr": {
@@ -8149,14 +8356,6 @@
         "description": "Zpool names are of the format ox{i,p}_<UUID>. They are either Internal or External, and should be unique",
         "type": "string",
         "pattern": "^ox[ip]_[0-9a-f]{8}-[0-9a-f]{4}-4[0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$"
-      },
-      "M2Slot": {
-        "description": "Describes an M.2 slot, often in the context of writing a system image to it.",
-        "type": "string",
-        "enum": [
-          "A",
-          "B"
-        ]
       },
       "TypedUuidForPropolisKind": {
         "type": "string",

--- a/schema/crdb/boot-partitions-inventory/up1.sql
+++ b/schema/crdb/boot-partitions-inventory/up1.sql
@@ -1,0 +1,15 @@
+CREATE TABLE IF NOT EXISTS omicron.public.inv_sled_config_reconciler (
+    inv_collection_id UUID NOT NULL,
+    sled_id UUID NOT NULL,
+    last_reconciled_config UUID NOT NULL,
+    boot_disk_slot INT2 CHECK (boot_disk_slot >= 0 AND boot_disk_slot <= 1),
+    boot_disk_error TEXT,
+    CONSTRAINT boot_disk_slot_or_error CHECK (
+        (boot_disk_slot IS NULL AND boot_disk_error IS NOT NULL)
+        OR
+        (boot_disk_slot IS NOT NULL AND boot_disk_error IS NULL)
+    ),
+    boot_partition_a_error TEXT,
+    boot_partition_b_error TEXT,
+    PRIMARY KEY (inv_collection_id, sled_id)
+);

--- a/schema/crdb/boot-partitions-inventory/up2.sql
+++ b/schema/crdb/boot-partitions-inventory/up2.sql
@@ -1,0 +1,15 @@
+CREATE TABLE IF NOT EXISTS omicron.public.inv_sled_boot_partition (
+    inv_collection_id UUID NOT NULL,
+    sled_id UUID NOT NULL,
+    boot_disk_slot INT2
+        CHECK (boot_disk_slot >= 0 AND boot_disk_slot <= 1) NOT NULL,
+    artifact_hash STRING(64) NOT NULL,
+    artifact_size INT8 NOT NULL,
+    header_flags INT8 NOT NULL,
+    header_data_size INT8 NOT NULL,
+    header_image_size INT8 NOT NULL,
+    header_target_size INT8 NOT NULL,
+    header_sha256 STRING(64) NOT NULL,
+    header_image_name TEXT NOT NULL,
+    PRIMARY KEY (inv_collection_id, sled_id, boot_disk_slot)
+);

--- a/schema/crdb/boot-partitions-inventory/up3.sql
+++ b/schema/crdb/boot-partitions-inventory/up3.sql
@@ -1,8 +1,9 @@
 SET LOCAL disallow_full_table_scans = off;
 
--- Move any non-NULL `last_reconciled_config` values out of `inv_sled_agent`
--- and into new rows in `inv_sled_config_reconciler`. We fill in the rest of the
--- columns with dummy errors for old collections that don't have data.
+-- Move any non-NULL `last_reconciliation_sled_config` values out of
+-- `inv_sled_agent` and into new rows in `inv_sled_config_reconciler`. We fill
+-- in the rest of the columns with dummy errors for old collections that don't
+-- have data.
 INSERT INTO omicron.public.inv_sled_config_reconciler (
     inv_collection_id,
     sled_id,

--- a/schema/crdb/boot-partitions-inventory/up3.sql
+++ b/schema/crdb/boot-partitions-inventory/up3.sql
@@ -1,0 +1,29 @@
+SET LOCAL disallow_full_table_scans = off;
+
+-- Move any non-NULL `last_reconciled_config` values out of `inv_sled_agent`
+-- and into new rows in `inv_sled_config_reconciler`. We fill in the rest of the
+-- columns with dummy errors for old collections that don't have data.
+INSERT INTO omicron.public.inv_sled_config_reconciler (
+    inv_collection_id,
+    sled_id,
+    last_reconciled_config,
+    boot_disk_slot,
+    boot_disk_error,
+    boot_partition_a_error,
+    boot_partition_b_error
+)
+
+SELECT
+    inv_collection_id,
+    sled_id,
+    last_reconciliation_sled_config,
+    NULL, -- boot_disk_slot
+    'old collection, data missing', -- boot_disk_error
+    'old collection, data missing', -- boot_partition_a_error
+    'old collection, data missing'  -- boot_partition_b_error
+FROM omicron.public.inv_sled_agent
+WHERE last_reconciliation_sled_config IS NOT NULL
+
+-- This is a new table we just created; the only way to get conflicts is if
+-- we're rerunning this migration. Do nothing to make it idempotent.
+ON CONFLICT DO NOTHING;

--- a/schema/crdb/boot-partitions-inventory/up4.sql
+++ b/schema/crdb/boot-partitions-inventory/up4.sql
@@ -1,0 +1,2 @@
+ALTER TABLE omicron.public.inv_sled_agent
+DROP COLUMN IF EXISTS last_reconciliation_sled_config;

--- a/schema/crdb/dbinit.sql
+++ b/schema/crdb/dbinit.sql
@@ -3800,6 +3800,7 @@ CREATE TABLE IF NOT EXISTS omicron.public.inv_sled_boot_partition (
     header_image_size INT8 NOT NULL,
     header_target_size INT8 NOT NULL,
     header_sha256 STRING(64) NOT NULL,
+    header_image_name TEXT NOT NULL,
 
     PRIMARY KEY (inv_collection_id, sled_id, boot_disk_slot)
 );

--- a/schema/crdb/dbinit.sql
+++ b/schema/crdb/dbinit.sql
@@ -3645,11 +3645,6 @@ CREATE TABLE IF NOT EXISTS omicron.public.inv_sled_agent (
     -- This is optional because newly-added sleds don't yet have a config.
     ledgered_sled_config UUID,
 
-    -- Most-recently-reconciled `OmicronSledConfig`
-    -- (foreign key into `inv_omicron_sled_config` table)
-    -- This is optional because the reconciler may not have run yet
-    last_reconciliation_sled_config UUID,
-
     -- Columns making up the status of the config reconciler.
     reconciler_status_kind omicron.public.inv_config_reconciler_status_kind NOT NULL,
     -- (foreign key into `inv_omicron_sled_config` table)
@@ -3739,6 +3734,74 @@ CREATE TABLE IF NOT EXISTS omicron.public.inv_sled_agent (
     ),
 
     PRIMARY KEY (inv_collection_id, sled_id)
+);
+
+CREATE TABLE IF NOT EXISTS omicron.public.inv_sled_config_reconciler (
+    -- where this observation came from
+    -- (foreign key into `inv_collection` table)
+    inv_collection_id UUID NOT NULL,
+
+    -- unique id for this sled (should be foreign keys into `sled` table, though
+    -- it's conceivable a sled will report an id that we don't know about);
+    -- guaranteed to match a row in this collection's `inv_sled_agent`
+    sled_id UUID NOT NULL,
+
+    -- Most-recently-reconciled `OmicronSledConfig`
+    -- (foreign key into `inv_omicron_sled_config` table)
+    last_reconciled_config UUID NOT NULL,
+
+    -- Which internal disk slot did we use at boot?
+    --
+    -- If not NULL, `boot_disk_slot` must be 0 or 1 (corresponding to M2Slot::A
+    -- and M2Slot::B, respectively). The column pair `boot_disk_slot` /
+    -- `boot_disk_error` represents a Rust `Result`; one or the other must be
+    -- non-NULL, but not both.
+    boot_disk_slot INT2 CHECK (boot_disk_slot >= 0 AND boot_disk_slot <= 1),
+    boot_disk_error TEXT,
+    CONSTRAINT boot_disk_slot_or_error CHECK (
+        (boot_disk_slot IS NULL AND boot_disk_error IS NOT NULL)
+        OR
+        (boot_disk_slot IS NOT NULL AND boot_disk_error IS NULL)
+    ),
+
+    -- If either error string is present, there was an error reading the boot
+    -- partition for the corresponding M2Slot.
+    --
+    -- For either or both columns if NULL, there will be a row in
+    -- `inv_sled_boot_partition` describing the contents of the boot partition
+    -- for the given slot. As above 0=a and 1=b.
+    boot_partition_a_error TEXT,
+    boot_partition_b_error TEXT,
+
+    PRIMARY KEY (inv_collection_id, sled_id)
+);
+
+CREATE TABLE IF NOT EXISTS omicron.public.inv_sled_boot_partition (
+    -- where this observation came from
+    -- (foreign key into `inv_collection` table)
+    inv_collection_id UUID NOT NULL,
+
+    -- unique id for this sled (should be foreign keys into `sled` table, though
+    -- it's conceivable a sled will report an id that we don't know about)
+    sled_id UUID NOT NULL,
+
+    -- the boot disk slot (0=M2Slot::A, 1=M2Slot::B)
+    boot_disk_slot INT2 CHECK (boot_disk_slot >= 0 AND boot_disk_slot <= 1) NOT NULL,
+
+    -- SHA256 hash of the artifact; if we have a TUF repo containing this OS
+    -- image, this will match the artifact hash of the phase 2 image
+    artifact_hash STRING(64) NOT NULL,
+    -- The length of the artifact in bytes
+    artifact_size INT8 NOT NULL,
+
+    -- Fields comprising the header of the phase 2 image
+    header_flags INT8 NOT NULL,
+    header_data_size INT8 NOT NULL,
+    header_image_size INT8 NOT NULL,
+    header_target_size INT8 NOT NULL,
+    header_sha256 STRING(64) NOT NULL,
+
+    PRIMARY KEY (inv_collection_id, sled_id, boot_disk_slot)
 );
 
 CREATE TABLE IF NOT EXISTS omicron.public.inv_physical_disk (

--- a/schema/crdb/dbinit.sql
+++ b/schema/crdb/dbinit.sql
@@ -3786,7 +3786,8 @@ CREATE TABLE IF NOT EXISTS omicron.public.inv_sled_boot_partition (
     sled_id UUID NOT NULL,
 
     -- the boot disk slot (0=M2Slot::A, 1=M2Slot::B)
-    boot_disk_slot INT2 CHECK (boot_disk_slot >= 0 AND boot_disk_slot <= 1) NOT NULL,
+    boot_disk_slot INT2
+        CHECK (boot_disk_slot >= 0 AND boot_disk_slot <= 1) NOT NULL,
 
     -- SHA256 hash of the artifact; if we have a TUF repo containing this OS
     -- image, this will match the artifact hash of the phase 2 image
@@ -6174,7 +6175,7 @@ INSERT INTO omicron.public.db_metadata (
     version,
     target_version
 ) VALUES
-    (TRUE, NOW(), NOW(), '155.0.0', NULL)
+    (TRUE, NOW(), NOW(), '156.0.0', NULL)
 ON CONFLICT DO NOTHING;
 
 COMMIT;

--- a/sled-agent/config-reconciler/src/host_phase_2.rs
+++ b/sled-agent/config-reconciler/src/host_phase_2.rs
@@ -6,19 +6,14 @@
 //! partitions.
 
 use crate::InternalDisks;
-use bytes::Buf as _;
 use camino::Utf8PathBuf;
-use illumos_utils::dkio::MediaInfoExtended;
+use nexus_sled_agent_shared::inventory::BootPartitionDetails;
 use omicron_common::disk::M2Slot;
-use sha2::Digest as _;
 use sled_hardware::PooledDiskError;
-use std::cmp;
-use std::fs::File;
 use std::io;
 use std::io::BufRead as _;
 use std::io::BufReader;
 use std::io::Read as _;
-use std::os::fd::AsRawFd as _;
 use std::sync::Arc;
 use tufaceous_artifact::ArtifactHash;
 
@@ -77,14 +72,6 @@ pub enum BootPartitionError {
 }
 
 #[derive(Debug)]
-#[allow(unused)] // TODO remove once this is reported in inventory
-pub struct BootPartitionDetails {
-    pub header: BootImageHeader,
-    pub artifact_hash: ArtifactHash,
-    pub artifact_size: usize,
-}
-
-#[derive(Debug)]
 pub struct BootPartitionContents {
     pub boot_disk: Result<M2Slot, BootDiskNotFound>,
     pub slot_a: Result<BootPartitionDetails, BootPartitionError>,
@@ -94,8 +81,8 @@ pub struct BootPartitionContents {
 impl BootPartitionContents {
     pub async fn read(internal_disks: &InternalDisks) -> Self {
         let (slot_a, slot_b) = futures::join!(
-            BootPartitionDetails::read(M2Slot::A, internal_disks),
-            BootPartitionDetails::read(M2Slot::B, internal_disks),
+            boot_partition_details::read(M2Slot::A, internal_disks),
+            boot_partition_details::read(M2Slot::B, internal_disks),
         );
         Self {
             boot_disk: internal_disks.boot_disk_slot().ok_or(BootDiskNotFound),
@@ -105,14 +92,23 @@ impl BootPartitionContents {
     }
 }
 
-impl BootPartitionDetails {
-    async fn read(
+// These would be methods on `BootPartitionDetails` if we defined it,
+// but it's defined in `nexus_sled_agent_shared`. Use a module instead.
+mod boot_partition_details {
+    use super::*;
+    use illumos_utils::dkio::MediaInfoExtended;
+    use sha2::Digest as _;
+    use std::cmp;
+    use std::fs::File;
+    use std::os::fd::AsRawFd as _;
+
+    pub(super) async fn read(
         slot: M2Slot,
         internal_disks: &InternalDisks,
-    ) -> Result<Self, BootPartitionError> {
+    ) -> Result<BootPartitionDetails, BootPartitionError> {
         match internal_disks.image_raw_devfs_path(slot) {
             Some(Ok(path)) => {
-                tokio::task::spawn_blocking(|| Self::read_blocking(path))
+                tokio::task::spawn_blocking(|| read_blocking(path))
                     .await
                     .expect("read_blocking() did not panic")
             }
@@ -121,7 +117,9 @@ impl BootPartitionDetails {
         }
     }
 
-    fn read_blocking(path: Utf8PathBuf) -> Result<Self, BootPartitionError> {
+    fn read_blocking(
+        path: Utf8PathBuf,
+    ) -> Result<BootPartitionDetails, BootPartitionError> {
         const ONE_MIB: usize = 1024 * 1024;
 
         let f = File::open(&path).map_err(|err| {
@@ -152,7 +150,7 @@ impl BootPartitionDetails {
             block_size = 128 * ONE_MIB;
         }
 
-        Self::read_blocking_with_buf_size(
+        read_blocking_with_buf_size(
             &mut BufReaderExactSize::with_capacity(block_size, f),
             path,
         )
@@ -161,10 +159,12 @@ impl BootPartitionDetails {
     // This is separated from `read_blocking()` so we can write unit tests over
     // this function without needing real disks that respond to the
     // `MediaInfoExtended` ioctl.
-    fn read_blocking_with_buf_size<R: io::Read>(
+    //
+    // This is `pub(super)` only so it can be tested.
+    pub(super) fn read_blocking_with_buf_size<R: io::Read>(
         f: &mut BufReaderExactSize<R>,
         path: Utf8PathBuf,
-    ) -> Result<Self, BootPartitionError> {
+    ) -> Result<BootPartitionDetails, BootPartitionError> {
         // Compute two SHA256 hashes as we read the contents of this boot image.
         // The `image_header` contains a sha256 of the data _after_ the header
         // itself, but the artifact hash that lands in the TUF repo depo
@@ -176,11 +176,11 @@ impl BootPartitionDetails {
         // Read the image header and accumulate it into artifact_hasher but not
         // data_hasher.
         let image_header = {
-            let mut buf = [0; BootImageHeader::SIZE];
+            let mut buf = [0; boot_image_header::SIZE];
             f.read_exact(&mut buf).map_err(|err| {
                 BootPartitionError::ReadImageHeader { path: path.clone(), err }
             })?;
-            let header = BootImageHeader::parse(&buf).map_err(|err| {
+            let header = boot_image_header::parse(&buf).map_err(|err| {
                 BootPartitionError::ParseImageHeader { path: path.clone(), err }
             })?;
             artifact_hasher.update(&buf);
@@ -188,7 +188,7 @@ impl BootPartitionDetails {
         };
 
         let mut nleft = image_header.data_size as usize;
-        let mut offset = BootImageHeader::SIZE;
+        let mut offset = boot_image_header::SIZE;
         let artifact_size = nleft + offset;
         while nleft > 0 {
             // Read the rest of the image in block-sized chunks by filling the
@@ -225,7 +225,7 @@ impl BootPartitionDetails {
             });
         }
 
-        Ok(Self {
+        Ok(BootPartitionDetails {
             artifact_hash: ArtifactHash(artifact_hash.into()),
             artifact_size,
             header: image_header,
@@ -247,44 +247,39 @@ pub enum ImageHeaderParseError {
     BadImageTargetSize { image_size: u64, target_size: u64 },
 }
 
-// There are several other fields in the header that we either parse and discard
-// or ignore completely; see https://github.com/oxidecomputer/boot-image-tools
-// for more thorough support.
-#[derive(Debug)]
-#[allow(unused)] // TODO remove once this is reported in inventory
-pub struct BootImageHeader {
-    pub flags: u64,
-    pub data_size: u64,
-    pub image_size: u64,
-    pub target_size: u64,
-    pub sha256: [u8; 32],
-}
+// These would be constants and methods on `BootImageHeader` if we defined it,
+// but it's defined in `nexus_sled_agent_shared`. Use a module instead.
+mod boot_image_header {
+    use super::ImageHeaderParseError;
+    use bytes::Buf as _;
+    use nexus_sled_agent_shared::inventory::BootImageHeader;
 
-impl BootImageHeader {
-    const SIZE: usize = 4096;
-    const MAGIC: u32 = 0x1deb0075;
-    const VERSION: u32 = 2;
+    pub(super) const SIZE: usize = 4096;
+    pub(super) const MAGIC: u32 = 0x1deb0075;
+    pub(super) const VERSION: u32 = 2;
 
-    fn parse(mut buf: &[u8]) -> Result<Self, ImageHeaderParseError> {
+    pub(super) fn parse(
+        mut buf: &[u8],
+    ) -> Result<BootImageHeader, ImageHeaderParseError> {
         // The `get_*_le()` methods below (from `bytes::Buf`) panic if the slice
         // isn't long enough. We can check once that we have enough data for a
         // full header, guaranteeing none of the `get_*`s below will panic.
-        if buf.len() < Self::SIZE {
+        if buf.len() < SIZE {
             return Err(ImageHeaderParseError::TooSmall);
         }
 
         let magic = buf.get_u32_le();
-        if magic != Self::MAGIC {
+        if magic != MAGIC {
             return Err(ImageHeaderParseError::BadMagic {
-                expected: Self::MAGIC,
+                expected: MAGIC,
                 got: magic,
             });
         }
 
         let version = buf.get_u32_le();
-        if version != Self::VERSION {
+        if version != VERSION {
             return Err(ImageHeaderParseError::BadVersion {
-                expected: Self::VERSION,
+                expected: VERSION,
                 got: version,
             });
         }
@@ -303,7 +298,13 @@ impl BootImageHeader {
         let mut sha256 = [0; 32];
         sha256.copy_from_slice(&buf[..32]);
 
-        Ok(Self { flags, data_size, image_size, target_size, sha256 })
+        Ok(BootImageHeader {
+            flags,
+            data_size,
+            image_size,
+            target_size,
+            sha256,
+        })
     }
 }
 
@@ -360,6 +361,7 @@ mod tests {
     use proptest::collection::vec;
     use proptest::prelude::*;
     use proptest::prop_oneof;
+    use sha2::Digest as _;
     use slog_error_chain::InlineErrorChain;
     use test_strategy::proptest;
 
@@ -403,10 +405,10 @@ mod tests {
 
     fn prepend_valid_image_hader(data: &mut Vec<u8>) -> [u8; 32] {
         let sha256 = sha2::Sha256::digest(&data);
-        let mut header = [0; BootImageHeader::SIZE];
+        let mut header = [0; boot_image_header::SIZE];
         let mut buf = header.as_mut_slice();
-        buf.put_u32_le(BootImageHeader::MAGIC);
-        buf.put_u32_le(BootImageHeader::VERSION);
+        buf.put_u32_le(boot_image_header::MAGIC);
+        buf.put_u32_le(boot_image_header::VERSION);
         buf.put_u64_le(0); // flags
         buf.put_u64_le(data.len() as u64);
         buf.put_u64_le(data.len() as u64);
@@ -449,7 +451,7 @@ mod tests {
             block_size,
             NeverEndingReader::new(&*data),
         );
-        match BootPartitionDetails::read_blocking_with_buf_size(
+        match boot_partition_details::read_blocking_with_buf_size(
             &mut reader,
             "/does-not-matter".into(),
         ) {

--- a/sled-agent/config-reconciler/src/host_phase_2.rs
+++ b/sled-agent/config-reconciler/src/host_phase_2.rs
@@ -7,9 +7,11 @@
 
 use crate::InternalDisks;
 use camino::Utf8PathBuf;
+use nexus_sled_agent_shared::inventory::BootPartitionContents as BootPartitionContentsInventory;
 use nexus_sled_agent_shared::inventory::BootPartitionDetails;
 use omicron_common::disk::M2Slot;
 use sled_hardware::PooledDiskError;
+use slog_error_chain::InlineErrorChain;
 use std::io;
 use std::io::BufRead as _;
 use std::io::BufReader;
@@ -88,6 +90,17 @@ impl BootPartitionContents {
             boot_disk: internal_disks.boot_disk_slot().ok_or(BootDiskNotFound),
             slot_a,
             slot_b,
+        }
+    }
+
+    pub fn into_inventory(self) -> BootPartitionContentsInventory {
+        let err_to_string = |err: &dyn std::error::Error| {
+            InlineErrorChain::new(err).to_string()
+        };
+        BootPartitionContentsInventory {
+            boot_disk: self.boot_disk.map_err(|e| err_to_string(&e)),
+            slot_a: self.slot_a.map_err(|e| err_to_string(&e)),
+            slot_b: self.slot_b.map_err(|e| err_to_string(&e)),
         }
     }
 }


### PR DESCRIPTION
This is stacked on top of #8450. It adds a `BootPartitionContents` structure to the inventory reported by the sled-agent-config-reconciler which contains:

* which slot we booted from (A or B)
* the contents of each slot

each of which is a `Result` in case we failed to determine any of those three items. In practice, I'd expect us to basically never fail to report which slot we booted from, and to only fail on the contents of a slot if that slot doesn't have a valid phase 2 image in it.

Almost all of the changes here are related to updating the db schema to store this new information (and updating the queries to insert/read/delete the new tables). `up3.sql` is worth a particularly close look, because we've moved a field out of `inv_sled_agent` and into a new table, so that part of the migration attempts to ensure we create rows in the new table for each row in `inv_sled_agent` that had a value for that field. There's a data migration test that covers this.