### PR TITLE
remove tuf_base_url from omicron.public.rack

### DIFF
--- a/dev-tools/omdb/src/bin/omdb/db.rs
+++ b/dev-tools/omdb/src/bin/omdb/db.rs
@@ -2188,7 +2188,6 @@ async fn cmd_db_rack_list(
     struct RackRow {
         id: String,
         initialized: bool,
-        tuf_base_url: String,
         rack_subnet: String,
     }
 
@@ -2204,7 +2203,6 @@ async fn cmd_db_rack_list(
     let rows = rack_list.into_iter().map(|rack| RackRow {
         id: rack.id().to_string(),
         initialized: rack.initialized,
-        tuf_base_url: rack.tuf_base_url.unwrap_or_else(|| "-".to_string()),
         rack_subnet: rack
             .rack_subnet
             .map(|subnet| subnet.to_string())

--- a/nexus/db-model/src/rack.rs
+++ b/nexus/db-model/src/rack.rs
@@ -16,7 +16,6 @@ pub struct Rack {
     #[diesel(embed)]
     pub identity: RackIdentity,
     pub initialized: bool,
-    pub tuf_base_url: Option<String>,
     pub rack_subnet: Option<IpNetwork>,
 }
 
@@ -25,7 +24,6 @@ impl Rack {
         Self {
             identity: RackIdentity::new(id),
             initialized: false,
-            tuf_base_url: None,
             rack_subnet: None,
         }
     }

--- a/nexus/db-model/src/schema_versions.rs
+++ b/nexus/db-model/src/schema_versions.rs
@@ -16,7 +16,7 @@ use std::{collections::BTreeMap, sync::LazyLock};
 ///
 /// This must be updated when you change the database schema.  Refer to
 /// schema/crdb/README.adoc in the root of this repository for details.
-pub const SCHEMA_VERSION: Version = Version::new(246, 0, 0);
+pub const SCHEMA_VERSION: Version = Version::new(247, 0, 0);
 
 /// List of all past database schema versions, in *reverse* order
 ///
@@ -28,6 +28,7 @@ pub static KNOWN_VERSIONS: LazyLock<Vec<KnownVersion>> = LazyLock::new(|| {
         // |  leaving the first copy as an example for the next person.
         // v
         // KnownVersion::new(next_int, "unique-dirname-with-the-sql-files"),
+        KnownVersion::new(247, "remove-tuf-base-url"),
         KnownVersion::new(246, "ereport-marked-seen"),
         KnownVersion::new(245, "rename-default-igw-ip-pool"),
         KnownVersion::new(244, "ereporter-restart-order-is-bad-actually"),

--- a/nexus/db-schema/src/schema.rs
+++ b/nexus/db-schema/src/schema.rs
@@ -1048,7 +1048,6 @@ table! {
         time_created -> Timestamptz,
         time_modified -> Timestamptz,
         initialized -> Bool,
-        tuf_base_url -> Nullable<Text>,
         rack_subnet -> Nullable<Inet>,
     }
 }

--- a/schema/crdb/dbinit.sql
+++ b/schema/crdb/dbinit.sql
@@ -149,9 +149,6 @@ CREATE TABLE IF NOT EXISTS omicron.public.rack (
      */
     initialized BOOL NOT NULL,
 
-    /* Used to configure the updates service URL */
-    tuf_base_url STRING(512),
-
     /* The IPv6 underlay /56 prefix for the rack */
     rack_subnet INET
 );
@@ -8315,7 +8312,7 @@ INSERT INTO omicron.public.db_metadata (
     version,
     target_version
 ) VALUES
-    (TRUE, NOW(), NOW(), '246.0.0', NULL)
+    (TRUE, NOW(), NOW(), '247.0.0', NULL)
 ON CONFLICT DO NOTHING;
 
 COMMIT;

--- a/schema/crdb/remove-tuf-base-url/up1.sql
+++ b/schema/crdb/remove-tuf-base-url/up1.sql
@@ -1,0 +1,1 @@
+ALTER TABLE omicron.public.rack DROP COLUMN IF EXISTS tuf_base_url;


### PR DESCRIPTION
This hasn't been used since #4690 and I don't think we intend to ever use it.

The original purpose of this field was for the rack to be able to retrieve updates automatically from an HTTPS URL.