### PR TITLE
omdb should not crash on SIGPIPE

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -8345,6 +8345,7 @@ dependencies = [
  "reqwest",
  "serde",
  "serde_json",
+ "sigpipe",
  "sled-agent-client",
  "slog",
  "slog-error-chain",

--- a/dev-tools/omdb/Cargo.toml
+++ b/dev-tools/omdb/Cargo.toml
@@ -70,6 +70,7 @@ ratatui.workspace = true
 reedline.workspace = true
 reqwest.workspace = true
 serde.workspace = true
+sigpipe.workspace = true
 serde_json.workspace = true
 sled-agent-client.workspace = true
 slog.workspace = true

--- a/dev-tools/omdb/src/bin/omdb/main.rs
+++ b/dev-tools/omdb/src/bin/omdb/main.rs
@@ -60,6 +60,7 @@ mod sled_agent;
 mod support_bundle;
 
 fn main() -> Result<(), anyhow::Error> {
+    sigpipe::reset();
     oxide_tokio_rt::run(main_impl())
 }
 


### PR DESCRIPTION
Fixes #8352 in the same way as #5358 fixed `oxlog`.