### PR TITLE
Blueprint sled editor: don't track decommissioned sleds

### DIFF
--- a/nexus/reconfigurator/planning/src/blueprint_editor/sled_editor.rs
+++ b/nexus/reconfigurator/planning/src/blueprint_editor/sled_editor.rs
@@ -19,7 +19,6 @@ use host_phase_2::HostPhase2Editor;
 use iddqd::IdOrdMap;
 use iddqd::id_ord_map::Entry;
 use illumos_utils::zpool::ZpoolName;
-use itertools::Either;
 use nexus_types::deployment::BlueprintDatasetConfig;
 use nexus_types::deployment::BlueprintDatasetDisposition;
 use nexus_types::deployment::BlueprintExpungedZoneAccessReason;
@@ -48,7 +47,6 @@ use omicron_uuid_kinds::ZpoolUuid;
 use scalar::ScalarEditor;
 use sled_agent_types::inventory::MupdateOverrideBootInventory;
 use sled_agent_types::inventory::ZoneKind;
-use std::iter;
 use std::mem;
 use std::net::Ipv6Addr;
 use underlay_ip_allocator::SledUnderlayIpAllocator;
@@ -72,6 +70,8 @@ use self::zones::ZonesEditor;
 
 #[derive(Debug, thiserror::Error)]
 pub enum SledInputError {
+    #[error("attempted to construct SledEditor for decommissioned sled")]
+    DecommissionedSled,
     #[error(transparent)]
     MultipleDatasetsOfKind(#[from] MultipleDatasetsOfKind),
 }
@@ -146,363 +146,7 @@ pub enum SledEditError {
 }
 
 #[derive(Debug)]
-pub(crate) struct SledEditor(InnerSledEditor);
-
-#[derive(Debug)]
-#[allow(clippy::large_enum_variant)]
-enum InnerSledEditor {
-    // Internally, `SledEditor` has a variant for each variant of `SledState`,
-    // as the operations allowed in different states are substantially different
-    // (i.e., an active sled allows any edit; a decommissioned sled allows
-    // none).
-    Active(ActiveSledEditor),
-    Decommissioned(EditedSled),
-}
-
-impl SledEditor {
-    pub fn for_existing(
-        config: BlueprintSledConfig,
-    ) -> Result<Self, SledInputError> {
-        let inner = match config.state {
-            SledState::Active => {
-                InnerSledEditor::Active(ActiveSledEditor::new(config)?)
-            }
-            SledState::Decommissioned => {
-                InnerSledEditor::Decommissioned(EditedSled::new(config))
-            }
-        };
-        Ok(Self(inner))
-    }
-
-    pub fn for_new_active(subnet: Ipv6Subnet<SLED_PREFIX>) -> Self {
-        Self(InnerSledEditor::Active(ActiveSledEditor::new_empty(subnet)))
-    }
-
-    pub fn finalize(self) -> EditedSled {
-        match self.0 {
-            InnerSledEditor::Active(editor) => editor.finalize(),
-            InnerSledEditor::Decommissioned(edited) => edited,
-        }
-    }
-
-    pub fn state(&self) -> SledState {
-        match &self.0 {
-            InnerSledEditor::Active(_) => SledState::Active,
-            InnerSledEditor::Decommissioned(_) => SledState::Decommissioned,
-        }
-    }
-
-    /// Returns the subnet of this sled if it is active, or `None` if it is
-    /// decommissioned.
-    pub fn subnet(&self) -> Option<Ipv6Subnet<SLED_PREFIX>> {
-        match &self.0 {
-            InnerSledEditor::Active(active) => {
-                Some(active.underlay_ip_allocator.subnet())
-            }
-            InnerSledEditor::Decommissioned(_) => None,
-        }
-    }
-
-    pub fn edit_counts(&self) -> SledEditCounts {
-        match &self.0 {
-            InnerSledEditor::Active(editor) => editor.edit_counts(),
-            InnerSledEditor::Decommissioned(edited) => edited.edit_counts,
-        }
-    }
-
-    pub fn decommission(self) -> Result<EditedSled, (Self, SledEditError)> {
-        match self.0 {
-            InnerSledEditor::Active(editor) => {
-                // Decommissioning a sled is a one-way trip that has many
-                // preconditions. We can't check all of them here (e.g., we
-                // should kick the sled out of trust quorum before
-                // decommissioning, which is entirely outside the realm of
-                // `SledEditor`. But we can do some basic checks: all of the
-                // disks, datasets, and zones for this sled should be expunged.
-                match editor.validate_decommisionable() {
-                    Ok(()) => {
-                        let mut finalized = editor.finalize();
-                        finalized.config.state = SledState::Decommissioned;
-                        Ok(finalized)
-                    }
-                    Err(err) => {
-                        Err((Self(InnerSledEditor::Active(editor)), err))
-                    }
-                }
-            }
-            // If we're already decommissioned, there's nothing to do.
-            InnerSledEditor::Decommissioned(edited) => Ok(edited),
-        }
-    }
-
-    pub fn alloc_underlay_ip(&mut self) -> Result<Ipv6Addr, SledEditError> {
-        self.as_active_mut()?
-            .alloc_underlay_ip()
-            .ok_or(SledEditError::OutOfUnderlayIps)
-    }
-
-    pub fn disks<F>(
-        &self,
-        mut filter: F,
-    ) -> impl Iterator<Item = &BlueprintPhysicalDiskConfig>
-    where
-        F: FnMut(BlueprintPhysicalDiskDisposition) -> bool,
-    {
-        match &self.0 {
-            InnerSledEditor::Active(editor) => {
-                Either::Left(editor.disks(filter))
-            }
-            InnerSledEditor::Decommissioned(edited) => Either::Right(
-                edited
-                    .config
-                    .disks
-                    .iter()
-                    .filter(move |disk| filter(disk.disposition)),
-            ),
-        }
-    }
-
-    pub fn datasets<F>(
-        &self,
-        mut filter: F,
-    ) -> impl Iterator<Item = &BlueprintDatasetConfig>
-    where
-        F: FnMut(BlueprintDatasetDisposition) -> bool,
-    {
-        match &self.0 {
-            InnerSledEditor::Active(editor) => {
-                Either::Left(editor.datasets(filter))
-            }
-            InnerSledEditor::Decommissioned(edited) => Either::Right(
-                edited
-                    .config
-                    .datasets
-                    .iter()
-                    .filter(move |disk| filter(disk.disposition)),
-            ),
-        }
-    }
-
-    pub fn in_service_zones(
-        &self,
-    ) -> impl Iterator<Item = &BlueprintZoneConfig> {
-        match &self.0 {
-            InnerSledEditor::Active(editor) => {
-                Either::Left(editor.in_service_zones())
-            }
-            InnerSledEditor::Decommissioned(_) => {
-                // A decommissioned sled cannot have any in-service zones!
-                Either::Right(iter::empty())
-            }
-        }
-    }
-
-    pub fn could_be_running_zones(
-        &self,
-    ) -> impl Iterator<Item = &BlueprintZoneConfig> {
-        match &self.0 {
-            InnerSledEditor::Active(editor) => {
-                Either::Left(editor.could_be_running_zones())
-            }
-            InnerSledEditor::Decommissioned(_) => {
-                // A decommissioned sled cannot have any running zones!
-                Either::Right(iter::empty())
-            }
-        }
-    }
-
-    pub fn expunged_zones(
-        &self,
-        reason: BlueprintExpungedZoneAccessReason,
-    ) -> impl Iterator<Item = &BlueprintZoneConfig> {
-        match &self.0 {
-            InnerSledEditor::Active(editor) => {
-                Either::Left(editor.expunged_zones(reason))
-            }
-            InnerSledEditor::Decommissioned(edited) => Either::Right(
-                edited
-                    .config
-                    .zones
-                    .iter()
-                    .filter(move |zone| zone.disposition.is_expunged()),
-            ),
-        }
-    }
-
-    pub fn all_in_service_and_expunged_zones(
-        &self,
-        reason: BlueprintExpungedZoneAccessReason,
-    ) -> impl Iterator<Item = &BlueprintZoneConfig> {
-        match &self.0 {
-            InnerSledEditor::Active(editor) => {
-                Either::Left(editor.all_in_service_and_expunged_zones(reason))
-            }
-            InnerSledEditor::Decommissioned(edited) => {
-                Either::Right(edited.config.zones.iter())
-            }
-        }
-    }
-
-    pub fn host_phase_2(&self) -> BlueprintHostPhase2DesiredSlots {
-        match &self.0 {
-            InnerSledEditor::Active(editor) => editor.host_phase_2(),
-            InnerSledEditor::Decommissioned(edited) => {
-                edited.config.host_phase_2.clone()
-            }
-        }
-    }
-
-    /// Returns the remove_mupdate_override field for this sled.
-    pub fn get_remove_mupdate_override(&self) -> Option<MupdateOverrideUuid> {
-        match &self.0 {
-            InnerSledEditor::Active(editor) => {
-                *editor.remove_mupdate_override.value()
-            }
-            InnerSledEditor::Decommissioned(sled) => {
-                sled.config.remove_mupdate_override
-            }
-        }
-    }
-
-    fn as_active_mut(
-        &mut self,
-    ) -> Result<&mut ActiveSledEditor, SledEditError> {
-        match &mut self.0 {
-            InnerSledEditor::Active(editor) => Ok(editor),
-            InnerSledEditor::Decommissioned(_) => {
-                Err(SledEditError::EditDecommissioned)
-            }
-        }
-    }
-
-    pub fn ensure_disk(
-        &mut self,
-        disk: BlueprintPhysicalDiskConfig,
-        rng: &mut SledPlannerRng,
-    ) -> Result<(), SledEditError> {
-        self.as_active_mut()?.ensure_disk(disk, rng)
-    }
-
-    pub fn expunge_disk(
-        &mut self,
-        disk_id: &PhysicalDiskUuid,
-    ) -> Result<DiskExpungeDetails, SledEditError> {
-        self.as_active_mut()?.expunge_disk(disk_id)
-    }
-
-    pub fn decommission_disk(
-        &mut self,
-        disk_id: &PhysicalDiskUuid,
-    ) -> Result<(), SledEditError> {
-        self.as_active_mut()?.decommission_disk(disk_id)?;
-        Ok(())
-    }
-
-    pub fn add_zone(
-        &mut self,
-        zone: BlueprintZoneConfig,
-        rng: &mut SledPlannerRng,
-    ) -> Result<(), SledEditError> {
-        self.as_active_mut()?.add_zone(zone, rng)
-    }
-
-    pub fn expunge_zone(
-        &mut self,
-        zone_id: &OmicronZoneUuid,
-    ) -> Result<bool, SledEditError> {
-        self.as_active_mut()?.expunge_zone(zone_id)
-    }
-
-    pub fn mark_expunged_zone_ready_for_cleanup(
-        &mut self,
-        zone_id: &OmicronZoneUuid,
-    ) -> Result<bool, SledEditError> {
-        self.as_active_mut()?.mark_expunged_zone_ready_for_cleanup(zone_id)
-    }
-
-    /// Sets the image source for a zone, returning the old image source.
-    pub fn set_zone_image_source(
-        &mut self,
-        zone_id: &OmicronZoneUuid,
-        image_source: BlueprintZoneImageSource,
-    ) -> Result<BlueprintZoneImageSource, SledEditError> {
-        self.as_active_mut()?.set_zone_image_source(zone_id, image_source)
-    }
-
-    // Sets the desired host phase 2 contents.
-    pub fn set_host_phase_2(
-        &mut self,
-        host_phase_2: BlueprintHostPhase2DesiredSlots,
-    ) -> Result<(), SledEditError> {
-        self.as_active_mut()?.set_host_phase_2(host_phase_2);
-        Ok(())
-    }
-
-    // Sets the desired host phase 2 contents of a particular slot.
-    pub fn set_host_phase_2_slot(
-        &mut self,
-        slot: M2Slot,
-        host_phase_2: BlueprintHostPhase2DesiredContents,
-    ) -> Result<(), SledEditError> {
-        self.as_active_mut()?.set_host_phase_2_slot(slot, host_phase_2);
-        Ok(())
-    }
-
-    /// Updates a sled's mupdate override field based on the mupdate override
-    /// provided by inventory.
-    pub fn ensure_mupdate_override(
-        &mut self,
-        // inv_mupdate_override_info has a weird type (not Option<&T>, not &str)
-        // because this is what `Result::as_ref` returns.
-        inv_mupdate_override_info: Result<
-            &Option<MupdateOverrideBootInventory>,
-            &String,
-        >,
-        pending_mgs_update: Entry<'_, PendingMgsUpdate>,
-        noop_sled_info: NoopConvertSledInfoMut<'_>,
-    ) -> Result<EnsureMupdateOverrideAction, SledEditError> {
-        self.as_active_mut()?.ensure_mupdate_override(
-            inv_mupdate_override_info,
-            pending_mgs_update,
-            noop_sled_info,
-        )
-    }
-
-    /// Sets remove-mupdate-override configuration for this sled.
-    ///
-    /// Currently only used in test code.
-    pub fn set_remove_mupdate_override(
-        &mut self,
-        remove_mupdate_override: Option<MupdateOverrideUuid>,
-    ) -> Result<(), SledEditError> {
-        self.as_active_mut()?
-            .set_remove_mupdate_override(remove_mupdate_override);
-        Ok(())
-    }
-
-    /// Backwards compatibility / test helper: If we're given a blueprint that
-    /// has zones but wasn't created via `SledEditor`, it might not have
-    /// datasets for all its zones. This method backfills them.
-    pub fn ensure_datasets_for_running_zones(
-        &mut self,
-        rng: &mut SledPlannerRng,
-    ) -> Result<(), SledEditError> {
-        self.as_active_mut()?.ensure_datasets_for_running_zones(rng)
-    }
-
-    /// Debug method to force a sled agent generation number to be bumped, even
-    /// if there are no changes to the sled.
-    ///
-    /// Do not use in production. Instead, update the logic that decides if the
-    /// generation number should be bumped.
-    pub fn debug_force_generation_bump(&mut self) -> Result<(), SledEditError> {
-        self.as_active_mut()?.debug_force_generation_bump();
-        Ok(())
-    }
-}
-
-#[derive(Debug)]
-struct ActiveSledEditor {
+pub struct SledEditor {
     underlay_ip_allocator: SledUnderlayIpAllocator,
     incoming_sled_agent_generation: Generation,
     zones: ZonesEditor,
@@ -530,8 +174,18 @@ impl EditedSled {
     }
 }
 
-impl ActiveSledEditor {
-    pub fn new(config: BlueprintSledConfig) -> Result<Self, SledInputError> {
+impl SledEditor {
+    pub fn for_existing(
+        config: BlueprintSledConfig,
+    ) -> Result<Self, SledInputError> {
+        // We should only attempt to wrap active sleds in `SledEditor`s.
+        match config.state {
+            SledState::Active => (), // fallthrough
+            SledState::Decommissioned => {
+                return Err(SledInputError::DecommissionedSled);
+            }
+        }
+
         let zones =
             ZonesEditor::new(config.sled_agent_generation, config.zones);
 
@@ -552,7 +206,7 @@ impl ActiveSledEditor {
         })
     }
 
-    pub fn new_empty(subnet: Ipv6Subnet<SLED_PREFIX>) -> Self {
+    pub fn for_new_active(subnet: Ipv6Subnet<SLED_PREFIX>) -> Self {
         Self {
             underlay_ip_allocator: SledUnderlayIpAllocator::new(
                 subnet,
@@ -620,6 +274,16 @@ impl ActiveSledEditor {
         }
     }
 
+    pub fn decommission(self) -> Result<EditedSled, (Self, SledEditError)> {
+        if let Err(err) = self.validate_decommisionable() {
+            return Err((self, err));
+        }
+
+        let mut finalized = self.finalize();
+        finalized.config.state = SledState::Decommissioned;
+        Ok(finalized)
+    }
+
     fn validate_decommisionable(&self) -> Result<(), SledEditError> {
         // A sled is only decommissionable if all its zones have been expunged
         // (i.e., there are no zones left with an in-service disposition).
@@ -639,6 +303,10 @@ impl ActiveSledEditor {
             datasets: self.datasets.edit_counts(),
             zones: self.zones.edit_counts(),
         }
+    }
+
+    pub fn subnet(&self) -> Ipv6Subnet<SLED_PREFIX> {
+        self.underlay_ip_allocator.subnet()
     }
 
     pub fn alloc_underlay_ip(&mut self) -> Option<Ipv6Addr> {
@@ -663,6 +331,11 @@ impl ActiveSledEditor {
         F: FnMut(BlueprintDatasetDisposition) -> bool,
     {
         self.datasets.datasets(filter)
+    }
+
+    /// Returns the remove_mupdate_override field for this sled.
+    pub fn get_remove_mupdate_override(&self) -> Option<MupdateOverrideUuid> {
+        *self.remove_mupdate_override.value()
     }
 
     pub fn in_service_zones(


### PR DESCRIPTION
This is the small cleanup I mentioned in https://github.com/oxidecomputer/omicron/pull/9608#discussion_r2670241794. Prior to this PR, `SledEditor` wrapped an `InnerSledEditor` enum with active / decommissioned variants, and `SledEditor`'s methods were mostly just passthroughs to the two inner variants, except for a handful of methods that were only valid for commissioned sleds. After this PR, `SledEditor` only handles active sleds, and `BlueprintBuilder` keeps a separate set of all the configs for decommissioned sleds. Most of the other changes to the buildprint builder were minor fallout from slight changes (e.g., some `SledEditor` methods were fallible and now are infallible).