### PR TITLE
Remove unused method `DataStore::service_delete_network_interface()`

### DIFF
--- a/nexus/db-errors/src/transaction_error.rs
+++ b/nexus/db-errors/src/transaction_error.rs
@@ -14,7 +14,7 @@ use omicron_common::api::external::{
 use crate::OptionalError;
 
 /// Wrapper around an error which may be returned from a Diesel transaction.
-#[derive(Debug, thiserror::Error)]
+#[derive(Debug, PartialEq, thiserror::Error)]
 pub enum TransactionError<T> {
     /// The customizable error type.
     ///

--- a/nexus/db-queries/src/db/datastore/network_interface.rs
+++ b/nexus/db-queries/src/db/datastore/network_interface.rs
@@ -540,61 +540,17 @@ impl DataStore {
 
     /// Delete a `ServiceNetworkInterface` attached to a provided service.
     ///
-    /// To support idempotency, such as in saga operations, this method returns
-    /// an extra boolean. The meaning of return values are:
+    /// To support idempotency,  this method returns an extra boolean. The
+    /// meaning of return values are:
+    ///
     /// - `Ok(true)`: The record was deleted during this call
     /// - `Ok(false)`: The record was already deleted, such as by a previous
     /// call
     /// - `Err(_)`: Any other condition, including a non-existent record.
-    pub async fn service_delete_network_interface(
-        &self,
-        opctx: &OpContext,
-        service_id: Uuid,
-        network_interface_id: Uuid,
-    ) -> Result<bool, network_interface::DeleteError> {
-        // See the comment in `service_create_network_interface`. There's no
-        // obvious parent for a service network interface (as opposed to
-        // instance network interfaces, which require permissions on the
-        // instance). As a logical proxy, we check for listing children of the
-        // service IP pool.
-        //
-        // Note that the IP version here doesn't matter, both pools have the
-        // same permissions.
-        let (authz_service_ip_pool, _) = self
-            .ip_pools_service_lookup(opctx, IpVersion::V4)
-            .await
-            .map_err(network_interface::DeleteError::External)?;
-        opctx
-            .authorize(authz::Action::Delete, &authz_service_ip_pool)
-            .await
-            .map_err(network_interface::DeleteError::External)?;
-
-        let conn = self
-            .pool_connection_authorized(opctx)
-            .await
-            .map_err(network_interface::DeleteError::External)?;
-        self.service_delete_network_interface_on_connection(
-            &conn,
-            service_id,
-            network_interface_id,
-        )
-        .await
-        .map_err(|txn_error| match txn_error {
-            TransactionError::CustomError(err) => err,
-            TransactionError::Database(err) => {
-                let query = network_interface::DeleteQuery::new(
-                    NetworkInterfaceKind::Service,
-                    service_id,
-                    network_interface_id,
-                );
-                network_interface::DeleteError::from_diesel(err, &query)
-            }
-        })
-    }
-
-    /// Variant of [Self::service_delete_network_interface] which may be called
-    /// from a transaction context.
-    pub async fn service_delete_network_interface_on_connection(
+    ///
+    /// Should only be called from a transaction context which has already
+    /// performed any necessary auth checks.
+    pub(crate) async fn service_delete_network_interface_on_connection(
         &self,
         conn: &async_bb8_diesel::Connection<DbConnection>,
         service_id: Uuid,
@@ -1165,13 +1121,14 @@ mod tests {
         assert_eq!(nics, service_nics);
 
         // Delete a few, and ensure we don't see them anymore.
+        let conn = datastore.pool_connection_authorized(&opctx).await.unwrap();
         let mut removed_nic_ids = BTreeSet::new();
         for (i, nic) in service_nics.iter().enumerate() {
             if i % 3 == 0 {
                 let id = nic.id();
                 datastore
-                    .service_delete_network_interface(
-                        &opctx,
+                    .service_delete_network_interface_on_connection(
+                        &conn,
                         nic.service_id,
                         id,
                     )

--- a/nexus/db-queries/src/db/datastore/vpc.rs
+++ b/nexus/db-queries/src/db/datastore/vpc.rs
@@ -3412,19 +3412,25 @@ mod tests {
         assert_service_sled_ids(&datastore, &[]).await;
 
         // Delete the service NIC record so we can reuse this IP later.
-        datastore
-            .service_delete_network_interface(
-                &opctx,
-                bp1.sleds[&sled_ids[2]]
-                    .zones
-                    .first()
-                    .unwrap()
-                    .id
-                    .into_untyped_uuid(),
-                bp1_nic.id(),
-            )
-            .await
-            .expect("deleted bp1 nic");
+        {
+            let conn = datastore
+                .pool_connection_for_tests()
+                .await
+                .expect("got connection for tests");
+            datastore
+                .service_delete_network_interface_on_connection(
+                    &conn,
+                    bp1.sleds[&sled_ids[2]]
+                        .zones
+                        .first()
+                        .unwrap()
+                        .id
+                        .into_untyped_uuid(),
+                    bp1_nic.id(),
+                )
+                .await
+                .expect("deleted bp1 nic");
+        }
 
         // Create a blueprint with Nexus on all our sleds.
         let bp3 = {

--- a/nexus/db-queries/src/db/queries/network_interface.rs
+++ b/nexus/db-queries/src/db/queries/network_interface.rs
@@ -2003,6 +2003,7 @@ mod tests {
     use async_bb8_diesel::AsyncRunQueryDsl;
     use dropshot::test_util::LogContext;
     use model::NetworkInterfaceKind;
+    use nexus_db_errors::TransactionError;
     use nexus_db_lookup::LookupPath;
     use nexus_db_model::IpVersion;
     use nexus_types::external_api::instance::InstanceCreate;
@@ -2291,13 +2292,18 @@ mod tests {
             .service_create_network_interface_raw(context.opctx(), interface)
             .await
             .expect("Failed to insert interface");
+        let conn = context
+            .datastore()
+            .pool_connection_for_tests()
+            .await
+            .expect("got connection for tests");
 
         // We should be able to delete twice, and be told that the first delete
         // modified the row and the second did not.
         let first_deleted = context
             .datastore()
-            .service_delete_network_interface(
-                context.opctx(),
+            .service_delete_network_interface_on_connection(
+                &conn,
                 service_id,
                 inserted_interface.id(),
             )
@@ -2307,8 +2313,8 @@ mod tests {
 
         let second_deleted = context
             .datastore()
-            .service_delete_network_interface(
-                context.opctx(),
+            .service_delete_network_interface_on_connection(
+                &conn,
                 service_id,
                 inserted_interface.id(),
             )
@@ -2320,20 +2326,19 @@ mod tests {
         let bogus_id = Uuid::new_v4();
         let err = context
             .datastore()
-            .service_delete_network_interface(
-                context.opctx(),
-                service_id,
-                bogus_id,
+            .service_delete_network_interface_on_connection(
+                &conn, service_id, bogus_id,
             )
             .await
             .expect_err(
                 "unexpectedly succeeded deleting nonexistent interface",
             );
-        let expected_err =
+        let expected_err = TransactionError::CustomError(
             DeleteError::External(external::Error::ObjectNotFound {
                 type_name: external::ResourceType::ServiceNetworkInterface,
                 lookup_type: external::LookupType::ById(bogus_id),
-            });
+            }),
+        );
         assert_eq!(err, expected_err);
         context.success().await;
     }


### PR DESCRIPTION
This was only called by tests; updated them to call the `...on_connection()` variant. Restrict that variant from `pub` to `pub(crate)`.

@davepacheco noted this while we were investigating #10025.