### PR TITLE
[simulated omicron] Display sled agent address

### DIFF
--- a/dev-tools/omicron-dev/src/main.rs
+++ b/dev-tools/omicron-dev/src/main.rs
@@ -121,6 +121,10 @@ impl RunAllArgs {
             cptestctx.server.get_http_server_lockstep_address(),
         );
         println!(
+            "omicron-dev: sled agent API:         http://{:?}",
+            cptestctx.sled_agents[0].local_addr(),
+        );
+        println!(
             "omicron-dev: cockroachdb pid:        {}",
             cptestctx.database.pid(),
         );

--- a/nexus/test-utils/src/starter.rs
+++ b/nexus/test-utils/src/starter.rs
@@ -1870,8 +1870,6 @@ pub async fn start_sled_agent_with_config(
         sim::Server::start(&config, &log, true, simulated_upstairs, sled_index)
             .await
             .map_err(|e| e.to_string())?;
-
-    eprintln!("Sled agent address: {:?}", server.http_server.local_addr());
     Ok(server)
 }
 


### PR DESCRIPTION
This patch adds the sled agent address to the initial output when starting up a simulated omicron. I've done this in a similar manner as to how the DB address is displayed.

```
$ cargo xtask omicron-dev run-all
<...>
omicron-dev: setting up all services ... 
log file: /tmp/omicron-dev-omicron-dev.18697.0.log
note: configured to log to "/tmp/omicron-dev-omicron-dev.18697.0.log"
DB URL: postgresql://root@[::1]:64671/omicron?sslmode=disable
DB address: [::1]:64671
log file: /tmp/omicron-dev-omicron-dev.18697.2.log
note: configured to log to "/tmp/omicron-dev-omicron-dev.18697.2.log"
Sled agent address: [::1]:35925
omicron-dev: Adding disks to first sled agent
omicron-dev: services are running.
omicron-dev: nexus external API:     127.0.0.1:12220
omicron-dev: nexus internal API:     [::1]:12221
omicron-dev: nexus lockstep API:     [::1]:12232
omicron-dev: cockroachdb pid:        18706
omicron-dev: cockroachdb URL:        postgresql://root@[::1]:64671/omicron?sslmode=disable
omicron-dev: cockroachdb directory:  /tmp/.tmpdd1mDX
omicron-dev: clickhouse native addr: [::1]:53824
omicron-dev: clickhouse http addr:   [::1]:63310
omicron-dev: internal DNS HTTP:      http://[::1]:55005
omicron-dev: internal DNS:           [::1]:49384
omicron-dev: external DNS name:      oxide-dev.test
omicron-dev: external DNS HTTP:      http://[::1]:61727
omicron-dev: external DNS:           [::1]:48201
omicron-dev:   e.g. `dig @::1 -p 48201 test-suite-silo.sys.oxide-dev.test`
omicron-dev: management gateway:     http://[::1]:38919 (switch0)
omicron-dev: silo name:              test-suite-silo
omicron-dev: privileged user name:   test-privileged
omicron-dev: privileged password:    oxide

```

I've constantly found myself having to check omdb to get the sled agent address. It was a little annoying. I think sled agent is important enough to warrant showing it's address when the simulated omicron is started.
