### PR TITLE
BlueprintBuilder: remove SledEditor::baseboard_id()

### DIFF
--- a/nexus/reconfigurator/planning/src/blueprint_builder/builder.rs
+++ b/nexus/reconfigurator/planning/src/blueprint_builder/builder.rs
@@ -631,7 +631,6 @@ impl<'a> BlueprintBuilder<'a> {
                             )
                         })?;
                     SledEditor::for_existing_active(
-                        Arc::new(details.baseboard_id.clone()),
                         details.resources.subnet,
                         sled_cfg.clone(),
                     )
@@ -652,7 +651,6 @@ impl<'a> BlueprintBuilder<'a> {
         for (sled_id, details) in input.all_sleds(SledFilter::Commissioned) {
             if let Entry::Vacant(slot) = sled_editors.entry(sled_id) {
                 slot.insert(SledEditor::for_new_active(
-                    Arc::new(details.baseboard_id.clone()),
                     details.resources.subnet,
                 ));
             }
@@ -1299,6 +1297,7 @@ impl<'a> BlueprintBuilder<'a> {
     pub(crate) fn sled_ensure_mupdate_override(
         &mut self,
         sled_id: SledUuid,
+        baseboard_id: &BaseboardId,
         // inv_mupdate_override_info has a weird type (not Option<&T>, not &str)
         // because this is what `Result::as_ref` returns.
         inv_mupdate_override_info: Result<
@@ -1310,13 +1309,6 @@ impl<'a> BlueprintBuilder<'a> {
         let editor = self.sled_editors.get_mut(&sled_id).ok_or_else(|| {
             Error::Planner(anyhow!(
                 "tried to ensure mupdate override for unknown sled {sled_id}"
-            ))
-        })?;
-        let baseboard_id = editor.baseboard_id().ok_or_else(|| {
-            // All commissioned sleds have baseboards; this should never fail.
-            Error::Planner(anyhow!(
-                "tried to ensure mupdate override for \
-                 decommissioned sled {sled_id}"
             ))
         })?;
 

--- a/nexus/reconfigurator/planning/src/planner.rs
+++ b/nexus/reconfigurator/planning/src/planner.rs
@@ -1835,7 +1835,9 @@ impl<'a> Planner<'a> {
 
         // We use the list of in-service sleds here -- we don't want to alter
         // expunged or decommissioned sleds.
-        for sled_id in self.input.all_sled_ids(SledFilter::InService) {
+        for (sled_id, sled_details) in
+            self.input.all_sleds(SledFilter::InService)
+        {
             let log = log.new(o!("sled_id" => sled_id.to_string()));
             let Some(inv_sled) = self.inventory.sled_agents.get(&sled_id)
             else {
@@ -1844,6 +1846,7 @@ impl<'a> Planner<'a> {
             };
             let action = self.blueprint.sled_ensure_mupdate_override(
                 sled_id,
+                &sled_details.baseboard_id,
                 inv_sled
                     .zone_image_resolver
                     .mupdate_override


### PR DESCRIPTION
`SledEditor` was storing each sled's baseboard ID, but:

* it's only available via `PlanningInput`, and putting it directly into the blueprint is difficult for mostly-irrelevant reasons
* there was only one caller of `SledEditor::baseboard_id()`: `sled_ensure_mupdate_override()` (to match up sled ID <-> baseboard ID)
* `sled_ensure_mupdate_override()` itself only has one caller, the planner, which already knows the baseboard ID of the sled it's ensuring

So this PR removes `SledEditor::baseboard_id()` entirely, and has the planner pass the baseboard ID in. (On the update watercooler today we also mentioned the possibility of a separate `BlueprintBuilder::clear_pending_mgs_updates(baseboard_id)` method, but that's tricky to implement because some nontrivial logic for "should we clear pending MGS updates" is nested inside `SledEditor` itself.)