### PR TITLE
bump to v18; API version to planned release date

### DIFF
--- a/dev-tools/dropshot-apis/src/main.rs
+++ b/dev-tools/dropshot-apis/src/main.rs
@@ -193,7 +193,7 @@ fn all_apis() -> anyhow::Result<ManagedApis> {
         ManagedApiConfig {
             title: "Oxide Region API",
             versions: Versions::new_lockstep(semver::Version::new(
-                20251008, 0, 0,
+                20251208, 0, 0,
             )),
             metadata: ManagedApiMetadata {
                 description: Some(

--- a/dev-tools/releng/src/main.rs
+++ b/dev-tools/releng/src/main.rs
@@ -46,7 +46,7 @@ use crate::job::Jobs;
 /// to as "v8", "version 8", or "release 8" to customers). The use of semantic
 /// versioning is mostly to hedge for perhaps wanting something more granular in
 /// the future.
-const BASE_VERSION: Version = Version::new(17, 0, 0);
+const BASE_VERSION: Version = Version::new(18, 0, 0);
 
 const RETRY_ATTEMPTS: usize = 3;
 

--- a/nexus/external-api/src/lib.rs
+++ b/nexus/external-api/src/lib.rs
@@ -30,7 +30,7 @@ use omicron_common::api::external::{
 };
 use openapiv3::OpenAPI;
 
-pub const API_VERSION: &str = "20251008.0.0";
+pub const API_VERSION: &str = "20251208.0.0";
 
 const MIB: usize = 1024 * 1024;
 const GIB: usize = 1024 * MIB;

--- a/openapi/nexus.json
+++ b/openapi/nexus.json
@@ -7,7 +7,7 @@
       "url": "https://oxide.computer",
       "email": "api@oxide.computer"
     },
-    "version": "20251008.0.0"
+    "version": "20251208.0.0"
   },
   "paths": {
     "/device/auth": {


### PR DESCRIPTION
I've run out of numbers that Count von Count can reliably be found to have counted to on television, so I'm going to now do an extremely protracted Let's Remember Some Guys bit on my version bump PRs. Here's journeyman Rich Hill, who wore number 18 on his brief stint with the Oakland A's in 2016 (Keith Allison/Flickr; UCinternational/Wikimedia Commons; CC BY-SA 2.0).

<a href="https://commons.wikimedia.org/wiki/File:Rich_Hill_on_May_7,_2016.jpg"><img width="320" height="480" alt="image" src="https://github.com/user-attachments/assets/9f248402-fd27-4841-98b9-ed8c2cb782b3" /></a>