### PR TITLE
Fix returned pagination param for alert_class_list

### DIFF
--- a/nexus/src/external_api/http_entrypoints.rs
+++ b/nexus/src/external_api/http_entrypoints.rs
@@ -8192,7 +8192,9 @@ impl NexusExternalApi for NexusExternalApiImpl {
             Ok(HttpResponseOk(ResultsPage::new(
                 alert_classes,
                 &EmptyScanParams {},
-                |class: &views::AlertClass, _| class.name.clone(),
+                |class: &views::AlertClass, _| params::AlertClassPage {
+                    last_seen: class.name.clone(),
+                },
             )?))
         };
         apictx


### PR DESCRIPTION
Currently the `alert_receiver_list` endpoiint will return a String as its pagination parameter, serialized as
`{"v":"v1","page_start":"probe"}`. However, this endpoint is expecting a `AlertClassPage` struct in its query parameters, causing clients that use the returned pagination token in their subsequent request to fail with error "failed to parse pagination token: corrupted token".

To resolve this, set the page selector to return the expected `AlertClassPage` instead.

Closes https://github.com/oxidecomputer/omicron/issues/8660