### PR TITLE
Nexus must hang onto qorb resolvers used for MGS updates

### DIFF
--- a/nexus/src/app/mod.rs
+++ b/nexus/src/app/mod.rs
@@ -269,6 +269,18 @@ pub struct Nexus {
 
     /// reports status of pending MGS-managed updates
     mgs_update_status_rx: watch::Receiver<MgsUpdateDriverStatus>,
+
+    /// DNS resolver used by MgsUpdateDriver for MGS
+    // We don't need to do anything with this, but we can't let it be dropped
+    // while Nexus is running.
+    #[allow(dead_code)]
+    mgs_resolver: Box<dyn qorb::resolver::Resolver>,
+
+    /// DNS resolver used by MgsUpdateDriver for Repo Depot
+    // We don't need to do anything with this, but we can't let it be dropped
+    // while Nexus is running.
+    #[allow(dead_code)]
+    repo_depot_resolver: Box<dyn qorb::resolver::Resolver>,
 }
 
 impl Nexus {
@@ -496,6 +508,8 @@ impl Nexus {
             )),
             tuf_artifact_replication_tx,
             mgs_update_status_rx,
+            mgs_resolver,
+            repo_depot_resolver,
         };
 
         // TODO-cleanup all the extra Arcs here seems wrong


### PR DESCRIPTION
The failure mode here is that when using Nexus to update SPs, all the updates fail with messages like this:

```
23:40:39.213Z INFO bea4cc1e-0758-4643-a4b4-669f67689c6c (ServerContext): update attempt done
    artifact_hash = 100352eb10b8e657bfa168dddd6a3e1cff3f1a3f5600feacfa5bf6b8983ec145
    artifact_version = 1.0.39
    elapsed_millis = 0
    error = found no MGS backends in DNS
    expected_active_version = 1.0.38
    expected_inactive_version = Version(ArtifactVersion("1.0.38"))
    file = nexus/mgs-updates/src/driver.rs:422
    part_number = 913-0000006
    serial_number = BRM23230002
    sp_slot = 0
    sp_type = Switch
    update_id = e17b53c0-f1d6-4f1c-a77d-d63fc08587e5
```

It says "found no MGS backends in DNS" but there _are_ MGS backends in DNS.  The problem is that we dropped the resolvers and so they're not doing any DNS resolution.