### PR TITLE
refactor SledSelection: All vs Specific(HashSet<SledUuid>)

### DIFF
--- a/nexus/src/app/background/tasks/support_bundle/request.rs
+++ b/nexus/src/app/background/tasks/support_bundle/request.rs
@@ -46,14 +46,13 @@ impl BundleRequest {
     }
 
     pub fn include_sled_host_info(&self, id: SledUuid) -> bool {
-        let selection =
-            match self.data_selection.get(BundleDataCategory::HostInfo) {
-                Some(BundleData::HostInfo(selection)) => selection,
-                _ => return false,
-            };
-
-        selection.contains(&SledSelection::Specific(id))
-            || selection.contains(&SledSelection::All)
+        match self.data_selection.get(BundleDataCategory::HostInfo) {
+            Some(BundleData::HostInfo(SledSelection::All)) => true,
+            Some(BundleData::HostInfo(SledSelection::Specific(sleds))) => {
+                sleds.contains(&id)
+            }
+            _ => false,
+        }
     }
 
     pub fn get_ereport_filters(&self) -> Option<&EreportFilters> {

--- a/nexus/src/app/background/tasks/support_bundle_collector.rs
+++ b/nexus/src/app/background/tasks/support_bundle_collector.rs
@@ -455,7 +455,7 @@ mod test {
     use nexus_types::internal_api::background::SupportBundleCollectionStep;
     use nexus_types::internal_api::background::SupportBundleEreportStatus;
     use nexus_types::inventory::SpType;
-    use nexus_types::support_bundle::BundleData;
+    use nexus_types::support_bundle::{BundleData, SledSelection};
     use omicron_common::api::external::ByteCount;
     use omicron_common::api::internal::shared::DatasetKind;
     use omicron_common::disk::DatasetConfig;
@@ -831,7 +831,9 @@ mod test {
         // NOTE: The support bundle querying interface isn't supported on
         // the simulated sled agent (yet?) so we're using an empty sled selection.
         let mut request = BundleRequest::default();
-        request.data_selection.insert(BundleData::HostInfo(HashSet::new()));
+        request.data_selection.insert(BundleData::HostInfo(
+            SledSelection::Specific(HashSet::new()),
+        ));
         let report = collector
             .collect_bundle(&opctx, &request)
             .await
@@ -908,7 +910,9 @@ mod test {
 
         // Collect the bundle
         let mut request = BundleRequest::default();
-        request.data_selection.insert(BundleData::HostInfo(HashSet::new()));
+        request.data_selection.insert(BundleData::HostInfo(
+            SledSelection::Specific(HashSet::new()),
+        ));
         let report = collector
             .collect_bundle(&opctx, &request)
             .await
@@ -1025,7 +1029,7 @@ mod test {
             transfer_chunk_size: NonZeroU64::new(16).unwrap(),
             data_selection: [
                 BundleData::Reconfigurator,
-                BundleData::HostInfo(HashSet::new()),
+                BundleData::HostInfo(SledSelection::Specific(HashSet::new())),
                 BundleData::SledCubbyInfo,
                 BundleData::SpDumps,
             ]
@@ -1127,7 +1131,9 @@ mod test {
 
         // Each time we call "collect_bundle", we collect a SINGLE bundle.
         let mut request = BundleRequest::default();
-        request.data_selection.insert(BundleData::HostInfo(HashSet::new()));
+        request.data_selection.insert(BundleData::HostInfo(
+            SledSelection::Specific(HashSet::new()),
+        ));
         let report = collector
             .collect_bundle(&opctx, &request)
             .await
@@ -1292,7 +1298,9 @@ mod test {
             nexus.id(),
         );
         let mut request = BundleRequest::default();
-        request.data_selection.insert(BundleData::HostInfo(HashSet::new()));
+        request.data_selection.insert(BundleData::HostInfo(
+            SledSelection::Specific(HashSet::new()),
+        ));
         let report = collector
             .collect_bundle(&opctx, &request)
             .await
@@ -1447,7 +1455,9 @@ mod test {
             nexus.id(),
         );
         let mut request = BundleRequest::default();
-        request.data_selection.insert(BundleData::HostInfo(HashSet::new()));
+        request.data_selection.insert(BundleData::HostInfo(
+            SledSelection::Specific(HashSet::new()),
+        ));
         let report = collector
             .collect_bundle(&opctx, &request)
             .await
@@ -1532,7 +1542,9 @@ mod test {
             nexus.id(),
         );
         let mut request = BundleRequest::default();
-        request.data_selection.insert(BundleData::HostInfo(HashSet::new()));
+        request.data_selection.insert(BundleData::HostInfo(
+            SledSelection::Specific(HashSet::new()),
+        ));
         let report = collector
             .collect_bundle(&opctx, &request)
             .await
@@ -1618,7 +1630,9 @@ mod test {
 
         // Collect the bundle
         let mut request = BundleRequest::default();
-        request.data_selection.insert(BundleData::HostInfo(HashSet::new()));
+        request.data_selection.insert(BundleData::HostInfo(
+            SledSelection::Specific(HashSet::new()),
+        ));
         let report = collector
             .collect_bundle(&opctx, &request)
             .await

--- a/nexus/types/src/support_bundle.rs
+++ b/nexus/types/src/support_bundle.rs
@@ -38,7 +38,7 @@ pub enum BundleDataCategory {
 #[derive(Debug, Clone, Eq, PartialEq)]
 pub enum BundleData {
     Reconfigurator,
-    HostInfo(HashSet<SledSelection>),
+    HostInfo(SledSelection),
     SledCubbyInfo,
     SpDumps,
     Ereports(EreportFilters),
@@ -111,7 +111,7 @@ impl Default for BundleDataSelection {
     fn default() -> Self {
         [
             BundleData::Reconfigurator,
-            BundleData::HostInfo(HashSet::from([SledSelection::All])),
+            BundleData::HostInfo(SledSelection::All),
             BundleData::SledCubbyInfo,
             BundleData::SpDumps,
             BundleData::Ereports(EreportFilters {
@@ -124,12 +124,10 @@ impl Default for BundleDataSelection {
     }
 }
 
-/// The set of sleds to include.
-///
-/// Multiple values of this enum are joined together into a HashSet.
-/// Therefore "SledSelection::All" overrides specific sleds.
-#[derive(Debug, Clone, Hash, Eq, PartialEq)]
+/// The set of sleds to include. This can either be all sleds, or a set of
+/// specific sleds.
+#[derive(Debug, Clone, Eq, PartialEq)]
 pub enum SledSelection {
     All,
-    Specific(SledUuid),
+    Specific(HashSet<SledUuid>),
 }


### PR DESCRIPTION
Currently, `SledSelection` has two variants: `All` and `Specific(SledUuid)`. These can be lumped into a `HashSet` together, which is a little weird. This PR pushes the `HashSet` down into the `Specific` variant.