### PR TITLE
update dropshot-api-manager to 0.6.0

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3159,9 +3159,9 @@ dependencies = [
 
 [[package]]
 name = "dropshot-api-manager"
-version = "0.5.2"
+version = "0.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c38a99616a680fafd8b7a03cc300aab80b0bbf0fb17c6baac53431d9d12b64b5"
+checksum = "bf576868db63e888512129acd5f59e36e61b7d1ac285239e76ed40dc43d7b2e8"
 dependencies = [
  "anyhow",
  "atomicwrites",
@@ -3192,9 +3192,9 @@ dependencies = [
 
 [[package]]
 name = "dropshot-api-manager-types"
-version = "0.5.2"
+version = "0.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f5116e3d69b975bb89824a721d0326707b8643e4fd3ba69ca880de1aada768cf"
+checksum = "a04cc5bc280e21332f33acfd180705a9e8ace302e9eb08000786135d27497731"
 dependencies = [
  "anyhow",
  "camino",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -479,8 +479,8 @@ dns-server-api = { path = "dns-server-api" }
 dns-service-client = { path = "clients/dns-service-client" }
 dpd-client = { git = "https://github.com/oxidecomputer/dendrite", rev = "c0bf0a3b536baab0393c96fec3204b32e4f9368b" }
 dropshot = { version = "0.16.6", features = [ "usdt-probes" ] }
-dropshot-api-manager = "0.5.2"
-dropshot-api-manager-types = "0.5.2"
+dropshot-api-manager = "0.6.0"
+dropshot-api-manager-types = "0.6.0"
 dyn-clone = "1.0.20"
 either = "1.15.0"
 ereport-types = { path = "ereport/types" }


### PR DESCRIPTION
Includes support for jj workspaces.