### PR TITLE
trivial: shorten tuf repo view endpoint description by one word

### DIFF
--- a/nexus/external-api/src/lib.rs
+++ b/nexus/external-api/src/lib.rs
@@ -3189,7 +3189,7 @@ pub trait NexusExternalApi {
         body: StreamingBody,
     ) -> Result<HttpResponseOk<views::TufRepoUpload>, HttpError>;
 
-    /// Fetch system release repository description by version
+    /// Fetch system release repository by version
     #[endpoint {
         method = GET,
         path = "/v1/system/update/repositories/{system_version}",

--- a/openapi/nexus.json
+++ b/openapi/nexus.json
@@ -11184,7 +11184,7 @@
         "tags": [
           "system/update"
         ],
-        "summary": "Fetch system release repository description by version",
+        "summary": "Fetch system release repository by version",
         "operationId": "system_update_repository_view",
         "parameters": [
           {


### PR DESCRIPTION
Just something I noticed in the v17 docs site preview.

### Before

<img width="276" height="421" alt="Screenshot 2025-10-28 at 6 32 05 PM" src="https://github.com/user-attachments/assets/0087267f-0da5-484e-8f47-4a98ffce5252" />


### After

<img width="272" height="385" alt="Screenshot 2025-10-28 at 6 31 59 PM" src="https://github.com/user-attachments/assets/8a88ae13-0b8c-46eb-8464-926278a10775" />
