### PR TITLE
[20/n] [reconfigurator-planning] do decommission before add

### DIFF
--- a/nexus/reconfigurator/planning/src/planner.rs
+++ b/nexus/reconfigurator/planning/src/planner.rs
@@ -146,8 +146,8 @@ impl<'a> Planner<'a> {
 
     fn do_plan(&mut self) -> Result<(), Error> {
         self.do_plan_expunge()?;
-        self.do_plan_add()?;
         self.do_plan_decommission()?;
+        self.do_plan_add()?;
         if let UpdateStepResult::ContinueToNextStep = self.do_plan_mgs_updates()
         {
             self.do_plan_zone_updates()?;


### PR DESCRIPTION
In #8456 we'll block the `do_plan_add` step on whether the system is currently recovering from a mupdate override. But there's no reason to block the `do_plan_decommission` step on that.

This is easiest expressed by moving decommission to before add.
