### PR TITLE
Use a non-`anyhow` error for non-illumos `OpteError`

### DIFF
--- a/illumos-utils/src/opte/port_manager.rs
+++ b/illumos-utils/src/opte/port_manager.rs
@@ -66,7 +66,6 @@ use slog::debug;
 use slog::error;
 use slog::info;
 use slog::warn;
-#[cfg(all(target_os = "illumos", not(test)))]
 use slog_error_chain::InlineErrorChain;
 use std::collections::BTreeMap;
 use std::collections::HashMap;
@@ -1104,23 +1103,13 @@ impl PortManager {
                 Ok(())
             }
             Err(e) => {
-                #[cfg(all(target_os = "illumos", not(test)))]
                 error!(
                     self.inner.log,
                     "failed to attach subnet";
                     "port_name" => %port.name(),
                     "subnet" => %cidr,
                     "kind" => ?kind,
-                    "error" => InlineErrorChain::new(&e),
-                );
-                #[cfg(not(all(target_os = "illumos", not(test))))]
-                error!(
-                    self.inner.log,
-                    "failed to attach subnet";
-                    "port_name" => %port.name(),
-                    "subnet" => %cidr,
-                    "kind" => ?kind,
-                    "error" => ?e,
+                    InlineErrorChain::new(&e),
                 );
                 Err(Error::from(e))
             }
@@ -1170,21 +1159,12 @@ impl PortManager {
                 Ok(())
             }
             Err(e) => {
-                #[cfg(all(target_os = "illumos", not(test)))]
                 error!(
                     self.inner.log,
                     "failed to detach subnet";
                     "port_name" => %port.name(),
                     "subnet" => %subnet,
-                    "error" => InlineErrorChain::new(&e),
-                );
-                #[cfg(not(all(target_os = "illumos", not(test))))]
-                error!(
-                    self.inner.log,
-                    "failed to detach subnet";
-                    "port_name" => %port.name(),
-                    "subnet" => %subnet,
-                    "error" => ?e,
+                    InlineErrorChain::new(&e),
                 );
                 Err(Error::from(e))
             }


### PR DESCRIPTION
Fixes #9793.

(This is not urgent, but is followup from urgent R18 PR reviews, and I'm trying to chip away at some of those to keep them from piling up.)