### PR TITLE
[meta] use latest_version from new dropshot-api-manager-types

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2976,9 +2976,9 @@ dependencies = [
 
 [[package]]
 name = "dropshot-api-manager"
-version = "0.2.1"
+version = "0.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2f448e29400392b55ed2c0133c79841e1bc1bc771e6e20841cb1a5c70a77ef65"
+checksum = "6d0c9a9b3587eb5c7da419466203773307767124fa20e84068d9dd06ee34caa9"
 dependencies = [
  "anyhow",
  "atomicwrites",
@@ -3006,9 +3006,9 @@ dependencies = [
 
 [[package]]
 name = "dropshot-api-manager-types"
-version = "0.2.1"
+version = "0.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1b913840b90fcccce6afbdb146acf39aa3243b8510e255a70572e53a964fc96a"
+checksum = "00be3e4459aae391b88805e9f735c7cf9cf4ed6aad02bc0e92b224b590af39ab"
 dependencies = [
  "anyhow",
  "camino",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -436,8 +436,8 @@ dns-server-api = { path = "dns-server-api" }
 dns-service-client = { path = "clients/dns-service-client" }
 dpd-client = { git = "https://github.com/oxidecomputer/dendrite", rev = "b3cdd095437f388069aa57be5efac4b4fadc7b4f" }
 dropshot = { version = "0.16.3", features = [ "usdt-probes" ] }
-dropshot-api-manager = "0.2.1"
-dropshot-api-manager-types = "0.2.1"
+dropshot-api-manager = "0.2.2"
+dropshot-api-manager-types = "0.2.2"
 dyn-clone = "1.0.20"
 either = "1.15.0"
 ereport-types = { path = "ereport/types" }

--- a/cockroach-admin/src/lib.rs
+++ b/cockroach-admin/src/lib.rs
@@ -72,7 +72,7 @@ pub async fn start_server(
     .version_policy(dropshot::VersionPolicy::Dynamic(Box::new(
         dropshot::ClientSpecifiesVersionInHeader::new(
             omicron_common::api::VERSION_HEADER,
-            cockroach_admin_api::VERSION_NEWTYPE_UUID_BUMP,
+            cockroach_admin_api::latest_version(),
         ),
     )))
     .start()

--- a/gateway/src/lib.rs
+++ b/gateway/src/lib.rs
@@ -106,7 +106,7 @@ fn start_dropshot_server(
             .version_policy(dropshot::VersionPolicy::Dynamic(Box::new(
                 dropshot::ClientSpecifiesVersionInHeader::new(
                     omicron_common::api::VERSION_HEADER,
-                    gateway_api::VERSION_NEWTYPE_UUID_BUMP,
+                    gateway_api::latest_version(),
                 ),
             )))
             .start()

--- a/nexus/mgs-updates/src/test_util/host_phase_2_test_state.rs
+++ b/nexus/mgs-updates/src/test_util/host_phase_2_test_state.rs
@@ -127,7 +127,7 @@ impl HostPhase2TestContext {
             .version_policy(dropshot::VersionPolicy::Dynamic(Box::new(
                 dropshot::ClientSpecifiesVersionInHeader::new(
                     omicron_common::api::VERSION_HEADER,
-                    sled_agent_api::VERSION_NEWTYPE_UUID_BUMP,
+                    sled_agent_api::latest_version(),
                 ),
             )))
             .start()

--- a/sled-agent/src/server.rs
+++ b/sled-agent/src/server.rs
@@ -79,7 +79,7 @@ impl Server {
                 .version_policy(dropshot::VersionPolicy::Dynamic(Box::new(
                     dropshot::ClientSpecifiesVersionInHeader::new(
                         omicron_common::api::VERSION_HEADER,
-                        sled_agent_api::VERSION_NEWTYPE_UUID_BUMP,
+                        sled_agent_api::latest_version(),
                     ),
                 )))
                 .start()

--- a/sled-agent/src/sim/server.rs
+++ b/sled-agent/src/sim/server.rs
@@ -123,7 +123,7 @@ impl Server {
         .version_policy(dropshot::VersionPolicy::Dynamic(Box::new(
             dropshot::ClientSpecifiesVersionInHeader::new(
                 omicron_common::api::VERSION_HEADER,
-                sled_agent_api::VERSION_NEWTYPE_UUID_BUMP,
+                sled_agent_api::latest_version(),
             ),
         )))
         .start()


### PR DESCRIPTION
Saves us having to do version bumps in calling code all the time.
