### PR TITLE
fix: typo in `omdb db sql` usage text

### DIFF
--- a/dev-tools/omdb/src/bin/omdb/db.rs
+++ b/dev-tools/omdb/src/bin/omdb/db.rs
@@ -357,7 +357,7 @@ pub struct DbFetchOptions {
 enum DbCommands {
     /// Launch `cockroach-sql`
     ///
-    /// This launches with the session variable `default_transcation_read_only`
+    /// This launches with the session variable `default_transaction_read_only`
     /// to on. Because this variable can be disabled, it is required to use
     /// `--destructive` with this command.
     Sql,


### PR DESCRIPTION
Fixed a minor typo in `omdb db sql` usage text. I was running non-simulated locally and wanted to write to the database and copied that session variable only to realize it was wrong.