### PR TITLE
BFD status shouldn't 404 if only one scrimlet is present

### DIFF
--- a/nexus/src/app/bfd.rs
+++ b/nexus/src/app/bfd.rs
@@ -11,31 +11,6 @@ use sled_agent_types::early_networking::BfdMode;
 use sled_agent_types::early_networking::SwitchSlot;
 
 impl super::Nexus {
-    async fn mg_client_for_switch_slot(
-        &self,
-        switch: SwitchSlot,
-    ) -> Result<mg_admin_client::Client, Error> {
-        let mg_client: mg_admin_client::Client = self
-            .mg_clients()
-            .await
-            .map_err(|e| {
-                Error::internal_error(&format!("failed to get mg clients: {e}"))
-            })?
-            .get(&switch)
-            .ok_or_else(|| {
-                // TODO-correctness Only having one switch shouldn't be an
-                // error; this will be fixed by
-                // <https://github.com/oxidecomputer/omicron/pull/9979> or
-                // <https://github.com/oxidecomputer/omicron/pull/9533>.
-                Error::internal_error(&format!(
-                    "failed to find switch {switch:?}"
-                ))
-            })?
-            .clone();
-
-        Ok(mg_client)
-    }
-
     pub async fn bfd_enable(
         &self,
         opctx: &OpContext,
@@ -72,9 +47,22 @@ impl super::Nexus {
     ) -> Result<Vec<bfd::BfdStatus>, Error> {
         // ask each rack switch about all its BFD sessions. This will need to
         // be updated for multirack.
+        let mg_clients = self.mg_clients().await.map_err(|err| {
+            Error::internal_error(&format!("failed to get mg clients: {err}"))
+        })?;
         let mut result = Vec::new();
         for switch_slot in [SwitchSlot::Switch0, SwitchSlot::Switch1] {
-            let mg_client = self.mg_client_for_switch_slot(switch_slot).await?;
+            // If we only have one scrimlet, we won't have an entry in
+            // `mg_clients` for one of the switch locations. Log that, but
+            // continue so we can still report status from whichever switch we
+            // do have.
+            let Some(mg_client) = mg_clients.get(&switch_slot) else {
+                warn!(
+                    self.log, "no mgd client found for switch slot";
+                    "switch-slot" => ?switch_slot,
+                );
+                continue;
+            };
             let status = mg_client
                 .get_bfd_peers()
                 .await

--- a/nexus/src/app/mod.rs
+++ b/nexus/src/app/mod.rs
@@ -44,6 +44,7 @@ use sled_agent_types::early_networking::SwitchSlot;
 use slog::Logger;
 use slog_error_chain::InlineErrorChain;
 use std::collections::HashMap;
+use std::net::SocketAddr;
 use std::net::SocketAddrV6;
 use std::net::{IpAddr, Ipv6Addr};
 use std::num::NonZeroU32;
@@ -1183,18 +1184,41 @@ impl Nexus {
         let resolver = self.resolver();
         let mappings =
             switch_zone_address_mappings(resolver, &self.log).await?;
-        let mut clients: Vec<(SwitchSlot, mg_admin_client::Client)> = vec![];
-        for (switch_slot, addr) in &mappings {
-            let port = MGD_PORT;
-            let socketaddr =
-                std::net::SocketAddr::V6(SocketAddrV6::new(*addr, port, 0, 0));
-            let client = mg_admin_client::Client::new(
-                format!("http://{}", socketaddr).as_str(),
-                self.log.clone(),
+        let mgd_addrs = resolver
+            .lookup_all_socket_v6(ServiceName::Mgd)
+            .await
+            .map_err(|err| {
+            format!(
+                "failed to resolve mgd in DNS: {}",
+                InlineErrorChain::new(&err)
+            )
+        })?;
+        let mut clients = HashMap::new();
+        for (switch_slot, ip) in mappings {
+            let addr =
+                match mgd_addrs.iter().copied().find(|addr| *addr.ip() == ip) {
+                    Some(addr) => SocketAddr::V6(addr),
+                    None => {
+                        warn!(
+                            self.log,
+                            "no MGD DNS entry found matching switch slot \
+                             IP address; assuming default port";
+                            "switch-slot" => ?switch_slot,
+                            "switch-ip" => %ip,
+                            "mgd-dns-entries" => ?mgd_addrs,
+                        );
+                        SocketAddr::V6(SocketAddrV6::new(ip, MGD_PORT, 0, 0))
+                    }
+                };
+            clients.insert(
+                switch_slot,
+                mg_admin_client::Client::new(
+                    &format!("http://{addr}"),
+                    self.log.clone(),
+                ),
             );
-            clients.push((*switch_slot, client));
         }
-        Ok(clients.into_iter().collect::<HashMap<_, _>>())
+        Ok(clients)
     }
 
     pub(crate) fn demo_sagas(

--- a/nexus/tests/integration_tests/bfd.rs
+++ b/nexus/tests/integration_tests/bfd.rs
@@ -1,0 +1,30 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at https://mozilla.org/MPL/2.0/.
+
+//! Tests BFD support in the API
+
+use nexus_test_utils::http_testing::AuthnMode;
+use nexus_test_utils::http_testing::NexusRequest;
+use nexus_test_utils_macros::nexus_test;
+use nexus_types::external_api::bfd::BfdStatus;
+
+type ControlPlaneTestContext =
+    nexus_test_utils::ControlPlaneTestContext<omicron_nexus::Server>;
+
+const STATUS_URL: &str = "/v1/system/networking/bfd-status";
+
+#[nexus_test]
+async fn test_empty_bfd_status(cptestctx: &ControlPlaneTestContext) {
+    let client = &cptestctx.external_client;
+
+    let status = NexusRequest::object_get(client, STATUS_URL)
+        .authn_as(AuthnMode::PrivilegedUser)
+        .execute_and_parse_unwrap::<Vec<BfdStatus>>()
+        .await;
+
+    // `#[nexus_test]` doesn't set up BFD, so we should have no status. But we
+    // should still be able to ask for that! (#[nexus_test] also only sets up
+    // one fake scrimlet - that used to cause this endpoint to fail.)
+    assert_eq!(status, Vec::new());
+}

--- a/nexus/tests/integration_tests/mod.rs
+++ b/nexus/tests/integration_tests/mod.rs
@@ -14,6 +14,7 @@ mod audit_log;
 mod authn_http;
 mod authz;
 mod basic;
+mod bfd;
 mod certificates;
 mod cockroach;
 mod commands;


### PR DESCRIPTION
(I ran into this while shaving yaks as a part of #9832.)

There are three changes here:

af1090cd3b1d6114ff7152c0d8de1b5d1a15e135 changes `Nexus::mg_clients()` to look up MGD in DNS to find ports instead of assuming the hardcoded `MGD_PORT`. This allows `mg_clients()` to be useful in tests. (`#[nexus_test]` assigns random ports to services, but does put those ports in DNS.) This is kinda grody; we end up doing _three_ DNS lookups (dendrite, MGS, and MGD) to build a `HashMap<SwitchLocation, MgdClient>`), but I didn't want to try to tackle that in this same PR. #8999 is related, and discussions some possible options that would let us squash this down.

ae54bbc5f753dd30d72c974bf7930e4c34e9707d adds a very simple test that hits the BFD status endpoint, expecting it to be empty. Without the fix from the next commit, this test fails with a 404 because `#[nexus_test]` only sets up one scrimlet (switch0), causing the BFD status endpoint to 404 because it can't find the other switch:

```
16:39:39.882Z INFO 913233fe-92a8-4635-9572-183f495429c4 (dropshot_external): request completed
    error_message_external = not found: switch with name "switch1"
    error_message_internal = not found: switch with name "switch1"
    latency_us = 385976
    local_addr = 127.0.0.1:38549
    method = GET
    remote_addr = 127.0.0.1:43174
    req_id = 262916c6-77d8-439f-8252-cede9b46f169
    response_code = 404
    uri = /v1/system/networking/bfd-status
```

bd7932447a4eeffcb5344add7d3892f87f497e91 changes `bfd_status()` to skip missing switches instead of 404ing, so we still get status from the one switch. This allows the test in the previous commit to pass.