### PR TITLE
Make `UnstableReconfiguratorState::target_blueprint` non-optional

### DIFF
--- a/dev-tools/omdb/src/bin/omdb/reconfigurator.rs
+++ b/dev-tools/omdb/src/bin/omdb/reconfigurator.rs
@@ -202,14 +202,7 @@ async fn cmd_reconfigurator_archive(
     //    successfully archived some blueprints before hitting this error. We
     //    attempt to notice this and log a message for the operator in this
     //    case.
-    let target_blueprint_id = saved_state
-        .target_blueprint
-        .context(
-            "system has no current target blueprint: \
-             cannot remove non-target blueprints",
-        )?
-        .target_id;
-
+    let target_blueprint_id = saved_state.target_blueprint.target_id;
     let mut ndeleted = 0;
 
     eprintln!("removing saved, non-target blueprints ...");

--- a/dev-tools/reconfigurator-cli/src/lib.rs
+++ b/dev-tools/reconfigurator-cli/src/lib.rs
@@ -2121,12 +2121,12 @@ fn cmd_blueprint_list(
     let mut rows = state.system().all_blueprints().collect::<Vec<_>>();
     rows.sort_unstable_by_key(|blueprint| blueprint.time_created);
     let rows = rows.into_iter().map(|blueprint| {
-        let (is_target, enabled) = match target_blueprint {
-            Some(t) if t.target_id == blueprint.id => {
-                let enabled = if t.enabled { "yes" } else { "no" };
-                ("*", enabled)
-            }
-            _ => ("", ""),
+        let (is_target, enabled) = if target_blueprint.target_id == blueprint.id
+        {
+            let enabled = if target_blueprint.enabled { "yes" } else { "no" };
+            ("*", enabled)
+        } else {
+            ("", "")
         };
         BlueprintRow {
             is_target,

--- a/dev-tools/reconfigurator-cli/tests/output/cmds-stdout
+++ b/dev-tools/reconfigurator-cli/tests/output/cmds-stdout
@@ -11,7 +11,8 @@ ID SERIAL NZPOOLS SUBNET
 ID NERRORS TIME_DONE 
 
 > blueprint-list
-T ENA ID PARENT TIME_CREATED 
+T ENA ID                                   PARENT TIME_CREATED             
+* no  00000000-0000-0000-0000-000000000000 <none> <REDACTED_TIMESTAMP> 
 
 
 > sled-show dde1c0e2-b10d-4621-b420-f179f7a7a00a
@@ -863,14 +864,12 @@ wiped system
 
 > load state.json
 loaded data from "state.json"
-warnings:
-  could not determine active Nexus generation from serialized state: no target blueprint set (using default of 1)
 result:
   system:
     using collection 6e066695-94bc-4250-bd63-fd799c166cc1 as source of sled inventory data
     loaded sleds: 04ef3330-c682-4a08-8def-fcc4bef31bcd, 90c1102a-b9f5-4d88-92a2-60d54a2d98cc, dde1c0e2-b10d-4621-b420-f179f7a7a00a
     loaded collections: 6e066695-94bc-4250-bd63-fd799c166cc1
-    loaded blueprints: (none)
+    loaded blueprints: 00000000-0000-0000-0000-000000000000
     loaded external IP policy: ExternalIpPolicy { service_pool_ipv4_ranges: [Ipv4Range { first: 192.0.2.2, last: 192.0.2.20 }], service_pool_ipv6_ranges: [], external_dns_ips: {} }
     loaded internal DNS generations: (none)
     loaded external DNS generations: (none)

--- a/nexus/reconfigurator/preparation/src/lib.rs
+++ b/nexus/reconfigurator/preparation/src/lib.rs
@@ -582,7 +582,7 @@ pub async fn reconfigurator_state_load(
     Ok(UnstableReconfiguratorState {
         planning_input,
         collections,
-        target_blueprint: Some(target_blueprint),
+        target_blueprint,
         blueprints,
         internal_dns,
         external_dns,

--- a/nexus/reconfigurator/simulation/src/errors.rs
+++ b/nexus/reconfigurator/simulation/src/errors.rs
@@ -105,10 +105,6 @@ impl KeyError {
         Self { id: ObjectId::Collection(id) }
     }
 
-    pub(crate) fn blueprint(id: BlueprintId) -> Self {
-        Self { id: ObjectId::Blueprint(id) }
-    }
-
     pub(crate) fn resolved_collection(id: ResolvedCollectionId) -> Self {
         Self { id: ObjectId::ResolvedCollection(id) }
     }

--- a/nexus/reconfigurator/simulation/src/state.rs
+++ b/nexus/reconfigurator/simulation/src/state.rs
@@ -237,7 +237,7 @@ impl SimStateBuilder {
             state.external_dns_zone_names.clone(),
             state.silo_names.clone(),
             state.planning_input.active_nexus_zones(),
-            state.target_blueprint.as_ref(),
+            &state.target_blueprint,
             &state.blueprints,
             &mut res,
         );

--- a/nexus/reconfigurator/simulation/src/system.rs
+++ b/nexus/reconfigurator/simulation/src/system.rs
@@ -6,9 +6,11 @@
 
 use std::{collections::BTreeMap, fmt, sync::Arc};
 
-use chrono::Utc;
+use chrono::{DateTime, Utc};
 use indexmap::IndexMap;
+use itertools::Either;
 use nexus_reconfigurator_planning::{
+    blueprint_builder::BlueprintBuilder,
     example::ExampleSystem,
     system::{SledHwInventory, SystemDescription},
 };
@@ -77,14 +79,8 @@ pub struct SimSystem {
     /// Stored with `Arc` to allow cheap cloning.
     collections: IndexMap<CollectionUuid, Arc<Collection>>,
 
-    /// Blueprints created by the user. Invariant: the `IndexMap` is ordered by
-    /// time created.
-    ///
-    /// Stored with `Arc` to allow cheap cloning.
-    blueprints: IndexMap<BlueprintUuid, Arc<Blueprint>>,
-
-    /// Current target blueprint.
-    target_blueprint: Option<BlueprintTarget>,
+    /// Internal blueprint state.
+    blueprints: SimBlueprintState,
 
     /// Internal DNS configurations.
     ///
@@ -97,13 +93,140 @@ pub struct SimSystem {
     external_dns: BTreeMap<Generation, Arc<DnsConfigParams>>,
 }
 
+#[derive(Clone, Debug)]
+enum SimBlueprintState {
+    Empty(Arc<Blueprint>),
+    Nonempty {
+        /// Blueprints created by the user. Invariant: the `IndexMap` is ordered
+        /// by time created.
+        ///
+        /// Stored with `Arc` to allow cheap cloning.
+        blueprints: IndexMap<BlueprintUuid, Arc<Blueprint>>,
+
+        /// Current target blueprint.
+        target: BlueprintTarget,
+    },
+}
+
+impl SimBlueprintState {
+    /// Every real system always has a target blueprint set. We'd like that to
+    /// be true for simulated systems, too, but also we'd like to be able to
+    /// start from an "empty" simulated system. Any time our empty simulated
+    /// system is asked for information about its blueprints, it will claim it
+    /// has exactly one blueprint: itself empty, with the special all-zeroes ID
+    /// (so it sticks out like a sore thumb in any output).
+    fn empty() -> Self {
+        let mut blueprint = BlueprintBuilder::build_empty("reconfigurator-sim");
+        blueprint.id = BlueprintUuid::nil();
+        Self::Empty(Arc::new(blueprint))
+    }
+
+    /// Create a simulated blueprint state containing a single blueprint (the
+    /// target).
+    fn sole_target(blueprint: Arc<Blueprint>) -> Self {
+        let target = BlueprintTarget {
+            target_id: blueprint.id,
+            enabled: true,
+            time_made_target: blueprint.time_created,
+        };
+
+        let mut blueprints = IndexMap::new();
+        blueprints.insert(blueprint.id, blueprint);
+
+        Self::Nonempty { blueprints, target }
+    }
+
+    fn target(&self) -> BlueprintTarget {
+        match self {
+            SimBlueprintState::Empty(blueprint) => BlueprintTarget {
+                target_id: blueprint.id,
+                enabled: false,
+                time_made_target: DateTime::UNIX_EPOCH,
+            },
+            SimBlueprintState::Nonempty { target, .. } => *target,
+        }
+    }
+
+    fn latest(&self) -> &Arc<Blueprint> {
+        match self {
+            SimBlueprintState::Empty(blueprint) => &blueprint,
+            SimBlueprintState::Nonempty { blueprints, .. } => {
+                // The invariant of `blueprints` is that the last element is
+                // the latest.
+                blueprints
+                    .last()
+                    .expect(
+                        "SimBlueprintState::Nonempty always has \
+                         at least one blueprint",
+                    )
+                    .1
+            }
+        }
+    }
+
+    fn get(&self, id: &BlueprintUuid) -> Option<&Arc<Blueprint>> {
+        match self {
+            SimBlueprintState::Empty(blueprint) => {
+                (*id == blueprint.id).then_some(blueprint)
+            }
+            SimBlueprintState::Nonempty { blueprints, .. } => {
+                blueprints.get(id)
+            }
+        }
+    }
+
+    pub fn all_blueprints(&self) -> impl ExactSizeIterator<Item = &Blueprint> {
+        match self {
+            SimBlueprintState::Empty(blueprint) => {
+                Either::Left(std::iter::once(&**blueprint))
+            }
+            SimBlueprintState::Nonempty { blueprints, .. } => {
+                Either::Right(blueprints.values().map(|b| &**b))
+            }
+        }
+    }
+
+    pub fn add_blueprint(
+        &mut self,
+        blueprint: Arc<Blueprint>,
+    ) -> Result<(), DuplicateError> {
+        let blueprint_id = blueprint.id;
+        let time_created = blueprint.time_created;
+
+        match self {
+            SimBlueprintState::Empty(existing) => {
+                if existing.id == blueprint_id {
+                    return Err(DuplicateError::blueprint(BlueprintId::Id(
+                        blueprint_id,
+                    )));
+                }
+
+                *self = Self::sole_target(blueprint);
+                Ok(())
+            }
+            SimBlueprintState::Nonempty { blueprints, .. } => {
+                match insert_sorted_by(
+                    blueprints,
+                    blueprint_id,
+                    blueprint,
+                    |_, other| other.time_created <= time_created,
+                ) {
+                    Ok(()) => Ok(()),
+                    Err(_) => Err(DuplicateError::blueprint(BlueprintId::Id(
+                        blueprint_id,
+                    ))),
+                }
+            }
+        }
+    }
+}
+
 impl SimSystem {
     pub fn new() -> Self {
         Self {
             description: SystemDescription::new(),
             collections: IndexMap::new(),
-            blueprints: IndexMap::new(),
-            target_blueprint: None,
+            blueprints: SimBlueprintState::empty(),
             internal_dns: BTreeMap::new(),
             external_dns: BTreeMap::new(),
         }
@@ -112,10 +235,9 @@ impl SimSystem {
     pub fn is_empty(&self) -> bool {
         !self.description.has_sleds()
             && self.collections.is_empty()
-            && self.blueprints.is_empty()
-            && self.target_blueprint.is_none()
             && self.internal_dns.is_empty()
             && self.external_dns.is_empty()
+            && matches!(self.blueprints, SimBlueprintState::Empty(_))
     }
 
     #[inline]
@@ -163,20 +285,8 @@ impl SimSystem {
         original: BlueprintId,
     ) -> Result<ResolvedBlueprintId, KeyError> {
         let resolved = match original {
-            BlueprintId::Target => {
-                self.target_blueprint
-                    .ok_or_else(|| KeyError::blueprint(original))?
-                    .target_id
-            }
-            BlueprintId::Latest => {
-                // The invariant of self.blueprints is that the last element is
-                // the latest.
-                let (id, _) = self
-                    .blueprints
-                    .last()
-                    .ok_or_else(|| KeyError::blueprint(original))?;
-                *id
-            }
+            BlueprintId::Target => self.blueprints.target().target_id,
+            BlueprintId::Latest => self.blueprints.latest().id,
             BlueprintId::Id(id) => id,
         };
         Ok(ResolvedBlueprintId { original, resolved })
@@ -204,12 +314,12 @@ impl SimSystem {
         self.get_blueprint(&id)
     }
 
-    pub fn target_blueprint(&self) -> Option<BlueprintTarget> {
-        self.target_blueprint
+    pub fn target_blueprint(&self) -> BlueprintTarget {
+        self.blueprints.target()
     }
 
     pub fn all_blueprints(&self) -> impl ExactSizeIterator<Item = &Blueprint> {
-        self.blueprints.values().map(|b| &**b)
+        self.blueprints.all_blueprints()
     }
 
     pub fn get_internal_dns(
@@ -714,25 +824,20 @@ impl SimSystemBuilderInner {
         let initial_blueprint_id = example.initial_blueprint.id;
         let target_blueprint_id = blueprint.id;
 
-        self.add_blueprint_inner(Arc::new(example.initial_blueprint))
-            .expect("already checked that system is empty");
-
-        self.system.target_blueprint = Some(BlueprintTarget {
-            target_id: target_blueprint_id,
-            enabled: true,
-            time_made_target: blueprint.time_created,
-        });
+        self.system.blueprints =
+            SimBlueprintState::sole_target(Arc::new(blueprint));
 
         // XXX: it's not normal, but hypothetically possible, that the initial
         // and target blueprints have the same ID. This will panic if so. Maybe
         // we should make it not panic.
-        self.add_blueprint_inner(Arc::new(blueprint)).unwrap_or_else(|_| {
-            panic!(
-                "possible conflict between initial blueprint \
+        self.add_blueprint_inner(Arc::new(example.initial_blueprint))
+            .unwrap_or_else(|_| {
+                panic!(
+                    "possible conflict between initial blueprint \
                  (ID {initial_blueprint_id}) and target blueprint \
-                 (ID {target_blueprint_id}"
-            )
-        });
+                 (ID {target_blueprint_id})"
+                )
+            });
     }
 
     // This method MUST be infallible. It should only be called after checking
@@ -864,7 +969,10 @@ impl SimSystemBuilderInner {
             }
         }
 
-        self.system.target_blueprint = state.target_blueprint;
+        self.system.blueprints = SimBlueprintState::Nonempty {
+            blueprints: IndexMap::new(),
+            target: state.target_blueprint,
+        };
 
         for blueprint in state.blueprints {
             let blueprint_id = blueprint.id;
@@ -921,20 +1029,7 @@ impl SimSystemBuilderInner {
         &mut self,
         blueprint: Arc<Blueprint>,
     ) -> Result<(), DuplicateError> {
-        let blueprint_id = blueprint.id;
-        let time_created = blueprint.time_created;
-
-        match insert_sorted_by(
-            &mut self.system.blueprints,
-            blueprint_id,
-            blueprint,
-            |_, other| other.time_created <= time_created,
-        ) {
-            Ok(()) => Ok(()),
-            Err(_) => {
-                Err(DuplicateError::blueprint(BlueprintId::Id(blueprint_id)))
-            }
-        }
+        self.system.blueprints.add_blueprint(blueprint)
     }
 
     fn add_internal_dns_inner(

--- a/nexus/types/src/deployment.rs
+++ b/nexus/types/src/deployment.rs
@@ -2382,12 +2382,7 @@ impl From<&crate::inventory::Dataset> for CollectionDatasetIdentifier {
 pub struct UnstableReconfiguratorState {
     pub planning_input: PlanningInput,
     pub collections: Vec<Collection>,
-    // When collected from a deployed system, `target_blueprint` will always be
-    // `Some(_)`. `UnstableReconfiguratorState` is also used by
-    // `reconfigurator-cli`, which allows construction of states that do not
-    // represent a fully-deployed system (and maybe no blueprints at all, hence
-    // no target blueprint).
-    pub target_blueprint: Option<BlueprintTarget>,
+    pub target_blueprint: BlueprintTarget,
     pub blueprints: Vec<Blueprint>,
     pub internal_dns: BTreeMap<Generation, DnsConfigParams>,
     pub external_dns: BTreeMap<Generation, DnsConfigParams>,


### PR DESCRIPTION
`UnstableReconfiguratorState`s constructed from real systems always supplied a target blueprint, because real systems are required to always have one. We'd kept this as optional to allow for `reconfigurator-cli`'s simulated system to not have a blueprint at all, but I'd like to make other changes related to the `PlanningInput` that trip over this difference.

This PR addresses the simulator side by having it claim to have a blueprint with the nil ID and containing nothing any time it's asked for the current list of blueprints or current target blueprint and one hasn't otherwise been set (i.e., by loading an example system or an existing serialized state).

(Staged on top of #9417)