### PR TITLE
Blueprint planner: clean up pending MGS test support utilities

### DIFF
--- a/nexus/reconfigurator/planning/src/mgs_updates/mod.rs
+++ b/nexus/reconfigurator/planning/src/mgs_updates/mod.rs
@@ -476,9 +476,8 @@ mod test {
         // will remain no updates pending.
         let collection = test_boards
             .collection_builder()
-            .sp_active_version(ARTIFACT_VERSION_2)
+            .sp_versions(ARTIFACT_VERSION_2, ExpectedVersion::NoValidVersion)
             .rot_active_version(ARTIFACT_VERSION_2)
-            .sp_inactive_version(ExpectedVersion::NoValidVersion)
             .rot_inactive_version(ExpectedVersion::NoValidVersion)
             .sp_active_version_exception(SpType::Sled, 0, ARTIFACT_VERSION_1)
             .build();
@@ -536,9 +535,8 @@ mod test {
         // nmax_updates).
         let later_collection = test_boards
             .collection_builder()
-            .sp_active_version(ARTIFACT_VERSION_2)
+            .sp_versions(ARTIFACT_VERSION_2, ExpectedVersion::NoValidVersion)
             .rot_active_version(ARTIFACT_VERSION_2)
-            .sp_inactive_version(ExpectedVersion::NoValidVersion)
             .rot_inactive_version(ExpectedVersion::NoValidVersion)
             .sp_active_version_exception(SpType::Sled, 0, ARTIFACT_VERSION_1)
             .sp_active_version_exception(SpType::Switch, 1, ARTIFACT_VERSION_1)
@@ -560,9 +558,8 @@ mod test {
         // second that we noticed another thing needed an update
         let later_collection = test_boards
             .collection_builder()
-            .sp_active_version(ARTIFACT_VERSION_2)
+            .sp_versions(ARTIFACT_VERSION_2, ExpectedVersion::NoValidVersion)
             .rot_active_version(ARTIFACT_VERSION_2)
-            .sp_inactive_version(ExpectedVersion::NoValidVersion)
             .rot_inactive_version(ExpectedVersion::NoValidVersion)
             .sp_active_version_exception(SpType::Switch, 1, ARTIFACT_VERSION_1)
             .build();
@@ -589,9 +586,8 @@ mod test {
         // configured.
         let updated_collection = test_boards
             .collection_builder()
-            .sp_active_version(ARTIFACT_VERSION_2)
+            .sp_versions(ARTIFACT_VERSION_2, ExpectedVersion::NoValidVersion)
             .rot_active_version(ARTIFACT_VERSION_2)
-            .sp_inactive_version(ExpectedVersion::NoValidVersion)
             .rot_inactive_version(ExpectedVersion::NoValidVersion)
             .build();
         let later_updates = plan_mgs_updates(
@@ -609,9 +605,8 @@ mod test {
         // `current_boards`, even if they're in inventory and outdated.
         let collection = test_boards
             .collection_builder()
-            .sp_active_version(ARTIFACT_VERSION_2)
+            .sp_versions(ARTIFACT_VERSION_2, ExpectedVersion::NoValidVersion)
             .rot_active_version(ARTIFACT_VERSION_2)
-            .sp_inactive_version(ExpectedVersion::NoValidVersion)
             .rot_inactive_version(ExpectedVersion::NoValidVersion)
             .sp_active_version_exception(SpType::Sled, 0, ARTIFACT_VERSION_1)
             .build();
@@ -659,9 +654,11 @@ mod test {
         // a new update reflecting that.
         let collection = test_boards
             .collection_builder()
-            .sp_active_version(ARTIFACT_VERSION_2)
+            .sp_versions(
+                ARTIFACT_VERSION_2,
+                ExpectedVersion::Version(ARTIFACT_VERSION_1),
+            )
             .rot_active_version(ARTIFACT_VERSION_2)
-            .sp_inactive_version(ExpectedVersion::Version(ARTIFACT_VERSION_1))
             .rot_inactive_version(ExpectedVersion::NoValidVersion)
             .sp_active_version_exception(SpType::Sled, 0, ARTIFACT_VERSION_1)
             .build();
@@ -701,9 +698,8 @@ mod test {
         // a new update reflecting that.
         let collection = test_boards
             .collection_builder()
-            .sp_active_version(ARTIFACT_VERSION_2)
+            .sp_versions(ARTIFACT_VERSION_2, ExpectedVersion::NoValidVersion)
             .rot_active_version(ARTIFACT_VERSION_2)
-            .sp_inactive_version(ExpectedVersion::NoValidVersion)
             .rot_inactive_version(ExpectedVersion::NoValidVersion)
             .sp_active_version_exception(SpType::Sled, 0, ARTIFACT_VERSION_1_5)
             .build();
@@ -757,9 +753,8 @@ mod test {
         // will remain no updates pending.
         let collection = test_boards
             .collection_builder()
-            .sp_active_version(ARTIFACT_VERSION_2)
+            .sp_versions(ARTIFACT_VERSION_2, ExpectedVersion::NoValidVersion)
             .rot_active_version(ARTIFACT_VERSION_2)
-            .sp_inactive_version(ExpectedVersion::NoValidVersion)
             .rot_inactive_version(ExpectedVersion::NoValidVersion)
             .rot_active_version_exception(SpType::Sled, 0, ARTIFACT_VERSION_1)
             .build();
@@ -817,9 +812,8 @@ mod test {
         // nmax_updates).
         let later_collection = test_boards
             .collection_builder()
-            .sp_active_version(ARTIFACT_VERSION_2)
+            .sp_versions(ARTIFACT_VERSION_2, ExpectedVersion::NoValidVersion)
             .rot_active_version(ARTIFACT_VERSION_2)
-            .sp_inactive_version(ExpectedVersion::NoValidVersion)
             .rot_inactive_version(ExpectedVersion::NoValidVersion)
             .rot_active_version_exception(SpType::Sled, 0, ARTIFACT_VERSION_1)
             .rot_active_version_exception(SpType::Switch, 1, ARTIFACT_VERSION_1)
@@ -843,9 +837,8 @@ mod test {
         // and second SP.
         let later_collection = test_boards
             .collection_builder()
-            .sp_active_version(ARTIFACT_VERSION_2)
+            .sp_versions(ARTIFACT_VERSION_2, ExpectedVersion::NoValidVersion)
             .rot_active_version(ARTIFACT_VERSION_2)
-            .sp_inactive_version(ExpectedVersion::NoValidVersion)
             .rot_inactive_version(ExpectedVersion::NoValidVersion)
             .sp_active_version_exception(SpType::Switch, 1, ARTIFACT_VERSION_1)
             .rot_active_version_exception(SpType::Switch, 1, ARTIFACT_VERSION_1)
@@ -873,9 +866,8 @@ mod test {
         // are configured.
         let updated_collection = test_boards
             .collection_builder()
-            .sp_active_version(ARTIFACT_VERSION_2)
+            .sp_versions(ARTIFACT_VERSION_2, ExpectedVersion::NoValidVersion)
             .rot_active_version(ARTIFACT_VERSION_2)
-            .sp_inactive_version(ExpectedVersion::NoValidVersion)
             .rot_inactive_version(ExpectedVersion::NoValidVersion)
             .build();
         let later_updates = plan_mgs_updates(
@@ -893,9 +885,8 @@ mod test {
         // `current_boards`, even if they're in inventory and outdated.
         let collection = test_boards
             .collection_builder()
-            .sp_active_version(ARTIFACT_VERSION_2)
+            .sp_versions(ARTIFACT_VERSION_2, ExpectedVersion::NoValidVersion)
             .rot_active_version(ARTIFACT_VERSION_2)
-            .sp_inactive_version(ExpectedVersion::NoValidVersion)
             .rot_inactive_version(ExpectedVersion::NoValidVersion)
             .rot_active_version_exception(SpType::Sled, 0, ARTIFACT_VERSION_1)
             .build();
@@ -944,9 +935,11 @@ mod test {
         // a new update reflecting that.
         let collection = test_boards
             .collection_builder()
-            .sp_active_version(ARTIFACT_VERSION_2)
+            .sp_versions(
+                ARTIFACT_VERSION_2,
+                ExpectedVersion::Version(ARTIFACT_VERSION_1),
+            )
             .rot_active_version(ARTIFACT_VERSION_2)
-            .sp_inactive_version(ExpectedVersion::Version(ARTIFACT_VERSION_1))
             .rot_inactive_version(ExpectedVersion::Version(ARTIFACT_VERSION_1))
             .rot_active_version_exception(SpType::Sled, 0, ARTIFACT_VERSION_1)
             .build();
@@ -987,9 +980,8 @@ mod test {
         // a new update reflecting that.
         let collection = test_boards
             .collection_builder()
-            .sp_active_version(ARTIFACT_VERSION_2)
+            .sp_versions(ARTIFACT_VERSION_2, ExpectedVersion::NoValidVersion)
             .rot_active_version(ARTIFACT_VERSION_2)
-            .sp_inactive_version(ExpectedVersion::NoValidVersion)
             .rot_inactive_version(ExpectedVersion::NoValidVersion)
             .rot_active_version_exception(SpType::Sled, 0, ARTIFACT_VERSION_1_5)
             .build();
@@ -1042,9 +1034,11 @@ mod test {
         // Initial setup: sled 0 has active version 1 and inactive version 1.5.
         let collection = test_boards
             .collection_builder()
-            .sp_active_version(ARTIFACT_VERSION_2)
+            .sp_versions(
+                ARTIFACT_VERSION_2,
+                ExpectedVersion::Version(ARTIFACT_VERSION_1_5),
+            )
             .rot_active_version(ARTIFACT_VERSION_2)
-            .sp_inactive_version(ExpectedVersion::Version(ARTIFACT_VERSION_1_5))
             .rot_inactive_version(ExpectedVersion::Version(
                 ARTIFACT_VERSION_1_5,
             ))
@@ -1101,9 +1095,8 @@ mod test {
         // no caboose to read.
         let collection = test_boards
             .collection_builder()
-            .sp_active_version(ARTIFACT_VERSION_2)
+            .sp_versions(ARTIFACT_VERSION_2, ExpectedVersion::NoValidVersion)
             .rot_active_version(ARTIFACT_VERSION_2)
-            .sp_inactive_version(ExpectedVersion::NoValidVersion)
             .rot_inactive_version(ExpectedVersion::Version(
                 ARTIFACT_VERSION_1_5,
             ))
@@ -1181,9 +1174,8 @@ mod test {
         // exceptions as we step through updates below.
         let mut builder = test_boards
             .collection_builder()
-            .sp_active_version(ARTIFACT_VERSION_1)
+            .sp_versions(ARTIFACT_VERSION_1, ExpectedVersion::NoValidVersion)
             .rot_active_version(ARTIFACT_VERSION_1)
-            .sp_inactive_version(ExpectedVersion::NoValidVersion)
             .rot_inactive_version(ExpectedVersion::NoValidVersion);
         for _ in 0..expected_updates.len() {
             let collection = builder.clone().build();
@@ -1279,9 +1271,8 @@ mod test {
         // the RoTs, but stages at most one pending update per board.
         let collection = test_boards
             .collection_builder()
-            .sp_active_version(ARTIFACT_VERSION_1)
+            .sp_versions(ARTIFACT_VERSION_1, ExpectedVersion::NoValidVersion)
             .rot_active_version(ARTIFACT_VERSION_1)
-            .sp_inactive_version(ExpectedVersion::NoValidVersion)
             .rot_inactive_version(ExpectedVersion::NoValidVersion)
             .build();
         let all_updates = plan_mgs_updates(
@@ -1310,9 +1301,8 @@ mod test {
         // been updated already; this should attempt to update all of the SPs.
         let collection = test_boards
             .collection_builder()
-            .sp_active_version(ARTIFACT_VERSION_1)
+            .sp_versions(ARTIFACT_VERSION_1, ExpectedVersion::NoValidVersion)
             .rot_active_version(ARTIFACT_VERSION_2)
-            .sp_inactive_version(ExpectedVersion::NoValidVersion)
             .rot_inactive_version(ExpectedVersion::NoValidVersion)
             .build();
         let all_updates = plan_mgs_updates(
@@ -1344,9 +1334,8 @@ mod test {
         // one.
         let collection = test_boards
             .collection_builder()
-            .sp_active_version(ARTIFACT_VERSION_2)
+            .sp_versions(ARTIFACT_VERSION_2, ExpectedVersion::NoValidVersion)
             .rot_active_version(ARTIFACT_VERSION_2)
-            .sp_inactive_version(ExpectedVersion::NoValidVersion)
             .rot_inactive_version(ExpectedVersion::NoValidVersion)
             .build();
         let all_updates_done = plan_mgs_updates(
@@ -1378,9 +1367,8 @@ mod test {
         let repo = test_boards.tuf_repo();
         let mut collection = test_boards
             .collection_builder()
-            .sp_active_version(ARTIFACT_VERSION_2)
+            .sp_versions(ARTIFACT_VERSION_2, ExpectedVersion::NoValidVersion)
             .rot_active_version(ARTIFACT_VERSION_2)
-            .sp_inactive_version(ExpectedVersion::NoValidVersion)
             .rot_inactive_version(ExpectedVersion::NoValidVersion)
             .sp_active_version_exception(SpType::Sled, 0, ARTIFACT_VERSION_1)
             .rot_active_version_exception(SpType::Sled, 0, ARTIFACT_VERSION_1)

--- a/nexus/reconfigurator/planning/src/mgs_updates/mod.rs
+++ b/nexus/reconfigurator/planning/src/mgs_updates/mod.rs
@@ -477,8 +477,7 @@ mod test {
         let collection = test_boards
             .collection_builder()
             .sp_versions(ARTIFACT_VERSION_2, ExpectedVersion::NoValidVersion)
-            .rot_active_version(ARTIFACT_VERSION_2)
-            .rot_inactive_version(ExpectedVersion::NoValidVersion)
+            .rot_versions(ARTIFACT_VERSION_2, ExpectedVersion::NoValidVersion)
             .sp_active_version_exception(SpType::Sled, 0, ARTIFACT_VERSION_1)
             .build();
         let current_boards = &collection.baseboards;
@@ -536,8 +535,7 @@ mod test {
         let later_collection = test_boards
             .collection_builder()
             .sp_versions(ARTIFACT_VERSION_2, ExpectedVersion::NoValidVersion)
-            .rot_active_version(ARTIFACT_VERSION_2)
-            .rot_inactive_version(ExpectedVersion::NoValidVersion)
+            .rot_versions(ARTIFACT_VERSION_2, ExpectedVersion::NoValidVersion)
             .sp_active_version_exception(SpType::Sled, 0, ARTIFACT_VERSION_1)
             .sp_active_version_exception(SpType::Switch, 1, ARTIFACT_VERSION_1)
             .build();
@@ -559,8 +557,7 @@ mod test {
         let later_collection = test_boards
             .collection_builder()
             .sp_versions(ARTIFACT_VERSION_2, ExpectedVersion::NoValidVersion)
-            .rot_active_version(ARTIFACT_VERSION_2)
-            .rot_inactive_version(ExpectedVersion::NoValidVersion)
+            .rot_versions(ARTIFACT_VERSION_2, ExpectedVersion::NoValidVersion)
             .sp_active_version_exception(SpType::Switch, 1, ARTIFACT_VERSION_1)
             .build();
         let later_updates = plan_mgs_updates(
@@ -587,8 +584,7 @@ mod test {
         let updated_collection = test_boards
             .collection_builder()
             .sp_versions(ARTIFACT_VERSION_2, ExpectedVersion::NoValidVersion)
-            .rot_active_version(ARTIFACT_VERSION_2)
-            .rot_inactive_version(ExpectedVersion::NoValidVersion)
+            .rot_versions(ARTIFACT_VERSION_2, ExpectedVersion::NoValidVersion)
             .build();
         let later_updates = plan_mgs_updates(
             log,
@@ -606,8 +602,7 @@ mod test {
         let collection = test_boards
             .collection_builder()
             .sp_versions(ARTIFACT_VERSION_2, ExpectedVersion::NoValidVersion)
-            .rot_active_version(ARTIFACT_VERSION_2)
-            .rot_inactive_version(ExpectedVersion::NoValidVersion)
+            .rot_versions(ARTIFACT_VERSION_2, ExpectedVersion::NoValidVersion)
             .sp_active_version_exception(SpType::Sled, 0, ARTIFACT_VERSION_1)
             .build();
         let updates = plan_mgs_updates(
@@ -658,8 +653,7 @@ mod test {
                 ARTIFACT_VERSION_2,
                 ExpectedVersion::Version(ARTIFACT_VERSION_1),
             )
-            .rot_active_version(ARTIFACT_VERSION_2)
-            .rot_inactive_version(ExpectedVersion::NoValidVersion)
+            .rot_versions(ARTIFACT_VERSION_2, ExpectedVersion::NoValidVersion)
             .sp_active_version_exception(SpType::Sled, 0, ARTIFACT_VERSION_1)
             .build();
         let new_updates = plan_mgs_updates(
@@ -699,8 +693,7 @@ mod test {
         let collection = test_boards
             .collection_builder()
             .sp_versions(ARTIFACT_VERSION_2, ExpectedVersion::NoValidVersion)
-            .rot_active_version(ARTIFACT_VERSION_2)
-            .rot_inactive_version(ExpectedVersion::NoValidVersion)
+            .rot_versions(ARTIFACT_VERSION_2, ExpectedVersion::NoValidVersion)
             .sp_active_version_exception(SpType::Sled, 0, ARTIFACT_VERSION_1_5)
             .build();
         let new_updates = plan_mgs_updates(
@@ -754,8 +747,7 @@ mod test {
         let collection = test_boards
             .collection_builder()
             .sp_versions(ARTIFACT_VERSION_2, ExpectedVersion::NoValidVersion)
-            .rot_active_version(ARTIFACT_VERSION_2)
-            .rot_inactive_version(ExpectedVersion::NoValidVersion)
+            .rot_versions(ARTIFACT_VERSION_2, ExpectedVersion::NoValidVersion)
             .rot_active_version_exception(SpType::Sled, 0, ARTIFACT_VERSION_1)
             .build();
         let current_boards = &collection.baseboards;
@@ -813,8 +805,7 @@ mod test {
         let later_collection = test_boards
             .collection_builder()
             .sp_versions(ARTIFACT_VERSION_2, ExpectedVersion::NoValidVersion)
-            .rot_active_version(ARTIFACT_VERSION_2)
-            .rot_inactive_version(ExpectedVersion::NoValidVersion)
+            .rot_versions(ARTIFACT_VERSION_2, ExpectedVersion::NoValidVersion)
             .rot_active_version_exception(SpType::Sled, 0, ARTIFACT_VERSION_1)
             .rot_active_version_exception(SpType::Switch, 1, ARTIFACT_VERSION_1)
             .build();
@@ -838,8 +829,7 @@ mod test {
         let later_collection = test_boards
             .collection_builder()
             .sp_versions(ARTIFACT_VERSION_2, ExpectedVersion::NoValidVersion)
-            .rot_active_version(ARTIFACT_VERSION_2)
-            .rot_inactive_version(ExpectedVersion::NoValidVersion)
+            .rot_versions(ARTIFACT_VERSION_2, ExpectedVersion::NoValidVersion)
             .sp_active_version_exception(SpType::Switch, 1, ARTIFACT_VERSION_1)
             .rot_active_version_exception(SpType::Switch, 1, ARTIFACT_VERSION_1)
             .build();
@@ -867,8 +857,7 @@ mod test {
         let updated_collection = test_boards
             .collection_builder()
             .sp_versions(ARTIFACT_VERSION_2, ExpectedVersion::NoValidVersion)
-            .rot_active_version(ARTIFACT_VERSION_2)
-            .rot_inactive_version(ExpectedVersion::NoValidVersion)
+            .rot_versions(ARTIFACT_VERSION_2, ExpectedVersion::NoValidVersion)
             .build();
         let later_updates = plan_mgs_updates(
             log,
@@ -886,8 +875,7 @@ mod test {
         let collection = test_boards
             .collection_builder()
             .sp_versions(ARTIFACT_VERSION_2, ExpectedVersion::NoValidVersion)
-            .rot_active_version(ARTIFACT_VERSION_2)
-            .rot_inactive_version(ExpectedVersion::NoValidVersion)
+            .rot_versions(ARTIFACT_VERSION_2, ExpectedVersion::NoValidVersion)
             .rot_active_version_exception(SpType::Sled, 0, ARTIFACT_VERSION_1)
             .build();
         let updates = plan_mgs_updates(
@@ -939,8 +927,10 @@ mod test {
                 ARTIFACT_VERSION_2,
                 ExpectedVersion::Version(ARTIFACT_VERSION_1),
             )
-            .rot_active_version(ARTIFACT_VERSION_2)
-            .rot_inactive_version(ExpectedVersion::Version(ARTIFACT_VERSION_1))
+            .rot_versions(
+                ARTIFACT_VERSION_2,
+                ExpectedVersion::Version(ARTIFACT_VERSION_1),
+            )
             .rot_active_version_exception(SpType::Sled, 0, ARTIFACT_VERSION_1)
             .build();
         let new_updates = plan_mgs_updates(
@@ -981,8 +971,7 @@ mod test {
         let collection = test_boards
             .collection_builder()
             .sp_versions(ARTIFACT_VERSION_2, ExpectedVersion::NoValidVersion)
-            .rot_active_version(ARTIFACT_VERSION_2)
-            .rot_inactive_version(ExpectedVersion::NoValidVersion)
+            .rot_versions(ARTIFACT_VERSION_2, ExpectedVersion::NoValidVersion)
             .rot_active_version_exception(SpType::Sled, 0, ARTIFACT_VERSION_1_5)
             .build();
         let new_updates = plan_mgs_updates(
@@ -1038,10 +1027,10 @@ mod test {
                 ARTIFACT_VERSION_2,
                 ExpectedVersion::Version(ARTIFACT_VERSION_1_5),
             )
-            .rot_active_version(ARTIFACT_VERSION_2)
-            .rot_inactive_version(ExpectedVersion::Version(
-                ARTIFACT_VERSION_1_5,
-            ))
+            .rot_versions(
+                ARTIFACT_VERSION_2,
+                ExpectedVersion::Version(ARTIFACT_VERSION_1_5),
+            )
             .sp_active_version_exception(SpType::Sled, 0, ARTIFACT_VERSION_1)
             .build();
         let current_boards = &collection.baseboards;
@@ -1096,10 +1085,10 @@ mod test {
         let collection = test_boards
             .collection_builder()
             .sp_versions(ARTIFACT_VERSION_2, ExpectedVersion::NoValidVersion)
-            .rot_active_version(ARTIFACT_VERSION_2)
-            .rot_inactive_version(ExpectedVersion::Version(
-                ARTIFACT_VERSION_1_5,
-            ))
+            .rot_versions(
+                ARTIFACT_VERSION_2,
+                ExpectedVersion::Version(ARTIFACT_VERSION_1_5),
+            )
             .sp_active_version_exception(SpType::Sled, 0, ARTIFACT_VERSION_1)
             .build();
 
@@ -1175,8 +1164,7 @@ mod test {
         let mut builder = test_boards
             .collection_builder()
             .sp_versions(ARTIFACT_VERSION_1, ExpectedVersion::NoValidVersion)
-            .rot_active_version(ARTIFACT_VERSION_1)
-            .rot_inactive_version(ExpectedVersion::NoValidVersion);
+            .rot_versions(ARTIFACT_VERSION_1, ExpectedVersion::NoValidVersion);
         for _ in 0..expected_updates.len() {
             let collection = builder.clone().build();
 
@@ -1272,8 +1260,7 @@ mod test {
         let collection = test_boards
             .collection_builder()
             .sp_versions(ARTIFACT_VERSION_1, ExpectedVersion::NoValidVersion)
-            .rot_active_version(ARTIFACT_VERSION_1)
-            .rot_inactive_version(ExpectedVersion::NoValidVersion)
+            .rot_versions(ARTIFACT_VERSION_1, ExpectedVersion::NoValidVersion)
             .build();
         let all_updates = plan_mgs_updates(
             log,
@@ -1302,8 +1289,7 @@ mod test {
         let collection = test_boards
             .collection_builder()
             .sp_versions(ARTIFACT_VERSION_1, ExpectedVersion::NoValidVersion)
-            .rot_active_version(ARTIFACT_VERSION_2)
-            .rot_inactive_version(ExpectedVersion::NoValidVersion)
+            .rot_versions(ARTIFACT_VERSION_2, ExpectedVersion::NoValidVersion)
             .build();
         let all_updates = plan_mgs_updates(
             log,
@@ -1335,8 +1321,7 @@ mod test {
         let collection = test_boards
             .collection_builder()
             .sp_versions(ARTIFACT_VERSION_2, ExpectedVersion::NoValidVersion)
-            .rot_active_version(ARTIFACT_VERSION_2)
-            .rot_inactive_version(ExpectedVersion::NoValidVersion)
+            .rot_versions(ARTIFACT_VERSION_2, ExpectedVersion::NoValidVersion)
             .build();
         let all_updates_done = plan_mgs_updates(
             log,
@@ -1368,8 +1353,7 @@ mod test {
         let mut collection = test_boards
             .collection_builder()
             .sp_versions(ARTIFACT_VERSION_2, ExpectedVersion::NoValidVersion)
-            .rot_active_version(ARTIFACT_VERSION_2)
-            .rot_inactive_version(ExpectedVersion::NoValidVersion)
+            .rot_versions(ARTIFACT_VERSION_2, ExpectedVersion::NoValidVersion)
             .sp_active_version_exception(SpType::Sled, 0, ARTIFACT_VERSION_1)
             .rot_active_version_exception(SpType::Sled, 0, ARTIFACT_VERSION_1)
             .build();

--- a/nexus/reconfigurator/planning/src/mgs_updates/test_helpers.rs
+++ b/nexus/reconfigurator/planning/src/mgs_updates/test_helpers.rs
@@ -1,0 +1,111 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at https://mozilla.org/MPL/2.0/.
+
+//! Test-only support code for testing MGS update planning.
+
+use gateway_client::types::SpIdentifier;
+use gateway_client::types::SpType;
+use iddqd::IdOrdItem;
+use iddqd::IdOrdMap;
+
+/// Hash of fake RoT signing keys
+const ROT_SIGN_GIMLET: &str =
+    "1111111111111111111111111111111111111111111111111111111111111111";
+const ROT_SIGN_PSC: &str =
+    "2222222222222222222222222222222222222222222222222222222222222222";
+const ROT_SIGN_SWITCH: &str =
+    "3333333333333333333333333333333333333333333333333333333333333333";
+
+/// Description of a single fake board (sled, switch, or PSC).
+#[derive(Debug)]
+pub(super) struct TestBoard {
+    pub(super) id: SpIdentifier,
+    pub(super) serial: &'static str,
+    pub(super) sp_board: &'static str,
+    pub(super) rot_board: &'static str,
+    pub(super) rot_sign: &'static str,
+}
+
+impl IdOrdItem for TestBoard {
+    type Key<'a> = SpIdentifier;
+
+    fn key(&self) -> Self::Key<'_> {
+        self.id
+    }
+
+    iddqd::id_upcast!();
+}
+
+/// Collection of [`TestBoard`]s used throughout MGS planning tests.
+#[derive(Debug)]
+pub(super) struct TestBoards {
+    boards: IdOrdMap<TestBoard>,
+}
+
+impl TestBoards {
+    /// Describes the SPs and RoTs in the environment used in these tests
+    ///
+    /// There will be:
+    ///
+    /// - 4 sled SPs
+    /// - 2 switch SPs
+    /// - 2 PSC SPs
+    ///
+    /// The specific set of hardware (boards) vary and are hardcoded:
+    ///
+    /// - sled 0: gimlet-d, oxide-rot-1
+    /// - other sleds: gimlet-e, oxide-rot-1
+    /// - switch 0: sidecar-b, oxide-rot-1
+    /// - switch 1: sidecar-c, oxide-rot-1
+    /// - psc 0: psc-b, oxide-rot-1
+    /// - psc 1: psc-c, oxide-rot-1
+    pub fn new() -> Self {
+        let mut boards = IdOrdMap::new();
+        for (type_, details) in [
+            (
+                SpType::Sled,
+                &[
+                    ("sled_0", "gimlet-d", "oxide-rot-1", ROT_SIGN_GIMLET),
+                    ("sled_1", "gimlet-e", "oxide-rot-1", ROT_SIGN_GIMLET),
+                    ("sled_2", "gimlet-e", "oxide-rot-1", ROT_SIGN_GIMLET),
+                    ("sled_3", "gimlet-e", "oxide-rot-1", ROT_SIGN_GIMLET),
+                ] as &[_],
+            ),
+            (
+                SpType::Switch,
+                &[
+                    ("switch_0", "sidecar-b", "oxide-rot-1", ROT_SIGN_SWITCH),
+                    ("switch_1", "sidecar-c", "oxide-rot-1", ROT_SIGN_SWITCH),
+                ],
+            ),
+            (
+                SpType::Power,
+                &[
+                    ("power_0", "psc-b", "oxide-rot-1", ROT_SIGN_PSC),
+                    ("power_1", "psc-c", "oxide-rot-1", ROT_SIGN_PSC),
+                ],
+            ),
+        ] {
+            for (slot, (serial, sp_board, rot_board, rot_sign)) in
+                details.into_iter().enumerate()
+            {
+                let slot = slot as u16;
+                boards
+                    .insert_unique(TestBoard {
+                        id: SpIdentifier { type_, slot },
+                        serial,
+                        sp_board,
+                        rot_board,
+                        rot_sign,
+                    })
+                    .expect("test board IDs are unique");
+            }
+        }
+        Self { boards }
+    }
+
+    pub fn into_iter(self) -> impl Iterator<Item = TestBoard> {
+        self.boards.into_iter()
+    }
+}

--- a/nexus/reconfigurator/planning/src/mgs_updates/test_helpers.rs
+++ b/nexus/reconfigurator/planning/src/mgs_updates/test_helpers.rs
@@ -450,10 +450,8 @@ impl ExpectedUpdates {
 ///
 /// After construction, the caller _must_ call:
 ///
-/// * `sp_active_version()`
-/// * `rot_active_version()`
-/// * `sp_inactive_version()`
-/// * `rot_inactive_version()`
+/// * `sp_versions()`
+/// * `rot_versions()`
 ///
 /// to set the default active and inactive versions reported for all SPs and
 /// RoTs. The caller may also call the various `*_exception` methods to override
@@ -487,13 +485,13 @@ impl<'a> TestBoardCollectionBuilder<'a> {
         }
     }
 
-    pub fn sp_active_version(mut self, v: ArtifactVersion) -> Self {
-        self.sp_active_version = Some(v);
-        self
-    }
-
-    pub fn sp_inactive_version(mut self, v: ExpectedVersion) -> Self {
-        self.sp_inactive_version = Some(v);
+    pub fn sp_versions(
+        mut self,
+        active: ArtifactVersion,
+        inactive: ExpectedVersion,
+    ) -> Self {
+        self.sp_active_version = Some(active);
+        self.sp_inactive_version = Some(inactive);
         self
     }
 

--- a/nexus/reconfigurator/planning/src/mgs_updates/test_helpers.rs
+++ b/nexus/reconfigurator/planning/src/mgs_updates/test_helpers.rs
@@ -4,10 +4,21 @@
 
 //! Test-only support code for testing MGS update planning.
 
+use std::collections::BTreeMap;
+
+use gateway_client::types::PowerState;
+use gateway_client::types::RotState;
+use gateway_client::types::SpComponentCaboose;
 use gateway_client::types::SpIdentifier;
+use gateway_client::types::SpState;
 use gateway_client::types::SpType;
+use gateway_types::rot::RotSlot;
 use iddqd::IdOrdItem;
 use iddqd::IdOrdMap;
+use nexus_types::deployment::ExpectedVersion;
+use nexus_types::inventory::CabooseWhich;
+use nexus_types::inventory::Collection;
+use tufaceous_artifact::ArtifactVersion;
 
 /// Hash of fake RoT signing keys
 const ROT_SIGN_GIMLET: &str =
@@ -40,6 +51,7 @@ impl IdOrdItem for TestBoard {
 /// Collection of [`TestBoard`]s used throughout MGS planning tests.
 #[derive(Debug)]
 pub(super) struct TestBoards {
+    test_name: &'static str,
     boards: IdOrdMap<TestBoard>,
 }
 
@@ -60,7 +72,7 @@ impl TestBoards {
     /// - switch 1: sidecar-c, oxide-rot-1
     /// - psc 0: psc-b, oxide-rot-1
     /// - psc 1: psc-c, oxide-rot-1
-    pub fn new() -> Self {
+    pub fn new(test_name: &'static str) -> Self {
         let mut boards = IdOrdMap::new();
         for (type_, details) in [
             (
@@ -102,10 +114,260 @@ impl TestBoards {
                     .expect("test board IDs are unique");
             }
         }
-        Self { boards }
+        Self { boards, test_name }
     }
 
     pub fn into_iter(self) -> impl Iterator<Item = TestBoard> {
         self.boards.into_iter()
+    }
+
+    /// Get a helper to build an inventory collection reflecting specific
+    /// versions of our test boards.
+    pub fn collection_builder<'a>(&'a self) -> TestBoardCollectionBuilder<'a> {
+        TestBoardCollectionBuilder::new(self)
+    }
+}
+
+/// Test helper that will produce an inventory collection.
+///
+/// After construction, the caller _must_ call:
+///
+/// * `sp_active_version()`
+/// * `rot_active_version()`
+/// * `sp_inactive_version()`
+/// * `rot_inactive_version()`
+///
+/// to set the default active and inactive versions reported for all SPs and
+/// RoTs. The caller may also call the various `*_exception` methods to override
+/// these defaults for specific boards. Once all properties have been set, call
+/// `build()` to produce a collection.
+#[derive(Debug, Clone)]
+pub(super) struct TestBoardCollectionBuilder<'a> {
+    boards: &'a TestBoards,
+
+    // fields that callers _must_ provide before calling `build()`
+    sp_active_version: Option<ArtifactVersion>,
+    sp_inactive_version: Option<ExpectedVersion>,
+    rot_active_version: Option<ArtifactVersion>,
+    rot_inactive_version: Option<ExpectedVersion>,
+
+    // fields that callers _may_ influence before calling `build()`
+    sp_active_version_exceptions: BTreeMap<SpIdentifier, ArtifactVersion>,
+    rot_active_version_exceptions: BTreeMap<SpIdentifier, ArtifactVersion>,
+}
+
+impl<'a> TestBoardCollectionBuilder<'a> {
+    fn new(boards: &'a TestBoards) -> Self {
+        Self {
+            boards,
+            sp_active_version: None,
+            sp_inactive_version: None,
+            rot_active_version: None,
+            rot_inactive_version: None,
+            sp_active_version_exceptions: BTreeMap::new(),
+            rot_active_version_exceptions: BTreeMap::new(),
+        }
+    }
+
+    pub fn sp_active_version(mut self, v: ArtifactVersion) -> Self {
+        self.sp_active_version = Some(v);
+        self
+    }
+
+    pub fn sp_inactive_version(mut self, v: ExpectedVersion) -> Self {
+        self.sp_inactive_version = Some(v);
+        self
+    }
+
+    pub fn sp_active_version_exception(
+        mut self,
+        type_: SpType,
+        slot: u16,
+        v: ArtifactVersion,
+    ) -> Self {
+        self.sp_active_version_exceptions
+            .insert(SpIdentifier { type_, slot }, v);
+        self
+    }
+
+    pub fn has_sp_active_version_exception(
+        &self,
+        type_: SpType,
+        slot: u16,
+    ) -> bool {
+        self.sp_active_version_exceptions
+            .contains_key(&SpIdentifier { type_, slot })
+    }
+
+    pub fn rot_active_version(mut self, v: ArtifactVersion) -> Self {
+        self.rot_active_version = Some(v);
+        self
+    }
+
+    pub fn rot_inactive_version(mut self, v: ExpectedVersion) -> Self {
+        self.rot_inactive_version = Some(v);
+        self
+    }
+
+    pub fn rot_active_version_exception(
+        mut self,
+        type_: SpType,
+        slot: u16,
+        v: ArtifactVersion,
+    ) -> Self {
+        self.rot_active_version_exceptions
+            .insert(SpIdentifier { type_, slot }, v);
+        self
+    }
+
+    pub fn has_rot_active_version_exception(
+        &self,
+        type_: SpType,
+        slot: u16,
+    ) -> bool {
+        self.rot_active_version_exceptions
+            .contains_key(&SpIdentifier { type_, slot })
+    }
+
+
+    pub fn build(self) -> Collection {
+        let sp_active_version =
+            self.sp_active_version.expect("sp_active_version() was provided");
+        let sp_inactive_version = self
+            .sp_inactive_version
+            .expect("sp_inactive_version() was provided");
+        let rot_active_version =
+            self.rot_active_version.expect("rot_active_version() was provided");
+        let rot_inactive_version = self
+            .rot_inactive_version
+            .expect("rot_inactive_version() was provided");
+
+        let mut builder =
+            nexus_inventory::CollectionBuilder::new(self.boards.test_name);
+
+        let dummy_sp_state = SpState {
+            base_mac_address: [0; 6],
+            hubris_archive_id: String::from("unused"),
+            model: String::from("unused"),
+            power_state: PowerState::A0,
+            revision: 0,
+            rot: RotState::V3 {
+                active: RotSlot::A,
+                pending_persistent_boot_preference: None,
+                persistent_boot_preference: RotSlot::A,
+                slot_a_error: None,
+                slot_a_fwid: Default::default(),
+                slot_b_error: None,
+                slot_b_fwid: Default::default(),
+                stage0_error: None,
+                stage0_fwid: Default::default(),
+                stage0next_error: None,
+                stage0next_fwid: Default::default(),
+                transient_boot_preference: None,
+            },
+            serial_number: String::from("unused"),
+        };
+
+        for board in &self.boards.boards {
+            let &TestBoard {
+                id: sp_id,
+                serial,
+                sp_board: caboose_sp_board,
+                rot_board: caboose_rot_board,
+                rot_sign: rkth,
+            } = board;
+
+            let sp_state = SpState {
+                model: format!("dummy_{}", sp_id.type_),
+                serial_number: serial.to_string(),
+                ..dummy_sp_state.clone()
+            };
+
+            let baseboard_id = builder
+                .found_sp_state("test", sp_id.type_, sp_id.slot, sp_state)
+                .unwrap();
+            let sp_active_version = self
+                .sp_active_version_exceptions
+                .get(&sp_id)
+                .unwrap_or(&sp_active_version);
+            let rot_active_version = self
+                .rot_active_version_exceptions
+                .get(&sp_id)
+                .unwrap_or(&rot_active_version);
+
+            builder
+                .found_caboose(
+                    &baseboard_id,
+                    CabooseWhich::SpSlot0,
+                    "test",
+                    SpComponentCaboose {
+                        board: caboose_sp_board.to_string(),
+                        epoch: None,
+                        git_commit: String::from("unused"),
+                        name: caboose_sp_board.to_string(),
+                        sign: None,
+                        version: sp_active_version.as_str().to_string(),
+                    },
+                )
+                .unwrap();
+
+            builder
+                .found_caboose(
+                    &baseboard_id,
+                    CabooseWhich::RotSlotA,
+                    "test",
+                    SpComponentCaboose {
+                        board: caboose_rot_board.to_string(),
+                        epoch: None,
+                        git_commit: String::from("unused"),
+                        name: caboose_rot_board.to_string(),
+                        sign: Some(rkth.to_string()),
+                        version: rot_active_version.as_str().to_string(),
+                    },
+                )
+                .unwrap();
+
+            if let ExpectedVersion::Version(sp_inactive_version) =
+                &sp_inactive_version
+            {
+                builder
+                    .found_caboose(
+                        &baseboard_id,
+                        CabooseWhich::SpSlot1,
+                        "test",
+                        SpComponentCaboose {
+                            board: caboose_sp_board.to_string(),
+                            epoch: None,
+                            git_commit: String::from("unused"),
+                            name: caboose_sp_board.to_string(),
+                            sign: None,
+                            version: sp_inactive_version.as_str().to_string(),
+                        },
+                    )
+                    .unwrap();
+            }
+
+            if let ExpectedVersion::Version(rot_inactive_version) =
+                &rot_inactive_version
+            {
+                builder
+                    .found_caboose(
+                        &baseboard_id,
+                        CabooseWhich::RotSlotB,
+                        "test",
+                        SpComponentCaboose {
+                            board: caboose_rot_board.to_string(),
+                            epoch: None,
+                            git_commit: String::from("unused"),
+                            name: caboose_rot_board.to_string(),
+                            sign: Some(rkth.to_string()),
+                            version: rot_inactive_version.as_str().to_string(),
+                        },
+                    )
+                    .unwrap();
+            }
+        }
+
+        builder.build()
     }
 }

--- a/nexus/reconfigurator/planning/src/mgs_updates/test_helpers.rs
+++ b/nexus/reconfigurator/planning/src/mgs_updates/test_helpers.rs
@@ -515,13 +515,13 @@ impl<'a> TestBoardCollectionBuilder<'a> {
             .contains_key(&SpIdentifier { type_, slot })
     }
 
-    pub fn rot_active_version(mut self, v: ArtifactVersion) -> Self {
-        self.rot_active_version = Some(v);
-        self
-    }
-
-    pub fn rot_inactive_version(mut self, v: ExpectedVersion) -> Self {
-        self.rot_inactive_version = Some(v);
+    pub fn rot_versions(
+        mut self,
+        active: ArtifactVersion,
+        inactive: ExpectedVersion,
+    ) -> Self {
+        self.rot_active_version = Some(active);
+        self.rot_inactive_version = Some(inactive);
         self
     }
 

--- a/nexus/reconfigurator/planning/src/mgs_updates/test_helpers.rs
+++ b/nexus/reconfigurator/planning/src/mgs_updates/test_helpers.rs
@@ -402,10 +402,19 @@ pub(super) struct ExpectedUpdates {
 }
 
 impl ExpectedUpdates {
+    pub fn is_empty(&self) -> bool {
+        self.updates.is_empty()
+    }
+
     pub fn len(&self) -> usize {
         self.updates.len()
     }
 
+    /// Confirm that `update` matches one of our expected updates, and _remove_
+    /// that update.
+    ///
+    /// Callers can confirm that all updates have been verified by calling this
+    /// method for each expected update and then checking `self.is_empty()`.
     pub fn verify_one(&mut self, update: &PendingMgsUpdate) {
         let sp_type = update.sp_type;
         let sp_slot = update.slot_id;


### PR DESCRIPTION
This is mostly because I found the existing support stuff pretty unwieldy when I went to try to extend it to do host OS updates too; e.g., this return type

```rust
    fn test_collection_config() -> BTreeMap<
        (SpType, u16),
        (&'static str, &'static str, &'static str, &'static str),
    > { .. }
```

and the arguments to this function

```rust
    fn make_collection(
        active_version: ArtifactVersion,
        active_version_exceptions: &BTreeMap<(SpType, u16), ArtifactVersion>,
        inactive_version: ExpectedVersion,
        active_rot_version: ArtifactVersion,
        active_rot_version_exceptions: &BTreeMap<
            (SpType, u16),
            ArtifactVersion,
        >,
        inactive_rot_version: ExpectedVersion,
    ) -> Collection { .. }
```

are already pretty rough, and I was only going to make that worse by adding host OS stuff to them.

I took a stab at pulling this out and putting some names on things; I'm sure there's more that could be done (and we may want to do that as we add host OS and bootloader tests), but figured this was a decent stopping point.

The changes here are _mostly_ refactoring. I did add one extra assertion: we had a couple tests that would build a set of `expected_updates`, then confirm all the updates produced by planning were present in `expected_updates`. But they weren't confirming that we'd seen _all_ the expected updates. When I added this assertion, the `test_whole_system_simultaneous()` test failed. I think this is because we can't actually update the whole system simultaneously: we do at most one kind of update to a given board at once. I reworked this test some to "update all the RoTs" then "update all the SPs" instead.

In terms of reviewing, I'd probably look mostly at the reworked tests themselves and see if these changes are a clarity improvement. The changes there are a lot smaller than the diff, since all of the supporting code moved around. This will conflict with #8664; I'm happy to do the work to merge those together. (It looks like we had similar ideas; e.g., about `make_collection()` not really being sustainable as it was written!)

I think with these changes we could also move the respective SP / RoT tests into their submodules instead of leaving them all in the higher-level `mod.rs`.