### PR TITLE
TQ: cluster proptest Action/Event cleanup

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -842,6 +842,11 @@ opt-level = 3
 [profile.dev.package.bootstore]
 opt-level = 3
 
+[profile.dev.package.trust-quorum]
+opt-level = 3
+[profile.dev.package.trust-quorum-test-utils]
+opt-level = 3
+
 # Crypto stuff always needs optimizations
 [profile.dev.package.sha3]
 opt-level = 3

--- a/trust-quorum/Cargo.toml
+++ b/trust-quorum/Cargo.toml
@@ -52,3 +52,4 @@ trust-quorum-test-utils.workspace = true
 # subtle when we do this. On the other hand its very useful for testing and
 # debugging outside of production.
 danger_partial_eq_ct_wrapper = ["gfss/danger_partial_eq_ct_wrapper"]
+testing = []

--- a/trust-quorum/src/lib.rs
+++ b/trust-quorum/src/lib.rs
@@ -139,6 +139,15 @@ pub struct Envelope {
     pub msg: PeerMsg,
 }
 
+#[cfg(feature = "testing")]
+impl Envelope {
+    pub fn equal_except_for_crypto_data(&self, other: &Self) -> bool {
+        self.to == other.to
+            && self.from == other.from
+            && self.msg.equal_except_for_crypto_data(&other.msg)
+    }
+}
+
 /// Check if a received share is valid for a given configuration
 ///
 /// Return true if valid, false otherwise.

--- a/trust-quorum/src/messages.rs
+++ b/trust-quorum/src/messages.rs
@@ -30,6 +30,14 @@ pub struct PeerMsg {
     pub kind: PeerMsgKind,
 }
 
+impl PeerMsg {
+    #[cfg(feature = "testing")]
+    pub fn equal_except_for_crypto_data(&self, other: &Self) -> bool {
+        self.rack_id == other.rack_id
+            && self.kind.equal_except_for_crypto_data(&other.kind)
+    }
+}
+
 #[derive(Debug, Clone, Serialize, Deserialize)]
 #[cfg_attr(feature = "danger_partial_eq_ct_wrapper", derive(PartialEq, Eq))]
 pub enum PeerMsgKind {
@@ -90,6 +98,30 @@ impl PeerMsgKind {
             Self::LrtqShare(_) => "lrtq_share",
             Self::Expunged(_) => "expunged",
             Self::CommitAdvance(_) => "commit_advance",
+        }
+    }
+
+    /// This is useful for our replay tests without having to worry about seeding
+    /// the various random number generators in our production code.
+    #[cfg(feature = "testing")]
+    pub fn equal_except_for_crypto_data(&self, other: &Self) -> bool {
+        match (self, other) {
+            (
+                Self::Prepare { config: config1, .. },
+                Self::Prepare { config: config2, .. },
+            ) => config1.equal_except_for_crypto_data(config2),
+            (Self::Config(config1), Self::Config(config2)) => {
+                config1.equal_except_for_crypto_data(config2)
+            }
+            (
+                Self::Share { epoch: epoch1, .. },
+                Self::Share { epoch: epoch2, .. },
+            ) => epoch1 == epoch2,
+            (Self::LrtqShare(_), Self::LrtqShare(_)) => true,
+            (Self::CommitAdvance(config1), Self::CommitAdvance(config2)) => {
+                config1.equal_except_for_crypto_data(config2)
+            }
+            (s, o) => s == o,
         }
     }
 }

--- a/trust-quorum/test-utils/Cargo.toml
+++ b/trust-quorum/test-utils/Cargo.toml
@@ -16,6 +16,6 @@ omicron-uuid-kinds.workspace = true
 serde.workspace = true
 serde_json.workspace = true
 slog.workspace = true
-trust-quorum = { workspace = true, features = ["danger_partial_eq_ct_wrapper"] }
+trust-quorum = { workspace = true, features = ["danger_partial_eq_ct_wrapper", "testing"] }
 
 omicron-workspace-hack.workspace = true

--- a/trust-quorum/test-utils/src/nexus.rs
+++ b/trust-quorum/test-utils/src/nexus.rs
@@ -113,7 +113,9 @@ pub struct NexusState {
 impl NexusState {
     #[allow(clippy::new_without_default)]
     pub fn new() -> NexusState {
-        NexusState { rack_id: RackUuid::new_v4(), configs: IdOrdMap::new() }
+        // We end up replaying events in tqdb, and can't use a random rack
+        // uuid.
+        NexusState { rack_id: RackUuid::nil(), configs: IdOrdMap::new() }
     }
 
     // Create a `ReconfigureMsg` for the latest nexus config


### PR DESCRIPTION
This builds on #8874 

To make using using tqdb easier, we put all necessary information inside events. This works because of deterministic replay using the same infrastucture as the proptest itself. To ensure we are truly deterministically replaying we must assert that any Event in our log has actually been generated when we go to apply it in tqdb. In the common case case this is equivalent to asserting that the `DeliveredEnvelope` is actually the same as the one pulled off the `bootstrap_network` vec during runs. In order to guarantee this a few changes needed to be made:

1. Determinism exists, except for in the crypto code because we don't seed the various random number generators, and therefore different key shares and rack secrets get generated in different runs. We could seed them, but then this makes it possible that we accidentally seed them in production code. More importantly for our current purposes, though, is that it's tedious and unnecessary. Instead we just implement comparison methods for messages that ignore things like key shares. This works fine because if the shares are not self-consistent with the rack secret and the parameters such as threshold that we don't change the crypto code itself will fail immediately.

2. We had a few actions that generated multiple events. Unfortunately, applying these events would result in mutating the test networks multiple times,  resulting in a difference between which message was recorded and which was actually pulled out to be delivered. This was fixed by changing each action to only do a single thing at a time, like deliver one envelope or commit a configuration at one node. This also allows for finer grain interleaving and matches better with our TLA+ spec/model checking. This was observable by looking at the event logs.

The change to an action typically generating a single event means, however, that we need to generate more actions per run to get the equivalent functionality. A single action won't result in N commits or N envelopes delivered. Therefore, each test run now needs to have significantly more actions generated. Unfortunately this can make test runs even longer. In order to help alleviate this we made three other changes:

1. We change the invariant checks to only look at nodes that could possibly be mutated by an event application. We call these the "affected nodes". This prevents looping over every node in each check.
2. We reduce the member universe, and hence the size of the state space.
3. We reduce the total number of test cases per run.