### PR TITLE
Use PostgreSQL v18 client libraries

### DIFF
--- a/package-manifest.toml
+++ b/package-manifest.toml
@@ -122,7 +122,7 @@ source.type = "local"
 source.rust.binary_names = ["nexus", "schema-updater"]
 source.rust.release = true
 source.paths = [
-  { from = "/opt/ooce/pgsql-13/lib/amd64", to = "/opt/ooce/pgsql-13/lib/amd64" },
+  { from = "/opt/ooce/pgsql-18/lib/amd64", to = "/opt/ooce/pgsql-18/lib/amd64" },
   { from = "smf/nexus/manifest.xml", to = "/var/svc/manifest/site/nexus/manifest.xml" },
   { from = "smf/nexus/{{rack-topology}}", to = "/var/svc/manifest/site/nexus" },
   { from = "out/console-assets", to = "/var/nexus/static" },
@@ -132,7 +132,8 @@ source.paths = [
 output.type = "zone"
 setup_hint = """
 - Run `cargo xtask download console` to download the web console assets
-- Run `pkg install library/postgresql-13` to download Postgres libraries
+- Run `pkg install library/postgresql-18` to download Postgres libraries
+- Run `pkg set-mediator -V 18 postgresql` to select the library version
 """
 output.intermediate_only = true
 
@@ -540,10 +541,14 @@ source.type = "local"
 source.paths = [
   { from = "smf/switch_zone_setup/manifest.xml", to = "/var/svc/manifest/site/switch_zone_setup/manifest.xml" },
   { from = "smf/switch_zone_setup/support_authorized_keys", to = "/opt/oxide/support/authorized_keys" },
-  { from = "/opt/ooce/pgsql-13/lib/amd64", to = "/opt/ooce/pgsql-13/lib/amd64" },
+  { from = "/opt/ooce/pgsql-18/lib/amd64", to = "/opt/ooce/pgsql-18/lib/amd64" },
 ]
 output.type = "zone"
 output.intermediate_only = true
+setup_hint = """
+- Run `pkg install library/postgresql-18` to download Postgres libraries
+- Run `pkg set-mediator -V 18 postgresql` to select the library version
+"""
 
 [package.sp-sim]
 service_name = "sp-sim"

--- a/tools/install_builder_prerequisites.sh
+++ b/tools/install_builder_prerequisites.sh
@@ -117,7 +117,7 @@ HOST_OS=$(uname -s)
 function install_packages {
   if [[ "${HOST_OS}" == "Linux" ]]; then
     # If Nix is in use, we don't need to install any packagess here,
-    # as they're provided by the Nix flake. 
+    # as they're provided by the Nix flake.
     if [[ "${OMICRON_USE_FLAKE-}" = 1 ]] && nix flake show &> /dev/null; then
       echo "OMICRON_USE_FLAKE=1 in environment and nix detected in PATH, skipping package installation"
       return
@@ -145,7 +145,7 @@ function install_packages {
     fi
   elif [[ "${HOST_OS}" == "SunOS" ]]; then
     CLANGVER=15
-    PGVER=13
+    PGVER=18
     packages=(
       "pkg:/package/pkg"
       "build-essential"
@@ -174,7 +174,8 @@ function install_packages {
     # Explicitly manage the return code using "rc" to observe the result of this
     # command without exiting the script entirely (due to bash's "errexit").
     rc=0
-    confirm "Install (or update) [${packages[*]}]?" && { pfexec pkg install -v "${packages[@]}" || rc=$?; }
+    confirm "Install (or update) [${packages[*]}]?" &&
+	{ pfexec pkg install -v "${packages[@]}" || rc=$?; }
     # Return codes:
     #  0: Normal Success
     #  4: Failure because we're already up-to-date. Also acceptable.
@@ -191,13 +192,19 @@ function install_packages {
     pkg publisher
     pkg list -afv "${packages[@]}"
   elif [[ "${HOST_OS}" == "Darwin" ]]; then
+    PGVER=18
     packages=(
-      'coreutils'
-      'postgresql@14'
-      'pkg-config'
-      'libxmlsec1'
+      "coreutils"
+      "postgresql@$PGVER"
+      "pkg-config"
+      "libxmlsec1"
     )
-    confirm "Install (or update) [${packages[*]}]?" && brew install "${packages[@]}"
+    confirm "Install (or update) [${packages[*]}]?" &&
+        brew install "${packages[@]}"
+    confirm "Set symlinks?" && {
+        brew unlink postgresql
+        brew link --force --overwrite postgresql@$PGVER
+    }
   else
     echo "Skipping builder prereqs for unsupported OS: ${HOST_OS}"
     exit 1
@@ -239,12 +246,12 @@ function show_hint
   case "$1" in
     "pg_config")
       if [[ "${HOST_OS}" == "SunOS" ]]; then
-        echo "On illumos, $1 is typically found in '/opt/ooce/bin'"
+        echo "On helios, $1 is typically found in '/opt/ooce/bin'"
       fi
       ;;
     "pkg-config")
       if [[ "${HOST_OS}" == "SunOS" ]]; then
-        echo "On illumos, $1 is typically found in '/usr/bin'"
+        echo "On helios, $1 is typically found in '/usr/bin'"
       fi
       ;;
     "cockroach")

--- a/tools/install_runner_prerequisites.sh
+++ b/tools/install_runner_prerequisites.sh
@@ -112,7 +112,7 @@ function install_packages {
   if [[ "${HOST_OS}" == "SunOS" ]]; then
     packages=(
       'pkg:/package/pkg'
-      'library/postgresql-13'
+      'library/postgresql-18'
       'pkg-config'
       'brand/omicron1/tools'
       'library/libxmlsec1'


### PR DESCRIPTION
As part of preparing for updating to HeliosV3, update the PostgreSQL client libraries used by
the `pq-sys` crate and nexus from version 13 to version 18. This is a version that is available
in both Heliosv2 and Heliosv3, easing migration later.

This will likely require developers to update build machines 

```
% pfexec pkg install library/postgresql-18
% pkg set-mediator -V 18 postgresql
```

Or re-running `tools/install_builder_prerequisites.sh` should do the same thing.