### PR TITLE
[mgs-updates] RoT bootloader FirstPageErased error should be ignored

### DIFF
--- a/nexus/mgs-updates/src/common_sp_update.rs
+++ b/nexus/mgs-updates/src/common_sp_update.rs
@@ -322,4 +322,5 @@ pub(crate) fn error_means_caboose_is_invalid(
     let message = format!("{error:?}");
     message.contains("the image caboose does not contain")
         || message.contains("the image does not include a caboose")
+        || message.contains("failed to read data from the caboose")
 }

--- a/nexus/mgs-updates/src/rot_bootloader_updater.rs
+++ b/nexus/mgs-updates/src/rot_bootloader_updater.rs
@@ -200,9 +200,16 @@ impl SpComponentUpdateHelperImpl for ReconfiguratorRotBootloaderUpdater {
             // stage0_next, the device won't let us load this image onto stage0.
             // We return a fatal error.
             if let Some(e) = stage0next_error {
-                return Err(PostUpdateError::FatalError {
-                    error: InlineErrorChain::new(&e).to_string(),
-                });
+                // With some RoT bootloaders in manufacturing, it isn't strictly
+                // necessary to go through our update process and stage0next will
+                // still be erased. This raises an FirstPageErased error, but it
+                // doesn't mean that we should stop the update process. We
+                // ignore it.
+                if e != RotImageError::FirstPageErased {
+                    return Err(PostUpdateError::FatalError {
+                        error: InlineErrorChain::new(&e).to_string(),
+                    });
+                }
             }
 
             // This operation is very delicate. Here, we're overwriting the


### PR DESCRIPTION
As per https://github.com/oxidecomputer/omicron/issues/8044#issuecomment-2828614002 , the `RotImageError::FirstPageErased` error for the RoT bootloader is not fatal, and should not be treated as such. This patch does two things:

1. Interprets the error response from the SP as an invalid caboose when retrieving caboose information
2. Carries on updating the RoT bootloader when when it finds this error during an image signature check.

Closes https://github.com/oxidecomputer/omicron/issues/8045