### PR TITLE
Fix flaky test_support_bundle_lifecycle

### DIFF
--- a/dev-tools/omdb/tests/successes.out
+++ b/dev-tools/omdb/tests/successes.out
@@ -918,7 +918,12 @@ task: "sp_ereport_ingester"
   configured period: every <REDACTED_DURATION>s
   last completed activation: <REDACTED ITERATIONS>, triggered by <TRIGGERED_BY_REDACTED>
     started at <REDACTED_TIMESTAMP> (<REDACTED DURATION>s ago) and ran for <REDACTED DURATION>ms
-    SP ereport ingestion explicitly disabled by config!
+    total ereports received:             <TOTAL_EREPORTS_RECEIVED_REDACTED>
+      new ereports ingested:             <NEW_EREPORTS_INGESTED_REDACTED>
+    total HTTP requests sent:            <TOTAL_HTTP_REQUESTS_SENT_REDACTED>
+      total collection errors:           <TOTAL_COLLECTION_ERRORS_REDACTED>
+    reporters with ereports:             <REPORTERS_WITH_EREPORTS_REDACTED>
+    reporters with collection errors:    <REPORTERS_WITH_COLLECTION_ERRORS_REDACTED>
 
 task: "support_bundle_collector"
   configured period: every <REDACTED_DURATION>days <REDACTED_DURATION>h <REDACTED_DURATION>m <REDACTED_DURATION>s
@@ -1546,7 +1551,12 @@ task: "sp_ereport_ingester"
   configured period: every <REDACTED_DURATION>s
   last completed activation: <REDACTED ITERATIONS>, triggered by <TRIGGERED_BY_REDACTED>
     started at <REDACTED_TIMESTAMP> (<REDACTED DURATION>s ago) and ran for <REDACTED DURATION>ms
-    SP ereport ingestion explicitly disabled by config!
+    total ereports received:             <TOTAL_EREPORTS_RECEIVED_REDACTED>
+      new ereports ingested:             <NEW_EREPORTS_INGESTED_REDACTED>
+    total HTTP requests sent:            <TOTAL_HTTP_REQUESTS_SENT_REDACTED>
+      total collection errors:           <TOTAL_COLLECTION_ERRORS_REDACTED>
+    reporters with ereports:             <REPORTERS_WITH_EREPORTS_REDACTED>
+    reporters with collection errors:    <REPORTERS_WITH_COLLECTION_ERRORS_REDACTED>
 
 task: "support_bundle_collector"
   configured period: every <REDACTED_DURATION>days <REDACTED_DURATION>h <REDACTED_DURATION>m <REDACTED_DURATION>s

--- a/dev-tools/omdb/tests/test_all_output.rs
+++ b/dev-tools/omdb/tests/test_all_output.rs
@@ -131,8 +131,19 @@ async fn test_omdb_usage_errors() {
     assert_contents("tests/usage_errors.out", &output);
 }
 
-#[nexus_test(extra_sled_agents = 1)]
-async fn test_omdb_success_cases(cptestctx: &ControlPlaneTestContext) {
+#[tokio::test]
+async fn test_omdb_success_cases() {
+    // Use a custom ControlPlaneBuilder so we can enable background tasks
+    // which might otherwise be disabled.
+    // We want it enabled here so the omdb is realistic.
+    let cptestctx =
+        nexus_test_utils::ControlPlaneBuilder::new("test_omdb_success_cases")
+            .with_extra_sled_agents(1)
+            .customize_nexus_config(&|config| {
+                config.pkg.background_tasks.sp_ereport_ingester.disable = false;
+            })
+            .start::<omicron_nexus::Server>()
+            .await;
     clear_omdb_env();
 
     let cmd_path = path_to_executable(CMD_OMDB);
@@ -443,6 +454,8 @@ async fn test_omdb_success_cases(cptestctx: &ControlPlaneTestContext) {
         &ox_url,
         ox_test_producer,
     );
+
+    cptestctx.teardown().await;
 }
 
 /// Verify that we properly deal with cases where:

--- a/nexus/tests/config.test.toml
+++ b/nexus/tests/config.test.toml
@@ -192,6 +192,8 @@ webhook_deliverator.first_retry_backoff_secs = 10
 webhook_deliverator.second_retry_backoff_secs = 20
 read_only_region_replacement_start.period_secs = 999999
 sp_ereport_ingester.period_secs = 30
+# Disabled to prevent nondeterministic ereport ingestion from simulated SPs,
+# which causes the support bundle lifecycle test to flake (see #10179).
 sp_ereport_ingester.disable = true
 # How frequently to check for a new fault management sitrep (made by any Nexus).
 # This is cheap, so we should check frequently.


### PR DESCRIPTION
The sp_ereport_ingester background task runs on a 30-second timer and ingests ereports from simulated SPs into the database. The support bundle collection test asserts that zero ereports are found, but if the ingester fires before the bundle collector runs, it populates the DB with 11 ereports from the simulated SPs (configured in sp_sim_config.test.toml), causing the assertion to fail.

Fix this by disabling the sp_ereport_ingester in the test config. The ingester has its own dedicated tests that construct it directly, so no test coverage is lost. Comments are added at both assertion sites explaining the dependency on the ingester being disabled.

Fixes #10179