### PR TITLE
Apply optimal drive settings for Ultrastar DC SN681

### DIFF
--- a/sled-hardware/src/illumos/partitions.rs
+++ b/sled-hardware/src/illumos/partitions.rs
@@ -302,7 +302,7 @@ fn ensure_size_and_formatting(
     // Check that we are on real Oxide hardware so that we avoid:
     // - Messing with NVMe devices in other environments
     // - Failing tests which use zvols rather than real NVMe devices
-    // - Breaking virutal environments like a4x2 which likely don't expose or
+    // - Breaking virtual environments like a4x2 which likely don't expose or
     //   implement changing the LBA on emulated devices.
     if !is_oxide_sled().map_err(NvmeFormattingError::SystemDetection)? {
         return Ok(());


### PR DESCRIPTION
This adds the SDS6BA138PSP9X3 nvme drive to sled-agent's
PREFERRED_NVME_DEVICE_SETTINGS hash map, additionally it shuffles some
logic around to always apply a 4K LBA data size to all devices as Robert
suggested in #8867


Fixes #8867
