### PR TITLE
[ereport-types] less ugly `Display` impl for `EreportId`

### DIFF
--- a/ereport/types/src/lib.rs
+++ b/ereport/types/src/lib.rs
@@ -110,7 +110,7 @@ pub struct EreportId {
 
 impl fmt::Display for EreportId {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        write!(f, "{:?}:{:x}", self.restart_id, self.ena)
+        write!(f, "{}:{:x}", self.restart_id, self.ena.0)
     }
 }
 


### PR DESCRIPTION
The `Display` impl for `EreportId` was _supposed_ to format the ereport ID as `{uuid}:{ena}`. Unfortunately, I mixed up which of the `Debug` and `Display` impls for `TypedUuid` was the one that included the type tag, so currently, it looks like this instead:

```
acb6b01f-5a41-46e2-81bd-2a908051acb3 (ereporter_restart):0x2
```

which, IMO, looks Kinda Bad.

This branch changes it slightly to use the `Display` impl for the
`TypedUuid` so that there's no unslightly ` (ereporter_restart)`
included in the output. I've also formatted the underlying u64 from the
`Ena` so that it doesn't have an `0x` prefix, since the UUID makes it
pretty obvious that the whole string is hex.

Now it should look more like this:

```
acb6b01f-5a41-46e2-81bd-2a908051acb3:2 
```

Which, IMO, is much nicer.