### PR TITLE
Search new tuf repo before old for zone versions

### DIFF
--- a/nexus/types/src/internal_api/views.rs
+++ b/nexus/types/src/internal_api/views.rs
@@ -685,18 +685,18 @@ impl UpdateStatus {
             return TufRepoVersion::InstallDataset;
         };
 
-        if let Some(old) = old.tuf_repo() {
-            if old.artifacts.iter().any(|meta| meta.hash == hash) {
-                return TufRepoVersion::Version(
-                    old.repo.system_version.clone(),
-                );
-            }
-        }
-
         if let Some(new) = new.tuf_repo() {
             if new.artifacts.iter().any(|meta| meta.hash == hash) {
                 return TufRepoVersion::Version(
                     new.repo.system_version.clone(),
+                );
+            }
+        }
+
+        if let Some(old) = old.tuf_repo() {
+            if old.artifacts.iter().any(|meta| meta.hash == hash) {
+                return TufRepoVersion::Version(
+                    old.repo.system_version.clone(),
                 );
             }
         }


### PR DESCRIPTION
This fixes repo version selection to match what is in `caboose_to_version`. In the case that both repos have the same artifact hash for some reason, we want to show the version for the newer TUF repo.