### PR TITLE
[omdb] add disk type to `omdb db disks list`

### DIFF
--- a/dev-tools/omdb/tests/successes.out
+++ b/dev-tools/omdb/tests/successes.out
@@ -25,7 +25,7 @@ EXECUTING COMMAND: omdb ["db", "disks", "list"]
 termination: Exited(0)
 ---------------------------------------------
 stdout:
-ID SIZE STATE NAME ATTACHED_TO 
+ID SIZE TYPE STATE NAME ATTACHED_TO 
 ---------------------------------------------
 stderr:
 note: using database URL postgresql://root@[::1]:REDACTED_PORT/omicron?sslmode=disable


### PR DESCRIPTION
Presently, `omdb db` commands that display lists of virtual disks do not indicate whether the disks are Crucible or local storage disks. This includes both `omdb db disk list` and `omdb db instance show`, which use shared code for printing tables of virtual disks. It would be nice to include this information in the lists.

This commit adds that. I've also added the option to pass `--type crucible` or `--type local` to `omdb db disks list` to filter the list to include only crucible or local disks.