### PR TITLE
[direnv] invalidate nix-direnv cache when flake inputs change

### DIFF
--- a/.envrc
+++ b/.envrc
@@ -8,5 +8,12 @@ PATH_add out/mgd/root/opt/oxide/mgd/bin
 
 if [ "$OMICRON_USE_FLAKE" = 1 ] && nix flake show &> /dev/null
 then
+    # watch version files which should cause the nix-direnv cache to be
+    # invalidated, as they are inputs to the Nix flake.
+    watch_file tools/maghemite_mg_openapi_version
+    watch_file tools/dendrite_version
+    watch_file tools/clickhouse_version
+    watch_file tools/cocroachdb_version
+    watch_file rust-toolchain.toml
     use flake;
 fi


### PR DESCRIPTION
When `direnv` is configured to use the Nix flake, this tells it to add files to the watchlist which are flake inputs. This way, changes to the versions of things which the Nix flake manages will cause the cached evaluation to be invalidated. This way, we *don't* have to run `nix flake update` when the CRDB version changes just to blow away my local cache lol sorry.