### PR TITLE
Fix FM test copy-paste bug: case2 alert request was silently dropped

### DIFF
--- a/nexus/db-queries/src/db/datastore/fm.rs
+++ b/nexus/db-queries/src/db/datastore/fm.rs
@@ -1801,7 +1801,7 @@ mod tests {
                 closed_sitrep_id: None,
                 de: fm::DiagnosisEngineKind::PowerShelf,
                 ereports,
-                alerts_requested: Default::default(),
+                alerts_requested,
                 comment: "break in case of emergency".to_string(),
             }
         };
@@ -1925,8 +1925,8 @@ mod tests {
             .await
             .expect("failed to count alert requests before deletion");
         assert_eq!(
-            alert_requests_before, 2,
-            "two alert requests should exist before deletion"
+            alert_requests_before, 3,
+            "three alert requests should exist before deletion"
         );
 
         // Now delete the sitrep


### PR DESCRIPTION
In `make_sitrep_with_cases`, `case2` constructed a local `alerts_requested` map with a `TestQuuxBar` alert but used `Default::default()` in the struct literal instead. Update the corresponding assertion from 2 to 3.