### PR TITLE
[nexus] re-enable `sp_ereport_ingester` a second time

### DIFF
--- a/smf/nexus/multi-sled/config-partial.toml
+++ b/smf/nexus/multi-sled/config-partial.toml
@@ -94,10 +94,6 @@ read_only_region_replacement_start.period_secs = 30
 alert_dispatcher.period_secs = 60
 webhook_deliverator.period_secs = 60
 sp_ereport_ingester.period_secs = 30
-# Disabled in R16, as the Hubris task that handles ereport ingestion requests
-# has not merged yet, and trying to ingest them will just result in Nexus
-# logging a bunch of errors.
-sp_ereport_ingester.disable = true
 # How frequently to check for a new fault management sitrep (made by any
 # Nexus).
 # This is cheap, so we should check frequently.

--- a/smf/nexus/single-sled/config-partial.toml
+++ b/smf/nexus/single-sled/config-partial.toml
@@ -94,10 +94,6 @@ read_only_region_replacement_start.period_secs = 30
 alert_dispatcher.period_secs = 60
 webhook_deliverator.period_secs = 60
 sp_ereport_ingester.period_secs = 30
-# Disabled in R16, as the Hubris task that handles ereport ingestion requests
-# has not merged yet, and trying to ingest them will just result in Nexus
-# logging a bunch of errors.
-sp_ereport_ingester.disable = true
 # How frequently to check for a new fault management sitrep (made by any
 # Nexus).
 # This is cheap, so we should check frequently.


### PR DESCRIPTION
PR #8709 temporarily disabled the `sp_ereport_ingester` background task in the config file for R16, as at the time, the Hubris task that actually exported ereports to the control plane had not merged, and trying to collect them would just result in Nexus logging a bunch of errors. After the Hubris code was merged, PR #8838 removed the config file changes that disabled the `sp_ereport_ingester` task, and all was well...

...for exactly 35 days. Then, an unrelated PR, #9091 inadvertently [put back the config][1] for disabling the background task, due to what appears to be a bad merge. Whoops.

Therefore, this PR un-disables the `sp_ereport_ingester` background task a _second_ time. Sigh.

[1]:
https://github.com/oxidecomputer/omicron/commit/18058fcad61863324e3be38f17001ed5760d1458#diff-4bc8cb2586b5997322a5977452772052073f9c5392dd2a578b9d9930a2aedd72