### PR TITLE
[1/n] [reconfigurator-planning] move determination of add/update zones into a separate method

### DIFF
--- a/dev-tools/reconfigurator-cli/tests/output/cmds-mupdate-update-flow-stdout
+++ b/dev-tools/reconfigurator-cli/tests/output/cmds-mupdate-update-flow-stdout
@@ -505,9 +505,12 @@ planning report for blueprint a5a8f242-ffa5-473c-8efd-2acf2dc0b736:
 chicken switches:
     add zones with mupdate override:   false
 
-* waiting on MUPdate overrides
-* MUPdate overrides exist
-* zone updates waiting on MUPdate overrides
+* zone adds waiting on blockers
+* zone adds and updates are blocked:
+  - current target release generation (2) is lower than minimum required by blueprint (3)
+  - sleds have remove mupdate override set in blueprint: 98e6b7c2-2efa-41ca-b20a-0a4d61102fe6, d81c6a84-79b8-4958-ae41-ea46c9b19763
+  - sleds have mupdate override errors: 2b8f0cb3-0295-4b3c-bc58-4fe88b57112c
+* zone updates waiting on zone add blockers
 
 
 
@@ -880,9 +883,11 @@ planning report for blueprint 626487fa-7139-45ec-8416-902271fc730b:
 chicken switches:
     add zones with mupdate override:   false
 
-* waiting on MUPdate overrides
-* MUPdate overrides exist
-* zone updates waiting on MUPdate overrides
+* zone adds waiting on blockers
+* zone adds and updates are blocked:
+  - sleds have remove mupdate override set in blueprint: 98e6b7c2-2efa-41ca-b20a-0a4d61102fe6, d81c6a84-79b8-4958-ae41-ea46c9b19763
+  - sleds have mupdate override errors: 2b8f0cb3-0295-4b3c-bc58-4fe88b57112c
+* zone updates waiting on zone add blockers
 
 
 > blueprint-diff latest
@@ -1104,9 +1109,12 @@ chicken switches:
     add zones with mupdate override:   false
 
 * noop converting 6/6 install-dataset zones to artifact store on sled 98e6b7c2-2efa-41ca-b20a-0a4d61102fe6
-* waiting on MUPdate overrides
-* MUPdate overrides exist
-* zone updates waiting on MUPdate overrides
+* zone adds waiting on blockers
+* zone adds and updates are blocked:
+  - current target release generation (3) is lower than minimum required by blueprint (4)
+  - sleds have remove mupdate override set in blueprint: d81c6a84-79b8-4958-ae41-ea46c9b19763
+  - sleds have mupdate override errors: 2b8f0cb3-0295-4b3c-bc58-4fe88b57112c
+* zone updates waiting on zone add blockers
 
 
 
@@ -1393,9 +1401,11 @@ chicken switches:
     add zones with mupdate override:   false
 
 * skipping noop zone image source check on sled 98e6b7c2-2efa-41ca-b20a-0a4d61102fe6: all 6 zones are already from artifacts
-* waiting on MUPdate overrides
-* MUPdate overrides exist
-* zone updates waiting on MUPdate overrides
+* zone adds waiting on blockers
+* zone adds and updates are blocked:
+  - current target release generation (3) is lower than minimum required by blueprint (4)
+  - sleds have mupdate override errors: 2b8f0cb3-0295-4b3c-bc58-4fe88b57112c
+* zone updates waiting on zone add blockers
 
 
 > blueprint-show latest
@@ -1568,9 +1578,11 @@ chicken switches:
     add zones with mupdate override:   false
 
 * skipping noop zone image source check on sled 98e6b7c2-2efa-41ca-b20a-0a4d61102fe6: all 6 zones are already from artifacts
-* waiting on MUPdate overrides
-* MUPdate overrides exist
-* zone updates waiting on MUPdate overrides
+* zone adds waiting on blockers
+* zone adds and updates are blocked:
+  - current target release generation (3) is lower than minimum required by blueprint (4)
+  - sleds have mupdate override errors: 2b8f0cb3-0295-4b3c-bc58-4fe88b57112c
+* zone updates waiting on zone add blockers
 
 
 
@@ -1811,9 +1823,10 @@ chicken switches:
 
 * skipping noop zone image source check on sled 98e6b7c2-2efa-41ca-b20a-0a4d61102fe6: all 6 zones are already from artifacts
 * noop converting 6/6 install-dataset zones to artifact store on sled d81c6a84-79b8-4958-ae41-ea46c9b19763
-* waiting on MUPdate overrides
-* MUPdate overrides exist
-* zone updates waiting on MUPdate overrides
+* zone adds waiting on blockers
+* zone adds and updates are blocked:
+  - sleds have mupdate override errors: 2b8f0cb3-0295-4b3c-bc58-4fe88b57112c
+* zone updates waiting on zone add blockers
 
 
 > blueprint-show latest
@@ -1987,9 +2000,10 @@ chicken switches:
 
 * skipping noop zone image source check on sled 98e6b7c2-2efa-41ca-b20a-0a4d61102fe6: all 6 zones are already from artifacts
 * noop converting 6/6 install-dataset zones to artifact store on sled d81c6a84-79b8-4958-ae41-ea46c9b19763
-* waiting on MUPdate overrides
-* MUPdate overrides exist
-* zone updates waiting on MUPdate overrides
+* zone adds waiting on blockers
+* zone adds and updates are blocked:
+  - sleds have mupdate override errors: 2b8f0cb3-0295-4b3c-bc58-4fe88b57112c
+* zone updates waiting on zone add blockers
 
 
 
@@ -2962,9 +2976,11 @@ chicken switches:
 
 * skipping noop zone image source check on sled c3bc4c6d-fdde-4fc4-8493-89d2a1e5ee6b: all 0 zones are already from artifacts
 * skipping noop zone image source check on sled d81c6a84-79b8-4958-ae41-ea46c9b19763: all 6 zones are already from artifacts
-* waiting on MUPdate overrides
-* MUPdate overrides exist
-* zone updates waiting on MUPdate overrides
+* zone adds waiting on blockers
+* zone adds and updates are blocked:
+  - current target release generation (4) is lower than minimum required by blueprint (5)
+  - sleds have remove mupdate override set in blueprint: 98e6b7c2-2efa-41ca-b20a-0a4d61102fe6
+* zone updates waiting on zone add blockers
 
 
 > blueprint-diff latest
@@ -3191,11 +3207,13 @@ generated blueprint 27e755bc-dc10-4647-853c-f89bb3a15a2c based on parent bluepri
 planning report for blueprint 27e755bc-dc10-4647-853c-f89bb3a15a2c:
 * skipping noop zone image source check on sled c3bc4c6d-fdde-4fc4-8493-89d2a1e5ee6b: all 0 zones are already from artifacts
 * skipping noop zone image source check on sled d81c6a84-79b8-4958-ae41-ea46c9b19763: all 6 zones are already from artifacts
-* MUPdate overrides exist
-* adding zones despite MUPdate override, as specified by the `add_zones_with_mupdate_override` chicken switch
+* zone adds and updates are blocked:
+  - current target release generation (4) is lower than minimum required by blueprint (5)
+  - sleds have remove mupdate override set in blueprint: 98e6b7c2-2efa-41ca-b20a-0a4d61102fe6
+* adding zones despite being blocked, as specified by the `add_zones_with_mupdate_override` chicken switch
 * discretionary zone placement waiting for NTP zones on sleds: c3bc4c6d-fdde-4fc4-8493-89d2a1e5ee6b
 * missing NTP zone on sled c3bc4c6d-fdde-4fc4-8493-89d2a1e5ee6b
-* zone updates waiting on MUPdate overrides
+* zone updates waiting on zone add blockers
 
 
 > blueprint-diff latest

--- a/dev-tools/reconfigurator-cli/tests/output/cmds-noop-image-source-stdout
+++ b/dev-tools/reconfigurator-cli/tests/output/cmds-noop-image-source-stdout
@@ -183,9 +183,10 @@ chicken switches:
 
 * noop converting 6/6 install-dataset zones to artifact store on sled 98e6b7c2-2efa-41ca-b20a-0a4d61102fe6
 * noop converting 5/6 install-dataset zones to artifact store on sled aff6c093-197d-42c5-ad80-9f10ba051a34
-* waiting on MUPdate overrides
-* MUPdate overrides exist
-* zone updates waiting on MUPdate overrides
+* zone adds waiting on blockers
+* zone adds and updates are blocked:
+  - sleds have remove mupdate override set in blueprint: d81c6a84-79b8-4958-ae41-ea46c9b19763
+* zone updates waiting on zone add blockers
 
 
 
@@ -549,9 +550,10 @@ chicken switches:
 
 * skipping noop zone image source check on sled 98e6b7c2-2efa-41ca-b20a-0a4d61102fe6: all 6 zones are already from artifacts
 * noop converting 2/2 install-dataset zones to artifact store on sled e96e226f-4ed9-4c01-91b9-69a9cd076c9e
-* waiting on MUPdate overrides
-* MUPdate overrides exist
-* zone updates waiting on MUPdate overrides
+* zone adds waiting on blockers
+* zone adds and updates are blocked:
+  - sleds have remove mupdate override set in blueprint: d81c6a84-79b8-4958-ae41-ea46c9b19763
+* zone updates waiting on zone add blockers
 
 
 

--- a/openapi/nexus-internal.json
+++ b/openapi/nexus-internal.json
@@ -6573,8 +6573,15 @@
       "PlanningAddStepReport": {
         "type": "object",
         "properties": {
+          "add_update_blocked_reasons": {
+            "description": "Reasons why zone adds and any updates are blocked.\n\nThis is typically a list of MUPdate-related reasons.",
+            "type": "array",
+            "items": {
+              "type": "string"
+            }
+          },
           "add_zones_with_mupdate_override": {
-            "description": "The value of the homonymous chicken switch.",
+            "description": "The value of the homonymous chicken switch. (What this really means is that zone adds happen despite being blocked by one or more MUPdate-related reasons.)",
             "type": "boolean"
           },
           "discretionary_zones_placed": {
@@ -6586,10 +6593,6 @@
                 "type": "string"
               }
             }
-          },
-          "has_mupdate_override": {
-            "description": "Are there any outstanding MUPdate overrides?",
-            "type": "boolean"
           },
           "out_of_eligible_sleds": {
             "description": "Discretionary zone kind → (placed, wanted to place)",
@@ -6660,9 +6663,9 @@
           }
         },
         "required": [
+          "add_update_blocked_reasons",
           "add_zones_with_mupdate_override",
           "discretionary_zones_placed",
-          "has_mupdate_override",
           "out_of_eligible_sleds",
           "sleds_getting_ntp_and_discretionary_zones",
           "sleds_missing_crucible_zone",
@@ -9122,13 +9125,13 @@
       "ZoneAddWaitingOn": {
         "oneOf": [
           {
-            "description": "Waiting on one or more MUPdate overrides to clear.",
+            "description": "Waiting on one or more blockers (typically MUPdate-related reasons) to clear.",
             "type": "object",
             "properties": {
               "type": {
                 "type": "string",
                 "enum": [
-                  "mupdate_overrides"
+                  "blockers"
                 ]
               }
             },
@@ -9264,13 +9267,13 @@
             ]
           },
           {
-            "description": "Waiting on one or more MUPdate overrides to clear.",
+            "description": "Waiting on the same set of blockers zone adds are waiting on.",
             "type": "object",
             "properties": {
               "type": {
                 "type": "string",
                 "enum": [
-                  "mupdate_overrides"
+                  "zone_add_blockers"
                 ]
               }
             },


### PR DESCRIPTION
I'd like to determine condition 4 of whether to perform updates (all deployment units are at known versions) by looking at the blueprint after noop conversions have been applied. We could either try and guess what would happen by looking at the noop info, or just move this determination to after noop updates have been applied.

Also make the planning report store the reasons zone adds and updates are blocked, and print them as part of the planning report.

There are no behavior changes in this PR.
