### PR TITLE
Show example cycle when ls-apis errors about them

### DIFF
--- a/dev-tools/ls-apis/src/system_apis.rs
+++ b/dev-tools/ls-apis/src/system_apis.rs
@@ -119,6 +119,39 @@ impl<'a> IdOrdItem for FilteredApiConsumer<'a> {
     id_upcast!();
 }
 
+/// Find a cycle in `graph` and render that cycle as a String. Returns None if
+/// there is no cycle containing `node`.
+///
+/// This is primarily useful for debugging, especially when considering graphs
+/// that are typically acyclic. Any cycle containing `node` is, hopefully,
+/// informative. There is no particular order promised about how the cycle is
+/// printed.
+fn print_example_cycle<Name: fmt::Display>(
+    graph: &Graph<&Name, &ClientPackageName>,
+    reverse_nodes: &BTreeMap<&NodeIndex, &&Name>,
+    node: &NodeIndex,
+) -> Option<String> {
+    let mut sccs = petgraph::algo::scc::tarjan_scc(&graph);
+    sccs.retain(|scc| scc.contains(node));
+
+    let Some(first_cycle) = sccs.get(0) else {
+        return None;
+    };
+
+    let mut cycle_rendered = String::new();
+    for component in first_cycle.iter() {
+        if !cycle_rendered.is_empty() {
+            cycle_rendered.push_str(", ");
+        }
+
+        use fmt::Write;
+        write!(cycle_rendered, "{}", reverse_nodes.get(&component).unwrap())
+            .unwrap()
+    }
+
+    Some(cycle_rendered)
+}
+
 impl SystemApis {
     /// Load information about APIs in the system based on both developer-
     /// maintained metadata and Cargo-provided metadata
@@ -861,10 +894,14 @@ impl SystemApis {
         let reverse_nodes: BTreeMap<_, _> =
             nodes.iter().map(|(s_c, node)| (node, s_c)).collect();
         if let Err(error) = petgraph::algo::toposort(&graph, None) {
+            let example_cycle =
+                print_example_cycle(&graph, &reverse_nodes, &error.node_id())
+                    .expect("graph has a cycle containing the node");
             bail!(
                 "graph of server-managed API dependencies between components \
-                 has a cycle (includes node: {:?})",
-                reverse_nodes.get(&error.node_id()).unwrap()
+                 has a cycle (includes node: {:?}, example cycle: {})",
+                reverse_nodes.get(&error.node_id()).unwrap(),
+                example_cycle,
             );
         }
 
@@ -876,10 +913,14 @@ impl SystemApis {
         let reverse_nodes: BTreeMap<_, _> =
             nodes.iter().map(|(d_u, node)| (node, d_u)).collect();
         if let Err(error) = petgraph::algo::toposort(&graph, None) {
+            let example_cycle =
+                print_example_cycle(&graph, &reverse_nodes, &error.node_id())
+                    .expect("graph has a cycle containing the node");
             bail!(
                 "graph of server-managed API dependencies between deployment \
-                 units has a cycle (includes node: {:?})",
-                reverse_nodes.get(&error.node_id()).unwrap()
+                 units has a cycle (includes node: {:?}, example cycle: {})",
+                reverse_nodes.get(&error.node_id()).unwrap(),
+                example_cycle,
             );
         }
 


### PR DESCRIPTION
`cargo xtask ls-apis check` will report an error if the software component graph contains a cycle, as well as if the deployment units form a cycle, but prints only the name of a node in the graph that was in the cycle. If you've added a cycle to either of these graphs, the error and node can tell you about the what that is wrong. Going a bit further and printing an example cycle including the troublesome node can help with the how you got there.

With this change, the first approach at #10231 (which introduced a cycle
in, but all in one deployment unit: sled-agent -> propolis-server ->
sled-agent) errors with a more clear message about propolis-server and sled-agent being the problems:

```
Error: graph of server-managed API dependencies between components has a cycle
(includes node: "propolis-server", example cycle: propolis-server, omicron-sled-agent)
```

(this is the PR that @jgallagher alluded to me putting together, in https://github.com/oxidecomputer/omicron/issues/10232 )