### PR TITLE
[inventory] Add active host phase 1 slot 

### DIFF
--- a/nexus/db-model/src/inventory.rs
+++ b/nexus/db-model/src/inventory.rs
@@ -30,8 +30,8 @@ use nexus_db_schema::schema::inv_zone_manifest_zone;
 use nexus_db_schema::schema::{
     hw_baseboard_id, inv_caboose, inv_clickhouse_keeper_membership,
     inv_cockroachdb_status, inv_collection, inv_collection_error, inv_dataset,
-    inv_host_phase_1_flash_hash, inv_internal_dns,
-    inv_last_reconciliation_dataset_result,
+    inv_host_phase_1_active_slot, inv_host_phase_1_flash_hash,
+    inv_internal_dns, inv_last_reconciliation_dataset_result,
     inv_last_reconciliation_disk_result,
     inv_last_reconciliation_orphaned_dataset,
     inv_last_reconciliation_zone_result, inv_mupdate_override_non_boot,
@@ -62,6 +62,7 @@ use nexus_sled_agent_shared::inventory::{
     ConfigReconcilerInventoryResult, OmicronSledConfig, OmicronZoneConfig,
     OmicronZoneDataset, OmicronZoneImageSource, OmicronZoneType,
 };
+use nexus_types::inventory::HostPhase1ActiveSlot;
 use nexus_types::inventory::{
     BaseboardId, Caboose, CockroachStatus, Collection,
     InternalDnsGenerationStatus, NvmeFirmware, PowerState, RotPage, RotSlot,
@@ -782,6 +783,28 @@ impl From<InvRootOfTrust> for nexus_types::inventory::RotState {
             stage0next_error: row
                 .stage0next_error
                 .map(nexus_types::inventory::RotImageError::from),
+        }
+    }
+}
+
+/// See [`nexus_types::inventory::HostPhase1ActiveSlot`].
+#[derive(Queryable, Clone, Debug, Selectable)]
+#[diesel(table_name = inv_host_phase_1_active_slot)]
+pub struct InvHostPhase1ActiveSlot {
+    pub inv_collection_id: Uuid,
+    pub hw_baseboard_id: Uuid,
+    pub time_collected: DateTime<Utc>,
+    pub source: String,
+
+    pub slot: HwM2Slot,
+}
+
+impl From<InvHostPhase1ActiveSlot> for HostPhase1ActiveSlot {
+    fn from(value: InvHostPhase1ActiveSlot) -> Self {
+        Self {
+            time_collected: value.time_collected,
+            source: value.source,
+            slot: value.slot.into(),
         }
     }
 }

--- a/nexus/db-model/src/schema_versions.rs
+++ b/nexus/db-model/src/schema_versions.rs
@@ -16,7 +16,7 @@ use std::{collections::BTreeMap, sync::LazyLock};
 ///
 /// This must be updated when you change the database schema.  Refer to
 /// schema/crdb/README.adoc in the root of this repository for details.
-pub const SCHEMA_VERSION: Version = Version::new(174, 0, 0);
+pub const SCHEMA_VERSION: Version = Version::new(175, 0, 0);
 
 /// List of all past database schema versions, in *reverse* order
 ///
@@ -28,6 +28,7 @@ static KNOWN_VERSIONS: LazyLock<Vec<KnownVersion>> = LazyLock::new(|| {
         // |  leaving the first copy as an example for the next person.
         // v
         // KnownVersion::new(next_int, "unique-dirname-with-the-sql-files"),
+        KnownVersion::new(175, "inv-host-phase-1-active-slot"),
         KnownVersion::new(174, "add-tuf-rot-by-sign"),
         KnownVersion::new(173, "inv-internal-dns"),
         KnownVersion::new(172, "add-zones-with-mupdate-override"),

--- a/nexus/db-schema/src/schema.rs
+++ b/nexus/db-schema/src/schema.rs
@@ -1560,6 +1560,17 @@ table! {
 }
 
 table! {
+    inv_host_phase_1_active_slot (inv_collection_id, hw_baseboard_id) {
+        inv_collection_id -> Uuid,
+        hw_baseboard_id -> Uuid,
+        time_collected -> Timestamptz,
+        source -> Text,
+
+        slot -> crate::enums::HwM2SlotEnum,
+    }
+}
+
+table! {
     inv_host_phase_1_flash_hash (inv_collection_id, hw_baseboard_id, slot) {
         inv_collection_id -> Uuid,
         hw_baseboard_id -> Uuid,

--- a/nexus/inventory/src/builder.rs
+++ b/nexus/inventory/src/builder.rs
@@ -181,6 +181,7 @@ impl CollectionBuilder {
             cabooses: self.cabooses,
             rot_pages: self.rot_pages,
             sps: self.sps,
+            host_phase_1_active_slots: self.host_phase_1_active_slots,
             host_phase_1_flash_hashes: self.host_phase_1_flash_hashes,
             rots: self.rots,
             cabooses_found: self.cabooses_found,

--- a/nexus/inventory/src/builder.rs
+++ b/nexus/inventory/src/builder.rs
@@ -25,6 +25,7 @@ use nexus_types::inventory::CabooseFound;
 use nexus_types::inventory::CabooseWhich;
 use nexus_types::inventory::CockroachStatus;
 use nexus_types::inventory::Collection;
+use nexus_types::inventory::HostPhase1ActiveSlot;
 use nexus_types::inventory::HostPhase1FlashHash;
 use nexus_types::inventory::InternalDnsGenerationStatus;
 use nexus_types::inventory::RotPage;
@@ -116,6 +117,7 @@ pub struct CollectionBuilder {
     cabooses: BTreeSet<Arc<Caboose>>,
     rot_pages: BTreeSet<Arc<RotPage>>,
     sps: BTreeMap<Arc<BaseboardId>, ServiceProcessor>,
+    host_phase_1_active_slots: BTreeMap<Arc<BaseboardId>, HostPhase1ActiveSlot>,
     host_phase_1_flash_hashes:
         BTreeMap<M2Slot, BTreeMap<Arc<BaseboardId>, HostPhase1FlashHash>>,
     rots: BTreeMap<Arc<BaseboardId>, RotState>,
@@ -153,6 +155,7 @@ impl CollectionBuilder {
             cabooses: BTreeSet::new(),
             rot_pages: BTreeSet::new(),
             sps: BTreeMap::new(),
+            host_phase_1_active_slots: BTreeMap::new(),
             host_phase_1_flash_hashes: BTreeMap::new(),
             rots: BTreeMap::new(),
             cabooses_found: BTreeMap::new(),
@@ -316,6 +319,63 @@ impl CollectionBuilder {
         }
 
         Some(baseboard)
+    }
+
+    /// Returns true if we already found the active host phase 1 flash slot for
+    /// baseboard `baseboard`
+    ///
+    /// This is used to avoid requesting it multiple times (from multiple MGS
+    /// instances).
+    pub fn found_host_phase_1_active_slot_already(
+        &self,
+        baseboard: &BaseboardId,
+    ) -> bool {
+        self.host_phase_1_active_slots.contains_key(baseboard)
+    }
+
+    /// Record the given host phase 1 active slot found for the given baseboard
+    ///
+    /// The baseboard must previously have been reported using
+    /// `found_sp_state()`.
+    ///
+    /// `source` is an arbitrary string for debugging that describes the MGS
+    /// that reported this data (generally a URL string).
+    pub fn found_host_phase_1_active_slot(
+        &mut self,
+        baseboard: &BaseboardId,
+        source: &str,
+        slot: M2Slot,
+    ) -> Result<(), CollectorBug> {
+        let (baseboard, _) =
+            self.sps.get_key_value(baseboard).ok_or_else(|| {
+                anyhow!(
+                    "reporting host phase 1 active slot for unknown baseboard: \
+                    {baseboard:?} ({slot:?})",
+                )
+            })?;
+        if let Some(previous) = self.host_phase_1_active_slots.insert(
+            baseboard.clone(),
+            HostPhase1ActiveSlot {
+                time_collected: now_db_precision(),
+                source: source.to_owned(),
+                slot,
+            },
+        ) {
+            let error = if previous.slot == slot {
+                anyhow!("reported multiple times (same value)")
+            } else {
+                anyhow!(
+                    "reported host phase 1 flash hash \
+                     (previously {}, now {slot})",
+                    previous.slot,
+                )
+            };
+            Err(CollectorBug::from(
+                error.context(format!("baseboard {baseboard:?}")),
+            ))
+        } else {
+            Ok(())
+        }
     }
 
     /// Returns true if we already found the host phase 1 flash hash for `slot`

--- a/nexus/inventory/src/collector.rs
+++ b/nexus/inventory/src/collector.rs
@@ -238,8 +238,7 @@ impl<'a> Collector<'a> {
                             }
                         }
                         Err(err) => {
-                            in_progress
-                                .found_error(InventoryError::from(err));
+                            in_progress.found_error(InventoryError::from(err));
                         }
                     }
                 }

--- a/nexus/inventory/src/examples.rs
+++ b/nexus/inventory/src/examples.rs
@@ -217,6 +217,14 @@ pub fn representative() -> Representative {
         )
         .unwrap();
 
+    // Report some phase 1 active slots.
+    builder
+        .found_host_phase_1_active_slot(&sled1_bb, "fake MGS 1", M2Slot::A)
+        .unwrap();
+    builder
+        .found_host_phase_1_active_slot(&sled2_bb, "fake MGS 1", M2Slot::B)
+        .unwrap();
+
     // Report some phase 1 hashes.
     //
     // We'll report hashes for both slots for sled 1, only a hash for slot B on

--- a/nexus/types/src/inventory.rs
+++ b/nexus/types/src/inventory.rs
@@ -412,6 +412,17 @@ pub struct RotState {
     pub stage0next_error: Option<RotImageError>,
 }
 
+/// Describes a host phase 1 flash active slot found from a service processor
+/// during collection
+#[derive(
+    Clone, Debug, Ord, Eq, PartialOrd, PartialEq, Deserialize, Serialize,
+)]
+pub struct HostPhase1ActiveSlot {
+    pub time_collected: DateTime<Utc>,
+    pub source: String,
+    pub slot: M2Slot,
+}
+
 /// Describes a host phase 1 flash hash found from a service processor
 /// during collection
 #[derive(

--- a/nexus/types/src/inventory.rs
+++ b/nexus/types/src/inventory.rs
@@ -106,6 +106,13 @@ pub struct Collection {
     /// table.
     #[serde_as(as = "Vec<(_, _)>")]
     pub sps: BTreeMap<Arc<BaseboardId>, ServiceProcessor>,
+    /// all host phase 1 active slots, keyed by baseboard id
+    ///
+    /// In practice, these will be inserted into the
+    /// `inv_host_phase_1_active_slot` table.
+    #[serde_as(as = "Vec<(_, _)>")]
+    pub host_phase_1_active_slots:
+        BTreeMap<Arc<BaseboardId>, HostPhase1ActiveSlot>,
     /// all host phase 1 flash hashes, keyed first by the phase 1 slot, then the
     /// baseboard id of the sled where they were found
     ///

--- a/schema/crdb/dbinit.sql
+++ b/schema/crdb/dbinit.sql
@@ -3517,6 +3517,25 @@ CREATE TYPE IF NOT EXISTS omicron.public.hw_m2_slot AS ENUM (
     'B'
 );
 
+-- host phase 1 active slots found
+CREATE TABLE IF NOT EXISTS omicron.public.inv_host_phase_1_active_slot (
+    -- where this observation came from
+    -- (foreign key into `inv_collection` table)
+    inv_collection_id UUID NOT NULL,
+    -- which system this SP reports it is part of
+    -- (foreign key into `hw_baseboard_id` table)
+    hw_baseboard_id UUID NOT NULL,
+    -- when this observation was made
+    time_collected TIMESTAMPTZ NOT NULL,
+    -- which MGS instance reported this data
+    source TEXT NOT NULL,
+
+    -- active phase 1 slot
+    slot omicron.public.hw_m2_slot NOT NULL,
+
+    PRIMARY KEY (inv_collection_id, hw_baseboard_id)
+);
+
 -- host phase 1 flash hashes found
 -- There are usually two rows here for each row in inv_service_processor, but
 -- not necessarily (either or both slots' hash collection may fail).
@@ -6350,7 +6369,7 @@ INSERT INTO omicron.public.db_metadata (
     version,
     target_version
 ) VALUES
-    (TRUE, NOW(), NOW(), '174.0.0', NULL)
+    (TRUE, NOW(), NOW(), '175.0.0', NULL)
 ON CONFLICT DO NOTHING;
 
 COMMIT;

--- a/schema/crdb/inv-host-phase-1-active-slot/up.sql
+++ b/schema/crdb/inv-host-phase-1-active-slot/up.sql
@@ -1,0 +1,8 @@
+CREATE TABLE IF NOT EXISTS omicron.public.inv_host_phase_1_active_slot (
+    inv_collection_id UUID NOT NULL,
+    hw_baseboard_id UUID NOT NULL,
+    time_collected TIMESTAMPTZ NOT NULL,
+    source TEXT NOT NULL,
+    slot omicron.public.hw_m2_slot NOT NULL,
+    PRIMARY KEY (inv_collection_id, hw_baseboard_id)
+);


### PR DESCRIPTION
This was an oversight; we're already collecting the host phase 1 hashes; we also need to know which slot is active (for host OS updates).

I'll test this on a racklette before merging, but I think it's straightforward enough to review.