### PR TITLE
Bump Propolis

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -734,7 +734,7 @@ dependencies = [
 [[package]]
 name = "bhyve_api"
 version = "0.0.0"
-source = "git+https://github.com/oxidecomputer/propolis?rev=7d4e2a49b9ef7750140bdddd2391d24d4729ec8c#7d4e2a49b9ef7750140bdddd2391d24d4729ec8c"
+source = "git+https://github.com/oxidecomputer/propolis?rev=d6bad48ee01b70e904d006e45d82fcdf4ceec1f9#d6bad48ee01b70e904d006e45d82fcdf4ceec1f9"
 dependencies = [
  "bhyve_api_sys",
  "libc",
@@ -744,7 +744,7 @@ dependencies = [
 [[package]]
 name = "bhyve_api_sys"
 version = "0.0.0"
-source = "git+https://github.com/oxidecomputer/propolis?rev=7d4e2a49b9ef7750140bdddd2391d24d4729ec8c#7d4e2a49b9ef7750140bdddd2391d24d4729ec8c"
+source = "git+https://github.com/oxidecomputer/propolis?rev=d6bad48ee01b70e904d006e45d82fcdf4ceec1f9#d6bad48ee01b70e904d006e45d82fcdf4ceec1f9"
 dependencies = [
  "libc",
  "strum 0.26.3",
@@ -8512,7 +8512,7 @@ dependencies = [
  "pq-sys",
  "pretty_assertions",
  "progenitor-client 0.10.0",
- "propolis-client 0.1.0 (git+https://github.com/oxidecomputer/propolis?rev=7d4e2a49b9ef7750140bdddd2391d24d4729ec8c)",
+ "propolis-client 0.1.0 (git+https://github.com/oxidecomputer/propolis?rev=d6bad48ee01b70e904d006e45d82fcdf4ceec1f9)",
  "qorb",
  "rand 0.9.2",
  "range-requests",
@@ -8953,7 +8953,7 @@ dependencies = [
  "oxnet",
  "pretty_assertions",
  "progenitor 0.10.0",
- "propolis-client 0.1.0 (git+https://github.com/oxidecomputer/propolis?rev=7d4e2a49b9ef7750140bdddd2391d24d4729ec8c)",
+ "propolis-client 0.1.0 (git+https://github.com/oxidecomputer/propolis?rev=d6bad48ee01b70e904d006e45d82fcdf4ceec1f9)",
  "propolis-mock-server",
  "propolis_api_types",
  "rand 0.9.2",
@@ -11045,7 +11045,7 @@ dependencies = [
 [[package]]
 name = "propolis-client"
 version = "0.1.0"
-source = "git+https://github.com/oxidecomputer/propolis?rev=7d4e2a49b9ef7750140bdddd2391d24d4729ec8c#7d4e2a49b9ef7750140bdddd2391d24d4729ec8c"
+source = "git+https://github.com/oxidecomputer/propolis?rev=d6bad48ee01b70e904d006e45d82fcdf4ceec1f9#d6bad48ee01b70e904d006e45d82fcdf4ceec1f9"
 dependencies = [
  "async-trait",
  "base64 0.21.7",
@@ -11090,7 +11090,7 @@ dependencies = [
 [[package]]
 name = "propolis-mock-server"
 version = "0.0.0"
-source = "git+https://github.com/oxidecomputer/propolis?rev=7d4e2a49b9ef7750140bdddd2391d24d4729ec8c#7d4e2a49b9ef7750140bdddd2391d24d4729ec8c"
+source = "git+https://github.com/oxidecomputer/propolis?rev=d6bad48ee01b70e904d006e45d82fcdf4ceec1f9#d6bad48ee01b70e904d006e45d82fcdf4ceec1f9"
 dependencies = [
  "anyhow",
  "atty",
@@ -11134,7 +11134,7 @@ dependencies = [
 [[package]]
 name = "propolis_api_types"
 version = "0.0.0"
-source = "git+https://github.com/oxidecomputer/propolis?rev=7d4e2a49b9ef7750140bdddd2391d24d4729ec8c#7d4e2a49b9ef7750140bdddd2391d24d4729ec8c"
+source = "git+https://github.com/oxidecomputer/propolis?rev=d6bad48ee01b70e904d006e45d82fcdf4ceec1f9#d6bad48ee01b70e904d006e45d82fcdf4ceec1f9"
 dependencies = [
  "crucible-client-types",
  "propolis_types",
@@ -11147,7 +11147,7 @@ dependencies = [
 [[package]]
 name = "propolis_types"
 version = "0.0.0"
-source = "git+https://github.com/oxidecomputer/propolis?rev=7d4e2a49b9ef7750140bdddd2391d24d4729ec8c#7d4e2a49b9ef7750140bdddd2391d24d4729ec8c"
+source = "git+https://github.com/oxidecomputer/propolis?rev=d6bad48ee01b70e904d006e45d82fcdf4ceec1f9#d6bad48ee01b70e904d006e45d82fcdf4ceec1f9"
 dependencies = [
  "schemars 0.8.22",
  "serde",
@@ -13091,7 +13091,7 @@ dependencies = [
  "omicron-workspace-hack",
  "oxnet",
  "progenitor 0.10.0",
- "propolis-client 0.1.0 (git+https://github.com/oxidecomputer/propolis?rev=7d4e2a49b9ef7750140bdddd2391d24d4729ec8c)",
+ "propolis-client 0.1.0 (git+https://github.com/oxidecomputer/propolis?rev=d6bad48ee01b70e904d006e45d82fcdf4ceec1f9)",
  "regress",
  "reqwest",
  "schemars 0.8.22",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -680,10 +680,10 @@ progenitor-client = "0.10.0"
 # NOTE: if you change the pinned revision of the `bhyve_api` and propolis
 # dependencies, you must also update the references in package-manifest.toml to
 # match the new revision.
-bhyve_api = { git = "https://github.com/oxidecomputer/propolis", rev = "7d4e2a49b9ef7750140bdddd2391d24d4729ec8c" }
-propolis_api_types = { git = "https://github.com/oxidecomputer/propolis", rev = "7d4e2a49b9ef7750140bdddd2391d24d4729ec8c" }
-propolis-client = { git = "https://github.com/oxidecomputer/propolis", rev = "7d4e2a49b9ef7750140bdddd2391d24d4729ec8c" }
-propolis-mock-server = { git = "https://github.com/oxidecomputer/propolis", rev = "7d4e2a49b9ef7750140bdddd2391d24d4729ec8c" }
+bhyve_api = { git = "https://github.com/oxidecomputer/propolis", rev = "d6bad48ee01b70e904d006e45d82fcdf4ceec1f9" }
+propolis_api_types = { git = "https://github.com/oxidecomputer/propolis", rev = "d6bad48ee01b70e904d006e45d82fcdf4ceec1f9" }
+propolis-client = { git = "https://github.com/oxidecomputer/propolis", rev = "d6bad48ee01b70e904d006e45d82fcdf4ceec1f9" }
+propolis-mock-server = { git = "https://github.com/oxidecomputer/propolis", rev = "d6bad48ee01b70e904d006e45d82fcdf4ceec1f9" }
 # NOTE: see above!
 proptest = "1.7.0"
 qorb = "0.4.1"

--- a/package-manifest.toml
+++ b/package-manifest.toml
@@ -650,10 +650,10 @@ service_name = "propolis-server"
 only_for_targets.image = "standard"
 source.type = "prebuilt"
 source.repo = "propolis"
-source.commit = "7d4e2a49b9ef7750140bdddd2391d24d4729ec8c"
+source.commit = "d6bad48ee01b70e904d006e45d82fcdf4ceec1f9"
 # The SHA256 digest is automatically posted to:
 # https://buildomat.eng.oxide.computer/public/file/oxidecomputer/propolis/image/<commit>/propolis-server.sha256.txt
-source.sha256 = "0d5998ffd44f7103e5012a06ba1280260f6c8ed6f48bb2f58fcc70cbc96cb873"
+source.sha256 = "129ee8f1dbff8075b594bc5c889d62bfefd047be5ef1f2bbbb05bc9aaf308540"
 output.type = "zone"
 
 [package.mg-ddm-gz]


### PR DESCRIPTION
relevant changes:

* I don't want no scrubs (for read-only Crucible backends) (propolis#1028)
* Be more specific about version errors, raise min required viona API
* awful: pre-grow propolis-server heap to avoid propolis#1008 (propolis#1032)
* viona: reset device more completely (propolis#1033)
* awful (2): prevent alloc elimination and size better (propolis#1038)