### PR TITLE
nexus-mgs-updates: decouple errors from ArtifactKind

### DIFF
--- a/nexus/mgs-updates/src/common_sp_update.rs
+++ b/nexus/mgs-updates/src/common_sp_update.rs
@@ -19,11 +19,11 @@ use nexus_types::deployment::PendingMgsUpdate;
 use nexus_types::deployment::PendingMgsUpdateDetails;
 use nexus_types::inventory::SpType;
 use omicron_common::disk::M2Slot;
+use std::fmt::Display;
 use std::net::SocketAddrV6;
 use std::time::Duration;
 use thiserror::Error;
 use tufaceous_artifact::ArtifactHash;
-use tufaceous_artifact::ArtifactKind;
 use tufaceous_artifact::ArtifactVersion;
 use uuid::Uuid;
 
@@ -192,13 +192,13 @@ pub enum PrecheckError {
         "expected to find active {kind} artifact {expected}, but found {found}"
     )]
     WrongActiveArtifact {
-        kind: ArtifactKind,
+        kind: ExpectedArtifactKind,
         expected: ArtifactHash,
         found: ArtifactHash,
     },
 
     #[error("failed to determine current active {kind} artifact: {err}")]
-    DeterminingActiveArtifact { kind: ArtifactKind, err: String },
+    DeterminingActiveArtifact { kind: ExpectedArtifactKind, err: String },
 
     #[error(
         "expected to find inactive version {expected:?}, but found {found:?}"
@@ -210,7 +210,7 @@ pub enum PrecheckError {
          but found {found}"
     )]
     WrongInactiveArtifact {
-        kind: ArtifactKind,
+        kind: ExpectedArtifactKind,
         expected: ArtifactHash,
         found: ArtifactHash,
     },
@@ -246,6 +246,21 @@ pub enum PrecheckError {
 
     #[error("inventory reported an error determining boot disk: {err}")]
     DeterminingHostOsBootDisk { err: String },
+}
+
+#[derive(Debug, Clone, Copy)]
+pub enum ExpectedArtifactKind {
+    HostPhase1,
+    HostPhase2,
+}
+
+impl Display for ExpectedArtifactKind {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            ExpectedArtifactKind::HostPhase1 => write!(f, "host phase 1"),
+            ExpectedArtifactKind::HostPhase2 => write!(f, "host phase 2"),
+        }
+    }
 }
 
 #[derive(Debug, thiserror::Error)]

--- a/nexus/mgs-updates/src/driver_update/test_host_phase_1.rs
+++ b/nexus/mgs-updates/src/driver_update/test_host_phase_1.rs
@@ -528,7 +528,7 @@ async fn basic_failures() {
         let message = InlineErrorChain::new(error).to_string();
         eprintln!("{}", message);
         assert!(message.contains(&format!(
-            "expected to find active gimlet_host_phase_1 artifact {bad_hash}, \
+            "expected to find active host phase 1 artifact {bad_hash}, \
              but found {active_phase_1_hash}"
         )));
 
@@ -562,7 +562,7 @@ async fn basic_failures() {
         let message = InlineErrorChain::new(error).to_string();
         eprintln!("{}", message);
         assert!(message.contains(&format!(
-            "expected to find inactive gimlet_host_phase_1 artifact {bad_hash}, \
+            "expected to find inactive host phase 1 artifact {bad_hash}, \
              but found {inactive_phase_1_hash}"
         )));
 
@@ -595,7 +595,7 @@ async fn basic_failures() {
         let message = InlineErrorChain::new(error).to_string();
         eprintln!("{}", message);
         assert!(message.contains(&format!(
-            "expected to find active host_phase_2 artifact {bad_hash}, \
+            "expected to find active host phase 2 artifact {bad_hash}, \
              but found {active_phase_2_hash}"
         )));
 
@@ -629,7 +629,7 @@ async fn basic_failures() {
         let message = InlineErrorChain::new(error).to_string();
         eprintln!("{}", message);
         assert!(message.contains(&format!(
-            "expected to find inactive host_phase_2 artifact {bad_hash}, \
+            "expected to find inactive host phase 2 artifact {bad_hash}, \
              but found {inactive_phase_2_hash}"
         )));
 

--- a/nexus/mgs-updates/src/host_phase1_updater.rs
+++ b/nexus/mgs-updates/src/host_phase1_updater.rs
@@ -130,6 +130,7 @@
 
 use super::MgsClients;
 use crate::SpComponentUpdateHelperImpl;
+use crate::common_sp_update::ExpectedArtifactKind;
 use crate::common_sp_update::PostUpdateError;
 use crate::common_sp_update::PrecheckError;
 use crate::common_sp_update::PrecheckStatus;
@@ -149,7 +150,6 @@ use slog::debug;
 use slog_error_chain::InlineErrorChain;
 use std::time::Duration;
 use tufaceous_artifact::ArtifactHash;
-use tufaceous_artifact::ArtifactKind;
 
 // Hashing the current phase 1 contents on the SP is an asynchronous operation:
 // we request a hash and then poll until the hashing completes. We have to pick
@@ -266,7 +266,7 @@ impl ReconfiguratorHostPhase1Updater {
         // blueprint.)
         if current_active_slot_hash != *expected_active_phase_1_hash {
             return Err(PrecheckError::WrongActiveArtifact {
-                kind: ArtifactKind::GIMLET_HOST_PHASE_1,
+                kind: ExpectedArtifactKind::HostPhase1,
                 expected: *expected_active_phase_1_hash,
                 found: current_active_slot_hash,
             });
@@ -298,7 +298,7 @@ impl ReconfiguratorHostPhase1Updater {
             Ok(PrecheckStatus::ReadyForUpdate)
         } else {
             Err(PrecheckError::WrongInactiveArtifact {
-                kind: ArtifactKind::GIMLET_HOST_PHASE_1,
+                kind: ExpectedArtifactKind::HostPhase1,
                 expected: *expected_inactive_phase_1_hash,
                 found: found_inactive_artifact,
             })
@@ -334,7 +334,7 @@ impl ReconfiguratorHostPhase1Updater {
                 err @ (HostPhase1HashError::Timeout(_)
                 | HostPhase1HashError::ContentsModifiedWhileHashing),
             ) => Err(PrecheckError::DeterminingActiveArtifact {
-                kind: ArtifactKind::GIMLET_HOST_PHASE_1,
+                kind: ExpectedArtifactKind::HostPhase1,
                 err: InlineErrorChain::new(&err).to_string(),
             }),
         }
@@ -421,14 +421,14 @@ impl ReconfiguratorHostPhase1Updater {
             Ok(details) => details.artifact_hash,
             Err(err) => {
                 return Err(PrecheckError::DeterminingActiveArtifact {
-                    kind: ArtifactKind::HOST_PHASE_2,
+                    kind: ExpectedArtifactKind::HostPhase2,
                     err,
                 });
             }
         };
         if active != *expected_active_phase_2_hash {
             return Err(PrecheckError::WrongActiveArtifact {
-                kind: ArtifactKind::HOST_PHASE_2,
+                kind: ExpectedArtifactKind::HostPhase2,
                 expected: *expected_active_phase_2_hash,
                 found: active,
             });
@@ -444,7 +444,7 @@ impl ReconfiguratorHostPhase1Updater {
         };
         if inactive != *expected_inactive_phase_2_hash {
             return Err(PrecheckError::WrongInactiveArtifact {
-                kind: ArtifactKind::HOST_PHASE_2,
+                kind: ExpectedArtifactKind::HostPhase2,
                 expected: *expected_inactive_phase_2_hash,
                 found: inactive,
             });


### PR DESCRIPTION
This is part of the upcoming Tufaceous v2 changes but is small and independent of the rest. `ArtifactKind` doesn't really exist in the new version in the sense that these error types want it to.