### PR TITLE
Add html-based view of build information to buildomat

### DIFF
--- a/.github/buildomat/build-and-test.sh
+++ b/.github/buildomat/build-and-test.sh
@@ -122,13 +122,12 @@ export RUSTC_BOOTSTRAP=1
 ptime -m cargo build -Z unstable-options --timings=json,html \
     --workspace --exclude=omicron-nexus --tests --locked --verbose \
     1>> "$OUTPUT_DIR/crate-build-timings.json"
+cp target/cargo-timings/cargo-timing.html "$OUTPUT_DIR/cargo-timing-without-nexus.html"
+
 ptime -m cargo build -Z unstable-options --timings=json,html \
     --workspace --tests --locked --verbose \
     1>> "$OUTPUT_DIR/crate-build-timings.json"
-
-# Copy the HTML timing report to the output directory.
-# Cargo writes to target/cargo-timings/cargo-timing.html (a symlink to the latest).
-cp target/cargo-timings/cargo-timing.html "$OUTPUT_DIR/cargo-timing.html"
+cp target/cargo-timings/cargo-timing.html "$OUTPUT_DIR/cargo-timing-with-nexus.html"
 
 #
 # We apply our own timeout to ensure that we get a normal failure on timeout

--- a/.github/buildomat/jobs/build-and-test-helios.sh
+++ b/.github/buildomat/jobs/build-and-test-helios.sh
@@ -32,9 +32,14 @@
 #: from_output = "/work/crate-build-timings.json"
 #:
 #: [[publish]]
-#: series = "build-info-helios"
-#: name = "cargo-timing.html"
-#: from_output = "/work/cargo-timing.html"
+#: series = "build-info-without-nexus-helios"
+#: name = "cargo-timing-without-nexus.html"
+#: from_output = "/work/cargo-timing-without-nexus.html"
+#:
+#: [[publish]]
+#: series = "build-info-with-nexus-helios"
+#: name = "cargo-timing-with-nexus.html"
+#: from_output = "/work/cargo-timing-with-nexus.html"
 #:
 #: [[publish]]
 #: series = "live-tests"

--- a/.github/buildomat/jobs/build-and-test-linux.sh
+++ b/.github/buildomat/jobs/build-and-test-linux.sh
@@ -31,10 +31,14 @@
 #: from_output = "/work/crate-build-timings.json"
 #:
 #: [[publish]]
-#: series = "build-info-linux"
-#: name = "cargo-timing.html"
-#: from_output = "/work/cargo-timing.html"
-
+#: series = "build-info-without-nexus-linux"
+#: name = "cargo-timing-without-nexus.html"
+#: from_output = "/work/cargo-timing-without-nexus.html"
+#:
+#: [[publish]]
+#: series = "build-info-with-nexus-linux"
+#: name = "cargo-timing-with-nexus.html"
+#: from_output = "/work/cargo-timing-with-nexus.html"
 
 sudo apt-get install -y jq
 exec .github/buildomat/build-and-test.sh linux


### PR DESCRIPTION
I've been toying around with tracking build/test times in https://github.com/oxidecomputer/history.

Parsing through our existing build timings info - the `--timings=json` format - we can extract the build
times of individual crates. Unfortunately, however, we cannot see when crates "started to build", which means
we have no insight into e.g. crate dependencies, parallelism of the build, etc.

By extracting `--timings=html`, we should be able to see this information, presented as a graph,
for all commits that get merged into main.