### PR TITLE
oximeter: clarify empty table errors.

### DIFF
--- a/oximeter/db/src/oxql/ast/table_ops/group_by.rs
+++ b/oximeter/db/src/oxql/ast/table_ops/group_by.rs
@@ -52,6 +52,10 @@ impl GroupBy {
         );
         let table = &tables[0];
         anyhow::ensure!(
+            table.len() > 0,
+            "Input tables to a `group_by` must not be empty"
+        );
+        anyhow::ensure!(
             table.is_aligned(),
             "Input tables to a `group_by` must be aligned"
         );

--- a/oximeter/db/src/oxql/ast/table_ops/join.rs
+++ b/oximeter/db/src/oxql/ast/table_ops/join.rs
@@ -24,6 +24,10 @@ impl Join {
         let mut tables = tables.iter().cloned().enumerate();
         let (_, mut out) = tables.next().unwrap();
         anyhow::ensure!(
+            out.len() > 0,
+            "Input tables for a join operation must not be empty",
+        );
+        anyhow::ensure!(
             out.is_aligned(),
             "Input tables for a join operation must be aligned"
         );


### PR DESCRIPTION
We don't support group by or join operations on empty tables. However, the current error message isn't particularly clear on this point:

> Input tables to a `group_by` must be aligned

This patch adds a new error message specifically for empty tables, so that the user has a better idea of what to do in this situation.