### PR TITLE
fix: use lazy argument evaluation to handle errors

### DIFF
--- a/sled-agent/src/bin/sled-agent.rs
+++ b/sled-agent/src/bin/sled-agent.rs
@@ -62,13 +62,18 @@ async fn do_run() -> Result<(), CmdError> {
                 rss_config_path.push("config-rss.toml");
                 rss_config_path
             };
-            let rss_config = rss_config_path.exists().then_some({
+            let rss_config = if rss_config_path.exists() {
                 let rss_config =
                     RackInitializeRequest::from_file(rss_config_path)
                         .map_err(|e| CmdError::Failure(anyhow!(e)))?;
                 let skip_timesync = config.skip_timesync.unwrap_or(false);
-                RackInitializeRequestParams::new(rss_config, skip_timesync)
-            });
+                Some(RackInitializeRequestParams::new(
+                    rss_config,
+                    skip_timesync,
+                ))
+            } else {
+                None
+            };
 
             let server = bootstrap_server::Server::start(config)
                 .await


### PR DESCRIPTION
An instance of `.then_some` on a bool should have been `.then`. The former evaluates its arguments eagerly, so runs _regardless of the value of the bool_, while the latter does so lazily, which was the desired behavior.

In testing, all of our configurations had the file we were testing the presence of before reading.  But other folks do not.

Fixes #9051