### PR TITLE
[installinator] lengthen total timeout for artifact fetch to 5 minutes

### DIFF
--- a/installinator/src/artifact.rs
+++ b/installinator/src/artifact.rs
@@ -155,6 +155,7 @@ impl ArtifactClient {
         let log = log.new(
             slog::o!("component" => "ArtifactClient", "peer" => addr.to_string()),
         );
+
         // Set a connect timeout of 15 seconds (the progenitor default), and a
         // total timeout of 5 minutes. The progenitor default for the total
         // timeout is 15 seconds, which can easily be exceeded for large
@@ -176,6 +177,7 @@ impl ArtifactClient {
             client,
             log.clone(),
         );
+
         Self { log, client }
     }
 

--- a/installinator/src/fetch.rs
+++ b/installinator/src/fetch.rs
@@ -126,17 +126,17 @@ impl fmt::Debug for FetchedArtifact {
 pub(crate) struct FetchArtifactBackend {
     log: slog::Logger,
     imp: Box<dyn FetchArtifactImpl>,
-    timeout: Duration,
+    read_timeout: Duration,
 }
 
 impl FetchArtifactBackend {
     pub(crate) fn new(
         log: &slog::Logger,
         imp: Box<dyn FetchArtifactImpl>,
-        timeout: Duration,
+        read_timeout: Duration,
     ) -> Self {
         let log = log.new(slog::o!("component" => "Peers"));
-        Self { log, imp, timeout }
+        Self { log, imp, read_timeout }
     }
 
     pub(crate) async fn fetch_artifact(
@@ -227,8 +227,10 @@ impl FetchArtifactBackend {
             InstallinatorProgressMetadata::Download { peer: peer.address() };
 
         loop {
-            // This is the read timeout.
-            match tokio::time::timeout(self.timeout, receiver.recv()).await {
+            // This is the read timeout. See ArtifactClient::new for details
+            // about connect, read, and total timeouts.
+            match tokio::time::timeout(self.read_timeout, receiver.recv()).await
+            {
                 Ok(Some(Ok(bytes))) => {
                     slog::debug!(
                         &log,
@@ -271,14 +273,14 @@ impl FetchArtifactBackend {
                         metadata,
                         message: format!(
                             "operation timed out ({:?})",
-                            self.timeout
+                            self.read_timeout
                         )
                         .into(),
                     })
                     .await;
                     return Err(ArtifactFetchError::Timeout {
                         peer: peer.address(),
-                        timeout: self.timeout,
+                        timeout: self.read_timeout,
                         bytes_fetched: artifact_bytes.num_bytes(),
                     });
                 }


### PR DESCRIPTION
We were previously setting a connect and total timeout of 15 seconds each, which was easy to hit in berlin, especially with a DEBUG kernel.
