### PR TITLE
Error if requested nics aren't all created.

### DIFF
--- a/nexus/tests/integration_tests/subnet_allocation.rs
+++ b/nexus/tests/integration_tests/subnet_allocation.rs
@@ -176,8 +176,8 @@ async fn test_subnet_allocation(cptestctx: &ControlPlaneTestContext) {
     )
     .await;
     assert!(error.message.starts_with(&format!(
-        "No available IP addresses for interface in \
-        subnet '{SUBNET_NAME}' with ID '"
+        "No available IPv4 addresses for interface \
+        in subnet '{SUBNET_NAME}' with ID '"
     )));
 
     // Verify the subnet lists the two addresses as in use


### PR DESCRIPTION
This patch fixes a subtle and rare bug in instance creation. If the user requests an instance with a v4-only nic or a v6-only nic and there isn't an available address in the subet, the request will fail due to a sql constraint requiring at least one of ip and ipv6 to be not null. However, if the user requests a dual-stack nic and one address type (but not the other) is exhausted, the sql constraint is satisfied, and the request succeeds. But the created nic won't have both requested address types.

This patch adds a check after the query runs to ensure that all requested address types were created, and fail if they weren't.

Note: this is a nit-picky follow-up to #9880. This bug would be pretty hard to tickle in real life, but I wanted to submit the fix for completeness.