### PR TITLE
Use single execution_id for log and UpdateEngine.execution_id field

### DIFF
--- a/update-engine/src/engine.rs
+++ b/update-engine/src/engine.rs
@@ -126,7 +126,7 @@ impl<'a, S: StepSpec + 'a> UpdateEngine<'a, S> {
                 "component" => "UpdateEngine",
                 "execution_id" => format!("{execution_id}"),
             )),
-            execution_id: ExecutionId(Uuid::new_v4()),
+            execution_id,
             sender,
             canceler: Some(canceler),
             cancel_receiver,


### PR DESCRIPTION
Previously, one UUID was used for the slog field and another for the struct field, this seems likely to be a copy-paste error.