### PR TITLE
[reconfigurator-planning] allow adding zones if target release generation is 1

### DIFF
--- a/dev-tools/reconfigurator-cli/tests/input/cmds-add-sled-no-disks.txt
+++ b/dev-tools/reconfigurator-cli/tests/input/cmds-add-sled-no-disks.txt
@@ -12,10 +12,6 @@ sled-add --ndisks 0
 # Generate a new inventory collection that includes that sled.
 inventory-generate
 
-# Set the add_zones_with_mupdate_override planner config to ensure that zone
-# adds happen despite zone image sources not being Artifact.
-set planner-config --add-zones-with-mupdate-override true
-
 # Try to plan a new blueprint; this should be okay even though the sled
 # we added has no disks.
 blueprint-plan dbcbd3d6-41ff-48ae-ac0b-1becc9b2fd21 eb0796d5-ab8a-4f7b-a884-b4aeacb8ab51

--- a/dev-tools/reconfigurator-cli/tests/input/cmds-add-zones-with-mupdate-override.txt
+++ b/dev-tools/reconfigurator-cli/tests/input/cmds-add-zones-with-mupdate-override.txt
@@ -1,0 +1,40 @@
+# This script tests the add-zones-with-mupdate-override
+# planner config.
+
+# Load example system
+load-example --nsleds 3 --ndisks-per-sled 3
+
+# Create a TUF repository from a fake manifest. We're going to use this
+# repository to test out the minimum release generation flow.
+tuf-assemble ../../update-common/manifests/fake.toml
+set target-release repo-1.0.0.zip
+
+# Update the install dataset on this sled to the target release.
+# (This populates the zone manifest, used for no-op conversions from
+# install dataset to artifact down the road.)
+sled-update-install-dataset serial0 --to-target-release
+
+# Simulate a mupdate on sled 0 by setting the mupdate override field to a
+# new UUID (generated using uuidgen).
+sled-set serial0 mupdate-override 2d0f6cbc-addc-47a2-962a-6a01e13376bf
+
+# Generate a new inventory and plan against that.
+inventory-generate
+blueprint-plan latest latest
+
+# Diff the blueprints. This diff should show "will remove mupdate override"
+# and the target release minimum generation being set.
+blueprint-diff latest
+
+# Set Nexus redundancy to 4.
+set num-nexus 4
+
+# Plan with the new Nexus. This will not add any Nexus zones.
+blueprint-plan latest latest
+blueprint-diff latest
+
+# Set the add-zones-with-mupdate-override config, then do a planning run.
+# This *will* add a new Nexus zone.
+set planner-config --add-zones-with-mupdate-override true
+blueprint-plan latest latest
+blueprint-diff latest

--- a/dev-tools/reconfigurator-cli/tests/input/cmds-expunge-newly-added-internal-dns.txt
+++ b/dev-tools/reconfigurator-cli/tests/input/cmds-expunge-newly-added-internal-dns.txt
@@ -12,10 +12,6 @@ blueprint-diff dbcbd3d6-41ff-48ae-ac0b-1becc9b2fd21 8da82a8e-bf97-4fbd-8ddd-9f64
 blueprint-edit 8da82a8e-bf97-4fbd-8ddd-9f6462732cf1 mark-for-cleanup 99e2f30b-3174-40bf-a78a-90da8abba8ca
 blueprint-diff 8da82a8e-bf97-4fbd-8ddd-9f6462732cf1 58d5e830-0884-47d8-a7cd-b2b3751adeb4
 
-# Set the add_zones_with_mupdate_override planner config to ensure that zone
-# adds happen despite zone image sources not being Artifact.
-set planner-config --add-zones-with-mupdate-override true
-
 # Planning a new blueprint will now replace the expunged zone, with new records for its replacement.
 blueprint-plan 58d5e830-0884-47d8-a7cd-b2b3751adeb4
 blueprint-diff 58d5e830-0884-47d8-a7cd-b2b3751adeb4 af934083-59b5-4bf6-8966-6fb5292c29e1

--- a/dev-tools/reconfigurator-cli/tests/output/cmds-add-sled-no-disks-stdout
+++ b/dev-tools/reconfigurator-cli/tests/output/cmds-add-sled-no-disks-stdout
@@ -33,14 +33,6 @@ added sled 00320471-945d-413c-85e7-03e091a70b3c (serial: serial3)
 generated inventory collection eb0796d5-ab8a-4f7b-a884-b4aeacb8ab51 from configured sleds
 
 
-> # Set the add_zones_with_mupdate_override planner config to ensure that zone
-> # adds happen despite zone image sources not being Artifact.
-> set planner-config --add-zones-with-mupdate-override true
-planner config updated:
-*   add zones with mupdate override:   false -> true
-
-
-
 > # Try to plan a new blueprint; this should be okay even though the sled
 > # we added has no disks.
 > blueprint-plan dbcbd3d6-41ff-48ae-ac0b-1becc9b2fd21 eb0796d5-ab8a-4f7b-a884-b4aeacb8ab51
@@ -48,16 +40,13 @@ INFO skipping noop image source check for all sleds, reason: no target release i
 generated blueprint 8da82a8e-bf97-4fbd-8ddd-9f6462732cf1 based on parent blueprint dbcbd3d6-41ff-48ae-ac0b-1becc9b2fd21
 blueprint source: planner with report:
 planning report:
-planner config:
-    add zones with mupdate override:   true
-
 * zone adds and updates are blocked:
   - sleds have deployment units with image sources not set to Artifact:
     - sled 2b8f0cb3-0295-4b3c-bc58-4fe88b57112c: 9 zones
     - sled 98e6b7c2-2efa-41ca-b20a-0a4d61102fe6: 8 zones
     - sled d81c6a84-79b8-4958-ae41-ea46c9b19763: 8 zones
 
-* adding zones despite being blocked, as specified by the `add_zones_with_mupdate_override` planner config option
+* adding zones despite being blocked, because: target release generation is 1
 * no zpools in service for NTP zones on sleds: 00320471-945d-413c-85e7-03e091a70b3c
 * discretionary zone placement waiting for NTP zones on sleds: 00320471-945d-413c-85e7-03e091a70b3c
 * zone updates waiting on zone add blockers
@@ -297,16 +286,13 @@ parent:    dbcbd3d6-41ff-48ae-ac0b-1becc9b2fd21
 
 blueprint source: planner with report:
 planning report:
-planner config:
-    add zones with mupdate override:   true
-
 * zone adds and updates are blocked:
   - sleds have deployment units with image sources not set to Artifact:
     - sled 2b8f0cb3-0295-4b3c-bc58-4fe88b57112c: 9 zones
     - sled 98e6b7c2-2efa-41ca-b20a-0a4d61102fe6: 8 zones
     - sled d81c6a84-79b8-4958-ae41-ea46c9b19763: 8 zones
 
-* adding zones despite being blocked, as specified by the `add_zones_with_mupdate_override` planner config option
+* adding zones despite being blocked, because: target release generation is 1
 * no zpools in service for NTP zones on sleds: 00320471-945d-413c-85e7-03e091a70b3c
 * discretionary zone placement waiting for NTP zones on sleds: 00320471-945d-413c-85e7-03e091a70b3c
 * zone updates waiting on zone add blockers

--- a/dev-tools/reconfigurator-cli/tests/output/cmds-add-zones-with-mupdate-override-stdout
+++ b/dev-tools/reconfigurator-cli/tests/output/cmds-add-zones-with-mupdate-override-stdout
@@ -1,0 +1,412 @@
+using provided RNG seed: reconfigurator-cli-test
+> # This script tests the add-zones-with-mupdate-override
+> # planner config.
+
+> # Load example system
+> load-example --nsleds 3 --ndisks-per-sled 3
+loaded example system with:
+- collection: f45ba181-4b56-42cc-a762-874d90184a43
+- blueprint: dbcbd3d6-41ff-48ae-ac0b-1becc9b2fd21
+
+
+> # Create a TUF repository from a fake manifest. We're going to use this
+> # repository to test out the minimum release generation flow.
+> tuf-assemble ../../update-common/manifests/fake.toml
+INFO assembling repository in <ASSEMBLING_REPOSITORY_IN_REDACTED>
+INFO artifacts assembled and archived to `repo-1.0.0.zip`, component: OmicronRepoAssembler
+created repo-1.0.0.zip for system version 1.0.0
+
+> set target-release repo-1.0.0.zip
+INFO extracting uploaded archive to <EXTRACTING_UPLOADED_ARCHIVE_TO_REDACTED>
+INFO created directory to store extracted artifacts, path: <CREATED_DIRECTORY_TO_STORE_EXTRACTED_ARTIFACTS_PATH_REDACTED>
+INFO added artifact, name: fake-gimlet-sp, kind: gimlet_sp, version: 1.0.0, hash: 68465b8e3f808f475510b525cfd62086d37ddd57688bd854184fdafb2b2198a4, length: 732
+INFO added artifact, name: fake-rot, kind: gimlet_rot_image_a, version: 1.0.0, hash: d11e65f934bf0de51df2e5b484f61ee72072417b43ac87f33e958008428e7b02, length: 783
+INFO added artifact, name: fake-rot, kind: gimlet_rot_image_b, version: 1.0.0, hash: d11e65f934bf0de51df2e5b484f61ee72072417b43ac87f33e958008428e7b02, length: 783
+INFO added artifact, name: fake-rot-bootloader, kind: gimlet_rot_bootloader, version: 1.0.0, hash: 5b0f601b1fbb8674db9c751a02f8b14f8e6d4e8470f4f7b686fecb2c49ec11f9, length: 797
+INFO added artifact, name: fake-host, kind: gimlet_host_phase_1, version: 1.0.0, hash: b99d5273ba1418bebb19d74b701d716896409566d41de76ada71bded4c9b166b, length: 524288
+INFO added artifact, name: fake-host, kind: cosmo_host_phase_1, version: 1.0.0, hash: 9525f567106549a3fc32df870a74803d77e51dcc44190b218e227a2c5d444f58, length: 524288
+INFO added artifact, name: fake-host, kind: host_phase_2, version: 1.0.0, hash: d944ae205b61ccf4322448f7d0311a819c53d9844769de066c5307c1682abb47, length: 1048576
+INFO added artifact, name: fake-trampoline, kind: gimlet_trampoline_phase_1, version: 1.0.0, hash: bcb27520ee5a56e19f6df9662c66d69ac681fbd873a97547be5f6a5ae3d250c4, length: 524288
+INFO added artifact, name: fake-trampoline, kind: cosmo_trampoline_phase_1, version: 1.0.0, hash: e235b8afb58ee69d966853bd5efe7c7e904da84b9035a332b3e691dc1d5cdbd0, length: 524288
+INFO added artifact, name: fake-trampoline, kind: trampoline_phase_2, version: 1.0.0, hash: a5dfcc4bc69b791f1c509df499e9e72cce844cb2b53a56d8bb357b264bdf13b6, length: 1048576
+INFO added artifact, name: clickhouse, kind: zone, version: 1.0.0, hash: 52b1eb4daff6f9140491d547b11248392920230db3db0eef5f5fa5333fe9e659, length: 1686
+INFO added artifact, name: clickhouse_keeper, kind: zone, version: 1.0.0, hash: cda702919449d86663be97295043aeca0ead69ae5db3bbdb20053972254a27a3, length: 1690
+INFO added artifact, name: clickhouse_server, kind: zone, version: 1.0.0, hash: 5f9ae6a9821bbe8ff0bf60feddf8b167902fe5f3e2c98bd21edd1ec9d969a001, length: 1690
+INFO added artifact, name: cockroachdb, kind: zone, version: 1.0.0, hash: f3a1a3c0b3469367b005ee78665d982059d5e14e93a479412426bf941c4ed291, length: 1689
+INFO added artifact, name: crucible-zone, kind: zone, version: 1.0.0, hash: 6f17cf65fb5a5bec5542dd07c03cd0acc01e59130f02c532c8d848ecae810047, length: 1690
+INFO added artifact, name: crucible-pantry-zone, kind: zone, version: 1.0.0, hash: 21f0ada306859c23917361f2e0b9235806c32607ec689c7e8cf16bb898bc5a02, length: 1695
+INFO added artifact, name: external-dns, kind: zone, version: 1.0.0, hash: ccca13ed19b8731f9adaf0d6203b02ea3b9ede4fa426b9fac0a07ce95440046d, length: 1689
+INFO added artifact, name: internal-dns, kind: zone, version: 1.0.0, hash: ffbf1373f7ee08dddd74c53ed2a94e7c4c572a982d3a9bc94000c6956b700c6a, length: 1689
+INFO added artifact, name: ntp, kind: zone, version: 1.0.0, hash: 67593d686ed04a1709f93972b71f4ebc148a9362120f65d239943e814a9a7439, length: 1681
+INFO added artifact, name: nexus, kind: zone, version: 1.0.0, hash: 0e32b4a3e5d3668bb1d6a16fb06b74dc60b973fa479dcee0aae3adbb52bf1388, length: 1682
+INFO added artifact, name: oximeter, kind: zone, version: 1.0.0, hash: 048d8fe8cdef5b175aad714d0f148aa80ce36c9114ac15ce9d02ed3d37877a77, length: 1682
+INFO added artifact, name: fake-psc-sp, kind: psc_sp, version: 1.0.0, hash: 89245fe2ac7e6a2ac8dfa4e7d6891a6e6df95e4141395c07c64026778f6d76d7, length: 721
+INFO added artifact, name: fake-psc-rot, kind: psc_rot_image_a, version: 1.0.0, hash: 5d8ea834dd6d42d386f1eb8a2c5f6e99b697c9958bb4ab8edf63e56003e25d8d, length: 775
+INFO added artifact, name: fake-psc-rot, kind: psc_rot_image_b, version: 1.0.0, hash: 5d8ea834dd6d42d386f1eb8a2c5f6e99b697c9958bb4ab8edf63e56003e25d8d, length: 775
+INFO added artifact, name: fake-psc-rot-bootloader, kind: psc_rot_bootloader, version: 1.0.0, hash: 18c9c774bfe4bb086e869509dcccacee8476fd87670692b765aee216f2c7f003, length: 805
+INFO added artifact, name: fake-switch-sp, kind: switch_sp, version: 1.0.0, hash: bf1bc1da5059f76182c3007c3049941f8898abede2f3765b106c6e7f7c42d44c, length: 740
+INFO added artifact, name: fake-switch-rot, kind: switch_rot_image_a, version: 1.0.0, hash: 32307d6d75c9707e8499ba4a4d379f99c0358237b6e190ff6a8024b470f62342, length: 774
+INFO added artifact, name: fake-switch-rot, kind: switch_rot_image_b, version: 1.0.0, hash: 32307d6d75c9707e8499ba4a4d379f99c0358237b6e190ff6a8024b470f62342, length: 774
+INFO added artifact, name: fake-switch-rot-bootloader, kind: switch_rot_bootloader, version: 1.0.0, hash: 70836d170abd5621f95bb4225987b27b3d3dd6168e73cd60e44309bdfeb94e98, length: 804
+INFO added artifact, name: installinator_document, kind: installinator_document, version: 1.0.0, hash: a6a636b5d57813578766b3f1c2559abf9af5d8c86187538167937c476beeefa3, length: 367
+set target release based on repo-1.0.0.zip
+
+
+> # Update the install dataset on this sled to the target release.
+> # (This populates the zone manifest, used for no-op conversions from
+> # install dataset to artifact down the road.)
+> sled-update-install-dataset serial0 --to-target-release
+sled 98e6b7c2-2efa-41ca-b20a-0a4d61102fe6: install dataset updated: to target release (system version 1.0.0)
+
+
+> # Simulate a mupdate on sled 0 by setting the mupdate override field to a
+> # new UUID (generated using uuidgen).
+> sled-set serial0 mupdate-override 2d0f6cbc-addc-47a2-962a-6a01e13376bf
+set sled 98e6b7c2-2efa-41ca-b20a-0a4d61102fe6 mupdate override: unset -> 2d0f6cbc-addc-47a2-962a-6a01e13376bf
+
+
+> # Generate a new inventory and plan against that.
+> inventory-generate
+generated inventory collection eb0796d5-ab8a-4f7b-a884-b4aeacb8ab51 from configured sleds
+
+> blueprint-plan latest latest
+INFO blueprint mupdate override updated to match inventory, phase: do_plan_mupdate_override, sled_id: 98e6b7c2-2efa-41ca-b20a-0a4d61102fe6, new_bp_override: 2d0f6cbc-addc-47a2-962a-6a01e13376bf, prev_bp_override: None, zones: 
+  - zone 058fd5f9-60a8-4e11-9302-15172782e17d (Crucible) left unchanged, image source: install dataset
+  - zone 0c71b3b2-6ceb-4e8f-b020-b08675e83038 (Nexus) left unchanged, image source: install dataset
+  - zone 427ec88f-f467-42fa-9bbb-66a91a36103c (InternalDns) left unchanged, image source: install dataset
+  - zone 5199c033-4cf9-4ab6-8ae7-566bd7606363 (Crucible) left unchanged, image source: install dataset
+  - zone 6444f8a5-6465-4f0b-a549-1993c113569c (InternalNtp) left unchanged, image source: install dataset
+  - zone 803bfb63-c246-41db-b0da-d3b87ddfc63d (ExternalDns) left unchanged, image source: install dataset
+  - zone ba4994a8-23f9-4b1a-a84f-a08d74591389 (CruciblePantry) left unchanged, image source: install dataset
+  - zone dfac80b4-a887-430a-ae87-a4e065dba787 (Crucible) left unchanged, image source: install dataset
+, host_phase_2: 
+  - host phase 2 slot A: current contents (unchanged)
+  - host phase 2 slot B: current contents (unchanged)
+
+INFO no previous MGS update found as part of updating blueprint mupdate override to match inventory, phase: do_plan_mupdate_override, sled_id: 98e6b7c2-2efa-41ca-b20a-0a4d61102fe6
+INFO updating target release minimum generation based on new set-override actions, phase: do_plan_mupdate_override, current_generation: 1, new_generation: 3
+INFO performed noop zone image source checks on sled, sled_id: 2b8f0cb3-0295-4b3c-bc58-4fe88b57112c, num_total: 9, num_already_artifact: 0, num_eligible: 0, num_ineligible: 9
+INFO BootPartitionDetails inventory hash not found in TUF repo, ignoring for noop checks, sled_id: 2b8f0cb3-0295-4b3c-bc58-4fe88b57112c, slot: a, expected_hash: 0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a
+INFO BootPartitionDetails inventory hash not found in TUF repo, ignoring for noop checks, sled_id: 2b8f0cb3-0295-4b3c-bc58-4fe88b57112c, slot: b, expected_hash: 0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b
+INFO skipped noop image source check on sled, sled_id: 98e6b7c2-2efa-41ca-b20a-0a4d61102fe6, reason: remove_mupdate_override is set in the blueprint (2d0f6cbc-addc-47a2-962a-6a01e13376bf)
+INFO performed noop zone image source checks on sled, sled_id: d81c6a84-79b8-4958-ae41-ea46c9b19763, num_total: 8, num_already_artifact: 0, num_eligible: 0, num_ineligible: 8
+INFO BootPartitionDetails inventory hash not found in TUF repo, ignoring for noop checks, sled_id: d81c6a84-79b8-4958-ae41-ea46c9b19763, slot: a, expected_hash: 0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a
+INFO BootPartitionDetails inventory hash not found in TUF repo, ignoring for noop checks, sled_id: d81c6a84-79b8-4958-ae41-ea46c9b19763, slot: b, expected_hash: 0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b
+generated blueprint 8da82a8e-bf97-4fbd-8ddd-9f6462732cf1 based on parent blueprint dbcbd3d6-41ff-48ae-ac0b-1becc9b2fd21
+blueprint source: planner with report:
+planning report:
+* zone adds waiting on blockers
+* zone adds and updates are blocked:
+  - current target release generation (2) is lower than minimum required by blueprint (3)
+  - sleds have remove mupdate override set in blueprint: 98e6b7c2-2efa-41ca-b20a-0a4d61102fe6
+  - sleds have deployment units with image sources not set to Artifact:
+    - sled 2b8f0cb3-0295-4b3c-bc58-4fe88b57112c: 9 zones
+    - sled 98e6b7c2-2efa-41ca-b20a-0a4d61102fe6: 8 zones
+    - sled d81c6a84-79b8-4958-ae41-ea46c9b19763: 8 zones
+
+* zone updates waiting on zone add blockers
+* waiting to update top-level nexus_generation: some non-Nexus zone are not yet updated
+
+
+
+
+> # Diff the blueprints. This diff should show "will remove mupdate override"
+> # and the target release minimum generation being set.
+> blueprint-diff latest
+from: blueprint dbcbd3d6-41ff-48ae-ac0b-1becc9b2fd21
+to:   blueprint 8da82a8e-bf97-4fbd-8ddd-9f6462732cf1
+
+ MODIFIED SLEDS:
+
+  sled 98e6b7c2-2efa-41ca-b20a-0a4d61102fe6 (active, config generation 2 -> 3):
++   will remove mupdate override:   (none) -> 2d0f6cbc-addc-47a2-962a-6a01e13376bf
+
+    host phase 2 contents:
+    ------------------------
+    slot   boot image source
+    ------------------------
+    A      current contents 
+    B      current contents 
+
+
+    physical disks:
+    ------------------------------------------------------------------------------------
+    vendor        model        serial                                        disposition
+    ------------------------------------------------------------------------------------
+    fake-vendor   fake-model   serial-073979dd-3248-44a5-9fa1-cc72a140d682   in service 
+    fake-vendor   fake-model   serial-c6d33b64-fb96-4129-bab1-7878a06a5f9b   in service 
+    fake-vendor   fake-model   serial-e4d937e1-6ddc-4eca-bb08-c1f73791e608   in service 
+
+
+    datasets:
+    -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
+    dataset name                                                                                                   dataset id                             disposition   quota     reservation   compression
+    -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
+    oxp_073979dd-3248-44a5-9fa1-cc72a140d682/crucible                                                              7b4ce6bf-95bb-42fe-a4a0-dff31211ab88   in service    none      none          off        
+    oxp_c6d33b64-fb96-4129-bab1-7878a06a5f9b/crucible                                                              ea8a11bf-a884-4c4f-8df0-3ef9b7aacf43   in service    none      none          off        
+    oxp_e4d937e1-6ddc-4eca-bb08-c1f73791e608/crucible                                                              50b029e3-96aa-41e5-bf39-023193a4355e   in service    none      none          off        
+    oxp_073979dd-3248-44a5-9fa1-cc72a140d682/crypt/external_dns                                                    4847a96e-a267-4ae7-aa3d-805c1e77f81e   in service    none      none          off        
+    oxp_073979dd-3248-44a5-9fa1-cc72a140d682/crypt/internal_dns                                                    ad41be71-6c15-4428-b510-20ceacde4fa6   in service    none      none          off        
+    oxp_073979dd-3248-44a5-9fa1-cc72a140d682/crypt/zone                                                            4617d206-4330-4dfa-b9f3-f63a3db834f9   in service    none      none          off        
+    oxp_c6d33b64-fb96-4129-bab1-7878a06a5f9b/crypt/zone                                                            793ac181-1b01-403c-850d-7f5c54bda6c9   in service    none      none          off        
+    oxp_e4d937e1-6ddc-4eca-bb08-c1f73791e608/crypt/zone                                                            4f60b534-eaa3-40a1-b60f-bfdf147af478   in service    none      none          off        
+    oxp_e4d937e1-6ddc-4eca-bb08-c1f73791e608/crypt/zone/oxz_crucible_058fd5f9-60a8-4e11-9302-15172782e17d          02c56a30-7d97-406d-bd34-1eb437fd517d   in service    none      none          off        
+    oxp_073979dd-3248-44a5-9fa1-cc72a140d682/crypt/zone/oxz_crucible_5199c033-4cf9-4ab6-8ae7-566bd7606363          832fd140-d467-4bad-b5e9-63171634087c   in service    none      none          off        
+    oxp_c6d33b64-fb96-4129-bab1-7878a06a5f9b/crypt/zone/oxz_crucible_dfac80b4-a887-430a-ae87-a4e065dba787          4d7e3e8e-06bd-414c-a468-779e056a9b75   in service    none      none          off        
+    oxp_073979dd-3248-44a5-9fa1-cc72a140d682/crypt/zone/oxz_crucible_pantry_ba4994a8-23f9-4b1a-a84f-a08d74591389   42430c80-7836-4191-a4f6-bcee749010fe   in service    none      none          off        
+    oxp_073979dd-3248-44a5-9fa1-cc72a140d682/crypt/zone/oxz_external_dns_803bfb63-c246-41db-b0da-d3b87ddfc63d      43931274-7fe8-4077-825d-dff2bc8efa58   in service    none      none          off        
+    oxp_073979dd-3248-44a5-9fa1-cc72a140d682/crypt/zone/oxz_internal_dns_427ec88f-f467-42fa-9bbb-66a91a36103c      1bca7f71-5e42-4749-91ec-fa40793a3a9a   in service    none      none          off        
+    oxp_073979dd-3248-44a5-9fa1-cc72a140d682/crypt/zone/oxz_nexus_0c71b3b2-6ceb-4e8f-b020-b08675e83038             a4c3032e-21fa-4d4a-b040-a7e3c572cf3c   in service    none      none          off        
+    oxp_073979dd-3248-44a5-9fa1-cc72a140d682/crypt/zone/oxz_ntp_6444f8a5-6465-4f0b-a549-1993c113569c               3ac089c9-9dec-465b-863a-188e80d71fb4   in service    none      none          off        
+    oxp_073979dd-3248-44a5-9fa1-cc72a140d682/crypt/debug                                                           248c6c10-1ac6-45de-bb55-ede36ca56bbd   in service    100 GiB   none          gzip-9     
+    oxp_c6d33b64-fb96-4129-bab1-7878a06a5f9b/crypt/debug                                                           cdf3684f-a6cf-4449-b9ec-e696b2c663e2   in service    100 GiB   none          gzip-9     
+    oxp_e4d937e1-6ddc-4eca-bb08-c1f73791e608/crypt/debug                                                           686c19cf-a0d7-45f6-866f-c564612b2664   in service    100 GiB   none          gzip-9     
+
+
+    omicron zones:
+    ---------------------------------------------------------------------------------------------------------------
+    zone type         zone id                                image source      disposition   underlay IP           
+    ---------------------------------------------------------------------------------------------------------------
+    crucible          058fd5f9-60a8-4e11-9302-15172782e17d   install dataset   in service    fd00:1122:3344:101::27
+    crucible          5199c033-4cf9-4ab6-8ae7-566bd7606363   install dataset   in service    fd00:1122:3344:101::25
+    crucible          dfac80b4-a887-430a-ae87-a4e065dba787   install dataset   in service    fd00:1122:3344:101::26
+    crucible_pantry   ba4994a8-23f9-4b1a-a84f-a08d74591389   install dataset   in service    fd00:1122:3344:101::24
+    external_dns      803bfb63-c246-41db-b0da-d3b87ddfc63d   install dataset   in service    fd00:1122:3344:101::23
+    internal_dns      427ec88f-f467-42fa-9bbb-66a91a36103c   install dataset   in service    fd00:1122:3344:2::1   
+    internal_ntp      6444f8a5-6465-4f0b-a549-1993c113569c   install dataset   in service    fd00:1122:3344:101::21
+    nexus             0c71b3b2-6ceb-4e8f-b020-b08675e83038   install dataset   in service    fd00:1122:3344:101::22
+
+
+ COCKROACHDB SETTINGS:
+    state fingerprint:::::::::::::::::   (none) (unchanged)
+    cluster.preserve_downgrade_option:   (do not modify) (unchanged)
+
+ METADATA:
+    internal DNS version:::   1 (unchanged)
+    external DNS version:::   1 (unchanged)
+*   target release min gen:   1 -> 3
+    nexus gen::::::::::::::   1 (unchanged)
+
+ OXIMETER SETTINGS:
+    generation:   1 (unchanged)
+    read from::   SingleNode (unchanged)
+
+
+internal DNS:
+  DNS zone: "control-plane.oxide.internal" (unchanged)
+    unchanged names: 51 (records: 65)
+
+external DNS:
+  DNS zone: "oxide.example" (unchanged)
+    unchanged names: 5 (records: 9)
+
+
+
+
+> # Set Nexus redundancy to 4.
+> set num-nexus 4
+target number of Nexus zones: None -> 4
+
+
+> # Plan with the new Nexus. This will not add any Nexus zones.
+> blueprint-plan latest latest
+INFO performed noop zone image source checks on sled, sled_id: 2b8f0cb3-0295-4b3c-bc58-4fe88b57112c, num_total: 9, num_already_artifact: 0, num_eligible: 0, num_ineligible: 9
+INFO BootPartitionDetails inventory hash not found in TUF repo, ignoring for noop checks, sled_id: 2b8f0cb3-0295-4b3c-bc58-4fe88b57112c, slot: a, expected_hash: 0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a
+INFO BootPartitionDetails inventory hash not found in TUF repo, ignoring for noop checks, sled_id: 2b8f0cb3-0295-4b3c-bc58-4fe88b57112c, slot: b, expected_hash: 0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b
+INFO skipped noop image source check on sled, sled_id: 98e6b7c2-2efa-41ca-b20a-0a4d61102fe6, reason: remove_mupdate_override is set in the blueprint (2d0f6cbc-addc-47a2-962a-6a01e13376bf)
+INFO performed noop zone image source checks on sled, sled_id: d81c6a84-79b8-4958-ae41-ea46c9b19763, num_total: 8, num_already_artifact: 0, num_eligible: 0, num_ineligible: 8
+INFO BootPartitionDetails inventory hash not found in TUF repo, ignoring for noop checks, sled_id: d81c6a84-79b8-4958-ae41-ea46c9b19763, slot: a, expected_hash: 0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a
+INFO BootPartitionDetails inventory hash not found in TUF repo, ignoring for noop checks, sled_id: d81c6a84-79b8-4958-ae41-ea46c9b19763, slot: b, expected_hash: 0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b
+generated blueprint 58d5e830-0884-47d8-a7cd-b2b3751adeb4 based on parent blueprint 8da82a8e-bf97-4fbd-8ddd-9f6462732cf1
+blueprint source: planner with report:
+planning report:
+* zone adds waiting on blockers
+* zone adds and updates are blocked:
+  - current target release generation (2) is lower than minimum required by blueprint (3)
+  - sleds have remove mupdate override set in blueprint: 98e6b7c2-2efa-41ca-b20a-0a4d61102fe6
+  - sleds have deployment units with image sources not set to Artifact:
+    - sled 2b8f0cb3-0295-4b3c-bc58-4fe88b57112c: 9 zones
+    - sled 98e6b7c2-2efa-41ca-b20a-0a4d61102fe6: 8 zones
+    - sled d81c6a84-79b8-4958-ae41-ea46c9b19763: 8 zones
+
+* zone updates waiting on zone add blockers
+* waiting to update top-level nexus_generation: some non-Nexus zone are not yet updated
+
+
+
+> blueprint-diff latest
+from: blueprint 8da82a8e-bf97-4fbd-8ddd-9f6462732cf1
+to:   blueprint 58d5e830-0884-47d8-a7cd-b2b3751adeb4
+
+ COCKROACHDB SETTINGS:
+    state fingerprint:::::::::::::::::   (none) (unchanged)
+    cluster.preserve_downgrade_option:   (do not modify) (unchanged)
+
+ METADATA:
+    internal DNS version:::   1 (unchanged)
+    external DNS version:::   1 (unchanged)
+    target release min gen:   3 (unchanged)
+    nexus gen::::::::::::::   1 (unchanged)
+
+ OXIMETER SETTINGS:
+    generation:   1 (unchanged)
+    read from::   SingleNode (unchanged)
+
+
+internal DNS:
+  DNS zone: "control-plane.oxide.internal" (unchanged)
+    unchanged names: 51 (records: 65)
+
+external DNS:
+  DNS zone: "oxide.example" (unchanged)
+    unchanged names: 5 (records: 9)
+
+
+
+
+> # Set the add-zones-with-mupdate-override config, then do a planning run.
+> # This *will* add a new Nexus zone.
+> set planner-config --add-zones-with-mupdate-override true
+planner config updated:
+*   add zones with mupdate override:   false -> true
+
+
+> blueprint-plan latest latest
+INFO performed noop zone image source checks on sled, sled_id: 2b8f0cb3-0295-4b3c-bc58-4fe88b57112c, num_total: 9, num_already_artifact: 0, num_eligible: 0, num_ineligible: 9
+INFO BootPartitionDetails inventory hash not found in TUF repo, ignoring for noop checks, sled_id: 2b8f0cb3-0295-4b3c-bc58-4fe88b57112c, slot: a, expected_hash: 0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a
+INFO BootPartitionDetails inventory hash not found in TUF repo, ignoring for noop checks, sled_id: 2b8f0cb3-0295-4b3c-bc58-4fe88b57112c, slot: b, expected_hash: 0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b
+INFO skipped noop image source check on sled, sled_id: 98e6b7c2-2efa-41ca-b20a-0a4d61102fe6, reason: remove_mupdate_override is set in the blueprint (2d0f6cbc-addc-47a2-962a-6a01e13376bf)
+INFO performed noop zone image source checks on sled, sled_id: d81c6a84-79b8-4958-ae41-ea46c9b19763, num_total: 8, num_already_artifact: 0, num_eligible: 0, num_ineligible: 8
+INFO BootPartitionDetails inventory hash not found in TUF repo, ignoring for noop checks, sled_id: d81c6a84-79b8-4958-ae41-ea46c9b19763, slot: a, expected_hash: 0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a0a
+INFO BootPartitionDetails inventory hash not found in TUF repo, ignoring for noop checks, sled_id: d81c6a84-79b8-4958-ae41-ea46c9b19763, slot: b, expected_hash: 0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b
+generated blueprint af934083-59b5-4bf6-8966-6fb5292c29e1 based on parent blueprint 58d5e830-0884-47d8-a7cd-b2b3751adeb4
+blueprint source: planner with report:
+planning report:
+planner config:
+    add zones with mupdate override:   true
+
+* zone adds and updates are blocked:
+  - current target release generation (2) is lower than minimum required by blueprint (3)
+  - sleds have remove mupdate override set in blueprint: 98e6b7c2-2efa-41ca-b20a-0a4d61102fe6
+  - sleds have deployment units with image sources not set to Artifact:
+    - sled 2b8f0cb3-0295-4b3c-bc58-4fe88b57112c: 9 zones
+    - sled 98e6b7c2-2efa-41ca-b20a-0a4d61102fe6: 8 zones
+    - sled d81c6a84-79b8-4958-ae41-ea46c9b19763: 8 zones
+
+* adding zones despite being blocked, because: planner config `add_zones_with_mupdate_override` is true
+* discretionary zones placed:
+  * nexus zone on sled d81c6a84-79b8-4958-ae41-ea46c9b19763 from source install dataset
+* zone updates waiting on discretionary zones
+* waiting to update top-level nexus_generation: some non-Nexus zone are not yet updated
+
+
+
+> blueprint-diff latest
+from: blueprint 58d5e830-0884-47d8-a7cd-b2b3751adeb4
+to:   blueprint af934083-59b5-4bf6-8966-6fb5292c29e1
+
+ MODIFIED SLEDS:
+
+  sled d81c6a84-79b8-4958-ae41-ea46c9b19763 (active, config generation 2 -> 3):
+
+    host phase 2 contents:
+    ------------------------
+    slot   boot image source
+    ------------------------
+    A      current contents 
+    B      current contents 
+
+
+    physical disks:
+    ------------------------------------------------------------------------------------
+    vendor        model        serial                                        disposition
+    ------------------------------------------------------------------------------------
+    fake-vendor   fake-model   serial-18b20749-0748-4105-bb10-7b13cfc776e2   in service 
+    fake-vendor   fake-model   serial-30c16fe4-4229-49d0-ab01-3138f2c7dff2   in service 
+    fake-vendor   fake-model   serial-4930954e-9ac7-4453-b63f-5ab97c389a99   in service 
+
+
+    datasets:
+    -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
+    dataset name                                                                                                   dataset id                             disposition   quota     reservation   compression
+    -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
+    oxp_18b20749-0748-4105-bb10-7b13cfc776e2/crucible                                                              7ea73f80-c4e0-450a-92dc-8397ce2af14f   in service    none      none          off        
+    oxp_30c16fe4-4229-49d0-ab01-3138f2c7dff2/crucible                                                              6f04dd20-5e2c-4fa8-8430-a886470ed140   in service    none      none          off        
+    oxp_4930954e-9ac7-4453-b63f-5ab97c389a99/crucible                                                              a50cd13a-5749-4e79-bb8b-19229500a8b3   in service    none      none          off        
+    oxp_18b20749-0748-4105-bb10-7b13cfc776e2/crypt/external_dns                                                    96ae8389-3027-4260-9374-e0f6ce851de2   in service    none      none          off        
+    oxp_18b20749-0748-4105-bb10-7b13cfc776e2/crypt/internal_dns                                                    1cb0a47a-59ac-4892-8e92-cf87b4290f96   in service    none      none          off        
+    oxp_18b20749-0748-4105-bb10-7b13cfc776e2/crypt/zone                                                            45cd9687-20be-4247-b62a-dfdacf324929   in service    none      none          off        
+    oxp_30c16fe4-4229-49d0-ab01-3138f2c7dff2/crypt/zone                                                            e009d8b8-4695-4322-b53f-f03f2744aef7   in service    none      none          off        
+    oxp_4930954e-9ac7-4453-b63f-5ab97c389a99/crypt/zone                                                            252ac39f-b9e2-4697-8c07-3a833115d704   in service    none      none          off        
+    oxp_30c16fe4-4229-49d0-ab01-3138f2c7dff2/crypt/zone/oxz_crucible_694bd14f-cb24-4be4-bb19-876e79cda2c8          3443a368-199e-4d26-b59f-3f2bbd507761   in service    none      none          off        
+    oxp_4930954e-9ac7-4453-b63f-5ab97c389a99/crypt/zone/oxz_crucible_7c252b64-c5af-4ec1-989e-9a03f3b0f111          429da94b-19f7-48bd-98e9-47842863ba7b   in service    none      none          off        
+    oxp_18b20749-0748-4105-bb10-7b13cfc776e2/crypt/zone/oxz_crucible_f55647d4-5500-4ad3-893a-df45bd50d622          50ea8c15-c4c0-4403-a490-d14b3405dfc2   in service    none      none          off        
+    oxp_18b20749-0748-4105-bb10-7b13cfc776e2/crypt/zone/oxz_crucible_pantry_75b220ba-a0f4-4872-8202-dc7c87f062d0   54bbadaf-ec04-41a2-a62f-f5ac5bf321be   in service    none      none          off        
+    oxp_18b20749-0748-4105-bb10-7b13cfc776e2/crypt/zone/oxz_external_dns_f6ec9c67-946a-4da3-98d5-581f72ce8bf0      090bd88d-0a43-4040-a832-b13ae721f74f   in service    none      none          off        
+    oxp_18b20749-0748-4105-bb10-7b13cfc776e2/crypt/zone/oxz_internal_dns_ea5b4030-b52f-44b2-8d70-45f15f987d01      b1deff4b-51df-4a37-9043-afbd7c70a1cb   in service    none      none          off        
+    oxp_18b20749-0748-4105-bb10-7b13cfc776e2/crypt/zone/oxz_nexus_3eeb8d49-eb1a-43f8-bb64-c2338421c2c6             4da74a5b-6911-4cca-b624-b90c65530117   in service    none      none          off        
+    oxp_18b20749-0748-4105-bb10-7b13cfc776e2/crypt/zone/oxz_ntp_f10a4fb9-759f-4a65-b25e-5794ad2d07d8               c65a9c1c-36dc-4ddb-8aac-ec3be8dbb209   in service    none      none          off        
+    oxp_18b20749-0748-4105-bb10-7b13cfc776e2/crypt/debug                                                           7a6a2058-ea78-49de-9730-cce5e28b4cfb   in service    100 GiB   none          gzip-9     
+    oxp_30c16fe4-4229-49d0-ab01-3138f2c7dff2/crypt/debug                                                           41071985-1dfd-4ce5-8bc2-897161a8bce4   in service    100 GiB   none          gzip-9     
+    oxp_4930954e-9ac7-4453-b63f-5ab97c389a99/crypt/debug                                                           21fd4f3a-ec31-469b-87b1-087c343a2422   in service    100 GiB   none          gzip-9     
++   oxp_30c16fe4-4229-49d0-ab01-3138f2c7dff2/crypt/zone/oxz_nexus_571a8adf-f0b8-458c-8e6c-5a71e82af7ae             f26dc500-70ea-445e-9033-e2f494739dfc   in service    none      none          off        
+
+
+    omicron zones:
+    ---------------------------------------------------------------------------------------------------------------
+    zone type         zone id                                image source      disposition   underlay IP           
+    ---------------------------------------------------------------------------------------------------------------
+    crucible          694bd14f-cb24-4be4-bb19-876e79cda2c8   install dataset   in service    fd00:1122:3344:103::26
+    crucible          7c252b64-c5af-4ec1-989e-9a03f3b0f111   install dataset   in service    fd00:1122:3344:103::27
+    crucible          f55647d4-5500-4ad3-893a-df45bd50d622   install dataset   in service    fd00:1122:3344:103::25
+    crucible_pantry   75b220ba-a0f4-4872-8202-dc7c87f062d0   install dataset   in service    fd00:1122:3344:103::24
+    external_dns      f6ec9c67-946a-4da3-98d5-581f72ce8bf0   install dataset   in service    fd00:1122:3344:103::23
+    internal_dns      ea5b4030-b52f-44b2-8d70-45f15f987d01   install dataset   in service    fd00:1122:3344:3::1   
+    internal_ntp      f10a4fb9-759f-4a65-b25e-5794ad2d07d8   install dataset   in service    fd00:1122:3344:103::21
+    nexus             3eeb8d49-eb1a-43f8-bb64-c2338421c2c6   install dataset   in service    fd00:1122:3344:103::22
++   nexus             571a8adf-f0b8-458c-8e6c-5a71e82af7ae   install dataset   in service    fd00:1122:3344:103::28
+
+
+ COCKROACHDB SETTINGS:
+    state fingerprint:::::::::::::::::   (none) (unchanged)
+    cluster.preserve_downgrade_option:   (do not modify) (unchanged)
+
+ METADATA:
+    internal DNS version:::   1 (unchanged)
+    external DNS version:::   1 (unchanged)
+    target release min gen:   3 (unchanged)
+    nexus gen::::::::::::::   1 (unchanged)
+
+ OXIMETER SETTINGS:
+    generation:   1 (unchanged)
+    read from::   SingleNode (unchanged)
+
+
+internal DNS:
+* DNS zone: "control-plane.oxide.internal": 
++   name: 571a8adf-f0b8-458c-8e6c-5a71e82af7ae.host          (records: 1)
++       AAAA fd00:1122:3344:103::28
+*   name: _nexus._tcp                                        (records: 3 -> 4)
+-       SRV  port 12221 0c71b3b2-6ceb-4e8f-b020-b08675e83038.host.control-plane.oxide.internal
+-       SRV  port 12221 3eeb8d49-eb1a-43f8-bb64-c2338421c2c6.host.control-plane.oxide.internal
+-       SRV  port 12221 466a9f29-62bf-4e63-924a-b9efdb86afec.host.control-plane.oxide.internal
++       SRV  port 12221 0c71b3b2-6ceb-4e8f-b020-b08675e83038.host.control-plane.oxide.internal
++       SRV  port 12221 3eeb8d49-eb1a-43f8-bb64-c2338421c2c6.host.control-plane.oxide.internal
++       SRV  port 12221 466a9f29-62bf-4e63-924a-b9efdb86afec.host.control-plane.oxide.internal
++       SRV  port 12221 571a8adf-f0b8-458c-8e6c-5a71e82af7ae.host.control-plane.oxide.internal
+    unchanged names: 50 (records: 62)
+
+external DNS:
+* DNS zone: "oxide.example": 
+*   name: example-silo.sys                                   (records: 3 -> 4)
+-       A    192.0.2.2
+-       A    192.0.2.3
+-       A    192.0.2.4
++       A    192.0.2.2
++       A    192.0.2.3
++       A    192.0.2.4
++       A    192.0.2.5
+    unchanged names: 4 (records: 6)
+
+
+

--- a/dev-tools/reconfigurator-cli/tests/output/cmds-example-stdout
+++ b/dev-tools/reconfigurator-cli/tests/output/cmds-example-stdout
@@ -602,11 +602,11 @@ INFO skipping noop image source check for all sleds, reason: no target release i
 generated blueprint 86db3308-f817-4626-8838-4085949a6a41 based on parent blueprint ade5749d-bdf3-4fab-a8ae-00bea01b3a5a
 blueprint source: planner with report:
 planning report:
-* zone adds waiting on blockers
 * zone adds and updates are blocked:
   - sleds have deployment units with image sources not set to Artifact:
     - sled 89d02b1b-478c-401a-8e28-7a26f74fa41b: 18 zones
 
+* adding zones despite being blocked, because: target release generation is 1
 * zone updates waiting on zone add blockers
 
 
@@ -1847,12 +1847,12 @@ INFO skipping noop image source check for all sleds, reason: no target release i
 generated blueprint 86db3308-f817-4626-8838-4085949a6a41 based on parent blueprint ade5749d-bdf3-4fab-a8ae-00bea01b3a5a
 blueprint source: planner with report:
 planning report:
-* zone adds waiting on blockers
 * zone adds and updates are blocked:
   - sleds have deployment units with image sources not set to Artifact:
     - sled 2eb69596-f081-4e2d-9425-9994926e0832: 4 zones
     - sled 89d02b1b-478c-401a-8e28-7a26f74fa41b: 17 zones
 
+* adding zones despite being blocked, because: target release generation is 1
 * zone updates waiting on zone add blockers
 
 

--- a/dev-tools/reconfigurator-cli/tests/output/cmds-expunge-newly-added-external-dns-stdout
+++ b/dev-tools/reconfigurator-cli/tests/output/cmds-expunge-newly-added-external-dns-stdout
@@ -861,7 +861,7 @@ planner config:
     - sled 9dc50690-f9bf-4520-bf80-051d0f465c2c: 15 zones
     - sled a88790de-5962-4871-8686-61c1fd5b7094: 15 zones
 
-* adding zones despite being blocked, as specified by the `add_zones_with_mupdate_override` planner config option
+* adding zones despite being blocked, because: planner config `add_zones_with_mupdate_override` is true, target release generation is 1
 * discretionary zones placed:
   * external_dns zone on sled 711ac7f8-d19e-4572-bdb9-e9b50f6e362a from source install dataset
 * zone updates waiting on discretionary zones
@@ -1370,7 +1370,7 @@ planner config:
     - sled 9dc50690-f9bf-4520-bf80-051d0f465c2c: 15 zones
     - sled a88790de-5962-4871-8686-61c1fd5b7094: 15 zones
 
-* adding zones despite being blocked, as specified by the `add_zones_with_mupdate_override` planner config option
+* adding zones despite being blocked, because: planner config `add_zones_with_mupdate_override` is true, target release generation is 1
 * discretionary zones placed:
   * external_dns zone on sled 711ac7f8-d19e-4572-bdb9-e9b50f6e362a from source install dataset
 * zone updates waiting on discretionary zones

--- a/dev-tools/reconfigurator-cli/tests/output/cmds-expunge-newly-added-internal-dns-stdout
+++ b/dev-tools/reconfigurator-cli/tests/output/cmds-expunge-newly-added-internal-dns-stdout
@@ -645,30 +645,19 @@ external DNS:
 
 
 
-> # Set the add_zones_with_mupdate_override planner config to ensure that zone
-> # adds happen despite zone image sources not being Artifact.
-> set planner-config --add-zones-with-mupdate-override true
-planner config updated:
-*   add zones with mupdate override:   false -> true
-
-
-
 > # Planning a new blueprint will now replace the expunged zone, with new records for its replacement.
 > blueprint-plan 58d5e830-0884-47d8-a7cd-b2b3751adeb4
 INFO skipping noop image source check for all sleds, reason: no target release is currently set
 generated blueprint af934083-59b5-4bf6-8966-6fb5292c29e1 based on parent blueprint 58d5e830-0884-47d8-a7cd-b2b3751adeb4
 blueprint source: planner with report:
 planning report:
-planner config:
-    add zones with mupdate override:   true
-
 * zone adds and updates are blocked:
   - sleds have deployment units with image sources not set to Artifact:
     - sled 2b8f0cb3-0295-4b3c-bc58-4fe88b57112c: 15 zones
     - sled 98e6b7c2-2efa-41ca-b20a-0a4d61102fe6: 15 zones
     - sled d81c6a84-79b8-4958-ae41-ea46c9b19763: 15 zones
 
-* adding zones despite being blocked, as specified by the `add_zones_with_mupdate_override` planner config option
+* adding zones despite being blocked, because: target release generation is 1
 * discretionary zones placed:
   * internal_dns zone on sled 2b8f0cb3-0295-4b3c-bc58-4fe88b57112c from source install dataset
 * zone updates waiting on discretionary zones

--- a/dev-tools/reconfigurator-cli/tests/output/cmds-mupdate-update-flow-stdout
+++ b/dev-tools/reconfigurator-cli/tests/output/cmds-mupdate-update-flow-stdout
@@ -2563,7 +2563,7 @@ planner config:
   - sleds have deployment units with image sources not set to Artifact:
     - sled 98e6b7c2-2efa-41ca-b20a-0a4d61102fe6: 6 zones
 
-* adding zones despite being blocked, as specified by the `add_zones_with_mupdate_override` planner config option
+* adding zones despite being blocked, because: planner config `add_zones_with_mupdate_override` is true
 * discretionary zone placement waiting for NTP zones on sleds: c3bc4c6d-fdde-4fc4-8493-89d2a1e5ee6b
 * missing NTP zone on sled c3bc4c6d-fdde-4fc4-8493-89d2a1e5ee6b
 * only placed 0/1 desired nexus zones

--- a/nexus/reconfigurator/planning/src/planner.rs
+++ b/nexus/reconfigurator/planning/src/planner.rs
@@ -264,8 +264,7 @@ impl<'a> Planner<'a> {
         };
         add.add_update_blocked_reasons = add_update_blocked_reasons;
         add.add_zones_with_mupdate_override = add_zones_with_mupdate_override;
-        add.target_release_generation_is_one =
-            target_release_generation_is_one;
+        add.target_release_generation_is_one = target_release_generation_is_one;
 
         let zone_updates = if add.any_discretionary_zones_placed() {
             // Do not update any zones if we've added any discretionary zones

--- a/nexus/reconfigurator/planning/src/planner.rs
+++ b/nexus/reconfigurator/planning/src/planner.rs
@@ -239,11 +239,24 @@ impl<'a> Planner<'a> {
             PlanningMgsUpdatesStepReport::new(PendingMgsUpdates::new())
         };
 
-        // Likewise for zone additions, unless overridden by the config.
+        // Likewise for zone additions, unless overridden by the config, or
+        // unless a target release has never been set (i.e. we're effectively in
+        // a pre-Nexus-driven-update world).
+        //
+        // We don't have to check for the minimum target release generation in
+        // this case. On a freshly-installed or MUPdated system, Nexus will find
+        // the mupdate overrides and clear them. The act of clearing mupdate
+        // overrides always sets the minimum generation to the current target
+        // release generation plus one, so the minimum generation will always be
+        // exactly 2.
         let add_zones_with_mupdate_override =
             self.input.planner_config().add_zones_with_mupdate_override;
+        let target_release_generation_is_one =
+            self.input.tuf_repo().target_release_generation
+                == Generation::from_u32(1);
         let mut add = if add_update_blocked_reasons.is_empty()
             || add_zones_with_mupdate_override
+            || target_release_generation_is_one
         {
             self.do_plan_add(&mgs_updates)?
         } else {
@@ -251,6 +264,8 @@ impl<'a> Planner<'a> {
         };
         add.add_update_blocked_reasons = add_update_blocked_reasons;
         add.add_zones_with_mupdate_override = add_zones_with_mupdate_override;
+        add.target_release_generations_are_one =
+            target_release_generation_is_one;
 
         let zone_updates = if add.any_discretionary_zones_placed() {
             // Do not update any zones if we've added any discretionary zones
@@ -2721,12 +2736,6 @@ pub(crate) mod test {
         .build();
         verify_blueprint(&blueprint1);
 
-        // Set this chicken switch so that zones are added even though image
-        // sources are currently InstallDataset.
-        let mut config = example.system.get_planner_config();
-        config.add_zones_with_mupdate_override = true;
-        example.system.set_planner_config(config);
-
         let input = example
             .system
             .to_planning_input_builder()
@@ -2920,7 +2929,7 @@ pub(crate) mod test {
 
         // Use our example system with one sled and one Nexus instance as a
         // starting point.
-        let (mut example, blueprint1) =
+        let (example, blueprint1) =
             ExampleSystemBuilder::new(&logctx.log, TEST_NAME)
                 .nsleds(1)
                 .nexus_count(1)
@@ -2932,12 +2941,6 @@ pub(crate) mod test {
             .next()
             .map(|sa| sa.sled_id)
             .unwrap();
-
-        // Set this chicken switch so that zones are added even though image
-        // sources are currently InstallDataset.
-        let mut config = example.system.get_planner_config();
-        config.add_zones_with_mupdate_override = true;
-        example.system.set_planner_config(config);
 
         let input = example
             .system
@@ -3033,15 +3036,9 @@ pub(crate) mod test {
         let logctx = test_setup_log(TEST_NAME);
 
         // Use our example system as a starting point.
-        let (mut example, blueprint1) =
+        let (example, blueprint1) =
             ExampleSystemBuilder::new(&logctx.log, TEST_NAME).build();
         let collection = example.collection;
-
-        // Set this chicken switch so that zones are added even though image
-        // sources are currently InstallDataset.
-        let mut config = example.system.get_planner_config();
-        config.add_zones_with_mupdate_override = true;
-        example.system.set_planner_config(config);
 
         // This blueprint should only have 3 Nexus zones: one on each sled.
         assert_eq!(blueprint1.sleds.len(), 3);
@@ -3130,15 +3127,9 @@ pub(crate) mod test {
         let logctx = test_setup_log(TEST_NAME);
 
         // Use our example system as a starting point.
-        let (mut example, mut blueprint1) =
+        let (example, mut blueprint1) =
             ExampleSystemBuilder::new(&logctx.log, TEST_NAME).build();
         let collection = example.collection;
-
-        // Set this chicken switch so that zones are added even though image
-        // sources are currently InstallDataset.
-        let mut config = example.system.get_planner_config();
-        config.add_zones_with_mupdate_override = true;
-        example.system.set_planner_config(config);
 
         example
             .system
@@ -3284,15 +3275,9 @@ pub(crate) mod test {
         let logctx = test_setup_log(TEST_NAME);
 
         // Use our example system as a starting point.
-        let (mut example, blueprint1) =
+        let (example, blueprint1) =
             ExampleSystemBuilder::new(&logctx.log, TEST_NAME).build();
         let collection = example.collection;
-
-        // Set this chicken switch so that zones are added even though image
-        // sources are currently InstallDataset.
-        let mut config = example.system.get_planner_config();
-        config.add_zones_with_mupdate_override = true;
-        example.system.set_planner_config(config);
 
         // Expunge the first sled we see, which will result in a Nexus external
         // IP no longer being associated with a running zone, and a new Nexus
@@ -3402,15 +3387,9 @@ pub(crate) mod test {
         let logctx = test_setup_log(TEST_NAME);
 
         // Use our example system as a starting point.
-        let (mut example, blueprint1) =
+        let (example, blueprint1) =
             ExampleSystemBuilder::new(&logctx.log, TEST_NAME).build();
         let collection = example.collection;
-
-        // Set this chicken switch so that zones are added even though image
-        // sources are currently InstallDataset.
-        let mut config = example.system.get_planner_config();
-        config.add_zones_with_mupdate_override = true;
-        example.system.set_planner_config(config);
 
         let input = example
             .system
@@ -3600,14 +3579,9 @@ pub(crate) mod test {
         let logctx = test_setup_log(TEST_NAME);
 
         // Create an example system with a single sled
-        let (mut example, blueprint1) =
+        let (example, blueprint1) =
             ExampleSystemBuilder::new(&logctx.log, TEST_NAME).nsleds(1).build();
         let collection = example.collection;
-        // Set this chicken switch so that zones are added even though zones are
-        // currently InstallDataset.
-        let mut config = example.system.get_planner_config();
-        config.add_zones_with_mupdate_override = true;
-        example.system.set_planner_config(config);
 
         let mut builder = example
             .system
@@ -3708,15 +3682,9 @@ pub(crate) mod test {
         let logctx = test_setup_log(TEST_NAME);
 
         // Create an example system with a single sled
-        let (mut example, mut blueprint1) =
+        let (example, mut blueprint1) =
             ExampleSystemBuilder::new(&logctx.log, TEST_NAME).nsleds(1).build();
         let collection = example.collection;
-
-        // Set this chicken switch so that zones are added even though image
-        // sources are currently InstallDataset.
-        let mut config = example.system.get_planner_config();
-        config.add_zones_with_mupdate_override = true;
-        example.system.set_planner_config(config);
 
         let mut builder = example
             .system
@@ -3796,15 +3764,9 @@ pub(crate) mod test {
 
         // Create an example system with two sleds. We're going to expunge one
         // of these sleds.
-        let (mut example, blueprint1) =
+        let (example, blueprint1) =
             ExampleSystemBuilder::new(&logctx.log, TEST_NAME).nsleds(2).build();
         let mut collection = example.collection;
-
-        // Set this chicken switch so that zones are added even though image
-        // sources are currently InstallDataset.
-        let mut config = example.system.get_planner_config();
-        config.add_zones_with_mupdate_override = true;
-        example.system.set_planner_config(config);
 
         // The initial blueprint configuration has generation 2
         let (sled_id, sled_config) =
@@ -4166,18 +4128,12 @@ pub(crate) mod test {
         let logctx = test_setup_log(TEST_NAME);
 
         // Create an example system with a single sled
-        let (mut example, blueprint1) =
+        let (example, blueprint1) =
             ExampleSystemBuilder::new(&logctx.log, TEST_NAME)
                 .nsleds(1)
                 .nexus_count(2)
                 .build();
         let collection = example.collection;
-
-        // Set this chicken switch so that zones are added even though image
-        // sources are currently InstallDataset.
-        let mut config = example.system.get_planner_config();
-        config.add_zones_with_mupdate_override = true;
-        example.system.set_planner_config(config);
 
         let mut builder = example
             .system
@@ -4317,15 +4273,9 @@ pub(crate) mod test {
         // and decommissioned sleds. (When we add more kinds of
         // non-provisionable states in the future, we'll have to add more
         // sleds.)
-        let (mut example, mut blueprint1) =
+        let (example, mut blueprint1) =
             ExampleSystemBuilder::new(&logctx.log, TEST_NAME).nsleds(5).build();
         let collection = example.collection;
-
-        // Set this chicken switch so that zones are added even though image
-        // sources are currently InstallDataset.
-        let mut config = example.system.get_planner_config();
-        config.add_zones_with_mupdate_override = true;
-        example.system.set_planner_config(config);
 
         // This blueprint should only have 5 Nexus zones: one on each sled.
         assert_eq!(blueprint1.sleds.len(), 5);
@@ -4652,14 +4602,8 @@ pub(crate) mod test {
         let logctx = test_setup_log(TEST_NAME);
 
         // Use our example system as a starting point.
-        let (mut example, blueprint1) =
+        let (example, blueprint1) =
             ExampleSystemBuilder::new(&logctx.log, TEST_NAME).build();
-
-        // Set this chicken switch so that zones are added even though image
-        // sources are currently InstallDataset.
-        let mut config = example.system.get_planner_config();
-        config.add_zones_with_mupdate_override = true;
-        example.system.set_planner_config(config);
 
         let collection = example.collection;
 
@@ -4945,15 +4889,9 @@ pub(crate) mod test {
         let logctx = test_setup_log(TEST_NAME);
 
         // Use our example system as a starting point.
-        let (mut example, blueprint1) =
+        let (example, blueprint1) =
             ExampleSystemBuilder::new(&logctx.log, TEST_NAME).build();
         let collection = example.collection;
-
-        // Set this chicken switch so that zones are added even though image
-        // sources are currently InstallDataset.
-        let mut config = example.system.get_planner_config();
-        config.add_zones_with_mupdate_override = true;
-        example.system.set_planner_config(config);
 
         // We should start with CRUCIBLE_PANTRY_REDUNDANCY pantries spread out
         // to at most 1 per sled. Find one of the sleds running one.
@@ -5030,15 +4968,9 @@ pub(crate) mod test {
         let logctx = test_setup_log(TEST_NAME);
 
         // Use our example system as a starting point.
-        let (mut example, blueprint1) =
+        let (example, blueprint1) =
             ExampleSystemBuilder::new(&logctx.log, TEST_NAME).build();
         let collection = example.collection;
-
-        // Set this chicken switch so that zones are added even though image
-        // sources are currently InstallDataset.
-        let mut config = example.system.get_planner_config();
-        config.add_zones_with_mupdate_override = true;
-        example.system.set_planner_config(config);
 
         // We should start with one ClickHouse zone. Find out which sled it's on.
         let clickhouse_sleds = blueprint1
@@ -5111,16 +5043,10 @@ pub(crate) mod test {
         let log = logctx.log.clone();
 
         // Use our example system.
-        let (mut example, blueprint1) =
+        let (example, blueprint1) =
             ExampleSystemBuilder::new(&logctx.log, TEST_NAME).build();
         let mut collection = example.collection;
         verify_blueprint(&blueprint1);
-
-        // Set this chicken switch so that zones are added even though image
-        // sources are currently InstallDataset.
-        let mut config = example.system.get_planner_config();
-        config.add_zones_with_mupdate_override = true;
-        example.system.set_planner_config(config);
 
         // We shouldn't have a clickhouse cluster config, as we don't have a
         // clickhouse policy set yet
@@ -5469,15 +5395,9 @@ pub(crate) mod test {
         let log = logctx.log.clone();
 
         // Use our example system.
-        let (mut example, blueprint1) =
+        let (example, blueprint1) =
             ExampleSystemBuilder::new(&log, TEST_NAME).build();
         let mut collection = example.collection;
-
-        // Set this chicken switch so that zones are added even though image
-        // sources are currently InstallDataset.
-        let mut config = example.system.get_planner_config();
-        config.add_zones_with_mupdate_override = true;
-        example.system.set_planner_config(config);
 
         let mut input_builder = example
             .system
@@ -5700,15 +5620,9 @@ pub(crate) mod test {
         let log = logctx.log.clone();
 
         // Use our example system.
-        let (mut example, blueprint1) =
+        let (example, blueprint1) =
             ExampleSystemBuilder::new(&log, TEST_NAME).build();
         let collection = example.collection;
-
-        // Set this chicken switch so that zones are added even though image
-        // sources are currently InstallDataset.
-        let mut config = example.system.get_planner_config();
-        config.add_zones_with_mupdate_override = true;
-        example.system.set_planner_config(config);
 
         let mut input_builder = example
             .system
@@ -6096,15 +6010,9 @@ pub(crate) mod test {
         let log = logctx.log.clone();
 
         // Use our example system.
-        let (mut example, blueprint1) =
+        let (example, blueprint1) =
             ExampleSystemBuilder::new(&log, TEST_NAME).build();
         let mut collection = example.collection;
-
-        // Set this chicken switch so that zones are added even though image
-        // sources are currently InstallDataset.
-        let mut config = example.system.get_planner_config();
-        config.add_zones_with_mupdate_override = true;
-        example.system.set_planner_config(config);
 
         // Find a internal DNS zone we'll use for our test.
         let (sled_id, internal_dns_config) = blueprint1

--- a/nexus/reconfigurator/planning/src/planner.rs
+++ b/nexus/reconfigurator/planning/src/planner.rs
@@ -264,7 +264,7 @@ impl<'a> Planner<'a> {
         };
         add.add_update_blocked_reasons = add_update_blocked_reasons;
         add.add_zones_with_mupdate_override = add_zones_with_mupdate_override;
-        add.target_release_generations_are_one =
+        add.target_release_generation_is_one =
             target_release_generation_is_one;
 
         let zone_updates = if add.any_discretionary_zones_placed() {

--- a/nexus/reconfigurator/planning/tests/output/planner_decommissions_sleds_bp2.txt
+++ b/nexus/reconfigurator/planning/tests/output/planner_decommissions_sleds_bp2.txt
@@ -328,15 +328,12 @@ parent:    516e80a3-b362-4fac-bd3c-4559717120dd
 
 blueprint source: planner with report:
 planning report:
-planner config:
-    add zones with mupdate override:   true
-
 * zone adds and updates are blocked:
   - sleds have deployment units with image sources not set to Artifact:
     - sled d67ce8f0-a691-4010-b414-420d82e80527: 14 zones
     - sled fefcf4cf-f7e7-46b3-b629-058526ce440e: 14 zones
 
-* adding zones despite being blocked, as specified by the `add_zones_with_mupdate_override` planner config option
+* adding zones despite being blocked, because: target release generation is 1
 * discretionary zones placed:
   * crucible_pantry zone on sled d67ce8f0-a691-4010-b414-420d82e80527 from source install dataset
   * nexus zone on sled d67ce8f0-a691-4010-b414-420d82e80527 from source install dataset

--- a/nexus/reconfigurator/planning/tests/output/planner_nonprovisionable_bp2.txt
+++ b/nexus/reconfigurator/planning/tests/output/planner_nonprovisionable_bp2.txt
@@ -516,16 +516,13 @@ parent:    4d4e6c38-cd95-4c4e-8f45-6af4d686964b
 
 blueprint source: planner with report:
 planning report:
-planner config:
-    add zones with mupdate override:   true
-
 * zone adds and updates are blocked:
   - sleds have deployment units with image sources not set to Artifact:
     - sled 2d1cb4f2-cf44-40fc-b118-85036eb732a9: 15 zones
     - sled 75bc286f-2b4b-482c-9431-59272af529da: 12 zones
     - sled affab35f-600a-4109-8ea0-34a067a4e0bc: 12 zones
 
-* adding zones despite being blocked, as specified by the `add_zones_with_mupdate_override` planner config option
+* adding zones despite being blocked, because: target release generation is 1
 * discretionary zones placed:
   * nexus zone on sled 75bc286f-2b4b-482c-9431-59272af529da from source install dataset
   * nexus zone on sled 75bc286f-2b4b-482c-9431-59272af529da from source install dataset

--- a/nexus/src/app/background/tasks/blueprint_planner.rs
+++ b/nexus/src/app/background/tasks/blueprint_planner.rs
@@ -359,14 +359,7 @@ mod test {
                 version: 1,
                 config: ReconfiguratorConfig {
                     planner_enabled: true,
-                    planner_config: PlannerConfig {
-                        // Set this config to true because we'd like to test
-                        // adding zones even if no target release is set. In the
-                        // future, we'll allow adding zones if no target release
-                        // has ever been set, in which case we can go back to
-                        // setting this field to false.
-                        add_zones_with_mupdate_override: true,
-                    },
+                    planner_config: PlannerConfig::default(),
                 },
                 time_modified: now_db_precision(),
             }),

--- a/nexus/types/src/deployment/planning_report.rs
+++ b/nexus/types/src/deployment/planning_report.rs
@@ -563,6 +563,10 @@ pub struct PlanningAddStepReport {
     /// MUPdate-related reasons.)
     pub add_zones_with_mupdate_override: bool,
 
+    /// Set to true if the target release generation and minimum release
+    /// generation are both 1, which would allow zones to be added.
+    pub target_release_generations_are_one: bool,
+
     pub sleds_without_ntp_zones_in_inventory: BTreeSet<SledUuid>,
     pub sleds_without_zpools_for_ntp_zones: BTreeSet<SledUuid>,
     pub sleds_waiting_for_ntp_zone: BTreeSet<SledUuid>,
@@ -590,6 +594,7 @@ impl PlanningAddStepReport {
             waiting_on: None,
             add_update_blocked_reasons: Vec::new(),
             add_zones_with_mupdate_override: false,
+            target_release_generations_are_one: false,
             sleds_without_ntp_zones_in_inventory: BTreeSet::new(),
             sleds_without_zpools_for_ntp_zones: BTreeSet::new(),
             sleds_waiting_for_ntp_zone: BTreeSet::new(),
@@ -689,6 +694,7 @@ impl fmt::Display for PlanningAddStepReport {
             waiting_on,
             add_update_blocked_reasons,
             add_zones_with_mupdate_override,
+            target_release_generations_are_one,
             sleds_without_ntp_zones_in_inventory,
             sleds_without_zpools_for_ntp_zones,
             sleds_waiting_for_ntp_zone,
@@ -718,12 +724,21 @@ impl fmt::Display for PlanningAddStepReport {
             }
         }
 
+        let mut add_zones_despite_being_blocked_reasons = Vec::new();
         if *add_zones_with_mupdate_override {
+            add_zones_despite_being_blocked_reasons.push(
+                "planner config `add_zones_with_mupdate_override` is true",
+            );
+        }
+        if *target_release_generations_are_one {
+            add_zones_despite_being_blocked_reasons
+                .push("target release generation is 1");
+        }
+        if !add_zones_despite_being_blocked_reasons.is_empty() {
             writeln!(
                 f,
-                "* adding zones despite being blocked, \
-                   as specified by the `add_zones_with_mupdate_override` \
-                   planner config option"
+                "* adding zones despite being blocked, because: {}",
+                add_zones_despite_being_blocked_reasons.join(", "),
             )?;
         }
 

--- a/nexus/types/src/deployment/planning_report.rs
+++ b/nexus/types/src/deployment/planning_report.rs
@@ -563,9 +563,9 @@ pub struct PlanningAddStepReport {
     /// MUPdate-related reasons.)
     pub add_zones_with_mupdate_override: bool,
 
-    /// Set to true if the target release generation and minimum release
-    /// generation are both 1, which would allow zones to be added.
-    pub target_release_generations_are_one: bool,
+    /// Set to true if the target release generation is 1, which would allow
+    /// zones to be added.
+    pub target_release_generation_is_one: bool,
 
     pub sleds_without_ntp_zones_in_inventory: BTreeSet<SledUuid>,
     pub sleds_without_zpools_for_ntp_zones: BTreeSet<SledUuid>,
@@ -594,7 +594,7 @@ impl PlanningAddStepReport {
             waiting_on: None,
             add_update_blocked_reasons: Vec::new(),
             add_zones_with_mupdate_override: false,
-            target_release_generations_are_one: false,
+            target_release_generation_is_one: false,
             sleds_without_ntp_zones_in_inventory: BTreeSet::new(),
             sleds_without_zpools_for_ntp_zones: BTreeSet::new(),
             sleds_waiting_for_ntp_zone: BTreeSet::new(),
@@ -694,7 +694,7 @@ impl fmt::Display for PlanningAddStepReport {
             waiting_on,
             add_update_blocked_reasons,
             add_zones_with_mupdate_override,
-            target_release_generations_are_one,
+            target_release_generation_is_one,
             sleds_without_ntp_zones_in_inventory,
             sleds_without_zpools_for_ntp_zones,
             sleds_waiting_for_ntp_zone,
@@ -730,7 +730,7 @@ impl fmt::Display for PlanningAddStepReport {
                 "planner config `add_zones_with_mupdate_override` is true",
             );
         }
-        if *target_release_generations_are_one {
+        if *target_release_generation_is_one {
             add_zones_despite_being_blocked_reasons
                 .push("target release generation is 1");
         }

--- a/openapi/nexus-internal.json
+++ b/openapi/nexus-internal.json
@@ -7081,6 +7081,10 @@
               "$ref": "#/components/schemas/PlanningAddSufficientZonesExist"
             }
           },
+          "target_release_generation_is_one": {
+            "description": "Set to true if the target release generation is 1, which would allow zones to be added.",
+            "type": "boolean"
+          },
           "waiting_on": {
             "nullable": true,
             "description": "What are we waiting on to start zone additions?",
@@ -7102,7 +7106,8 @@
           "sleds_waiting_for_ntp_zone",
           "sleds_without_ntp_zones_in_inventory",
           "sleds_without_zpools_for_ntp_zones",
-          "sufficient_zones_exist"
+          "sufficient_zones_exist",
+          "target_release_generation_is_one"
         ]
       },
       "PlanningAddSufficientZonesExist": {


### PR DESCRIPTION
For customers that are going to continue relying on MUPdate, the planner should act the same way as it did before self-service update existed. We ascertain this by looking at whether a target release has ever been set.

Most of the tests no longer require the `add_zones_with_mupdate_override` config, so add a new reconfigurator-cli script which specifically tests that config.
