### PR TITLE
Bump propolis to bc489dd (propolis lifecycle fix)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -623,7 +623,7 @@ dependencies = [
 [[package]]
 name = "bhyve_api"
 version = "0.0.0"
-source = "git+https://github.com/oxidecomputer/propolis?rev=2c9d7052cc12b3feca1c5a0e09d10b724b8e7cb4#2c9d7052cc12b3feca1c5a0e09d10b724b8e7cb4"
+source = "git+https://github.com/oxidecomputer/propolis?rev=bc489ddf0f38f75e0c194b86cf6f0de377f68845#bc489ddf0f38f75e0c194b86cf6f0de377f68845"
 dependencies = [
  "bhyve_api_sys",
  "libc",
@@ -633,7 +633,7 @@ dependencies = [
 [[package]]
 name = "bhyve_api_sys"
 version = "0.0.0"
-source = "git+https://github.com/oxidecomputer/propolis?rev=2c9d7052cc12b3feca1c5a0e09d10b724b8e7cb4#2c9d7052cc12b3feca1c5a0e09d10b724b8e7cb4"
+source = "git+https://github.com/oxidecomputer/propolis?rev=bc489ddf0f38f75e0c194b86cf6f0de377f68845#bc489ddf0f38f75e0c194b86cf6f0de377f68845"
 dependencies = [
  "libc",
  "strum 0.26.3",
@@ -11245,7 +11245,7 @@ dependencies = [
 [[package]]
 name = "propolis-api-types-versions"
 version = "0.0.0"
-source = "git+https://github.com/oxidecomputer/propolis?rev=2c9d7052cc12b3feca1c5a0e09d10b724b8e7cb4#2c9d7052cc12b3feca1c5a0e09d10b724b8e7cb4"
+source = "git+https://github.com/oxidecomputer/propolis?rev=bc489ddf0f38f75e0c194b86cf6f0de377f68845#bc489ddf0f38f75e0c194b86cf6f0de377f68845"
 dependencies = [
  "crucible-client-types",
  "propolis_types",
@@ -11258,7 +11258,7 @@ dependencies = [
 [[package]]
 name = "propolis-client"
 version = "0.1.0"
-source = "git+https://github.com/oxidecomputer/propolis?rev=2c9d7052cc12b3feca1c5a0e09d10b724b8e7cb4#2c9d7052cc12b3feca1c5a0e09d10b724b8e7cb4"
+source = "git+https://github.com/oxidecomputer/propolis?rev=bc489ddf0f38f75e0c194b86cf6f0de377f68845#bc489ddf0f38f75e0c194b86cf6f0de377f68845"
 dependencies = [
  "async-trait",
  "base64 0.21.7",
@@ -11282,7 +11282,7 @@ dependencies = [
 [[package]]
 name = "propolis-mock-server"
 version = "0.0.0"
-source = "git+https://github.com/oxidecomputer/propolis?rev=2c9d7052cc12b3feca1c5a0e09d10b724b8e7cb4#2c9d7052cc12b3feca1c5a0e09d10b724b8e7cb4"
+source = "git+https://github.com/oxidecomputer/propolis?rev=bc489ddf0f38f75e0c194b86cf6f0de377f68845#bc489ddf0f38f75e0c194b86cf6f0de377f68845"
 dependencies = [
  "anyhow",
  "atty",
@@ -11315,7 +11315,7 @@ dependencies = [
 [[package]]
 name = "propolis_api_types"
 version = "0.0.0"
-source = "git+https://github.com/oxidecomputer/propolis?rev=2c9d7052cc12b3feca1c5a0e09d10b724b8e7cb4#2c9d7052cc12b3feca1c5a0e09d10b724b8e7cb4"
+source = "git+https://github.com/oxidecomputer/propolis?rev=bc489ddf0f38f75e0c194b86cf6f0de377f68845#bc489ddf0f38f75e0c194b86cf6f0de377f68845"
 dependencies = [
  "crucible-client-types",
  "propolis-api-types-versions",
@@ -11324,7 +11324,7 @@ dependencies = [
 [[package]]
 name = "propolis_types"
 version = "0.0.0"
-source = "git+https://github.com/oxidecomputer/propolis?rev=2c9d7052cc12b3feca1c5a0e09d10b724b8e7cb4#2c9d7052cc12b3feca1c5a0e09d10b724b8e7cb4"
+source = "git+https://github.com/oxidecomputer/propolis?rev=bc489ddf0f38f75e0c194b86cf6f0de377f68845#bc489ddf0f38f75e0c194b86cf6f0de377f68845"
 dependencies = [
  "schemars 0.8.22",
  "serde",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -713,11 +713,11 @@ progenitor-client010 = { package = "progenitor-client", version = "0.10.0" }
 # NOTE: if you change the pinned revision of the `bhyve_api` and propolis
 # dependencies, you must also update the references in package-manifest.toml to
 # match the new revision.
-bhyve_api = { git = "https://github.com/oxidecomputer/propolis", rev = "2c9d7052cc12b3feca1c5a0e09d10b724b8e7cb4" }
-propolis-api-types-versions = { git = "https://github.com/oxidecomputer/propolis", rev = "2c9d7052cc12b3feca1c5a0e09d10b724b8e7cb4" }
-propolis_api_types = { git = "https://github.com/oxidecomputer/propolis", rev = "2c9d7052cc12b3feca1c5a0e09d10b724b8e7cb4" }
-propolis-client = { git = "https://github.com/oxidecomputer/propolis", rev = "2c9d7052cc12b3feca1c5a0e09d10b724b8e7cb4" }
-propolis-mock-server = { git = "https://github.com/oxidecomputer/propolis", rev = "2c9d7052cc12b3feca1c5a0e09d10b724b8e7cb4" }
+bhyve_api = { git = "https://github.com/oxidecomputer/propolis", rev = "bc489ddf0f38f75e0c194b86cf6f0de377f68845" }
+propolis-api-types-versions = { git = "https://github.com/oxidecomputer/propolis", rev = "bc489ddf0f38f75e0c194b86cf6f0de377f68845" }
+propolis_api_types = { git = "https://github.com/oxidecomputer/propolis", rev = "bc489ddf0f38f75e0c194b86cf6f0de377f68845" }
+propolis-client = { git = "https://github.com/oxidecomputer/propolis", rev = "bc489ddf0f38f75e0c194b86cf6f0de377f68845" }
+propolis-mock-server = { git = "https://github.com/oxidecomputer/propolis", rev = "bc489ddf0f38f75e0c194b86cf6f0de377f68845" }
 # NOTE: see above!
 proptest = "1.7.0"
 qorb = "0.4.1"

--- a/package-manifest.toml
+++ b/package-manifest.toml
@@ -662,10 +662,10 @@ service_name = "propolis-server"
 only_for_targets.image = "standard"
 source.type = "prebuilt"
 source.repo = "propolis"
-source.commit = "2c9d7052cc12b3feca1c5a0e09d10b724b8e7cb4"
+source.commit = "bc489ddf0f38f75e0c194b86cf6f0de377f68845"
 # The SHA256 digest is automatically posted to:
 # https://buildomat.eng.oxide.computer/public/file/oxidecomputer/propolis/image/<commit>/propolis-server.sha256.txt
-source.sha256 = "598a88b27835926d2889e5dfcf7601e051040b04e151d1805283f637eaf77465"
+source.sha256 = "f4c742c766a7260f20d6ef3c0d68c362e7ba768037836bfa09abdf1c3c72e605"
 output.type = "zone"
 
 [package.mg-ddm-gz]


### PR DESCRIPTION
This bumps propolis to commit bc489dd.

This brings in the following:
- https://github.com/oxidecomputer/propolis/pull/1112   **(the reason for this PR)**
- https://github.com/oxidecomputer/propolis/pull/1109
- https://github.com/oxidecomputer/propolis/pull/1084