### PR TITLE
Add USDT probes to `oximeter`

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -8951,6 +8951,7 @@ dependencies = [
  "thiserror 2.0.12",
  "tokio",
  "toml 0.8.23",
+ "usdt",
  "uuid",
 ]
 

--- a/oximeter/collector/Cargo.toml
+++ b/oximeter/collector/Cargo.toml
@@ -40,6 +40,7 @@ strum.workspace = true
 thiserror.workspace = true
 tokio.workspace = true
 toml.workspace = true
+usdt.workspace = true
 uuid.workspace = true
 omicron-workspace-hack.workspace = true
 nexus-client.workspace = true

--- a/oximeter/collector/src/agent.rs
+++ b/oximeter/collector/src/agent.rs
@@ -12,6 +12,7 @@ use crate::ProducerEndpoint;
 use crate::collection_task::CollectionTaskHandle;
 use crate::collection_task::CollectionTaskOutput;
 use crate::collection_task::ForcedCollectionError;
+use crate::probes;
 use crate::results_sink;
 use crate::self_stats;
 use anyhow::anyhow;
@@ -368,6 +369,14 @@ impl OximeterAgent {
                 }
             }
         }
+        probes::producer__registered!(|| {
+            (
+                self.id.to_string(),
+                id.to_string(),
+                info.address.to_string(),
+                format!("{:?}", info.interval),
+            )
+        });
     }
 
     /// Enqueue requests to forces collection from all producers.
@@ -432,6 +441,9 @@ impl OximeterAgent {
             "removed collection task from set";
             "producer_id" => %id,
         );
+        probes::producer__deleted!(|| {
+            (self.id.to_string(), task.details().id.to_string())
+        });
         task.shutdown();
     }
 
@@ -756,6 +768,7 @@ mod tests {
     // Test that we count successful collections from a target correctly.
     #[tokio::test]
     async fn test_self_stat_collection_count() {
+        usdt::register_probes().unwrap();
         let logctx = test_setup_log("test_self_stat_collection_count");
         let log = &logctx.log;
 
@@ -827,6 +840,7 @@ mod tests {
 
     #[tokio::test]
     async fn test_self_stat_unreachable_counter() {
+        usdt::register_probes().unwrap();
         let logctx = test_setup_log("test_self_stat_unreachable_counter");
         let log = &logctx.log;
 
@@ -889,6 +903,7 @@ mod tests {
 
     #[tokio::test]
     async fn test_self_stat_error_counter() {
+        usdt::register_probes().unwrap();
         let logctx = test_setup_log("test_self_stat_error_counter");
         let log = &logctx.log;
 
@@ -993,6 +1008,7 @@ mod tests {
 
     #[tokio::test]
     async fn verify_producer_details() {
+        usdt::register_probes().unwrap();
         let logctx = test_setup_log("verify_producer_details");
         let log = &logctx.log;
 
@@ -1076,6 +1092,7 @@ mod tests {
 
     #[tokio::test]
     async fn test_updated_producer_is_still_collected_from() {
+        usdt::register_probes().unwrap();
         let logctx =
             test_setup_log("test_updated_producer_is_still_collected_from");
         let log = &logctx.log;

--- a/oximeter/collector/src/lib.rs
+++ b/oximeter/collector/src/lib.rs
@@ -53,6 +53,31 @@ pub use http_entrypoints::oximeter_api;
 pub use standalone::Server as StandaloneNexus;
 pub use standalone::standalone_nexus_api;
 
+#[usdt::provider(provider = "oximeter")]
+mod probes {
+    /// Fires when a producer is registered or updated.
+    fn producer__registered(
+        collector_id: &str,
+        producer_id: &str,
+        addr: &str,
+        interval: &str,
+    ) {
+    }
+
+    /// Fires when a new producer is deleted.
+    fn producer__deleted(collector_id: &str, producer_id: &str) {}
+
+    /// Fires just before starting a collection from a producer.
+    fn collection__start(producer_id: &str, addr: &str) {}
+
+    /// Fires just after finishing a collection from a producer.
+    ///
+    /// Details about the collection are in the last argument. If the colleciton
+    /// succeeded, the number of samples is included. If the collection failed,
+    /// a failure reason is included.
+    fn collection__done(producer_id: &str, details: Result<u64, String>) {}
+}
+
 /// Errors collecting metric data
 #[derive(Debug, Error)]
 pub enum Error {


### PR DESCRIPTION
Adds probes when producers are registered or deleted, and when collections start and complete.