### PR TITLE
`kill_on_drop` to avoid leaking `yes` processes

### DIFF
--- a/test-utils/src/dev/dendrite.rs
+++ b/test-utils/src/dev/dendrite.rs
@@ -239,6 +239,7 @@ mod tests {
             .stdin(Stdio::null())
             .stdout(Stdio::null())
             .stderr(Stdio::piped())
+            .kill_on_drop(true)
             .spawn()
             .unwrap();
         let stderr = child.stderr.take().unwrap();


### PR DESCRIPTION
As much as I like Yes, let's not leak processes.