### PR TITLE
Configure clickhouse backup path for single-node topology.

### DIFF
--- a/smf/clickhouse/config.xml
+++ b/smf/clickhouse/config.xml
@@ -71,6 +71,10 @@
         <default/>
     </quotas>
 
+    <backups>
+        <allowed_path>backup</allowed_path>
+    </backups>
+
     <merge_tree>
         <ratio_of_defaults_for_sparse_serialization>1.0</ratio_of_defaults_for_sparse_serialization>
     </merge_tree>


### PR DESCRIPTION
In #9277, we enabled clickhouse backups for the clustered topology. However, the clickhouse-admin configs updated there aren't used for the single-node topology. This patch enables backups for single-node clickhouse as well. Note that we should eventually manage both topologies with clickhouse-admin, or deprecate the single-node topology.