### PR TITLE
quiesce test should not compare wall timestamps durations with monotonic ones

### DIFF
--- a/nexus/src/app/quiesce.rs
+++ b/nexus/src/app/quiesce.rs
@@ -535,6 +535,7 @@ mod test {
     use std::collections::BTreeSet;
     use std::sync::Arc;
     use std::time::Duration;
+    use std::time::Instant;
     use tokio::sync::watch;
     use uuid::Uuid;
 


### PR DESCRIPTION
Fixes #9089.