### PR TITLE
update to Rust 1.89

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1049,9 +1049,9 @@ dependencies = [
 
 [[package]]
 name = "camino"
-version = "1.1.10"
+version = "1.1.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0da45bc31171d8d6960122e222a67740df867c1dd53b4d51caa297084c185cab"
+checksum = "5d07aa9a93b00c76f71bc35d598bed923f6d4f3a9ca5c24b7737ae1a292841c0"
 dependencies = [
  "serde",
 ]
@@ -2916,9 +2916,9 @@ dependencies = [
 
 [[package]]
 name = "dropshot"
-version = "0.16.2"
+version = "0.16.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "50e8fed669e35e757646ad10f97c4d26dd22cce3da689b307954f7000d2719d0"
+checksum = "eedf902e40c1024b8ed9ca16378a54e9655cdf0e698245ba82d81a3778dcbc54"
 dependencies = [
  "async-stream",
  "async-trait",
@@ -2958,7 +2958,7 @@ dependencies = [
  "thiserror 2.0.12",
  "tokio",
  "tokio-rustls 0.25.0",
- "toml 0.8.23",
+ "toml 0.9.5",
  "usdt",
  "uuid",
  "version_check",
@@ -2967,9 +2967,9 @@ dependencies = [
 
 [[package]]
 name = "dropshot_endpoint"
-version = "0.16.2"
+version = "0.16.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "acebb687581abdeaa2c89fa448818a5f803b0e68e5d7e7a1cf585a8f3c5c57ac"
+checksum = "085c02a4c441ce91e77db3f9a8d1a2d557fc13f5d594dac98a5b389781a8642e"
 dependencies = [
  "heck 0.5.0",
  "proc-macro2",
@@ -5650,7 +5650,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4979f22fdb869068da03c9f7528f8297c6fd2606bc3a4affe42e6a823fdb8da4"
 dependencies = [
  "cfg-if",
- "windows-targets 0.48.5",
+ "windows-targets 0.52.6",
 ]
 
 [[package]]
@@ -8623,6 +8623,7 @@ dependencies = [
  "usdt-impl",
  "uuid",
  "winnow 0.6.26",
+ "winnow 0.7.10",
  "x509-cert",
  "zerocopy 0.7.35",
  "zerocopy 0.8.26",
@@ -11954,9 +11955,9 @@ dependencies = [
 
 [[package]]
 name = "serde_json"
-version = "1.0.141"
+version = "1.0.142"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "30b9eff21ebe718216c6ec64e1d9ac57087aad11efc64e32002bce4a0d4c03d3"
+checksum = "030fedb782600dcbd6f02d479bf0d817ac3bb40d644745b769d6a96bc3afc5a7"
 dependencies = [
  "itoa",
  "memchr",
@@ -13817,9 +13818,9 @@ dependencies = [
 
 [[package]]
 name = "toml"
-version = "0.9.2"
+version = "0.9.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ed0aee96c12fa71097902e0bb061a5e1ebd766a6636bb605ba401c45c1650eac"
+checksum = "75129e1dc5000bfbaa9fee9d1b21f974f9fbad9daec557a521ee6e080825f6e8"
 dependencies = [
  "indexmap 2.10.0",
  "serde",
@@ -13877,9 +13878,9 @@ dependencies = [
 
 [[package]]
 name = "toml_parser"
-version = "1.0.1"
+version = "1.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "97200572db069e74c512a14117b296ba0a80a30123fbbb5aa1f4a348f639ca30"
+checksum = "b551886f449aa90d4fe2bdaa9f4a2577ad2dde302c61ecf262d80b116db95c10"
 dependencies = [
  "winnow 0.7.10",
 ]
@@ -14194,7 +14195,7 @@ dependencies = [
  "serde_json",
  "target-triple",
  "termcolor",
- "toml 0.9.2",
+ "toml 0.9.5",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -374,7 +374,7 @@ bootstrap-agent-client = { path = "clients/bootstrap-agent-client" }
 buf-list = { version = "1.0.3", features = ["tokio1"] }
 byteorder = "1.5.0"
 bytes = "1.10.1"
-camino = { version = "1.1", features = ["serde1"] }
+camino = { version = "1.1.11", features = ["serde1"] }
 camino-tempfile = "1.4.1"
 camino-tempfile-ext = { version = "0.3.2", features = ["assert-color"] }
 cancel-safe-futures = "0.1.5"
@@ -429,7 +429,7 @@ dns-server = { path = "dns-server" }
 dns-server-api = { path = "dns-server-api" }
 dns-service-client = { path = "clients/dns-service-client" }
 dpd-client = { git = "https://github.com/oxidecomputer/dendrite", rev = "6e666520620e26432333d9060bc7d249ba9fa92e" }
-dropshot = { version = "0.16.2", features = [ "usdt-probes" ] }
+dropshot = { version = "0.16.3", features = [ "usdt-probes" ] }
 dyn-clone = "1.0.19"
 either = "1.15.0"
 ereport-types = { path = "ereport/types" }
@@ -672,7 +672,7 @@ semver = { version = "1.0.26", features = ["std", "serde"] }
 serde = { version = "1.0", default-features = false, features = [ "derive", "rc" ] }
 serde_cbor = "0.11.2"
 serde_human_bytes = { git = "https://github.com/oxidecomputer/serde_human_bytes", branch = "main" }
-serde_json = "1.0.141"
+serde_json = "1.0.142"
 serde_tokenstream = "0.2"
 serde_urlencoded = "0.7.1"
 serde_with = { version = "3.14.0", default-features = false, features = ["alloc", "macros"] }

--- a/common/src/api/external/http_pagination.rs
+++ b/common/src/api/external/http_pagination.rs
@@ -200,7 +200,7 @@ where
 fn data_page_params_with_limit<S>(
     limit: NonZeroU32,
     pag_params: &PaginationParams<S, PageSelector<S, S::MarkerValue>>,
-) -> Result<DataPageParams<S::MarkerValue>, HttpError>
+) -> Result<DataPageParams<'_, S::MarkerValue>, HttpError>
 where
     S: ScanParams,
 {

--- a/dev-tools/openapi-manager/src/resolved.rs
+++ b/dev-tools/openapi-manager/src/resolved.rs
@@ -560,11 +560,11 @@ impl<'a> Resolved<'a> {
         &self,
         ident: &ApiIdent,
         version: &semver::Version,
-    ) -> Option<&Resolution> {
+    ) -> Option<&Resolution<'_>> {
         self.api_results.get(ident).and_then(|v| v.by_version.get(version))
     }
 
-    pub fn symlink_problem(&self, ident: &ApiIdent) -> Option<&Problem> {
+    pub fn symlink_problem(&self, ident: &ApiIdent) -> Option<&Problem<'_>> {
         self.api_results.get(ident).and_then(|v| v.symlink.as_ref())
     }
 

--- a/nexus-sled-agent-shared/src/inventory.rs
+++ b/nexus-sled-agent-shared/src/inventory.rs
@@ -558,7 +558,7 @@ impl ZoneManifestBootInventory {
     }
 
     /// Returns a displayer for this inventory.
-    pub fn display(&self) -> ZoneManifestBootInventoryDisplay {
+    pub fn display(&self) -> ZoneManifestBootInventoryDisplay<'_> {
         ZoneManifestBootInventoryDisplay { inner: self }
     }
 }

--- a/nexus/db-model/src/l4_port_range.rs
+++ b/nexus/db-model/src/l4_port_range.rs
@@ -24,7 +24,7 @@ NewtypeDeref! { () pub struct L4PortRange(external::L4PortRange); }
 impl DatabaseString for L4PortRange {
     type Error = <external::L4PortRange as FromStr>::Err;
 
-    fn to_database_string(&self) -> Cow<str> {
+    fn to_database_string(&self) -> Cow<'_, str> {
         self.0.to_string().into()
     }
 

--- a/nexus/db-model/src/lib.rs
+++ b/nexus/db-model/src/lib.rs
@@ -432,7 +432,7 @@ pub(crate) use impl_from_sql_text;
 pub trait DatabaseString: Sized {
     type Error: std::fmt::Display;
 
-    fn to_database_string(&self) -> Cow<str>;
+    fn to_database_string(&self) -> Cow<'_, str>;
     fn from_database_string(s: &str) -> Result<Self, Self::Error>;
 }
 
@@ -445,7 +445,7 @@ use std::borrow::Cow;
 impl DatabaseString for FleetRole {
     type Error = anyhow::Error;
 
-    fn to_database_string(&self) -> Cow<str> {
+    fn to_database_string(&self) -> Cow<'_, str> {
         match self {
             FleetRole::Admin => "admin",
             FleetRole::Collaborator => "collaborator",
@@ -470,7 +470,7 @@ impl DatabaseString for FleetRole {
 impl DatabaseString for SiloRole {
     type Error = anyhow::Error;
 
-    fn to_database_string(&self) -> Cow<str> {
+    fn to_database_string(&self) -> Cow<'_, str> {
         match self {
             SiloRole::Admin => "admin",
             SiloRole::Collaborator => "collaborator",
@@ -495,7 +495,7 @@ impl DatabaseString for SiloRole {
 impl DatabaseString for ProjectRole {
     type Error = anyhow::Error;
 
-    fn to_database_string(&self) -> Cow<str> {
+    fn to_database_string(&self) -> Cow<'_, str> {
         match self {
             ProjectRole::Admin => "admin",
             ProjectRole::Collaborator => "collaborator",

--- a/nexus/db-model/src/role_assignment.rs
+++ b/nexus/db-model/src/role_assignment.rs
@@ -129,7 +129,7 @@ mod tests {
     impl crate::DatabaseString for DummyRoles {
         type Error = anyhow::Error;
 
-        fn to_database_string(&self) -> Cow<str> {
+        fn to_database_string(&self) -> Cow<'_, str> {
             unimplemented!()
         }
 

--- a/nexus/db-model/src/vpc_firewall_rule.rs
+++ b/nexus/db-model/src/vpc_firewall_rule.rs
@@ -70,7 +70,7 @@ NewtypeDeref! { () pub struct VpcFirewallRuleProtocol(external::VpcFirewallRuleP
 impl DatabaseString for VpcFirewallRuleProtocol {
     type Error = <external::VpcFirewallRuleProtocol as FromStr>::Err;
 
-    fn to_database_string(&self) -> Cow<str> {
+    fn to_database_string(&self) -> Cow<'_, str> {
         self.0.to_string().into()
     }
 
@@ -93,7 +93,7 @@ NewtypeDeref! { () pub struct VpcFirewallRuleTarget(external::VpcFirewallRuleTar
 impl DatabaseString for VpcFirewallRuleTarget {
     type Error = <external::VpcFirewallRuleTarget as FromStr>::Err;
 
-    fn to_database_string(&self) -> Cow<str> {
+    fn to_database_string(&self) -> Cow<'_, str> {
         self.0.to_string().into()
     }
 
@@ -116,7 +116,7 @@ NewtypeDeref! { () pub struct VpcFirewallRuleHostFilter(external::VpcFirewallRul
 impl DatabaseString for VpcFirewallRuleHostFilter {
     type Error = <external::VpcFirewallRuleHostFilter as FromStr>::Err;
 
-    fn to_database_string(&self) -> Cow<str> {
+    fn to_database_string(&self) -> Cow<'_, str> {
         self.0.to_string().into()
     }
 

--- a/nexus/db-model/src/vpc_route.rs
+++ b/nexus/db-model/src/vpc_route.rs
@@ -35,7 +35,7 @@ pub struct RouteTarget(pub external::RouteTarget);
 impl DatabaseString for RouteTarget {
     type Error = <external::RouteTarget as FromStr>::Err;
 
-    fn to_database_string(&self) -> Cow<str> {
+    fn to_database_string(&self) -> Cow<'_, str> {
         self.0.to_string().into()
     }
 
@@ -63,7 +63,7 @@ impl RouteDestination {
 impl DatabaseString for RouteDestination {
     type Error = <external::RouteDestination as FromStr>::Err;
 
-    fn to_database_string(&self) -> Cow<str> {
+    fn to_database_string(&self) -> Cow<'_, str> {
         self.0.to_string().into()
     }
 

--- a/nexus/db-queries/src/db/datastore/inventory.rs
+++ b/nexus/db-queries/src/db/datastore/inventory.rs
@@ -4371,13 +4371,13 @@ pub trait DataStoreInventoryTest: Send + Sync {
     /// This does not paginate.
     fn inventory_collections(
         &self,
-    ) -> BoxFuture<anyhow::Result<Vec<InvCollection>>>;
+    ) -> BoxFuture<'_, anyhow::Result<Vec<InvCollection>>>;
 }
 
 impl DataStoreInventoryTest for DataStore {
     fn inventory_collections(
         &self,
-    ) -> BoxFuture<anyhow::Result<Vec<InvCollection>>> {
+    ) -> BoxFuture<'_, anyhow::Result<Vec<InvCollection>>> {
         async {
             let conn = self
                 .pool_connection_for_tests()

--- a/nexus/db-queries/src/db/datastore/rendezvous_debug_dataset.rs
+++ b/nexus/db-queries/src/db/datastore/rendezvous_debug_dataset.rs
@@ -248,7 +248,7 @@ mod tests {
             .expect("inserted dataset");
         assert_eq!(
             datastore.debug_dataset_list_all_batched(opctx).await.unwrap(),
-            [dataset.clone()],
+            std::slice::from_ref(&dataset),
         );
 
         // Tombstoning it should now succeed, and we should see the tombstoned

--- a/nexus/src/app/mod.rs
+++ b/nexus/src/app/mod.rs
@@ -1052,7 +1052,7 @@ impl Nexus {
 
     pub(crate) fn demo_sagas(
         &self,
-    ) -> Result<std::sync::MutexGuard<CompletingDemoSagas>, Error> {
+    ) -> Result<std::sync::MutexGuard<'_, CompletingDemoSagas>, Error> {
         self.demo_sagas.lock().map_err(|error| {
             Error::internal_error(&format!(
                 "failed to acquire demo_sagas lock: {:#}",

--- a/nexus/test-utils/src/resource_helpers.rs
+++ b/nexus/test-utils/src/resource_helpers.rs
@@ -1523,7 +1523,7 @@ impl<'a, N: NexusServer> DiskTest<'a, N> {
             .expect("Cannot find sled")
     }
 
-    pub fn zpools(&self) -> ZpoolIterator {
+    pub fn zpools(&self) -> ZpoolIterator<'_> {
         ZpoolIterator {
             sleds: &self.sleds,
             sled: self.sleds.keys().next().copied(),

--- a/nexus/tests/integration_tests/silos.rs
+++ b/nexus/tests/integration_tests/silos.rs
@@ -2004,7 +2004,7 @@ async fn test_local_silo_users(cptestctx: &ControlPlaneTestContext) {
         client,
         &silo1,
         &AuthnMode::SiloUser(admin_user.id),
-        &[admin_user.clone()],
+        std::slice::from_ref(&admin_user),
     )
     .await;
 }

--- a/nexus/tests/integration_tests/updates.rs
+++ b/nexus/tests/integration_tests/updates.rs
@@ -591,7 +591,7 @@ async fn test_trust_root_operations(cptestctx: &ControlPlaneTestContext) {
         .expect("trust root list failed")
         .parsed_body()
         .expect("failed to parse list response");
-    assert_eq!(response.items, &[trust_root_view.clone()]);
+    assert_eq!(response.items, std::slice::from_ref(&trust_root_view.clone()));
 
     // GET /v1/system/update/trust-roots/{id}
     let id_url = format!("{TRUST_ROOTS_URL}/{}", trust_root_view.id);

--- a/oximeter/db/src/client/mod.rs
+++ b/oximeter/db/src/client/mod.rs
@@ -1907,6 +1907,7 @@ mod tests {
 
     mod type_mismatch {
         #[derive(oximeter::Target)]
+        #[expect(dead_code)]
         pub struct TestTarget {
             pub name1: uuid::Uuid,
             pub name2: String,
@@ -1983,7 +1984,7 @@ mod tests {
         client.schema.lock().await.clear();
 
         // Insert the new sample
-        client.insert_samples(&[sample.clone()]).await.unwrap();
+        client.insert_samples(std::slice::from_ref(&sample)).await.unwrap();
 
         // The internal map should now contain both the new timeseries schema
         let actual_schema = TimeseriesSchema::from(&sample);
@@ -3549,7 +3550,7 @@ mod tests {
         // the database data hasn't been dropped.
         assert_eq!(0, get_schema_count(&client, None).await);
         let sample = oximeter_test_utils::make_sample();
-        client.insert_samples(&[sample.clone()]).await.unwrap();
+        client.insert_samples(std::slice::from_ref(&sample)).await.unwrap();
         assert_eq!(1, get_schema_count(&client, None).await);
 
         // Re-initialize the database, see that our data still exists

--- a/oximeter/db/src/oxql/query/mod.rs
+++ b/oximeter/db/src/oxql/query/mod.rs
@@ -480,7 +480,8 @@ mod tests {
             }),
         };
         assert_eq!(
-            restrict_filter_idents(&filter, &[ident.clone()]).unwrap(),
+            restrict_filter_idents(&filter, std::slice::from_ref(&ident))
+                .unwrap(),
             filter
         );
         assert_eq!(restrict_filter_idents(&filter, &[]), None);

--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -2,5 +2,5 @@
 # We choose a specific toolchain (rather than "stable") for repeatability.  The
 # intent is to keep this up-to-date with recently-released stable Rust.
 
-channel = "1.88.0"
+channel = "1.89.0"
 profile = "default"

--- a/sled-agent/config-reconciler/src/dataset_serialization_task.rs
+++ b/sled-agent/config-reconciler/src/dataset_serialization_task.rs
@@ -1040,7 +1040,7 @@ impl DatasetTask {
         let root_path = dataset.full_name();
         let get_properties_result = zfs
             .get_dataset_properties(
-                &[root_path.clone()],
+                std::slice::from_ref(&root_path),
                 WhichDatasets::SelfAndChildren,
             )
             .await;

--- a/sled-agent/src/sim/storage.rs
+++ b/sled-agent/src/sim/storage.rs
@@ -1291,7 +1291,7 @@ impl Storage {
         }
     }
 
-    pub fn lock(&self) -> std::sync::MutexGuard<StorageInner> {
+    pub fn lock(&self) -> std::sync::MutexGuard<'_, StorageInner> {
         self.inner.lock().unwrap()
     }
 

--- a/sled-agent/src/support_bundle/storage.rs
+++ b/sled-agent/src/support_bundle/storage.rs
@@ -1120,7 +1120,7 @@ mod tests {
         ) -> Result<DatasetProperties, Error> {
             let Some(dataset) =
                 illumos_utils::zfs::Zfs::get_dataset_properties(
-                    &[dataset_name.clone()],
+                    std::slice::from_ref(dataset_name),
                     illumos_utils::zfs::WhichDatasets::SelfOnly,
                 )
                 .await

--- a/sled-agent/src/support_bundle/storage.rs
+++ b/sled-agent/src/support_bundle/storage.rs
@@ -220,7 +220,7 @@ impl LocalStorage for ConfigReconcilerHandle {
         dataset_name: &String,
     ) -> Result<DatasetProperties, Error> {
         let Some(dataset) = illumos_utils::zfs::Zfs::get_dataset_properties(
-            &[dataset_name.clone()],
+            std::slice::from_ref(dataset_name),
             illumos_utils::zfs::WhichDatasets::SelfOnly,
         )
         .await

--- a/sled-diagnostics/src/logs.rs
+++ b/sled-diagnostics/src/logs.rs
@@ -853,7 +853,7 @@ fn sort_cockroach_extra_logs(logs: &[LogFile]) -> HashMap<&str, ExtraLogs<'_>> {
 /// - service-1.log.4
 /// - service-2.stderr.log
 /// - service-2.stderr.log.2
-fn parse_extra_log(logfile: &LogFile) -> Option<ExtraLogKind> {
+fn parse_extra_log(logfile: &LogFile) -> Option<ExtraLogKind<'_>> {
     static RE: LazyLock<Regex> = LazyLock::new(|| {
         //Regex explanation:
         // ^                : start of the line

--- a/test-utils/src/dev/clickhouse.rs
+++ b/test-utils/src/dev/clickhouse.rs
@@ -1106,7 +1106,7 @@ impl ClickHouseCluster {
     // This is pretty hacky, but used to wait _any_ child in
     // `wait_for_shutdown()`, along with child kind and its index among that
     // kind.
-    fn children_mut(&mut self) -> impl Iterator<Item = ChildWaitInfo> {
+    fn children_mut(&mut self) -> impl Iterator<Item = ChildWaitInfo<'_>> {
         let keepers =
             self.keepers.iter_mut().enumerate().map(|(index, keeper)| {
                 ChildWaitInfo {

--- a/trust-quorum/src/crypto.rs
+++ b/trust-quorum/src/crypto.rs
@@ -473,8 +473,7 @@ mod tests {
         let res = RackSecret::reconstruct(
             &shares.shares.expose_secret()[0..(input.threshold - 2) as usize],
         );
-        if res.is_ok() {
-            let rs = res.unwrap();
+        if let Ok(rs) = res {
             prop_assert_ne!(rs.expose_secret(), original.expose_secret());
         }
 

--- a/typed-rng/src/lib.rs
+++ b/typed-rng/src/lib.rs
@@ -262,6 +262,7 @@ mod tests {
     // Test that TypedRng<T, ...> is Send and Sync even if T isn't.
     const _: fn() = || {
         fn assert_send_sync<T: Send + Sync>() {}
+        #[expect(dead_code)]
         struct NotSendSync(*mut u8);
         assert_send_sync::<TypedRng<NotSendSync, StdRng>>();
     };

--- a/wicket/src/state/update.rs
+++ b/wicket/src/state/update.rs
@@ -94,7 +94,7 @@ impl RackUpdateState {
         }
     }
 
-    pub fn item_state(&self, component: ComponentId) -> UpdateItemState {
+    pub fn item_state(&self, component: ComponentId) -> UpdateItemState<'_> {
         if self.artifacts.is_empty() {
             UpdateItemState::AwaitingRepository
         } else {

--- a/wicket/src/ui/panes/overview.rs
+++ b/wicket/src/ui/panes/overview.rs
@@ -465,7 +465,7 @@ impl Control for InventoryView {
     }
 }
 
-fn inventory_description(component: &Component) -> Text {
+fn inventory_description(component: &Component) -> Text<'_> {
     let sp = component.sp();
 
     let label_style = style::text_label();

--- a/workspace-hack/Cargo.toml
+++ b/workspace-hack/Cargo.toml
@@ -116,7 +116,7 @@ schemars = { version = "0.8.22", features = ["bytes", "chrono", "semver", "url",
 scopeguard = { version = "1.2.0" }
 semver = { version = "1.0.26", features = ["serde"] }
 serde = { version = "1.0.219", features = ["alloc", "derive", "rc"] }
-serde_json = { version = "1.0.141", features = ["raw_value", "unbounded_depth"] }
+serde_json = { version = "1.0.142", features = ["raw_value", "unbounded_depth"] }
 sha1 = { version = "0.10.6", features = ["oid"] }
 sha2 = { version = "0.10.9", features = ["oid"] }
 similar = { version = "2.7.0", features = ["bytes", "inline", "unicode"] }
@@ -145,6 +145,7 @@ url = { version = "2.5.4", features = ["serde"] }
 usdt = { version = "0.5.0" }
 usdt-impl = { version = "0.5.0", default-features = false, features = ["asm", "des"] }
 uuid = { version = "1.17.0", features = ["serde", "v4"] }
+winnow-ca01ad9e24f5d932 = { package = "winnow", version = "0.7.10" }
 x509-cert = { version = "0.2.5" }
 zerocopy-c38e5c1d305a1b54 = { package = "zerocopy", version = "0.8.26", default-features = false, features = ["derive", "simd"] }
 zerocopy-ca01ad9e24f5d932 = { package = "zerocopy", version = "0.7.35", features = ["derive", "simd"] }
@@ -252,7 +253,7 @@ schemars = { version = "0.8.22", features = ["bytes", "chrono", "semver", "url",
 scopeguard = { version = "1.2.0" }
 semver = { version = "1.0.26", features = ["serde"] }
 serde = { version = "1.0.219", features = ["alloc", "derive", "rc"] }
-serde_json = { version = "1.0.141", features = ["raw_value", "unbounded_depth"] }
+serde_json = { version = "1.0.142", features = ["raw_value", "unbounded_depth"] }
 sha1 = { version = "0.10.6", features = ["oid"] }
 sha2 = { version = "0.10.9", features = ["oid"] }
 similar = { version = "2.7.0", features = ["bytes", "inline", "unicode"] }
@@ -283,6 +284,7 @@ url = { version = "2.5.4", features = ["serde"] }
 usdt = { version = "0.5.0" }
 usdt-impl = { version = "0.5.0", default-features = false, features = ["asm", "des"] }
 uuid = { version = "1.17.0", features = ["serde", "v4"] }
+winnow-ca01ad9e24f5d932 = { package = "winnow", version = "0.7.10" }
 x509-cert = { version = "0.2.5" }
 zerocopy-c38e5c1d305a1b54 = { package = "zerocopy", version = "0.8.26", default-features = false, features = ["derive", "simd"] }
 zerocopy-ca01ad9e24f5d932 = { package = "zerocopy", version = "0.7.35", features = ["derive", "simd"] }
@@ -367,7 +369,7 @@ mio = { version = "1.0.2", features = ["net", "os-ext"] }
 rustix-d585fab2519d2d1 = { package = "rustix", version = "0.38.37", features = ["event", "fs", "net", "pipe", "process", "stdio", "system", "termios", "time"] }
 rustix-dff4ba8e3ae991db = { package = "rustix", version = "1.0.7", features = ["fs", "stdio", "termios"] }
 toml_edit-cdcf2f9584511fe6 = { package = "toml_edit", version = "0.19.15", features = ["serde"] }
-winnow = { version = "0.6.26", features = ["simd"] }
+winnow-3b31131e45eafb45 = { package = "winnow", version = "0.6.26", features = ["simd"] }
 
 [target.x86_64-unknown-illumos.build-dependencies]
 bitflags-f595c2ba2a3f28df = { package = "bitflags", version = "2.9.1", default-features = false, features = ["std"] }
@@ -383,6 +385,6 @@ mio = { version = "1.0.2", features = ["net", "os-ext"] }
 rustix-d585fab2519d2d1 = { package = "rustix", version = "0.38.37", features = ["event", "fs", "net", "pipe", "process", "stdio", "system", "termios", "time"] }
 rustix-dff4ba8e3ae991db = { package = "rustix", version = "1.0.7", features = ["fs", "stdio", "termios"] }
 toml_edit-cdcf2f9584511fe6 = { package = "toml_edit", version = "0.19.15", features = ["serde"] }
-winnow = { version = "0.6.26", features = ["simd"] }
+winnow-3b31131e45eafb45 = { package = "winnow", version = "0.6.26", features = ["simd"] }
 
 ### END HAKARI SECTION


### PR DESCRIPTION
Update Dropshot to 0.16.3 to address a new lint warning (thanks @ahl for getting it out!), plus some other dependency updates that Dropshot pulled in.