### PR TITLE
Report IP Pool utilization as capacity and remaining

### DIFF
--- a/nexus/db-model/src/utilization.rs
+++ b/nexus/db-model/src/utilization.rs
@@ -57,39 +57,15 @@ impl From<SiloUtilization> for views::Utilization {
     }
 }
 
-#[derive(Debug, Clone, Serialize, Deserialize)]
-pub struct Ipv4Utilization {
-    pub allocated: u32,
-    pub capacity: u32,
-}
-
-#[derive(Debug, Clone, Serialize, Deserialize)]
-pub struct Ipv6Utilization {
-    pub allocated: u128,
-    pub capacity: u128,
-}
-
 // Not really a DB model, just the result of a datastore function
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct IpPoolUtilization {
-    pub ipv4: Ipv4Utilization,
-    pub ipv6: Ipv6Utilization,
-}
-
-impl From<Ipv4Utilization> for views::Ipv4Utilization {
-    fn from(util: Ipv4Utilization) -> Self {
-        Self { allocated: util.allocated, capacity: util.capacity }
-    }
-}
-
-impl From<Ipv6Utilization> for views::Ipv6Utilization {
-    fn from(util: Ipv6Utilization) -> Self {
-        Self { allocated: util.allocated, capacity: util.capacity }
-    }
+    pub remaining: f64,
+    pub capacity: f64,
 }
 
 impl From<IpPoolUtilization> for views::IpPoolUtilization {
     fn from(util: IpPoolUtilization) -> Self {
-        Self { ipv4: util.ipv4.into(), ipv6: util.ipv6.into() }
+        Self { remaining: util.remaining, capacity: util.capacity }
     }
 }

--- a/nexus/test-utils/src/resource_helpers.rs
+++ b/nexus/test-utils/src/resource_helpers.rs
@@ -1060,32 +1060,20 @@ pub async fn detach_ip_address_from_igw(
 pub async fn assert_ip_pool_utilization(
     client: &ClientTestContext,
     pool_name: &str,
-    ipv4_allocated: u32,
-    ipv4_capacity: u32,
-    ipv6_allocated: u128,
-    ipv6_capacity: u128,
+    remaining: f64,
+    capacity: f64,
 ) {
     let url = format!("/v1/system/ip-pools/{}/utilization", pool_name);
     let utilization: views::IpPoolUtilization = object_get(client, &url).await;
     assert_eq!(
-        utilization.ipv4.allocated, ipv4_allocated,
-        "IP pool '{}': expected {} IPv4 allocated, got {:?}",
-        pool_name, ipv4_allocated, utilization.ipv4.allocated
+        remaining, utilization.remaining,
+        "IP pool '{}': expected {} remaining, got {}",
+        pool_name, remaining, utilization.remaining,
     );
     assert_eq!(
-        utilization.ipv4.capacity, ipv4_capacity,
-        "IP pool '{}': expected {} IPv4 capacity, got {:?}",
-        pool_name, ipv4_capacity, utilization.ipv4.capacity
-    );
-    assert_eq!(
-        utilization.ipv6.allocated, ipv6_allocated,
-        "IP pool '{}': expected {} IPv6 allocated, got {:?}",
-        pool_name, ipv6_allocated, utilization.ipv6.allocated
-    );
-    assert_eq!(
-        utilization.ipv6.capacity, ipv6_capacity,
-        "IP pool '{}': expected {} IPv6 capacity, got {:?}",
-        pool_name, ipv6_capacity, utilization.ipv6.capacity
+        capacity, utilization.capacity,
+        "IP pool '{}': expected {} capacity, got {:?}",
+        pool_name, capacity, utilization.capacity,
     );
 }
 

--- a/nexus/test-utils/src/resource_helpers.rs
+++ b/nexus/test-utils/src/resource_helpers.rs
@@ -1057,14 +1057,20 @@ pub async fn detach_ip_address_from_igw(
         .unwrap();
 }
 
+/// Assert that the utilization of the provided pool matches expectations.
+///
+/// Note that the third argument is the number of _allocated_ addresses as an
+/// integer. This is compared against the count of remaining addresses
+/// internally, which is what the API returns.
 pub async fn assert_ip_pool_utilization(
     client: &ClientTestContext,
     pool_name: &str,
-    remaining: f64,
+    allocated: u32,
     capacity: f64,
 ) {
     let url = format!("/v1/system/ip-pools/{}/utilization", pool_name);
     let utilization: views::IpPoolUtilization = object_get(client, &url).await;
+    let remaining = capacity - f64::from(allocated);
     assert_eq!(
         remaining, utilization.remaining,
         "IP pool '{}': expected {} remaining, got {}",

--- a/nexus/tests/integration_tests/external_ips.rs
+++ b/nexus/tests/integration_tests/external_ips.rs
@@ -166,24 +166,18 @@ async fn test_floating_ip_create(cptestctx: &ControlPlaneTestContext) {
     let default_pool = create_default_ip_pool(&client).await;
 
     const CAPACITY: f64 = 65536.0;
-    assert_ip_pool_utilization(client, "default", CAPACITY, CAPACITY).await;
+    assert_ip_pool_utilization(client, "default", 0, CAPACITY).await;
 
     let ipv4_range =
         Ipv4Range::new(Ipv4Addr::new(10, 1, 0, 1), Ipv4Addr::new(10, 1, 0, 5))
             .unwrap();
-    let other_capacity = ipv4_range.len() as f64;
+    let other_capacity = ipv4_range.len().into();
     let other_pool_range = IpRange::V4(ipv4_range);
     // not automatically linked to currently silo. see below
     let (other_pool, ..) =
         create_ip_pool(&client, "other-pool", Some(other_pool_range)).await;
 
-    assert_ip_pool_utilization(
-        client,
-        "other-pool",
-        other_capacity,
-        other_capacity,
-    )
-    .await;
+    assert_ip_pool_utilization(client, "other-pool", 0, other_capacity).await;
 
     let project = create_project(client, PROJECT_NAME).await;
 
@@ -203,8 +197,7 @@ async fn test_floating_ip_create(cptestctx: &ControlPlaneTestContext) {
     assert_eq!(fip.ip, IpAddr::from(Ipv4Addr::new(10, 0, 0, 0)));
     assert_eq!(fip.ip_pool_id, default_pool.identity.id);
 
-    assert_ip_pool_utilization(client, "default", CAPACITY - 1.0, CAPACITY)
-        .await;
+    assert_ip_pool_utilization(client, "default", 1, CAPACITY).await;
 
     // Create with chosen IP and fallback to default pool.
     let fip_name = FIP_NAMES[1];
@@ -223,8 +216,7 @@ async fn test_floating_ip_create(cptestctx: &ControlPlaneTestContext) {
     assert_eq!(fip.ip, ip_addr);
     assert_eq!(fip.ip_pool_id, default_pool.identity.id);
 
-    assert_ip_pool_utilization(client, "default", CAPACITY - 2.0, CAPACITY)
-        .await;
+    assert_ip_pool_utilization(client, "default", 2, CAPACITY).await;
 
     // Creating with other-pool fails with 404 until it is linked to the current silo
     let fip_name = FIP_NAMES[2];
@@ -241,13 +233,7 @@ async fn test_floating_ip_create(cptestctx: &ControlPlaneTestContext) {
         object_create_error(client, &url, &params, StatusCode::NOT_FOUND).await;
     assert_eq!(error.message, "not found: ip-pool with name \"other-pool\"");
 
-    assert_ip_pool_utilization(
-        client,
-        "other-pool",
-        other_capacity,
-        other_capacity,
-    )
-    .await;
+    assert_ip_pool_utilization(client, "other-pool", 0, other_capacity).await;
 
     // now link the pool and everything should work with the exact same params
     let silo_id = DEFAULT_SILO.id();
@@ -261,13 +247,7 @@ async fn test_floating_ip_create(cptestctx: &ControlPlaneTestContext) {
     assert_eq!(fip.ip, IpAddr::from(Ipv4Addr::new(10, 1, 0, 1)));
     assert_eq!(fip.ip_pool_id, other_pool.identity.id);
 
-    assert_ip_pool_utilization(
-        client,
-        "other-pool",
-        other_capacity - 1.0,
-        other_capacity,
-    )
-    .await;
+    assert_ip_pool_utilization(client, "other-pool", 1, other_capacity).await;
 
     // Create with chosen IP from non-default pool.
     let fip_name = FIP_NAMES[3];
@@ -286,13 +266,7 @@ async fn test_floating_ip_create(cptestctx: &ControlPlaneTestContext) {
     assert_eq!(fip.ip, ip_addr);
     assert_eq!(fip.ip_pool_id, other_pool.identity.id);
 
-    assert_ip_pool_utilization(
-        client,
-        "other-pool",
-        other_capacity - 2.0,
-        other_capacity,
-    )
-    .await;
+    assert_ip_pool_utilization(client, "other-pool", 2, other_capacity).await;
 }
 
 #[nexus_test]
@@ -772,7 +746,7 @@ async fn test_external_ip_live_attach_detach(
     let project = create_project(client, PROJECT_NAME).await;
 
     const CAPACITY: f64 = 65536.0;
-    assert_ip_pool_utilization(client, "default", CAPACITY, CAPACITY).await;
+    assert_ip_pool_utilization(client, "default", 0, CAPACITY).await;
 
     // Create 2 instances, and a floating IP for each instance.
     // One instance will be started, and one will be stopped.
@@ -791,8 +765,7 @@ async fn test_external_ip_live_attach_detach(
     }
 
     // 2 floating IPs have been allocated
-    assert_ip_pool_utilization(client, "default", CAPACITY - 2.0, CAPACITY)
-        .await;
+    assert_ip_pool_utilization(client, "default", 2, CAPACITY).await;
 
     let mut instances = vec![];
     for (i, start) in [false, true].iter().enumerate() {
@@ -829,8 +802,7 @@ async fn test_external_ip_live_attach_detach(
 
     // the two instances above were deliberately not given ephemeral IPs, but
     // they still always get SNAT IPs, but they share one, so we go from 2 to 3
-    assert_ip_pool_utilization(client, "default", CAPACITY - 3.0, CAPACITY)
-        .await;
+    assert_ip_pool_utilization(client, "default", 3, CAPACITY).await;
 
     // Attach a floating IP and ephemeral IP to each instance.
     let mut recorded_ephs = vec![];
@@ -878,8 +850,7 @@ async fn test_external_ip_live_attach_detach(
 
     // now 5 because an ephemeral IP was added for each instance. floating IPs
     // were attached, but they were already allocated
-    assert_ip_pool_utilization(client, "default", CAPACITY - 5.0, CAPACITY)
-        .await;
+    assert_ip_pool_utilization(client, "default", 5, CAPACITY).await;
 
     // Detach a floating IP and ephemeral IP from each instance.
     for (instance, fip) in instances.iter().zip(&fips) {
@@ -913,8 +884,7 @@ async fn test_external_ip_live_attach_detach(
     }
 
     // 2 ephemeral go away on detachment but still 2 floating and 1 SNAT
-    assert_ip_pool_utilization(client, "default", CAPACITY - 3.0, CAPACITY)
-        .await;
+    assert_ip_pool_utilization(client, "default", 3, CAPACITY).await;
 
     // Finally, two kind of funny tests. There is special logic in the handler
     // for the case where the floating IP is specified by name but the instance
@@ -1002,8 +972,7 @@ async fn test_external_ip_live_attach_detach(
     );
 
     // none of that changed the number of allocated IPs
-    assert_ip_pool_utilization(client, "default", CAPACITY - 3.0, CAPACITY)
-        .await;
+    assert_ip_pool_utilization(client, "default", 3, CAPACITY).await;
 }
 
 #[nexus_test]

--- a/nexus/tests/integration_tests/instances.rs
+++ b/nexus/tests/integration_tests/instances.rs
@@ -6138,32 +6138,32 @@ async fn test_instance_ephemeral_ip_from_correct_pool(
     //
     // The first is given to the "default" pool, the provided to a distinct
     // explicit pool.
-    let range1 = IpRange::V4(
-        Ipv4Range::new(
-            std::net::Ipv4Addr::new(10, 0, 0, 1),
-            std::net::Ipv4Addr::new(10, 0, 0, 5),
-        )
-        .unwrap(),
-    );
-    let range2 = IpRange::V4(
-        Ipv4Range::new(
-            std::net::Ipv4Addr::new(10, 1, 0, 1),
-            std::net::Ipv4Addr::new(10, 1, 0, 5),
-        )
-        .unwrap(),
-    );
+    let ipv4_range1 = Ipv4Range::new(
+        std::net::Ipv4Addr::new(10, 0, 0, 1),
+        std::net::Ipv4Addr::new(10, 0, 0, 5),
+    )
+    .unwrap();
+    let capacity1 = ipv4_range1.len() as _;
+    let range1 = IpRange::V4(ipv4_range1);
+    let ipv4_range2 = Ipv4Range::new(
+        std::net::Ipv4Addr::new(10, 1, 0, 1),
+        std::net::Ipv4Addr::new(10, 1, 0, 5),
+    )
+    .unwrap();
+    let capacity2 = ipv4_range2.len() as _;
+    let range2 = IpRange::V4(ipv4_range2);
 
     // make first pool the default for the priv user's silo
     create_ip_pool(&client, "pool1", Some(range1)).await;
     link_ip_pool(&client, "pool1", &DEFAULT_SILO.id(), /*default*/ true).await;
 
-    assert_ip_pool_utilization(client, "pool1", 0, 5, 0, 0).await;
+    assert_ip_pool_utilization(client, "pool1", capacity1, capacity1).await;
 
     // second pool is associated with the silo but not default
     create_ip_pool(&client, "pool2", Some(range2)).await;
     link_ip_pool(&client, "pool2", &DEFAULT_SILO.id(), /*default*/ false).await;
 
-    assert_ip_pool_utilization(client, "pool2", 0, 5, 0, 0).await;
+    assert_ip_pool_utilization(client, "pool2", capacity2, capacity2).await;
 
     // Create an instance with pool name blank, expect IP from default pool
     create_instance_with_pool(client, "pool1-inst", None).await;
@@ -6174,9 +6174,10 @@ async fn test_instance_ephemeral_ip_from_correct_pool(
         "Expected ephemeral IP to come from pool1"
     );
     // 1 ephemeral + 1 snat
-    assert_ip_pool_utilization(client, "pool1", 2, 5, 0, 0).await;
+    assert_ip_pool_utilization(client, "pool1", capacity1 - 2.0, capacity1)
+        .await;
     // pool2 unaffected
-    assert_ip_pool_utilization(client, "pool2", 0, 5, 0, 0).await;
+    assert_ip_pool_utilization(client, "pool2", capacity2, capacity2).await;
 
     // Create an instance explicitly using the non-default "other-pool".
     create_instance_with_pool(client, "pool2-inst", Some("pool2")).await;
@@ -6189,10 +6190,12 @@ async fn test_instance_ephemeral_ip_from_correct_pool(
     // SNAT comes from default pool, but count does not change because
     // SNAT IPs can be shared. https://github.com/oxidecomputer/omicron/issues/5043
     // is about getting SNAT IP from specified pool instead of default.
-    assert_ip_pool_utilization(client, "pool1", 2, 5, 0, 0).await;
+    assert_ip_pool_utilization(client, "pool1", capacity1 - 2.0, capacity1)
+        .await;
 
     // ephemeral IP comes from specified pool
-    assert_ip_pool_utilization(client, "pool2", 1, 5, 0, 0).await;
+    assert_ip_pool_utilization(client, "pool2", capacity2 - 1.0, capacity2)
+        .await;
 
     // make pool2 default and create instance with default pool. check that it now it comes from pool2
     let _: views::IpPoolSiloLink = object_put(
@@ -6210,9 +6213,11 @@ async fn test_instance_ephemeral_ip_from_correct_pool(
     );
 
     // pool1 unchanged
-    assert_ip_pool_utilization(client, "pool1", 2, 5, 0, 0).await;
-    // +1 snat (now that pool2 is default) and +1 ephemeral
-    assert_ip_pool_utilization(client, "pool2", 3, 5, 0, 0).await;
+    assert_ip_pool_utilization(client, "pool1", capacity1 - 2.0, capacity1)
+        .await;
+    // +1 snat (now that pool2 is default) and +1 ephemeral, so 5 - 3 == 2.
+    assert_ip_pool_utilization(client, "pool2", capacity2 - 3.0, capacity2)
+        .await;
 
     // try to delete association with pool1, but it fails because there is an
     // instance with an IP from the pool in this silo
@@ -6232,11 +6237,12 @@ async fn test_instance_ephemeral_ip_from_correct_pool(
     stop_and_delete_instance(&cptestctx, "pool1-inst").await;
     stop_and_delete_instance(&cptestctx, "pool2-inst").await;
 
-    // pool1 is down to 0 because it had 1 snat + 1 ephemeral from pool1-inst
+    // pool1 is back up to 5 because it had 1 snat + 1 ephemeral from pool1-inst
     // and 1 snat from pool2-inst
-    assert_ip_pool_utilization(client, "pool1", 0, 5, 0, 0).await;
+    assert_ip_pool_utilization(client, "pool1", capacity1, capacity1).await;
     // pool2 drops one because it had 1 ephemeral from pool2-inst
-    assert_ip_pool_utilization(client, "pool2", 2, 5, 0, 0).await;
+    assert_ip_pool_utilization(client, "pool2", capacity2 - 2.0, capacity2)
+        .await;
 
     // now unlink works
     object_delete(client, &pool1_silo_url).await;
@@ -6426,17 +6432,17 @@ async fn test_instance_attach_several_external_ips(
     let _ = create_project(&client, PROJECT_NAME).await;
 
     // Create a single (large) IP pool
-    let default_pool_range = IpRange::V4(
-        Ipv4Range::new(
-            std::net::Ipv4Addr::new(10, 0, 0, 1),
-            std::net::Ipv4Addr::new(10, 0, 0, 10),
-        )
-        .unwrap(),
-    );
+    let range = Ipv4Range::new(
+        std::net::Ipv4Addr::new(10, 0, 0, 1),
+        std::net::Ipv4Addr::new(10, 0, 0, 10),
+    )
+    .unwrap();
+    let capacity = range.len() as _;
+    let default_pool_range = IpRange::V4(range);
     create_ip_pool(&client, "default", Some(default_pool_range)).await;
     link_ip_pool(&client, "default", &DEFAULT_SILO.id(), true).await;
 
-    assert_ip_pool_utilization(client, "default", 0, 10, 0, 0).await;
+    assert_ip_pool_utilization(client, "default", capacity, capacity).await;
 
     // Create several floating IPs for the instance, totalling 8 IPs.
     let mut external_ip_create =
@@ -6467,9 +6473,14 @@ async fn test_instance_attach_several_external_ips(
     .await;
 
     // 1 ephemeral + 7 floating + 1 SNAT
-    const N_EXPECTED_IPS: u32 = 9;
-    assert_ip_pool_utilization(client, "default", N_EXPECTED_IPS, 10, 0, 0)
-        .await;
+    const N_EXPECTED_IPS: f64 = 9.0;
+    assert_ip_pool_utilization(
+        client,
+        "default",
+        capacity - N_EXPECTED_IPS,
+        capacity,
+    )
+    .await;
 
     // Verify that all external IPs are visible on the instance and have
     // been allocated in order.
@@ -6629,7 +6640,8 @@ async fn test_instance_create_in_silo(cptestctx: &ControlPlaneTestContext) {
     create_ip_pool(&client, "default", None).await;
     link_ip_pool(&client, "default", &silo.identity.id, true).await;
 
-    assert_ip_pool_utilization(client, "default", 0, 65536, 0, 0).await;
+    const CAPACITY: f64 = 65536.0;
+    assert_ip_pool_utilization(client, "default", CAPACITY, CAPACITY).await;
 
     // Create test projects
     NexusRequest::objects_post(

--- a/nexus/tests/integration_tests/ip_pools.rs
+++ b/nexus/tests/integration_tests/ip_pools.rs
@@ -830,7 +830,7 @@ async fn test_ipv4_ip_pool_utilization_total(
 
     let _pool = create_pool(client, "p0").await;
 
-    assert_ip_pool_utilization(client, "p0", 0.0, 0.0).await;
+    assert_ip_pool_utilization(client, "p0", 0, 0.0).await;
 
     let add_url = "/v1/system/ip-pools/p0/ranges/add";
 
@@ -844,7 +844,7 @@ async fn test_ipv4_ip_pool_utilization_total(
     );
     object_create::<IpRange, IpPoolRange>(client, &add_url, &range).await;
 
-    assert_ip_pool_utilization(client, "p0", 5.0, 5.0).await;
+    assert_ip_pool_utilization(client, "p0", 0, 5.0).await;
 }
 
 // We're going to test adding an IPv6 pool and collecting its utilization, even
@@ -877,7 +877,7 @@ async fn test_ipv6_ip_pool_utilization_total(
         .expect("should be able to create IPv6 pool");
 
     // Check the utilization is zero.
-    assert_ip_pool_utilization(client, "p0", 0.0, 0.0).await;
+    assert_ip_pool_utilization(client, "p0", 0, 0.0).await;
 
     // Now let's add a gigantic range. This requires direct datastore
     // shenanigans because adding IPv6 ranges through the API is currently not
@@ -904,7 +904,7 @@ async fn test_ipv6_ip_pool_utilization_total(
         .expect("could not add range");
 
     let capacity = ipv6_range.len() as f64;
-    assert_ip_pool_utilization(client, "p0", capacity, capacity).await;
+    assert_ip_pool_utilization(client, "p0", 0, capacity).await;
 }
 
 // Data for testing overlapping IP ranges

--- a/nexus/tests/integration_tests/ip_pools.rs
+++ b/nexus/tests/integration_tests/ip_pools.rs
@@ -830,7 +830,7 @@ async fn test_ipv4_ip_pool_utilization_total(
 
     let _pool = create_pool(client, "p0").await;
 
-    assert_ip_pool_utilization(client, "p0", 0, 0, 0, 0).await;
+    assert_ip_pool_utilization(client, "p0", 0.0, 0.0).await;
 
     let add_url = "/v1/system/ip-pools/p0/ranges/add";
 
@@ -844,7 +844,7 @@ async fn test_ipv4_ip_pool_utilization_total(
     );
     object_create::<IpRange, IpPoolRange>(client, &add_url, &range).await;
 
-    assert_ip_pool_utilization(client, "p0", 0, 5, 0, 0).await;
+    assert_ip_pool_utilization(client, "p0", 5.0, 5.0).await;
 }
 
 // We're going to test adding an IPv6 pool and collecting its utilization, even
@@ -877,7 +877,7 @@ async fn test_ipv6_ip_pool_utilization_total(
         .expect("should be able to create IPv6 pool");
 
     // Check the utilization is zero.
-    assert_ip_pool_utilization(client, "p0", 0, 0, 0, 0).await;
+    assert_ip_pool_utilization(client, "p0", 0.0, 0.0).await;
 
     // Now let's add a gigantic range. This requires direct datastore
     // shenanigans because adding IPv6 ranges through the API is currently not
@@ -890,21 +890,21 @@ async fn test_ipv6_ip_pool_utilization_total(
         .fetch_for(authz::Action::CreateChild)
         .await
         .expect("should be able to fetch pool we just created");
-    let big_range = IpRange::V6(
-        Ipv6Range::new(
-            std::net::Ipv6Addr::new(0xfd00, 0, 0, 0, 0, 0, 0, 0),
-            std::net::Ipv6Addr::new(
-                0xfd00, 0, 0, 0xffff, 0xffff, 0xffff, 0xffff, 0xffff,
-            ),
-        )
-        .unwrap(),
-    );
+    let ipv6_range = Ipv6Range::new(
+        std::net::Ipv6Addr::new(0xfd00, 0, 0, 0, 0, 0, 0, 0),
+        std::net::Ipv6Addr::new(
+            0xfd00, 0, 0, 0xffff, 0xffff, 0xffff, 0xffff, 0xffff,
+        ),
+    )
+    .unwrap();
+    let big_range = IpRange::V6(ipv6_range);
     datastore
         .ip_pool_add_range(&opctx, &authz_pool, &db_pool, &big_range)
         .await
         .expect("could not add range");
 
-    assert_ip_pool_utilization(client, "p0", 0, 0, 0, 2u128.pow(80)).await;
+    let capacity = ipv6_range.len() as f64;
+    assert_ip_pool_utilization(client, "p0", capacity, capacity).await;
 }
 
 // Data for testing overlapping IP ranges

--- a/nexus/types/src/external_api/views.rs
+++ b/nexus/types/src/external_api/views.rs
@@ -390,80 +390,13 @@ pub struct IpPool {
     pub identity: IdentityMetadata,
 }
 
-#[derive(Debug, Clone, Serialize, Deserialize, JsonSchema)]
-pub struct Ipv4Utilization {
-    /// The number of IPv4 addresses allocated from this pool
-    pub allocated: u32,
-    /// The total number of IPv4 addresses in the pool, i.e., the sum of the
-    /// lengths of the IPv4 ranges. Unlike IPv6 capacity, can be a 32-bit
-    /// integer because there are only 2^32 IPv4 addresses.
-    pub capacity: u32,
-}
-
-#[derive(Debug, Clone, Serialize, Deserialize, JsonSchema)]
-pub struct Ipv6Utilization {
-    /// The number of IPv6 addresses allocated from this pool. A 128-bit integer
-    /// string to match the capacity field.
-    #[serde(with = "U128String")]
-    pub allocated: u128,
-
-    /// The total number of IPv6 addresses in the pool, i.e., the sum of the
-    /// lengths of the IPv6 ranges. An IPv6 range can contain up to 2^128
-    /// addresses, so we represent this value in JSON as a numeric string with a
-    /// custom "uint128" format.
-    #[serde(with = "U128String")]
-    pub capacity: u128,
-}
-
+/// The utilization of IP addresses in a pool.
 #[derive(Clone, Debug, Deserialize, Serialize, JsonSchema)]
 pub struct IpPoolUtilization {
-    /// Number of allocated and total available IPv4 addresses in pool
-    pub ipv4: Ipv4Utilization,
-    /// Number of allocated and total available IPv6 addresses in pool
-    pub ipv6: Ipv6Utilization,
-}
-
-// Custom struct for serializing/deserializing u128 as a string. The serde
-// docs will suggest using a module (or serialize_with and deserialize_with
-// functions), but as discussed in the comments on the UserData de/serializer,
-// schemars wants this to be a type, so it has to be a struct.
-struct U128String;
-impl U128String {
-    pub fn serialize<S>(value: &u128, serializer: S) -> Result<S::Ok, S::Error>
-    where
-        S: serde::Serializer,
-    {
-        serializer.serialize_str(&value.to_string())
-    }
-
-    pub fn deserialize<'de, D>(deserializer: D) -> Result<u128, D::Error>
-    where
-        D: serde::Deserializer<'de>,
-    {
-        let s = String::deserialize(deserializer)?;
-        s.parse().map_err(serde::de::Error::custom)
-    }
-}
-
-impl JsonSchema for U128String {
-    fn schema_name() -> String {
-        "String".to_string()
-    }
-
-    fn json_schema(
-        _: &mut schemars::gen::SchemaGenerator,
-    ) -> schemars::schema::Schema {
-        schemars::schema::SchemaObject {
-            instance_type: Some(schemars::schema::InstanceType::String.into()),
-            format: Some("uint128".to_string()),
-            ..Default::default()
-        }
-        .into()
-    }
-
-    fn is_referenceable() -> bool {
-        false
-    }
+    /// The number of remaining addresses in the pool.
+    pub remaining: f64,
+    /// The total number of addresses in the pool.
+    pub capacity: f64,
 }
 
 /// An IP pool in the context of a silo

--- a/nexus/types/src/external_api/views.rs
+++ b/nexus/types/src/external_api/views.rs
@@ -391,6 +391,13 @@ pub struct IpPool {
 }
 
 /// The utilization of IP addresses in a pool.
+///
+/// Note that both the count of remaining addresses and the total capacity are
+/// integers, reported as floating point numbers. This accommodates allocations
+/// larger than a 64-bit integer, which is common with IPv6 address spaces. With
+/// very large IP Pools (> 2**53 addresses), integer precision will be lost, in
+/// exchange for representing the entire range. In such a case the pool still
+/// has many available addresses.
 #[derive(Clone, Debug, Deserialize, Serialize, JsonSchema)]
 pub struct IpPoolUtilization {
     /// The number of remaining addresses in the pool.

--- a/openapi/nexus.json
+++ b/openapi/nexus.json
@@ -21389,7 +21389,7 @@
         }
       },
       "IpPoolUtilization": {
-        "description": "The utilization of IP addresses in a pool.",
+        "description": "The utilization of IP addresses in a pool.\n\nNote that both the count of remaining addresses and the total capacity are integers, reported as floating point numbers. This accommodates allocations larger than a 64-bit integer, which is common with IPv6 address spaces. With very large IP Pools (> 2**53 addresses), integer precision will be lost, in exchange for representing the entire range. In such a case the pool still has many available addresses.",
         "type": "object",
         "properties": {
           "capacity": {

--- a/openapi/nexus.json
+++ b/openapi/nexus.json
@@ -21389,28 +21389,23 @@
         }
       },
       "IpPoolUtilization": {
+        "description": "The utilization of IP addresses in a pool.",
         "type": "object",
         "properties": {
-          "ipv4": {
-            "description": "Number of allocated and total available IPv4 addresses in pool",
-            "allOf": [
-              {
-                "$ref": "#/components/schemas/Ipv4Utilization"
-              }
-            ]
+          "capacity": {
+            "description": "The total number of addresses in the pool.",
+            "type": "number",
+            "format": "double"
           },
-          "ipv6": {
-            "description": "Number of allocated and total available IPv6 addresses in pool",
-            "allOf": [
-              {
-                "$ref": "#/components/schemas/Ipv6Utilization"
-              }
-            ]
+          "remaining": {
+            "description": "The number of remaining addresses in the pool.",
+            "type": "number",
+            "format": "double"
           }
         },
         "required": [
-          "ipv4",
-          "ipv6"
+          "capacity",
+          "remaining"
         ]
       },
       "IpRange": {
@@ -21463,27 +21458,6 @@
           "last"
         ]
       },
-      "Ipv4Utilization": {
-        "type": "object",
-        "properties": {
-          "allocated": {
-            "description": "The number of IPv4 addresses allocated from this pool",
-            "type": "integer",
-            "format": "uint32",
-            "minimum": 0
-          },
-          "capacity": {
-            "description": "The total number of IPv4 addresses in the pool, i.e., the sum of the lengths of the IPv4 ranges. Unlike IPv6 capacity, can be a 32-bit integer because there are only 2^32 IPv4 addresses.",
-            "type": "integer",
-            "format": "uint32",
-            "minimum": 0
-          }
-        },
-        "required": [
-          "allocated",
-          "capacity"
-        ]
-      },
       "Ipv6Net": {
         "example": "fd12:3456::/64",
         "title": "An IPv6 subnet",
@@ -21512,25 +21486,6 @@
         "required": [
           "first",
           "last"
-        ]
-      },
-      "Ipv6Utilization": {
-        "type": "object",
-        "properties": {
-          "allocated": {
-            "description": "The number of IPv6 addresses allocated from this pool. A 128-bit integer string to match the capacity field.",
-            "type": "string",
-            "format": "uint128"
-          },
-          "capacity": {
-            "description": "The total number of IPv6 addresses in the pool, i.e., the sum of the lengths of the IPv6 ranges. An IPv6 range can contain up to 2^128 addresses, so we represent this value in JSON as a numeric string with a custom \"uint128\" format.",
-            "type": "string",
-            "format": "uint128"
-          }
-        },
-        "required": [
-          "allocated",
-          "capacity"
         ]
       },
       "L4PortRange": {


### PR DESCRIPTION
- Remove IP version-specific utilization types. All pools are only of one version, so we can use the same types for both.
- Report IP Pool utilization through the API as a floating-point capacity and count of _remaining_ addresses, rather than count of allocated. This avoids dealing with enormous bit-width numbers like a u128. The cost is reduced precision when either the capacity or remaining is > 2**53, but in that case, the caller almost certainly doesn't care about that. As the remaining number of addresses is smaller, they get perfect precision.
- Fixes #8888
- Fixes #5347