### PR TITLE
start updating quiesce for new Nexus handoff

### DIFF
--- a/common/src/address.rs
+++ b/common/src/address.rs
@@ -396,7 +396,9 @@ impl std::fmt::Display for IpVersion {
 ///
 /// The first address in the range is guaranteed to be no greater than the last
 /// address.
-#[derive(Clone, Copy, Debug, PartialEq, Eq, Deserialize, Serialize)]
+#[derive(
+    Clone, Copy, Debug, PartialEq, Eq, Deserialize, Serialize, Ord, PartialOrd,
+)]
 #[serde(untagged)]
 pub enum IpRange {
     V4(Ipv4Range),
@@ -548,7 +550,16 @@ impl From<Ipv6Range> for IpRange {
 ///
 /// The first address must be less than or equal to the last address.
 #[derive(
-    Clone, Copy, Debug, PartialEq, Eq, Deserialize, Serialize, JsonSchema,
+    Clone,
+    Copy,
+    Debug,
+    PartialEq,
+    Eq,
+    Deserialize,
+    Serialize,
+    JsonSchema,
+    PartialOrd,
+    Ord,
 )]
 #[serde(try_from = "AnyIpv4Range")]
 pub struct Ipv4Range {
@@ -612,7 +623,16 @@ impl TryFrom<AnyIpv4Range> for Ipv4Range {
 ///
 /// The first address must be less than or equal to the last address.
 #[derive(
-    Clone, Copy, Debug, PartialEq, Eq, Deserialize, Serialize, JsonSchema,
+    PartialOrd,
+    Ord,
+    Clone,
+    Copy,
+    Debug,
+    PartialEq,
+    Eq,
+    Deserialize,
+    Serialize,
+    JsonSchema,
 )]
 #[serde(try_from = "AnyIpv6Range")]
 pub struct Ipv6Range {

--- a/dev-tools/omdb/tests/successes.out
+++ b/dev-tools/omdb/tests/successes.out
@@ -32,7 +32,9 @@ changes:                    names added: 3, names removed: 0
 
 +  @                                                  NS   ns1.oxide-dev.test
 +  ns1                                                AAAA ::1
-+  test-suite-silo.sys                                A    127.0.0.1
++  test-suite-silo.sys                                (records: 2)
++      A    127.0.0.1
++      AAAA 100::1
 ---------------------------------------------
 stderr:
 note: using database URL postgresql://root@[::1]:REDACTED_PORT/omicron?sslmode=disable
@@ -46,7 +48,9 @@ External zone: oxide-dev.test
   NAME                                               RECORDS
   @                                                  NS   ns1.oxide-dev.test
   ns1                                                AAAA ::1
-  test-suite-silo.sys                                A    127.0.0.1
+  test-suite-silo.sys                                (records: 2)
+      A    127.0.0.1
+      AAAA 100::1
 ---------------------------------------------
 stderr:
 note: using database URL postgresql://root@[::1]:REDACTED_PORT/omicron?sslmode=disable
@@ -489,15 +493,33 @@ task: "nat_garbage_collector"
 
 task: "blueprint_loader"
   configured period: every <REDACTED_DURATION>m <REDACTED_DURATION>s
+<<<<<<< HEAD
   last completed activation: <REDACTED ITERATIONS>, triggered by <TRIGGERED_BY_REDACTED>
+||||||| parent of 127d5a805 (add the "second" Nexus to the test suite blueprint; fix omdb tests)
+  last completed activation: <REDACTED ITERATIONS>, triggered by a periodic timer firing
+=======
+  last completed activation: <REDACTED ITERATIONS>, triggered by an explicit signal
+>>>>>>> 127d5a805 (add the "second" Nexus to the test suite blueprint; fix omdb tests)
     started at <REDACTED_TIMESTAMP> (<REDACTED DURATION>s ago) and ran for <REDACTED DURATION>ms
-    last completion reported error: failed to read target blueprint: Internal Error: no target blueprint set
+    target blueprint: ......<REDACTED_BLUEPRINT_ID>.......
+    execution:        disabled
+    created at:       <REDACTED_TIMESTAMP>
+    status:           first target blueprint
 
 task: "blueprint_executor"
   configured period: every <REDACTED_DURATION>m
+<<<<<<< HEAD
   last completed activation: <REDACTED ITERATIONS>, triggered by <TRIGGERED_BY_REDACTED>
+||||||| parent of 127d5a805 (add the "second" Nexus to the test suite blueprint; fix omdb tests)
+  last completed activation: <REDACTED ITERATIONS>, triggered by a periodic timer firing
+=======
+  last completed activation: <REDACTED ITERATIONS>, triggered by a dependent task completing
+>>>>>>> 127d5a805 (add the "second" Nexus to the test suite blueprint; fix omdb tests)
     started at <REDACTED_TIMESTAMP> (<REDACTED DURATION>s ago) and ran for <REDACTED DURATION>ms
-    last completion reported error: no blueprint
+    target blueprint: ......<REDACTED_BLUEPRINT_ID>....... 
+    execution:        disabled                             
+    status:           (no event report found)              
+    error:            (none)                               
 
 task: "abandoned_vmm_reaper"
   configured period: every <REDACTED_DURATION>m
@@ -531,7 +553,18 @@ task: "blueprint_rendezvous"
   configured period: every <REDACTED_DURATION>m
   last completed activation: <REDACTED ITERATIONS>, triggered by <TRIGGERED_BY_REDACTED>
     started at <REDACTED_TIMESTAMP> (<REDACTED DURATION>s ago) and ran for <REDACTED DURATION>ms
-    last completion reported error: no blueprint
+    target blueprint:     ......<REDACTED_BLUEPRINT_ID>.......
+    inventory collection: ..........<REDACTED_UUID>...........
+    debug_dataset rendezvous counts:
+        num_inserted:           0
+        num_already_exist:      0
+        num_not_in_inventory:   0
+        num_tombstoned:         0
+        num_already_tombstoned: 0
+    crucible_dataset rendezvous counts:
+        num_inserted:         0
+        num_already_exist:    0
+        num_not_in_inventory: 0
 
 task: "chicken_switches_watcher"
   configured period: every <REDACTED_DURATION>s
@@ -541,9 +574,15 @@ warning: unknown background task: "chicken_switches_watcher" (don't know how to 
 
 task: "crdb_node_id_collector"
   configured period: every <REDACTED_DURATION>m
+<<<<<<< HEAD
   last completed activation: <REDACTED ITERATIONS>, triggered by <TRIGGERED_BY_REDACTED>
+||||||| parent of 127d5a805 (add the "second" Nexus to the test suite blueprint; fix omdb tests)
+  last completed activation: <REDACTED ITERATIONS>, triggered by a periodic timer firing
+=======
+  last completed activation: <REDACTED ITERATIONS>, triggered by a dependent task completing
+>>>>>>> 127d5a805 (add the "second" Nexus to the test suite blueprint; fix omdb tests)
     started at <REDACTED_TIMESTAMP> (<REDACTED DURATION>s ago) and ran for <REDACTED DURATION>ms
-    last completion reported error: no blueprint
+warning: unknown background task: "crdb_node_id_collector" (don't know how to interpret details: Object {"errors": Array [Object {"err": String("failed to fetch node ID for zone ..........<REDACTED_UUID>........... at http://[::1]:REDACTED_PORT: Communication Error: error sending request for url (http://[::1]:REDACTED_PORT/node/id): error sending request for url (http://[::1]:REDACTED_PORT/node/id): client error (Connect): tcp connect error: Connection refused (os error 146)"), "zone_id": String("..........<REDACTED_UUID>...........")}], "nsuccess": Number(0)})
 
 task: "decommissioned_disk_cleaner"
   configured period: every <REDACTED_DURATION>m
@@ -842,15 +881,37 @@ termination: Exited(0)
 stdout:
 task: "blueprint_loader"
   configured period: every <REDACTED_DURATION>m <REDACTED_DURATION>s
+<<<<<<< HEAD
   last completed activation: <REDACTED ITERATIONS>, triggered by <TRIGGERED_BY_REDACTED>
+||||||| parent of 127d5a805 (add the "second" Nexus to the test suite blueprint; fix omdb tests)
+  currently executing: no
+  last completed activation: <REDACTED ITERATIONS>, triggered by a periodic timer firing
+=======
+  currently executing: no
+  last completed activation: <REDACTED ITERATIONS>, triggered by an explicit signal
+>>>>>>> 127d5a805 (add the "second" Nexus to the test suite blueprint; fix omdb tests)
     started at <REDACTED_TIMESTAMP> (<REDACTED DURATION>s ago) and ran for <REDACTED DURATION>ms
-    last completion reported error: failed to read target blueprint: Internal Error: no target blueprint set
+    target blueprint: ......<REDACTED_BLUEPRINT_ID>.......
+    execution:        disabled
+    created at:       <REDACTED_TIMESTAMP>
+    status:           first target blueprint
 
 task: "blueprint_executor"
   configured period: every <REDACTED_DURATION>m
+<<<<<<< HEAD
   last completed activation: <REDACTED ITERATIONS>, triggered by <TRIGGERED_BY_REDACTED>
+||||||| parent of 127d5a805 (add the "second" Nexus to the test suite blueprint; fix omdb tests)
+  currently executing: no
+  last completed activation: <REDACTED ITERATIONS>, triggered by a periodic timer firing
+=======
+  currently executing: no
+  last completed activation: <REDACTED ITERATIONS>, triggered by a dependent task completing
+>>>>>>> 127d5a805 (add the "second" Nexus to the test suite blueprint; fix omdb tests)
     started at <REDACTED_TIMESTAMP> (<REDACTED DURATION>s ago) and ran for <REDACTED DURATION>ms
-    last completion reported error: no blueprint
+    target blueprint: ......<REDACTED_BLUEPRINT_ID>....... 
+    execution:        disabled                             
+    status:           (no event report found)              
+    error:            (none)                               
 
 ---------------------------------------------
 stderr:
@@ -984,15 +1045,37 @@ task: "nat_garbage_collector"
 
 task: "blueprint_loader"
   configured period: every <REDACTED_DURATION>m <REDACTED_DURATION>s
+<<<<<<< HEAD
   last completed activation: <REDACTED ITERATIONS>, triggered by <TRIGGERED_BY_REDACTED>
+||||||| parent of 127d5a805 (add the "second" Nexus to the test suite blueprint; fix omdb tests)
+  currently executing: no
+  last completed activation: <REDACTED ITERATIONS>, triggered by a periodic timer firing
+=======
+  currently executing: no
+  last completed activation: <REDACTED ITERATIONS>, triggered by an explicit signal
+>>>>>>> 127d5a805 (add the "second" Nexus to the test suite blueprint; fix omdb tests)
     started at <REDACTED_TIMESTAMP> (<REDACTED DURATION>s ago) and ran for <REDACTED DURATION>ms
-    last completion reported error: failed to read target blueprint: Internal Error: no target blueprint set
+    target blueprint: ......<REDACTED_BLUEPRINT_ID>.......
+    execution:        disabled
+    created at:       <REDACTED_TIMESTAMP>
+    status:           first target blueprint
 
 task: "blueprint_executor"
   configured period: every <REDACTED_DURATION>m
+<<<<<<< HEAD
   last completed activation: <REDACTED ITERATIONS>, triggered by <TRIGGERED_BY_REDACTED>
+||||||| parent of 127d5a805 (add the "second" Nexus to the test suite blueprint; fix omdb tests)
+  currently executing: no
+  last completed activation: <REDACTED ITERATIONS>, triggered by a periodic timer firing
+=======
+  currently executing: no
+  last completed activation: <REDACTED ITERATIONS>, triggered by a dependent task completing
+>>>>>>> 127d5a805 (add the "second" Nexus to the test suite blueprint; fix omdb tests)
     started at <REDACTED_TIMESTAMP> (<REDACTED DURATION>s ago) and ran for <REDACTED DURATION>ms
-    last completion reported error: no blueprint
+    target blueprint: ......<REDACTED_BLUEPRINT_ID>....... 
+    execution:        disabled                             
+    status:           (no event report found)              
+    error:            (none)                               
 
 task: "abandoned_vmm_reaper"
   configured period: every <REDACTED_DURATION>m
@@ -1026,7 +1109,18 @@ task: "blueprint_rendezvous"
   configured period: every <REDACTED_DURATION>m
   last completed activation: <REDACTED ITERATIONS>, triggered by <TRIGGERED_BY_REDACTED>
     started at <REDACTED_TIMESTAMP> (<REDACTED DURATION>s ago) and ran for <REDACTED DURATION>ms
-    last completion reported error: no blueprint
+    target blueprint:     ......<REDACTED_BLUEPRINT_ID>.......
+    inventory collection: ..........<REDACTED_UUID>...........
+    debug_dataset rendezvous counts:
+        num_inserted:           0
+        num_already_exist:      0
+        num_not_in_inventory:   0
+        num_tombstoned:         0
+        num_already_tombstoned: 0
+    crucible_dataset rendezvous counts:
+        num_inserted:         0
+        num_already_exist:    0
+        num_not_in_inventory: 0
 
 task: "chicken_switches_watcher"
   configured period: every <REDACTED_DURATION>s
@@ -1036,9 +1130,17 @@ warning: unknown background task: "chicken_switches_watcher" (don't know how to 
 
 task: "crdb_node_id_collector"
   configured period: every <REDACTED_DURATION>m
+<<<<<<< HEAD
   last completed activation: <REDACTED ITERATIONS>, triggered by <TRIGGERED_BY_REDACTED>
+||||||| parent of 127d5a805 (add the "second" Nexus to the test suite blueprint; fix omdb tests)
+  currently executing: no
+  last completed activation: <REDACTED ITERATIONS>, triggered by a periodic timer firing
+=======
+  currently executing: no
+  last completed activation: <REDACTED ITERATIONS>, triggered by a dependent task completing
+>>>>>>> 127d5a805 (add the "second" Nexus to the test suite blueprint; fix omdb tests)
     started at <REDACTED_TIMESTAMP> (<REDACTED DURATION>s ago) and ran for <REDACTED DURATION>ms
-    last completion reported error: no blueprint
+warning: unknown background task: "crdb_node_id_collector" (don't know how to interpret details: Object {"errors": Array [Object {"err": String("failed to fetch node ID for zone ..........<REDACTED_UUID>........... at http://[::1]:REDACTED_PORT: Communication Error: error sending request for url (http://[::1]:REDACTED_PORT/node/id): error sending request for url (http://[::1]:REDACTED_PORT/node/id): client error (Connect): tcp connect error: Connection refused (os error 146)"), "zone_id": String("..........<REDACTED_UUID>...........")}], "nsuccess": Number(0)})
 
 task: "decommissioned_disk_cleaner"
   configured period: every <REDACTED_DURATION>m
@@ -1303,53 +1405,6 @@ task: "webhook_deliverator"
 stderr:
 note: using Nexus URL http://127.0.0.1:REDACTED_PORT/
 =============================================
-EXECUTING COMMAND: omdb ["nexus", "chicken-switches", "show", "current"]
-termination: Exited(0)
----------------------------------------------
-stdout:
-No chicken switches enabled
----------------------------------------------
-stderr:
-note: using Nexus URL http://127.0.0.1:REDACTED_PORT/
-=============================================
-EXECUTING COMMAND: omdb ["-w", "nexus", "chicken-switches", "set", "--planner-enabled", "true"]
-termination: Exited(0)
----------------------------------------------
-stdout:
-chicken switches updated to version 1:
-    planner enabled: true
-    planner switches:
-        add zones with mupdate override:   true
----------------------------------------------
-stderr:
-note: using Nexus URL http://127.0.0.1:REDACTED_PORT/
-=============================================
-EXECUTING COMMAND: omdb ["-w", "nexus", "chicken-switches", "set", "--add-zones-with-mupdate-override", "false"]
-termination: Exited(0)
----------------------------------------------
-stdout:
-chicken switches updated to version 2:
-    planner enabled:   true (unchanged)
-    planner switches:
-    *   add zones with mupdate override:   true -> false
----------------------------------------------
-stderr:
-note: using Nexus URL http://127.0.0.1:REDACTED_PORT/
-=============================================
-EXECUTING COMMAND: omdb ["nexus", "chicken-switches", "show", "current"]
-termination: Exited(0)
----------------------------------------------
-stdout:
-Reconfigurator chicken switches:
-    version: 2
-    modified time: <REDACTED_TIMESTAMP>
-    planner enabled: true
-    planner switches:
-        add zones with mupdate override:   false
----------------------------------------------
-stderr:
-note: using Nexus URL http://127.0.0.1:REDACTED_PORT/
-=============================================
 EXECUTING COMMAND: omdb ["nexus", "sagas", "list"]
 termination: Exited(0)
 ---------------------------------------------
@@ -1486,6 +1541,7 @@ parent:    <none>
     oxp_..........<REDACTED_UUID>.........../crypt/zone/oxz_external_dns_..........<REDACTED_UUID>...........      ..........<REDACTED_UUID>...........   in service    none    none          off        
     oxp_..........<REDACTED_UUID>.........../crypt/zone/oxz_internal_dns_..........<REDACTED_UUID>...........      ..........<REDACTED_UUID>...........   in service    none    none          off        
     oxp_..........<REDACTED_UUID>.........../crypt/zone/oxz_nexus_..........<REDACTED_UUID>...........             ..........<REDACTED_UUID>...........   in service    none    none          off        
+    oxp_..........<REDACTED_UUID>.........../crypt/zone/oxz_nexus_..........<REDACTED_UUID>...........             ..........<REDACTED_UUID>...........   in service    none    none          off        
     oxp_..........<REDACTED_UUID>.........../crypt/zone/oxz_ntp_..........<REDACTED_UUID>...........               ..........<REDACTED_UUID>...........   in service    none    none          off        
 
 
@@ -1500,6 +1556,7 @@ parent:    <none>
     external_dns      ..........<REDACTED_UUID>...........   install dataset   in service    ::1             
     internal_dns      ..........<REDACTED_UUID>...........   install dataset   in service    ::1             
     nexus             ..........<REDACTED_UUID>...........   install dataset   in service    ::ffff:127.0.0.1
+    nexus             ..........<REDACTED_UUID>...........   install dataset   in service    ::1             
 
 
  COCKROACHDB SETTINGS:
@@ -1610,6 +1667,7 @@ parent:    <none>
     oxp_..........<REDACTED_UUID>.........../crypt/zone/oxz_external_dns_..........<REDACTED_UUID>...........      ..........<REDACTED_UUID>...........   in service    none    none          off        
     oxp_..........<REDACTED_UUID>.........../crypt/zone/oxz_internal_dns_..........<REDACTED_UUID>...........      ..........<REDACTED_UUID>...........   in service    none    none          off        
     oxp_..........<REDACTED_UUID>.........../crypt/zone/oxz_nexus_..........<REDACTED_UUID>...........             ..........<REDACTED_UUID>...........   in service    none    none          off        
+    oxp_..........<REDACTED_UUID>.........../crypt/zone/oxz_nexus_..........<REDACTED_UUID>...........             ..........<REDACTED_UUID>...........   in service    none    none          off        
     oxp_..........<REDACTED_UUID>.........../crypt/zone/oxz_ntp_..........<REDACTED_UUID>...........               ..........<REDACTED_UUID>...........   in service    none    none          off        
 
 
@@ -1624,6 +1682,7 @@ parent:    <none>
     external_dns      ..........<REDACTED_UUID>...........   install dataset   in service    ::1             
     internal_dns      ..........<REDACTED_UUID>...........   install dataset   in service    ::1             
     nexus             ..........<REDACTED_UUID>...........   install dataset   in service    ::ffff:127.0.0.1
+    nexus             ..........<REDACTED_UUID>...........   install dataset   in service    ::1             
 
 
  COCKROACHDB SETTINGS:
@@ -1686,6 +1745,53 @@ stdout:
 stderr:
 note: using Nexus URL http://127.0.0.1:REDACTED_PORT/
 Error: `blueprint2_id` was not specified and blueprint1 has no parent
+=============================================
+EXECUTING COMMAND: omdb ["nexus", "chicken-switches", "show", "current"]
+termination: Exited(0)
+---------------------------------------------
+stdout:
+No chicken switches enabled
+---------------------------------------------
+stderr:
+note: using Nexus URL http://127.0.0.1:REDACTED_PORT/
+=============================================
+EXECUTING COMMAND: omdb ["-w", "nexus", "chicken-switches", "set", "--planner-enabled", "true"]
+termination: Exited(0)
+---------------------------------------------
+stdout:
+chicken switches updated to version 1:
+    planner enabled: true
+    planner switches:
+        add zones with mupdate override:   true
+---------------------------------------------
+stderr:
+note: using Nexus URL http://127.0.0.1:REDACTED_PORT/
+=============================================
+EXECUTING COMMAND: omdb ["-w", "nexus", "chicken-switches", "set", "--add-zones-with-mupdate-override", "false"]
+termination: Exited(0)
+---------------------------------------------
+stdout:
+chicken switches updated to version 2:
+    planner enabled:   true (unchanged)
+    planner switches:
+    *   add zones with mupdate override:   true -> false
+---------------------------------------------
+stderr:
+note: using Nexus URL http://127.0.0.1:REDACTED_PORT/
+=============================================
+EXECUTING COMMAND: omdb ["nexus", "chicken-switches", "show", "current"]
+termination: Exited(0)
+---------------------------------------------
+stdout:
+Reconfigurator chicken switches:
+    version: 2
+    modified time: <REDACTED_TIMESTAMP>
+    planner enabled: true
+    planner switches:
+        add zones with mupdate override:   false
+---------------------------------------------
+stderr:
+note: using Nexus URL http://127.0.0.1:REDACTED_PORT/
 =============================================
 EXECUTING COMMAND: omdb ["reconfigurator", "export", "<TMP_PATH_REDACTED>"]
 termination: Exited(0)

--- a/dev-tools/omdb/tests/successes.out
+++ b/dev-tools/omdb/tests/successes.out
@@ -32,9 +32,7 @@ changes:                    names added: 3, names removed: 0
 
 +  @                                                  NS   ns1.oxide-dev.test
 +  ns1                                                AAAA ::1
-+  test-suite-silo.sys                                (records: 2)
-+      A    127.0.0.1
-+      AAAA 100::1
++  test-suite-silo.sys                                A    127.0.0.1
 ---------------------------------------------
 stderr:
 note: using database URL postgresql://root@[::1]:REDACTED_PORT/omicron?sslmode=disable
@@ -48,9 +46,7 @@ External zone: oxide-dev.test
   NAME                                               RECORDS
   @                                                  NS   ns1.oxide-dev.test
   ns1                                                AAAA ::1
-  test-suite-silo.sys                                (records: 2)
-      A    127.0.0.1
-      AAAA 100::1
+  test-suite-silo.sys                                A    127.0.0.1
 ---------------------------------------------
 stderr:
 note: using database URL postgresql://root@[::1]:REDACTED_PORT/omicron?sslmode=disable
@@ -1541,7 +1537,6 @@ parent:    <none>
     oxp_..........<REDACTED_UUID>.........../crypt/zone/oxz_external_dns_..........<REDACTED_UUID>...........      ..........<REDACTED_UUID>...........   in service    none    none          off        
     oxp_..........<REDACTED_UUID>.........../crypt/zone/oxz_internal_dns_..........<REDACTED_UUID>...........      ..........<REDACTED_UUID>...........   in service    none    none          off        
     oxp_..........<REDACTED_UUID>.........../crypt/zone/oxz_nexus_..........<REDACTED_UUID>...........             ..........<REDACTED_UUID>...........   in service    none    none          off        
-    oxp_..........<REDACTED_UUID>.........../crypt/zone/oxz_nexus_..........<REDACTED_UUID>...........             ..........<REDACTED_UUID>...........   in service    none    none          off        
     oxp_..........<REDACTED_UUID>.........../crypt/zone/oxz_ntp_..........<REDACTED_UUID>...........               ..........<REDACTED_UUID>...........   in service    none    none          off        
 
 
@@ -1556,7 +1551,6 @@ parent:    <none>
     external_dns      ..........<REDACTED_UUID>...........   install dataset   in service    ::1             
     internal_dns      ..........<REDACTED_UUID>...........   install dataset   in service    ::1             
     nexus             ..........<REDACTED_UUID>...........   install dataset   in service    ::ffff:127.0.0.1
-    nexus             ..........<REDACTED_UUID>...........   install dataset   in service    ::1             
 
 
  COCKROACHDB SETTINGS:
@@ -1667,7 +1661,6 @@ parent:    <none>
     oxp_..........<REDACTED_UUID>.........../crypt/zone/oxz_external_dns_..........<REDACTED_UUID>...........      ..........<REDACTED_UUID>...........   in service    none    none          off        
     oxp_..........<REDACTED_UUID>.........../crypt/zone/oxz_internal_dns_..........<REDACTED_UUID>...........      ..........<REDACTED_UUID>...........   in service    none    none          off        
     oxp_..........<REDACTED_UUID>.........../crypt/zone/oxz_nexus_..........<REDACTED_UUID>...........             ..........<REDACTED_UUID>...........   in service    none    none          off        
-    oxp_..........<REDACTED_UUID>.........../crypt/zone/oxz_nexus_..........<REDACTED_UUID>...........             ..........<REDACTED_UUID>...........   in service    none    none          off        
     oxp_..........<REDACTED_UUID>.........../crypt/zone/oxz_ntp_..........<REDACTED_UUID>...........               ..........<REDACTED_UUID>...........   in service    none    none          off        
 
 
@@ -1682,7 +1675,6 @@ parent:    <none>
     external_dns      ..........<REDACTED_UUID>...........   install dataset   in service    ::1             
     internal_dns      ..........<REDACTED_UUID>...........   install dataset   in service    ::1             
     nexus             ..........<REDACTED_UUID>...........   install dataset   in service    ::ffff:127.0.0.1
-    nexus             ..........<REDACTED_UUID>...........   install dataset   in service    ::1             
 
 
  COCKROACHDB SETTINGS:

--- a/dev-tools/omdb/tests/successes.out
+++ b/dev-tools/omdb/tests/successes.out
@@ -489,13 +489,7 @@ task: "nat_garbage_collector"
 
 task: "blueprint_loader"
   configured period: every <REDACTED_DURATION>m <REDACTED_DURATION>s
-<<<<<<< HEAD
   last completed activation: <REDACTED ITERATIONS>, triggered by <TRIGGERED_BY_REDACTED>
-||||||| parent of 127d5a805 (add the "second" Nexus to the test suite blueprint; fix omdb tests)
-  last completed activation: <REDACTED ITERATIONS>, triggered by a periodic timer firing
-=======
-  last completed activation: <REDACTED ITERATIONS>, triggered by an explicit signal
->>>>>>> 127d5a805 (add the "second" Nexus to the test suite blueprint; fix omdb tests)
     started at <REDACTED_TIMESTAMP> (<REDACTED DURATION>s ago) and ran for <REDACTED DURATION>ms
     target blueprint: ......<REDACTED_BLUEPRINT_ID>.......
     execution:        disabled
@@ -504,13 +498,7 @@ task: "blueprint_loader"
 
 task: "blueprint_executor"
   configured period: every <REDACTED_DURATION>m
-<<<<<<< HEAD
   last completed activation: <REDACTED ITERATIONS>, triggered by <TRIGGERED_BY_REDACTED>
-||||||| parent of 127d5a805 (add the "second" Nexus to the test suite blueprint; fix omdb tests)
-  last completed activation: <REDACTED ITERATIONS>, triggered by a periodic timer firing
-=======
-  last completed activation: <REDACTED ITERATIONS>, triggered by a dependent task completing
->>>>>>> 127d5a805 (add the "second" Nexus to the test suite blueprint; fix omdb tests)
     started at <REDACTED_TIMESTAMP> (<REDACTED DURATION>s ago) and ran for <REDACTED DURATION>ms
     target blueprint: ......<REDACTED_BLUEPRINT_ID>....... 
     execution:        disabled                             
@@ -570,13 +558,7 @@ warning: unknown background task: "chicken_switches_watcher" (don't know how to 
 
 task: "crdb_node_id_collector"
   configured period: every <REDACTED_DURATION>m
-<<<<<<< HEAD
   last completed activation: <REDACTED ITERATIONS>, triggered by <TRIGGERED_BY_REDACTED>
-||||||| parent of 127d5a805 (add the "second" Nexus to the test suite blueprint; fix omdb tests)
-  last completed activation: <REDACTED ITERATIONS>, triggered by a periodic timer firing
-=======
-  last completed activation: <REDACTED ITERATIONS>, triggered by a dependent task completing
->>>>>>> 127d5a805 (add the "second" Nexus to the test suite blueprint; fix omdb tests)
     started at <REDACTED_TIMESTAMP> (<REDACTED DURATION>s ago) and ran for <REDACTED DURATION>ms
 warning: unknown background task: "crdb_node_id_collector" (don't know how to interpret details: Object {"errors": Array [Object {"err": String("failed to fetch node ID for zone ..........<REDACTED_UUID>........... at http://[::1]:REDACTED_PORT: Communication Error: error sending request for url (http://[::1]:REDACTED_PORT/node/id): error sending request for url (http://[::1]:REDACTED_PORT/node/id): client error (Connect): tcp connect error: Connection refused (os error <OS_ERROR_REDACTED>)"), "zone_id": String("..........<REDACTED_UUID>...........")}], "nsuccess": Number(0)})
 
@@ -877,15 +859,7 @@ termination: Exited(0)
 stdout:
 task: "blueprint_loader"
   configured period: every <REDACTED_DURATION>m <REDACTED_DURATION>s
-<<<<<<< HEAD
   last completed activation: <REDACTED ITERATIONS>, triggered by <TRIGGERED_BY_REDACTED>
-||||||| parent of 127d5a805 (add the "second" Nexus to the test suite blueprint; fix omdb tests)
-  currently executing: no
-  last completed activation: <REDACTED ITERATIONS>, triggered by a periodic timer firing
-=======
-  currently executing: no
-  last completed activation: <REDACTED ITERATIONS>, triggered by an explicit signal
->>>>>>> 127d5a805 (add the "second" Nexus to the test suite blueprint; fix omdb tests)
     started at <REDACTED_TIMESTAMP> (<REDACTED DURATION>s ago) and ran for <REDACTED DURATION>ms
     target blueprint: ......<REDACTED_BLUEPRINT_ID>.......
     execution:        disabled
@@ -894,15 +868,7 @@ task: "blueprint_loader"
 
 task: "blueprint_executor"
   configured period: every <REDACTED_DURATION>m
-<<<<<<< HEAD
   last completed activation: <REDACTED ITERATIONS>, triggered by <TRIGGERED_BY_REDACTED>
-||||||| parent of 127d5a805 (add the "second" Nexus to the test suite blueprint; fix omdb tests)
-  currently executing: no
-  last completed activation: <REDACTED ITERATIONS>, triggered by a periodic timer firing
-=======
-  currently executing: no
-  last completed activation: <REDACTED ITERATIONS>, triggered by a dependent task completing
->>>>>>> 127d5a805 (add the "second" Nexus to the test suite blueprint; fix omdb tests)
     started at <REDACTED_TIMESTAMP> (<REDACTED DURATION>s ago) and ran for <REDACTED DURATION>ms
     target blueprint: ......<REDACTED_BLUEPRINT_ID>....... 
     execution:        disabled                             
@@ -1041,15 +1007,7 @@ task: "nat_garbage_collector"
 
 task: "blueprint_loader"
   configured period: every <REDACTED_DURATION>m <REDACTED_DURATION>s
-<<<<<<< HEAD
   last completed activation: <REDACTED ITERATIONS>, triggered by <TRIGGERED_BY_REDACTED>
-||||||| parent of 127d5a805 (add the "second" Nexus to the test suite blueprint; fix omdb tests)
-  currently executing: no
-  last completed activation: <REDACTED ITERATIONS>, triggered by a periodic timer firing
-=======
-  currently executing: no
-  last completed activation: <REDACTED ITERATIONS>, triggered by an explicit signal
->>>>>>> 127d5a805 (add the "second" Nexus to the test suite blueprint; fix omdb tests)
     started at <REDACTED_TIMESTAMP> (<REDACTED DURATION>s ago) and ran for <REDACTED DURATION>ms
     target blueprint: ......<REDACTED_BLUEPRINT_ID>.......
     execution:        disabled
@@ -1058,15 +1016,7 @@ task: "blueprint_loader"
 
 task: "blueprint_executor"
   configured period: every <REDACTED_DURATION>m
-<<<<<<< HEAD
   last completed activation: <REDACTED ITERATIONS>, triggered by <TRIGGERED_BY_REDACTED>
-||||||| parent of 127d5a805 (add the "second" Nexus to the test suite blueprint; fix omdb tests)
-  currently executing: no
-  last completed activation: <REDACTED ITERATIONS>, triggered by a periodic timer firing
-=======
-  currently executing: no
-  last completed activation: <REDACTED ITERATIONS>, triggered by a dependent task completing
->>>>>>> 127d5a805 (add the "second" Nexus to the test suite blueprint; fix omdb tests)
     started at <REDACTED_TIMESTAMP> (<REDACTED DURATION>s ago) and ran for <REDACTED DURATION>ms
     target blueprint: ......<REDACTED_BLUEPRINT_ID>....... 
     execution:        disabled                             
@@ -1126,15 +1076,7 @@ warning: unknown background task: "chicken_switches_watcher" (don't know how to 
 
 task: "crdb_node_id_collector"
   configured period: every <REDACTED_DURATION>m
-<<<<<<< HEAD
   last completed activation: <REDACTED ITERATIONS>, triggered by <TRIGGERED_BY_REDACTED>
-||||||| parent of 127d5a805 (add the "second" Nexus to the test suite blueprint; fix omdb tests)
-  currently executing: no
-  last completed activation: <REDACTED ITERATIONS>, triggered by a periodic timer firing
-=======
-  currently executing: no
-  last completed activation: <REDACTED ITERATIONS>, triggered by a dependent task completing
->>>>>>> 127d5a805 (add the "second" Nexus to the test suite blueprint; fix omdb tests)
     started at <REDACTED_TIMESTAMP> (<REDACTED DURATION>s ago) and ran for <REDACTED DURATION>ms
 warning: unknown background task: "crdb_node_id_collector" (don't know how to interpret details: Object {"errors": Array [Object {"err": String("failed to fetch node ID for zone ..........<REDACTED_UUID>........... at http://[::1]:REDACTED_PORT: Communication Error: error sending request for url (http://[::1]:REDACTED_PORT/node/id): error sending request for url (http://[::1]:REDACTED_PORT/node/id): client error (Connect): tcp connect error: Connection refused (os error <OS_ERROR_REDACTED>)"), "zone_id": String("..........<REDACTED_UUID>...........")}], "nsuccess": Number(0)})
 

--- a/dev-tools/omdb/tests/successes.out
+++ b/dev-tools/omdb/tests/successes.out
@@ -582,7 +582,7 @@ task: "crdb_node_id_collector"
   last completed activation: <REDACTED ITERATIONS>, triggered by a dependent task completing
 >>>>>>> 127d5a805 (add the "second" Nexus to the test suite blueprint; fix omdb tests)
     started at <REDACTED_TIMESTAMP> (<REDACTED DURATION>s ago) and ran for <REDACTED DURATION>ms
-warning: unknown background task: "crdb_node_id_collector" (don't know how to interpret details: Object {"errors": Array [Object {"err": String("failed to fetch node ID for zone ..........<REDACTED_UUID>........... at http://[::1]:REDACTED_PORT: Communication Error: error sending request for url (http://[::1]:REDACTED_PORT/node/id): error sending request for url (http://[::1]:REDACTED_PORT/node/id): client error (Connect): tcp connect error: Connection refused (os error 146)"), "zone_id": String("..........<REDACTED_UUID>...........")}], "nsuccess": Number(0)})
+warning: unknown background task: "crdb_node_id_collector" (don't know how to interpret details: Object {"errors": Array [Object {"err": String("failed to fetch node ID for zone ..........<REDACTED_UUID>........... at http://[::1]:REDACTED_PORT: Communication Error: error sending request for url (http://[::1]:REDACTED_PORT/node/id): error sending request for url (http://[::1]:REDACTED_PORT/node/id): client error (Connect): tcp connect error: Connection refused (os error <OS_ERROR_REDACTED>)"), "zone_id": String("..........<REDACTED_UUID>...........")}], "nsuccess": Number(0)})
 
 task: "decommissioned_disk_cleaner"
   configured period: every <REDACTED_DURATION>m
@@ -1140,7 +1140,7 @@ task: "crdb_node_id_collector"
   last completed activation: <REDACTED ITERATIONS>, triggered by a dependent task completing
 >>>>>>> 127d5a805 (add the "second" Nexus to the test suite blueprint; fix omdb tests)
     started at <REDACTED_TIMESTAMP> (<REDACTED DURATION>s ago) and ran for <REDACTED DURATION>ms
-warning: unknown background task: "crdb_node_id_collector" (don't know how to interpret details: Object {"errors": Array [Object {"err": String("failed to fetch node ID for zone ..........<REDACTED_UUID>........... at http://[::1]:REDACTED_PORT: Communication Error: error sending request for url (http://[::1]:REDACTED_PORT/node/id): error sending request for url (http://[::1]:REDACTED_PORT/node/id): client error (Connect): tcp connect error: Connection refused (os error 146)"), "zone_id": String("..........<REDACTED_UUID>...........")}], "nsuccess": Number(0)})
+warning: unknown background task: "crdb_node_id_collector" (don't know how to interpret details: Object {"errors": Array [Object {"err": String("failed to fetch node ID for zone ..........<REDACTED_UUID>........... at http://[::1]:REDACTED_PORT: Communication Error: error sending request for url (http://[::1]:REDACTED_PORT/node/id): error sending request for url (http://[::1]:REDACTED_PORT/node/id): client error (Connect): tcp connect error: Connection refused (os error <OS_ERROR_REDACTED>)"), "zone_id": String("..........<REDACTED_UUID>...........")}], "nsuccess": Number(0)})
 
 task: "decommissioned_disk_cleaner"
   configured period: every <REDACTED_DURATION>m

--- a/dev-tools/omdb/tests/test_all_output.rs
+++ b/dev-tools/omdb/tests/test_all_output.rs
@@ -280,7 +280,9 @@ async fn test_omdb_success_cases(cptestctx: &ControlPlaneTestContext) {
         .extra_variable_length(
             "cockroachdb_fingerprint",
             &initial_blueprint.cockroachdb_fingerprint,
-        );
+        )
+        // Error numbers vary between operating systems.
+        .field("os error", r"\d+");
 
     let crdb_version =
         initial_blueprint.cockroachdb_setting_preserve_downgrade.to_string();

--- a/dev-tools/omdb/tests/test_all_output.rs
+++ b/dev-tools/omdb/tests/test_all_output.rs
@@ -224,27 +224,6 @@ async fn test_omdb_success_cases(cptestctx: &ControlPlaneTestContext) {
             "--no-executing-info",
         ],
         &["nexus", "background-tasks", "show", "all", "--no-executing-info"],
-        // chicken switches: show and set
-        &["nexus", "chicken-switches", "show", "current"],
-        &[
-            "-w",
-            "nexus",
-            "chicken-switches",
-            "set",
-            "--planner-enabled",
-            "true",
-        ],
-        &[
-            "-w",
-            "nexus",
-            "chicken-switches",
-            "set",
-            "--add-zones-with-mupdate-override",
-            "false",
-        ],
-        // After the set commands above, we should see chicken switches
-        // populated.
-        &["nexus", "chicken-switches", "show", "current"],
         &["nexus", "sagas", "list"],
         &["--destructive", "nexus", "sagas", "demo-create"],
         &["nexus", "sagas", "list"],
@@ -267,6 +246,27 @@ async fn test_omdb_success_cases(cptestctx: &ControlPlaneTestContext) {
         ],
         // This one should fail because it has no parent.
         &["nexus", "blueprints", "diff", &initial_blueprint_id],
+        // chicken switches: show and set
+        &["nexus", "chicken-switches", "show", "current"],
+        &[
+            "-w",
+            "nexus",
+            "chicken-switches",
+            "set",
+            "--planner-enabled",
+            "true",
+        ],
+        &[
+            "-w",
+            "nexus",
+            "chicken-switches",
+            "set",
+            "--add-zones-with-mupdate-override",
+            "false",
+        ],
+        // After the set commands above, we should see chicken switches
+        // populated.
+        &["nexus", "chicken-switches", "show", "current"],
         &["reconfigurator", "export", tmppath.as_str()],
         // We can't easily test the sled agent output because that's only
         // provided by a real sled agent, which is not available in the

--- a/dev-tools/omicron-dev/src/main.rs
+++ b/dev-tools/omicron-dev/src/main.rs
@@ -100,8 +100,8 @@ impl RunAllArgs {
         println!("omicron-dev: services are running.");
 
         // Print out basic information about what was started.
-        // NOTE: The stdout strings here are not intended to be stable, but they are
-        // used by the test suite.
+        // NOTE: The stdout strings here are not intended to be stable, but they
+        // are used by the test suite.
         let addr = cptestctx.external_client.bind_address;
         println!("omicron-dev: nexus external API:    {:?}", addr);
         println!(

--- a/nexus/reconfigurator/execution/src/lib.rs
+++ b/nexus/reconfigurator/execution/src/lib.rs
@@ -646,50 +646,36 @@ fn register_reassign_sagas_step<'a>(
                         .into();
                 };
 
-                // Re-assign sagas, but only if we're allowed to.  If Nexus is
-                // quiescing, we don't want to assign any new sagas to
-                // ourselves.
-                let result = saga_quiesce.reassign_if_possible(async || {
-                    // For any expunged Nexus zones, re-assign in-progress sagas
-                    // to some other Nexus.  If this fails for some reason, it
-                    // doesn't affect anything else.
-                    let sec_id = nexus_db_model::SecId::from(nexus_id);
-                    let reassigned = sagas::reassign_sagas_from_expunged(
-                        opctx, datastore, blueprint, sec_id,
-                    )
-                    .await
-                    .context("failed to re-assign sagas");
-                    match reassigned {
-                        Ok(needs_saga_recovery) => (
-                            StepSuccess::new(needs_saga_recovery).build(),
-                            needs_saga_recovery,
-                        ),
-                        Err(error) => {
-                            // It's possible that we failed after having
-                            // re-assigned sagas in the database.
-                            let maybe_reassigned = true;
-                            (
-                                StepWarning::new(false, error.to_string())
-                                    .build(),
-                                maybe_reassigned,
-                            )
+                // Re-assign sagas.
+                Ok(saga_quiesce
+                    .reassign_sagas(async || {
+                        // For any expunged Nexus zones, re-assign in-progress
+                        // sagas to some other Nexus.  If this fails for some
+                        // reason, it doesn't affect anything else.
+                        let sec_id = nexus_db_model::SecId::from(nexus_id);
+                        let reassigned = sagas::reassign_sagas_from_expunged(
+                            opctx, datastore, blueprint, sec_id,
+                        )
+                        .await
+                        .context("failed to re-assign sagas");
+                        match reassigned {
+                            Ok(needs_saga_recovery) => (
+                                StepSuccess::new(needs_saga_recovery).build(),
+                                needs_saga_recovery,
+                            ),
+                            Err(error) => {
+                                // It's possible that we failed after having
+                                // re-assigned sagas in the database.
+                                let maybe_reassigned = true;
+                                (
+                                    StepWarning::new(false, error.to_string())
+                                        .build(),
+                                    maybe_reassigned,
+                                )
+                            }
                         }
-                    }
-                });
-
-                match result.await {
-                    // Re-assignment is allowed, and we did try.  It may or may
-                    // not have succeeded.  Either way, that's reflected in
-                    // `step_result`.
-                    Ok(step_result) => Ok(step_result),
-                    // Re-assignment is disallowed.  Report this step skipped
-                    // with an explanation of why.
-                    Err(error) => StepSkipped::new(
-                        false,
-                        InlineErrorChain::new(&error).to_string(),
-                    )
-                    .into(),
-                }
+                    })
+                    .await)
             },
         )
         .register()

--- a/nexus/reconfigurator/execution/src/lib.rs
+++ b/nexus/reconfigurator/execution/src/lib.rs
@@ -650,8 +650,9 @@ fn register_reassign_sagas_step<'a>(
                 Ok(saga_quiesce
                     .reassign_sagas(async || {
                         // For any expunged Nexus zones, re-assign in-progress
-                        // sagas to some other Nexus.  If this fails for some
-                        // reason, it doesn't affect anything else.
+                        // sagas to `nexus_id` (which, in practice, is
+                        // ourselves).  If this fails for some reason, it
+                        // doesn't affect anything else.
                         let sec_id = nexus_db_model::SecId::from(nexus_id);
                         let reassigned = sagas::reassign_sagas_from_expunged(
                             opctx, datastore, blueprint, sec_id,

--- a/nexus/reconfigurator/planning/src/blueprint_builder/builder.rs
+++ b/nexus/reconfigurator/planning/src/blueprint_builder/builder.rs
@@ -353,6 +353,10 @@ pub(crate) enum Operation {
         num_datasets_expunged: usize,
         num_zones_expunged: usize,
     },
+    SetNexusGeneration {
+        current_generation: Generation,
+        new_generation: Generation,
+    },
     SetTargetReleaseMinimumGeneration {
         current_generation: Generation,
         new_generation: Generation,
@@ -462,6 +466,13 @@ impl fmt::Display for Operation {
                 write!(
                     f,
                     "updated target release minimum generation from \
+                     {current_generation} to {new_generation}"
+                )
+            }
+            Self::SetNexusGeneration { current_generation, new_generation } => {
+                write!(
+                    f,
+                    "updated nexus generation from \
                      {current_generation} to {new_generation}"
                 )
             }
@@ -2185,6 +2196,22 @@ impl<'a> BlueprintBuilder<'a> {
             new_generation,
         });
         Ok(())
+    }
+
+    /// Get the value of `nexus_generation`.
+    pub fn nexus_generation(&self) -> Generation {
+        self.nexus_generation
+    }
+
+    /// Given the current value of `nexus_generation`, set the new value for
+    /// this blueprint.
+    pub fn set_nexus_generation(&mut self, new_generation: Generation) {
+        let current_generation = self.nexus_generation;
+        self.nexus_generation = new_generation;
+        self.record_operation(Operation::SetNexusGeneration {
+            current_generation,
+            new_generation,
+        });
     }
 
     /// Allow a test to manually add an external DNS address, which could

--- a/nexus/src/app/background/init.rs
+++ b/nexus/src/app/background/init.rs
@@ -131,6 +131,7 @@ use super::tasks::vpc_routes;
 use super::tasks::webhook_deliverator;
 use crate::Nexus;
 use crate::app::oximeter::PRODUCER_LEASE_DURATION;
+use crate::app::quiesce::NexusQuiesceHandle;
 use crate::app::saga::StartSaga;
 use nexus_background_task_interface::Activator;
 use nexus_background_task_interface::BackgroundTasks;
@@ -437,7 +438,7 @@ impl BackgroundTasksInitializer {
             nexus_id,
             task_saga_recovery.clone(),
             args.mgs_updates_tx,
-            args.saga_recovery.quiesce.clone(),
+            args.nexus_quiesce,
         );
         let rx_blueprint_exec = blueprint_executor.watcher();
         driver.register(TaskDefinition {
@@ -1028,6 +1029,8 @@ pub struct BackgroundTasksData {
     pub webhook_delivery_client: reqwest::Client,
     /// Channel for configuring pending MGS updates
     pub mgs_updates_tx: watch::Sender<PendingMgsUpdates>,
+    /// handle for controlling Nexus quiesce
+    pub nexus_quiesce: NexusQuiesceHandle,
 }
 
 /// Starts the three DNS-propagation-related background tasks for either

--- a/nexus/src/app/background/tasks/blueprint_execution.rs
+++ b/nexus/src/app/background/tasks/blueprint_execution.rs
@@ -4,7 +4,10 @@
 
 //! Background task for realizing a plan blueprint
 
-use crate::app::background::{Activator, BackgroundTask};
+use crate::app::{
+    background::{Activator, BackgroundTask},
+    quiesce::NexusQuiesceHandle,
+};
 use futures::FutureExt;
 use futures::future::BoxFuture;
 use internal_dns_resolver::Resolver;
@@ -13,14 +16,12 @@ use nexus_db_queries::db::DataStore;
 use nexus_reconfigurator_execution::{
     RealizeBlueprintOutput, RequiredRealizeArgs,
 };
-use nexus_types::{
-    deployment::{
-        Blueprint, BlueprintTarget, PendingMgsUpdates, execution::EventBuffer,
-    },
-    quiesce::SagaQuiesceHandle,
+use nexus_types::deployment::{
+    Blueprint, BlueprintTarget, PendingMgsUpdates, execution::EventBuffer,
 };
 use omicron_uuid_kinds::OmicronZoneUuid;
 use serde_json::json;
+use slog_error_chain::InlineErrorChain;
 use std::sync::Arc;
 use tokio::sync::watch;
 use update_engine::NestedError;
@@ -35,7 +36,7 @@ pub struct BlueprintExecutor {
     tx: watch::Sender<usize>,
     saga_recovery: Activator,
     mgs_update_tx: watch::Sender<PendingMgsUpdates>,
-    saga_quiesce: SagaQuiesceHandle,
+    nexus_quiesce: NexusQuiesceHandle,
 }
 
 impl BlueprintExecutor {
@@ -48,7 +49,7 @@ impl BlueprintExecutor {
         nexus_id: OmicronZoneUuid,
         saga_recovery: Activator,
         mgs_update_tx: watch::Sender<PendingMgsUpdates>,
-        saga_quiesce: SagaQuiesceHandle,
+        nexus_quiesce: NexusQuiesceHandle,
     ) -> BlueprintExecutor {
         let (tx, _) = watch::channel(0);
         BlueprintExecutor {
@@ -59,7 +60,7 @@ impl BlueprintExecutor {
             tx,
             saga_recovery,
             mgs_update_tx,
-            saga_quiesce,
+            nexus_quiesce,
         }
     }
 
@@ -87,6 +88,47 @@ impl BlueprintExecutor {
         };
 
         let (bp_target, blueprint) = &*update;
+
+        // Regardless of anything else: propagate whatever this blueprint
+        // says about our quiescing state.
+        //
+        // During startup under normal operation, the blueprint will reflect
+        // that we're not quiescing.  Propagating this will enable sagas to
+        // be created elsewhere in Nexus.
+        //
+        // At some point during an upgrade, we'll encounter a blueprint that
+        // reflects that we are quiescing.  Propagating this will disable sagas
+        // from being created.
+        //
+        // In all other cases, this will have no effect.
+        //
+        // We do this now, before doing anything else, for two reasons: (1)
+        // during startup, we want to do this ASAP to minimize unnecessary saga
+        // creation failures (i.e., don't wait until we try to execute the
+        // blueprint before enabling sagas, since we already know if we're
+        // quiescing or not); and (2) because we want to do it even if blueprint
+        // execution is disabled.
+        match blueprint.nexus_quiescing(self.nexus_id) {
+            Ok(quiescing) => {
+                debug!(
+                    &opctx.log,
+                    "blueprint execution: quiesce check";
+                    "quiescing" => quiescing
+                );
+                self.nexus_quiesce.set_quiescing(quiescing);
+            }
+            Err(error) => {
+                // This should be impossible.  But it doesn't really affect
+                // anything else so there's no reason to stop execution.
+                error!(
+                    &opctx.log,
+                    "blueprint execution: failed to determine if this Nexus \
+                     is quiescing";
+                    InlineErrorChain::new(&*error)
+                );
+            }
+        };
+
         if !bp_target.enabled {
             warn!(&opctx.log,
                       "Blueprint execution: skipped";
@@ -119,7 +161,7 @@ impl BlueprintExecutor {
                 blueprint,
                 sender,
                 mgs_updates: self.mgs_update_tx.clone(),
-                saga_quiesce: self.saga_quiesce.clone(),
+                saga_quiesce: self.nexus_quiesce.sagas(),
             }
             .as_nexus(self.nexus_id),
         )
@@ -181,6 +223,7 @@ impl BackgroundTask for BlueprintExecutor {
 mod test {
     use super::BlueprintExecutor;
     use crate::app::background::{Activator, BackgroundTask};
+    use crate::app::quiesce::NexusQuiesceHandle;
     use httptest::Expectation;
     use httptest::matchers::{not, request};
     use httptest::responders::status_code;
@@ -207,7 +250,6 @@ mod test {
         PlanningReport, blueprint_zone_type,
     };
     use nexus_types::external_api::views::SledState;
-    use nexus_types::quiesce::SagaQuiesceHandle;
     use omicron_common::api::external;
     use omicron_common::api::external::Generation;
     use omicron_common::zpool_name::ZpoolName;
@@ -390,7 +432,7 @@ mod test {
             OmicronZoneUuid::new_v4(),
             Activator::new(),
             dummy_tx,
-            SagaQuiesceHandle::new(opctx.log.clone()),
+            NexusQuiesceHandle::new(&opctx.log, datastore.clone()),
         );
 
         // Now we're ready.

--- a/nexus/src/app/background/tasks/blueprint_execution.rs
+++ b/nexus/src/app/background/tasks/blueprint_execution.rs
@@ -108,7 +108,7 @@ impl BlueprintExecutor {
         // blueprint before enabling sagas, since we already know if we're
         // quiescing or not); and (2) because we want to do it even if blueprint
         // execution is disabled.
-        match blueprint.nexus_quiescing(self.nexus_id) {
+        match blueprint.is_nexus_quiescing(self.nexus_id) {
             Ok(quiescing) => {
                 debug!(
                     &opctx.log,

--- a/nexus/src/app/background/tasks/blueprint_planner.rs
+++ b/nexus/src/app/background/tasks/blueprint_planner.rs
@@ -273,18 +273,15 @@ impl BackgroundTask for BlueprintPlanner {
 #[cfg(test)]
 mod test {
     use super::*;
-    use crate::app::background::Activator;
     use crate::app::background::tasks::blueprint_execution::BlueprintExecutor;
     use crate::app::background::tasks::blueprint_load::TargetBlueprintLoader;
     use crate::app::background::tasks::inventory_collection::InventoryCollector;
+    use crate::app::{background::Activator, quiesce::NexusQuiesceHandle};
     use nexus_inventory::now_db_precision;
     use nexus_test_utils_macros::nexus_test;
-    use nexus_types::{
-        deployment::{
-            PendingMgsUpdates, PlannerChickenSwitches,
-            ReconfiguratorChickenSwitches,
-        },
-        quiesce::SagaQuiesceHandle,
+    use nexus_types::deployment::{
+        PendingMgsUpdates, PlannerChickenSwitches,
+        ReconfiguratorChickenSwitches,
     };
     use omicron_uuid_kinds::OmicronZoneUuid;
 
@@ -423,7 +420,7 @@ mod test {
             OmicronZoneUuid::new_v4(),
             Activator::new(),
             dummy_tx,
-            SagaQuiesceHandle::new(opctx.log.clone()),
+            NexusQuiesceHandle::new(&opctx.log, datastore.clone()),
         );
         let value = executor.activate(&opctx).await;
         let value = value.as_object().expect("response is not a JSON object");

--- a/nexus/src/app/mod.rs
+++ b/nexus/src/app/mod.rs
@@ -621,6 +621,14 @@ impl Nexus {
         }
     }
 
+    // Waits for Nexus to determine whether sagas are supposed to be quiesced
+    //
+    // This is used by the test suite because most tests assume that sagas are
+    // operational as soon as they start.
+    pub(crate) async fn wait_for_saga_determination(&self) {
+        self.quiesce.sagas().wait_for_determination().await;
+    }
+
     pub(crate) async fn external_tls_config(
         &self,
         tls_enabled: bool,

--- a/nexus/src/app/quiesce.rs
+++ b/nexus/src/app/quiesce.rs
@@ -92,13 +92,13 @@ impl NexusQuiesceHandle {
             }
         });
 
+        // Immediately (synchronously) update the saga quiesce status.  It's
+        // okay to do this even if there wasn't a change.
+        self.sagas.set_quiescing(quiescing);
+
         if changed && quiescing {
-            // Immediately quiesce sagas.
-            self.sagas.set_quiescing(quiescing);
             // Asynchronously complete the rest of the quiesce process.
-            if quiescing {
-                tokio::spawn(do_quiesce(self.clone()));
-            }
+            tokio::spawn(do_quiesce(self.clone()));
         }
     }
 }

--- a/nexus/src/app/quiesce.rs
+++ b/nexus/src/app/quiesce.rs
@@ -129,7 +129,9 @@ async fn do_quiesce(quiesce: NexusQuiesceHandle) {
     // TODO per RFD 588, this is where we will enter a loop, pausing either on
     // timeout or when our local quiesce state changes.  At each pause: if we
     // need to update our db_metadata_nexus record, do so.  Then load the
-    // current blueprint and check the records for all nexus instances.
+    // current blueprint and check the records for all nexus instances.  This
+    // work is covered by a combination of oxidecomputer/omicron#8859,
+    // oxidecomputer/omicron#8857, and oxidecomputer/omicron#8796.
     //
     // For now, we skip the cross-Nexus coordination and simply wait for our own
     // Nexus to finish what it's doing.
@@ -175,7 +177,7 @@ async fn do_quiesce(quiesce: NexusQuiesceHandle) {
     });
 
     // TODO per RFD 588, this is where we will enter a loop trying to update our
-    // database record for the last time.
+    // database record for the last time.  See oxidecomputer/omicron#8971.
 
     quiesce.state.send_modify(|q| {
         let QuiesceState::RecordingQuiesce {

--- a/nexus/src/app/rack.rs
+++ b/nexus/src/app/rack.rs
@@ -740,7 +740,8 @@ impl super::Nexus {
 
         // We've potentially updated the list of DNS servers and the DNS
         // configuration for both internal and external DNS, plus the Silo
-        // certificates.  Activate the relevant background tasks.
+        // certificates and target blueprint.  Activate the relevant background
+        // tasks.
         for task in &[
             &self.background_tasks.task_internal_dns_config,
             &self.background_tasks.task_internal_dns_servers,
@@ -748,6 +749,7 @@ impl super::Nexus {
             &self.background_tasks.task_external_dns_servers,
             &self.background_tasks.task_external_endpoints,
             &self.background_tasks.task_inventory_collection,
+            &self.background_tasks.task_blueprint_loader,
         ] {
             self.background_tasks.activate(task);
         }

--- a/nexus/src/lib.rs
+++ b/nexus/src/lib.rs
@@ -341,9 +341,9 @@ impl nexus_test_interface::NexusServer for Server {
             .await
             .expect("Could not initialize rack");
 
-        // Now that we have a blueprint, determination of whether sagas are
-        // quiesced can complete.  Wait for that so that tests can assume they
-        // can immediately kick off sagas.
+        // Now that we have a blueprint, determine whether sagas should be
+        // quiesced.  Wait for that so that tests can assume they can
+        // immediately kick off sagas.
         internal_server
             .apictx
             .context

--- a/nexus/src/lib.rs
+++ b/nexus/src/lib.rs
@@ -138,6 +138,15 @@ impl Server {
         // the external server we're about to start.
         apictx.context.nexus.await_ip_allowlist_plumbing().await;
 
+        // Wait until Nexus has determined if sagas are supposed to be quiesced.
+        // This is not strictly necessary.  The goal here is to prevent 503
+        // errors to clients that reach this Nexus while it's starting up and
+        // before it's figured out that it doesn't need to quiesce.  The risk of
+        // doing this is that Nexus gets stuck here, but that should only happen
+        // if it's unable to load the current blueprint, in which case
+        // something's pretty wrong and it's likely pretty stuck anyway.
+        apictx.context.nexus.wait_for_saga_determination().await;
+
         // Launch the external server.
         let tls_config = apictx
             .context
@@ -331,6 +340,16 @@ impl nexus_test_interface::NexusServer for Server {
             )
             .await
             .expect("Could not initialize rack");
+
+        // Now that we have a blueprint, determination of whether sagas are
+        // quiesced can complete.  Wait for that so that tests can assume they
+        // can immediately kick off sagas.
+        internal_server
+            .apictx
+            .context
+            .nexus
+            .wait_for_saga_determination()
+            .await;
 
         // Start the Nexus external API.
         Server::start(internal_server).await.unwrap()

--- a/nexus/tests/integration_tests/mod.rs
+++ b/nexus/tests/integration_tests/mod.rs
@@ -35,6 +35,7 @@ mod pantry;
 mod password_login;
 mod probe;
 mod projects;
+mod quiesce;
 mod quotas;
 mod rack;
 mod role_assignments;

--- a/nexus/tests/integration_tests/quiesce.rs
+++ b/nexus/tests/integration_tests/quiesce.rs
@@ -60,14 +60,10 @@ async fn test_quiesce(cptestctx: &ControlPlaneTestContext) {
         .map_or_else(PlannerChickenSwitches::default, |cs| {
             cs.switches.planner_switches
         });
-    let planning_input = PlanningInputFromDb::assemble(
-        &opctx,
-        &datastore,
-        chicken_switches,
-        None,
-    )
-    .await
-    .expect("planning input");
+    let planning_input =
+        PlanningInputFromDb::assemble(&opctx, &datastore, chicken_switches)
+            .await
+            .expect("planning input");
     let target_blueprint = nexus
         .blueprint_target_view(&opctx)
         .await
@@ -88,12 +84,7 @@ async fn test_quiesce(cptestctx: &ControlPlaneTestContext) {
         PlannerRng::from_entropy(),
     )
     .expect("creating BlueprintBuilder");
-    builder
-        .set_nexus_generation(
-            blueprint1.nexus_generation,
-            blueprint1.nexus_generation.next(),
-        )
-        .expect("failed to set blueprint's Nexus generation");
+    builder.set_nexus_generation(blueprint1.nexus_generation.next());
     let blueprint2 = builder.build();
     nexus
         .blueprint_import(&opctx, blueprint2.clone())

--- a/nexus/tests/integration_tests/quiesce.rs
+++ b/nexus/tests/integration_tests/quiesce.rs
@@ -1,0 +1,139 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at https://mozilla.org/MPL/2.0/.
+
+use anyhow::{Context, anyhow};
+use nexus_auth::context::OpContext;
+use nexus_client::types::QuiesceState;
+use nexus_reconfigurator_planning::blueprint_builder::BlueprintBuilder;
+use nexus_reconfigurator_planning::planner::PlannerRng;
+use nexus_reconfigurator_preparation::PlanningInputFromDb;
+use nexus_test_interface::NexusServer;
+use nexus_test_utils_macros::nexus_test;
+use nexus_types::deployment::BlueprintTargetSet;
+use nexus_types::deployment::PlannerChickenSwitches;
+use omicron_common::api::external::Error;
+use omicron_test_utils::dev::poll::CondCheckError;
+use omicron_test_utils::dev::poll::wait_for_condition;
+use omicron_uuid_kinds::GenericUuid;
+use std::time::Duration;
+
+type ControlPlaneTestContext =
+    nexus_test_utils::ControlPlaneTestContext<omicron_nexus::Server>;
+
+/// Tests that Nexus quiesces when the blueprint says that it should
+#[nexus_test]
+async fn test_quiesce(cptestctx: &ControlPlaneTestContext) {
+    let log = &cptestctx.logctx.log;
+    let nexus = &cptestctx.server.server_context().nexus;
+    let datastore = nexus.datastore();
+    let opctx = OpContext::for_tests(log.clone(), datastore.clone());
+    let nexus_internal_url = format!(
+        "http://{}",
+        cptestctx.server.get_http_server_internal_address().await
+    );
+    let nexus_client =
+        nexus_client::Client::new(&nexus_internal_url, log.clone());
+
+    // Collect what we need to modify the blueprint.
+    let collection = wait_for_condition(
+        || async {
+            let collection = datastore
+                .inventory_get_latest_collection(&opctx)
+                .await
+                .map_err(CondCheckError::Failed)?;
+            match collection {
+                Some(s) => Ok(s),
+                None => Err(CondCheckError::<Error>::NotYet),
+            }
+        },
+        &Duration::from_secs(1),
+        &Duration::from_secs(60),
+    )
+    .await
+    .expect("initial inventory collection");
+
+    let chicken_switches = datastore
+        .reconfigurator_chicken_switches_get_latest(&opctx)
+        .await
+        .expect("obtained latest chicken switches")
+        .map_or_else(PlannerChickenSwitches::default, |cs| {
+            cs.switches.planner_switches
+        });
+    let planning_input = PlanningInputFromDb::assemble(
+        &opctx,
+        &datastore,
+        chicken_switches,
+        None,
+    )
+    .await
+    .expect("planning input");
+    let target_blueprint = nexus
+        .blueprint_target_view(&opctx)
+        .await
+        .expect("fetch current target config");
+    let blueprint1 = nexus
+        .blueprint_view(&opctx, *target_blueprint.target_id.as_untyped_uuid())
+        .await
+        .expect("fetch current target blueprint");
+
+    // Now, update the target blueprint to reflect that Nexus should quiesce.
+    // We don't need it to be enabled to still reflect quiescing.
+    let mut builder = BlueprintBuilder::new_based_on(
+        log,
+        &blueprint1,
+        &planning_input,
+        &collection,
+        "test-suite",
+        PlannerRng::from_entropy(),
+    )
+    .expect("creating BlueprintBuilder");
+    builder
+        .set_nexus_generation(
+            blueprint1.nexus_generation,
+            blueprint1.nexus_generation.next(),
+        )
+        .expect("failed to set blueprint's Nexus generation");
+    let blueprint2 = builder.build();
+    nexus
+        .blueprint_import(&opctx, blueprint2.clone())
+        .await
+        .expect("importing new blueprint");
+    nexus
+        .blueprint_target_set(
+            &opctx,
+            BlueprintTargetSet { enabled: false, target_id: blueprint2.id },
+        )
+        .await
+        .expect("setting new target");
+
+    // Wait for Nexus to quiesce.
+    let _ = wait_for_condition(
+        || async {
+            let quiesce = nexus_client
+                .quiesce_get()
+                .await
+                .context("fetching quiesce state")
+                .map_err(CondCheckError::Failed)?
+                .into_inner();
+            eprintln!("quiesce state: {:#?}\n", quiesce);
+            match quiesce.state {
+                QuiesceState::Undetermined => {
+                    Err(CondCheckError::Failed(anyhow!(
+                        "quiesce state should have been determined before \
+                         test started"
+                    )))
+                }
+                QuiesceState::Running => Err(CondCheckError::NotYet),
+                QuiesceState::DrainingSagas { .. }
+                | QuiesceState::DrainingDb { .. }
+                | QuiesceState::RecordingQuiesce { .. }
+                | QuiesceState::Quiesced { .. } => Ok(()),
+            }
+        },
+        &Duration::from_millis(50),
+        &Duration::from_secs(30),
+    )
+    .await
+    .expect("Nexus should have quiesced");
+}

--- a/nexus/types/src/deployment.rs
+++ b/nexus/types/src/deployment.rs
@@ -388,7 +388,7 @@ impl Blueprint {
 
     /// Returns whether the given Nexus instance should be quiescing or quiesced
     /// in preparation for handoff to the next generation
-    pub fn nexus_quiescing(
+    pub fn is_nexus_quiescing(
         &self,
         nexus_id: OmicronZoneUuid,
     ) -> Result<bool, anyhow::Error> {

--- a/nexus/types/src/quiesce.rs
+++ b/nexus/types/src/quiesce.rs
@@ -218,6 +218,18 @@ impl SagaQuiesceHandle {
         let _ = self.inner.subscribe().wait_for(|q| q.is_fully_drained()).await;
     }
 
+    /// Wait for the initial determination to be made about whether sagas are
+    /// allowed or not.
+    pub async fn wait_for_determination(&self) {
+        let _ = self
+            .inner
+            .subscribe()
+            .wait_for(|q| {
+                q.new_sagas_allowed != SagasAllowed::DisallowedUnknown
+            })
+            .await;
+    }
+
     /// Returns information about running sagas (involves a clone)
     pub fn sagas_pending(&self) -> IdOrdMap<PendingSagaInfo> {
         self.inner.borrow().sagas_pending.clone()

--- a/openapi/nexus-internal.json
+++ b/openapi/nexus-internal.json
@@ -7576,8 +7576,23 @@
         ]
       },
       "QuiesceState": {
-        "description": "See [`QuiesceStatus`] for more on Nexus quiescing.\n\nAt any given time, Nexus is always in one of these states:\n\n```text Running             (normal operation) | | quiesce starts v WaitingForSagas     (no new sagas are allowed, but some are still running) | | no more sagas running v WaitingForDb        (no sagas running; no new db connections may be acquired by Nexus at-large, but some are still held) | | no more database connections held v Quiesced            (no sagas running, no database connections in use) ```\n\nQuiescing is (currently) a one-way trip: once a Nexus process starts quiescing, it will never go back to normal operation.  It will never go back to an earlier stage, either.",
+        "description": "See [`QuiesceStatus`] for more on Nexus quiescing.\n\nAt any given time, Nexus is always in one of these states:\n\n```text Undetermined        (have not loaded persistent state; don't know yet) | | load persistent state and find we're not quiescing v Running             (normal operation) | | quiesce starts v DrainingSagas       (no new sagas are allowed, but some are still running) | | no more sagas running v DrainingDb          (no sagas running; no new db connections may be |                  acquired by Nexus at-large, but some are still held) | | no more database connections held v RecordingQuiesce    (everything is quiesced aside from one connection being |                  used to record our final quiesced state) | | finish recording quiesce state in database v Quiesced            (no sagas running, no database connections in use) ```\n\nQuiescing is (currently) a one-way trip: once a Nexus process starts quiescing, it will never go back to normal operation.  It will never go back to an earlier stage, either.",
         "oneOf": [
+          {
+            "description": "We have not yet determined based on persistent state if we're supposed to be quiesced or not",
+            "type": "object",
+            "properties": {
+              "state": {
+                "type": "string",
+                "enum": [
+                  "undetermined"
+                ]
+              }
+            },
+            "required": [
+              "state"
+            ]
+          },
           {
             "description": "Normal operation",
             "type": "object",
@@ -7594,7 +7609,7 @@
             ]
           },
           {
-            "description": "New sagas disallowed, but some are still running.",
+            "description": "New sagas disallowed, but some are still running on some Nexus instances",
             "type": "object",
             "properties": {
               "quiesce_details": {
@@ -7612,7 +7627,7 @@
               "state": {
                 "type": "string",
                 "enum": [
-                  "waiting_for_sagas"
+                  "draining_sagas"
                 ]
               }
             },
@@ -7622,13 +7637,13 @@
             ]
           },
           {
-            "description": "No sagas running, no new database connections may be claimed, but some database connections are still held.",
+            "description": "No sagas running on any Nexus instances\n\nNo new database connections may be claimed, but some database connections are still held.",
             "type": "object",
             "properties": {
               "quiesce_details": {
                 "type": "object",
                 "properties": {
-                  "duration_waiting_for_sagas": {
+                  "duration_draining_sagas": {
                     "$ref": "#/components/schemas/Duration"
                   },
                   "time_requested": {
@@ -7637,14 +7652,50 @@
                   }
                 },
                 "required": [
-                  "duration_waiting_for_sagas",
+                  "duration_draining_sagas",
                   "time_requested"
                 ]
               },
               "state": {
                 "type": "string",
                 "enum": [
-                  "waiting_for_db"
+                  "draining_db"
+                ]
+              }
+            },
+            "required": [
+              "quiesce_details",
+              "state"
+            ]
+          },
+          {
+            "description": "No database connections in use except to record the final \"quiesced\" state",
+            "type": "object",
+            "properties": {
+              "quiesce_details": {
+                "type": "object",
+                "properties": {
+                  "duration_draining_db": {
+                    "$ref": "#/components/schemas/Duration"
+                  },
+                  "duration_draining_sagas": {
+                    "$ref": "#/components/schemas/Duration"
+                  },
+                  "time_requested": {
+                    "type": "string",
+                    "format": "date-time"
+                  }
+                },
+                "required": [
+                  "duration_draining_db",
+                  "duration_draining_sagas",
+                  "time_requested"
+                ]
+              },
+              "state": {
+                "type": "string",
+                "enum": [
+                  "recording_quiesce"
                 ]
               }
             },
@@ -7660,13 +7711,16 @@
               "quiesce_details": {
                 "type": "object",
                 "properties": {
+                  "duration_draining_db": {
+                    "$ref": "#/components/schemas/Duration"
+                  },
+                  "duration_draining_sagas": {
+                    "$ref": "#/components/schemas/Duration"
+                  },
+                  "duration_recording_quiesce": {
+                    "$ref": "#/components/schemas/Duration"
+                  },
                   "duration_total": {
-                    "$ref": "#/components/schemas/Duration"
-                  },
-                  "duration_waiting_for_db": {
-                    "$ref": "#/components/schemas/Duration"
-                  },
-                  "duration_waiting_for_sagas": {
                     "$ref": "#/components/schemas/Duration"
                   },
                   "time_quiesced": {
@@ -7679,9 +7733,10 @@
                   }
                 },
                 "required": [
+                  "duration_draining_db",
+                  "duration_draining_sagas",
+                  "duration_recording_quiesce",
                   "duration_total",
-                  "duration_waiting_for_db",
-                  "duration_waiting_for_sagas",
                   "time_quiesced",
                   "time_requested"
                 ]


### PR DESCRIPTION
~~Depends on #8863.~~  Fixes #8855 and #8856.

~~**Note:** since this branches from 8863, if that branch gets force-pushed, this one will also need to be force-pushed.  This may break your incremental review flow.~~

This PR makes the initial changes required for Nexus quiesce described by RFD 588:

- Refactors the mechanics of Nexus quiesce to use a new `NexusQuiesceHandle`.  This was so that that can be invoked from a background task.
- Triggers quiesce from the `blueprint_execution` background task based on whether the current target blueprint says we should be handing off.  (This is what fixes #8855 and #8856.)  It does this even if blueprint execution is disabled.
- Disallows the creation of new sagas until we figure out if we're quiesced or not.  In practice, this should happen soon after Nexus startup.  It depends on the blueprint_loader and then blueprint_execution background tasks running.
- Changes the quiesce states to reflect what they will be when we finish RFD 588.  "WaitingFor" is changed to "Draining" (e.g., `WaitingForSagas` -> `DrainingSagas`) and there's a new `RecordingQuiesce` state that will cover the period after we've determined we're quiesced and before we've written the database record saying so.
- Makes it *legal* to re-assign sagas after becoming "locally drained" (as defined in RFD 588).  #8796 explains why this is desirable.  RFD 588 explains how this will eventually result in a safe handoff.  However, this PR does not implement 8796 -- more below.

This PR does *not* change the quiesce process to coordinate among the Nexus instances (as described in RFD 588) nor update the `db_metadata_nexus` table.  Both of these are blocked on #8845.

The net result is a little awkward:

- There's this new `RecordingQuiesce` state that's basically unused (it _is_ technically used, but we transition through it immediately)
- Since this PR now _allows_ saga reassignment after becoming locally drained, but does not wait for other Nexus instances to finish draining before entering db-quiesce, it is now possible to drain sagas fro this Nexus and have it enter db-quiesce _and_ wind up assigning sagas to itself, which would then become implicitly abandoned.

I think this is okay as an intermediate state, even on "main", since this cannot be triggered except by an online update, and we know we're going to fix these as part of shipping that.