### PR TITLE
Add .DS_Store to .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -18,3 +18,4 @@ tags
 .img/*
 connectivity-report.json
 *.local
+.DS_Store


### PR DESCRIPTION
These files are left all over the filesystem by the macOS Finder; they're always noise.