### PR TITLE
oximeter: consistent logging for producer/consumer details.

### DIFF
--- a/oximeter/collector/src/collection_task.rs
+++ b/oximeter/collector/src/collection_task.rs
@@ -381,6 +381,8 @@ impl CollectionTaskHandle {
         let log = log.new(o!(
             "component" => "collection-task-handle",
             "producer_id" => producer.id.to_string(),
+            "producer_ip" => producer.address.ip().to_string(),
+            "producer_port" => producer.address.port(),
         ));
         Self { notifiers, log }
     }
@@ -536,6 +538,8 @@ impl CollectionTask {
         let log = log.new(o!(
             "component" => "collection-task",
             "producer_id" => producer.id.to_string(),
+            "producer_ip" => producer.address.ip().to_string(),
+            "producer_port" => producer.address.port(),
         ));
 
         // Watch channel for changes to the producer's endpoint information.


### PR DESCRIPTION
Nit: Update CollectionTask logs to include the producer ip and port, to match oximeter stats and consumer details in the existing logs.

This isn't important—I just noticed a mismatch between producer/consumer logging attributes, and we also include consumer details in oximeter's metrics about itself.