### PR TITLE
Support Bundles: Add user comment support

### DIFF
--- a/dev-tools/omdb/src/bin/omdb/nexus.rs
+++ b/dev-tools/omdb/src/bin/omdb/nexus.rs
@@ -4009,6 +4009,7 @@ async fn cmd_nexus_support_bundles_list(
         reason_for_creation: String,
         reason_for_failure: String,
         state: String,
+        user_comment: String,
     }
     let rows = support_bundles.into_iter().map(|sb| SupportBundleInfo {
         id: *sb.id,
@@ -4018,6 +4019,7 @@ async fn cmd_nexus_support_bundles_list(
             .reason_for_failure
             .unwrap_or_else(|| "-".to_string()),
         state: format!("{:?}", sb.state),
+        user_comment: sb.user_comment.unwrap_or_else(|| "-".to_string()),
     });
     let table = tabled::Table::new(rows)
         .with(tabled::settings::Style::empty())
@@ -4033,7 +4035,9 @@ async fn cmd_nexus_support_bundles_create(
     _destruction_token: DestructiveOperationToken,
 ) -> Result<(), anyhow::Error> {
     let support_bundle_id = client
-        .support_bundle_create()
+        .support_bundle_create(&nexus_client::types::SupportBundleCreate {
+            user_comment: None,
+        })
         .await
         .context("creating support bundle")?
         .into_inner()

--- a/nexus/db-model/src/schema_versions.rs
+++ b/nexus/db-model/src/schema_versions.rs
@@ -16,7 +16,7 @@ use std::{collections::BTreeMap, sync::LazyLock};
 ///
 /// This must be updated when you change the database schema.  Refer to
 /// schema/crdb/README.adoc in the root of this repository for details.
-pub const SCHEMA_VERSION: Version = Version::new(165, 0, 0);
+pub const SCHEMA_VERSION: Version = Version::new(166, 0, 0);
 
 /// List of all past database schema versions, in *reverse* order
 ///
@@ -28,6 +28,7 @@ static KNOWN_VERSIONS: LazyLock<Vec<KnownVersion>> = LazyLock::new(|| {
         // |  leaving the first copy as an example for the next person.
         // v
         // KnownVersion::new(next_int, "unique-dirname-with-the-sql-files"),
+        KnownVersion::new(166, "bundle-user-comment"),
         KnownVersion::new(165, "route-config-rib-priority"),
         KnownVersion::new(164, "fix-leaked-bp-oximeter-read-policy-rows"),
         KnownVersion::new(163, "bp-desired-host-phase-2"),

--- a/nexus/db-model/src/support_bundle.rs
+++ b/nexus/db-model/src/support_bundle.rs
@@ -95,6 +95,7 @@ pub struct SupportBundle {
     pub zpool_id: DbTypedUuid<ZpoolKind>,
     pub dataset_id: DbTypedUuid<DatasetKind>,
     pub assigned_nexus: Option<DbTypedUuid<OmicronZoneKind>>,
+    pub user_comment: Option<String>,
 }
 
 impl SupportBundle {
@@ -103,6 +104,7 @@ impl SupportBundle {
         zpool_id: ZpoolUuid,
         dataset_id: DatasetUuid,
         nexus_id: OmicronZoneUuid,
+        user_comment: Option<String>,
     ) -> Self {
         Self {
             id: SupportBundleUuid::new_v4().into(),
@@ -113,6 +115,7 @@ impl SupportBundle {
             zpool_id: zpool_id.into(),
             dataset_id: dataset_id.into(),
             assigned_nexus: Some(nexus_id.into()),
+            user_comment,
         }
     }
 
@@ -128,6 +131,7 @@ impl From<SupportBundle> for SupportBundleView {
             time_created: bundle.time_created,
             reason_for_creation: bundle.reason_for_creation,
             reason_for_failure: bundle.reason_for_failure,
+            user_comment: bundle.user_comment,
             state: bundle.state.into(),
         }
     }

--- a/nexus/db-schema/src/schema.rs
+++ b/nexus/db-schema/src/schema.rs
@@ -1470,6 +1470,7 @@ table! {
         dataset_id -> Uuid,
 
         assigned_nexus -> Nullable<Uuid>,
+        user_comment -> Nullable<Text>,
     }
 }
 

--- a/nexus/external-api/output/nexus_tags.txt
+++ b/nexus/external-api/output/nexus_tags.txt
@@ -62,6 +62,7 @@ support_bundle_head                      HEAD     /experimental/v1/system/suppor
 support_bundle_head_file                 HEAD     /experimental/v1/system/support-bundles/{bundle_id}/download/{file}
 support_bundle_index                     GET      /experimental/v1/system/support-bundles/{bundle_id}/index
 support_bundle_list                      GET      /experimental/v1/system/support-bundles
+support_bundle_update                    PUT      /experimental/v1/system/support-bundles/{bundle_id}
 support_bundle_view                      GET      /experimental/v1/system/support-bundles/{bundle_id}
 system_update_get_repository             GET      /v1/system/update/repository/{system_version}
 system_update_put_repository             PUT      /v1/system/update/repository

--- a/nexus/external-api/src/lib.rs
+++ b/nexus/external-api/src/lib.rs
@@ -3368,6 +3368,7 @@ pub trait NexusExternalApi {
     }]
     async fn support_bundle_create(
         rqctx: RequestContext<Self::Context>,
+        body: TypedBody<params::SupportBundleCreate>,
     ) -> Result<HttpResponseCreated<shared::SupportBundleInfo>, HttpError>;
 
     /// Delete an existing support bundle
@@ -3383,6 +3384,18 @@ pub trait NexusExternalApi {
         rqctx: RequestContext<Self::Context>,
         path_params: Path<params::SupportBundlePath>,
     ) -> Result<HttpResponseDeleted, HttpError>;
+
+    /// Update a support bundle
+    #[endpoint {
+        method = PUT,
+        path = "/experimental/v1/system/support-bundles/{bundle_id}",
+        tags = ["experimental"], // system/support-bundles: only one tag is allowed
+    }]
+    async fn support_bundle_update(
+        rqctx: RequestContext<Self::Context>,
+        path_params: Path<params::SupportBundlePath>,
+        body: TypedBody<params::SupportBundleUpdate>,
+    ) -> Result<HttpResponseOk<shared::SupportBundleInfo>, HttpError>;
 
     // Probes (experimental)
 

--- a/nexus/internal-api/src/lib.rs
+++ b/nexus/internal-api/src/lib.rs
@@ -665,6 +665,7 @@ pub trait NexusInternalApi {
     }]
     async fn support_bundle_create(
         rqctx: RequestContext<Self::Context>,
+        body: TypedBody<params::SupportBundleCreate>,
     ) -> Result<HttpResponseCreated<shared::SupportBundleInfo>, HttpError>;
 
     /// Delete an existing support bundle
@@ -679,6 +680,17 @@ pub trait NexusInternalApi {
         rqctx: RequestContext<Self::Context>,
         path_params: Path<params::SupportBundlePath>,
     ) -> Result<HttpResponseDeleted, HttpError>;
+
+    /// Update a support bundle
+    #[endpoint {
+        method = PUT,
+        path = "/experimental/v1/system/support-bundles/{bundle_id}",
+    }]
+    async fn support_bundle_update(
+        rqctx: RequestContext<Self::Context>,
+        path_params: Path<params::SupportBundlePath>,
+        body: TypedBody<params::SupportBundleUpdate>,
+    ) -> Result<HttpResponseOk<shared::SupportBundleInfo>, HttpError>;
 
     /// Get all the probes associated with a given sled.
     #[endpoint {

--- a/nexus/src/app/background/tasks/support_bundle_collector.rs
+++ b/nexus/src/app/background/tasks/support_bundle_collector.rs
@@ -1454,7 +1454,12 @@ mod test {
         // Assign a bundle to ourselves. We expect to collect it on
         // the next call to "collect_bundle".
         let bundle = datastore
-            .support_bundle_create(&opctx, "For collection testing", nexus.id())
+            .support_bundle_create(
+                &opctx,
+                "For collection testing",
+                nexus.id(),
+                None,
+            )
             .await
             .expect("Couldn't allocate a support bundle");
         assert_eq!(bundle.state, SupportBundleState::Collecting);
@@ -1514,7 +1519,12 @@ mod test {
             TestDataset::setup(cptestctx, &datastore, &opctx, 1).await;
 
         let bundle = datastore
-            .support_bundle_create(&opctx, "For collection testing", nexus.id())
+            .support_bundle_create(
+                &opctx,
+                "For collection testing",
+                nexus.id(),
+                None,
+            )
             .await
             .expect("Couldn't allocate a support bundle");
         assert_eq!(bundle.state, SupportBundleState::Collecting);
@@ -1594,11 +1604,21 @@ mod test {
 
         // Assign two bundles to ourselves.
         let bundle1 = datastore
-            .support_bundle_create(&opctx, "For collection testing", nexus.id())
+            .support_bundle_create(
+                &opctx,
+                "For collection testing",
+                nexus.id(),
+                None,
+            )
             .await
             .expect("Couldn't allocate a support bundle");
         let bundle2 = datastore
-            .support_bundle_create(&opctx, "For collection testing", nexus.id())
+            .support_bundle_create(
+                &opctx,
+                "For collection testing",
+                nexus.id(),
+                None,
+            )
             .await
             .expect("Couldn't allocate a second support bundle");
 
@@ -1679,7 +1699,12 @@ mod test {
         // If we delete the bundle before we start collection, we can delete it
         // immediately.
         let bundle = datastore
-            .support_bundle_create(&opctx, "For collection testing", nexus.id())
+            .support_bundle_create(
+                &opctx,
+                "For collection testing",
+                nexus.id(),
+                None,
+            )
             .await
             .expect("Couldn't allocate a support bundle");
         assert_eq!(bundle.state, SupportBundleState::Collecting);
@@ -1738,7 +1763,12 @@ mod test {
 
         // We can allocate a support bundle and collect it
         let bundle = datastore
-            .support_bundle_create(&opctx, "For collection testing", nexus.id())
+            .support_bundle_create(
+                &opctx,
+                "For collection testing",
+                nexus.id(),
+                None,
+            )
             .await
             .expect("Couldn't allocate a support bundle");
         assert_eq!(bundle.state, SupportBundleState::Collecting);
@@ -1811,7 +1841,12 @@ mod test {
         // We can allocate a support bundle, though we'll fail it before it gets
         // collected.
         let bundle = datastore
-            .support_bundle_create(&opctx, "For collection testing", nexus.id())
+            .support_bundle_create(
+                &opctx,
+                "For collection testing",
+                nexus.id(),
+                None,
+            )
             .await
             .expect("Couldn't allocate a support bundle");
         assert_eq!(bundle.state, SupportBundleState::Collecting);
@@ -1875,7 +1910,12 @@ mod test {
 
         // We can allocate a support bundle and collect it
         let bundle = datastore
-            .support_bundle_create(&opctx, "For collection testing", nexus.id())
+            .support_bundle_create(
+                &opctx,
+                "For collection testing",
+                nexus.id(),
+                None,
+            )
             .await
             .expect("Couldn't allocate a support bundle");
         assert_eq!(bundle.state, SupportBundleState::Collecting);
@@ -1955,7 +1995,12 @@ mod test {
 
         // We can allocate a support bundle and collect it
         let bundle = datastore
-            .support_bundle_create(&opctx, "For collection testing", nexus.id())
+            .support_bundle_create(
+                &opctx,
+                "For collection testing",
+                nexus.id(),
+                None,
+            )
             .await
             .expect("Couldn't allocate a support bundle");
         assert_eq!(bundle.state, SupportBundleState::Collecting);

--- a/nexus/tests/integration_tests/endpoints.rs
+++ b/nexus/tests/integration_tests/endpoints.rs
@@ -1421,8 +1421,8 @@ pub static URL_USERS_DB_INIT: LazyLock<String> = LazyLock::new(|| {
 });
 
 /// List of endpoints to be verified
-pub static VERIFY_ENDPOINTS: LazyLock<Vec<VerifyEndpoint>> =
-    LazyLock::new(|| {
+pub static VERIFY_ENDPOINTS: LazyLock<Vec<VerifyEndpoint>> = LazyLock::new(
+    || {
         vec![
             // Global IAM policy
             VerifyEndpoint {
@@ -2499,7 +2499,9 @@ pub static VERIFY_ENDPOINTS: LazyLock<Vec<VerifyEndpoint>> =
                 unprivileged_access: UnprivilegedAccess::None,
                 allowed_methods: vec![
                     AllowedMethod::Get,
-                    AllowedMethod::Post(serde_json::to_value(()).unwrap()),
+                    AllowedMethod::Post(serde_json::to_value(&nexus_types::external_api::params::SupportBundleCreate {
+                        user_comment: None,
+                    }).unwrap()),
                 ],
             },
             VerifyEndpoint {
@@ -2509,6 +2511,12 @@ pub static VERIFY_ENDPOINTS: LazyLock<Vec<VerifyEndpoint>> =
                 allowed_methods: vec![
                     AllowedMethod::Get,
                     AllowedMethod::Delete,
+                    AllowedMethod::Put(
+                        serde_json::to_value(&params::SupportBundleUpdate {
+                            user_comment: None,
+                        })
+                        .unwrap(),
+                    ),
                 ],
             },
             /* Updates */
@@ -3021,4 +3029,5 @@ pub static VERIFY_ENDPOINTS: LazyLock<Vec<VerifyEndpoint>> =
                 allowed_methods: vec![AllowedMethod::Get],
             },
         ]
-    });
+    },
+);

--- a/nexus/tests/integration_tests/unauthorized.rs
+++ b/nexus/tests/integration_tests/unauthorized.rs
@@ -397,7 +397,12 @@ static SETUP_REQUESTS: LazyLock<Vec<SetupReq>> = LazyLock::new(|| {
         // Create a Support Bundle
         SetupReq::Post {
             url: &SUPPORT_BUNDLES_URL,
-            body: serde_json::to_value(()).unwrap(),
+            body: serde_json::to_value(
+                &nexus_types::external_api::params::SupportBundleCreate {
+                    user_comment: None,
+                },
+            )
+            .unwrap(),
             id_routes: vec!["/experimental/v1/system/support-bundles/{id}"],
         },
         // Create a trusted root for updates

--- a/nexus/types/src/external_api/params.rs
+++ b/nexus/types/src/external_api/params.rs
@@ -159,6 +159,18 @@ pub struct SupportBundleFilePath {
     pub file: String,
 }
 
+#[derive(Debug, Clone, Serialize, Deserialize, JsonSchema)]
+pub struct SupportBundleCreate {
+    /// User comment for the support bundle
+    pub user_comment: Option<String>,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, JsonSchema)]
+pub struct SupportBundleUpdate {
+    /// User comment for the support bundle
+    pub user_comment: Option<String>,
+}
+
 #[derive(Debug, Clone, Serialize, Deserialize, JsonSchema, PartialEq)]
 pub struct OptionalSiloSelector {
     /// Name or ID of the silo

--- a/nexus/types/src/external_api/shared.rs
+++ b/nexus/types/src/external_api/shared.rs
@@ -645,6 +645,7 @@ pub struct SupportBundleInfo {
     pub time_created: DateTime<Utc>,
     pub reason_for_creation: String,
     pub reason_for_failure: Option<String>,
+    pub user_comment: Option<String>,
     pub state: SupportBundleState,
 }
 

--- a/openapi/nexus-internal.json
+++ b/openapi/nexus-internal.json
@@ -911,6 +911,16 @@
       "post": {
         "summary": "Create a new support bundle",
         "operationId": "support_bundle_create",
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/SupportBundleCreate"
+              }
+            }
+          },
+          "required": true
+        },
         "responses": {
           "201": {
             "description": "successful creation",
@@ -947,6 +957,50 @@
             }
           }
         ],
+        "responses": {
+          "200": {
+            "description": "successful operation",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/SupportBundleInfo"
+                }
+              }
+            }
+          },
+          "4XX": {
+            "$ref": "#/components/responses/Error"
+          },
+          "5XX": {
+            "$ref": "#/components/responses/Error"
+          }
+        }
+      },
+      "put": {
+        "summary": "Update a support bundle",
+        "operationId": "support_bundle_update",
+        "parameters": [
+          {
+            "in": "path",
+            "name": "bundle_id",
+            "description": "ID of the support bundle",
+            "required": true,
+            "schema": {
+              "type": "string",
+              "format": "uuid"
+            }
+          }
+        ],
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/SupportBundleUpdate"
+              }
+            }
+          },
+          "required": true
+        },
         "responses": {
           "200": {
             "description": "successful operation",
@@ -7419,6 +7473,16 @@
           "weight"
         ]
       },
+      "SupportBundleCreate": {
+        "type": "object",
+        "properties": {
+          "user_comment": {
+            "nullable": true,
+            "description": "User comment for the support bundle",
+            "type": "string"
+          }
+        }
+      },
       "SupportBundleInfo": {
         "type": "object",
         "properties": {
@@ -7438,6 +7502,10 @@
           "time_created": {
             "type": "string",
             "format": "date-time"
+          },
+          "user_comment": {
+            "nullable": true,
+            "type": "string"
           }
         },
         "required": [
@@ -7499,6 +7567,16 @@
             ]
           }
         ]
+      },
+      "SupportBundleUpdate": {
+        "type": "object",
+        "properties": {
+          "user_comment": {
+            "nullable": true,
+            "description": "User comment for the support bundle",
+            "type": "string"
+          }
+        }
       },
       "SwitchLocation": {
         "description": "Identifies switch physical location",

--- a/openapi/nexus.json
+++ b/openapi/nexus.json
@@ -365,6 +365,16 @@
         ],
         "summary": "Create a new support bundle",
         "operationId": "support_bundle_create",
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/SupportBundleCreate"
+              }
+            }
+          },
+          "required": true
+        },
         "responses": {
           "201": {
             "description": "successful creation",
@@ -404,6 +414,53 @@
             }
           }
         ],
+        "responses": {
+          "200": {
+            "description": "successful operation",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/SupportBundleInfo"
+                }
+              }
+            }
+          },
+          "4XX": {
+            "$ref": "#/components/responses/Error"
+          },
+          "5XX": {
+            "$ref": "#/components/responses/Error"
+          }
+        }
+      },
+      "put": {
+        "tags": [
+          "experimental"
+        ],
+        "summary": "Update a support bundle",
+        "operationId": "support_bundle_update",
+        "parameters": [
+          {
+            "in": "path",
+            "name": "bundle_id",
+            "description": "ID of the support bundle",
+            "required": true,
+            "schema": {
+              "type": "string",
+              "format": "uuid"
+            }
+          }
+        ],
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/SupportBundleUpdate"
+              }
+            }
+          },
+          "required": true
+        },
         "responses": {
           "200": {
             "description": "successful operation",
@@ -24173,6 +24230,16 @@
           "items"
         ]
       },
+      "SupportBundleCreate": {
+        "type": "object",
+        "properties": {
+          "user_comment": {
+            "nullable": true,
+            "description": "User comment for the support bundle",
+            "type": "string"
+          }
+        }
+      },
       "SupportBundleInfo": {
         "type": "object",
         "properties": {
@@ -24192,6 +24259,10 @@
           "time_created": {
             "type": "string",
             "format": "date-time"
+          },
+          "user_comment": {
+            "nullable": true,
+            "type": "string"
           }
         },
         "required": [
@@ -24253,6 +24324,16 @@
             ]
           }
         ]
+      },
+      "SupportBundleUpdate": {
+        "type": "object",
+        "properties": {
+          "user_comment": {
+            "nullable": true,
+            "description": "User comment for the support bundle",
+            "type": "string"
+          }
+        }
       },
       "Switch": {
         "description": "An operator's view of a Switch.",

--- a/schema/crdb/bundle-user-comment/up01.sql
+++ b/schema/crdb/bundle-user-comment/up01.sql
@@ -1,0 +1,1 @@
+ALTER TABLE omicron.public.support_bundle ADD COLUMN IF NOT EXISTS user_comment TEXT;

--- a/schema/crdb/dbinit.sql
+++ b/schema/crdb/dbinit.sql
@@ -2650,7 +2650,10 @@ CREATE TABLE IF NOT EXISTS omicron.public.support_bundle (
 
     -- The Nexus which is in charge of collecting the support bundle,
     -- and later managing its storage.
-    assigned_nexus UUID
+    assigned_nexus UUID,
+
+    user_comment TEXT
+
 );
 
 -- The "UNIQUE" part of this index helps enforce that we allow one support bundle
@@ -6209,7 +6212,7 @@ INSERT INTO omicron.public.db_metadata (
     version,
     target_version
 ) VALUES
-    (TRUE, NOW(), NOW(), '165.0.0', NULL)
+    (TRUE, NOW(), NOW(), '166.0.0', NULL)
 ON CONFLICT DO NOTHING;
 
 COMMIT;


### PR DESCRIPTION
Adds a text field for support bundles, letting users supply string labels as comments

Fixes https://github.com/oxidecomputer/omicron/issues/8550