### PR TITLE
[oxlog] want chrony logs in support bundles

### DIFF
--- a/dev-tools/oxlog/src/lib.rs
+++ b/dev-tools/oxlog/src/lib.rs
@@ -272,6 +272,15 @@ impl Zones {
                     paths.extra.push(("cockroachdb", dir));
                 }
 
+                // Grab the chrony logs that are not apart of the standard SMF
+                // logs.
+                if zone.starts_with("oxz_ntp") {
+                    let mut dir = zones_path.clone();
+                    dir.push(zone);
+                    dir.push("root/var/log/chrony");
+                    paths.extra.push(("ntp", dir));
+                }
+
                 zones.insert(zone.to_string(), paths);
             }
         }


### PR DESCRIPTION
This threads chrony's logs found in the zone root at `/var/log/chrony/*` into oxlog's extra logs for `ntp`.

```
BRM42220009 # /var/tmp/oxlog logs --extra oxz_ntp_7529be1c-ca8b-441a-89aa-37166cc450df
/pool/ext/845ff39a-3205-416f-8bda-e35829107c8a/crypt/zone/oxz_ntp_7529be1c-ca8b-441a-89aa-37166cc450df/root/var/log/chrony/measurements.log
/pool/ext/845ff39a-3205-416f-8bda-e35829107c8a/crypt/zone/oxz_ntp_7529be1c-ca8b-441a-89aa-37166cc450df/root/var/log/chrony/statistics.log
/pool/ext/845ff39a-3205-416f-8bda-e35829107c8a/crypt/zone/oxz_ntp_7529be1c-ca8b-441a-89aa-37166cc450df/root/var/log/chrony/tracking.log
```

This is part of the fix for #8516
