### PR TITLE
Fix intermittently failing test

### DIFF
--- a/nexus/src/app/background/tasks/inventory_collection.rs
+++ b/nexus/src/app/background/tasks/inventory_collection.rs
@@ -359,7 +359,10 @@ mod test {
             // our collection, and at most one more if we lose the race
             // with Nexus and it happens to insert another collection
             // after we pruned down to `nkeep`.
-            assert!(num_collections <= nkeep + 2, "expected {num_collections} <= {nkeep} + 2");
+            assert!(
+                num_collections <= nkeep + 2,
+                "expected {num_collections} <= {nkeep} + 2"
+            );
 
             // Filter down to just the collections we activated. (This could be
             // empty if Nexus shoved several collections in!)

--- a/nexus/src/app/background/tasks/inventory_collection.rs
+++ b/nexus/src/app/background/tasks/inventory_collection.rs
@@ -355,8 +355,11 @@ mod test {
             assert!(num_collections > 0);
 
             // Regardless of the activation source, we should have at
-            // most `nkeep + 1` collections.
-            assert!(num_collections <= nkeep + 1);
+            // most `nkeep + 2` collections: at most `nkeep + 1` from
+            // our collection, and at most one more if we lose the race
+            // with Nexus.
+            println!("have {num_collections} for nkeep = {nkeep}");
+            assert!(num_collections <= nkeep + 2);
 
             // Filter down to just the collections we activated. (This could be
             // empty if Nexus shoved several collections in!)

--- a/nexus/src/app/background/tasks/inventory_collection.rs
+++ b/nexus/src/app/background/tasks/inventory_collection.rs
@@ -357,7 +357,8 @@ mod test {
             // Regardless of the activation source, we should have at
             // most `nkeep + 2` collections: at most `nkeep + 1` from
             // our collection, and at most one more if we lose the race
-            // with Nexus.
+            // with Nexus and it happens to insert another collection
+            // after we pruned down to `nkeep`.
             println!("have {num_collections} for nkeep = {nkeep}");
             assert!(num_collections <= nkeep + 2);
 

--- a/nexus/src/app/background/tasks/inventory_collection.rs
+++ b/nexus/src/app/background/tasks/inventory_collection.rs
@@ -359,8 +359,7 @@ mod test {
             // our collection, and at most one more if we lose the race
             // with Nexus and it happens to insert another collection
             // after we pruned down to `nkeep`.
-            println!("have {num_collections} for nkeep = {nkeep}");
-            assert!(num_collections <= nkeep + 2);
+            assert!(num_collections <= nkeep + 2, "expected {num_collections} <= {nkeep} + 2");
 
             // Filter down to just the collections we activated. (This could be
             // empty if Nexus shoved several collections in!)


### PR DESCRIPTION
`app::background::tasks::inventory_collection::test::test_basic` fails intermittently, more often when run as part of a large batch. The problem seems to be the race between manual inventory collection and Nexus' own background task. This PR accounts for the race (but does not eliminate it) by allowing for one extra Nexus-initiated collection. More than one seems theoretically possible but extremely unlikely in this test.