### PR TITLE
Do not create bundles of Omicron zones automatically

### DIFF
--- a/sled-agent/config-reconciler/src/sled_agent_facilities.rs
+++ b/sled-agent/config-reconciler/src/sled_agent_facilities.rs
@@ -11,7 +11,6 @@ use illumos_utils::zpool::PathInPool;
 use omicron_common::address::Ipv6Subnet;
 use omicron_common::address::SLED_PREFIX;
 use omicron_uuid_kinds::MupdateOverrideUuid;
-use sled_agent_types::zone_bundle::ZoneBundleCause;
 use sled_agent_types::zone_images::PreparedOmicronZone;
 use sled_agent_types::zone_images::RemoveMupdateOverrideResult;
 use sled_agent_types::zone_images::ResolverStatus;
@@ -61,13 +60,6 @@ pub trait SledAgentFacilities: Send + Sync + 'static {
 
     /// Instruct DDM to stop advertising a prefix.
     fn ddm_remove_internal_dns_prefix(&self, prefix: Ipv6Subnet<SLED_PREFIX>);
-
-    /// Create a zone bundle.
-    fn zone_bundle_create(
-        &self,
-        zone: &RunningZone,
-        cause: ZoneBundleCause,
-    ) -> impl Future<Output = anyhow::Result<()>> + Send;
 }
 
 pub trait SledAgentArtifactStore: Send + Sync + 'static {

--- a/sled-agent/src/sled_agent.rs
+++ b/sled-agent/src/sled_agent.rs
@@ -20,8 +20,8 @@ use crate::services::{self, ServiceManager, UnderlayInfo};
 use crate::support_bundle::logs::SupportBundleLogs;
 use crate::support_bundle::storage::SupportBundleManager;
 use crate::vmm_reservoir::{ReservoirMode, VmmReservoirManager};
+use crate::zone_bundle;
 use crate::zone_bundle::BundleError;
-use crate::zone_bundle::{self, ZoneBundler};
 use anyhow::anyhow;
 use bootstore::schemes::v0 as bootstore;
 use camino::Utf8PathBuf;
@@ -67,7 +67,7 @@ use sled_agent_types::instance::{
 use sled_agent_types::sled::{BaseboardId, StartSledAgentRequest};
 use sled_agent_types::zone_bundle::{
     BundleUtilization, CleanupContext, CleanupCount, CleanupPeriod,
-    PriorityOrder, StorageLimit, ZoneBundleCause, ZoneBundleMetadata,
+    PriorityOrder, StorageLimit, ZoneBundleMetadata,
 };
 use sled_agent_types::zone_images::{
     PreparedOmicronZone, RemoveMupdateOverrideResult, ResolverStatus,
@@ -611,7 +611,6 @@ impl SledAgent {
                 etherstub_vnic,
                 service_manager: services.clone(),
                 metrics_queue: metrics_manager.request_queue(),
-                zone_bundler: long_running_task_handles.zone_bundler.clone(),
             },
             SledAgentArtifactStoreWrapper(Arc::clone(&artifact_store)),
             config_reconciler_spawn_token,
@@ -1294,7 +1293,6 @@ struct ReconcilerFacilities {
     etherstub_vnic: EtherstubVnic,
     service_manager: ServiceManager,
     metrics_queue: MetricsRequestQueue,
-    zone_bundler: ZoneBundler,
 }
 
 impl SledAgentFacilities for ReconcilerFacilities {
@@ -1354,15 +1352,6 @@ impl SledAgentFacilities for ReconcilerFacilities {
         self.service_manager
             .ddm_reconciler()
             .remove_internal_dns_subnet(prefix);
-    }
-
-    async fn zone_bundle_create(
-        &self,
-        zone: &RunningZone,
-        cause: ZoneBundleCause,
-    ) -> anyhow::Result<()> {
-        self.zone_bundler.create(zone, cause).await?;
-        Ok(())
     }
 }
 


### PR DESCRIPTION
- Remove automatic zone bundle creation for Omicron zones when the sled-agent config reconciler shuts down a zone.
- Fixes #9164 in the simplest possible way. Does not actually remove the zone-bundle functionality entirely or automatic creation for Propolis zones. Bundles can still be made on-demand.