### PR TITLE
trivial: move console session utility to shared utils file

### DIFF
--- a/nexus/tests/integration_tests/console_api.rs
+++ b/nexus/tests/integration_tests/console_api.rs
@@ -6,7 +6,6 @@ use anyhow::Context;
 use camino::Utf8PathBuf;
 use dropshot::ResultsPage;
 use dropshot::test_util::ClientTestContext;
-use http::header::HeaderName;
 use http::{StatusCode, header, method::Method};
 use nexus_auth::context::OpContext;
 use std::env::current_dir;
@@ -17,16 +16,12 @@ use internal_dns_types::names::DNS_ZONE_EXTERNAL_TESTING;
 use nexus_db_queries::authn::{USER_TEST_PRIVILEGED, USER_TEST_UNPRIVILEGED};
 use nexus_db_queries::db::fixed_data::silo::DEFAULT_SILO;
 use nexus_db_queries::db::identity::{Asset, Resource};
-use nexus_test_utils::http_testing::{
-    AuthnMode, NexusRequest, RequestBuilder, TestResponse,
-};
-use nexus_test_utils::resource_helpers::test_params;
+use nexus_test_utils::http_testing::{AuthnMode, NexusRequest, RequestBuilder};
+use nexus_test_utils::resource_helpers::create_console_session;
 use nexus_test_utils::resource_helpers::{
     create_silo, grant_iam, object_create,
 };
-use nexus_test_utils::{
-    TEST_SUITE_PASSWORD, load_test_config, test_setup_with_config,
-};
+use nexus_test_utils::{load_test_config, test_setup_with_config};
 use nexus_test_utils_macros::nexus_test;
 use nexus_types::external_api::params::{self, ProjectCreate};
 use nexus_types::external_api::shared::{SiloIdentityMode, SiloRole};
@@ -54,7 +49,7 @@ async fn test_sessions(cptestctx: &ControlPlaneTestContext) {
         .expect("failed to clear cookie and 204 on logout");
 
     // log in and pull the token out of the header so we can use it for authed requests
-    let session_token = log_in_and_extract_token(cptestctx).await;
+    let session_token = create_console_session(cptestctx).await;
 
     let project_params = ProjectCreate {
         identity: IdentityMetadataCreateParams {
@@ -208,7 +203,7 @@ async fn test_console_pages(cptestctx: &ControlPlaneTestContext) {
     )
     .await;
 
-    let session_token = log_in_and_extract_token(cptestctx).await;
+    let session_token = create_console_session(cptestctx).await;
 
     // hit console pages with session, should get back HTML response
     let console_paths = &[
@@ -882,35 +877,6 @@ async fn test_login_redirect_multiple_silos(
     )
 }
 
-fn get_header_value(resp: TestResponse, header_name: HeaderName) -> String {
-    resp.headers.get(header_name).unwrap().to_str().unwrap().to_string()
-}
-
-async fn log_in_and_extract_token(
-    cptestctx: &ControlPlaneTestContext,
-) -> String {
-    let testctx = &cptestctx.external_client;
-    let url = format!("/v1/login/{}/local", cptestctx.silo_name);
-    let credentials = test_params::UsernamePasswordCredentials {
-        username: cptestctx.user_name.as_ref().parse().unwrap(),
-        password: TEST_SUITE_PASSWORD.to_string(),
-    };
-    let login = RequestBuilder::new(&testctx, Method::POST, &url)
-        .body(Some(&credentials))
-        .expect_status(Some(StatusCode::NO_CONTENT))
-        .execute()
-        .await
-        .expect("failed to log in");
-
-    let session_cookie = get_header_value(login, header::SET_COOKIE);
-    let (session_token, rest) = session_cookie.split_once("; ").unwrap();
-
-    assert!(session_token.starts_with("session="));
-    assert_eq!(rest, "Path=/; HttpOnly; SameSite=Lax; Max-Age=86400");
-
-    session_token.to_string()
-}
-
 async fn expect_redirect(testctx: &ClientTestContext, from: &str, to: &str) {
     let _ = RequestBuilder::new(&testctx, Method::GET, from)
         .expect_status(Some(StatusCode::FOUND))
@@ -942,7 +908,7 @@ async fn test_session_idle_timeout_deletes_session() {
     let testctx = &cptestctx.external_client;
 
     // Start session
-    let session_cookie = log_in_and_extract_token(&cptestctx).await;
+    let session_cookie = create_console_session(&cptestctx).await;
 
     // sleep here not necessary given TTL of 0
 


### PR DESCRIPTION
Trivial, just making this its own PR to keep noise out of #7339.