### PR TITLE
[mgs-updates] Adjust RoT bootloader post-update timeout

### DIFF
--- a/nexus/mgs-updates/src/driver_update.rs
+++ b/nexus/mgs-updates/src/driver_update.rs
@@ -658,7 +658,7 @@ fn post_update_timeout(update: &PendingMgsUpdate) -> Duration {
         PendingMgsUpdateDetails::RotBootloader { .. } => {
             // Resetting the bootloader requires multiple RoT resets; give this
             // a longer timeout.
-            Duration::from_secs(120)
+            Duration::from_secs(180)
         }
     }
 }


### PR DESCRIPTION
During the RoT bootloader's post_update stage, we are currently giving [120 seconds](https://github.com/oxidecomputer/omicron/blob/main/nexus/mgs-updates/src/rot_bootloader_updater.rs#L31) to [poll the RoT to retrieve boot_info](https://github.com/oxidecomputer/omicron/blob/main/nexus/mgs-updates/src/rot_bootloader_updater.rs#L191-L203), and then [resetting the device again](https://github.com/oxidecomputer/omicron/blob/main/nexus/mgs-updates/src/rot_bootloader_updater.rs#L252). `post_update_timeout()` should align more closely to that.