### PR TITLE
[nexus] allow abbreviating ereport 'class' as 'k'

### DIFF
--- a/gateway-test-utils/configs/sp_sim_config.test.toml
+++ b/gateway-test-utils/configs/sp_sim_config.test.toml
@@ -55,7 +55,7 @@ restart_id = "0d3e464a-666e-4687-976f-90e31238be8b"
 task_name = "task_thermal_server"
 task_gen = 1
 uptime = 1235
-class = "oxide.sidecar.thermal.sensor_read_error"
+k = "oxide.sidecar.thermal.sensor_read_error"
 sensor = { id = "dev-1", device = "fake-tmp-sensor", location = "South", presence = "Failed" }
 error = "DeviceError"
 
@@ -209,14 +209,14 @@ restart_id = "af1ebf85-36ba-4c31-bbec-b9825d6d9d8b"
 task_name = "task_apollo_server"
 task_gen = 13
 uptime = 1233
-class = "gov.nasa.apollo.o2_tanks.stir.begin"
+k = "gov.nasa.apollo.o2_tanks.stir.begin"
 message = "stirring the tanks"
 
 [[simulated_sps.gimlet.ereport_config.ereports]]
 task_name = "drv_ae35_server"
 task_gen = 1
 uptime = 1234
-class = "io.discovery.ae35.fault"
+k = "io.discovery.ae35.fault"
 message = "i've just picked up a fault in the AE-35 unit"
 de = { scheme = "fmd", authority = { product-id = "HAL-9000-series computer", server-id = "HAL 9000"}, mod-name = "ae35-diagnosis" }
 hours_to_failure = 72
@@ -225,7 +225,7 @@ hours_to_failure = 72
 task_name = "task_apollo_server"
 task_gen = 13
 uptime = 1237
-class = "gov.nasa.apollo.fault"
+k = "gov.nasa.apollo.fault"
 message = "houston, we have a problem"
 crew = ["Lovell", "Swigert", "Haise"]
 
@@ -233,14 +233,14 @@ crew = ["Lovell", "Swigert", "Haise"]
 task_name = "drv_thingy_server"
 task_gen = 2
 uptime = 1240
-class = "flagrant_error"
+k = "flagrant_error"
 computer = false
 
 [[simulated_sps.gimlet.ereport_config.ereports]]
 task_name = "task_latex_server"
 task_gen = 1
 uptime = 1245
-class = "overfull_hbox"
+k = "overfull_hbox"
 badness  = 10000
 
 [[simulated_sps.gimlet]]

--- a/gateway/tests/integration_tests/ereports.rs
+++ b/gateway/tests/integration_tests/ereports.rs
@@ -73,6 +73,20 @@ mod sled0 {
     });
 
     def_ereport! {
+        LOSS: {
+            "baseboard_part_number": "SimGimletSp",
+            "baseboard_serial_number": "SimGimlet00",
+            "hubris_archive_id": "ffffffff",
+            "hubris_version": "0.0.2",
+            "hubris_task_name": "packrat",
+            "hubris_task_gen": 0,
+            "hubris_uptime_ms": 666,
+            "ereport_message_version": 0,
+            "lost": null,
+        }
+    }
+
+    def_ereport! {
         EREPORT_1: {
             "baseboard_part_number": "SimGimletSp",
             "baseboard_serial_number": "SimGimlet00",
@@ -167,6 +181,20 @@ mod sled1 {
     });
 
     def_ereport! {
+        LOSS: {
+            "baseboard_part_number": "SimGimletSp",
+            "baseboard_serial_number": "SimGimlet01",
+            "hubris_archive_id": "ffffffff",
+            "hubris_version": "0.0.2",
+            "hubris_task_name": "packrat",
+            "hubris_task_gen": 0,
+            "hubris_uptime_ms": 666,
+            "ereport_message_version": 0,
+            "lost": null,
+        }
+    }
+
+    def_ereport! {
         EREPORT_1: {
             "baseboard_part_number": "SimGimletSp",
             "baseboard_serial_number": "SimGimlet01",
@@ -233,9 +261,14 @@ async fn ereports_basic() {
 
     assert_eq!(restart_id.as_untyped_uuid(), &*sled1::RESTART_0);
     let reports = reports.items;
-    assert_eq!(reports.len(), 1, "expected 1 ereport, found: {:#?}", reports);
+    assert_eq!(reports.len(), 2, "expected 2 ereports, found: {:#?}", reports);
+
     let report = &reports[0];
     assert_eq!(report.ena, ereport_types::Ena(1));
+    assert_eq!(report.data, *sled1::LOSS);
+
+    let report = &reports[1];
+    assert_eq!(report.ena, ereport_types::Ena(2));
     assert_eq!(report.data, *sled1::EREPORT_1);
 
     testctx.teardown().await;
@@ -254,7 +287,7 @@ async fn ereports_limit() {
             restart_id: Uuid::new_v4(),
             start_ena: 0,
             committed_ena: None,
-            limit: 2
+            limit: 3
         }
         .response(client)
         .await
@@ -262,13 +295,18 @@ async fn ereports_limit() {
 
     assert_eq!(restart_id.as_untyped_uuid(), &*sled0::RESTART_0);
     let reports = reports.items;
-    assert_eq!(reports.len(), 2, "expected 2 ereports, found: {:#?}", reports);
+    assert_eq!(reports.len(), 3, "expected 3 ereports, found: {:#?}", reports);
+
     let report = &reports[0];
     assert_eq!(report.ena, ereport_types::Ena(1));
-    assert_eq!(report.data, *sled0::EREPORT_1);
+    assert_eq!(report.data, *sled0::LOSS);
 
     let report = &reports[1];
     assert_eq!(report.ena, ereport_types::Ena(2));
+    assert_eq!(report.data, *sled0::EREPORT_1);
+
+    let report = &reports[2];
+    assert_eq!(report.ena, ereport_types::Ena(3));
     assert_eq!(report.data, *sled0::EREPORT_2);
 
     let ereport_types::Ereports { restart_id, reports } = dbg!(
@@ -288,11 +326,11 @@ async fn ereports_limit() {
     assert_eq!(reports.len(), 2, "expected 2 ereports, found: {:#?}", reports);
     let report = &reports[0];
     assert_eq!(report.ena, ereport_types::Ena(3));
-    assert_eq!(report.data, *sled0::EREPORT_3);
+    assert_eq!(report.data, *sled0::EREPORT_2);
 
     let report = &reports[1];
     assert_eq!(report.ena, ereport_types::Ena(4));
-    assert_eq!(report.data, *sled0::EREPORT_4);
+    assert_eq!(report.data, *sled0::EREPORT_3);
 
     testctx.teardown().await;
 }
@@ -323,11 +361,11 @@ async fn ereports_commit() {
     assert_eq!(reports.len(), 2, "expected 2 ereports, found: {:#?}", reports);
     let report = &reports[0];
     assert_eq!(report.ena, ereport_types::Ena(1));
-    assert_eq!(report.data, *sled0::EREPORT_1);
+    assert_eq!(report.data, *sled0::LOSS);
 
     let report = &reports[1];
     assert_eq!(report.ena, ereport_types::Ena(2));
-    assert_eq!(report.data, *sled0::EREPORT_2);
+    assert_eq!(report.data, *sled0::EREPORT_1);
 
     // Now, send a request with a committed ENA *and* a matching restart ID.
     let ereport_types::Ereports { restart_id, reports } = dbg!(
@@ -347,11 +385,11 @@ async fn ereports_commit() {
     assert_eq!(reports.len(), 2, "expected 2 ereports, found: {:#?}", reports);
     let report = &reports[0];
     assert_eq!(report.ena, ereport_types::Ena(3));
-    assert_eq!(report.data, *sled0::EREPORT_3);
+    assert_eq!(report.data, *sled0::EREPORT_2);
 
     let report = &reports[1];
     assert_eq!(report.ena, ereport_types::Ena(4));
-    assert_eq!(report.data, *sled0::EREPORT_4);
+    assert_eq!(report.data, *sled0::EREPORT_3);
 
     // Even if the start ENA of a subsequent request is 0, we shouldn't see any
     // ereports with ENAs lower than the committed ENA.
@@ -369,17 +407,21 @@ async fn ereports_commit() {
 
     assert_eq!(restart_id.as_untyped_uuid(), &*sled0::RESTART_0);
     let reports = reports.items;
-    assert_eq!(reports.len(), 3, "expected 3 ereports, found: {:#?}", reports);
+    assert_eq!(reports.len(), 4, "expected 3 ereports, found: {:#?}", reports);
     let report = &reports[0];
     assert_eq!(report.ena, ereport_types::Ena(3));
-    assert_eq!(report.data, *sled0::EREPORT_3);
+    assert_eq!(report.data, *sled0::EREPORT_2);
 
     let report = &reports[1];
     assert_eq!(report.ena, ereport_types::Ena(4));
-    assert_eq!(report.data, *sled0::EREPORT_4);
+    assert_eq!(report.data, *sled0::EREPORT_3);
 
     let report = &reports[2];
     assert_eq!(report.ena, ereport_types::Ena(5));
+    assert_eq!(report.data, *sled0::EREPORT_4);
+
+    let report = &reports[3];
+    assert_eq!(report.ena, ereport_types::Ena(6));
     assert_eq!(report.data, *sled0::EREPORT_5);
 
     testctx.teardown().await;

--- a/gateway/tests/integration_tests/ereports.rs
+++ b/gateway/tests/integration_tests/ereports.rs
@@ -82,7 +82,7 @@ mod sled0 {
             "hubris_task_gen": 13,
             "hubris_uptime_ms": 1233,
             "ereport_message_version": 0,
-            "class": "gov.nasa.apollo.o2_tanks.stir.begin",
+            "k": "gov.nasa.apollo.o2_tanks.stir.begin",
             "message": "stirring the tanks",
         }
     }
@@ -96,7 +96,7 @@ mod sled0 {
             "hubris_task_gen": 1,
             "hubris_uptime_ms": 1234,
             "ereport_message_version": 0,
-            "class": "io.discovery.ae35.fault",
+            "k": "io.discovery.ae35.fault",
             "message": "i've just picked up a fault in the AE-35 unit",
             "de": {
                 "scheme": "fmd",
@@ -119,7 +119,7 @@ mod sled0 {
             "hubris_task_gen": 13,
             "hubris_uptime_ms": 1237,
             "ereport_message_version": 0,
-            "class": "gov.nasa.apollo.fault",
+            "k": "gov.nasa.apollo.fault",
             "message": "houston, we have a problem",
             "crew": [
                 "Lovell",
@@ -139,7 +139,7 @@ mod sled0 {
             "hubris_task_gen": 2,
             "hubris_uptime_ms": 1240,
             "ereport_message_version": 0,
-            "class": "flagrant_error",
+            "k": "flagrant_error",
             "computer": false,
         }
     }
@@ -154,7 +154,7 @@ mod sled0 {
             "hubris_task_gen": 1,
             "hubris_uptime_ms": 1245,
             "ereport_message_version": 0,
-            "class": "overfull_hbox",
+            "k": "overfull_hbox",
             "badness": 10000,
         }
     }

--- a/nexus/src/app/background/tasks/ereport_ingester.rs
+++ b/nexus/src/app/background/tasks/ereport_ingester.rs
@@ -298,7 +298,7 @@ impl Ingester {
                         (None, Some(serde_json::Value::Number(_))) => {
                             Some("ereport.data_loss.certain".to_string())
                         }
-                        None => {
+                        (None, _) => {
                             slog::warn!(
                                 &opctx.log,
                                 "ereport missing 'k'/'class' key";

--- a/nexus/src/app/background/tasks/ereport_ingester.rs
+++ b/nexus/src/app/background/tasks/ereport_ingester.rs
@@ -528,8 +528,8 @@ mod tests {
         dbg!(&activation1);
         assert_eq!(
             activation1.sps.len(),
-            3,
-            "ereports from 3 SPs should be observed: {:?}",
+            4,
+            "ereports from 4 SPs should be observed: {:?}",
             activation1.sps,
         );
 
@@ -554,12 +554,26 @@ mod tests {
             "55e30cc7-a109-492f-aca9-735ed725df3c"
         ));
 
+        let sled0 =
+            ExpectedReporter { serial: "SimGimlet00", part: "SimGimletSp" };
         let sled0_ereports = [
-            (
-                Ena::from(1),
+            sled0.ereport(
+                1,
+                "loss",
                 serde_json::json!({
-                    "baseboard_part_number": "SimGimletSp",
-                    "baseboard_serial_number": "SimGimlet00",
+                    "hubris_archive_id": "ffffffff",
+                    "hubris_version": "0.0.2",
+                    "hubris_task_name": "packrat",
+                    "hubris_task_gen": 0,
+                    "hubris_uptime_ms": 666,
+                    "ereport_message_version": 0,
+                    "lost": null,
+                }),
+            ),
+            sled0.ereport(
+                2,
+                "gov.nasa.apollo.o2_tanks.stir.begin",
+                serde_json::json!({
                     "hubris_archive_id": "ffffffff",
                     "hubris_version": "0.0.2",
                     "hubris_task_name": "task_apollo_server",
@@ -570,11 +584,10 @@ mod tests {
                     "message": "stirring the tanks",
                 }),
             ),
-            (
-                Ena::from(2),
+            sled0.ereport(
+                3,
+                "io.discovery.ae35.fault",
                 serde_json::json!({
-                    "baseboard_part_number": "SimGimletSp",
-                    "baseboard_serial_number": "SimGimlet00",
                     "hubris_archive_id": "ffffffff",
                     "hubris_version": "0.0.2",
                     "hubris_task_name": "drv_ae35_server",
@@ -594,11 +607,10 @@ mod tests {
                     "hours_to_failure": 72,
                 }),
             ),
-            (
-                Ena::from(3),
+            sled0.ereport(
+                4,
+                "gov.nasa.apollo.fault",
                 serde_json::json!({
-                    "baseboard_part_number": "SimGimletSp",
-                    "baseboard_serial_number": "SimGimlet00",
                     "hubris_archive_id": "ffffffff",
                     "hubris_version": "0.0.2",
                     "hubris_task_name": "task_apollo_server",
@@ -614,11 +626,10 @@ mod tests {
                     ],
                 }),
             ),
-            (
-                Ena::from(4),
+            sled0.ereport(
+                5,
+                "flagrant_error",
                 serde_json::json!({
-                    "baseboard_part_number": "SimGimletSp",
-                    "baseboard_serial_number": "SimGimlet00",
                     "hubris_archive_id": "ffffffff",
                     "hubris_version": "0.0.2",
                     "hubris_task_name": "drv_thingy_server",
@@ -629,11 +640,10 @@ mod tests {
                     "computer": false,
                 }),
             ),
-            (
-                Ena::from(5),
+            sled0.ereport(
+                6,
+                "overfull_hbox",
                 serde_json::json!({
-                    "baseboard_part_number": "SimGimletSp",
-                    "baseboard_serial_number": "SimGimlet00",
                     "hubris_archive_id": "ffffffff",
                     "hubris_version": "0.0.2",
                     "hubris_task_name": "task_latex_server",
@@ -646,33 +656,49 @@ mod tests {
             ),
         ];
 
-        let sled1_ereports = [(
-            Ena::from(1),
-            serde_json::json!({
-                "baseboard_part_number": "SimGimletSp",
-                "baseboard_serial_number": "SimGimlet01",
-                "hubris_archive_id": "ffffffff",
-                "hubris_version": "0.0.2",
-                "hubris_task_name": "task_thermal_server",
-                "hubris_task_gen": 1,
-                "hubris_uptime_ms": 1233,
-                "ereport_message_version": 0,
-                "class": "computer.oxide.gimlet.chassis_integrity.fault",
-                "nosub_class": "chassis_integrity.cat_hair_detected",
-                "message": "cat hair detected inside gimlet",
-                "de": {
-                    "scheme": "fmd",
-                    "mod-name": "hubris-thermal-diagnosis",
-                    "mod-version": "1.0",
-                    "authority": {
-                        "product-id": "oxide",
-                        "server-id": "SimGimlet1",
-                    }
-                },
-                "certainty": 0x64,
-                "cat_hair_amount": 10000,
-            }),
-        )];
+        let sled1 =
+            ExpectedReporter { part: "SimGimletSp", serial: "SimGimlet01" };
+        let sled1_ereports = [
+            sled1.ereport(
+                1,
+                "loss",
+                serde_json::json!({
+                    "hubris_archive_id": "ffffffff",
+                    "hubris_version": "0.0.2",
+                    "hubris_task_name": "packrat",
+                    "hubris_task_gen": 0,
+                    "hubris_uptime_ms": 666,
+                    "ereport_message_version": 0,
+                    "lost": null,
+                }),
+            ),
+            sled1.ereport(
+                2,
+                "computer.oxide.gimlet.chassis_integrity.fault",
+                serde_json::json!({
+                    "hubris_archive_id": "ffffffff",
+                    "hubris_version": "0.0.2",
+                    "hubris_task_name": "task_thermal_server",
+                    "hubris_task_gen": 1,
+                    "hubris_uptime_ms": 1233,
+                    "ereport_message_version": 0,
+                    "class": "computer.oxide.gimlet.chassis_integrity.fault",
+                    "nosub_class": "chassis_integrity.cat_hair_detected",
+                    "message": "cat hair detected inside gimlet",
+                    "de": {
+                        "scheme": "fmd",
+                        "mod-name": "hubris-thermal-diagnosis",
+                        "mod-version": "1.0",
+                        "authority": {
+                            "product-id": "oxide",
+                            "server-id": "SimGimlet1",
+                        }
+                    },
+                    "certainty": 0x64,
+                    "cat_hair_amount": 10000,
+                }),
+            ),
+        ];
 
         check_sp_ereports_exist(
             datastore,
@@ -717,11 +743,56 @@ mod tests {
         .await;
     }
 
+    struct ExpectedReporter {
+        serial: &'static str,
+        part: &'static str,
+    }
+
+    struct ExpectedEreport {
+        ena: Ena,
+        class: Option<&'static str>,
+        serial: Option<&'static str>,
+        part: Option<&'static str>,
+        json: serde_json::Value,
+    }
+
+    impl ExpectedReporter {
+        fn ereport(
+            &self,
+            ena: u64,
+            class: impl Into<Option<&'static str>>,
+            mut json: serde_json::Value,
+        ) -> ExpectedEreport {
+            if let serde_json::Value::Object(ref mut map) = &mut json {
+                map.insert(
+                    "baseboard_part_number".to_string(),
+                    self.part.into(),
+                );
+                map.insert(
+                    "baseboard_serial_number".to_string(),
+                    self.serial.into(),
+                );
+            } else {
+                panic!(
+                    "Expected ereport JSON to be an object, but it was some \
+                     other thing. This is a bug in your test code!",
+                );
+            };
+            ExpectedEreport {
+                ena: Ena(ena),
+                class: class.into(),
+                serial: Some(self.serial),
+                part: Some(self.part),
+                json,
+            }
+        }
+    }
+
     async fn check_sp_ereports_exist(
         datastore: &DataStore,
         opctx: &OpContext,
         restart_id: EreporterRestartUuid,
-        expected_ereports: &[(Ena, serde_json::Value)],
+        expected_ereports: &[ExpectedEreport],
     ) {
         let mut paginator = Paginator::new(
             std::num::NonZeroU32::new(100).unwrap(),
@@ -749,14 +820,35 @@ mod tests {
             expected_ereports.len()
         );
 
-        for (ena, report) in expected_ereports {
+        for ExpectedEreport { ena, json, serial, part, class } in
+            expected_ereports
+        {
             let Some(found_report) = found_ereports.get(ena) else {
                 panic!(
-                    "expected ereport {restart_id:?}:{ena} not found in database"
+                    "expected ereport {restart_id:?}:{ena} not found in \
+                     database"
                 )
             };
             assert_eq!(
-                report, &found_report.report,
+                serial,
+                &found_report.serial_number.as_deref(),
+                "expected ereport {restart_id:?}:{ena} to have serial \
+                 {serial:?}"
+            );
+            assert_eq!(
+                part,
+                &found_report.part_number.as_deref(),
+                "expected ereport {restart_id:?}:{ena} to have part number \
+                 {part:?}"
+            );
+            assert_eq!(
+                class,
+                &found_report.class.as_deref(),
+                "expected ereport {restart_id:?}:{ena} to have class \
+                 {class:?}"
+            );
+            assert_eq!(
+                json, &found_report.report,
                 "ereport data for {restart_id:?}:{ena} doesn't match expected"
             );
         }

--- a/nexus/src/app/background/tasks/ereport_ingester.rs
+++ b/nexus/src/app/background/tasks/ereport_ingester.rs
@@ -292,7 +292,7 @@ impl Ingester {
                             None
                         }
                         None if ereport.data.contains_key("lost") => {
-                            // Tjis is a loss record! I know this!
+                            // This is a loss record! I know this!
                             Some("loss".to_string())
                         }
                         None => {

--- a/sp-sim/src/config.rs
+++ b/sp-sim/src/config.rs
@@ -11,6 +11,7 @@ use gateway_messages::DeviceCapabilities;
 use gateway_messages::DevicePresence;
 use serde::Deserialize;
 use serde::Serialize;
+use std::collections::BTreeMap;
 use std::net::Ipv6Addr;
 use std::net::SocketAddrV6;
 use std::path::Path;
@@ -255,5 +256,5 @@ pub struct Ereport {
     pub task_gen: u32,
     pub uptime: u64,
     #[serde(flatten)]
-    pub data: toml::map::Map<String, toml::Value>,
+    pub data: BTreeMap<String, serde_cbor::Value>,
 }

--- a/sp-sim/src/ereport.rs
+++ b/sp-sim/src/ereport.rs
@@ -78,7 +78,7 @@ impl EreportState {
             // that were previously buffered but not ingested *may* have been
             // lost.
             std::iter::once(Ereport::loss_internal(None))
-                .chain(ereports.into_iter())
+                .chain(ereports)
                 .enumerate()
                 .map(|(i, ereport)| {
                     // DON'T EMIT ENA 0
@@ -347,7 +347,7 @@ impl Ereport {
         match amount {
             Some(amount) => data.insert(
                 "lost".to_string(),
-                serde_cbor::Value::Integer(amount as i128),
+                serde_cbor::Value::Integer(i128::from(amount)),
             ),
             None => data.insert("lost".to_string(), serde_cbor::Value::Null),
         };


### PR DESCRIPTION
This was one of @cbiffle's ideas to save a few bytes of CBO. Since we expect to encode a "class" key for every ereport, shortening the fields that are included in every message has a meaningful impact on how much we can buffer. Also, loss records (which are generated when the SP restarts or when ereports don't fit in the buffer) lack a class string, because the presence of a top-level "lost" key can be used to identify them. So, we should handle that here, as well.