### PR TITLE
dep hygiene: switch from vergen-gitcl to vergen-git2

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -6473,7 +6473,7 @@ dependencies = [
  "tokio",
  "tufaceous-artifact",
  "uuid",
- "vergen-gitcl",
+ "vergen-git2",
 ]
 
 [[package]]
@@ -8220,7 +8220,7 @@ dependencies = [
  "update-engine",
  "url",
  "uuid",
- "vergen-gitcl",
+ "vergen-git2",
 ]
 
 [[package]]
@@ -15185,20 +15185,6 @@ dependencies = [
  "anyhow",
  "derive_builder",
  "git2",
- "rustversion",
- "time",
- "vergen",
- "vergen-lib",
-]
-
-[[package]]
-name = "vergen-gitcl"
-version = "1.0.8"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b9dfc1de6eb2e08a4ddf152f1b179529638bedc0ea95e6d667c014506377aefe"
-dependencies = [
- "anyhow",
- "derive_builder",
  "rustversion",
  "time",
  "vergen",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -774,7 +774,7 @@ url = "2.5.4"
 usdt = "0.5.0"
 uuid = { version = "1.17.0", features = ["serde", "v4"] }
 uzers = "0.12"
-vergen-gitcl = { version = "1.0.8" }
+vergen-git2 = { version = "1.0.7" }
 walkdir = "2.5"
 whoami = "1.5"
 wicket = { path = "wicket" }

--- a/dev-tools/omdb/Cargo.toml
+++ b/dev-tools/omdb/Cargo.toml
@@ -9,7 +9,7 @@ workspace = true
 
 [build-dependencies]
 omicron-rpaths.workspace = true
-vergen-gitcl.workspace = true
+vergen-git2.workspace = true
 
 [dependencies]
 anyhow.workspace = true

--- a/dev-tools/omdb/build.rs
+++ b/dev-tools/omdb/build.rs
@@ -2,8 +2,8 @@
 // License, v. 2.0. If a copy of the MPL was not distributed with this
 // file, You can obtain one at https://mozilla.org/MPL/2.0/.
 
-use vergen_gitcl::Emitter;
-use vergen_gitcl::GitclBuilder;
+use vergen_git2::Emitter;
+use vergen_git2::Git2Builder;
 
 fn main() {
     // See omicron-rpaths for documentation. NOTE: This file MUST be kept in
@@ -16,13 +16,13 @@ fn main() {
     //
     // We use this to check our own git SHA against the git SHA of the Nexus
     // that generated blueprint planner debug logs.
-    let gitcl = GitclBuilder::default()
+    let git2 = Git2Builder::default()
         .sha(/* short= */ false)
         .dirty(/* include_untracked= */ false)
         .build()
-        .expect("valid GitclBuilder configuration");
+        .expect("valid Git2Builder configuration");
     Emitter::default()
-        .add_instructions(&gitcl)
+        .add_instructions(&git2)
         .expect("valid instructions")
         .emit()
         .expect("emitted version information");

--- a/nexus/db-model/Cargo.toml
+++ b/nexus/db-model/Cargo.toml
@@ -9,7 +9,7 @@ workspace = true
 
 [build-dependencies]
 omicron-rpaths.workspace = true
-vergen-gitcl.workspace = true
+vergen-git2.workspace = true
 
 [dependencies]
 anyhow.workspace = true

--- a/nexus/db-model/build.rs
+++ b/nexus/db-model/build.rs
@@ -2,8 +2,8 @@
 // License, v. 2.0. If a copy of the MPL was not distributed with this
 // file, You can obtain one at https://mozilla.org/MPL/2.0/.
 
-use vergen_gitcl::Emitter;
-use vergen_gitcl::GitclBuilder;
+use vergen_git2::Emitter;
+use vergen_git2::Git2Builder;
 
 fn main() {
     // See omicron-rpaths for documentation. NOTE: This file MUST be kept in
@@ -17,13 +17,13 @@ fn main() {
     // We embed our git SHA in the JSON blobs for blueprint planner debug logs,
     // so `omdb` can report if it's out of sync with the Nexus that created the
     // debug log.
-    let gitcl = GitclBuilder::default()
+    let git2 = Git2Builder::default()
         .sha(/* short= */ false)
         .dirty(/* include_untracked= */ false)
         .build()
-        .expect("valid GitclBuilder configuration");
+        .expect("valid Git2Builder configuration");
     Emitter::default()
-        .add_instructions(&gitcl)
+        .add_instructions(&git2)
         .expect("valid instructions")
         .emit()
         .expect("emitted version information");


### PR DESCRIPTION
This matches what crucible is using to read git info at build time. (We were using `vergen-gitcl` which spawns a git CLI to avoid colliding on different versions of sys-libgit2 with crucible, but we recently pulled in a new crucible version and can now switch to match.)