### PR TITLE
remove unused `sled_firewall_rules_request` API

### DIFF
--- a/nexus/internal-api/src/lib.rs
+++ b/nexus/internal-api/src/lib.rs
@@ -75,20 +75,6 @@ pub trait NexusInternalApi {
         sled_info: TypedBody<SledAgentInfo>,
     ) -> Result<HttpResponseUpdatedNoContent, HttpError>;
 
-    /// Request a new set of firewall rules for a sled.
-    ///
-    /// This causes Nexus to read the latest set of rules for the sled,
-    /// and call a Sled endpoint which applies the rules to all OPTE ports
-    /// that happen to exist.
-    #[endpoint {
-        method = POST,
-        path = "/sled-agents/{sled_id}/firewall-rules-update",
-    }]
-    async fn sled_firewall_rules_request(
-        rqctx: RequestContext<Self::Context>,
-        path_params: Path<SledAgentPathParam>,
-    ) -> Result<HttpResponseUpdatedNoContent, HttpError>;
-
     /// Report that the Rack Setup Service initialization is complete
     ///
     /// See RFD 278 for more details.

--- a/nexus/src/app/sled.rs
+++ b/nexus/src/app/sled.rs
@@ -126,16 +126,6 @@ impl super::Nexus {
         Ok(prev_policy)
     }
 
-    pub(crate) async fn sled_request_firewall_rules(
-        &self,
-        opctx: &OpContext,
-        id: SledUuid,
-    ) -> Result<(), Error> {
-        info!(self.log, "requesting firewall rules"; "sled_uuid" => id.to_string());
-        self.plumb_service_firewall_rules(opctx, &[id]).await?;
-        Ok(())
-    }
-
     pub(crate) async fn sled_list(
         &self,
         opctx: &OpContext,

--- a/nexus/src/internal_api/http_entrypoints.rs
+++ b/nexus/src/internal_api/http_entrypoints.rs
@@ -90,25 +90,6 @@ impl NexusInternalApi for NexusInternalApiImpl {
             .await
     }
 
-    async fn sled_firewall_rules_request(
-        rqctx: RequestContext<Self::Context>,
-        path_params: Path<SledAgentPathParam>,
-    ) -> Result<HttpResponseUpdatedNoContent, HttpError> {
-        let apictx = &rqctx.context().context;
-        let nexus = &apictx.nexus;
-        let opctx = crate::context::op_context_for_internal_api(&rqctx).await;
-        let path = path_params.into_inner();
-        let sled_id = &path.sled_id;
-        let handler = async {
-            nexus.sled_request_firewall_rules(&opctx, *sled_id).await?;
-            Ok(HttpResponseUpdatedNoContent())
-        };
-        apictx
-            .internal_latencies
-            .instrument_dropshot_handler(&rqctx, handler)
-            .await
-    }
-
     async fn rack_initialization_complete(
         rqctx: RequestContext<Self::Context>,
         path_params: Path<RackPathParam>,

--- a/openapi/nexus-internal.json
+++ b/openapi/nexus-internal.json
@@ -671,34 +671,6 @@
         }
       }
     },
-    "/sled-agents/{sled_id}/firewall-rules-update": {
-      "post": {
-        "summary": "Request a new set of firewall rules for a sled.",
-        "description": "This causes Nexus to read the latest set of rules for the sled, and call a Sled endpoint which applies the rules to all OPTE ports that happen to exist.",
-        "operationId": "sled_firewall_rules_request",
-        "parameters": [
-          {
-            "in": "path",
-            "name": "sled_id",
-            "required": true,
-            "schema": {
-              "$ref": "#/components/schemas/SledUuid"
-            }
-          }
-        ],
-        "responses": {
-          "204": {
-            "description": "resource updated"
-          },
-          "4XX": {
-            "$ref": "#/components/responses/Error"
-          },
-          "5XX": {
-            "$ref": "#/components/responses/Error"
-          }
-        }
-      }
-    },
     "/switch/{switch_id}": {
       "put": {
         "operationId": "switch_put",


### PR DESCRIPTION
This doorbell API was used by Sled Agent prior to the config reconciler introduced in #8064. Nothing currently appears to use it.