### PR TITLE
prevent dendrite check from hogging a CI machine for 90 minutes

### DIFF
--- a/.github/buildomat/jobs/deploy.sh
+++ b/.github/buildomat/jobs/deploy.sh
@@ -359,10 +359,10 @@ OMICRON_NO_UNINSTALL=1 \
 
 # Wait for switch zone to come up
 retry=0
-until curl --head --silent -o /dev/null "http://[fd00:1122:3344:101::2]:12224/"
+until curl --max-time 1 --head --silent --show-error -o /dev/null "http://[fd00:1122:3344:101::2]:12224/"
 do
 	if [[ $retry -gt 30 ]]; then
-		echo "Failed to reach switch zone after 30 seconds"
+		echo "Failed to reach switch zone after 30 attempts"
 		exit 1
 	fi
 	sleep 1


### PR DESCRIPTION
@jclulow reported this job: https://buildomat.eng.oxide.computer/wg/0/details/01KG5JNVNBG9BBVWG8S874737E/Ar9EJfdSbD1qqfZ2jmuXxeF7mjn15W2b1GpI5ljIsFKgOJNn/01KG5JPR9Q4AHGSK2A6CYK3FPM#S367

Our check that the switch zone is up was, for whatever reason, hanging for approximately 195 seconds on each iteration. This resulted in what should have been a 30-second timeout becoming about 90 minutes.

This does not fix whatever the root cause is, but it does keep it from hogging one of our two available machines that can run this CI job.