### PR TITLE
Add boolean `fleet_viewer` and `silo_admin` to `/v1/me` response

### DIFF
--- a/nexus/src/external_api/http_entrypoints.rs
+++ b/nexus/src/external_api/http_entrypoints.rs
@@ -7152,17 +7152,28 @@ impl NexusExternalApi for NexusExternalApiImpl {
             let (authz_silo, silo) =
                 nexus.current_silo_lookup(&opctx)?.fetch().await?;
 
+            // only eat Forbidden errors indicating lack of perms. other errors
+            // blow up normally
+            let fleet_viewer =
+                match opctx.authorize(authz::Action::Read, &authz::FLEET).await
+                {
+                    Ok(()) => true,
+                    Err(Error::Forbidden) => false,
+                    Err(e) => return Err(e.into()),
+                };
+            let silo_admin =
+                match opctx.authorize(authz::Action::Modify, &authz_silo).await
+                {
+                    Ok(()) => true,
+                    Err(Error::Forbidden) => false,
+                    Err(e) => return Err(e.into()),
+                };
+
             Ok(HttpResponseOk(views::CurrentUser {
                 user: user.into(),
                 silo_name: silo.name().clone(),
-                fleet_viewer: opctx
-                    .authorize(authz::Action::Read, &authz::FLEET)
-                    .await
-                    .is_ok(),
-                silo_admin: opctx
-                    .authorize(authz::Action::Modify, &authz_silo)
-                    .await
-                    .is_ok(),
+                fleet_viewer,
+                silo_admin,
             }))
         };
         apictx

--- a/nexus/types/src/external_api/views.rs
+++ b/nexus/types/src/external_api/views.rs
@@ -955,9 +955,18 @@ pub struct User {
 pub struct CurrentUser {
     #[serde(flatten)]
     pub user: User,
-
     /** Name of the silo to which this user belongs. */
     pub silo_name: Name,
+    /**
+     * Whether this user has the viewer role on the fleet. Used by the web
+     * console to determine whether to show system-level UI.
+     */
+    pub fleet_viewer: bool,
+    /**
+     * Whether this user has the admin role on their silo. Used by the web
+     * console to determine whether to show admin-only UI elements.
+     */
+    pub silo_admin: bool,
 }
 
 // SILO GROUPS

--- a/openapi/nexus.json
+++ b/openapi/nexus.json
@@ -16819,9 +16819,17 @@
             "description": "Human-readable name that can identify the user",
             "type": "string"
           },
+          "fleet_viewer": {
+            "description": "Whether this user has the viewer role on the fleet. Used by the web console to determine whether to show system-level UI.",
+            "type": "boolean"
+          },
           "id": {
             "type": "string",
             "format": "uuid"
+          },
+          "silo_admin": {
+            "description": "Whether this user has the admin role on their silo. Used by the web console to determine whether to show admin-only UI elements.",
+            "type": "boolean"
           },
           "silo_id": {
             "description": "Uuid of the silo to which this user belongs",
@@ -16839,7 +16847,9 @@
         },
         "required": [
           "display_name",
+          "fleet_viewer",
           "id",
+          "silo_admin",
           "silo_id",
           "silo_name"
         ]


### PR DESCRIPTION
Dramatically simpler alternative to #8515. Rather than doing the rigmarole required to get the actual specific role on the fleet and silo, we just do little authz checks to get the specific things we care about. The web console is the only consumer that cares about this endpoint so it feels fine to do it that way.