### PR TITLE
Initial schema updates disallowing default IP Pool for the internal silo

### DIFF
--- a/nexus/db-model/src/ip_pool.rs
+++ b/nexus/db-model/src/ip_pool.rs
@@ -153,7 +153,16 @@ impl_enum_type!(
     Silo => b"silo"
 );
 
-#[derive(Queryable, Insertable, Selectable, Clone, Debug)]
+#[derive(
+    AsChangeset,
+    Queryable,
+    Insertable,
+    Selectable,
+    Clone,
+    Copy,
+    Debug,
+    PartialEq,
+)]
 #[diesel(table_name = ip_pool_resource)]
 pub struct IpPoolResource {
     pub ip_pool_id: Uuid,

--- a/nexus/db-model/src/ip_pool.rs
+++ b/nexus/db-model/src/ip_pool.rs
@@ -153,16 +153,7 @@ impl_enum_type!(
     Silo => b"silo"
 );
 
-#[derive(
-    AsChangeset,
-    Queryable,
-    Insertable,
-    Selectable,
-    Clone,
-    Copy,
-    Debug,
-    PartialEq,
-)]
+#[derive(Queryable, Insertable, Selectable, Clone, Copy, Debug, PartialEq)]
 #[diesel(table_name = ip_pool_resource)]
 pub struct IpPoolResource {
     pub ip_pool_id: Uuid,

--- a/nexus/db-model/src/schema_versions.rs
+++ b/nexus/db-model/src/schema_versions.rs
@@ -16,7 +16,7 @@ use std::{collections::BTreeMap, sync::LazyLock};
 ///
 /// This must be updated when you change the database schema.  Refer to
 /// schema/crdb/README.adoc in the root of this repository for details.
-pub const SCHEMA_VERSION: Version = Version::new(186, 0, 0);
+pub const SCHEMA_VERSION: Version = Version::new(187, 0, 0);
 
 /// List of all past database schema versions, in *reverse* order
 ///
@@ -28,6 +28,7 @@ static KNOWN_VERSIONS: LazyLock<Vec<KnownVersion>> = LazyLock::new(|| {
         // |  leaving the first copy as an example for the next person.
         // v
         // KnownVersion::new(next_int, "unique-dirname-with-the-sql-files"),
+        KnownVersion::new(187, "no-default-pool-for-internal-silo"),
         KnownVersion::new(186, "nexus-generation"),
         KnownVersion::new(185, "populate-db-metadata-nexus"),
         KnownVersion::new(184, "store-silo-admin-group-name"),

--- a/nexus/db-queries/src/db/datastore/rack.rs
+++ b/nexus/db-queries/src/db/datastore/rack.rs
@@ -991,9 +991,9 @@ impl DataStore {
                 },
                 version,
             );
-
+            // Create the pool, and link it to the internal silo if needed. But
+            // we cannot set a default.
             let internal_pool_id = internal_pool.id();
-
             let internal_created = self
                 .ip_pool_create(opctx, internal_pool)
                 .await
@@ -1002,25 +1002,14 @@ impl DataStore {
                     Error::ObjectAlreadyExists { .. } => Ok(false),
                     _ => Err(e),
                 })?;
-
-            // make default for the internal silo. only need to do this if
-            // the create went through, i.e., if it wasn't already there
-            //
-            // TODO-completeness: We're linking both IP pools here, but only the
-            // IPv4 pool is set as a default. We need a way for the operator to
-            // control this, either at RSS or through the API. An alternative is
-            // to not set a default at all, even though both are linked.
-            //
-            // See https://github.com/oxidecomputer/omicron/issues/8884
             if internal_created {
-                let is_default = matches!(version, IpVersion::V4);
                 self.ip_pool_link_silo(
                     opctx,
                     db::model::IpPoolResource {
                         ip_pool_id: internal_pool_id,
                         resource_type: db::model::IpPoolResourceType::Silo,
                         resource_id: INTERNAL_SILO_ID,
-                        is_default,
+                        is_default: false,
                     },
                 )
                 .await?;

--- a/nexus/src/app/silo.rs
+++ b/nexus/src/app/silo.rs
@@ -50,6 +50,7 @@ impl super::Nexus {
         let silo = self.silo_lookup(opctx, NameOrId::Id(silo.id()))?;
         Ok(silo)
     }
+
     pub fn silo_lookup<'a>(
         &'a self,
         opctx: &'a OpContext,

--- a/nexus/tests/integration_tests/ip_pools.rs
+++ b/nexus/tests/integration_tests/ip_pools.rs
@@ -501,9 +501,15 @@ async fn test_ip_pool_silo_link(cptestctx: &ControlPlaneTestContext) {
     let _: IpPoolSiloLink =
         object_create(client, "/v1/system/ip-pools/p0/silos", &params).await;
 
-    // second attempt to create the same link is successful too.
-    let _: IpPoolSiloLink =
-        object_create(client, "/v1/system/ip-pools/p0/silos", &params).await;
+    // second attempt to create the same link errors due to conflict
+    let error = object_create_error(
+        client,
+        "/v1/system/ip-pools/p0/silos",
+        &params,
+        StatusCode::BAD_REQUEST,
+    )
+    .await;
+    assert_eq!(error.error_code.unwrap(), "ObjectAlreadyExists");
 
     // get silo ID so we can test association by ID as well
     let silo_url = format!("/v1/system/silos/{}", silo.name());

--- a/nexus/tests/integration_tests/ip_pools.rs
+++ b/nexus/tests/integration_tests/ip_pools.rs
@@ -501,15 +501,9 @@ async fn test_ip_pool_silo_link(cptestctx: &ControlPlaneTestContext) {
     let _: IpPoolSiloLink =
         object_create(client, "/v1/system/ip-pools/p0/silos", &params).await;
 
-    // second attempt to create the same link errors due to conflict
-    let error = object_create_error(
-        client,
-        "/v1/system/ip-pools/p0/silos",
-        &params,
-        StatusCode::BAD_REQUEST,
-    )
-    .await;
-    assert_eq!(error.error_code.unwrap(), "ObjectAlreadyExists");
+    // second attempt to create the same link is successful too.
+    let _: IpPoolSiloLink =
+        object_create(client, "/v1/system/ip-pools/p0/silos", &params).await;
 
     // get silo ID so we can test association by ID as well
     let silo_url = format!("/v1/system/silos/{}", silo.name());

--- a/schema/crdb/dbinit.sql
+++ b/schema/crdb/dbinit.sql
@@ -2110,7 +2110,20 @@ CREATE TABLE IF NOT EXISTS omicron.public.ip_pool_resource (
 
     -- resource_type is redundant because resource IDs are globally unique, but
     -- logically it belongs here
-    PRIMARY KEY (ip_pool_id, resource_type, resource_id)
+    PRIMARY KEY (ip_pool_id, resource_type, resource_id),
+
+    -- Check that there are no default pools for the internal silo
+    CONSTRAINT internal_silo_has_no_default_pool CHECK (
+        -- A = linked to internal, B = (not default)
+        -- A -> B iff ¬A v B
+        -- ¬(linked to internal silo) OR (not default)
+        NOT (
+            resource_type = 'silo' AND
+            resource_id = '001de000-5110-4000-8000-000000000001'
+        )
+        OR NOT is_default
+    )
+
 );
 
 -- a given resource can only have one default ip pool
@@ -2123,6 +2136,7 @@ CREATE UNIQUE INDEX IF NOT EXISTS one_default_ip_pool_per_resource ON omicron.pu
 CREATE INDEX IF NOT EXISTS ip_pool_resource_id ON omicron.public.ip_pool_resource (
     resource_id
 );
+
 CREATE INDEX IF NOT EXISTS ip_pool_resource_ip_pool_id ON omicron.public.ip_pool_resource (
     ip_pool_id
 );
@@ -6602,7 +6616,7 @@ INSERT INTO omicron.public.db_metadata (
     version,
     target_version
 ) VALUES
-    (TRUE, NOW(), NOW(), '186.0.0', NULL)
+    (TRUE, NOW(), NOW(), '187.0.0', NULL)
 ON CONFLICT DO NOTHING;
 
 COMMIT;

--- a/schema/crdb/dbinit.sql
+++ b/schema/crdb/dbinit.sql
@@ -2114,14 +2114,11 @@ CREATE TABLE IF NOT EXISTS omicron.public.ip_pool_resource (
 
     -- Check that there are no default pools for the internal silo
     CONSTRAINT internal_silo_has_no_default_pool CHECK (
-        -- A = linked to internal, B = (not default)
-        -- A -> B iff ¬A v B
-        -- ¬(linked to internal silo) OR (not default)
         NOT (
             resource_type = 'silo' AND
-            resource_id = '001de000-5110-4000-8000-000000000001'
+            resource_id = '001de000-5110-4000-8000-000000000001' AND
+            is_default
         )
-        OR NOT is_default
     )
 
 );

--- a/schema/crdb/no-default-pool-for-internal-silo/up01.sql
+++ b/schema/crdb/no-default-pool-for-internal-silo/up01.sql
@@ -1,0 +1,9 @@
+/*
+ * Ensure we have no default pool for the internal silo.
+ */
+SET LOCAL disallow_full_table_scans = 'off';
+UPDATE omicron.public.ip_pool_resource
+SET is_default = FALSE
+WHERE
+    resource_type = 'silo' AND
+    resource_id = '001de000-5110-4000-8000-000000000001';

--- a/schema/crdb/no-default-pool-for-internal-silo/up02.sql
+++ b/schema/crdb/no-default-pool-for-internal-silo/up02.sql
@@ -1,0 +1,18 @@
+/*
+ * Add check constraint ensuring that, if the pool is linked
+ * to the internal Oxide services silo, it's not marked as
+ * a default pool.
+ */
+ALTER TABLE IF EXISTS
+omicron.public.ip_pool_resource
+ADD CONSTRAINT IF NOT EXISTS
+internal_silo_has_no_default_pool CHECK (
+    -- A = linked to internal, B = (not default)
+    -- A -> B iff ¬A v B
+    -- ¬(linked to internal silo) OR (not default)
+    NOT (
+        resource_type = 'silo' AND
+        resource_id = '001de000-5110-4000-8000-000000000001'
+    )
+    OR NOT is_default
+);

--- a/schema/crdb/no-default-pool-for-internal-silo/up02.sql
+++ b/schema/crdb/no-default-pool-for-internal-silo/up02.sql
@@ -3,16 +3,13 @@
  * to the internal Oxide services silo, it's not marked as
  * a default pool.
  */
-ALTER TABLE IF EXISTS
+ALTER TABLE
 omicron.public.ip_pool_resource
 ADD CONSTRAINT IF NOT EXISTS
 internal_silo_has_no_default_pool CHECK (
-    -- A = linked to internal, B = (not default)
-    -- A -> B iff ¬A v B
-    -- ¬(linked to internal silo) OR (not default)
     NOT (
         resource_type = 'silo' AND
-        resource_id = '001de000-5110-4000-8000-000000000001'
+        resource_id = '001de000-5110-4000-8000-000000000001' AND
+        is_default
     )
-    OR NOT is_default
 );


### PR DESCRIPTION
- Add database constraints that ensure that we can't set a default pool for the Oxide internal silo. Add tests for this specifically.
- This is part of #8948, but does not resolve it.