### PR TITLE
Bump Propolis

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -734,7 +734,7 @@ dependencies = [
 [[package]]
 name = "bhyve_api"
 version = "0.0.0"
-source = "git+https://github.com/oxidecomputer/propolis?rev=d6cd9573a8134d6d9b1aa26e9adc10a823642275#d6cd9573a8134d6d9b1aa26e9adc10a823642275"
+source = "git+https://github.com/oxidecomputer/propolis?rev=7d4e2a49b9ef7750140bdddd2391d24d4729ec8c#7d4e2a49b9ef7750140bdddd2391d24d4729ec8c"
 dependencies = [
  "bhyve_api_sys",
  "libc",
@@ -744,7 +744,7 @@ dependencies = [
 [[package]]
 name = "bhyve_api_sys"
 version = "0.0.0"
-source = "git+https://github.com/oxidecomputer/propolis?rev=d6cd9573a8134d6d9b1aa26e9adc10a823642275#d6cd9573a8134d6d9b1aa26e9adc10a823642275"
+source = "git+https://github.com/oxidecomputer/propolis?rev=7d4e2a49b9ef7750140bdddd2391d24d4729ec8c#7d4e2a49b9ef7750140bdddd2391d24d4729ec8c"
 dependencies = [
  "libc",
  "strum 0.26.3",
@@ -8465,7 +8465,7 @@ dependencies = [
  "pq-sys",
  "pretty_assertions",
  "progenitor-client 0.10.0",
- "propolis-client 0.1.0 (git+https://github.com/oxidecomputer/propolis?rev=d6cd9573a8134d6d9b1aa26e9adc10a823642275)",
+ "propolis-client 0.1.0 (git+https://github.com/oxidecomputer/propolis?rev=7d4e2a49b9ef7750140bdddd2391d24d4729ec8c)",
  "qorb",
  "rand 0.9.2",
  "range-requests",
@@ -8905,7 +8905,7 @@ dependencies = [
  "oxnet",
  "pretty_assertions",
  "progenitor 0.10.0",
- "propolis-client 0.1.0 (git+https://github.com/oxidecomputer/propolis?rev=d6cd9573a8134d6d9b1aa26e9adc10a823642275)",
+ "propolis-client 0.1.0 (git+https://github.com/oxidecomputer/propolis?rev=7d4e2a49b9ef7750140bdddd2391d24d4729ec8c)",
  "propolis-mock-server",
  "propolis_api_types",
  "rand 0.9.2",
@@ -10994,7 +10994,7 @@ dependencies = [
 [[package]]
 name = "propolis-client"
 version = "0.1.0"
-source = "git+https://github.com/oxidecomputer/propolis?rev=d6cd9573a8134d6d9b1aa26e9adc10a823642275#d6cd9573a8134d6d9b1aa26e9adc10a823642275"
+source = "git+https://github.com/oxidecomputer/propolis?rev=7d4e2a49b9ef7750140bdddd2391d24d4729ec8c#7d4e2a49b9ef7750140bdddd2391d24d4729ec8c"
 dependencies = [
  "async-trait",
  "base64 0.21.7",
@@ -11039,7 +11039,7 @@ dependencies = [
 [[package]]
 name = "propolis-mock-server"
 version = "0.0.0"
-source = "git+https://github.com/oxidecomputer/propolis?rev=d6cd9573a8134d6d9b1aa26e9adc10a823642275#d6cd9573a8134d6d9b1aa26e9adc10a823642275"
+source = "git+https://github.com/oxidecomputer/propolis?rev=7d4e2a49b9ef7750140bdddd2391d24d4729ec8c#7d4e2a49b9ef7750140bdddd2391d24d4729ec8c"
 dependencies = [
  "anyhow",
  "atty",
@@ -11083,7 +11083,7 @@ dependencies = [
 [[package]]
 name = "propolis_api_types"
 version = "0.0.0"
-source = "git+https://github.com/oxidecomputer/propolis?rev=d6cd9573a8134d6d9b1aa26e9adc10a823642275#d6cd9573a8134d6d9b1aa26e9adc10a823642275"
+source = "git+https://github.com/oxidecomputer/propolis?rev=7d4e2a49b9ef7750140bdddd2391d24d4729ec8c#7d4e2a49b9ef7750140bdddd2391d24d4729ec8c"
 dependencies = [
  "crucible-client-types",
  "propolis_types",
@@ -11096,7 +11096,7 @@ dependencies = [
 [[package]]
 name = "propolis_types"
 version = "0.0.0"
-source = "git+https://github.com/oxidecomputer/propolis?rev=d6cd9573a8134d6d9b1aa26e9adc10a823642275#d6cd9573a8134d6d9b1aa26e9adc10a823642275"
+source = "git+https://github.com/oxidecomputer/propolis?rev=7d4e2a49b9ef7750140bdddd2391d24d4729ec8c#7d4e2a49b9ef7750140bdddd2391d24d4729ec8c"
 dependencies = [
  "schemars 0.8.22",
  "serde",
@@ -13040,7 +13040,7 @@ dependencies = [
  "omicron-workspace-hack",
  "oxnet",
  "progenitor 0.10.0",
- "propolis-client 0.1.0 (git+https://github.com/oxidecomputer/propolis?rev=d6cd9573a8134d6d9b1aa26e9adc10a823642275)",
+ "propolis-client 0.1.0 (git+https://github.com/oxidecomputer/propolis?rev=7d4e2a49b9ef7750140bdddd2391d24d4729ec8c)",
  "regress",
  "reqwest",
  "schemars 0.8.22",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -680,10 +680,10 @@ progenitor-client = "0.10.0"
 # NOTE: if you change the pinned revision of the `bhyve_api` and propolis
 # dependencies, you must also update the references in package-manifest.toml to
 # match the new revision.
-bhyve_api = { git = "https://github.com/oxidecomputer/propolis", rev = "d6cd9573a8134d6d9b1aa26e9adc10a823642275" }
-propolis_api_types = { git = "https://github.com/oxidecomputer/propolis", rev = "d6cd9573a8134d6d9b1aa26e9adc10a823642275" }
-propolis-client = { git = "https://github.com/oxidecomputer/propolis", rev = "d6cd9573a8134d6d9b1aa26e9adc10a823642275" }
-propolis-mock-server = { git = "https://github.com/oxidecomputer/propolis", rev = "d6cd9573a8134d6d9b1aa26e9adc10a823642275" }
+bhyve_api = { git = "https://github.com/oxidecomputer/propolis", rev = "7d4e2a49b9ef7750140bdddd2391d24d4729ec8c" }
+propolis_api_types = { git = "https://github.com/oxidecomputer/propolis", rev = "7d4e2a49b9ef7750140bdddd2391d24d4729ec8c" }
+propolis-client = { git = "https://github.com/oxidecomputer/propolis", rev = "7d4e2a49b9ef7750140bdddd2391d24d4729ec8c" }
+propolis-mock-server = { git = "https://github.com/oxidecomputer/propolis", rev = "7d4e2a49b9ef7750140bdddd2391d24d4729ec8c" }
 # NOTE: see above!
 proptest = "1.7.0"
 qorb = "0.4.1"

--- a/package-manifest.toml
+++ b/package-manifest.toml
@@ -650,10 +650,10 @@ service_name = "propolis-server"
 only_for_targets.image = "standard"
 source.type = "prebuilt"
 source.repo = "propolis"
-source.commit = "d6cd9573a8134d6d9b1aa26e9adc10a823642275"
+source.commit = "7d4e2a49b9ef7750140bdddd2391d24d4729ec8c"
 # The SHA256 digest is automatically posted to:
 # https://buildomat.eng.oxide.computer/public/file/oxidecomputer/propolis/image/<commit>/propolis-server.sha256.txt
-source.sha256 = "6705a397f4dde7e4a8213eb85a555a00d4670755058548d64e86e38b56dde645"
+source.sha256 = "0d5998ffd44f7103e5012a06ba1280260f6c8ed6f48bb2f58fcc70cbc96cb873"
 output.type = "zone"
 
 [package.mg-ddm-gz]


### PR DESCRIPTION
relevant propolis change since last bump (plus some commits that are docs/tools-only, and disabling doorbell buffers + reverting the disable):

* nvme: CQ db_buf EventIdx should slightly lag CQ tail

this fixes what we ended up finding as an associated issue in https://github.com/oxidecomputer/propolis/issues/1008, where guests could end up having submitted disk operations we were told to process and subsequently never did.