### PR TITLE
ci: OPTE rev check could be better with GitHub errors

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -990,4 +990,3 @@ path = "workspace-hack"
 [patch."https://github.com/oxidecomputer/omicron"]
 omicron-uuid-kinds = { path = "uuid-kinds" }
 omicron-common = { path = "common" }
-


### PR DESCRIPTION
Helps with https://github.com/oxidecomputer/omicron/issues/8535. I don't think it's worth "fixing" 8535 directly with a retry or anything but this gets the script in a state that we'll not have to question what went wrong.

as long as I didn't break the script along the way (seems like maybe this check doesn't go until the PR is open?)