### PR TITLE
Improve BundleRequest and BundleDataSelection ergonomics and pedantry.

### DIFF
--- a/nexus/src/app/background/tasks/support_bundle/request.rs
+++ b/nexus/src/app/background/tasks/support_bundle/request.rs
@@ -37,6 +37,13 @@ pub struct BundleRequest {
 }
 
 impl BundleRequest {
+    pub fn all() -> Self {
+        Self {
+            transfer_chunk_size: CHUNK_SIZE,
+            data_selection: BundleDataSelection::all(),
+        }
+    }
+
     pub fn include_reconfigurator_data(&self) -> bool {
         self.data_selection.contains(BundleDataCategory::Reconfigurator)
     }
@@ -68,14 +75,5 @@ impl BundleRequest {
 
     pub fn include_sp_dumps(&self) -> bool {
         self.data_selection.contains(BundleDataCategory::SpDumps)
-    }
-}
-
-impl Default for BundleRequest {
-    fn default() -> Self {
-        Self {
-            transfer_chunk_size: CHUNK_SIZE,
-            data_selection: BundleDataSelection::default(),
-        }
     }
 }

--- a/nexus/src/app/background/tasks/support_bundle_collector.rs
+++ b/nexus/src/app/background/tasks/support_bundle_collector.rs
@@ -416,7 +416,7 @@ impl BackgroundTask for SupportBundleCollector {
                 }
             };
 
-            let request = BundleRequest::default();
+            let request = BundleRequest::all();
             match self.collect_bundle(&opctx, &request).await {
                 Ok(report) => collection_report = Some(report),
                 Err(err) => {
@@ -519,7 +519,7 @@ mod test {
             nexus.id(),
         );
 
-        let request = BundleRequest::default();
+        let request = BundleRequest::all();
         let report = collector
             .collect_bundle(&opctx, &request)
             .await
@@ -834,7 +834,7 @@ mod test {
         // The bundle collection should complete successfully.
         // NOTE: The support bundle querying interface isn't supported on
         // the simulated sled agent (yet?) so we're using an empty sled selection.
-        let mut request = BundleRequest::default();
+        let mut request = BundleRequest::all();
         request.data_selection = request.data_selection.with_specific_sleds([]);
         let report = collector
             .collect_bundle(&opctx, &request)
@@ -911,7 +911,7 @@ mod test {
         );
 
         // Collect the bundle
-        let mut request = BundleRequest::default();
+        let mut request = BundleRequest::all();
         request.data_selection = request.data_selection.with_specific_sleds([]);
         let report = collector
             .collect_bundle(&opctx, &request)
@@ -1130,7 +1130,7 @@ mod test {
         );
 
         // Each time we call "collect_bundle", we collect a SINGLE bundle.
-        let mut request = BundleRequest::default();
+        let mut request = BundleRequest::all();
         request.data_selection = request.data_selection.with_specific_sleds([]);
         let report = collector
             .collect_bundle(&opctx, &request)
@@ -1295,7 +1295,7 @@ mod test {
             false,
             nexus.id(),
         );
-        let mut request = BundleRequest::default();
+        let mut request = BundleRequest::all();
         request.data_selection = request.data_selection.with_specific_sleds([]);
         let report = collector
             .collect_bundle(&opctx, &request)
@@ -1450,7 +1450,7 @@ mod test {
             false,
             nexus.id(),
         );
-        let mut request = BundleRequest::default();
+        let mut request = BundleRequest::all();
         request.data_selection = request.data_selection.with_specific_sleds([]);
         let report = collector
             .collect_bundle(&opctx, &request)
@@ -1535,7 +1535,7 @@ mod test {
             false,
             nexus.id(),
         );
-        let mut request = BundleRequest::default();
+        let mut request = BundleRequest::all();
         request.data_selection = request.data_selection.with_specific_sleds([]);
         let report = collector
             .collect_bundle(&opctx, &request)
@@ -1621,7 +1621,7 @@ mod test {
         );
 
         // Collect the bundle
-        let mut request = BundleRequest::default();
+        let mut request = BundleRequest::all();
         request.data_selection = request.data_selection.with_specific_sleds([]);
         let report = collector
             .collect_bundle(&opctx, &request)

--- a/nexus/types/src/fm/case.rs
+++ b/nexus/types/src/fm/case.rs
@@ -100,7 +100,7 @@ pub struct SupportBundleRequest {
     /// The sitrep in which this support bundle was requested.
     pub requested_sitrep_id: SitrepUuid,
     /// Which data to include in the support bundle. Use
-    /// [`BundleDataSelection::default()`] to request all default data.
+    /// [`BundleDataSelection::all()`] to request all data.
     pub data_selection: BundleDataSelection,
 }
 
@@ -429,7 +429,7 @@ mod tests {
             .insert_unique(SupportBundleRequest {
                 id: bundle2_id,
                 requested_sitrep_id: closed_sitrep_id,
-                data_selection: BundleDataSelection::default(),
+                data_selection: BundleDataSelection::all(),
             })
             .unwrap();
 

--- a/nexus/types/src/support_bundle.rs
+++ b/nexus/types/src/support_bundle.rs
@@ -101,54 +101,70 @@ pub struct BundleDataSelection {
 
 impl BundleDataSelection {
     /// Creates an empty selection with no data categories.
-    ///
-    /// This is distinct from [`Self::default`], which returns a selection
-    /// containing all categories (i.e. "collect everything").
     pub fn new() -> Self {
         Self { data: HashMap::new() }
     }
 
+    /// Returns a selection containing all default data categories
+    /// (i.e. "collect everything").
+    pub fn all() -> Self {
+        Self::new()
+            .with_reconfigurator()
+            .with_all_sleds()
+            .with_sled_cubby_info()
+            .with_sp_dumps()
+            .with_ereports(
+                EreportFilters::new()
+                    .with_start_time(chrono::Utc::now() - chrono::Days::new(7))
+                    .expect("no end time set, cannot fail"),
+            )
+    }
+
     /// Adds reconfigurator state collection.
-    pub fn with_reconfigurator(self) -> Self {
-        self.with(BundleData::Reconfigurator)
+    pub fn with_reconfigurator(mut self) -> Self {
+        self.insert(BundleData::Reconfigurator);
+        self
     }
 
     /// Adds sled cubby info collection.
-    pub fn with_sled_cubby_info(self) -> Self {
-        self.with(BundleData::SledCubbyInfo)
+    pub fn with_sled_cubby_info(mut self) -> Self {
+        self.insert(BundleData::SledCubbyInfo);
+        self
     }
 
     /// Adds SP dump collection.
-    pub fn with_sp_dumps(self) -> Self {
-        self.with(BundleData::SpDumps)
+    pub fn with_sp_dumps(mut self) -> Self {
+        self.insert(BundleData::SpDumps);
+        self
     }
 
     /// Adds host info collection from all sleds.
-    pub fn with_all_sleds(self) -> Self {
-        self.with(BundleData::HostInfo(SledSelection::All))
+    pub fn with_all_sleds(mut self) -> Self {
+        self.insert(BundleData::HostInfo(SledSelection::All));
+        self
     }
 
     /// Adds host info collection from specific sleds.
     pub fn with_specific_sleds(
-        self,
+        mut self,
         sleds: impl IntoIterator<Item = SledUuid>,
     ) -> Self {
-        self.with(BundleData::HostInfo(SledSelection::Specific(
+        self.insert(BundleData::HostInfo(SledSelection::Specific(
             sleds.into_iter().collect(),
-        )))
+        )));
+        self
     }
 
     /// Adds ereport collection with the given filters.
-    pub fn with_ereports(self, filters: EreportFilters) -> Self {
-        self.with(BundleData::Ereports(filters))
+    pub fn with_ereports(mut self, filters: EreportFilters) -> Self {
+        self.insert(BundleData::Ereports(filters));
+        self
     }
 
-    /// Builder-style method that inserts a [`BundleData`] value and returns
-    /// `self`. If multiple BundleData entries with the same type are inserted,
-    /// the last write wins.
-    pub fn with(mut self, bundle_data: BundleData) -> Self {
+    /// Inserts a [`BundleData`] value. If a value with the same category
+    /// already exists, the last write wins.
+    pub fn insert(&mut self, bundle_data: BundleData) {
         self.data.insert(bundle_data.category(), bundle_data);
-        self
     }
 
     pub fn contains(&self, category: BundleDataCategory) -> bool {
@@ -158,10 +174,35 @@ impl BundleDataSelection {
     pub fn get(&self, category: BundleDataCategory) -> Option<&BundleData> {
         self.data.get(&category)
     }
+}
 
-    /// Iterates over the data entries in this selection.
-    pub fn iter(&self) -> impl Iterator<Item = &BundleData> {
+impl IntoIterator for BundleDataSelection {
+    type Item = BundleData;
+    type IntoIter =
+        std::collections::hash_map::IntoValues<BundleDataCategory, BundleData>;
+
+    fn into_iter(self) -> Self::IntoIter {
+        self.data.into_values()
+    }
+}
+
+impl<'a> IntoIterator for &'a BundleDataSelection {
+    type Item = &'a BundleData;
+    type IntoIter =
+        std::collections::hash_map::Values<'a, BundleDataCategory, BundleData>;
+
+    fn into_iter(self) -> Self::IntoIter {
         self.data.values()
+    }
+}
+
+impl FromIterator<BundleData> for BundleDataSelection {
+    fn from_iter<T: IntoIterator<Item = BundleData>>(iter: T) -> Self {
+        let mut sel = Self::new();
+        for data in iter {
+            sel.insert(data);
+        }
+        sel
     }
 }
 
@@ -191,27 +232,9 @@ impl fmt::Display for DisplayBundleDataSelection<'_> {
     }
 }
 
-impl FromIterator<BundleData> for BundleDataSelection {
-    fn from_iter<T: IntoIterator<Item = BundleData>>(iter: T) -> Self {
-        iter.into_iter().fold(Self::new(), |sel, data| sel.with(data))
-    }
-}
-
 impl Default for BundleDataSelection {
-    /// Returns a selection containing all data categories (i.e. "collect
-    /// everything"). This is distinct from [`Self::new`], which returns an
-    /// empty selection.
     fn default() -> Self {
         Self::new()
-            .with_reconfigurator()
-            .with_all_sleds()
-            .with_sled_cubby_info()
-            .with_sp_dumps()
-            .with_ereports(
-                EreportFilters::new()
-                    .with_start_time(chrono::Utc::now() - chrono::Days::new(7))
-                    .expect("no end time set, cannot fail"),
-            )
     }
 }
 


### PR DESCRIPTION
First: revive `BundleDataSelection::insert` to be less annoying than `with`.
Second: add some `IntoIterator` implementations for `BundleDataSelection` instead of an ad-hoc `iter()` method.

More important: `Default` is typically understood to mean an empty/zero/identity value in polymorphic contexts. For example, the thing you might kick off a `fold` or `reduce` with, or the thing you might want to get from a map if the key weren't found.

In the present code, we don't use `default()` polymorphically via the `Default` trait, we only use it directly as `BundleRequest::default()` or `BundleDataSelection::default()`. In the usual case where the support bundle is requested by the user (rather than, say, via fault management), we _explicitly want to select all data_. So for clarity, we rename `default` to `all` here.

These will both be important in upcoming PRs, requesting support bundles with certain data selections from a fault management sitrep.