### PR TITLE
Prune potential sled reservations that cannot work

### DIFF
--- a/nexus/db-queries/src/db/datastore/sled.rs
+++ b/nexus/db-queries/src/db/datastore/sled.rs
@@ -31,6 +31,7 @@ use crate::db::update_and_check::{UpdateAndCheck, UpdateStatus};
 use async_bb8_diesel::AsyncRunQueryDsl;
 use chrono::Utc;
 use diesel::prelude::*;
+use iddqd::IdOrdMap;
 use nexus_db_errors::ErrorHandler;
 use nexus_db_errors::OptionalError;
 use nexus_db_errors::TransactionError;
@@ -62,7 +63,6 @@ use sled_hardware_types::BaseboardId;
 use slog::Logger;
 use std::cmp::Ordering;
 use std::collections::BinaryHeap;
-use std::collections::HashMap;
 use std::collections::HashSet;
 use std::fmt;
 use strum::IntoEnumIterator;
@@ -367,7 +367,7 @@ impl<'a> CompleteLocalStorageAllocationLists<'a> {
     fn new(
         log: &Logger,
         sled_target: SledUuid,
-        zpools_for_sled: NonEmpty<ZpoolGetForSledReservationResult>,
+        mut zpools_for_sled: IdOrdMap<ZpoolGetForSledReservationResult>,
         local_storage_disks: &'a [LocalStorageDisk],
     ) -> Option<Self> {
         let local_storage_allocation_required: Vec<&LocalStorageDisk> =
@@ -397,12 +397,11 @@ impl<'a> CompleteLocalStorageAllocationLists<'a> {
             })
             .collect();
 
-        let zpools_for_sled: Vec<_> = zpools_for_sled
-            .into_iter()
-            .filter(|zpool_get_result| {
-                !local_storage_zpools_used.contains(&zpool_get_result.pool.id())
-            })
-            .collect();
+        // Do not allow multiple disks backed by local storage to use the same
+        // pool for the same instance.
+        zpools_for_sled.retain(|zpool_get_result| {
+            !local_storage_zpools_used.contains(&zpool_get_result.pool.id())
+        });
 
         if local_storage_allocation_required.len() > zpools_for_sled.len() {
             // Not enough zpools to satisfy the number of allocations required.
@@ -498,15 +497,8 @@ impl<'a> CompleteLocalStorageAllocationLists<'a> {
     /// now shows that there is not enough room.
     pub fn prune_invalidated_allocation_lists(
         &mut self,
-        zpools_for_sled: Vec<ZpoolGetForSledReservationResult>,
+        zpools_for_sled: IdOrdMap<ZpoolGetForSledReservationResult>,
     ) {
-        let zpools_for_sled: HashMap<_, _> = zpools_for_sled
-            .into_iter()
-            .map(|zpool_get_result| {
-                (zpool_get_result.pool.id(), zpool_get_result)
-            })
-            .collect();
-
         self.queue.retain(|incomplete_allocation_list| {
             // An incomplete allocation list has a set of local storage
             // allocations that were matched to zpools with available space:
@@ -1218,20 +1210,15 @@ impl DataStore {
                     .zpool_get_for_sled_reservation(&opctx, sled_target)
                     .await?;
 
-                let zpools_for_sled = match NonEmpty::from_vec(zpools_for_sled)
-                {
-                    Some(zpools_for_sled) => zpools_for_sled,
+                if zpools_for_sled.is_empty() {
+                    warn!(&log, "no zpools for {sled_target:?}?");
 
-                    None => {
-                        warn!(&log, "no zpools for {sled_target:?}?");
+                    sled_targets.remove(&sled_target);
+                    banned.remove(&sled_target);
+                    unpreferred.remove(&sled_target);
+                    preferred.remove(&sled_target);
 
-                        sled_targets.remove(&sled_target);
-                        banned.remove(&sled_target);
-                        unpreferred.remove(&sled_target);
-                        preferred.remove(&sled_target);
-
-                        continue;
-                    }
+                    continue;
                 };
 
                 let mut complete_allocation_lists =

--- a/nexus/db-queries/src/db/datastore/sled.rs
+++ b/nexus/db-queries/src/db/datastore/sled.rs
@@ -62,6 +62,7 @@ use sled_hardware_types::BaseboardId;
 use slog::Logger;
 use std::cmp::Ordering;
 use std::collections::BinaryHeap;
+use std::collections::HashMap;
 use std::collections::HashSet;
 use std::fmt;
 use strum::IntoEnumIterator;
@@ -428,32 +429,15 @@ impl<'a> CompleteLocalStorageAllocationLists<'a> {
             let candidate_datasets: HashSet<CandidateDataset> = zpools_for_sled
                 .iter()
                 .filter(|zpool_get_result| {
-                    let ZpoolGetForSledReservationResult {
-                        pool,
-                        last_inv_total_size,
-                        rendezvous_local_storage_unencrypted_dataset_id: _,
-                        crucible_dataset_usage,
-                        local_storage_usage,
-                    } = zpool_get_result;
-
                     // The total request size for the local storage dataset
                     // allocation is the disk size plus the required
                     // overhead.
                     let request_size: i64 = request.size().to_bytes() as i64
                         + request.required_dataset_overhead().to_bytes() as i64;
 
-                    let new_size_used: i64 = crucible_dataset_usage
-                        + local_storage_usage
-                        + request_size;
-
-                    let control_plane_storage_buffer: i64 =
-                        pool.control_plane_storage_buffer().into();
-                    let adjusted_total: i64 =
-                        last_inv_total_size - control_plane_storage_buffer;
-
                     // Any zpool that has space for this local storage
                     // dataset allocation is considered a candidate.
-                    new_size_used < adjusted_total
+                    zpool_get_result.has_room_for_allocation(request_size)
                 })
                 .map(|zpool_get_result| CandidateDataset {
                     rendezvous_local_storage_unencrypted_dataset_id:
@@ -508,6 +492,62 @@ impl<'a> CompleteLocalStorageAllocationLists<'a> {
         });
 
         Some(Self { log: log.clone(), allocations_to_perform, queue })
+    }
+
+    /// Remove items from the queue if the _current_ size usage for the pools
+    /// now shows that there is not enough room.
+    pub fn prune(
+        &mut self,
+        zpools_for_sled: Vec<ZpoolGetForSledReservationResult>,
+    ) {
+        let zpools_for_sled: HashMap<_, _> = zpools_for_sled
+            .into_iter()
+            .map(|zpool_get_result| {
+                (zpool_get_result.pool.id(), zpool_get_result)
+            })
+            .collect();
+
+        self.queue.retain(|incomplete_allocation_list| {
+            // An incomplete allocation list has a set of local storage
+            // allocations that were matched to zpools with available space:
+            //
+            // | A -> Z | A -> Z | A -> Z |
+            //
+            // Check that each of of these is still valid: this iterator was
+            // constructed from a `ZpoolGetForSledReservationResult` that was
+            // taken previously, and other sled reservations (or crucible
+            // allocations!) may have consumed space that was previously free.
+            // If the sled reservation query was run for one of these
+            // allocations it would always fail.
+            //
+            // Do not retain an incomplete allocation list if any of the
+            // allocations are no longer valid. This also prunes the search
+            // space, as going any further would not make sense.
+
+            for allocation in &incomplete_allocation_list.allocations {
+                match zpools_for_sled.get(&allocation.pool_id) {
+                    Some(zpool_for_sled) => {
+                        // Zpool still exists, does it still have room?
+
+                        if !zpool_for_sled.has_room_for_allocation(
+                            allocation.required_dataset_size,
+                        ) {
+                            // Do not retain this incomplete list of
+                            // allocations: one of them is no longer valid.
+                            return false;
+                        }
+                    }
+
+                    None => {
+                        // Zpool doesn't exist anymore!
+                        return false;
+                    }
+                }
+            }
+
+            // by default, continue searching further
+            true
+        });
     }
 }
 
@@ -1170,8 +1210,9 @@ impl DataStore {
             } else {
                 // If local storage allocation is required, match the requests
                 // with all the zpools of this sled that have available space.
-                // This iterator finds all possible configurations that would
-                // satisfy the requests for local storage and tries them all.
+                // The `CompleteLocalStorageAllocationLists` iterator finds all
+                // possible configurations that would satisfy the requests for
+                // local storage and tries them all.
 
                 let zpools_for_sled = self
                     .zpool_get_for_sled_reservation(&opctx, sled_target)
@@ -1193,7 +1234,7 @@ impl DataStore {
                     }
                 };
 
-                let complete_allocation_lists =
+                let mut complete_allocation_lists =
                     match CompleteLocalStorageAllocationLists::new(
                         &log,
                         sled_target,
@@ -1218,9 +1259,9 @@ impl DataStore {
                         }
                     };
 
-                // Loop here over each complete set of local storage allocations
+                // Search for each complete set of local storage allocations
                 // required, and attempt the sled insert resource query with
-                // that particular allocation.
+                // that particular set.
                 //
                 // If the `complate_allocation_lists` iterator returns None,
                 // control will pass to the end of the loop marked with 'outer,
@@ -1229,7 +1270,35 @@ impl DataStore {
                 // there will _not_ be any more sleds to try and the user will
                 // see a capacity error.
 
-                for allocations in complete_allocation_lists {
+                loop {
+                    // If other concurrent sled reservations are not taken into
+                    // account, another sled reservation could allocate local
+                    // storage onto the same pools that this one considers
+                    // candidates, and then this iterator will return an
+                    // allocation that will never work. Because the iterator
+                    // searches for _every_ possible combination, this will end
+                    // up searching for a long time. It's important to prune the
+                    // list that we're searching from: using the _current_
+                    // results from `zpool_get_for_sled_reservation`, remove
+                    // allocations from the search list if the current free
+                    // space on candidate pools no longer has the required room.
+
+                    let zpools_for_sled = self
+                        .zpool_get_for_sled_reservation(&opctx, sled_target)
+                        .await?;
+
+                    complete_allocation_lists.prune(zpools_for_sled);
+
+                    let allocations = match complete_allocation_lists.next() {
+                        Some(allocations) => allocations,
+
+                        None => {
+                            // All done searching, nothing worked. Try another
+                            // sled!
+                            break;
+                        }
+                    };
+
                     info!(
                         &log,
                         "attempting to insert sled resource record";
@@ -1804,6 +1873,7 @@ pub(in crate::db::datastore) mod test {
     use omicron_uuid_kinds::SledUuid;
     use predicates::{BoxPredicate, prelude::*};
     use sled_agent_types::inventory::ZpoolHealth;
+    use std::collections::BTreeMap;
     use std::collections::HashMap;
     use std::net::SocketAddrV6;
 
@@ -5643,6 +5713,131 @@ pub(in crate::db::datastore) mod test {
                 .unwrap();
 
             vmms.push(vmm);
+        }
+
+        let sleds: HashSet<_> =
+            vmms.into_iter().map(|vmm| vmm.sled_id).collect();
+
+        assert_eq!(sleds.len(), 32);
+
+        validate_local_storage_allocations(&datastore).await;
+
+        db.terminate().await;
+        logctx.cleanup_successful();
+    }
+
+    /// Ensure that a full rack can have one VMM take all the U2s on each sled,
+    /// where the sled reservations happen concurrently in chunks
+    #[tokio::test]
+    async fn local_storage_allocation_full_rack_concurrent() {
+        let logctx = dev::test_setup_log("local_storage_allocation_full_rack");
+        let db = TestDatabase::new_with_datastore(&logctx.log).await;
+        let (opctx, datastore) = (db.opctx(), db.datastore());
+
+        let mut config = LocalStorageTest {
+            sleds: vec![],
+            affinity_groups: vec![],
+            anti_affinity_groups: vec![],
+            instances: vec![],
+        };
+
+        const MAX_U2_PER_INSTANCE: usize = 10;
+
+        for i in 0..32 {
+            let mut u2s = vec![];
+
+            for n in 0..MAX_U2_PER_INSTANCE {
+                u2s.push(LocalStorageTestSledU2 {
+                    physical_disk_id: PhysicalDiskUuid::new_v4(),
+                    physical_disk_serial: format!("phys_{i}_{n}"),
+
+                    zpool_id: ZpoolUuid::new_v4(),
+                    control_plane_storage_buffer:
+                        external::ByteCount::from_gibibytes_u32(250),
+
+                    inventory_total_size:
+                        external::ByteCount::from_gibibytes_u32(1024),
+
+                    crucible_dataset_id: DatasetUuid::new_v4(),
+                    crucible_dataset_addr: format!(
+                        "[fd00:1122:3344:{i}{n:02x}::1]:12345"
+                    )
+                    .parse()
+                    .unwrap(),
+
+                    local_storage_unencrypted_dataset_id: DatasetUuid::new_v4(),
+                });
+            }
+
+            config.sleds.push(LocalStorageTestSled {
+                sled_id: SledUuid::new_v4(),
+                sled_serial: format!("sled_{i}"),
+                u2s,
+            });
+
+            let mut disks = vec![];
+
+            for n in 0..MAX_U2_PER_INSTANCE {
+                disks.push(LocalStorageTestInstanceDisk {
+                    id: Uuid::new_v4(),
+                    name: external::Name::try_from(format!("local-{i}-{n}"))
+                        .unwrap(),
+                    size: external::ByteCount::from_gibibytes_u32(512),
+                });
+            }
+
+            config.instances.push(LocalStorageTestInstance {
+                id: InstanceUuid::new_v4(),
+                name: format!("inst{i}"),
+                affinity: None,
+                disks,
+            });
+        }
+
+        setup_local_storage_allocation_test(&opctx, datastore, &config).await;
+
+        let mut vmms = vec![];
+
+        // Reserve the instances concurrently in chunks - 8 at a time, because
+        // that's the maximum concurrent claims that qorb currently supports.
+        for chunk in config.instances.chunks(8) {
+            let mut jhs = vec![];
+
+            for (i, config_instance) in chunk.iter().enumerate() {
+                let instance = Instance::new_with_id(config_instance.id);
+
+                let datastore = datastore.clone();
+
+                let opctx = opctx.child(BTreeMap::from([(
+                    String::from("task"),
+                    format!("{i}"),
+                )]));
+
+                let jh = tokio::spawn(async move {
+                    let vmm = datastore
+                        .sled_reservation_create_inner(
+                            &opctx,
+                            instance.id,
+                            PropolisUuid::new_v4(),
+                            db::model::Resources::new(
+                                128,
+                                ByteCount::try_from(1024).unwrap(),
+                                ByteCount::try_from(1024).unwrap(),
+                            ),
+                            db::model::SledReservationConstraints::none(),
+                        )
+                        .await
+                        .unwrap();
+                    vmm
+                });
+
+                jhs.push(jh);
+            }
+
+            for jh in jhs {
+                let vmm = jh.await.unwrap();
+                vmms.push(vmm);
+            }
         }
 
         let sleds: HashSet<_> =

--- a/nexus/db-queries/src/db/datastore/sled.rs
+++ b/nexus/db-queries/src/db/datastore/sled.rs
@@ -5814,7 +5814,7 @@ pub(in crate::db::datastore) mod test {
                 )]));
 
                 let jh = tokio::spawn(async move {
-                    let vmm = datastore
+                    datastore
                         .sled_reservation_create_inner(
                             &opctx,
                             instance.id,
@@ -5827,8 +5827,7 @@ pub(in crate::db::datastore) mod test {
                             db::model::SledReservationConstraints::none(),
                         )
                         .await
-                        .unwrap();
-                    vmm
+                        .unwrap()
                 });
 
                 jhs.push(jh);

--- a/nexus/db-queries/src/db/datastore/sled.rs
+++ b/nexus/db-queries/src/db/datastore/sled.rs
@@ -496,7 +496,7 @@ impl<'a> CompleteLocalStorageAllocationLists<'a> {
 
     /// Remove items from the queue if the _current_ size usage for the pools
     /// now shows that there is not enough room.
-    pub fn prune(
+    pub fn prune_invalidated_allocation_lists(
         &mut self,
         zpools_for_sled: Vec<ZpoolGetForSledReservationResult>,
     ) {
@@ -511,7 +511,7 @@ impl<'a> CompleteLocalStorageAllocationLists<'a> {
             // An incomplete allocation list has a set of local storage
             // allocations that were matched to zpools with available space:
             //
-            // | A -> Z | A -> Z | A -> Z |
+            // | allocation -> zpool | allocation -> zpool | ...
             //
             // Check that each of of these is still valid: this iterator was
             // constructed from a `ZpoolGetForSledReservationResult` that was
@@ -1287,16 +1287,14 @@ impl DataStore {
                         .zpool_get_for_sled_reservation(&opctx, sled_target)
                         .await?;
 
-                    complete_allocation_lists.prune(zpools_for_sled);
+                    complete_allocation_lists
+                        .prune_invalidated_allocation_lists(zpools_for_sled);
 
-                    let allocations = match complete_allocation_lists.next() {
-                        Some(allocations) => allocations,
-
-                        None => {
-                            // All done searching, nothing worked. Try another
-                            // sled!
-                            break;
-                        }
+                    let Some(allocations) = complete_allocation_lists.next()
+                    else {
+                        // All done searching, nothing worked. Try another
+                        // sled!
+                        break;
                     };
 
                     info!(
@@ -5618,7 +5616,7 @@ pub(in crate::db::datastore) mod test {
         logctx.cleanup_successful();
     }
 
-    /// Ensure that a full rack can have one VMM take all the U2s on each sled
+    /// Ensure that a full rack can have one VMM take all the U.2s on each sled
     #[tokio::test]
     async fn local_storage_allocation_full_rack() {
         let logctx = dev::test_setup_log("local_storage_allocation_full_rack");
@@ -5726,11 +5724,13 @@ pub(in crate::db::datastore) mod test {
         logctx.cleanup_successful();
     }
 
-    /// Ensure that a full rack can have one VMM take all the U2s on each sled,
+    /// Ensure that a full rack can have one VMM take all the U.2s on each sled,
     /// where the sled reservations happen concurrently in chunks
     #[tokio::test]
     async fn local_storage_allocation_full_rack_concurrent() {
-        let logctx = dev::test_setup_log("local_storage_allocation_full_rack");
+        let logctx = dev::test_setup_log(
+            "local_storage_allocation_full_rack_concurrent",
+        );
         let db = TestDatabase::new_with_datastore(&logctx.log).await;
         let (opctx, datastore) = (db.opctx(), db.datastore());
 

--- a/nexus/db-queries/src/db/datastore/zpool.rs
+++ b/nexus/db-queries/src/db/datastore/zpool.rs
@@ -24,6 +24,7 @@ use async_bb8_diesel::AsyncRunQueryDsl;
 use chrono::Utc;
 use diesel::prelude::*;
 use diesel::upsert::excluded;
+use iddqd::{IdOrdItem, IdOrdMap, id_upcast};
 use nexus_db_errors::ErrorHandler;
 use nexus_db_errors::TransactionError;
 use nexus_db_errors::public_error_from_diesel;
@@ -77,6 +78,16 @@ impl ZpoolGetForSledReservationResult {
 
         new_size_used < adjusted_total_available
     }
+}
+
+impl IdOrdItem for ZpoolGetForSledReservationResult {
+    type Key<'a> = ZpoolUuid;
+
+    fn key(&self) -> Self::Key<'_> {
+        self.pool.id()
+    }
+
+    id_upcast!();
 }
 
 impl DataStore {
@@ -426,7 +437,7 @@ impl DataStore {
         &self,
         opctx: &OpContext,
         sled_id: SledUuid,
-    ) -> ListResultVec<ZpoolGetForSledReservationResult> {
+    ) -> LookupResult<IdOrdMap<ZpoolGetForSledReservationResult>> {
         opctx.authorize(authz::Action::ListChildren, &authz::FLEET).await?;
 
         use nexus_db_schema::schema::crucible_dataset;
@@ -510,7 +521,7 @@ impl DataStore {
                 )
             })?;
 
-        let mut converted = Vec::with_capacity(tuples.len());
+        let mut converted = IdOrdMap::with_capacity(tuples.len());
 
         for tuple in tuples {
             let (
@@ -558,16 +569,22 @@ impl DataStore {
                 continue;
             };
 
-            converted.push(ZpoolGetForSledReservationResult {
-                pool,
-                last_inv_total_size,
-                rendezvous_local_storage_unencrypted_dataset_id:
-                    DatasetUuid::from_untyped_uuid(
-                        rendezvous_local_storage_unencrypted_dataset_id,
-                    ),
-                crucible_dataset_usage: crucible_dataset_usage.into(),
-                local_storage_usage: local_storage_usage.into(),
-            });
+            converted
+                .insert_unique(ZpoolGetForSledReservationResult {
+                    pool,
+                    last_inv_total_size,
+                    rendezvous_local_storage_unencrypted_dataset_id:
+                        DatasetUuid::from_untyped_uuid(
+                            rendezvous_local_storage_unencrypted_dataset_id,
+                        ),
+                    crucible_dataset_usage: crucible_dataset_usage.into(),
+                    local_storage_usage: local_storage_usage.into(),
+                })
+                .map_err(|e| {
+                    Error::internal_error(format!(
+                        "multiple results for the same pool: {e}"
+                    ))
+                })?;
         }
 
         Ok(converted)

--- a/nexus/db-queries/src/db/datastore/zpool.rs
+++ b/nexus/db-queries/src/db/datastore/zpool.rs
@@ -50,16 +50,33 @@ pub struct ZpoolGetForSledReservationResult {
     pub pool: Zpool,
 
     /// Last reported inventory size for the zpool
-    pub last_inv_total_size: i64,
+    last_inv_total_size: i64,
 
     /// The rendezvous local storage dataset (unencrypted) for this zpool
     pub rendezvous_local_storage_unencrypted_dataset_id: DatasetUuid,
 
     /// Upper bound on Crucible dataset usage
-    pub crucible_dataset_usage: i64,
+    crucible_dataset_usage: i64,
 
     /// Upper bound on Local Storage dataset usage
-    pub local_storage_usage: i64,
+    local_storage_usage: i64,
+}
+
+impl ZpoolGetForSledReservationResult {
+    /// Does this Zpool have room for additional bytes to be allocated to it?
+    pub fn has_room_for_allocation(&self, additional_size: i64) -> bool {
+        let new_size_used: i64 = self.crucible_dataset_usage
+            + self.local_storage_usage
+            + additional_size;
+
+        let control_plane_storage_buffer: i64 =
+            self.pool.control_plane_storage_buffer().into();
+
+        let adjusted_total_available: i64 =
+            self.last_inv_total_size - control_plane_storage_buffer;
+
+        new_size_used < adjusted_total_available
+    }
 }
 
 impl DataStore {


### PR DESCRIPTION
Allocating local storage for disks currently occurs during sled reservation: the decision of placing a VMM on a physical sled has to take into account the available storage for disks backed by local storage.

This is done by taking a snapshot of information related to those zpools, figuring out an assignment of requested local storage to those zpools (according to some constraints, like available space), and attempting the sled reservation insert query, which will check that all constraints are met before inserting both the VMM record and the local storage allocations.

For sled reservation where local storage allocations are required, an iterator is created for each sled target that will result in Nexus trying all possible mappings of requested local storage to zpools available for that sled target. Once all possible combinations have been tried, Nexus will try the next potential sled target, or return that the sled reservation cannot succeed.

In the uncontended case, the first attempted sled reservation insert will succeed. In the contended case however, another sled reservation could have succeeded, allocating local storage and invalidating the snapshot taken that the iterator is using to return all potential allocation mappings. Prior to this commit, if no possible allocation mapping will work (such as if all zpools no longer have any space), Nexus will end up trying them all anyway: the iterator was working with out-of-date information. This resulted in `instance-start` sagas that looked stuck, but in reality were just taking a long time exploring all possible permutations.

This commit adds a pruning step: each iteration, Nexus will request a new snapshot of information related to a sled's zpools, and use that to prune the search space of all possible combinations. A test was also added (`local_storage_allocation_full_rack_concurrent`) that successfully reproduced the "stuck" scenario.