### PR TITLE
Change LocalStorage dataset to non-zoned

### DIFF
--- a/common/src/api/internal/shared.rs
+++ b/common/src/api/internal/shared.rs
@@ -1012,9 +1012,9 @@ impl DatasetKind {
             Cockroach | Crucible | Clickhouse | ClickhouseKeeper
             | ClickhouseServer | ExternalDns | InternalDns => true,
 
-            TransientZoneRoot | TransientZone { .. } | Debug => false,
-
-            LocalStorage => false,
+            TransientZoneRoot | TransientZone { .. } | Debug | LocalStorage => {
+                false
+            }
         }
     }
 


### PR DESCRIPTION
I misunderstood the meaning of the `zoned` function on DatasetKind. Correct this by returning false for LocalStorage.