### PR TITLE
Add basic TUF repo check after generation

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -8185,6 +8185,7 @@ dependencies = [
  "toml 0.8.23",
  "tufaceous-artifact",
  "tufaceous-lib",
+ "update-common",
 ]
 
 [[package]]

--- a/dev-tools/releng/Cargo.toml
+++ b/dev-tools/releng/Cargo.toml
@@ -31,6 +31,7 @@ tokio = { workspace = true, features = ["full"] }
 toml.workspace = true
 tufaceous-artifact.workspace = true
 tufaceous-lib.workspace = true
+update-common.workspace = true
 
 [lints]
 workspace = true


### PR DESCRIPTION
There are an extended number of tests designed to catch issues with TUF repos. Despite this, it is still possible (though unlikely) to generate a TUF repo that fails one or more checks. Nobody likes broken builds so add an extra last check to verify that we can do "something" with the TUF repo.