### PR TITLE
commonize logging and error handling in `blueprint_planner` task

### DIFF
--- a/nexus/src/app/background/tasks/blueprint_planner.rs
+++ b/nexus/src/app/background/tasks/blueprint_planner.rs
@@ -32,13 +32,13 @@ use tokio::sync::watch::{self, Receiver, Sender};
 /// Error type for blueprint planning operations.
 #[derive(Debug, thiserror::Error)]
 enum PlanError {
-    // Warning-level errors
+    // Warning-level problems
     #[error("no target blueprint available")]
     NoTargetBlueprint,
     #[error("no inventory collection available")]
     NoInventoryCollection,
 
-    // Error-level errors
+    // Error-level problems
     #[error("failed to assemble planning input")]
     AssemblePlanningInput(#[source] Error),
     #[error("failed to make planner")]


### PR DESCRIPTION
I'm looking at updating this task for #7278 and found that it'd be helpful to commonize the logging and error handling paths (since I'll be adding a couple more).  The only behavioral changes here should be limited to slight changes in the text of some log messages or task status messages.