### PR TITLE
[fm] Temporarily disable fm_analysis background task

### DIFF
--- a/dev-tools/omdb/tests/env.out
+++ b/dev-tools/omdb/tests/env.out
@@ -112,10 +112,6 @@ task: "external_endpoints"
     on each one
 
 
-task: "fm_analysis"
-    performs fault management analysis and updates the sitrep
-
-
 task: "fm_rendezvous"
     updates externally visible database tables to match the current fault
     management sitrep
@@ -375,10 +371,6 @@ task: "external_endpoints"
     on each one
 
 
-task: "fm_analysis"
-    performs fault management analysis and updates the sitrep
-
-
 task: "fm_rendezvous"
     updates externally visible database tables to match the current fault
     management sitrep
@@ -623,10 +615,6 @@ task: "external_endpoints"
     reads config for silos and TLS certificates to determine the right set of
     HTTP endpoints, their HTTP server names, and which TLS certificates to use
     on each one
-
-
-task: "fm_analysis"
-    performs fault management analysis and updates the sitrep
 
 
 task: "fm_rendezvous"

--- a/dev-tools/omdb/tests/successes.out
+++ b/dev-tools/omdb/tests/successes.out
@@ -347,10 +347,6 @@ task: "external_endpoints"
     on each one
 
 
-task: "fm_analysis"
-    performs fault management analysis and updates the sitrep
-
-
 task: "fm_rendezvous"
     updates externally visible database tables to match the current fault
     management sitrep
@@ -690,29 +686,6 @@ task: "external_endpoints"
         warning: silo ..........<REDACTED_UUID>........... with DNS name "test-suite-silo.sys.oxide-dev.test" has no usable certificates
 
     TLS certificates: 0
-
-task: "fm_analysis"
-  configured period: every <REDACTED_DURATION>m
-  last completed activation: <REDACTED ITERATIONS>, triggered by <TRIGGERED_BY_REDACTED>
-    started at <REDACTED_TIMESTAMP> (<REDACTED DURATION>s ago) and ran for <REDACTED DURATION>ms
-    parent sitrep ID:                None
-    current inventory collection ID: Some(..........<REDACTED_UUID>........... (collection))
-    FAULT MANAGEMENT ANALYSIS SUMMARY
-    =================================
-/!\ analysis failed: FM analysis is not yet implemented
-
-    fault management analysis inputs
-    --------------------------------
-    parent sitrep:        <none>
-    inventory collection: ..........<REDACTED_UUID>...........
-    no new ereports since the parent sitrep
-    no cases copied forward
-
-    fault management analysis report
-    --------------------------------
-    sitrep ID: ..........<REDACTED_UUID>...........
-    no cases changed in this analysis step
-    started at <REDACTED_TIMESTAMP> (<REDACTED DURATION>s ago) and ran for <REDACTED DURATION>ms
 
 task: "fm_rendezvous"
   configured period: every <REDACTED_DURATION>m
@@ -1371,29 +1344,6 @@ task: "external_endpoints"
         warning: silo ..........<REDACTED_UUID>........... with DNS name "test-suite-silo.sys.oxide-dev.test" has no usable certificates
 
     TLS certificates: 0
-
-task: "fm_analysis"
-  configured period: every <REDACTED_DURATION>m
-  last completed activation: <REDACTED ITERATIONS>, triggered by <TRIGGERED_BY_REDACTED>
-    started at <REDACTED_TIMESTAMP> (<REDACTED DURATION>s ago) and ran for <REDACTED DURATION>ms
-    parent sitrep ID:                None
-    current inventory collection ID: Some(..........<REDACTED_UUID>........... (collection))
-    FAULT MANAGEMENT ANALYSIS SUMMARY
-    =================================
-/!\ analysis failed: FM analysis is not yet implemented
-
-    fault management analysis inputs
-    --------------------------------
-    parent sitrep:        <none>
-    inventory collection: ..........<REDACTED_UUID>...........
-    no new ereports since the parent sitrep
-    no cases copied forward
-
-    fault management analysis report
-    --------------------------------
-    sitrep ID: ..........<REDACTED_UUID>...........
-    no cases changed in this analysis step
-    started at <REDACTED_TIMESTAMP> (<REDACTED DURATION>s ago) and ran for <REDACTED DURATION>ms
 
 task: "fm_rendezvous"
   configured period: every <REDACTED_DURATION>m

--- a/nexus/src/app/background/init.rs
+++ b/nexus/src/app/background/init.rs
@@ -107,7 +107,8 @@ use super::tasks::dns_propagation;
 use super::tasks::dns_servers;
 use super::tasks::ereport_ingester;
 use super::tasks::external_endpoints;
-use super::tasks::fm_analysis::{self, FmAnalysis};
+// TODO(#10348): re-enable when fm_analysis is re-registered below.
+// use super::tasks::fm_analysis::{self, FmAnalysis};
 use super::tasks::fm_rendezvous::FmRendezvous;
 use super::tasks::fm_sitrep_gc;
 use super::tasks::fm_sitrep_load;
@@ -1140,30 +1141,34 @@ impl BackgroundTasksInitializer {
             activator: task_fm_sitrep_loader,
         });
 
-        let fm_analysis = FmAnalysis::new(
-            datastore.clone(),
-            sitrep_watcher.clone(),
-            inventory_load_watcher.clone(),
-            fm_analysis::Activators {
-                inventory_loader: task_inventory_loader.clone(),
-                sitrep_loader: task_fm_sitrep_loader.clone(),
-                sitrep_gc: task_fm_sitrep_gc.clone(),
-            },
-            nexus_id,
-        );
-        driver.register(TaskDefinition {
-            name: "fm_analysis",
-            description:
-                "performs fault management analysis and updates the sitrep",
-            period: config.fm.analysis_period_secs,
-            task_impl: Box::new(fm_analysis),
-            opctx: opctx.child(BTreeMap::new()),
-            watchers: vec![
-                Box::new(sitrep_watcher.clone()),
-                Box::new(inventory_load_watcher.clone()),
-            ],
-            activator: task_fm_analysis,
-        });
+        // TODO(#10348): fm_analysis is temporarily disabled. Re-enable
+        // by uncommenting this block and the `use` at the top of this
+        // file.
+        //
+        // let fm_analysis = FmAnalysis::new(
+        //     datastore.clone(),
+        //     sitrep_watcher.clone(),
+        //     inventory_load_watcher.clone(),
+        //     fm_analysis::Activators {
+        //         inventory_loader: task_inventory_loader.clone(),
+        //         sitrep_loader: task_fm_sitrep_loader.clone(),
+        //         sitrep_gc: task_fm_sitrep_gc.clone(),
+        //     },
+        //     nexus_id,
+        // );
+        // driver.register(TaskDefinition {
+        //     name: "fm_analysis",
+        //     description:
+        //         "performs fault management analysis and updates the sitrep",
+        //     period: config.fm.analysis_period_secs,
+        //     task_impl: Box::new(fm_analysis),
+        //     opctx: opctx.child(BTreeMap::new()),
+        //     watchers: vec![
+        //         Box::new(sitrep_watcher.clone()),
+        //         Box::new(inventory_load_watcher.clone()),
+        //     ],
+        //     activator: task_fm_analysis,
+        // });
 
         driver.register(TaskDefinition {
             name: "fm_rendezvous",

--- a/nexus/src/app/background/tasks/fm_analysis.rs
+++ b/nexus/src/app/background/tasks/fm_analysis.rs
@@ -24,6 +24,7 @@ use slog_error_chain::InlineErrorChain;
 use std::sync::Arc;
 use tokio::sync::watch;
 
+#[allow(dead_code)] // TODO(#10348)
 #[derive(Clone)]
 pub struct FmAnalysis {
     datastore: Arc<DataStore>,
@@ -35,6 +36,7 @@ pub struct FmAnalysis {
 
 /// This is just because I don't like it when a constructor takes multiple
 /// positional arguments of the same type...
+#[allow(dead_code)] // TODO(#10348)
 #[derive(Clone)]
 pub struct Activators {
     pub inventory_loader: Activator,
@@ -63,6 +65,7 @@ impl BackgroundTask for FmAnalysis {
     }
 }
 
+#[allow(dead_code)] // TODO(#10348)
 impl FmAnalysis {
     pub fn new(
         datastore: Arc<DataStore>,
@@ -330,6 +333,7 @@ impl FmAnalysis {
     }
 }
 
+#[allow(dead_code)] // TODO(#10348)
 #[derive(Debug, thiserror::Error)]
 enum PreparationError {
     #[error(transparent)]


### PR DESCRIPTION
This PR is coarse-grained, but simple, and provides a solution to https://github.com/oxidecomputer/omicron/issues/10348 that can be cherry-picked easily.

It should be reverted by https://github.com/oxidecomputer/omicron/pull/10349