### PR TITLE
Wait for all timeseries deletions to complete

### DIFF
--- a/oximeter/db/src/client/mod.rs
+++ b/oximeter/db/src/client/mod.rs
@@ -1338,6 +1338,10 @@ impl Client {
                 "n_timeseries" => chunk.len(),
             );
             for table in tables.iter() {
+                // NOTE: The settings on this query make it fully synchronous
+                // across the entire cluster. That is, wait for all deletions on
+                // every node to complete. This is slow, but we don't run this
+                // out of tests right now.
                 let sql = format!(
                     "ALTER TABLE {}.{} \
                     {} \


### PR DESCRIPTION
This is an attempt to address #10052, a flaky test deleting a timeseries by name. It's hard to generate a repro for that failure, since it relies on racing the deletion across all the ClickHouse nodes. But this should probably address it by ensuring we completely wait for the deletion to occur on all replicas before returning.

This does make the query slower but (1) we don't run this today and (2) we definitely don't run multinode ClickHouse, which is the only place this would matter anyway.