### PR TITLE
[api] Fix casing in external subnet allocation error messages

### DIFF
--- a/nexus/db-queries/src/db/datastore/external_subnet.rs
+++ b/nexus/db-queries/src/db/datastore/external_subnet.rs
@@ -292,8 +292,8 @@ impl DataStore {
                 info,
             ) if info.constraint_name() == Some("single_default_per_silo") => {
                 Error::invalid_request(
-                    "Can only have a single default Subnet Pool for a \
-                    Silo for each IP version.",
+                    "Each silo can only have one default subnet pool \
+                    for each IP version.",
                 )
             }
             DieselError::DatabaseError(
@@ -302,7 +302,7 @@ impl DataStore {
             ) if info.constraint_name()
                 == Some("subnet_pool_silo_link_pkey") =>
             {
-                Error::conflict("Subnet Pool is already linked to Silo")
+                Error::conflict("Subnet pool is already linked to silo")
             }
             DieselError::DatabaseError(
                 DatabaseErrorKind::NotNullViolation,
@@ -356,8 +356,8 @@ impl DataStore {
         .map_err(|e| public_error_from_diesel(e, ErrorHandler::Server))?;
         if has_children {
             return Err(Error::invalid_request(
-                "Cannot unlink Subnet Pool from Silo while there are \
-                External Subnets allocated from the pool. Delete the \
+                "Cannot unlink subnet pool from silo while there are \
+                external subnets allocated from the pool. Delete the \
                 subnets first, and try again.",
             ));
         }
@@ -407,8 +407,8 @@ impl DataStore {
                 ref info,
             ) if info.constraint_name() == Some("single_default_per_silo") => {
                 Error::invalid_request(
-                    "Can only have a single default Subnet Pool for a \
-                    Silo for each IP version.",
+                    "Each silo can only have one default subnet pool \
+                    for each IP version.",
                 )
             }
             e => public_error_from_diesel(e, ErrorHandler::Server),
@@ -532,7 +532,7 @@ impl DataStore {
         };
         if pool_version != member_version {
             return Err(Error::invalid_request(&format!(
-                "Cannot add IP{} members to IP{} Subnet Pool",
+                "Cannot add IP{} members to IP{} subnet pool",
                 member_version, pool_version,
             )));
         }
@@ -544,7 +544,7 @@ impl DataStore {
             .map_err(|e| match e {
                 DieselError::NotFound => Error::invalid_request(&format!(
                     "The IP subnet {} overlaps with an existing \
-                    Subnet Pool member or IP Pool range",
+                    subnet pool member or IP pool range",
                     params.subnet,
                 )),
                 e => public_error_from_diesel(e, ErrorHandler::Server),
@@ -597,7 +597,7 @@ impl DataStore {
             .await
             .map_err(|e| match e {
                 DieselError::NotFound => Error::invalid_request(format!(
-                    "A provided External Subnet Pool member with \
+                    "A provided subnet pool member with \
                         subnet {subnet} does not exist",
                 )),
                 _ => public_error_from_diesel(e, ErrorHandler::Server),
@@ -1690,7 +1690,7 @@ mod tests {
         assert_eq!(
             message.external_message(),
             "The IP subnet 10.1.1.0/24 overlaps with an existing \
-            Subnet Pool member or IP Pool range"
+            subnet pool member or IP pool range"
         );
 
         db.terminate().await;
@@ -1744,7 +1744,7 @@ mod tests {
         };
         assert_eq!(
             message.external_message(),
-            "Subnet Pool is already linked to Silo"
+            "Subnet pool is already linked to silo"
         );
 
         // We should not be able to link another default of the same IP version.
@@ -1773,7 +1773,7 @@ mod tests {
         };
         assert_eq!(
             message.external_message(),
-            "Can only have a single default Subnet Pool for a Silo \
+            "Each silo can only have one default subnet pool \
             for each IP version."
         );
 
@@ -2083,8 +2083,8 @@ mod tests {
         };
         assert_eq!(
             message.external_message(),
-            "Cannot unlink Subnet Pool from Silo while there are \
-            External Subnets allocated from the pool. Delete the \
+            "Cannot unlink subnet pool from silo while there are \
+            external subnets allocated from the pool. Delete the \
             subnets first, and try again.",
         );
 
@@ -2212,7 +2212,7 @@ mod tests {
         assert_eq!(
             message.external_message(),
             "The requested IP subnet is not contained in any \
-            Subnet Pool available in the current Silo."
+            subnet pool available in the current silo."
         );
 
         context.db.terminate().await;
@@ -2588,8 +2588,8 @@ mod tests {
         };
         assert_eq!(
             message.external_message(),
-            "All subnets are used in the default Subnet Pool for \
-            the current Silo",
+            "Could not allocate a /48 subnet from the default \
+            subnet pool for the current silo",
         );
 
         // Also fail, but since we're requesting a pool by version, the error
@@ -2621,8 +2621,8 @@ mod tests {
         };
         assert_eq!(
             message.external_message(),
-            "All subnets are used in the default IPv6 Subnet Pool \
-            for the current Silo",
+            "Could not allocate a /48 subnet from the default \
+            IPv6 subnet pool for the current silo",
         );
 
         // Also fail, but since we're requesting a pool, the error message
@@ -2657,7 +2657,8 @@ mod tests {
         assert_eq!(
             message.external_message(),
             format!(
-                "All subnets are used in the Subnet Pool with ID '{}'",
+                "Could not allocate a /48 subnet \
+                from the subnet pool with ID '{}'",
                 context.authz_pool.id().into_untyped_uuid(),
             ),
         );
@@ -2694,7 +2695,8 @@ mod tests {
         assert_eq!(
             message.external_message(),
             format!(
-                "All subnets are used in the Subnet Pool with name '{}'",
+                "Could not allocate a /56 subnet \
+                from the subnet pool with name '{}'",
                 context.db_pool.name(),
             ),
         );
@@ -3523,6 +3525,13 @@ mod tests {
                                 allocated_subnets.insert(net, subnet.id());
                             }
                             Err(Error::InvalidRequest { message }) => {
+                                let ExternalSubnetAllocator::Auto {
+                                    prefix_length,
+                                    ..
+                                } = &allocator
+                                else {
+                                    unreachable!();
+                                };
                                 let expected_message = match kind {
                                     AllocationKind::ExplicitInvalidSubnet
                                     | AllocationKind::ExplicitValidSubnet => {
@@ -3530,23 +3539,23 @@ mod tests {
                                     }
                                     AllocationKind::ExplicitPool => {
                                         format!(
-                                            "All subnets are used in the \
-                                            Subnet Pool with ID '{}'",
+                                            "Could not allocate a /{prefix_length} subnet \
+                                            from the subnet pool with ID '{}'",
                                             context.authz_pool.id(),
                                         )
                                     }
                                     AllocationKind::AutoVersion => {
-                                        String::from(
-                                            "All subnets are used in the \
-                                            default IPv6 Subnet Pool for \
-                                            the current Silo",
+                                        format!(
+                                            "Could not allocate a /{prefix_length} subnet \
+                                            from the default IPv6 subnet pool \
+                                            for the current silo",
                                         )
                                     }
                                     AllocationKind::AutoDefaultPool => {
-                                        String::from(
-                                            "All subnets are used in the \
-                                            default Subnet Pool for \
-                                            the current Silo",
+                                        format!(
+                                            "Could not allocate a /{prefix_length} subnet \
+                                            from the default subnet pool \
+                                            for the current silo",
                                         )
                                     }
                                 };
@@ -3771,8 +3780,8 @@ mod tests {
         };
         assert_eq!(
             message.external_message(),
-            "The IP subnet fd00::/48 overlaps with an existing Subnet Pool \
-            member or IP Pool range",
+            "The IP subnet fd00::/48 overlaps with an existing subnet pool \
+            member or IP pool range",
         );
 
         db.terminate().await;

--- a/nexus/db-queries/src/db/datastore/ip_pool.rs
+++ b/nexus/db-queries/src/db/datastore/ip_pool.rs
@@ -1648,7 +1648,7 @@ impl DataStore {
                         Error::invalid_request(
                             format!(
                                 "The provided IP range {}-{} overlaps with \
-                            an existing IP Pool range or Subnet Pool member",
+                            an existing IP pool range or subnet pool member",
                                 range.first_address(),
                                 range.last_address(),
                             )
@@ -5996,7 +5996,7 @@ mod test {
             message.external_message(),
             format!(
                 "The provided IP range {}-{} overlaps with an existing \
-                IP Pool range or Subnet Pool member",
+                IP pool range or subnet pool member",
                 range.first_address(),
                 range.last_address(),
             ),

--- a/nexus/db-queries/src/db/queries/external_subnet.rs
+++ b/nexus/db-queries/src/db/queries/external_subnet.rs
@@ -1124,7 +1124,7 @@ pub fn decode_insert_external_subnet_error(
                 Error::internal_error(&format!(
                     "Silo appears to have been deleted between \
                     looking it up and running the query to insert \
-                    the new External Subnet in it. silo_id = {silo_id}",
+                    the new external subnet in it. silo_id = {silo_id}",
                 ))
             } else if is_bool_parse_error(
                 msg,
@@ -1138,10 +1138,10 @@ pub fn decode_insert_external_subnet_error(
                 } = subnet
                 else {
                     return Error::internal_error(&format!(
-                        "Query to insert External Subnet failed \
-                        because an explicitly requested Silo was not \
+                        "Query to insert external subnet failed \
+                        because an explicitly requested silo was not \
                         linked, but the parameters for the query \
-                        do not have an explicit Silo by name or ID. \
+                        do not have an explicit silo by name or ID. \
                         This is a programmer error. \
                         selector = {subnet:#?}"
                     ));
@@ -1182,24 +1182,24 @@ pub fn decode_insert_external_subnet_error(
 fn report_exhaustion(subnet: &ExternalSubnetAllocator) -> Error {
     match subnet {
         ExternalSubnetAllocator::Explicit { .. } => Error::internal_error(
-            "Inserted 0 rows during the External Subnet \
+            "Inserted 0 rows during the external subnet \
                 insert query, which should only happen when \
                 we're doing an automatic allocation from a \
                 pool or IP version. This is a programmer bug.",
         ),
-        ExternalSubnetAllocator::Auto { pool_selector, .. } => {
+        ExternalSubnetAllocator::Auto { pool_selector, prefix_length } => {
             let msg = match pool_selector {
                 PoolSelector::Explicit { pool } => match pool {
                     NameOrId::Id(id) => {
                         format!(
-                            "All subnets are used in the \
-                                Subnet Pool with ID '{id}'"
+                            "Could not allocate a /{prefix_length} subnet \
+                                from the subnet pool with ID '{id}'"
                         )
                     }
                     NameOrId::Name(name) => {
                         format!(
-                            "All subnets are used in the \
-                                Subnet Pool with name '{name}'"
+                            "Could not allocate a /{prefix_length} subnet \
+                                from the subnet pool with name '{name}'"
                         )
                     }
                 },
@@ -1208,8 +1208,9 @@ fn report_exhaustion(subnet: &ExternalSubnetAllocator) -> Error {
                         .map(|v| format!("IP{v} "))
                         .unwrap_or_else(String::new);
                     format!(
-                        "All subnets are used in the default \
-                        {version}Subnet Pool for the current Silo"
+                        "Could not allocate a /{prefix_length} subnet \
+                        from the default {version}subnet pool \
+                        for the current silo"
                     )
                 }
             };
@@ -1275,13 +1276,13 @@ const NO_LINKED_POOL_CONTAINS_REQUESTED_SUBNET_SENTINEL: &str =
     "no-linked-pool";
 pub const NO_LINKED_POOL_CONTAINS_SUBNET_ERR_MSG: &'static str = "\
 The requested IP subnet is not contained in \
-    any Subnet Pool available in the current Silo.";
+    any subnet pool available in the current silo.";
 
 // Error sentinel emitted when requesting an explicit subnet, and it overlaps
 // an existing subnet that's already allocated.
 const SUBNET_OVERLAPS_EXISTING_SENTINEL: &str = "overlap-existing";
 pub const SUBNET_OVERLAPS_EXISTING_ERR_MSG: &'static str =
-    "The requested IP subnet overlaps with an existing External Subnet";
+    "The requested IP subnet overlaps with an existing external subnet";
 
 // Error sentinel emitted when we try to insert a subnet into a project that
 // has now been deleted.
@@ -1306,14 +1307,14 @@ const REQUESTED_POOL_NOT_LINKED_TO_SILO_SENTINEL: &str = "pool-not-linked";
 // Error emitted when there are no default pools for the silo.
 const NO_LINKED_DEFAULT_POOL: &str = "no-linked-default";
 pub const NO_LINKED_DEFAULT_POOL_ERR_MSG: &str = "\
-Must specify a Subnet Pool, as there is no linked default pool for the \
-        current Silo";
+Must specify a subnet pool, as there is no linked default pool for the \
+        current silo";
 
 // Error emitted when there are multiple default pools for the silo.
 const MULTIPLE_LINKED_DEFAULT_POOLS: &str = "multiple-linked-defaults";
 pub const MULTIPLE_LINKED_DEFAULT_POOLS_ERR_MSG: &str = "\
 Must specify an IP version when there is more than one default \
-        Subnet Pool for the Silo";
+        subnet pool for the silo";
 
 #[cfg(test)]
 mod tests {

--- a/nexus/tests/integration_tests/ip_pools.rs
+++ b/nexus/tests/integration_tests/ip_pools.rs
@@ -1158,7 +1158,7 @@ async fn test_bad_ip_ranges(
         .unwrap();
         let expected_message = format!(
             "The provided IP range {}-{} overlaps with an existing \
-            IP Pool range or Subnet Pool member",
+            IP pool range or subnet pool member",
             bad_range.first_address(),
             bad_range.last_address(),
         );

--- a/nexus/types/versions/src/floating_ip_allocator_update/external_subnet.rs
+++ b/nexus/types/versions/src/floating_ip_allocator_update/external_subnet.rs
@@ -64,7 +64,7 @@ impl TryFrom<crate::v2026_01_16_01::external_subnet::ExternalSubnetAllocator>
             } => {
                 if pool.is_some() {
                     return Err(Error::invalid_request(
-                        "May not specify both an IP subnet and a Subnet Pool",
+                        "May not specify both an IP subnet and a subnet pool",
                     ));
                 }
                 Ok(Self::Explicit { subnet })

--- a/nexus/types/versions/src/floating_ip_allocator_update/subnet_pool.rs
+++ b/nexus/types/versions/src/floating_ip_allocator_update/subnet_pool.rs
@@ -73,7 +73,7 @@ impl TryFrom<crate::v2026_01_16_01::subnet_pool::SubnetPoolCreate>
         } = value;
         if pool_type != crate::v2025_11_20_00::ip_pool::IpPoolType::Unicast {
             return Err(Error::invalid_request(
-                "Subnet Pools must have pool type unicast",
+                "Subnet pools must have pool type unicast",
             ));
         }
         Ok(Self { identity, ip_version })


### PR DESCRIPTION
Easy stuff. Almost all are external-facing errors but I fixed a couple of internal errors too. Why not be perfect.

In addition to casing fixes, there are a couple of more substantive tweaks to avoid being misleadingly specific about the reason a subnet can't be allocated.