### PR TITLE
Switch to a faster linux test instance

### DIFF
--- a/.github/buildomat/jobs/build-and-test-linux.sh
+++ b/.github/buildomat/jobs/build-and-test-linux.sh
@@ -2,7 +2,7 @@
 #:
 #: name = "build-and-test (ubuntu-22.04)"
 #: variety = "basic"
-#: target = "ubuntu-22.04"
+#: target = "ubuntu-22.04-large"
 #: rust_toolchain = true
 #: output_rules = [
 #:	"%/work/*",


### PR DESCRIPTION
This PR switches the buildomat build-and-test Linux job from the `m6a.2xlarge` AWS instance (8 core, 32 GB RAM, Zen 3) to the `c8a.4xlarge` AWS instance (16 core, 32 GB RAM, Zen 5). In my testing this should bring the execution time for that builder from 80 minutes to 25 minutes.

I did a fair amount of testing with multiple instance types before landing on a `c8a.4xlarge`:

| Instance type | Architecture | CPU | RAM | Duration | Per hour price | Per build price |
| --- | --- | --- | --- | --- | --- | --- |
| `m6a.2xlarge` | Zen 3 | 8 core | 32 GB | 80 min | $0.345/hr | $0.46/build |
| `c8a.2xlarge` | Zen 5 | 8 core | 16 GB | 44 min | $0.431/hr | $0.32/build |
| `c8a.4xlarge` | Zen 5 | 16 core | 32 GB | 25 min | $0.862/hr | $0.36/build |
| `c8a.8xlarge` | Zen 5 | 32 core | 64 GB | 21 min | $1.724/hr | $0.60/build |

I did all of my testing on compute-optimized instances (`c` class, with half the ram compared to general purpose `m` instances) because I noticed that we were only using 25% of the RAM at peak, so compute-optimized instances would be cheaper while still leaving a 50% headroom. The CPU was fully saturated for most of the build in the 8 core instances, mostly saturated in the 16 core instance and not much used in the 32 cores (see graphs below). That's how I chose `c8a.4xlarge`.

<details><summary>CPU and RAM graphs for <code>m6a.2xlarge</code></summary>

<img width="1202" height="328" alt="image" src="https://github.com/user-attachments/assets/ca7e2f45-1920-408a-98b2-e5687d2628cc" />

</details> 

<details><summary>CPU and RAM graphs for <code>c8a.2xlarge</code></summary>

<img width="1196" height="336" alt="image" src="https://github.com/user-attachments/assets/0bddaa6b-b640-4669-b974-cd546a948c96" />

</details>

<details><summary>CPU and RAM graphs for <code>c8a.4xlarge</code></summary>

<img width="1196" height="336" alt="image" src="https://github.com/user-attachments/assets/720390d2-ef60-45f5-96aa-396fd191c3fd" />

</details>

<details><summary>CPU and RAM graphs for <code>c8a.8xlarge</code></summary>

<img width="1196" height="336" alt="image" src="https://github.com/user-attachments/assets/29012a9a-c501-4aaa-a7fd-e33d085a5c4a" />

</details>