### PR TITLE
[nexus] re-enable `sp_ereport_ingester` post-R16

### DIFF
--- a/smf/nexus/multi-sled/config-partial.toml
+++ b/smf/nexus/multi-sled/config-partial.toml
@@ -83,10 +83,6 @@ read_only_region_replacement_start.period_secs = 30
 alert_dispatcher.period_secs = 60
 webhook_deliverator.period_secs = 60
 sp_ereport_ingester.period_secs = 30
-# Disabled in R16, as the Hubris task that handles ereport ingestion requests
-# has not merged yet, and trying to ingest them will just result in Nexus
-# logging a bunch of errors.
-sp_ereport_ingester.disable = true
 
 [default_region_allocation_strategy]
 # by default, allocate across 3 distinct sleds

--- a/smf/nexus/single-sled/config-partial.toml
+++ b/smf/nexus/single-sled/config-partial.toml
@@ -83,10 +83,6 @@ read_only_region_replacement_start.period_secs = 30
 alert_dispatcher.period_secs = 60
 webhook_deliverator.period_secs = 60
 sp_ereport_ingester.period_secs = 30
-# Disabled in R16, as the Hubris task that handles ereport ingestion requests
-# has not merged yet, and trying to ingest them will just result in Nexus
-# logging a bunch of errors.
-sp_ereport_ingester.disable = true
 
 [default_region_allocation_strategy]
 # by default, allocate without requirement for distinct sleds.


### PR DESCRIPTION
For R16, the `sp_ereport_ingester` background task was disabled in the production Nexus config file (see #8709). This is because the corresponding Hubris code for evacuating ereports from the SP had not yet merged, resulting in Nexus yelling constantly about trying to collect ereports from SPs that weren't listening on the ereport port. Now, however, oxidecomputer/hubris#2126 has merged, and R16 has been cut, so we can turn this back on. This commit does that.