### PR TITLE
update tufaceous

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -13815,7 +13815,7 @@ dependencies = [
 [[package]]
 name = "tufaceous"
 version = "0.1.0"
-source = "git+https://github.com/oxidecomputer/tufaceous?branch=main#3923a4358e8be55fef0f50859e8ea1efa48f00f0"
+source = "git+https://github.com/oxidecomputer/tufaceous?branch=main#c269f5704d39eb4234e67e18be10d424ef23ac77"
 dependencies = [
  "anyhow",
  "camino",
@@ -13836,7 +13836,7 @@ dependencies = [
 [[package]]
 name = "tufaceous-artifact"
 version = "0.1.0"
-source = "git+https://github.com/oxidecomputer/tufaceous?branch=main#3923a4358e8be55fef0f50859e8ea1efa48f00f0"
+source = "git+https://github.com/oxidecomputer/tufaceous?branch=main#c269f5704d39eb4234e67e18be10d424ef23ac77"
 dependencies = [
  "daft",
  "hex",
@@ -13853,7 +13853,7 @@ dependencies = [
 [[package]]
 name = "tufaceous-brand-metadata"
 version = "0.1.0"
-source = "git+https://github.com/oxidecomputer/tufaceous?branch=main#3923a4358e8be55fef0f50859e8ea1efa48f00f0"
+source = "git+https://github.com/oxidecomputer/tufaceous?branch=main#c269f5704d39eb4234e67e18be10d424ef23ac77"
 dependencies = [
  "semver 1.0.26",
  "serde",
@@ -13865,7 +13865,7 @@ dependencies = [
 [[package]]
 name = "tufaceous-lib"
 version = "0.1.0"
-source = "git+https://github.com/oxidecomputer/tufaceous?branch=main#3923a4358e8be55fef0f50859e8ea1efa48f00f0"
+source = "git+https://github.com/oxidecomputer/tufaceous?branch=main#c269f5704d39eb4234e67e18be10d424ef23ac77"
 dependencies = [
  "anyhow",
  "async-trait",


### PR DESCRIPTION
Pulls in https://github.com/oxidecomputer/tufaceous/pull/34, which fixes loading repositories with many roots in the trust store.