### PR TITLE
[omdb] de-flake and tidy up `sp_ereport_ingester` status

### DIFF
--- a/dev-tools/omdb/src/bin/omdb/nexus.rs
+++ b/dev-tools/omdb/src/bin/omdb/nexus.rs
@@ -2834,6 +2834,7 @@ fn print_task_webhook_deliverator(details: &serde_json::Value) {
 }
 
 fn print_task_sp_ereport_ingester(details: &serde_json::Value) {
+    use ereporter_status_fields::*;
     use nexus_types::internal_api::background::SpEreportIngesterStatus;
     use nexus_types::internal_api::background::SpEreporterStatus;
 
@@ -2849,15 +2850,8 @@ fn print_task_sp_ereport_ingester(details: &serde_json::Value) {
             Ok(status) => status,
         };
 
-    const NEW_EREPORTS: &str = "new ereports ingested:";
-    const HTTP_REQUESTS: &str = "HTTP requests sent:";
-    const ERRORS: &str = "errors:";
-    const WIDTH: usize =
-        const_max_len(&[NEW_EREPORTS, HTTP_REQUESTS, ERRORS]) + 1;
-    const NUM_WIDTH: usize = 3;
-
     if !errors.is_empty() {
-        println!("{ERRICON} {ERRORS:<WIDTH$}{:>NUM_WIDTH$}", errors.len());
+        println!("    errors listing reporters:");
         for error in errors {
             println!("      - {error}");
         }
@@ -2876,6 +2870,7 @@ fn print_task_sp_ereport_ingester(details: &serde_json::Value) {
                  some SP statuses were recorded!"
             )
         }
+
         println!("\n    service processors:");
         for SpEreporterStatus { sp_type, slot, status } in &sps {
             println!(
@@ -2933,22 +2928,7 @@ fn print_ereporter_status_totals<'status>(
         }
     }
 
-    const EREPORTS_RECEIVED: &str = "total ereports received:";
-    const NEW_EREPORTS: &str = "  new ereports ingested:";
-    const HTTP_REQUESTS: &str = "total HTTP requests sent:";
-    const ERRORS: &str = "  total collection errors:";
-    const REPORTERS_WITH_EREPORTS: &str = "reporters with ereports:";
-    const REPORTERS_WITH_ERRORS: &str = "reporters with collection errors:";
-    const WIDTH: usize = const_max_len(&[
-        EREPORTS_RECEIVED,
-        NEW_EREPORTS,
-        HTTP_REQUESTS,
-        ERRORS,
-        REPORTERS_WITH_EREPORTS,
-        REPORTERS_WITH_ERRORS,
-    ]) + 1;
-    const NUM_WIDTH: usize = 4;
-
+    use ereporter_status_fields::*;
     println!("    {EREPORTS_RECEIVED:<WIDTH$}{total_received:>NUM_WIDTH$}");
     println!("    {NEW_EREPORTS:<WIDTH$}{total_new:>NUM_WIDTH$}");
     println!("    {HTTP_REQUESTS:<WIDTH$}{total_reqs:>NUM_WIDTH$}");
@@ -2961,6 +2941,29 @@ fn print_ereporter_status_totals<'status>(
         "    {REPORTERS_WITH_ERRORS:<WIDTH$}\
          {reporters_with_errors:>NUM_WIDTH$}"
     );
+}
+
+mod ereporter_status_fields {
+    pub const TOTAL_NEW_EREPORTS: &str = "new ereports ingested:";
+    pub const TOTAL_HTTP_REQUESTS: &str = "HTTP requests sent:";
+
+    pub const EREPORTS_RECEIVED: &str = "total ereports received:";
+    pub const NEW_EREPORTS: &str = "  new ereports ingested:";
+    pub const HTTP_REQUESTS: &str = "total HTTP requests sent:";
+    pub const ERRORS: &str = "  total collection errors:";
+    pub const REPORTERS_WITH_EREPORTS: &str = "reporters with ereports:";
+    pub const REPORTERS_WITH_ERRORS: &str = "reporters with collection errors:";
+    pub const WIDTH: usize = super::const_max_len(&[
+        TOTAL_NEW_EREPORTS,
+        TOTAL_HTTP_REQUESTS,
+        EREPORTS_RECEIVED,
+        NEW_EREPORTS,
+        HTTP_REQUESTS,
+        ERRORS,
+        REPORTERS_WITH_EREPORTS,
+        REPORTERS_WITH_ERRORS,
+    ]) + 1;
+    pub const NUM_WIDTH: usize = 4;
 }
 
 const ERRICON: &str = "/!\\";

--- a/dev-tools/omdb/src/bin/omdb/nexus.rs
+++ b/dev-tools/omdb/src/bin/omdb/nexus.rs
@@ -2945,6 +2945,7 @@ fn print_ereporter_status_totals<'status>(
         HTTP_REQUESTS,
         ERRORS,
         REPORTERS_WITH_EREPORTS,
+        REPORTERS_WITH_ERRORS,
     ]) + 1;
     const NUM_WIDTH: usize = 4;
 

--- a/dev-tools/omdb/tests/successes.out
+++ b/dev-tools/omdb/tests/successes.out
@@ -759,14 +759,12 @@ task: "sp_ereport_ingester"
   configured period: every <REDACTED_DURATION>s
   last completed activation: <REDACTED ITERATIONS>, triggered by <TRIGGERED_BY_REDACTED>
     started at <REDACTED_TIMESTAMP> (<REDACTED DURATION>s ago) and ran for <REDACTED DURATION>ms
-/!\ errors:                  1
-      - failed to resolve MGS addresses: proto error: no records found for Query { name: Name("_mgs._tcp.control-plane.oxide.internal."), query_type: SRV, query_class: IN }
-    total ereports received:      0
-      new ereports ingested:      0
-    total HTTP requests sent:     0
-      total collection errors:    0
-    reporters with ereports:      0
-    reporters with collection errors:   0
+    total ereports received:             <TOTAL_EREPORTS_RECEIVED_REDACTED>
+      new ereports ingested:             <NEW_EREPORTS_INGESTED_REDACTED>
+    total HTTP requests sent:            <TOTAL_HTTP_REQUESTS_SENT_REDACTED>
+      total collection errors:           <TOTAL_COLLECTION_ERRORS_REDACTED>
+    reporters with ereports:             <REPORTERS_WITH_EREPORTS_REDACTED>
+    reporters with collection errors:    <REPORTERS_WITH_COLLECTION_ERRORS_REDACTED>
 
 task: "support_bundle_collector"
   configured period: every <REDACTED_DURATION>days <REDACTED_DURATION>h <REDACTED_DURATION>m <REDACTED_DURATION>s
@@ -1277,14 +1275,12 @@ task: "sp_ereport_ingester"
   configured period: every <REDACTED_DURATION>s
   last completed activation: <REDACTED ITERATIONS>, triggered by <TRIGGERED_BY_REDACTED>
     started at <REDACTED_TIMESTAMP> (<REDACTED DURATION>s ago) and ran for <REDACTED DURATION>ms
-/!\ errors:                  1
-      - failed to resolve MGS addresses: proto error: no records found for Query { name: Name("_mgs._tcp.control-plane.oxide.internal."), query_type: SRV, query_class: IN }
-    total ereports received:      0
-      new ereports ingested:      0
-    total HTTP requests sent:     0
-      total collection errors:    0
-    reporters with ereports:      0
-    reporters with collection errors:   0
+    total ereports received:             <TOTAL_EREPORTS_RECEIVED_REDACTED>
+      new ereports ingested:             <NEW_EREPORTS_INGESTED_REDACTED>
+    total HTTP requests sent:            <TOTAL_HTTP_REQUESTS_SENT_REDACTED>
+      total collection errors:           <TOTAL_COLLECTION_ERRORS_REDACTED>
+    reporters with ereports:             <REPORTERS_WITH_EREPORTS_REDACTED>
+    reporters with collection errors:    <REPORTERS_WITH_COLLECTION_ERRORS_REDACTED>
 
 task: "support_bundle_collector"
   configured period: every <REDACTED_DURATION>days <REDACTED_DURATION>h <REDACTED_DURATION>m <REDACTED_DURATION>s

--- a/dev-tools/omdb/tests/test_all_output.rs
+++ b/dev-tools/omdb/tests/test_all_output.rs
@@ -303,6 +303,26 @@ async fn test_omdb_success_cases(cptestctx: &ControlPlaneTestContext) {
         .field("triggered by", r"[\w ]+")
         .section(&["task: \"tuf_artifact_replication\"", "request ringbuf:"]);
 
+    // The `sp_ereport_ingester` task's output depends on how many simulated
+    // sled agents ahppen to register with Nexus before its first execution.
+    // These redactions work around the issue described in
+    // https://github.com/oxidecomputer/omicron/issues/8979
+    redactor
+        .field("total ereports received:", r"\d+")
+        .field("new ereports ingested:", r"\d+")
+        .field("total HTTP requests sent:", r"\d+")
+        .field("total collection errors:", r"\d+")
+        .field("reporters with ereports:", r"\d+")
+        .field("reporters with collection errors:", r"\d+")
+        .totally_annihilate_section(&[
+            "task: \"sp_ereport_ingester\"",
+            "errors listing reporters:",
+        ])
+        .totally_annihilate_section(&[
+            "task: \"sp_ereport_ingester\"",
+            "service processors:",
+        ]);
+
     for args in invocations {
         println!("running commands with args: {:?}", args);
         let p = postgres_url.to_string();


### PR DESCRIPTION
There's currently a test flake in the `test_omdb_success_cases` test due to the output from the `sp_ereport_ingester` background task (see #8979). This is because [the status output for that test will depend on the number of MGSes and simulated SPs that are currently present when the test runs][1]. In particular, this means that the output may [differ based on whether the test is run in isolation or as part of a run including other tests][2], as it's likelier that Nexus will have discovered the simulated SPs when other tests have already run.

This branch fixes the flake by adding additional redaction configs for this task's status output. We now redact all the numbers in the output. Additionally, we must redact the sections listing individual SPs and their ereport counts, and the section listing top level errors. Since these sections are only shown when the lists of SPs or errors are non-empty (the output looks weird if we print an empty section heading for them), we don't use the existing `Redactor::section` method. This method will replace the _indented contents_ of a section with the string `<{section_name}_REDACTED>`. That's sufficient when just the section _contents_ are variable, but in this case, the sections may or may not be present depending on whether MGS was up, so we would get either a redacted section (if it was present) _or_ nothing.  Therefore, I've added a new `Redactor::totally_annihilate_section` method that removes a section _along with its heading_ for use in this case. It's a bit of a shame to totally wipe these sections from the output, but it seemed like the best choice under the circumstances.

I've also tweaked the status output a little bit to fix some cases where numbers in the output were not aligned the way I wanted them to be, and to make it slightly friendlier to the redactor by removing totals from the headings of redacted sections.

Fixes #8979

[1]: https://github.com/oxidecomputer/omicron/issues/8926#issuecomment-3229946163
[2]: https://github.com/oxidecomputer/omicron/issues/8926#issuecomment-3235291262
