### PR TITLE
nexus: update example configuration

### DIFF
--- a/nexus/examples/config.toml
+++ b/nexus/examples/config.toml
@@ -140,10 +140,10 @@ sp_ereport_ingester.period_secs = 30
 
 [default_region_allocation_strategy]
 # allocate region on 3 random distinct zpools, on 3 random distinct sleds.
-type = "random_with_distinct_sleds"
+# type = "random_with_distinct_sleds"
 
 # the same as random_with_distinct_sleds, but without requiring distinct sleds
-# type = "random"
+type = "random"
 
 # setting `seed` to a fixed value will make dataset selection ordering use the
 # same shuffling order for every region allocation.

--- a/tools/generate-nexus-api.sh
+++ b/tools/generate-nexus-api.sh
@@ -1,3 +1,0 @@
-#!/usr/bin/env bash
-
-./target/debug/nexus nexus/examples/config.toml -O > openapi/nexus.json

--- a/tools/generate-sled-agent-api.sh
+++ b/tools/generate-sled-agent-api.sh
@@ -1,4 +1,0 @@
-#!/usr/bin/env bash
-
-./target/debug/sled-agent openapi bootstrap > openapi/bootstrap-agent.json
-./target/debug/sled-agent openapi sled > openapi/sled-agent.json


### PR DESCRIPTION
Updated Nexus' example configuration to no longer require regions to allocate on distinct sleds. This allows a local simulated Omicron started by `cargo xtask omicron-dev run-all` to successfully create disk resources rather than error with insufficient capacity, allowing us to run acceptance tests for the Go SDK and Terraform provider against this environment.

A few OpenAPI generation scripts have also been removed that were deemed unnecessary. OpenAPI generation is handled by `cargo xtask openapi generate` these days.