### PR TITLE
[nexus-test-interface] make get_*_address non-async

### DIFF
--- a/dev-tools/omicron-dev/src/main.rs
+++ b/dev-tools/omicron-dev/src/main.rs
@@ -114,11 +114,11 @@ impl RunAllArgs {
         println!("omicron-dev: nexus external API:     {:?}", addr);
         println!(
             "omicron-dev: nexus internal API:     {:?}",
-            cptestctx.server.get_http_server_internal_address().await,
+            cptestctx.server.get_http_server_internal_address(),
         );
         println!(
             "omicron-dev: nexus lockstep API:     {:?}",
-            cptestctx.server.get_http_server_lockstep_address().await,
+            cptestctx.server.get_http_server_lockstep_address(),
         );
         println!(
             "omicron-dev: cockroachdb pid:        {}",

--- a/nexus/src/app/mod.rs
+++ b/nexus/src/app/mod.rs
@@ -836,7 +836,7 @@ impl Nexus {
         Ok(())
     }
 
-    pub(crate) async fn get_external_server_address(
+    pub(crate) fn get_external_server_address(
         &self,
     ) -> Option<std::net::SocketAddr> {
         self.external_server
@@ -846,7 +846,7 @@ impl Nexus {
             .map(|server| server.local_addr())
     }
 
-    pub(crate) async fn get_techport_server_address(
+    pub(crate) fn get_techport_server_address(
         &self,
     ) -> Option<std::net::SocketAddr> {
         self.techport_external_server
@@ -856,7 +856,7 @@ impl Nexus {
             .map(|server| server.local_addr())
     }
 
-    pub(crate) async fn get_internal_server_address(
+    pub(crate) fn get_internal_server_address(
         &self,
     ) -> Option<std::net::SocketAddr> {
         self.internal_server
@@ -866,7 +866,7 @@ impl Nexus {
             .map(|server| server.local_addr())
     }
 
-    pub(crate) async fn get_lockstep_server_address(
+    pub(crate) fn get_lockstep_server_address(
         &self,
     ) -> Option<std::net::SocketAddr> {
         self.lockstep_server

--- a/nexus/src/app/quiesce.rs
+++ b/nexus/src/app/quiesce.rs
@@ -631,7 +631,7 @@ mod test {
         let log = &cptestctx.logctx.log;
         let nexus_lockstep_url = format!(
             "http://{}",
-            cptestctx.server.get_http_server_lockstep_address().await
+            cptestctx.server.get_http_server_lockstep_address(),
         );
         let nexus_client = nexus_lockstep_client::Client::new(
             &nexus_lockstep_url,
@@ -663,7 +663,7 @@ mod test {
         let log = &cptestctx.logctx.log;
         let nexus_lockstep_url = format!(
             "http://{}",
-            cptestctx.server.get_http_server_lockstep_address().await
+            cptestctx.server.get_http_server_lockstep_address(),
         );
         let nexus_client = nexus_lockstep_client::Client::new(
             &nexus_lockstep_url,

--- a/nexus/src/lib.rs
+++ b/nexus/src/lib.rs
@@ -418,20 +418,20 @@ impl nexus_test_interface::NexusServer for Server {
         self.apictx.context.nexus.inventory_load_rx()
     }
 
-    async fn get_http_server_external_address(&self) -> SocketAddr {
-        self.apictx.context.nexus.get_external_server_address().await.unwrap()
+    fn get_http_server_external_address(&self) -> SocketAddr {
+        self.apictx.context.nexus.get_external_server_address().unwrap()
     }
 
-    async fn get_http_server_techport_address(&self) -> SocketAddr {
-        self.apictx.context.nexus.get_techport_server_address().await.unwrap()
+    fn get_http_server_techport_address(&self) -> SocketAddr {
+        self.apictx.context.nexus.get_techport_server_address().unwrap()
     }
 
-    async fn get_http_server_internal_address(&self) -> SocketAddr {
-        self.apictx.context.nexus.get_internal_server_address().await.unwrap()
+    fn get_http_server_internal_address(&self) -> SocketAddr {
+        self.apictx.context.nexus.get_internal_server_address().unwrap()
     }
 
-    async fn get_http_server_lockstep_address(&self) -> SocketAddr {
-        self.apictx.context.nexus.get_lockstep_server_address().await.unwrap()
+    fn get_http_server_lockstep_address(&self) -> SocketAddr {
+        self.apictx.context.nexus.get_lockstep_server_address().unwrap()
     }
 
     async fn upsert_test_dataset(

--- a/nexus/test-interface/src/lib.rs
+++ b/nexus/test-interface/src/lib.rs
@@ -88,10 +88,10 @@ pub trait NexusServer: Send + Sync + 'static {
 
     fn inventory_load_rx(&self) -> watch::Receiver<Option<Arc<Collection>>>;
 
-    async fn get_http_server_external_address(&self) -> SocketAddr;
-    async fn get_http_server_techport_address(&self) -> SocketAddr;
-    async fn get_http_server_internal_address(&self) -> SocketAddr;
-    async fn get_http_server_lockstep_address(&self) -> SocketAddr;
+    fn get_http_server_external_address(&self) -> SocketAddr;
+    fn get_http_server_techport_address(&self) -> SocketAddr;
+    fn get_http_server_internal_address(&self) -> SocketAddr;
+    fn get_http_server_lockstep_address(&self) -> SocketAddr;
 
     // Previously, as a dataset was created (within the sled agent),
     // we'd use an internal API from Nexus to record that the dataset

--- a/nexus/test-utils/src/lib.rs
+++ b/nexus/test-utils/src/lib.rs
@@ -1171,14 +1171,11 @@ impl<'a, N: NexusServer> ControlPlaneTestContextBuilder<'a, N> {
         )
         .await;
 
-        let external_server_addr =
-            server.get_http_server_external_address().await;
+        let external_server_addr = server.get_http_server_external_address();
         let techport_external_server_addr =
-            server.get_http_server_techport_address().await;
-        let internal_server_addr =
-            server.get_http_server_internal_address().await;
-        let lockstep_server_addr =
-            server.get_http_server_lockstep_address().await;
+            server.get_http_server_techport_address();
+        let internal_server_addr = server.get_http_server_internal_address();
+        let lockstep_server_addr = server.get_http_server_lockstep_address();
         let testctx_external = ClientTestContext::new(
             external_server_addr,
             self.logctx

--- a/nexus/tests/integration_tests/demo_saga.rs
+++ b/nexus/tests/integration_tests/demo_saga.rs
@@ -23,7 +23,7 @@ async fn test_demo_saga(cptestctx: &ControlPlaneTestContext) {
     let log = &cptestctx.logctx.log;
     let nexus_lockstep_url = format!(
         "http://{}",
-        cptestctx.server.get_http_server_lockstep_address().await
+        cptestctx.server.get_http_server_lockstep_address(),
     );
     let nexus_client =
         nexus_lockstep_client::Client::new(&nexus_lockstep_url, log.clone());

--- a/nexus/tests/integration_tests/instances.rs
+++ b/nexus/tests/integration_tests/instances.rs
@@ -1129,8 +1129,7 @@ async fn test_instance_migration_compatible_cpu_platforms(
     // Set up a second sled-agent representing a sled with a Turin processor.
     // The instance itself requires only Milan, so it should be able to migrate
     // both directions.
-    let nexus_address =
-        cptestctx.server.get_http_server_internal_address().await;
+    let nexus_address = cptestctx.server.get_http_server_internal_address();
 
     let config = omicron_sled_agent::sim::Config::for_testing(
         SledUuid::new_v4(),
@@ -1319,8 +1318,7 @@ async fn test_instance_migration_incompatible_cpu_platforms(
 
     // Set up a second sled-agent representing a sled with a Turin processor.
     // The instance will require Turin, so it will be placed here.
-    let nexus_address =
-        cptestctx.server.get_http_server_internal_address().await;
+    let nexus_address = cptestctx.server.get_http_server_internal_address();
 
     let config = omicron_sled_agent::sim::Config::for_testing(
         SledUuid::new_v4(),
@@ -1397,8 +1395,7 @@ async fn test_instance_migration_unknown_sled_type(
 
     // Set up a second sled-agent representing a sled with unknown processor
     // type. We won't be able to migrate to (or from) here.
-    let nexus_address =
-        cptestctx.server.get_http_server_internal_address().await;
+    let nexus_address = cptestctx.server.get_http_server_internal_address();
 
     let config = omicron_sled_agent::sim::Config::for_testing(
         SledUuid::new_v4(),
@@ -6737,8 +6734,7 @@ async fn test_can_start_instance_with_cpu_platform(
         1
     );
 
-    let nexus_address =
-        cptestctx.server.get_http_server_internal_address().await;
+    let nexus_address = cptestctx.server.get_http_server_internal_address();
 
     let config = omicron_sled_agent::sim::Config::for_testing(
         SledUuid::new_v4(),

--- a/nexus/tests/integration_tests/oximeter.rs
+++ b/nexus/tests/integration_tests/oximeter.rs
@@ -226,7 +226,7 @@ async fn test_oximeter_reregistration() {
     // Restart the producer, and verify that we have _more_ data than before
     // Set up a test metric producer server
     context.producer = nexus_test_utils::start_producer_server(
-        context.server.get_http_server_internal_address().await,
+        context.server.get_http_server_internal_address(),
         nexus_test_utils::PRODUCER_UUID.parse().unwrap(),
     )
     .expect("Failed to restart metric producer server");
@@ -303,7 +303,7 @@ async fn test_oximeter_reregistration() {
     // Restart oximeter again, and verify that we have even more new data.
     context.oximeter = nexus_test_utils::start_oximeter(
         context.logctx.log.new(o!("component" => "oximeter")),
-        context.server.get_http_server_internal_address().await,
+        context.server.get_http_server_internal_address(),
         context.clickhouse.native_address().port(),
         oximeter_id,
     )

--- a/nexus/tests/integration_tests/quiesce.rs
+++ b/nexus/tests/integration_tests/quiesce.rs
@@ -30,7 +30,7 @@ async fn test_quiesce(cptestctx: &ControlPlaneTestContext) {
     let opctx = OpContext::for_tests(log.clone(), datastore.clone());
     let nexus_lockstep_url = format!(
         "http://{}",
-        cptestctx.server.get_http_server_lockstep_address().await
+        cptestctx.server.get_http_server_lockstep_address(),
     );
     let nexus_client =
         nexus_lockstep_client::Client::new(&nexus_lockstep_url, log.clone());

--- a/nexus/tests/integration_tests/sleds.rs
+++ b/nexus/tests/integration_tests/sleds.rs
@@ -66,7 +66,7 @@ async fn test_sleds_list(cptestctx: &ControlPlaneTestContext) {
         let sa_id = SledUuid::new_v4();
         let log =
             cptestctx.logctx.log.new(o!( "sled_id" => sa_id.to_string() ));
-        let addr = cptestctx.server.get_http_server_internal_address().await;
+        let addr = cptestctx.server.get_http_server_internal_address();
         let update_directory = Utf8Path::new("/should/not/be/used");
         sas.push(
             start_sled_agent(


### PR DESCRIPTION
No need for these to be async, they just return values from memory.
