### PR TITLE
update tufaceous (tough 0.22, rand 0.8.6)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -495,9 +495,9 @@ checksum = "c08606f8c3cbf4ce6ec8e28fb0014a2c086708fe954eaa885384a6165172e7e8"
 
 [[package]]
 name = "aws-lc-rs"
-version = "1.16.0"
+version = "1.16.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d9a7b350e3bb1767102698302bc37256cbd48422809984b98d292c40e2579aa9"
+checksum = "0ec6fb3fe69024a75fa7e1bfb48aa6cf59706a101658ea01bfd33b2b248a038f"
 dependencies = [
  "aws-lc-sys",
  "untrusted 0.7.1",
@@ -506,9 +506,9 @@ dependencies = [
 
 [[package]]
 name = "aws-lc-sys"
-version = "0.37.1"
+version = "0.40.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b092fe214090261288111db7a2b2c2118e5a7f30dc2569f1732c4069a6840549"
+checksum = "f50037ee5e1e41e7b8f9d161680a725bd1626cb6f8c7e901f91f942850852fe7"
 dependencies = [
  "cc",
  "cmake",
@@ -526,7 +526,7 @@ dependencies = [
  "getrandom 0.2.17",
  "instant",
  "pin-project-lite",
- "rand 0.8.5",
+ "rand 0.8.6",
  "tokio",
 ]
 
@@ -827,7 +827,7 @@ dependencies = [
  "omicron-ledger",
  "omicron-workspace-hack",
  "proptest",
- "rand 0.8.5",
+ "rand 0.8.6",
  "secrecy 0.10.3",
  "serde",
  "serde_with",
@@ -2738,7 +2738,7 @@ dependencies = [
  "hex",
  "hickory-proto 0.24.4",
  "ipnet",
- "rand 0.8.5",
+ "rand 0.8.6",
  "thiserror 1.0.69",
  "url",
 ]
@@ -4668,7 +4668,7 @@ dependencies = [
  "idna",
  "ipnet",
  "once_cell",
- "rand 0.8.5",
+ "rand 0.8.6",
  "thiserror 1.0.69",
  "tinyvec",
  "tokio",
@@ -4715,7 +4715,7 @@ dependencies = [
  "lru-cache",
  "once_cell",
  "parking_lot 0.12.5",
- "rand 0.8.5",
+ "rand 0.8.6",
  "resolv-conf",
  "smallvec 1.15.1",
  "thiserror 1.0.69",
@@ -5055,7 +5055,7 @@ dependencies = [
  "hyper",
  "mime_guess",
  "percent-encoding",
- "rand 0.8.5",
+ "rand 0.8.6",
  "tokio",
  "url",
  "winapi",
@@ -7993,7 +7993,7 @@ checksum = "a5e44f723f1133c9deac646763579fdb3ac745e418f2a7af9cd0c431da1f20b9"
 dependencies = [
  "num-integer",
  "num-traits",
- "rand 0.8.5",
+ "rand 0.8.6",
 ]
 
 [[package]]
@@ -8007,7 +8007,7 @@ dependencies = [
  "num-integer",
  "num-iter",
  "num-traits",
- "rand 0.8.5",
+ "rand 0.8.6",
  "serde",
  "smallvec 1.15.1",
  "zeroize",
@@ -9394,7 +9394,7 @@ dependencies = [
  "proc-macro2",
  "proptest",
  "quote",
- "rand 0.8.5",
+ "rand 0.8.6",
  "rand 0.9.2",
  "rand_chacha 0.3.1",
  "rand_chacha 0.9.0",
@@ -9446,6 +9446,7 @@ dependencies = [
  "toml_edit 0.19.15",
  "toml_edit 0.22.27",
  "toml_parser",
+ "tough",
  "tracing",
  "url",
  "usdt 0.6.0",
@@ -10598,7 +10599,7 @@ dependencies = [
  "itertools 0.14.0",
  "proc-macro2",
  "quote",
- "rand 0.8.5",
+ "rand 0.8.6",
 ]
 
 [[package]]
@@ -10742,7 +10743,7 @@ dependencies = [
  "p384",
  "pem-rfc7468",
  "pkcs8",
- "rand 0.8.5",
+ "rand 0.8.6",
  "rsa",
  "sha1",
  "sha2",
@@ -11630,9 +11631,9 @@ dependencies = [
 
 [[package]]
 name = "rand"
-version = "0.8.5"
+version = "0.8.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "34af8d1a0e25924bc5b7c43c079c942339d8f0a8b57c39049bef581b46327404"
+checksum = "5ca0ecfa931c29007047d1bc58e623ab12e5590e8c7cc53200d5202b69266d8a"
 dependencies = [
  "libc",
  "rand_chacha 0.3.1",
@@ -12356,7 +12357,7 @@ dependencies = [
  "p384",
  "p521",
  "poly1305",
- "rand 0.8.5",
+ "rand 0.8.6",
  "rand_core 0.6.4",
  "russh-cryptovec",
  "russh-keys",
@@ -12412,7 +12413,7 @@ dependencies = [
  "pkcs1",
  "pkcs5",
  "pkcs8",
- "rand 0.8.5",
+ "rand 0.8.6",
  "rand_core 0.6.4",
  "rsa",
  "russh-cryptovec",
@@ -14106,7 +14107,7 @@ version = "0.8.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c1c97747dbf44bb1ca44a561ece23508e99cb592e862f22222dcf42f51d1e451"
 dependencies = [
- "heck 0.4.1",
+ "heck 0.5.0",
  "proc-macro2",
  "quote",
  "syn 2.0.117",
@@ -15400,9 +15401,9 @@ checksum = "ea68304e134ecd095ac6c3574494fc62b909f416c4fca77e440530221e549d3d"
 
 [[package]]
 name = "tough"
-version = "0.20.0"
+version = "0.22.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6fe73519c5c485dc0b585088523ad861cda19836b2eb94896fac278db68bd5ab"
+checksum = "8031cff0872dd1c6312370515a6be8098f6ea5512f1bad725016046fc725f272"
 dependencies = [
  "async-recursion",
  "async-trait",
@@ -15825,7 +15826,7 @@ dependencies = [
 [[package]]
 name = "tufaceous"
 version = "0.1.0"
-source = "git+https://github.com/oxidecomputer/tufaceous?branch=main#1eacfcf0cade44f77d433f31744dbee4abb96465"
+source = "git+https://github.com/oxidecomputer/tufaceous?branch=main#a7d440f5a111c7e3504e8eb125c105d7baf0deab"
 dependencies = [
  "anyhow",
  "camino",
@@ -15846,7 +15847,7 @@ dependencies = [
 [[package]]
 name = "tufaceous-artifact"
 version = "0.1.0"
-source = "git+https://github.com/oxidecomputer/tufaceous?branch=main#1eacfcf0cade44f77d433f31744dbee4abb96465"
+source = "git+https://github.com/oxidecomputer/tufaceous?branch=main#a7d440f5a111c7e3504e8eb125c105d7baf0deab"
 dependencies = [
  "daft",
  "hex",
@@ -15863,7 +15864,7 @@ dependencies = [
 [[package]]
 name = "tufaceous-brand-metadata"
 version = "0.1.0"
-source = "git+https://github.com/oxidecomputer/tufaceous?branch=main#1eacfcf0cade44f77d433f31744dbee4abb96465"
+source = "git+https://github.com/oxidecomputer/tufaceous?branch=main#a7d440f5a111c7e3504e8eb125c105d7baf0deab"
 dependencies = [
  "semver 1.0.28",
  "serde",
@@ -15875,7 +15876,7 @@ dependencies = [
 [[package]]
 name = "tufaceous-lib"
 version = "0.1.0"
-source = "git+https://github.com/oxidecomputer/tufaceous?branch=main#1eacfcf0cade44f77d433f31744dbee4abb96465"
+source = "git+https://github.com/oxidecomputer/tufaceous?branch=main#a7d440f5a111c7e3504e8eb125c105d7baf0deab"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -15896,7 +15897,7 @@ dependencies = [
  "indent_write",
  "itertools 0.13.0",
  "parse-size",
- "rand 0.8.5",
+ "rand 0.8.6",
  "semver 1.0.28",
  "serde",
  "serde_json",
@@ -15936,7 +15937,7 @@ dependencies = [
  "http",
  "httparse",
  "log",
- "rand 0.8.5",
+ "rand 0.8.6",
  "sha1",
  "thiserror 1.0.69",
  "url",
@@ -15955,7 +15956,7 @@ dependencies = [
  "http",
  "httparse",
  "log",
- "rand 0.8.5",
+ "rand 0.8.6",
  "sha1",
  "thiserror 1.0.69",
  "utf-8",
@@ -16556,7 +16557,7 @@ dependencies = [
  "curve25519-dalek",
  "elliptic-curve",
  "hex",
- "rand 0.8.5",
+ "rand 0.8.6",
  "rand_chacha 0.3.1",
  "rand_core 0.6.4",
  "serde",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -731,7 +731,7 @@ proptest = "1.7.0"
 qorb = "0.4.1"
 quote = "1.0"
 # Some dependencies still require rand 0.8.x.
-rand08 = { package = "rand", version = "0.8.5" }
+rand08 = { package = "rand", version = "0.8.6" }
 rand = "0.9.2"
 rand_core = "0.9.3"
 rand_distr = "0.5.1"
@@ -846,7 +846,7 @@ tokio-tungstenite = "0.23.1"
 tokio-util = { version = "0.7.15", features = ["io", "io-util", "time"] }
 toml = "0.8.23"
 toml_edit = "0.22.27"
-tough = { version = "0.20.0", features = [ "http" ] }
+tough = { version = "0.22.0" }
 transceiver-controller = { git = "https://github.com/oxidecomputer/transceiver-control", features = [ "api-traits" ] }
 transient-dns-server = { path = "dns-server/transient" }
 trybuild = "1.0.106"

--- a/workspace-hack/Cargo.toml
+++ b/workspace-hack/Cargo.toml
@@ -21,7 +21,6 @@ workspace = true
 ahash = { version = "0.8.12" }
 aho-corasick = { version = "1.1.4" }
 anyhow = { version = "1.0.102", features = ["backtrace"] }
-aws-lc-rs = { version = "1.16.0", features = ["prebuilt-nasm"] }
 base16ct = { version = "0.2.0", default-features = false, features = ["alloc"] }
 base64 = { version = "0.22.1" }
 base64ct = { version = "1.8.3", default-features = false, features = ["std"] }
@@ -106,7 +105,7 @@ proc-macro2 = { version = "1.0.106" }
 proptest = { version = "1.10.0" }
 quote = { version = "1.0.45" }
 rand-274715c4dabd11b0 = { package = "rand", version = "0.9.2" }
-rand-c38e5c1d305a1b54 = { package = "rand", version = "0.8.5" }
+rand-c38e5c1d305a1b54 = { package = "rand", version = "0.8.6" }
 rand_chacha-274715c4dabd11b0 = { package = "rand_chacha", version = "0.9.0", default-features = false, features = ["std"] }
 rand_chacha-468e82937335b1c9 = { package = "rand_chacha", version = "0.3.1", default-features = false, features = ["std"] }
 regex = { version = "1.12.3" }
@@ -150,6 +149,7 @@ toml = { version = "0.7.8" }
 toml_datetime-ca01ad9e24f5d932 = { package = "toml_datetime", version = "0.7.5", features = ["serde"] }
 toml_edit-3c51e837cfc5589a = { package = "toml_edit", version = "0.22.27", features = ["serde"] }
 toml_parser = { version = "1.0.9" }
+tough = { version = "0.22.0", default-features = false, features = ["http"] }
 tracing = { version = "0.1.44", features = ["log"] }
 url = { version = "2.5.8", features = ["serde"] }
 usdt = { version = "0.6.0" }
@@ -167,7 +167,6 @@ zip-3b31131e45eafb45 = { package = "zip", version = "0.6.6", default-features = 
 ahash = { version = "0.8.12" }
 aho-corasick = { version = "1.1.4" }
 anyhow = { version = "1.0.102", features = ["backtrace"] }
-aws-lc-rs = { version = "1.16.0", features = ["prebuilt-nasm"] }
 base16ct = { version = "0.2.0", default-features = false, features = ["alloc"] }
 base64 = { version = "0.22.1" }
 base64ct = { version = "1.8.3", default-features = false, features = ["std"] }
@@ -254,7 +253,7 @@ proc-macro2 = { version = "1.0.106" }
 proptest = { version = "1.10.0" }
 quote = { version = "1.0.45" }
 rand-274715c4dabd11b0 = { package = "rand", version = "0.9.2" }
-rand-c38e5c1d305a1b54 = { package = "rand", version = "0.8.5" }
+rand-c38e5c1d305a1b54 = { package = "rand", version = "0.8.6" }
 rand_chacha-274715c4dabd11b0 = { package = "rand_chacha", version = "0.9.0", default-features = false, features = ["std"] }
 rand_chacha-468e82937335b1c9 = { package = "rand_chacha", version = "0.3.1", default-features = false, features = ["std"] }
 regex = { version = "1.12.3" }
@@ -301,6 +300,7 @@ toml = { version = "0.7.8" }
 toml_datetime-ca01ad9e24f5d932 = { package = "toml_datetime", version = "0.7.5", features = ["serde"] }
 toml_edit-3c51e837cfc5589a = { package = "toml_edit", version = "0.22.27", features = ["serde"] }
 toml_parser = { version = "1.0.9" }
+tough = { version = "0.22.0", default-features = false, features = ["http"] }
 tracing = { version = "0.1.44", features = ["log"] }
 url = { version = "2.5.8", features = ["serde"] }
 usdt = { version = "0.6.0" }
@@ -317,6 +317,7 @@ zip-164d15cefe24d7eb = { package = "zip", version = "4.6.1", default-features = 
 zip-3b31131e45eafb45 = { package = "zip", version = "0.6.6", default-features = false, features = ["bzip2", "deflate"] }
 
 [target.x86_64-unknown-linux-gnu.dependencies]
+aws-lc-rs = { version = "1.16.3", features = ["prebuilt-nasm"] }
 cookie = { version = "0.18.1", default-features = false, features = ["percent-encode"] }
 dof-468e82937335b1c9 = { package = "dof", version = "0.3.0", default-features = false, features = ["des"] }
 dof-9fbad63c4bcf4a8f = { package = "dof", version = "0.4.0", default-features = false, features = ["des"] }
@@ -330,6 +331,7 @@ rustix-dff4ba8e3ae991db = { package = "rustix", version = "1.1.3", features = ["
 tokio-rustls = { version = "0.26.4", default-features = false, features = ["aws-lc-rs"] }
 
 [target.x86_64-unknown-linux-gnu.build-dependencies]
+aws-lc-rs = { version = "1.16.3", features = ["prebuilt-nasm"] }
 cookie = { version = "0.18.1", default-features = false, features = ["percent-encode"] }
 dof-468e82937335b1c9 = { package = "dof", version = "0.3.0", default-features = false, features = ["des"] }
 dof-9fbad63c4bcf4a8f = { package = "dof", version = "0.4.0", default-features = false, features = ["des"] }
@@ -343,6 +345,7 @@ rustix-dff4ba8e3ae991db = { package = "rustix", version = "1.1.3", features = ["
 tokio-rustls = { version = "0.26.4", default-features = false, features = ["aws-lc-rs"] }
 
 [target.x86_64-apple-darwin.dependencies]
+aws-lc-rs = { version = "1.16.3", features = ["prebuilt-nasm"] }
 cookie = { version = "0.18.1", default-features = false, features = ["percent-encode"] }
 errno = { version = "0.3.14" }
 hyper-rustls = { version = "0.27.7", features = ["http2", "ring", "webpki-tokio"] }
@@ -354,6 +357,7 @@ rustix-dff4ba8e3ae991db = { package = "rustix", version = "1.1.3", features = ["
 tokio-rustls = { version = "0.26.4", default-features = false, features = ["aws-lc-rs"] }
 
 [target.x86_64-apple-darwin.build-dependencies]
+aws-lc-rs = { version = "1.16.3", features = ["prebuilt-nasm"] }
 cookie = { version = "0.18.1", default-features = false, features = ["percent-encode"] }
 errno = { version = "0.3.14" }
 hyper-rustls = { version = "0.27.7", features = ["http2", "ring", "webpki-tokio"] }
@@ -365,6 +369,7 @@ rustix-dff4ba8e3ae991db = { package = "rustix", version = "1.1.3", features = ["
 tokio-rustls = { version = "0.26.4", default-features = false, features = ["aws-lc-rs"] }
 
 [target.aarch64-apple-darwin.dependencies]
+aws-lc-rs = { version = "1.16.3", features = ["prebuilt-nasm"] }
 cookie = { version = "0.18.1", default-features = false, features = ["percent-encode"] }
 errno = { version = "0.3.14" }
 hyper-rustls = { version = "0.27.7", features = ["http2", "ring", "webpki-tokio"] }
@@ -376,6 +381,7 @@ rustix-dff4ba8e3ae991db = { package = "rustix", version = "1.1.3", features = ["
 tokio-rustls = { version = "0.26.4", default-features = false, features = ["aws-lc-rs"] }
 
 [target.aarch64-apple-darwin.build-dependencies]
+aws-lc-rs = { version = "1.16.3", features = ["prebuilt-nasm"] }
 cookie = { version = "0.18.1", default-features = false, features = ["percent-encode"] }
 errno = { version = "0.3.14" }
 hyper-rustls = { version = "0.27.7", features = ["http2", "ring", "webpki-tokio"] }
@@ -387,6 +393,7 @@ rustix-dff4ba8e3ae991db = { package = "rustix", version = "1.1.3", features = ["
 tokio-rustls = { version = "0.26.4", default-features = false, features = ["aws-lc-rs"] }
 
 [target.x86_64-unknown-illumos.dependencies]
+aws-lc-rs = { version = "1.16.3", features = ["prebuilt-nasm"] }
 cookie = { version = "0.18.1", default-features = false, features = ["percent-encode"] }
 dof-468e82937335b1c9 = { package = "dof", version = "0.3.0", default-features = false, features = ["des"] }
 dof-9fbad63c4bcf4a8f = { package = "dof", version = "0.4.0", default-features = false, features = ["des"] }
@@ -403,6 +410,7 @@ toml_datetime-3b31131e45eafb45 = { package = "toml_datetime", version = "0.6.11"
 toml_edit-cdcf2f9584511fe6 = { package = "toml_edit", version = "0.19.15", features = ["serde"] }
 
 [target.x86_64-unknown-illumos.build-dependencies]
+aws-lc-rs = { version = "1.16.3", features = ["prebuilt-nasm"] }
 cookie = { version = "0.18.1", default-features = false, features = ["percent-encode"] }
 dof-468e82937335b1c9 = { package = "dof", version = "0.3.0", default-features = false, features = ["des"] }
 dof-9fbad63c4bcf4a8f = { package = "dof", version = "0.4.0", default-features = false, features = ["des"] }


### PR DESCRIPTION
Not Tufaceous v2, but brings tough to the same version that Tufaceous v2 depends on.