### PR TITLE
[SCIM 2/4]: Add SCIM user, group, and IDP

### DIFF
--- a/nexus/db-model/src/schema_versions.rs
+++ b/nexus/db-model/src/schema_versions.rs
@@ -16,7 +16,7 @@ use std::{collections::BTreeMap, sync::LazyLock};
 ///
 /// This must be updated when you change the database schema.  Refer to
 /// schema/crdb/README.adoc in the root of this repository for details.
-pub const SCHEMA_VERSION: Version = Version::new(196, 0, 0);
+pub const SCHEMA_VERSION: Version = Version::new(197, 0, 0);
 
 /// List of all past database schema versions, in *reverse* order
 ///
@@ -28,6 +28,7 @@ static KNOWN_VERSIONS: LazyLock<Vec<KnownVersion>> = LazyLock::new(|| {
         // |  leaving the first copy as an example for the next person.
         // v
         // KnownVersion::new(next_int, "unique-dirname-with-the-sql-files"),
+        KnownVersion::new(197, "scim-users-and-groups"),
         KnownVersion::new(196, "user-provision-type-for-silo-user-and-group"),
         KnownVersion::new(195, "tuf-pruned-index"),
         KnownVersion::new(194, "tuf-pruned"),

--- a/nexus/db-model/src/silo.rs
+++ b/nexus/db-model/src/silo.rs
@@ -56,6 +56,7 @@ impl_enum_type!(
     // Enum values
     ApiOnly => b"api_only"
     Jit => b"jit"
+    Scim => b"scim"
 );
 
 impl From<shared::UserProvisionType> for UserProvisionType {
@@ -63,6 +64,7 @@ impl From<shared::UserProvisionType> for UserProvisionType {
         match params {
             shared::UserProvisionType::ApiOnly => UserProvisionType::ApiOnly,
             shared::UserProvisionType::Jit => UserProvisionType::Jit,
+            shared::UserProvisionType::Scim => UserProvisionType::Scim,
         }
     }
 }
@@ -72,6 +74,7 @@ impl From<UserProvisionType> for shared::UserProvisionType {
         match model {
             UserProvisionType::ApiOnly => Self::ApiOnly,
             UserProvisionType::Jit => Self::Jit,
+            UserProvisionType::Scim => Self::Scim,
         }
     }
 }
@@ -221,11 +224,16 @@ impl TryFrom<Silo> for views::Silo {
             (AuthenticationMode::Saml, UserProvisionType::Jit) => {
                 Some(SiloIdentityMode::SamlJit)
             }
-            (AuthenticationMode::Saml, UserProvisionType::ApiOnly) => None,
+
             (AuthenticationMode::Local, UserProvisionType::ApiOnly) => {
                 Some(SiloIdentityMode::LocalOnly)
             }
-            (AuthenticationMode::Local, UserProvisionType::Jit) => None,
+
+            (AuthenticationMode::Saml, UserProvisionType::Scim) => {
+                Some(SiloIdentityMode::SamlScim)
+            }
+
+            _ => None,
         }
         .ok_or_else(|| {
             Error::internal_error(&format!(

--- a/nexus/db-model/src/silo_group.rs
+++ b/nexus/db-model/src/silo_group.rs
@@ -34,6 +34,9 @@ pub struct SiloGroup {
     pub external_id: Option<String>,
 
     pub user_provision_type: UserProvisionType,
+
+    /// For SCIM groups, display name must be Some.
+    pub display_name: Option<String>,
 }
 
 impl SiloGroup {
@@ -48,6 +51,7 @@ impl SiloGroup {
             silo_id,
             user_provision_type: UserProvisionType::ApiOnly,
             external_id: Some(external_id),
+            display_name: None,
         }
     }
 
@@ -62,6 +66,23 @@ impl SiloGroup {
             silo_id,
             user_provision_type: UserProvisionType::Jit,
             external_id: Some(external_id),
+            display_name: None,
+        }
+    }
+
+    pub fn new_scim_group(
+        id: SiloGroupUuid,
+        silo_id: Uuid,
+        display_name: String,
+        external_id: Option<String>,
+    ) -> Self {
+        Self {
+            identity: SiloGroupIdentity::new(id),
+            time_deleted: None,
+            silo_id,
+            user_provision_type: UserProvisionType::Scim,
+            external_id,
+            display_name: Some(display_name),
         }
     }
 }

--- a/nexus/db-model/src/silo_user.rs
+++ b/nexus/db-model/src/silo_user.rs
@@ -29,6 +29,13 @@ pub struct SiloUser {
     pub external_id: Option<String>,
 
     pub user_provision_type: UserProvisionType,
+
+    /// For SCIM users, user name must be Some.
+    pub user_name: Option<String>,
+
+    /// For SCIM users, active describes whether or not the user is allowed to
+    /// have active sessions.
+    pub active: Option<bool>,
 }
 
 impl SiloUser {
@@ -43,6 +50,8 @@ impl SiloUser {
             silo_id,
             external_id: Some(external_id),
             user_provision_type: UserProvisionType::ApiOnly,
+            user_name: None,
+            active: None,
         }
     }
 
@@ -57,6 +66,26 @@ impl SiloUser {
             silo_id,
             external_id: Some(external_id),
             user_provision_type: UserProvisionType::Jit,
+            user_name: None,
+            active: None,
+        }
+    }
+
+    pub fn new_scim_user(
+        silo_id: Uuid,
+        user_id: SiloUserUuid,
+        user_name: String,
+        external_id: Option<String>,
+        active: Option<bool>,
+    ) -> Self {
+        Self {
+            identity: SiloUserIdentity::new(user_id),
+            time_deleted: None,
+            silo_id,
+            external_id,
+            user_provision_type: UserProvisionType::Scim,
+            user_name: Some(user_name),
+            active,
         }
     }
 }

--- a/nexus/db-queries/src/db/datastore/mod.rs
+++ b/nexus/db-queries/src/db/datastore/mod.rs
@@ -151,6 +151,7 @@ pub use silo_user::SiloUser;
 pub use silo_user::SiloUserApiOnly;
 pub use silo_user::SiloUserJit;
 pub use silo_user::SiloUserLookup;
+pub use silo_user::SiloUserScim;
 pub use sled::SledTransition;
 pub use sled::TransitionError;
 pub use support_bundle::SupportBundleExpungementReport;

--- a/nexus/db-queries/src/db/datastore/silo_user.rs
+++ b/nexus/db-queries/src/db/datastore/silo_user.rs
@@ -54,6 +54,9 @@ pub enum SiloUser {
 
     /// A User created during an authenticated SAML login
     Jit(SiloUserJit),
+
+    /// A User created by a SCIM provisioning client
+    Scim(SiloUserScim),
 }
 
 impl SiloUser {
@@ -61,6 +64,7 @@ impl SiloUser {
         match &self {
             SiloUser::ApiOnly(u) => u.id,
             SiloUser::Jit(u) => u.id,
+            SiloUser::Scim(u) => u.id,
         }
     }
 
@@ -68,13 +72,16 @@ impl SiloUser {
         match &self {
             SiloUser::ApiOnly(u) => u.silo_id,
             SiloUser::Jit(u) => u.silo_id,
+            SiloUser::Scim(u) => u.silo_id,
         }
     }
 
-    pub fn external_id(&self) -> &str {
+    /// Return what field is guaranteed to be unique for this type
+    pub fn conflict_field(&self) -> &str {
         match &self {
             SiloUser::ApiOnly(u) => &u.external_id,
             SiloUser::Jit(u) => &u.external_id,
+            SiloUser::Scim(u) => &u.user_name,
         }
     }
 }
@@ -93,7 +100,7 @@ impl From<model::SiloUser> for SiloUser {
                 // null external id.
                 external_id: record
                     .external_id
-                    .expect("constraint lookup_silo_user_by_silo exists"),
+                    .expect("constraint external_id_consistency exists"),
             }),
 
             UserProvisionType::Jit => SiloUser::Jit(SiloUserJit {
@@ -107,7 +114,23 @@ impl From<model::SiloUser> for SiloUser {
                 // external id.
                 external_id: record
                     .external_id
-                    .expect("constraint lookup_silo_user_by_silo exists"),
+                    .expect("constraint external_id_consistency exists"),
+            }),
+
+            UserProvisionType::Scim => SiloUser::Scim(SiloUserScim {
+                id: record.id(),
+                time_created: record.time_created(),
+                time_modified: record.time_modified(),
+                time_deleted: record.time_deleted,
+                silo_id: record.silo_id,
+                // About the expect here: the mentioned database constraint
+                // prevents a user with provision type 'scim' from having a
+                // null user name
+                user_name: record
+                    .user_name
+                    .expect("constraint user_name_consistency exists"),
+                active: record.active,
+                external_id: record.external_id,
             }),
         }
     }
@@ -118,6 +141,7 @@ impl From<SiloUser> for model::SiloUser {
         match u {
             SiloUser::ApiOnly(u) => u.into(),
             SiloUser::Jit(u) => u.into(),
+            SiloUser::Scim(u) => u.into(),
         }
     }
 }
@@ -127,6 +151,7 @@ impl From<SiloUser> for views::User {
         match u {
             SiloUser::ApiOnly(u) => u.into(),
             SiloUser::Jit(u) => u.into(),
+            SiloUser::Scim(u) => u.into(),
         }
     }
 }
@@ -168,6 +193,8 @@ impl From<SiloUserApiOnly> for model::SiloUser {
             silo_id: u.silo_id,
             external_id: Some(u.external_id),
             user_provision_type: UserProvisionType::ApiOnly,
+            user_name: None,
+            active: None,
         }
     }
 }
@@ -226,6 +253,8 @@ impl From<SiloUserJit> for model::SiloUser {
             silo_id: u.silo_id,
             external_id: Some(u.external_id),
             user_provision_type: UserProvisionType::Jit,
+            user_name: None,
+            active: None,
         }
     }
 }
@@ -247,6 +276,77 @@ impl From<SiloUserJit> for views::User {
     }
 }
 
+#[derive(Debug, Clone)]
+pub struct SiloUserScim {
+    pub id: SiloUserUuid,
+    pub time_created: DateTime<Utc>,
+    pub time_modified: DateTime<Utc>,
+    pub time_deleted: Option<DateTime<Utc>>,
+    pub silo_id: Uuid,
+
+    /// The identity provider's ID for this user.
+    pub user_name: String,
+
+    pub active: Option<bool>,
+    pub external_id: Option<String>,
+}
+
+impl SiloUserScim {
+    pub fn new(
+        silo_id: Uuid,
+        id: SiloUserUuid,
+        user_name: String,
+        active: Option<bool>,
+        external_id: Option<String>,
+    ) -> Self {
+        Self {
+            id,
+            time_created: Utc::now(),
+            time_modified: Utc::now(),
+            time_deleted: None,
+            silo_id,
+            user_name,
+            active,
+            external_id,
+        }
+    }
+}
+
+impl From<SiloUserScim> for model::SiloUser {
+    fn from(u: SiloUserScim) -> model::SiloUser {
+        model::SiloUser {
+            identity: model::SiloUserIdentity {
+                id: u.id.into(),
+                time_created: u.time_created,
+                time_modified: u.time_modified,
+            },
+            time_deleted: u.time_deleted,
+            silo_id: u.silo_id,
+            external_id: u.external_id,
+            user_provision_type: UserProvisionType::Scim,
+            user_name: Some(u.user_name),
+            active: u.active,
+        }
+    }
+}
+
+impl From<SiloUserScim> for SiloUser {
+    fn from(u: SiloUserScim) -> SiloUser {
+        SiloUser::Scim(u)
+    }
+}
+
+impl From<SiloUserScim> for views::User {
+    fn from(u: SiloUserScim) -> views::User {
+        views::User {
+            id: u.id,
+            // TODO the use of user_name as display_name is temporary
+            display_name: u.user_name,
+            silo_id: u.silo_id,
+        }
+    }
+}
+
 /// Different types of user have different fields that are considered unique,
 /// and therefore lookup needs to be typed as well.
 #[derive(Debug)]
@@ -254,6 +354,8 @@ pub enum SiloUserLookup<'a> {
     ApiOnly { external_id: &'a str },
 
     Jit { external_id: &'a str },
+
+    Scim { user_name: &'a str },
 }
 
 impl<'a> SiloUserLookup<'a> {
@@ -261,6 +363,7 @@ impl<'a> SiloUserLookup<'a> {
         match &self {
             SiloUserLookup::ApiOnly { .. } => UserProvisionType::ApiOnly,
             SiloUserLookup::Jit { .. } => UserProvisionType::Jit,
+            SiloUserLookup::Scim { .. } => UserProvisionType::Scim,
         }
     }
 }
@@ -276,7 +379,7 @@ impl DataStore {
     ) -> CreateResult<(authz::SiloUser, SiloUser)> {
         // TODO-security This needs an authz check.
 
-        let silo_user_external_id = silo_user.external_id().to_string();
+        let silo_user_conflict_field = silo_user.conflict_field().to_string();
         let model: model::SiloUser = silo_user.into();
 
         let conn = self.pool_connection_unauthorized().await?;
@@ -327,7 +430,7 @@ impl DataStore {
                     e,
                     ErrorHandler::Conflict(
                         ResourceType::SiloUser,
-                        &silo_user_external_id,
+                        &silo_user_conflict_field,
                     ),
                 )
             })
@@ -515,6 +618,35 @@ impl DataStore {
                     authz_silo.clone(),
                     db_silo_user.id(),
                     LookupType::ByName(external_id.to_string()),
+                );
+
+                Ok(Some((authz_silo_user, db_silo_user.into())))
+            }
+
+            SiloUserLookup::Scim { user_name } => {
+                let maybe_db_silo_user = dsl::silo_user
+                    .filter(dsl::silo_id.eq(authz_silo.id()))
+                    .filter(
+                        dsl::user_provision_type.eq(lookup_user_provision_type),
+                    )
+                    .filter(dsl::user_name.eq(user_name.to_string()))
+                    .filter(dsl::time_deleted.is_null())
+                    .select(model::SiloUser::as_select())
+                    .get_result_async::<model::SiloUser>(&*conn)
+                    .await
+                    .optional()
+                    .map_err(|e| {
+                        public_error_from_diesel(e, ErrorHandler::Server)
+                    })?;
+
+                let Some(db_silo_user) = maybe_db_silo_user else {
+                    return Ok(None);
+                };
+
+                let authz_silo_user = authz::SiloUser::new(
+                    authz_silo.clone(),
+                    db_silo_user.id(),
+                    LookupType::ByName(user_name.to_string()),
                 );
 
                 Ok(Some((authz_silo_user, db_silo_user.into())))

--- a/nexus/db-schema/src/schema.rs
+++ b/nexus/db-schema/src/schema.rs
@@ -768,6 +768,8 @@ table! {
         silo_id -> Uuid,
         external_id -> Nullable<Text>,
         user_provision_type -> crate::enums::UserProvisionTypeEnum,
+        user_name -> Nullable<Text>,
+        active -> Nullable<Bool>,
     }
 }
 
@@ -789,6 +791,8 @@ table! {
         silo_id -> Uuid,
         external_id -> Nullable<Text>,
         user_provision_type -> crate::enums::UserProvisionTypeEnum,
+        display_name -> Nullable<Text>,
+        active -> Nullable<Bool>,
     }
 }
 

--- a/nexus/tests/integration_tests/mod.rs
+++ b/nexus/tests/integration_tests/mod.rs
@@ -42,6 +42,7 @@ mod role_assignments;
 mod router_routes;
 mod saml;
 mod schema;
+mod scim;
 mod silo_users;
 mod silos;
 mod sleds;

--- a/nexus/tests/integration_tests/scim.rs
+++ b/nexus/tests/integration_tests/scim.rs
@@ -1,0 +1,209 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at https://mozilla.org/MPL/2.0/.
+
+use nexus_db_queries::authn::silos::{IdentityProviderType, SamlLoginPost};
+use nexus_test_utils::http_testing::{AuthnMode, NexusRequest, RequestBuilder};
+use nexus_test_utils::resource_helpers::{create_silo, object_create};
+use nexus_test_utils_macros::nexus_test;
+use nexus_types::external_api::views::{self, Silo};
+use nexus_types::external_api::{params, shared};
+use omicron_common::api::external::IdentityMetadataCreateParams;
+use omicron_nexus::TestInterfaces;
+
+use base64::Engine;
+use http::StatusCode;
+use http::method::Method;
+
+use crate::integration_tests::saml::SAML_IDP_DESCRIPTOR;
+use crate::integration_tests::saml::SAML_RESPONSE_IDP_DESCRIPTOR;
+use crate::integration_tests::saml::SAML_RESPONSE_WITH_GROUPS;
+
+type ControlPlaneTestContext =
+    nexus_test_utils::ControlPlaneTestContext<omicron_nexus::Server>;
+
+// Create a SAML+SCIM Silo, test we can create a SAML IDP for it
+#[nexus_test]
+async fn test_create_a_saml_scim_silo(cptestctx: &ControlPlaneTestContext) {
+    let client = &cptestctx.external_client;
+
+    const SILO_NAME: &str = "saml-scim-silo";
+    create_silo(&client, SILO_NAME, true, shared::SiloIdentityMode::SamlScim)
+        .await;
+    let silo: Silo = NexusRequest::object_get(
+        &client,
+        &format!("/v1/system/silos/{}", SILO_NAME),
+    )
+    .authn_as(AuthnMode::PrivilegedUser)
+    .execute()
+    .await
+    .expect("failed to make request")
+    .parsed_body()
+    .unwrap();
+
+    // Assert we can create a SAML IDP for this identity type
+
+    let silo_saml_idp: views::SamlIdentityProvider = object_create(
+        client,
+        &format!("/v1/system/identity-providers/saml?silo={}", SILO_NAME),
+        &params::SamlIdentityProviderCreate {
+            identity: IdentityMetadataCreateParams {
+                name: "some-totally-real-saml-provider"
+                    .to_string()
+                    .parse()
+                    .unwrap(),
+                description: "a demo provider".to_string(),
+            },
+
+            idp_metadata_source: params::IdpMetadataSource::Base64EncodedXml {
+                data: base64::engine::general_purpose::STANDARD
+                    .encode(SAML_IDP_DESCRIPTOR),
+            },
+
+            idp_entity_id: "entity_id".to_string(),
+            sp_client_id: "client_id".to_string(),
+            acs_url: "http://acs".to_string(),
+            slo_url: "http://slo".to_string(),
+            technical_contact_email: "technical@fake".to_string(),
+
+            signing_keypair: None,
+
+            group_attribute_name: None,
+        },
+    )
+    .await;
+
+    // Assert external authenticator opctx can read it
+    let nexus = &cptestctx.server.server_context().nexus;
+    let (.., _retrieved_silo_nexus) = nexus
+        .silo_lookup(
+            &nexus.opctx_external_authn(),
+            omicron_common::api::external::Name::try_from(
+                SILO_NAME.to_string(),
+            )
+            .unwrap()
+            .into(),
+        )
+        .unwrap()
+        .fetch()
+        .await
+        .unwrap();
+
+    let (.., retrieved_silo_idp_from_nexus) = nexus
+        .datastore()
+        .identity_provider_lookup(
+            &nexus.opctx_external_authn(),
+            &omicron_common::api::external::Name::try_from(
+                SILO_NAME.to_string(),
+            )
+            .unwrap()
+            .into(),
+            &omicron_common::api::external::Name::try_from(
+                "some-totally-real-saml-provider".to_string(),
+            )
+            .unwrap()
+            .into(),
+        )
+        .await
+        .unwrap();
+
+    match retrieved_silo_idp_from_nexus {
+        IdentityProviderType::Saml(_) => {
+            // ok
+        }
+    }
+
+    // Expect the SSO redirect when trying to log in unauthenticated
+    let result = NexusRequest::new(
+        RequestBuilder::new(
+            client,
+            Method::GET,
+            &format!(
+                "/login/{}/saml/{}/redirect",
+                silo.identity.name, silo_saml_idp.identity.name
+            ),
+        )
+        .expect_status(Some(StatusCode::FOUND)),
+    )
+    .execute()
+    .await
+    .expect("expected success");
+
+    assert!(
+        result.headers["Location"].to_str().unwrap().to_string().starts_with(
+            "https://idp.example.org/SAML2/SSO/Redirect?SAMLRequest=",
+        )
+    );
+}
+
+// Test that users are not JITed for SamlScim silos
+#[nexus_test]
+async fn test_no_jit_for_saml_scim_silos(cptestctx: &ControlPlaneTestContext) {
+    let client = &cptestctx.external_client;
+
+    const SILO_NAME: &str = "saml-scim-silo";
+    create_silo(&client, SILO_NAME, true, shared::SiloIdentityMode::SamlScim)
+        .await;
+
+    let _silo_saml_idp: views::SamlIdentityProvider = object_create(
+        client,
+        &format!("/v1/system/identity-providers/saml?silo={}", SILO_NAME),
+        &params::SamlIdentityProviderCreate {
+            identity: IdentityMetadataCreateParams {
+                name: "some-totally-real-saml-provider"
+                    .to_string()
+                    .parse()
+                    .unwrap(),
+                description: "a demo provider".to_string(),
+            },
+
+            idp_metadata_source: params::IdpMetadataSource::Base64EncodedXml {
+                data: base64::engine::general_purpose::STANDARD
+                    .encode(SAML_RESPONSE_IDP_DESCRIPTOR),
+            },
+
+            idp_entity_id: "https://some.idp.test/oxide_rack/".to_string(),
+            sp_client_id: "client_id".to_string(),
+            acs_url: "https://customer.site/oxide_rack/saml".to_string(),
+            slo_url: "https://customer.site/oxide_rack/saml".to_string(),
+            technical_contact_email: "technical@fake".to_string(),
+
+            signing_keypair: None,
+
+            group_attribute_name: Some("groups".into()),
+        },
+    )
+    .await;
+
+    let nexus = &cptestctx.server.server_context().nexus;
+    nexus.set_samael_max_issue_delay(
+        chrono::Utc::now()
+            - "2022-05-04T15:36:12.631Z"
+                .parse::<chrono::DateTime<chrono::Utc>>()
+                .unwrap()
+            + chrono::Duration::seconds(60),
+    );
+
+    NexusRequest::new(
+        RequestBuilder::new(
+            client,
+            Method::POST,
+            &format!(
+                "/login/{}/saml/some-totally-real-saml-provider",
+                SILO_NAME
+            ),
+        )
+        .raw_body(Some(
+            serde_urlencoded::to_string(SamlLoginPost {
+                saml_response: base64::engine::general_purpose::STANDARD
+                    .encode(SAML_RESPONSE_WITH_GROUPS),
+                relay_state: None,
+            })
+            .unwrap(),
+        ))
+        .expect_status(Some(StatusCode::UNAUTHORIZED)),
+    )
+    .execute()
+    .await
+    .expect("expected 401");
+}

--- a/nexus/tests/integration_tests/silos.rs
+++ b/nexus/tests/integration_tests/silos.rs
@@ -13,6 +13,7 @@ use nexus_db_queries::db;
 use nexus_db_queries::db::datastore::SiloGroupLookup;
 use nexus_db_queries::db::datastore::SiloUserJit;
 use nexus_db_queries::db::datastore::SiloUserLookup;
+use nexus_db_queries::db::datastore::SiloUserScim;
 use nexus_db_queries::db::fixed_data::silo::DEFAULT_SILO;
 use nexus_db_queries::db::identity::Asset;
 use nexus_test_utils::http_testing::{AuthnMode, NexusRequest, RequestBuilder};
@@ -784,6 +785,20 @@ async fn test_silo_user_provision_types(cptestctx: &ControlPlaneTestContext) {
             existing_silo_user: false,
             expect_user: true,
         },
+        // A silo configured with a "SCIM" user provision type should fetch a
+        // user if it exists already.
+        TestSiloUserProvisionTypes {
+            identity_mode: shared::SiloIdentityMode::SamlScim,
+            existing_silo_user: true,
+            expect_user: true,
+        },
+        // A silo configured with a "SCIM" user provision type should not do any
+        // user management except via the SCIM provisioning client.
+        TestSiloUserProvisionTypes {
+            identity_mode: shared::SiloIdentityMode::SamlScim,
+            existing_silo_user: false,
+            expect_user: false,
+        },
     ];
 
     for test_case in test_cases {
@@ -796,6 +811,7 @@ async fn test_silo_user_provision_types(cptestctx: &ControlPlaneTestContext) {
                 shared::SiloIdentityMode::SamlJit => {
                     create_jit_user(datastore, &silo, "external-id-com").await;
                 }
+
                 shared::SiloIdentityMode::LocalOnly => {
                     create_local_user(
                         client,
@@ -804,6 +820,10 @@ async fn test_silo_user_provision_types(cptestctx: &ControlPlaneTestContext) {
                         test_params::UserPassword::LoginDisallowed,
                     )
                     .await;
+                }
+
+                shared::SiloIdentityMode::SamlScim => {
+                    create_scim_user(datastore, &silo, "external-id-com").await;
                 }
             };
         }
@@ -1795,6 +1815,32 @@ async fn create_jit_user(
         .into()
 }
 
+/// Create a user in a SamlScim Silo for testing
+async fn create_scim_user(
+    datastore: &db::DataStore,
+    silo: &views::Silo,
+    user_name: &str,
+) -> views::User {
+    assert_eq!(silo.identity_mode, shared::SiloIdentityMode::SamlScim);
+    let silo_id = silo.identity.id;
+    let silo_user_id = SiloUserUuid::new_v4();
+    let authz_silo =
+        authz::Silo::new(authz::FLEET, silo_id, LookupType::ById(silo_id));
+    let silo_user = SiloUserScim::new(
+        silo_id,
+        silo_user_id,
+        user_name.to_owned(),
+        None,
+        None,
+    );
+    datastore
+        .silo_user_create(&authz_silo, silo_user.into())
+        .await
+        .expect("failed to create user in SamlScim Silo")
+        .1
+        .into()
+}
+
 /// Tests that LocalOnly-specific endpoints are not available in SamlJit Silos
 #[nexus_test]
 async fn test_jit_silo_constraints(cptestctx: &ControlPlaneTestContext) {
@@ -1998,7 +2044,7 @@ async fn test_local_silo_constraints(cptestctx: &ControlPlaneTestContext) {
 
     assert_eq!(
         error.message,
-        "cannot create identity providers in this kind of Silo"
+        "cannot create saml identity providers in api-only silos"
     );
 
     // The SAML login endpoints should not work, either.

--- a/nexus/types/src/external_api/shared.rs
+++ b/nexus/types/src/external_api/shared.rs
@@ -208,6 +208,11 @@ pub enum SiloIdentityMode {
     // NOTE: authentication for these users is not supported yet at all.  It
     // will eventually be password-based.
     LocalOnly,
+
+    /// Users are authenticated with SAML using an external authentication
+    /// provider. Users and groups are managed with SCIM API calls, likely from
+    /// the same authentication provider.
+    SamlScim,
 }
 
 impl SiloIdentityMode {
@@ -215,6 +220,7 @@ impl SiloIdentityMode {
         match self {
             SiloIdentityMode::LocalOnly => AuthenticationMode::Local,
             SiloIdentityMode::SamlJit => AuthenticationMode::Saml,
+            SiloIdentityMode::SamlScim => AuthenticationMode::Saml,
         }
     }
 
@@ -222,6 +228,7 @@ impl SiloIdentityMode {
         match self {
             SiloIdentityMode::LocalOnly => UserProvisionType::ApiOnly,
             SiloIdentityMode::SamlJit => UserProvisionType::Jit,
+            SiloIdentityMode::SamlScim => UserProvisionType::Scim,
         }
     }
 }
@@ -249,6 +256,9 @@ pub enum UserProvisionType {
     /// Users and groups are created or updated during authentication using
     /// information provided by the authentication provider
     Jit,
+
+    /// Users and groups are managed by SCIM
+    Scim,
 }
 
 /// The service intended to use this certificate.

--- a/openapi/nexus.json
+++ b/openapi/nexus.json
@@ -23865,6 +23865,13 @@
             "enum": [
               "local_only"
             ]
+          },
+          {
+            "description": "Users are authenticated with SAML using an external authentication provider. Users and groups are managed with SCIM API calls, likely from the same authentication provider.",
+            "type": "string",
+            "enum": [
+              "saml_scim"
+            ]
           }
         ]
       },

--- a/schema/crdb/dbinit.sql
+++ b/schema/crdb/dbinit.sql
@@ -856,7 +856,8 @@ CREATE TYPE IF NOT EXISTS omicron.public.authentication_mode AS ENUM (
 
 CREATE TYPE IF NOT EXISTS omicron.public.user_provision_type AS ENUM (
   'api_only',
-  'jit'
+  'jit',
+  'scim'
 );
 
 CREATE TABLE IF NOT EXISTS omicron.public.silo (
@@ -902,6 +903,11 @@ CREATE TABLE IF NOT EXISTS omicron.public.silo_user (
 
     user_provision_type omicron.public.user_provision_type,
 
+    -- if the user provision type is 'scim' then this field must contain a value
+    user_name TEXT,
+
+    active BOOL,
+
     CONSTRAINT user_provision_type_required_for_non_deleted CHECK (
       (user_provision_type IS NOT NULL AND time_deleted IS NULL)
       OR (time_deleted IS NOT NULL)
@@ -912,19 +918,31 @@ CREATE TABLE IF NOT EXISTS omicron.public.silo_user (
           WHEN 'api_only' THEN external_id IS NOT NULL
           WHEN 'jit' THEN external_id IS NOT NULL
         END
+    ),
+
+    CONSTRAINT user_name_consistency CHECK (
+        CASE user_provision_type
+          WHEN 'scim' THEN user_name IS NOT NULL
+        END
     )
 );
 
-/* This index lets us quickly find users for a given silo, and prevents
-   multiple users from having the same external id (for certain provision
-   types). */
+/* These indexes let us quickly find users for a given silo, and prevents
+   multiple users from having the same provision specific unique identifier. */
 CREATE UNIQUE INDEX IF NOT EXISTS
- lookup_silo_user_by_silo
+  lookup_silo_user_by_silo_and_external_id
 ON
- omicron.public.silo_user (silo_id, external_id)
+  omicron.public.silo_user (silo_id, external_id)
 WHERE
- time_deleted IS NULL AND
- (user_provision_type = 'api_only' OR user_provision_type = 'jit');
+  time_deleted IS NULL AND
+  (user_provision_type = 'api_only' OR user_provision_type = 'jit');
+
+CREATE UNIQUE INDEX IF NOT EXISTS
+  lookup_silo_user_by_silo_and_user_name
+ON
+  omicron.public.silo_user (silo_id, user_name)
+WHERE
+  time_deleted IS NULL AND user_provision_type = 'scim';
 
 CREATE TABLE IF NOT EXISTS omicron.public.silo_user_password_hash (
     silo_user_id UUID NOT NULL,
@@ -952,6 +970,9 @@ CREATE TABLE IF NOT EXISTS omicron.public.silo_group (
 
     user_provision_type omicron.public.user_provision_type,
 
+    -- if the user provision type is 'scim' then this field must contain a value
+    display_name TEXT,
+
     CONSTRAINT user_provision_type_required_for_non_deleted CHECK (
       (user_provision_type IS NOT NULL AND time_deleted IS NULL)
       OR (time_deleted IS NOT NULL)
@@ -962,16 +983,29 @@ CREATE TABLE IF NOT EXISTS omicron.public.silo_group (
           WHEN 'api_only' THEN external_id IS NOT NULL
           WHEN 'jit' THEN external_id IS NOT NULL
         END
+    ),
+
+    CONSTRAINT display_name_consistency CHECK (
+        CASE user_provision_type
+          WHEN 'scim' THEN display_name IS NOT NULL
+        END
     )
 );
 
 CREATE UNIQUE INDEX IF NOT EXISTS
- lookup_silo_group_by_silo
+  lookup_silo_group_by_silo_and_external_id
 ON
- omicron.public.silo_group (silo_id, external_id)
+  omicron.public.silo_group (silo_id, external_id)
 WHERE
- time_deleted IS NULL and
- (user_provision_type = 'api_only' OR user_provision_type = 'jit');
+  time_deleted IS NULL and
+  (user_provision_type = 'api_only' OR user_provision_type = 'jit');
+
+CREATE UNIQUE INDEX IF NOT EXISTS
+  lookup_silo_group_by_silo_and_display_name
+ON
+  omicron.public.silo_group (silo_id, display_name)
+WHERE
+  time_deleted IS NULL AND user_provision_type = 'scim';
 
 /*
  * Silo group membership
@@ -6735,7 +6769,7 @@ INSERT INTO omicron.public.db_metadata (
     version,
     target_version
 ) VALUES
-    (TRUE, NOW(), NOW(), '196.0.0', NULL)
+    (TRUE, NOW(), NOW(), '197.0.0', NULL)
 ON CONFLICT DO NOTHING;
 
 COMMIT;

--- a/schema/crdb/scim-users-and-groups/up01.sql
+++ b/schema/crdb/scim-users-and-groups/up01.sql
@@ -1,0 +1,7 @@
+ALTER TYPE
+  omicron.public.user_provision_type
+ADD VALUE IF NOT EXISTS
+  'scim'
+AFTER
+  'jit'
+;

--- a/schema/crdb/scim-users-and-groups/up02.sql
+++ b/schema/crdb/scim-users-and-groups/up02.sql
@@ -1,0 +1,5 @@
+ALTER TABLE
+  omicron.public.silo_user
+ADD COLUMN IF NOT EXISTS
+  user_name TEXT
+;

--- a/schema/crdb/scim-users-and-groups/up03.sql
+++ b/schema/crdb/scim-users-and-groups/up03.sql
@@ -1,0 +1,5 @@
+ALTER TABLE
+  omicron.public.silo_user
+ADD COLUMN IF NOT EXISTS
+  active BOOL
+;

--- a/schema/crdb/scim-users-and-groups/up04.sql
+++ b/schema/crdb/scim-users-and-groups/up04.sql
@@ -1,0 +1,9 @@
+ALTER TABLE
+  omicron.public.silo_user
+ADD CONSTRAINT IF NOT EXISTS
+  user_name_consistency CHECK (
+    CASE user_provision_type
+      WHEN 'scim' THEN user_name IS NOT NULL
+    END
+  )
+;

--- a/schema/crdb/scim-users-and-groups/up05.sql
+++ b/schema/crdb/scim-users-and-groups/up05.sql
@@ -1,0 +1,1 @@
+DROP INDEX IF EXISTS lookup_silo_user_by_silo;

--- a/schema/crdb/scim-users-and-groups/up06.sql
+++ b/schema/crdb/scim-users-and-groups/up06.sql
@@ -1,0 +1,7 @@
+CREATE UNIQUE INDEX IF NOT EXISTS
+  lookup_silo_user_by_silo_and_external_id
+ON
+  omicron.public.silo_user (silo_id, external_id)
+WHERE
+  time_deleted IS NULL AND
+  (user_provision_type = 'api_only' OR user_provision_type = 'jit');

--- a/schema/crdb/scim-users-and-groups/up07.sql
+++ b/schema/crdb/scim-users-and-groups/up07.sql
@@ -1,0 +1,6 @@
+CREATE UNIQUE INDEX IF NOT EXISTS
+  lookup_silo_user_by_silo_and_user_name
+ON
+  omicron.public.silo_user (silo_id, user_name)
+WHERE
+  time_deleted IS NULL AND user_provision_type = 'scim';

--- a/schema/crdb/scim-users-and-groups/up08.sql
+++ b/schema/crdb/scim-users-and-groups/up08.sql
@@ -1,0 +1,5 @@
+ALTER TABLE
+  omicron.public.silo_group
+ADD COLUMN IF NOT EXISTS
+  display_name TEXT
+;

--- a/schema/crdb/scim-users-and-groups/up09.sql
+++ b/schema/crdb/scim-users-and-groups/up09.sql
@@ -1,0 +1,9 @@
+ALTER TABLE
+  omicron.public.silo_group
+ADD CONSTRAINT IF NOT EXISTS
+  display_name_consistency CHECK (
+    CASE user_provision_type
+      WHEN 'scim' THEN display_name IS NOT NULL
+    END
+  )
+;

--- a/schema/crdb/scim-users-and-groups/up10.sql
+++ b/schema/crdb/scim-users-and-groups/up10.sql
@@ -1,0 +1,1 @@
+DROP INDEX IF EXISTS lookup_silo_group_by_silo;

--- a/schema/crdb/scim-users-and-groups/up11.sql
+++ b/schema/crdb/scim-users-and-groups/up11.sql
@@ -1,0 +1,7 @@
+CREATE UNIQUE INDEX IF NOT EXISTS
+  lookup_silo_group_by_silo_and_external_id
+ON
+  omicron.public.silo_group (silo_id, external_id)
+WHERE
+  time_deleted IS NULL and
+  (user_provision_type = 'api_only' OR user_provision_type = 'jit');

--- a/schema/crdb/scim-users-and-groups/up12.sql
+++ b/schema/crdb/scim-users-and-groups/up12.sql
@@ -1,0 +1,6 @@
+CREATE UNIQUE INDEX IF NOT EXISTS
+  lookup_silo_group_by_silo_and_display_name
+ON
+  omicron.public.silo_group (silo_id, display_name)
+WHERE
+  time_deleted IS NULL AND user_provision_type = 'scim';


### PR DESCRIPTION
Build on #8981 and add the SCIM user provision type to users and groups. Users must have a user name, and optionally have an external id field and/or an active field. Groups must have a display name and optionally have an external id field.

Also add a new SiloIdentityMode named SamlScim.

A few functions have to change to account for these new variants, but not many. Silos using the SamlScim identity mode will use all the same SAML code that exists today.