### PR TITLE
TQ: Add support for reconfiguration

### DIFF
--- a/trust-quorum/src/compute_key_share.rs
+++ b/trust-quorum/src/compute_key_share.rs
@@ -1,0 +1,149 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at https://mozilla.org/MPL/2.0/.
+
+//! Mechanism to track and compute this node's key share for a configuration
+//!
+//! When a node learns of a committed configuration but does not have a key
+//! share for that configuration it must collect a threshold of key shares from
+//! other nodes so  that it can compute its own key share.
+
+use crate::crypto::Sha3_256Digest;
+use crate::{Configuration, Epoch, NodeHandlerCtx, PeerMsgKind, PlatformId};
+use gfss::gf256::Gf256;
+use gfss::shamir::{self, Share};
+use slog::{Logger, error, o, warn};
+use std::collections::BTreeMap;
+
+/// In memory state that tracks retrieval of key shares in order to compute
+/// this node's key share for a given configuration.
+pub struct KeyShareComputer {
+    log: Logger,
+
+    // A copy of the configuration stored in persistent state
+    config: Configuration,
+
+    collected_shares: BTreeMap<PlatformId, Share>,
+}
+
+impl KeyShareComputer {
+    pub fn new(
+        log: &Logger,
+        ctx: &mut impl NodeHandlerCtx,
+        config: Configuration,
+    ) -> KeyShareComputer {
+        let log = log.new(o!("component" => "tq-key-share-computer"));
+
+        for id in config.members.keys() {
+            if ctx.connected().contains(id) {
+                ctx.send(id.clone(), PeerMsgKind::GetShare(config.epoch));
+            }
+        }
+
+        KeyShareComputer { log, config, collected_shares: BTreeMap::new() }
+    }
+
+    pub fn config(&self) -> &Configuration {
+        &self.config
+    }
+
+    pub fn on_connect(
+        &mut self,
+        ctx: &mut impl NodeHandlerCtx,
+        peer: PlatformId,
+    ) {
+        if !self.collected_shares.contains_key(&peer) {
+            ctx.send(peer, PeerMsgKind::GetShare(self.config.epoch));
+        }
+    }
+
+    /// We received a key share
+    ///
+    /// Return true if we have computed and saved our key share to the
+    /// persistent state, false otherwise.
+    pub fn handle_share(
+        &mut self,
+        ctx: &mut impl NodeHandlerCtx,
+        from: PlatformId,
+        epoch: Epoch,
+        share: Share,
+    ) -> bool {
+        // Are we trying to retrieve shares for `epoch`?
+        if epoch != self.config.epoch {
+            warn!(
+                self.log,
+                "Received Share from node with wrong epoch";
+                "received_epoch" => %epoch,
+                "from" => %from
+            );
+            return false;
+        }
+
+        // Is the sender a member of the configuration `epoch`?
+        // Was the sender a member of the configuration at `old_epoch`?
+        let Some(expected_digest) = self.config.members.get(&from) else {
+            warn!(
+                self.log,
+                "Received Share from unexpected node";
+                "epoch" => %epoch,
+                "from" => %from
+            );
+            return false;
+        };
+
+        // Does the share hash match what we expect?
+        let mut digest = Sha3_256Digest::default();
+        share.digest::<sha3::Sha3_256>(&mut digest.0);
+        if digest != *expected_digest {
+            error!(
+                self.log,
+                "Received share with invalid digest";
+                "epoch" => %epoch,
+                "from" => %from
+            );
+        }
+
+        // A valid share was received. Is it new?
+        if self.collected_shares.insert(from, share).is_some() {
+            return false;
+        }
+
+        // Do we have enough shares to computer our rack share?
+        if self.collected_shares.len() < self.config.threshold.0 as usize {
+            return false;
+        }
+
+        // What index are we in the configuration? This is our "x-coordinate"
+        // for our key share calculation. We always start indexing from 1, since
+        // 0 is the rack secret.
+        let index = self
+            .config
+            .members
+            .keys()
+            .position(|id| id == ctx.platform_id())
+            .expect("node exists");
+        let x_coordinate =
+            Gf256::new(u8::try_from(index + 1).expect("index fits in u8"));
+
+        let shares: Vec<_> = self.collected_shares.values().cloned().collect();
+
+        match shamir::compute_share(&shares, x_coordinate) {
+            Ok(our_share) => {
+                ctx.update_persistent_state(|ps| {
+                    let inserted_share =
+                        ps.shares.insert(epoch, our_share).is_none();
+                    let inserted_commit = ps.commits.insert(epoch);
+                    inserted_share || inserted_commit
+                });
+                true
+            }
+            Err(e) => {
+                // TODO: put the node into into an `Alarm` state similar to
+                // https://github.com/oxidecomputer/omicron/pull/8062 once we
+                // have alarms?
+                error!(self.log, "Failed to compute share: {}", e);
+                false
+            }
+        }
+    }
+}

--- a/trust-quorum/src/coordinator_state.rs
+++ b/trust-quorum/src/coordinator_state.rs
@@ -5,12 +5,15 @@
 //! State of a reconfiguration coordinator inside a [`crate::Node`]
 
 use crate::NodeHandlerCtx;
-use crate::crypto::{LrtqShare, Sha3_256Digest, ShareDigestLrtq};
+use crate::crypto::{
+    LrtqShare, PlaintextRackSecrets, Sha3_256Digest, ShareDigestLrtq,
+};
 use crate::validators::{ReconfigurationError, ValidatedReconfigureMsg};
-use crate::{Configuration, Epoch, PeerMsgKind, PlatformId};
+use crate::{Configuration, Epoch, PeerMsgKind, PlatformId, RackSecret};
 use gfss::shamir::Share;
-use slog::{Logger, o, warn};
+use slog::{Logger, error, info, o, warn};
 use std::collections::{BTreeMap, BTreeSet};
+use std::mem;
 
 /// The state of a reconfiguration coordinator.
 ///
@@ -68,8 +71,15 @@ impl CoordinatorState {
         }
         let op = CoordinatorOperation::Prepare {
             prepares,
-            prepare_acks: BTreeSet::new(),
+            // Always include ourself
+            prepare_acks: BTreeSet::from([msg.coordinator_id().clone()]),
         };
+
+        info!(
+            log,
+            "Starting coordination on uninitialized node";
+            "epoch" => %config.epoch
+        );
 
         let state = CoordinatorState::new(log, msg, config.clone(), op);
 
@@ -83,16 +93,28 @@ impl CoordinatorState {
     pub fn new_reconfiguration(
         log: Logger,
         msg: ValidatedReconfigureMsg,
-        last_committed_config: &Configuration,
+        latest_committed_config: &Configuration,
+        our_latest_committed_share: Share,
     ) -> Result<CoordinatorState, ReconfigurationError> {
         let (config, new_shares) = Configuration::new(&msg)?;
 
-        // We must collect shares from the last configuration
-        // so we can recompute the old rack secret.
+        info!(
+            log,
+            "Starting coordination on existing node";
+            "epoch" => %config.epoch,
+            "last_committed_epoch" => %latest_committed_config.epoch
+        );
+
+        // We must collect shares from the last committed configuration so we
+        // can recompute the old rack secret.
         let op = CoordinatorOperation::CollectShares {
-            epoch: last_committed_config.epoch,
-            members: last_committed_config.members.clone(),
-            collected_shares: BTreeMap::new(),
+            // We save this so we can grab the old configuration
+            old_epoch: latest_committed_config.epoch,
+            // Always include ourself
+            old_collected_shares: BTreeMap::from([(
+                msg.coordinator_id().clone(),
+                our_latest_committed_share,
+            )]),
             new_shares,
         };
 
@@ -117,7 +139,7 @@ impl CoordinatorState {
         }
     }
 
-    // Return the `ValidatedReconfigureMsg` that started this reconfiguration
+    /// Return the `ValidatedReconfigureMsg` that started this reconfiguration
     pub fn reconfigure_msg(&self) -> &ValidatedReconfigureMsg {
         &self.reconfigure_msg
     }
@@ -126,24 +148,34 @@ impl CoordinatorState {
         &self.op
     }
 
-    // Send any required messages as a reconfiguration coordinator
-    //
-    // This varies depending upon the current `CoordinatorState`.
-    //
-    // In some cases a `PrepareMsg` will be added locally to the
-    // `PersistentState`, requiring persistence from the caller. In this case we
-    // will return a copy of it.
-    //
-    // This method is "in progress" - allow unused parameters for now
+    /// Send any required messages as a reconfiguration coordinator
+    ///
+    /// This varies depending upon the current `CoordinatorState`.
     pub fn send_msgs(&mut self, ctx: &mut impl NodeHandlerCtx) {
         match &self.op {
-            #[expect(unused)]
             CoordinatorOperation::CollectShares {
-                epoch,
-                members,
-                collected_shares,
+                old_epoch,
+                old_collected_shares,
                 ..
-            } => {}
+            } => {
+                // Send to all connected members in the last committed
+                // configuration that we haven't yet collected shares from.
+                let destinations: Vec<_> = ctx
+                    .persistent_state()
+                    .configuration(*old_epoch)
+                    .expect("config exists")
+                    .members
+                    .keys()
+                    .filter(|&m| {
+                        !old_collected_shares.contains_key(m)
+                            && ctx.connected().contains(m)
+                    })
+                    .cloned()
+                    .collect();
+                for to in destinations {
+                    ctx.send(to, PeerMsgKind::GetShare(*old_epoch));
+                }
+            }
             #[expect(unused)]
             CoordinatorOperation::CollectLrtqShares { members, shares } => {}
             CoordinatorOperation::Prepare { prepares, .. } => {
@@ -171,9 +203,8 @@ impl CoordinatorState {
     ) {
         match &self.op {
             CoordinatorOperation::CollectShares {
-                epoch,
-                members,
-                collected_shares,
+                old_epoch,
+                old_collected_shares,
                 ..
             } => {}
             CoordinatorOperation::CollectLrtqShares { members, shares } => {}
@@ -225,15 +256,224 @@ impl CoordinatorState {
             }
         }
     }
+
+    pub fn handle_share(
+        &mut self,
+        ctx: &mut impl NodeHandlerCtx,
+        from: PlatformId,
+        epoch: Epoch,
+        share: Share,
+    ) {
+        match &mut self.op {
+            CoordinatorOperation::CollectShares {
+                old_epoch,
+                old_collected_shares,
+                new_shares,
+            } => {
+                // SAFETY: We started coordinating by looking up the last
+                // committed configuration, which gave us `old_epoch`. Therefore
+                // the configuration must exist.
+                let old_config = ctx
+                    .persistent_state()
+                    .configuration(*old_epoch)
+                    .expect("config exists");
+
+                let new_epoch = self.configuration.epoch;
+
+                let log = self.log.new(o!(
+                    "last_committed_epoch" => old_epoch.to_string(),
+                    "new_epoch" => new_epoch.to_string()
+                ));
+
+                // Are we trying to retrieve shares for `epoch`?
+                if *old_epoch != epoch {
+                    warn!(
+                        log,
+                        "Received Share from node with wrong epoch";
+                        "received_epoch" => %epoch,
+                        "from" => %from
+                    );
+                    return;
+                }
+
+                // Was the sender a member of the configuration at `old_epoch`?
+                let Some(expected_digest) = old_config.members.get(&from)
+                else {
+                    warn!(
+                        log,
+                        "Received Share from unexpected node";
+                        "received_epoch" => %epoch,
+                        "from" => %from
+                    );
+                    return;
+                };
+
+                // Does the share hash match what we expect?
+                let mut digest = Sha3_256Digest::default();
+                share.digest::<sha3::Sha3_256>(&mut digest.0);
+                if digest != *expected_digest {
+                    error!(
+                        log,
+                        "Received share with invalid digest";
+                        "received_epoch" => %epoch,
+                        "from" => %from
+                    );
+                }
+
+                // A valid share was received. Is it new?
+                if old_collected_shares.insert(from, share).is_some() {
+                    return;
+                }
+
+                // Do we have enough shares to recompute the old rack secret?
+                if old_collected_shares.len() < old_config.threshold.0 as usize
+                {
+                    return;
+                }
+
+                // Reconstruct the old rack secret from the shares we collected.
+                let shares: Vec<_> =
+                    old_collected_shares.values().cloned().collect();
+                let old_rack_secret = match RackSecret::reconstruct(&shares) {
+                    Ok(secret) => {
+                        info!(
+                            log,
+                            "Successfully reconstructed old rack secret"
+                        );
+                        secret
+                    }
+                    Err(err) => {
+                        error!(
+                            log,
+                            "Failed to reconstruct old rack secret";
+                            &err
+                        );
+                        return;
+                    }
+                };
+
+                // Reconstruct the new rack secret from the shares we created
+                // at coordination start time.
+                let shares: Vec<_> = new_shares.values().cloned().collect();
+                let new_rack_secret = match RackSecret::reconstruct(&shares) {
+                    Ok(secret) => {
+                        info!(
+                            log,
+                            "Successfully reconstructed new rack secret"
+                        );
+                        secret
+                    }
+                    Err(err) => {
+                        error!(
+                            log,
+                            "Failed to reconstruct new rack secret";
+                            &err
+                        );
+                        return;
+                    }
+                };
+
+                // Decrypt the encrypted rack secrets from the old config so
+                // that we can add `old_rack_secret` to that set for use in the
+                // new configuration.
+                let mut plaintext_secrets = if let Some(encrypted_secrets) =
+                    &old_config.encrypted_rack_secrets
+                {
+                    match encrypted_secrets.decrypt(
+                        old_config.rack_id,
+                        old_config.epoch,
+                        &old_rack_secret,
+                    ) {
+                        Ok(plaintext) => plaintext,
+                        Err(err) => {
+                            error!(log, "Rack secrets decryption error"; &err);
+                            return;
+                        }
+                    }
+                } else {
+                    PlaintextRackSecrets::new()
+                };
+                plaintext_secrets.insert(*old_epoch, old_rack_secret);
+
+                // Now encrypt the set of old rack secrets with the new rack
+                // secret.
+                let new_encrypted_rack_secrets = match plaintext_secrets
+                    .encrypt(
+                        self.configuration.rack_id,
+                        new_epoch,
+                        &new_rack_secret,
+                    ) {
+                    Ok(ciphertext) => ciphertext,
+                    Err(_) => {
+                        error!(log, "Failed to encrypt plaintext rack secrets");
+                        return;
+                    }
+                };
+
+                // Save the encrypted rack secrets in the current configuration
+                assert!(self.configuration.encrypted_rack_secrets.is_none());
+                self.configuration.encrypted_rack_secrets =
+                    Some(new_encrypted_rack_secrets);
+
+                // Take `new_shares` out of `self.op` so we can include them in
+                // `Prepare` messages;
+                let mut new_shares = mem::take(new_shares);
+
+                // Update our persistent state
+                //
+                // We remove ourself because we don't send a `Prepare` message
+                // to ourself.
+                //
+                // SAFETY: our share already exists at this point and has been
+                // validated as part of the `Configuration` construction.
+                let share = new_shares
+                    .remove(ctx.platform_id())
+                    .expect("my share exists");
+                ctx.update_persistent_state(|ps| {
+                    ps.shares.insert(new_epoch, share);
+                    ps.configs
+                        .insert_unique(self.configuration.clone())
+                        .expect("no existing configuration");
+                    true
+                });
+
+                // Now transition to `CoordinatorOperation::Prepare`
+                let prepares: BTreeMap<_, _> = new_shares
+                    .into_iter()
+                    .map(|(id, share)| {
+                        (id, (self.configuration.clone(), share))
+                    })
+                    .collect();
+                self.op = CoordinatorOperation::Prepare {
+                    prepares,
+                    // Always include ourself
+                    prepare_acks: BTreeSet::from([ctx.platform_id().clone()]),
+                };
+
+                info!(log, "Starting to prepare after collecting shares");
+                self.send_msgs(ctx);
+            }
+            op => {
+                warn!(
+                    self.log,
+                    "Share received when coordinator is not expecting it";
+                    "op" => op.name(),
+                    "epoch" => %epoch,
+                    "from" => %from
+                );
+            }
+        }
+    }
 }
 
 /// What should the coordinator be doing?
 pub enum CoordinatorOperation {
-    // We haven't started implementing this yet
     CollectShares {
-        epoch: Epoch,
-        members: BTreeMap<PlatformId, Sha3_256Digest>,
-        collected_shares: BTreeMap<PlatformId, Share>,
+        old_epoch: Epoch,
+        old_collected_shares: BTreeMap<PlatformId, Share>,
+
+        // These are new shares that the coordinator created that we carry along
+        // until we get to `CoordinatorOperation::Prepare`
         new_shares: BTreeMap<PlatformId, Share>,
     },
     // We haven't started implementing this yet

--- a/trust-quorum/src/crypto.rs
+++ b/trust-quorum/src/crypto.rs
@@ -271,7 +271,7 @@ pub struct EncryptedRackSecrets {
     data: Box<[u8]>,
 }
 
-#[derive(Debug, Clone, PartialEq, Eq, thiserror::Error)]
+#[derive(Debug, Clone, PartialEq, Eq, thiserror::Error, SlogInlineError)]
 pub enum DecryptionError {
     // An opaque error indicating decryption failed
     #[error("Failed to decrypt rack secrets")]

--- a/trust-quorum/src/lib.rs
+++ b/trust-quorum/src/lib.rs
@@ -12,6 +12,7 @@
 use derive_more::Display;
 use serde::{Deserialize, Serialize};
 
+mod compute_key_share;
 mod configuration;
 mod coordinator_state;
 pub(crate) mod crypto;
@@ -45,6 +46,12 @@ pub use persistent_state::{PersistentState, PersistentStateSummary};
     Display,
 )]
 pub struct Epoch(pub u64);
+
+impl Epoch {
+    pub fn next(&self) -> Epoch {
+        Epoch(self.0.checked_add(1).expect("fewer than 2^64 epochs"))
+    }
+}
 
 /// The number of shares required to reconstruct the rack secret
 ///

--- a/trust-quorum/src/persistent_state.rs
+++ b/trust-quorum/src/persistent_state.rs
@@ -22,6 +22,8 @@ pub struct PersistentState {
     // data it read from disk. This allows us to upgrade from LRTQ.
     pub lrtq: Option<LrtqShareData>,
     pub configs: IdOrdMap<Configuration>,
+
+    // Our own key shares per configuration
     pub shares: BTreeMap<Epoch, Share>,
     pub commits: BTreeSet<Epoch>,
 
@@ -80,6 +82,18 @@ impl PersistentState {
         self.latest_committed_epoch().map(|epoch| {
             // There *must* be a configuration if we have a commit
             self.configuration(epoch).expect("missing prepare")
+        })
+    }
+
+    pub fn latest_committed_config_and_share(
+        &self,
+    ) -> Option<(&Configuration, &Share)> {
+        self.latest_committed_epoch().map(|epoch| {
+            // There *must* be a configuration and share if we have a commit
+            (
+                self.configs.get(&epoch).expect("latest config exists"),
+                self.shares.get(&epoch).expect("latest share exists"),
+            )
         })
     }
 

--- a/trust-quorum/src/validators.rs
+++ b/trust-quorum/src/validators.rs
@@ -288,12 +288,11 @@ impl ValidatedReconfigureMsg {
             });
         }
 
-        // Ensure that we haven't seen a prepare message for a newer
-        // configuration.
-        if let Some(last_prepared_epoch) = persistent_state.latest_config {
-            if msg.epoch <= last_prepared_epoch {
+        // Ensure that we haven't seen a newer configuration
+        if let Some(latest_epoch) = persistent_state.latest_config {
+            if msg.epoch <= latest_epoch {
                 return Err(ReconfigurationError::PreparedEpochMismatch {
-                    existing: last_prepared_epoch,
+                    existing: latest_epoch,
                     new: msg.epoch,
                 });
             }

--- a/trust-quorum/tests/cluster.rs
+++ b/trust-quorum/tests/cluster.rs
@@ -1103,5 +1103,5 @@ fn test_trust_quorum_protocol(input: TestInput) {
         "skipped_actions" => state.skipped_actions
     );
 
-    //    logctx.cleanup_successful();
+    logctx.cleanup_successful();
 }


### PR DESCRIPTION
Builds upon #8682

This PR implements the ability to reconfigure the trust quorum after a commit. This includes the ability to fetch shares for the most recently committed configuration to recompute the rack secret and then include that in an encrypted form in the new configuration for key rotation purposes.

The cluster proptest was enhanced to allow this, and it generates enough races - even without crashing and restarting nodes - that it forced the handling of `CommitAdvance` messages to be implemented. This implementation includes the ability to construct key shares for a new configuration when a node misses a prepare and commit for that configuration. This required adding a `KeyShareComputer` which collects key shares for the configuration returned in a `CommitAdvance` so that it can construct its own key share and commit the newly learned configuration.

Importantly, constructing a key share and coordinating a reconfiguration are mutually exclusive, and so a new invariant was added to the cluster test.

We also start keeping track of expunged nodes in the cluster test, although we don't yet inform them that they are expunged if they reach out to other nodes.

There are a few places in the code where a runtime invariant is violated and an error message is logged. This always occurs on message receipt and we don't want to panic at runtime because of an errant message and take down the sled-agent. However, we'd like to be able to report these upstream. The first step here is to be able to report when these situations are hit and put the node in an `Alarm` state such that it is stuck until remedied via support. We should *never* see an Alarm in practice, but since the states are possible to reach, we should manage them appropriately. This will come in a follow up PR and be similar to what I implemented in #8062.