### PR TITLE
sp-sim: instant host phase 1 flash hashing by default

### DIFF
--- a/sp-sim/src/lib.rs
+++ b/sp-sim/src/lib.rs
@@ -27,6 +27,7 @@ use std::net::SocketAddrV6;
 use tokio::sync::mpsc;
 use tokio::sync::watch;
 pub use update::HostFlashHashCompletionSender;
+pub use update::HostFlashHashPolicy;
 
 pub const SIM_ROT_BOARD: &str = "SimRot";
 pub const SIM_ROT_STAGE0_BOARD: &str = "SimRotStage0";
@@ -156,6 +157,11 @@ impl SimRack {
             gimlets.push(
                 Gimlet::spawn(
                     gimlet,
+                    // We could expose this in the config file if we want
+                    // callers to be able configure timer-based hashing instead?
+                    // For now, just use the fastest version (assume contents
+                    // are always hashed).
+                    HostFlashHashPolicy::assume_already_hashed(),
                     log.new(slog::o!("slot" => format!("gimlet {}", i))),
                 )
                 .await?,

--- a/sp-sim/src/sidecar.rs
+++ b/sp-sim/src/sidecar.rs
@@ -2,6 +2,7 @@
 // License, v. 2.0. If a copy of the MPL was not distributed with this
 // file, You can obtain one at https://mozilla.org/MPL/2.0/.
 
+use crate::HostFlashHashPolicy;
 use crate::Responsiveness;
 use crate::SimulatedSp;
 use crate::config::Config;
@@ -531,6 +532,8 @@ impl Handler {
             update_state: SimSpUpdate::new(
                 BaseboardKind::Sidecar,
                 no_stage0_caboose,
+                // sidecar doesn't have phase 1 flash; any policy is fine
+                HostFlashHashPolicy::assume_already_hashed(),
             ),
             reset_pending: None,
             should_fail_to_respond_signal: None,


### PR DESCRIPTION
This removes almost all of the slowdown introduced in test inventory collections in #8624. (There are still extra API calls to gather the phase 1 hashes, but no more sleep-while-waiting-for-hashing.)