### PR TITLE
Fix external subnet creation error handling and enforce pool-silo linking

### DIFF
--- a/nexus/db-queries/src/db/datastore/external_subnet.rs
+++ b/nexus/db-queries/src/db/datastore/external_subnet.rs
@@ -648,6 +648,7 @@ impl DataStore {
     ) -> CreateResult<ExternalSubnet> {
         opctx.authorize(authz::Action::CreateChild, authz_project).await?;
         let ExternalSubnetCreate { identity, allocator } = params;
+        let subnet_name = identity.name.to_string();
         let identity =
             ExternalSubnetIdentity::new(ExternalSubnetUuid::new_v4(), identity);
         insert_external_subnet_query(
@@ -664,6 +665,7 @@ impl DataStore {
                 silo_id,
                 authz_project,
                 &allocator,
+                &subnet_name,
             )
         })
     }

--- a/nexus/db-queries/src/db/queries/external_subnet.rs
+++ b/nexus/db-queries/src/db/queries/external_subnet.rs
@@ -794,13 +794,21 @@ fn push_cte_to_select_pool_id(builder: &mut QueryBuilder, pool: &NameOrId) {
 
 // Push a CTE that fails with a bool-parse error if the current Pool is not
 // linked to the current Silo.
+//
+// MATERIALIZED forces CockroachDB to evaluate this CTE even though it isn't
+// referenced by downstream CTEs. Without it, the optimizer could elide the
+// check entirely.
+//
+// The sentinel string is inlined as a SQL literal rather than a bind parameter
+// so that it appears verbatim in the bool-parse error message. A bind parameter
+// would show up as `$N`, which `is_bool_parse_error` wouldn't match.
 fn push_cte_to_ensure_pool_is_linked_to_silo(
     builder: &mut QueryBuilder,
     silo_id: &Uuid,
 ) {
     builder
         .sql(
-            "ensure_silo_is_linked_to_pool AS (\
+            "ensure_silo_is_linked_to_pool AS MATERIALIZED(\
         SELECT CAST(IF(EXISTS((\
             SELECT 1 \
             FROM subnet_pool_silo_link AS l \
@@ -810,8 +818,7 @@ fn push_cte_to_ensure_pool_is_linked_to_silo(
         .param()
         .bind::<sql_types::Uuid, _>(*silo_id)
         .sql(")), 'true', '")
-        .param()
-        .bind::<sql_types::Text, _>(REQUESTED_POOL_NOT_LINKED_TO_SILO_SENTINEL)
+        .sql(REQUESTED_POOL_NOT_LINKED_TO_SILO_SENTINEL)
         .sql("') AS BOOL))");
 }
 
@@ -1078,6 +1085,7 @@ pub fn decode_insert_external_subnet_error(
     silo_id: &Uuid,
     authz_project: &authz::Project,
     subnet: &ExternalSubnetAllocator,
+    subnet_name: &str,
 ) -> Error {
     match &e {
         DieselError::DatabaseError(DatabaseErrorKind::Unknown, info) => {
@@ -1138,18 +1146,21 @@ pub fn decode_insert_external_subnet_error(
                         LookupType::ByName(name.to_string())
                     }
                 };
-                public_error_from_diesel(
-                    e,
-                    ErrorHandler::NotFoundByLookup(
-                        ResourceType::SubnetPool,
-                        lookup_type,
-                    ),
-                )
+                lookup_type.into_not_found(ResourceType::SubnetPool)
             } else if msg == "result out of range" {
                 report_exhaustion(subnet)
             } else {
                 public_error_from_diesel(e, ErrorHandler::Server)
             }
+        }
+        DieselError::DatabaseError(DatabaseErrorKind::UniqueViolation, _) => {
+            public_error_from_diesel(
+                e,
+                ErrorHandler::Conflict(
+                    ResourceType::ExternalSubnet,
+                    subnet_name,
+                ),
+            )
         }
         DieselError::NotFound => report_exhaustion(subnet),
         _ => public_error_from_diesel(e, ErrorHandler::Server),

--- a/nexus/src/app/background/tasks/attached_subnets.rs
+++ b/nexus/src/app/background/tasks/attached_subnets.rs
@@ -445,10 +445,10 @@ mod test {
     use nexus_db_model::IpAttachState;
     use nexus_db_schema::schema::external_subnet::dsl;
     use nexus_test_utils::resource_helpers::create_default_ip_pools;
+    use nexus_test_utils::resource_helpers::create_default_subnet_pool;
     use nexus_test_utils::resource_helpers::create_external_subnet_in_pool;
     use nexus_test_utils::resource_helpers::create_instance;
     use nexus_test_utils::resource_helpers::create_project;
-    use nexus_test_utils::resource_helpers::create_subnet_pool;
     use nexus_test_utils::resource_helpers::create_subnet_pool_member;
     use nexus_test_utils_macros::nexus_test;
     use omicron_common::address::IpVersion;
@@ -567,7 +567,7 @@ mod test {
 
         // Create a resource hierarchy.
         let _subnet_pool =
-            create_subnet_pool(client, "apple", IpVersion::V6).await;
+            create_default_subnet_pool(client, "apple", IpVersion::V6).await;
         let _member = create_subnet_pool_member(
             client,
             "apple",

--- a/nexus/src/app/sagas/subnet_attach.rs
+++ b/nexus/src/app/sagas/subnet_attach.rs
@@ -263,10 +263,10 @@ pub(crate) mod test {
     use nexus_db_lookup::LookupPath;
     use nexus_db_queries::context::OpContext;
     use nexus_test_utils::resource_helpers::create_default_ip_pools;
+    use nexus_test_utils::resource_helpers::create_default_subnet_pool;
     use nexus_test_utils::resource_helpers::create_external_subnet_in_pool;
     use nexus_test_utils::resource_helpers::create_instance;
     use nexus_test_utils::resource_helpers::create_project;
-    use nexus_test_utils::resource_helpers::create_subnet_pool;
     use nexus_test_utils::resource_helpers::create_subnet_pool_member;
     use nexus_test_utils_macros::nexus_test;
     use nexus_types::external_api::external_subnet;
@@ -299,7 +299,8 @@ pub(crate) mod test {
 
     async fn setup_test(client: &ClientTestContext) -> Context {
         let subnet_pool =
-            create_subnet_pool(client, SUBNET_POOL_NAME, IpVersion::V4).await;
+            create_default_subnet_pool(client, SUBNET_POOL_NAME, IpVersion::V4)
+                .await;
         let member = create_subnet_pool_member(
             client,
             SUBNET_POOL_NAME,

--- a/nexus/src/app/sagas/subnet_detach.rs
+++ b/nexus/src/app/sagas/subnet_detach.rs
@@ -272,10 +272,10 @@ pub(crate) mod test {
     use crate::app::sagas::test_helpers;
     use nexus_db_lookup::LookupPath;
     use nexus_test_utils::resource_helpers::create_default_ip_pools;
+    use nexus_test_utils::resource_helpers::create_default_subnet_pool;
     use nexus_test_utils::resource_helpers::create_external_subnet_in_pool;
     use nexus_test_utils::resource_helpers::create_instance;
     use nexus_test_utils::resource_helpers::create_project;
-    use nexus_test_utils::resource_helpers::create_subnet_pool;
     use nexus_test_utils::resource_helpers::create_subnet_pool_member;
     use nexus_test_utils_macros::nexus_test;
     use nexus_types::external_api::external_subnet::ExternalSubnet;
@@ -314,7 +314,8 @@ pub(crate) mod test {
         let datastore = cptestctx.server.server_context().nexus.datastore();
 
         let subnet_pool =
-            create_subnet_pool(client, SUBNET_POOL_NAME, IpVersion::V4).await;
+            create_default_subnet_pool(client, SUBNET_POOL_NAME, IpVersion::V4)
+                .await;
         let member = create_subnet_pool_member(
             client,
             SUBNET_POOL_NAME,

--- a/nexus/test-utils/src/resource_helpers.rs
+++ b/nexus/test-utils/src/resource_helpers.rs
@@ -434,6 +434,23 @@ pub async fn create_subnet_pool(
     .await
 }
 
+/// Create a subnet pool and link it to the default silo.
+pub async fn create_default_subnet_pool(
+    client: &ClientTestContext,
+    pool_name: &str,
+    ip_version: IpVersion,
+) -> SubnetPool {
+    let pool = create_subnet_pool(client, pool_name, ip_version).await;
+    link_subnet_pool(
+        client,
+        pool_name,
+        &nexus_types::silo::DEFAULT_SILO_ID,
+        true,
+    )
+    .await;
+    pool
+}
+
 /// Create a subnet pool member, with the min / max prefix lengths taken from
 /// the subnet itself.
 pub async fn create_subnet_pool_member(


### PR DESCRIPTION
Closes #9872
Closes #9873

This turned out to be a lot more interesting than I expected. Three bugs fixed:

1. The `ensure_silo_is_linked_to_pool` CTE was not `MATERIALIZED` and not referenced by any downstream CTE, so CockroachDB never evaluated it. This meant pool-silo linking was never enforced on the Auto/Explicit allocation path. Adding `MATERIALIZED` fixes both the nonexistent pool error (#9872, since a nonexistent pool is trivially not linked) and starts enforcing pool-silo linking for the first time on this path.

2. The sentinel value in the CTE was bound as a query parameter (`$N`) instead of being embedded directly in the SQL. CockroachDB error messages contain the literal placeholder, so `is_bool_parse_error` never matched.

3. The error decoder did not handle `DatabaseErrorKind::UniqueViolation`, so name conflicts fell through to `ErrorHandler::Server` (500). Now returns `ObjectAlreadyExists`.

Also fixes the error decoder to construct the 404 directly via `LookupType::into_not_found` instead of routing through `public_error_from_diesel`, which would return 500 for `DatabaseError` variants.

Updates all tests to use a helper that creates and links a pool in one call, matching the pattern used by IP pool tests.