### PR TITLE
sled-agent-config-reconciler: actually call `on_time_sync()`

### DIFF
--- a/sled-agent/config-reconciler/src/reconciler_task.rs
+++ b/sled-agent/config-reconciler/src/reconciler_task.rs
@@ -466,6 +466,12 @@ impl ReconcilerTask {
         // and also we want to report it as part of each reconciler result).
         let timesync_status = self.zones.check_timesync().await;
 
+        // Call back into sled-agent and let it do any work that needs to happen
+        // once time is sync'd (e.g., rewrite `uptime`).
+        if timesync_status.is_synchronized() {
+            sled_agent_facilities.on_time_sync();
+        }
+
         // We conservatively refuse to start any new zones if any zones have
         // failed to shut down cleanly. This could be more precise, but we want
         // to avoid wandering into some really weird cases, such as:

--- a/sled-agent/config-reconciler/src/reconciler_task/zones.rs
+++ b/sled-agent/config-reconciler/src/reconciler_task/zones.rs
@@ -1129,7 +1129,7 @@ mod tests {
             &self.underlay_vnic
         }
 
-        async fn on_time_sync(&self) {}
+        fn on_time_sync(&self) {}
 
         async fn start_omicron_zone(
             &self,

--- a/sled-agent/config-reconciler/src/sled_agent_facilities.rs
+++ b/sled-agent/config-reconciler/src/sled_agent_facilities.rs
@@ -27,7 +27,7 @@ pub trait SledAgentFacilities: Send + Sync + 'static {
     // currently implemented by `ServiceManager` and does a couple one-time
     // setup things (like rewrite the OS boot time). We could probably absorb
     // that work and remove this callback.
-    fn on_time_sync(&self) -> impl Future<Output = ()> + Send;
+    fn on_time_sync(&self);
 
     /// Method to start a zone.
     // TODO-cleanup This is implemented by

--- a/sled-agent/src/services.rs
+++ b/sled-agent/src/services.rs
@@ -3118,14 +3118,14 @@ impl ServiceManager {
     ///
     /// This function only executes the out-of-band actions once, once the
     /// synchronization state has shifted to true.
-    pub(crate) async fn on_time_sync(&self) {
+    pub(crate) fn on_time_sync(&self) {
         if self
             .inner
             .time_synced
             .compare_exchange(false, true, Ordering::Acquire, Ordering::Relaxed)
             .is_ok()
         {
-            debug!(self.inner.log, "Time is now synchronized");
+            info!(self.inner.log, "Time is now synchronized");
             // We only want to rewrite the boot time once, so we do it here
             // when we know the time is synchronized.
             self.boottime_rewrite();
@@ -3138,11 +3138,11 @@ impl ServiceManager {
             // https://github.com/oxidecomputer/omicron/issues/8022.
             let queue = self.metrics_queue();
             match queue.notify_time_synced_sled(self.sled_id()) {
-                Ok(_) => debug!(
+                Ok(_) => info!(
                     self.inner.log,
                     "Notified metrics task that time is now synced",
                 ),
-                Err(e) => error!(
+                Err(e) => warn!(
                     self.inner.log,
                     "Failed to notify metrics task that \
                      time is now synced, metrics may not be produced.";

--- a/sled-agent/src/sled_agent.rs
+++ b/sled-agent/src/sled_agent.rs
@@ -1336,8 +1336,8 @@ impl SledAgentFacilities for ReconcilerFacilities {
         &self.etherstub_vnic
     }
 
-    async fn on_time_sync(&self) {
-        self.service_manager.on_time_sync().await
+    fn on_time_sync(&self) {
+        self.service_manager.on_time_sync();
     }
 
     async fn start_omicron_zone(


### PR DESCRIPTION
@askfongjojo noticed that our `uptime`s on dogfood are all nonsense:

```
 8  BRM44220011        ok: 14:05:34    up 14066 day(s), 14:06,  1 user,  load average: 5.54, 5.60, 5.62
 9  BRM44220005        ok: 14:05:34    up 14066 day(s), 14:06,  1 user,  load average: 17.51, 17.81, 17.81
10  BRM42220009        ok: 14:05:35    up 14066 day(s), 14:06,  1 user,  load average: 15.00, 14.46, 14.01
11  BRM42220006        ok: 14:05:35    up 14066 day(s), 14:06,  0 users,  load average: 11.49, 11.21, 11.10
12  BRM42220057        ok: 14:05:35    up 14066 day(s), 14:06,  0 users,  load average: 2.88, 2.62, 2.03
...
```

I _think_ #8064 introduced this. It shuffled around how time sync is checked and added a callback that the config-reconciler is supposed to run when it detects time has synchronized; that callback is responsible for rewriting `uptime` (among other things), but it never actually executes the callback. This PR fixes that.

However, we have some racklettes that are running commits that include #8064 that have reasonable uptimes. I'm not sure how that's possible - is there some other way `uptime` can be correct if sled-agent doesn't fix it?