### PR TITLE
bump RESET_TIMEOUT because Sidecar SPs can take a while

### DIFF
--- a/nexus/mgs-updates/src/driver_update.rs
+++ b/nexus/mgs-updates/src/driver_update.rs
@@ -44,7 +44,9 @@ const PROGRESS_POLL_INTERVAL: Duration = Duration::from_secs(10);
 pub const DEFAULT_RETRY_TIMEOUT: Duration = Duration::from_secs(60);
 
 /// How long to wait after resetting the device before expecting it to come up
-const RESET_TIMEOUT: Duration = Duration::from_secs(60);
+// 120 seconds is chosen as a generous overestimate, based on reports that
+// Sidecar SPs have been observed to take as many as 30 seconds to reset.
+const RESET_TIMEOUT: Duration = Duration::from_secs(120);
 
 /// Parameters describing a request to update one SP-managed component
 ///


### PR DESCRIPTION
In https://github.com/oxidecomputer/management-gateway-service/issues/284, I see that successful Sidecar resets can take at least 25s (and maybe 30).  This timeout should be more generous.