### PR TITLE
Allow implementations of AuthorizedResource::load_roles to use async fn syntax.

### DIFF
--- a/nexus/auth/src/authz/api_resources.rs
+++ b/nexus/auth/src/authz/api_resources.rs
@@ -37,8 +37,6 @@ use super::{Authz, actor::AuthenticatedActor};
 use crate::authn;
 use crate::context::OpContext;
 use authz_macros::authz_resource;
-use futures::FutureExt;
-use futures::future::BoxFuture;
 use nexus_db_fixed_data::FLEET_ID;
 use nexus_types::external_api::policy::{FleetRole, ProjectRole, SiloRole};
 use omicron_common::api::external::{Error, LookupType, ResourceType};
@@ -46,8 +44,49 @@ use oso::PolarClass;
 use serde::{Deserialize, Serialize};
 use uuid::Uuid;
 
+/// An uninhabited type representing a resource with no parent.
+///
+/// Used as the `Parent` associated type for root resources like `Fleet`.
+/// Since it has no variants, code handling `NoParent` values is unreachable.
+#[derive(Clone, Debug)]
+pub enum NoParent {}
+
+impl oso::ToPolar for NoParent {
+    fn to_polar(self) -> oso::PolarValue {
+        match self {}
+    }
+}
+
+impl AuthorizedResource for NoParent {
+    async fn load_roles(
+        &self,
+        _opctx: &OpContext,
+        _authn: &authn::Context,
+        _roleset: &mut RoleSet,
+    ) -> Result<(), Error> {
+        match *self {}
+    }
+
+    fn on_unauthorized(
+        &self,
+        _authz: &Authz,
+        _error: Error,
+        _actor: AnyActor,
+        _action: Action,
+    ) -> Error {
+        match *self {}
+    }
+
+    fn polar_class(&self) -> oso::Class {
+        match *self {}
+    }
+}
+
 /// Describes an authz resource that corresponds to an API resource that has a
-/// corresponding ResourceType and is stored in the database
+/// corresponding ResourceType and is stored in the database.
+///
+/// This trait is object-safe and can be used with `dyn ApiResource`. For
+/// resources that have a parent in the hierarchy, see [`ApiResourceWithParent`].
 pub trait ApiResource:
     std::fmt::Debug + oso::ToPolar + Send + Sync + 'static
 {
@@ -57,11 +96,6 @@ pub trait ApiResource:
     /// If roles cannot be assigned to this resource, returns `None`.
     fn as_resource_with_roles(&self) -> Option<&dyn ApiResourceWithRoles>;
 
-    /// If this resource has a parent in the API hierarchy whose assigned roles
-    /// can affect access to this resource, return the parent resource.
-    /// Otherwise, returns `None`.
-    fn parent(&self) -> Option<&dyn AuthorizedResource>;
-
     fn resource_type(&self) -> ResourceType;
     fn lookup_type(&self) -> &LookupType;
 
@@ -70,6 +104,21 @@ pub trait ApiResource:
     fn not_found(&self) -> Error {
         self.lookup_type().clone().into_not_found(self.resource_type())
     }
+}
+
+/// Extension of [`ApiResource`] for resources that have a parent in the hierarchy.
+///
+/// This trait adds the `Parent` associated type, which makes it non-object-safe.
+/// The blanket impl of [`AuthorizedResource`] is provided for types implementing
+/// this trait.
+pub trait ApiResourceWithParent: ApiResource {
+    /// The parent resource type. Use `NoParent` for root resources.
+    type Parent: AuthorizedResource;
+
+    /// If this resource has a parent in the API hierarchy whose assigned roles
+    /// can affect access to this resource, return the parent resource.
+    /// Otherwise, returns `None`.
+    fn parent(&self) -> Option<&Self::Parent>;
 }
 
 /// Describes an authz resource on which we allow users to assign roles
@@ -107,15 +156,15 @@ pub trait ApiResourceWithRolesType: ApiResourceWithRoles {
 
 impl<T> AuthorizedResource for T
 where
-    T: ApiResource + oso::PolarClass + Clone,
+    T: ApiResourceWithParent + oso::PolarClass + Clone,
 {
-    fn load_roles<'fut>(
-        &'fut self,
-        opctx: &'fut OpContext,
-        authn: &'fut authn::Context,
-        roleset: &'fut mut RoleSet,
-    ) -> BoxFuture<'fut, Result<(), Error>> {
-        load_roles_for_resource_tree(self, opctx, authn, roleset).boxed()
+    async fn load_roles(
+        &self,
+        opctx: &OpContext,
+        authn: &authn::Context,
+        roleset: &mut RoleSet,
+    ) -> Result<(), Error> {
+        load_roles_for_resource_tree(self, opctx, authn, roleset).await
     }
 
     fn on_unauthorized(
@@ -187,10 +236,6 @@ impl ApiResource for Fleet {
         Some(self)
     }
 
-    fn parent(&self) -> Option<&dyn AuthorizedResource> {
-        None
-    }
-
     fn resource_type(&self) -> ResourceType {
         ResourceType::Fleet
     }
@@ -202,6 +247,14 @@ impl ApiResource for Fleet {
     fn not_found(&self) -> Error {
         // The Fleet is always visible.
         Error::Forbidden
+    }
+}
+
+impl ApiResourceWithParent for Fleet {
+    type Parent = NoParent;
+
+    fn parent(&self) -> Option<&NoParent> {
+        None
     }
 }
 
@@ -258,14 +311,14 @@ impl PartialEq for QuiesceState {
 }
 
 impl AuthorizedResource for QuiesceState {
-    fn load_roles<'fut>(
-        &'fut self,
-        _: &'fut OpContext,
-        _: &'fut authn::Context,
-        _: &'fut mut RoleSet,
-    ) -> BoxFuture<'fut, Result<(), Error>> {
+    async fn load_roles(
+        &self,
+        _opctx: &OpContext,
+        _authn: &authn::Context,
+        _roleset: &mut RoleSet,
+    ) -> Result<(), Error> {
         // We don't use (database) roles to grant access to the quiesce state.
-        futures::future::ready(Ok(())).boxed()
+        Ok(())
     }
 
     fn on_unauthorized(
@@ -299,17 +352,17 @@ impl oso::PolarClass for BlueprintConfig {
 }
 
 impl AuthorizedResource for BlueprintConfig {
-    fn load_roles<'fut>(
-        &'fut self,
-        opctx: &'fut OpContext,
-        authn: &'fut authn::Context,
-        roleset: &'fut mut RoleSet,
-    ) -> futures::future::BoxFuture<'fut, Result<(), Error>> {
+    async fn load_roles(
+        &self,
+        opctx: &OpContext,
+        authn: &authn::Context,
+        roleset: &mut RoleSet,
+    ) -> Result<(), Error> {
         // There are no roles on the BlueprintConfig, only permissions. But we
         // still need to load the Fleet-related roles to verify that the actor
         // has the "admin" role on the Fleet (possibly conferred from a Silo
         // role).
-        load_roles_for_resource_tree(&FLEET, opctx, authn, roleset).boxed()
+        load_roles_for_resource_tree(&FLEET, opctx, authn, roleset).await
     }
 
     fn on_unauthorized(
@@ -350,13 +403,13 @@ impl oso::PolarClass for ConsoleSessionList {
 }
 
 impl AuthorizedResource for ConsoleSessionList {
-    fn load_roles<'fut>(
-        &'fut self,
-        opctx: &'fut OpContext,
-        authn: &'fut authn::Context,
-        roleset: &'fut mut RoleSet,
-    ) -> futures::future::BoxFuture<'fut, Result<(), Error>> {
-        load_roles_for_resource_tree(&FLEET, opctx, authn, roleset).boxed()
+    async fn load_roles(
+        &self,
+        opctx: &OpContext,
+        authn: &authn::Context,
+        roleset: &mut RoleSet,
+    ) -> Result<(), Error> {
+        load_roles_for_resource_tree(&FLEET, opctx, authn, roleset).await
     }
 
     fn on_unauthorized(
@@ -397,13 +450,13 @@ impl oso::PolarClass for DnsConfig {
 }
 
 impl AuthorizedResource for DnsConfig {
-    fn load_roles<'fut>(
-        &'fut self,
-        opctx: &'fut OpContext,
-        authn: &'fut authn::Context,
-        roleset: &'fut mut RoleSet,
-    ) -> futures::future::BoxFuture<'fut, Result<(), Error>> {
-        load_roles_for_resource_tree(&FLEET, opctx, authn, roleset).boxed()
+    async fn load_roles(
+        &self,
+        opctx: &OpContext,
+        authn: &authn::Context,
+        roleset: &mut RoleSet,
+    ) -> Result<(), Error> {
+        load_roles_for_resource_tree(&FLEET, opctx, authn, roleset).await
     }
 
     fn on_unauthorized(
@@ -444,16 +497,16 @@ impl oso::PolarClass for IpPoolList {
 }
 
 impl AuthorizedResource for IpPoolList {
-    fn load_roles<'fut>(
-        &'fut self,
-        opctx: &'fut OpContext,
-        authn: &'fut authn::Context,
-        roleset: &'fut mut RoleSet,
-    ) -> futures::future::BoxFuture<'fut, Result<(), Error>> {
+    async fn load_roles(
+        &self,
+        opctx: &OpContext,
+        authn: &authn::Context,
+        roleset: &mut RoleSet,
+    ) -> Result<(), Error> {
         // There are no roles on the IpPoolList, only permissions. But we still
         // need to load the Fleet-related roles to verify that the actor's role
         // on the Fleet (possibly conferred from a Silo role).
-        load_roles_for_resource_tree(&FLEET, opctx, authn, roleset).boxed()
+        load_roles_for_resource_tree(&FLEET, opctx, authn, roleset).await
     }
 
     fn on_unauthorized(
@@ -508,16 +561,16 @@ impl oso::PolarClass for MulticastGroupList {
 }
 
 impl AuthorizedResource for MulticastGroupList {
-    fn load_roles<'fut>(
-        &'fut self,
-        opctx: &'fut OpContext,
-        authn: &'fut authn::Context,
-        roleset: &'fut mut RoleSet,
-    ) -> futures::future::BoxFuture<'fut, Result<(), Error>> {
+    async fn load_roles(
+        &self,
+        opctx: &OpContext,
+        authn: &authn::Context,
+        roleset: &mut RoleSet,
+    ) -> Result<(), Error> {
         // There are no roles on the MulticastGroupList, only permissions. But we
         // still need to load the Fleet-related roles to verify that the actor's
         // role on the Fleet (possibly conferred from a Silo role).
-        load_roles_for_resource_tree(&FLEET, opctx, authn, roleset).boxed()
+        load_roles_for_resource_tree(&FLEET, opctx, authn, roleset).await
     }
 
     fn on_unauthorized(
@@ -566,16 +619,16 @@ impl oso::PolarClass for AuditLog {
 }
 
 impl AuthorizedResource for AuditLog {
-    fn load_roles<'fut>(
-        &'fut self,
-        opctx: &'fut OpContext,
-        authn: &'fut authn::Context,
-        roleset: &'fut mut RoleSet,
-    ) -> futures::future::BoxFuture<'fut, Result<(), Error>> {
+    async fn load_roles(
+        &self,
+        opctx: &OpContext,
+        authn: &authn::Context,
+        roleset: &mut RoleSet,
+    ) -> Result<(), Error> {
         // There are no roles on the AuditLog, only permissions. But we still
         // need to load the Fleet-related roles to verify that the actor has the
         // viewer role on the Fleet (possibly conferred from a Silo role).
-        load_roles_for_resource_tree(&FLEET, opctx, authn, roleset).boxed()
+        load_roles_for_resource_tree(&FLEET, opctx, authn, roleset).await
     }
 
     fn on_unauthorized(
@@ -608,16 +661,16 @@ impl oso::PolarClass for DeviceAuthRequestList {
 }
 
 impl AuthorizedResource for DeviceAuthRequestList {
-    fn load_roles<'fut>(
-        &'fut self,
-        opctx: &'fut OpContext,
-        authn: &'fut authn::Context,
-        roleset: &'fut mut RoleSet,
-    ) -> futures::future::BoxFuture<'fut, Result<(), Error>> {
+    async fn load_roles(
+        &self,
+        opctx: &OpContext,
+        authn: &authn::Context,
+        roleset: &mut RoleSet,
+    ) -> Result<(), Error> {
         // There are no roles on the DeviceAuthRequestList, only permissions. But we
         // still need to load the Fleet-related roles to verify that the actor has the
         // "admin" role on the Fleet.
-        load_roles_for_resource_tree(&FLEET, opctx, authn, roleset).boxed()
+        load_roles_for_resource_tree(&FLEET, opctx, authn, roleset).await
     }
 
     fn on_unauthorized(
@@ -657,13 +710,13 @@ impl oso::PolarClass for Inventory {
 }
 
 impl AuthorizedResource for Inventory {
-    fn load_roles<'fut>(
-        &'fut self,
-        opctx: &'fut OpContext,
-        authn: &'fut authn::Context,
-        roleset: &'fut mut RoleSet,
-    ) -> futures::future::BoxFuture<'fut, Result<(), Error>> {
-        load_roles_for_resource_tree(&FLEET, opctx, authn, roleset).boxed()
+    async fn load_roles(
+        &self,
+        opctx: &OpContext,
+        authn: &authn::Context,
+        roleset: &mut RoleSet,
+    ) -> Result<(), Error> {
+        load_roles_for_resource_tree(&FLEET, opctx, authn, roleset).await
     }
 
     fn on_unauthorized(
@@ -707,15 +760,15 @@ impl oso::PolarClass for SiloCertificateList {
 }
 
 impl AuthorizedResource for SiloCertificateList {
-    fn load_roles<'fut>(
-        &'fut self,
-        opctx: &'fut OpContext,
-        authn: &'fut authn::Context,
-        roleset: &'fut mut RoleSet,
-    ) -> futures::future::BoxFuture<'fut, Result<(), Error>> {
+    async fn load_roles(
+        &self,
+        opctx: &OpContext,
+        authn: &authn::Context,
+        roleset: &mut RoleSet,
+    ) -> Result<(), Error> {
         // There are no roles on this resource, but we still need to load the
         // Silo-related roles.
-        self.silo().load_roles(opctx, authn, roleset)
+        self.silo().load_roles(opctx, authn, roleset).await
     }
 
     fn on_unauthorized(
@@ -759,15 +812,15 @@ impl oso::PolarClass for SiloIdentityProviderList {
 }
 
 impl AuthorizedResource for SiloIdentityProviderList {
-    fn load_roles<'fut>(
-        &'fut self,
-        opctx: &'fut OpContext,
-        authn: &'fut authn::Context,
-        roleset: &'fut mut RoleSet,
-    ) -> futures::future::BoxFuture<'fut, Result<(), Error>> {
+    async fn load_roles(
+        &self,
+        opctx: &OpContext,
+        authn: &authn::Context,
+        roleset: &mut RoleSet,
+    ) -> Result<(), Error> {
         // There are no roles on this resource, but we still need to load the
         // Silo-related roles.
-        self.silo().load_roles(opctx, authn, roleset)
+        self.silo().load_roles(opctx, authn, roleset).await
     }
 
     fn on_unauthorized(
@@ -808,15 +861,15 @@ impl oso::PolarClass for SiloUserList {
 }
 
 impl AuthorizedResource for SiloUserList {
-    fn load_roles<'fut>(
-        &'fut self,
-        opctx: &'fut OpContext,
-        authn: &'fut authn::Context,
-        roleset: &'fut mut RoleSet,
-    ) -> futures::future::BoxFuture<'fut, Result<(), Error>> {
+    async fn load_roles(
+        &self,
+        opctx: &OpContext,
+        authn: &authn::Context,
+        roleset: &mut RoleSet,
+    ) -> Result<(), Error> {
         // There are no roles on this resource, but we still need to load the
         // Silo-related roles.
-        self.silo().load_roles(opctx, authn, roleset)
+        self.silo().load_roles(opctx, authn, roleset).await
     }
 
     fn on_unauthorized(
@@ -857,15 +910,15 @@ impl oso::PolarClass for SiloGroupList {
 }
 
 impl AuthorizedResource for SiloGroupList {
-    fn load_roles<'fut>(
-        &'fut self,
-        opctx: &'fut OpContext,
-        authn: &'fut authn::Context,
-        roleset: &'fut mut RoleSet,
-    ) -> futures::future::BoxFuture<'fut, Result<(), Error>> {
+    async fn load_roles(
+        &self,
+        opctx: &OpContext,
+        authn: &authn::Context,
+        roleset: &mut RoleSet,
+    ) -> Result<(), Error> {
         // There are no roles on this resource, but we still need to load the
         // Silo-related roles.
-        self.silo().load_roles(opctx, authn, roleset)
+        self.silo().load_roles(opctx, authn, roleset).await
     }
 
     fn on_unauthorized(
@@ -915,14 +968,14 @@ impl oso::PolarClass for SiloUserSessionList {
 }
 
 impl AuthorizedResource for SiloUserSessionList {
-    fn load_roles<'fut>(
-        &'fut self,
-        opctx: &'fut OpContext,
-        authn: &'fut authn::Context,
-        roleset: &'fut mut RoleSet,
-    ) -> futures::future::BoxFuture<'fut, Result<(), Error>> {
+    async fn load_roles(
+        &self,
+        opctx: &OpContext,
+        authn: &authn::Context,
+        roleset: &mut RoleSet,
+    ) -> Result<(), Error> {
         // To check for silo admin, we need to load roles from the parent silo.
-        self.silo_user().parent.load_roles(opctx, authn, roleset)
+        self.silo_user().parent.load_roles(opctx, authn, roleset).await
     }
 
     fn on_unauthorized(
@@ -970,14 +1023,14 @@ impl oso::PolarClass for SiloUserTokenList {
 }
 
 impl AuthorizedResource for SiloUserTokenList {
-    fn load_roles<'fut>(
-        &'fut self,
-        opctx: &'fut OpContext,
-        authn: &'fut authn::Context,
-        roleset: &'fut mut RoleSet,
-    ) -> futures::future::BoxFuture<'fut, Result<(), Error>> {
+    async fn load_roles(
+        &self,
+        opctx: &OpContext,
+        authn: &authn::Context,
+        roleset: &mut RoleSet,
+    ) -> Result<(), Error> {
         // To check for silo admin, we need to load roles from the parent silo.
-        self.silo_user().parent.load_roles(opctx, authn, roleset)
+        self.silo_user().parent.load_roles(opctx, authn, roleset).await
     }
 
     fn on_unauthorized(
@@ -1018,15 +1071,15 @@ impl oso::PolarClass for VpcList {
 }
 
 impl AuthorizedResource for VpcList {
-    fn load_roles<'fut>(
-        &'fut self,
-        opctx: &'fut OpContext,
-        authn: &'fut authn::Context,
-        roleset: &'fut mut RoleSet,
-    ) -> futures::future::BoxFuture<'fut, Result<(), Error>> {
+    async fn load_roles(
+        &self,
+        opctx: &OpContext,
+        authn: &authn::Context,
+        roleset: &mut RoleSet,
+    ) -> Result<(), Error> {
         // There are no roles on this resource, but we still need to load the
         // Project-related roles.
-        self.project().load_roles(opctx, authn, roleset)
+        self.project().load_roles(opctx, authn, roleset).await
     }
 
     fn on_unauthorized(
@@ -1067,17 +1120,17 @@ impl oso::PolarClass for UpdateTrustRootList {
 }
 
 impl AuthorizedResource for UpdateTrustRootList {
-    fn load_roles<'fut>(
-        &'fut self,
-        opctx: &'fut OpContext,
-        authn: &'fut authn::Context,
-        roleset: &'fut mut RoleSet,
-    ) -> futures::future::BoxFuture<'fut, Result<(), Error>> {
+    async fn load_roles(
+        &self,
+        opctx: &OpContext,
+        authn: &authn::Context,
+        roleset: &mut RoleSet,
+    ) -> Result<(), Error> {
         // There are no roles on the UpdateTrustRootList, only permissions.
         // But we still need to load the Fleet-related roles to verify that the
         // actor has the "admin" role on the Fleet (possibly conferred from a
         // Silo role).
-        load_roles_for_resource_tree(&FLEET, opctx, authn, roleset).boxed()
+        load_roles_for_resource_tree(&FLEET, opctx, authn, roleset).await
     }
 
     fn on_unauthorized(
@@ -1110,17 +1163,17 @@ impl oso::PolarClass for TargetReleaseConfig {
 }
 
 impl AuthorizedResource for TargetReleaseConfig {
-    fn load_roles<'fut>(
-        &'fut self,
-        opctx: &'fut OpContext,
-        authn: &'fut authn::Context,
-        roleset: &'fut mut RoleSet,
-    ) -> futures::future::BoxFuture<'fut, Result<(), Error>> {
+    async fn load_roles(
+        &self,
+        opctx: &OpContext,
+        authn: &authn::Context,
+        roleset: &mut RoleSet,
+    ) -> Result<(), Error> {
         // There are no roles on the TargetReleaseConfig, only permissions. But we
         // still need to load the Fleet-related roles to verify that the actor
         // has the "admin" role on the Fleet (possibly conferred from a Silo
         // role).
-        load_roles_for_resource_tree(&FLEET, opctx, authn, roleset).boxed()
+        load_roles_for_resource_tree(&FLEET, opctx, authn, roleset).await
     }
 
     fn on_unauthorized(
@@ -1153,13 +1206,13 @@ impl oso::PolarClass for AlertClassList {
 }
 
 impl AuthorizedResource for AlertClassList {
-    fn load_roles<'fut>(
-        &'fut self,
-        opctx: &'fut OpContext,
-        authn: &'fut authn::Context,
-        roleset: &'fut mut RoleSet,
-    ) -> futures::future::BoxFuture<'fut, Result<(), Error>> {
-        load_roles_for_resource_tree(&FLEET, opctx, authn, roleset).boxed()
+    async fn load_roles(
+        &self,
+        opctx: &OpContext,
+        authn: &authn::Context,
+        roleset: &mut RoleSet,
+    ) -> Result<(), Error> {
+        load_roles_for_resource_tree(&FLEET, opctx, authn, roleset).await
     }
 
     fn on_unauthorized(
@@ -1203,15 +1256,15 @@ impl oso::PolarClass for ScimClientBearerTokenList {
 }
 
 impl AuthorizedResource for ScimClientBearerTokenList {
-    fn load_roles<'fut>(
-        &'fut self,
-        opctx: &'fut OpContext,
-        authn: &'fut authn::Context,
-        roleset: &'fut mut RoleSet,
-    ) -> futures::future::BoxFuture<'fut, Result<(), Error>> {
+    async fn load_roles(
+        &self,
+        opctx: &OpContext,
+        authn: &authn::Context,
+        roleset: &mut RoleSet,
+    ) -> Result<(), Error> {
         // There are no roles on this resource, but we still need to load the
         // Silo-related roles.
-        self.silo().load_roles(opctx, authn, roleset)
+        self.silo().load_roles(opctx, authn, roleset).await
     }
 
     fn on_unauthorized(
@@ -1246,16 +1299,16 @@ impl oso::PolarClass for SubnetPoolList {
 }
 
 impl AuthorizedResource for SubnetPoolList {
-    fn load_roles<'fut>(
-        &'fut self,
-        opctx: &'fut OpContext,
-        authn: &'fut authn::Context,
-        roleset: &'fut mut RoleSet,
-    ) -> futures::future::BoxFuture<'fut, Result<(), Error>> {
+    async fn load_roles(
+        &self,
+        opctx: &OpContext,
+        authn: &authn::Context,
+        roleset: &mut RoleSet,
+    ) -> Result<(), Error> {
         // There are no roles on the SubnetPoolList, only permissions.
         // But we still need to load the Fleet-related roles to verify that
         // the actor's role on the Fleet (possibly conferred from a Silo role).
-        load_roles_for_resource_tree(&FLEET, opctx, authn, roleset).boxed()
+        load_roles_for_resource_tree(&FLEET, opctx, authn, roleset).await
     }
 
     fn on_unauthorized(

--- a/nexus/auth/src/authz/context.rs
+++ b/nexus/auth/src/authz/context.rs
@@ -11,13 +11,13 @@ use crate::authz::Action;
 use crate::authz::oso_generic;
 use crate::context::OpContext;
 use crate::storage::Storage;
-use futures::future::BoxFuture;
 use omicron_common::api::external::Error;
 use omicron_common::bail_unless;
 use oso::Oso;
 use oso::OsoError;
 use slog::debug;
 use std::collections::BTreeSet;
+use std::future::Future;
 use std::sync::Arc;
 
 /// Server-wide authorization context
@@ -164,12 +164,12 @@ pub trait AuthorizedResource: oso::ToPolar + Send + Sync + 'static {
     /// That's how this works for most resources.  There are other kinds of
     /// resources (like the Database itself) that aren't stored in the database
     /// and for which a different mechanism might be used.
-    fn load_roles<'fut>(
-        &'fut self,
-        opctx: &'fut OpContext,
-        authn: &'fut authn::Context,
-        roleset: &'fut mut RoleSet,
-    ) -> BoxFuture<'fut, Result<(), Error>>;
+    fn load_roles(
+        &self,
+        opctx: &OpContext,
+        authn: &authn::Context,
+        roleset: &mut RoleSet,
+    ) -> impl Future<Output = Result<(), Error>>;
 
     /// Invoked on authz failure to determine the final authz result
     ///
@@ -252,13 +252,12 @@ mod test {
         #[derive(Clone, PolarClass)]
         struct UnregisteredResource;
         impl AuthorizedResource for UnregisteredResource {
-            fn load_roles<'fut>(
-                &'fut self,
-                _: &'fut OpContext,
-                _: &'fut authn::Context,
-                _: &'fut mut RoleSet,
-            ) -> futures::future::BoxFuture<'fut, Result<(), Error>>
-            {
+            async fn load_roles(
+                &self,
+                _: &OpContext,
+                _: &authn::Context,
+                _: &mut RoleSet,
+            ) -> Result<(), Error> {
                 // authorize() shouldn't get far enough to call this.
                 unimplemented!();
             }

--- a/nexus/auth/src/authz/oso_generic.rs
+++ b/nexus/auth/src/authz/oso_generic.rs
@@ -14,8 +14,6 @@ use crate::authn;
 use crate::context::OpContext;
 use anyhow::Context;
 use anyhow::ensure;
-use futures::FutureExt;
-use futures::future::BoxFuture;
 use omicron_common::api::external::Error;
 use oso::Oso;
 use oso::PolarClass;
@@ -291,12 +289,12 @@ impl oso::PolarClass for Database {
 }
 
 impl AuthorizedResource for Database {
-    fn load_roles<'fut>(
-        &'fut self,
-        _: &'fut OpContext,
-        _: &'fut authn::Context,
-        _: &'fut mut RoleSet,
-    ) -> BoxFuture<'fut, Result<(), Error>> {
+    async fn load_roles(
+        &self,
+        _opctx: &OpContext,
+        _authn: &authn::Context,
+        _roleset: &mut RoleSet,
+    ) -> Result<(), Error> {
         // We don't use (database) roles to grant access to the database.  The
         // role assignment is hardcoded for all authenticated users.  See the
         // "has_role" Polar method above.
@@ -306,7 +304,7 @@ impl AuthorizedResource for Database {
         // the type signature of roles supported by RoleSet.  RoleSet is really
         // for roles on database objects -- it assumes they have a ResourceType
         // and id, neither of which is true for `Database`.
-        futures::future::ready(Ok(())).boxed()
+        Ok(())
     }
 
     fn on_unauthorized(

--- a/nexus/auth/src/authz/roles.rs
+++ b/nexus/auth/src/authz/roles.rs
@@ -34,7 +34,8 @@
 //! request, and we don't want that thread to block while we hit the database.
 //! Both of these issues could be addressed with considerably more work.
 
-use super::api_resources::ApiResource;
+use super::api_resources::ApiResourceWithParent;
+use super::context::AuthorizedResource;
 use crate::authn;
 use crate::context::OpContext;
 use omicron_common::api::external::Error;
@@ -91,7 +92,7 @@ pub async fn load_roles_for_resource_tree<R>(
     roleset: &mut RoleSet,
 ) -> Result<(), Error>
 where
-    R: ApiResource,
+    R: ApiResourceWithParent,
 {
     // If roles can be assigned directly on this resource, load them.
     if let Some(with_roles) = resource.as_resource_with_roles() {

--- a/nexus/authz-macros/outputs/instance.txt
+++ b/nexus/authz-macros/outputs/instance.txt
@@ -64,9 +64,6 @@ impl oso::PolarClass for Instance {
     }
 }
 impl ApiResource for Instance {
-    fn parent(&self) -> Option<&dyn AuthorizedResource> {
-        Some(&self.parent)
-    }
     fn resource_type(&self) -> ResourceType {
         ResourceType::Instance
     }
@@ -75,5 +72,11 @@ impl ApiResource for Instance {
     }
     fn as_resource_with_roles(&self) -> Option<&dyn ApiResourceWithRoles> {
         None
+    }
+}
+impl ApiResourceWithParent for Instance {
+    type Parent = Project;
+    fn parent(&self) -> Option<&Project> {
+        Some(&self.parent)
     }
 }

--- a/nexus/authz-macros/outputs/organization.txt
+++ b/nexus/authz-macros/outputs/organization.txt
@@ -60,9 +60,6 @@ impl oso::PolarClass for Organization {
     }
 }
 impl ApiResource for Organization {
-    fn parent(&self) -> Option<&dyn AuthorizedResource> {
-        Some(&self.parent)
-    }
     fn resource_type(&self) -> ResourceType {
         ResourceType::Organization
     }
@@ -71,5 +68,11 @@ impl ApiResource for Organization {
     }
     fn as_resource_with_roles(&self) -> Option<&dyn ApiResourceWithRoles> {
         None
+    }
+}
+impl ApiResourceWithParent for Organization {
+    type Parent = Fleet;
+    fn parent(&self) -> Option<&Fleet> {
+        Some(&self.parent)
     }
 }

--- a/nexus/authz-macros/outputs/rack.txt
+++ b/nexus/authz-macros/outputs/rack.txt
@@ -60,9 +60,6 @@ impl oso::PolarClass for Rack {
     }
 }
 impl ApiResource for Rack {
-    fn parent(&self) -> Option<&dyn AuthorizedResource> {
-        Some(&self.parent)
-    }
     fn resource_type(&self) -> ResourceType {
         ResourceType::Rack
     }
@@ -71,5 +68,11 @@ impl ApiResource for Rack {
     }
     fn as_resource_with_roles(&self) -> Option<&dyn ApiResourceWithRoles> {
         None
+    }
+}
+impl ApiResourceWithParent for Rack {
+    type Parent = Fleet;
+    fn parent(&self) -> Option<&Fleet> {
+        Some(&self.parent)
     }
 }

--- a/nexus/authz-macros/src/lib.rs
+++ b/nexus/authz-macros/src/lib.rs
@@ -606,10 +606,6 @@ fn do_authz_resource(
         }
 
         impl ApiResource for #resource_name {
-            fn parent(&self) -> Option<&dyn AuthorizedResource> {
-                Some(&self.parent)
-            }
-
             fn resource_type(&self) -> ResourceType {
                 ResourceType::#resource_name
             }
@@ -622,6 +618,14 @@ fn do_authz_resource(
                 &self,
             ) -> Option<&dyn ApiResourceWithRoles> {
                 #as_roles_body
+            }
+        }
+
+        impl ApiResourceWithParent for #resource_name {
+            type Parent = #parent_resource_name;
+
+            fn parent(&self) -> Option<&#parent_resource_name> {
+                Some(&self.parent)
             }
         }
 

--- a/nexus/db-queries/src/policy_test/coverage.rs
+++ b/nexus/db-queries/src/policy_test/coverage.rs
@@ -28,7 +28,7 @@ impl Coverage {
 
     /// Record that the Polar class associated with `covered` is covered by the
     /// test
-    pub fn covered(&mut self, covered: &dyn AuthorizedResource) {
+    pub fn covered<R: AuthorizedResource>(&mut self, covered: &R) {
         self.covered_class(covered.polar_class())
     }
 


### PR DESCRIPTION
Motivation: I was reviewing some code that added an `impl AuthorizedResource` (#9679) and was curious about the `'fut` lifetime and use of `futures::BoxFuture`. I learned that this is the pre-Rust 1.75 way of writing([`async fn` or `-> impl Future` in a trait](https://blog.rust-lang.org/2023/12/28/Rust-1.75.0/#async-fn-and-return-position-impl-trait-in-traits)).

This change enables native `async fn` syntax for `AuthorizedResource::load_roles` by replacing dynamic dispatch with associated types.

Key changes:

1. Split `ApiResource` into two traits:
    - `ApiResource` - object-safe base trait with all existing methods except `parent()`.
    - `ApiResourceWithParent` - extends `ApiResource`, adds associated type `Parent` and `parent()` method. We use the `NoParent` uninhabited type for root resources (e.g. `Fleet`).
2. Changed `AuthorizedResource::load_roles` signature:
    - From: `fn load_roles<'fut>(...) -> BoxFuture<'fut, Result<(), Error>>`
    - To: `fn load_roles(...) -> impl Future<Output = Result<(), Error>>`
    - Implementations can now use `async fn` syntax directly instead of `.boxed()`, and no longer need an explicit `'fut` lifetime.
3. Updated `authz_resource!` macro to generate both `ApiResource` and `ApiResourceWithParent` impls.
4. Minor cleanup in `resource_builder.rs` - removed unused import and redundant trait bound.