### PR TITLE
oximeter: optimize measurements tables.

### DIFF
--- a/oximeter/db/schema/replicated/15/up.sql
+++ b/oximeter/db/schema/replicated/15/up.sql
@@ -1,0 +1,22 @@
+CREATE TABLE IF NOT EXISTS oximeter.measurements_cumulativef64_local_new_15 ON CLUSTER oximeter_cluster
+(
+    timeseries_name String,
+    timeseries_key UInt64,
+    start_time DateTime64(9, 'UTC'),
+    timestamp DateTime64(9, 'UTC'),
+    datum Nullable(Float64)
+)
+ENGINE = ReplicatedMergeTree('/clickhouse/tables/{shard}/measurements_cumulativef64_local', '{replica}')
+PARTITION BY (toYYYYMMDD(timestamp))
+ORDER BY (timeseries_name, timeseries_key, start_time, timestamp)
+TTL toDateTime(timestamp) + INTERVAL 30 DAY;
+
+INSERT INTO oximeter.measurements_cumulativef64_local_new_15
+SELECT * FROM oximeter.measurements_cumulativef64_local;
+
+RENAME TABLE
+    oximeter.measurements_cumulativef64_local_new_15 to oximeter.measurements.cumulativef64_local,
+    oximeter.measurements_cumulativef64_local to oximeter.measurements.cumulativef64_local_old_15;
+
+-- TODO: Drop the original table in a separate step, after verifying the migration.
+-- DROP TABLE oximeter.measurements_cumulativef64_old_15;

--- a/oximeter/db/schema/replicated/db-init-1.sql
+++ b/oximeter/db/schema/replicated/db-init-1.sql
@@ -49,6 +49,7 @@ CREATE TABLE IF NOT EXISTS oximeter.measurements_cumulativef64_local ON CLUSTER 
     datum Nullable(Float64)
 )
 ENGINE = ReplicatedMergeTree('/clickhouse/tables/{shard}/measurements_cumulativef64_local', '{replica}')
+PARTITION BY (toYYYYMMDD(timestamp))
 ORDER BY (timeseries_name, timeseries_key, start_time, timestamp)
 TTL toDateTime(timestamp) + INTERVAL 30 DAY;
 


### PR DESCRIPTION
Apply a few ddl-only optimizations to the oximeter measurements tables:

* Encode timestamps columns using delta encoding. Rows are sorted by (timeseries_name, timeseries_key, timestamp), so timestamps compress very well as deltas.
* Partition measurements tables by timestamp, within days. Many queries care about a small time range, and partitioning by day will make those queries significantly cheaper.

Note: this is a draft, since I need to better understand how clickhouse migrations work, and how to do this safely. I'll apply these changes to all measurements tables if/when we agree to an approach and convince ourselves that this will be safe to run.