### PR TITLE
[nexus] decrease auto-restart cooldown to 5 minutes

### DIFF
--- a/nexus/db-model/src/instance.rs
+++ b/nexus/db-model/src/instance.rs
@@ -377,7 +377,7 @@ impl InstanceAutoRestart {
     /// The default cooldown used when an instance has no overridden cooldown.
     pub const DEFAULT_COOLDOWN: TimeDelta = match TimeDelta::try_minutes(5) {
         Some(delta) => delta,
-        None => unreachable!(), // 5 minutesshould be representable...
+        None => unreachable!(), // 5 minutes should be representable...
     };
 
     /// The default policy used when an instance does not override the


### PR DESCRIPTION
When an instance is automatically restarted, it will not be permitted to restart again until a cooldown period has elapsed since the previous restart. Currently, that cooldown period is one hour, in order to prevent situations where an instance that crashes every time it's restarted is restarted in a hot loop. However, when an instance is on a sled that is updated, it may then be restarted on another sled that is also updated, and the cooldown timer will apply to the subsequent restart. This means that during an update, some instances may not come back for an hour, which is sad. Therefore, this commit decreases the cooldown to 5 minutes, as discussed in #9094.

Fixes #9083