### PR TITLE
TQ: Encrypt all necessary prior rack secrets

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -13806,6 +13806,7 @@ dependencies = [
  "sha3",
  "slog",
  "slog-error-chain",
+ "static_assertions",
  "subtle",
  "test-strategy",
  "thiserror 2.0.12",

--- a/trust-quorum/Cargo.toml
+++ b/trust-quorum/Cargo.toml
@@ -17,6 +17,7 @@ gfss.workspace = true
 hex.workspace = true
 hkdf.workspace = true
 iddqd.workspace = true
+omicron-uuid-kinds.workspace = true
 rand = { workspace = true, features = ["getrandom"] }
 secrecy.workspace = true
 serde.workspace = true
@@ -24,11 +25,11 @@ serde_with.workspace = true
 sha3.workspace = true
 slog.workspace = true
 slog-error-chain.workspace = true
+static_assertions.workspace = true
 subtle.workspace = true
 thiserror.workspace = true
 tokio.workspace = true
 uuid.workspace = true
-omicron-uuid-kinds.workspace = true
 zeroize.workspace = true
 omicron-workspace-hack.workspace = true
 

--- a/trust-quorum/src/configuration.rs
+++ b/trust-quorum/src/configuration.rs
@@ -4,7 +4,7 @@
 
 //! A configuration of a trust quroum at a given epoch
 
-use crate::crypto::{EncryptedRackSecret, RackSecret, Salt, Sha3_256Digest};
+use crate::crypto::{EncryptedRackSecrets, RackSecret, Sha3_256Digest};
 use crate::validators::ValidatedReconfigureMsg;
 use crate::{Epoch, PlatformId, Threshold};
 use gfss::shamir::{Share, SplitError};
@@ -47,8 +47,8 @@ pub struct Configuration {
     /// The number of sleds required to reconstruct the rack secret
     pub threshold: Threshold,
 
-    // There is no previous configuration for the initial configuration
-    pub previous_configuration: Option<PreviousConfiguration>,
+    // There are no encrypted rack secrets for the initial configuration
+    pub encrypted_rack_secrets: Option<EncryptedRackSecrets>,
 }
 
 impl IdOrdItem for Configuration {
@@ -105,34 +105,9 @@ impl Configuration {
                 coordinator,
                 members,
                 threshold: reconfigure_msg.threshold(),
-                previous_configuration: None,
+                encrypted_rack_secrets: None,
             },
             shares,
         ))
     }
-}
-
-/// Information for the last committed configuration that is necessary to track
-/// in the next `Configuration`.
-#[derive(
-    Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Serialize, Deserialize,
-)]
-pub struct PreviousConfiguration {
-    /// The epoch of the last committed configuration
-    pub epoch: Epoch,
-
-    /// Is the previous configuration LRTQ?
-    pub is_lrtq: bool,
-
-    /// The encrypted rack secret for the last committed epoch
-    ///
-    /// This allows us to derive old encryption keys so they can be rotated
-    pub encrypted_last_committed_rack_secret: EncryptedRackSecret,
-
-    /// A random value used to derive the key to encrypt the rack secret from
-    /// the last committed epoch.
-    ///
-    /// We only encrypt the rack secret once and so we use a nonce of all zeros.
-    /// This is why there is no corresponding `nonce` field.
-    pub encrypted_last_committed_rack_secret_salt: Salt,
 }

--- a/trust-quorum/src/crypto.rs
+++ b/trust-quorum/src/crypto.rs
@@ -9,7 +9,7 @@ use chacha20poly1305::{ChaCha20Poly1305, Key, KeyInit, aead, aead::Aead};
 use derive_more::From;
 use gfss::shamir::{self, CombineError, SecretShares, Share, SplitError};
 use hkdf::Hkdf;
-use omicron_uuid_kinds::{GenericUuid, RackUuid};
+use omicron_uuid_kinds::RackUuid;
 use rand::RngCore;
 use rand::rngs::OsRng;
 use secrecy::{ExposeSecret, SecretBox};
@@ -428,11 +428,7 @@ fn derive_encryption_key_for_rack_secrets(
 
     // SAFETY: `key` is sized such that `prk.expand_multi_info` will never fail.
     prk.expand_multi_info(
-        &[
-            KEY_CONTEXT,
-            rack_id.as_untyped_uuid().as_ref(),
-            &epoch.0.to_be_bytes(),
-        ],
+        &[KEY_CONTEXT, rack_id.as_ref(), &epoch.0.to_be_bytes()],
         key.as_mut(),
     )
     .unwrap();

--- a/trust-quorum/src/crypto.rs
+++ b/trust-quorum/src/crypto.rs
@@ -339,7 +339,7 @@ impl EncryptedRackSecrets {
 /// at. Eventually they will learn the latest configuration and decrypt
 /// `EncryptedRackSecrets` in order to get these plaintext versions. They will
 /// then use the rack secret for their currently committed configuration for key
-/// rotation .
+/// rotation.
 pub struct PlaintextRackSecrets {
     secrets: BTreeMap<Epoch, ReconstructedRackSecret>,
 }

--- a/trust-quorum/src/crypto.rs
+++ b/trust-quorum/src/crypto.rs
@@ -5,19 +5,24 @@
 //! Various cryptographic constructs used by trust quroum.
 
 use bootstore::trust_quorum::RackSecret as LrtqRackSecret;
+use chacha20poly1305::{ChaCha20Poly1305, Key, KeyInit, aead, aead::Aead};
 use derive_more::From;
 use gfss::shamir::{self, CombineError, SecretShares, Share, SplitError};
+use hkdf::Hkdf;
+use omicron_uuid_kinds::{GenericUuid, RackUuid};
 use rand::RngCore;
 use rand::rngs::OsRng;
 use secrecy::{ExposeSecret, SecretBox};
 use serde::{Deserialize, Serialize};
 use sha3::{Digest, Sha3_256};
 use slog_error_chain::SlogInlineError;
+use static_assertions::const_assert_eq;
+use std::collections::BTreeMap;
 use std::fmt::Debug;
 use subtle::ConstantTimeEq;
-use zeroize::{Zeroize, ZeroizeOnDrop};
+use zeroize::{Zeroize, ZeroizeOnDrop, Zeroizing};
 
-use crate::Threshold;
+use crate::{Epoch, Threshold};
 
 /// Each share contains a byte for the y-coordinate of 32 points on 32 different
 /// polynomials over Ed25519. All points share an x-coordinate, which is the 0th
@@ -26,13 +31,12 @@ use crate::Threshold;
 /// This is enough information to share a secret 32 bytes long.
 const LRTQ_SHARE_SIZE: usize = 33;
 
-/// We don't distinguish whether this is an Ed25519 Scalar or set of GF(256)
-/// polynomials points with an x-coordinate of 0. Both can be treated as 32 byte
-/// blobs when decrypted, as they are immediately fed into HKDF.
-#[derive(
-    Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Serialize, Deserialize,
-)]
-pub struct EncryptedRackSecret(pub Vec<u8>);
+// The size in bytes of a single rack secret
+const SECRET_LEN: usize = 32;
+
+// The size in bytes of an `Epoch`
+const EPOCH_LEN: usize = size_of::<Epoch>();
+const_assert_eq!(EPOCH_LEN, 8);
 
 // The key share format used for LRTQ
 #[derive(Clone, Serialize, Deserialize, Zeroize, ZeroizeOnDrop, From)]
@@ -102,6 +106,14 @@ impl ExposeSecret<[u8; 32]> for ReconstructedRackSecret {
     }
 }
 
+// Only use this in unit tests in this module
+#[cfg(test)]
+impl Clone for ReconstructedRackSecret {
+    fn clone(&self) -> Self {
+        self.expose_secret().as_slice().try_into().unwrap()
+    }
+}
+
 #[derive(Debug, Clone, PartialEq, Eq, thiserror::Error)]
 #[error("invalid rack secret size")]
 pub struct InvalidRackSecretSizeError;
@@ -121,12 +133,30 @@ impl TryFrom<SecretBox<[u8]>> for ReconstructedRackSecret {
     }
 }
 
+impl TryFrom<&[u8]> for ReconstructedRackSecret {
+    type Error = InvalidRackSecretSizeError;
+    fn try_from(value: &[u8]) -> Result<Self, Self::Error> {
+        let data: Box<[u8; 32]> =
+            Box::new(value.try_into().map_err(|_| InvalidRackSecretSizeError)?);
+        Ok(ReconstructedRackSecret {
+            secret: RackSecretData(SecretBox::new(data)),
+        })
+    }
+}
+
 impl From<LrtqRackSecret> for ReconstructedRackSecret {
     fn from(value: LrtqRackSecret) -> Self {
         let secret = value.expose_secret().as_bytes();
         ReconstructedRackSecret {
             secret: RackSecretData(SecretBox::new(Box::new(*secret))),
         }
+    }
+}
+
+impl From<RackSecret> for ReconstructedRackSecret {
+    fn from(value: RackSecret) -> Self {
+        let RackSecret { secret } = value;
+        ReconstructedRackSecret { secret }
     }
 }
 
@@ -223,6 +253,177 @@ impl Default for Salt {
     }
 }
 
+#[derive(
+    Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Serialize, Deserialize,
+)]
+/// All possibly relevant __encrypted__ rack secrets for _prior_ committed
+/// configurations
+pub struct EncryptedRackSecrets {
+    /// A random value used to derive the key to encrypt the rack secrets for
+    /// prior committed epochs.
+    salt: Salt,
+    data: Box<[u8]>,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, thiserror::Error)]
+pub enum DecryptionError {
+    // An opaque error indicating decryption failed
+    #[error("Failed to decrypt rack secrets")]
+    Aead,
+
+    // The length of the plaintext is not the correct size and cannot
+    // be decoded.
+    #[error("Plaintext length is invalid")]
+    InvalidLength,
+}
+
+impl From<aead::Error> for DecryptionError {
+    fn from(_: aead::Error) -> Self {
+        DecryptionError::Aead
+    }
+}
+
+impl EncryptedRackSecrets {
+    pub fn new(salt: Salt, data: Box<[u8]>) -> Self {
+        EncryptedRackSecrets { salt, data }
+    }
+
+    pub fn decrypt(
+        &self,
+        rack_id: RackUuid,
+        epoch: Epoch,
+        rack_secret: &ReconstructedRackSecret,
+    ) -> Result<PlaintextRackSecrets, DecryptionError> {
+        let key = derive_encryption_key_for_rack_secrets(
+            rack_id,
+            epoch,
+            self.salt,
+            rack_secret,
+        );
+
+        // This key only encrypts a single plaintext and so a nonce of all zeroes
+        // is all that's required.
+        let nonce = [0u8; 12].into();
+
+        let plaintext =
+            Zeroizing::new(key.decrypt(&nonce, self.data.as_ref())?);
+
+        if plaintext.len() % (SECRET_LEN + EPOCH_LEN) != 0 {
+            return Err(DecryptionError::InvalidLength);
+        }
+
+        let mut plaintext_secrets = PlaintextRackSecrets::new();
+
+        for p in plaintext.chunks_exact(SECRET_LEN + EPOCH_LEN) {
+            // SAFETY: Neither of these unwraps will ever fail as we've checked
+            // the validity of plaintext length above.
+            let epoch =
+                Epoch(u64::from_be_bytes(p[0..EPOCH_LEN].try_into().unwrap()));
+            let secret: ReconstructedRackSecret =
+                p[EPOCH_LEN..].try_into().unwrap();
+            plaintext_secrets.insert(epoch, secret);
+        }
+
+        Ok(plaintext_secrets)
+    }
+}
+
+/// All possibly relevant __unencrypted__ rack secrets for _prior_ committed
+/// configurations
+///
+/// For secret rotations we need to maintain all prior rack secrets for
+/// configurations that any current trust quorum members may be stuck
+/// at. Eventually they will learn the latest configuration and decrypt
+/// `EncryptedRackSecrets` in order to get these plaintext versions. They will
+/// then use the rack secret for their currently committed configuration for key
+/// rotation .
+pub struct PlaintextRackSecrets {
+    secrets: BTreeMap<Epoch, ReconstructedRackSecret>,
+}
+
+impl PlaintextRackSecrets {
+    pub fn new() -> PlaintextRackSecrets {
+        PlaintextRackSecrets { secrets: BTreeMap::new() }
+    }
+
+    pub fn insert(&mut self, epoch: Epoch, secret: ReconstructedRackSecret) {
+        assert!(self.secrets.insert(epoch, secret).is_none());
+    }
+
+    pub fn get(&self, epoch: Epoch) -> Option<&ReconstructedRackSecret> {
+        self.secrets.get(&epoch)
+    }
+
+    /// Consume the plaintext and return an `EncryptedRackSecrets`
+    ///
+    /// We are encrypting rack secrets for prior epochs with the latest
+    /// rack secret.
+    pub fn encrypt(
+        self,
+        rack_id: RackUuid,
+        new_epoch: Epoch,
+        new_rack_secret: &ReconstructedRackSecret,
+    ) -> aead::Result<EncryptedRackSecrets> {
+        assert!(self.secrets.len() > 0);
+
+        // We generate a fresh salt because we should only be encrypting
+        // once for this epoch. This is also why we consume `self`.
+        let salt = Salt::new();
+        let key = derive_encryption_key_for_rack_secrets(
+            rack_id,
+            new_epoch,
+            salt,
+            new_rack_secret,
+        );
+
+        // Figure out the size of our plaintext and create a zeroizable buffer
+        // for it.
+        let plaintext_size = (SECRET_LEN + EPOCH_LEN) * self.secrets.len();
+        let mut plaintext =
+            Zeroizing::new(Vec::<u8>::with_capacity(plaintext_size));
+
+        // Write each epoch as a big endian u64 followed by the plaintext secret
+        for (epoch, secret) in &self.secrets {
+            plaintext.extend_from_slice(&epoch.0.to_be_bytes());
+            plaintext.extend_from_slice(secret.secret.0.expose_secret());
+        }
+
+        // This key only encrypts a single plaintext and so a nonce of all zeroes
+        // is all that's required.
+        let nonce = [0u8; 12].into();
+        let encrypted =
+            key.encrypt(&nonce, plaintext.as_ref())?.into_boxed_slice();
+        Ok(EncryptedRackSecrets { salt, data: encrypted })
+    }
+}
+
+/// Derive an encryption key from a rack secret used to decrypt
+/// `EncryptedRackSecrets` and encrypt `PlaintextRackSecrets`
+fn derive_encryption_key_for_rack_secrets(
+    rack_id: RackUuid,
+    epoch: Epoch,
+    salt: Salt,
+    rack_secret: &ReconstructedRackSecret,
+) -> ChaCha20Poly1305 {
+    let prk =
+        Hkdf::<Sha3_256>::new(Some(&salt.0[..]), rack_secret.expose_secret());
+
+    // The "info" string is context to bind the key to its purpose
+    let mut key = Zeroizing::new([0u8; 32]);
+
+    // SAFETY: `key` is sized such that `prk.expand_multi_info` will never fail.
+    prk.expand_multi_info(
+        &[
+            b"trust-quorum-v1-rack-secret",
+            rack_id.as_untyped_uuid().as_ref(),
+            &epoch.0.to_be_bytes(),
+        ],
+        key.as_mut(),
+    )
+    .unwrap();
+    ChaCha20Poly1305::new(Key::from_slice(key.as_ref()))
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -275,5 +476,76 @@ mod tests {
         let rs = RackSecret::new();
         let res = rs.split(Threshold(input.threshold), input.total_shares);
         check_rack_secret_invariants(&input, rs, res)?;
+    }
+
+    #[test]
+    fn rack_secrets_encrypt_decrypt_roundtrip() {
+        let mut plaintext = PlaintextRackSecrets::new();
+        let mut plaintext2 = PlaintextRackSecrets::new();
+        for i in 1..5u64 {
+            let rs: ReconstructedRackSecret = RackSecret::new().into();
+            let rs2 = rs.clone();
+            plaintext.insert(Epoch(i), rs);
+            plaintext2.insert(Epoch(i), rs2);
+        }
+        let rack_id = RackUuid::new_v4();
+        let new_epoch = Epoch(7);
+        let new_rack_secret = RackSecret::new().into();
+        let encrypted =
+            plaintext.encrypt(rack_id, new_epoch, &new_rack_secret).unwrap();
+        let decrypted =
+            encrypted.decrypt(rack_id, new_epoch, &new_rack_secret).unwrap();
+
+        // We don't actually do any comparisons of rack secrets outside this
+        // test and we don't want to derive `PartialEq` due to data dependent
+        // timing. Therefore we do a basic loop comparison here, which is a
+        // bit tedious.
+        for i in 1..5u64 {
+            assert_eq!(
+                decrypted.get(Epoch(i)).unwrap().expose_secret(),
+                plaintext2.get(Epoch(i)).unwrap().expose_secret()
+            );
+        }
+    }
+
+    #[test]
+    fn rack_secrets_decryption_failure() {
+        let mut plaintext = PlaintextRackSecrets::new();
+        for i in 1..5u64 {
+            let rs: ReconstructedRackSecret = RackSecret::new().into();
+            plaintext.insert(Epoch(i), rs);
+        }
+        let rack_id = RackUuid::new_v4();
+        let new_epoch = Epoch(7);
+        let new_rack_secret = RackSecret::new().into();
+        let mut encrypted =
+            plaintext.encrypt(rack_id, new_epoch, &new_rack_secret).unwrap();
+
+        // Decrypting with wrong rack_id fails.
+        assert!(
+            encrypted
+                .decrypt(RackUuid::new_v4(), new_epoch, &new_rack_secret)
+                .is_err()
+        );
+
+        // Decrypting with wrong epoch fails.
+        assert!(
+            encrypted
+                .decrypt(RackUuid::new_v4(), Epoch(99), &new_rack_secret)
+                .is_err()
+        );
+
+        // Decrypting with the wrong secret fails
+        assert!(
+            encrypted
+                .decrypt(rack_id, new_epoch, &RackSecret::new().into())
+                .is_err()
+        );
+
+        // Decrypting with corrupted plaintext is invalid
+        encrypted.data = vec![0u8, 1u8].into_boxed_slice();
+        assert!(
+            encrypted.decrypt(rack_id, new_epoch, &new_rack_secret).is_err()
+        );
     }
 }

--- a/trust-quorum/src/crypto.rs
+++ b/trust-quorum/src/crypto.rs
@@ -364,7 +364,7 @@ impl PlaintextRackSecrets {
         new_epoch: Epoch,
         new_rack_secret: &ReconstructedRackSecret,
     ) -> aead::Result<EncryptedRackSecrets> {
-        assert!(self.secrets.len() > 0);
+        assert!(!self.secrets.is_empty());
 
         // We generate a fresh salt because we should only be encrypting
         // once for this epoch. This is also why we consume `self`.

--- a/trust-quorum/src/node.rs
+++ b/trust-quorum/src/node.rs
@@ -291,7 +291,7 @@ mod tests {
         assert_eq!(config.coordinator, *node.platform_id());
         assert_eq!(config.members.len(), input.reconfigure_msg.members.len());
         assert_eq!(config.threshold, input.reconfigure_msg.threshold);
-        assert!(config.previous_configuration.is_none());
+        assert!(config.encrypted_rack_secrets.is_none());
 
         // Ensure that prepare messages are properly put in the outbox to be
         // sent by the I/O parts of the codebase

--- a/trust-quorum/tests/coordinator.rs
+++ b/trust-quorum/tests/coordinator.rs
@@ -442,10 +442,9 @@ impl TestState {
         }
         prop_assert_eq!(config.threshold, msg.threshold);
 
-        prop_assert_eq!(
-            config.previous_configuration.as_ref().map(|c| c.epoch),
-            msg.last_committed_epoch
-        );
+        if msg.last_committed_epoch.is_some() {
+            prop_assert!(config.encrypted_rack_secrets.is_some());
+        }
 
         Ok(())
     }


### PR DESCRIPTION
This is an update to the trust quorum protocol that no longer relies on tracking the last committed configuration. Instead it encrypts multiple rack secrets to allow upgrading past only one missed reconfiguration if a sled is offline.

This is based off the TLA+ spec and what is written in RFD 238.