### PR TITLE
Properly check for expunged status during deletes

### DIFF
--- a/nexus/db-queries/src/db/datastore/physical_disk.rs
+++ b/nexus/db-queries/src/db/datastore/physical_disk.rs
@@ -66,12 +66,22 @@ impl DataStore {
                     // functions below check that the Sled hasn't been deleted,
                     // they do not currently check that the Sled has not been
                     // expunged.
-                    Self::check_sled_in_service_on_connection(
-                        &conn,
-                        disk.sled_id(),
-                    )
-                    .await
-                    .map_err(|txn_error| txn_error.into_diesel(&err))?;
+                    let sled_in_service =
+                        Self::check_sled_in_service_on_connection(
+                            &conn,
+                            disk.sled_id(),
+                        )
+                        .await
+                        .map_err(|txn_error| txn_error.into_diesel(&err))?;
+
+                    if !sled_in_service {
+                        return Err(err.bail(TransactionError::CustomError(
+                            Error::internal_error(&format!(
+                                "Sled {} is not in service",
+                                disk.sled_id(),
+                            )),
+                        )));
+                    }
 
                     Self::physical_disk_insert_on_connection(
                         &conn, opctx, disk,

--- a/nexus/db-queries/src/db/datastore/sled.rs
+++ b/nexus/db-queries/src/db/datastore/sled.rs
@@ -50,7 +50,6 @@ use omicron_common::api::external::Error;
 use omicron_common::api::external::ListResultVec;
 use omicron_common::api::external::ResourceType;
 use omicron_common::api::external::http_pagination::PaginatedBy;
-use omicron_common::bail_unless;
 use omicron_uuid_kinds::DatasetUuid;
 use omicron_uuid_kinds::GenericUuid;
 use omicron_uuid_kinds::InstanceUuid;
@@ -681,26 +680,27 @@ impl DataStore {
         Ok((sled, was_modified))
     }
 
-    /// Confirms that a sled exists and is in-service.
+    /// Returns true if a sled exists and is in-service, false if not.
     pub async fn check_sled_in_service(
         &self,
         opctx: &OpContext,
         sled_id: SledUuid,
-    ) -> Result<(), Error> {
+    ) -> Result<bool, Error> {
         let conn = &*self.pool_connection_authorized(&opctx).await?;
         Self::check_sled_in_service_on_connection(conn, sled_id)
             .await
             .map_err(|e| e.into_public_ignore_retries())
     }
 
-    /// Confirms that a sled exists and is in-service.
+    /// Returns true if a sled exists and is in-service, false if not.
     ///
     /// This function may be called from a transaction context.
     pub async fn check_sled_in_service_on_connection(
         conn: &async_bb8_diesel::Connection<DbConnection>,
         sled_id: SledUuid,
-    ) -> Result<(), TransactionError<Error>> {
+    ) -> Result<bool, TransactionError<Error>> {
         use nexus_db_schema::schema::sled::dsl;
+
         let sled_exists_and_in_service = diesel::select(diesel::dsl::exists(
             dsl::sled
                 .filter(dsl::time_deleted.is_null())
@@ -710,13 +710,7 @@ impl DataStore {
         .get_result_async::<bool>(conn)
         .await?;
 
-        bail_unless!(
-            sled_exists_and_in_service,
-            "Sled {} is not in service",
-            sled_id,
-        );
-
-        Ok(())
+        Ok(sled_exists_and_in_service)
     }
 
     // Return the rack id of a commissioned sled if it exists, given its

--- a/nexus/db-queries/src/db/datastore/zpool.rs
+++ b/nexus/db-queries/src/db/datastore/zpool.rs
@@ -303,6 +303,37 @@ impl DataStore {
         Ok(())
     }
 
+    /// Returns true if a zpool exists and is in-service, false if not.
+    pub async fn check_zpool_in_service(
+        &self,
+        opctx: &OpContext,
+        id: ZpoolUuid,
+    ) -> Result<bool, Error> {
+        let conn = self.pool_connection_authorized(opctx).await?;
+
+        use nexus_db_schema::schema::physical_disk::dsl as physical_disk_dsl;
+        use nexus_db_schema::schema::zpool::dsl as zpool_dsl;
+
+        let zpool_exists_and_in_service =
+            diesel::select(diesel::dsl::exists(
+                zpool_dsl::zpool
+                    .filter(zpool_dsl::id.eq(to_db_typed_uuid(id)))
+                    .filter(zpool_dsl::time_deleted.is_null())
+                    .inner_join(physical_disk_dsl::physical_disk.on(
+                        zpool_dsl::physical_disk_id.eq(physical_disk_dsl::id),
+                    ))
+                    .filter(
+                        physical_disk_dsl::disk_policy
+                            .eq(PhysicalDiskPolicy::InService),
+                    ),
+            ))
+            .get_result_async::<bool>(&*conn)
+            .await
+            .map_err(|e| public_error_from_diesel(e, ErrorHandler::Server))?;
+
+        Ok(zpool_exists_and_in_service)
+    }
+
     pub async fn zpool_get_sled_if_in_service(
         &self,
         opctx: &OpContext,

--- a/nexus/src/app/sagas/common_storage.rs
+++ b/nexus/src/app/sagas/common_storage.rs
@@ -139,6 +139,10 @@ pub(crate) async fn call_pantry_attach_for_volume(
     let gone_check =
         || async { Ok(is_pantry_gone(nexus, pantry_address, log).await) };
 
+    // Do not match on `e.is_gone` here: if the Pantry is gone, then return an
+    // error. The attach may have succeeded for one of the previous calls but if
+    // the retry loop bails out after determining that the Pantry is gone, that
+    // attachment is now gone too.
     ProgenitorOperationRetry::new(attach_operation, gone_check)
         .run(log)
         .await
@@ -169,10 +173,18 @@ pub(crate) async fn call_pantry_detach(
     let gone_check =
         || async { Ok(is_pantry_gone(nexus, pantry_address, log).await) };
 
-    ProgenitorOperationRetry::new(detach_operation, gone_check)
+    match ProgenitorOperationRetry::new(detach_operation, gone_check)
         .run(log)
         .await
-        .map(|_response| ())
+    {
+        Ok(_) => Ok(()),
+
+        // The pantry is stateless: if it is gone, then the Volume was
+        // destroyed, and we can proceed as if it was detached.
+        Err(e) if e.is_gone() => Ok(()),
+
+        Err(e) => Err(e),
+    }
 }
 
 pub(crate) fn find_only_new_region(

--- a/nexus/src/app/sagas/common_storage.rs
+++ b/nexus/src/app/sagas/common_storage.rs
@@ -169,18 +169,10 @@ pub(crate) async fn call_pantry_detach(
     let gone_check =
         || async { Ok(is_pantry_gone(nexus, pantry_address, log).await) };
 
-    match ProgenitorOperationRetry::new(detach_operation, gone_check)
+    ProgenitorOperationRetry::new(detach_operation, gone_check)
         .run(log)
         .await
-    {
-        Ok(_) => Ok(()),
-
-        // The pantry is stateless: if it is gone, then the Volume was
-        // destroyed, and we can proceed as if it was detached.
-        Err(e) if e.is_gone() => Ok(()),
-
-        Err(e) => Err(e),
-    }
+        .map(|_response| ())
 }
 
 pub(crate) fn find_only_new_region(

--- a/nexus/src/app/sagas/common_storage.rs
+++ b/nexus/src/app/sagas/common_storage.rs
@@ -139,10 +139,6 @@ pub(crate) async fn call_pantry_attach_for_volume(
     let gone_check =
         || async { Ok(is_pantry_gone(nexus, pantry_address, log).await) };
 
-    // Do not match on `e.is_gone` here: if the Pantry is gone, then return an
-    // error. The attach may have succeeded for one of the previous calls but if
-    // the retry loop bails out after determining that the Pantry is gone, that
-    // attachment is now gone too.
     ProgenitorOperationRetry::new(attach_operation, gone_check)
         .run(log)
         .await

--- a/nexus/src/app/sagas/disk_delete.rs
+++ b/nexus/src/app/sagas/disk_delete.rs
@@ -339,14 +339,35 @@ pub(crate) mod test {
         app::saga::create_saga_dag, app::sagas::disk_delete::Params,
         app::sagas::disk_delete::SagaDiskDelete,
     };
+    use async_bb8_diesel::AsyncRunQueryDsl;
+    use chrono::Utc;
+    use diesel::ExpressionMethods;
+    use diesel::QueryDsl;
+    use diesel::SelectableHelper;
+    use nexus_db_lookup::LookupPath;
+    use nexus_db_model::LocalStorageUnencryptedDatasetAllocation;
+    use nexus_db_model::PhysicalDiskPolicy;
+    use nexus_db_model::RendezvousLocalStorageUnencryptedDataset;
+    use nexus_db_model::to_db_typed_uuid;
     use nexus_db_queries::authn::saga::Serialized;
+    use nexus_db_queries::authz;
     use nexus_db_queries::context::OpContext;
     use nexus_db_queries::db::datastore::Disk;
     use nexus_test_utils::resource_helpers::DiskTest;
     use nexus_test_utils::resource_helpers::create_project;
     use nexus_test_utils_macros::nexus_test;
+    use nexus_types::external_api::disk;
     use nexus_types::external_api::project;
+    use nexus_types::identity::Asset;
+    use omicron_common::api::external::ByteCount;
+    use omicron_common::api::external::IdentityMetadataCreateParams;
     use omicron_common::api::external::Name;
+    use omicron_uuid_kinds::BlueprintUuid;
+    use omicron_uuid_kinds::DatasetUuid;
+    use omicron_uuid_kinds::ExternalZpoolUuid;
+    use omicron_uuid_kinds::GenericUuid;
+    use omicron_uuid_kinds::ZpoolUuid;
+    use uuid::Uuid;
 
     type ControlPlaneTestContext =
         nexus_test_utils::ControlPlaneTestContext<crate::Server>;
@@ -360,7 +381,39 @@ pub(crate) mod test {
         )
     }
 
-    async fn create_disk(cptestctx: &ControlPlaneTestContext) -> Disk {
+    pub fn new_disk_create_params() -> disk::DiskCreate {
+        disk::DiskCreate {
+            identity: IdentityMetadataCreateParams {
+                name: "distributed".parse().expect("Invalid disk name"),
+                description: "My disk".to_string(),
+            },
+            disk_backend: disk::DiskBackend::Distributed {
+                disk_source: disk::DiskSource::Blank {
+                    block_size: disk::BlockSize(512),
+                },
+            },
+            size: ByteCount::from_gibibytes_u32(1),
+        }
+    }
+
+    pub fn new_local_disk_create_params() -> disk::DiskCreate {
+        disk::DiskCreate {
+            identity: IdentityMetadataCreateParams {
+                name: "local".parse().expect("Invalid disk name"),
+                description: "My disk".to_string(),
+            },
+            disk_backend: disk::DiskBackend::Local {},
+            size: ByteCount::from_gibibytes_u32(1),
+        }
+    }
+
+    async fn create_disk<F>(
+        cptestctx: &ControlPlaneTestContext,
+        create_params: F,
+    ) -> Disk
+    where
+        F: Fn() -> disk::DiskCreate,
+    {
         let nexus = &cptestctx.server.server_context().nexus;
         let opctx = test_opctx(&cptestctx);
 
@@ -372,11 +425,7 @@ pub(crate) mod test {
             nexus.project_lookup(&opctx, project_selector).unwrap();
 
         nexus
-            .project_create_disk(
-                &opctx,
-                &project_lookup,
-                &crate::app::sagas::disk_create::test::new_disk_create_params(),
-            )
+            .project_create_disk(&opctx, &project_lookup, &create_params())
             .await
             .expect("Failed to create disk")
     }
@@ -390,7 +439,7 @@ pub(crate) mod test {
         let client = &cptestctx.external_client;
         let nexus = &cptestctx.server.server_context().nexus;
         let project_id = create_project(client, PROJECT_NAME).await.identity.id;
-        let disk = create_disk(&cptestctx).await;
+        let disk = create_disk(&cptestctx, new_disk_create_params).await;
 
         // Build the saga DAG with the provided test parameters and run it.
         let opctx = test_opctx(&cptestctx);
@@ -412,7 +461,7 @@ pub(crate) mod test {
         let client = &cptestctx.external_client;
         let nexus = &cptestctx.server.server_context().nexus;
         let project_id = create_project(client, PROJECT_NAME).await.identity.id;
-        let disk = create_disk(&cptestctx).await;
+        let disk = create_disk(&cptestctx, new_disk_create_params).await;
 
         // Build the saga DAG with the provided test parameters
         let opctx = test_opctx(&cptestctx);
@@ -432,5 +481,268 @@ pub(crate) mod test {
             &cptestctx, &test,
         )
         .await;
+    }
+
+    struct ExpungeTestHarness<'a> {
+        cptestctx: &'a ControlPlaneTestContext,
+        zpool_id: ZpoolUuid,
+        allocation: LocalStorageUnencryptedDatasetAllocation,
+    }
+
+    impl<'a> ExpungeTestHarness<'a> {
+        pub async fn setup(
+            cptestctx: &'a ControlPlaneTestContext,
+            disk_id: Uuid,
+            zpool_id: ZpoolUuid,
+        ) -> Self {
+            // TODO normally these allocations are only performed during sled
+            // reservation so manually inserting records bypasses the need for
+            // also creating an instance in this test. Further, Nexus created
+            // for unit and integration tests using the `nexus_test` does _not_
+            // perform reconfigurator execution, which means local storage
+            // datasets are not created, which necessitates extra manual steps
+            // here to create the relevant rendezvous table entries. Once this
+            // occurs, this test (and others!) will need to be updated.
+
+            let nexus = &cptestctx.server.server_context().nexus;
+            let datastore = nexus.datastore();
+
+            let opctx = OpContext::for_tests(
+                cptestctx.logctx.log.new(o!()),
+                datastore.clone(),
+            );
+
+            // Manually insert into rendezvous table
+
+            let local_storage_dataset = datastore
+                .local_storage_unencrypted_dataset_insert_if_not_exists(
+                    &opctx,
+                    RendezvousLocalStorageUnencryptedDataset::new(
+                        DatasetUuid::new_v4(),
+                        zpool_id,
+                        BlueprintUuid::new_v4(),
+                    ),
+                )
+                .await
+                .unwrap()
+                .unwrap();
+
+            // Manually populate both the `disk_type_local_storage` table's
+            // allocation id, and the allocation table.
+
+            let (.., db_zpool) = LookupPath::new(&opctx, datastore)
+                .zpool_id(zpool_id)
+                .fetch()
+                .await
+                .unwrap();
+
+            let allocation =
+                LocalStorageUnencryptedDatasetAllocation::new_for_tests_only(
+                    DatasetUuid::new_v4(),
+                    Utc::now(),
+                    local_storage_dataset.id(),
+                    ExternalZpoolUuid::from_untyped_uuid(
+                        db_zpool.id().into_untyped_uuid(),
+                    ),
+                    db_zpool.sled_id(),
+                    ByteCount::from_gibibytes_u32(1).into(),
+                );
+
+            {
+                let conn = datastore.pool_connection_for_tests().await.unwrap();
+
+                use nexus_db_schema::schema::disk_type_local_storage::dsl;
+
+                diesel::update(dsl::disk_type_local_storage)
+                    .filter(dsl::disk_id.eq(disk_id))
+                    .set(
+                        dsl::local_storage_unencrypted_dataset_allocation_id
+                            .eq(to_db_typed_uuid(allocation.id())),
+                    )
+                    .execute_async(&*conn)
+                    .await
+                    .unwrap();
+            }
+
+            {
+                let conn = datastore.pool_connection_for_tests().await.unwrap();
+
+                use nexus_db_schema::schema::local_storage_unencrypted_dataset_allocation::dsl;
+
+                diesel::insert_into(
+                    dsl::local_storage_unencrypted_dataset_allocation,
+                )
+                .values(allocation.clone())
+                .execute_async(&*conn)
+                .await
+                .unwrap();
+            }
+
+            ExpungeTestHarness { cptestctx, zpool_id, allocation }
+        }
+
+        pub async fn expunge_sled(&self) {
+            // Set the sled backing the zpool's policy to expunged
+
+            let nexus = &self.cptestctx.server.server_context().nexus;
+            let datastore = nexus.datastore();
+
+            let opctx = OpContext::for_tests(
+                self.cptestctx.logctx.log.new(o!()),
+                datastore.clone(),
+            );
+
+            let (.., db_zpool) = LookupPath::new(&opctx, datastore)
+                .zpool_id(self.zpool_id)
+                .fetch()
+                .await
+                .unwrap();
+
+            let (.., authz_sled) = LookupPath::new(&opctx, datastore)
+                .sled_id(db_zpool.sled_id())
+                .lookup_for(authz::Action::Modify)
+                .await
+                .unwrap();
+
+            datastore
+                .sled_set_policy_to_expunged(&opctx, &authz_sled)
+                .await
+                .unwrap();
+        }
+
+        pub async fn expunge_disk(&self) {
+            // Set the physical disk backing the zpool's policy to expunged
+
+            let nexus = &self.cptestctx.server.server_context().nexus;
+            let datastore = nexus.datastore();
+
+            let opctx = OpContext::for_tests(
+                self.cptestctx.logctx.log.new(o!()),
+                datastore.clone(),
+            );
+
+            let (.., db_zpool) = LookupPath::new(&opctx, datastore)
+                .zpool_id(self.zpool_id)
+                .fetch()
+                .await
+                .unwrap();
+
+            datastore
+                .physical_disk_update_policy(
+                    &opctx,
+                    db_zpool.physical_disk_id(),
+                    PhysicalDiskPolicy::Expunged,
+                )
+                .await
+                .unwrap();
+        }
+
+        pub async fn validate_allocation_deleted(&self) {
+            let nexus = &self.cptestctx.server.server_context().nexus;
+            let datastore = nexus.datastore();
+
+            let conn = datastore.pool_connection_for_tests().await.unwrap();
+
+            use nexus_db_schema::schema::local_storage_unencrypted_dataset_allocation::dsl;
+
+            let allocation = dsl::local_storage_unencrypted_dataset_allocation
+                .filter(dsl::id.eq(to_db_typed_uuid(self.allocation.id())))
+                .select(LocalStorageUnencryptedDatasetAllocation::as_select())
+                .get_result_async(&*conn)
+                .await
+                .unwrap();
+
+            assert!(allocation.time_deleted.is_some());
+        }
+    }
+
+    #[nexus_test(server = crate::Server)]
+    async fn test_delete_local_disk_backed_by_expunged_sled(
+        cptestctx: &ControlPlaneTestContext,
+    ) {
+        let disk_test = DiskTest::new(cptestctx).await;
+
+        let client = &cptestctx.external_client;
+        let nexus = &cptestctx.server.server_context().nexus;
+        let datastore = nexus.datastore();
+        let opctx = OpContext::for_tests(
+            cptestctx.logctx.log.new(o!()),
+            datastore.clone(),
+        );
+
+        let project_id = create_project(client, PROJECT_NAME).await.identity.id;
+        let disk = create_disk(&cptestctx, new_local_disk_create_params).await;
+
+        // Manually create an allocation for that local storage on a pool, then
+        // expunge the sled backing the pool.
+
+        let zpool = disk_test.zpools().next().unwrap();
+
+        let harness =
+            ExpungeTestHarness::setup(cptestctx, disk.id(), zpool.id).await;
+
+        harness.expunge_sled().await;
+
+        // Now that the disk' local storage specific information has been
+        // populated, re-fetch it.
+
+        let disk = datastore.disk_get(&opctx, disk.id()).await.unwrap();
+
+        // Build the saga DAG with the provided test parameters
+        let opctx = test_opctx(&cptestctx);
+        let params = Params {
+            serialized_authn: Serialized::for_opctx(&opctx),
+            project_id,
+            disk,
+        };
+
+        nexus.sagas.saga_execute::<SagaDiskDelete>(params).await.unwrap();
+
+        harness.validate_allocation_deleted().await;
+    }
+
+    #[nexus_test(server = crate::Server)]
+    async fn test_delete_local_disk_backed_by_expunged_zpool(
+        cptestctx: &ControlPlaneTestContext,
+    ) {
+        let disk_test = DiskTest::new(cptestctx).await;
+
+        let client = &cptestctx.external_client;
+        let nexus = &cptestctx.server.server_context().nexus;
+        let datastore = nexus.datastore();
+        let opctx = OpContext::for_tests(
+            cptestctx.logctx.log.new(o!()),
+            datastore.clone(),
+        );
+
+        let project_id = create_project(client, PROJECT_NAME).await.identity.id;
+        let disk = create_disk(&cptestctx, new_local_disk_create_params).await;
+
+        // Manually create an allocation for that local storage on a pool, then
+        // expunge the physical disk backing the pool.
+
+        let zpool = disk_test.zpools().next().unwrap();
+
+        let harness =
+            ExpungeTestHarness::setup(cptestctx, disk.id(), zpool.id).await;
+
+        harness.expunge_disk().await;
+
+        // Now that the disk' local storage specific information has been
+        // populated, re-fetch it.
+
+        let disk = datastore.disk_get(&opctx, disk.id()).await.unwrap();
+
+        // Build the saga DAG with the provided test parameters
+        let opctx = test_opctx(&cptestctx);
+        let params = Params {
+            serialized_authn: Serialized::for_opctx(&opctx),
+            project_id,
+            disk,
+        };
+
+        nexus.sagas.saga_execute::<SagaDiskDelete>(params).await.unwrap();
+
+        harness.validate_allocation_deleted().await;
     }
 }

--- a/nexus/src/app/sagas/disk_delete.rs
+++ b/nexus/src/app/sagas/disk_delete.rs
@@ -8,7 +8,9 @@ use super::NexusSaga;
 use crate::app::InlineErrorChain;
 use crate::app::sagas::SagaInitError;
 use crate::app::sagas::declare_saga_actions;
+use crate::app::sagas::sled_out_of_service_gone_check;
 use crate::app::sagas::volume_delete;
+use crate::app::sagas::zpool_out_of_service_gone_check;
 use nexus_db_queries::authn;
 use nexus_db_queries::db;
 use nexus_db_queries::db::datastore;
@@ -229,6 +231,7 @@ async fn sdd_delete_local_storage(
     };
 
     let sled_id = allocation.sled_id();
+    let zpool_id = allocation.pool_id().upcast();
 
     let request = LocalStorageDatasetDeleteRequest {
         zpool_id: allocation.pool_id(),
@@ -250,18 +253,31 @@ async fn sdd_delete_local_storage(
         sled_agent_client.local_storage_dataset_delete(&request).await
     };
 
-    // `check_sled_in_service` returns an error if the sled is no longer in
-    // service; if it succeeds, the sled is not gone.
+    // Bail out of the retry loop if either the disk or sled is no longer
+    // in-service.
     let gone_check = || async {
-        osagactx
-            .datastore()
-            .check_sled_in_service(&opctx, sled_id)
+        match sled_out_of_service_gone_check(
+            osagactx.datastore(),
+            &opctx,
+            sled_id,
+        )
+        .await?
+        {
+            GoneCheckResult::StillAvailable => {
+                // proceed to zpool check
+            }
+
+            GoneCheckResult::Gone => {
+                return Ok(GoneCheckResult::Gone);
+            }
+        }
+
+        zpool_out_of_service_gone_check(osagactx.datastore(), &opctx, zpool_id)
             .await
-            .map(|()| GoneCheckResult::StillAvailable)
     };
 
     let log = osagactx.log().clone();
-    retry_operation_while_indefinitely(
+    let result = retry_operation_while_indefinitely(
         backon_retry_policy_internal_service(),
         delete_operation,
         gone_check,
@@ -274,15 +290,21 @@ async fn sdd_delete_local_storage(
             );
         },
     )
-    .await
-    .map_err(|e| {
-        saga_action_failed(Error::internal_error(&format!(
+    .await;
+
+    match result {
+        Ok(_) => Ok(()),
+
+        // In this case, if the particular disk hosting this local storage was
+        // expunged, or if the sled was expunged, then proceed with the rest of
+        // the saga.
+        Err(e) if e.is_gone() => Ok(()),
+
+        Err(e) => Err(saga_action_failed(Error::internal_error(&format!(
             "failed to delete local storage: {}",
             InlineErrorChain::new(&e)
-        )))
-    })?;
-
-    Ok(())
+        )))),
+    }
 }
 
 async fn sdd_deallocate_local_storage(

--- a/nexus/src/app/sagas/disk_delete.rs
+++ b/nexus/src/app/sagas/disk_delete.rs
@@ -372,7 +372,7 @@ pub(crate) mod test {
     type ControlPlaneTestContext =
         nexus_test_utils::ControlPlaneTestContext<crate::Server>;
 
-    const PROJECT_NAME: &str = "springfield-squidport";
+    const PROJECT_NAME: &str = "test-project";
 
     pub fn test_opctx(cptestctx: &ControlPlaneTestContext) -> OpContext {
         OpContext::for_tests(
@@ -407,7 +407,7 @@ pub(crate) mod test {
         }
     }
 
-    async fn create_disk<F>(
+    pub async fn create_disk<F>(
         cptestctx: &ControlPlaneTestContext,
         create_params: F,
     ) -> Disk
@@ -483,7 +483,7 @@ pub(crate) mod test {
         .await;
     }
 
-    struct ExpungeTestHarness<'a> {
+    pub struct ExpungeTestHarness<'a> {
         cptestctx: &'a ControlPlaneTestContext,
         zpool_id: ZpoolUuid,
         allocation: LocalStorageUnencryptedDatasetAllocation,
@@ -673,8 +673,8 @@ pub(crate) mod test {
         let project_id = create_project(client, PROJECT_NAME).await.identity.id;
         let disk = create_disk(&cptestctx, new_local_disk_create_params).await;
 
-        // Manually create an allocation for that local storage on a pool, then
-        // expunge the sled backing the pool.
+        // Create a local storage disk, manually create an allocation for that
+        // local storage on a pool, then expunge the sled backing the pool.
 
         let zpool = disk_test.zpools().next().unwrap();
 
@@ -718,8 +718,8 @@ pub(crate) mod test {
         let project_id = create_project(client, PROJECT_NAME).await.identity.id;
         let disk = create_disk(&cptestctx, new_local_disk_create_params).await;
 
-        // Manually create an allocation for that local storage on a pool, then
-        // expunge the physical disk backing the pool.
+        // Create a local storage disk, manually create an allocation for that
+        // local storage on a pool, then expunge the sled backing the pool.
 
         let zpool = disk_test.zpools().next().unwrap();
 

--- a/nexus/src/app/sagas/instance_start.rs
+++ b/nexus/src/app/sagas/instance_start.rs
@@ -739,9 +739,6 @@ async fn sis_ensure_local_storage(
     )
     .await
     .map_err(|e| {
-        // Do not match on `e.is_gone` here: If the ensure retry loop bailed out
-        // due to a disk or sled being expunged, then we have to unwind the
-        // saga.
         saga_action_failed(Error::internal_error(&format!(
             "failed to ensure local storage: {}",
             InlineErrorChain::new(&e)

--- a/nexus/src/app/sagas/instance_start.rs
+++ b/nexus/src/app/sagas/instance_start.rs
@@ -18,6 +18,8 @@ use crate::app::instance::{
 };
 use crate::app::instance_network::InstanceNetworkFilters;
 use crate::app::sagas::declare_saga_actions;
+use crate::app::sagas::sled_out_of_service_gone_check;
+use crate::app::sagas::zpool_out_of_service_gone_check;
 use chrono::Utc;
 use nexus_db_lookup::LookupPath;
 use nexus_db_queries::db::datastore::Disk;
@@ -30,7 +32,11 @@ use omicron_common::api::external::DataPageParams;
 use omicron_common::api::external::Error;
 use omicron_common::api::external::http_pagination::PaginatedBy;
 use omicron_common::backoff::backon_retry_policy_internal_service;
-use omicron_uuid_kinds::{GenericUuid, InstanceUuid, PropolisUuid, SledUuid};
+use omicron_uuid_kinds::GenericUuid;
+use omicron_uuid_kinds::InstanceUuid;
+use omicron_uuid_kinds::PropolisUuid;
+use omicron_uuid_kinds::SledUuid;
+use omicron_uuid_kinds::ZpoolUuid;
 use paste::paste;
 use progenitor_extras::retry::{
     GoneCheckResult, retry_operation_while_indefinitely,
@@ -658,9 +664,10 @@ async fn sis_ensure_local_storage(
 
     // Ensure that the local storage is created
 
-    let (sled_id, ensure_request) = match allocation {
+    let (sled_id, zpool_id, ensure_request) = match allocation {
         LocalStorageAllocation::Unencrypted(allocation) => {
             let sled_id = allocation.sled_id();
+            let pool_id: ZpoolUuid = allocation.pool_id().upcast();
 
             let ensure_request = LocalStorageDatasetEnsureRequest {
                 zpool_id: allocation.pool_id(),
@@ -670,7 +677,7 @@ async fn sis_ensure_local_storage(
                 encrypted_at_rest: false,
             };
 
-            (sled_id, ensure_request)
+            (sled_id, pool_id, ensure_request)
         }
 
         LocalStorageAllocation::Encrypted(_) => {
@@ -693,14 +700,27 @@ async fn sis_ensure_local_storage(
         sled_agent_client.local_storage_dataset_ensure(&ensure_request).await
     };
 
-    // `check_sled_in_service` returns an error if the sled is no longer in
-    // service; if it succeeds, the sled is not gone.
+    // Bail out of the retry loop if either the disk or sled is no longer
+    // in-service.
     let gone_check = || async {
-        osagactx
-            .datastore()
-            .check_sled_in_service(&opctx, sled_id)
+        match sled_out_of_service_gone_check(
+            osagactx.datastore(),
+            &opctx,
+            sled_id,
+        )
+        .await?
+        {
+            GoneCheckResult::StillAvailable => {
+                // proceed to zpool check
+            }
+
+            GoneCheckResult::Gone => {
+                return Ok(GoneCheckResult::Gone);
+            }
+        }
+
+        zpool_out_of_service_gone_check(osagactx.datastore(), &opctx, zpool_id)
             .await
-            .map(|()| GoneCheckResult::StillAvailable)
     };
 
     let log = osagactx.log().clone();
@@ -719,6 +739,9 @@ async fn sis_ensure_local_storage(
     )
     .await
     .map_err(|e| {
+        // Do not match on `e.is_gone` here: If the ensure retry loop bailed out
+        // due to a disk or sled being expunged, then we have to unwind the
+        // saga.
         saga_action_failed(Error::internal_error(&format!(
             "failed to ensure local storage: {}",
             InlineErrorChain::new(&e)

--- a/nexus/src/app/sagas/instance_start.rs
+++ b/nexus/src/app/sagas/instance_start.rs
@@ -1157,11 +1157,16 @@ mod test {
     use core::time::Duration;
     use std::net::SocketAddrV6;
 
+    use crate::app::sagas::disk_delete::test::ExpungeTestHarness;
+    use crate::app::sagas::disk_delete::test::create_disk;
+    use crate::app::sagas::disk_delete::test::new_local_disk_create_params;
     use crate::app::{saga::create_saga_dag, sagas::test_helpers};
     use dropshot::test_util::ClientTestContext;
     use nexus_db_queries::authn;
+    use nexus_test_utils::resource_helpers::DiskTest;
     use nexus_test_utils::resource_helpers::{
-        create_default_ip_pools, create_project, object_create,
+        attach_disk_to_instance, create_default_ip_pools, create_project,
+        object_create,
     };
     use nexus_test_utils_macros::nexus_test;
     use nexus_types::external_api::{instance as instance_types, networking};
@@ -1717,6 +1722,88 @@ mod test {
             )
             .await
         );
+        assert!(test_helpers::no_virtual_provisioning_collection_records_using_instances(cptestctx).await);
+    }
+
+    #[nexus_test(server = crate::Server)]
+    async fn test_cannot_start_local_storage_disk_gone(
+        cptestctx: &ControlPlaneTestContext,
+    ) {
+        let client = &cptestctx.external_client;
+        let nexus = &cptestctx.server.server_context().nexus;
+        let _project_id = setup_test_project(&client).await;
+        let opctx = test_helpers::test_opctx(cptestctx);
+
+        let instance = create_instance(client).await;
+
+        // Create a local storage disk, manually create an allocation for that
+        // local storage on a pool, attach the disk to the instance, then
+        // expunge the disk backing the pool.
+
+        let disk_test = DiskTest::new(cptestctx).await;
+        let zpool = disk_test.zpools().next().unwrap();
+        let disk = create_disk(&cptestctx, new_local_disk_create_params).await;
+        let harness =
+            ExpungeTestHarness::setup(&cptestctx, disk.id(), zpool.id).await;
+
+        attach_disk_to_instance(
+            client,
+            PROJECT_NAME,
+            INSTANCE_NAME,
+            disk.name().as_str(),
+        )
+        .await;
+
+        harness.expunge_disk().await;
+
+        // Run the saga and make sure that the instance does not start
+
+        let instance_id = InstanceUuid::from_untyped_uuid(instance.identity.id);
+        let db_instance = test_helpers::instance_fetch(cptestctx, instance_id)
+            .await
+            .instance()
+            .clone();
+
+        let params = Params {
+            serialized_authn: authn::saga::Serialized::for_opctx(&opctx),
+            db_instance,
+            reason: Reason::User,
+        };
+
+        let dag = create_saga_dag::<SagaInstanceStart>(params).unwrap();
+
+        let runnable_saga = nexus.sagas.saga_prepare(dag).await.unwrap();
+        let saga_result = runnable_saga
+            .run_to_completion()
+            .await
+            .expect("saga execution should have started")
+            .into_raw_result();
+
+        let saga_error = saga_result
+            .kind
+            .expect_err("saga should fail when ensuring local storage");
+
+        assert_eq!(
+            saga_error.error_node_name.as_ref(),
+            "ensure_local_storage_0",
+        );
+
+        let db_instance =
+            test_helpers::instance_fetch(cptestctx, instance_id).await;
+
+        assert_eq!(
+            db_instance.instance().nexus_state,
+            nexus_db_model::InstanceState::NoVmm
+        );
+        assert!(db_instance.vmm().is_none());
+
+        assert!(
+            test_helpers::no_virtual_provisioning_resource_records_exist(
+                cptestctx
+            )
+            .await
+        );
+
         assert!(test_helpers::no_virtual_provisioning_collection_records_using_instances(cptestctx).await);
     }
 }

--- a/nexus/src/app/sagas/mod.rs
+++ b/nexus/src/app/sagas/mod.rs
@@ -10,6 +10,12 @@
 // easier it will be to test, version, and update in deployed systems.
 
 use crate::saga_interface::SagaContext;
+use nexus_db_queries::context::OpContext;
+use nexus_db_queries::db::DataStore;
+use omicron_common::api::external::Error;
+use omicron_uuid_kinds::SledUuid;
+use omicron_uuid_kinds::ZpoolUuid;
+use progenitor_extras::retry::GoneCheckResult;
 use serde::Serialize;
 use std::sync::Arc;
 use std::sync::LazyLock;
@@ -526,4 +532,41 @@ fn subsaga_append<S: Serialize>(
     ));
 
     Ok(())
+}
+
+/// Returns a GoneCheckResult corresponding to if a sled is still exists and is
+/// in-service. Will return an error if the associated query fails.
+async fn sled_out_of_service_gone_check(
+    datastore: &DataStore,
+    opctx: &OpContext,
+    sled_id: SledUuid,
+) -> Result<GoneCheckResult, Error> {
+    datastore.check_sled_in_service(&opctx, sled_id).await.map(
+        |sled_in_service| {
+            if sled_in_service {
+                GoneCheckResult::StillAvailable
+            } else {
+                GoneCheckResult::Gone
+            }
+        },
+    )
+}
+
+/// Returns a GoneCheckResult corresponding to if a zpool is still exists and
+/// the backing physical disk is still in-service. Will return an error if the
+/// associated query fails.
+async fn zpool_out_of_service_gone_check(
+    datastore: &DataStore,
+    opctx: &OpContext,
+    zpool_id: ZpoolUuid,
+) -> Result<GoneCheckResult, Error> {
+    datastore.check_zpool_in_service(&opctx, zpool_id).await.map(
+        |zpool_in_service| {
+            if zpool_in_service {
+                GoneCheckResult::StillAvailable
+            } else {
+                GoneCheckResult::Gone
+            }
+        },
+    )
 }

--- a/nexus/src/app/sagas/snapshot_create.rs
+++ b/nexus/src/app/sagas/snapshot_create.rs
@@ -885,8 +885,6 @@ async fn ssc_send_snapshot_request_to_sled_agent(
     )
     .await
     .map_err(|e| {
-        // Do not match on `e.is_gone` here: if the ensure fails due to the sled
-        // being expunged, then the saga should unwind.
         saga_action_failed(Error::internal_error(&format!(
             "failed to issue VMM disk snapshot request: {}",
             InlineErrorChain::new(&e)

--- a/nexus/src/app/sagas/snapshot_create.rs
+++ b/nexus/src/app/sagas/snapshot_create.rs
@@ -97,6 +97,7 @@ use super::{
     },
 };
 use crate::app::sagas::declare_saga_actions;
+use crate::app::sagas::sled_out_of_service_gone_check;
 use crate::app::{authn, authz, db};
 use anyhow::anyhow;
 use nexus_db_lookup::LookupPath;
@@ -111,9 +112,7 @@ use omicron_common::{
     api::external, backoff::backon_retry_policy_internal_service,
 };
 use omicron_uuid_kinds::{GenericUuid, PropolisUuid, VolumeUuid};
-use progenitor_extras::retry::{
-    GoneCheckResult, retry_operation_while_indefinitely,
-};
+use progenitor_extras::retry::retry_operation_while_indefinitely;
 use rand::{RngCore, SeedableRng, rngs::StdRng};
 use serde::Deserialize;
 use serde::Serialize;
@@ -863,14 +862,11 @@ async fn ssc_send_snapshot_request_to_sled_agent(
             )
             .await
     };
-    // `check_sled_in_service` returns an error if the sled is no longer in
-    // service; if it succeeds, the sled is not gone.
+
+    // Bail out of the retry loop if the sled is gone.
     let gone_check = || async {
-        osagactx
-            .datastore()
-            .check_sled_in_service(&opctx, sled_id)
+        sled_out_of_service_gone_check(osagactx.datastore(), &opctx, sled_id)
             .await
-            .map(|()| GoneCheckResult::StillAvailable)
     };
 
     let notify_log = log.clone();
@@ -889,6 +885,8 @@ async fn ssc_send_snapshot_request_to_sled_agent(
     )
     .await
     .map_err(|e| {
+        // Do not match on `e.is_gone` here: if the ensure fails due to the sled
+        // being expunged, then the saga should unwind.
         saga_action_failed(Error::internal_error(&format!(
             "failed to issue VMM disk snapshot request: {}",
             InlineErrorChain::new(&e)

--- a/nexus/test-utils/src/resource_helpers.rs
+++ b/nexus/test-utils/src/resource_helpers.rs
@@ -42,6 +42,7 @@ use nexus_types::external_api::ip_pool::{
     IpPool, IpPoolRange, IpRange, IpVersion,
 };
 use nexus_types::external_api::multicast;
+use nexus_types::external_api::path_params;
 use nexus_types::external_api::policy;
 use nexus_types::external_api::project;
 use nexus_types::external_api::project::Project;
@@ -959,6 +960,31 @@ where
 {
     let url = format!("/v1/instances?project={project_name}");
     object_create_error(client, &url, body, status).await
+}
+
+pub async fn attach_disk_to_instance(
+    client: &ClientTestContext,
+    project_name: &str,
+    instance_name: &str,
+    disk_name: &str,
+) {
+    let url = format!(
+        "/v1/instances/{instance_name}/disks/attach?project={project_name}",
+    );
+
+    let body = path_params::DiskPath {
+        disk: disk_name.to_string().try_into().unwrap(),
+    };
+
+    NexusRequest::new(
+        RequestBuilder::new(client, Method::POST, &url)
+            .body(Some(&body))
+            .expect_status(Some(StatusCode::ACCEPTED)),
+    )
+    .authn_as(AuthnMode::PrivilegedUser)
+    .execute()
+    .await
+    .unwrap();
 }
 
 pub async fn create_affinity_group(


### PR DESCRIPTION
When sending a delete request to a remote service during a saga, the usual pattern is to provide a "gone" check to bail out of the retry loop: if the remote service was impacted by an expunge then it's pointless to continue retrying a delete request, as something backing that service is gone.

There were TWO places not doing this correctly:

- when detaching a volume from a pantry
- when deleting local storage datasets

In these cases correct this by matching on the returned error of either `ProgenitorOperationRetry::run` or `retry_operation_while_indefinitely` (from progenitor-extras), and checking `e.is_gone`. If that matches then the saga can proceed.

Additionally, there are places where the gone check only checked if the sled was still in-service, but in reality needed to also check if the physical disk backing a zpool was expunged. Fix that too.

Also! The check functions bailed with an error if a sled or disk was not in-service, instead of returning a boolean. This meant that if a sled or disk was not in-service, the retry loop would exit with a `GoneCheckError` instead of a `Gone` value. This would not properly match for call sites that checked `is_gone` for a returned error, leading to saga unwinds that were ultimately not necessary. Change those functions to return a bool corresponding to whether or not the thing is in-service, and map that into a `GoneCheckResult` inside gone check functions.

Fixes #10224