### PR TITLE
Builder APIs for BundleDataSelection and EreportFilters

### DIFF
--- a/nexus/db-queries/src/db/datastore/ereport.rs
+++ b/nexus/db-queries/src/db/datastore/ereport.rs
@@ -95,7 +95,6 @@ impl DataStore {
         pagparams: &DataPageParams<'_, (Uuid, DbEna)>,
     ) -> ListResultVec<Ereport> {
         opctx.authorize(authz::Action::ListChildren, &authz::FLEET).await?;
-        filters.check_time_range()?;
 
         let query = Self::ereport_fetch_matching_query(filters, pagparams);
         query
@@ -116,23 +115,23 @@ impl DataStore {
         .filter(dsl::time_deleted.is_null())
         .select(Ereport::as_select());
 
-        if let Some(start) = filters.start_time {
+        if let Some(start) = filters.start_time() {
             query = query.filter(dsl::time_collected.ge(start));
         }
 
-        if let Some(end) = filters.end_time {
+        if let Some(end) = filters.end_time() {
             query = query.filter(dsl::time_collected.le(end));
         }
 
-        if !filters.only_serials.is_empty() {
+        if !filters.only_serials().is_empty() {
             query = query.filter(
-                dsl::serial_number.eq_any(filters.only_serials.clone()),
+                dsl::serial_number.eq_any(filters.only_serials().to_vec()),
             );
         }
 
-        if !filters.only_classes.is_empty() {
-            query =
-                query.filter(dsl::class.eq_any(filters.only_classes.clone()));
+        if !filters.only_classes().is_empty() {
+            query = query
+                .filter(dsl::class.eq_any(filters.only_classes().to_vec()));
         }
 
         query
@@ -419,13 +418,7 @@ mod tests {
     async fn explain_ereport_fetch_matching_only_serials() {
         explain_fetch_matching_query(
             "explain_ereport_fetch_matching_only_serials",
-            EreportFilters {
-                only_serials: vec![
-                    "BRM6900420".to_string(),
-                    "BRM5555555".to_string(),
-                ],
-                ..Default::default()
-            },
+            EreportFilters::new().with_serials(["BRM6900420", "BRM5555555"]),
         )
         .await
     }
@@ -434,17 +427,12 @@ mod tests {
     async fn explain_ereport_fetch_matching_serials_and_classes() {
         explain_fetch_matching_query(
             "explain_ereport_fetch_matching_serials_and_classes",
-            EreportFilters {
-                only_serials: vec![
-                    "BRM6900420".to_string(),
-                    "BRM5555555".to_string(),
-                ],
-                only_classes: vec![
-                    "my.cool.ereport".to_string(),
-                    "hw.frobulator.fault.frobulation_failed".to_string(),
-                ],
-                ..Default::default()
-            },
+            EreportFilters::new()
+                .with_serials(["BRM6900420", "BRM5555555"])
+                .with_classes([
+                    "my.cool.ereport",
+                    "hw.frobulator.fault.frobulation_failed",
+                ]),
         )
         .await
     }
@@ -453,10 +441,9 @@ mod tests {
     async fn explain_ereport_fetch_matching_only_time() {
         explain_fetch_matching_query(
             "explain_ereport_fetch_matching_only_time",
-            EreportFilters {
-                end_time: Some(chrono::Utc::now()),
-                ..Default::default()
-            },
+            EreportFilters::new()
+                .with_end_time(chrono::Utc::now())
+                .expect("no start time set"),
         )
         .await
     }
@@ -465,14 +452,10 @@ mod tests {
     async fn explain_ereport_fetch_matching_time_and_serials() {
         explain_fetch_matching_query(
             "explain_ereport_fetch_matching_only_time",
-            EreportFilters {
-                only_serials: vec![
-                    "BRM6900420".to_string(),
-                    "BRM5555555".to_string(),
-                ],
-                end_time: Some(chrono::Utc::now()),
-                ..Default::default()
-            },
+            EreportFilters::new()
+                .with_serials(["BRM6900420", "BRM5555555"])
+                .with_end_time(chrono::Utc::now())
+                .expect("no start time set"),
         )
         .await
     }
@@ -585,12 +568,11 @@ mod tests {
         let found_by_time_range = datastore
             .ereport_fetch_matching(
                 opctx,
-                &EreportFilters {
-                    start_time: Some(
+                &EreportFilters::new()
+                    .with_start_time(
                         ereport.time_collected - Duration::from_secs(600),
-                    ),
-                    ..Default::default()
-                },
+                    )
+                    .expect("no end time set"),
                 &pagparams,
             )
             .await
@@ -600,10 +582,7 @@ mod tests {
         let found_by_serial = datastore
             .ereport_fetch_matching(
                 opctx,
-                &EreportFilters {
-                    only_serials: vec!["my cool serial".to_string()],
-                    ..Default::default()
-                },
+                &EreportFilters::new().with_serials(["my cool serial"]),
                 &pagparams,
             )
             .await
@@ -613,10 +592,7 @@ mod tests {
         let found_by_class = datastore
             .ereport_fetch_matching(
                 opctx,
-                &EreportFilters {
-                    only_classes: vec!["my cool ereport".to_string()],
-                    ..Default::default()
-                },
+                &EreportFilters::new().with_classes(["my cool ereport"]),
                 &pagparams,
             )
             .await

--- a/nexus/src/app/background/tasks/support_bundle_collector.rs
+++ b/nexus/src/app/background/tasks/support_bundle_collector.rs
@@ -831,9 +831,7 @@ mod test {
         // NOTE: The support bundle querying interface isn't supported on
         // the simulated sled agent (yet?) so we're using an empty sled selection.
         let mut request = BundleRequest::default();
-        request.data_selection.insert(BundleData::HostInfo(
-            SledSelection::Specific(HashSet::new()),
-        ));
+        request.data_selection = request.data_selection.with_specific_sleds([]);
         let report = collector
             .collect_bundle(&opctx, &request)
             .await
@@ -910,9 +908,7 @@ mod test {
 
         // Collect the bundle
         let mut request = BundleRequest::default();
-        request.data_selection.insert(BundleData::HostInfo(
-            SledSelection::Specific(HashSet::new()),
-        ));
+        request.data_selection = request.data_selection.with_specific_sleds([]);
         let report = collector
             .collect_bundle(&opctx, &request)
             .await
@@ -1131,9 +1127,7 @@ mod test {
 
         // Each time we call "collect_bundle", we collect a SINGLE bundle.
         let mut request = BundleRequest::default();
-        request.data_selection.insert(BundleData::HostInfo(
-            SledSelection::Specific(HashSet::new()),
-        ));
+        request.data_selection = request.data_selection.with_specific_sleds([]);
         let report = collector
             .collect_bundle(&opctx, &request)
             .await
@@ -1298,9 +1292,7 @@ mod test {
             nexus.id(),
         );
         let mut request = BundleRequest::default();
-        request.data_selection.insert(BundleData::HostInfo(
-            SledSelection::Specific(HashSet::new()),
-        ));
+        request.data_selection = request.data_selection.with_specific_sleds([]);
         let report = collector
             .collect_bundle(&opctx, &request)
             .await
@@ -1455,9 +1447,7 @@ mod test {
             nexus.id(),
         );
         let mut request = BundleRequest::default();
-        request.data_selection.insert(BundleData::HostInfo(
-            SledSelection::Specific(HashSet::new()),
-        ));
+        request.data_selection = request.data_selection.with_specific_sleds([]);
         let report = collector
             .collect_bundle(&opctx, &request)
             .await
@@ -1542,9 +1532,7 @@ mod test {
             nexus.id(),
         );
         let mut request = BundleRequest::default();
-        request.data_selection.insert(BundleData::HostInfo(
-            SledSelection::Specific(HashSet::new()),
-        ));
+        request.data_selection = request.data_selection.with_specific_sleds([]);
         let report = collector
             .collect_bundle(&opctx, &request)
             .await
@@ -1630,9 +1618,7 @@ mod test {
 
         // Collect the bundle
         let mut request = BundleRequest::default();
-        request.data_selection.insert(BundleData::HostInfo(
-            SledSelection::Specific(HashSet::new()),
-        ));
+        request.data_selection = request.data_selection.with_specific_sleds([]);
         let report = collector
             .collect_bundle(&opctx, &request)
             .await

--- a/nexus/types/src/fm/case.rs
+++ b/nexus/types/src/fm/case.rs
@@ -299,9 +299,7 @@ mod tests {
     use crate::fm::DiagnosisEngineKind;
     use crate::fm::ereport::EreportFilters;
     use crate::inventory::SpType;
-    use crate::support_bundle::{
-        BundleData, BundleDataSelection, SledSelection,
-    };
+    use crate::support_bundle::BundleDataSelection;
     use ereport_types::{Ena, EreportId};
     use omicron_uuid_kinds::{
         AlertUuid, CaseUuid, EreporterRestartUuid, OmicronZoneUuid, SitrepUuid,
@@ -413,14 +411,11 @@ mod tests {
             })
             .unwrap();
 
-        let mut bundle1_data = BundleDataSelection::new();
-        bundle1_data.insert(BundleData::Reconfigurator);
-        bundle1_data.insert(BundleData::SpDumps);
-        bundle1_data.insert(BundleData::HostInfo(SledSelection::All));
-        bundle1_data.insert(BundleData::Ereports(EreportFilters {
-            only_classes: vec!["hw.pwr.*".to_string()],
-            ..Default::default()
-        }));
+        let bundle1_data = BundleDataSelection::new()
+            .with_reconfigurator()
+            .with_sp_dumps()
+            .with_all_sleds()
+            .with_ereports(EreportFilters::new().with_classes(["hw.pwr.*"]));
 
         let mut support_bundles_requested = IdOrdMap::new();
         support_bundles_requested

--- a/nexus/types/src/fm/ereport.rs
+++ b/nexus/types/src/fm/ereport.rs
@@ -217,27 +217,72 @@ fn get_sp_metadata_string(
 }
 
 /// A set of filters for fetching ereports.
+///
+/// Construct using [`EreportFilters::new`] and the builder methods:
+///
+/// ```
+/// # use nexus_types::fm::ereport::EreportFilters;
+/// let filters = EreportFilters::new()
+///     .with_start_time(chrono::Utc::now() - chrono::Days::new(7))
+///     .expect("no end time set")
+///     .with_serials(["BRM6900420"])
+///     .with_classes(["hw.pwr.*"]);
+/// ```
+///
+/// Note: JSON deserialization validates the start_time/end_time constraints
+/// using `TryFrom<EreportFiltersUnvalidated>`.
 #[derive(Clone, Debug, Default, Eq, PartialEq, Serialize, Deserialize)]
+#[serde(try_from = "EreportFiltersUnvalidated")]
 pub struct EreportFilters {
     /// If present, include only ereports that were collected at the specified
     /// timestamp or later.
     ///
-    /// If `end_time` is also present, this value *must* be earlier than
-    /// `end_time`.
-    pub start_time: Option<DateTime<Utc>>,
+    /// If `end_time` is also present, this value *must* be at or before
+    /// `end_time`. This invariant is enforced by [`Self::with_start_time`].
+    start_time: Option<DateTime<Utc>>,
     /// If present, include only ereports that were collected at the specified
     /// timestamp or before.
     ///
-    /// If `start_time` is also present, this value *must* be later than
-    /// `start_time`.
-    pub end_time: Option<DateTime<Utc>>,
+    /// If `start_time` is also present, this value *must* be at or after
+    /// `start_time`. This invariant is enforced by [`Self::with_end_time`].
+    end_time: Option<DateTime<Utc>>,
     /// If this list is non-empty, include only ereports that were reported by
     /// systems with the provided serial numbers.
-    pub only_serials: Vec<String>,
+    only_serials: Vec<String>,
     /// If this list is non-empty, include only ereports with the provided class
     /// strings.
     // TODO(eliza): globbing could be nice to add here eventually...
-    pub only_classes: Vec<String>,
+    only_classes: Vec<String>,
+}
+
+/// Private deserialization helper for [`EreportFilters`] that validates the
+/// `start_time <= end_time` invariant.
+#[derive(Deserialize)]
+struct EreportFiltersUnvalidated {
+    start_time: Option<DateTime<Utc>>,
+    end_time: Option<DateTime<Utc>>,
+    only_serials: Vec<String>,
+    only_classes: Vec<String>,
+}
+
+impl TryFrom<EreportFiltersUnvalidated> for EreportFilters {
+    type Error = Error;
+
+    fn try_from(
+        unvalidated: EreportFiltersUnvalidated,
+    ) -> Result<Self, Self::Error> {
+        let mut f = Self::new();
+        if let Some(t) = unvalidated.start_time {
+            f = f.with_start_time(t)?;
+        }
+        if let Some(t) = unvalidated.end_time {
+            f = f.with_end_time(t)?;
+        }
+        f = f
+            .with_serials(unvalidated.only_serials)
+            .with_classes(unvalidated.only_classes);
+        Ok(f)
+    }
 }
 
 /// Displayer for pretty-printing [`EreportFilters`].
@@ -247,6 +292,88 @@ pub struct DisplayEreportFilters<'a> {
 }
 
 impl EreportFilters {
+    /// Creates an empty set of filters (no filtering).
+    pub fn new() -> Self {
+        Self::default()
+    }
+
+    /// Includes only ereports collected at or after `time`.
+    ///
+    /// Returns an error if `time` is after a previously set end time.
+    pub fn with_start_time(
+        mut self,
+        time: DateTime<Utc>,
+    ) -> Result<Self, Error> {
+        if let Some(end) = self.end_time {
+            if time > end {
+                return Err(Error::invalid_request(
+                    "start time must be before end time",
+                ));
+            }
+        }
+        self.start_time = Some(time);
+        Ok(self)
+    }
+
+    /// Includes only ereports collected at or before `time`.
+    ///
+    /// Returns an error if `time` is before a previously set start time.
+    pub fn with_end_time(mut self, time: DateTime<Utc>) -> Result<Self, Error> {
+        if let Some(start) = self.start_time {
+            if start > time {
+                return Err(Error::invalid_request(
+                    "start time must be before end time",
+                ));
+            }
+        }
+        self.end_time = Some(time);
+        Ok(self)
+    }
+
+    /// Adds serial numbers to the inclusion filter.
+    ///
+    /// When one or more serials are present, only ereports reported by
+    /// systems with those serial numbers are included.
+    pub fn with_serials(
+        mut self,
+        serials: impl IntoIterator<Item = impl Into<String>>,
+    ) -> Self {
+        self.only_serials.extend(serials.into_iter().map(Into::into));
+        self
+    }
+
+    /// Adds ereport classes to the inclusion filter.
+    ///
+    /// When one or more classes are present, only ereports with those
+    /// class strings are included.
+    pub fn with_classes(
+        mut self,
+        classes: impl IntoIterator<Item = impl Into<String>>,
+    ) -> Self {
+        self.only_classes.extend(classes.into_iter().map(Into::into));
+        self
+    }
+
+    /// Returns the start time filter, if set.
+    pub fn start_time(&self) -> Option<DateTime<Utc>> {
+        self.start_time
+    }
+
+    /// Returns the end time filter, if set.
+    pub fn end_time(&self) -> Option<DateTime<Utc>> {
+        self.end_time
+    }
+
+    /// Returns the serial number inclusion filter.
+    pub fn only_serials(&self) -> &[String] {
+        &self.only_serials
+    }
+
+    /// Returns the ereport class inclusion filter.
+    pub fn only_classes(&self) -> &[String] {
+        &self.only_classes
+    }
+
     pub fn display(&self) -> DisplayEreportFilters<'_> {
         DisplayEreportFilters { filters: self }
     }
@@ -270,27 +397,27 @@ impl fmt::Display for DisplayEreportFilters<'_> {
                 f.write_fmt(args)
             };
 
-        if let Some(start) = &filters.start_time {
+        if let Some(start) = filters.start_time() {
             fmt_part(f, format_args!("start: {start}"))?;
         }
-        if let Some(end) = &filters.end_time {
+        if let Some(end) = filters.end_time() {
             fmt_part(f, format_args!("end: {end}"))?;
         }
-        if !filters.only_serials.is_empty() {
+        if !filters.only_serials().is_empty() {
             fmt_part(
                 f,
                 format_args!(
                     "serials: {}",
-                    filters.only_serials.iter().format(", ")
+                    filters.only_serials().iter().format(", ")
                 ),
             )?;
         }
-        if !filters.only_classes.is_empty() {
+        if !filters.only_classes().is_empty() {
             fmt_part(
                 f,
                 format_args!(
                     "classes: {}",
-                    filters.only_classes.iter().format(", ")
+                    filters.only_classes().iter().format(", ")
                 ),
             )?;
         }
@@ -299,20 +426,6 @@ impl fmt::Display for DisplayEreportFilters<'_> {
         if empty {
             write!(f, "none")?;
         }
-        Ok(())
-    }
-}
-
-impl EreportFilters {
-    pub fn check_time_range(&self) -> Result<(), Error> {
-        if let (Some(start), Some(end)) = (self.start_time, self.end_time) {
-            if start > end {
-                return Err(Error::invalid_request(
-                    "start time must be before end time",
-                ));
-            }
-        }
-
         Ok(())
     }
 }
@@ -339,16 +452,27 @@ pub(crate) mod test_utils {
                 prop::collection::vec(".*", 0..=3),
                 prop::collection::vec(".*", 0..=3),
             )
-                .prop_map(
-                    |(start_time, end_time, only_serials, only_classes)| {
-                        EreportFilters {
-                            start_time,
-                            end_time,
-                            only_serials,
-                            only_classes,
-                        }
-                    },
-                )
+                .prop_map(|(time_a, time_b, only_serials, only_classes)| {
+                    // Ensure start <= end when both are present.
+                    let (start_time, end_time) = match (time_a, time_b) {
+                        (Some(a), Some(b)) if a > b => (Some(b), Some(a)),
+                        other => other,
+                    };
+                    let mut filters = EreportFilters::new();
+                    if let Some(t) = start_time {
+                        filters = filters
+                            .with_start_time(t)
+                            .expect("no end time set yet");
+                    }
+                    if let Some(t) = end_time {
+                        filters = filters
+                            .with_end_time(t)
+                            .expect("start <= end by construction");
+                    }
+                    filters
+                        .with_serials(only_serials)
+                        .with_classes(only_classes)
+                })
                 .boxed()
         }
     }

--- a/nexus/types/src/support_bundle.rs
+++ b/nexus/types/src/support_bundle.rs
@@ -108,14 +108,47 @@ impl BundleDataSelection {
         Self { data: HashMap::new() }
     }
 
-    /// Inserts BundleData to be queried for a particular category within the
-    /// bundle.
-    ///
-    /// Each category of data can only be specified once (e.g., inserting
-    /// BundleData::HostInfo multiple times will only use the most-recently
-    /// inserted specification)
-    pub fn insert(&mut self, bundle_data: BundleData) {
+    /// Adds reconfigurator state collection.
+    pub fn with_reconfigurator(self) -> Self {
+        self.with(BundleData::Reconfigurator)
+    }
+
+    /// Adds sled cubby info collection.
+    pub fn with_sled_cubby_info(self) -> Self {
+        self.with(BundleData::SledCubbyInfo)
+    }
+
+    /// Adds SP dump collection.
+    pub fn with_sp_dumps(self) -> Self {
+        self.with(BundleData::SpDumps)
+    }
+
+    /// Adds host info collection from all sleds.
+    pub fn with_all_sleds(self) -> Self {
+        self.with(BundleData::HostInfo(SledSelection::All))
+    }
+
+    /// Adds host info collection from specific sleds.
+    pub fn with_specific_sleds(
+        self,
+        sleds: impl IntoIterator<Item = SledUuid>,
+    ) -> Self {
+        self.with(BundleData::HostInfo(SledSelection::Specific(
+            sleds.into_iter().collect(),
+        )))
+    }
+
+    /// Adds ereport collection with the given filters.
+    pub fn with_ereports(self, filters: EreportFilters) -> Self {
+        self.with(BundleData::Ereports(filters))
+    }
+
+    /// Builder-style method that inserts a [`BundleData`] value and returns
+    /// `self`. If multiple BundleData entries with the same type are inserted,
+    /// the last write wins.
+    pub fn with(mut self, bundle_data: BundleData) -> Self {
         self.data.insert(bundle_data.category(), bundle_data);
+        self
     }
 
     pub fn contains(&self, category: BundleDataCategory) -> bool {
@@ -124,6 +157,11 @@ impl BundleDataSelection {
 
     pub fn get(&self, category: BundleDataCategory) -> Option<&BundleData> {
         self.data.get(&category)
+    }
+
+    /// Iterates over the data entries in this selection.
+    pub fn iter(&self) -> impl Iterator<Item = &BundleData> {
+        self.data.values()
     }
 }
 
@@ -155,11 +193,7 @@ impl fmt::Display for DisplayBundleDataSelection<'_> {
 
 impl FromIterator<BundleData> for BundleDataSelection {
     fn from_iter<T: IntoIterator<Item = BundleData>>(iter: T) -> Self {
-        let mut selection = Self::new();
-        for bundle_data in iter {
-            selection.insert(bundle_data);
-        }
-        selection
+        iter.into_iter().fold(Self::new(), |sel, data| sel.with(data))
     }
 }
 
@@ -168,18 +202,16 @@ impl Default for BundleDataSelection {
     /// everything"). This is distinct from [`Self::new`], which returns an
     /// empty selection.
     fn default() -> Self {
-        [
-            BundleData::Reconfigurator,
-            BundleData::HostInfo(SledSelection::All),
-            BundleData::SledCubbyInfo,
-            BundleData::SpDumps,
-            BundleData::Ereports(EreportFilters {
-                start_time: Some(chrono::Utc::now() - chrono::Days::new(7)),
-                ..EreportFilters::default()
-            }),
-        ]
-        .into_iter()
-        .collect()
+        Self::new()
+            .with_reconfigurator()
+            .with_all_sleds()
+            .with_sled_cubby_info()
+            .with_sp_dumps()
+            .with_ereports(
+                EreportFilters::new()
+                    .with_start_time(chrono::Utc::now() - chrono::Days::new(7))
+                    .expect("no end time set, cannot fail"),
+            )
     }
 }
 


### PR DESCRIPTION
Address @hawkw feedback from #10090 and #10089:

* `EreportFilters` should have a builder API that validates datetime ranges.
* `BundleDataSelection` should have a builder API that makes it more ergonomic and hides storage details.