### PR TITLE
sled-diagnostics: Capture nvmeadm health logpage

### DIFF
--- a/nexus/mgs-updates/src/test_util/host_phase_2_test_state.rs
+++ b/nexus/mgs-updates/src/test_util/host_phase_2_test_state.rs
@@ -861,7 +861,7 @@ mod api_impl {
 
         async fn support_nvmeadm_info(
             _request_context: RequestContext<Self::Context>,
-        ) -> Result<HttpResponseOk<SledDiagnosticsQueryOutput>, HttpError>
+        ) -> Result<HttpResponseOk<Vec<SledDiagnosticsQueryOutput>>, HttpError>
         {
             unimplemented!()
         }

--- a/openapi/sled-agent/sled-agent-27.0.0-42911d.json.gitstub
+++ b/openapi/sled-agent/sled-agent-27.0.0-42911d.json.gitstub
@@ -1,0 +1,1 @@
+df724fae54459e6ffa609f932547c643fb52e3f7:openapi/sled-agent/sled-agent-27.0.0-42911d.json

--- a/openapi/sled-agent/sled-agent-28.0.0-137ef2.json
+++ b/openapi/sled-agent/sled-agent-28.0.0-137ef2.json
@@ -7,7 +7,7 @@
       "url": "https://oxide.computer",
       "email": "api@oxide.computer"
     },
-    "version": "27.0.0"
+    "version": "28.0.0"
   },
   "paths": {
     "/artifacts": {
@@ -766,7 +766,11 @@
             "content": {
               "application/json": {
                 "schema": {
-                  "$ref": "#/components/schemas/SledDiagnosticsQueryOutput"
+                  "title": "Array_of_SledDiagnosticsQueryOutput",
+                  "type": "array",
+                  "items": {
+                    "$ref": "#/components/schemas/SledDiagnosticsQueryOutput"
+                  }
                 }
               }
             }

--- a/openapi/sled-agent/sled-agent-latest.json
+++ b/openapi/sled-agent/sled-agent-latest.json
@@ -1,1 +1,1 @@
-sled-agent-27.0.0-42911d.json
+sled-agent-28.0.0-137ef2.json

--- a/sled-agent/api/src/lib.rs
+++ b/sled-agent/api/src/lib.rs
@@ -37,6 +37,7 @@ api_versions!([
     // |  example for the next person.
     // v
     // (next_int, IDENT),
+    (28, MORE_NVMEADM_OUTPUT),
     (27, RENAME_SWITCH_LOCATION_TO_SWITCH_SLOT),
     (26, RACK_NETWORK_CONFIG_NOT_OPTIONAL),
     (25, BOOTSTORE_VERSIONING),
@@ -1103,10 +1104,31 @@ pub trait SledAgentApi {
     #[endpoint {
         method = GET,
         path = "/support/nvmeadm-info",
+        versions = VERSION_MORE_NVMEADM_OUTPUT..,
     }]
     async fn support_nvmeadm_info(
         request_context: RequestContext<Self::Context>,
-    ) -> Result<HttpResponseOk<SledDiagnosticsQueryOutput>, HttpError>;
+    ) -> Result<HttpResponseOk<Vec<SledDiagnosticsQueryOutput>>, HttpError>;
+
+    #[endpoint {
+        operation_id = "support_nvmeadm_info",
+        method = GET,
+        path = "/support/nvmeadm-info",
+        versions = ..VERSION_MORE_NVMEADM_OUTPUT,
+    }]
+    async fn support_nvmeadm_info_v27(
+        request_context: RequestContext<Self::Context>,
+    ) -> Result<HttpResponseOk<SledDiagnosticsQueryOutput>, HttpError> {
+        Self::support_nvmeadm_info(request_context).await.map(
+            |HttpResponseOk(items)| {
+                HttpResponseOk(items.into_iter().next().unwrap_or(
+                    SledDiagnosticsQueryOutput::Failure {
+                        error: String::from("no nvmeadm output available"),
+                    },
+                ))
+            },
+        )
+    }
 
     #[endpoint {
         method = GET,

--- a/sled-agent/src/http_entrypoints.rs
+++ b/sled-agent/src/http_entrypoints.rs
@@ -1252,12 +1252,18 @@ impl SledAgentApi for SledAgentImpl {
 
     async fn support_nvmeadm_info(
         request_context: RequestContext<Self::Context>,
-    ) -> Result<HttpResponseOk<SledDiagnosticsQueryOutput>, HttpError> {
+    ) -> Result<HttpResponseOk<Vec<SledDiagnosticsQueryOutput>>, HttpError>
+    {
         let sa = request_context.context();
         sa.latencies()
             .instrument_dropshot_handler(&request_context, async {
-                let res = sa.support_nvmeadm_info().await;
-                Ok(HttpResponseOk(res.get_output()))
+                let res = sa
+                    .support_nvmeadm_info()
+                    .await
+                    .into_iter()
+                    .map(|cmd| cmd.get_output())
+                    .collect::<Vec<_>>();
+                Ok(HttpResponseOk(res))
             })
             .await
     }

--- a/sled-agent/src/sim/http_entrypoints.rs
+++ b/sled-agent/src/sim/http_entrypoints.rs
@@ -919,7 +919,8 @@ impl SledAgentApi for SledAgentSimImpl {
 
     async fn support_nvmeadm_info(
         _request_context: RequestContext<Self::Context>,
-    ) -> Result<HttpResponseOk<SledDiagnosticsQueryOutput>, HttpError> {
+    ) -> Result<HttpResponseOk<Vec<SledDiagnosticsQueryOutput>>, HttpError>
+    {
         method_unimplemented()
     }
 

--- a/sled-agent/src/sled_agent.rs
+++ b/sled-agent/src/sled_agent.rs
@@ -1255,7 +1255,7 @@ impl SledAgent {
 
     pub(crate) async fn support_nvmeadm_info(
         &self,
-    ) -> Result<SledDiagnosticsCmdOutput, SledDiagnosticsCmdError> {
+    ) -> Vec<Result<SledDiagnosticsCmdOutput, SledDiagnosticsCmdError>> {
         sled_diagnostics::nvmeadm_info().await
     }
 

--- a/sled-diagnostics/src/lib.rs
+++ b/sled-diagnostics/src/lib.rs
@@ -34,6 +34,9 @@ use queries::*;
 /// Max number of ptool commands to run in parallel
 const MAX_PTOOL_PARALLELISM: usize = 50;
 
+/// Number of NVMe drives on a sled.
+const NUM_NVME_DRIVES: u32 = 12;
+
 /// List all zones on a sled.
 pub async fn zoneadm_info()
 -> Result<SledDiagnosticsCmdOutput, SledDiagnosticsCmdError> {
@@ -83,8 +86,25 @@ pub async fn dladm_info()
 }
 
 pub async fn nvmeadm_info()
--> Result<SledDiagnosticsCmdOutput, SledDiagnosticsCmdError> {
-    execute_command_with_timeout(nvmeadm_list(), DEFAULT_TIMEOUT).await
+-> Vec<Result<SledDiagnosticsCmdOutput, SledDiagnosticsCmdError>> {
+    let mut results = Vec::new();
+
+    // Run these serially so that the disk log pages are listed in order in the
+    // output.
+    let res =
+        execute_command_with_timeout(nvmeadm_list(), DEFAULT_TIMEOUT).await;
+    results.push(res);
+
+    for disk_num in 0..NUM_NVME_DRIVES {
+        let res = execute_command_with_timeout(
+            nvmeadm_logpage_health(disk_num),
+            DEFAULT_TIMEOUT,
+        )
+        .await;
+        results.push(res);
+    }
+
+    results
 }
 
 pub async fn pargs_oxide_processes(

--- a/sled-diagnostics/src/queries.rs
+++ b/sled-diagnostics/src/queries.rs
@@ -248,6 +248,17 @@ pub fn nvmeadm_list() -> Command {
     cmd
 }
 
+pub fn nvmeadm_logpage_health(nvme_num: u32) -> Command {
+    let mut cmd = std::process::Command::new(PFEXEC);
+    cmd.env_clear()
+        .arg(NVMEADM)
+        .arg("-v")
+        .arg("get-logpage")
+        .arg(&format!("nvme{nvme_num}"))
+        .arg("health");
+    cmd
+}
+
 pub fn pargs_process(pid: i32) -> Command {
     let mut cmd = std::process::Command::new(PFEXEC);
     cmd.env_clear().arg(PARGS).arg("-ae").arg(pid.to_string());


### PR DESCRIPTION
During recent customer installs we have found that the `health` logpage exposed by `nvmeadm(8)` was useful in identifying failing drives.

Add this output to support bundles.