### PR TITLE
[omdb] add --no-executing-info to the other background-tasks commands

### DIFF
--- a/dev-tools/omdb/tests/successes.out
+++ b/dev-tools/omdb/tests/successes.out
@@ -808,13 +808,12 @@ task: "webhook_deliverator"
 stderr:
 note: using Nexus URL http://127.0.0.1:REDACTED_PORT/
 =============================================
-EXECUTING COMMAND: omdb ["nexus", "background-tasks", "show", "saga_recovery"]
+EXECUTING COMMAND: omdb ["nexus", "background-tasks", "show", "saga_recovery", "--no-executing-info"]
 termination: Exited(0)
 ---------------------------------------------
 stdout:
 task: "saga_recovery"
   configured period: every <REDACTED_DURATION>m
-  currently executing: no
   last completed activation: <REDACTED ITERATIONS>, triggered by a periodic timer firing
     started at <REDACTED_TIMESTAMP> (<REDACTED DURATION>s ago) and ran for <REDACTED DURATION>ms
     since Nexus started:
@@ -837,20 +836,18 @@ task: "saga_recovery"
 stderr:
 note: using Nexus URL http://127.0.0.1:REDACTED_PORT/
 =============================================
-EXECUTING COMMAND: omdb ["nexus", "background-tasks", "show", "blueprint_loader", "blueprint_executor"]
+EXECUTING COMMAND: omdb ["nexus", "background-tasks", "show", "blueprint_loader", "blueprint_executor", "--no-executing-info"]
 termination: Exited(0)
 ---------------------------------------------
 stdout:
 task: "blueprint_loader"
   configured period: every <REDACTED_DURATION>m <REDACTED_DURATION>s
-  currently executing: no
   last completed activation: <REDACTED ITERATIONS>, triggered by a periodic timer firing
     started at <REDACTED_TIMESTAMP> (<REDACTED DURATION>s ago) and ran for <REDACTED DURATION>ms
     last completion reported error: failed to read target blueprint: Internal Error: no target blueprint set
 
 task: "blueprint_executor"
   configured period: every <REDACTED_DURATION>m
-  currently executing: no
   last completed activation: <REDACTED ITERATIONS>, triggered by a periodic timer firing
     started at <REDACTED_TIMESTAMP> (<REDACTED DURATION>s ago) and ran for <REDACTED DURATION>ms
     last completion reported error: no blueprint
@@ -859,20 +856,18 @@ task: "blueprint_executor"
 stderr:
 note: using Nexus URL http://127.0.0.1:REDACTED_PORT/
 =============================================
-EXECUTING COMMAND: omdb ["nexus", "background-tasks", "show", "dns_internal"]
+EXECUTING COMMAND: omdb ["nexus", "background-tasks", "show", "dns_internal", "--no-executing-info"]
 termination: Exited(0)
 ---------------------------------------------
 stdout:
 task: "dns_config_internal"
   configured period: every <REDACTED_DURATION>m
-  currently executing: no
   last completed activation: <REDACTED ITERATIONS>, triggered by an explicit signal
     started at <REDACTED_TIMESTAMP> (<REDACTED DURATION>s ago) and ran for <REDACTED DURATION>ms
     last generation found: 1
 
 task: "dns_servers_internal"
   configured period: every <REDACTED_DURATION>m
-  currently executing: no
   last completed activation: <REDACTED ITERATIONS>, triggered by an explicit signal
     started at <REDACTED_TIMESTAMP> (<REDACTED DURATION>s ago) and ran for <REDACTED DURATION>ms
     servers found: 1
@@ -882,7 +877,6 @@ task: "dns_servers_internal"
 
 task: "dns_propagation_internal"
   configured period: every <REDACTED_DURATION>m
-  currently executing: no
   last completed activation: <REDACTED ITERATIONS>, triggered by a dependent task completing
     started at <REDACTED_TIMESTAMP> (<REDACTED DURATION>s ago) and ran for <REDACTED DURATION>ms
     attempt to propagate generation: 1
@@ -895,20 +889,18 @@ task: "dns_propagation_internal"
 stderr:
 note: using Nexus URL http://127.0.0.1:REDACTED_PORT/
 =============================================
-EXECUTING COMMAND: omdb ["nexus", "background-tasks", "show", "dns_external"]
+EXECUTING COMMAND: omdb ["nexus", "background-tasks", "show", "dns_external", "--no-executing-info"]
 termination: Exited(0)
 ---------------------------------------------
 stdout:
 task: "dns_config_external"
   configured period: every <REDACTED_DURATION>m
-  currently executing: no
   last completed activation: <REDACTED ITERATIONS>, triggered by an explicit signal
     started at <REDACTED_TIMESTAMP> (<REDACTED DURATION>s ago) and ran for <REDACTED DURATION>ms
     last generation found: 2
 
 task: "dns_servers_external"
   configured period: every <REDACTED_DURATION>m
-  currently executing: no
   last completed activation: <REDACTED ITERATIONS>, triggered by an explicit signal
     started at <REDACTED_TIMESTAMP> (<REDACTED DURATION>s ago) and ran for <REDACTED DURATION>ms
     servers found: 1
@@ -918,7 +910,6 @@ task: "dns_servers_external"
 
 task: "dns_propagation_external"
   configured period: every <REDACTED_DURATION>m
-  currently executing: no
   last completed activation: <REDACTED ITERATIONS>, triggered by a dependent task completing
     started at <REDACTED_TIMESTAMP> (<REDACTED DURATION>s ago) and ran for <REDACTED DURATION>ms
     attempt to propagate generation: 2
@@ -931,20 +922,18 @@ task: "dns_propagation_external"
 stderr:
 note: using Nexus URL http://127.0.0.1:REDACTED_PORT/
 =============================================
-EXECUTING COMMAND: omdb ["nexus", "background-tasks", "show", "all"]
+EXECUTING COMMAND: omdb ["nexus", "background-tasks", "show", "all", "--no-executing-info"]
 termination: Exited(0)
 ---------------------------------------------
 stdout:
 task: "dns_config_internal"
   configured period: every <REDACTED_DURATION>m
-  currently executing: no
   last completed activation: <REDACTED ITERATIONS>, triggered by an explicit signal
     started at <REDACTED_TIMESTAMP> (<REDACTED DURATION>s ago) and ran for <REDACTED DURATION>ms
     last generation found: 1
 
 task: "dns_servers_internal"
   configured period: every <REDACTED_DURATION>m
-  currently executing: no
   last completed activation: <REDACTED ITERATIONS>, triggered by an explicit signal
     started at <REDACTED_TIMESTAMP> (<REDACTED DURATION>s ago) and ran for <REDACTED DURATION>ms
     servers found: 1
@@ -954,7 +943,6 @@ task: "dns_servers_internal"
 
 task: "dns_propagation_internal"
   configured period: every <REDACTED_DURATION>m
-  currently executing: no
   last completed activation: <REDACTED ITERATIONS>, triggered by a dependent task completing
     started at <REDACTED_TIMESTAMP> (<REDACTED DURATION>s ago) and ran for <REDACTED DURATION>ms
     attempt to propagate generation: 1
@@ -965,14 +953,12 @@ task: "dns_propagation_internal"
 
 task: "dns_config_external"
   configured period: every <REDACTED_DURATION>m
-  currently executing: no
   last completed activation: <REDACTED ITERATIONS>, triggered by an explicit signal
     started at <REDACTED_TIMESTAMP> (<REDACTED DURATION>s ago) and ran for <REDACTED DURATION>ms
     last generation found: 2
 
 task: "dns_servers_external"
   configured period: every <REDACTED_DURATION>m
-  currently executing: no
   last completed activation: <REDACTED ITERATIONS>, triggered by an explicit signal
     started at <REDACTED_TIMESTAMP> (<REDACTED DURATION>s ago) and ran for <REDACTED DURATION>ms
     servers found: 1
@@ -982,7 +968,6 @@ task: "dns_servers_external"
 
 task: "dns_propagation_external"
   configured period: every <REDACTED_DURATION>m
-  currently executing: no
   last completed activation: <REDACTED ITERATIONS>, triggered by a dependent task completing
     started at <REDACTED_TIMESTAMP> (<REDACTED DURATION>s ago) and ran for <REDACTED DURATION>ms
     attempt to propagate generation: 2
@@ -993,28 +978,24 @@ task: "dns_propagation_external"
 
 task: "nat_garbage_collector"
   configured period: every <REDACTED_DURATION>s
-  currently executing: no
   last completed activation: <REDACTED ITERATIONS>, triggered by a periodic timer firing
     started at <REDACTED_TIMESTAMP> (<REDACTED DURATION>s ago) and ran for <REDACTED DURATION>ms
     last completion reported error: failed to resolve addresses for Dendrite services: proto error: no records found for Query { name: Name("_dendrite._tcp.control-plane.oxide.internal."), query_type: SRV, query_class: IN }
 
 task: "blueprint_loader"
   configured period: every <REDACTED_DURATION>m <REDACTED_DURATION>s
-  currently executing: no
   last completed activation: <REDACTED ITERATIONS>, triggered by a periodic timer firing
     started at <REDACTED_TIMESTAMP> (<REDACTED DURATION>s ago) and ran for <REDACTED DURATION>ms
     last completion reported error: failed to read target blueprint: Internal Error: no target blueprint set
 
 task: "blueprint_executor"
   configured period: every <REDACTED_DURATION>m
-  currently executing: no
   last completed activation: <REDACTED ITERATIONS>, triggered by a periodic timer firing
     started at <REDACTED_TIMESTAMP> (<REDACTED DURATION>s ago) and ran for <REDACTED DURATION>ms
     last completion reported error: no blueprint
 
 task: "abandoned_vmm_reaper"
   configured period: every <REDACTED_DURATION>m
-  currently executing: no
   last completed activation: <REDACTED ITERATIONS>, triggered by a periodic timer firing
     started at <REDACTED_TIMESTAMP> (<REDACTED DURATION>s ago) and ran for <REDACTED DURATION>ms
     total abandoned VMMs found:                0
@@ -1024,7 +1005,6 @@ task: "abandoned_vmm_reaper"
 
 task: "alert_dispatcher"
   configured period: every <REDACTED_DURATION>m
-  currently executing: no
   last completed activation: <REDACTED ITERATIONS>, triggered by a periodic timer firing
     started at <REDACTED_TIMESTAMP> (<REDACTED DURATION>s ago) and ran for <REDACTED DURATION>ms
     alerts dispatched:                            0
@@ -1032,49 +1012,42 @@ task: "alert_dispatcher"
 
 task: "bfd_manager"
   configured period: every <REDACTED_DURATION>s
-  currently executing: no
   last completed activation: <REDACTED ITERATIONS>, triggered by a periodic timer firing
     started at <REDACTED_TIMESTAMP> (<REDACTED DURATION>s ago) and ran for <REDACTED DURATION>ms
     last completion reported error: failed to resolve addresses for Dendrite services: proto error: no records found for Query { name: Name("_dendrite._tcp.control-plane.oxide.internal."), query_type: SRV, query_class: IN }
 
 task: "blueprint_planner"
   configured period: every <REDACTED_DURATION>m
-  currently executing: no
   last completed activation: <REDACTED ITERATIONS>, triggered by a dependent task completing
     started at <REDACTED_TIMESTAMP> (<REDACTED DURATION>s ago) and ran for <REDACTED DURATION>ms
     blueprint planning explicitly disabled by config!
 
 task: "blueprint_rendezvous"
   configured period: every <REDACTED_DURATION>m
-  currently executing: no
   last completed activation: <REDACTED ITERATIONS>, triggered by a dependent task completing
     started at <REDACTED_TIMESTAMP> (<REDACTED DURATION>s ago) and ran for <REDACTED DURATION>ms
     last completion reported error: no blueprint
 
 task: "chicken_switches_watcher"
   configured period: every <REDACTED_DURATION>s
-  currently executing: no
   last completed activation: <REDACTED ITERATIONS>, triggered by a periodic timer firing
     started at <REDACTED_TIMESTAMP> (<REDACTED DURATION>s ago) and ran for <REDACTED DURATION>ms
 warning: unknown background task: "chicken_switches_watcher" (don't know how to interpret details: Object {"chicken_switches_updated": Bool(false)})
 
 task: "crdb_node_id_collector"
   configured period: every <REDACTED_DURATION>m
-  currently executing: no
   last completed activation: <REDACTED ITERATIONS>, triggered by a periodic timer firing
     started at <REDACTED_TIMESTAMP> (<REDACTED DURATION>s ago) and ran for <REDACTED DURATION>ms
     last completion reported error: no blueprint
 
 task: "decommissioned_disk_cleaner"
   configured period: every <REDACTED_DURATION>m
-  currently executing: no
   last completed activation: <REDACTED ITERATIONS>, triggered by a periodic timer firing
     started at <REDACTED_TIMESTAMP> (<REDACTED DURATION>s ago) and ran for <REDACTED DURATION>ms
 warning: unknown background task: "decommissioned_disk_cleaner" (don't know how to interpret details: Object {"deleted": Number(0), "error": Null, "error_count": Number(0), "found": Number(0), "not_ready_to_be_deleted": Number(0)})
 
 task: "external_endpoints"
   configured period: every <REDACTED_DURATION>m
-  currently executing: no
   last completed activation: <REDACTED ITERATIONS>, triggered by an explicit signal
     started at <REDACTED_TIMESTAMP> (<REDACTED DURATION>s ago) and ran for <REDACTED DURATION>ms
     external API endpoints: 2 ('*' below marks default)
@@ -1091,7 +1064,6 @@ task: "external_endpoints"
 
 task: "instance_reincarnation"
   configured period: every <REDACTED_DURATION>m
-  currently executing: no
   last completed activation: <REDACTED ITERATIONS>, triggered by a periodic timer firing
     started at <REDACTED_TIMESTAMP> (<REDACTED DURATION>s ago) and ran for <REDACTED DURATION>ms
     instances eligible for reincarnation:                          0
@@ -1103,7 +1075,6 @@ task: "instance_reincarnation"
 
 task: "instance_updater"
   configured period: every <REDACTED_DURATION>s
-  currently executing: no
   last completed activation: <REDACTED ITERATIONS>, triggered by a periodic timer firing
     started at <REDACTED_TIMESTAMP> (<REDACTED DURATION>s ago) and ran for <REDACTED DURATION>ms
     task explicitly disabled by config!
@@ -1117,7 +1088,6 @@ task: "instance_updater"
 
 task: "instance_watcher"
   configured period: every <REDACTED_DURATION>s
-  currently executing: no
   last completed activation: <REDACTED ITERATIONS>, triggered by a periodic timer firing
     started at <REDACTED_TIMESTAMP> (<REDACTED DURATION>s ago) and ran for <REDACTED DURATION>ms
     total instances checked: 0
@@ -1130,7 +1100,6 @@ task: "instance_watcher"
 
 task: "inventory_collection"
   configured period: every <REDACTED_DURATION>m
-  currently executing: no
   last completed activation: <REDACTED ITERATIONS>, triggered by an explicit signal
     started at <REDACTED_TIMESTAMP> (<REDACTED DURATION>s ago) and ran for <REDACTED DURATION>ms
     last collection id:      ..........<REDACTED_UUID>...........
@@ -1139,7 +1108,6 @@ task: "inventory_collection"
 
 task: "lookup_region_port"
   configured period: every <REDACTED_DURATION>m
-  currently executing: no
   last completed activation: <REDACTED ITERATIONS>, triggered by a periodic timer firing
     started at <REDACTED_TIMESTAMP> (<REDACTED DURATION>s ago) and ran for <REDACTED DURATION>ms
     total filled in ports: 0
@@ -1147,14 +1115,12 @@ task: "lookup_region_port"
 
 task: "metrics_producer_gc"
   configured period: every <REDACTED_DURATION>m
-  currently executing: no
   last completed activation: <REDACTED ITERATIONS>, triggered by a periodic timer firing
     started at <REDACTED_TIMESTAMP> (<REDACTED DURATION>s ago) and ran for <REDACTED DURATION>ms
 warning: unknown background task: "metrics_producer_gc" (don't know how to interpret details: Object {"expiration": String("<REDACTED_TIMESTAMP>"), "pruned": Array []})
 
 task: "phantom_disks"
   configured period: every <REDACTED_DURATION>s
-  currently executing: no
   last completed activation: <REDACTED ITERATIONS>, triggered by a periodic timer firing
     started at <REDACTED_TIMESTAMP> (<REDACTED DURATION>s ago) and ran for <REDACTED DURATION>ms
     number of phantom disks deleted: 0
@@ -1162,14 +1128,12 @@ task: "phantom_disks"
 
 task: "physical_disk_adoption"
   configured period: every <REDACTED_DURATION>s
-  currently executing: no
   last completed activation: <REDACTED ITERATIONS>, triggered by a dependent task completing
     started at <REDACTED_TIMESTAMP> (<REDACTED DURATION>s ago) and ran for <REDACTED DURATION>ms
     last completion reported error: task disabled
 
 task: "read_only_region_replacement_start"
   configured period: every <REDACTED_DURATION>m
-  currently executing: no
   last completed activation: <REDACTED ITERATIONS>, triggered by a periodic timer firing
     started at <REDACTED_TIMESTAMP> (<REDACTED DURATION>s ago) and ran for <REDACTED DURATION>ms
     total requests created ok: 0
@@ -1177,7 +1141,6 @@ task: "read_only_region_replacement_start"
 
 task: "region_replacement"
   configured period: every <REDACTED_DURATION>m
-  currently executing: no
   last completed activation: <REDACTED ITERATIONS>, triggered by a periodic timer firing
     started at <REDACTED_TIMESTAMP> (<REDACTED DURATION>s ago) and ran for <REDACTED DURATION>ms
     region replacement requests created ok: 0
@@ -1187,7 +1150,6 @@ task: "region_replacement"
 
 task: "region_replacement_driver"
   configured period: every <REDACTED_DURATION>m
-  currently executing: no
   last completed activation: <REDACTED ITERATIONS>, triggered by a periodic timer firing
     started at <REDACTED_TIMESTAMP> (<REDACTED DURATION>s ago) and ran for <REDACTED DURATION>ms
     region replacement drive sagas started ok: 0
@@ -1196,7 +1158,6 @@ task: "region_replacement_driver"
 
 task: "region_snapshot_replacement_finish"
   configured period: every <REDACTED_DURATION>m
-  currently executing: no
   last completed activation: <REDACTED ITERATIONS>, triggered by a periodic timer firing
     started at <REDACTED_TIMESTAMP> (<REDACTED DURATION>s ago) and ran for <REDACTED DURATION>ms
     region snapshot replacement finish sagas started ok: 0
@@ -1204,7 +1165,6 @@ task: "region_snapshot_replacement_finish"
 
 task: "region_snapshot_replacement_garbage_collection"
   configured period: every <REDACTED_DURATION>m
-  currently executing: no
   last completed activation: <REDACTED ITERATIONS>, triggered by a periodic timer firing
     started at <REDACTED_TIMESTAMP> (<REDACTED DURATION>s ago) and ran for <REDACTED DURATION>ms
     total garbage collections requested: 0
@@ -1212,7 +1172,6 @@ task: "region_snapshot_replacement_garbage_collection"
 
 task: "region_snapshot_replacement_start"
   configured period: every <REDACTED_DURATION>m
-  currently executing: no
   last completed activation: <REDACTED ITERATIONS>, triggered by a periodic timer firing
     started at <REDACTED_TIMESTAMP> (<REDACTED DURATION>s ago) and ran for <REDACTED DURATION>ms
     total requests created ok: 0
@@ -1222,7 +1181,6 @@ task: "region_snapshot_replacement_start"
 
 task: "region_snapshot_replacement_step"
   configured period: every <REDACTED_DURATION>m
-  currently executing: no
   last completed activation: <REDACTED ITERATIONS>, triggered by a periodic timer firing
     started at <REDACTED_TIMESTAMP> (<REDACTED DURATION>s ago) and ran for <REDACTED DURATION>ms
     total step records created ok: 0
@@ -1233,7 +1191,6 @@ task: "region_snapshot_replacement_step"
 
 task: "saga_recovery"
   configured period: every <REDACTED_DURATION>m
-  currently executing: no
   last completed activation: <REDACTED ITERATIONS>, triggered by a periodic timer firing
     started at <REDACTED_TIMESTAMP> (<REDACTED DURATION>s ago) and ran for <REDACTED DURATION>ms
     since Nexus started:
@@ -1254,20 +1211,17 @@ task: "saga_recovery"
 
 task: "service_firewall_rule_propagation"
   configured period: every <REDACTED_DURATION>m
-  currently executing: no
   last completed activation: <REDACTED ITERATIONS>, triggered by a periodic timer firing
     started at <REDACTED_TIMESTAMP> (<REDACTED DURATION>s ago) and ran for <REDACTED DURATION>ms
 
 task: "service_zone_nat_tracker"
   configured period: every <REDACTED_DURATION>s
-  currently executing: no
   last completed activation: <REDACTED ITERATIONS>, triggered by a periodic timer firing
     started at <REDACTED_TIMESTAMP> (<REDACTED DURATION>s ago) and ran for <REDACTED DURATION>ms
     last completion reported error: inventory collection is None
 
 task: "sp_ereport_ingester"
   configured period: every <REDACTED_DURATION>s
-  currently executing: no
   last completed activation: <REDACTED ITERATIONS>, triggered by a periodic timer firing
     started at <REDACTED_TIMESTAMP> (<REDACTED DURATION>s ago) and ran for <REDACTED DURATION>ms
 /!\ errors:                  1
@@ -1281,7 +1235,6 @@ task: "sp_ereport_ingester"
 
 task: "support_bundle_collector"
   configured period: every <REDACTED_DURATION>days <REDACTED_DURATION>h <REDACTED_DURATION>m <REDACTED_DURATION>s
-  currently executing: no
   last completed activation: <REDACTED ITERATIONS>, triggered by a periodic timer firing
     started at <REDACTED_TIMESTAMP> (<REDACTED DURATION>s ago) and ran for <REDACTED DURATION>ms
     Support Bundle Cleanup Report:
@@ -1293,14 +1246,12 @@ task: "support_bundle_collector"
 
 task: "switch_port_config_manager"
   configured period: every <REDACTED_DURATION>s
-  currently executing: no
   last completed activation: <REDACTED ITERATIONS>, triggered by a periodic timer firing
     started at <REDACTED_TIMESTAMP> (<REDACTED DURATION>s ago) and ran for <REDACTED DURATION>ms
 warning: unknown background task: "switch_port_config_manager" (don't know how to interpret details: Object {})
 
 task: "tuf_artifact_replication"
   configured period: every <REDACTED_DURATION>h
-  currently executing: no
   last completed activation: <REDACTED ITERATIONS>, triggered by a periodic timer firing
     started at <REDACTED_TIMESTAMP> (<REDACTED DURATION>s ago) and ran for <REDACTED DURATION>ms
     request ringbuf:
@@ -1327,21 +1278,18 @@ task: "tuf_artifact_replication"
 
 task: "v2p_manager"
   configured period: every <REDACTED_DURATION>s
-  currently executing: no
   last completed activation: <REDACTED ITERATIONS>, triggered by a periodic timer firing
     started at <REDACTED_TIMESTAMP> (<REDACTED DURATION>s ago) and ran for <REDACTED DURATION>ms
 warning: unknown background task: "v2p_manager" (don't know how to interpret details: Object {})
 
 task: "vpc_route_manager"
   configured period: every <REDACTED_DURATION>s
-  currently executing: no
   last completed activation: <REDACTED ITERATIONS>, triggered by a periodic timer firing
     started at <REDACTED_TIMESTAMP> (<REDACTED DURATION>s ago) and ran for <REDACTED DURATION>ms
 warning: unknown background task: "vpc_route_manager" (don't know how to interpret details: Object {})
 
 task: "webhook_deliverator"
   configured period: every <REDACTED_DURATION>m
-  currently executing: no
   last completed activation: <REDACTED ITERATIONS>, triggered by a periodic timer firing
     started at <REDACTED_TIMESTAMP> (<REDACTED DURATION>s ago) and ran for <REDACTED DURATION>ms
     receivers:                            0

--- a/dev-tools/omdb/tests/test_all_output.rs
+++ b/dev-tools/omdb/tests/test_all_output.rs
@@ -196,18 +196,37 @@ async fn test_omdb_success_cases(cptestctx: &ControlPlaneTestContext) {
         // actually being flaky yet, though.
         &["nexus", "background-tasks", "show", "--no-executing-info"],
         // background tasks: test picking out specific names
-        &["nexus", "background-tasks", "show", "saga_recovery"],
+        &[
+            "nexus",
+            "background-tasks",
+            "show",
+            "saga_recovery",
+            "--no-executing-info",
+        ],
         &[
             "nexus",
             "background-tasks",
             "show",
             "blueprint_loader",
             "blueprint_executor",
+            "--no-executing-info",
         ],
         // background tasks: test recognized group names
-        &["nexus", "background-tasks", "show", "dns_internal"],
-        &["nexus", "background-tasks", "show", "dns_external"],
-        &["nexus", "background-tasks", "show", "all"],
+        &[
+            "nexus",
+            "background-tasks",
+            "show",
+            "dns_internal",
+            "--no-executing-info",
+        ],
+        &[
+            "nexus",
+            "background-tasks",
+            "show",
+            "dns_external",
+            "--no-executing-info",
+        ],
+        &["nexus", "background-tasks", "show", "all", "--no-executing-info"],
         // chicken switches: show and set
         &["nexus", "chicken-switches", "show", "current"],
         &[


### PR DESCRIPTION
In `test_omdb_success_cases`, we previously (https://github.com/oxidecomputer/omicron/pull/8840) added `--no-executing-info` to one of the commands. I somehow completely missed that there were a number of other `background-tasks` commands all of which are flaky in the same way -- add this flag to all of them.
