### PR TITLE
[nexus] fix webhook update.

### DIFF
--- a/nexus/db-model/src/webhook_rx.rs
+++ b/nexus/db-model/src/webhook_rx.rs
@@ -81,12 +81,13 @@ impl TryFrom<WebhookReceiverConfig> for views::WebhookReceiver {
 pub struct AlertReceiver {
     #[diesel(embed)]
     pub identity: AlertReceiverIdentity,
-    pub endpoint: String,
 
     /// child resource generation number for secrets, per RFD 192
     pub secret_gen: Generation,
     /// child resource generation number for event subscriptions, per RFD 192
     pub subscription_gen: Generation,
+
+    pub endpoint: String,
 }
 
 impl DatastoreCollectionConfig<WebhookSecret> for AlertReceiver {

--- a/nexus/db-queries/src/db/datastore/alert_rx.rs
+++ b/nexus/db-queries/src/db/datastore/alert_rx.rs
@@ -354,11 +354,12 @@ impl DataStore {
             endpoint: params.endpoint.as_ref().map(ToString::to_string),
             time_modified: chrono::Utc::now(),
         };
+
         let updated = diesel::update(rx_dsl::alert_receiver)
             .filter(rx_dsl::id.eq(rx_id))
             .filter(rx_dsl::time_deleted.is_null())
             .set(update)
-            .check_if_exists(rx_id)
+            .check_if_exists::<AlertReceiver>(rx_id)
             .execute_and_check(&conn)
             .await
             .map_err(|e| {


### PR DESCRIPTION
As of main, a PUT to `/v1/webhook-receivers/{receiver}` throws a 500, as we attempt to unmarshal an INT8 into a STRING. This patch fixes the order of fields such that we unmarshal correctly, and adds a regression integration test.

When I try to update a receiver on main:

```
joshcarp@mac ~/c/webhook> oxide --profile sim alert receiver webhook update --receiver jmcarp-test-02 --json-body webhook-update.json
error
Error Response: status: 500 Internal Server Error; headers: {"content-type": "application/json", "x-request-id": "cf6fc6e1-c5bc-4aad-aaf2-ca5044b9c6e9", "content-length": "124", "date": "Tue, 26 Aug 2025 21:06:50 GMT"}; value: Error { error_code: Some("Internal"), message: "Internal Server Error", request_id: "cf6fc6e1-c5bc-4aad-aaf2-ca5044b9c6e9" }
```

And the corresponding log line:

```
{"msg":"request completed","v":0,"name":"omicron-dev","level":30,"time":"2025-08-26T21:06:51.826786Z","hostname":"mac.lan","pid":33979,"uri":"/v1/webhook-receivers/jmcarp-test-02","method":"PUT","req_id":"cf6fc6e1-c5bc-4aad-aaf2-ca5044b9c6e9","remote_addr":"127.0.0.1:63893","local_addr":"127.0.0.1:12220","component":"dropshot_external","name":"e6bff1ff-24fb-49dc-a54e-c6a350cd4d6c","error_message_external":"Internal Server Error","error_message_internal":"Unknown diesel error accessing AlertReceiver ByName(\"jmcarp-test-02\"): Error deserializing field 'endpoint': Received more than 8 bytes while decoding an i64. Was an expression of a different type expression accidentally marked as BigInt?","latency_us":37412,"response_code":500}
```

Submitting as a draft because I'm not familiar with the code. I was just testing out the alerting feature and noticed the 500.