### PR TITLE
omdb: Fix component details error in 'mgs sensors'

### DIFF
--- a/dev-tools/omdb/src/bin/omdb/mgs/sensors.rs
+++ b/dev-tools/omdb/src/bin/omdb/mgs/sensors.rs
@@ -275,27 +275,33 @@ async fn sp_info(
     // of the sensor as well as the retrieved value.
     //
     for c in &components.components {
-        for s in mgs_client
-            .sp_component_get(&type_, slot, &c.component)
-            .await?
-            .iter()
-            .filter_map(|detail| match detail {
-                SpComponentDetails::Measurement { kind, name, value } => Some(
-                    (Sensor { name: name.clone(), kind: *kind }, Some(*value)),
-                ),
-                SpComponentDetails::MeasurementError { kind, name, error } => {
-                    match error {
-                        MeasurementErrorCode::NoReading
-                        | MeasurementErrorCode::NotPresent => None,
-                        _ => Some((
-                            Sensor { name: name.clone(), kind: *kind },
-                            None,
-                        )),
+        let details =
+            match mgs_client.sp_component_get(&type_, slot, &c.component).await
+            {
+                Ok(s) => s,
+                Err(gateway_client::Error::ErrorResponse(rsp))
+                    if rsp.error_code.as_deref()
+                        == Some("UnsupportedComponentDetails") =>
+                {
+                    continue;
+                }
+                Err(e) => return Err(e.into()),
+            };
+        for s in details.iter().filter_map(|detail| match detail {
+            SpComponentDetails::Measurement { kind, name, value } => {
+                Some((Sensor { name: name.clone(), kind: *kind }, Some(*value)))
+            }
+            SpComponentDetails::MeasurementError { kind, name, error } => {
+                match error {
+                    MeasurementErrorCode::NoReading
+                    | MeasurementErrorCode::NotPresent => None,
+                    _ => {
+                        Some((Sensor { name: name.clone(), kind: *kind }, None))
                     }
                 }
-                _ => None,
-            })
-        {
+            }
+            _ => None,
+        }) {
             devices.insert(DeviceIdentifier::Device(c.component.clone()), s);
         }
     }

--- a/gateway-types/versions/src/impls/component_details.rs
+++ b/gateway-types/versions/src/impls/component_details.rs
@@ -15,7 +15,7 @@ use crate::latest::component_details::{
 impl From<UnsupportedComponentDetails> for HttpError {
     fn from(value: UnsupportedComponentDetails) -> Self {
         HttpError::for_bad_request(
-            None,
+            Some("UnsupportedComponentDetails".to_string()),
             format!(
                 "requested component details are not yet supported: {value}"
             ),


### PR DESCRIPTION
In https://github.com/oxidecomputer/omicron/pull/9354, we added component details types that don't support being converted into a measurement. As a result, `omdb mgs sensors` will fail to load any data, instead printing this for each sled:

```
failed to read devices for SpIdentifier { slot: 2, type_: Sled }:
Error Response: status: 400 Bad Request; value:
  Error {
    error_code: None,
    message: "requested component details are not yet supported: unsupported component details: last post code: LastPostCode(3993043480)"
  }
```

Add an error code to `UnsupportedComponentDetails` so clients can reliably identify these failures, and filter them out in the `sensors` subcommand.