### PR TITLE
oximeter: simplify histogram response.

### DIFF
--- a/openapi/nexus.json
+++ b/openapi/nexus.json
@@ -18226,27 +18226,18 @@
           },
           "p50": {
             "nullable": true,
-            "allOf": [
-              {
-                "$ref": "#/components/schemas/Quantile"
-              }
-            ]
+            "type": "number",
+            "format": "double"
           },
           "p90": {
             "nullable": true,
-            "allOf": [
-              {
-                "$ref": "#/components/schemas/Quantile"
-              }
-            ]
+            "type": "number",
+            "format": "double"
           },
           "p99": {
             "nullable": true,
-            "allOf": [
-              {
-                "$ref": "#/components/schemas/Quantile"
-              }
-            ]
+            "type": "number",
+            "format": "double"
           },
           "squared_mean": {
             "type": "number",
@@ -18295,27 +18286,18 @@
           },
           "p50": {
             "nullable": true,
-            "allOf": [
-              {
-                "$ref": "#/components/schemas/Quantile"
-              }
-            ]
+            "type": "number",
+            "format": "double"
           },
           "p90": {
             "nullable": true,
-            "allOf": [
-              {
-                "$ref": "#/components/schemas/Quantile"
-              }
-            ]
+            "type": "number",
+            "format": "double"
           },
           "p99": {
             "nullable": true,
-            "allOf": [
-              {
-                "$ref": "#/components/schemas/Quantile"
-              }
-            ]
+            "type": "number",
+            "format": "double"
           },
           "squared_mean": {
             "type": "number",
@@ -19172,22 +19154,28 @@
             "minimum": 0
           },
           "p50": {
-            "nullable": true,
             "description": "p50 Quantile",
-            "type": "number",
-            "format": "double"
+            "allOf": [
+              {
+                "$ref": "#/components/schemas/Quantile"
+              }
+            ]
           },
           "p90": {
-            "nullable": true,
             "description": "p95 Quantile",
-            "type": "number",
-            "format": "double"
+            "allOf": [
+              {
+                "$ref": "#/components/schemas/Quantile"
+              }
+            ]
           },
           "p99": {
-            "nullable": true,
             "description": "p99 Quantile",
-            "type": "number",
-            "format": "double"
+            "allOf": [
+              {
+                "$ref": "#/components/schemas/Quantile"
+              }
+            ]
           },
           "squared_mean": {
             "description": "M2 for Welford's algorithm for variance calculation.\n\nRead about [Welford's algorithm](https://en.wikipedia.org/wiki/Algorithms_for_calculating_variance#Welford's_online_algorithm) for more information on the algorithm.",
@@ -19210,6 +19198,9 @@
           "max",
           "min",
           "n_samples",
+          "p50",
+          "p90",
+          "p99",
           "squared_mean",
           "start_time",
           "sum_of_samples"
@@ -19243,22 +19234,28 @@
             "minimum": 0
           },
           "p50": {
-            "nullable": true,
             "description": "p50 Quantile",
-            "type": "number",
-            "format": "double"
+            "allOf": [
+              {
+                "$ref": "#/components/schemas/Quantile"
+              }
+            ]
           },
           "p90": {
-            "nullable": true,
             "description": "p95 Quantile",
-            "type": "number",
-            "format": "double"
+            "allOf": [
+              {
+                "$ref": "#/components/schemas/Quantile"
+              }
+            ]
           },
           "p99": {
-            "nullable": true,
             "description": "p99 Quantile",
-            "type": "number",
-            "format": "double"
+            "allOf": [
+              {
+                "$ref": "#/components/schemas/Quantile"
+              }
+            ]
           },
           "squared_mean": {
             "description": "M2 for Welford's algorithm for variance calculation.\n\nRead about [Welford's algorithm](https://en.wikipedia.org/wiki/Algorithms_for_calculating_variance#Welford's_online_algorithm) for more information on the algorithm.",
@@ -19281,6 +19278,9 @@
           "max",
           "min",
           "n_samples",
+          "p50",
+          "p90",
+          "p99",
           "squared_mean",
           "start_time",
           "sum_of_samples"
@@ -19314,22 +19314,28 @@
             "minimum": 0
           },
           "p50": {
-            "nullable": true,
             "description": "p50 Quantile",
-            "type": "number",
-            "format": "double"
+            "allOf": [
+              {
+                "$ref": "#/components/schemas/Quantile"
+              }
+            ]
           },
           "p90": {
-            "nullable": true,
             "description": "p95 Quantile",
-            "type": "number",
-            "format": "double"
+            "allOf": [
+              {
+                "$ref": "#/components/schemas/Quantile"
+              }
+            ]
           },
           "p99": {
-            "nullable": true,
             "description": "p99 Quantile",
-            "type": "number",
-            "format": "double"
+            "allOf": [
+              {
+                "$ref": "#/components/schemas/Quantile"
+              }
+            ]
           },
           "squared_mean": {
             "description": "M2 for Welford's algorithm for variance calculation.\n\nRead about [Welford's algorithm](https://en.wikipedia.org/wiki/Algorithms_for_calculating_variance#Welford's_online_algorithm) for more information on the algorithm.",
@@ -19352,6 +19358,9 @@
           "max",
           "min",
           "n_samples",
+          "p50",
+          "p90",
+          "p99",
           "squared_mean",
           "start_time",
           "sum_of_samples"
@@ -19385,22 +19394,28 @@
             "minimum": 0
           },
           "p50": {
-            "nullable": true,
             "description": "p50 Quantile",
-            "type": "number",
-            "format": "double"
+            "allOf": [
+              {
+                "$ref": "#/components/schemas/Quantile"
+              }
+            ]
           },
           "p90": {
-            "nullable": true,
             "description": "p95 Quantile",
-            "type": "number",
-            "format": "double"
+            "allOf": [
+              {
+                "$ref": "#/components/schemas/Quantile"
+              }
+            ]
           },
           "p99": {
-            "nullable": true,
             "description": "p99 Quantile",
-            "type": "number",
-            "format": "double"
+            "allOf": [
+              {
+                "$ref": "#/components/schemas/Quantile"
+              }
+            ]
           },
           "squared_mean": {
             "description": "M2 for Welford's algorithm for variance calculation.\n\nRead about [Welford's algorithm](https://en.wikipedia.org/wiki/Algorithms_for_calculating_variance#Welford's_online_algorithm) for more information on the algorithm.",
@@ -19423,6 +19438,9 @@
           "max",
           "min",
           "n_samples",
+          "p50",
+          "p90",
+          "p99",
           "squared_mean",
           "start_time",
           "sum_of_samples"
@@ -19456,22 +19474,28 @@
             "minimum": 0
           },
           "p50": {
-            "nullable": true,
             "description": "p50 Quantile",
-            "type": "number",
-            "format": "double"
+            "allOf": [
+              {
+                "$ref": "#/components/schemas/Quantile"
+              }
+            ]
           },
           "p90": {
-            "nullable": true,
             "description": "p95 Quantile",
-            "type": "number",
-            "format": "double"
+            "allOf": [
+              {
+                "$ref": "#/components/schemas/Quantile"
+              }
+            ]
           },
           "p99": {
-            "nullable": true,
             "description": "p99 Quantile",
-            "type": "number",
-            "format": "double"
+            "allOf": [
+              {
+                "$ref": "#/components/schemas/Quantile"
+              }
+            ]
           },
           "squared_mean": {
             "description": "M2 for Welford's algorithm for variance calculation.\n\nRead about [Welford's algorithm](https://en.wikipedia.org/wiki/Algorithms_for_calculating_variance#Welford's_online_algorithm) for more information on the algorithm.",
@@ -19494,6 +19518,9 @@
           "max",
           "min",
           "n_samples",
+          "p50",
+          "p90",
+          "p99",
           "squared_mean",
           "start_time",
           "sum_of_samples"
@@ -19527,22 +19554,28 @@
             "minimum": 0
           },
           "p50": {
-            "nullable": true,
             "description": "p50 Quantile",
-            "type": "number",
-            "format": "double"
+            "allOf": [
+              {
+                "$ref": "#/components/schemas/Quantile"
+              }
+            ]
           },
           "p90": {
-            "nullable": true,
             "description": "p95 Quantile",
-            "type": "number",
-            "format": "double"
+            "allOf": [
+              {
+                "$ref": "#/components/schemas/Quantile"
+              }
+            ]
           },
           "p99": {
-            "nullable": true,
             "description": "p99 Quantile",
-            "type": "number",
-            "format": "double"
+            "allOf": [
+              {
+                "$ref": "#/components/schemas/Quantile"
+              }
+            ]
           },
           "squared_mean": {
             "description": "M2 for Welford's algorithm for variance calculation.\n\nRead about [Welford's algorithm](https://en.wikipedia.org/wiki/Algorithms_for_calculating_variance#Welford's_online_algorithm) for more information on the algorithm.",
@@ -19565,6 +19598,9 @@
           "max",
           "min",
           "n_samples",
+          "p50",
+          "p90",
+          "p99",
           "squared_mean",
           "start_time",
           "sum_of_samples"
@@ -19600,22 +19636,28 @@
             "minimum": 0
           },
           "p50": {
-            "nullable": true,
             "description": "p50 Quantile",
-            "type": "number",
-            "format": "double"
+            "allOf": [
+              {
+                "$ref": "#/components/schemas/Quantile"
+              }
+            ]
           },
           "p90": {
-            "nullable": true,
             "description": "p95 Quantile",
-            "type": "number",
-            "format": "double"
+            "allOf": [
+              {
+                "$ref": "#/components/schemas/Quantile"
+              }
+            ]
           },
           "p99": {
-            "nullable": true,
             "description": "p99 Quantile",
-            "type": "number",
-            "format": "double"
+            "allOf": [
+              {
+                "$ref": "#/components/schemas/Quantile"
+              }
+            ]
           },
           "squared_mean": {
             "description": "M2 for Welford's algorithm for variance calculation.\n\nRead about [Welford's algorithm](https://en.wikipedia.org/wiki/Algorithms_for_calculating_variance#Welford's_online_algorithm) for more information on the algorithm.",
@@ -19638,6 +19680,9 @@
           "max",
           "min",
           "n_samples",
+          "p50",
+          "p90",
+          "p99",
           "squared_mean",
           "start_time",
           "sum_of_samples"
@@ -19673,22 +19718,28 @@
             "minimum": 0
           },
           "p50": {
-            "nullable": true,
             "description": "p50 Quantile",
-            "type": "number",
-            "format": "double"
+            "allOf": [
+              {
+                "$ref": "#/components/schemas/Quantile"
+              }
+            ]
           },
           "p90": {
-            "nullable": true,
             "description": "p95 Quantile",
-            "type": "number",
-            "format": "double"
+            "allOf": [
+              {
+                "$ref": "#/components/schemas/Quantile"
+              }
+            ]
           },
           "p99": {
-            "nullable": true,
             "description": "p99 Quantile",
-            "type": "number",
-            "format": "double"
+            "allOf": [
+              {
+                "$ref": "#/components/schemas/Quantile"
+              }
+            ]
           },
           "squared_mean": {
             "description": "M2 for Welford's algorithm for variance calculation.\n\nRead about [Welford's algorithm](https://en.wikipedia.org/wiki/Algorithms_for_calculating_variance#Welford's_online_algorithm) for more information on the algorithm.",
@@ -19711,6 +19762,9 @@
           "max",
           "min",
           "n_samples",
+          "p50",
+          "p90",
+          "p99",
           "squared_mean",
           "start_time",
           "sum_of_samples"
@@ -19746,22 +19800,28 @@
             "minimum": 0
           },
           "p50": {
-            "nullable": true,
             "description": "p50 Quantile",
-            "type": "number",
-            "format": "double"
+            "allOf": [
+              {
+                "$ref": "#/components/schemas/Quantile"
+              }
+            ]
           },
           "p90": {
-            "nullable": true,
             "description": "p95 Quantile",
-            "type": "number",
-            "format": "double"
+            "allOf": [
+              {
+                "$ref": "#/components/schemas/Quantile"
+              }
+            ]
           },
           "p99": {
-            "nullable": true,
             "description": "p99 Quantile",
-            "type": "number",
-            "format": "double"
+            "allOf": [
+              {
+                "$ref": "#/components/schemas/Quantile"
+              }
+            ]
           },
           "squared_mean": {
             "description": "M2 for Welford's algorithm for variance calculation.\n\nRead about [Welford's algorithm](https://en.wikipedia.org/wiki/Algorithms_for_calculating_variance#Welford's_online_algorithm) for more information on the algorithm.",
@@ -19784,6 +19844,9 @@
           "max",
           "min",
           "n_samples",
+          "p50",
+          "p90",
+          "p99",
           "squared_mean",
           "start_time",
           "sum_of_samples"
@@ -19819,22 +19882,28 @@
             "minimum": 0
           },
           "p50": {
-            "nullable": true,
             "description": "p50 Quantile",
-            "type": "number",
-            "format": "double"
+            "allOf": [
+              {
+                "$ref": "#/components/schemas/Quantile"
+              }
+            ]
           },
           "p90": {
-            "nullable": true,
             "description": "p95 Quantile",
-            "type": "number",
-            "format": "double"
+            "allOf": [
+              {
+                "$ref": "#/components/schemas/Quantile"
+              }
+            ]
           },
           "p99": {
-            "nullable": true,
             "description": "p99 Quantile",
-            "type": "number",
-            "format": "double"
+            "allOf": [
+              {
+                "$ref": "#/components/schemas/Quantile"
+              }
+            ]
           },
           "squared_mean": {
             "description": "M2 for Welford's algorithm for variance calculation.\n\nRead about [Welford's algorithm](https://en.wikipedia.org/wiki/Algorithms_for_calculating_variance#Welford's_online_algorithm) for more information on the algorithm.",
@@ -19857,6 +19926,9 @@
           "max",
           "min",
           "n_samples",
+          "p50",
+          "p90",
+          "p99",
           "squared_mean",
           "start_time",
           "sum_of_samples"

--- a/oximeter/oxql-types/src/point.rs
+++ b/oximeter/oxql-types/src/point.rs
@@ -1670,9 +1670,26 @@ pub struct Distribution<T: DistributionSupport> {
     max: Option<T>,
     sum_of_samples: T,
     squared_mean: f64,
+    #[serde(serialize_with = "serialize_quantile")]
+    #[schemars(with = "Option<f64>")]
     p50: Option<Quantile>,
+    #[serde(serialize_with = "serialize_quantile")]
+    #[schemars(with = "Option<f64>")]
     p90: Option<Quantile>,
+    #[serde(serialize_with = "serialize_quantile")]
+    #[schemars(with = "Option<f64>")]
     p99: Option<Quantile>,
+}
+
+/// Simplify quantiles to an estimate to abstract the details of the algorithm from the user.
+fn serialize_quantile<S>(
+    q: &Option<Quantile>,
+    serializer: S,
+) -> Result<S::Ok, S::Error>
+where
+    S: serde::Serializer,
+{
+    q.and_then(|quantile| quantile.estimate().ok()).serialize(serializer)
 }
 
 impl<T> fmt::Display for Distribution<T>

--- a/oximeter/types/src/histogram.rs
+++ b/oximeter/types/src/histogram.rs
@@ -299,14 +299,6 @@ pub struct Bin<T> {
 /// implement conversion(s).
 struct Bins<T>(Vec<Bin<T>>);
 
-/// Simplify quantiles to an estimate to abstract the details of the algorithm from the user.
-fn serialize_quantile<S>(q: &Quantile, serializer: S) -> Result<S::Ok, S::Error>
-where
-    S: serde::Serializer,
-{
-    q.estimate().ok().serialize(serializer)
-}
-
 /// Histogram metric
 ///
 /// A histogram maintains the count of any number of samples, over a set of bins. Bins are
@@ -390,16 +382,10 @@ where
     /// for more information on the algorithm.
     squared_mean: f64,
     /// p50 Quantile
-    #[serde(serialize_with = "serialize_quantile")]
-    #[schemars(with = "Option<f64>")]
     p50: Quantile,
     /// p95 Quantile
-    #[serde(serialize_with = "serialize_quantile")]
-    #[schemars(with = "Option<f64>")]
     p90: Quantile,
     /// p99 Quantile
-    #[serde(serialize_with = "serialize_quantile")]
-    #[schemars(with = "Option<f64>")]
     p99: Quantile,
 }
 


### PR DESCRIPTION
Simplify oximeter histogram responses to show the estimates for each quantile, rather than details of the P² algorithm.

Part of #9345.

Notes:
* If we're only showing the quantile estimates and not other details of the algorithm, we could also simplify our clickhouse queries for histograms. We can add this here, or get to it separately later on.
* This is technically a breaking change, in the event that customers are using quantile fields in histograms—although I'm inclined to doubt they are, because I don't think we document how to use those fields. Not sure if this is a problem, but wanted to note it.