### PR TITLE
Fix dep from nexus-db-schema, nexus-test-interface on pq-sys

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -6487,7 +6487,9 @@ name = "nexus-db-schema"
 version = "0.1.0"
 dependencies = [
  "diesel",
+ "omicron-rpaths",
  "omicron-workspace-hack",
+ "pq-sys",
 ]
 
 [[package]]
@@ -6953,8 +6955,10 @@ dependencies = [
  "nexus-sled-agent-shared",
  "nexus-types",
  "omicron-common",
+ "omicron-rpaths",
  "omicron-uuid-kinds",
  "omicron-workspace-hack",
+ "pq-sys",
  "slog",
  "uuid",
 ]

--- a/nexus/db-schema/Cargo.toml
+++ b/nexus/db-schema/Cargo.toml
@@ -7,9 +7,14 @@ license = "MPL-2.0"
 [lints]
 workspace = true
 
+[build-dependencies]
+omicron-rpaths.workspace = true
+
 [dependencies]
 # NOTE: This list of dependencies is kept very small so that this code (which is
 # expensive to compile) can be parallelized with other parts of Omicron. Please
 # avoid adding dependencies to other parts of Omicron here!
 diesel.workspace = true
 omicron-workspace-hack.workspace = true
+# See omicron-rpaths for more about the "pq-sys" dependency.
+pq-sys = "*"

--- a/nexus/db-schema/build.rs
+++ b/nexus/db-schema/build.rs
@@ -1,0 +1,10 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at https://mozilla.org/MPL/2.0/.
+
+// See omicron-rpaths for documentation.
+// NOTE: This file MUST be kept in sync with the other build.rs files in this
+// repository.
+fn main() {
+    omicron_rpaths::configure_default_omicron_rpaths();
+}

--- a/nexus/test-interface/Cargo.toml
+++ b/nexus/test-interface/Cargo.toml
@@ -7,6 +7,9 @@ license = "MPL-2.0"
 [lints]
 workspace = true
 
+[build-dependencies]
+omicron-rpaths.workspace = true
+
 [dependencies]
 async-trait.workspace = true
 nexus-config.workspace = true
@@ -14,6 +17,8 @@ nexus-db-queries.workspace = true
 nexus-sled-agent-shared.workspace = true
 nexus-types.workspace = true
 omicron-common.workspace = true
+# See omicron-rpaths for more about the "pq-sys" dependency.
+pq-sys = "*"
 slog.workspace = true
 uuid.workspace = true
 omicron-workspace-hack.workspace = true

--- a/nexus/test-interface/build.rs
+++ b/nexus/test-interface/build.rs
@@ -1,0 +1,10 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at https://mozilla.org/MPL/2.0/.
+
+// See omicron-rpaths for documentation.
+// NOTE: This file MUST be kept in sync with the other build.rs files in this
+// repository.
+fn main() {
+    omicron_rpaths::configure_default_omicron_rpaths();
+}


### PR DESCRIPTION
While working through https://github.com/oxidecomputer/omicron/issues/8756 , I noticed that I couldn't run `cargo nt --no-fail-fast -j32 -- crucible` on my helios machine because it couldn't find `libpq`.

This PR adds the "workspace hack" fix to `nexus-db-schema` and `nexus-test-interface`, so I can run isolated tests for this package on Helios.