### PR TITLE
Instrument sled-agent http endpoints with oximeter latency tracking.

### DIFF
--- a/sled-agent/src/sled_agent.rs
+++ b/sled-agent/src/sled_agent.rs
@@ -63,6 +63,7 @@ use omicron_ddm_admin_client::Client as DdmAdminClient;
 use omicron_uuid_kinds::{
     GenericUuid, MupdateOverrideUuid, PropolisUuid, SledUuid,
 };
+use oximeter_instruments::http::LatencyTracker;
 use oxnet::IpNet;
 use sled_agent_config_reconciler::{
     ConfigReconcilerHandle, ConfigReconcilerSpawnToken, InternalDisks,
@@ -404,7 +405,7 @@ struct SledAgentInner {
     health_monitor: HealthMonitorHandle,
 
     // Object handling production of metrics for oximeter.
-    _metrics_manager: MetricsManager,
+    metrics_manager: MetricsManager,
 
     // Component of Sled Agent responsible for managing instrumentation probes.
     probes: ProbeManager,
@@ -721,7 +722,7 @@ impl SledAgent {
                 health_monitor: long_running_task_handles
                     .health_monitor
                     .clone(),
-                _metrics_manager: metrics_manager,
+                metrics_manager,
                 repo_depot,
                 measurements: long_running_task_handles.measurements.clone(),
             }),
@@ -760,6 +761,10 @@ impl SledAgent {
 
     pub fn id(&self) -> SledUuid {
         self.inner.id
+    }
+
+    pub(crate) fn latencies(&self) -> &LatencyTracker {
+        &self.inner.metrics_manager.latencies
     }
 
     pub fn logger(&self) -> &Logger {


### PR DESCRIPTION
Note: feel free to tell me this a bad idea! I was putting together [a dashboard](https://grafana.monitoring.oxeng.dev/d/httpmetrics/http-metrics?orgId=1&from=now-30m&to=now&timezone=browser&var-rack_label=colo&var-operation_id=$__all) on http metrics from the rack, and I noticed that sled-agent isn't instrumented. Without thinking about it too hard, my feeling is that we should instrument all the http services, unless there's a specific reason not to. Claude was able to do the repetitive work of instrumenting each handler, so if we don't want to do this, we won't have spent much time on the experiment.