### PR TITLE
[sled-agent] remove nexus-lockstep-client conversion

### DIFF
--- a/sled-agent/src/nexus.rs
+++ b/sled-agent/src/nexus.rs
@@ -8,7 +8,6 @@ use internal_dns_types::names::ServiceName;
 use nexus_client::types::SledAgentInfo;
 use omicron_common::address::NEXUS_INTERNAL_PORT;
 use omicron_common::api::external::Generation;
-use omicron_common::disk::DiskVariant;
 use omicron_uuid_kinds::SledUuid;
 use sled_hardware::HardwareManager;
 use slog::Logger;

--- a/sled-agent/src/nexus.rs
+++ b/sled-agent/src/nexus.rs
@@ -54,19 +54,6 @@ pub(crate) trait ConvertInto<T>: Sized {
     fn convert(self) -> T;
 }
 
-impl ConvertInto<nexus_lockstep_client::types::PhysicalDiskKind>
-    for DiskVariant
-{
-    fn convert(self) -> nexus_lockstep_client::types::PhysicalDiskKind {
-        use nexus_lockstep_client::types::PhysicalDiskKind;
-
-        match self {
-            DiskVariant::U2 => PhysicalDiskKind::U2,
-            DiskVariant::M2 => PhysicalDiskKind::M2,
-        }
-    }
-}
-
 impl ConvertInto<nexus_client::types::Baseboard>
     for sled_hardware_types::Baseboard
 {


### PR DESCRIPTION
This conversion seems to be vestigial, and removes the only non-sim sled-agent use.
