### PR TITLE
Fix test flake related to slow inventory collection

### DIFF
--- a/nexus/src/app/background/tasks/inventory_collection.rs
+++ b/nexus/src/app/background/tasks/inventory_collection.rs
@@ -45,7 +45,7 @@ impl InventoryCollector {
         disable: bool,
     ) -> InventoryCollector {
         let (tx, _) = watch::channel(None);
-        let timeout = Duration::from_secs(15);
+        let timeout = Duration::from_secs(5);
         let cockroach_admin_client = CockroachClusterAdminClient::new(
             opctx
                 .log


### PR DESCRIPTION
This fixes https://github.com/oxidecomputer/omicron/issues/8756 by setting the NTP and CRDB timeouts to "five seconds".

As documented in https://github.com/oxidecomputer/omicron/issues/8756#issuecomment-3152459100, we are hitting timeouts in inventory collection. We are hitting worst-case behavior with the CRDB admin service and the NTP admin service on Helios for still-unknown reasons.

We still need to work on https://github.com/oxidecomputer/omicron/issues/8762, but this PR should mitigate most of the observed flakes.