### PR TITLE
Blueprint: replace `report` with `source`

### DIFF
--- a/dev-tools/omdb/tests/successes.out
+++ b/dev-tools/omdb/tests/successes.out
@@ -1514,7 +1514,7 @@ parent:    <none>
 
  PENDING MGS-MANAGED UPDATES: 0
 
-empty planning report for blueprint ......<REDACTED_BLUEPRINT_ID>........
+blueprint source: test
 
 
 ---------------------------------------------
@@ -1638,7 +1638,7 @@ parent:    <none>
 
  PENDING MGS-MANAGED UPDATES: 0
 
-empty planning report for blueprint ......<REDACTED_BLUEPRINT_ID>........
+blueprint source: test
 
 
 ---------------------------------------------

--- a/dev-tools/reconfigurator-cli/src/lib.rs
+++ b/dev-tools/reconfigurator-cli/src/lib.rs
@@ -29,7 +29,6 @@ use nexus_reconfigurator_simulation::{BlueprintId, CollectionId, SimState};
 use nexus_reconfigurator_simulation::{SimStateBuilder, SimTufRepoSource};
 use nexus_reconfigurator_simulation::{SimTufRepoDescription, Simulator};
 use nexus_sled_agent_shared::inventory::ZoneKind;
-use nexus_types::deployment::SledFilter;
 use nexus_types::deployment::execution;
 use nexus_types::deployment::execution::blueprint_external_dns_config;
 use nexus_types::deployment::execution::blueprint_internal_dns_config;
@@ -38,6 +37,7 @@ use nexus_types::deployment::{BlueprintArtifactVersion, PendingMgsUpdate};
 use nexus_types::deployment::{
     BlueprintHostPhase2DesiredContents, PlannerConfig,
 };
+use nexus_types::deployment::{BlueprintSource, SledFilter};
 use nexus_types::deployment::{BlueprintZoneDisposition, ExpectedVersion};
 use nexus_types::deployment::{
     BlueprintZoneImageSource, PendingMgsUpdateDetails,
@@ -2105,7 +2105,7 @@ fn cmd_blueprint_plan(
     let blueprint = planner.plan().context("generating blueprint")?;
     let rv = format!(
         "generated blueprint {} based on parent blueprint {}\n{}",
-        blueprint.id, parent_blueprint.id, blueprint.report,
+        blueprint.id, parent_blueprint.id, blueprint.source,
     );
     system.add_blueprint(blueprint)?;
 
@@ -2320,7 +2320,8 @@ fn cmd_blueprint_edit(
         }
     };
 
-    let mut new_blueprint = builder.build();
+    let mut new_blueprint =
+        builder.build(BlueprintSource::ReconfiguratorCliEdit);
 
     // Normally `builder.build()` would construct the cockroach fingerprint
     // based on what we read from CRDB and put into the planning input, but

--- a/dev-tools/reconfigurator-cli/src/lib.rs
+++ b/dev-tools/reconfigurator-cli/src/lib.rs
@@ -2104,7 +2104,8 @@ fn cmd_blueprint_plan(
 
     let blueprint = planner.plan().context("generating blueprint")?;
     let rv = format!(
-        "generated blueprint {} based on parent blueprint {}\n{}",
+        "generated blueprint {} based on parent blueprint {}\n\
+         blueprint source: {}",
         blueprint.id, parent_blueprint.id, blueprint.source,
     );
     system.add_blueprint(blueprint)?;

--- a/dev-tools/reconfigurator-cli/tests/output/cmds-add-sled-no-disks-stdout
+++ b/dev-tools/reconfigurator-cli/tests/output/cmds-add-sled-no-disks-stdout
@@ -39,9 +39,11 @@ generated inventory collection eb0796d5-ab8a-4f7b-a884-b4aeacb8ab51 from configu
 INFO skipping noop image source check for all sleds, reason: no target release is currently set
 WARN cannot issue more MGS-driven updates (no current artifacts)
 generated blueprint 8da82a8e-bf97-4fbd-8ddd-9f6462732cf1 based on parent blueprint dbcbd3d6-41ff-48ae-ac0b-1becc9b2fd21
+blueprint source: planner with report:
 planning report for blueprint 8da82a8e-bf97-4fbd-8ddd-9f6462732cf1:
 * no zpools in service for NTP zones on sleds: 00320471-945d-413c-85e7-03e091a70b3c
 * discretionary zone placement waiting for NTP zones on sleds: 00320471-945d-413c-85e7-03e091a70b3c
+
 
 
 > blueprint-show 8da82a8e-bf97-4fbd-8ddd-9f6462732cf1
@@ -275,9 +277,11 @@ parent:    dbcbd3d6-41ff-48ae-ac0b-1becc9b2fd21
 
  PENDING MGS-MANAGED UPDATES: 0
 
+blueprint source: planner with report:
 planning report for blueprint 8da82a8e-bf97-4fbd-8ddd-9f6462732cf1:
 * no zpools in service for NTP zones on sleds: 00320471-945d-413c-85e7-03e091a70b3c
 * discretionary zone placement waiting for NTP zones on sleds: 00320471-945d-413c-85e7-03e091a70b3c
+
 
 
 

--- a/dev-tools/reconfigurator-cli/tests/output/cmds-example-stdout
+++ b/dev-tools/reconfigurator-cli/tests/output/cmds-example-stdout
@@ -403,7 +403,7 @@ parent:    02697f74-b14a-4418-90f0-c28b2a3a6aa9
 
  PENDING MGS-MANAGED UPDATES: 0
 
-empty planning report for blueprint ade5749d-bdf3-4fab-a8ae-00bea01b3a5a.
+blueprint source: test
 
 
 
@@ -570,7 +570,7 @@ parent:    02697f74-b14a-4418-90f0-c28b2a3a6aa9
 
  PENDING MGS-MANAGED UPDATES: 0
 
-empty planning report for blueprint ade5749d-bdf3-4fab-a8ae-00bea01b3a5a.
+blueprint source: test
 
 
 
@@ -601,7 +601,9 @@ T ENA ID                                   PARENT                               
 INFO skipping noop image source check for all sleds, reason: no target release is currently set
 WARN cannot issue more MGS-driven updates (no current artifacts)
 generated blueprint 86db3308-f817-4626-8838-4085949a6a41 based on parent blueprint ade5749d-bdf3-4fab-a8ae-00bea01b3a5a
+blueprint source: planner with report:
 empty planning report for blueprint 86db3308-f817-4626-8838-4085949a6a41.
+
 
 
 > blueprint-list
@@ -1289,7 +1291,7 @@ parent:    02697f74-b14a-4418-90f0-c28b2a3a6aa9
 
  PENDING MGS-MANAGED UPDATES: 0
 
-empty planning report for blueprint ade5749d-bdf3-4fab-a8ae-00bea01b3a5a.
+blueprint source: test
 
 
 
@@ -1839,7 +1841,9 @@ INTERNAL DNS STATUS
 INFO skipping noop image source check for all sleds, reason: no target release is currently set
 WARN cannot issue more MGS-driven updates (no current artifacts)
 generated blueprint 86db3308-f817-4626-8838-4085949a6a41 based on parent blueprint ade5749d-bdf3-4fab-a8ae-00bea01b3a5a
+blueprint source: planner with report:
 empty planning report for blueprint 86db3308-f817-4626-8838-4085949a6a41.
+
 
 
 > blueprint-diff ade5749d-bdf3-4fab-a8ae-00bea01b3a5a latest

--- a/dev-tools/reconfigurator-cli/tests/output/cmds-expunge-newly-added-external-dns-stdout
+++ b/dev-tools/reconfigurator-cli/tests/output/cmds-expunge-newly-added-external-dns-stdout
@@ -335,7 +335,7 @@ parent:    06c88262-f435-410e-ba98-101bed41ec27
 
  PENDING MGS-MANAGED UPDATES: 0
 
-empty planning report for blueprint 3f00b694-1b16-4aaa-8f78-e6b3a527b434.
+blueprint source: test
 
 
 
@@ -832,7 +832,7 @@ parent:    3f00b694-1b16-4aaa-8f78-e6b3a527b434
 
  PENDING MGS-MANAGED UPDATES: 0
 
-empty planning report for blueprint 366b0b68-d80e-4bc1-abd3-dc69837847e0.
+blueprint source: reconfigurator-cli
 
 
 
@@ -841,10 +841,12 @@ empty planning report for blueprint 366b0b68-d80e-4bc1-abd3-dc69837847e0.
 INFO skipping noop image source check for all sleds, reason: no target release is currently set
 WARN cannot issue more MGS-driven updates (no current artifacts)
 generated blueprint 9c998c1d-1a7b-440a-ae0c-40f781dea6e2 based on parent blueprint 366b0b68-d80e-4bc1-abd3-dc69837847e0
+blueprint source: planner with report:
 planning report for blueprint 9c998c1d-1a7b-440a-ae0c-40f781dea6e2:
 * discretionary zones placed:
   * external_dns zone on sled 711ac7f8-d19e-4572-bdb9-e9b50f6e362a from source install dataset
 * zone updates waiting on discretionary zones
+
 
 
 > blueprint-diff 366b0b68-d80e-4bc1-abd3-dc69837847e0 9c998c1d-1a7b-440a-ae0c-40f781dea6e2
@@ -1338,10 +1340,12 @@ parent:    366b0b68-d80e-4bc1-abd3-dc69837847e0
 
  PENDING MGS-MANAGED UPDATES: 0
 
+blueprint source: planner with report:
 planning report for blueprint 9c998c1d-1a7b-440a-ae0c-40f781dea6e2:
 * discretionary zones placed:
   * external_dns zone on sled 711ac7f8-d19e-4572-bdb9-e9b50f6e362a from source install dataset
 * zone updates waiting on discretionary zones
+
 
 
 

--- a/dev-tools/reconfigurator-cli/tests/output/cmds-expunge-newly-added-internal-dns-stdout
+++ b/dev-tools/reconfigurator-cli/tests/output/cmds-expunge-newly-added-internal-dns-stdout
@@ -333,7 +333,7 @@ parent:    184f10b3-61cb-41ef-9b93-3489b2bac559
 
  PENDING MGS-MANAGED UPDATES: 0
 
-empty planning report for blueprint dbcbd3d6-41ff-48ae-ac0b-1becc9b2fd21.
+blueprint source: test
 
 
 
@@ -649,10 +649,12 @@ external DNS:
 INFO skipping noop image source check for all sleds, reason: no target release is currently set
 WARN cannot issue more MGS-driven updates (no current artifacts)
 generated blueprint af934083-59b5-4bf6-8966-6fb5292c29e1 based on parent blueprint 58d5e830-0884-47d8-a7cd-b2b3751adeb4
+blueprint source: planner with report:
 planning report for blueprint af934083-59b5-4bf6-8966-6fb5292c29e1:
 * discretionary zones placed:
   * internal_dns zone on sled 2b8f0cb3-0295-4b3c-bc58-4fe88b57112c from source install dataset
 * zone updates waiting on discretionary zones
+
 
 
 > blueprint-diff 58d5e830-0884-47d8-a7cd-b2b3751adeb4 af934083-59b5-4bf6-8966-6fb5292c29e1

--- a/dev-tools/reconfigurator-cli/tests/output/cmds-host-phase-2-source-stdout
+++ b/dev-tools/reconfigurator-cli/tests/output/cmds-host-phase-2-source-stdout
@@ -475,7 +475,7 @@ parent:    8da82a8e-bf97-4fbd-8ddd-9f6462732cf1
 
  PENDING MGS-MANAGED UPDATES: 0
 
-empty planning report for blueprint 58d5e830-0884-47d8-a7cd-b2b3751adeb4.
+blueprint source: reconfigurator-cli
 
 
 
@@ -948,7 +948,7 @@ parent:    af934083-59b5-4bf6-8966-6fb5292c29e1
 
  PENDING MGS-MANAGED UPDATES: 0
 
-empty planning report for blueprint df06bb57-ad42-4431-9206-abff322896c7.
+blueprint source: reconfigurator-cli
 
 
 

--- a/dev-tools/reconfigurator-cli/tests/output/cmds-mupdate-update-flow-stdout
+++ b/dev-tools/reconfigurator-cli/tests/output/cmds-mupdate-update-flow-stdout
@@ -501,6 +501,7 @@ WARN skipped noop image source check on sled, sled_id: 2b8f0cb3-0295-4b3c-bc58-4
 INFO skipped noop image source check on sled, sled_id: 98e6b7c2-2efa-41ca-b20a-0a4d61102fe6, reason: remove_mupdate_override is set in the blueprint (6123eac1-ec5b-42ba-b73f-9845105a9971)
 INFO skipped noop image source check on sled, sled_id: d81c6a84-79b8-4958-ae41-ea46c9b19763, reason: remove_mupdate_override is set in the blueprint (203fa72c-85c1-466a-8ed3-338ee029530d)
 generated blueprint a5a8f242-ffa5-473c-8efd-2acf2dc0b736 based on parent blueprint d60afc57-f15d-476c-bd0f-b1071e2bb976
+blueprint source: planner with report:
 planning report for blueprint a5a8f242-ffa5-473c-8efd-2acf2dc0b736:
 * zone adds waiting on blockers
 * zone adds and updates are blocked:
@@ -508,6 +509,7 @@ planning report for blueprint a5a8f242-ffa5-473c-8efd-2acf2dc0b736:
   - sleds have remove mupdate override set in blueprint: 98e6b7c2-2efa-41ca-b20a-0a4d61102fe6, d81c6a84-79b8-4958-ae41-ea46c9b19763
   - sleds have mupdate override errors: 2b8f0cb3-0295-4b3c-bc58-4fe88b57112c
 * zone updates waiting on zone add blockers
+
 
 
 
@@ -773,12 +775,14 @@ WARN skipped noop image source check on sled, sled_id: 2b8f0cb3-0295-4b3c-bc58-4
 INFO skipped noop image source check on sled, sled_id: 98e6b7c2-2efa-41ca-b20a-0a4d61102fe6, reason: sled not found in inventory
 INFO skipped noop image source check on sled, sled_id: d81c6a84-79b8-4958-ae41-ea46c9b19763, reason: remove_mupdate_override is set in the blueprint (203fa72c-85c1-466a-8ed3-338ee029530d)
 generated blueprint 626487fa-7139-45ec-8416-902271fc730b based on parent blueprint a5a8f242-ffa5-473c-8efd-2acf2dc0b736
+blueprint source: planner with report:
 planning report for blueprint 626487fa-7139-45ec-8416-902271fc730b:
 * zone adds waiting on blockers
 * zone adds and updates are blocked:
   - sleds have remove mupdate override set in blueprint: 98e6b7c2-2efa-41ca-b20a-0a4d61102fe6, d81c6a84-79b8-4958-ae41-ea46c9b19763
   - sleds have mupdate override errors: 2b8f0cb3-0295-4b3c-bc58-4fe88b57112c
 * zone updates waiting on zone add blockers
+
 
 
 > blueprint-diff latest
@@ -895,6 +899,7 @@ INFO BootPartitionDetails inventory hash not found in TUF repo, ignoring for noo
 INFO BootPartitionDetails inventory hash not found in TUF repo, ignoring for noop checks, sled_id: 98e6b7c2-2efa-41ca-b20a-0a4d61102fe6, slot: b, expected_hash: 0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b
 INFO skipped noop image source check on sled, sled_id: d81c6a84-79b8-4958-ae41-ea46c9b19763, reason: remove_mupdate_override is set in the blueprint (1c0ce176-6dc8-4a90-adea-d4a8000751da)
 generated blueprint c1a0d242-9160-40f4-96ae-61f8f40a0b1b based on parent blueprint 626487fa-7139-45ec-8416-902271fc730b
+blueprint source: planner with report:
 planning report for blueprint c1a0d242-9160-40f4-96ae-61f8f40a0b1b:
 * noop converting 6/6 install-dataset zones to artifact store on sled 98e6b7c2-2efa-41ca-b20a-0a4d61102fe6
 * zone adds waiting on blockers
@@ -903,6 +908,7 @@ planning report for blueprint c1a0d242-9160-40f4-96ae-61f8f40a0b1b:
   - sleds have remove mupdate override set in blueprint: d81c6a84-79b8-4958-ae41-ea46c9b19763
   - sleds have mupdate override errors: 2b8f0cb3-0295-4b3c-bc58-4fe88b57112c
 * zone updates waiting on zone add blockers
+
 
 
 
@@ -1081,6 +1087,7 @@ INFO install dataset artifact hash not found in TUF repo, ignoring for noop chec
 INFO BootPartitionDetails inventory hash not found in TUF repo, ignoring for noop checks, sled_id: d81c6a84-79b8-4958-ae41-ea46c9b19763, slot: a, expected_hash: 0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a
 INFO BootPartitionDetails inventory hash not found in TUF repo, ignoring for noop checks, sled_id: d81c6a84-79b8-4958-ae41-ea46c9b19763, slot: b, expected_hash: 0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b
 generated blueprint afb09faf-a586-4483-9289-04d4f1d8ba23 based on parent blueprint c1a0d242-9160-40f4-96ae-61f8f40a0b1b
+blueprint source: planner with report:
 planning report for blueprint afb09faf-a586-4483-9289-04d4f1d8ba23:
 * skipping noop zone image source check on sled 98e6b7c2-2efa-41ca-b20a-0a4d61102fe6: all 6 zones are already from artifacts
 * zone adds waiting on blockers
@@ -1088,6 +1095,7 @@ planning report for blueprint afb09faf-a586-4483-9289-04d4f1d8ba23:
   - current target release generation (3) is lower than minimum required by blueprint (4)
   - sleds have mupdate override errors: 2b8f0cb3-0295-4b3c-bc58-4fe88b57112c
 * zone updates waiting on zone add blockers
+
 
 
 > blueprint-show latest
@@ -1256,6 +1264,7 @@ parent:    c1a0d242-9160-40f4-96ae-61f8f40a0b1b
 
  PENDING MGS-MANAGED UPDATES: 0
 
+blueprint source: planner with report:
 planning report for blueprint afb09faf-a586-4483-9289-04d4f1d8ba23:
 * skipping noop zone image source check on sled 98e6b7c2-2efa-41ca-b20a-0a4d61102fe6: all 6 zones are already from artifacts
 * zone adds waiting on blockers
@@ -1263,6 +1272,7 @@ planning report for blueprint afb09faf-a586-4483-9289-04d4f1d8ba23:
   - current target release generation (3) is lower than minimum required by blueprint (4)
   - sleds have mupdate override errors: 2b8f0cb3-0295-4b3c-bc58-4fe88b57112c
 * zone updates waiting on zone add blockers
+
 
 
 
@@ -1394,6 +1404,7 @@ INFO performed noop zone image source checks on sled, sled_id: d81c6a84-79b8-495
 INFO BootPartitionDetails inventory hash not found in TUF repo, ignoring for noop checks, sled_id: d81c6a84-79b8-4958-ae41-ea46c9b19763, slot: a, expected_hash: 0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a
 INFO BootPartitionDetails inventory hash not found in TUF repo, ignoring for noop checks, sled_id: d81c6a84-79b8-4958-ae41-ea46c9b19763, slot: b, expected_hash: 0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b
 generated blueprint ce365dff-2cdb-4f35-a186-b15e20e1e700 based on parent blueprint afb09faf-a586-4483-9289-04d4f1d8ba23
+blueprint source: planner with report:
 planning report for blueprint ce365dff-2cdb-4f35-a186-b15e20e1e700:
 * skipping noop zone image source check on sled 98e6b7c2-2efa-41ca-b20a-0a4d61102fe6: all 6 zones are already from artifacts
 * noop converting 6/6 install-dataset zones to artifact store on sled d81c6a84-79b8-4958-ae41-ea46c9b19763
@@ -1401,6 +1412,7 @@ planning report for blueprint ce365dff-2cdb-4f35-a186-b15e20e1e700:
 * zone adds and updates are blocked:
   - sleds have mupdate override errors: 2b8f0cb3-0295-4b3c-bc58-4fe88b57112c
 * zone updates waiting on zone add blockers
+
 
 
 > blueprint-show latest
@@ -1569,6 +1581,7 @@ parent:    afb09faf-a586-4483-9289-04d4f1d8ba23
 
  PENDING MGS-MANAGED UPDATES: 0
 
+blueprint source: planner with report:
 planning report for blueprint ce365dff-2cdb-4f35-a186-b15e20e1e700:
 * skipping noop zone image source check on sled 98e6b7c2-2efa-41ca-b20a-0a4d61102fe6: all 6 zones are already from artifacts
 * noop converting 6/6 install-dataset zones to artifact store on sled d81c6a84-79b8-4958-ae41-ea46c9b19763
@@ -1576,6 +1589,7 @@ planning report for blueprint ce365dff-2cdb-4f35-a186-b15e20e1e700:
 * zone adds and updates are blocked:
   - sleds have mupdate override errors: 2b8f0cb3-0295-4b3c-bc58-4fe88b57112c
 * zone updates waiting on zone add blockers
+
 
 
 
@@ -1686,12 +1700,14 @@ INFO BootPartitionDetails inventory hash not found in TUF repo, ignoring for noo
 INFO configuring MGS-driven update, artifact_version: 2.0.0, artifact_hash: 8f89bf8bc5f3271650ad72a26fc0d116c910161ca143731473a2b20fb82653cc, expected_stage0_next_version: NoValidVersion, expected_stage0_version: 0.0.1, component: rot_bootloader, sp_slot: 0, sp_type: Sled, serial_number: serial0, part_number: model0
 INFO reached maximum number of pending MGS-driven updates, max: 1
 generated blueprint 8f2d1f39-7c88-4701-aa43-56bf281b28c1 based on parent blueprint ce365dff-2cdb-4f35-a186-b15e20e1e700
+blueprint source: planner with report:
 planning report for blueprint 8f2d1f39-7c88-4701-aa43-56bf281b28c1:
 * skipping noop zone image source check on sled 98e6b7c2-2efa-41ca-b20a-0a4d61102fe6: all 6 zones are already from artifacts
 * skipping noop zone image source check on sled d81c6a84-79b8-4958-ae41-ea46c9b19763: all 6 zones are already from artifacts
 * 1 pending MGS update:
   * model0:serial0: RotBootloader(PendingMgsUpdateRotBootloaderDetails { expected_stage0_version: ArtifactVersion("0.0.1"), expected_stage0_next_version: NoValidVersion })
 * zone updates waiting on pending MGS updates (RoT / SP / Host OS / etc.)
+
 
 
 > blueprint-show latest
@@ -1866,12 +1882,14 @@ parent:    ce365dff-2cdb-4f35-a186-b15e20e1e700
     sled      0      model0        serial0         8f89bf8bc5f3271650ad72a26fc0d116c910161ca143731473a2b20fb82653cc   2.0.0              RotBootloader(PendingMgsUpdateRotBootloaderDetails { expected_stage0_version: ArtifactVersion("0.0.1"), expected_stage0_next_version: NoValidVersion })
 
 
+blueprint source: planner with report:
 planning report for blueprint 8f2d1f39-7c88-4701-aa43-56bf281b28c1:
 * skipping noop zone image source check on sled 98e6b7c2-2efa-41ca-b20a-0a4d61102fe6: all 6 zones are already from artifacts
 * skipping noop zone image source check on sled d81c6a84-79b8-4958-ae41-ea46c9b19763: all 6 zones are already from artifacts
 * 1 pending MGS update:
   * model0:serial0: RotBootloader(PendingMgsUpdateRotBootloaderDetails { expected_stage0_version: ArtifactVersion("0.0.1"), expected_stage0_next_version: NoValidVersion })
 * zone updates waiting on pending MGS updates (RoT / SP / Host OS / etc.)
+
 
 
 
@@ -1990,12 +2008,14 @@ INFO skipping board for MGS-driven update, serial_number: serial2, part_number: 
 INFO ran out of boards for MGS-driven update
 INFO some zones not yet up-to-date, sled_id: 98e6b7c2-2efa-41ca-b20a-0a4d61102fe6, zones_currently_updating: [ZoneCurrentlyUpdating { zone_id: 0c71b3b2-6ceb-4e8f-b020-b08675e83038 (service), zone_kind: Nexus, reason: ImageSourceMismatch { bp_image_source: Artifact { version: Available { version: ArtifactVersion("1.0.0") }, hash: ArtifactHash("0e32b4a3e5d3668bb1d6a16fb06b74dc60b973fa479dcee0aae3adbb52bf1388") }, inv_image_source: InstallDataset } }, ZoneCurrentlyUpdating { zone_id: 427ec88f-f467-42fa-9bbb-66a91a36103c (service), zone_kind: InternalDns, reason: ImageSourceMismatch { bp_image_source: Artifact { version: Available { version: ArtifactVersion("1.0.0") }, hash: ArtifactHash("ffbf1373f7ee08dddd74c53ed2a94e7c4c572a982d3a9bc94000c6956b700c6a") }, inv_image_source: InstallDataset } }, ZoneCurrentlyUpdating { zone_id: 5199c033-4cf9-4ab6-8ae7-566bd7606363 (service), zone_kind: Crucible, reason: ImageSourceMismatch { bp_image_source: Artifact { version: Available { version: ArtifactVersion("1.0.0") }, hash: ArtifactHash("6f17cf65fb5a5bec5542dd07c03cd0acc01e59130f02c532c8d848ecae810047") }, inv_image_source: InstallDataset } }, ZoneCurrentlyUpdating { zone_id: 6444f8a5-6465-4f0b-a549-1993c113569c (service), zone_kind: InternalNtp, reason: ImageSourceMismatch { bp_image_source: Artifact { version: Available { version: ArtifactVersion("1.0.0") }, hash: ArtifactHash("67593d686ed04a1709f93972b71f4ebc148a9362120f65d239943e814a9a7439") }, inv_image_source: InstallDataset } }, ZoneCurrentlyUpdating { zone_id: 803bfb63-c246-41db-b0da-d3b87ddfc63d (service), zone_kind: ExternalDns, reason: ImageSourceMismatch { bp_image_source: Artifact { version: Available { version: ArtifactVersion("1.0.0") }, hash: ArtifactHash("ccca13ed19b8731f9adaf0d6203b02ea3b9ede4fa426b9fac0a07ce95440046d") }, inv_image_source: InstallDataset } }, ZoneCurrentlyUpdating { zone_id: ba4994a8-23f9-4b1a-a84f-a08d74591389 (service), zone_kind: CruciblePantry, reason: ImageSourceMismatch { bp_image_source: Artifact { version: Available { version: ArtifactVersion("1.0.0") }, hash: ArtifactHash("21f0ada306859c23917361f2e0b9235806c32607ec689c7e8cf16bb898bc5a02") }, inv_image_source: InstallDataset } }]
 generated blueprint 12d602a6-5ab4-487a-b94e-eb30cdf30300 based on parent blueprint 8f2d1f39-7c88-4701-aa43-56bf281b28c1
+blueprint source: planner with report:
 planning report for blueprint 12d602a6-5ab4-487a-b94e-eb30cdf30300:
 * skipping noop zone image source check on sled 98e6b7c2-2efa-41ca-b20a-0a4d61102fe6: all 6 zones are already from artifacts
 * skipping noop zone image source check on sled d81c6a84-79b8-4958-ae41-ea46c9b19763: all 6 zones are already from artifacts
 * noop converting host phase 2 slot B to Artifact on sled 2b8f0cb3-0295-4b3c-bc58-4fe88b57112c
 * noop converting host phase 2 slot B to Artifact on sled 98e6b7c2-2efa-41ca-b20a-0a4d61102fe6
 * noop converting host phase 2 slot B to Artifact on sled d81c6a84-79b8-4958-ae41-ea46c9b19763
+
 
 
 > blueprint-diff latest
@@ -2225,6 +2245,7 @@ INFO BootPartitionDetails inventory hash not found in TUF repo, ignoring for noo
 INFO performed noop zone image source checks on sled, sled_id: d81c6a84-79b8-4958-ae41-ea46c9b19763, num_total: 6, num_already_artifact: 6, num_eligible: 0, num_ineligible: 0
 INFO BootPartitionDetails inventory hash not found in TUF repo, ignoring for noop checks, sled_id: d81c6a84-79b8-4958-ae41-ea46c9b19763, slot: a, expected_hash: 0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a
 generated blueprint 61a93ea3-c872-48e0-aace-e86b0c52b839 based on parent blueprint 12d602a6-5ab4-487a-b94e-eb30cdf30300
+blueprint source: planner with report:
 planning report for blueprint 61a93ea3-c872-48e0-aace-e86b0c52b839:
 * skipping noop zone image source check on sled c3bc4c6d-fdde-4fc4-8493-89d2a1e5ee6b: all 0 zones are already from artifacts
 * skipping noop zone image source check on sled d81c6a84-79b8-4958-ae41-ea46c9b19763: all 6 zones are already from artifacts
@@ -2233,6 +2254,7 @@ planning report for blueprint 61a93ea3-c872-48e0-aace-e86b0c52b839:
   - current target release generation (4) is lower than minimum required by blueprint (5)
   - sleds have remove mupdate override set in blueprint: 98e6b7c2-2efa-41ca-b20a-0a4d61102fe6
 * zone updates waiting on zone add blockers
+
 
 
 > blueprint-diff latest
@@ -2350,6 +2372,7 @@ INFO performed noop zone image source checks on sled, sled_id: d81c6a84-79b8-495
 INFO BootPartitionDetails inventory hash not found in TUF repo, ignoring for noop checks, sled_id: d81c6a84-79b8-4958-ae41-ea46c9b19763, slot: a, expected_hash: 0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a
 INFO altered physical disks, sled_id: c3bc4c6d-fdde-4fc4-8493-89d2a1e5ee6b, sled_edits: SledEditCounts { disks: EditCounts { added: 10, updated: 0, expunged: 0, removed: 0 }, datasets: EditCounts { added: 20, updated: 0, expunged: 0, removed: 0 }, zones: EditCounts { added: 0, updated: 0, expunged: 0, removed: 0 } }
 generated blueprint 27e755bc-dc10-4647-853c-f89bb3a15a2c based on parent blueprint 61a93ea3-c872-48e0-aace-e86b0c52b839
+blueprint source: planner with report:
 planning report for blueprint 27e755bc-dc10-4647-853c-f89bb3a15a2c:
 planner config:
     add zones with mupdate override:   true
@@ -2363,6 +2386,7 @@ planner config:
 * discretionary zone placement waiting for NTP zones on sleds: c3bc4c6d-fdde-4fc4-8493-89d2a1e5ee6b
 * missing NTP zone on sled c3bc4c6d-fdde-4fc4-8493-89d2a1e5ee6b
 * zone updates waiting on zone add blockers
+
 
 
 > blueprint-diff latest

--- a/dev-tools/reconfigurator-cli/tests/output/cmds-noop-image-source-stdout
+++ b/dev-tools/reconfigurator-cli/tests/output/cmds-noop-image-source-stdout
@@ -177,6 +177,7 @@ INFO BootPartitionDetails inventory hash not found in TUF repo, ignoring for noo
 INFO skipped noop image source check on sled, sled_id: d81c6a84-79b8-4958-ae41-ea46c9b19763, reason: remove_mupdate_override is set in the blueprint (ffffffff-ffff-ffff-ffff-ffffffffffff)
 INFO skipped noop image source check on sled, sled_id: e96e226f-4ed9-4c01-91b9-69a9cd076c9e, reason: sled not found in inventory
 generated blueprint 58d5e830-0884-47d8-a7cd-b2b3751adeb4 based on parent blueprint 8da82a8e-bf97-4fbd-8ddd-9f6462732cf1
+blueprint source: planner with report:
 planning report for blueprint 58d5e830-0884-47d8-a7cd-b2b3751adeb4:
 * noop converting 6/6 install-dataset zones to artifact store on sled 98e6b7c2-2efa-41ca-b20a-0a4d61102fe6
 * noop converting 5/6 install-dataset zones to artifact store on sled aff6c093-197d-42c5-ad80-9f10ba051a34
@@ -184,6 +185,7 @@ planning report for blueprint 58d5e830-0884-47d8-a7cd-b2b3751adeb4:
 * zone adds and updates are blocked:
   - sleds have remove mupdate override set in blueprint: d81c6a84-79b8-4958-ae41-ea46c9b19763
 * zone updates waiting on zone add blockers
+
 
 
 
@@ -415,6 +417,7 @@ INFO performed noop zone image source checks on sled, sled_id: e96e226f-4ed9-4c0
 INFO BootPartitionDetails inventory hash not found in TUF repo, ignoring for noop checks, sled_id: e96e226f-4ed9-4c01-91b9-69a9cd076c9e, slot: a, expected_hash: 0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a
 INFO BootPartitionDetails inventory hash not found in TUF repo, ignoring for noop checks, sled_id: e96e226f-4ed9-4c01-91b9-69a9cd076c9e, slot: b, expected_hash: 0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b
 generated blueprint af934083-59b5-4bf6-8966-6fb5292c29e1 based on parent blueprint 58d5e830-0884-47d8-a7cd-b2b3751adeb4
+blueprint source: planner with report:
 planning report for blueprint af934083-59b5-4bf6-8966-6fb5292c29e1:
 * skipping noop zone image source check on sled 98e6b7c2-2efa-41ca-b20a-0a4d61102fe6: all 6 zones are already from artifacts
 * noop converting 2/2 install-dataset zones to artifact store on sled e96e226f-4ed9-4c01-91b9-69a9cd076c9e
@@ -422,6 +425,7 @@ planning report for blueprint af934083-59b5-4bf6-8966-6fb5292c29e1:
 * zone adds and updates are blocked:
   - sleds have remove mupdate override set in blueprint: d81c6a84-79b8-4958-ae41-ea46c9b19763
 * zone updates waiting on zone add blockers
+
 
 
 

--- a/dev-tools/reconfigurator-cli/tests/output/cmds-set-mgs-updates-stdout
+++ b/dev-tools/reconfigurator-cli/tests/output/cmds-set-mgs-updates-stdout
@@ -209,7 +209,7 @@ parent:    6ccc786b-17f1-4562-958f-5a7d9a5a15fd
 
  PENDING MGS-MANAGED UPDATES: 0
 
-empty planning report for blueprint ad97e762-7bf1-45a6-a98f-60afb7e491c0.
+blueprint source: test
 
 
 
@@ -427,7 +427,7 @@ parent:    ad97e762-7bf1-45a6-a98f-60afb7e491c0
     sled      2      model2        serial2         e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855   1.1.0              Sp(PendingMgsUpdateSpDetails { expected_active_version: ArtifactVersion("1.0.0"), expected_inactive_version: Version(ArtifactVersion("1.0.1")) })
 
 
-empty planning report for blueprint cca24b71-09b5-4042-9185-b33e9f2ebba0.
+blueprint source: reconfigurator-cli
 
 
 
@@ -721,7 +721,7 @@ parent:    cca24b71-09b5-4042-9185-b33e9f2ebba0
     sled      2      model2        serial2         e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855   newest             Sp(PendingMgsUpdateSpDetails { expected_active_version: ArtifactVersion("newer"), expected_inactive_version: Version(ArtifactVersion("older")) })
 
 
-empty planning report for blueprint 5bf974f3-81f9-455b-b24e-3099f765664c.
+blueprint source: reconfigurator-cli
 
 
 
@@ -1019,7 +1019,7 @@ parent:    5bf974f3-81f9-455b-b24e-3099f765664c
     sled      2      model2        serial2         e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855   newest             Sp(PendingMgsUpdateSpDetails { expected_active_version: ArtifactVersion("newer"), expected_inactive_version: Version(ArtifactVersion("older")) })
 
 
-empty planning report for blueprint 1b837a27-3be1-4fcb-8499-a921c839e1d0.
+blueprint source: reconfigurator-cli
 
 
 
@@ -1274,7 +1274,7 @@ parent:    1b837a27-3be1-4fcb-8499-a921c839e1d0
     sled      0      model0        serial0         e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855   three              Sp(PendingMgsUpdateSpDetails { expected_active_version: ArtifactVersion("two"), expected_inactive_version: NoValidVersion })
 
 
-empty planning report for blueprint 3682a71b-c6ca-4b7e-8f84-16df80c85960.
+blueprint source: reconfigurator-cli
 
 
 

--- a/dev-tools/reconfigurator-cli/tests/output/cmds-set-remove-mupdate-override-stdout
+++ b/dev-tools/reconfigurator-cli/tests/output/cmds-set-remove-mupdate-override-stdout
@@ -364,7 +364,7 @@ parent:    df06bb57-ad42-4431-9206-abff322896c7
 
  PENDING MGS-MANAGED UPDATES: 0
 
-empty planning report for blueprint 7f976e0d-d2a5-4eeb-9e82-c82bc2824aba.
+blueprint source: reconfigurator-cli
 
 
 
@@ -990,7 +990,7 @@ parent:    afb09faf-a586-4483-9289-04d4f1d8ba23
 
  PENDING MGS-MANAGED UPDATES: 0
 
-empty planning report for blueprint ce365dff-2cdb-4f35-a186-b15e20e1e700.
+blueprint source: reconfigurator-cli
 
 
 

--- a/dev-tools/reconfigurator-cli/tests/output/cmds-set-zone-images-stdout
+++ b/dev-tools/reconfigurator-cli/tests/output/cmds-set-zone-images-stdout
@@ -111,7 +111,7 @@ parent:    1b013011-2062-4b48-b544-a32b23bce83a
 
  PENDING MGS-MANAGED UPDATES: 0
 
-empty planning report for blueprint 971eeb12-1830-4fa0-a699-98ea0164505c.
+blueprint source: test
 
 
 
@@ -230,7 +230,7 @@ parent:    9766ca20-38d4-4380-b005-e7c43c797e7c
 
  PENDING MGS-MANAGED UPDATES: 0
 
-empty planning report for blueprint f714e6ea-e85a-4d7d-93c2-a018744fe176.
+blueprint source: reconfigurator-cli
 
 
 
@@ -462,7 +462,7 @@ parent:    bb128f06-a2e1-44c1-8874-4f789d0ff896
 
  PENDING MGS-MANAGED UPDATES: 0
 
-empty planning report for blueprint d9c572a1-a68c-4945-b1ec-5389bd588fe9.
+blueprint source: reconfigurator-cli
 
 
 

--- a/dev-tools/reconfigurator-cli/tests/output/cmds-target-release-stdout
+++ b/dev-tools/reconfigurator-cli/tests/output/cmds-target-release-stdout
@@ -215,10 +215,12 @@ INFO BootPartitionDetails inventory hash not found in TUF repo, ignoring for noo
 INFO configuring MGS-driven update, artifact_version: 1.0.0, artifact_hash: 5b0f601b1fbb8674db9c751a02f8b14f8e6d4e8470f4f7b686fecb2c49ec11f9, expected_stage0_next_version: NoValidVersion, expected_stage0_version: 0.0.1, component: rot_bootloader, sp_slot: 0, sp_type: Sled, serial_number: serial0, part_number: model0
 INFO reached maximum number of pending MGS-driven updates, max: 1
 generated blueprint 8da82a8e-bf97-4fbd-8ddd-9f6462732cf1 based on parent blueprint dbcbd3d6-41ff-48ae-ac0b-1becc9b2fd21
+blueprint source: planner with report:
 planning report for blueprint 8da82a8e-bf97-4fbd-8ddd-9f6462732cf1:
 * 1 pending MGS update:
   * model0:serial0: RotBootloader(PendingMgsUpdateRotBootloaderDetails { expected_stage0_version: ArtifactVersion("0.0.1"), expected_stage0_next_version: NoValidVersion })
 * zone updates waiting on pending MGS updates (RoT / SP / Host OS / etc.)
+
 
 
 > blueprint-diff latest
@@ -273,10 +275,12 @@ INFO BootPartitionDetails inventory hash not found in TUF repo, ignoring for noo
 INFO MGS-driven update not yet completed (will keep it), artifact_version: 1.0.0, artifact_hash: 5b0f601b1fbb8674db9c751a02f8b14f8e6d4e8470f4f7b686fecb2c49ec11f9, expected_stage0_next_version: NoValidVersion, expected_stage0_version: 0.0.1, component: rot_bootloader, sp_slot: 0, sp_type: Sled, serial_number: serial0, part_number: model0
 INFO reached maximum number of pending MGS-driven updates, max: 1
 generated blueprint 58d5e830-0884-47d8-a7cd-b2b3751adeb4 based on parent blueprint 8da82a8e-bf97-4fbd-8ddd-9f6462732cf1
+blueprint source: planner with report:
 planning report for blueprint 58d5e830-0884-47d8-a7cd-b2b3751adeb4:
 * 1 pending MGS update:
   * model0:serial0: RotBootloader(PendingMgsUpdateRotBootloaderDetails { expected_stage0_version: ArtifactVersion("0.0.1"), expected_stage0_next_version: NoValidVersion })
 * zone updates waiting on pending MGS updates (RoT / SP / Host OS / etc.)
+
 
 
 > blueprint-diff latest
@@ -333,10 +337,12 @@ INFO MGS-driven update completed (will remove it and re-evaluate board), artifac
 INFO configuring MGS-driven update, artifact_version: 1.0.0, artifact_hash: d11e65f934bf0de51df2e5b484f61ee72072417b43ac87f33e958008428e7b02, expected_transient_boot_preference: None, expected_pending_persistent_boot_preference: None, expected_persistent_boot_preference: A, expected_active_slot: ExpectedActiveRotSlot { slot: A, version: ArtifactVersion("0.0.2") }, expected_inactive_version: NoValidVersion, component: rot, sp_slot: 0, sp_type: Sled, serial_number: serial0, part_number: model0
 INFO reached maximum number of pending MGS-driven updates, max: 1
 generated blueprint af934083-59b5-4bf6-8966-6fb5292c29e1 based on parent blueprint 58d5e830-0884-47d8-a7cd-b2b3751adeb4
+blueprint source: planner with report:
 planning report for blueprint af934083-59b5-4bf6-8966-6fb5292c29e1:
 * 1 pending MGS update:
   * model0:serial0: Rot(PendingMgsUpdateRotDetails { expected_active_slot: ExpectedActiveRotSlot { slot: A, version: ArtifactVersion("0.0.2") }, expected_inactive_version: NoValidVersion, expected_persistent_boot_preference: A, expected_pending_persistent_boot_preference: None, expected_transient_boot_preference: None })
 * zone updates waiting on pending MGS updates (RoT / SP / Host OS / etc.)
+
 
 
 > blueprint-diff latest
@@ -402,10 +408,12 @@ INFO MGS-driven update completed (will remove it and re-evaluate board), artifac
 INFO configuring MGS-driven update, artifact_version: 1.0.0, artifact_hash: 68465b8e3f808f475510b525cfd62086d37ddd57688bd854184fdafb2b2198a4, expected_inactive_version: NoValidVersion, expected_active_version: 0.0.1, component: sp, sp_slot: 0, sp_type: Sled, serial_number: serial0, part_number: model0
 INFO reached maximum number of pending MGS-driven updates, max: 1
 generated blueprint df06bb57-ad42-4431-9206-abff322896c7 based on parent blueprint af934083-59b5-4bf6-8966-6fb5292c29e1
+blueprint source: planner with report:
 planning report for blueprint df06bb57-ad42-4431-9206-abff322896c7:
 * 1 pending MGS update:
   * model0:serial0: Sp(PendingMgsUpdateSpDetails { expected_active_version: ArtifactVersion("0.0.1"), expected_inactive_version: NoValidVersion })
 * zone updates waiting on pending MGS updates (RoT / SP / Host OS / etc.)
+
 
 
 > blueprint-diff latest
@@ -472,10 +480,12 @@ INFO MGS-driven update completed (will remove it and re-evaluate board), artifac
 INFO configuring MGS-driven update, artifact_version: 1.0.0, artifact_hash: 2053f8594971bbf0a7326c833e2ffc12b065b9d823b9c0b967d275fa595e4e89, sled_agent_address: [fd00:1122:3344:101::1]:12345, expected_inactive_phase_2_hash: f3dd0c7a1bd4500ea0d8bcf67581f576d47752b2f1998a4cb0f0c3155c483008, expected_inactive_phase_1_hash: 0202020202020202020202020202020202020202020202020202020202020202, expected_active_phase_2_hash: 0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a, expected_active_phase_1_hash: 0101010101010101010101010101010101010101010101010101010101010101, expected_boot_disk: A, expected_active_phase_1_slot: A, component: host_phase_1, sp_slot: 0, sp_type: Sled, serial_number: serial0, part_number: model0
 INFO reached maximum number of pending MGS-driven updates, max: 1
 generated blueprint 7f976e0d-d2a5-4eeb-9e82-c82bc2824aba based on parent blueprint df06bb57-ad42-4431-9206-abff322896c7
+blueprint source: planner with report:
 planning report for blueprint 7f976e0d-d2a5-4eeb-9e82-c82bc2824aba:
 * 1 pending MGS update:
   * model0:serial0: HostPhase1(PendingMgsUpdateHostPhase1Details { expected_active_phase_1_slot: A, expected_boot_disk: A, expected_active_phase_1_hash: ArtifactHash("0101010101010101010101010101010101010101010101010101010101010101"), expected_active_phase_2_hash: ArtifactHash("0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a"), expected_inactive_phase_1_hash: ArtifactHash("0202020202020202020202020202020202020202020202020202020202020202"), expected_inactive_phase_2_hash: ArtifactHash("f3dd0c7a1bd4500ea0d8bcf67581f576d47752b2f1998a4cb0f0c3155c483008"), sled_agent_address: [fd00:1122:3344:101::1]:12345 })
 * zone updates waiting on pending MGS updates (RoT / SP / Host OS / etc.)
+
 
 
 > blueprint-diff latest
@@ -591,10 +601,12 @@ INFO BootPartitionDetails inventory hash not found in TUF repo, ignoring for noo
 INFO MGS-driven update not yet completed (will keep it), artifact_version: 1.0.0, artifact_hash: 2053f8594971bbf0a7326c833e2ffc12b065b9d823b9c0b967d275fa595e4e89, sled_agent_address: [fd00:1122:3344:101::1]:12345, expected_inactive_phase_2_hash: f3dd0c7a1bd4500ea0d8bcf67581f576d47752b2f1998a4cb0f0c3155c483008, expected_inactive_phase_1_hash: 0202020202020202020202020202020202020202020202020202020202020202, expected_active_phase_2_hash: 0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a, expected_active_phase_1_hash: 0101010101010101010101010101010101010101010101010101010101010101, expected_boot_disk: A, expected_active_phase_1_slot: A, component: host_phase_1, sp_slot: 0, sp_type: Sled, serial_number: serial0, part_number: model0
 INFO reached maximum number of pending MGS-driven updates, max: 1
 generated blueprint 9034c710-3e57-45f3-99e5-4316145e87ac based on parent blueprint 7f976e0d-d2a5-4eeb-9e82-c82bc2824aba
+blueprint source: planner with report:
 planning report for blueprint 9034c710-3e57-45f3-99e5-4316145e87ac:
 * 1 pending MGS update:
   * model0:serial0: HostPhase1(PendingMgsUpdateHostPhase1Details { expected_active_phase_1_slot: A, expected_boot_disk: A, expected_active_phase_1_hash: ArtifactHash("0101010101010101010101010101010101010101010101010101010101010101"), expected_active_phase_2_hash: ArtifactHash("0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a"), expected_inactive_phase_1_hash: ArtifactHash("0202020202020202020202020202020202020202020202020202020202020202"), expected_inactive_phase_2_hash: ArtifactHash("f3dd0c7a1bd4500ea0d8bcf67581f576d47752b2f1998a4cb0f0c3155c483008"), sled_agent_address: [fd00:1122:3344:101::1]:12345 })
 * zone updates waiting on pending MGS updates (RoT / SP / Host OS / etc.)
+
 
 
 > blueprint-diff latest
@@ -650,10 +662,12 @@ INFO BootPartitionDetails inventory hash not found in TUF repo, ignoring for noo
 INFO MGS-driven update not yet completed (will keep it), artifact_version: 1.0.0, artifact_hash: 2053f8594971bbf0a7326c833e2ffc12b065b9d823b9c0b967d275fa595e4e89, sled_agent_address: [fd00:1122:3344:101::1]:12345, expected_inactive_phase_2_hash: f3dd0c7a1bd4500ea0d8bcf67581f576d47752b2f1998a4cb0f0c3155c483008, expected_inactive_phase_1_hash: 0202020202020202020202020202020202020202020202020202020202020202, expected_active_phase_2_hash: 0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a, expected_active_phase_1_hash: 0101010101010101010101010101010101010101010101010101010101010101, expected_boot_disk: A, expected_active_phase_1_slot: A, component: host_phase_1, sp_slot: 0, sp_type: Sled, serial_number: serial0, part_number: model0
 INFO reached maximum number of pending MGS-driven updates, max: 1
 generated blueprint d60afc57-f15d-476c-bd0f-b1071e2bb976 based on parent blueprint 9034c710-3e57-45f3-99e5-4316145e87ac
+blueprint source: planner with report:
 planning report for blueprint d60afc57-f15d-476c-bd0f-b1071e2bb976:
 * 1 pending MGS update:
   * model0:serial0: HostPhase1(PendingMgsUpdateHostPhase1Details { expected_active_phase_1_slot: A, expected_boot_disk: A, expected_active_phase_1_hash: ArtifactHash("0101010101010101010101010101010101010101010101010101010101010101"), expected_active_phase_2_hash: ArtifactHash("0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a"), expected_inactive_phase_1_hash: ArtifactHash("0202020202020202020202020202020202020202020202020202020202020202"), expected_inactive_phase_2_hash: ArtifactHash("f3dd0c7a1bd4500ea0d8bcf67581f576d47752b2f1998a4cb0f0c3155c483008"), sled_agent_address: [fd00:1122:3344:101::1]:12345 })
 * zone updates waiting on pending MGS updates (RoT / SP / Host OS / etc.)
+
 
 
 > blueprint-diff latest
@@ -708,10 +722,12 @@ INFO BootPartitionDetails inventory hash not found in TUF repo, ignoring for noo
 INFO keeping apparently-impossible MGS-driven update (waiting for recent update to be applied), artifact_version: 1.0.0, artifact_hash: 2053f8594971bbf0a7326c833e2ffc12b065b9d823b9c0b967d275fa595e4e89, sled_agent_address: [fd00:1122:3344:101::1]:12345, expected_inactive_phase_2_hash: f3dd0c7a1bd4500ea0d8bcf67581f576d47752b2f1998a4cb0f0c3155c483008, expected_inactive_phase_1_hash: 0202020202020202020202020202020202020202020202020202020202020202, expected_active_phase_2_hash: 0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a, expected_active_phase_1_hash: 0101010101010101010101010101010101010101010101010101010101010101, expected_boot_disk: A, expected_active_phase_1_slot: A, component: host_phase_1, sp_slot: 0, sp_type: Sled, serial_number: serial0, part_number: model0
 INFO reached maximum number of pending MGS-driven updates, max: 1
 generated blueprint a5a8f242-ffa5-473c-8efd-2acf2dc0b736 based on parent blueprint d60afc57-f15d-476c-bd0f-b1071e2bb976
+blueprint source: planner with report:
 planning report for blueprint a5a8f242-ffa5-473c-8efd-2acf2dc0b736:
 * 1 pending MGS update:
   * model0:serial0: HostPhase1(PendingMgsUpdateHostPhase1Details { expected_active_phase_1_slot: A, expected_boot_disk: A, expected_active_phase_1_hash: ArtifactHash("0101010101010101010101010101010101010101010101010101010101010101"), expected_active_phase_2_hash: ArtifactHash("0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a"), expected_inactive_phase_1_hash: ArtifactHash("0202020202020202020202020202020202020202020202020202020202020202"), expected_inactive_phase_2_hash: ArtifactHash("f3dd0c7a1bd4500ea0d8bcf67581f576d47752b2f1998a4cb0f0c3155c483008"), sled_agent_address: [fd00:1122:3344:101::1]:12345 })
 * zone updates waiting on pending MGS updates (RoT / SP / Host OS / etc.)
+
 
 
 > blueprint-diff latest
@@ -768,10 +784,12 @@ INFO skipping board for MGS-driven update, serial_number: serial0, part_number: 
 INFO configuring MGS-driven update, artifact_version: 1.0.0, artifact_hash: 5b0f601b1fbb8674db9c751a02f8b14f8e6d4e8470f4f7b686fecb2c49ec11f9, expected_stage0_next_version: NoValidVersion, expected_stage0_version: 0.0.1, component: rot_bootloader, sp_slot: 1, sp_type: Sled, serial_number: serial1, part_number: model1
 INFO reached maximum number of pending MGS-driven updates, max: 1
 generated blueprint 626487fa-7139-45ec-8416-902271fc730b based on parent blueprint a5a8f242-ffa5-473c-8efd-2acf2dc0b736
+blueprint source: planner with report:
 planning report for blueprint 626487fa-7139-45ec-8416-902271fc730b:
 * 1 pending MGS update:
   * model1:serial1: RotBootloader(PendingMgsUpdateRotBootloaderDetails { expected_stage0_version: ArtifactVersion("0.0.1"), expected_stage0_next_version: NoValidVersion })
 * zone updates waiting on pending MGS updates (RoT / SP / Host OS / etc.)
+
 
 
 > blueprint-diff latest
@@ -839,10 +857,12 @@ INFO MGS-driven update impossible (will remove it and re-evaluate board), artifa
 INFO configuring MGS-driven update, artifact_version: 1.0.0, artifact_hash: 5b0f601b1fbb8674db9c751a02f8b14f8e6d4e8470f4f7b686fecb2c49ec11f9, expected_stage0_next_version: Version(ArtifactVersion("0.5.0")), expected_stage0_version: 0.0.1, component: rot_bootloader, sp_slot: 1, sp_type: Sled, serial_number: serial1, part_number: model1
 INFO reached maximum number of pending MGS-driven updates, max: 1
 generated blueprint c1a0d242-9160-40f4-96ae-61f8f40a0b1b based on parent blueprint 626487fa-7139-45ec-8416-902271fc730b
+blueprint source: planner with report:
 planning report for blueprint c1a0d242-9160-40f4-96ae-61f8f40a0b1b:
 * 1 pending MGS update:
   * model1:serial1: RotBootloader(PendingMgsUpdateRotBootloaderDetails { expected_stage0_version: ArtifactVersion("0.0.1"), expected_stage0_next_version: Version(ArtifactVersion("0.5.0")) })
 * zone updates waiting on pending MGS updates (RoT / SP / Host OS / etc.)
+
 
 
 > blueprint-diff latest
@@ -905,10 +925,12 @@ INFO MGS-driven update completed (will remove it and re-evaluate board), artifac
 INFO configuring MGS-driven update, artifact_version: 1.0.0, artifact_hash: d11e65f934bf0de51df2e5b484f61ee72072417b43ac87f33e958008428e7b02, expected_transient_boot_preference: None, expected_pending_persistent_boot_preference: None, expected_persistent_boot_preference: A, expected_active_slot: ExpectedActiveRotSlot { slot: A, version: ArtifactVersion("0.0.2") }, expected_inactive_version: NoValidVersion, component: rot, sp_slot: 1, sp_type: Sled, serial_number: serial1, part_number: model1
 INFO reached maximum number of pending MGS-driven updates, max: 1
 generated blueprint afb09faf-a586-4483-9289-04d4f1d8ba23 based on parent blueprint c1a0d242-9160-40f4-96ae-61f8f40a0b1b
+blueprint source: planner with report:
 planning report for blueprint afb09faf-a586-4483-9289-04d4f1d8ba23:
 * 1 pending MGS update:
   * model1:serial1: Rot(PendingMgsUpdateRotDetails { expected_active_slot: ExpectedActiveRotSlot { slot: A, version: ArtifactVersion("0.0.2") }, expected_inactive_version: NoValidVersion, expected_persistent_boot_preference: A, expected_pending_persistent_boot_preference: None, expected_transient_boot_preference: None })
 * zone updates waiting on pending MGS updates (RoT / SP / Host OS / etc.)
+
 
 
 > blueprint-diff latest
@@ -975,10 +997,12 @@ INFO MGS-driven update impossible (will remove it and re-evaluate board), artifa
 INFO configuring MGS-driven update, artifact_version: 1.0.0, artifact_hash: d11e65f934bf0de51df2e5b484f61ee72072417b43ac87f33e958008428e7b02, expected_transient_boot_preference: None, expected_pending_persistent_boot_preference: None, expected_persistent_boot_preference: A, expected_active_slot: ExpectedActiveRotSlot { slot: A, version: ArtifactVersion("0.0.2") }, expected_inactive_version: Version(ArtifactVersion("0.5.0")), component: rot, sp_slot: 1, sp_type: Sled, serial_number: serial1, part_number: model1
 INFO reached maximum number of pending MGS-driven updates, max: 1
 generated blueprint ce365dff-2cdb-4f35-a186-b15e20e1e700 based on parent blueprint afb09faf-a586-4483-9289-04d4f1d8ba23
+blueprint source: planner with report:
 planning report for blueprint ce365dff-2cdb-4f35-a186-b15e20e1e700:
 * 1 pending MGS update:
   * model1:serial1: Rot(PendingMgsUpdateRotDetails { expected_active_slot: ExpectedActiveRotSlot { slot: A, version: ArtifactVersion("0.0.2") }, expected_inactive_version: Version(ArtifactVersion("0.5.0")), expected_persistent_boot_preference: A, expected_pending_persistent_boot_preference: None, expected_transient_boot_preference: None })
 * zone updates waiting on pending MGS updates (RoT / SP / Host OS / etc.)
+
 
 
 > blueprint-diff latest
@@ -1041,10 +1065,12 @@ INFO MGS-driven update completed (will remove it and re-evaluate board), artifac
 INFO configuring MGS-driven update, artifact_version: 1.0.0, artifact_hash: 68465b8e3f808f475510b525cfd62086d37ddd57688bd854184fdafb2b2198a4, expected_inactive_version: NoValidVersion, expected_active_version: 0.0.1, component: sp, sp_slot: 1, sp_type: Sled, serial_number: serial1, part_number: model1
 INFO reached maximum number of pending MGS-driven updates, max: 1
 generated blueprint 8f2d1f39-7c88-4701-aa43-56bf281b28c1 based on parent blueprint ce365dff-2cdb-4f35-a186-b15e20e1e700
+blueprint source: planner with report:
 planning report for blueprint 8f2d1f39-7c88-4701-aa43-56bf281b28c1:
 * 1 pending MGS update:
   * model1:serial1: Sp(PendingMgsUpdateSpDetails { expected_active_version: ArtifactVersion("0.0.1"), expected_inactive_version: NoValidVersion })
 * zone updates waiting on pending MGS updates (RoT / SP / Host OS / etc.)
+
 
 
 > blueprint-diff latest
@@ -1110,10 +1136,12 @@ INFO MGS-driven update impossible (will remove it and re-evaluate board), artifa
 INFO configuring MGS-driven update, artifact_version: 1.0.0, artifact_hash: 68465b8e3f808f475510b525cfd62086d37ddd57688bd854184fdafb2b2198a4, expected_inactive_version: Version(ArtifactVersion("0.5.0")), expected_active_version: 0.0.1, component: sp, sp_slot: 1, sp_type: Sled, serial_number: serial1, part_number: model1
 INFO reached maximum number of pending MGS-driven updates, max: 1
 generated blueprint 12d602a6-5ab4-487a-b94e-eb30cdf30300 based on parent blueprint 8f2d1f39-7c88-4701-aa43-56bf281b28c1
+blueprint source: planner with report:
 planning report for blueprint 12d602a6-5ab4-487a-b94e-eb30cdf30300:
 * 1 pending MGS update:
   * model1:serial1: Sp(PendingMgsUpdateSpDetails { expected_active_version: ArtifactVersion("0.0.1"), expected_inactive_version: Version(ArtifactVersion("0.5.0")) })
 * zone updates waiting on pending MGS updates (RoT / SP / Host OS / etc.)
+
 
 
 > blueprint-diff latest
@@ -1177,10 +1205,12 @@ INFO MGS-driven update completed (will remove it and re-evaluate board), artifac
 INFO configuring MGS-driven update, artifact_version: 1.0.0, artifact_hash: 2053f8594971bbf0a7326c833e2ffc12b065b9d823b9c0b967d275fa595e4e89, sled_agent_address: [fd00:1122:3344:102::1]:12345, expected_inactive_phase_2_hash: f3dd0c7a1bd4500ea0d8bcf67581f576d47752b2f1998a4cb0f0c3155c483008, expected_inactive_phase_1_hash: 0202020202020202020202020202020202020202020202020202020202020202, expected_active_phase_2_hash: 0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a, expected_active_phase_1_hash: 0101010101010101010101010101010101010101010101010101010101010101, expected_boot_disk: A, expected_active_phase_1_slot: A, component: host_phase_1, sp_slot: 1, sp_type: Sled, serial_number: serial1, part_number: model1
 INFO reached maximum number of pending MGS-driven updates, max: 1
 generated blueprint 61a93ea3-c872-48e0-aace-e86b0c52b839 based on parent blueprint 12d602a6-5ab4-487a-b94e-eb30cdf30300
+blueprint source: planner with report:
 planning report for blueprint 61a93ea3-c872-48e0-aace-e86b0c52b839:
 * 1 pending MGS update:
   * model1:serial1: HostPhase1(PendingMgsUpdateHostPhase1Details { expected_active_phase_1_slot: A, expected_boot_disk: A, expected_active_phase_1_hash: ArtifactHash("0101010101010101010101010101010101010101010101010101010101010101"), expected_active_phase_2_hash: ArtifactHash("0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a"), expected_inactive_phase_1_hash: ArtifactHash("0202020202020202020202020202020202020202020202020202020202020202"), expected_inactive_phase_2_hash: ArtifactHash("f3dd0c7a1bd4500ea0d8bcf67581f576d47752b2f1998a4cb0f0c3155c483008"), sled_agent_address: [fd00:1122:3344:102::1]:12345 })
 * zone updates waiting on pending MGS updates (RoT / SP / Host OS / etc.)
+
 
 
 > blueprint-diff latest
@@ -1311,10 +1341,12 @@ INFO MGS-driven update impossible (will remove it and re-evaluate board), artifa
 INFO configuring MGS-driven update, artifact_version: 1.0.0, artifact_hash: 2053f8594971bbf0a7326c833e2ffc12b065b9d823b9c0b967d275fa595e4e89, sled_agent_address: [fd00:1122:3344:102::1]:12345, expected_inactive_phase_2_hash: f3dd0c7a1bd4500ea0d8bcf67581f576d47752b2f1998a4cb0f0c3155c483008, expected_inactive_phase_1_hash: ffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff, expected_active_phase_2_hash: 0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a, expected_active_phase_1_hash: 0101010101010101010101010101010101010101010101010101010101010101, expected_boot_disk: A, expected_active_phase_1_slot: A, component: host_phase_1, sp_slot: 1, sp_type: Sled, serial_number: serial1, part_number: model1
 INFO reached maximum number of pending MGS-driven updates, max: 1
 generated blueprint 27e755bc-dc10-4647-853c-f89bb3a15a2c based on parent blueprint 61a93ea3-c872-48e0-aace-e86b0c52b839
+blueprint source: planner with report:
 planning report for blueprint 27e755bc-dc10-4647-853c-f89bb3a15a2c:
 * 1 pending MGS update:
   * model1:serial1: HostPhase1(PendingMgsUpdateHostPhase1Details { expected_active_phase_1_slot: A, expected_boot_disk: A, expected_active_phase_1_hash: ArtifactHash("0101010101010101010101010101010101010101010101010101010101010101"), expected_active_phase_2_hash: ArtifactHash("0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a"), expected_inactive_phase_1_hash: ArtifactHash("ffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff"), expected_inactive_phase_2_hash: ArtifactHash("f3dd0c7a1bd4500ea0d8bcf67581f576d47752b2f1998a4cb0f0c3155c483008"), sled_agent_address: [fd00:1122:3344:102::1]:12345 })
 * zone updates waiting on pending MGS updates (RoT / SP / Host OS / etc.)
+
 
 
 > blueprint-diff latest
@@ -1383,10 +1415,12 @@ INFO skipping board for MGS-driven update, serial_number: serial0, part_number: 
 INFO configuring MGS-driven update, artifact_version: 1.0.0, artifact_hash: 5b0f601b1fbb8674db9c751a02f8b14f8e6d4e8470f4f7b686fecb2c49ec11f9, expected_stage0_next_version: NoValidVersion, expected_stage0_version: 0.0.1, component: rot_bootloader, sp_slot: 2, sp_type: Sled, serial_number: serial2, part_number: model2
 INFO ran out of boards for MGS-driven update
 generated blueprint 9f89efdf-a23e-4137-b7cc-79f4a91cbe1f based on parent blueprint 27e755bc-dc10-4647-853c-f89bb3a15a2c
+blueprint source: planner with report:
 planning report for blueprint 9f89efdf-a23e-4137-b7cc-79f4a91cbe1f:
 * 1 pending MGS update:
   * model2:serial2: RotBootloader(PendingMgsUpdateRotBootloaderDetails { expected_stage0_version: ArtifactVersion("0.0.1"), expected_stage0_next_version: NoValidVersion })
 * zone updates waiting on pending MGS updates (RoT / SP / Host OS / etc.)
+
 
 
 > blueprint-diff latest
@@ -1448,10 +1482,12 @@ INFO MGS-driven update completed (will remove it and re-evaluate board), artifac
 INFO configuring MGS-driven update, artifact_version: 1.0.0, artifact_hash: d11e65f934bf0de51df2e5b484f61ee72072417b43ac87f33e958008428e7b02, expected_transient_boot_preference: None, expected_pending_persistent_boot_preference: None, expected_persistent_boot_preference: A, expected_active_slot: ExpectedActiveRotSlot { slot: A, version: ArtifactVersion("0.0.2") }, expected_inactive_version: NoValidVersion, component: rot, sp_slot: 2, sp_type: Sled, serial_number: serial2, part_number: model2
 INFO reached maximum number of pending MGS-driven updates, max: 1
 generated blueprint 9a9e6c32-5a84-4020-a159-33dceff18d35 based on parent blueprint 9f89efdf-a23e-4137-b7cc-79f4a91cbe1f
+blueprint source: planner with report:
 planning report for blueprint 9a9e6c32-5a84-4020-a159-33dceff18d35:
 * 1 pending MGS update:
   * model2:serial2: Rot(PendingMgsUpdateRotDetails { expected_active_slot: ExpectedActiveRotSlot { slot: A, version: ArtifactVersion("0.0.2") }, expected_inactive_version: NoValidVersion, expected_persistent_boot_preference: A, expected_pending_persistent_boot_preference: None, expected_transient_boot_preference: None })
 * zone updates waiting on pending MGS updates (RoT / SP / Host OS / etc.)
+
 
 
 > blueprint-diff latest
@@ -1517,10 +1553,12 @@ INFO MGS-driven update impossible (will remove it and re-evaluate board), artifa
 INFO configuring MGS-driven update, artifact_version: 1.0.0, artifact_hash: d11e65f934bf0de51df2e5b484f61ee72072417b43ac87f33e958008428e7b02, expected_transient_boot_preference: None, expected_pending_persistent_boot_preference: None, expected_persistent_boot_preference: B, expected_active_slot: ExpectedActiveRotSlot { slot: A, version: ArtifactVersion("0.0.2") }, expected_inactive_version: Version(ArtifactVersion("1.0.0")), component: rot, sp_slot: 2, sp_type: Sled, serial_number: serial2, part_number: model2
 INFO reached maximum number of pending MGS-driven updates, max: 1
 generated blueprint 13cfdd24-52ba-4e94-8c83-02e3a48fc746 based on parent blueprint 9a9e6c32-5a84-4020-a159-33dceff18d35
+blueprint source: planner with report:
 planning report for blueprint 13cfdd24-52ba-4e94-8c83-02e3a48fc746:
 * 1 pending MGS update:
   * model2:serial2: Rot(PendingMgsUpdateRotDetails { expected_active_slot: ExpectedActiveRotSlot { slot: A, version: ArtifactVersion("0.0.2") }, expected_inactive_version: Version(ArtifactVersion("1.0.0")), expected_persistent_boot_preference: B, expected_pending_persistent_boot_preference: None, expected_transient_boot_preference: None })
 * zone updates waiting on pending MGS updates (RoT / SP / Host OS / etc.)
+
 
 
 > blueprint-diff latest
@@ -1588,10 +1626,12 @@ INFO MGS-driven update impossible (will remove it and re-evaluate board), artifa
 INFO configuring MGS-driven update, artifact_version: 1.0.0, artifact_hash: d11e65f934bf0de51df2e5b484f61ee72072417b43ac87f33e958008428e7b02, expected_transient_boot_preference: None, expected_pending_persistent_boot_preference: Some(B), expected_persistent_boot_preference: B, expected_active_slot: ExpectedActiveRotSlot { slot: B, version: ArtifactVersion("1.1.0") }, expected_inactive_version: Version(ArtifactVersion("0.0.2")), component: rot, sp_slot: 2, sp_type: Sled, serial_number: serial2, part_number: model2
 INFO reached maximum number of pending MGS-driven updates, max: 1
 generated blueprint b82656b0-a9be-433d-83d0-e2bdf371777a based on parent blueprint 13cfdd24-52ba-4e94-8c83-02e3a48fc746
+blueprint source: planner with report:
 planning report for blueprint b82656b0-a9be-433d-83d0-e2bdf371777a:
 * 1 pending MGS update:
   * model2:serial2: Rot(PendingMgsUpdateRotDetails { expected_active_slot: ExpectedActiveRotSlot { slot: B, version: ArtifactVersion("1.1.0") }, expected_inactive_version: Version(ArtifactVersion("0.0.2")), expected_persistent_boot_preference: B, expected_pending_persistent_boot_preference: Some(B), expected_transient_boot_preference: None })
 * zone updates waiting on pending MGS updates (RoT / SP / Host OS / etc.)
+
 
 
 > blueprint-diff latest
@@ -1656,10 +1696,12 @@ INFO MGS-driven update impossible (will remove it and re-evaluate board), artifa
 INFO configuring MGS-driven update, artifact_version: 1.0.0, artifact_hash: d11e65f934bf0de51df2e5b484f61ee72072417b43ac87f33e958008428e7b02, expected_transient_boot_preference: Some(B), expected_pending_persistent_boot_preference: None, expected_persistent_boot_preference: B, expected_active_slot: ExpectedActiveRotSlot { slot: B, version: ArtifactVersion("1.1.0") }, expected_inactive_version: Version(ArtifactVersion("0.0.2")), component: rot, sp_slot: 2, sp_type: Sled, serial_number: serial2, part_number: model2
 INFO reached maximum number of pending MGS-driven updates, max: 1
 generated blueprint 31c84831-be52-4630-bc3f-128d72cd8f22 based on parent blueprint b82656b0-a9be-433d-83d0-e2bdf371777a
+blueprint source: planner with report:
 planning report for blueprint 31c84831-be52-4630-bc3f-128d72cd8f22:
 * 1 pending MGS update:
   * model2:serial2: Rot(PendingMgsUpdateRotDetails { expected_active_slot: ExpectedActiveRotSlot { slot: B, version: ArtifactVersion("1.1.0") }, expected_inactive_version: Version(ArtifactVersion("0.0.2")), expected_persistent_boot_preference: B, expected_pending_persistent_boot_preference: None, expected_transient_boot_preference: Some(B) })
 * zone updates waiting on pending MGS updates (RoT / SP / Host OS / etc.)
+
 
 
 > blueprint-diff latest
@@ -1722,10 +1764,12 @@ INFO MGS-driven update completed (will remove it and re-evaluate board), artifac
 INFO configuring MGS-driven update, artifact_version: 1.0.0, artifact_hash: 68465b8e3f808f475510b525cfd62086d37ddd57688bd854184fdafb2b2198a4, expected_inactive_version: NoValidVersion, expected_active_version: 0.0.1, component: sp, sp_slot: 2, sp_type: Sled, serial_number: serial2, part_number: model2
 INFO reached maximum number of pending MGS-driven updates, max: 1
 generated blueprint 778e3f3a-58b1-4a5e-acff-d23c5d7124c2 based on parent blueprint 31c84831-be52-4630-bc3f-128d72cd8f22
+blueprint source: planner with report:
 planning report for blueprint 778e3f3a-58b1-4a5e-acff-d23c5d7124c2:
 * 1 pending MGS update:
   * model2:serial2: Sp(PendingMgsUpdateSpDetails { expected_active_version: ArtifactVersion("0.0.1"), expected_inactive_version: NoValidVersion })
 * zone updates waiting on pending MGS updates (RoT / SP / Host OS / etc.)
+
 
 
 > blueprint-diff latest
@@ -1787,10 +1831,12 @@ INFO MGS-driven update completed (will remove it and re-evaluate board), artifac
 INFO configuring MGS-driven update, artifact_version: 1.0.0, artifact_hash: 2053f8594971bbf0a7326c833e2ffc12b065b9d823b9c0b967d275fa595e4e89, sled_agent_address: [fd00:1122:3344:103::1]:12345, expected_inactive_phase_2_hash: f3dd0c7a1bd4500ea0d8bcf67581f576d47752b2f1998a4cb0f0c3155c483008, expected_inactive_phase_1_hash: 0202020202020202020202020202020202020202020202020202020202020202, expected_active_phase_2_hash: 0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a, expected_active_phase_1_hash: 0101010101010101010101010101010101010101010101010101010101010101, expected_boot_disk: A, expected_active_phase_1_slot: A, component: host_phase_1, sp_slot: 2, sp_type: Sled, serial_number: serial2, part_number: model2
 INFO reached maximum number of pending MGS-driven updates, max: 1
 generated blueprint 386a7ec3-7c2e-43cf-8f00-999e91e1d5e6 based on parent blueprint 778e3f3a-58b1-4a5e-acff-d23c5d7124c2
+blueprint source: planner with report:
 planning report for blueprint 386a7ec3-7c2e-43cf-8f00-999e91e1d5e6:
 * 1 pending MGS update:
   * model2:serial2: HostPhase1(PendingMgsUpdateHostPhase1Details { expected_active_phase_1_slot: A, expected_boot_disk: A, expected_active_phase_1_hash: ArtifactHash("0101010101010101010101010101010101010101010101010101010101010101"), expected_active_phase_2_hash: ArtifactHash("0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a"), expected_inactive_phase_1_hash: ArtifactHash("0202020202020202020202020202020202020202020202020202020202020202"), expected_inactive_phase_2_hash: ArtifactHash("f3dd0c7a1bd4500ea0d8bcf67581f576d47752b2f1998a4cb0f0c3155c483008"), sled_agent_address: [fd00:1122:3344:103::1]:12345 })
 * zone updates waiting on pending MGS updates (RoT / SP / Host OS / etc.)
+
 
 
 > blueprint-diff latest
@@ -1918,10 +1964,12 @@ INFO skipping board for MGS-driven update, serial_number: serial0, part_number: 
 INFO skipping board for MGS-driven update, serial_number: serial1, part_number: model1
 INFO ran out of boards for MGS-driven update
 generated blueprint e54a0836-53e1-4948-a3af-0b77165289b5 based on parent blueprint 386a7ec3-7c2e-43cf-8f00-999e91e1d5e6
+blueprint source: planner with report:
 planning report for blueprint e54a0836-53e1-4948-a3af-0b77165289b5:
 * 1 out-of-date zone updated in-place:
   * sled 2b8f0cb3-0295-4b3c-bc58-4fe88b57112c, zone 353b3b65-20f7-48c3-88f7-495bd5d31545 (clickhouse)
 * 25 remaining out-of-date zones
+
 
 
 > blueprint-diff latest
@@ -2046,10 +2094,12 @@ INFO skipping board for MGS-driven update, serial_number: serial1, part_number: 
 INFO skipping board for MGS-driven update, serial_number: serial2, part_number: model2
 INFO ran out of boards for MGS-driven update
 generated blueprint 459a45a5-616e-421f-873b-2fb08c36205c based on parent blueprint e54a0836-53e1-4948-a3af-0b77165289b5
+blueprint source: planner with report:
 planning report for blueprint 459a45a5-616e-421f-873b-2fb08c36205c:
 * 1 out-of-date zone expunged:
   * sled 2b8f0cb3-0295-4b3c-bc58-4fe88b57112c, zone 62620961-fc4a-481e-968b-f5acbac0dc63 (internal_ntp)
 * 24 remaining out-of-date zones
+
 
 
 > blueprint-diff latest
@@ -2180,10 +2230,12 @@ INFO skipping board for MGS-driven update, serial_number: serial2, part_number: 
 INFO ran out of boards for MGS-driven update
 INFO some zones not yet up-to-date, sled_id: 2b8f0cb3-0295-4b3c-bc58-4fe88b57112c, zones_currently_updating: [ZoneCurrentlyUpdating { zone_id: f83ade6d-9ab1-4679-813b-b9457e039c0b (service), zone_kind: InternalNtp, reason: MissingInInventory { bp_image_source: Artifact { version: Available { version: ArtifactVersion("1.0.0") }, hash: ArtifactHash("67593d686ed04a1709f93972b71f4ebc148a9362120f65d239943e814a9a7439") } } }]
 generated blueprint b2295597-5788-482e-acf9-1731ec63fbd2 based on parent blueprint 459a45a5-616e-421f-873b-2fb08c36205c
+blueprint source: planner with report:
 planning report for blueprint b2295597-5788-482e-acf9-1731ec63fbd2:
 * waiting for NTP zones to appear in inventory on sleds: 2b8f0cb3-0295-4b3c-bc58-4fe88b57112c
 * sleds getting NTP zones and which have other services already, making them eligible for discretionary zones: 2b8f0cb3-0295-4b3c-bc58-4fe88b57112c
 * missing NTP zone on sled 2b8f0cb3-0295-4b3c-bc58-4fe88b57112c
+
 
 
 > blueprint-diff latest
@@ -2308,10 +2360,12 @@ INFO skipping board for MGS-driven update, serial_number: serial1, part_number: 
 INFO skipping board for MGS-driven update, serial_number: serial2, part_number: model2
 INFO ran out of boards for MGS-driven update
 generated blueprint 6fad8fd4-e825-433f-b76d-495484e068ce based on parent blueprint b2295597-5788-482e-acf9-1731ec63fbd2
+blueprint source: planner with report:
 planning report for blueprint 6fad8fd4-e825-433f-b76d-495484e068ce:
 * 1 out-of-date zone expunged:
   * sled 2b8f0cb3-0295-4b3c-bc58-4fe88b57112c, zone 6c3ae381-04f7-41ea-b0ac-74db387dbc3a (external_dns)
 * 23 remaining out-of-date zones
+
 
 
 > blueprint-diff latest
@@ -2452,10 +2506,12 @@ INFO skipping board for MGS-driven update, serial_number: serial1, part_number: 
 INFO skipping board for MGS-driven update, serial_number: serial2, part_number: model2
 INFO ran out of boards for MGS-driven update
 generated blueprint 24b6e243-100c-428d-8ea6-35b504226f55 based on parent blueprint 6fad8fd4-e825-433f-b76d-495484e068ce
+blueprint source: planner with report:
 planning report for blueprint 24b6e243-100c-428d-8ea6-35b504226f55:
 * discretionary zones placed:
   * external_dns zone on sled 2b8f0cb3-0295-4b3c-bc58-4fe88b57112c from source artifact: version 1.0.0
 * zone updates waiting on discretionary zones
+
 
 
 > blueprint-diff latest
@@ -2597,10 +2653,12 @@ INFO skipping board for MGS-driven update, serial_number: serial1, part_number: 
 INFO skipping board for MGS-driven update, serial_number: serial2, part_number: model2
 INFO ran out of boards for MGS-driven update
 generated blueprint 79fff7a2-2495-4c75-8465-4dc01bab48ce based on parent blueprint 24b6e243-100c-428d-8ea6-35b504226f55
+blueprint source: planner with report:
 planning report for blueprint 79fff7a2-2495-4c75-8465-4dc01bab48ce:
 * 1 out-of-date zone updated in-place:
   * sled 2b8f0cb3-0295-4b3c-bc58-4fe88b57112c, zone 86a22a56-0168-453d-9df1-cb2a7c64b5d3 (crucible)
 * 22 remaining out-of-date zones
+
 
 
 > blueprint-diff latest
@@ -2720,10 +2778,12 @@ INFO skipping board for MGS-driven update, serial_number: serial1, part_number: 
 INFO skipping board for MGS-driven update, serial_number: serial2, part_number: model2
 INFO ran out of boards for MGS-driven update
 generated blueprint 3bcc37b2-0c0b-44d0-b4ed-3bcb605e4312 based on parent blueprint 79fff7a2-2495-4c75-8465-4dc01bab48ce
+blueprint source: planner with report:
 planning report for blueprint 3bcc37b2-0c0b-44d0-b4ed-3bcb605e4312:
 * 1 out-of-date zone expunged:
   * sled 2b8f0cb3-0295-4b3c-bc58-4fe88b57112c, zone 99e2f30b-3174-40bf-a78a-90da8abba8ca (internal_dns)
 * 21 remaining out-of-date zones
+
 
 
 > blueprint-diff latest
@@ -2867,10 +2927,12 @@ INFO skipping board for MGS-driven update, serial_number: serial1, part_number: 
 INFO skipping board for MGS-driven update, serial_number: serial2, part_number: model2
 INFO ran out of boards for MGS-driven update
 generated blueprint 4d2eb6f3-7eb1-443a-8e76-7ecf05da2f6d based on parent blueprint 3bcc37b2-0c0b-44d0-b4ed-3bcb605e4312
+blueprint source: planner with report:
 planning report for blueprint 4d2eb6f3-7eb1-443a-8e76-7ecf05da2f6d:
 * discretionary zones placed:
   * internal_dns zone on sled 2b8f0cb3-0295-4b3c-bc58-4fe88b57112c from source artifact: version 1.0.0
 * zone updates waiting on discretionary zones
+
 
 
 > blueprint-diff latest
@@ -3015,10 +3077,12 @@ INFO skipping board for MGS-driven update, serial_number: serial1, part_number: 
 INFO skipping board for MGS-driven update, serial_number: serial2, part_number: model2
 INFO ran out of boards for MGS-driven update
 generated blueprint e2125c83-b255-45c9-bc9b-802cff09a812 based on parent blueprint 4d2eb6f3-7eb1-443a-8e76-7ecf05da2f6d
+blueprint source: planner with report:
 planning report for blueprint e2125c83-b255-45c9-bc9b-802cff09a812:
 * 1 out-of-date zone expunged:
   * sled 2b8f0cb3-0295-4b3c-bc58-4fe88b57112c, zone ad6a3a03-8d0f-4504-99a4-cbf73d69b973 (crucible_pantry)
 * 20 remaining out-of-date zones
+
 
 
 > blueprint-diff latest
@@ -3150,10 +3214,12 @@ INFO skipping board for MGS-driven update, serial_number: serial1, part_number: 
 INFO skipping board for MGS-driven update, serial_number: serial2, part_number: model2
 INFO ran out of boards for MGS-driven update
 generated blueprint f4a6848e-d13c-46e1-8c6a-944f886d7ba3 based on parent blueprint e2125c83-b255-45c9-bc9b-802cff09a812
+blueprint source: planner with report:
 planning report for blueprint f4a6848e-d13c-46e1-8c6a-944f886d7ba3:
 * discretionary zones placed:
   * crucible_pantry zone on sled 2b8f0cb3-0295-4b3c-bc58-4fe88b57112c from source artifact: version 1.0.0
 * zone updates waiting on discretionary zones
+
 
 
 > blueprint-diff latest
@@ -3286,10 +3352,12 @@ INFO skipping board for MGS-driven update, serial_number: serial1, part_number: 
 INFO skipping board for MGS-driven update, serial_number: serial2, part_number: model2
 INFO ran out of boards for MGS-driven update
 generated blueprint 834e4dbe-3b71-443d-bd4c-20e8253abc0c based on parent blueprint f4a6848e-d13c-46e1-8c6a-944f886d7ba3
+blueprint source: planner with report:
 planning report for blueprint 834e4dbe-3b71-443d-bd4c-20e8253abc0c:
 * 1 out-of-date zone updated in-place:
   * sled 2b8f0cb3-0295-4b3c-bc58-4fe88b57112c, zone bd354eef-d8a6-4165-9124-283fb5e46d77 (crucible)
 * 19 remaining out-of-date zones
+
 
 
 > blueprint-diff latest
@@ -3414,10 +3482,12 @@ INFO skipping board for MGS-driven update, serial_number: serial1, part_number: 
 INFO skipping board for MGS-driven update, serial_number: serial2, part_number: model2
 INFO ran out of boards for MGS-driven update
 generated blueprint d9c5c5e3-c532-4c45-9ef5-22cb00f6a2e1 based on parent blueprint 834e4dbe-3b71-443d-bd4c-20e8253abc0c
+blueprint source: planner with report:
 planning report for blueprint d9c5c5e3-c532-4c45-9ef5-22cb00f6a2e1:
 * 1 out-of-date zone updated in-place:
   * sled 2b8f0cb3-0295-4b3c-bc58-4fe88b57112c, zone e2fdefe7-95b2-4fd2-ae37-56929a06d58c (crucible)
 * 18 remaining out-of-date zones
+
 
 
 > blueprint-diff latest
@@ -3545,10 +3615,12 @@ INFO skipping board for MGS-driven update, serial_number: serial1, part_number: 
 INFO skipping board for MGS-driven update, serial_number: serial2, part_number: model2
 INFO ran out of boards for MGS-driven update
 generated blueprint e2deb7c0-2262-49fe-855f-4250c22afb36 based on parent blueprint d9c5c5e3-c532-4c45-9ef5-22cb00f6a2e1
+blueprint source: planner with report:
 planning report for blueprint e2deb7c0-2262-49fe-855f-4250c22afb36:
 * 1 out-of-date zone updated in-place:
   * sled 98e6b7c2-2efa-41ca-b20a-0a4d61102fe6, zone 058fd5f9-60a8-4e11-9302-15172782e17d (crucible)
 * 17 remaining out-of-date zones
+
 
 
 > blueprint-diff latest
@@ -3661,10 +3733,12 @@ INFO skipping board for MGS-driven update, serial_number: serial1, part_number: 
 INFO skipping board for MGS-driven update, serial_number: serial2, part_number: model2
 INFO ran out of boards for MGS-driven update
 generated blueprint 23ce505c-8991-44a5-8863-f2b906fba9cf based on parent blueprint e2deb7c0-2262-49fe-855f-4250c22afb36
+blueprint source: planner with report:
 planning report for blueprint 23ce505c-8991-44a5-8863-f2b906fba9cf:
 * 1 out-of-date zone expunged:
   * sled 98e6b7c2-2efa-41ca-b20a-0a4d61102fe6, zone 427ec88f-f467-42fa-9bbb-66a91a36103c (internal_dns)
 * 16 remaining out-of-date zones
+
 
 
 > blueprint-diff latest
@@ -3797,10 +3871,12 @@ INFO skipping board for MGS-driven update, serial_number: serial1, part_number: 
 INFO skipping board for MGS-driven update, serial_number: serial2, part_number: model2
 INFO ran out of boards for MGS-driven update
 generated blueprint c0d81ea6-909c-4efb-964e-beff67f6da0d based on parent blueprint 23ce505c-8991-44a5-8863-f2b906fba9cf
+blueprint source: planner with report:
 planning report for blueprint c0d81ea6-909c-4efb-964e-beff67f6da0d:
 * discretionary zones placed:
   * internal_dns zone on sled 98e6b7c2-2efa-41ca-b20a-0a4d61102fe6 from source artifact: version 1.0.0
 * zone updates waiting on discretionary zones
+
 
 
 > blueprint-diff latest
@@ -3934,10 +4010,12 @@ INFO skipping board for MGS-driven update, serial_number: serial1, part_number: 
 INFO skipping board for MGS-driven update, serial_number: serial2, part_number: model2
 INFO ran out of boards for MGS-driven update
 generated blueprint 60b55d33-5fec-4277-9864-935197eaead7 based on parent blueprint c0d81ea6-909c-4efb-964e-beff67f6da0d
+blueprint source: planner with report:
 planning report for blueprint 60b55d33-5fec-4277-9864-935197eaead7:
 * 1 out-of-date zone updated in-place:
   * sled 98e6b7c2-2efa-41ca-b20a-0a4d61102fe6, zone 5199c033-4cf9-4ab6-8ae7-566bd7606363 (crucible)
 * 15 remaining out-of-date zones
+
 
 
 > blueprint-diff latest
@@ -4052,10 +4130,12 @@ INFO skipping board for MGS-driven update, serial_number: serial1, part_number: 
 INFO skipping board for MGS-driven update, serial_number: serial2, part_number: model2
 INFO ran out of boards for MGS-driven update
 generated blueprint aa13f40f-41ff-4b68-bee1-df2e1f805544 based on parent blueprint 60b55d33-5fec-4277-9864-935197eaead7
+blueprint source: planner with report:
 planning report for blueprint aa13f40f-41ff-4b68-bee1-df2e1f805544:
 * 1 out-of-date zone expunged:
   * sled 98e6b7c2-2efa-41ca-b20a-0a4d61102fe6, zone 6444f8a5-6465-4f0b-a549-1993c113569c (internal_ntp)
 * 14 remaining out-of-date zones
+
 
 
 > blueprint-diff latest
@@ -4180,10 +4260,12 @@ INFO skipping board for MGS-driven update, serial_number: serial2, part_number: 
 INFO ran out of boards for MGS-driven update
 INFO some zones not yet up-to-date, sled_id: 98e6b7c2-2efa-41ca-b20a-0a4d61102fe6, zones_currently_updating: [ZoneCurrentlyUpdating { zone_id: cc6fdaf4-0195-4cef-950d-7bacd7059787 (service), zone_kind: InternalNtp, reason: MissingInInventory { bp_image_source: Artifact { version: Available { version: ArtifactVersion("1.0.0") }, hash: ArtifactHash("67593d686ed04a1709f93972b71f4ebc148a9362120f65d239943e814a9a7439") } } }]
 generated blueprint 316ccd9e-5c53-46c3-a2e9-20c3867b7111 based on parent blueprint aa13f40f-41ff-4b68-bee1-df2e1f805544
+blueprint source: planner with report:
 planning report for blueprint 316ccd9e-5c53-46c3-a2e9-20c3867b7111:
 * waiting for NTP zones to appear in inventory on sleds: 98e6b7c2-2efa-41ca-b20a-0a4d61102fe6
 * sleds getting NTP zones and which have other services already, making them eligible for discretionary zones: 98e6b7c2-2efa-41ca-b20a-0a4d61102fe6
 * missing NTP zone on sled 98e6b7c2-2efa-41ca-b20a-0a4d61102fe6
+
 
 
 > blueprint-diff latest
@@ -4308,10 +4390,12 @@ INFO skipping board for MGS-driven update, serial_number: serial1, part_number: 
 INFO skipping board for MGS-driven update, serial_number: serial2, part_number: model2
 INFO ran out of boards for MGS-driven update
 generated blueprint 02078c95-3d58-4b7b-a03f-9b160361c50a based on parent blueprint 316ccd9e-5c53-46c3-a2e9-20c3867b7111
+blueprint source: planner with report:
 planning report for blueprint 02078c95-3d58-4b7b-a03f-9b160361c50a:
 * 1 out-of-date zone expunged:
   * sled 98e6b7c2-2efa-41ca-b20a-0a4d61102fe6, zone 803bfb63-c246-41db-b0da-d3b87ddfc63d (external_dns)
 * 13 remaining out-of-date zones
+
 
 
 > blueprint-diff latest
@@ -4449,10 +4533,12 @@ INFO skipping board for MGS-driven update, serial_number: serial1, part_number: 
 INFO skipping board for MGS-driven update, serial_number: serial2, part_number: model2
 INFO ran out of boards for MGS-driven update
 generated blueprint e7a01ffc-6b0e-408b-917b-b1efe18b3110 based on parent blueprint 02078c95-3d58-4b7b-a03f-9b160361c50a
+blueprint source: planner with report:
 planning report for blueprint e7a01ffc-6b0e-408b-917b-b1efe18b3110:
 * discretionary zones placed:
   * external_dns zone on sled 98e6b7c2-2efa-41ca-b20a-0a4d61102fe6 from source artifact: version 1.0.0
 * zone updates waiting on discretionary zones
+
 
 
 > blueprint-diff latest
@@ -4591,10 +4677,12 @@ INFO skipping board for MGS-driven update, serial_number: serial1, part_number: 
 INFO skipping board for MGS-driven update, serial_number: serial2, part_number: model2
 INFO ran out of boards for MGS-driven update
 generated blueprint 880e2ffc-8187-4275-a2f3-1b36aa2f4482 based on parent blueprint e7a01ffc-6b0e-408b-917b-b1efe18b3110
+blueprint source: planner with report:
 planning report for blueprint 880e2ffc-8187-4275-a2f3-1b36aa2f4482:
 * 1 out-of-date zone expunged:
   * sled 98e6b7c2-2efa-41ca-b20a-0a4d61102fe6, zone ba4994a8-23f9-4b1a-a84f-a08d74591389 (crucible_pantry)
 * 12 remaining out-of-date zones
+
 
 
 > blueprint-diff latest
@@ -4723,10 +4811,12 @@ INFO skipping board for MGS-driven update, serial_number: serial1, part_number: 
 INFO skipping board for MGS-driven update, serial_number: serial2, part_number: model2
 INFO ran out of boards for MGS-driven update
 generated blueprint c4a20bcb-1a71-4e88-97b4-36d16f55daec based on parent blueprint 880e2ffc-8187-4275-a2f3-1b36aa2f4482
+blueprint source: planner with report:
 planning report for blueprint c4a20bcb-1a71-4e88-97b4-36d16f55daec:
 * discretionary zones placed:
   * crucible_pantry zone on sled 98e6b7c2-2efa-41ca-b20a-0a4d61102fe6 from source artifact: version 1.0.0
 * zone updates waiting on discretionary zones
+
 
 
 > blueprint-diff latest
@@ -4856,10 +4946,12 @@ INFO skipping board for MGS-driven update, serial_number: serial1, part_number: 
 INFO skipping board for MGS-driven update, serial_number: serial2, part_number: model2
 INFO ran out of boards for MGS-driven update
 generated blueprint a2c6496d-98fc-444d-aa36-99508aa72367 based on parent blueprint c4a20bcb-1a71-4e88-97b4-36d16f55daec
+blueprint source: planner with report:
 planning report for blueprint a2c6496d-98fc-444d-aa36-99508aa72367:
 * 1 out-of-date zone updated in-place:
   * sled 98e6b7c2-2efa-41ca-b20a-0a4d61102fe6, zone dfac80b4-a887-430a-ae87-a4e065dba787 (crucible)
 * 11 remaining out-of-date zones
+
 
 
 > blueprint-diff latest
@@ -4984,10 +5076,12 @@ INFO skipping board for MGS-driven update, serial_number: serial1, part_number: 
 INFO skipping board for MGS-driven update, serial_number: serial2, part_number: model2
 INFO ran out of boards for MGS-driven update
 generated blueprint 6ed56354-5941-40d1-a06c-b0e940701d52 based on parent blueprint a2c6496d-98fc-444d-aa36-99508aa72367
+blueprint source: planner with report:
 planning report for blueprint 6ed56354-5941-40d1-a06c-b0e940701d52:
 * 1 out-of-date zone updated in-place:
   * sled d81c6a84-79b8-4958-ae41-ea46c9b19763, zone 694bd14f-cb24-4be4-bb19-876e79cda2c8 (crucible)
 * 10 remaining out-of-date zones
+
 
 
 > blueprint-diff latest
@@ -5100,10 +5194,12 @@ INFO skipping board for MGS-driven update, serial_number: serial1, part_number: 
 INFO skipping board for MGS-driven update, serial_number: serial2, part_number: model2
 INFO ran out of boards for MGS-driven update
 generated blueprint 9078c4ba-3a73-4b3f-ac2c-acb501f89cb2 based on parent blueprint 6ed56354-5941-40d1-a06c-b0e940701d52
+blueprint source: planner with report:
 planning report for blueprint 9078c4ba-3a73-4b3f-ac2c-acb501f89cb2:
 * 1 out-of-date zone expunged:
   * sled d81c6a84-79b8-4958-ae41-ea46c9b19763, zone 75b220ba-a0f4-4872-8202-dc7c87f062d0 (crucible_pantry)
 * 9 remaining out-of-date zones
+
 
 
 > blueprint-diff latest
@@ -5224,10 +5320,12 @@ INFO skipping board for MGS-driven update, serial_number: serial1, part_number: 
 INFO skipping board for MGS-driven update, serial_number: serial2, part_number: model2
 INFO ran out of boards for MGS-driven update
 generated blueprint 8763abc1-8a42-4932-b5a7-33109e0e0152 based on parent blueprint 9078c4ba-3a73-4b3f-ac2c-acb501f89cb2
+blueprint source: planner with report:
 planning report for blueprint 8763abc1-8a42-4932-b5a7-33109e0e0152:
 * discretionary zones placed:
   * crucible_pantry zone on sled d81c6a84-79b8-4958-ae41-ea46c9b19763 from source artifact: version 1.0.0
 * zone updates waiting on discretionary zones
+
 
 
 > blueprint-diff latest
@@ -5349,10 +5447,12 @@ INFO skipping board for MGS-driven update, serial_number: serial1, part_number: 
 INFO skipping board for MGS-driven update, serial_number: serial2, part_number: model2
 INFO ran out of boards for MGS-driven update
 generated blueprint 2b89e0d7-f15b-4474-8ac4-85959ed1bc88 based on parent blueprint 8763abc1-8a42-4932-b5a7-33109e0e0152
+blueprint source: planner with report:
 planning report for blueprint 2b89e0d7-f15b-4474-8ac4-85959ed1bc88:
 * 1 out-of-date zone updated in-place:
   * sled d81c6a84-79b8-4958-ae41-ea46c9b19763, zone 7c252b64-c5af-4ec1-989e-9a03f3b0f111 (crucible)
 * 8 remaining out-of-date zones
+
 
 
 > blueprint-diff latest
@@ -5466,10 +5566,12 @@ INFO skipping board for MGS-driven update, serial_number: serial1, part_number: 
 INFO skipping board for MGS-driven update, serial_number: serial2, part_number: model2
 INFO ran out of boards for MGS-driven update
 generated blueprint 7f6b7297-c2bc-4f67-b3c0-c8e555ebbdc4 based on parent blueprint 2b89e0d7-f15b-4474-8ac4-85959ed1bc88
+blueprint source: planner with report:
 planning report for blueprint 7f6b7297-c2bc-4f67-b3c0-c8e555ebbdc4:
 * 1 out-of-date zone expunged:
   * sled d81c6a84-79b8-4958-ae41-ea46c9b19763, zone ea5b4030-b52f-44b2-8d70-45f15f987d01 (internal_dns)
 * 7 remaining out-of-date zones
+
 
 
 > blueprint-diff latest
@@ -5601,10 +5703,12 @@ INFO skipping board for MGS-driven update, serial_number: serial1, part_number: 
 INFO skipping board for MGS-driven update, serial_number: serial2, part_number: model2
 INFO ran out of boards for MGS-driven update
 generated blueprint 59630e63-c953-4807-9e84-9e750a79f68e based on parent blueprint 7f6b7297-c2bc-4f67-b3c0-c8e555ebbdc4
+blueprint source: planner with report:
 planning report for blueprint 59630e63-c953-4807-9e84-9e750a79f68e:
 * discretionary zones placed:
   * internal_dns zone on sled d81c6a84-79b8-4958-ae41-ea46c9b19763 from source artifact: version 1.0.0
 * zone updates waiting on discretionary zones
+
 
 
 > blueprint-diff latest
@@ -5737,10 +5841,12 @@ INFO skipping board for MGS-driven update, serial_number: serial1, part_number: 
 INFO skipping board for MGS-driven update, serial_number: serial2, part_number: model2
 INFO ran out of boards for MGS-driven update
 generated blueprint e93650dc-b5ba-4ec7-8550-9171c1ada194 based on parent blueprint 59630e63-c953-4807-9e84-9e750a79f68e
+blueprint source: planner with report:
 planning report for blueprint e93650dc-b5ba-4ec7-8550-9171c1ada194:
 * 1 out-of-date zone expunged:
   * sled d81c6a84-79b8-4958-ae41-ea46c9b19763, zone f10a4fb9-759f-4a65-b25e-5794ad2d07d8 (internal_ntp)
 * 6 remaining out-of-date zones
+
 
 
 > blueprint-diff latest
@@ -5867,10 +5973,12 @@ INFO skipping board for MGS-driven update, serial_number: serial2, part_number: 
 INFO ran out of boards for MGS-driven update
 INFO some zones not yet up-to-date, sled_id: d81c6a84-79b8-4958-ae41-ea46c9b19763, zones_currently_updating: [ZoneCurrentlyUpdating { zone_id: d5fd048a-8786-42d3-938e-820eae95d7f4 (service), zone_kind: InternalNtp, reason: MissingInInventory { bp_image_source: Artifact { version: Available { version: ArtifactVersion("1.0.0") }, hash: ArtifactHash("67593d686ed04a1709f93972b71f4ebc148a9362120f65d239943e814a9a7439") } } }]
 generated blueprint 90650737-8142-47a6-9a48-a10efc487e57 based on parent blueprint e93650dc-b5ba-4ec7-8550-9171c1ada194
+blueprint source: planner with report:
 planning report for blueprint 90650737-8142-47a6-9a48-a10efc487e57:
 * waiting for NTP zones to appear in inventory on sleds: d81c6a84-79b8-4958-ae41-ea46c9b19763
 * sleds getting NTP zones and which have other services already, making them eligible for discretionary zones: d81c6a84-79b8-4958-ae41-ea46c9b19763
 * missing NTP zone on sled d81c6a84-79b8-4958-ae41-ea46c9b19763
+
 
 
 > blueprint-diff latest
@@ -5997,10 +6105,12 @@ INFO skipping board for MGS-driven update, serial_number: serial1, part_number: 
 INFO skipping board for MGS-driven update, serial_number: serial2, part_number: model2
 INFO ran out of boards for MGS-driven update
 generated blueprint 2182613d-dc9f-41eb-9c6a-d33801849caa based on parent blueprint 90650737-8142-47a6-9a48-a10efc487e57
+blueprint source: planner with report:
 planning report for blueprint 2182613d-dc9f-41eb-9c6a-d33801849caa:
 * 1 out-of-date zone updated in-place:
   * sled d81c6a84-79b8-4958-ae41-ea46c9b19763, zone f55647d4-5500-4ad3-893a-df45bd50d622 (crucible)
 * 5 remaining out-of-date zones
+
 
 
 > blueprint-diff latest
@@ -6119,10 +6229,12 @@ INFO skipping board for MGS-driven update, serial_number: serial1, part_number: 
 INFO skipping board for MGS-driven update, serial_number: serial2, part_number: model2
 INFO ran out of boards for MGS-driven update
 generated blueprint e8b088a8-7da0-480b-a2dc-75ffef068ece based on parent blueprint 2182613d-dc9f-41eb-9c6a-d33801849caa
+blueprint source: planner with report:
 planning report for blueprint e8b088a8-7da0-480b-a2dc-75ffef068ece:
 * 1 out-of-date zone expunged:
   * sled d81c6a84-79b8-4958-ae41-ea46c9b19763, zone f6ec9c67-946a-4da3-98d5-581f72ce8bf0 (external_dns)
 * 4 remaining out-of-date zones
+
 
 
 > blueprint-diff latest
@@ -6259,10 +6371,12 @@ INFO skipping board for MGS-driven update, serial_number: serial1, part_number: 
 INFO skipping board for MGS-driven update, serial_number: serial2, part_number: model2
 INFO ran out of boards for MGS-driven update
 generated blueprint 810ea95a-4730-43dd-867e-1984aeb9d873 based on parent blueprint e8b088a8-7da0-480b-a2dc-75ffef068ece
+blueprint source: planner with report:
 planning report for blueprint 810ea95a-4730-43dd-867e-1984aeb9d873:
 * discretionary zones placed:
   * external_dns zone on sled d81c6a84-79b8-4958-ae41-ea46c9b19763 from source artifact: version 1.0.0
 * zone updates waiting on discretionary zones
+
 
 
 > blueprint-diff latest
@@ -6617,10 +6731,12 @@ parent:    e8b088a8-7da0-480b-a2dc-75ffef068ece
 
  PENDING MGS-MANAGED UPDATES: 0
 
+blueprint source: planner with report:
 planning report for blueprint 810ea95a-4730-43dd-867e-1984aeb9d873:
 * discretionary zones placed:
   * external_dns zone on sled d81c6a84-79b8-4958-ae41-ea46c9b19763 from source artifact: version 1.0.0
 * zone updates waiting on discretionary zones
+
 
 
 

--- a/live-tests/tests/common/reconfigurator.rs
+++ b/live-tests/tests/common/reconfigurator.rs
@@ -10,7 +10,7 @@ use nexus_db_queries::context::OpContext;
 use nexus_db_queries::db::DataStore;
 use nexus_reconfigurator_planning::blueprint_builder::BlueprintBuilder;
 use nexus_reconfigurator_planning::planner::PlannerRng;
-use nexus_types::deployment::{Blueprint, PlanningInput};
+use nexus_types::deployment::{Blueprint, BlueprintSource, PlanningInput};
 use nexus_types::external_api::views::SledState;
 use nexus_types::inventory::Collection;
 use omicron_test_utils::dev::poll::{CondCheckError, wait_for_condition};
@@ -101,7 +101,7 @@ pub async fn blueprint_edit_current_target(
     edit_fn(&mut builder)?;
 
     // Assemble the new blueprint, import it, and make it the new target.
-    let blueprint2 = builder.build();
+    let blueprint2 = builder.build(BlueprintSource::Test);
     info!(log, "assembled new blueprint based on target";
         "current_target_id" => %blueprint1.id,
         "new_blueprint_id" => %blueprint2.id,

--- a/nexus/db-model/src/deployment.rs
+++ b/nexus/db-model/src/deployment.rs
@@ -28,7 +28,6 @@ use nexus_db_schema::schema::{
     debug_log_blueprint_planning,
 };
 use nexus_sled_agent_shared::inventory::OmicronZoneDataset;
-use nexus_types::deployment::BlueprintPhysicalDiskConfig;
 use nexus_types::deployment::BlueprintPhysicalDiskDisposition;
 use nexus_types::deployment::BlueprintTarget;
 use nexus_types::deployment::BlueprintZoneConfig;
@@ -52,6 +51,7 @@ use nexus_types::deployment::{
 use nexus_types::deployment::{
     BlueprintHostPhase2DesiredSlots, PlanningReport,
 };
+use nexus_types::deployment::{BlueprintPhysicalDiskConfig, BlueprintSource};
 use nexus_types::deployment::{BlueprintZoneImageSource, blueprint_zone_type};
 use nexus_types::deployment::{
     OmicronZoneExternalFloatingAddr, OmicronZoneExternalFloatingIp,
@@ -85,6 +85,7 @@ pub struct Blueprint {
     pub comment: String,
     pub target_release_minimum_generation: Generation,
     pub nexus_generation: Generation,
+    pub source: DbBpSource,
 }
 
 impl From<&'_ nexus_types::deployment::Blueprint> for Blueprint {
@@ -105,6 +106,7 @@ impl From<&'_ nexus_types::deployment::Blueprint> for Blueprint {
                 bp.target_release_minimum_generation,
             ),
             nexus_generation: Generation(bp.nexus_generation),
+            source: DbBpSource::from(&bp.source),
         }
     }
 }
@@ -128,6 +130,47 @@ impl From<Blueprint> for nexus_types::deployment::BlueprintMetadata {
             time_created: value.time_created,
             creator: value.creator,
             comment: value.comment,
+            source: value.source.into(),
+        }
+    }
+}
+
+impl_enum_type!(
+    BpSourceEnum:
+
+    #[derive(Clone, Copy, Debug, AsExpression, FromSqlRow, PartialEq)]
+    pub enum DbBpSource;
+
+    // Enum values
+    Rss => b"rss"
+    Planner => b"planner"
+    ReconfiguratorCliEdit => b"reconfigurator_cli_edit"
+    Test => b"test"
+);
+
+impl From<&'_ BlueprintSource> for DbBpSource {
+    fn from(value: &'_ BlueprintSource) -> Self {
+        match value {
+            BlueprintSource::Rss => Self::Rss,
+            // We don't store planning reports, so both of these variants squish
+            // to `Planner`.
+            BlueprintSource::Planner(_)
+            | BlueprintSource::PlannerLoadedFromDatabase => Self::Planner,
+            BlueprintSource::ReconfiguratorCliEdit => {
+                Self::ReconfiguratorCliEdit
+            }
+            BlueprintSource::Test => Self::Test,
+        }
+    }
+}
+
+impl From<DbBpSource> for BlueprintSource {
+    fn from(value: DbBpSource) -> Self {
+        match value {
+            DbBpSource::Rss => Self::Rss,
+            DbBpSource::Planner => Self::PlannerLoadedFromDatabase,
+            DbBpSource::ReconfiguratorCliEdit => Self::ReconfiguratorCliEdit,
+            DbBpSource::Test => Self::Test,
         }
     }
 }

--- a/nexus/db-model/src/deployment.rs
+++ b/nexus/db-model/src/deployment.rs
@@ -1530,10 +1530,10 @@ pub struct DebugLogBlueprintPlanning {
     pub debug_blob: serde_json::Value,
 }
 
-impl TryFrom<PlanningReport> for DebugLogBlueprintPlanning {
+impl TryFrom<Arc<PlanningReport>> for DebugLogBlueprintPlanning {
     type Error = serde_json::Error;
 
-    fn try_from(report: PlanningReport) -> Result<Self, Self::Error> {
+    fn try_from(report: Arc<PlanningReport>) -> Result<Self, Self::Error> {
         let blueprint_id = report.blueprint_id.into();
         let report = serde_json::to_value(report)?;
 

--- a/nexus/db-model/src/schema_versions.rs
+++ b/nexus/db-model/src/schema_versions.rs
@@ -16,7 +16,7 @@ use std::{collections::BTreeMap, sync::LazyLock};
 ///
 /// This must be updated when you change the database schema.  Refer to
 /// schema/crdb/README.adoc in the root of this repository for details.
-pub const SCHEMA_VERSION: Version = Version::new(191, 0, 0);
+pub const SCHEMA_VERSION: Version = Version::new(192, 0, 0);
 
 /// List of all past database schema versions, in *reverse* order
 ///
@@ -28,6 +28,7 @@ static KNOWN_VERSIONS: LazyLock<Vec<KnownVersion>> = LazyLock::new(|| {
         // |  leaving the first copy as an example for the next person.
         // v
         // KnownVersion::new(next_int, "unique-dirname-with-the-sql-files"),
+        KnownVersion::new(192, "blueprint-source"),
         KnownVersion::new(191, "debug-log-blueprint-planner"),
         KnownVersion::new(190, "add-instance-cpu-platform"),
         KnownVersion::new(189, "reconfigurator-chicken-switches-to-config"),

--- a/nexus/db-queries/src/db/datastore/deployment.rs
+++ b/nexus/db-queries/src/db/datastore/deployment.rs
@@ -3580,7 +3580,7 @@ mod tests {
         let num_new_crucible_zones = new_sled_zpools.len();
         let num_new_sled_zones = num_new_ntp_zones + num_new_crucible_zones;
 
-        let blueprint2 = builder.build();
+        let blueprint2 = builder.build(BlueprintSource::Test);
         let authz_blueprint2 = authz_blueprint_from_id(blueprint2.id);
 
         let diff = blueprint2.diff_since_blueprint(&blueprint1);
@@ -3708,7 +3708,7 @@ mod tests {
             artifact_hash: ArtifactHash([72; 32]),
             artifact_version: "2.0.0".parse().unwrap(),
         });
-        let blueprint3 = builder.build();
+        let blueprint3 = builder.build(BlueprintSource::Test);
         let authz_blueprint3 = authz_blueprint_from_id(blueprint3.id);
         datastore
             .blueprint_insert(&opctx, &blueprint3)
@@ -3762,7 +3762,7 @@ mod tests {
             artifact_hash: ArtifactHash([72; 32]),
             artifact_version: "2.0.0".parse().unwrap(),
         });
-        let blueprint4 = builder.build();
+        let blueprint4 = builder.build(BlueprintSource::Test);
         let authz_blueprint4 = authz_blueprint_from_id(blueprint4.id);
         datastore
             .blueprint_insert(&opctx, &blueprint4)
@@ -3820,7 +3820,7 @@ mod tests {
             artifact_hash: ArtifactHash([72; 32]),
             artifact_version: "2.0.0".parse().unwrap(),
         });
-        let blueprint5 = builder.build();
+        let blueprint5 = builder.build(BlueprintSource::Test);
         let authz_blueprint5 = authz_blueprint_from_id(blueprint5.id);
         datastore
             .blueprint_insert(&opctx, &blueprint5)
@@ -3856,7 +3856,7 @@ mod tests {
             PlannerRng::from_entropy(),
         )
         .expect("failed to create builder")
-        .build();
+        .build(BlueprintSource::Test);
         datastore
             .blueprint_insert(&opctx, &blueprint6)
             .await
@@ -3934,7 +3934,7 @@ mod tests {
             PlannerRng::from_entropy(),
         )
         .expect("failed to create builder")
-        .build();
+        .build(BlueprintSource::Test);
         let blueprint3 = BlueprintBuilder::new_based_on(
             &logctx.log,
             &blueprint1,
@@ -3944,7 +3944,7 @@ mod tests {
             PlannerRng::from_entropy(),
         )
         .expect("failed to create builder")
-        .build();
+        .build(BlueprintSource::Test);
         assert_eq!(blueprint1.parent_blueprint_id, None);
         assert_eq!(blueprint2.parent_blueprint_id, Some(blueprint1.id));
         assert_eq!(blueprint3.parent_blueprint_id, Some(blueprint1.id));
@@ -4045,7 +4045,7 @@ mod tests {
             PlannerRng::from_entropy(),
         )
         .expect("failed to create builder")
-        .build();
+        .build(BlueprintSource::Test);
         assert_eq!(blueprint4.parent_blueprint_id, Some(blueprint3.id));
         datastore.blueprint_insert(&opctx, &blueprint4).await.unwrap();
         let bp4_target = BlueprintTarget {
@@ -4091,7 +4091,7 @@ mod tests {
             PlannerRng::from_entropy(),
         )
         .expect("failed to create builder")
-        .build();
+        .build(BlueprintSource::Test);
         assert_eq!(blueprint1.parent_blueprint_id, None);
         assert_eq!(blueprint2.parent_blueprint_id, Some(blueprint1.id));
 
@@ -4330,7 +4330,7 @@ mod tests {
             PlannerRng::from_entropy(),
         )
         .expect("failed to create builder")
-        .build();
+        .build(BlueprintSource::Test);
 
         // Insert an IP pool range covering the one Nexus IP.
         let nexus_ip = blueprint1

--- a/nexus/db-queries/src/db/datastore/rack.rs
+++ b/nexus/db-queries/src/db/datastore/rack.rs
@@ -1048,6 +1048,7 @@ mod test {
     use nexus_sled_agent_shared::inventory::OmicronZoneDataset;
     use nexus_types::deployment::BlueprintHostPhase2DesiredSlots;
     use nexus_types::deployment::BlueprintSledConfig;
+    use nexus_types::deployment::BlueprintSource;
     use nexus_types::deployment::CockroachDbPreserveDowngrade;
     use nexus_types::deployment::PendingMgsUpdates;
     use nexus_types::deployment::{
@@ -1056,7 +1057,7 @@ mod test {
     };
     use nexus_types::deployment::{
         BlueprintZoneDisposition, BlueprintZoneImageSource,
-        OmicronZoneExternalSnatIp, OximeterReadMode, PlanningReport,
+        OmicronZoneExternalSnatIp, OximeterReadMode,
     };
     use nexus_types::external_api::shared::SiloIdentityMode;
     use nexus_types::external_api::views::SledState;
@@ -1113,7 +1114,7 @@ mod test {
                     time_created: Utc::now(),
                     creator: "test suite".to_string(),
                     comment: "test suite".to_string(),
-                    report: PlanningReport::new(blueprint_id),
+                    source: BlueprintSource::Test,
                 },
                 blueprint_execution_enabled: false,
                 physical_disks: vec![],
@@ -1604,7 +1605,7 @@ mod test {
             time_created: now_db_precision(),
             creator: "test suite".to_string(),
             comment: "test blueprint".to_string(),
-            report: PlanningReport::new(blueprint_id),
+            source: BlueprintSource::Test,
         };
 
         let rack = datastore
@@ -1870,7 +1871,7 @@ mod test {
             time_created: now_db_precision(),
             creator: "test suite".to_string(),
             comment: "test blueprint".to_string(),
-            report: PlanningReport::new(blueprint_id),
+            source: BlueprintSource::Test,
         };
 
         let rack = datastore
@@ -2118,7 +2119,7 @@ mod test {
             time_created: now_db_precision(),
             creator: "test suite".to_string(),
             comment: "test blueprint".to_string(),
-            report: PlanningReport::new(blueprint_id),
+            source: BlueprintSource::Test,
             nexus_generation: *Generation::new(),
         };
 
@@ -2318,7 +2319,7 @@ mod test {
             time_created: now_db_precision(),
             creator: "test suite".to_string(),
             comment: "test blueprint".to_string(),
-            report: PlanningReport::new(blueprint_id),
+            source: BlueprintSource::Test,
         };
 
         let result = datastore
@@ -2460,7 +2461,7 @@ mod test {
             time_created: now_db_precision(),
             creator: "test suite".to_string(),
             comment: "test blueprint".to_string(),
-            report: PlanningReport::new(blueprint_id),
+            source: BlueprintSource::Test,
         };
 
         let result = datastore

--- a/nexus/db-queries/src/db/datastore/support_bundle.rs
+++ b/nexus/db-queries/src/db/datastore/support_bundle.rs
@@ -1096,7 +1096,6 @@ mod test {
         let bp2 = {
             let mut bp2 = bp1.clone();
             bp2.id = BlueprintUuid::new_v4();
-            bp2.report.blueprint_id = bp2.id;
             bp2.parent_blueprint_id = Some(bp1.id);
             expunge_dataset_for_bundle(&mut bp2, &bundle);
             bp2
@@ -1213,7 +1212,6 @@ mod test {
         let bp2 = {
             let mut bp2 = bp1.clone();
             bp2.id = BlueprintUuid::new_v4();
-            bp2.report.blueprint_id = bp2.id;
             bp2.parent_blueprint_id = Some(bp1.id);
             expunge_dataset_for_bundle(&mut bp2, &bundle);
             bp2
@@ -1297,7 +1295,6 @@ mod test {
         let bp2 = {
             let mut bp2 = bp1.clone();
             bp2.id = BlueprintUuid::new_v4();
-            bp2.report.blueprint_id = bp2.id;
             bp2.parent_blueprint_id = Some(bp1.id);
             expunge_dataset_for_bundle(&mut bp2, &bundle);
             bp2
@@ -1332,7 +1329,6 @@ mod test {
         let bp3 = {
             let mut bp3 = bp2.clone();
             bp3.id = BlueprintUuid::new_v4();
-            bp3.report.blueprint_id = bp3.id;
             bp3.parent_blueprint_id = Some(bp2.id);
             expunge_nexus_for_bundle(&mut bp3, &bundle);
             bp3
@@ -1433,7 +1429,6 @@ mod test {
         let bp2 = {
             let mut bp2 = bp1.clone();
             bp2.id = BlueprintUuid::new_v4();
-            bp2.report.blueprint_id = bp2.id;
             bp2.parent_blueprint_id = Some(bp1.id);
             expunge_nexus_for_bundle(&mut bp2, &bundle);
             bp2

--- a/nexus/db-queries/src/db/datastore/vpc.rs
+++ b/nexus/db-queries/src/db/datastore/vpc.rs
@@ -2981,6 +2981,7 @@ mod tests {
     use nexus_reconfigurator_planning::system::SledBuilder;
     use nexus_reconfigurator_planning::system::SystemDescription;
     use nexus_types::deployment::Blueprint;
+    use nexus_types::deployment::BlueprintSource;
     use nexus_types::deployment::BlueprintTarget;
     use nexus_types::deployment::BlueprintZoneConfig;
     use nexus_types::deployment::BlueprintZoneDisposition;
@@ -3348,7 +3349,7 @@ mod tests {
                     bp0.nexus_generation,
                 )
                 .expect("added nexus to third sled");
-            builder.build()
+            builder.build(BlueprintSource::Test)
         };
         bp_insert_and_make_target(&opctx, &datastore, &bp1).await;
 
@@ -3375,7 +3376,6 @@ mod tests {
         let bp2 = {
             let mut bp2 = bp1.clone();
             bp2.id = BlueprintUuid::new_v4();
-            bp2.report.blueprint_id = bp2.id;
             bp2.parent_blueprint_id = Some(bp1.id);
             let sled2 =
                 bp2.sleds.get_mut(&sled_ids[2]).expect("config for third sled");
@@ -3426,7 +3426,7 @@ mod tests {
                     )
                     .expect("added nexus to third sled");
             }
-            builder.build()
+            builder.build(BlueprintSource::Test)
         };
 
         // Insert the service NIC records for all the Nexuses.
@@ -3482,7 +3482,6 @@ mod tests {
         let bp4 = {
             let mut bp4 = bp3.clone();
             bp4.id = BlueprintUuid::new_v4();
-            bp4.report.blueprint_id = bp4.id;
             bp4.parent_blueprint_id = Some(bp3.id);
 
             // Sled index 3's zone is expunged (should be excluded).

--- a/nexus/db-schema/src/enums.rs
+++ b/nexus/db-schema/src/enums.rs
@@ -32,6 +32,7 @@ define_enums! {
     BlockSizeEnum => "block_size",
     BpDatasetDispositionEnum => "bp_dataset_disposition",
     BpPhysicalDiskDispositionEnum => "bp_physical_disk_disposition",
+    BpSourceEnum => "bp_source",
     BpZoneDispositionEnum => "bp_zone_disposition",
     BpZoneImageSourceEnum => "bp_zone_image_source",
     CabooseWhichEnum => "caboose_which",

--- a/nexus/db-schema/src/schema.rs
+++ b/nexus/db-schema/src/schema.rs
@@ -1983,6 +1983,8 @@ table! {
         target_release_minimum_generation -> Int8,
 
         nexus_generation -> Int8,
+
+        source -> crate::enums::BpSourceEnum,
     }
 }
 

--- a/nexus/reconfigurator/execution/src/database.rs
+++ b/nexus/reconfigurator/execution/src/database.rs
@@ -72,6 +72,7 @@ mod test {
     use nexus_types::deployment::Blueprint;
     use nexus_types::deployment::BlueprintHostPhase2DesiredSlots;
     use nexus_types::deployment::BlueprintSledConfig;
+    use nexus_types::deployment::BlueprintSource;
     use nexus_types::deployment::BlueprintTarget;
     use nexus_types::deployment::BlueprintZoneConfig;
     use nexus_types::deployment::BlueprintZoneDisposition;
@@ -80,7 +81,6 @@ mod test {
     use nexus_types::deployment::CockroachDbPreserveDowngrade;
     use nexus_types::deployment::OximeterReadMode;
     use nexus_types::deployment::PendingMgsUpdates;
-    use nexus_types::deployment::PlanningReport;
     use nexus_types::deployment::blueprint_zone_type;
     use nexus_types::external_api::views::SledState;
     use nexus_types::inventory::NetworkInterface;
@@ -179,7 +179,7 @@ mod test {
             time_created: now_db_precision(),
             creator: "test suite".to_string(),
             comment: "test blueprint".to_string(),
-            report: PlanningReport::new(blueprint_id),
+            source: BlueprintSource::Test,
         }
     }
 

--- a/nexus/reconfigurator/execution/src/dns.rs
+++ b/nexus/reconfigurator/execution/src/dns.rs
@@ -337,6 +337,7 @@ mod test {
     use nexus_types::deployment::Blueprint;
     use nexus_types::deployment::BlueprintHostPhase2DesiredSlots;
     use nexus_types::deployment::BlueprintSledConfig;
+    use nexus_types::deployment::BlueprintSource;
     use nexus_types::deployment::BlueprintTarget;
     use nexus_types::deployment::BlueprintZoneConfig;
     use nexus_types::deployment::BlueprintZoneDisposition;
@@ -352,7 +353,6 @@ mod test {
     use nexus_types::deployment::OximeterReadPolicy;
     use nexus_types::deployment::PendingMgsUpdates;
     use nexus_types::deployment::PlannerConfig;
-    use nexus_types::deployment::PlanningReport;
     use nexus_types::deployment::SledFilter;
     use nexus_types::deployment::TufRepoPolicy;
     use nexus_types::deployment::blueprint_zone_type;
@@ -730,7 +730,7 @@ mod test {
             time_created: now_db_precision(),
             creator: "test-suite".to_string(),
             comment: "test blueprint".to_string(),
-            report: PlanningReport::new(blueprint_id),
+            source: BlueprintSource::Test,
         };
 
         // To make things slightly more interesting, let's add a zone that's
@@ -1574,7 +1574,7 @@ mod test {
                 blueprint.nexus_generation,
             )
             .unwrap();
-        let blueprint2 = builder.build();
+        let blueprint2 = builder.build(BlueprintSource::Test);
         eprintln!("blueprint2: {}", blueprint2.display());
         // Figure out the id of the new zone.
         let zones_before = blueprint

--- a/nexus/reconfigurator/planning/src/blueprint_builder/builder.rs
+++ b/nexus/reconfigurator/planning/src/blueprint_builder/builder.rs
@@ -2818,7 +2818,7 @@ pub mod test {
             }
         }
 
-        let blueprint2 = builder.build();
+        let blueprint2 = builder.build(BlueprintSource::Test);
         verify_blueprint(&blueprint2);
         let summary = blueprint2.diff_since_blueprint(&blueprint1);
         println!(
@@ -2867,7 +2867,7 @@ pub mod test {
         }
         builder.sled_ensure_zone_datasets(new_sled_id).unwrap();
 
-        let blueprint3 = builder.build();
+        let blueprint3 = builder.build(BlueprintSource::Test);
         verify_blueprint(&blueprint3);
         let summary = blueprint3.diff_since_blueprint(&blueprint2);
         println!(
@@ -3014,7 +3014,7 @@ pub mod test {
             rng.next_planner_rng(),
         )
         .expect("created builder")
-        .build();
+        .build(BlueprintSource::Test);
         verify_blueprint(&blueprint2);
 
         // We carried forward the desired state.
@@ -3052,7 +3052,7 @@ pub mod test {
             rng.next_planner_rng(),
         )
         .expect("created builder")
-        .build();
+        .build(BlueprintSource::Test);
         verify_blueprint(&blueprint3);
         assert_eq!(
             blueprint3.sleds.get(&decommision_sled_id).map(|c| c.state),
@@ -3233,7 +3233,7 @@ pub mod test {
         let r = builder.sled_ensure_zone_datasets(sled_id).unwrap();
         assert_eq!(r, EnsureMultiple::NotNeeded);
 
-        let blueprint = builder.build();
+        let blueprint = builder.build(BlueprintSource::Test);
         verify_blueprint(&blueprint);
 
         let mut builder = BlueprintBuilder::new_based_on(
@@ -3251,7 +3251,7 @@ pub mod test {
         let r = builder.sled_ensure_zone_datasets(sled_id).unwrap();
         assert_eq!(r, EnsureMultiple::NotNeeded);
 
-        let blueprint = builder.build();
+        let blueprint = builder.build(BlueprintSource::Test);
         verify_blueprint(&blueprint);
 
         // Find the datasets we've expunged in the blueprint
@@ -3587,7 +3587,7 @@ pub mod test {
         }
         builder.sled_ensure_zone_datasets(target_sled_id).unwrap();
 
-        let blueprint = builder.build();
+        let blueprint = builder.build(BlueprintSource::Test);
         verify_blueprint(&blueprint);
         assert_eq!(
             blueprint
@@ -3703,7 +3703,7 @@ pub mod test {
                 .expect("set zone image source successfully");
         }
 
-        let blueprint2 = blueprint_builder.build();
+        let blueprint2 = blueprint_builder.build(BlueprintSource::Test);
         let diff = blueprint2.diff_since_blueprint(&blueprint1);
         let display = diff.display();
         assert_contents(

--- a/nexus/reconfigurator/planning/src/example.rs
+++ b/nexus/reconfigurator/planning/src/example.rs
@@ -16,6 +16,7 @@ use crate::system::SystemDescription;
 use anyhow::bail;
 use nexus_inventory::CollectionBuilderRng;
 use nexus_types::deployment::Blueprint;
+use nexus_types::deployment::BlueprintSource;
 use nexus_types::deployment::BlueprintZoneImageSource;
 use nexus_types::deployment::OmicronZoneNic;
 use nexus_types::deployment::PlanningInput;
@@ -546,7 +547,7 @@ impl ExampleSystemBuilder {
             builder.sled_ensure_zone_datasets(sled_id).unwrap();
         }
 
-        let blueprint = builder.build();
+        let blueprint = builder.build(BlueprintSource::Test);
         for sled_cfg in blueprint.sleds.values() {
             for zone in sled_cfg.zones.iter() {
                 let service_id = zone.id;

--- a/nexus/reconfigurator/planning/src/planner.rs
+++ b/nexus/reconfigurator/planning/src/planner.rs
@@ -28,6 +28,7 @@ use nexus_sled_agent_shared::inventory::OmicronZoneType;
 use nexus_sled_agent_shared::inventory::ZoneKind;
 use nexus_types::deployment::Blueprint;
 use nexus_types::deployment::BlueprintPhysicalDiskDisposition;
+use nexus_types::deployment::BlueprintSource;
 use nexus_types::deployment::BlueprintZoneConfig;
 use nexus_types::deployment::BlueprintZoneDisposition;
 use nexus_types::deployment::BlueprintZoneImageSource;
@@ -65,6 +66,7 @@ use slog_error_chain::InlineErrorChain;
 use std::collections::BTreeMap;
 use std::collections::BTreeSet;
 use std::str::FromStr;
+use std::sync::Arc;
 
 pub(crate) use self::image_source::NoopConvertGlobalIneligibleReason;
 pub(crate) use self::image_source::NoopConvertInfo;
@@ -152,8 +154,7 @@ impl<'a> Planner<'a> {
     pub fn plan(mut self) -> Result<Blueprint, Error> {
         let checked = self.check_input_validity()?;
         let report = self.do_plan(checked)?;
-        self.blueprint.set_report(report);
-        Ok(self.blueprint.build())
+        Ok(self.blueprint.build(BlueprintSource::Planner(Arc::new(report))))
     }
 
     fn check_input_validity(&self) -> Result<InputChecked, Error> {

--- a/nexus/reconfigurator/planning/src/planner.rs
+++ b/nexus/reconfigurator/planning/src/planner.rs
@@ -2930,7 +2930,7 @@ pub(crate) mod test {
             )
             .expect("added external DNS zone");
 
-        let blueprint1a = blueprint_builder.build();
+        let blueprint1a = blueprint_builder.build(BlueprintSource::Test);
         assert_eq!(
             blueprint1a
                 .all_omicron_zones(BlueprintZoneDisposition::is_in_service)
@@ -6613,7 +6613,7 @@ pub(crate) mod test {
                 "diff between blueprints (should be expunging boundary NTP using install dataset):\n{}",
                 summary.display()
             );
-            eprintln!("{}", new_blueprint.report);
+            eprintln!("{}", new_blueprint.source);
 
             assert_eq!(summary.total_zones_added(), 0);
             assert_eq!(summary.total_zones_removed(), 0);
@@ -6662,7 +6662,7 @@ pub(crate) mod test {
                 "diff between blueprints (should be adding one internal NTP and promoting another to boundary):\n{}",
                 summary.display()
             );
-            eprintln!("{}", new_blueprint.report);
+            eprintln!("{}", new_blueprint.source);
 
             assert_eq!(summary.total_zones_added(), 2);
             assert_eq!(summary.total_zones_removed(), 0);
@@ -6702,7 +6702,7 @@ pub(crate) mod test {
                 "diff between blueprints (should be expunging another boundary NTP):\n{}",
                 summary.display()
             );
-            eprintln!("{}", new_blueprint.report);
+            eprintln!("{}", new_blueprint.source);
 
             assert_eq!(summary.total_zones_added(), 0);
             assert_eq!(summary.total_zones_removed(), 0);
@@ -6743,7 +6743,7 @@ pub(crate) mod test {
                 "diff between blueprints (should be adding promoting internal -> boundary NTP):\n{}",
                 summary.display()
             );
-            eprintln!("{}", new_blueprint.report);
+            eprintln!("{}", new_blueprint.source);
 
             assert_eq!(summary.total_zones_added(), 2);
             assert_eq!(summary.total_zones_removed(), 0);
@@ -6780,7 +6780,7 @@ pub(crate) mod test {
                 "diff between blueprints (should be adding wrapping up internal NTP expungement):\n{}",
                 summary.display()
             );
-            eprintln!("{}", new_blueprint.report);
+            eprintln!("{}", new_blueprint.source);
 
             assert_eq!(summary.total_zones_added(), 0);
             assert_eq!(summary.total_zones_removed(), 0);
@@ -7171,8 +7171,11 @@ pub(crate) mod test {
             .plan()
             .unwrap_or_else(|_| panic!("can't re-plan after {i} iterations"));
 
-            assert_eq!(blueprint.report.blueprint_id, blueprint.id);
-            eprintln!("{}\n", blueprint.report);
+            let BlueprintSource::Planner(report) = &blueprint.source else {
+                panic!("unexpected source: {:?}", blueprint.source);
+            };
+            assert_eq!(report.blueprint_id, blueprint.id);
+            eprintln!("{report}\n");
             // TODO: more report testing
 
             {

--- a/nexus/reconfigurator/planning/tests/output/example_builder_zone_counts_blueprint.txt
+++ b/nexus/reconfigurator/planning/tests/output/example_builder_zone_counts_blueprint.txt
@@ -535,5 +535,5 @@ parent:    e35b2fdd-354d-48d9-acb5-703b2c269a54
 
  PENDING MGS-MANAGED UPDATES: 0
 
-empty planning report for blueprint 4a0b8410-b14f-41e7-85e7-3c0fe7050ccc.
+blueprint source: test
 

--- a/nexus/reconfigurator/planning/tests/output/planner_decommissions_sleds_bp2.txt
+++ b/nexus/reconfigurator/planning/tests/output/planner_decommissions_sleds_bp2.txt
@@ -326,6 +326,7 @@ parent:    516e80a3-b362-4fac-bd3c-4559717120dd
 
  PENDING MGS-MANAGED UPDATES: 0
 
+blueprint source: planner with report:
 planning report for blueprint 1ac2d88f-27dd-4506-8585-6b2be832528e:
 * discretionary zones placed:
   * crucible_pantry zone on sled d67ce8f0-a691-4010-b414-420d82e80527 from source install dataset
@@ -333,4 +334,5 @@ planning report for blueprint 1ac2d88f-27dd-4506-8585-6b2be832528e:
   * clickhouse zone on sled fefcf4cf-f7e7-46b3-b629-058526ce440e from source install dataset
   * internal_dns zone on sled fefcf4cf-f7e7-46b3-b629-058526ce440e from source install dataset
 * zone updates waiting on discretionary zones
+
 

--- a/nexus/reconfigurator/planning/tests/output/planner_nonprovisionable_bp2.txt
+++ b/nexus/reconfigurator/planning/tests/output/planner_nonprovisionable_bp2.txt
@@ -514,6 +514,7 @@ parent:    4d4e6c38-cd95-4c4e-8f45-6af4d686964b
 
  PENDING MGS-MANAGED UPDATES: 0
 
+blueprint source: planner with report:
 planning report for blueprint 9f71f5d3-a272-4382-9154-6ea2e171a6c6:
 * discretionary zones placed:
   * nexus zone on sled 75bc286f-2b4b-482c-9431-59272af529da from source install dataset
@@ -523,4 +524,5 @@ planning report for blueprint 9f71f5d3-a272-4382-9154-6ea2e171a6c6:
   * nexus zone on sled affab35f-600a-4109-8ea0-34a067a4e0bc from source install dataset
   * nexus zone on sled affab35f-600a-4109-8ea0-34a067a4e0bc from source install dataset
 * zone updates waiting on discretionary zones
+
 

--- a/nexus/src/app/background/tasks/blueprint_execution.rs
+++ b/nexus/src/app/background/tasks/blueprint_execution.rs
@@ -244,10 +244,10 @@ mod test {
     };
     use nexus_types::deployment::{
         Blueprint, BlueprintHostPhase2DesiredSlots, BlueprintSledConfig,
-        BlueprintTarget, BlueprintZoneConfig, BlueprintZoneDisposition,
-        BlueprintZoneImageSource, BlueprintZoneType,
+        BlueprintSource, BlueprintTarget, BlueprintZoneConfig,
+        BlueprintZoneDisposition, BlueprintZoneImageSource, BlueprintZoneType,
         CockroachDbPreserveDowngrade, OximeterReadMode, PendingMgsUpdates,
-        PlanningReport, blueprint_zone_type,
+        blueprint_zone_type,
     };
     use nexus_types::external_api::views::SledState;
     use omicron_common::api::external;
@@ -328,7 +328,7 @@ mod test {
             time_created: chrono::Utc::now(),
             creator: "test".to_string(),
             comment: "test blueprint".to_string(),
-            report: PlanningReport::new(id),
+            source: BlueprintSource::Test,
         };
 
         datastore

--- a/nexus/src/app/background/tasks/blueprint_load.rs
+++ b/nexus/src/app/background/tasks/blueprint_load.rs
@@ -196,8 +196,8 @@ mod test {
     use nexus_inventory::now_db_precision;
     use nexus_test_utils_macros::nexus_test;
     use nexus_types::deployment::{
-        Blueprint, BlueprintTarget, CockroachDbPreserveDowngrade,
-        OximeterReadMode, PendingMgsUpdates, PlanningReport,
+        Blueprint, BlueprintSource, BlueprintTarget,
+        CockroachDbPreserveDowngrade, OximeterReadMode, PendingMgsUpdates,
     };
     use omicron_common::api::external::Generation;
     use omicron_uuid_kinds::BlueprintUuid;
@@ -235,7 +235,7 @@ mod test {
                 time_created: now_db_precision(),
                 creator: "test".to_string(),
                 comment: "test blueprint".to_string(),
-                report: PlanningReport::new(id),
+                source: BlueprintSource::Test,
             },
         )
     }

--- a/nexus/src/app/background/tasks/blueprint_planner.rs
+++ b/nexus/src/app/background/tasks/blueprint_planner.rs
@@ -14,6 +14,8 @@ use nexus_db_queries::db::DataStore;
 use nexus_reconfigurator_planning::planner::Planner;
 use nexus_reconfigurator_planning::planner::PlannerRng;
 use nexus_reconfigurator_preparation::PlanningInputFromDb;
+use nexus_types::deployment::BlueprintSource;
+use nexus_types::deployment::PlanningReport;
 use nexus_types::deployment::{Blueprint, BlueprintTarget};
 use nexus_types::internal_api::background::BlueprintPlannerStatus;
 use omicron_common::api::external::LookupType;
@@ -257,7 +259,19 @@ impl BlueprintPlanner {
         }
 
         // We have a new target!
-        let report = blueprint.report.clone();
+
+        // We just ran the planner, so we should always get its report. This
+        // output is for debugging only, though, so just make an empty one in
+        // the unreachable arms.
+        let report = match &blueprint.source {
+            BlueprintSource::Planner(report) => Arc::clone(report),
+            BlueprintSource::Rss
+            | BlueprintSource::PlannerLoadedFromDatabase
+            | BlueprintSource::ReconfiguratorCliEdit
+            | BlueprintSource::Test => {
+                Arc::new(PlanningReport::new(blueprint.id))
+            }
+        };
         self.tx_blueprint.send_replace(Some(Arc::new((target, blueprint))));
         BlueprintPlannerStatus::Targeted {
             parent_blueprint_id,

--- a/nexus/test-utils/src/lib.rs
+++ b/nexus/test-utils/src/lib.rs
@@ -50,6 +50,7 @@ use nexus_types::deployment::BlueprintHostPhase2DesiredSlots;
 use nexus_types::deployment::BlueprintPhysicalDiskConfig;
 use nexus_types::deployment::BlueprintPhysicalDiskDisposition;
 use nexus_types::deployment::BlueprintSledConfig;
+use nexus_types::deployment::BlueprintSource;
 use nexus_types::deployment::BlueprintZoneConfig;
 use nexus_types::deployment::BlueprintZoneDisposition;
 use nexus_types::deployment::BlueprintZoneImageSource;
@@ -60,7 +61,6 @@ use nexus_types::deployment::OmicronZoneExternalFloatingIp;
 use nexus_types::deployment::OmicronZoneExternalSnatIp;
 use nexus_types::deployment::OximeterReadMode;
 use nexus_types::deployment::PlannerConfig;
-use nexus_types::deployment::PlanningReport;
 use nexus_types::deployment::ReconfiguratorConfig;
 use nexus_types::deployment::blueprint_zone_type;
 use nexus_types::external_api::views::SledState;
@@ -1035,7 +1035,7 @@ impl<'a, N: NexusServer> ControlPlaneTestContextBuilder<'a, N> {
             time_created: Utc::now(),
             creator: "nexus-test-utils".to_string(),
             comment: "initial test blueprint".to_string(),
-            report: PlanningReport::new(id),
+            source: BlueprintSource::Test,
         };
 
         self.initial_blueprint_id = Some(blueprint.id);

--- a/nexus/tests/integration_tests/quiesce.rs
+++ b/nexus/tests/integration_tests/quiesce.rs
@@ -10,6 +10,7 @@ use nexus_reconfigurator_planning::planner::PlannerRng;
 use nexus_reconfigurator_preparation::PlanningInputFromDb;
 use nexus_test_interface::NexusServer;
 use nexus_test_utils_macros::nexus_test;
+use nexus_types::deployment::BlueprintSource;
 use nexus_types::deployment::BlueprintTargetSet;
 use nexus_types::deployment::PlannerConfig;
 use omicron_common::api::external::Error;
@@ -83,7 +84,7 @@ async fn test_quiesce(cptestctx: &ControlPlaneTestContext) {
     )
     .expect("creating BlueprintBuilder");
     builder.set_nexus_generation(blueprint1.nexus_generation.next());
-    let blueprint2 = builder.build();
+    let blueprint2 = builder.build(BlueprintSource::Test);
     nexus
         .blueprint_import(&opctx, blueprint2.clone())
         .await

--- a/nexus/types/src/deployment.rs
+++ b/nexus/types/src/deployment.rs
@@ -430,6 +430,7 @@ impl Blueprint {
 #[derive(
     Clone, Debug, Eq, PartialEq, JsonSchema, Deserialize, Serialize, Diffable,
 )]
+#[serde(tag = "source", rename_all = "snake_case")]
 pub enum BlueprintSource {
     /// The initial blueprint created by the rack setup service.
     Rss,

--- a/nexus/types/src/deployment.rs
+++ b/nexus/types/src/deployment.rs
@@ -452,7 +452,9 @@ impl fmt::Display for BlueprintSource {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         match self {
             Self::Rss => writeln!(f, "rack setup"),
-            Self::Planner(report) => writeln!(f, "planner\n{report}"),
+            Self::Planner(report) => {
+                writeln!(f, "planner with report:\n{report}")
+            }
             Self::PlannerLoadedFromDatabase => {
                 writeln!(f, "planner (no report available")
             }

--- a/nexus/types/src/deployment.rs
+++ b/nexus/types/src/deployment.rs
@@ -292,6 +292,7 @@ impl Blueprint {
             time_created: self.time_created,
             creator: self.creator.clone(),
             comment: self.comment.clone(),
+            source: self.source.clone(),
         }
     }
 
@@ -2179,6 +2180,8 @@ pub struct BlueprintMetadata {
     /// human-readable string describing why this blueprint was created
     /// (for debugging)
     pub comment: String,
+    /// source of the blueprint (for debugging)
+    pub source: BlueprintSource,
 }
 
 /// Describes what blueprint, if any, the system is currently working toward

--- a/nexus/types/src/deployment/blueprint_diff.rs
+++ b/nexus/types/src/deployment/blueprint_diff.rs
@@ -77,7 +77,7 @@ impl<'a> BlueprintDiffSummary<'a> {
             oximeter_read_mode,
             creator: _,
             comment: _,
-            report: _,
+            source: _,
         } = &self.diff;
 
         // Did we modify, add, or remove any sleds?

--- a/nexus/types/src/internal_api/background.rs
+++ b/nexus/types/src/internal_api/background.rs
@@ -481,7 +481,6 @@ impl slog::KV for DebugDatasetsRendezvousStats {
 }
 
 /// The status of a `blueprint_planner` background task activation.
-#[allow(clippy::large_enum_variant)]
 #[derive(Clone, Debug, Deserialize, Serialize, PartialEq, Eq)]
 pub enum BlueprintPlannerStatus {
     /// Automatic blueprint planning has been explicitly disabled
@@ -504,7 +503,7 @@ pub enum BlueprintPlannerStatus {
     Targeted {
         parent_blueprint_id: BlueprintUuid,
         blueprint_id: BlueprintUuid,
-        report: PlanningReport,
+        report: Arc<PlanningReport>,
     },
 }
 

--- a/openapi/nexus-internal.json
+++ b/openapi/nexus-internal.json
@@ -2609,20 +2609,20 @@
               }
             ]
           },
-          "report": {
-            "description": "Report on the planning session that resulted in this blueprint",
-            "allOf": [
-              {
-                "$ref": "#/components/schemas/PlanningReport"
-              }
-            ]
-          },
           "sleds": {
             "description": "A map of sled id -> desired configuration of the sled.",
             "type": "object",
             "additionalProperties": {
               "$ref": "#/components/schemas/BlueprintSledConfig"
             }
+          },
+          "source": {
+            "description": "Source of this blueprint",
+            "allOf": [
+              {
+                "$ref": "#/components/schemas/BlueprintSource"
+              }
+            ]
           },
           "target_release_minimum_generation": {
             "description": "The minimum release generation to accept for target release configuration. Target release configuration with a generation less than this number will be ignored.\n\nFor example, let's say that the current target release generation is 5. Then, when reconfigurator detects a MUPdate:\n\n* the target release is ignored in favor of the install dataset * this field is set to 6\n\nOnce an operator sets a new target release, its generation will be 6 or higher. Reconfigurator will then know that it is back in charge of driving the system to the target release.",
@@ -2650,8 +2650,8 @@
           "oximeter_read_mode",
           "oximeter_read_version",
           "pending_mgs_updates",
-          "report",
           "sleds",
+          "source",
           "target_release_minimum_generation",
           "time_created"
         ]
@@ -3051,6 +3051,132 @@
           "sled_agent_generation",
           "state",
           "zones"
+        ]
+      },
+      "BlueprintSource": {
+        "description": "Description of the source of a blueprint.",
+        "oneOf": [
+          {
+            "description": "The initial blueprint created by the rack setup service.",
+            "type": "object",
+            "properties": {
+              "source": {
+                "type": "string",
+                "enum": [
+                  "rss"
+                ]
+              }
+            },
+            "required": [
+              "source"
+            ]
+          },
+          {
+            "description": "A blueprint created by the planner, and we still have the associated planning report.",
+            "type": "object",
+            "properties": {
+              "add": {
+                "$ref": "#/components/schemas/PlanningAddStepReport"
+              },
+              "blueprint_id": {
+                "description": "The blueprint produced by the planning run this report describes.",
+                "allOf": [
+                  {
+                    "$ref": "#/components/schemas/TypedUuidForBlueprintKind"
+                  }
+                ]
+              },
+              "cockroachdb_settings": {
+                "$ref": "#/components/schemas/PlanningCockroachdbSettingsStepReport"
+              },
+              "decommission": {
+                "$ref": "#/components/schemas/PlanningDecommissionStepReport"
+              },
+              "expunge": {
+                "$ref": "#/components/schemas/PlanningExpungeStepReport"
+              },
+              "mgs_updates": {
+                "$ref": "#/components/schemas/PlanningMgsUpdatesStepReport"
+              },
+              "noop_image_source": {
+                "$ref": "#/components/schemas/PlanningNoopImageSourceStepReport"
+              },
+              "planner_config": {
+                "description": "The configuration in effect for this planning run.",
+                "allOf": [
+                  {
+                    "$ref": "#/components/schemas/PlannerConfig"
+                  }
+                ]
+              },
+              "source": {
+                "type": "string",
+                "enum": [
+                  "planner"
+                ]
+              },
+              "zone_updates": {
+                "$ref": "#/components/schemas/PlanningZoneUpdatesStepReport"
+              }
+            },
+            "required": [
+              "add",
+              "blueprint_id",
+              "cockroachdb_settings",
+              "decommission",
+              "expunge",
+              "mgs_updates",
+              "noop_image_source",
+              "planner_config",
+              "source",
+              "zone_updates"
+            ]
+          },
+          {
+            "description": "A blueprint created by the planner but loaded from the database, so we no longer have the associated planning report.",
+            "type": "object",
+            "properties": {
+              "source": {
+                "type": "string",
+                "enum": [
+                  "planner_loaded_from_database"
+                ]
+              }
+            },
+            "required": [
+              "source"
+            ]
+          },
+          {
+            "description": "This blueprint was created by one of `reconfigurator-cli`'s blueprint editing subcommands.",
+            "type": "object",
+            "properties": {
+              "source": {
+                "type": "string",
+                "enum": [
+                  "reconfigurator_cli_edit"
+                ]
+              }
+            },
+            "required": [
+              "source"
+            ]
+          },
+          {
+            "description": "This blueprint was created by a test.",
+            "type": "object",
+            "properties": {
+              "source": {
+                "type": "string",
+                "enum": [
+                  "test"
+                ]
+              }
+            },
+            "required": [
+              "source"
+            ]
+          }
         ]
       },
       "BlueprintTarget": {
@@ -7249,60 +7375,6 @@
         "required": [
           "desired_image_source",
           "zone_config"
-        ]
-      },
-      "PlanningReport": {
-        "description": "A full blueprint planning report. Other than the blueprint ID, each field corresponds to a step in the update planner, i.e., a subroutine of `omicron_nexus::reconfigurator::planning::Planner::do_plan`.\n\nThe intent of a planning report is to capture information useful to an operator or developer about the planning process itself, especially if it has become \"stuck\" (unable to proceed with an update). It is *not* a summary of the plan (blueprint), but rather a description of non-fatal conditions the planner is waiting on, unexpected or invalid configurations encountered during planning, etc. The planner may make internal decisions based on the step reports; the intent is that an operator may make administrative decisions based on the full report.\n\nOnly successful planning runs are currently covered by this report. Failures to plan (i.e., to generate a valid blueprint) are represented by `nexus-reconfigurator-planning::blueprint_builder::Error`.",
-        "type": "object",
-        "properties": {
-          "add": {
-            "$ref": "#/components/schemas/PlanningAddStepReport"
-          },
-          "blueprint_id": {
-            "description": "The blueprint produced by the planning run this report describes.",
-            "allOf": [
-              {
-                "$ref": "#/components/schemas/TypedUuidForBlueprintKind"
-              }
-            ]
-          },
-          "cockroachdb_settings": {
-            "$ref": "#/components/schemas/PlanningCockroachdbSettingsStepReport"
-          },
-          "decommission": {
-            "$ref": "#/components/schemas/PlanningDecommissionStepReport"
-          },
-          "expunge": {
-            "$ref": "#/components/schemas/PlanningExpungeStepReport"
-          },
-          "mgs_updates": {
-            "$ref": "#/components/schemas/PlanningMgsUpdatesStepReport"
-          },
-          "noop_image_source": {
-            "$ref": "#/components/schemas/PlanningNoopImageSourceStepReport"
-          },
-          "planner_config": {
-            "description": "The configuration in effect for this planning run.",
-            "allOf": [
-              {
-                "$ref": "#/components/schemas/PlannerConfig"
-              }
-            ]
-          },
-          "zone_updates": {
-            "$ref": "#/components/schemas/PlanningZoneUpdatesStepReport"
-          }
-        },
-        "required": [
-          "add",
-          "blueprint_id",
-          "cockroachdb_settings",
-          "decommission",
-          "expunge",
-          "mgs_updates",
-          "noop_image_source",
-          "planner_config",
-          "zone_updates"
         ]
       },
       "PlanningZoneUpdatesStepReport": {

--- a/openapi/nexus-internal.json
+++ b/openapi/nexus-internal.json
@@ -2888,6 +2888,14 @@
               }
             ]
           },
+          "source": {
+            "description": "source of the blueprint (for debugging)",
+            "allOf": [
+              {
+                "$ref": "#/components/schemas/BlueprintSource"
+              }
+            ]
+          },
           "target_release_minimum_generation": {
             "description": "The minimum generation for the target release.\n\nSee [`Blueprint::target_release_minimum_generation`].",
             "allOf": [
@@ -2910,6 +2918,7 @@
           "id",
           "internal_dns_version",
           "nexus_generation",
+          "source",
           "target_release_minimum_generation",
           "time_created"
         ]

--- a/schema/crdb/blueprint-source/up1.sql
+++ b/schema/crdb/blueprint-source/up1.sql
@@ -1,0 +1,6 @@
+CREATE TYPE IF NOT EXISTS omicron.public.bp_source AS ENUM (
+    'rss',
+    'planner',
+    'reconfigurator_cli_edit',
+    'test'
+);

--- a/schema/crdb/blueprint-source/up2.sql
+++ b/schema/crdb/blueprint-source/up2.sql
@@ -1,0 +1,11 @@
+ALTER TABLE omicron.public.blueprint
+    ADD COLUMN IF NOT EXISTS source omicron.public.bp_source NOT NULL
+    -- This will be wrong for any deployed systems that still have a blueprint
+    -- produced by RSS (unlikely, given we archive old blueprints during
+    -- updates, but possible) or that have blueprints produced from
+    -- reconfigurator-cli edits (unlikely for customer systems, but maybe we've
+    -- done that on dogfood or colo?). However: this value is only for
+    -- debugging, and almost all blueprints on all systems will have been
+    -- produced by the planner. It seems more prudent to be slightly wrong on
+    -- some unlikely cases than to do a bunch of work to be more precise.
+    DEFAULT 'planner';

--- a/schema/crdb/blueprint-source/up3.sql
+++ b/schema/crdb/blueprint-source/up3.sql
@@ -1,0 +1,1 @@
+ALTER TABLE omicron.public.blueprint ALTER COLUMN source DROP DEFAULT;

--- a/schema/crdb/dbinit.sql
+++ b/schema/crdb/dbinit.sql
@@ -4506,6 +4506,13 @@ CREATE TYPE IF NOT EXISTS omicron.public.bp_physical_disk_disposition AS ENUM (
     'expunged'
 );
 
+CREATE TYPE IF NOT EXISTS omicron.public.bp_source AS ENUM (
+    'rss',
+    'planner',
+    'reconfigurator_cli_edit',
+    'test'
+);
+
 -- list of all blueprints
 CREATE TABLE IF NOT EXISTS omicron.public.blueprint (
     id UUID PRIMARY KEY,
@@ -4559,7 +4566,10 @@ CREATE TABLE IF NOT EXISTS omicron.public.blueprint (
     target_release_minimum_generation INT8 NOT NULL,
 
     -- The generation of the active group of Nexus instances
-    nexus_generation INT8 NOT NULL
+    nexus_generation INT8 NOT NULL,
+
+    -- The source of this blueprint
+    source bp_source NOT NULL
 );
 
 -- table describing both the current and historical target blueprints of the

--- a/schema/crdb/dbinit.sql
+++ b/schema/crdb/dbinit.sql
@@ -4569,7 +4569,7 @@ CREATE TABLE IF NOT EXISTS omicron.public.blueprint (
     nexus_generation INT8 NOT NULL,
 
     -- The source of this blueprint
-    source bp_source NOT NULL
+    source omicron.public.bp_source NOT NULL
 );
 
 -- table describing both the current and historical target blueprints of the

--- a/schema/crdb/dbinit.sql
+++ b/schema/crdb/dbinit.sql
@@ -6668,7 +6668,7 @@ INSERT INTO omicron.public.db_metadata (
     version,
     target_version
 ) VALUES
-    (TRUE, NOW(), NOW(), '191.0.0', NULL)
+    (TRUE, NOW(), NOW(), '192.0.0', NULL)
 ON CONFLICT DO NOTHING;
 
 COMMIT;

--- a/sled-agent/src/rack_setup/service.rs
+++ b/sled-agent/src/rack_setup/service.rs
@@ -95,9 +95,9 @@ use nexus_sled_agent_shared::inventory::{
 };
 use nexus_types::deployment::{
     Blueprint, BlueprintDatasetConfig, BlueprintDatasetDisposition,
-    BlueprintHostPhase2DesiredSlots, BlueprintSledConfig, BlueprintZoneType,
-    CockroachDbPreserveDowngrade, OximeterReadMode, PendingMgsUpdates,
-    PlanningReport, blueprint_zone_type,
+    BlueprintHostPhase2DesiredSlots, BlueprintSledConfig, BlueprintSource,
+    BlueprintZoneType, CockroachDbPreserveDowngrade, OximeterReadMode,
+    PendingMgsUpdates, blueprint_zone_type,
 };
 use nexus_types::external_api::views::SledState;
 use ntp_admin_client::{
@@ -1646,7 +1646,7 @@ pub(crate) fn build_initial_blueprint_from_sled_configs(
         time_created: Utc::now(),
         creator: "RSS".to_string(),
         comment: "initial blueprint from rack setup".to_string(),
-        report: PlanningReport::new(id),
+        source: BlueprintSource::Rss,
     })
 }
 


### PR DESCRIPTION
This is the new path we discussed in https://github.com/oxidecomputer/omicron/pull/9032#discussion_r2356299501:

* Replace `report` with `source` in `Blueprint`
* We do serialize `source` in the db, but it has two variants for a source of `Planner`: one that has a report (when the blueprint is first created) and one that doesn't (when the blueprint has been loaded from the db)