### PR TITLE
No need for 3000 row tests

### DIFF
--- a/nexus/db-queries/src/db/datastore/user_data_export.rs
+++ b/nexus/db-queries/src/db/datastore/user_data_export.rs
@@ -928,7 +928,10 @@ mod tests {
     use std::net::Ipv6Addr;
 
     const PROJECT_NAME: &str = "bobs-barrel-of-bits";
-    const LARGE_NUMBER_OF_ROWS: usize = 3000;
+
+    // Enough rows that CRDB's query planner will complain when full table
+    // scans are not allowed.
+    const LARGE_NUMBER_OF_ROWS: usize = 10;
 
     #[tokio::test]
     async fn test_resource_id_collision() {


### PR DESCRIPTION
LARGE_NUMBER_OF_ROWS was set to 3000 in order to confirm that the queries related to user data export do not trigger full table scans for a large number of rows, but it's only necessary to have a non-zero amount of rows. Tune this down as it was causing tests to take a long time.