### PR TITLE
Bump Propolis once more

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -734,7 +734,7 @@ dependencies = [
 [[package]]
 name = "bhyve_api"
 version = "0.0.0"
-source = "git+https://github.com/oxidecomputer/propolis?rev=1a277249eba47a716848825a5a443a56532dbfeb#1a277249eba47a716848825a5a443a56532dbfeb"
+source = "git+https://github.com/oxidecomputer/propolis?rev=2aa7f9d0ee84a1c45e821d6444b1d2f0e69b743e#2aa7f9d0ee84a1c45e821d6444b1d2f0e69b743e"
 dependencies = [
  "bhyve_api_sys",
  "libc",
@@ -744,7 +744,7 @@ dependencies = [
 [[package]]
 name = "bhyve_api_sys"
 version = "0.0.0"
-source = "git+https://github.com/oxidecomputer/propolis?rev=1a277249eba47a716848825a5a443a56532dbfeb#1a277249eba47a716848825a5a443a56532dbfeb"
+source = "git+https://github.com/oxidecomputer/propolis?rev=2aa7f9d0ee84a1c45e821d6444b1d2f0e69b743e#2aa7f9d0ee84a1c45e821d6444b1d2f0e69b743e"
 dependencies = [
  "libc",
  "strum 0.26.3",
@@ -8443,7 +8443,7 @@ dependencies = [
  "pq-sys",
  "pretty_assertions",
  "progenitor-client 0.10.0",
- "propolis-client 0.1.0 (git+https://github.com/oxidecomputer/propolis?rev=1a277249eba47a716848825a5a443a56532dbfeb)",
+ "propolis-client 0.1.0 (git+https://github.com/oxidecomputer/propolis?rev=2aa7f9d0ee84a1c45e821d6444b1d2f0e69b743e)",
  "qorb",
  "rand 0.9.2",
  "range-requests",
@@ -8881,7 +8881,7 @@ dependencies = [
  "oxnet",
  "pretty_assertions",
  "progenitor 0.10.0",
- "propolis-client 0.1.0 (git+https://github.com/oxidecomputer/propolis?rev=1a277249eba47a716848825a5a443a56532dbfeb)",
+ "propolis-client 0.1.0 (git+https://github.com/oxidecomputer/propolis?rev=2aa7f9d0ee84a1c45e821d6444b1d2f0e69b743e)",
  "propolis-mock-server",
  "propolis_api_types",
  "rand 0.9.2",
@@ -10969,7 +10969,7 @@ dependencies = [
 [[package]]
 name = "propolis-client"
 version = "0.1.0"
-source = "git+https://github.com/oxidecomputer/propolis?rev=1a277249eba47a716848825a5a443a56532dbfeb#1a277249eba47a716848825a5a443a56532dbfeb"
+source = "git+https://github.com/oxidecomputer/propolis?rev=2aa7f9d0ee84a1c45e821d6444b1d2f0e69b743e#2aa7f9d0ee84a1c45e821d6444b1d2f0e69b743e"
 dependencies = [
  "async-trait",
  "base64 0.21.7",
@@ -11014,7 +11014,7 @@ dependencies = [
 [[package]]
 name = "propolis-mock-server"
 version = "0.0.0"
-source = "git+https://github.com/oxidecomputer/propolis?rev=1a277249eba47a716848825a5a443a56532dbfeb#1a277249eba47a716848825a5a443a56532dbfeb"
+source = "git+https://github.com/oxidecomputer/propolis?rev=2aa7f9d0ee84a1c45e821d6444b1d2f0e69b743e#2aa7f9d0ee84a1c45e821d6444b1d2f0e69b743e"
 dependencies = [
  "anyhow",
  "atty",
@@ -11058,7 +11058,7 @@ dependencies = [
 [[package]]
 name = "propolis_api_types"
 version = "0.0.0"
-source = "git+https://github.com/oxidecomputer/propolis?rev=1a277249eba47a716848825a5a443a56532dbfeb#1a277249eba47a716848825a5a443a56532dbfeb"
+source = "git+https://github.com/oxidecomputer/propolis?rev=2aa7f9d0ee84a1c45e821d6444b1d2f0e69b743e#2aa7f9d0ee84a1c45e821d6444b1d2f0e69b743e"
 dependencies = [
  "crucible-client-types",
  "propolis_types",
@@ -11071,7 +11071,7 @@ dependencies = [
 [[package]]
 name = "propolis_types"
 version = "0.0.0"
-source = "git+https://github.com/oxidecomputer/propolis?rev=1a277249eba47a716848825a5a443a56532dbfeb#1a277249eba47a716848825a5a443a56532dbfeb"
+source = "git+https://github.com/oxidecomputer/propolis?rev=2aa7f9d0ee84a1c45e821d6444b1d2f0e69b743e#2aa7f9d0ee84a1c45e821d6444b1d2f0e69b743e"
 dependencies = [
  "schemars 0.8.22",
  "serde",
@@ -13016,7 +13016,7 @@ dependencies = [
  "omicron-workspace-hack",
  "oxnet",
  "progenitor 0.10.0",
- "propolis-client 0.1.0 (git+https://github.com/oxidecomputer/propolis?rev=1a277249eba47a716848825a5a443a56532dbfeb)",
+ "propolis-client 0.1.0 (git+https://github.com/oxidecomputer/propolis?rev=2aa7f9d0ee84a1c45e821d6444b1d2f0e69b743e)",
  "regress",
  "reqwest",
  "schemars 0.8.22",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -678,10 +678,10 @@ progenitor-client = "0.10.0"
 # NOTE: if you change the pinned revision of the `bhyve_api` and propolis
 # dependencies, you must also update the references in package-manifest.toml to
 # match the new revision.
-bhyve_api = { git = "https://github.com/oxidecomputer/propolis", rev = "1a277249eba47a716848825a5a443a56532dbfeb" }
-propolis_api_types = { git = "https://github.com/oxidecomputer/propolis", rev = "1a277249eba47a716848825a5a443a56532dbfeb" }
-propolis-client = { git = "https://github.com/oxidecomputer/propolis", rev = "1a277249eba47a716848825a5a443a56532dbfeb" }
-propolis-mock-server = { git = "https://github.com/oxidecomputer/propolis", rev = "1a277249eba47a716848825a5a443a56532dbfeb" }
+bhyve_api = { git = "https://github.com/oxidecomputer/propolis", rev = "2aa7f9d0ee84a1c45e821d6444b1d2f0e69b743e" }
+propolis_api_types = { git = "https://github.com/oxidecomputer/propolis", rev = "2aa7f9d0ee84a1c45e821d6444b1d2f0e69b743e" }
+propolis-client = { git = "https://github.com/oxidecomputer/propolis", rev = "2aa7f9d0ee84a1c45e821d6444b1d2f0e69b743e" }
+propolis-mock-server = { git = "https://github.com/oxidecomputer/propolis", rev = "2aa7f9d0ee84a1c45e821d6444b1d2f0e69b743e" }
 # NOTE: see above!
 proptest = "1.7.0"
 qorb = "0.4.1"

--- a/package-manifest.toml
+++ b/package-manifest.toml
@@ -638,10 +638,10 @@ service_name = "propolis-server"
 only_for_targets.image = "standard"
 source.type = "prebuilt"
 source.repo = "propolis"
-source.commit = "1a277249eba47a716848825a5a443a56532dbfeb"
+source.commit = "2aa7f9d0ee84a1c45e821d6444b1d2f0e69b743e"
 # The SHA256 digest is automatically posted to:
 # https://buildomat.eng.oxide.computer/public/file/oxidecomputer/propolis/image/<commit>/propolis-server.sha256.txt
-source.sha256 = "f6c41220902d1e31df691366fe3f5e05ac5f66a5fe0d8addc45359dcd4b82d73"
+source.sha256 = "32bd7ec72221b16c1b4705192e13f665deea9d9b4a1c80b2bd558463d94f5f6e"
 output.type = "zone"
 
 [package.mg-ddm-gz]


### PR DESCRIPTION
only two changes that are actually interesting for Omicron, but the full set:

* ASpace should allow spaces with size 1 (propolis#1020)
* run header-check in CI (propolis#1017)
* small typo that I couldn't ignore (propolis#1018)
* Indicator should allow stopping instances at Init (propolis#1007)

The first one fixes a Propolis panic when guests use fixed interrupts for VirtIO NICs (so far as we know the only currently-relevant case of this is iPXE)

That last one fixes an issue where stopping a started-but-not-running VM crashes Propolis. I haven't tried to reach that issue via Neuxs, but I imagine it is reachable you stop an instance at the right moment after trying to start it. Either way, Propolis shouldn't die like that.