### PR TITLE
tla: typo in invariant makes it trivially true

### DIFF
--- a/trust-quorum/tla/trust_quorum.tla
+++ b/trust-quorum/tla/trust_quorum.tla
@@ -404,7 +404,6 @@ CommittedNodesHaveShares ==
   \A id \in DOMAIN nodes:
     \/ nodes[id] = NONE
     \/ /\ nodes[id] # NONE
-    \/ /\ nodes[id] # NONE
        /\ \/ /\ nodes[id].is_committed
              /\  nodes[id].has_share
           \/ ~nodes[id].is_committed


### PR DESCRIPTION
I suspect this is a bad merge, or copy-paste typo but it renders the whole invariant trivially true.

I don't think this will actually expose any bugs, because the only way this invariant can be broken is if some id has `is_committed = TRUE /\ has_share = FALSE`. Looking at all the actions which set `is_committed = TRUE`, they almost all either set `has_share = TRUE` in the same move, or have it as a precondition.

`RecvCommit` is the single exception, but that has an inline `Assert(_.has_share)` which is duplicating the constraints of the invariant here. Barring some unconstrained state change, this invariant is being enforced or checked in other ways, so I don't expect this fix to reveal any issues in the actions. It's more for future-proofing, or documentation purposes :)