### PR TITLE
ExampleSystem deploys internal NTP zone with boundary NTP zone image

### DIFF
--- a/nexus/reconfigurator/planning/src/example.rs
+++ b/nexus/reconfigurator/planning/src/example.rs
@@ -578,8 +578,8 @@ impl ExampleSystemBuilder {
                     .sled_ensure_zone_ntp(
                         sled_id,
                         self.target_release
-                            .zone_image_source(ZoneKind::BoundaryNtp)
-                            .expect("obtained BoundaryNtp image source"),
+                            .zone_image_source(ZoneKind::InternalNtp)
+                            .expect("obtained InternalNtp image source"),
                     )
                     .unwrap();
 


### PR DESCRIPTION
The ExampleSystem picks an image for `BoundaryNtp` zone but then calls `sled_ensure_zone_ntp()` with it, which always produces an internal NTP zone.