### PR TITLE
Better inventory formatting for NTP, DNS

### DIFF
--- a/dev-tools/reconfigurator-cli/tests/output/cmds-example-stdout
+++ b/dev-tools/reconfigurator-cli/tests/output/cmds-example-stdout
@@ -1198,7 +1198,6 @@ LEDGERED SLED CONFIG
     slot A details UNAVAILABLE: constructed via debug_assume_success()
     slot B details UNAVAILABLE: constructed via debug_assume_success()
     last reconciled config: matches ledgered config
-    no information from NTP for this sled
         no mupdate override to clear
         no orphaned datasets
         all disks reconciled successfully
@@ -1307,7 +1306,6 @@ LEDGERED SLED CONFIG
     slot A details UNAVAILABLE: constructed via debug_assume_success()
     slot B details UNAVAILABLE: constructed via debug_assume_success()
     last reconciled config: matches ledgered config
-    no information from NTP for this sled
         no mupdate override to clear
         no orphaned datasets
         all disks reconciled successfully
@@ -1509,8 +1507,6 @@ LEDGERED SLED CONFIG
     slot A details UNAVAILABLE: constructed via debug_assume_success()
     slot B details UNAVAILABLE: constructed via debug_assume_success()
     last reconciled config: matches ledgered config
-    no information from NTP for this sled
-    Internal DNS generation: 1
         no mupdate override to clear
         no orphaned datasets
         all disks reconciled successfully
@@ -1525,6 +1521,14 @@ KEEPER MEMBERSHIP
 COCKROACH STATUS
     no cockroach status retrieved
 
+
+NTP STATUS
+    No NTP zones reported timesync information
+
+INTERNAL DNS STATUS
+    Zone 4692cc31-6eb6-437c-9634-9688663d06ae: Internal DNS generation @ 1
+    Zone 587da9e8-8fc0-4854-b585-070741a7b00d: Internal DNS generation @ 1
+    Zone ffbf02f0-261d-4723-b613-eb861245acbd: Internal DNS generation @ 1
 
 
 

--- a/dev-tools/reconfigurator-cli/tests/output/cmds-mupdate-update-flow-stdout
+++ b/dev-tools/reconfigurator-cli/tests/output/cmds-mupdate-update-flow-stdout
@@ -182,8 +182,6 @@ LEDGERED SLED CONFIG
     slot A details UNAVAILABLE: constructed via debug_assume_success()
     slot B details UNAVAILABLE: constructed via debug_assume_success()
     last reconciled config: matches ledgered config
-    no information from NTP for this sled
-    Internal DNS generation: 1
         error reading mupdate override, so sled agent didn't attempt to clear it
         no orphaned datasets
         all disks reconciled successfully
@@ -291,8 +289,6 @@ LEDGERED SLED CONFIG
     slot A details UNAVAILABLE: constructed via debug_assume_success()
     slot B details UNAVAILABLE: constructed via debug_assume_success()
     last reconciled config: matches ledgered config
-    no information from NTP for this sled
-    Internal DNS generation: 1
         mupdate override present, but sled agent was not instructed to clear it
         no orphaned datasets
         all disks reconciled successfully
@@ -389,8 +385,6 @@ LEDGERED SLED CONFIG
     slot A details UNAVAILABLE: constructed via debug_assume_success()
     slot B details UNAVAILABLE: constructed via debug_assume_success()
     last reconciled config: matches ledgered config
-    no information from NTP for this sled
-    Internal DNS generation: 1
         mupdate override present, but sled agent was not instructed to clear it
         no orphaned datasets
         all disks reconciled successfully
@@ -405,5 +399,13 @@ KEEPER MEMBERSHIP
 COCKROACH STATUS
     no cockroach status retrieved
 
+
+NTP STATUS
+    No NTP zones reported timesync information
+
+INTERNAL DNS STATUS
+    Zone 427ec88f-f467-42fa-9bbb-66a91a36103c: Internal DNS generation @ 1
+    Zone 99e2f30b-3174-40bf-a78a-90da8abba8ca: Internal DNS generation @ 1
+    Zone ea5b4030-b52f-44b2-8d70-45f15f987d01: Internal DNS generation @ 1
 
 

--- a/nexus/types/src/inventory/display.rs
+++ b/nexus/types/src/inventory/display.rs
@@ -47,6 +47,8 @@ pub struct CollectionDisplay<'a> {
     include_orphaned_datasets: bool,
     include_clickhouse_keeper_membership: bool,
     include_cockroach_status: bool,
+    include_ntp_status: bool,
+    include_internal_dns_status: bool,
     long_string_formatter: LongStringFormatter,
 }
 
@@ -60,6 +62,8 @@ impl<'a> CollectionDisplay<'a> {
             include_orphaned_datasets: true,
             include_clickhouse_keeper_membership: true,
             include_cockroach_status: true,
+            include_ntp_status: true,
+            include_internal_dns_status: true,
             long_string_formatter: LongStringFormatter::new(),
         }
     }
@@ -109,6 +113,24 @@ impl<'a> CollectionDisplay<'a> {
         self
     }
 
+    /// Control display of NTP timesync information (defaults to true).
+    pub fn include_ntp_status(
+        &mut self,
+        include_ntp_status: bool,
+    ) -> &mut Self {
+        self.include_ntp_status = include_ntp_status;
+        self
+    }
+
+    /// Control display of Internal DNS generation information (defaults to true).
+    pub fn include_internal_dns_status(
+        &mut self,
+        include_internal_dns_status: bool,
+    ) -> &mut Self {
+        self.include_internal_dns_status = include_internal_dns_status;
+        self
+    }
+
     /// Show long strings (defaults to false).
     pub fn show_long_strings(&mut self, show_long_strings: bool) -> &mut Self {
         self.long_string_formatter.show_long_strings = show_long_strings;
@@ -127,6 +149,8 @@ impl<'a> CollectionDisplay<'a> {
                 filter.include_keeper_membership(),
             )
             .include_cockroach_status(filter.include_cockroach_status())
+            .include_ntp_status(filter.include_ntp_status())
+            .include_internal_dns_status(filter.include_internal_dns_status())
     }
 }
 
@@ -152,6 +176,15 @@ impl fmt::Display for CollectionDisplay<'_> {
         }
         if self.include_cockroach_status {
             display_cockroach_status(&self.collection, f)?;
+        }
+        if self.include_ntp_status {
+            display_ntp_status(&self.collection.ntp_timesync, f)?;
+        }
+        if self.include_internal_dns_status {
+            display_internal_dns_status(
+                &self.collection.internal_dns_generation_status,
+                f,
+            )?;
         }
 
         if nerrors > 0 {
@@ -220,6 +253,22 @@ impl CollectionDisplayCliFilter {
     }
 
     fn include_cockroach_status(&self) -> bool {
+        match self {
+            Self::All => true,
+            Self::Sp { .. } => false,
+            Self::OrphanedDatasets => false,
+        }
+    }
+
+    fn include_ntp_status(&self) -> bool {
+        match self {
+            Self::All => true,
+            Self::Sp { .. } => false,
+            Self::OrphanedDatasets => false,
+        }
+    }
+
+    fn include_internal_dns_status(&self) -> bool {
         match self {
             Self::All => true,
             Self::Sp { .. } => false,
@@ -695,20 +744,6 @@ fn display_sleds(
                 indented = IndentWriter::new("    ", f);
             }
 
-            if let Some(config) = ledgered_sled_config.as_ref() {
-                display_ntp_status(
-                    config,
-                    &collection.ntp_timesync,
-                    &mut indented,
-                )?;
-
-                display_internal_dns_status(
-                    config,
-                    &collection.internal_dns_generation_status,
-                    &mut indented,
-                )?;
-            }
-
             {
                 let mut indent2 = IndentWriter::new("    ", &mut indented);
 
@@ -856,22 +891,26 @@ fn display_sleds(
 }
 
 fn display_ntp_status(
-    ledgered_sled_config: &OmicronSledConfig,
     ntp_timesync: &IdOrdMap<TimeSync>,
     f: &mut dyn fmt::Write,
 ) -> fmt::Result {
-    let timesync = ledgered_sled_config
-        .zones
-        .keys()
-        .find_map(|zone_id| ntp_timesync.get(zone_id));
+    writeln!(f, "\nNTP STATUS")?;
+    let mut f = IndentWriter::new("    ", f);
 
-    match timesync {
-        None => writeln!(f, "no information from NTP for this sled")?,
-        Some(ts) if ts.synced => {
-            writeln!(f, "NTP reports that time is synced")?
+    let mut ntp_found = false;
+    for ts in ntp_timesync {
+        ntp_found = true;
+        let zone_id = ts.zone_id;
+        if ts.synced {
+            writeln!(f, "Zone {zone_id}: NTP reports that time is synced")?;
+        } else {
+            writeln!(f, "Zone {zone_id}: NTP reports that time is NOT synced")?;
         }
-        Some(_) => writeln!(f, "NTP reports that time is NOT synced")?,
-    };
+    }
+
+    if !ntp_found {
+        writeln!(f, "No NTP zones reported timesync information")?;
+    }
 
     Ok(())
 }
@@ -914,17 +953,26 @@ fn display_boot_partition_contents(
 }
 
 fn display_internal_dns_status(
-    ledgered_sled_config: &OmicronSledConfig,
     internal_dns_generation_status: &IdOrdMap<InternalDnsGenerationStatus>,
     f: &mut dyn fmt::Write,
 ) -> fmt::Result {
-    let internal_dns_generation_status = ledgered_sled_config
-        .zones
-        .keys()
-        .find_map(|zone_id| internal_dns_generation_status.get(zone_id));
-    if let Some(st) = internal_dns_generation_status {
-        writeln!(f, "Internal DNS generation: {}", st.generation)?
+    writeln!(f, "\nINTERNAL DNS STATUS")?;
+    let mut f = IndentWriter::new("    ", f);
+
+    let mut internal_dns_found = false;
+    for st in internal_dns_generation_status {
+        internal_dns_found = true;
+        writeln!(
+            f,
+            "Zone {}: Internal DNS generation @ {}",
+            st.zone_id, st.generation
+        )?
     }
+
+    if !internal_dns_found {
+        writeln!(f, "No Internal DNS zones found which reported a generation")?;
+    }
+
     Ok(())
 }
 
@@ -1196,6 +1244,7 @@ fn display_cockroach_status(
     f: &mut dyn fmt::Write,
 ) -> fmt::Result {
     writeln!(f, "\nCOCKROACH STATUS")?;
+    let mut f = IndentWriter::new("    ", f);
 
     // Under normal conditions, cockroach nodes will report the same data. For
     // brevity, we will map "status" -> "nodes reporting that status", to avoid
@@ -1209,21 +1258,21 @@ fn display_cockroach_status(
     for (status, nodes) in &status_to_node {
         writeln!(
             f,
-            "\n  status from nodes: {}",
+            "status from nodes: {}",
             nodes.iter().map(|n| n.to_string()).join(", ")
         )?;
 
         writeln!(
             f,
-            "\n    ranges underreplicated: {}",
+            "ranges underreplicated: {}",
             status
                 .ranges_underreplicated
                 .map(|r| r.to_string())
-                .unwrap_or_else(|| "<cOULD NOT BE PARSED>".to_string())
+                .unwrap_or_else(|| "<COULD NOT BE PARSED>".to_string())
         )?;
         writeln!(
             f,
-            "\n    live nodes: {}",
+            "live nodes: {}",
             status
                 .liveness_live_nodes
                 .map(|r| r.to_string())
@@ -1231,7 +1280,7 @@ fn display_cockroach_status(
         )?;
     }
     if status_to_node.is_empty() {
-        writeln!(f, "    no cockroach status retrieved")?;
+        writeln!(f, "no cockroach status retrieved")?;
     }
     writeln!(f)?;
 


### PR DESCRIPTION
Response to https://github.com/oxidecomputer/omicron/pull/8683#discussion_r2237933052

- Move this display outside "sled ledger", but keep co-located with sled
- Display results for all zones present, not just first zone present
- Identify zone UUID