### PR TITLE
nexus-types: add SupportBundleRequest type and Case field

### DIFF
--- a/nexus/db-model/src/fm/case.rs
+++ b/nexus/db-model/src/fm/case.rs
@@ -58,6 +58,7 @@ impl CaseMetadata {
             de,
             comment,
             alerts_requested: _,
+            support_bundles_requested: _,
             ereports: _,
         } = case;
         Self {

--- a/nexus/db-queries/src/db/datastore/fm.rs
+++ b/nexus/db-queries/src/db/datastore/fm.rs
@@ -385,6 +385,7 @@ impl DataStore {
                         comment,
                         ereports,
                         alerts_requested,
+                        support_bundles_requested: iddqd::IdOrdMap::new(),
                     }
                 }));
             }
@@ -1552,6 +1553,7 @@ mod tests {
                 de,
                 ereports,
                 alerts_requested,
+                support_bundles_requested: _,
             } = case;
             let case_id = id;
             let Some(expected) = this.cases.get(&case_id) else {
@@ -1770,6 +1772,7 @@ mod tests {
                 de: fm::DiagnosisEngineKind::PowerShelf,
                 ereports,
                 alerts_requested,
+                support_bundles_requested: iddqd::IdOrdMap::new(),
                 comment: "my cool case".to_string(),
             }
         };
@@ -1802,6 +1805,7 @@ mod tests {
                 de: fm::DiagnosisEngineKind::PowerShelf,
                 ereports,
                 alerts_requested,
+                support_bundles_requested: iddqd::IdOrdMap::new(),
                 comment: "break in case of emergency".to_string(),
             }
         };

--- a/nexus/fm/src/builder/case.rs
+++ b/nexus/fm/src/builder/case.rs
@@ -67,6 +67,7 @@ impl AllCases {
                     comment: String::new(),
                     ereports: Default::default(),
                     alerts_requested: Default::default(),
+                    support_bundles_requested: Default::default(),
                 };
                 entry.insert(CaseBuilder::new(
                     &self.log, sitrep_id, case, case_rng,

--- a/nexus/src/app/background/tasks/fm_rendezvous.rs
+++ b/nexus/src/app/background/tasks/fm_rendezvous.rs
@@ -230,6 +230,7 @@ mod tests {
             de: fm::DiagnosisEngineKind::PowerShelf,
             alerts_requested: iddqd::IdOrdMap::new(),
             ereports: iddqd::IdOrdMap::new(),
+            support_bundles_requested: iddqd::IdOrdMap::new(),
             comment: "my great case".to_string(),
         };
         case1
@@ -305,6 +306,7 @@ mod tests {
             de: fm::DiagnosisEngineKind::PowerShelf,
             alerts_requested: iddqd::IdOrdMap::new(),
             ereports: iddqd::IdOrdMap::new(),
+            support_bundles_requested: iddqd::IdOrdMap::new(),
             comment: "my other great case".to_string(),
         };
         case2

--- a/nexus/types/src/fm/case.rs
+++ b/nexus/types/src/fm/case.rs
@@ -5,8 +5,11 @@
 use crate::alert::AlertClass;
 use crate::fm::DiagnosisEngineKind;
 use crate::fm::Ereport;
+use crate::support_bundle::BundleDataSelection;
 use iddqd::{IdOrdItem, IdOrdMap};
-use omicron_uuid_kinds::{AlertUuid, CaseEreportUuid, CaseUuid, SitrepUuid};
+use omicron_uuid_kinds::{
+    AlertUuid, CaseEreportUuid, CaseUuid, SitrepUuid, SupportBundleUuid,
+};
 use serde::{Deserialize, Serialize};
 use std::fmt;
 use std::sync::Arc;
@@ -21,6 +24,7 @@ pub struct Case {
 
     pub ereports: IdOrdMap<CaseEreport>,
     pub alerts_requested: IdOrdMap<AlertRequest>,
+    pub support_bundles_requested: IdOrdMap<SupportBundleRequest>,
 
     pub comment: String,
 }
@@ -88,6 +92,27 @@ impl iddqd::IdOrdItem for AlertRequest {
     iddqd::id_upcast!();
 }
 
+/// A request to create a support bundle, associated with a [`Case`].
+#[derive(Clone, Debug, Serialize, Deserialize, PartialEq, Eq)]
+pub struct SupportBundleRequest {
+    /// Unique identifier for this support bundle request.
+    pub id: SupportBundleUuid,
+    /// The sitrep in which this support bundle was requested.
+    pub requested_sitrep_id: SitrepUuid,
+    /// Which data to include in the support bundle. Use
+    /// [`BundleDataSelection::default()`] to request all default data.
+    pub data_selection: BundleDataSelection,
+}
+
+impl iddqd::IdOrdItem for SupportBundleRequest {
+    type Key<'a> = &'a SupportBundleUuid;
+    fn key(&self) -> Self::Key<'_> {
+        &self.id
+    }
+
+    iddqd::id_upcast!();
+}
+
 struct DisplayCase<'a> {
     case: &'a Case,
     indent: usize,
@@ -120,6 +145,7 @@ impl fmt::Display for DisplayCase<'_> {
                     ereports,
                     comment,
                     alerts_requested,
+                    support_bundles_requested,
                 },
             indent,
             sitrep_id,
@@ -234,6 +260,33 @@ impl fmt::Display for DisplayCase<'_> {
             }
         }
 
+        if !support_bundles_requested.is_empty() {
+            writeln!(f, "\n{:>indent$}support bundles requested:", "")?;
+            writeln!(f, "{:>indent$}-------------------------", "")?;
+
+            let indent = indent + 2;
+            for SupportBundleRequest {
+                id,
+                requested_sitrep_id,
+                data_selection,
+            } in support_bundles_requested.iter()
+            {
+                const REQUESTED_IN: &str = "requested in:";
+                const DATA: &str = "data:";
+                const WIDTH: usize = const_max_len(&[REQUESTED_IN, DATA]);
+
+                writeln!(f, "{BULLET:>indent$}bundle {id}",)?;
+                writeln!(
+                    f,
+                    "{:>indent$}{REQUESTED_IN:<WIDTH$} {requested_sitrep_id}{}",
+                    "",
+                    this_sitrep(*requested_sitrep_id)
+                )?;
+                writeln!(f, "{:>indent$}{DATA}", "")?;
+                writeln!(f, "{}\n", data_selection.display(indent + 2))?;
+            }
+        }
+
         writeln!(f)?;
 
         Ok(())
@@ -244,10 +297,15 @@ impl fmt::Display for DisplayCase<'_> {
 mod tests {
     use super::*;
     use crate::fm::DiagnosisEngineKind;
+    use crate::fm::ereport::EreportFilters;
     use crate::inventory::SpType;
+    use crate::support_bundle::{
+        BundleData, BundleDataSelection, SledSelection,
+    };
     use ereport_types::{Ena, EreportId};
     use omicron_uuid_kinds::{
         AlertUuid, CaseUuid, EreporterRestartUuid, OmicronZoneUuid, SitrepUuid,
+        SupportBundleUuid,
     };
     use std::str::FromStr;
     use std::sync::Arc;
@@ -275,6 +333,12 @@ mod tests {
                 .unwrap();
         let alert2_id =
             AlertUuid::from_str("8a6f88ef-c436-44a9-b4cb-cae91d7306c9")
+                .unwrap();
+        let bundle1_id =
+            SupportBundleUuid::from_str("d1a2b3c4-e5f6-7890-abcd-ef1234567890")
+                .unwrap();
+        let bundle2_id =
+            SupportBundleUuid::from_str("a9b8c7d6-e5f4-3210-fedc-ba0987654321")
                 .unwrap();
 
         // Create some ereports
@@ -349,6 +413,31 @@ mod tests {
             })
             .unwrap();
 
+        let mut bundle1_data = BundleDataSelection::new();
+        bundle1_data.insert(BundleData::Reconfigurator);
+        bundle1_data.insert(BundleData::SpDumps);
+        bundle1_data.insert(BundleData::HostInfo(SledSelection::All));
+        bundle1_data.insert(BundleData::Ereports(EreportFilters {
+            only_classes: vec!["hw.pwr.*".to_string()],
+            ..Default::default()
+        }));
+
+        let mut support_bundles_requested = IdOrdMap::new();
+        support_bundles_requested
+            .insert_unique(SupportBundleRequest {
+                id: bundle1_id,
+                requested_sitrep_id: created_sitrep_id,
+                data_selection: bundle1_data,
+            })
+            .unwrap();
+        support_bundles_requested
+            .insert_unique(SupportBundleRequest {
+                id: bundle2_id,
+                requested_sitrep_id: closed_sitrep_id,
+                data_selection: BundleDataSelection::default(),
+            })
+            .unwrap();
+
         // Create the case
         let case = Case {
             id: case_id,
@@ -357,6 +446,7 @@ mod tests {
             de: DiagnosisEngineKind::PowerShelf,
             ereports,
             alerts_requested,
+            support_bundles_requested,
             comment: "Power shelf rectifier added and removed here :-)"
                 .to_string(),
         };

--- a/nexus/types/src/fm/ereport.rs
+++ b/nexus/types/src/fm/ereport.rs
@@ -217,7 +217,7 @@ fn get_sp_metadata_string(
 }
 
 /// A set of filters for fetching ereports.
-#[derive(Clone, Debug, Default, Eq, PartialEq)]
+#[derive(Clone, Debug, Default, Eq, PartialEq, Serialize, Deserialize)]
 pub struct EreportFilters {
     /// If present, include only ereports that were collected at the specified
     /// timestamp or later.
@@ -240,6 +240,69 @@ pub struct EreportFilters {
     pub only_classes: Vec<String>,
 }
 
+/// Displayer for pretty-printing [`EreportFilters`].
+#[must_use = "this struct does nothing unless displayed"]
+pub struct DisplayEreportFilters<'a> {
+    filters: &'a EreportFilters,
+}
+
+impl EreportFilters {
+    pub fn display(&self) -> DisplayEreportFilters<'_> {
+        DisplayEreportFilters { filters: self }
+    }
+}
+
+impl fmt::Display for DisplayEreportFilters<'_> {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        use itertools::Itertools;
+
+        let filters = self.filters;
+
+        // Writes a semicolon-separated part to the formatter, tracking whether
+        // we've written anything yet.
+        let mut empty = true;
+        let mut fmt_part =
+            |f: &mut fmt::Formatter, args: fmt::Arguments| -> fmt::Result {
+                if !empty {
+                    write!(f, "; ")?;
+                }
+                empty = false;
+                f.write_fmt(args)
+            };
+
+        if let Some(start) = &filters.start_time {
+            fmt_part(f, format_args!("start: {start}"))?;
+        }
+        if let Some(end) = &filters.end_time {
+            fmt_part(f, format_args!("end: {end}"))?;
+        }
+        if !filters.only_serials.is_empty() {
+            fmt_part(
+                f,
+                format_args!(
+                    "serials: {}",
+                    filters.only_serials.iter().format(", ")
+                ),
+            )?;
+        }
+        if !filters.only_classes.is_empty() {
+            fmt_part(
+                f,
+                format_args!(
+                    "classes: {}",
+                    filters.only_classes.iter().format(", ")
+                ),
+            )?;
+        }
+
+        // If no filters are set, display "none" rather than empty output.
+        if empty {
+            write!(f, "none")?;
+        }
+        Ok(())
+    }
+}
+
 impl EreportFilters {
     pub fn check_time_range(&self) -> Result<(), Error> {
         if let (Some(start), Some(end)) = (self.start_time, self.end_time) {
@@ -251,5 +314,42 @@ impl EreportFilters {
         }
 
         Ok(())
+    }
+}
+
+#[cfg(test)]
+pub(crate) mod test_utils {
+    use super::*;
+    use proptest::prelude::*;
+
+    fn arb_datetime() -> impl Strategy<Value = DateTime<Utc>> {
+        // Generate timestamps in a reasonable range (2020-2030).
+        (1577836800i64..1893456000i64)
+            .prop_map(|secs| DateTime::from_timestamp(secs, 0).unwrap())
+    }
+
+    impl Arbitrary for EreportFilters {
+        type Parameters = ();
+        type Strategy = BoxedStrategy<Self>;
+
+        fn arbitrary_with(_: Self::Parameters) -> Self::Strategy {
+            (
+                prop::option::of(arb_datetime()),
+                prop::option::of(arb_datetime()),
+                prop::collection::vec(".*", 0..=3),
+                prop::collection::vec(".*", 0..=3),
+            )
+                .prop_map(
+                    |(start_time, end_time, only_serials, only_classes)| {
+                        EreportFilters {
+                            start_time,
+                            end_time,
+                            only_serials,
+                            only_classes,
+                        }
+                    },
+                )
+                .boxed()
+        }
     }
 }

--- a/nexus/types/src/support_bundle.rs
+++ b/nexus/types/src/support_bundle.rs
@@ -8,12 +8,16 @@
 //! They are shared between the support bundle collector and FM case types.
 
 use crate::fm::ereport::EreportFilters;
+use itertools::Itertools;
 use omicron_uuid_kinds::SledUuid;
+use serde::{Deserialize, Serialize};
 use std::collections::HashMap;
 use std::collections::HashSet;
+use std::fmt;
 
 /// Describes the category of support bundle data.
-#[derive(Debug, Clone, Copy, Hash, Eq, PartialEq)]
+#[derive(Debug, Clone, Copy, Hash, Eq, PartialEq, Serialize, Deserialize)]
+#[cfg_attr(test, derive(test_strategy::Arbitrary))]
 pub enum BundleDataCategory {
     /// Collects reconfigurator state (some of the latest blueprints,
     /// information about the target blueprint).
@@ -35,7 +39,8 @@ pub enum BundleDataCategory {
 /// For categories without additional parameters, the variant is a unit variant.
 /// For categories that can be filtered or configured, the variant contains
 /// that configuration data.
-#[derive(Debug, Clone, Eq, PartialEq)]
+#[derive(Debug, Clone, Eq, PartialEq, Serialize, Deserialize)]
+#[cfg_attr(test, derive(test_strategy::Arbitrary))]
 pub enum BundleData {
     Reconfigurator,
     HostInfo(SledSelection),
@@ -56,12 +61,40 @@ impl BundleData {
     }
 }
 
+/// Displayer for pretty-printing [`BundleData`].
+#[must_use = "this struct does nothing unless displayed"]
+pub struct DisplayBundleData<'a> {
+    data: &'a BundleData,
+}
+
+impl BundleData {
+    pub fn display(&self) -> DisplayBundleData<'_> {
+        DisplayBundleData { data: self }
+    }
+}
+
+impl fmt::Display for DisplayBundleData<'_> {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self.data {
+            BundleData::Reconfigurator => write!(f, "reconfigurator"),
+            BundleData::HostInfo(selection) => {
+                write!(f, "host_info({})", selection.display())
+            }
+            BundleData::SledCubbyInfo => write!(f, "sled_cubby_info"),
+            BundleData::SpDumps => write!(f, "sp_dumps"),
+            BundleData::Ereports(filters) => {
+                write!(f, "ereports({})", filters.display())
+            }
+        }
+    }
+}
+
 /// A collection of bundle data specifications.
 ///
 /// This wrapper ensures that categories and data always match - you can't
 /// insert (BundleDataCategory::Reconfigurator, BundleData::SpDumps)
 /// because each BundleData determines its own category.
-#[derive(Debug, Clone, Eq, PartialEq)]
+#[derive(Debug, Clone, Eq, PartialEq, Serialize, Deserialize)]
 pub struct BundleDataSelection {
     data: HashMap<BundleDataCategory, BundleData>,
 }
@@ -91,6 +124,32 @@ impl BundleDataSelection {
 
     pub fn get(&self, category: BundleDataCategory) -> Option<&BundleData> {
         self.data.get(&category)
+    }
+}
+
+/// Displayer for pretty-printing [`BundleDataSelection`].
+#[must_use = "this struct does nothing unless displayed"]
+pub struct DisplayBundleDataSelection<'a> {
+    selection: &'a BundleDataSelection,
+    indent: usize,
+}
+
+impl BundleDataSelection {
+    pub fn display(&self, indent: usize) -> DisplayBundleDataSelection<'_> {
+        DisplayBundleDataSelection { selection: self, indent }
+    }
+}
+
+impl fmt::Display for DisplayBundleDataSelection<'_> {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        let indent = self.indent;
+        for (i, item) in self.selection.data.values().enumerate() {
+            if i > 0 {
+                writeln!(f)?;
+            }
+            write!(f, "{:>indent$}- {}", "", item.display())?;
+        }
+        Ok(())
     }
 }
 
@@ -126,8 +185,64 @@ impl Default for BundleDataSelection {
 
 /// The set of sleds to include. This can either be all sleds, or a set of
 /// specific sleds.
-#[derive(Debug, Clone, Eq, PartialEq)]
+#[derive(Debug, Clone, Eq, PartialEq, Serialize, Deserialize)]
+#[cfg_attr(test, derive(test_strategy::Arbitrary))]
 pub enum SledSelection {
     All,
     Specific(HashSet<SledUuid>),
+}
+
+/// Displayer for pretty-printing [`SledSelection`].
+#[must_use = "this struct does nothing unless displayed"]
+pub struct DisplaySledSelection<'a> {
+    selection: &'a SledSelection,
+}
+
+impl SledSelection {
+    pub fn display(&self) -> DisplaySledSelection<'_> {
+        DisplaySledSelection { selection: self }
+    }
+}
+
+impl fmt::Display for DisplaySledSelection<'_> {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self.selection {
+            SledSelection::All => write!(f, "all"),
+            SledSelection::Specific(ids) => {
+                write!(f, "{}", ids.iter().format(", "))
+            }
+        }
+    }
+}
+
+#[cfg(test)]
+pub(crate) mod test_utils {
+    use super::*;
+    use proptest::prelude::*;
+
+    impl Arbitrary for BundleDataSelection {
+        type Parameters = ();
+        type Strategy = BoxedStrategy<Self>;
+
+        fn arbitrary_with(_: Self::Parameters) -> Self::Strategy {
+            prop::collection::vec(any::<BundleData>(), 0..=5)
+                .prop_map(|data| data.into_iter().collect())
+                .boxed()
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use proptest::prelude::*;
+    use test_strategy::proptest;
+
+    #[proptest]
+    fn bundle_data_selection_serde_round_trip(selection: BundleDataSelection) {
+        let json = serde_json::to_string(&selection).unwrap();
+        let deserialized: BundleDataSelection =
+            serde_json::from_str(&json).unwrap();
+        prop_assert_eq!(selection, deserialized);
+    }
 }


### PR DESCRIPTION
The core thing this PR does is:
* Introduce a new `SupportBundleRequest` type to `fm::case` (analogous to @hawkw's `AlertRequest`), and
* Introduce a new `support_bundles_requested` field to `Case` (analogous to `alerts_requested`).

There's a lot of ✨ceremony✨ around this small change, though:

* `DisplayCase` has a sophisticated `impl Display` that formats the stuff it contains. So we need `Display` impls for all the things `SupportBundleRequest` transitively contains (`BundleData`, etc.). Here's what this comes out looking like:

    ```
         support bundles requested:
         -------------------------
         * bundle a9b8c7d6-e5f4-3210-fedc-ba0987654321
           requested in: bba63ba7-bf6b-45f4-b241-d13ccd07fe1c <-- this sitrep
           data:         all (default)

         * bundle d1a2b3c4-e5f6-7890-abcd-ef1234567890
           requested in: ea7affb0-36eb-4a9a-b9bd-22e00f1bcc04
           data:
             - sp_dumps
             - ereports(classes: hw.pwr.*)
             - host_info(all)
             - reconfigurator
    ```

* Since `Case` is `serde::Serialize/Deserialize`, we also need to add derives to `SupportBundleRequest` and all the things it transitively contains.

* Lastly, since we want to have some sort of reasonable round-trip test for the serialization / deserialization, we use proptest to generate arbitrary inputs. This requires `Arbitrary` impls (or functions that return `Strategy`) for all the things too.

Context: #10062.