### PR TITLE
Bump Propolis and Crucible

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2053,7 +2053,7 @@ dependencies = [
 [[package]]
 name = "crucible-agent-client"
 version = "0.0.1"
-source = "git+https://github.com/oxidecomputer/crucible?rev=65ca41e821ef53ec9c28909357f23e3348169e4f#65ca41e821ef53ec9c28909357f23e3348169e4f"
+source = "git+https://github.com/oxidecomputer/crucible?rev=102b0bb8305cfbc3fa74c52d643d716653756372#102b0bb8305cfbc3fa74c52d643d716653756372"
 dependencies = [
  "anyhow",
  "chrono",
@@ -2082,7 +2082,7 @@ dependencies = [
 [[package]]
 name = "crucible-common"
 version = "0.0.1"
-source = "git+https://github.com/oxidecomputer/crucible?rev=65ca41e821ef53ec9c28909357f23e3348169e4f#65ca41e821ef53ec9c28909357f23e3348169e4f"
+source = "git+https://github.com/oxidecomputer/crucible?rev=102b0bb8305cfbc3fa74c52d643d716653756372#102b0bb8305cfbc3fa74c52d643d716653756372"
 dependencies = [
  "anyhow",
  "atty",
@@ -2112,7 +2112,7 @@ dependencies = [
 [[package]]
 name = "crucible-pantry-client"
 version = "0.0.1"
-source = "git+https://github.com/oxidecomputer/crucible?rev=65ca41e821ef53ec9c28909357f23e3348169e4f#65ca41e821ef53ec9c28909357f23e3348169e4f"
+source = "git+https://github.com/oxidecomputer/crucible?rev=102b0bb8305cfbc3fa74c52d643d716653756372#102b0bb8305cfbc3fa74c52d643d716653756372"
 dependencies = [
  "anyhow",
  "chrono",
@@ -2129,7 +2129,7 @@ dependencies = [
 [[package]]
 name = "crucible-smf"
 version = "0.0.0"
-source = "git+https://github.com/oxidecomputer/crucible?rev=65ca41e821ef53ec9c28909357f23e3348169e4f#65ca41e821ef53ec9c28909357f23e3348169e4f"
+source = "git+https://github.com/oxidecomputer/crucible?rev=102b0bb8305cfbc3fa74c52d643d716653756372#102b0bb8305cfbc3fa74c52d643d716653756372"
 dependencies = [
  "crucible-workspace-hack",
  "libc",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -411,10 +411,10 @@ crossterm = { version = "0.29.0", features = ["event-stream"] }
 # NOTE: if you change the pinned revision of the `crucible` dependencies, you
 # must also update the references in package-manifest.toml to match the new
 # revision.
-crucible-agent-client = { git = "https://github.com/oxidecomputer/crucible", rev = "65ca41e821ef53ec9c28909357f23e3348169e4f" }
-crucible-pantry-client = { git = "https://github.com/oxidecomputer/crucible", rev = "65ca41e821ef53ec9c28909357f23e3348169e4f" }
-crucible-smf = { git = "https://github.com/oxidecomputer/crucible", rev = "65ca41e821ef53ec9c28909357f23e3348169e4f" }
-crucible-common = { git = "https://github.com/oxidecomputer/crucible", rev = "65ca41e821ef53ec9c28909357f23e3348169e4f" }
+crucible-agent-client = { git = "https://github.com/oxidecomputer/crucible", rev = "102b0bb8305cfbc3fa74c52d643d716653756372" }
+crucible-pantry-client = { git = "https://github.com/oxidecomputer/crucible", rev = "102b0bb8305cfbc3fa74c52d643d716653756372" }
+crucible-smf = { git = "https://github.com/oxidecomputer/crucible", rev = "102b0bb8305cfbc3fa74c52d643d716653756372" }
+crucible-common = { git = "https://github.com/oxidecomputer/crucible", rev = "102b0bb8305cfbc3fa74c52d643d716653756372" }
 # NOTE: See above!
 csv = "1.3.1"
 curve25519-dalek = "4"

--- a/package-manifest.toml
+++ b/package-manifest.toml
@@ -595,10 +595,10 @@ only_for_targets.image = "standard"
 # 3. Use source.type = "manual" instead of "prebuilt"
 source.type = "prebuilt"
 source.repo = "crucible"
-source.commit = "65ca41e821ef53ec9c28909357f23e3348169e4f"
+source.commit = "102b0bb8305cfbc3fa74c52d643d716653756372"
 # The SHA256 digest is automatically posted to:
 # https://buildomat.eng.oxide.computer/public/file/oxidecomputer/crucible/image/<commit>/crucible.sha256.txt
-source.sha256 = "7a19eda420ebd1126a25746c2198ed58a62647c755a375c746e84351e651b278"
+source.sha256 = "5edb5f8b85002115bdf81bcfbbf3bb233b8ee560e1d315a8e2b9989ec9dc43fc"
 output.type = "zone"
 output.intermediate_only = true
 
@@ -607,10 +607,10 @@ service_name = "crucible_pantry_prebuilt"
 only_for_targets.image = "standard"
 source.type = "prebuilt"
 source.repo = "crucible"
-source.commit = "65ca41e821ef53ec9c28909357f23e3348169e4f"
+source.commit = "102b0bb8305cfbc3fa74c52d643d716653756372"
 # The SHA256 digest is automatically posted to:
 # https://buildomat.eng.oxide.computer/public/file/oxidecomputer/crucible/image/<commit>/crucible-pantry.sha256.txt
-source.sha256 = "e5dcf53aac3ddb5060663d2950837b3c4c81c68ede23b4ff5b1778cd1d4fb51e"
+source.sha256 = "d0ec6e365cf9e918d7aa4711dc48b4eec9362b37d5becfa3133895dff801ceca"
 output.type = "zone"
 output.intermediate_only = true
 
@@ -624,10 +624,10 @@ service_name = "crucible_dtrace"
 only_for_targets.image = "standard"
 source.type = "prebuilt"
 source.repo = "crucible"
-source.commit = "65ca41e821ef53ec9c28909357f23e3348169e4f"
+source.commit = "102b0bb8305cfbc3fa74c52d643d716653756372"
 # The SHA256 digest is automatically posted to:
 # https://buildomat.eng.oxide.computer/public/file/oxidecomputer/crucible/image/<commit>/crucible-dtrace.sha256.txt
-source.sha256 = "4ec3f612b0c10ef3372e22e99ef8170ab39d198f394b0e51d6c1065dc7d01b40"
+source.sha256 = "580fc58e717e245ea8a8171e25d7765edf58d57d3d9d190cdf61a4a1cae474be"
 output.type = "tarball"
 
 # Refer to


### PR DESCRIPTION
Propolis changes:

* oxidecomputer/propolis#950
* oxidecomputer/propolis#952
* oxidecomputer/propolis#951
* oxidecomputer/propolis#954
* oxidecomputer/propolis#957
* oxidecomputer/propolis#960
* oxidecomputer/propolis#961
* oxidecomputer/propolis#955

Crucible changes:

* oxidecomputer/crucible#1773
* oxidecomputer/crucible#1774
* oxidecomputer/crucible#1780
* oxidecomputer/crucible#1778

Crucible shouldn't have functional changes here, Propolis' big ones are @sunshowers' work moving Propolis to versioned APIs, plus propolis#960 turning the crank on MAXCPU.

propolis#961 changes the initial Milan CPU profile one last time before the release in service of propolis#959. Propolis will clear [this bit](https://github.com/oxidecomputer/omicron/blob/d74f5e3f1ae0a378dcdb9795a0ada2426702b046/nexus/src/app/instance_platform/cpu_platform.rs#L423). Later we want to actually set up leaf 8000_001E, so after this merges I'll have a followup to remove that leaf from the inital Milan definition to keep the profile constant when `propolis-server` is smarter about the leaf.