### PR TITLE
fm: add CaseBuilder::request_support_bundle

### DIFF
--- a/nexus/fm/src/analysis_input.rs
+++ b/nexus/fm/src/analysis_input.rs
@@ -586,6 +586,12 @@ mod tests {
                     "requesting an alert to tell someone about something",
                 )
                 .unwrap();
+            new_case
+                .request_support_bundle(
+                    nexus_types::support_bundle::BundleDataSelection::all(),
+                    "requesting a support bundle",
+                )
+                .unwrap();
             *new_case.id()
         };
 
@@ -626,6 +632,27 @@ mod tests {
         assert!(
             new_case.is_open(),
             "new case should be open in the output sitrep"
+        );
+        assert_eq!(
+            new_case.alerts_requested.len(),
+            1,
+            "new case should have the one requested alert"
+        );
+        assert_eq!(
+            new_case.support_bundles_requested.len(),
+            1,
+            "new case should have the one requested support bundle"
+        );
+        let bundle_req = new_case
+            .support_bundles_requested
+            .iter()
+            .next()
+            .expect("new case should have a support bundle request");
+        assert_eq!(bundle_req.comment, "requesting a support bundle");
+        assert_eq!(
+            bundle_req.requested_sitrep_id, output_sitrep.metadata.id,
+            "support bundle request should be tagged with the sitrep ID in \
+             which it was requested"
         );
 
         assert!(

--- a/nexus/fm/src/builder/case.rs
+++ b/nexus/fm/src/builder/case.rs
@@ -8,6 +8,7 @@ use fm::analysis_reports;
 use iddqd::id_ord_map::{self, IdOrdMap};
 use nexus_types::alert::AlertClass;
 use nexus_types::fm;
+use nexus_types::support_bundle::BundleDataSelection;
 use omicron_uuid_kinds::CaseUuid;
 use omicron_uuid_kinds::SitrepUuid;
 use std::sync::Arc;
@@ -155,6 +156,41 @@ impl CaseBuilder {
             .entry("requested alert")
             .kv("alert_id", id)
             .kv("alert_class", &class)
+            .comment(comment);
+
+        Ok(())
+    }
+
+    pub fn request_support_bundle(
+        &mut self,
+        data_selection: BundleDataSelection,
+        comment: impl ToString,
+    ) -> anyhow::Result<()> {
+        let id = self.rng.next_support_bundle();
+        let req = fm::case::SupportBundleRequest {
+            id,
+            requested_sitrep_id: self.sitrep_id,
+            data_selection,
+            comment: comment.to_string(),
+        };
+        self.case.support_bundles_requested.insert_unique(req).map_err(
+            |_| {
+                anyhow::anyhow!(
+                    "a support bundle request with ID {id:?} already exists"
+                )
+            },
+        )?;
+
+        let comment = comment.to_string();
+        slog::info!(
+            &self.log,
+            "requested a support bundle";
+            "support_bundle_id" => %id,
+            "comment" => %comment,
+        );
+        self.report_log
+            .entry("requested support bundle")
+            .kv("support_bundle_id", id)
             .comment(comment);
 
         Ok(())

--- a/nexus/fm/src/builder/rng.rs
+++ b/nexus/fm/src/builder/rng.rs
@@ -15,6 +15,8 @@ use omicron_uuid_kinds::CaseEreportUuid;
 use omicron_uuid_kinds::CaseKind;
 use omicron_uuid_kinds::CaseUuid;
 use omicron_uuid_kinds::SitrepUuid;
+use omicron_uuid_kinds::SupportBundleKind;
+use omicron_uuid_kinds::SupportBundleUuid;
 use rand::SeedableRng as _;
 use rand::rngs::StdRng;
 use std::hash::Hash;
@@ -61,6 +63,7 @@ impl SitrepBuilderRng {
 pub(super) struct CaseBuilderRng {
     ereport_assignment_rng: TypedUuidRng<CaseEreportKind>,
     alert_rng: TypedUuidRng<AlertKind>,
+    support_bundle_rng: TypedUuidRng<SupportBundleKind>,
 }
 
 impl CaseBuilderRng {
@@ -77,7 +80,12 @@ impl CaseBuilderRng {
             &mut sitrep.parent,
             (case_id, "case-ereport"),
         );
-        Self { alert_rng, ereport_assignment_rng }
+
+        let support_bundle_rng = TypedUuidRng::from_parent_rng(
+            &mut sitrep.parent,
+            (case_id, "support-bundle"),
+        );
+        Self { alert_rng, ereport_assignment_rng, support_bundle_rng }
     }
 
     pub(super) fn next_alert(&mut self) -> AlertUuid {
@@ -86,5 +94,9 @@ impl CaseBuilderRng {
 
     pub(super) fn next_case_ereport(&mut self) -> CaseEreportUuid {
         self.ereport_assignment_rng.next()
+    }
+
+    pub(super) fn next_support_bundle(&mut self) -> SupportBundleUuid {
+        self.support_bundle_rng.next()
     }
 }


### PR DESCRIPTION
Add a sitrep builder method for requesting support bundles, similar to `CaseBuilder::request_alert`.