### PR TITLE
Prevent wicket from updating cosmo sleds

### DIFF
--- a/openapi/wicketd.json
+++ b/openapi/wicketd.json
@@ -7273,6 +7273,34 @@
               "id": {
                 "type": "string",
                 "enum": [
+                  "fetch_host_type"
+                ]
+              }
+            },
+            "required": [
+              "id"
+            ]
+          },
+          {
+            "type": "object",
+            "properties": {
+              "id": {
+                "type": "string",
+                "enum": [
+                  "check_host_type"
+                ]
+              }
+            },
+            "required": [
+              "id"
+            ]
+          },
+          {
+            "type": "object",
+            "properties": {
+              "id": {
+                "type": "string",
+                "enum": [
                   "downloading_installinator"
                 ]
               }

--- a/wicket-common/src/update_events.rs
+++ b/wicket-common/src/update_events.rs
@@ -51,6 +51,8 @@ pub enum UpdateStepId {
     ClearingInstallinatorImageId,
     SettingHostStartupOptions,
     WaitingForTrampolinePhase2Upload,
+    FetchHostType,
+    CheckHostType,
     DownloadingInstallinator,
     RunningInstallinator,
 }
@@ -219,6 +221,15 @@ pub enum UpdateTerminalError {
         #[source]
         error: anyhow::Error,
     },
+    #[error("Can't update Cosmo")]
+    CosmoHost,
+    #[error("getting SP state failed")]
+    SpGetFailed {
+        #[source]
+        error: gateway_client::Error<gateway_client::types::Error>,
+    },
+    #[error("Unknown host type {0}")]
+    UnknownHost(String),
 }
 
 impl update_engine::AsError for UpdateTerminalError {


### PR DESCRIPTION
We need more work to be able to update the cosmo host OS. For now, error out if we encounter a cosmo sled.