### PR TITLE
reconfigurator-cli: ability to expunge multiple zones at once

### DIFF
--- a/dev-tools/reconfigurator-cli/tests/input/cmds-expunge-newly-added-external-dns.txt
+++ b/dev-tools/reconfigurator-cli/tests/input/cmds-expunge-newly-added-external-dns.txt
@@ -3,7 +3,7 @@
 load-example --seed test_expunge_newly_added_external_dns
 
 blueprint-show 3f00b694-1b16-4aaa-8f78-e6b3a527b434
-blueprint-edit 3f00b694-1b16-4aaa-8f78-e6b3a527b434 expunge-zone 8429c772-07e8-40a6-acde-2ed47d16cf84
+blueprint-edit 3f00b694-1b16-4aaa-8f78-e6b3a527b434 expunge-zones 8429c772-07e8-40a6-acde-2ed47d16cf84
 
 # Diff DNS to see that the expunged zone is no longer has DNS records.
 blueprint-diff 3f00b694-1b16-4aaa-8f78-e6b3a527b434 366b0b68-d80e-4bc1-abd3-dc69837847e0
@@ -15,5 +15,5 @@ blueprint-diff 366b0b68-d80e-4bc1-abd3-dc69837847e0 9c998c1d-1a7b-440a-ae0c-40f7
 
 blueprint-show 9c998c1d-1a7b-440a-ae0c-40f781dea6e2
 # expunging the new zone should work, then diff again to see the new zone also have its DNS records removed.
-blueprint-edit 9c998c1d-1a7b-440a-ae0c-40f781dea6e2 expunge-zone 8c0a1969-15b6-4165-ba6d-a27c24151037
+blueprint-edit 9c998c1d-1a7b-440a-ae0c-40f781dea6e2 expunge-zones 8c0a1969-15b6-4165-ba6d-a27c24151037
 blueprint-diff 9c998c1d-1a7b-440a-ae0c-40f781dea6e2 2ac8c740-444d-42ff-8d66-9812a7e51288

--- a/dev-tools/reconfigurator-cli/tests/input/cmds-expunge-newly-added-internal-dns.txt
+++ b/dev-tools/reconfigurator-cli/tests/input/cmds-expunge-newly-added-internal-dns.txt
@@ -2,7 +2,7 @@ load-example
 
 blueprint-show dbcbd3d6-41ff-48ae-ac0b-1becc9b2fd21
 # Expunge an internal DNS zone
-blueprint-edit dbcbd3d6-41ff-48ae-ac0b-1becc9b2fd21 expunge-zone 99e2f30b-3174-40bf-a78a-90da8abba8ca
+blueprint-edit dbcbd3d6-41ff-48ae-ac0b-1becc9b2fd21 expunge-zones 99e2f30b-3174-40bf-a78a-90da8abba8ca
 # Diff against the new blueprint; the zone has been expunged so its records should be removed.
 blueprint-diff dbcbd3d6-41ff-48ae-ac0b-1becc9b2fd21 8da82a8e-bf97-4fbd-8ddd-9f6462732cf1
 

--- a/dev-tools/reconfigurator-cli/tests/input/cmds-expunge-zones.txt
+++ b/dev-tools/reconfigurator-cli/tests/input/cmds-expunge-zones.txt
@@ -1,0 +1,12 @@
+# Load example system
+load-example --nsleds 3 --ndisks-per-sled 3
+blueprint-list
+blueprint-show dbcbd3d6-41ff-48ae-ac0b-1becc9b2fd21
+
+# Expunge one zone.
+blueprint-edit dbcbd3d6-41ff-48ae-ac0b-1becc9b2fd21 expunge-zones 694bd14f-cb24-4be4-bb19-876e79cda2c8
+blueprint-diff 8da82a8e-bf97-4fbd-8ddd-9f6462732cf1
+
+# Expunge multiple zones.
+blueprint-edit 8da82a8e-bf97-4fbd-8ddd-9f6462732cf1 expunge-zones 7c252b64-c5af-4ec1-989e-9a03f3b0f111 dfac80b4-a887-430a-ae87-a4e065dba787
+blueprint-diff 58d5e830-0884-47d8-a7cd-b2b3751adeb4

--- a/dev-tools/reconfigurator-cli/tests/output/cmds-expunge-newly-added-external-dns-stdout
+++ b/dev-tools/reconfigurator-cli/tests/output/cmds-expunge-newly-added-external-dns-stdout
@@ -339,8 +339,9 @@ empty planning report for blueprint 3f00b694-1b16-4aaa-8f78-e6b3a527b434.
 
 
 
-> blueprint-edit 3f00b694-1b16-4aaa-8f78-e6b3a527b434 expunge-zone 8429c772-07e8-40a6-acde-2ed47d16cf84
+> blueprint-edit 3f00b694-1b16-4aaa-8f78-e6b3a527b434 expunge-zones 8429c772-07e8-40a6-acde-2ed47d16cf84
 blueprint 366b0b68-d80e-4bc1-abd3-dc69837847e0 created from blueprint 3f00b694-1b16-4aaa-8f78-e6b3a527b434: expunged zone 8429c772-07e8-40a6-acde-2ed47d16cf84 from sled 711ac7f8-d19e-4572-bdb9-e9b50f6e362a
+
 
 
 > # Diff DNS to see that the expunged zone is no longer has DNS records.
@@ -1346,8 +1347,9 @@ planning report for blueprint 9c998c1d-1a7b-440a-ae0c-40f781dea6e2:
 
 
 > # expunging the new zone should work, then diff again to see the new zone also have its DNS records removed.
-> blueprint-edit 9c998c1d-1a7b-440a-ae0c-40f781dea6e2 expunge-zone 8c0a1969-15b6-4165-ba6d-a27c24151037
+> blueprint-edit 9c998c1d-1a7b-440a-ae0c-40f781dea6e2 expunge-zones 8c0a1969-15b6-4165-ba6d-a27c24151037
 blueprint 2ac8c740-444d-42ff-8d66-9812a7e51288 created from blueprint 9c998c1d-1a7b-440a-ae0c-40f781dea6e2: expunged zone 8c0a1969-15b6-4165-ba6d-a27c24151037 from sled 9dc50690-f9bf-4520-bf80-051d0f465c2c
+
 
 > blueprint-diff 9c998c1d-1a7b-440a-ae0c-40f781dea6e2 2ac8c740-444d-42ff-8d66-9812a7e51288
 from: blueprint 9c998c1d-1a7b-440a-ae0c-40f781dea6e2

--- a/dev-tools/reconfigurator-cli/tests/output/cmds-expunge-newly-added-internal-dns-stdout
+++ b/dev-tools/reconfigurator-cli/tests/output/cmds-expunge-newly-added-internal-dns-stdout
@@ -338,8 +338,9 @@ empty planning report for blueprint dbcbd3d6-41ff-48ae-ac0b-1becc9b2fd21.
 
 
 > # Expunge an internal DNS zone
-> blueprint-edit dbcbd3d6-41ff-48ae-ac0b-1becc9b2fd21 expunge-zone 99e2f30b-3174-40bf-a78a-90da8abba8ca
+> blueprint-edit dbcbd3d6-41ff-48ae-ac0b-1becc9b2fd21 expunge-zones 99e2f30b-3174-40bf-a78a-90da8abba8ca
 blueprint 8da82a8e-bf97-4fbd-8ddd-9f6462732cf1 created from blueprint dbcbd3d6-41ff-48ae-ac0b-1becc9b2fd21: expunged zone 99e2f30b-3174-40bf-a78a-90da8abba8ca from sled 2b8f0cb3-0295-4b3c-bc58-4fe88b57112c
+
 
 > # Diff against the new blueprint; the zone has been expunged so its records should be removed.
 > blueprint-diff dbcbd3d6-41ff-48ae-ac0b-1becc9b2fd21 8da82a8e-bf97-4fbd-8ddd-9f6462732cf1

--- a/dev-tools/reconfigurator-cli/tests/output/cmds-expunge-zones-stdout
+++ b/dev-tools/reconfigurator-cli/tests/output/cmds-expunge-zones-stdout
@@ -1,0 +1,488 @@
+using provided RNG seed: reconfigurator-cli-test
+> # Load example system
+> load-example --nsleds 3 --ndisks-per-sled 3
+loaded example system with:
+- collection: f45ba181-4b56-42cc-a762-874d90184a43
+- blueprint: dbcbd3d6-41ff-48ae-ac0b-1becc9b2fd21
+
+> blueprint-list
+T ENA ID                                   PARENT                               TIME_CREATED             
+      184f10b3-61cb-41ef-9b93-3489b2bac559 <none>                               <REDACTED_TIMESTAMP> 
+* yes dbcbd3d6-41ff-48ae-ac0b-1becc9b2fd21 184f10b3-61cb-41ef-9b93-3489b2bac559 <REDACTED_TIMESTAMP> 
+
+> blueprint-show dbcbd3d6-41ff-48ae-ac0b-1becc9b2fd21
+blueprint  dbcbd3d6-41ff-48ae-ac0b-1becc9b2fd21
+parent:    184f10b3-61cb-41ef-9b93-3489b2bac559
+
+  sled: 2b8f0cb3-0295-4b3c-bc58-4fe88b57112c (active, config generation 2)
+
+    host phase 2 contents:
+    ------------------------
+    slot   boot image source
+    ------------------------
+    A      current contents 
+    B      current contents 
+
+
+    physical disks:
+    ------------------------------------------------------------------------------------
+    vendor        model        serial                                        disposition
+    ------------------------------------------------------------------------------------
+    fake-vendor   fake-model   serial-727522a7-934f-494d-b5b3-160968e74463   in service 
+    fake-vendor   fake-model   serial-72c59873-31ff-4e36-8d76-ff834009349a   in service 
+    fake-vendor   fake-model   serial-b5fd5bc1-099e-4e77-8028-a9793c11f43b   in service 
+
+
+    datasets:
+    -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
+    dataset name                                                                                                   dataset id                             disposition   quota     reservation   compression
+    -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
+    oxp_727522a7-934f-494d-b5b3-160968e74463/crucible                                                              2f204c50-a327-479c-8852-f53ec7a19c1f   in service    none      none          off        
+    oxp_72c59873-31ff-4e36-8d76-ff834009349a/crucible                                                              78f34ce7-42f1-41da-995f-318f32054ad2   in service    none      none          off        
+    oxp_b5fd5bc1-099e-4e77-8028-a9793c11f43b/crucible                                                              1640adb6-70bf-44cf-b05c-bff6dd300cf3   in service    none      none          off        
+    oxp_727522a7-934f-494d-b5b3-160968e74463/crypt/clickhouse                                                      841d5648-05f0-47b0-b446-92f6b60fe9a6   in service    none      none          off        
+    oxp_727522a7-934f-494d-b5b3-160968e74463/crypt/external_dns                                                    8e0bd2bd-23b7-4bc6-9e73-c4d4ebc0bc8c   in service    none      none          off        
+    oxp_727522a7-934f-494d-b5b3-160968e74463/crypt/internal_dns                                                    2ad1875a-92ac-472f-8c26-593309f0e4da   in service    none      none          off        
+    oxp_727522a7-934f-494d-b5b3-160968e74463/crypt/zone                                                            4829f422-aa31-41a8-ab73-95684ff1ef48   in service    none      none          off        
+    oxp_72c59873-31ff-4e36-8d76-ff834009349a/crypt/zone                                                            775f9207-c42d-4af2-9186-27ffef67735e   in service    none      none          off        
+    oxp_b5fd5bc1-099e-4e77-8028-a9793c11f43b/crypt/zone                                                            3b66453b-7148-4c1b-84a9-499e43290ab4   in service    none      none          off        
+    oxp_727522a7-934f-494d-b5b3-160968e74463/crypt/zone/oxz_clickhouse_353b3b65-20f7-48c3-88f7-495bd5d31545        b46de15d-33e7-4cd0-aa7c-e7be2a61e71b   in service    none      none          off        
+    oxp_b5fd5bc1-099e-4e77-8028-a9793c11f43b/crypt/zone/oxz_crucible_86a22a56-0168-453d-9df1-cb2a7c64b5d3          3e0d6188-c503-49cf-a441-fa7df40ceb43   in service    none      none          off        
+    oxp_727522a7-934f-494d-b5b3-160968e74463/crypt/zone/oxz_crucible_bd354eef-d8a6-4165-9124-283fb5e46d77          5ae11c7e-08fa-4d78-a4ea-14b4a9a10241   in service    none      none          off        
+    oxp_72c59873-31ff-4e36-8d76-ff834009349a/crypt/zone/oxz_crucible_e2fdefe7-95b2-4fd2-ae37-56929a06d58c          b8f2a09f-8bd2-4418-872b-a4457a3f958c   in service    none      none          off        
+    oxp_727522a7-934f-494d-b5b3-160968e74463/crypt/zone/oxz_crucible_pantry_ad6a3a03-8d0f-4504-99a4-cbf73d69b973   49f8fbb6-5bac-4609-907f-6e3dfc206059   in service    none      none          off        
+    oxp_727522a7-934f-494d-b5b3-160968e74463/crypt/zone/oxz_external_dns_6c3ae381-04f7-41ea-b0ac-74db387dbc3a      8c4fa711-1d5d-4e93-85f0-d17bff47b063   in service    none      none          off        
+    oxp_727522a7-934f-494d-b5b3-160968e74463/crypt/zone/oxz_internal_dns_99e2f30b-3174-40bf-a78a-90da8abba8ca      c31623de-c19b-4615-9f1d-5e1daa5d3bda   in service    none      none          off        
+    oxp_727522a7-934f-494d-b5b3-160968e74463/crypt/zone/oxz_nexus_466a9f29-62bf-4e63-924a-b9efdb86afec             3560dd69-3b23-4c69-807d-d673104cfc68   in service    none      none          off        
+    oxp_727522a7-934f-494d-b5b3-160968e74463/crypt/zone/oxz_ntp_62620961-fc4a-481e-968b-f5acbac0dc63               09b9cc9b-3426-470b-a7bc-538f82dede03   in service    none      none          off        
+    oxp_727522a7-934f-494d-b5b3-160968e74463/crypt/debug                                                           93957ca0-9ed1-4e7b-8c34-2ce07a69541c   in service    100 GiB   none          gzip-9     
+    oxp_72c59873-31ff-4e36-8d76-ff834009349a/crypt/debug                                                           2db6b7c1-0f46-4ced-a3ad-48872793360e   in service    100 GiB   none          gzip-9     
+    oxp_b5fd5bc1-099e-4e77-8028-a9793c11f43b/crypt/debug                                                           318fae85-abcb-4259-b1b6-ac96d193f7b7   in service    100 GiB   none          gzip-9     
+
+
+    omicron zones:
+    ---------------------------------------------------------------------------------------------------------------
+    zone type         zone id                                image source      disposition   underlay IP           
+    ---------------------------------------------------------------------------------------------------------------
+    clickhouse        353b3b65-20f7-48c3-88f7-495bd5d31545   install dataset   in service    fd00:1122:3344:102::23
+    crucible          86a22a56-0168-453d-9df1-cb2a7c64b5d3   install dataset   in service    fd00:1122:3344:102::28
+    crucible          bd354eef-d8a6-4165-9124-283fb5e46d77   install dataset   in service    fd00:1122:3344:102::26
+    crucible          e2fdefe7-95b2-4fd2-ae37-56929a06d58c   install dataset   in service    fd00:1122:3344:102::27
+    crucible_pantry   ad6a3a03-8d0f-4504-99a4-cbf73d69b973   install dataset   in service    fd00:1122:3344:102::25
+    external_dns      6c3ae381-04f7-41ea-b0ac-74db387dbc3a   install dataset   in service    fd00:1122:3344:102::24
+    internal_dns      99e2f30b-3174-40bf-a78a-90da8abba8ca   install dataset   in service    fd00:1122:3344:1::1   
+    internal_ntp      62620961-fc4a-481e-968b-f5acbac0dc63   install dataset   in service    fd00:1122:3344:102::21
+    nexus             466a9f29-62bf-4e63-924a-b9efdb86afec   install dataset   in service    fd00:1122:3344:102::22
+
+
+
+  sled: 98e6b7c2-2efa-41ca-b20a-0a4d61102fe6 (active, config generation 2)
+
+    host phase 2 contents:
+    ------------------------
+    slot   boot image source
+    ------------------------
+    A      current contents 
+    B      current contents 
+
+
+    physical disks:
+    ------------------------------------------------------------------------------------
+    vendor        model        serial                                        disposition
+    ------------------------------------------------------------------------------------
+    fake-vendor   fake-model   serial-073979dd-3248-44a5-9fa1-cc72a140d682   in service 
+    fake-vendor   fake-model   serial-c6d33b64-fb96-4129-bab1-7878a06a5f9b   in service 
+    fake-vendor   fake-model   serial-e4d937e1-6ddc-4eca-bb08-c1f73791e608   in service 
+
+
+    datasets:
+    -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
+    dataset name                                                                                                   dataset id                             disposition   quota     reservation   compression
+    -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
+    oxp_073979dd-3248-44a5-9fa1-cc72a140d682/crucible                                                              7b4ce6bf-95bb-42fe-a4a0-dff31211ab88   in service    none      none          off        
+    oxp_c6d33b64-fb96-4129-bab1-7878a06a5f9b/crucible                                                              ea8a11bf-a884-4c4f-8df0-3ef9b7aacf43   in service    none      none          off        
+    oxp_e4d937e1-6ddc-4eca-bb08-c1f73791e608/crucible                                                              50b029e3-96aa-41e5-bf39-023193a4355e   in service    none      none          off        
+    oxp_073979dd-3248-44a5-9fa1-cc72a140d682/crypt/external_dns                                                    4847a96e-a267-4ae7-aa3d-805c1e77f81e   in service    none      none          off        
+    oxp_073979dd-3248-44a5-9fa1-cc72a140d682/crypt/internal_dns                                                    ad41be71-6c15-4428-b510-20ceacde4fa6   in service    none      none          off        
+    oxp_073979dd-3248-44a5-9fa1-cc72a140d682/crypt/zone                                                            4617d206-4330-4dfa-b9f3-f63a3db834f9   in service    none      none          off        
+    oxp_c6d33b64-fb96-4129-bab1-7878a06a5f9b/crypt/zone                                                            793ac181-1b01-403c-850d-7f5c54bda6c9   in service    none      none          off        
+    oxp_e4d937e1-6ddc-4eca-bb08-c1f73791e608/crypt/zone                                                            4f60b534-eaa3-40a1-b60f-bfdf147af478   in service    none      none          off        
+    oxp_e4d937e1-6ddc-4eca-bb08-c1f73791e608/crypt/zone/oxz_crucible_058fd5f9-60a8-4e11-9302-15172782e17d          02c56a30-7d97-406d-bd34-1eb437fd517d   in service    none      none          off        
+    oxp_073979dd-3248-44a5-9fa1-cc72a140d682/crypt/zone/oxz_crucible_5199c033-4cf9-4ab6-8ae7-566bd7606363          832fd140-d467-4bad-b5e9-63171634087c   in service    none      none          off        
+    oxp_c6d33b64-fb96-4129-bab1-7878a06a5f9b/crypt/zone/oxz_crucible_dfac80b4-a887-430a-ae87-a4e065dba787          4d7e3e8e-06bd-414c-a468-779e056a9b75   in service    none      none          off        
+    oxp_073979dd-3248-44a5-9fa1-cc72a140d682/crypt/zone/oxz_crucible_pantry_ba4994a8-23f9-4b1a-a84f-a08d74591389   42430c80-7836-4191-a4f6-bcee749010fe   in service    none      none          off        
+    oxp_073979dd-3248-44a5-9fa1-cc72a140d682/crypt/zone/oxz_external_dns_803bfb63-c246-41db-b0da-d3b87ddfc63d      43931274-7fe8-4077-825d-dff2bc8efa58   in service    none      none          off        
+    oxp_073979dd-3248-44a5-9fa1-cc72a140d682/crypt/zone/oxz_internal_dns_427ec88f-f467-42fa-9bbb-66a91a36103c      1bca7f71-5e42-4749-91ec-fa40793a3a9a   in service    none      none          off        
+    oxp_073979dd-3248-44a5-9fa1-cc72a140d682/crypt/zone/oxz_nexus_0c71b3b2-6ceb-4e8f-b020-b08675e83038             a4c3032e-21fa-4d4a-b040-a7e3c572cf3c   in service    none      none          off        
+    oxp_073979dd-3248-44a5-9fa1-cc72a140d682/crypt/zone/oxz_ntp_6444f8a5-6465-4f0b-a549-1993c113569c               3ac089c9-9dec-465b-863a-188e80d71fb4   in service    none      none          off        
+    oxp_073979dd-3248-44a5-9fa1-cc72a140d682/crypt/debug                                                           248c6c10-1ac6-45de-bb55-ede36ca56bbd   in service    100 GiB   none          gzip-9     
+    oxp_c6d33b64-fb96-4129-bab1-7878a06a5f9b/crypt/debug                                                           cdf3684f-a6cf-4449-b9ec-e696b2c663e2   in service    100 GiB   none          gzip-9     
+    oxp_e4d937e1-6ddc-4eca-bb08-c1f73791e608/crypt/debug                                                           686c19cf-a0d7-45f6-866f-c564612b2664   in service    100 GiB   none          gzip-9     
+
+
+    omicron zones:
+    ---------------------------------------------------------------------------------------------------------------
+    zone type         zone id                                image source      disposition   underlay IP           
+    ---------------------------------------------------------------------------------------------------------------
+    crucible          058fd5f9-60a8-4e11-9302-15172782e17d   install dataset   in service    fd00:1122:3344:101::27
+    crucible          5199c033-4cf9-4ab6-8ae7-566bd7606363   install dataset   in service    fd00:1122:3344:101::25
+    crucible          dfac80b4-a887-430a-ae87-a4e065dba787   install dataset   in service    fd00:1122:3344:101::26
+    crucible_pantry   ba4994a8-23f9-4b1a-a84f-a08d74591389   install dataset   in service    fd00:1122:3344:101::24
+    external_dns      803bfb63-c246-41db-b0da-d3b87ddfc63d   install dataset   in service    fd00:1122:3344:101::23
+    internal_dns      427ec88f-f467-42fa-9bbb-66a91a36103c   install dataset   in service    fd00:1122:3344:2::1   
+    internal_ntp      6444f8a5-6465-4f0b-a549-1993c113569c   install dataset   in service    fd00:1122:3344:101::21
+    nexus             0c71b3b2-6ceb-4e8f-b020-b08675e83038   install dataset   in service    fd00:1122:3344:101::22
+
+
+
+  sled: d81c6a84-79b8-4958-ae41-ea46c9b19763 (active, config generation 2)
+
+    host phase 2 contents:
+    ------------------------
+    slot   boot image source
+    ------------------------
+    A      current contents 
+    B      current contents 
+
+
+    physical disks:
+    ------------------------------------------------------------------------------------
+    vendor        model        serial                                        disposition
+    ------------------------------------------------------------------------------------
+    fake-vendor   fake-model   serial-18b20749-0748-4105-bb10-7b13cfc776e2   in service 
+    fake-vendor   fake-model   serial-30c16fe4-4229-49d0-ab01-3138f2c7dff2   in service 
+    fake-vendor   fake-model   serial-4930954e-9ac7-4453-b63f-5ab97c389a99   in service 
+
+
+    datasets:
+    -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
+    dataset name                                                                                                   dataset id                             disposition   quota     reservation   compression
+    -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
+    oxp_18b20749-0748-4105-bb10-7b13cfc776e2/crucible                                                              7ea73f80-c4e0-450a-92dc-8397ce2af14f   in service    none      none          off        
+    oxp_30c16fe4-4229-49d0-ab01-3138f2c7dff2/crucible                                                              6f04dd20-5e2c-4fa8-8430-a886470ed140   in service    none      none          off        
+    oxp_4930954e-9ac7-4453-b63f-5ab97c389a99/crucible                                                              a50cd13a-5749-4e79-bb8b-19229500a8b3   in service    none      none          off        
+    oxp_18b20749-0748-4105-bb10-7b13cfc776e2/crypt/external_dns                                                    96ae8389-3027-4260-9374-e0f6ce851de2   in service    none      none          off        
+    oxp_18b20749-0748-4105-bb10-7b13cfc776e2/crypt/internal_dns                                                    1cb0a47a-59ac-4892-8e92-cf87b4290f96   in service    none      none          off        
+    oxp_18b20749-0748-4105-bb10-7b13cfc776e2/crypt/zone                                                            45cd9687-20be-4247-b62a-dfdacf324929   in service    none      none          off        
+    oxp_30c16fe4-4229-49d0-ab01-3138f2c7dff2/crypt/zone                                                            e009d8b8-4695-4322-b53f-f03f2744aef7   in service    none      none          off        
+    oxp_4930954e-9ac7-4453-b63f-5ab97c389a99/crypt/zone                                                            252ac39f-b9e2-4697-8c07-3a833115d704   in service    none      none          off        
+    oxp_30c16fe4-4229-49d0-ab01-3138f2c7dff2/crypt/zone/oxz_crucible_694bd14f-cb24-4be4-bb19-876e79cda2c8          3443a368-199e-4d26-b59f-3f2bbd507761   in service    none      none          off        
+    oxp_4930954e-9ac7-4453-b63f-5ab97c389a99/crypt/zone/oxz_crucible_7c252b64-c5af-4ec1-989e-9a03f3b0f111          429da94b-19f7-48bd-98e9-47842863ba7b   in service    none      none          off        
+    oxp_18b20749-0748-4105-bb10-7b13cfc776e2/crypt/zone/oxz_crucible_f55647d4-5500-4ad3-893a-df45bd50d622          50ea8c15-c4c0-4403-a490-d14b3405dfc2   in service    none      none          off        
+    oxp_18b20749-0748-4105-bb10-7b13cfc776e2/crypt/zone/oxz_crucible_pantry_75b220ba-a0f4-4872-8202-dc7c87f062d0   54bbadaf-ec04-41a2-a62f-f5ac5bf321be   in service    none      none          off        
+    oxp_18b20749-0748-4105-bb10-7b13cfc776e2/crypt/zone/oxz_external_dns_f6ec9c67-946a-4da3-98d5-581f72ce8bf0      090bd88d-0a43-4040-a832-b13ae721f74f   in service    none      none          off        
+    oxp_18b20749-0748-4105-bb10-7b13cfc776e2/crypt/zone/oxz_internal_dns_ea5b4030-b52f-44b2-8d70-45f15f987d01      b1deff4b-51df-4a37-9043-afbd7c70a1cb   in service    none      none          off        
+    oxp_18b20749-0748-4105-bb10-7b13cfc776e2/crypt/zone/oxz_nexus_3eeb8d49-eb1a-43f8-bb64-c2338421c2c6             4da74a5b-6911-4cca-b624-b90c65530117   in service    none      none          off        
+    oxp_18b20749-0748-4105-bb10-7b13cfc776e2/crypt/zone/oxz_ntp_f10a4fb9-759f-4a65-b25e-5794ad2d07d8               c65a9c1c-36dc-4ddb-8aac-ec3be8dbb209   in service    none      none          off        
+    oxp_18b20749-0748-4105-bb10-7b13cfc776e2/crypt/debug                                                           7a6a2058-ea78-49de-9730-cce5e28b4cfb   in service    100 GiB   none          gzip-9     
+    oxp_30c16fe4-4229-49d0-ab01-3138f2c7dff2/crypt/debug                                                           41071985-1dfd-4ce5-8bc2-897161a8bce4   in service    100 GiB   none          gzip-9     
+    oxp_4930954e-9ac7-4453-b63f-5ab97c389a99/crypt/debug                                                           21fd4f3a-ec31-469b-87b1-087c343a2422   in service    100 GiB   none          gzip-9     
+
+
+    omicron zones:
+    ---------------------------------------------------------------------------------------------------------------
+    zone type         zone id                                image source      disposition   underlay IP           
+    ---------------------------------------------------------------------------------------------------------------
+    crucible          694bd14f-cb24-4be4-bb19-876e79cda2c8   install dataset   in service    fd00:1122:3344:103::26
+    crucible          7c252b64-c5af-4ec1-989e-9a03f3b0f111   install dataset   in service    fd00:1122:3344:103::27
+    crucible          f55647d4-5500-4ad3-893a-df45bd50d622   install dataset   in service    fd00:1122:3344:103::25
+    crucible_pantry   75b220ba-a0f4-4872-8202-dc7c87f062d0   install dataset   in service    fd00:1122:3344:103::24
+    external_dns      f6ec9c67-946a-4da3-98d5-581f72ce8bf0   install dataset   in service    fd00:1122:3344:103::23
+    internal_dns      ea5b4030-b52f-44b2-8d70-45f15f987d01   install dataset   in service    fd00:1122:3344:3::1   
+    internal_ntp      f10a4fb9-759f-4a65-b25e-5794ad2d07d8   install dataset   in service    fd00:1122:3344:103::21
+    nexus             3eeb8d49-eb1a-43f8-bb64-c2338421c2c6   install dataset   in service    fd00:1122:3344:103::22
+
+
+ COCKROACHDB SETTINGS:
+    state fingerprint:::::::::::::::::   (none)
+    cluster.preserve_downgrade_option:   (do not modify)
+
+ OXIMETER SETTINGS:
+    generation:   1
+    read from::   SingleNode
+
+ METADATA:
+    created by:::::::::::::   test suite
+    created at:::::::::::::   <REDACTED_TIMESTAMP>
+    comment::::::::::::::::   (none)
+    internal DNS version:::   1
+    external DNS version:::   1
+    target release min gen:   1
+    nexus gen::::::::::::::   1
+
+ PENDING MGS-MANAGED UPDATES: 0
+
+empty planning report for blueprint dbcbd3d6-41ff-48ae-ac0b-1becc9b2fd21.
+
+
+
+
+> # Expunge one zone.
+> blueprint-edit dbcbd3d6-41ff-48ae-ac0b-1becc9b2fd21 expunge-zones 694bd14f-cb24-4be4-bb19-876e79cda2c8
+blueprint 8da82a8e-bf97-4fbd-8ddd-9f6462732cf1 created from blueprint dbcbd3d6-41ff-48ae-ac0b-1becc9b2fd21: expunged zone 694bd14f-cb24-4be4-bb19-876e79cda2c8 from sled d81c6a84-79b8-4958-ae41-ea46c9b19763
+
+
+> blueprint-diff 8da82a8e-bf97-4fbd-8ddd-9f6462732cf1
+from: blueprint dbcbd3d6-41ff-48ae-ac0b-1becc9b2fd21
+to:   blueprint 8da82a8e-bf97-4fbd-8ddd-9f6462732cf1
+
+ MODIFIED SLEDS:
+
+  sled d81c6a84-79b8-4958-ae41-ea46c9b19763 (active, config generation 2 -> 3):
+
+    host phase 2 contents:
+    ------------------------
+    slot   boot image source
+    ------------------------
+    A      current contents 
+    B      current contents 
+
+
+    physical disks:
+    ------------------------------------------------------------------------------------
+    vendor        model        serial                                        disposition
+    ------------------------------------------------------------------------------------
+    fake-vendor   fake-model   serial-18b20749-0748-4105-bb10-7b13cfc776e2   in service 
+    fake-vendor   fake-model   serial-30c16fe4-4229-49d0-ab01-3138f2c7dff2   in service 
+    fake-vendor   fake-model   serial-4930954e-9ac7-4453-b63f-5ab97c389a99   in service 
+
+
+    datasets:
+    --------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
+    dataset name                                                                                                   dataset id                             disposition    quota     reservation   compression
+    --------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
+    oxp_18b20749-0748-4105-bb10-7b13cfc776e2/crucible                                                              7ea73f80-c4e0-450a-92dc-8397ce2af14f   in service     none      none          off        
+    oxp_4930954e-9ac7-4453-b63f-5ab97c389a99/crucible                                                              a50cd13a-5749-4e79-bb8b-19229500a8b3   in service     none      none          off        
+    oxp_18b20749-0748-4105-bb10-7b13cfc776e2/crypt/external_dns                                                    96ae8389-3027-4260-9374-e0f6ce851de2   in service     none      none          off        
+    oxp_18b20749-0748-4105-bb10-7b13cfc776e2/crypt/internal_dns                                                    1cb0a47a-59ac-4892-8e92-cf87b4290f96   in service     none      none          off        
+    oxp_18b20749-0748-4105-bb10-7b13cfc776e2/crypt/zone                                                            45cd9687-20be-4247-b62a-dfdacf324929   in service     none      none          off        
+    oxp_30c16fe4-4229-49d0-ab01-3138f2c7dff2/crypt/zone                                                            e009d8b8-4695-4322-b53f-f03f2744aef7   in service     none      none          off        
+    oxp_4930954e-9ac7-4453-b63f-5ab97c389a99/crypt/zone                                                            252ac39f-b9e2-4697-8c07-3a833115d704   in service     none      none          off        
+    oxp_4930954e-9ac7-4453-b63f-5ab97c389a99/crypt/zone/oxz_crucible_7c252b64-c5af-4ec1-989e-9a03f3b0f111          429da94b-19f7-48bd-98e9-47842863ba7b   in service     none      none          off        
+    oxp_18b20749-0748-4105-bb10-7b13cfc776e2/crypt/zone/oxz_crucible_f55647d4-5500-4ad3-893a-df45bd50d622          50ea8c15-c4c0-4403-a490-d14b3405dfc2   in service     none      none          off        
+    oxp_18b20749-0748-4105-bb10-7b13cfc776e2/crypt/zone/oxz_crucible_pantry_75b220ba-a0f4-4872-8202-dc7c87f062d0   54bbadaf-ec04-41a2-a62f-f5ac5bf321be   in service     none      none          off        
+    oxp_18b20749-0748-4105-bb10-7b13cfc776e2/crypt/zone/oxz_external_dns_f6ec9c67-946a-4da3-98d5-581f72ce8bf0      090bd88d-0a43-4040-a832-b13ae721f74f   in service     none      none          off        
+    oxp_18b20749-0748-4105-bb10-7b13cfc776e2/crypt/zone/oxz_internal_dns_ea5b4030-b52f-44b2-8d70-45f15f987d01      b1deff4b-51df-4a37-9043-afbd7c70a1cb   in service     none      none          off        
+    oxp_18b20749-0748-4105-bb10-7b13cfc776e2/crypt/zone/oxz_nexus_3eeb8d49-eb1a-43f8-bb64-c2338421c2c6             4da74a5b-6911-4cca-b624-b90c65530117   in service     none      none          off        
+    oxp_18b20749-0748-4105-bb10-7b13cfc776e2/crypt/zone/oxz_ntp_f10a4fb9-759f-4a65-b25e-5794ad2d07d8               c65a9c1c-36dc-4ddb-8aac-ec3be8dbb209   in service     none      none          off        
+    oxp_18b20749-0748-4105-bb10-7b13cfc776e2/crypt/debug                                                           7a6a2058-ea78-49de-9730-cce5e28b4cfb   in service     100 GiB   none          gzip-9     
+    oxp_30c16fe4-4229-49d0-ab01-3138f2c7dff2/crypt/debug                                                           41071985-1dfd-4ce5-8bc2-897161a8bce4   in service     100 GiB   none          gzip-9     
+    oxp_4930954e-9ac7-4453-b63f-5ab97c389a99/crypt/debug                                                           21fd4f3a-ec31-469b-87b1-087c343a2422   in service     100 GiB   none          gzip-9     
+*   oxp_30c16fe4-4229-49d0-ab01-3138f2c7dff2/crucible                                                              6f04dd20-5e2c-4fa8-8430-a886470ed140   - in service   none      none          off        
+     └─                                                                                                                                                   + expunged                                        
+*   oxp_30c16fe4-4229-49d0-ab01-3138f2c7dff2/crypt/zone/oxz_crucible_694bd14f-cb24-4be4-bb19-876e79cda2c8          3443a368-199e-4d26-b59f-3f2bbd507761   - in service   none      none          off        
+     └─                                                                                                                                                   + expunged                                        
+
+
+    omicron zones:
+    ------------------------------------------------------------------------------------------------------------------
+    zone type         zone id                                image source      disposition      underlay IP           
+    ------------------------------------------------------------------------------------------------------------------
+    crucible          7c252b64-c5af-4ec1-989e-9a03f3b0f111   install dataset   in service       fd00:1122:3344:103::27
+    crucible          f55647d4-5500-4ad3-893a-df45bd50d622   install dataset   in service       fd00:1122:3344:103::25
+    crucible_pantry   75b220ba-a0f4-4872-8202-dc7c87f062d0   install dataset   in service       fd00:1122:3344:103::24
+    external_dns      f6ec9c67-946a-4da3-98d5-581f72ce8bf0   install dataset   in service       fd00:1122:3344:103::23
+    internal_dns      ea5b4030-b52f-44b2-8d70-45f15f987d01   install dataset   in service       fd00:1122:3344:3::1   
+    internal_ntp      f10a4fb9-759f-4a65-b25e-5794ad2d07d8   install dataset   in service       fd00:1122:3344:103::21
+    nexus             3eeb8d49-eb1a-43f8-bb64-c2338421c2c6   install dataset   in service       fd00:1122:3344:103::22
+*   crucible          694bd14f-cb24-4be4-bb19-876e79cda2c8   install dataset   - in service     fd00:1122:3344:103::26
+     └─                                                                        + expunged ⏳                           
+
+
+ COCKROACHDB SETTINGS:
+    state fingerprint:::::::::::::::::   (none) (unchanged)
+    cluster.preserve_downgrade_option:   (do not modify) (unchanged)
+
+ METADATA:
+    internal DNS version:::   1 (unchanged)
+    external DNS version:::   1 (unchanged)
+    target release min gen:   1 (unchanged)
+    nexus gen::::::::::::::   1 (unchanged)
+
+ OXIMETER SETTINGS:
+    generation:   1 (unchanged)
+    read from::   SingleNode (unchanged)
+
+
+internal DNS:
+* DNS zone: "control-plane.oxide.internal": 
+-   name: 694bd14f-cb24-4be4-bb19-876e79cda2c8.host          (records: 1)
+-       AAAA fd00:1122:3344:103::26
+-   name: _crucible._tcp.694bd14f-cb24-4be4-bb19-876e79cda2c8 (records: 1)
+-       SRV  port 32345 694bd14f-cb24-4be4-bb19-876e79cda2c8.host.control-plane.oxide.internal
+    unchanged names: 49 (records: 63)
+
+external DNS:
+  DNS zone: "oxide.example" (unchanged)
+    unchanged names: 5 (records: 9)
+
+
+
+
+> # Expunge multiple zones.
+> blueprint-edit 8da82a8e-bf97-4fbd-8ddd-9f6462732cf1 expunge-zones 7c252b64-c5af-4ec1-989e-9a03f3b0f111 dfac80b4-a887-430a-ae87-a4e065dba787
+blueprint 58d5e830-0884-47d8-a7cd-b2b3751adeb4 created from blueprint 8da82a8e-bf97-4fbd-8ddd-9f6462732cf1: expunged zone 7c252b64-c5af-4ec1-989e-9a03f3b0f111 from sled d81c6a84-79b8-4958-ae41-ea46c9b19763
+expunged zone dfac80b4-a887-430a-ae87-a4e065dba787 from sled 98e6b7c2-2efa-41ca-b20a-0a4d61102fe6
+
+
+> blueprint-diff 58d5e830-0884-47d8-a7cd-b2b3751adeb4
+from: blueprint 8da82a8e-bf97-4fbd-8ddd-9f6462732cf1
+to:   blueprint 58d5e830-0884-47d8-a7cd-b2b3751adeb4
+
+ MODIFIED SLEDS:
+
+  sled 98e6b7c2-2efa-41ca-b20a-0a4d61102fe6 (active, config generation 2 -> 3):
+
+    host phase 2 contents:
+    ------------------------
+    slot   boot image source
+    ------------------------
+    A      current contents 
+    B      current contents 
+
+
+    physical disks:
+    ------------------------------------------------------------------------------------
+    vendor        model        serial                                        disposition
+    ------------------------------------------------------------------------------------
+    fake-vendor   fake-model   serial-073979dd-3248-44a5-9fa1-cc72a140d682   in service 
+    fake-vendor   fake-model   serial-c6d33b64-fb96-4129-bab1-7878a06a5f9b   in service 
+    fake-vendor   fake-model   serial-e4d937e1-6ddc-4eca-bb08-c1f73791e608   in service 
+
+
+    datasets:
+    --------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
+    dataset name                                                                                                   dataset id                             disposition    quota     reservation   compression
+    --------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
+    oxp_073979dd-3248-44a5-9fa1-cc72a140d682/crucible                                                              7b4ce6bf-95bb-42fe-a4a0-dff31211ab88   in service     none      none          off        
+    oxp_e4d937e1-6ddc-4eca-bb08-c1f73791e608/crucible                                                              50b029e3-96aa-41e5-bf39-023193a4355e   in service     none      none          off        
+    oxp_073979dd-3248-44a5-9fa1-cc72a140d682/crypt/external_dns                                                    4847a96e-a267-4ae7-aa3d-805c1e77f81e   in service     none      none          off        
+    oxp_073979dd-3248-44a5-9fa1-cc72a140d682/crypt/internal_dns                                                    ad41be71-6c15-4428-b510-20ceacde4fa6   in service     none      none          off        
+    oxp_073979dd-3248-44a5-9fa1-cc72a140d682/crypt/zone                                                            4617d206-4330-4dfa-b9f3-f63a3db834f9   in service     none      none          off        
+    oxp_c6d33b64-fb96-4129-bab1-7878a06a5f9b/crypt/zone                                                            793ac181-1b01-403c-850d-7f5c54bda6c9   in service     none      none          off        
+    oxp_e4d937e1-6ddc-4eca-bb08-c1f73791e608/crypt/zone                                                            4f60b534-eaa3-40a1-b60f-bfdf147af478   in service     none      none          off        
+    oxp_e4d937e1-6ddc-4eca-bb08-c1f73791e608/crypt/zone/oxz_crucible_058fd5f9-60a8-4e11-9302-15172782e17d          02c56a30-7d97-406d-bd34-1eb437fd517d   in service     none      none          off        
+    oxp_073979dd-3248-44a5-9fa1-cc72a140d682/crypt/zone/oxz_crucible_5199c033-4cf9-4ab6-8ae7-566bd7606363          832fd140-d467-4bad-b5e9-63171634087c   in service     none      none          off        
+    oxp_073979dd-3248-44a5-9fa1-cc72a140d682/crypt/zone/oxz_crucible_pantry_ba4994a8-23f9-4b1a-a84f-a08d74591389   42430c80-7836-4191-a4f6-bcee749010fe   in service     none      none          off        
+    oxp_073979dd-3248-44a5-9fa1-cc72a140d682/crypt/zone/oxz_external_dns_803bfb63-c246-41db-b0da-d3b87ddfc63d      43931274-7fe8-4077-825d-dff2bc8efa58   in service     none      none          off        
+    oxp_073979dd-3248-44a5-9fa1-cc72a140d682/crypt/zone/oxz_internal_dns_427ec88f-f467-42fa-9bbb-66a91a36103c      1bca7f71-5e42-4749-91ec-fa40793a3a9a   in service     none      none          off        
+    oxp_073979dd-3248-44a5-9fa1-cc72a140d682/crypt/zone/oxz_nexus_0c71b3b2-6ceb-4e8f-b020-b08675e83038             a4c3032e-21fa-4d4a-b040-a7e3c572cf3c   in service     none      none          off        
+    oxp_073979dd-3248-44a5-9fa1-cc72a140d682/crypt/zone/oxz_ntp_6444f8a5-6465-4f0b-a549-1993c113569c               3ac089c9-9dec-465b-863a-188e80d71fb4   in service     none      none          off        
+    oxp_073979dd-3248-44a5-9fa1-cc72a140d682/crypt/debug                                                           248c6c10-1ac6-45de-bb55-ede36ca56bbd   in service     100 GiB   none          gzip-9     
+    oxp_c6d33b64-fb96-4129-bab1-7878a06a5f9b/crypt/debug                                                           cdf3684f-a6cf-4449-b9ec-e696b2c663e2   in service     100 GiB   none          gzip-9     
+    oxp_e4d937e1-6ddc-4eca-bb08-c1f73791e608/crypt/debug                                                           686c19cf-a0d7-45f6-866f-c564612b2664   in service     100 GiB   none          gzip-9     
+*   oxp_c6d33b64-fb96-4129-bab1-7878a06a5f9b/crucible                                                              ea8a11bf-a884-4c4f-8df0-3ef9b7aacf43   - in service   none      none          off        
+     └─                                                                                                                                                   + expunged                                        
+*   oxp_c6d33b64-fb96-4129-bab1-7878a06a5f9b/crypt/zone/oxz_crucible_dfac80b4-a887-430a-ae87-a4e065dba787          4d7e3e8e-06bd-414c-a468-779e056a9b75   - in service   none      none          off        
+     └─                                                                                                                                                   + expunged                                        
+
+
+    omicron zones:
+    ------------------------------------------------------------------------------------------------------------------
+    zone type         zone id                                image source      disposition      underlay IP           
+    ------------------------------------------------------------------------------------------------------------------
+    crucible          058fd5f9-60a8-4e11-9302-15172782e17d   install dataset   in service       fd00:1122:3344:101::27
+    crucible          5199c033-4cf9-4ab6-8ae7-566bd7606363   install dataset   in service       fd00:1122:3344:101::25
+    crucible_pantry   ba4994a8-23f9-4b1a-a84f-a08d74591389   install dataset   in service       fd00:1122:3344:101::24
+    external_dns      803bfb63-c246-41db-b0da-d3b87ddfc63d   install dataset   in service       fd00:1122:3344:101::23
+    internal_dns      427ec88f-f467-42fa-9bbb-66a91a36103c   install dataset   in service       fd00:1122:3344:2::1   
+    internal_ntp      6444f8a5-6465-4f0b-a549-1993c113569c   install dataset   in service       fd00:1122:3344:101::21
+    nexus             0c71b3b2-6ceb-4e8f-b020-b08675e83038   install dataset   in service       fd00:1122:3344:101::22
+*   crucible          dfac80b4-a887-430a-ae87-a4e065dba787   install dataset   - in service     fd00:1122:3344:101::26
+     └─                                                                        + expunged ⏳                           
+
+
+  sled d81c6a84-79b8-4958-ae41-ea46c9b19763 (active, config generation 3 -> 4):
+
+    host phase 2 contents:
+    ------------------------
+    slot   boot image source
+    ------------------------
+    A      current contents 
+    B      current contents 
+
+
+    physical disks:
+    ------------------------------------------------------------------------------------
+    vendor        model        serial                                        disposition
+    ------------------------------------------------------------------------------------
+    fake-vendor   fake-model   serial-18b20749-0748-4105-bb10-7b13cfc776e2   in service 
+    fake-vendor   fake-model   serial-30c16fe4-4229-49d0-ab01-3138f2c7dff2   in service 
+    fake-vendor   fake-model   serial-4930954e-9ac7-4453-b63f-5ab97c389a99   in service 
+
+
+    datasets:
+    --------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
+    dataset name                                                                                                   dataset id                             disposition    quota     reservation   compression
+    --------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
+    oxp_18b20749-0748-4105-bb10-7b13cfc776e2/crucible                                                              7ea73f80-c4e0-450a-92dc-8397ce2af14f   in service     none      none          off        
+    oxp_30c16fe4-4229-49d0-ab01-3138f2c7dff2/crucible                                                              6f04dd20-5e2c-4fa8-8430-a886470ed140   expunged       none      none          off        
+    oxp_18b20749-0748-4105-bb10-7b13cfc776e2/crypt/external_dns                                                    96ae8389-3027-4260-9374-e0f6ce851de2   in service     none      none          off        
+    oxp_18b20749-0748-4105-bb10-7b13cfc776e2/crypt/internal_dns                                                    1cb0a47a-59ac-4892-8e92-cf87b4290f96   in service     none      none          off        
+    oxp_18b20749-0748-4105-bb10-7b13cfc776e2/crypt/zone                                                            45cd9687-20be-4247-b62a-dfdacf324929   in service     none      none          off        
+    oxp_30c16fe4-4229-49d0-ab01-3138f2c7dff2/crypt/zone                                                            e009d8b8-4695-4322-b53f-f03f2744aef7   in service     none      none          off        
+    oxp_4930954e-9ac7-4453-b63f-5ab97c389a99/crypt/zone                                                            252ac39f-b9e2-4697-8c07-3a833115d704   in service     none      none          off        
+    oxp_30c16fe4-4229-49d0-ab01-3138f2c7dff2/crypt/zone/oxz_crucible_694bd14f-cb24-4be4-bb19-876e79cda2c8          3443a368-199e-4d26-b59f-3f2bbd507761   expunged       none      none          off        
+    oxp_18b20749-0748-4105-bb10-7b13cfc776e2/crypt/zone/oxz_crucible_f55647d4-5500-4ad3-893a-df45bd50d622          50ea8c15-c4c0-4403-a490-d14b3405dfc2   in service     none      none          off        
+    oxp_18b20749-0748-4105-bb10-7b13cfc776e2/crypt/zone/oxz_crucible_pantry_75b220ba-a0f4-4872-8202-dc7c87f062d0   54bbadaf-ec04-41a2-a62f-f5ac5bf321be   in service     none      none          off        
+    oxp_18b20749-0748-4105-bb10-7b13cfc776e2/crypt/zone/oxz_external_dns_f6ec9c67-946a-4da3-98d5-581f72ce8bf0      090bd88d-0a43-4040-a832-b13ae721f74f   in service     none      none          off        
+    oxp_18b20749-0748-4105-bb10-7b13cfc776e2/crypt/zone/oxz_internal_dns_ea5b4030-b52f-44b2-8d70-45f15f987d01      b1deff4b-51df-4a37-9043-afbd7c70a1cb   in service     none      none          off        
+    oxp_18b20749-0748-4105-bb10-7b13cfc776e2/crypt/zone/oxz_nexus_3eeb8d49-eb1a-43f8-bb64-c2338421c2c6             4da74a5b-6911-4cca-b624-b90c65530117   in service     none      none          off        
+    oxp_18b20749-0748-4105-bb10-7b13cfc776e2/crypt/zone/oxz_ntp_f10a4fb9-759f-4a65-b25e-5794ad2d07d8               c65a9c1c-36dc-4ddb-8aac-ec3be8dbb209   in service     none      none          off        
+    oxp_18b20749-0748-4105-bb10-7b13cfc776e2/crypt/debug                                                           7a6a2058-ea78-49de-9730-cce5e28b4cfb   in service     100 GiB   none          gzip-9     
+    oxp_30c16fe4-4229-49d0-ab01-3138f2c7dff2/crypt/debug                                                           41071985-1dfd-4ce5-8bc2-897161a8bce4   in service     100 GiB   none          gzip-9     
+    oxp_4930954e-9ac7-4453-b63f-5ab97c389a99/crypt/debug                                                           21fd4f3a-ec31-469b-87b1-087c343a2422   in service     100 GiB   none          gzip-9     
+*   oxp_4930954e-9ac7-4453-b63f-5ab97c389a99/crucible                                                              a50cd13a-5749-4e79-bb8b-19229500a8b3   - in service   none      none          off        
+     └─                                                                                                                                                   + expunged                                        
+*   oxp_4930954e-9ac7-4453-b63f-5ab97c389a99/crypt/zone/oxz_crucible_7c252b64-c5af-4ec1-989e-9a03f3b0f111          429da94b-19f7-48bd-98e9-47842863ba7b   - in service   none      none          off        
+     └─                                                                                                                                                   + expunged                                        
+
+
+    omicron zones:
+    ------------------------------------------------------------------------------------------------------------------
+    zone type         zone id                                image source      disposition      underlay IP           
+    ------------------------------------------------------------------------------------------------------------------
+    crucible          694bd14f-cb24-4be4-bb19-876e79cda2c8   install dataset   expunged ⏳       fd00:1122:3344:103::26
+    crucible          f55647d4-5500-4ad3-893a-df45bd50d622   install dataset   in service       fd00:1122:3344:103::25
+    crucible_pantry   75b220ba-a0f4-4872-8202-dc7c87f062d0   install dataset   in service       fd00:1122:3344:103::24
+    external_dns      f6ec9c67-946a-4da3-98d5-581f72ce8bf0   install dataset   in service       fd00:1122:3344:103::23
+    internal_dns      ea5b4030-b52f-44b2-8d70-45f15f987d01   install dataset   in service       fd00:1122:3344:3::1   
+    internal_ntp      f10a4fb9-759f-4a65-b25e-5794ad2d07d8   install dataset   in service       fd00:1122:3344:103::21
+    nexus             3eeb8d49-eb1a-43f8-bb64-c2338421c2c6   install dataset   in service       fd00:1122:3344:103::22
+*   crucible          7c252b64-c5af-4ec1-989e-9a03f3b0f111   install dataset   - in service     fd00:1122:3344:103::27
+     └─                                                                        + expunged ⏳                           
+
+
+ COCKROACHDB SETTINGS:
+    state fingerprint:::::::::::::::::   (none) (unchanged)
+    cluster.preserve_downgrade_option:   (do not modify) (unchanged)
+
+ METADATA:
+    internal DNS version:::   1 (unchanged)
+    external DNS version:::   1 (unchanged)
+    target release min gen:   1 (unchanged)
+    nexus gen::::::::::::::   1 (unchanged)
+
+ OXIMETER SETTINGS:
+    generation:   1 (unchanged)
+    read from::   SingleNode (unchanged)
+
+
+internal DNS:
+* DNS zone: "control-plane.oxide.internal": 
+-   name: 7c252b64-c5af-4ec1-989e-9a03f3b0f111.host          (records: 1)
+-       AAAA fd00:1122:3344:103::27
+-   name: _crucible._tcp.7c252b64-c5af-4ec1-989e-9a03f3b0f111 (records: 1)
+-       SRV  port 32345 7c252b64-c5af-4ec1-989e-9a03f3b0f111.host.control-plane.oxide.internal
+-   name: _crucible._tcp.dfac80b4-a887-430a-ae87-a4e065dba787 (records: 1)
+-       SRV  port 32345 dfac80b4-a887-430a-ae87-a4e065dba787.host.control-plane.oxide.internal
+-   name: dfac80b4-a887-430a-ae87-a4e065dba787.host          (records: 1)
+-       AAAA fd00:1122:3344:101::26
+    unchanged names: 45 (records: 59)
+
+external DNS:
+  DNS zone: "oxide.example" (unchanged)
+    unchanged names: 5 (records: 9)
+
+
+

--- a/dev-tools/reconfigurator-cli/tests/output/cmds-set-mgs-updates-stdout
+++ b/dev-tools/reconfigurator-cli/tests/output/cmds-set-mgs-updates-stdout
@@ -1337,7 +1337,7 @@ Commands:
   set-target-release-minimum-generation
           set the minimum generation for which target releases are accepted [aliases:
           set-target-release-min-gen]
-  expunge-zone
+  expunge-zones
           expunge a zone
   mark-for-cleanup
           mark an expunged zone ready for cleanup

--- a/dev-tools/reconfigurator-cli/tests/output/cmds-set-zone-images-stdout
+++ b/dev-tools/reconfigurator-cli/tests/output/cmds-set-zone-images-stdout
@@ -601,7 +601,7 @@ Commands:
   set-target-release-minimum-generation
           set the minimum generation for which target releases are accepted [aliases:
           set-target-release-min-gen]
-  expunge-zone
+  expunge-zones
           expunge a zone
   mark-for-cleanup
           mark an expunged zone ready for cleanup


### PR DESCRIPTION
When testing Nexus handoff, you wind up creating several Nexus zones.  Cleaning up if it goes wrong is a pain because you need a sequence of three blueprints.  You gotta run `blueprint-edit` three times, then save each individually, then import them individually, then set them as the target in the right order.

This lets you do it in one go.  I didn't bother to preserve backwards compatibility of the command, though it wouldn't be hard to do that if we want.