### PR TITLE
`InstanceUpdate` body: change `Option` fields to `Nullable` so they're required to be present

### DIFF
--- a/nexus/src/app/instance.rs
+++ b/nexus/src/app/instance.rs
@@ -367,7 +367,7 @@ impl super::Nexus {
 
         check_instance_cpu_memory_sizes(*ncpus, *memory)?;
 
-        let boot_disk_id = match &**boot_disk {
+        let boot_disk_id = match boot_disk.as_ref() {
             Some(disk) => {
                 let selector = params::DiskSelector {
                     project: match &disk {

--- a/nexus/src/app/instance.rs
+++ b/nexus/src/app/instance.rs
@@ -367,7 +367,7 @@ impl super::Nexus {
 
         check_instance_cpu_memory_sizes(*ncpus, *memory)?;
 
-        let boot_disk_id = match boot_disk {
+        let boot_disk_id = match &**boot_disk {
             Some(disk) => {
                 let selector = params::DiskSelector {
                     project: match &disk {

--- a/nexus/tests/integration_tests/endpoints.rs
+++ b/nexus/tests/integration_tests/endpoints.rs
@@ -687,9 +687,9 @@ pub static DEMO_STOPPED_INSTANCE_CREATE: LazyLock<params::InstanceCreate> =
     });
 pub static DEMO_INSTANCE_UPDATE: LazyLock<params::InstanceUpdate> =
     LazyLock::new(|| params::InstanceUpdate {
-        boot_disk: None,
-        cpu_platform: None,
-        auto_restart_policy: None,
+        boot_disk: Nullable(None),
+        cpu_platform: Nullable(None),
+        auto_restart_policy: Nullable(None),
         ncpus: InstanceCpuCount(1),
         memory: ByteCount::from_gibibytes_u32(16),
     });

--- a/nexus/types/src/external_api/params.rs
+++ b/nexus/types/src/external_api/params.rs
@@ -1301,7 +1301,7 @@ pub struct InstanceUpdate {
 
     /// Name or ID of the disk the instance should be instructed to boot from.
     ///
-    /// If not provided, unset the instance's boot disk.
+    /// A null value unsets the boot disk.
     pub boot_disk: Nullable<NameOrId>,
 
     /// Sets the auto-restart policy for this instance.

--- a/nexus/types/src/external_api/params.rs
+++ b/nexus/types/src/external_api/params.rs
@@ -1302,7 +1302,7 @@ pub struct InstanceUpdate {
     /// Name or ID of the disk the instance should be instructed to boot from.
     ///
     /// If not provided, unset the instance's boot disk.
-    pub boot_disk: Option<NameOrId>,
+    pub boot_disk: Nullable<NameOrId>,
 
     /// Sets the auto-restart policy for this instance.
     ///
@@ -1318,11 +1318,11 @@ pub struct InstanceUpdate {
     /// configurable through other mechanisms, such as on a per-project basis.
     /// In that case, any configured default policy will be used if this is
     /// `null`.
-    pub auto_restart_policy: Option<InstanceAutoRestartPolicy>,
+    pub auto_restart_policy: Nullable<InstanceAutoRestartPolicy>,
 
     /// The CPU platform to be used for this instance. If this is `null`, the
     /// instance requires no particular CPU platform.
-    pub cpu_platform: Option<InstanceCpuPlatform>,
+    pub cpu_platform: Nullable<InstanceCpuPlatform>,
 }
 
 #[inline]

--- a/openapi/nexus.json
+++ b/openapi/nexus.json
@@ -20876,6 +20876,9 @@
           }
         },
         "required": [
+          "auto_restart_policy",
+          "boot_disk",
+          "cpu_platform",
           "memory",
           "ncpus"
         ]

--- a/openapi/nexus.json
+++ b/openapi/nexus.json
@@ -20842,7 +20842,7 @@
           },
           "boot_disk": {
             "nullable": true,
-            "description": "Name or ID of the disk the instance should be instructed to boot from.\n\nIf not provided, unset the instance's boot disk.",
+            "description": "Name or ID of the disk the instance should be instructed to boot from.\n\nA null value unsets the boot disk.",
             "allOf": [
               {
                 "$ref": "#/components/schemas/NameOrId"


### PR DESCRIPTION
Optional fields on a request body can be left out completely from the JSON. In the case of instance update (and probably many other endpoints) this is a problem because passing `null` and passing nothing have the same effect, namely unsetting that field if it is already set in the DB. And because the fields are optional, the generated client types do not enforce that they are present (at least when creating the JSON by hand and also in TypeScript, which distinguishes between optional and nullable at the type level). It is easy to do this by accident: while working on [this](https://github.com/oxidecomputer/console/pull/2900), I [discovered a bug](https://github.com/oxidecomputer/console/pull/2900#discussion_r2357519012) in the console where we accidentally unset the auto restart policy on an instance when you resize an instance.

This PR changes `Option` to `Nullable`, which I added in #8214 to fix this problem: `null` remains a valid value, but the client is no longer allowed to leave that field out of the body. If we don't want to do this, I can live with it because in the console, I have [made a helper](https://github.com/oxidecomputer/console/pull/2900/commits/60ca75e6827ae810dba1d53f87a70cf248f4f942) that enforces that all fields are explicitly present. But I do think the status quo is very error-prone.

https://github.com/oxidecomputer/omicron/blob/c6989117c72ecf88d4e3dc8a597d9fe703152a93/common/src/api/external/mod.rs#L3564-L3570