### PR TITLE
Test making sure we don't audit log GET endpoints

### DIFF
--- a/nexus/tests/output/audited-get-endpoints.txt
+++ b/nexus/tests/output/audited-get-endpoints.txt
@@ -1,0 +1,1 @@
+GET endpoints with audit logging:


### PR DESCRIPTION
Turns out we were auditing a few already! Very straightforward: modified the existing coverage test from #9467 to also look at the list of GET endpoints and make sure none of them have audit logging in them.