### PR TITLE
update `cc` crate

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1200,9 +1200,9 @@ dependencies = [
 
 [[package]]
 name = "cc"
-version = "1.2.15"
+version = "1.2.30"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c736e259eea577f443d5c86c304f9f4ae0295c43f3ba05c21f1d66b5f06001af"
+checksum = "deec109607ca693028562ed836a5f1c4b8bd77755c4e132fc5ce11b0b6211ae7"
 dependencies = [
  "jobserver",
  "libc",

--- a/workspace-hack/Cargo.toml
+++ b/workspace-hack/Cargo.toml
@@ -166,7 +166,7 @@ bstr = { version = "1.10.0" }
 buf-list = { version = "1.0.3", default-features = false, features = ["tokio1"] }
 byteorder = { version = "1.5.0" }
 bytes = { version = "1.10.1", features = ["serde"] }
-cc = { version = "1.2.15", default-features = false, features = ["parallel"] }
+cc = { version = "1.2.30", default-features = false, features = ["parallel"] }
 chrono = { version = "0.4.41", features = ["serde"] }
 cipher = { version = "0.4.4", default-features = false, features = ["block-padding", "zeroize"] }
 clap = { version = "4.5.40", features = ["cargo", "derive", "env", "wrap_help"] }


### PR DESCRIPTION
most importantly this gets us
https://github.com/rust-lang/cc-rs/pull/1496 which fixes https://github.com/oxidecomputer/helios/issues/192 -style miscompilation of neuxs (and several other binaries here).

While for `clickhouse-admin-*`, `cockroach-admin`, and `dns-server` both errnos are present, I suspect the global `errno` goes unused - it's present through rustls/ring/aws-lc-rs/etc being compiled and linked in, but if TLS interfaces aren't used there (yet!) then it's not an issue (yet!).

Nexus presents HTTPS though, so the `errno`-clobbery code is used there. Lets get that fixed.