### PR TITLE
[41/n] be consistent with remove-mupdate-override terminology

### DIFF
--- a/nexus-sled-agent-shared/src/inventory.rs
+++ b/nexus-sled-agent-shared/src/inventory.rs
@@ -208,9 +208,9 @@ impl ConfigReconcilerInventory {
             config.remove_mupdate_override.map(|_| {
                 RemoveMupdateOverrideInventory {
                     boot_disk_result: Ok(
-                        RemoveMupdateOverrideBootSuccessInventory::Cleared,
+                        RemoveMupdateOverrideBootSuccessInventory::Removed,
                     ),
-                    non_boot_message: "mupdate override successfully cleared \
+                    non_boot_message: "mupdate override successfully removed \
                                    on non-boot disks"
                         .to_owned(),
                 }
@@ -294,10 +294,10 @@ impl IdOrdItem for OrphanedDataset {
     id_upcast!();
 }
 
-/// Status of clearing the mupdate override in the inventory.
+/// Status of removing the mupdate override in the inventory.
 #[derive(Clone, Debug, PartialEq, Eq, Deserialize, JsonSchema, Serialize)]
 pub struct RemoveMupdateOverrideInventory {
-    /// The result of clearing the mupdate override on the boot disk.
+    /// The result of removing the mupdate override on the boot disk.
     #[serde(with = "snake_case_result")]
     #[schemars(
         schema_with = "SnakeCaseResult::<RemoveMupdateOverrideBootSuccessInventory, String>::json_schema"
@@ -312,12 +312,12 @@ pub struct RemoveMupdateOverrideInventory {
     pub non_boot_message: String,
 }
 
-/// Status of clearing the mupdate override on the boot disk.
+/// Status of removing the mupdate override on the boot disk.
 #[derive(Clone, Debug, PartialEq, Eq, Deserialize, JsonSchema, Serialize)]
 #[serde(rename_all = "snake_case")]
 pub enum RemoveMupdateOverrideBootSuccessInventory {
     /// The mupdate override was successfully removed.
-    Cleared,
+    Removed,
 
     /// No mupdate override was found.
     ///

--- a/nexus/db-model/src/inventory.rs
+++ b/nexus/db-model/src/inventory.rs
@@ -1089,7 +1089,7 @@ impl From<RemoveMupdateOverrideBootSuccessInventory>
 {
     fn from(value: RemoveMupdateOverrideBootSuccessInventory) -> Self {
         match value {
-            RemoveMupdateOverrideBootSuccessInventory::Cleared => Self::Cleared,
+            RemoveMupdateOverrideBootSuccessInventory::Removed => Self::Cleared,
             RemoveMupdateOverrideBootSuccessInventory::NoOverride => {
                 Self::NoOverride
             }
@@ -1102,7 +1102,7 @@ impl From<DbRemoveMupdateOverrideBootSuccess>
 {
     fn from(value: DbRemoveMupdateOverrideBootSuccess) -> Self {
         match value {
-            DbRemoveMupdateOverrideBootSuccess::Cleared => Self::Cleared,
+            DbRemoveMupdateOverrideBootSuccess::Cleared => Self::Removed,
             DbRemoveMupdateOverrideBootSuccess::NoOverride => Self::NoOverride,
         }
     }

--- a/nexus/db-model/src/inventory.rs
+++ b/nexus/db-model/src/inventory.rs
@@ -44,8 +44,6 @@ use nexus_db_schema::schema::{
 };
 use nexus_sled_agent_shared::inventory::BootImageHeader;
 use nexus_sled_agent_shared::inventory::BootPartitionDetails;
-use nexus_sled_agent_shared::inventory::ClearMupdateOverrideBootSuccessInventory;
-use nexus_sled_agent_shared::inventory::ClearMupdateOverrideInventory;
 use nexus_sled_agent_shared::inventory::ConfigReconcilerInventoryStatus;
 use nexus_sled_agent_shared::inventory::HostPhase2DesiredContents;
 use nexus_sled_agent_shared::inventory::HostPhase2DesiredSlots;
@@ -53,6 +51,8 @@ use nexus_sled_agent_shared::inventory::MupdateOverrideBootInventory;
 use nexus_sled_agent_shared::inventory::MupdateOverrideInventory;
 use nexus_sled_agent_shared::inventory::MupdateOverrideNonBootInventory;
 use nexus_sled_agent_shared::inventory::OrphanedDataset;
+use nexus_sled_agent_shared::inventory::RemoveMupdateOverrideBootSuccessInventory;
+use nexus_sled_agent_shared::inventory::RemoveMupdateOverrideInventory;
 use nexus_sled_agent_shared::inventory::ZoneArtifactInventory;
 use nexus_sled_agent_shared::inventory::ZoneImageResolverInventory;
 use nexus_sled_agent_shared::inventory::ZoneManifestBootInventory;
@@ -1003,7 +1003,7 @@ pub struct InvSledConfigReconciler {
     pub boot_partition_a_error: Option<String>,
     pub boot_partition_b_error: Option<String>,
     #[diesel(embed)]
-    pub clear_mupdate_override: InvClearMupdateOverride,
+    pub remove_mupdate_override: InvRemoveMupdateOverride,
 }
 
 impl InvSledConfigReconciler {
@@ -1014,7 +1014,7 @@ impl InvSledConfigReconciler {
         boot_disk: Result<M2Slot, String>,
         boot_partition_a_error: Option<String>,
         boot_partition_b_error: Option<String>,
-        clear_mupdate_override: InvClearMupdateOverride,
+        remove_mupdate_override: InvRemoveMupdateOverride,
     ) -> Self {
         // TODO-cleanup We should use `HwM2Slot` instead of integers for this
         // column: https://github.com/oxidecomputer/omicron/issues/8642
@@ -1032,7 +1032,7 @@ impl InvSledConfigReconciler {
             boot_disk_error,
             boot_partition_a_error,
             boot_partition_b_error,
-            clear_mupdate_override,
+            remove_mupdate_override,
         }
     }
 
@@ -1072,48 +1072,50 @@ impl InvSledConfigReconciler {
     }
 }
 
-// See [`nexus_sled_agent_shared::inventory::DbClearMupdateOverrideBootSuccess`].
+// See [`nexus_sled_agent_shared::inventory::DbRemoveMupdateOverrideBootSuccess`].
 impl_enum_type!(
-    ClearMupdateOverrideBootSuccessEnum:
+    RemoveMupdateOverrideBootSuccessEnum:
 
     #[derive(Copy, Clone, Debug, AsExpression, FromSqlRow, PartialEq)]
-    pub enum DbClearMupdateOverrideBootSuccess;
+    pub enum DbRemoveMupdateOverrideBootSuccess;
 
     // Enum values
     Cleared => b"cleared"
     NoOverride => b"no-override"
 );
 
-impl From<ClearMupdateOverrideBootSuccessInventory>
-    for DbClearMupdateOverrideBootSuccess
+impl From<RemoveMupdateOverrideBootSuccessInventory>
+    for DbRemoveMupdateOverrideBootSuccess
 {
-    fn from(value: ClearMupdateOverrideBootSuccessInventory) -> Self {
+    fn from(value: RemoveMupdateOverrideBootSuccessInventory) -> Self {
         match value {
-            ClearMupdateOverrideBootSuccessInventory::Cleared => Self::Cleared,
-            ClearMupdateOverrideBootSuccessInventory::NoOverride => {
+            RemoveMupdateOverrideBootSuccessInventory::Cleared => Self::Cleared,
+            RemoveMupdateOverrideBootSuccessInventory::NoOverride => {
                 Self::NoOverride
             }
         }
     }
 }
 
-impl From<DbClearMupdateOverrideBootSuccess>
-    for ClearMupdateOverrideBootSuccessInventory
+impl From<DbRemoveMupdateOverrideBootSuccess>
+    for RemoveMupdateOverrideBootSuccessInventory
 {
-    fn from(value: DbClearMupdateOverrideBootSuccess) -> Self {
+    fn from(value: DbRemoveMupdateOverrideBootSuccess) -> Self {
         match value {
-            DbClearMupdateOverrideBootSuccess::Cleared => Self::Cleared,
-            DbClearMupdateOverrideBootSuccess::NoOverride => Self::NoOverride,
+            DbRemoveMupdateOverrideBootSuccess::Cleared => Self::Cleared,
+            DbRemoveMupdateOverrideBootSuccess::NoOverride => Self::NoOverride,
         }
     }
 }
 
-/// See [`nexus_sled_agent_shared::inventory::ClearMupdateOverrideInventory`].
+/// See [`nexus_sled_agent_shared::inventory::RemoveMupdateOverrideInventory`].
 #[derive(Queryable, Clone, Debug, Selectable, Insertable)]
 #[diesel(table_name = inv_sled_config_reconciler)]
-pub struct InvClearMupdateOverride {
+pub struct InvRemoveMupdateOverride {
+    // NOTE: the column names start with "clear_" for legacy reasons. Prefer
+    // "remove" in the future.
     #[diesel(column_name = clear_mupdate_override_boot_success)]
-    pub boot_success: Option<DbClearMupdateOverrideBootSuccess>,
+    pub boot_success: Option<DbRemoveMupdateOverrideBootSuccess>,
 
     #[diesel(column_name = clear_mupdate_override_boot_error)]
     pub boot_error: Option<String>,
@@ -1122,30 +1124,30 @@ pub struct InvClearMupdateOverride {
     pub non_boot_message: Option<String>,
 }
 
-impl InvClearMupdateOverride {
+impl InvRemoveMupdateOverride {
     pub fn new(
-        clear_mupdate_override: Option<&ClearMupdateOverrideInventory>,
+        remove_mupdate_override: Option<&RemoveMupdateOverrideInventory>,
     ) -> Self {
-        let boot_success = clear_mupdate_override.and_then(|inv| {
+        let boot_success = remove_mupdate_override.and_then(|inv| {
             inv.boot_disk_result.as_ref().ok().map(|v| v.clone().into())
         });
-        let boot_error = clear_mupdate_override
+        let boot_error = remove_mupdate_override
             .and_then(|inv| inv.boot_disk_result.as_ref().err().cloned());
         let non_boot_message =
-            clear_mupdate_override.map(|inv| inv.non_boot_message.clone());
+            remove_mupdate_override.map(|inv| inv.non_boot_message.clone());
 
         Self { boot_success, boot_error, non_boot_message }
     }
 
     pub fn into_inventory(
         self,
-    ) -> anyhow::Result<Option<ClearMupdateOverrideInventory>> {
+    ) -> anyhow::Result<Option<RemoveMupdateOverrideInventory>> {
         match self {
             Self {
                 boot_success: Some(success),
                 boot_error: None,
                 non_boot_message: Some(non_boot_message),
-            } => Ok(Some(ClearMupdateOverrideInventory {
+            } => Ok(Some(RemoveMupdateOverrideInventory {
                 boot_disk_result: Ok(success.into()),
                 non_boot_message,
             })),
@@ -1153,7 +1155,7 @@ impl InvClearMupdateOverride {
                 boot_success: None,
                 boot_error: Some(boot_error),
                 non_boot_message: Some(non_boot_message),
-            } => Ok(Some(ClearMupdateOverrideInventory {
+            } => Ok(Some(RemoveMupdateOverrideInventory {
                 boot_disk_result: Err(boot_error),
                 non_boot_message,
             })),

--- a/nexus/db-queries/src/db/datastore/inventory.rs
+++ b/nexus/db-queries/src/db/datastore/inventory.rs
@@ -73,7 +73,7 @@ use nexus_db_model::{
 };
 use nexus_db_model::{HwPowerState, InvZoneManifestNonBoot};
 use nexus_db_model::{HwRotSlot, InvMupdateOverrideNonBoot};
-use nexus_db_model::{InvCaboose, InvClearMupdateOverride};
+use nexus_db_model::{InvCaboose, InvRemoveMupdateOverride};
 use nexus_db_schema::enums::HwM2SlotEnum;
 use nexus_db_schema::enums::HwRotSlotEnum;
 use nexus_db_schema::enums::RotImageErrorEnum;
@@ -3789,8 +3789,8 @@ impl DataStore {
                         BootPartitionContents { boot_disk, slot_a, slot_b }
                     };
 
-                    let clear_mupdate_override = reconciler
-                        .clear_mupdate_override
+                    let remove_mupdate_override = reconciler
+                        .remove_mupdate_override
                         .into_inventory()
                         .map_err(|err| {
                             Error::internal_error(&format!("{err:#}"))
@@ -3812,7 +3812,7 @@ impl DataStore {
                             .remove(&sled_id)
                             .unwrap_or_default(),
                         boot_partitions,
-                        clear_mupdate_override,
+                        remove_mupdate_override,
                     })
                 })
                 .transpose()?;
@@ -4036,8 +4036,8 @@ impl ConfigReconcilerRows {
                     )?
                 };
             last_reconciliation_config_id = Some(last_reconciled_config);
-            let clear_mupdate_override = InvClearMupdateOverride::new(
-                last_reconciliation.clear_mupdate_override.as_ref(),
+            let remove_mupdate_override = InvRemoveMupdateOverride::new(
+                last_reconciliation.remove_mupdate_override.as_ref(),
             );
 
             self.config_reconcilers.push(InvSledConfigReconciler::new(
@@ -4057,7 +4057,7 @@ impl ConfigReconcilerRows {
                     .as_ref()
                     .err()
                     .cloned(),
-                clear_mupdate_override,
+                remove_mupdate_override,
             ));
 
             // Boot partition _errors_ are kept in `InvSledConfigReconciler`
@@ -4310,8 +4310,8 @@ mod test {
     use nexus_sled_agent_shared::inventory::BootPartitionDetails;
     use nexus_sled_agent_shared::inventory::OrphanedDataset;
     use nexus_sled_agent_shared::inventory::{
-        BootImageHeader, ClearMupdateOverrideBootSuccessInventory,
-        ClearMupdateOverrideInventory,
+        BootImageHeader, RemoveMupdateOverrideBootSuccessInventory,
+        RemoveMupdateOverrideInventory,
     };
     use nexus_sled_agent_shared::inventory::{
         ConfigReconcilerInventory, ConfigReconcilerInventoryResult,
@@ -5174,10 +5174,10 @@ mod test {
                             artifact_size: 456789,
                         }),
                     },
-                    clear_mupdate_override: Some(
-                        ClearMupdateOverrideInventory {
+                    remove_mupdate_override: Some(
+                        RemoveMupdateOverrideInventory {
                             boot_disk_result: Ok(
-                                ClearMupdateOverrideBootSuccessInventory::Cleared,
+                                RemoveMupdateOverrideBootSuccessInventory::Cleared,
                             ),
                             non_boot_message: "simulated non-boot message"
                                 .to_owned(),

--- a/nexus/db-queries/src/db/datastore/inventory.rs
+++ b/nexus/db-queries/src/db/datastore/inventory.rs
@@ -5177,7 +5177,7 @@ mod test {
                     remove_mupdate_override: Some(
                         RemoveMupdateOverrideInventory {
                             boot_disk_result: Ok(
-                                RemoveMupdateOverrideBootSuccessInventory::Cleared,
+                                RemoveMupdateOverrideBootSuccessInventory::Removed,
                             ),
                             non_boot_message: "simulated non-boot message"
                                 .to_owned(),

--- a/nexus/db-schema/src/enums.rs
+++ b/nexus/db-schema/src/enums.rs
@@ -33,7 +33,6 @@ define_enums! {
     BpZoneDispositionEnum => "bp_zone_disposition",
     BpZoneImageSourceEnum => "bp_zone_image_source",
     CabooseWhichEnum => "caboose_which",
-    ClearMupdateOverrideBootSuccessEnum => "clear_mupdate_override_boot_success",
     ClickhouseModeEnum => "clickhouse_mode",
     DatasetKindEnum => "dataset_kind",
     DnsGroupEnum => "dns_group",
@@ -67,6 +66,9 @@ define_enums! {
     RegionReservationPercentEnum => "region_reservation_percent",
     RegionSnapshotReplacementStateEnum => "region_snapshot_replacement_state",
     RegionSnapshotReplacementStepStateEnum => "region_snapshot_replacement_step_state",
+    // NOTE: The database enum name starts with "clear_" for legacy reasons.
+    // Prefer "remove" in the future.
+    RemoveMupdateOverrideBootSuccessEnum => "clear_mupdate_override_boot_success",
     RotImageErrorEnum => "rot_image_error",
     RotPageWhichEnum => "root_of_trust_page_which",
     RouterRouteKindEnum => "router_route_kind",

--- a/nexus/db-schema/src/schema.rs
+++ b/nexus/db-schema/src/schema.rs
@@ -1640,7 +1640,7 @@ table! {
         boot_partition_a_error -> Nullable<Text>,
         boot_partition_b_error -> Nullable<Text>,
 
-        clear_mupdate_override_boot_success -> Nullable<crate::enums::ClearMupdateOverrideBootSuccessEnum>,
+        clear_mupdate_override_boot_success -> Nullable<crate::enums::RemoveMupdateOverrideBootSuccessEnum>,
         clear_mupdate_override_boot_error -> Nullable<Text>,
         clear_mupdate_override_non_boot_message -> Nullable<Text>,
     }

--- a/nexus/types/src/inventory/display.rs
+++ b/nexus/types/src/inventory/display.rs
@@ -749,10 +749,10 @@ fn display_sleds(
 
                 if let Some(remove_mupdate_override) = remove_mupdate_override {
                     match &remove_mupdate_override.boot_disk_result {
-                        Ok(RemoveMupdateOverrideBootSuccessInventory::Cleared) => {
+                        Ok(RemoveMupdateOverrideBootSuccessInventory::Removed) => {
                             writeln!(
                                 indent2,
-                                "cleared mupdate override on boot disk",
+                                "removed mupdate override on boot disk",
                             )?;
                         }
                         Ok(
@@ -760,21 +760,21 @@ fn display_sleds(
                         ) => {
                             writeln!(
                                 indent2,
-                                "attempted to clear mupdate override \
+                                "attempted to remove mupdate override \
                                  on boot disk, but no override was set",
                             )?;
                         }
                         Err(message) => {
                             writeln!(
                                 indent2,
-                                "failed to clear mupdate override on boot disk: {}",
-                                message
+                                "failed to remove mupdate override \
+                                 on boot disk: {message}",
                             )?;
                         }
                     }
                     writeln!(
                         indent2,
-                        "clear mupdate override on non-boot disk:"
+                        "remove mupdate override on non-boot disk:"
                     )?;
 
                     let mut indent3 = IndentWriter::new("  ", &mut indent2);

--- a/nexus/types/src/inventory/display.rs
+++ b/nexus/types/src/inventory/display.rs
@@ -19,10 +19,10 @@ use indent_write::fmt::IndentWriter;
 use itertools::Itertools;
 use nexus_sled_agent_shared::inventory::{
     BootImageHeader, BootPartitionContents, BootPartitionDetails,
-    ClearMupdateOverrideBootSuccessInventory, ConfigReconcilerInventory,
-    ConfigReconcilerInventoryResult, ConfigReconcilerInventoryStatus,
-    HostPhase2DesiredContents, OmicronSledConfig, OmicronZoneImageSource,
-    OrphanedDataset,
+    ConfigReconcilerInventory, ConfigReconcilerInventoryResult,
+    ConfigReconcilerInventoryStatus, HostPhase2DesiredContents,
+    OmicronSledConfig, OmicronZoneImageSource, OrphanedDataset,
+    RemoveMupdateOverrideBootSuccessInventory,
 };
 use omicron_common::disk::M2Slot;
 use omicron_uuid_kinds::{
@@ -724,7 +724,7 @@ fn display_sleds(
                 orphaned_datasets,
                 zones,
                 boot_partitions,
-                clear_mupdate_override,
+                remove_mupdate_override,
             } = last_reconciliation;
 
             display_boot_partition_contents(boot_partitions, &mut indented)?;
@@ -747,16 +747,16 @@ fn display_sleds(
             {
                 let mut indent2 = IndentWriter::new("    ", &mut indented);
 
-                if let Some(clear_mupdate_override) = clear_mupdate_override {
-                    match &clear_mupdate_override.boot_disk_result {
-                        Ok(ClearMupdateOverrideBootSuccessInventory::Cleared) => {
+                if let Some(remove_mupdate_override) = remove_mupdate_override {
+                    match &remove_mupdate_override.boot_disk_result {
+                        Ok(RemoveMupdateOverrideBootSuccessInventory::Cleared) => {
                             writeln!(
                                 indent2,
                                 "cleared mupdate override on boot disk",
                             )?;
                         }
                         Ok(
-                            ClearMupdateOverrideBootSuccessInventory::NoOverride,
+                            RemoveMupdateOverrideBootSuccessInventory::NoOverride,
                         ) => {
                             writeln!(
                                 indent2,
@@ -781,7 +781,7 @@ fn display_sleds(
                     writeln!(
                         indent3,
                         "{}",
-                        clear_mupdate_override.non_boot_message
+                        remove_mupdate_override.non_boot_message
                     )?;
                 } else {
                     match &zone_image_resolver.mupdate_override.boot_override {

--- a/openapi/sled-agent.json
+++ b/openapi/sled-agent.json
@@ -3119,79 +3119,6 @@
           }
         ]
       },
-      "ClearMupdateOverrideBootSuccessInventory": {
-        "description": "Status of clearing the mupdate override on the boot disk.",
-        "oneOf": [
-          {
-            "description": "The mupdate override was successfully cleared.",
-            "type": "string",
-            "enum": [
-              "cleared"
-            ]
-          },
-          {
-            "description": "No mupdate override was found.\n\nThis is considered a success for idempotency reasons.",
-            "type": "string",
-            "enum": [
-              "no_override"
-            ]
-          }
-        ]
-      },
-      "ClearMupdateOverrideInventory": {
-        "description": "Status of clearing the mupdate override in the inventory.",
-        "type": "object",
-        "properties": {
-          "boot_disk_result": {
-            "description": "The result of clearing the mupdate override on the boot disk.",
-            "x-rust-type": {
-              "crate": "std",
-              "parameters": [
-                {
-                  "$ref": "#/components/schemas/ClearMupdateOverrideBootSuccessInventory"
-                },
-                {
-                  "type": "string"
-                }
-              ],
-              "path": "::std::result::Result",
-              "version": "*"
-            },
-            "oneOf": [
-              {
-                "type": "object",
-                "properties": {
-                  "ok": {
-                    "$ref": "#/components/schemas/ClearMupdateOverrideBootSuccessInventory"
-                  }
-                },
-                "required": [
-                  "ok"
-                ]
-              },
-              {
-                "type": "object",
-                "properties": {
-                  "err": {
-                    "type": "string"
-                  }
-                },
-                "required": [
-                  "err"
-                ]
-              }
-            ]
-          },
-          "non_boot_message": {
-            "description": "What happened on non-boot disks.\n\nWe aren't modeling this out in more detail, because we plan to not try and keep ledgered data in sync across both disks in the future.",
-            "type": "string"
-          }
-        },
-        "required": [
-          "boot_disk_result",
-          "non_boot_message"
-        ]
-      },
       "ComponentV0": {
         "oneOf": [
           {
@@ -3632,15 +3559,6 @@
           "boot_partitions": {
             "$ref": "#/components/schemas/BootPartitionContents"
           },
-          "clear_mupdate_override": {
-            "nullable": true,
-            "description": "The result of clearing the mupdate override field.\n\n`None` if `remove_mupdate_override` was not provided in the sled config.",
-            "allOf": [
-              {
-                "$ref": "#/components/schemas/ClearMupdateOverrideInventory"
-              }
-            ]
-          },
           "datasets": {
             "type": "object",
             "additionalProperties": {
@@ -3673,6 +3591,15 @@
               "$ref": "#/components/schemas/OrphanedDataset"
             },
             "uniqueItems": true
+          },
+          "remove_mupdate_override": {
+            "nullable": true,
+            "description": "The result of removing the mupdate override file on disk.\n\n`None` if `remove_mupdate_override` was not provided in the sled config.",
+            "allOf": [
+              {
+                "$ref": "#/components/schemas/RemoveMupdateOverrideInventory"
+              }
+            ]
           },
           "zones": {
             "type": "object",
@@ -6660,6 +6587,79 @@
           "infra_ip_last",
           "ports",
           "rack_subnet"
+        ]
+      },
+      "RemoveMupdateOverrideBootSuccessInventory": {
+        "description": "Status of clearing the mupdate override on the boot disk.",
+        "oneOf": [
+          {
+            "description": "The mupdate override was successfully removed.",
+            "type": "string",
+            "enum": [
+              "cleared"
+            ]
+          },
+          {
+            "description": "No mupdate override was found.\n\nThis is considered a success for idempotency reasons.",
+            "type": "string",
+            "enum": [
+              "no_override"
+            ]
+          }
+        ]
+      },
+      "RemoveMupdateOverrideInventory": {
+        "description": "Status of clearing the mupdate override in the inventory.",
+        "type": "object",
+        "properties": {
+          "boot_disk_result": {
+            "description": "The result of clearing the mupdate override on the boot disk.",
+            "x-rust-type": {
+              "crate": "std",
+              "parameters": [
+                {
+                  "$ref": "#/components/schemas/RemoveMupdateOverrideBootSuccessInventory"
+                },
+                {
+                  "type": "string"
+                }
+              ],
+              "path": "::std::result::Result",
+              "version": "*"
+            },
+            "oneOf": [
+              {
+                "type": "object",
+                "properties": {
+                  "ok": {
+                    "$ref": "#/components/schemas/RemoveMupdateOverrideBootSuccessInventory"
+                  }
+                },
+                "required": [
+                  "ok"
+                ]
+              },
+              {
+                "type": "object",
+                "properties": {
+                  "err": {
+                    "type": "string"
+                  }
+                },
+                "required": [
+                  "err"
+                ]
+              }
+            ]
+          },
+          "non_boot_message": {
+            "description": "What happened on non-boot disks.\n\nWe aren't modeling this out in more detail, because we plan to not try and keep ledgered data in sync across both disks in the future.",
+            "type": "string"
+          }
+        },
+        "required": [
+          "boot_disk_result",
+          "non_boot_message"
         ]
       },
       "ResolvedVpcFirewallRule": {

--- a/openapi/sled-agent.json
+++ b/openapi/sled-agent.json
@@ -6590,13 +6590,13 @@
         ]
       },
       "RemoveMupdateOverrideBootSuccessInventory": {
-        "description": "Status of clearing the mupdate override on the boot disk.",
+        "description": "Status of removing the mupdate override on the boot disk.",
         "oneOf": [
           {
             "description": "The mupdate override was successfully removed.",
             "type": "string",
             "enum": [
-              "cleared"
+              "removed"
             ]
           },
           {
@@ -6609,11 +6609,11 @@
         ]
       },
       "RemoveMupdateOverrideInventory": {
-        "description": "Status of clearing the mupdate override in the inventory.",
+        "description": "Status of removing the mupdate override in the inventory.",
         "type": "object",
         "properties": {
           "boot_disk_result": {
-            "description": "The result of clearing the mupdate override on the boot disk.",
+            "description": "The result of removing the mupdate override on the boot disk.",
             "x-rust-type": {
               "crate": "std",
               "parameters": [

--- a/schema/crdb/dbinit.sql
+++ b/schema/crdb/dbinit.sql
@@ -3736,7 +3736,7 @@ CREATE TABLE IF NOT EXISTS omicron.public.inv_sled_agent (
     PRIMARY KEY (inv_collection_id, sled_id)
 );
 
-CREATE TYPE IF NOT EXISTS omicron.public.clear_mupdate_override_boot_success
+CREATE TYPE IF NOT EXISTS omicron.public.remove_mupdate_override_boot_success
 AS ENUM (
     'cleared',
     'no-override'
@@ -3779,22 +3779,25 @@ CREATE TABLE IF NOT EXISTS omicron.public.inv_sled_config_reconciler (
     boot_partition_a_error TEXT,
     boot_partition_b_error TEXT,
 
-    -- Success clearing the mupdate override.
+    -- The names below start with "clear_" for legacy reasons. Prefer "remove"
+    -- in the future.
+    --
+    -- Success removing the mupdate override.
     clear_mupdate_override_boot_success omicron.public.clear_mupdate_override_boot_success,
-    -- Error clearing the mupdate override.
+    -- Error removing the mupdate override.
     clear_mupdate_override_boot_error TEXT,
 
-    -- A message describing the result clearing the mupdate override on the
-    -- non-boot disk.
+    -- A message describing the result removing the mupdate override on the
+    -- non-boot disk (success or error).
     clear_mupdate_override_non_boot_message TEXT,
 
     -- Three cases:
     --
-    -- 1. No clear_mupdate_override instruction was passed in. All three
+    -- 1. No remove_mupdate_override instruction was passed in. All three
     --    columns are NULL.
-    -- 2. Clearing the override was successful. boot_success is NOT NULL,
+    -- 2. Removing the override was successful. boot_success is NOT NULL,
     --    boot_error is NULL, and non_boot_message is NOT NULL.
-    -- 3. Clearing the override failed. boot_success is NULL, boot_error is
+    -- 3. Removing the override failed. boot_success is NULL, boot_error is
     --    NOT NULL, and non_boot_message is NOT NULL.
     CONSTRAINT clear_mupdate_override_consistency CHECK (
         (clear_mupdate_override_boot_success IS NULL

--- a/sled-agent/config-reconciler/src/reconciler_task/zones.rs
+++ b/sled-agent/config-reconciler/src/reconciler_task/zones.rs
@@ -1289,10 +1289,10 @@ mod tests {
     use omicron_uuid_kinds::DatasetUuid;
     use omicron_uuid_kinds::MupdateOverrideUuid;
     use omicron_uuid_kinds::ZpoolUuid;
-    use sled_agent_types::zone_images::ClearMupdateOverrideBootSuccess;
-    use sled_agent_types::zone_images::ClearMupdateOverrideResult;
     use sled_agent_types::zone_images::MupdateOverrideStatus;
     use sled_agent_types::zone_images::OmicronZoneFileSource;
+    use sled_agent_types::zone_images::RemoveMupdateOverrideBootSuccess;
+    use sled_agent_types::zone_images::RemoveMupdateOverrideResult;
     use sled_agent_types::zone_images::ResolverStatus;
     use sled_agent_types::zone_images::ZoneImageLocationError;
     use sled_agent_types::zone_images::ZoneManifestArtifactsResult;
@@ -1567,13 +1567,13 @@ mod tests {
             &self,
             _override_id: MupdateOverrideUuid,
             _internal_disks: &InternalDisks,
-        ) -> ClearMupdateOverrideResult {
+        ) -> RemoveMupdateOverrideResult {
             // TODO: In the future, we'll probably want to model this better and
             // not just return no-override.
-            ClearMupdateOverrideResult {
+            RemoveMupdateOverrideResult {
                 boot_disk_path: Utf8PathBuf::from(BOOT_DISK_PATH),
                 boot_disk_result: Ok(
-                    ClearMupdateOverrideBootSuccess::NoOverride,
+                    RemoveMupdateOverrideBootSuccess::NoOverride,
                 ),
                 non_boot_disk_info: IdOrdMap::new(),
             }

--- a/sled-agent/config-reconciler/src/reconciler_task/zones.rs
+++ b/sled-agent/config-reconciler/src/reconciler_task/zones.rs
@@ -1563,7 +1563,7 @@ mod tests {
             self.inner.lock().unwrap().resolver_status.clone()
         }
 
-        fn clear_mupdate_override(
+        fn remove_mupdate_override(
             &self,
             _override_id: MupdateOverrideUuid,
             _internal_disks: &InternalDisks,

--- a/sled-agent/config-reconciler/src/sled_agent_facilities.rs
+++ b/sled-agent/config-reconciler/src/sled_agent_facilities.rs
@@ -12,8 +12,8 @@ use omicron_common::address::Ipv6Subnet;
 use omicron_common::address::SLED_PREFIX;
 use omicron_uuid_kinds::MupdateOverrideUuid;
 use sled_agent_types::zone_bundle::ZoneBundleCause;
-use sled_agent_types::zone_images::ClearMupdateOverrideResult;
 use sled_agent_types::zone_images::PreparedOmicronZone;
+use sled_agent_types::zone_images::RemoveMupdateOverrideResult;
 use sled_agent_types::zone_images::ResolverStatus;
 use std::future::Future;
 use tufaceous_artifact::ArtifactHash;
@@ -46,12 +46,12 @@ pub trait SledAgentFacilities: Send + Sync + 'static {
     /// This can be used to prepare zones as well as start them.
     fn zone_image_resolver_status(&self) -> ResolverStatus;
 
-    /// Clear out the mupdate override
-    fn clear_mupdate_override(
+    /// Remove the mupdate override file from disk.
+    fn remove_mupdate_override(
         &self,
         override_id: MupdateOverrideUuid,
         internal_disks: &InternalDisks,
-    ) -> ClearMupdateOverrideResult;
+    ) -> RemoveMupdateOverrideResult;
 
     /// Stop tracking metrics for a zone's datalinks.
     fn metrics_untrack_zone_links(

--- a/sled-agent/src/sled_agent.rs
+++ b/sled-agent/src/sled_agent.rs
@@ -69,7 +69,7 @@ use sled_agent_types::zone_bundle::{
     PriorityOrder, StorageLimit, ZoneBundleCause, ZoneBundleMetadata,
 };
 use sled_agent_types::zone_images::{
-    ClearMupdateOverrideResult, PreparedOmicronZone, ResolverStatus,
+    PreparedOmicronZone, RemoveMupdateOverrideResult, ResolverStatus,
 };
 use sled_diagnostics::SledDiagnosticsCmdError;
 use sled_diagnostics::SledDiagnosticsCmdOutput;
@@ -1321,14 +1321,14 @@ impl SledAgentFacilities for ReconcilerFacilities {
         self.service_manager.zone_image_resolver().status()
     }
 
-    fn clear_mupdate_override(
+    fn remove_mupdate_override(
         &self,
         override_id: MupdateOverrideUuid,
         internal_disks: &InternalDisks,
-    ) -> ClearMupdateOverrideResult {
+    ) -> RemoveMupdateOverrideResult {
         self.service_manager
             .zone_image_resolver()
-            .clear_mupdate_override(override_id, internal_disks)
+            .remove_mupdate_override(override_id, internal_disks)
     }
 
     fn metrics_untrack_zone_links(

--- a/sled-agent/zone-images/src/mupdate_override.rs
+++ b/sled-agent/zone-images/src/mupdate_override.rs
@@ -114,7 +114,7 @@ impl AllMupdateOverrides {
                             Ok(()) => {
                                 // Remove the in-memory override.
                                 self.boot_disk_override = Ok(None);
-                                Ok(RemoveMupdateOverrideBootSuccess::Cleared(
+                                Ok(RemoveMupdateOverrideBootSuccess::Removed(
                                     info,
                                 ))
                             }
@@ -185,7 +185,7 @@ impl AllMupdateOverrides {
             {
                 // If the boot disk was successfully cleared, we may have
                 // introduced a mismatch.
-                if let Ok(RemoveMupdateOverrideBootSuccess::Cleared(
+                if let Ok(RemoveMupdateOverrideBootSuccess::Removed(
                     boot_disk_info,
                 )) = &boot_disk_result
                 {
@@ -468,7 +468,7 @@ fn remove_non_boot_file(
         Ok(()) => {
             // The new status is now MatchesAbsent.
             let new_result = MupdateOverrideNonBootResult::MatchesAbsent;
-            let clear_result = RemoveMupdateOverrideNonBootResult::Cleared {
+            let clear_result = RemoveMupdateOverrideNonBootResult::Removed {
                 prev_result: info.result.clone(),
             };
             (new_result, clear_result)
@@ -941,7 +941,7 @@ mod tests {
         // The boot disk should be cleared.
         assert_eq!(
             result.boot_disk_result,
-            Ok(RemoveMupdateOverrideBootSuccess::Cleared(info))
+            Ok(RemoveMupdateOverrideBootSuccess::Removed(info))
         );
 
         // The non-boot disk should be cleared too.
@@ -951,7 +951,7 @@ mod tests {
                 RemoveMupdateOverrideNonBootInfo {
                     zpool_id: NON_BOOT_UUID,
                     path: Some(dir.path().join(&NON_BOOT_PATHS.mupdate_override_json)),
-                    result: RemoveMupdateOverrideNonBootResult::Cleared {
+                    result: RemoveMupdateOverrideNonBootResult::Removed {
                         prev_result: MupdateOverrideNonBootResult::MatchesPresent,
                     },
                 }
@@ -1046,7 +1046,7 @@ mod tests {
         // The boot disk should be cleared.
         assert_eq!(
             result.boot_disk_result,
-            Ok(RemoveMupdateOverrideBootSuccess::Cleared(info))
+            Ok(RemoveMupdateOverrideBootSuccess::Removed(info))
         );
 
         // The non-boot disk should remain MatchesAbsent with a NoOverride
@@ -1162,7 +1162,7 @@ mod tests {
         // The boot disk should be cleared.
         assert_eq!(
             result.boot_disk_result,
-            Ok(RemoveMupdateOverrideBootSuccess::Cleared(info))
+            Ok(RemoveMupdateOverrideBootSuccess::Removed(info))
         );
 
         // The non-boot disk should transition to MatchesAbsent.
@@ -1307,7 +1307,7 @@ mod tests {
                 RemoveMupdateOverrideNonBootInfo {
                     zpool_id: NON_BOOT_UUID,
                     path: Some(dir.path().join(&NON_BOOT_PATHS.mupdate_override_json)),
-                    result: RemoveMupdateOverrideNonBootResult::Cleared {
+                    result: RemoveMupdateOverrideNonBootResult::Removed {
                         prev_result: MupdateOverrideNonBootResult::Mismatch(
                             MupdateOverrideNonBootMismatch::BootAbsentOtherPresent {
                                 non_boot_disk_info: info
@@ -1368,7 +1368,7 @@ mod tests {
         // The boot disk should be cleared.
         assert_eq!(
             result.boot_disk_result,
-            Ok(RemoveMupdateOverrideBootSuccess::Cleared(info))
+            Ok(RemoveMupdateOverrideBootSuccess::Removed(info))
         );
 
         // The non-boot disk should be cleared too.
@@ -1378,7 +1378,7 @@ mod tests {
                 RemoveMupdateOverrideNonBootInfo {
                     zpool_id: NON_BOOT_UUID,
                     path: Some(dir.path().join(&NON_BOOT_PATHS.mupdate_override_json)),
-                    result: RemoveMupdateOverrideNonBootResult::Cleared {
+                    result: RemoveMupdateOverrideNonBootResult::Removed {
                         prev_result: MupdateOverrideNonBootResult::Mismatch(
                             MupdateOverrideNonBootMismatch::ValueMismatch {
                                 non_boot_disk_info: info2
@@ -1551,7 +1551,7 @@ mod tests {
         // The boot disk should be cleared.
         assert_eq!(
             result.boot_disk_result,
-            Ok(RemoveMupdateOverrideBootSuccess::Cleared(info))
+            Ok(RemoveMupdateOverrideBootSuccess::Removed(info))
         );
 
         // The non-boot disk should not be altered due to a read error on the
@@ -1619,7 +1619,7 @@ mod tests {
         // The boot disk should be cleared.
         assert_eq!(
             result.boot_disk_result,
-            Ok(RemoveMupdateOverrideBootSuccess::Cleared(info.clone()))
+            Ok(RemoveMupdateOverrideBootSuccess::Removed(info.clone()))
         );
 
         // The non-boot disk should return a DiskMissing result.
@@ -1684,7 +1684,7 @@ mod tests {
         // The boot disk should be cleared.
         assert_eq!(
             result.boot_disk_result,
-            Ok(RemoveMupdateOverrideBootSuccess::Cleared(info))
+            Ok(RemoveMupdateOverrideBootSuccess::Removed(info))
         );
 
         // The non-boot disk should return a NoStatus result.

--- a/sled-agent/zone-images/src/source_resolver.rs
+++ b/sled-agent/zone-images/src/source_resolver.rs
@@ -11,7 +11,7 @@ use nexus_sled_agent_shared::inventory::OmicronZoneImageSource;
 use omicron_uuid_kinds::MupdateOverrideUuid;
 use sled_agent_config_reconciler::InternalDisks;
 use sled_agent_config_reconciler::InternalDisksWithBootDisk;
-use sled_agent_types::zone_images::ClearMupdateOverrideResult;
+use sled_agent_types::zone_images::RemoveMupdateOverrideResult;
 use sled_agent_types::zone_images::ResolverStatus;
 use slog::o;
 use std::sync::Arc;
@@ -65,12 +65,12 @@ impl ZoneImageSourceResolver {
         }
     }
 
-    /// Clears out the mupdate override field and files on disk.
-    pub fn clear_mupdate_override(
+    /// Removes the mupdate override field and files on disk.
+    pub fn remove_mupdate_override(
         &self,
         override_id: MupdateOverrideUuid,
         internal_disks: &InternalDisks,
-    ) -> ClearMupdateOverrideResult {
+    ) -> RemoveMupdateOverrideResult {
         let mut inner = self.inner.lock().unwrap();
         let ret =
             inner.mupdate_overrides.clear_override(override_id, internal_disks);


### PR DESCRIPTION
We now use "remove mupdate override" consistently (other than in the database storage where a migration would be required and we don't support renaming columns or enum values).

Closes #8745.
