### PR TITLE
NIC `DeleteQuery`: add expectorate tests

### DIFF
--- a/nexus/db-queries/src/db/queries/network_interface.rs
+++ b/nexus/db-queries/src/db/queries/network_interface.rs
@@ -1981,6 +1981,7 @@ fn decode_delete_network_interface_database_error(
 #[cfg(test)]
 mod tests {
     use super::DeleteError;
+    use super::DeleteQuery;
     use super::InsertError;
     use super::MAX_NICS_PER_INSTANCE;
     use super::NUM_INITIAL_RESERVED_IP_ADDRESSES;
@@ -2000,6 +2001,7 @@ mod tests {
     use crate::db::queries::network_interface::first_available_ipv6_address;
     use crate::db::queries::network_interface::last_available_ipv4_address;
     use crate::db::queries::network_interface::last_available_ipv6_address;
+    use crate::db::raw_query_builder::expectorate_query_contents;
     use async_bb8_diesel::AsyncRunQueryDsl;
     use dropshot::test_util::LogContext;
     use model::NetworkInterfaceKind;
@@ -2260,6 +2262,21 @@ mod tests {
                 )
                 .await
                 .expect("Failed to delete NICs");
+        }
+    }
+
+    #[tokio::test]
+    async fn expectorate_query() {
+        for (kind, kind_description) in [
+            (NetworkInterfaceKind::Service, "service"),
+            (NetworkInterfaceKind::Instance, "instance"),
+            (NetworkInterfaceKind::Probe, "probe"),
+        ] {
+            let path = format!(
+                "tests/output/delete_vnic_{kind_description}_query.sql"
+            );
+            let query = DeleteQuery::new(kind, Uuid::nil(), Uuid::nil());
+            expectorate_query_contents(&query, &path).await;
         }
     }
 

--- a/nexus/db-queries/tests/output/delete_vnic_instance_query.sql
+++ b/nexus/db-queries/tests/output/delete_vnic_instance_query.sql
@@ -1,0 +1,62 @@
+WITH
+  instance
+    AS MATERIALIZED (
+      SELECT
+        CAST(
+          CASE COALESCE(
+            (
+              SELECT
+                CASE WHEN active_propolis_id IS NULL THEN state ELSE $1 END
+              FROM
+                instance
+              WHERE
+                id = $2 AND time_deleted IS NULL
+            ),
+            $3
+          )
+          WHEN $4 THEN $5
+          WHEN $6 THEN $7
+          WHEN $8 THEN $9
+          WHEN $10 THEN $11
+          ELSE $12
+          END
+            AS UUID
+        )
+    ),
+  interface
+    AS MATERIALIZED (
+      SELECT
+        CAST(
+          IF(
+            (SELECT NOT is_primary FROM network_interface WHERE id = $13 AND time_deleted IS NULL)
+            OR (
+                SELECT
+                  count(*)
+                FROM
+                  network_interface
+                WHERE
+                  parent_id = $14 AND kind = $15 AND time_deleted IS NULL
+              )
+              <= 1,
+            $16,
+            $17
+          )
+            AS UUID
+        )
+    ),
+  found_interface AS (SELECT id FROM network_interface WHERE id = $18),
+  updated
+    AS (
+      UPDATE
+        network_interface
+      SET
+        time_deleted = now()
+      WHERE
+        id = $19 AND time_deleted IS NULL
+      RETURNING
+        id
+    )
+SELECT
+  found_interface.id, updated.id
+FROM
+  found_interface LEFT JOIN updated ON found_interface.id = updated.id

--- a/nexus/db-queries/tests/output/delete_vnic_probe_query.sql
+++ b/nexus/db-queries/tests/output/delete_vnic_probe_query.sql
@@ -1,0 +1,38 @@
+WITH
+  interface
+    AS MATERIALIZED (
+      SELECT
+        CAST(
+          IF(
+            (SELECT NOT is_primary FROM network_interface WHERE id = $1 AND time_deleted IS NULL)
+            OR (
+                SELECT
+                  count(*)
+                FROM
+                  network_interface
+                WHERE
+                  parent_id = $2 AND kind = $3 AND time_deleted IS NULL
+              )
+              <= 1,
+            $4,
+            $5
+          )
+            AS UUID
+        )
+    ),
+  found_interface AS (SELECT id FROM network_interface WHERE id = $6),
+  updated
+    AS (
+      UPDATE
+        network_interface
+      SET
+        time_deleted = now()
+      WHERE
+        id = $7 AND time_deleted IS NULL
+      RETURNING
+        id
+    )
+SELECT
+  found_interface.id, updated.id
+FROM
+  found_interface LEFT JOIN updated ON found_interface.id = updated.id

--- a/nexus/db-queries/tests/output/delete_vnic_service_query.sql
+++ b/nexus/db-queries/tests/output/delete_vnic_service_query.sql
@@ -1,0 +1,38 @@
+WITH
+  interface
+    AS MATERIALIZED (
+      SELECT
+        CAST(
+          IF(
+            (SELECT NOT is_primary FROM network_interface WHERE id = $1 AND time_deleted IS NULL)
+            OR (
+                SELECT
+                  count(*)
+                FROM
+                  network_interface
+                WHERE
+                  parent_id = $2 AND kind = $3 AND time_deleted IS NULL
+              )
+              <= 1,
+            $4,
+            $5
+          )
+            AS UUID
+        )
+    ),
+  found_interface AS (SELECT id FROM network_interface WHERE id = $6),
+  updated
+    AS (
+      UPDATE
+        network_interface
+      SET
+        time_deleted = now()
+      WHERE
+        id = $7 AND time_deleted IS NULL
+      RETURNING
+        id
+    )
+SELECT
+  found_interface.id, updated.id
+FROM
+  found_interface LEFT JOIN updated ON found_interface.id = updated.id


### PR DESCRIPTION
I think I'll need to change this query slightly to fix #10025, and that will be much easier to review / debug if we have expectorate tests showing the fully-expanded query.