### PR TITLE
make bgp max paths not null in db

### DIFF
--- a/nexus/db-model/src/schema_versions.rs
+++ b/nexus/db-model/src/schema_versions.rs
@@ -16,7 +16,7 @@ use std::{collections::BTreeMap, sync::LazyLock};
 ///
 /// This must be updated when you change the database schema.  Refer to
 /// schema/crdb/README.adoc in the root of this repository for details.
-pub const SCHEMA_VERSION: Version = Version::new(230, 0, 0);
+pub const SCHEMA_VERSION: Version = Version::new(231, 0, 0);
 
 /// List of all past database schema versions, in *reverse* order
 ///
@@ -28,6 +28,7 @@ static KNOWN_VERSIONS: LazyLock<Vec<KnownVersion>> = LazyLock::new(|| {
         // |  leaving the first copy as an example for the next person.
         // v
         // KnownVersion::new(next_int, "unique-dirname-with-the-sql-files"),
+        KnownVersion::new(231, "bgp-config-max-paths-not-null"),
         KnownVersion::new(230, "bgp-unnumbered-peers"),
         KnownVersion::new(229, "fix-session-token-column-order"),
         KnownVersion::new(228, "read-only-crucible-disks"),

--- a/schema/crdb/bgp-config-max-paths-not-null/up1.sql
+++ b/schema/crdb/bgp-config-max-paths-not-null/up1.sql
@@ -1,0 +1,6 @@
+-- Backfill any existing bgp_config rows that have NULL max_paths.
+-- The column was added as nullable in migration 230, but nexus
+-- rust code (SqlU8, not Option<SqlU8>) assumes it is NOT NULL.
+
+SET LOCAL disallow_full_table_scans = 'off';
+UPDATE omicron.public.bgp_config SET max_paths = 1 WHERE max_paths IS NULL;

--- a/schema/crdb/bgp-config-max-paths-not-null/up2.sql
+++ b/schema/crdb/bgp-config-max-paths-not-null/up2.sql
@@ -1,0 +1,4 @@
+-- Now that all existing rows have been backfilled, enforce NOT NULL.
+
+ALTER TABLE omicron.public.bgp_config
+  ALTER COLUMN max_paths SET NOT NULL;

--- a/schema/crdb/dbinit.sql
+++ b/schema/crdb/dbinit.sql
@@ -3751,7 +3751,7 @@ CREATE TABLE IF NOT EXISTS omicron.public.bgp_config (
     bgp_announce_set_id UUID NOT NULL,
     shaper TEXT,
     checker TEXT,
-    max_paths INT2 CHECK (max_paths > 0 AND max_paths <= 32)
+    max_paths INT2 NOT NULL CHECK (max_paths > 0 AND max_paths <= 32)
 );
 
 CREATE UNIQUE INDEX IF NOT EXISTS lookup_bgp_config_by_name ON omicron.public.bgp_config (
@@ -8192,7 +8192,7 @@ INSERT INTO omicron.public.db_metadata (
     version,
     target_version
 ) VALUES
-    (TRUE, NOW(), NOW(), '230.0.0', NULL)
+    (TRUE, NOW(), NOW(), '231.0.0', NULL)
 ON CONFLICT DO NOTHING;
 
 COMMIT;


### PR DESCRIPTION
Take 2 on issue noted in
- #9863 

Creates new database version 231 that makes `max_paths` not null and updates existing rows to have `max_paths` set to 1.