### PR TITLE
clickhouse-admin: enable part log.

### DIFF
--- a/clickhouse-admin/types/src/config.rs
+++ b/clickhouse-admin/types/src/config.rs
@@ -178,6 +178,11 @@ impl ReplicaConfig {
         <flush_on_crash>false</flush_on_crash>
     </asynchronous_metric_log>
 
+    <part_log>
+        <database>system</database>
+        <table>part_log</table>
+    </part_log>
+
     <tmp_path>{temp_files_path}</tmp_path>
     <user_files_path>{user_files_path}</user_files_path>
     <default_profile>default</default_profile>

--- a/clickhouse-admin/types/testutils/replica-server-config.xml
+++ b/clickhouse-admin/types/testutils/replica-server-config.xml
@@ -81,6 +81,11 @@
         <flush_on_crash>false</flush_on_crash>
     </asynchronous_metric_log>
 
+    <part_log>
+        <database>system</database>
+        <table>part_log</table>
+    </part_log>
+
     <tmp_path>./data/tmp</tmp_path>
     <user_files_path>./data/user_files</user_files_path>
     <default_profile>default</default_profile>


### PR DESCRIPTION
To help investigate issues like #9234, enable the ClickHouse part log. This will help us understand, for example, whether a part has been merged into a new part, or is missing.