### PR TITLE
Add mapping of cubby to sled ID to support bundles

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -8067,6 +8067,7 @@ dependencies = [
  "gateway-client",
  "gateway-messages",
  "gateway-test-utils",
+ "gateway-types",
  "headers",
  "hex",
  "hickory-resolver 0.25.2",

--- a/nexus/Cargo.toml
+++ b/nexus/Cargo.toml
@@ -37,6 +37,7 @@ dropshot.workspace = true
 fatfs.workspace = true
 futures.workspace = true
 gateway-client.workspace = true
+gateway-types.workspace = true
 headers.workspace = true
 hex.workspace = true
 hickory-resolver.workspace = true


### PR DESCRIPTION
Currently support bundles contain the sled UUID in file paths, and serial number in `sled.txt`. However, when accessing the sled via the tech port we generally refer to a sled by its cubby.

To make identification of sleds simpler, add a new `sled_info.json` file to the bundle with a JSON-encoded mapping of sled serial to cubby and UUID.