### PR TITLE
Add filters to IP pool list endpoint (#9147)

### DIFF
--- a/nexus/db-model/src/ip_pool.rs
+++ b/nexus/db-model/src/ip_pool.rs
@@ -16,6 +16,7 @@ use nexus_db_schema::schema::ip_pool;
 use nexus_db_schema::schema::ip_pool_range;
 use nexus_db_schema::schema::ip_pool_resource;
 use nexus_types::external_api::ip_pool as ip_pool_types;
+use nexus_types::external_api::ip_pool::IpPoolListFilter;
 use nexus_types::identity::Resource;
 use omicron_common::api::external;
 use std::net::IpAddr;
@@ -421,4 +422,19 @@ impl DatastoreCollectionConfig<IpPoolRange> for IpPool {
     type GenerationNumberColumn = ip_pool::dsl::rcgen;
     type CollectionTimeDeletedColumn = ip_pool::dsl::time_deleted;
     type CollectionIdColumn = ip_pool_range::dsl::ip_pool_id;
+}
+
+#[derive(Clone, Copy, Debug, Default)]
+pub struct IpPoolListFilters {
+    pub ip_version: Option<IpVersion>,
+    pub delegated_for_internal_use: Option<bool>,
+}
+
+impl From<IpPoolListFilter> for IpPoolListFilters {
+    fn from(value: IpPoolListFilter) -> Self {
+        Self {
+            ip_version: value.ip_version.map(Into::into),
+            delegated_for_internal_use: value.delegated_for_internal_use,
+        }
+    }
 }

--- a/nexus/db-queries/src/db/datastore/ip_pool.rs
+++ b/nexus/db-queries/src/db/datastore/ip_pool.rs
@@ -46,6 +46,7 @@ use nexus_db_lookup::DbConnection;
 use nexus_db_lookup::LookupPath;
 use nexus_db_model::InternetGateway;
 use nexus_db_model::InternetGatewayIpPool;
+use nexus_db_model::IpPoolListFilters;
 use nexus_db_model::IpVersion;
 use nexus_db_model::Project;
 use nexus_db_model::Vpc;
@@ -188,16 +189,21 @@ impl DataStore {
 
     /// List IP Pools
     ///
-    /// This returns the pools available for external customer use.
+    /// This returns the pools available. Pools are filterable by IP Version and
+    /// whether the pool is delegated for external or internal usage.
     pub async fn ip_pools_list(
         &self,
         opctx: &OpContext,
         pagparams: &PaginatedBy<'_>,
+        filters: &IpPoolListFilters,
     ) -> ListResultVec<IpPool> {
         self.ip_pools_list_paginated(
             opctx,
-            IpPoolReservationType::ExternalSilos,
-            None,
+            match filters.delegated_for_internal_use {
+                Some(true) => IpPoolReservationType::OxideInternal,
+                _ => IpPoolReservationType::ExternalSilos,
+            },
+            filters.ip_version,
             None,
             pagparams,
         )
@@ -2536,7 +2542,7 @@ mod test {
         let pagbyid = PaginatedBy::Id(pagparams_id);
 
         let all_pools = datastore
-            .ip_pools_list(&opctx, &pagbyid)
+            .ip_pools_list(&opctx, &pagbyid, &Default::default())
             .await
             .expect("Should list IP pools");
         assert_eq!(all_pools.len(), 0);
@@ -2571,7 +2577,7 @@ mod test {
 
         // shows up in full list but not silo list
         let all_pools = datastore
-            .ip_pools_list(&opctx, &pagbyid)
+            .ip_pools_list(&opctx, &pagbyid, &Default::default())
             .await
             .expect("Should list IP pools");
         assert_eq!(all_pools.len(), 1);
@@ -3188,7 +3194,7 @@ mod test {
 
         // Regular pool listing should also include it
         let all_pools = datastore
-            .ip_pools_list(&opctx, &pagbyid)
+            .ip_pools_list(&opctx, &pagbyid, &Default::default())
             .await
             .expect("Should list all IP pools");
         assert_eq!(all_pools.len(), 1);

--- a/nexus/external-api/src/lib.rs
+++ b/nexus/external-api/src/lib.rs
@@ -79,6 +79,7 @@ api_versions!([
     // |  date-based version should be at the top of the list.
     // v
     // (next_yyyy_mm_dd_nn, IDENT),
+    (2026_04_15_00, IP_POOL_LIST_FILTERS),
     (2026_03_25_00, SUBNET_POOL_UTILIZATION_REMAINING),
     (2026_03_24_00, ADD_ICMPV6_FIREWALL_SUPPORT),
     (2026_03_23_00, RENAME_PREFIX_LEN),
@@ -1277,12 +1278,36 @@ pub trait NexusExternalApi {
         method = GET,
         path = "/v1/system/ip-pools",
         tags = ["system/ip-pools"],
-        versions = VERSION_RENAME_POOL_ENDPOINTS..,
+        versions = VERSION_IP_POOL_LIST_FILTERS..,
     }]
     async fn system_ip_pool_list(
         rqctx: RequestContext<Self::Context>,
         query_params: Query<PaginatedByNameOrId>,
+        filter_params: Query<latest::ip_pool::IpPoolListFilter>,
     ) -> Result<HttpResponseOk<ResultsPage<latest::ip_pool::IpPool>>, HttpError>;
+
+    /// List IP pools
+    #[endpoint {
+        operation_id = "system_ip_pool_list",
+        method = GET,
+        path = "/v1/system/ip-pools",
+        tags = ["system/ip-pools"],
+        versions = VERSION_RENAME_POOL_ENDPOINTS..VERSION_IP_POOL_LIST_FILTERS,
+    }]
+    async fn system_ip_pool_list_v2026_02_09_00(
+        rqctx: RequestContext<Self::Context>,
+        query_params: Query<PaginatedByNameOrId>,
+    ) -> Result<
+        HttpResponseOk<ResultsPage<v2025_11_20_00::ip_pool::IpPool>>,
+        HttpError,
+    > {
+        Self::system_ip_pool_list(
+            rqctx,
+            query_params,
+            latest::ip_pool::IpPoolListFilter::default().into(),
+        )
+        .await
+    }
 
     /// List IP pools
     #[endpoint {
@@ -1299,7 +1324,7 @@ pub trait NexusExternalApi {
         HttpResponseOk<ResultsPage<v2025_11_20_00::ip_pool::IpPool>>,
         HttpError,
     > {
-        Self::system_ip_pool_list(rqctx, query_params).await
+        Self::system_ip_pool_list_v2026_02_09_00(rqctx, query_params).await
     }
 
     /// Create IP pool

--- a/nexus/src/app/ip_pool.rs
+++ b/nexus/src/app/ip_pool.rs
@@ -8,6 +8,7 @@ use ipnetwork::IpNetwork;
 use nexus_db_lookup::LookupPath;
 use nexus_db_lookup::lookup;
 use nexus_db_model::IpPool;
+use nexus_db_model::IpPoolListFilters;
 use nexus_db_model::IpPoolReservationType;
 use nexus_db_model::IpPoolType;
 use nexus_db_model::IpPoolUpdate;
@@ -387,8 +388,9 @@ impl super::Nexus {
         &self,
         opctx: &OpContext,
         pagparams: &PaginatedBy<'_>,
+        filters: &IpPoolListFilters,
     ) -> ListResultVec<db::model::IpPool> {
-        self.db_datastore.ip_pools_list(opctx, pagparams).await
+        self.db_datastore.ip_pools_list(opctx, pagparams, filters).await
     }
 
     pub(crate) async fn ip_pool_delete(

--- a/nexus/src/external_api/http_entrypoints.rs
+++ b/nexus/src/external_api/http_entrypoints.rs
@@ -54,7 +54,9 @@ use nexus_types::external_api::certificate::Certificate;
 use nexus_types::external_api::floating_ip::FloatingIp;
 use nexus_types::external_api::identity_provider::IdentityProvider;
 use nexus_types::external_api::image::Image;
-use nexus_types::external_api::ip_pool::{IpPool, IpPoolRange};
+use nexus_types::external_api::ip_pool::{
+    IpPool, IpPoolListFilter, IpPoolRange,
+};
 use nexus_types::external_api::metrics::SystemMetricsPathParam;
 use nexus_types::external_api::physical_disk::PhysicalDisk;
 use nexus_types::external_api::probe::ProbeInfo;
@@ -1289,18 +1291,20 @@ impl NexusExternalApi for NexusExternalApiImpl {
     async fn system_ip_pool_list(
         rqctx: RequestContext<ApiContext>,
         query_params: Query<PaginatedByNameOrId>,
+        filter_params: Query<IpPoolListFilter>,
     ) -> Result<HttpResponseOk<ResultsPage<IpPool>>, HttpError> {
         let apictx = rqctx.context();
         let handler = async {
             let nexus = &apictx.context.nexus;
             let query = query_params.into_inner();
+            let filter = filter_params.into_inner();
             let pag_params = data_page_params_for(&rqctx, &query)?;
             let scan_params = ScanByNameOrId::from_query(&query)?;
             let paginated_by = name_or_id_pagination(&pag_params, scan_params)?;
             let opctx =
                 crate::context::op_context_for_external_api(&rqctx).await?;
             let pools = nexus
-                .ip_pools_list(&opctx, &paginated_by)
+                .ip_pools_list(&opctx, &paginated_by, &filter.into())
                 .await?
                 .into_iter()
                 .map(IpPool::from)

--- a/nexus/test-utils/src/http_testing.rs
+++ b/nexus/test-utils/src/http_testing.rs
@@ -776,12 +776,20 @@ impl<'a> NexusRequest<'a> {
         };
 
         loop {
-            let url = if let Some(next_token) = &next_token {
-                format!("{}&page_token={}", url_base, next_token)
-            } else if !initial_params.is_empty() {
-                format!("{}&{}", url_base, initial_params)
-            } else {
-                url_base.clone()
+            let url = match (&next_token, initial_params.is_empty()) {
+                (Some(next_token), true) => {
+                    format!("{}&page_token={}", url_base, next_token)
+                }
+                (Some(next_token), false) => {
+                    format!(
+                        "{}&{}&page_token={}",
+                        url_base, initial_params, next_token
+                    )
+                }
+                (None, false) => {
+                    format!("{}&{}", url_base, initial_params)
+                }
+                (None, true) => url_base.clone(),
             };
 
             let page = NexusRequest::object_get(testctx, &url)

--- a/nexus/tests/integration_tests/ip_pools.rs
+++ b/nexus/tests/integration_tests/ip_pools.rs
@@ -13,7 +13,9 @@ use http::StatusCode;
 use http::method::Method;
 use nexus_db_queries::authz;
 use nexus_db_queries::context::OpContext;
-use nexus_db_queries::db::datastore::SERVICE_IPV4_POOL_NAME;
+use nexus_db_queries::db::datastore::{
+    SERVICE_IPV4_POOL_NAME, SERVICE_IPV6_POOL_NAME,
+};
 use nexus_db_queries::db::fixed_data::silo::DEFAULT_SILO;
 use nexus_test_utils::http_testing::AuthnMode;
 use nexus_test_utils::http_testing::NexusRequest;
@@ -224,16 +226,23 @@ async fn test_ip_pool_basic_crud(cptestctx: &ControlPlaneTestContext) {
         .expect("Expected to be able to delete an empty IP Pool");
 }
 
-async fn get_ip_pools(client: &ClientTestContext) -> Vec<IpPool> {
+async fn get_ip_pools_with_params(
+    client: &ClientTestContext,
+    params: &str,
+) -> Vec<IpPool> {
     NexusRequest::iter_collection_authn::<IpPool>(
         client,
         "/v1/system/ip-pools",
-        "",
+        params,
         None,
     )
     .await
     .expect("Failed to list IP Pools")
     .all_items
+}
+
+async fn get_ip_pools(client: &ClientTestContext) -> Vec<IpPool> {
+    get_ip_pools_with_params(client, "").await
 }
 
 // this test exists primarily because of a bug in the initial implementation
@@ -815,6 +824,188 @@ async fn test_ip_pool_update_default(cptestctx: &ControlPlaneTestContext) {
     let silos_p1 = silos_for_pool(client, "p1").await;
     assert_eq!(silos_p1.items.len(), 1);
     assert_eq!(silos_p1.items[0].is_default, false);
+}
+
+#[nexus_test]
+async fn test_ip_pool_list_filter_delegated(
+    cptestctx: &ControlPlaneTestContext,
+) {
+    let client = &cptestctx.external_client;
+
+    let (user_pool, ..) = create_ip_pool(client, "pool-filter", None).await;
+
+    // With no filter, internal pools are excluded by default.
+    let default_pools = get_ip_pools(client).await;
+    assert!(
+        default_pools
+            .iter()
+            .any(|pool| pool.identity.id == user_pool.identity.id)
+    );
+    assert!(default_pools.iter().all(|pool| {
+        pool.identity.name != SERVICE_IPV4_POOL_NAME
+            && pool.identity.name != SERVICE_IPV6_POOL_NAME
+    }));
+
+    let delegated_only =
+        get_ip_pools_with_params(client, "delegated_for_internal_use=true")
+            .await;
+    assert!(
+        delegated_only
+            .iter()
+            .any(|pool| pool.identity.name == SERVICE_IPV4_POOL_NAME)
+    );
+    assert!(
+        delegated_only
+            .iter()
+            .any(|pool| pool.identity.name == SERVICE_IPV6_POOL_NAME)
+    );
+    assert!(
+        delegated_only
+            .iter()
+            .all(|pool| pool.identity.id != user_pool.identity.id)
+    );
+
+    let non_delegated =
+        get_ip_pools_with_params(client, "delegated_for_internal_use=false")
+            .await;
+    assert!(
+        non_delegated
+            .iter()
+            .any(|pool| pool.identity.id == user_pool.identity.id)
+    );
+    assert!(non_delegated.iter().all(|pool| {
+        pool.identity.name != SERVICE_IPV4_POOL_NAME
+            && pool.identity.name != SERVICE_IPV6_POOL_NAME
+    }));
+}
+
+#[nexus_test]
+async fn test_ip_pool_list_filter_ip_version(
+    cptestctx: &ControlPlaneTestContext,
+) {
+    let client = &cptestctx.external_client;
+
+    let (user_v4, ..) = create_ip_pool(client, "pool-filter-v4", None).await;
+    let ipv6_range = IpRange::V6(
+        Ipv6Range::new(
+            "fd00:1::1".parse().unwrap(),
+            "fd00:1::ff".parse().unwrap(),
+        )
+        .unwrap(),
+    );
+    let (user_v6, ..) =
+        create_ip_pool(client, "pool-filter-v6", Some(ipv6_range)).await;
+
+    // `ip_version=v4` alone (default delegation: excludes internal pools).
+    let v4_pools = get_ip_pools_with_params(client, "ip_version=v4").await;
+    assert!(v4_pools.iter().all(|pool| pool.ip_version == IpVersion::V4));
+    assert!(
+        v4_pools.iter().any(|pool| pool.identity.id == user_v4.identity.id)
+    );
+    assert!(v4_pools.iter().all(|pool| {
+        pool.identity.name != SERVICE_IPV4_POOL_NAME
+            && pool.identity.name != SERVICE_IPV6_POOL_NAME
+    }));
+
+    // `ip_version=v6` alone returns the user IPv6 pool, no service pools.
+    let v6_pools = get_ip_pools_with_params(client, "ip_version=v6").await;
+    assert!(v6_pools.iter().all(|pool| pool.ip_version == IpVersion::V6));
+    assert!(
+        v6_pools.iter().any(|pool| pool.identity.id == user_v6.identity.id)
+    );
+
+    let v4_pools = get_ip_pools_with_params(
+        client,
+        "ip_version=v4&delegated_for_internal_use=false",
+    )
+    .await;
+    assert!(v4_pools.iter().all(|pool| pool.ip_version == IpVersion::V4));
+    assert!(
+        v4_pools.iter().any(|pool| pool.identity.id == user_v4.identity.id)
+    );
+
+    // Delegated IPv6 only returns the service pool, not the user IPv6 pool.
+    let delegated_v6 = get_ip_pools_with_params(
+        client,
+        "delegated_for_internal_use=true&ip_version=v6",
+    )
+    .await;
+    assert!(delegated_v6.iter().all(|pool| pool.ip_version == IpVersion::V6));
+    assert!(
+        delegated_v6
+            .iter()
+            .any(|pool| pool.identity.name == SERVICE_IPV6_POOL_NAME)
+    );
+    assert!(
+        delegated_v6
+            .iter()
+            .all(|pool| pool.identity.id != user_v6.identity.id)
+    );
+}
+
+// Invalid filter values should be rejected with 400.
+#[nexus_test]
+async fn test_ip_pool_list_filter_invalid(
+    cptestctx: &ControlPlaneTestContext,
+) {
+    let client = &cptestctx.external_client;
+
+    object_get_error(
+        client,
+        "/v1/system/ip-pools?delegated_for_internal_use=notabool",
+        StatusCode::BAD_REQUEST,
+    )
+    .await;
+
+    object_get_error(
+        client,
+        "/v1/system/ip-pools?ip_version=v5",
+        StatusCode::BAD_REQUEST,
+    )
+    .await;
+}
+
+// Filter parameters must persist across paginated requests.
+#[nexus_test]
+async fn test_ip_pool_list_filter_pagination(
+    cptestctx: &ControlPlaneTestContext,
+) {
+    let client = &cptestctx.external_client;
+
+    // Create enough user pools to require multiple pages at limit=5.
+    for i in 1..=8 {
+        create_ipv4_pool(client, &format!("paged-pool-{}", i)).await;
+    }
+
+    // Page through with a filter applied. The service pools should never
+    // appear, on any page.
+    let pools = get_ip_pools_with_params_and_limit(
+        client,
+        "delegated_for_internal_use=false",
+        5,
+    )
+    .await;
+    assert!(pools.len() >= 8);
+    assert!(pools.iter().all(|pool| {
+        pool.identity.name != SERVICE_IPV4_POOL_NAME
+            && pool.identity.name != SERVICE_IPV6_POOL_NAME
+    }));
+}
+
+async fn get_ip_pools_with_params_and_limit(
+    client: &ClientTestContext,
+    params: &str,
+    limit: usize,
+) -> Vec<IpPool> {
+    NexusRequest::iter_collection_authn::<IpPool>(
+        client,
+        "/v1/system/ip-pools",
+        params,
+        Some(limit),
+    )
+    .await
+    .expect("Failed to list IP Pools")
+    .all_items
 }
 
 // IP pool list fetch logic includes a join to ip_pool_resource, which is

--- a/nexus/types/versions/src/ip_pool_list_filters/ip_pool.rs
+++ b/nexus/types/versions/src/ip_pool_list_filters/ip_pool.rs
@@ -1,0 +1,19 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at https://mozilla.org/MPL/2.0/.
+
+use omicron_common::api::external::IpVersion;
+use schemars::JsonSchema;
+use serde::{Deserialize, Serialize};
+
+/// Filters for listing IP pools.
+#[derive(Clone, Debug, Default, Deserialize, Serialize, JsonSchema)]
+pub struct IpPoolListFilter {
+    /// Restrict pools to a specific IP version.
+    pub ip_version: Option<IpVersion>,
+
+    /// Filter on pools delegated for internal Oxide use.
+    ///
+    /// Defaults to excluding internal pools when unset.
+    pub delegated_for_internal_use: Option<bool>,
+}

--- a/nexus/types/versions/src/ip_pool_list_filters/mod.rs
+++ b/nexus/types/versions/src/ip_pool_list_filters/mod.rs
@@ -1,0 +1,10 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at https://mozilla.org/MPL/2.0/.
+
+//! Version `IP_POOL_LIST_FILTERS` of the Nexus external API.
+//!
+//! Adds optional query parameters to the IP pool list endpoint to filter by
+//! IP version and by whether the pool is delegated for internal Oxide use.
+
+pub mod ip_pool;

--- a/nexus/types/versions/src/latest.rs
+++ b/nexus/types/versions/src/latest.rs
@@ -211,6 +211,8 @@ pub mod ip_pool {
     pub use crate::v2026_01_05_00::ip_pool::IpPoolLinkSilo;
     pub use crate::v2026_01_05_00::ip_pool::IpPoolSiloUpdate;
     pub use crate::v2026_01_05_00::ip_pool::PoolSelector;
+
+    pub use crate::v2026_04_15_00::ip_pool::IpPoolListFilter;
 }
 
 pub mod metrics {

--- a/nexus/types/versions/src/lib.rs
+++ b/nexus/types/versions/src/lib.rs
@@ -77,3 +77,5 @@ pub mod v2026_03_14_00;
 pub mod v2026_03_23_00;
 #[path = "subnet_pool_utilization_remaining/mod.rs"]
 pub mod v2026_03_25_00;
+#[path = "ip_pool_list_filters/mod.rs"]
+pub mod v2026_04_15_00;

--- a/openapi/nexus/nexus-2026032500.0.0-cf1221.json.gitstub
+++ b/openapi/nexus/nexus-2026032500.0.0-cf1221.json.gitstub
@@ -1,0 +1,1 @@
+254a0c51bc0beecb79c8a9dfccce8e7bc35b5ca4:openapi/nexus/nexus-2026032500.0.0-cf1221.json

--- a/openapi/nexus/nexus-2026041500.0.0-a0c0db.json
+++ b/openapi/nexus/nexus-2026041500.0.0-a0c0db.json
@@ -7,7 +7,7 @@
       "url": "https://oxide.computer",
       "email": "api@oxide.computer"
     },
-    "version": "2026032500.0.0"
+    "version": "2026041500.0.0"
   },
   "paths": {
     "/device/auth": {
@@ -9236,6 +9236,23 @@
             "name": "sort_by",
             "schema": {
               "$ref": "#/components/schemas/NameOrIdSortMode"
+            }
+          },
+          {
+            "in": "query",
+            "name": "delegated_for_internal_use",
+            "description": "Filter on pools delegated for internal Oxide use.\n\nDefaults to excluding internal pools when unset.",
+            "schema": {
+              "nullable": true,
+              "type": "boolean"
+            }
+          },
+          {
+            "in": "query",
+            "name": "ip_version",
+            "description": "Restrict pools to a specific IP version.",
+            "schema": {
+              "$ref": "#/components/schemas/IpVersion"
             }
           }
         ],

--- a/openapi/nexus/nexus-latest.json
+++ b/openapi/nexus/nexus-latest.json
@@ -1,1 +1,1 @@
-nexus-2026032500.0.0-cf1221.json
+nexus-2026041500.0.0-a0c0db.json


### PR DESCRIPTION
Introduces a new API version (2026-04-15) adding optional `ip_version` and `delegated_for_internal_use` query parameters to the `/v1/system/ip-pools` endpoint, allowing server-side filtering of pools by IP version and whether they are delegated for internal Oxide use.

The changes and tests were based off a [previous PR](https://github.com/oxidecomputer/omicron/pull/9151) that was closed by the author. Issues with [serde(flatten)](https://github.com/nox/serde_urlencoded/issues/33) made it so the scanner pattern wasn't possible with `Option<bool>`, so separate params were added. This meant I needed to modify the http_testing utility to pass parameters that don't end up encoded with the pagination parameters into the next page. All other tests still pass with this change.

I used the /add-api-version skill since this would modify blessed openapi spec versions even though this is a strictly additive PR with defaults that would result in the same exact functionality.