### PR TITLE
oximeter: clean up query summary logic and docs.

### DIFF
--- a/nexus/src/external_api/http_entrypoints.rs
+++ b/nexus/src/external_api/http_entrypoints.rs
@@ -7157,13 +7157,13 @@ impl NexusExternalApi for NexusExternalApiImpl {
                             .into_iter()
                             .map(Into::into)
                             .collect(),
-                        query_summaries: include_summaries.then_some(
+                        query_summaries: include_summaries.then(|| {
                             result
                                 .query_summaries
                                 .into_iter()
                                 .map(Into::into)
-                                .collect(),
-                        ),
+                                .collect()
+                        }),
                     })
                 })
                 .map_err(HttpError::from)
@@ -7201,13 +7201,13 @@ impl NexusExternalApi for NexusExternalApiImpl {
                             .into_iter()
                             .map(Into::into)
                             .collect(),
-                        query_summaries: include_summaries.then_some(
+                        query_summaries: include_summaries.then(|| {
                             result
                                 .query_summaries
                                 .into_iter()
                                 .map(Into::into)
-                                .collect(),
-                        ),
+                                .collect()
+                        }),
                     })
                 })
                 .map_err(HttpError::from)

--- a/nexus/types/src/external_api/params.rs
+++ b/nexus/types/src/external_api/params.rs
@@ -2443,8 +2443,11 @@ pub struct ProbeListSelector {
 pub struct TimeseriesQuery {
     /// A timeseries query string, written in the Oximeter query language.
     pub query: String,
-    /// Whether to include ClickHouse query summaries in the response.
+    /// Whether to include query summaries in the response. Note: we omit this
+    /// field from the generated docs, since it is not intended for consumption
+    /// by customers.
     #[serde(default)]
+    #[schemars(skip)]
     pub include_summaries: bool,
 }
 

--- a/nexus/types/src/external_api/views.rs
+++ b/nexus/types/src/external_api/views.rs
@@ -1123,14 +1123,14 @@ impl From<oxql_types::Table> for OxqlTable {
     }
 }
 
-/// Basic metadata about the resource usage of a single ClickHouse SQL query.
+/// Basic metadata about the resource usage of a query.
 #[derive(Clone, Debug, Deserialize, JsonSchema, Serialize)]
 pub struct OxqlQuerySummary {
     /// The database-assigned query ID.
     pub id: Uuid,
-    /// The raw ClickHouse SQL query.
+    /// The raw query.
     pub query: String,
-    /// The total duration of the ClickHouse query (network plus execution).
+    /// The total duration of the query (network plus execution).
     pub elapsed_ms: usize,
     /// Summary of the data read and written.
     pub io_summary: oxql_types::IoSummary,
@@ -1152,7 +1152,10 @@ impl From<oxql_types::QuerySummary> for OxqlQuerySummary {
 pub struct OxqlQueryResult {
     /// Tables resulting from the query, each containing timeseries.
     pub tables: Vec<OxqlTable>,
-    /// Summaries of queries run against ClickHouse.
+    /// Summaries of queries run against ClickHouse. Note: we omit this field
+    /// from the generated docs, since it is not intended for consumption by
+    /// customers.
+    #[schemars(skip)]
     pub query_summaries: Option<Vec<OxqlQuerySummary>>,
 }
 

--- a/openapi/nexus.json
+++ b/openapi/nexus.json
@@ -21386,54 +21386,6 @@
           "items"
         ]
       },
-      "IoCount": {
-        "description": "A count of bytes / rows accessed during a query.",
-        "type": "object",
-        "properties": {
-          "bytes": {
-            "description": "The number of bytes accessed.",
-            "type": "integer",
-            "format": "uint64",
-            "minimum": 0
-          },
-          "rows": {
-            "description": "The number of rows accessed.",
-            "type": "integer",
-            "format": "uint64",
-            "minimum": 0
-          }
-        },
-        "required": [
-          "bytes",
-          "rows"
-        ]
-      },
-      "IoSummary": {
-        "description": "Summary of the I/O resources used by a query.",
-        "type": "object",
-        "properties": {
-          "read": {
-            "description": "The bytes and rows read by the query.",
-            "allOf": [
-              {
-                "$ref": "#/components/schemas/IoCount"
-              }
-            ]
-          },
-          "written": {
-            "description": "The bytes and rows written by the query.",
-            "allOf": [
-              {
-                "$ref": "#/components/schemas/IoCount"
-              }
-            ]
-          }
-        },
-        "required": [
-          "read",
-          "written"
-        ]
-      },
       "IpNet": {
         "x-rust-type": {
           "crate": "oxnet",
@@ -22551,14 +22503,6 @@
         "description": "The result of a successful OxQL query.",
         "type": "object",
         "properties": {
-          "query_summaries": {
-            "nullable": true,
-            "description": "Summaries of queries run against ClickHouse.",
-            "type": "array",
-            "items": {
-              "$ref": "#/components/schemas/OxqlQuerySummary"
-            }
-          },
           "tables": {
             "description": "Tables resulting from the query, each containing timeseries.",
             "type": "array",
@@ -22569,41 +22513,6 @@
         },
         "required": [
           "tables"
-        ]
-      },
-      "OxqlQuerySummary": {
-        "description": "Basic metadata about the resource usage of a single ClickHouse SQL query.",
-        "type": "object",
-        "properties": {
-          "elapsed_ms": {
-            "description": "The total duration of the ClickHouse query (network plus execution).",
-            "type": "integer",
-            "format": "uint",
-            "minimum": 0
-          },
-          "id": {
-            "description": "The database-assigned query ID.",
-            "type": "string",
-            "format": "uuid"
-          },
-          "io_summary": {
-            "description": "Summary of the data read and written.",
-            "allOf": [
-              {
-                "$ref": "#/components/schemas/IoSummary"
-              }
-            ]
-          },
-          "query": {
-            "description": "The raw ClickHouse SQL query.",
-            "type": "string"
-          }
-        },
-        "required": [
-          "elapsed_ms",
-          "id",
-          "io_summary",
-          "query"
         ]
       },
       "OxqlTable": {
@@ -26036,11 +25945,6 @@
         "description": "A timeseries query string, written in the Oximeter query language.",
         "type": "object",
         "properties": {
-          "include_summaries": {
-            "description": "Whether to include ClickHouse query summaries in the response.",
-            "default": false,
-            "type": "boolean"
-          },
           "query": {
             "description": "A timeseries query string, written in the Oximeter query language.",
             "type": "string"


### PR DESCRIPTION
* Convert query summaries lazily; h/t @david-crespo.
* Drop query summaries from user-facing docs; h/t @ahl. This feature is only useful for Oxide engineers to investigate oximeter performance, and we don't want to leak implementation details into public docs.