### PR TITLE
nexus-db-queries: verify blueprint test covers all tables (#8455)

### DIFF
--- a/nexus/db-queries/src/db/datastore/deployment.rs
+++ b/nexus/db-queries/src/db/datastore/deployment.rs
@@ -4562,6 +4562,7 @@ mod tests {
                     bp_pending_mgs_update_rot_bootloader,
                     blueprint_id
                 ),
+                query_count!(bp_pending_mgs_update_host_phase_1, blueprint_id),
             ] {
                 let count: i64 = result.unwrap();
                 counts.insert(table_name.to_string(), count);
@@ -4671,6 +4672,7 @@ mod tests {
             "bp_pending_mgs_update_sp",
             "bp_pending_mgs_update_rot",
             "bp_pending_mgs_update_rot_bootloader",
+            "bp_pending_mgs_update_host_phase_1",
             "bp_clickhouse_cluster_config",
             "bp_clickhouse_keeper_zone_id_to_node_id",
             "bp_clickhouse_server_zone_id_to_node_id",


### PR DESCRIPTION
Add ensure_blueprint_fully_populated() to check all bp_* tables get populated by representative blueprint. Complements existing ensure_blueprint_fully_deleted().

Add ClickHouse config to representative blueprint.

Fixes #8455