### PR TITLE
[reconfigurator] Validate a minimal value of INTERNAL_DNS_REDUNDANCY

### DIFF
--- a/nexus/reconfigurator/planning/src/blueprint_builder/builder.rs
+++ b/nexus/reconfigurator/planning/src/blueprint_builder/builder.rs
@@ -142,6 +142,10 @@ pub enum Error {
     AllocateInternalDnsSubnet(#[from] NoAvailableDnsSubnets),
     #[error("error allocating external networking resources")]
     AllocateExternalNetworking(#[from] ExternalNetworkingError),
+    #[error(
+        "must have at least {INTERNAL_DNS_REDUNDANCY} internal DNS servers"
+    )]
+    PolicySpecifiesNotEnoughInternalDnsServers,
     #[error("can only have {INTERNAL_DNS_REDUNDANCY} internal DNS servers")]
     PolicySpecifiesTooManyInternalDnsServers,
     #[error("zone is already up-to-date and should not be updated")]


### PR DESCRIPTION
This is partially in response to https://github.com/oxidecomputer/omicron/pull/9236, in an attempt to ensure that planning policies cannot break the system.

Clearly additional zone target counts should be verified here, but each one propagates pervasively through tests.