### PR TITLE
Delete disk metrics endpoint

### DIFF
--- a/nexus/external-api/output/nexus_tags.txt
+++ b/nexus/external-api/output/nexus_tags.txt
@@ -35,7 +35,6 @@ disk_create                              POST     /v1/disks
 disk_delete                              DELETE   /v1/disks/{disk}
 disk_finalize_import                     POST     /v1/disks/{disk}/finalize
 disk_list                                GET      /v1/disks
-disk_metrics_list                        GET      /v1/disks/{disk}/metrics/{metric}
 disk_view                                GET      /v1/disks/{disk}
 
 API operations found with tag "experimental"

--- a/nexus/external-api/src/lib.rs
+++ b/nexus/external-api/src/lib.rs
@@ -1048,24 +1048,6 @@ pub trait NexusExternalApi {
         query_params: Query<params::OptionalProjectSelector>,
     ) -> Result<HttpResponseDeleted, HttpError>;
 
-    /// Fetch disk metrics
-    #[endpoint {
-        method = GET,
-        path = "/v1/disks/{disk}/metrics/{metric}",
-        tags = ["disks"],
-    }]
-    async fn disk_metrics_list(
-        rqctx: RequestContext<Self::Context>,
-        path_params: Path<params::DiskMetricsPath>,
-        query_params: Query<
-            PaginationParams<params::ResourceMetrics, params::ResourceMetrics>,
-        >,
-        selector_params: Query<params::OptionalProjectSelector>,
-    ) -> Result<
-        HttpResponseOk<ResultsPage<oximeter_types::Measurement>>,
-        HttpError,
-    >;
-
     /// Start importing blocks into disk
     ///
     /// Start the process of importing blocks into a disk

--- a/nexus/src/external_api/http_entrypoints.rs
+++ b/nexus/src/external_api/http_entrypoints.rs
@@ -1921,52 +1921,6 @@ impl NexusExternalApi for NexusExternalApiImpl {
             .await
     }
 
-    async fn disk_metrics_list(
-        rqctx: RequestContext<ApiContext>,
-        path_params: Path<params::DiskMetricsPath>,
-        query_params: Query<
-            PaginationParams<params::ResourceMetrics, params::ResourceMetrics>,
-        >,
-        selector_params: Query<params::OptionalProjectSelector>,
-    ) -> Result<HttpResponseOk<ResultsPage<oximeter_db::Measurement>>, HttpError>
-    {
-        let apictx = rqctx.context();
-        let handler = async {
-            let nexus = &apictx.context.nexus;
-            let path = path_params.into_inner();
-            let query = query_params.into_inner();
-
-            let selector = selector_params.into_inner();
-            let limit = rqctx.page_limit(&query)?;
-            let disk_selector = params::DiskSelector {
-                disk: path.disk,
-                project: selector.project,
-            };
-            let opctx =
-                crate::context::op_context_for_external_api(&rqctx).await?;
-            let (.., authz_disk) = nexus
-                .disk_lookup(&opctx, disk_selector)?
-                .lookup_for(authz::Action::Read)
-                .await?;
-
-            let result = nexus
-                .select_timeseries(
-                    &format!("crucible_upstairs:{}", path.metric),
-                    &[&format!("upstairs_uuid=={}", authz_disk.id())],
-                    query,
-                    limit,
-                )
-                .await?;
-
-            Ok(HttpResponseOk(result))
-        };
-        apictx
-            .context
-            .external_latencies
-            .instrument_dropshot_handler(&rqctx, handler)
-            .await
-    }
-
     async fn disk_bulk_write_import_start(
         rqctx: RequestContext<ApiContext>,
         path_params: Path<params::DiskPath>,

--- a/nexus/tests/integration_tests/endpoints.rs
+++ b/nexus/tests/integration_tests/endpoints.rs
@@ -401,15 +401,6 @@ pub static DEMO_DISK_CREATE: LazyLock<params::DiskCreate> =
             ),
         }
     });
-pub static DEMO_DISK_METRICS_URL: LazyLock<String> = LazyLock::new(|| {
-    format!(
-        "/v1/disks/{}/metrics/activated?start_time={:?}&end_time={:?}&{}",
-        *DEMO_DISK_NAME,
-        Utc::now(),
-        Utc::now(),
-        *DEMO_PROJECT_SELECTOR,
-    )
-});
 
 // Related to importing blocks from an external source
 pub static DEMO_IMPORT_DISK_NAME: LazyLock<Name> =
@@ -2047,12 +2038,6 @@ pub static VERIFY_ENDPOINTS: LazyLock<Vec<VerifyEndpoint>> = LazyLock::new(
                     AllowedMethod::Get,
                     AllowedMethod::Delete,
                 ],
-            },
-            VerifyEndpoint {
-                url: &DEMO_DISK_METRICS_URL,
-                visibility: Visibility::Protected,
-                unprivileged_access: UnprivilegedAccess::None,
-                allowed_methods: vec![AllowedMethod::Get],
             },
             VerifyEndpoint {
                 url: &DEMO_INSTANCE_DISKS_URL,

--- a/nexus/tests/integration_tests/metrics_querier.rs
+++ b/nexus/tests/integration_tests/metrics_querier.rs
@@ -143,27 +143,6 @@ impl<'a, N> MetricsQuerier<'a, N> {
         self.wait_for_objects(|| endpoint.to_string(), cond).await
     }
 
-    /// Repeatedly fetch a specific disk metric until `cond` returns `Ok(_)`.
-    pub async fn wait_for_disk_metric<F, T>(
-        &self,
-        project_name: &str,
-        disk_name: &str,
-        metric_name: &str,
-        cond: F,
-    ) -> T
-    where
-        F: Fn(Vec<Measurement>) -> Result<T, MetricsNotYet>,
-    {
-        let endpoint = || {
-            format!(
-                "/v1/disks/{disk_name}/metrics/{metric_name}?start_time={:?}&end_time={:?}&project={project_name}",
-                self.ctx.start_time,
-                Utc::now(),
-            )
-        };
-        self.wait_for_objects(endpoint, cond).await
-    }
-
     /// Repeatedly fetch the single newest system metric until `cond` returns
     /// `Ok(_)`.
     pub async fn wait_for_latest_system_metric<F, T>(

--- a/openapi/nexus.json
+++ b/openapi/nexus.json
@@ -2800,111 +2800,6 @@
         }
       }
     },
-    "/v1/disks/{disk}/metrics/{metric}": {
-      "get": {
-        "tags": [
-          "disks"
-        ],
-        "summary": "Fetch disk metrics",
-        "operationId": "disk_metrics_list",
-        "parameters": [
-          {
-            "in": "path",
-            "name": "disk",
-            "required": true,
-            "schema": {
-              "$ref": "#/components/schemas/NameOrId"
-            }
-          },
-          {
-            "in": "path",
-            "name": "metric",
-            "required": true,
-            "schema": {
-              "$ref": "#/components/schemas/DiskMetricName"
-            }
-          },
-          {
-            "in": "query",
-            "name": "end_time",
-            "description": "An exclusive end time of metrics.",
-            "schema": {
-              "type": "string",
-              "format": "date-time"
-            }
-          },
-          {
-            "in": "query",
-            "name": "limit",
-            "description": "Maximum number of items returned by a single call",
-            "schema": {
-              "nullable": true,
-              "type": "integer",
-              "format": "uint32",
-              "minimum": 1
-            }
-          },
-          {
-            "in": "query",
-            "name": "order",
-            "description": "Query result order",
-            "schema": {
-              "$ref": "#/components/schemas/PaginationOrder"
-            }
-          },
-          {
-            "in": "query",
-            "name": "page_token",
-            "description": "Token returned by previous call to retrieve the subsequent page",
-            "schema": {
-              "nullable": true,
-              "type": "string"
-            }
-          },
-          {
-            "in": "query",
-            "name": "start_time",
-            "description": "An inclusive start time of metrics.",
-            "schema": {
-              "type": "string",
-              "format": "date-time"
-            }
-          },
-          {
-            "in": "query",
-            "name": "project",
-            "description": "Name or ID of the project",
-            "schema": {
-              "$ref": "#/components/schemas/NameOrId"
-            }
-          }
-        ],
-        "responses": {
-          "200": {
-            "description": "successful operation",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/MeasurementResultsPage"
-                }
-              }
-            }
-          },
-          "4XX": {
-            "$ref": "#/components/responses/Error"
-          },
-          "5XX": {
-            "$ref": "#/components/responses/Error"
-          }
-        },
-        "x-dropshot-pagination": {
-          "required": [
-            "end_time",
-            "start_time"
-          ]
-        }
-      }
-    },
     "/v1/floating-ips": {
       "get": {
         "tags": [
@@ -27502,25 +27397,6 @@
           }
         ]
       },
-      "DiskMetricName": {
-        "type": "string",
-        "enum": [
-          "activated",
-          "flush",
-          "read",
-          "read_bytes",
-          "write",
-          "write_bytes"
-        ]
-      },
-      "PaginationOrder": {
-        "description": "The order in which the client wants to page through the requested collection",
-        "type": "string",
-        "enum": [
-          "ascending",
-          "descending"
-        ]
-      },
       "IdSortMode": {
         "description": "Supported set of sort modes for scanning by id only.\n\nCurrently, we only support scanning in ascending order.",
         "oneOf": [
@@ -27539,6 +27415,14 @@
           "virtual_disk_space_provisioned",
           "cpus_provisioned",
           "ram_provisioned"
+        ]
+      },
+      "PaginationOrder": {
+        "description": "The order in which the client wants to page through the requested collection",
+        "type": "string",
+        "enum": [
+          "ascending",
+          "descending"
         ]
       },
       "NameSortMode": {


### PR DESCRIPTION
Closes #8720 

We'll have to confirm no one is relying on this endpoint, but as far as I know, the only thing relying on it was the instance disk metrics page in console, and that was switched to OxQL in February in https://github.com/oxidecomputer/console/pull/2654.