### PR TITLE
Blueprint PlanningInput: Fewer `Option`s

### DIFF
--- a/dev-tools/reconfigurator-cli/src/lib.rs
+++ b/dev-tools/reconfigurator-cli/src/lib.rs
@@ -23,7 +23,6 @@ use nexus_reconfigurator_planning::system::{SledBuilder, SystemDescription};
 use nexus_reconfigurator_simulation::SimStateBuilder;
 use nexus_reconfigurator_simulation::Simulator;
 use nexus_reconfigurator_simulation::{BlueprintId, SimState};
-use nexus_types::deployment::OmicronZoneNic;
 use nexus_types::deployment::PlanningInput;
 use nexus_types::deployment::SledFilter;
 use nexus_types::deployment::execution;
@@ -35,6 +34,7 @@ use nexus_types::deployment::{
     BlueprintZoneImageSource, PendingMgsUpdateDetails,
 };
 use nexus_types::deployment::{BlueprintZoneImageVersion, PendingMgsUpdate};
+use nexus_types::deployment::{OmicronZoneNic, TargetReleaseDescription};
 use nexus_types::external_api::views::SledPolicy;
 use nexus_types::external_api::views::SledProvisionPolicy;
 use omicron_common::address::REPO_DEPOT_PORT;
@@ -1673,7 +1673,7 @@ fn cmd_show(sim: &mut ReconfiguratorSim) -> anyhow::Result<Option<String>> {
 
     let target_release = state.system().description().target_release();
     match target_release.description() {
-        Some(tuf_desc) => {
+        TargetReleaseDescription::TufRepo(tuf_desc) => {
             swriteln!(
                 s,
                 "target release (generation {}): {} ({})",
@@ -1692,7 +1692,7 @@ fn cmd_show(sim: &mut ReconfiguratorSim) -> anyhow::Result<Option<String>> {
                 );
             }
         }
-        None => {
+        TargetReleaseDescription::Initial => {
             swriteln!(
                 s,
                 "target release (generation {}): unset",
@@ -1759,10 +1759,9 @@ fn cmd_set(
             })?;
             let description = artifacts_with_plan.description().clone();
             drop(artifacts_with_plan);
-            state
-                .system_mut()
-                .description_mut()
-                .set_target_release(Some(description));
+            state.system_mut().description_mut().set_target_release(
+                TargetReleaseDescription::TufRepo(description),
+            );
             format!("set target release based on {}", filename)
         }
     };

--- a/nexus/reconfigurator/execution/src/dns.rs
+++ b/nexus/reconfigurator/execution/src/dns.rs
@@ -1497,7 +1497,7 @@ mod test {
                 clickhouse_policy: None,
                 oximeter_read_policy: OximeterReadPolicy::new(1),
                 tuf_repo: TufRepoPolicy::initial(),
-                old_repo: None,
+                old_repo: TufRepoPolicy::initial(),
                 log,
             }
             .build()

--- a/nexus/reconfigurator/planning/src/mgs_updates/mod.rs
+++ b/nexus/reconfigurator/planning/src/mgs_updates/mod.rs
@@ -8,6 +8,7 @@ use nexus_types::deployment::ExpectedVersion;
 use nexus_types::deployment::PendingMgsUpdate;
 use nexus_types::deployment::PendingMgsUpdateDetails;
 use nexus_types::deployment::PendingMgsUpdates;
+use nexus_types::deployment::TargetReleaseDescription;
 use nexus_types::inventory::BaseboardId;
 use nexus_types::inventory::CabooseWhich;
 use nexus_types::inventory::Collection;
@@ -38,7 +39,7 @@ pub fn plan_mgs_updates(
     inventory: &Collection,
     current_boards: &BTreeSet<Arc<BaseboardId>>,
     current_updates: &PendingMgsUpdates,
-    current_artifacts: Option<&TufRepoDescription>,
+    current_artifacts: &TargetReleaseDescription,
     nmax_updates: usize,
 ) -> PendingMgsUpdates {
     let mut rv = PendingMgsUpdates::new();
@@ -97,11 +98,14 @@ pub fn plan_mgs_updates(
         }
     }
 
-    // If we don't have any current artifacts (i.e., there is no target release
-    // set), then we cannot configure more updates.
-    let Some(current_artifacts) = &current_artifacts else {
-        warn!(log, "cannot issue more SP updates (no current artifacts)");
-        return rv;
+    // If we don't have a "real" target release (i.e., an uploaded TUF repo
+    // containing artifacts), then we cannot configure more updates.
+    let current_artifacts = match current_artifacts {
+        TargetReleaseDescription::Initial => {
+            warn!(log, "cannot issue more SP updates (no current artifacts)");
+            return rv;
+        }
+        TargetReleaseDescription::TufRepo(description) => description,
     };
 
     // Next, configure new updates for any boards that need an update, up to
@@ -491,6 +495,7 @@ mod test {
     use nexus_types::deployment::PendingMgsUpdate;
     use nexus_types::deployment::PendingMgsUpdateDetails;
     use nexus_types::deployment::PendingMgsUpdates;
+    use nexus_types::deployment::TargetReleaseDescription;
     use nexus_types::inventory::CabooseWhich;
     use nexus_types::inventory::Collection;
     use nexus_types::inventory::RotSlot;
@@ -776,7 +781,7 @@ mod test {
             &collection,
             current_boards,
             &initial_updates,
-            None,
+            &TargetReleaseDescription::Initial,
             nmax_updates,
         );
         assert!(updates.is_empty());
@@ -789,7 +794,7 @@ mod test {
             &collection,
             current_boards,
             &initial_updates,
-            Some(&repo),
+            &TargetReleaseDescription::TufRepo(repo.clone()),
             nmax_updates,
         );
         assert_eq!(updates.len(), 1);
@@ -808,7 +813,7 @@ mod test {
             &collection,
             current_boards,
             &updates,
-            Some(&repo),
+            &TargetReleaseDescription::TufRepo(repo.clone()),
             nmax_updates,
         );
         assert_eq!(updates, later_updates);
@@ -829,7 +834,7 @@ mod test {
             &later_collection,
             current_boards,
             &updates,
-            Some(&repo),
+            &TargetReleaseDescription::TufRepo(repo.clone()),
             nmax_updates,
         );
         assert_eq!(updates, later_updates);
@@ -848,7 +853,7 @@ mod test {
             &later_collection,
             current_boards,
             &updates,
-            Some(&repo),
+            &TargetReleaseDescription::TufRepo(repo.clone()),
             nmax_updates,
         );
         assert_eq!(later_updates.len(), 1);
@@ -873,7 +878,7 @@ mod test {
             &updated_collection,
             current_boards,
             &later_updates,
-            Some(&repo),
+            &TargetReleaseDescription::TufRepo(repo.clone()),
             nmax_updates,
         );
         assert!(later_updates.is_empty());
@@ -890,7 +895,7 @@ mod test {
             &collection,
             &BTreeSet::new(),
             &PendingMgsUpdates::new(),
-            Some(&repo),
+            &TargetReleaseDescription::TufRepo(repo.clone()),
             nmax_updates,
         );
         assert!(updates.is_empty());
@@ -899,7 +904,7 @@ mod test {
             &collection,
             &collection.baseboards,
             &PendingMgsUpdates::new(),
-            Some(&repo),
+            &TargetReleaseDescription::TufRepo(repo.clone()),
             nmax_updates,
         );
         // We verified most of the details above.  Here we're just double
@@ -935,7 +940,7 @@ mod test {
             &collection,
             &collection.baseboards,
             &updates,
-            Some(&repo),
+            &TargetReleaseDescription::TufRepo(repo.clone()),
             nmax_updates,
         );
         assert_ne!(updates, new_updates);
@@ -973,7 +978,7 @@ mod test {
             &collection,
             &collection.baseboards,
             &updates,
-            Some(&repo),
+            &TargetReleaseDescription::TufRepo(repo.clone()),
             nmax_updates,
         );
         assert_ne!(updates, new_updates);
@@ -1047,7 +1052,7 @@ mod test {
                 &collection,
                 current_boards,
                 &latest_updates,
-                Some(&repo),
+                &TargetReleaseDescription::TufRepo(repo.clone()),
                 nmax_updates,
             );
             assert_eq!(new_updates.len(), 1);
@@ -1077,7 +1082,7 @@ mod test {
             &collection,
             &collection.baseboards,
             &latest_updates,
-            Some(&repo),
+            &TargetReleaseDescription::TufRepo(repo.clone()),
             nmax_updates,
         );
         assert!(last_updates.is_empty());
@@ -1113,7 +1118,7 @@ mod test {
             &collection,
             &collection.baseboards,
             &PendingMgsUpdates::new(),
-            Some(&repo),
+            &TargetReleaseDescription::TufRepo(repo.clone()),
             usize::MAX,
         );
         assert_eq!(all_updates.len(), expected_updates.len());
@@ -1133,7 +1138,7 @@ mod test {
             &collection,
             &collection.baseboards,
             &all_updates,
-            Some(&repo),
+            &TargetReleaseDescription::TufRepo(repo.clone()),
             1,
         );
         assert!(all_updates_done.is_empty());
@@ -1186,7 +1191,7 @@ mod test {
             &collection,
             &collection.baseboards,
             &PendingMgsUpdates::new(),
-            Some(&repo),
+            &TargetReleaseDescription::TufRepo(repo.clone()),
             1,
         );
         assert!(!updates.is_empty());
@@ -1208,7 +1213,7 @@ mod test {
             &collection,
             &collection.baseboards,
             &updates,
-            Some(&repo),
+            &TargetReleaseDescription::TufRepo(repo.clone()),
             1,
         );
         assert!(!new_updates.is_empty());

--- a/nexus/reconfigurator/planning/src/system.rs
+++ b/nexus/reconfigurator/planning/src/system.rs
@@ -109,7 +109,7 @@ pub struct SystemDescription {
     clickhouse_policy: Option<ClickhousePolicy>,
     oximeter_read_policy: OximeterReadPolicy,
     tuf_repo: TufRepoPolicy,
-    old_repo: Option<TufRepoPolicy>,
+    old_repo: TufRepoPolicy,
 }
 
 impl SystemDescription {
@@ -190,7 +190,7 @@ impl SystemDescription {
             clickhouse_policy: None,
             oximeter_read_policy: OximeterReadPolicy::new(1),
             tuf_repo: TufRepoPolicy::initial(),
-            old_repo: None,
+            old_repo: TufRepoPolicy::initial(),
         }
     }
 

--- a/nexus/reconfigurator/planning/src/system.rs
+++ b/nexus/reconfigurator/planning/src/system.rs
@@ -34,6 +34,7 @@ use nexus_types::deployment::Policy;
 use nexus_types::deployment::SledDetails;
 use nexus_types::deployment::SledDisk;
 use nexus_types::deployment::SledResources;
+use nexus_types::deployment::TargetReleaseDescription;
 use nexus_types::deployment::TufRepoPolicy;
 use nexus_types::external_api::views::PhysicalDiskPolicy;
 use nexus_types::external_api::views::PhysicalDiskState;
@@ -53,7 +54,6 @@ use omicron_common::address::SLED_PREFIX;
 use omicron_common::address::get_sled_address;
 use omicron_common::api::external::ByteCount;
 use omicron_common::api::external::Generation;
-use omicron_common::api::external::TufRepoDescription;
 use omicron_common::disk::DiskIdentity;
 use omicron_common::disk::DiskVariant;
 use omicron_common::policy::INTERNAL_DNS_REDUNDANCY;
@@ -475,7 +475,7 @@ impl SystemDescription {
 
     pub fn set_target_release(
         &mut self,
-        tuf_repo: Option<TufRepoDescription>,
+        description: TargetReleaseDescription,
     ) -> &mut Self {
         // Create a new TufRepoPolicy by bumping the generation.
         let new_repo = TufRepoPolicy {
@@ -483,7 +483,7 @@ impl SystemDescription {
                 .tuf_repo
                 .target_release_generation
                 .next(),
-            description: tuf_repo,
+            description,
         };
 
         self.tuf_repo = new_repo;

--- a/nexus/reconfigurator/preparation/src/lib.rs
+++ b/nexus/reconfigurator/preparation/src/lib.rs
@@ -83,7 +83,7 @@ pub struct PlanningInputFromDb<'a> {
     pub clickhouse_policy: Option<ClickhousePolicy>,
     pub oximeter_read_policy: OximeterReadPolicy,
     pub tuf_repo: TufRepoPolicy,
-    pub old_repo: Option<TufRepoPolicy>,
+    pub old_repo: TufRepoPolicy,
     pub log: &'a Logger,
 }
 
@@ -197,9 +197,9 @@ impl PlanningInputFromDb<'_> {
             } else {
                 TargetReleaseDescription::Initial
             };
-            Some(TufRepoPolicy { target_release_generation: prev, description })
+            TufRepoPolicy { target_release_generation: prev, description }
         } else {
-            None
+            TufRepoPolicy::initial()
         };
 
         let oximeter_read_policy = datastore

--- a/nexus/src/app/deployment.rs
+++ b/nexus/src/app/deployment.rs
@@ -214,7 +214,7 @@ impl super::Nexus {
         let old = planning_context
             .planning_input
             .old_repo()
-            .and_then(|repo| repo.description());
+            .map(|repo| repo.description());
         let status = UpdateStatus::new(
             old,
             new,

--- a/nexus/src/app/deployment.rs
+++ b/nexus/src/app/deployment.rs
@@ -211,10 +211,7 @@ impl super::Nexus {
             Error::internal_error("no recent inventory collection found")
         })?;
         let new = planning_context.planning_input.tuf_repo().description();
-        let old = planning_context
-            .planning_input
-            .old_repo()
-            .map(|repo| repo.description());
+        let old = planning_context.planning_input.old_repo().description();
         let status = UpdateStatus::new(
             old,
             new,

--- a/nexus/types/src/deployment.rs
+++ b/nexus/types/src/deployment.rs
@@ -101,6 +101,7 @@ pub use planning_input::SledFilter;
 pub use planning_input::SledLookupError;
 pub use planning_input::SledLookupErrorKind;
 pub use planning_input::SledResources;
+pub use planning_input::TargetReleaseDescription;
 pub use planning_input::TufRepoPolicy;
 pub use planning_input::ZpoolFilter;
 use std::sync::Arc;

--- a/nexus/types/src/deployment/planning_input.rs
+++ b/nexus/types/src/deployment/planning_input.rs
@@ -977,8 +977,8 @@ pub struct TufRepoPolicy {
     /// The generation of the target release for the TUF repo.
     pub target_release_generation: Generation,
 
-    /// A description of the TUF repo, or None if no TUF repo is in use.
-    pub description: Option<TufRepoDescription>,
+    /// A description of the target release.
+    pub description: TargetReleaseDescription,
 }
 
 impl TufRepoPolicy {
@@ -988,12 +988,36 @@ impl TufRepoPolicy {
     /// * There is no target release.
     #[inline]
     pub fn initial() -> Self {
-        Self { target_release_generation: Generation::new(), description: None }
+        Self {
+            target_release_generation: Generation::new(),
+            description: TargetReleaseDescription::Initial,
+        }
     }
 
     #[inline]
-    pub fn description(&self) -> Option<&TufRepoDescription> {
-        self.description.as_ref()
+    pub fn description(&self) -> &TargetReleaseDescription {
+        &self.description
+    }
+}
+
+/// Source of artifacts for a given target release.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub enum TargetReleaseDescription {
+    /// The initial release source for an Oxide deployment, before any TUF repo
+    /// has been provided for upgrades.
+    Initial,
+
+    /// A TUF repo: this is the target release once an Oxide deployment has
+    /// undergone operator-driven updates.
+    TufRepo(TufRepoDescription),
+}
+
+impl TargetReleaseDescription {
+    pub fn tuf_repo(&self) -> Option<&TufRepoDescription> {
+        match self {
+            Self::Initial => None,
+            Self::TufRepo(tuf_repo) => Some(tuf_repo),
+        }
     }
 }
 

--- a/nexus/types/src/deployment/planning_input.rs
+++ b/nexus/types/src/deployment/planning_input.rs
@@ -158,8 +158,8 @@ impl PlanningInput {
         &self.policy.tuf_repo
     }
 
-    pub fn old_repo(&self) -> Option<&TufRepoPolicy> {
-        self.policy.old_repo.as_ref()
+    pub fn old_repo(&self) -> &TufRepoPolicy {
+        &self.policy.old_repo
     }
 
     pub fn service_ip_pool_ranges(&self) -> &[IpRange] {
@@ -944,12 +944,19 @@ pub struct Policy {
     /// with one that does.
     pub tuf_repo: TufRepoPolicy,
 
-    /// Previous system software release repository, if any. Once Nexus-driven
-    /// update is active on a rack, this is always `Some`.
+    /// Previous system software release repository.
+    ///
+    /// On initial system deployment, both `tuf_repo` and `old_repo` will be set
+    /// to `TufRepoPolicy::initial()` (the special TUF repo policy for "we don't
+    /// have a TUF repo yet"). After one target release has been set, `tuf_repo`
+    /// will reflect that target release and `old_repo` will still be
+    /// `TufRepoPolicy::initial()`. Once two or more target releases have been
+    /// set, `old_repo` will contain "the previous target release" behind
+    /// whatever value is in `tuf_repo`.
     ///
     /// New zones deployed mid-update may use artifacts in this repo as
     /// their image sources. See RFD 565 §9.
-    pub old_repo: Option<TufRepoPolicy>,
+    pub old_repo: TufRepoPolicy,
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize, JsonSchema)]
@@ -1172,7 +1179,7 @@ impl PlanningInputBuilder {
                 clickhouse_policy: None,
                 oximeter_read_policy: OximeterReadPolicy::new(1),
                 tuf_repo: TufRepoPolicy::initial(),
-                old_repo: None,
+                old_repo: TufRepoPolicy::initial(),
             },
             internal_dns_version: Generation::new(),
             external_dns_version: Generation::new(),

--- a/nexus/types/src/internal_api/views.rs
+++ b/nexus/types/src/internal_api/views.rs
@@ -529,7 +529,7 @@ pub struct UpdateStatus {
 
 impl UpdateStatus {
     pub fn new<'a>(
-        old: Option<&TargetReleaseDescription>,
+        old: &TargetReleaseDescription,
         new: &TargetReleaseDescription,
         sleds: impl Iterator<
             Item = (&'a SledUuid, &'a Option<ConfigReconcilerInventory>),
@@ -560,7 +560,7 @@ impl UpdateStatus {
     }
 
     pub fn zone_image_source_to_version(
-        old: Option<&TargetReleaseDescription>,
+        old: &TargetReleaseDescription,
         new: &TargetReleaseDescription,
         source: &OmicronZoneImageSource,
         res: &ConfigReconcilerInventoryResult,
@@ -573,7 +573,7 @@ impl UpdateStatus {
             return ZoneStatusVersion::InstallDataset;
         };
 
-        if let Some(old) = old.and_then(|old| old.tuf_repo()) {
+        if let Some(old) = old.tuf_repo() {
             if old.artifacts.iter().any(|meta| meta.hash == hash) {
                 return ZoneStatusVersion::Version(
                     old.repo.system_version.clone(),


### PR DESCRIPTION
This gets rid of two `Option<_>`s in the planning input:

* `TufRepoPolicy::description` changes from `Option<TufRepoDescription>` to non-optional `TargetReleaseDescription`. The latter is isomorphic to `Option`, but spells the `None` case as `TargetReleaseDescription::Initial`.
* `PlanningInput::old_repo` is now a non-optional `TufRepoPolicy`. In the case where `tuf_repo` is "the initial policy" (i.e., `TargetReleaseDescription::Initial`, `old_repo` is _also_ set to the initial policy. In all other cases, it's "the previous policy".