### PR TITLE
smf: update PATH for clustered clickhouse.

### DIFF
--- a/smf/profile/profile
+++ b/smf/profile/profile
@@ -13,7 +13,7 @@ case "$HOSTNAME" in
 	PATH+=:/opt/oxide/crucible/bin
 	;;
     oxz_clickhouse*)
-	PATH+=:/opt/oxide/clickhouse:/opt/oxide/clickhouse_keeper
+	PATH+=:/opt/oxide/clickhouse:/opt/oxide/clickhouse_server:/opt/oxide/clickhouse_keeper
 	;;
     oxz_external_dns*|oxz_internal_dns*)
 	PATH+=:/opt/oxide/dns-server/bin


### PR DESCRIPTION
We put the clickhouse binary in /opt/oxide/clickhouse for single-node clickhouse, but in /opt/oxide/clickhouse_server for clustered clickhouse. This patch adds the latter path to $PATH so that the clickhouse binary is in the path for both single-node and clustered clickhouse topologies.

@bnaecker, do you know if I made this change in the right place? Full disclosure: I just looked around the codebase for lines that add clickhouse binaries to PATH and guessed that this did the right thing.