### PR TITLE
Separate tasks for batching and inserting oximeter collection results

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -9801,6 +9801,7 @@ dependencies = [
  "oximeter-client",
  "oximeter-db",
  "oximeter-types 0.1.0",
+ "proptest",
  "qorb",
  "rand 0.9.2",
  "reqwest 0.13.2",

--- a/nexus/src/app/mod.rs
+++ b/nexus/src/app/mod.rs
@@ -449,7 +449,11 @@ impl Nexus {
             None => {
                 let native_resolver =
                     qorb_resolver.for_service(ServiceName::OximeterReader);
-                oximeter_db::Client::new_with_resolver(native_resolver, &log)
+                oximeter_db::Client::new_with_resolver(
+                    native_resolver,
+                    "clickhouse",
+                    &log,
+                )
             }
             Some(address) => oximeter_db::Client::new(*address, &log),
         };

--- a/nexus/src/app/mod.rs
+++ b/nexus/src/app/mod.rs
@@ -451,7 +451,7 @@ impl Nexus {
                     qorb_resolver.for_service(ServiceName::OximeterReader);
                 oximeter_db::Client::new_with_resolver(
                     native_resolver,
-                    "clickhouse",
+                    "nexus-oximeter-reader",
                     &log,
                 )
             }

--- a/oximeter/collector/Cargo.toml
+++ b/oximeter/collector/Cargo.toml
@@ -52,5 +52,6 @@ httpmock.workspace = true
 omicron-test-utils.workspace = true
 openapi-lint.workspace = true
 openapiv3.workspace = true
+proptest.workspace = true
 serde_json.workspace = true
 subprocess.workspace = true

--- a/oximeter/collector/src/agent.rs
+++ b/oximeter/collector/src/agent.rs
@@ -112,7 +112,8 @@ impl OximeterAgent {
         // - The DB doesn't exist at all. This reports a version number of 0. We
         // need to create the DB here, at the latest version. This is used in
         // fresh installations and tests.
-        let client = Client::new_with_resolver(native_resolver, &log);
+        let client =
+            Client::new_with_resolver(native_resolver, "clickhouse", &log);
         match client.check_db_is_at_expected_version().await {
             Ok(_) => {}
             Err(oximeter_db::Error::DatabaseVersionMismatch {
@@ -173,8 +174,12 @@ impl OximeterAgent {
             ..Default::default()
         };
 
-        let cluster_client =
-            Client::new_with_pool_policy(cluster_resolver, claim_policy, &log);
+        let cluster_client = Client::new_with_pool_policy(
+            cluster_resolver,
+            "clickhouse-cluster",
+            claim_policy,
+            &log,
+        );
 
         // Spawn the task for aggregating and inserting all metrics to a
         // replicated cluster ClickHouse installation

--- a/oximeter/collector/src/agent.rs
+++ b/oximeter/collector/src/agent.rs
@@ -112,8 +112,11 @@ impl OximeterAgent {
         // - The DB doesn't exist at all. This reports a version number of 0. We
         // need to create the DB here, at the latest version. This is used in
         // fresh installations and tests.
-        let client =
-            Client::new_with_resolver(native_resolver, "clickhouse", &log);
+        let client = Client::new_with_resolver(
+            native_resolver,
+            "clickhouse-inserter",
+            &log,
+        );
         match client.check_db_is_at_expected_version().await {
             Ok(_) => {}
             Err(oximeter_db::Error::DatabaseVersionMismatch {
@@ -176,7 +179,7 @@ impl OximeterAgent {
 
         let cluster_client = Client::new_with_pool_policy(
             cluster_resolver,
-            "clickhouse-cluster",
+            "replicated-clickhouse-inserter",
             claim_policy,
             &log,
         );

--- a/oximeter/collector/src/agent.rs
+++ b/oximeter/collector/src/agent.rs
@@ -141,7 +141,7 @@ impl OximeterAgent {
         // Spawn the task for aggregating and inserting all metrics to a
         // single node ClickHouse installation.
         tokio::spawn(async move {
-            crate::results_sink::database_inserter(
+            crate::results_sink::database_batcher(
                 insertion_log,
                 client,
                 db_config.batch_size,
@@ -184,7 +184,7 @@ impl OximeterAgent {
         // Spawn the task for aggregating and inserting all metrics to a
         // replicated cluster ClickHouse installation
         tokio::spawn(async move {
-            results_sink::database_inserter(
+            results_sink::database_batcher(
                 instertion_log_cluster,
                 cluster_client,
                 db_config.batch_size,
@@ -270,7 +270,7 @@ impl OximeterAgent {
 
             // Spawn the task for aggregating and inserting all metrics
             tokio::spawn(async move {
-                results_sink::database_inserter(
+                results_sink::database_batcher(
                     insertion_log,
                     client,
                     db_config.batch_size,

--- a/oximeter/collector/src/collection_task.rs
+++ b/oximeter/collector/src/collection_task.rs
@@ -722,6 +722,8 @@ impl CollectionTask {
             .send_modify(|details| details.update(&new_info));
         self.stats.update(&new_info);
         self.collection_timer = interval(new_info.interval);
+        self.collection_timer
+            .set_missed_tick_behavior(MissedTickBehavior::Delay);
     }
 
     /// Handle a single message from the task handle.

--- a/oximeter/collector/src/collection_task.rs
+++ b/oximeter/collector/src/collection_task.rs
@@ -31,6 +31,7 @@ use tokio::sync::oneshot;
 use tokio::sync::watch;
 use tokio::time::Instant;
 use tokio::time::Interval;
+use tokio::time::MissedTickBehavior;
 use tokio::time::interval;
 use uuid::Uuid;
 
@@ -99,10 +100,20 @@ async fn perform_collection(
             if res.status().is_success() {
                 match res.json::<ProducerResults>().await {
                     Ok(results) => {
+                        let n_samples: usize = results
+                            .iter()
+                            .map(|r| match r {
+                                ProducerResultsItem::Ok(samples) => {
+                                    samples.len()
+                                }
+                                ProducerResultsItem::Err(_) => 0,
+                            })
+                            .sum();
                         debug!(
                             log,
                             "collected results from producer";
-                            "n_results" => results.len()
+                            "n_results" => results.len(),
+                            "n_samples" => n_samples,
                         );
                         Ok(results)
                     }
@@ -613,9 +624,17 @@ impl CollectionTask {
         };
 
         // Construct self-collection statistics and our collection times.
+        //
+        // If we miss a tick, say because the results sink is full when we try
+        // to pass off our collection result, we'll delay the next tick rather
+        // than burst to catch up.
         let stats = self_stats::CollectionTaskStats::new(collector, &producer);
-        let collection_timer = interval(producer.interval);
-        let self_collection_timer = interval(self_stats::COLLECTION_INTERVAL);
+        let mut collection_timer = interval(producer.interval);
+        collection_timer.set_missed_tick_behavior(MissedTickBehavior::Delay);
+        let mut self_collection_timer =
+            interval(self_stats::COLLECTION_INTERVAL);
+        self_collection_timer
+            .set_missed_tick_behavior(MissedTickBehavior::Delay);
         let self_ = Self {
             log,
             producer_details_tx,
@@ -828,6 +847,11 @@ impl CollectionTask {
                 };
                 self.producer_details_tx
                     .send_modify(|details| details.on_success(success));
+                probes::results__sink__send__start!(|| {
+                    let producer_id =
+                        self.producer_info_rx.borrow().id.to_string();
+                    (producer_id, n_samples)
+                });
                 if self
                     .outbox
                     .send(
@@ -844,6 +868,9 @@ impl CollectionTask {
                     );
                     return TaskAction::Break(());
                 }
+                probes::results__sink__send__done!(|| {
+                    self.producer_info_rx.borrow().id.to_string()
+                });
             }
             Err(reason) => {
                 let failure = FailedCollection {

--- a/oximeter/collector/src/lib.rs
+++ b/oximeter/collector/src/lib.rs
@@ -114,7 +114,7 @@ mod probes {
     fn insert__samples__done() {}
 
     /// Fires just after failing to insert a batch of samples into the database,
-    /// with, the error details.
+    /// with the error details.
     fn insert__samples__failed(msg: &str) {}
 }
 

--- a/oximeter/collector/src/lib.rs
+++ b/oximeter/collector/src/lib.rs
@@ -80,6 +80,42 @@ mod probes {
     /// Fires just after a failed collection from a producer, with an error
     /// message describing the failure.
     fn collection__failed(producer_id: &str, msg: &str) {}
+
+    /// Fires just before forwarding successful results to the result sink task.
+    fn results__sink__send__start(producer_id: &str, n_samples: u64) {}
+
+    /// Fires just after forwarding successful results to the result sink task.
+    fn results__sink__send__done(producer_id: &str) {}
+
+    /// Fires when the results sink dequeues an item from its result queue, but
+    /// before processing it.
+    fn results__sink__item__dequeued() {}
+
+    /// Fires after the results sink processes an item dequeued from its results
+    /// queue, with the number of samples.
+    fn results__sink__item__processed(n_samples: usize) {}
+
+    /// Fires when we have dropped old samples because the database insertion is
+    /// slower than the data batching task.
+    ///
+    /// We batch data from individual collection tasks into a ring buffer. When
+    /// that gets large enough, we insert the full contents into the database.
+    /// In the event that the database insertions are _very_ slow, and cannot
+    /// keep up with new batches, we'll drop the oldest samples. This probe
+    /// fires with the number of samples we dropped.
+    fn dropped__old__samples(n_dropped: usize) {}
+
+    /// Fires just before attempting to insert a batch of samples into the
+    /// database.
+    fn insert__samples__start(n_samples: usize) {}
+
+    /// Fires just after successfully inserting a batch of samples into the
+    /// database.
+    fn insert__samples__done() {}
+
+    /// Fires just after failing to insert a batch of samples into the database,
+    /// with, the error details.
+    fn insert__samples__failed(msg: &str) {}
 }
 
 /// Errors collecting metric data

--- a/oximeter/collector/src/results_sink.rs
+++ b/oximeter/collector/src/results_sink.rs
@@ -358,11 +358,12 @@ pub async fn logger(log: Logger, mut rx: mpsc::Receiver<CollectionTaskOutput>) {
 
 #[cfg(test)]
 mod tests {
+    use super::*;
+    use proptest::prelude::*;
     use tokio::time::timeout;
 
-    use super::*;
-
     const BATCH_SIZE: usize = 10;
+    const MAX_BUFFER_SIZE: usize = BATCH_SIZE * MAX_BUFFER_SIZE_MULTIPLIER;
 
     #[tokio::test]
     async fn batch_handoff_notifies_receiver_when_forced() {
@@ -381,114 +382,92 @@ mod tests {
         assert!(batch_tx.handoff.batch.lock().unwrap().is_empty());
     }
 
-    // Basic test that we append new samples and don't drop anything.
-    #[tokio::test]
-    async fn batch_handoff_handles_new_samples_when_empty() {
-        let (batch_tx, batch_rx) = batch_handoff::<()>(BATCH_SIZE);
-        let n_samples = 3;
-        let samples = vec![(); n_samples];
-        let n_dropped = batch_tx.send_and_notify(samples, false);
-        assert_eq!(n_dropped, 0);
-        assert_eq!(batch_tx.handoff.batch.lock().unwrap().len(), n_samples);
-        let _ = timeout(
-            Duration::from_millis(10),
-            batch_rx.handoff.notify.notified(),
-        )
-        .await
-        .expect_err("Should not be notified in this case");
-    }
+    proptest! {
+        #[test]
+        fn test_batch_handoff_overflow(
+            current_size in 0..=2*MAX_BUFFER_SIZE,
+            new_size in 0..=2*MAX_BUFFER_SIZE,
+        ) {
+            let rt = tokio::runtime::Builder::new_current_thread()
+                .enable_all()
+                .build()
+                .unwrap();
 
-    #[tokio::test]
-    async fn batch_handoff_drops_old_batched_samples() {
-        let (batch_tx, batch_rx) = batch_handoff::<()>(BATCH_SIZE);
+            // Insert the first batch of samples.
+            let (batch_tx, batch_rx) = batch_handoff::<usize>(BATCH_SIZE);
+            let samples = (0..current_size).collect();
+            let n_dropped = batch_tx.send_and_notify(samples, false);
+            let expected_n_dropped = current_size.saturating_sub(MAX_BUFFER_SIZE);
+            let expected_n_samples = current_size.min(MAX_BUFFER_SIZE);
+            assert_eq!(n_dropped, expected_n_dropped);
 
-        // Push enough samples to get us just near the end of the maximum buffer
-        // size.
-        let n_samples = MAX_BUFFER_SIZE_MULTIPLIER * BATCH_SIZE - 1;
-        let samples = vec![(); n_samples];
-        let n_dropped = batch_tx.send_and_notify(samples, false);
+            // Assert that we've retained only the tail of the samples.
+            let tail = (current_size.saturating_sub(MAX_BUFFER_SIZE)..current_size)
+                .collect::<VecDeque<_>>();
+            {
+                let buf = batch_tx.handoff.batch.lock().unwrap();
+                assert_eq!(buf.len(), expected_n_samples);
+                assert_eq!(*buf, tail);
+            }
 
-        // We still should not drop anything.
-        assert_eq!(n_dropped, 0);
-        assert_eq!(batch_tx.handoff.batch.lock().unwrap().len(), n_samples);
+            // Check that we're either notified, or not, if the current batch is
+            // large enough.
+            //
+            // NOTE: We're not calling `wait_for_batch()` here, but using the
+            // shared buffer directly. That's so that we don't swap it out
+            // during this part of the test. We do use that method later.
+            const TIMEOUT: Duration = Duration::from_millis(1);
+            let fut = batch_rx.handoff.notify.notified();
+            if current_size >= BATCH_SIZE {
+                rt.block_on(async {
+                    timeout(TIMEOUT, fut).await
+                }).expect("Should be notified");
+                assert_eq!(*batch_rx.handoff.batch.lock().unwrap(), tail);
+            } else {
+                rt.block_on(async {
+                    timeout(TIMEOUT, fut).await
+                }).expect_err("Should not be notified");
+            }
 
-        // But we _should_ be notified since this is larger than the batch.
-        let _ = timeout(
-            Duration::from_millis(10),
-            batch_rx.handoff.notify.notified(),
-        )
-        .await
-        .expect("Should have notified receiver now");
+            // Push the new set of samples, which start at the end of the first
+            // batch, even if we've dropped some.
+            let new_samples = (current_size..(current_size + new_size)).collect();
+            let n_dropped = batch_tx.send_and_notify(new_samples, false);
 
-        // Now, push just a measly 2 samples. We should drop one, since we had
-        // space for just one left.
-        let n_dropped = batch_tx.send_and_notify(vec![(); 2], false);
-        assert_eq!(n_dropped, 1);
+            // We expect to drop all the samples beyond the maximum buffer size.
+            // We need to include what we have in the buffer already (some of
+            // which we could have dropped) and what we add in this next step.
+            let expected_n_dropped = (expected_n_samples + new_size)
+                .saturating_sub(MAX_BUFFER_SIZE);
 
-        // The batch should be completely full now
-        assert_eq!(
-            batch_tx.handoff.batch.lock().unwrap().len(),
-            MAX_BUFFER_SIZE_MULTIPLIER * BATCH_SIZE
-        );
-        assert_eq!(
-            batch_rx.handoff.batch.lock().unwrap().len(),
-            MAX_BUFFER_SIZE_MULTIPLIER * BATCH_SIZE
-        );
+            // We expect to retain the minimum of what we (had already plus what
+            // we add) and the maximum buffer size.
+            let expected_n_samples = (expected_n_samples + new_size)
+                .min(MAX_BUFFER_SIZE);
+            assert_eq!(n_dropped, expected_n_dropped);
 
-        // And we should have notified the receiver.
-        let _ = timeout(
-            Duration::from_millis(10),
-            batch_rx.handoff.notify.notified(),
-        )
-        .await
-        .expect("Should have notified receiver now");
-    }
+            // Again, check that we retain the tail of _all_ the samples we've
+            // added thus far, including the first and second batch.
+            let total_size = current_size + new_size;
+            let tail = (total_size.saturating_sub(MAX_BUFFER_SIZE)..total_size).collect::<VecDeque<_>>();
+            {
+                let buf = batch_tx.handoff.batch.lock().unwrap();
+                assert_eq!(buf.len(), expected_n_samples);
+                assert_eq!(*buf, tail);
+            }
 
-    #[tokio::test]
-    async fn batch_handoff_drops_old_and_new_samples_if_needed() {
-        // Push a few samples
-        let (batch_tx, batch_rx) = batch_handoff::<()>(BATCH_SIZE);
-        let n_samples = 3;
-        let samples = vec![(); n_samples];
-        let n_dropped = batch_tx.send_and_notify(samples, false);
-        assert_eq!(n_dropped, 0);
-        assert_eq!(batch_tx.handoff.batch.lock().unwrap().len(), n_samples);
-        let _ = timeout(
-            Duration::from_millis(10),
-            batch_rx.handoff.notify.notified(),
-        )
-        .await
-        .expect_err("Should not be notified in this case");
-
-        // Now push enough to get us all the way past the max size and then
-        // some. We should drop the contents of the existing batch, plus some of
-        // the new samples.
-        let n_current_samples = n_samples;
-        let n_samples = MAX_BUFFER_SIZE_MULTIPLIER * BATCH_SIZE + BATCH_SIZE;
-        let samples = vec![(); n_samples];
-
-        // We've appended a full extra batch, and we also have the contents of
-        // the existing buffer. All of those should be dropped.
-        let expected_n_dropped = BATCH_SIZE + n_current_samples;
-        let n_dropped = batch_tx.send_and_notify(samples, false);
-        assert_eq!(n_dropped, expected_n_dropped);
-
-        // The batch should be completely full now.
-        assert_eq!(
-            batch_tx.handoff.batch.lock().unwrap().len(),
-            MAX_BUFFER_SIZE_MULTIPLIER * BATCH_SIZE
-        );
-        assert_eq!(
-            batch_rx.handoff.batch.lock().unwrap().len(),
-            MAX_BUFFER_SIZE_MULTIPLIER * BATCH_SIZE
-        );
-
-        // And the receiver should now have everything.
-        let _ = timeout(
-            Duration::from_millis(10),
-            batch_rx.handoff.notify.notified(),
-        )
-        .await
-        .expect("Should be notified in this case");
+            // And check we've notified the receiver again.
+            let fut = batch_rx.wait_for_batch();
+            if expected_n_samples >= BATCH_SIZE {
+                let received = rt.block_on(async {
+                    timeout(TIMEOUT, fut).await
+                }).expect("Should be notified");
+                assert_eq!(received, tail);
+            } else {
+                rt.block_on(async {
+                    timeout(TIMEOUT, fut).await
+                }).expect_err("Should not be notified");
+            }
+        }
     }
 }

--- a/oximeter/collector/src/results_sink.rs
+++ b/oximeter/collector/src/results_sink.rs
@@ -31,12 +31,12 @@ use tokio::sync::mpsc;
 use tokio::time::MissedTickBehavior;
 use tokio::time::interval;
 
-/// A sink that inserts all results into the ClickHouse database.
+/// A sink that batches and inserts all results into the ClickHouse database.
 ///
 /// This sink is used in production, when running the `oximeter` collector
 /// normally. It aggregates all results, from all collection tasks, and inserts
 /// them into ClickHouse in batches.
-pub async fn database_inserter(
+pub async fn database_batcher(
     log: Logger,
     client: Client,
     batch_size: usize,
@@ -55,9 +55,10 @@ pub async fn database_inserter(
 
     // Spawn a task for doing the actual insertion into the database.
     //
-    // This outer task is responsible only for taking results from the
-    // individual collection tasks and batching them up for insertion.
-    let inserter = tokio::spawn(database_inserter_impl(
+    // Our task is only responsible for taking results from individual
+    // collection tasks and batching them for insertion. `database_inserter` is
+    // responsible for the actual insertion.
+    let inserter = tokio::spawn(database_inserter(
         log.new(slog::o!("component" => "database-inserter")),
         client,
         batch_rx,
@@ -87,8 +88,8 @@ pub async fn database_inserter(
                         // NOTE: We could call `batch_tx.send_and_notify()` here
                         // in the loop. I'm avoiding that for now because it
                         // takes a lock on the shared buffer of samples, so
-                        // there's a lot of locking / unlocking in this loop.
-                        // Instead, do it once at the end.
+                        // that would cause a lot of locking / unlocking in this
+                        // loop. Instead, do it once at the end.
                         let mut n_samples = 0;
                         let mut batch = Vec::with_capacity(results.len());
                         for inner_batch in results.into_iter() {
@@ -148,12 +149,12 @@ const MAX_BUFFER_SIZE_MULTIPLIER: usize = 100;
 // The other side is then notified if the existing batch is at least the
 // insertion batch size.
 #[derive(Clone)]
-struct BatchHandoff {
+struct BatchHandoff<T> {
     notify: Arc<Notify>,
-    batch: Arc<Mutex<VecDeque<Sample>>>,
+    batch: Arc<Mutex<VecDeque<T>>>,
 }
 
-impl BatchHandoff {
+impl<T> BatchHandoff<T> {
     fn new(batch_size: usize) -> Self {
         Self {
             notify: Arc::new(Notify::new()),
@@ -162,9 +163,9 @@ impl BatchHandoff {
     }
 }
 
-struct BatchSender {
+struct BatchSender<T> {
     // Handoff point between the sender and database inserter.
-    handoff: BatchHandoff,
+    handoff: BatchHandoff<T>,
     // Minimum size of the buffer before inserting into the database.
     batch_size: usize,
     // Maximum size we let the ring buffer grow before starting to drop older
@@ -173,8 +174,8 @@ struct BatchSender {
     max_buffer_size: usize,
 }
 
-impl BatchSender {
-    fn new(handoff: BatchHandoff, batch_size: usize) -> Self {
+impl<T> BatchSender<T> {
+    fn new(handoff: BatchHandoff<T>, batch_size: usize) -> Self {
         Self {
             handoff,
             batch_size,
@@ -199,19 +200,51 @@ impl BatchSender {
     // attempt.
     fn send_and_notify(
         &self,
-        samples: Vec<Sample>,
+        samples: Vec<T>,
         was_forced_collection: bool,
     ) -> usize {
         let mut batch = self.handoff.batch.lock().unwrap();
-        batch.extend(samples);
 
-        // Drop the oldest samples from the front if we've exceeded the limit.
-        // VecDeque makes front-removal O(1) per element.
-        let n_dropped = batch.len().saturating_sub(self.max_buffer_size);
-        if n_dropped > 0 {
-            drop(batch.drain(..n_dropped));
-        }
+        // Append the new samples, ensuring we never exceed the maximum buffer
+        // size.
+        let n_current_samples = batch.len();
+        let n_new_samples = samples.len();
+        let n_total_samples = n_current_samples + n_new_samples;
 
+        // The easy case is when all the samples fit. Just append them and
+        // return 0, since we've not dropped anything.
+        let n_dropped = if n_total_samples <= self.max_buffer_size {
+            batch.extend(samples);
+            0
+        } else {
+            // Now, drop samples first from the existing batch, then the new set of
+            // samples, until we're under our limit. Start by computing the total
+            // number to be dropped.
+            //
+            // NOTE: This can't underflow, we're in the branch where
+            // `n_total_samples > self.max_buffer size`.
+            let n_dropped = n_total_samples - self.max_buffer_size;
+
+            // We want to drop from the existing batch first. We can drop the
+            // minimum of the number to be dropped and the batch length. If
+            // we're only dropping part of the batch, we'll take `n_dropped` off
+            // the front. If we need to drop the whole batch and then some,
+            // we'll take the batch length and drop the whole thing.
+            let n_to_drop_from_batch = n_dropped.min(batch.len());
+            drop(batch.drain(..n_to_drop_from_batch));
+
+            // At this point, we've dropped something (potentially everything)
+            // from the existing batch. We need to figure out how many, if any,
+            // to drop from the _incoming_ set of samples. Subtract whatever we
+            // dropped immediately above to compute the number left to drop.
+            let n_left_to_drop = n_dropped - n_to_drop_from_batch;
+
+            // Append whatever we don't want to drop.
+            batch.extend(samples.into_iter().skip(n_left_to_drop));
+            n_dropped
+        };
+
+        // Notify the insertion task if needed.
         if was_forced_collection || batch.len() >= self.batch_size {
             self.notify_inserter();
         }
@@ -219,26 +252,28 @@ impl BatchSender {
     }
 }
 
-struct BatchReceiver {
-    handoff: BatchHandoff,
+struct BatchReceiver<T> {
+    handoff: BatchHandoff<T>,
     batch_size: usize,
 }
 
-impl BatchReceiver {
+impl<T> BatchReceiver<T> {
     // Wait for a notification and atomically swap out the entire buffer.
     //
     // Returns a `VecDeque` so the caller can use `make_contiguous()` to obtain
     // a contiguous `&[Sample]` without an additional heap allocation.
-    async fn wait_for_batch(&self) -> VecDeque<Sample> {
+    async fn wait_for_batch(&self) -> VecDeque<T> {
         self.handoff.notify.notified().await;
-        let mut empty = VecDeque::with_capacity(self.batch_size);
+        let mut stolen = VecDeque::with_capacity(self.batch_size);
         let mut batch = self.handoff.batch.lock().unwrap();
-        std::mem::swap(&mut empty, &mut *batch);
-        empty
+        std::mem::swap(&mut stolen, &mut *batch);
+        stolen
     }
 }
 
-fn batch_handoff(batch_size: usize) -> (BatchSender, BatchReceiver) {
+fn batch_handoff<T: Clone>(
+    batch_size: usize,
+) -> (BatchSender<T>, BatchReceiver<T>) {
     let handoff = BatchHandoff::new(batch_size);
     let sender = BatchSender::new(handoff.clone(), batch_size);
     let receiver = BatchReceiver { handoff, batch_size };
@@ -246,10 +281,10 @@ fn batch_handoff(batch_size: usize) -> (BatchSender, BatchReceiver) {
 }
 
 // The task that actually inserts results into the database.
-async fn database_inserter_impl(
+async fn database_inserter(
     log: Logger,
     client: Client,
-    batch_rx: BatchReceiver,
+    batch_rx: BatchReceiver<Sample>,
 ) {
     loop {
         // Wait for a notification that there are samples to insert, and consume
@@ -318,5 +353,142 @@ pub async fn logger(log: Logger, mut rx: mpsc::Receiver<CollectionTaskOutput>) {
                 return;
             }
         }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use tokio::time::timeout;
+
+    use super::*;
+
+    const BATCH_SIZE: usize = 10;
+
+    #[tokio::test]
+    async fn batch_handoff_notifies_receiver_when_forced() {
+        let (batch_tx, batch_rx) = batch_handoff::<()>(BATCH_SIZE);
+        let n_samples = 3;
+        let samples = vec![(); n_samples];
+        let n_dropped = batch_tx.send_and_notify(samples, true);
+        assert_eq!(n_dropped, 0);
+        assert_eq!(batch_tx.handoff.batch.lock().unwrap().len(), n_samples);
+
+        let batch =
+            timeout(Duration::from_millis(10), batch_rx.wait_for_batch())
+                .await
+                .expect("Should be notified with force collection");
+        assert_eq!(batch.len(), n_samples);
+        assert!(batch_tx.handoff.batch.lock().unwrap().is_empty());
+    }
+
+    // Basic test that we append new samples and don't drop anything.
+    #[tokio::test]
+    async fn batch_handoff_handles_new_samples_when_empty() {
+        let (batch_tx, batch_rx) = batch_handoff::<()>(BATCH_SIZE);
+        let n_samples = 3;
+        let samples = vec![(); n_samples];
+        let n_dropped = batch_tx.send_and_notify(samples, false);
+        assert_eq!(n_dropped, 0);
+        assert_eq!(batch_tx.handoff.batch.lock().unwrap().len(), n_samples);
+        let _ = timeout(
+            Duration::from_millis(10),
+            batch_rx.handoff.notify.notified(),
+        )
+        .await
+        .expect_err("Should not be notified in this case");
+    }
+
+    #[tokio::test]
+    async fn batch_handoff_drops_old_batched_samples() {
+        let (batch_tx, batch_rx) = batch_handoff::<()>(BATCH_SIZE);
+
+        // Push enough samples to get us just near the end of the maximum buffer
+        // size.
+        let n_samples = MAX_BUFFER_SIZE_MULTIPLIER * BATCH_SIZE - 1;
+        let samples = vec![(); n_samples];
+        let n_dropped = batch_tx.send_and_notify(samples, false);
+
+        // We still should not drop anything.
+        assert_eq!(n_dropped, 0);
+        assert_eq!(batch_tx.handoff.batch.lock().unwrap().len(), n_samples);
+
+        // But we _should_ be notified since this is larger than the batch.
+        let _ = timeout(
+            Duration::from_millis(10),
+            batch_rx.handoff.notify.notified(),
+        )
+        .await
+        .expect("Should have notified receiver now");
+
+        // Now, push just a measly 2 samples. We should drop one, since we had
+        // space for just one left.
+        let n_dropped = batch_tx.send_and_notify(vec![(); 2], false);
+        assert_eq!(n_dropped, 1);
+
+        // The batch should be completely full now
+        assert_eq!(
+            batch_tx.handoff.batch.lock().unwrap().len(),
+            MAX_BUFFER_SIZE_MULTIPLIER * BATCH_SIZE
+        );
+        assert_eq!(
+            batch_rx.handoff.batch.lock().unwrap().len(),
+            MAX_BUFFER_SIZE_MULTIPLIER * BATCH_SIZE
+        );
+
+        // And we should have notified the receiver.
+        let _ = timeout(
+            Duration::from_millis(10),
+            batch_rx.handoff.notify.notified(),
+        )
+        .await
+        .expect("Should have notified receiver now");
+    }
+
+    #[tokio::test]
+    async fn batch_handoff_drops_old_and_new_samples_if_needed() {
+        // Push a few samples
+        let (batch_tx, batch_rx) = batch_handoff::<()>(BATCH_SIZE);
+        let n_samples = 3;
+        let samples = vec![(); n_samples];
+        let n_dropped = batch_tx.send_and_notify(samples, false);
+        assert_eq!(n_dropped, 0);
+        assert_eq!(batch_tx.handoff.batch.lock().unwrap().len(), n_samples);
+        let _ = timeout(
+            Duration::from_millis(10),
+            batch_rx.handoff.notify.notified(),
+        )
+        .await
+        .expect_err("Should not be notified in this case");
+
+        // Now push enough to get us all the way past the max size and then
+        // some. We should drop the contents of the existing batch, plus some of
+        // the new samples.
+        let n_current_samples = n_samples;
+        let n_samples = MAX_BUFFER_SIZE_MULTIPLIER * BATCH_SIZE + BATCH_SIZE;
+        let samples = vec![(); n_samples];
+
+        // We've appended a full extra batch, and we also have the contents of
+        // the existing buffer. All of those should be dropped.
+        let expected_n_dropped = BATCH_SIZE + n_current_samples;
+        let n_dropped = batch_tx.send_and_notify(samples, false);
+        assert_eq!(n_dropped, expected_n_dropped);
+
+        // The batch should be completely full now.
+        assert_eq!(
+            batch_tx.handoff.batch.lock().unwrap().len(),
+            MAX_BUFFER_SIZE_MULTIPLIER * BATCH_SIZE
+        );
+        assert_eq!(
+            batch_rx.handoff.batch.lock().unwrap().len(),
+            MAX_BUFFER_SIZE_MULTIPLIER * BATCH_SIZE
+        );
+
+        // And the receiver should now have everything.
+        let _ = timeout(
+            Duration::from_millis(10),
+            batch_rx.handoff.notify.notified(),
+        )
+        .await
+        .expect("Should be notified in this case");
     }
 }

--- a/oximeter/collector/src/results_sink.rs
+++ b/oximeter/collector/src/results_sink.rs
@@ -7,9 +7,11 @@
 //! This includes the usual task that inserts data into ClickHouse, and a
 //! printing task used in `oximeter` standalone.
 
-// Copyright 2024 Oxide Computer Company
+// Copyright 2026 Oxide Computer Company
 
 use crate::collection_task::CollectionTaskOutput;
+use crate::probes;
+use oximeter::Sample;
 use oximeter::types::ProducerResultsItem;
 use oximeter_db::Client;
 use oximeter_db::DbWrite as _;
@@ -20,8 +22,13 @@ use slog::info;
 use slog::trace;
 use slog::warn;
 use slog_error_chain::InlineErrorChain;
+use std::collections::VecDeque;
+use std::sync::Arc;
+use std::sync::Mutex;
 use std::time::Duration;
+use tokio::sync::Notify;
 use tokio::sync::mpsc;
+use tokio::time::MissedTickBehavior;
 use tokio::time::interval;
 
 /// A sink that inserts all results into the ClickHouse database.
@@ -36,74 +43,246 @@ pub async fn database_inserter(
     batch_interval: Duration,
     mut rx: mpsc::Receiver<CollectionTaskOutput>,
 ) {
-    let mut timer = interval(batch_interval);
-    timer.tick().await; // completes immediately
-    let mut batch = Vec::with_capacity(batch_size);
+    // Construct a handoff point between the batch task here, and the database
+    // insertion task.
+    //
+    // As this task receives individual collection results from the collection
+    // tasks, it batches them up in a shared buffer. When that buffer reaches at
+    // least the batch size, or a timer expires, it then notifies the insertion
+    // task that it should consume the buffer and insert those samples into the
+    // database.
+    let (batch_tx, batch_rx) = batch_handoff(batch_size);
+
+    // Spawn a task for doing the actual insertion into the database.
+    //
+    // This outer task is responsible only for taking results from the
+    // individual collection tasks and batching them up for insertion.
+    let inserter = tokio::spawn(database_inserter_impl(
+        log.new(slog::o!("component" => "database-inserter")),
+        client,
+        batch_rx,
+    ));
+
+    // Spawn a timer for ensuring we periodically notify the inserter to
+    // actually flush to the database, regardless of the number of samples we've
+    // collected in the batch.
+    let mut batch_timer = interval(batch_interval);
+    batch_timer.set_missed_tick_behavior(MissedTickBehavior::Delay);
+    batch_timer.tick().await;
+
     loop {
-        let insert = tokio::select! {
-            _ = timer.tick() => {
-                if batch.is_empty() {
-                    trace!(log, "batch interval expired, but no samples to insert");
-                    false
-                } else {
-                    true
-                }
-            }
+        tokio::select! {
+            _ = batch_timer.tick() => batch_tx.notify_inserter(),
             results = rx.recv() => {
                 match results {
                     Some(CollectionTaskOutput {
                         was_forced_collection,
                         results,
                     }) => {
-                        let flattened_results = {
-                            let mut flattened = Vec::with_capacity(results.len());
-                            for inner_batch in results.into_iter() {
-                                match inner_batch {
-                                    ProducerResultsItem::Ok(samples) => flattened.extend(samples.into_iter()),
-                                    ProducerResultsItem::Err(e) => {
-                                        debug!(
-                                            log,
-                                            "received error (not samples) from a producer: {}",
-                                            e.to_string()
-                                        );
-                                    }
+                        probes::results__sink__item__dequeued!();
+
+                        // Collect all samples from this one collection result
+                        // into an intermediate batch.
+                        //
+                        // NOTE: We could call `batch_tx.send_and_notify()` here
+                        // in the loop. I'm avoiding that for now because it
+                        // takes a lock on the shared buffer of samples, so
+                        // there's a lot of locking / unlocking in this loop.
+                        // Instead, do it once at the end.
+                        let mut n_samples = 0;
+                        let mut batch = Vec::with_capacity(results.len());
+                        for inner_batch in results.into_iter() {
+                            match inner_batch {
+                                ProducerResultsItem::Ok(mut samples) => {
+                                    n_samples += samples.len();
+                                    batch.append(&mut samples);
+                                }
+                                ProducerResultsItem::Err(e) => {
+                                    debug!(
+                                        log,
+                                        "received error (not samples) from a producer";
+                                        InlineErrorChain::new(&e),
+                                    );
                                 }
                             }
-                            flattened
-                        };
-                        batch.extend(flattened_results);
+                        }
+                        probes::results__sink__item__processed!(|| n_samples);
 
-                        // Always insert if this was a forced collection request
-                        was_forced_collection || batch.len() >= batch_size
+                        // Append the current batch to the handoff buffer.
+                        let n_dropped =
+                            batch_tx.send_and_notify(batch, was_forced_collection);
+                        if n_dropped > 0 {
+                            probes::dropped__old__samples!(|| n_dropped);
+                            warn!(
+                                log,
+                                "sample buffer full, dropped oldest samples";
+                                "n_dropped" => n_dropped,
+                            );
+                        }
                     }
                     None => {
                         warn!(log, "result queue closed, exiting");
+                        inserter.abort();
                         return;
                     }
                 }
             }
         };
+    }
+}
 
-        if insert {
-            debug!(log, "inserting {} samples into database", batch.len());
-            match client.insert_samples(&batch).await {
-                Ok(()) => trace!(log, "successfully inserted samples"),
-                Err(e) => {
-                    warn!(
-                        log,
-                        "failed to insert some results into metric DB";
-                        InlineErrorChain::new(&e)
-                    );
-                }
+// The maximum number of samples the shared ring buffer can hold, expressed as a
+// multiple of the batch size. If the insertion task falls behind (e.g., because
+// ClickHouse is slow or unreachable), new samples evict the oldest ones once
+// this limit is reached. This bounds memory consumption while preferring
+// recent data.
+const MAX_BUFFER_SIZE_MULTIPLIER: usize = 100;
+
+// A handoff point for a batch of samples from collectors and the database
+// inserter.
+//
+// This acts as a rendezvous point for the batching task, which collects results
+// from individual collection tasks and aggregates them, and the actual database
+// insertion task. As results are collected from the tasks, they are appended
+// onto the existing ring buffer of samples, which is protected by a sync mutex.
+// The other side is then notified if the existing batch is at least the
+// insertion batch size.
+#[derive(Clone)]
+struct BatchHandoff {
+    notify: Arc<Notify>,
+    batch: Arc<Mutex<VecDeque<Sample>>>,
+}
+
+impl BatchHandoff {
+    fn new(batch_size: usize) -> Self {
+        Self {
+            notify: Arc::new(Notify::new()),
+            batch: Arc::new(Mutex::new(VecDeque::with_capacity(batch_size))),
+        }
+    }
+}
+
+struct BatchSender {
+    // Handoff point between the sender and database inserter.
+    handoff: BatchHandoff,
+    // Minimum size of the buffer before inserting into the database.
+    batch_size: usize,
+    // Maximum size we let the ring buffer grow before starting to drop older
+    // samples. This is a relief value, in the case where the database is
+    // completely partitioned or insertions have slowed dramatically.
+    max_buffer_size: usize,
+}
+
+impl BatchSender {
+    fn new(handoff: BatchHandoff, batch_size: usize) -> Self {
+        Self {
+            handoff,
+            batch_size,
+            max_buffer_size: batch_size * MAX_BUFFER_SIZE_MULTIPLIER,
+        }
+    }
+
+    // Notify the insertion task that it should insert the batch of results.
+    fn notify_inserter(&self) {
+        self.handoff.notify.notify_one()
+    }
+
+    // Append a list of samples to the ring buffer, and possibly notify the
+    // inserter.
+    //
+    // If appending would exceed the maximum buffer size, the oldest samples are
+    // dropped from the front to make room. Returns the number of samples
+    // dropped.
+    //
+    // This notifies the insertion task if either the current batch is at least
+    // the batch size, or if the new data was the result of a forced collection
+    // attempt.
+    fn send_and_notify(
+        &self,
+        samples: Vec<Sample>,
+        was_forced_collection: bool,
+    ) -> usize {
+        let mut batch = self.handoff.batch.lock().unwrap();
+        batch.extend(samples);
+
+        // Drop the oldest samples from the front if we've exceeded the limit.
+        // VecDeque makes front-removal O(1) per element.
+        let n_dropped = batch.len().saturating_sub(self.max_buffer_size);
+        if n_dropped > 0 {
+            drop(batch.drain(..n_dropped));
+        }
+
+        if was_forced_collection || batch.len() >= self.batch_size {
+            self.notify_inserter();
+        }
+        n_dropped
+    }
+}
+
+struct BatchReceiver {
+    handoff: BatchHandoff,
+    batch_size: usize,
+}
+
+impl BatchReceiver {
+    // Wait for a notification and atomically swap out the entire buffer.
+    //
+    // Returns a `VecDeque` so the caller can use `make_contiguous()` to obtain
+    // a contiguous `&[Sample]` without an additional heap allocation.
+    async fn wait_for_batch(&self) -> VecDeque<Sample> {
+        self.handoff.notify.notified().await;
+        let mut empty = VecDeque::with_capacity(self.batch_size);
+        let mut batch = self.handoff.batch.lock().unwrap();
+        std::mem::swap(&mut empty, &mut *batch);
+        empty
+    }
+}
+
+fn batch_handoff(batch_size: usize) -> (BatchSender, BatchReceiver) {
+    let handoff = BatchHandoff::new(batch_size);
+    let sender = BatchSender::new(handoff.clone(), batch_size);
+    let receiver = BatchReceiver { handoff, batch_size };
+    (sender, receiver)
+}
+
+// The task that actually inserts results into the database.
+async fn database_inserter_impl(
+    log: Logger,
+    client: Client,
+    batch_rx: BatchReceiver,
+) {
+    loop {
+        // Wait for a notification that there are samples to insert, and consume
+        // them. This swaps out the buffer of samples shared with the batching
+        // task.
+        //
+        // TODO-correctness The `insert_samples` call below may fail. The method itself needs
+        // better handling of partially-inserted results in that case, but we may need to retry
+        // or otherwise handle an error here as well.
+        //
+        // See https://github.com/oxidecomputer/omicron/issues/740 for a
+        // disucssion.
+        let mut batch = batch_rx.wait_for_batch().await;
+        if batch.is_empty() {
+            debug!(log, "batch interval expired, but no samples to insert");
+            continue;
+        }
+        debug!(log, "inserting samples into database"; "n_samples" => batch.len());
+        probes::insert__samples__start!(|| batch.len());
+        match client.insert_samples(batch.make_contiguous()).await {
+            Ok(()) => {
+                probes::insert__samples__done!();
+                trace!(log, "successfully inserted samples");
             }
-
-            // TODO-correctness The `insert_samples` call above may fail. The method itself needs
-            // better handling of partially-inserted results in that case, but we may need to retry
-            // or otherwise handle an error here as well.
-            //
-            // See https://github.com/oxidecomputer/omicron/issues/740 for a
-            // disucssion.
-            batch.clear();
+            Err(e) => {
+                let err = InlineErrorChain::new(&e);
+                probes::insert__samples__failed!(|| err.to_string());
+                warn!(
+                    log,
+                    "failed to insert some results into metric DB";
+                    err,
+                );
+            }
         }
     }
 }

--- a/oximeter/db/src/client/mod.rs
+++ b/oximeter/db/src/client/mod.rs
@@ -5091,7 +5091,7 @@ mod tests {
         };
         let new_client = Client::new_with_pool_policy(
             resolver,
-            "clickhouse",
+            "oximeter-test",
             policy,
             &logctx.log,
         );

--- a/oximeter/db/src/client/mod.rs
+++ b/oximeter/db/src/client/mod.rs
@@ -103,15 +103,22 @@ impl Client {
     /// connection pool.
     pub fn new_with_resolver(
         native_resolver: BoxedResolver,
+        pool_name: &str,
         log: &Logger,
     ) -> Self {
-        Self::new_with_pool_policy(native_resolver, Default::default(), log)
+        Self::new_with_pool_policy(
+            native_resolver,
+            pool_name,
+            Default::default(),
+            log,
+        )
     }
 
     /// Construct a ClickHouse client with a specific qorb connection pool
     /// policy.
     pub fn new_with_pool_policy(
         native_resolver: BoxedResolver,
+        pool_name: &str,
         policy: Policy,
         log: &Logger,
     ) -> Self {
@@ -123,7 +130,7 @@ impl Client {
         let schema = Mutex::new(BTreeMap::new());
         let request_timeout = DEFAULT_REQUEST_TIMEOUT;
         let native_pool = match Pool::new(
-            "clickhouse".to_string(),
+            pool_name.to_string(),
             native_resolver,
             Arc::new(native::connection::Connector),
             policy,
@@ -5082,8 +5089,12 @@ mod tests {
             claim_timeout: Duration::from_secs(1),
             ..Default::default()
         };
-        let new_client =
-            Client::new_with_pool_policy(resolver, policy, &logctx.log);
+        let new_client = Client::new_with_pool_policy(
+            resolver,
+            "clickhouse",
+            policy,
+            &logctx.log,
+        );
 
         // And then assert that when we try to insert samples, we _fail_ rather
         // than timeout. Timing out here would only happen if we tried to do


### PR DESCRIPTION
- Create a new, separate task solely for inserting a batch of results into ClickHouse. By separating the tasks, we do not block processing of collection results from the individual tasks on the database insertion. That can actually take a while, since oximeter is still attempting to insert data in a replicated ClickHouse cluster, which doesn't exist in most deployments. That would block the _next collection_, since starting a new interval-based collection and pushing the results onto the queue are in the same task.
- Add some more DTrace probes to better observe these new tasks
- Some misc new and improved logging
- Require that the caller specify a name for the qorb pool for ClickHouse clients. Since these were hardcoded internally before, we couldn't easily disambiguate DTrace probes or logs for the qorb pool for the single-node or replicated cluster. They both showed up with a pool name of "clickhouse". The collector now creates a "clickhouse" and "clickhouse-cluster" pool to tell them apart.