### PR TITLE
Add desired host phase 2 contents to blueprint

### DIFF
--- a/dev-tools/omdb/tests/successes.out
+++ b/dev-tools/omdb/tests/successes.out
@@ -1461,6 +1461,14 @@ parent:    <none>
 
   sled: ..........<REDACTED_UUID>........... (active, config generation 2)
 
+    host phase 2 contents:
+    ------------------------
+    slot   boot image source
+    ------------------------
+    A      current contents 
+    B      current contents 
+
+
     physical disks:
     -----------------------------------------------------------------
     vendor        model              serial               disposition
@@ -1491,6 +1499,14 @@ parent:    <none>
 
 
   sled: ..........<REDACTED_UUID>........... (active, config generation 2)
+
+    host phase 2 contents:
+    ------------------------
+    slot   boot image source
+    ------------------------
+    A      current contents 
+    B      current contents 
+
 
     physical disks:
     ----------------------------------------------------------------
@@ -1565,6 +1581,14 @@ parent:    <none>
 
   sled: ..........<REDACTED_UUID>........... (active, config generation 2)
 
+    host phase 2 contents:
+    ------------------------
+    slot   boot image source
+    ------------------------
+    A      current contents 
+    B      current contents 
+
+
     physical disks:
     -----------------------------------------------------------------
     vendor        model              serial               disposition
@@ -1595,6 +1619,14 @@ parent:    <none>
 
 
   sled: ..........<REDACTED_UUID>........... (active, config generation 2)
+
+    host phase 2 contents:
+    ------------------------
+    slot   boot image source
+    ------------------------
+    A      current contents 
+    B      current contents 
+
 
     physical disks:
     ----------------------------------------------------------------

--- a/dev-tools/reconfigurator-cli/src/lib.rs
+++ b/dev-tools/reconfigurator-cli/src/lib.rs
@@ -32,11 +32,11 @@ use nexus_types::deployment::execution;
 use nexus_types::deployment::execution::blueprint_external_dns_config;
 use nexus_types::deployment::execution::blueprint_internal_dns_config;
 use nexus_types::deployment::{Blueprint, UnstableReconfiguratorState};
+use nexus_types::deployment::{BlueprintArtifactVersion, PendingMgsUpdate};
 use nexus_types::deployment::{BlueprintZoneDisposition, ExpectedVersion};
 use nexus_types::deployment::{
     BlueprintZoneImageSource, PendingMgsUpdateDetails,
 };
-use nexus_types::deployment::{BlueprintZoneImageVersion, PendingMgsUpdate};
 use nexus_types::deployment::{OmicronZoneNic, TargetReleaseDescription};
 use nexus_types::external_api::views::SledPolicy;
 use nexus_types::external_api::views::SledProvisionPolicy;
@@ -841,8 +841,8 @@ enum ImageSourceArgs {
     InstallDataset,
     /// the zone image comes from a specific TUF repo artifact
     Artifact {
-        #[clap(value_parser = parse_blueprint_zone_image_version)]
-        version: BlueprintZoneImageVersion,
+        #[clap(value_parser = parse_blueprint_artifact_version)]
+        version: BlueprintArtifactVersion,
         hash: ArtifactHash,
     },
 }
@@ -881,10 +881,10 @@ fn image_source_unwrap_or(
                 Ok(BlueprintZoneImageSource::InstallDataset) | Err(_) => (),
                 Ok(BlueprintZoneImageSource::Artifact { version, hash }) => {
                     let version = match version {
-                        BlueprintZoneImageVersion::Available { version } => {
+                        BlueprintArtifactVersion::Available { version } => {
                             version.to_string()
                         }
-                        BlueprintZoneImageVersion::Unknown => {
+                        BlueprintArtifactVersion::Unknown => {
                             "unknown".to_string()
                         }
                     };
@@ -914,15 +914,15 @@ impl From<ImageSourceArgs> for BlueprintZoneImageSource {
     }
 }
 
-fn parse_blueprint_zone_image_version(
+fn parse_blueprint_artifact_version(
     version: &str,
-) -> Result<BlueprintZoneImageVersion, ArtifactVersionError> {
+) -> Result<BlueprintArtifactVersion, ArtifactVersionError> {
     // Treat the literal string "unknown" as an unknown version.
     if version == "unknown" {
-        return Ok(BlueprintZoneImageVersion::Unknown);
+        return Ok(BlueprintArtifactVersion::Unknown);
     }
 
-    Ok(BlueprintZoneImageVersion::Available {
+    Ok(BlueprintArtifactVersion::Available {
         version: version.parse::<ArtifactVersion>()?,
     })
 }

--- a/dev-tools/reconfigurator-cli/src/lib.rs
+++ b/dev-tools/reconfigurator-cli/src/lib.rs
@@ -26,6 +26,7 @@ use nexus_reconfigurator_simulation::{BlueprintId, CollectionId, SimState};
 use nexus_reconfigurator_simulation::{SimStateBuilder, SimTufRepoSource};
 use nexus_reconfigurator_simulation::{SimTufRepoDescription, Simulator};
 use nexus_sled_agent_shared::inventory::ZoneKind;
+use nexus_types::deployment::BlueprintHostPhase2DesiredContents;
 use nexus_types::deployment::PlanningInput;
 use nexus_types::deployment::SledFilter;
 use nexus_types::deployment::execution;
@@ -43,6 +44,7 @@ use nexus_types::external_api::views::SledProvisionPolicy;
 use omicron_common::address::REPO_DEPOT_PORT;
 use omicron_common::api::external::Name;
 use omicron_common::api::external::{Generation, TufRepoDescription};
+use omicron_common::disk::M2Slot;
 use omicron_common::policy::NEXUS_REDUNDANCY;
 use omicron_common::update::OmicronZoneManifestSource;
 use omicron_repl_utils::run_repl_from_file;
@@ -573,6 +575,16 @@ enum BlueprintEditCommands {
         #[command(subcommand)]
         image_source: ImageSourceArgs,
     },
+    /// set the desired host phase 2 image for an internal disk slot
+    SetHostPhase2 {
+        /// sled to set the field on
+        sled_id: SledOpt,
+        /// internal disk slot
+        #[clap(value_parser = parse_m2_slot)]
+        slot: M2Slot,
+        #[command(subcommand)]
+        phase_2_source: HostPhase2SourceArgs,
+    },
     /// set the remove_mupdate_override field for a sled
     SetRemoveMupdateOverride {
         /// sled to set the field on
@@ -914,6 +926,29 @@ impl From<ImageSourceArgs> for BlueprintZoneImageSource {
     }
 }
 
+#[derive(Debug, Subcommand)]
+enum HostPhase2SourceArgs {
+    /// keep the current phase 2 contents
+    CurrentContents,
+    /// the host phase 2 comes from a specific TUF repo artifact
+    Artifact {
+        #[clap(value_parser = parse_blueprint_artifact_version)]
+        version: BlueprintArtifactVersion,
+        hash: ArtifactHash,
+    },
+}
+
+impl From<HostPhase2SourceArgs> for BlueprintHostPhase2DesiredContents {
+    fn from(value: HostPhase2SourceArgs) -> Self {
+        match value {
+            HostPhase2SourceArgs::CurrentContents => Self::CurrentContents,
+            HostPhase2SourceArgs::Artifact { version, hash } => {
+                Self::Artifact { version, hash }
+            }
+        }
+    }
+}
+
 fn parse_blueprint_artifact_version(
     version: &str,
 ) -> Result<BlueprintArtifactVersion, ArtifactVersionError> {
@@ -925,6 +960,14 @@ fn parse_blueprint_artifact_version(
     Ok(BlueprintArtifactVersion::Available {
         version: version.parse::<ArtifactVersion>()?,
     })
+}
+
+fn parse_m2_slot(slot: &str) -> anyhow::Result<M2Slot> {
+    match slot {
+        "a" | "A" | "0" => Ok(M2Slot::A),
+        "b" | "B" | "1" => Ok(M2Slot::B),
+        _ => bail!("invalid slot `{slot}` (expected `a` or `b`)"),
+    }
 }
 
 #[derive(Debug, Args)]
@@ -1635,6 +1678,24 @@ fn cmd_blueprint_edit(
             builder
                 .sled_set_zone_source(sled_id, zone_id, source)
                 .context("failed to set image source")?;
+            rv
+        }
+        BlueprintEditCommands::SetHostPhase2 {
+            sled_id,
+            slot,
+            phase_2_source,
+        } => {
+            let sled_id = sled_id.to_sled_id(system.description())?;
+            let source =
+                BlueprintHostPhase2DesiredContents::from(phase_2_source);
+            let rv = format!(
+                "set sled {sled_id} host phase 2 slot {slot:?} source to \
+                 {source}\n\
+                 warn: no validation is done on the requested source"
+            );
+            builder
+                .sled_set_host_phase_2_slot(sled_id, slot, source)
+                .context("failed to set host phase 2 source")?;
             rv
         }
         BlueprintEditCommands::ExpungeZone { zone_id } => {

--- a/dev-tools/reconfigurator-cli/src/lib.rs
+++ b/dev-tools/reconfigurator-cli/src/lib.rs
@@ -964,9 +964,9 @@ fn parse_blueprint_artifact_version(
 
 fn parse_m2_slot(slot: &str) -> anyhow::Result<M2Slot> {
     match slot {
-        "a" | "A" | "0" => Ok(M2Slot::A),
-        "b" | "B" | "1" => Ok(M2Slot::B),
-        _ => bail!("invalid slot `{slot}` (expected `a` or `b`)"),
+        "A" | "a" | "0" => Ok(M2Slot::A),
+        "B" | "b" | "1" => Ok(M2Slot::B),
+        _ => bail!("invalid slot `{slot}` (expected `A` or `B`)"),
     }
 }
 

--- a/dev-tools/reconfigurator-cli/tests/input/cmds-host-phase-2-source.txt
+++ b/dev-tools/reconfigurator-cli/tests/input/cmds-host-phase-2-source.txt
@@ -10,9 +10,13 @@ blueprint-diff latest
 blueprint-edit latest set-host-phase2 serial0 B artifact 2.0.0 044d45ad681b44e89c10e056cabdedf19fd8b1e54bc95e6622bcdd23f16bc8f2
 blueprint-diff latest
 
-# Restore both to "current contents"
+blueprint-show latest
+
+# Restore A to "current contents"
 blueprint-edit latest set-host-phase2 serial0 A current-contents
 blueprint-diff latest
+
+# Restore B to "current contents"
 blueprint-edit latest set-host-phase2 serial0 B current-contents
 blueprint-diff latest
 

--- a/dev-tools/reconfigurator-cli/tests/input/cmds-host-phase-2-source.txt
+++ b/dev-tools/reconfigurator-cli/tests/input/cmds-host-phase-2-source.txt
@@ -1,0 +1,19 @@
+# Load example system
+
+load-example --nsleds 1
+
+# Set slot A
+blueprint-edit latest set-host-phase2 serial0 A artifact 1.0.0 3a9607047b03ccaab6d222249d890e93ca51b94ad631c7ca38be74cba60802ff
+blueprint-diff latest
+
+# Set slot B
+blueprint-edit latest set-host-phase2 serial0 B artifact 2.0.0 044d45ad681b44e89c10e056cabdedf19fd8b1e54bc95e6622bcdd23f16bc8f2
+blueprint-diff latest
+
+# Restore both to "current contents"
+blueprint-edit latest set-host-phase2 serial0 A current-contents
+blueprint-diff latest
+blueprint-edit latest set-host-phase2 serial0 B current-contents
+blueprint-diff latest
+
+blueprint-show latest

--- a/dev-tools/reconfigurator-cli/tests/output/cmds-add-sled-no-disks-stdout
+++ b/dev-tools/reconfigurator-cli/tests/output/cmds-add-sled-no-disks-stdout
@@ -59,6 +59,14 @@ parent:    dbcbd3d6-41ff-48ae-ac0b-1becc9b2fd21
 
   sled: 00320471-945d-413c-85e7-03e091a70b3c (active, config generation 1)
 
+    host phase 2 contents:
+    ------------------------
+    slot   boot image source
+    ------------------------
+    A      current contents 
+    B      current contents 
+
+
     physical disks:
     -------------------------------------
     vendor   model   serial   disposition
@@ -79,6 +87,14 @@ parent:    dbcbd3d6-41ff-48ae-ac0b-1becc9b2fd21
 
 
   sled: 2b8f0cb3-0295-4b3c-bc58-4fe88b57112c (active, config generation 2)
+
+    host phase 2 contents:
+    ------------------------
+    slot   boot image source
+    ------------------------
+    A      current contents 
+    B      current contents 
+
 
     physical disks:
     ------------------------------------------------------------------------------------
@@ -134,6 +150,14 @@ parent:    dbcbd3d6-41ff-48ae-ac0b-1becc9b2fd21
 
   sled: 98e6b7c2-2efa-41ca-b20a-0a4d61102fe6 (active, config generation 2)
 
+    host phase 2 contents:
+    ------------------------
+    slot   boot image source
+    ------------------------
+    A      current contents 
+    B      current contents 
+
+
     physical disks:
     ------------------------------------------------------------------------------------
     vendor        model        serial                                        disposition
@@ -184,6 +208,14 @@ parent:    dbcbd3d6-41ff-48ae-ac0b-1becc9b2fd21
 
 
   sled: d81c6a84-79b8-4958-ae41-ea46c9b19763 (active, config generation 2)
+
+    host phase 2 contents:
+    ------------------------
+    slot   boot image source
+    ------------------------
+    A      current contents 
+    B      current contents 
+
 
     physical disks:
     ------------------------------------------------------------------------------------

--- a/dev-tools/reconfigurator-cli/tests/output/cmds-example-stdout
+++ b/dev-tools/reconfigurator-cli/tests/output/cmds-example-stdout
@@ -71,6 +71,14 @@ parent:    02697f74-b14a-4418-90f0-c28b2a3a6aa9
 
   sled: 2eb69596-f081-4e2d-9425-9994926e0832 (active, config generation 2)
 
+    host phase 2 contents:
+    ------------------------
+    slot   boot image source
+    ------------------------
+    A      current contents 
+    B      current contents 
+
+
     physical disks:
     ------------------------------------------------------------------------------------
     vendor        model        serial                                        disposition
@@ -167,6 +175,14 @@ parent:    02697f74-b14a-4418-90f0-c28b2a3a6aa9
 
   sled: 32d8d836-4d8a-4e54-8fa9-f31d79c42646 (active, config generation 2)
 
+    host phase 2 contents:
+    ------------------------
+    slot   boot image source
+    ------------------------
+    A      current contents 
+    B      current contents 
+
+
     physical disks:
     ------------------------------------------------------------------------------------
     vendor        model        serial                                        disposition
@@ -259,6 +275,14 @@ parent:    02697f74-b14a-4418-90f0-c28b2a3a6aa9
 
 
   sled: 89d02b1b-478c-401a-8e28-7a26f74fa41b (active, config generation 2)
+
+    host phase 2 contents:
+    ------------------------
+    slot   boot image source
+    ------------------------
+    A      current contents 
+    B      current contents 
+
 
     physical disks:
     ------------------------------------------------------------------------------------
@@ -420,6 +444,14 @@ parent:    02697f74-b14a-4418-90f0-c28b2a3a6aa9
 
   sled: 89d02b1b-478c-401a-8e28-7a26f74fa41b (active, config generation 2)
 
+    host phase 2 contents:
+    ------------------------
+    slot   boot image source
+    ------------------------
+    A      current contents 
+    B      current contents 
+
+
     physical disks:
     ------------------------------------------------------------------------------------
     vendor        model        serial                                        disposition
@@ -530,6 +562,14 @@ to:   blueprint 86db3308-f817-4626-8838-4085949a6a41
 
   sled 89d02b1b-478c-401a-8e28-7a26f74fa41b (active, config generation 2 -> 3):
 
+    host phase 2 contents:
+    ------------------------
+    slot   boot image source
+    ------------------------
+    A      current contents 
+    B      current contents 
+
+
     physical disks:
     ------------------------------------------------------------------------------------
     vendor        model        serial                                        disposition
@@ -602,6 +642,14 @@ to:   blueprint 86db3308-f817-4626-8838-4085949a6a41
 
   sled 89d02b1b-478c-401a-8e28-7a26f74fa41b (active, config generation 1 -> 3):
 
+    host phase 2 contents:
+    ------------------------
+    slot   boot image source
+    ------------------------
+    A      current contents 
+    B      current contents 
+
+
     physical disks:
     ------------------------------------------------------------------------------------
     vendor        model        serial                                        disposition
@@ -673,6 +721,14 @@ to:   blueprint 02697f74-b14a-4418-90f0-c28b2a3a6aa9
  MODIFIED SLEDS:
 
   sled 89d02b1b-478c-401a-8e28-7a26f74fa41b (active, config generation 3 -> 1):
+
+    host phase 2 contents:
+    ------------------------
+    slot   boot image source
+    ------------------------
+    A      current contents 
+    B      current contents 
+
 
     physical disks:
     ------------------------------------------------------------------------------------
@@ -761,6 +817,14 @@ parent:    02697f74-b14a-4418-90f0-c28b2a3a6aa9
 
   sled: 2eb69596-f081-4e2d-9425-9994926e0832 (active, config generation 2)
 
+    host phase 2 contents:
+    ------------------------
+    slot   boot image source
+    ------------------------
+    A      current contents 
+    B      current contents 
+
+
     physical disks:
     ------------------------------------------------------------------------------------
     vendor        model        serial                                        disposition
@@ -802,6 +866,14 @@ parent:    02697f74-b14a-4418-90f0-c28b2a3a6aa9
 
   sled: 32d8d836-4d8a-4e54-8fa9-f31d79c42646 (active, config generation 2)
 
+    host phase 2 contents:
+    ------------------------
+    slot   boot image source
+    ------------------------
+    A      current contents 
+    B      current contents 
+
+
     physical disks:
     ------------------------------------------------------------------------------------
     vendor        model        serial                                        disposition
@@ -842,6 +914,14 @@ parent:    02697f74-b14a-4418-90f0-c28b2a3a6aa9
 
 
   sled: 89d02b1b-478c-401a-8e28-7a26f74fa41b (active, config generation 2)
+
+    host phase 2 contents:
+    ------------------------
+    slot   boot image source
+    ------------------------
+    A      current contents 
+    B      current contents 
+
 
     physical disks:
     ------------------------------------------------------------------------------------
@@ -960,6 +1040,14 @@ to:   blueprint 86db3308-f817-4626-8838-4085949a6a41
  MODIFIED SLEDS:
 
   sled 32d8d836-4d8a-4e54-8fa9-f31d79c42646 (active -> decommissioned, config generation 2 -> 3):
+
+    host phase 2 contents:
+    ------------------------
+    slot   boot image source
+    ------------------------
+    A      current contents 
+    B      current contents 
+
 
     physical disks:
     ---------------------------------------------------------------------------------------

--- a/dev-tools/reconfigurator-cli/tests/output/cmds-expunge-newly-added-external-dns-stdout
+++ b/dev-tools/reconfigurator-cli/tests/output/cmds-expunge-newly-added-external-dns-stdout
@@ -13,6 +13,14 @@ parent:    06c88262-f435-410e-ba98-101bed41ec27
 
   sled: 711ac7f8-d19e-4572-bdb9-e9b50f6e362a (active, config generation 2)
 
+    host phase 2 contents:
+    ------------------------
+    slot   boot image source
+    ------------------------
+    A      current contents 
+    B      current contents 
+
+
     physical disks:
     ------------------------------------------------------------------------------------
     vendor        model        serial                                        disposition
@@ -109,6 +117,14 @@ parent:    06c88262-f435-410e-ba98-101bed41ec27
 
   sled: 9dc50690-f9bf-4520-bf80-051d0f465c2c (active, config generation 2)
 
+    host phase 2 contents:
+    ------------------------
+    slot   boot image source
+    ------------------------
+    A      current contents 
+    B      current contents 
+
+
     physical disks:
     ------------------------------------------------------------------------------------
     vendor        model        serial                                        disposition
@@ -201,6 +217,14 @@ parent:    06c88262-f435-410e-ba98-101bed41ec27
 
 
   sled: a88790de-5962-4871-8686-61c1fd5b7094 (active, config generation 2)
+
+    host phase 2 contents:
+    ------------------------
+    slot   boot image source
+    ------------------------
+    A      current contents 
+    B      current contents 
+
 
     physical disks:
     ------------------------------------------------------------------------------------
@@ -323,6 +347,14 @@ to:   blueprint 366b0b68-d80e-4bc1-abd3-dc69837847e0
  MODIFIED SLEDS:
 
   sled 711ac7f8-d19e-4572-bdb9-e9b50f6e362a (active, config generation 2 -> 3):
+
+    host phase 2 contents:
+    ------------------------
+    slot   boot image source
+    ------------------------
+    A      current contents 
+    B      current contents 
+
 
     physical disks:
     ------------------------------------------------------------------------------------
@@ -669,6 +701,14 @@ parent:    3f00b694-1b16-4aaa-8f78-e6b3a527b434
 
   sled: 711ac7f8-d19e-4572-bdb9-e9b50f6e362a (active, config generation 3)
 
+    host phase 2 contents:
+    ------------------------
+    slot   boot image source
+    ------------------------
+    A      current contents 
+    B      current contents 
+
+
     physical disks:
     ------------------------------------------------------------------------------------
     vendor        model        serial                                        disposition
@@ -765,6 +805,14 @@ parent:    3f00b694-1b16-4aaa-8f78-e6b3a527b434
 
   sled: 9dc50690-f9bf-4520-bf80-051d0f465c2c (active, config generation 2)
 
+    host phase 2 contents:
+    ------------------------
+    slot   boot image source
+    ------------------------
+    A      current contents 
+    B      current contents 
+
+
     physical disks:
     ------------------------------------------------------------------------------------
     vendor        model        serial                                        disposition
@@ -857,6 +905,14 @@ parent:    3f00b694-1b16-4aaa-8f78-e6b3a527b434
 
 
   sled: a88790de-5962-4871-8686-61c1fd5b7094 (active, config generation 2)
+
+    host phase 2 contents:
+    ------------------------
+    slot   boot image source
+    ------------------------
+    A      current contents 
+    B      current contents 
+
 
     physical disks:
     ------------------------------------------------------------------------------------
@@ -992,6 +1048,14 @@ to:   blueprint 9c998c1d-1a7b-440a-ae0c-40f781dea6e2
  MODIFIED SLEDS:
 
   sled 711ac7f8-d19e-4572-bdb9-e9b50f6e362a (active, config generation 3 -> 4):
+
+    host phase 2 contents:
+    ------------------------
+    slot   boot image source
+    ------------------------
+    A      current contents 
+    B      current contents 
+
 
     physical disks:
     ------------------------------------------------------------------------------------
@@ -1338,6 +1402,14 @@ parent:    366b0b68-d80e-4bc1-abd3-dc69837847e0
 
   sled: 711ac7f8-d19e-4572-bdb9-e9b50f6e362a (active, config generation 4)
 
+    host phase 2 contents:
+    ------------------------
+    slot   boot image source
+    ------------------------
+    A      current contents 
+    B      current contents 
+
+
     physical disks:
     ------------------------------------------------------------------------------------
     vendor        model        serial                                        disposition
@@ -1437,6 +1509,14 @@ parent:    366b0b68-d80e-4bc1-abd3-dc69837847e0
 
   sled: 9dc50690-f9bf-4520-bf80-051d0f465c2c (active, config generation 2)
 
+    host phase 2 contents:
+    ------------------------
+    slot   boot image source
+    ------------------------
+    A      current contents 
+    B      current contents 
+
+
     physical disks:
     ------------------------------------------------------------------------------------
     vendor        model        serial                                        disposition
@@ -1529,6 +1609,14 @@ parent:    366b0b68-d80e-4bc1-abd3-dc69837847e0
 
 
   sled: a88790de-5962-4871-8686-61c1fd5b7094 (active, config generation 2)
+
+    host phase 2 contents:
+    ------------------------
+    slot   boot image source
+    ------------------------
+    A      current contents 
+    B      current contents 
+
 
     physical disks:
     ------------------------------------------------------------------------------------
@@ -1650,6 +1738,14 @@ to:   blueprint 2ac8c740-444d-42ff-8d66-9812a7e51288
  MODIFIED SLEDS:
 
   sled 9dc50690-f9bf-4520-bf80-051d0f465c2c (active, config generation 2 -> 3):
+
+    host phase 2 contents:
+    ------------------------
+    slot   boot image source
+    ------------------------
+    A      current contents 
+    B      current contents 
+
 
     physical disks:
     ------------------------------------------------------------------------------------

--- a/dev-tools/reconfigurator-cli/tests/output/cmds-expunge-newly-added-internal-dns-stdout
+++ b/dev-tools/reconfigurator-cli/tests/output/cmds-expunge-newly-added-internal-dns-stdout
@@ -11,6 +11,14 @@ parent:    184f10b3-61cb-41ef-9b93-3489b2bac559
 
   sled: 2b8f0cb3-0295-4b3c-bc58-4fe88b57112c (active, config generation 2)
 
+    host phase 2 contents:
+    ------------------------
+    slot   boot image source
+    ------------------------
+    A      current contents 
+    B      current contents 
+
+
     physical disks:
     ------------------------------------------------------------------------------------
     vendor        model        serial                                        disposition
@@ -107,6 +115,14 @@ parent:    184f10b3-61cb-41ef-9b93-3489b2bac559
 
   sled: 98e6b7c2-2efa-41ca-b20a-0a4d61102fe6 (active, config generation 2)
 
+    host phase 2 contents:
+    ------------------------
+    slot   boot image source
+    ------------------------
+    A      current contents 
+    B      current contents 
+
+
     physical disks:
     ------------------------------------------------------------------------------------
     vendor        model        serial                                        disposition
@@ -199,6 +215,14 @@ parent:    184f10b3-61cb-41ef-9b93-3489b2bac559
 
 
   sled: d81c6a84-79b8-4958-ae41-ea46c9b19763 (active, config generation 2)
+
+    host phase 2 contents:
+    ------------------------
+    slot   boot image source
+    ------------------------
+    A      current contents 
+    B      current contents 
+
 
     physical disks:
     ------------------------------------------------------------------------------------
@@ -321,6 +345,14 @@ to:   blueprint 8da82a8e-bf97-4fbd-8ddd-9f6462732cf1
  MODIFIED SLEDS:
 
   sled 2b8f0cb3-0295-4b3c-bc58-4fe88b57112c (active, config generation 2 -> 3):
+
+    host phase 2 contents:
+    ------------------------
+    slot   boot image source
+    ------------------------
+    A      current contents 
+    B      current contents 
+
 
     physical disks:
     ------------------------------------------------------------------------------------
@@ -675,6 +707,14 @@ to:   blueprint 58d5e830-0884-47d8-a7cd-b2b3751adeb4
 
   sled 2b8f0cb3-0295-4b3c-bc58-4fe88b57112c (active, config generation 3):
 
+    host phase 2 contents:
+    ------------------------
+    slot   boot image source
+    ------------------------
+    A      current contents 
+    B      current contents 
+
+
     physical disks:
     ------------------------------------------------------------------------------------
     vendor        model        serial                                        disposition
@@ -1025,6 +1065,14 @@ to:   blueprint af934083-59b5-4bf6-8966-6fb5292c29e1
  MODIFIED SLEDS:
 
   sled 2b8f0cb3-0295-4b3c-bc58-4fe88b57112c (active, config generation 3 -> 4):
+
+    host phase 2 contents:
+    ------------------------
+    slot   boot image source
+    ------------------------
+    A      current contents 
+    B      current contents 
+
 
     physical disks:
     ------------------------------------------------------------------------------------

--- a/dev-tools/reconfigurator-cli/tests/output/cmds-host-phase-2-source-stdout
+++ b/dev-tools/reconfigurator-cli/tests/output/cmds-host-phase-2-source-stdout
@@ -1,0 +1,1273 @@
+using provided RNG seed: reconfigurator-cli-test
+> # Load example system
+
+> load-example --nsleds 1
+loaded example system with:
+- collection: f45ba181-4b56-42cc-a762-874d90184a43
+- blueprint: dbcbd3d6-41ff-48ae-ac0b-1becc9b2fd21
+
+
+> # Set slot A
+> blueprint-edit latest set-host-phase2 serial0 A artifact 1.0.0 3a9607047b03ccaab6d222249d890e93ca51b94ad631c7ca38be74cba60802ff
+blueprint 8da82a8e-bf97-4fbd-8ddd-9f6462732cf1 created from latest blueprint (dbcbd3d6-41ff-48ae-ac0b-1becc9b2fd21): set sled 98e6b7c2-2efa-41ca-b20a-0a4d61102fe6 host phase 2 slot A source to artifact: version 1.0.0
+warn: no validation is done on the requested source
+
+> blueprint-diff latest
+from: blueprint dbcbd3d6-41ff-48ae-ac0b-1becc9b2fd21
+to:   blueprint 8da82a8e-bf97-4fbd-8ddd-9f6462732cf1
+
+ MODIFIED SLEDS:
+
+  sled 98e6b7c2-2efa-41ca-b20a-0a4d61102fe6 (active, config generation 2 -> 3):
+
+    host phase 2 contents:
+    --------------------------------
+    slot   boot image source        
+    --------------------------------
+*   A      - current contents       
+     └─    + artifact: version 1.0.0
+    B      current contents         
+
+
+    physical disks:
+    ------------------------------------------------------------------------------------
+    vendor        model        serial                                        disposition
+    ------------------------------------------------------------------------------------
+    fake-vendor   fake-model   serial-073979dd-3248-44a5-9fa1-cc72a140d682   in service 
+    fake-vendor   fake-model   serial-3efc84af-8a54-4006-8323-4a752e91c049   in service 
+    fake-vendor   fake-model   serial-5f86efdc-a0cf-404c-88af-c878ae6dfdf4   in service 
+    fake-vendor   fake-model   serial-981c69c9-f4f5-4423-bbbc-4578282d53e2   in service 
+    fake-vendor   fake-model   serial-c6d33b64-fb96-4129-bab1-7878a06a5f9b   in service 
+    fake-vendor   fake-model   serial-d8305049-7ee6-4895-a2cb-f63868dae12d   in service 
+    fake-vendor   fake-model   serial-e36f7294-8191-4d79-a791-44f2ec37a5ca   in service 
+    fake-vendor   fake-model   serial-e4d937e1-6ddc-4eca-bb08-c1f73791e608   in service 
+    fake-vendor   fake-model   serial-f09e1f43-f474-423e-8884-c8fa31cf6b60   in service 
+    fake-vendor   fake-model   serial-f355a206-1299-4ef3-9f8f-1a47459160dc   in service 
+
+
+    datasets:
+    -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
+    dataset name                                                                                                   dataset id                             disposition   quota     reservation   compression
+    -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
+    oxp_073979dd-3248-44a5-9fa1-cc72a140d682/crucible                                                              fb2b6175-e812-4a1a-b50e-55a8870c4a38   in service    none      none          off        
+    oxp_3efc84af-8a54-4006-8323-4a752e91c049/crucible                                                              9b70a45a-5901-4bd5-a821-b06ba5a25b39   in service    none      none          off        
+    oxp_5f86efdc-a0cf-404c-88af-c878ae6dfdf4/crucible                                                              9e38b1ba-354d-4528-b61b-3db3ac4814e6   in service    none      none          off        
+    oxp_981c69c9-f4f5-4423-bbbc-4578282d53e2/crucible                                                              d5611d9e-3bdd-435e-972f-1fb618a4b8ae   in service    none      none          off        
+    oxp_c6d33b64-fb96-4129-bab1-7878a06a5f9b/crucible                                                              45b9d4b3-aca7-4b88-9165-2b94e4b6bbbd   in service    none      none          off        
+    oxp_d8305049-7ee6-4895-a2cb-f63868dae12d/crucible                                                              d4ddb5dd-affa-4f78-97fb-4a6579277fa1   in service    none      none          off        
+    oxp_e36f7294-8191-4d79-a791-44f2ec37a5ca/crucible                                                              9d33acef-e0f7-4e6c-bcaf-fc2eb79d4c26   in service    none      none          off        
+    oxp_e4d937e1-6ddc-4eca-bb08-c1f73791e608/crucible                                                              f1ef5a95-f2cf-4ec7-90d6-25b628fbe019   in service    none      none          off        
+    oxp_f09e1f43-f474-423e-8884-c8fa31cf6b60/crucible                                                              29b2c25e-dce4-4195-8c8f-82368fdddff0   in service    none      none          off        
+    oxp_f355a206-1299-4ef3-9f8f-1a47459160dc/crucible                                                              b206319c-0e91-456d-aa4f-e1632794e1bb   in service    none      none          off        
+    oxp_073979dd-3248-44a5-9fa1-cc72a140d682/crypt/clickhouse                                                      d3cd3ec4-703f-4e73-8cc2-b4bc19c7d596   in service    none      none          off        
+    oxp_073979dd-3248-44a5-9fa1-cc72a140d682/crypt/external_dns                                                    f3ddb3ca-388d-4462-9fc8-e552cf7de668   in service    none      none          off        
+    oxp_3efc84af-8a54-4006-8323-4a752e91c049/crypt/external_dns                                                    dd1954a2-7848-4950-a694-38870c339d3e   in service    none      none          off        
+    oxp_5f86efdc-a0cf-404c-88af-c878ae6dfdf4/crypt/external_dns                                                    32bb65ae-855f-461b-9203-32b2ddfe5a64   in service    none      none          off        
+    oxp_073979dd-3248-44a5-9fa1-cc72a140d682/crypt/internal_dns                                                    c7e90d9c-22db-43ca-a602-2a295bac7eec   in service    none      none          off        
+    oxp_3efc84af-8a54-4006-8323-4a752e91c049/crypt/internal_dns                                                    bef875a9-3cf1-4b02-9682-c0286fb23d4d   in service    none      none          off        
+    oxp_5f86efdc-a0cf-404c-88af-c878ae6dfdf4/crypt/internal_dns                                                    f822a7e2-28aa-4ae2-ba86-d4e552a15bcb   in service    none      none          off        
+    oxp_073979dd-3248-44a5-9fa1-cc72a140d682/crypt/zone                                                            e4b83186-c6e2-4d33-ae1b-803c32d1a86e   in service    none      none          off        
+    oxp_3efc84af-8a54-4006-8323-4a752e91c049/crypt/zone                                                            f306ebde-464c-49ef-94eb-1d72cf9afc7e   in service    none      none          off        
+    oxp_5f86efdc-a0cf-404c-88af-c878ae6dfdf4/crypt/zone                                                            20cb5d98-bcd7-4a11-9190-7570a0aa6fe0   in service    none      none          off        
+    oxp_981c69c9-f4f5-4423-bbbc-4578282d53e2/crypt/zone                                                            2aeeb036-0e23-419f-82f7-9ab04c06d7ec   in service    none      none          off        
+    oxp_c6d33b64-fb96-4129-bab1-7878a06a5f9b/crypt/zone                                                            aa860565-2bbb-4a70-ae8e-7d8f29f1a536   in service    none      none          off        
+    oxp_d8305049-7ee6-4895-a2cb-f63868dae12d/crypt/zone                                                            53e5b466-aac5-4cf0-a93b-9f68f58ac755   in service    none      none          off        
+    oxp_e36f7294-8191-4d79-a791-44f2ec37a5ca/crypt/zone                                                            ac802759-2ac3-4c5c-b8e7-6d51689e1537   in service    none      none          off        
+    oxp_e4d937e1-6ddc-4eca-bb08-c1f73791e608/crypt/zone                                                            6b672182-6d17-41d5-81d7-19debe7d3f9b   in service    none      none          off        
+    oxp_f09e1f43-f474-423e-8884-c8fa31cf6b60/crypt/zone                                                            b1007e3d-7aaf-4ccb-9773-241dcbf79b21   in service    none      none          off        
+    oxp_f355a206-1299-4ef3-9f8f-1a47459160dc/crypt/zone                                                            66788e15-bb3a-4369-a5cb-3357f7b85f64   in service    none      none          off        
+    oxp_073979dd-3248-44a5-9fa1-cc72a140d682/crypt/zone/oxz_clickhouse_10676bfe-b61f-40e1-bc07-a4cb76ea1f30        49dc7c86-c865-457f-8d58-37b92b002691   in service    none      none          off        
+    oxp_f09e1f43-f474-423e-8884-c8fa31cf6b60/crypt/zone/oxz_crucible_2470c0fb-7af3-4b6b-8db3-424e4c297bd9          9fd6854b-5144-4d4a-b575-5e22050b04d6   in service    none      none          off        
+    oxp_981c69c9-f4f5-4423-bbbc-4578282d53e2/crypt/zone/oxz_crucible_289a6d4b-ddfe-4101-9715-6693398704f2          c0399553-58e7-4e51-a7b3-556211309dc5   in service    none      none          off        
+    oxp_e4d937e1-6ddc-4eca-bb08-c1f73791e608/crypt/zone/oxz_crucible_2a063d42-9caf-4364-b099-c7c302c87cdd          f01f9303-448a-4050-9841-f6681f05ae0f   in service    none      none          off        
+    oxp_e36f7294-8191-4d79-a791-44f2ec37a5ca/crypt/zone/oxz_crucible_2dcb07a4-b9cc-4ae6-9119-ccd241acbf3a          a5c85a9b-8fe8-4ad6-9bae-fbb04ff13807   in service    none      none          off        
+    oxp_5f86efdc-a0cf-404c-88af-c878ae6dfdf4/crypt/zone/oxz_crucible_3d9b7487-d7b9-4e25-960f-f2086f3e2919          7176fd89-69a6-401b-8b4b-d80163d522fd   in service    none      none          off        
+    oxp_3efc84af-8a54-4006-8323-4a752e91c049/crypt/zone/oxz_crucible_4b19d194-8b25-4396-88da-3df1b3788601          4c8935c4-1f31-41c6-97a0-1c64d9748e91   in service    none      none          off        
+    oxp_f355a206-1299-4ef3-9f8f-1a47459160dc/crypt/zone/oxz_crucible_bbae1838-0a4c-4489-b141-5aff19c2f277          1abeb2b2-f387-4c31-8c8e-55786ce40fe2   in service    none      none          off        
+    oxp_073979dd-3248-44a5-9fa1-cc72a140d682/crypt/zone/oxz_crucible_c204730a-0946-4793-a470-64c88e89da96          b6afb646-131e-4778-8d80-27f059ba01c2   in service    none      none          off        
+    oxp_d8305049-7ee6-4895-a2cb-f63868dae12d/crypt/zone/oxz_crucible_e0075607-793a-4348-a808-84a9dbe3e841          27caffd0-464c-47b8-8b3c-adc62a76529f   in service    none      none          off        
+    oxp_c6d33b64-fb96-4129-bab1-7878a06a5f9b/crypt/zone/oxz_crucible_edce5918-6d13-4cde-9d64-54e00f4c09e6          5019131f-9456-4c96-b53a-08dfce9bf8ee   in service    none      none          off        
+    oxp_5f86efdc-a0cf-404c-88af-c878ae6dfdf4/crypt/zone/oxz_crucible_pantry_2de1c525-4e04-4ba6-ac6b-377aaa542f96   08662183-4261-47b3-a2e0-e12229f378b7   in service    none      none          off        
+    oxp_073979dd-3248-44a5-9fa1-cc72a140d682/crypt/zone/oxz_crucible_pantry_31b26053-8b94-4d8c-9e4a-d7d720afe265   6dd64de1-7dd3-492c-830f-d4a4e4c3dda7   in service    none      none          off        
+    oxp_3efc84af-8a54-4006-8323-4a752e91c049/crypt/zone/oxz_crucible_pantry_f87ada51-4419-4144-86a8-e5e4ff0f64d3   056f6da7-b92d-4231-b0df-0e8a2c9bce42   in service    none      none          off        
+    oxp_3efc84af-8a54-4006-8323-4a752e91c049/crypt/zone/oxz_external_dns_005548be-c5e4-49ff-a27b-88f314f1bc51      42bd3fb3-2aae-4754-9c41-0f9b50a77322   in service    none      none          off        
+    oxp_5f86efdc-a0cf-404c-88af-c878ae6dfdf4/crypt/zone/oxz_external_dns_2205353a-e1d2-48ff-863b-9d6b1487d474      b7813bc0-d5ee-487d-95ad-6c5cce6fdcd6   in service    none      none          off        
+    oxp_073979dd-3248-44a5-9fa1-cc72a140d682/crypt/zone/oxz_external_dns_70aab480-3d6c-47d5-aaf9-8d2ddab2931c      c6d7ecb4-135c-4f09-8948-b73fec13db76   in service    none      none          off        
+    oxp_3efc84af-8a54-4006-8323-4a752e91c049/crypt/zone/oxz_internal_dns_3fd06852-06cb-4d8a-b4b2-eb88ff5a6035      8355e747-b375-4d9e-b5da-03d9540ab5cd   in service    none      none          off        
+    oxp_073979dd-3248-44a5-9fa1-cc72a140d682/crypt/zone/oxz_internal_dns_45ce130e-c5ac-4e26-ab73-7589ba634418      0c7e4b2a-502a-4f4c-8ac4-4068db25252e   in service    none      none          off        
+    oxp_5f86efdc-a0cf-404c-88af-c878ae6dfdf4/crypt/zone/oxz_internal_dns_a7b7bfbe-0588-4781-9a5e-fba63584e5d2      d4f66eab-2870-4a74-b4d5-ae5da3276682   in service    none      none          off        
+    oxp_5f86efdc-a0cf-404c-88af-c878ae6dfdf4/crypt/zone/oxz_nexus_2bc0b0c4-63a9-44cc-afff-76ce645ef1d4             ebfd425c-4e5d-4385-a105-8f2ce32fa9ec   in service    none      none          off        
+    oxp_3efc84af-8a54-4006-8323-4a752e91c049/crypt/zone/oxz_nexus_3c2cd97f-7b4a-4ff3-a9d5-6ce141fcdbbe             382cbbf2-8b08-4388-839a-b43b8bc82999   in service    none      none          off        
+    oxp_073979dd-3248-44a5-9fa1-cc72a140d682/crypt/zone/oxz_nexus_c2cbbf34-b852-4164-a572-01d4d79445a1             d88eb02f-b66d-4ae7-91a1-23154417c1f1   in service    none      none          off        
+    oxp_073979dd-3248-44a5-9fa1-cc72a140d682/crypt/zone/oxz_ntp_9b135c74-c09a-4dcc-ba19-f6f8deae135a               506ddf0e-8cbf-44a9-93d7-130a550fd42d   in service    none      none          off        
+    oxp_073979dd-3248-44a5-9fa1-cc72a140d682/crypt/debug                                                           38fafd69-0275-4f4d-885d-3bbf2ea77551   in service    100 GiB   none          gzip-9     
+    oxp_3efc84af-8a54-4006-8323-4a752e91c049/crypt/debug                                                           cb8d5371-640d-4364-8a5e-0fde125d28af   in service    100 GiB   none          gzip-9     
+    oxp_5f86efdc-a0cf-404c-88af-c878ae6dfdf4/crypt/debug                                                           ba445402-2775-4f97-87e9-640be3a00c6f   in service    100 GiB   none          gzip-9     
+    oxp_981c69c9-f4f5-4423-bbbc-4578282d53e2/crypt/debug                                                           f4ea4a15-b3b3-4a67-b61a-8fba7c7ab61f   in service    100 GiB   none          gzip-9     
+    oxp_c6d33b64-fb96-4129-bab1-7878a06a5f9b/crypt/debug                                                           4d322f8a-d461-4ead-995b-9ba7d76becad   in service    100 GiB   none          gzip-9     
+    oxp_d8305049-7ee6-4895-a2cb-f63868dae12d/crypt/debug                                                           647f344c-b4c5-4788-a732-40658e852f63   in service    100 GiB   none          gzip-9     
+    oxp_e36f7294-8191-4d79-a791-44f2ec37a5ca/crypt/debug                                                           8144f1ee-dbef-45c1-9397-2031a9ca8b38   in service    100 GiB   none          gzip-9     
+    oxp_e4d937e1-6ddc-4eca-bb08-c1f73791e608/crypt/debug                                                           8b89525f-0764-4937-9fa8-022242647c0f   in service    100 GiB   none          gzip-9     
+    oxp_f09e1f43-f474-423e-8884-c8fa31cf6b60/crypt/debug                                                           3523db58-10ab-4e2c-95d9-fec43036c0f5   in service    100 GiB   none          gzip-9     
+    oxp_f355a206-1299-4ef3-9f8f-1a47459160dc/crypt/debug                                                           d1611973-b22d-4097-b6fd-0a480f2199a5   in service    100 GiB   none          gzip-9     
+
+
+    omicron zones:
+    ---------------------------------------------------------------------------------------------------------------
+    zone type         zone id                                image source      disposition   underlay IP           
+    ---------------------------------------------------------------------------------------------------------------
+    clickhouse        10676bfe-b61f-40e1-bc07-a4cb76ea1f30   install dataset   in service    fd00:1122:3344:101::25
+    crucible          2470c0fb-7af3-4b6b-8db3-424e4c297bd9   install dataset   in service    fd00:1122:3344:101::34
+    crucible          289a6d4b-ddfe-4101-9715-6693398704f2   install dataset   in service    fd00:1122:3344:101::2f
+    crucible          2a063d42-9caf-4364-b099-c7c302c87cdd   install dataset   in service    fd00:1122:3344:101::33
+    crucible          2dcb07a4-b9cc-4ae6-9119-ccd241acbf3a   install dataset   in service    fd00:1122:3344:101::32
+    crucible          3d9b7487-d7b9-4e25-960f-f2086f3e2919   install dataset   in service    fd00:1122:3344:101::2e
+    crucible          4b19d194-8b25-4396-88da-3df1b3788601   install dataset   in service    fd00:1122:3344:101::2d
+    crucible          bbae1838-0a4c-4489-b141-5aff19c2f277   install dataset   in service    fd00:1122:3344:101::35
+    crucible          c204730a-0946-4793-a470-64c88e89da96   install dataset   in service    fd00:1122:3344:101::2c
+    crucible          e0075607-793a-4348-a808-84a9dbe3e841   install dataset   in service    fd00:1122:3344:101::31
+    crucible          edce5918-6d13-4cde-9d64-54e00f4c09e6   install dataset   in service    fd00:1122:3344:101::30
+    crucible_pantry   2de1c525-4e04-4ba6-ac6b-377aaa542f96   install dataset   in service    fd00:1122:3344:101::2b
+    crucible_pantry   31b26053-8b94-4d8c-9e4a-d7d720afe265   install dataset   in service    fd00:1122:3344:101::29
+    crucible_pantry   f87ada51-4419-4144-86a8-e5e4ff0f64d3   install dataset   in service    fd00:1122:3344:101::2a
+    external_dns      005548be-c5e4-49ff-a27b-88f314f1bc51   install dataset   in service    fd00:1122:3344:101::27
+    external_dns      2205353a-e1d2-48ff-863b-9d6b1487d474   install dataset   in service    fd00:1122:3344:101::28
+    external_dns      70aab480-3d6c-47d5-aaf9-8d2ddab2931c   install dataset   in service    fd00:1122:3344:101::26
+    internal_dns      3fd06852-06cb-4d8a-b4b2-eb88ff5a6035   install dataset   in service    fd00:1122:3344:2::1   
+    internal_dns      45ce130e-c5ac-4e26-ab73-7589ba634418   install dataset   in service    fd00:1122:3344:1::1   
+    internal_dns      a7b7bfbe-0588-4781-9a5e-fba63584e5d2   install dataset   in service    fd00:1122:3344:3::1   
+    internal_ntp      9b135c74-c09a-4dcc-ba19-f6f8deae135a   install dataset   in service    fd00:1122:3344:101::21
+    nexus             2bc0b0c4-63a9-44cc-afff-76ce645ef1d4   install dataset   in service    fd00:1122:3344:101::24
+    nexus             3c2cd97f-7b4a-4ff3-a9d5-6ce141fcdbbe   install dataset   in service    fd00:1122:3344:101::23
+    nexus             c2cbbf34-b852-4164-a572-01d4d79445a1   install dataset   in service    fd00:1122:3344:101::22
+
+
+ COCKROACHDB SETTINGS:
+    state fingerprint:::::::::::::::::   (none) (unchanged)
+    cluster.preserve_downgrade_option:   (do not modify) (unchanged)
+
+ METADATA:
+    internal DNS version:::   1 (unchanged)
+    external DNS version:::   1 (unchanged)
+    target release min gen:   1 (unchanged)
+
+ OXIMETER SETTINGS:
+    generation:   1 (unchanged)
+    read from::   SingleNode (unchanged)
+
+
+internal DNS:
+  DNS zone: "control-plane.oxide.internal" (unchanged)
+    name: 005548be-c5e4-49ff-a27b-88f314f1bc51.host          (records: 1)
+        AAAA fd00:1122:3344:101::27
+    name: 10676bfe-b61f-40e1-bc07-a4cb76ea1f30.host          (records: 1)
+        AAAA fd00:1122:3344:101::25
+    name: 2205353a-e1d2-48ff-863b-9d6b1487d474.host          (records: 1)
+        AAAA fd00:1122:3344:101::28
+    name: 2470c0fb-7af3-4b6b-8db3-424e4c297bd9.host          (records: 1)
+        AAAA fd00:1122:3344:101::34
+    name: 289a6d4b-ddfe-4101-9715-6693398704f2.host          (records: 1)
+        AAAA fd00:1122:3344:101::2f
+    name: 2a063d42-9caf-4364-b099-c7c302c87cdd.host          (records: 1)
+        AAAA fd00:1122:3344:101::33
+    name: 2bc0b0c4-63a9-44cc-afff-76ce645ef1d4.host          (records: 1)
+        AAAA fd00:1122:3344:101::24
+    name: 2dcb07a4-b9cc-4ae6-9119-ccd241acbf3a.host          (records: 1)
+        AAAA fd00:1122:3344:101::32
+    name: 2de1c525-4e04-4ba6-ac6b-377aaa542f96.host          (records: 1)
+        AAAA fd00:1122:3344:101::2b
+    name: 31b26053-8b94-4d8c-9e4a-d7d720afe265.host          (records: 1)
+        AAAA fd00:1122:3344:101::29
+    name: 3c2cd97f-7b4a-4ff3-a9d5-6ce141fcdbbe.host          (records: 1)
+        AAAA fd00:1122:3344:101::23
+    name: 3d9b7487-d7b9-4e25-960f-f2086f3e2919.host          (records: 1)
+        AAAA fd00:1122:3344:101::2e
+    name: 3fd06852-06cb-4d8a-b4b2-eb88ff5a6035.host          (records: 1)
+        AAAA fd00:1122:3344:2::1
+    name: 45ce130e-c5ac-4e26-ab73-7589ba634418.host          (records: 1)
+        AAAA fd00:1122:3344:1::1
+    name: 4b19d194-8b25-4396-88da-3df1b3788601.host          (records: 1)
+        AAAA fd00:1122:3344:101::2d
+    name: 70aab480-3d6c-47d5-aaf9-8d2ddab2931c.host          (records: 1)
+        AAAA fd00:1122:3344:101::26
+    name: 98e6b7c2-2efa-41ca-b20a-0a4d61102fe6.sled          (records: 1)
+        AAAA fd00:1122:3344:101::1
+    name: 9b135c74-c09a-4dcc-ba19-f6f8deae135a.host          (records: 1)
+        AAAA fd00:1122:3344:101::21
+    name: @                                                  (records: 3)
+        NS   ns1.control-plane.oxide.internal
+        NS   ns2.control-plane.oxide.internal
+        NS   ns3.control-plane.oxide.internal
+    name: _clickhouse-admin-single-server._tcp               (records: 1)
+        SRV  port  8888 10676bfe-b61f-40e1-bc07-a4cb76ea1f30.host.control-plane.oxide.internal
+    name: _clickhouse-native._tcp                            (records: 1)
+        SRV  port  9000 10676bfe-b61f-40e1-bc07-a4cb76ea1f30.host.control-plane.oxide.internal
+    name: _clickhouse._tcp                                   (records: 1)
+        SRV  port  8123 10676bfe-b61f-40e1-bc07-a4cb76ea1f30.host.control-plane.oxide.internal
+    name: _crucible-pantry._tcp                              (records: 3)
+        SRV  port 17000 2de1c525-4e04-4ba6-ac6b-377aaa542f96.host.control-plane.oxide.internal
+        SRV  port 17000 31b26053-8b94-4d8c-9e4a-d7d720afe265.host.control-plane.oxide.internal
+        SRV  port 17000 f87ada51-4419-4144-86a8-e5e4ff0f64d3.host.control-plane.oxide.internal
+    name: _crucible._tcp.2470c0fb-7af3-4b6b-8db3-424e4c297bd9 (records: 1)
+        SRV  port 32345 2470c0fb-7af3-4b6b-8db3-424e4c297bd9.host.control-plane.oxide.internal
+    name: _crucible._tcp.289a6d4b-ddfe-4101-9715-6693398704f2 (records: 1)
+        SRV  port 32345 289a6d4b-ddfe-4101-9715-6693398704f2.host.control-plane.oxide.internal
+    name: _crucible._tcp.2a063d42-9caf-4364-b099-c7c302c87cdd (records: 1)
+        SRV  port 32345 2a063d42-9caf-4364-b099-c7c302c87cdd.host.control-plane.oxide.internal
+    name: _crucible._tcp.2dcb07a4-b9cc-4ae6-9119-ccd241acbf3a (records: 1)
+        SRV  port 32345 2dcb07a4-b9cc-4ae6-9119-ccd241acbf3a.host.control-plane.oxide.internal
+    name: _crucible._tcp.3d9b7487-d7b9-4e25-960f-f2086f3e2919 (records: 1)
+        SRV  port 32345 3d9b7487-d7b9-4e25-960f-f2086f3e2919.host.control-plane.oxide.internal
+    name: _crucible._tcp.4b19d194-8b25-4396-88da-3df1b3788601 (records: 1)
+        SRV  port 32345 4b19d194-8b25-4396-88da-3df1b3788601.host.control-plane.oxide.internal
+    name: _crucible._tcp.bbae1838-0a4c-4489-b141-5aff19c2f277 (records: 1)
+        SRV  port 32345 bbae1838-0a4c-4489-b141-5aff19c2f277.host.control-plane.oxide.internal
+    name: _crucible._tcp.c204730a-0946-4793-a470-64c88e89da96 (records: 1)
+        SRV  port 32345 c204730a-0946-4793-a470-64c88e89da96.host.control-plane.oxide.internal
+    name: _crucible._tcp.e0075607-793a-4348-a808-84a9dbe3e841 (records: 1)
+        SRV  port 32345 e0075607-793a-4348-a808-84a9dbe3e841.host.control-plane.oxide.internal
+    name: _crucible._tcp.edce5918-6d13-4cde-9d64-54e00f4c09e6 (records: 1)
+        SRV  port 32345 edce5918-6d13-4cde-9d64-54e00f4c09e6.host.control-plane.oxide.internal
+    name: _external-dns._tcp                                 (records: 3)
+        SRV  port  5353 005548be-c5e4-49ff-a27b-88f314f1bc51.host.control-plane.oxide.internal
+        SRV  port  5353 2205353a-e1d2-48ff-863b-9d6b1487d474.host.control-plane.oxide.internal
+        SRV  port  5353 70aab480-3d6c-47d5-aaf9-8d2ddab2931c.host.control-plane.oxide.internal
+    name: _internal-ntp._tcp                                 (records: 1)
+        SRV  port   123 9b135c74-c09a-4dcc-ba19-f6f8deae135a.host.control-plane.oxide.internal
+    name: _nameservice._tcp                                  (records: 3)
+        SRV  port  5353 3fd06852-06cb-4d8a-b4b2-eb88ff5a6035.host.control-plane.oxide.internal
+        SRV  port  5353 45ce130e-c5ac-4e26-ab73-7589ba634418.host.control-plane.oxide.internal
+        SRV  port  5353 a7b7bfbe-0588-4781-9a5e-fba63584e5d2.host.control-plane.oxide.internal
+    name: _nexus._tcp                                        (records: 3)
+        SRV  port 12221 2bc0b0c4-63a9-44cc-afff-76ce645ef1d4.host.control-plane.oxide.internal
+        SRV  port 12221 3c2cd97f-7b4a-4ff3-a9d5-6ce141fcdbbe.host.control-plane.oxide.internal
+        SRV  port 12221 c2cbbf34-b852-4164-a572-01d4d79445a1.host.control-plane.oxide.internal
+    name: _oximeter-reader._tcp                              (records: 1)
+        SRV  port  9000 10676bfe-b61f-40e1-bc07-a4cb76ea1f30.host.control-plane.oxide.internal
+    name: _repo-depot._tcp                                   (records: 1)
+        SRV  port 12348 98e6b7c2-2efa-41ca-b20a-0a4d61102fe6.sled.control-plane.oxide.internal
+    name: a7b7bfbe-0588-4781-9a5e-fba63584e5d2.host          (records: 1)
+        AAAA fd00:1122:3344:3::1
+    name: bbae1838-0a4c-4489-b141-5aff19c2f277.host          (records: 1)
+        AAAA fd00:1122:3344:101::35
+    name: c204730a-0946-4793-a470-64c88e89da96.host          (records: 1)
+        AAAA fd00:1122:3344:101::2c
+    name: c2cbbf34-b852-4164-a572-01d4d79445a1.host          (records: 1)
+        AAAA fd00:1122:3344:101::22
+    name: e0075607-793a-4348-a808-84a9dbe3e841.host          (records: 1)
+        AAAA fd00:1122:3344:101::31
+    name: edce5918-6d13-4cde-9d64-54e00f4c09e6.host          (records: 1)
+        AAAA fd00:1122:3344:101::30
+    name: f87ada51-4419-4144-86a8-e5e4ff0f64d3.host          (records: 1)
+        AAAA fd00:1122:3344:101::2a
+    name: ns1                                                (records: 1)
+        AAAA fd00:1122:3344:1::1
+    name: ns2                                                (records: 1)
+        AAAA fd00:1122:3344:2::1
+    name: ns3                                                (records: 1)
+        AAAA fd00:1122:3344:3::1
+
+external DNS:
+  DNS zone: "oxide.example" (unchanged)
+    name: @                                                  (records: 3)
+        NS   ns1.oxide.example
+        NS   ns2.oxide.example
+        NS   ns3.oxide.example
+    name: example-silo.sys                                   (records: 3)
+        A    192.0.2.4
+        A    192.0.2.3
+        A    192.0.2.2
+    name: ns1                                                (records: 1)
+        A    198.51.100.1
+    name: ns2                                                (records: 1)
+        A    198.51.100.2
+    name: ns3                                                (records: 1)
+        A    198.51.100.3
+
+
+
+
+> # Set slot B
+> blueprint-edit latest set-host-phase2 serial0 B artifact 2.0.0 044d45ad681b44e89c10e056cabdedf19fd8b1e54bc95e6622bcdd23f16bc8f2
+blueprint 58d5e830-0884-47d8-a7cd-b2b3751adeb4 created from latest blueprint (8da82a8e-bf97-4fbd-8ddd-9f6462732cf1): set sled 98e6b7c2-2efa-41ca-b20a-0a4d61102fe6 host phase 2 slot B source to artifact: version 2.0.0
+warn: no validation is done on the requested source
+
+> blueprint-diff latest
+from: blueprint 8da82a8e-bf97-4fbd-8ddd-9f6462732cf1
+to:   blueprint 58d5e830-0884-47d8-a7cd-b2b3751adeb4
+
+ MODIFIED SLEDS:
+
+  sled 98e6b7c2-2efa-41ca-b20a-0a4d61102fe6 (active, config generation 3 -> 4):
+
+    host phase 2 contents:
+    --------------------------------
+    slot   boot image source        
+    --------------------------------
+    A      artifact: version 1.0.0  
+*   B      - current contents       
+     └─    + artifact: version 2.0.0
+
+
+    physical disks:
+    ------------------------------------------------------------------------------------
+    vendor        model        serial                                        disposition
+    ------------------------------------------------------------------------------------
+    fake-vendor   fake-model   serial-073979dd-3248-44a5-9fa1-cc72a140d682   in service 
+    fake-vendor   fake-model   serial-3efc84af-8a54-4006-8323-4a752e91c049   in service 
+    fake-vendor   fake-model   serial-5f86efdc-a0cf-404c-88af-c878ae6dfdf4   in service 
+    fake-vendor   fake-model   serial-981c69c9-f4f5-4423-bbbc-4578282d53e2   in service 
+    fake-vendor   fake-model   serial-c6d33b64-fb96-4129-bab1-7878a06a5f9b   in service 
+    fake-vendor   fake-model   serial-d8305049-7ee6-4895-a2cb-f63868dae12d   in service 
+    fake-vendor   fake-model   serial-e36f7294-8191-4d79-a791-44f2ec37a5ca   in service 
+    fake-vendor   fake-model   serial-e4d937e1-6ddc-4eca-bb08-c1f73791e608   in service 
+    fake-vendor   fake-model   serial-f09e1f43-f474-423e-8884-c8fa31cf6b60   in service 
+    fake-vendor   fake-model   serial-f355a206-1299-4ef3-9f8f-1a47459160dc   in service 
+
+
+    datasets:
+    -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
+    dataset name                                                                                                   dataset id                             disposition   quota     reservation   compression
+    -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
+    oxp_073979dd-3248-44a5-9fa1-cc72a140d682/crucible                                                              fb2b6175-e812-4a1a-b50e-55a8870c4a38   in service    none      none          off        
+    oxp_3efc84af-8a54-4006-8323-4a752e91c049/crucible                                                              9b70a45a-5901-4bd5-a821-b06ba5a25b39   in service    none      none          off        
+    oxp_5f86efdc-a0cf-404c-88af-c878ae6dfdf4/crucible                                                              9e38b1ba-354d-4528-b61b-3db3ac4814e6   in service    none      none          off        
+    oxp_981c69c9-f4f5-4423-bbbc-4578282d53e2/crucible                                                              d5611d9e-3bdd-435e-972f-1fb618a4b8ae   in service    none      none          off        
+    oxp_c6d33b64-fb96-4129-bab1-7878a06a5f9b/crucible                                                              45b9d4b3-aca7-4b88-9165-2b94e4b6bbbd   in service    none      none          off        
+    oxp_d8305049-7ee6-4895-a2cb-f63868dae12d/crucible                                                              d4ddb5dd-affa-4f78-97fb-4a6579277fa1   in service    none      none          off        
+    oxp_e36f7294-8191-4d79-a791-44f2ec37a5ca/crucible                                                              9d33acef-e0f7-4e6c-bcaf-fc2eb79d4c26   in service    none      none          off        
+    oxp_e4d937e1-6ddc-4eca-bb08-c1f73791e608/crucible                                                              f1ef5a95-f2cf-4ec7-90d6-25b628fbe019   in service    none      none          off        
+    oxp_f09e1f43-f474-423e-8884-c8fa31cf6b60/crucible                                                              29b2c25e-dce4-4195-8c8f-82368fdddff0   in service    none      none          off        
+    oxp_f355a206-1299-4ef3-9f8f-1a47459160dc/crucible                                                              b206319c-0e91-456d-aa4f-e1632794e1bb   in service    none      none          off        
+    oxp_073979dd-3248-44a5-9fa1-cc72a140d682/crypt/clickhouse                                                      d3cd3ec4-703f-4e73-8cc2-b4bc19c7d596   in service    none      none          off        
+    oxp_073979dd-3248-44a5-9fa1-cc72a140d682/crypt/external_dns                                                    f3ddb3ca-388d-4462-9fc8-e552cf7de668   in service    none      none          off        
+    oxp_3efc84af-8a54-4006-8323-4a752e91c049/crypt/external_dns                                                    dd1954a2-7848-4950-a694-38870c339d3e   in service    none      none          off        
+    oxp_5f86efdc-a0cf-404c-88af-c878ae6dfdf4/crypt/external_dns                                                    32bb65ae-855f-461b-9203-32b2ddfe5a64   in service    none      none          off        
+    oxp_073979dd-3248-44a5-9fa1-cc72a140d682/crypt/internal_dns                                                    c7e90d9c-22db-43ca-a602-2a295bac7eec   in service    none      none          off        
+    oxp_3efc84af-8a54-4006-8323-4a752e91c049/crypt/internal_dns                                                    bef875a9-3cf1-4b02-9682-c0286fb23d4d   in service    none      none          off        
+    oxp_5f86efdc-a0cf-404c-88af-c878ae6dfdf4/crypt/internal_dns                                                    f822a7e2-28aa-4ae2-ba86-d4e552a15bcb   in service    none      none          off        
+    oxp_073979dd-3248-44a5-9fa1-cc72a140d682/crypt/zone                                                            e4b83186-c6e2-4d33-ae1b-803c32d1a86e   in service    none      none          off        
+    oxp_3efc84af-8a54-4006-8323-4a752e91c049/crypt/zone                                                            f306ebde-464c-49ef-94eb-1d72cf9afc7e   in service    none      none          off        
+    oxp_5f86efdc-a0cf-404c-88af-c878ae6dfdf4/crypt/zone                                                            20cb5d98-bcd7-4a11-9190-7570a0aa6fe0   in service    none      none          off        
+    oxp_981c69c9-f4f5-4423-bbbc-4578282d53e2/crypt/zone                                                            2aeeb036-0e23-419f-82f7-9ab04c06d7ec   in service    none      none          off        
+    oxp_c6d33b64-fb96-4129-bab1-7878a06a5f9b/crypt/zone                                                            aa860565-2bbb-4a70-ae8e-7d8f29f1a536   in service    none      none          off        
+    oxp_d8305049-7ee6-4895-a2cb-f63868dae12d/crypt/zone                                                            53e5b466-aac5-4cf0-a93b-9f68f58ac755   in service    none      none          off        
+    oxp_e36f7294-8191-4d79-a791-44f2ec37a5ca/crypt/zone                                                            ac802759-2ac3-4c5c-b8e7-6d51689e1537   in service    none      none          off        
+    oxp_e4d937e1-6ddc-4eca-bb08-c1f73791e608/crypt/zone                                                            6b672182-6d17-41d5-81d7-19debe7d3f9b   in service    none      none          off        
+    oxp_f09e1f43-f474-423e-8884-c8fa31cf6b60/crypt/zone                                                            b1007e3d-7aaf-4ccb-9773-241dcbf79b21   in service    none      none          off        
+    oxp_f355a206-1299-4ef3-9f8f-1a47459160dc/crypt/zone                                                            66788e15-bb3a-4369-a5cb-3357f7b85f64   in service    none      none          off        
+    oxp_073979dd-3248-44a5-9fa1-cc72a140d682/crypt/zone/oxz_clickhouse_10676bfe-b61f-40e1-bc07-a4cb76ea1f30        49dc7c86-c865-457f-8d58-37b92b002691   in service    none      none          off        
+    oxp_f09e1f43-f474-423e-8884-c8fa31cf6b60/crypt/zone/oxz_crucible_2470c0fb-7af3-4b6b-8db3-424e4c297bd9          9fd6854b-5144-4d4a-b575-5e22050b04d6   in service    none      none          off        
+    oxp_981c69c9-f4f5-4423-bbbc-4578282d53e2/crypt/zone/oxz_crucible_289a6d4b-ddfe-4101-9715-6693398704f2          c0399553-58e7-4e51-a7b3-556211309dc5   in service    none      none          off        
+    oxp_e4d937e1-6ddc-4eca-bb08-c1f73791e608/crypt/zone/oxz_crucible_2a063d42-9caf-4364-b099-c7c302c87cdd          f01f9303-448a-4050-9841-f6681f05ae0f   in service    none      none          off        
+    oxp_e36f7294-8191-4d79-a791-44f2ec37a5ca/crypt/zone/oxz_crucible_2dcb07a4-b9cc-4ae6-9119-ccd241acbf3a          a5c85a9b-8fe8-4ad6-9bae-fbb04ff13807   in service    none      none          off        
+    oxp_5f86efdc-a0cf-404c-88af-c878ae6dfdf4/crypt/zone/oxz_crucible_3d9b7487-d7b9-4e25-960f-f2086f3e2919          7176fd89-69a6-401b-8b4b-d80163d522fd   in service    none      none          off        
+    oxp_3efc84af-8a54-4006-8323-4a752e91c049/crypt/zone/oxz_crucible_4b19d194-8b25-4396-88da-3df1b3788601          4c8935c4-1f31-41c6-97a0-1c64d9748e91   in service    none      none          off        
+    oxp_f355a206-1299-4ef3-9f8f-1a47459160dc/crypt/zone/oxz_crucible_bbae1838-0a4c-4489-b141-5aff19c2f277          1abeb2b2-f387-4c31-8c8e-55786ce40fe2   in service    none      none          off        
+    oxp_073979dd-3248-44a5-9fa1-cc72a140d682/crypt/zone/oxz_crucible_c204730a-0946-4793-a470-64c88e89da96          b6afb646-131e-4778-8d80-27f059ba01c2   in service    none      none          off        
+    oxp_d8305049-7ee6-4895-a2cb-f63868dae12d/crypt/zone/oxz_crucible_e0075607-793a-4348-a808-84a9dbe3e841          27caffd0-464c-47b8-8b3c-adc62a76529f   in service    none      none          off        
+    oxp_c6d33b64-fb96-4129-bab1-7878a06a5f9b/crypt/zone/oxz_crucible_edce5918-6d13-4cde-9d64-54e00f4c09e6          5019131f-9456-4c96-b53a-08dfce9bf8ee   in service    none      none          off        
+    oxp_5f86efdc-a0cf-404c-88af-c878ae6dfdf4/crypt/zone/oxz_crucible_pantry_2de1c525-4e04-4ba6-ac6b-377aaa542f96   08662183-4261-47b3-a2e0-e12229f378b7   in service    none      none          off        
+    oxp_073979dd-3248-44a5-9fa1-cc72a140d682/crypt/zone/oxz_crucible_pantry_31b26053-8b94-4d8c-9e4a-d7d720afe265   6dd64de1-7dd3-492c-830f-d4a4e4c3dda7   in service    none      none          off        
+    oxp_3efc84af-8a54-4006-8323-4a752e91c049/crypt/zone/oxz_crucible_pantry_f87ada51-4419-4144-86a8-e5e4ff0f64d3   056f6da7-b92d-4231-b0df-0e8a2c9bce42   in service    none      none          off        
+    oxp_3efc84af-8a54-4006-8323-4a752e91c049/crypt/zone/oxz_external_dns_005548be-c5e4-49ff-a27b-88f314f1bc51      42bd3fb3-2aae-4754-9c41-0f9b50a77322   in service    none      none          off        
+    oxp_5f86efdc-a0cf-404c-88af-c878ae6dfdf4/crypt/zone/oxz_external_dns_2205353a-e1d2-48ff-863b-9d6b1487d474      b7813bc0-d5ee-487d-95ad-6c5cce6fdcd6   in service    none      none          off        
+    oxp_073979dd-3248-44a5-9fa1-cc72a140d682/crypt/zone/oxz_external_dns_70aab480-3d6c-47d5-aaf9-8d2ddab2931c      c6d7ecb4-135c-4f09-8948-b73fec13db76   in service    none      none          off        
+    oxp_3efc84af-8a54-4006-8323-4a752e91c049/crypt/zone/oxz_internal_dns_3fd06852-06cb-4d8a-b4b2-eb88ff5a6035      8355e747-b375-4d9e-b5da-03d9540ab5cd   in service    none      none          off        
+    oxp_073979dd-3248-44a5-9fa1-cc72a140d682/crypt/zone/oxz_internal_dns_45ce130e-c5ac-4e26-ab73-7589ba634418      0c7e4b2a-502a-4f4c-8ac4-4068db25252e   in service    none      none          off        
+    oxp_5f86efdc-a0cf-404c-88af-c878ae6dfdf4/crypt/zone/oxz_internal_dns_a7b7bfbe-0588-4781-9a5e-fba63584e5d2      d4f66eab-2870-4a74-b4d5-ae5da3276682   in service    none      none          off        
+    oxp_5f86efdc-a0cf-404c-88af-c878ae6dfdf4/crypt/zone/oxz_nexus_2bc0b0c4-63a9-44cc-afff-76ce645ef1d4             ebfd425c-4e5d-4385-a105-8f2ce32fa9ec   in service    none      none          off        
+    oxp_3efc84af-8a54-4006-8323-4a752e91c049/crypt/zone/oxz_nexus_3c2cd97f-7b4a-4ff3-a9d5-6ce141fcdbbe             382cbbf2-8b08-4388-839a-b43b8bc82999   in service    none      none          off        
+    oxp_073979dd-3248-44a5-9fa1-cc72a140d682/crypt/zone/oxz_nexus_c2cbbf34-b852-4164-a572-01d4d79445a1             d88eb02f-b66d-4ae7-91a1-23154417c1f1   in service    none      none          off        
+    oxp_073979dd-3248-44a5-9fa1-cc72a140d682/crypt/zone/oxz_ntp_9b135c74-c09a-4dcc-ba19-f6f8deae135a               506ddf0e-8cbf-44a9-93d7-130a550fd42d   in service    none      none          off        
+    oxp_073979dd-3248-44a5-9fa1-cc72a140d682/crypt/debug                                                           38fafd69-0275-4f4d-885d-3bbf2ea77551   in service    100 GiB   none          gzip-9     
+    oxp_3efc84af-8a54-4006-8323-4a752e91c049/crypt/debug                                                           cb8d5371-640d-4364-8a5e-0fde125d28af   in service    100 GiB   none          gzip-9     
+    oxp_5f86efdc-a0cf-404c-88af-c878ae6dfdf4/crypt/debug                                                           ba445402-2775-4f97-87e9-640be3a00c6f   in service    100 GiB   none          gzip-9     
+    oxp_981c69c9-f4f5-4423-bbbc-4578282d53e2/crypt/debug                                                           f4ea4a15-b3b3-4a67-b61a-8fba7c7ab61f   in service    100 GiB   none          gzip-9     
+    oxp_c6d33b64-fb96-4129-bab1-7878a06a5f9b/crypt/debug                                                           4d322f8a-d461-4ead-995b-9ba7d76becad   in service    100 GiB   none          gzip-9     
+    oxp_d8305049-7ee6-4895-a2cb-f63868dae12d/crypt/debug                                                           647f344c-b4c5-4788-a732-40658e852f63   in service    100 GiB   none          gzip-9     
+    oxp_e36f7294-8191-4d79-a791-44f2ec37a5ca/crypt/debug                                                           8144f1ee-dbef-45c1-9397-2031a9ca8b38   in service    100 GiB   none          gzip-9     
+    oxp_e4d937e1-6ddc-4eca-bb08-c1f73791e608/crypt/debug                                                           8b89525f-0764-4937-9fa8-022242647c0f   in service    100 GiB   none          gzip-9     
+    oxp_f09e1f43-f474-423e-8884-c8fa31cf6b60/crypt/debug                                                           3523db58-10ab-4e2c-95d9-fec43036c0f5   in service    100 GiB   none          gzip-9     
+    oxp_f355a206-1299-4ef3-9f8f-1a47459160dc/crypt/debug                                                           d1611973-b22d-4097-b6fd-0a480f2199a5   in service    100 GiB   none          gzip-9     
+
+
+    omicron zones:
+    ---------------------------------------------------------------------------------------------------------------
+    zone type         zone id                                image source      disposition   underlay IP           
+    ---------------------------------------------------------------------------------------------------------------
+    clickhouse        10676bfe-b61f-40e1-bc07-a4cb76ea1f30   install dataset   in service    fd00:1122:3344:101::25
+    crucible          2470c0fb-7af3-4b6b-8db3-424e4c297bd9   install dataset   in service    fd00:1122:3344:101::34
+    crucible          289a6d4b-ddfe-4101-9715-6693398704f2   install dataset   in service    fd00:1122:3344:101::2f
+    crucible          2a063d42-9caf-4364-b099-c7c302c87cdd   install dataset   in service    fd00:1122:3344:101::33
+    crucible          2dcb07a4-b9cc-4ae6-9119-ccd241acbf3a   install dataset   in service    fd00:1122:3344:101::32
+    crucible          3d9b7487-d7b9-4e25-960f-f2086f3e2919   install dataset   in service    fd00:1122:3344:101::2e
+    crucible          4b19d194-8b25-4396-88da-3df1b3788601   install dataset   in service    fd00:1122:3344:101::2d
+    crucible          bbae1838-0a4c-4489-b141-5aff19c2f277   install dataset   in service    fd00:1122:3344:101::35
+    crucible          c204730a-0946-4793-a470-64c88e89da96   install dataset   in service    fd00:1122:3344:101::2c
+    crucible          e0075607-793a-4348-a808-84a9dbe3e841   install dataset   in service    fd00:1122:3344:101::31
+    crucible          edce5918-6d13-4cde-9d64-54e00f4c09e6   install dataset   in service    fd00:1122:3344:101::30
+    crucible_pantry   2de1c525-4e04-4ba6-ac6b-377aaa542f96   install dataset   in service    fd00:1122:3344:101::2b
+    crucible_pantry   31b26053-8b94-4d8c-9e4a-d7d720afe265   install dataset   in service    fd00:1122:3344:101::29
+    crucible_pantry   f87ada51-4419-4144-86a8-e5e4ff0f64d3   install dataset   in service    fd00:1122:3344:101::2a
+    external_dns      005548be-c5e4-49ff-a27b-88f314f1bc51   install dataset   in service    fd00:1122:3344:101::27
+    external_dns      2205353a-e1d2-48ff-863b-9d6b1487d474   install dataset   in service    fd00:1122:3344:101::28
+    external_dns      70aab480-3d6c-47d5-aaf9-8d2ddab2931c   install dataset   in service    fd00:1122:3344:101::26
+    internal_dns      3fd06852-06cb-4d8a-b4b2-eb88ff5a6035   install dataset   in service    fd00:1122:3344:2::1   
+    internal_dns      45ce130e-c5ac-4e26-ab73-7589ba634418   install dataset   in service    fd00:1122:3344:1::1   
+    internal_dns      a7b7bfbe-0588-4781-9a5e-fba63584e5d2   install dataset   in service    fd00:1122:3344:3::1   
+    internal_ntp      9b135c74-c09a-4dcc-ba19-f6f8deae135a   install dataset   in service    fd00:1122:3344:101::21
+    nexus             2bc0b0c4-63a9-44cc-afff-76ce645ef1d4   install dataset   in service    fd00:1122:3344:101::24
+    nexus             3c2cd97f-7b4a-4ff3-a9d5-6ce141fcdbbe   install dataset   in service    fd00:1122:3344:101::23
+    nexus             c2cbbf34-b852-4164-a572-01d4d79445a1   install dataset   in service    fd00:1122:3344:101::22
+
+
+ COCKROACHDB SETTINGS:
+    state fingerprint:::::::::::::::::   (none) (unchanged)
+    cluster.preserve_downgrade_option:   (do not modify) (unchanged)
+
+ METADATA:
+    internal DNS version:::   1 (unchanged)
+    external DNS version:::   1 (unchanged)
+    target release min gen:   1 (unchanged)
+
+ OXIMETER SETTINGS:
+    generation:   1 (unchanged)
+    read from::   SingleNode (unchanged)
+
+
+internal DNS:
+  DNS zone: "control-plane.oxide.internal" (unchanged)
+    name: 005548be-c5e4-49ff-a27b-88f314f1bc51.host          (records: 1)
+        AAAA fd00:1122:3344:101::27
+    name: 10676bfe-b61f-40e1-bc07-a4cb76ea1f30.host          (records: 1)
+        AAAA fd00:1122:3344:101::25
+    name: 2205353a-e1d2-48ff-863b-9d6b1487d474.host          (records: 1)
+        AAAA fd00:1122:3344:101::28
+    name: 2470c0fb-7af3-4b6b-8db3-424e4c297bd9.host          (records: 1)
+        AAAA fd00:1122:3344:101::34
+    name: 289a6d4b-ddfe-4101-9715-6693398704f2.host          (records: 1)
+        AAAA fd00:1122:3344:101::2f
+    name: 2a063d42-9caf-4364-b099-c7c302c87cdd.host          (records: 1)
+        AAAA fd00:1122:3344:101::33
+    name: 2bc0b0c4-63a9-44cc-afff-76ce645ef1d4.host          (records: 1)
+        AAAA fd00:1122:3344:101::24
+    name: 2dcb07a4-b9cc-4ae6-9119-ccd241acbf3a.host          (records: 1)
+        AAAA fd00:1122:3344:101::32
+    name: 2de1c525-4e04-4ba6-ac6b-377aaa542f96.host          (records: 1)
+        AAAA fd00:1122:3344:101::2b
+    name: 31b26053-8b94-4d8c-9e4a-d7d720afe265.host          (records: 1)
+        AAAA fd00:1122:3344:101::29
+    name: 3c2cd97f-7b4a-4ff3-a9d5-6ce141fcdbbe.host          (records: 1)
+        AAAA fd00:1122:3344:101::23
+    name: 3d9b7487-d7b9-4e25-960f-f2086f3e2919.host          (records: 1)
+        AAAA fd00:1122:3344:101::2e
+    name: 3fd06852-06cb-4d8a-b4b2-eb88ff5a6035.host          (records: 1)
+        AAAA fd00:1122:3344:2::1
+    name: 45ce130e-c5ac-4e26-ab73-7589ba634418.host          (records: 1)
+        AAAA fd00:1122:3344:1::1
+    name: 4b19d194-8b25-4396-88da-3df1b3788601.host          (records: 1)
+        AAAA fd00:1122:3344:101::2d
+    name: 70aab480-3d6c-47d5-aaf9-8d2ddab2931c.host          (records: 1)
+        AAAA fd00:1122:3344:101::26
+    name: 98e6b7c2-2efa-41ca-b20a-0a4d61102fe6.sled          (records: 1)
+        AAAA fd00:1122:3344:101::1
+    name: 9b135c74-c09a-4dcc-ba19-f6f8deae135a.host          (records: 1)
+        AAAA fd00:1122:3344:101::21
+    name: @                                                  (records: 3)
+        NS   ns1.control-plane.oxide.internal
+        NS   ns2.control-plane.oxide.internal
+        NS   ns3.control-plane.oxide.internal
+    name: _clickhouse-admin-single-server._tcp               (records: 1)
+        SRV  port  8888 10676bfe-b61f-40e1-bc07-a4cb76ea1f30.host.control-plane.oxide.internal
+    name: _clickhouse-native._tcp                            (records: 1)
+        SRV  port  9000 10676bfe-b61f-40e1-bc07-a4cb76ea1f30.host.control-plane.oxide.internal
+    name: _clickhouse._tcp                                   (records: 1)
+        SRV  port  8123 10676bfe-b61f-40e1-bc07-a4cb76ea1f30.host.control-plane.oxide.internal
+    name: _crucible-pantry._tcp                              (records: 3)
+        SRV  port 17000 2de1c525-4e04-4ba6-ac6b-377aaa542f96.host.control-plane.oxide.internal
+        SRV  port 17000 31b26053-8b94-4d8c-9e4a-d7d720afe265.host.control-plane.oxide.internal
+        SRV  port 17000 f87ada51-4419-4144-86a8-e5e4ff0f64d3.host.control-plane.oxide.internal
+    name: _crucible._tcp.2470c0fb-7af3-4b6b-8db3-424e4c297bd9 (records: 1)
+        SRV  port 32345 2470c0fb-7af3-4b6b-8db3-424e4c297bd9.host.control-plane.oxide.internal
+    name: _crucible._tcp.289a6d4b-ddfe-4101-9715-6693398704f2 (records: 1)
+        SRV  port 32345 289a6d4b-ddfe-4101-9715-6693398704f2.host.control-plane.oxide.internal
+    name: _crucible._tcp.2a063d42-9caf-4364-b099-c7c302c87cdd (records: 1)
+        SRV  port 32345 2a063d42-9caf-4364-b099-c7c302c87cdd.host.control-plane.oxide.internal
+    name: _crucible._tcp.2dcb07a4-b9cc-4ae6-9119-ccd241acbf3a (records: 1)
+        SRV  port 32345 2dcb07a4-b9cc-4ae6-9119-ccd241acbf3a.host.control-plane.oxide.internal
+    name: _crucible._tcp.3d9b7487-d7b9-4e25-960f-f2086f3e2919 (records: 1)
+        SRV  port 32345 3d9b7487-d7b9-4e25-960f-f2086f3e2919.host.control-plane.oxide.internal
+    name: _crucible._tcp.4b19d194-8b25-4396-88da-3df1b3788601 (records: 1)
+        SRV  port 32345 4b19d194-8b25-4396-88da-3df1b3788601.host.control-plane.oxide.internal
+    name: _crucible._tcp.bbae1838-0a4c-4489-b141-5aff19c2f277 (records: 1)
+        SRV  port 32345 bbae1838-0a4c-4489-b141-5aff19c2f277.host.control-plane.oxide.internal
+    name: _crucible._tcp.c204730a-0946-4793-a470-64c88e89da96 (records: 1)
+        SRV  port 32345 c204730a-0946-4793-a470-64c88e89da96.host.control-plane.oxide.internal
+    name: _crucible._tcp.e0075607-793a-4348-a808-84a9dbe3e841 (records: 1)
+        SRV  port 32345 e0075607-793a-4348-a808-84a9dbe3e841.host.control-plane.oxide.internal
+    name: _crucible._tcp.edce5918-6d13-4cde-9d64-54e00f4c09e6 (records: 1)
+        SRV  port 32345 edce5918-6d13-4cde-9d64-54e00f4c09e6.host.control-plane.oxide.internal
+    name: _external-dns._tcp                                 (records: 3)
+        SRV  port  5353 005548be-c5e4-49ff-a27b-88f314f1bc51.host.control-plane.oxide.internal
+        SRV  port  5353 2205353a-e1d2-48ff-863b-9d6b1487d474.host.control-plane.oxide.internal
+        SRV  port  5353 70aab480-3d6c-47d5-aaf9-8d2ddab2931c.host.control-plane.oxide.internal
+    name: _internal-ntp._tcp                                 (records: 1)
+        SRV  port   123 9b135c74-c09a-4dcc-ba19-f6f8deae135a.host.control-plane.oxide.internal
+    name: _nameservice._tcp                                  (records: 3)
+        SRV  port  5353 3fd06852-06cb-4d8a-b4b2-eb88ff5a6035.host.control-plane.oxide.internal
+        SRV  port  5353 45ce130e-c5ac-4e26-ab73-7589ba634418.host.control-plane.oxide.internal
+        SRV  port  5353 a7b7bfbe-0588-4781-9a5e-fba63584e5d2.host.control-plane.oxide.internal
+    name: _nexus._tcp                                        (records: 3)
+        SRV  port 12221 2bc0b0c4-63a9-44cc-afff-76ce645ef1d4.host.control-plane.oxide.internal
+        SRV  port 12221 3c2cd97f-7b4a-4ff3-a9d5-6ce141fcdbbe.host.control-plane.oxide.internal
+        SRV  port 12221 c2cbbf34-b852-4164-a572-01d4d79445a1.host.control-plane.oxide.internal
+    name: _oximeter-reader._tcp                              (records: 1)
+        SRV  port  9000 10676bfe-b61f-40e1-bc07-a4cb76ea1f30.host.control-plane.oxide.internal
+    name: _repo-depot._tcp                                   (records: 1)
+        SRV  port 12348 98e6b7c2-2efa-41ca-b20a-0a4d61102fe6.sled.control-plane.oxide.internal
+    name: a7b7bfbe-0588-4781-9a5e-fba63584e5d2.host          (records: 1)
+        AAAA fd00:1122:3344:3::1
+    name: bbae1838-0a4c-4489-b141-5aff19c2f277.host          (records: 1)
+        AAAA fd00:1122:3344:101::35
+    name: c204730a-0946-4793-a470-64c88e89da96.host          (records: 1)
+        AAAA fd00:1122:3344:101::2c
+    name: c2cbbf34-b852-4164-a572-01d4d79445a1.host          (records: 1)
+        AAAA fd00:1122:3344:101::22
+    name: e0075607-793a-4348-a808-84a9dbe3e841.host          (records: 1)
+        AAAA fd00:1122:3344:101::31
+    name: edce5918-6d13-4cde-9d64-54e00f4c09e6.host          (records: 1)
+        AAAA fd00:1122:3344:101::30
+    name: f87ada51-4419-4144-86a8-e5e4ff0f64d3.host          (records: 1)
+        AAAA fd00:1122:3344:101::2a
+    name: ns1                                                (records: 1)
+        AAAA fd00:1122:3344:1::1
+    name: ns2                                                (records: 1)
+        AAAA fd00:1122:3344:2::1
+    name: ns3                                                (records: 1)
+        AAAA fd00:1122:3344:3::1
+
+external DNS:
+  DNS zone: "oxide.example" (unchanged)
+    name: @                                                  (records: 3)
+        NS   ns1.oxide.example
+        NS   ns2.oxide.example
+        NS   ns3.oxide.example
+    name: example-silo.sys                                   (records: 3)
+        A    192.0.2.4
+        A    192.0.2.3
+        A    192.0.2.2
+    name: ns1                                                (records: 1)
+        A    198.51.100.1
+    name: ns2                                                (records: 1)
+        A    198.51.100.2
+    name: ns3                                                (records: 1)
+        A    198.51.100.3
+
+
+
+
+> # Restore both to "current contents"
+> blueprint-edit latest set-host-phase2 serial0 A current-contents
+blueprint af934083-59b5-4bf6-8966-6fb5292c29e1 created from latest blueprint (58d5e830-0884-47d8-a7cd-b2b3751adeb4): set sled 98e6b7c2-2efa-41ca-b20a-0a4d61102fe6 host phase 2 slot A source to current contents
+warn: no validation is done on the requested source
+
+> blueprint-diff latest
+from: blueprint 58d5e830-0884-47d8-a7cd-b2b3751adeb4
+to:   blueprint af934083-59b5-4bf6-8966-6fb5292c29e1
+
+ MODIFIED SLEDS:
+
+  sled 98e6b7c2-2efa-41ca-b20a-0a4d61102fe6 (active, config generation 4 -> 5):
+
+    host phase 2 contents:
+    --------------------------------
+    slot   boot image source        
+    --------------------------------
+*   A      - artifact: version 1.0.0
+     └─    + current contents       
+    B      artifact: version 2.0.0  
+
+
+    physical disks:
+    ------------------------------------------------------------------------------------
+    vendor        model        serial                                        disposition
+    ------------------------------------------------------------------------------------
+    fake-vendor   fake-model   serial-073979dd-3248-44a5-9fa1-cc72a140d682   in service 
+    fake-vendor   fake-model   serial-3efc84af-8a54-4006-8323-4a752e91c049   in service 
+    fake-vendor   fake-model   serial-5f86efdc-a0cf-404c-88af-c878ae6dfdf4   in service 
+    fake-vendor   fake-model   serial-981c69c9-f4f5-4423-bbbc-4578282d53e2   in service 
+    fake-vendor   fake-model   serial-c6d33b64-fb96-4129-bab1-7878a06a5f9b   in service 
+    fake-vendor   fake-model   serial-d8305049-7ee6-4895-a2cb-f63868dae12d   in service 
+    fake-vendor   fake-model   serial-e36f7294-8191-4d79-a791-44f2ec37a5ca   in service 
+    fake-vendor   fake-model   serial-e4d937e1-6ddc-4eca-bb08-c1f73791e608   in service 
+    fake-vendor   fake-model   serial-f09e1f43-f474-423e-8884-c8fa31cf6b60   in service 
+    fake-vendor   fake-model   serial-f355a206-1299-4ef3-9f8f-1a47459160dc   in service 
+
+
+    datasets:
+    -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
+    dataset name                                                                                                   dataset id                             disposition   quota     reservation   compression
+    -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
+    oxp_073979dd-3248-44a5-9fa1-cc72a140d682/crucible                                                              fb2b6175-e812-4a1a-b50e-55a8870c4a38   in service    none      none          off        
+    oxp_3efc84af-8a54-4006-8323-4a752e91c049/crucible                                                              9b70a45a-5901-4bd5-a821-b06ba5a25b39   in service    none      none          off        
+    oxp_5f86efdc-a0cf-404c-88af-c878ae6dfdf4/crucible                                                              9e38b1ba-354d-4528-b61b-3db3ac4814e6   in service    none      none          off        
+    oxp_981c69c9-f4f5-4423-bbbc-4578282d53e2/crucible                                                              d5611d9e-3bdd-435e-972f-1fb618a4b8ae   in service    none      none          off        
+    oxp_c6d33b64-fb96-4129-bab1-7878a06a5f9b/crucible                                                              45b9d4b3-aca7-4b88-9165-2b94e4b6bbbd   in service    none      none          off        
+    oxp_d8305049-7ee6-4895-a2cb-f63868dae12d/crucible                                                              d4ddb5dd-affa-4f78-97fb-4a6579277fa1   in service    none      none          off        
+    oxp_e36f7294-8191-4d79-a791-44f2ec37a5ca/crucible                                                              9d33acef-e0f7-4e6c-bcaf-fc2eb79d4c26   in service    none      none          off        
+    oxp_e4d937e1-6ddc-4eca-bb08-c1f73791e608/crucible                                                              f1ef5a95-f2cf-4ec7-90d6-25b628fbe019   in service    none      none          off        
+    oxp_f09e1f43-f474-423e-8884-c8fa31cf6b60/crucible                                                              29b2c25e-dce4-4195-8c8f-82368fdddff0   in service    none      none          off        
+    oxp_f355a206-1299-4ef3-9f8f-1a47459160dc/crucible                                                              b206319c-0e91-456d-aa4f-e1632794e1bb   in service    none      none          off        
+    oxp_073979dd-3248-44a5-9fa1-cc72a140d682/crypt/clickhouse                                                      d3cd3ec4-703f-4e73-8cc2-b4bc19c7d596   in service    none      none          off        
+    oxp_073979dd-3248-44a5-9fa1-cc72a140d682/crypt/external_dns                                                    f3ddb3ca-388d-4462-9fc8-e552cf7de668   in service    none      none          off        
+    oxp_3efc84af-8a54-4006-8323-4a752e91c049/crypt/external_dns                                                    dd1954a2-7848-4950-a694-38870c339d3e   in service    none      none          off        
+    oxp_5f86efdc-a0cf-404c-88af-c878ae6dfdf4/crypt/external_dns                                                    32bb65ae-855f-461b-9203-32b2ddfe5a64   in service    none      none          off        
+    oxp_073979dd-3248-44a5-9fa1-cc72a140d682/crypt/internal_dns                                                    c7e90d9c-22db-43ca-a602-2a295bac7eec   in service    none      none          off        
+    oxp_3efc84af-8a54-4006-8323-4a752e91c049/crypt/internal_dns                                                    bef875a9-3cf1-4b02-9682-c0286fb23d4d   in service    none      none          off        
+    oxp_5f86efdc-a0cf-404c-88af-c878ae6dfdf4/crypt/internal_dns                                                    f822a7e2-28aa-4ae2-ba86-d4e552a15bcb   in service    none      none          off        
+    oxp_073979dd-3248-44a5-9fa1-cc72a140d682/crypt/zone                                                            e4b83186-c6e2-4d33-ae1b-803c32d1a86e   in service    none      none          off        
+    oxp_3efc84af-8a54-4006-8323-4a752e91c049/crypt/zone                                                            f306ebde-464c-49ef-94eb-1d72cf9afc7e   in service    none      none          off        
+    oxp_5f86efdc-a0cf-404c-88af-c878ae6dfdf4/crypt/zone                                                            20cb5d98-bcd7-4a11-9190-7570a0aa6fe0   in service    none      none          off        
+    oxp_981c69c9-f4f5-4423-bbbc-4578282d53e2/crypt/zone                                                            2aeeb036-0e23-419f-82f7-9ab04c06d7ec   in service    none      none          off        
+    oxp_c6d33b64-fb96-4129-bab1-7878a06a5f9b/crypt/zone                                                            aa860565-2bbb-4a70-ae8e-7d8f29f1a536   in service    none      none          off        
+    oxp_d8305049-7ee6-4895-a2cb-f63868dae12d/crypt/zone                                                            53e5b466-aac5-4cf0-a93b-9f68f58ac755   in service    none      none          off        
+    oxp_e36f7294-8191-4d79-a791-44f2ec37a5ca/crypt/zone                                                            ac802759-2ac3-4c5c-b8e7-6d51689e1537   in service    none      none          off        
+    oxp_e4d937e1-6ddc-4eca-bb08-c1f73791e608/crypt/zone                                                            6b672182-6d17-41d5-81d7-19debe7d3f9b   in service    none      none          off        
+    oxp_f09e1f43-f474-423e-8884-c8fa31cf6b60/crypt/zone                                                            b1007e3d-7aaf-4ccb-9773-241dcbf79b21   in service    none      none          off        
+    oxp_f355a206-1299-4ef3-9f8f-1a47459160dc/crypt/zone                                                            66788e15-bb3a-4369-a5cb-3357f7b85f64   in service    none      none          off        
+    oxp_073979dd-3248-44a5-9fa1-cc72a140d682/crypt/zone/oxz_clickhouse_10676bfe-b61f-40e1-bc07-a4cb76ea1f30        49dc7c86-c865-457f-8d58-37b92b002691   in service    none      none          off        
+    oxp_f09e1f43-f474-423e-8884-c8fa31cf6b60/crypt/zone/oxz_crucible_2470c0fb-7af3-4b6b-8db3-424e4c297bd9          9fd6854b-5144-4d4a-b575-5e22050b04d6   in service    none      none          off        
+    oxp_981c69c9-f4f5-4423-bbbc-4578282d53e2/crypt/zone/oxz_crucible_289a6d4b-ddfe-4101-9715-6693398704f2          c0399553-58e7-4e51-a7b3-556211309dc5   in service    none      none          off        
+    oxp_e4d937e1-6ddc-4eca-bb08-c1f73791e608/crypt/zone/oxz_crucible_2a063d42-9caf-4364-b099-c7c302c87cdd          f01f9303-448a-4050-9841-f6681f05ae0f   in service    none      none          off        
+    oxp_e36f7294-8191-4d79-a791-44f2ec37a5ca/crypt/zone/oxz_crucible_2dcb07a4-b9cc-4ae6-9119-ccd241acbf3a          a5c85a9b-8fe8-4ad6-9bae-fbb04ff13807   in service    none      none          off        
+    oxp_5f86efdc-a0cf-404c-88af-c878ae6dfdf4/crypt/zone/oxz_crucible_3d9b7487-d7b9-4e25-960f-f2086f3e2919          7176fd89-69a6-401b-8b4b-d80163d522fd   in service    none      none          off        
+    oxp_3efc84af-8a54-4006-8323-4a752e91c049/crypt/zone/oxz_crucible_4b19d194-8b25-4396-88da-3df1b3788601          4c8935c4-1f31-41c6-97a0-1c64d9748e91   in service    none      none          off        
+    oxp_f355a206-1299-4ef3-9f8f-1a47459160dc/crypt/zone/oxz_crucible_bbae1838-0a4c-4489-b141-5aff19c2f277          1abeb2b2-f387-4c31-8c8e-55786ce40fe2   in service    none      none          off        
+    oxp_073979dd-3248-44a5-9fa1-cc72a140d682/crypt/zone/oxz_crucible_c204730a-0946-4793-a470-64c88e89da96          b6afb646-131e-4778-8d80-27f059ba01c2   in service    none      none          off        
+    oxp_d8305049-7ee6-4895-a2cb-f63868dae12d/crypt/zone/oxz_crucible_e0075607-793a-4348-a808-84a9dbe3e841          27caffd0-464c-47b8-8b3c-adc62a76529f   in service    none      none          off        
+    oxp_c6d33b64-fb96-4129-bab1-7878a06a5f9b/crypt/zone/oxz_crucible_edce5918-6d13-4cde-9d64-54e00f4c09e6          5019131f-9456-4c96-b53a-08dfce9bf8ee   in service    none      none          off        
+    oxp_5f86efdc-a0cf-404c-88af-c878ae6dfdf4/crypt/zone/oxz_crucible_pantry_2de1c525-4e04-4ba6-ac6b-377aaa542f96   08662183-4261-47b3-a2e0-e12229f378b7   in service    none      none          off        
+    oxp_073979dd-3248-44a5-9fa1-cc72a140d682/crypt/zone/oxz_crucible_pantry_31b26053-8b94-4d8c-9e4a-d7d720afe265   6dd64de1-7dd3-492c-830f-d4a4e4c3dda7   in service    none      none          off        
+    oxp_3efc84af-8a54-4006-8323-4a752e91c049/crypt/zone/oxz_crucible_pantry_f87ada51-4419-4144-86a8-e5e4ff0f64d3   056f6da7-b92d-4231-b0df-0e8a2c9bce42   in service    none      none          off        
+    oxp_3efc84af-8a54-4006-8323-4a752e91c049/crypt/zone/oxz_external_dns_005548be-c5e4-49ff-a27b-88f314f1bc51      42bd3fb3-2aae-4754-9c41-0f9b50a77322   in service    none      none          off        
+    oxp_5f86efdc-a0cf-404c-88af-c878ae6dfdf4/crypt/zone/oxz_external_dns_2205353a-e1d2-48ff-863b-9d6b1487d474      b7813bc0-d5ee-487d-95ad-6c5cce6fdcd6   in service    none      none          off        
+    oxp_073979dd-3248-44a5-9fa1-cc72a140d682/crypt/zone/oxz_external_dns_70aab480-3d6c-47d5-aaf9-8d2ddab2931c      c6d7ecb4-135c-4f09-8948-b73fec13db76   in service    none      none          off        
+    oxp_3efc84af-8a54-4006-8323-4a752e91c049/crypt/zone/oxz_internal_dns_3fd06852-06cb-4d8a-b4b2-eb88ff5a6035      8355e747-b375-4d9e-b5da-03d9540ab5cd   in service    none      none          off        
+    oxp_073979dd-3248-44a5-9fa1-cc72a140d682/crypt/zone/oxz_internal_dns_45ce130e-c5ac-4e26-ab73-7589ba634418      0c7e4b2a-502a-4f4c-8ac4-4068db25252e   in service    none      none          off        
+    oxp_5f86efdc-a0cf-404c-88af-c878ae6dfdf4/crypt/zone/oxz_internal_dns_a7b7bfbe-0588-4781-9a5e-fba63584e5d2      d4f66eab-2870-4a74-b4d5-ae5da3276682   in service    none      none          off        
+    oxp_5f86efdc-a0cf-404c-88af-c878ae6dfdf4/crypt/zone/oxz_nexus_2bc0b0c4-63a9-44cc-afff-76ce645ef1d4             ebfd425c-4e5d-4385-a105-8f2ce32fa9ec   in service    none      none          off        
+    oxp_3efc84af-8a54-4006-8323-4a752e91c049/crypt/zone/oxz_nexus_3c2cd97f-7b4a-4ff3-a9d5-6ce141fcdbbe             382cbbf2-8b08-4388-839a-b43b8bc82999   in service    none      none          off        
+    oxp_073979dd-3248-44a5-9fa1-cc72a140d682/crypt/zone/oxz_nexus_c2cbbf34-b852-4164-a572-01d4d79445a1             d88eb02f-b66d-4ae7-91a1-23154417c1f1   in service    none      none          off        
+    oxp_073979dd-3248-44a5-9fa1-cc72a140d682/crypt/zone/oxz_ntp_9b135c74-c09a-4dcc-ba19-f6f8deae135a               506ddf0e-8cbf-44a9-93d7-130a550fd42d   in service    none      none          off        
+    oxp_073979dd-3248-44a5-9fa1-cc72a140d682/crypt/debug                                                           38fafd69-0275-4f4d-885d-3bbf2ea77551   in service    100 GiB   none          gzip-9     
+    oxp_3efc84af-8a54-4006-8323-4a752e91c049/crypt/debug                                                           cb8d5371-640d-4364-8a5e-0fde125d28af   in service    100 GiB   none          gzip-9     
+    oxp_5f86efdc-a0cf-404c-88af-c878ae6dfdf4/crypt/debug                                                           ba445402-2775-4f97-87e9-640be3a00c6f   in service    100 GiB   none          gzip-9     
+    oxp_981c69c9-f4f5-4423-bbbc-4578282d53e2/crypt/debug                                                           f4ea4a15-b3b3-4a67-b61a-8fba7c7ab61f   in service    100 GiB   none          gzip-9     
+    oxp_c6d33b64-fb96-4129-bab1-7878a06a5f9b/crypt/debug                                                           4d322f8a-d461-4ead-995b-9ba7d76becad   in service    100 GiB   none          gzip-9     
+    oxp_d8305049-7ee6-4895-a2cb-f63868dae12d/crypt/debug                                                           647f344c-b4c5-4788-a732-40658e852f63   in service    100 GiB   none          gzip-9     
+    oxp_e36f7294-8191-4d79-a791-44f2ec37a5ca/crypt/debug                                                           8144f1ee-dbef-45c1-9397-2031a9ca8b38   in service    100 GiB   none          gzip-9     
+    oxp_e4d937e1-6ddc-4eca-bb08-c1f73791e608/crypt/debug                                                           8b89525f-0764-4937-9fa8-022242647c0f   in service    100 GiB   none          gzip-9     
+    oxp_f09e1f43-f474-423e-8884-c8fa31cf6b60/crypt/debug                                                           3523db58-10ab-4e2c-95d9-fec43036c0f5   in service    100 GiB   none          gzip-9     
+    oxp_f355a206-1299-4ef3-9f8f-1a47459160dc/crypt/debug                                                           d1611973-b22d-4097-b6fd-0a480f2199a5   in service    100 GiB   none          gzip-9     
+
+
+    omicron zones:
+    ---------------------------------------------------------------------------------------------------------------
+    zone type         zone id                                image source      disposition   underlay IP           
+    ---------------------------------------------------------------------------------------------------------------
+    clickhouse        10676bfe-b61f-40e1-bc07-a4cb76ea1f30   install dataset   in service    fd00:1122:3344:101::25
+    crucible          2470c0fb-7af3-4b6b-8db3-424e4c297bd9   install dataset   in service    fd00:1122:3344:101::34
+    crucible          289a6d4b-ddfe-4101-9715-6693398704f2   install dataset   in service    fd00:1122:3344:101::2f
+    crucible          2a063d42-9caf-4364-b099-c7c302c87cdd   install dataset   in service    fd00:1122:3344:101::33
+    crucible          2dcb07a4-b9cc-4ae6-9119-ccd241acbf3a   install dataset   in service    fd00:1122:3344:101::32
+    crucible          3d9b7487-d7b9-4e25-960f-f2086f3e2919   install dataset   in service    fd00:1122:3344:101::2e
+    crucible          4b19d194-8b25-4396-88da-3df1b3788601   install dataset   in service    fd00:1122:3344:101::2d
+    crucible          bbae1838-0a4c-4489-b141-5aff19c2f277   install dataset   in service    fd00:1122:3344:101::35
+    crucible          c204730a-0946-4793-a470-64c88e89da96   install dataset   in service    fd00:1122:3344:101::2c
+    crucible          e0075607-793a-4348-a808-84a9dbe3e841   install dataset   in service    fd00:1122:3344:101::31
+    crucible          edce5918-6d13-4cde-9d64-54e00f4c09e6   install dataset   in service    fd00:1122:3344:101::30
+    crucible_pantry   2de1c525-4e04-4ba6-ac6b-377aaa542f96   install dataset   in service    fd00:1122:3344:101::2b
+    crucible_pantry   31b26053-8b94-4d8c-9e4a-d7d720afe265   install dataset   in service    fd00:1122:3344:101::29
+    crucible_pantry   f87ada51-4419-4144-86a8-e5e4ff0f64d3   install dataset   in service    fd00:1122:3344:101::2a
+    external_dns      005548be-c5e4-49ff-a27b-88f314f1bc51   install dataset   in service    fd00:1122:3344:101::27
+    external_dns      2205353a-e1d2-48ff-863b-9d6b1487d474   install dataset   in service    fd00:1122:3344:101::28
+    external_dns      70aab480-3d6c-47d5-aaf9-8d2ddab2931c   install dataset   in service    fd00:1122:3344:101::26
+    internal_dns      3fd06852-06cb-4d8a-b4b2-eb88ff5a6035   install dataset   in service    fd00:1122:3344:2::1   
+    internal_dns      45ce130e-c5ac-4e26-ab73-7589ba634418   install dataset   in service    fd00:1122:3344:1::1   
+    internal_dns      a7b7bfbe-0588-4781-9a5e-fba63584e5d2   install dataset   in service    fd00:1122:3344:3::1   
+    internal_ntp      9b135c74-c09a-4dcc-ba19-f6f8deae135a   install dataset   in service    fd00:1122:3344:101::21
+    nexus             2bc0b0c4-63a9-44cc-afff-76ce645ef1d4   install dataset   in service    fd00:1122:3344:101::24
+    nexus             3c2cd97f-7b4a-4ff3-a9d5-6ce141fcdbbe   install dataset   in service    fd00:1122:3344:101::23
+    nexus             c2cbbf34-b852-4164-a572-01d4d79445a1   install dataset   in service    fd00:1122:3344:101::22
+
+
+ COCKROACHDB SETTINGS:
+    state fingerprint:::::::::::::::::   (none) (unchanged)
+    cluster.preserve_downgrade_option:   (do not modify) (unchanged)
+
+ METADATA:
+    internal DNS version:::   1 (unchanged)
+    external DNS version:::   1 (unchanged)
+    target release min gen:   1 (unchanged)
+
+ OXIMETER SETTINGS:
+    generation:   1 (unchanged)
+    read from::   SingleNode (unchanged)
+
+
+internal DNS:
+  DNS zone: "control-plane.oxide.internal" (unchanged)
+    name: 005548be-c5e4-49ff-a27b-88f314f1bc51.host          (records: 1)
+        AAAA fd00:1122:3344:101::27
+    name: 10676bfe-b61f-40e1-bc07-a4cb76ea1f30.host          (records: 1)
+        AAAA fd00:1122:3344:101::25
+    name: 2205353a-e1d2-48ff-863b-9d6b1487d474.host          (records: 1)
+        AAAA fd00:1122:3344:101::28
+    name: 2470c0fb-7af3-4b6b-8db3-424e4c297bd9.host          (records: 1)
+        AAAA fd00:1122:3344:101::34
+    name: 289a6d4b-ddfe-4101-9715-6693398704f2.host          (records: 1)
+        AAAA fd00:1122:3344:101::2f
+    name: 2a063d42-9caf-4364-b099-c7c302c87cdd.host          (records: 1)
+        AAAA fd00:1122:3344:101::33
+    name: 2bc0b0c4-63a9-44cc-afff-76ce645ef1d4.host          (records: 1)
+        AAAA fd00:1122:3344:101::24
+    name: 2dcb07a4-b9cc-4ae6-9119-ccd241acbf3a.host          (records: 1)
+        AAAA fd00:1122:3344:101::32
+    name: 2de1c525-4e04-4ba6-ac6b-377aaa542f96.host          (records: 1)
+        AAAA fd00:1122:3344:101::2b
+    name: 31b26053-8b94-4d8c-9e4a-d7d720afe265.host          (records: 1)
+        AAAA fd00:1122:3344:101::29
+    name: 3c2cd97f-7b4a-4ff3-a9d5-6ce141fcdbbe.host          (records: 1)
+        AAAA fd00:1122:3344:101::23
+    name: 3d9b7487-d7b9-4e25-960f-f2086f3e2919.host          (records: 1)
+        AAAA fd00:1122:3344:101::2e
+    name: 3fd06852-06cb-4d8a-b4b2-eb88ff5a6035.host          (records: 1)
+        AAAA fd00:1122:3344:2::1
+    name: 45ce130e-c5ac-4e26-ab73-7589ba634418.host          (records: 1)
+        AAAA fd00:1122:3344:1::1
+    name: 4b19d194-8b25-4396-88da-3df1b3788601.host          (records: 1)
+        AAAA fd00:1122:3344:101::2d
+    name: 70aab480-3d6c-47d5-aaf9-8d2ddab2931c.host          (records: 1)
+        AAAA fd00:1122:3344:101::26
+    name: 98e6b7c2-2efa-41ca-b20a-0a4d61102fe6.sled          (records: 1)
+        AAAA fd00:1122:3344:101::1
+    name: 9b135c74-c09a-4dcc-ba19-f6f8deae135a.host          (records: 1)
+        AAAA fd00:1122:3344:101::21
+    name: @                                                  (records: 3)
+        NS   ns1.control-plane.oxide.internal
+        NS   ns2.control-plane.oxide.internal
+        NS   ns3.control-plane.oxide.internal
+    name: _clickhouse-admin-single-server._tcp               (records: 1)
+        SRV  port  8888 10676bfe-b61f-40e1-bc07-a4cb76ea1f30.host.control-plane.oxide.internal
+    name: _clickhouse-native._tcp                            (records: 1)
+        SRV  port  9000 10676bfe-b61f-40e1-bc07-a4cb76ea1f30.host.control-plane.oxide.internal
+    name: _clickhouse._tcp                                   (records: 1)
+        SRV  port  8123 10676bfe-b61f-40e1-bc07-a4cb76ea1f30.host.control-plane.oxide.internal
+    name: _crucible-pantry._tcp                              (records: 3)
+        SRV  port 17000 2de1c525-4e04-4ba6-ac6b-377aaa542f96.host.control-plane.oxide.internal
+        SRV  port 17000 31b26053-8b94-4d8c-9e4a-d7d720afe265.host.control-plane.oxide.internal
+        SRV  port 17000 f87ada51-4419-4144-86a8-e5e4ff0f64d3.host.control-plane.oxide.internal
+    name: _crucible._tcp.2470c0fb-7af3-4b6b-8db3-424e4c297bd9 (records: 1)
+        SRV  port 32345 2470c0fb-7af3-4b6b-8db3-424e4c297bd9.host.control-plane.oxide.internal
+    name: _crucible._tcp.289a6d4b-ddfe-4101-9715-6693398704f2 (records: 1)
+        SRV  port 32345 289a6d4b-ddfe-4101-9715-6693398704f2.host.control-plane.oxide.internal
+    name: _crucible._tcp.2a063d42-9caf-4364-b099-c7c302c87cdd (records: 1)
+        SRV  port 32345 2a063d42-9caf-4364-b099-c7c302c87cdd.host.control-plane.oxide.internal
+    name: _crucible._tcp.2dcb07a4-b9cc-4ae6-9119-ccd241acbf3a (records: 1)
+        SRV  port 32345 2dcb07a4-b9cc-4ae6-9119-ccd241acbf3a.host.control-plane.oxide.internal
+    name: _crucible._tcp.3d9b7487-d7b9-4e25-960f-f2086f3e2919 (records: 1)
+        SRV  port 32345 3d9b7487-d7b9-4e25-960f-f2086f3e2919.host.control-plane.oxide.internal
+    name: _crucible._tcp.4b19d194-8b25-4396-88da-3df1b3788601 (records: 1)
+        SRV  port 32345 4b19d194-8b25-4396-88da-3df1b3788601.host.control-plane.oxide.internal
+    name: _crucible._tcp.bbae1838-0a4c-4489-b141-5aff19c2f277 (records: 1)
+        SRV  port 32345 bbae1838-0a4c-4489-b141-5aff19c2f277.host.control-plane.oxide.internal
+    name: _crucible._tcp.c204730a-0946-4793-a470-64c88e89da96 (records: 1)
+        SRV  port 32345 c204730a-0946-4793-a470-64c88e89da96.host.control-plane.oxide.internal
+    name: _crucible._tcp.e0075607-793a-4348-a808-84a9dbe3e841 (records: 1)
+        SRV  port 32345 e0075607-793a-4348-a808-84a9dbe3e841.host.control-plane.oxide.internal
+    name: _crucible._tcp.edce5918-6d13-4cde-9d64-54e00f4c09e6 (records: 1)
+        SRV  port 32345 edce5918-6d13-4cde-9d64-54e00f4c09e6.host.control-plane.oxide.internal
+    name: _external-dns._tcp                                 (records: 3)
+        SRV  port  5353 005548be-c5e4-49ff-a27b-88f314f1bc51.host.control-plane.oxide.internal
+        SRV  port  5353 2205353a-e1d2-48ff-863b-9d6b1487d474.host.control-plane.oxide.internal
+        SRV  port  5353 70aab480-3d6c-47d5-aaf9-8d2ddab2931c.host.control-plane.oxide.internal
+    name: _internal-ntp._tcp                                 (records: 1)
+        SRV  port   123 9b135c74-c09a-4dcc-ba19-f6f8deae135a.host.control-plane.oxide.internal
+    name: _nameservice._tcp                                  (records: 3)
+        SRV  port  5353 3fd06852-06cb-4d8a-b4b2-eb88ff5a6035.host.control-plane.oxide.internal
+        SRV  port  5353 45ce130e-c5ac-4e26-ab73-7589ba634418.host.control-plane.oxide.internal
+        SRV  port  5353 a7b7bfbe-0588-4781-9a5e-fba63584e5d2.host.control-plane.oxide.internal
+    name: _nexus._tcp                                        (records: 3)
+        SRV  port 12221 2bc0b0c4-63a9-44cc-afff-76ce645ef1d4.host.control-plane.oxide.internal
+        SRV  port 12221 3c2cd97f-7b4a-4ff3-a9d5-6ce141fcdbbe.host.control-plane.oxide.internal
+        SRV  port 12221 c2cbbf34-b852-4164-a572-01d4d79445a1.host.control-plane.oxide.internal
+    name: _oximeter-reader._tcp                              (records: 1)
+        SRV  port  9000 10676bfe-b61f-40e1-bc07-a4cb76ea1f30.host.control-plane.oxide.internal
+    name: _repo-depot._tcp                                   (records: 1)
+        SRV  port 12348 98e6b7c2-2efa-41ca-b20a-0a4d61102fe6.sled.control-plane.oxide.internal
+    name: a7b7bfbe-0588-4781-9a5e-fba63584e5d2.host          (records: 1)
+        AAAA fd00:1122:3344:3::1
+    name: bbae1838-0a4c-4489-b141-5aff19c2f277.host          (records: 1)
+        AAAA fd00:1122:3344:101::35
+    name: c204730a-0946-4793-a470-64c88e89da96.host          (records: 1)
+        AAAA fd00:1122:3344:101::2c
+    name: c2cbbf34-b852-4164-a572-01d4d79445a1.host          (records: 1)
+        AAAA fd00:1122:3344:101::22
+    name: e0075607-793a-4348-a808-84a9dbe3e841.host          (records: 1)
+        AAAA fd00:1122:3344:101::31
+    name: edce5918-6d13-4cde-9d64-54e00f4c09e6.host          (records: 1)
+        AAAA fd00:1122:3344:101::30
+    name: f87ada51-4419-4144-86a8-e5e4ff0f64d3.host          (records: 1)
+        AAAA fd00:1122:3344:101::2a
+    name: ns1                                                (records: 1)
+        AAAA fd00:1122:3344:1::1
+    name: ns2                                                (records: 1)
+        AAAA fd00:1122:3344:2::1
+    name: ns3                                                (records: 1)
+        AAAA fd00:1122:3344:3::1
+
+external DNS:
+  DNS zone: "oxide.example" (unchanged)
+    name: @                                                  (records: 3)
+        NS   ns1.oxide.example
+        NS   ns2.oxide.example
+        NS   ns3.oxide.example
+    name: example-silo.sys                                   (records: 3)
+        A    192.0.2.4
+        A    192.0.2.3
+        A    192.0.2.2
+    name: ns1                                                (records: 1)
+        A    198.51.100.1
+    name: ns2                                                (records: 1)
+        A    198.51.100.2
+    name: ns3                                                (records: 1)
+        A    198.51.100.3
+
+
+
+> blueprint-edit latest set-host-phase2 serial0 B current-contents
+blueprint df06bb57-ad42-4431-9206-abff322896c7 created from latest blueprint (af934083-59b5-4bf6-8966-6fb5292c29e1): set sled 98e6b7c2-2efa-41ca-b20a-0a4d61102fe6 host phase 2 slot B source to current contents
+warn: no validation is done on the requested source
+
+> blueprint-diff latest
+from: blueprint af934083-59b5-4bf6-8966-6fb5292c29e1
+to:   blueprint df06bb57-ad42-4431-9206-abff322896c7
+
+ MODIFIED SLEDS:
+
+  sled 98e6b7c2-2efa-41ca-b20a-0a4d61102fe6 (active, config generation 5 -> 6):
+
+    host phase 2 contents:
+    --------------------------------
+    slot   boot image source        
+    --------------------------------
+    A      current contents         
+*   B      - artifact: version 2.0.0
+     └─    + current contents       
+
+
+    physical disks:
+    ------------------------------------------------------------------------------------
+    vendor        model        serial                                        disposition
+    ------------------------------------------------------------------------------------
+    fake-vendor   fake-model   serial-073979dd-3248-44a5-9fa1-cc72a140d682   in service 
+    fake-vendor   fake-model   serial-3efc84af-8a54-4006-8323-4a752e91c049   in service 
+    fake-vendor   fake-model   serial-5f86efdc-a0cf-404c-88af-c878ae6dfdf4   in service 
+    fake-vendor   fake-model   serial-981c69c9-f4f5-4423-bbbc-4578282d53e2   in service 
+    fake-vendor   fake-model   serial-c6d33b64-fb96-4129-bab1-7878a06a5f9b   in service 
+    fake-vendor   fake-model   serial-d8305049-7ee6-4895-a2cb-f63868dae12d   in service 
+    fake-vendor   fake-model   serial-e36f7294-8191-4d79-a791-44f2ec37a5ca   in service 
+    fake-vendor   fake-model   serial-e4d937e1-6ddc-4eca-bb08-c1f73791e608   in service 
+    fake-vendor   fake-model   serial-f09e1f43-f474-423e-8884-c8fa31cf6b60   in service 
+    fake-vendor   fake-model   serial-f355a206-1299-4ef3-9f8f-1a47459160dc   in service 
+
+
+    datasets:
+    -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
+    dataset name                                                                                                   dataset id                             disposition   quota     reservation   compression
+    -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
+    oxp_073979dd-3248-44a5-9fa1-cc72a140d682/crucible                                                              fb2b6175-e812-4a1a-b50e-55a8870c4a38   in service    none      none          off        
+    oxp_3efc84af-8a54-4006-8323-4a752e91c049/crucible                                                              9b70a45a-5901-4bd5-a821-b06ba5a25b39   in service    none      none          off        
+    oxp_5f86efdc-a0cf-404c-88af-c878ae6dfdf4/crucible                                                              9e38b1ba-354d-4528-b61b-3db3ac4814e6   in service    none      none          off        
+    oxp_981c69c9-f4f5-4423-bbbc-4578282d53e2/crucible                                                              d5611d9e-3bdd-435e-972f-1fb618a4b8ae   in service    none      none          off        
+    oxp_c6d33b64-fb96-4129-bab1-7878a06a5f9b/crucible                                                              45b9d4b3-aca7-4b88-9165-2b94e4b6bbbd   in service    none      none          off        
+    oxp_d8305049-7ee6-4895-a2cb-f63868dae12d/crucible                                                              d4ddb5dd-affa-4f78-97fb-4a6579277fa1   in service    none      none          off        
+    oxp_e36f7294-8191-4d79-a791-44f2ec37a5ca/crucible                                                              9d33acef-e0f7-4e6c-bcaf-fc2eb79d4c26   in service    none      none          off        
+    oxp_e4d937e1-6ddc-4eca-bb08-c1f73791e608/crucible                                                              f1ef5a95-f2cf-4ec7-90d6-25b628fbe019   in service    none      none          off        
+    oxp_f09e1f43-f474-423e-8884-c8fa31cf6b60/crucible                                                              29b2c25e-dce4-4195-8c8f-82368fdddff0   in service    none      none          off        
+    oxp_f355a206-1299-4ef3-9f8f-1a47459160dc/crucible                                                              b206319c-0e91-456d-aa4f-e1632794e1bb   in service    none      none          off        
+    oxp_073979dd-3248-44a5-9fa1-cc72a140d682/crypt/clickhouse                                                      d3cd3ec4-703f-4e73-8cc2-b4bc19c7d596   in service    none      none          off        
+    oxp_073979dd-3248-44a5-9fa1-cc72a140d682/crypt/external_dns                                                    f3ddb3ca-388d-4462-9fc8-e552cf7de668   in service    none      none          off        
+    oxp_3efc84af-8a54-4006-8323-4a752e91c049/crypt/external_dns                                                    dd1954a2-7848-4950-a694-38870c339d3e   in service    none      none          off        
+    oxp_5f86efdc-a0cf-404c-88af-c878ae6dfdf4/crypt/external_dns                                                    32bb65ae-855f-461b-9203-32b2ddfe5a64   in service    none      none          off        
+    oxp_073979dd-3248-44a5-9fa1-cc72a140d682/crypt/internal_dns                                                    c7e90d9c-22db-43ca-a602-2a295bac7eec   in service    none      none          off        
+    oxp_3efc84af-8a54-4006-8323-4a752e91c049/crypt/internal_dns                                                    bef875a9-3cf1-4b02-9682-c0286fb23d4d   in service    none      none          off        
+    oxp_5f86efdc-a0cf-404c-88af-c878ae6dfdf4/crypt/internal_dns                                                    f822a7e2-28aa-4ae2-ba86-d4e552a15bcb   in service    none      none          off        
+    oxp_073979dd-3248-44a5-9fa1-cc72a140d682/crypt/zone                                                            e4b83186-c6e2-4d33-ae1b-803c32d1a86e   in service    none      none          off        
+    oxp_3efc84af-8a54-4006-8323-4a752e91c049/crypt/zone                                                            f306ebde-464c-49ef-94eb-1d72cf9afc7e   in service    none      none          off        
+    oxp_5f86efdc-a0cf-404c-88af-c878ae6dfdf4/crypt/zone                                                            20cb5d98-bcd7-4a11-9190-7570a0aa6fe0   in service    none      none          off        
+    oxp_981c69c9-f4f5-4423-bbbc-4578282d53e2/crypt/zone                                                            2aeeb036-0e23-419f-82f7-9ab04c06d7ec   in service    none      none          off        
+    oxp_c6d33b64-fb96-4129-bab1-7878a06a5f9b/crypt/zone                                                            aa860565-2bbb-4a70-ae8e-7d8f29f1a536   in service    none      none          off        
+    oxp_d8305049-7ee6-4895-a2cb-f63868dae12d/crypt/zone                                                            53e5b466-aac5-4cf0-a93b-9f68f58ac755   in service    none      none          off        
+    oxp_e36f7294-8191-4d79-a791-44f2ec37a5ca/crypt/zone                                                            ac802759-2ac3-4c5c-b8e7-6d51689e1537   in service    none      none          off        
+    oxp_e4d937e1-6ddc-4eca-bb08-c1f73791e608/crypt/zone                                                            6b672182-6d17-41d5-81d7-19debe7d3f9b   in service    none      none          off        
+    oxp_f09e1f43-f474-423e-8884-c8fa31cf6b60/crypt/zone                                                            b1007e3d-7aaf-4ccb-9773-241dcbf79b21   in service    none      none          off        
+    oxp_f355a206-1299-4ef3-9f8f-1a47459160dc/crypt/zone                                                            66788e15-bb3a-4369-a5cb-3357f7b85f64   in service    none      none          off        
+    oxp_073979dd-3248-44a5-9fa1-cc72a140d682/crypt/zone/oxz_clickhouse_10676bfe-b61f-40e1-bc07-a4cb76ea1f30        49dc7c86-c865-457f-8d58-37b92b002691   in service    none      none          off        
+    oxp_f09e1f43-f474-423e-8884-c8fa31cf6b60/crypt/zone/oxz_crucible_2470c0fb-7af3-4b6b-8db3-424e4c297bd9          9fd6854b-5144-4d4a-b575-5e22050b04d6   in service    none      none          off        
+    oxp_981c69c9-f4f5-4423-bbbc-4578282d53e2/crypt/zone/oxz_crucible_289a6d4b-ddfe-4101-9715-6693398704f2          c0399553-58e7-4e51-a7b3-556211309dc5   in service    none      none          off        
+    oxp_e4d937e1-6ddc-4eca-bb08-c1f73791e608/crypt/zone/oxz_crucible_2a063d42-9caf-4364-b099-c7c302c87cdd          f01f9303-448a-4050-9841-f6681f05ae0f   in service    none      none          off        
+    oxp_e36f7294-8191-4d79-a791-44f2ec37a5ca/crypt/zone/oxz_crucible_2dcb07a4-b9cc-4ae6-9119-ccd241acbf3a          a5c85a9b-8fe8-4ad6-9bae-fbb04ff13807   in service    none      none          off        
+    oxp_5f86efdc-a0cf-404c-88af-c878ae6dfdf4/crypt/zone/oxz_crucible_3d9b7487-d7b9-4e25-960f-f2086f3e2919          7176fd89-69a6-401b-8b4b-d80163d522fd   in service    none      none          off        
+    oxp_3efc84af-8a54-4006-8323-4a752e91c049/crypt/zone/oxz_crucible_4b19d194-8b25-4396-88da-3df1b3788601          4c8935c4-1f31-41c6-97a0-1c64d9748e91   in service    none      none          off        
+    oxp_f355a206-1299-4ef3-9f8f-1a47459160dc/crypt/zone/oxz_crucible_bbae1838-0a4c-4489-b141-5aff19c2f277          1abeb2b2-f387-4c31-8c8e-55786ce40fe2   in service    none      none          off        
+    oxp_073979dd-3248-44a5-9fa1-cc72a140d682/crypt/zone/oxz_crucible_c204730a-0946-4793-a470-64c88e89da96          b6afb646-131e-4778-8d80-27f059ba01c2   in service    none      none          off        
+    oxp_d8305049-7ee6-4895-a2cb-f63868dae12d/crypt/zone/oxz_crucible_e0075607-793a-4348-a808-84a9dbe3e841          27caffd0-464c-47b8-8b3c-adc62a76529f   in service    none      none          off        
+    oxp_c6d33b64-fb96-4129-bab1-7878a06a5f9b/crypt/zone/oxz_crucible_edce5918-6d13-4cde-9d64-54e00f4c09e6          5019131f-9456-4c96-b53a-08dfce9bf8ee   in service    none      none          off        
+    oxp_5f86efdc-a0cf-404c-88af-c878ae6dfdf4/crypt/zone/oxz_crucible_pantry_2de1c525-4e04-4ba6-ac6b-377aaa542f96   08662183-4261-47b3-a2e0-e12229f378b7   in service    none      none          off        
+    oxp_073979dd-3248-44a5-9fa1-cc72a140d682/crypt/zone/oxz_crucible_pantry_31b26053-8b94-4d8c-9e4a-d7d720afe265   6dd64de1-7dd3-492c-830f-d4a4e4c3dda7   in service    none      none          off        
+    oxp_3efc84af-8a54-4006-8323-4a752e91c049/crypt/zone/oxz_crucible_pantry_f87ada51-4419-4144-86a8-e5e4ff0f64d3   056f6da7-b92d-4231-b0df-0e8a2c9bce42   in service    none      none          off        
+    oxp_3efc84af-8a54-4006-8323-4a752e91c049/crypt/zone/oxz_external_dns_005548be-c5e4-49ff-a27b-88f314f1bc51      42bd3fb3-2aae-4754-9c41-0f9b50a77322   in service    none      none          off        
+    oxp_5f86efdc-a0cf-404c-88af-c878ae6dfdf4/crypt/zone/oxz_external_dns_2205353a-e1d2-48ff-863b-9d6b1487d474      b7813bc0-d5ee-487d-95ad-6c5cce6fdcd6   in service    none      none          off        
+    oxp_073979dd-3248-44a5-9fa1-cc72a140d682/crypt/zone/oxz_external_dns_70aab480-3d6c-47d5-aaf9-8d2ddab2931c      c6d7ecb4-135c-4f09-8948-b73fec13db76   in service    none      none          off        
+    oxp_3efc84af-8a54-4006-8323-4a752e91c049/crypt/zone/oxz_internal_dns_3fd06852-06cb-4d8a-b4b2-eb88ff5a6035      8355e747-b375-4d9e-b5da-03d9540ab5cd   in service    none      none          off        
+    oxp_073979dd-3248-44a5-9fa1-cc72a140d682/crypt/zone/oxz_internal_dns_45ce130e-c5ac-4e26-ab73-7589ba634418      0c7e4b2a-502a-4f4c-8ac4-4068db25252e   in service    none      none          off        
+    oxp_5f86efdc-a0cf-404c-88af-c878ae6dfdf4/crypt/zone/oxz_internal_dns_a7b7bfbe-0588-4781-9a5e-fba63584e5d2      d4f66eab-2870-4a74-b4d5-ae5da3276682   in service    none      none          off        
+    oxp_5f86efdc-a0cf-404c-88af-c878ae6dfdf4/crypt/zone/oxz_nexus_2bc0b0c4-63a9-44cc-afff-76ce645ef1d4             ebfd425c-4e5d-4385-a105-8f2ce32fa9ec   in service    none      none          off        
+    oxp_3efc84af-8a54-4006-8323-4a752e91c049/crypt/zone/oxz_nexus_3c2cd97f-7b4a-4ff3-a9d5-6ce141fcdbbe             382cbbf2-8b08-4388-839a-b43b8bc82999   in service    none      none          off        
+    oxp_073979dd-3248-44a5-9fa1-cc72a140d682/crypt/zone/oxz_nexus_c2cbbf34-b852-4164-a572-01d4d79445a1             d88eb02f-b66d-4ae7-91a1-23154417c1f1   in service    none      none          off        
+    oxp_073979dd-3248-44a5-9fa1-cc72a140d682/crypt/zone/oxz_ntp_9b135c74-c09a-4dcc-ba19-f6f8deae135a               506ddf0e-8cbf-44a9-93d7-130a550fd42d   in service    none      none          off        
+    oxp_073979dd-3248-44a5-9fa1-cc72a140d682/crypt/debug                                                           38fafd69-0275-4f4d-885d-3bbf2ea77551   in service    100 GiB   none          gzip-9     
+    oxp_3efc84af-8a54-4006-8323-4a752e91c049/crypt/debug                                                           cb8d5371-640d-4364-8a5e-0fde125d28af   in service    100 GiB   none          gzip-9     
+    oxp_5f86efdc-a0cf-404c-88af-c878ae6dfdf4/crypt/debug                                                           ba445402-2775-4f97-87e9-640be3a00c6f   in service    100 GiB   none          gzip-9     
+    oxp_981c69c9-f4f5-4423-bbbc-4578282d53e2/crypt/debug                                                           f4ea4a15-b3b3-4a67-b61a-8fba7c7ab61f   in service    100 GiB   none          gzip-9     
+    oxp_c6d33b64-fb96-4129-bab1-7878a06a5f9b/crypt/debug                                                           4d322f8a-d461-4ead-995b-9ba7d76becad   in service    100 GiB   none          gzip-9     
+    oxp_d8305049-7ee6-4895-a2cb-f63868dae12d/crypt/debug                                                           647f344c-b4c5-4788-a732-40658e852f63   in service    100 GiB   none          gzip-9     
+    oxp_e36f7294-8191-4d79-a791-44f2ec37a5ca/crypt/debug                                                           8144f1ee-dbef-45c1-9397-2031a9ca8b38   in service    100 GiB   none          gzip-9     
+    oxp_e4d937e1-6ddc-4eca-bb08-c1f73791e608/crypt/debug                                                           8b89525f-0764-4937-9fa8-022242647c0f   in service    100 GiB   none          gzip-9     
+    oxp_f09e1f43-f474-423e-8884-c8fa31cf6b60/crypt/debug                                                           3523db58-10ab-4e2c-95d9-fec43036c0f5   in service    100 GiB   none          gzip-9     
+    oxp_f355a206-1299-4ef3-9f8f-1a47459160dc/crypt/debug                                                           d1611973-b22d-4097-b6fd-0a480f2199a5   in service    100 GiB   none          gzip-9     
+
+
+    omicron zones:
+    ---------------------------------------------------------------------------------------------------------------
+    zone type         zone id                                image source      disposition   underlay IP           
+    ---------------------------------------------------------------------------------------------------------------
+    clickhouse        10676bfe-b61f-40e1-bc07-a4cb76ea1f30   install dataset   in service    fd00:1122:3344:101::25
+    crucible          2470c0fb-7af3-4b6b-8db3-424e4c297bd9   install dataset   in service    fd00:1122:3344:101::34
+    crucible          289a6d4b-ddfe-4101-9715-6693398704f2   install dataset   in service    fd00:1122:3344:101::2f
+    crucible          2a063d42-9caf-4364-b099-c7c302c87cdd   install dataset   in service    fd00:1122:3344:101::33
+    crucible          2dcb07a4-b9cc-4ae6-9119-ccd241acbf3a   install dataset   in service    fd00:1122:3344:101::32
+    crucible          3d9b7487-d7b9-4e25-960f-f2086f3e2919   install dataset   in service    fd00:1122:3344:101::2e
+    crucible          4b19d194-8b25-4396-88da-3df1b3788601   install dataset   in service    fd00:1122:3344:101::2d
+    crucible          bbae1838-0a4c-4489-b141-5aff19c2f277   install dataset   in service    fd00:1122:3344:101::35
+    crucible          c204730a-0946-4793-a470-64c88e89da96   install dataset   in service    fd00:1122:3344:101::2c
+    crucible          e0075607-793a-4348-a808-84a9dbe3e841   install dataset   in service    fd00:1122:3344:101::31
+    crucible          edce5918-6d13-4cde-9d64-54e00f4c09e6   install dataset   in service    fd00:1122:3344:101::30
+    crucible_pantry   2de1c525-4e04-4ba6-ac6b-377aaa542f96   install dataset   in service    fd00:1122:3344:101::2b
+    crucible_pantry   31b26053-8b94-4d8c-9e4a-d7d720afe265   install dataset   in service    fd00:1122:3344:101::29
+    crucible_pantry   f87ada51-4419-4144-86a8-e5e4ff0f64d3   install dataset   in service    fd00:1122:3344:101::2a
+    external_dns      005548be-c5e4-49ff-a27b-88f314f1bc51   install dataset   in service    fd00:1122:3344:101::27
+    external_dns      2205353a-e1d2-48ff-863b-9d6b1487d474   install dataset   in service    fd00:1122:3344:101::28
+    external_dns      70aab480-3d6c-47d5-aaf9-8d2ddab2931c   install dataset   in service    fd00:1122:3344:101::26
+    internal_dns      3fd06852-06cb-4d8a-b4b2-eb88ff5a6035   install dataset   in service    fd00:1122:3344:2::1   
+    internal_dns      45ce130e-c5ac-4e26-ab73-7589ba634418   install dataset   in service    fd00:1122:3344:1::1   
+    internal_dns      a7b7bfbe-0588-4781-9a5e-fba63584e5d2   install dataset   in service    fd00:1122:3344:3::1   
+    internal_ntp      9b135c74-c09a-4dcc-ba19-f6f8deae135a   install dataset   in service    fd00:1122:3344:101::21
+    nexus             2bc0b0c4-63a9-44cc-afff-76ce645ef1d4   install dataset   in service    fd00:1122:3344:101::24
+    nexus             3c2cd97f-7b4a-4ff3-a9d5-6ce141fcdbbe   install dataset   in service    fd00:1122:3344:101::23
+    nexus             c2cbbf34-b852-4164-a572-01d4d79445a1   install dataset   in service    fd00:1122:3344:101::22
+
+
+ COCKROACHDB SETTINGS:
+    state fingerprint:::::::::::::::::   (none) (unchanged)
+    cluster.preserve_downgrade_option:   (do not modify) (unchanged)
+
+ METADATA:
+    internal DNS version:::   1 (unchanged)
+    external DNS version:::   1 (unchanged)
+    target release min gen:   1 (unchanged)
+
+ OXIMETER SETTINGS:
+    generation:   1 (unchanged)
+    read from::   SingleNode (unchanged)
+
+
+internal DNS:
+  DNS zone: "control-plane.oxide.internal" (unchanged)
+    name: 005548be-c5e4-49ff-a27b-88f314f1bc51.host          (records: 1)
+        AAAA fd00:1122:3344:101::27
+    name: 10676bfe-b61f-40e1-bc07-a4cb76ea1f30.host          (records: 1)
+        AAAA fd00:1122:3344:101::25
+    name: 2205353a-e1d2-48ff-863b-9d6b1487d474.host          (records: 1)
+        AAAA fd00:1122:3344:101::28
+    name: 2470c0fb-7af3-4b6b-8db3-424e4c297bd9.host          (records: 1)
+        AAAA fd00:1122:3344:101::34
+    name: 289a6d4b-ddfe-4101-9715-6693398704f2.host          (records: 1)
+        AAAA fd00:1122:3344:101::2f
+    name: 2a063d42-9caf-4364-b099-c7c302c87cdd.host          (records: 1)
+        AAAA fd00:1122:3344:101::33
+    name: 2bc0b0c4-63a9-44cc-afff-76ce645ef1d4.host          (records: 1)
+        AAAA fd00:1122:3344:101::24
+    name: 2dcb07a4-b9cc-4ae6-9119-ccd241acbf3a.host          (records: 1)
+        AAAA fd00:1122:3344:101::32
+    name: 2de1c525-4e04-4ba6-ac6b-377aaa542f96.host          (records: 1)
+        AAAA fd00:1122:3344:101::2b
+    name: 31b26053-8b94-4d8c-9e4a-d7d720afe265.host          (records: 1)
+        AAAA fd00:1122:3344:101::29
+    name: 3c2cd97f-7b4a-4ff3-a9d5-6ce141fcdbbe.host          (records: 1)
+        AAAA fd00:1122:3344:101::23
+    name: 3d9b7487-d7b9-4e25-960f-f2086f3e2919.host          (records: 1)
+        AAAA fd00:1122:3344:101::2e
+    name: 3fd06852-06cb-4d8a-b4b2-eb88ff5a6035.host          (records: 1)
+        AAAA fd00:1122:3344:2::1
+    name: 45ce130e-c5ac-4e26-ab73-7589ba634418.host          (records: 1)
+        AAAA fd00:1122:3344:1::1
+    name: 4b19d194-8b25-4396-88da-3df1b3788601.host          (records: 1)
+        AAAA fd00:1122:3344:101::2d
+    name: 70aab480-3d6c-47d5-aaf9-8d2ddab2931c.host          (records: 1)
+        AAAA fd00:1122:3344:101::26
+    name: 98e6b7c2-2efa-41ca-b20a-0a4d61102fe6.sled          (records: 1)
+        AAAA fd00:1122:3344:101::1
+    name: 9b135c74-c09a-4dcc-ba19-f6f8deae135a.host          (records: 1)
+        AAAA fd00:1122:3344:101::21
+    name: @                                                  (records: 3)
+        NS   ns1.control-plane.oxide.internal
+        NS   ns2.control-plane.oxide.internal
+        NS   ns3.control-plane.oxide.internal
+    name: _clickhouse-admin-single-server._tcp               (records: 1)
+        SRV  port  8888 10676bfe-b61f-40e1-bc07-a4cb76ea1f30.host.control-plane.oxide.internal
+    name: _clickhouse-native._tcp                            (records: 1)
+        SRV  port  9000 10676bfe-b61f-40e1-bc07-a4cb76ea1f30.host.control-plane.oxide.internal
+    name: _clickhouse._tcp                                   (records: 1)
+        SRV  port  8123 10676bfe-b61f-40e1-bc07-a4cb76ea1f30.host.control-plane.oxide.internal
+    name: _crucible-pantry._tcp                              (records: 3)
+        SRV  port 17000 2de1c525-4e04-4ba6-ac6b-377aaa542f96.host.control-plane.oxide.internal
+        SRV  port 17000 31b26053-8b94-4d8c-9e4a-d7d720afe265.host.control-plane.oxide.internal
+        SRV  port 17000 f87ada51-4419-4144-86a8-e5e4ff0f64d3.host.control-plane.oxide.internal
+    name: _crucible._tcp.2470c0fb-7af3-4b6b-8db3-424e4c297bd9 (records: 1)
+        SRV  port 32345 2470c0fb-7af3-4b6b-8db3-424e4c297bd9.host.control-plane.oxide.internal
+    name: _crucible._tcp.289a6d4b-ddfe-4101-9715-6693398704f2 (records: 1)
+        SRV  port 32345 289a6d4b-ddfe-4101-9715-6693398704f2.host.control-plane.oxide.internal
+    name: _crucible._tcp.2a063d42-9caf-4364-b099-c7c302c87cdd (records: 1)
+        SRV  port 32345 2a063d42-9caf-4364-b099-c7c302c87cdd.host.control-plane.oxide.internal
+    name: _crucible._tcp.2dcb07a4-b9cc-4ae6-9119-ccd241acbf3a (records: 1)
+        SRV  port 32345 2dcb07a4-b9cc-4ae6-9119-ccd241acbf3a.host.control-plane.oxide.internal
+    name: _crucible._tcp.3d9b7487-d7b9-4e25-960f-f2086f3e2919 (records: 1)
+        SRV  port 32345 3d9b7487-d7b9-4e25-960f-f2086f3e2919.host.control-plane.oxide.internal
+    name: _crucible._tcp.4b19d194-8b25-4396-88da-3df1b3788601 (records: 1)
+        SRV  port 32345 4b19d194-8b25-4396-88da-3df1b3788601.host.control-plane.oxide.internal
+    name: _crucible._tcp.bbae1838-0a4c-4489-b141-5aff19c2f277 (records: 1)
+        SRV  port 32345 bbae1838-0a4c-4489-b141-5aff19c2f277.host.control-plane.oxide.internal
+    name: _crucible._tcp.c204730a-0946-4793-a470-64c88e89da96 (records: 1)
+        SRV  port 32345 c204730a-0946-4793-a470-64c88e89da96.host.control-plane.oxide.internal
+    name: _crucible._tcp.e0075607-793a-4348-a808-84a9dbe3e841 (records: 1)
+        SRV  port 32345 e0075607-793a-4348-a808-84a9dbe3e841.host.control-plane.oxide.internal
+    name: _crucible._tcp.edce5918-6d13-4cde-9d64-54e00f4c09e6 (records: 1)
+        SRV  port 32345 edce5918-6d13-4cde-9d64-54e00f4c09e6.host.control-plane.oxide.internal
+    name: _external-dns._tcp                                 (records: 3)
+        SRV  port  5353 005548be-c5e4-49ff-a27b-88f314f1bc51.host.control-plane.oxide.internal
+        SRV  port  5353 2205353a-e1d2-48ff-863b-9d6b1487d474.host.control-plane.oxide.internal
+        SRV  port  5353 70aab480-3d6c-47d5-aaf9-8d2ddab2931c.host.control-plane.oxide.internal
+    name: _internal-ntp._tcp                                 (records: 1)
+        SRV  port   123 9b135c74-c09a-4dcc-ba19-f6f8deae135a.host.control-plane.oxide.internal
+    name: _nameservice._tcp                                  (records: 3)
+        SRV  port  5353 3fd06852-06cb-4d8a-b4b2-eb88ff5a6035.host.control-plane.oxide.internal
+        SRV  port  5353 45ce130e-c5ac-4e26-ab73-7589ba634418.host.control-plane.oxide.internal
+        SRV  port  5353 a7b7bfbe-0588-4781-9a5e-fba63584e5d2.host.control-plane.oxide.internal
+    name: _nexus._tcp                                        (records: 3)
+        SRV  port 12221 2bc0b0c4-63a9-44cc-afff-76ce645ef1d4.host.control-plane.oxide.internal
+        SRV  port 12221 3c2cd97f-7b4a-4ff3-a9d5-6ce141fcdbbe.host.control-plane.oxide.internal
+        SRV  port 12221 c2cbbf34-b852-4164-a572-01d4d79445a1.host.control-plane.oxide.internal
+    name: _oximeter-reader._tcp                              (records: 1)
+        SRV  port  9000 10676bfe-b61f-40e1-bc07-a4cb76ea1f30.host.control-plane.oxide.internal
+    name: _repo-depot._tcp                                   (records: 1)
+        SRV  port 12348 98e6b7c2-2efa-41ca-b20a-0a4d61102fe6.sled.control-plane.oxide.internal
+    name: a7b7bfbe-0588-4781-9a5e-fba63584e5d2.host          (records: 1)
+        AAAA fd00:1122:3344:3::1
+    name: bbae1838-0a4c-4489-b141-5aff19c2f277.host          (records: 1)
+        AAAA fd00:1122:3344:101::35
+    name: c204730a-0946-4793-a470-64c88e89da96.host          (records: 1)
+        AAAA fd00:1122:3344:101::2c
+    name: c2cbbf34-b852-4164-a572-01d4d79445a1.host          (records: 1)
+        AAAA fd00:1122:3344:101::22
+    name: e0075607-793a-4348-a808-84a9dbe3e841.host          (records: 1)
+        AAAA fd00:1122:3344:101::31
+    name: edce5918-6d13-4cde-9d64-54e00f4c09e6.host          (records: 1)
+        AAAA fd00:1122:3344:101::30
+    name: f87ada51-4419-4144-86a8-e5e4ff0f64d3.host          (records: 1)
+        AAAA fd00:1122:3344:101::2a
+    name: ns1                                                (records: 1)
+        AAAA fd00:1122:3344:1::1
+    name: ns2                                                (records: 1)
+        AAAA fd00:1122:3344:2::1
+    name: ns3                                                (records: 1)
+        AAAA fd00:1122:3344:3::1
+
+external DNS:
+  DNS zone: "oxide.example" (unchanged)
+    name: @                                                  (records: 3)
+        NS   ns1.oxide.example
+        NS   ns2.oxide.example
+        NS   ns3.oxide.example
+    name: example-silo.sys                                   (records: 3)
+        A    192.0.2.4
+        A    192.0.2.3
+        A    192.0.2.2
+    name: ns1                                                (records: 1)
+        A    198.51.100.1
+    name: ns2                                                (records: 1)
+        A    198.51.100.2
+    name: ns3                                                (records: 1)
+        A    198.51.100.3
+
+
+
+
+> blueprint-show latest
+blueprint  df06bb57-ad42-4431-9206-abff322896c7
+parent:    af934083-59b5-4bf6-8966-6fb5292c29e1
+
+  sled: 98e6b7c2-2efa-41ca-b20a-0a4d61102fe6 (active, config generation 6)
+
+    host phase 2 contents:
+    ------------------------
+    slot   boot image source
+    ------------------------
+    A      current contents 
+    B      current contents 
+
+
+    physical disks:
+    ------------------------------------------------------------------------------------
+    vendor        model        serial                                        disposition
+    ------------------------------------------------------------------------------------
+    fake-vendor   fake-model   serial-073979dd-3248-44a5-9fa1-cc72a140d682   in service 
+    fake-vendor   fake-model   serial-3efc84af-8a54-4006-8323-4a752e91c049   in service 
+    fake-vendor   fake-model   serial-5f86efdc-a0cf-404c-88af-c878ae6dfdf4   in service 
+    fake-vendor   fake-model   serial-981c69c9-f4f5-4423-bbbc-4578282d53e2   in service 
+    fake-vendor   fake-model   serial-c6d33b64-fb96-4129-bab1-7878a06a5f9b   in service 
+    fake-vendor   fake-model   serial-d8305049-7ee6-4895-a2cb-f63868dae12d   in service 
+    fake-vendor   fake-model   serial-e36f7294-8191-4d79-a791-44f2ec37a5ca   in service 
+    fake-vendor   fake-model   serial-e4d937e1-6ddc-4eca-bb08-c1f73791e608   in service 
+    fake-vendor   fake-model   serial-f09e1f43-f474-423e-8884-c8fa31cf6b60   in service 
+    fake-vendor   fake-model   serial-f355a206-1299-4ef3-9f8f-1a47459160dc   in service 
+
+
+    datasets:
+    -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
+    dataset name                                                                                                   dataset id                             disposition   quota     reservation   compression
+    -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
+    oxp_073979dd-3248-44a5-9fa1-cc72a140d682/crucible                                                              fb2b6175-e812-4a1a-b50e-55a8870c4a38   in service    none      none          off        
+    oxp_3efc84af-8a54-4006-8323-4a752e91c049/crucible                                                              9b70a45a-5901-4bd5-a821-b06ba5a25b39   in service    none      none          off        
+    oxp_5f86efdc-a0cf-404c-88af-c878ae6dfdf4/crucible                                                              9e38b1ba-354d-4528-b61b-3db3ac4814e6   in service    none      none          off        
+    oxp_981c69c9-f4f5-4423-bbbc-4578282d53e2/crucible                                                              d5611d9e-3bdd-435e-972f-1fb618a4b8ae   in service    none      none          off        
+    oxp_c6d33b64-fb96-4129-bab1-7878a06a5f9b/crucible                                                              45b9d4b3-aca7-4b88-9165-2b94e4b6bbbd   in service    none      none          off        
+    oxp_d8305049-7ee6-4895-a2cb-f63868dae12d/crucible                                                              d4ddb5dd-affa-4f78-97fb-4a6579277fa1   in service    none      none          off        
+    oxp_e36f7294-8191-4d79-a791-44f2ec37a5ca/crucible                                                              9d33acef-e0f7-4e6c-bcaf-fc2eb79d4c26   in service    none      none          off        
+    oxp_e4d937e1-6ddc-4eca-bb08-c1f73791e608/crucible                                                              f1ef5a95-f2cf-4ec7-90d6-25b628fbe019   in service    none      none          off        
+    oxp_f09e1f43-f474-423e-8884-c8fa31cf6b60/crucible                                                              29b2c25e-dce4-4195-8c8f-82368fdddff0   in service    none      none          off        
+    oxp_f355a206-1299-4ef3-9f8f-1a47459160dc/crucible                                                              b206319c-0e91-456d-aa4f-e1632794e1bb   in service    none      none          off        
+    oxp_073979dd-3248-44a5-9fa1-cc72a140d682/crypt/clickhouse                                                      d3cd3ec4-703f-4e73-8cc2-b4bc19c7d596   in service    none      none          off        
+    oxp_073979dd-3248-44a5-9fa1-cc72a140d682/crypt/external_dns                                                    f3ddb3ca-388d-4462-9fc8-e552cf7de668   in service    none      none          off        
+    oxp_3efc84af-8a54-4006-8323-4a752e91c049/crypt/external_dns                                                    dd1954a2-7848-4950-a694-38870c339d3e   in service    none      none          off        
+    oxp_5f86efdc-a0cf-404c-88af-c878ae6dfdf4/crypt/external_dns                                                    32bb65ae-855f-461b-9203-32b2ddfe5a64   in service    none      none          off        
+    oxp_073979dd-3248-44a5-9fa1-cc72a140d682/crypt/internal_dns                                                    c7e90d9c-22db-43ca-a602-2a295bac7eec   in service    none      none          off        
+    oxp_3efc84af-8a54-4006-8323-4a752e91c049/crypt/internal_dns                                                    bef875a9-3cf1-4b02-9682-c0286fb23d4d   in service    none      none          off        
+    oxp_5f86efdc-a0cf-404c-88af-c878ae6dfdf4/crypt/internal_dns                                                    f822a7e2-28aa-4ae2-ba86-d4e552a15bcb   in service    none      none          off        
+    oxp_073979dd-3248-44a5-9fa1-cc72a140d682/crypt/zone                                                            e4b83186-c6e2-4d33-ae1b-803c32d1a86e   in service    none      none          off        
+    oxp_3efc84af-8a54-4006-8323-4a752e91c049/crypt/zone                                                            f306ebde-464c-49ef-94eb-1d72cf9afc7e   in service    none      none          off        
+    oxp_5f86efdc-a0cf-404c-88af-c878ae6dfdf4/crypt/zone                                                            20cb5d98-bcd7-4a11-9190-7570a0aa6fe0   in service    none      none          off        
+    oxp_981c69c9-f4f5-4423-bbbc-4578282d53e2/crypt/zone                                                            2aeeb036-0e23-419f-82f7-9ab04c06d7ec   in service    none      none          off        
+    oxp_c6d33b64-fb96-4129-bab1-7878a06a5f9b/crypt/zone                                                            aa860565-2bbb-4a70-ae8e-7d8f29f1a536   in service    none      none          off        
+    oxp_d8305049-7ee6-4895-a2cb-f63868dae12d/crypt/zone                                                            53e5b466-aac5-4cf0-a93b-9f68f58ac755   in service    none      none          off        
+    oxp_e36f7294-8191-4d79-a791-44f2ec37a5ca/crypt/zone                                                            ac802759-2ac3-4c5c-b8e7-6d51689e1537   in service    none      none          off        
+    oxp_e4d937e1-6ddc-4eca-bb08-c1f73791e608/crypt/zone                                                            6b672182-6d17-41d5-81d7-19debe7d3f9b   in service    none      none          off        
+    oxp_f09e1f43-f474-423e-8884-c8fa31cf6b60/crypt/zone                                                            b1007e3d-7aaf-4ccb-9773-241dcbf79b21   in service    none      none          off        
+    oxp_f355a206-1299-4ef3-9f8f-1a47459160dc/crypt/zone                                                            66788e15-bb3a-4369-a5cb-3357f7b85f64   in service    none      none          off        
+    oxp_073979dd-3248-44a5-9fa1-cc72a140d682/crypt/zone/oxz_clickhouse_10676bfe-b61f-40e1-bc07-a4cb76ea1f30        49dc7c86-c865-457f-8d58-37b92b002691   in service    none      none          off        
+    oxp_f09e1f43-f474-423e-8884-c8fa31cf6b60/crypt/zone/oxz_crucible_2470c0fb-7af3-4b6b-8db3-424e4c297bd9          9fd6854b-5144-4d4a-b575-5e22050b04d6   in service    none      none          off        
+    oxp_981c69c9-f4f5-4423-bbbc-4578282d53e2/crypt/zone/oxz_crucible_289a6d4b-ddfe-4101-9715-6693398704f2          c0399553-58e7-4e51-a7b3-556211309dc5   in service    none      none          off        
+    oxp_e4d937e1-6ddc-4eca-bb08-c1f73791e608/crypt/zone/oxz_crucible_2a063d42-9caf-4364-b099-c7c302c87cdd          f01f9303-448a-4050-9841-f6681f05ae0f   in service    none      none          off        
+    oxp_e36f7294-8191-4d79-a791-44f2ec37a5ca/crypt/zone/oxz_crucible_2dcb07a4-b9cc-4ae6-9119-ccd241acbf3a          a5c85a9b-8fe8-4ad6-9bae-fbb04ff13807   in service    none      none          off        
+    oxp_5f86efdc-a0cf-404c-88af-c878ae6dfdf4/crypt/zone/oxz_crucible_3d9b7487-d7b9-4e25-960f-f2086f3e2919          7176fd89-69a6-401b-8b4b-d80163d522fd   in service    none      none          off        
+    oxp_3efc84af-8a54-4006-8323-4a752e91c049/crypt/zone/oxz_crucible_4b19d194-8b25-4396-88da-3df1b3788601          4c8935c4-1f31-41c6-97a0-1c64d9748e91   in service    none      none          off        
+    oxp_f355a206-1299-4ef3-9f8f-1a47459160dc/crypt/zone/oxz_crucible_bbae1838-0a4c-4489-b141-5aff19c2f277          1abeb2b2-f387-4c31-8c8e-55786ce40fe2   in service    none      none          off        
+    oxp_073979dd-3248-44a5-9fa1-cc72a140d682/crypt/zone/oxz_crucible_c204730a-0946-4793-a470-64c88e89da96          b6afb646-131e-4778-8d80-27f059ba01c2   in service    none      none          off        
+    oxp_d8305049-7ee6-4895-a2cb-f63868dae12d/crypt/zone/oxz_crucible_e0075607-793a-4348-a808-84a9dbe3e841          27caffd0-464c-47b8-8b3c-adc62a76529f   in service    none      none          off        
+    oxp_c6d33b64-fb96-4129-bab1-7878a06a5f9b/crypt/zone/oxz_crucible_edce5918-6d13-4cde-9d64-54e00f4c09e6          5019131f-9456-4c96-b53a-08dfce9bf8ee   in service    none      none          off        
+    oxp_5f86efdc-a0cf-404c-88af-c878ae6dfdf4/crypt/zone/oxz_crucible_pantry_2de1c525-4e04-4ba6-ac6b-377aaa542f96   08662183-4261-47b3-a2e0-e12229f378b7   in service    none      none          off        
+    oxp_073979dd-3248-44a5-9fa1-cc72a140d682/crypt/zone/oxz_crucible_pantry_31b26053-8b94-4d8c-9e4a-d7d720afe265   6dd64de1-7dd3-492c-830f-d4a4e4c3dda7   in service    none      none          off        
+    oxp_3efc84af-8a54-4006-8323-4a752e91c049/crypt/zone/oxz_crucible_pantry_f87ada51-4419-4144-86a8-e5e4ff0f64d3   056f6da7-b92d-4231-b0df-0e8a2c9bce42   in service    none      none          off        
+    oxp_3efc84af-8a54-4006-8323-4a752e91c049/crypt/zone/oxz_external_dns_005548be-c5e4-49ff-a27b-88f314f1bc51      42bd3fb3-2aae-4754-9c41-0f9b50a77322   in service    none      none          off        
+    oxp_5f86efdc-a0cf-404c-88af-c878ae6dfdf4/crypt/zone/oxz_external_dns_2205353a-e1d2-48ff-863b-9d6b1487d474      b7813bc0-d5ee-487d-95ad-6c5cce6fdcd6   in service    none      none          off        
+    oxp_073979dd-3248-44a5-9fa1-cc72a140d682/crypt/zone/oxz_external_dns_70aab480-3d6c-47d5-aaf9-8d2ddab2931c      c6d7ecb4-135c-4f09-8948-b73fec13db76   in service    none      none          off        
+    oxp_3efc84af-8a54-4006-8323-4a752e91c049/crypt/zone/oxz_internal_dns_3fd06852-06cb-4d8a-b4b2-eb88ff5a6035      8355e747-b375-4d9e-b5da-03d9540ab5cd   in service    none      none          off        
+    oxp_073979dd-3248-44a5-9fa1-cc72a140d682/crypt/zone/oxz_internal_dns_45ce130e-c5ac-4e26-ab73-7589ba634418      0c7e4b2a-502a-4f4c-8ac4-4068db25252e   in service    none      none          off        
+    oxp_5f86efdc-a0cf-404c-88af-c878ae6dfdf4/crypt/zone/oxz_internal_dns_a7b7bfbe-0588-4781-9a5e-fba63584e5d2      d4f66eab-2870-4a74-b4d5-ae5da3276682   in service    none      none          off        
+    oxp_5f86efdc-a0cf-404c-88af-c878ae6dfdf4/crypt/zone/oxz_nexus_2bc0b0c4-63a9-44cc-afff-76ce645ef1d4             ebfd425c-4e5d-4385-a105-8f2ce32fa9ec   in service    none      none          off        
+    oxp_3efc84af-8a54-4006-8323-4a752e91c049/crypt/zone/oxz_nexus_3c2cd97f-7b4a-4ff3-a9d5-6ce141fcdbbe             382cbbf2-8b08-4388-839a-b43b8bc82999   in service    none      none          off        
+    oxp_073979dd-3248-44a5-9fa1-cc72a140d682/crypt/zone/oxz_nexus_c2cbbf34-b852-4164-a572-01d4d79445a1             d88eb02f-b66d-4ae7-91a1-23154417c1f1   in service    none      none          off        
+    oxp_073979dd-3248-44a5-9fa1-cc72a140d682/crypt/zone/oxz_ntp_9b135c74-c09a-4dcc-ba19-f6f8deae135a               506ddf0e-8cbf-44a9-93d7-130a550fd42d   in service    none      none          off        
+    oxp_073979dd-3248-44a5-9fa1-cc72a140d682/crypt/debug                                                           38fafd69-0275-4f4d-885d-3bbf2ea77551   in service    100 GiB   none          gzip-9     
+    oxp_3efc84af-8a54-4006-8323-4a752e91c049/crypt/debug                                                           cb8d5371-640d-4364-8a5e-0fde125d28af   in service    100 GiB   none          gzip-9     
+    oxp_5f86efdc-a0cf-404c-88af-c878ae6dfdf4/crypt/debug                                                           ba445402-2775-4f97-87e9-640be3a00c6f   in service    100 GiB   none          gzip-9     
+    oxp_981c69c9-f4f5-4423-bbbc-4578282d53e2/crypt/debug                                                           f4ea4a15-b3b3-4a67-b61a-8fba7c7ab61f   in service    100 GiB   none          gzip-9     
+    oxp_c6d33b64-fb96-4129-bab1-7878a06a5f9b/crypt/debug                                                           4d322f8a-d461-4ead-995b-9ba7d76becad   in service    100 GiB   none          gzip-9     
+    oxp_d8305049-7ee6-4895-a2cb-f63868dae12d/crypt/debug                                                           647f344c-b4c5-4788-a732-40658e852f63   in service    100 GiB   none          gzip-9     
+    oxp_e36f7294-8191-4d79-a791-44f2ec37a5ca/crypt/debug                                                           8144f1ee-dbef-45c1-9397-2031a9ca8b38   in service    100 GiB   none          gzip-9     
+    oxp_e4d937e1-6ddc-4eca-bb08-c1f73791e608/crypt/debug                                                           8b89525f-0764-4937-9fa8-022242647c0f   in service    100 GiB   none          gzip-9     
+    oxp_f09e1f43-f474-423e-8884-c8fa31cf6b60/crypt/debug                                                           3523db58-10ab-4e2c-95d9-fec43036c0f5   in service    100 GiB   none          gzip-9     
+    oxp_f355a206-1299-4ef3-9f8f-1a47459160dc/crypt/debug                                                           d1611973-b22d-4097-b6fd-0a480f2199a5   in service    100 GiB   none          gzip-9     
+
+
+    omicron zones:
+    ---------------------------------------------------------------------------------------------------------------
+    zone type         zone id                                image source      disposition   underlay IP           
+    ---------------------------------------------------------------------------------------------------------------
+    clickhouse        10676bfe-b61f-40e1-bc07-a4cb76ea1f30   install dataset   in service    fd00:1122:3344:101::25
+    crucible          2470c0fb-7af3-4b6b-8db3-424e4c297bd9   install dataset   in service    fd00:1122:3344:101::34
+    crucible          289a6d4b-ddfe-4101-9715-6693398704f2   install dataset   in service    fd00:1122:3344:101::2f
+    crucible          2a063d42-9caf-4364-b099-c7c302c87cdd   install dataset   in service    fd00:1122:3344:101::33
+    crucible          2dcb07a4-b9cc-4ae6-9119-ccd241acbf3a   install dataset   in service    fd00:1122:3344:101::32
+    crucible          3d9b7487-d7b9-4e25-960f-f2086f3e2919   install dataset   in service    fd00:1122:3344:101::2e
+    crucible          4b19d194-8b25-4396-88da-3df1b3788601   install dataset   in service    fd00:1122:3344:101::2d
+    crucible          bbae1838-0a4c-4489-b141-5aff19c2f277   install dataset   in service    fd00:1122:3344:101::35
+    crucible          c204730a-0946-4793-a470-64c88e89da96   install dataset   in service    fd00:1122:3344:101::2c
+    crucible          e0075607-793a-4348-a808-84a9dbe3e841   install dataset   in service    fd00:1122:3344:101::31
+    crucible          edce5918-6d13-4cde-9d64-54e00f4c09e6   install dataset   in service    fd00:1122:3344:101::30
+    crucible_pantry   2de1c525-4e04-4ba6-ac6b-377aaa542f96   install dataset   in service    fd00:1122:3344:101::2b
+    crucible_pantry   31b26053-8b94-4d8c-9e4a-d7d720afe265   install dataset   in service    fd00:1122:3344:101::29
+    crucible_pantry   f87ada51-4419-4144-86a8-e5e4ff0f64d3   install dataset   in service    fd00:1122:3344:101::2a
+    external_dns      005548be-c5e4-49ff-a27b-88f314f1bc51   install dataset   in service    fd00:1122:3344:101::27
+    external_dns      2205353a-e1d2-48ff-863b-9d6b1487d474   install dataset   in service    fd00:1122:3344:101::28
+    external_dns      70aab480-3d6c-47d5-aaf9-8d2ddab2931c   install dataset   in service    fd00:1122:3344:101::26
+    internal_dns      3fd06852-06cb-4d8a-b4b2-eb88ff5a6035   install dataset   in service    fd00:1122:3344:2::1   
+    internal_dns      45ce130e-c5ac-4e26-ab73-7589ba634418   install dataset   in service    fd00:1122:3344:1::1   
+    internal_dns      a7b7bfbe-0588-4781-9a5e-fba63584e5d2   install dataset   in service    fd00:1122:3344:3::1   
+    internal_ntp      9b135c74-c09a-4dcc-ba19-f6f8deae135a   install dataset   in service    fd00:1122:3344:101::21
+    nexus             2bc0b0c4-63a9-44cc-afff-76ce645ef1d4   install dataset   in service    fd00:1122:3344:101::24
+    nexus             3c2cd97f-7b4a-4ff3-a9d5-6ce141fcdbbe   install dataset   in service    fd00:1122:3344:101::23
+    nexus             c2cbbf34-b852-4164-a572-01d4d79445a1   install dataset   in service    fd00:1122:3344:101::22
+
+
+ COCKROACHDB SETTINGS:
+    state fingerprint:::::::::::::::::   (none)
+    cluster.preserve_downgrade_option:   (do not modify)
+
+ OXIMETER SETTINGS:
+    generation:   1
+    read from::   SingleNode
+
+ METADATA:
+    created by:::::::::::::   reconfigurator-cli
+    created at:::::::::::::   <REDACTED_TIMESTAMP>
+    comment::::::::::::::::   (none)
+    internal DNS version:::   1
+    external DNS version:::   1
+    target release min gen:   1
+
+ PENDING MGS-MANAGED UPDATES: 0
+
+

--- a/dev-tools/reconfigurator-cli/tests/output/cmds-host-phase-2-source-stdout
+++ b/dev-tools/reconfigurator-cli/tests/output/cmds-host-phase-2-source-stdout
@@ -567,7 +567,154 @@ external DNS:
 
 
 
-> # Restore both to "current contents"
+> blueprint-show latest
+blueprint  58d5e830-0884-47d8-a7cd-b2b3751adeb4
+parent:    8da82a8e-bf97-4fbd-8ddd-9f6462732cf1
+
+  sled: 98e6b7c2-2efa-41ca-b20a-0a4d61102fe6 (active, config generation 4)
+
+    host phase 2 contents:
+    ------------------------------
+    slot   boot image source      
+    ------------------------------
+    A      artifact: version 1.0.0
+    B      artifact: version 2.0.0
+
+
+    physical disks:
+    ------------------------------------------------------------------------------------
+    vendor        model        serial                                        disposition
+    ------------------------------------------------------------------------------------
+    fake-vendor   fake-model   serial-073979dd-3248-44a5-9fa1-cc72a140d682   in service 
+    fake-vendor   fake-model   serial-3efc84af-8a54-4006-8323-4a752e91c049   in service 
+    fake-vendor   fake-model   serial-5f86efdc-a0cf-404c-88af-c878ae6dfdf4   in service 
+    fake-vendor   fake-model   serial-981c69c9-f4f5-4423-bbbc-4578282d53e2   in service 
+    fake-vendor   fake-model   serial-c6d33b64-fb96-4129-bab1-7878a06a5f9b   in service 
+    fake-vendor   fake-model   serial-d8305049-7ee6-4895-a2cb-f63868dae12d   in service 
+    fake-vendor   fake-model   serial-e36f7294-8191-4d79-a791-44f2ec37a5ca   in service 
+    fake-vendor   fake-model   serial-e4d937e1-6ddc-4eca-bb08-c1f73791e608   in service 
+    fake-vendor   fake-model   serial-f09e1f43-f474-423e-8884-c8fa31cf6b60   in service 
+    fake-vendor   fake-model   serial-f355a206-1299-4ef3-9f8f-1a47459160dc   in service 
+
+
+    datasets:
+    -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
+    dataset name                                                                                                   dataset id                             disposition   quota     reservation   compression
+    -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
+    oxp_073979dd-3248-44a5-9fa1-cc72a140d682/crucible                                                              fb2b6175-e812-4a1a-b50e-55a8870c4a38   in service    none      none          off        
+    oxp_3efc84af-8a54-4006-8323-4a752e91c049/crucible                                                              9b70a45a-5901-4bd5-a821-b06ba5a25b39   in service    none      none          off        
+    oxp_5f86efdc-a0cf-404c-88af-c878ae6dfdf4/crucible                                                              9e38b1ba-354d-4528-b61b-3db3ac4814e6   in service    none      none          off        
+    oxp_981c69c9-f4f5-4423-bbbc-4578282d53e2/crucible                                                              d5611d9e-3bdd-435e-972f-1fb618a4b8ae   in service    none      none          off        
+    oxp_c6d33b64-fb96-4129-bab1-7878a06a5f9b/crucible                                                              45b9d4b3-aca7-4b88-9165-2b94e4b6bbbd   in service    none      none          off        
+    oxp_d8305049-7ee6-4895-a2cb-f63868dae12d/crucible                                                              d4ddb5dd-affa-4f78-97fb-4a6579277fa1   in service    none      none          off        
+    oxp_e36f7294-8191-4d79-a791-44f2ec37a5ca/crucible                                                              9d33acef-e0f7-4e6c-bcaf-fc2eb79d4c26   in service    none      none          off        
+    oxp_e4d937e1-6ddc-4eca-bb08-c1f73791e608/crucible                                                              f1ef5a95-f2cf-4ec7-90d6-25b628fbe019   in service    none      none          off        
+    oxp_f09e1f43-f474-423e-8884-c8fa31cf6b60/crucible                                                              29b2c25e-dce4-4195-8c8f-82368fdddff0   in service    none      none          off        
+    oxp_f355a206-1299-4ef3-9f8f-1a47459160dc/crucible                                                              b206319c-0e91-456d-aa4f-e1632794e1bb   in service    none      none          off        
+    oxp_073979dd-3248-44a5-9fa1-cc72a140d682/crypt/clickhouse                                                      d3cd3ec4-703f-4e73-8cc2-b4bc19c7d596   in service    none      none          off        
+    oxp_073979dd-3248-44a5-9fa1-cc72a140d682/crypt/external_dns                                                    f3ddb3ca-388d-4462-9fc8-e552cf7de668   in service    none      none          off        
+    oxp_3efc84af-8a54-4006-8323-4a752e91c049/crypt/external_dns                                                    dd1954a2-7848-4950-a694-38870c339d3e   in service    none      none          off        
+    oxp_5f86efdc-a0cf-404c-88af-c878ae6dfdf4/crypt/external_dns                                                    32bb65ae-855f-461b-9203-32b2ddfe5a64   in service    none      none          off        
+    oxp_073979dd-3248-44a5-9fa1-cc72a140d682/crypt/internal_dns                                                    c7e90d9c-22db-43ca-a602-2a295bac7eec   in service    none      none          off        
+    oxp_3efc84af-8a54-4006-8323-4a752e91c049/crypt/internal_dns                                                    bef875a9-3cf1-4b02-9682-c0286fb23d4d   in service    none      none          off        
+    oxp_5f86efdc-a0cf-404c-88af-c878ae6dfdf4/crypt/internal_dns                                                    f822a7e2-28aa-4ae2-ba86-d4e552a15bcb   in service    none      none          off        
+    oxp_073979dd-3248-44a5-9fa1-cc72a140d682/crypt/zone                                                            e4b83186-c6e2-4d33-ae1b-803c32d1a86e   in service    none      none          off        
+    oxp_3efc84af-8a54-4006-8323-4a752e91c049/crypt/zone                                                            f306ebde-464c-49ef-94eb-1d72cf9afc7e   in service    none      none          off        
+    oxp_5f86efdc-a0cf-404c-88af-c878ae6dfdf4/crypt/zone                                                            20cb5d98-bcd7-4a11-9190-7570a0aa6fe0   in service    none      none          off        
+    oxp_981c69c9-f4f5-4423-bbbc-4578282d53e2/crypt/zone                                                            2aeeb036-0e23-419f-82f7-9ab04c06d7ec   in service    none      none          off        
+    oxp_c6d33b64-fb96-4129-bab1-7878a06a5f9b/crypt/zone                                                            aa860565-2bbb-4a70-ae8e-7d8f29f1a536   in service    none      none          off        
+    oxp_d8305049-7ee6-4895-a2cb-f63868dae12d/crypt/zone                                                            53e5b466-aac5-4cf0-a93b-9f68f58ac755   in service    none      none          off        
+    oxp_e36f7294-8191-4d79-a791-44f2ec37a5ca/crypt/zone                                                            ac802759-2ac3-4c5c-b8e7-6d51689e1537   in service    none      none          off        
+    oxp_e4d937e1-6ddc-4eca-bb08-c1f73791e608/crypt/zone                                                            6b672182-6d17-41d5-81d7-19debe7d3f9b   in service    none      none          off        
+    oxp_f09e1f43-f474-423e-8884-c8fa31cf6b60/crypt/zone                                                            b1007e3d-7aaf-4ccb-9773-241dcbf79b21   in service    none      none          off        
+    oxp_f355a206-1299-4ef3-9f8f-1a47459160dc/crypt/zone                                                            66788e15-bb3a-4369-a5cb-3357f7b85f64   in service    none      none          off        
+    oxp_073979dd-3248-44a5-9fa1-cc72a140d682/crypt/zone/oxz_clickhouse_10676bfe-b61f-40e1-bc07-a4cb76ea1f30        49dc7c86-c865-457f-8d58-37b92b002691   in service    none      none          off        
+    oxp_f09e1f43-f474-423e-8884-c8fa31cf6b60/crypt/zone/oxz_crucible_2470c0fb-7af3-4b6b-8db3-424e4c297bd9          9fd6854b-5144-4d4a-b575-5e22050b04d6   in service    none      none          off        
+    oxp_981c69c9-f4f5-4423-bbbc-4578282d53e2/crypt/zone/oxz_crucible_289a6d4b-ddfe-4101-9715-6693398704f2          c0399553-58e7-4e51-a7b3-556211309dc5   in service    none      none          off        
+    oxp_e4d937e1-6ddc-4eca-bb08-c1f73791e608/crypt/zone/oxz_crucible_2a063d42-9caf-4364-b099-c7c302c87cdd          f01f9303-448a-4050-9841-f6681f05ae0f   in service    none      none          off        
+    oxp_e36f7294-8191-4d79-a791-44f2ec37a5ca/crypt/zone/oxz_crucible_2dcb07a4-b9cc-4ae6-9119-ccd241acbf3a          a5c85a9b-8fe8-4ad6-9bae-fbb04ff13807   in service    none      none          off        
+    oxp_5f86efdc-a0cf-404c-88af-c878ae6dfdf4/crypt/zone/oxz_crucible_3d9b7487-d7b9-4e25-960f-f2086f3e2919          7176fd89-69a6-401b-8b4b-d80163d522fd   in service    none      none          off        
+    oxp_3efc84af-8a54-4006-8323-4a752e91c049/crypt/zone/oxz_crucible_4b19d194-8b25-4396-88da-3df1b3788601          4c8935c4-1f31-41c6-97a0-1c64d9748e91   in service    none      none          off        
+    oxp_f355a206-1299-4ef3-9f8f-1a47459160dc/crypt/zone/oxz_crucible_bbae1838-0a4c-4489-b141-5aff19c2f277          1abeb2b2-f387-4c31-8c8e-55786ce40fe2   in service    none      none          off        
+    oxp_073979dd-3248-44a5-9fa1-cc72a140d682/crypt/zone/oxz_crucible_c204730a-0946-4793-a470-64c88e89da96          b6afb646-131e-4778-8d80-27f059ba01c2   in service    none      none          off        
+    oxp_d8305049-7ee6-4895-a2cb-f63868dae12d/crypt/zone/oxz_crucible_e0075607-793a-4348-a808-84a9dbe3e841          27caffd0-464c-47b8-8b3c-adc62a76529f   in service    none      none          off        
+    oxp_c6d33b64-fb96-4129-bab1-7878a06a5f9b/crypt/zone/oxz_crucible_edce5918-6d13-4cde-9d64-54e00f4c09e6          5019131f-9456-4c96-b53a-08dfce9bf8ee   in service    none      none          off        
+    oxp_5f86efdc-a0cf-404c-88af-c878ae6dfdf4/crypt/zone/oxz_crucible_pantry_2de1c525-4e04-4ba6-ac6b-377aaa542f96   08662183-4261-47b3-a2e0-e12229f378b7   in service    none      none          off        
+    oxp_073979dd-3248-44a5-9fa1-cc72a140d682/crypt/zone/oxz_crucible_pantry_31b26053-8b94-4d8c-9e4a-d7d720afe265   6dd64de1-7dd3-492c-830f-d4a4e4c3dda7   in service    none      none          off        
+    oxp_3efc84af-8a54-4006-8323-4a752e91c049/crypt/zone/oxz_crucible_pantry_f87ada51-4419-4144-86a8-e5e4ff0f64d3   056f6da7-b92d-4231-b0df-0e8a2c9bce42   in service    none      none          off        
+    oxp_3efc84af-8a54-4006-8323-4a752e91c049/crypt/zone/oxz_external_dns_005548be-c5e4-49ff-a27b-88f314f1bc51      42bd3fb3-2aae-4754-9c41-0f9b50a77322   in service    none      none          off        
+    oxp_5f86efdc-a0cf-404c-88af-c878ae6dfdf4/crypt/zone/oxz_external_dns_2205353a-e1d2-48ff-863b-9d6b1487d474      b7813bc0-d5ee-487d-95ad-6c5cce6fdcd6   in service    none      none          off        
+    oxp_073979dd-3248-44a5-9fa1-cc72a140d682/crypt/zone/oxz_external_dns_70aab480-3d6c-47d5-aaf9-8d2ddab2931c      c6d7ecb4-135c-4f09-8948-b73fec13db76   in service    none      none          off        
+    oxp_3efc84af-8a54-4006-8323-4a752e91c049/crypt/zone/oxz_internal_dns_3fd06852-06cb-4d8a-b4b2-eb88ff5a6035      8355e747-b375-4d9e-b5da-03d9540ab5cd   in service    none      none          off        
+    oxp_073979dd-3248-44a5-9fa1-cc72a140d682/crypt/zone/oxz_internal_dns_45ce130e-c5ac-4e26-ab73-7589ba634418      0c7e4b2a-502a-4f4c-8ac4-4068db25252e   in service    none      none          off        
+    oxp_5f86efdc-a0cf-404c-88af-c878ae6dfdf4/crypt/zone/oxz_internal_dns_a7b7bfbe-0588-4781-9a5e-fba63584e5d2      d4f66eab-2870-4a74-b4d5-ae5da3276682   in service    none      none          off        
+    oxp_5f86efdc-a0cf-404c-88af-c878ae6dfdf4/crypt/zone/oxz_nexus_2bc0b0c4-63a9-44cc-afff-76ce645ef1d4             ebfd425c-4e5d-4385-a105-8f2ce32fa9ec   in service    none      none          off        
+    oxp_3efc84af-8a54-4006-8323-4a752e91c049/crypt/zone/oxz_nexus_3c2cd97f-7b4a-4ff3-a9d5-6ce141fcdbbe             382cbbf2-8b08-4388-839a-b43b8bc82999   in service    none      none          off        
+    oxp_073979dd-3248-44a5-9fa1-cc72a140d682/crypt/zone/oxz_nexus_c2cbbf34-b852-4164-a572-01d4d79445a1             d88eb02f-b66d-4ae7-91a1-23154417c1f1   in service    none      none          off        
+    oxp_073979dd-3248-44a5-9fa1-cc72a140d682/crypt/zone/oxz_ntp_9b135c74-c09a-4dcc-ba19-f6f8deae135a               506ddf0e-8cbf-44a9-93d7-130a550fd42d   in service    none      none          off        
+    oxp_073979dd-3248-44a5-9fa1-cc72a140d682/crypt/debug                                                           38fafd69-0275-4f4d-885d-3bbf2ea77551   in service    100 GiB   none          gzip-9     
+    oxp_3efc84af-8a54-4006-8323-4a752e91c049/crypt/debug                                                           cb8d5371-640d-4364-8a5e-0fde125d28af   in service    100 GiB   none          gzip-9     
+    oxp_5f86efdc-a0cf-404c-88af-c878ae6dfdf4/crypt/debug                                                           ba445402-2775-4f97-87e9-640be3a00c6f   in service    100 GiB   none          gzip-9     
+    oxp_981c69c9-f4f5-4423-bbbc-4578282d53e2/crypt/debug                                                           f4ea4a15-b3b3-4a67-b61a-8fba7c7ab61f   in service    100 GiB   none          gzip-9     
+    oxp_c6d33b64-fb96-4129-bab1-7878a06a5f9b/crypt/debug                                                           4d322f8a-d461-4ead-995b-9ba7d76becad   in service    100 GiB   none          gzip-9     
+    oxp_d8305049-7ee6-4895-a2cb-f63868dae12d/crypt/debug                                                           647f344c-b4c5-4788-a732-40658e852f63   in service    100 GiB   none          gzip-9     
+    oxp_e36f7294-8191-4d79-a791-44f2ec37a5ca/crypt/debug                                                           8144f1ee-dbef-45c1-9397-2031a9ca8b38   in service    100 GiB   none          gzip-9     
+    oxp_e4d937e1-6ddc-4eca-bb08-c1f73791e608/crypt/debug                                                           8b89525f-0764-4937-9fa8-022242647c0f   in service    100 GiB   none          gzip-9     
+    oxp_f09e1f43-f474-423e-8884-c8fa31cf6b60/crypt/debug                                                           3523db58-10ab-4e2c-95d9-fec43036c0f5   in service    100 GiB   none          gzip-9     
+    oxp_f355a206-1299-4ef3-9f8f-1a47459160dc/crypt/debug                                                           d1611973-b22d-4097-b6fd-0a480f2199a5   in service    100 GiB   none          gzip-9     
+
+
+    omicron zones:
+    ---------------------------------------------------------------------------------------------------------------
+    zone type         zone id                                image source      disposition   underlay IP           
+    ---------------------------------------------------------------------------------------------------------------
+    clickhouse        10676bfe-b61f-40e1-bc07-a4cb76ea1f30   install dataset   in service    fd00:1122:3344:101::25
+    crucible          2470c0fb-7af3-4b6b-8db3-424e4c297bd9   install dataset   in service    fd00:1122:3344:101::34
+    crucible          289a6d4b-ddfe-4101-9715-6693398704f2   install dataset   in service    fd00:1122:3344:101::2f
+    crucible          2a063d42-9caf-4364-b099-c7c302c87cdd   install dataset   in service    fd00:1122:3344:101::33
+    crucible          2dcb07a4-b9cc-4ae6-9119-ccd241acbf3a   install dataset   in service    fd00:1122:3344:101::32
+    crucible          3d9b7487-d7b9-4e25-960f-f2086f3e2919   install dataset   in service    fd00:1122:3344:101::2e
+    crucible          4b19d194-8b25-4396-88da-3df1b3788601   install dataset   in service    fd00:1122:3344:101::2d
+    crucible          bbae1838-0a4c-4489-b141-5aff19c2f277   install dataset   in service    fd00:1122:3344:101::35
+    crucible          c204730a-0946-4793-a470-64c88e89da96   install dataset   in service    fd00:1122:3344:101::2c
+    crucible          e0075607-793a-4348-a808-84a9dbe3e841   install dataset   in service    fd00:1122:3344:101::31
+    crucible          edce5918-6d13-4cde-9d64-54e00f4c09e6   install dataset   in service    fd00:1122:3344:101::30
+    crucible_pantry   2de1c525-4e04-4ba6-ac6b-377aaa542f96   install dataset   in service    fd00:1122:3344:101::2b
+    crucible_pantry   31b26053-8b94-4d8c-9e4a-d7d720afe265   install dataset   in service    fd00:1122:3344:101::29
+    crucible_pantry   f87ada51-4419-4144-86a8-e5e4ff0f64d3   install dataset   in service    fd00:1122:3344:101::2a
+    external_dns      005548be-c5e4-49ff-a27b-88f314f1bc51   install dataset   in service    fd00:1122:3344:101::27
+    external_dns      2205353a-e1d2-48ff-863b-9d6b1487d474   install dataset   in service    fd00:1122:3344:101::28
+    external_dns      70aab480-3d6c-47d5-aaf9-8d2ddab2931c   install dataset   in service    fd00:1122:3344:101::26
+    internal_dns      3fd06852-06cb-4d8a-b4b2-eb88ff5a6035   install dataset   in service    fd00:1122:3344:2::1   
+    internal_dns      45ce130e-c5ac-4e26-ab73-7589ba634418   install dataset   in service    fd00:1122:3344:1::1   
+    internal_dns      a7b7bfbe-0588-4781-9a5e-fba63584e5d2   install dataset   in service    fd00:1122:3344:3::1   
+    internal_ntp      9b135c74-c09a-4dcc-ba19-f6f8deae135a   install dataset   in service    fd00:1122:3344:101::21
+    nexus             2bc0b0c4-63a9-44cc-afff-76ce645ef1d4   install dataset   in service    fd00:1122:3344:101::24
+    nexus             3c2cd97f-7b4a-4ff3-a9d5-6ce141fcdbbe   install dataset   in service    fd00:1122:3344:101::23
+    nexus             c2cbbf34-b852-4164-a572-01d4d79445a1   install dataset   in service    fd00:1122:3344:101::22
+
+
+ COCKROACHDB SETTINGS:
+    state fingerprint:::::::::::::::::   (none)
+    cluster.preserve_downgrade_option:   (do not modify)
+
+ OXIMETER SETTINGS:
+    generation:   1
+    read from::   SingleNode
+
+ METADATA:
+    created by:::::::::::::   reconfigurator-cli
+    created at:::::::::::::   <REDACTED_TIMESTAMP>
+    comment::::::::::::::::   (none)
+    internal DNS version:::   1
+    external DNS version:::   1
+    target release min gen:   1
+
+ PENDING MGS-MANAGED UPDATES: 0
+
+
+
+> # Restore A to "current contents"
 > blueprint-edit latest set-host-phase2 serial0 A current-contents
 blueprint af934083-59b5-4bf6-8966-6fb5292c29e1 created from latest blueprint (58d5e830-0884-47d8-a7cd-b2b3751adeb4): set sled 98e6b7c2-2efa-41ca-b20a-0a4d61102fe6 host phase 2 slot A source to current contents
 warn: no validation is done on the requested source
@@ -846,6 +993,8 @@ external DNS:
 
 
 
+
+> # Restore B to "current contents"
 > blueprint-edit latest set-host-phase2 serial0 B current-contents
 blueprint df06bb57-ad42-4431-9206-abff322896c7 created from latest blueprint (af934083-59b5-4bf6-8966-6fb5292c29e1): set sled 98e6b7c2-2efa-41ca-b20a-0a4d61102fe6 host phase 2 slot B source to current contents
 warn: no validation is done on the requested source

--- a/dev-tools/reconfigurator-cli/tests/output/cmds-noop-image-source-stdout
+++ b/dev-tools/reconfigurator-cli/tests/output/cmds-noop-image-source-stdout
@@ -200,6 +200,14 @@ to:   blueprint 58d5e830-0884-47d8-a7cd-b2b3751adeb4
 
   sled 98e6b7c2-2efa-41ca-b20a-0a4d61102fe6 (active, config generation 2 -> 3):
 
+    host phase 2 contents:
+    ------------------------
+    slot   boot image source
+    ------------------------
+    A      current contents 
+    B      current contents 
+
+
     physical disks:
     ------------------------------------------------------------------------------------
     vendor        model        serial                                        disposition
@@ -244,6 +252,14 @@ to:   blueprint 58d5e830-0884-47d8-a7cd-b2b3751adeb4
 
   sled 9a867dc9-d505-427f-9eff-cdb1d4d9bd73 (active -> decommissioned, config generation 2 -> 3):
 
+    host phase 2 contents:
+    ------------------------
+    slot   boot image source
+    ------------------------
+    A      current contents 
+    B      current contents 
+
+
     physical disks:
     ---------------------------------------------------------------------------------------
     vendor        model        serial                                        disposition   
@@ -279,6 +295,14 @@ to:   blueprint 58d5e830-0884-47d8-a7cd-b2b3751adeb4
 
 
   sled aff6c093-197d-42c5-ad80-9f10ba051a34 (active, config generation 2 -> 3):
+
+    host phase 2 contents:
+    ------------------------
+    slot   boot image source
+    ------------------------
+    A      current contents 
+    B      current contents 
+
 
     physical disks:
     ------------------------------------------------------------------------------------
@@ -544,6 +568,14 @@ to:   blueprint af934083-59b5-4bf6-8966-6fb5292c29e1
  MODIFIED SLEDS:
 
   sled e96e226f-4ed9-4c01-91b9-69a9cd076c9e (active, config generation 2 -> 3):
+
+    host phase 2 contents:
+    ------------------------
+    slot   boot image source
+    ------------------------
+    A      current contents 
+    B      current contents 
+
 
     physical disks:
     ------------------------------------------------------------------------------------

--- a/dev-tools/reconfigurator-cli/tests/output/cmds-set-mgs-updates-stdout
+++ b/dev-tools/reconfigurator-cli/tests/output/cmds-set-mgs-updates-stdout
@@ -1952,6 +1952,8 @@ Commands:
           add a CockroachDB instance to a particular sled
   set-zone-image
           set the image source for a zone
+  set-host-phase2
+          set the desired host phase 2 image for an internal disk slot
   set-remove-mupdate-override
           set the remove_mupdate_override field for a sled
   set-target-release-minimum-generation

--- a/dev-tools/reconfigurator-cli/tests/output/cmds-set-mgs-updates-stdout
+++ b/dev-tools/reconfigurator-cli/tests/output/cmds-set-mgs-updates-stdout
@@ -13,6 +13,14 @@ parent:    6ccc786b-17f1-4562-958f-5a7d9a5a15fd
 
   sled: bb0ec23a-f97c-4b6a-a5bc-864b1ebc9236 (active, config generation 2)
 
+    host phase 2 contents:
+    ------------------------
+    slot   boot image source
+    ------------------------
+    A      current contents 
+    B      current contents 
+
+
     physical disks:
     ------------------------------------------------------------------------------------
     vendor        model        serial                                        disposition
@@ -67,6 +75,14 @@ parent:    6ccc786b-17f1-4562-958f-5a7d9a5a15fd
 
   sled: bba6ea73-6c9c-4ab5-8bb4-1dd145071407 (active, config generation 2)
 
+    host phase 2 contents:
+    ------------------------
+    slot   boot image source
+    ------------------------
+    A      current contents 
+    B      current contents 
+
+
     physical disks:
     ------------------------------------------------------------------------------------
     vendor        model        serial                                        disposition
@@ -117,6 +133,14 @@ parent:    6ccc786b-17f1-4562-958f-5a7d9a5a15fd
 
 
   sled: cc00b21a-5685-480a-ab5e-d2e29cf369df (active, config generation 2)
+
+    host phase 2 contents:
+    ------------------------
+    slot   boot image source
+    ------------------------
+    A      current contents 
+    B      current contents 
+
 
     physical disks:
     ------------------------------------------------------------------------------------
@@ -197,6 +221,14 @@ parent:    ad97e762-7bf1-45a6-a98f-60afb7e491c0
 
   sled: bb0ec23a-f97c-4b6a-a5bc-864b1ebc9236 (active, config generation 2)
 
+    host phase 2 contents:
+    ------------------------
+    slot   boot image source
+    ------------------------
+    A      current contents 
+    B      current contents 
+
+
     physical disks:
     ------------------------------------------------------------------------------------
     vendor        model        serial                                        disposition
@@ -251,6 +283,14 @@ parent:    ad97e762-7bf1-45a6-a98f-60afb7e491c0
 
   sled: bba6ea73-6c9c-4ab5-8bb4-1dd145071407 (active, config generation 2)
 
+    host phase 2 contents:
+    ------------------------
+    slot   boot image source
+    ------------------------
+    A      current contents 
+    B      current contents 
+
+
     physical disks:
     ------------------------------------------------------------------------------------
     vendor        model        serial                                        disposition
@@ -301,6 +341,14 @@ parent:    ad97e762-7bf1-45a6-a98f-60afb7e491c0
 
 
   sled: cc00b21a-5685-480a-ab5e-d2e29cf369df (active, config generation 2)
+
+    host phase 2 contents:
+    ------------------------
+    slot   boot image source
+    ------------------------
+    A      current contents 
+    B      current contents 
+
 
     physical disks:
     ------------------------------------------------------------------------------------
@@ -717,6 +765,14 @@ parent:    cca24b71-09b5-4042-9185-b33e9f2ebba0
 
   sled: bb0ec23a-f97c-4b6a-a5bc-864b1ebc9236 (active, config generation 2)
 
+    host phase 2 contents:
+    ------------------------
+    slot   boot image source
+    ------------------------
+    A      current contents 
+    B      current contents 
+
+
     physical disks:
     ------------------------------------------------------------------------------------
     vendor        model        serial                                        disposition
@@ -771,6 +827,14 @@ parent:    cca24b71-09b5-4042-9185-b33e9f2ebba0
 
   sled: bba6ea73-6c9c-4ab5-8bb4-1dd145071407 (active, config generation 2)
 
+    host phase 2 contents:
+    ------------------------
+    slot   boot image source
+    ------------------------
+    A      current contents 
+    B      current contents 
+
+
     physical disks:
     ------------------------------------------------------------------------------------
     vendor        model        serial                                        disposition
@@ -821,6 +885,14 @@ parent:    cca24b71-09b5-4042-9185-b33e9f2ebba0
 
 
   sled: cc00b21a-5685-480a-ab5e-d2e29cf369df (active, config generation 2)
+
+    host phase 2 contents:
+    ------------------------
+    slot   boot image source
+    ------------------------
+    A      current contents 
+    B      current contents 
+
 
     physical disks:
     ------------------------------------------------------------------------------------
@@ -1240,6 +1312,14 @@ parent:    5bf974f3-81f9-455b-b24e-3099f765664c
 
   sled: bb0ec23a-f97c-4b6a-a5bc-864b1ebc9236 (active, config generation 2)
 
+    host phase 2 contents:
+    ------------------------
+    slot   boot image source
+    ------------------------
+    A      current contents 
+    B      current contents 
+
+
     physical disks:
     ------------------------------------------------------------------------------------
     vendor        model        serial                                        disposition
@@ -1294,6 +1374,14 @@ parent:    5bf974f3-81f9-455b-b24e-3099f765664c
 
   sled: bba6ea73-6c9c-4ab5-8bb4-1dd145071407 (active, config generation 2)
 
+    host phase 2 contents:
+    ------------------------
+    slot   boot image source
+    ------------------------
+    A      current contents 
+    B      current contents 
+
+
     physical disks:
     ------------------------------------------------------------------------------------
     vendor        model        serial                                        disposition
@@ -1344,6 +1432,14 @@ parent:    5bf974f3-81f9-455b-b24e-3099f765664c
 
 
   sled: cc00b21a-5685-480a-ab5e-d2e29cf369df (active, config generation 2)
+
+    host phase 2 contents:
+    ------------------------
+    slot   boot image source
+    ------------------------
+    A      current contents 
+    B      current contents 
+
 
     physical disks:
     ------------------------------------------------------------------------------------
@@ -1595,6 +1691,14 @@ parent:    1b837a27-3be1-4fcb-8499-a921c839e1d0
 
   sled: bb0ec23a-f97c-4b6a-a5bc-864b1ebc9236 (active, config generation 2)
 
+    host phase 2 contents:
+    ------------------------
+    slot   boot image source
+    ------------------------
+    A      current contents 
+    B      current contents 
+
+
     physical disks:
     ------------------------------------------------------------------------------------
     vendor        model        serial                                        disposition
@@ -1649,6 +1753,14 @@ parent:    1b837a27-3be1-4fcb-8499-a921c839e1d0
 
   sled: bba6ea73-6c9c-4ab5-8bb4-1dd145071407 (active, config generation 2)
 
+    host phase 2 contents:
+    ------------------------
+    slot   boot image source
+    ------------------------
+    A      current contents 
+    B      current contents 
+
+
     physical disks:
     ------------------------------------------------------------------------------------
     vendor        model        serial                                        disposition
@@ -1699,6 +1811,14 @@ parent:    1b837a27-3be1-4fcb-8499-a921c839e1d0
 
 
   sled: cc00b21a-5685-480a-ab5e-d2e29cf369df (active, config generation 2)
+
+    host phase 2 contents:
+    ------------------------
+    slot   boot image source
+    ------------------------
+    A      current contents 
+    B      current contents 
+
 
     physical disks:
     ------------------------------------------------------------------------------------

--- a/dev-tools/reconfigurator-cli/tests/output/cmds-set-remove-mupdate-override-stdout
+++ b/dev-tools/reconfigurator-cli/tests/output/cmds-set-remove-mupdate-override-stdout
@@ -54,6 +54,14 @@ parent:    df06bb57-ad42-4431-9206-abff322896c7
 
   sled: 2b8f0cb3-0295-4b3c-bc58-4fe88b57112c (active, config generation 1)
 
+    host phase 2 contents:
+    ------------------------
+    slot   boot image source
+    ------------------------
+    A      current contents 
+    B      current contents 
+
+
     physical disks:
     -------------------------------------
     vendor   model   serial   disposition
@@ -74,6 +82,14 @@ parent:    df06bb57-ad42-4431-9206-abff322896c7
 
 
   sled: 98e6b7c2-2efa-41ca-b20a-0a4d61102fe6 (active, config generation 1)
+
+    host phase 2 contents:
+    ------------------------
+    slot   boot image source
+    ------------------------
+    A      current contents 
+    B      current contents 
+
 
     physical disks:
     -------------------------------------
@@ -97,6 +113,14 @@ parent:    df06bb57-ad42-4431-9206-abff322896c7
   sled: 9a867dc9-d505-427f-9eff-cdb1d4d9bd73 (active, config generation 2)
     will remove mupdate override:   00000000-0000-0000-0000-000000000000
 
+    host phase 2 contents:
+    ------------------------
+    slot   boot image source
+    ------------------------
+    A      current contents 
+    B      current contents 
+
+
     physical disks:
     -------------------------------------
     vendor   model   serial   disposition
@@ -118,6 +142,14 @@ parent:    df06bb57-ad42-4431-9206-abff322896c7
 
   sled: aff6c093-197d-42c5-ad80-9f10ba051a34 (active, config generation 2)
     will remove mupdate override:   00000000-0000-0000-0000-000000000000
+
+    host phase 2 contents:
+    ------------------------
+    slot   boot image source
+    ------------------------
+    A      current contents 
+    B      current contents 
+
 
     physical disks:
     -------------------------------------
@@ -141,6 +173,14 @@ parent:    df06bb57-ad42-4431-9206-abff322896c7
   sled: b82ede02-399c-48c6-a1de-411df4fa49a7 (active, config generation 2)
     will remove mupdate override:   00000000-0000-0000-0000-000000000000
 
+    host phase 2 contents:
+    ------------------------
+    slot   boot image source
+    ------------------------
+    A      current contents 
+    B      current contents 
+
+
     physical disks:
     -------------------------------------
     vendor   model   serial   disposition
@@ -163,6 +203,14 @@ parent:    df06bb57-ad42-4431-9206-abff322896c7
   sled: d81c6a84-79b8-4958-ae41-ea46c9b19763 (active, config generation 2)
     will remove mupdate override:   00000000-0000-0000-0000-000000000000
 
+    host phase 2 contents:
+    ------------------------
+    slot   boot image source
+    ------------------------
+    A      current contents 
+    B      current contents 
+
+
     physical disks:
     -------------------------------------
     vendor   model   serial   disposition
@@ -184,6 +232,14 @@ parent:    df06bb57-ad42-4431-9206-abff322896c7
 
   sled: e96e226f-4ed9-4c01-91b9-69a9cd076c9e (active, config generation 2)
     will remove mupdate override:   00000000-0000-0000-0000-000000000000
+
+    host phase 2 contents:
+    ------------------------
+    slot   boot image source
+    ------------------------
+    A      current contents 
+    B      current contents 
+
 
     physical disks:
     -------------------------------------
@@ -263,24 +319,72 @@ to:   blueprint afb09faf-a586-4483-9289-04d4f1d8ba23
   sled e96e226f-4ed9-4c01-91b9-69a9cd076c9e (was active, config generation 2):
 -   would have removed mupdate override:   00000000-0000-0000-0000-000000000000
 
+    host phase 2 contents:
+    ------------------------
+    slot   boot image source
+    ------------------------
+-   A      current contents 
+-   B      current contents 
+
+
  MODIFIED SLEDS:
 
   sled 2b8f0cb3-0295-4b3c-bc58-4fe88b57112c (active, config generation 1 -> 2):
 +   will remove mupdate override:   (none) -> ffffffff-ffff-ffff-ffff-ffffffffffff
 
+    host phase 2 contents:
+    ------------------------
+    slot   boot image source
+    ------------------------
+    A      current contents 
+    B      current contents 
+
+
   sled 9a867dc9-d505-427f-9eff-cdb1d4d9bd73 (active, config generation 2 -> 3):
     will remove mupdate override:   00000000-0000-0000-0000-000000000000 (unchanged)
+
+    host phase 2 contents:
+    ------------------------
+    slot   boot image source
+    ------------------------
+    A      current contents 
+    B      current contents 
+
 
   sled b82ede02-399c-48c6-a1de-411df4fa49a7 (active, config generation 2 -> 3):
 *   will remove mupdate override:   00000000-0000-0000-0000-000000000000 -> ffffffff-ffff-ffff-ffff-ffffffffffff
 
+    host phase 2 contents:
+    ------------------------
+    slot   boot image source
+    ------------------------
+    A      current contents 
+    B      current contents 
+
+
   sled d81c6a84-79b8-4958-ae41-ea46c9b19763 (active, config generation 2 -> 3):
 -   will remove mupdate override:   00000000-0000-0000-0000-000000000000 -> (none)
+
+    host phase 2 contents:
+    ------------------------
+    slot   boot image source
+    ------------------------
+    A      current contents 
+    B      current contents 
+
 
  ADDED SLEDS:
 
   sled 00320471-945d-413c-85e7-03e091a70b3c (active, config generation 2):
 +   will remove mupdate override:   ffffffff-ffff-ffff-ffff-ffffffffffff
+
+    host phase 2 contents:
+    ------------------------
+    slot   boot image source
+    ------------------------
++   A      current contents 
++   B      current contents 
+
 
  COCKROACHDB SETTINGS:
     state fingerprint:::::::::::::::::   (none) (unchanged)
@@ -339,6 +443,14 @@ parent:    afb09faf-a586-4483-9289-04d4f1d8ba23
   sled: 00320471-945d-413c-85e7-03e091a70b3c (active, config generation 2)
     will remove mupdate override:   ffffffff-ffff-ffff-ffff-ffffffffffff
 
+    host phase 2 contents:
+    ------------------------
+    slot   boot image source
+    ------------------------
+    A      current contents 
+    B      current contents 
+
+
     physical disks:
     -------------------------------------
     vendor   model   serial   disposition
@@ -361,6 +473,14 @@ parent:    afb09faf-a586-4483-9289-04d4f1d8ba23
   sled: 2b8f0cb3-0295-4b3c-bc58-4fe88b57112c (active, config generation 2)
     will remove mupdate override:   ffffffff-ffff-ffff-ffff-ffffffffffff
 
+    host phase 2 contents:
+    ------------------------
+    slot   boot image source
+    ------------------------
+    A      current contents 
+    B      current contents 
+
+
     physical disks:
     -------------------------------------
     vendor   model   serial   disposition
@@ -381,6 +501,14 @@ parent:    afb09faf-a586-4483-9289-04d4f1d8ba23
 
 
   sled: 98e6b7c2-2efa-41ca-b20a-0a4d61102fe6 (active, config generation 1)
+
+    host phase 2 contents:
+    ------------------------
+    slot   boot image source
+    ------------------------
+    A      current contents 
+    B      current contents 
+
 
     physical disks:
     -------------------------------------
@@ -404,6 +532,14 @@ parent:    afb09faf-a586-4483-9289-04d4f1d8ba23
   sled: 9a867dc9-d505-427f-9eff-cdb1d4d9bd73 (active, config generation 3)
     will remove mupdate override:   00000000-0000-0000-0000-000000000000
 
+    host phase 2 contents:
+    ------------------------
+    slot   boot image source
+    ------------------------
+    A      current contents 
+    B      current contents 
+
+
     physical disks:
     -------------------------------------
     vendor   model   serial   disposition
@@ -425,6 +561,14 @@ parent:    afb09faf-a586-4483-9289-04d4f1d8ba23
 
   sled: aff6c093-197d-42c5-ad80-9f10ba051a34 (active, config generation 2)
     will remove mupdate override:   00000000-0000-0000-0000-000000000000
+
+    host phase 2 contents:
+    ------------------------
+    slot   boot image source
+    ------------------------
+    A      current contents 
+    B      current contents 
+
 
     physical disks:
     -------------------------------------
@@ -448,6 +592,14 @@ parent:    afb09faf-a586-4483-9289-04d4f1d8ba23
   sled: b82ede02-399c-48c6-a1de-411df4fa49a7 (active, config generation 3)
     will remove mupdate override:   ffffffff-ffff-ffff-ffff-ffffffffffff
 
+    host phase 2 contents:
+    ------------------------
+    slot   boot image source
+    ------------------------
+    A      current contents 
+    B      current contents 
+
+
     physical disks:
     -------------------------------------
     vendor   model   serial   disposition
@@ -468,6 +620,14 @@ parent:    afb09faf-a586-4483-9289-04d4f1d8ba23
 
 
   sled: d81c6a84-79b8-4958-ae41-ea46c9b19763 (active, config generation 3)
+
+    host phase 2 contents:
+    ------------------------
+    slot   boot image source
+    ------------------------
+    A      current contents 
+    B      current contents 
+
 
     physical disks:
     -------------------------------------

--- a/dev-tools/reconfigurator-cli/tests/output/cmds-set-zone-images-stdout
+++ b/dev-tools/reconfigurator-cli/tests/output/cmds-set-zone-images-stdout
@@ -13,6 +13,14 @@ parent:    1b013011-2062-4b48-b544-a32b23bce83a
 
   sled: 868d5b02-7792-4fc0-b6a9-654afcae9ea0 (active, config generation 2)
 
+    host phase 2 contents:
+    ------------------------
+    slot   boot image source
+    ------------------------
+    A      current contents 
+    B      current contents 
+
+
     physical disks:
     ------------------------------------------------------------------------------------
     vendor        model        serial                                        disposition
@@ -120,6 +128,14 @@ parent:    9766ca20-38d4-4380-b005-e7c43c797e7c
 
   sled: 868d5b02-7792-4fc0-b6a9-654afcae9ea0 (active, config generation 4)
 
+    host phase 2 contents:
+    ------------------------
+    slot   boot image source
+    ------------------------
+    A      current contents 
+    B      current contents 
+
+
     physical disks:
     ------------------------------------------------------------------------------------
     vendor        model        serial                                        disposition
@@ -217,6 +233,14 @@ to:   blueprint f714e6ea-e85a-4d7d-93c2-a018744fe176
  MODIFIED SLEDS:
 
   sled 868d5b02-7792-4fc0-b6a9-654afcae9ea0 (active, config generation 2 -> 4):
+
+    host phase 2 contents:
+    ------------------------
+    slot   boot image source
+    ------------------------
+    A      current contents 
+    B      current contents 
+
 
     physical disks:
     ------------------------------------------------------------------------------------
@@ -423,6 +447,14 @@ parent:    bb128f06-a2e1-44c1-8874-4f789d0ff896
 
   sled: 868d5b02-7792-4fc0-b6a9-654afcae9ea0 (active, config generation 6)
 
+    host phase 2 contents:
+    ------------------------
+    slot   boot image source
+    ------------------------
+    A      current contents 
+    B      current contents 
+
+
     physical disks:
     ------------------------------------------------------------------------------------
     vendor        model        serial                                        disposition
@@ -520,6 +552,14 @@ to:   blueprint d9c572a1-a68c-4945-b1ec-5389bd588fe9
  MODIFIED SLEDS:
 
   sled 868d5b02-7792-4fc0-b6a9-654afcae9ea0 (active, config generation 4 -> 6):
+
+    host phase 2 contents:
+    ------------------------
+    slot   boot image source
+    ------------------------
+    A      current contents 
+    B      current contents 
+
 
     physical disks:
     ------------------------------------------------------------------------------------

--- a/dev-tools/reconfigurator-cli/tests/output/cmds-set-zone-images-stdout
+++ b/dev-tools/reconfigurator-cli/tests/output/cmds-set-zone-images-stdout
@@ -724,6 +724,8 @@ Commands:
           add a CockroachDB instance to a particular sled
   set-zone-image
           set the image source for a zone
+  set-host-phase2
+          set the desired host phase 2 image for an internal disk slot
   set-remove-mupdate-override
           set the remove_mupdate_override field for a sled
   set-target-release-minimum-generation

--- a/dev-tools/reconfigurator-cli/tests/output/cmds-target-release-stdout
+++ b/dev-tools/reconfigurator-cli/tests/output/cmds-target-release-stdout
@@ -1179,6 +1179,14 @@ to:   blueprint 9034c710-3e57-45f3-99e5-4316145e87ac
 
   sled 2b8f0cb3-0295-4b3c-bc58-4fe88b57112c (active, config generation 2 -> 3):
 
+    host phase 2 contents:
+    ------------------------
+    slot   boot image source
+    ------------------------
+    A      current contents 
+    B      current contents 
+
+
     physical disks:
     ------------------------------------------------------------------------------------
     vendor        model        serial                                        disposition

--- a/nexus/db-model/src/schema_versions.rs
+++ b/nexus/db-model/src/schema_versions.rs
@@ -16,7 +16,7 @@ use std::{collections::BTreeMap, sync::LazyLock};
 ///
 /// This must be updated when you change the database schema.  Refer to
 /// schema/crdb/README.adoc in the root of this repository for details.
-pub const SCHEMA_VERSION: Version = Version::new(161, 0, 0);
+pub const SCHEMA_VERSION: Version = Version::new(162, 0, 0);
 
 /// List of all past database schema versions, in *reverse* order
 ///
@@ -28,6 +28,7 @@ static KNOWN_VERSIONS: LazyLock<Vec<KnownVersion>> = LazyLock::new(|| {
         // |  leaving the first copy as an example for the next person.
         // v
         // KnownVersion::new(next_int, "unique-dirname-with-the-sql-files"),
+        KnownVersion::new(162, "bp-desired-host-phase-2"),
         KnownVersion::new(161, "inv_cockroachdb_status"),
         KnownVersion::new(160, "tuf-trust-root"),
         KnownVersion::new(159, "sled-config-desired-host-phase-2"),

--- a/nexus/db-queries/src/db/datastore/rack.rs
+++ b/nexus/db-queries/src/db/datastore/rack.rs
@@ -1010,6 +1010,7 @@ mod test {
         SledBuilder, SystemDescription,
     };
     use nexus_sled_agent_shared::inventory::OmicronZoneDataset;
+    use nexus_types::deployment::BlueprintHostPhase2DesiredSlots;
     use nexus_types::deployment::BlueprintSledConfig;
     use nexus_types::deployment::CockroachDbPreserveDowngrade;
     use nexus_types::deployment::PendingMgsUpdates;
@@ -1315,6 +1316,8 @@ mod test {
                         datasets: IdMap::new(),
                         zones,
                         remove_mupdate_override: None,
+                        host_phase_2:
+                            BlueprintHostPhase2DesiredSlots::current_contents(),
                     },
                 )
             })

--- a/nexus/db-schema/src/schema.rs
+++ b/nexus/db-schema/src/schema.rs
@@ -1940,8 +1940,13 @@ table! {
         sled_state -> crate::enums::SledStateEnum,
         sled_agent_generation -> Int8,
         remove_mupdate_override -> Nullable<Uuid>,
+
+        host_phase_2_desired_slot_a -> Nullable<Text>,
+        host_phase_2_desired_slot_b -> Nullable<Text>,
     }
 }
+
+allow_tables_to_appear_in_same_query!(bp_sled_metadata, tuf_artifact);
 
 table! {
     bp_omicron_physical_disk (blueprint_id, id) {

--- a/nexus/reconfigurator/blippy/src/blippy.rs
+++ b/nexus/reconfigurator/blippy/src/blippy.rs
@@ -7,9 +7,9 @@ use crate::report::BlippyReport;
 use crate::report::BlippyReportSortKey;
 use core::fmt;
 use nexus_types::deployment::Blueprint;
+use nexus_types::deployment::BlueprintArtifactVersion;
 use nexus_types::deployment::BlueprintDatasetConfig;
 use nexus_types::deployment::BlueprintZoneConfig;
-use nexus_types::deployment::BlueprintZoneImageVersion;
 use nexus_types::inventory::ZpoolName;
 use omicron_common::address::DnsSubnet;
 use omicron_common::address::Ipv6Subnet;
@@ -183,7 +183,7 @@ pub enum SledKind {
     MupdateOverrideWithArtifactZone {
         mupdate_override_id: MupdateOverrideUuid,
         zone: BlueprintZoneConfig,
-        version: BlueprintZoneImageVersion,
+        version: BlueprintArtifactVersion,
         hash: ArtifactHash,
     },
 }

--- a/nexus/reconfigurator/blippy/src/checks.rs
+++ b/nexus/reconfigurator/blippy/src/checks.rs
@@ -597,7 +597,7 @@ mod tests {
     use crate::blippy::Note;
     use nexus_reconfigurator_planning::example::ExampleSystemBuilder;
     use nexus_reconfigurator_planning::example::example;
-    use nexus_types::deployment::BlueprintZoneImageVersion;
+    use nexus_types::deployment::BlueprintArtifactVersion;
     use nexus_types::deployment::BlueprintZoneType;
     use nexus_types::deployment::blueprint_zone_type;
     use omicron_test_utils::dev::test_setup_log;
@@ -1644,7 +1644,7 @@ mod tests {
                 .find(|z| z.disposition.is_in_service())
                 .expect("at least one in-service zone");
 
-            let version = BlueprintZoneImageVersion::Available {
+            let version = BlueprintArtifactVersion::Available {
                 version: ArtifactVersion::new_const("1.0.0"),
             };
             let hash = ArtifactHash([1u8; 32]);

--- a/nexus/reconfigurator/execution/src/dns.rs
+++ b/nexus/reconfigurator/execution/src/dns.rs
@@ -333,6 +333,7 @@ mod test {
     use nexus_test_utils::resource_helpers::create_silo;
     use nexus_test_utils_macros::nexus_test;
     use nexus_types::deployment::Blueprint;
+    use nexus_types::deployment::BlueprintHostPhase2DesiredSlots;
     use nexus_types::deployment::BlueprintSledConfig;
     use nexus_types::deployment::BlueprintTarget;
     use nexus_types::deployment::BlueprintZoneConfig;
@@ -697,6 +698,8 @@ mod test {
                     datasets: IdMap::new(),
                     zones,
                     remove_mupdate_override: None,
+                    host_phase_2:
+                        BlueprintHostPhase2DesiredSlots::current_contents(),
                 },
             );
         }

--- a/nexus/reconfigurator/execution/src/omicron_sled_config.rs
+++ b/nexus/reconfigurator/execution/src/omicron_sled_config.rs
@@ -88,6 +88,7 @@ mod tests {
     use nexus_test_utils_macros::nexus_test;
     use nexus_types::deployment::BlueprintDatasetConfig;
     use nexus_types::deployment::BlueprintDatasetDisposition;
+    use nexus_types::deployment::BlueprintHostPhase2DesiredSlots;
     use nexus_types::deployment::BlueprintPhysicalDiskConfig;
     use nexus_types::deployment::BlueprintPhysicalDiskDisposition;
     use nexus_types::deployment::BlueprintZoneConfig;
@@ -253,6 +254,7 @@ mod tests {
             datasets,
             zones,
             remove_mupdate_override: None,
+            host_phase_2: BlueprintHostPhase2DesiredSlots::current_contents(),
         };
         let sled_configs =
             [(sim_sled_agent.id, sled_config.clone())].into_iter().collect();

--- a/nexus/reconfigurator/planning/src/blueprint_builder/builder.rs
+++ b/nexus/reconfigurator/planning/src/blueprint_builder/builder.rs
@@ -1829,7 +1829,6 @@ impl<'a> BlueprintBuilder<'a> {
         Ok(final_counts.difference_since(initial_counts))
     }
 
-    // TODO-john return type?
     pub fn sled_set_host_phase_2(
         &mut self,
         sled_id: SledUuid,
@@ -1842,8 +1841,7 @@ impl<'a> BlueprintBuilder<'a> {
         })?;
         editor
             .set_host_phase_2(host_phase_2)
-            .map_err(|err| Error::SledEditError { sled_id, err })?;
-        Ok(())
+            .map_err(|err| Error::SledEditError { sled_id, err })
     }
 
     /// Set the `remove_mupdate_override` field of the given sled.

--- a/nexus/reconfigurator/planning/src/blueprint_builder/builder.rs
+++ b/nexus/reconfigurator/planning/src/blueprint_builder/builder.rs
@@ -27,6 +27,7 @@ use nexus_sled_agent_shared::inventory::OmicronZoneDataset;
 use nexus_sled_agent_shared::inventory::ZoneKind;
 use nexus_types::deployment::Blueprint;
 use nexus_types::deployment::BlueprintDatasetDisposition;
+use nexus_types::deployment::BlueprintHostPhase2DesiredSlots;
 use nexus_types::deployment::BlueprintPhysicalDiskConfig;
 use nexus_types::deployment::BlueprintPhysicalDiskDisposition;
 use nexus_types::deployment::BlueprintSledConfig;
@@ -477,6 +478,8 @@ impl<'a> BlueprintBuilder<'a> {
                     datasets: IdMap::default(),
                     zones: IdMap::default(),
                     remove_mupdate_override: None,
+                    host_phase_2:
+                        BlueprintHostPhase2DesiredSlots::current_contents(),
                 };
                 (sled_id, config)
             })
@@ -2219,8 +2222,8 @@ pub mod test {
     use expectorate::assert_contents;
     use nexus_reconfigurator_blippy::Blippy;
     use nexus_reconfigurator_blippy::BlippyReportSortKey;
+    use nexus_types::deployment::BlueprintArtifactVersion;
     use nexus_types::deployment::BlueprintDatasetDisposition;
-    use nexus_types::deployment::BlueprintZoneImageVersion;
     use nexus_types::deployment::OmicronZoneNetworkResources;
     use nexus_types::external_api::views::SledPolicy;
     use omicron_common::address::IpRange;
@@ -3141,7 +3144,7 @@ pub mod test {
                 .set_zone_image_source(
                     &zone_id,
                     BlueprintZoneImageSource::Artifact {
-                        version: BlueprintZoneImageVersion::Available {
+                        version: BlueprintArtifactVersion::Available {
                             version: ARTIFACT_VERSION,
                         },
                         // The hash is not displayed in the diff -- only the

--- a/nexus/reconfigurator/planning/src/blueprint_builder/builder.rs
+++ b/nexus/reconfigurator/planning/src/blueprint_builder/builder.rs
@@ -27,6 +27,7 @@ use nexus_sled_agent_shared::inventory::OmicronZoneDataset;
 use nexus_sled_agent_shared::inventory::ZoneKind;
 use nexus_types::deployment::Blueprint;
 use nexus_types::deployment::BlueprintDatasetDisposition;
+use nexus_types::deployment::BlueprintHostPhase2DesiredContents;
 use nexus_types::deployment::BlueprintHostPhase2DesiredSlots;
 use nexus_types::deployment::BlueprintPhysicalDiskConfig;
 use nexus_types::deployment::BlueprintPhysicalDiskDisposition;
@@ -61,6 +62,7 @@ use omicron_common::api::external::Generation;
 use omicron_common::api::external::Vni;
 use omicron_common::api::internal::shared::NetworkInterface;
 use omicron_common::api::internal::shared::NetworkInterfaceKind;
+use omicron_common::disk::M2Slot;
 use omicron_common::policy::INTERNAL_DNS_REDUNDANCY;
 use omicron_uuid_kinds::GenericUuid;
 use omicron_uuid_kinds::MupdateOverrideUuid;
@@ -1841,6 +1843,22 @@ impl<'a> BlueprintBuilder<'a> {
         })?;
         editor
             .set_host_phase_2(host_phase_2)
+            .map_err(|err| Error::SledEditError { sled_id, err })
+    }
+
+    pub fn sled_set_host_phase_2_slot(
+        &mut self,
+        sled_id: SledUuid,
+        slot: M2Slot,
+        host_phase_2: BlueprintHostPhase2DesiredContents,
+    ) -> Result<(), Error> {
+        let editor = self.sled_editors.get_mut(&sled_id).ok_or_else(|| {
+            Error::Planner(anyhow!(
+                "tried to change image of zone on unknown sled {sled_id}"
+            ))
+        })?;
+        editor
+            .set_host_phase_2_slot(slot, host_phase_2)
             .map_err(|err| Error::SledEditError { sled_id, err })
     }
 

--- a/nexus/reconfigurator/planning/src/blueprint_builder/builder.rs
+++ b/nexus/reconfigurator/planning/src/blueprint_builder/builder.rs
@@ -1829,6 +1829,23 @@ impl<'a> BlueprintBuilder<'a> {
         Ok(final_counts.difference_since(initial_counts))
     }
 
+    // TODO-john return type?
+    pub fn sled_set_host_phase_2(
+        &mut self,
+        sled_id: SledUuid,
+        host_phase_2: BlueprintHostPhase2DesiredSlots,
+    ) -> Result<(), Error> {
+        let editor = self.sled_editors.get_mut(&sled_id).ok_or_else(|| {
+            Error::Planner(anyhow!(
+                "tried to change image of zone on unknown sled {sled_id}"
+            ))
+        })?;
+        editor
+            .set_host_phase_2(host_phase_2)
+            .map_err(|err| Error::SledEditError { sled_id, err })?;
+        Ok(())
+    }
+
     /// Set the `remove_mupdate_override` field of the given sled.
     pub fn sled_set_remove_mupdate_override(
         &mut self,

--- a/nexus/reconfigurator/planning/src/blueprint_editor/sled_editor.rs
+++ b/nexus/reconfigurator/planning/src/blueprint_editor/sled_editor.rs
@@ -355,13 +355,22 @@ impl SledEditor {
         self.as_active_mut()?.mark_expunged_zone_ready_for_cleanup(zone_id)
     }
 
-    /// Sets the image source for a zone.
+    /// Sets the image source for a zone, returning the old image source.
     pub fn set_zone_image_source(
         &mut self,
         zone_id: &OmicronZoneUuid,
         image_source: BlueprintZoneImageSource,
     ) -> Result<BlueprintZoneImageSource, SledEditError> {
         self.as_active_mut()?.set_zone_image_source(zone_id, image_source)
+    }
+
+    // Sets the desired host phase 2 contents, returning the old desired phase 2
+    // contents.
+    pub fn set_host_phase_2(
+        &mut self,
+        host_phase_2: BlueprintHostPhase2DesiredSlots,
+    ) -> Result<BlueprintHostPhase2DesiredSlots, SledEditError> {
+        Ok(self.as_active_mut()?.set_host_phase_2(host_phase_2))
     }
 
     /// Sets remove-mupdate-override configuration for this sled.
@@ -686,6 +695,17 @@ impl ActiveSledEditor {
         image_source: BlueprintZoneImageSource,
     ) -> Result<BlueprintZoneImageSource, SledEditError> {
         Ok(self.zones.set_zone_image_source(zone_id, image_source)?)
+    }
+
+    // Sets the desired host phase 2 contents, returning the old desired phase 2
+    // contents.
+    pub fn set_host_phase_2(
+        &mut self,
+        mut host_phase_2: BlueprintHostPhase2DesiredSlots,
+    ) -> BlueprintHostPhase2DesiredSlots {
+        // TODO-john FIXME bump generation if changed
+        mem::swap(&mut host_phase_2, &mut self.host_phase_2);
+        host_phase_2
     }
 
     /// Backwards compatibility / test helper: If we're given a blueprint that

--- a/nexus/reconfigurator/planning/src/blueprint_editor/sled_editor.rs
+++ b/nexus/reconfigurator/planning/src/blueprint_editor/sled_editor.rs
@@ -11,6 +11,7 @@ use itertools::Either;
 use nexus_sled_agent_shared::inventory::ZoneKind;
 use nexus_types::deployment::BlueprintDatasetConfig;
 use nexus_types::deployment::BlueprintDatasetDisposition;
+use nexus_types::deployment::BlueprintHostPhase2DesiredSlots;
 use nexus_types::deployment::BlueprintPhysicalDiskConfig;
 use nexus_types::deployment::BlueprintPhysicalDiskDisposition;
 use nexus_types::deployment::BlueprintSledConfig;
@@ -404,6 +405,8 @@ struct ActiveSledEditor {
     disks: DisksEditor,
     datasets: DatasetsEditor,
     remove_mupdate_override: ScalarEditor<Option<MupdateOverrideUuid>>,
+    // TODO-john make a host phase 2 editor type
+    host_phase_2: BlueprintHostPhase2DesiredSlots,
     debug_force_generation_bump: bool,
 }
 
@@ -439,6 +442,7 @@ impl ActiveSledEditor {
             remove_mupdate_override: ScalarEditor::new(
                 config.remove_mupdate_override,
             ),
+            host_phase_2: config.host_phase_2,
             debug_force_generation_bump: false,
         })
     }
@@ -458,6 +462,7 @@ impl ActiveSledEditor {
             disks: DisksEditor::empty(),
             datasets: DatasetsEditor::empty(),
             remove_mupdate_override: ScalarEditor::new(None),
+            host_phase_2: BlueprintHostPhase2DesiredSlots::current_contents(),
             debug_force_generation_bump: false,
         }
     }
@@ -490,6 +495,7 @@ impl ActiveSledEditor {
                 remove_mupdate_override: self
                     .remove_mupdate_override
                     .finalize(),
+                host_phase_2: self.host_phase_2,
             },
             edit_counts: SledEditCounts {
                 disks: disks_counts,

--- a/nexus/reconfigurator/planning/src/blueprint_editor/sled_editor.rs
+++ b/nexus/reconfigurator/planning/src/blueprint_editor/sled_editor.rs
@@ -12,6 +12,7 @@ use itertools::Either;
 use nexus_sled_agent_shared::inventory::ZoneKind;
 use nexus_types::deployment::BlueprintDatasetConfig;
 use nexus_types::deployment::BlueprintDatasetDisposition;
+use nexus_types::deployment::BlueprintHostPhase2DesiredContents;
 use nexus_types::deployment::BlueprintHostPhase2DesiredSlots;
 use nexus_types::deployment::BlueprintPhysicalDiskConfig;
 use nexus_types::deployment::BlueprintPhysicalDiskDisposition;
@@ -26,6 +27,7 @@ use omicron_common::address::Ipv6Subnet;
 use omicron_common::address::SLED_PREFIX;
 use omicron_common::api::external::Generation;
 use omicron_common::disk::DatasetKind;
+use omicron_common::disk::M2Slot;
 use omicron_uuid_kinds::DatasetUuid;
 use omicron_uuid_kinds::MupdateOverrideUuid;
 use omicron_uuid_kinds::OmicronZoneUuid;
@@ -375,6 +377,16 @@ impl SledEditor {
         Ok(())
     }
 
+    // Sets the desired host phase 2 contents of a particular slot.
+    pub fn set_host_phase_2_slot(
+        &mut self,
+        slot: M2Slot,
+        host_phase_2: BlueprintHostPhase2DesiredContents,
+    ) -> Result<(), SledEditError> {
+        self.as_active_mut()?.set_host_phase_2_slot(slot, host_phase_2);
+        Ok(())
+    }
+
     /// Sets remove-mupdate-override configuration for this sled.
     ///
     /// Currently only used in test code.
@@ -708,6 +720,15 @@ impl ActiveSledEditor {
         host_phase_2: BlueprintHostPhase2DesiredSlots,
     ) {
         self.host_phase_2.set_value(host_phase_2);
+    }
+
+    // Sets the desired host phase 2 contents for a specific slot on this sled.
+    pub fn set_host_phase_2_slot(
+        &mut self,
+        slot: M2Slot,
+        host_phase_2: BlueprintHostPhase2DesiredContents,
+    ) {
+        self.host_phase_2.set_slot(slot, host_phase_2);
     }
 
     /// Backwards compatibility / test helper: If we're given a blueprint that

--- a/nexus/reconfigurator/planning/src/blueprint_editor/sled_editor/host_phase_2.rs
+++ b/nexus/reconfigurator/planning/src/blueprint_editor/sled_editor/host_phase_2.rs
@@ -1,0 +1,42 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at https://mozilla.org/MPL/2.0/.
+
+use super::scalar::ScalarEditor;
+use nexus_types::deployment::BlueprintHostPhase2DesiredContents;
+use nexus_types::deployment::BlueprintHostPhase2DesiredSlots;
+
+#[derive(Debug)]
+pub(super) struct HostPhase2Editor {
+    slot_a: ScalarEditor<BlueprintHostPhase2DesiredContents>,
+    slot_b: ScalarEditor<BlueprintHostPhase2DesiredContents>,
+}
+
+impl HostPhase2Editor {
+    pub fn new(host_phase_2: BlueprintHostPhase2DesiredSlots) -> Self {
+        let BlueprintHostPhase2DesiredSlots { slot_a, slot_b } = host_phase_2;
+        Self {
+            slot_a: ScalarEditor::new(slot_a),
+            slot_b: ScalarEditor::new(slot_b),
+        }
+    }
+
+    pub fn set_value(&mut self, host_phase_2: BlueprintHostPhase2DesiredSlots) {
+        let BlueprintHostPhase2DesiredSlots { slot_a, slot_b } = host_phase_2;
+        self.slot_a.set_value(slot_a);
+        self.slot_b.set_value(slot_b);
+    }
+
+    pub fn is_modified(&self) -> bool {
+        let Self { slot_a, slot_b } = self;
+        slot_a.is_modified() || slot_b.is_modified()
+    }
+
+    pub fn finalize(self) -> BlueprintHostPhase2DesiredSlots {
+        let Self { slot_a, slot_b } = self;
+        BlueprintHostPhase2DesiredSlots {
+            slot_a: slot_a.finalize(),
+            slot_b: slot_b.finalize(),
+        }
+    }
+}

--- a/nexus/reconfigurator/planning/src/blueprint_editor/sled_editor/host_phase_2.rs
+++ b/nexus/reconfigurator/planning/src/blueprint_editor/sled_editor/host_phase_2.rs
@@ -5,6 +5,7 @@
 use super::scalar::ScalarEditor;
 use nexus_types::deployment::BlueprintHostPhase2DesiredContents;
 use nexus_types::deployment::BlueprintHostPhase2DesiredSlots;
+use omicron_common::disk::M2Slot;
 
 #[derive(Debug)]
 pub(super) struct HostPhase2Editor {
@@ -25,6 +26,18 @@ impl HostPhase2Editor {
         let BlueprintHostPhase2DesiredSlots { slot_a, slot_b } = host_phase_2;
         self.slot_a.set_value(slot_a);
         self.slot_b.set_value(slot_b);
+    }
+
+    pub fn set_slot(
+        &mut self,
+        slot: M2Slot,
+        desired: BlueprintHostPhase2DesiredContents,
+    ) {
+        let target = match slot {
+            M2Slot::A => &mut self.slot_a,
+            M2Slot::B => &mut self.slot_b,
+        };
+        target.set_value(desired);
     }
 
     pub fn is_modified(&self) -> bool {

--- a/nexus/reconfigurator/planning/src/planner.rs
+++ b/nexus/reconfigurator/planning/src/planner.rs
@@ -1608,12 +1608,12 @@ pub(crate) mod test {
     use expectorate::assert_contents;
     use nexus_sled_agent_shared::inventory::ConfigReconcilerInventory;
     use nexus_sled_agent_shared::inventory::ConfigReconcilerInventoryResult;
+    use nexus_types::deployment::BlueprintArtifactVersion;
     use nexus_types::deployment::BlueprintDatasetDisposition;
     use nexus_types::deployment::BlueprintDiffSummary;
     use nexus_types::deployment::BlueprintPhysicalDiskDisposition;
     use nexus_types::deployment::BlueprintZoneDisposition;
     use nexus_types::deployment::BlueprintZoneImageSource;
-    use nexus_types::deployment::BlueprintZoneImageVersion;
     use nexus_types::deployment::BlueprintZoneType;
     use nexus_types::deployment::ClickhouseMode;
     use nexus_types::deployment::ClickhousePolicy;
@@ -5112,7 +5112,7 @@ pub(crate) mod test {
             .expect("can't parse artifact version");
         let fake_hash = ArtifactHash([0; 32]);
         let image_source = BlueprintZoneImageSource::Artifact {
-            version: BlueprintZoneImageVersion::Available {
+            version: BlueprintArtifactVersion::Available {
                 version: version.clone(),
             },
             hash: fake_hash,
@@ -5182,7 +5182,7 @@ pub(crate) mod test {
             })
         {
             zone.image_source = BlueprintZoneImageSource::Artifact {
-                version: BlueprintZoneImageVersion::Available {
+                version: BlueprintArtifactVersion::Available {
                     version: version.clone(),
                 },
                 hash: fake_hash,
@@ -5398,7 +5398,7 @@ pub(crate) mod test {
             .expect("can't parse artifact version");
         let fake_hash = ArtifactHash([0; 32]);
         let image_source = BlueprintZoneImageSource::Artifact {
-            version: BlueprintZoneImageVersion::Available {
+            version: BlueprintArtifactVersion::Available {
                 version: version.clone(),
             },
             hash: fake_hash,

--- a/nexus/reconfigurator/planning/src/planner.rs
+++ b/nexus/reconfigurator/planning/src/planner.rs
@@ -5487,7 +5487,7 @@ pub(crate) mod test {
             .expect("can't parse artifact version");
         let fake_hash = ArtifactHash([0; 32]);
         let image_source = BlueprintZoneImageSource::Artifact {
-            version: BlueprintZoneImageVersion::Available {
+            version: BlueprintArtifactVersion::Available {
                 version: version.clone(),
             },
             hash: fake_hash,
@@ -5536,7 +5536,7 @@ pub(crate) mod test {
             .filter(|z| !z.zone_type.is_cockroach())
         {
             zone.image_source = BlueprintZoneImageSource::Artifact {
-                version: BlueprintZoneImageVersion::Available {
+                version: BlueprintArtifactVersion::Available {
                     version: version.clone(),
                 },
                 hash: fake_hash,

--- a/nexus/reconfigurator/planning/tests/output/example_builder_zone_counts_blueprint.txt
+++ b/nexus/reconfigurator/planning/tests/output/example_builder_zone_counts_blueprint.txt
@@ -3,6 +3,14 @@ parent:    e35b2fdd-354d-48d9-acb5-703b2c269a54
 
   sled: 0dbf1e39-e265-4071-a8df-6d1225b46694 (active, config generation 2)
 
+    host phase 2 contents:
+    ------------------------
+    slot   boot image source
+    ------------------------
+    A      current contents 
+    B      current contents 
+
+
     physical disks:
     ------------------------------------------------------------------------------------
     vendor        model        serial                                        disposition
@@ -104,6 +112,14 @@ parent:    e35b2fdd-354d-48d9-acb5-703b2c269a54
 
   sled: 15cf73a6-445b-4d36-9232-5ed364019bc6 (active, config generation 2)
 
+    host phase 2 contents:
+    ------------------------
+    slot   boot image source
+    ------------------------
+    A      current contents 
+    B      current contents 
+
+
     physical disks:
     ------------------------------------------------------------------------------------
     vendor        model        serial                                        disposition
@@ -200,6 +216,14 @@ parent:    e35b2fdd-354d-48d9-acb5-703b2c269a54
 
   sled: 50e6c1c0-43b2-4abc-9041-41165597f639 (active, config generation 2)
 
+    host phase 2 contents:
+    ------------------------
+    slot   boot image source
+    ------------------------
+    A      current contents 
+    B      current contents 
+
+
     physical disks:
     ------------------------------------------------------------------------------------
     vendor        model        serial                                        disposition
@@ -293,6 +317,14 @@ parent:    e35b2fdd-354d-48d9-acb5-703b2c269a54
 
   sled: 969ff976-df34-402c-a362-53db03a6b97f (active, config generation 2)
 
+    host phase 2 contents:
+    ------------------------
+    slot   boot image source
+    ------------------------
+    A      current contents 
+    B      current contents 
+
+
     physical disks:
     ------------------------------------------------------------------------------------
     vendor        model        serial                                        disposition
@@ -385,6 +417,14 @@ parent:    e35b2fdd-354d-48d9-acb5-703b2c269a54
 
 
   sled: ec5c0b37-b651-4c45-ac1c-24541ef9c44b (active, config generation 2)
+
+    host phase 2 contents:
+    ------------------------
+    slot   boot image source
+    ------------------------
+    A      current contents 
+    B      current contents 
+
 
     physical disks:
     ------------------------------------------------------------------------------------

--- a/nexus/reconfigurator/planning/tests/output/planner_basic_add_sled_2_3.txt
+++ b/nexus/reconfigurator/planning/tests/output/planner_basic_add_sled_2_3.txt
@@ -5,6 +5,14 @@ to:   blueprint 4171ad05-89dd-474b-846b-b007e4346366
 
   sled ec61eded-c34f-443d-a580-dadf757529c4 (active, config generation 2):
 
+    host phase 2 contents:
+    ------------------------
+    slot   boot image source
+    ------------------------
++   A      current contents 
++   B      current contents 
+
+
     physical disks:
     ------------------------------------------------------------------------------------
     vendor        model        serial                                        disposition

--- a/nexus/reconfigurator/planning/tests/output/planner_basic_add_sled_3_5.txt
+++ b/nexus/reconfigurator/planning/tests/output/planner_basic_add_sled_3_5.txt
@@ -5,6 +5,14 @@ to:   blueprint f432fcd5-1284-4058-8b4a-9286a3de6163
 
   sled ec61eded-c34f-443d-a580-dadf757529c4 (active, config generation 2 -> 3):
 
+    host phase 2 contents:
+    ------------------------
+    slot   boot image source
+    ------------------------
+    A      current contents 
+    B      current contents 
+
+
     physical disks:
     ------------------------------------------------------------------------------------
     vendor        model        serial                                        disposition

--- a/nexus/reconfigurator/planning/tests/output/planner_dataset_settings_modified_in_place_1_2.txt
+++ b/nexus/reconfigurator/planning/tests/output/planner_dataset_settings_modified_in_place_1_2.txt
@@ -5,6 +5,14 @@ to:   blueprint fe13be30-94c2-4fa6-aad5-ae3c5028f6bb
 
   sled c52410de-5fea-4e77-b162-756d103523b3 (active, config generation 2 -> 3):
 
+    host phase 2 contents:
+    ------------------------
+    slot   boot image source
+    ------------------------
+    A      current contents 
+    B      current contents 
+
+
     physical disks:
     ------------------------------------------------------------------------------------
     vendor        model        serial                                        disposition

--- a/nexus/reconfigurator/planning/tests/output/planner_decommissions_sleds_1_2.txt
+++ b/nexus/reconfigurator/planning/tests/output/planner_decommissions_sleds_1_2.txt
@@ -5,6 +5,14 @@ to:   blueprint 1ac2d88f-27dd-4506-8585-6b2be832528e
 
   sled a1b477db-b629-48eb-911d-1ccdafca75b9 (active -> decommissioned, config generation 2 -> 3):
 
+    host phase 2 contents:
+    ------------------------
+    slot   boot image source
+    ------------------------
+    A      current contents 
+    B      current contents 
+
+
     physical disks:
     ---------------------------------------------------------------------------------------
     vendor        model        serial                                        disposition   
@@ -169,6 +177,14 @@ to:   blueprint 1ac2d88f-27dd-4506-8585-6b2be832528e
 
   sled d67ce8f0-a691-4010-b414-420d82e80527 (active, config generation 2 -> 3):
 
+    host phase 2 contents:
+    ------------------------
+    slot   boot image source
+    ------------------------
+    A      current contents 
+    B      current contents 
+
+
     physical disks:
     ------------------------------------------------------------------------------------
     vendor        model        serial                                        disposition
@@ -261,6 +277,14 @@ to:   blueprint 1ac2d88f-27dd-4506-8585-6b2be832528e
 
 
   sled fefcf4cf-f7e7-46b3-b629-058526ce440e (active, config generation 2 -> 3):
+
+    host phase 2 contents:
+    ------------------------
+    slot   boot image source
+    ------------------------
+    A      current contents 
+    B      current contents 
+
 
     physical disks:
     ------------------------------------------------------------------------------------

--- a/nexus/reconfigurator/planning/tests/output/planner_decommissions_sleds_bp2.txt
+++ b/nexus/reconfigurator/planning/tests/output/planner_decommissions_sleds_bp2.txt
@@ -3,6 +3,14 @@ parent:    516e80a3-b362-4fac-bd3c-4559717120dd
 
   sled: a1b477db-b629-48eb-911d-1ccdafca75b9 (decommissioned, config generation 3)
 
+    host phase 2 contents:
+    ------------------------
+    slot   boot image source
+    ------------------------
+    A      current contents 
+    B      current contents 
+
+
     physical disks:
     -------------------------------------------------------------------------------------
     vendor        model        serial                                        disposition 
@@ -95,6 +103,14 @@ parent:    516e80a3-b362-4fac-bd3c-4559717120dd
 
 
   sled: d67ce8f0-a691-4010-b414-420d82e80527 (active, config generation 3)
+
+    host phase 2 contents:
+    ------------------------
+    slot   boot image source
+    ------------------------
+    A      current contents 
+    B      current contents 
+
 
     physical disks:
     ------------------------------------------------------------------------------------
@@ -189,6 +205,14 @@ parent:    516e80a3-b362-4fac-bd3c-4559717120dd
 
 
   sled: fefcf4cf-f7e7-46b3-b629-058526ce440e (active, config generation 3)
+
+    host phase 2 contents:
+    ------------------------
+    slot   boot image source
+    ------------------------
+    A      current contents 
+    B      current contents 
+
 
     physical disks:
     ------------------------------------------------------------------------------------

--- a/nexus/reconfigurator/planning/tests/output/planner_deploy_all_keeper_nodes_1_2.txt
+++ b/nexus/reconfigurator/planning/tests/output/planner_deploy_all_keeper_nodes_1_2.txt
@@ -5,6 +5,14 @@ to:   blueprint 31ef2071-2ec9-49d9-8827-fd83b17a0e3d
 
   sled 164d275d-a936-4f06-ad53-a32cb3c8d3c8 (active, config generation 2 -> 3):
 
+    host phase 2 contents:
+    ------------------------
+    slot   boot image source
+    ------------------------
+    A      current contents 
+    B      current contents 
+
+
     physical disks:
     ------------------------------------------------------------------------------------
     vendor        model        serial                                        disposition
@@ -100,6 +108,14 @@ to:   blueprint 31ef2071-2ec9-49d9-8827-fd83b17a0e3d
 
   sled 6a4c45f6-e02f-490c-bbfa-b32fb89e8e86 (active, config generation 2 -> 3):
 
+    host phase 2 contents:
+    ------------------------
+    slot   boot image source
+    ------------------------
+    A      current contents 
+    B      current contents 
+
+
     physical disks:
     ------------------------------------------------------------------------------------
     vendor        model        serial                                        disposition
@@ -194,6 +210,14 @@ to:   blueprint 31ef2071-2ec9-49d9-8827-fd83b17a0e3d
 
 
   sled be531a62-9897-430d-acd2-ce14b4632627 (active, config generation 2 -> 3):
+
+    host phase 2 contents:
+    ------------------------
+    slot   boot image source
+    ------------------------
+    A      current contents 
+    B      current contents 
+
 
     physical disks:
     ------------------------------------------------------------------------------------

--- a/nexus/reconfigurator/planning/tests/output/planner_deploy_all_keeper_nodes_4_5.txt
+++ b/nexus/reconfigurator/planning/tests/output/planner_deploy_all_keeper_nodes_4_5.txt
@@ -5,6 +5,14 @@ to:   blueprint 2886dab5-61a2-46b4-87af-bc7aeb44cccb
 
   sled 6a4c45f6-e02f-490c-bbfa-b32fb89e8e86 (active, config generation 3 -> 4):
 
+    host phase 2 contents:
+    ------------------------
+    slot   boot image source
+    ------------------------
+    A      current contents 
+    B      current contents 
+
+
     physical disks:
     ------------------------------------------------------------------------------------
     vendor        model        serial                                        disposition
@@ -102,6 +110,14 @@ to:   blueprint 2886dab5-61a2-46b4-87af-bc7aeb44cccb
 
 
   sled be531a62-9897-430d-acd2-ce14b4632627 (active, config generation 3 -> 4):
+
+    host phase 2 contents:
+    ------------------------
+    slot   boot image source
+    ------------------------
+    A      current contents 
+    B      current contents 
+
 
     physical disks:
     ------------------------------------------------------------------------------------

--- a/nexus/reconfigurator/planning/tests/output/planner_expunge_clickhouse_clusters_3_4.txt
+++ b/nexus/reconfigurator/planning/tests/output/planner_expunge_clickhouse_clusters_3_4.txt
@@ -5,6 +5,14 @@ to:   blueprint 74f2e7fd-687e-4c9e-b5d8-e474a5bb8e7c
 
   sled b340c044-bd87-4a3b-aee3-e6ccd9d3ff02 (active -> decommissioned, config generation 3 -> 4):
 
+    host phase 2 contents:
+    ------------------------
+    slot   boot image source
+    ------------------------
+    A      current contents 
+    B      current contents 
+
+
     physical disks:
     ---------------------------------------------------------------------------------------
     vendor        model        serial                                        disposition   
@@ -175,6 +183,14 @@ to:   blueprint 74f2e7fd-687e-4c9e-b5d8-e474a5bb8e7c
 
   sled cdba3bea-3407-4b6e-a029-19bf4a02fca7 (active, config generation 3 -> 4):
 
+    host phase 2 contents:
+    ------------------------
+    slot   boot image source
+    ------------------------
+    A      current contents 
+    B      current contents 
+
+
     physical disks:
     ------------------------------------------------------------------------------------
     vendor        model        serial                                        disposition
@@ -275,6 +291,14 @@ to:   blueprint 74f2e7fd-687e-4c9e-b5d8-e474a5bb8e7c
 
 
   sled fe7b9b01-e803-41ea-9e39-db240dcd9029 (active, config generation 3 -> 4):
+
+    host phase 2 contents:
+    ------------------------
+    slot   boot image source
+    ------------------------
+    A      current contents 
+    B      current contents 
+
 
     physical disks:
     ------------------------------------------------------------------------------------

--- a/nexus/reconfigurator/planning/tests/output/planner_expunge_clickhouse_zones_after_policy_is_changed_3_4.txt
+++ b/nexus/reconfigurator/planning/tests/output/planner_expunge_clickhouse_zones_after_policy_is_changed_3_4.txt
@@ -5,6 +5,14 @@ to:   blueprint d895ef50-9978-454c-bdfb-b8dbe2c9a918
 
   sled 883d9767-021c-4836-81cf-fa02d73fead0 (active, config generation 4 -> 5):
 
+    host phase 2 contents:
+    ------------------------
+    slot   boot image source
+    ------------------------
+    A      current contents 
+    B      current contents 
+
+
     physical disks:
     ------------------------------------------------------------------------------------
     vendor        model        serial                                        disposition
@@ -102,6 +110,14 @@ to:   blueprint d895ef50-9978-454c-bdfb-b8dbe2c9a918
 
 
   sled aae6114d-956b-4980-9759-b00b1ed893ee (active, config generation 3 -> 4):
+
+    host phase 2 contents:
+    ------------------------
+    slot   boot image source
+    ------------------------
+    A      current contents 
+    B      current contents 
+
 
     physical disks:
     ------------------------------------------------------------------------------------
@@ -203,6 +219,14 @@ to:   blueprint d895ef50-9978-454c-bdfb-b8dbe2c9a918
 
 
   sled be4a3b25-dde1-40a4-b909-9fa4379a8510 (active, config generation 3 -> 4):
+
+    host phase 2 contents:
+    ------------------------
+    slot   boot image source
+    ------------------------
+    A      current contents 
+    B      current contents 
+
 
     physical disks:
     ------------------------------------------------------------------------------------

--- a/nexus/reconfigurator/planning/tests/output/planner_nonprovisionable_1_2.txt
+++ b/nexus/reconfigurator/planning/tests/output/planner_nonprovisionable_1_2.txt
@@ -5,6 +5,14 @@ to:   blueprint 9f71f5d3-a272-4382-9154-6ea2e171a6c6
 
   sled 48d95fef-bc9f-4f50-9a53-1e075836291d (active -> decommissioned, config generation 2 -> 3):
 
+    host phase 2 contents:
+    ------------------------
+    slot   boot image source
+    ------------------------
+    A      current contents 
+    B      current contents 
+
+
     physical disks:
     ---------------------------------------------------------------------------------------
     vendor        model        serial                                        disposition   
@@ -163,6 +171,14 @@ to:   blueprint 9f71f5d3-a272-4382-9154-6ea2e171a6c6
 
   sled 75bc286f-2b4b-482c-9431-59272af529da (active, config generation 2 -> 3):
 
+    host phase 2 contents:
+    ------------------------
+    slot   boot image source
+    ------------------------
+    A      current contents 
+    B      current contents 
+
+
     physical disks:
     ------------------------------------------------------------------------------------
     vendor        model        serial                                        disposition
@@ -252,6 +268,14 @@ to:   blueprint 9f71f5d3-a272-4382-9154-6ea2e171a6c6
 
 
   sled affab35f-600a-4109-8ea0-34a067a4e0bc (active, config generation 2 -> 3):
+
+    host phase 2 contents:
+    ------------------------
+    slot   boot image source
+    ------------------------
+    A      current contents 
+    B      current contents 
+
 
     physical disks:
     ------------------------------------------------------------------------------------

--- a/nexus/reconfigurator/planning/tests/output/planner_nonprovisionable_2_2a.txt
+++ b/nexus/reconfigurator/planning/tests/output/planner_nonprovisionable_2_2a.txt
@@ -5,6 +5,14 @@ to:   blueprint 9f71f5d3-a272-4382-9154-6ea2e171a6c6
 
   sled 68d24ac5-f341-49ea-a92a-0381b52ab387 (was decommissioned, config generation 2):
 
+    host phase 2 contents:
+    ------------------------
+    slot   boot image source
+    ------------------------
+-   A      current contents 
+-   B      current contents 
+
+
     physical disks:
     ------------------------------------------------------------------------------------
     vendor        model        serial                                        disposition
@@ -96,6 +104,14 @@ to:   blueprint 9f71f5d3-a272-4382-9154-6ea2e171a6c6
 
   sled 2d1cb4f2-cf44-40fc-b118-85036eb732a9 (active, config generation 2):
 
+    host phase 2 contents:
+    ------------------------
+    slot   boot image source
+    ------------------------
+    A      current contents 
+    B      current contents 
+
+
     physical disks:
     ------------------------------------------------------------------------------------
     vendor        model        serial                                        disposition
@@ -186,6 +202,14 @@ to:   blueprint 9f71f5d3-a272-4382-9154-6ea2e171a6c6
 
 
   sled 48d95fef-bc9f-4f50-9a53-1e075836291d (decommissioned, config generation 3 -> 4):
+
+    host phase 2 contents:
+    ------------------------
+    slot   boot image source
+    ------------------------
+    A      current contents 
+    B      current contents 
+
 
     physical disks:
     -------------------------------------------------------------------------------------

--- a/nexus/reconfigurator/planning/tests/output/planner_nonprovisionable_bp2.txt
+++ b/nexus/reconfigurator/planning/tests/output/planner_nonprovisionable_bp2.txt
@@ -3,6 +3,14 @@ parent:    4d4e6c38-cd95-4c4e-8f45-6af4d686964b
 
   sled: 2d1cb4f2-cf44-40fc-b118-85036eb732a9 (active, config generation 2)
 
+    host phase 2 contents:
+    ------------------------
+    slot   boot image source
+    ------------------------
+    A      current contents 
+    B      current contents 
+
+
     physical disks:
     ------------------------------------------------------------------------------------
     vendor        model        serial                                        disposition
@@ -96,6 +104,14 @@ parent:    4d4e6c38-cd95-4c4e-8f45-6af4d686964b
 
   sled: 48d95fef-bc9f-4f50-9a53-1e075836291d (decommissioned, config generation 3)
 
+    host phase 2 contents:
+    ------------------------
+    slot   boot image source
+    ------------------------
+    A      current contents 
+    B      current contents 
+
+
     physical disks:
     -------------------------------------------------------------------------------------
     vendor        model        serial                                        disposition 
@@ -185,6 +201,14 @@ parent:    4d4e6c38-cd95-4c4e-8f45-6af4d686964b
 
 
   sled: 68d24ac5-f341-49ea-a92a-0381b52ab387 (decommissioned, config generation 2)
+
+    host phase 2 contents:
+    ------------------------
+    slot   boot image source
+    ------------------------
+    A      current contents 
+    B      current contents 
+
 
     physical disks:
     ------------------------------------------------------------------------------------
@@ -276,6 +300,14 @@ parent:    4d4e6c38-cd95-4c4e-8f45-6af4d686964b
 
   sled: 75bc286f-2b4b-482c-9431-59272af529da (active, config generation 3)
 
+    host phase 2 contents:
+    ------------------------
+    slot   boot image source
+    ------------------------
+    A      current contents 
+    B      current contents 
+
+
     physical disks:
     ------------------------------------------------------------------------------------
     vendor        model        serial                                        disposition
@@ -366,6 +398,14 @@ parent:    4d4e6c38-cd95-4c4e-8f45-6af4d686964b
 
 
   sled: affab35f-600a-4109-8ea0-34a067a4e0bc (active, config generation 3)
+
+    host phase 2 contents:
+    ------------------------
+    slot   boot image source
+    ------------------------
+    A      current contents 
+    B      current contents 
+
 
     physical disks:
     ------------------------------------------------------------------------------------

--- a/nexus/reconfigurator/planning/tests/output/zone_image_source_change_1.txt
+++ b/nexus/reconfigurator/planning/tests/output/zone_image_source_change_1.txt
@@ -5,6 +5,14 @@ to:   blueprint 665dc34a-dbf2-4d13-9ceb-9542d434ab0e
 
   sled 216f8913-f977-46da-8803-e6b98db7f437 (active, config generation 2 -> 3):
 
+    host phase 2 contents:
+    ------------------------
+    slot   boot image source
+    ------------------------
+    A      current contents 
+    B      current contents 
+
+
     physical disks:
     ------------------------------------------------------------------------------------
     vendor        model        serial                                        disposition

--- a/nexus/src/app/background/tasks/blueprint_execution.rs
+++ b/nexus/src/app/background/tasks/blueprint_execution.rs
@@ -192,8 +192,9 @@ mod test {
         StepOutcome, StepStatus,
     };
     use nexus_types::deployment::{
-        Blueprint, BlueprintSledConfig, BlueprintTarget, BlueprintZoneConfig,
-        BlueprintZoneDisposition, BlueprintZoneImageSource, BlueprintZoneType,
+        Blueprint, BlueprintHostPhase2DesiredSlots, BlueprintSledConfig,
+        BlueprintTarget, BlueprintZoneConfig, BlueprintZoneDisposition,
+        BlueprintZoneImageSource, BlueprintZoneType,
         CockroachDbPreserveDowngrade, OximeterReadMode, PendingMgsUpdates,
         blueprint_zone_type,
     };
@@ -238,6 +239,8 @@ mod test {
                         datasets: IdMap::new(),
                         zones,
                         remove_mupdate_override: None,
+                        host_phase_2:
+                            BlueprintHostPhase2DesiredSlots::current_contents(),
                     },
                 )
             })

--- a/nexus/test-utils/src/lib.rs
+++ b/nexus/test-utils/src/lib.rs
@@ -42,6 +42,7 @@ use nexus_test_interface::NexusServer;
 use nexus_types::deployment::Blueprint;
 use nexus_types::deployment::BlueprintDatasetConfig;
 use nexus_types::deployment::BlueprintDatasetDisposition;
+use nexus_types::deployment::BlueprintHostPhase2DesiredSlots;
 use nexus_types::deployment::BlueprintPhysicalDiskConfig;
 use nexus_types::deployment::BlueprintPhysicalDiskDisposition;
 use nexus_types::deployment::BlueprintSledConfig;
@@ -1498,6 +1499,8 @@ impl<'a, N: NexusServer> ControlPlaneTestContextBuilder<'a, N> {
                     datasets,
                     zones,
                     remove_mupdate_override: None,
+                    host_phase_2:
+                        BlueprintHostPhase2DesiredSlots::current_contents(),
                 },
             );
         }

--- a/nexus/types/src/deployment.rs
+++ b/nexus/types/src/deployment.rs
@@ -1181,6 +1181,19 @@ impl BlueprintHostPhase2DesiredContents {
     }
 }
 
+impl fmt::Display for BlueprintHostPhase2DesiredContents {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self {
+            Self::CurrentContents => {
+                write!(f, "current contents")
+            }
+            Self::Artifact { version, hash: _ } => {
+                write!(f, "artifact: {version}")
+            }
+        }
+    }
+}
+
 #[derive(Clone, Debug, Eq, PartialEq, JsonSchema, Diffable)]
 pub struct PendingMgsUpdates {
     // The IdMap key is the baseboard_id.  Only one outstanding MGS-managed

--- a/nexus/types/src/deployment/blueprint_display.rs
+++ b/nexus/types/src/deployment/blueprint_display.rs
@@ -347,6 +347,18 @@ impl fmt::Display for BpTable {
     }
 }
 
+/// The [`BpTable`] schema for desired host phase 2 contents
+pub struct BpHostPhase2TableSchema {}
+impl BpTableSchema for BpHostPhase2TableSchema {
+    fn table_name(&self) -> &'static str {
+        "host phase 2 contents"
+    }
+
+    fn column_names(&self) -> &'static [&'static str] {
+        &["slot", "boot image source"]
+    }
+}
+
 /// The [`BpTable`] schema for physical disks
 pub struct BpPhysicalDisksTableSchema {}
 impl BpTableSchema for BpPhysicalDisksTableSchema {

--- a/openapi/nexus-internal.json
+++ b/openapi/nexus-internal.json
@@ -2544,6 +2544,45 @@
           "time_created"
         ]
       },
+      "BlueprintArtifactVersion": {
+        "description": "The version of an artifact in a blueprint.\n\nThis is used for debugging output.",
+        "oneOf": [
+          {
+            "description": "A specific version of the image is available.",
+            "type": "object",
+            "properties": {
+              "artifact_version": {
+                "type": "string",
+                "enum": [
+                  "available"
+                ]
+              },
+              "version": {
+                "$ref": "#/components/schemas/ArtifactVersion"
+              }
+            },
+            "required": [
+              "artifact_version",
+              "version"
+            ]
+          },
+          {
+            "description": "The version could not be determined. This is non-fatal.",
+            "type": "object",
+            "properties": {
+              "artifact_version": {
+                "type": "string",
+                "enum": [
+                  "unknown"
+                ]
+              }
+            },
+            "required": [
+              "artifact_version"
+            ]
+          }
+        ]
+      },
       "BlueprintDatasetConfig": {
         "description": "Information about a dataset as recorded in a blueprint",
         "type": "object",
@@ -2609,6 +2648,66 @@
               "expunged"
             ]
           }
+        ]
+      },
+      "BlueprintHostPhase2DesiredContents": {
+        "description": "Describes the desired contents of a host phase 2 slot (i.e., the boot partition on one of the internal M.2 drives).\n\nThis is the blueprint version of [`HostPhase2DesiredContents`].",
+        "oneOf": [
+          {
+            "description": "Do not change the current contents.\n\nWe use this value when we've detected a sled has been mupdated (and we don't want to overwrite phase 2 images until we understand how to recover from that mupdate) and as the default value when reading a blueprint that was ledgered before this concept existed.",
+            "type": "object",
+            "properties": {
+              "type": {
+                "type": "string",
+                "enum": [
+                  "current_contents"
+                ]
+              }
+            },
+            "required": [
+              "type"
+            ]
+          },
+          {
+            "description": "Set the phase 2 slot to the given artifact.\n\nThe artifact will come from an unpacked and distributed TUF repo.",
+            "type": "object",
+            "properties": {
+              "hash": {
+                "type": "string",
+                "format": "hex string (32 bytes)"
+              },
+              "type": {
+                "type": "string",
+                "enum": [
+                  "artifact"
+                ]
+              },
+              "version": {
+                "$ref": "#/components/schemas/BlueprintArtifactVersion"
+              }
+            },
+            "required": [
+              "hash",
+              "type",
+              "version"
+            ]
+          }
+        ]
+      },
+      "BlueprintHostPhase2DesiredSlots": {
+        "description": "Describes the desired contents for both host phase 2 slots.\n\nThis is the blueprint version of [`HostPhase2DesiredSlots`].",
+        "type": "object",
+        "properties": {
+          "slot_a": {
+            "$ref": "#/components/schemas/BlueprintHostPhase2DesiredContents"
+          },
+          "slot_b": {
+            "$ref": "#/components/schemas/BlueprintHostPhase2DesiredContents"
+          }
+        },
+        "required": [
+          "slot_a",
+          "slot_b"
         ]
       },
       "BlueprintMetadata": {
@@ -2798,6 +2897,9 @@
           "disks": {
             "$ref": "#/components/schemas/IdMapBlueprintPhysicalDiskConfig"
           },
+          "host_phase_2": {
+            "$ref": "#/components/schemas/BlueprintHostPhase2DesiredSlots"
+          },
           "remove_mupdate_override": {
             "nullable": true,
             "allOf": [
@@ -2824,6 +2926,7 @@
         "required": [
           "datasets",
           "disks",
+          "host_phase_2",
           "sled_agent_generation",
           "state",
           "zones"
@@ -2993,52 +3096,13 @@
                 ]
               },
               "version": {
-                "$ref": "#/components/schemas/BlueprintZoneImageVersion"
+                "$ref": "#/components/schemas/BlueprintArtifactVersion"
               }
             },
             "required": [
               "hash",
               "type",
               "version"
-            ]
-          }
-        ]
-      },
-      "BlueprintZoneImageVersion": {
-        "description": "The version of a blueprint zone image in use.\n\nThis is used for debugging output.",
-        "oneOf": [
-          {
-            "description": "A specific version of the image is available.",
-            "type": "object",
-            "properties": {
-              "image_version": {
-                "type": "string",
-                "enum": [
-                  "available"
-                ]
-              },
-              "version": {
-                "$ref": "#/components/schemas/ArtifactVersion"
-              }
-            },
-            "required": [
-              "image_version",
-              "version"
-            ]
-          },
-          {
-            "description": "The version could not be determined. This is non-fatal.",
-            "type": "object",
-            "properties": {
-              "image_version": {
-                "type": "string",
-                "enum": [
-                  "unknown"
-                ]
-              }
-            },
-            "required": [
-              "image_version"
             ]
           }
         ]

--- a/schema/crdb/bp-desired-host-phase-2/up1.sql
+++ b/schema/crdb/bp-desired-host-phase-2/up1.sql
@@ -1,0 +1,3 @@
+ALTER TABLE omicron.public.bp_sled_metadata
+    ADD COLUMN IF NOT EXISTS
+    host_phase_2_desired_slot_a STRING(64);

--- a/schema/crdb/bp-desired-host-phase-2/up2.sql
+++ b/schema/crdb/bp-desired-host-phase-2/up2.sql
@@ -1,0 +1,3 @@
+ALTER TABLE omicron.public.bp_sled_metadata
+    ADD COLUMN IF NOT EXISTS
+    host_phase_2_desired_slot_b STRING(64);

--- a/schema/crdb/dbinit.sql
+++ b/schema/crdb/dbinit.sql
@@ -6205,7 +6205,7 @@ INSERT INTO omicron.public.db_metadata (
     version,
     target_version
 ) VALUES
-    (TRUE, NOW(), NOW(), '161.0.0', NULL)
+    (TRUE, NOW(), NOW(), '162.0.0', NULL)
 ON CONFLICT DO NOTHING;
 
 COMMIT;

--- a/schema/crdb/dbinit.sql
+++ b/schema/crdb/dbinit.sql
@@ -4404,6 +4404,13 @@ CREATE TABLE IF NOT EXISTS omicron.public.bp_sled_metadata (
     sled_agent_generation INT8 NOT NULL,
     -- NULL means do not remove any overrides
     remove_mupdate_override UUID,
+
+    -- desired artifact hash for internal disk slots' boot partitions
+    -- NULL is translated to
+    -- `BlueprintHostPhase2DesiredContents::CurrentContents`
+    host_phase_2_desired_slot_a STRING(64),
+    host_phase_2_desired_slot_b STRING(64),
+
     PRIMARY KEY (blueprint_id, sled_id)
 );
 

--- a/sled-agent/src/rack_setup/service.rs
+++ b/sled-agent/src/rack_setup/service.rs
@@ -94,7 +94,8 @@ use nexus_sled_agent_shared::inventory::{
 };
 use nexus_types::deployment::{
     Blueprint, BlueprintDatasetConfig, BlueprintDatasetDisposition,
-    BlueprintZoneType, CockroachDbPreserveDowngrade, blueprint_zone_type,
+    BlueprintHostPhase2DesiredSlots, BlueprintZoneType,
+    CockroachDbPreserveDowngrade, blueprint_zone_type,
 };
 use nexus_types::deployment::{
     BlueprintSledConfig, OximeterReadMode, PendingMgsUpdates,
@@ -1581,6 +1582,8 @@ pub(crate) fn build_initial_blueprint_from_sled_configs(
                 disks: sled_config.disks.clone(),
                 datasets,
                 zones: sled_config.zones.iter().cloned().collect(),
+                host_phase_2: BlueprintHostPhase2DesiredSlots::current_contents(
+                ),
                 remove_mupdate_override: None,
             },
         );


### PR DESCRIPTION
This is a followup to the stack of PRs that added desired host phase 2 contents to `OmicronSledConfig` (#8538 and its followups). We now have a `BlueprintHostPhase2DesiredSlots` inside each `BlueprintSledConfig` that specifies the desired contents (artifact by hash-and-version or "just the current contents", analogous to the install dataset for zones) for each of the two phase 2 slots.

The actual diff is much smaller than github claims; ~75% of the diff here is expectorate output that changed because our blueprint displays and diffs now include a table for this new information.