### PR TITLE
[hakari] use final-excludes rather than traversal-excludes

### DIFF
--- a/.config/hakari.toml
+++ b/.config/hakari.toml
@@ -29,7 +29,10 @@ platforms = [
 # Write out exact versions rather than a semver range. (Defaults to false.)
 exact-versions = true
 
-[traversal-excludes]
+# Use final-excludes rather than traversal-excludes because we'd like to unify
+# features across builds performed by rust-analyzer (with `--workspace`) and
+# those performed on the command line (without `--workspace`).
+[final-excludes]
 workspace-members = [
     # Exclude dev-tools-common and xtask because they need to be built quickly.
     "dev-tools-common",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -8503,6 +8503,7 @@ dependencies = [
  "ppv-lite86",
  "predicates",
  "proc-macro2",
+ "proptest",
  "rand 0.8.5",
  "rand 0.9.1",
  "rand_chacha 0.3.1",

--- a/workspace-hack/Cargo.toml
+++ b/workspace-hack/Cargo.toml
@@ -80,7 +80,7 @@ libc = { version = "0.2.174", features = ["extra_traits"] }
 log = { version = "0.4.27", default-features = false, features = ["kv_unstable", "std"] }
 managed = { version = "0.8.0", default-features = false, features = ["alloc", "map"] }
 memchr = { version = "2.7.4" }
-newtype-uuid = { version = "1.2.4" }
+newtype-uuid = { version = "1.2.4", features = ["proptest1", "schemars08", "serde", "v4"] }
 nix = { version = "0.29.0", features = ["feature", "net", "uio"] }
 nom = { version = "7.1.3" }
 num-bigint-dig = { version = "0.8.4", default-features = false, features = ["i128", "prime", "serde", "u64_digit", "zeroize"] }
@@ -100,6 +100,7 @@ postgres-types = { version = "0.2.9", default-features = false, features = ["wit
 ppv-lite86 = { version = "0.2.20", default-features = false, features = ["simd", "std"] }
 predicates = { version = "3.1.3" }
 proc-macro2 = { version = "1.0.95" }
+proptest = { version = "1.7.0" }
 rand-274715c4dabd11b0 = { package = "rand", version = "0.9.1" }
 rand-c38e5c1d305a1b54 = { package = "rand", version = "0.8.5" }
 rand_chacha-274715c4dabd11b0 = { package = "rand_chacha", version = "0.9.0", default-features = false, features = ["std"] }
@@ -216,7 +217,7 @@ libc = { version = "0.2.174", features = ["extra_traits"] }
 log = { version = "0.4.27", default-features = false, features = ["kv_unstable", "std"] }
 managed = { version = "0.8.0", default-features = false, features = ["alloc", "map"] }
 memchr = { version = "2.7.4" }
-newtype-uuid = { version = "1.2.4" }
+newtype-uuid = { version = "1.2.4", features = ["proptest1", "schemars08", "serde", "v4"] }
 nix = { version = "0.29.0", features = ["feature", "net", "uio"] }
 nom = { version = "7.1.3" }
 num-bigint-dig = { version = "0.8.4", default-features = false, features = ["i128", "prime", "serde", "u64_digit", "zeroize"] }
@@ -236,6 +237,7 @@ postgres-types = { version = "0.2.9", default-features = false, features = ["wit
 ppv-lite86 = { version = "0.2.20", default-features = false, features = ["simd", "std"] }
 predicates = { version = "3.1.3" }
 proc-macro2 = { version = "1.0.95" }
+proptest = { version = "1.7.0" }
 rand-274715c4dabd11b0 = { package = "rand", version = "0.9.1" }
 rand-c38e5c1d305a1b54 = { package = "rand", version = "0.8.5" }
 rand_chacha-274715c4dabd11b0 = { package = "rand_chacha", version = "0.9.0", default-features = false, features = ["std"] }


### PR DESCRIPTION
While looking at build performance I realized that we weren't unifying feature sets across rust-analyzer builds and ones done on the command line. Switching from traversal-excludes (i.e. omitted while computing the set of features for each package) to final-excludes (removed at the very end) addresses this issue.

This doesn't completely unify all feature sets (e.g. we have a few `testing` features within the workspace that can't be unified), but it does ensure that third-party dependencies are shared across all builds.

With this change, after running a `cargo check` within `rust-analyzer`:

```
% cargo check --all-targets
    Finished `dev` profile [unoptimized + debuginfo] target(s) in 0.91s
```