### PR TITLE
Update Propolis (again)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -734,7 +734,7 @@ dependencies = [
 [[package]]
 name = "bhyve_api"
 version = "0.0.0"
-source = "git+https://github.com/oxidecomputer/propolis?rev=2dc643742f82d2e072a1281dab23ba2bfdcee440#2dc643742f82d2e072a1281dab23ba2bfdcee440"
+source = "git+https://github.com/oxidecomputer/propolis?rev=ff31c527515d65886e599fc07eb41240aeb767c6#ff31c527515d65886e599fc07eb41240aeb767c6"
 dependencies = [
  "bhyve_api_sys",
  "libc",
@@ -744,7 +744,7 @@ dependencies = [
 [[package]]
 name = "bhyve_api_sys"
 version = "0.0.0"
-source = "git+https://github.com/oxidecomputer/propolis?rev=2dc643742f82d2e072a1281dab23ba2bfdcee440#2dc643742f82d2e072a1281dab23ba2bfdcee440"
+source = "git+https://github.com/oxidecomputer/propolis?rev=ff31c527515d65886e599fc07eb41240aeb767c6#ff31c527515d65886e599fc07eb41240aeb767c6"
 dependencies = [
  "libc",
  "strum 0.26.3",
@@ -8440,7 +8440,7 @@ dependencies = [
  "pq-sys",
  "pretty_assertions",
  "progenitor-client 0.10.0",
- "propolis-client 0.1.0 (git+https://github.com/oxidecomputer/propolis?rev=2dc643742f82d2e072a1281dab23ba2bfdcee440)",
+ "propolis-client 0.1.0 (git+https://github.com/oxidecomputer/propolis?rev=ff31c527515d65886e599fc07eb41240aeb767c6)",
  "qorb",
  "rand 0.9.2",
  "range-requests",
@@ -8878,7 +8878,7 @@ dependencies = [
  "oxnet",
  "pretty_assertions",
  "progenitor 0.10.0",
- "propolis-client 0.1.0 (git+https://github.com/oxidecomputer/propolis?rev=2dc643742f82d2e072a1281dab23ba2bfdcee440)",
+ "propolis-client 0.1.0 (git+https://github.com/oxidecomputer/propolis?rev=ff31c527515d65886e599fc07eb41240aeb767c6)",
  "propolis-mock-server",
  "propolis_api_types",
  "rand 0.9.2",
@@ -10963,7 +10963,28 @@ dependencies = [
 [[package]]
 name = "propolis-client"
 version = "0.1.0"
-source = "git+https://github.com/oxidecomputer/propolis?rev=2dc643742f82d2e072a1281dab23ba2bfdcee440#2dc643742f82d2e072a1281dab23ba2bfdcee440"
+source = "git+https://github.com/oxidecomputer/propolis?rev=fae5334bcad5e864794332c6fed5e6bb9ec88831#fae5334bcad5e864794332c6fed5e6bb9ec88831"
+dependencies = [
+ "async-trait",
+ "base64 0.21.7",
+ "futures",
+ "progenitor 0.8.0",
+ "rand 0.8.5",
+ "reqwest",
+ "schemars 0.8.22",
+ "serde",
+ "serde_json",
+ "slog",
+ "thiserror 1.0.69",
+ "tokio",
+ "tokio-tungstenite 0.21.0",
+ "uuid",
+]
+
+[[package]]
+name = "propolis-client"
+version = "0.1.0"
+source = "git+https://github.com/oxidecomputer/propolis?rev=ff31c527515d65886e599fc07eb41240aeb767c6#ff31c527515d65886e599fc07eb41240aeb767c6"
 dependencies = [
  "async-trait",
  "base64 0.21.7",
@@ -10985,30 +11006,9 @@ dependencies = [
 ]
 
 [[package]]
-name = "propolis-client"
-version = "0.1.0"
-source = "git+https://github.com/oxidecomputer/propolis?rev=fae5334bcad5e864794332c6fed5e6bb9ec88831#fae5334bcad5e864794332c6fed5e6bb9ec88831"
-dependencies = [
- "async-trait",
- "base64 0.21.7",
- "futures",
- "progenitor 0.8.0",
- "rand 0.8.5",
- "reqwest",
- "schemars 0.8.22",
- "serde",
- "serde_json",
- "slog",
- "thiserror 1.0.69",
- "tokio",
- "tokio-tungstenite 0.21.0",
- "uuid",
-]
-
-[[package]]
 name = "propolis-mock-server"
 version = "0.0.0"
-source = "git+https://github.com/oxidecomputer/propolis?rev=2dc643742f82d2e072a1281dab23ba2bfdcee440#2dc643742f82d2e072a1281dab23ba2bfdcee440"
+source = "git+https://github.com/oxidecomputer/propolis?rev=ff31c527515d65886e599fc07eb41240aeb767c6#ff31c527515d65886e599fc07eb41240aeb767c6"
 dependencies = [
  "anyhow",
  "atty",
@@ -11052,7 +11052,7 @@ dependencies = [
 [[package]]
 name = "propolis_api_types"
 version = "0.0.0"
-source = "git+https://github.com/oxidecomputer/propolis?rev=2dc643742f82d2e072a1281dab23ba2bfdcee440#2dc643742f82d2e072a1281dab23ba2bfdcee440"
+source = "git+https://github.com/oxidecomputer/propolis?rev=ff31c527515d65886e599fc07eb41240aeb767c6#ff31c527515d65886e599fc07eb41240aeb767c6"
 dependencies = [
  "crucible-client-types",
  "propolis_types",
@@ -11065,7 +11065,7 @@ dependencies = [
 [[package]]
 name = "propolis_types"
 version = "0.0.0"
-source = "git+https://github.com/oxidecomputer/propolis?rev=2dc643742f82d2e072a1281dab23ba2bfdcee440#2dc643742f82d2e072a1281dab23ba2bfdcee440"
+source = "git+https://github.com/oxidecomputer/propolis?rev=ff31c527515d65886e599fc07eb41240aeb767c6#ff31c527515d65886e599fc07eb41240aeb767c6"
 dependencies = [
  "schemars 0.8.22",
  "serde",
@@ -13009,7 +13009,7 @@ dependencies = [
  "omicron-workspace-hack",
  "oxnet",
  "progenitor 0.10.0",
- "propolis-client 0.1.0 (git+https://github.com/oxidecomputer/propolis?rev=2dc643742f82d2e072a1281dab23ba2bfdcee440)",
+ "propolis-client 0.1.0 (git+https://github.com/oxidecomputer/propolis?rev=ff31c527515d65886e599fc07eb41240aeb767c6)",
  "regress",
  "reqwest",
  "schemars 0.8.22",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -678,10 +678,10 @@ progenitor-client = "0.10.0"
 # NOTE: if you change the pinned revision of the `bhyve_api` and propolis
 # dependencies, you must also update the references in package-manifest.toml to
 # match the new revision.
-bhyve_api = { git = "https://github.com/oxidecomputer/propolis", rev = "2dc643742f82d2e072a1281dab23ba2bfdcee440" }
-propolis_api_types = { git = "https://github.com/oxidecomputer/propolis", rev = "2dc643742f82d2e072a1281dab23ba2bfdcee440" }
-propolis-client = { git = "https://github.com/oxidecomputer/propolis", rev = "2dc643742f82d2e072a1281dab23ba2bfdcee440" }
-propolis-mock-server = { git = "https://github.com/oxidecomputer/propolis", rev = "2dc643742f82d2e072a1281dab23ba2bfdcee440" }
+bhyve_api = { git = "https://github.com/oxidecomputer/propolis", rev = "ff31c527515d65886e599fc07eb41240aeb767c6" }
+propolis_api_types = { git = "https://github.com/oxidecomputer/propolis", rev = "ff31c527515d65886e599fc07eb41240aeb767c6" }
+propolis-client = { git = "https://github.com/oxidecomputer/propolis", rev = "ff31c527515d65886e599fc07eb41240aeb767c6" }
+propolis-mock-server = { git = "https://github.com/oxidecomputer/propolis", rev = "ff31c527515d65886e599fc07eb41240aeb767c6" }
 # NOTE: see above!
 proptest = "1.7.0"
 qorb = "0.4.1"

--- a/package-manifest.toml
+++ b/package-manifest.toml
@@ -638,10 +638,10 @@ service_name = "propolis-server"
 only_for_targets.image = "standard"
 source.type = "prebuilt"
 source.repo = "propolis"
-source.commit = "2dc643742f82d2e072a1281dab23ba2bfdcee440"
+source.commit = "ff31c527515d65886e599fc07eb41240aeb767c6"
 # The SHA256 digest is automatically posted to:
 # https://buildomat.eng.oxide.computer/public/file/oxidecomputer/propolis/image/<commit>/propolis-server.sha256.txt
-source.sha256 = "fcdea02123f396e7532726a8ab2534165d68b48b66ba215ab9fe945555daaa6f"
+source.sha256 = "8e361311d7f53aaa34c0bd5ee868274703dcbb7380e8dcc06d56c271e1748f41"
 output.type = "zone"
 
 [package.mg-ddm-gz]


### PR DESCRIPTION
Last of the stuff we want in for 18:

* avoid excessive Arc<Mapping> contention (propolis#1012)
* VirtIO 1.0 and multi-queue support
* Add non-Arc-clone'ing variant of access() (propolis#1003)
* viona: FFI out of bounds fix

The first and third are to get more overhead out of the way in heavy disk I/O paths. The second gets us more network performance, and the fourth ... fixes a bug introduced by the second, an hour after it landed, unfortunately.

@jmpesp had asked if the Propolis update earlier requires any specific host OS bits and I'd mangled the multi-queue support here with the viona fastpath there. The answer I gave James there actually applies here:

> it does, and those are integrated as of https://github.com/oxidecomputer/illumos-gate/commit/20d447aa864f704bc29da5264b01904932151dfa and https://github.com/oxidecomputer/illumos-gate/commit/9415077713e713ff3b4ac8a09f7e65c400e78c93. Angela had seen the panic you get with a NIC without those, though I'm not sure how clear the panic message is.

(almost certainly something about an "inappropriate ioctl on device ...")