### PR TITLE
[2/n] [reconfigurator-planning] avoid wiping out boot partition state

### DIFF
--- a/nexus-sled-agent-shared/src/inventory.rs
+++ b/nexus-sled-agent-shared/src/inventory.rs
@@ -234,7 +234,7 @@ impl ConfigReconcilerInventory {
                         RemoveMupdateOverrideBootSuccessInventory::Removed,
                     ),
                     non_boot_message: "mupdate override successfully removed \
-                                   on non-boot disks"
+                                       on non-boot disks"
                         .to_owned(),
                 }
             });

--- a/nexus-sled-agent-shared/src/inventory.rs
+++ b/nexus-sled-agent-shared/src/inventory.rs
@@ -191,13 +191,16 @@ impl ConfigReconcilerInventory {
     /// [`Inventory`].
     pub fn debug_assume_success(config: OmicronSledConfig) -> Self {
         let mut ret = Self {
+            // These fields will be filled in by `debug_update_assume_success`.
             last_reconciled_config: OmicronSledConfig::default(),
             external_disks: BTreeMap::new(),
             datasets: BTreeMap::new(),
             orphaned_datasets: IdOrdMap::new(),
             zones: BTreeMap::new(),
-            boot_partitions: BootPartitionContents::debug_assume_success(),
             remove_mupdate_override: None,
+
+            // These fields will not.
+            boot_partitions: BootPartitionContents::debug_assume_success(),
         };
 
         ret.debug_update_assume_success(config);

--- a/nexus/reconfigurator/planning/src/system.rs
+++ b/nexus/reconfigurator/planning/src/system.rs
@@ -461,8 +461,17 @@ impl SystemDescription {
                 completed_at: Utc::now(),
                 ran_for: Duration::from_secs(5),
             };
-        sled.inventory_sled_agent.last_reconciliation =
-            Some(ConfigReconcilerInventory::debug_assume_success(sled_config));
+        match sled.inventory_sled_agent.last_reconciliation.as_mut() {
+            Some(last_reconciliation) => {
+                last_reconciliation.debug_update_assume_success(sled_config);
+            }
+            None => {
+                sled.inventory_sled_agent.last_reconciliation =
+                    Some(ConfigReconcilerInventory::debug_assume_success(
+                        sled_config,
+                    ));
+            }
+        };
 
         Ok(self)
     }


### PR DESCRIPTION
The boot partition state is going to become important in tests soon, since we want to set up the simulated system such that no MGS-driven updates are happening. Simply calling `debug_assume_success` wipes out MGS-related state, so add an alternative that doesn't.
