### PR TITLE
[2/5] User data export: omdb sub commands

### DIFF
--- a/dev-tools/omdb/src/bin/omdb/db.rs
+++ b/dev-tools/omdb/src/bin/omdb/db.rs
@@ -103,6 +103,8 @@ use nexus_db_model::SwCaboose;
 use nexus_db_model::SwRotPage;
 use nexus_db_model::UpstairsRepairNotification;
 use nexus_db_model::UpstairsRepairProgress;
+use nexus_db_model::UserDataExportRecord;
+use nexus_db_model::UserDataExportResource;
 use nexus_db_model::Vmm;
 use nexus_db_model::Volume;
 use nexus_db_model::VolumeRepair;
@@ -188,6 +190,7 @@ use uuid::Uuid;
 mod alert;
 mod ereport;
 mod saga;
+mod user_data_export;
 
 const NO_ACTIVE_PROPOLIS_MSG: &str = "<no active Propolis>";
 const NOT_ON_SLED_MSG: &str = "<not on any sled>";
@@ -407,6 +410,8 @@ enum DbCommands {
     Alert(AlertArgs),
     /// Commands for querying and interacting with pools
     Zpool(ZpoolArgs),
+    /// Commands for querying and interacting with user data export objects
+    UserDataExport(user_data_export::UserDataExportArgs),
 }
 
 #[derive(Debug, Args, Clone)]
@@ -1506,6 +1511,9 @@ impl DbArgs {
                     },
                     DbCommands::Ereport(args) => {
                         cmd_db_ereport(&datastore, &fetch_opts, &args).await
+                    }
+                    DbCommands::UserDataExport(args) => {
+                        args.exec(&omdb, &opctx, &datastore).await
                     }
                 }
             }
@@ -3575,6 +3583,33 @@ async fn volume_used_by(
         String::from("listing images used")
     });
 
+    let export_used: Vec<UserDataExportRecord> = {
+        let volumes = volumes.to_vec();
+        datastore
+            .pool_connection_for_tests()
+            .await?
+            .transaction_async(async move |conn| {
+                use nexus_db_schema::schema::user_data_export::dsl;
+
+                conn.batch_execute_async(ALLOW_FULL_TABLE_SCAN_SQL).await?;
+
+                paginated(
+                    dsl::user_data_export,
+                    dsl::id,
+                    &first_page::<dsl::id>(fetch_opts.fetch_limit),
+                )
+                .filter(dsl::volume_id.eq_any(volumes))
+                .select(UserDataExportRecord::as_select())
+                .load_async(&conn)
+                .await
+            })
+            .await?
+    };
+
+    check_limit(&export_used, fetch_opts.fetch_limit, || {
+        String::from("listing user data export used")
+    });
+
     Ok(volumes
         .iter()
         .map(|volume_id| {
@@ -3592,6 +3627,9 @@ async fn volume_used_by(
 
             let maybe_disk =
                 disks_used.iter().find(|x| x.volume_id() == volume_id);
+
+            let maybe_export =
+                export_used.iter().find(|x| x.volume_id() == Some(volume_id));
 
             if let Some(image) = maybe_image {
                 VolumeUsedBy {
@@ -3624,6 +3662,23 @@ async fn volume_used_by(
                     usage_id: disk.id().to_string(),
                     usage_name: disk.name().to_string(),
                     deleted: disk.time_deleted().is_some(),
+                }
+            } else if let Some(export) = maybe_export {
+                match export.resource() {
+                    UserDataExportResource::Snapshot { id } => VolumeUsedBy {
+                        volume_id,
+                        usage_type: String::from("export"),
+                        usage_id: id.to_string(),
+                        usage_name: String::from("snapshot"),
+                        deleted: export.deleted(),
+                    },
+                    UserDataExportResource::Image { id } => VolumeUsedBy {
+                        volume_id,
+                        usage_type: String::from("export"),
+                        usage_id: id.to_string(),
+                        usage_name: String::from("image"),
+                        deleted: export.deleted(),
+                    },
                 }
             } else {
                 VolumeUsedBy {

--- a/dev-tools/omdb/src/bin/omdb/db/user_data_export.rs
+++ b/dev-tools/omdb/src/bin/omdb/db/user_data_export.rs
@@ -1,0 +1,266 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at https://mozilla.org/MPL/2.0/.
+
+//! `omdb db user-data-export` subcommands
+
+use crate::Omdb;
+use crate::check_allow_destructive::DestructiveOperationToken;
+use crate::helpers::display_debug;
+use crate::helpers::display_option_blank;
+use async_bb8_diesel::AsyncRunQueryDsl;
+use clap::Args;
+use clap::Subcommand;
+use diesel::prelude::*;
+use nexus_db_model::UserDataExportRecord;
+use nexus_db_model::UserDataExportResourceType;
+use nexus_db_model::UserDataExportState;
+use nexus_db_queries::context::OpContext;
+use nexus_db_queries::db::DataStore;
+use omicron_uuid_kinds::UserDataExportUuid;
+use omicron_uuid_kinds::VolumeUuid;
+use std::net::SocketAddrV6;
+use tabled::Tabled;
+use uuid::Uuid;
+
+/// `omdb db user-data-export` subcommand
+#[derive(Debug, Args, Clone)]
+pub struct UserDataExportArgs {
+    #[command(subcommand)]
+    command: UserDataExportCommands,
+}
+
+#[derive(Debug, Subcommand, Clone)]
+enum UserDataExportCommands {
+    /// Check if a read-only resource has a user data export object
+    Query(UserDataExportQueryArgs),
+
+    /// Manually request that a user data export object be deleted.
+    Delete(UserDataExportDeleteArgs),
+
+    /// Show the user data export related changes required by Nexus
+    ShowChangeset,
+}
+
+#[derive(Clone, Debug, Args)]
+struct UserDataExportQueryArgs {
+    #[clap(long)]
+    resource_type: UserDataExportResourceType,
+
+    #[clap(long)]
+    resource_id: Uuid,
+}
+
+#[derive(Clone, Debug, Args)]
+struct UserDataExportDeleteArgs {
+    #[clap(long)]
+    user_data_export_id: UserDataExportUuid,
+}
+
+impl UserDataExportArgs {
+    pub async fn exec(
+        &self,
+        omdb: &Omdb,
+        opctx: &OpContext,
+        datastore: &DataStore,
+    ) -> Result<(), anyhow::Error> {
+        match &self.command {
+            UserDataExportCommands::Query(args) => {
+                cmd_user_data_export_query(opctx, datastore, args).await
+            }
+
+            UserDataExportCommands::Delete(args) => {
+                let token = omdb.check_allow_destructive()?;
+
+                cmd_user_data_export_delete(opctx, datastore, args, token).await
+            }
+
+            UserDataExportCommands::ShowChangeset => {
+                cmd_user_data_export_show_changeset(opctx, datastore).await
+            }
+        }
+    }
+}
+
+async fn cmd_user_data_export_query(
+    _opctx: &OpContext,
+    datastore: &DataStore,
+    args: &UserDataExportQueryArgs,
+) -> Result<(), anyhow::Error> {
+    let conn = datastore.pool_connection_for_tests().await?;
+
+    let record = {
+        use nexus_db_schema::schema::user_data_export::dsl;
+
+        dsl::user_data_export
+            .filter(dsl::resource_type.eq(args.resource_type))
+            .filter(dsl::resource_id.eq(args.resource_id))
+            .select(UserDataExportRecord::as_select())
+            .first_async(&*conn)
+            .await?
+    };
+
+    #[derive(Tabled)]
+    struct Row {
+        id: UserDataExportUuid,
+
+        #[tabled(display_with = "display_debug")]
+        state: UserDataExportState,
+        #[tabled(display_with = "display_option_blank")]
+        operating_saga_id: Option<Uuid>,
+        generation: i64,
+
+        resource_type: String,
+        resource_id: Uuid,
+        resource_deleted: bool,
+
+        #[tabled(display_with = "display_option_blank")]
+        pantry_address: Option<SocketAddrV6>,
+        #[tabled(display_with = "display_option_blank")]
+        volume_id: Option<VolumeUuid>,
+    }
+
+    let rows: Vec<_> = vec![Row {
+        id: record.id(),
+
+        state: record.state(),
+        operating_saga_id: record.operating_saga_id(),
+        generation: record.generation(),
+
+        resource_type: args.resource_type.to_string(),
+        resource_id: args.resource_id,
+        resource_deleted: record.deleted(),
+
+        pantry_address: record.pantry_address(),
+        volume_id: record.volume_id(),
+    }];
+
+    let table = tabled::Table::new(rows)
+        .with(tabled::settings::Style::psql())
+        .to_string();
+
+    println!("{}", table);
+
+    Ok(())
+}
+
+async fn cmd_user_data_export_delete(
+    _opctx: &OpContext,
+    datastore: &DataStore,
+    args: &UserDataExportDeleteArgs,
+    _destruction_token: DestructiveOperationToken,
+) -> Result<(), anyhow::Error> {
+    datastore.user_data_export_mark_deleted(args.user_data_export_id).await?;
+
+    println!("marked record {} for deletion", args.user_data_export_id);
+
+    Ok(())
+}
+
+async fn cmd_user_data_export_show_changeset(
+    opctx: &OpContext,
+    datastore: &DataStore,
+) -> Result<(), anyhow::Error> {
+    let changeset = datastore.compute_user_data_export_changeset(opctx).await?;
+
+    #[derive(Tabled)]
+    struct RequestRow {
+        action: String,
+        resource_type: String,
+        resource_id: Uuid,
+    }
+
+    #[derive(Tabled)]
+    struct CreateOrDeleteRow {
+        action: String,
+
+        id: UserDataExportUuid,
+
+        #[tabled(display_with = "display_debug")]
+        state: UserDataExportState,
+        #[tabled(display_with = "display_option_blank")]
+        operating_saga_id: Option<Uuid>,
+        generation: i64,
+
+        resource_type: String,
+        resource_id: Uuid,
+        resource_deleted: bool,
+
+        #[tabled(display_with = "display_option_blank")]
+        pantry_address: Option<SocketAddrV6>,
+        #[tabled(display_with = "display_option_blank")]
+        volume_id: Option<VolumeUuid>,
+    }
+
+    let request_rows: Vec<_> = changeset
+        .request_required
+        .iter()
+        .map(|resource| RequestRow {
+            action: String::from("request"),
+            resource_type: resource.type_string(),
+            resource_id: resource.id(),
+        })
+        .collect();
+
+    let create_rows: Vec<_> = changeset
+        .create_required
+        .iter()
+        .map(|record| CreateOrDeleteRow {
+            action: String::from("create"),
+
+            id: record.id(),
+
+            state: record.state(),
+            operating_saga_id: record.operating_saga_id(),
+            generation: record.generation(),
+
+            resource_type: record.resource().type_string(),
+            resource_id: record.resource().id(),
+            resource_deleted: record.deleted(),
+
+            pantry_address: record.pantry_address(),
+            volume_id: record.volume_id(),
+        })
+        .collect();
+
+    let delete_rows: Vec<_> = changeset
+        .delete_required
+        .iter()
+        .map(|record| CreateOrDeleteRow {
+            action: String::from("delete"),
+
+            id: record.id(),
+
+            state: record.state(),
+            operating_saga_id: record.operating_saga_id(),
+            generation: record.generation(),
+
+            resource_type: record.resource().type_string(),
+            resource_id: record.resource().id(),
+            resource_deleted: record.deleted(),
+
+            pantry_address: record.pantry_address(),
+            volume_id: record.volume_id(),
+        })
+        .collect();
+
+    let table = tabled::Table::new(request_rows)
+        .with(tabled::settings::Style::psql())
+        .to_string();
+
+    println!("{}", table);
+
+    let table = tabled::Table::new(create_rows)
+        .with(tabled::settings::Style::psql())
+        .to_string();
+
+    println!("{}", table);
+
+    let table = tabled::Table::new(delete_rows)
+        .with(tabled::settings::Style::psql())
+        .to_string();
+
+    println!("{}", table);
+
+    Ok(())
+}

--- a/dev-tools/omdb/src/bin/omdb/helpers.rs
+++ b/dev-tools/omdb/src/bin/omdb/helpers.rs
@@ -38,6 +38,11 @@ pub(crate) const fn const_max_len(strs: &[&str]) -> usize {
     max
 }
 
+// Wrapper for deriving Tabled with something that derives Debug
+pub(crate) fn display_debug<T: std::fmt::Debug>(v: &T) -> String {
+    format!("{:?}", v)
+}
+
 // Display an empty cell for an Option<T> if it's None.
 pub(crate) fn display_option_blank<T: std::fmt::Display>(
     opt: &Option<T>,

--- a/dev-tools/omdb/tests/usage_errors.out
+++ b/dev-tools/omdb/tests/usage_errors.out
@@ -144,6 +144,7 @@ Commands:
   oximeter                     Print information about the oximeter collector
   alert                        Print information about alerts
   zpool                        Commands for querying and interacting with pools
+  user-data-export             Commands for querying and interacting with user data export objects
   help                         Print this message or the help of the given subcommand(s)
 
 Options:
@@ -202,6 +203,7 @@ Commands:
   oximeter                     Print information about the oximeter collector
   alert                        Print information about alerts
   zpool                        Commands for querying and interacting with pools
+  user-data-export             Commands for querying and interacting with user data export objects
   help                         Print this message or the help of the given subcommand(s)
 
 Options:


### PR DESCRIPTION
Before adding anything else, start with new omdb commands. This will enable inspection and debugging in the future PRs of this set.