### PR TITLE
Delete sitreps non-transactionally with improved pagination

### DIFF
--- a/nexus/db-queries/src/db/datastore/fm.rs
+++ b/nexus/db-queries/src/db/datastore/fm.rs
@@ -2265,6 +2265,8 @@ mod tests {
         db.terminate().await;
         logctx.cleanup_successful();
     }
+
+    /// Test that deeply orphaned child rows (whose fm_sitrep metadata
     /// row doesn't exist) are cleaned up by `fm_sitrep_gc_orphans`.
     #[tokio::test]
     async fn test_gc_deeply_orphaned_children() {


### PR DESCRIPTION
Follow-up to https://github.com/oxidecomputer/omicron/pull/10143

Adds pagination during sitrep garbage collection.

While I was there, I realized that we actually don't need transactions on the delete pathway anymore.

- The delete operation (within the garbage collection pass) deletes sitreps by deleting out-of-history `fm_sitrep` rows, which immediately orphans all other sub-tables within the sitrep.
- All the "concurrent reads" of sitreps go through `fm_sitrep_read_on_conn`, which reads metadata from `fm_sitrep` **last**. If this sitrep can be read: it has not been deleted yet. If this sitrep cannot be read: it has been deleted, and prior reads can be discarded.
- All the "concurrent inserts" of sitreps are contingent on the parent sitrep not being stale. So: because sitrep insert writes to the `fm_sitrep` table first, the child rows are "not orphaned" (won't be GC-ed). This protection lasts for the duration of `fm_sitrep_insert`, OR until the parent sitrep is marked stale - at which point insert should fail anyway.

All this is to say: the "read" and "insert" pathways function fine if a `fm_sitrep` row is deleted non-atomically before subsequent child rows. Therefore: no transaction is necessary here.