### PR TITLE
Fix path resolution to dpd for MacOS

### DIFF
--- a/test-utils/src/dev/dendrite.rs
+++ b/test-utils/src/dev/dendrite.rs
@@ -63,7 +63,14 @@ impl DendriteInstance {
             args.push(socket_addr.to_string());
         }
 
-        let mut child = tokio::process::Command::new("dpd")
+        let (dpd_bin, p4_dir) = get_dpd_path();
+        let mut cmd = tokio::process::Command::new(dpd_bin);
+        if let Some(ref p4_dir) = p4_dir {
+            if std::env::var("P4_DIR").is_err() {
+                cmd.env("P4_DIR", p4_dir);
+            }
+        }
+        let mut child = cmd
             .args(&args)
             .stdin(Stdio::null())
             .stdout(Stdio::from(redirect_file(
@@ -108,6 +115,26 @@ impl DendriteInstance {
         }
         Ok(())
     }
+}
+
+fn get_dpd_path() -> (PathBuf, Option<PathBuf>) {
+    // On macOS, std::env::current_exe() does not resolve symlinks.
+    let dpd_path = Path::new("dpd");
+    let resolved_dpd = std::env::var_os("PATH")
+        .and_then(|paths| {
+            std::env::split_paths(&paths)
+                .map(|dir| dir.join("dpd"))
+                .find(|p| p.is_file())
+        })
+        .and_then(|p| std::fs::canonicalize(&p).ok());
+
+    // Rebuild the p4 directory path from dpd path
+    let p4_dir = resolved_dpd.as_ref().and_then(|p| {
+        p.parent().and_then(|p| p.parent()).map(|p| p.join("sidecar"))
+    });
+
+    let dpd_bin = resolved_dpd.as_deref().unwrap_or(dpd_path).to_owned();
+    (dpd_bin, p4_dir)
 }
 
 impl Drop for DendriteInstance {
@@ -206,6 +233,8 @@ async fn find_dendrite_port_in_log(
 
 #[cfg(test)]
 mod tests {
+    use crate::dev::dendrite::get_dpd_path;
+
     use super::find_dendrite_port_in_log;
     use std::io::Write;
     use std::process::Stdio;
@@ -216,7 +245,8 @@ mod tests {
     #[tokio::test]
     async fn test_dpd_in_path() {
         // With no arguments, we expect to see the default help message.
-        tokio::process::Command::new("dpd")
+        let (dpd_bin, _) = get_dpd_path();
+        tokio::process::Command::new(dpd_bin)
             .stdin(Stdio::null())
             .stdout(Stdio::null())
             .stderr(Stdio::null())


### PR DESCRIPTION
First of all, sorry if this is noise. I was trying to get a better understanding of `omicron` and had trouble running it through the simulated environment. If there is a different process I should use for PRs, I'm willing to go through that too, but might need to be pointed to a doc I missed.

On macOS, `std::env::current_exe()` does not resolve symlinks.
        
The dendrite-stub download creates a symlink:
- `out/dendrite-stub/bin` -> `out/dendrite-stub/root/opt/oxide/dendrite/bin`
- dpd's built-in infer_p4_dir() walks up from its path expecting `.../opt/oxide/dendrite/bin/dpd`, but through the symlink it sees `".../dendrite-stub/bin/dpd` and fails.

The real dpd path is resolved and then derive P4_DIR from it to bypass this.

I couldn't run the tests locally due to issues pointed out in docs already about trying this on MacOS. Thanks for your time!