### PR TITLE
support-bundle: store user_comment in bundle meta/ directory

### DIFF
--- a/nexus/src/app/background/tasks/support_bundle/steps/metadata.rs
+++ b/nexus/src/app/background/tasks/support_bundle/steps/metadata.rs
@@ -2,13 +2,14 @@
 // License, v. 2.0. If a copy of the MPL was not distributed with this
 // file, You can obtain one at https://mozilla.org/MPL/2.0/.
 
-//! Collects metadata about the bundle itself (currently only the ID)
+//! Collects metadata about the bundle itself
 
 use crate::app::background::tasks::support_bundle::collection::BundleCollection;
 use crate::app::background::tasks::support_bundle::step::CollectionStepOutput;
 use camino::Utf8Path;
 
-pub async fn collect(
+/// Writes the bundle ID to a file
+pub async fn collect_bundle_id(
     collection: &BundleCollection,
     dir: &Utf8Path,
 ) -> anyhow::Result<CollectionStepOutput> {
@@ -17,6 +18,23 @@ pub async fn collect(
         collection.bundle().id.to_string(),
     )
     .await?;
+
+    Ok(CollectionStepOutput::None)
+}
+
+/// Writes the user-provided comment to the meta directory, if present
+pub async fn collect_user_comment(
+    collection: &BundleCollection,
+    dir: &Utf8Path,
+) -> anyhow::Result<CollectionStepOutput> {
+    let Some(comment) = &collection.bundle().user_comment else {
+        return Ok(CollectionStepOutput::Skipped);
+    };
+
+    let meta_dir = dir.join("meta");
+    tokio::fs::create_dir_all(&meta_dir).await?;
+
+    tokio::fs::write(meta_dir.join("user_comment.txt"), comment).await?;
 
     Ok(CollectionStepOutput::None)
 }

--- a/nexus/src/app/background/tasks/support_bundle/steps/mod.rs
+++ b/nexus/src/app/background/tasks/support_bundle/steps/mod.rs
@@ -9,9 +9,9 @@ use crate::app::background::tasks::support_bundle::step::CollectionStep;
 use futures::FutureExt;
 use nexus_types::internal_api::background::SupportBundleCollectionStep;
 
-mod bundle_id;
 mod ereports;
 mod host_info;
+mod metadata;
 mod reconfigurator;
 mod sled_cubby;
 mod sp_dumps;
@@ -26,7 +26,13 @@ pub fn all(cache: &Cache) -> Vec<CollectionStep> {
         CollectionStep::new(
             SupportBundleCollectionStep::STEP_BUNDLE_ID,
             Box::new(|collection, dir| {
-                bundle_id::collect(collection, dir).boxed()
+                metadata::collect_bundle_id(collection, dir).boxed()
+            }),
+        ),
+        CollectionStep::new(
+            SupportBundleCollectionStep::STEP_USER_COMMENT,
+            Box::new(|collection, dir| {
+                metadata::collect_user_comment(collection, dir).boxed()
             }),
         ),
         CollectionStep::new(

--- a/nexus/types/src/internal_api/background.rs
+++ b/nexus/types/src/internal_api/background.rs
@@ -300,6 +300,7 @@ impl SupportBundleCollectionStep {
     ///
     /// These are used both when creating steps and when validating in tests.
     pub const STEP_BUNDLE_ID: &'static str = "bundle id";
+    pub const STEP_USER_COMMENT: &'static str = "user comment";
     pub const STEP_RECONFIGURATOR_STATE: &'static str = "reconfigurator state";
     pub const STEP_EREPORTS: &'static str = "ereports";
     pub const STEP_SLED_CUBBY_INFO: &'static str = "sled cubby info";


### PR DESCRIPTION
## Summary
- Adds a new collection step that writes the user-provided comment to `meta/user_comment.txt` within the support bundle
- Consolidates `bundle_id.rs` into a new `metadata.rs` module alongside the user comment step
- The comment is now stored both in the database and within the bundle itself, making bundles self-documenting