### PR TITLE
Update testing measurements for local sprockets configuration

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -13624,7 +13624,7 @@ dependencies = [
 [[package]]
 name = "sprockets-tls"
 version = "0.1.0"
-source = "git+https://github.com/oxidecomputer/sprockets.git?rev=dea3bbfac7d9d3c45f088898fcd05ee5d2ec2210#dea3bbfac7d9d3c45f088898fcd05ee5d2ec2210"
+source = "git+https://github.com/oxidecomputer/sprockets.git?rev=1b01d737447c6c72380a5fe51ebb1dd0f111de1f#1b01d737447c6c72380a5fe51ebb1dd0f111de1f"
 dependencies = [
  "anyhow",
  "attest-data 0.4.0",
@@ -13657,7 +13657,7 @@ dependencies = [
 [[package]]
 name = "sprockets-tls-test-utils"
 version = "0.1.0"
-source = "git+https://github.com/oxidecomputer/sprockets.git?rev=dea3bbfac7d9d3c45f088898fcd05ee5d2ec2210#dea3bbfac7d9d3c45f088898fcd05ee5d2ec2210"
+source = "git+https://github.com/oxidecomputer/sprockets.git?rev=1b01d737447c6c72380a5fe51ebb1dd0f111de1f#1b01d737447c6c72380a5fe51ebb1dd0f111de1f"
 dependencies = [
  "camino",
  "pki-playground",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -763,8 +763,8 @@ slog-term = "2.9.1"
 smf = "0.2"
 socket2 = { version = "0.5", features = ["all"] }
 sp-sim = { path = "sp-sim" }
-sprockets-tls = { git = "https://github.com/oxidecomputer/sprockets.git", rev = "dea3bbfac7d9d3c45f088898fcd05ee5d2ec2210" }
-sprockets-tls-test-utils = { git = "https://github.com/oxidecomputer/sprockets.git", rev = "dea3bbfac7d9d3c45f088898fcd05ee5d2ec2210" }
+sprockets-tls = { git = "https://github.com/oxidecomputer/sprockets.git", rev = "1b01d737447c6c72380a5fe51ebb1dd0f111de1f" }
+sprockets-tls-test-utils = { git = "https://github.com/oxidecomputer/sprockets.git", rev = "1b01d737447c6c72380a5fe51ebb1dd0f111de1f" }
 sqlformat = "0.3.5"
 sqlparser = { version = "0.45.0", features = [ "visitor" ] }
 static_assertions = "1.1.0"

--- a/sled-agent/zone-images/src/install_dataset_metadata.rs
+++ b/sled-agent/zone-images/src/install_dataset_metadata.rs
@@ -39,11 +39,11 @@ where
     where
         F: Fn(&Utf8Path) -> Result<Option<T>, InstallMetadataReadError>,
     {
-        let boot_dataset_dir =
-            internal_disks.boot_disk_install_dataset().join(subdir);
+        let boot_dataset_dir = internal_disks.boot_disk_install_dataset();
 
         // Read the file from the boot disk.
-        let boot_disk_path = boot_dataset_dir.join(metadata_file_name);
+        let boot_disk_path =
+            boot_dataset_dir.join(subdir).join(metadata_file_name);
 
         let boot_disk_metadata =
             read_install_metadata_file::<T>(&boot_dataset_dir, &boot_disk_path);
@@ -58,8 +58,7 @@ where
         let non_boot_datasets = internal_disks.non_boot_disk_install_datasets();
         let non_boot_disk_overrides = non_boot_datasets
             .map(|(zpool_id, dataset_dir)| {
-                let dataset_dir = dataset_dir.join(subdir);
-                let path = dataset_dir.join(metadata_file_name);
+                let path = dataset_dir.join(subdir).join(metadata_file_name);
                 let res = read_install_metadata_file::<T>(&dataset_dir, &path);
                 let res =
                     InstallMetadata::new(res, || with_default(&dataset_dir));

--- a/smf/sled-agent/non-gimlet/config.toml
+++ b/smf/sled-agent/non-gimlet/config.toml
@@ -121,5 +121,5 @@ if_exists = "append"
 # See the .kdl file for use with pki-playground for generating
 [sprockets]
 resolve = { which = "local", priv_key = "/opt/oxide/sled-agent/pkg/sprockets-auth.key.pem", cert_chain = "/opt/oxide/sled-agent/pkg/sprockets-chain.pem" }
-attest = { which = "local", priv_key = "/opt/oxide/sled-agent/pkg/sprockets-attest.key.pem", cert_chain = "/opt/oxide/sled-agent/pkg/sprockets-attest-chain.pem", log = "/opt/oxide/sled-agent/pkg/sprockets-log.bin" }
+attest = { which = "local", priv_key = "/opt/oxide/sled-agent/pkg/sprockets-attest.key.pem", cert_chain = "/opt/oxide/sled-agent/pkg/sprockets-attest-chain.pem", log = "/opt/oxide/sled-agent/pkg/sprockets-log.bin", test_corpus = [ "/opt/oxide/sled-agent/pkg/testing-measurements/corim-rot.cbor", "/opt/oxide/sled-agent/pkg/testing-measurements/corim-sp.cbor"] }
 roots = ["/opt/oxide/sled-agent/pkg/root.cert.pem"]

--- a/trust-quorum/src/task.rs
+++ b/trust-quorum/src/task.rs
@@ -900,8 +900,8 @@ mod tests {
                             &alias_key_name,
                         ),
                         cert_chain: certlist_path(dir.clone(), &alias_key_name),
-                        // TODO: We need attest-mock to generate a real log
                         log: dir.join("log.bin"),
+                        test_corpus: vec![dir.join("corim.cbor")],
                     },
                     roots: vec![cert_path(dir.clone(), &root_prefix())],
                 };
@@ -945,6 +945,29 @@ mod tests {
         // Write out the log document to the filesystem
         let out = attest_mock::log::mock(attest_log_doc).unwrap();
         std::fs::write(dir.join("log.bin"), &out).unwrap();
+
+        let corim_doc = attest_mock::corim::Document {
+            vendor: "Test Bed".into(),
+            tag_id: "test-v0.0.99999".into(),
+            id: "corim-test-v0.0.99999".into(),
+            measurements: vec![
+                // fake SP digest from the log
+                attest_mock::corim::Measurement {
+                    mkey: "fake-sp".into(),
+                    algorithm: 10,
+                    digest: "be4df4e085175f3de0c8ac4837e1c2c9a34e8983209dac6b549e94154f7cdd9c".into()
+                },
+                // fake fwid from the cert-chain (this is constant currently)
+                attest_mock::corim::Measurement {
+                    mkey: "fake-fwid".into(),
+                    algorithm: 10,
+                    digest: "72fa8f8ea84a42251031366002cbb36281d0131f78cd680436116a720cdd9de5".into()
+                },
+            ],
+        };
+
+        let corim = attest_mock::corim::mock(corim_doc).unwrap();
+        std::fs::write(dir.join("corim.cbor"), &corim).unwrap();
     }
 
     struct TestSetup {


### PR DESCRIPTION
Sprockets has been updated to take a path in the configuration file for local measurements. Also tweak how the measurement manifest gets synthesized for testing.