### PR TITLE
Add IP version to IP Pool API objects

### DIFF
--- a/end-to-end-tests/src/helpers/mod.rs
+++ b/end-to-end-tests/src/helpers/mod.rs
@@ -4,7 +4,7 @@ pub mod icmp;
 
 use self::ctx::nexus_addr;
 use anyhow::{Result, bail};
-use oxide_client::types::Name;
+use oxide_client::types::{IpRange, Ipv4Range, Ipv6Range, Name};
 use rand::Rng;
 use std::env;
 use std::net::{IpAddr, Ipv4Addr};
@@ -15,17 +15,21 @@ pub fn generate_name(prefix: &str) -> Result<Name> {
         .map_err(anyhow::Error::msg)
 }
 
-pub async fn get_system_ip_pool() -> Result<(Ipv4Addr, Ipv4Addr)> {
+pub async fn get_system_ip_pool() -> Result<(IpAddr, IpAddr)> {
     if let (Ok(s), Ok(e)) = (env::var("IPPOOL_START"), env::var("IPPOOL_END")) {
         return Ok((
-            s.parse::<Ipv4Addr>().expect("IPPOOL_START is not an IP address"),
-            e.parse::<Ipv4Addr>().expect("IPPOOL_END is not an IP address"),
+            s.parse::<Ipv4Addr>()
+                .expect("IPPOOL_START is not an IP address")
+                .into(),
+            e.parse::<Ipv4Addr>()
+                .expect("IPPOOL_END is not an IP address")
+                .into(),
         ));
     }
 
     let nexus_addr = match nexus_addr().await? {
         IpAddr::V4(addr) => addr.octets(),
-        IpAddr::V6(_) => bail!("not sure what to do about IPv6 here"),
+        IpAddr::V6(_) => bail!("IPv6 IP Pools are not yet supported"),
     };
 
     // HACK: we're picking a range that doesn't conflict with either iliana's
@@ -36,5 +40,31 @@ pub async fn get_system_ip_pool() -> Result<(Ipv4Addr, Ipv4Addr)> {
     let first = [nexus_addr[0], nexus_addr[1], nexus_addr[2], 50].into();
     let last = [nexus_addr[0], nexus_addr[1], nexus_addr[2], 90].into();
 
-    Ok((first, last))
+    Ok((IpAddr::V4(first), IpAddr::V4(last)))
+}
+
+/// Try to construct an IP range from a pair of addresses.
+///
+/// An error is returned if the addresses aren't the same version, or first >
+/// last.
+pub fn try_create_ip_range(first: IpAddr, last: IpAddr) -> Result<IpRange> {
+    match (first, last) {
+        (IpAddr::V4(first), IpAddr::V4(last)) => {
+            anyhow::ensure!(
+                first <= last,
+                "IP range first address must be <= last"
+            );
+            Ok(IpRange::V4(Ipv4Range { first, last }))
+        }
+        (IpAddr::V6(first), IpAddr::V6(last)) => {
+            anyhow::ensure!(
+                first <= last,
+                "IP range first address must be <= last"
+            );
+            Ok(IpRange::V6(Ipv6Range { first, last }))
+        }
+        (_, _) => anyhow::bail!(
+            "Invalid IP addresses for IP range: {first} and {last}"
+        ),
+    }
 }

--- a/nexus/db-model/src/ip_pool.rs
+++ b/nexus/db-model/src/ip_pool.rs
@@ -121,7 +121,7 @@ impl IpPool {
 
 impl From<IpPool> for views::IpPool {
     fn from(pool: IpPool) -> Self {
-        Self { identity: pool.identity() }
+        Self { identity: pool.identity(), ip_version: pool.ip_version.into() }
     }
 }
 

--- a/nexus/test-utils/src/resource_helpers.rs
+++ b/nexus/test-utils/src/resource_helpers.rs
@@ -258,6 +258,9 @@ pub async fn create_ip_pool(
                 name: pool_name.parse().unwrap(),
                 description: String::from("an ip pool"),
             },
+            ip_version: ip_range
+                .map(|r| r.version())
+                .unwrap_or_else(views::IpVersion::v4),
         },
     )
     .await;

--- a/nexus/tests/integration_tests/endpoints.rs
+++ b/nexus/tests/integration_tests/endpoints.rs
@@ -22,6 +22,7 @@ use nexus_test_utils::resource_helpers::test_params;
 use nexus_types::external_api::params;
 use nexus_types::external_api::shared;
 use nexus_types::external_api::shared::IpRange;
+use nexus_types::external_api::shared::IpVersion;
 use nexus_types::external_api::shared::Ipv4Range;
 use nexus_types::external_api::views::SledProvisionPolicy;
 use omicron_common::api::external::AddressLotKind;
@@ -929,6 +930,7 @@ pub static DEMO_IP_POOL_CREATE: LazyLock<params::IpPoolCreate> =
             name: DEMO_IP_POOL_NAME.clone(),
             description: String::from("an IP pool"),
         },
+        ip_version: IpVersion::V4,
     });
 pub static DEMO_IP_POOL_PROJ_URL: LazyLock<String> = LazyLock::new(|| {
     format!(

--- a/nexus/tests/integration_tests/ip_pools.rs
+++ b/nexus/tests/integration_tests/ip_pools.rs
@@ -50,6 +50,7 @@ use nexus_types::external_api::shared::SiloRole;
 use nexus_types::external_api::views::IpPool;
 use nexus_types::external_api::views::IpPoolRange;
 use nexus_types::external_api::views::IpPoolSiloLink;
+use nexus_types::external_api::views::IpVersion;
 use nexus_types::external_api::views::Silo;
 use nexus_types::external_api::views::SiloIpPool;
 use nexus_types::identity::Resource;
@@ -102,14 +103,16 @@ async fn test_ip_pool_basic_crud(cptestctx: &ControlPlaneTestContext) {
     // directly
     let params = IpPoolCreate {
         identity: IdentityMetadataCreateParams {
-            name: String::from(pool_name).parse().unwrap(),
+            name: pool_name.parse().unwrap(),
             description: String::from(description),
         },
+        ip_version: IpVersion::V4,
     };
     let created_pool: IpPool =
         object_create(client, ip_pools_url, &params).await;
     assert_eq!(created_pool.identity.name, pool_name);
     assert_eq!(created_pool.identity.description, description);
+    assert_eq!(created_pool.ip_version, IpVersion::V4);
 
     let list = get_ip_pools(client).await;
     assert_eq!(list.len(), 1, "Expected exactly 1 IP pool");
@@ -122,7 +125,13 @@ async fn test_ip_pool_basic_crud(cptestctx: &ControlPlaneTestContext) {
     let error = object_create_error(
         client,
         ip_pools_url,
-        &params,
+        &params::IpPoolCreate {
+            identity: IdentityMetadataCreateParams {
+                name: pool_name.parse().unwrap(),
+                description: String::new(),
+            },
+            ip_version: IpVersion::V4,
+        },
         StatusCode::BAD_REQUEST,
     )
     .await;
@@ -445,8 +454,8 @@ async fn test_ip_pool_service_no_cud(cptestctx: &ControlPlaneTestContext) {
 async fn test_ip_pool_silo_link(cptestctx: &ControlPlaneTestContext) {
     let client = &cptestctx.external_client;
 
-    let p0 = create_pool(client, "p0").await;
-    let p1 = create_pool(client, "p1").await;
+    let p0 = create_ipv4_pool(client, "p0").await;
+    let p1 = create_ipv4_pool(client, "p1").await;
 
     // there should be no associations
     let assocs_p0 = silos_for_pool(client, "p0").await;
@@ -547,7 +556,7 @@ async fn test_ip_pool_silo_link(cptestctx: &ControlPlaneTestContext) {
     assert_eq!(silo_pools[1].is_default, true);
 
     // creating a third pool and trying to link it as default: true should fail
-    create_pool(client, "p2").await;
+    create_ipv4_pool(client, "p2").await;
     let url = "/v1/system/ip-pools/p2/silos";
     let error = object_create_error(
         client,
@@ -583,7 +592,7 @@ async fn test_ip_pool_silo_list_only_discoverable(
     cptestctx: &ControlPlaneTestContext,
 ) {
     let client = &cptestctx.external_client;
-    create_pool(client, "p0").await;
+    create_ipv4_pool(client, "p0").await;
 
     // there should be no linked silos
     let silos_p0 = silos_for_pool(client, "p0").await;
@@ -608,8 +617,8 @@ async fn test_ip_pool_silo_list_only_discoverable(
 async fn test_ip_pool_update_default(cptestctx: &ControlPlaneTestContext) {
     let client = &cptestctx.external_client;
 
-    create_pool(client, "p0").await;
-    create_pool(client, "p1").await;
+    create_ipv4_pool(client, "p0").await;
+    create_ipv4_pool(client, "p1").await;
 
     // there should be no linked silos
     let silos_p0 = silos_for_pool(client, "p0").await;
@@ -715,7 +724,7 @@ async fn test_ip_pool_pagination(cptestctx: &ControlPlaneTestContext) {
     for i in 1..=8 {
         let name = format!("other-pool-{}", i);
         pool_names.push(name.clone());
-        create_pool(client, &name).await;
+        create_ipv4_pool(client, &name).await;
     }
 
     let first_five_url = format!("{}?limit=5", base_url);
@@ -739,7 +748,7 @@ async fn test_ip_pool_silos_pagination(cptestctx: &ControlPlaneTestContext) {
     let client = &cptestctx.external_client;
 
     // one pool, and there should be no linked silos
-    create_pool(client, "p0").await;
+    create_ipv4_pool(client, "p0").await;
     let silos_p0 = silos_for_pool(client, "p0").await;
     assert_eq!(silos_p0.items.len(), 0);
 
@@ -803,12 +812,21 @@ async fn pools_for_silo(
     objects_list_page_authz::<SiloIpPool>(client, &url).await.items
 }
 
-async fn create_pool(client: &ClientTestContext, name: &str) -> IpPool {
+async fn create_ipv4_pool(client: &ClientTestContext, name: &str) -> IpPool {
+    create_pool(client, name, IpVersion::V4).await
+}
+
+async fn create_pool(
+    client: &ClientTestContext,
+    name: &str,
+    ip_version: IpVersion,
+) -> IpPool {
     let params = IpPoolCreate {
         identity: IdentityMetadataCreateParams {
             name: Name::try_from(name.to_string()).unwrap(),
             description: "".to_string(),
         },
+        ip_version,
     };
     NexusRequest::objects_post(client, "/v1/system/ip-pools", &params)
         .authn_as(AuthnMode::PrivilegedUser)
@@ -828,7 +846,7 @@ async fn test_ipv4_ip_pool_utilization_total(
 ) {
     let client = &cptestctx.external_client;
 
-    let _pool = create_pool(client, "p0").await;
+    let _pool = create_ipv4_pool(client, "p0").await;
 
     assert_ip_pool_utilization(client, "p0", 0, 0, 0, 0).await;
 
@@ -932,22 +950,16 @@ async fn test_ip_pool_range_overlapping_ranges_fails(
     // Create the pool, verify basic properties
     let params = IpPoolCreate {
         identity: IdentityMetadataCreateParams {
-            name: String::from(pool_name).parse().unwrap(),
+            name: pool_name.parse().unwrap(),
             description: String::from(description),
         },
-        // silo: None,
-        // is_default: false,
+        ip_version: IpVersion::V4,
     };
     let created_pool: IpPool =
-        NexusRequest::objects_post(client, ip_pools_url, &params)
-            .authn_as(AuthnMode::PrivilegedUser)
-            .execute()
-            .await
-            .unwrap()
-            .parsed_body()
-            .unwrap();
+        object_create(client, ip_pools_url, &params).await;
     assert_eq!(created_pool.identity.name, pool_name);
     assert_eq!(created_pool.identity.description, description);
+    assert_eq!(created_pool.ip_version, IpVersion::V4);
 
     // Test data for IPv4 ranges that should fail due to overlap
     let ipv4_range = TestRange {
@@ -1097,20 +1109,16 @@ async fn test_ip_pool_range_pagination(cptestctx: &ControlPlaneTestContext) {
     // Create the pool, verify basic properties
     let params = IpPoolCreate {
         identity: IdentityMetadataCreateParams {
-            name: String::from(pool_name).parse().unwrap(),
+            name: pool_name.parse().unwrap(),
             description: String::from(description),
         },
+        ip_version: IpVersion::V4,
     };
     let created_pool: IpPool =
-        NexusRequest::objects_post(client, ip_pools_url, &params)
-            .authn_as(AuthnMode::PrivilegedUser)
-            .execute()
-            .await
-            .unwrap()
-            .parsed_body()
-            .unwrap();
+        object_create(client, ip_pools_url, &params).await;
     assert_eq!(created_pool.identity.name, pool_name);
     assert_eq!(created_pool.identity.description, description);
+    assert_eq!(created_pool.ip_version, IpVersion::V4);
 
     // Add some ranges, out of order. These will be paginated by their first
     // address, which sorts all IPv4 before IPv6, then within protocol versions
@@ -1289,16 +1297,7 @@ async fn test_ip_range_delete_with_allocated_external_ip_fails(
     let ip_pool_rem_range_url = format!("{}/remove", ip_pool_ranges_url);
 
     // create pool
-    let params = IpPoolCreate {
-        identity: IdentityMetadataCreateParams {
-            name: String::from(pool_name).parse().unwrap(),
-            description: String::from("right on cue"),
-        },
-    };
-    NexusRequest::objects_post(client, ip_pools_url, &params)
-        .authn_as(AuthnMode::PrivilegedUser)
-        .execute_and_parse_unwrap::<IpPool>()
-        .await;
+    let _ = create_ipv4_pool(client, pool_name).await;
 
     // associate pool with default silo, which is the privileged user's silo
     let params = IpPoolLinkSilo {
@@ -1515,6 +1514,7 @@ async fn test_ip_pool_service(cptestctx: &ControlPlaneTestContext) {
 
 fn assert_pools_eq(first: &IpPool, second: &IpPool) {
     assert_eq!(first.identity, second.identity);
+    assert_eq!(first.ip_version, second.ip_version);
 }
 
 fn assert_ranges_eq(first: &IpPoolRange, second: &IpPoolRange) {

--- a/nexus/types/src/external_api/params.rs
+++ b/nexus/types/src/external_api/params.rs
@@ -13,7 +13,7 @@ use omicron_common::api::external::{
     AddressLotKind, AffinityPolicy, AllowedSourceIps, BfdMode, BgpPeer,
     ByteCount, FailureDomain, Hostname, IdentityMetadataCreateParams,
     IdentityMetadataUpdateParams, InstanceAutoRestartPolicy, InstanceCpuCount,
-    LinkFec, LinkSpeed, Name, NameOrId, Nullable, PaginationOrder,
+    IpVersion, LinkFec, LinkSpeed, Name, NameOrId, Nullable, PaginationOrder,
     RouteDestination, RouteTarget, UserId,
 };
 use omicron_common::disk::DiskVariant;
@@ -1002,6 +1002,11 @@ impl std::fmt::Debug for CertificateCreate {
 pub struct IpPoolCreate {
     #[serde(flatten)]
     pub identity: IdentityMetadataCreateParams,
+    /// The IP version of the pool.
+    ///
+    /// The default is IPv4.
+    #[serde(default = "IpVersion::v4")]
+    pub ip_version: IpVersion,
 }
 
 /// Parameters for updating an IP Pool

--- a/nexus/types/src/external_api/views.rs
+++ b/nexus/types/src/external_api/views.rs
@@ -396,6 +396,8 @@ pub struct InternetGatewayIpAddress {
 pub struct IpPool {
     #[serde(flatten)]
     pub identity: IdentityMetadata,
+    /// The IP version for the pool.
+    pub ip_version: IpVersion,
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize, JsonSchema)]

--- a/openapi/nexus.json
+++ b/openapi/nexus.json
@@ -21187,6 +21187,14 @@
             "type": "string",
             "format": "uuid"
           },
+          "ip_version": {
+            "description": "The IP version for the pool.",
+            "allOf": [
+              {
+                "$ref": "#/components/schemas/IpVersion"
+              }
+            ]
+          },
           "name": {
             "description": "unique, mutable, user-controlled identifier for each resource",
             "allOf": [
@@ -21209,6 +21217,7 @@
         "required": [
           "description",
           "id",
+          "ip_version",
           "name",
           "time_created",
           "time_modified"
@@ -21220,6 +21229,15 @@
         "properties": {
           "description": {
             "type": "string"
+          },
+          "ip_version": {
+            "description": "The IP version of the pool.\n\nThe default is IPv4.",
+            "default": "v4",
+            "allOf": [
+              {
+                "$ref": "#/components/schemas/IpVersion"
+              }
+            ]
           },
           "name": {
             "$ref": "#/components/schemas/Name"
@@ -21431,6 +21449,14 @@
               }
             ]
           }
+        ]
+      },
+      "IpVersion": {
+        "description": "The IP address version.",
+        "type": "string",
+        "enum": [
+          "v4",
+          "v6"
         ]
       },
       "Ipv4Net": {


### PR DESCRIPTION
- Add IP version when creating IP Pools, defaulting to IPv4.
- Add version to views when listing / fetching pools
- Flesh out some of the end-to-end tests in preparation for IPv6 pool support
- Closes #8881