### PR TITLE
Make sure we still do writeback on test failure

### DIFF
--- a/.config/nextest.toml
+++ b/.config/nextest.toml
@@ -69,7 +69,7 @@ threads-required = 4
 [[profile.ci.overrides]]
 # `omicron-test-utils` is included in this block that uses a longer-than-normal
 # timeout because under some conditions it waits for CockroachDB to shut down
-# gracefully. Not that `omicron-test-utils` depends on `omicron-nexus`, so this
+# gracefully. Note that `omicron-test-utils` depends on `omicron-nexus`, so this
 # is redundant, but we do this for future-proofing.
 filter = 'binary_id(omicron-nexus::test_all) + rdeps(omicron-test-utils)'
 # As of 2023-01-08, the slowest test in test_all takes 196s on a Ryzen 7950X.

--- a/test-utils/src/dev/db.rs
+++ b/test-utils/src/dev/db.rs
@@ -762,7 +762,10 @@ impl Drop for CockroachInstance {
             // written to the WAL but may only exist in Pebble's user-space
             // write buffer. SIGTERM triggers Pebble's DB.Close() which flushes
             // and fsyncs the WAL before exiting.
-            // See: https://github.com/oxidecomputer/omicron/issues/10085
+            //
+            // See also:
+            // - https://github.com/oxidecomputer/cockroach/blob/release-22.1-oxide/pkg/cli/start_unix.go#L37
+            // - https://github.com/oxidecomputer/omicron/issues/10085
             if let Some(child_process) = self.child_process.as_mut() {
                 let pid = self.pid as libc::pid_t;
                 unsafe { libc::kill(pid, libc::SIGTERM) };


### PR DESCRIPTION
Uses SIGTERM for `CockroachInstances` that are dropped without being cleaned, to propagate ongoing
writes back to durable storage for inspection.

Additionally, adds a test which validates this behavior (torn writes should no longer appear with the new SIGTERM-on-drop implementation).

Fixes https://github.com/oxidecomputer/omicron/issues/10085