### PR TITLE
Define pagination order for `Paginator`

### DIFF
--- a/dev-tools/omdb/src/bin/omdb/db.rs
+++ b/dev-tools/omdb/src/bin/omdb/db.rs
@@ -3270,7 +3270,8 @@ async fn cmd_db_volume_cannot_activate(
 ) -> Result<(), anyhow::Error> {
     let conn = datastore.pool_connection_for_tests().await?;
 
-    let mut paginator = Paginator::new(SQL_BATCH_SIZE);
+    let mut paginator =
+        Paginator::new(SQL_BATCH_SIZE, dropshot::PaginationOrder::Ascending);
     while let Some(p) = paginator.next() {
         use nexus_db_schema::schema::volume::dsl;
         let batch = paginated(dsl::volume, dsl::id, &p.current_pagparams())

--- a/dev-tools/omdb/src/bin/omdb/db/saga.rs
+++ b/dev-tools/omdb/src/bin/omdb/db/saga.rs
@@ -412,7 +412,8 @@ async fn get_all_sagas_in_state(
     state: SagaState,
 ) -> Result<Vec<Saga>, anyhow::Error> {
     let mut sagas = Vec::new();
-    let mut paginator = Paginator::new(SQL_BATCH_SIZE);
+    let mut paginator =
+        Paginator::new(SQL_BATCH_SIZE, dropshot::PaginationOrder::Ascending);
     while let Some(p) = paginator.next() {
         use nexus_db_schema::schema::saga::dsl;
         let records_batch =

--- a/dev-tools/omdb/src/bin/omdb/reconfigurator.rs
+++ b/dev-tools/omdb/src/bin/omdb/reconfigurator.rs
@@ -254,7 +254,8 @@ async fn cmd_reconfigurator_history(
     // This shouldn't be very large.
     let mut all_blueprints: BTreeMap<BlueprintUuid, BlueprintMetadata> =
         BTreeMap::new();
-    let mut paginator = Paginator::new(SQL_BATCH_SIZE);
+    let mut paginator =
+        Paginator::new(SQL_BATCH_SIZE, dropshot::PaginationOrder::Ascending);
     while let Some(p) = paginator.next() {
         let records_batch = datastore
             .blueprints_list(opctx, &p.current_pagparams())

--- a/nexus/db-queries/src/db/datastore/alert_rx.rs
+++ b/nexus/db-queries/src/db/datastore/alert_rx.rs
@@ -440,7 +440,10 @@ impl DataStore {
 
         // Before we can check whether the receiver is subscribed to the
         // provided event, ensure that its glob subscriptions are up to date.
-        let mut paginator = Paginator::new(SQL_BATCH_SIZE);
+        let mut paginator = Paginator::new(
+            SQL_BATCH_SIZE,
+            dropshot::PaginationOrder::Ascending,
+        );
         while let Some(p) = paginator.next() {
             let batch = self
                 .rx_list_reprocessable_globs_on_conn(
@@ -1297,7 +1300,10 @@ mod test {
         // event classes, we must generate exact subscriptions for their globs.
         // The webhook dispatcher background task does this prior to listing
         // subscribed receivers, so this simulates its behavior.
-        let mut paginator = Paginator::new(SQL_BATCH_SIZE);
+        let mut paginator = Paginator::new(
+            SQL_BATCH_SIZE,
+            dropshot::PaginationOrder::Ascending,
+        );
         while let Some(p) = paginator.next() {
             let batch = datastore
                 .alert_glob_list_reprocessable(opctx, &p.current_pagparams())

--- a/nexus/db-queries/src/db/datastore/crucible_dataset.rs
+++ b/nexus/db-queries/src/db/datastore/crucible_dataset.rs
@@ -181,7 +181,10 @@ impl DataStore {
         opctx.check_complex_operations_allowed()?;
 
         let mut all_datasets = Vec::new();
-        let mut paginator = Paginator::new(SQL_BATCH_SIZE);
+        let mut paginator = Paginator::new(
+            SQL_BATCH_SIZE,
+            dropshot::PaginationOrder::Ascending,
+        );
         while let Some(p) = paginator.next() {
             let batch = self
                 .crucible_dataset_list(opctx, &p.current_pagparams())

--- a/nexus/db-queries/src/db/datastore/deployment.rs
+++ b/nexus/db-queries/src/db/datastore/deployment.rs
@@ -534,7 +534,10 @@ impl DataStore {
             use nexus_db_schema::schema::bp_sled_metadata::dsl;
 
             let mut sled_configs = BTreeMap::new();
-            let mut paginator = Paginator::new(SQL_BATCH_SIZE);
+            let mut paginator = Paginator::new(
+                SQL_BATCH_SIZE,
+                dropshot::PaginationOrder::Ascending,
+            );
             while let Some(p) = paginator.next() {
                 let batch = paginated(
                     dsl::bp_sled_metadata,
@@ -581,7 +584,10 @@ impl DataStore {
             use nexus_db_schema::schema::bp_omicron_zone_nic::dsl;
 
             let mut omicron_zone_nics = BTreeMap::new();
-            let mut paginator = Paginator::new(SQL_BATCH_SIZE);
+            let mut paginator = Paginator::new(
+                SQL_BATCH_SIZE,
+                dropshot::PaginationOrder::Ascending,
+            );
             while let Some(p) = paginator.next() {
                 let batch = paginated(
                     dsl::bp_omicron_zone_nic,
@@ -617,7 +623,10 @@ impl DataStore {
             use nexus_db_schema::schema::bp_omicron_zone::dsl;
             use nexus_db_schema::schema::tuf_artifact::dsl as tuf_artifact_dsl;
 
-            let mut paginator = Paginator::new(SQL_BATCH_SIZE);
+            let mut paginator = Paginator::new(
+                SQL_BATCH_SIZE,
+                dropshot::PaginationOrder::Ascending,
+            );
             while let Some(p) = paginator.next() {
                 // `paginated` implicitly orders by our `id`, which is also
                 // handy for testing: the zones are always consistently ordered
@@ -708,7 +717,10 @@ impl DataStore {
         {
             use nexus_db_schema::schema::bp_omicron_physical_disk::dsl;
 
-            let mut paginator = Paginator::new(SQL_BATCH_SIZE);
+            let mut paginator = Paginator::new(
+                SQL_BATCH_SIZE,
+                dropshot::PaginationOrder::Ascending,
+            );
             while let Some(p) = paginator.next() {
                 // `paginated` implicitly orders by our `id`, which is also
                 // handy for testing: the physical disks are always consistently ordered
@@ -756,7 +768,10 @@ impl DataStore {
         {
             use nexus_db_schema::schema::bp_omicron_dataset::dsl;
 
-            let mut paginator = Paginator::new(SQL_BATCH_SIZE);
+            let mut paginator = Paginator::new(
+                SQL_BATCH_SIZE,
+                dropshot::PaginationOrder::Ascending,
+            );
             while let Some(p) = paginator.next() {
                 // `paginated` implicitly orders by our `id`, which is also
                 // handy for testing: the datasets are always consistently ordered
@@ -822,7 +837,10 @@ impl DataStore {
                     let keepers: BTreeMap<OmicronZoneUuid, KeeperId> = {
                         use nexus_db_schema::schema::bp_clickhouse_keeper_zone_id_to_node_id::dsl;
                         let mut keepers = BTreeMap::new();
-                        let mut paginator = Paginator::new(SQL_BATCH_SIZE);
+                        let mut paginator = Paginator::new(
+                            SQL_BATCH_SIZE,
+                            dropshot::PaginationOrder::Ascending,
+                        );
                         while let Some(p) = paginator.next() {
                             let batch = paginated(
                                 dsl::bp_clickhouse_keeper_zone_id_to_node_id,
@@ -872,7 +890,10 @@ impl DataStore {
                     let servers: BTreeMap<OmicronZoneUuid, ServerId> = {
                         use nexus_db_schema::schema::bp_clickhouse_server_zone_id_to_node_id::dsl;
                         let mut servers = BTreeMap::new();
-                        let mut paginator = Paginator::new(SQL_BATCH_SIZE);
+                        let mut paginator = Paginator::new(
+                            SQL_BATCH_SIZE,
+                            dropshot::PaginationOrder::Ascending,
+                        );
                         while let Some(p) = paginator.next() {
                             let batch = paginated(
                                 dsl::bp_clickhouse_server_zone_id_to_node_id,

--- a/nexus/db-queries/src/db/datastore/dns.rs
+++ b/nexus/db-queries/src/db/datastore/dns.rs
@@ -245,7 +245,10 @@ impl DataStore {
         let mut zones = Vec::with_capacity(dns_zones.len());
         for zone in dns_zones {
             let mut zone_records = Vec::new();
-            let mut paginator = Paginator::new(batch_size);
+            let mut paginator = Paginator::new(
+                batch_size,
+                dropshot::PaginationOrder::Ascending,
+            );
             while let Some(p) = paginator.next() {
                 debug!(log, "listing DNS names for zone";
                     "dns_zone_id" => zone.id.to_string(),

--- a/nexus/db-queries/src/db/datastore/external_ip.rs
+++ b/nexus/db-queries/src/db/datastore/external_ip.rs
@@ -381,7 +381,10 @@ impl DataStore {
         opctx.check_complex_operations_allowed()?;
 
         let mut all_ips = Vec::new();
-        let mut paginator = Paginator::new(SQL_BATCH_SIZE);
+        let mut paginator = Paginator::new(
+            SQL_BATCH_SIZE,
+            dropshot::PaginationOrder::Ascending,
+        );
         while let Some(p) = paginator.next() {
             let batch = self
                 .external_ip_list_service_all(opctx, &p.current_pagparams())

--- a/nexus/db-queries/src/db/datastore/instance.rs
+++ b/nexus/db-queries/src/db/datastore/instance.rs
@@ -3341,6 +3341,7 @@ mod tests {
             // Make sure the batch size is small enough that we will require two
             // batches to list all the instances on a sled.
             std::num::NonZeroU32::new(INSTANCES_PER_SLED as u32 / 2).unwrap(),
+            dropshot::PaginationOrder::Ascending,
         );
         let mut i = 0;
         while let Some(p) = paginator.next() {

--- a/nexus/db-queries/src/db/datastore/inventory.rs
+++ b/nexus/db-queries/src/db/datastore/inventory.rs
@@ -2077,7 +2077,10 @@ impl DataStore {
         let errors: Vec<String> = {
             use nexus_db_schema::schema::inv_collection_error::dsl;
             let mut errors = Vec::new();
-            let mut paginator = Paginator::new(batch_size);
+            let mut paginator = Paginator::new(
+                batch_size,
+                dropshot::PaginationOrder::Ascending,
+            );
             while let Some(p) = paginator.next() {
                 let batch = paginated(
                     dsl::inv_collection_error,
@@ -2104,7 +2107,10 @@ impl DataStore {
 
             let mut sps = BTreeMap::new();
 
-            let mut paginator = Paginator::new(batch_size);
+            let mut paginator = Paginator::new(
+                batch_size,
+                dropshot::PaginationOrder::Ascending,
+            );
             while let Some(p) = paginator.next() {
                 let batch = paginated(
                     dsl::inv_service_processor,
@@ -2135,7 +2141,10 @@ impl DataStore {
 
             let mut rots = BTreeMap::new();
 
-            let mut paginator = Paginator::new(batch_size);
+            let mut paginator = Paginator::new(
+                batch_size,
+                dropshot::PaginationOrder::Ascending,
+            );
             while let Some(p) = paginator.next() {
                 let batch = paginated(
                     dsl::inv_root_of_trust,
@@ -2166,7 +2175,10 @@ impl DataStore {
 
             let mut rows = Vec::new();
 
-            let mut paginator = Paginator::new(batch_size);
+            let mut paginator = Paginator::new(
+                batch_size,
+                dropshot::PaginationOrder::Ascending,
+            );
             while let Some(p) = paginator.next() {
                 let mut batch = paginated(
                     dsl::inv_sled_agent,
@@ -2198,7 +2210,10 @@ impl DataStore {
                 SledUuid,
                 BTreeMap<i64, nexus_types::inventory::PhysicalDiskFirmware>,
             >::new();
-            let mut paginator = Paginator::new(batch_size);
+            let mut paginator = Paginator::new(
+                batch_size,
+                dropshot::PaginationOrder::Ascending,
+            );
             while let Some(p) = paginator.next() {
                 let batch = paginated_multicolumn(
                     dsl::inv_nvme_disk_firmware,
@@ -2240,7 +2255,10 @@ impl DataStore {
                 SledUuid,
                 Vec<nexus_types::inventory::PhysicalDisk>,
             >::new();
-            let mut paginator = Paginator::new(batch_size);
+            let mut paginator = Paginator::new(
+                batch_size,
+                dropshot::PaginationOrder::Ascending,
+            );
             while let Some(p) = paginator.next() {
                 let batch = paginated_multicolumn(
                     dsl::inv_physical_disk,
@@ -2286,7 +2304,10 @@ impl DataStore {
 
             let mut zpools =
                 BTreeMap::<Uuid, Vec<nexus_types::inventory::Zpool>>::new();
-            let mut paginator = Paginator::new(batch_size);
+            let mut paginator = Paginator::new(
+                batch_size,
+                dropshot::PaginationOrder::Ascending,
+            );
             while let Some(p) = paginator.next() {
                 let batch = paginated_multicolumn(
                     dsl::inv_zpool,
@@ -2317,7 +2338,10 @@ impl DataStore {
 
             let mut datasets =
                 BTreeMap::<Uuid, Vec<nexus_types::inventory::Dataset>>::new();
-            let mut paginator = Paginator::new(batch_size);
+            let mut paginator = Paginator::new(
+                batch_size,
+                dropshot::PaginationOrder::Ascending,
+            );
             while let Some(p) = paginator.next() {
                 let batch = paginated_multicolumn(
                     dsl::inv_dataset,
@@ -2358,7 +2382,10 @@ impl DataStore {
 
             let mut bbs = BTreeMap::new();
 
-            let mut paginator = Paginator::new(batch_size);
+            let mut paginator = Paginator::new(
+                batch_size,
+                dropshot::PaginationOrder::Ascending,
+            );
             while let Some(p) = paginator.next() {
                 let batch = paginated(
                     dsl::hw_baseboard_id,
@@ -2418,7 +2445,10 @@ impl DataStore {
 
             let mut cabooses = Vec::new();
 
-            let mut paginator = Paginator::new(batch_size);
+            let mut paginator = Paginator::new(
+                batch_size,
+                dropshot::PaginationOrder::Ascending,
+            );
             while let Some(p) = paginator.next() {
                 let mut batch = paginated_multicolumn(
                     dsl::inv_caboose,
@@ -2452,7 +2482,10 @@ impl DataStore {
 
             let mut cabooses = BTreeMap::new();
 
-            let mut paginator = Paginator::new(batch_size);
+            let mut paginator = Paginator::new(
+                batch_size,
+                dropshot::PaginationOrder::Ascending,
+            );
             while let Some(p) = paginator.next() {
                 let batch =
                     paginated(dsl::sw_caboose, dsl::id, &p.current_pagparams())
@@ -2520,7 +2553,10 @@ impl DataStore {
 
             let mut rot_pages = Vec::new();
 
-            let mut paginator = Paginator::new(batch_size);
+            let mut paginator = Paginator::new(
+                batch_size,
+                dropshot::PaginationOrder::Ascending,
+            );
             while let Some(p) = paginator.next() {
                 let mut batch = paginated_multicolumn(
                     dsl::inv_root_of_trust_page,
@@ -2554,7 +2590,10 @@ impl DataStore {
 
             let mut rot_pages = BTreeMap::new();
 
-            let mut paginator = Paginator::new(batch_size);
+            let mut paginator = Paginator::new(
+                batch_size,
+                dropshot::PaginationOrder::Ascending,
+            );
             while let Some(p) = paginator.next() {
                 let batch = paginated(
                     dsl::sw_root_of_trust_page,
@@ -2638,7 +2677,10 @@ impl DataStore {
 
             let mut configs = IdMap::new();
 
-            let mut paginator = Paginator::new(batch_size);
+            let mut paginator = Paginator::new(
+                batch_size,
+                dropshot::PaginationOrder::Ascending,
+            );
             while let Some(p) = paginator.next() {
                 let batch = paginated(
                     dsl::inv_omicron_sled_config,
@@ -2681,7 +2723,10 @@ impl DataStore {
 
             let mut nics = BTreeMap::new();
 
-            let mut paginator = Paginator::new(batch_size);
+            let mut paginator = Paginator::new(
+                batch_size,
+                dropshot::PaginationOrder::Ascending,
+            );
             while let Some(p) = paginator.next() {
                 let batch = paginated(
                     dsl::inv_omicron_sled_config_zone_nic,
@@ -2713,7 +2758,10 @@ impl DataStore {
 
             let mut zones = Vec::new();
 
-            let mut paginator = Paginator::new(batch_size);
+            let mut paginator = Paginator::new(
+                batch_size,
+                dropshot::PaginationOrder::Ascending,
+            );
             while let Some(p) = paginator.next() {
                 let mut batch = paginated(
                     dsl::inv_omicron_sled_config_zone,
@@ -2785,7 +2833,10 @@ impl DataStore {
         {
             use nexus_db_schema::schema::inv_omicron_sled_config_dataset::dsl;
 
-            let mut paginator = Paginator::new(batch_size);
+            let mut paginator = Paginator::new(
+                batch_size,
+                dropshot::PaginationOrder::Ascending,
+            );
             while let Some(p) = paginator.next() {
                 let batch = paginated(
                     dsl::inv_omicron_sled_config_dataset,
@@ -2823,7 +2874,10 @@ impl DataStore {
         {
             use nexus_db_schema::schema::inv_omicron_sled_config_disk::dsl;
 
-            let mut paginator = Paginator::new(batch_size);
+            let mut paginator = Paginator::new(
+                batch_size,
+                dropshot::PaginationOrder::Ascending,
+            );
             while let Some(p) = paginator.next() {
                 let batch = paginated(
                     dsl::inv_omicron_sled_config_disk,
@@ -2863,7 +2917,10 @@ impl DataStore {
                 BTreeMap<PhysicalDiskUuid, ConfigReconcilerInventoryResult>,
             > = BTreeMap::new();
 
-            let mut paginator = Paginator::new(batch_size);
+            let mut paginator = Paginator::new(
+                batch_size,
+                dropshot::PaginationOrder::Ascending,
+            );
             while let Some(p) = paginator.next() {
                 let batch = paginated(
                     dsl::inv_last_reconciliation_disk_result,
@@ -2899,7 +2956,10 @@ impl DataStore {
                 BTreeMap<DatasetUuid, ConfigReconcilerInventoryResult>,
             > = BTreeMap::new();
 
-            let mut paginator = Paginator::new(batch_size);
+            let mut paginator = Paginator::new(
+                batch_size,
+                dropshot::PaginationOrder::Ascending,
+            );
             while let Some(p) = paginator.next() {
                 let batch = paginated(
                     dsl::inv_last_reconciliation_dataset_result,
@@ -2978,7 +3038,10 @@ impl DataStore {
                 BTreeMap<OmicronZoneUuid, ConfigReconcilerInventoryResult>,
             > = BTreeMap::new();
 
-            let mut paginator = Paginator::new(batch_size);
+            let mut paginator = Paginator::new(
+                batch_size,
+                dropshot::PaginationOrder::Ascending,
+            );
             while let Some(p) = paginator.next() {
                 let batch = paginated(
                     dsl::inv_last_reconciliation_zone_result,
@@ -3013,7 +3076,10 @@ impl DataStore {
                 IdOrdMap<ZoneArtifactInventory>,
             > = BTreeMap::new();
 
-            let mut paginator = Paginator::new(batch_size);
+            let mut paginator = Paginator::new(
+                batch_size,
+                dropshot::PaginationOrder::Ascending,
+            );
             while let Some(p) = paginator.next() {
                 let batch = paginated_multicolumn(
                     dsl::inv_zone_manifest_zone,
@@ -3052,7 +3118,10 @@ impl DataStore {
                 IdOrdMap<ZoneManifestNonBootInventory>,
             > = BTreeMap::new();
 
-            let mut paginator = Paginator::new(batch_size);
+            let mut paginator = Paginator::new(
+                batch_size,
+                dropshot::PaginationOrder::Ascending,
+            );
             while let Some(p) = paginator.next() {
                 let batch = paginated_multicolumn(
                     dsl::inv_zone_manifest_non_boot,
@@ -3091,7 +3160,10 @@ impl DataStore {
                 IdOrdMap<MupdateOverrideNonBootInventory>,
             > = BTreeMap::new();
 
-            let mut paginator = Paginator::new(batch_size);
+            let mut paginator = Paginator::new(
+                batch_size,
+                dropshot::PaginationOrder::Ascending,
+            );
             while let Some(p) = paginator.next() {
                 let batch = paginated_multicolumn(
                     dsl::inv_mupdate_override_non_boot,
@@ -3124,7 +3196,10 @@ impl DataStore {
         let clickhouse_keeper_cluster_membership = {
             use nexus_db_schema::schema::inv_clickhouse_keeper_membership::dsl;
             let mut memberships = BTreeSet::new();
-            let mut paginator = Paginator::new(batch_size);
+            let mut paginator = Paginator::new(
+                batch_size,
+                dropshot::PaginationOrder::Ascending,
+            );
             while let Some(p) = paginator.next() {
                 let batch = paginated(
                     dsl::inv_clickhouse_keeper_membership,

--- a/nexus/db-queries/src/db/datastore/ip_pool.rs
+++ b/nexus/db-queries/src/db/datastore/ip_pool.rs
@@ -982,7 +982,10 @@ impl DataStore {
     ) -> ListResultVec<IpPoolRange> {
         opctx.check_complex_operations_allowed()?;
         let mut ip_ranges = Vec::new();
-        let mut paginator = Paginator::new(SQL_BATCH_SIZE);
+        let mut paginator = Paginator::new(
+            SQL_BATCH_SIZE,
+            dropshot::PaginationOrder::Ascending,
+        );
         while let Some(p) = paginator.next() {
             let batch = self
                 .ip_pool_list_ranges(opctx, &authz_pool, &p.current_pagparams())

--- a/nexus/db-queries/src/db/datastore/network_interface.rs
+++ b/nexus/db-queries/src/db/datastore/network_interface.rs
@@ -214,7 +214,10 @@ impl DataStore {
         opctx.check_complex_operations_allowed()?;
 
         let mut all_ips = Vec::new();
-        let mut paginator = Paginator::new(SQL_BATCH_SIZE);
+        let mut paginator = Paginator::new(
+            SQL_BATCH_SIZE,
+            dropshot::PaginationOrder::Ascending,
+        );
         while let Some(p) = paginator.next() {
             let batch = self
                 .service_network_interfaces_all_list(
@@ -854,7 +857,10 @@ impl DataStore {
         opctx.check_complex_operations_allowed()?;
 
         let mut all_interfaces = Vec::new();
-        let mut paginator = Paginator::new(SQL_BATCH_SIZE);
+        let mut paginator = Paginator::new(
+            SQL_BATCH_SIZE,
+            dropshot::PaginationOrder::Ascending,
+        );
         while let Some(p) = paginator.next() {
             let batch = self
                 .instance_network_interfaces_all_list(

--- a/nexus/db-queries/src/db/datastore/oximeter.rs
+++ b/nexus/db-queries/src/db/datastore/oximeter.rs
@@ -271,7 +271,10 @@ impl DataStore {
         opctx.check_complex_operations_allowed()?;
 
         let mut producers = Vec::new();
-        let mut paginator = Paginator::new(SQL_BATCH_SIZE);
+        let mut paginator = Paginator::new(
+            SQL_BATCH_SIZE,
+            dropshot::PaginationOrder::Ascending,
+        );
         while let Some(p) = paginator.next() {
             let batch = self
                 .producers_list_expired(

--- a/nexus/db-queries/src/db/datastore/region.rs
+++ b/nexus/db-queries/src/db/datastore/region.rs
@@ -486,7 +486,10 @@ impl DataStore {
 
         let mut records = Vec::new();
 
-        let mut paginator = Paginator::new(SQL_BATCH_SIZE);
+        let mut paginator = Paginator::new(
+            SQL_BATCH_SIZE,
+            dropshot::PaginationOrder::Ascending,
+        );
         let conn = self.pool_connection_authorized(opctx).await?;
 
         while let Some(p) = paginator.next() {

--- a/nexus/db-queries/src/db/datastore/region_replacement.rs
+++ b/nexus/db-queries/src/db/datastore/region_replacement.rs
@@ -120,7 +120,10 @@ impl DataStore {
         opctx.check_complex_operations_allowed()?;
 
         let mut replacements = Vec::new();
-        let mut paginator = Paginator::new(SQL_BATCH_SIZE);
+        let mut paginator = Paginator::new(
+            SQL_BATCH_SIZE,
+            dropshot::PaginationOrder::Ascending,
+        );
         let conn = self.pool_connection_authorized(opctx).await?;
 
         while let Some(p) = paginator.next() {

--- a/nexus/db-queries/src/db/datastore/region_snapshot_replacement.rs
+++ b/nexus/db-queries/src/db/datastore/region_snapshot_replacement.rs
@@ -989,7 +989,10 @@ impl DataStore {
         opctx.check_complex_operations_allowed()?;
 
         let mut records = Vec::new();
-        let mut paginator = Paginator::new(SQL_BATCH_SIZE);
+        let mut paginator = Paginator::new(
+            SQL_BATCH_SIZE,
+            dropshot::PaginationOrder::Ascending,
+        );
         let conn = self.pool_connection_authorized(opctx).await?;
 
         while let Some(p) = paginator.next() {

--- a/nexus/db-queries/src/db/datastore/rendezvous_debug_dataset.rs
+++ b/nexus/db-queries/src/db/datastore/rendezvous_debug_dataset.rs
@@ -66,7 +66,10 @@ impl DataStore {
         opctx.check_complex_operations_allowed()?;
 
         let mut all_datasets = Vec::new();
-        let mut paginator = Paginator::new(SQL_BATCH_SIZE);
+        let mut paginator = Paginator::new(
+            SQL_BATCH_SIZE,
+            dropshot::PaginationOrder::Ascending,
+        );
         while let Some(p) = paginator.next() {
             let batch = self
                 .debug_dataset_list_all_page(opctx, &p.current_pagparams())

--- a/nexus/db-queries/src/db/datastore/saga.rs
+++ b/nexus/db-queries/src/db/datastore/saga.rs
@@ -138,7 +138,10 @@ impl DataStore {
         sec_id: db::saga_types::SecId,
     ) -> Result<Vec<db::saga_types::Saga>, Error> {
         let mut sagas = vec![];
-        let mut paginator = Paginator::new(SQL_BATCH_SIZE);
+        let mut paginator = Paginator::new(
+            SQL_BATCH_SIZE,
+            dropshot::PaginationOrder::Ascending,
+        );
         let conn = self.pool_connection_authorized(opctx).await?;
         while let Some(p) = paginator.next() {
             use nexus_db_schema::schema::saga::dsl;
@@ -171,7 +174,10 @@ impl DataStore {
         saga_id: db::saga_types::SagaId,
     ) -> Result<Vec<steno::SagaNodeEvent>, Error> {
         let mut events = vec![];
-        let mut paginator = Paginator::new(SQL_BATCH_SIZE);
+        let mut paginator = Paginator::new(
+            SQL_BATCH_SIZE,
+            dropshot::PaginationOrder::Ascending,
+        );
         let conn = self.pool_connection_authorized(opctx).await?;
         while let Some(p) = paginator.next() {
             use nexus_db_schema::schema::saga_node_event::dsl;

--- a/nexus/db-queries/src/db/datastore/silo.rs
+++ b/nexus/db-queries/src/db/datastore/silo.rs
@@ -381,7 +381,10 @@ impl DataStore {
     ) -> ListResultVec<Silo> {
         opctx.check_complex_operations_allowed()?;
         let mut all_silos = Vec::new();
-        let mut paginator = Paginator::new(SQL_BATCH_SIZE);
+        let mut paginator = Paginator::new(
+            SQL_BATCH_SIZE,
+            dropshot::PaginationOrder::Ascending,
+        );
         while let Some(p) = paginator.next() {
             let batch = self
                 .silos_list(

--- a/nexus/db-queries/src/db/datastore/sled.rs
+++ b/nexus/db-queries/src/db/datastore/sled.rs
@@ -400,7 +400,10 @@ impl DataStore {
         opctx.check_complex_operations_allowed()?;
 
         let mut all_sleds = Vec::new();
-        let mut paginator = Paginator::new(SQL_BATCH_SIZE);
+        let mut paginator = Paginator::new(
+            SQL_BATCH_SIZE,
+            dropshot::PaginationOrder::Ascending,
+        );
         while let Some(p) = paginator.next() {
             let batch = self
                 .sled_list(opctx, &p.current_pagparams(), sled_filter)

--- a/nexus/db-queries/src/db/datastore/v2p_mapping.rs
+++ b/nexus/db-queries/src/db/datastore/v2p_mapping.rs
@@ -36,7 +36,10 @@ impl DataStore {
 
         // Query for instance v2p mappings
         let mut mappings = Vec::new();
-        let mut paginator = Paginator::new(SQL_BATCH_SIZE);
+        let mut paginator = Paginator::new(
+            SQL_BATCH_SIZE,
+            dropshot::PaginationOrder::Ascending,
+        );
         while let Some(p) = paginator.next() {
             let batch: Vec<_> =
                 paginated(
@@ -93,7 +96,10 @@ impl DataStore {
         }
 
         // Query for probe v2p mappings
-        let mut paginator = Paginator::new(SQL_BATCH_SIZE);
+        let mut paginator = Paginator::new(
+            SQL_BATCH_SIZE,
+            dropshot::PaginationOrder::Ascending,
+        );
         while let Some(p) = paginator.next() {
             let batch: Vec<_> =
                 paginated(

--- a/nexus/db-queries/src/db/datastore/volume.rs
+++ b/nexus/db-queries/src/db/datastore/volume.rs
@@ -3951,7 +3951,10 @@ impl DataStore {
         opctx.check_complex_operations_allowed()?;
 
         let mut volumes = Vec::new();
-        let mut paginator = Paginator::new(SQL_BATCH_SIZE);
+        let mut paginator = Paginator::new(
+            SQL_BATCH_SIZE,
+            dropshot::PaginationOrder::Ascending,
+        );
         let conn = self.pool_connection_authorized(opctx).await?;
 
         let needle = match address {
@@ -4013,7 +4016,10 @@ impl DataStore {
         opctx.check_complex_operations_allowed()?;
 
         let mut volumes = Vec::new();
-        let mut paginator = Paginator::new(SQL_BATCH_SIZE);
+        let mut paginator = Paginator::new(
+            SQL_BATCH_SIZE,
+            dropshot::PaginationOrder::Ascending,
+        );
         let conn = self.pool_connection_authorized(opctx).await?;
 
         while let Some(p) = paginator.next() {
@@ -4060,7 +4066,10 @@ impl DataStore {
         opctx.check_complex_operations_allowed()?;
 
         let mut volumes = Vec::new();
-        let mut paginator = Paginator::new(SQL_BATCH_SIZE);
+        let mut paginator = Paginator::new(
+            SQL_BATCH_SIZE,
+            dropshot::PaginationOrder::Ascending,
+        );
         let conn = self.pool_connection_authorized(opctx).await?;
 
         while let Some(p) = paginator.next() {
@@ -4304,7 +4313,10 @@ impl DataStore {
     pub(crate) async fn validate_volume_invariants(
         conn: &async_bb8_diesel::Connection<DbConnection>,
     ) -> Result<(), diesel::result::Error> {
-        let mut paginator = Paginator::new(SQL_BATCH_SIZE);
+        let mut paginator = Paginator::new(
+            SQL_BATCH_SIZE,
+            dropshot::PaginationOrder::Ascending,
+        );
 
         while let Some(p) = paginator.next() {
             use nexus_db_schema::schema::volume::dsl;
@@ -4324,7 +4336,10 @@ impl DataStore {
             }
         }
 
-        let mut paginator = Paginator::new(SQL_BATCH_SIZE);
+        let mut paginator = Paginator::new(
+            SQL_BATCH_SIZE,
+            dropshot::PaginationOrder::Ascending,
+        );
 
         while let Some(p) = paginator.next() {
             use nexus_db_schema::schema::region::dsl;

--- a/nexus/db-queries/src/db/datastore/vpc.rs
+++ b/nexus/db-queries/src/db/datastore/vpc.rs
@@ -2505,7 +2505,10 @@ impl DataStore {
                 .internal_context("lookup router by id for rules")?;
         let vpc_id = authz_vpc.id();
 
-        let mut paginator = Paginator::new(SQL_BATCH_SIZE);
+        let mut paginator = Paginator::new(
+            SQL_BATCH_SIZE,
+            dropshot::PaginationOrder::Ascending,
+        );
         let mut all_rules = vec![];
         while let Some(p) = paginator.next() {
             let batch = self

--- a/nexus/db-queries/src/db/datastore/webhook_delivery.rs
+++ b/nexus/db-queries/src/db/datastore/webhook_delivery.rs
@@ -549,8 +549,10 @@ mod test {
         );
 
         let mut all_deliveries = std::collections::HashSet::new();
-        let mut paginator =
-            Paginator::new(crate::db::datastore::SQL_BATCH_SIZE);
+        let mut paginator = Paginator::new(
+            crate::db::datastore::SQL_BATCH_SIZE,
+            dropshot::PaginationOrder::Ascending,
+        );
         while let Some(p) = paginator.next() {
             let deliveries = datastore
                 .webhook_rx_delivery_list(

--- a/nexus/db-queries/src/db/datastore/zpool.rs
+++ b/nexus/db-queries/src/db/datastore/zpool.rs
@@ -132,7 +132,10 @@ impl DataStore {
         opctx.authorize(authz::Action::ListChildren, &authz::FLEET).await?;
         opctx.check_complex_operations_allowed()?;
         let mut zpools = Vec::new();
-        let mut paginator = Paginator::new(SQL_BATCH_SIZE);
+        let mut paginator = Paginator::new(
+            SQL_BATCH_SIZE,
+            dropshot::PaginationOrder::Ascending,
+        );
         while let Some(p) = paginator.next() {
             let batch = self
                 .zpool_list_all_external(opctx, &p.current_pagparams())

--- a/nexus/db-queries/src/db/pagination.rs
+++ b/nexus/db-queries/src/db/pagination.rs
@@ -1036,7 +1036,11 @@ mod test {
         let query =
             paginated(dsl::test_users, dsl::age, &p.current_pagparams());
         let batch = execute_query(&pool, query).await;
+        paginator = p.found_batch(&batch, &|i| i.age);
         assert_eq!(ages(batch), vec![5]);
+
+        // There is nothing left
+        assert!(paginator.next().is_none());
 
         db.terminate().await;
         logctx.cleanup_successful();
@@ -1087,7 +1091,11 @@ mod test {
         let query =
             paginated(dsl::test_users, dsl::age, &p.current_pagparams());
         let batch = execute_query(&pool, query).await;
+        paginator = p.found_batch(&batch, &|i| i.age);
         assert_eq!(ages(batch), vec![1]);
+
+        // There is nothing left
+        assert!(paginator.next().is_none());
 
         db.terminate().await;
         logctx.cleanup_successful();

--- a/nexus/db-queries/src/db/pagination.rs
+++ b/nexus/db-queries/src/db/pagination.rs
@@ -415,7 +415,8 @@ impl<M1, M2> RawPaginatorWithParams<'_, (M1, M2)> {
 /// let item2marker: &dyn Fn(&Item) -> Marker = &|u: &u32| *u;
 ///
 /// let mut all_records = Vec::new();
-/// let mut paginator = Paginator::new(batch_size);
+/// let direction = dropshot::PaginationOrder::Ascending;
+/// let mut paginator = Paginator::new(batch_size, direction);
 /// while let Some(p) = paginator.next() {
 ///     let records_batch = do_query(&p.current_pagparams());
 ///     paginator = p.found_batch(&records_batch, item2marker);
@@ -439,11 +440,15 @@ impl<M1, M2> RawPaginatorWithParams<'_, (M1, M2)> {
 pub struct Paginator<N> {
     batch_size: NonZeroU32,
     state: PaginatorState<N>,
+    direction: dropshot::PaginationOrder,
 }
 
 impl<N> Paginator<N> {
-    pub fn new(batch_size: NonZeroU32) -> Paginator<N> {
-        Paginator { batch_size, state: PaginatorState::Initial }
+    pub fn new(
+        batch_size: NonZeroU32,
+        direction: dropshot::PaginationOrder,
+    ) -> Paginator<N> {
+        Paginator { batch_size, state: PaginatorState::Initial, direction }
     }
 
     pub fn next(self) -> Option<PaginatorHelper<N>> {
@@ -451,10 +456,12 @@ impl<N> Paginator<N> {
             PaginatorState::Initial => Some(PaginatorHelper {
                 batch_size: self.batch_size,
                 marker: None,
+                direction: self.direction,
             }),
             PaginatorState::Middle { marker } => Some(PaginatorHelper {
                 batch_size: self.batch_size,
                 marker: Some(marker),
+                direction: self.direction,
             }),
             PaginatorState::Done => None,
         }
@@ -470,6 +477,7 @@ enum PaginatorState<N> {
 pub struct PaginatorHelper<N> {
     batch_size: NonZeroU32,
     marker: Option<N>,
+    direction: dropshot::PaginationOrder,
 }
 
 impl<N> PaginatorHelper<N> {
@@ -477,7 +485,7 @@ impl<N> PaginatorHelper<N> {
     pub fn current_pagparams(&self) -> DataPageParams<'_, N> {
         DataPageParams {
             marker: self.marker.as_ref(),
-            direction: dropshot::PaginationOrder::Ascending,
+            direction: self.direction,
             limit: self.batch_size,
         }
     }
@@ -506,7 +514,11 @@ impl<N> PaginatorHelper<N> {
                 PaginatorState::Middle { marker }
             };
 
-        Paginator { batch_size: self.batch_size, state }
+        Paginator {
+            batch_size: self.batch_size,
+            state,
+            direction: self.direction,
+        }
     }
 }
 
@@ -948,7 +960,10 @@ mod test {
         let do_list =
             |query: &dyn Fn(&DataPageParams<'_, Marker>) -> Vec<Item>| {
                 let mut all_records = Vec::new();
-                let mut paginator = Paginator::new(batch_size);
+                let mut paginator = Paginator::new(
+                    batch_size,
+                    dropshot::PaginationOrder::Ascending,
+                );
                 while let Some(p) = paginator.next() {
                     let records_batch = query(&p.current_pagparams());
                     paginator =

--- a/nexus/reconfigurator/preparation/src/lib.rs
+++ b/nexus/reconfigurator/preparation/src/lib.rs
@@ -397,7 +397,10 @@ pub async fn reconfigurator_state_load(
         .context("failed to read current target blueprint")?;
 
     let mut blueprint_ids = Vec::new();
-    let mut paginator = Paginator::new(SQL_BATCH_SIZE);
+    let mut paginator = Paginator::new(
+        SQL_BATCH_SIZE,
+        omicron_common::api::external::PaginationOrder::Ascending,
+    );
     while let Some(p) = paginator.next() {
         let batch = datastore
             .blueprints_list(opctx, &p.current_pagparams())

--- a/nexus/src/app/background/tasks/abandoned_vmm_reaper.rs
+++ b/nexus/src/app/background/tasks/abandoned_vmm_reaper.rs
@@ -60,7 +60,10 @@ impl AbandonedVmmReaper {
         status: &mut AbandonedVmmReaperStatus,
         opctx: &OpContext,
     ) -> Result<(), anyhow::Error> {
-        let mut paginator = Paginator::new(SQL_BATCH_SIZE);
+        let mut paginator = Paginator::new(
+            SQL_BATCH_SIZE,
+            dropshot::PaginationOrder::Ascending,
+        );
         while let Some(p) = paginator.next() {
             let vmms = self
                 .datastore
@@ -364,7 +367,10 @@ mod tests {
         // order to simulate a condition where the VMM record was deleted
         // between when the listing query was run and when the bg task attempted
         // to delete the VMM record.
-        let paginator = Paginator::new(SQL_BATCH_SIZE);
+        let paginator = Paginator::new(
+            SQL_BATCH_SIZE,
+            dropshot::PaginationOrder::Ascending,
+        );
         let p = paginator.next().unwrap();
         let abandoned_vmms = datastore
             .vmm_list_abandoned(&opctx, &p.current_pagparams())
@@ -411,7 +417,10 @@ mod tests {
         // order to simulate a condition where the sled reservation record was
         // deleted between when the listing query was run and when the bg task
         // attempted to delete the sled reservation..
-        let paginator = Paginator::new(SQL_BATCH_SIZE);
+        let paginator = Paginator::new(
+            SQL_BATCH_SIZE,
+            dropshot::PaginationOrder::Ascending,
+        );
         let p = paginator.next().unwrap();
         let abandoned_vmms = datastore
             .vmm_list_abandoned(&opctx, &p.current_pagparams())

--- a/nexus/src/app/background/tasks/alert_dispatcher.rs
+++ b/nexus/src/app/background/tasks/alert_dispatcher.rs
@@ -129,7 +129,10 @@ impl AlertDispatcher {
         // haven't yet been updated may lack exact subscriptions to event
         // classes that match its globs but were added after the last time its
         // globs were reprocessed.
-        let mut paginator = Paginator::new(SQL_BATCH_SIZE);
+        let mut paginator = Paginator::new(
+            SQL_BATCH_SIZE,
+            dropshot::PaginationOrder::Ascending,
+        );
         let mut globs_reprocessed = 0;
         let mut globs_failed = 0;
         let mut globs_already_reprocessed = 0;
@@ -527,7 +530,10 @@ mod test {
         // webhook_deliverator background task may have activated and might
         // attempt to deliver the event, making it no longer show up in the
         // "ready" query.
-        let mut paginator = Paginator::new(db::datastore::SQL_BATCH_SIZE);
+        let mut paginator = Paginator::new(
+            db::datastore::SQL_BATCH_SIZE,
+            dropshot::PaginationOrder::Ascending,
+        );
         let mut deliveries = Vec::new();
         while let Some(p) = paginator.next() {
             let batch = datastore

--- a/nexus/src/app/background/tasks/decommissioned_disk_cleaner.rs
+++ b/nexus/src/app/background/tasks/decommissioned_disk_cleaner.rs
@@ -52,7 +52,8 @@ impl DecommissionedDiskCleaner {
     ) -> Result<(), anyhow::Error> {
         slog::info!(opctx.log, "Decommissioned disk cleaner running");
 
-        let mut paginator = Paginator::new(MAX_BATCH);
+        let mut paginator =
+            Paginator::new(MAX_BATCH, dropshot::PaginationOrder::Ascending);
         let mut last_err = Ok(());
         while let Some(p) = paginator.next() {
             let zpools = self

--- a/nexus/src/app/background/tasks/ereport_ingester.rs
+++ b/nexus/src/app/background/tasks/ereport_ingester.rs
@@ -690,8 +690,10 @@ mod tests {
         restart_id: EreporterRestartUuid,
         expected_ereports: &[(Ena, serde_json::Value)],
     ) {
-        let mut paginator =
-            Paginator::new(std::num::NonZeroU32::new(100).unwrap());
+        let mut paginator = Paginator::new(
+            std::num::NonZeroU32::new(100).unwrap(),
+            dropshot::PaginationOrder::Ascending,
+        );
         let mut found_ereports = BTreeMap::new();
         while let Some(p) = paginator.next() {
             let batch = datastore

--- a/nexus/src/app/background/tasks/instance_reincarnation.rs
+++ b/nexus/src/app/background/tasks/instance_reincarnation.rs
@@ -147,7 +147,10 @@ impl InstanceReincarnation {
     ) -> anyhow::Result<()> {
         let serialized_authn = authn::saga::Serialized::for_opctx(opctx);
 
-        let mut paginator = Paginator::new(self.concurrency_limit);
+        let mut paginator = Paginator::new(
+            self.concurrency_limit,
+            dropshot::PaginationOrder::Ascending,
+        );
         let instances_found = status.instances_found.entry(reason).or_insert(0);
         let mut sagas_started = 0;
         while let Some(p) = paginator.next() {

--- a/nexus/src/app/background/tasks/instance_watcher.rs
+++ b/nexus/src/app/background/tasks/instance_watcher.rs
@@ -437,7 +437,10 @@ impl BackgroundTask for InstanceWatcher {
         opctx: &'a OpContext,
     ) -> BoxFuture<'a, serde_json::Value> {
         async {
-            let mut paginator = Some(Paginator::new(nexus_db_queries::db::datastore::SQL_BATCH_SIZE));
+            let mut paginator = Some(Paginator::new(
+                nexus_db_queries::db::datastore::SQL_BATCH_SIZE,
+                dropshot::PaginationOrder::Ascending
+            ));
             let mut tasks = ParallelTaskSet::new_with_parallelism(
                 MAX_CONCURRENT_CHECKS,
             );

--- a/nexus/src/app/background/tasks/tuf_artifact_replication.rs
+++ b/nexus/src/app/background/tasks/tuf_artifact_replication.rs
@@ -593,7 +593,10 @@ impl ArtifactReplication {
     ) -> Result<(ArtifactConfig, Inventory)> {
         let generation = self.datastore.tuf_get_generation(opctx).await?;
         let mut inventory = Inventory::default();
-        let mut paginator = Paginator::new(SQL_BATCH_SIZE);
+        let mut paginator = Paginator::new(
+            SQL_BATCH_SIZE,
+            dropshot::PaginationOrder::Ascending,
+        );
         while let Some(p) = paginator.next() {
             let batch = self
                 .datastore

--- a/nexus/src/app/background/tasks/webhook_deliverator.rs
+++ b/nexus/src/app/background/tasks/webhook_deliverator.rs
@@ -149,8 +149,10 @@ impl WebhookDeliverator {
     ) -> Result<(), Error> {
         let mut tasks =
             ParallelTaskSet::new_with_parallelism(Self::MAX_CONCURRENT_RXS);
-        let mut paginator =
-            Paginator::new(nexus_db_queries::db::datastore::SQL_BATCH_SIZE);
+        let mut paginator = Paginator::new(
+            nexus_db_queries::db::datastore::SQL_BATCH_SIZE,
+            dropshot::PaginationOrder::Ascending,
+        );
         while let Some(p) = paginator.next() {
             let rxs = self
                 .datastore

--- a/nexus/src/app/external_endpoints.rs
+++ b/nexus/src/app/external_endpoints.rs
@@ -502,7 +502,8 @@ pub(crate) async fn read_all_endpoints(
 
     // Fetch all silos.
     let mut silos = Vec::new();
-    let mut paginator = Paginator::new(batch_size);
+    let mut paginator =
+        Paginator::new(batch_size, dropshot::PaginationOrder::Ascending);
     while let Some(p) = paginator.next() {
         let batch = datastore
             .silos_list(
@@ -518,7 +519,8 @@ pub(crate) async fn read_all_endpoints(
     // Fetch all external DNS zones.  We should really only ever have one, but
     // we may as well paginate this.
     let mut external_dns_zones = Vec::new();
-    let mut paginator = Paginator::new(batch_size);
+    let mut paginator =
+        Paginator::new(batch_size, dropshot::PaginationOrder::Ascending);
     while let Some(p) = paginator.next() {
         let batch = datastore
             .dns_zones_list(opctx, DnsGroup::External, &p.current_pagparams())
@@ -533,7 +535,8 @@ pub(crate) async fn read_all_endpoints(
 
     // Fetch all TLS certificates.
     let mut certs = Vec::new();
-    let mut paginator = Paginator::new(batch_size);
+    let mut paginator =
+        Paginator::new(batch_size, dropshot::PaginationOrder::Ascending);
     while let Some(p) = paginator.next() {
         let batch = datastore
             .certificate_list_for(

--- a/nexus/tests/integration_tests/volume_management.rs
+++ b/nexus/tests/integration_tests/volume_management.rs
@@ -5175,7 +5175,8 @@ async fn get_volume_resource_usage_records(
     use nexus_db_schema::schema::volume_resource_usage::dsl;
 
     let mut records: Vec<VolumeResourceUsageRecord> = Vec::new();
-    let mut paginator = Paginator::new(SQL_BATCH_SIZE);
+    let mut paginator =
+        Paginator::new(SQL_BATCH_SIZE, dropshot::PaginationOrder::Ascending);
     let conn = datastore.pool_connection_for_tests().await.unwrap();
 
     while let Some(p) = paginator.next() {


### PR DESCRIPTION
Pagination was previously hardcoded to be `Ascending`. I ran into an [issue](https://github.com/oxidecomputer/omicron/pull/8465#discussion_r2175606984) when paginating across multiple pages when descending order was required.

I fixed this by adding a parameter for the desired order into `Paginator::new` rather than hardcoding it. The rest is fixes to existing callsites.