### PR TITLE
[reconfigurator] database support for PendingMgsUpdate for host phase 1

### DIFF
--- a/nexus/db-model/src/deployment.rs
+++ b/nexus/db-model/src/deployment.rs
@@ -27,6 +27,7 @@ use nexus_db_schema::schema::{
     bp_pending_mgs_update_sp, bp_sled_metadata, bp_target,
 };
 use nexus_sled_agent_shared::inventory::OmicronZoneDataset;
+use nexus_types::deployment::BlueprintHostPhase2DesiredSlots;
 use nexus_types::deployment::BlueprintPhysicalDiskConfig;
 use nexus_types::deployment::BlueprintPhysicalDiskDisposition;
 use nexus_types::deployment::BlueprintTarget;
@@ -44,10 +45,6 @@ use nexus_types::deployment::{
 use nexus_types::deployment::{BlueprintDatasetDisposition, ExpectedVersion};
 use nexus_types::deployment::{
     BlueprintHostPhase2DesiredContents, PendingMgsUpdateHostPhase1Details,
-};
-use nexus_types::deployment::{
-    BlueprintHostPhase2DesiredSlots, ExpectedActiveHostOsSlot,
-    ExpectedInactiveHostOsArtifact,
 };
 use nexus_types::deployment::{BlueprintZoneImageSource, blueprint_zone_type};
 use nexus_types::deployment::{
@@ -1456,7 +1453,7 @@ pub struct BpPendingMgsUpdateHostPhase1 {
     pub artifact_sha256: ArtifactHash,
     pub artifact_version: DbArtifactVersion,
     pub expected_active_phase_1_slot: HwM2Slot,
-    pub expected_active_boot_disk: HwM2Slot,
+    pub expected_boot_disk: HwM2Slot,
     pub expected_active_phase_1_hash: ArtifactHash,
     pub expected_active_phase_2_hash: ArtifactHash,
     pub expected_inactive_phase_1_hash: ArtifactHash,
@@ -1479,17 +1476,22 @@ impl BpPendingMgsUpdateComponent for BpPendingMgsUpdateHostPhase1 {
             artifact_version: (*self.artifact_version).clone(),
             details: PendingMgsUpdateDetails::HostPhase1(
                 PendingMgsUpdateHostPhase1Details {
-                    expected_active_slot: ExpectedActiveHostOsSlot {
-                        phase_1_slot: self.expected_active_phase_1_slot.into(),
-                        boot_disk: self.expected_active_boot_disk.into(),
-                        phase_1: self.expected_active_phase_1_hash.into(),
-                        phase_2: self.expected_active_phase_2_hash.into(),
-                    },
-                    expected_inactive_artifact:
-                        ExpectedInactiveHostOsArtifact {
-                            phase_1: self.expected_inactive_phase_1_hash.into(),
-                            phase_2: self.expected_inactive_phase_2_hash.into(),
-                        },
+                    expected_active_phase_1_slot: self
+                        .expected_active_phase_1_slot
+                        .into(),
+                    expected_boot_disk: self.expected_boot_disk.into(),
+                    expected_active_phase_1_hash: self
+                        .expected_active_phase_1_hash
+                        .into(),
+                    expected_active_phase_2_hash: self
+                        .expected_active_phase_2_hash
+                        .into(),
+                    expected_inactive_phase_1_hash: self
+                        .expected_inactive_phase_1_hash
+                        .into(),
+                    expected_inactive_phase_2_hash: self
+                        .expected_inactive_phase_2_hash
+                        .into(),
                     sled_agent_address: SocketAddrV6::new(
                         self.sled_agent_ip.into(),
                         *self.sled_agent_port,

--- a/nexus/db-model/src/schema_versions.rs
+++ b/nexus/db-model/src/schema_versions.rs
@@ -16,7 +16,7 @@ use std::{collections::BTreeMap, sync::LazyLock};
 ///
 /// This must be updated when you change the database schema.  Refer to
 /// schema/crdb/README.adoc in the root of this repository for details.
-pub const SCHEMA_VERSION: Version = Version::new(178, 0, 0);
+pub const SCHEMA_VERSION: Version = Version::new(179, 0, 0);
 
 /// List of all past database schema versions, in *reverse* order
 ///
@@ -28,6 +28,7 @@ static KNOWN_VERSIONS: LazyLock<Vec<KnownVersion>> = LazyLock::new(|| {
         // |  leaving the first copy as an example for the next person.
         // v
         // KnownVersion::new(next_int, "unique-dirname-with-the-sql-files"),
+        KnownVersion::new(179, "add-pending-mgs-updates-host-phase-1"),
         KnownVersion::new(178, "change-lldp-management-ip-to-inet"),
         KnownVersion::new(177, "add-host-ereport-part-number"),
         KnownVersion::new(176, "audit-log"),

--- a/nexus/db-queries/src/db/datastore/deployment.rs
+++ b/nexus/db-queries/src/db/datastore/deployment.rs
@@ -80,8 +80,6 @@ use nexus_types::deployment::BlueprintSledConfig;
 use nexus_types::deployment::BlueprintTarget;
 use nexus_types::deployment::ClickhouseClusterConfig;
 use nexus_types::deployment::CockroachDbPreserveDowngrade;
-use nexus_types::deployment::ExpectedActiveHostOsSlot;
-use nexus_types::deployment::ExpectedInactiveHostOsArtifact;
 use nexus_types::deployment::ExpectedVersion;
 use nexus_types::deployment::OximeterReadMode;
 use nexus_types::deployment::PendingMgsUpdate;
@@ -2399,18 +2397,12 @@ async fn insert_pending_mgs_update(
         }
         PendingMgsUpdateDetails::HostPhase1(
             PendingMgsUpdateHostPhase1Details {
-                expected_active_slot:
-                    ExpectedActiveHostOsSlot {
-                        phase_1_slot: expected_active_phase_1_slot,
-                        boot_disk: expected_active_boot_disk,
-                        phase_1: expected_active_phase_1_hash,
-                        phase_2: expected_active_phase_2_hash,
-                    },
-                expected_inactive_artifact:
-                    ExpectedInactiveHostOsArtifact {
-                        phase_1: expected_inactive_phase_1_hash,
-                        phase_2: expected_inactive_phase_2_hash,
-                    },
+                expected_active_phase_1_slot,
+                expected_boot_disk,
+                expected_active_phase_1_hash,
+                expected_active_phase_2_hash,
+                expected_inactive_phase_1_hash,
+                expected_inactive_phase_2_hash,
                 sled_agent_address,
             },
         ) => {
@@ -2429,8 +2421,7 @@ async fn insert_pending_mgs_update(
                 HwM2Slot::from(*expected_active_phase_1_slot)
                     .into_sql::<HwM2SlotEnum>();
             let db_expected_active_boot_disk =
-                HwM2Slot::from(*expected_active_boot_disk)
-                    .into_sql::<HwM2SlotEnum>();
+                HwM2Slot::from(*expected_boot_disk).into_sql::<HwM2SlotEnum>();
             let db_expected_active_phase_1_hash =
                 ArtifactHash(*expected_active_phase_1_hash)
                     .into_sql::<diesel::sql_types::Text>();
@@ -2490,7 +2481,7 @@ async fn insert_pending_mgs_update(
                 update_dsl::artifact_sha256,
                 update_dsl::artifact_version,
                 update_dsl::expected_active_phase_1_slot,
-                update_dsl::expected_active_boot_disk,
+                update_dsl::expected_boot_disk,
                 update_dsl::expected_active_phase_1_hash,
                 update_dsl::expected_active_phase_2_hash,
                 update_dsl::expected_inactive_phase_1_hash,
@@ -3814,17 +3805,12 @@ mod tests {
             slot_id: sp.sp_slot,
             details: PendingMgsUpdateDetails::HostPhase1(
                 PendingMgsUpdateHostPhase1Details {
-                    expected_active_slot: ExpectedActiveHostOsSlot {
-                        phase_1_slot: M2Slot::A,
-                        boot_disk: M2Slot::B,
-                        phase_1: ArtifactHash([1; 32]),
-                        phase_2: ArtifactHash([2; 32]),
-                    },
-                    expected_inactive_artifact:
-                        ExpectedInactiveHostOsArtifact {
-                            phase_1: ArtifactHash([3; 32]),
-                            phase_2: ArtifactHash([4; 32]),
-                        },
+                    expected_active_phase_1_slot: M2Slot::A,
+                    expected_boot_disk: M2Slot::B,
+                    expected_active_phase_1_hash: ArtifactHash([1; 32]),
+                    expected_active_phase_2_hash: ArtifactHash([2; 32]),
+                    expected_inactive_phase_1_hash: ArtifactHash([3; 32]),
+                    expected_inactive_phase_2_hash: ArtifactHash([4; 32]),
                     sled_agent_address: "[::1]:12345".parse().unwrap(),
                 },
             ),

--- a/nexus/db-queries/src/db/datastore/deployment.rs
+++ b/nexus/db-queries/src/db/datastore/deployment.rs
@@ -2420,7 +2420,7 @@ async fn insert_pending_mgs_update(
             let db_expected_active_phase_1_slot =
                 HwM2Slot::from(*expected_active_phase_1_slot)
                     .into_sql::<HwM2SlotEnum>();
-            let db_expected_active_boot_disk =
+            let db_expected_boot_disk =
                 HwM2Slot::from(*expected_boot_disk).into_sql::<HwM2SlotEnum>();
             let db_expected_active_phase_1_hash =
                 ArtifactHash(*expected_active_phase_1_hash)
@@ -2453,7 +2453,7 @@ async fn insert_pending_mgs_update(
                     db_artifact_hash,
                     db_artifact_version,
                     db_expected_active_phase_1_slot,
-                    db_expected_active_boot_disk,
+                    db_expected_boot_disk,
                     db_expected_active_phase_1_hash,
                     db_expected_active_phase_2_hash,
                     db_expected_inactive_phase_1_hash,
@@ -2524,7 +2524,7 @@ async fn insert_pending_mgs_update(
                 _artifact_sha256,
                 _artifact_version,
                 _expected_active_phase_1_slot,
-                _expected_active_boot_disk,
+                _expected_boot_disk,
                 _expected_active_phase_1_hash,
                 _expected_active_phase_2_hash,
                 _expected_inactive_phase_1_hash,

--- a/nexus/db-queries/src/db/datastore/deployment.rs
+++ b/nexus/db-queries/src/db/datastore/deployment.rs
@@ -2502,7 +2502,7 @@ async fn insert_pending_mgs_update(
                     "count" => count,
                     &update.baseboard_id,
                 );
-                return Err(TxnError::BadInsertCount {
+                return Err(InsertTxnError::BadInsertCount {
                     table_name: "bp_pending_mgs_update_host_phase_1",
                     count,
                     baseboard_id: update.baseboard_id.clone(),

--- a/nexus/db-schema/src/schema.rs
+++ b/nexus/db-schema/src/schema.rs
@@ -2178,7 +2178,7 @@ table! {
         artifact_sha256 -> Text,
         artifact_version -> Text,
         expected_active_phase_1_slot -> crate::enums::HwM2SlotEnum,
-        expected_active_boot_disk -> crate::enums::HwM2SlotEnum,
+        expected_boot_disk -> crate::enums::HwM2SlotEnum,
         expected_active_phase_1_hash -> Text,
         expected_active_phase_2_hash -> Text,
         expected_inactive_phase_1_hash -> Text,

--- a/nexus/db-schema/src/schema.rs
+++ b/nexus/db-schema/src/schema.rs
@@ -2170,6 +2170,25 @@ table! {
 }
 
 table! {
+    bp_pending_mgs_update_host_phase_1 (blueprint_id, hw_baseboard_id) {
+        blueprint_id -> Uuid,
+        hw_baseboard_id -> Uuid,
+        sp_type -> crate::enums::SpTypeEnum,
+        sp_slot -> Int4,
+        artifact_sha256 -> Text,
+        artifact_version -> Text,
+        expected_active_phase_1_slot -> crate::enums::HwM2SlotEnum,
+        expected_active_boot_disk -> crate::enums::HwM2SlotEnum,
+        expected_active_phase_1_hash -> Text,
+        expected_active_phase_2_hash -> Text,
+        expected_inactive_phase_1_hash -> Text,
+        expected_inactive_phase_2_hash -> Text,
+        sled_agent_ip -> Inet,
+        sled_agent_port -> Int4,
+    }
+}
+
+table! {
     bootstore_keys (key, generation) {
         key -> Text,
         generation -> Int8,

--- a/nexus/mgs-updates/src/host_phase1_updater.rs
+++ b/nexus/mgs-updates/src/host_phase1_updater.rs
@@ -566,7 +566,7 @@ impl ReconfiguratorHostPhase1Updater {
         log: &Logger,
     ) -> Result<(), PrecheckError> {
         let PendingMgsUpdateHostPhase1Details {
-            expected_boot_disk: expected_active_boot_disk,
+            expected_boot_disk,
             expected_active_phase_2_hash,
             expected_inactive_phase_2_hash,
             ..
@@ -577,7 +577,7 @@ impl ReconfiguratorHostPhase1Updater {
             self.get_boot_partition_inventory_from_sled_agent(log).await?;
 
         // Confirm the expected boot disk.
-        match (sled_inventory.boot_disk, *expected_active_boot_disk) {
+        match (sled_inventory.boot_disk, *expected_boot_disk) {
             (Ok(found), expected) if found == expected => (),
             (Ok(found), expected) => {
                 return Err(PrecheckError::WrongHostOsBootDisk {
@@ -594,7 +594,7 @@ impl ReconfiguratorHostPhase1Updater {
         // can't proceed: either our update has become impossible due to other
         // changes (requires replanning), or we're waiting for sled-agent to
         // write the phase 2 we expect.
-        let (active, inactive) = match expected_active_boot_disk {
+        let (active, inactive) = match expected_boot_disk {
             M2Slot::A => (sled_inventory.slot_a, sled_inventory.slot_b),
             M2Slot::B => (sled_inventory.slot_b, sled_inventory.slot_a),
         };

--- a/schema/crdb/add-pending-mgs-updates-host-phase-1/up.sql
+++ b/schema/crdb/add-pending-mgs-updates-host-phase-1/up.sql
@@ -1,0 +1,17 @@
+CREATE TABLE IF NOT EXISTS omicron.public.bp_pending_mgs_update_host_phase_1 (
+    blueprint_id UUID,
+    hw_baseboard_id UUID NOT NULL,
+    sp_type omicron.public.sp_type NOT NULL,
+    sp_slot INT4 NOT NULL,
+    artifact_sha256 STRING(64) NOT NULL,
+    artifact_version STRING(64) NOT NULL,
+    expected_active_phase_1_slot omicron.public.hw_m2_slot NOT NULL,
+    expected_boot_disk omicron.public.hw_m2_slot NOT NULL,
+    expected_active_phase_1_hash STRING(64) NOT NULL,
+    expected_active_phase_2_hash STRING(64) NOT NULL,
+    expected_inactive_phase_1_hash STRING(64) NOT NULL,
+    expected_inactive_phase_2_hash STRING(64) NOT NULL,
+    sled_agent_ip INET NOT NULL,
+    sled_agent_port INT4 NOT NULL CHECK (sled_agent_port BETWEEN 0 AND 65535),
+    PRIMARY KEY(blueprint_id, hw_baseboard_id)
+);

--- a/schema/crdb/dbinit.sql
+++ b/schema/crdb/dbinit.sql
@@ -6524,7 +6524,7 @@ INSERT INTO omicron.public.db_metadata (
     version,
     target_version
 ) VALUES
-    (TRUE, NOW(), NOW(), '178.0.0', NULL)
+    (TRUE, NOW(), NOW(), '179.0.0', NULL)
 ON CONFLICT DO NOTHING;
 
 COMMIT;

--- a/schema/crdb/dbinit.sql
+++ b/schema/crdb/dbinit.sql
@@ -4864,6 +4864,33 @@ CREATE TABLE IF NOT EXISTS omicron.public.bp_pending_mgs_update_rot (
     PRIMARY KEY(blueprint_id, hw_baseboard_id)
 );
 
+-- Blueprint information related to pending host OS phase 1 updates.
+CREATE TABLE IF NOT EXISTS omicron.public.bp_pending_mgs_update_host_phase_1 (
+    -- Foreign key into the `blueprint` table
+    blueprint_id UUID,
+    -- identify of the device to be updated
+    -- (foreign key into the `hw_baseboard_id` table)
+    hw_baseboard_id UUID NOT NULL,
+    -- location of this device according to MGS
+    sp_type omicron.public.sp_type NOT NULL,
+    sp_slot INT4 NOT NULL,
+    -- artifact to be deployed to this device
+    artifact_sha256 STRING(64) NOT NULL,
+    artifact_version STRING(64) NOT NULL,
+
+    -- host-phase-1-specific details
+    expected_active_phase_1_slot omicron.public.hw_m2_slot NOT NULL,
+    expected_active_boot_disk omicron.public.hw_m2_slot NOT NULL,
+    expected_active_phase_1_hash STRING(64) NOT NULL,
+    expected_active_phase_2_hash STRING(64) NOT NULL,
+    expected_inactive_phase_1_hash STRING(64) NOT NULL,
+    expected_inactive_phase_2_hash STRING(64) NOT NULL,
+    sled_agent_ip INET NOT NULL,
+    sled_agent_port INT4 NOT NULL CHECK (sled_agent_port BETWEEN 0 AND 65535),
+
+    PRIMARY KEY(blueprint_id, hw_baseboard_id)
+);
+
 -- Mapping of Omicron zone ID to CockroachDB node ID. This isn't directly used
 -- by the blueprint tables above, but is used by the more general Reconfigurator
 -- system along with them (e.g., to decommission expunged CRDB nodes).

--- a/schema/crdb/dbinit.sql
+++ b/schema/crdb/dbinit.sql
@@ -4880,7 +4880,7 @@ CREATE TABLE IF NOT EXISTS omicron.public.bp_pending_mgs_update_host_phase_1 (
 
     -- host-phase-1-specific details
     expected_active_phase_1_slot omicron.public.hw_m2_slot NOT NULL,
-    expected_active_boot_disk omicron.public.hw_m2_slot NOT NULL,
+    expected_boot_disk omicron.public.hw_m2_slot NOT NULL,
     expected_active_phase_1_hash STRING(64) NOT NULL,
     expected_active_phase_2_hash STRING(64) NOT NULL,
     expected_inactive_phase_1_hash STRING(64) NOT NULL,

--- a/schema/crdb/dbinit.sql
+++ b/schema/crdb/dbinit.sql
@@ -4800,7 +4800,7 @@ CREATE TABLE IF NOT EXISTS omicron.public.bp_oximeter_read_policy (
 -- Blueprint information related to pending RoT bootloader upgrades.
 CREATE TABLE IF NOT EXISTS omicron.public.bp_pending_mgs_update_rot_bootloader (
     -- Foreign key into the `blueprint` table
-    blueprint_id UUID,
+    blueprint_id UUID NOT NULL,
     -- identify of the device to be updated
     -- (foreign key into the `hw_baseboard_id` table)
     hw_baseboard_id UUID NOT NULL,
@@ -4821,7 +4821,7 @@ CREATE TABLE IF NOT EXISTS omicron.public.bp_pending_mgs_update_rot_bootloader (
 -- Blueprint information related to pending SP upgrades.
 CREATE TABLE IF NOT EXISTS omicron.public.bp_pending_mgs_update_sp (
     -- Foreign key into the `blueprint` table
-    blueprint_id UUID,
+    blueprint_id UUID NOT NULL,
     -- identify of the device to be updated
     -- (foreign key into the `hw_baseboard_id` table)
     hw_baseboard_id UUID NOT NULL,
@@ -4842,7 +4842,7 @@ CREATE TABLE IF NOT EXISTS omicron.public.bp_pending_mgs_update_sp (
 -- Blueprint information related to pending RoT upgrades.
 CREATE TABLE IF NOT EXISTS omicron.public.bp_pending_mgs_update_rot (
     -- Foreign key into the `blueprint` table
-    blueprint_id UUID,
+    blueprint_id UUID NOT NULL,
     -- identify of the device to be updated
     -- (foreign key into the `hw_baseboard_id` table)
     hw_baseboard_id UUID NOT NULL,
@@ -4867,7 +4867,7 @@ CREATE TABLE IF NOT EXISTS omicron.public.bp_pending_mgs_update_rot (
 -- Blueprint information related to pending host OS phase 1 updates.
 CREATE TABLE IF NOT EXISTS omicron.public.bp_pending_mgs_update_host_phase_1 (
     -- Foreign key into the `blueprint` table
-    blueprint_id UUID,
+    blueprint_id UUID NOT NULL,
     -- identify of the device to be updated
     -- (foreign key into the `hw_baseboard_id` table)
     hw_baseboard_id UUID NOT NULL,


### PR DESCRIPTION
This is more of the same as the other PendingMgsUpdate database implementations, plus a small bugfix that affected RoT and bootloader database storage.

Staged on top of #8737.