### PR TITLE
Update hubtools for fixed `verify` function

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3919,7 +3919,7 @@ dependencies = [
  "gateway-messages",
  "hex",
  "hubpack",
- "hubtools",
+ "hubtools 0.4.6",
  "lru-cache",
  "lzss",
  "nix 0.27.1",
@@ -4726,6 +4726,27 @@ dependencies = [
 name = "hubtools"
 version = "0.4.6"
 source = "git+https://github.com/oxidecomputer/hubtools.git?branch=main#cec2560e9a0126e9e687d51b385a57891abc87c3"
+dependencies = [
+ "digest",
+ "hex",
+ "lpc55_areas",
+ "lpc55_sign",
+ "object 0.30.4",
+ "path-slash",
+ "rsa",
+ "thiserror 1.0.69",
+ "tlvc 0.3.1 (git+https://github.com/oxidecomputer/tlvc)",
+ "tlvc-text",
+ "toml 0.7.8",
+ "x509-cert",
+ "zerocopy 0.6.6",
+ "zip 0.6.6",
+]
+
+[[package]]
+name = "hubtools"
+version = "0.4.7"
+source = "git+https://github.com/oxidecomputer/hubtools.git?rev=2b1ef9b38d75563ea800baa3b17327eec17b1b7a#2b1ef9b38d75563ea800baa3b17327eec17b1b7a"
 dependencies = [
  "digest",
  "hex",
@@ -6118,7 +6139,7 @@ dependencies = [
 [[package]]
 name = "lpc55_areas"
 version = "0.2.5"
-source = "git+https://github.com/oxidecomputer/lpc55_support#b507bc6d5dbebabc1d4c9b1ea3c8f24afd68fcae"
+source = "git+https://github.com/oxidecomputer/lpc55_support#205d47d497aa59985136b3c5eddaa0a39da203a2"
 dependencies = [
  "bitfield",
  "clap",
@@ -6128,8 +6149,8 @@ dependencies = [
 
 [[package]]
 name = "lpc55_sign"
-version = "0.3.4"
-source = "git+https://github.com/oxidecomputer/lpc55_support#b507bc6d5dbebabc1d4c9b1ea3c8f24afd68fcae"
+version = "0.3.5"
+source = "git+https://github.com/oxidecomputer/lpc55_support#205d47d497aa59985136b3c5eddaa0a39da203a2"
 dependencies = [
  "byteorder",
  "const-oid",
@@ -7015,7 +7036,7 @@ dependencies = [
  "gateway-test-utils",
  "gateway-types",
  "http",
- "hubtools",
+ "hubtools 0.4.7",
  "iddqd",
  "internal-dns-resolver",
  "internal-dns-types",
@@ -8264,7 +8285,7 @@ dependencies = [
  "http-body-util",
  "httpmock",
  "httptest",
- "hubtools",
+ "hubtools 0.4.7",
  "hyper",
  "hyper-rustls",
  "hyper-staticfile",
@@ -13341,7 +13362,7 @@ dependencies = [
  "gateway-messages",
  "gateway-types",
  "hex",
- "hubtools",
+ "hubtools 0.4.7",
  "nexus-types",
  "nix 0.30.1",
  "omicron-common",
@@ -15032,7 +15053,7 @@ dependencies = [
  "fs-err 2.11.0",
  "futures",
  "hex",
- "hubtools",
+ "hubtools 0.4.6",
  "indent_write",
  "itertools 0.13.0",
  "parse-size",
@@ -15377,7 +15398,7 @@ dependencies = [
  "fs-err 3.1.1",
  "futures",
  "hex",
- "hubtools",
+ "hubtools 0.4.7",
  "omicron-common",
  "omicron-test-utils",
  "omicron-workspace-hack",
@@ -16068,7 +16089,7 @@ dependencies = [
  "hickory-resolver 0.25.2",
  "http",
  "http-body-util",
- "hubtools",
+ "hubtools 0.4.7",
  "hyper",
  "illumos-utils",
  "installinator",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -496,7 +496,7 @@ http-body-util = "0.1.3"
 http-range = "0.1.5"
 httpmock = "0.8.0-alpha.1"
 httptest = "0.16.3"
-hubtools = { git = "https://github.com/oxidecomputer/hubtools.git", branch = "main" }
+hubtools = { git = "https://github.com/oxidecomputer/hubtools.git", rev = "2b1ef9b38d75563ea800baa3b17327eec17b1b7a" }
 humantime = "2.2.0"
 hyper = "1.6.0"
 hyper-util = "0.1.16"


### PR DESCRIPTION
Some refactoring in a dependent lpc55 crate accidentally dropped a check against the root key table hash on the RoT. This resulted in `archive.verify` incorrectly passing in places like wicketd and selecting incorrect RoT images for installation.