### PR TITLE
Remove support for automatic IPv6 SNAT addresses

### DIFF
--- a/nexus/tests/integration_tests/instances.rs
+++ b/nexus/tests/integration_tests/instances.rs
@@ -8009,6 +8009,24 @@ async fn create_instance_with_pool(
     .await
 }
 
+pub async fn fetch_instance_network_interfaces(
+    client: &ClientTestContext,
+    instance_name: &str,
+    project_name: &str,
+) -> Vec<InstanceNetworkInterface> {
+    let url = format!(
+        "/v1/network-interfaces?project={project_name}&instance={instance_name}"
+    );
+    let nics = NexusRequest::object_get(client, &url)
+        .authn_as(AuthnMode::PrivilegedUser)
+        .execute()
+        .await
+        .expect("Failed to fetch instance NICs")
+        .parsed_body::<ResultsPage<InstanceNetworkInterface>>()
+        .expect("Failed to parse NICs");
+    nics.items
+}
+
 pub async fn fetch_instance_external_ips(
     client: &ClientTestContext,
     instance_name: &str,


### PR DESCRIPTION
- Do not create SNAT IPv6 addresses automatically in the instance-creation saga. External addresses can still be created by explicitly requesting an Ephemeral or Floating IPv6 address, either at instance-creation or later by attaching one.
- This fixes #9683, but is an intentionally short-term fix. The right longer term goal is to solve #4317.