### PR TITLE
add Claude skill to review code for strong type safety (RFD 643)

### DIFF
--- a/.claude/skills/type-safety-review/SKILL.md
+++ b/.claude/skills/type-safety-review/SKILL.md
@@ -179,9 +179,13 @@ Then use the local variables in the `.bind()` calls.
 
 ## Output format
 
+**IMPORTANT: Output the entire report inside a single fenced code block** using FOUR backticks (```` ```` ````) with no language tag, so that the Markdown is not rendered and can be copy-pasted into another tool. Do not render the Markdown directly. Four backticks are required because the report contains triple-backtick code sketches inside it — a triple-backtick outer fence would be closed by the first inner code block.
+
+**Use soft line wrapping for all prose text in the report.** Do not insert hard line breaks in the middle of sentences or paragraphs. Write each paragraph as a single long line and let the reader's tool wrap it. Hard line breaks are only appropriate inside fenced code blocks.
+
 Structure the report as follows:
 
-```
+````
 ## Type Safety Review
 
 ### Mode
@@ -202,7 +206,7 @@ Structure the report as follows:
 
 ### Summary
 X blocking issues, Y suggestions.
-```
+````
 
 If there are no findings at all, say so clearly and briefly.
 

--- a/.claude/skills/type-safety-review/SKILL.md
+++ b/.claude/skills/type-safety-review/SKILL.md
@@ -1,0 +1,213 @@
+---
+name: type-safety-review
+description: This skill should be used when the user asks to "review types", "review for type safety", "check for weak types", "look for stringly-typed code", "RFD 643 review", "check static invariants", "review the types in this file", or asks to review a branch or set of files for Rust type-safety issues. Applies RFD 643 patterns to identify where runtime errors could instead be caught at compile time.
+---
+
+# Type Safety Review
+
+Review Rust code in the Omicron repository for type-safety issues: places where runtime failures could be caught at compile time, where implicit behavior could be made explicit, and where weak representations (strings, booleans, sentinels) could be replaced by stronger types.
+
+The relevant principles come from RFD 643 ("Effective Rust"). The goal is to find code that works today but creates traps for future maintainers—including LLMs—by hiding invariants in documentation or convention rather than the type system.
+
+## Two modes of operation
+
+### Mode 1: Branch diff review
+
+When the user asks to review the current branch or "the PR":
+
+1. Find the merge base with `origin/main`:
+   ```
+   git merge-base HEAD origin/main
+   ```
+2. Get the diff of Rust files since that point:
+   ```
+   git diff <merge-base> HEAD -- '*.rs'
+   ```
+3. Identify which types, structs, enums, and functions were added or meaningfully changed.
+4. Review those types and their usage context (read surrounding code as needed).
+
+### Mode 2: Targeted review
+
+When the user points at a specific file, module, type, or set of types:
+
+1. Read the specified files.
+2. Review all types, structs, enums, and functions in scope.
+3. Look at call sites in nearby code to understand how types are used in practice.
+
+---
+
+## Review process
+
+For each piece of code in scope, work through all the anti-pattern categories below. For each finding:
+
+- Record the **file and line number**
+- State which **category** it falls into (by name, not number)
+- Explain **why** the current code is weak
+- Propose a **concrete fix** (code sketch, not necessarily compilable)
+- Classify as **Blocking** (likely to cause bugs or silent data loss) or **Suggestion** (robustness and maintainability improvement)
+
+When nothing problematic is found in a category, say so briefly. Don't pad the output.
+
+---
+
+## Anti-pattern categories
+
+### 1. Stringly-typed values
+
+**What to look for:**
+- `String` or `&str` fields/parameters where only a small fixed set of values is valid
+- `match s.as_str() { "foo" => ..., "bar" => ... }` or `if s == "foo"`
+- Database columns typed as `TEXT` (in SQL or diesel) for values that are an enumerated set
+- API request/response types with `String` fields that are documented as having a fixed set of values
+
+**Why it matters:** The compiler cannot catch typos, missing match arms, or invalid values. Invalid strings reach deep into the system before erroring.
+
+**Fix direction:** Define an `enum` with `#[derive(Deserialize, Serialize)]` (and diesel `AsExpression`/`FromSql` if stored in the DB). For database types, see the `crdb-change` skill for migration guidance.
+
+---
+
+### 2. `Display` / `FromStr` as footguns
+
+**What to look for:**
+- `impl fmt::Display for SomeDomainType` where the string representation is context-specific (e.g., it's used for SMF properties in one place and API output in another)
+- `impl FromStr for SomeDomainType` that parses strings from multiple unrelated sources
+- Code that calls `.to_string()` on a domain type and passes it to an API or config file
+- Code that calls `.parse::<SomeDomainType>()` from a source-of-truth that isn't user input
+
+**Why it matters:** Generic `Display`/`FromStr` implementations lock in one string format globally. When different consumers need different representations (e.g., `rx_only` vs. `rx only`), the implementations diverge or produce silent mismatches.
+
+**Fix direction:** Remove the generic `impl` and replace with context-specific methods: `to_smf_property() -> &'static str`, `to_display_label() -> &str`, etc. Let the compiler find all the call sites.
+
+---
+
+### 3. Multiple representations / sentinel values
+
+**What to look for:**
+- `Option<IpAddr>` (or `Option<SomeType>`) where both `None` and a special value like `Some(0.0.0.0)` or `Some("")` mean "not present"
+- Fields documented as "use X to mean Y" (sentinel value pattern)
+- Multiple code paths that convert between representations of the same concept
+- Structs with `is_foo: bool` plus a field that only makes sense when `is_foo` is true
+
+**Why it matters:** Every consumer must know which representation to use and check for both. Invariants expressed only in documentation will eventually be violated.
+
+**Fix direction:** Use an explicit `enum`:
+```rust
+enum PeerAddress {
+    Numbered(SpecifiedIpAddr),
+    Unnumbered,
+}
+```
+Or use typestates when the distinction affects which operations are valid.
+
+---
+
+### 4. Magic literals / missing constants
+
+**What to look for:**
+- Numeric literals repeated in multiple places (timeouts, port numbers, retry counts, sizes)
+- String literals repeated across files
+- Values that are documented as related to each other but expressed as independent literals
+- Configuration defaults scattered through code without a single source of truth
+
+**Why it matters:** Scattered literals can drift apart. The relationship between related values is invisible to the compiler and future readers.
+
+**Fix direction:** Define named `const` or `static` values. Group related constants in a module. When values are structurally related (e.g., hold time must be 3× keepalive), document or enforce that relationship.
+
+---
+
+### 5. Missing newtypes for domain values
+
+**What to look for:**
+- Bare `Uuid` fields where multiple different UUID kinds appear in the same context (instance IDs, sled IDs, disk IDs, etc.)
+- Numeric fields without units (`u64` for a byte count, or a duration in seconds)
+- `String` fields for things like names, user IDs, or other constrained identifiers that have their own validation rules
+- Functions that take two or more parameters of the same primitive type in an order that's easy to reverse
+
+**Why it matters:** The compiler cannot catch passing a sled ID where an instance ID is expected, or passing bytes where MiB are expected.
+
+**Fix direction:** Use `newtype-uuid` for UUID types; define newtype structs for other domain values. For byte counts, consider `ByteCount` (already defined in `common/src/api/external/`). Validate constraints in the constructor.
+
+---
+
+### 6. Implicit runtime panics
+
+**What to look for:**
+- `.unwrap()` or `.expect()` without an explanatory comment (`// unwrap: reason why this cannot fail`)
+- Slice/Vec subscript access `v[i]` on a dynamically-sized collection (use `.get(i)` to get an `Option`)
+- Map subscript `map["key"]` (use `.get("key")`)
+- `as` casts between numeric types (use `from`/`try_from` or clippy's `cast_lossless`)
+- `unsafe` blocks without a `// SAFETY:` comment
+
+**Why it matters:** Undocumented panics are surprising; they can turn into crash loops. Lossless-looking `as` casts silently truncate when types change.
+
+**Fix direction:** Add `// unwrap:` comments explaining why the panic is impossible. Replace subscripts with `.get()` + explicit handling. Replace `as` with `i64::from(x)` or `i64::try_from(x)?`.
+
+---
+
+### 7. Weak enum / bool usage
+
+**What to look for:**
+- `bool` parameters or fields where the meaning isn't obvious at the call site (`do_thing(true, false, true)`)
+- `Option<T>` used as a boolean flag with no semantic meaning beyond presence/absence (when absence has a specific business meaning that should be named)
+- `match` arms with a `_` wildcard in contexts where it matters to handle every case (new variants would be silently ignored)
+- Enum variants with inline struct fields when those fields could instead be a named struct that functions could accept directly
+
+**Why it matters:** `bool` arguments are easy to get backwards. Wildcard match arms cause silent incorrect behavior when new variants are added.
+
+**Fix direction:** Replace `bool` parameters with two-variant enums (`enum Verbose { Yes, No }`). Replace semantically loaded `Option<T>` with an explicit enum. Replace `_` wildcards with explicit arms in exhaustive matches. Define named structs for enum variant payloads when functions need to accept a specific variant.
+
+---
+
+### 8. Missing full-struct destructuring in serialization
+
+**What to look for:**
+- Manual SQL `INSERT` statements that bind struct fields individually via `.bind()` calls, without a preceding `let StructName { field1, field2 } = value;` destructuring
+- Manual JSON/TOML/etc. serialization or `From` implementations that access fields via `.field_name` rather than destructuring
+- Any code that "knows" the complete set of fields in a struct without making that dependency compile-time-checked
+
+**Why it matters:** When a new field is added to the struct, the compiler will not flag the serialization site. The new field will be silently omitted from the serialized form, causing data loss or subtle bugs.
+
+**Fix direction:** Add an explicit destructuring before the serialization code:
+```rust
+// This statement exists to cause a compile error if fields are added
+// or removed. If you get an error here, update the query below.
+let MyStruct { field1, field2, field3 } = *value;
+```
+Then use the local variables in the `.bind()` calls.
+
+---
+
+## Output format
+
+Structure the report as follows:
+
+```
+## Type Safety Review
+
+### Mode
+[Branch diff from <merge-base> | Targeted review of <files/types>]
+
+### Findings
+
+#### [BLOCKING | SUGGESTION] Category Name — file.rs:line
+**Problem:** ...
+**Fix:** ...
+[code sketch if helpful]
+
+... (repeat for each finding)
+
+### No issues found in:
+- Category "name": [brief reason]
+- ...
+
+### Summary
+X blocking issues, Y suggestions.
+```
+
+If there are no findings at all, say so clearly and briefly.
+
+---
+
+## Additional resources
+
+- **`references/patterns.md`** — Detailed before/after code examples for each category, drawn from real Omicron PRs

--- a/.claude/skills/type-safety-review/SKILL.md
+++ b/.claude/skills/type-safety-review/SKILL.md
@@ -188,8 +188,9 @@ Then use the local variables in the `.bind()` calls.
 **Why it matters:** A `Vec` does not enforce uniqueness. Callers can silently produce duplicates; consumers must defensively deduplicate. Every place that iterates or looks up in the collection must be written to tolerate (or guard against) duplicates. The invariant lives in documentation, not the type.
 
 **Fix direction:**
-- When uniqueness matters, consider `BTreeSet<T>` or `BTreeMap<K, V>`.  If using a map and the key is contained in the value, considered `iddqd::IdOrdMap<T>`.  `IdOrdMap` enforces the identity between the key and the value's own identifier field at the type level, removing a class of key/value mismatch bugs.
-- When the caller must preserve insertion order *and* guarantee uniqueness, consider `IdOrdMap`.
+- When a collection of values is keyed by an identifier field that lives inside the value (e.g., `BTreeMap<XxxUuid, Xxx>` where `Xxx` has an `id: XxxUuid` field), **use `iddqd::IdOrdMap<T>`**. Do not recommend `BTreeMap` in this case even if it seems lower-friction — `IdOrdMap` eliminates the key/value mismatch invariant entirely at the type level and is the correct tool. "Lower friction" is not a reason to leave a type-safety gap.
+- When uniqueness matters but there is no associated identifier field, use `BTreeSet<T>`.
+- When insertion order must also be preserved, use `iddqd::IdOrdMap<T>` (for keyed values) or `IndexSet` from the `indexmap` crate (for plain values).
 
 ---
 

--- a/.claude/skills/type-safety-review/SKILL.md
+++ b/.claude/skills/type-safety-review/SKILL.md
@@ -177,6 +177,22 @@ Then use the local variables in the `.bind()` calls.
 
 ---
 
+### 9. `Vec` when uniqueness matters
+
+**What to look for:**
+- `Vec<T>` fields or return types where duplicates are semantically invalid (e.g., a list of sled IDs, a set of allowed roles, a collection of unique resource identifiers)
+- Code that deduplicates a `Vec` manually (`.dedup()`, `.sort(); .dedup()`, or a loop that checks `contains()` before inserting)
+- `Vec` used as the value of a map where the entries are themselves keyed by an identifier field
+- Comments or documentation saying "elements must be unique" or "no duplicates allowed"
+
+**Why it matters:** A `Vec` does not enforce uniqueness. Callers can silently produce duplicates; consumers must defensively deduplicate. Every place that iterates or looks up in the collection must be written to tolerate (or guard against) duplicates. The invariant lives in documentation, not the type.
+
+**Fix direction:**
+- When uniqueness matters, consider `BTreeSet<T>` or `BTreeMap<K, V>`.  If using a map and the key is contained in the value, considered `iddqd::IdOrdMap<T>`.  `IdOrdMap` enforces the identity between the key and the value's own identifier field at the type level, removing a class of key/value mismatch bugs.
+- When the caller must preserve insertion order *and* guarantee uniqueness, consider `IdOrdMap`.
+
+---
+
 ## Output format
 
 **IMPORTANT: Output the entire report inside a single fenced code block** using FOUR backticks (```` ```` ````) with no language tag, so that the Markdown is not rendered and can be copy-pasted into another tool. Do not render the Markdown directly. Four backticks are required because the report contains triple-backtick code sketches inside it — a triple-backtick outer fence would be closed by the first inner code block.

--- a/.claude/skills/type-safety-review/references/patterns.md
+++ b/.claude/skills/type-safety-review/references/patterns.md
@@ -461,6 +461,73 @@ sql_query("INSERT INTO reconfigurator_config \
 
 ---
 
+## Category 9: `Vec` when uniqueness matters
+
+### Example: Collection of sled IDs
+
+**Before:**
+```rust
+pub struct Policy {
+    // Must not contain duplicates.
+    pub sleds: Vec<SledUuid>,
+}
+
+fn add_sled(policy: &mut Policy, sled_id: SledUuid) {
+    if !policy.sleds.contains(&sled_id) {  // O(n) and easy to forget
+        policy.sleds.push(sled_id);
+    }
+}
+```
+
+**After:**
+```rust
+pub struct Policy {
+    pub sleds: BTreeSet<SledUuid>,
+}
+
+fn add_sled(policy: &mut Policy, sled_id: SledUuid) {
+    policy.sleds.insert(sled_id);  // uniqueness is automatic
+}
+```
+
+**Why this matters:** Any code that builds or extends the `Vec` must remember to deduplicate. Any code that iterates or searches the `Vec` must be written to tolerate duplicates. Changing the type to `BTreeSet` makes the compiler enforce the invariant everywhere.
+
+---
+
+### Example: Map keyed by identifier field
+
+**Before:**
+```rust
+// The key must match zone.id — this is checked by convention, not the compiler.
+pub zones: BTreeMap<OmicronZoneUuid, OmicronZoneConfig>,
+
+// Insertion is error-prone:
+zones.insert(zone.id, zone);   // fine
+zones.insert(other_id, zone);  // compiles, wrong at runtime
+```
+
+**After (using `iddqd::IdOrdMap`):**
+```rust
+use iddqd::IdOrdMap;
+
+pub zones: IdOrdMap<OmicronZoneConfig>,
+// OmicronZoneConfig must impl IdOrd, which provides the key (zone.id).
+// The map owns both key and value as one unit.
+
+// Insertion no longer takes a separate key:
+zones.insert_unique(zone)?;  // key is derived from zone.id automatically
+```
+
+**Why this matters:** `BTreeMap<Id, Value>` has an implicit invariant that `key == value.id`. `IdOrdMap` eliminates that invariant entirely: the key *is* the value's identifier, enforced by the type. There is no way to insert a value under the wrong key.
+
+**Red flags to spot:**
+- `BTreeMap<XxxUuid, SomeStruct>` where `SomeStruct` has a field of type `XxxUuid`
+- Comments like "key must equal value.id" or "keyed by the zone's own id"
+- Manual `map.insert(thing.id, thing)` patterns
+- `Vec<T>` with a comment saying "no duplicates" or followed by `.sort(); .dedup()`
+
+---
+
 ## Calibration notes
 
 **Not every instance of these patterns is a problem.** Context matters:

--- a/.claude/skills/type-safety-review/references/patterns.md
+++ b/.claude/skills/type-safety-review/references/patterns.md
@@ -1,0 +1,477 @@
+# Type Safety Patterns: Detailed Examples
+
+Concrete examples illustrating each anti-pattern. Use these to calibrate what each pattern looks like in context.
+
+---
+
+## Category 1: Stringly-typed values
+
+### Example: Switch slot
+
+**Before:**
+```rust
+// API type
+pub struct LoopbackAddressCreate {
+    pub switch_location: String,  // only "switch0" or "switch1" are valid
+}
+
+// Database column
+-- switch_location TEXT NOT NULL
+```
+
+**After — enum everywhere:**
+```rust
+// Rust type
+#[derive(Debug, Clone, Deserialize, Serialize, JsonSchema)]
+#[serde(rename_all = "snake_case")]
+pub enum SwitchSlot {
+    Switch0,
+    Switch1,
+}
+
+// Database schema
+CREATE TYPE IF NOT EXISTS db_switch_slot AS ENUM (
+    'switch0',
+    'switch1'
+);
+
+// Diesel conversion
+impl ToSql<DbSwitchSlot, Pg> for SwitchSlot { ... }
+impl FromSql<DbSwitchSlot, Pg> for SwitchSlot { ... }
+```
+
+**Why this matters:** With `String`, invalid values reach the database layer before the error is caught (or not at all, if no validation was added). With an enum, the OpenAPI spec enforces valid values, the Rust compiler enforces valid values, and the database schema enforces valid values—three independent layers, all for free.
+
+---
+
+### Example: BGP peer state as string
+
+**Before:**
+```rust
+fn is_peer_established(state: &str) -> bool {
+    state == "Established"
+}
+```
+
+**After:**
+```rust
+#[derive(Debug, PartialEq, Eq)]
+enum PeerState {
+    Idle,
+    Connect,
+    Active,
+    OpenSent,
+    OpenConfirm,
+    Established,
+}
+
+fn is_peer_established(state: PeerState) -> bool {
+    state == PeerState::Established
+}
+```
+
+**Red flags to spot:** `match s.as_str()`, `if s == "..."`, `s.contains("...")` on domain-concept strings.
+
+---
+
+## Category 2: `Display`/`FromStr` as footguns
+
+### Example: `LldpAdminStatus`
+
+**Before:**
+```rust
+impl fmt::Display for LldpAdminStatus {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self {
+            LldpAdminStatus::Enabled => write!(f, "enabled"),
+            LldpAdminStatus::Disabled => write!(f, "disabled"),
+            LldpAdminStatus::RxOnly => write!(f, "rx_only"),   // note: underscore
+            LldpAdminStatus::TxOnly => write!(f, "tx_only"),
+        }
+    }
+}
+```
+
+In this specific case, the wicket UI wants to display `"rx only"` (with a space), while the SMF property layer wants `"rx_only"`. With a single `Display`, one of them has to be wrong, or one has to work around the trait.
+
+**After:**
+```rust
+impl LldpAdminStatus {
+    /// Returns the string used as the SMF property value for this status.
+    pub fn to_smf_property(&self) -> &'static str {
+        match self {
+            LldpAdminStatus::Enabled => "enabled",
+            LldpAdminStatus::Disabled => "disabled",
+            LldpAdminStatus::RxOnly => "rx_only",
+            LldpAdminStatus::TxOnly => "tx_only",
+        }
+    }
+}
+
+// In the UI layer:
+fn display_label(status: LldpAdminStatus) -> &'static str {
+    match status {
+        LldpAdminStatus::Enabled => "enabled",
+        LldpAdminStatus::Disabled => "disabled",
+        LldpAdminStatus::RxOnly => "rx only",    // natural English
+        LldpAdminStatus::TxOnly => "tx only",
+    }
+}
+```
+
+**When `Display` is fine:** For types that have one canonical human-readable form for all contexts (e.g., a `Name` type, an IP address). The problem is types where different contexts want different string forms.
+
+**Red flags to spot:**
+- `impl Display` plus a comment like "used for serialization" or "used for SMF"
+- `impl FromStr` that parses values coming from multiple unrelated sources
+- `.to_string()` on a type passed directly into a config file or external API
+
+---
+
+## Category 3: Multiple representations / sentinel values
+
+### Example: BGP unnumbered peer address
+
+**Before:**
+```rust
+// In one part of the code:
+peer_addr: Option<IpAddr>,  // None means unnumbered
+
+// In another part:
+peer_addr: IpAddr,          // Ipv6Addr::UNSPECIFIED means unnumbered
+
+// In the database:
+peer_addr: Option<String>,  // NULL means unnumbered
+```
+
+Converting between these representations requires careful, error-prone code at every boundary. The invariant is enforced only by convention. Instead, this version has an unambiguous, statically-checked representation for unnumbered peers:
+
+**After — one explicit type:**
+```rust
+pub enum RouterPeerAddress {
+    Numbered(SpecifiedAddr),   // cannot be unspecified, loopback, multicast
+    Unnumbered,
+}
+
+// SpecifiedAddr rejects invalid addresses at construction time:
+pub struct SpecifiedAddr(IpAddr);
+impl SpecifiedAddr {
+    pub fn new(addr: IpAddr) -> Option<Self> {
+        if addr.is_unspecified() || addr.is_loopback() || addr.is_multicast() {
+            None
+        } else {
+            Some(Self(addr))
+        }
+    }
+}
+```
+
+**Red flags to spot:**
+- Comments like "use X to represent absence" or "0 means disabled"
+- `if addr == Ipv6Addr::UNSPECIFIED` guards on values that could come in multiple shapes
+- Parallel conversions: `Option<T>` in one layer, a sentinel in another, `Option<String>` in the database
+- Structs with `enabled: bool` plus fields that only make sense when `enabled` is true
+
+---
+
+## Category 4: Magic literals / missing constants
+
+### Example: BGP timer defaults
+
+**Before:**
+```rust
+// In one file:
+let config = BgpPeerConfig {
+    hold_time: 6,
+    idle_hold_time: 3,
+    delay_open: 0,
+    connect_retry: 3,
+    keepalive: 2,
+};
+
+// In a test file:
+assert_eq!(peer.hold_time, 6);
+assert_eq!(peer.keepalive, 2);
+
+// In a third file:
+if hold_time < 6 { return Err(...) }
+```
+
+When a timer value changes, all three locations must be updated. There's no guarantee they stay in sync, and no name explaining what `6` means.
+
+**After:**
+```rust
+pub const BGP_DEFAULT_HOLD_TIME_SECS: u64 = 6;
+pub const BGP_DEFAULT_IDLE_HOLD_TIME_SECS: u64 = 3;
+pub const BGP_DEFAULT_DELAY_OPEN_SECS: u64 = 0;
+pub const BGP_DEFAULT_CONNECT_RETRY_SECS: u64 = 3;
+pub const BGP_DEFAULT_KEEPALIVE_SECS: u64 = 2;
+
+// All sites reference the constant:
+let config = BgpPeerConfig {
+    hold_time: BGP_DEFAULT_HOLD_TIME_SECS,
+    ...
+};
+```
+
+**Red flags to spot:** The same numeric literal appearing in more than one file; literals with comments like `// 6 seconds`; literals that are structurally related (e.g., hold time = 3× keepalive) but expressed independently.
+
+---
+
+## Category 5: Missing newtypes for domain values
+
+### Example: UUID kinds
+
+**Before:**
+```rust
+pub struct InstanceRecord {
+    pub id: Uuid,
+    pub sled_id: Uuid,
+    pub vmm_id: Uuid,
+    pub boot_disk_id: Uuid,
+}
+
+fn find_instance(instance_id: Uuid, sled_id: Uuid) -> Result<...> { ... }
+
+// Call site — are these in the right order?
+find_instance(record.sled_id, record.id)  // WRONG, but compiles
+```
+
+**After (using `newtype-uuid`):**
+```rust
+// In uuid-kinds/src/lib.rs:
+impl_typed_uuid_kind!(
+    Instance => "instance",
+    Sled => "sled",
+    Vmm => "vmm",
+    Disk => "disk",
+);
+
+pub struct InstanceRecord {
+    pub id: TypedUuid<Instance>,
+    pub sled_id: TypedUuid<Sled>,
+    pub vmm_id: TypedUuid<Vmm>,
+    pub boot_disk_id: TypedUuid<Disk>,
+}
+
+fn find_instance(instance_id: TypedUuid<Instance>, sled_id: TypedUuid<Sled>) -> Result<...> { ... }
+
+// This now fails to compile:
+find_instance(record.sled_id, record.id)  // type error!
+```
+
+### Example: Byte counts
+
+**Before:**
+```rust
+fn allocate_disk(size_bytes: u64) { ... }
+
+// Caller passes GiB, not bytes — wrong but compiles:
+allocate_disk(disk.size_gib)
+```
+
+**After:**
+```rust
+fn allocate_disk(size: ByteCount) { ... }
+// ByteCount is defined in common/src/api/external/
+```
+
+**Red flags to spot:** Multiple `Uuid` fields in the same struct; `u64` or `i64` parameters named `_bytes`, `_gib`, `_mib` suggesting unit mismatch risk; functions with two or more parameters of the same primitive type.
+
+---
+
+## Category 6: Implicit runtime panics
+
+### Example: Documented unwrap
+
+**Before:**
+```rust
+let name = path.file_name().unwrap();
+```
+
+**After:**
+```rust
+// unwrap: `file_name()` returns None only for paths ending in `..`,
+// but we got this path from `read_dir_utf8()` which skips `..`.
+let name = path.file_name().unwrap();
+```
+
+### Example: Map subscript
+
+**Before:**
+```rust
+let handler = handlers[&event_type];  // panics if missing
+```
+
+**After:**
+```rust
+let handler = handlers.get(&event_type)
+    .ok_or_else(|| anyhow!("no handler for {event_type:?}"))?;
+```
+
+### Example: `as` cast
+
+**Before:**
+```rust
+let count = items.len() as i64;  // silently truncates on 32-bit if len > i64::MAX
+```
+
+**After:**
+```rust
+let count = i64::try_from(items.len())
+    .context("item count overflows i64")?;
+```
+
+**When `as` is fine:** Intentional truncation/wrapping that is understood and documented. For example, bitwise masking. Clippy's `cast_lossless` and `cast_possible_truncation` lints flag the problematic cases.
+
+---
+
+## Category 7: Weak enum / bool usage
+
+### Example: Boolean function arguments
+
+**Before:**
+```rust
+fn sync_config(state: &State, verbose: bool, dry_run: bool) { ... }
+
+// Call site — which bool is which?
+sync_config(&state, false, true)
+```
+
+**After:**
+```rust
+#[derive(Debug, Clone, Copy)]
+enum Verbosity { Verbose, Quiet }
+
+#[derive(Debug, Clone, Copy)]
+enum DryRun { Yes, No }
+
+fn sync_config(state: &State, verbosity: Verbosity, dry_run: DryRun) { ... }
+
+// Call site is now self-documenting:
+sync_config(&state, Verbosity::Quiet, DryRun::Yes)
+```
+
+### Example: Wildcard match arm
+
+**Before:**
+```rust
+match event {
+    Event::Foo => handle_foo(),
+    Event::Bar => handle_bar(),
+    _ => {}  // silently ignores any new variants
+}
+```
+
+**After (when all cases matter):**
+```rust
+match event {
+    Event::Foo => handle_foo(),
+    Event::Bar => handle_bar(),
+    Event::Baz => {}  // explicitly considered and intentionally ignored
+}
+```
+
+### Example: Inline enum variant data vs. named struct
+
+**Before:**
+```rust
+pub enum SiloUser {
+    Jit {
+        external_id: String,
+        silo_id: Uuid,
+        roles: Vec<Role>,
+    },
+    Scim { ... },
+}
+
+// Cannot write a function that only accepts JIT users:
+fn jit_only(user: SiloUser) {
+    let SiloUser::Jit { external_id, .. } = user else {
+        return Err("wrong type");  // runtime error for what could be compile-time
+    };
+}
+```
+
+**After:**
+```rust
+pub struct SiloUserJit {
+    pub external_id: String,
+    pub silo_id: Uuid,
+    pub roles: Vec<Role>,
+}
+
+pub enum SiloUser {
+    Jit(SiloUserJit),
+    Scim(SiloUserScim),
+}
+
+// Now this is a compile-time guarantee:
+fn jit_only(user: SiloUserJit) { ... }
+```
+
+---
+
+## Category 8: Missing full-struct destructuring in serialization
+
+### Example: SQL INSERT without destructuring
+
+**Before:**
+```rust
+// If someone adds `planner_config.new_field`, this code compiles but
+// silently omits the new field from the database row.
+sql_query("INSERT INTO reconfigurator_config (version, planner_enabled, time_modified) \
+           SELECT $1, $2, $3 ...")
+    .bind::<BigInt, _>(switches.version.into())
+    .bind::<Bool, _>(switches.config.planner_enabled)
+    .bind::<Timestamptz, _>(switches.time_modified)
+    .execute_async(conn)
+```
+
+**After:**
+```rust
+// This statement exists to cause a compile error if the struct changes.
+// If you get an error here, update the query below.
+let ReconfiguratorConfigView {
+    version,
+    config: ReconfiguratorConfig {
+        planner_enabled,
+        planner_config: PlannerConfig { add_zones_with_mupdate_override },
+        tuf_repo_pruner_enabled,
+    },
+    time_modified,
+} = *switches;
+
+sql_query("INSERT INTO reconfigurator_config \
+           (version, planner_enabled, time_modified, \
+            add_zones_with_mupdate_override, tuf_repo_pruner_enabled) \
+           SELECT $1, $2, $3, $4, $5 ...")
+    .bind::<BigInt, SqlU32>(version.into())
+    .bind::<Bool, _>(planner_enabled)
+    .bind::<Timestamptz, _>(time_modified)
+    .bind::<Bool, _>(add_zones_with_mupdate_override)
+    .bind::<Bool, _>(tuf_repo_pruner_enabled)
+    .execute_async(conn)
+```
+
+**Red flags to spot:**
+- `.bind()` chains that access `value.field` directly
+- `impl From<MyStruct> for DbRow` that lists fields individually without a destructuring `let`
+- `serde::Serialize` derived but with `#[serde(skip)]` on fields that probably shouldn't be skipped
+
+---
+
+## Calibration notes
+
+**Not every instance of these patterns is a problem.** Context matters:
+
+- A `String` field is fine if the valid values are truly open-ended (e.g., a user-provided description).
+- `Display` is fine if the type has one canonical string form used everywhere.
+- A single `unwrap()` with a clear comment is fine; it's the undocumented ones that are risky.
+- `bool` is fine for truly binary properties with obvious meaning at the call site.
+
+**Prioritize findings where:**
+1. The type appears in multiple files or across a client-server boundary
+2. The type is likely to grow (new variants, new fields)
+3. A mistake would be silent at runtime rather than producing an obvious error
+4. The fix is localized and the blast radius of the current problem is large


### PR DESCRIPTION
This skill enables Claude to review either existing code or a specific PR for the code's use of types to enable strong static type checking.  It covers the patterns described in RFD 643 using examples from some of @jgallagher's recent PRs that clean up these kinds of problems.

This is my first real Claude skill and I'd welcome feedback.  It's also Claude-written.  I know from experience that can result in work that's deceptively time-consuming to review.  Do feel free to stop and say "go back to the drawing board because this needs more serious thought before we review it more carefully".

There's one thing I'm struggling to resolve here, which is that ideally, the "source of truth" for the anti-patterns that this looks for would be the same as the one we refer people to: RFD 643.  But RFD 643 includes a lot more context about each item, which I think is helpful for humans but maybe less useful for the LLM.