### PR TITLE
Port/ICMP parameter ranges should enforce `first <= last`

### DIFF
--- a/common/src/api/external/mod.rs
+++ b/common/src/api/external/mod.rs
@@ -3870,6 +3870,13 @@ mod test {
                 "range has no start value"
             ))
         );
+        assert_eq!(
+            L4PortRange::try_from("21-20".to_string()).map_err(Into::into),
+            Err(Error::invalid_value(
+                "l4_port_range",
+                "range has larger start value than end value"
+            ))
+        );
     }
 
     #[test]
@@ -4167,6 +4174,13 @@ mod test {
         assert_eq!(
             "icmp:0,30-".parse::<VpcFirewallRuleProtocol>(),
             Err(Error::invalid_value("code", "range has no end value"))
+        );
+        assert_eq!(
+            "icmp:0,21-20".parse::<VpcFirewallRuleProtocol>(),
+            Err(Error::invalid_value(
+                "code",
+                "range has larger start value than end value"
+            ))
         );
     }
 

--- a/nexus/db-fixed-data/src/vpc_firewall_rule.rs
+++ b/nexus/db-fixed-data/src/vpc_firewall_rule.rs
@@ -106,7 +106,7 @@ pub static NEXUS_ICMP_FW_RULE: LazyLock<VpcFirewallRuleUpdate> =
                     // Type 3 -- Destination Unreachable
                     icmp_type: 3,
                     // Codes 3,4 -- Port Unreachable, Fragmentation needed
-                    code: Some((3..=4).into()),
+                    code: Some((3..=4).try_into().expect("3 <= 4")),
                 })),
                 VpcFirewallRuleProtocol::Icmp(Some(VpcFirewallIcmpFilter {
                     // Type 5 -- Redirect

--- a/nexus/db-model/src/vpc_firewall_rule.rs
+++ b/nexus/db-model/src/vpc_firewall_rule.rs
@@ -211,6 +211,17 @@ fn ensure_max_len<T>(
     Ok(())
 }
 
+fn validate_port_ranges(
+    items: &[external::L4PortRange],
+) -> Result<(), external::Error> {
+    for range in items {
+        if range.last < range.first {
+            return Err(external::L4PortRangeError::EmptyRange.into());
+        }
+    }
+    Ok(())
+}
+
 impl VpcFirewallRule {
     pub fn new(
         rule_id: Uuid,
@@ -232,6 +243,7 @@ impl VpcFirewallRule {
         }
         if let Some(ports) = rule.filters.ports.as_ref() {
             ensure_max_len(&ports, "filters.ports", MAX_FW_RULE_PARTS)?;
+            validate_port_ranges(ports.as_slice())?;
         }
         if let Some(protocols) = rule.filters.protocols.as_ref() {
             ensure_max_len(&protocols, "filters.protocols", MAX_FW_RULE_PARTS)?;

--- a/nexus/tests/integration_tests/vpc_firewall.rs
+++ b/nexus/tests/integration_tests/vpc_firewall.rs
@@ -631,7 +631,7 @@ async fn test_firewall_rules_illegal_range(
     assert_eq!(error.error_code, Some("InvalidValue".to_string()));
     assert_eq!(
         error.message,
-        "unsupported value for \"l4_port_range\": range has larger start value than end value"
+        "unsupported value for \"code\": range has larger start value than end value"
     );
 
     rule.filters.protocols = None;

--- a/nexus/tests/integration_tests/vpc_firewall.rs
+++ b/nexus/tests/integration_tests/vpc_firewall.rs
@@ -17,11 +17,12 @@ use nexus_test_utils::resource_helpers::{
 use nexus_test_utils_macros::nexus_test;
 use nexus_types::external_api::views::Vpc;
 use omicron_common::api::external::{
-    IdentityMetadata, L4Port, L4PortRange, ServiceIcmpConfig, VpcFirewallRule,
-    VpcFirewallRuleAction, VpcFirewallRuleDirection, VpcFirewallRuleFilter,
-    VpcFirewallRuleHostFilter, VpcFirewallRulePriority,
-    VpcFirewallRuleProtocol, VpcFirewallRuleStatus, VpcFirewallRuleTarget,
-    VpcFirewallRuleUpdate, VpcFirewallRuleUpdateParams, VpcFirewallRules,
+    IcmpParamRange, IdentityMetadata, L4Port, L4PortRange, ServiceIcmpConfig,
+    VpcFirewallIcmpFilter, VpcFirewallRule, VpcFirewallRuleAction,
+    VpcFirewallRuleDirection, VpcFirewallRuleFilter, VpcFirewallRuleHostFilter,
+    VpcFirewallRulePriority, VpcFirewallRuleProtocol, VpcFirewallRuleStatus,
+    VpcFirewallRuleTarget, VpcFirewallRuleUpdate, VpcFirewallRuleUpdateParams,
+    VpcFirewallRules,
 };
 use omicron_nexus::Nexus;
 use std::convert::TryFrom;
@@ -588,6 +589,68 @@ async fn test_firewall_rules_max_lengths(cptestctx: &ControlPlaneTestContext) {
         format!(
             "unsupported value for \"filters.protocols\": max length {max_parts}"
         )
+    );
+}
+
+#[nexus_test]
+async fn test_firewall_rules_illegal_range(
+    cptestctx: &ControlPlaneTestContext,
+) {
+    let client = &cptestctx.external_client;
+
+    let project_name = "my-project";
+    create_project(&client, &project_name).await;
+
+    let mut rule = VpcFirewallRuleUpdate {
+        name: "illegal-range".parse().unwrap(),
+        description: "".to_string(),
+        status: VpcFirewallRuleStatus::Enabled,
+        direction: VpcFirewallRuleDirection::Inbound,
+        targets: vec![],
+        filters: VpcFirewallRuleFilter {
+            hosts: None,
+            protocols: Some(vec![VpcFirewallRuleProtocol::Icmp(Some(
+                VpcFirewallIcmpFilter {
+                    icmp_type: 0,
+                    code: Some(IcmpParamRange { first: 21, last: 20 }),
+                },
+            ))]),
+            ports: None,
+        },
+        action: VpcFirewallRuleAction::Allow,
+        priority: VpcFirewallRulePriority(65534),
+    };
+
+    let error = object_put_error(
+        client,
+        &format!("/v1/vpc-firewall-rules?vpc=default&project={}", project_name),
+        &VpcFirewallRuleUpdateParams { rules: vec![rule.clone()] },
+        StatusCode::BAD_REQUEST,
+    )
+    .await;
+    assert_eq!(error.error_code, Some("InvalidValue".to_string()));
+    assert_eq!(
+        error.message,
+        "unsupported value for \"l4_port_range\": range has larger start value than end value"
+    );
+
+    rule.filters.protocols = None;
+    rule.filters.ports = Some(vec![L4PortRange {
+        first: L4Port::try_from(1000).unwrap(),
+        last: L4Port::try_from(900).unwrap(),
+    }]);
+
+    let error = object_put_error(
+        client,
+        &format!("/v1/vpc-firewall-rules?vpc=default&project={}", project_name),
+        &VpcFirewallRuleUpdateParams { rules: vec![rule] },
+        StatusCode::BAD_REQUEST,
+    )
+    .await;
+    assert_eq!(error.error_code, Some("InvalidValue".to_string()));
+    assert_eq!(
+        error.message,
+        "unsupported value for \"l4_port_range\": range has larger start value than end value"
     );
 }
 


### PR DESCRIPTION
The console correctly prevents ranges like `3000-1000` for `L4PortRange`s, but we don't catch this in the API itself. This PR enforces that on the frontend, with some allowances for the fact that we might still have such rows in CRDB.

I was torn between enforcing this using transparent types to apply the first/last constraint, which worked in terms of being invisible in the JsonSchema, versus what I did here which is just checking the invariant on conversion to a db::VpcFirewallRule. Unfortunately the former was far messier, and ended up splitting the logic such that it was a little harder to intuit what was checked and where. So, we validate this next to the filter array length checks, which felt fairly natural.