### PR TITLE
make sleds report their CPU families to Nexus

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -6555,6 +6555,7 @@ dependencies = [
  "id-map",
  "iddqd",
  "itertools 0.14.0",
+ "nexus-client",
  "nexus-sled-agent-shared",
  "nexus-types",
  "ntp-admin-client",

--- a/nexus/db-model/src/lib.rs
+++ b/nexus/db-model/src/lib.rs
@@ -103,6 +103,7 @@ mod silo_group;
 mod silo_user;
 mod silo_user_password_hash;
 mod sled;
+mod sled_cpu_family;
 mod sled_instance;
 mod sled_policy;
 mod sled_resource_vmm;
@@ -223,6 +224,7 @@ pub use silo_group::*;
 pub use silo_user::*;
 pub use silo_user_password_hash::*;
 pub use sled::*;
+pub use sled_cpu_family::*;
 pub use sled_instance::*;
 pub use sled_policy::to_db_sled_policy; // Do not expose DbSledPolicy
 pub use sled_resource_vmm::*;

--- a/nexus/db-model/src/schema_versions.rs
+++ b/nexus/db-model/src/schema_versions.rs
@@ -16,7 +16,7 @@ use std::{collections::BTreeMap, sync::LazyLock};
 ///
 /// This must be updated when you change the database schema.  Refer to
 /// schema/crdb/README.adoc in the root of this repository for details.
-pub const SCHEMA_VERSION: Version = Version::new(173, 0, 0);
+pub const SCHEMA_VERSION: Version = Version::new(174, 0, 0);
 
 /// List of all past database schema versions, in *reverse* order
 ///
@@ -28,6 +28,7 @@ static KNOWN_VERSIONS: LazyLock<Vec<KnownVersion>> = LazyLock::new(|| {
         // |  leaving the first copy as an example for the next person.
         // v
         // KnownVersion::new(next_int, "unique-dirname-with-the-sql-files"),
+        KnownVersion::new(174, "sled-cpu-family"),
         KnownVersion::new(173, "inv-internal-dns"),
         KnownVersion::new(172, "add-zones-with-mupdate-override"),
         KnownVersion::new(171, "inv-clear-mupdate-override"),

--- a/nexus/db-model/src/sled.rs
+++ b/nexus/db-model/src/sled.rs
@@ -6,6 +6,7 @@ use super::{ByteCount, Generation, SledState, SqlU16, SqlU32};
 use crate::collection::DatastoreCollectionConfig;
 use crate::ipv6;
 use crate::sled::shared::Baseboard;
+use crate::sled_cpu_family::SledCpuFamily;
 use crate::sled_policy::DbSledPolicy;
 use chrono::{DateTime, Utc};
 use db_macros::Asset;
@@ -40,6 +41,8 @@ pub struct SledSystemHardware {
 
     // current VMM reservoir size
     pub reservoir_size: ByteCount,
+
+    pub cpu_family: SledCpuFamily,
 }
 
 /// Database representation of a Sled.
@@ -84,6 +87,9 @@ pub struct Sled {
 
     // ServiceAddress (Repo Depot API). Uses `ip`.
     pub repo_depot_port: SqlU16,
+
+    /// The family of this sled's CPU.
+    pub cpu_family: SledCpuFamily,
 }
 
 impl Sled {
@@ -141,6 +147,7 @@ impl From<Sled> for views::Sled {
             state: sled.state.into(),
             usable_hardware_threads: sled.usable_hardware_threads.0,
             usable_physical_ram: *sled.usable_physical_ram,
+            cpu_family: sled.cpu_family.into(),
         }
     }
 }
@@ -185,6 +192,7 @@ impl From<Sled> for params::SledAgentInfo {
             usable_physical_ram: sled.usable_physical_ram.into(),
             reservoir_size: sled.reservoir_size.into(),
             generation: sled.sled_agent_gen.into(),
+            cpu_family: sled.cpu_family.into(),
             decommissioned,
         }
     }
@@ -229,6 +237,8 @@ pub struct SledUpdate {
     // ServiceAddress (Repo Depot API). Uses `ip`.
     pub repo_depot_port: SqlU16,
 
+    pub cpu_family: SledCpuFamily,
+
     // Generation number - owned and incremented by sled-agent.
     pub sled_agent_gen: Generation,
 }
@@ -258,6 +268,7 @@ impl SledUpdate {
             ip: addr.ip().into(),
             port: addr.port().into(),
             repo_depot_port: repo_depot_port.into(),
+            cpu_family: hardware.cpu_family,
             sled_agent_gen,
         }
     }
@@ -296,6 +307,7 @@ impl SledUpdate {
             repo_depot_port: self.repo_depot_port,
             last_used_address,
             sled_agent_gen: self.sled_agent_gen,
+            cpu_family: self.cpu_family,
         }
     }
 

--- a/nexus/db-model/src/sled_cpu_family.rs
+++ b/nexus/db-model/src/sled_cpu_family.rs
@@ -1,0 +1,57 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at https://mozilla.org/MPL/2.0/.
+
+use super::impl_enum_type;
+use serde::{Deserialize, Serialize};
+
+impl_enum_type!(
+    SledCpuFamilyEnum:
+
+    #[derive(
+        Copy,
+        Clone,
+        Debug,
+        PartialEq,
+        AsExpression,
+        FromSqlRow,
+        Serialize,
+        Deserialize
+    )]
+    pub enum SledCpuFamily;
+
+    Unknown => b"unknown"
+    AmdMilan => b"amd_milan"
+    AmdTurin => b"amd_turin"
+);
+
+impl From<nexus_types::internal_api::params::SledCpuFamily> for SledCpuFamily {
+    fn from(value: nexus_types::internal_api::params::SledCpuFamily) -> Self {
+        use nexus_types::internal_api::params::SledCpuFamily as InputFamily;
+        match value {
+            InputFamily::Unknown => Self::Unknown,
+            InputFamily::AmdMilan => Self::AmdMilan,
+            InputFamily::AmdTurin => Self::AmdTurin,
+        }
+    }
+}
+
+impl From<SledCpuFamily> for nexus_types::internal_api::params::SledCpuFamily {
+    fn from(value: SledCpuFamily) -> Self {
+        match value {
+            SledCpuFamily::Unknown => Self::Unknown,
+            SledCpuFamily::AmdMilan => Self::AmdMilan,
+            SledCpuFamily::AmdTurin => Self::AmdTurin,
+        }
+    }
+}
+
+impl From<SledCpuFamily> for nexus_types::external_api::views::SledCpuFamily {
+    fn from(value: SledCpuFamily) -> Self {
+        match value {
+            SledCpuFamily::Unknown => Self::Unknown,
+            SledCpuFamily::AmdMilan => Self::AmdMilan,
+            SledCpuFamily::AmdTurin => Self::AmdTurin,
+        }
+    }
+}

--- a/nexus/db-queries/src/db/datastore/crucible_dataset.rs
+++ b/nexus/db-queries/src/db/datastore/crucible_dataset.rs
@@ -294,6 +294,7 @@ mod test {
     use crate::db::pub_test_utils::TestDatabase;
     use nexus_db_model::Generation;
     use nexus_db_model::SledBaseboard;
+    use nexus_db_model::SledCpuFamily;
     use nexus_db_model::SledSystemHardware;
     use nexus_db_model::SledUpdate;
     use omicron_common::api::external::ByteCount;
@@ -323,6 +324,7 @@ mod test {
                 usable_hardware_threads: 128,
                 usable_physical_ram: (64 << 30).try_into().unwrap(),
                 reservoir_size: (16 << 30).try_into().unwrap(),
+                cpu_family: SledCpuFamily::AmdMilan,
             },
             Uuid::new_v4(),
             Generation::new(),

--- a/nexus/db-queries/src/db/datastore/support_bundle.rs
+++ b/nexus/db-queries/src/db/datastore/support_bundle.rs
@@ -515,6 +515,7 @@ mod test {
     use crate::db::pub_test_utils::TestDatabase;
     use nexus_db_model::Generation;
     use nexus_db_model::SledBaseboard;
+    use nexus_db_model::SledCpuFamily;
     use nexus_db_model::SledSystemHardware;
     use nexus_db_model::SledUpdate;
     use nexus_db_model::Zpool;
@@ -617,6 +618,7 @@ mod test {
                     usable_hardware_threads: 128,
                     usable_physical_ram: (64 << 30).try_into().unwrap(),
                     reservoir_size: (16 << 30).try_into().unwrap(),
+                    cpu_family: SledCpuFamily::AmdMilan,
                 },
                 rack_id,
                 Generation::new(),

--- a/nexus/db-queries/src/db/pub_test_utils/helpers.rs
+++ b/nexus/db-queries/src/db/pub_test_utils/helpers.rs
@@ -25,6 +25,7 @@ use nexus_db_model::ProjectImage;
 use nexus_db_model::ProjectImageIdentity;
 use nexus_db_model::Resources;
 use nexus_db_model::SledBaseboard;
+use nexus_db_model::SledCpuFamily;
 use nexus_db_model::SledSystemHardware;
 use nexus_db_model::SledUpdate;
 use nexus_db_model::Snapshot;
@@ -77,6 +78,7 @@ pub struct SledSystemHardwareBuilder {
     usable_hardware_threads: u32,
     usable_physical_ram: i64,
     reservoir_size: i64,
+    cpu_family: SledCpuFamily,
 }
 
 impl Default for SledSystemHardwareBuilder {
@@ -86,6 +88,7 @@ impl Default for SledSystemHardwareBuilder {
             usable_hardware_threads: 4,
             usable_physical_ram: 1 << 40,
             reservoir_size: 1 << 39,
+            cpu_family: SledCpuFamily::AmdMilan,
         }
     }
 }
@@ -121,12 +124,18 @@ impl SledSystemHardwareBuilder {
         self
     }
 
+    pub fn cpu_family(&mut self, family: SledCpuFamily) -> &mut Self {
+        self.cpu_family = family;
+        self
+    }
+
     pub fn build(&self) -> SledSystemHardware {
         SledSystemHardware {
             is_scrimlet: self.is_scrimlet,
             usable_hardware_threads: self.usable_hardware_threads,
             usable_physical_ram: self.usable_physical_ram.try_into().unwrap(),
             reservoir_size: self.reservoir_size.try_into().unwrap(),
+            cpu_family: self.cpu_family,
         }
     }
 }

--- a/nexus/db-schema/src/enums.rs
+++ b/nexus/db-schema/src/enums.rs
@@ -72,6 +72,7 @@ define_enums! {
     RouterRouteKindEnum => "router_route_kind",
     SagaStateEnum => "saga_state",
     ServiceKindEnum => "service_kind",
+    SledCpuFamilyEnum => "sled_cpu_family",
     SledPolicyEnum => "sled_policy",
     SledRoleEnum => "sled_role",
     SledStateEnum => "sled_state",

--- a/nexus/db-schema/src/schema.rs
+++ b/nexus/db-schema/src/schema.rs
@@ -971,6 +971,7 @@ table! {
         sled_state -> crate::enums::SledStateEnum,
         sled_agent_gen -> Int8,
         repo_depot_port -> Int4,
+        cpu_family -> crate::enums::SledCpuFamilyEnum,
     }
 }
 

--- a/nexus/inventory/Cargo.toml
+++ b/nexus/inventory/Cargo.toml
@@ -48,6 +48,7 @@ omicron-workspace-hack.workspace = true
 expectorate.workspace = true
 gateway-test-utils.workspace = true
 httpmock.workspace = true
+nexus-client.workspace = true
 omicron-sled-agent.workspace = true
 regex.workspace = true
 tokio.workspace = true

--- a/nexus/inventory/src/collector.rs
+++ b/nexus/inventory/src/collector.rs
@@ -666,6 +666,7 @@ mod test {
     use crate::StaticSledAgentEnumerator;
     use gateway_messages::SpPort;
     use id_map::IdMap;
+    use nexus_client::types::SledCpuFamily;
     use nexus_sled_agent_shared::inventory::ConfigReconcilerInventoryStatus;
     use nexus_sled_agent_shared::inventory::HostPhase2DesiredSlots;
     use nexus_sled_agent_shared::inventory::OmicronSledConfig;
@@ -913,6 +914,7 @@ mod test {
             None,
             None,
             sim::ZpoolConfig::None,
+            SledCpuFamily::AmdMilan,
         );
 
         let agent =

--- a/nexus/reconfigurator/rendezvous/src/crucible_dataset.rs
+++ b/nexus/reconfigurator/rendezvous/src/crucible_dataset.rs
@@ -130,6 +130,7 @@ mod tests {
     use async_bb8_diesel::AsyncSimpleConnection;
     use nexus_db_model::Generation;
     use nexus_db_model::SledBaseboard;
+    use nexus_db_model::SledCpuFamily;
     use nexus_db_model::SledSystemHardware;
     use nexus_db_model::SledUpdate;
     use nexus_db_model::Zpool;
@@ -201,6 +202,7 @@ mod tests {
                         usable_hardware_threads: 128,
                         usable_physical_ram: (64 << 30).try_into().unwrap(),
                         reservoir_size: (16 << 30).try_into().unwrap(),
+                        cpu_family: SledCpuFamily::Unknown,
                     },
                     Uuid::new_v4(),
                     Generation::new(),

--- a/nexus/src/app/background/tasks/blueprint_execution.rs
+++ b/nexus/src/app/background/tasks/blueprint_execution.rs
@@ -180,7 +180,8 @@ mod test {
     use id_map::IdMap;
     use itertools::Itertools as _;
     use nexus_db_model::{
-        ByteCount, SledBaseboard, SledSystemHardware, SledUpdate, Zpool,
+        ByteCount, SledBaseboard, SledCpuFamily, SledSystemHardware,
+        SledUpdate, Zpool,
     };
     use nexus_db_queries::authn;
     use nexus_db_queries::context::OpContext;
@@ -359,6 +360,7 @@ mod test {
                     usable_hardware_threads: 4,
                     usable_physical_ram: ByteCount(1000.into()),
                     reservoir_size: ByteCount(999.into()),
+                    cpu_family: SledCpuFamily::AmdMilan,
                 },
                 rack_id,
                 nexus_db_model::Generation::new(),

--- a/nexus/src/app/background/tasks/inventory_collection.rs
+++ b/nexus/src/app/background/tasks/inventory_collection.rs
@@ -267,6 +267,7 @@ mod test {
     use crate::app::background::BackgroundTask;
     use nexus_db_model::Generation;
     use nexus_db_model::SledBaseboard;
+    use nexus_db_model::SledCpuFamily;
     use nexus_db_model::SledSystemHardware;
     use nexus_db_model::SledUpdate;
     use nexus_db_queries::context::OpContext;
@@ -443,6 +444,7 @@ mod test {
                     usable_physical_ram: ByteCount::from_gibibytes_u32(16)
                         .into(),
                     reservoir_size: ByteCount::from_gibibytes_u32(8).into(),
+                    cpu_family: SledCpuFamily::AmdMilan,
                 },
                 rack_id,
                 Generation::new(),

--- a/nexus/src/app/sled.rs
+++ b/nexus/src/app/sled.rs
@@ -77,6 +77,7 @@ impl super::Nexus {
                 usable_hardware_threads: info.usable_hardware_threads,
                 usable_physical_ram: info.usable_physical_ram.into(),
                 reservoir_size: info.reservoir_size.into(),
+                cpu_family: info.cpu_family.into(),
             },
             self.rack_id,
             info.generation.into(),

--- a/nexus/test-utils/src/lib.rs
+++ b/nexus/test-utils/src/lib.rs
@@ -27,6 +27,7 @@ use id_map::IdMap;
 use internal_dns_types::config::DnsConfigBuilder;
 use internal_dns_types::names::DNS_ZONE_EXTERNAL_TESTING;
 use internal_dns_types::names::ServiceName;
+use nexus_client::types::SledCpuFamily;
 use nexus_config::Database;
 use nexus_config::DpdConfig;
 use nexus_config::InternalDns;
@@ -1902,7 +1903,18 @@ pub async fn start_sled_agent(
         Some(nexus_address),
         Some(update_directory),
         sim::ZpoolConfig::None,
+        SledCpuFamily::AmdMilan,
     );
+    start_sled_agent_with_config(log, &config, sled_index, simulated_upstairs)
+        .await
+}
+
+pub async fn start_sled_agent_with_config(
+    log: Logger,
+    config: &sim::Config,
+    sled_index: u16,
+    simulated_upstairs: &Arc<sim::SimulatedUpstairs>,
+) -> Result<sim::Server, String> {
     let server =
         sim::Server::start(&config, &log, true, simulated_upstairs, sled_index)
             .await

--- a/nexus/tests/integration_tests/rack.rs
+++ b/nexus/tests/integration_tests/rack.rs
@@ -7,6 +7,7 @@ use http::Method;
 use http::StatusCode;
 use nexus_client::types::SledId;
 use nexus_db_model::SledBaseboard;
+use nexus_db_model::SledCpuFamily as DbSledCpuFamily;
 use nexus_db_model::SledSystemHardware;
 use nexus_db_model::SledUpdate;
 use nexus_sled_agent_shared::inventory::SledRole;
@@ -20,6 +21,7 @@ use nexus_types::external_api::params;
 use nexus_types::external_api::shared::UninitializedSled;
 use nexus_types::external_api::views::Rack;
 use nexus_types::internal_api::params::SledAgentInfo;
+use nexus_types::internal_api::params::SledCpuFamily;
 use omicron_common::api::external::ByteCount;
 use omicron_common::api::external::Generation;
 use omicron_uuid_kinds::GenericUuid;
@@ -135,6 +137,7 @@ async fn test_sled_list_uninitialized(cptestctx: &ControlPlaneTestContext) {
         usable_hardware_threads: 32,
         usable_physical_ram: ByteCount::from_gibibytes_u32(100),
         reservoir_size: ByteCount::from_mebibytes_u32(100),
+        cpu_family: SledCpuFamily::Unknown,
         generation: Generation::new(),
         decommissioned: false,
     };
@@ -240,6 +243,7 @@ async fn test_sled_add(cptestctx: &ControlPlaneTestContext) {
                 usable_hardware_threads: 8,
                 usable_physical_ram: (1 << 30).try_into().unwrap(),
                 reservoir_size: (1 << 20).try_into().unwrap(),
+                cpu_family: DbSledCpuFamily::Unknown,
             },
             nexus.rack_id(),
             Generation::new().into(),

--- a/nexus/tests/integration_tests/sleds.rs
+++ b/nexus/tests/integration_tests/sleds.rs
@@ -15,10 +15,10 @@ use nexus_test_utils::resource_helpers::create_default_ip_pool;
 use nexus_test_utils::resource_helpers::create_instance;
 use nexus_test_utils::resource_helpers::create_project;
 use nexus_test_utils::resource_helpers::objects_list_page_authz;
-use nexus_test_utils::start_sled_agent;
+use nexus_test_utils::{start_sled_agent, start_sled_agent_with_config};
 use nexus_test_utils_macros::nexus_test;
 use nexus_types::external_api::views::SledInstance;
-use nexus_types::external_api::views::{PhysicalDisk, Sled};
+use nexus_types::external_api::views::{PhysicalDisk, Sled, SledCpuFamily};
 use omicron_sled_agent::sim;
 use omicron_test_utils::dev::poll::{CondCheckError, wait_for_condition};
 use omicron_uuid_kinds::GenericUuid;
@@ -60,40 +60,81 @@ async fn test_sleds_list(cptestctx: &ControlPlaneTestContext) {
     assert_eq!(sleds_list(&client, &sleds_url).await.len(), 2);
 
     // Now start a few more sled agents.
-    let nsleds = 3;
-    let mut sas = Vec::with_capacity(nsleds);
-    for i in 0..nsleds {
+    let mut sas = Vec::new();
+    let nexus_address =
+        cptestctx.server.get_http_server_internal_address().await;
+    let update_directory = Utf8Path::new("/should/not/be/used");
+    let simulated_upstairs = &cptestctx.first_sled_agent().simulated_upstairs;
+
+    for _ in 0..4 {
         let sa_id = SledUuid::new_v4();
         let log =
             cptestctx.logctx.log.new(o!( "sled_id" => sa_id.to_string() ));
-        let addr = cptestctx.server.get_http_server_internal_address().await;
-        let update_directory = Utf8Path::new("/should/not/be/used");
         sas.push(
             start_sled_agent(
                 log,
-                addr,
+                nexus_address,
                 sa_id,
                 // Index starts at 2: the `nexus_test` macro already created two
                 // sled agents as part of the ControlPlaneTestContext setup.
-                2 + i as u16,
+                2 + sas.len() as u16 + 1,
                 &update_directory,
                 sim::SimMode::Explicit,
-                &cptestctx.first_sled_agent().simulated_upstairs,
+                &simulated_upstairs,
             )
             .await
             .unwrap(),
         );
     }
 
+    let turin_sled_id = SledUuid::new_v4();
+    let turin_sled_agent_log =
+        cptestctx.logctx.log.new(o!( "sled_id" => turin_sled_id.to_string() ));
+
+    let turin_config = omicron_sled_agent::sim::Config::for_testing(
+        turin_sled_id,
+        omicron_sled_agent::sim::SimMode::Explicit,
+        Some(nexus_address),
+        Some(&update_directory),
+        omicron_sled_agent::sim::ZpoolConfig::None,
+        nexus_client::types::SledCpuFamily::AmdTurin,
+    );
+
+    sas.push(
+        start_sled_agent_with_config(
+            turin_sled_agent_log,
+            &turin_config,
+            2 + sas.len() as u16 + 1,
+            &simulated_upstairs,
+        )
+        .await
+        .unwrap(),
+    );
+
     // List sleds again.
     let sleds_found = sleds_list(&client, &sleds_url).await;
-    assert_eq!(sleds_found.len(), nsleds + 2);
+    assert_eq!(sleds_found.len(), sas.len() + 2);
 
     let sledids_found =
         sleds_found.iter().map(|sv| sv.identity.id).collect::<Vec<Uuid>>();
     let mut sledids_found_sorted = sledids_found.clone();
     sledids_found_sorted.sort();
     assert_eq!(sledids_found, sledids_found_sorted);
+
+    let milans_found = sleds_found
+        .iter()
+        .filter(|sv| sv.cpu_family == SledCpuFamily::AmdMilan)
+        .count();
+    // Simulated sled-agents report Milan processors by default. The two fake
+    // sled-agents created by `#[nexus_test]` as well as the four manually
+    // created above should be counted here.
+    assert_eq!(milans_found, 2 + 4);
+
+    let turins_found = sleds_found
+        .iter()
+        .filter(|sv| sv.cpu_family == SledCpuFamily::AmdTurin)
+        .count();
+    assert_eq!(turins_found, 1);
 
     // Tear down the agents.
     for sa in sas {

--- a/nexus/types/src/external_api/views.rs
+++ b/nexus/types/src/external_api/views.rs
@@ -596,6 +596,8 @@ pub struct Sled {
     pub usable_hardware_threads: u32,
     /// Amount of RAM which may be used by the Sled's OS
     pub usable_physical_ram: ByteCount,
+    /// The family of the sled's CPU(s).
+    pub cpu_family: SledCpuFamily,
 }
 
 /// The operator-defined provision policy of a sled.
@@ -763,6 +765,26 @@ impl fmt::Display for SledState {
             SledState::Decommissioned => write!(f, "decommissioned"),
         }
     }
+}
+
+/// Identifies the kind of CPU present on a sled, determined by reading CPUID.
+/// This is the CPU family used in deciding if this sled can support an instance
+/// with a particular required CPU platform.
+// In lab and development environments in particular, the family reported here
+// may differ from the real processor family. `sled-hardware::detect_cpu_family`
+// tries to map various CPUs that we would not ship in a rack to their
+// greatest-common-denominator family names here.
+#[derive(Clone, Serialize, Deserialize, Debug, JsonSchema, PartialEq)]
+#[serde(rename_all = "snake_case")]
+pub enum SledCpuFamily {
+    /// The CPU vendor or its model/family numbers were not recognized.
+    Unknown,
+
+    /// The sled has an AMD Milan (Zen 3) processor.
+    AmdMilan,
+
+    /// The sled has an AMD Turin (Zen 5) processor.
+    AmdTurin,
 }
 
 /// An operator's view of an instance running on a given sled

--- a/nexus/types/src/internal_api/params.rs
+++ b/nexus/types/src/internal_api/params.rs
@@ -30,6 +30,24 @@ use std::net::SocketAddr;
 use std::net::SocketAddrV6;
 use uuid::Uuid;
 
+/// Identifies the kind of CPU present on a sled, determined by reading CPUID.
+#[derive(Serialize, Deserialize, Debug, JsonSchema)]
+#[serde(rename_all = "snake_case")]
+pub enum SledCpuFamily {
+    /// The CPU vendor or its family number don't correspond to any of the
+    /// known family variants.
+    Unknown,
+
+    /// AMD Milan processors (or very close). Could be an actual Milan in a
+    /// Gimlet, a close-to-Milan client Zen 3 part, or Zen 4 (for which Milan is
+    /// the greatest common denominator).
+    AmdMilan,
+
+    /// AMD Turin processors (or very close). Could be an actual Turin in a
+    /// Cosmo, or a close-to-Turin client Zen 5 part.
+    AmdTurin,
+}
+
 /// Sent by a sled agent to Nexus to inform about resources
 #[derive(Serialize, Deserialize, Debug, JsonSchema)]
 pub struct SledAgentInfo {
@@ -55,6 +73,9 @@ pub struct SledAgentInfo {
     ///
     /// Must be smaller than "usable_physical_ram"
     pub reservoir_size: ByteCount,
+
+    /// The family of the sled's CPU.
+    pub cpu_family: SledCpuFamily,
 
     /// The generation number of this request from sled-agent
     pub generation: Generation,

--- a/openapi/nexus-internal.json
+++ b/openapi/nexus-internal.json
@@ -7195,6 +7195,14 @@
               }
             ]
           },
+          "cpu_family": {
+            "description": "The family of the sled's CPU.",
+            "allOf": [
+              {
+                "$ref": "#/components/schemas/SledCpuFamily"
+              }
+            ]
+          },
           "decommissioned": {
             "description": "Whether the sled-agent has been decommissioned by nexus\n\nThis flag is only set to true by nexus. Setting it on an upsert from sled-agent has no effect.",
             "type": "boolean"
@@ -7250,6 +7258,7 @@
         },
         "required": [
           "baseboard",
+          "cpu_family",
           "decommissioned",
           "generation",
           "repo_depot_port",
@@ -7258,6 +7267,32 @@
           "sa_address",
           "usable_hardware_threads",
           "usable_physical_ram"
+        ]
+      },
+      "SledCpuFamily": {
+        "description": "Identifies the kind of CPU present on a sled, determined by reading CPUID.",
+        "oneOf": [
+          {
+            "description": "The CPU vendor or its family number don't correspond to any of the known family variants.",
+            "type": "string",
+            "enum": [
+              "unknown"
+            ]
+          },
+          {
+            "description": "AMD Milan processors (or very close). Could be an actual Milan in a Gimlet, a close-to-Milan client Zen 3 part, or Zen 4 (for which Milan is the greatest common denominator).",
+            "type": "string",
+            "enum": [
+              "amd_milan"
+            ]
+          },
+          {
+            "description": "AMD Turin processors (or very close). Could be an actual Turin in a Cosmo, or a close-to-Turin client Zen 5 part.",
+            "type": "string",
+            "enum": [
+              "amd_turin"
+            ]
+          }
         ]
       },
       "SledId": {

--- a/openapi/nexus.json
+++ b/openapi/nexus.json
@@ -23719,6 +23719,14 @@
           "baseboard": {
             "$ref": "#/components/schemas/Baseboard"
           },
+          "cpu_family": {
+            "description": "The family of the sled's CPU(s).",
+            "allOf": [
+              {
+                "$ref": "#/components/schemas/SledCpuFamily"
+              }
+            ]
+          },
           "id": {
             "description": "unique, immutable, system-controlled identifier for each resource",
             "type": "string",
@@ -23772,6 +23780,7 @@
         },
         "required": [
           "baseboard",
+          "cpu_family",
           "id",
           "policy",
           "rack_id",
@@ -23780,6 +23789,32 @@
           "time_modified",
           "usable_hardware_threads",
           "usable_physical_ram"
+        ]
+      },
+      "SledCpuFamily": {
+        "description": "Identifies the kind of CPU present on a sled, determined by reading CPUID. This is the CPU family used in deciding if this sled can support an instance with a particular required CPU platform.",
+        "oneOf": [
+          {
+            "description": "The CPU vendor or its model/family numbers were not recognized.",
+            "type": "string",
+            "enum": [
+              "unknown"
+            ]
+          },
+          {
+            "description": "The sled has an AMD Milan (Zen 3) processor.",
+            "type": "string",
+            "enum": [
+              "amd_milan"
+            ]
+          },
+          {
+            "description": "The sled has an AMD Turin (Zen 5) processor.",
+            "type": "string",
+            "enum": [
+              "amd_turin"
+            ]
+          }
         ]
       },
       "SledId": {

--- a/schema/crdb/dbinit.sql
+++ b/schema/crdb/dbinit.sql
@@ -187,6 +187,21 @@ CREATE TYPE IF NOT EXISTS omicron.public.sled_state AS ENUM (
     'decommissioned'
 );
 
+-- The model of CPU installed in a particular sled, discovered by sled-agent
+-- and reported to Nexus. This determines what VMs can run on a sled: instances
+-- that require a specific minimum CPU platform can only run on sleds whose
+-- CPUs support all the features of that platform.
+CREATE TYPE IF NOT EXISTS omicron.public.sled_cpu_family AS ENUM (
+    -- Sled-agent didn't recognize the sled's CPU.
+    'unknown',
+
+    -- AMD Milan, or lab CPU close enough that sled-agent reported it as one.
+    'amd_milan',
+
+    -- AMD Turin, or lab CPU close enough that sled-agent reported it as one.
+    'amd_turin'
+);
+
 CREATE TABLE IF NOT EXISTS omicron.public.sled (
     /* Identity metadata (asset) */
     id UUID PRIMARY KEY,
@@ -229,7 +244,10 @@ CREATE TABLE IF NOT EXISTS omicron.public.sled (
 
     /* The bound port of the Repo Depot API server, running on the same IP as
        the sled agent server. */
-    repo_depot_port INT4 CHECK (port BETWEEN 0 AND 65535) NOT NULL
+    repo_depot_port INT4 CHECK (port BETWEEN 0 AND 65535) NOT NULL,
+
+    /* The sled's detected CPU family. */
+    cpu_family omicron.public.sled_cpu_family NOT NULL
 );
 
 -- Add an index that ensures a given physical sled (identified by serial and
@@ -6342,7 +6360,7 @@ INSERT INTO omicron.public.db_metadata (
     version,
     target_version
 ) VALUES
-    (TRUE, NOW(), NOW(), '173.0.0', NULL)
+    (TRUE, NOW(), NOW(), '174.0.0', NULL)
 ON CONFLICT DO NOTHING;
 
 COMMIT;

--- a/schema/crdb/sled-cpu-family/up01.sql
+++ b/schema/crdb/sled-cpu-family/up01.sql
@@ -1,0 +1,5 @@
+CREATE TYPE IF NOT EXISTS omicron.public.sled_cpu_family AS ENUM (
+    'unknown',
+    'amd_milan',
+    'amd_turin'
+);

--- a/schema/crdb/sled-cpu-family/up02.sql
+++ b/schema/crdb/sled-cpu-family/up02.sql
@@ -1,0 +1,2 @@
+ALTER TABLE omicron.public.sled ADD COLUMN IF NOT EXISTS 
+    cpu_family omicron.public.sled_cpu_family NOT NULL DEFAULT 'unknown';

--- a/schema/crdb/sled-cpu-family/up03.sql
+++ b/schema/crdb/sled-cpu-family/up03.sql
@@ -1,0 +1,1 @@
+ALTER TABLE omicron.public.sled ALTER COLUMN cpu_family DROP DEFAULT;

--- a/sled-agent/src/bin/sled-agent-sim.rs
+++ b/sled-agent/src/bin/sled-agent-sim.rs
@@ -12,6 +12,7 @@ use clap::Parser;
 use dropshot::ConfigDropshot;
 use dropshot::ConfigLogging;
 use dropshot::ConfigLoggingLevel;
+use nexus_client::types::SledCpuFamily;
 use omicron_common::api::internal::nexus::Certificate;
 use omicron_common::cmd::CmdError;
 use omicron_common::cmd::fatal;
@@ -110,6 +111,7 @@ async fn do_run() -> Result<(), CmdError> {
             hardware_threads: 32,
             physical_ram: 64 * (1 << 30),
             reservoir_ram: 32 * (1 << 30),
+            cpu_family: SledCpuFamily::AmdMilan,
             baseboard: Baseboard::Gimlet {
                 identifier: format!("sim-{}", args.uuid),
                 model: String::from("sim-gimlet"),
@@ -122,6 +124,7 @@ async fn do_run() -> Result<(), CmdError> {
             Some(args.nexus_addr),
             Some(tmp.path()),
             ZpoolConfig::TenVirtualU2s,
+            SledCpuFamily::AmdMilan,
         )
     };
 

--- a/sled-agent/src/nexus.rs
+++ b/sled-agent/src/nexus.rs
@@ -77,6 +77,24 @@ impl ConvertInto<nexus_client::types::Baseboard>
     }
 }
 
+impl ConvertInto<nexus_client::types::SledCpuFamily>
+    for sled_hardware_types::CpuFamily
+{
+    fn convert(self) -> nexus_client::types::SledCpuFamily {
+        match self {
+            sled_hardware_types::CpuFamily::Unknown => {
+                nexus_client::types::SledCpuFamily::Unknown
+            }
+            sled_hardware_types::CpuFamily::AmdMilan => {
+                nexus_client::types::SledCpuFamily::AmdMilan
+            }
+            sled_hardware_types::CpuFamily::AmdTurin => {
+                nexus_client::types::SledCpuFamily::AmdTurin
+            }
+        }
+    }
+}
+
 // Somewhat arbitrary bound size, large enough that we should never hit it.
 const QUEUE_SIZE: usize = 256;
 
@@ -275,6 +293,7 @@ impl NexusNotifierTask {
                     .usable_physical_ram_bytes()
                     .into(),
                 reservoir_size: vmm_reservoir_manager.reservoir_size().into(),
+                cpu_family: hardware.cpu_family().convert(),
                 generation,
                 decommissioned: false,
             }
@@ -654,6 +673,7 @@ mod test {
                 usable_physical_ram: ByteCount::from(1024 * 1024 * 1024u32)
                     .into(),
                 reservoir_size: ByteCount::from(0u32).into(),
+                cpu_family: nexus_client::types::SledCpuFamily::Unknown,
                 generation: Generation::new(),
                 decommissioned: false,
             }));

--- a/sled-agent/src/sim/config.rs
+++ b/sled-agent/src/sim/config.rs
@@ -7,6 +7,7 @@
 use crate::updates::ConfigUpdates;
 use camino::Utf8Path;
 use dropshot::ConfigDropshot;
+use nexus_client::types::SledCpuFamily;
 use omicron_uuid_kinds::SledUuid;
 use serde::Deserialize;
 use serde::Serialize;
@@ -56,6 +57,12 @@ pub struct ConfigHardware {
     pub hardware_threads: u32,
     pub physical_ram: u64,
     pub reservoir_ram: u64,
+    /// The kind of CPU to report the simulated sled as. In reality this is
+    /// constrained by `baseboard`; a `Baseboard::Gimlet` will only have an
+    /// `SledCpuFamily::AmdMilan`. A future `Baseboard::Cosmo` will *never* have
+    /// a `SledCpuFamily::AmdMilan`. Because the baseboard does not imply a
+    /// specific individual CPU family, though, it's simpler to record here.
+    pub cpu_family: SledCpuFamily,
     pub baseboard: Baseboard,
 }
 
@@ -93,6 +100,7 @@ impl Config {
         nexus_address: Option<SocketAddr>,
         update_directory: Option<&Utf8Path>,
         zpool_config: ZpoolConfig,
+        cpu_family: SledCpuFamily,
     ) -> Config {
         // This IP range is guaranteed by RFC 6666 to discard traffic.
         // For tests that don't use a Nexus, we use this address to simulate a
@@ -133,6 +141,7 @@ impl Config {
                 hardware_threads: TEST_HARDWARE_THREADS,
                 physical_ram: TEST_PHYSICAL_RAM,
                 reservoir_ram: TEST_RESERVOIR_RAM,
+                cpu_family,
                 baseboard: Baseboard::Gimlet {
                     identifier: format!("sim-{}", id),
                     model: String::from("sim-gimlet"),

--- a/sled-agent/src/sim/server.rs
+++ b/sled-agent/src/sim/server.rs
@@ -166,6 +166,7 @@ impl Server {
                                 config.hardware.reservoir_ram,
                             )
                             .unwrap(),
+                            cpu_family: config.hardware.cpu_family,
                             generation: Generation::new(),
                             decommissioned: false,
                         },

--- a/sled-hardware/src/illumos/mod.rs
+++ b/sled-hardware/src/illumos/mod.rs
@@ -9,7 +9,7 @@ use gethostname::gethostname;
 use illumos_devinfo::{DevInfo, DevLinkType, DevLinks, Node, Property};
 use libnvme::{Nvme, controller::Controller};
 use omicron_common::disk::{DiskIdentity, DiskVariant};
-use sled_hardware_types::Baseboard;
+use sled_hardware_types::{Baseboard, CpuFamily};
 use slog::Logger;
 use slog::debug;
 use slog::error;
@@ -795,6 +795,11 @@ impl HardwareManager {
             .as_ref()
             .cloned()
             .unwrap_or_else(|| Baseboard::unknown())
+    }
+
+    pub fn cpu_family(&self) -> CpuFamily {
+        let log = self.log.new(slog::o!("component" => "detect_cpu_family"));
+        crate::detect_cpu_family(&log)
     }
 
     pub fn online_processor_count(&self) -> u32 {

--- a/sled-hardware/src/lib.rs
+++ b/sled-hardware/src/lib.rs
@@ -149,3 +149,138 @@ impl MemoryReservations {
         vmm_eligible
     }
 }
+
+/// Detects the current sled's CPU family using the CPUID instruction.
+#[cfg(target_arch = "x86_64")]
+pub fn detect_cpu_family(log: &Logger) -> sled_hardware_types::CpuFamily {
+    use core::arch::x86_64::__cpuid_count;
+    use sled_hardware_types::CpuFamily;
+
+    // Read leaf 0 to figure out the processor's vendor and whether leaf 1
+    // (which contains family, model, and stepping information) is available.
+    let leaf_0 = unsafe { __cpuid_count(0, 0) };
+
+    info!(log, "read CPUID leaf 0 to detect CPU vendor"; "values" => ?leaf_0);
+
+    // If leaf 1 is unavailable, there's no way to figure out what family this
+    // processor belongs to.
+    if leaf_0.eax < 1 {
+        return CpuFamily::Unknown;
+    }
+
+    // Check the vendor ID string in ebx/ecx/edx.
+    match (leaf_0.ebx, leaf_0.ecx, leaf_0.edx) {
+        // "AuthenticAMD"; see AMD APM volume 3 (March 2024) section E.3.1.
+        (0x68747541, 0x444D4163, 0x69746E65) => {}
+        _ => return CpuFamily::Unknown,
+    }
+
+    // Feature detection after this point is AMD-specific - if we find ourselves
+    // supporting other CPU vendors we'll want to split this out accordingly.
+
+    // Per AMD APM volume 3 (March 2024) section E.3.2, the processor family
+    // number is computed as follows:
+    //
+    // - Read bits 11:8 of leaf 1 eax to get the "base" family value. If this
+    //   value is less than 0xF, the family value is equal to the base family
+    //   value.
+    // - If the base family value is 0xF, eax[27:20] contains the "extended"
+    //   family value, and the actual family value is the sum of the base and
+    //   the extended values.
+    let leaf_1 = unsafe { __cpuid_count(1, 0) };
+    let mut family = (leaf_1.eax & 0x00000F00) >> 8;
+    if family == 0xF {
+        family += (leaf_1.eax & 0x0FF00000) >> 20;
+    }
+
+    // Also from the APM volume 3 section E.3.2, the processor model number is
+    // computed as follows:
+    //
+    // - Read bits 7:4 of leaf 1 eax to get the "base" model value.
+    // - If the "base" family value is less than 0xF, the "base" model stands.
+    //   Otherwise, four additional bits of the model come from eax[19:16].
+    //
+    // If the computed family number is 0xF or greater, that implies the "bsae"
+    // family was 0xF or greater as well.
+    let mut model = (leaf_1.eax & 0x000000F0) >> 4;
+    if family >= 0xF {
+        model |= (leaf_1.eax & 0x000F0000) >> 12;
+    }
+
+    info!(
+        log,
+        "read CPUID leaf 1 to detect CPU family";
+        "values" => ?leaf_1,
+        "family" => family,
+        "model" => model,
+    );
+
+    // Match on the family/model ranges we've detected. Notably client parts are
+    // reported as if they were their server counterparts; the feature parity is
+    // close enough that guests probably won't run into issues. This lowers
+    // friction for testing migrations where the control plane would need to
+    // tell what hosts could be compatible with a VMM's CPU platform.
+    //
+    // TODO(?): Exhaustively check that client parts support all CPU features of
+    // the corresponding Oxide CPU platform before doing this "as-if" reporting.
+    // Lab systems built out of client parts may have hardware which support all
+    // features in the corresponding instance CPU platform, but have individual
+    // features disabled in the BIOS or by client part microcode. This can
+    // result in funky situations, like an Oxide CPU platform advertising CPU
+    // features that lab systems don't support. This is unlikely, but take
+    // AVX512 as an example: users can often disable AVX512 entirely on Zen 5
+    // BIOSes. In this case a VM on a 9000-series Ryzen will be told those
+    // instructions are available only for the guest to get #UD at runtime.
+    match family {
+        0x19 if model <= 0x0F => {
+            // This covers both Milan and Zen 3-based Threadrippers. I don't
+            // have a 5000-series Threadripper on hand to test but I believe
+            // they are feature-compatible.
+            CpuFamily::AmdMilan
+        }
+        0x19 if model >= 0x10 && model <= 0x1F => {
+            // This covers both Genoa and Zen 4-based Threadrippers. Again,
+            // don't have a comparable Threadripper to test here.
+            //
+            // We intend to expose Turin and Milan as families a guest can
+            // choose, skipping the Zen 4 EPYC parts. So, round this down to
+            // Milan; if we're here it's a lab system and the alternative is
+            // "unknown".
+            CpuFamily::AmdMilan
+        }
+        0x19 if model >= 0x20 && model <= 0x2F => {
+            // These are client Zen 3 parts aka Vermeer. Feature-wise, they are
+            // missing INVLPGB from Milan, but are otherwise close, and we don't
+            // expose INVLPGB to guests currently anyway.
+            CpuFamily::AmdMilan
+        }
+        0x19 if model >= 0x60 && model <= 0x6F => {
+            // These are client Zen 4 parts aka Raphael. Similar to the above
+            // with Genoa and Vermeer, round these down to Milan in support of
+            // lab clusters instead of calling them unknown.
+            CpuFamily::AmdMilan
+        }
+        0x1A if model <= 0x0F => CpuFamily::AmdTurin,
+        0x1A if model >= 0x10 && model <= 0x1F => {
+            // These are Turin Dense, but from a CPU feature perspective they're
+            // equivalently capable to Turin, so for our purposes they're the
+            // same.
+            CpuFamily::AmdTurin
+        }
+        0x1A if model >= 0x40 && model <= 0x4F => {
+            // These are client Zen 5 parts aka Granite Ridge. Won't be in a
+            // rack, but plausibly in a lab cluster. Like other non-server
+            // parts, these don't have INVLPGB, which we don't expose to guests.
+            // They should otherwise be a sufficient stand-in for Turin.
+            CpuFamily::AmdTurin
+        }
+        // Remaining family/model ranges in known families are likely mobile
+        // parts and intentionally rolled up into "Unknown." There, it's harder
+        // to predict what features out of the corresponding CPU platform would
+        // actually be present. It's also less likely that someone has a laptop
+        // or APU as part of a development cluster!
+        //
+        // Other families are, of course, unknown.
+        _ => CpuFamily::Unknown,
+    }
+}

--- a/sled-hardware/src/non_illumos/mod.rs
+++ b/sled-hardware/src/non_illumos/mod.rs
@@ -6,7 +6,7 @@ use crate::SledMode;
 use crate::disk::{DiskPaths, Partition, PooledDiskError, UnparsedDisk};
 use omicron_common::disk::{DiskIdentity, DiskVariant};
 use omicron_uuid_kinds::ZpoolUuid;
-use sled_hardware_types::Baseboard;
+use sled_hardware_types::{Baseboard, CpuFamily};
 use slog::Logger;
 use std::collections::HashMap;
 use tokio::sync::broadcast;
@@ -38,6 +38,10 @@ impl HardwareManager {
     }
 
     pub fn baseboard(&self) -> Baseboard {
+        unimplemented!("Accessing hardware unsupported on non-illumos");
+    }
+
+    pub fn cpu_family(&self) -> CpuFamily {
         unimplemented!("Accessing hardware unsupported on non-illumos");
     }
 

--- a/sled-hardware/types/src/lib.rs
+++ b/sled-hardware/types/src/lib.rs
@@ -95,3 +95,10 @@ impl std::fmt::Display for Baseboard {
         }
     }
 }
+
+#[derive(Clone, Copy, Debug)]
+pub enum CpuFamily {
+    Unknown,
+    AmdMilan,
+    AmdTurin,
+}


### PR DESCRIPTION
RFD 505 proposes that instances should be able to set a "minimum hardware platform" or "minimum CPU platform" that allows users to constrain an instance to run on sleds that have a specific set of CPU features available. This allows a user to opt a VM into advanced hardware features (e.g. AVX-512 support) by constraining it to run only on sleds that support those features. For this to work, Nexus needs to understand what CPUs are present in which sleds.

Have sled-agent query CPUID to get CPU vendor and family information and report this to Nexus as part of the sled hardware manifest.

----

This is largely code Greg had put together that, now that the control plane bits that build on it are imminently to be PR'd, I'd like to get merged. Initially it was oriented around `AmdFamilyXXh`, but I've adjusted towards specific family names since there is precedent for one family (19h) which has very different features (Zen 4-based parts have AVX512, Zen 3-based parts do not). Additionally, client vs server parts sometimes are segmented along feature lines in annoying ways - not such that VMs would see a difference, but over in Intel land that *does* happen. If times were to so substantially change...

I mostly mention this because if that rationale is not clear from the code and comments, please say so!