### PR TITLE
nexus: Removed 'unzipped_logs' from log path

### DIFF
--- a/nexus/src/app/background/tasks/support_bundle/steps/host_info.rs
+++ b/nexus/src/app/background/tasks/support_bundle/steps/host_info.rs
@@ -270,7 +270,7 @@ async fn save_zone_log_zip_or_error(
         Ok(res) => {
             let bytestream = res.into_inner();
             let output_dir = path.join(format!("logs/{zone}"));
-            let output_path = output_dir.join("logs.zip");
+            let zipfile_path = output_dir.join("logs.zip");
 
             // Ensure the logs output directory exists.
             tokio::fs::create_dir_all(&output_dir).await.with_context(
@@ -279,8 +279,8 @@ async fn save_zone_log_zip_or_error(
 
             // Stream the log zip file to disk.
             let mut file =
-                tokio::fs::File::create(&output_path).await.with_context(
-                    || format!("failed to create log zip file: {output_path}"),
+                tokio::fs::File::create(&zipfile_path).await.with_context(
+                    || format!("failed to create log zip file: {zipfile_path}"),
                 )?;
 
             let stream = bytestream
@@ -291,10 +291,9 @@ async fn save_zone_log_zip_or_error(
             file.flush().await?;
 
             // Unzip the log file into the same directory.
-            let output_path_unzip = output_dir.join("unzipped_logs");
-            let zipfile_path = output_path.clone();
+            let zip_path = zipfile_path.clone();
             tokio::task::spawn_blocking(move || {
-                extract_zip_file(&output_path_unzip, &zipfile_path)
+                extract_zip_file(&output_dir, &zip_path)
             })
             .await
             .map_err(|join_error| {
@@ -303,12 +302,12 @@ async fn save_zone_log_zip_or_error(
             })??;
 
             // Clean up the zip file that was written to disk.
-            if let Err(e) = tokio::fs::remove_file(&output_path).await {
+            if let Err(e) = tokio::fs::remove_file(&zipfile_path).await {
                 error!(
                     logger,
                     "failed to cleanup temporary logs zip file";
                     InlineErrorChain::new(&e),
-                    "file" => %output_path,
+                    "file" => %zipfile_path,
 
                 );
             }


### PR DESCRIPTION
As part of the changes in #9498, we added an `unzipped_logs` directory to the path of all log files captured in bundles, like this:

```
rack/<RACK_UUID>/sled/<SLED_UUID>/logs/<ZONE>/unzipped_logs/<SERVICE>/archive/<LOG>
```

Remove `unzipped_logs` element from the path, as we're already in a directory tree named `logs`. The updated path is:

```
rack/<RACK_UUID>/sled/<SLED_UUID>/logs/<ZONE>/<SERVICE>/archive/<LOG>
```

While we're at it, rename `output_path` to `zipfile_path` to disambiguate between the parent `output_dir` directory, and the zipfile.