### PR TITLE
Update Propolis

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -692,7 +692,7 @@ dependencies = [
 [[package]]
 name = "bhyve_api"
 version = "0.0.0"
-source = "git+https://github.com/oxidecomputer/propolis?rev=e3988414bd68ecf806078fb898120e1194451ee9#e3988414bd68ecf806078fb898120e1194451ee9"
+source = "git+https://github.com/oxidecomputer/propolis?rev=c03bd1a29c775acfc65de561b8fc436e2459a633#c03bd1a29c775acfc65de561b8fc436e2459a633"
 dependencies = [
  "bhyve_api_sys",
  "libc",
@@ -702,7 +702,7 @@ dependencies = [
 [[package]]
 name = "bhyve_api_sys"
 version = "0.0.0"
-source = "git+https://github.com/oxidecomputer/propolis?rev=e3988414bd68ecf806078fb898120e1194451ee9#e3988414bd68ecf806078fb898120e1194451ee9"
+source = "git+https://github.com/oxidecomputer/propolis?rev=c03bd1a29c775acfc65de561b8fc436e2459a633#c03bd1a29c775acfc65de561b8fc436e2459a633"
 dependencies = [
  "libc",
  "strum",
@@ -7678,7 +7678,7 @@ dependencies = [
  "pq-sys",
  "pretty_assertions",
  "progenitor-client 0.10.0",
- "propolis-client 0.1.0 (git+https://github.com/oxidecomputer/propolis?rev=e3988414bd68ecf806078fb898120e1194451ee9)",
+ "propolis-client 0.1.0 (git+https://github.com/oxidecomputer/propolis?rev=c03bd1a29c775acfc65de561b8fc436e2459a633)",
  "qorb",
  "rand 0.8.5",
  "range-requests",
@@ -8053,7 +8053,7 @@ dependencies = [
  "oximeter-producer",
  "oxnet",
  "pretty_assertions",
- "propolis-client 0.1.0 (git+https://github.com/oxidecomputer/propolis?rev=e3988414bd68ecf806078fb898120e1194451ee9)",
+ "propolis-client 0.1.0 (git+https://github.com/oxidecomputer/propolis?rev=c03bd1a29c775acfc65de561b8fc436e2459a633)",
  "propolis-mock-server",
  "propolis_api_types",
  "rand 0.8.5",
@@ -10121,7 +10121,7 @@ dependencies = [
 [[package]]
 name = "propolis-client"
 version = "0.1.0"
-source = "git+https://github.com/oxidecomputer/propolis?rev=e3988414bd68ecf806078fb898120e1194451ee9#e3988414bd68ecf806078fb898120e1194451ee9"
+source = "git+https://github.com/oxidecomputer/propolis?rev=c03bd1a29c775acfc65de561b8fc436e2459a633#c03bd1a29c775acfc65de561b8fc436e2459a633"
 dependencies = [
  "async-trait",
  "base64 0.21.7",
@@ -10166,7 +10166,7 @@ dependencies = [
 [[package]]
 name = "propolis-mock-server"
 version = "0.0.0"
-source = "git+https://github.com/oxidecomputer/propolis?rev=e3988414bd68ecf806078fb898120e1194451ee9#e3988414bd68ecf806078fb898120e1194451ee9"
+source = "git+https://github.com/oxidecomputer/propolis?rev=c03bd1a29c775acfc65de561b8fc436e2459a633#c03bd1a29c775acfc65de561b8fc436e2459a633"
 dependencies = [
  "anyhow",
  "atty",
@@ -10210,7 +10210,7 @@ dependencies = [
 [[package]]
 name = "propolis_api_types"
 version = "0.0.0"
-source = "git+https://github.com/oxidecomputer/propolis?rev=e3988414bd68ecf806078fb898120e1194451ee9#e3988414bd68ecf806078fb898120e1194451ee9"
+source = "git+https://github.com/oxidecomputer/propolis?rev=c03bd1a29c775acfc65de561b8fc436e2459a633#c03bd1a29c775acfc65de561b8fc436e2459a633"
 dependencies = [
  "crucible-client-types",
  "propolis_types",
@@ -10223,7 +10223,7 @@ dependencies = [
 [[package]]
 name = "propolis_types"
 version = "0.0.0"
-source = "git+https://github.com/oxidecomputer/propolis?rev=e3988414bd68ecf806078fb898120e1194451ee9#e3988414bd68ecf806078fb898120e1194451ee9"
+source = "git+https://github.com/oxidecomputer/propolis?rev=c03bd1a29c775acfc65de561b8fc436e2459a633#c03bd1a29c775acfc65de561b8fc436e2459a633"
 dependencies = [
  "schemars",
  "serde",
@@ -11975,7 +11975,7 @@ dependencies = [
  "omicron-workspace-hack",
  "oxnet",
  "progenitor 0.10.0",
- "propolis-client 0.1.0 (git+https://github.com/oxidecomputer/propolis?rev=e3988414bd68ecf806078fb898120e1194451ee9)",
+ "propolis-client 0.1.0 (git+https://github.com/oxidecomputer/propolis?rev=c03bd1a29c775acfc65de561b8fc436e2459a633)",
  "regress",
  "reqwest",
  "schemars",
@@ -12050,7 +12050,7 @@ dependencies = [
  "omicron-uuid-kinds",
  "omicron-workspace-hack",
  "oxnet",
- "propolis-client 0.1.0 (git+https://github.com/oxidecomputer/propolis?rev=e3988414bd68ecf806078fb898120e1194451ee9)",
+ "propolis-client 0.1.0 (git+https://github.com/oxidecomputer/propolis?rev=c03bd1a29c775acfc65de561b8fc436e2459a633)",
  "rcgen",
  "schemars",
  "serde",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -619,10 +619,10 @@ progenitor-client = "0.10.0"
 # NOTE: if you change the pinned revision of the `bhyve_api` and propolis
 # dependencies, you must also update the references in package-manifest.toml to
 # match the new revision.
-bhyve_api = { git = "https://github.com/oxidecomputer/propolis", rev = "e3988414bd68ecf806078fb898120e1194451ee9" }
-propolis_api_types = { git = "https://github.com/oxidecomputer/propolis", rev = "e3988414bd68ecf806078fb898120e1194451ee9" }
-propolis-client = { git = "https://github.com/oxidecomputer/propolis", rev = "e3988414bd68ecf806078fb898120e1194451ee9" }
-propolis-mock-server = { git = "https://github.com/oxidecomputer/propolis", rev = "e3988414bd68ecf806078fb898120e1194451ee9" }
+bhyve_api = { git = "https://github.com/oxidecomputer/propolis", rev = "c03bd1a29c775acfc65de561b8fc436e2459a633" }
+propolis_api_types = { git = "https://github.com/oxidecomputer/propolis", rev = "c03bd1a29c775acfc65de561b8fc436e2459a633" }
+propolis-client = { git = "https://github.com/oxidecomputer/propolis", rev = "c03bd1a29c775acfc65de561b8fc436e2459a633" }
+propolis-mock-server = { git = "https://github.com/oxidecomputer/propolis", rev = "c03bd1a29c775acfc65de561b8fc436e2459a633" }
 # NOTE: see above!
 proptest = "1.7.0"
 qorb = "0.4.0"

--- a/nexus/src/app/mod.rs
+++ b/nexus/src/app/mod.rs
@@ -141,9 +141,8 @@ pub const MIN_MEMORY_BYTES_PER_INSTANCE: u32 = 1 << 30; // 1 GiB
 // Before raising or removing this limit, testing has been valuable. See:
 // * illumos bug #17403
 // * Propolis issue #903
-// There are known issues setting this above 1028 GiB. See:
 // * Propolis issue #907
-pub const MAX_MEMORY_BYTES_PER_INSTANCE: u64 = 1024 * (1 << 30); // 1 TiB
+pub const MAX_MEMORY_BYTES_PER_INSTANCE: u64 = 1536 * (1 << 30); // 1.5 TiB
 
 pub const MIN_DISK_SIZE_BYTES: u32 = 1 << 30; // 1 GiB
 pub const MAX_DISK_SIZE_BYTES: u64 = 1023 * (1 << 30); // 1023 GiB

--- a/package-manifest.toml
+++ b/package-manifest.toml
@@ -622,10 +622,10 @@ service_name = "propolis-server"
 only_for_targets.image = "standard"
 source.type = "prebuilt"
 source.repo = "propolis"
-source.commit = "e3988414bd68ecf806078fb898120e1194451ee9"
+source.commit = "c03bd1a29c775acfc65de561b8fc436e2459a633"
 # The SHA256 digest is automatically posted to:
 # https://buildomat.eng.oxide.computer/public/file/oxidecomputer/propolis/image/<commit>/propolis-server.sha256.txt
-source.sha256 = "a858fe9db8db262b402a44598e991c6298f92531421029f7728b3fdd45fe621b"
+source.sha256 = "a83979355bd5b7346c3647ad674c1da5a746d7045b992c1edcf8729cc7634e5d"
 output.type = "zone"
 
 [package.mg-ddm-gz]


### PR DESCRIPTION
Changes here are:
* update zerocopy to 0.8.25 (Propolis#910)
* Rust 1.87.0 clippy lints (Propolis#911)
* Support guest memory sizes >=1028 GiB (Propolis#912)
* Fix new lints (Propolis#914)
* server: build Tokio runtime using `oxide-tokio-rt` (Propolis#913)
* Handle CPUID subleaves more precisely when using Bhyve defaults (Propolis#915)

Since the Propolis update increases the max viable memory size, I'm bumping that to 1.5 TiB here as well (it's the largest size I've tested on `dublin`)

The CPUID changes in #915 are guest-visible and on production racks will have us stop advertising platform QoS features, whose MSRs aren't made available to guests anyway.