### PR TITLE
Show import address if disk is importing to a pantry

### DIFF
--- a/dev-tools/omdb/src/bin/omdb/db.rs
+++ b/dev-tools/omdb/src/bin/omdb/db.rs
@@ -2085,6 +2085,7 @@ async fn cmd_db_disk_info(
         propolis_zone: String,
         volume_id: String,
         disk_state: String,
+        pantry_address: String,
     }
 
     // The rows describing the downstairs regions for this disk/volume
@@ -2156,6 +2157,10 @@ async fn cmd_db_disk_info(
                 .await
                 .context("failed to look up sled")?;
 
+            let pantry_address = match disk.pantry_address {
+                Some(ref pa) => format!("{:?}", pa.clone()),
+                None => format!("-"),
+            };
             UpstairsRow {
                 host_serial: my_sled.serial_number().to_string(),
                 disk_name,
@@ -2163,8 +2168,13 @@ async fn cmd_db_disk_info(
                 propolis_zone: format!("oxz_propolis-server_{}", propolis_id),
                 volume_id: disk.volume_id().to_string(),
                 disk_state: disk.runtime_state.disk_state.to_string(),
+                pantry_address,
             }
         } else {
+            let pantry_address = match disk.pantry_address {
+                Some(ref pa) => format!("{:?}", pa.clone()),
+                None => format!("-"),
+            };
             UpstairsRow {
                 host_serial: NOT_ON_SLED_MSG.to_string(),
                 disk_name,
@@ -2172,11 +2182,16 @@ async fn cmd_db_disk_info(
                 propolis_zone: NO_ACTIVE_PROPOLIS_MSG.to_string(),
                 volume_id: disk.volume_id().to_string(),
                 disk_state: disk.runtime_state.disk_state.to_string(),
+                pantry_address,
             }
         }
     } else {
         // If the disk is not attached to anything, just print empty
         // fields.
+        let pantry_address = match disk.pantry_address {
+            Some(ref pa) => format!("{:?}", pa.clone()),
+            None => format!("-"),
+        };
         UpstairsRow {
             host_serial: "-".to_string(),
             disk_name: disk.name().to_string(),
@@ -2184,6 +2199,7 @@ async fn cmd_db_disk_info(
             propolis_zone: "-".to_string(),
             volume_id: disk.volume_id().to_string(),
             disk_state: disk.runtime_state.disk_state.to_string(),
+            pantry_address,
         }
     };
     rows.push(usr);

--- a/dev-tools/omdb/src/bin/omdb/db.rs
+++ b/dev-tools/omdb/src/bin/omdb/db.rs
@@ -2158,8 +2158,8 @@ async fn cmd_db_disk_info(
                 .context("failed to look up sled")?;
 
             let import_address = match disk.pantry_address {
-                Some(ref pa) => format!("{}", pa.clone()),
-                None => format!("-"),
+                Some(ref pa) => pa.clone().to_string(),
+                None => "-".to_string(),
             };
             UpstairsRow {
                 host_serial: my_sled.serial_number().to_string(),
@@ -2172,8 +2172,8 @@ async fn cmd_db_disk_info(
             }
         } else {
             let import_address = match disk.pantry_address {
-                Some(ref pa) => format!("{}", pa.clone()),
-                None => format!("-"),
+                Some(ref pa) => pa.clone().to_string(),
+                None => "-".to_string(),
             };
             UpstairsRow {
                 host_serial: NOT_ON_SLED_MSG.to_string(),
@@ -2189,8 +2189,8 @@ async fn cmd_db_disk_info(
         // If the disk is not attached to anything, just print empty
         // fields.
         let import_address = match disk.pantry_address {
-            Some(ref pa) => format!("{}", pa.clone()),
-            None => format!("-"),
+            Some(ref pa) => pa.clone().to_string(),
+            None => "-".to_string(),
         };
         UpstairsRow {
             host_serial: "-".to_string(),

--- a/dev-tools/omdb/src/bin/omdb/db.rs
+++ b/dev-tools/omdb/src/bin/omdb/db.rs
@@ -2085,7 +2085,7 @@ async fn cmd_db_disk_info(
         propolis_zone: String,
         volume_id: String,
         disk_state: String,
-        pantry_address: String,
+        import_address: String,
     }
 
     // The rows describing the downstairs regions for this disk/volume
@@ -2114,6 +2114,7 @@ async fn cmd_db_disk_info(
         bail!("no disk: {} found", args.uuid);
     };
 
+    println!("Found disk: {:?}", disk);
     // For information about where this disk is attached.
     let mut rows = Vec::new();
 
@@ -2157,8 +2158,8 @@ async fn cmd_db_disk_info(
                 .await
                 .context("failed to look up sled")?;
 
-            let pantry_address = match disk.pantry_address {
-                Some(ref pa) => format!("{:?}", pa.clone()),
+            let import_address = match disk.pantry_address {
+                Some(ref pa) => format!("{}", pa.clone()),
                 None => format!("-"),
             };
             UpstairsRow {
@@ -2168,11 +2169,11 @@ async fn cmd_db_disk_info(
                 propolis_zone: format!("oxz_propolis-server_{}", propolis_id),
                 volume_id: disk.volume_id().to_string(),
                 disk_state: disk.runtime_state.disk_state.to_string(),
-                pantry_address,
+                import_address,
             }
         } else {
-            let pantry_address = match disk.pantry_address {
-                Some(ref pa) => format!("{:?}", pa.clone()),
+            let import_address = match disk.pantry_address {
+                Some(ref pa) => format!("{}", pa.clone()),
                 None => format!("-"),
             };
             UpstairsRow {
@@ -2182,14 +2183,14 @@ async fn cmd_db_disk_info(
                 propolis_zone: NO_ACTIVE_PROPOLIS_MSG.to_string(),
                 volume_id: disk.volume_id().to_string(),
                 disk_state: disk.runtime_state.disk_state.to_string(),
-                pantry_address,
+                import_address,
             }
         }
     } else {
         // If the disk is not attached to anything, just print empty
         // fields.
-        let pantry_address = match disk.pantry_address {
-            Some(ref pa) => format!("{:?}", pa.clone()),
+        let import_address = match disk.pantry_address {
+            Some(ref pa) => format!("{}", pa.clone()),
             None => format!("-"),
         };
         UpstairsRow {
@@ -2199,7 +2200,7 @@ async fn cmd_db_disk_info(
             propolis_zone: "-".to_string(),
             volume_id: disk.volume_id().to_string(),
             disk_state: disk.runtime_state.disk_state.to_string(),
-            pantry_address,
+            import_address,
         }
     };
     rows.push(usr);

--- a/dev-tools/omdb/src/bin/omdb/db.rs
+++ b/dev-tools/omdb/src/bin/omdb/db.rs
@@ -2114,7 +2114,6 @@ async fn cmd_db_disk_info(
         bail!("no disk: {} found", args.uuid);
     };
 
-    println!("Found disk: {:?}", disk);
     // For information about where this disk is attached.
     let mut rows = Vec::new();
 


### PR DESCRIPTION
Here is what the output looks like:

```
root@oxz_switch1:~# /tmp/omdb-alan db disks info $(omdb db disks list 2> /dev/null | grep importer | awk '{print $1}' )
HOST_SERIAL DISK_NAME INSTANCE_NAME PROPOLIS_ZONE VOLUME_ID                            DISK_STATE                 IMPORT_ADDRESS                
-           importer  -             -             6aea4f5f-1089-4726-a06a-9d4fa3f46196 importing_from_bulk_writes [fd00:1122:3344:104::6]:17000 
HOST_SERIAL REGION                               DATASET                              PHYSICAL_DISK                        
BRM27230037 c8ffcef5-64ca-43ba-b85c-527e814c7afe 042b3fa1-2071-4ee4-930a-f8a3586609c1 ea3e664c-5dbc-4c60-8094-6364b5784c3d 
BRM23230010 f3b624d8-d971-4b2f-8e77-e99e983dc8b0 48e86be5-eb30-4877-bb9b-3da3d0d4fb9b fe6cebc3-da38-4231-8025-8c28d8c938dc 
BRM42220026 db607aad-57a5-43b0-a922-8391fd4cd69c f3557023-92eb-4b18-9022-e377ded39632 98592154-b33b-4695-a804-832b860bf9b0 
VCR from volume ID 6aea4f5f-1089-4726-a06a-9d4fa3f46196
ID                                   BS  SUB_VOLUMES READ_ONLY_PARENT 
80158a71-9b76-4c76-9ef6-d2e4add721ab 512 1           false            

SUB VOLUME 0
    ID                                   BS  BPE    EC  GEN READ_ONLY 
    80158a71-9b76-4c76-9ef6-d2e4add721ab 512 131072 208 2   false     
    [fd00:1122:3344:101::b]:19003
    [fd00:1122:3344:102::f]:19000
    [fd00:1122:3344:104::10]:19000
```