### PR TITLE
nexus: make oximeter database pool size configurable.

### DIFF
--- a/nexus-config/src/nexus_config.rs
+++ b/nexus-config/src/nexus_config.rs
@@ -254,6 +254,9 @@ pub struct TimeseriesDbConfig {
     /// The native TCP address of the ClickHouse server.
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub address: Option<SocketAddr>,
+    /// The max size of the connection pool.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub max_slots: Option<usize>,
 }
 
 /// Configuration for the `Dendrite` dataplane daemon.


### PR DESCRIPTION
We use qorb as the connection pooler for ClickHouse within oximeter, and inherit the default pool max_slots of 16. We may be saturating that pool size for some OxQL workloads, such as the proposed otel receiver, which runs many tiny queries in parallel against ClickHouse. This patch makes the pool size configurable, so that we can adjust it if necessary.