### PR TITLE
Planner bg task: Save report even if we don't make a new target

### DIFF
--- a/dev-tools/omdb/src/bin/omdb/nexus.rs
+++ b/dev-tools/omdb/src/bin/omdb/nexus.rs
@@ -1295,14 +1295,20 @@ fn print_task_blueprint_planner(details: &serde_json::Value) {
         BlueprintPlannerStatus::Error(error) => {
             println!("    task did not complete successfully: {error}");
         }
-        BlueprintPlannerStatus::Unchanged { parent_blueprint_id } => {
+        BlueprintPlannerStatus::Unchanged { parent_blueprint_id, report } => {
             println!("    plan unchanged from parent {parent_blueprint_id}");
+            println!("{report}");
         }
-        BlueprintPlannerStatus::Planned { parent_blueprint_id, error } => {
+        BlueprintPlannerStatus::Planned {
+            parent_blueprint_id,
+            error,
+            report,
+        } => {
             println!(
                 "    planned new blueprint from parent {parent_blueprint_id}, \
                      but could not make it the target: {error}"
             );
+            println!("{report}");
         }
         BlueprintPlannerStatus::Targeted { blueprint_id, report, .. } => {
             println!(

--- a/nexus/types/src/internal_api/background.rs
+++ b/nexus/types/src/internal_api/background.rs
@@ -492,11 +492,18 @@ pub enum BlueprintPlannerStatus {
 
     /// Planning produced a blueprint identital to the current target,
     /// so we threw it away and did nothing.
-    Unchanged { parent_blueprint_id: BlueprintUuid },
+    Unchanged {
+        parent_blueprint_id: BlueprintUuid,
+        report: Arc<PlanningReport>,
+    },
 
     /// Planning produced a new blueprint, but we failed to make it
     /// the current target and so deleted it.
-    Planned { parent_blueprint_id: BlueprintUuid, error: String },
+    Planned {
+        parent_blueprint_id: BlueprintUuid,
+        error: String,
+        report: Arc<PlanningReport>,
+    },
 
     /// Planing succeeded, and we saved and made the new blueprint the
     /// current target.


### PR DESCRIPTION
We talked about putting the background task's report in a watch channel, and we might still want to do that if we decide we want to expose it in the external API. But this change puts it into the _existing_ watch channel that omdb can poke for debugging, and is a really trivial change. With this it should be easy to compare the report of the current target blueprint with the report of running the planner again after it's realized.