### PR TITLE
Fix dpd-client reflector

### DIFF
--- a/.github/workflows/update-dendrite.yml
+++ b/.github/workflows/update-dendrite.yml
@@ -43,11 +43,12 @@ jobs:
       - name: Update dendrite versions
         run: |
           ./tools/update_dendrite.sh
-          - name: Extract new dendrite package version
-            run: |
-              eval $(cat tools/dendrite_version | grep COMMIT)
-              echo "version=${COMMIT:0:7}" >> $GITHUB_OUTPUT
-            id: updated
+
+      - name: Extract new dendrite package version
+        run: |
+          eval $(cat tools/dendrite_version | grep COMMIT)
+          echo "version=${COMMIT:0:7}" >> $GITHUB_OUTPUT
+        id: updated
 
       - name: Commit changes
         run: |

--- a/.github/workflows/update-dendrite.yml
+++ b/.github/workflows/update-dendrite.yml
@@ -27,7 +27,6 @@ jobs:
       INT_BRANCH: dendrite-integration
       TARGET_BRANCH: main
     steps:
-
       # Checkout both the target and integration branches
       - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
         with:
@@ -44,6 +43,26 @@ jobs:
       - name: Update dendrite versions
         run: |
           ./tools/update_dendrite.sh
+
+      - name: Extract new dendrite package version
+        run: |
+          COMMIT=$(cargo metadata | \
+            jq -r '.resolve.nodes[] | select(.id | startswith("git+https://github.com/oxidecomputer/dendrite?rev=")) | select(.id | contains("dpd-client")) | .id' | \
+            awk 'match($0, /\?rev=([^#]+)/) { print substr($0, RSTART + 5, RLENGTH - 5) }')
+
+          echo "version=${COMMIT}" >> $GITHUB_OUTPUT
+        id: updated
+
+      - name: Commit changes
+        run: |
+          . ./tools/reflector/helpers.sh
+
+          PATHS=("Cargo.toml" "Cargo.lock")
+          CHANGES=()
+          commit $TARGET_BRANCH $INT_BRANCH ${{ inputs.reflector_user_id }} PATHS CHANGES
+
+          echo "api=${CHANGES[0]}" >> $GITHUB_OUTPUT
+        id: committed
 
       - name: Update pull request
         env:

--- a/.github/workflows/update-dendrite.yml
+++ b/.github/workflows/update-dendrite.yml
@@ -43,21 +43,17 @@ jobs:
       - name: Update dendrite versions
         run: |
           ./tools/update_dendrite.sh
-
-      - name: Extract new dendrite package version
-        run: |
-          COMMIT=$(cargo metadata | \
-            jq -r '.resolve.nodes[] | select(.id | startswith("git+https://github.com/oxidecomputer/dendrite?rev=")) | select(.id | contains("dpd-client")) | .id' | \
-            awk 'match($0, /\?rev=([^#]+)/) { print substr($0, RSTART + 5, RLENGTH - 5) }')
-
-          echo "version=${COMMIT}" >> $GITHUB_OUTPUT
-        id: updated
+          - name: Extract new dendrite package version
+            run: |
+              eval $(cat tools/dendrite_version | grep COMMIT)
+              echo "version=${COMMIT:0:7}" >> $GITHUB_OUTPUT
+            id: updated
 
       - name: Commit changes
         run: |
           . ./tools/reflector/helpers.sh
 
-          PATHS=("Cargo.toml" "Cargo.lock")
+          PATHS=("tools/dendrite_version" "Cargo.toml" "Cargo.lock")
           CHANGES=()
           commit $TARGET_BRANCH $INT_BRANCH ${{ inputs.reflector_user_id }} PATHS CHANGES
 


### PR DESCRIPTION
This should fix the dendrite reflector bot integration to work with the cargo tracked dendrite dependency introduced in #7907 