### PR TITLE
[bootstore] fix flaky test: schemes::v0::peer::tests::network_config

### DIFF
--- a/bootstore/src/schemes/v0/peer.rs
+++ b/bootstore/src/schemes/v0/peer.rs
@@ -1232,7 +1232,8 @@ mod tests {
             );
 
             let fsm_file = format!("test-learner-{n}-fsm-state-ledger");
-            let network_file = format!("test-{n}-network-config-ledger");
+            let network_file =
+                format!("test-learner-{n}-network-config-ledger");
             let config = Config {
                 id: learner_id(n),
                 addr: SocketAddrV6::new(std::net::Ipv6Addr::LOCALHOST, 0, 0, 0),


### PR DESCRIPTION
See this failure: https://buildomat.eng.oxide.computer/wg/0/details/01KN02PY451PZYF3H5FKR99G7E/XhPWJ5Y9hYidiHof0Dg3hH5QhN8cFsRzzXmBAc4JNSX0EIKi/01KN02Q95YCQ9SY3V907RCXCXB#S7385

There was a collision between the network file paths for the learner 1 and `pc-b-1`.
