### PR TITLE
Remove incorrect comment

### DIFF
--- a/nexus/mgs-updates/src/rot_updater.rs
+++ b/nexus/mgs-updates/src/rot_updater.rs
@@ -293,9 +293,6 @@ pub async fn wait_for_boot_info(
             .await
         {
             Ok(state) => match state.clone() {
-                // The minimum we will ever return is v3.
-                // Additionally, V2 does not report image errors, so we cannot
-                // know with certainty if a signature check came back with errors
                 RotState::V2 { .. } | RotState::V3 { .. } => {
                     debug!(log, "successfuly retrieved boot info");
                     return Ok(state.into_inner());


### PR DESCRIPTION
In https://github.com/oxidecomputer/omicron/pull/8905 I extracted some of the functionality of the helper function `wait_for_stage0_next_image_check` into a new `wait_for_boot_info` function. A comment that made sense for `wait_for_stage0_next_image_check` does not make sense for `wait_for_boot_info` because the behaviour is different. This patch removes that comment.