### PR TITLE
[nexus] factor out shared code for making MGS clients

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -7333,7 +7333,11 @@ dependencies = [
 name = "nexus-networking"
 version = "0.1.0"
 dependencies = [
+ "anyhow",
  "futures",
+ "gateway-client",
+ "internal-dns-resolver",
+ "internal-dns-types",
  "ipnetwork",
  "nexus-db-lookup",
  "nexus-db-queries",

--- a/dev-tools/ls-apis/tests/api_dependencies.out
+++ b/dev-tools/ls-apis/tests/api_dependencies.out
@@ -51,7 +51,7 @@ Management Gateway Service (client: gateway-client)
     consumed by: dpd (dendrite/dpd) via 1 path
     consumed by: lldpd (lldp/lldpd) via 1 path
     consumed by: mgd (maghemite/mgd) via 1 path
-    consumed by: omicron-nexus (omicron/nexus) via 4 paths
+    consumed by: omicron-nexus (omicron/nexus) via 5 paths
     consumed by: omicron-sled-agent (omicron/sled-agent) via 1 path
     consumed by: wicketd (omicron/wicketd) via 3 paths
 

--- a/nexus/networking/Cargo.toml
+++ b/nexus/networking/Cargo.toml
@@ -11,8 +11,12 @@ workspace = true
 omicron-rpaths.workspace = true
 
 [dependencies]
+anyhow.workspace = true
 futures.workspace = true
+gateway-client.workspace = true
 ipnetwork.workspace = true
+internal-dns-resolver.workspace = true
+internal-dns-types.workspace = true
 nexus-db-lookup.workspace = true
 nexus-db-queries.workspace = true
 omicron-common.workspace = true

--- a/nexus/networking/src/gateway_client.rs
+++ b/nexus/networking/src/gateway_client.rs
@@ -1,0 +1,37 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at https://mozilla.org/MPL/2.0/.
+
+use slog::{Logger, o};
+use std::net::SocketAddrV6;
+
+#[derive(Clone, Debug)]
+pub struct GatewayClient {
+    pub addr: SocketAddrV6,
+    pub client: gateway_client::Client,
+}
+
+impl GatewayClient {
+    pub fn from_addr(log: &Logger, addr: SocketAddrV6) -> Self {
+        let url = format!("http://{addr}");
+        let log = log
+            .new(o!("gateway_url" => url.clone(), "addr" => addr.to_string()));
+        let client = gateway_client::Client::new(&url, log);
+        GatewayClient { addr, client }
+    }
+
+    pub async fn resolve_all_gateways<'l>(
+        log: &'l Logger,
+        resolver: &internal_dns_resolver::Resolver,
+    ) -> Result<impl Iterator<Item = Self> + 'l, anyhow::Error> {
+        let addrs = resolver
+            .lookup_all_socket_v6(
+                internal_dns_types::names::ServiceName::ManagementGatewayService,
+            )
+            .await?;
+
+        anyhow::ensure!(!addrs.is_empty(), "no MGS addresses resolved");
+
+        Ok(addrs.into_iter().map(move |addr| Self::from_addr(log, addr)))
+    }
+}

--- a/nexus/networking/src/lib.rs
+++ b/nexus/networking/src/lib.rs
@@ -6,7 +6,9 @@
 //! tasks or sagas.
 
 mod firewall_rules;
+mod gateway_client;
 mod sled_client;
 
 pub use firewall_rules::*;
+pub use gateway_client::*;
 pub use sled_client::*;

--- a/nexus/src/app/background/tasks/ereport_ingester.rs
+++ b/nexus/src/app/background/tasks/ereport_ingester.rs
@@ -15,9 +15,9 @@ use chrono::Utc;
 use ereport_types::Ena;
 use ereport_types::EreportId;
 use futures::future::BoxFuture;
-use internal_dns_types::names::ServiceName;
 use nexus_db_queries::context::OpContext;
 use nexus_db_queries::db::DataStore;
+use nexus_networking::GatewayClient;
 use nexus_types::fm::ereport::EreportData;
 use nexus_types::internal_api::background::EreporterStatus;
 use nexus_types::internal_api::background::SpEreportIngesterStatus;
@@ -25,8 +25,8 @@ use nexus_types::internal_api::background::SpEreporterStatus;
 use omicron_uuid_kinds::EreporterRestartUuid;
 use omicron_uuid_kinds::OmicronZoneUuid;
 use parallel_task_set::ParallelTaskSet;
+use slog_error_chain::InlineErrorChain;
 use std::collections::BTreeMap;
-use std::net::SocketAddrV6;
 use std::sync::Arc;
 
 pub struct SpEreportIngester {
@@ -89,37 +89,20 @@ impl SpEreportIngester {
         }
         // Find MGS clients.
         // TODO(eliza): reuse the same client across activations; qorb, etc.
-        let mgs_clients = {
-            let lookup = self
-                .resolver
-                .lookup_all_socket_v6(ServiceName::ManagementGatewayService)
-                .await;
-            let addrs = match lookup {
-                Err(error) => {
-                    const MSG: &str = "failed to resolve MGS addresses";
-                    error!(opctx.log, "{MSG}"; "error" => ?error);
-                    status.errors.push(format!("{MSG}: {error}"));
-                    return status;
-                }
-                Ok(addrs) => addrs,
-            };
-
-            addrs
-                .into_iter()
-                .map(|addr| {
-                    let url = format!("http://{addr}");
-                    let log = opctx.log.new(o!("gateway_url" => url.clone()));
-                    let client = gateway_client::Client::new(&url, log);
-                    GatewayClient { addr, client }
-                })
-                .collect::<Arc<[_]>>()
-        };
-
-        if mgs_clients.is_empty() {
-            const MSG: &str = "no MGS addresses resolved";
-            error!(opctx.log, "{MSG}");
-            status.errors.push(MSG.to_string());
-            return status;
+        let mgs_clients = match GatewayClient::resolve_all_gateways(
+            &opctx.log,
+            &self.resolver,
+        )
+        .await
+        {
+            Err(error) => {
+                const MSG: &str = "no MGS successfully returned SP ID list";
+                let error = InlineErrorChain::new(&*error);
+                error!(opctx.log, "{MSG}"; "error" => &error);
+                status.errors.push(format!("{MSG}: {error}"));
+                return status;
+            }
+            Ok(clients) => clients.collect::<Arc<[_]>>(),
         };
 
         // Ask MGS for the list of all present SP identifiers. If a request to
@@ -239,11 +222,6 @@ impl SpEreportIngester {
 
         status
     }
-}
-
-struct GatewayClient {
-    addr: SocketAddrV6,
-    client: gateway_client::Client,
 }
 
 const LIMIT: std::num::NonZeroU32 = match std::num::NonZeroU32::new(255) {

--- a/nexus/src/app/background/tasks/inventory_collection.rs
+++ b/nexus/src/app/background/tasks/inventory_collection.rs
@@ -13,6 +13,7 @@ use internal_dns_types::names::ServiceName;
 use nexus_db_queries::context::OpContext;
 use nexus_db_queries::db::DataStore;
 use nexus_inventory::InventoryError;
+use nexus_networking::GatewayClient;
 use nexus_types::deployment::SledFilter;
 use nexus_types::inventory::Collection;
 use omicron_cockroach_metrics::CockroachClusterAdminClient;
@@ -136,16 +137,9 @@ async fn inventory_activate(
         .context("pruning old collections")?;
 
     // Find MGS clients.
-    let mgs_clients = resolver
-        .lookup_all_socket_v6(ServiceName::ManagementGatewayService)
-        .await
-        .context("looking up MGS addresses")?
-        .into_iter()
-        .map(|sockaddr| {
-            let url = format!("http://{}", sockaddr);
-            let log = opctx.log.new(o!("gateway_url" => url.clone()));
-            gateway_client::Client::new(&url, log)
-        })
+    let mgs_clients = GatewayClient::resolve_all_gateways(&opctx.log, resolver)
+        .await?
+        .map(|GatewayClient { client, .. }| client)
         .collect::<Vec<_>>();
 
     // Find clickhouse-admin-keeper servers if there are any.


### PR DESCRIPTION
This is just an itty-bitty refactor in service of #10275: this almost-identical code for looking up MGS addresses and creating Dropshot clients for talking to them occurs in both the `ereport_ingester` and `inventory_collection` background tasks. In order to implement #10275, we will also similarly want to do this in the `instance_watcher` background task, in order to ask the management gateway whether the sled on which an unreachable sled-agent resides is actually powered on. I didn't want to repeat this a third time, so I thought I might as well throw it in `nexus_networking` instead.

I think that the behavior in `ereport_ingester`, which retries a request with *both* gateways before declaring it to have been unsuccessful, is probably also worth trying to factor out, since I'll want to do that as well. But I haven't done that here because I figured I'd try to pull out the obviously-identical code and worry about the more complex bits after.