### PR TITLE
Return disk model from crdb from disk create.

### DIFF
--- a/common/src/lib.rs
+++ b/common/src/lib.rs
@@ -57,6 +57,19 @@ impl slog::KV for FileKv {
     }
 }
 
+/// Returns the current time, truncated to the previous microsecond.
+///
+/// This exists because the database doesn't store nanosecond-precision, so if
+/// we store nanosecond-precision timestamps, then DateTime conversion is lossy
+/// when round-tripping through the database.  That's rather inconvenient.
+pub fn now_db_precision() -> chrono::DateTime<chrono::Utc> {
+    let ts = chrono::Utc::now();
+    let nanosecs = ts.timestamp_subsec_nanos();
+    let micros = ts.timestamp_subsec_micros();
+    let only_nanos = nanosecs - micros * 1000;
+    ts - std::time::Duration::from_nanos(u64::from(only_nanos))
+}
+
 pub const OMICRON_DPD_TAG: &str = "omicron";
 
 /// A wrapper struct that does nothing other than elide the inner value from

--- a/nexus/db-macros/outputs/asset_with_uuid_kind.txt
+++ b/nexus/db-macros/outputs/asset_with_uuid_kind.txt
@@ -19,7 +19,7 @@ impl AssetWithUuidKindIdentity {
     pub fn new(
         id: ::omicron_uuid_kinds::TypedUuid<::omicron_uuid_kinds::CustomKind>,
     ) -> Self {
-        let now = ::chrono::Utc::now();
+        let now = ::omicron_common::now_db_precision();
         Self {
             id: crate::to_db_typed_uuid(id),
             time_created: now,

--- a/nexus/db-macros/outputs/resource_with_uuid_kind.txt
+++ b/nexus/db-macros/outputs/resource_with_uuid_kind.txt
@@ -24,7 +24,7 @@ impl ResourceWithUuidKindIdentity {
         id: ::omicron_uuid_kinds::TypedUuid<::omicron_uuid_kinds::CustomKind>,
         params: ::omicron_common::api::external::IdentityMetadataCreateParams,
     ) -> Self {
-        let now = ::chrono::Utc::now();
+        let now = ::omicron_common::now_db_precision();
         Self {
             id: crate::to_db_typed_uuid(id),
             name: params.name.into(),

--- a/nexus/db-macros/src/lib.rs
+++ b/nexus/db-macros/src/lib.rs
@@ -338,7 +338,7 @@ fn build_resource_identity(
                 id: #external_uuid_ty,
                 params: ::omicron_common::api::external::IdentityMetadataCreateParams
             ) -> Self {
-                let now = ::chrono::Utc::now();
+                let now = ::omicron_common::now_db_precision();
                 Self {
                     id: #convert_external_to_db,
                     name: params.name.into(),
@@ -383,7 +383,7 @@ fn build_asset_identity(
             pub fn new(
                 id: #external_uuid_ty,
             ) -> Self {
-                let now = ::chrono::Utc::now();
+                let now = ::omicron_common::now_db_precision();
                 Self {
                     id: #convert_external_to_db,
                     time_created: now,

--- a/nexus/inventory/src/builder.rs
+++ b/nexus/inventory/src/builder.rs
@@ -772,18 +772,7 @@ impl CollectionBuilder {
     }
 }
 
-/// Returns the current time, truncated to the previous microsecond.
-///
-/// This exists because the database doesn't store nanosecond-precision, so if
-/// we store nanosecond-precision timestamps, then DateTime conversion is lossy
-/// when round-tripping through the database.  That's rather inconvenient.
-pub fn now_db_precision() -> DateTime<Utc> {
-    let ts = Utc::now();
-    let nanosecs = ts.timestamp_subsec_nanos();
-    let micros = ts.timestamp_subsec_micros();
-    let only_nanos = nanosecs - micros * 1000;
-    ts - std::time::Duration::from_nanos(u64::from(only_nanos))
-}
+pub use omicron_common::now_db_precision;
 
 #[cfg(test)]
 mod test {


### PR DESCRIPTION
Currently, we return the in-memory representation of the disk model when creating a disk. However, if the system timestamp precision differs from the timestamp precision of TIMESTAMPTZ in cockroachdb, we can see different timestamp values for the create timestamp field at creation time and on a subsequent view. This patch uses the disk model read back from crdb in the return value for disk creation, such that timestamp fields will be consistent across create and view.

Fixes #9406.

cc @lgfa29. I was reminded of the workaround we added in the terraform provider here and wanted to chase it down. Confirmed the fix in https://github.com/oxidecomputer/terraform-provider-oxide/pull/629, although as of this writing some acceptance tests are failing for unrelated reasons 🙃.