### PR TITLE
sled-agent: Change timeout waiting to find switch zones

### DIFF
--- a/sled-agent/src/rack_setup/service.rs
+++ b/sled-agent/src/rack_setup/service.rs
@@ -1382,7 +1382,17 @@ impl ServiceInner {
 
         // Ask MGS in each switch zone which switch it is.
         let switch_mgmt_addrs = EarlyNetworkSetup::new(&self.log)
-            .lookup_switch_zone_underlay_addrs(&resolver)
+            .lookup_uplinked_switch_zone_underlay_addrs(
+                &resolver,
+                &config.rack_network_config,
+                // We willing to wait forever to find all the switches that have
+                // configured uplinks; if we attempt to proceed without doing
+                // so, we'll fail handing off to Nexus later. (Ideally we could
+                // complete RSS with only one switch up and then configure the
+                // second later, but that currently doesn't work.)
+                // <https://github.com/oxidecomputer/omicron/issues/9678>
+                Duration::MAX,
+            )
             .await;
 
         rss_step.update(RssStep::InitNtp);

--- a/sled-agent/src/services.rs
+++ b/sled-agent/src/services.rs
@@ -1031,7 +1031,35 @@ impl ServiceManager {
         &self,
         zone_args: &ZoneArgs<'_>,
     ) -> Result<Vec<(Port, PortTicket)>, Error> {
-        // Only some services currently need OPTE ports
+        // As a part of setting up OPTE ports, we notify dendrite on all
+        // switches that have an uplink about the new required NAT entries. This
+        // requires finding the switch zone IP addresses. We currently block
+        // until either:
+        //
+        // 1. We find all switch zone IPs.
+        // 2. We find at least one switch zone IP and this timeout elapses.
+        //
+        // If Nexus is up, we don't really need to do any of this work; it has a
+        // background task that will sync NAT entries periodically. However,
+        // it's critical that we set up NAT entries for boundary NTP in
+        // particular during cold boot; otherwise, we won't be able to timesync
+        // and bring the rack up.
+        //
+        // The choice of timeout here is a tension between wanting to wait for
+        // both switches and not wanting to block zone startup indefinitely if
+        // one of the scrimlets or switches is unavailable for an extended
+        // period of time. We should probably revist this entirely - maybe
+        // sled-agent should have its own NAT config reconciler for cold boot
+        // (although it's unclear how something like that wout interact with
+        // Nexus)?
+        //
+        // We'll pick 5 minutes, which has historically been the timeout here
+        // and should hopefully give enough time for a "just rebooted" scrimlet
+        // to bring its switch zone up, if we get unlucky in coincidental
+        // timings.
+        const WAIT_FOR_ALL_SWITCH_ZONES_TIMEOUT: Duration =
+            Duration::from_secs(5 * 60);
+
         if !matches!(
             zone_args.omicron_type(),
             Some(OmicronZoneType::ExternalDns { .. })
@@ -1065,11 +1093,12 @@ impl ServiceManager {
                 .lookup_uplinked_switch_zone_underlay_addrs(
                     resolver,
                     rack_network_config,
+                    WAIT_FOR_ALL_SWITCH_ZONES_TIMEOUT,
                 )
                 .await;
 
         let dpd_clients: Vec<DpdClient> = uplinked_switch_zone_addrs
-            .iter()
+            .values()
             .map(|addr| {
                 DpdClient::new(
                     &format!("http://[{}]:{}", addr, DENDRITE_PORT),


### PR DESCRIPTION
sled-agent attempts to find the IPs of all switch zones in two places:

1. During rack setup (to know what to tell Nexus during handoff)
2. When starting a zone that requires external connectivity (to set up NAT entries in dendrite)

Prior to this PR, both of these would attempt to find both switches for 5 minutes, and after that point would proceed as long as they'd found at least one. This is sorta-okay-but-not-really (more on this in another issue shortly) fine for NAT entries, because Nexus has a background task that will come back around and sync NAT entries for services eventually. But it's not fine for rack setup: if we proceed with only one switch found when the RSS config specifies uplinks for both, we'll fail to hand off to Nexus (details in #9678).

After this change, we change rack setup to wait forever for all switches which have a configured uplink. This means if a switch hasn't come up yet RSS won't proceed, but that should be okay. (It seems _better_ if we could come up with one switch then have Nexus reconcile things after the fact, but that will be a larger change with more risk and more testing difficulty, I think.)

Fixes #9678.