### PR TITLE
[fix(tests)] handle cleanup failures gracefully in failure-focused multicast tests

### DIFF
--- a/clients/sled-agent-client/src/lib.rs
+++ b/clients/sled-agent-client/src/lib.rs
@@ -359,6 +359,10 @@ impl ApiVersionHeader for reqwest::RequestBuilder {
 pub trait TestInterfaces {
     async fn vmm_single_step(&self, id: PropolisUuid);
     async fn vmm_finish_transition(&self, id: PropolisUuid);
+    async fn try_vmm_finish_transition(
+        &self,
+        id: PropolisUuid,
+    ) -> Result<(), reqwest::Error>;
     async fn vmm_simulate_migration_source(
         &self,
         id: PropolisUuid,
@@ -382,15 +386,20 @@ impl TestInterfaces for Client {
     }
 
     async fn vmm_finish_transition(&self, id: PropolisUuid) {
+        self.try_vmm_finish_transition(id)
+            .await
+            .expect("instance_finish_transition() failed unexpectedly");
+    }
+
+    async fn try_vmm_finish_transition(
+        &self,
+        id: PropolisUuid,
+    ) -> Result<(), reqwest::Error> {
         let baseurl = self.baseurl();
         let client = self.client();
         let url = format!("{}/vmms/{}/poke", baseurl, id);
-        client
-            .post(url)
-            .api_version_header(self.api_version())
-            .send()
-            .await
-            .expect("instance_finish_transition() failed unexpectedly");
+        client.post(url).api_version_header(self.api_version()).send().await?;
+        Ok(())
     }
 
     async fn disk_finish_transition(&self, id: Uuid) {

--- a/nexus/tests/integration_tests/instances.rs
+++ b/nexus/tests/integration_tests/instances.rs
@@ -9002,6 +9002,32 @@ pub async fn instance_simulate(nexus: &Arc<Nexus>, id: &InstanceUuid) {
     sled_info.sled_client.vmm_finish_transition(sled_info.propolis_id).await;
 }
 
+/// Fallible version of instance_simulate for test cleanup.
+///
+/// Returns an error instead of panicking if the sled agent communication fails.
+/// This is useful during test cleanup where the sled agent may be unavailable.
+pub async fn try_instance_simulate(
+    nexus: &Arc<Nexus>,
+    id: &InstanceUuid,
+) -> Result<(), anyhow::Error> {
+    let sled_info = nexus
+        .active_instance_info(id, None)
+        .await?
+        .ok_or_else(|| anyhow::anyhow!("instance not on a sled"))?;
+
+    sled_info
+        .sled_client
+        .try_vmm_finish_transition(sled_info.propolis_id)
+        .await
+        .map_err(|e| {
+            anyhow::anyhow!(
+                "sled agent communication failed for VMM {}: {e}",
+                sled_info.propolis_id
+            )
+        })?;
+    Ok(())
+}
+
 /// Simulate one step of an ongoing instance state transition.  To do this, we
 /// have to look up the instance, then get the sled agent associated with that
 /// instance, and then tell it to finish simulating whatever async transition is


### PR DESCRIPTION
Fixes [#9729](https://github.com/oxidecomputer/omicron/issues/9729)

The test `test_multicast_group_dpd_communication_failure_recovery` can possibly panic during cleanup because it intentionally stops DPD to test failure recovery. When cleanup tries to simulate instance state transitions, the sled agent cannot communicate with the stopped DPD, causing a panic.

The fix is to add fallible versions of simulation helpers for test cleanup:

- `try_vmm_finish_transition` in sled-agent-client: returns Result instead of panicking on communication failure
- `try_instance_simulate` in instances.rs: wraps the fallible client method, includes VMM ID in error messages for debugging

Then, we update `cleanup_instances` and `stop_instances` in multicast/mod.rs to  use these versions for cleanup. 

I had a version of this in another PR, but that's still in review. Let's bring this in now. 

Actual issues and true outcomes are still caught during test execution. Some cleanup failures are expected when tests intentionally break infrastructure.