### PR TITLE
bump to v19

### DIFF
--- a/dev-tools/releng/src/main.rs
+++ b/dev-tools/releng/src/main.rs
@@ -46,7 +46,7 @@ use crate::job::Jobs;
 /// to as "v8", "version 8", or "release 8" to customers). The use of semantic
 /// versioning is mostly to hedge for perhaps wanting something more granular in
 /// the future.
-const BASE_VERSION: Version = Version::new(18, 0, 0);
+const BASE_VERSION: Version = Version::new(19, 0, 0);
 
 const RETRY_ATTEMPTS: usize = 3;
 


### PR DESCRIPTION
No longer bumping the API version in these pull requests as that is now being done as part of API versioning. Yay!