### PR TITLE
Fix omdb support-bundles download --output

### DIFF
--- a/dev-tools/omdb/src/bin/omdb/nexus.rs
+++ b/dev-tools/omdb/src/bin/omdb/nexus.rs
@@ -4500,13 +4500,18 @@ async fn cmd_nexus_support_bundles_download(
     let stream =
         support_bundle_download_ranges(client, args.id, start, total_length);
 
+    let mut open_opts = OpenOptions::new();
+    open_opts.create(true);
+
     let sink: Box<dyn std::io::Write> = match &args.output {
         Some(path) => Box::new(
-            OpenOptions::new()
-                .create(true)
-                .append(true)
-                .truncate(!args.resume)
-                .open(path)?,
+            if args.resume {
+                open_opts.append(true)
+            } else {
+                open_opts.write(true).truncate(true)
+            }
+            .open(path)
+            .with_context(|| format!("failed to create {path}"))?,
         ),
         None => Box::new(std::io::stdout()),
     };


### PR DESCRIPTION
I noticed we were unable to save a support bundle when passing an output location.
```
root@oxz_switch1:~# omdb nexus support-bundles list
note: Nexus URL not specified.  Will pick one from DNS.
note: using DNS server for subnet fd00:1122:3344::/48
note: (if this is not right, use --dns-server to specify an alternate DNS server)
note: using Nexus URL http://[fd00:1122:3344:102::5]:12232
ID                                   TIME_CREATED                   REASON_FOR_CREATION     REASON_FOR_FAILURE STATE  USER_COMMENT
e3adf9b8-f16a-4d89-b8c9-d1de6e888b89 2025-11-12 16:38:21.171665 UTC Created by internal API -                  Active -


root@oxz_switch1:~# omdb nexus support-bundles download -o /root/support-bundle.zip e3adf9b8-f16a-4d89-b8c9-d1de6e888b89
note: Nexus URL not specified.  Will pick one from DNS.
note: using DNS server for subnet fd00:1122:3344::/48
note: (if this is not right, use --dns-server to specify an alternate DNS server)
note: using Nexus URL http://[fd00:1122:3344:102::5]:12232
Error: Invalid argument (os error 22)
```

I spent some time with DTrace and truss but I couldn't find any calls to `open(2)` where an actual `EINVAL` was being returned. After some further inspection it turns out[ Rust is making up this `EINVAL`](
https://github.com/rust-lang/rust/blob/1159e78c4747b02ef996e55082b704c09b970588/library/std/src/sys/fs/unix.rs#L1129-L1142) on it's own rather then passing the open flags to the `open(2)` call.


```rust
    fn get_creation_mode(&self) -> io::Result<c_int> {
        match (self.write, self.append) {
            (true, false) => {}
            (false, false) => {
                if self.truncate || self.create || self.create_new {
                    return Err(Error::from_raw_os_error(libc::EINVAL));
                }
            }
            (_, true) => {
                if self.truncate && !self.create_new {
                    return Err(Error::from_raw_os_error(libc::EINVAL));
                }
            }
        }
```