### PR TITLE
TQ: don't claim tasks panicked when they haven't

### DIFF
--- a/trust-quorum/src/connection_manager.rs
+++ b/trust-quorum/src/connection_manager.rs
@@ -502,7 +502,14 @@ impl ConnMgr {
                         Some(self.on_task_exit(task_id))
                     }
                     Err(err) => {
-                        warn!(self.log, "Connection task panic: {err}");
+                        if err.is_panic() {
+                            warn!(self.log, "Connection task panic: {err}");
+                        } else {
+                            debug!(
+                                self.log,
+                                "Connection task {} cancelled", err.id(),
+                            );
+                        }
                         Some(self.on_task_exit(err.id()))
                     }
                 }


### PR DESCRIPTION
`tokio::task::JoinSet::join_next_with_id` can return a `JoinError` if a task has panicked _or_ if a task sapwned on the `JoinSet` was aborted through its `AbortHandle`...which the trust-quorum `ConnectionManager` will do when disconnecting a client connection:
https://github.com/oxidecomputer/omicron/blob/e00aabaee707ae1fab7203d72c0243f8dacf5403/trust-quorum/src/connection_manager.rs#L866-L886

This is a normal operation and probably deserves to be logged at a less verbose level than `Warn`, and the log line which suggests both cancelled _and_ panicked `JoinError`s are panics is incorrect. This is a potential red herring while debugging, so I've changed it to be more accurate.