### PR TITLE
Fix previous attempts for a commit not being uploaded to Trunk

### DIFF
--- a/tools/upload_buildomat_junit_to_trunk.sh
+++ b/tools/upload_buildomat_junit_to_trunk.sh
@@ -40,7 +40,11 @@ branch="$(jq -r .head_branch api/check_suite)"
 commit="$(jq -r .head_sha api/check_suite)"
 github_app="$(jq -r .app.slug api/check_suite)"
 
-gh api "repos/${GITHUB_REPOSITORY}/check-suites/${check_suite_id}/check-runs" > api/check_suite_runs
+# By default the check-runs endpoint returns only the most recent check run with any given name. We
+# want to upload the JUnit XML reports for *all* attempts though, as Trunk's flaky test detection
+# relies on a test both passing and failing for the same commit. The filter=all query parameter
+# ensures we also get past attempts (the default is filter=latest).
+gh api "repos/${GITHUB_REPOSITORY}/check-suites/${check_suite_id}/check-runs?filter=all" > api/check_suite_runs
 
 gh api "repos/${GITHUB_REPOSITORY}/commits/${commit}" > api/commit
 author_email="$(jq -r .commit.author.email api/commit)"


### PR DESCRIPTION
In https://github.com/oxidecomputer/omicron/issues/9333#issuecomment-3484186904 it was reported that when a failed Buildomat job was restarted before the whole GitHub Check Suite finished, the old job's JUnit XML was not uploaded to Trunk. This PR fixes that by loading all check runs belonging to the check suite, not just the most recent run with any given name.

I also did some testing on the behavior of the `check_suite` webhook to ensure we don't lose any upload. Turns out that the `check_suite` webhook is triggered every time all check runs are completed. So, simulating a few cases:

**Job restarted before every job finishes:**

* Run 1 is registered as `in_progress`
* Run 2 is registered as `in_progress`
* Run 1 is marked as `completed:failure`
* Human clicks the "Restart" button on Run 1
* Run 3 is registered as `in_progress` (as the new attempt of Run 1)
* Run 2 is marked as `completed:success`
* Run 3 is marked as `completed:success`
* All runs are completed, `check_suite` webhook is sent containing Run 1, Run 2, Run 3

**Job restarted after every job finishes:**

* Run 1 is registered as `in_progress`
* Run 2 is registered as `in_progress`
* Run 1 is marked as `completed:failure`
* Run 2 is marked as `completed:success`
* All runs are completed, `check_suite` webhook is sent containing Run 1, Run 2
* Human clicks the "Restart" button on Run 1
* Run 3 is registered as `in_progress` (as the new attempt of Run 1)
* Run 3 is marked as `completed:success`
* All runs are completed, `check_suite` webhook is sent containing Run 1, Run 2, Run 3

There is only one problem with this approach, shown by the last bullet point of the second test case: the `check_suite` event (indirectly) returns all runs as part of the suite, even though some of them were already included in the previous webhook. This will result in the JUnit XML reports of the non-retried jobs being uploaded twice, but Trunk should handle that fine. It would be cleaner to only upload each job once, but I don't see a way to do that without either maintaining state or reverting https://github.com/oxidecomputer/omicron/pull/9249.