### PR TITLE
[bootstore] Remove impl From<NodeRequestError> for external::Error

### DIFF
--- a/bootstore/src/schemes/v0/peer.rs
+++ b/bootstore/src/schemes/v0/peer.rs
@@ -63,14 +63,6 @@ pub enum NodeRequestError {
     },
 }
 
-impl From<NodeRequestError> for omicron_common::api::external::Error {
-    fn from(error: NodeRequestError) -> Self {
-        omicron_common::api::external::Error::internal_error(
-            &InlineErrorChain::new(&error).to_string(),
-        )
-    }
-}
-
 /// A request sent to the `Node` task from the `NodeHandle`
 pub enum NodeApiRequest {
     /// Initialize a rack at the behest of RSS running on the same scrimlet as

--- a/sled-agent/src/http_entrypoints.rs
+++ b/sled-agent/src/http_entrypoints.rs
@@ -1155,8 +1155,8 @@ impl SledAgentApi for SledAgentImpl {
                     .get_status()
                     .await
                     .map_err(|e| {
-                        HttpError::from(
-                            omicron_common::api::external::Error::from(e),
+                        HttpError::for_internal_error(
+                            InlineErrorChain::new(&e).to_string(),
                         )
                     })?
                     .into();


### PR DESCRIPTION
The `impl From<NodeRequestError> for omicron_common::api::external::Error` in bootstore's peer.rs couples bootstore to omicron-common's API error types, but bootstore probably shouldn't know anything about omicron-common HTTP API errors (or, really anything about omicron-common at all, see also #10034). Replace the single call site in sled-agent's http_entrypoints.rs with a direct `HttpError` conversion.