### PR TITLE
nexus: update `switch_port_settings_route_config` schema

### DIFF
--- a/common/src/api/external/mod.rs
+++ b/common/src/api/external/mod.rs
@@ -2998,7 +2998,8 @@ pub struct SwitchPortRouteConfig {
     /// over an 802.1Q tagged L2 segment.
     pub vlan_id: Option<u16>,
 
-    /// RIB Priority indicating priority within and across protocols.
+    /// Route RIB priority. Higher priority indicates precedence within and across
+    /// protocols.
     pub rib_priority: Option<u8>,
 }
 

--- a/nexus/db-model/src/schema_versions.rs
+++ b/nexus/db-model/src/schema_versions.rs
@@ -16,7 +16,7 @@ use std::{collections::BTreeMap, sync::LazyLock};
 ///
 /// This must be updated when you change the database schema.  Refer to
 /// schema/crdb/README.adoc in the root of this repository for details.
-pub const SCHEMA_VERSION: Version = Version::new(161, 0, 0);
+pub const SCHEMA_VERSION: Version = Version::new(162, 0, 0);
 
 /// List of all past database schema versions, in *reverse* order
 ///
@@ -28,6 +28,7 @@ static KNOWN_VERSIONS: LazyLock<Vec<KnownVersion>> = LazyLock::new(|| {
         // |  leaving the first copy as an example for the next person.
         // v
         // KnownVersion::new(next_int, "unique-dirname-with-the-sql-files"),
+        KnownVersion::new(162, "route-config-rib-priority"),
         KnownVersion::new(161, "inv_cockroachdb_status"),
         KnownVersion::new(160, "tuf-trust-root"),
         KnownVersion::new(159, "sled-config-desired-host-phase-2"),

--- a/nexus/db-model/src/switch_port.rs
+++ b/nexus/db-model/src/switch_port.rs
@@ -609,7 +609,6 @@ pub struct SwitchPortRouteConfig {
     pub dst: IpNetwork,
     pub gw: IpNetwork,
     pub vid: Option<SqlU16>,
-    #[diesel(column_name = local_pref)]
     pub rib_priority: Option<SqlU8>,
 }
 

--- a/nexus/db-schema/src/schema.rs
+++ b/nexus/db-schema/src/schema.rs
@@ -202,7 +202,7 @@ table! {
         dst -> Inet,
         gw -> Inet,
         vid -> Nullable<Int4>,
-        local_pref -> Nullable<Int2>,
+        rib_priority -> Nullable<Int2>,
     }
 }
 

--- a/nexus/types/src/external_api/params.rs
+++ b/nexus/types/src/external_api/params.rs
@@ -2003,8 +2003,8 @@ pub struct Route {
     /// VLAN id the gateway is reachable over.
     pub vid: Option<u16>,
 
-    /// Local preference for route. Higher preference indictes precedence
-    /// within and across protocols.
+    /// Route RIB priority. Higher priority indicates precedence within and across
+    /// protocols.
     pub rib_priority: Option<u8>,
 }
 

--- a/openapi/nexus.json
+++ b/openapi/nexus.json
@@ -22294,7 +22294,7 @@
           },
           "rib_priority": {
             "nullable": true,
-            "description": "Local preference for route. Higher preference indictes precedence within and across protocols.",
+            "description": "Route RIB priority. Higher priority indicates precedence within and across protocols.",
             "type": "integer",
             "format": "uint8",
             "minimum": 0
@@ -24570,7 +24570,7 @@
           },
           "rib_priority": {
             "nullable": true,
-            "description": "RIB Priority indicating priority within and across protocols.",
+            "description": "Route RIB priority. Higher priority indicates precedence within and across protocols.",
             "type": "integer",
             "format": "uint8",
             "minimum": 0

--- a/schema/crdb/dbinit.sql
+++ b/schema/crdb/dbinit.sql
@@ -3144,7 +3144,7 @@ CREATE TABLE IF NOT EXISTS omicron.public.switch_port_settings_route_config (
     dst INET,
     gw INET,
     vid INT4,
-    local_pref INT8,
+    rib_priority INT2,
 
     /* TODO https://github.com/oxidecomputer/omicron/issues/3013 */
     PRIMARY KEY (port_settings_id, interface_name, dst, gw)
@@ -6198,7 +6198,7 @@ INSERT INTO omicron.public.db_metadata (
     version,
     target_version
 ) VALUES
-    (TRUE, NOW(), NOW(), '161.0.0', NULL)
+    (TRUE, NOW(), NOW(), '162.0.0', NULL)
 ON CONFLICT DO NOTHING;
 
 COMMIT;

--- a/schema/crdb/route-config-rib-priority/up01.sql
+++ b/schema/crdb/route-config-rib-priority/up01.sql
@@ -1,0 +1,1 @@
+ALTER TABLE omicron.public.switch_port_settings_route_config ADD COLUMN rib_priority INT2;

--- a/schema/crdb/route-config-rib-priority/up02.sql
+++ b/schema/crdb/route-config-rib-priority/up02.sql
@@ -1,0 +1,7 @@
+UPDATE omicron.public.switch_port_settings_route_config
+SET rib_priority = 
+    CASE 
+        WHEN local_pref > 255 THEN 255
+        WHEN local_pref < 0 THEN 0
+        ELSE local_pref::INT2
+    END;

--- a/schema/crdb/route-config-rib-priority/up03.sql
+++ b/schema/crdb/route-config-rib-priority/up03.sql
@@ -1,0 +1,1 @@
+ALTER TABLE omicron.public.switch_port_settings_route_config DROP COLUMN local_pref;


### PR DESCRIPTION
I renamed the `local_pref` column to `rib_priority` to complete the rename in https://github.com/oxidecomputer/omicron/pull/6693.

I also changed the type of the renamed column from `INT8` to `INT2`, clamping existing values to `0` or `255`. This was missed in https://github.com/oxidecomputer/omicron/pull/6693 and led to the following error when reading the value from the database.

```
{"msg":"request completed","v":0,"name":"omicron-dev","level":30,"time":"2025-07-11T13:57:48.670343242Z","hostname":"ms-ox01","pid":3113,"uri":"/v1/system/networking/switch-port-settings","method":"POST","req_id":"12b35f5a-2255-4244-a5aa-f9c84032fb81","remote_addr":"127.0.0.1:41766","local_addr":"127.0.0.1:12220","component":"dropshot_external","name":"e6bff1ff-24fb-49dc-a54e-c6a350cd4d6c","error_message_external":"Internal Server Error","error_message_internal":"Unknown diesel error creating SwitchPortSettings called \"example\": Error deserializing field 'local_pref': Received more than 2 bytes while decoding an i16. Was an Integer expression accidentally marked as SmallInt?","latency_us":133766,"response_code":500}
```

The error occurred because the Rust type was `SqlU8` and the database type was `INT8`. Reads would fail because `INT8` columns could not be read into `SqlU8` types without loss of precision.

This was caught in
https://github.com/oxidecomputer/terraform-provider-oxide/pull/426 when implementing a Terraform provider resource for switch port settings. It's likely that this has been broken since https://github.com/oxidecomputer/omicron/pull/6693 and any user that attempted to set `rib_priority` in their Rack Setup Service (RSS) would have encountered this error. However, `rib_priority` is an uncommon configuration option and none of our customer's RSS configurations show this as being set.

Given this information, it seems safe to assume that no customer has the `rib_priority` column set so the clamping logic implemented here should work well for customer installations.