### PR TITLE
[omdb] Add missing newline to `omdb db ereport show`

### DIFF
--- a/dev-tools/omdb/src/bin/omdb/db/ereport.rs
+++ b/dev-tools/omdb/src/bin/omdb/db/ereport.rs
@@ -369,6 +369,7 @@ async fn cmd_db_ereport_info(
     println!("\n{:=<80}", "== EREPORT ");
     serde_json::to_writer_pretty(std::io::stdout(), &report)
         .with_context(|| format!("failed to serialize ereport: {report:?}"))?;
+    println!();
 
     Ok(())
 }


### PR DESCRIPTION
As seen in today's demo hour, the use of `serde_json::to_writer_pretty` doesn't include a trailing newline, so the closing `}` of the ereport JSON is followed immediately by the shell prompt. This both looks bad and makes copying/pasting the JSON annoyinger. This commit adds the newline. Whoopsie.