### PR TITLE
Don't create unnecessary SP dump dirs

### DIFF
--- a/nexus/src/app/background/tasks/support_bundle_collector.rs
+++ b/nexus/src/app/background/tasks/support_bundle_collector.rs
@@ -1389,6 +1389,10 @@ async fn save_sp_dumps(
         .context("failed to get task dump count from SP")?
         .into_inner();
 
+    if dump_count == 0 {
+        return Ok(());
+    }
+
     let output_dir = sp_dumps_dir.join(format!("{}_{}", sp.type_, sp.slot));
     tokio::fs::create_dir_all(&output_dir).await?;
 


### PR DESCRIPTION
Currently we create a support bundle directory for SP dumps for each component queried, regardless of whether it has any dumps to collect.

Create this directory only when needed.