### PR TITLE
Add reference measurements to inventory

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -539,7 +539,7 @@ dependencies = [
 [[package]]
 name = "attest-data"
 version = "0.5.0"
-source = "git+https://github.com/oxidecomputer/dice-util?rev=173a5d19ee354cc8f0bc00d4e477923f8d2dc4be#173a5d19ee354cc8f0bc00d4e477923f8d2dc4be"
+source = "git+https://github.com/oxidecomputer/dice-util?rev=6e0ef48f72ff85ba50fc8286c8e89dc5f9c822dd#6e0ef48f72ff85ba50fc8286c8e89dc5f9c822dd"
 dependencies = [
  "const-oid",
  "der",
@@ -2700,7 +2700,7 @@ dependencies = [
 [[package]]
 name = "dice-mfg-msgs"
 version = "0.3.0"
-source = "git+https://github.com/oxidecomputer/dice-util?rev=173a5d19ee354cc8f0bc00d4e477923f8d2dc4be#173a5d19ee354cc8f0bc00d4e477923f8d2dc4be"
+source = "git+https://github.com/oxidecomputer/dice-util?rev=6e0ef48f72ff85ba50fc8286c8e89dc5f9c822dd#6e0ef48f72ff85ba50fc8286c8e89dc5f9c822dd"
 dependencies = [
  "const-oid",
  "corncobs",
@@ -2716,7 +2716,7 @@ dependencies = [
 [[package]]
 name = "dice-util-barcode"
 version = "0.1.0"
-source = "git+https://github.com/oxidecomputer/dice-util?rev=173a5d19ee354cc8f0bc00d4e477923f8d2dc4be#173a5d19ee354cc8f0bc00d4e477923f8d2dc4be"
+source = "git+https://github.com/oxidecomputer/dice-util?rev=6e0ef48f72ff85ba50fc8286c8e89dc5f9c822dd#6e0ef48f72ff85ba50fc8286c8e89dc5f9c822dd"
 dependencies = [
  "thiserror 2.0.17",
 ]
@@ -2724,12 +2724,13 @@ dependencies = [
 [[package]]
 name = "dice-verifier"
 version = "0.3.0-pre0"
-source = "git+https://github.com/oxidecomputer/dice-util?rev=173a5d19ee354cc8f0bc00d4e477923f8d2dc4be#173a5d19ee354cc8f0bc00d4e477923f8d2dc4be"
+source = "git+https://github.com/oxidecomputer/dice-util?rev=6e0ef48f72ff85ba50fc8286c8e89dc5f9c822dd#6e0ef48f72ff85ba50fc8286c8e89dc5f9c822dd"
 dependencies = [
- "attest-data 0.5.0 (git+https://github.com/oxidecomputer/dice-util?rev=173a5d19ee354cc8f0bc00d4e477923f8d2dc4be)",
+ "attest-data 0.5.0 (git+https://github.com/oxidecomputer/dice-util?rev=6e0ef48f72ff85ba50fc8286c8e89dc5f9c822dd)",
  "const-oid",
  "ed25519-dalek",
  "env_logger",
+ "hex",
  "hubpack",
  "libipcc 0.1.0 (git+https://github.com/oxidecomputer/ipcc-rs?rev=dbaad520e1f5ae32c10db16ce176f9c24de95652)",
  "log",
@@ -13137,6 +13138,7 @@ dependencies = [
  "anyhow",
  "bytes",
  "camino",
+ "iddqd",
  "key-manager",
  "omicron-workspace-hack",
  "serde",
@@ -13679,10 +13681,10 @@ dependencies = [
 [[package]]
 name = "sprockets-tls"
 version = "0.1.0"
-source = "git+https://github.com/oxidecomputer/sprockets.git?rev=9122d6eb288dc88bfdbcd98cc93cb02cc8c89f96#9122d6eb288dc88bfdbcd98cc93cb02cc8c89f96"
+source = "git+https://github.com/oxidecomputer/sprockets.git?rev=8ba93f6e785e11175059b3303bfd7e8b52ad12f8#8ba93f6e785e11175059b3303bfd7e8b52ad12f8"
 dependencies = [
  "anyhow",
- "attest-data 0.5.0 (git+https://github.com/oxidecomputer/dice-util?rev=173a5d19ee354cc8f0bc00d4e477923f8d2dc4be)",
+ "attest-data 0.5.0 (git+https://github.com/oxidecomputer/dice-util?rev=6e0ef48f72ff85ba50fc8286c8e89dc5f9c822dd)",
  "camino",
  "cfg-if",
  "clap",
@@ -13712,7 +13714,7 @@ dependencies = [
 [[package]]
 name = "sprockets-tls-test-utils"
 version = "0.1.0"
-source = "git+https://github.com/oxidecomputer/sprockets.git?rev=9122d6eb288dc88bfdbcd98cc93cb02cc8c89f96#9122d6eb288dc88bfdbcd98cc93cb02cc8c89f96"
+source = "git+https://github.com/oxidecomputer/sprockets.git?rev=8ba93f6e785e11175059b3303bfd7e8b52ad12f8#8ba93f6e785e11175059b3303bfd7e8b52ad12f8"
 dependencies = [
  "camino",
  "pki-playground",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -766,8 +766,8 @@ slog-term = "2.9.1"
 smf = "0.2"
 socket2 = { version = "0.5", features = ["all"] }
 sp-sim = { path = "sp-sim" }
-sprockets-tls = { git = "https://github.com/oxidecomputer/sprockets.git", rev = "9122d6eb288dc88bfdbcd98cc93cb02cc8c89f96" }
-sprockets-tls-test-utils = { git = "https://github.com/oxidecomputer/sprockets.git", rev = "9122d6eb288dc88bfdbcd98cc93cb02cc8c89f96" }
+sprockets-tls = { git = "https://github.com/oxidecomputer/sprockets.git", rev = "8ba93f6e785e11175059b3303bfd7e8b52ad12f8" }
+sprockets-tls-test-utils = { git = "https://github.com/oxidecomputer/sprockets.git", rev = "8ba93f6e785e11175059b3303bfd7e8b52ad12f8" }
 sqlformat = "0.3.5"
 sqlparser = { version = "0.45.0", features = [ "visitor" ] }
 static_assertions = "1.1.0"

--- a/dev-tools/reconfigurator-cli/tests/output/cmds-example-stdout
+++ b/dev-tools/reconfigurator-cli/tests/output/cmds-example-stdout
@@ -1604,9 +1604,9 @@ LEDGERED SLED CONFIG
         all disks reconciled successfully
         all datasets reconciled successfully
         all zones reconciled successfully
+    reconciler task status: idle (finished at <REDACTED_TIMESTAMP> after running for <REDACTED_DURATION>s)
     reference measurements:
         (measurement set is empty)
-    reconciler task status: idle (finished at <REDACTED_TIMESTAMP> after running for <REDACTED_DURATION>s)
 
 sled 32d8d836-4d8a-4e54-8fa9-f31d79c42646 (role = Gimlet, serial serial2)
     found at:    <REDACTED_TIMESTAMP> from fake sled agent
@@ -1740,9 +1740,9 @@ LEDGERED SLED CONFIG
         all disks reconciled successfully
         all datasets reconciled successfully
         all zones reconciled successfully
+    reconciler task status: idle (finished at <REDACTED_TIMESTAMP> after running for <REDACTED_DURATION>s)
     reference measurements:
         (measurement set is empty)
-    reconciler task status: idle (finished at <REDACTED_TIMESTAMP> after running for <REDACTED_DURATION>s)
 
 sled 89d02b1b-478c-401a-8e28-7a26f74fa41b (role = Gimlet, serial serial0)
     found at:    <REDACTED_TIMESTAMP> from fake sled agent
@@ -1969,9 +1969,9 @@ LEDGERED SLED CONFIG
         all disks reconciled successfully
         all datasets reconciled successfully
         all zones reconciled successfully
+    reconciler task status: idle (finished at <REDACTED_TIMESTAMP> after running for <REDACTED_DURATION>s)
     reference measurements:
         (measurement set is empty)
-    reconciler task status: idle (finished at <REDACTED_TIMESTAMP> after running for <REDACTED_DURATION>s)
 
 KEEPER MEMBERSHIP
     no membership retrieved

--- a/dev-tools/reconfigurator-cli/tests/output/cmds-mupdate-update-flow-stdout
+++ b/dev-tools/reconfigurator-cli/tests/output/cmds-mupdate-update-flow-stdout
@@ -319,9 +319,9 @@ LEDGERED SLED CONFIG
         all disks reconciled successfully
         all datasets reconciled successfully
         all zones reconciled successfully
+    reconciler task status: idle (finished at <REDACTED_TIMESTAMP> after running for <REDACTED_DURATION>s)
     reference measurements:
         (measurement set is empty)
-    reconciler task status: idle (finished at <REDACTED_TIMESTAMP> after running for <REDACTED_DURATION>s)
 
 sled 98e6b7c2-2efa-41ca-b20a-0a4d61102fe6 (role = Gimlet, serial serial0)
     found at:    <REDACTED_TIMESTAMP> from fake sled agent
@@ -446,9 +446,9 @@ LEDGERED SLED CONFIG
         all disks reconciled successfully
         all datasets reconciled successfully
         all zones reconciled successfully
+    reconciler task status: idle (finished at <REDACTED_TIMESTAMP> after running for <REDACTED_DURATION>s)
     reference measurements:
         (measurement set is empty)
-    reconciler task status: idle (finished at <REDACTED_TIMESTAMP> after running for <REDACTED_DURATION>s)
 
 sled d81c6a84-79b8-4958-ae41-ea46c9b19763 (role = Gimlet, serial serial2)
     found at:    <REDACTED_TIMESTAMP> from fake sled agent
@@ -562,9 +562,9 @@ LEDGERED SLED CONFIG
         all disks reconciled successfully
         all datasets reconciled successfully
         all zones reconciled successfully
+    reconciler task status: idle (finished at <REDACTED_TIMESTAMP> after running for <REDACTED_DURATION>s)
     reference measurements:
         (measurement set is empty)
-    reconciler task status: idle (finished at <REDACTED_TIMESTAMP> after running for <REDACTED_DURATION>s)
 
 KEEPER MEMBERSHIP
     no membership retrieved

--- a/dev-tools/reconfigurator-cli/tests/output/cmds-nexus-generation-autobump-stdout
+++ b/dev-tools/reconfigurator-cli/tests/output/cmds-nexus-generation-autobump-stdout
@@ -707,9 +707,9 @@ LEDGERED SLED CONFIG
         all disks reconciled successfully
         all datasets reconciled successfully
         all zones reconciled successfully
+    reconciler task status: idle (finished at <REDACTED_TIMESTAMP> after running for <REDACTED_DURATION>s)
     reference measurements:
         (measurement set is empty)
-    reconciler task status: idle (finished at <REDACTED_TIMESTAMP> after running for <REDACTED_DURATION>s)
 
 sled 98e6b7c2-2efa-41ca-b20a-0a4d61102fe6 (role = Gimlet, serial serial0)
     found at:    <REDACTED_TIMESTAMP> from fake sled agent
@@ -882,9 +882,9 @@ LEDGERED SLED CONFIG
         all disks reconciled successfully
         all datasets reconciled successfully
         all zones reconciled successfully
+    reconciler task status: idle (finished at <REDACTED_TIMESTAMP> after running for <REDACTED_DURATION>s)
     reference measurements:
         (measurement set is empty)
-    reconciler task status: idle (finished at <REDACTED_TIMESTAMP> after running for <REDACTED_DURATION>s)
 
 sled d81c6a84-79b8-4958-ae41-ea46c9b19763 (role = Gimlet, serial serial2)
     found at:    <REDACTED_TIMESTAMP> from fake sled agent
@@ -1057,9 +1057,9 @@ LEDGERED SLED CONFIG
         all disks reconciled successfully
         all datasets reconciled successfully
         all zones reconciled successfully
+    reconciler task status: idle (finished at <REDACTED_TIMESTAMP> after running for <REDACTED_DURATION>s)
     reference measurements:
         (measurement set is empty)
-    reconciler task status: idle (finished at <REDACTED_TIMESTAMP> after running for <REDACTED_DURATION>s)
 
 KEEPER MEMBERSHIP
     no membership retrieved

--- a/dev-tools/reconfigurator-cli/tests/output/cmds-target-release-stdout
+++ b/dev-tools/reconfigurator-cli/tests/output/cmds-target-release-stdout
@@ -694,9 +694,9 @@ LEDGERED SLED CONFIG
         all disks reconciled successfully
         all datasets reconciled successfully
         all zones reconciled successfully
+    reconciler task status: idle (finished at <REDACTED_TIMESTAMP> after running for <REDACTED_DURATION>s)
     reference measurements:
         (measurement set is empty)
-    reconciler task status: idle (finished at <REDACTED_TIMESTAMP> after running for <REDACTED_DURATION>s)
 
 sled 98e6b7c2-2efa-41ca-b20a-0a4d61102fe6 (role = Gimlet, serial serial0)
     found at:    <REDACTED_TIMESTAMP> from fake sled agent
@@ -869,9 +869,9 @@ LEDGERED SLED CONFIG
         all disks reconciled successfully
         all datasets reconciled successfully
         all zones reconciled successfully
+    reconciler task status: idle (finished at <REDACTED_TIMESTAMP> after running for <REDACTED_DURATION>s)
     reference measurements:
         (measurement set is empty)
-    reconciler task status: idle (finished at <REDACTED_TIMESTAMP> after running for <REDACTED_DURATION>s)
 
 sled d81c6a84-79b8-4958-ae41-ea46c9b19763 (role = Gimlet, serial serial2)
     found at:    <REDACTED_TIMESTAMP> from fake sled agent
@@ -1044,9 +1044,9 @@ LEDGERED SLED CONFIG
         all disks reconciled successfully
         all datasets reconciled successfully
         all zones reconciled successfully
+    reconciler task status: idle (finished at <REDACTED_TIMESTAMP> after running for <REDACTED_DURATION>s)
     reference measurements:
         (measurement set is empty)
-    reconciler task status: idle (finished at <REDACTED_TIMESTAMP> after running for <REDACTED_DURATION>s)
 
 KEEPER MEMBERSHIP
     no membership retrieved

--- a/dev-tools/reconfigurator-cli/tests/output/cmds-unsafe-zone-mgs-stdout
+++ b/dev-tools/reconfigurator-cli/tests/output/cmds-unsafe-zone-mgs-stdout
@@ -678,9 +678,9 @@ LEDGERED SLED CONFIG
         all disks reconciled successfully
         all datasets reconciled successfully
         all zones reconciled successfully
+    reconciler task status: idle (finished at <REDACTED_TIMESTAMP> after running for <REDACTED_DURATION>s)
     reference measurements:
         (measurement set is empty)
-    reconciler task status: idle (finished at <REDACTED_TIMESTAMP> after running for <REDACTED_DURATION>s)
 
 sled 98e6b7c2-2efa-41ca-b20a-0a4d61102fe6 (role = Gimlet, serial serial0)
     found at:    <REDACTED_TIMESTAMP> from fake sled agent
@@ -853,9 +853,9 @@ LEDGERED SLED CONFIG
         all disks reconciled successfully
         all datasets reconciled successfully
         all zones reconciled successfully
+    reconciler task status: idle (finished at <REDACTED_TIMESTAMP> after running for <REDACTED_DURATION>s)
     reference measurements:
         (measurement set is empty)
-    reconciler task status: idle (finished at <REDACTED_TIMESTAMP> after running for <REDACTED_DURATION>s)
 
 sled d81c6a84-79b8-4958-ae41-ea46c9b19763 (role = Gimlet, serial serial2)
     found at:    <REDACTED_TIMESTAMP> from fake sled agent
@@ -1028,9 +1028,9 @@ LEDGERED SLED CONFIG
         all disks reconciled successfully
         all datasets reconciled successfully
         all zones reconciled successfully
+    reconciler task status: idle (finished at <REDACTED_TIMESTAMP> after running for <REDACTED_DURATION>s)
     reference measurements:
         (measurement set is empty)
-    reconciler task status: idle (finished at <REDACTED_TIMESTAMP> after running for <REDACTED_DURATION>s)
 
 KEEPER MEMBERSHIP
     no membership retrieved

--- a/nexus/db-model/src/schema_versions.rs
+++ b/nexus/db-model/src/schema_versions.rs
@@ -16,7 +16,7 @@ use std::{collections::BTreeMap, sync::LazyLock};
 ///
 /// This must be updated when you change the database schema.  Refer to
 /// schema/crdb/README.adoc in the root of this repository for details.
-pub const SCHEMA_VERSION: Version = Version::new(225, 0, 0);
+pub const SCHEMA_VERSION: Version = Version::new(226, 0, 0);
 
 /// List of all past database schema versions, in *reverse* order
 ///
@@ -28,6 +28,7 @@ static KNOWN_VERSIONS: LazyLock<Vec<KnownVersion>> = LazyLock::new(|| {
         // |  leaving the first copy as an example for the next person.
         // v
         // KnownVersion::new(next_int, "unique-dirname-with-the-sql-files"),
+        KnownVersion::new(226, "measurement-proper-inventory"),
         KnownVersion::new(225, "dual-stack-ephemeral-ip"),
         KnownVersion::new(224, "add-external-subnets"),
         KnownVersion::new(223, "ip-pool-range-by-pool-id-index"),

--- a/nexus/db-queries/src/db/datastore/physical_disk.rs
+++ b/nexus/db-queries/src/db/datastore/physical_disk.rs
@@ -339,6 +339,7 @@ mod test {
     use crate::db::pub_test_utils::TestDatabase;
     use crate::db::pub_test_utils::helpers::SledUpdateBuilder;
     use dropshot::PaginationOrder;
+    use iddqd::IdOrdMap;
     use nexus_db_lookup::LookupPath;
     use nexus_types::identity::Asset;
     use omicron_common::api::external::ByteCount;
@@ -708,6 +709,7 @@ mod test {
                     file_source_resolver:
                         OmicronFileSourceResolverInventory::new_fake(),
                     health_monitor: HealthMonitorInventory::new(),
+                    reference_measurements: IdOrdMap::new(),
                 },
             )
             .unwrap();

--- a/nexus/db-schema/src/schema.rs
+++ b/nexus/db-schema/src/schema.rs
@@ -1819,6 +1819,18 @@ table! {
 }
 
 table! {
+    inv_single_measurements
+        (inv_collection_id, sled_id, path)
+    {
+        inv_collection_id -> Uuid,
+        sled_id -> Uuid,
+
+        path -> Text,
+        error_message -> Nullable<Text>
+    }
+}
+
+table! {
     inv_last_reconciliation_measurements
         (inv_collection_id, sled_id, file_name)
     {

--- a/nexus/inventory/src/builder.rs
+++ b/nexus/inventory/src/builder.rs
@@ -676,6 +676,7 @@ impl CollectionBuilder {
             last_reconciliation: inventory.last_reconciliation,
             file_source_resolver: inventory.file_source_resolver,
             health_monitor: inventory.health_monitor,
+            reference_measurements: inventory.reference_measurements,
         };
 
         self.sleds

--- a/nexus/inventory/src/examples.rs
+++ b/nexus/inventory/src/examples.rs
@@ -61,7 +61,7 @@ use sled_agent_types::inventory::OmicronFileSourceResolverInventory;
 use sled_agent_types::inventory::OmicronSledConfig;
 use sled_agent_types::inventory::OmicronZonesConfig;
 use sled_agent_types::inventory::OrphanedDataset;
-use sled_agent_types::inventory::ReconciledSingleMeasurement;
+use sled_agent_types::inventory::SingleMeasurementInventory;
 use sled_agent_types::inventory::SledCpuFamily;
 use sled_agent_types::inventory::SledRole;
 use sled_agent_types::resolvable_files::MeasurementManifestStatus;
@@ -1048,17 +1048,6 @@ pub fn sled_agent(
             artifact_size: 10_000 + 4096,
         });
 
-        inv.measurements.insert_overwrite(ReconciledSingleMeasurement {
-            file_name: "file1".to_string(),
-            path: Utf8PathBuf::from("/this/path"),
-            result: ConfigReconcilerInventoryResult::Ok,
-        });
-        inv.measurements.insert_overwrite(ReconciledSingleMeasurement {
-            file_name: "file2".to_string(),
-            path: Utf8PathBuf::from("/this/path2"),
-            result: ConfigReconcilerInventoryResult::Ok,
-        });
-
         inv
     });
 
@@ -1070,6 +1059,17 @@ pub fn sled_agent(
     } else {
         ConfigReconcilerInventoryStatus::NotYetRun
     };
+
+    let mut reference_measurements = iddqd::IdOrdMap::new();
+
+    reference_measurements.insert_overwrite(SingleMeasurementInventory {
+        path: Utf8PathBuf::from("/this/path"),
+        result: ConfigReconcilerInventoryResult::Ok,
+    });
+    reference_measurements.insert_overwrite(SingleMeasurementInventory {
+        path: Utf8PathBuf::from("/this/path2"),
+        result: ConfigReconcilerInventoryResult::Ok,
+    });
 
     Inventory {
         baseboard,
@@ -1091,5 +1091,6 @@ pub fn sled_agent(
         // here in a future PR. This will be more useful when we add this
         // information to the DB.
         health_monitor: HealthMonitorInventory::new(),
+        reference_measurements,
     }
 }

--- a/nexus/mgs-updates/src/test_util/host_phase_2_test_state.rs
+++ b/nexus/mgs-updates/src/test_util/host_phase_2_test_state.rs
@@ -368,7 +368,6 @@ mod api_impl {
                     datasets: BTreeMap::new(),
                     orphaned_datasets: IdOrdMap::new(),
                     zones: BTreeMap::new(),
-                    measurements: IdOrdMap::new(),
                     remove_mupdate_override: None,
                     boot_partitions,
                 }),
@@ -399,6 +398,7 @@ mod api_impl {
                     },
                 },
                 health_monitor: HealthMonitorInventory::new(),
+                reference_measurements: IdOrdMap::new(),
             }))
         }
 

--- a/nexus/reconfigurator/planning/src/mgs_updates/test_helpers.rs
+++ b/nexus/reconfigurator/planning/src/mgs_updates/test_helpers.rs
@@ -1352,7 +1352,6 @@ impl<'a> TestBoardCollectionBuilder<'a> {
                                     datasets: BTreeMap::new(),
                                     orphaned_datasets: IdOrdMap::new(),
                                     zones: BTreeMap::new(),
-                                    measurements: IdOrdMap::new(),
                                     boot_partitions,
                                     remove_mupdate_override: None,
                                 },
@@ -1373,6 +1372,7 @@ impl<'a> TestBoardCollectionBuilder<'a> {
                             file_source_resolver:
                                 OmicronFileSourceResolverInventory::new_fake(),
                             health_monitor: HealthMonitorInventory::new(),
+                            reference_measurements: IdOrdMap::new(),
                         },
                     )
                     .unwrap();

--- a/nexus/reconfigurator/planning/src/system.rs
+++ b/nexus/reconfigurator/planning/src/system.rs
@@ -1476,6 +1476,7 @@ impl Sled {
                 file_source_resolver:
                     OmicronFileSourceResolverInventory::new_fake(),
                 health_monitor: HealthMonitorInventory::new(),
+                reference_measurements: iddqd::IdOrdMap::new(),
             }
         };
 
@@ -1655,6 +1656,9 @@ impl Sled {
             last_reconciliation: inv_sled_agent.last_reconciliation.clone(),
             file_source_resolver: inv_sled_agent.file_source_resolver.clone(),
             health_monitor: HealthMonitorInventory::new(),
+            reference_measurements: inv_sled_agent
+                .reference_measurements
+                .clone(),
         };
 
         Sled {

--- a/nexus/types/src/inventory.rs
+++ b/nexus/types/src/inventory.rs
@@ -45,6 +45,7 @@ use sled_agent_types_versions::latest::inventory::InventoryZpool;
 use sled_agent_types_versions::latest::inventory::OmicronFileSourceResolverInventory;
 use sled_agent_types_versions::latest::inventory::OmicronSledConfig;
 use sled_agent_types_versions::latest::inventory::OmicronZoneConfig;
+use sled_agent_types_versions::latest::inventory::SingleMeasurementInventory;
 use sled_agent_types_versions::latest::inventory::SledCpuFamily;
 use sled_agent_types_versions::latest::inventory::SledRole;
 use sled_hardware_types::BaseboardId;
@@ -643,6 +644,7 @@ pub struct SledAgent {
     pub last_reconciliation: Option<ConfigReconcilerInventory>,
     pub file_source_resolver: OmicronFileSourceResolverInventory,
     pub health_monitor: HealthMonitorInventory,
+    pub reference_measurements: IdOrdMap<SingleMeasurementInventory>,
 }
 
 impl IdOrdItem for SledAgent {

--- a/nexus/types/src/inventory/display.rs
+++ b/nexus/types/src/inventory/display.rs
@@ -620,6 +620,7 @@ fn display_sleds(
             last_reconciliation,
             file_source_resolver,
             health_monitor,
+            reference_measurements,
         } = sled;
 
         writeln!(
@@ -736,7 +737,6 @@ fn display_sleds(
                 zones,
                 boot_partitions,
                 remove_mupdate_override,
-                measurements,
             } = last_reconciliation;
 
             display_boot_partition_contents(boot_partitions, &mut indented)?;
@@ -857,16 +857,6 @@ fn display_sleds(
                     }
                 }
             }
-
-            writeln!(indented, "reference measurements:")?;
-            let mut indent2 = IndentWriter::new("    ", &mut indented);
-            if measurements.is_empty() {
-                writeln!(indent2, "(measurement set is empty)")?;
-            } else {
-                for m in measurements {
-                    writeln!(indent2, "{}", m.display())?;
-                }
-            }
         }
 
         write!(indented, "reconciler task status: ")?;
@@ -938,6 +928,16 @@ fn display_sleds(
                         "failed to retrieve SMF services in maintenance: {e}"
                     )?;
                 }
+            }
+        }
+
+        writeln!(indented, "reference measurements:")?;
+        let mut indent2 = IndentWriter::new("    ", &mut indented);
+        if reference_measurements.is_empty() {
+            writeln!(indent2, "(measurement set is empty)")?;
+        } else {
+            for m in reference_measurements {
+                writeln!(indent2, "{}", m.display())?;
             }
         }
 

--- a/openapi/sled-agent/sled-agent-16.0.0-1923e2.json
+++ b/openapi/sled-agent/sled-agent-16.0.0-1923e2.json
@@ -1,0 +1,10286 @@
+{
+  "openapi": "3.0.3",
+  "info": {
+    "title": "Oxide Sled Agent API",
+    "description": "API for interacting with individual sleds",
+    "contact": {
+      "url": "https://oxide.computer",
+      "email": "api@oxide.computer"
+    },
+    "version": "16.0.0"
+  },
+  "paths": {
+    "/artifacts": {
+      "get": {
+        "operationId": "artifact_list",
+        "responses": {
+          "200": {
+            "description": "successful operation",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ArtifactListResponse"
+                }
+              }
+            }
+          },
+          "4XX": {
+            "$ref": "#/components/responses/Error"
+          },
+          "5XX": {
+            "$ref": "#/components/responses/Error"
+          }
+        }
+      }
+    },
+    "/artifacts/{sha256}": {
+      "put": {
+        "operationId": "artifact_put",
+        "parameters": [
+          {
+            "in": "path",
+            "name": "sha256",
+            "required": true,
+            "schema": {
+              "type": "string",
+              "format": "hex string (32 bytes)"
+            }
+          },
+          {
+            "in": "query",
+            "name": "generation",
+            "required": true,
+            "schema": {
+              "$ref": "#/components/schemas/Generation"
+            }
+          }
+        ],
+        "requestBody": {
+          "content": {
+            "application/octet-stream": {
+              "schema": {
+                "type": "string",
+                "format": "binary"
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "200": {
+            "description": "successful operation",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ArtifactPutResponse"
+                }
+              }
+            }
+          },
+          "4XX": {
+            "$ref": "#/components/responses/Error"
+          },
+          "5XX": {
+            "$ref": "#/components/responses/Error"
+          }
+        }
+      }
+    },
+    "/artifacts/{sha256}/copy-from-depot": {
+      "post": {
+        "operationId": "artifact_copy_from_depot",
+        "parameters": [
+          {
+            "in": "path",
+            "name": "sha256",
+            "required": true,
+            "schema": {
+              "type": "string",
+              "format": "hex string (32 bytes)"
+            }
+          },
+          {
+            "in": "query",
+            "name": "generation",
+            "required": true,
+            "schema": {
+              "$ref": "#/components/schemas/Generation"
+            }
+          }
+        ],
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/ArtifactCopyFromDepotBody"
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "202": {
+            "description": "successfully enqueued operation",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ArtifactCopyFromDepotResponse"
+                }
+              }
+            }
+          },
+          "4XX": {
+            "$ref": "#/components/responses/Error"
+          },
+          "5XX": {
+            "$ref": "#/components/responses/Error"
+          }
+        }
+      }
+    },
+    "/artifacts-config": {
+      "get": {
+        "operationId": "artifact_config_get",
+        "responses": {
+          "200": {
+            "description": "successful operation",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ArtifactConfig"
+                }
+              }
+            }
+          },
+          "4XX": {
+            "$ref": "#/components/responses/Error"
+          },
+          "5XX": {
+            "$ref": "#/components/responses/Error"
+          }
+        }
+      },
+      "put": {
+        "operationId": "artifact_config_put",
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/ArtifactConfig"
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "204": {
+            "description": "resource updated"
+          },
+          "4XX": {
+            "$ref": "#/components/responses/Error"
+          },
+          "5XX": {
+            "$ref": "#/components/responses/Error"
+          }
+        }
+      }
+    },
+    "/bootstore/status": {
+      "get": {
+        "summary": "Get the internal state of the local bootstore node",
+        "operationId": "bootstore_status",
+        "responses": {
+          "200": {
+            "description": "successful operation",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/BootstoreStatus"
+                }
+              }
+            }
+          },
+          "4XX": {
+            "$ref": "#/components/responses/Error"
+          },
+          "5XX": {
+            "$ref": "#/components/responses/Error"
+          }
+        }
+      }
+    },
+    "/debug/switch-zone-policy": {
+      "get": {
+        "summary": "A debugging endpoint only used by `omdb` that allows us to test",
+        "description": "restarting the switch zone without restarting sled-agent. See <https://github.com/oxidecomputer/omicron/issues/8480> for context.",
+        "operationId": "debug_operator_switch_zone_policy_get",
+        "responses": {
+          "200": {
+            "description": "successful operation",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/OperatorSwitchZonePolicy"
+                }
+              }
+            }
+          },
+          "4XX": {
+            "$ref": "#/components/responses/Error"
+          },
+          "5XX": {
+            "$ref": "#/components/responses/Error"
+          }
+        }
+      },
+      "put": {
+        "summary": "A debugging endpoint only used by `omdb` that allows us to test",
+        "description": "restarting the switch zone without restarting sled-agent. See <https://github.com/oxidecomputer/omicron/issues/8480> for context.\n\nSetting the switch zone policy is asynchronous and inherently racy with the standard process of starting the switch zone. If the switch zone is in the process of being started or stopped when this policy is changed, the new policy may not take effect until that transition completes.",
+        "operationId": "debug_operator_switch_zone_policy_put",
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/OperatorSwitchZonePolicy"
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "204": {
+            "description": "resource updated"
+          },
+          "4XX": {
+            "$ref": "#/components/responses/Error"
+          },
+          "5XX": {
+            "$ref": "#/components/responses/Error"
+          }
+        }
+      }
+    },
+    "/disks/{disk_id}": {
+      "put": {
+        "operationId": "disk_put",
+        "parameters": [
+          {
+            "in": "path",
+            "name": "disk_id",
+            "required": true,
+            "schema": {
+              "type": "string",
+              "format": "uuid"
+            }
+          }
+        ],
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/DiskEnsureBody"
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "200": {
+            "description": "successful operation",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/DiskRuntimeState"
+                }
+              }
+            }
+          },
+          "4XX": {
+            "$ref": "#/components/responses/Error"
+          },
+          "5XX": {
+            "$ref": "#/components/responses/Error"
+          }
+        }
+      }
+    },
+    "/eip-gateways": {
+      "put": {
+        "summary": "Update per-NIC IP address <-> internet gateway mappings.",
+        "operationId": "set_eip_gateways",
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/ExternalIpGatewayMap"
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "204": {
+            "description": "resource updated"
+          },
+          "4XX": {
+            "$ref": "#/components/responses/Error"
+          },
+          "5XX": {
+            "$ref": "#/components/responses/Error"
+          }
+        }
+      }
+    },
+    "/inventory": {
+      "get": {
+        "summary": "Fetch basic information about this sled",
+        "operationId": "inventory",
+        "responses": {
+          "200": {
+            "description": "successful operation",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Inventory"
+                }
+              }
+            }
+          },
+          "4XX": {
+            "$ref": "#/components/responses/Error"
+          },
+          "5XX": {
+            "$ref": "#/components/responses/Error"
+          }
+        }
+      }
+    },
+    "/local-storage/{zpool_id}/{dataset_id}": {
+      "post": {
+        "summary": "Create a local storage dataset",
+        "operationId": "local_storage_dataset_ensure",
+        "parameters": [
+          {
+            "in": "path",
+            "name": "dataset_id",
+            "required": true,
+            "schema": {
+              "$ref": "#/components/schemas/DatasetUuid"
+            }
+          },
+          {
+            "in": "path",
+            "name": "zpool_id",
+            "required": true,
+            "schema": {
+              "$ref": "#/components/schemas/ExternalZpoolUuid"
+            }
+          }
+        ],
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/LocalStorageDatasetEnsureRequest"
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "204": {
+            "description": "resource updated"
+          },
+          "4XX": {
+            "$ref": "#/components/responses/Error"
+          },
+          "5XX": {
+            "$ref": "#/components/responses/Error"
+          }
+        }
+      },
+      "delete": {
+        "summary": "Delete a local storage dataset",
+        "operationId": "local_storage_dataset_delete",
+        "parameters": [
+          {
+            "in": "path",
+            "name": "dataset_id",
+            "required": true,
+            "schema": {
+              "$ref": "#/components/schemas/DatasetUuid"
+            }
+          },
+          {
+            "in": "path",
+            "name": "zpool_id",
+            "required": true,
+            "schema": {
+              "$ref": "#/components/schemas/ExternalZpoolUuid"
+            }
+          }
+        ],
+        "responses": {
+          "204": {
+            "description": "resource updated"
+          },
+          "4XX": {
+            "$ref": "#/components/responses/Error"
+          },
+          "5XX": {
+            "$ref": "#/components/responses/Error"
+          }
+        }
+      }
+    },
+    "/network-bootstore-config": {
+      "get": {
+        "summary": "This API endpoint is only reading the local sled agent's view of the",
+        "description": "bootstore. The boostore is a distributed data store that is eventually consistent. Reads from individual nodes may not represent the latest state.",
+        "operationId": "read_network_bootstore_config_cache",
+        "responses": {
+          "200": {
+            "description": "successful operation",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/EarlyNetworkConfig"
+                }
+              }
+            }
+          },
+          "4XX": {
+            "$ref": "#/components/responses/Error"
+          },
+          "5XX": {
+            "$ref": "#/components/responses/Error"
+          }
+        }
+      },
+      "put": {
+        "operationId": "write_network_bootstore_config",
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/EarlyNetworkConfig"
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "204": {
+            "description": "resource updated"
+          },
+          "4XX": {
+            "$ref": "#/components/responses/Error"
+          },
+          "5XX": {
+            "$ref": "#/components/responses/Error"
+          }
+        }
+      }
+    },
+    "/omicron-config": {
+      "put": {
+        "operationId": "omicron_config_put",
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/OmicronSledConfig"
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "204": {
+            "description": "resource updated"
+          },
+          "4XX": {
+            "$ref": "#/components/responses/Error"
+          },
+          "5XX": {
+            "$ref": "#/components/responses/Error"
+          }
+        }
+      }
+    },
+    "/probes": {
+      "put": {
+        "summary": "Update the entire set of probe zones on this sled.",
+        "description": "Probe zones are used to debug networking configuration. They look similar to instances, in that they have an OPTE port on a VPC subnet and external addresses, but no actual VM.",
+        "operationId": "probes_put",
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/ProbeSet"
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "204": {
+            "description": "resource updated"
+          },
+          "4XX": {
+            "$ref": "#/components/responses/Error"
+          },
+          "5XX": {
+            "$ref": "#/components/responses/Error"
+          }
+        }
+      }
+    },
+    "/sled-identifiers": {
+      "get": {
+        "summary": "Fetch sled identifiers",
+        "operationId": "sled_identifiers",
+        "responses": {
+          "200": {
+            "description": "successful operation",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/SledIdentifiers"
+                }
+              }
+            }
+          },
+          "4XX": {
+            "$ref": "#/components/responses/Error"
+          },
+          "5XX": {
+            "$ref": "#/components/responses/Error"
+          }
+        }
+      }
+    },
+    "/sleds": {
+      "put": {
+        "summary": "Add a sled to a rack that was already initialized via RSS",
+        "operationId": "sled_add",
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/AddSledRequest"
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "204": {
+            "description": "resource updated"
+          },
+          "4XX": {
+            "$ref": "#/components/responses/Error"
+          },
+          "5XX": {
+            "$ref": "#/components/responses/Error"
+          }
+        }
+      }
+    },
+    "/support/dladm-info": {
+      "get": {
+        "operationId": "support_dladm_info",
+        "responses": {
+          "200": {
+            "description": "successful operation",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "title": "Array_of_SledDiagnosticsQueryOutput",
+                  "type": "array",
+                  "items": {
+                    "$ref": "#/components/schemas/SledDiagnosticsQueryOutput"
+                  }
+                }
+              }
+            }
+          },
+          "4XX": {
+            "$ref": "#/components/responses/Error"
+          },
+          "5XX": {
+            "$ref": "#/components/responses/Error"
+          }
+        }
+      }
+    },
+    "/support/health-check": {
+      "get": {
+        "operationId": "support_health_check",
+        "responses": {
+          "200": {
+            "description": "successful operation",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "title": "Array_of_SledDiagnosticsQueryOutput",
+                  "type": "array",
+                  "items": {
+                    "$ref": "#/components/schemas/SledDiagnosticsQueryOutput"
+                  }
+                }
+              }
+            }
+          },
+          "4XX": {
+            "$ref": "#/components/responses/Error"
+          },
+          "5XX": {
+            "$ref": "#/components/responses/Error"
+          }
+        }
+      }
+    },
+    "/support/ipadm-info": {
+      "get": {
+        "operationId": "support_ipadm_info",
+        "responses": {
+          "200": {
+            "description": "successful operation",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "title": "Array_of_SledDiagnosticsQueryOutput",
+                  "type": "array",
+                  "items": {
+                    "$ref": "#/components/schemas/SledDiagnosticsQueryOutput"
+                  }
+                }
+              }
+            }
+          },
+          "4XX": {
+            "$ref": "#/components/responses/Error"
+          },
+          "5XX": {
+            "$ref": "#/components/responses/Error"
+          }
+        }
+      }
+    },
+    "/support/logs/download/{zone}": {
+      "get": {
+        "summary": "This endpoint returns a zip file of a zone's logs organized by service.",
+        "operationId": "support_logs_download",
+        "parameters": [
+          {
+            "in": "path",
+            "name": "zone",
+            "description": "The zone for which one would like to collect logs for",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "in": "query",
+            "name": "max_rotated",
+            "description": "The max number of rotated logs to include in the final support bundle",
+            "required": true,
+            "schema": {
+              "type": "integer",
+              "format": "uint",
+              "minimum": 0
+            }
+          }
+        ],
+        "responses": {
+          "default": {
+            "description": "",
+            "content": {
+              "*/*": {
+                "schema": {}
+              }
+            }
+          }
+        }
+      }
+    },
+    "/support/logs/zones": {
+      "get": {
+        "summary": "This endpoint returns a list of known zones on a sled that have service",
+        "description": "logs that can be collected into a support bundle.",
+        "operationId": "support_logs",
+        "responses": {
+          "200": {
+            "description": "successful operation",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "title": "Array_of_String",
+                  "type": "array",
+                  "items": {
+                    "type": "string"
+                  }
+                }
+              }
+            }
+          },
+          "4XX": {
+            "$ref": "#/components/responses/Error"
+          },
+          "5XX": {
+            "$ref": "#/components/responses/Error"
+          }
+        }
+      }
+    },
+    "/support/nvmeadm-info": {
+      "get": {
+        "operationId": "support_nvmeadm_info",
+        "responses": {
+          "200": {
+            "description": "successful operation",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/SledDiagnosticsQueryOutput"
+                }
+              }
+            }
+          },
+          "4XX": {
+            "$ref": "#/components/responses/Error"
+          },
+          "5XX": {
+            "$ref": "#/components/responses/Error"
+          }
+        }
+      }
+    },
+    "/support/pargs-info": {
+      "get": {
+        "operationId": "support_pargs_info",
+        "responses": {
+          "200": {
+            "description": "successful operation",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "title": "Array_of_SledDiagnosticsQueryOutput",
+                  "type": "array",
+                  "items": {
+                    "$ref": "#/components/schemas/SledDiagnosticsQueryOutput"
+                  }
+                }
+              }
+            }
+          },
+          "4XX": {
+            "$ref": "#/components/responses/Error"
+          },
+          "5XX": {
+            "$ref": "#/components/responses/Error"
+          }
+        }
+      }
+    },
+    "/support/pfiles-info": {
+      "get": {
+        "operationId": "support_pfiles_info",
+        "responses": {
+          "200": {
+            "description": "successful operation",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "title": "Array_of_SledDiagnosticsQueryOutput",
+                  "type": "array",
+                  "items": {
+                    "$ref": "#/components/schemas/SledDiagnosticsQueryOutput"
+                  }
+                }
+              }
+            }
+          },
+          "4XX": {
+            "$ref": "#/components/responses/Error"
+          },
+          "5XX": {
+            "$ref": "#/components/responses/Error"
+          }
+        }
+      }
+    },
+    "/support/pstack-info": {
+      "get": {
+        "operationId": "support_pstack_info",
+        "responses": {
+          "200": {
+            "description": "successful operation",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "title": "Array_of_SledDiagnosticsQueryOutput",
+                  "type": "array",
+                  "items": {
+                    "$ref": "#/components/schemas/SledDiagnosticsQueryOutput"
+                  }
+                }
+              }
+            }
+          },
+          "4XX": {
+            "$ref": "#/components/responses/Error"
+          },
+          "5XX": {
+            "$ref": "#/components/responses/Error"
+          }
+        }
+      }
+    },
+    "/support/zfs-info": {
+      "get": {
+        "operationId": "support_zfs_info",
+        "responses": {
+          "200": {
+            "description": "successful operation",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/SledDiagnosticsQueryOutput"
+                }
+              }
+            }
+          },
+          "4XX": {
+            "$ref": "#/components/responses/Error"
+          },
+          "5XX": {
+            "$ref": "#/components/responses/Error"
+          }
+        }
+      }
+    },
+    "/support/zoneadm-info": {
+      "get": {
+        "operationId": "support_zoneadm_info",
+        "responses": {
+          "200": {
+            "description": "successful operation",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/SledDiagnosticsQueryOutput"
+                }
+              }
+            }
+          },
+          "4XX": {
+            "$ref": "#/components/responses/Error"
+          },
+          "5XX": {
+            "$ref": "#/components/responses/Error"
+          }
+        }
+      }
+    },
+    "/support/zpool-info": {
+      "get": {
+        "operationId": "support_zpool_info",
+        "responses": {
+          "200": {
+            "description": "successful operation",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/SledDiagnosticsQueryOutput"
+                }
+              }
+            }
+          },
+          "4XX": {
+            "$ref": "#/components/responses/Error"
+          },
+          "5XX": {
+            "$ref": "#/components/responses/Error"
+          }
+        }
+      }
+    },
+    "/support-bundles/{zpool_id}/{dataset_id}": {
+      "get": {
+        "summary": "List all support bundles within a particular dataset",
+        "operationId": "support_bundle_list",
+        "parameters": [
+          {
+            "in": "path",
+            "name": "dataset_id",
+            "description": "The dataset on which this support bundle was provisioned",
+            "required": true,
+            "schema": {
+              "$ref": "#/components/schemas/DatasetUuid"
+            }
+          },
+          {
+            "in": "path",
+            "name": "zpool_id",
+            "description": "The zpool on which this support bundle was provisioned",
+            "required": true,
+            "schema": {
+              "$ref": "#/components/schemas/ZpoolUuid"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "successful operation",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "title": "Array_of_SupportBundleMetadata",
+                  "type": "array",
+                  "items": {
+                    "$ref": "#/components/schemas/SupportBundleMetadata"
+                  }
+                }
+              }
+            }
+          },
+          "4XX": {
+            "$ref": "#/components/responses/Error"
+          },
+          "5XX": {
+            "$ref": "#/components/responses/Error"
+          }
+        }
+      }
+    },
+    "/support-bundles/{zpool_id}/{dataset_id}/{support_bundle_id}": {
+      "post": {
+        "summary": "Starts creation of a support bundle within a particular dataset",
+        "description": "Callers should transfer chunks of the bundle with \"support_bundle_transfer\", and then call \"support_bundle_finalize\" once the bundle has finished transferring.\n\nIf a support bundle was previously created without being finalized successfully, this endpoint will reset the state.\n\nIf a support bundle was previously created and finalized successfully, this endpoint will return metadata indicating that it already exists.",
+        "operationId": "support_bundle_start_creation",
+        "parameters": [
+          {
+            "in": "path",
+            "name": "dataset_id",
+            "description": "The dataset on which this support bundle was provisioned",
+            "required": true,
+            "schema": {
+              "$ref": "#/components/schemas/DatasetUuid"
+            }
+          },
+          {
+            "in": "path",
+            "name": "support_bundle_id",
+            "description": "The ID of the support bundle itself",
+            "required": true,
+            "schema": {
+              "$ref": "#/components/schemas/SupportBundleUuid"
+            }
+          },
+          {
+            "in": "path",
+            "name": "zpool_id",
+            "description": "The zpool on which this support bundle was provisioned",
+            "required": true,
+            "schema": {
+              "$ref": "#/components/schemas/ZpoolUuid"
+            }
+          }
+        ],
+        "responses": {
+          "201": {
+            "description": "successful creation",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/SupportBundleMetadata"
+                }
+              }
+            }
+          },
+          "4XX": {
+            "$ref": "#/components/responses/Error"
+          },
+          "5XX": {
+            "$ref": "#/components/responses/Error"
+          }
+        }
+      },
+      "delete": {
+        "summary": "Delete a support bundle from a particular dataset",
+        "operationId": "support_bundle_delete",
+        "parameters": [
+          {
+            "in": "path",
+            "name": "dataset_id",
+            "description": "The dataset on which this support bundle was provisioned",
+            "required": true,
+            "schema": {
+              "$ref": "#/components/schemas/DatasetUuid"
+            }
+          },
+          {
+            "in": "path",
+            "name": "support_bundle_id",
+            "description": "The ID of the support bundle itself",
+            "required": true,
+            "schema": {
+              "$ref": "#/components/schemas/SupportBundleUuid"
+            }
+          },
+          {
+            "in": "path",
+            "name": "zpool_id",
+            "description": "The zpool on which this support bundle was provisioned",
+            "required": true,
+            "schema": {
+              "$ref": "#/components/schemas/ZpoolUuid"
+            }
+          }
+        ],
+        "responses": {
+          "204": {
+            "description": "successful deletion"
+          },
+          "4XX": {
+            "$ref": "#/components/responses/Error"
+          },
+          "5XX": {
+            "$ref": "#/components/responses/Error"
+          }
+        }
+      }
+    },
+    "/support-bundles/{zpool_id}/{dataset_id}/{support_bundle_id}/download": {
+      "get": {
+        "summary": "Fetch a support bundle from a particular dataset",
+        "operationId": "support_bundle_download",
+        "parameters": [
+          {
+            "in": "header",
+            "name": "range",
+            "description": "A request to access a portion of the resource, such as `bytes=0-499`\n\nSee: <https://developer.mozilla.org/en-US/docs/Web/HTTP/Reference/Headers/Range>",
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "in": "path",
+            "name": "dataset_id",
+            "description": "The dataset on which this support bundle was provisioned",
+            "required": true,
+            "schema": {
+              "$ref": "#/components/schemas/DatasetUuid"
+            }
+          },
+          {
+            "in": "path",
+            "name": "support_bundle_id",
+            "description": "The ID of the support bundle itself",
+            "required": true,
+            "schema": {
+              "$ref": "#/components/schemas/SupportBundleUuid"
+            }
+          },
+          {
+            "in": "path",
+            "name": "zpool_id",
+            "description": "The zpool on which this support bundle was provisioned",
+            "required": true,
+            "schema": {
+              "$ref": "#/components/schemas/ZpoolUuid"
+            }
+          }
+        ],
+        "responses": {
+          "default": {
+            "description": "",
+            "content": {
+              "*/*": {
+                "schema": {}
+              }
+            }
+          }
+        }
+      },
+      "head": {
+        "summary": "Fetch metadata about a support bundle from a particular dataset",
+        "operationId": "support_bundle_head",
+        "parameters": [
+          {
+            "in": "header",
+            "name": "range",
+            "description": "A request to access a portion of the resource, such as `bytes=0-499`\n\nSee: <https://developer.mozilla.org/en-US/docs/Web/HTTP/Reference/Headers/Range>",
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "in": "path",
+            "name": "dataset_id",
+            "description": "The dataset on which this support bundle was provisioned",
+            "required": true,
+            "schema": {
+              "$ref": "#/components/schemas/DatasetUuid"
+            }
+          },
+          {
+            "in": "path",
+            "name": "support_bundle_id",
+            "description": "The ID of the support bundle itself",
+            "required": true,
+            "schema": {
+              "$ref": "#/components/schemas/SupportBundleUuid"
+            }
+          },
+          {
+            "in": "path",
+            "name": "zpool_id",
+            "description": "The zpool on which this support bundle was provisioned",
+            "required": true,
+            "schema": {
+              "$ref": "#/components/schemas/ZpoolUuid"
+            }
+          }
+        ],
+        "responses": {
+          "default": {
+            "description": "",
+            "content": {
+              "*/*": {
+                "schema": {}
+              }
+            }
+          }
+        }
+      }
+    },
+    "/support-bundles/{zpool_id}/{dataset_id}/{support_bundle_id}/download/{file}": {
+      "get": {
+        "summary": "Fetch a file within a support bundle from a particular dataset",
+        "operationId": "support_bundle_download_file",
+        "parameters": [
+          {
+            "in": "header",
+            "name": "range",
+            "description": "A request to access a portion of the resource, such as `bytes=0-499`\n\nSee: <https://developer.mozilla.org/en-US/docs/Web/HTTP/Reference/Headers/Range>",
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "in": "path",
+            "name": "dataset_id",
+            "description": "The dataset on which this support bundle was provisioned",
+            "required": true,
+            "schema": {
+              "$ref": "#/components/schemas/DatasetUuid"
+            }
+          },
+          {
+            "in": "path",
+            "name": "file",
+            "description": "The path of the file within the support bundle to query",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "in": "path",
+            "name": "support_bundle_id",
+            "description": "The ID of the support bundle itself",
+            "required": true,
+            "schema": {
+              "$ref": "#/components/schemas/SupportBundleUuid"
+            }
+          },
+          {
+            "in": "path",
+            "name": "zpool_id",
+            "description": "The zpool on which this support bundle was provisioned",
+            "required": true,
+            "schema": {
+              "$ref": "#/components/schemas/ZpoolUuid"
+            }
+          }
+        ],
+        "responses": {
+          "default": {
+            "description": "",
+            "content": {
+              "*/*": {
+                "schema": {}
+              }
+            }
+          }
+        }
+      },
+      "head": {
+        "summary": "Fetch metadata about a file within a support bundle from a particular dataset",
+        "operationId": "support_bundle_head_file",
+        "parameters": [
+          {
+            "in": "header",
+            "name": "range",
+            "description": "A request to access a portion of the resource, such as `bytes=0-499`\n\nSee: <https://developer.mozilla.org/en-US/docs/Web/HTTP/Reference/Headers/Range>",
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "in": "path",
+            "name": "dataset_id",
+            "description": "The dataset on which this support bundle was provisioned",
+            "required": true,
+            "schema": {
+              "$ref": "#/components/schemas/DatasetUuid"
+            }
+          },
+          {
+            "in": "path",
+            "name": "file",
+            "description": "The path of the file within the support bundle to query",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "in": "path",
+            "name": "support_bundle_id",
+            "description": "The ID of the support bundle itself",
+            "required": true,
+            "schema": {
+              "$ref": "#/components/schemas/SupportBundleUuid"
+            }
+          },
+          {
+            "in": "path",
+            "name": "zpool_id",
+            "description": "The zpool on which this support bundle was provisioned",
+            "required": true,
+            "schema": {
+              "$ref": "#/components/schemas/ZpoolUuid"
+            }
+          }
+        ],
+        "responses": {
+          "default": {
+            "description": "",
+            "content": {
+              "*/*": {
+                "schema": {}
+              }
+            }
+          }
+        }
+      }
+    },
+    "/support-bundles/{zpool_id}/{dataset_id}/{support_bundle_id}/finalize": {
+      "post": {
+        "summary": "Finalizes the creation of a support bundle",
+        "description": "If the requested hash matched the bundle, the bundle is created. Otherwise, an error is returned.",
+        "operationId": "support_bundle_finalize",
+        "parameters": [
+          {
+            "in": "path",
+            "name": "dataset_id",
+            "description": "The dataset on which this support bundle was provisioned",
+            "required": true,
+            "schema": {
+              "$ref": "#/components/schemas/DatasetUuid"
+            }
+          },
+          {
+            "in": "path",
+            "name": "support_bundle_id",
+            "description": "The ID of the support bundle itself",
+            "required": true,
+            "schema": {
+              "$ref": "#/components/schemas/SupportBundleUuid"
+            }
+          },
+          {
+            "in": "path",
+            "name": "zpool_id",
+            "description": "The zpool on which this support bundle was provisioned",
+            "required": true,
+            "schema": {
+              "$ref": "#/components/schemas/ZpoolUuid"
+            }
+          },
+          {
+            "in": "query",
+            "name": "hash",
+            "required": true,
+            "schema": {
+              "type": "string",
+              "format": "hex string (32 bytes)"
+            }
+          }
+        ],
+        "responses": {
+          "201": {
+            "description": "successful creation",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/SupportBundleMetadata"
+                }
+              }
+            }
+          },
+          "4XX": {
+            "$ref": "#/components/responses/Error"
+          },
+          "5XX": {
+            "$ref": "#/components/responses/Error"
+          }
+        }
+      }
+    },
+    "/support-bundles/{zpool_id}/{dataset_id}/{support_bundle_id}/index": {
+      "get": {
+        "summary": "Fetch the index (list of files within a support bundle)",
+        "operationId": "support_bundle_index",
+        "parameters": [
+          {
+            "in": "header",
+            "name": "range",
+            "description": "A request to access a portion of the resource, such as `bytes=0-499`\n\nSee: <https://developer.mozilla.org/en-US/docs/Web/HTTP/Reference/Headers/Range>",
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "in": "path",
+            "name": "dataset_id",
+            "description": "The dataset on which this support bundle was provisioned",
+            "required": true,
+            "schema": {
+              "$ref": "#/components/schemas/DatasetUuid"
+            }
+          },
+          {
+            "in": "path",
+            "name": "support_bundle_id",
+            "description": "The ID of the support bundle itself",
+            "required": true,
+            "schema": {
+              "$ref": "#/components/schemas/SupportBundleUuid"
+            }
+          },
+          {
+            "in": "path",
+            "name": "zpool_id",
+            "description": "The zpool on which this support bundle was provisioned",
+            "required": true,
+            "schema": {
+              "$ref": "#/components/schemas/ZpoolUuid"
+            }
+          }
+        ],
+        "responses": {
+          "default": {
+            "description": "",
+            "content": {
+              "*/*": {
+                "schema": {}
+              }
+            }
+          }
+        }
+      },
+      "head": {
+        "summary": "Fetch metadata about the list of files within a support bundle",
+        "operationId": "support_bundle_head_index",
+        "parameters": [
+          {
+            "in": "header",
+            "name": "range",
+            "description": "A request to access a portion of the resource, such as `bytes=0-499`\n\nSee: <https://developer.mozilla.org/en-US/docs/Web/HTTP/Reference/Headers/Range>",
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "in": "path",
+            "name": "dataset_id",
+            "description": "The dataset on which this support bundle was provisioned",
+            "required": true,
+            "schema": {
+              "$ref": "#/components/schemas/DatasetUuid"
+            }
+          },
+          {
+            "in": "path",
+            "name": "support_bundle_id",
+            "description": "The ID of the support bundle itself",
+            "required": true,
+            "schema": {
+              "$ref": "#/components/schemas/SupportBundleUuid"
+            }
+          },
+          {
+            "in": "path",
+            "name": "zpool_id",
+            "description": "The zpool on which this support bundle was provisioned",
+            "required": true,
+            "schema": {
+              "$ref": "#/components/schemas/ZpoolUuid"
+            }
+          }
+        ],
+        "responses": {
+          "default": {
+            "description": "",
+            "content": {
+              "*/*": {
+                "schema": {}
+              }
+            }
+          }
+        }
+      }
+    },
+    "/support-bundles/{zpool_id}/{dataset_id}/{support_bundle_id}/transfer": {
+      "put": {
+        "summary": "Transfers a chunk of a support bundle within a particular dataset",
+        "operationId": "support_bundle_transfer",
+        "parameters": [
+          {
+            "in": "path",
+            "name": "dataset_id",
+            "description": "The dataset on which this support bundle was provisioned",
+            "required": true,
+            "schema": {
+              "$ref": "#/components/schemas/DatasetUuid"
+            }
+          },
+          {
+            "in": "path",
+            "name": "support_bundle_id",
+            "description": "The ID of the support bundle itself",
+            "required": true,
+            "schema": {
+              "$ref": "#/components/schemas/SupportBundleUuid"
+            }
+          },
+          {
+            "in": "path",
+            "name": "zpool_id",
+            "description": "The zpool on which this support bundle was provisioned",
+            "required": true,
+            "schema": {
+              "$ref": "#/components/schemas/ZpoolUuid"
+            }
+          },
+          {
+            "in": "query",
+            "name": "offset",
+            "required": true,
+            "schema": {
+              "type": "integer",
+              "format": "uint64",
+              "minimum": 0
+            }
+          }
+        ],
+        "requestBody": {
+          "content": {
+            "application/octet-stream": {
+              "schema": {
+                "type": "string",
+                "format": "binary"
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "201": {
+            "description": "successful creation",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/SupportBundleMetadata"
+                }
+              }
+            }
+          },
+          "4XX": {
+            "$ref": "#/components/responses/Error"
+          },
+          "5XX": {
+            "$ref": "#/components/responses/Error"
+          }
+        }
+      }
+    },
+    "/switch-ports": {
+      "post": {
+        "operationId": "uplink_ensure",
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/SwitchPorts"
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "204": {
+            "description": "resource updated"
+          },
+          "4XX": {
+            "$ref": "#/components/responses/Error"
+          },
+          "5XX": {
+            "$ref": "#/components/responses/Error"
+          }
+        }
+      }
+    },
+    "/trust-quorum/commit": {
+      "put": {
+        "summary": "Commit a trust quorum configuration",
+        "operationId": "trust_quorum_commit",
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/CommitRequest"
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "204": {
+            "description": "resource updated"
+          },
+          "4XX": {
+            "$ref": "#/components/responses/Error"
+          },
+          "5XX": {
+            "$ref": "#/components/responses/Error"
+          }
+        }
+      }
+    },
+    "/trust-quorum/configuration": {
+      "post": {
+        "summary": "Initiate a trust quorum reconfiguration",
+        "operationId": "trust_quorum_reconfigure",
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/ReconfigureMsg"
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "204": {
+            "description": "resource updated"
+          },
+          "4XX": {
+            "$ref": "#/components/responses/Error"
+          },
+          "5XX": {
+            "$ref": "#/components/responses/Error"
+          }
+        }
+      }
+    },
+    "/trust-quorum/coordinator-status": {
+      "get": {
+        "summary": "Get the coordinator status if this node is coordinating a reconfiguration",
+        "operationId": "trust_quorum_coordinator_status",
+        "responses": {
+          "200": {
+            "description": "successful operation",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/CoordinatorStatus"
+                }
+              }
+            }
+          },
+          "4XX": {
+            "$ref": "#/components/responses/Error"
+          },
+          "5XX": {
+            "$ref": "#/components/responses/Error"
+          }
+        }
+      }
+    },
+    "/trust-quorum/network-config": {
+      "get": {
+        "summary": "Get the current network config from trust quorum",
+        "operationId": "trust_quorum_network_config_get",
+        "responses": {
+          "200": {
+            "description": "successful operation",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/TrustQuorumNetworkConfig"
+                }
+              }
+            }
+          },
+          "4XX": {
+            "$ref": "#/components/responses/Error"
+          },
+          "5XX": {
+            "$ref": "#/components/responses/Error"
+          }
+        }
+      },
+      "put": {
+        "summary": "Update the network config in trust quorum",
+        "operationId": "trust_quorum_network_config_put",
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/TrustQuorumNetworkConfig"
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "204": {
+            "description": "resource updated"
+          },
+          "4XX": {
+            "$ref": "#/components/responses/Error"
+          },
+          "5XX": {
+            "$ref": "#/components/responses/Error"
+          }
+        }
+      }
+    },
+    "/trust-quorum/prepare-and-commit": {
+      "put": {
+        "summary": "Attempt to prepare and commit a trust quorum configuration",
+        "operationId": "trust_quorum_prepare_and_commit",
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/PrepareAndCommitRequest"
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "200": {
+            "description": "successful operation",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/CommitStatus"
+                }
+              }
+            }
+          },
+          "4XX": {
+            "$ref": "#/components/responses/Error"
+          },
+          "5XX": {
+            "$ref": "#/components/responses/Error"
+          }
+        }
+      }
+    },
+    "/trust-quorum/proxy/commit": {
+      "put": {
+        "summary": "Proxy a commit operation to another trust quorum node",
+        "operationId": "trust_quorum_proxy_commit",
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/ProxyCommitRequest"
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "204": {
+            "description": "resource updated"
+          },
+          "4XX": {
+            "$ref": "#/components/responses/Error"
+          },
+          "5XX": {
+            "$ref": "#/components/responses/Error"
+          }
+        }
+      }
+    },
+    "/trust-quorum/proxy/prepare-and-commit": {
+      "put": {
+        "summary": "Proxy a prepare-and-commit operation to another trust quorum node",
+        "operationId": "trust_quorum_proxy_prepare_and_commit",
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/ProxyPrepareAndCommitRequest"
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "200": {
+            "description": "successful operation",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/CommitStatus"
+                }
+              }
+            }
+          },
+          "4XX": {
+            "$ref": "#/components/responses/Error"
+          },
+          "5XX": {
+            "$ref": "#/components/responses/Error"
+          }
+        }
+      }
+    },
+    "/trust-quorum/proxy/status": {
+      "get": {
+        "summary": "Proxy a status request to another trust quorum node",
+        "operationId": "trust_quorum_proxy_status",
+        "parameters": [
+          {
+            "in": "query",
+            "name": "part_number",
+            "description": "Oxide Part Number",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "in": "query",
+            "name": "serial_number",
+            "description": "Serial number (unique for a given part number)",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "successful operation",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/NodeStatus"
+                }
+              }
+            }
+          },
+          "4XX": {
+            "$ref": "#/components/responses/Error"
+          },
+          "5XX": {
+            "$ref": "#/components/responses/Error"
+          }
+        }
+      }
+    },
+    "/trust-quorum/status": {
+      "get": {
+        "summary": "Get the status of this trust quorum node",
+        "operationId": "trust_quorum_status",
+        "responses": {
+          "200": {
+            "description": "successful operation",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/NodeStatus"
+                }
+              }
+            }
+          },
+          "4XX": {
+            "$ref": "#/components/responses/Error"
+          },
+          "5XX": {
+            "$ref": "#/components/responses/Error"
+          }
+        }
+      }
+    },
+    "/trust-quorum/upgrade": {
+      "post": {
+        "summary": "Initiate an upgrade from LRTQ",
+        "operationId": "trust_quorum_upgrade_from_lrtq",
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/LrtqUpgradeMsg"
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "204": {
+            "description": "resource updated"
+          },
+          "4XX": {
+            "$ref": "#/components/responses/Error"
+          },
+          "5XX": {
+            "$ref": "#/components/responses/Error"
+          }
+        }
+      }
+    },
+    "/v2p": {
+      "get": {
+        "summary": "List v2p mappings present on sled",
+        "operationId": "list_v2p",
+        "responses": {
+          "200": {
+            "description": "successful operation",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "title": "Array_of_VirtualNetworkInterfaceHost",
+                  "type": "array",
+                  "items": {
+                    "$ref": "#/components/schemas/VirtualNetworkInterfaceHost"
+                  }
+                }
+              }
+            }
+          },
+          "4XX": {
+            "$ref": "#/components/responses/Error"
+          },
+          "5XX": {
+            "$ref": "#/components/responses/Error"
+          }
+        }
+      },
+      "put": {
+        "summary": "Create a mapping from a virtual NIC to a physical host",
+        "operationId": "set_v2p",
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/VirtualNetworkInterfaceHost"
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "204": {
+            "description": "resource updated"
+          },
+          "4XX": {
+            "$ref": "#/components/responses/Error"
+          },
+          "5XX": {
+            "$ref": "#/components/responses/Error"
+          }
+        }
+      },
+      "delete": {
+        "summary": "Delete a mapping from a virtual NIC to a physical host",
+        "operationId": "del_v2p",
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/VirtualNetworkInterfaceHost"
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "204": {
+            "description": "resource updated"
+          },
+          "4XX": {
+            "$ref": "#/components/responses/Error"
+          },
+          "5XX": {
+            "$ref": "#/components/responses/Error"
+          }
+        }
+      }
+    },
+    "/vmms/{propolis_id}": {
+      "put": {
+        "operationId": "vmm_register",
+        "parameters": [
+          {
+            "in": "path",
+            "name": "propolis_id",
+            "required": true,
+            "schema": {
+              "$ref": "#/components/schemas/PropolisUuid"
+            }
+          }
+        ],
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/InstanceEnsureBody"
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "200": {
+            "description": "successful operation",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/SledVmmState"
+                }
+              }
+            }
+          },
+          "4XX": {
+            "$ref": "#/components/responses/Error"
+          },
+          "5XX": {
+            "$ref": "#/components/responses/Error"
+          }
+        }
+      },
+      "delete": {
+        "operationId": "vmm_unregister",
+        "parameters": [
+          {
+            "in": "path",
+            "name": "propolis_id",
+            "required": true,
+            "schema": {
+              "$ref": "#/components/schemas/PropolisUuid"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "successful operation",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/VmmUnregisterResponse"
+                }
+              }
+            }
+          },
+          "4XX": {
+            "$ref": "#/components/responses/Error"
+          },
+          "5XX": {
+            "$ref": "#/components/responses/Error"
+          }
+        }
+      }
+    },
+    "/vmms/{propolis_id}/disks/{disk_id}/snapshot": {
+      "post": {
+        "summary": "Take a snapshot of a disk that is attached to an instance",
+        "operationId": "vmm_issue_disk_snapshot_request",
+        "parameters": [
+          {
+            "in": "path",
+            "name": "disk_id",
+            "required": true,
+            "schema": {
+              "type": "string",
+              "format": "uuid"
+            }
+          },
+          {
+            "in": "path",
+            "name": "propolis_id",
+            "required": true,
+            "schema": {
+              "$ref": "#/components/schemas/PropolisUuid"
+            }
+          }
+        ],
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/VmmIssueDiskSnapshotRequestBody"
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "200": {
+            "description": "successful operation",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/VmmIssueDiskSnapshotRequestResponse"
+                }
+              }
+            }
+          },
+          "4XX": {
+            "$ref": "#/components/responses/Error"
+          },
+          "5XX": {
+            "$ref": "#/components/responses/Error"
+          }
+        }
+      }
+    },
+    "/vmms/{propolis_id}/external-ip": {
+      "put": {
+        "operationId": "vmm_put_external_ip",
+        "parameters": [
+          {
+            "in": "path",
+            "name": "propolis_id",
+            "required": true,
+            "schema": {
+              "$ref": "#/components/schemas/PropolisUuid"
+            }
+          }
+        ],
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/InstanceExternalIpBody"
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "204": {
+            "description": "resource updated"
+          },
+          "4XX": {
+            "$ref": "#/components/responses/Error"
+          },
+          "5XX": {
+            "$ref": "#/components/responses/Error"
+          }
+        }
+      },
+      "delete": {
+        "operationId": "vmm_delete_external_ip",
+        "parameters": [
+          {
+            "in": "path",
+            "name": "propolis_id",
+            "required": true,
+            "schema": {
+              "$ref": "#/components/schemas/PropolisUuid"
+            }
+          }
+        ],
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/InstanceExternalIpBody"
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "204": {
+            "description": "resource updated"
+          },
+          "4XX": {
+            "$ref": "#/components/responses/Error"
+          },
+          "5XX": {
+            "$ref": "#/components/responses/Error"
+          }
+        }
+      }
+    },
+    "/vmms/{propolis_id}/multicast-group": {
+      "put": {
+        "operationId": "vmm_join_multicast_group",
+        "parameters": [
+          {
+            "in": "path",
+            "name": "propolis_id",
+            "required": true,
+            "schema": {
+              "$ref": "#/components/schemas/PropolisUuid"
+            }
+          }
+        ],
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/InstanceMulticastBody"
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "204": {
+            "description": "resource updated"
+          },
+          "4XX": {
+            "$ref": "#/components/responses/Error"
+          },
+          "5XX": {
+            "$ref": "#/components/responses/Error"
+          }
+        }
+      },
+      "delete": {
+        "operationId": "vmm_leave_multicast_group",
+        "parameters": [
+          {
+            "in": "path",
+            "name": "propolis_id",
+            "required": true,
+            "schema": {
+              "$ref": "#/components/schemas/PropolisUuid"
+            }
+          }
+        ],
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/InstanceMulticastBody"
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "204": {
+            "description": "resource updated"
+          },
+          "4XX": {
+            "$ref": "#/components/responses/Error"
+          },
+          "5XX": {
+            "$ref": "#/components/responses/Error"
+          }
+        }
+      }
+    },
+    "/vmms/{propolis_id}/state": {
+      "get": {
+        "operationId": "vmm_get_state",
+        "parameters": [
+          {
+            "in": "path",
+            "name": "propolis_id",
+            "required": true,
+            "schema": {
+              "$ref": "#/components/schemas/PropolisUuid"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "successful operation",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/SledVmmState"
+                }
+              }
+            }
+          },
+          "4XX": {
+            "$ref": "#/components/responses/Error"
+          },
+          "5XX": {
+            "$ref": "#/components/responses/Error"
+          }
+        }
+      },
+      "put": {
+        "operationId": "vmm_put_state",
+        "parameters": [
+          {
+            "in": "path",
+            "name": "propolis_id",
+            "required": true,
+            "schema": {
+              "$ref": "#/components/schemas/PropolisUuid"
+            }
+          }
+        ],
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/VmmPutStateBody"
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "200": {
+            "description": "successful operation",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/VmmPutStateResponse"
+                }
+              }
+            }
+          },
+          "4XX": {
+            "$ref": "#/components/responses/Error"
+          },
+          "5XX": {
+            "$ref": "#/components/responses/Error"
+          }
+        }
+      }
+    },
+    "/vpc/{vpc_id}/firewall/rules": {
+      "put": {
+        "operationId": "vpc_firewall_rules_put",
+        "parameters": [
+          {
+            "in": "path",
+            "name": "vpc_id",
+            "required": true,
+            "schema": {
+              "type": "string",
+              "format": "uuid"
+            }
+          }
+        ],
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/VpcFirewallRulesEnsureBody"
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "204": {
+            "description": "resource updated"
+          },
+          "4XX": {
+            "$ref": "#/components/responses/Error"
+          },
+          "5XX": {
+            "$ref": "#/components/responses/Error"
+          }
+        }
+      }
+    },
+    "/vpc-routes": {
+      "get": {
+        "summary": "Get the current versions of VPC routing rules.",
+        "operationId": "list_vpc_routes",
+        "responses": {
+          "200": {
+            "description": "successful operation",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "title": "Array_of_ResolvedVpcRouteState",
+                  "type": "array",
+                  "items": {
+                    "$ref": "#/components/schemas/ResolvedVpcRouteState"
+                  }
+                }
+              }
+            }
+          },
+          "4XX": {
+            "$ref": "#/components/responses/Error"
+          },
+          "5XX": {
+            "$ref": "#/components/responses/Error"
+          }
+        }
+      },
+      "put": {
+        "summary": "Update VPC routing rules.",
+        "operationId": "set_vpc_routes",
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "title": "Array_of_ResolvedVpcRouteSet",
+                "type": "array",
+                "items": {
+                  "$ref": "#/components/schemas/ResolvedVpcRouteSet"
+                }
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "204": {
+            "description": "resource updated"
+          },
+          "4XX": {
+            "$ref": "#/components/responses/Error"
+          },
+          "5XX": {
+            "$ref": "#/components/responses/Error"
+          }
+        }
+      }
+    },
+    "/zones": {
+      "get": {
+        "summary": "List the zones that are currently managed by the sled agent.",
+        "operationId": "zones_list",
+        "responses": {
+          "200": {
+            "description": "successful operation",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "title": "Array_of_String",
+                  "type": "array",
+                  "items": {
+                    "type": "string"
+                  }
+                }
+              }
+            }
+          },
+          "4XX": {
+            "$ref": "#/components/responses/Error"
+          },
+          "5XX": {
+            "$ref": "#/components/responses/Error"
+          }
+        }
+      }
+    },
+    "/zones/bundle-cleanup": {
+      "post": {
+        "summary": "Trigger a zone bundle cleanup.",
+        "operationId": "zone_bundle_cleanup",
+        "responses": {
+          "200": {
+            "description": "successful operation",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "title": "Map_of_CleanupCount",
+                  "type": "object",
+                  "additionalProperties": {
+                    "$ref": "#/components/schemas/CleanupCount"
+                  }
+                }
+              }
+            }
+          },
+          "4XX": {
+            "$ref": "#/components/responses/Error"
+          },
+          "5XX": {
+            "$ref": "#/components/responses/Error"
+          }
+        }
+      }
+    },
+    "/zones/bundle-cleanup/context": {
+      "get": {
+        "summary": "Return context used by the zone-bundle cleanup task.",
+        "operationId": "zone_bundle_cleanup_context",
+        "responses": {
+          "200": {
+            "description": "successful operation",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/CleanupContext"
+                }
+              }
+            }
+          },
+          "4XX": {
+            "$ref": "#/components/responses/Error"
+          },
+          "5XX": {
+            "$ref": "#/components/responses/Error"
+          }
+        }
+      },
+      "put": {
+        "summary": "Update context used by the zone-bundle cleanup task.",
+        "operationId": "zone_bundle_cleanup_context_update",
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/CleanupContextUpdate"
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "204": {
+            "description": "resource updated"
+          },
+          "4XX": {
+            "$ref": "#/components/responses/Error"
+          },
+          "5XX": {
+            "$ref": "#/components/responses/Error"
+          }
+        }
+      }
+    },
+    "/zones/bundle-cleanup/utilization": {
+      "get": {
+        "summary": "Return utilization information about all zone bundles.",
+        "operationId": "zone_bundle_utilization",
+        "responses": {
+          "200": {
+            "description": "successful operation",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "title": "Map_of_BundleUtilization",
+                  "type": "object",
+                  "additionalProperties": {
+                    "$ref": "#/components/schemas/BundleUtilization"
+                  }
+                }
+              }
+            }
+          },
+          "4XX": {
+            "$ref": "#/components/responses/Error"
+          },
+          "5XX": {
+            "$ref": "#/components/responses/Error"
+          }
+        }
+      }
+    },
+    "/zones/bundles": {
+      "get": {
+        "summary": "List all zone bundles that exist, even for now-deleted zones.",
+        "operationId": "zone_bundle_list_all",
+        "parameters": [
+          {
+            "in": "query",
+            "name": "filter",
+            "description": "An optional substring used to filter zone bundles.",
+            "schema": {
+              "nullable": true,
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "successful operation",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "title": "Array_of_ZoneBundleMetadata",
+                  "type": "array",
+                  "items": {
+                    "$ref": "#/components/schemas/ZoneBundleMetadata"
+                  }
+                }
+              }
+            }
+          },
+          "4XX": {
+            "$ref": "#/components/responses/Error"
+          },
+          "5XX": {
+            "$ref": "#/components/responses/Error"
+          }
+        }
+      }
+    },
+    "/zones/bundles/{zone_name}": {
+      "get": {
+        "summary": "List the zone bundles that are available for a running zone.",
+        "operationId": "zone_bundle_list",
+        "parameters": [
+          {
+            "in": "path",
+            "name": "zone_name",
+            "description": "The name of the zone.",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "successful operation",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "title": "Array_of_ZoneBundleMetadata",
+                  "type": "array",
+                  "items": {
+                    "$ref": "#/components/schemas/ZoneBundleMetadata"
+                  }
+                }
+              }
+            }
+          },
+          "4XX": {
+            "$ref": "#/components/responses/Error"
+          },
+          "5XX": {
+            "$ref": "#/components/responses/Error"
+          }
+        }
+      }
+    },
+    "/zones/bundles/{zone_name}/{bundle_id}": {
+      "get": {
+        "summary": "Fetch the binary content of a single zone bundle.",
+        "operationId": "zone_bundle_get",
+        "parameters": [
+          {
+            "in": "path",
+            "name": "bundle_id",
+            "description": "The ID for this bundle itself.",
+            "required": true,
+            "schema": {
+              "type": "string",
+              "format": "uuid"
+            }
+          },
+          {
+            "in": "path",
+            "name": "zone_name",
+            "description": "The name of the zone this bundle is derived from.",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "",
+            "content": {
+              "*/*": {
+                "schema": {}
+              }
+            }
+          },
+          "4XX": {
+            "$ref": "#/components/responses/Error"
+          },
+          "5XX": {
+            "$ref": "#/components/responses/Error"
+          }
+        }
+      },
+      "delete": {
+        "summary": "Delete a zone bundle.",
+        "operationId": "zone_bundle_delete",
+        "parameters": [
+          {
+            "in": "path",
+            "name": "bundle_id",
+            "description": "The ID for this bundle itself.",
+            "required": true,
+            "schema": {
+              "type": "string",
+              "format": "uuid"
+            }
+          },
+          {
+            "in": "path",
+            "name": "zone_name",
+            "description": "The name of the zone this bundle is derived from.",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "204": {
+            "description": "successful deletion"
+          },
+          "4XX": {
+            "$ref": "#/components/responses/Error"
+          },
+          "5XX": {
+            "$ref": "#/components/responses/Error"
+          }
+        }
+      }
+    }
+  },
+  "components": {
+    "schemas": {
+      "AddSledRequest": {
+        "description": "A request to Add a given sled after rack initialization has occurred",
+        "type": "object",
+        "properties": {
+          "sled_id": {
+            "$ref": "#/components/schemas/BaseboardId"
+          },
+          "start_request": {
+            "$ref": "#/components/schemas/StartSledAgentRequest"
+          }
+        },
+        "required": [
+          "sled_id",
+          "start_request"
+        ]
+      },
+      "Alarm": {
+        "description": "An alarm indicating a protocol invariant violation.",
+        "oneOf": [
+          {
+            "description": "Different configurations found for the same epoch.\n\nReason: Nexus creates configurations and stores them in CRDB before sending them to a coordinator of its choosing. Nexus will not send the same reconfiguration request to different coordinators. If it does those coordinators will generate different key shares. However, since Nexus will not tell different nodes to coordinate the same configuration, this state should be impossible to reach.",
+            "type": "object",
+            "properties": {
+              "mismatched_configurations": {
+                "type": "object",
+                "properties": {
+                  "config1": {
+                    "$ref": "#/components/schemas/Configuration"
+                  },
+                  "config2": {
+                    "$ref": "#/components/schemas/Configuration"
+                  },
+                  "from": {
+                    "description": "Either a stringified `BaseboardId` or \"Nexus\".",
+                    "type": "string"
+                  }
+                },
+                "required": [
+                  "config1",
+                  "config2",
+                  "from"
+                ]
+              }
+            },
+            "required": [
+              "mismatched_configurations"
+            ],
+            "additionalProperties": false
+          },
+          {
+            "description": "The `keyShareComputer` could not compute this node's share.\n\nReason: A threshold of valid key shares were received based on the the share digests in the Configuration. However, computation of the share still failed. This should be impossible.",
+            "type": "object",
+            "properties": {
+              "share_computation_failed": {
+                "type": "object",
+                "properties": {
+                  "epoch": {
+                    "type": "integer",
+                    "format": "uint64",
+                    "minimum": 0
+                  },
+                  "err": {
+                    "$ref": "#/components/schemas/CombineError"
+                  }
+                },
+                "required": [
+                  "epoch",
+                  "err"
+                ]
+              }
+            },
+            "required": [
+              "share_computation_failed"
+            ],
+            "additionalProperties": false
+          },
+          {
+            "description": "We started collecting shares for a committed configuration, but we no longer have that configuration in our persistent state.",
+            "type": "object",
+            "properties": {
+              "committed_configuration_lost": {
+                "type": "object",
+                "properties": {
+                  "collecting_epoch": {
+                    "type": "integer",
+                    "format": "uint64",
+                    "minimum": 0
+                  },
+                  "latest_committed_epoch": {
+                    "type": "integer",
+                    "format": "uint64",
+                    "minimum": 0
+                  }
+                },
+                "required": [
+                  "collecting_epoch",
+                  "latest_committed_epoch"
+                ]
+              }
+            },
+            "required": [
+              "committed_configuration_lost"
+            ],
+            "additionalProperties": false
+          },
+          {
+            "description": "Decrypting the encrypted rack secrets failed when presented with a `valid` RackSecret.\n\n`Configuration` membership contains the hashes of each valid share. All shares utilized to reconstruct the rack secret were validated against these hashes, and the rack secret was reconstructed. However, using the rack secret to derive encryption keys and decrypt the secrets from old configurations still failed. This should never be possible, and therefore we raise an alarm.",
+            "type": "object",
+            "properties": {
+              "rack_secret_decryption_failed": {
+                "type": "object",
+                "properties": {
+                  "epoch": {
+                    "type": "integer",
+                    "format": "uint64",
+                    "minimum": 0
+                  },
+                  "err": {
+                    "$ref": "#/components/schemas/DecryptionError"
+                  }
+                },
+                "required": [
+                  "epoch",
+                  "err"
+                ]
+              }
+            },
+            "required": [
+              "rack_secret_decryption_failed"
+            ],
+            "additionalProperties": false
+          },
+          {
+            "description": "Reconstructing the rack secret failed when presented with `valid` shares.\n\n`Configuration` membership contains the hashes of each valid share. All shares utilized to reconstruct the rack secret were validated against these hashes, and yet, the reconstruction still failed. This indicates either a bit flip in a share after validation, or, more likely, an invalid hash.",
+            "type": "object",
+            "properties": {
+              "rack_secret_reconstruction_failed": {
+                "type": "object",
+                "properties": {
+                  "epoch": {
+                    "type": "integer",
+                    "format": "uint64",
+                    "minimum": 0
+                  },
+                  "err": {
+                    "$ref": "#/components/schemas/RackSecretReconstructError"
+                  }
+                },
+                "required": [
+                  "epoch",
+                  "err"
+                ]
+              }
+            },
+            "required": [
+              "rack_secret_reconstruction_failed"
+            ],
+            "additionalProperties": false
+          }
+        ]
+      },
+      "ArtifactConfig": {
+        "description": "Artifact configuration.\n\nThis type is used in both GET (response) and PUT (request) operations.",
+        "type": "object",
+        "properties": {
+          "artifacts": {
+            "type": "array",
+            "items": {
+              "type": "string",
+              "format": "hex string (32 bytes)"
+            },
+            "uniqueItems": true
+          },
+          "generation": {
+            "$ref": "#/components/schemas/Generation"
+          }
+        },
+        "required": [
+          "artifacts",
+          "generation"
+        ]
+      },
+      "ArtifactCopyFromDepotBody": {
+        "description": "Request body for copying artifacts from a depot.",
+        "type": "object",
+        "properties": {
+          "depot_base_url": {
+            "type": "string"
+          }
+        },
+        "required": [
+          "depot_base_url"
+        ]
+      },
+      "ArtifactCopyFromDepotResponse": {
+        "description": "Response for copying artifacts from a depot.",
+        "type": "object"
+      },
+      "ArtifactListResponse": {
+        "description": "Response for listing artifacts.",
+        "type": "object",
+        "properties": {
+          "generation": {
+            "$ref": "#/components/schemas/Generation"
+          },
+          "list": {
+            "type": "object",
+            "additionalProperties": {
+              "type": "integer",
+              "format": "uint",
+              "minimum": 0
+            }
+          }
+        },
+        "required": [
+          "generation",
+          "list"
+        ]
+      },
+      "ArtifactPutResponse": {
+        "description": "Response for putting an artifact.",
+        "type": "object",
+        "properties": {
+          "datasets": {
+            "description": "The number of valid M.2 artifact datasets we found on the sled. There is typically one of these datasets for each functional M.2.",
+            "type": "integer",
+            "format": "uint",
+            "minimum": 0
+          },
+          "successful_writes": {
+            "description": "The number of valid writes to the M.2 artifact datasets. This should be less than or equal to the number of artifact datasets.",
+            "type": "integer",
+            "format": "uint",
+            "minimum": 0
+          }
+        },
+        "required": [
+          "datasets",
+          "successful_writes"
+        ]
+      },
+      "Baseboard": {
+        "description": "Describes properties that should uniquely identify a Gimlet.",
+        "oneOf": [
+          {
+            "type": "object",
+            "properties": {
+              "identifier": {
+                "type": "string"
+              },
+              "model": {
+                "type": "string"
+              },
+              "revision": {
+                "type": "integer",
+                "format": "uint32",
+                "minimum": 0
+              },
+              "type": {
+                "type": "string",
+                "enum": [
+                  "gimlet"
+                ]
+              }
+            },
+            "required": [
+              "identifier",
+              "model",
+              "revision",
+              "type"
+            ]
+          },
+          {
+            "type": "object",
+            "properties": {
+              "type": {
+                "type": "string",
+                "enum": [
+                  "unknown"
+                ]
+              }
+            },
+            "required": [
+              "type"
+            ]
+          },
+          {
+            "type": "object",
+            "properties": {
+              "identifier": {
+                "type": "string"
+              },
+              "model": {
+                "type": "string"
+              },
+              "type": {
+                "type": "string",
+                "enum": [
+                  "pc"
+                ]
+              }
+            },
+            "required": [
+              "identifier",
+              "model",
+              "type"
+            ]
+          }
+        ]
+      },
+      "BaseboardId": {
+        "description": "A representation of a Baseboard ID as used in the inventory subsystem.\n\nThis type is essentially the same as a `Baseboard` except it doesn't have a revision or HW type (Gimlet, PC, Unknown).",
+        "type": "object",
+        "properties": {
+          "part_number": {
+            "description": "Oxide Part Number",
+            "type": "string"
+          },
+          "serial_number": {
+            "description": "Serial number (unique for a given part number)",
+            "type": "string"
+          }
+        },
+        "required": [
+          "part_number",
+          "serial_number"
+        ]
+      },
+      "BfdMode": {
+        "description": "BFD connection mode.",
+        "type": "string",
+        "enum": [
+          "single_hop",
+          "multi_hop"
+        ]
+      },
+      "BfdPeerConfig": {
+        "type": "object",
+        "properties": {
+          "detection_threshold": {
+            "type": "integer",
+            "format": "uint8",
+            "minimum": 0
+          },
+          "local": {
+            "nullable": true,
+            "type": "string",
+            "format": "ip"
+          },
+          "mode": {
+            "$ref": "#/components/schemas/BfdMode"
+          },
+          "remote": {
+            "type": "string",
+            "format": "ip"
+          },
+          "required_rx": {
+            "type": "integer",
+            "format": "uint64",
+            "minimum": 0
+          },
+          "switch": {
+            "$ref": "#/components/schemas/SwitchLocation"
+          }
+        },
+        "required": [
+          "detection_threshold",
+          "mode",
+          "remote",
+          "required_rx",
+          "switch"
+        ]
+      },
+      "BgpConfig": {
+        "type": "object",
+        "properties": {
+          "asn": {
+            "description": "The autonomous system number for the BGP configuration.",
+            "type": "integer",
+            "format": "uint32",
+            "minimum": 0
+          },
+          "checker": {
+            "nullable": true,
+            "description": "Checker to apply to incoming messages.",
+            "default": null,
+            "type": "string"
+          },
+          "originate": {
+            "description": "The set of prefixes for the BGP router to originate.",
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/Ipv4Net"
+            }
+          },
+          "shaper": {
+            "nullable": true,
+            "description": "Shaper to apply to outgoing messages.",
+            "default": null,
+            "type": "string"
+          }
+        },
+        "required": [
+          "asn",
+          "originate"
+        ]
+      },
+      "BgpPeerConfig": {
+        "type": "object",
+        "properties": {
+          "addr": {
+            "description": "Address of the peer.",
+            "type": "string",
+            "format": "ipv4"
+          },
+          "allowed_export": {
+            "description": "Define export policy for a peer.",
+            "default": {
+              "type": "no_filtering"
+            },
+            "allOf": [
+              {
+                "$ref": "#/components/schemas/ImportExportPolicy"
+              }
+            ]
+          },
+          "allowed_import": {
+            "description": "Define import policy for a peer.",
+            "default": {
+              "type": "no_filtering"
+            },
+            "allOf": [
+              {
+                "$ref": "#/components/schemas/ImportExportPolicy"
+              }
+            ]
+          },
+          "asn": {
+            "description": "The autonomous system number of the router the peer belongs to.",
+            "type": "integer",
+            "format": "uint32",
+            "minimum": 0
+          },
+          "communities": {
+            "description": "Include the provided communities in updates sent to the peer.",
+            "default": [],
+            "type": "array",
+            "items": {
+              "type": "integer",
+              "format": "uint32",
+              "minimum": 0
+            }
+          },
+          "connect_retry": {
+            "nullable": true,
+            "description": "The interval in seconds between peer connection retry attempts.",
+            "type": "integer",
+            "format": "uint64",
+            "minimum": 0
+          },
+          "delay_open": {
+            "nullable": true,
+            "description": "How long to delay sending open messages to a peer. In seconds.",
+            "type": "integer",
+            "format": "uint64",
+            "minimum": 0
+          },
+          "enforce_first_as": {
+            "description": "Enforce that the first AS in paths received from this peer is the peer's AS.",
+            "default": false,
+            "type": "boolean"
+          },
+          "hold_time": {
+            "nullable": true,
+            "description": "How long to keep a session alive without a keepalive in seconds. Defaults to 6.",
+            "type": "integer",
+            "format": "uint64",
+            "minimum": 0
+          },
+          "idle_hold_time": {
+            "nullable": true,
+            "description": "How long to keep a peer in idle after a state machine reset in seconds.",
+            "type": "integer",
+            "format": "uint64",
+            "minimum": 0
+          },
+          "keepalive": {
+            "nullable": true,
+            "description": "The interval to send keepalive messages at.",
+            "type": "integer",
+            "format": "uint64",
+            "minimum": 0
+          },
+          "local_pref": {
+            "nullable": true,
+            "description": "Apply a local preference to routes received from this peer.",
+            "default": null,
+            "type": "integer",
+            "format": "uint32",
+            "minimum": 0
+          },
+          "md5_auth_key": {
+            "nullable": true,
+            "description": "Use the given key for TCP-MD5 authentication with the peer.",
+            "default": null,
+            "type": "string"
+          },
+          "min_ttl": {
+            "nullable": true,
+            "description": "Require messages from a peer have a minimum IP time to live field.",
+            "default": null,
+            "type": "integer",
+            "format": "uint8",
+            "minimum": 0
+          },
+          "multi_exit_discriminator": {
+            "nullable": true,
+            "description": "Apply the provided multi-exit discriminator (MED) updates sent to the peer.",
+            "default": null,
+            "type": "integer",
+            "format": "uint32",
+            "minimum": 0
+          },
+          "port": {
+            "description": "Switch port the peer is reachable on.",
+            "type": "string"
+          },
+          "remote_asn": {
+            "nullable": true,
+            "description": "Require that a peer has a specified ASN.",
+            "default": null,
+            "type": "integer",
+            "format": "uint32",
+            "minimum": 0
+          },
+          "vlan_id": {
+            "nullable": true,
+            "description": "Associate a VLAN ID with a BGP peer session.",
+            "default": null,
+            "type": "integer",
+            "format": "uint16",
+            "minimum": 0
+          }
+        },
+        "required": [
+          "addr",
+          "asn",
+          "port"
+        ]
+      },
+      "BlobStorageBackend": {
+        "description": "A storage backend for a disk whose initial contents are given explicitly by the specification.",
+        "type": "object",
+        "properties": {
+          "base64": {
+            "description": "The disk's initial contents, encoded as a base64 string.",
+            "type": "string"
+          },
+          "readonly": {
+            "description": "Indicates whether the storage is read-only.",
+            "type": "boolean"
+          }
+        },
+        "required": [
+          "base64",
+          "readonly"
+        ],
+        "additionalProperties": false
+      },
+      "Board": {
+        "description": "A VM's mainboard.",
+        "type": "object",
+        "properties": {
+          "chipset": {
+            "description": "The chipset to expose to guest software.",
+            "allOf": [
+              {
+                "$ref": "#/components/schemas/Chipset"
+              }
+            ]
+          },
+          "cpuid": {
+            "nullable": true,
+            "description": "The CPUID values to expose to the guest. If `None`, bhyve will derive default values from the host's CPUID values.",
+            "allOf": [
+              {
+                "$ref": "#/components/schemas/Cpuid"
+              }
+            ]
+          },
+          "cpus": {
+            "description": "The number of virtual logical processors attached to this VM.",
+            "type": "integer",
+            "format": "uint8",
+            "minimum": 0
+          },
+          "guest_hv_interface": {
+            "description": "The hypervisor platform to expose to the guest. The default is a bhyve-compatible interface with no additional features.\n\nFor compatibility with older versions of Propolis, this field is only serialized if it specifies a non-default interface.",
+            "allOf": [
+              {
+                "$ref": "#/components/schemas/GuestHypervisorInterface"
+              }
+            ]
+          },
+          "memory_mb": {
+            "description": "The amount of guest RAM attached to this VM.",
+            "type": "integer",
+            "format": "uint64",
+            "minimum": 0
+          }
+        },
+        "required": [
+          "chipset",
+          "cpus",
+          "memory_mb"
+        ],
+        "additionalProperties": false
+      },
+      "BootImageHeader": {
+        "type": "object",
+        "properties": {
+          "data_size": {
+            "type": "integer",
+            "format": "uint64",
+            "minimum": 0
+          },
+          "flags": {
+            "type": "integer",
+            "format": "uint64",
+            "minimum": 0
+          },
+          "image_name": {
+            "type": "string"
+          },
+          "image_size": {
+            "type": "integer",
+            "format": "uint64",
+            "minimum": 0
+          },
+          "sha256": {
+            "type": "array",
+            "items": {
+              "type": "integer",
+              "format": "uint8",
+              "minimum": 0
+            },
+            "minItems": 32,
+            "maxItems": 32
+          },
+          "target_size": {
+            "type": "integer",
+            "format": "uint64",
+            "minimum": 0
+          }
+        },
+        "required": [
+          "data_size",
+          "flags",
+          "image_name",
+          "image_size",
+          "sha256",
+          "target_size"
+        ]
+      },
+      "BootOrderEntry": {
+        "description": "An entry in the boot order stored in a [`BootSettings`] component.",
+        "type": "object",
+        "properties": {
+          "id": {
+            "description": "The ID of another component in the spec that Propolis should try to boot from.\n\nCurrently, only disk device components are supported.",
+            "allOf": [
+              {
+                "$ref": "#/components/schemas/SpecKey"
+              }
+            ]
+          }
+        },
+        "required": [
+          "id"
+        ]
+      },
+      "BootPartitionContents": {
+        "type": "object",
+        "properties": {
+          "boot_disk": {
+            "x-rust-type": {
+              "crate": "std",
+              "parameters": [
+                {
+                  "$ref": "#/components/schemas/M2Slot"
+                },
+                {
+                  "type": "string"
+                }
+              ],
+              "path": "::std::result::Result",
+              "version": "*"
+            },
+            "oneOf": [
+              {
+                "type": "object",
+                "properties": {
+                  "ok": {
+                    "$ref": "#/components/schemas/M2Slot"
+                  }
+                },
+                "required": [
+                  "ok"
+                ]
+              },
+              {
+                "type": "object",
+                "properties": {
+                  "err": {
+                    "type": "string"
+                  }
+                },
+                "required": [
+                  "err"
+                ]
+              }
+            ]
+          },
+          "slot_a": {
+            "x-rust-type": {
+              "crate": "std",
+              "parameters": [
+                {
+                  "$ref": "#/components/schemas/BootPartitionDetails"
+                },
+                {
+                  "type": "string"
+                }
+              ],
+              "path": "::std::result::Result",
+              "version": "*"
+            },
+            "oneOf": [
+              {
+                "type": "object",
+                "properties": {
+                  "ok": {
+                    "$ref": "#/components/schemas/BootPartitionDetails"
+                  }
+                },
+                "required": [
+                  "ok"
+                ]
+              },
+              {
+                "type": "object",
+                "properties": {
+                  "err": {
+                    "type": "string"
+                  }
+                },
+                "required": [
+                  "err"
+                ]
+              }
+            ]
+          },
+          "slot_b": {
+            "x-rust-type": {
+              "crate": "std",
+              "parameters": [
+                {
+                  "$ref": "#/components/schemas/BootPartitionDetails"
+                },
+                {
+                  "type": "string"
+                }
+              ],
+              "path": "::std::result::Result",
+              "version": "*"
+            },
+            "oneOf": [
+              {
+                "type": "object",
+                "properties": {
+                  "ok": {
+                    "$ref": "#/components/schemas/BootPartitionDetails"
+                  }
+                },
+                "required": [
+                  "ok"
+                ]
+              },
+              {
+                "type": "object",
+                "properties": {
+                  "err": {
+                    "type": "string"
+                  }
+                },
+                "required": [
+                  "err"
+                ]
+              }
+            ]
+          }
+        },
+        "required": [
+          "boot_disk",
+          "slot_a",
+          "slot_b"
+        ]
+      },
+      "BootPartitionDetails": {
+        "type": "object",
+        "properties": {
+          "artifact_hash": {
+            "type": "string",
+            "format": "hex string (32 bytes)"
+          },
+          "artifact_size": {
+            "type": "integer",
+            "format": "uint",
+            "minimum": 0
+          },
+          "header": {
+            "$ref": "#/components/schemas/BootImageHeader"
+          }
+        },
+        "required": [
+          "artifact_hash",
+          "artifact_size",
+          "header"
+        ]
+      },
+      "BootSettings": {
+        "description": "Settings supplied to the guest's firmware image that specify the order in which it should consider its options when selecting a device to try to boot from.",
+        "type": "object",
+        "properties": {
+          "order": {
+            "description": "An ordered list of components to attempt to boot from.",
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/BootOrderEntry"
+            }
+          }
+        },
+        "required": [
+          "order"
+        ],
+        "additionalProperties": false
+      },
+      "BootstoreStatus": {
+        "description": "Status of the local bootstore node.",
+        "type": "object",
+        "properties": {
+          "accepted_connections": {
+            "type": "array",
+            "items": {
+              "type": "string"
+            },
+            "uniqueItems": true
+          },
+          "established_connections": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/EstablishedConnection"
+            }
+          },
+          "fsm_ledger_generation": {
+            "type": "integer",
+            "format": "uint64",
+            "minimum": 0
+          },
+          "fsm_state": {
+            "type": "string"
+          },
+          "negotiating_connections": {
+            "type": "array",
+            "items": {
+              "type": "string"
+            },
+            "uniqueItems": true
+          },
+          "network_config_ledger_generation": {
+            "nullable": true,
+            "type": "integer",
+            "format": "uint64",
+            "minimum": 0
+          },
+          "peers": {
+            "type": "array",
+            "items": {
+              "type": "string"
+            },
+            "uniqueItems": true
+          }
+        },
+        "required": [
+          "accepted_connections",
+          "established_connections",
+          "fsm_ledger_generation",
+          "fsm_state",
+          "negotiating_connections",
+          "peers"
+        ]
+      },
+      "BundleUtilization": {
+        "description": "The portion of a debug dataset used for zone bundles.",
+        "type": "object",
+        "properties": {
+          "bytes_available": {
+            "description": "The total number of bytes available for zone bundles.\n\nThis is `dataset_quota` multiplied by the context's storage limit.",
+            "type": "integer",
+            "format": "uint64",
+            "minimum": 0
+          },
+          "bytes_used": {
+            "description": "Total bundle usage, in bytes.",
+            "type": "integer",
+            "format": "uint64",
+            "minimum": 0
+          },
+          "dataset_quota": {
+            "description": "The total dataset quota, in bytes.",
+            "type": "integer",
+            "format": "uint64",
+            "minimum": 0
+          }
+        },
+        "required": [
+          "bytes_available",
+          "bytes_used",
+          "dataset_quota"
+        ]
+      },
+      "ByteCount": {
+        "description": "Byte count to express memory or storage capacity.",
+        "type": "integer",
+        "format": "uint64",
+        "minimum": 0
+      },
+      "Chipset": {
+        "description": "A kind of virtual chipset.",
+        "oneOf": [
+          {
+            "description": "An Intel 440FX-compatible chipset.",
+            "type": "object",
+            "properties": {
+              "type": {
+                "type": "string",
+                "enum": [
+                  "i440_fx"
+                ]
+              },
+              "value": {
+                "$ref": "#/components/schemas/I440Fx"
+              }
+            },
+            "required": [
+              "type",
+              "value"
+            ],
+            "additionalProperties": false
+          }
+        ]
+      },
+      "CleanupContext": {
+        "description": "Context provided for the zone bundle cleanup task.",
+        "type": "object",
+        "properties": {
+          "period": {
+            "description": "The period on which automatic checks and cleanup is performed.",
+            "allOf": [
+              {
+                "$ref": "#/components/schemas/CleanupPeriod"
+              }
+            ]
+          },
+          "priority": {
+            "description": "The priority ordering for keeping old bundles.",
+            "allOf": [
+              {
+                "$ref": "#/components/schemas/PriorityOrder"
+              }
+            ]
+          },
+          "storage_limit": {
+            "description": "The limit on the dataset quota available for zone bundles.",
+            "allOf": [
+              {
+                "$ref": "#/components/schemas/StorageLimit"
+              }
+            ]
+          }
+        },
+        "required": [
+          "period",
+          "priority",
+          "storage_limit"
+        ]
+      },
+      "CleanupContextUpdate": {
+        "description": "Parameters used to update the zone bundle cleanup context.",
+        "type": "object",
+        "properties": {
+          "period": {
+            "nullable": true,
+            "description": "The new period on which automatic cleanups are run.",
+            "allOf": [
+              {
+                "$ref": "#/components/schemas/Duration"
+              }
+            ]
+          },
+          "priority": {
+            "nullable": true,
+            "description": "The priority ordering for preserving old zone bundles.",
+            "allOf": [
+              {
+                "$ref": "#/components/schemas/PriorityOrder"
+              }
+            ]
+          },
+          "storage_limit": {
+            "nullable": true,
+            "description": "The new limit on the underlying dataset quota allowed for bundles.",
+            "type": "integer",
+            "format": "uint8",
+            "minimum": 0
+          }
+        }
+      },
+      "CleanupCount": {
+        "description": "The count of bundles / bytes removed during a cleanup operation.",
+        "type": "object",
+        "properties": {
+          "bundles": {
+            "description": "The number of bundles removed.",
+            "type": "integer",
+            "format": "uint64",
+            "minimum": 0
+          },
+          "bytes": {
+            "description": "The number of bytes removed.",
+            "type": "integer",
+            "format": "uint64",
+            "minimum": 0
+          }
+        },
+        "required": [
+          "bundles",
+          "bytes"
+        ]
+      },
+      "CleanupPeriod": {
+        "description": "A period on which bundles are automatically cleaned up.",
+        "allOf": [
+          {
+            "$ref": "#/components/schemas/Duration"
+          }
+        ]
+      },
+      "CombineError": {
+        "type": "string",
+        "enum": [
+          "too_few_shares",
+          "duplicate_x_coordinates",
+          "invalid_share_lengths",
+          "invalid_share_id"
+        ]
+      },
+      "CommitRequest": {
+        "description": "Request to commit a trust quorum configuration at a given epoch.",
+        "type": "object",
+        "properties": {
+          "epoch": {
+            "type": "integer",
+            "format": "uint64",
+            "minimum": 0
+          },
+          "rack_id": {
+            "$ref": "#/components/schemas/RackUuid"
+          }
+        },
+        "required": [
+          "epoch",
+          "rack_id"
+        ]
+      },
+      "CommitStatus": {
+        "description": "Whether or not a configuration has been committed or is still underway.",
+        "type": "string",
+        "enum": [
+          "committed",
+          "pending"
+        ]
+      },
+      "ComponentV0": {
+        "oneOf": [
+          {
+            "type": "object",
+            "properties": {
+              "component": {
+                "$ref": "#/components/schemas/VirtioDisk"
+              },
+              "type": {
+                "type": "string",
+                "enum": [
+                  "virtio_disk"
+                ]
+              }
+            },
+            "required": [
+              "component",
+              "type"
+            ],
+            "additionalProperties": false
+          },
+          {
+            "type": "object",
+            "properties": {
+              "component": {
+                "$ref": "#/components/schemas/NvmeDisk"
+              },
+              "type": {
+                "type": "string",
+                "enum": [
+                  "nvme_disk"
+                ]
+              }
+            },
+            "required": [
+              "component",
+              "type"
+            ],
+            "additionalProperties": false
+          },
+          {
+            "type": "object",
+            "properties": {
+              "component": {
+                "$ref": "#/components/schemas/VirtioNic"
+              },
+              "type": {
+                "type": "string",
+                "enum": [
+                  "virtio_nic"
+                ]
+              }
+            },
+            "required": [
+              "component",
+              "type"
+            ],
+            "additionalProperties": false
+          },
+          {
+            "type": "object",
+            "properties": {
+              "component": {
+                "$ref": "#/components/schemas/SerialPort"
+              },
+              "type": {
+                "type": "string",
+                "enum": [
+                  "serial_port"
+                ]
+              }
+            },
+            "required": [
+              "component",
+              "type"
+            ],
+            "additionalProperties": false
+          },
+          {
+            "type": "object",
+            "properties": {
+              "component": {
+                "$ref": "#/components/schemas/PciPciBridge"
+              },
+              "type": {
+                "type": "string",
+                "enum": [
+                  "pci_pci_bridge"
+                ]
+              }
+            },
+            "required": [
+              "component",
+              "type"
+            ],
+            "additionalProperties": false
+          },
+          {
+            "type": "object",
+            "properties": {
+              "component": {
+                "$ref": "#/components/schemas/QemuPvpanic"
+              },
+              "type": {
+                "type": "string",
+                "enum": [
+                  "qemu_pvpanic"
+                ]
+              }
+            },
+            "required": [
+              "component",
+              "type"
+            ],
+            "additionalProperties": false
+          },
+          {
+            "type": "object",
+            "properties": {
+              "component": {
+                "$ref": "#/components/schemas/BootSettings"
+              },
+              "type": {
+                "type": "string",
+                "enum": [
+                  "boot_settings"
+                ]
+              }
+            },
+            "required": [
+              "component",
+              "type"
+            ],
+            "additionalProperties": false
+          },
+          {
+            "type": "object",
+            "properties": {
+              "component": {
+                "$ref": "#/components/schemas/SoftNpuPciPort"
+              },
+              "type": {
+                "type": "string",
+                "enum": [
+                  "soft_npu_pci_port"
+                ]
+              }
+            },
+            "required": [
+              "component",
+              "type"
+            ],
+            "additionalProperties": false
+          },
+          {
+            "type": "object",
+            "properties": {
+              "component": {
+                "$ref": "#/components/schemas/SoftNpuPort"
+              },
+              "type": {
+                "type": "string",
+                "enum": [
+                  "soft_npu_port"
+                ]
+              }
+            },
+            "required": [
+              "component",
+              "type"
+            ],
+            "additionalProperties": false
+          },
+          {
+            "type": "object",
+            "properties": {
+              "component": {
+                "$ref": "#/components/schemas/SoftNpuP9"
+              },
+              "type": {
+                "type": "string",
+                "enum": [
+                  "soft_npu_p9"
+                ]
+              }
+            },
+            "required": [
+              "component",
+              "type"
+            ],
+            "additionalProperties": false
+          },
+          {
+            "type": "object",
+            "properties": {
+              "component": {
+                "$ref": "#/components/schemas/P9fs"
+              },
+              "type": {
+                "type": "string",
+                "enum": [
+                  "p9fs"
+                ]
+              }
+            },
+            "required": [
+              "component",
+              "type"
+            ],
+            "additionalProperties": false
+          },
+          {
+            "type": "object",
+            "properties": {
+              "component": {
+                "$ref": "#/components/schemas/MigrationFailureInjector"
+              },
+              "type": {
+                "type": "string",
+                "enum": [
+                  "migration_failure_injector"
+                ]
+              }
+            },
+            "required": [
+              "component",
+              "type"
+            ],
+            "additionalProperties": false
+          },
+          {
+            "type": "object",
+            "properties": {
+              "component": {
+                "$ref": "#/components/schemas/CrucibleStorageBackend"
+              },
+              "type": {
+                "type": "string",
+                "enum": [
+                  "crucible_storage_backend"
+                ]
+              }
+            },
+            "required": [
+              "component",
+              "type"
+            ],
+            "additionalProperties": false
+          },
+          {
+            "type": "object",
+            "properties": {
+              "component": {
+                "$ref": "#/components/schemas/FileStorageBackend"
+              },
+              "type": {
+                "type": "string",
+                "enum": [
+                  "file_storage_backend"
+                ]
+              }
+            },
+            "required": [
+              "component",
+              "type"
+            ],
+            "additionalProperties": false
+          },
+          {
+            "type": "object",
+            "properties": {
+              "component": {
+                "$ref": "#/components/schemas/BlobStorageBackend"
+              },
+              "type": {
+                "type": "string",
+                "enum": [
+                  "blob_storage_backend"
+                ]
+              }
+            },
+            "required": [
+              "component",
+              "type"
+            ],
+            "additionalProperties": false
+          },
+          {
+            "type": "object",
+            "properties": {
+              "component": {
+                "$ref": "#/components/schemas/VirtioNetworkBackend"
+              },
+              "type": {
+                "type": "string",
+                "enum": [
+                  "virtio_network_backend"
+                ]
+              }
+            },
+            "required": [
+              "component",
+              "type"
+            ],
+            "additionalProperties": false
+          },
+          {
+            "type": "object",
+            "properties": {
+              "component": {
+                "$ref": "#/components/schemas/DlpiNetworkBackend"
+              },
+              "type": {
+                "type": "string",
+                "enum": [
+                  "dlpi_network_backend"
+                ]
+              }
+            },
+            "required": [
+              "component",
+              "type"
+            ],
+            "additionalProperties": false
+          }
+        ]
+      },
+      "CompressionAlgorithm": {
+        "oneOf": [
+          {
+            "type": "object",
+            "properties": {
+              "type": {
+                "type": "string",
+                "enum": [
+                  "on"
+                ]
+              }
+            },
+            "required": [
+              "type"
+            ]
+          },
+          {
+            "type": "object",
+            "properties": {
+              "type": {
+                "type": "string",
+                "enum": [
+                  "off"
+                ]
+              }
+            },
+            "required": [
+              "type"
+            ]
+          },
+          {
+            "type": "object",
+            "properties": {
+              "type": {
+                "type": "string",
+                "enum": [
+                  "gzip"
+                ]
+              }
+            },
+            "required": [
+              "type"
+            ]
+          },
+          {
+            "type": "object",
+            "properties": {
+              "level": {
+                "$ref": "#/components/schemas/GzipLevel"
+              },
+              "type": {
+                "type": "string",
+                "enum": [
+                  "gzip_n"
+                ]
+              }
+            },
+            "required": [
+              "level",
+              "type"
+            ]
+          },
+          {
+            "type": "object",
+            "properties": {
+              "type": {
+                "type": "string",
+                "enum": [
+                  "lz4"
+                ]
+              }
+            },
+            "required": [
+              "type"
+            ]
+          },
+          {
+            "type": "object",
+            "properties": {
+              "type": {
+                "type": "string",
+                "enum": [
+                  "lzjb"
+                ]
+              }
+            },
+            "required": [
+              "type"
+            ]
+          },
+          {
+            "type": "object",
+            "properties": {
+              "type": {
+                "type": "string",
+                "enum": [
+                  "zle"
+                ]
+              }
+            },
+            "required": [
+              "type"
+            ]
+          }
+        ]
+      },
+      "ConfigReconcilerInventory": {
+        "description": "Describes the last attempt made by the sled-agent-config-reconciler to reconcile the current sled config against the actual state of the sled.",
+        "type": "object",
+        "properties": {
+          "boot_partitions": {
+            "$ref": "#/components/schemas/BootPartitionContents"
+          },
+          "datasets": {
+            "type": "object",
+            "additionalProperties": {
+              "$ref": "#/components/schemas/ConfigReconcilerInventoryResult"
+            }
+          },
+          "external_disks": {
+            "type": "object",
+            "additionalProperties": {
+              "$ref": "#/components/schemas/ConfigReconcilerInventoryResult"
+            }
+          },
+          "last_reconciled_config": {
+            "$ref": "#/components/schemas/OmicronSledConfig"
+          },
+          "orphaned_datasets": {
+            "title": "IdOrdMap",
+            "x-rust-type": {
+              "crate": "iddqd",
+              "parameters": [
+                {
+                  "$ref": "#/components/schemas/OrphanedDataset"
+                }
+              ],
+              "path": "iddqd::IdOrdMap",
+              "version": "*"
+            },
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/OrphanedDataset"
+            },
+            "uniqueItems": true
+          },
+          "remove_mupdate_override": {
+            "nullable": true,
+            "description": "The result of removing the mupdate override file on disk.\n\n`None` if `remove_mupdate_override` was not provided in the sled config.",
+            "allOf": [
+              {
+                "$ref": "#/components/schemas/RemoveMupdateOverrideInventory"
+              }
+            ]
+          },
+          "zones": {
+            "type": "object",
+            "additionalProperties": {
+              "$ref": "#/components/schemas/ConfigReconcilerInventoryResult"
+            }
+          }
+        },
+        "required": [
+          "boot_partitions",
+          "datasets",
+          "external_disks",
+          "last_reconciled_config",
+          "orphaned_datasets",
+          "zones"
+        ]
+      },
+      "ConfigReconcilerInventoryResult": {
+        "oneOf": [
+          {
+            "type": "object",
+            "properties": {
+              "result": {
+                "type": "string",
+                "enum": [
+                  "ok"
+                ]
+              }
+            },
+            "required": [
+              "result"
+            ]
+          },
+          {
+            "type": "object",
+            "properties": {
+              "message": {
+                "type": "string"
+              },
+              "result": {
+                "type": "string",
+                "enum": [
+                  "err"
+                ]
+              }
+            },
+            "required": [
+              "message",
+              "result"
+            ]
+          }
+        ]
+      },
+      "ConfigReconcilerInventoryStatus": {
+        "description": "Status of the sled-agent-config-reconciler task.",
+        "oneOf": [
+          {
+            "description": "The reconciler task has not yet run for the first time since sled-agent started.",
+            "type": "object",
+            "properties": {
+              "status": {
+                "type": "string",
+                "enum": [
+                  "not_yet_run"
+                ]
+              }
+            },
+            "required": [
+              "status"
+            ]
+          },
+          {
+            "description": "The reconciler task is actively running.",
+            "type": "object",
+            "properties": {
+              "config": {
+                "$ref": "#/components/schemas/OmicronSledConfig"
+              },
+              "running_for": {
+                "$ref": "#/components/schemas/Duration"
+              },
+              "started_at": {
+                "type": "string",
+                "format": "date-time"
+              },
+              "status": {
+                "type": "string",
+                "enum": [
+                  "running"
+                ]
+              }
+            },
+            "required": [
+              "config",
+              "running_for",
+              "started_at",
+              "status"
+            ]
+          },
+          {
+            "description": "The reconciler task is currently idle, but previously did complete a reconciliation attempt.\n\nThis variant does not include the `OmicronSledConfig` used in the last attempt, because that's always available via [`ConfigReconcilerInventory::last_reconciled_config`].",
+            "type": "object",
+            "properties": {
+              "completed_at": {
+                "type": "string",
+                "format": "date-time"
+              },
+              "ran_for": {
+                "$ref": "#/components/schemas/Duration"
+              },
+              "status": {
+                "type": "string",
+                "enum": [
+                  "idle"
+                ]
+              }
+            },
+            "required": [
+              "completed_at",
+              "ran_for",
+              "status"
+            ]
+          }
+        ]
+      },
+      "Configuration": {
+        "description": "The configuration for a given epoch.\n\nOnly valid for non-lrtq configurations.",
+        "type": "object",
+        "properties": {
+          "coordinator": {
+            "description": "Who was the coordinator of this reconfiguration?",
+            "allOf": [
+              {
+                "$ref": "#/components/schemas/BaseboardId"
+              }
+            ]
+          },
+          "encrypted_rack_secrets": {
+            "nullable": true,
+            "description": "There are no encrypted rack secrets for the initial configuration.",
+            "allOf": [
+              {
+                "$ref": "#/components/schemas/EncryptedRackSecrets"
+              }
+            ]
+          },
+          "epoch": {
+            "description": "Unique, monotonically increasing identifier for a configuration.",
+            "type": "integer",
+            "format": "uint64",
+            "minimum": 0
+          },
+          "members": {
+            "description": "All members of the current configuration and the hash of their key shares.",
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/ConfigurationMember"
+            }
+          },
+          "rack_id": {
+            "description": "Unique Id of the rack.",
+            "allOf": [
+              {
+                "$ref": "#/components/schemas/RackUuid"
+              }
+            ]
+          },
+          "threshold": {
+            "description": "The number of sleds required to reconstruct the rack secret.",
+            "type": "integer",
+            "format": "uint8",
+            "minimum": 0
+          }
+        },
+        "required": [
+          "coordinator",
+          "epoch",
+          "members",
+          "rack_id",
+          "threshold"
+        ]
+      },
+      "ConfigurationMember": {
+        "description": "A member entry in a trust quorum configuration.\n\nThis type is used for OpenAPI schema generation since OpenAPI v3.0.x doesn't support tuple arrays.",
+        "type": "object",
+        "properties": {
+          "id": {
+            "description": "The baseboard ID of the member.",
+            "allOf": [
+              {
+                "$ref": "#/components/schemas/BaseboardId"
+              }
+            ]
+          },
+          "share_digest": {
+            "description": "The SHA3-256 hash of the member's key share.",
+            "type": "string",
+            "format": "hex string (32 bytes)"
+          }
+        },
+        "required": [
+          "id",
+          "share_digest"
+        ]
+      },
+      "CoordinatorStatus": {
+        "description": "Status of the node coordinating the reconfiguration or LRTQ upgrade.",
+        "type": "object",
+        "properties": {
+          "acked_prepares": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/BaseboardId"
+            },
+            "uniqueItems": true
+          },
+          "config": {
+            "$ref": "#/components/schemas/Configuration"
+          }
+        },
+        "required": [
+          "acked_prepares",
+          "config"
+        ]
+      },
+      "Cpuid": {
+        "description": "A set of CPUID values to expose to a guest.",
+        "type": "object",
+        "properties": {
+          "entries": {
+            "description": "A list of CPUID leaves/subleaves and their associated values.\n\nPropolis servers require that each entry's `leaf` be unique and that it falls in either the \"standard\" (0 to 0xFFFF) or \"extended\" (0x8000_0000 to 0x8000_FFFF) function ranges, since these are the only valid input ranges currently defined by Intel and AMD. See the Intel 64 and IA-32 Architectures Software Developer's Manual (June 2024) Table 3-17 and the AMD64 Architecture Programmer's Manual (March 2024) Volume 3's documentation of the CPUID instruction.",
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/CpuidEntry"
+            }
+          },
+          "vendor": {
+            "description": "The CPU vendor to emulate.\n\nCPUID leaves in the extended range (0x8000_0000 to 0x8000_FFFF) have vendor-defined semantics. Propolis uses this value to determine these semantics when deciding whether it needs to specialize the supplied template values for these leaves.",
+            "allOf": [
+              {
+                "$ref": "#/components/schemas/CpuidVendor"
+              }
+            ]
+          }
+        },
+        "required": [
+          "entries",
+          "vendor"
+        ],
+        "additionalProperties": false
+      },
+      "CpuidEntry": {
+        "description": "A full description of a CPUID leaf/subleaf and the values it produces.",
+        "type": "object",
+        "properties": {
+          "eax": {
+            "description": "The value to return in eax.",
+            "type": "integer",
+            "format": "uint32",
+            "minimum": 0
+          },
+          "ebx": {
+            "description": "The value to return in ebx.",
+            "type": "integer",
+            "format": "uint32",
+            "minimum": 0
+          },
+          "ecx": {
+            "description": "The value to return in ecx.",
+            "type": "integer",
+            "format": "uint32",
+            "minimum": 0
+          },
+          "edx": {
+            "description": "The value to return in edx.",
+            "type": "integer",
+            "format": "uint32",
+            "minimum": 0
+          },
+          "leaf": {
+            "description": "The leaf (function) number for this entry.",
+            "type": "integer",
+            "format": "uint32",
+            "minimum": 0
+          },
+          "subleaf": {
+            "nullable": true,
+            "description": "The subleaf (index) number for this entry, if it uses subleaves.",
+            "type": "integer",
+            "format": "uint32",
+            "minimum": 0
+          }
+        },
+        "required": [
+          "eax",
+          "ebx",
+          "ecx",
+          "edx",
+          "leaf"
+        ],
+        "additionalProperties": false
+      },
+      "CpuidVendor": {
+        "description": "A CPU vendor to use when interpreting the meanings of CPUID leaves in the extended ID range (0x80000000 to 0x8000FFFF).",
+        "type": "string",
+        "enum": [
+          "amd",
+          "intel"
+        ]
+      },
+      "CrucibleStorageBackend": {
+        "description": "A Crucible storage backend.",
+        "type": "object",
+        "properties": {
+          "readonly": {
+            "description": "Indicates whether the storage is read-only.",
+            "type": "boolean"
+          },
+          "request_json": {
+            "description": "A serialized `[crucible_client_types::VolumeConstructionRequest]`. This is stored in serialized form so that breaking changes to the definition of a `VolumeConstructionRequest` do not inadvertently break instance spec deserialization.\n\nWhen using a spec to initialize a new instance, the spec author must ensure this request is well-formed and can be deserialized by the version of `crucible_client_types` used by the target Propolis.",
+            "type": "string"
+          }
+        },
+        "required": [
+          "readonly",
+          "request_json"
+        ],
+        "additionalProperties": false
+      },
+      "DatasetConfig": {
+        "description": "Configuration information necessary to request a single dataset.\n\nThese datasets are tracked directly by Nexus.",
+        "type": "object",
+        "properties": {
+          "compression": {
+            "description": "The compression mode to be used by the dataset",
+            "allOf": [
+              {
+                "$ref": "#/components/schemas/CompressionAlgorithm"
+              }
+            ]
+          },
+          "id": {
+            "description": "The UUID of the dataset being requested",
+            "allOf": [
+              {
+                "$ref": "#/components/schemas/DatasetUuid"
+              }
+            ]
+          },
+          "name": {
+            "description": "The dataset's name",
+            "allOf": [
+              {
+                "$ref": "#/components/schemas/DatasetName"
+              }
+            ]
+          },
+          "quota": {
+            "nullable": true,
+            "description": "The upper bound on the amount of storage used by this dataset",
+            "allOf": [
+              {
+                "$ref": "#/components/schemas/ByteCount"
+              }
+            ]
+          },
+          "reservation": {
+            "nullable": true,
+            "description": "The lower bound on the amount of storage usable by this dataset",
+            "allOf": [
+              {
+                "$ref": "#/components/schemas/ByteCount"
+              }
+            ]
+          }
+        },
+        "required": [
+          "compression",
+          "id",
+          "name"
+        ]
+      },
+      "DatasetKind": {
+        "description": "The kind of dataset. See the `DatasetKind` enum in omicron-common for possible values.",
+        "type": "string"
+      },
+      "DatasetName": {
+        "type": "object",
+        "properties": {
+          "kind": {
+            "$ref": "#/components/schemas/DatasetKind"
+          },
+          "pool_name": {
+            "$ref": "#/components/schemas/ZpoolName"
+          }
+        },
+        "required": [
+          "kind",
+          "pool_name"
+        ]
+      },
+      "DatasetUuid": {
+        "x-rust-type": {
+          "crate": "omicron-uuid-kinds",
+          "path": "omicron_uuid_kinds::DatasetUuid",
+          "version": "*"
+        },
+        "type": "string",
+        "format": "uuid"
+      },
+      "DecryptionError": {
+        "description": "Error decrypting rack secrets.",
+        "oneOf": [
+          {
+            "description": "An opaque error indicating decryption failed.",
+            "type": "string",
+            "enum": [
+              "aead"
+            ]
+          },
+          {
+            "description": "The length of the plaintext is not the correct size and cannot be decoded.",
+            "type": "string",
+            "enum": [
+              "invalid_length"
+            ]
+          }
+        ]
+      },
+      "DelegatedZvol": {
+        "description": "Delegate a ZFS volume to a zone",
+        "oneOf": [
+          {
+            "description": "Delegate a slice of the local storage dataset present on this pool into the zone.",
+            "type": "object",
+            "properties": {
+              "dataset_id": {
+                "$ref": "#/components/schemas/DatasetUuid"
+              },
+              "type": {
+                "type": "string",
+                "enum": [
+                  "local_storage"
+                ]
+              },
+              "zpool_id": {
+                "$ref": "#/components/schemas/ExternalZpoolUuid"
+              }
+            },
+            "required": [
+              "dataset_id",
+              "type",
+              "zpool_id"
+            ]
+          }
+        ]
+      },
+      "DhcpConfig": {
+        "description": "DHCP configuration for a port\n\nNot present here: Hostname (DHCPv4 option 12; used in DHCPv6 option 39); we use `InstanceRuntimeState::hostname` for this value.",
+        "type": "object",
+        "properties": {
+          "dns_servers": {
+            "description": "DNS servers to send to the instance\n\n(DHCPv4 option 6; DHCPv6 option 23)",
+            "type": "array",
+            "items": {
+              "type": "string",
+              "format": "ip"
+            }
+          },
+          "host_domain": {
+            "nullable": true,
+            "description": "DNS zone this instance's hostname belongs to (e.g. the `project.example` part of `instance1.project.example`)\n\n(DHCPv4 option 15; used in DHCPv6 option 39)",
+            "type": "string"
+          },
+          "search_domains": {
+            "description": "DNS search domains\n\n(DHCPv4 option 119; DHCPv6 option 24)",
+            "type": "array",
+            "items": {
+              "type": "string"
+            }
+          }
+        },
+        "required": [
+          "dns_servers",
+          "search_domains"
+        ]
+      },
+      "DiskEnsureBody": {
+        "description": "Sent from to a sled agent to establish the runtime state of a Disk",
+        "type": "object",
+        "properties": {
+          "initial_runtime": {
+            "description": "Last runtime state of the Disk known to Nexus (used if the agent has never seen this Disk before).",
+            "allOf": [
+              {
+                "$ref": "#/components/schemas/DiskRuntimeState"
+              }
+            ]
+          },
+          "target": {
+            "description": "requested runtime state of the Disk",
+            "allOf": [
+              {
+                "$ref": "#/components/schemas/DiskStateRequested"
+              }
+            ]
+          }
+        },
+        "required": [
+          "initial_runtime",
+          "target"
+        ]
+      },
+      "DiskIdentity": {
+        "description": "Uniquely identifies a disk.",
+        "type": "object",
+        "properties": {
+          "model": {
+            "type": "string"
+          },
+          "serial": {
+            "type": "string"
+          },
+          "vendor": {
+            "type": "string"
+          }
+        },
+        "required": [
+          "model",
+          "serial",
+          "vendor"
+        ]
+      },
+      "DiskRuntimeState": {
+        "description": "Runtime state of the Disk, which includes its attach state and some minimal metadata",
+        "type": "object",
+        "properties": {
+          "disk_state": {
+            "description": "runtime state of the Disk",
+            "allOf": [
+              {
+                "$ref": "#/components/schemas/DiskState"
+              }
+            ]
+          },
+          "gen": {
+            "description": "generation number for this state",
+            "allOf": [
+              {
+                "$ref": "#/components/schemas/Generation"
+              }
+            ]
+          },
+          "time_updated": {
+            "description": "timestamp for this information",
+            "type": "string",
+            "format": "date-time"
+          }
+        },
+        "required": [
+          "disk_state",
+          "gen",
+          "time_updated"
+        ]
+      },
+      "DiskState": {
+        "description": "State of a Disk",
+        "oneOf": [
+          {
+            "description": "Disk is being initialized",
+            "type": "object",
+            "properties": {
+              "state": {
+                "type": "string",
+                "enum": [
+                  "creating"
+                ]
+              }
+            },
+            "required": [
+              "state"
+            ]
+          },
+          {
+            "description": "Disk is ready but detached from any Instance",
+            "type": "object",
+            "properties": {
+              "state": {
+                "type": "string",
+                "enum": [
+                  "detached"
+                ]
+              }
+            },
+            "required": [
+              "state"
+            ]
+          },
+          {
+            "description": "Disk is ready to receive blocks from an external source",
+            "type": "object",
+            "properties": {
+              "state": {
+                "type": "string",
+                "enum": [
+                  "import_ready"
+                ]
+              }
+            },
+            "required": [
+              "state"
+            ]
+          },
+          {
+            "description": "Disk is importing blocks from a URL",
+            "type": "object",
+            "properties": {
+              "state": {
+                "type": "string",
+                "enum": [
+                  "importing_from_url"
+                ]
+              }
+            },
+            "required": [
+              "state"
+            ]
+          },
+          {
+            "description": "Disk is importing blocks from bulk writes",
+            "type": "object",
+            "properties": {
+              "state": {
+                "type": "string",
+                "enum": [
+                  "importing_from_bulk_writes"
+                ]
+              }
+            },
+            "required": [
+              "state"
+            ]
+          },
+          {
+            "description": "Disk is being finalized to state Detached",
+            "type": "object",
+            "properties": {
+              "state": {
+                "type": "string",
+                "enum": [
+                  "finalizing"
+                ]
+              }
+            },
+            "required": [
+              "state"
+            ]
+          },
+          {
+            "description": "Disk is undergoing maintenance",
+            "type": "object",
+            "properties": {
+              "state": {
+                "type": "string",
+                "enum": [
+                  "maintenance"
+                ]
+              }
+            },
+            "required": [
+              "state"
+            ]
+          },
+          {
+            "description": "Disk is being attached to the given Instance",
+            "type": "object",
+            "properties": {
+              "instance": {
+                "type": "string",
+                "format": "uuid"
+              },
+              "state": {
+                "type": "string",
+                "enum": [
+                  "attaching"
+                ]
+              }
+            },
+            "required": [
+              "instance",
+              "state"
+            ]
+          },
+          {
+            "description": "Disk is attached to the given Instance",
+            "type": "object",
+            "properties": {
+              "instance": {
+                "type": "string",
+                "format": "uuid"
+              },
+              "state": {
+                "type": "string",
+                "enum": [
+                  "attached"
+                ]
+              }
+            },
+            "required": [
+              "instance",
+              "state"
+            ]
+          },
+          {
+            "description": "Disk is being detached from the given Instance",
+            "type": "object",
+            "properties": {
+              "instance": {
+                "type": "string",
+                "format": "uuid"
+              },
+              "state": {
+                "type": "string",
+                "enum": [
+                  "detaching"
+                ]
+              }
+            },
+            "required": [
+              "instance",
+              "state"
+            ]
+          },
+          {
+            "description": "Disk has been destroyed",
+            "type": "object",
+            "properties": {
+              "state": {
+                "type": "string",
+                "enum": [
+                  "destroyed"
+                ]
+              }
+            },
+            "required": [
+              "state"
+            ]
+          },
+          {
+            "description": "Disk is unavailable",
+            "type": "object",
+            "properties": {
+              "state": {
+                "type": "string",
+                "enum": [
+                  "faulted"
+                ]
+              }
+            },
+            "required": [
+              "state"
+            ]
+          }
+        ]
+      },
+      "DiskStateRequested": {
+        "description": "Used to request a Disk state change",
+        "oneOf": [
+          {
+            "type": "object",
+            "properties": {
+              "state": {
+                "type": "string",
+                "enum": [
+                  "detached"
+                ]
+              }
+            },
+            "required": [
+              "state"
+            ]
+          },
+          {
+            "type": "object",
+            "properties": {
+              "instance": {
+                "type": "string",
+                "format": "uuid"
+              },
+              "state": {
+                "type": "string",
+                "enum": [
+                  "attached"
+                ]
+              }
+            },
+            "required": [
+              "instance",
+              "state"
+            ]
+          },
+          {
+            "type": "object",
+            "properties": {
+              "state": {
+                "type": "string",
+                "enum": [
+                  "destroyed"
+                ]
+              }
+            },
+            "required": [
+              "state"
+            ]
+          },
+          {
+            "type": "object",
+            "properties": {
+              "state": {
+                "type": "string",
+                "enum": [
+                  "faulted"
+                ]
+              }
+            },
+            "required": [
+              "state"
+            ]
+          }
+        ]
+      },
+      "DiskVariant": {
+        "type": "string",
+        "enum": [
+          "U2",
+          "M2"
+        ]
+      },
+      "DlpiNetworkBackend": {
+        "description": "A network backend associated with a DLPI VNIC on the host.",
+        "type": "object",
+        "properties": {
+          "vnic_name": {
+            "description": "The name of the VNIC to use as a backend.",
+            "type": "string"
+          }
+        },
+        "required": [
+          "vnic_name"
+        ],
+        "additionalProperties": false
+      },
+      "Duration": {
+        "type": "object",
+        "properties": {
+          "nanos": {
+            "type": "integer",
+            "format": "uint32",
+            "minimum": 0
+          },
+          "secs": {
+            "type": "integer",
+            "format": "uint64",
+            "minimum": 0
+          }
+        },
+        "required": [
+          "nanos",
+          "secs"
+        ]
+      },
+      "EarlyNetworkConfig": {
+        "description": "Network configuration required to bring up the control plane\n\nThe fields in this structure are those from `RackInitializeRequest` necessary for use beyond RSS. This is just for the initial rack configuration and cold boot purposes. Updates come from Nexus.",
+        "type": "object",
+        "properties": {
+          "body": {
+            "$ref": "#/components/schemas/EarlyNetworkConfigBody"
+          },
+          "generation": {
+            "type": "integer",
+            "format": "uint64",
+            "minimum": 0
+          },
+          "schema_version": {
+            "type": "integer",
+            "format": "uint32",
+            "minimum": 0
+          }
+        },
+        "required": [
+          "body",
+          "generation",
+          "schema_version"
+        ]
+      },
+      "EarlyNetworkConfigBody": {
+        "description": "This is the actual configuration of EarlyNetworking.\n\nWe nest it below the \"header\" of `generation` and `schema_version` so that we can perform partial deserialization of `EarlyNetworkConfig` to only read the header and defer deserialization of the body once we know the schema version. This is possible via the use of [`serde_json::value::RawValue`] in future (post-v1) deserialization paths.",
+        "type": "object",
+        "properties": {
+          "ntp_servers": {
+            "description": "The external NTP server addresses.",
+            "type": "array",
+            "items": {
+              "type": "string"
+            }
+          },
+          "rack_network_config": {
+            "nullable": true,
+            "allOf": [
+              {
+                "$ref": "#/components/schemas/RackNetworkConfigV2"
+              }
+            ]
+          }
+        },
+        "required": [
+          "ntp_servers"
+        ]
+      },
+      "EncryptedRackSecrets": {
+        "description": "All possibly relevant __encrypted__ rack secrets for _prior_ committed configurations.",
+        "type": "object",
+        "properties": {
+          "data": {
+            "description": "Encrypted data.",
+            "type": "string",
+            "format": "hex string"
+          },
+          "salt": {
+            "description": "A random value used to derive the key to encrypt the rack secrets for prior committed epochs.",
+            "type": "string",
+            "format": "hex string (32 bytes)"
+          }
+        },
+        "required": [
+          "data",
+          "salt"
+        ]
+      },
+      "Error": {
+        "description": "Error information from a response.",
+        "type": "object",
+        "properties": {
+          "error_code": {
+            "type": "string"
+          },
+          "message": {
+            "type": "string"
+          },
+          "request_id": {
+            "type": "string"
+          }
+        },
+        "required": [
+          "message",
+          "request_id"
+        ]
+      },
+      "EstablishedConnection": {
+        "description": "An established connection to a bootstore peer.",
+        "type": "object",
+        "properties": {
+          "addr": {
+            "type": "string"
+          },
+          "baseboard": {
+            "$ref": "#/components/schemas/Baseboard"
+          }
+        },
+        "required": [
+          "addr",
+          "baseboard"
+        ]
+      },
+      "ExpungedMetadata": {
+        "description": "Metadata about a node being expunged from the trust quorum.",
+        "type": "object",
+        "properties": {
+          "epoch": {
+            "description": "The committed epoch, later than its current configuration at which the node learned that it had been expunged.",
+            "type": "integer",
+            "format": "uint64",
+            "minimum": 0
+          },
+          "from": {
+            "description": "Which node this commit information was learned from.",
+            "allOf": [
+              {
+                "$ref": "#/components/schemas/BaseboardId"
+              }
+            ]
+          }
+        },
+        "required": [
+          "epoch",
+          "from"
+        ]
+      },
+      "ExternalIp": {
+        "description": "An external IP address used by a probe.",
+        "type": "object",
+        "properties": {
+          "first_port": {
+            "description": "The first port used by the address.",
+            "type": "integer",
+            "format": "uint16",
+            "minimum": 0
+          },
+          "ip": {
+            "description": "The external IP address.",
+            "type": "string",
+            "format": "ip"
+          },
+          "kind": {
+            "description": "The kind of address this is.",
+            "allOf": [
+              {
+                "$ref": "#/components/schemas/IpKind"
+              }
+            ]
+          },
+          "last_port": {
+            "description": "The last port used by the address.",
+            "type": "integer",
+            "format": "uint16",
+            "minimum": 0
+          }
+        },
+        "required": [
+          "first_port",
+          "ip",
+          "kind",
+          "last_port"
+        ]
+      },
+      "ExternalIpConfig": {
+        "description": "A single- or dual-stack external IP configuration.",
+        "oneOf": [
+          {
+            "description": "Single-stack IPv4 external IP configuration.",
+            "type": "object",
+            "properties": {
+              "type": {
+                "type": "string",
+                "enum": [
+                  "v4"
+                ]
+              },
+              "value": {
+                "$ref": "#/components/schemas/ExternalIpv4Config"
+              }
+            },
+            "required": [
+              "type",
+              "value"
+            ]
+          },
+          {
+            "description": "Single-stack IPv6 external IP configuration.",
+            "type": "object",
+            "properties": {
+              "type": {
+                "type": "string",
+                "enum": [
+                  "v6"
+                ]
+              },
+              "value": {
+                "$ref": "#/components/schemas/ExternalIpv6Config"
+              }
+            },
+            "required": [
+              "type",
+              "value"
+            ]
+          },
+          {
+            "description": "Both IPv4 and IPv6 external IP configuration.",
+            "type": "object",
+            "properties": {
+              "type": {
+                "type": "string",
+                "enum": [
+                  "dual_stack"
+                ]
+              },
+              "value": {
+                "type": "object",
+                "properties": {
+                  "v4": {
+                    "$ref": "#/components/schemas/ExternalIpv4Config"
+                  },
+                  "v6": {
+                    "$ref": "#/components/schemas/ExternalIpv6Config"
+                  }
+                },
+                "required": [
+                  "v4",
+                  "v6"
+                ]
+              }
+            },
+            "required": [
+              "type",
+              "value"
+            ]
+          }
+        ]
+      },
+      "ExternalIpGatewayMap": {
+        "description": "Per-NIC mappings from external IP addresses to the Internet Gateways which can choose them as a source.",
+        "type": "object",
+        "properties": {
+          "mappings": {
+            "type": "object",
+            "additionalProperties": {
+              "type": "object",
+              "additionalProperties": {
+                "type": "array",
+                "items": {
+                  "type": "string",
+                  "format": "uuid"
+                },
+                "uniqueItems": true
+              }
+            }
+          }
+        },
+        "required": [
+          "mappings"
+        ]
+      },
+      "ExternalIpv4Config": {
+        "description": "External IP address configuration.\n\nThis encapsulates all the external addresses of a single IP version, including source NAT, Ephemeral, and Floating IPs. Note that not all of these need to be specified, but this type can only be constructed if _at least one_ of them is.",
+        "type": "object",
+        "properties": {
+          "ephemeral_ip": {
+            "nullable": true,
+            "description": "An Ephemeral address for in- and outbound connectivity.",
+            "type": "string",
+            "format": "ipv4"
+          },
+          "floating_ips": {
+            "description": "Additional Floating IPs for in- and outbound connectivity.",
+            "type": "array",
+            "items": {
+              "type": "string",
+              "format": "ipv4"
+            }
+          },
+          "source_nat": {
+            "nullable": true,
+            "description": "Source NAT configuration, for outbound-only connectivity.",
+            "allOf": [
+              {
+                "$ref": "#/components/schemas/SourceNatConfigV4"
+              }
+            ]
+          }
+        },
+        "required": [
+          "floating_ips"
+        ]
+      },
+      "ExternalIpv6Config": {
+        "description": "External IP address configuration.\n\nThis encapsulates all the external addresses of a single IP version, including source NAT, Ephemeral, and Floating IPs. Note that not all of these need to be specified, but this type can only be constructed if _at least one_ of them is.",
+        "type": "object",
+        "properties": {
+          "ephemeral_ip": {
+            "nullable": true,
+            "description": "An Ephemeral address for in- and outbound connectivity.",
+            "type": "string",
+            "format": "ipv6"
+          },
+          "floating_ips": {
+            "description": "Additional Floating IPs for in- and outbound connectivity.",
+            "type": "array",
+            "items": {
+              "type": "string",
+              "format": "ipv6"
+            }
+          },
+          "source_nat": {
+            "nullable": true,
+            "description": "Source NAT configuration, for outbound-only connectivity.",
+            "allOf": [
+              {
+                "$ref": "#/components/schemas/SourceNatConfigV6"
+              }
+            ]
+          }
+        },
+        "required": [
+          "floating_ips"
+        ]
+      },
+      "ExternalZpoolUuid": {
+        "x-rust-type": {
+          "crate": "omicron-uuid-kinds",
+          "path": "omicron_uuid_kinds::ExternalZpoolUuid",
+          "version": "*"
+        },
+        "type": "string",
+        "format": "uuid"
+      },
+      "FileStorageBackend": {
+        "description": "A storage backend backed by a file in the host system's file system.",
+        "type": "object",
+        "properties": {
+          "block_size": {
+            "description": "Block size of the backend",
+            "type": "integer",
+            "format": "uint32",
+            "minimum": 0
+          },
+          "path": {
+            "description": "A path to a file that backs a disk.",
+            "type": "string"
+          },
+          "readonly": {
+            "description": "Indicates whether the storage is read-only.",
+            "type": "boolean"
+          },
+          "workers": {
+            "nullable": true,
+            "description": "Optional worker threads for the file backend, exposed for testing only.",
+            "type": "integer",
+            "format": "uint",
+            "minimum": 1
+          }
+        },
+        "required": [
+          "block_size",
+          "path",
+          "readonly"
+        ],
+        "additionalProperties": false
+      },
+      "Generation": {
+        "description": "Generation numbers stored in the database, used for optimistic concurrency control",
+        "type": "integer",
+        "format": "uint64",
+        "minimum": 0
+      },
+      "GuestHypervisorInterface": {
+        "description": "A hypervisor interface to expose to the guest.",
+        "oneOf": [
+          {
+            "description": "Expose a bhyve-like interface (\"bhyve bhyve \" as the hypervisor ID in leaf 0x4000_0000 and no additional leaves or features).",
+            "type": "object",
+            "properties": {
+              "type": {
+                "type": "string",
+                "enum": [
+                  "bhyve"
+                ]
+              }
+            },
+            "required": [
+              "type"
+            ],
+            "additionalProperties": false
+          },
+          {
+            "description": "Expose a Hyper-V-compatible hypervisor interface with the supplied features enabled.",
+            "type": "object",
+            "properties": {
+              "type": {
+                "type": "string",
+                "enum": [
+                  "hyper_v"
+                ]
+              },
+              "value": {
+                "type": "object",
+                "properties": {
+                  "features": {
+                    "type": "array",
+                    "items": {
+                      "$ref": "#/components/schemas/HyperVFeatureFlag"
+                    },
+                    "uniqueItems": true
+                  }
+                },
+                "required": [
+                  "features"
+                ],
+                "additionalProperties": false
+              }
+            },
+            "required": [
+              "type",
+              "value"
+            ],
+            "additionalProperties": false
+          }
+        ]
+      },
+      "GzipLevel": {
+        "type": "integer",
+        "format": "uint8",
+        "minimum": 0
+      },
+      "HealthMonitorInventory": {
+        "description": "Fields of sled-agent inventory reported by the health monitor subsystem.",
+        "type": "object",
+        "properties": {
+          "smf_services_in_maintenance": {
+            "x-rust-type": {
+              "crate": "std",
+              "parameters": [
+                {
+                  "$ref": "#/components/schemas/SvcsInMaintenanceResult"
+                },
+                {
+                  "type": "string"
+                }
+              ],
+              "path": "::std::result::Result",
+              "version": "*"
+            },
+            "oneOf": [
+              {
+                "type": "object",
+                "properties": {
+                  "ok": {
+                    "$ref": "#/components/schemas/SvcsInMaintenanceResult"
+                  }
+                },
+                "required": [
+                  "ok"
+                ]
+              },
+              {
+                "type": "object",
+                "properties": {
+                  "err": {
+                    "type": "string"
+                  }
+                },
+                "required": [
+                  "err"
+                ]
+              }
+            ]
+          }
+        },
+        "required": [
+          "smf_services_in_maintenance"
+        ]
+      },
+      "HostIdentifier": {
+        "description": "A `HostIdentifier` represents either an IP host or network (v4 or v6), or an entire VPC (identified by its VNI). It is used in firewall rule host filters.",
+        "oneOf": [
+          {
+            "type": "object",
+            "properties": {
+              "type": {
+                "type": "string",
+                "enum": [
+                  "ip"
+                ]
+              },
+              "value": {
+                "$ref": "#/components/schemas/IpNet"
+              }
+            },
+            "required": [
+              "type",
+              "value"
+            ]
+          },
+          {
+            "type": "object",
+            "properties": {
+              "type": {
+                "type": "string",
+                "enum": [
+                  "vpc"
+                ]
+              },
+              "value": {
+                "$ref": "#/components/schemas/Vni"
+              }
+            },
+            "required": [
+              "type",
+              "value"
+            ]
+          }
+        ]
+      },
+      "HostPhase2DesiredContents": {
+        "description": "Describes the desired contents of a host phase 2 slot (i.e., the boot partition on one of the internal M.2 drives).",
+        "oneOf": [
+          {
+            "description": "Do not change the current contents.\n\nWe use this value when we've detected a sled has been mupdated (and we don't want to overwrite phase 2 images until we understand how to recover from that mupdate) and as the default value when reading an [`OmicronSledConfig`] that was ledgered before this concept existed.",
+            "type": "object",
+            "properties": {
+              "type": {
+                "type": "string",
+                "enum": [
+                  "current_contents"
+                ]
+              }
+            },
+            "required": [
+              "type"
+            ]
+          },
+          {
+            "description": "Set the phase 2 slot to the given artifact.\n\nThe artifact will come from an unpacked and distributed TUF repo.",
+            "type": "object",
+            "properties": {
+              "hash": {
+                "type": "string",
+                "format": "hex string (32 bytes)"
+              },
+              "type": {
+                "type": "string",
+                "enum": [
+                  "artifact"
+                ]
+              }
+            },
+            "required": [
+              "hash",
+              "type"
+            ]
+          }
+        ]
+      },
+      "HostPhase2DesiredSlots": {
+        "description": "Describes the desired contents for both host phase 2 slots.",
+        "type": "object",
+        "properties": {
+          "slot_a": {
+            "$ref": "#/components/schemas/HostPhase2DesiredContents"
+          },
+          "slot_b": {
+            "$ref": "#/components/schemas/HostPhase2DesiredContents"
+          }
+        },
+        "required": [
+          "slot_a",
+          "slot_b"
+        ]
+      },
+      "HostPortConfig": {
+        "type": "object",
+        "properties": {
+          "addrs": {
+            "description": "IP Address and prefix (e.g., `192.168.0.1/16`) to apply to switchport (must be in infra_ip pool).  May also include an optional VLAN ID.",
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/UplinkAddressConfig"
+            }
+          },
+          "lldp": {
+            "nullable": true,
+            "allOf": [
+              {
+                "$ref": "#/components/schemas/LldpPortConfig"
+              }
+            ]
+          },
+          "port": {
+            "description": "Switchport to use for external connectivity",
+            "type": "string"
+          },
+          "tx_eq": {
+            "nullable": true,
+            "allOf": [
+              {
+                "$ref": "#/components/schemas/TxEqConfig"
+              }
+            ]
+          }
+        },
+        "required": [
+          "addrs",
+          "port"
+        ]
+      },
+      "Hostname": {
+        "title": "An RFC-1035-compliant hostname",
+        "description": "A hostname identifies a host on a network, and is usually a dot-delimited sequence of labels, where each label contains only letters, digits, or the hyphen. See RFCs 1035 and 952 for more details.",
+        "type": "string",
+        "pattern": "^([a-zA-Z0-9]+[a-zA-Z0-9\\-]*(?<!-))(\\.[a-zA-Z0-9]+[a-zA-Z0-9\\-]*(?<!-))*$",
+        "minLength": 1,
+        "maxLength": 253
+      },
+      "HyperVFeatureFlag": {
+        "description": "Flags that enable \"simple\" Hyper-V enlightenments that require no feature-specific configuration.",
+        "type": "string",
+        "enum": [
+          "reference_tsc"
+        ]
+      },
+      "I440Fx": {
+        "description": "An Intel 440FX-compatible chipset.",
+        "type": "object",
+        "properties": {
+          "enable_pcie": {
+            "description": "Specifies whether the chipset should allow PCI configuration space to be accessed through the PCIe extended configuration mechanism.",
+            "type": "boolean"
+          }
+        },
+        "required": [
+          "enable_pcie"
+        ],
+        "additionalProperties": false
+      },
+      "IcmpParamRange": {
+        "example": "3",
+        "title": "A range of ICMP(v6) types or codes",
+        "description": "An inclusive-inclusive range of ICMP(v6) types or codes. The second value may be omitted to represent a single parameter.",
+        "type": "string",
+        "pattern": "^[0-9]{1,3}(-[0-9]{1,3})?$",
+        "minLength": 1,
+        "maxLength": 7
+      },
+      "ImportExportPolicy": {
+        "description": "Define policy relating to the import and export of prefixes from a BGP peer.",
+        "oneOf": [
+          {
+            "description": "Do not perform any filtering.",
+            "type": "object",
+            "properties": {
+              "type": {
+                "type": "string",
+                "enum": [
+                  "no_filtering"
+                ]
+              }
+            },
+            "required": [
+              "type"
+            ]
+          },
+          {
+            "type": "object",
+            "properties": {
+              "type": {
+                "type": "string",
+                "enum": [
+                  "allow"
+                ]
+              },
+              "value": {
+                "type": "array",
+                "items": {
+                  "$ref": "#/components/schemas/IpNet"
+                }
+              }
+            },
+            "required": [
+              "type",
+              "value"
+            ]
+          }
+        ]
+      },
+      "InstanceEnsureBody": {
+        "description": "The body of a request to ensure that a instance and VMM are known to a sled agent.",
+        "type": "object",
+        "properties": {
+          "instance_id": {
+            "description": "The ID of the instance for which this VMM is being created.",
+            "allOf": [
+              {
+                "$ref": "#/components/schemas/InstanceUuid"
+              }
+            ]
+          },
+          "local_config": {
+            "description": "Information about the sled-local configuration that needs to be established to make the VM's virtual hardware fully functional.",
+            "allOf": [
+              {
+                "$ref": "#/components/schemas/InstanceSledLocalConfig"
+              }
+            ]
+          },
+          "metadata": {
+            "description": "Metadata used to track instance statistics.",
+            "allOf": [
+              {
+                "$ref": "#/components/schemas/InstanceMetadata"
+              }
+            ]
+          },
+          "migration_id": {
+            "nullable": true,
+            "description": "The ID of the migration in to this VMM, if this VMM is being ensured is part of a migration in. If this is `None`, the VMM is not being created due to a migration.",
+            "type": "string",
+            "format": "uuid"
+          },
+          "propolis_addr": {
+            "description": "The address at which this VMM should serve a Propolis server API.",
+            "type": "string"
+          },
+          "vmm_runtime": {
+            "description": "The initial VMM runtime state for the VMM being registered.",
+            "allOf": [
+              {
+                "$ref": "#/components/schemas/VmmRuntimeState"
+              }
+            ]
+          },
+          "vmm_spec": {
+            "description": "The virtual hardware configuration this virtual machine should have when it is started.",
+            "allOf": [
+              {
+                "$ref": "#/components/schemas/VmmSpec"
+              }
+            ]
+          }
+        },
+        "required": [
+          "instance_id",
+          "local_config",
+          "metadata",
+          "propolis_addr",
+          "vmm_runtime",
+          "vmm_spec"
+        ]
+      },
+      "InstanceExternalIpBody": {
+        "description": "Used to dynamically update external IPs attached to an instance.",
+        "oneOf": [
+          {
+            "type": "object",
+            "properties": {
+              "type": {
+                "type": "string",
+                "enum": [
+                  "ephemeral"
+                ]
+              },
+              "value": {
+                "type": "string",
+                "format": "ip"
+              }
+            },
+            "required": [
+              "type",
+              "value"
+            ]
+          },
+          {
+            "type": "object",
+            "properties": {
+              "type": {
+                "type": "string",
+                "enum": [
+                  "floating"
+                ]
+              },
+              "value": {
+                "type": "string",
+                "format": "ip"
+              }
+            },
+            "required": [
+              "type",
+              "value"
+            ]
+          }
+        ]
+      },
+      "InstanceMetadata": {
+        "description": "Metadata used to track statistics about an instance.",
+        "type": "object",
+        "properties": {
+          "project_id": {
+            "type": "string",
+            "format": "uuid"
+          },
+          "silo_id": {
+            "type": "string",
+            "format": "uuid"
+          }
+        },
+        "required": [
+          "project_id",
+          "silo_id"
+        ]
+      },
+      "InstanceMigrationTargetParams": {
+        "description": "Parameters used when directing Propolis to initialize itself via live migration.",
+        "type": "object",
+        "properties": {
+          "src_propolis_addr": {
+            "description": "The address of the Propolis server that will serve as the migration source.",
+            "type": "string"
+          }
+        },
+        "required": [
+          "src_propolis_addr"
+        ]
+      },
+      "InstanceMulticastBody": {
+        "description": "Request body for multicast group operations.",
+        "oneOf": [
+          {
+            "type": "object",
+            "properties": {
+              "join": {
+                "$ref": "#/components/schemas/InstanceMulticastMembership"
+              }
+            },
+            "required": [
+              "join"
+            ],
+            "additionalProperties": false
+          },
+          {
+            "type": "object",
+            "properties": {
+              "leave": {
+                "$ref": "#/components/schemas/InstanceMulticastMembership"
+              }
+            },
+            "required": [
+              "leave"
+            ],
+            "additionalProperties": false
+          }
+        ]
+      },
+      "InstanceMulticastMembership": {
+        "description": "Represents a multicast group membership for an instance.\n\nIntroduced in v7.",
+        "type": "object",
+        "properties": {
+          "group_ip": {
+            "type": "string",
+            "format": "ip"
+          },
+          "sources": {
+            "type": "array",
+            "items": {
+              "type": "string",
+              "format": "ip"
+            }
+          }
+        },
+        "required": [
+          "group_ip",
+          "sources"
+        ]
+      },
+      "InstanceSledLocalConfig": {
+        "description": "Describes sled-local configuration that a sled-agent must establish to make the instance's virtual hardware fully functional.",
+        "type": "object",
+        "properties": {
+          "delegated_zvols": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/DelegatedZvol"
+            }
+          },
+          "dhcp_config": {
+            "$ref": "#/components/schemas/DhcpConfig"
+          },
+          "external_ips": {
+            "nullable": true,
+            "allOf": [
+              {
+                "$ref": "#/components/schemas/ExternalIpConfig"
+              }
+            ]
+          },
+          "firewall_rules": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/ResolvedVpcFirewallRule"
+            }
+          },
+          "hostname": {
+            "$ref": "#/components/schemas/Hostname"
+          },
+          "multicast_groups": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/InstanceMulticastMembership"
+            }
+          },
+          "nics": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/NetworkInterface"
+            }
+          }
+        },
+        "required": [
+          "delegated_zvols",
+          "dhcp_config",
+          "firewall_rules",
+          "hostname",
+          "multicast_groups",
+          "nics"
+        ]
+      },
+      "InstanceSpecV0": {
+        "type": "object",
+        "properties": {
+          "board": {
+            "$ref": "#/components/schemas/Board"
+          },
+          "components": {
+            "type": "object",
+            "additionalProperties": {
+              "$ref": "#/components/schemas/ComponentV0"
+            }
+          }
+        },
+        "required": [
+          "board",
+          "components"
+        ],
+        "additionalProperties": false
+      },
+      "InstanceUuid": {
+        "x-rust-type": {
+          "crate": "omicron-uuid-kinds",
+          "path": "omicron_uuid_kinds::InstanceUuid",
+          "version": "*"
+        },
+        "type": "string",
+        "format": "uuid"
+      },
+      "InternalZpoolUuid": {
+        "x-rust-type": {
+          "crate": "omicron-uuid-kinds",
+          "path": "omicron_uuid_kinds::InternalZpoolUuid",
+          "version": "*"
+        },
+        "type": "string",
+        "format": "uuid"
+      },
+      "InternetGatewayRouterTarget": {
+        "description": "An Internet Gateway router target.",
+        "oneOf": [
+          {
+            "description": "Targets the gateway for the system-internal services VPC.",
+            "type": "object",
+            "properties": {
+              "type": {
+                "type": "string",
+                "enum": [
+                  "system"
+                ]
+              }
+            },
+            "required": [
+              "type"
+            ]
+          },
+          {
+            "description": "Targets a gateway for an instance's VPC.",
+            "type": "object",
+            "properties": {
+              "type": {
+                "type": "string",
+                "enum": [
+                  "instance"
+                ]
+              },
+              "value": {
+                "type": "string",
+                "format": "uuid"
+              }
+            },
+            "required": [
+              "type",
+              "value"
+            ]
+          }
+        ]
+      },
+      "InvalidRackSecretSizeError": {
+        "description": "Error indicating the rack secret has an invalid size.",
+        "type": "string",
+        "enum": [
+          null
+        ]
+      },
+      "Inventory": {
+        "description": "Identity and basic status information about this sled agent",
+        "type": "object",
+        "properties": {
+          "baseboard": {
+            "$ref": "#/components/schemas/Baseboard"
+          },
+          "cpu_family": {
+            "$ref": "#/components/schemas/SledCpuFamily"
+          },
+          "datasets": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/InventoryDataset"
+            }
+          },
+          "disks": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/InventoryDisk"
+            }
+          },
+          "file_source_resolver": {
+            "$ref": "#/components/schemas/OmicronFileSourceResolverInventory"
+          },
+          "health_monitor": {
+            "$ref": "#/components/schemas/HealthMonitorInventory"
+          },
+          "last_reconciliation": {
+            "nullable": true,
+            "allOf": [
+              {
+                "$ref": "#/components/schemas/ConfigReconcilerInventory"
+              }
+            ]
+          },
+          "ledgered_sled_config": {
+            "nullable": true,
+            "allOf": [
+              {
+                "$ref": "#/components/schemas/OmicronSledConfig"
+              }
+            ]
+          },
+          "reconciler_status": {
+            "$ref": "#/components/schemas/ConfigReconcilerInventoryStatus"
+          },
+          "reference_measurements": {
+            "title": "IdOrdMap",
+            "x-rust-type": {
+              "crate": "iddqd",
+              "parameters": [
+                {
+                  "$ref": "#/components/schemas/SingleMeasurementInventory"
+                }
+              ],
+              "path": "iddqd::IdOrdMap",
+              "version": "*"
+            },
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/SingleMeasurementInventory"
+            },
+            "uniqueItems": true
+          },
+          "reservoir_size": {
+            "$ref": "#/components/schemas/ByteCount"
+          },
+          "sled_agent_address": {
+            "type": "string"
+          },
+          "sled_id": {
+            "$ref": "#/components/schemas/SledUuid"
+          },
+          "sled_role": {
+            "$ref": "#/components/schemas/SledRole"
+          },
+          "usable_hardware_threads": {
+            "type": "integer",
+            "format": "uint32",
+            "minimum": 0
+          },
+          "usable_physical_ram": {
+            "$ref": "#/components/schemas/ByteCount"
+          },
+          "zpools": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/InventoryZpool"
+            }
+          }
+        },
+        "required": [
+          "baseboard",
+          "cpu_family",
+          "datasets",
+          "disks",
+          "file_source_resolver",
+          "health_monitor",
+          "reconciler_status",
+          "reference_measurements",
+          "reservoir_size",
+          "sled_agent_address",
+          "sled_id",
+          "sled_role",
+          "usable_hardware_threads",
+          "usable_physical_ram",
+          "zpools"
+        ]
+      },
+      "InventoryDataset": {
+        "description": "Identifies information about datasets within Oxide-managed zpools",
+        "type": "object",
+        "properties": {
+          "available": {
+            "description": "The amount of remaining space usable by the dataset (and children) assuming there is no other activity within the pool.",
+            "allOf": [
+              {
+                "$ref": "#/components/schemas/ByteCount"
+              }
+            ]
+          },
+          "compression": {
+            "description": "The compression algorithm used for this dataset, if any.",
+            "type": "string"
+          },
+          "id": {
+            "nullable": true,
+            "description": "Although datasets mandated by the control plane will have UUIDs, datasets can be created (and have been created) without UUIDs.",
+            "allOf": [
+              {
+                "$ref": "#/components/schemas/DatasetUuid"
+              }
+            ]
+          },
+          "name": {
+            "description": "This name is the full path of the dataset.",
+            "type": "string"
+          },
+          "quota": {
+            "nullable": true,
+            "description": "The maximum amount of space usable by a dataset and all descendents.",
+            "allOf": [
+              {
+                "$ref": "#/components/schemas/ByteCount"
+              }
+            ]
+          },
+          "reservation": {
+            "nullable": true,
+            "description": "The minimum amount of space guaranteed to a dataset and descendents.",
+            "allOf": [
+              {
+                "$ref": "#/components/schemas/ByteCount"
+              }
+            ]
+          },
+          "used": {
+            "description": "The amount of space consumed by this dataset and descendents.",
+            "allOf": [
+              {
+                "$ref": "#/components/schemas/ByteCount"
+              }
+            ]
+          }
+        },
+        "required": [
+          "available",
+          "compression",
+          "name",
+          "used"
+        ]
+      },
+      "InventoryDisk": {
+        "description": "Identifies information about disks which may be attached to Sleds.",
+        "type": "object",
+        "properties": {
+          "active_firmware_slot": {
+            "type": "integer",
+            "format": "uint8",
+            "minimum": 0
+          },
+          "identity": {
+            "$ref": "#/components/schemas/DiskIdentity"
+          },
+          "next_active_firmware_slot": {
+            "nullable": true,
+            "type": "integer",
+            "format": "uint8",
+            "minimum": 0
+          },
+          "number_of_firmware_slots": {
+            "type": "integer",
+            "format": "uint8",
+            "minimum": 0
+          },
+          "slot": {
+            "type": "integer",
+            "format": "int64"
+          },
+          "slot1_is_read_only": {
+            "type": "boolean"
+          },
+          "slot_firmware_versions": {
+            "type": "array",
+            "items": {
+              "nullable": true,
+              "type": "string"
+            }
+          },
+          "variant": {
+            "$ref": "#/components/schemas/DiskVariant"
+          }
+        },
+        "required": [
+          "active_firmware_slot",
+          "identity",
+          "number_of_firmware_slots",
+          "slot",
+          "slot1_is_read_only",
+          "slot_firmware_versions",
+          "variant"
+        ]
+      },
+      "InventoryZpool": {
+        "description": "Identifies information about zpools managed by the control plane",
+        "type": "object",
+        "properties": {
+          "id": {
+            "$ref": "#/components/schemas/ZpoolUuid"
+          },
+          "total_size": {
+            "$ref": "#/components/schemas/ByteCount"
+          }
+        },
+        "required": [
+          "id",
+          "total_size"
+        ]
+      },
+      "IpKind": {
+        "description": "The kind of external IP address of a probe.",
+        "type": "string",
+        "enum": [
+          "snat",
+          "ephemeral",
+          "floating"
+        ]
+      },
+      "IpNet": {
+        "x-rust-type": {
+          "crate": "oxnet",
+          "path": "oxnet::IpNet",
+          "version": "0.1.0"
+        },
+        "oneOf": [
+          {
+            "title": "v4",
+            "allOf": [
+              {
+                "$ref": "#/components/schemas/Ipv4Net"
+              }
+            ]
+          },
+          {
+            "title": "v6",
+            "allOf": [
+              {
+                "$ref": "#/components/schemas/Ipv6Net"
+              }
+            ]
+          }
+        ]
+      },
+      "Ipv4Net": {
+        "example": "192.168.1.0/24",
+        "title": "An IPv4 subnet",
+        "description": "An IPv4 subnet, including prefix and prefix length",
+        "x-rust-type": {
+          "crate": "oxnet",
+          "path": "oxnet::Ipv4Net",
+          "version": "0.1.0"
+        },
+        "type": "string",
+        "pattern": "^(([0-9]|[1-9][0-9]|1[0-9][0-9]|2[0-4][0-9]|25[0-5])\\.){3}([0-9]|[1-9][0-9]|1[0-9][0-9]|2[0-4][0-9]|25[0-5])/([0-9]|1[0-9]|2[0-9]|3[0-2])$"
+      },
+      "Ipv6Net": {
+        "example": "fd12:3456::/64",
+        "title": "An IPv6 subnet",
+        "description": "An IPv6 subnet, including prefix and subnet mask",
+        "x-rust-type": {
+          "crate": "oxnet",
+          "path": "oxnet::Ipv6Net",
+          "version": "0.1.0"
+        },
+        "type": "string",
+        "pattern": "^(([0-9a-fA-F]{1,4}:){7,7}[0-9a-fA-F]{1,4}|([0-9a-fA-F]{1,4}:){1,7}:|([0-9a-fA-F]{1,4}:){1,6}:[0-9a-fA-F]{1,4}|([0-9a-fA-F]{1,4}:){1,5}(:[0-9a-fA-F]{1,4}){1,2}|([0-9a-fA-F]{1,4}:){1,4}(:[0-9a-fA-F]{1,4}){1,3}|([0-9a-fA-F]{1,4}:){1,3}(:[0-9a-fA-F]{1,4}){1,4}|([0-9a-fA-F]{1,4}:){1,2}(:[0-9a-fA-F]{1,4}){1,5}|[0-9a-fA-F]{1,4}:((:[0-9a-fA-F]{1,4}){1,6})|:((:[0-9a-fA-F]{1,4}){1,7}|:)|fe80:(:[0-9a-fA-F]{0,4}){0,4}%[0-9a-zA-Z]{1,}|::(ffff(:0{1,4}){0,1}:){0,1}((25[0-5]|(2[0-4]|1{0,1}[0-9]){0,1}[0-9])\\.){3,3}(25[0-5]|(2[0-4]|1{0,1}[0-9]){0,1}[0-9])|([0-9a-fA-F]{1,4}:){1,4}:((25[0-5]|(2[0-4]|1{0,1}[0-9]){0,1}[0-9])\\.){3,3}(25[0-5]|(2[0-4]|1{0,1}[0-9]){0,1}[0-9]))\\/([0-9]|[1-9][0-9]|1[0-1][0-9]|12[0-8])$"
+      },
+      "Ipv6Subnet": {
+        "description": "Wraps an [`Ipv6Net`] with a compile-time prefix length.",
+        "type": "object",
+        "properties": {
+          "net": {
+            "$ref": "#/components/schemas/Ipv6Net"
+          }
+        },
+        "required": [
+          "net"
+        ]
+      },
+      "L4PortRange": {
+        "example": "22",
+        "title": "A range of IP ports",
+        "description": "An inclusive-inclusive range of IP ports. The second port may be omitted to represent a single port.",
+        "type": "string",
+        "pattern": "^[0-9]{1,5}(-[0-9]{1,5})?$",
+        "minLength": 1,
+        "maxLength": 11
+      },
+      "LldpAdminStatus": {
+        "description": "To what extent should this port participate in LLDP",
+        "type": "string",
+        "enum": [
+          "enabled",
+          "disabled",
+          "rx_only",
+          "tx_only"
+        ]
+      },
+      "LldpPortConfig": {
+        "description": "Per-port LLDP configuration settings.  Only the \"status\" setting is mandatory.  All other fields have natural defaults or may be inherited from the switch.",
+        "type": "object",
+        "properties": {
+          "chassis_id": {
+            "nullable": true,
+            "description": "Chassis ID to advertise.  If this is set, it will be advertised as a LocallyAssigned ID type.  If this is not set, it will be inherited from the switch-level settings.",
+            "type": "string"
+          },
+          "management_addrs": {
+            "nullable": true,
+            "description": "Management IP addresses to advertise.  If this is not set, it will be inherited from the switch-level settings.",
+            "type": "array",
+            "items": {
+              "type": "string",
+              "format": "ip"
+            }
+          },
+          "port_description": {
+            "nullable": true,
+            "description": "Port description to advertise.  If this is not set, no description will be advertised.",
+            "type": "string"
+          },
+          "port_id": {
+            "nullable": true,
+            "description": "Port ID to advertise.  If this is set, it will be advertised as a LocallyAssigned ID type.  If this is not set, it will be set to the port name. e.g., qsfp0/0.",
+            "type": "string"
+          },
+          "status": {
+            "description": "To what extent should this port participate in LLDP",
+            "allOf": [
+              {
+                "$ref": "#/components/schemas/LldpAdminStatus"
+              }
+            ]
+          },
+          "system_description": {
+            "nullable": true,
+            "description": "System description to advertise.  If this is not set, it will be inherited from the switch-level settings.",
+            "type": "string"
+          },
+          "system_name": {
+            "nullable": true,
+            "description": "System name to advertise.  If this is not set, it will be inherited from the switch-level settings.",
+            "type": "string"
+          }
+        },
+        "required": [
+          "status"
+        ]
+      },
+      "LocalStorageDatasetEnsureRequest": {
+        "description": "Dataset and Volume details for a Local Storage dataset ensure request.",
+        "type": "object",
+        "properties": {
+          "dataset_size": {
+            "description": "Size of the parent dataset",
+            "allOf": [
+              {
+                "$ref": "#/components/schemas/ByteCount"
+              }
+            ]
+          },
+          "volume_size": {
+            "description": "Size of the zvol",
+            "allOf": [
+              {
+                "$ref": "#/components/schemas/ByteCount"
+              }
+            ]
+          }
+        },
+        "required": [
+          "dataset_size",
+          "volume_size"
+        ]
+      },
+      "LrtqUpgradeMsg": {
+        "description": "A request from Nexus informing a node to start coordinating an upgrade from LRTQ.",
+        "type": "object",
+        "properties": {
+          "epoch": {
+            "type": "integer",
+            "format": "uint64",
+            "minimum": 0
+          },
+          "members": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/BaseboardId"
+            },
+            "uniqueItems": true
+          },
+          "rack_id": {
+            "$ref": "#/components/schemas/RackUuid"
+          },
+          "threshold": {
+            "type": "integer",
+            "format": "uint8",
+            "minimum": 0
+          }
+        },
+        "required": [
+          "epoch",
+          "members",
+          "rack_id",
+          "threshold"
+        ]
+      },
+      "M2Slot": {
+        "description": "Describes an M.2 slot, often in the context of writing a system image to it.",
+        "type": "string",
+        "enum": [
+          "A",
+          "B"
+        ]
+      },
+      "MacAddr": {
+        "example": "ff:ff:ff:ff:ff:ff",
+        "title": "A MAC address",
+        "description": "A Media Access Control address, in EUI-48 format",
+        "type": "string",
+        "pattern": "^([0-9a-fA-F]{0,2}:){5}[0-9a-fA-F]{0,2}$",
+        "minLength": 5,
+        "maxLength": 17
+      },
+      "ManifestBootInventory": {
+        "description": "Inventory representation of zone artifacts on the boot disk.\n\nPart of [`ManifestInventory`].",
+        "type": "object",
+        "properties": {
+          "artifacts": {
+            "title": "IdOrdMap",
+            "description": "The artifacts on disk.",
+            "x-rust-type": {
+              "crate": "iddqd",
+              "parameters": [
+                {
+                  "$ref": "#/components/schemas/ZoneArtifactInventory"
+                }
+              ],
+              "path": "iddqd::IdOrdMap",
+              "version": "*"
+            },
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/ZoneArtifactInventory"
+            },
+            "uniqueItems": true
+          },
+          "source": {
+            "description": "The manifest source.\n\nIn production this is [`OmicronInstallManifestSource::Installinator`], but in some development and testing flows Sled Agent synthesizes zone manifests. In those cases, the source is [`OmicronInstallManifestSource::SledAgent`].",
+            "allOf": [
+              {
+                "$ref": "#/components/schemas/OmicronInstallManifestSource"
+              }
+            ]
+          }
+        },
+        "required": [
+          "artifacts",
+          "source"
+        ]
+      },
+      "ManifestInventory": {
+        "description": "Inventory representation of a manifest.\n\nPart of [`ZoneImageResolverInventory`].\n\nA manifest is used for both zones and reference measurements. A zone manifest is a listing of all the zones present in a system's install dataset. A measurement manifset is a listing of all the reference measurements present in a system's install dataset. This struct contains information about the install dataset gathered from a system.",
+        "type": "object",
+        "properties": {
+          "boot_disk_path": {
+            "description": "The full path to the zone manifest file on the boot disk.",
+            "type": "string",
+            "format": "Utf8PathBuf"
+          },
+          "boot_inventory": {
+            "description": "The manifest read from the boot disk, and whether the manifest is valid.",
+            "x-rust-type": {
+              "crate": "std",
+              "parameters": [
+                {
+                  "$ref": "#/components/schemas/ManifestBootInventory"
+                },
+                {
+                  "type": "string"
+                }
+              ],
+              "path": "::std::result::Result",
+              "version": "*"
+            },
+            "oneOf": [
+              {
+                "type": "object",
+                "properties": {
+                  "ok": {
+                    "$ref": "#/components/schemas/ManifestBootInventory"
+                  }
+                },
+                "required": [
+                  "ok"
+                ]
+              },
+              {
+                "type": "object",
+                "properties": {
+                  "err": {
+                    "type": "string"
+                  }
+                },
+                "required": [
+                  "err"
+                ]
+              }
+            ]
+          },
+          "non_boot_status": {
+            "title": "IdOrdMap",
+            "description": "Information about the install dataset on non-boot disks.",
+            "x-rust-type": {
+              "crate": "iddqd",
+              "parameters": [
+                {
+                  "$ref": "#/components/schemas/ManifestNonBootInventory"
+                }
+              ],
+              "path": "iddqd::IdOrdMap",
+              "version": "*"
+            },
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/ManifestNonBootInventory"
+            },
+            "uniqueItems": true
+          }
+        },
+        "required": [
+          "boot_disk_path",
+          "boot_inventory",
+          "non_boot_status"
+        ]
+      },
+      "ManifestNonBootInventory": {
+        "description": "Inventory representation of a zone manifest on a non-boot disk.\n\nUnlike [`ManifestBootInventory`] which is structured since Reconfigurator makes decisions based on it, information about non-boot disks is purely advisory. For simplicity, we store information in an unstructured format.",
+        "type": "object",
+        "properties": {
+          "is_valid": {
+            "description": "Whether the status is valid.",
+            "type": "boolean"
+          },
+          "message": {
+            "description": "A message describing the status.\n\nIf `is_valid` is true, then the message describes the list of artifacts found and their hashes.\n\nIf `is_valid` is false, then this message describes the reason for the invalid status. This could include errors reading the zone manifest, or zone file mismatches.",
+            "type": "string"
+          },
+          "path": {
+            "description": "The full path to the zone manifest JSON on the non-boot disk.",
+            "type": "string",
+            "format": "Utf8PathBuf"
+          },
+          "zpool_id": {
+            "description": "The ID of the non-boot zpool.",
+            "allOf": [
+              {
+                "$ref": "#/components/schemas/InternalZpoolUuid"
+              }
+            ]
+          }
+        },
+        "required": [
+          "is_valid",
+          "message",
+          "path",
+          "zpool_id"
+        ]
+      },
+      "MigrationFailureInjector": {
+        "description": "Describes a synthetic device that registers for VM lifecycle notifications and returns errors during attempts to migrate.\n\nThis is only supported by Propolis servers compiled with the `failure-injection` feature.",
+        "type": "object",
+        "properties": {
+          "fail_exports": {
+            "description": "The number of times this device should fail requests to export state.",
+            "type": "integer",
+            "format": "uint32",
+            "minimum": 0
+          },
+          "fail_imports": {
+            "description": "The number of times this device should fail requests to import state.",
+            "type": "integer",
+            "format": "uint32",
+            "minimum": 0
+          }
+        },
+        "required": [
+          "fail_exports",
+          "fail_imports"
+        ],
+        "additionalProperties": false
+      },
+      "MigrationRuntimeState": {
+        "description": "An update from a sled regarding the state of a migration, indicating the role of the VMM whose migration state was updated.",
+        "type": "object",
+        "properties": {
+          "gen": {
+            "$ref": "#/components/schemas/Generation"
+          },
+          "migration_id": {
+            "type": "string",
+            "format": "uuid"
+          },
+          "state": {
+            "$ref": "#/components/schemas/MigrationState"
+          },
+          "time_updated": {
+            "description": "Timestamp for the migration state update.",
+            "type": "string",
+            "format": "date-time"
+          }
+        },
+        "required": [
+          "gen",
+          "migration_id",
+          "state",
+          "time_updated"
+        ]
+      },
+      "MigrationState": {
+        "description": "The state of an instance's live migration.",
+        "oneOf": [
+          {
+            "description": "The migration has not started for this VMM.",
+            "type": "string",
+            "enum": [
+              "pending"
+            ]
+          },
+          {
+            "description": "The migration is in progress.",
+            "type": "string",
+            "enum": [
+              "in_progress"
+            ]
+          },
+          {
+            "description": "The migration has failed.",
+            "type": "string",
+            "enum": [
+              "failed"
+            ]
+          },
+          {
+            "description": "The migration has completed.",
+            "type": "string",
+            "enum": [
+              "completed"
+            ]
+          }
+        ]
+      },
+      "MupdateOverrideBootInventory": {
+        "description": "Inventory representation of the MUPdate override on the boot disk.",
+        "type": "object",
+        "properties": {
+          "mupdate_override_id": {
+            "description": "The ID of the MUPdate override.\n\nThis is unique and generated by Installinator each time it is run. During a MUPdate, each sled gets a MUPdate override ID. (The ID is shared across boot disks and non-boot disks, though.)",
+            "allOf": [
+              {
+                "$ref": "#/components/schemas/MupdateOverrideUuid"
+              }
+            ]
+          }
+        },
+        "required": [
+          "mupdate_override_id"
+        ]
+      },
+      "MupdateOverrideInventory": {
+        "description": "Inventory representation of MUPdate override status.\n\nPart of [`ZoneImageResolverInventory`].\n\nThis is used by Reconfigurator to determine if a MUPdate override has occurred. For more about mixing MUPdate and updates, see RFD 556.",
+        "type": "object",
+        "properties": {
+          "boot_disk_path": {
+            "description": "The full path to the mupdate override JSON on the boot disk.",
+            "type": "string",
+            "format": "Utf8PathBuf"
+          },
+          "boot_override": {
+            "description": "The boot disk override, or an error if it could not be parsed.\n\nThis is `None` if the override is not present.",
+            "x-rust-type": {
+              "crate": "std",
+              "parameters": [
+                {
+                  "$ref": "#/components/schemas/MupdateOverrideBootInventory",
+                  "nullable": true
+                },
+                {
+                  "type": "string"
+                }
+              ],
+              "path": "::std::result::Result",
+              "version": "*"
+            },
+            "oneOf": [
+              {
+                "type": "object",
+                "properties": {
+                  "ok": {
+                    "nullable": true,
+                    "allOf": [
+                      {
+                        "$ref": "#/components/schemas/MupdateOverrideBootInventory"
+                      }
+                    ]
+                  }
+                },
+                "required": [
+                  "ok"
+                ]
+              },
+              {
+                "type": "object",
+                "properties": {
+                  "err": {
+                    "type": "string"
+                  }
+                },
+                "required": [
+                  "err"
+                ]
+              }
+            ]
+          },
+          "non_boot_status": {
+            "title": "IdOrdMap",
+            "description": "Information about the MUPdate override on non-boot disks.",
+            "x-rust-type": {
+              "crate": "iddqd",
+              "parameters": [
+                {
+                  "$ref": "#/components/schemas/MupdateOverrideNonBootInventory"
+                }
+              ],
+              "path": "iddqd::IdOrdMap",
+              "version": "*"
+            },
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/MupdateOverrideNonBootInventory"
+            },
+            "uniqueItems": true
+          }
+        },
+        "required": [
+          "boot_disk_path",
+          "boot_override",
+          "non_boot_status"
+        ]
+      },
+      "MupdateOverrideNonBootInventory": {
+        "description": "Inventory representation of the MUPdate override on a non-boot disk.\n\nUnlike [`MupdateOverrideBootInventory`] which is structured since Reconfigurator makes decisions based on it, information about non-boot disks is purely advisory. For simplicity, we store information in an unstructured format.",
+        "type": "object",
+        "properties": {
+          "is_valid": {
+            "description": "Whether the status is valid.",
+            "type": "boolean"
+          },
+          "message": {
+            "description": "A message describing the status.\n\nIf `is_valid` is true, then the message is a short description saying that it matches the boot disk, and whether the MUPdate override is present.\n\nIf `is_valid` is false, then this message describes the reason for the invalid status. This could include errors reading the MUPdate override JSON, or a mismatch between the boot and non-boot disks.",
+            "type": "string"
+          },
+          "path": {
+            "description": "The path to the mupdate override JSON on the non-boot disk.",
+            "type": "string",
+            "format": "Utf8PathBuf"
+          },
+          "zpool_id": {
+            "description": "The non-boot zpool ID.",
+            "allOf": [
+              {
+                "$ref": "#/components/schemas/InternalZpoolUuid"
+              }
+            ]
+          }
+        },
+        "required": [
+          "is_valid",
+          "message",
+          "path",
+          "zpool_id"
+        ]
+      },
+      "MupdateOverrideUuid": {
+        "x-rust-type": {
+          "crate": "omicron-uuid-kinds",
+          "path": "omicron_uuid_kinds::MupdateOverrideUuid",
+          "version": "*"
+        },
+        "type": "string",
+        "format": "uuid"
+      },
+      "MupdateUuid": {
+        "x-rust-type": {
+          "crate": "omicron-uuid-kinds",
+          "path": "omicron_uuid_kinds::MupdateUuid",
+          "version": "*"
+        },
+        "type": "string",
+        "format": "uuid"
+      },
+      "Name": {
+        "title": "A name unique within the parent collection",
+        "description": "Names must begin with a lower case ASCII letter, be composed exclusively of lowercase ASCII, uppercase ASCII, numbers, and '-', and may not end with a '-'. Names cannot be a UUID, but they may contain a UUID. They can be at most 63 characters long.",
+        "type": "string",
+        "pattern": "^(?![0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{12}$)^[a-z]([a-zA-Z0-9-]*[a-zA-Z0-9]+)?$",
+        "minLength": 1,
+        "maxLength": 63
+      },
+      "NetworkInterface": {
+        "description": "Information required to construct a virtual network interface",
+        "type": "object",
+        "properties": {
+          "id": {
+            "type": "string",
+            "format": "uuid"
+          },
+          "ip_config": {
+            "$ref": "#/components/schemas/PrivateIpConfig"
+          },
+          "kind": {
+            "$ref": "#/components/schemas/NetworkInterfaceKind"
+          },
+          "mac": {
+            "$ref": "#/components/schemas/MacAddr"
+          },
+          "name": {
+            "$ref": "#/components/schemas/Name"
+          },
+          "primary": {
+            "type": "boolean"
+          },
+          "slot": {
+            "type": "integer",
+            "format": "uint8",
+            "minimum": 0
+          },
+          "vni": {
+            "$ref": "#/components/schemas/Vni"
+          }
+        },
+        "required": [
+          "id",
+          "ip_config",
+          "kind",
+          "mac",
+          "name",
+          "primary",
+          "slot",
+          "vni"
+        ]
+      },
+      "NetworkInterfaceKind": {
+        "description": "The type of network interface",
+        "oneOf": [
+          {
+            "description": "A vNIC attached to a guest instance",
+            "type": "object",
+            "properties": {
+              "id": {
+                "type": "string",
+                "format": "uuid"
+              },
+              "type": {
+                "type": "string",
+                "enum": [
+                  "instance"
+                ]
+              }
+            },
+            "required": [
+              "id",
+              "type"
+            ]
+          },
+          {
+            "description": "A vNIC associated with an internal service",
+            "type": "object",
+            "properties": {
+              "id": {
+                "type": "string",
+                "format": "uuid"
+              },
+              "type": {
+                "type": "string",
+                "enum": [
+                  "service"
+                ]
+              }
+            },
+            "required": [
+              "id",
+              "type"
+            ]
+          },
+          {
+            "description": "A vNIC associated with a probe",
+            "type": "object",
+            "properties": {
+              "id": {
+                "type": "string",
+                "format": "uuid"
+              },
+              "type": {
+                "type": "string",
+                "enum": [
+                  "probe"
+                ]
+              }
+            },
+            "required": [
+              "id",
+              "type"
+            ]
+          }
+        ]
+      },
+      "NodePersistentStateSummary": {
+        "description": "A summary of a node's persistent state.",
+        "type": "object",
+        "properties": {
+          "commits": {
+            "type": "array",
+            "items": {
+              "type": "integer",
+              "format": "uint64",
+              "minimum": 0
+            },
+            "uniqueItems": true
+          },
+          "configs": {
+            "type": "array",
+            "items": {
+              "type": "integer",
+              "format": "uint64",
+              "minimum": 0
+            },
+            "uniqueItems": true
+          },
+          "expunged": {
+            "nullable": true,
+            "allOf": [
+              {
+                "$ref": "#/components/schemas/ExpungedMetadata"
+              }
+            ]
+          },
+          "has_lrtq_share": {
+            "type": "boolean"
+          },
+          "shares": {
+            "type": "array",
+            "items": {
+              "type": "integer",
+              "format": "uint64",
+              "minimum": 0
+            },
+            "uniqueItems": true
+          }
+        },
+        "required": [
+          "commits",
+          "configs",
+          "has_lrtq_share",
+          "shares"
+        ]
+      },
+      "NodeStatus": {
+        "description": "Details about a given node's status.",
+        "type": "object",
+        "properties": {
+          "alarms": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/Alarm"
+            },
+            "uniqueItems": true
+          },
+          "connected_peers": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/BaseboardId"
+            },
+            "uniqueItems": true
+          },
+          "persistent_state": {
+            "$ref": "#/components/schemas/NodePersistentStateSummary"
+          },
+          "proxied_requests": {
+            "type": "integer",
+            "format": "uint64",
+            "minimum": 0
+          }
+        },
+        "required": [
+          "alarms",
+          "connected_peers",
+          "persistent_state",
+          "proxied_requests"
+        ]
+      },
+      "NvmeDisk": {
+        "description": "A disk that presents an NVMe interface to the guest.",
+        "type": "object",
+        "properties": {
+          "backend_id": {
+            "description": "The name of the disk's backend component.",
+            "allOf": [
+              {
+                "$ref": "#/components/schemas/SpecKey"
+              }
+            ]
+          },
+          "pci_path": {
+            "description": "The PCI bus/device/function at which this disk should be attached.",
+            "allOf": [
+              {
+                "$ref": "#/components/schemas/PciPath"
+              }
+            ]
+          },
+          "serial_number": {
+            "description": "The serial number to return in response to an NVMe Identify Controller command.",
+            "type": "array",
+            "items": {
+              "type": "integer",
+              "format": "uint8",
+              "minimum": 0
+            },
+            "minItems": 20,
+            "maxItems": 20
+          }
+        },
+        "required": [
+          "backend_id",
+          "pci_path",
+          "serial_number"
+        ],
+        "additionalProperties": false
+      },
+      "OmicronFileSourceResolverInventory": {
+        "description": "Inventory representation of zone image resolver and measurement resolver status and health. Previously known as `ZoneImageResolverInventory`",
+        "type": "object",
+        "properties": {
+          "measurement_manifest": {
+            "description": "The measurement manifest status.",
+            "allOf": [
+              {
+                "$ref": "#/components/schemas/ManifestInventory"
+              }
+            ]
+          },
+          "mupdate_override": {
+            "$ref": "#/components/schemas/MupdateOverrideInventory"
+          },
+          "zone_manifest": {
+            "description": "The zone manifest status.",
+            "allOf": [
+              {
+                "$ref": "#/components/schemas/ManifestInventory"
+              }
+            ]
+          }
+        },
+        "required": [
+          "measurement_manifest",
+          "mupdate_override",
+          "zone_manifest"
+        ]
+      },
+      "OmicronInstallManifestSource": {
+        "description": "The source of truth for an Omicron zone manifest.",
+        "oneOf": [
+          {
+            "description": "The manifest was written out by installinator and the mupdate process.",
+            "type": "object",
+            "properties": {
+              "mupdate_id": {
+                "description": "The UUID of the mupdate.",
+                "allOf": [
+                  {
+                    "$ref": "#/components/schemas/MupdateUuid"
+                  }
+                ]
+              },
+              "source": {
+                "type": "string",
+                "enum": [
+                  "installinator"
+                ]
+              }
+            },
+            "required": [
+              "mupdate_id",
+              "source"
+            ]
+          },
+          {
+            "description": "The zone manifest was not found during the install process. A synthetic zone manifest was generated by Sled Agent by looking at all the `.tar.gz` files in the install dataset.",
+            "type": "object",
+            "properties": {
+              "source": {
+                "type": "string",
+                "enum": [
+                  "sled_agent"
+                ]
+              }
+            },
+            "required": [
+              "source"
+            ]
+          }
+        ]
+      },
+      "OmicronPhysicalDiskConfig": {
+        "type": "object",
+        "properties": {
+          "id": {
+            "$ref": "#/components/schemas/PhysicalDiskUuid"
+          },
+          "identity": {
+            "$ref": "#/components/schemas/DiskIdentity"
+          },
+          "pool_id": {
+            "$ref": "#/components/schemas/ZpoolUuid"
+          }
+        },
+        "required": [
+          "id",
+          "identity",
+          "pool_id"
+        ]
+      },
+      "OmicronSingleMeasurement": {
+        "description": "Represents a single measurement artfact from the TUF artifact store (aka \"TUF repo depot\"). The fully resolved measurement set is used with trust quorum.\n\nMeasurements may also come from outside the TUF repo depot via the install dataset from MUPdate but are not represented here",
+        "type": "object",
+        "properties": {
+          "hash": {
+            "description": "Measurements are the artifacts matching the hashes from the TUF artifact store (aka \"TUF repo depot\")\n\nMeasurements may also come from outside the TUF repo depot via the install dataset from MUPdate but are not explicitly tracked here",
+            "type": "string",
+            "format": "hex string (32 bytes)"
+          }
+        },
+        "required": [
+          "hash"
+        ]
+      },
+      "OmicronSledConfig": {
+        "description": "Describes the set of Reconfigurator-managed configuration elements of a sled",
+        "type": "object",
+        "properties": {
+          "datasets": {
+            "title": "IdOrdMapAsMap",
+            "x-rust-type": {
+              "crate": "iddqd",
+              "parameters": [
+                {
+                  "$ref": "#/components/schemas/DatasetConfig"
+                }
+              ],
+              "path": "iddqd::IdOrdMap",
+              "version": "*"
+            },
+            "type": "object",
+            "additionalProperties": {
+              "$ref": "#/components/schemas/DatasetConfig"
+            }
+          },
+          "disks": {
+            "title": "IdOrdMapAsMap",
+            "x-rust-type": {
+              "crate": "iddqd",
+              "parameters": [
+                {
+                  "$ref": "#/components/schemas/OmicronPhysicalDiskConfig"
+                }
+              ],
+              "path": "iddqd::IdOrdMap",
+              "version": "*"
+            },
+            "type": "object",
+            "additionalProperties": {
+              "$ref": "#/components/schemas/OmicronPhysicalDiskConfig"
+            }
+          },
+          "generation": {
+            "$ref": "#/components/schemas/Generation"
+          },
+          "host_phase_2": {
+            "default": {
+              "slot_a": {
+                "type": "current_contents"
+              },
+              "slot_b": {
+                "type": "current_contents"
+              }
+            },
+            "allOf": [
+              {
+                "$ref": "#/components/schemas/HostPhase2DesiredSlots"
+              }
+            ]
+          },
+          "measurements": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/OmicronSingleMeasurement"
+            },
+            "uniqueItems": true
+          },
+          "remove_mupdate_override": {
+            "nullable": true,
+            "allOf": [
+              {
+                "$ref": "#/components/schemas/MupdateOverrideUuid"
+              }
+            ]
+          },
+          "zones": {
+            "title": "IdOrdMapAsMap",
+            "x-rust-type": {
+              "crate": "iddqd",
+              "parameters": [
+                {
+                  "$ref": "#/components/schemas/OmicronZoneConfig"
+                }
+              ],
+              "path": "iddqd::IdOrdMap",
+              "version": "*"
+            },
+            "type": "object",
+            "additionalProperties": {
+              "$ref": "#/components/schemas/OmicronZoneConfig"
+            }
+          }
+        },
+        "required": [
+          "datasets",
+          "disks",
+          "generation",
+          "measurements",
+          "zones"
+        ]
+      },
+      "OmicronZoneConfig": {
+        "description": "Describes one Omicron-managed zone running on a sled",
+        "type": "object",
+        "properties": {
+          "filesystem_pool": {
+            "nullable": true,
+            "description": "The pool on which we'll place this zone's root filesystem.\n\nNote that the root filesystem is transient -- the sled agent is permitted to destroy this dataset each time the zone is initialized.",
+            "allOf": [
+              {
+                "$ref": "#/components/schemas/ZpoolName"
+              }
+            ]
+          },
+          "id": {
+            "$ref": "#/components/schemas/OmicronZoneUuid"
+          },
+          "image_source": {
+            "default": {
+              "type": "install_dataset"
+            },
+            "allOf": [
+              {
+                "$ref": "#/components/schemas/OmicronZoneImageSource"
+              }
+            ]
+          },
+          "zone_type": {
+            "$ref": "#/components/schemas/OmicronZoneType"
+          }
+        },
+        "required": [
+          "id",
+          "zone_type"
+        ]
+      },
+      "OmicronZoneDataset": {
+        "description": "Describes a persistent ZFS dataset associated with an Omicron zone",
+        "type": "object",
+        "properties": {
+          "pool_name": {
+            "$ref": "#/components/schemas/ZpoolName"
+          }
+        },
+        "required": [
+          "pool_name"
+        ]
+      },
+      "OmicronZoneImageSource": {
+        "description": "Where Sled Agent should get the image for a zone.",
+        "oneOf": [
+          {
+            "description": "This zone's image source is whatever happens to be on the sled's \"install\" dataset.\n\nThis is whatever was put in place at the factory or by the latest MUPdate. The image used here can vary by sled and even over time (if the sled gets MUPdated again).\n\nHistorically, this was the only source for zone images. In an system with automated control-plane-driven update we expect to only use this variant in emergencies where the system had to be recovered via MUPdate.",
+            "type": "object",
+            "properties": {
+              "type": {
+                "type": "string",
+                "enum": [
+                  "install_dataset"
+                ]
+              }
+            },
+            "required": [
+              "type"
+            ]
+          },
+          {
+            "description": "This zone's image source is the artifact matching this hash from the TUF artifact store (aka \"TUF repo depot\").\n\nThis originates from TUF repos uploaded to Nexus which are then replicated out to all sleds.",
+            "type": "object",
+            "properties": {
+              "hash": {
+                "type": "string",
+                "format": "hex string (32 bytes)"
+              },
+              "type": {
+                "type": "string",
+                "enum": [
+                  "artifact"
+                ]
+              }
+            },
+            "required": [
+              "hash",
+              "type"
+            ]
+          }
+        ]
+      },
+      "OmicronZoneType": {
+        "description": "Describes what kind of zone this is (i.e., what component is running in it) as well as any type-specific configuration",
+        "oneOf": [
+          {
+            "type": "object",
+            "properties": {
+              "address": {
+                "type": "string"
+              },
+              "dns_servers": {
+                "type": "array",
+                "items": {
+                  "type": "string",
+                  "format": "ip"
+                }
+              },
+              "domain": {
+                "nullable": true,
+                "type": "string"
+              },
+              "nic": {
+                "description": "The service vNIC providing outbound connectivity using OPTE.",
+                "allOf": [
+                  {
+                    "$ref": "#/components/schemas/NetworkInterface"
+                  }
+                ]
+              },
+              "ntp_servers": {
+                "type": "array",
+                "items": {
+                  "type": "string"
+                }
+              },
+              "snat_cfg": {
+                "description": "The SNAT configuration for outbound connections.",
+                "allOf": [
+                  {
+                    "$ref": "#/components/schemas/SourceNatConfigGeneric"
+                  }
+                ]
+              },
+              "type": {
+                "type": "string",
+                "enum": [
+                  "boundary_ntp"
+                ]
+              }
+            },
+            "required": [
+              "address",
+              "dns_servers",
+              "nic",
+              "ntp_servers",
+              "snat_cfg",
+              "type"
+            ]
+          },
+          {
+            "description": "Type of clickhouse zone used for a single node clickhouse deployment",
+            "type": "object",
+            "properties": {
+              "address": {
+                "type": "string"
+              },
+              "dataset": {
+                "$ref": "#/components/schemas/OmicronZoneDataset"
+              },
+              "type": {
+                "type": "string",
+                "enum": [
+                  "clickhouse"
+                ]
+              }
+            },
+            "required": [
+              "address",
+              "dataset",
+              "type"
+            ]
+          },
+          {
+            "description": "A zone used to run a Clickhouse Keeper node\n\nKeepers are only used in replicated clickhouse setups",
+            "type": "object",
+            "properties": {
+              "address": {
+                "type": "string"
+              },
+              "dataset": {
+                "$ref": "#/components/schemas/OmicronZoneDataset"
+              },
+              "type": {
+                "type": "string",
+                "enum": [
+                  "clickhouse_keeper"
+                ]
+              }
+            },
+            "required": [
+              "address",
+              "dataset",
+              "type"
+            ]
+          },
+          {
+            "description": "A zone used to run a Clickhouse Server in a replicated deployment",
+            "type": "object",
+            "properties": {
+              "address": {
+                "type": "string"
+              },
+              "dataset": {
+                "$ref": "#/components/schemas/OmicronZoneDataset"
+              },
+              "type": {
+                "type": "string",
+                "enum": [
+                  "clickhouse_server"
+                ]
+              }
+            },
+            "required": [
+              "address",
+              "dataset",
+              "type"
+            ]
+          },
+          {
+            "type": "object",
+            "properties": {
+              "address": {
+                "type": "string"
+              },
+              "dataset": {
+                "$ref": "#/components/schemas/OmicronZoneDataset"
+              },
+              "type": {
+                "type": "string",
+                "enum": [
+                  "cockroach_db"
+                ]
+              }
+            },
+            "required": [
+              "address",
+              "dataset",
+              "type"
+            ]
+          },
+          {
+            "type": "object",
+            "properties": {
+              "address": {
+                "type": "string"
+              },
+              "dataset": {
+                "$ref": "#/components/schemas/OmicronZoneDataset"
+              },
+              "type": {
+                "type": "string",
+                "enum": [
+                  "crucible"
+                ]
+              }
+            },
+            "required": [
+              "address",
+              "dataset",
+              "type"
+            ]
+          },
+          {
+            "type": "object",
+            "properties": {
+              "address": {
+                "type": "string"
+              },
+              "type": {
+                "type": "string",
+                "enum": [
+                  "crucible_pantry"
+                ]
+              }
+            },
+            "required": [
+              "address",
+              "type"
+            ]
+          },
+          {
+            "type": "object",
+            "properties": {
+              "dataset": {
+                "$ref": "#/components/schemas/OmicronZoneDataset"
+              },
+              "dns_address": {
+                "description": "The address at which the external DNS server is reachable.",
+                "type": "string"
+              },
+              "http_address": {
+                "description": "The address at which the external DNS server API is reachable.",
+                "type": "string"
+              },
+              "nic": {
+                "description": "The service vNIC providing external connectivity using OPTE.",
+                "allOf": [
+                  {
+                    "$ref": "#/components/schemas/NetworkInterface"
+                  }
+                ]
+              },
+              "type": {
+                "type": "string",
+                "enum": [
+                  "external_dns"
+                ]
+              }
+            },
+            "required": [
+              "dataset",
+              "dns_address",
+              "http_address",
+              "nic",
+              "type"
+            ]
+          },
+          {
+            "type": "object",
+            "properties": {
+              "dataset": {
+                "$ref": "#/components/schemas/OmicronZoneDataset"
+              },
+              "dns_address": {
+                "type": "string"
+              },
+              "gz_address": {
+                "description": "The addresses in the global zone which should be created\n\nFor the DNS service, which exists outside the sleds's typical subnet - adding an address in the GZ is necessary to allow inter-zone traffic routing.",
+                "type": "string",
+                "format": "ipv6"
+              },
+              "gz_address_index": {
+                "description": "The address is also identified with an auxiliary bit of information to ensure that the created global zone address can have a unique name.",
+                "type": "integer",
+                "format": "uint32",
+                "minimum": 0
+              },
+              "http_address": {
+                "type": "string"
+              },
+              "type": {
+                "type": "string",
+                "enum": [
+                  "internal_dns"
+                ]
+              }
+            },
+            "required": [
+              "dataset",
+              "dns_address",
+              "gz_address",
+              "gz_address_index",
+              "http_address",
+              "type"
+            ]
+          },
+          {
+            "type": "object",
+            "properties": {
+              "address": {
+                "type": "string"
+              },
+              "type": {
+                "type": "string",
+                "enum": [
+                  "internal_ntp"
+                ]
+              }
+            },
+            "required": [
+              "address",
+              "type"
+            ]
+          },
+          {
+            "type": "object",
+            "properties": {
+              "external_dns_servers": {
+                "description": "External DNS servers Nexus can use to resolve external hosts.",
+                "type": "array",
+                "items": {
+                  "type": "string",
+                  "format": "ip"
+                }
+              },
+              "external_ip": {
+                "description": "The address at which the external nexus server is reachable.",
+                "type": "string",
+                "format": "ip"
+              },
+              "external_tls": {
+                "description": "Whether Nexus's external endpoint should use TLS",
+                "type": "boolean"
+              },
+              "internal_address": {
+                "description": "The address at which the internal nexus server is reachable.",
+                "type": "string"
+              },
+              "lockstep_port": {
+                "description": "The port at which the internal lockstep server is reachable. This shares the same IP address with `internal_address`.",
+                "default": 12232,
+                "type": "integer",
+                "format": "uint16",
+                "minimum": 0
+              },
+              "nic": {
+                "description": "The service vNIC providing external connectivity using OPTE.",
+                "allOf": [
+                  {
+                    "$ref": "#/components/schemas/NetworkInterface"
+                  }
+                ]
+              },
+              "type": {
+                "type": "string",
+                "enum": [
+                  "nexus"
+                ]
+              }
+            },
+            "required": [
+              "external_dns_servers",
+              "external_ip",
+              "external_tls",
+              "internal_address",
+              "nic",
+              "type"
+            ]
+          },
+          {
+            "type": "object",
+            "properties": {
+              "address": {
+                "type": "string"
+              },
+              "type": {
+                "type": "string",
+                "enum": [
+                  "oximeter"
+                ]
+              }
+            },
+            "required": [
+              "address",
+              "type"
+            ]
+          }
+        ]
+      },
+      "OmicronZoneUuid": {
+        "x-rust-type": {
+          "crate": "omicron-uuid-kinds",
+          "path": "omicron_uuid_kinds::OmicronZoneUuid",
+          "version": "*"
+        },
+        "type": "string",
+        "format": "uuid"
+      },
+      "OperatorSwitchZonePolicy": {
+        "description": "Policy allowing an operator (via `omdb`) to control whether the switch zone is started or stopped.\n\nThis is an _extremely_ dicey operation in general; a stopped switch zone leaves the rack inoperable! We are only adding this as a workaround and test tool for handling sidecar resets; see <https://github.com/oxidecomputer/omicron/issues/8480> for background.",
+        "oneOf": [
+          {
+            "description": "Start the switch zone if a switch is present.\n\nThis is the default policy.",
+            "type": "object",
+            "properties": {
+              "policy": {
+                "type": "string",
+                "enum": [
+                  "start_if_switch_present"
+                ]
+              }
+            },
+            "required": [
+              "policy"
+            ]
+          },
+          {
+            "description": "Even if a switch zone is present, stop the switch zone.",
+            "type": "object",
+            "properties": {
+              "policy": {
+                "type": "string",
+                "enum": [
+                  "stop_despite_switch_presence"
+                ]
+              }
+            },
+            "required": [
+              "policy"
+            ]
+          }
+        ]
+      },
+      "OrphanedDataset": {
+        "type": "object",
+        "properties": {
+          "available": {
+            "$ref": "#/components/schemas/ByteCount"
+          },
+          "id": {
+            "nullable": true,
+            "allOf": [
+              {
+                "$ref": "#/components/schemas/DatasetUuid"
+              }
+            ]
+          },
+          "mounted": {
+            "type": "boolean"
+          },
+          "name": {
+            "$ref": "#/components/schemas/DatasetName"
+          },
+          "reason": {
+            "type": "string"
+          },
+          "used": {
+            "$ref": "#/components/schemas/ByteCount"
+          }
+        },
+        "required": [
+          "available",
+          "mounted",
+          "name",
+          "reason",
+          "used"
+        ]
+      },
+      "P9fs": {
+        "description": "Describes a filesystem to expose through a P9 device.\n\nThis is only supported by Propolis servers compiled with the `falcon` feature.",
+        "type": "object",
+        "properties": {
+          "chunk_size": {
+            "description": "The chunk size to use in the 9P protocol. Vanilla Helios images should use 8192. Falcon Helios base images and Linux can use up to 65536.",
+            "type": "integer",
+            "format": "uint32",
+            "minimum": 0
+          },
+          "pci_path": {
+            "description": "The PCI path at which to attach the guest to this P9 filesystem.",
+            "allOf": [
+              {
+                "$ref": "#/components/schemas/PciPath"
+              }
+            ]
+          },
+          "source": {
+            "description": "The host source path to mount into the guest.",
+            "type": "string"
+          },
+          "target": {
+            "description": "The 9P target filesystem tag.",
+            "type": "string"
+          }
+        },
+        "required": [
+          "chunk_size",
+          "pci_path",
+          "source",
+          "target"
+        ],
+        "additionalProperties": false
+      },
+      "PciPath": {
+        "description": "A PCI bus/device/function tuple.",
+        "type": "object",
+        "properties": {
+          "bus": {
+            "type": "integer",
+            "format": "uint8",
+            "minimum": 0
+          },
+          "device": {
+            "type": "integer",
+            "format": "uint8",
+            "minimum": 0
+          },
+          "function": {
+            "type": "integer",
+            "format": "uint8",
+            "minimum": 0
+          }
+        },
+        "required": [
+          "bus",
+          "device",
+          "function"
+        ]
+      },
+      "PciPciBridge": {
+        "description": "A PCI-PCI bridge.",
+        "type": "object",
+        "properties": {
+          "downstream_bus": {
+            "description": "The logical bus number of this bridge's downstream bus. Other devices may use this bus number in their PCI paths to indicate they should be attached to this bridge's bus.",
+            "type": "integer",
+            "format": "uint8",
+            "minimum": 0
+          },
+          "pci_path": {
+            "description": "The PCI path at which to attach this bridge.",
+            "allOf": [
+              {
+                "$ref": "#/components/schemas/PciPath"
+              }
+            ]
+          }
+        },
+        "required": [
+          "downstream_bus",
+          "pci_path"
+        ],
+        "additionalProperties": false
+      },
+      "PhysicalDiskUuid": {
+        "x-rust-type": {
+          "crate": "omicron-uuid-kinds",
+          "path": "omicron_uuid_kinds::PhysicalDiskUuid",
+          "version": "*"
+        },
+        "type": "string",
+        "format": "uuid"
+      },
+      "PortConfigV2": {
+        "type": "object",
+        "properties": {
+          "addresses": {
+            "description": "This port's addresses and optional vlan IDs",
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/UplinkAddressConfig"
+            }
+          },
+          "autoneg": {
+            "description": "Whether or not to set autonegotiation",
+            "default": false,
+            "type": "boolean"
+          },
+          "bgp_peers": {
+            "description": "BGP peers on this port",
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/BgpPeerConfig"
+            }
+          },
+          "lldp": {
+            "nullable": true,
+            "description": "LLDP configuration for this port",
+            "allOf": [
+              {
+                "$ref": "#/components/schemas/LldpPortConfig"
+              }
+            ]
+          },
+          "port": {
+            "description": "Nmae of the port this config applies to.",
+            "type": "string"
+          },
+          "routes": {
+            "description": "The set of routes associated with this port.",
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/RouteConfig"
+            }
+          },
+          "switch": {
+            "description": "Switch the port belongs to.",
+            "allOf": [
+              {
+                "$ref": "#/components/schemas/SwitchLocation"
+              }
+            ]
+          },
+          "tx_eq": {
+            "nullable": true,
+            "description": "TX-EQ configuration for this port",
+            "allOf": [
+              {
+                "$ref": "#/components/schemas/TxEqConfig"
+              }
+            ]
+          },
+          "uplink_port_fec": {
+            "nullable": true,
+            "description": "Port forward error correction type.",
+            "allOf": [
+              {
+                "$ref": "#/components/schemas/PortFec"
+              }
+            ]
+          },
+          "uplink_port_speed": {
+            "description": "Port speed.",
+            "allOf": [
+              {
+                "$ref": "#/components/schemas/PortSpeed"
+              }
+            ]
+          }
+        },
+        "required": [
+          "addresses",
+          "bgp_peers",
+          "port",
+          "routes",
+          "switch",
+          "uplink_port_speed"
+        ]
+      },
+      "PortFec": {
+        "description": "Switchport FEC options",
+        "type": "string",
+        "enum": [
+          "firecode",
+          "none",
+          "rs"
+        ]
+      },
+      "PortSpeed": {
+        "description": "Switchport Speed options",
+        "type": "string",
+        "enum": [
+          "speed0_g",
+          "speed1_g",
+          "speed10_g",
+          "speed25_g",
+          "speed40_g",
+          "speed50_g",
+          "speed100_g",
+          "speed200_g",
+          "speed400_g"
+        ]
+      },
+      "PrepareAndCommitRequest": {
+        "description": "Request to prepare and commit a trust quorum configuration.\n\nThis is the `Configuration` sent to a node that missed the `Prepare` phase.",
+        "type": "object",
+        "properties": {
+          "config": {
+            "$ref": "#/components/schemas/Configuration"
+          }
+        },
+        "required": [
+          "config"
+        ]
+      },
+      "PriorityDimension": {
+        "description": "A dimension along with bundles can be sorted, to determine priority.",
+        "oneOf": [
+          {
+            "description": "Sorting by time, with older bundles with lower priority.",
+            "type": "string",
+            "enum": [
+              "time"
+            ]
+          },
+          {
+            "description": "Sorting by the cause for creating the bundle.",
+            "type": "string",
+            "enum": [
+              "cause"
+            ]
+          }
+        ]
+      },
+      "PriorityOrder": {
+        "description": "The priority order for bundles during cleanup.\n\nBundles are sorted along the dimensions in [`PriorityDimension`], with each dimension appearing exactly once. During cleanup, lesser-priority bundles are pruned first, to maintain the dataset quota. Note that bundles are sorted by each dimension in the order in which they appear, with each dimension having higher priority than the next.\n\nTODO: The serde deserializer does not currently verify uniqueness of dimensions.",
+        "type": "array",
+        "items": {
+          "$ref": "#/components/schemas/PriorityDimension"
+        },
+        "minItems": 2,
+        "maxItems": 2
+      },
+      "PrivateIpConfig": {
+        "description": "VPC-private IP address configuration for a network interface.",
+        "oneOf": [
+          {
+            "description": "The interface has only an IPv4 configuration.",
+            "type": "object",
+            "properties": {
+              "type": {
+                "type": "string",
+                "enum": [
+                  "v4"
+                ]
+              },
+              "value": {
+                "$ref": "#/components/schemas/PrivateIpv4Config"
+              }
+            },
+            "required": [
+              "type",
+              "value"
+            ]
+          },
+          {
+            "description": "The interface has only an IPv6 configuration.",
+            "type": "object",
+            "properties": {
+              "type": {
+                "type": "string",
+                "enum": [
+                  "v6"
+                ]
+              },
+              "value": {
+                "$ref": "#/components/schemas/PrivateIpv6Config"
+              }
+            },
+            "required": [
+              "type",
+              "value"
+            ]
+          },
+          {
+            "description": "The interface is dual-stack.",
+            "type": "object",
+            "properties": {
+              "type": {
+                "type": "string",
+                "enum": [
+                  "dual_stack"
+                ]
+              },
+              "value": {
+                "type": "object",
+                "properties": {
+                  "v4": {
+                    "description": "The interface's IPv4 configuration.",
+                    "allOf": [
+                      {
+                        "$ref": "#/components/schemas/PrivateIpv4Config"
+                      }
+                    ]
+                  },
+                  "v6": {
+                    "description": "The interface's IPv6 configuration.",
+                    "allOf": [
+                      {
+                        "$ref": "#/components/schemas/PrivateIpv6Config"
+                      }
+                    ]
+                  }
+                },
+                "required": [
+                  "v4",
+                  "v6"
+                ]
+              }
+            },
+            "required": [
+              "type",
+              "value"
+            ]
+          }
+        ]
+      },
+      "PrivateIpv4Config": {
+        "description": "VPC-private IPv4 configuration for a network interface.",
+        "type": "object",
+        "properties": {
+          "ip": {
+            "description": "VPC-private IP address.",
+            "type": "string",
+            "format": "ipv4"
+          },
+          "subnet": {
+            "description": "The IP subnet.",
+            "allOf": [
+              {
+                "$ref": "#/components/schemas/Ipv4Net"
+              }
+            ]
+          },
+          "transit_ips": {
+            "description": "Additional networks on which the interface can send / receive traffic.",
+            "default": [],
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/Ipv4Net"
+            }
+          }
+        },
+        "required": [
+          "ip",
+          "subnet"
+        ]
+      },
+      "PrivateIpv6Config": {
+        "description": "VPC-private IPv6 configuration for a network interface.",
+        "type": "object",
+        "properties": {
+          "ip": {
+            "description": "VPC-private IP address.",
+            "type": "string",
+            "format": "ipv6"
+          },
+          "subnet": {
+            "description": "The IP subnet.",
+            "allOf": [
+              {
+                "$ref": "#/components/schemas/Ipv6Net"
+              }
+            ]
+          },
+          "transit_ips": {
+            "description": "Additional networks on which the interface can send / receive traffic.",
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/Ipv6Net"
+            }
+          }
+        },
+        "required": [
+          "ip",
+          "subnet",
+          "transit_ips"
+        ]
+      },
+      "ProbeCreate": {
+        "description": "Parameters used to create a probe.",
+        "type": "object",
+        "properties": {
+          "external_ips": {
+            "description": "The external IP addresses assigned to the probe.",
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/ExternalIp"
+            }
+          },
+          "id": {
+            "description": "The ID for the probe.",
+            "allOf": [
+              {
+                "$ref": "#/components/schemas/ProbeUuid"
+              }
+            ]
+          },
+          "interface": {
+            "description": "The probe's networking interface.",
+            "allOf": [
+              {
+                "$ref": "#/components/schemas/NetworkInterface"
+              }
+            ]
+          }
+        },
+        "required": [
+          "external_ips",
+          "id",
+          "interface"
+        ]
+      },
+      "ProbeSet": {
+        "description": "A set of probes that the target sled should run.",
+        "type": "object",
+        "properties": {
+          "probes": {
+            "title": "IdHashMap",
+            "description": "The exact set of probes to run.",
+            "x-rust-type": {
+              "crate": "iddqd",
+              "parameters": [
+                {
+                  "$ref": "#/components/schemas/ProbeCreate"
+                }
+              ],
+              "path": "iddqd::IdHashMap",
+              "version": "*"
+            },
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/ProbeCreate"
+            },
+            "uniqueItems": true
+          }
+        },
+        "required": [
+          "probes"
+        ]
+      },
+      "ProbeUuid": {
+        "x-rust-type": {
+          "crate": "omicron-uuid-kinds",
+          "path": "omicron_uuid_kinds::ProbeUuid",
+          "version": "*"
+        },
+        "type": "string",
+        "format": "uuid"
+      },
+      "ProxyCommitRequest": {
+        "description": "Request to proxy a commit operation to another trust quorum node.",
+        "type": "object",
+        "properties": {
+          "destination": {
+            "description": "The target node to proxy the request to.",
+            "allOf": [
+              {
+                "$ref": "#/components/schemas/BaseboardId"
+              }
+            ]
+          },
+          "request": {
+            "description": "The commit request to proxy.",
+            "allOf": [
+              {
+                "$ref": "#/components/schemas/CommitRequest"
+              }
+            ]
+          }
+        },
+        "required": [
+          "destination",
+          "request"
+        ]
+      },
+      "ProxyPrepareAndCommitRequest": {
+        "description": "Request to proxy a prepare-and-commit operation to another trust quorum node.",
+        "type": "object",
+        "properties": {
+          "destination": {
+            "description": "The target node to proxy the request to.",
+            "allOf": [
+              {
+                "$ref": "#/components/schemas/BaseboardId"
+              }
+            ]
+          },
+          "request": {
+            "description": "The prepare-and-commit request to proxy.",
+            "allOf": [
+              {
+                "$ref": "#/components/schemas/PrepareAndCommitRequest"
+              }
+            ]
+          }
+        },
+        "required": [
+          "destination",
+          "request"
+        ]
+      },
+      "QemuPvpanic": {
+        "type": "object",
+        "properties": {
+          "enable_isa": {
+            "description": "Enable the QEMU PVPANIC ISA bus device (I/O port 0x505).",
+            "type": "boolean"
+          }
+        },
+        "required": [
+          "enable_isa"
+        ],
+        "additionalProperties": false
+      },
+      "RackNetworkConfigV2": {
+        "description": "Initial network configuration",
+        "type": "object",
+        "properties": {
+          "bfd": {
+            "description": "BFD configuration for connecting the rack to external networks",
+            "default": [],
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/BfdPeerConfig"
+            }
+          },
+          "bgp": {
+            "description": "BGP configurations for connecting the rack to external networks",
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/BgpConfig"
+            }
+          },
+          "infra_ip_first": {
+            "description": "First ip address to be used for configuring network infrastructure",
+            "type": "string",
+            "format": "ipv4"
+          },
+          "infra_ip_last": {
+            "description": "Last ip address to be used for configuring network infrastructure",
+            "type": "string",
+            "format": "ipv4"
+          },
+          "ports": {
+            "description": "Uplinks for connecting the rack to external networks",
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/PortConfigV2"
+            }
+          },
+          "rack_subnet": {
+            "$ref": "#/components/schemas/Ipv6Net"
+          }
+        },
+        "required": [
+          "bgp",
+          "infra_ip_first",
+          "infra_ip_last",
+          "ports",
+          "rack_subnet"
+        ]
+      },
+      "RackSecretReconstructError": {
+        "description": "Error reconstructing a rack secret from shares.",
+        "oneOf": [
+          {
+            "type": "object",
+            "properties": {
+              "combine": {
+                "$ref": "#/components/schemas/CombineError"
+              }
+            },
+            "required": [
+              "combine"
+            ],
+            "additionalProperties": false
+          },
+          {
+            "type": "object",
+            "properties": {
+              "size": {
+                "$ref": "#/components/schemas/InvalidRackSecretSizeError"
+              }
+            },
+            "required": [
+              "size"
+            ],
+            "additionalProperties": false
+          }
+        ]
+      },
+      "RackUuid": {
+        "x-rust-type": {
+          "crate": "omicron-uuid-kinds",
+          "path": "omicron_uuid_kinds::RackUuid",
+          "version": "*"
+        },
+        "type": "string",
+        "format": "uuid"
+      },
+      "ReconfigureMsg": {
+        "description": "A request from Nexus informing a node to start coordinating a reconfiguration.",
+        "type": "object",
+        "properties": {
+          "epoch": {
+            "type": "integer",
+            "format": "uint64",
+            "minimum": 0
+          },
+          "last_committed_epoch": {
+            "nullable": true,
+            "type": "integer",
+            "format": "uint64",
+            "minimum": 0
+          },
+          "members": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/BaseboardId"
+            },
+            "uniqueItems": true
+          },
+          "rack_id": {
+            "$ref": "#/components/schemas/RackUuid"
+          },
+          "threshold": {
+            "type": "integer",
+            "format": "uint8",
+            "minimum": 0
+          }
+        },
+        "required": [
+          "epoch",
+          "members",
+          "rack_id",
+          "threshold"
+        ]
+      },
+      "RemoveMupdateOverrideBootSuccessInventory": {
+        "description": "Status of removing the mupdate override on the boot disk.",
+        "oneOf": [
+          {
+            "description": "The mupdate override was successfully removed.",
+            "type": "string",
+            "enum": [
+              "removed"
+            ]
+          },
+          {
+            "description": "No mupdate override was found.\n\nThis is considered a success for idempotency reasons.",
+            "type": "string",
+            "enum": [
+              "no_override"
+            ]
+          }
+        ]
+      },
+      "RemoveMupdateOverrideInventory": {
+        "description": "Status of removing the mupdate override in the inventory.",
+        "type": "object",
+        "properties": {
+          "boot_disk_result": {
+            "description": "The result of removing the mupdate override on the boot disk.",
+            "x-rust-type": {
+              "crate": "std",
+              "parameters": [
+                {
+                  "$ref": "#/components/schemas/RemoveMupdateOverrideBootSuccessInventory"
+                },
+                {
+                  "type": "string"
+                }
+              ],
+              "path": "::std::result::Result",
+              "version": "*"
+            },
+            "oneOf": [
+              {
+                "type": "object",
+                "properties": {
+                  "ok": {
+                    "$ref": "#/components/schemas/RemoveMupdateOverrideBootSuccessInventory"
+                  }
+                },
+                "required": [
+                  "ok"
+                ]
+              },
+              {
+                "type": "object",
+                "properties": {
+                  "err": {
+                    "type": "string"
+                  }
+                },
+                "required": [
+                  "err"
+                ]
+              }
+            ]
+          },
+          "non_boot_message": {
+            "description": "What happened on non-boot disks.\n\nWe aren't modeling this out in more detail, because we plan to not try and keep ledgered data in sync across both disks in the future.",
+            "type": "string"
+          }
+        },
+        "required": [
+          "boot_disk_result",
+          "non_boot_message"
+        ]
+      },
+      "ResolvedVpcFirewallRule": {
+        "description": "VPC firewall rule after object name resolution has been performed by Nexus",
+        "type": "object",
+        "properties": {
+          "action": {
+            "$ref": "#/components/schemas/VpcFirewallRuleAction"
+          },
+          "direction": {
+            "$ref": "#/components/schemas/VpcFirewallRuleDirection"
+          },
+          "filter_hosts": {
+            "nullable": true,
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/HostIdentifier"
+            },
+            "uniqueItems": true
+          },
+          "filter_ports": {
+            "nullable": true,
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/L4PortRange"
+            }
+          },
+          "filter_protocols": {
+            "nullable": true,
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/VpcFirewallRuleProtocol"
+            }
+          },
+          "priority": {
+            "type": "integer",
+            "format": "uint16",
+            "minimum": 0
+          },
+          "status": {
+            "$ref": "#/components/schemas/VpcFirewallRuleStatus"
+          },
+          "targets": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/NetworkInterface"
+            }
+          }
+        },
+        "required": [
+          "action",
+          "direction",
+          "priority",
+          "status",
+          "targets"
+        ]
+      },
+      "ResolvedVpcRoute": {
+        "description": "A VPC route resolved into a concrete target.",
+        "type": "object",
+        "properties": {
+          "dest": {
+            "$ref": "#/components/schemas/IpNet"
+          },
+          "target": {
+            "$ref": "#/components/schemas/RouterTarget"
+          }
+        },
+        "required": [
+          "dest",
+          "target"
+        ]
+      },
+      "ResolvedVpcRouteSet": {
+        "description": "An updated set of routes for a given VPC and/or subnet.",
+        "type": "object",
+        "properties": {
+          "id": {
+            "$ref": "#/components/schemas/RouterId"
+          },
+          "routes": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/ResolvedVpcRoute"
+            },
+            "uniqueItems": true
+          },
+          "version": {
+            "nullable": true,
+            "allOf": [
+              {
+                "$ref": "#/components/schemas/RouterVersion"
+              }
+            ]
+          }
+        },
+        "required": [
+          "id",
+          "routes"
+        ]
+      },
+      "ResolvedVpcRouteState": {
+        "description": "Version information for routes on a given VPC subnet.",
+        "type": "object",
+        "properties": {
+          "id": {
+            "$ref": "#/components/schemas/RouterId"
+          },
+          "version": {
+            "nullable": true,
+            "allOf": [
+              {
+                "$ref": "#/components/schemas/RouterVersion"
+              }
+            ]
+          }
+        },
+        "required": [
+          "id"
+        ]
+      },
+      "RouteConfig": {
+        "type": "object",
+        "properties": {
+          "destination": {
+            "description": "The destination of the route.",
+            "allOf": [
+              {
+                "$ref": "#/components/schemas/IpNet"
+              }
+            ]
+          },
+          "nexthop": {
+            "description": "The nexthop/gateway address.",
+            "type": "string",
+            "format": "ip"
+          },
+          "rib_priority": {
+            "nullable": true,
+            "description": "The RIB priority (i.e. Admin Distance) associated with this route.",
+            "default": null,
+            "type": "integer",
+            "format": "uint8",
+            "minimum": 0
+          },
+          "vlan_id": {
+            "nullable": true,
+            "description": "The VLAN id associated with this route.",
+            "default": null,
+            "type": "integer",
+            "format": "uint16",
+            "minimum": 0
+          }
+        },
+        "required": [
+          "destination",
+          "nexthop"
+        ]
+      },
+      "RouterId": {
+        "description": "Identifier for a VPC and/or subnet.",
+        "type": "object",
+        "properties": {
+          "kind": {
+            "$ref": "#/components/schemas/RouterKind"
+          },
+          "vni": {
+            "$ref": "#/components/schemas/Vni"
+          }
+        },
+        "required": [
+          "kind",
+          "vni"
+        ]
+      },
+      "RouterKind": {
+        "description": "The scope of a set of VPC router rules.",
+        "oneOf": [
+          {
+            "type": "object",
+            "properties": {
+              "type": {
+                "type": "string",
+                "enum": [
+                  "system"
+                ]
+              }
+            },
+            "required": [
+              "type"
+            ]
+          },
+          {
+            "type": "object",
+            "properties": {
+              "subnet": {
+                "$ref": "#/components/schemas/IpNet"
+              },
+              "type": {
+                "type": "string",
+                "enum": [
+                  "custom"
+                ]
+              }
+            },
+            "required": [
+              "subnet",
+              "type"
+            ]
+          }
+        ]
+      },
+      "RouterTarget": {
+        "description": "The target for a given router entry.",
+        "oneOf": [
+          {
+            "type": "object",
+            "properties": {
+              "type": {
+                "type": "string",
+                "enum": [
+                  "drop"
+                ]
+              }
+            },
+            "required": [
+              "type"
+            ]
+          },
+          {
+            "type": "object",
+            "properties": {
+              "type": {
+                "type": "string",
+                "enum": [
+                  "internet_gateway"
+                ]
+              },
+              "value": {
+                "$ref": "#/components/schemas/InternetGatewayRouterTarget"
+              }
+            },
+            "required": [
+              "type",
+              "value"
+            ]
+          },
+          {
+            "type": "object",
+            "properties": {
+              "type": {
+                "type": "string",
+                "enum": [
+                  "ip"
+                ]
+              },
+              "value": {
+                "type": "string",
+                "format": "ip"
+              }
+            },
+            "required": [
+              "type",
+              "value"
+            ]
+          },
+          {
+            "type": "object",
+            "properties": {
+              "type": {
+                "type": "string",
+                "enum": [
+                  "vpc_subnet"
+                ]
+              },
+              "value": {
+                "$ref": "#/components/schemas/IpNet"
+              }
+            },
+            "required": [
+              "type",
+              "value"
+            ]
+          }
+        ]
+      },
+      "RouterVersion": {
+        "description": "Information on the current parent router (and version) of a route set according to the control plane.",
+        "type": "object",
+        "properties": {
+          "router_id": {
+            "type": "string",
+            "format": "uuid"
+          },
+          "version": {
+            "type": "integer",
+            "format": "uint64",
+            "minimum": 0
+          }
+        },
+        "required": [
+          "router_id",
+          "version"
+        ]
+      },
+      "SerialPort": {
+        "description": "A serial port device.",
+        "type": "object",
+        "properties": {
+          "num": {
+            "description": "The serial port number for this port.",
+            "allOf": [
+              {
+                "$ref": "#/components/schemas/SerialPortNumber"
+              }
+            ]
+          }
+        },
+        "required": [
+          "num"
+        ],
+        "additionalProperties": false
+      },
+      "SerialPortNumber": {
+        "description": "A serial port identifier, which determines what I/O ports a guest can use to access a port.",
+        "type": "string",
+        "enum": [
+          "com1",
+          "com2",
+          "com3",
+          "com4"
+        ]
+      },
+      "SingleMeasurementInventory": {
+        "description": "An attempt at resolving a single measurement file to a valid path",
+        "type": "object",
+        "properties": {
+          "path": {
+            "type": "string",
+            "format": "Utf8PathBuf"
+          },
+          "result": {
+            "$ref": "#/components/schemas/ConfigReconcilerInventoryResult"
+          }
+        },
+        "required": [
+          "path",
+          "result"
+        ]
+      },
+      "SledCpuFamily": {
+        "description": "Identifies the kind of CPU present on a sled, determined by reading CPUID.\n\nThis is intended to broadly support the control plane answering the question \"can I run this instance on that sled?\" given an instance with either no or some CPU platform requirement. It is not enough information for more precise placement questions - for example, is a CPU a high-frequency part or many-core part? We don't include Genoa here, but in that CPU family there are high frequency parts, many-core parts, and large-cache parts. To support those questions (or satisfactorily answer #8730) we would need to collect additional information and send it along.",
+        "oneOf": [
+          {
+            "description": "The CPU vendor or its family number don't correspond to any of the known family variants.",
+            "type": "string",
+            "enum": [
+              "unknown"
+            ]
+          },
+          {
+            "description": "AMD Milan processors (or very close). Could be an actual Milan in a Gimlet, a close-to-Milan client Zen 3 part, or Zen 4 (for which Milan is the greatest common denominator).",
+            "type": "string",
+            "enum": [
+              "amd_milan"
+            ]
+          },
+          {
+            "description": "AMD Turin processors (or very close). Could be an actual Turin in a Cosmo, or a close-to-Turin client Zen 5 part.",
+            "type": "string",
+            "enum": [
+              "amd_turin"
+            ]
+          },
+          {
+            "description": "AMD Turin Dense processors. There are no \"Turin Dense-like\" CPUs unlike other cases, so this means a bona fide Zen 5c Turin Dense part.",
+            "type": "string",
+            "enum": [
+              "amd_turin_dense"
+            ]
+          }
+        ]
+      },
+      "SledDiagnosticsQueryOutput": {
+        "oneOf": [
+          {
+            "type": "object",
+            "properties": {
+              "success": {
+                "type": "object",
+                "properties": {
+                  "command": {
+                    "description": "The command and its arguments.",
+                    "type": "string"
+                  },
+                  "exit_code": {
+                    "nullable": true,
+                    "description": "The exit code if one was present when the command exited.",
+                    "type": "integer",
+                    "format": "int32"
+                  },
+                  "exit_status": {
+                    "description": "The exit status of the command. This will be the exit code (if any) and exit reason such as from a signal.",
+                    "type": "string"
+                  },
+                  "stdio": {
+                    "description": "Any stdout/stderr produced by the command.",
+                    "type": "string"
+                  }
+                },
+                "required": [
+                  "command",
+                  "exit_status",
+                  "stdio"
+                ]
+              }
+            },
+            "required": [
+              "success"
+            ],
+            "additionalProperties": false
+          },
+          {
+            "type": "object",
+            "properties": {
+              "failure": {
+                "type": "object",
+                "properties": {
+                  "error": {
+                    "description": "The reason the command failed to execute.",
+                    "type": "string"
+                  }
+                },
+                "required": [
+                  "error"
+                ]
+              }
+            },
+            "required": [
+              "failure"
+            ],
+            "additionalProperties": false
+          }
+        ]
+      },
+      "SledIdentifiers": {
+        "description": "Identifiers for a single sled.\n\nThis is intended primarily to be used in timeseries, to identify sled from which metric data originates.",
+        "type": "object",
+        "properties": {
+          "model": {
+            "description": "Model name of the sled",
+            "type": "string"
+          },
+          "rack_id": {
+            "description": "Control plane ID of the rack this sled is a member of",
+            "type": "string",
+            "format": "uuid"
+          },
+          "revision": {
+            "description": "Revision number of the sled",
+            "type": "integer",
+            "format": "uint32",
+            "minimum": 0
+          },
+          "serial": {
+            "description": "Serial number of the sled",
+            "type": "string"
+          },
+          "sled_id": {
+            "description": "Control plane ID for the sled itself",
+            "type": "string",
+            "format": "uuid"
+          }
+        },
+        "required": [
+          "model",
+          "rack_id",
+          "revision",
+          "serial",
+          "sled_id"
+        ]
+      },
+      "SledRole": {
+        "description": "Describes the role of the sled within the rack.\n\nNote that this may change if the sled is physically moved within the rack.",
+        "oneOf": [
+          {
+            "description": "The sled is a general compute sled.",
+            "type": "string",
+            "enum": [
+              "gimlet"
+            ]
+          },
+          {
+            "description": "The sled is attached to the network switch, and has additional responsibilities.",
+            "type": "string",
+            "enum": [
+              "scrimlet"
+            ]
+          }
+        ]
+      },
+      "SledUuid": {
+        "x-rust-type": {
+          "crate": "omicron-uuid-kinds",
+          "path": "omicron_uuid_kinds::SledUuid",
+          "version": "*"
+        },
+        "type": "string",
+        "format": "uuid"
+      },
+      "SledVmmState": {
+        "description": "A wrapper type containing a sled's total knowledge of the state of a VMM.",
+        "type": "object",
+        "properties": {
+          "migration_in": {
+            "nullable": true,
+            "description": "The current state of any inbound migration to this VMM.",
+            "allOf": [
+              {
+                "$ref": "#/components/schemas/MigrationRuntimeState"
+              }
+            ]
+          },
+          "migration_out": {
+            "nullable": true,
+            "description": "The state of any outbound migration from this VMM.",
+            "allOf": [
+              {
+                "$ref": "#/components/schemas/MigrationRuntimeState"
+              }
+            ]
+          },
+          "vmm_state": {
+            "description": "The most recent state of the sled's VMM process.",
+            "allOf": [
+              {
+                "$ref": "#/components/schemas/VmmRuntimeState"
+              }
+            ]
+          }
+        },
+        "required": [
+          "vmm_state"
+        ]
+      },
+      "SoftNpuP9": {
+        "description": "Describes a PCI device that shares host files with the guest using the P9 protocol.\n\nThis is only supported by Propolis servers compiled with the `falcon` feature.",
+        "type": "object",
+        "properties": {
+          "pci_path": {
+            "description": "The PCI path at which to attach the guest to this port.",
+            "allOf": [
+              {
+                "$ref": "#/components/schemas/PciPath"
+              }
+            ]
+          }
+        },
+        "required": [
+          "pci_path"
+        ],
+        "additionalProperties": false
+      },
+      "SoftNpuPciPort": {
+        "description": "Describes a SoftNPU PCI device.\n\nThis is only supported by Propolis servers compiled with the `falcon` feature.",
+        "type": "object",
+        "properties": {
+          "pci_path": {
+            "description": "The PCI path at which to attach the guest to this port.",
+            "allOf": [
+              {
+                "$ref": "#/components/schemas/PciPath"
+              }
+            ]
+          }
+        },
+        "required": [
+          "pci_path"
+        ],
+        "additionalProperties": false
+      },
+      "SoftNpuPort": {
+        "description": "Describes a port in a SoftNPU emulated ASIC.\n\nThis is only supported by Propolis servers compiled with the `falcon` feature.",
+        "type": "object",
+        "properties": {
+          "backend_id": {
+            "description": "The name of the port's associated DLPI backend.",
+            "allOf": [
+              {
+                "$ref": "#/components/schemas/SpecKey"
+              }
+            ]
+          },
+          "link_name": {
+            "description": "The data link name for this port.",
+            "type": "string"
+          }
+        },
+        "required": [
+          "backend_id",
+          "link_name"
+        ],
+        "additionalProperties": false
+      },
+      "SourceNatConfigGeneric": {
+        "description": "An IP address and port range used for source NAT, i.e., making outbound network connections from guests or services.",
+        "type": "object",
+        "properties": {
+          "first_port": {
+            "description": "The first port used for source NAT, inclusive.",
+            "type": "integer",
+            "format": "uint16",
+            "minimum": 0
+          },
+          "ip": {
+            "description": "The external address provided to the instance or service.",
+            "type": "string",
+            "format": "ip"
+          },
+          "last_port": {
+            "description": "The last port used for source NAT, also inclusive.",
+            "type": "integer",
+            "format": "uint16",
+            "minimum": 0
+          }
+        },
+        "required": [
+          "first_port",
+          "ip",
+          "last_port"
+        ]
+      },
+      "SourceNatConfigV4": {
+        "description": "An IP address and port range used for source NAT, i.e., making outbound network connections from guests or services.",
+        "type": "object",
+        "properties": {
+          "first_port": {
+            "description": "The first port used for source NAT, inclusive.",
+            "type": "integer",
+            "format": "uint16",
+            "minimum": 0
+          },
+          "ip": {
+            "description": "The external address provided to the instance or service.",
+            "type": "string",
+            "format": "ipv4"
+          },
+          "last_port": {
+            "description": "The last port used for source NAT, also inclusive.",
+            "type": "integer",
+            "format": "uint16",
+            "minimum": 0
+          }
+        },
+        "required": [
+          "first_port",
+          "ip",
+          "last_port"
+        ]
+      },
+      "SourceNatConfigV6": {
+        "description": "An IP address and port range used for source NAT, i.e., making outbound network connections from guests or services.",
+        "type": "object",
+        "properties": {
+          "first_port": {
+            "description": "The first port used for source NAT, inclusive.",
+            "type": "integer",
+            "format": "uint16",
+            "minimum": 0
+          },
+          "ip": {
+            "description": "The external address provided to the instance or service.",
+            "type": "string",
+            "format": "ipv6"
+          },
+          "last_port": {
+            "description": "The last port used for source NAT, also inclusive.",
+            "type": "integer",
+            "format": "uint16",
+            "minimum": 0
+          }
+        },
+        "required": [
+          "first_port",
+          "ip",
+          "last_port"
+        ]
+      },
+      "SpecKey": {
+        "description": "A key identifying a component in an instance spec.",
+        "oneOf": [
+          {
+            "title": "uuid",
+            "allOf": [
+              {
+                "type": "string",
+                "format": "uuid"
+              }
+            ]
+          },
+          {
+            "title": "name",
+            "allOf": [
+              {
+                "type": "string"
+              }
+            ]
+          }
+        ]
+      },
+      "StartSledAgentRequest": {
+        "description": "Configuration information for launching a Sled Agent.",
+        "type": "object",
+        "properties": {
+          "body": {
+            "$ref": "#/components/schemas/StartSledAgentRequestBody"
+          },
+          "generation": {
+            "description": "The current generation number of data as stored in CRDB.\n\nThe initial generation is set during RSS time and then only mutated by Nexus. For now, we don't actually anticipate mutating this data, but we leave open the possiblity.",
+            "type": "integer",
+            "format": "uint64",
+            "minimum": 0
+          },
+          "schema_version": {
+            "type": "integer",
+            "format": "uint32",
+            "minimum": 0
+          }
+        },
+        "required": [
+          "body",
+          "generation",
+          "schema_version"
+        ]
+      },
+      "StartSledAgentRequestBody": {
+        "description": "This is the actual app level data of `StartSledAgentRequest`\n\nWe nest it below the \"header\" of `generation` and `schema_version` so that we can perform partial deserialization of `EarlyNetworkConfig` to only read the header and defer deserialization of the body once we know the schema version. This is possible via the use of [`serde_json::value::RawValue`] in future (post-v1) deserialization paths.",
+        "type": "object",
+        "properties": {
+          "id": {
+            "description": "Uuid of the Sled Agent to be created.",
+            "allOf": [
+              {
+                "$ref": "#/components/schemas/SledUuid"
+              }
+            ]
+          },
+          "is_lrtq_learner": {
+            "description": "Is this node an LRTQ learner node?\n\nWe only put the node into learner mode if `use_trust_quorum` is also true.",
+            "type": "boolean"
+          },
+          "rack_id": {
+            "description": "Uuid of the rack to which this sled agent belongs.",
+            "type": "string",
+            "format": "uuid"
+          },
+          "subnet": {
+            "description": "Portion of the IP space to be managed by the Sled Agent.",
+            "allOf": [
+              {
+                "$ref": "#/components/schemas/Ipv6Subnet"
+              }
+            ]
+          },
+          "use_trust_quorum": {
+            "description": "Use trust quorum for key generation",
+            "type": "boolean"
+          }
+        },
+        "required": [
+          "id",
+          "is_lrtq_learner",
+          "rack_id",
+          "subnet",
+          "use_trust_quorum"
+        ]
+      },
+      "StorageLimit": {
+        "description": "The limit on space allowed for zone bundles, as a percentage of the overall dataset's quota.",
+        "type": "integer",
+        "format": "uint8",
+        "minimum": 0
+      },
+      "SupportBundleMetadata": {
+        "description": "Metadata about a support bundle.",
+        "type": "object",
+        "properties": {
+          "state": {
+            "$ref": "#/components/schemas/SupportBundleState"
+          },
+          "support_bundle_id": {
+            "$ref": "#/components/schemas/SupportBundleUuid"
+          }
+        },
+        "required": [
+          "state",
+          "support_bundle_id"
+        ]
+      },
+      "SupportBundleState": {
+        "description": "State of a support bundle.",
+        "type": "string",
+        "enum": [
+          "complete",
+          "incomplete"
+        ]
+      },
+      "SupportBundleUuid": {
+        "x-rust-type": {
+          "crate": "omicron-uuid-kinds",
+          "path": "omicron_uuid_kinds::SupportBundleUuid",
+          "version": "*"
+        },
+        "type": "string",
+        "format": "uuid"
+      },
+      "SvcInMaintenance": {
+        "description": "Information about an SMF service that is enabled but not running",
+        "type": "object",
+        "properties": {
+          "fmri": {
+            "type": "string"
+          },
+          "zone": {
+            "type": "string"
+          }
+        },
+        "required": [
+          "fmri",
+          "zone"
+        ]
+      },
+      "SvcsInMaintenanceResult": {
+        "description": "Lists services in maintenance status if any, and the time the health check for SMF services ran",
+        "type": "object",
+        "properties": {
+          "errors": {
+            "type": "array",
+            "items": {
+              "type": "string"
+            }
+          },
+          "services": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/SvcInMaintenance"
+            }
+          },
+          "time_of_status": {
+            "nullable": true,
+            "type": "string",
+            "format": "date-time"
+          }
+        },
+        "required": [
+          "errors",
+          "services"
+        ]
+      },
+      "SwitchLocation": {
+        "description": "Identifies switch physical location",
+        "oneOf": [
+          {
+            "description": "Switch in upper slot",
+            "type": "string",
+            "enum": [
+              "switch0"
+            ]
+          },
+          {
+            "description": "Switch in lower slot",
+            "type": "string",
+            "enum": [
+              "switch1"
+            ]
+          }
+        ]
+      },
+      "SwitchPorts": {
+        "description": "A set of switch uplinks.",
+        "type": "object",
+        "properties": {
+          "uplinks": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/HostPortConfig"
+            }
+          }
+        },
+        "required": [
+          "uplinks"
+        ]
+      },
+      "TrustQuorumNetworkConfig": {
+        "description": "Network configuration used to bring up the control plane.\n\nThis type mirrors `bootstore::schemes::v0::NetworkConfig` but adds `JsonSchema` for API compatibility.",
+        "type": "object",
+        "properties": {
+          "blob": {
+            "description": "A serialized blob of configuration data (base64 encoded).",
+            "type": "string"
+          },
+          "generation": {
+            "type": "integer",
+            "format": "uint64",
+            "minimum": 0
+          }
+        },
+        "required": [
+          "blob",
+          "generation"
+        ]
+      },
+      "TxEqConfig": {
+        "description": "Per-port tx-eq overrides.  This can be used to fine-tune the transceiver equalization settings to improve signal integrity.",
+        "type": "object",
+        "properties": {
+          "main": {
+            "nullable": true,
+            "description": "Main tap",
+            "type": "integer",
+            "format": "int32"
+          },
+          "post1": {
+            "nullable": true,
+            "description": "Post-cursor tap1",
+            "type": "integer",
+            "format": "int32"
+          },
+          "post2": {
+            "nullable": true,
+            "description": "Post-cursor tap2",
+            "type": "integer",
+            "format": "int32"
+          },
+          "pre1": {
+            "nullable": true,
+            "description": "Pre-cursor tap1",
+            "type": "integer",
+            "format": "int32"
+          },
+          "pre2": {
+            "nullable": true,
+            "description": "Pre-cursor tap2",
+            "type": "integer",
+            "format": "int32"
+          }
+        }
+      },
+      "UplinkAddressConfig": {
+        "type": "object",
+        "properties": {
+          "address": {
+            "$ref": "#/components/schemas/IpNet"
+          },
+          "vlan_id": {
+            "nullable": true,
+            "description": "The VLAN id (if any) associated with this address.",
+            "default": null,
+            "type": "integer",
+            "format": "uint16",
+            "minimum": 0
+          }
+        },
+        "required": [
+          "address"
+        ]
+      },
+      "VirtioDisk": {
+        "description": "A disk that presents a virtio-block interface to the guest.",
+        "type": "object",
+        "properties": {
+          "backend_id": {
+            "description": "The name of the disk's backend component.",
+            "allOf": [
+              {
+                "$ref": "#/components/schemas/SpecKey"
+              }
+            ]
+          },
+          "pci_path": {
+            "description": "The PCI bus/device/function at which this disk should be attached.",
+            "allOf": [
+              {
+                "$ref": "#/components/schemas/PciPath"
+              }
+            ]
+          }
+        },
+        "required": [
+          "backend_id",
+          "pci_path"
+        ],
+        "additionalProperties": false
+      },
+      "VirtioNetworkBackend": {
+        "description": "A network backend associated with a virtio-net (viona) VNIC on the host.",
+        "type": "object",
+        "properties": {
+          "vnic_name": {
+            "description": "The name of the viona VNIC to use as a backend.",
+            "type": "string"
+          }
+        },
+        "required": [
+          "vnic_name"
+        ],
+        "additionalProperties": false
+      },
+      "VirtioNic": {
+        "description": "A network card that presents a virtio-net interface to the guest.",
+        "type": "object",
+        "properties": {
+          "backend_id": {
+            "description": "The name of the device's backend.",
+            "allOf": [
+              {
+                "$ref": "#/components/schemas/SpecKey"
+              }
+            ]
+          },
+          "interface_id": {
+            "description": "A caller-defined correlation identifier for this interface. If Propolis is configured to collect network interface kstats in its Oximeter metrics, the metric series for this interface will be associated with this identifier.",
+            "type": "string",
+            "format": "uuid"
+          },
+          "pci_path": {
+            "description": "The PCI path at which to attach this device.",
+            "allOf": [
+              {
+                "$ref": "#/components/schemas/PciPath"
+              }
+            ]
+          }
+        },
+        "required": [
+          "backend_id",
+          "interface_id",
+          "pci_path"
+        ],
+        "additionalProperties": false
+      },
+      "VirtualNetworkInterfaceHost": {
+        "description": "A mapping from a virtual NIC to a physical host",
+        "type": "object",
+        "properties": {
+          "physical_host_ip": {
+            "type": "string",
+            "format": "ipv6"
+          },
+          "virtual_ip": {
+            "type": "string",
+            "format": "ip"
+          },
+          "virtual_mac": {
+            "$ref": "#/components/schemas/MacAddr"
+          },
+          "vni": {
+            "$ref": "#/components/schemas/Vni"
+          }
+        },
+        "required": [
+          "physical_host_ip",
+          "virtual_ip",
+          "virtual_mac",
+          "vni"
+        ]
+      },
+      "VmmIssueDiskSnapshotRequestBody": {
+        "description": "Request body for VMM disk snapshot requests.",
+        "type": "object",
+        "properties": {
+          "snapshot_id": {
+            "type": "string",
+            "format": "uuid"
+          }
+        },
+        "required": [
+          "snapshot_id"
+        ]
+      },
+      "VmmIssueDiskSnapshotRequestResponse": {
+        "description": "Response for VMM disk snapshot requests.",
+        "type": "object",
+        "properties": {
+          "snapshot_id": {
+            "type": "string",
+            "format": "uuid"
+          }
+        },
+        "required": [
+          "snapshot_id"
+        ]
+      },
+      "VmmPutStateBody": {
+        "description": "The body of a request to move a previously-ensured instance into a specific runtime state.",
+        "type": "object",
+        "properties": {
+          "state": {
+            "description": "The state into which the instance should be driven.",
+            "allOf": [
+              {
+                "$ref": "#/components/schemas/VmmStateRequested"
+              }
+            ]
+          }
+        },
+        "required": [
+          "state"
+        ]
+      },
+      "VmmPutStateResponse": {
+        "description": "The response sent from a request to move an instance into a specific runtime state.",
+        "type": "object",
+        "properties": {
+          "updated_runtime": {
+            "nullable": true,
+            "description": "The current runtime state of the instance after handling the request to change its state. If the instance's state did not change, this field is `None`.",
+            "allOf": [
+              {
+                "$ref": "#/components/schemas/SledVmmState"
+              }
+            ]
+          }
+        }
+      },
+      "VmmRuntimeState": {
+        "description": "The dynamic runtime properties of an individual VMM process.",
+        "type": "object",
+        "properties": {
+          "gen": {
+            "description": "The generation number for this VMM's state.",
+            "allOf": [
+              {
+                "$ref": "#/components/schemas/Generation"
+              }
+            ]
+          },
+          "state": {
+            "description": "The last state reported by this VMM.",
+            "allOf": [
+              {
+                "$ref": "#/components/schemas/VmmState"
+              }
+            ]
+          },
+          "time_updated": {
+            "description": "Timestamp for the VMM's state.",
+            "type": "string",
+            "format": "date-time"
+          }
+        },
+        "required": [
+          "gen",
+          "state",
+          "time_updated"
+        ]
+      },
+      "VmmSpec": {
+        "description": "Specifies the virtual hardware configuration of a new Propolis VMM in the form of a Propolis instance specification.",
+        "allOf": [
+          {
+            "$ref": "#/components/schemas/InstanceSpecV0"
+          }
+        ]
+      },
+      "VmmState": {
+        "description": "One of the states that a VMM can be in.",
+        "oneOf": [
+          {
+            "description": "The VMM is initializing and has not started running guest CPUs yet.",
+            "type": "string",
+            "enum": [
+              "starting"
+            ]
+          },
+          {
+            "description": "The VMM has finished initializing and may be running guest CPUs.",
+            "type": "string",
+            "enum": [
+              "running"
+            ]
+          },
+          {
+            "description": "The VMM is shutting down.",
+            "type": "string",
+            "enum": [
+              "stopping"
+            ]
+          },
+          {
+            "description": "The VMM's guest has stopped, and the guest will not run again, but the VMM process may not have released all of its resources yet.",
+            "type": "string",
+            "enum": [
+              "stopped"
+            ]
+          },
+          {
+            "description": "The VMM is being restarted or its guest OS is rebooting.",
+            "type": "string",
+            "enum": [
+              "rebooting"
+            ]
+          },
+          {
+            "description": "The VMM is part of a live migration.",
+            "type": "string",
+            "enum": [
+              "migrating"
+            ]
+          },
+          {
+            "description": "The VMM process reported an internal failure.",
+            "type": "string",
+            "enum": [
+              "failed"
+            ]
+          },
+          {
+            "description": "The VMM process has been destroyed and its resources have been released.",
+            "type": "string",
+            "enum": [
+              "destroyed"
+            ]
+          }
+        ]
+      },
+      "VmmStateRequested": {
+        "description": "Requestable running state of an Instance.\n\nA subset of [`omicron_common::api::external::InstanceState`].",
+        "oneOf": [
+          {
+            "description": "Run this instance by migrating in from a previous running incarnation of the instance.",
+            "type": "object",
+            "properties": {
+              "type": {
+                "type": "string",
+                "enum": [
+                  "migration_target"
+                ]
+              },
+              "value": {
+                "$ref": "#/components/schemas/InstanceMigrationTargetParams"
+              }
+            },
+            "required": [
+              "type",
+              "value"
+            ]
+          },
+          {
+            "description": "Start the instance if it is not already running.",
+            "type": "object",
+            "properties": {
+              "type": {
+                "type": "string",
+                "enum": [
+                  "running"
+                ]
+              }
+            },
+            "required": [
+              "type"
+            ]
+          },
+          {
+            "description": "Stop the instance.",
+            "type": "object",
+            "properties": {
+              "type": {
+                "type": "string",
+                "enum": [
+                  "stopped"
+                ]
+              }
+            },
+            "required": [
+              "type"
+            ]
+          },
+          {
+            "description": "Immediately reset the instance, as though it had stopped and immediately began to run again.",
+            "type": "object",
+            "properties": {
+              "type": {
+                "type": "string",
+                "enum": [
+                  "reboot"
+                ]
+              }
+            },
+            "required": [
+              "type"
+            ]
+          }
+        ]
+      },
+      "VmmUnregisterResponse": {
+        "description": "The response sent from a request to unregister an instance.",
+        "type": "object",
+        "properties": {
+          "updated_runtime": {
+            "nullable": true,
+            "description": "The current state of the instance after handling the request to unregister it. If the instance's state did not change, this field is `None`.",
+            "allOf": [
+              {
+                "$ref": "#/components/schemas/SledVmmState"
+              }
+            ]
+          }
+        }
+      },
+      "Vni": {
+        "description": "A Geneve Virtual Network Identifier",
+        "type": "integer",
+        "format": "uint32",
+        "minimum": 0
+      },
+      "VpcFirewallIcmpFilter": {
+        "type": "object",
+        "properties": {
+          "code": {
+            "nullable": true,
+            "allOf": [
+              {
+                "$ref": "#/components/schemas/IcmpParamRange"
+              }
+            ]
+          },
+          "icmp_type": {
+            "type": "integer",
+            "format": "uint8",
+            "minimum": 0
+          }
+        },
+        "required": [
+          "icmp_type"
+        ]
+      },
+      "VpcFirewallRuleAction": {
+        "type": "string",
+        "enum": [
+          "allow",
+          "deny"
+        ]
+      },
+      "VpcFirewallRuleDirection": {
+        "type": "string",
+        "enum": [
+          "inbound",
+          "outbound"
+        ]
+      },
+      "VpcFirewallRuleProtocol": {
+        "description": "The protocols that may be specified in a firewall rule's filter",
+        "oneOf": [
+          {
+            "type": "object",
+            "properties": {
+              "type": {
+                "type": "string",
+                "enum": [
+                  "tcp"
+                ]
+              }
+            },
+            "required": [
+              "type"
+            ]
+          },
+          {
+            "type": "object",
+            "properties": {
+              "type": {
+                "type": "string",
+                "enum": [
+                  "udp"
+                ]
+              }
+            },
+            "required": [
+              "type"
+            ]
+          },
+          {
+            "type": "object",
+            "properties": {
+              "type": {
+                "type": "string",
+                "enum": [
+                  "icmp"
+                ]
+              },
+              "value": {
+                "nullable": true,
+                "allOf": [
+                  {
+                    "$ref": "#/components/schemas/VpcFirewallIcmpFilter"
+                  }
+                ]
+              }
+            },
+            "required": [
+              "type",
+              "value"
+            ]
+          }
+        ]
+      },
+      "VpcFirewallRuleStatus": {
+        "type": "string",
+        "enum": [
+          "disabled",
+          "enabled"
+        ]
+      },
+      "VpcFirewallRulesEnsureBody": {
+        "description": "Update firewall rules for a VPC",
+        "type": "object",
+        "properties": {
+          "rules": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/ResolvedVpcFirewallRule"
+            }
+          },
+          "vni": {
+            "$ref": "#/components/schemas/Vni"
+          }
+        },
+        "required": [
+          "rules",
+          "vni"
+        ]
+      },
+      "ZoneArtifactInventory": {
+        "description": "Inventory representation of a single zone artifact on a boot disk.\n\nPart of [`ManifestBootInventory`].",
+        "type": "object",
+        "properties": {
+          "expected_hash": {
+            "description": "The expected digest of the file's contents.",
+            "type": "string",
+            "format": "hex string (32 bytes)"
+          },
+          "expected_size": {
+            "description": "The expected size of the file, in bytes.",
+            "type": "integer",
+            "format": "uint64",
+            "minimum": 0
+          },
+          "file_name": {
+            "description": "The name of the zone file on disk, for example `nexus.tar.gz`. Zone files are always \".tar.gz\".",
+            "type": "string"
+          },
+          "path": {
+            "description": "The full path to the zone file.",
+            "type": "string",
+            "format": "Utf8PathBuf"
+          },
+          "status": {
+            "description": "The status of the artifact.\n\nThis is `Ok(())` if the artifact is present and matches the expected size and digest, or an error message if it is missing or does not match.",
+            "x-rust-type": {
+              "crate": "std",
+              "parameters": [
+                {
+                  "type": "null"
+                },
+                {
+                  "type": "string"
+                }
+              ],
+              "path": "::std::result::Result",
+              "version": "*"
+            },
+            "oneOf": [
+              {
+                "type": "object",
+                "properties": {
+                  "ok": {
+                    "type": "string",
+                    "enum": [
+                      null
+                    ]
+                  }
+                },
+                "required": [
+                  "ok"
+                ]
+              },
+              {
+                "type": "object",
+                "properties": {
+                  "err": {
+                    "type": "string"
+                  }
+                },
+                "required": [
+                  "err"
+                ]
+              }
+            ]
+          }
+        },
+        "required": [
+          "expected_hash",
+          "expected_size",
+          "file_name",
+          "path",
+          "status"
+        ]
+      },
+      "ZoneBundleCause": {
+        "description": "The reason or cause for a zone bundle, i.e., why it was created.",
+        "oneOf": [
+          {
+            "description": "Some other, unspecified reason.",
+            "type": "string",
+            "enum": [
+              "other"
+            ]
+          },
+          {
+            "description": "A zone bundle taken when a sled agent finds a zone that it does not expect to be running.",
+            "type": "string",
+            "enum": [
+              "unexpected_zone"
+            ]
+          },
+          {
+            "description": "An instance zone was terminated.",
+            "type": "string",
+            "enum": [
+              "terminated_instance"
+            ]
+          }
+        ]
+      },
+      "ZoneBundleId": {
+        "description": "An identifier for a zone bundle.",
+        "type": "object",
+        "properties": {
+          "bundle_id": {
+            "description": "The ID for this bundle itself.",
+            "type": "string",
+            "format": "uuid"
+          },
+          "zone_name": {
+            "description": "The name of the zone this bundle is derived from.",
+            "type": "string"
+          }
+        },
+        "required": [
+          "bundle_id",
+          "zone_name"
+        ]
+      },
+      "ZoneBundleMetadata": {
+        "description": "Metadata about a zone bundle.",
+        "type": "object",
+        "properties": {
+          "cause": {
+            "description": "The reason or cause a bundle was created.",
+            "allOf": [
+              {
+                "$ref": "#/components/schemas/ZoneBundleCause"
+              }
+            ]
+          },
+          "id": {
+            "description": "Identifier for this zone bundle",
+            "allOf": [
+              {
+                "$ref": "#/components/schemas/ZoneBundleId"
+              }
+            ]
+          },
+          "time_created": {
+            "description": "The time at which this zone bundle was created.",
+            "type": "string",
+            "format": "date-time"
+          },
+          "version": {
+            "description": "A version number for this zone bundle.",
+            "type": "integer",
+            "format": "uint8",
+            "minimum": 0
+          }
+        },
+        "required": [
+          "cause",
+          "id",
+          "time_created",
+          "version"
+        ]
+      },
+      "ZpoolName": {
+        "title": "The name of a Zpool",
+        "description": "Zpool names are of the format ox{i,p}_<UUID>. They are either Internal or External, and should be unique",
+        "type": "string",
+        "pattern": "^ox[ip]_[0-9a-f]{8}-[0-9a-f]{4}-4[0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$"
+      },
+      "ZpoolUuid": {
+        "x-rust-type": {
+          "crate": "omicron-uuid-kinds",
+          "path": "omicron_uuid_kinds::ZpoolUuid",
+          "version": "*"
+        },
+        "type": "string",
+        "format": "uuid"
+      },
+      "PropolisUuid": {
+        "x-rust-type": {
+          "crate": "omicron-uuid-kinds",
+          "path": "omicron_uuid_kinds::PropolisUuid",
+          "version": "*"
+        },
+        "type": "string",
+        "format": "uuid"
+      }
+    },
+    "responses": {
+      "Error": {
+        "description": "Error",
+        "content": {
+          "application/json": {
+            "schema": {
+              "$ref": "#/components/schemas/Error"
+            }
+          }
+        }
+      }
+    }
+  }
+}

--- a/openapi/sled-agent/sled-agent-latest.json
+++ b/openapi/sled-agent/sled-agent-latest.json
@@ -1,1 +1,1 @@
-sled-agent-15.0.0-92bd2d.json
+sled-agent-16.0.0-1923e2.json

--- a/schema/crdb/dbinit.sql
+++ b/schema/crdb/dbinit.sql
@@ -4544,7 +4544,7 @@ CREATE TABLE IF NOT EXISTS omicron.public.inv_omicron_sled_config (
     PRIMARY KEY (inv_collection_id, id)
 );
 
-CREATE TABLE IF NOT EXISTS omicron.public.inv_last_reconciliation_measurements (
+CREATE TABLE IF NOT EXISTS omicron.public.inv_single_measurements (
     -- where this observation came from
     -- (foreign key into `inv_collection` table)
     inv_collection_id UUID NOT NULL,
@@ -4553,16 +4553,13 @@ CREATE TABLE IF NOT EXISTS omicron.public.inv_last_reconciliation_measurements (
     -- it's conceivable a sled will report an id that we don't know about)
     sled_id UUID NOT NULL,
 
-    -- file name of the measurement file
-    file_name TEXT NOT NULL,
-
     -- full path to the measurement file
     path TEXT NOT NULL,
 
     -- error message; if NULL, an "ok" result
     error_message TEXT,
 
-    PRIMARY KEY (inv_collection_id, sled_id, file_name)
+    PRIMARY KEY (inv_collection_id, sled_id, path)
 );
 
 
@@ -8062,7 +8059,7 @@ INSERT INTO omicron.public.db_metadata (
     version,
     target_version
 ) VALUES
-    (TRUE, NOW(), NOW(), '225.0.0', NULL)
+    (TRUE, NOW(), NOW(), '226.0.0', NULL)
 ON CONFLICT DO NOTHING;
 
 COMMIT;

--- a/schema/crdb/measurement-proper-inventory/up01.sql
+++ b/schema/crdb/measurement-proper-inventory/up01.sql
@@ -1,0 +1,17 @@
+CREATE TABLE IF NOT EXISTS omicron.public.inv_single_measurements (
+    -- where this observation came from
+    -- (foreign key into `inv_collection` table)
+    inv_collection_id UUID NOT NULL,
+
+    -- unique id for this sled (should be foreign keys into `sled` table, though
+    -- it's conceivable a sled will report an id that we don't know about)
+    sled_id UUID NOT NULL,
+
+    -- full path to the measurement file
+    path TEXT NOT NULL,
+    
+    -- error message; if NULL, an "ok" result
+    error_message TEXT,
+    PRIMARY KEY (inv_collection_id, sled_id, path)
+);
+

--- a/schema/crdb/measurement-proper-inventory/up02.sql
+++ b/schema/crdb/measurement-proper-inventory/up02.sql
@@ -1,0 +1,15 @@
+-- Move from the old table to the new
+
+set local disallow_full_table_scans = off;
+
+INSERT INTO omicron.public.inv_single_measurements (
+    inv_collection_id,
+    sled_id,
+    path
+)
+SELECT
+   inv_collection_id,
+   sled_id,
+   path
+FROM
+   omicron.public.inv_last_reconciliation_measurements;

--- a/schema/crdb/measurement-proper-inventory/up03.sql
+++ b/schema/crdb/measurement-proper-inventory/up03.sql
@@ -1,0 +1,1 @@
+DROP TABLE if exists omicron.public.inv_last_reconciliation_measurements;

--- a/sled-agent/api/src/lib.rs
+++ b/sled-agent/api/src/lib.rs
@@ -19,7 +19,9 @@ use omicron_common::api::internal::{
         SledIdentifiers, SwitchPorts, VirtualNetworkInterfaceHost,
     },
 };
-use sled_agent_types_versions::{latest, v1, v4, v6, v7, v9, v10, v11, v12};
+use sled_agent_types_versions::{
+    latest, v1, v4, v6, v7, v9, v10, v11, v12, v14,
+};
 use sled_diagnostics::SledDiagnosticsQueryOutput;
 
 api_versions!([
@@ -34,6 +36,7 @@ api_versions!([
     // |  example for the next person.
     // v
     // (next_int, IDENT),
+    (16, MEASUREMENT_PROPER_INVENTORY),
     (15, ADD_TRUST_QUORUM_STATUS),
     (14, MEASUREMENTS),
     (13, ADD_TRUST_QUORUM),
@@ -742,11 +745,25 @@ pub trait SledAgentApi {
     #[endpoint {
         method = GET,
         path = "/inventory",
-        versions = VERSION_MEASUREMENTS..,
+        versions = VERSION_MEASUREMENT_PROPER_INVENTORY..,
     }]
     async fn inventory(
         rqctx: RequestContext<Self::Context>,
     ) -> Result<HttpResponseOk<latest::inventory::Inventory>, HttpError>;
+
+    /// Fetch basic information about this sled
+    #[endpoint {
+        operation_id = "inventory",
+        method = GET,
+        path = "/inventory",
+        versions = VERSION_MEASUREMENTS..VERSION_MEASUREMENT_PROPER_INVENTORY,
+    }]
+    async fn inventory_v14(
+        rqctx: RequestContext<Self::Context>,
+    ) -> Result<HttpResponseOk<v14::inventory::Inventory>, HttpError> {
+        let HttpResponseOk(inventory) = Self::inventory(rqctx).await?;
+        inventory.try_into().map_err(HttpError::from).map(HttpResponseOk)
+    }
 
     /// Fetch basic information about this sled
     #[endpoint {
@@ -758,7 +775,7 @@ pub trait SledAgentApi {
     async fn inventory_v12(
         rqctx: RequestContext<Self::Context>,
     ) -> Result<HttpResponseOk<v12::inventory::Inventory>, HttpError> {
-        let HttpResponseOk(inventory) = Self::inventory(rqctx).await?;
+        let HttpResponseOk(inventory) = Self::inventory_v14(rqctx).await?;
         inventory.try_into().map_err(HttpError::from).map(HttpResponseOk)
     }
 

--- a/sled-agent/config-reconciler/src/reconciler_task.rs
+++ b/sled-agent/config-reconciler/src/reconciler_task.rs
@@ -236,7 +236,6 @@ impl LatestReconciliationResult {
             zones: self.zones_inventory.clone(),
             boot_partitions: self.boot_partitions.clone(),
             remove_mupdate_override: self.remove_mupdate_override.clone(),
-            measurements: IdOrdMap::new(),
         }
     }
 

--- a/sled-agent/measurements/Cargo.toml
+++ b/sled-agent/measurements/Cargo.toml
@@ -11,6 +11,7 @@ workspace = true
 anyhow.workspace = true
 bytes.workspace = true
 camino.workspace = true
+iddqd.workspace = true
 key-manager.workspace = true
 sled-agent-types.workspace = true
 sled-agent-types-versions.workspace = true

--- a/sled-agent/src/rack_setup/plan/service.rs
+++ b/sled-agent/src/rack_setup/plan/service.rs
@@ -1539,6 +1539,7 @@ mod tests {
                 file_source_resolver:
                     OmicronFileSourceResolverInventory::new_fake(),
                 health_monitor: HealthMonitorInventory::new(),
+                reference_measurements: IdOrdMap::new(),
             },
             is_scrimlet,
         )];

--- a/sled-agent/src/rack_setup/service.rs
+++ b/sled-agent/src/rack_setup/service.rs
@@ -1738,6 +1738,7 @@ impl<'a> OmicronZonesConfigGenerator<'a> {
 mod test {
     use super::*;
     use crate::rack_setup::plan::service::{Plan as ServicePlan, SledInfo};
+    use iddqd::IdOrdMap;
     use nexus_reconfigurator_blippy::{Blippy, BlippyReportSortKey};
     use omicron_common::{
         address::{Ipv6Subnet, SLED_PREFIX, get_sled_address},
@@ -1794,6 +1795,7 @@ mod test {
                 file_source_resolver:
                     OmicronFileSourceResolverInventory::new_fake(),
                 health_monitor: HealthMonitorInventory::new(),
+                reference_measurements: IdOrdMap::new(),
             },
             true,
         )

--- a/sled-agent/src/sim/sled_agent.rs
+++ b/sled-agent/src/sim/sled_agent.rs
@@ -61,10 +61,11 @@ use sled_agent_types::instance::{
     VmmPutStateResponse, VmmStateRequested, VmmUnregisterResponse,
 };
 use sled_agent_types::inventory::{
-    ConfigReconcilerInventory, ConfigReconcilerInventoryStatus,
-    HostPhase2DesiredSlots, Inventory, InventoryDataset, InventoryDisk,
-    InventoryZpool, OmicronFileSourceResolverInventory, OmicronSledConfig,
-    OmicronZonesConfig, SledRole,
+    ConfigReconcilerInventory, ConfigReconcilerInventoryResult,
+    ConfigReconcilerInventoryStatus, HostPhase2DesiredSlots, Inventory,
+    InventoryDataset, InventoryDisk, InventoryZpool,
+    OmicronFileSourceResolverInventory, OmicronSledConfig, OmicronZonesConfig,
+    SingleMeasurementInventory, SledRole,
 };
 use sled_agent_types::support_bundle::SupportBundleMetadata;
 
@@ -829,6 +830,21 @@ impl SledAgent {
             measurements: Default::default(),
         };
 
+        let reference_measurements = vec![
+            SingleMeasurementInventory {
+                path: "this/is/fake1".into(),
+                result: ConfigReconcilerInventoryResult::Ok,
+            },
+            SingleMeasurementInventory {
+                path: "this/is/fake2".into(),
+                result: ConfigReconcilerInventoryResult::Err {
+                    message: "this is an error".to_string(),
+                },
+            },
+        ]
+        .into_iter()
+        .collect();
+
         Ok(Inventory {
             sled_id: self.id,
             sled_agent_address,
@@ -903,6 +919,7 @@ impl SledAgent {
             file_source_resolver: OmicronFileSourceResolverInventory::new_fake(
             ),
             health_monitor,
+            reference_measurements,
         })
     }
 

--- a/sled-agent/src/sled_agent.rs
+++ b/sled-agent/src/sled_agent.rs
@@ -1175,6 +1175,7 @@ impl SledAgent {
             last_reconciliation,
             file_source_resolver,
             health_monitor,
+            reference_measurements: self.inner.measurements.to_inventory(),
         })
     }
 

--- a/sled-agent/types/versions/src/impls/inventory.rs
+++ b/sled-agent/types/versions/src/impls/inventory.rs
@@ -25,7 +25,7 @@ use crate::latest::inventory::{
     OmicronFileSourceResolverInventory, OmicronSledConfig, OmicronZoneConfig,
     OmicronZoneImageSource, OmicronZoneType, OmicronZonesConfig,
     RemoveMupdateOverrideBootSuccessInventory, RemoveMupdateOverrideInventory,
-    ZoneArtifactInventory, ZoneKind,
+    SingleMeasurementInventory, ZoneArtifactInventory, ZoneKind,
 };
 
 impl ZoneKind {
@@ -417,7 +417,6 @@ impl ConfigReconcilerInventory {
             zones: BTreeMap::new(),
             remove_mupdate_override: None,
             boot_partitions: BootPartitionContents::debug_assume_success(),
-            measurements: IdOrdMap::new(),
         };
         ret.debug_update_assume_success(config);
         ret
@@ -875,5 +874,32 @@ impl Default for OmicronSledConfig {
             host_phase_2: HostPhase2DesiredSlots::current_contents(),
             measurements: BTreeSet::new(),
         }
+    }
+}
+
+impl SingleMeasurementInventory {
+    pub fn display(&self) -> SingleMeasurementInventoryDisplay<'_> {
+        SingleMeasurementInventoryDisplay { inner: self }
+    }
+}
+
+/// a displayer for [`SingleMeasurementInventory`]
+pub struct SingleMeasurementInventoryDisplay<'a> {
+    inner: &'a SingleMeasurementInventory,
+}
+
+impl fmt::Display for SingleMeasurementInventoryDisplay<'_> {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        let SingleMeasurementInventory { path, result } = self.inner;
+
+        match result {
+            ConfigReconcilerInventoryResult::Ok => {
+                writeln!(f, "entry {path} ok")?
+            }
+            ConfigReconcilerInventoryResult::Err { message } => {
+                writeln!(f, "entry error : {message}")?
+            }
+        }
+        Ok(())
     }
 }

--- a/sled-agent/types/versions/src/latest.rs
+++ b/sled-agent/types/versions/src/latest.rs
@@ -110,13 +110,15 @@ pub mod inventory {
 
     pub use crate::v12::inventory::HealthMonitorInventory;
 
-    pub use crate::v14::inventory::ConfigReconcilerInventory;
     pub use crate::v14::inventory::ConfigReconcilerInventoryStatus;
-    pub use crate::v14::inventory::Inventory;
     pub use crate::v14::inventory::OmicronFileSourceResolverInventory;
     pub use crate::v14::inventory::OmicronSingleMeasurement;
     pub use crate::v14::inventory::OmicronSledConfig;
     pub use crate::v14::inventory::ReconciledSingleMeasurement;
+
+    pub use crate::v16::inventory::ConfigReconcilerInventory;
+    pub use crate::v16::inventory::Inventory;
+    pub use crate::v16::inventory::SingleMeasurementInventory;
 
     pub use crate::impls::inventory::ManifestBootInventoryDisplay;
     pub use crate::impls::inventory::ManifestInventoryDisplay;

--- a/sled-agent/types/versions/src/lib.rs
+++ b/sled-agent/types/versions/src/lib.rs
@@ -47,6 +47,8 @@ pub mod v13;
 pub mod v14;
 #[path = "add_trust_quorum_status/mod.rs"]
 pub mod v15;
+#[path = "measurement_proper_inventory/mod.rs"]
+pub mod v16;
 #[path = "add_switch_zone_operator_policy/mod.rs"]
 pub mod v3;
 #[path = "add_nexus_lockstep_port_to_inventory/mod.rs"]

--- a/sled-agent/types/versions/src/measurement_proper_inventory/inventory.rs
+++ b/sled-agent/types/versions/src/measurement_proper_inventory/inventory.rs
@@ -1,0 +1,143 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at https://mozilla.org/MPL/2.0/.
+
+use camino::Utf8PathBuf;
+use iddqd::id_upcast;
+use iddqd::{IdOrdItem, IdOrdMap};
+use omicron_common::api::external;
+use omicron_common::api::external::ByteCount;
+use omicron_uuid_kinds::PhysicalDiskUuid;
+use omicron_uuid_kinds::SledUuid;
+use omicron_uuid_kinds::{DatasetUuid, OmicronZoneUuid};
+use schemars::{
+    JsonSchema, SchemaGenerator, schema::Schema, schema::SchemaObject,
+};
+use serde::{Deserialize, Serialize};
+use sled_hardware_types::{Baseboard, SledCpuFamily};
+use std::collections::BTreeMap;
+use std::net::SocketAddrV6;
+
+use crate::v1::inventory::{
+    BootPartitionContents, ConfigReconcilerInventoryResult, InventoryDataset,
+    InventoryDisk, InventoryZpool, OrphanedDataset,
+    RemoveMupdateOverrideInventory, SledRole,
+};
+use crate::v14;
+use crate::v14::inventory::{
+    ConfigReconcilerInventoryStatus, HealthMonitorInventory,
+    OmicronFileSourceResolverInventory, OmicronSledConfig,
+    ReconciledSingleMeasurement,
+};
+
+/// Identity and basic status information about this sled agent
+#[derive(Clone, Debug, Deserialize, JsonSchema, Serialize)]
+pub struct Inventory {
+    pub sled_id: SledUuid,
+    pub sled_agent_address: SocketAddrV6,
+    pub sled_role: SledRole,
+    pub baseboard: Baseboard,
+    pub usable_hardware_threads: u32,
+    pub usable_physical_ram: ByteCount,
+    pub cpu_family: SledCpuFamily,
+    pub reservoir_size: ByteCount,
+    pub disks: Vec<InventoryDisk>,
+    pub zpools: Vec<InventoryZpool>,
+    pub datasets: Vec<InventoryDataset>,
+    pub ledgered_sled_config: Option<OmicronSledConfig>,
+    pub reconciler_status: ConfigReconcilerInventoryStatus,
+    pub last_reconciliation: Option<ConfigReconcilerInventory>,
+    pub file_source_resolver: OmicronFileSourceResolverInventory,
+    pub health_monitor: HealthMonitorInventory,
+    pub reference_measurements: IdOrdMap<SingleMeasurementInventory>,
+}
+
+impl TryFrom<Inventory> for v14::inventory::Inventory {
+    type Error = external::Error;
+
+    fn try_from(value: Inventory) -> Result<Self, Self::Error> {
+        let measurements = value
+            .reference_measurements
+            .into_iter()
+            .map(|m| ReconciledSingleMeasurement {
+                file_name: m.path.file_name().unwrap_or("").to_string(),
+                path: m.path,
+                result: m.result,
+            })
+            .collect();
+
+        let last_reconciliation = value.last_reconciliation.map(|v| {
+            v14::inventory::ConfigReconcilerInventory {
+                last_reconciled_config: v.last_reconciled_config,
+                external_disks: v.external_disks,
+                datasets: v.datasets,
+                orphaned_datasets: v.orphaned_datasets,
+                zones: v.zones,
+                boot_partitions: v.boot_partitions,
+                remove_mupdate_override: v.remove_mupdate_override,
+                measurements,
+            }
+        });
+
+        Ok(Self {
+            sled_id: value.sled_id,
+            sled_agent_address: value.sled_agent_address,
+            sled_role: value.sled_role,
+            baseboard: value.baseboard,
+            usable_hardware_threads: value.usable_hardware_threads,
+            usable_physical_ram: value.usable_physical_ram,
+            cpu_family: value.cpu_family,
+            reservoir_size: value.reservoir_size,
+            disks: value.disks,
+            zpools: value.zpools,
+            datasets: value.datasets,
+            ledgered_sled_config: value.ledgered_sled_config,
+            reconciler_status: value.reconciler_status,
+            last_reconciliation,
+            file_source_resolver: value.file_source_resolver,
+            health_monitor: value.health_monitor,
+        })
+    }
+}
+
+/// Describes the last attempt made by the sled-agent-config-reconciler to
+/// reconcile the current sled config against the actual state of the sled.
+#[derive(Clone, Debug, PartialEq, Eq, Deserialize, JsonSchema, Serialize)]
+#[serde(rename_all = "snake_case")]
+pub struct ConfigReconcilerInventory {
+    pub last_reconciled_config: OmicronSledConfig,
+    pub external_disks:
+        BTreeMap<PhysicalDiskUuid, ConfigReconcilerInventoryResult>,
+    pub datasets: BTreeMap<DatasetUuid, ConfigReconcilerInventoryResult>,
+    pub orphaned_datasets: IdOrdMap<OrphanedDataset>,
+    pub zones: BTreeMap<OmicronZoneUuid, ConfigReconcilerInventoryResult>,
+    pub boot_partitions: BootPartitionContents,
+    /// The result of removing the mupdate override file on disk.
+    ///
+    /// `None` if `remove_mupdate_override` was not provided in the sled config.
+    pub remove_mupdate_override: Option<RemoveMupdateOverrideInventory>,
+}
+
+/// An attempt at resolving a single measurement file to a valid path
+#[derive(Clone, Debug, PartialEq, Eq, Deserialize, JsonSchema, Serialize)]
+pub struct SingleMeasurementInventory {
+    #[schemars(schema_with = "path_schema")]
+    pub path: Utf8PathBuf,
+    pub result: ConfigReconcilerInventoryResult,
+}
+
+impl IdOrdItem for SingleMeasurementInventory {
+    type Key<'a> = &'a Utf8PathBuf;
+    fn key(&self) -> Self::Key<'_> {
+        &self.path
+    }
+    id_upcast!();
+}
+
+// Used for schemars to be able to be used with camino:
+// See https://github.com/camino-rs/camino/issues/91#issuecomment-2027908513
+fn path_schema(generator: &mut SchemaGenerator) -> Schema {
+    let mut schema: SchemaObject = <String>::json_schema(generator).into();
+    schema.format = Some("Utf8PathBuf".to_owned());
+    schema.into()
+}

--- a/sled-agent/types/versions/src/measurement_proper_inventory/mod.rs
+++ b/sled-agent/types/versions/src/measurement_proper_inventory/mod.rs
@@ -1,0 +1,10 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at https://mozilla.org/MPL/2.0/.
+
+//! Version `MEASUREMENT_PROPER_INVENTORY` of the Sled Agent API.
+//!
+//! This version fixes up reference measurements to be a real part
+//! of the inventory
+
+pub mod inventory;

--- a/sled-agent/types/versions/src/measurements/inventory.rs
+++ b/sled-agent/types/versions/src/measurements/inventory.rs
@@ -32,7 +32,7 @@ use crate::v1::inventory::{
 };
 use crate::v11::inventory::OmicronZoneConfig;
 use crate::v12;
-use crate::v12::inventory::HealthMonitorInventory;
+pub use crate::v12::inventory::HealthMonitorInventory;
 use camino::Utf8PathBuf;
 use schemars::SchemaGenerator;
 use schemars::schema::{Schema, SchemaObject};


### PR DESCRIPTION
Earlier versions of this had measurements as part of the config reconciler. The measurements are now separate so move them out of the config reconciler and into the inventory directly. No database change is needed because we can re-use the existing table. Also improve debugging output.