### PR TITLE
nexus: allow instance updates to complete when one switch is down

### DIFF
--- a/nexus/src/app/instance_network.rs
+++ b/nexus/src/app/instance_network.rs
@@ -652,7 +652,13 @@ pub(crate) async fn instance_delete_dpd_config(
         instance_id,
     )
     .await;
-    notify_dendrite_nat_state(
+
+    // Just like in `instance_ensure_dpd_config`, we should not bail out if
+    // there is an error while notifying dendrite. If there is an error
+    // communicating with one dendrite instance but the other is operational and
+    // we bail here, it will prevent users from starting an instance. Dendrite
+    // should still catch back up via a RPW if we fail to notify it here.
+    if let Err(error) = notify_dendrite_nat_state(
         datastore,
         log,
         resolver,
@@ -660,6 +666,15 @@ pub(crate) async fn instance_delete_dpd_config(
         Some(instance_id),
     )
     .await
+    {
+        warn!(
+            log,
+            "error encountered while notifying dendrite of deleted instance";
+            "error" => InlineErrorChain::new(&error),
+        );
+    }
+
+    Ok(())
 }
 
 async fn instance_send_attached_subnets_to_dendrite(

--- a/nexus/src/app/instance_network.rs
+++ b/nexus/src/app/instance_network.rs
@@ -656,8 +656,10 @@ pub(crate) async fn instance_delete_dpd_config(
     // Just like in `instance_ensure_dpd_config`, we should not bail out if
     // there is an error while notifying dendrite. If there is an error
     // communicating with one dendrite instance but the other is operational and
-    // we bail here, it will prevent users from starting an instance. Dendrite
-    // should still catch back up via a RPW if we fail to notify it here.
+    // we bail here, it will prevent Nexus from tearing down the VMM's network
+    // config, leaving the instance stuck and preventing it from being restarted
+    // or deleted. Dendrite should still catch back up via a RPW if we fail to
+    // notify it here.
     if let Err(error) = notify_dendrite_nat_state(
         datastore,
         log,

--- a/nexus/src/app/sagas/instance_update/mod.rs
+++ b/nexus/src/app/sagas/instance_update/mod.rs
@@ -2403,6 +2403,7 @@ mod test {
             SwitchSlot::Switch0,
             1,
         )
+        .await
         .unwrap();
         wait_for_n_nat_entries(
             &log,
@@ -2410,6 +2411,7 @@ mod test {
             SwitchSlot::Switch1,
             1,
         )
+        .await
         .unwrap();
 
         // Shutdown switch 0.
@@ -2440,7 +2442,7 @@ mod test {
             &log,
             &switch1_dpd_client,
             SwitchSlot::Switch1,
-            1,
+            0,
         )
         .await
         .unwrap();

--- a/nexus/src/app/sagas/instance_update/mod.rs
+++ b/nexus/src/app/sagas/instance_update/mod.rs
@@ -2583,7 +2583,7 @@ mod test {
             .await
             .expect("switch0 process should get cleaned up");
 
-        // calls to switch0's dpd should fail
+        // Valls to switch0's dpd should fail
         assert!(switch0_dpd_client.dpd_uptime().await.is_err());
 
         // Okay, now that we've taken down one of the simulated switches, we
@@ -2602,7 +2602,52 @@ mod test {
             .await
             .expect("instance update saga did not complete within 60 seconds");
 
+        // Check that the VMM's resources were torn down properly.
         verify_active_vmm_destroyed(&cptestctx, instance_id).await;
+
+        // The still-alive switch should have had the NAT entries for the
+        // destroyed instance removed.
+        poll::wait_for_condition(
+            async || {
+                let dpd1_result = switch1_dpd_client
+                    .nat_ipv4_list(&nat_subnet, None, None)
+                    .await;
+
+                slog::info!(&log,
+                    "nat_ipv4_list";
+                    "dpd1_result" => ?dpd1_result,
+                );
+
+                let dpd1_data = dpd1_result
+                    .map_err(|_| poll::CondCheckError::<()>::NotYet)?;
+                
+                if !dpd1_data.items.is_empty() {
+                    slog::error!(
+                        &log,
+                        "we are expecting no NAT entries on switch1, but we \
+                         found: {:?}",
+                        dpd1_data.items,
+                    );
+                    Err(poll::CondCheckError::<()>::NotYet)
+                } else {
+                    Ok(())
+                }
+            },
+            &poll_interval,
+            &poll_max,
+        )
+        .await
+        .expect("NAT entry should appear on both switches");
+
+        // Ideally we would test that when switch 0 comes back, the desired
+        // state is propagated to it as well, but...since the state we expect is
+        // "no NAT entries", there isn't really a difference between the state
+        // where it has been propagated and the state where it hasn't, because,
+        // well...it's empty either way. So, no use checking that here.
+        //
+        // TODO(eliza): add a test for a migration rather than VMM-destroyed
+        // update, so that we can check that the *new* NAT entries for the
+        // destination vmm are propagated to switch 0 when it comes back.
 
         cptestctx.teardown().await;
     }

--- a/nexus/src/app/sagas/instance_update/mod.rs
+++ b/nexus/src/app/sagas/instance_update/mod.rs
@@ -1546,6 +1546,7 @@ async fn unwind_instance_lock(
 mod test {
     use super::*;
     use crate::app::OpContext;
+    use crate::app::db;
     use crate::app::db::model::Instance;
     use crate::app::db::model::VmmRuntimeState;
     use crate::app::saga::create_saga_dag;
@@ -1554,19 +1555,29 @@ mod test {
     use dropshot::test_util::ClientTestContext;
     use nexus_db_lookup::LookupPath;
     use nexus_db_queries::db::datastore::InstanceAndActiveVmm;
+    use nexus_test_utils;
     use nexus_test_utils::resource_helpers::{
         create_default_ip_pools, create_project, object_create,
     };
     use nexus_test_utils_macros::nexus_test;
-    use nexus_types::external_api::instance as instance_types;
+    use nexus_types::external_api::{
+        instance as instance_types, networking as networking_types,
+    };
     use nexus_types::internal_api::params::InstanceMigrateRequest;
+    use omicron_common::api::external::{
+        ByteCount, DataPageParams, IdentityMetadataCreateParams,
+        InstanceCpuCount, Name,
+    };
+    use omicron_test_utils::dev::poll;
     use omicron_uuid_kinds::GenericUuid;
     use omicron_uuid_kinds::PropolisUuid;
+    use sled_agent_types::early_networking::SwitchSlot;
     use sled_agent_types::instance::{
         MigrationRuntimeState, MigrationState, Migrations,
     };
     use std::sync::Arc;
     use std::sync::Mutex;
+    use std::time::Duration;
     use uuid::Uuid;
 
     type ControlPlaneTestContext =
@@ -1604,9 +1615,6 @@ mod test {
     async fn create_instance(
         client: &ClientTestContext,
     ) -> omicron_common::api::external::Instance {
-        use omicron_common::api::external::{
-            ByteCount, IdentityMetadataCreateParams, InstanceCpuCount,
-        };
         let instances_url = format!("/v1/instances?project={}", PROJECT_NAME);
         object_create(
             client,
@@ -1621,8 +1629,10 @@ mod test {
                 hostname: INSTANCE_NAME.parse().unwrap(),
                 user_data: b"#cloud-config".to_vec(),
                 ssh_public_keys: Some(Vec::new()),
+                // The instance should have one IPv4 NIC in order for the tests
+                // for networking state to work.
                 network_interfaces:
-                    instance_types::InstanceNetworkInterfaceAttachment::None,
+                    instance_types::InstanceNetworkInterfaceAttachment::DefaultIpv4,
                 external_ips: vec![],
                 disks: vec![],
                 boot_disk: None,
@@ -2354,6 +2364,247 @@ mod test {
             .source(MigrationState::Completed, VmmState::Stopping)
             .run_unwinding_test(cptestctx)
             .await;
+    }
+
+    /// Tests that instance update sagas can complete successfully if one switch
+    /// zone is not available.
+    /// This reproduces <https://github.com/oxidecomputer/omicron/issues/10343>
+    #[tokio::test]
+    async fn instance_updates_can_complete_with_dead_switch() {
+        // The setup here is all more or less copied from the
+        // `should_start_with_dead_switch` test in the `instance_start` saga. We
+        // will manually construct the switches so that we can make one of them
+        // go away.
+        let cptestctx = nexus_test_utils::ControlPlaneBuilder::new(
+            "should_start_with_dead_switch",
+        )
+        .with_extra_sled_agents(3)
+        .start::<crate::Server>()
+        .await;
+
+        let nexus = &cptestctx.server.server_context().nexus;
+        let opctx = test_helpers::test_opctx(&cptestctx);
+        let log = &cptestctx.logctx.log;
+
+        let datastore =
+            cptestctx.server.server_context().nexus.datastore().clone();
+
+        // Create uplinks
+        // We only eagerly populate NAT entries on switches that have
+        // uplinks configured, so we need to do some switch configuration
+        // before starting the instance in order to test that section of logic
+        let mut uplink0_params =
+            networking_types::SwitchPortSettingsCreate::new(
+                IdentityMetadataCreateParams {
+                    name: "test-uplink0".parse().unwrap(),
+                    description: "test uplink".into(),
+                },
+            );
+
+        uplink0_params.routes = vec![networking_types::RouteConfig {
+            link_name: "phy0".parse().unwrap(),
+            routes: vec![networking_types::Route {
+                dst: "0.0.0.0/0".parse().unwrap(),
+                gw: "1.1.1.1".parse().unwrap(),
+                vid: None,
+                rib_priority: None,
+            }],
+        }];
+
+        let mut uplink1_params =
+            networking_types::SwitchPortSettingsCreate::new(
+                IdentityMetadataCreateParams {
+                    name: "test-uplink1".parse().unwrap(),
+                    description: "test uplink".into(),
+                },
+            );
+
+        uplink1_params.routes = vec![networking_types::RouteConfig {
+            link_name: "phy0".parse().unwrap(),
+            routes: vec![networking_types::Route {
+                dst: "0.0.0.0/0".parse().unwrap(),
+                gw: "2.2.2.2".parse().unwrap(),
+                vid: None,
+                rib_priority: None,
+            }],
+        }];
+
+        let uplink0_settings = datastore
+            .switch_port_settings_create(&opctx, &uplink0_params, None)
+            .await
+            .expect("should be able to create configuration for uplink0");
+
+        let uplink1_settings = datastore
+            .switch_port_settings_create(&opctx, &uplink1_params, None)
+            .await
+            .expect("should be able to create configuration for uplink1");
+
+        let rack_id = datastore
+            .rack_list(&opctx, &DataPageParams::max_page())
+            .await
+            .unwrap()
+            .pop()
+            .unwrap()
+            .identity
+            .id;
+
+        let uplink0 = datastore
+            .switch_port_get_id(
+                &opctx,
+                rack_id,
+                SwitchSlot::Switch0,
+                Name::try_from("qsfp0".to_string()).unwrap().into(),
+            )
+            .await
+            .expect("there should be a switch port for switch0");
+
+        let uplink1 = datastore
+            .switch_port_get_id(
+                &opctx,
+                rack_id,
+                SwitchSlot::Switch1,
+                Name::try_from("qsfp0".to_string()).unwrap().into(),
+            )
+            .await
+            .expect("there should be a switch port for switch1");
+
+        datastore
+            .switch_port_set_settings_id(
+                &opctx,
+                uplink0,
+                Some(uplink0_settings.settings.id()),
+                db::datastore::UpdatePrecondition::DontCare,
+            )
+            .await
+            .expect("unable to update switch0 settings");
+
+        datastore
+            .switch_port_set_settings_id(
+                &opctx,
+                uplink1,
+                Some(uplink1_settings.settings.id()),
+                db::datastore::UpdatePrecondition::DontCare,
+            )
+            .await
+            .expect("unable to update switch1 settings");
+
+        // Before we make one of the switch zones go away, start a test
+        // instance, and simulate it into the `Running` state so that its
+        // network config is propagated.
+        let _project_id = setup_test_project(&cptestctx.external_client).await;
+        let (state, params) = setup_active_vmm_destroyed_test(&cptestctx).await;
+        let instance_id = state.instance.id();
+
+        fn mk_dpd_client(
+            cptestctx: &ControlPlaneTestContext,
+            switch_slot: SwitchSlot,
+        ) -> dpd_client::Client {
+            let dendrite_guard = cptestctx.dendrite.read().unwrap();
+            let port = dendrite_guard
+                .get(&switch_slot)
+                .expect("two dendrites should be present in test context")
+                .port;
+            let client_state = dpd_client::ClientState {
+                tag: String::from("nexus"),
+                log: cptestctx.logctx.log.new(o!(
+                    "component" => "DpdClient",
+                    "switch" => format!("{switch_slot:?}"),
+                )),
+            };
+
+            let addr = std::net::Ipv6Addr::LOCALHOST;
+
+            dpd_client::Client::new(
+                &format!("http://[{addr}]:{port}"),
+                client_state.clone(),
+            )
+        }
+
+        let switch0_dpd_client = mk_dpd_client(&cptestctx, SwitchSlot::Switch0);
+        let switch1_dpd_client = mk_dpd_client(&cptestctx, SwitchSlot::Switch1);
+
+        // Check to ensure that the nat entry for the address has made it onto
+        // both dendrites. Note: ipv4_nat_trigger_update() triggers dendrite's
+        // RPW asynchronously and returns immediately, but dendrite still needs
+        // time to process the update and create the NAT entries. Tests need to
+        // poll/wait for entries rather than checking immediately, or they'll be
+        // flaky.
+        let nat_subnet = std::net::Ipv4Addr::new(10, 0, 0, 0);
+        let poll_interval = Duration::from_millis(100);
+        let poll_max = Duration::from_secs(60); // Allow time for RPW to process
+
+        poll::wait_for_condition(
+            async || {
+                let dpd0_result = switch0_dpd_client
+                    .nat_ipv4_list(&nat_subnet, None, None)
+                    .await;
+
+                let dpd1_result = switch1_dpd_client
+                    .nat_ipv4_list(&nat_subnet, None, None)
+                    .await;
+
+                slog::info!(&log,
+                    "nat_ipv4_list";
+                    "dpd0_result" => ?dpd0_result,
+                    "dpd1_result" => ?dpd1_result,
+                );
+
+                let dpd0_data = dpd0_result
+                    .map_err(|_| poll::CondCheckError::<()>::NotYet)?;
+                let dpd1_data = dpd1_result
+                    .map_err(|_| poll::CondCheckError::<()>::NotYet)?;
+
+                if dpd0_data.items.is_empty() || dpd1_data.items.is_empty() {
+                    slog::error!(
+                        &log,
+                        "we are expecting NAT entries but none were found"
+                    );
+                    Err(poll::CondCheckError::<()>::NotYet)
+                } else {
+                    Ok(())
+                }
+            },
+            &poll_interval,
+            &poll_max,
+        )
+        .await
+        .expect("NAT entry should appear on both switches");
+
+        // Shutdown one of the switch daemons
+        let mut switch0_dpd = cptestctx
+            .dendrite
+            .write()
+            .unwrap()
+            .remove(&SwitchSlot::Switch0)
+            .expect("switch 0 dendrite running is running");
+
+        switch0_dpd
+            .cleanup()
+            .await
+            .expect("switch0 process should get cleaned up");
+
+        // calls to switch0's dpd should fail
+        assert!(switch0_dpd_client.dpd_uptime().await.is_err());
+
+        // Okay, now that we've taken down one of the simulated switches, we
+        // should be able to run an instance-update saga to destroy the VMM.
+        //
+        // Build the saga DAG with the provided test parameters
+        let real_params = make_real_params(&cptestctx, &opctx, params).await;
+        let dag =
+            create_saga_dag::<SagaDoActualInstanceUpdate>(real_params).unwrap();
+
+        let saga_done =
+            crate::app::sagas::test_helpers::actions_succeed_idempotently(
+                &nexus, dag,
+            );
+        tokio::time::timeout(Duration::from_secs(60), saga_done)
+            .await
+            .expect("instance update saga did not complete within 60 seconds");
+
+        verify_active_vmm_destroyed(&cptestctx, instance_id).await;
+
+        cptestctx.teardown().await;
     }
 
     #[derive(Clone, Copy, Default)]

--- a/nexus/src/app/sagas/instance_update/mod.rs
+++ b/nexus/src/app/sagas/instance_update/mod.rs
@@ -1576,7 +1576,6 @@ mod test {
     use sled_agent_types::instance::{
         MigrationRuntimeState, MigrationState, Migrations,
     };
-    use std::collections::BTreeSet;
     use std::sync::Arc;
     use std::sync::Mutex;
     use std::time::Duration;

--- a/nexus/src/app/sagas/instance_update/mod.rs
+++ b/nexus/src/app/sagas/instance_update/mod.rs
@@ -2791,7 +2791,7 @@ mod test {
             log,
             &switch0_dpd_client,
             SwitchSlot::Switch0,
-            1,
+            1,,
         )
         .await
         .unwrap();

--- a/nexus/src/app/sagas/instance_update/mod.rs
+++ b/nexus/src/app/sagas/instance_update/mod.rs
@@ -1575,6 +1575,7 @@ mod test {
     use sled_agent_types::instance::{
         MigrationRuntimeState, MigrationState, Migrations,
     };
+    use std::collections::BTreeSet;
     use std::sync::Arc;
     use std::sync::Mutex;
     use std::time::Duration;
@@ -2366,33 +2367,13 @@ mod test {
             .await;
     }
 
-    /// Tests that instance update sagas can complete successfully if one switch
-    /// zone is not available.
-    /// This reproduces <https://github.com/oxidecomputer/omicron/issues/10343>
-    #[tokio::test]
-    async fn instance_updates_can_complete_with_dead_switch() {
-        // The setup here is all more or less copied from the
-        // `should_start_with_dead_switch` test in the `instance_start` saga. We
-        // will manually construct the switches so that we can make one of them
-        // go away.
-        let cptestctx = nexus_test_utils::ControlPlaneBuilder::new(
-            "should_start_with_dead_switch",
-        )
-        .with_extra_sled_agents(3)
-        .start::<crate::Server>()
-        .await;
+    // === dead-switch test helpers ===
 
-        let nexus = &cptestctx.server.server_context().nexus;
-        let opctx = test_helpers::test_opctx(&cptestctx);
-        let log = &cptestctx.logctx.log;
-
+    async fn setup_dendrite(cptestctx: &ControlPlaneTestContext) {
+        let opctx = test_helpers::test_opctx(cptestctx);
         let datastore =
             cptestctx.server.server_context().nexus.datastore().clone();
 
-        // Create uplinks
-        // We only eagerly populate NAT entries on switches that have
-        // uplinks configured, so we need to do some switch configuration
-        // before starting the instance in order to test that section of logic
         let mut uplink0_params =
             networking_types::SwitchPortSettingsCreate::new(
                 IdentityMetadataCreateParams {
@@ -2487,6 +2468,156 @@ mod test {
             )
             .await
             .expect("unable to update switch1 settings");
+    }
+
+    fn mk_dpd_client(
+        cptestctx: &ControlPlaneTestContext,
+        switch_slot: SwitchSlot,
+    ) -> dpd_client::Client {
+        let dendrite_guard = cptestctx.dendrite.read().unwrap();
+        let port = dendrite_guard
+            .get(&switch_slot)
+            .expect("dendrite should be present for this switch slot")
+            .port;
+        let client_state = dpd_client::ClientState {
+            tag: String::from("nexus"),
+            log: cptestctx.logctx.log.new(o!(
+                "component" => "DpdClient",
+                "switch" => format!("{switch_slot:?}"),
+            )),
+        };
+        let addr = std::net::Ipv6Addr::LOCALHOST;
+        dpd_client::Client::new(
+            &format!("http://[{addr}]:{port}"),
+            client_state.clone(),
+        )
+    }
+
+    /// The NAT subnet used for polling NAT entries in tests.
+    const NAT_SUBNET: std::net::Ipv4Addr = std::net::Ipv4Addr::new(10, 0, 0, 0);
+
+    /// Poll a switch zone until its NAT entries no longer equal `prior`.
+    async fn wait_for_nat_entries_to_change(
+        log: &slog::Logger,
+        client: &dpd_client::Client,
+        switch: SwitchSlot,
+        prior: &BTreeSet<String>,
+    ) -> BTreeSet<String> {
+        let max_wait = Duration::from_secs(60);
+
+        poll::wait_for_condition(
+            async || {
+                let result =
+                    client.nat_ipv4_list(&NAT_SUBNET, None, None).await;
+
+                slog::info!(log,
+                    "nat_ipv4_list";
+                    "switch" => ?switch,
+                    "result" => ?result,
+                );
+
+                let data =
+                    result.map_err(|_| poll::CondCheckError::<()>::NotYet)?;
+                let current = data.items.iter().map(|entry| {
+                    // I don't love that we are representing the NAT entries as
+                    // strings here, but...we need something which is either
+                    // `Hash + Eq` or `Ord` so that we can put them in sets, and
+                    // the `dpd-client` types don't implement either, so...this
+                    // is fine I Guess.
+                    format!("{entry:?}")
+                }).collect::<BTreeSet<_>>();
+
+                if &current == prior {
+                    slog::info!(
+                        log,
+                        "NAT entries have not changed yet";
+                        "switch" => ?switch,
+                        "current" => ?current,
+                        "prior" => ?prior,
+                    );
+                    return Err(poll::CondCheckError::<()>::NotYet);
+                }
+
+                Ok(current)
+            },
+            &Duration::from_millis(100),
+            &max_wait,
+        )
+        .await
+        .unwrap_or_else(|_| {
+            panic!(
+                "NAT entries on {switch:?} did not change from {prior:?} after {max_wait:?}"
+            )
+        })
+    }
+
+    /// Shut down switch 0's dendrite, returning the port it was listening on.
+    async fn shutdown_switch0(cptestctx: &ControlPlaneTestContext) -> u16 {
+        let mut switch0_dpd = cptestctx
+            .dendrite
+            .write()
+            .unwrap()
+            .remove(&SwitchSlot::Switch0)
+            .expect("switch 0 dendrite should be running");
+
+        let port = switch0_dpd.port;
+
+        switch0_dpd
+            .cleanup()
+            .await
+            .expect("switch0 process should get cleaned up");
+
+        port
+    }
+
+    /// Restart switch 0's dendrite on the given port.
+    async fn restart_switch0(
+        cptestctx: &ControlPlaneTestContext,
+        switch0_port: u16,
+    ) {
+        use std::net::Ipv6Addr;
+        use std::net::SocketAddrV6;
+
+        let nexus_address = cptestctx.internal_client.bind_address;
+        let mgs = cptestctx.gateway.get(&SwitchSlot::Switch0).unwrap();
+        let mgs_address =
+            SocketAddrV6::new(Ipv6Addr::LOCALHOST, mgs.port, 0, 0).into();
+
+        let new_switch0 =
+            omicron_test_utils::dev::dendrite::DendriteInstance::start(
+                switch0_port,
+                Some(nexus_address),
+                Some(mgs_address),
+            )
+            .await
+            .unwrap();
+
+        cptestctx
+            .dendrite
+            .write()
+            .unwrap()
+            .insert(SwitchSlot::Switch0, new_switch0);
+    }
+
+    // === dead-switch tests ===
+
+    /// Tests that instance update sagas can complete successfully if one switch
+    /// zone is not available.
+    /// This reproduces <https://github.com/oxidecomputer/omicron/issues/10343>
+    #[tokio::test]
+    async fn destroyed_update_can_complete_with_dead_switch() {
+        let cptestctx = nexus_test_utils::ControlPlaneBuilder::new(
+            "destroyed_update_can_complete_with_dead_switch",
+        )
+        .with_extra_sled_agents(3)
+        .start::<crate::Server>()
+        .await;
+
+        let nexus = &cptestctx.server.server_context().nexus;
+        let opctx = test_helpers::test_opctx(&cptestctx);
+        let log = &cptestctx.logctx.log;
+
+        setup_dendrite(&cptestctx).await;
 
         // Before we make one of the switch zones go away, start a test
         // instance, and simulate it into the `Running` state so that its
@@ -2495,95 +2626,26 @@ mod test {
         let (state, params) = setup_active_vmm_destroyed_test(&cptestctx).await;
         let instance_id = state.instance.id();
 
-        fn mk_dpd_client(
-            cptestctx: &ControlPlaneTestContext,
-            switch_slot: SwitchSlot,
-        ) -> dpd_client::Client {
-            let dendrite_guard = cptestctx.dendrite.read().unwrap();
-            let port = dendrite_guard
-                .get(&switch_slot)
-                .expect("two dendrites should be present in test context")
-                .port;
-            let client_state = dpd_client::ClientState {
-                tag: String::from("nexus"),
-                log: cptestctx.logctx.log.new(o!(
-                    "component" => "DpdClient",
-                    "switch" => format!("{switch_slot:?}"),
-                )),
-            };
-
-            let addr = std::net::Ipv6Addr::LOCALHOST;
-
-            dpd_client::Client::new(
-                &format!("http://[{addr}]:{port}"),
-                client_state.clone(),
-            )
-        }
-
         let switch0_dpd_client = mk_dpd_client(&cptestctx, SwitchSlot::Switch0);
         let switch1_dpd_client = mk_dpd_client(&cptestctx, SwitchSlot::Switch1);
 
-        // Check to ensure that the nat entry for the address has made it onto
-        // both dendrites. Note: ipv4_nat_trigger_update() triggers dendrite's
-        // RPW asynchronously and returns immediately, but dendrite still needs
-        // time to process the update and create the NAT entries. Tests need to
-        // poll/wait for entries rather than checking immediately, or they'll be
-        // flaky.
-        let nat_subnet = std::net::Ipv4Addr::new(10, 0, 0, 0);
-        let poll_interval = Duration::from_millis(100);
-        let poll_max = Duration::from_secs(60); // Allow time for RPW to process
-
-        poll::wait_for_condition(
-            async || {
-                let dpd0_result = switch0_dpd_client
-                    .nat_ipv4_list(&nat_subnet, None, None)
-                    .await;
-
-                let dpd1_result = switch1_dpd_client
-                    .nat_ipv4_list(&nat_subnet, None, None)
-                    .await;
-
-                slog::info!(&log,
-                    "nat_ipv4_list";
-                    "dpd0_result" => ?dpd0_result,
-                    "dpd1_result" => ?dpd1_result,
-                );
-
-                let dpd0_data = dpd0_result
-                    .map_err(|_| poll::CondCheckError::<()>::NotYet)?;
-                let dpd1_data = dpd1_result
-                    .map_err(|_| poll::CondCheckError::<()>::NotYet)?;
-
-                if dpd0_data.items.is_empty() || dpd1_data.items.is_empty() {
-                    slog::error!(
-                        &log,
-                        "we are expecting NAT entries but none were found"
-                    );
-                    Err(poll::CondCheckError::<()>::NotYet)
-                } else {
-                    Ok(())
-                }
-            },
-            &poll_interval,
-            &poll_max,
+        wait_for_nat_entries_to_change(
+            &log,
+            &switch0_dpd_client,
+            SwitchSlot::Switch0,
+            &BTreeSet::new(),
         )
-        .await
-        .expect("NAT entry should appear on both switches");
+        .await;
+        let switch1_old_nat_entries = wait_for_nat_entries_to_change(
+            &log,
+            &switch1_dpd_client,
+            SwitchSlot::Switch1,
+            &BTreeSet::new(),
+        )
+        .await;
 
-        // Shutdown one of the switch daemons
-        let mut switch0_dpd = cptestctx
-            .dendrite
-            .write()
-            .unwrap()
-            .remove(&SwitchSlot::Switch0)
-            .expect("switch 0 dendrite running is running");
-
-        switch0_dpd
-            .cleanup()
-            .await
-            .expect("switch0 process should get cleaned up");
-
-        // Valls to switch0's dpd should fail
+        // Shutdown switch 0.
+        shutdown_switch0(&cptestctx).await;
         assert!(switch0_dpd_client.dpd_uptime().await.is_err());
 
         // Okay, now that we've taken down one of the simulated switches, we
@@ -2605,49 +2667,138 @@ mod test {
         // Check that the VMM's resources were torn down properly.
         verify_active_vmm_destroyed(&cptestctx, instance_id).await;
 
-        // The still-alive switch should have had the NAT entries for the
-        // destroyed instance removed.
-        poll::wait_for_condition(
-            async || {
-                let dpd1_result = switch1_dpd_client
-                    .nat_ipv4_list(&nat_subnet, None, None)
-                    .await;
-
-                slog::info!(&log,
-                    "nat_ipv4_list";
-                    "dpd1_result" => ?dpd1_result,
-                );
-
-                let dpd1_data = dpd1_result
-                    .map_err(|_| poll::CondCheckError::<()>::NotYet)?;
-                
-                if !dpd1_data.items.is_empty() {
-                    slog::error!(
-                        &log,
-                        "we are expecting no NAT entries on switch1, but we \
-                         found: {:?}",
-                        dpd1_data.items,
-                    );
-                    Err(poll::CondCheckError::<()>::NotYet)
-                } else {
-                    Ok(())
-                }
-            },
-            &poll_interval,
-            &poll_max,
+        // The still-alive switch should have had the NAT entries removed.
+        let new_entries = wait_for_nat_entries_to_change(
+            &log,
+            &switch1_dpd_client,
+            SwitchSlot::Switch1,
+            &switch1_old_nat_entries,
         )
-        .await
-        .expect("NAT entry should appear on both switches");
+        .await;
+        assert!(
+            new_entries.is_empty(),
+            "switch1 NAT entries should be empty, but were: {new_entries:?}",
+        );
 
-        // Ideally we would test that when switch 0 comes back, the desired
-        // state is propagated to it as well, but...since the state we expect is
-        // "no NAT entries", there isn't really a difference between the state
-        // where it has been propagated and the state where it hasn't, because,
-        // well...it's empty either way. So, no use checking that here.
-        //
-        // TODO(eliza): add a test for a migration rather than VMM-destroyed
-        // update, so that we can check that the *new* NAT entries for the
-        // destination vmm are propagated to switch 0 when it comes back.
+        // Since the expected state after destroying a VMM is "no NAT entries",
+        // we can't meaningfully distinguish "propagated" from "never set" on
+        // the dead switch. The migration variant of this test (below) is also
+        // able to assert that the proper state is synced to the dead switch
+        // when it comes back to life.
+
+        cptestctx.teardown().await;
+    }
+
+    /// Tests that instance update sagas for a completed migration can complete
+    /// successfully if one switch zone is not available, and that the NAT
+    /// entries are correctly updated on *both* switches (including the one that
+    /// was restarted) to point at the new sled.
+    #[tokio::test]
+    async fn migration_update_can_complete_with_dead_switch() {
+        let cptestctx = nexus_test_utils::ControlPlaneBuilder::new(
+            "migration_update_can_complete_with_dead_switch",
+        )
+        .with_extra_sled_agents(3)
+        .start::<crate::Server>()
+        .await;
+
+        let nexus = &cptestctx.server.server_context().nexus;
+        let opctx = test_helpers::test_opctx(&cptestctx);
+        let log = &cptestctx.logctx.log;
+
+        setup_dendrite(&cptestctx).await;
+
+        // Create a running instance and start migrating it.
+        setup_test_project(&cptestctx.external_client).await;
+        let migration_test =
+            MigrationTest::setup(MigrationOutcome::default(), &cptestctx).await;
+
+        let switch0_dpd_client = mk_dpd_client(&cptestctx, SwitchSlot::Switch0);
+        let switch1_dpd_client = mk_dpd_client(&cptestctx, SwitchSlot::Switch1);
+
+        // Record the initial NAT entries (pointing at the source sled).
+        let switch0_nat_entries = wait_for_nat_entries_to_change(
+            &log,
+            &switch0_dpd_client,
+            SwitchSlot::Switch0,
+            &BTreeSet::new(),
+        )
+        .await;
+        let switch1_nat_entries = wait_for_nat_entries_to_change(
+            &log,
+            &switch1_dpd_client,
+            SwitchSlot::Switch1,
+            &BTreeSet::new(),
+        )
+        .await;
+        assert_eq!(switch0_nat_entries, switch1_nat_entries);
+        let initial_nat_entries = switch0_nat_entries;
+
+        // Simulate the migration completing.
+        migration_test
+            .update_src_state(
+                &cptestctx,
+                VmmState::Destroyed,
+                MigrationState::Completed,
+            )
+            .await;
+        migration_test
+            .update_target_state(
+                &cptestctx,
+                VmmState::Running,
+                MigrationState::Completed,
+            )
+            .await;
+
+        // Shut down switch 0.
+        let switch0_port = shutdown_switch0(&cptestctx).await;
+        assert!(switch0_dpd_client.dpd_uptime().await.is_err());
+
+        // Run the instance-update saga to complete the migration.
+        let real_params = make_real_params(
+            &cptestctx,
+            &opctx,
+            migration_test.start_saga_params(),
+        )
+        .await;
+        let dag =
+            create_saga_dag::<SagaDoActualInstanceUpdate>(real_params).unwrap();
+
+        let saga_done =
+            crate::app::sagas::test_helpers::actions_succeed_idempotently(
+                &nexus, dag,
+            );
+        tokio::time::timeout(Duration::from_secs(60), saga_done)
+            .await
+            .expect("instance update saga did not complete within 60 seconds");
+
+        // Verify switch 1 has the *updated* NAT entries.
+        let switch1_new_nat_entries = wait_for_nat_entries_to_change(
+            log,
+            &switch1_dpd_client,
+            SwitchSlot::Switch1,
+            &initial_nat_entries,
+        )
+        .await;
+        assert!(
+            !switch1_new_nat_entries.is_empty(),
+            "switch 1 should have updated NAT entries, but they were empty"
+        );
+
+        // Restart switch 0 and verify it also gets the new entries.
+        restart_switch0(&cptestctx, switch0_port).await;
+
+        let switch0_new_nat_entries = wait_for_nat_entries_to_change(
+            log,
+            &switch0_dpd_client,
+            SwitchSlot::Switch0,
+            &initial_nat_entries,
+        )
+        .await;
+        assert_eq!(
+            switch1_new_nat_entries, switch0_new_nat_entries,
+            "new NAT entries should be synced to switch 0"
+        );
 
         cptestctx.teardown().await;
     }

--- a/nexus/src/app/sagas/instance_update/mod.rs
+++ b/nexus/src/app/sagas/instance_update/mod.rs
@@ -1551,6 +1551,7 @@ mod test {
     use crate::app::db::model::VmmRuntimeState;
     use crate::app::saga::create_saga_dag;
     use crate::app::sagas::test_helpers;
+    use anyhow::Context;
     use chrono::Utc;
     use dropshot::test_util::ClientTestContext;
     use nexus_db_lookup::LookupPath;
@@ -2496,13 +2497,15 @@ mod test {
     /// The NAT subnet used for polling NAT entries in tests.
     const NAT_SUBNET: std::net::Ipv4Addr = std::net::Ipv4Addr::new(10, 0, 0, 0);
 
-    /// Poll a switch zone until its NAT entries no longer equal `prior`.
+    /// Poll a switch zone until it has `n` NAT entries, or 60 seconds elapse.
+    /// This returns a `Result` so that it can be `unwrap()`ed and panic with a
+    /// useful source location.
     async fn wait_for_nat_entries_to_change(
         log: &slog::Logger,
         client: &dpd_client::Client,
         switch: SwitchSlot,
-        prior: &BTreeSet<String>,
-    ) -> BTreeSet<String> {
+        n: usize,
+    ) -> anyhow::Result<()> {
         let max_wait = Duration::from_secs(60);
 
         poll::wait_for_condition(
@@ -2516,37 +2519,34 @@ mod test {
                     "result" => ?result,
                 );
 
-                let data =
-                    result.map_err(|_| poll::CondCheckError::<()>::NotYet)?;
-                let current = data.items.iter().map(|entry| {
-                    // I don't love that we are representing the NAT entries as
-                    // strings here, but...we need something which is either
-                    // `Hash + Eq` or `Ord` so that we can put them in sets, and
-                    // the `dpd-client` types don't implement either, so...this
-                    // is fine I Guess.
-                    format!("{entry:?}")
-                }).collect::<BTreeSet<_>>();
-
-                if &current == prior {
+                let data = result.map_err(|_| {
+                    // Use `&'static str` as the permanent error type so that it
+                    // implements `Display`, which is necessary for the
+                    // `poll::Error` to be `Display`...even though we never
+                    // return a `Permanent` error here. I love types.
+                    poll::CondCheckError::<&'static str>::NotYet
+                })?;
+                let len = data.items.len();
+                if len != n {
                     slog::info!(
                         log,
-                        "NAT entries have not changed yet";
+                        "{switch:?} still has {len} NAT entries";
                         "switch" => ?switch,
-                        "current" => ?current,
-                        "prior" => ?prior,
+                        "entries" => ?data.items,
+                        "expected_len" => n,
                     );
-                    return Err(poll::CondCheckError::<()>::NotYet);
+                    return Err(poll::CondCheckError::<&'static str>::NotYet);
                 }
 
-                Ok(current)
+                Ok(())
             },
             &Duration::from_millis(100),
             &max_wait,
         )
         .await
-        .unwrap_or_else(|_| {
-            panic!(
-                "NAT entries on {switch:?} did not change from {prior:?} after {max_wait:?}"
+        .with_context(|| {
+            format!(
+                "{switch:?} did not have {n} NAT entries after {max_wait:?}"
             )
         })
     }
@@ -2629,20 +2629,20 @@ mod test {
         let switch0_dpd_client = mk_dpd_client(&cptestctx, SwitchSlot::Switch0);
         let switch1_dpd_client = mk_dpd_client(&cptestctx, SwitchSlot::Switch1);
 
-        wait_for_nat_entries_to_change(
+        wait_for_n_nat_entries(
             &log,
             &switch0_dpd_client,
             SwitchSlot::Switch0,
-            &BTreeSet::new(),
+            1,
         )
-        .await;
-        let switch1_old_nat_entries = wait_for_nat_entries_to_change(
+        .unwrap();
+        wait_for_n_nat_entries(
             &log,
             &switch1_dpd_client,
             SwitchSlot::Switch1,
-            &BTreeSet::new(),
+            1,
         )
-        .await;
+        .unwrap();
 
         // Shutdown switch 0.
         shutdown_switch0(&cptestctx).await;
@@ -2668,17 +2668,14 @@ mod test {
         verify_active_vmm_destroyed(&cptestctx, instance_id).await;
 
         // The still-alive switch should have had the NAT entries removed.
-        let new_entries = wait_for_nat_entries_to_change(
+        wait_for_nat_entries_to_change(
             &log,
             &switch1_dpd_client,
             SwitchSlot::Switch1,
-            &switch1_old_nat_entries,
+            1,
         )
-        .await;
-        assert!(
-            new_entries.is_empty(),
-            "switch1 NAT entries should be empty, but were: {new_entries:?}",
-        );
+        .await
+        .unwrap();
 
         // Since the expected state after destroying a VMM is "no NAT entries",
         // we can't meaningfully distinguish "propagated" from "never set" on
@@ -2691,8 +2688,8 @@ mod test {
 
     /// Tests that instance update sagas for a completed migration can complete
     /// successfully if one switch zone is not available, and that the NAT
-    /// entries are correctly updated on *both* switches (including the one that
-    /// was restarted) to point at the new sled.
+    /// entries for the instance are propagated to both switches once the
+    /// missing one has come back.
     #[tokio::test]
     async fn migration_update_can_complete_with_dead_switch() {
         let cptestctx = nexus_test_utils::ControlPlaneBuilder::new(
@@ -2716,23 +2713,22 @@ mod test {
         let switch0_dpd_client = mk_dpd_client(&cptestctx, SwitchSlot::Switch0);
         let switch1_dpd_client = mk_dpd_client(&cptestctx, SwitchSlot::Switch1);
 
-        // Record the initial NAT entries (pointing at the source sled).
-        let switch0_nat_entries = wait_for_nat_entries_to_change(
+        wait_for_n_nat_entries(
             &log,
             &switch0_dpd_client,
             SwitchSlot::Switch0,
-            &BTreeSet::new(),
+            1,
         )
-        .await;
-        let switch1_nat_entries = wait_for_nat_entries_to_change(
+        .await
+        .unwrap();
+        wait_for_n_nat_entries(
             &log,
             &switch1_dpd_client,
             SwitchSlot::Switch1,
-            &BTreeSet::new(),
+            1,
         )
-        .await;
-        assert_eq!(switch0_nat_entries, switch1_nat_entries);
-        let initial_nat_entries = switch0_nat_entries;
+        .await
+        .unwrap();
 
         // Simulate the migration completing.
         migration_test
@@ -2772,33 +2768,34 @@ mod test {
             .await
             .expect("instance update saga did not complete within 60 seconds");
 
-        // Verify switch 1 has the *updated* NAT entries.
-        let switch1_new_nat_entries = wait_for_nat_entries_to_change(
-            log,
+        // In real life, the NAT entries on the alive switch should *change* to
+        // point at the new sled. However, in this test, the NAT entry for both
+        // the source and destination sleds will both point at localhost, since
+        // both "sleds" are actually just processes running on that computer.
+        // So, we're just asserting that there is one NAT entry before and after
+        // the migration...which would catch a bug where we delete the old NAT
+        // entry for the source sled but don't create the new one for the target
+        // sled, I guess, but doesn't actually validate that they have
+        // *changed*...since they *haven't*. Oh well.
+        wait_for_n_nat_entries(
+            &log,
             &switch1_dpd_client,
             SwitchSlot::Switch1,
-            &initial_nat_entries,
+            1,
         )
-        .await;
-        assert!(
-            !switch1_new_nat_entries.is_empty(),
-            "switch 1 should have updated NAT entries, but they were empty"
-        );
+        .await
+        .unwrap();
 
         // Restart switch 0 and verify it also gets the new entries.
         restart_switch0(&cptestctx, switch0_port).await;
-
-        let switch0_new_nat_entries = wait_for_nat_entries_to_change(
+        wait_for_n_nat_entries(
             log,
             &switch0_dpd_client,
             SwitchSlot::Switch0,
-            &initial_nat_entries,
+            1,
         )
-        .await;
-        assert_eq!(
-            switch1_new_nat_entries, switch0_new_nat_entries,
-            "new NAT entries should be synced to switch 0"
-        );
+        .await
+        .unwrap();
 
         cptestctx.teardown().await;
     }

--- a/nexus/src/app/sagas/instance_update/mod.rs
+++ b/nexus/src/app/sagas/instance_update/mod.rs
@@ -2367,6 +2367,207 @@ mod test {
             .await;
     }
 
+    // === dead-switch tests ===
+
+    /// Tests that instance update sagas can complete successfully if one switch
+    /// zone is not available.
+    /// This reproduces <https://github.com/oxidecomputer/omicron/issues/10343>
+    #[tokio::test]
+    async fn destroyed_update_can_complete_with_dead_switch() {
+        let cptestctx = nexus_test_utils::ControlPlaneBuilder::new(
+            "destroyed_update_can_complete_with_dead_switch",
+        )
+        .with_extra_sled_agents(3)
+        .start::<crate::Server>()
+        .await;
+
+        let nexus = &cptestctx.server.server_context().nexus;
+        let opctx = test_helpers::test_opctx(&cptestctx);
+        let log = &cptestctx.logctx.log;
+
+        setup_dendrite(&cptestctx).await;
+
+        // Before we make one of the switch zones go away, start a test
+        // instance, and simulate it into the `Running` state so that its
+        // network config is propagated.
+        let _project_id = setup_test_project(&cptestctx.external_client).await;
+        let (state, params) = setup_active_vmm_destroyed_test(&cptestctx).await;
+        let instance_id = state.instance.id();
+
+        let switch0_dpd_client = mk_dpd_client(&cptestctx, SwitchSlot::Switch0);
+        let switch1_dpd_client = mk_dpd_client(&cptestctx, SwitchSlot::Switch1);
+
+        wait_for_n_nat_entries(
+            &log,
+            &switch0_dpd_client,
+            SwitchSlot::Switch0,
+            1,
+        )
+        .unwrap();
+        wait_for_n_nat_entries(
+            &log,
+            &switch1_dpd_client,
+            SwitchSlot::Switch1,
+            1,
+        )
+        .unwrap();
+
+        // Shutdown switch 0.
+        shutdown_switch0(&cptestctx).await;
+        assert!(switch0_dpd_client.dpd_uptime().await.is_err());
+
+        // Okay, now that we've taken down one of the simulated switches, we
+        // should be able to run an instance-update saga to destroy the VMM.
+        //
+        // Build the saga DAG with the provided test parameters
+        let real_params = make_real_params(&cptestctx, &opctx, params).await;
+        let dag =
+            create_saga_dag::<SagaDoActualInstanceUpdate>(real_params).unwrap();
+
+        let saga_done =
+            crate::app::sagas::test_helpers::actions_succeed_idempotently(
+                &nexus, dag,
+            );
+        tokio::time::timeout(Duration::from_secs(60), saga_done)
+            .await
+            .expect("instance update saga did not complete within 60 seconds");
+
+        // Check that the VMM's resources were torn down properly.
+        verify_active_vmm_destroyed(&cptestctx, instance_id).await;
+
+        // The still-alive switch should have had the NAT entries removed.
+        wait_for_n_nat_entries(
+            &log,
+            &switch1_dpd_client,
+            SwitchSlot::Switch1,
+            1,
+        )
+        .await
+        .unwrap();
+
+        // Since the expected state after destroying a VMM is "no NAT entries",
+        // we can't meaningfully distinguish "propagated" from "never set" on
+        // the dead switch. The migration variant of this test (below) is also
+        // able to assert that the proper state is synced to the dead switch
+        // when it comes back to life.
+
+        cptestctx.teardown().await;
+    }
+
+    /// Tests that instance update sagas for a completed migration can complete
+    /// successfully if one switch zone is not available, and that the NAT
+    /// entries for the instance are propagated to both switches once the
+    /// missing one has come back.
+    #[tokio::test]
+    async fn migration_update_can_complete_with_dead_switch() {
+        let cptestctx = nexus_test_utils::ControlPlaneBuilder::new(
+            "migration_update_can_complete_with_dead_switch",
+        )
+        .with_extra_sled_agents(3)
+        .start::<crate::Server>()
+        .await;
+
+        let nexus = &cptestctx.server.server_context().nexus;
+        let opctx = test_helpers::test_opctx(&cptestctx);
+        let log = &cptestctx.logctx.log;
+
+        setup_dendrite(&cptestctx).await;
+
+        // Create a running instance and start migrating it.
+        setup_test_project(&cptestctx.external_client).await;
+        let migration_test =
+            MigrationTest::setup(MigrationOutcome::default(), &cptestctx).await;
+
+        let switch0_dpd_client = mk_dpd_client(&cptestctx, SwitchSlot::Switch0);
+        let switch1_dpd_client = mk_dpd_client(&cptestctx, SwitchSlot::Switch1);
+
+        wait_for_n_nat_entries(
+            &log,
+            &switch0_dpd_client,
+            SwitchSlot::Switch0,
+            1,
+        )
+        .await
+        .unwrap();
+        wait_for_n_nat_entries(
+            &log,
+            &switch1_dpd_client,
+            SwitchSlot::Switch1,
+            1,
+        )
+        .await
+        .unwrap();
+
+        // Simulate the migration completing.
+        migration_test
+            .update_src_state(
+                &cptestctx,
+                VmmState::Destroyed,
+                MigrationState::Completed,
+            )
+            .await;
+        migration_test
+            .update_target_state(
+                &cptestctx,
+                VmmState::Running,
+                MigrationState::Completed,
+            )
+            .await;
+
+        // Shut down switch 0.
+        let switch0_port = shutdown_switch0(&cptestctx).await;
+        assert!(switch0_dpd_client.dpd_uptime().await.is_err());
+
+        // Run the instance-update saga to complete the migration.
+        let real_params = make_real_params(
+            &cptestctx,
+            &opctx,
+            migration_test.start_saga_params(),
+        )
+        .await;
+        let dag =
+            create_saga_dag::<SagaDoActualInstanceUpdate>(real_params).unwrap();
+
+        let saga_done =
+            crate::app::sagas::test_helpers::actions_succeed_idempotently(
+                &nexus, dag,
+            );
+        tokio::time::timeout(Duration::from_secs(60), saga_done)
+            .await
+            .expect("instance update saga did not complete within 60 seconds");
+
+        // In real life, the NAT entries on the alive switch should *change* to
+        // point at the new sled. However, in this test, the NAT entry for both
+        // the source and destination sleds will both point at localhost, since
+        // both "sleds" are actually just processes running on that computer.
+        // So, we're just asserting that there is one NAT entry before and after
+        // the migration...which would catch a bug where we delete the old NAT
+        // entry for the source sled but don't create the new one for the target
+        // sled, I guess, but doesn't actually validate that they have
+        // *changed*...since they *haven't*. Oh well.
+        wait_for_n_nat_entries(
+            &log,
+            &switch1_dpd_client,
+            SwitchSlot::Switch1,
+            1,
+        )
+        .await
+        .unwrap();
+
+        // Restart switch 0 and verify it also gets the new entries.
+        restart_switch0(&cptestctx, switch0_port).await;
+        wait_for_n_nat_entries(
+            log,
+            &switch0_dpd_client,
+            SwitchSlot::Switch0,
+            1,
+        )
+        .await
+        .unwrap();
+
+        cptestctx.teardown().await;
+    }
+
     // === dead-switch test helpers ===
 
     async fn setup_dendrite(cptestctx: &ControlPlaneTestContext) {
@@ -2499,7 +2700,7 @@ mod test {
     /// Poll a switch zone until it has `n` NAT entries, or 60 seconds elapse.
     /// This returns a `Result` so that it can be `unwrap()`ed and panic with a
     /// useful source location.
-    async fn wait_for_nat_entries_to_change(
+    async fn wait_for_n_nat_entries(
         log: &slog::Logger,
         client: &dpd_client::Client,
         switch: SwitchSlot,
@@ -2598,206 +2799,7 @@ mod test {
             .insert(SwitchSlot::Switch0, new_switch0);
     }
 
-    // === dead-switch tests ===
-
-    /// Tests that instance update sagas can complete successfully if one switch
-    /// zone is not available.
-    /// This reproduces <https://github.com/oxidecomputer/omicron/issues/10343>
-    #[tokio::test]
-    async fn destroyed_update_can_complete_with_dead_switch() {
-        let cptestctx = nexus_test_utils::ControlPlaneBuilder::new(
-            "destroyed_update_can_complete_with_dead_switch",
-        )
-        .with_extra_sled_agents(3)
-        .start::<crate::Server>()
-        .await;
-
-        let nexus = &cptestctx.server.server_context().nexus;
-        let opctx = test_helpers::test_opctx(&cptestctx);
-        let log = &cptestctx.logctx.log;
-
-        setup_dendrite(&cptestctx).await;
-
-        // Before we make one of the switch zones go away, start a test
-        // instance, and simulate it into the `Running` state so that its
-        // network config is propagated.
-        let _project_id = setup_test_project(&cptestctx.external_client).await;
-        let (state, params) = setup_active_vmm_destroyed_test(&cptestctx).await;
-        let instance_id = state.instance.id();
-
-        let switch0_dpd_client = mk_dpd_client(&cptestctx, SwitchSlot::Switch0);
-        let switch1_dpd_client = mk_dpd_client(&cptestctx, SwitchSlot::Switch1);
-
-        wait_for_n_nat_entries(
-            &log,
-            &switch0_dpd_client,
-            SwitchSlot::Switch0,
-            1,
-        )
-        .unwrap();
-        wait_for_n_nat_entries(
-            &log,
-            &switch1_dpd_client,
-            SwitchSlot::Switch1,
-            1,
-        )
-        .unwrap();
-
-        // Shutdown switch 0.
-        shutdown_switch0(&cptestctx).await;
-        assert!(switch0_dpd_client.dpd_uptime().await.is_err());
-
-        // Okay, now that we've taken down one of the simulated switches, we
-        // should be able to run an instance-update saga to destroy the VMM.
-        //
-        // Build the saga DAG with the provided test parameters
-        let real_params = make_real_params(&cptestctx, &opctx, params).await;
-        let dag =
-            create_saga_dag::<SagaDoActualInstanceUpdate>(real_params).unwrap();
-
-        let saga_done =
-            crate::app::sagas::test_helpers::actions_succeed_idempotently(
-                &nexus, dag,
-            );
-        tokio::time::timeout(Duration::from_secs(60), saga_done)
-            .await
-            .expect("instance update saga did not complete within 60 seconds");
-
-        // Check that the VMM's resources were torn down properly.
-        verify_active_vmm_destroyed(&cptestctx, instance_id).await;
-
-        // The still-alive switch should have had the NAT entries removed.
-        wait_for_nat_entries_to_change(
-            &log,
-            &switch1_dpd_client,
-            SwitchSlot::Switch1,
-            1,
-        )
-        .await
-        .unwrap();
-
-        // Since the expected state after destroying a VMM is "no NAT entries",
-        // we can't meaningfully distinguish "propagated" from "never set" on
-        // the dead switch. The migration variant of this test (below) is also
-        // able to assert that the proper state is synced to the dead switch
-        // when it comes back to life.
-
-        cptestctx.teardown().await;
-    }
-
-    /// Tests that instance update sagas for a completed migration can complete
-    /// successfully if one switch zone is not available, and that the NAT
-    /// entries for the instance are propagated to both switches once the
-    /// missing one has come back.
-    #[tokio::test]
-    async fn migration_update_can_complete_with_dead_switch() {
-        let cptestctx = nexus_test_utils::ControlPlaneBuilder::new(
-            "migration_update_can_complete_with_dead_switch",
-        )
-        .with_extra_sled_agents(3)
-        .start::<crate::Server>()
-        .await;
-
-        let nexus = &cptestctx.server.server_context().nexus;
-        let opctx = test_helpers::test_opctx(&cptestctx);
-        let log = &cptestctx.logctx.log;
-
-        setup_dendrite(&cptestctx).await;
-
-        // Create a running instance and start migrating it.
-        setup_test_project(&cptestctx.external_client).await;
-        let migration_test =
-            MigrationTest::setup(MigrationOutcome::default(), &cptestctx).await;
-
-        let switch0_dpd_client = mk_dpd_client(&cptestctx, SwitchSlot::Switch0);
-        let switch1_dpd_client = mk_dpd_client(&cptestctx, SwitchSlot::Switch1);
-
-        wait_for_n_nat_entries(
-            &log,
-            &switch0_dpd_client,
-            SwitchSlot::Switch0,
-            1,
-        )
-        .await
-        .unwrap();
-        wait_for_n_nat_entries(
-            &log,
-            &switch1_dpd_client,
-            SwitchSlot::Switch1,
-            1,
-        )
-        .await
-        .unwrap();
-
-        // Simulate the migration completing.
-        migration_test
-            .update_src_state(
-                &cptestctx,
-                VmmState::Destroyed,
-                MigrationState::Completed,
-            )
-            .await;
-        migration_test
-            .update_target_state(
-                &cptestctx,
-                VmmState::Running,
-                MigrationState::Completed,
-            )
-            .await;
-
-        // Shut down switch 0.
-        let switch0_port = shutdown_switch0(&cptestctx).await;
-        assert!(switch0_dpd_client.dpd_uptime().await.is_err());
-
-        // Run the instance-update saga to complete the migration.
-        let real_params = make_real_params(
-            &cptestctx,
-            &opctx,
-            migration_test.start_saga_params(),
-        )
-        .await;
-        let dag =
-            create_saga_dag::<SagaDoActualInstanceUpdate>(real_params).unwrap();
-
-        let saga_done =
-            crate::app::sagas::test_helpers::actions_succeed_idempotently(
-                &nexus, dag,
-            );
-        tokio::time::timeout(Duration::from_secs(60), saga_done)
-            .await
-            .expect("instance update saga did not complete within 60 seconds");
-
-        // In real life, the NAT entries on the alive switch should *change* to
-        // point at the new sled. However, in this test, the NAT entry for both
-        // the source and destination sleds will both point at localhost, since
-        // both "sleds" are actually just processes running on that computer.
-        // So, we're just asserting that there is one NAT entry before and after
-        // the migration...which would catch a bug where we delete the old NAT
-        // entry for the source sled but don't create the new one for the target
-        // sled, I guess, but doesn't actually validate that they have
-        // *changed*...since they *haven't*. Oh well.
-        wait_for_n_nat_entries(
-            &log,
-            &switch1_dpd_client,
-            SwitchSlot::Switch1,
-            1,
-        )
-        .await
-        .unwrap();
-
-        // Restart switch 0 and verify it also gets the new entries.
-        restart_switch0(&cptestctx, switch0_port).await;
-        wait_for_n_nat_entries(
-            log,
-            &switch0_dpd_client,
-            SwitchSlot::Switch0,
-            1,,
-        )
-        .await
-        .unwrap();
-
-        cptestctx.teardown().await;
-    }
+    // === migration test helpers ===
 
     #[derive(Clone, Copy, Default)]
     struct MigrationOutcome {


### PR DESCRIPTION
Currently, the `instance_update` saga will unwind if it attempts to update an instance whose active VMM has transitioned to `Destroyed` or `Failed` while one switch zone is unreachable. This means that the instance will remain in the `Stopping` state, and will not transition to `Stopped` or `Failed`, until both switch zones have come back. This is unfortunate, since it prevents the instance from being deleted or restarted, either manually by a user or automatically by instance reincarnation, until the disappeared switch reappears. This is described in #10343.

This commit fixes this issue by changing the `instance_networking::instance_delete_dpd_config` function to return `Ok(())` even if an error occurs while notifying dendrite of the NAT state change. This is safe to do because the latest NAT state is propagated to both switches by an RPW, so when the switch that has disappeared returns, it will still receive the latest state even if we were not able to notify it in the saga. This is identical to what `instance_ensure_dpd_config` has done since PR #8914 --- we just needed to make the same change in `instance_delete_dpd_config`.

I've also added a test ensuring that the instance update saga can complete while one Dendrite is gone, which failed prior to this change.

Fixes #10343.