### PR TITLE
[nexus] refactor SP ereport processing into `nexus-types`

### DIFF
--- a/nexus/types/src/fm/ereport.rs
+++ b/nexus/types/src/fm/ereport.rs
@@ -6,6 +6,7 @@
 
 use crate::inventory::SpType;
 use chrono::{DateTime, Utc};
+use omicron_uuid_kinds::EreporterRestartUuid;
 use omicron_uuid_kinds::OmicronZoneUuid;
 use omicron_uuid_kinds::SledUuid;
 use serde::Deserialize;
@@ -35,6 +36,91 @@ pub struct EreportData {
     pub report: serde_json::Value,
 }
 
+impl EreportData {
+    /// Interpret a service processor ereport from a raw JSON blobule, plus the
+    /// restart ID and collection metadata.
+    ///
+    /// This conversion is lossy; if some information is not present in the raw
+    /// ereport JSON, such as the SP's VPD identity, we log a warning, rather
+    /// than returning an error, and leave those fields empty in the returned
+    /// `EreportData`. This is because, if we receive an ereport that is
+    /// incomplete, we would still like to preserve whatever information *is*
+    /// present, rather than throwing the whole thing away. Thus, this function
+    /// also takes a `slog::Logger` for logging warnings if some expected fields
+    /// are not present or malformed.
+    pub fn from_sp_ereport(
+        log: &slog::Logger,
+        restart_id: EreporterRestartUuid,
+        ereport: ereport_types::Ereport,
+        time_collected: DateTime<Utc>,
+        collector_id: OmicronZoneUuid,
+    ) -> Self {
+        const MISSING_VPD: &str = " (perhaps the SP doesn't know its own VPD?)";
+        let part_number = get_sp_metadata_string(
+            "baseboard_part_number",
+            &ereport,
+            &restart_id,
+            &log,
+            MISSING_VPD,
+        );
+        let serial_number = get_sp_metadata_string(
+            "baseboard_serial_number",
+            &ereport,
+            &restart_id,
+            &log,
+            MISSING_VPD,
+        );
+        let ena = ereport.ena;
+        let class = ereport
+            .data
+            // "k" (for "kind") is used as an abbreviation of
+            // "class" to save 4 bytes of ereport.
+            .get("k")
+            .or_else(|| ereport.data.get("class"));
+        let class = match (class, ereport.data.get("lost")) {
+            (Some(serde_json::Value::String(class)), _) => {
+                Some(class.to_string())
+            }
+            (Some(v), _) => {
+                slog::warn!(
+                    &log,
+                    "malformed ereport: value for 'k'/'class' \
+                     should be a string, but found: {v:?}";
+                    "ena" => ?ena,
+                    "restart_id" => ?restart_id,
+                );
+                None
+            }
+            // This is a loss record! I know this!
+            (None, Some(serde_json::Value::Null)) => {
+                Some("ereport.data_loss.possible".to_string())
+            }
+            (None, Some(serde_json::Value::Number(_))) => {
+                Some("ereport.data_loss.certain".to_string())
+            }
+            (None, _) => {
+                slog::warn!(
+                    &log,
+                    "ereport missing 'k'/'class' key";
+                    "ena" => ?ena,
+                    "restart_id" => ?restart_id,
+                );
+                None
+            }
+        };
+
+        EreportData {
+            id: EreportId { restart_id, ena },
+            time_collected,
+            collector_id,
+            part_number,
+            serial_number,
+            class,
+            report: serde_json::Value::Object(ereport.data),
+        }
+    }
+}
+
 /// Describes the source of an ereport.
 #[derive(
     Copy, Clone, Debug, Eq, PartialEq, Ord, PartialOrd, Serialize, Deserialize,
@@ -60,6 +146,41 @@ impl fmt::Display for Reporter {
             Self::HostOs { sled } => {
                 write!(f, "Sled (OS) {sled:?}")
             }
+        }
+    }
+}
+
+/// Attempt to extract a VPD metadata from an SP ereport, logging a warning if
+/// it's missing. We still want to keep such ereports, as the error condition
+/// could be that the SP couldn't determine the metadata field, but it's
+/// uncomfortable, so we ought to complain about it.
+fn get_sp_metadata_string(
+    key: &str,
+    ereport: &ereport_types::Ereport,
+    restart_id: &EreporterRestartUuid,
+    log: &slog::Logger,
+    extra_context: &'static str,
+) -> Option<String> {
+    match ereport.data.get(key) {
+        Some(serde_json::Value::String(s)) => Some(s.clone()),
+        Some(v) => {
+            slog::warn!(
+                &log,
+                "malformed ereport: value for '{key}' should be a string, \
+                 but found: {v:?}";
+                "ena" => ?ereport.ena,
+                "restart_id" => ?restart_id,
+            );
+            None
+        }
+        None => {
+            slog::warn!(
+                &log,
+                "ereport missing '{key}'{extra_context}";
+                "ena" => ?ereport.ena,
+                "restart_id" => ?restart_id,
+            );
+            None
         }
     }
 }


### PR DESCRIPTION
This commit moves the code that processes raw JSON representations of SP ereports from the `ereport_ingester` background task to `nexus_types::fm::ereport`. While a production system will only perform this processing when an ereport is received from a service processor via MGS in the `ereprot_ingester` task, I'd like to be able to also invoke the same logic with hard-coded example JSON ereports for test purposes. Currently, the test code for diagnosis engines in #9346 implemented its own version of this which was slightly different from the ereport_ingester version, so I've moved it to here so that we can use the same logic when processing test inputs.

Note that this change was cherry-picked from #9346, where I had actually written tests that needed to use this logic. I figured it was a small and uncontroversial enough refactor (that makes no functional change whatsoever) to pull it out to merge now, in an attempt to keep that branch from getting even bigger and touching even more files.