### PR TITLE
bootstore type reorg PR 4/?: Move latest `BgpPeer` and `SwitchPortSettings` from `common` to `nexus-types`

### DIFF
--- a/common/src/api/external/mod.rs
+++ b/common/src/api/external/mod.rs
@@ -2894,39 +2894,6 @@ pub struct SwitchPortSettingsIdentity {
     pub identity: IdentityMetadata,
 }
 
-/// This structure contains all port settings information in one place. It's a
-/// convenience data structure for getting a complete view of a particular
-/// port's settings.
-#[derive(Clone, Debug, Deserialize, JsonSchema, Serialize, PartialEq)]
-pub struct SwitchPortSettings {
-    #[serde(flatten)]
-    pub identity: IdentityMetadata,
-
-    /// Switch port settings included from other switch port settings groups.
-    pub groups: Vec<SwitchPortSettingsGroups>,
-
-    /// Layer 1 physical port settings.
-    pub port: SwitchPortConfig,
-
-    /// Layer 2 link settings.
-    pub links: Vec<SwitchPortLinkConfig>,
-
-    /// Layer 3 interface settings.
-    pub interfaces: Vec<SwitchInterfaceConfig>,
-
-    /// Vlan interface settings.
-    pub vlan_interfaces: Vec<SwitchVlanInterfaceConfig>,
-
-    /// IP route settings.
-    pub routes: Vec<SwitchPortRouteConfig>,
-
-    /// BGP peer settings.
-    pub bgp_peers: Vec<BgpPeer>,
-
-    /// Layer 3 IP address settings.
-    pub addresses: Vec<SwitchPortAddressView>,
-}
-
 /// This structure maps a port settings object to a port settings groups. Port
 /// settings objects may inherit settings from groups. This mapping defines the
 /// relationship between settings objects and the groups they reference.
@@ -3234,78 +3201,6 @@ pub struct SwitchPortRouteConfig {
     /// Route RIB priority. Higher priority indicates precedence within and across
     /// protocols.
     pub rib_priority: Option<u8>,
-}
-
-/// A BGP peer configuration for an interface. Includes the set of announcements
-/// that will be advertised to the peer identified by `addr`. The `bgp_config`
-/// parameter is a reference to global BGP parameters. The `interface_name`
-/// indicates what interface the peer should be contacted on.
-#[derive(Clone, Debug, Deserialize, Serialize, JsonSchema, PartialEq)]
-pub struct BgpPeer {
-    /// The global BGP configuration used for establishing a session with this
-    /// peer.
-    pub bgp_config: NameOrId,
-
-    /// The name of interface to peer on. This is relative to the port
-    /// configuration this BGP peer configuration is a part of. For example this
-    /// value could be phy0 to refer to a primary physical interface. Or it
-    /// could be vlan47 to refer to a VLAN interface.
-    pub interface_name: Name,
-
-    /// The address of the host to peer with. If not provided, this is an
-    /// unnumbered BGP session that will be established over the interface
-    /// specified by `interface_name`.
-    pub addr: Option<IpAddr>,
-
-    /// How long to hold peer connections between keepalives (seconds).
-    pub hold_time: u32,
-
-    /// How long to hold a peer in idle before attempting a new session
-    /// (seconds).
-    pub idle_hold_time: u32,
-
-    /// How long to delay sending an open request after establishing a TCP
-    /// session (seconds).
-    pub delay_open: u32,
-
-    /// How long to to wait between TCP connection retries (seconds).
-    pub connect_retry: u32,
-
-    /// How often to send keepalive requests (seconds).
-    pub keepalive: u32,
-
-    /// Require that a peer has a specified ASN.
-    pub remote_asn: Option<u32>,
-
-    /// Require messages from a peer have a minimum IP time to live field.
-    pub min_ttl: Option<u8>,
-
-    /// Use the given key for TCP-MD5 authentication with the peer.
-    pub md5_auth_key: Option<String>,
-
-    /// Apply the provided multi-exit discriminator (MED) updates sent to the peer.
-    pub multi_exit_discriminator: Option<u32>,
-
-    /// Include the provided communities in updates sent to the peer.
-    pub communities: Vec<u32>,
-
-    /// Apply a local preference to routes received from this peer.
-    pub local_pref: Option<u32>,
-
-    /// Enforce that the first AS in paths received from this peer is the peer's AS.
-    pub enforce_first_as: bool,
-
-    /// Define import policy for a peer.
-    pub allowed_import: ImportExportPolicy,
-
-    /// Define export policy for a peer.
-    pub allowed_export: ImportExportPolicy,
-
-    /// Associate a VLAN ID with a peer.
-    pub vlan_id: Option<u16>,
-
-    /// Router lifetime in seconds for unnumbered BGP peers.
-    pub router_lifetime: u16,
 }
 
 /// A base BGP configuration.

--- a/nexus/db-model/src/switch_port.rs
+++ b/nexus/db-model/src/switch_port.rs
@@ -22,7 +22,7 @@ use nexus_db_schema::schema::{
 use nexus_types::external_api::networking as networking_types;
 use nexus_types::identity::Resource;
 use omicron_common::api::external;
-use omicron_common::api::external::{BgpPeer, ImportExportPolicy};
+use omicron_common::api::external::ImportExportPolicy;
 use omicron_common::api::internal::shared::{PortFec, PortSpeed};
 use serde::{Deserialize, Serialize};
 use uuid::Uuid;
@@ -741,7 +741,7 @@ impl SwitchPortBgpPeerConfig {
         port_settings_id: Uuid,
         bgp_config_id: Uuid,
         interface_name: Name,
-        p: &BgpPeer,
+        p: &networking_types::BgpPeer,
     ) -> Self {
         Self {
             id: Uuid::new_v4(),

--- a/nexus/db-queries/src/db/datastore/switch_port.rs
+++ b/nexus/db-queries/src/db/datastore/switch_port.rs
@@ -70,9 +70,9 @@ pub struct BgpPeerConfig {
     pub router_lifetime: SqlU16,
 }
 
-impl Into<external::BgpPeer> for BgpPeerConfig {
-    fn into(self) -> external::BgpPeer {
-        external::BgpPeer {
+impl Into<networking::BgpPeer> for BgpPeerConfig {
+    fn into(self) -> networking::BgpPeer {
+        networking::BgpPeer {
             bgp_config: self.bgp_config_id.into(),
             interface_name: self.interface_name.into(),
             addr: self.addr.map(|a| a.ip()),
@@ -131,9 +131,9 @@ impl SwitchPortSettingsCombinedResult {
     }
 }
 
-impl Into<external::SwitchPortSettings> for SwitchPortSettingsCombinedResult {
-    fn into(self) -> external::SwitchPortSettings {
-        external::SwitchPortSettings {
+impl Into<networking::SwitchPortSettings> for SwitchPortSettingsCombinedResult {
+    fn into(self) -> networking::SwitchPortSettings {
+        networking::SwitchPortSettings {
             identity: self.settings.identity(),
             port: self.port.into(),
             groups: self.groups.into_iter().map(Into::into).collect(),
@@ -1398,7 +1398,7 @@ async fn do_switch_port_settings_create(
     .get_results_async(conn)
     .await?;
 
-    let mut peer_by_addr: BTreeMap<IpAddr, &external::BgpPeer> =
+    let mut peer_by_addr: BTreeMap<IpAddr, &networking::BgpPeer> =
         BTreeMap::new();
 
     let mut bgp_peer_config = Vec::new();
@@ -1869,12 +1869,11 @@ mod test {
     use crate::db::datastore::UpdatePrecondition;
     use crate::db::pub_test_utils::TestDatabase;
     use nexus_types::external_api::networking::{
-        BgpAnnounceSetCreate, BgpConfigCreate, BgpPeerConfig,
+        BgpAnnounceSetCreate, BgpConfigCreate, BgpPeer, BgpPeerConfig,
         SwitchPortConfigCreate, SwitchPortGeometry, SwitchPortSettingsCreate,
     };
     use omicron_common::api::external::{
-        BgpPeer, IdentityMetadataCreateParams, ImportExportPolicy, Name,
-        NameOrId,
+        IdentityMetadataCreateParams, ImportExportPolicy, Name, NameOrId,
     };
     use omicron_test_utils::dev;
     use std::{collections::HashMap, str::FromStr};

--- a/nexus/external-api/src/lib.rs
+++ b/nexus/external-api/src/lib.rs
@@ -4325,7 +4325,10 @@ pub trait NexusExternalApi {
     async fn networking_switch_port_settings_create(
         rqctx: RequestContext<Self::Context>,
         new_settings: TypedBody<latest::networking::SwitchPortSettingsCreate>,
-    ) -> Result<HttpResponseCreated<SwitchPortSettings>, HttpError>;
+    ) -> Result<
+        HttpResponseCreated<latest::networking::SwitchPortSettings>,
+        HttpError,
+    >;
 
     /// Create switch port settings (old version with required BgpPeer.addr)
     #[endpoint {
@@ -4394,7 +4397,7 @@ pub trait NexusExternalApi {
     async fn networking_switch_port_settings_view(
         rqctx: RequestContext<Self::Context>,
         path_params: Path<latest::networking::SwitchPortSettingsInfoSelector>,
-    ) -> Result<HttpResponseOk<SwitchPortSettings>, HttpError>;
+    ) -> Result<HttpResponseOk<latest::networking::SwitchPortSettings>, HttpError>;
 
     /// Get information about switch port (old version with required BgpPeer.addr)
     #[endpoint {

--- a/nexus/src/app/rack.rs
+++ b/nexus/src/app/rack.rs
@@ -31,7 +31,6 @@ use nexus_types::inventory::SpType;
 use nexus_types::silo::silo_dns_name;
 use omicron_common::address::{Ipv6Subnet, RACK_PREFIX, get_64_subnet};
 use omicron_common::api::external::AddressLotKind;
-use omicron_common::api::external::BgpPeer;
 use omicron_common::api::external::DataPageParams;
 use omicron_common::api::external::Error;
 use omicron_common::api::external::IdentityMetadataCreateParams;
@@ -595,10 +594,10 @@ impl super::Nexus {
                 routes,
             });
 
-            let peers: Vec<BgpPeer> = uplink_config
+            let peers: Vec<networking::BgpPeer> = uplink_config
                 .bgp_peers
                 .iter()
-                .map(|r| BgpPeer {
+                .map(|r| networking::BgpPeer {
                     bgp_config: NameOrId::Name(
                         format!("as{}", r.asn).parse().unwrap(),
                     ),

--- a/nexus/src/external_api/http_entrypoints.rs
+++ b/nexus/src/external_api/http_entrypoints.rs
@@ -99,7 +99,6 @@ use omicron_common::api::external::RouterRoute;
 use omicron_common::api::external::RouterRouteKind;
 use omicron_common::api::external::ServiceIcmpConfig;
 use omicron_common::api::external::SwitchPort;
-use omicron_common::api::external::SwitchPortSettings;
 use omicron_common::api::external::SwitchPortSettingsIdentity;
 use omicron_common::api::external::VpcFirewallRuleUpdateParams;
 use omicron_common::api::external::VpcFirewallRules;
@@ -4056,12 +4055,13 @@ impl NexusExternalApi for NexusExternalApiImpl {
     async fn networking_switch_port_settings_create(
         rqctx: RequestContext<ApiContext>,
         new_settings: TypedBody<networking::SwitchPortSettingsCreate>,
-    ) -> Result<HttpResponseCreated<SwitchPortSettings>, HttpError> {
+    ) -> Result<HttpResponseCreated<networking::SwitchPortSettings>, HttpError>
+    {
         audit_and_time(&rqctx, |opctx, nexus| async move {
             let params = new_settings.into_inner();
             let result =
                 nexus.switch_port_settings_post(&opctx, params).await?;
-            let settings: SwitchPortSettings = result.into();
+            let settings: networking::SwitchPortSettings = result.into();
             Ok(HttpResponseCreated(settings))
         })
         .await
@@ -4120,7 +4120,7 @@ impl NexusExternalApi for NexusExternalApiImpl {
     async fn networking_switch_port_settings_view(
         rqctx: RequestContext<ApiContext>,
         path_params: Path<networking::SwitchPortSettingsInfoSelector>,
-    ) -> Result<HttpResponseOk<SwitchPortSettings>, HttpError> {
+    ) -> Result<HttpResponseOk<networking::SwitchPortSettings>, HttpError> {
         let apictx = rqctx.context();
         let handler = async {
             let nexus = &apictx.context.nexus;

--- a/nexus/tests/integration_tests/switch_port.rs
+++ b/nexus/tests/integration_tests/switch_port.rs
@@ -12,15 +12,15 @@ use nexus_test_utils::http_testing::{AuthnMode, NexusRequest, RequestBuilder};
 use nexus_test_utils_macros::nexus_test;
 use nexus_types::external_api::networking::{
     Address, AddressConfig, AddressLotBlockCreate, AddressLotCreate,
-    BgpAnnounceSetCreate, BgpAnnouncementCreate, BgpConfigCreate,
+    BgpAnnounceSetCreate, BgpAnnouncementCreate, BgpConfigCreate, BgpPeer,
     BgpPeerConfig, LinkConfigCreate, LldpLinkConfigCreate, Route, RouteConfig,
     SwitchInterfaceConfigCreate, SwitchInterfaceKind, SwitchPortApplySettings,
-    SwitchPortSettingsCreate,
+    SwitchPortSettings, SwitchPortSettingsCreate,
 };
 use nexus_types::external_api::rack::Rack;
 use omicron_common::api::external::{
-    self, AddressLotKind, BgpPeer, IdentityMetadataCreateParams, LinkFec,
-    LinkSpeed, NameOrId, SwitchLocation, SwitchPort, SwitchPortSettings,
+    self, AddressLotKind, IdentityMetadataCreateParams, LinkFec, LinkSpeed,
+    NameOrId, SwitchLocation, SwitchPort,
 };
 use omicron_common::api::external::{ImportExportPolicy, Name};
 use oxnet::IpNet;

--- a/nexus/types/versions/src/bgp_unnumbered_peers/networking.rs
+++ b/nexus/types/versions/src/bgp_unnumbered_peers/networking.rs
@@ -6,15 +6,17 @@
 //!
 //! This version:
 //! - Adds `max_paths` to `BgpConfigCreate`.
-//! - Uses `external::BgpPeer` (optional `addr`, `router_lifetime`) in
-//!   `BgpPeerConfig`.
+//! - `BgpPeer`: makes `addr` optional; adds `router_lifetime`
+//! - Updates `SwitchPortSettings` to use the new `BgpPeer`
 //! - Updates `SwitchPortSettingsCreate` to use the new `BgpPeerConfig`.
 
 use omicron_common::api::external::{
-    self, IdentityMetadataCreateParams, MaxPathConfig, Name, NameOrId,
+    self, IdentityMetadata, IdentityMetadataCreateParams, MaxPathConfig, Name,
+    NameOrId,
 };
 use schemars::JsonSchema;
 use serde::{Deserialize, Serialize};
+use std::net::IpAddr;
 
 /// Parameters for creating a BGP configuration. This includes an autonomous
 /// system number (ASN) and a virtual routing and forwarding (VRF) identifier.
@@ -61,6 +63,138 @@ impl From<crate::v2025_11_20_00::networking::BgpConfigCreate>
     }
 }
 
+/// A BGP peer configuration for an interface. Includes the set of announcements
+/// that will be advertised to the peer identified by `addr`. The `bgp_config`
+/// parameter is a reference to global BGP parameters. The `interface_name`
+/// indicates what interface the peer should be contacted on.
+#[derive(Clone, Debug, Deserialize, Serialize, JsonSchema, PartialEq)]
+pub struct BgpPeer {
+    /// The global BGP configuration used for establishing a session with this
+    /// peer.
+    pub bgp_config: NameOrId,
+
+    /// The name of interface to peer on. This is relative to the port
+    /// configuration this BGP peer configuration is a part of. For example this
+    /// value could be phy0 to refer to a primary physical interface. Or it
+    /// could be vlan47 to refer to a VLAN interface.
+    pub interface_name: Name,
+
+    /// The address of the host to peer with. If not provided, this is an
+    /// unnumbered BGP session that will be established over the interface
+    /// specified by `interface_name`.
+    pub addr: Option<IpAddr>,
+
+    /// How long to hold peer connections between keepalives (seconds).
+    pub hold_time: u32,
+
+    /// How long to hold a peer in idle before attempting a new session
+    /// (seconds).
+    pub idle_hold_time: u32,
+
+    /// How long to delay sending an open request after establishing a TCP
+    /// session (seconds).
+    pub delay_open: u32,
+
+    /// How long to to wait between TCP connection retries (seconds).
+    pub connect_retry: u32,
+
+    /// How often to send keepalive requests (seconds).
+    pub keepalive: u32,
+
+    /// Require that a peer has a specified ASN.
+    pub remote_asn: Option<u32>,
+
+    /// Require messages from a peer have a minimum IP time to live field.
+    pub min_ttl: Option<u8>,
+
+    /// Use the given key for TCP-MD5 authentication with the peer.
+    pub md5_auth_key: Option<String>,
+
+    /// Apply the provided multi-exit discriminator (MED) updates sent to the peer.
+    pub multi_exit_discriminator: Option<u32>,
+
+    /// Include the provided communities in updates sent to the peer.
+    pub communities: Vec<u32>,
+
+    /// Apply a local preference to routes received from this peer.
+    pub local_pref: Option<u32>,
+
+    /// Enforce that the first AS in paths received from this peer is the peer's AS.
+    pub enforce_first_as: bool,
+
+    /// Define import policy for a peer.
+    pub allowed_import: external::ImportExportPolicy,
+
+    /// Define export policy for a peer.
+    pub allowed_export: external::ImportExportPolicy,
+
+    /// Associate a VLAN ID with a peer.
+    pub vlan_id: Option<u16>,
+
+    /// Router lifetime in seconds for unnumbered BGP peers.
+    pub router_lifetime: u16,
+}
+
+impl From<crate::v2025_11_20_00::networking::BgpPeer> for BgpPeer {
+    fn from(old: crate::v2025_11_20_00::networking::BgpPeer) -> Self {
+        BgpPeer {
+            bgp_config: old.bgp_config,
+            interface_name: old.interface_name,
+            addr: Some(old.addr),
+            hold_time: old.hold_time,
+            idle_hold_time: old.idle_hold_time,
+            delay_open: old.delay_open,
+            connect_retry: old.connect_retry,
+            keepalive: old.keepalive,
+            remote_asn: old.remote_asn,
+            min_ttl: old.min_ttl,
+            md5_auth_key: old.md5_auth_key,
+            multi_exit_discriminator: old.multi_exit_discriminator,
+            communities: old.communities,
+            local_pref: old.local_pref,
+            enforce_first_as: old.enforce_first_as,
+            allowed_import: old.allowed_import,
+            allowed_export: old.allowed_export,
+            vlan_id: old.vlan_id,
+            router_lifetime: 0,
+        }
+    }
+}
+
+impl TryFrom<BgpPeer> for crate::v2025_11_20_00::networking::BgpPeer {
+    type Error = external::Error;
+
+    fn try_from(new: BgpPeer) -> Result<Self, Self::Error> {
+        let addr = new.addr.ok_or_else(|| {
+            external::Error::invalid_request(
+                "BGP peer has no address configured, but the API version \
+                 in use requires an address. Update your client to use \
+                 BGP unnumbered peers.",
+            )
+        })?;
+        Ok(Self {
+            bgp_config: new.bgp_config,
+            interface_name: new.interface_name,
+            addr,
+            hold_time: new.hold_time,
+            idle_hold_time: new.idle_hold_time,
+            delay_open: new.delay_open,
+            connect_retry: new.connect_retry,
+            keepalive: new.keepalive,
+            remote_asn: new.remote_asn,
+            min_ttl: new.min_ttl,
+            md5_auth_key: new.md5_auth_key,
+            multi_exit_discriminator: new.multi_exit_discriminator,
+            communities: new.communities,
+            local_pref: new.local_pref,
+            enforce_first_as: new.enforce_first_as,
+            allowed_import: new.allowed_import,
+            allowed_export: new.allowed_export,
+            vlan_id: new.vlan_id,
+        })
+    }
+}
+
 #[derive(Clone, Debug, Deserialize, Serialize, JsonSchema)]
 pub struct BgpPeerConfig {
     /// Link that the peer is reachable on.
@@ -69,7 +203,7 @@ pub struct BgpPeerConfig {
     /// phy0-phy3, etc.
     pub link_name: Name,
 
-    pub peers: Vec<external::BgpPeer>,
+    pub peers: Vec<BgpPeer>,
 }
 
 impl From<crate::v2025_11_20_00::networking::BgpPeerConfig> for BgpPeerConfig {
@@ -78,6 +212,68 @@ impl From<crate::v2025_11_20_00::networking::BgpPeerConfig> for BgpPeerConfig {
             link_name: old.link_name,
             peers: old.peers.into_iter().map(Into::into).collect(),
         }
+    }
+}
+
+/// This structure contains all port settings information in one place. It's a
+/// convenience data structure for getting a complete view of a particular
+/// port's settings.
+// TODO: several fields below embed `external::*` types directly from
+// `omicron-common`, which means their serialized shape is not truly frozen.
+// Once `omicron-common-versions` exists, replace these with version-local
+// copies of the types to ensure the initial version's wire format is
+// immutable.
+#[derive(Clone, Debug, Deserialize, JsonSchema, Serialize, PartialEq)]
+pub struct SwitchPortSettings {
+    #[serde(flatten)]
+    pub identity: IdentityMetadata,
+
+    /// Switch port settings included from other switch port settings groups.
+    pub groups: Vec<external::SwitchPortSettingsGroups>,
+
+    /// Layer 1 physical port settings.
+    pub port: external::SwitchPortConfig,
+
+    /// Layer 2 link settings.
+    pub links: Vec<external::SwitchPortLinkConfig>,
+
+    /// Layer 3 interface settings.
+    pub interfaces: Vec<external::SwitchInterfaceConfig>,
+
+    /// Vlan interface settings.
+    pub vlan_interfaces: Vec<external::SwitchVlanInterfaceConfig>,
+
+    /// IP route settings.
+    pub routes: Vec<external::SwitchPortRouteConfig>,
+
+    /// BGP peer settings.
+    pub bgp_peers: Vec<BgpPeer>,
+
+    /// Layer 3 IP address settings.
+    pub addresses: Vec<external::SwitchPortAddressView>,
+}
+
+impl TryFrom<SwitchPortSettings>
+    for crate::v2025_11_20_00::networking::SwitchPortSettings
+{
+    type Error = external::Error;
+
+    fn try_from(new: SwitchPortSettings) -> Result<Self, Self::Error> {
+        Ok(Self {
+            identity: new.identity,
+            groups: new.groups,
+            port: new.port,
+            links: new.links,
+            interfaces: new.interfaces,
+            vlan_interfaces: new.vlan_interfaces,
+            routes: new.routes,
+            bgp_peers: new
+                .bgp_peers
+                .into_iter()
+                .map(crate::v2025_11_20_00::networking::BgpPeer::try_from)
+                .collect::<Result<Vec<_>, _>>()?,
+            addresses: new.addresses,
+        })
     }
 }
 

--- a/nexus/types/versions/src/initial/networking.rs
+++ b/nexus/types/versions/src/initial/networking.rs
@@ -456,71 +456,6 @@ pub struct BgpPeer {
     pub vlan_id: Option<u16>,
 }
 
-// TODO: per RFD 619, these conversion impls between initial types and
-// `omicron_common::api::external` types should live in the later version
-// module that introduced the shape change (e.g. `bgp_unnumbered_peers`).
-// They currently live here because `omicron-common-versions` does not yet
-// exist; once it does, move these conversions out of the initial module.
-impl From<BgpPeer> for external::BgpPeer {
-    fn from(old: BgpPeer) -> external::BgpPeer {
-        external::BgpPeer {
-            bgp_config: old.bgp_config,
-            interface_name: old.interface_name,
-            addr: Some(old.addr),
-            hold_time: old.hold_time,
-            idle_hold_time: old.idle_hold_time,
-            delay_open: old.delay_open,
-            connect_retry: old.connect_retry,
-            keepalive: old.keepalive,
-            remote_asn: old.remote_asn,
-            min_ttl: old.min_ttl,
-            md5_auth_key: old.md5_auth_key,
-            multi_exit_discriminator: old.multi_exit_discriminator,
-            communities: old.communities,
-            local_pref: old.local_pref,
-            enforce_first_as: old.enforce_first_as,
-            allowed_import: old.allowed_import,
-            allowed_export: old.allowed_export,
-            vlan_id: old.vlan_id,
-            router_lifetime: 0,
-        }
-    }
-}
-
-impl TryFrom<external::BgpPeer> for BgpPeer {
-    type Error = external::Error;
-
-    fn try_from(new: external::BgpPeer) -> Result<Self, Self::Error> {
-        let addr = new.addr.ok_or_else(|| {
-            external::Error::invalid_request(
-                "BGP peer has no address configured, but the API version \
-                 in use requires an address. Update your client to use \
-                 BGP unnumbered peers.",
-            )
-        })?;
-        Ok(BgpPeer {
-            bgp_config: new.bgp_config,
-            interface_name: new.interface_name,
-            addr,
-            hold_time: new.hold_time,
-            idle_hold_time: new.idle_hold_time,
-            delay_open: new.delay_open,
-            connect_retry: new.connect_retry,
-            keepalive: new.keepalive,
-            remote_asn: new.remote_asn,
-            min_ttl: new.min_ttl,
-            md5_auth_key: new.md5_auth_key,
-            multi_exit_discriminator: new.multi_exit_discriminator,
-            communities: new.communities,
-            local_pref: new.local_pref,
-            enforce_first_as: new.enforce_first_as,
-            allowed_import: new.allowed_import,
-            allowed_export: new.allowed_export,
-            vlan_id: new.vlan_id,
-        })
-    }
-}
-
 /// Parameters for creating a named set of BGP announcements.
 #[derive(Clone, Debug, Deserialize, Serialize, JsonSchema)]
 pub struct BgpAnnounceSetCreate {
@@ -923,30 +858,4 @@ pub struct SwitchPortSettings {
 
     /// Layer 3 IP address settings.
     pub addresses: Vec<external::SwitchPortAddressView>,
-}
-
-// TODO: this conversion impl should move out of the initial module once
-// `omicron-common-versions` exists. See comment on `BgpPeer` above.
-impl TryFrom<external::SwitchPortSettings> for SwitchPortSettings {
-    type Error = external::Error;
-
-    fn try_from(
-        new: external::SwitchPortSettings,
-    ) -> Result<Self, Self::Error> {
-        Ok(SwitchPortSettings {
-            identity: new.identity,
-            groups: new.groups,
-            port: new.port,
-            links: new.links,
-            interfaces: new.interfaces,
-            vlan_interfaces: new.vlan_interfaces,
-            routes: new.routes,
-            bgp_peers: new
-                .bgp_peers
-                .into_iter()
-                .map(BgpPeer::try_from)
-                .collect::<Result<Vec<_>, _>>()?,
-            addresses: new.addresses,
-        })
-    }
 }

--- a/nexus/types/versions/src/latest.rs
+++ b/nexus/types/versions/src/latest.rs
@@ -277,7 +277,9 @@ pub mod networking {
     pub use crate::v2025_11_20_00::networking::TxEqConfig;
 
     pub use crate::v2026_02_13_01::networking::BgpConfigCreate;
+    pub use crate::v2026_02_13_01::networking::BgpPeer;
     pub use crate::v2026_02_13_01::networking::BgpPeerConfig;
+    pub use crate::v2026_02_13_01::networking::SwitchPortSettings;
     pub use crate::v2026_02_13_01::networking::SwitchPortSettingsCreate;
 }
 


### PR DESCRIPTION
This also addresses some lingering TODOs from #9568 about `From` impls being defined in the wrong place per RFD 619.

Part of https://github.com/oxidecomputer/omicron/issues/9801. ~~Staged on top of https://github.com/oxidecomputer/omicron/pull/9906.~~ Now rebased onto `main`.