### PR TITLE
audit log creds [1/3]: authn scheme strings -> enum

### DIFF
--- a/nexus-config/src/nexus_config.rs
+++ b/nexus-config/src/nexus_config.rs
@@ -6,7 +6,6 @@
 //! at deployment time.
 
 use crate::PostgresConfigWithUrl;
-use anyhow::anyhow;
 use camino::{Utf8Path, Utf8PathBuf};
 use dropshot::ConfigDropshot;
 use dropshot::ConfigLogging;
@@ -21,10 +20,8 @@ use omicron_common::api::internal::shared::SwitchLocation;
 use omicron_uuid_kinds::OmicronZoneUuid;
 use schemars::JsonSchema;
 use serde::{Deserialize, Serialize};
-use serde_with::DeserializeFromStr;
 use serde_with::DisplayFromStr;
 use serde_with::DurationSeconds;
-use serde_with::SerializeDisplay;
 use serde_with::serde_as;
 use std::collections::HashMap;
 use std::fmt;
@@ -1008,45 +1005,8 @@ pub struct PackageConfig {
     pub default_region_allocation_strategy: RegionAllocationStrategy,
 }
 
-/// List of supported external authn schemes
-///
-/// Note that the authn subsystem doesn't know about this type.  It allows
-/// schemes to be called whatever they want.  This is just to provide a set of
-/// allowed values for configuration.
-#[derive(
-    Clone, Copy, Debug, DeserializeFromStr, Eq, PartialEq, SerializeDisplay,
-)]
-pub enum SchemeName {
-    Spoof,
-    SessionCookie,
-    AccessToken,
-    ScimToken,
-}
-
-impl std::str::FromStr for SchemeName {
-    type Err = anyhow::Error;
-
-    fn from_str(s: &str) -> Result<Self, Self::Err> {
-        match s {
-            "spoof" => Ok(SchemeName::Spoof),
-            "session_cookie" => Ok(SchemeName::SessionCookie),
-            "access_token" => Ok(SchemeName::AccessToken),
-            "scim_token" => Ok(SchemeName::ScimToken),
-            _ => Err(anyhow!("unsupported authn scheme: {:?}", s)),
-        }
-    }
-}
-
-impl std::fmt::Display for SchemeName {
-    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-        f.write_str(match self {
-            SchemeName::Spoof => "spoof",
-            SchemeName::SessionCookie => "session_cookie",
-            SchemeName::AccessToken => "access_token",
-            SchemeName::ScimToken => "scim",
-        })
-    }
-}
+// Re-export SchemeName from nexus-types for use in config parsing.
+pub use nexus_types::authn::SchemeName;
 
 impl WebhookDeliveratorConfig {
     const fn default_lease_timeout_secs() -> u64 {

--- a/nexus/auth/src/authn/external/mod.rs
+++ b/nexus/auth/src/authn/external/mod.rs
@@ -264,7 +264,7 @@ mod test {
         let flag1 = Arc::new(AtomicU8::new(SKIP));
         let count1 = Arc::new(AtomicU8::new(0));
         let mut expected_count1 = 0;
-        let name1 = authn::SchemeName("grunt1");
+        let name1 = authn::SchemeName::Spoof;
         let actor1 = authn::Actor::UserBuiltin {
             user_builtin_id: "1c91bab2-4841-669f-cc32-de80da5bbf39"
                 .parse()
@@ -280,7 +280,7 @@ mod test {
         let flag2 = Arc::new(AtomicU8::new(SKIP));
         let count2 = Arc::new(AtomicU8::new(0));
         let mut expected_count2 = 0;
-        let name2 = authn::SchemeName("grunt2");
+        let name2 = authn::SchemeName::AccessToken;
         let actor2 = authn::Actor::UserBuiltin {
             user_builtin_id: "799684af-533a-cb66-b5ac-ab55a791d5ef"
                 .parse()
@@ -391,7 +391,7 @@ mod test {
         expected_count1 += 1;
         assert_eq!(
             error.to_string(),
-            "authentication failed (tried schemes: [SchemeName(\"grunt1\")])"
+            "authentication failed (tried schemes: [Spoof])"
         );
         assert_eq!(expected_count1, count1.load(Ordering::SeqCst));
         assert_eq!(expected_count2, count2.load(Ordering::SeqCst));
@@ -439,8 +439,7 @@ mod test {
             .expect_err("expected authn to fail");
         assert_eq!(
             error.to_string(),
-            "authentication failed (tried schemes: \
-            [SchemeName(\"grunt1\"), SchemeName(\"grunt2\")])"
+            "authentication failed (tried schemes: [Spoof, AccessToken])"
         );
         assert_eq!(expected_count1, count1.load(Ordering::SeqCst));
         assert_eq!(expected_count2, count2.load(Ordering::SeqCst));

--- a/nexus/auth/src/authn/external/scim.rs
+++ b/nexus/auth/src/authn/external/scim.rs
@@ -32,7 +32,7 @@ use headers::authorization::{Authorization, Bearer};
 // code usually describes an _authentication_ error.)
 
 pub const SCIM_TOKEN_SCHEME_NAME: authn::SchemeName =
-    authn::SchemeName("scim_token");
+    authn::SchemeName::ScimToken;
 
 /// Prefix used on the bearer token to identify this scheme
 // RFC 6750 expects bearer tokens to be opaque base64-encoded data. In our case,

--- a/nexus/auth/src/authn/external/session_cookie.rs
+++ b/nexus/auth/src/authn/external/session_cookie.rs
@@ -58,7 +58,7 @@ pub trait SessionStore {
 // generic cookie name is recommended by OWASP
 pub const SESSION_COOKIE_COOKIE_NAME: &str = "session";
 pub const SESSION_COOKIE_SCHEME_NAME: authn::SchemeName =
-    authn::SchemeName("session_cookie");
+    authn::SchemeName::SessionCookie;
 
 /// Generate session cookie header
 pub fn session_cookie_header_value(

--- a/nexus/auth/src/authn/external/spoof.rs
+++ b/nexus/auth/src/authn/external/spoof.rs
@@ -45,7 +45,7 @@ use std::str::FromStr;
 // they say they are.  That's true of any bearer token, but this one is
 // particularly dangerous because the tokens are long-lived and not secret.
 
-pub const SPOOF_SCHEME_NAME: authn::SchemeName = authn::SchemeName("spoof");
+pub const SPOOF_SCHEME_NAME: authn::SchemeName = authn::SchemeName::Spoof;
 
 /// Magic value to produce a "no such actor" error
 const SPOOF_RESERVED_BAD_ACTOR: &str = "Jack-Donaghy";

--- a/nexus/auth/src/authn/external/token.rs
+++ b/nexus/auth/src/authn/external/token.rs
@@ -33,7 +33,7 @@ use headers::authorization::{Authorization, Bearer};
 // _authentication_ information.  Similarly, the "Unauthorized" HTTP response
 // code usually describes an _authentication_ error.)
 
-pub const TOKEN_SCHEME_NAME: authn::SchemeName = authn::SchemeName("token");
+pub const TOKEN_SCHEME_NAME: authn::SchemeName = authn::SchemeName::AccessToken;
 
 /// Prefix used on the bearer token to identify this scheme
 // RFC 6750 expects bearer tokens to be opaque base64-encoded data.  In our

--- a/nexus/auth/src/authn/mod.rs
+++ b/nexus/auth/src/authn/mod.rs
@@ -39,7 +39,6 @@ pub use nexus_db_fixed_data::user_builtin::USER_SERVICE_BALANCER;
 
 use crate::authz;
 use chrono::{DateTime, Utc};
-use newtype_derive::NewtypeDisplay;
 use nexus_db_fixed_data::silo::DEFAULT_SILO;
 use nexus_types::external_api::shared::FleetRole;
 use nexus_types::external_api::shared::SiloRole;
@@ -513,11 +512,8 @@ pub struct ConsoleSessionWithSiloId {
     pub silo_id: Uuid,
 }
 
-/// Label for a particular authentication scheme (used in log messages and
-/// internal error messages)
-#[derive(Clone, Copy, Debug, Eq, PartialEq)]
-pub struct SchemeName(&'static str);
-NewtypeDisplay! { () pub struct SchemeName(&'static str); }
+// Re-export SchemeName from nexus-types.
+pub use nexus_types::authn::SchemeName;
 
 /// Describes why authentication failed
 ///

--- a/nexus/auth/src/lib.rs
+++ b/nexus/auth/src/lib.rs
@@ -3,9 +3,6 @@ pub mod authz;
 pub mod context;
 pub mod storage;
 
-#[macro_use]
-extern crate newtype_derive;
-
 #[allow(unused_imports)]
 #[macro_use]
 extern crate slog;

--- a/nexus/types/src/authn/mod.rs
+++ b/nexus/types/src/authn/mod.rs
@@ -5,3 +5,59 @@
 //! Authentication types for the Nexus API.
 
 pub mod cookies;
+
+use anyhow::anyhow;
+use serde_with::DeserializeFromStr;
+use serde_with::SerializeDisplay;
+use std::fmt;
+
+/// Identifies a particular external authentication scheme.
+///
+/// This is a closed set of schemes. Adding a new scheme requires updating this
+/// enum, which ensures all consumers (config parsing, authn, audit logging)
+/// handle it explicitly.
+#[derive(
+    Clone, Copy, Debug, DeserializeFromStr, Eq, PartialEq, SerializeDisplay,
+)]
+pub enum SchemeName {
+    /// Session cookie authentication (web console)
+    SessionCookie,
+    /// Access token authentication (API clients)
+    AccessToken,
+    /// SCIM token authentication (provisioning)
+    ScimToken,
+    /// Spoof authentication (development/testing only)
+    Spoof,
+}
+
+impl SchemeName {
+    /// String representation used in config files and logs.
+    pub fn as_str(&self) -> &'static str {
+        match self {
+            SchemeName::SessionCookie => "session_cookie",
+            SchemeName::AccessToken => "access_token",
+            SchemeName::ScimToken => "scim_token",
+            SchemeName::Spoof => "spoof",
+        }
+    }
+}
+
+impl fmt::Display for SchemeName {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.write_str(self.as_str())
+    }
+}
+
+impl std::str::FromStr for SchemeName {
+    type Err = anyhow::Error;
+
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        match s {
+            "spoof" => Ok(SchemeName::Spoof),
+            "session_cookie" => Ok(SchemeName::SessionCookie),
+            "access_token" => Ok(SchemeName::AccessToken),
+            "scim_token" => Ok(SchemeName::ScimToken),
+            _ => Err(anyhow!("unsupported authn scheme: {:?}", s)),
+        }
+    }
+}


### PR DESCRIPTION
In order to log a credential ID (token, session, or scim) in the audit log, we need to log what type of cred it is. We already do that with the `auth_method` column, but I made that a string because the authn schemes use a string field for that. Since it's essentially working as a `type` field for the `credential_id` column, I would much rather `auth_method` be locked down as an enum.

Well, I realized that there is no reason the authn scheme key needs to be a string in the first place, since the set of possible schemes is always statically known. And indeed, we already had such an enum and used it to parse the scheme strings out of the config. 

So, what this change does is:

1. Move the existing authn scheme enum to `nexus-types`
2. Use it instead of a string to identify each scheme

See also:

* https://github.com/oxidecomputer/omicron/pull/9655
* https://github.com/oxidecomputer/omicron/pull/9656