### PR TITLE
Add blippy check to validate nexus_gen info

### DIFF
--- a/nexus/reconfigurator/blippy/src/blippy.rs
+++ b/nexus/reconfigurator/blippy/src/blippy.rs
@@ -14,10 +14,12 @@ use nexus_types::inventory::ZpoolName;
 use omicron_common::address::DnsSubnet;
 use omicron_common::address::Ipv6Subnet;
 use omicron_common::address::SLED_PREFIX;
+use omicron_common::api::external::Generation;
 use omicron_common::api::external::MacAddr;
 use omicron_common::disk::DatasetKind;
 use omicron_common::disk::M2Slot;
 use omicron_uuid_kinds::MupdateOverrideUuid;
+use omicron_uuid_kinds::OmicronZoneUuid;
 use omicron_uuid_kinds::SledUuid;
 use omicron_uuid_kinds::ZpoolUuid;
 use std::collections::BTreeSet;
@@ -51,43 +53,66 @@ impl fmt::Display for Severity {
 
 #[derive(Debug, Clone, PartialEq, Eq, PartialOrd, Ord)]
 pub enum Kind {
-    Sled { sled_id: SledUuid, kind: SledKind },
+    Blueprint(BlueprintKind),
+    Sled { sled_id: SledUuid, kind: Box<SledKind> },
 }
 
 impl Kind {
     pub fn display_component(&self) -> impl fmt::Display + '_ {
         enum Component<'a> {
+            Blueprint,
             Sled(&'a SledUuid),
         }
 
         impl fmt::Display for Component<'_> {
             fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
                 match self {
+                    Component::Blueprint => write!(f, "blueprint"),
                     Component::Sled(id) => write!(f, "sled {id}"),
                 }
             }
         }
 
         match self {
+            Kind::Blueprint { .. } => Component::Blueprint,
             Kind::Sled { sled_id, .. } => Component::Sled(sled_id),
         }
     }
 
     pub fn display_subkind(&self) -> impl fmt::Display + '_ {
         enum Subkind<'a> {
+            Blueprint(&'a BlueprintKind),
             Sled(&'a SledKind),
         }
 
         impl fmt::Display for Subkind<'_> {
             fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
                 match self {
+                    Subkind::Blueprint(kind) => write!(f, "{kind}"),
                     Subkind::Sled(kind) => write!(f, "{kind}"),
                 }
             }
         }
 
         match self {
+            Kind::Blueprint(kind) => Subkind::Blueprint(kind),
             Kind::Sled { kind, .. } => Subkind::Sled(kind),
+        }
+    }
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, PartialOrd, Ord)]
+pub enum BlueprintKind {
+    /// No zones exist in the blueprint using the active Nexus generation
+    NoZonesWithActiveNexusGeneration(Generation),
+}
+
+impl fmt::Display for BlueprintKind {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self {
+            BlueprintKind::NoZonesWithActiveNexusGeneration(gen) => {
+                write!(f, "No zones with active nexus generation @ {gen}",)
+            }
         }
     }
 }
@@ -192,6 +217,19 @@ pub enum SledKind {
         slot: M2Slot,
         version: BlueprintArtifactVersion,
         hash: ArtifactHash,
+    },
+    /// A Nexus zone exists which is too new, relative to the "active
+    /// generation".
+    NexusZoneGenerationTooNew {
+        active_generation: Generation,
+        zone_generation: Generation,
+        id: OmicronZoneUuid,
+    },
+    /// Nexus zones with the same generation have different image sources.
+    NexusZoneGenerationImageSourceMismatch {
+        zone1: BlueprintZoneConfig,
+        zone2: BlueprintZoneConfig,
+        generation: Generation,
     },
 }
 
@@ -415,6 +453,29 @@ impl fmt::Display for SledKind {
                      (version {version}, hash {hash})",
                 )
             }
+            SledKind::NexusZoneGenerationTooNew {
+                active_generation,
+                zone_generation,
+                id,
+            } => {
+                write!(
+                    f,
+                    "Nexus zone {id} has a generation {zone_generation}, which \
+                     is too new relative to the active generation {active_generation}"
+                )
+            }
+            SledKind::NexusZoneGenerationImageSourceMismatch {
+                zone1,
+                zone2,
+                generation,
+            } => {
+                write!(
+                    f,
+                    "Nexus zones {} and {} both have generation {generation} but \
+                     different image sources ({:?} vs {:?})",
+                    zone1.id, zone2.id, zone1.image_source, zone2.image_source,
+                )
+            }
         }
     }
 }
@@ -473,13 +534,24 @@ impl<'a> Blippy<'a> {
         self.blueprint
     }
 
+    pub(crate) fn push_blueprint_note(
+        &mut self,
+        severity: Severity,
+        kind: BlueprintKind,
+    ) {
+        self.notes.push(Note { severity, kind: Kind::Blueprint(kind) });
+    }
+
     pub(crate) fn push_sled_note(
         &mut self,
         sled_id: SledUuid,
         severity: Severity,
         kind: SledKind,
     ) {
-        self.notes.push(Note { severity, kind: Kind::Sled { sled_id, kind } });
+        self.notes.push(Note {
+            severity,
+            kind: Kind::Sled { sled_id, kind: Box::new(kind) },
+        });
     }
 
     pub fn into_report(


### PR DESCRIPTION
This is split off from https://github.com/oxidecomputer/omicron/pull/8936, and intended to make that diff smaller

Adds a check verifying that Nexus zones with the same generation all use the same image, and verifying that the generation is not "too new".