### PR TITLE
README: add two rust-analyzer configuration examples for Neovim users

### DIFF
--- a/README.adoc
+++ b/README.adoc
@@ -81,6 +81,13 @@ NOTE: This section assumes you're already familiar with the prerequisites and en
 * Use `cargo check` when you just want to know if your code compiles.  It's _much_ faster than `cargo build` or `cargo nextest run`.
 * When using Cargo's check/build/test/clippy commands, you can use the `-p PACKAGE` flag to only operate on a specific package.  This often saves a lot of time for incremental builds.
 * When using Cargo's check/build/clippy commands, use `--all-targets` to make sure you're checking or building the test code, too.
+* Beware of rust-analyzer's memory usage, which can easily be over 12 GB per
+  process. If you spawn multiple instances of it for this codebase, whether by
+  using multiple instances of vim, multiple editors, or some combination of
+  editors and coding agents, it's easy to accidentally overwhelm your system.
+  Consider using something like https://codeberg.org/p2502/lspmux[lspmux] (or
+  https://github.com/sunshowers/lspmux-rust-analyzer[sunshowers/lspmux-rust-analyzer])
+  to prevent this from happening.
 * Use https://rust-analyzer.github.io/book/configuration#cargo.targetDir[`cargo.targetDir`] to give rust-analyzer a target directory other than `./target` so it doesn't block you from running commands in the terminal. This uses extra disk space.
 
 These are explained a bit more below, along with some common pitfalls.


### PR DESCRIPTION
There are multiple different ways one can integrate rust-analyzer into Neovim, each configured slightly differently. Even for Neovim users who aren't covered, though, these examples should help simplify the process of figuring it out.