### PR TITLE
cockroach-admin-server: use a smaller tokio worker pool

### DIFF
--- a/cockroach-admin/src/bin/cockroach-admin.rs
+++ b/cockroach-admin/src/bin/cockroach-admin.rs
@@ -51,7 +51,9 @@ enum Args {
 }
 
 fn main() {
-    if let Err(err) = oxide_tokio_rt::run(main_impl()) {
+    let mut builder = oxide_tokio_rt::Builder::new_multi_thread();
+    builder.worker_threads(8);
+    if let Err(err) = oxide_tokio_rt::run_builder(&mut builder, main_impl()) {
         fatal(err);
     }
 }


### PR DESCRIPTION
followup from https://github.com/oxidecomputer/omicron/pull/8555#discussion_r2199377772