### PR TITLE
clickhouse: update replication config in the correct file.

### DIFF
--- a/smf/clickhouse/config.xml
+++ b/smf/clickhouse/config.xml
@@ -72,6 +72,10 @@
     </quotas>
 
     <merge_tree>
+        <!-- Disable sparse column serialization, which we expect to not need -->
         <ratio_of_defaults_for_sparse_serialization>1.0</ratio_of_defaults_for_sparse_serialization>
+        <!-- Prevent ClickHouse from setting distributed tables to read-only. -->
+        <!-- See https://github.com/oxidecomputer/omicron/issues/8595 for details. -->
+        <replicated_max_ratio_of_wrong_parts>1.0</replicated_max_ratio_of_wrong_parts>
     </merge_tree>
 </clickhouse>


### PR DESCRIPTION
As a follow-up to #9183, update the replicated_max_ratio_of_wrong_parts setting in the relevant file. After merging the previous PR, we noticed that the change there didn't propagate to the config file in use on the rack. This patch applies that same update to the correct config file in smf/.