### PR TITLE
BUGFIX: Static routes flapping due to missing comparison logic

### DIFF
--- a/nexus/src/app/background/tasks/sync_switch_configuration.rs
+++ b/nexus/src/app/background/tasks/sync_switch_configuration.rs
@@ -1845,7 +1845,7 @@ struct SwitchStaticRouteV4 {
     nexthop: Ipv4Addr,
     prefix: Prefix4,
     vlan: Option<u16>,
-    priority: Option<u8>,
+    priority: u8,
 }
 
 #[derive(PartialEq, Eq, Hash, Debug)]
@@ -1853,7 +1853,7 @@ struct SwitchStaticRouteV6 {
     nexthop: Ipv6Addr,
     prefix: Prefix6,
     vlan: Option<u16>,
-    priority: Option<u8>,
+    priority: u8,
 }
 
 #[derive(PartialEq, Eq, Hash, Debug)]
@@ -1885,9 +1885,7 @@ fn static_routes_to_del(
                             nexthop: x.nexthop,
                             prefix: x.prefix,
                             vlan_id: x.vlan,
-                            rib_priority: x
-                                .priority
-                                .unwrap_or(DEFAULT_RIB_PRIORITY_STATIC),
+                            rib_priority: x.priority,
                         })
                     }
                     SwitchStaticRoute::V6(x) => {
@@ -1895,9 +1893,7 @@ fn static_routes_to_del(
                             nexthop: x.nexthop,
                             prefix: x.prefix,
                             vlan_id: x.vlan,
-                            rib_priority: x
-                                .priority
-                                .unwrap_or(DEFAULT_RIB_PRIORITY_STATIC),
+                            rib_priority: x.priority,
                         })
                     }
                 }
@@ -1913,9 +1909,7 @@ fn static_routes_to_del(
                             nexthop: x.nexthop,
                             prefix: x.prefix,
                             vlan_id: x.vlan,
-                            rib_priority: x
-                                .priority
-                                .unwrap_or(DEFAULT_RIB_PRIORITY_STATIC),
+                            rib_priority: x.priority,
                         })
                     }
                     SwitchStaticRoute::V6(x) => {
@@ -1923,9 +1917,7 @@ fn static_routes_to_del(
                             nexthop: x.nexthop,
                             prefix: x.prefix,
                             vlan_id: x.vlan,
-                            rib_priority: x
-                                .priority
-                                .unwrap_or(DEFAULT_RIB_PRIORITY_STATIC),
+                            rib_priority: x.priority,
                         })
                     }
                 }
@@ -1978,9 +1970,7 @@ fn static_routes_to_add(
                         nexthop: x.nexthop,
                         prefix: x.prefix,
                         vlan_id: x.vlan,
-                        rib_priority: x
-                            .priority
-                            .unwrap_or(DEFAULT_RIB_PRIORITY_STATIC),
+                        rib_priority: x.priority,
                     })
                 }
                 SwitchStaticRoute::V6(x) => {
@@ -1988,9 +1978,7 @@ fn static_routes_to_add(
                         nexthop: x.nexthop,
                         prefix: x.prefix,
                         vlan_id: x.vlan,
-                        rib_priority: x
-                            .priority
-                            .unwrap_or(DEFAULT_RIB_PRIORITY_STATIC),
+                        rib_priority: x.priority,
                     })
                 }
             }
@@ -2039,8 +2027,8 @@ fn static_routes_in_db(
                     // and instead want to use an enum to more accurately represent what
                     // is happening.
                     let priority = match route.rib_priority {
-                        Some(v) => Some(v.0),
-                        None => Some(DEFAULT_RIB_PRIORITY_STATIC),
+                        Some(v) => v.0,
+                        None => DEFAULT_RIB_PRIORITY_STATIC,
                     };
                     routes.insert(SwitchStaticRoute::V4(SwitchStaticRouteV4 {
                         nexthop,
@@ -2059,8 +2047,8 @@ fn static_routes_in_db(
                     // and instead want to use an enum to more accurately represent what
                     // is happening.
                     let priority = match route.rib_priority {
-                        Some(v) => Some(v.0),
-                        None => Some(DEFAULT_RIB_PRIORITY_STATIC),
+                        Some(v) => v.0,
+                        None => DEFAULT_RIB_PRIORITY_STATIC,
                     };
                     routes.insert(SwitchStaticRoute::V6(SwitchStaticRouteV6 {
                         nexthop,
@@ -2310,7 +2298,7 @@ async fn static_routes_on_switch(
                                 nexthop: addr,
                                 prefix: dst,
                                 vlan: p.vlan_id,
-                                priority: Some(p.rib_priority),
+                                priority: p.rib_priority,
                             },
                         ));
                     }
@@ -2328,7 +2316,7 @@ async fn static_routes_on_switch(
                                 nexthop: addr,
                                 prefix: dst,
                                 vlan: p.vlan_id,
-                                priority: Some(p.rib_priority),
+                                priority: p.rib_priority,
                             },
                         ));
                     }


### PR DESCRIPTION
It was found that the switch sync background task was removing and adding the same route repeatedly. This is due to the static route being stored in the DB with no value set for the `rib_priority` field, which deserializes to `None`. We need to fill this value in with the default value before comparing it to the route that is active in `mgd`, as the mgd route will have the default value instead of `None`.

It the future we plan to make this less cumbersome by putting stronger types around this data, but we need bootstore versioning before implementing such types.

## Testing
Changes were tested using a local single node deployment of `omicron`

### Before
```
21:33:34.429Z INFO 8d40ca16-5146-4f5b-b56f-4cdfce6ccff8 (ServerContext): retrieved existing routes
    background_task = switch_port_config_manager
    file = nexus/src/app/background/tasks/sync_switch_configuration.rs:433
    rack_id = 8309decf-e513-4e46-806b-060f95608a61
    routes = {Switch0: {V4(SwitchStaticRouteV4 { nexthop: 10.8.0.1, prefix: Prefix4 { value: 0.0.0.0, length: 0 }, vlan: None, priority: Some(1) })}}
21:33:34.429Z INFO 8d40ca16-5146-4f5b-b56f-4cdfce6ccff8 (ServerContext): retrieved desired routes
    background_task = switch_port_config_manager
    file = nexus/src/app/background/tasks/sync_switch_configuration.rs:437
    rack_id = 8309decf-e513-4e46-806b-060f95608a61
    routes = {Switch0: {V4(SwitchStaticRouteV4 { nexthop: 10.8.0.1, prefix: Prefix4 { value: 0.0.0.0, length: 0 }, vlan: None, priority: None })}}
21:33:34.429Z INFO 8d40ca16-5146-4f5b-b56f-4cdfce6ccff8 (ServerContext): calculated static routes to add
    background_task = switch_port_config_manager
    file = nexus/src/app/background/tasks/sync_switch_configuration.rs:446
    rack_id = 8309decf-e513-4e46-806b-060f95608a61
    routes = {Switch0: AddStaticRouteRequest { v4: AddStaticRoute4Request { routes: StaticRoute4List { list: [StaticRoute4 { nexthop: 10.8.0.1, prefix: Prefix4 { valu
e: 0.0.0.0, length: 0 }, rib_priority: 1, vlan_id: None }] } }, v6: AddStaticRoute6Request { routes: StaticRoute6List { list: [] } } }}
21:33:34.429Z INFO 8d40ca16-5146-4f5b-b56f-4cdfce6ccff8 (ServerContext): calculated static routes to delete
    background_task = switch_port_config_manager
    file = nexus/src/app/background/tasks/sync_switch_configuration.rs:452
    rack_id = 8309decf-e513-4e46-806b-060f95608a61
    routes = {Switch0: DeleteStaticRouteRequest { v4: DeleteStaticRoute4Request { routes: StaticRoute4List { list: [StaticRoute4 { nexthop: 10.8.0.1, prefix: Prefix4
{ value: 0.0.0.0, length: 0 }, rib_priority: 1, vlan_id: None }] } }, v6: DeleteStaticRoute6Request { routes: StaticRoute6List { list: [] } } }}
```

### After
```
21:58:15.357Z INFO a9235b08-9002-440f-abce-7a00c7fdbfaa (ServerContext): retrieved existing routes
    background_task = switch_port_config_manager
    file = nexus/src/app/background/tasks/sync_switch_configuration.rs:433
    rack_id = ef46c585-94dc-4c00-87c8-e21a8259b4f8
    routes = {Switch0: {V4(SwitchStaticRouteV4 { nexthop: 10.8.0.1, prefix: Prefix4 { value: 0.0.0.0, length: 0 }, vlan: None, priority: Some(1) })}}
21:58:15.357Z INFO a9235b08-9002-440f-abce-7a00c7fdbfaa (ServerContext): retrieved desired routes
    background_task = switch_port_config_manager
    file = nexus/src/app/background/tasks/sync_switch_configuration.rs:437
    rack_id = ef46c585-94dc-4c00-87c8-e21a8259b4f8
    routes = {Switch0: {V4(SwitchStaticRouteV4 { nexthop: 10.8.0.1, prefix: Prefix4 { value: 0.0.0.0, length: 0 }, vlan: None, priority: Some(1) })}}
21:58:15.357Z INFO a9235b08-9002-440f-abce-7a00c7fdbfaa (ServerContext): calculated static routes to add
    background_task = switch_port_config_manager
    file = nexus/src/app/background/tasks/sync_switch_configuration.rs:446
    rack_id = ef46c585-94dc-4c00-87c8-e21a8259b4f8
    routes = {}
21:58:15.357Z INFO a9235b08-9002-440f-abce-7a00c7fdbfaa (ServerContext): calculated static routes to delete
    background_task = switch_port_config_manager
    file = nexus/src/app/background/tasks/sync_switch_configuration.rs:452
    rack_id = ef46c585-94dc-4c00-87c8-e21a8259b4f8
    routes = {}
```