### PR TITLE
ci: change `deploy.sh` to programmatically enumerate disks

### DIFF
--- a/.github/buildomat/jobs/deploy.sh
+++ b/.github/buildomat/jobs/deploy.sh
@@ -246,7 +246,15 @@ routeadm -e ipv4-forwarding -u
 PXA_START="$EXTRA_IP_START"
 PXA_END="$EXTRA_IP_END"
 
-pfexec zpool create -f scratch c1t1d0 c2t1d0
+# Enumerate the names of NVMe devices on on which one might place a zpool.
+#
+# N.B. that it is fine to do use "every NVMe device on the box" since this
+# script only runs on buildomat workers which do not have any disks used for
+# storing anything persistently, and which are PXE-booted...so we're not gonna
+# clobber anything that anyone might have cared about on sock and buskin, at
+# least.
+DISKS=( $(pfexec nvmeadm list -p -o disk) )
+pfexec zpool create -f scratch "${DISKS[@]}"
 
 ptime -m \
     pfexec ./target/release/xtask virtual-hardware \


### PR DESCRIPTION
At present, the `deploy.sh` buildomat job hard-codes the disk names `c1t1d0` and `c2t1d0` when creating a scratch zpool. This means that, should the job run on a computer which does not have disks by those names, it will, of course, not work. This is sad because, after `sock` was pulled from the Build-O-Mat worker pool due to a failed disk, the replacement NVMe device shows up with a WWN in its name and therefore breaks the hard-coded assumption. We really should never have been doing that.

Thus, this commit changes it to just list NVMe block device names by invoking `nvmeadm list -p -o disk`, and using the returned block devices to create the scratch zpool. This should work no matter what NVMe devices  @internalincident puts in the two new imminently arriving buildomat workers, too! Yay!

Fixes #10354