### PR TITLE
TQ: Add omdb support for individual sled-agent status

### DIFF
--- a/dev-tools/omdb/tests/usage_errors.out
+++ b/dev-tools/omdb/tests/usage_errors.out
@@ -1122,6 +1122,7 @@ Commands:
   zones               print information about zones
   switch-zone-policy  control the switch zone policy
   bootstore           print information about the local bootstore node
+  trust-quorum        print information about the local trust quorum node
   help                Print this message or the help of the given subcommand(s)
 
 Options:


### PR DESCRIPTION
It looks like this on an LRTQ system.

```
root@oxz_switch:~# omdb sled-agent trust-quorum status --sled-agent-url='http://[fd00:17:1:d01::1]:12345'
connected peers:
    913-0000019:20000001
    913-0000019:20000002
    913-0000019:20000003
alarms:
    <none>
persistent state:
    has lrtq share: true
    configs: []
    shares: []
    commits: []
    expunged: None
proxied requests: 0
```

Unfortunately all the nodes in a4x2 didn't restart correctly so I didn't have a chance to run `omdb nexus lrtq-upgrade` and check more details. I'm going to add a similar method for proxy status and will do more testing and possible cleanup then.