### PR TITLE
[reconfigurator] Consider Internal DNS generation in planner

### DIFF
--- a/dev-tools/reconfigurator-cli/tests/output/cmds-example-stdout
+++ b/dev-tools/reconfigurator-cli/tests/output/cmds-example-stdout
@@ -1510,6 +1510,7 @@ LEDGERED SLED CONFIG
     slot B details UNAVAILABLE: constructed via debug_assume_success()
     last reconciled config: matches ledgered config
     no information from NTP for this sled
+    Internal DNS generation: 1
         no mupdate override to clear
         no orphaned datasets
         all disks reconciled successfully

--- a/dev-tools/reconfigurator-cli/tests/output/cmds-mupdate-update-flow-stdout
+++ b/dev-tools/reconfigurator-cli/tests/output/cmds-mupdate-update-flow-stdout
@@ -183,6 +183,7 @@ LEDGERED SLED CONFIG
     slot B details UNAVAILABLE: constructed via debug_assume_success()
     last reconciled config: matches ledgered config
     no information from NTP for this sled
+    Internal DNS generation: 1
         error reading mupdate override, so sled agent didn't attempt to clear it
         no orphaned datasets
         all disks reconciled successfully
@@ -291,6 +292,7 @@ LEDGERED SLED CONFIG
     slot B details UNAVAILABLE: constructed via debug_assume_success()
     last reconciled config: matches ledgered config
     no information from NTP for this sled
+    Internal DNS generation: 1
         mupdate override present, but sled agent was not instructed to clear it
         no orphaned datasets
         all disks reconciled successfully
@@ -388,6 +390,7 @@ LEDGERED SLED CONFIG
     slot B details UNAVAILABLE: constructed via debug_assume_success()
     last reconciled config: matches ledgered config
     no information from NTP for this sled
+    Internal DNS generation: 1
         mupdate override present, but sled agent was not instructed to clear it
         no orphaned datasets
         all disks reconciled successfully


### PR DESCRIPTION
Refuse to tear down an Internal DNS zone unless we're at sufficient redundancy, with an expected generation number for "last deployed data".

Also:
- Fixes a blippy bug that was overly conservative for expunged datasets, when finding duplicate dataset kinds
- Adds internal DNS generation statuses when converting a system description to an inventory collection

Fixes https://github.com/oxidecomputer/omicron/issues/8545