### PR TITLE
pin postgresql@14 on macOS CI for now

### DIFF
--- a/tools/install_builder_prerequisites.sh
+++ b/tools/install_builder_prerequisites.sh
@@ -193,7 +193,7 @@ function install_packages {
   elif [[ "${HOST_OS}" == "Darwin" ]]; then
     packages=(
       'coreutils'
-      'postgresql'
+      'postgresql@14'
       'pkg-config'
       'libxmlsec1'
     )


### PR DESCRIPTION
Brew has recently changed `postgresql` to default to `postgresql@18`. This is a little too new for us right now. Helios v3 will bring Postgres 18 and at that time we can also change this.