### PR TITLE
[sp-sim] configurable initial contents of the cabooses

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -12727,6 +12727,7 @@ dependencies = [
  "gateway-types",
  "hex",
  "hubtools",
+ "nexus-types",
  "nix 0.30.1",
  "omicron-common",
  "omicron-workspace-hack",

--- a/gateway-test-utils/configs/sp_sim_config.test.toml
+++ b/gateway-test-utils/configs/sp_sim_config.test.toml
@@ -84,6 +84,7 @@ bind_addr = "[::1]:0"
 serial_number = "SimGimlet00"
 manufacturing_root_cert_seed = "01de01de01de01de01de01de01de01de01de01de01de01de01de01de01de01de"
 device_id_cert_seed = "01de000000000000000000000000000000000000000000000000000000000002"
+board = "BOB"
 
 [[simulated_sps.gimlet.network_config]]
 [simulated_sps.gimlet.network_config.simulated]

--- a/gateway-test-utils/configs/sp_sim_config.test.toml
+++ b/gateway-test-utils/configs/sp_sim_config.test.toml
@@ -84,7 +84,47 @@ bind_addr = "[::1]:0"
 serial_number = "SimGimlet00"
 manufacturing_root_cert_seed = "01de01de01de01de01de01de01de01de01de01de01de01de01de01de01de01de"
 device_id_cert_seed = "01de000000000000000000000000000000000000000000000000000000000002"
-board = "BOB"
+
+# TODO-K: Fix these up or remove
+[simulated_sps.gimlet.cabooses.sp_slot_0]
+board = "1"
+git_commit = "2"
+name = "3"
+version = "4"
+
+[simulated_sps.gimlet.cabooses.sp_slot_1]
+board = "5"
+git_commit = "6"
+name = "7"
+version = "8"
+
+[simulated_sps.gimlet.cabooses.rot_slot_a]
+board = "9"
+git_commit = "10"
+name = "11"
+version = "12"
+sign = "13"
+
+[simulated_sps.gimlet.cabooses.rot_slot_b]
+board = "14"
+git_commit = "15"
+name = "16"
+version = "17"
+sign = "18"
+
+[simulated_sps.gimlet.cabooses.stage0]
+board = "19"
+git_commit = "20"
+name = "21"
+version = "22"
+sign = "23"
+
+[simulated_sps.gimlet.cabooses.stage0_next]
+board = "24"
+git_commit = "25"
+name = "26"
+version = "27"
+sign = "28"
 
 [[simulated_sps.gimlet.network_config]]
 [simulated_sps.gimlet.network_config.simulated]

--- a/gateway-test-utils/configs/sp_sim_config.test.toml
+++ b/gateway-test-utils/configs/sp_sim_config.test.toml
@@ -86,45 +86,45 @@ manufacturing_root_cert_seed = "01de01de01de01de01de01de01de01de01de01de01de01de
 device_id_cert_seed = "01de000000000000000000000000000000000000000000000000000000000002"
 
 # TODO-K: Fix these up or remove
-[simulated_sps.gimlet.cabooses.sp_slot_0]
-board = "1"
-git_commit = "2"
-name = "3"
-version = "4"
-
-[simulated_sps.gimlet.cabooses.sp_slot_1]
-board = "5"
-git_commit = "6"
-name = "7"
-version = "8"
-
-[simulated_sps.gimlet.cabooses.rot_slot_a]
-board = "9"
-git_commit = "10"
-name = "11"
-version = "12"
-sign = "13"
-
-[simulated_sps.gimlet.cabooses.rot_slot_b]
-board = "14"
-git_commit = "15"
-name = "16"
-version = "17"
-sign = "18"
-
-[simulated_sps.gimlet.cabooses.stage0]
-board = "19"
-git_commit = "20"
-name = "21"
-version = "22"
-sign = "23"
-
-[simulated_sps.gimlet.cabooses.stage0_next]
-board = "24"
-git_commit = "25"
-name = "26"
-version = "27"
-sign = "28"
+# [simulated_sps.gimlet.cabooses.sp_slot_0]
+# board = "1"
+# git_commit = "2"
+# name = "3"
+# version = "4"
+# 
+# [simulated_sps.gimlet.cabooses.sp_slot_1]
+# board = "5"
+# git_commit = "6"
+# name = "7"
+# version = "8"
+# 
+# [simulated_sps.gimlet.cabooses.rot_slot_a]
+# board = "9"
+# git_commit = "10"
+# name = "11"
+# version = "12"
+# sign = "13"
+# 
+# [simulated_sps.gimlet.cabooses.rot_slot_b]
+# board = "14"
+# git_commit = "15"
+# name = "16"
+# version = "17"
+# sign = "18"
+# 
+# [simulated_sps.gimlet.cabooses.stage0]
+# board = "19"
+# git_commit = "20"
+# name = "21"
+# version = "22"
+# sign = "23"
+# 
+# [simulated_sps.gimlet.cabooses.stage0_next]
+# board = "24"
+# git_commit = "25"
+# name = "26"
+# version = "27"
+# sign = "28"
 
 [[simulated_sps.gimlet.network_config]]
 [simulated_sps.gimlet.network_config.simulated]

--- a/gateway-test-utils/src/setup.rs
+++ b/gateway-test-utils/src/setup.rs
@@ -62,6 +62,7 @@ impl GatewayTestContext {
     }
 }
 
+// TODO-K: load a test config with a specific sp_sim file
 pub fn load_test_config() -> (omicron_gateway::Config, sp_sim::Config) {
     // The test configs are located relative to the directory this file is in.
     // TODO: embed these with include_str! instead?

--- a/sp-sim/Cargo.toml
+++ b/sp-sim/Cargo.toml
@@ -18,6 +18,7 @@ gateway-messages.workspace = true
 gateway-types.workspace = true
 hex = { workspace = true, features = [ "serde" ] }
 hubtools.workspace = true
+nexus-types.workspace = true
 omicron-common.workspace = true
 oxide-tokio-rt.workspace = true
 serde.workspace = true

--- a/sp-sim/src/config.rs
+++ b/sp-sim/src/config.rs
@@ -9,6 +9,7 @@ use crate::sensors;
 use dropshot::ConfigLogging;
 use gateway_messages::DeviceCapabilities;
 use gateway_messages::DevicePresence;
+use nexus_types::inventory::Caboose;
 use serde::Deserialize;
 use serde::Serialize;
 use std::net::Ipv6Addr;
@@ -70,6 +71,17 @@ impl slog::KV for NetworkConfig {
     }
 }
 
+/// Configuration for every caboose in the SP
+#[derive(Clone, Debug, Deserialize, PartialEq, Serialize)]
+pub struct SpCabooses {
+    pub sp_slot_0: Caboose,
+    pub sp_slot_1: Caboose,
+    pub rot_slot_a: Caboose,
+    pub rot_slot_b: Caboose,
+    pub stage0: Caboose,
+    pub stage0_next: Caboose,
+}
+
 /// Common configuration for all flavors of SP
 #[derive(Clone, Debug, Deserialize, PartialEq, Serialize)]
 pub struct SpCommonConfig {
@@ -100,9 +112,10 @@ pub struct SpCommonConfig {
     /// Fake ereport configuration
     #[serde(default)]
     pub ereport_config: EreportConfig,
-    /// Configurable name of the board in the caboose. If unset, it will be
+    /// Configurable caboose values. If unset, these will be
     /// populated with default values
-    pub board: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub cabooses: Option<SpCabooses>,
 }
 
 /// Configuration of a simulated SP component

--- a/sp-sim/src/config.rs
+++ b/sp-sim/src/config.rs
@@ -137,7 +137,6 @@ pub struct SpComponentConfig {
     pub sensors: Vec<SensorConfig>,
 }
 
-// TODO-K: Change config here
 /// Configuration of a simulated sidecar SP
 #[derive(Clone, Debug, Deserialize, PartialEq, Serialize)]
 pub struct SidecarConfig {
@@ -145,7 +144,6 @@ pub struct SidecarConfig {
     pub common: SpCommonConfig,
 }
 
-// TODO-K: Change config here
 /// Configuration of a simulated gimlet SP
 #[derive(Clone, Debug, Deserialize, PartialEq, Serialize)]
 pub struct GimletConfig {

--- a/sp-sim/src/config.rs
+++ b/sp-sim/src/config.rs
@@ -100,6 +100,9 @@ pub struct SpCommonConfig {
     /// Fake ereport configuration
     #[serde(default)]
     pub ereport_config: EreportConfig,
+    /// Configurable name of the board in the caboose. If unset, it will be
+    /// populated with default values
+    pub board: Option<String>,
 }
 
 /// Configuration of a simulated SP component
@@ -121,6 +124,7 @@ pub struct SpComponentConfig {
     pub sensors: Vec<SensorConfig>,
 }
 
+// TODO-K: Change config here
 /// Configuration of a simulated sidecar SP
 #[derive(Clone, Debug, Deserialize, PartialEq, Serialize)]
 pub struct SidecarConfig {
@@ -128,6 +132,7 @@ pub struct SidecarConfig {
     pub common: SpCommonConfig,
 }
 
+// TODO-K: Change config here
 /// Configuration of a simulated gimlet SP
 #[derive(Clone, Debug, Deserialize, PartialEq, Serialize)]
 pub struct GimletConfig {

--- a/sp-sim/src/gimlet.rs
+++ b/sp-sim/src/gimlet.rs
@@ -270,6 +270,7 @@ impl Gimlet {
             BaseboardKind::Gimlet,
             gimlet.common.no_stage0_caboose,
             phase1_hash_policy,
+            gimlet.common.board.clone(),
         );
         let ereport_state = {
             let mut cfg = gimlet.common.ereport_config.clone();

--- a/sp-sim/src/gimlet.rs
+++ b/sp-sim/src/gimlet.rs
@@ -270,7 +270,7 @@ impl Gimlet {
             BaseboardKind::Gimlet,
             gimlet.common.no_stage0_caboose,
             phase1_hash_policy,
-            gimlet.common.board.clone(),
+            gimlet.common.cabooses.clone(),
         );
         let ereport_state = {
             let mut cfg = gimlet.common.ereport_config.clone();

--- a/sp-sim/src/sidecar.rs
+++ b/sp-sim/src/sidecar.rs
@@ -534,6 +534,8 @@ impl Handler {
                 no_stage0_caboose,
                 // sidecar doesn't have phase 1 flash; any policy is fine
                 HostFlashHashPolicy::assume_already_hashed(),
+                // TODO-K: For now none, change later
+                None,
             ),
             reset_pending: None,
             should_fail_to_respond_signal: None,

--- a/sp-sim/src/update.rs
+++ b/sp-sim/src/update.rs
@@ -711,7 +711,6 @@ pub enum BaseboardKind {
 }
 
 impl BaseboardKind {
-    // TODO-K: This is where the boards are set?
     fn sp_board(&self) -> &str {
         match self {
             BaseboardKind::Gimlet => &SIM_GIMLET_BOARD,

--- a/sp-sim/src/update.rs
+++ b/sp-sim/src/update.rs
@@ -75,6 +75,7 @@ impl SimSpUpdate {
         baseboard_kind: BaseboardKind,
         no_stage0_caboose: bool,
         phase1_hash_policy: HostFlashHashPolicy,
+        sp_board_name: Option<String>,
     ) -> Self {
         const SP_GITC0: &str = "ffffffff";
         const SP_GITC1: &str = "fefefefe";
@@ -94,14 +95,17 @@ impl SimSpUpdate {
         const STAGE0_VERS0: &str = "0.0.200";
         const STAGE0_VERS1: &str = "0.0.200";
 
-        let sp_board = baseboard_kind.sp_board();
+        // TODO-K: This is where the boards are set?
+        let sp_board = if let Some(b) = sp_board_name  {
+            b
+        } else {baseboard_kind.sp_board().to_string()};
         let sp_name = baseboard_kind.sp_name();
         let rot_name = baseboard_kind.rot_name();
 
         let caboose_sp_active = CabooseValue::Caboose(
             hubtools::CabooseBuilder::default()
                 .git_commit(SP_GITC0)
-                .board(sp_board)
+                .board(&sp_board)
                 .name(sp_name)
                 .version(SP_VERS0)
                 .build(),
@@ -109,7 +113,7 @@ impl SimSpUpdate {
         let caboose_sp_inactive = CabooseValue::Caboose(
             hubtools::CabooseBuilder::default()
                 .git_commit(SP_GITC1)
-                .board(sp_board)
+                .board(&sp_board)
                 .name(sp_name)
                 .version(SP_VERS1)
                 .build(),
@@ -659,6 +663,7 @@ pub enum BaseboardKind {
 }
 
 impl BaseboardKind {
+    // TODO-K: This is where the boards are set?
     fn sp_board(&self) -> &str {
         match self {
             BaseboardKind::Gimlet => &SIM_GIMLET_BOARD,


### PR DESCRIPTION
Manual testing with the following configuration file

```toml
[[simulated_sps.gimlet]]
serial_number = "SimGimlet00"
manufacturing_root_cert_seed = "01de01de01de01de01de01de01de01de01de01de01de01de01de01de01de01de"
device_id_cert_seed = "01de000000000000000000000000000000000000000000000000000000000002"

[simulated_sps.gimlet.cabooses.sp_slot_0]
board = "1"
git_commit = "2"
name = "3"
version = "4"

[simulated_sps.gimlet.cabooses.sp_slot_1]
board = "5"
git_commit = "6"
name = "7"
version = "8"

[simulated_sps.gimlet.cabooses.rot_slot_a]
board = "9"
git_commit = "10"
name = "11"
version = "12"
sign = "13"

[simulated_sps.gimlet.cabooses.rot_slot_b]
board = "14"
git_commit = "15"
name = "16"
version = "17"
sign = "18"

[simulated_sps.gimlet.cabooses.stage0]
board = "19"
git_commit = "20"
name = "21"
version = "22"
sign = "23"

[simulated_sps.gimlet.cabooses.stage0_next]
board = "24"
git_commit = "25"
name = "26"
version = "27"
sign = "28"
```

Against a simulated omicron environment

```console
$ ./target/debug/omdb --dns-server [::1]:48071 db inventory collections show latest sp
<...>

Sled SimGimlet00
    part number: i86pc
    power:    A2
    revision: 0
    MGS slot: Sled 0 (cubby 0)
    found at: 2025-07-31T09:11:03.335Z from http://[::1]:50220
    host phase 1 hashes:
        SLOT HASH                                                             
        A    e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855 
        B    e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855 
    cabooses:
        SLOT       BOARD NAME VERSION GIT_COMMIT SIGN 
        SpSlot0    1     3    4       2          n/a  
        SpSlot1    5     7    8       6          n/a  
        RotSlotA   9     11   12      10         13   
        RotSlotB   14    16   17      15         18   
        Stage0     19    21   22      20         23   
        Stage0Next 24    26   27      25         28   
    RoT pages:
        SLOT         DATA_BASE64                         
        Cmpa         Z2ltbGV0LWNtcGEAAAAAAAAAAAAAAAAA... 
        CfpaActive   Z2ltbGV0LWNmcGEtYWN0aXZlAAAAAAAA... 
        CfpaInactive Z2ltbGV0LWNmcGEtaW5hY3RpdmUAAAAA... 
        CfpaScratch  Z2ltbGV0LWNmcGEtc2NyYXRjaAAAAAAA... 
    RoT: active slot: slot A
    RoT: persistent boot preference: slot A
    RoT: pending persistent boot preference: -
    RoT: transient boot preference: -
    RoT: slot A SHA3-256: aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa
    RoT: slot B SHA3-256: bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb

<...>
```

Closes: https://github.com/oxidecomputer/omicron/issues/7913