### PR TITLE
fm: minimum viable sitrep equality check

### DIFF
--- a/dev-tools/omdb/src/bin/omdb/db/sitrep.rs
+++ b/dev-tools/omdb/src/bin/omdb/db/sitrep.rs
@@ -238,7 +238,8 @@ async fn cmd_db_sitrep_show(
         }
     };
 
-    let fm::Sitrep { metadata, cases, ereports_by_id } = sitrep;
+    let fm::Sitrep { metadata, data: fm::SitrepData { cases, ereports_by_id } } =
+        sitrep;
     let fm::SitrepMetadata {
         id,
         creator_id,

--- a/nexus/db-queries/src/db/datastore/fm.rs
+++ b/nexus/db-queries/src/db/datastore/fm.rs
@@ -437,7 +437,10 @@ impl DataStore {
         let metadata =
             self.fm_sitrep_metadata_read_on_conn(id, &conn).await?.into();
 
-        Ok(Sitrep { metadata, cases, ereports_by_id: ereports })
+        Ok(Sitrep {
+            metadata,
+            data: fm::SitrepData { cases, ereports_by_id: ereports },
+        })
     }
 
     /// Fetch all alert requests belonging to cases in the given sitrep.
@@ -735,12 +738,12 @@ impl DataStore {
         // garbage collection is keyed on sitrep_id (which is inserted first
         // above). If we crash partway through, orphaned child records will be
         // cleaned up when the orphaned sitrep is garbage collected.
-        let mut cases = Vec::with_capacity(sitrep.cases.len());
+        let mut cases = Vec::with_capacity(sitrep.data.cases.len());
         let mut alerts_requested = Vec::new();
         let mut support_bundles_requested = Vec::new();
         let mut bundle_data_selections_requested = Vec::new();
         let mut case_ereports = Vec::new();
-        for case in sitrep.cases {
+        for case in sitrep.data.cases {
             let case_id = case.id;
             cases.push(model::fm::CaseMetadata::from_sitrep(sitrep_id, &case));
             case_ereports.extend(case.ereports.into_iter().map(|ereport| {
@@ -1782,8 +1785,10 @@ mod tests {
                 parent_sitrep_id: None,
                 next_inv_min_time_started: Utc::now(),
             },
-            cases: Default::default(),
-            ereports_by_id: Default::default(),
+            data: fm::SitrepData {
+                cases: Default::default(),
+                ereports_by_id: Default::default(),
+            },
         };
 
         datastore.fm_sitrep_insert(&opctx, sitrep.clone()).await.unwrap();
@@ -1833,8 +1838,10 @@ mod tests {
                 parent_sitrep_id: None,
                 next_inv_min_time_started: Utc::now(),
             },
-            cases: Default::default(),
-            ereports_by_id: Default::default(),
+            data: fm::SitrepData {
+                cases: Default::default(),
+                ereports_by_id: Default::default(),
+            },
         };
         datastore.fm_sitrep_insert(&opctx, sitrep1.clone()).await.unwrap();
 
@@ -1849,8 +1856,10 @@ mod tests {
                 parent_sitrep_id: Some(sitrep1.id()),
                 next_inv_min_time_started: Utc::now(),
             },
-            cases: Default::default(),
-            ereports_by_id: Default::default(),
+            data: fm::SitrepData {
+                cases: Default::default(),
+                ereports_by_id: Default::default(),
+            },
         };
         datastore.fm_sitrep_insert(&opctx, sitrep2.clone()).await.expect(
             "inserting a sitrep whose parent is current should succeed",
@@ -1892,8 +1901,10 @@ mod tests {
                 parent_sitrep_id: None,
                 next_inv_min_time_started: Utc::now(),
             },
-            cases: Default::default(),
-            ereports_by_id: Default::default(),
+            data: fm::SitrepData {
+                cases: Default::default(),
+                ereports_by_id: Default::default(),
+            },
         };
         datastore.fm_sitrep_insert(&opctx, sitrep1.clone()).await.unwrap();
 
@@ -1909,8 +1920,10 @@ mod tests {
                 parent_sitrep_id: Some(nonexistent_id),
                 next_inv_min_time_started: Utc::now(),
             },
-            cases: Default::default(),
-            ereports_by_id: Default::default(),
+            data: fm::SitrepData {
+                cases: Default::default(),
+                ereports_by_id: Default::default(),
+            },
         };
 
         let result = datastore.fm_sitrep_insert(&opctx, sitrep2).await;
@@ -1946,8 +1959,10 @@ mod tests {
                 parent_sitrep_id: None,
                 next_inv_min_time_started: Utc::now(),
             },
-            cases: Default::default(),
-            ereports_by_id: Default::default(),
+            data: fm::SitrepData {
+                cases: Default::default(),
+                ereports_by_id: Default::default(),
+            },
         };
         datastore.fm_sitrep_insert(&opctx, sitrep1.clone()).await.unwrap();
 
@@ -1962,8 +1977,10 @@ mod tests {
                 parent_sitrep_id: Some(sitrep1.id()),
                 next_inv_min_time_started: Utc::now(),
             },
-            cases: Default::default(),
-            ereports_by_id: Default::default(),
+            data: fm::SitrepData {
+                cases: Default::default(),
+                ereports_by_id: Default::default(),
+            },
         };
         datastore.fm_sitrep_insert(&opctx, sitrep2.clone()).await.unwrap();
 
@@ -1979,8 +1996,10 @@ mod tests {
                 parent_sitrep_id: Some(sitrep1.id()),
                 next_inv_min_time_started: Utc::now(),
             },
-            cases: Default::default(),
-            ereports_by_id: Default::default(),
+            data: fm::SitrepData {
+                cases: Default::default(),
+                ereports_by_id: Default::default(),
+            },
         };
         let result = datastore.fm_sitrep_insert(&opctx, sitrep3.clone()).await;
 
@@ -2023,8 +2042,8 @@ mod tests {
         );
 
         // Verify all the expected cases exist in both sitreps
-        assert_eq!(this.cases.len(), that.cases.len());
-        for case in &that.cases {
+        assert_eq!(this.cases().len(), that.cases().len());
+        for case in that.cases() {
             let fm::Case {
                 id,
                 metadata:
@@ -2039,12 +2058,12 @@ mod tests {
                 support_bundles_requested,
             } = case;
             let case_id = id;
-            let Some(expected) = this.cases.get(&case_id) else {
+            let Some(expected) = this.cases().get(&case_id) else {
                 panic!(
                     "assertion failed: left == right\n  \
                     right sitrep contained case {case_id}\n  \
                     left sitrep contains only cases {:?}\n",
-                    this.cases.iter().map(|case| case.id).collect::<Vec<_>>(),
+                    this.cases().iter().map(|case| case.id).collect::<Vec<_>>(),
                 )
             };
             // N.B.: we must assert each bit of the case manually, as ereports
@@ -2310,8 +2329,7 @@ mod tests {
                 parent_sitrep_id: None,
                 next_inv_min_time_started: Utc::now(),
             },
-            cases,
-            ereports_by_id,
+            data: fm::SitrepData { cases, ereports_by_id },
         }
     }
 
@@ -2420,8 +2438,7 @@ mod tests {
                 parent_sitrep_id: None,
                 next_inv_min_time_started: Utc::now(),
             },
-            cases,
-            ereports_by_id: Default::default(),
+            data: fm::SitrepData { cases, ereports_by_id: Default::default() },
         };
 
         datastore
@@ -2472,8 +2489,10 @@ mod tests {
                         inv_collection_id: CollectionUuid::new_v4(),
                         next_inv_min_time_started: Utc::now(),
                     },
-                    cases: Default::default(),
-                    ereports_by_id: Default::default(),
+                    data: fm::SitrepData {
+                        cases: Default::default(),
+                        ereports_by_id: Default::default(),
+                    },
                 },
             )
             .await
@@ -2629,8 +2648,10 @@ mod tests {
                         inv_collection_id: CollectionUuid::new_v4(),
                         next_inv_min_time_started: Utc::now(),
                     },
-                    cases: Default::default(),
-                    ereports_by_id: Default::default(),
+                    data: fm::SitrepData {
+                        cases: Default::default(),
+                        ereports_by_id: Default::default(),
+                    },
                 },
             )
             .await
@@ -2763,8 +2784,10 @@ mod tests {
                 parent_sitrep_id: None,
                 next_inv_min_time_started: Utc::now(),
             },
-            cases: Default::default(),
-            ereports_by_id: Default::default(),
+            data: fm::SitrepData {
+                cases: Default::default(),
+                ereports_by_id: Default::default(),
+            },
         };
         datastore
             .fm_sitrep_insert(opctx, sitrep1)
@@ -3000,8 +3023,10 @@ mod tests {
                 parent_sitrep_id: None,
                 next_inv_min_time_started: Utc::now(),
             },
-            cases: Default::default(),
-            ereports_by_id: Default::default(),
+            data: fm::SitrepData {
+                cases: Default::default(),
+                ereports_by_id: Default::default(),
+            },
         };
         datastore
             .fm_sitrep_insert(opctx, sitrep1)
@@ -3127,8 +3152,10 @@ mod tests {
                 parent_sitrep_id: None,
                 next_inv_min_time_started: Utc::now(),
             },
-            cases: Default::default(),
-            ereports_by_id: Default::default(),
+            data: fm::SitrepData {
+                cases: Default::default(),
+                ereports_by_id: Default::default(),
+            },
         };
         datastore
             .fm_sitrep_insert(opctx, sitrep1)
@@ -3422,8 +3449,10 @@ mod tests {
                         inv_collection_id: CollectionUuid::new_v4(),
                         next_inv_min_time_started: Utc::now(),
                     },
-                    cases: Default::default(),
-                    ereports_by_id: Default::default(),
+                    data: fm::SitrepData {
+                        cases: Default::default(),
+                        ereports_by_id: Default::default(),
+                    },
                 },
             )
             .await

--- a/nexus/fm/src/analysis_input.rs
+++ b/nexus/fm/src/analysis_input.rs
@@ -142,7 +142,7 @@ impl Builder {
         self.new_ereports.extend(ereports.into_iter().filter_map(|ereport| {
             if let Some(sitrep) = parent_sitrep {
                 let id = ereport.id();
-                if sitrep.ereports_by_id.contains_key(&id) {
+                if sitrep.ereports_by_id().contains_key(&id) {
                     self.unmarked_seen_ereports.insert(*id);
                     return None;
                 }
@@ -190,7 +190,7 @@ impl Builder {
         // - The case has been closed, but it contains an ereport which has not
         //   yet been marked as "seen" in the database.
         let mut closed_cases_copied_forward = IdOrdMap::new();
-        for case in parent_sitrep.iter().flat_map(|s| s.cases.iter()) {
+        for case in parent_sitrep.iter().flat_map(|s| s.cases().iter()) {
             if case.is_open() {
                 report.open_cases.insert(case.id, case.metadata.clone());
                 open_cases.insert_unique(case.clone()).expect(
@@ -445,8 +445,7 @@ mod tests {
                     time_created: chrono::Utc::now(),
                     next_inv_min_time_started: inv.time_done,
                 },
-                cases,
-                ereports_by_id,
+                data: fm::SitrepData { cases, ereports_by_id },
             };
             Arc::new((
                 SitrepVersion {
@@ -606,7 +605,7 @@ mod tests {
         eprintln!("{}", report.display_multiline(0));
 
         let open_case1 = output_sitrep
-            .cases
+            .cases()
             .get(&open_case1_id)
             .expect("open case 1 should be in the output sitrep's cases");
         assert!(
@@ -615,7 +614,7 @@ mod tests {
         );
 
         let open_case2 = output_sitrep
-            .cases
+            .cases()
             .get(&open_case2_id)
             .expect("open case 2 should be in the output sitrep's cases");
         assert!(
@@ -624,7 +623,7 @@ mod tests {
         );
 
         let new_case = output_sitrep
-            .cases
+            .cases()
             .get(&new_case_id)
             .expect("new case should be in the output sitrep's cases");
         assert!(
@@ -654,17 +653,19 @@ mod tests {
         );
 
         assert!(
-            output_sitrep.cases.contains_key(&closed_case_with_unmarked_id),
+            output_sitrep.cases().contains_key(&closed_case_with_unmarked_id),
             "closed cases with unmarked ereports should be copied forward \
              into the output sitrep"
         );
         assert!(
-            !output_sitrep.cases.contains_key(&closed_case_without_unmarked_id),
+            !output_sitrep
+                .cases()
+                .contains_key(&closed_case_without_unmarked_id),
             "closed cases WITHOUT unmarked ereports should NOT be copied \
             forward into the output sitrep"
         );
         assert_eq!(
-            output_sitrep.cases.len(),
+            output_sitrep.cases().len(),
             4,
             "the output sitrep should have exactly 4 cases: the open case, \
              the newly-closed case, the closed-but-copied-forward case, and \

--- a/nexus/fm/src/builder.rs
+++ b/nexus/fm/src/builder.rs
@@ -130,8 +130,7 @@ impl<'a> SitrepBuilder<'a> {
                 // inventory collection ended.
                 next_inv_min_time_started: self.inventory.time_done,
             },
-            cases,
-            ereports_by_id,
+            data: fm::SitrepData { cases, ereports_by_id },
         };
         (sitrep, report)
     }

--- a/nexus/src/app/background/tasks/fm_analysis.rs
+++ b/nexus/src/app/background/tasks/fm_analysis.rs
@@ -378,8 +378,10 @@ mod tests {
                     comment: "test sitrep".to_string(),
                     time_created: Utc::now(),
                 },
-                cases: Default::default(),
-                ereports_by_id: Default::default(),
+                data: fm::SitrepData {
+                    cases: Default::default(),
+                    ereports_by_id: Default::default(),
+                },
             },
         ))
     }

--- a/nexus/src/app/background/tasks/fm_analysis.rs
+++ b/nexus/src/app/background/tasks/fm_analysis.rs
@@ -263,21 +263,26 @@ impl FmAnalysis {
             };
         }
 
-        // TODO(eliza): diff the sitrep against the parent, and return
-        // `Unchanged` if it's the same.
-        let unchanged = true;
-        if unchanged {
-            slog::info!(
-                &opctx.log,
-                "fault management analysis produced no changes from the \
-                 current sitrep"
-            );
-            return status::AnalysisStatus {
-                start_time,
-                end_time,
-                report,
-                outcome: status::AnalysisOutcome::Unchanged,
-            };
+        // If the sitrep's data is equal to the parent sitrep, then the
+        // situation has not changed.
+        //
+        // Note that this comparison ignores the sitrep's *metadata*, as the two
+        // sitreps may have different IDs and may have been created by different
+        // Nexus zones at different times.
+        if let Some(parent) = inputs.parent_sitrep() {
+            if parent.data == sitrep.data {
+                slog::info!(
+                    &opctx.log,
+                    "fault management analysis produced no changes from the \
+                     current sitrep"
+                );
+                return status::AnalysisStatus {
+                    start_time,
+                    end_time,
+                    report,
+                    outcome: status::AnalysisOutcome::Unchanged,
+                };
+            }
         }
 
         let sitrep_id = sitrep.id();

--- a/nexus/src/app/background/tasks/fm_rendezvous.rs
+++ b/nexus/src/app/background/tasks/fm_rendezvous.rs
@@ -258,12 +258,12 @@ impl FmRendezvous {
         let (_, ref sitrep) = *sitrep;
         let mut status = EreportMarkingStatus {
             batch_size: BATCH_SIZE,
-            total_ereports_in_sitrep: sitrep.ereports_by_id.len(),
+            total_ereports_in_sitrep: sitrep.ereports_by_id().len(),
             ..EreportMarkingStatus::default()
         };
 
         let mut ereport_ids = sitrep
-            .ereports_by_id
+            .ereports_by_id()
             .iter()
             // it is unfortunately necessary to clone the arc here, for if we do
             // not, the async block in `activate` is not valid for the requisite
@@ -578,8 +578,10 @@ mod tests {
                     time_created: Utc::now(),
                     next_inv_min_time_started: Utc::now(),
                 },
-                cases,
-                ereports_by_id: Default::default(),
+                data: fm::SitrepData {
+                    cases,
+                    ereports_by_id: Default::default(),
+                },
             }
         };
 
@@ -669,8 +671,10 @@ mod tests {
                     time_created: Utc::now(),
                     next_inv_min_time_started: Utc::now(),
                 },
-                cases,
-                ereports_by_id: Default::default(),
+                data: fm::SitrepData {
+                    cases,
+                    ereports_by_id: Default::default(),
+                },
             }
         };
 
@@ -966,8 +970,7 @@ mod tests {
                     time_created: Utc::now(),
                     next_inv_min_time_started: Utc::now(),
                 },
-                cases,
-                ereports_by_id,
+                data: fm::SitrepData { cases, ereports_by_id },
             }
         };
 
@@ -1178,8 +1181,7 @@ mod tests {
                     time_created: Utc::now(),
                     next_inv_min_time_started: Utc::now(),
                 },
-                cases,
-                ereports_by_id,
+                data: fm::SitrepData { cases, ereports_by_id },
             }
         };
 
@@ -1287,8 +1289,7 @@ mod tests {
                     time_created: Utc::now(),
                     next_inv_min_time_started: Utc::now(),
                 },
-                cases,
-                ereports_by_id,
+                data: fm::SitrepData { cases, ereports_by_id },
             }
         };
 
@@ -1485,8 +1486,10 @@ mod tests {
                     time_created: Utc::now(),
                     next_inv_min_time_started: Utc::now(),
                 },
-                cases,
-                ereports_by_id: Default::default(),
+                data: fm::SitrepData {
+                    cases,
+                    ereports_by_id: Default::default(),
+                },
             }
         };
 
@@ -1561,8 +1564,10 @@ mod tests {
                     time_created: Utc::now(),
                     next_inv_min_time_started: Utc::now(),
                 },
-                cases,
-                ereports_by_id: Default::default(),
+                data: fm::SitrepData {
+                    cases,
+                    ereports_by_id: Default::default(),
+                },
             }
         };
 
@@ -1660,8 +1665,10 @@ mod tests {
                     comment: "test sitrep no capacity".to_string(),
                     time_created: Utc::now(),
                 },
-                cases,
-                ereports_by_id: Default::default(),
+                data: fm::SitrepData {
+                    cases,
+                    ereports_by_id: Default::default(),
+                },
             }
         };
 

--- a/nexus/src/app/background/tasks/fm_sitrep_gc.rs
+++ b/nexus/src/app/background/tasks/fm_sitrep_gc.rs
@@ -119,8 +119,10 @@ mod tests {
                 parent_sitrep_id: None,
                 next_inv_min_time_started: Utc::now(),
             },
-            cases: Default::default(),
-            ereports_by_id: Default::default(),
+            data: fm::SitrepData {
+                cases: Default::default(),
+                ereports_by_id: Default::default(),
+            },
         };
         datastore
             .fm_sitrep_insert(&opctx, sitrep1.clone())
@@ -144,8 +146,10 @@ mod tests {
                 parent_sitrep_id: Some(sitrep1.metadata.id),
                 next_inv_min_time_started: Utc::now(),
             },
-            cases: Default::default(),
-            ereports_by_id: Default::default(),
+            data: fm::SitrepData {
+                cases: Default::default(),
+                ereports_by_id: Default::default(),
+            },
         };
         datastore
             .fm_sitrep_insert(&opctx, sitrep2.clone())
@@ -243,8 +247,10 @@ mod tests {
             // `nexus_db_queries::db::datastore::fm` module which ensures that
             // deleting a sitrep removes all the other records associated with
             // it, so it should be safe to trust that this works properly.
-            cases: Default::default(),
-            ereports_by_id: Default::default(),
+            data: fm::SitrepData {
+                cases: Default::default(),
+                ereports_by_id: Default::default(),
+            },
         };
         match datastore.fm_sitrep_insert(&opctx, sitrep).await {
             Ok(_) => {

--- a/nexus/src/app/background/tasks/fm_sitrep_load.rs
+++ b/nexus/src/app/background/tasks/fm_sitrep_load.rs
@@ -192,7 +192,7 @@ mod test {
     use super::*;
     use crate::app::background::BackgroundTask;
     use nexus_db_queries::db::pub_test_utils::TestDatabase;
-    use nexus_types::fm::SitrepMetadata;
+    use nexus_types::fm::{SitrepData, SitrepMetadata};
     use omicron_test_utils::dev;
     use omicron_uuid_kinds::CollectionUuid;
     use omicron_uuid_kinds::OmicronZoneUuid;
@@ -225,8 +225,10 @@ mod test {
                 time_created: Utc::now(),
                 next_inv_min_time_started: Utc::now(),
             },
-            cases: Default::default(),
-            ereports_by_id: Default::default(),
+            data: SitrepData {
+                cases: Default::default(),
+                ereports_by_id: Default::default(),
+            },
         };
         datastore
             .fm_sitrep_insert(&opctx, sitrep1.clone())
@@ -292,8 +294,10 @@ mod test {
                 time_created: Utc::now(),
                 next_inv_min_time_started: Utc::now(),
             },
-            cases: Default::default(),
-            ereports_by_id: Default::default(),
+            data: SitrepData {
+                cases: Default::default(),
+                ereports_by_id: Default::default(),
+            },
         };
         datastore
             .fm_sitrep_insert(&opctx, sitrep2.clone())

--- a/nexus/types/src/fm.rs
+++ b/nexus/types/src/fm.rs
@@ -42,6 +42,66 @@ pub struct Sitrep {
     /// Metadata describing this sitrep, when it was created, its parent sitrep
     /// ID, and which Nexus produced it.
     pub metadata: SitrepMetadata,
+
+    /// The sitrep itself.
+    #[serde(flatten)]
+    pub data: SitrepData,
+}
+
+impl Sitrep {
+    pub fn id(&self) -> SitrepUuid {
+        self.metadata.id
+    }
+
+    pub fn parent_id(&self) -> Option<SitrepUuid> {
+        self.metadata.parent_sitrep_id
+    }
+
+    /// Returns a reference to the cases in this sitrep.
+    pub fn cases(&self) -> &IdOrdMap<Case> {
+        &self.data.cases
+    }
+
+    /// Returns a reference to the ereports-by-id map in this sitrep.
+    pub fn ereports_by_id(&self) -> &IdOrdMap<Arc<Ereport>> {
+        &self.data.ereports_by_id
+    }
+
+    /// Iterate over all the open cases in this sitrep.
+    ///
+    /// All cases returned by this iterator will be copied forward into any
+    /// child sitreps that descend from this one.
+    pub fn open_cases(&self) -> impl Iterator<Item = &Case> + '_ {
+        self.data.cases.iter().filter(|c| c.is_open())
+    }
+
+    /// Iterate over all alerts requested by cases in this sitrep.
+    pub fn alerts_requested(
+        &self,
+    ) -> impl Iterator<Item = (CaseUuid, &'_ AlertRequest)> + '_ {
+        self.data.cases.iter().flat_map(|case| {
+            let case_id = *case.id();
+            case.alerts_requested.iter().map(move |alert| (case_id, alert))
+        })
+    }
+
+    /// Iterate over all support bundles requested by cases in this sitrep.
+    pub fn support_bundles_requested(
+        &self,
+    ) -> impl Iterator<Item = (&Case, &case::SupportBundleRequest)> {
+        self.data.cases.iter().flat_map(|case| {
+            case.support_bundles_requested.iter().map(move |req| (case, req))
+        })
+    }
+}
+
+/// The actual sitrep.
+///
+/// This struct contains the cases and ereports that make up the sitrep's
+/// content, separate from its [`SitrepMetadata`]. This makes it easy to compare
+/// whether two sitreps which have different metadata are otherwise equal.
+#[derive(Clone, Debug, Eq, PartialEq, Deserialize, Serialize)]
+pub struct SitrepData {
     pub cases: IdOrdMap<Case>,
     /// A map of all ereports associated with cases in this sitrep.
     pub ereports_by_id: IdOrdMap<Arc<Ereport>>,
@@ -57,43 +117,6 @@ pub struct Sitrep {
     //
     // Thank you for your cooperation!
     //
-}
-
-impl Sitrep {
-    pub fn id(&self) -> SitrepUuid {
-        self.metadata.id
-    }
-
-    pub fn parent_id(&self) -> Option<SitrepUuid> {
-        self.metadata.parent_sitrep_id
-    }
-
-    /// Iterate over all the open cases in this sitrep.
-    ///
-    /// All cases returned by this iterator will be copied forward into any
-    /// child sitreps that descend from this one.
-    pub fn open_cases(&self) -> impl Iterator<Item = &Case> + '_ {
-        self.cases.iter().filter(|c| c.is_open())
-    }
-
-    /// Iterate over all alerts requested by cases in this sitrep.
-    pub fn alerts_requested(
-        &self,
-    ) -> impl Iterator<Item = (CaseUuid, &'_ AlertRequest)> + '_ {
-        self.cases.iter().flat_map(|case| {
-            let case_id = *case.id();
-            case.alerts_requested.iter().map(move |alert| (case_id, alert))
-        })
-    }
-
-    /// Iterate over all support bundles requested by cases in this sitrep.
-    pub fn support_bundles_requested(
-        &self,
-    ) -> impl Iterator<Item = (&Case, &case::SupportBundleRequest)> {
-        self.cases.iter().flat_map(|case| {
-            case.support_bundles_requested.iter().map(move |req| (case, req))
-        })
-    }
 }
 
 /// Metadata describing a sitrep.

--- a/nexus/types/src/fm.rs
+++ b/nexus/types/src/fm.rs
@@ -98,8 +98,11 @@ impl Sitrep {
 /// The actual sitrep.
 ///
 /// This struct contains the cases and ereports that make up the sitrep's
-/// content, separate from its [`SitrepMetadata`]. This makes it easy to compare
-/// whether two sitreps which have different metadata are otherwise equal.
+/// content, separate from its [`SitrepMetadata`]. This is intended to
+/// facilitate testing whether two sitreps with different metadata are otherwise
+/// equivalent: if the `SitrepData` is equal, then the sitreps represent the
+/// same state of the system, even if they have different IDs or were created by
+/// different Nexii at different times.
 #[derive(Clone, Debug, Eq, PartialEq, Deserialize, Serialize)]
 pub struct SitrepData {
     pub cases: IdOrdMap<Case>,


### PR DESCRIPTION
This branch implements the sitrep equality check that I left unimplemented in #10258. Now, when a new sitrep is generated, we check if it represents the same situation as the parent sitrep, and if it does not, we will insert it into the database. This is done using a normal `PartialEq` implementation. I punted on implementing proper diffing support (see #10259), since it's not actually necessary to test if two sitreps are equivalent.

In order to make this a bit easier to implement correctly, I refactored the `nexus_types::fm::Sitrep` struct to pull the non-metadata fields (the map of ereports and the map of cases, currently) into a new `SitrepData` struct, so that the top-level `Sitrep` now consists of `SitrepMetadata` and `SitrepData`. This is intended to make it easier to implement the comparison we need: checking that the sitrep contains identical cases and ereports to the parent, while ignoring the sitrep's ID, timestamp, and nexus ID (as these will differ for otherwise equal sitreps). I decided to factor out the data into its own struct so that the struct can just derive `PartialEq`, and we can test that the data is equal. This way, we don't have to individually check that the non-metadata fields are equal, which felt error-prone --- we don't want to have to remember to add any new non-metadata fields to the comparison later, since forgetting to do so might result in a non-equal sitrep being accidentally considered unchanged.