### PR TITLE
Make user_provision_type NOT NULL

### DIFF
--- a/nexus/db-model/src/schema_versions.rs
+++ b/nexus/db-model/src/schema_versions.rs
@@ -16,7 +16,7 @@ use std::{collections::BTreeMap, sync::LazyLock};
 ///
 /// This must be updated when you change the database schema.  Refer to
 /// schema/crdb/README.adoc in the root of this repository for details.
-pub const SCHEMA_VERSION: Version = Version::new(234, 0, 0);
+pub const SCHEMA_VERSION: Version = Version::new(235, 0, 0);
 
 /// List of all past database schema versions, in *reverse* order
 ///
@@ -28,6 +28,7 @@ static KNOWN_VERSIONS: LazyLock<Vec<KnownVersion>> = LazyLock::new(|| {
         // |  leaving the first copy as an example for the next person.
         // v
         // KnownVersion::new(next_int, "unique-dirname-with-the-sql-files"),
+        KnownVersion::new(235, "silo-user-group-provision-type-not-null"),
         KnownVersion::new(234, "inv-zpool-health"),
         KnownVersion::new(233, "measurement-blueprints"),
         KnownVersion::new(232, "index-backfill-batch-size"),

--- a/nexus/db-schema/tests/output/schema_known_drift.txt
+++ b/nexus/db-schema/tests/output/schema_known_drift.txt
@@ -15,8 +15,6 @@ nat_version.is_called
 nat_version.last_value
 nat_version.log_cnt
 nat_version.value
-silo_group.user_provision_type
-silo_user.user_provision_type
 subnet_pool_member.first_address
 subnet_pool_member.last_address
 switch_port.port_name

--- a/schema/crdb/dbinit.sql
+++ b/schema/crdb/dbinit.sql
@@ -913,7 +913,7 @@ CREATE TABLE IF NOT EXISTS omicron.public.silo_user (
     -- contain a value
     external_id TEXT,
 
-    user_provision_type omicron.public.user_provision_type,
+    user_provision_type omicron.public.user_provision_type NOT NULL,
 
     -- if the user provision type is 'scim' then this field must contain a value
     user_name TEXT,
@@ -921,11 +921,6 @@ CREATE TABLE IF NOT EXISTS omicron.public.silo_user (
     -- if user provision type is 'scim', this field _may_ contain a value: it
     -- is not mandatory that the SCIM provisioning client support this field.
     active BOOL,
-
-    CONSTRAINT user_provision_type_required_for_non_deleted CHECK (
-      (user_provision_type IS NOT NULL AND time_deleted IS NULL)
-      OR (time_deleted IS NOT NULL)
-    ),
 
     CONSTRAINT external_id_consistency CHECK (
         CASE user_provision_type
@@ -982,15 +977,10 @@ CREATE TABLE IF NOT EXISTS omicron.public.silo_group (
     -- contain a value
     external_id TEXT,
 
-    user_provision_type omicron.public.user_provision_type,
+    user_provision_type omicron.public.user_provision_type NOT NULL,
 
     -- if the user provision type is 'scim' then this field must contain a value
     display_name TEXT,
-
-    CONSTRAINT user_provision_type_required_for_non_deleted CHECK (
-      (user_provision_type IS NOT NULL AND time_deleted IS NULL)
-      OR (time_deleted IS NOT NULL)
-    ),
 
     CONSTRAINT external_id_consistency CHECK (
         CASE user_provision_type
@@ -8241,7 +8231,7 @@ INSERT INTO omicron.public.db_metadata (
     version,
     target_version
 ) VALUES
-    (TRUE, NOW(), NOW(), '234.0.0', NULL)
+    (TRUE, NOW(), NOW(), '235.0.0', NULL)
 ON CONFLICT DO NOTHING;
 
 COMMIT;

--- a/schema/crdb/silo-user-group-provision-type-not-null/up1.sql
+++ b/schema/crdb/silo-user-group-provision-type-not-null/up1.sql
@@ -1,0 +1,22 @@
+-- Backfill any silo_user rows that have NULL user_provision_type.
+-- The original migration (196) only backfilled non-deleted rows,
+-- leaving already-deleted rows with NULL.
+
+SET LOCAL disallow_full_table_scans = 'off';
+
+-- First, backfill from the parent silo where possible.
+UPDATE omicron.public.silo_user
+SET user_provision_type = silo.user_provision_type
+FROM omicron.public.silo
+WHERE silo.id = silo_user.silo_id
+  AND silo_user.user_provision_type IS NULL;
+
+-- If the parent silo was also deleted, the JOIN above won't match.
+-- Use a fallback value for any remaining NULLs. These are all
+-- soft-deleted rows, so the exact value doesn't matter operationally.
+UPDATE omicron.public.silo_user
+SET user_provision_type = 'jit'
+WHERE user_provision_type IS NULL;
+
+ALTER TABLE omicron.public.silo_user
+  ALTER COLUMN user_provision_type SET NOT NULL;

--- a/schema/crdb/silo-user-group-provision-type-not-null/up2.sql
+++ b/schema/crdb/silo-user-group-provision-type-not-null/up2.sql
@@ -1,0 +1,5 @@
+-- The CHECK constraint is now redundant: NOT NULL on user_provision_type
+-- subsumes the condition that was previously enforced only for non-deleted rows.
+
+ALTER TABLE omicron.public.silo_user
+  DROP CONSTRAINT IF EXISTS user_provision_type_required_for_non_deleted;

--- a/schema/crdb/silo-user-group-provision-type-not-null/up3.sql
+++ b/schema/crdb/silo-user-group-provision-type-not-null/up3.sql
@@ -1,0 +1,21 @@
+-- Backfill any silo_group rows that have NULL user_provision_type.
+-- Same situation as silo_user (migration 196 only backfilled non-deleted rows).
+
+SET LOCAL disallow_full_table_scans = 'off';
+
+-- First, backfill from the parent silo where possible.
+UPDATE omicron.public.silo_group
+SET user_provision_type = silo.user_provision_type
+FROM omicron.public.silo
+WHERE silo.id = silo_group.silo_id
+  AND silo_group.user_provision_type IS NULL;
+
+-- If the parent silo was also deleted, the JOIN above won't match.
+-- Use a fallback value for any remaining NULLs. These are all
+-- soft-deleted rows, so the exact value doesn't matter operationally.
+UPDATE omicron.public.silo_group
+SET user_provision_type = 'jit'
+WHERE user_provision_type IS NULL;
+
+ALTER TABLE omicron.public.silo_group
+  ALTER COLUMN user_provision_type SET NOT NULL;

--- a/schema/crdb/silo-user-group-provision-type-not-null/up4.sql
+++ b/schema/crdb/silo-user-group-provision-type-not-null/up4.sql
@@ -1,0 +1,5 @@
+-- The CHECK constraint is now redundant: NOT NULL on user_provision_type
+-- subsumes the condition that was previously enforced only for non-deleted rows.
+
+ALTER TABLE omicron.public.silo_group
+  DROP CONSTRAINT IF EXISTS user_provision_type_required_for_non_deleted;


### PR DESCRIPTION
Part of https://github.com/oxidecomputer/omicron/issues/9966

These columns are "Not Null" in the Diesel schema, but "Nullable" in the CRDB schema. This PR aligns them.