### PR TITLE
remove `bgtask_activate` from nexus-internal

### DIFF
--- a/nexus/internal-api/src/lib.rs
+++ b/nexus/internal-api/src/lib.rs
@@ -256,20 +256,6 @@ pub trait NexusInternalApi {
         downstairs_client_stopped: TypedBody<DownstairsClientStopped>,
     ) -> Result<HttpResponseUpdatedNoContent, HttpError>;
 
-    /// **Do not use in new code!**
-    ///
-    /// Callers to this API should either be capable of using the nexus-lockstep
-    /// API or should be rewritten to use a doorbell API to activate a specific
-    /// task. Task names are internal to Nexus.
-    #[endpoint {
-        method = POST,
-        path = "/bgtasks/activate",
-    }]
-    async fn bgtask_activate(
-        rqctx: RequestContext<Self::Context>,
-        body: TypedBody<BackgroundTasksActivateRequest>,
-    ) -> Result<HttpResponseUpdatedNoContent, HttpError>;
-
     // NAT RPW internal APIs
 
     /// Fetch NAT ChangeSet
@@ -290,6 +276,9 @@ pub trait NexusInternalApi {
     ) -> Result<HttpResponseOk<Vec<NatEntryView>>, HttpError>;
 
     /// Get all the probes associated with a given sled.
+    ///
+    /// This should not be used in new code, and abandoned if a change is
+    /// required. See #9157.
     #[endpoint {
         method = GET,
         path = "/probes/{sled}"
@@ -299,6 +288,18 @@ pub trait NexusInternalApi {
         path_params: Path<ProbePathParam>,
         query_params: Query<PaginatedById>,
     ) -> Result<HttpResponseOk<Vec<ProbeInfo>>, HttpError>;
+
+    /// Request that Nexus refreshes VPC routes.
+    ///
+    /// This should not be used in new code, and abandoned if a change is
+    /// required. See #9157.
+    #[endpoint {
+        method = POST,
+        path = "/refresh-vpc-routes"
+    }]
+    async fn refresh_vpc_routes(
+        rqctx: RequestContext<Self::Context>,
+    ) -> Result<HttpResponseUpdatedNoContent, HttpError>;
 }
 
 /// Path parameters for Sled Agent requests (internal API)

--- a/nexus/src/app/probe.rs
+++ b/nexus/src/app/probe.rs
@@ -131,4 +131,10 @@ impl super::Nexus {
             project_lookup.lookup_for(authz::Action::CreateChild).await?;
         self.db_datastore.probe_delete(opctx, &authz_project, &name_or_id).await
     }
+
+    /// Activate the VPC route manager background task by request of a sled
+    /// agent's probe manager.
+    pub(crate) fn refresh_vpc_routes(&self) {
+        self.background_tasks.task_vpc_route_manager.activate();
+    }
 }

--- a/nexus/src/internal_api/http_entrypoints.rs
+++ b/nexus/src/internal_api/http_entrypoints.rs
@@ -452,25 +452,6 @@ impl NexusInternalApi for NexusInternalApiImpl {
             .await
     }
 
-    async fn bgtask_activate(
-        rqctx: RequestContext<Self::Context>,
-        body: TypedBody<BackgroundTasksActivateRequest>,
-    ) -> Result<HttpResponseUpdatedNoContent, HttpError> {
-        let apictx = &rqctx.context().context;
-        let handler = async {
-            let opctx =
-                crate::context::op_context_for_internal_api(&rqctx).await;
-            let nexus = &apictx.nexus;
-            let body = body.into_inner();
-            nexus.bgtask_activate(&opctx, body.bgtask_names).await?;
-            Ok(HttpResponseUpdatedNoContent())
-        };
-        apictx
-            .internal_latencies
-            .instrument_dropshot_handler(&rqctx, handler)
-            .await
-    }
-
     // NAT RPW internal APIs
 
     async fn ipv4_nat_changeset(
@@ -516,6 +497,20 @@ impl NexusInternalApi for NexusInternalApiImpl {
                     .probe_list_for_sled(&opctx, &pagparams, path.sled)
                     .await?,
             ))
+        };
+        apictx
+            .internal_latencies
+            .instrument_dropshot_handler(&rqctx, handler)
+            .await
+    }
+
+    async fn refresh_vpc_routes(
+        rqctx: RequestContext<Self::Context>,
+    ) -> Result<HttpResponseUpdatedNoContent, HttpError> {
+        let apictx = &rqctx.context().context;
+        let handler = async {
+            apictx.nexus.refresh_vpc_routes();
+            Ok(HttpResponseUpdatedNoContent())
         };
         apictx
             .internal_latencies

--- a/openapi/nexus-internal.json
+++ b/openapi/nexus-internal.json
@@ -10,34 +10,6 @@
     "version": "0.0.1"
   },
   "paths": {
-    "/bgtasks/activate": {
-      "post": {
-        "summary": "**Do not use in new code!**",
-        "description": "Callers to this API should either be capable of using the nexus-lockstep API or should be rewritten to use a doorbell API to activate a specific task. Task names are internal to Nexus.",
-        "operationId": "bgtask_activate",
-        "requestBody": {
-          "content": {
-            "application/json": {
-              "schema": {
-                "$ref": "#/components/schemas/BackgroundTasksActivateRequest"
-              }
-            }
-          },
-          "required": true
-        },
-        "responses": {
-          "204": {
-            "description": "resource updated"
-          },
-          "4XX": {
-            "$ref": "#/components/responses/Error"
-          },
-          "5XX": {
-            "$ref": "#/components/responses/Error"
-          }
-        }
-      }
-    },
     "/crucible/0/upstairs/{upstairs_id}/downstairs/{downstairs_id}/stop-request": {
       "post": {
         "summary": "An Upstairs will update this endpoint if a Downstairs client task is",
@@ -497,6 +469,7 @@
     "/probes/{sled}": {
       "get": {
         "summary": "Get all the probes associated with a given sled.",
+        "description": "This should not be used in new code, and abandoned if a change is required. See #9157.",
         "operationId": "probes_get",
         "parameters": [
           {
@@ -589,6 +562,24 @@
           },
           "required": true
         },
+        "responses": {
+          "204": {
+            "description": "resource updated"
+          },
+          "4XX": {
+            "$ref": "#/components/responses/Error"
+          },
+          "5XX": {
+            "$ref": "#/components/responses/Error"
+          }
+        }
+      }
+    },
+    "/refresh-vpc-routes": {
+      "post": {
+        "summary": "Request that Nexus refreshes VPC routes.",
+        "description": "This should not be used in new code, and abandoned if a change is required. See #9157.",
+        "operationId": "refresh_vpc_routes",
         "responses": {
           "204": {
             "description": "resource updated"
@@ -882,22 +873,6 @@
         "description": "An artifact version.\n\nThis is a freeform identifier with some basic validation. It may be the serialized form of a semver version, or a custom identifier that uses the same character set as a semver, plus `_`.\n\nThe exact pattern accepted is `^[a-zA-Z0-9._+-]{1,63}$`.\n\n# Ord implementation\n\n`ArtifactVersion`s are not intended to be sorted, just compared for equality. `ArtifactVersion` implements `Ord` only for storage within sorted collections.",
         "type": "string",
         "pattern": "^[a-zA-Z0-9._+-]{1,63}$"
-      },
-      "BackgroundTasksActivateRequest": {
-        "description": "Query parameters for Background Task activation requests.",
-        "type": "object",
-        "properties": {
-          "bgtask_names": {
-            "type": "array",
-            "items": {
-              "type": "string"
-            },
-            "uniqueItems": true
-          }
-        },
-        "required": [
-          "bgtask_names"
-        ]
       },
       "Baseboard": {
         "description": "Properties that uniquely identify an Oxide hardware component",

--- a/sled-agent/src/probe_manager.rs
+++ b/sled-agent/src/probe_manager.rs
@@ -6,9 +6,7 @@ use illumos_utils::link::VnicAllocator;
 use illumos_utils::opte::{DhcpCfg, PortCreateParams, PortManager};
 use illumos_utils::running_zone::{RunningZone, ZoneBuilderFactory};
 use illumos_utils::zpool::ZpoolOrRamdisk;
-use nexus_client::types::{
-    BackgroundTasksActivateRequest, ProbeExternalIp, ProbeInfo,
-};
+use nexus_client::types::{ProbeExternalIp, ProbeInfo};
 use omicron_common::api::external::{
     VpcFirewallRuleAction, VpcFirewallRuleDirection, VpcFirewallRulePriority,
     VpcFirewallRuleStatus,
@@ -247,12 +245,7 @@ impl ProbeManagerInner {
                 // If we have created some new probes, we may need the control plane
                 // to provide us with valid routes for the VPC the probe belongs to.
                 if n_added > 0 {
-                    if let Err(e) = self
-                        .nexus_client
-                        .bgtask_activate(&BackgroundTasksActivateRequest {
-                            bgtask_names: vec!["vpc_route_manager".into()],
-                        })
-                        .await
+                    if let Err(e) = self.nexus_client.refresh_vpc_routes().await
                     {
                         error!(self.log, "get routes for probe: {e}");
                     }


### PR DESCRIPTION
This was intended to be moved to nexus-lockstep in #9037 but the probe manager uses it. This replaces the API call with a more specific doorbell to prevent arbitrary background task names from being part of nexus-internal's API.

Related to #9157 and #8902.