### PR TITLE
add timestamps to db_metadata_nexus records for debugging handoff

### DIFF
--- a/nexus/db-model/src/db_metadata.rs
+++ b/nexus/db-model/src/db_metadata.rs
@@ -71,14 +71,26 @@ pub struct DbMetadataNexus {
     nexus_id: DbTypedUuid<OmicronZoneKind>,
     last_drained_blueprint_id: Option<DbTypedUuid<BlueprintKind>>,
     state: DbMetadataNexusState,
+    time_row_created: Option<DateTime<Utc>>,
+    time_quiesced: Option<DateTime<Utc>>,
+    time_active: Option<DateTime<Utc>>,
 }
 
 impl DbMetadataNexus {
     pub fn new(nexus_id: OmicronZoneUuid, state: DbMetadataNexusState) -> Self {
+        let now = Utc::now();
+        let (time_active, time_quiesced) = match state {
+            DbMetadataNexusState::Active => (Some(now), None),
+            DbMetadataNexusState::Quiesced => (None, Some(now)),
+            DbMetadataNexusState::NotYet => (None, None),
+        };
         Self {
             nexus_id: nexus_id.into(),
             last_drained_blueprint_id: None,
             state,
+            time_row_created: Some(now),
+            time_quiesced,
+            time_active,
         }
     }
 
@@ -92,5 +104,13 @@ impl DbMetadataNexus {
 
     pub fn last_drained_blueprint_id(&self) -> Option<BlueprintUuid> {
         self.last_drained_blueprint_id.map(|id| id.into())
+    }
+
+    pub fn time_active(&self) -> Option<DateTime<Utc>> {
+        self.time_active
+    }
+
+    pub fn time_quiesced(&self) -> Option<DateTime<Utc>> {
+        self.time_quiesced
     }
 }

--- a/nexus/db-model/src/schema_versions.rs
+++ b/nexus/db-model/src/schema_versions.rs
@@ -16,7 +16,7 @@ use std::{collections::BTreeMap, sync::LazyLock};
 ///
 /// This must be updated when you change the database schema.  Refer to
 /// schema/crdb/README.adoc in the root of this repository for details.
-pub const SCHEMA_VERSION: Version = Version::new(194, 0, 0);
+pub const SCHEMA_VERSION: Version = Version::new(195, 0, 0);
 
 /// List of all past database schema versions, in *reverse* order
 ///
@@ -28,6 +28,7 @@ static KNOWN_VERSIONS: LazyLock<Vec<KnownVersion>> = LazyLock::new(|| {
         // |  leaving the first copy as an example for the next person.
         // v
         // KnownVersion::new(next_int, "unique-dirname-with-the-sql-files"),
+        KnownVersion::new(195, "db-metadata-timestamps"),
         KnownVersion::new(194, "tuf-pruned"),
         KnownVersion::new(193, "nexus-lockstep-port"),
         KnownVersion::new(192, "blueprint-source"),

--- a/nexus/db-schema/src/schema.rs
+++ b/nexus/db-schema/src/schema.rs
@@ -2398,6 +2398,9 @@ table! {
         nexus_id -> Uuid,
         last_drained_blueprint_id -> Nullable<Uuid>,
         state -> crate::enums::DbMetadataNexusStateEnum,
+        time_row_created -> Nullable<Timestamptz>,
+        time_quiesced -> Nullable<Timestamptz>,
+        time_active -> Nullable<Timestamptz>,
     }
 }
 

--- a/schema/crdb/db-metadata-timestamps/up.sql
+++ b/schema/crdb/db-metadata-timestamps/up.sql
@@ -1,0 +1,4 @@
+ALTER TABLE omicron.public.db_metadata_nexus
+    ADD COLUMN IF NOT EXISTS time_row_created TIMESTAMPTZ,
+    ADD COLUMN IF NOT EXISTS time_quiesced TIMESTAMPTZ,
+    ADD COLUMN IF NOT EXISTS time_active TIMESTAMPTZ

--- a/schema/crdb/dbinit.sql
+++ b/schema/crdb/dbinit.sql
@@ -6675,6 +6675,10 @@ CREATE TABLE IF NOT EXISTS omicron.public.db_metadata_nexus (
     nexus_id UUID NOT NULL PRIMARY KEY,
     last_drained_blueprint_id UUID,
     state omicron.public.db_metadata_nexus_state NOT NULL
+    -- the following fields are for debugging only
+    time_row_created TIMESTAMPTZ, -- nullable
+    time_quiesced TIMESTAMPTZ,    -- nullable
+    time_active TIMESTAMPTZ,      -- nullable
 );
 
 CREATE UNIQUE INDEX IF NOT EXISTS lookup_db_metadata_nexus_by_state on omicron.public.db_metadata_nexus (


### PR DESCRIPTION
While working on Nexus handoff, I wondered how we were going to debug it if things went sideways.  We may lose the Nexus logs (due to #3860).  An easy thing to do would be to record in the database the timestamps when individual instances marked themselves quiesced or active.  That would help us construct a timeline of what happened.

This is less urgent than most of the other stuff going on since we've been fortunate to not have observed any handoff bugs yet.  I'd say this is not a blocker for R17, but I'm marking it for milestone 17 because if it's as low-risk (and finished) as I hope then it'll be worth getting in.