### PR TITLE
Fix ipv6 nic creation when only ipv4 addresses exist.

### DIFF
--- a/nexus/db-queries/src/db/queries/next_item.rs
+++ b/nexus/db-queries/src/db/queries/next_item.rs
@@ -787,6 +787,9 @@ where
             &self.scope_key,
         )?;
         out.push_sql(" AND ");
+        out.push_identifier(ItemColumn::NAME)?;
+        out.push_sql(" IS NOT NULL ");
+        out.push_sql(" AND ");
         out.push_identifier(TIME_DELETED_COLUMN_IDENT)?;
         out.push_sql(" IS NULL LIMIT 1)");
         Ok(())


### PR DESCRIPTION
Fix a bug in nic creation after adding ipv6 support. Previously, the `ip` column was `NOT NULL`, but ipv6 support made both the existing `ip` and new `ipv6` columns nullable. This revealed a bug in the next item helper, which didn't expect the item column to be null. As a result, creating an ipv6 address in a subnet that only previously had ipv4 addresses would silently fail: for example, creating a dual-stack instance in a subnet with only ipv4 addresses actually produced an ipv4-only instance.

This patch fixes the bug by checking that the item column is not null, and adds a regression test.

cc @lgfa29. This fixes at least one category of terraform test flake, but there may be other related flakes as well.