### PR TITLE
helios/deploy: Wait for inventory collection

### DIFF
--- a/.github/buildomat/jobs/deploy.sh
+++ b/.github/buildomat/jobs/deploy.sh
@@ -421,7 +421,7 @@ retry=0
 INVENTORY_COLLECTION_COUNT=$(pfexec zlogin oxz_switch /opt/oxide/omdb/bin/omdb db inventory collections list | wc -l)
 until [[ "${INVENTORY_COLLECTION_COUNT}" -gt 1 ]]; do
 	if [[ $retry -gt 300 ]]; then
-		echo "Failed to handoff to Nexus after 300 seconds"
+		echo "Failed to wait for inventory collection after 300 seconds"
 		exit 1
 	fi
 	sleep 1


### PR DESCRIPTION
This adds another "wait for a thing to happen" loop in between waiting for the RSS -> Nexus handoff and waiting for all the zpools to show up. Attempting to query for the zpools fails if there hasn't been an inventory collection yet, so prior to this change we were racing.

Fixes #8647.