### PR TITLE
Create Oximeter producer API trait

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -9974,6 +9974,7 @@ dependencies = [
  "dropshot 0.16.7",
  "omicron-workspace-hack",
  "oximeter-types 0.1.0",
+ "oximeter-types-versions 0.1.0",
 ]
 
 [[package]]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -9954,6 +9954,7 @@ dependencies = [
  "omicron-test-utils",
  "omicron-workspace-hack",
  "oximeter 0.1.0",
+ "oximeter-producer-api",
  "schemars 0.8.22",
  "serde",
  "serde_json",
@@ -9964,6 +9965,15 @@ dependencies = [
  "thiserror 2.0.18",
  "tokio",
  "uuid",
+]
+
+[[package]]
+name = "oximeter-producer-api"
+version = "0.1.0"
+dependencies = [
+ "dropshot 0.16.7",
+ "omicron-workspace-hack",
+ "oximeter-types 0.1.0",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -129,6 +129,7 @@ members = [
     "oximeter/oximeter",
     "oximeter/oxql-types",
     "oximeter/producer",
+    "oximeter/producer-api",
     "oximeter/schema",
     "oximeter/test-utils",
     "oximeter/timeseries-macro",
@@ -312,6 +313,7 @@ default-members = [
     "oximeter/oximeter",
     "oximeter/oxql-types",
     "oximeter/producer",
+    "oximeter/producer-api",
     "oximeter/schema",
     "oximeter/test-utils",
     "oximeter/timeseries-macro",
@@ -680,6 +682,7 @@ oximeter-collector = { path = "oximeter/collector" }
 oximeter-instruments = { path = "oximeter/instruments" }
 oximeter-macro-impl = { path = "oximeter/oximeter-macro-impl" }
 oximeter-producer = { path = "oximeter/producer" }
+oximeter-producer-api = { path = "oximeter/producer-api" }
 oximeter-schema = { path = "oximeter/schema" }
 oximeter-test-utils = { path = "oximeter/test-utils" }
 oximeter-timeseries-macro = { path = "oximeter/timeseries-macro" }

--- a/oximeter/producer-api/Cargo.toml
+++ b/oximeter/producer-api/Cargo.toml
@@ -1,0 +1,14 @@
+[package]
+name = "oximeter-producer-api"
+version = "0.1.0"
+edition.workspace = true
+description = "API description for the Oximeter producer server"
+license = "MPL-2.0"
+
+[lints]
+workspace = true
+
+[dependencies]
+dropshot.workspace = true
+omicron-workspace-hack.workspace = true
+oximeter-types.workspace = true

--- a/oximeter/producer-api/Cargo.toml
+++ b/oximeter/producer-api/Cargo.toml
@@ -12,3 +12,4 @@ workspace = true
 dropshot.workspace = true
 omicron-workspace-hack.workspace = true
 oximeter-types.workspace = true
+oximeter-types-versions.workspace = true

--- a/oximeter/producer-api/src/lib.rs
+++ b/oximeter/producer-api/src/lib.rs
@@ -1,0 +1,29 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at https://mozilla.org/MPL/2.0/.
+
+//! API description for the Oximeter producer server.
+
+// Copyright 2026 Oxide Computer Company
+
+use dropshot::HttpError;
+use dropshot::HttpResponseOk;
+use dropshot::Path;
+use dropshot::RequestContext;
+use oximeter_types::producer::ProducerIdPathParams;
+use oximeter_types::types::ProducerResults;
+
+#[dropshot::api_description]
+pub trait ProducerApi {
+    type Context;
+
+    /// Collect metric data from this producer.
+    #[endpoint {
+        method = GET,
+        path = "/{producer_id}",
+    }]
+    async fn collect(
+        request_context: RequestContext<Self::Context>,
+        path_params: Path<ProducerIdPathParams>,
+    ) -> Result<HttpResponseOk<ProducerResults>, HttpError>;
+}

--- a/oximeter/producer-api/src/lib.rs
+++ b/oximeter/producer-api/src/lib.rs
@@ -10,7 +10,9 @@ use dropshot::HttpError;
 use dropshot::HttpResponseOk;
 use dropshot::Path;
 use dropshot::RequestContext;
-use oximeter_types::producer::ProducerIdPathParams;
+use oximeter_types_versions::latest::producer::ProducerIdPathParams;
+// ProducerResults is imported from oximeter-types rather than oximeter-types-versions because
+// it is a fundamental type shared across all oximeter API versions and is unlikely to change.
 use oximeter_types::types::ProducerResults;
 
 #[dropshot::api_description]

--- a/oximeter/producer/Cargo.toml
+++ b/oximeter/producer/Cargo.toml
@@ -17,6 +17,7 @@ internal-dns-types.workspace = true
 nexus-client.workspace = true
 omicron-common.workspace = true
 oximeter.workspace = true
+oximeter-producer-api.workspace = true
 schemars = { workspace = true, features = [ "uuid1", "bytes", "chrono" ] }
 serde.workspace = true
 slog.workspace = true

--- a/oximeter/producer/src/lib.rs
+++ b/oximeter/producer/src/lib.rs
@@ -4,9 +4,8 @@
 
 //! Types for serving produced metric data to an Oximeter collector server.
 
-// Copyright 2024 Oxide Computer Company
+// Copyright 2026 Oxide Computer Company
 
-use dropshot::ApiDescription;
 use dropshot::ConfigDropshot;
 use dropshot::HttpError;
 use dropshot::HttpResponseOk;
@@ -14,7 +13,6 @@ use dropshot::HttpServer;
 use dropshot::Path;
 use dropshot::RequestContext;
 use dropshot::ServerBuilder;
-use dropshot::endpoint;
 use either::Either;
 use internal_dns_resolver::ResolveError;
 use internal_dns_resolver::Resolver;
@@ -26,9 +24,8 @@ use omicron_common::backoff;
 use omicron_common::backoff::BackoffError;
 use oximeter::types::ProducerRegistry;
 use oximeter::types::ProducerResults;
-use schemars::JsonSchema;
-use serde::Deserialize;
-use serde::Serialize;
+use oximeter_producer_api::ProducerApi;
+use oximeter_producer_api::producer_api_mod;
 use slog::Drain;
 use slog::Logger;
 use slog::debug;
@@ -41,7 +38,6 @@ use std::net::IpAddr;
 use std::net::SocketAddr;
 use std::time::Duration;
 use thiserror::Error;
-use uuid::Uuid;
 
 // Our public interface depends directly or indirectly on these types; we
 // export them so that consumers need not depend on dropshot themselves and
@@ -394,40 +390,34 @@ async fn resolve_nexus_and_register(
 }
 
 // Register API endpoints of the `Server`.
-fn metric_server_api() -> ApiDescription<ProducerRegistry> {
-    let mut api = ApiDescription::new();
-    api.register(collect).expect("Failed to register handler for collect");
-    api
+fn metric_server_api() -> dropshot::ApiDescription<ProducerRegistry> {
+    producer_api_mod::api_description::<ProducerApiImpl>()
+        .expect("registered entrypoints")
 }
 
-#[derive(Clone, Copy, Debug, Deserialize, JsonSchema, Serialize)]
-pub struct ProducerIdPathParams {
-    /// The ID of the producer to be polled.
-    pub producer_id: Uuid,
-}
+enum ProducerApiImpl {}
 
-/// Collect metric data from this producer.
-#[endpoint {
-    method = GET,
-    path = "/{producer_id}",
-}]
-async fn collect(
-    request_context: RequestContext<ProducerRegistry>,
-    path_params: Path<ProducerIdPathParams>,
-) -> Result<HttpResponseOk<ProducerResults>, HttpError> {
-    let registry = request_context.context();
-    let producer_id = path_params.into_inner().producer_id;
-    if producer_id == registry.producer_id() {
-        Ok(HttpResponseOk(registry.collect()))
-    } else {
-        Err(HttpError::for_not_found(
-            None,
-            format!(
-                "Producer ID {} is not valid, expected {}",
-                producer_id,
-                registry.producer_id()
-            ),
-        ))
+impl ProducerApi for ProducerApiImpl {
+    type Context = ProducerRegistry;
+
+    async fn collect(
+        request_context: RequestContext<ProducerRegistry>,
+        path_params: Path<oximeter::producer::ProducerIdPathParams>,
+    ) -> Result<HttpResponseOk<ProducerResults>, HttpError> {
+        let registry = request_context.context();
+        let producer_id = path_params.into_inner().producer_id;
+        if producer_id == registry.producer_id() {
+            Ok(HttpResponseOk(registry.collect()))
+        } else {
+            Err(HttpError::for_not_found(
+                None,
+                format!(
+                    "Producer ID {} is not valid, expected {}",
+                    producer_id,
+                    registry.producer_id()
+                ),
+            ))
+        }
     }
 }
 


### PR DESCRIPTION
Add a new `oximeter-producer-api` crate, using the newer trait-based Dropshot machinery. This is only code movement, without functional changes, and some preliminary work to making the producer API paginated.