### PR TITLE
rename DumpSetup to DebugCollector

### DIFF
--- a/sled-agent/config-reconciler/src/handle.rs
+++ b/sled-agent/config-reconciler/src/handle.rs
@@ -50,8 +50,8 @@ use crate::SledAgentFacilities;
 use crate::TimeSyncStatus;
 use crate::dataset_serialization_task::DatasetTaskHandle;
 use crate::dataset_serialization_task::NestedDatasetMountError;
-use crate::dump_setup_task;
-use crate::dump_setup_task::FormerZoneRootArchiver;
+use crate::debug_collector_task;
+use crate::debug_collector_task::FormerZoneRootArchiver;
 use crate::internal_disks::InternalDisksReceiver;
 use crate::ledger::CurrentSledConfig;
 use crate::ledger::LedgerTaskHandle;
@@ -136,7 +136,7 @@ impl ConfigReconcilerHandle {
         // Spawn the task that manages dump devices.
         let (external_disks_tx, external_disks_rx) =
             watch::channel(HashSet::new());
-        let former_zone_root_archiver = dump_setup_task::spawn(
+        let former_zone_root_archiver = debug_collector_task::spawn(
             internal_disks_rx.clone(),
             external_disks_rx,
             Arc::clone(&mount_config),

--- a/sled-agent/config-reconciler/src/lib.rs
+++ b/sled-agent/config-reconciler/src/lib.rs
@@ -46,9 +46,9 @@
 //!   [`ConfigReconcilerHandle::inventory()`].
 
 mod dataset_serialization_task;
+mod debug_collector;
+mod debug_collector_task;
 mod disks_common;
-mod dump_setup;
-mod dump_setup_task;
 mod handle;
 mod host_phase_2;
 mod internal_disks;

--- a/sled-agent/config-reconciler/src/reconciler_task.rs
+++ b/sled-agent/config-reconciler/src/reconciler_task.rs
@@ -42,7 +42,7 @@ use crate::InternalDisksReceiver;
 use crate::SledAgentArtifactStore;
 use crate::TimeSyncConfig;
 use crate::dataset_serialization_task::DatasetTaskHandle;
-use crate::dump_setup_task::FormerZoneRootArchiver;
+use crate::debug_collector_task::FormerZoneRootArchiver;
 use crate::host_phase_2::BootPartitionReconciler;
 use crate::ledger::CurrentSledConfig;
 use crate::raw_disks::RawDisksReceiver;

--- a/sled-agent/config-reconciler/src/reconciler_task/external_disks.rs
+++ b/sled-agent/config-reconciler/src/reconciler_task/external_disks.rs
@@ -45,9 +45,9 @@ use std::sync::Arc;
 use std::sync::OnceLock;
 use tokio::sync::watch;
 
+use crate::debug_collector_task::FormerZoneRootArchiver;
 use crate::disks_common::MaybeUpdatedDisk;
 use crate::disks_common::update_properties_from_raw_disk;
-use crate::dump_setup_task::FormerZoneRootArchiver;
 use camino::Utf8PathBuf;
 use illumos_utils::zfs::Mountpoint;
 
@@ -238,7 +238,7 @@ pub(super) struct ExternalDisks {
     currently_managed_zpools_tx: watch::Sender<Arc<CurrentlyManagedZpools>>,
 
     // Output channel for the raw disks we're managing. This is only consumed
-    // within this crate by `DumpSetupTask` (for managing dump devices).
+    // within this crate by `DebugCollectorTask` (for managing dump devices).
     external_disks_tx: watch::Sender<HashSet<Disk>>,
 
     // For requesting archival of former zone root directories.
@@ -501,8 +501,8 @@ impl ExternalDisks {
 
         // Update the output channels now.  This is important to do before
         // cleaning up former zone root datasets because that step will require
-        // that the archival task (DumpSetup) has seen the new disks and added
-        // any debug datasets found on them.
+        // that the archival task (DebugCollector) has seen the new disks and
+        // added any debug datasets found on them.
         self.update_output_watch_channels();
 
         // For any newly-adopted disks, clean up any former zone root datasets

--- a/sled-agent/config-reconciler/src/reconciler_task/zones.rs
+++ b/sled-agent/config-reconciler/src/reconciler_task/zones.rs
@@ -11,7 +11,7 @@ use crate::InternalDisks;
 use crate::ResolverStatusExt;
 use crate::SledAgentFacilities;
 use crate::TimeSyncConfig;
-use crate::dump_setup_task::FormerZoneRootArchiver;
+use crate::debug_collector_task::FormerZoneRootArchiver;
 use camino::Utf8PathBuf;
 use futures::FutureExt as _;
 use futures::future;

--- a/sled-agent/src/zone_bundle.rs
+++ b/sled-agent/src/zone_bundle.rs
@@ -670,7 +670,8 @@ async fn create_snapshot(
 // A key feature of the zone-bundle process is that we pull all the log files
 // for a zone. This is tricky. The logs are both being written to by the
 // programs we're interested in, and also potentially being rotated by `logadm`,
-// and / or archived out to the U.2s through the code in `crate::dump_setup`.
+// and / or archived out to the U.2s through the code in
+// `crate::debug_collector`.
 //
 // We need to capture all these logs, while avoiding inconsistent state (e.g., a
 // missing log message that existed when the bundle was created) and also
@@ -1033,8 +1034,8 @@ async fn create(
     //
     // Both of these are dynamic. The current log file is likely being written
     // by the service itself, and `logadm` may also be rotating files. At the
-    // same time, the log-archival process in `dump_setup.rs` may be copying
-    // these out to the U.2s, after which it deletes those on the zone
+    // same time, the log-archival process in `debug_collector.rs` may be
+    // copying these out to the U.2s, after which it deletes those on the zone
     // filesystem itself.
     //
     // To avoid various kinds of corruption, such as a bad tarball or missing
@@ -1261,7 +1262,7 @@ async fn find_archived_log_files<'a, T: Iterator<Item = &'a Utf8PathBuf>>(
                 }
             }
         } else {
-            // The logic in `dump_setup` picks some U.2 in which to start
+            // The logic in `debug_collector` picks some U.2 in which to start
             // archiving logs, and thereafter tries to keep placing new ones
             // there, subject to space constraints. It's not really an error for
             // there to be no entries for the named zone in any particular U.2

--- a/sled-agent/types/src/support_bundle.rs
+++ b/sled-agent/types/src/support_bundle.rs
@@ -13,9 +13,9 @@
 //                              |               | This is a per-bundle nested dataset
 //                              | This is a Debug dataset
 //
-// NOTE: The "DumpSetupWorker" has been explicitly configured to ignore these files, so they are
-// not removed. If the files used here change in the future, DumpSetupWorker should also be
-// updated.
+// NOTE: The DebugCollector has been explicitly configured to ignore these
+// files, so they are not removed. If the files used here change in the future,
+// DebugCollector should also be updated.
 pub const BUNDLE_FILE_NAME: &str = "bundle.zip";
 pub const BUNDLE_TMP_FILE_NAME: &str = "bundle.zip.tmp";
 


### PR DESCRIPTION
I assume when this module was initially named, all it did was set up a dump device.  But now it does a whole lot more: it runs savecore to save those dumps, it configures coreadm, it archives log files from zones, it deletes old data, etc.  What's common to all of it is that it's managing the collection and archival of debug data (kernel crash dumps, process core dumps, log files, and soon other debug data).  I propose calling it `DebugCollector`.

This PR does not change any behavior.  It just renames the Rust modules (which requires renaming files), a few Rust types, a few local variables, and a function.  It also updates a few comments.