### PR TITLE
Add a user provision type to silo user and group

### DIFF
--- a/nexus/db-fixed-data/src/silo_user.rs
+++ b/nexus/db-fixed-data/src/silo_user.rs
@@ -4,7 +4,8 @@
 //! Built-in Silo Users
 
 use nexus_db_model as model;
-use nexus_types::{identity::Asset, silo::DEFAULT_SILO_ID};
+use nexus_types::identity::Asset;
+use nexus_types::silo::DEFAULT_SILO_ID;
 use omicron_common::api::external::ResourceType;
 use std::sync::LazyLock;
 
@@ -15,7 +16,7 @@ use std::sync::LazyLock;
 // not automatically at Nexus startup.  See omicron#2305.
 pub static USER_TEST_PRIVILEGED: LazyLock<model::SiloUser> =
     LazyLock::new(|| {
-        model::SiloUser::new(
+        model::SiloUser::new_api_only_user(
             DEFAULT_SILO_ID,
             // "4007" looks a bit like "root".
             "001de000-05e4-4000-8000-000000004007".parse().unwrap(),
@@ -50,7 +51,7 @@ pub static ROLE_ASSIGNMENTS_PRIVILEGED: LazyLock<Vec<model::RoleAssignment>> =
 // not automatically at Nexus startup.  See omicron#2305.
 pub static USER_TEST_UNPRIVILEGED: LazyLock<model::SiloUser> =
     LazyLock::new(|| {
-        model::SiloUser::new(
+        model::SiloUser::new_api_only_user(
             DEFAULT_SILO_ID,
             // 60001 is the decimal uid for "nobody" on Helios.
             "001de000-05e4-4000-8000-000000060001".parse().unwrap(),

--- a/nexus/db-model/src/schema_versions.rs
+++ b/nexus/db-model/src/schema_versions.rs
@@ -16,7 +16,7 @@ use std::{collections::BTreeMap, sync::LazyLock};
 ///
 /// This must be updated when you change the database schema.  Refer to
 /// schema/crdb/README.adoc in the root of this repository for details.
-pub const SCHEMA_VERSION: Version = Version::new(186, 0, 0);
+pub const SCHEMA_VERSION: Version = Version::new(187, 0, 0);
 
 /// List of all past database schema versions, in *reverse* order
 ///
@@ -28,6 +28,7 @@ static KNOWN_VERSIONS: LazyLock<Vec<KnownVersion>> = LazyLock::new(|| {
         // |  leaving the first copy as an example for the next person.
         // v
         // KnownVersion::new(next_int, "unique-dirname-with-the-sql-files"),
+        KnownVersion::new(187, "user-provision-type-for-silo-user-and-group"),
         KnownVersion::new(186, "nexus-generation"),
         KnownVersion::new(185, "populate-db-metadata-nexus"),
         KnownVersion::new(184, "store-silo-admin-group-name"),

--- a/nexus/db-model/src/silo_group.rs
+++ b/nexus/db-model/src/silo_group.rs
@@ -2,12 +2,11 @@
 // License, v. 2.0. If a copy of the MPL was not distributed with this
 // file, You can obtain one at https://mozilla.org/MPL/2.0/.
 
+use super::UserProvisionType;
 use crate::DbTypedUuid;
 use crate::to_db_typed_uuid;
 use db_macros::Asset;
 use nexus_db_schema::schema::{silo_group, silo_group_membership};
-use nexus_types::external_api::views;
-use nexus_types::identity::Asset;
 use omicron_uuid_kinds::SiloGroupKind;
 use omicron_uuid_kinds::SiloGroupUuid;
 use omicron_uuid_kinds::SiloUserKind;
@@ -20,17 +19,49 @@ use uuid::Uuid;
 #[asset(uuid_kind = SiloGroupKind)]
 pub struct SiloGroup {
     #[diesel(embed)]
-    identity: SiloGroupIdentity,
+    pub identity: SiloGroupIdentity,
+    pub time_deleted: Option<chrono::DateTime<chrono::Utc>>,
 
     pub silo_id: Uuid,
 
-    /// The identity provider's name for this group.
-    pub external_id: String,
+    /// If the user provision type is ApiOnly or JIT, then the external id is
+    /// the identity provider's ID for this group. There is a database
+    /// constraint that this field must be non-null for those provision types.
+    ///
+    /// For SCIM, this may be null, which would trigger the uniqueness
+    /// constraint if that wasn't limited to specific provision types.
+    pub external_id: Option<String>,
+
+    pub user_provision_type: UserProvisionType,
 }
 
 impl SiloGroup {
-    pub fn new(id: SiloGroupUuid, silo_id: Uuid, external_id: String) -> Self {
-        Self { identity: SiloGroupIdentity::new(id), silo_id, external_id }
+    pub fn new_api_only_group(
+        id: SiloGroupUuid,
+        silo_id: Uuid,
+        external_id: String,
+    ) -> Self {
+        Self {
+            identity: SiloGroupIdentity::new(id),
+            time_deleted: None,
+            silo_id,
+            user_provision_type: UserProvisionType::ApiOnly,
+            external_id: Some(external_id),
+        }
+    }
+
+    pub fn new_jit_group(
+        id: SiloGroupUuid,
+        silo_id: Uuid,
+        external_id: String,
+    ) -> Self {
+        Self {
+            identity: SiloGroupIdentity::new(id),
+            time_deleted: None,
+            silo_id,
+            user_provision_type: UserProvisionType::Jit,
+            external_id: Some(external_id),
+        }
     }
 }
 
@@ -50,17 +81,6 @@ impl SiloGroupMembership {
         Self {
             silo_group_id: to_db_typed_uuid(silo_group_id),
             silo_user_id: to_db_typed_uuid(silo_user_id),
-        }
-    }
-}
-
-impl From<SiloGroup> for views::Group {
-    fn from(group: SiloGroup) -> Self {
-        Self {
-            id: group.id(),
-            // TODO the use of external_id as display_name is temporary
-            display_name: group.external_id,
-            silo_id: group.silo_id,
         }
     }
 }

--- a/nexus/db-model/src/silo_user.rs
+++ b/nexus/db-model/src/silo_user.rs
@@ -2,10 +2,9 @@
 // License, v. 2.0. If a copy of the MPL was not distributed with this
 // file, You can obtain one at https://mozilla.org/MPL/2.0/.
 
+use super::UserProvisionType;
 use db_macros::Asset;
 use nexus_db_schema::schema::silo_user;
-use nexus_types::external_api::views;
-use nexus_types::identity::Asset;
 use omicron_uuid_kinds::SiloUserUuid;
 use uuid::Uuid;
 
@@ -15,17 +14,24 @@ use uuid::Uuid;
 #[asset(uuid_kind = SiloUserKind)]
 pub struct SiloUser {
     #[diesel(embed)]
-    identity: SiloUserIdentity,
+    pub identity: SiloUserIdentity,
 
     pub time_deleted: Option<chrono::DateTime<chrono::Utc>>,
     pub silo_id: Uuid,
 
-    /// The identity provider's ID for this user.
-    pub external_id: String,
+    /// If the user provision type is ApiOnly or JIT, then the external id is
+    /// the identity provider's ID for this user. There is a database constraint
+    /// that this field must be non-null for those provision types.
+    ///
+    /// For SCIM, this may be null, which would trigger the uniqueness
+    /// constraint if that wasn't limited to specific provision types.
+    pub external_id: Option<String>,
+
+    pub user_provision_type: UserProvisionType,
 }
 
 impl SiloUser {
-    pub fn new(
+    pub fn new_api_only_user(
         silo_id: Uuid,
         user_id: SiloUserUuid,
         external_id: String,
@@ -34,18 +40,22 @@ impl SiloUser {
             identity: SiloUserIdentity::new(user_id),
             time_deleted: None,
             silo_id,
-            external_id,
+            external_id: Some(external_id),
+            user_provision_type: UserProvisionType::ApiOnly,
         }
     }
-}
 
-impl From<SiloUser> for views::User {
-    fn from(user: SiloUser) -> Self {
+    pub fn new_jit_user(
+        silo_id: Uuid,
+        user_id: SiloUserUuid,
+        external_id: String,
+    ) -> Self {
         Self {
-            id: user.id(),
-            // TODO the use of external_id as display_name is temporary
-            display_name: user.external_id,
-            silo_id: user.silo_id,
+            identity: SiloUserIdentity::new(user_id),
+            time_deleted: None,
+            silo_id,
+            external_id: Some(external_id),
+            user_provision_type: UserProvisionType::Jit,
         }
     }
 }

--- a/nexus/db-queries/src/db/datastore/mod.rs
+++ b/nexus/db-queries/src/db/datastore/mod.rs
@@ -138,6 +138,14 @@ pub use region::RegionAllocationParameters;
 pub use region_snapshot_replacement::NewRegionVolumeId;
 pub use region_snapshot_replacement::OldSnapshotVolumeId;
 pub use silo::Discoverability;
+pub use silo_group::SiloGroup;
+pub use silo_group::SiloGroupApiOnly;
+pub use silo_group::SiloGroupJit;
+pub use silo_group::SiloGroupLookup;
+pub use silo_user::SiloUser;
+pub use silo_user::SiloUserApiOnly;
+pub use silo_user::SiloUserJit;
+pub use silo_user::SiloUserLookup;
 pub use sled::SledTransition;
 pub use sled::TransitionError;
 pub use support_bundle::SupportBundleExpungementReport;
@@ -483,7 +491,7 @@ mod test {
     use crate::db::model::{
         BlockSize, ConsoleSession, CrucibleDataset, ExternalIp, PhysicalDisk,
         PhysicalDiskKind, PhysicalDiskPolicy, PhysicalDiskState, Project, Rack,
-        Region, SiloUser, SshKey, Zpool,
+        Region, SshKey, Zpool,
     };
     use crate::db::pub_test_utils::TestDatabase;
     use crate::db::pub_test_utils::helpers::SledUpdateBuilder;
@@ -621,11 +629,12 @@ mod test {
         datastore
             .silo_user_create(
                 &authz_silo,
-                SiloUser::new(
+                SiloUserApiOnly::new(
                     authz_silo.id(),
                     silo_user_id,
                     "external_id".into(),
-                ),
+                )
+                .into(),
             )
             .await
             .unwrap();
@@ -1760,11 +1769,12 @@ mod test {
         datastore
             .silo_user_create(
                 &authz_silo,
-                SiloUser::new(
+                SiloUserApiOnly::new(
                     authz_silo.id(),
                     silo_user_id,
                     "external@id".into(),
-                ),
+                )
+                .into(),
             )
             .await
             .unwrap();

--- a/nexus/db-queries/src/db/datastore/rack.rs
+++ b/nexus/db-queries/src/db/datastore/rack.rs
@@ -19,6 +19,7 @@ use crate::db::model::CrucibleDataset;
 use crate::db::model::IncompleteExternalIp;
 use crate::db::model::PhysicalDisk;
 use crate::db::model::Rack;
+use crate::db::model::UserProvisionType;
 use crate::db::model::Zpool;
 use crate::db::pagination::paginated;
 use async_bb8_diesel::AsyncRunQueryDsl;
@@ -435,6 +436,18 @@ impl DataStore {
         recovery_user_password_hash: omicron_passwords::PasswordHashString,
         dns_update: DnsVersionUpdateBuilder,
     ) -> Result<(), RackInitError> {
+        match &recovery_silo.identity_mode {
+            shared::SiloIdentityMode::LocalOnly => {
+                // Ok
+            }
+
+            shared::SiloIdentityMode::SamlJit => {
+                return Err(RackInitError::Silo(Error::invalid_request(
+                    "recovery silo should only use identity mode LocalOnly",
+                )));
+            }
+        }
+
         let db_silo = self
             .silo_create_conn(
                 conn,
@@ -453,11 +466,19 @@ impl DataStore {
 
         // Create the first user in the initial Recovery Silo
         let silo_user_id = SiloUserUuid::new_v4();
-        let silo_user = SiloUser::new(
-            db_silo.id(),
-            silo_user_id,
-            recovery_user_id.as_ref().to_owned(),
-        );
+
+        let silo_user = match &db_silo.user_provision_type {
+            UserProvisionType::ApiOnly => SiloUser::new_api_only_user(
+                db_silo.id(),
+                silo_user_id,
+                recovery_user_id.as_ref().to_owned(),
+            ),
+
+            UserProvisionType::Jit => {
+                unreachable!("match at start of function should prevent this");
+            }
+        };
+
         {
             use nexus_db_schema::schema::silo_user::dsl;
             diesel::insert_into(dsl::silo_user)
@@ -1250,7 +1271,7 @@ mod test {
             .expect("failed to list users");
         assert_eq!(silo_users.len(), 1);
         assert_eq!(
-            silo_users[0].external_id,
+            silo_users[0].external_id(),
             rack_init.recovery_user_id.as_ref()
         );
         let authz_silo_user = authz::SiloUser::new(

--- a/nexus/db-queries/src/db/datastore/silo_group.rs
+++ b/nexus/db-queries/src/db/datastore/silo_group.rs
@@ -7,11 +7,12 @@
 use super::DataStore;
 use crate::authz;
 use crate::context::OpContext;
-use crate::db;
 use crate::db::IncompleteOnConflictExt;
 use crate::db::datastore::RunnableQueryNoReturn;
-use crate::db::model::SiloGroup;
+use crate::db::model;
+use crate::db::model::Silo;
 use crate::db::model::SiloGroupMembership;
+use crate::db::model::UserProvisionType;
 use crate::db::model::to_db_typed_uuid;
 use crate::db::pagination::paginated;
 use async_bb8_diesel::AsyncRunQueryDsl;
@@ -20,6 +21,8 @@ use diesel::prelude::*;
 use nexus_db_errors::ErrorHandler;
 use nexus_db_errors::TransactionError;
 use nexus_db_errors::public_error_from_diesel;
+use nexus_types::external_api::views;
+use nexus_types::identity::Asset;
 use omicron_common::api::external::CreateResult;
 use omicron_common::api::external::DataPageParams;
 use omicron_common::api::external::DeleteResult;
@@ -27,16 +30,236 @@ use omicron_common::api::external::Error;
 use omicron_common::api::external::InternalContext;
 use omicron_common::api::external::ListResultVec;
 use omicron_common::api::external::LookupResult;
+use omicron_common::api::external::ResourceType;
 use omicron_common::api::external::UpdateResult;
+use omicron_uuid_kinds::GenericUuid;
 use omicron_uuid_kinds::SiloGroupUuid;
 use omicron_uuid_kinds::SiloUserUuid;
 use uuid::Uuid;
+
+/// The datastore crate's SiloGroup is intended to provide type safety above the
+/// database model, as the same database model is used to store semantically
+/// different group types. Higher level parts of Nexus should use this type
+/// instead.
+#[derive(Debug, Clone)]
+pub enum SiloGroup {
+    /// A Group created via the API
+    ApiOnly(SiloGroupApiOnly),
+
+    /// A Group created during an authenticated SAML login
+    Jit(SiloGroupJit),
+}
+
+impl SiloGroup {
+    pub fn id(&self) -> SiloGroupUuid {
+        match &self {
+            SiloGroup::ApiOnly(u) => u.id,
+            SiloGroup::Jit(u) => u.id,
+        }
+    }
+
+    pub fn silo_id(&self) -> Uuid {
+        match &self {
+            SiloGroup::ApiOnly(u) => u.silo_id,
+            SiloGroup::Jit(u) => u.silo_id,
+        }
+    }
+
+    pub fn external_id(&self) -> &str {
+        match &self {
+            SiloGroup::ApiOnly(u) => &u.external_id,
+            SiloGroup::Jit(u) => &u.external_id,
+        }
+    }
+}
+
+impl From<model::SiloGroup> for SiloGroup {
+    fn from(record: model::SiloGroup) -> SiloGroup {
+        match record.user_provision_type {
+            UserProvisionType::ApiOnly => {
+                SiloGroup::ApiOnly(SiloGroupApiOnly {
+                    id: record.id(),
+                    time_created: record.time_created(),
+                    time_modified: record.time_modified(),
+                    time_deleted: record.time_deleted,
+                    silo_id: record.silo_id,
+                    // SAFETY: there is a database constraint that prevents a group
+                    // with provision type 'api_only' from having a null external id
+                    external_id: record.external_id.unwrap(),
+                })
+            }
+
+            UserProvisionType::Jit => SiloGroup::Jit(SiloGroupJit {
+                id: record.id(),
+                time_created: record.time_created(),
+                time_modified: record.time_modified(),
+                time_deleted: record.time_deleted,
+                silo_id: record.silo_id,
+                // SAFETY: there is a database constraint that prevents a group
+                // with provision type 'jit' from having a null external id
+                external_id: record.external_id.unwrap(),
+            }),
+        }
+    }
+}
+
+impl From<SiloGroup> for model::SiloGroup {
+    fn from(u: SiloGroup) -> model::SiloGroup {
+        match u {
+            SiloGroup::ApiOnly(u) => u.into(),
+            SiloGroup::Jit(u) => u.into(),
+        }
+    }
+}
+
+impl From<SiloGroup> for views::Group {
+    fn from(u: SiloGroup) -> views::Group {
+        match u {
+            SiloGroup::ApiOnly(u) => u.into(),
+            SiloGroup::Jit(u) => u.into(),
+        }
+    }
+}
+
+#[derive(Debug, Clone)]
+pub struct SiloGroupApiOnly {
+    pub id: SiloGroupUuid,
+    pub time_created: chrono::DateTime<chrono::Utc>,
+    pub time_modified: chrono::DateTime<chrono::Utc>,
+    pub time_deleted: Option<chrono::DateTime<chrono::Utc>>,
+    pub silo_id: Uuid,
+
+    /// The identity provider's ID for this group.
+    pub external_id: String,
+}
+
+impl SiloGroupApiOnly {
+    pub fn new(silo_id: Uuid, id: SiloGroupUuid, external_id: String) -> Self {
+        Self {
+            id,
+            time_created: chrono::Utc::now(),
+            time_modified: chrono::Utc::now(),
+            time_deleted: None,
+            silo_id,
+            external_id,
+        }
+    }
+}
+
+impl From<SiloGroupApiOnly> for model::SiloGroup {
+    fn from(u: SiloGroupApiOnly) -> model::SiloGroup {
+        model::SiloGroup {
+            identity: model::SiloGroupIdentity {
+                id: u.id.into(),
+                time_created: u.time_created,
+                time_modified: u.time_modified,
+            },
+            time_deleted: u.time_deleted,
+            silo_id: u.silo_id,
+            external_id: Some(u.external_id),
+            user_provision_type: UserProvisionType::ApiOnly,
+        }
+    }
+}
+
+impl From<SiloGroupApiOnly> for SiloGroup {
+    fn from(u: SiloGroupApiOnly) -> SiloGroup {
+        SiloGroup::ApiOnly(u)
+    }
+}
+
+impl From<SiloGroupApiOnly> for views::Group {
+    fn from(u: SiloGroupApiOnly) -> views::Group {
+        views::Group {
+            id: u.id,
+            // TODO the use of external_id as display_name is temporary
+            display_name: u.external_id,
+            silo_id: u.silo_id,
+        }
+    }
+}
+
+#[derive(Debug, Clone)]
+pub struct SiloGroupJit {
+    pub id: SiloGroupUuid,
+    pub time_created: chrono::DateTime<chrono::Utc>,
+    pub time_modified: chrono::DateTime<chrono::Utc>,
+    pub time_deleted: Option<chrono::DateTime<chrono::Utc>>,
+    pub silo_id: Uuid,
+
+    /// The identity provider's ID for this user.
+    pub external_id: String,
+}
+
+impl SiloGroupJit {
+    pub fn new(silo_id: Uuid, id: SiloGroupUuid, external_id: String) -> Self {
+        Self {
+            id,
+            time_created: chrono::Utc::now(),
+            time_modified: chrono::Utc::now(),
+            time_deleted: None,
+            silo_id,
+            external_id,
+        }
+    }
+}
+
+impl From<SiloGroupJit> for model::SiloGroup {
+    fn from(u: SiloGroupJit) -> model::SiloGroup {
+        model::SiloGroup {
+            identity: model::SiloGroupIdentity {
+                id: u.id.into(),
+                time_created: u.time_created,
+                time_modified: u.time_modified,
+            },
+            time_deleted: u.time_deleted,
+            silo_id: u.silo_id,
+            external_id: Some(u.external_id),
+            user_provision_type: UserProvisionType::Jit,
+        }
+    }
+}
+
+impl From<SiloGroupJit> for SiloGroup {
+    fn from(u: SiloGroupJit) -> SiloGroup {
+        SiloGroup::Jit(u)
+    }
+}
+
+impl From<SiloGroupJit> for views::Group {
+    fn from(u: SiloGroupJit) -> views::Group {
+        views::Group {
+            id: u.id,
+            // TODO the use of external_id as display_name is temporary
+            display_name: u.external_id,
+            silo_id: u.silo_id,
+        }
+    }
+}
+
+/// Different types of group have different fields that are considered unique,
+/// and therefore lookup needs to be typed as well.
+#[derive(Debug)]
+pub enum SiloGroupLookup<'a> {
+    ApiOnly { external_id: &'a str },
+
+    Jit { external_id: &'a str },
+}
+
+impl<'a> SiloGroupLookup<'a> {
+    pub fn user_provision_type(&self) -> UserProvisionType {
+        match &self {
+            SiloGroupLookup::ApiOnly { .. } => UserProvisionType::ApiOnly,
+            SiloGroupLookup::Jit { .. } => UserProvisionType::Jit,
+        }
+    }
+}
 
 impl DataStore {
     pub(super) async fn silo_group_ensure_query(
         opctx: &OpContext,
         authz_silo: &authz::Silo,
-        silo_group: SiloGroup,
+        silo_group: model::SiloGroup,
     ) -> Result<impl RunnableQueryNoReturn, Error> {
         opctx.authorize(authz::Action::CreateChild, authz_silo).await?;
 
@@ -54,39 +277,136 @@ impl DataStore {
         authz_silo: &authz::Silo,
         silo_group: SiloGroup,
     ) -> CreateResult<SiloGroup> {
-        let external_id = silo_group.external_id.clone();
+        let conn = self.pool_connection_authorized(opctx).await?;
 
-        DataStore::silo_group_ensure_query(opctx, authz_silo, silo_group)
+        let group_id = silo_group.id();
+        let model: model::SiloGroup = silo_group.into();
+
+        // Check the user's provision type matches the silo
+
+        let silo = {
+            use nexus_db_schema::schema::silo::dsl;
+            dsl::silo
+                .filter(dsl::id.eq(authz_silo.id()))
+                .select(model::Silo::as_select())
+                .get_result_async::<model::Silo>(&*conn)
+                .await
+                .map_err(|e| {
+                    public_error_from_diesel(
+                        e,
+                        ErrorHandler::NotFoundByResource(authz_silo),
+                    )
+                })?
+        };
+
+        if silo.user_provision_type != model.user_provision_type {
+            error!(
+                self.log,
+                "silo {} provision type {:?} does not match silo group {} \
+                provision type {:?}",
+                authz_silo.id(),
+                silo.user_provision_type,
+                model.id(),
+                model.user_provision_type,
+            );
+
+            return Err(Error::invalid_request(
+                "user provision type of silo does not match silo group",
+            ));
+        }
+
+        DataStore::silo_group_ensure_query(opctx, authz_silo, model)
             .await?
-            .execute_async(&*self.pool_connection_authorized(opctx).await?)
+            .execute_async(&*conn)
             .await
             .map_err(|e| public_error_from_diesel(e, ErrorHandler::Server))?;
 
-        Ok(self
-            .silo_group_optional_lookup(opctx, authz_silo, external_id)
-            .await?
-            .unwrap())
+        let silo_group = {
+            use nexus_db_schema::schema::silo_group::dsl;
+
+            let maybe_silo_group = dsl::silo_group
+                .filter(dsl::silo_id.eq(authz_silo.id()))
+                .filter(dsl::id.eq(to_db_typed_uuid(group_id)))
+                .select(model::SiloGroup::as_select())
+                .first_async(&*conn)
+                .await
+                .optional()
+                .map_err(|e| {
+                    public_error_from_diesel(e, ErrorHandler::Server)
+                })?;
+
+            // This function is _not_ transactional, meaning a delete could race
+            // between the ensure query and the lookup.
+
+            let Some(silo_group) = maybe_silo_group else {
+                return Err(Error::not_found_by_id(
+                    ResourceType::SiloGroup,
+                    group_id.as_untyped_uuid(),
+                ));
+            };
+
+            silo_group
+        };
+
+        Ok(silo_group.into())
     }
 
-    pub async fn silo_group_optional_lookup(
+    pub async fn silo_group_optional_lookup<'a>(
         &self,
         opctx: &OpContext,
         authz_silo: &authz::Silo,
-        external_id: String,
-    ) -> LookupResult<Option<db::model::SiloGroup>> {
+        silo_group_lookup: &'a SiloGroupLookup<'a>,
+    ) -> LookupResult<Option<SiloGroup>> {
         opctx.authorize(authz::Action::ListChildren, authz_silo).await?;
+
+        // Check the silo's provision type matches the lookup.
+
+        let conn = self.pool_connection_authorized(opctx).await?;
+
+        let silo = {
+            use nexus_db_schema::schema::silo::dsl;
+            dsl::silo
+                .filter(dsl::id.eq(authz_silo.id()))
+                .select(Silo::as_select())
+                .get_result_async::<Silo>(&*conn)
+                .await
+                .map_err(|e| {
+                    public_error_from_diesel(
+                        e,
+                        ErrorHandler::NotFoundByResource(authz_silo),
+                    )
+                })?
+        };
+
+        let lookup_user_provision_type =
+            silo_group_lookup.user_provision_type();
+
+        if silo.user_provision_type != lookup_user_provision_type {
+            return Err(Error::invalid_request(format!(
+                "silo provision type {:?} does not match lookup {:?}",
+                silo.user_provision_type, lookup_user_provision_type,
+            )));
+        }
 
         use nexus_db_schema::schema::silo_group::dsl;
 
-        dsl::silo_group
-            .filter(dsl::silo_id.eq(authz_silo.id()))
-            .filter(dsl::external_id.eq(external_id))
-            .filter(dsl::time_deleted.is_null())
-            .select(db::model::SiloGroup::as_select())
-            .first_async(&*self.pool_connection_authorized(opctx).await?)
-            .await
-            .optional()
-            .map_err(|e| public_error_from_diesel(e, ErrorHandler::Server))
+        let maybe_silo_group = match silo_group_lookup {
+            SiloGroupLookup::ApiOnly { external_id }
+            | SiloGroupLookup::Jit { external_id } => dsl::silo_group
+                .filter(dsl::silo_id.eq(authz_silo.id()))
+                .filter(dsl::user_provision_type.eq(lookup_user_provision_type))
+                .filter(dsl::external_id.eq(external_id.to_string()))
+                .filter(dsl::time_deleted.is_null())
+                .select(model::SiloGroup::as_select())
+                .first_async(&*conn)
+                .await
+                .optional()
+                .map_err(|e| {
+                    public_error_from_diesel(e, ErrorHandler::Server)
+                })?,
+        };
+
+        Ok(maybe_silo_group.map(|group| group.into()))
     }
 
     pub async fn silo_group_membership_for_user(
@@ -100,6 +420,23 @@ impl DataStore {
         use nexus_db_schema::schema::silo_group_membership::dsl;
         dsl::silo_group_membership
             .filter(dsl::silo_user_id.eq(to_db_typed_uuid(silo_user_id)))
+            .select(SiloGroupMembership::as_returning())
+            .get_results_async(&*self.pool_connection_authorized(opctx).await?)
+            .await
+            .map_err(|e| public_error_from_diesel(e, ErrorHandler::Server))
+    }
+
+    pub async fn silo_group_membership_for_group(
+        &self,
+        opctx: &OpContext,
+        authz_silo: &authz::Silo,
+        silo_group_id: SiloGroupUuid,
+    ) -> ListResultVec<SiloGroupMembership> {
+        opctx.authorize(authz::Action::ListChildren, authz_silo).await?;
+
+        use nexus_db_schema::schema::silo_group_membership::dsl;
+        dsl::silo_group_membership
+            .filter(dsl::silo_group_id.eq(to_db_typed_uuid(silo_group_id)))
             .select(SiloGroupMembership::as_returning())
             .get_results_async(&*self.pool_connection_authorized(opctx).await?)
             .await
@@ -131,14 +468,20 @@ impl DataStore {
         use nexus_db_schema::schema::{
             silo_group as sg, silo_group_membership as sgm,
         };
-        paginated(sg::dsl::silo_group, sg::id, pagparams)
+
+        let page = paginated(sg::dsl::silo_group, sg::id, pagparams)
             .inner_join(sgm::table.on(sgm::silo_group_id.eq(sg::id)))
             .filter(sgm::silo_user_id.eq(to_db_typed_uuid(silo_user_id)))
             .filter(sg::time_deleted.is_null())
-            .select(SiloGroup::as_returning())
+            .select(model::SiloGroup::as_returning())
             .get_results_async(&*self.pool_connection_authorized(opctx).await?)
             .await
-            .map_err(|e| public_error_from_diesel(e, ErrorHandler::Server))
+            .map_err(|e| public_error_from_diesel(e, ErrorHandler::Server))?
+            .into_iter()
+            .map(|group: model::SiloGroup| group.into())
+            .collect::<Vec<SiloGroup>>();
+
+        Ok(page)
     }
 
     /// Update a silo user's group membership:
@@ -178,10 +521,10 @@ impl DataStore {
 
                     // Create new memberships for user
                     let silo_group_memberships: Vec<
-                        db::model::SiloGroupMembership,
+                        model::SiloGroupMembership,
                     > = silo_group_ids
                         .iter()
-                        .map(|group_id| db::model::SiloGroupMembership {
+                        .map(|group_id| model::SiloGroupMembership {
                             silo_group_id: to_db_typed_uuid(*group_id),
                             silo_user_id: to_db_typed_uuid(silo_user_id),
                         })
@@ -273,14 +616,36 @@ impl DataStore {
         use nexus_db_schema::schema::silo_group::dsl;
 
         opctx.authorize(authz::Action::Read, authz_silo).await?;
-        paginated(dsl::silo_group, dsl::id, pagparams)
+
+        let conn = self.pool_connection_authorized(opctx).await?;
+
+        let silo = {
+            use nexus_db_schema::schema::silo::dsl;
+            dsl::silo
+                .filter(dsl::id.eq(authz_silo.id()))
+                .select(model::Silo::as_select())
+                .get_result_async::<model::Silo>(&*conn)
+                .await
+                .map_err(|e| {
+                    public_error_from_diesel(
+                        e,
+                        ErrorHandler::NotFoundByResource(authz_silo),
+                    )
+                })?
+        };
+
+        let page = paginated(dsl::silo_group, dsl::id, pagparams)
             .filter(dsl::silo_id.eq(authz_silo.id()))
             .filter(dsl::time_deleted.is_null())
-            .select(SiloGroup::as_select())
-            .load_async::<SiloGroup>(
-                &*self.pool_connection_authorized(opctx).await?,
-            )
+            .filter(dsl::user_provision_type.eq(silo.user_provision_type))
+            .select(model::SiloGroup::as_select())
+            .load_async::<model::SiloGroup>(&*conn)
             .await
-            .map_err(|e| public_error_from_diesel(e, ErrorHandler::Server))
+            .map_err(|e| public_error_from_diesel(e, ErrorHandler::Server))?
+            .into_iter()
+            .map(|group: model::SiloGroup| group.into())
+            .collect::<Vec<SiloGroup>>();
+
+        Ok(page)
     }
 }

--- a/nexus/db-queries/src/policy_test/resource_builder.rs
+++ b/nexus/db-queries/src/policy_test/resource_builder.rs
@@ -7,6 +7,7 @@
 
 use super::coverage::Coverage;
 use crate::db;
+use crate::db::datastore::SiloUserApiOnly;
 use authz::ApiResource;
 use futures::FutureExt;
 use futures::future::BoxFuture;
@@ -112,10 +113,9 @@ impl<'a> ResourceBuilder<'a> {
                 silo_id,
                 LookupType::ById(silo_id),
             );
-            let silo_user =
-                db::model::SiloUser::new(silo_id, user_id, username);
+            let silo_user = SiloUserApiOnly::new(silo_id, user_id, username);
             datastore
-                .silo_user_create(&authz_silo, silo_user)
+                .silo_user_create(&authz_silo, silo_user.into())
                 .await
                 .expect("failed to create silo user");
 

--- a/nexus/db-schema/src/schema.rs
+++ b/nexus/db-schema/src/schema.rs
@@ -764,7 +764,8 @@ table! {
         time_deleted -> Nullable<Timestamptz>,
 
         silo_id -> Uuid,
-        external_id -> Text,
+        external_id -> Nullable<Text>,
+        user_provision_type -> crate::enums::UserProvisionTypeEnum,
     }
 }
 
@@ -784,7 +785,8 @@ table! {
         time_deleted -> Nullable<Timestamptz>,
 
         silo_id -> Uuid,
-        external_id -> Text,
+        external_id -> Nullable<Text>,
+        user_provision_type -> crate::enums::UserProvisionTypeEnum,
     }
 }
 
@@ -801,6 +803,8 @@ allow_tables_to_appear_in_same_query!(
     silo_group_membership,
     silo_user,
 );
+allow_tables_to_appear_in_same_query!(silo_group, silo);
+allow_tables_to_appear_in_same_query!(silo_user, silo);
 allow_tables_to_appear_in_same_query!(role_assignment, silo_group_membership);
 
 table! {

--- a/nexus/src/app/iam.rs
+++ b/nexus/src/app/iam.rs
@@ -11,6 +11,8 @@ use nexus_db_lookup::lookup;
 use nexus_db_queries::authz;
 use nexus_db_queries::context::OpContext;
 use nexus_db_queries::db;
+use nexus_db_queries::db::datastore::SiloGroup;
+use nexus_db_queries::db::datastore::SiloUser;
 use nexus_db_queries::db::model::Name;
 use nexus_types::external_api::params;
 use omicron_common::api::external::DataPageParams;
@@ -70,7 +72,7 @@ impl super::Nexus {
         &self,
         opctx: &OpContext,
         pagparams: &DataPageParams<'_, Uuid>,
-    ) -> ListResultVec<db::model::SiloUser> {
+    ) -> ListResultVec<SiloUser> {
         let authz_silo = opctx
             .authn
             .silo_required()
@@ -88,7 +90,7 @@ impl super::Nexus {
         opctx: &OpContext,
         pagparams: &DataPageParams<'_, Uuid>,
         group_id: &SiloGroupUuid,
-    ) -> ListResultVec<db::model::SiloUser> {
+    ) -> ListResultVec<SiloUser> {
         let authz_silo = opctx
             .authn
             .silo_required()
@@ -115,7 +117,7 @@ impl super::Nexus {
     pub(crate) async fn silo_user_fetch_self(
         &self,
         opctx: &OpContext,
-    ) -> LookupResult<db::model::SiloUser> {
+    ) -> LookupResult<SiloUser> {
         let &actor = opctx
             .authn
             .actor_required()
@@ -124,14 +126,14 @@ impl super::Nexus {
             .silo_user_actor(&actor)?
             .fetch()
             .await?;
-        Ok(db_silo_user)
+        Ok(db_silo_user.into())
     }
 
     pub(crate) async fn silo_user_fetch_groups_for_self(
         &self,
         opctx: &OpContext,
         pagparams: &DataPageParams<'_, Uuid>,
-    ) -> ListResultVec<db::model::SiloGroup> {
+    ) -> ListResultVec<SiloGroup> {
         self.db_datastore.silo_groups_for_self(opctx, pagparams).await
     }
 
@@ -141,7 +143,7 @@ impl super::Nexus {
         &self,
         opctx: &OpContext,
         pagparams: &DataPageParams<'_, Uuid>,
-    ) -> ListResultVec<db::model::SiloGroup> {
+    ) -> ListResultVec<SiloGroup> {
         let authz_silo = opctx
             .authn
             .silo_required()

--- a/nexus/src/app/session.rs
+++ b/nexus/src/app/session.rs
@@ -11,7 +11,7 @@ use nexus_db_queries::authn::Reason;
 use nexus_db_queries::authz;
 use nexus_db_queries::context::OpContext;
 use nexus_db_queries::db;
-use nexus_db_queries::db::identity::Asset;
+use nexus_db_queries::db::datastore::SiloUser;
 use omicron_common::api::external::CreateResult;
 use omicron_common::api::external::DeleteResult;
 use omicron_common::api::external::Error;
@@ -41,7 +41,7 @@ impl super::Nexus {
     pub(crate) async fn session_create(
         &self,
         opctx: &OpContext,
-        user: &db::model::SiloUser,
+        user: &SiloUser,
     ) -> CreateResult<db::model::ConsoleSession> {
         let session =
             db::model::ConsoleSession::new(generate_session_token(), user.id());

--- a/nexus/src/external_api/http_entrypoints.rs
+++ b/nexus/src/external_api/http_entrypoints.rs
@@ -7071,8 +7071,7 @@ impl NexusExternalApi for NexusExternalApiImpl {
             let path = path_params.into_inner();
             let opctx =
                 crate::context::op_context_for_external_api(&rqctx).await?;
-            let (.., group) =
-                nexus.silo_group_lookup(&opctx, &path.group_id).fetch().await?;
+            let group = nexus.silo_group_lookup(&opctx, &path.group_id).await?;
             Ok(HttpResponseOk(group.into()))
         };
         apictx

--- a/nexus/tests/integration_tests/console_api.rs
+++ b/nexus/tests/integration_tests/console_api.rs
@@ -438,7 +438,7 @@ async fn test_session_me(cptestctx: &ControlPlaneTestContext) {
         views::CurrentUser {
             user: views::User {
                 id: USER_TEST_PRIVILEGED.id(),
-                display_name: USER_TEST_PRIVILEGED.external_id.clone(),
+                display_name: USER_TEST_PRIVILEGED.external_id.clone().unwrap(),
                 silo_id: DEFAULT_SILO.id(),
             },
             silo_name: DEFAULT_SILO.name().clone(),
@@ -457,7 +457,10 @@ async fn test_session_me(cptestctx: &ControlPlaneTestContext) {
         views::CurrentUser {
             user: views::User {
                 id: USER_TEST_UNPRIVILEGED.id(),
-                display_name: USER_TEST_UNPRIVILEGED.external_id.clone(),
+                display_name: USER_TEST_UNPRIVILEGED
+                    .external_id
+                    .clone()
+                    .unwrap(),
                 silo_id: DEFAULT_SILO.id(),
             },
             silo_name: DEFAULT_SILO.name().clone(),

--- a/nexus/tests/integration_tests/silo_users.rs
+++ b/nexus/tests/integration_tests/silo_users.rs
@@ -7,6 +7,7 @@ use http::{StatusCode, method::Method};
 use nexus_db_queries::authn::USER_TEST_UNPRIVILEGED;
 use nexus_db_queries::authz;
 use nexus_db_queries::context::OpContext;
+use nexus_db_queries::db::datastore::SiloGroupApiOnly;
 use nexus_test_utils::assert_same_items;
 use nexus_test_utils::http_testing::{AuthnMode, NexusRequest};
 use nexus_test_utils::resource_helpers::objects_list_page_authz;
@@ -15,6 +16,7 @@ use nexus_types::external_api::views;
 use nexus_types::identity::Asset;
 use nexus_types::silo::DEFAULT_SILO_ID;
 use omicron_common::api::external::LookupType;
+use omicron_uuid_kinds::SiloGroupUuid;
 use uuid::Uuid;
 
 type ControlPlaneTestContext =
@@ -53,7 +55,17 @@ async fn test_silo_group_users(cptestctx: &ControlPlaneTestContext) {
     // create a group
     let group_name = "group1".to_string();
     nexus
-        .silo_group_lookup_or_create_by_name(&opctx, &authz_silo, &group_name)
+        .datastore()
+        .silo_group_ensure(
+            &opctx,
+            &authz_silo,
+            SiloGroupApiOnly::new(
+                authz_silo.id(),
+                SiloGroupUuid::new_v4(),
+                group_name.clone(),
+            )
+            .into(),
+        )
         .await
         .expect("Group created");
 

--- a/nexus/tests/integration_tests/silos.rs
+++ b/nexus/tests/integration_tests/silos.rs
@@ -10,6 +10,9 @@ use nexus_db_queries::authn::{USER_TEST_PRIVILEGED, USER_TEST_UNPRIVILEGED};
 use nexus_db_queries::authz::{self};
 use nexus_db_queries::context::OpContext;
 use nexus_db_queries::db;
+use nexus_db_queries::db::datastore::SiloGroupLookup;
+use nexus_db_queries::db::datastore::SiloUserJit;
+use nexus_db_queries::db::datastore::SiloUserLookup;
 use nexus_db_queries::db::fixed_data::silo::DEFAULT_SILO;
 use nexus_db_queries::db::identity::Asset;
 use nexus_test_utils::http_testing::{AuthnMode, NexusRequest, RequestBuilder};
@@ -27,7 +30,7 @@ use nexus_types::external_api::{params, shared};
 use nexus_types::silo::DEFAULT_SILO_ID;
 use omicron_common::address::{IpRange, Ipv4Range};
 use omicron_common::api::external::{
-    IdentityMetadataCreateParams, LookupType, Name,
+    DataPageParams, IdentityMetadataCreateParams, LookupType, Name,
 };
 use omicron_common::api::external::{ObjectIdentity, UserId};
 use omicron_test_utils::certificates::CertificateChain;
@@ -312,7 +315,7 @@ async fn test_silo_admin_group(cptestctx: &ControlPlaneTestContext) {
             .silo_group_optional_lookup(
                 &authn_opctx,
                 &authz_silo,
-                "administrator".into(),
+                &SiloGroupLookup::Jit { external_id: "administrator" },
             )
             .await
             .unwrap()
@@ -879,10 +882,10 @@ async fn test_silo_user_fetch_by_external_id(
     // Fetching by external id that's not in the db should be Ok(None)
     let result = nexus
         .datastore()
-        .silo_user_fetch_by_external_id(
+        .silo_user_fetch(
             &opctx_external_authn,
             &authz_silo,
-            "123",
+            &SiloUserLookup::ApiOnly { external_id: "123" },
         )
         .await;
     assert!(result.is_ok());
@@ -891,10 +894,12 @@ async fn test_silo_user_fetch_by_external_id(
     // Fetching by external id that is should be Ok(Some)
     let result = nexus
         .datastore()
-        .silo_user_fetch_by_external_id(
+        .silo_user_fetch(
             &opctx_external_authn,
             &authz_silo,
-            "f5513e049dac9468de5bdff36ab17d04f",
+            &SiloUserLookup::ApiOnly {
+                external_id: "f5513e049dac9468de5bdff36ab17d04f",
+            },
         )
         .await;
     assert!(result.is_ok());
@@ -918,12 +923,15 @@ async fn test_silo_users_list(cptestctx: &ControlPlaneTestContext) {
         vec![
             views::User {
                 id: USER_TEST_PRIVILEGED.id(),
-                display_name: USER_TEST_PRIVILEGED.external_id.clone(),
+                display_name: USER_TEST_PRIVILEGED.external_id.clone().unwrap(),
                 silo_id: DEFAULT_SILO_ID,
             },
             views::User {
                 id: USER_TEST_UNPRIVILEGED.id(),
-                display_name: USER_TEST_UNPRIVILEGED.external_id.clone(),
+                display_name: USER_TEST_UNPRIVILEGED
+                    .external_id
+                    .clone()
+                    .unwrap(),
                 silo_id: DEFAULT_SILO_ID,
             },
         ]
@@ -957,12 +965,15 @@ async fn test_silo_users_list(cptestctx: &ControlPlaneTestContext) {
             },
             views::User {
                 id: USER_TEST_PRIVILEGED.id(),
-                display_name: USER_TEST_PRIVILEGED.external_id.clone(),
+                display_name: USER_TEST_PRIVILEGED.external_id.clone().unwrap(),
                 silo_id: DEFAULT_SILO_ID,
             },
             views::User {
                 id: USER_TEST_UNPRIVILEGED.id(),
-                display_name: USER_TEST_UNPRIVILEGED.external_id.clone(),
+                display_name: USER_TEST_UNPRIVILEGED
+                    .external_id
+                    .clone()
+                    .unwrap(),
                 silo_id: DEFAULT_SILO_ID,
             },
         ]
@@ -1085,7 +1096,8 @@ async fn test_silo_groups_jit(cptestctx: &ControlPlaneTestContext) {
             .await
             .unwrap();
 
-        group_names.push(db_group.external_id);
+        // expect groups to have non-None external ids for JIT silos
+        group_names.push(db_group.external_id.unwrap());
     }
 
     assert!(group_names.contains(&"a-group".to_string()));
@@ -1214,7 +1226,8 @@ async fn test_silo_groups_remove_from_one_group(
             .await
             .unwrap();
 
-        group_names.push(db_group.external_id);
+        // expect groups to have non-None external ids for JIT silos
+        group_names.push(db_group.external_id.unwrap());
     }
 
     assert!(group_names.contains(&"a-group".to_string()));
@@ -1255,7 +1268,8 @@ async fn test_silo_groups_remove_from_one_group(
             .await
             .unwrap();
 
-        group_names.push(db_group.external_id);
+        // expect groups to have non-None external ids for JIT silos
+        group_names.push(db_group.external_id.unwrap());
     }
 
     assert!(group_names.contains(&"b-group".to_string()));
@@ -1325,7 +1339,8 @@ async fn test_silo_groups_remove_from_both_groups(
             .await
             .unwrap();
 
-        group_names.push(db_group.external_id);
+        // expect groups to have non-None external ids for JIT silos
+        group_names.push(db_group.external_id.unwrap());
     }
 
     assert!(group_names.contains(&"a-group".to_string()));
@@ -1366,7 +1381,8 @@ async fn test_silo_groups_remove_from_both_groups(
             .await
             .unwrap();
 
-        group_names.push(db_group.external_id);
+        // expect groups to have non-None external ids for JIT silos
+        group_names.push(db_group.external_id.unwrap());
     }
 
     assert!(group_names.contains(&"c-group".to_string()));
@@ -1427,7 +1443,7 @@ async fn test_silo_delete_clean_up_groups(cptestctx: &ControlPlaneTestContext) {
             .silo_group_optional_lookup(
                 &opctx_external_authn,
                 &authz_silo,
-                "a-group".into(),
+                &SiloGroupLookup::Jit { external_id: "a-group" },
             )
             .await
             .expect("silo_group_optional_lookup")
@@ -1475,6 +1491,17 @@ async fn test_ensure_same_silo_group(cptestctx: &ControlPlaneTestContext) {
         nexus.datastore().clone(),
     );
 
+    // Grant this user admin privileges on the new silo
+
+    grant_iam(
+        client,
+        "/v1/system/silos/test-silo",
+        SiloRole::Admin,
+        opctx.authn.actor().unwrap().silo_user_id().unwrap(),
+        AuthnMode::PrivilegedUser,
+    )
+    .await;
+
     let (authz_silo, db_silo) = LookupPath::new(&opctx, nexus.datastore())
         .silo_name(&silo.identity.name.into())
         .fetch()
@@ -1495,7 +1522,7 @@ async fn test_ensure_same_silo_group(cptestctx: &ControlPlaneTestContext) {
         .await
         .expect("silo_user_from_authenticated_subject 1");
 
-    // Add the first user with a group membership
+    // Add the second user with the same group membership
     let _silo_user_2 = nexus
         .silo_user_from_authenticated_subject(
             &nexus.opctx_external_authn(),
@@ -1509,7 +1536,42 @@ async fn test_ensure_same_silo_group(cptestctx: &ControlPlaneTestContext) {
         .await
         .expect("silo_user_from_authenticated_subject 2");
 
-    // TODO-coverage were we intending to verify something here?
+    // Validate only one group was created
+
+    let page = nexus
+        .datastore()
+        .silo_groups_list_by_id(
+            &opctx,
+            &authz_silo,
+            &DataPageParams::max_page(),
+        )
+        .await
+        .expect("silo_groups_list_by_id");
+
+    assert_eq!(page.len(), 1);
+
+    // Validate that the "sre" group was created
+
+    let sre_group = nexus
+        .datastore()
+        .silo_group_optional_lookup(
+            &opctx,
+            &authz_silo,
+            &SiloGroupLookup::Jit { external_id: "sre" },
+        )
+        .await
+        .expect("silo_group_optional_lookup")
+        .expect("sre group exists");
+
+    // Validate that the "sre" group has two members
+
+    let members = nexus
+        .datastore()
+        .silo_group_membership_for_group(&opctx, &authz_silo, sre_group.id())
+        .await
+        .expect("silo_group_membership_for_group");
+
+    assert_eq!(members.len(), 2);
 }
 
 /// Tests the behavior of the per-Silo "list users" and "fetch user" endpoints.
@@ -1724,9 +1786,9 @@ async fn create_jit_user(
     let authz_silo =
         authz::Silo::new(authz::FLEET, silo_id, LookupType::ById(silo_id));
     let silo_user =
-        db::model::SiloUser::new(silo_id, silo_user_id, external_id.to_owned());
+        SiloUserJit::new(silo_id, silo_user_id, external_id.to_owned());
     datastore
-        .silo_user_create(&authz_silo, silo_user)
+        .silo_user_create(&authz_silo, silo_user.into())
         .await
         .expect("failed to create user in SamlJit Silo")
         .1

--- a/schema/crdb/dbinit.sql
+++ b/schema/crdb/dbinit.sql
@@ -895,15 +895,36 @@ CREATE TABLE IF NOT EXISTS omicron.public.silo_user (
     time_deleted TIMESTAMPTZ,
 
     silo_id UUID NOT NULL,
-    external_id TEXT NOT NULL
+
+    -- if the user provision type is 'api_only' or 'jit', then this field must
+    -- contain a value
+    external_id TEXT,
+
+    user_provision_type omicron.public.user_provision_type,
+
+    CONSTRAINT user_provision_type_required_for_non_deleted CHECK (
+      (user_provision_type IS NOT NULL AND time_deleted IS NULL)
+      OR (time_deleted IS NOT NULL)
+    ),
+
+    CONSTRAINT external_id_consistency CHECK (
+        CASE user_provision_type
+          WHEN 'api_only' THEN external_id IS NOT NULL
+          WHEN 'jit' THEN external_id IS NOT NULL
+        END
+    )
 );
 
-/* This index lets us quickly find users for a given silo. */
-CREATE UNIQUE INDEX IF NOT EXISTS lookup_silo_user_by_silo ON omicron.public.silo_user (
-    silo_id,
-    external_id
-) WHERE
-    time_deleted IS NULL;
+/* This index lets us quickly find users for a given silo, and prevents
+   multiple users from having the same external id (for certain provision
+   types). */
+CREATE UNIQUE INDEX IF NOT EXISTS
+ lookup_silo_user_by_silo
+ON
+ omicron.public.silo_user (silo_id, external_id)
+WHERE
+ time_deleted IS NULL AND
+ (user_provision_type = 'api_only' OR user_provision_type = 'jit');
 
 CREATE TABLE IF NOT EXISTS omicron.public.silo_user_password_hash (
     silo_user_id UUID NOT NULL,
@@ -924,14 +945,33 @@ CREATE TABLE IF NOT EXISTS omicron.public.silo_group (
     time_deleted TIMESTAMPTZ,
 
     silo_id UUID NOT NULL,
-    external_id TEXT NOT NULL
+
+    -- if the user provision type is 'api_only' or 'jit', then this field must
+    -- contain a value
+    external_id TEXT,
+
+    user_provision_type omicron.public.user_provision_type,
+
+    CONSTRAINT user_provision_type_required_for_non_deleted CHECK (
+      (user_provision_type IS NOT NULL AND time_deleted IS NULL)
+      OR (time_deleted IS NOT NULL)
+    ),
+
+    CONSTRAINT external_id_consistency CHECK (
+        CASE user_provision_type
+          WHEN 'api_only' THEN external_id IS NOT NULL
+          WHEN 'jit' THEN external_id IS NOT NULL
+        END
+    )
 );
 
-CREATE UNIQUE INDEX IF NOT EXISTS lookup_silo_group_by_silo ON omicron.public.silo_group (
-    silo_id,
-    external_id
-) WHERE
-    time_deleted IS NULL;
+CREATE UNIQUE INDEX IF NOT EXISTS
+ lookup_silo_group_by_silo
+ON
+ omicron.public.silo_group (silo_id, external_id)
+WHERE
+ time_deleted IS NULL and
+ (user_provision_type = 'api_only' OR user_provision_type = 'jit');
 
 /*
  * Silo group membership
@@ -6602,7 +6642,7 @@ INSERT INTO omicron.public.db_metadata (
     version,
     target_version
 ) VALUES
-    (TRUE, NOW(), NOW(), '186.0.0', NULL)
+    (TRUE, NOW(), NOW(), '187.0.0', NULL)
 ON CONFLICT DO NOTHING;
 
 COMMIT;

--- a/schema/crdb/user-provision-type-for-silo-user-and-group/up01.sql
+++ b/schema/crdb/user-provision-type-for-silo-user-and-group/up01.sql
@@ -1,0 +1,5 @@
+ALTER TABLE
+ omicron.public.silo_user
+ADD COLUMN IF NOT EXISTS
+ user_provision_type omicron.public.user_provision_type
+DEFAULT NULL;

--- a/schema/crdb/user-provision-type-for-silo-user-and-group/up02.sql
+++ b/schema/crdb/user-provision-type-for-silo-user-and-group/up02.sql
@@ -1,0 +1,8 @@
+UPDATE
+ omicron.public.silo_user
+SET
+ user_provision_type = silo.user_provision_type
+FROM
+ silo
+WHERE
+ silo.id = silo_user.silo_id AND silo_user.time_deleted is null;

--- a/schema/crdb/user-provision-type-for-silo-user-and-group/up03.sql
+++ b/schema/crdb/user-provision-type-for-silo-user-and-group/up03.sql
@@ -1,0 +1,6 @@
+ALTER TABLE
+ omicron.public.silo_user
+ADD CONSTRAINT IF NOT EXISTS user_provision_type_required_for_non_deleted CHECK (
+ (user_provision_type IS NOT NULL AND time_deleted IS NULL)
+ OR (time_deleted IS NOT NULL)
+)

--- a/schema/crdb/user-provision-type-for-silo-user-and-group/up04.sql
+++ b/schema/crdb/user-provision-type-for-silo-user-and-group/up04.sql
@@ -1,0 +1,5 @@
+ALTER TABLE
+ omicron.public.silo_user
+ALTER COLUMN
+ external_id
+DROP NOT NULL

--- a/schema/crdb/user-provision-type-for-silo-user-and-group/up05.sql
+++ b/schema/crdb/user-provision-type-for-silo-user-and-group/up05.sql
@@ -1,0 +1,10 @@
+ALTER TABLE
+ omicron.public.silo_user
+ADD CONSTRAINT IF NOT EXISTS
+ external_id_consistency
+CHECK (
+ CASE user_provision_type
+   WHEN 'api_only' THEN external_id IS NOT NULL
+   WHEN 'jit' THEN external_id IS NOT NULL
+ END
+)

--- a/schema/crdb/user-provision-type-for-silo-user-and-group/up06.sql
+++ b/schema/crdb/user-provision-type-for-silo-user-and-group/up06.sql
@@ -1,0 +1,1 @@
+DROP INDEX IF EXISTS lookup_silo_user_by_silo;

--- a/schema/crdb/user-provision-type-for-silo-user-and-group/up07.sql
+++ b/schema/crdb/user-provision-type-for-silo-user-and-group/up07.sql
@@ -1,0 +1,7 @@
+CREATE UNIQUE INDEX IF NOT EXISTS
+ lookup_silo_user_by_silo
+ON
+ omicron.public.silo_user (silo_id, external_id)
+WHERE
+ time_deleted IS NULL AND
+ (user_provision_type = 'api_only' OR user_provision_type = 'jit');

--- a/schema/crdb/user-provision-type-for-silo-user-and-group/up08.sql
+++ b/schema/crdb/user-provision-type-for-silo-user-and-group/up08.sql
@@ -1,0 +1,5 @@
+ALTER TABLE
+ omicron.public.silo_group
+ADD COLUMN IF NOT EXISTS
+ user_provision_type omicron.public.user_provision_type
+DEFAULT NULL;

--- a/schema/crdb/user-provision-type-for-silo-user-and-group/up09.sql
+++ b/schema/crdb/user-provision-type-for-silo-user-and-group/up09.sql
@@ -1,0 +1,8 @@
+UPDATE
+ omicron.public.silo_group
+SET
+ user_provision_type = silo.user_provision_type
+FROM
+ silo
+WHERE
+ silo.id = silo_group.silo_id AND silo_group.time_deleted is null;

--- a/schema/crdb/user-provision-type-for-silo-user-and-group/up10.sql
+++ b/schema/crdb/user-provision-type-for-silo-user-and-group/up10.sql
@@ -1,0 +1,6 @@
+ALTER TABLE
+ omicron.public.silo_group
+ADD CONSTRAINT IF NOT EXISTS user_provision_type_required_for_non_deleted CHECK (
+ (user_provision_type IS NOT NULL AND time_deleted IS NULL)
+ OR (time_deleted IS NOT NULL)
+)

--- a/schema/crdb/user-provision-type-for-silo-user-and-group/up11.sql
+++ b/schema/crdb/user-provision-type-for-silo-user-and-group/up11.sql
@@ -1,0 +1,5 @@
+ALTER TABLE
+ omicron.public.silo_group
+ALTER COLUMN
+ external_id
+DROP NOT NULL

--- a/schema/crdb/user-provision-type-for-silo-user-and-group/up12.sql
+++ b/schema/crdb/user-provision-type-for-silo-user-and-group/up12.sql
@@ -1,0 +1,10 @@
+ALTER TABLE
+ omicron.public.silo_group
+ADD CONSTRAINT IF NOT EXISTS
+ external_id_consistency
+CHECK (
+ CASE user_provision_type
+   WHEN 'api_only' THEN external_id IS NOT NULL
+   WHEN 'jit' THEN external_id IS NOT NULL
+ END
+)

--- a/schema/crdb/user-provision-type-for-silo-user-and-group/up13.sql
+++ b/schema/crdb/user-provision-type-for-silo-user-and-group/up13.sql
@@ -1,0 +1,1 @@
+DROP INDEX IF EXISTS lookup_silo_group_by_silo;

--- a/schema/crdb/user-provision-type-for-silo-user-and-group/up14.sql
+++ b/schema/crdb/user-provision-type-for-silo-user-and-group/up14.sql
@@ -1,0 +1,7 @@
+CREATE UNIQUE INDEX IF NOT EXISTS
+ lookup_silo_group_by_silo
+ON
+ omicron.public.silo_group (silo_id, external_id)
+WHERE
+ time_deleted IS NULL AND
+ (user_provision_type = 'api_only' OR user_provision_type = 'jit');


### PR DESCRIPTION
Silo users and groups have traditionally defined "external id" as whatever the silo's identity provider (or in the case of ApiOnly silos, an operator) assigns for them: this could be username, email, a random id, etc.

SCIM throws one of many wrenches at us because the specification defines an external id attribute for users and groups that is distinct from other related attributes that could be sent, including username and email. Importantly the SCIM client that is creating a user or group could send a NULL external ID, which is not supported by the current field's database type.

The first step to supporting SCIM's extra attributes is to add the silo's user provision field to our user and group models, and use this field to change the semantics of the external id field depending on what provision type is used. For the existing ApiOnly and JIT silos this will stay the same.

The second step that will help with type safety is to use this new user provision type field to separate the silo user and group database models into distinct silo user and group types at the datastore level, and have separate enum variants for each type that wrap an inner typed object:

```rust
pub enum SiloUser {
    /// A User created via the API
    ApiOnly(SiloUserApiOnly),

    /// A User created during an authenticated SAML login
    Jit(SiloUserJit),
}
```

Call sites now have to use either the ApiOnly or Jit variant of this new higher level silo user type. With the addition of user provision type to the silo user model, Nexus can also now check that the provision type on the user matches the silo, or (like with some of the local idp functions) accept only one specific variant.

The third step that will also help with type safety is to have typed lookups for silo users and groups, as different user provision types will have different fields that they enforce uniqueness for: for example, only search for ApiOnly and JIT users using external_id, but for SCIM use username.

One possible bug that this commit addresses is that the creation of the recovery silo did not have a check to ensure that the created silo was a "LocalOnly" identity type. The code prior to this commit could create a SamlJit silo, which is not ideal for a recovery silo!

Another possible bug potential addressed is a mismatch in the silo's user provision type, and the users within that silo. This can be enforced via functions that only accept one variant of the new higher level enum, and is checked at the lower layers.

Another bug addressed: in `silo_group_ensure` there was a small window between `silo_group_ensure_query` and unwrapping the result of `silo_group_optional_lookup` where, if it were possible to delete groups, a racing delete would cause the unwrap to panic.

Also! Fill in `test_ensure_same_silo_group`, why that was left truncated is beyond me, but don't look at the git blame please.