### PR TITLE
doorbellify `cpapi_instances_put`

### DIFF
--- a/nexus/db-queries/src/db/datastore/vmm.rs
+++ b/nexus/db-queries/src/db/datastore/vmm.rs
@@ -6,6 +6,7 @@
 
 use super::DataStore;
 use crate::context::OpContext;
+use crate::db::model::Sled;
 use crate::db::model::Vmm;
 use crate::db::model::VmmRuntimeState;
 use crate::db::model::VmmState as DbVmmState;
@@ -128,6 +129,37 @@ impl DataStore {
             })?;
 
         Ok(vmm)
+    }
+
+    pub async fn vmm_fetch_with_sled(
+        &self,
+        opctx: &OpContext,
+        vmm_id: &PropolisUuid,
+    ) -> LookupResult<(Vmm, Sled)> {
+        use nexus_db_schema::schema::sled::dsl as sled_dsl;
+        let conn = self.pool_connection_authorized(opctx).await?;
+        let result = dsl::vmm
+            .filter(dsl::id.eq(vmm_id.into_untyped_uuid()))
+            .filter(dsl::time_deleted.is_null())
+            .inner_join(
+                sled_dsl::sled.on(sled_dsl::id
+                    .eq(dsl::sled_id)
+                    .and(sled_dsl::time_deleted.is_null())),
+            )
+            .select((Vmm::as_select(), Sled::as_select()))
+            .first_async::<(Vmm, Sled)>(&*conn)
+            .await
+            .map_err(|e| {
+                public_error_from_diesel(
+                    e,
+                    ErrorHandler::NotFoundByLookup(
+                        ResourceType::Vmm,
+                        LookupType::ById(vmm_id.into_untyped_uuid()),
+                    ),
+                )
+            })?;
+
+        Ok(result)
     }
 
     pub async fn vmm_update_runtime(

--- a/nexus/src/app/instance.rs
+++ b/nexus/src/app/instance.rs
@@ -2061,6 +2061,12 @@ impl super::Nexus {
     /// Update the runtime state of the VMM with the provided `propolis_id` to
     /// `new_runtime_state`, potentially spawning an instance update saga if
     /// the instance's state must change as a result of the VMM update.
+    ///
+    /// This method is called by [`Self::instance_request_state`] and
+    /// [`Self::instance_ensure_registered`] to write back the VMM state
+    /// received from sled-agent after requesting a change to an instance. In
+    /// addition, it's also called by [`Self::notify_vmm_updated`] when handling
+    /// a notification from a sled-agent that a VMM's state has changed.
     pub(crate) async fn update_vmm_state(
         &self,
         opctx: &OpContext,

--- a/nexus/src/app/instance.rs
+++ b/nexus/src/app/instance.rs
@@ -2004,8 +2004,8 @@ impl super::Nexus {
             Err(e) if e.vmm_gone() => {
                 info!(
                     &opctx.log,
-                    "notify_vmm_updated: sled-agent response indicates VMM has \
-                     failed";
+                    "notify_vmm_updated: sled-agent response indicates VMM \
+                     has failed";
                     "vmm_id" => %vmm_id,
                     "instance_id" => %instance_id,
                     "sled_id" => %sled_id,
@@ -2059,8 +2059,8 @@ impl super::Nexus {
     }
 
     /// Update the runtime state of the VMM with the provided `propolis_id` to
-    /// `new_runtime_state`, potentially spawning an instance update saga if the
-    /// instance's state must change as a result of the VMM update.
+    /// `new_runtime_state`, potentially spawning an instance update saga if
+    /// the instance's state must change as a result of the VMM update.
     pub(crate) async fn update_vmm_state(
         &self,
         opctx: &OpContext,

--- a/nexus/src/app/instance.rs
+++ b/nexus/src/app/instance.rs
@@ -1399,7 +1399,7 @@ impl super::Nexus {
                 // Ok(None) here, in which case, there's nothing to write back.
                 match instance_put_result {
                     Ok(Some(ref state)) => self
-                        .notify_vmm_updated(opctx, propolis_id, state)
+                        .update_vmm_state(opctx, propolis_id, state)
                         .await
                         .map_err(Into::into),
                     Ok(None) => Ok(()),
@@ -1687,7 +1687,7 @@ impl super::Nexus {
 
         match instance_register_result {
             Ok(state) => {
-                self.notify_vmm_updated(opctx, *propolis_id, &state).await?;
+                self.update_vmm_state(opctx, *propolis_id, &state).await?;
                 let runtime: db::model::VmmRuntimeState =
                     state.vmm_state.into();
                 Ok(db::model::Vmm {
@@ -1776,7 +1776,8 @@ impl super::Nexus {
                 // attempting to transition their instance's state, and then,
                 // upon fetching the instance, transiently see an instance state
                 // suggesting it's "doing fine" until the update saga completes.
-                self.update_instance(&opctx.log, saga, instance_id).await;
+                self.run_instance_update_saga(&opctx.log, saga, instance_id)
+                    .await;
             }
             // XXX: It's not clear what to do with this error; should it be
             // bubbled back up to the caller?
@@ -1940,9 +1941,10 @@ impl super::Nexus {
             .await
     }
 
-    /// Invoked by a sled agent to publish an updated runtime state for an
-    /// Instance.
-    pub(crate) async fn notify_vmm_updated(
+    /// Update the runtime state of the VMM with the provided `propolis_id` to
+    /// `new_runtime_state`, potentially spawning an instance update saga if the
+    /// instance's state must change as a result of the VMM update.
+    pub(crate) async fn update_vmm_state(
         &self,
         opctx: &OpContext,
         propolis_id: PropolisUuid,
@@ -1970,7 +1972,11 @@ impl super::Nexus {
                 "vmm_state" => ?new_runtime_state.vmm_state,
                 "migration_state" => ?new_runtime_state.migrations(),
             );
-            tokio::spawn(self.update_instance(&opctx.log, saga, instance_id));
+            tokio::spawn(self.run_instance_update_saga(
+                &opctx.log,
+                saga,
+                instance_id,
+            ));
         }
 
         Ok(())
@@ -2554,7 +2560,7 @@ impl super::Nexus {
     /// using `tokio::spawn`.
     ///
     /// [instance-update saga]: crate::app::sagas::instance_update
-    fn update_instance(
+    fn run_instance_update_saga(
         &self,
         log: &slog::Logger,
         saga: steno::SagaDag,

--- a/nexus/src/app/instance.rs
+++ b/nexus/src/app/instance.rs
@@ -39,6 +39,7 @@ use nexus_db_queries::db;
 use nexus_db_queries::db::DataStore;
 use nexus_db_queries::db::datastore::InstanceAndActiveVmm;
 use nexus_db_queries::db::datastore::InstanceStateComputer;
+use nexus_db_queries::db::identity::Asset;
 use nexus_db_queries::db::identity::Resource;
 use nexus_types::external_api::disk;
 use nexus_types::external_api::external_ip;
@@ -1939,6 +1940,38 @@ impl super::Nexus {
                 pagparams,
             )
             .await
+    }
+
+    pub(crate) async fn notify_vmm_updated(
+        &self,
+        opctx: &OpContext,
+        vmm_id: PropolisUuid,
+    ) -> Result<(), Error> {
+        slog::debug!(
+            &opctx.log,
+            "ding, dong! received doorbell notification for VMM {vmm_id}";
+            "vmm_id" => %vmm_id,
+        );
+        let (_, sled) =
+            match self.db_datastore.vmm_fetch_with_sled(opctx, &vmm_id).await {
+                Ok(vmm) => vmm,
+                Err(error) => {
+                    // Note that it would be quite weird if the VMM/sled-agent
+                    // lookup failed with `NotFound`, since...we just got a
+                    // notification *from* that sled-agent...
+                    slog::warn!(
+                        &opctx.log,
+                        "failed to look up VMM and sled-agent for updated VMM \
+                         {vmm_id}";
+                         "vmm_id" => %vmm_id,
+                         "error" => &InlineErrorChain::new(&error),
+                    );
+                    return Err(error);
+                }
+            };
+        let sled_agent = self.sled_client(&sled.id()).await?;
+        let state = sled_agent.vmm_get_state(&vmm_id).await?.into_inner();
+        self.update_vmm_state(opctx, vmm_id, &state).await
     }
 
     /// Update the runtime state of the VMM with the provided `propolis_id` to

--- a/nexus/src/app/instance.rs
+++ b/nexus/src/app/instance.rs
@@ -1766,7 +1766,7 @@ impl super::Nexus {
                         authz_instance,
                     },
                 )?;
-                // Unlike `notify_vmm_updated`, which spawns the update
+                // Unlike `update_vmm_state`, which spawns the update
                 // saga in a "fire and forget" fashion so that it can return a
                 // HTTP 200 OK as soon as the changed VMM records are persisted
                 // to the database, `mark_vmm_failed` performs the instance
@@ -1942,39 +1942,120 @@ impl super::Nexus {
             .await
     }
 
+    /// Process a VMM state change doorbell notification received from a
+    /// sled-agent.
+    ///
+    /// This function looks up the sled-agent for the sled on which the VMM
+    /// resides, requests the latest VMM state from that sled-agent, and then
+    /// calls [`Self::update_vmm_state`] to process the state change.
     pub(crate) async fn notify_vmm_updated(
         &self,
         opctx: &OpContext,
         vmm_id: PropolisUuid,
     ) -> Result<(), Error> {
-        slog::debug!(
+        info!(
             &opctx.log,
-            "ding, dong! received doorbell notification for VMM {vmm_id}";
+            "ding, dong! sled-agent rang the VMM doorbell for VMM {vmm_id}";
             "vmm_id" => %vmm_id,
         );
-        let (vmm, sled) =
-            match self.db_datastore.vmm_fetch_with_sled(opctx, &vmm_id).await {
-                Ok(vmm) => vmm,
-                Err(error) => {
-                    // Note that it would be quite weird if the VMM/sled-agent
-                    // lookup failed with `NotFound`, since...we just got a
-                    // notification *from* that sled-agent...
-                    slog::warn!(
-                        &opctx.log,
-                        "failed to look up VMM and sled-agent for updated VMM \
-                         {vmm_id}";
-                         "vmm_id" => %vmm_id,
-                         "error" => &InlineErrorChain::new(&error),
-                    );
-                    return Err(error);
+        let (vmm, sled) = self
+            .db_datastore
+            .vmm_fetch_with_sled(opctx, &vmm_id)
+            .await
+            .map_err(|e| {
+                // Note that it would be quite weird if the VMM/sled-agent
+                // lookup failed with `NotFound`, since...we just got a
+                // notification *from* that sled-agent...
+                e.internal_context(format!(
+                    "failed to look up sled-agent for updated VMM {vmm_id}"
+                ))
+            })?;
+
+        let sled_id = sled.id();
+        let instance_id = vmm.instance_id;
+        debug!(
+            &opctx.log,
+            "notify_vmm_updated: VMM {vmm_id} resides on sled {sled_id}";
+            "vmm_id" => %vmm_id,
+            "instance_id" => %instance_id,
+            "sled_id" => %sled_id,
+        );
+
+        let sled_agent = self.sled_client(&sled_id).await.map_err(|e| {
+            e.internal_context(format!(
+                "failed to get sled-agent client for sled {sled_id} \
+                 (updated VMM {vmm_id}, instance {instance_id})"
+            ))
+        })?;
+
+        // Ask the sled-agent for the latest state of the VMM, and transition
+        // its state.
+        let result = sled_agent
+            .vmm_get_state(&vmm_id)
+            .await
+            .map_err(SledAgentInstanceError);
+        match result {
+            Ok(rsp) => {
+                let state = rsp.into_inner();
+                self.update_vmm_state(opctx, vmm_id, &state).await
+            }
+            // If the sled-agent's response indicates the VMM has failed,
+            // transition it to the failed state.
+            Err(e) if e.vmm_gone() => {
+                info!(
+                    &opctx.log,
+                    "notify_vmm_updated: sled-agent response indicates VMM has \
+                     failed";
+                    "vmm_id" => %vmm_id,
+                    "instance_id" => %instance_id,
+                    "sled_id" => %sled_id,
+                    "error" => InlineErrorChain::new(&e),
+                );
+                let lookup = LookupPath::new(opctx, &self.db_datastore)
+                    .instance_id(instance_id)
+                    .lookup_for(authz::Action::Modify)
+                    .await;
+                match lookup {
+                    Ok((_, _, authz_instance)) => {
+                        self.mark_vmm_failed(opctx, authz_instance, &vmm, &e)
+                            .await
+                    }
+
+                    // Okay, this is a bit odd: we are trying to handle a
+                    // notification from a sled-agent that a VMM's state has
+                    // changed. When we asked the sled-agent for the VMM's
+                    // state, it said the VMM does not exist. Then, when we
+                    // tried to look up the instance for that VMM, the
+                    // *instance* also doesn't exist. This would mean the
+                    // instance record has already been deleted. In that case,
+                    // well, there's nothing left for us to do here...
+                    Err(Error::ObjectNotFound { .. }) => {
+                        warn!(
+                            &opctx.log,
+                            "notify_vmm_updated: VMM has gone away, and its \
+                             instance appears to have already been deleted!";
+                            "vmm_id" => %vmm_id,
+                            "instance_id" => %instance_id,
+                            "sled_id" => %sled_id,
+                        );
+                        Ok(())
+                    }
+
+                    // Other errors are unanticipated here.
+                    Err(e) => Err(e.internal_context(format!(
+                        "failed to look up instance {instance_id} for failed \
+                         VMM {vmm_id}",
+                    ))),
                 }
-            };
-        slog::info!(&opctx.log, "found vmm and sled for updated vmm id {vmm_id}"; "vmm" => #?vmm, "sled" => #?sled);
-        let sled_agent = self.sled_client(&sled.id()).await?;
-        slog::info!(&opctx.log, "got client for sled");
-        let state = sled_agent.vmm_get_state(&vmm_id).await?.into_inner();
-        slog::info!(&opctx.log, "got state from sled"; "state" => #?state);
-        self.update_vmm_state(opctx, vmm_id, &state).await
+            }
+            Err(SledAgentInstanceError(e)) => {
+                let error = Error::from(e).internal_context(format!(
+                    "failed to request the state of VMM {vmm_id} from \
+                     sled-agent {sled_id}"
+                ));
+                Err(error)
+            }
+        }
     }
 
     /// Update the runtime state of the VMM with the provided `propolis_id` to

--- a/nexus/src/app/instance.rs
+++ b/nexus/src/app/instance.rs
@@ -1952,7 +1952,7 @@ impl super::Nexus {
             "ding, dong! received doorbell notification for VMM {vmm_id}";
             "vmm_id" => %vmm_id,
         );
-        let (_, sled) =
+        let (vmm, sled) =
             match self.db_datastore.vmm_fetch_with_sled(opctx, &vmm_id).await {
                 Ok(vmm) => vmm,
                 Err(error) => {
@@ -1969,8 +1969,11 @@ impl super::Nexus {
                     return Err(error);
                 }
             };
+        slog::info!(&opctx.log, "found vmm and sled for updated vmm id {vmm_id}"; "vmm" => #?vmm, "sled" => #?sled);
         let sled_agent = self.sled_client(&sled.id()).await?;
+        slog::info!(&opctx.log, "got client for sled");
         let state = sled_agent.vmm_get_state(&vmm_id).await?.into_inner();
+        slog::info!(&opctx.log, "got state from sled"; "state" => #?state);
         self.update_vmm_state(opctx, vmm_id, &state).await
     }
 

--- a/nexus/src/internal_api/http_entrypoints.rs
+++ b/nexus/src/internal_api/http_entrypoints.rs
@@ -110,19 +110,18 @@ impl NexusInternalApi for NexusInternalApiImpl {
     async fn cpapi_instances_put(
         rqctx: RequestContext<Self::Context>,
         path_params: Path<VmmPathParam>,
-        new_runtime_state: TypedBody<
+        // This is ignored, as this API is now treated as ringing the VMM's
+        // doorbell, and the body is discarded.
+        _new_runtime_state: TypedBody<
             sled_agent_types_versions::v1::instance::SledVmmState,
         >,
     ) -> Result<HttpResponseUpdatedNoContent, HttpError> {
         let apictx = &rqctx.context().context;
         let nexus = &apictx.nexus;
         let path = path_params.into_inner();
-        let new_state = new_runtime_state.into_inner();
         let opctx = crate::context::op_context_for_internal_api(&rqctx).await;
         let handler = async {
-            nexus
-                .update_vmm_state(&opctx, path.propolis_id, &new_state)
-                .await?;
+            nexus.notify_vmm_updated(&opctx, path.propolis_id).await?;
             Ok(HttpResponseUpdatedNoContent())
         };
         apictx

--- a/nexus/src/internal_api/http_entrypoints.rs
+++ b/nexus/src/internal_api/http_entrypoints.rs
@@ -121,7 +121,7 @@ impl NexusInternalApi for NexusInternalApiImpl {
         let opctx = crate::context::op_context_for_internal_api(&rqctx).await;
         let handler = async {
             nexus
-                .notify_vmm_updated(&opctx, path.propolis_id, &new_state)
+                .update_vmm_state(&opctx, path.propolis_id, &new_state)
                 .await?;
             Ok(HttpResponseUpdatedNoContent())
         };

--- a/sled-agent/src/instance.rs
+++ b/sled-agent/src/instance.rs
@@ -3644,7 +3644,10 @@ mod tests {
                 multicast_groups: local_config.multicast_groups,
                 firewall_rules: local_config.firewall_rules,
                 dhcp_config,
-                state: InstanceStates::new(vmm_runtime, migration_id),
+                state: Arc::new(RwLock::new(InstanceStates::new(
+                    vmm_runtime,
+                    migration_id,
+                ))),
                 running_state: None,
                 nexus_client,
                 available_datasets_rx,

--- a/sled-agent/src/instance.rs
+++ b/sled-agent/src/instance.rs
@@ -53,6 +53,7 @@ use std::net::SocketAddr;
 use std::ops::ControlFlow;
 use std::pin::Pin;
 use std::sync::Arc;
+use std::sync::RwLock;
 use std::time::Duration;
 use tokio::sync::{mpsc, oneshot};
 use uuid::Uuid;
@@ -225,9 +226,6 @@ enum InstanceRequest {
     GetFilesystemPool {
         tx: oneshot::Sender<Result<Option<ZpoolName>, ManagerError>>,
     },
-    CurrentState {
-        tx: oneshot::Sender<Result<SledVmmState, ManagerError>>,
-    },
     PutState {
         state: VmmStateRequested,
         tx: oneshot::Sender<Result<VmmPutStateResponse, ManagerError>>,
@@ -305,9 +303,6 @@ impl InstanceRequest {
 
         match this {
             Self::GetFilesystemPool { tx } => tx
-                .send(Err(error.into()))
-                .map_err(|_| Error::FailedSendClientClosed),
-            Self::CurrentState { tx } => tx
                 .send(Err(error.into()))
                 .map_err(|_| Error::FailedSendClientClosed),
             Self::PutState { tx, .. } => tx
@@ -569,7 +564,7 @@ struct InstanceRunner {
     dhcp_config: DhcpCfg,
 
     // Internal State management
-    state: InstanceStates,
+    state: Arc<RwLock<InstanceStates>>,
     running_state: Option<RunningState>,
 
     // Connection to Nexus
@@ -660,7 +655,7 @@ impl InstanceRunner {
                     // Note that this timeout is only implicated when Nexus
                     // asks to stop an instance (it is not enabled when someone
                     // forcibly terminates a VM).
-                    self.state.force_state_to_destroyed();
+                    self.state.write().unwrap().force_state_to_destroyed();
                     self.terminate().await;
                     break;
                 }
@@ -712,10 +707,6 @@ impl InstanceRunner {
                         match request {
                             GetFilesystemPool { tx } => {
                                 tx.send(Ok(self.get_filesystem_zpool()))
-                                    .map_err(|_| Error::FailedSendClientClosed)
-                            },
-                            CurrentState{ tx } => {
-                                tx.send(Ok(self.current_state()))
                                     .map_err(|_| Error::FailedSendClientClosed)
                             },
                             PutState { state, tx } => {
@@ -829,15 +820,16 @@ impl InstanceRunner {
         // whereas incorrectly removing one VMM from the table will affect only
         // that VMM (and even that VMM's instance will get back on track when
         // Nexus realizes what has happened).
-        if !self.state.vmm_is_halted() {
+        let state = self.state.read().unwrap().clone();
+        if !state.vmm_is_halted() {
             error!(
                 self.log,
                 "instance runner exiting with VMM in non-terminal state";
-                "state" => ?self.current_state()
+                "state" => ?state.sled_instance_state(),
             );
 
             // Assert in tests, at least.
-            debug_assert!(self.state.vmm_is_halted());
+            debug_assert!(state.vmm_is_halted());
         } else {
             info!(self.log, "instance runner exited main loop");
         }
@@ -867,9 +859,6 @@ impl InstanceRunner {
             // the queue,
             let _ = match request {
                 GetFilesystemPool { tx } => tx.send(Ok(None)).map_err(|_| ()),
-                CurrentState { tx } => {
-                    tx.send(Ok(self.current_state())).map_err(|_| ())
-                }
                 PutState { tx, .. } => {
                     tx.send(Err(Error::Terminating.into())).map_err(|_| ())
                 }
@@ -914,7 +903,9 @@ impl InstanceRunner {
         while let Some(TerminateRequest { tx, .. }) = terminate_rx.recv().await
         {
             let _ = tx.send(Ok(VmmUnregisterResponse {
-                updated_runtime: Some(self.current_state()),
+                updated_runtime: Some(
+                    self.state.read().unwrap().sled_instance_state(),
+                ),
             }));
         }
     }
@@ -932,7 +923,7 @@ impl InstanceRunner {
         let result = backoff::retry_notify(
             backoff::retry_policy_internal_service(),
             || async {
-                let state = self.state.sled_instance_state();
+                let state = self.state.read().unwrap().sled_instance_state();
                 info!(self.log, "Publishing instance state update to Nexus";
                     "instance_id" => %self.instance_id(),
                     "propolis_id" => %self.propolis_id,
@@ -1018,12 +1009,13 @@ impl InstanceRunner {
         let InstanceMonitorMessage { update, tx } = request;
         let response = match update {
             InstanceMonitorUpdate::State(state) => {
-                self.observe_state(&ObservedPropolisState::new(&state));
+                let new =
+                    self.observe_state(&ObservedPropolisState::new(&state));
 
                 // If Propolis still has an active VM, just publish this state
                 // update and resume normal operation. Otherwise, go through the
                 // Propolis teardown sequence.
-                if !self.state.vmm_is_halted() {
+                if !new.vmm_is_halted() {
                     self.publish_state_to_nexus().await;
                     ControlFlow::Continue(())
                 } else {
@@ -1081,7 +1073,10 @@ impl InstanceRunner {
 
     /// Processes a Propolis state change observed by the Propolis monitoring
     /// task.
-    fn observe_state(&mut self, state: &ObservedPropolisState) {
+    fn observe_state(
+        &mut self,
+        state: &ObservedPropolisState,
+    ) -> InstanceStates {
         info!(self.log, "observed new Propolis state"; "state" => ?state);
 
         // This shouldn't happen: the monitor can't observe anything before a
@@ -1096,13 +1091,18 @@ impl InstanceRunner {
         //     return;
         // }
 
-        self.state.apply_propolis_observation(state);
+        let next_state = {
+            let mut current = self.state.write().unwrap();
+            current.apply_propolis_observation(state);
+            (&*current).clone()
+        };
         info!(
             self.log,
             "updated state after observing Propolis state change";
             "propolis_id" => %self.propolis_id,
-            "new_vmm_state" => ?self.state.vmm()
+            "new_vmm_state" => ?next_state.vmm()
         );
+        next_state
     }
 
     /// Sends an instance state PUT request to this instance's Propolis.
@@ -1172,6 +1172,8 @@ impl InstanceRunner {
             // instead of unwrapping if it's violated.
             let migration_id = self
                 .state
+                .read()
+                .unwrap()
                 .migration_in()
                 .ok_or_else(|| {
                     Error::Migration(anyhow::anyhow!(
@@ -1781,6 +1783,8 @@ pub struct Instance {
     /// over all other requests to the instance.
     terminate_tx: mpsc::Sender<TerminateRequest>,
 
+    state: Arc<RwLock<InstanceStates>>,
+
     /// This is reference-counted so that the `Instance` struct may be cloned.
     #[allow(dead_code)]
     runner_handle: Arc<tokio::task::JoinHandle<()>>,
@@ -1893,6 +1897,11 @@ impl Instance {
         // the `InstanceRunner`) and awaiting a termination request.
         let (terminate_tx, terminate_rx) = mpsc::channel(QUEUE_SIZE);
 
+        let state = Arc::new(RwLock::new(InstanceStates::new(
+            vmm_runtime,
+            migration_id,
+        )));
+
         let metadata = propolis_client::instance_spec::InstanceMetadata {
             project_id: metadata.project_id,
             silo_id: metadata.silo_id,
@@ -1925,7 +1934,7 @@ impl Instance {
             multicast_groups: local_config.multicast_groups,
             firewall_rules: local_config.firewall_rules,
             dhcp_config,
-            state: InstanceStates::new(vmm_runtime, migration_id),
+            state: state.clone(),
             running_state: None,
             nexus_client,
             available_datasets_rx,
@@ -1945,6 +1954,7 @@ impl Instance {
             tx,
             runner_handle: Arc::new(runner_handle),
             terminate_tx,
+            state,
         })
     }
 
@@ -1965,9 +1975,8 @@ impl Instance {
         &self,
         tx: oneshot::Sender<Result<SledVmmState, ManagerError>>,
     ) -> Result<(), Error> {
-        self.tx
-            .try_send(InstanceRequest::CurrentState { tx })
-            .or_else(InstanceRequest::fail_try_send)
+        let state = self.state.read().unwrap().sled_instance_state();
+        tx.send(Ok(state)).map_err(|_| Error::FailedSendClientClosed)
     }
 
     /// Attempts to update the current state of the instance by launching a
@@ -2148,10 +2157,6 @@ impl InstanceRunner {
         }
     }
 
-    fn current_state(&self) -> SledVmmState {
-        self.state.sled_instance_state()
-    }
-
     /// Idempotently ensures that there is an active Propolis zone and that it
     /// has been asked to create the VM described by this instance struct and
     /// the supplied `migration_params`.
@@ -2248,7 +2253,7 @@ impl InstanceRunner {
                 // which is what it would have reached if it *had* existed and
                 // then stopped in an orderly manner.
                 if self.running_state.is_none() {
-                    self.state.force_state_to_destroyed();
+                    self.state.write().unwrap().force_state_to_destroyed();
                     self.terminate().await;
                     (None, None)
                 } else {
@@ -2303,7 +2308,11 @@ impl InstanceRunner {
                         // chosen above. (Note that returning `Ok` here means it
                         // is possible for a state change operation to "succeed"
                         // even though the outcome is a failed instance.)
-                        return Ok(self.state.sled_instance_state());
+                        return Ok(self
+                            .state
+                            .read()
+                            .unwrap()
+                            .sled_instance_state());
                     }
                     _ => {
                         return Err(Error::Propolis(e));
@@ -2312,9 +2321,9 @@ impl InstanceRunner {
             }
         }
         if let Some(s) = next_published {
-            self.state.transition_vmm(s, Utc::now());
+            self.state.write().unwrap().transition_vmm(s, Utc::now());
         }
-        Ok(self.state.sled_instance_state())
+        Ok(self.state.read().unwrap().sled_instance_state())
     }
 
     /// Sets up the Propolis zone that will host this instance's virtual
@@ -2494,7 +2503,9 @@ impl InstanceRunner {
                 self.fail_vmm_and_terminate().await;
                 let result = tx
                     .send(Ok(VmmUnregisterResponse {
-                        updated_runtime: Some(self.state.sled_instance_state()),
+                        updated_runtime: Some(
+                            self.state.read().unwrap().sled_instance_state(),
+                        ),
                     }))
                     .map_err(|_| Error::FailedSendClientClosed);
                 if let Err(err) = result {
@@ -2547,7 +2558,7 @@ impl InstanceRunner {
     /// Forcibly moves this VMM to the Failed state, then goes through the
     /// runner termination sequence.
     async fn fail_vmm_and_terminate(&mut self) {
-        self.state.force_state_to_failed();
+        self.state.write().unwrap().force_state_to_failed();
         self.terminate().await;
     }
 

--- a/sled-agent/src/sim/collection.rs
+++ b/sled-agent/src/sim/collection.rs
@@ -233,9 +233,10 @@ impl<S: Simulatable + 'static> SimCollection<S> {
     /// is `SimMode::Api).
     pub async fn sim_poke(&self, id: Uuid, mode: PokeMode) {
         let mut should_step = true;
+        let mut should_destroy = false;
 
         while should_step {
-            let (new_state, to_destroy) = {
+            let new_state = {
                 // The object must be present in `objects` because it only gets
                 // removed when it comes to rest in the "Destroyed" state, but
                 // we can only get here if there's an asynchronous state
@@ -261,11 +262,11 @@ impl<S: Simulatable + 'static> SimCollection<S> {
                     info!(&self.log, "object is ready to destroy";
                           "object_id" => %id);
 
-                    (after, Some(object))
-                } else {
-                    objects.insert(id, object);
-                    (after, None)
+                    should_destroy = true;
                 }
+
+                objects.insert(id, object);
+                after
             };
 
             // Notify Nexus that the object's state has changed.
@@ -281,7 +282,14 @@ impl<S: Simulatable + 'static> SimCollection<S> {
             // TODO-correctness Is it a problem that nobody
             // waits on the background task?  If we did it here, we'd deadlock,
             // since we're invoked from the background task.
-            if let Some(destroyed_object) = to_destroy {
+            if should_destroy {
+                let destroyed_object = {
+                    let mut objects = self.objects.lock().await;
+
+                    info!(&self.log, "removing destroyed object";
+                          "object_id" => %id);
+                    objects.remove(&id).unwrap()
+                };
                 if let Some(mut tx) = destroyed_object.channel_tx {
                     tx.close_channel();
                 }


### PR DESCRIPTION
In order to be able to make changes to the sled-agent API's VMM state types, they must be able to participate in API versioning. Presently, these types cannot, as they appear in both the server-side-versioned sled-agent API (which is fine), and the client-side-versioned Nexus internal API (which is not fine, as the Nexus API is client-side versioned, and client-side versioning is not a real thing yet). In #10290, I described this problem in greater detail, and proposed a solution: we change the flow of VMM state data between Nexus and sled-agent so that the VMM state information is *only* transferred via a sled-agent API of which Nexus is a client, rather than being sent in both sled-agent responses to Nexus requests *and* in sled-agent requests to Nexus. 

In the current code, sled-agent calls Nexus' `cpapi_instances_put` endpoint to send Nexus a new VMM state in the request body. In #10303, I described changing this so that it is instead simply treated as a "doorbell" notification from the sled-agent that the instance's state has changed, and that Nexus will then handle the doorbell by requesting the current state from the sled-agent. This PR makes that change. Now, Nexus will ignore the `SledVmmState` body sent in `cpapi_instances_put` and then request the current state from the sled-agent. This makes it fine to have the client-side-versioned Nexus API always take the `v1` version of `SledVmmState`, because it doesn't actually look at it. Subsequently, we will introduce a new API which does not take a body at all, and both the new API and the current one will call into the same code path in Nexus.

In order to do this, it was necessary to change sled-agent so that requests to get a VMM's state no longer go into the single request channel to the VMM's `InstanceRunner` task. I described why this is necessary in [this comment][1], but basically, in the current sled-agent implementation, requests to get the VMM's state are not processed until the state change event from the `InstanceMonitor` task (which watches the Propolis instance state) has finished being processed. Processing the state change involves sending the new state to Nexus, which is retried until a Nexus replica confirms that it has written the new state to CRDB. In the current code, where Nexus' GET request for the current state is not handled until the state change has been completed, the request from Nexus in response to the doorbell ringing will always time out. It is necessary for this to remain synchronous and prevent the sled-agent's state machine from advancing to the next state change until Nexus has acknowledged the current one, or else Nexus may miss state changes. Therefore, I have changed the sled-agent so that the VMM's current state is shared between the `InstanceRunner` task and the `Instance` handle via an `Arc<RwLock<InstanceStates>>`, so that the GET request can read it even while the `InstanceRunner` is doing something else. For more detail on this, see [this comment][2] on #10290, and [this comment on this PR explaining why it's an `RwLock`][3].

[1]: https://github.com/oxidecomputer/omicron/issues/10290#issuecomment-4306116311
[2]: https://github.com/oxidecomputer/omicron/issues/10290#issuecomment-4306116311
[3]: https://github.com/oxidecomputer/omicron/pull/10303#discussion_r3139291747

