### PR TITLE
Added pantry support to omdb

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -7739,6 +7739,7 @@ dependencies = [
  "clap",
  "crossterm",
  "crucible-agent-client",
+ "crucible-pantry-client",
  "csv",
  "diesel",
  "dropshot",

--- a/dev-tools/omdb/Cargo.toml
+++ b/dev-tools/omdb/Cargo.toml
@@ -20,6 +20,7 @@ chrono.workspace = true
 clap.workspace = true
 crossterm.workspace = true
 crucible-agent-client.workspace = true
+crucible-pantry-client.workspace = true
 csv.workspace = true
 diesel.workspace = true
 dropshot.workspace = true

--- a/dev-tools/omdb/src/bin/omdb/crucible_pantry.rs
+++ b/dev-tools/omdb/src/bin/omdb/crucible_pantry.rs
@@ -1,0 +1,153 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at https://mozilla.org/MPL/2.0/.
+
+//! omdb commands that query a crucible-pantry
+
+use anyhow::Context;
+use anyhow::bail;
+use clap::Args;
+use clap::Subcommand;
+use crucible_pantry_client::Client;
+use tabled::Tabled;
+use uuid::Uuid;
+
+use crate::Omdb;
+use crate::helpers::CONNECTION_OPTIONS_HEADING;
+
+/// Arguments to the "omdb crucible-pantry" subcommand
+#[derive(Debug, Args)]
+pub struct CruciblePantryArgs {
+    /// URL of the crucible pantry internal API
+    #[clap(
+        long,
+        env = "OMDB_CRUCIBLE_PANTRY_URL",
+        global = true,
+        help_heading = CONNECTION_OPTIONS_HEADING,
+    )]
+    crucible_pantry_url: Option<String>,
+
+    #[command(subcommand)]
+    command: CruciblePantryCommands,
+}
+
+/// Subcommands for the "omdb crucible-pantry" subcommand
+#[derive(Debug, Subcommand)]
+enum CruciblePantryCommands {
+    /// Print information about a pantry jobs finished status
+    IsFinished(FinishedArgs),
+    /// Print information about the pantry
+    Status,
+    /// Print information about a specific volume
+    Volume(VolumeArgs),
+}
+
+#[derive(Debug, Args, Clone)]
+struct FinishedArgs {
+    /// The Job ID
+    id: String,
+}
+
+#[derive(Debug, Args, Clone)]
+struct VolumeArgs {
+    /// The UUID of the volume
+    uuid: Uuid,
+}
+
+impl CruciblePantryArgs {
+    /// Run a `omdb crucible-pantry` subcommand.
+    pub(crate) async fn run_cmd(
+        &self,
+        _omdb: &Omdb,
+    ) -> Result<(), anyhow::Error> {
+        // The crucible pantry URL is required, but can come from the
+        // environment, in which case it won't be on the command line.
+        let Some(crucible_pantry_url) = &self.crucible_pantry_url else {
+            bail!(
+                "crucible pantry URL must be specified with \
+                --crucible-pantry-url or by setting the environment variable \
+                OMDB_CRUCIBLE_PANTRY_URL"
+            );
+        };
+        let client = Client::new(crucible_pantry_url);
+
+        match &self.command {
+            CruciblePantryCommands::IsFinished(id) => {
+                cmd_is_finished(&client, id).await
+            }
+            CruciblePantryCommands::Status => cmd_pantry_status(&client).await,
+            CruciblePantryCommands::Volume(uuid) => {
+                cmd_volume_info(&client, uuid).await
+            }
+        }
+    }
+}
+
+/// Runs `omdb crucible-agent volume`
+async fn cmd_is_finished(
+    client: &crucible_pantry_client::Client,
+    args: &FinishedArgs,
+) -> Result<(), anyhow::Error> {
+    let is_finished =
+        client.is_job_finished(&args.id).await.context("checking jobs")?;
+    println!("Job: {} reports is_finished: {:?}", args.id, is_finished);
+    Ok(())
+}
+
+/// Runs `omdb crucible-agent volume`
+async fn cmd_volume_info(
+    client: &crucible_pantry_client::Client,
+    args: &VolumeArgs,
+) -> Result<(), anyhow::Error> {
+    let volume = args.uuid.to_string();
+    let vs = client.volume_status(&volume).await.context("listing volumes")?;
+    println!("          active: {}", vs.active);
+    println!(" num_job_handles: {}", vs.num_job_handles);
+    println!("     seen_active: {}", vs.seen_active);
+    Ok(())
+}
+
+#[derive(Tabled)]
+#[tabled(rename_all = "SCREAMING_SNAKE_CASE")]
+struct VolumeStatus {
+    volume_id: String,
+    active: String,
+    num_job_handles: String,
+    seen_active: String,
+}
+
+/// Runs `omdb crucible-pantry status`
+async fn cmd_pantry_status(
+    client: &crucible_pantry_client::Client,
+) -> Result<(), anyhow::Error> {
+    let status = client.pantry_status().await.context("listing volumes")?;
+
+    println!("num_job_handles {:?}", status.num_job_handles);
+    println!("Volumes found: {}", status.volumes.len());
+
+    let mut rows = Vec::new();
+    for v in &status.volumes {
+        // let vs = client.volume_status(&v).await.context("listing volumes")?;
+        match client.volume_status(&v).await.context("listing volumes") {
+            Ok(vs) => {
+                rows.push(VolumeStatus {
+                    volume_id: v.clone().to_string(),
+                    active: vs.active.clone().to_string(),
+                    num_job_handles: vs.num_job_handles.clone().to_string(),
+                    seen_active: vs.seen_active.clone().to_string(),
+                });
+            }
+            Err(e) => {
+                println!("Failed to get info for volume {v}: {e}");
+            }
+        }
+    }
+    let table = tabled::Table::new(rows)
+        .with(tabled::settings::Style::empty())
+        .with(tabled::settings::Padding::new(0, 1, 0, 0))
+        .to_string();
+
+    println!("{}", table);
+
+    Ok(())
+}

--- a/dev-tools/omdb/src/bin/omdb/main.rs
+++ b/dev-tools/omdb/src/bin/omdb/main.rs
@@ -48,6 +48,7 @@ use std::net::SocketAddrV6;
 use tokio::net::TcpSocket;
 
 mod crucible_agent;
+mod crucible_pantry;
 mod db;
 mod helpers;
 mod mgs;
@@ -82,6 +83,7 @@ async fn main_impl() -> Result<(), anyhow::Error> {
         }
         OmdbCommands::SledAgent(sled) => sled.run_cmd(&args, &log).await,
         OmdbCommands::CrucibleAgent(crucible) => crucible.run_cmd(&args).await,
+        OmdbCommands::CruciblePantry(crucible) => crucible.run_cmd(&args).await,
     }
 }
 
@@ -284,6 +286,8 @@ impl Omdb {
 enum OmdbCommands {
     /// Debug a specific crucible-agent
     CrucibleAgent(crucible_agent::CrucibleAgentArgs),
+    /// Query a specific crucible-pantry
+    CruciblePantry(crucible_pantry::CruciblePantryArgs),
     /// Query the control plane database (CockroachDB)
     Db(db::DbArgs),
     /// Debug a specific Management Gateway Service instance

--- a/dev-tools/omdb/tests/usage_errors.out
+++ b/dev-tools/omdb/tests/usage_errors.out
@@ -9,15 +9,16 @@ Omicron debugger (unstable)
 Usage: omdb [OPTIONS] <COMMAND>
 
 Commands:
-  crucible-agent  Debug a specific crucible-agent
-  db              Query the control plane database (CockroachDB)
-  mgs             Debug a specific Management Gateway Service instance
-  nexus           Debug a specific Nexus instance
-  oximeter        Query oximeter collector state
-  oxql            Enter the Oximeter Query Language shell for interactive querying
-  reconfigurator  Interact with the Reconfigurator system
-  sled-agent      Debug a specific Sled
-  help            Print this message or the help of the given subcommand(s)
+  crucible-agent   Debug a specific crucible-agent
+  crucible-pantry  Query a specific crucible-pantry
+  db               Query the control plane database (CockroachDB)
+  mgs              Debug a specific Management Gateway Service instance
+  nexus            Debug a specific Nexus instance
+  oximeter         Query oximeter collector state
+  oxql             Enter the Oximeter Query Language shell for interactive querying
+  reconfigurator   Interact with the Reconfigurator system
+  sled-agent       Debug a specific Sled
+  help             Print this message or the help of the given subcommand(s)
 
 Options:
       --log-level <LOG_LEVEL>  log level filter [env: LOG_LEVEL=] [default: warn]
@@ -42,15 +43,16 @@ using internal APIs.  This is a prototype.  The commands and output are unstable
 Usage: omdb [OPTIONS] <COMMAND>
 
 Commands:
-  crucible-agent  Debug a specific crucible-agent
-  db              Query the control plane database (CockroachDB)
-  mgs             Debug a specific Management Gateway Service instance
-  nexus           Debug a specific Nexus instance
-  oximeter        Query oximeter collector state
-  oxql            Enter the Oximeter Query Language shell for interactive querying
-  reconfigurator  Interact with the Reconfigurator system
-  sled-agent      Debug a specific Sled
-  help            Print this message or the help of the given subcommand(s)
+  crucible-agent   Debug a specific crucible-agent
+  crucible-pantry  Query a specific crucible-pantry
+  db               Query the control plane database (CockroachDB)
+  mgs              Debug a specific Management Gateway Service instance
+  nexus            Debug a specific Nexus instance
+  oximeter         Query oximeter collector state
+  oxql             Enter the Oximeter Query Language shell for interactive querying
+  reconfigurator   Interact with the Reconfigurator system
+  sled-agent       Debug a specific Sled
+  help             Print this message or the help of the given subcommand(s)
 
 Options:
       --log-level <LOG_LEVEL>


### PR DESCRIPTION
Allow omdb to connect to and query a pantry endpoint. 
Right now we support, status, volume <id>, and is-finished <job-id>

Sample output:
```
EVT22200005 # /alan/bin/omdb crucible-pantry                
error: 'omdb crucible-pantry' requires a subcommand but one was not provided
  [subcommands: is-finished, status, volume, help]

Usage: omdb crucible-pantry [OPTIONS] <COMMAND>

For more information, try '--help'.
```

pantry status:
```
EVT22200005 # /alan/bin/omdb crucible-pantry status
num_job_handles 0
Volumes found: 3
VOLUME_ID                            ACTIVE NUM_JOB_HANDLES SEEN_ACTIVE 
6754b69a-29bb-4153-a96a-f9d07b6a4cc6 true   0               true        
cc07be14-a60b-4e7d-af62-0626b4fb6721 true   0               true        
f98e3389-3b4d-42a3-916f-6bc04d700e8d true   0               true        
```

pantry volume:
```
EVT22200005 # /alan/bin/omdb crucible-pantry volume cc07be14-a60b-4e7d-af62-0626b4fb6721
          active: true
 num_job_handles: 0
     seen_active: true
```

is-finished (which I could never get to show me anything):
```
EVT22200005 # /alan/bin/omdb crucible-pantry is-finished 100                            
Error: checking jobs

Caused by:
    Error Response: status: 404 Not Found; headers: {"content-type": "application/json", "x-request-id": "2803e216-d302-4cb9-b8a5-13c031ac08ad", "content-length": "84", "date": "Wed, 02 Jul 2025 20:46:43 GMT"}; value: Error { error_code: None, message: "Not Found", request_id: "2803e216-d302-4cb9-b8a5-13c031ac08ad" }
```