### PR TITLE
[nexus] Add address lot view method.

### DIFF
--- a/nexus/external-api/output/nexus_tags.txt
+++ b/nexus/external-api/output/nexus_tags.txt
@@ -239,6 +239,7 @@ networking_address_lot_block_list        GET      /v1/system/networking/address-
 networking_address_lot_create            POST     /v1/system/networking/address-lot
 networking_address_lot_delete            DELETE   /v1/system/networking/address-lot/{address_lot}
 networking_address_lot_list              GET      /v1/system/networking/address-lot
+networking_address_lot_view              GET      /v1/system/networking/address-lot/{address_lot}
 networking_allow_list_update             PUT      /v1/system/networking/allow-list
 networking_allow_list_view               GET      /v1/system/networking/allow-list
 networking_bfd_disable                   POST     /v1/system/networking/bfd-disable

--- a/nexus/external-api/src/lib.rs
+++ b/nexus/external-api/src/lib.rs
@@ -1624,6 +1624,18 @@ pub trait NexusExternalApi {
         query_params: Query<PaginatedByNameOrId>,
     ) -> Result<HttpResponseOk<ResultsPage<AddressLot>>, HttpError>;
 
+    /// Fetch address lot
+    #[endpoint {
+        method = GET,
+        path = "/v1/system/networking/address-lot/{address_lot}",
+        tags = ["system/networking"],
+    }]
+    async fn networking_address_lot_view(
+        rqctx: RequestContext<Self::Context>,
+        path_params: Path<params::AddressLotPath>,
+    ) -> Result<HttpResponseOk<AddressLot>, HttpError>;
+
+
     /// List blocks in address lot
     #[endpoint {
         method = GET,

--- a/nexus/src/external_api/http_entrypoints.rs
+++ b/nexus/src/external_api/http_entrypoints.rs
@@ -3422,6 +3422,27 @@ impl NexusExternalApi for NexusExternalApiImpl {
             .await
     }
 
+    async fn networking_address_lot_view(
+        rqctx: RequestContext<ApiContext>,
+        path_params: Path<params::AddressLotPath>,
+    ) -> Result<HttpResponseOk<AddressLot>, HttpError> {
+        let apictx = rqctx.context();
+        let handler = async {
+            let opctx =
+                crate::context::op_context_for_external_api(&rqctx).await?;
+            let nexus = &apictx.context.nexus;
+            let path = path_params.into_inner();
+            let (.., address_lot) =
+                nexus.address_lot_lookup(&opctx, path.address_lot)?.fetch().await?;
+            Ok(HttpResponseOk(address_lot.into()))
+        };
+        apictx
+            .context
+            .external_latencies
+            .instrument_dropshot_handler(&rqctx, handler)
+            .await
+    }
+
     async fn networking_address_lot_delete(
         rqctx: RequestContext<ApiContext>,
         path_params: Path<params::AddressLotPath>,

--- a/nexus/tests/integration_tests/address_lots.rs
+++ b/nexus/tests/integration_tests/address_lots.rs
@@ -78,6 +78,16 @@ async fn test_address_lot_basic_crud(ctx: &ControlPlaneTestContext) {
         "203.0.113.20".parse::<IpAddr>().unwrap()
     );
 
+    // View a single lot by name
+    let view_lot = NexusRequest::object_get(
+        client,
+        "/v1/system/networking/address-lot/parkinglot",
+    )
+        .authn_as(AuthnMode::PrivilegedUser)
+        .execute_and_parse_unwrap::<AddressLot>()
+        .await;
+    assert_eq!(view_lot.identity.name, "parkinglot");
+
     // Verify there are lots
     let lots = NexusRequest::iter_collection_authn::<AddressLot>(
         client,

--- a/openapi/nexus.json
+++ b/openapi/nexus.json
@@ -9106,6 +9106,42 @@
       }
     },
     "/v1/system/networking/address-lot/{address_lot}": {
+      "get": {
+        "tags": [
+          "system/networking"
+        ],
+        "summary": "Fetch address lot",
+        "operationId": "networking_address_lot_view",
+        "parameters": [
+          {
+            "in": "path",
+            "name": "address_lot",
+            "description": "Name or ID of the address lot",
+            "required": true,
+            "schema": {
+              "$ref": "#/components/schemas/NameOrId"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "successful operation",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/AddressLot"
+                }
+              }
+            }
+          },
+          "4XX": {
+            "$ref": "#/components/responses/Error"
+          },
+          "5XX": {
+            "$ref": "#/components/responses/Error"
+          }
+        }
+      },
       "delete": {
         "tags": [
           "system/networking"


### PR DESCRIPTION
Part of https://github.com/oxidecomputer/terraform-provider-oxide/issues/468. The terraform resource expects to be able to create/read/delete address lots, and so far nexus only supports create/list/delete. This patch adds a new endpoint for viewing an address lot by name or id.

This is my first attempt to work on this repo, so let me know if this is off-base @internet-diglett.