### PR TITLE
TQ: Add support for "Expunge" messages

### DIFF
--- a/trust-quorum/src/lib.rs
+++ b/trust-quorum/src/lib.rs
@@ -39,7 +39,9 @@ pub use node::{Node, NodeDiff};
 // public only for docs.
 pub use node_ctx::NodeHandlerCtx;
 pub use node_ctx::{NodeCallerCtx, NodeCommonCtx, NodeCtx, NodeCtxDiff};
-pub use persistent_state::{PersistentState, PersistentStateSummary};
+pub use persistent_state::{
+    ExpungedMetadata, PersistentState, PersistentStateSummary,
+};
 
 #[derive(
     Debug,

--- a/trust-quorum/src/messages.rs
+++ b/trust-quorum/src/messages.rs
@@ -65,7 +65,7 @@ pub enum PeerMsgKind {
     LrtqShare(LrtqShare),
 
     /// Inform a node that it is no longer part of the trust quorum as of the
-    /// given epoch
+    /// given epoch, which the responder knows is commmitted.
     Expunged(Epoch),
 
     /// Inform a node that it is utilizing an old committed onfiguration and

--- a/trust-quorum/src/persistent_state.rs
+++ b/trust-quorum/src/persistent_state.rs
@@ -31,7 +31,7 @@ pub struct PersistentState {
 
     // Has the node been informed that it is no longer part of the trust quorum?
     //
-    // If at any time this gets set, than the it remains true for the lifetime
+    // If at any time this gets set, then the it remains true for the lifetime
     // of the node. The sled corresponding to the node must be factory reset by
     // wiping its storage.
     pub expunged: Option<ExpungedMetadata>,
@@ -62,11 +62,13 @@ impl PersistentState {
         self.lrtq.is_some() && self.latest_committed_epoch().is_none()
     }
 
-    // Are there any committed configurations or lrtq data?
+    /// Are there any committed configurations or lrtq data?
     pub fn is_uninitialized(&self) -> bool {
         self.lrtq.is_none() && self.latest_committed_epoch().is_none()
     }
 
+    /// The latest configuration that we know about, regardless of whether it
+    /// has been committed.
     pub fn latest_config(&self) -> Option<&Configuration> {
         self.configs.iter().last()
     }
@@ -107,6 +109,11 @@ impl PersistentState {
     // Do we have a configuration and share for this epoch?
     pub fn has_prepared(&self, epoch: Epoch) -> bool {
         self.configs.contains_key(&epoch) && self.shares.contains_key(&epoch)
+    }
+
+    /// Has this node been expunged?
+    pub fn is_expunged(&self) -> bool {
+        self.expunged.is_some()
     }
 }
 


### PR DESCRIPTION
When a node requests a share for an old configuration it will receive
an `Expunged` message if the share request receiving node has a later
committed configuration where the node is not a member. When the
`Expunged` message is receieved, the expunged node persists this fact
and stops replying to peer messages.

We also fix a bug in the test where nexus wasn't actually committing
configurations at all.

So far invariants really slow the test down. On my machine checking the
invariants after every applied event makes the test take ~120s. Without
invariant checking, it takes about 14s.

I definitely want to add more invariants for correctness, but maybe not
check them when they aren't applicable. Some may become postconditions
on certain events instead.