### PR TITLE
make the env.sh script idempotent

### DIFF
--- a/env.sh
+++ b/env.sh
@@ -13,6 +13,10 @@ export PATH="$OMICRON_WS/out/clickhouse:$PATH"
 export PATH="$OMICRON_WS/out/dendrite-stub/bin:$PATH"
 export PATH="$OMICRON_WS/out/mgd/root/opt/oxide/mgd/bin:$PATH"
 
+# remove duplicates, preserving order
+UPATH=$(echo "$PATH" |tr ':' '\n' | cat -n | sort -uk2 | sort -n | cut -f2- | paste -sd: -)
+export PATH=$UPATH
+
 # if xtrace was set previously, do not unset it
 case $OLD_SHELL_OPTS in
     *x*)


### PR DESCRIPTION
Hello! I noticed that the dev env setup script would keep pre-pending the omicron paths to `$PATH`; this just removes the duplicates (bonus of removing all dupes from your `$PATH`) while preserving order; works with zsh and bash.

Before, after sourcing the env script twice:

```
$ echo $PATH |tr ':' '\n'
/home/ardent/git/omicron/out/mgd/root/opt/oxide/mgd/bin
/home/ardent/git/omicron/out/dendrite-stub/bin
/home/ardent/git/omicron/out/clickhouse
/home/ardent/git/omicron/out/cockroachdb/bin
/home/ardent/git/omicron/out/mgd/root/opt/oxide/mgd/bin
/home/ardent/git/omicron/out/dendrite-stub/bin
/home/ardent/git/omicron/out/clickhouse
/home/ardent/git/omicron/out/cockroachdb/bin
/home/ardent/bin
....
```

After:

```
$ source env.sh ; source env.sh
......
$ echo $PATH |tr ':' '\n'
/home/ardent/git/omicron/out/mgd/root/opt/oxide/mgd/bin
/home/ardent/git/omicron/out/dendrite-stub/bin
/home/ardent/git/omicron/out/clickhouse
/home/ardent/git/omicron/out/cockroachdb/bin
/home/ardent/bin
....
```