### PR TITLE
Expose `ip_version` and internal delegation filters on `/v1/system/ip-pools`

### DIFF
--- a/nexus/external-api/src/lib.rs
+++ b/nexus/external-api/src/lib.rs
@@ -708,7 +708,7 @@ pub trait NexusExternalApi {
     }]
     async fn ip_pool_list(
         rqctx: RequestContext<Self::Context>,
-        query_params: Query<PaginatedByNameOrId>,
+        query_params: Query<PaginatedByNameOrId<params::IpPoolListSelector>>,
     ) -> Result<HttpResponseOk<ResultsPage<views::IpPool>>, HttpError>;
 
     /// Create IP pool

--- a/nexus/src/app/ip_pool.rs
+++ b/nexus/src/app/ip_pool.rs
@@ -14,6 +14,7 @@ use nexus_db_queries::authz;
 use nexus_db_queries::authz::ApiResource;
 use nexus_db_queries::context::OpContext;
 use nexus_db_queries::db;
+use nexus_db_queries::db::datastore::ip_pool::IpPoolListFilters;
 use nexus_db_queries::db::model::Name;
 use nexus_types::identity::Resource;
 use omicron_common::api::external::CreateResult;
@@ -44,6 +45,15 @@ fn not_found_from_lookup(pool_lookup: &lookup::IpPool<'_>) -> Error {
             Error::not_found_by_id(ResourceType::IpPool, &id)
         }
         lookup::IpPool::Error(_, error) => error.to_owned(),
+    }
+}
+
+impl From<&params::IpPoolListSelector> for IpPoolListFilters {
+    fn from(selector: &params::IpPoolListSelector) -> Self {
+        IpPoolListFilters {
+            ip_version: selector.ip_version.map(Into::into),
+            delegated_for_internal_use: selector.delegated_for_internal_use,
+        }
     }
 }
 
@@ -249,8 +259,10 @@ impl super::Nexus {
         &self,
         opctx: &OpContext,
         pagparams: &PaginatedBy<'_>,
+        selector: &params::IpPoolListSelector,
     ) -> ListResultVec<db::model::IpPool> {
-        self.db_datastore.ip_pools_list(opctx, pagparams).await
+        let filters = IpPoolListFilters::from(selector);
+        self.db_datastore.ip_pools_list(opctx, pagparams, &filters).await
     }
 
     pub(crate) async fn ip_pool_delete(

--- a/nexus/src/external_api/http_entrypoints.rs
+++ b/nexus/src/external_api/http_entrypoints.rs
@@ -1152,7 +1152,7 @@ impl NexusExternalApi for NexusExternalApiImpl {
 
     async fn ip_pool_list(
         rqctx: RequestContext<ApiContext>,
-        query_params: Query<PaginatedByNameOrId>,
+        query_params: Query<PaginatedByNameOrId<params::IpPoolListSelector>>,
     ) -> Result<HttpResponseOk<ResultsPage<IpPool>>, HttpError> {
         let apictx = rqctx.context();
         let handler = async {
@@ -1160,11 +1160,12 @@ impl NexusExternalApi for NexusExternalApiImpl {
             let query = query_params.into_inner();
             let pag_params = data_page_params_for(&rqctx, &query)?;
             let scan_params = ScanByNameOrId::from_query(&query)?;
+            let filters = scan_params.selector.clone();
             let paginated_by = name_or_id_pagination(&pag_params, scan_params)?;
             let opctx =
                 crate::context::op_context_for_external_api(&rqctx).await?;
             let pools = nexus
-                .ip_pools_list(&opctx, &paginated_by)
+                .ip_pools_list(&opctx, &paginated_by, &filters)
                 .await?
                 .into_iter()
                 .map(IpPool::from)

--- a/nexus/types/src/external_api/params.rs
+++ b/nexus/types/src/external_api/params.rs
@@ -997,6 +997,22 @@ impl std::fmt::Debug for CertificateCreate {
 
 // IP POOLS
 
+/// Filters for listing IP pools.
+#[derive(
+    Clone, Debug, Default, Deserialize, Serialize, JsonSchema, PartialEq,
+)]
+pub struct IpPoolListSelector {
+    /// Restrict pools to a specific IP version.
+    #[serde(default)]
+    pub ip_version: Option<IpVersion>,
+
+    /// Filter on pools delegated for internal Oxide use.
+    ///
+    /// Defaults to excluding internal pools when unset.
+    #[serde(default)]
+    pub delegated_for_internal_use: Option<bool>,
+}
+
 /// Create-time parameters for an `IpPool`
 #[derive(Clone, Debug, Deserialize, Serialize, JsonSchema)]
 pub struct IpPoolCreate {

--- a/openapi/nexus.json
+++ b/openapi/nexus.json
@@ -8251,6 +8251,23 @@
         "parameters": [
           {
             "in": "query",
+            "name": "delegated_for_internal_use",
+            "description": "Filter on pools delegated for internal Oxide use.\n\nDefaults to excluding internal pools when unset.",
+            "schema": {
+              "nullable": true,
+              "type": "boolean"
+            }
+          },
+          {
+            "in": "query",
+            "name": "ip_version",
+            "description": "Restrict pools to a specific IP version.",
+            "schema": {
+              "$ref": "#/components/schemas/IpVersion"
+            }
+          },
+          {
+            "in": "query",
             "name": "limit",
             "description": "Maximum number of items returned by a single call",
             "schema": {


### PR DESCRIPTION
Resolves https://github.com/oxidecomputer/omicron/issues/9147

This PR introduces explicit filter parameters to `/v1/system/ip-pools` so clients can request pools by IP version and opt in to the Oxide service pools. The endpoint now accepts a new `IpPoolListSelector` query struct, which flows through the HTTP handler, application service, and datastore. The datastore applies the requested IP version filter and either includes or excludes the two well-known service pools that previously were always hidden. 

I've also added a few integration tests that cover the new combinations, and regenerated Nexus OpenAPI documentation to include the the additional query parameters.