### PR TITLE
[datastore] Lookup expunged Oximeter returns `Ok(None)`

### DIFF
--- a/nexus/db-queries/src/db/datastore/oximeter.rs
+++ b/nexus/db-queries/src/db/datastore/oximeter.rs
@@ -41,18 +41,19 @@ pub enum CollectorReassignment {
 impl DataStore {
     /// Lookup an oximeter instance by its ID.
     ///
-    /// Fails if the instance has been expunged.
+    /// Returns `Ok(None)` if the instance does not exist or has been expunged.
     pub async fn oximeter_lookup(
         &self,
         opctx: &OpContext,
         id: &Uuid,
-    ) -> Result<OximeterInfo, Error> {
+    ) -> Result<Option<OximeterInfo>, Error> {
         use nexus_db_schema::schema::oximeter::dsl;
         dsl::oximeter
             .filter(dsl::time_expunged.is_null())
             .find(*id)
             .first_async(&*self.pool_connection_authorized(opctx).await?)
             .await
+            .optional()
             .map_err(|e| public_error_from_diesel(e, ErrorHandler::Server))
     }
 


### PR DESCRIPTION
This is a small change pulled out of upcoming blueprint pruning work. Reconfigurator needs to be able to look up a potentially-expunged Oximeter instance and know whether the cleanup work that marks it expunged in the `oximeter` crdb table is complete. It's easy to know if it's _not_ complete: we'll get back some Oximeter info. But if the cleanup work has happened, prior to this PR, we'd get back an error, and the details get squashed down by way of `public_error_from_diesel()` into an `Error::InternalError { ... }`. We need to be able to tell the difference between "lookup failed because there is no non-expunged Oximeter by this ID" and "query failed for $DATABASE_REASON", so this PR changes the lookup to return `Result<Option<OximeterInfo>, _>`, allowing us to return `Ok(None)` for the "query succeeded but no non-expunged Oximeter exists" case.

This required changing both callers, and in doing so I think the (rare) case of trying to operate on an expunged Oximeter would fail prior to this PR but will now succeed, because both are trying to notify Oximeter of no-longer-present producers.

While I was there, I added a tiny bit of in-memory caching (thrown away on each activation) to `ExpiredProducers::new()`. Previously, it would issue a db lookup for the assigned Oximeter ID of every expired producer. However:

* If we have any expired producers, we're likely to have several (e.g., from a sled going down - all its producers will expire at close to the same time)
* We only run one Oximeter instance at a time, so every producer is almost certain to be assigned to the same Oximeter

which meant we'd be issuing "num expired producers" queries for the same information. We'll now only issue one query for each unique Oximeter ID (almost always 1).