### PR TITLE
[reconfigurator] SP resets should be confirmed

### DIFF
--- a/nexus/mgs-updates/src/driver_update.rs
+++ b/nexus/mgs-updates/src/driver_update.rs
@@ -663,7 +663,7 @@ fn post_update_timeout(update: &PendingMgsUpdate) -> Duration {
             // more generous timeout for switches (which we've seen take 10-20
             // seconds in practice).
             match update.sp_type {
-                SpType::Sled | SpType::Power => Duration::from_secs(60),
+                SpType::Sled | SpType::Power => Duration::from_secs(90),
                 SpType::Switch => Duration::from_secs(120),
             }
         }

--- a/nexus/mgs-updates/src/host_phase1_updater.rs
+++ b/nexus/mgs-updates/src/host_phase1_updater.rs
@@ -133,6 +133,8 @@ use crate::SpComponentUpdateHelperImpl;
 use crate::common_sp_update::PostUpdateError;
 use crate::common_sp_update::PrecheckError;
 use crate::common_sp_update::PrecheckStatus;
+use crate::sp_updater::WAIT_FOR_SP_STATE_TIMEOUT;
+use crate::sp_updater::wait_for_sp_state;
 use futures::FutureExt as _;
 use futures::future::BoxFuture;
 use gateway_client::HostPhase1HashError;
@@ -505,6 +507,15 @@ impl ReconfiguratorHostPhase1Updater {
             })
             .await?;
 
+        // We wait for SP state to ensure a successful reset
+        wait_for_sp_state(
+            log,
+            mgs_clients,
+            update.sp_type,
+            update.slot_id,
+            WAIT_FOR_SP_STATE_TIMEOUT,
+        )
+        .await?;
         Ok(())
     }
 }


### PR DESCRIPTION
Yesterday we had an issue on Berlin where the SP didn't come back after a reset. It would have been nice if the planner hadn't carried on as if the SP update had been completed successfully.

Both the RoT and RoT bootloader call boot info after a reset to verify that the component has come back before reporting an update as finished. It's a good idea to have something similar when resetting the SP.

