### PR TITLE
Ensure quotas are non-negative

### DIFF
--- a/nexus/db-model/src/quota.rs
+++ b/nexus/db-model/src/quota.rs
@@ -80,9 +80,9 @@ impl From<SiloQuotas> for views::SiloQuotas {
 pub struct SiloQuotasUpdate {
     pub cpus: Option<i64>,
     #[diesel(column_name = memory_bytes)]
-    pub memory: Option<i64>,
+    pub memory: Option<ByteCount>,
     #[diesel(column_name = storage_bytes)]
-    pub storage: Option<i64>,
+    pub storage: Option<ByteCount>,
     pub time_modified: DateTime<Utc>,
 }
 

--- a/nexus/db-model/src/schema_versions.rs
+++ b/nexus/db-model/src/schema_versions.rs
@@ -16,7 +16,7 @@ use std::{collections::BTreeMap, sync::LazyLock};
 ///
 /// This must be updated when you change the database schema.  Refer to
 /// schema/crdb/README.adoc in the root of this repository for details.
-pub const SCHEMA_VERSION: Version = Version::new(187, 0, 0);
+pub const SCHEMA_VERSION: Version = Version::new(188, 0, 0);
 
 /// List of all past database schema versions, in *reverse* order
 ///
@@ -28,6 +28,7 @@ static KNOWN_VERSIONS: LazyLock<Vec<KnownVersion>> = LazyLock::new(|| {
         // |  leaving the first copy as an example for the next person.
         // v
         // KnownVersion::new(next_int, "unique-dirname-with-the-sql-files"),
+        KnownVersion::new(188, "positive-quotas"),
         KnownVersion::new(187, "no-default-pool-for-internal-silo"),
         KnownVersion::new(186, "nexus-generation"),
         KnownVersion::new(185, "populate-db-metadata-nexus"),

--- a/nexus/db-queries/src/db/datastore/virtual_provisioning_collection.rs
+++ b/nexus/db-queries/src/db/datastore/virtual_provisioning_collection.rs
@@ -407,8 +407,8 @@ mod test {
 
         let quotas_update = SiloQuotasUpdate {
             cpus: Some(24),
-            memory: Some(1 << 40),
-            storage: Some(1 << 50),
+            memory: Some((1 << 40).try_into().unwrap()),
+            storage: Some((1 << 50).try_into().unwrap()),
             time_modified: chrono::Utc::now(),
         };
         let authz_silo = LookupPath::new(&opctx, datastore)

--- a/nexus/test-utils/src/resource_helpers.rs
+++ b/nexus/test-utils/src/resource_helpers.rs
@@ -166,7 +166,7 @@ where
     .authn_as(AuthnMode::PrivilegedUser)
     .execute()
     .await
-    .unwrap()
+    .unwrap_or_else(|err| panic!("Error creating object with {path}: {err}"))
     .parsed_body::<HttpErrorResponseBody>()
     .unwrap()
 }

--- a/nexus/tests/integration_tests/schema.rs
+++ b/nexus/tests/integration_tests/schema.rs
@@ -3040,6 +3040,88 @@ fn after_185_0_0<'a>(ctx: &'a MigrationContext<'a>) -> BoxFuture<'a, ()> {
     })
 }
 
+const NEGATIVE_QUOTA: Uuid =
+    Uuid::from_u128(0x00006001_5c3d_4647_83b0_8f351dda7ce1);
+const POSITIVE_QUOTA: Uuid =
+    Uuid::from_u128(0x00006001_5c3d_4647_83b0_8f351dda7ce2);
+const MIXED_QUOTA: Uuid =
+    Uuid::from_u128(0x00006001_5c3d_4647_83b0_8f351dda7ce3);
+
+fn before_188_0_0<'a>(ctx: &'a MigrationContext<'a>) -> BoxFuture<'a, ()> {
+    Box::pin(async move {
+        ctx.client
+            .execute(
+                &format!(
+                    "INSERT INTO omicron.public.silo_quotas (
+                        silo_id,
+                        time_created,
+                        time_modified,
+                        cpus,
+                        memory_bytes,
+                        storage_bytes
+                    )
+                     VALUES
+                     ('{NEGATIVE_QUOTA}', now(), now(), -1, -2, -3),
+                     ('{POSITIVE_QUOTA}', now(), now(), 1, 2, 3),
+                     ('{MIXED_QUOTA}', now(), now(), -1, 0, 3);",
+                ),
+                &[],
+            )
+            .await
+            .expect("inserted silo_quotas");
+    })
+}
+
+fn after_188_0_0<'a>(ctx: &'a MigrationContext<'a>) -> BoxFuture<'a, ()> {
+    Box::pin(async move {
+        let rows = ctx
+            .client
+            .query(
+                "SELECT
+                   silo_id,
+                   cpus,
+                   memory_bytes,
+                   storage_bytes
+                 FROM omicron.public.silo_quotas ORDER BY silo_id ASC;",
+                &[],
+            )
+            .await
+            .expect("queried post-migration positive-quotas");
+
+        fn check_quota(
+            row: &Row,
+            id: Uuid,
+            cpus: i64,
+            memory: i64,
+            storage: i64,
+        ) {
+            assert_eq!(
+                row.values[0].expect("silo_id").unwrap(),
+                &AnySqlType::Uuid(id)
+            );
+            assert_eq!(
+                row.values[1].expect("cpus").unwrap(),
+                &AnySqlType::Int8(cpus)
+            );
+            assert_eq!(
+                row.values[2].expect("memory_bytes").unwrap(),
+                &AnySqlType::Int8(memory)
+            );
+            assert_eq!(
+                row.values[3].expect("storage_bytes").unwrap(),
+                &AnySqlType::Int8(storage)
+            );
+        }
+
+        let rows = process_rows(&rows);
+        assert_eq!(rows.len(), 3);
+
+        check_quota(&rows[0], NEGATIVE_QUOTA, 0, 0, 0);
+        check_quota(&rows[1], POSITIVE_QUOTA, 1, 2, 3);
+        check_quota(&rows[2], MIXED_QUOTA, 0, 0, 3);
+    })
+}
+
 // Lazily initializes all migration checks. The combination of Rust function
 // pointers and async makes defining a static table fairly painful, so we're
 // using lazy initialization instead.
@@ -3141,6 +3223,10 @@ fn get_migration_checks() -> BTreeMap<Version, DataMigrationFns> {
     map.insert(
         Version::new(185, 0, 0),
         DataMigrationFns::new().before(before_185_0_0).after(after_185_0_0),
+    );
+    map.insert(
+        Version::new(188, 0, 0),
+        DataMigrationFns::new().before(before_188_0_0).after(after_188_0_0),
     );
     map
 }

--- a/schema/crdb/dbinit.sql
+++ b/schema/crdb/dbinit.sql
@@ -1073,7 +1073,11 @@ CREATE TABLE IF NOT EXISTS omicron.public.silo_quotas (
     time_modified TIMESTAMPTZ NOT NULL,
     cpus INT8 NOT NULL,
     memory_bytes INT8 NOT NULL,
-    storage_bytes INT8 NOT NULL
+    storage_bytes INT8 NOT NULL,
+
+    CONSTRAINT cpus_not_negative CHECK (cpus >= 0),
+    CONSTRAINT memory_not_negative CHECK (memory_bytes >= 0),
+    CONSTRAINT storage_not_negative CHECK (storage_bytes >= 0)
 );
 
 /**
@@ -6613,7 +6617,7 @@ INSERT INTO omicron.public.db_metadata (
     version,
     target_version
 ) VALUES
-    (TRUE, NOW(), NOW(), '187.0.0', NULL)
+    (TRUE, NOW(), NOW(), '188.0.0', NULL)
 ON CONFLICT DO NOTHING;
 
 COMMIT;

--- a/schema/crdb/positive-quotas/up01.sql
+++ b/schema/crdb/positive-quotas/up01.sql
@@ -1,0 +1,8 @@
+SET LOCAL disallow_full_table_scans = off;
+
+UPDATE omicron.public.silo_quotas
+SET
+    cpus = GREATEST(cpus, 0),
+    memory_bytes = GREATEST(memory_bytes, 0),
+    storage_bytes = GREATEST(storage_bytes, 0)
+WHERE cpus < 0 OR memory_bytes < 0 OR storage_bytes < 0;

--- a/schema/crdb/positive-quotas/up02.sql
+++ b/schema/crdb/positive-quotas/up02.sql
@@ -1,0 +1,4 @@
+ALTER TABLE omicron.public.silo_quotas
+    ADD CONSTRAINT IF NOT EXISTS cpus_not_negative CHECK (cpus >= 0),
+    ADD CONSTRAINT IF NOT EXISTS memory_not_negative CHECK (memory_bytes >= 0),
+    ADD CONSTRAINT IF NOT EXISTS storage_not_negative CHECK (storage_bytes >= 0);


### PR DESCRIPTION
- Adds constraints that all the `INT8` quota components cannot be negative
- Adds a schema migration to ensure this is the case
- Adds tests validating that data migration, creation, and update cannot create negative silo values

Fixes https://github.com/oxidecomputer/omicron/issues/8973