### PR TITLE
Flush streaming downloads from "cargo xtask download"

### DIFF
--- a/dev-tools/downloader/src/lib.rs
+++ b/dev-tools/downloader/src/lib.rs
@@ -275,6 +275,7 @@ async fn streaming_download(url: &str, path: &Utf8Path) -> Result<()> {
     while let Some(chunk) = response.chunk().await? {
         tarball.write_all(chunk.as_ref()).await?;
     }
+    tarball.flush().await?;
     Ok(())
 }
 


### PR DESCRIPTION
This is another case like https://github.com/oxidecomputer/omicron/issues/8681

(See: https://play.rust-lang.org/?version=stable&mode=debug&edition=2024&gist=a9fdfeb0149e8ca0f84f3e164602da4e for an example)

We need to flush after writing this data to ensure it actually leaves our process