### PR TITLE
sled-agent: validate host phase 2 artifacts when ledgering configs (PR 2/4)

### DIFF
--- a/nexus-sled-agent-shared/src/inventory.rs
+++ b/nexus-sled-agent-shared/src/inventory.rs
@@ -597,6 +597,16 @@ pub enum HostPhase2DesiredContents {
     Artifact { hash: ArtifactHash },
 }
 
+impl HostPhase2DesiredContents {
+    /// The artifact hash described by `self`, if it has one.
+    pub fn artifact_hash(&self) -> Option<ArtifactHash> {
+        match self {
+            Self::CurrentContents => None,
+            Self::Artifact { hash } => Some(*hash),
+        }
+    }
+}
+
 /// Describes the desired contents for both host phase 2 slots.
 #[derive(Clone, Debug, Deserialize, Serialize, JsonSchema, PartialEq, Eq)]
 #[serde(rename_all = "snake_case")]


### PR DESCRIPTION
This builds on #8538 and addresses a couple of TODOs in it.

When ledgering a new `OmicronSledConfig`, prior to this PR we already check that we have all the zone artifacts in our local TUF repo depot. This PR extends that to confirm we also have any OS phase 2 artifacts specified in the incoming config.