### PR TITLE
Add active, not_yet zones to reconfigurator planner

### DIFF
--- a/dev-tools/reconfigurator-cli/src/lib.rs
+++ b/dev-tools/reconfigurator-cli/src/lib.rs
@@ -200,8 +200,8 @@ impl ReconfiguratorSim {
             }
         }
 
-        builder.set_active_nexuses(active_nexus_zones);
-        builder.set_not_yet_nexuses(not_yet_nexus_zones);
+        builder.set_active_nexus_zones(active_nexus_zones);
+        builder.set_not_yet_nexus_zones(not_yet_nexus_zones);
 
         Ok(builder.build())
     }

--- a/nexus/db-queries/src/db/datastore/db_metadata.rs
+++ b/nexus/db-queries/src/db/datastore/db_metadata.rs
@@ -300,6 +300,23 @@ impl DatastoreSetupAction {
 }
 
 impl DataStore {
+    /// Returns [`DbMetadataNexus`] records in any of the supplied states.
+    pub async fn get_db_metadata_nexus_in_state(
+        &self,
+        opctx: &OpContext,
+        states: &[DbMetadataNexusState],
+    ) -> Result<Vec<DbMetadataNexus>, Error> {
+        use nexus_db_schema::schema::db_metadata_nexus::dsl;
+
+        opctx.authorize(authz::Action::Read, &authz::FLEET).await?;
+
+        dsl::db_metadata_nexus
+            .filter(dsl::state.eq_any(states.to_vec()))
+            .load_async(&*self.pool_connection_authorized(&opctx).await?)
+            .await
+            .map_err(|e| public_error_from_diesel(e, ErrorHandler::Server))
+    }
+
     // Checks if the specified Nexus has access to the database.
     async fn check_nexus_access(
         &self,

--- a/nexus/reconfigurator/execution/src/dns.rs
+++ b/nexus/reconfigurator/execution/src/dns.rs
@@ -1540,7 +1540,7 @@ mod test {
                 old_repo: TufRepoPolicy::initial(),
                 planner_config: PlannerConfig::default(),
                 active_nexus_zones,
-                not_yet_nexus_zones: Vec::new(),
+                not_yet_nexus_zones: BTreeSet::new(),
                 log,
             }
             .build()

--- a/nexus/reconfigurator/planning/src/system.rs
+++ b/nexus/reconfigurator/planning/src/system.rs
@@ -67,6 +67,7 @@ use omicron_common::policy::CRUCIBLE_PANTRY_REDUNDANCY;
 use omicron_common::policy::INTERNAL_DNS_REDUNDANCY;
 use omicron_common::policy::NEXUS_REDUNDANCY;
 use omicron_uuid_kinds::MupdateOverrideUuid;
+use omicron_uuid_kinds::OmicronZoneUuid;
 use omicron_uuid_kinds::SledUuid;
 use omicron_uuid_kinds::ZpoolUuid;
 use std::collections::BTreeMap;
@@ -125,6 +126,8 @@ pub struct SystemDescription {
     old_repo: TufRepoPolicy,
     planner_config: PlannerConfig,
     ignore_impossible_mgs_updates_since: DateTime<Utc>,
+    active_nexus_zones: BTreeSet<OmicronZoneUuid>,
+    not_yet_nexus_zones: BTreeSet<OmicronZoneUuid>,
 }
 
 impl SystemDescription {
@@ -208,6 +211,8 @@ impl SystemDescription {
             old_repo: TufRepoPolicy::initial(),
             planner_config: PlannerConfig::default(),
             ignore_impossible_mgs_updates_since: Utc::now(),
+            active_nexus_zones: BTreeSet::new(),
+            not_yet_nexus_zones: BTreeSet::new(),
         }
     }
 
@@ -807,6 +812,22 @@ impl SystemDescription {
         self
     }
 
+    pub fn set_active_nexus_zones(
+        &mut self,
+        active_nexus_zones: BTreeSet<OmicronZoneUuid>,
+    ) -> &mut Self {
+        self.active_nexus_zones = active_nexus_zones;
+        self
+    }
+
+    pub fn set_not_yet_nexus_zones(
+        &mut self,
+        not_yet_nexus_zones: BTreeSet<OmicronZoneUuid>,
+    ) -> &mut Self {
+        self.not_yet_nexus_zones = not_yet_nexus_zones;
+        self
+    }
+
     pub fn target_release(&self) -> &TufRepoPolicy {
         &self.tuf_repo
     }
@@ -1029,6 +1050,8 @@ impl SystemDescription {
             self.external_dns_version,
             CockroachDbSettings::empty(),
         );
+        builder.set_active_nexus_zones(self.active_nexus_zones.clone());
+        builder.set_not_yet_nexus_zones(self.not_yet_nexus_zones.clone());
         builder.set_ignore_impossible_mgs_updates_since(
             self.ignore_impossible_mgs_updates_since,
         );

--- a/nexus/reconfigurator/preparation/src/lib.rs
+++ b/nexus/reconfigurator/preparation/src/lib.rs
@@ -6,6 +6,7 @@
 
 use anyhow::Context;
 use futures::StreamExt;
+use nexus_db_model::DbMetadataNexusState;
 use nexus_db_model::DnsGroup;
 use nexus_db_model::Generation;
 use nexus_db_queries::context::OpContext;
@@ -84,6 +85,8 @@ pub struct PlanningInputFromDb<'a> {
     pub tuf_repo: TufRepoPolicy,
     pub old_repo: TufRepoPolicy,
     pub planner_config: PlannerConfig,
+    pub active_nexus_zones: Vec<OmicronZoneUuid>,
+    pub not_yet_nexus_zones: Vec<OmicronZoneUuid>,
     pub log: &'a Logger,
 }
 
@@ -200,6 +203,27 @@ impl PlanningInputFromDb<'_> {
             .await
             .internal_context("fetching oximeter read policy")?;
 
+        let (active_nexus_zones, not_yet_nexus_zones): (Vec<_>, Vec<_>) =
+            datastore
+                .get_db_metadata_nexus_in_state(
+                    opctx,
+                    &[
+                        DbMetadataNexusState::Active,
+                        DbMetadataNexusState::NotYet,
+                    ],
+                )
+                .await
+                .internal_context("fetching db_metdata_nexus records")?
+                .into_iter()
+                .partition(|nexus| {
+                    nexus.state() == DbMetadataNexusState::Active
+                });
+
+        let active_nexus_zones =
+            active_nexus_zones.into_iter().map(|n| n.nexus_id()).collect();
+        let not_yet_nexus_zones =
+            not_yet_nexus_zones.into_iter().map(|n| n.nexus_id()).collect();
+
         let planning_input = PlanningInputFromDb {
             sled_rows: &sled_rows,
             zpool_rows: &zpool_rows,
@@ -223,6 +247,8 @@ impl PlanningInputFromDb<'_> {
             tuf_repo,
             old_repo,
             planner_config,
+            active_nexus_zones,
+            not_yet_nexus_zones,
         }
         .build()
         .internal_context("assembling planning_input")?;
@@ -255,6 +281,12 @@ impl PlanningInputFromDb<'_> {
             self.internal_dns_version.into(),
             self.external_dns_version.into(),
             self.cockroachdb_settings.clone(),
+        );
+        builder.set_active_nexuses(
+            self.active_nexus_zones.clone().into_iter().collect(),
+        );
+        builder.set_not_yet_nexuses(
+            self.not_yet_nexus_zones.clone().into_iter().collect(),
         );
 
         let mut zpools_by_sled_id = {

--- a/nexus/reconfigurator/preparation/src/lib.rs
+++ b/nexus/reconfigurator/preparation/src/lib.rs
@@ -85,8 +85,8 @@ pub struct PlanningInputFromDb<'a> {
     pub tuf_repo: TufRepoPolicy,
     pub old_repo: TufRepoPolicy,
     pub planner_config: PlannerConfig,
-    pub active_nexus_zones: Vec<OmicronZoneUuid>,
-    pub not_yet_nexus_zones: Vec<OmicronZoneUuid>,
+    pub active_nexus_zones: BTreeSet<OmicronZoneUuid>,
+    pub not_yet_nexus_zones: BTreeSet<OmicronZoneUuid>,
     pub log: &'a Logger,
 }
 
@@ -213,7 +213,7 @@ impl PlanningInputFromDb<'_> {
                     ],
                 )
                 .await
-                .internal_context("fetching db_metdata_nexus records")?
+                .internal_context("fetching db_metadata_nexus records")?
                 .into_iter()
                 .partition(|nexus| {
                     nexus.state() == DbMetadataNexusState::Active
@@ -282,10 +282,10 @@ impl PlanningInputFromDb<'_> {
             self.external_dns_version.into(),
             self.cockroachdb_settings.clone(),
         );
-        builder.set_active_nexuses(
+        builder.set_active_nexus_zones(
             self.active_nexus_zones.clone().into_iter().collect(),
         );
-        builder.set_not_yet_nexuses(
+        builder.set_not_yet_nexus_zones(
             self.not_yet_nexus_zones.clone().into_iter().collect(),
         );
 

--- a/nexus/types/src/deployment/planning_input.rs
+++ b/nexus/types/src/deployment/planning_input.rs
@@ -259,17 +259,9 @@ impl PlanningInput {
         &self.active_nexus_zones
     }
 
-    pub fn set_active_nexus_zones(&mut self, ids: BTreeSet<OmicronZoneUuid>) {
-        self.active_nexus_zones = ids;
-    }
-
     /// ID of the soon-to-be-running Nexus zones
     pub fn not_yet_nexus_zones(&self) -> &BTreeSet<OmicronZoneUuid> {
         &self.not_yet_nexus_zones
-    }
-
-    pub fn set_not_yet_nexus_zones(&mut self, ids: BTreeSet<OmicronZoneUuid>) {
-        self.not_yet_nexus_zones = ids;
     }
 
     pub fn all_sleds(
@@ -1347,20 +1339,6 @@ impl PlanningInputBuilder {
             active_nexus_zones: BTreeSet::new(),
             not_yet_nexus_zones: BTreeSet::new(),
         }
-    }
-
-    pub fn set_active_nexuses(
-        &mut self,
-        active_nexus_zones: BTreeSet<OmicronZoneUuid>,
-    ) {
-        self.active_nexus_zones = active_nexus_zones;
-    }
-
-    pub fn set_not_yet_nexuses(
-        &mut self,
-        not_yet_nexus_zones: BTreeSet<OmicronZoneUuid>,
-    ) {
-        self.not_yet_nexus_zones = not_yet_nexus_zones;
     }
 
     pub fn add_sled(


### PR DESCRIPTION
This is split off from https://github.com/oxidecomputer/omicron/pull/8936, and intended to make that diff smaller

Adds `active`, `not_yet` zones to reconfigurator planner, and adjusts tests

Does not meaningfully use these fields yet, but they are critical in https://github.com/oxidecomputer/omicron/pull/8936 when deciding whether or not to increase the top-level `nexus_generation`.