### PR TITLE
background task comment could mention other Nexus instances

### DIFF
--- a/nexus/src/app/background/mod.rs
+++ b/nexus/src/app/background/mod.rs
@@ -110,7 +110,7 @@
 //!   instances.  Thus, having reconcilers accept an explicit hint about what
 //!   changed (and then doing something differently based on that) bifurcates
 //!   the code: there's the common case where that hint is available and the
-//!   rarely-exercised case when it's not. This is what we're trying to avoid.
+//!   rarely-exercised case when it's not.  This is what we're trying to avoid.
 //! * We do allow reconcilers to be triggered by a `tokio::sync::watch` channel
 //!   -- but again, not using the _data_ from that channel.  There are two big
 //!   advantages here: (1) reduced latency from when a change is made to when


### PR DESCRIPTION
By design, background tasks can't accept per-activation input.  The comment explaining this mentions one reason: because Nexus may crash and the input won't be available on restart.  It should also mention that the background task may be running in a different Nexus instance than the one that saw the input.